### PR TITLE
fix: EXC-1992: Fix same round install code and draining queues

### DIFF
--- a/rs/execution_environment/src/ic00_permissions.rs
+++ b/rs/execution_environment/src/ic00_permissions.rs
@@ -24,7 +24,37 @@ pub(crate) struct Ic00MethodPermissions {
 impl Ic00MethodPermissions {
     pub fn new(method: Ic00Method) -> Self {
         match method {
-            Ic00Method::CanisterStatus => Self {
+            Ic00Method::CanisterStatus
+            | Ic00Method::CanisterInfo
+            | Ic00Method::DepositCycles
+            | Ic00Method::ECDSAPublicKey
+            | Ic00Method::SignWithECDSA
+            | Ic00Method::StartCanister
+            | Ic00Method::UninstallCode
+            | Ic00Method::UpdateSettings
+            | Ic00Method::SchnorrPublicKey
+            | Ic00Method::SignWithSchnorr
+            | Ic00Method::VetKdPublicKey
+            | Ic00Method::VetKdDeriveKey
+            | Ic00Method::BitcoinGetBalance
+            | Ic00Method::BitcoinGetUtxos
+            | Ic00Method::BitcoinGetBlockHeaders
+            | Ic00Method::BitcoinSendTransaction
+            | Ic00Method::BitcoinGetCurrentFeePercentiles
+            | Ic00Method::BitcoinSendTransactionInternal
+            | Ic00Method::BitcoinGetSuccessors
+            | Ic00Method::NodeMetricsHistory
+            | Ic00Method::SubnetInfo
+            | Ic00Method::ProvisionalCreateCanisterWithCycles
+            | Ic00Method::ProvisionalTopUpCanister
+            | Ic00Method::StoredChunks
+            | Ic00Method::ClearChunkStore
+            | Ic00Method::ListCanisterSnapshots
+            | Ic00Method::DeleteCanisterSnapshot
+            | Ic00Method::ReadCanisterSnapshotMetadata
+            | Ic00Method::ReadCanisterSnapshotData
+            | Ic00Method::UploadCanisterSnapshotMetadata
+            | Ic00Method::UploadCanisterSnapshotData => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
@@ -32,15 +62,7 @@ impl Ic00MethodPermissions {
                 does_not_run_on_aborted_canister: false,
                 installs_code: false,
             },
-            Ic00Method::CanisterInfo => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::CreateCanister => Self {
+            Ic00Method::CreateCanister | Ic00Method::HttpRequest | Ic00Method::RawRand => Self {
                 method,
                 allow_remote_subnet_sender: false,
                 allow_only_nns_subnet_sender: false,
@@ -48,230 +70,31 @@ impl Ic00MethodPermissions {
                 does_not_run_on_aborted_canister: false,
                 installs_code: false,
             },
-            Ic00Method::DeleteCanister => Self {
+            Ic00Method::DeleteCanister | Ic00Method::StopCanister => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
                 counts_toward_round_limit: false,
                 // Deleting an aborted canister requires to stop it first.
-                does_not_run_on_aborted_canister: true,
-                installs_code: false,
-            },
-            Ic00Method::DepositCycles => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::HttpRequest => Self {
-                method,
-                allow_remote_subnet_sender: false,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::ECDSAPublicKey => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::InstallCode => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: true,
-                does_not_run_on_aborted_canister: true,
-                // Only one install code message allowed at a time.
-                installs_code: true,
-            },
-            Ic00Method::InstallChunkedCode => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: true,
-                does_not_run_on_aborted_canister: true,
-                // Only one install code message allowed at a time.
-                installs_code: true,
-            },
-            Ic00Method::RawRand => Self {
-                method,
-                allow_remote_subnet_sender: false,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::SetupInitialDKG => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: true,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::SignWithECDSA => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::StartCanister => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::StopCanister => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
                 // Stopping an aborted canister does not generate a reply.
                 does_not_run_on_aborted_canister: true,
                 installs_code: false,
             },
-            Ic00Method::UninstallCode => Self {
+            Ic00Method::InstallCode | Ic00Method::InstallChunkedCode => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
+                counts_toward_round_limit: true,
+                does_not_run_on_aborted_canister: true,
+                // Only one install code message allowed at a time.
+                installs_code: true,
             },
-            Ic00Method::UpdateSettings => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::ComputeInitialIDkgDealings => Self {
+            Ic00Method::SetupInitialDKG
+            | Ic00Method::ComputeInitialIDkgDealings
+            | Ic00Method::ReshareChainKey => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: true,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::ReshareChainKey => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: true,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::SchnorrPublicKey => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::SignWithSchnorr => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::VetKdPublicKey => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::VetKdDeriveKey => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::BitcoinGetBalance => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::BitcoinGetUtxos => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::BitcoinGetBlockHeaders => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::BitcoinSendTransaction => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::BitcoinGetCurrentFeePercentiles => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::BitcoinSendTransactionInternal => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::BitcoinGetSuccessors => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::NodeMetricsHistory => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::SubnetInfo => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
                 counts_toward_round_limit: false,
                 does_not_run_on_aborted_canister: false,
                 installs_code: false,
@@ -286,39 +109,7 @@ impl Ic00MethodPermissions {
                 does_not_run_on_aborted_canister: false,
                 installs_code: false,
             },
-            Ic00Method::ProvisionalCreateCanisterWithCycles => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::ProvisionalTopUpCanister => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::UploadChunk => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: true,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::StoredChunks | Ic00Method::ClearChunkStore => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
-                installs_code: false,
-            },
-            Ic00Method::TakeCanisterSnapshot => Self {
+            Ic00Method::UploadChunk | Ic00Method::TakeCanisterSnapshot => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
@@ -333,19 +124,6 @@ impl Ic00MethodPermissions {
                 // Loading a snapshot is similar to the install code.
                 counts_toward_round_limit: true,
                 does_not_run_on_aborted_canister: true,
-                installs_code: false,
-            },
-            Ic00Method::ListCanisterSnapshots
-            | Ic00Method::DeleteCanisterSnapshot
-            | Ic00Method::ReadCanisterSnapshotMetadata
-            | Ic00Method::ReadCanisterSnapshotData
-            | Ic00Method::UploadCanisterSnapshotMetadata
-            | Ic00Method::UploadCanisterSnapshotData => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-                counts_toward_round_limit: false,
-                does_not_run_on_aborted_canister: false,
                 installs_code: false,
             },
         }

--- a/rs/execution_environment/src/ic00_permissions.rs
+++ b/rs/execution_environment/src/ic00_permissions.rs
@@ -13,165 +13,268 @@ pub(crate) struct Ic00MethodPermissions {
     allow_remote_subnet_sender: bool,
     /// Call initiated only by the NNS subnet.
     allow_only_nns_subnet_sender: bool,
+    /// Due to the substantial complexity of this call, it must be counted toward the round limit.
+    counts_toward_round_limit: bool,
+    /// As this call modifies the canister state, it must not be executed on an aborted canister.
+    does_not_run_on_aborted_canister: bool,
+    /// The call installs a new canister code.
+    installs_code: bool,
 }
 
 impl Ic00MethodPermissions {
     pub fn new(method: Ic00Method) -> Self {
         match method {
-            Ic00Method::SignWithECDSA => Self {
-                method,
-                allow_remote_subnet_sender: true,
-                allow_only_nns_subnet_sender: false,
-            },
             Ic00Method::CanisterStatus => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::CanisterInfo => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::CreateCanister => Self {
                 method,
                 allow_remote_subnet_sender: false,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::DeleteCanister => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                // Deleting an aborted canister requires to stop it first.
+                does_not_run_on_aborted_canister: true,
+                installs_code: false,
             },
             Ic00Method::DepositCycles => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::HttpRequest => Self {
                 method,
                 allow_remote_subnet_sender: false,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::ECDSAPublicKey => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::InstallCode => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: true,
+                does_not_run_on_aborted_canister: true,
+                // Only one install code message allowed at a time.
+                installs_code: true,
             },
             Ic00Method::InstallChunkedCode => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: true,
+                does_not_run_on_aborted_canister: true,
+                // Only one install code message allowed at a time.
+                installs_code: true,
             },
             Ic00Method::RawRand => Self {
                 method,
                 allow_remote_subnet_sender: false,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::SetupInitialDKG => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: true,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
+            },
+            Ic00Method::SignWithECDSA => Self {
+                method,
+                allow_remote_subnet_sender: true,
+                allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::StartCanister => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::StopCanister => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                // Stopping an aborted canister does not generate a reply.
+                does_not_run_on_aborted_canister: true,
+                installs_code: false,
             },
             Ic00Method::UninstallCode => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::UpdateSettings => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::ComputeInitialIDkgDealings => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: true,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::ReshareChainKey => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: true,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::SchnorrPublicKey => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::SignWithSchnorr => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::VetKdPublicKey => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::VetKdDeriveKey => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::BitcoinGetBalance => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::BitcoinGetUtxos => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::BitcoinGetBlockHeaders => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::BitcoinSendTransaction => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::BitcoinGetCurrentFeePercentiles => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::BitcoinSendTransactionInternal => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::BitcoinGetSuccessors => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::NodeMetricsHistory => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::SubnetInfo => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::FetchCanisterLogs => Self {
                 method,
@@ -179,27 +282,60 @@ impl Ic00MethodPermissions {
                 // all inter-canister call permissions are irrelevant and therefore set to false.
                 allow_remote_subnet_sender: false,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::ProvisionalCreateCanisterWithCycles => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
             Ic00Method::ProvisionalTopUpCanister => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
-            Ic00Method::UploadChunk | Ic00Method::StoredChunks | Ic00Method::ClearChunkStore => {
-                Self {
-                    method,
-                    allow_remote_subnet_sender: true,
-                    allow_only_nns_subnet_sender: false,
-                }
-            }
-            Ic00Method::TakeCanisterSnapshot
-            | Ic00Method::LoadCanisterSnapshot
-            | Ic00Method::ListCanisterSnapshots
+            Ic00Method::UploadChunk => Self {
+                method,
+                allow_remote_subnet_sender: true,
+                allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: true,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
+            },
+            Ic00Method::StoredChunks | Ic00Method::ClearChunkStore => Self {
+                method,
+                allow_remote_subnet_sender: true,
+                allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
+            },
+            Ic00Method::TakeCanisterSnapshot => Self {
+                method,
+                allow_remote_subnet_sender: true,
+                allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: true,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
+            },
+            Ic00Method::LoadCanisterSnapshot => Self {
+                method,
+                allow_remote_subnet_sender: true,
+                allow_only_nns_subnet_sender: false,
+                // Loading a snapshot is similar to the install code.
+                counts_toward_round_limit: true,
+                does_not_run_on_aborted_canister: true,
+                installs_code: false,
+            },
+            Ic00Method::ListCanisterSnapshots
             | Ic00Method::DeleteCanisterSnapshot
             | Ic00Method::ReadCanisterSnapshotMetadata
             | Ic00Method::ReadCanisterSnapshotData
@@ -208,6 +344,9 @@ impl Ic00MethodPermissions {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
+                counts_toward_round_limit: false,
+                does_not_run_on_aborted_canister: false,
+                installs_code: false,
             },
         }
     }
@@ -269,5 +408,16 @@ impl Ic00MethodPermissions {
             ));
         }
         Ok(())
+    }
+
+    pub(crate) fn can_be_executed(
+        &self,
+        instructions_reached: bool,
+        ongoing_long_install_code: bool,
+        effective_canister_is_aborted: bool,
+    ) -> bool {
+        !(self.counts_toward_round_limit && instructions_reached
+            || self.does_not_run_on_aborted_canister && effective_canister_is_aborted
+            || self.installs_code && ongoing_long_install_code)
     }
 }

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -3034,3 +3034,138 @@ fn yield_for_dirty_pages_copy_works_for_many_canisters() {
     // Only the first message per scheduler core must be completed after two rounds.
     assert_eq!(num_completed(), scheduler_cores);
 }
+
+#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
+const WRITE_MORE_THAN_1G_ON_INIT_WAT: &str = r#"
+(module
+    (func (export "canister_init")
+        (local $i i32)
+        (local.set $i (i32.const 1073745920)) ;; 1GiB + 4096
+        (loop $loop
+            (i32.store (local.get $i) (i32.const 1))
+            (br_if $loop (local.tee $i (i32.sub (local.get $i) (i32.const 4096))))
+        )
+    )
+    (memory 16385) ;; 1GiB + 65536
+)"#;
+
+#[test]
+#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
+fn yield_for_dirty_pages_copy_works_for_install_code() {
+    let env = ic_state_machine_tests::StateMachineBuilder::new()
+        .with_subnet_type(SubnetType::Application)
+        .build();
+
+    let wasm = wat::parse_str(WRITE_MORE_THAN_1G_ON_INIT_WAT).unwrap();
+    let canister_id = env.create_canister_with_cycles(None, INITIAL_CYCLES_BALANCE, None);
+
+    let mut payload = ic_state_machine_tests::PayloadBuilder::new().with_nonce(0);
+    // Send two install code messages to the same canister.
+    for _ in 0..2 {
+        payload = payload.ingress(
+            PrincipalId::new_anonymous(),
+            CanisterId::ic_00(),
+            Method::InstallCode,
+            InstallCodeArgs::new(
+                CanisterInstallMode::Reinstall,
+                canister_id,
+                wasm.clone(),
+                vec![],
+                None,
+                None,
+            )
+            .encode(),
+        );
+    }
+    let message_ids = payload.ingress_ids();
+    env.execute_payload(payload);
+
+    // Neither of messages should be completed after the first round.
+    assert_matches!(
+        ingress_state(env.ingress_status(&message_ids[0])),
+        Some(IngressState::Processing)
+    );
+    assert_matches!(
+        ingress_state(env.ingress_status(&message_ids[1])),
+        Some(IngressState::Received)
+    );
+
+    env.tick();
+
+    // Only the first message must be completed after two rounds.
+    assert_matches!(
+        ingress_state(env.ingress_status(&message_ids[0])),
+        Some(IngressState::Completed(_))
+    );
+    assert_matches!(
+        ingress_state(env.ingress_status(&message_ids[1])),
+        Some(IngressState::Received)
+    );
+}
+
+#[test]
+#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
+fn yield_for_dirty_pages_copy_works_for_install_code_and_many_canisters() {
+    let scheduler_cores = 4;
+    let num_canisters = scheduler_cores;
+    let num_messages = 2;
+    let env = ic_state_machine_tests::StateMachineBuilder::new()
+        .with_subnet_type(SubnetType::Application)
+        .build();
+
+    let wasm = wat::parse_str(WRITE_MORE_THAN_1G_ON_INIT_WAT).unwrap();
+    let mut canister_ids = vec![];
+    let mut payload = ic_state_machine_tests::PayloadBuilder::new().with_nonce(0);
+    for _ in 0..num_canisters {
+        let canister_id = env.create_canister_with_cycles(None, INITIAL_CYCLES_BALANCE, None);
+        canister_ids.push(canister_id);
+
+        for _ in 0..num_messages {
+            payload = payload.ingress(
+                PrincipalId::new_anonymous(),
+                CanisterId::ic_00(),
+                Method::InstallCode,
+                InstallCodeArgs::new(
+                    CanisterInstallMode::Reinstall,
+                    canister_id,
+                    wasm.clone(),
+                    vec![],
+                    None,
+                    None,
+                )
+                .encode(),
+            );
+        }
+    }
+    let message_ids = payload.ingress_ids();
+    env.execute_payload(payload);
+
+    let num_completed = || {
+        message_ids
+            .iter()
+            .filter_map(|id| match ingress_state(env.ingress_status(id)) {
+                Some(IngressState::Completed(_)) => Some(()),
+                Some(IngressState::Received) | Some(IngressState::Processing) => None,
+                _ => panic!("Unexpected ingress state"),
+            })
+            .count()
+    };
+
+    // Neither of messages should be completed after the first round.
+    assert_eq!(num_completed(), 0);
+
+    env.tick();
+
+    // Only the first message must be completed after two rounds.
+    assert_eq!(num_completed(), 1);
+
+    env.tick();
+
+    // Only the first message must be completed after three rounds.
+    assert_eq!(num_completed(), 1);
+
+    env.tick();
+
+    // Two heavy install code messages must be completed in four rounds.
+    assert_eq!(num_completed(), 2);
+}


### PR DESCRIPTION
The current scheduler logic permits `advance_long_running_install_code` to complete a lengthy install process and then immediately initiate a new one within `drain_subnet_queues`.

This PR uses the `can_execute_subnet_msg` function to differentiate between heavy subnet messages, which must respect the round limit, and light subnet messages, which can be executed at any time.

Fixes RUN-386