### PR TITLE
feat(crypto): CRP-2709 improve vetKD API naming

### DIFF
--- a/packages/ic-vetkd-utils/src/lib.rs
+++ b/packages/ic-vetkd-utils/src/lib.rs
@@ -66,13 +66,13 @@ impl TransportSecretKey {
         &self,
         encrypted_key_bytes: &[u8],
         derived_public_key_bytes: &[u8],
-        derivation_id: &[u8],
+        input: &[u8],
     ) -> Result<Vec<u8>, String> {
         let encrypted_key = EncryptedKey::deserialize(encrypted_key_bytes)?;
         let derived_public_key = DerivedPublicKey::deserialize(derived_public_key_bytes)
             .map_err(|e| format!("failed to deserialize public key: {:?}", e))?;
         Ok(encrypted_key
-            .decrypt_and_verify(self, derived_public_key, derivation_id)?
+            .decrypt_and_verify(self, derived_public_key, input)?
             .to_compressed()
             .to_vec())
     }
@@ -87,11 +87,11 @@ impl TransportSecretKey {
         &self,
         encrypted_key_bytes: &[u8],
         derived_public_key_bytes: &[u8],
-        derivation_id: &[u8],
+        input: &[u8],
         symmetric_key_bytes: usize,
         symmetric_key_associated_data: &[u8],
     ) -> Result<Vec<u8>, String> {
-        let key = self.decrypt(encrypted_key_bytes, derived_public_key_bytes, derivation_id)?;
+        let key = self.decrypt(encrypted_key_bytes, derived_public_key_bytes, input)?;
 
         let mut ro = ro::RandomOracle::new(&format!(
             "ic-crypto-vetkd-bls12-381-create-secret-key-{}-bytes",
@@ -171,11 +171,11 @@ impl EncryptedKey {
         &self,
         tsk: &TransportSecretKey,
         derived_public_key: DerivedPublicKey,
-        derivation_id: &[u8],
+        input: &[u8],
     ) -> Result<G1Affine, String> {
         let k = G1Affine::from(G1Projective::from(&self.c3) - self.c1 * tsk.secret_key);
 
-        let msg = augmented_hash_to_g1(&derived_public_key.point, derivation_id);
+        let msg = augmented_hash_to_g1(&derived_public_key.point, input);
         let dpk_prep = G2Prepared::from(G2Affine::from(derived_public_key));
         use pairing::group::Group;
         let is_valid = gt_multipairing(&[(&k, &G2PREPARED_NEG_G), (&msg, &dpk_prep)]).is_identity();
@@ -305,7 +305,7 @@ impl IBECiphertext {
     /// not reuse the seed for encrypting another message or any other purpose.
     pub fn encrypt(
         derived_public_key_bytes: &[u8],
-        derivation_id: &[u8],
+        input: &[u8],
         msg: &[u8],
         seed: &[u8],
     ) -> Result<IBECiphertext, String> {
@@ -317,7 +317,7 @@ impl IBECiphertext {
             .map_err(|_e| format!("Provided seed must be {} bytes long ", IBE_SEED_BYTES))?;
 
         let t = Self::hash_to_mask(seed, msg);
-        let pt = augmented_hash_to_g1(&dpk.point, derivation_id);
+        let pt = augmented_hash_to_g1(&dpk.point, input);
         let tsig = ic_bls12_381::pairing(&pt, &dpk.point) * t;
 
         let c1 = G2Affine::from(G2Affine::generator() * t);
@@ -331,7 +331,7 @@ impl IBECiphertext {
     ///
     /// For proper operation k_bytes should be the result of calling
     /// TransportSecretKey::decrypt where the same `derived_public_key_bytes`
-    /// and `derivation_id` were used when creating the ciphertext (with
+    /// and `input` were used when creating the ciphertext (with
     /// IBECiphertext::encrypt).
     ///
     /// Returns the plaintext, or Err if decryption failed

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -2264,8 +2264,8 @@ mod tests {
                     request: RequestBuilder::new().sender(canister_test_id(1)).build(),
                     args: ThresholdArguments::VetKd(VetKdArguments {
                         key_id: key_id.clone(),
-                        derivation_id: vec![],
-                        encryption_public_key: vec![],
+                        input: vec![],
+                        transport_public_key: vec![],
                         ni_dkg_id: fake_dkg_id(key_id),
                         height,
                     }),

--- a/rs/consensus/src/idkg/test_utils.rs
+++ b/rs/consensus/src/idkg/test_utils.rs
@@ -61,7 +61,7 @@ use ic_types::crypto::threshold_sig::ni_dkg::{
     NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
 };
 use ic_types::crypto::vetkd::{
-    VetKdArgs, VetKdDerivationDomain, VetKdEncryptedKeyShare, VetKdEncryptedKeyShareContent,
+    VetKdArgs, VetKdDerivationContext, VetKdEncryptedKeyShare, VetKdEncryptedKeyShareContent,
 };
 use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
 use ic_types::messages::CallbackId;
@@ -111,8 +111,8 @@ fn fake_signature_request_args(key_id: MasterPublicKeyId, height: Height) -> Thr
         }),
         MasterPublicKeyId::VetKd(key_id) => ThresholdArguments::VetKd(VetKdArguments {
             key_id: key_id.clone(),
-            derivation_id: vec![1; 32],
-            encryption_public_key: vec![1; 32],
+            input: vec![1; 32],
+            transport_public_key: vec![1; 32],
             ni_dkg_id: fake_dkg_id(key_id),
             height,
         }),
@@ -1374,12 +1374,12 @@ pub(crate) fn create_schnorr_sig_inputs_with_args(
 pub(crate) fn create_vetkd_inputs_with_args(caller: u8, key_id: &VetKdKeyId) -> TestSigInputs {
     let inputs = VetKdArgs {
         ni_dkg_id: fake_dkg_id(key_id.clone()),
-        derivation_domain: VetKdDerivationDomain {
+        context: VetKdDerivationContext {
             caller: PrincipalId::try_from(&vec![caller]).unwrap(),
-            domain: vec![],
+            context: vec![],
         },
-        derivation_id: vec![],
-        encryption_public_key: vec![1; 32],
+        input: vec![],
+        transport_public_key: vec![1; 32],
     };
 
     TestSigInputs {

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -33,7 +33,7 @@ use ic_types::crypto::canister_threshold_sig::idkg::{
     IDkgTranscript, IDkgTranscriptOperation, InitialIDkgDealings,
 };
 use ic_types::crypto::canister_threshold_sig::MasterPublicKey;
-use ic_types::crypto::vetkd::{VetKdArgs, VetKdDerivationDomain};
+use ic_types::crypto::vetkd::{VetKdArgs, VetKdDerivationContext};
 use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
 use ic_types::messages::CallbackId;
 use ic_types::registry::RegistryClientError;
@@ -332,13 +332,13 @@ pub(super) fn build_signature_inputs(
                 height: args.height,
             };
             let inputs = ThresholdSigInputsRef::VetKd(VetKdArgs {
-                derivation_domain: VetKdDerivationDomain {
+                context: VetKdDerivationContext {
                     caller: context.request.sender.into(),
-                    domain: context.derivation_path.iter().flatten().cloned().collect(),
+                    context: context.derivation_path.iter().flatten().cloned().collect(),
                 },
                 ni_dkg_id: args.ni_dkg_id.clone(),
-                derivation_id: args.derivation_id.clone(),
-                encryption_public_key: args.encryption_public_key.clone(),
+                input: args.input.clone(),
+                transport_public_key: args.transport_public_key.clone(),
             });
             Ok((request_id, inputs))
         }

--- a/rs/consensus/vetkd/src/lib.rs
+++ b/rs/consensus/vetkd/src/lib.rs
@@ -21,9 +21,7 @@ use ic_interfaces::{
 use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::StateReader;
 use ic_logger::{warn, ReplicaLogger};
-use ic_management_canister_types_private::{
-    MasterPublicKeyId, Payload, VetKdDeriveEncryptedKeyResult,
-};
+use ic_management_canister_types_private::{MasterPublicKeyId, Payload, VetKdDeriveKeyResult};
 use ic_metrics::MetricsRegistry;
 use ic_registry_client_helpers::chain_keys::ChainKeysRegistry;
 use ic_registry_client_helpers::subnet::SubnetRegistry;
@@ -37,7 +35,7 @@ use ic_types::{
         bytes_to_vetkd_payload, vetkd_payload_to_bytes, ConsensusResponse, ValidationContext,
         VetKdAgreement, VetKdErrorCode, VetKdPayload,
     },
-    crypto::vetkd::{VetKdArgs, VetKdDerivationDomain, VetKdEncryptedKey},
+    crypto::vetkd::{VetKdArgs, VetKdDerivationContext, VetKdEncryptedKey},
     messages::{CallbackId, Payload as ResponsePayload, RejectContext},
     CountBytes, Height, NumBytes, SubnetId, Time,
 };
@@ -232,20 +230,20 @@ impl VetKdPayloadBuilderImpl {
                     continue;
                 };
                 let args = VetKdArgs {
-                    derivation_domain: VetKdDerivationDomain {
+                    context: VetKdDerivationContext {
                         caller: context.request.sender.into(),
-                        domain: context.derivation_path.iter().flatten().cloned().collect(),
+                        context: context.derivation_path.iter().flatten().cloned().collect(),
                     },
                     ni_dkg_id: ctxt_args.ni_dkg_id.clone(),
-                    derivation_id: ctxt_args.derivation_id.clone(),
-                    encryption_public_key: ctxt_args.encryption_public_key.clone(),
+                    input: ctxt_args.input.clone(),
+                    transport_public_key: ctxt_args.transport_public_key.clone(),
                 };
                 let key_id = context.key_id();
                 match self.crypto.combine_encrypted_key_shares(shares, &args) {
                     Ok(key) => {
                         self.metrics
                             .payload_metrics_inc("vetkd_agreement_completed", &key_id);
-                        let result = VetKdDeriveEncryptedKeyResult {
+                        let result = VetKdDeriveKeyResult {
                             encrypted_key: key.encrypted_key,
                         };
                         VetKdAgreement::Success(result.encode())
@@ -349,15 +347,15 @@ impl VetKdPayloadBuilderImpl {
             return invalid_artifact_err(InvalidVetKdPayloadReason::UnexpectedIDkgContext(id));
         };
         let args = VetKdArgs {
-            derivation_domain: VetKdDerivationDomain {
+            context: VetKdDerivationContext {
                 caller: context.request.sender.into(),
-                domain: context.derivation_path.iter().flatten().cloned().collect(),
+                context: context.derivation_path.iter().flatten().cloned().collect(),
             },
             ni_dkg_id: ctxt_args.ni_dkg_id.clone(),
-            derivation_id: ctxt_args.derivation_id.clone(),
-            encryption_public_key: ctxt_args.encryption_public_key.clone(),
+            input: ctxt_args.input.clone(),
+            transport_public_key: ctxt_args.transport_public_key.clone(),
         };
-        let reply = match VetKdDeriveEncryptedKeyResult::decode(&data) {
+        let reply = match VetKdDeriveKeyResult::decode(&data) {
             Ok(data) => data,
             Err(error) => {
                 return invalid_artifact_err(InvalidVetKdPayloadReason::DecodingError(format!(

--- a/rs/consensus/vetkd/src/test_utils.rs
+++ b/rs/consensus/vetkd/src/test_utils.rs
@@ -132,8 +132,8 @@ pub(super) fn fake_signature_request_args(key_id: MasterPublicKeyId) -> Threshol
         }),
         MasterPublicKeyId::VetKd(key_id) => ThresholdArguments::VetKd(VetKdArguments {
             key_id: key_id.clone(),
-            derivation_id: vec![1; 32],
-            encryption_public_key: vec![1; 32],
+            input: vec![1; 32],
+            transport_public_key: vec![1; 32],
             ni_dkg_id: fake_dkg_id(key_id),
             height: Height::from(100),
         }),

--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/benches/vetkd.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/benches/vetkd.rs
@@ -14,8 +14,8 @@ fn vetkd_bench(c: &mut Criterion) {
         TransportPublicKey::deserialize(&(G1Affine::generator() * tsk).to_affine().serialize())
             .unwrap();
 
-    let derivation_domain = DerivationDomain::new(&[1, 2, 3, 4], &[1, 2, 3]);
-    let did = rng.gen::<[u8; 32]>();
+    let context = DerivationContext::new(&[1, 2, 3, 4], &[1, 2, 3]);
+    let input = rng.gen::<[u8; 32]>();
 
     for threshold in [9, 19] {
         let nodes = threshold + threshold / 2;
@@ -32,25 +32,11 @@ fn vetkd_bench(c: &mut Criterion) {
         if threshold == 9 {
             group.bench_function("EncryptedKeyShare::create", |b| {
                 b.iter(|| {
-                    EncryptedKeyShare::create(
-                        rng,
-                        &master_pk,
-                        &node_sk,
-                        &tpk,
-                        &derivation_domain,
-                        &did,
-                    )
+                    EncryptedKeyShare::create(rng, &master_pk, &node_sk, &tpk, &context, &input)
                 })
             });
 
-            let eks = EncryptedKeyShare::create(
-                rng,
-                &master_pk,
-                &node_sk,
-                &tpk,
-                &derivation_domain,
-                &did,
-            );
+            let eks = EncryptedKeyShare::create(rng, &master_pk, &node_sk, &tpk, &context, &input);
 
             group.bench_function("EncryptedKeyShare::serialize", |b| {
                 b.iter(|| eks.serialize())
@@ -65,7 +51,7 @@ fn vetkd_bench(c: &mut Criterion) {
             });
 
             group.bench_function("EncryptedKeyShare::is_valid", |b| {
-                b.iter(|| eks.is_valid(&master_pk, &node_pk, &derivation_domain, &did, &tpk))
+                b.iter(|| eks.is_valid(&master_pk, &node_pk, &context, &input, &tpk))
             });
         }
 
@@ -75,14 +61,7 @@ fn vetkd_bench(c: &mut Criterion) {
             let node_sk = poly.evaluate_at(&Scalar::from_node_index(node as u32));
             let node_pk = G2Affine::from(G2Affine::generator() * &node_sk);
 
-            let eks = EncryptedKeyShare::create(
-                rng,
-                &master_pk,
-                &node_sk,
-                &tpk,
-                &derivation_domain,
-                &did,
-            );
+            let eks = EncryptedKeyShare::create(rng, &master_pk, &node_sk, &tpk, &context, &input);
 
             node_info.push((node as u32, node_pk, eks));
         }
@@ -92,12 +71,7 @@ fn vetkd_bench(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     EncryptedKey::combine_valid_shares(
-                        &node_info,
-                        threshold,
-                        &master_pk,
-                        &tpk,
-                        &derivation_domain,
-                        &did,
+                        &node_info, threshold, &master_pk, &tpk, &context, &input,
                     )
                     .unwrap()
                 })

--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/src/lib.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/src/lib.rs
@@ -13,31 +13,31 @@ use rand::{CryptoRng, RngCore};
 /// The index of a node
 pub type NodeIndex = u32;
 
-/// The derivation domain
+/// The derivation context
 #[derive(Clone)]
-pub struct DerivationDomain {
+pub struct DerivationContext {
     delta: Scalar,
 }
 
 // Prefix-freeness is not required, as the domain separator is used with XMD,
 // which includes the domain separator's length as a distinct input.
-const DERIVATION_DOMAIN_DST: &[u8; 39] = b"ic-vetkd-bls12-381-g2-derivation-domain";
+const DERIVATION_CONTEXT_DST: &[u8; 29] = b"ic-vetkd-bls12-381-g2-context";
 
-impl DerivationDomain {
-    /// Create a new derivation domain
-    pub fn new(canister_id: &[u8], domain: &[u8]) -> Self {
+impl DerivationContext {
+    /// Create a new derivation context
+    pub fn new(canister_id: &[u8], context: &[u8]) -> Self {
         let mut input = vec![];
         input.extend_from_slice(&(canister_id.len() as u64).to_be_bytes()); // 8 bytes length
         input.extend_from_slice(canister_id);
 
-        let mut delta = Scalar::hash(DERIVATION_DOMAIN_DST, &input);
+        let mut delta = Scalar::hash(DERIVATION_CONTEXT_DST, &input);
 
-        if !domain.is_empty() {
+        if !context.is_empty() {
             let mut input = vec![];
-            input.extend_from_slice(&(domain.len() as u64).to_be_bytes()); // 8 bytes length
-            input.extend_from_slice(domain.as_ref());
+            input.extend_from_slice(&(context.len() as u64).to_be_bytes()); // 8 bytes length
+            input.extend_from_slice(context.as_ref());
 
-            delta += Scalar::hash(DERIVATION_DOMAIN_DST, &input);
+            delta += Scalar::hash(DERIVATION_CONTEXT_DST, &input);
         }
 
         Self { delta }
@@ -99,9 +99,9 @@ impl DerivedPublicKey {
     /// The length of the serialized encoding of this type
     pub const BYTES: usize = G2Affine::BYTES;
 
-    /// Derive a public key relative to another public key and a derivation domain
-    pub fn compute_derived_key(pk: &G2Affine, derivation_domain: &DerivationDomain) -> Self {
-        let pt = G2Affine::from(G2Affine::generator() * derivation_domain.delta() + pk);
+    /// Derive a public key relative to another public key and a derivation context
+    pub fn compute_derived_key(pk: &G2Affine, context: &DerivationContext) -> Self {
+        let pt = G2Affine::from(G2Affine::generator() * context.delta() + pk);
         Self { pt }
     }
 
@@ -230,11 +230,11 @@ impl EncryptedKey {
         reconstruction_threshold: usize,
         master_pk: &G2Affine,
         tpk: &TransportPublicKey,
-        derivation_domain: &DerivationDomain,
-        did: &[u8],
+        context: &DerivationContext,
+        input: &[u8],
     ) -> Result<Self, EncryptedKeyCombinationError> {
         let c = Self::combine_unchecked(nodes, reconstruction_threshold)?;
-        if c.is_valid(master_pk, derivation_domain, did, tpk) {
+        if c.is_valid(master_pk, context, input, tpk) {
             Ok(c)
         } else {
             Err(EncryptedKeyCombinationError::InvalidShares)
@@ -252,8 +252,8 @@ impl EncryptedKey {
         reconstruction_threshold: usize,
         master_pk: &G2Affine,
         tpk: &TransportPublicKey,
-        derivation_domain: &DerivationDomain,
-        did: &[u8],
+        context: &DerivationContext,
+        input: &[u8],
     ) -> Result<Self, EncryptedKeyCombinationError> {
         if nodes.len() < reconstruction_threshold {
             return Err(EncryptedKeyCombinationError::InsufficientShares);
@@ -263,7 +263,7 @@ impl EncryptedKey {
         let mut valid_shares = Vec::with_capacity(reconstruction_threshold);
 
         for (node_index, node_pk, node_eks) in nodes.iter() {
-            if node_eks.is_valid(master_pk, node_pk, derivation_domain, did, tpk) {
+            if node_eks.is_valid(master_pk, node_pk, context, input, tpk) {
                 valid_shares.push((*node_index, node_eks.clone()));
 
                 if valid_shares.len() >= reconstruction_threshold {
@@ -283,23 +283,23 @@ impl EncryptedKey {
         //
         // This check is mostly to catch the case where the reconstruction_threshold was
         // somehow incorrect.
-        if c.is_valid(master_pk, derivation_domain, did, tpk) {
+        if c.is_valid(master_pk, context, input, tpk) {
             Ok(c)
         } else {
             Err(EncryptedKeyCombinationError::ReconstructionFailed)
         }
     }
 
-    /// Check if this encrypted key is valid with respect to the provided derivation domain
+    /// Check if this encrypted key is valid with respect to the provided derivation input and context
     pub fn is_valid(
         &self,
         master_pk: &G2Affine,
-        derivation_domain: &DerivationDomain,
-        did: &[u8],
+        context: &DerivationContext,
+        input: &[u8],
         tpk: &TransportPublicKey,
     ) -> bool {
-        let dpk = DerivedPublicKey::compute_derived_key(master_pk, derivation_domain);
-        let msg = G1Affine::augmented_hash(&dpk.pt, did);
+        let dpk = DerivedPublicKey::compute_derived_key(master_pk, context);
+        let msg = G1Affine::augmented_hash(&dpk.pt, input);
         check_validity(&self.c1, &self.c2, &self.c3, tpk, &dpk.pt, &msg)
     }
 
@@ -380,17 +380,17 @@ impl EncryptedKeyShare {
         master_pk: &G2Affine,
         node_sk: &Scalar,
         transport_pk: &TransportPublicKey,
-        derivation_domain: &DerivationDomain,
-        did: &[u8],
+        context: &DerivationContext,
+        input: &[u8],
     ) -> Self {
-        let delta = derivation_domain.delta();
+        let delta = context.delta();
 
         let dsk = delta + node_sk;
         let dpk = G2Affine::from(G2Affine::generator() * delta + master_pk);
 
         let r = Scalar::random(rng);
 
-        let msg = G1Affine::augmented_hash(&dpk, did);
+        let msg = G1Affine::augmented_hash(&dpk, input);
 
         let c1 = G1Affine::from(G1Affine::generator() * &r);
         let c2 = G2Affine::from(G2Affine::generator() * &r);
@@ -404,14 +404,14 @@ impl EncryptedKeyShare {
         &self,
         master_pk: &G2Affine,
         master_pki: &G2Affine,
-        derivation_domain: &DerivationDomain,
-        did: &[u8],
+        context: &DerivationContext,
+        input: &[u8],
         tpk: &TransportPublicKey,
     ) -> bool {
-        let dpki = DerivedPublicKey::compute_derived_key(master_pki, derivation_domain);
-        let dpk = DerivedPublicKey::compute_derived_key(master_pk, derivation_domain);
+        let dpki = DerivedPublicKey::compute_derived_key(master_pki, context);
+        let dpk = DerivedPublicKey::compute_derived_key(master_pk, context);
 
-        let msg = G1Affine::augmented_hash(&dpk.pt, did);
+        let msg = G1Affine::augmented_hash(&dpk.pt, input);
 
         check_validity(&self.c1, &self.c2, &self.c3, tpk, &dpki.pt, &msg)
     }

--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
@@ -58,9 +58,9 @@ impl TransportSecretKey {
         &self,
         ek: &EncryptedKey,
         dpk: &DerivedPublicKey,
-        did: &[u8],
+        input: &[u8],
     ) -> Option<G1Affine> {
-        let msg = G1Affine::augmented_hash(dpk.point(), did);
+        let msg = G1Affine::augmented_hash(dpk.point(), input);
 
         let k = G1Affine::from(G1Projective::from(ek.c3()) - ek.c1() * self.secret());
 
@@ -90,11 +90,11 @@ fn transport_key_gen_is_stable() {
                "ac9524f219f1f958f261c87577e49dbbf2182c4060d51f84b8a0efac33c3c7ba9cd0bc9f41edf434d6c8a8fe20077e50");
 }
 
-fn random_derivation_domain<R: RngCore + CryptoRng>(rng: &mut R) -> DerivationDomain {
+fn random_derivation_context<R: RngCore + CryptoRng>(rng: &mut R) -> DerivationContext {
     let canister_id = rng.gen::<[u8; 32]>();
-    let derivation_domain = rng.gen::<[u8; 32]>();
+    let context = rng.gen::<[u8; 32]>();
 
-    DerivationDomain::new(&canister_id, &derivation_domain)
+    DerivationContext::new(&canister_id, &context)
 }
 
 #[test]
@@ -111,35 +111,28 @@ fn encrypted_key_share_creation_is_stable() {
     let master_sk = poly.coeff(0);
     let master_pk = G2Affine::from(G2Affine::generator() * master_sk);
 
-    let derivation_domain = random_derivation_domain(&mut rng);
-    let did = rng.gen::<[u8; 28]>();
+    let context = random_derivation_context(&mut rng);
+    let input = rng.gen::<[u8; 28]>();
 
     const EXPECTED_EKS_VALUE: [&str; NODES] = [
-        "811d9cd064cd7c6ab4a448c68b8b5fc8a5f08cd17c78d46469e810e8df3d1f8d3f1431ccf627e2198b72d850eb99b2e2b2dfe2c43ddf86e5403ba474a3a0ba596ddabecfe303eddfd70444057baaae733f92eca70509425f87633ce9d78a28040b559446e22f73d637b04c6eca6ecff71fb3d1a662d86ef22fa6c3ef8157c582e4afdc7a0047d4535c6e01e9c65eae78b2c70a180dd7545c16803bd5284294a9c09866544f02a28bbb9ad06728661942ba1e41c2c3043c121b2430b30debf927",
-"aca469bb1dd96297c86044e6032c15fbf2a2c380764085be21d50cff4b9f52f5e32e8c7fd718d64b435334b4aa9f8016a4dbcedc7da27a8b23d4b254850a26e75cb7e744585f0bcf5fb4b7ffb7befa0a983cbff9de8d22be23f6674a32fd058a03f31140af7af5934a23ef4494fe1bd2ff3947dae35f4bc653388878fdea0a451d7bdd1ecaabec217faa1efcf24dd5a6869bfcf18cb7c93554c18a1f763aa35c26ad851808256d335a8f09c37c3fdbb4dd1a4b5745ce4643fd11fda5a26ae44c",
-"abc9b461b441ce17b4d581f5a82f0f21dfb0091c9c097e2f4ce7962adf7c14d14d86c9765dc2e296c66a02187699fbe396767f7fdbe594a787368bb59ef5d43b70bd0c7a39e07b27107cdc7fb06de7da15a2a33cd10593b65764c98a7591726a0f603451396769fdaf5bd3b69ff0b7f515b4fd1dd0629b3762bc3916b8c2e01d2bfd5ddebc9f638191cc919da5a5d619b6152fe4a84bc85f9f8164c5eb6de30c61305e311981f92d4039e2b30c53575f48b6c8d68d30e4492055d85d584ec96f",
-"92ef0d8f00e18f23879783c51c72b9706c7ad0df2a2ba44d651c5c3d903431ca49732637a579eb8c423e2b79faf9fb0b95fb96958149013e2932286ccf93bcbb94386df13e0519927b231a39f9a40b82bcd7fea94490e574493fa38a7a809a2211f4f2296639157bfe932518a5b4d8ccee3ac4997dce11aab4ff31633f715c1b1c3a6cc3a9ee14b879d0c890721d0e3f8d2f4ecaa7e46a1e1f473a633ee7ea14a3ef1bec7d6b03565c393a51529d525fe9f6e3e9417376a3b4f4de8e000dd928",
-"8efef76050abe03984f8b22b1cd6075a89e361c8f70bd2b493185d710ff284cca2d32c41d05735f5d9f39a4ea9b5e2cb8b4b207ec0d535c835768f95a0a1e13018b185b77f6e506fe85c2014989113b2c59935f2e323db5913bdddff8b56aa5a000a6f4e4c409a9ead3945979e3914e903b75bf754587ffbcead720960dfbcb6407d193acc91734cf61ef47d8b8684c5a7fb880804d8961a60185fbec60ac08f7b8677a5de5e6d953c095d23a4386f9309d1108037d14490dae41bf1b4297e22",
-"80ac9ea725ec6101b18e316e7f8ff9cdbf7619549b5b9cea767203deb4b0e0496c1c84e828e74268d2368937e7f9a34195b3697321df62a084bcc2cc2bf079ce2638625bbf243d906130a700908ce481dbbe1d32b014e89baef97cc10aa6f914092a904efd5d904a1ed3687361a186126858f14bc84cdd00cc0c4671313874f1ebedf1bddc3bb3d0484e23dfc754a676a89ed48682ceed038160fdfbb0b78d67a7e43379e43588d7eba20234715c167e9a9154a55ff6076f487f09305be9c321",
-"92b3a643f608fd4ccbb7644cbb1b38ac39a6cb4461846c6cf79c3610a411fd4e8709b960260966586f67e2e0d6cf6c5b85b45c442c3f78bda0666389631a8a8c8b1c642eaa4c0214781c6ada600fd1a7663b43b844a6f7a96741315674090b7f10534d4789de9fc1829b7a97f30dedd86b8f801ac01c1f8a8e1fb247cec9f726dabe43a6f246e7248b8a6675370c4731a11c8e41e3c16a8c3385e728d5236dca1f99423de996ccd0dc5c3f8f588699c538fd5b992e2160a00bc9c27655d26645",
-"807e2fa6fe3e4bec12953acc2b57bf4cd49614cfbccb393bbaa4a04d614f1b85a7bbae48ed5c147e05786a7a29494c2092cfd5bd41d088213fa676abd137ad6e4511ff65811c7622068d995c1d38e36f5a90284c7a5769510c1e71fb46bace121742873aa75b1956f331d13e7541fdd862d617965ed541376598a541bf2bc47e370f728e86c909b943b1db0cf6e38dba8402d73ec34c7f79e05c5a8e2a6d3f3d089f783d8e555b0aeb9cf3fd16df53e2ffda5b507ae4dd7be3748178cea36353",
-"b90e01a902b1af0a9039d32b1325c030424791d2a7c72dbb68cf17c962b80e2897b29bccf1bda9587f62d019098938b1b68aaf0628576dd28569de2bbc705ac51ae9e69552e912894b47d87d3af588466ad30316de574dd7663129ee342c949f101501911075cb27af2255635e9ea68401ccda1edf127ec3472d1018b0e1a012d352849ef40b835ab5357785798bbd15a256954aafe184a96fc2702bf08e5ea6fd23a6dba11e3c7f04620cdec59c1d5ba5bef8c94008fd91bbdc5bd4090f5649",
-"b653a21c480fccfb9b69419240cdb530e18f23b8a2bc5296073e8bea44f49104172158f2e2deec0cc1f6ed44d667bab5ab0cabfb9bd23b775fc903c2d2ddb3874c522c54e3465ed7ebbb8cec4f3e0bbca5537c8e4792a4bd0ce0e81196c49e14046ea5482f08f760d3be6b524a86f81771934cc91e1f6ed5aafc38f236ae74eba2d3d21458c0d19907b762a8fa2b860da12f6c727808e176b4fd402a171f2f7bdbb3c282a7da823b1ccda8234375d2eb4869d953ac084d50dc3b53d72e3c5803",
-"8489576ac848031c6e90ad9e0477fc72e766ccf00894db8ae9536415d817a4478726e4e1247ffa8656209a23ca261fa088312490c4d7b4f029f9b944196e4e3f1eb52c6a89e1ba9fc87f42c09ed3ae1490d10cdbda013863c775f00f3d070de413af98b3b688a397ab4124bc316876a4c015059607040c9faed27191db1e875e072c923fb4575f771cdb70f4ef0fbd73b069a542f2b6b902b412ae7a2bcfd62b205ea5d3a684b12568df00e54f65990879d39dda2c153b140b15bdebac4c69e5",
-"87bfe03641974e967fb16ebeb7a571c5723c932bbe43620a81844e86857173b2800927111338080e8b33033b9253810b82a51763af54e9e05427740320aaedc813df05a17a572673502a331d5a243e4aa23bd1b49c09031c3618740f83ae3e7d0193dd05fdf4c198f88e68b7610f18667ffc547c8f432e530657f3be3ab383e08e5d1bf0945a960fa1fafed56392c1679318948965619db4e9fb1af707b33889a8570a07f5dd597ef3602c373c574e2e6d41189d5ee0734b8c2356848b8f46e3",
-"acba95a4699263d14effffef5c454e18dd77d0c319e3177ee3052b95f5ad12953f312359959345720f9fa58aacc42f3087687b8fedf4a03a50b67ede7b2719049f008434fb6fc02d4ac80502f8d8f4ce6be3ae729412572a89bd8442118eb61517625cf6ec00b9ff5bed334c1af93dd32d208c662c4b98d45a25ed7bb5410ef0e9f3d1cf628d1458a1e67ab7af2b39ed8258948ef8376d38540921fa30338879991b522ac37f4bf371ed3efb7a596c8c71e4d6730c37683a2658b475e8d85a06",
+        "811d9cd064cd7c6ab4a448c68b8b5fc8a5f08cd17c78d46469e810e8df3d1f8d3f1431ccf627e2198b72d850eb99b2e2b2dfe2c43ddf86e5403ba474a3a0ba596ddabecfe303eddfd70444057baaae733f92eca70509425f87633ce9d78a28040b559446e22f73d637b04c6eca6ecff71fb3d1a662d86ef22fa6c3ef8157c582e4afdc7a0047d4535c6e01e9c65eae78b2fd3c10078bac9d1c57348139f021362a3e3e48e37290fa07ed2eb502af07536c0b39b4f98c3c02c9c6c1abc0228f74",
+"aca469bb1dd96297c86044e6032c15fbf2a2c380764085be21d50cff4b9f52f5e32e8c7fd718d64b435334b4aa9f8016a4dbcedc7da27a8b23d4b254850a26e75cb7e744585f0bcf5fb4b7ffb7befa0a983cbff9de8d22be23f6674a32fd058a03f31140af7af5934a23ef4494fe1bd2ff3947dae35f4bc653388878fdea0a451d7bdd1ecaabec217faa1efcf24dd5a68b891df0a7df3256aa6e42ed2892450229838e7a511431768736c14c6715a58cd68ae689df2d899b662842658026a7bd",
+"abc9b461b441ce17b4d581f5a82f0f21dfb0091c9c097e2f4ce7962adf7c14d14d86c9765dc2e296c66a02187699fbe396767f7fdbe594a787368bb59ef5d43b70bd0c7a39e07b27107cdc7fb06de7da15a2a33cd10593b65764c98a7591726a0f603451396769fdaf5bd3b69ff0b7f515b4fd1dd0629b3762bc3916b8c2e01d2bfd5ddebc9f638191cc919da5a5d61988990a9c57a7ff63fa4fdc727ca7db153aa5ac5d911cbfe5b3b6557090eb6733054866c2e9a419b5493e80c6294db161",
+"92ef0d8f00e18f23879783c51c72b9706c7ad0df2a2ba44d651c5c3d903431ca49732637a579eb8c423e2b79faf9fb0b95fb96958149013e2932286ccf93bcbb94386df13e0519927b231a39f9a40b82bcd7fea94490e574493fa38a7a809a2211f4f2296639157bfe932518a5b4d8ccee3ac4997dce11aab4ff31633f715c1b1c3a6cc3a9ee14b879d0c890721d0e3fb58ec134e05c8c922a96c5a44e4d75e5d5b2b7a50222cf90b05ab847a3d632d5d24c26606ea69f494d9515ec44ffdfcc",
+"8efef76050abe03984f8b22b1cd6075a89e361c8f70bd2b493185d710ff284cca2d32c41d05735f5d9f39a4ea9b5e2cb8b4b207ec0d535c835768f95a0a1e13018b185b77f6e506fe85c2014989113b2c59935f2e323db5913bdddff8b56aa5a000a6f4e4c409a9ead3945979e3914e903b75bf754587ffbcead720960dfbcb6407d193acc91734cf61ef47d8b8684c591918f451f86b074cb9aa2759fe6a48b2fbac8de9aa3016a5e146663f32ee98263577228217e5a00d61838e606972098",
+"80ac9ea725ec6101b18e316e7f8ff9cdbf7619549b5b9cea767203deb4b0e0496c1c84e828e74268d2368937e7f9a34195b3697321df62a084bcc2cc2bf079ce2638625bbf243d906130a700908ce481dbbe1d32b014e89baef97cc10aa6f914092a904efd5d904a1ed3687361a186126858f14bc84cdd00cc0c4671313874f1ebedf1bddc3bb3d0484e23dfc754a676a1be9db0b3532ec1b4798a9f616bc18b888b80025f7b33df0ada3729ba68f2e2097bfed17997708c9143e270d7654f75",
+"92b3a643f608fd4ccbb7644cbb1b38ac39a6cb4461846c6cf79c3610a411fd4e8709b960260966586f67e2e0d6cf6c5b85b45c442c3f78bda0666389631a8a8c8b1c642eaa4c0214781c6ada600fd1a7663b43b844a6f7a96741315674090b7f10534d4789de9fc1829b7a97f30dedd86b8f801ac01c1f8a8e1fb247cec9f726dabe43a6f246e7248b8a6675370c4731aa68cfc3ad3a0357510618ca48b4c509d92b6427438ad07353fbc868a85a04d7a4b1adf65d6bfaa7fcece7217dd27b3d",
+"807e2fa6fe3e4bec12953acc2b57bf4cd49614cfbccb393bbaa4a04d614f1b85a7bbae48ed5c147e05786a7a29494c2092cfd5bd41d088213fa676abd137ad6e4511ff65811c7622068d995c1d38e36f5a90284c7a5769510c1e71fb46bace121742873aa75b1956f331d13e7541fdd862d617965ed541376598a541bf2bc47e370f728e86c909b943b1db0cf6e38dbab909272120421f1312038c54829e62758935408bc4369ed2db6951ee926135485a8262c1dd5b35202c1a3baa61618069",
+"b90e01a902b1af0a9039d32b1325c030424791d2a7c72dbb68cf17c962b80e2897b29bccf1bda9587f62d019098938b1b68aaf0628576dd28569de2bbc705ac51ae9e69552e912894b47d87d3af588466ad30316de574dd7663129ee342c949f101501911075cb27af2255635e9ea68401ccda1edf127ec3472d1018b0e1a012d352849ef40b835ab5357785798bbd15933adb417fb0fab32cfcc26465484bb0fe879756b3841113d8c3e61babe5189909ed523002ad6a21d8b534e1b83e6b0c",
+"b653a21c480fccfb9b69419240cdb530e18f23b8a2bc5296073e8bea44f49104172158f2e2deec0cc1f6ed44d667bab5ab0cabfb9bd23b775fc903c2d2ddb3874c522c54e3465ed7ebbb8cec4f3e0bbca5537c8e4792a4bd0ce0e81196c49e14046ea5482f08f760d3be6b524a86f81771934cc91e1f6ed5aafc38f236ae74eba2d3d21458c0d19907b762a8fa2b860d8c65eaa42ce4de689fab1bb08355ed84154ca2e3bf193d2f27b4c18cf60e6767a323c9f19e15ca0f70ae110ced640463",
+"8489576ac848031c6e90ad9e0477fc72e766ccf00894db8ae9536415d817a4478726e4e1247ffa8656209a23ca261fa088312490c4d7b4f029f9b944196e4e3f1eb52c6a89e1ba9fc87f42c09ed3ae1490d10cdbda013863c775f00f3d070de413af98b3b688a397ab4124bc316876a4c015059607040c9faed27191db1e875e072c923fb4575f771cdb70f4ef0fbd73b257c80458579e3f937f9f949253c6f56618f18d3a95b0274da8c90f419afdccdb134b9af1234e37845af749701b0202",
+"87bfe03641974e967fb16ebeb7a571c5723c932bbe43620a81844e86857173b2800927111338080e8b33033b9253810b82a51763af54e9e05427740320aaedc813df05a17a572673502a331d5a243e4aa23bd1b49c09031c3618740f83ae3e7d0193dd05fdf4c198f88e68b7610f18667ffc547c8f432e530657f3be3ab383e08e5d1bf0945a960fa1fafed56392c167ac5203693925b04ab67ada77b4b8969d697f0f17d2860e758ecda9a98d6a98d0405fcc1bc13ef360c8cdb6bbb821293d",
+"acba95a4699263d14effffef5c454e18dd77d0c319e3177ee3052b95f5ad12953f312359959345720f9fa58aacc42f3087687b8fedf4a03a50b67ede7b2719049f008434fb6fc02d4ac80502f8d8f4ce6be3ae729412572a89bd8442118eb61517625cf6ec00b9ff5bed334c1af93dd32d208c662c4b98d45a25ed7bb5410ef0e9f3d1cf628d1458a1e67ab7af2b39eda08b709f917bec7fe63a4b4aaac5a662a921098f9fbc5f61c6208ca44ab36241bdff9b0dd5d621329b9ff262e4ce239c",
     ];
 
     for (node_idx, expected_eks) in EXPECTED_EKS_VALUE.iter().enumerate() {
         let node_sk = poly.evaluate_at(&Scalar::from_node_index(node_idx as u32));
-        let eks = EncryptedKeyShare::create(
-            &mut rng,
-            &master_pk,
-            &node_sk,
-            &tpk,
-            &derivation_domain,
-            &did,
-        );
+        let eks = EncryptedKeyShare::create(&mut rng, &master_pk, &node_sk, &tpk, &context, &input);
         assert_eq!(*expected_eks, hex::encode(eks.serialize()));
     }
 }
@@ -185,8 +178,8 @@ impl VetkdTestProtocolSetup {
 
 struct VetkdTestProtocolExecution<'a> {
     setup: &'a VetkdTestProtocolSetup,
-    did: Vec<u8>,
-    derivation_path: DerivationDomain,
+    input: Vec<u8>,
+    context: DerivationContext,
     derived_pk: DerivedPublicKey,
 }
 
@@ -195,16 +188,15 @@ impl<'a> VetkdTestProtocolExecution<'a> {
         rng: &mut R,
         setup: &'a VetkdTestProtocolSetup,
     ) -> VetkdTestProtocolExecution<'a> {
-        let did = rng.gen::<[u8; 32]>().to_vec();
-        let derivation_domain = random_derivation_domain(rng);
+        let input = rng.gen::<[u8; 32]>().to_vec();
+        let context = random_derivation_context(rng);
 
-        let derived_pk =
-            DerivedPublicKey::compute_derived_key(&setup.master_pk, &derivation_domain);
+        let derived_pk = DerivedPublicKey::compute_derived_key(&setup.master_pk, &context);
 
         Self {
             setup,
-            did,
-            derivation_path: derivation_domain,
+            input,
+            context,
             derived_pk,
         }
     }
@@ -212,11 +204,11 @@ impl<'a> VetkdTestProtocolExecution<'a> {
     fn create_encrypted_key_shares<R: Rng + CryptoRng>(
         &self,
         rng: &mut R,
-        did: Option<&[u8]>,
+        input: Option<&[u8]>,
     ) -> Vec<(u32, G2Affine, EncryptedKeyShare)> {
         let mut node_info = Vec::with_capacity(self.setup.nodes);
 
-        let did = did.unwrap_or(&self.did);
+        let input = input.unwrap_or(&self.input);
 
         for (node_idx, (node_pk, node_sk)) in self.setup.node_key_material.iter().enumerate() {
             let eks = EncryptedKeyShare::create(
@@ -224,15 +216,15 @@ impl<'a> VetkdTestProtocolExecution<'a> {
                 &self.setup.master_pk,
                 node_sk,
                 &self.setup.transport_pk,
-                &self.derivation_path,
-                did,
+                &self.context,
+                input,
             );
 
             assert!(eks.is_valid(
                 &self.setup.master_pk,
                 node_pk,
-                &self.derivation_path,
-                did,
+                &self.context,
+                input,
                 &self.setup.transport_pk
             ));
 
@@ -256,8 +248,8 @@ impl<'a> VetkdTestProtocolExecution<'a> {
             self.setup.threshold,
             &self.setup.master_pk,
             &self.setup.transport_pk,
-            &self.derivation_path,
-            &self.did,
+            &self.context,
+            &self.input,
         )
     }
 
@@ -270,8 +262,8 @@ impl<'a> VetkdTestProtocolExecution<'a> {
             self.setup.threshold,
             &self.setup.master_pk,
             &self.setup.transport_pk,
-            &self.derivation_path,
-            &self.did,
+            &self.context,
+            &self.input,
         )
     }
 }
@@ -315,14 +307,14 @@ fn test_protocol_execution() {
 
             assert!(ek.is_valid(
                 &setup.master_pk,
-                &proto.derivation_path,
-                &proto.did,
+                &proto.context,
+                &proto.input,
                 &setup.transport_pk
             ));
 
             let k = setup
                 .transport_sk
-                .decrypt(&ek, &proto.derived_pk, &proto.did)
+                .decrypt(&ek, &proto.derived_pk, &proto.input)
                 .expect("Decryption failed");
 
             keys_recovered.push(k);
@@ -342,7 +334,7 @@ fn test_protocol_execution() {
     }
 
     // Check that the vetkey output is a valid BLS signature
-    let msg = G1Affine::augmented_hash(proto.derived_pk.point(), &proto.did);
+    let msg = G1Affine::augmented_hash(proto.derived_pk.point(), &proto.input);
 
     assert!(verify_bls_signature(
         &vetkey,
@@ -352,11 +344,11 @@ fn test_protocol_execution() {
 
     // Check that if we introduce incorrect shares then combine_all will fail
 
-    let other_did = rng.gen::<[u8; 24]>();
-    assert_ne!(proto.did, other_did);
-    let node_info_wrong_did = proto.create_encrypted_key_shares(rng, Some(&other_did));
+    let other_input = rng.gen::<[u8; 24]>();
+    assert_ne!(proto.input, other_input);
+    let node_info_wrong_input = proto.create_encrypted_key_shares(rng, Some(&other_input));
 
-    let node_eks_wrong_did = node_info_wrong_did
+    let node_eks_wrong_input = node_info_wrong_input
         .iter()
         .map(|(idx, _pk, eks)| (*idx, eks.clone()))
         .collect::<Vec<_>>();
@@ -368,13 +360,13 @@ fn test_protocol_execution() {
 
         // Avoid using a duplicate index for this test
         let random_unused_idx = loop {
-            let idx = (rng.gen::<usize>() % node_eks_wrong_did.len()) as u32;
+            let idx = (rng.gen::<usize>() % node_eks_wrong_input.len()) as u32;
             if !shares.iter().map(|(i, _eks)| *i).any(|x| x == idx) {
                 break idx as usize;
             }
         };
 
-        shares.push(node_eks_wrong_did[random_unused_idx].clone());
+        shares.push(node_eks_wrong_input[random_unused_idx].clone());
         shares.shuffle(rng);
 
         let expected_error = if rec_threshold < threshold {
@@ -412,7 +404,7 @@ fn test_protocol_execution() {
 
     for rec_threshold in threshold..nodes {
         let mut shares = random_subset(rng, &node_info, rec_threshold);
-        shares.append(&mut random_subset(rng, &node_info_wrong_did, 4));
+        shares.append(&mut random_subset(rng, &node_info_wrong_input, 4));
         shares.shuffle(rng);
 
         let combined = proto.combine_valid(&shares);
@@ -423,7 +415,7 @@ fn test_protocol_execution() {
             .decrypt(
                 &combined.expect("Already checked"),
                 &proto.derived_pk,
-                &proto.did,
+                &proto.input,
             )
             .expect("Decryption failed");
 

--- a/rs/crypto/internal/crypto_service_provider/src/vault/api.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/api.rs
@@ -25,7 +25,7 @@ use ic_types::crypto::canister_threshold_sig::error::{
 use ic_types::crypto::canister_threshold_sig::idkg::{
     BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
-use ic_types::crypto::vetkd::{VetKdDerivationDomain, VetKdEncryptedKeyShareContent};
+use ic_types::crypto::vetkd::{VetKdDerivationContext, VetKdEncryptedKeyShareContent};
 use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CryptoError, CurrentNodePublicKeys};
 use ic_types::{NodeId, NodeIndex, NumberOfNodes, Randomness};
@@ -959,9 +959,9 @@ pub trait VetKdCspVault {
         &self,
         key_id: KeyId,
         master_public_key: Vec<u8>,
-        encryption_public_key: Vec<u8>,
-        derivation_domain: VetKdDerivationDomain,
-        derivation_id: Vec<u8>,
+        transport_public_key: Vec<u8>,
+        context: VetKdDerivationContext,
+        input: Vec<u8>,
     ) -> Result<VetKdEncryptedKeyShareContent, VetKdEncryptedKeyShareCreationVaultError>;
 }
 

--- a/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/vetkd/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/vetkd/mod.rs
@@ -5,11 +5,11 @@ use crate::types::CspSecretKey;
 use crate::vault::api::{VetKdCspVault, VetKdEncryptedKeyShareCreationVaultError};
 use crate::vault::local_csp_vault::LocalCspVault;
 use ic_crypto_internal_bls12_381_vetkd::{
-    DerivationDomain, EncryptedKeyShare, G2Affine, PairingInvalidPoint, Scalar, TransportPublicKey,
-    TransportPublicKeyDeserializationError,
+    DerivationContext, EncryptedKeyShare, G2Affine, PairingInvalidPoint, Scalar,
+    TransportPublicKey, TransportPublicKeyDeserializationError,
 };
 use ic_crypto_internal_logmon::metrics::{MetricsDomain, MetricsResult, MetricsScope};
-use ic_types::crypto::vetkd::{VetKdDerivationDomain, VetKdEncryptedKeyShareContent};
+use ic_types::crypto::vetkd::{VetKdDerivationContext, VetKdEncryptedKeyShareContent};
 use rand::{CryptoRng, Rng};
 
 #[cfg(test)]
@@ -23,17 +23,17 @@ impl<R: Rng + CryptoRng, S: SecretKeyStore, C: SecretKeyStore, P: PublicKeyStore
         &self,
         key_id: KeyId,
         master_public_key: Vec<u8>,
-        encryption_public_key: Vec<u8>,
-        derivation_domain: VetKdDerivationDomain,
-        derivation_id: Vec<u8>,
+        transport_public_key: Vec<u8>,
+        context: VetKdDerivationContext,
+        input: Vec<u8>,
     ) -> Result<VetKdEncryptedKeyShareContent, VetKdEncryptedKeyShareCreationVaultError> {
         let start_time = self.metrics.now();
         let result = self.create_encrypted_vetkd_key_share_internal(
             key_id,
             master_public_key,
-            encryption_public_key,
-            derivation_domain,
-            derivation_id,
+            transport_public_key,
+            context,
+            input,
         );
         self.metrics.observe_duration_seconds(
             MetricsDomain::VetKd,
@@ -53,17 +53,17 @@ impl<R: Rng + CryptoRng, S: SecretKeyStore, C: SecretKeyStore, P: PublicKeyStore
         &self,
         key_id: KeyId,
         master_public_key: Vec<u8>,
-        encryption_public_key: Vec<u8>,
-        derivation_domain: VetKdDerivationDomain,
-        derivation_id: Vec<u8>,
+        transport_public_key: Vec<u8>,
+        context: VetKdDerivationContext,
+        input: Vec<u8>,
     ) -> Result<VetKdEncryptedKeyShareContent, VetKdEncryptedKeyShareCreationVaultError> {
         let master_public_key =
             G2Affine::deserialize(&master_public_key).map_err(|_: PairingInvalidPoint| {
                 VetKdEncryptedKeyShareCreationVaultError::InvalidArgumentMasterPublicKey
             })?;
 
-        let transport_public_key = TransportPublicKey::deserialize(&encryption_public_key)
-            .map_err(|e| match e {
+        let transport_public_key =
+            TransportPublicKey::deserialize(&transport_public_key).map_err(|e| match e {
                 TransportPublicKeyDeserializationError::InvalidPublicKey => {
                     VetKdEncryptedKeyShareCreationVaultError::InvalidArgumentEncryptionPublicKey
                 }
@@ -95,11 +95,8 @@ impl<R: Rng + CryptoRng, S: SecretKeyStore, C: SecretKeyStore, P: PublicKeyStore
             &master_public_key,
             &secret_bls_scalar,
             &transport_public_key,
-            &DerivationDomain::new(
-                derivation_domain.caller.as_slice(),
-                &derivation_domain.domain,
-            ),
-            &derivation_id,
+            &DerivationContext::new(context.caller.as_slice(), &context.context),
+            &input,
         );
 
         Ok(VetKdEncryptedKeyShareContent(

--- a/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/mod.rs
@@ -29,7 +29,7 @@ use ic_types::crypto::canister_threshold_sig::error::{
 use ic_types::crypto::canister_threshold_sig::idkg::{
     BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
-use ic_types::crypto::vetkd::{VetKdDerivationDomain, VetKdEncryptedKeyShareContent};
+use ic_types::crypto::vetkd::{VetKdDerivationContext, VetKdEncryptedKeyShareContent};
 use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CurrentNodePublicKeys};
 use ic_types::{NodeId, NodeIndex, NumberOfNodes, Randomness};
@@ -248,9 +248,9 @@ pub trait TarpcCspVault {
     async fn create_encrypted_vetkd_key_share(
         key_id: KeyId,
         master_public_key: ByteBuf,
-        encryption_public_key: ByteBuf,
-        derivation_domain: VetKdDerivationDomain,
-        derivation_id: ByteBuf,
+        transport_public_key: ByteBuf,
+        context: VetKdDerivationContext,
+        input: ByteBuf,
     ) -> Result<VetKdEncryptedKeyShareContent, VetKdEncryptedKeyShareCreationVaultError>;
 
     async fn new_public_seed() -> Result<Seed, PublicRandomSeedGeneratorError>;

--- a/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_client.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_client.rs
@@ -45,7 +45,7 @@ use ic_types::crypto::canister_threshold_sig::error::{
 use ic_types::crypto::canister_threshold_sig::idkg::{
     BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
-use ic_types::crypto::vetkd::{VetKdDerivationDomain, VetKdEncryptedKeyShareContent};
+use ic_types::crypto::vetkd::{VetKdDerivationContext, VetKdEncryptedKeyShareContent};
 use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CurrentNodePublicKeys};
 use ic_types::{NodeId, NumberOfNodes, Randomness};
@@ -822,17 +822,17 @@ impl VetKdCspVault for RemoteCspVault {
         &self,
         key_id: KeyId,
         master_public_key: Vec<u8>,
-        encryption_public_key: Vec<u8>,
-        derivation_domain: VetKdDerivationDomain,
-        derivation_id: Vec<u8>,
+        transport_public_key: Vec<u8>,
+        context: VetKdDerivationContext,
+        input: Vec<u8>,
     ) -> Result<VetKdEncryptedKeyShareContent, VetKdEncryptedKeyShareCreationVaultError> {
         self.tokio_block_on(self.tarpc_csp_client.create_encrypted_vetkd_key_share(
             context_with_timeout(self.rpc_timeout),
             key_id,
             ByteBuf::from(master_public_key),
-            ByteBuf::from(encryption_public_key),
-            derivation_domain,
-            ByteBuf::from(derivation_id),
+            ByteBuf::from(transport_public_key),
+            context,
+            ByteBuf::from(input),
         ))
         .unwrap_or_else(|rpc_error: tarpc::client::RpcError| {
             Err(

--- a/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_server.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_server.rs
@@ -45,7 +45,7 @@ use ic_types::crypto::canister_threshold_sig::error::{
 use ic_types::crypto::canister_threshold_sig::idkg::{
     BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
-use ic_types::crypto::vetkd::{VetKdDerivationDomain, VetKdEncryptedKeyShareContent};
+use ic_types::crypto::vetkd::{VetKdDerivationContext, VetKdEncryptedKeyShareContent};
 use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CurrentNodePublicKeys};
 use ic_types::{NodeId, NumberOfNodes, Randomness};
@@ -535,18 +535,18 @@ impl<C: CspVault + 'static> TarpcCspVault for TarpcCspVaultServerWorker<C> {
         _: context::Context,
         key_id: KeyId,
         master_public_key: ByteBuf,
-        encryption_public_key: ByteBuf,
-        derivation_domain: VetKdDerivationDomain,
-        derivation_id: ByteBuf,
+        transport_public_key: ByteBuf,
+        context: VetKdDerivationContext,
+        input: ByteBuf,
     ) -> Result<VetKdEncryptedKeyShareContent, VetKdEncryptedKeyShareCreationVaultError> {
         let vault = self.local_csp_vault;
         let job = move || {
             vault.create_encrypted_vetkd_key_share(
                 key_id,
                 master_public_key.into_vec(),
-                encryption_public_key.into_vec(),
-                derivation_domain,
-                derivation_id.into_vec(),
+                transport_public_key.into_vec(),
+                context,
+                input.into_vec(),
             )
         };
         execute_on_thread_pool(&self.thread_pool, job).await

--- a/rs/crypto/src/vetkd/mod.rs
+++ b/rs/crypto/src/vetkd/mod.rs
@@ -5,7 +5,7 @@ use crate::sign::BasicSignerInternal;
 use crate::sign::ThresholdSigDataStore;
 use crate::{CryptoComponentImpl, LockableThresholdSigDataStore};
 use ic_crypto_internal_bls12_381_vetkd::{
-    DerivationDomain, EncryptedKeyCombinationError, EncryptedKeyShare,
+    DerivationContext, EncryptedKeyCombinationError, EncryptedKeyShare,
     EncryptedKeyShareDeserializationError, G2Affine, NodeIndex, PairingInvalidPoint,
     TransportPublicKey, TransportPublicKeyDeserializationError,
 };
@@ -238,9 +238,9 @@ fn create_encrypted_key_share_internal<S: CspSigner>(
         .create_encrypted_vetkd_key_share(
             key_id,
             master_public_key.as_bytes().to_vec(),
-            args.encryption_public_key,
-            args.derivation_domain,
-            args.derivation_id,
+            args.transport_public_key,
+            args.context,
+            args.input,
         )
         .map_err(vetkd_key_share_creation_error_from_vault_error)?;
 
@@ -350,7 +350,7 @@ fn combine_encrypted_key_shares_internal<C: ThresholdSignatureCspClient>(
                 VetKdKeyShareCombinationError::InvalidArgumentMasterPublicKey
             }
         })?;
-    let transport_public_key = TransportPublicKey::deserialize(&args.encryption_public_key)
+    let transport_public_key = TransportPublicKey::deserialize(&args.transport_public_key)
         .map_err(|e| match e {
             TransportPublicKeyDeserializationError::InvalidPublicKey => {
                 VetKdKeyShareCombinationError::InvalidArgumentEncryptionPublicKey
@@ -380,18 +380,15 @@ fn combine_encrypted_key_shares_internal<C: ThresholdSignatureCspClient>(
         .iter()
         .map(|(_node_id, node_index, clib_share)| (*node_index, clib_share.clone()))
         .collect();
-    let derivation_domain = DerivationDomain::new(
-        args.derivation_domain.caller.as_slice(),
-        &args.derivation_domain.domain,
-    );
+    let context = DerivationContext::new(args.context.caller.as_slice(), &args.context.context);
 
     match ic_crypto_internal_bls12_381_vetkd::EncryptedKey::combine_all(
         &clib_shares_for_combine_all[..],
         reconstruction_threshold,
         &master_public_key,
         &transport_public_key,
-        &derivation_domain,
-        &args.derivation_id,
+        &context,
+        &args.input,
     ) {
         Ok(encrypted_key) => Ok(encrypted_key),
         Err(EncryptedKeyCombinationError::InsufficientShares) => {
@@ -434,8 +431,8 @@ fn combine_encrypted_key_shares_internal<C: ThresholdSignatureCspClient>(
                 reconstruction_threshold,
                 &master_public_key,
                 &transport_public_key,
-                &derivation_domain,
-                &args.derivation_id,
+                &context,
+                &args.input,
             )
             .map_err(|e| {
                 VetKdKeyShareCombinationError::CombinationError(format!(
@@ -492,7 +489,7 @@ fn verify_encrypted_key_internal(
         }
     };
 
-    let transport_public_key = TransportPublicKey::deserialize(&args.encryption_public_key)
+    let transport_public_key = TransportPublicKey::deserialize(&args.transport_public_key)
         .map_err(|e| match e {
             TransportPublicKeyDeserializationError::InvalidPublicKey => {
                 VetKdKeyVerificationError::InvalidArgumentEncryptionPublicKey
@@ -501,11 +498,8 @@ fn verify_encrypted_key_internal(
 
     match encrypted_key.is_valid(
         &master_public_key,
-        &DerivationDomain::new(
-            args.derivation_domain.caller.as_slice(),
-            &args.derivation_domain.domain,
-        ),
-        &args.derivation_id,
+        &DerivationContext::new(args.context.caller.as_slice(), &args.context.context),
+        &args.input,
         &transport_public_key,
     ) {
         true => Ok(()),

--- a/rs/crypto/test_utils/local_csp_vault/src/lib.rs
+++ b/rs/crypto/test_utils/local_csp_vault/src/lib.rs
@@ -52,7 +52,7 @@ use ic_types::crypto::canister_threshold_sig::error::{
 use ic_types::crypto::canister_threshold_sig::idkg::{
     BatchSignedIDkgDealing, IDkgTranscriptOperation,
 };
-use ic_types::crypto::vetkd::VetKdDerivationDomain;
+use ic_types::crypto::vetkd::VetKdDerivationContext;
 use ic_types::crypto::vetkd::VetKdEncryptedKeyShareContent;
 use ic_types::crypto::ExtendedDerivationPath;
 use ic_types::crypto::{AlgorithmId, CurrentNodePublicKeys};
@@ -228,9 +228,9 @@ mock! {
             &self,
             key_id: KeyId,
             master_public_key: Vec<u8>,
-            encryption_public_key: Vec<u8>,
-            derivation_domain: VetKdDerivationDomain,
-            derivation_id: Vec<u8>,
+            transport_public_key: Vec<u8>,
+            context: VetKdDerivationContext,
+            input: Vec<u8>,
         ) -> Result<VetKdEncryptedKeyShareContent, VetKdEncryptedKeyShareCreationVaultError>;
     }
 

--- a/rs/crypto/tests/vetkd.rs
+++ b/rs/crypto/tests/vetkd.rs
@@ -12,7 +12,7 @@ use ic_types::crypto::threshold_sig::ni_dkg::config::NiDkgConfig;
 use ic_types::crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTranscript};
 use ic_types::crypto::threshold_sig::ThresholdSigPublicKey;
 use ic_types::crypto::vetkd::VetKdArgs;
-use ic_types::crypto::vetkd::VetKdDerivationDomain;
+use ic_types::crypto::vetkd::VetKdDerivationContext;
 use ic_types::crypto::vetkd::VetKdEncryptedKey;
 use ic_types::crypto::vetkd::VetKdEncryptedKeyShare;
 use ic_types::crypto::AlgorithmId;
@@ -31,9 +31,9 @@ fn should_consistently_derive_the_same_vetkey_given_sufficient_shares() {
 
     let transcript = run_ni_dkg_and_load_transcript_for_receivers(&config, &crypto_components);
 
-    let derivation_domain = VetKdDerivationDomain {
+    let context = VetKdDerivationContext {
         caller: canister_test_id(234).get(),
-        domain: b"domain-123".to_vec(),
+        context: b"context-123".to_vec(),
     };
     let derived_public_key = ic_crypto_utils_canister_threshold_sig::derive_vetkd_public_key(
         &MasterPublicKey {
@@ -43,7 +43,7 @@ fn should_consistently_derive_the_same_vetkey_given_sufficient_shares() {
                 .into_bytes()
                 .to_vec(),
         },
-        &derivation_domain,
+        &context,
     )
     .expect("failed to compute derived public key");
     let transport_secret_key =
@@ -51,9 +51,9 @@ fn should_consistently_derive_the_same_vetkey_given_sufficient_shares() {
             .expect("failed to create transport secret key");
     let vetkd_args = VetKdArgs {
         ni_dkg_id: dkg_id,
-        derivation_domain,
-        derivation_id: b"some-derivation-id".to_vec(),
-        encryption_public_key: transport_secret_key.public_key(),
+        context,
+        input: b"some-input".to_vec(),
+        transport_public_key: transport_secret_key.public_key(),
     };
 
     let mut expected_decrypted_key: Option<Vec<u8>> = None;
@@ -82,7 +82,7 @@ fn should_consistently_derive_the_same_vetkey_given_sufficient_shares() {
             .decrypt(
                 &encrypted_key.encrypted_key,
                 &derived_public_key,
-                &vetkd_args.derivation_id,
+                &vetkd_args.input,
             )
             .expect("failed to decrypt vetKey");
 

--- a/rs/crypto/utils/canister_threshold_sig/src/lib.rs
+++ b/rs/crypto/utils/canister_threshold_sig/src/lib.rs
@@ -1,10 +1,10 @@
 use ic_crypto_internal_bls12_381_vetkd::{
-    DerivationDomain, DerivedPublicKey, G2Affine, TransportPublicKey,
+    DerivationContext, DerivedPublicKey, G2Affine, TransportPublicKey,
 };
 use ic_crypto_internal_threshold_sig_canister_threshold_sig::DeriveThresholdPublicKeyError;
 use ic_types::crypto::canister_threshold_sig::error::CanisterThresholdGetPublicKeyError;
 use ic_types::crypto::canister_threshold_sig::{MasterPublicKey, PublicKey};
-use ic_types::crypto::vetkd::VetKdDerivationDomain;
+use ic_types::crypto::vetkd::VetKdDerivationContext;
 use ic_types::crypto::AlgorithmId;
 use ic_types::crypto::ExtendedDerivationPath;
 use std::fmt;
@@ -33,7 +33,7 @@ pub fn derive_threshold_public_key(
 /// the given `extended_derivation_path`.
 pub fn derive_vetkd_public_key(
     master_public_key: &MasterPublicKey,
-    derivation_domain: &VetKdDerivationDomain,
+    context: &VetKdDerivationContext,
 ) -> Result<Vec<u8>, VetKdPublicKeyDeriveError> {
     match master_public_key.algorithm_id {
         AlgorithmId::VetKD => (),
@@ -43,12 +43,9 @@ pub fn derive_vetkd_public_key(
     let key = G2Affine::deserialize(&master_public_key.public_key)
         .map_err(|_| VetKdPublicKeyDeriveError::InvalidPublicKey)?;
 
-    let derivation_domain = DerivationDomain::new(
-        derivation_domain.caller.as_slice(),
-        &derivation_domain.domain,
-    );
+    let context = DerivationContext::new(context.caller.as_slice(), &context.context);
 
-    let derived_key = DerivedPublicKey::compute_derived_key(&key, &derivation_domain);
+    let derived_key = DerivedPublicKey::compute_derived_key(&key, &context);
     Ok(derived_key.serialize().to_vec())
 }
 

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -730,7 +730,7 @@ fn get_valid_system_apis_common(I: ValType) -> HashMap<String, HashMap<String, F
             )],
         ),
         (
-            "cost_vetkd_derive_encrypted_key",
+            "cost_vetkd_derive_key",
             vec![(
                 API_VERSION_IC0,
                 FunctionSignature {

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1343,18 +1343,16 @@ pub fn syscalls<
         .unwrap();
 
     linker
-        .func_wrap("ic0", "cost_vetkd_derive_encrypted_key", {
+        .func_wrap("ic0", "cost_vetkd_derive_key", {
             move |mut caller: Caller<'_, StoreData>, src: I, size: I, curve: u32, dst: I| {
                 let src: usize = src.try_into().expect("Failed to convert I to usize");
                 let size: usize = size.try_into().expect("Failed to convert I to usize");
                 charge_for_cpu_and_mem(&mut caller, overhead::COST_VETKD, size)?;
                 with_memory_and_system_api(&mut caller, |s, memory| {
                     let dst: usize = dst.try_into().expect("Failed to convert I to usize");
-                    s.ic0_cost_vetkd_derive_encrypted_key(src, size, curve, dst, memory)
+                    s.ic0_cost_vetkd_derive_key(src, size, curve, dst, memory)
                 })
-                .map_err(|e| {
-                    anyhow::Error::msg(format!("ic0_cost_vetkd_derive_encrypted_key failed: {}", e))
-                })
+                .map_err(|e| anyhow::Error::msg(format!("ic0_cost_vetkd_derive_key failed: {}", e)))
             }
         })
         .unwrap();

--- a/rs/execution_environment/benches/system_api/execute_update.rs
+++ b/rs/execution_environment/benches/system_api/execute_update.rs
@@ -1069,9 +1069,9 @@ pub fn execute_update_bench(c: &mut Criterion) {
             523000006,
         ),
         common::Benchmark(
-            "wasm32/ic0_cost_vetkd_derive_encrypted_key()".into(),
+            "wasm32/ic0_cost_vetkd_derive_key()".into(),
             Module::Test.from_ic0(
-                "cost_vetkd_derive_encrypted_key",
+                "cost_vetkd_derive_key",
                 Params4(1_i32, 2_i32, 3_i32, 3_i32),
                 Result::I32,
                 Wasm64::Disabled,
@@ -1079,9 +1079,9 @@ pub fn execute_update_bench(c: &mut Criterion) {
             523000006,
         ),
         common::Benchmark(
-            "wasm64/ic0_cost_vetkd_derive_encrypted_key()".into(),
+            "wasm64/ic0_cost_vetkd_derive_key()".into(),
             Module::Test.from_ic0(
-                "cost_vetkd_derive_encrypted_key",
+                "cost_vetkd_derive_key",
                 Params4(1_i64, 2_i64, 3_i32, 3_i64),
                 Result::I32,
                 Wasm64::Enabled,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -119,7 +119,7 @@ impl CanisterManager {
             | Ok(Ic00Method::SchnorrPublicKey)
             | Ok(Ic00Method::SignWithSchnorr)
             | Ok(Ic00Method::VetKdPublicKey)
-            | Ok(Ic00Method::VetKdDeriveEncryptedKey)
+            | Ok(Ic00Method::VetKdDeriveKey)
             // "DepositCycles" can be called by anyone however as ingress message
             // cannot carry cycles, it does not make sense to allow them from users.
             | Ok(Ic00Method::DepositCycles)

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -46,8 +46,8 @@ use ic_management_canister_types_private::{
     ReshareChainKeyArgs, SchnorrAlgorithm, SchnorrPublicKeyArgs, SchnorrPublicKeyResponse,
     SetupInitialDKGArgs, SignWithECDSAArgs, SignWithSchnorrArgs, SignWithSchnorrAux,
     StoredChunksArgs, SubnetInfoArgs, SubnetInfoResponse, TakeCanisterSnapshotArgs,
-    UninstallCodeArgs, UpdateSettingsArgs, UploadChunkArgs, VetKdDeriveEncryptedKeyArgs,
-    VetKdPublicKeyArgs, VetKdPublicKeyResult, IC_00,
+    UninstallCodeArgs, UpdateSettingsArgs, UploadChunkArgs, VetKdDeriveKeyArgs, VetKdPublicKeyArgs,
+    VetKdPublicKeyResult, IC_00,
 };
 use ic_metrics::MetricsRegistry;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -72,7 +72,7 @@ use ic_types::{
     crypto::{
         canister_threshold_sig::{MasterPublicKey, PublicKey},
         threshold_sig::ni_dkg::NiDkgTargetId,
-        vetkd::VetKdDerivationDomain,
+        vetkd::VetKdDerivationContext,
         ExtendedDerivationPath,
     },
     ingress::{IngressState, IngressStatus, WasmResult},
@@ -1296,14 +1296,10 @@ impl ExecutionEnvironment {
                                         Some(id) => id.into(),
                                         None => *msg.sender(),
                                     };
-                                    self.get_vetkd_public_key(
-                                        pubkey,
-                                        canister_id,
-                                        args.derivation_domain,
-                                    )
-                                    .map(|public_key| {
-                                        (VetKdPublicKeyResult { public_key }.encode(), None)
-                                    })
+                                    self.get_vetkd_public_key(pubkey, canister_id, args.context)
+                                        .map(|public_key| {
+                                            (VetKdPublicKeyResult { public_key }.encode(), None)
+                                        })
                                 }
                             },
                         };
@@ -1334,7 +1330,7 @@ impl ExecutionEnvironment {
                     }
                 }
             }
-            Ok(Ic00Method::VetKdDeriveEncryptedKey) => match &msg {
+            Ok(Ic00Method::VetKdDeriveKey) => match &msg {
                 CanisterCall::Request(request) => {
                     if payload.is_empty() {
                         use ic_types::messages;
@@ -1357,7 +1353,7 @@ impl ExecutionEnvironment {
                         return (state, Some(NumInstructions::from(0)));
                     }
 
-                    match self.vetkd_derive_encrypted_key(
+                    match self.vetkd_derive_key(
                         request,
                         payload,
                         chain_key_data,
@@ -1382,7 +1378,7 @@ impl ExecutionEnvironment {
                     }
                 }
                 CanisterCall::Ingress(_) => {
-                    self.reject_unexpected_ingress(Ic00Method::VetKdDeriveEncryptedKey)
+                    self.reject_unexpected_ingress(Ic00Method::VetKdDeriveKey)
                 }
             },
 
@@ -2825,14 +2821,11 @@ impl ExecutionEnvironment {
         &self,
         subnet_public_key: &MasterPublicKey,
         caller: PrincipalId,
-        derivation_domain: Vec<u8>,
+        context: Vec<u8>,
     ) -> Result<Vec<u8>, UserError> {
         derive_vetkd_public_key(
             subnet_public_key,
-            &VetKdDerivationDomain {
-                caller,
-                domain: derivation_domain,
-            },
+            &VetKdDerivationContext { caller, context },
         )
         .map_err(|err| {
             UserError::new(
@@ -2842,7 +2835,7 @@ impl ExecutionEnvironment {
         })
     }
 
-    fn vetkd_derive_encrypted_key(
+    fn vetkd_derive_key(
         &self,
         request: &Request,
         payload: &[u8],
@@ -2852,7 +2845,7 @@ impl ExecutionEnvironment {
         registry_settings: &RegistryExecutionSettings,
         current_round: ExecutionRound,
     ) -> Result<(), UserError> {
-        let args = VetKdDeriveEncryptedKeyArgs::decode(payload)?;
+        let args = VetKdDeriveKeyArgs::decode(payload)?;
         let key_id = MasterPublicKeyId::VetKd(args.key_id.clone());
         let _master_public_key_exists = get_master_public_key(
             &chain_key_data.master_public_keys,
@@ -2872,7 +2865,7 @@ impl ExecutionEnvironment {
                 ),
             ));
         };
-        if !is_valid_transport_public_key(&args.encryption_public_key) {
+        if !is_valid_transport_public_key(&args.transport_public_key) {
             return Err(UserError::new(
                 ErrorCode::CanisterRejectedMessage,
                 "The provided transport public key is invalid.",
@@ -2882,12 +2875,12 @@ impl ExecutionEnvironment {
             (*request).clone(),
             ThresholdArguments::VetKd(VetKdArguments {
                 key_id: args.key_id,
-                derivation_id: args.derivation_id,
-                encryption_public_key: args.encryption_public_key.to_vec(),
+                input: args.input,
+                transport_public_key: args.transport_public_key.to_vec(),
                 ni_dkg_id: ni_dkg_id.clone(),
                 height: Height::new(current_round.get()),
             }),
-            vec![args.derivation_domain],
+            vec![args.context],
             registry_settings
                 .chain_key_settings
                 .get(&key_id)

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -210,15 +210,15 @@ fn sign_with_threshold_key_payload(method: Method, key_id: MasterPublicKeyId) ->
             aux: None,
         }
         .encode(),
-        Method::VetKdDeriveEncryptedKey => ic00::VetKdDeriveEncryptedKeyArgs {
-            derivation_id: vec![],
-            encryption_public_key: [
+        Method::VetKdDeriveKey => ic00::VetKdDeriveKeyArgs {
+            input: vec![],
+            transport_public_key: [
                 // Generated via TransportSecretKey::from_seed(vec![0; 32]).unwrap().public_key()
                 178, 211, 206, 216, 102, 5, 127, 108, 175, 41, 31, 129, 99, 3, 1, 87, 24, 22, 102,
                 58, 81, 137, 170, 178, 61, 6, 208, 161, 20, 14, 134, 241, 34, 50, 176, 194, 32, 5,
                 19, 249, 66, 219, 9, 120, 165, 15, 9, 211,
             ],
-            derivation_domain: vec![],
+            context: vec![],
             key_id: into_inner_vetkd(key_id),
         }
         .encode(),
@@ -3628,7 +3628,7 @@ fn test_vetkd_public_key_api_is_enabled() {
         Method::VetKdPublicKey,
         ic00::VetKdPublicKeyArgs {
             canister_id: None,
-            derivation_domain: vec![],
+            context: vec![],
             key_id: nonexistent_key_id.clone(),
         }
         .encode(),
@@ -3638,7 +3638,7 @@ fn test_vetkd_public_key_api_is_enabled() {
         Method::VetKdPublicKey,
         ic00::VetKdPublicKeyArgs {
             canister_id: None,
-            derivation_domain: vec![],
+            context: vec![],
             key_id: into_inner_vetkd(key_id),
         }
         .encode(),
@@ -3668,7 +3668,7 @@ fn test_vetkd_public_key_api_is_enabled() {
 }
 
 #[test]
-fn test_vetkd_derive_encrypted_key_api_is_disabled_without_key() {
+fn test_vetkd_derive_key_api_is_disabled_without_key() {
     let own_subnet = subnet_test_id(1);
     let nns_subnet = subnet_test_id(2);
     let nns_canister = canister_test_id(0x10);
@@ -3677,7 +3677,7 @@ fn test_vetkd_derive_encrypted_key_api_is_disabled_without_key() {
         .with_nns_subnet_id(nns_subnet)
         .with_caller(nns_subnet, nns_canister)
         .build();
-    let method = Method::VetKdDeriveEncryptedKey;
+    let method = Method::VetKdDeriveKey;
     test.inject_call_to_ic00(
         method,
         sign_with_threshold_key_payload(method, make_vetkd_key("some_key")),
@@ -3692,7 +3692,7 @@ fn test_vetkd_derive_encrypted_key_api_is_disabled_without_key() {
 }
 
 #[test]
-fn test_vetkd_derive_encrypted_key_rejects_invalid_transport_keys() {
+fn test_vetkd_derive_key_rejects_invalid_transport_keys() {
     let key_id = make_vetkd_key("some_key");
     let own_subnet = subnet_test_id(1);
     let nns_subnet = subnet_test_id(2);
@@ -3703,12 +3703,12 @@ fn test_vetkd_derive_encrypted_key_rejects_invalid_transport_keys() {
         .with_caller(nns_subnet, nns_canister)
         .with_chain_key(key_id.clone())
         .build();
-    let method = Method::VetKdDeriveEncryptedKey;
-    let args = ic00::VetKdDeriveEncryptedKeyArgs {
-        derivation_id: vec![],
+    let method = Method::VetKdDeriveKey;
+    let args = ic00::VetKdDeriveKeyArgs {
+        input: vec![],
         // invalid transport key
-        encryption_public_key: [1; 48],
-        derivation_domain: vec![],
+        transport_public_key: [1; 48],
+        context: vec![],
         key_id: into_inner_vetkd(key_id),
     };
     test.inject_call_to_ic00(method, args.encode(), Cycles::new(0));
@@ -3721,7 +3721,7 @@ fn test_vetkd_derive_encrypted_key_rejects_invalid_transport_keys() {
 }
 
 #[test]
-fn test_vetkd_derive_encrypted_key_api_is_enabled() {
+fn test_vetkd_derive_key_api_is_enabled() {
     // Arrange.
     let key_id = make_vetkd_key("some_key");
     let own_subnet = subnet_test_id(1);
@@ -3744,7 +3744,7 @@ fn test_vetkd_derive_encrypted_key_api_is_enabled() {
     );
 
     // Act.
-    let method = Method::VetKdDeriveEncryptedKey;
+    let method = Method::VetKdDeriveKey;
     let run = wasm()
         .call_with_cycles(
             ic00::IC_00,

--- a/rs/execution_environment/src/execution_environment_metrics.rs
+++ b/rs/execution_environment/src/execution_environment_metrics.rs
@@ -217,7 +217,7 @@ impl ExecutionEnvironmentMetrics {
                     | ic00::Method::HttpRequest
                     | ic00::Method::SignWithECDSA
                     | ic00::Method::SignWithSchnorr
-                    | ic00::Method::VetKdDeriveEncryptedKey
+                    | ic00::Method::VetKdDeriveKey
                     | ic00::Method::ComputeInitialIDkgDealings
                     | ic00::Method::ReshareChainKey
                     | ic00::Method::BitcoinSendTransactionInternal

--- a/rs/execution_environment/src/ic00_permissions.rs
+++ b/rs/execution_environment/src/ic00_permissions.rs
@@ -123,7 +123,7 @@ impl Ic00MethodPermissions {
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,
             },
-            Ic00Method::VetKdDeriveEncryptedKey => Self {
+            Ic00Method::VetKdDeriveKey => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,

--- a/rs/execution_environment/src/query_handler/query_cache/tests.rs
+++ b/rs/execution_environment/src/query_handler/query_cache/tests.rs
@@ -1485,7 +1485,7 @@ fn query_cache_future_proof_test() {
         | SystemApiCallId::CostHttpRequest
         | SystemApiCallId::CostSignWithEcdsa
         | SystemApiCallId::CostSignWithSchnorr
-        | SystemApiCallId::CostVetkdDeriveEncryptedKey
+        | SystemApiCallId::CostVetkdDeriveKey
         | SystemApiCallId::CyclesBurn128
         | SystemApiCallId::DataCertificateCopy
         | SystemApiCallId::DataCertificatePresent

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -2239,7 +2239,7 @@ fn can_execute_subnet_msg(
         | Ic00Method::SchnorrPublicKey
         | Ic00Method::SignWithSchnorr
         | Ic00Method::VetKdPublicKey
-        | Ic00Method::VetKdDeriveEncryptedKey
+        | Ic00Method::VetKdDeriveKey
         | Ic00Method::BitcoinGetBalance
         | Ic00Method::BitcoinGetUtxos
         | Ic00Method::BitcoinGetBlockHeaders
@@ -2302,7 +2302,7 @@ fn get_instructions_limits_for_subnet_message(
             | SchnorrPublicKey
             | SignWithSchnorr
             | VetKdPublicKey
-            | VetKdDeriveEncryptedKey
+            | VetKdDeriveKey
             | StartCanister
             | StopCanister
             | UninstallCode

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -1158,7 +1158,7 @@ fn dts_aborted_execution_does_not_block_subnet_messages() {
             | Method::SchnorrPublicKey
             | Method::SignWithSchnorr
             | Method::VetKdPublicKey
-            | Method::VetKdDeriveEncryptedKey
+            | Method::VetKdDeriveKey
             | Method::BitcoinGetBalance
             | Method::BitcoinGetUtxos
             | Method::BitcoinGetBlockHeaders

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -8440,7 +8440,7 @@ fn cost_sign_with_schnorr_fails_bad_key_name() {
 }
 
 #[test]
-fn invoke_cost_vetkd_derive_encrypted_key() {
+fn invoke_cost_vetkd_derive_key() {
     let key_name = String::from("testkey");
     let curve_variant = 0;
     let mut test = ExecutionTestBuilder::new()
@@ -8452,7 +8452,7 @@ fn invoke_cost_vetkd_derive_encrypted_key() {
     let subnet_size = test.subnet_size();
     let canister_id = test.universal_canister().unwrap();
     let payload = wasm()
-        .cost_vetkd_derive_encrypted_key(key_name.as_bytes(), curve_variant)
+        .cost_vetkd_derive_key(key_name.as_bytes(), curve_variant)
         .reply_data_append()
         .reply()
         .build();
@@ -8466,7 +8466,7 @@ fn invoke_cost_vetkd_derive_encrypted_key() {
 }
 
 #[test]
-fn cost_vetkd_derive_encrypted_key_fails_bad_curve() {
+fn cost_vetkd_derive_key_fails_bad_curve() {
     let key_name = String::from("testkey");
     let curve_variant = 0;
     let mut test = ExecutionTestBuilder::new()
@@ -8477,7 +8477,7 @@ fn cost_vetkd_derive_encrypted_key_fails_bad_curve() {
         .build();
     let canister_id = test.universal_canister().unwrap();
     let payload = wasm()
-        .cost_vetkd_derive_encrypted_key(key_name.as_bytes(), curve_variant + 10)
+        .cost_vetkd_derive_key(key_name.as_bytes(), curve_variant + 10)
         .reply_data_append()
         .reply()
         .build();
@@ -8487,12 +8487,12 @@ fn cost_vetkd_derive_encrypted_key_fails_bad_curve() {
     };
     err.assert_contains(
         ErrorCode::CanisterCalledTrap,
-        "ic0.cost_vetkd_derive_encrypted_key failed with error code 1",
+        "ic0.cost_vetkd_derive_key failed with error code 1",
     );
 }
 
 #[test]
-fn cost_vetkd_derive_encrypted_key_fails_bad_key_name() {
+fn cost_vetkd_derive_key_fails_bad_key_name() {
     let key_name = String::from("testkey");
     let curve_variant = 0;
     let mut test = ExecutionTestBuilder::new()
@@ -8503,7 +8503,7 @@ fn cost_vetkd_derive_encrypted_key_fails_bad_key_name() {
         .build();
     let canister_id = test.universal_canister().unwrap();
     let payload = wasm()
-        .cost_vetkd_derive_encrypted_key(String::from("yesn't").as_bytes(), curve_variant)
+        .cost_vetkd_derive_key(String::from("yesn't").as_bytes(), curve_variant)
         .reply_data_append()
         .reply()
         .build();
@@ -8513,6 +8513,6 @@ fn cost_vetkd_derive_encrypted_key_fails_bad_key_name() {
     };
     err.assert_contains(
         ErrorCode::CanisterCalledTrap,
-        "ic0.cost_vetkd_derive_encrypted_key failed with error code 2",
+        "ic0.cost_vetkd_derive_key failed with error code 2",
     );
 }

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -168,8 +168,8 @@ pub enum SystemApiCallId {
     CostSignWithEcdsa,
     /// Tracker for `ic0.cost_sign_with_schnorr()`
     CostSignWithSchnorr,
-    /// Tracker for `ic0.cost_vetkd_derive_encrypted_key()`
-    CostVetkdDeriveEncryptedKey,
+    /// Tracker for `ic0.cost_vetkd_derive_key()`
+    CostVetkdDeriveKey,
     /// Tracker for `ic0.cycles_burn128()`
     CyclesBurn128,
     /// Tracker for `ic0.data_certificate_copy()`
@@ -1308,7 +1308,7 @@ pub trait SystemApi {
     ) -> HypervisorResult<u32>;
 
     /// This system call indicates the cycle cost of vetkd key derivation,
-    /// i.e., the management canister's `vetkd_derive_encrypted_key` for the key
+    /// i.e., the management canister's `vetkd_derive_key` for the key
     /// (whose name is given by textual representation at heap location `src`
     /// with byte length `size`) and the provided curve.
     ///
@@ -1321,7 +1321,7 @@ pub trait SystemApi {
     /// The amount of cycles is represented by a 128-bit value and is copied
     /// to the canister memory starting at the location `dst` if the return
     /// value is 0.
-    fn ic0_cost_vetkd_derive_encrypted_key(
+    fn ic0_cost_vetkd_derive_key(
         &self,
         src: usize,
         size: usize,

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -81,8 +81,8 @@ message SchnorrArguments {
 
 message VetKdArguments {
   types.v1.VetKdKeyId key_id = 1;
-  bytes derivation_id = 2;
-  bytes encryption_public_key = 3;
+  bytes input = 2;
+  bytes transport_public_key = 3;
   types.v1.NiDkgId ni_dkg_id = 4;
   uint64 height = 5;
 }

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -106,9 +106,9 @@ pub struct VetKdArguments {
     #[prost(message, optional, tag = "1")]
     pub key_id: ::core::option::Option<super::super::super::types::v1::VetKdKeyId>,
     #[prost(bytes = "vec", tag = "2")]
-    pub derivation_id: ::prost::alloc::vec::Vec<u8>,
+    pub input: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "3")]
-    pub encryption_public_key: ::prost::alloc::vec::Vec<u8>,
+    pub transport_public_key: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "4")]
     pub ni_dkg_id: ::core::option::Option<super::super::super::types::v1::NiDkgId>,
     #[prost(uint64, tag = "5")]

--- a/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
@@ -813,8 +813,8 @@ impl TryFrom<pb_metadata::SchnorrArguments> for SchnorrArguments {
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct VetKdArguments {
     pub key_id: VetKdKeyId,
-    pub derivation_id: Vec<u8>,
-    pub encryption_public_key: Vec<u8>,
+    pub input: Vec<u8>,
+    pub transport_public_key: Vec<u8>,
     pub ni_dkg_id: NiDkgId,
     pub height: Height,
 }
@@ -823,8 +823,8 @@ impl From<&VetKdArguments> for pb_metadata::VetKdArguments {
     fn from(args: &VetKdArguments) -> Self {
         Self {
             key_id: Some((&args.key_id).into()),
-            derivation_id: args.derivation_id.to_vec(),
-            encryption_public_key: args.encryption_public_key.to_vec(),
+            input: args.input.to_vec(),
+            transport_public_key: args.transport_public_key.to_vec(),
             ni_dkg_id: Some((args.ni_dkg_id.clone()).into()),
             height: args.height.get(),
         }
@@ -836,8 +836,8 @@ impl TryFrom<pb_metadata::VetKdArguments> for VetKdArguments {
     fn try_from(context: pb_metadata::VetKdArguments) -> Result<Self, Self::Error> {
         Ok(VetKdArguments {
             key_id: try_from_option_field(context.key_id, "VetKdArguments::key_id")?,
-            derivation_id: context.derivation_id.to_vec(),
-            encryption_public_key: context.encryption_public_key.to_vec(),
+            input: context.input.to_vec(),
+            transport_public_key: context.transport_public_key.to_vec(),
             ni_dkg_id: try_from_option_field(context.ni_dkg_id, "VetKdArguments::ni_dkg_id")?,
             height: Height::from(context.height),
         })

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -3877,7 +3877,7 @@ impl SystemApi for SystemApiImpl {
         Ok(CostReturnCode::Success as u32)
     }
 
-    fn ic0_cost_vetkd_derive_encrypted_key(
+    fn ic0_cost_vetkd_derive_key(
         &self,
         src: usize,
         size: usize,
@@ -3886,7 +3886,7 @@ impl SystemApi for SystemApiImpl {
         heap: &mut [u8],
     ) -> HypervisorResult<u32> {
         let key_bytes = valid_subslice(
-            "ic0.cost_vetkd_derive_encrypted_key heap",
+            "ic0.cost_vetkd_derive_key heap",
             InternalAddress::new(src),
             InternalAddress::new(size),
             heap,
@@ -3913,7 +3913,7 @@ impl SystemApi for SystemApiImpl {
             .sandbox_safe_system_state
             .get_cycles_account_manager()
             .vetkd_fee(subnet_size);
-        copy_cycles_to_heap(cost, dst, heap, "ic0_cost_vetkd_derive_encrypted_key")?;
+        copy_cycles_to_heap(cost, dst, heap, "ic0_cost_vetkd_derive_key")?;
         trace_syscall!(self, CostVetkdDeriveEncryptedKey, cost);
         Ok(CostReturnCode::Success as u32)
     }

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -259,7 +259,7 @@ impl SystemStateModifications {
             | Ok(Ic00Method::SchnorrPublicKey)
             | Ok(Ic00Method::SignWithSchnorr)
             | Ok(Ic00Method::VetKdPublicKey)
-            | Ok(Ic00Method::VetKdDeriveEncryptedKey)
+            | Ok(Ic00Method::VetKdDeriveKey)
             | Ok(Ic00Method::ProvisionalTopUpCanister)
             | Ok(Ic00Method::BitcoinSendTransactionInternal)
             | Ok(Ic00Method::BitcoinGetSuccessors)

--- a/rs/system_api/tests/system_api.rs
+++ b/rs/system_api/tests/system_api.rs
@@ -304,7 +304,7 @@ fn is_supported(api_type: SystemApiCallId, context: &str) -> bool {
         SystemApiCallId::CostSignWithEcdsa=> vec!["*", "s"],
         SystemApiCallId::CostHttpRequest=> vec!["*", "s"],
         SystemApiCallId::CostSignWithSchnorr=> vec!["*", "s"],
-        SystemApiCallId::CostVetkdDeriveEncryptedKey => vec!["*", "s"],
+        SystemApiCallId::CostVetkdDeriveKey => vec!["*", "s"],
         SystemApiCallId::DebugPrint => vec!["*", "s"],
         SystemApiCallId::Trap => vec!["*", "s"],
         SystemApiCallId::MintCycles => vec!["U", "Ry", "Rt", "T"],
@@ -845,7 +845,7 @@ fn api_availability_test(
         SystemApiCallId::CostHttpRequest => {}
         SystemApiCallId::CostSignWithEcdsa => {}
         SystemApiCallId::CostSignWithSchnorr => {}
-        SystemApiCallId::CostVetkdDeriveEncryptedKey => {}
+        SystemApiCallId::CostVetkdDeriveKey => {}
     }
 }
 

--- a/rs/tests/consensus/tecdsa/tecdsa_signature_fails_without_cycles_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_signature_fails_without_cycles_test.rs
@@ -67,7 +67,7 @@ fn test(env: TestEnv) {
             let method_name = match key_id {
                 MasterPublicKeyId::Ecdsa(_) => "sign_with_ecdsa",
                 MasterPublicKeyId::Schnorr(_) => "sign_with_schnorr",
-                MasterPublicKeyId::VetKd(_) => "vetkd_derive_encrypted_key",
+                MasterPublicKeyId::VetKd(_) => "vetkd_derive_key",
             };
             assert_eq!(
                 error,

--- a/rs/tests/consensus/tecdsa/tecdsa_signature_life_cycle_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_signature_life_cycle_test.rs
@@ -60,7 +60,7 @@ fn protocol_method_name(key_id: &MasterPublicKeyId) -> &str {
     match key_id {
         MasterPublicKeyId::Ecdsa(_) => "sign_with_ecdsa",
         MasterPublicKeyId::Schnorr(_) => "sign_with_schnorr",
-        MasterPublicKeyId::VetKd(_) => "vetkd_derive_encrypted_key",
+        MasterPublicKeyId::VetKd(_) => "vetkd_derive_key",
     }
 }
 

--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -10,8 +10,8 @@ use ic_management_canister_types_private::{
     DerivationPath, ECDSAPublicKeyArgs, ECDSAPublicKeyResponse, EcdsaCurve, EcdsaKeyId,
     MasterPublicKeyId, Payload, SchnorrAlgorithm, SchnorrKeyId, SchnorrPublicKeyArgs,
     SchnorrPublicKeyResponse, SignWithECDSAArgs, SignWithECDSAReply, SignWithSchnorrArgs,
-    SignWithSchnorrReply, VetKdCurve, VetKdDeriveEncryptedKeyArgs, VetKdDeriveEncryptedKeyResult,
-    VetKdKeyId, VetKdPublicKeyArgs, VetKdPublicKeyResult,
+    SignWithSchnorrReply, VetKdCurve, VetKdDeriveKeyArgs, VetKdDeriveKeyResult, VetKdKeyId,
+    VetKdPublicKeyArgs, VetKdPublicKeyResult,
 };
 use ic_message::ForwardParams;
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR};
@@ -451,7 +451,7 @@ pub async fn get_vetkd_public_key_with_retries(
 ) -> Result<Vec<u8>, AgentError> {
     let public_key_request = VetKdPublicKeyArgs {
         canister_id: None,
-        derivation_domain: vec![],
+        context: vec![],
         key_id: key_id.clone(),
     };
     info!(
@@ -718,7 +718,7 @@ pub async fn get_vetkd_with_logger(
 
     let mut count = 0;
     let result = loop {
-        let res = vetkd_derive_encrypted_key(
+        let res = vetkd_derive_key(
             transport_public_key,
             key_id.clone(),
             input.clone(),
@@ -735,7 +735,7 @@ pub async fn get_vetkd_with_logger(
                 if count < 5 {
                     debug!(
                         logger,
-                        "vetkd_derive_encrypted_key returns `{}`. Trying again in 2 seconds...",
+                        "vetkd_derive_key returns `{}`. Trying again in 2 seconds...",
                         err
                     );
                     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -746,7 +746,7 @@ pub async fn get_vetkd_with_logger(
         }
     };
 
-    info!(logger, "vetkd_derive_encrypted_key returns {:?}", result);
+    info!(logger, "vetkd_derive_key returns {:?}", result);
     Ok(result)
 }
 
@@ -967,7 +967,7 @@ pub fn verify_signature(key_id: &MasterPublicKeyId, msg: &[u8], pk: &[u8], sig: 
 pub enum SignWithChainKeyReply {
     Ecdsa(SignWithECDSAReply),
     Schnorr(SignWithSchnorrReply),
-    VetKd(VetKdDeriveEncryptedKeyResult),
+    VetKd(VetKdDeriveKeyResult),
 }
 
 #[derive(Clone)]
@@ -1029,15 +1029,15 @@ impl ChainSignatureRequest {
     }
 
     fn vetkd_params(vetkd_key_id: VetKdKeyId) -> ForwardParams {
-        let vetkd_request = VetKdDeriveEncryptedKeyArgs {
-            derivation_domain: vec![1; 32],
-            derivation_id: vec![],
+        let vetkd_request = VetKdDeriveKeyArgs {
+            context: vec![1; 32],
+            input: vec![],
             key_id: vetkd_key_id,
-            encryption_public_key: G1Affine::generator().to_compressed(),
+            transport_public_key: G1Affine::generator().to_compressed(),
         };
         ForwardParams {
             receiver: Principal::management_canister(),
-            method: "vetkd_derive_encrypted_key".to_string(),
+            method: "vetkd_derive_key".to_string(),
             cycles: VETKD_FEE.get() * 2,
             payload: Encode!(&vetkd_request).unwrap(),
         }
@@ -1070,37 +1070,37 @@ impl Request<SignWithChainKeyReply> for ChainSignatureRequest {
                 SignWithChainKeyReply::Schnorr(SignWithSchnorrReply::decode(raw_response)?)
             }
             MasterPublicKeyId::VetKd(_) => {
-                SignWithChainKeyReply::VetKd(VetKdDeriveEncryptedKeyResult::decode(raw_response)?)
+                SignWithChainKeyReply::VetKd(VetKdDeriveKeyResult::decode(raw_response)?)
             }
         })
     }
 }
 
-pub async fn vetkd_derive_encrypted_key(
-    encryption_public_key: [u8; 48],
+pub async fn vetkd_derive_key(
+    transport_public_key: [u8; 48],
     key_id: VetKdKeyId,
-    derivation_id: Vec<u8>,
+    input: Vec<u8>,
     msg_can: &MessageCanister<'_>,
     cycles: Cycles,
 ) -> Result<Vec<u8>, AgentError> {
-    let args = VetKdDeriveEncryptedKeyArgs {
-        derivation_domain: vec![],
-        derivation_id,
+    let args = VetKdDeriveKeyArgs {
+        context: vec![],
+        input,
         key_id,
-        encryption_public_key,
+        transport_public_key,
     };
 
     let res = msg_can
         .forward_with_cycles_to(
             &Principal::management_canister(),
-            "vetkd_derive_encrypted_key",
+            "vetkd_derive_key",
             Encode!(&args).unwrap(),
             cycles,
         )
         .await?;
 
-    let res = VetKdDeriveEncryptedKeyResult::decode(&res)
-        .expect("Failed to decode VetKdDeriveEncryptedKeyResult");
+    let res =
+        VetKdDeriveKeyResult::decode(&res).expect("Failed to decode VetKdDeriveKeyResult");
 
     Ok(res.encrypted_key)
 }

--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -735,8 +735,7 @@ pub async fn get_vetkd_with_logger(
                 if count < 5 {
                     debug!(
                         logger,
-                        "vetkd_derive_key returns `{}`. Trying again in 2 seconds...",
-                        err
+                        "vetkd_derive_key returns `{}`. Trying again in 2 seconds...", err
                     );
                     tokio::time::sleep(Duration::from_secs(2)).await;
                 } else {
@@ -1099,8 +1098,7 @@ pub async fn vetkd_derive_key(
         )
         .await?;
 
-    let res =
-        VetKdDeriveKeyResult::decode(&res).expect("Failed to decode VetKdDeriveKeyResult");
+    let res = VetKdDeriveKeyResult::decode(&res).expect("Failed to decode VetKdDeriveKeyResult");
 
     Ok(res.encrypted_key)
 }

--- a/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
+++ b/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
@@ -109,9 +109,8 @@ fn test(env: TestEnv) {
             let _key =
                 DerivedPublicKey::deserialize(&pub_key).expect("Failed to parse vetkd public key");
 
-            let enc_msg =
-                IBECiphertext::encrypt(&pub_key, INPUT.as_bytes(), MSG.as_bytes(), &SEED)
-                    .expect("Failed to encrypt message");
+            let enc_msg = IBECiphertext::encrypt(&pub_key, INPUT.as_bytes(), MSG.as_bytes(), &SEED)
+                .expect("Failed to encrypt message");
 
             let transport_key = TransportSecretKey::from_seed(SEED.to_vec())
                 .expect("Failed to generate transport secret key");

--- a/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
+++ b/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
@@ -22,7 +22,7 @@ use anyhow::{anyhow, Result};
 use canister_test::Canister;
 use futures::FutureExt;
 use ic_consensus_threshold_sig_system_test_utils::{
-    enable_chain_key_signing, get_public_key_with_logger, vetkd_derive_encrypted_key,
+    enable_chain_key_signing, get_public_key_with_logger, vetkd_derive_key,
 };
 use ic_management_canister_types_private::{MasterPublicKeyId, VetKdCurve, VetKdKeyId};
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
@@ -49,7 +49,7 @@ const NODES_COUNT: usize = 4;
 const DKG_INTERVAL: u64 = 20;
 
 const MSG: &str = "Secret message that is totally important";
-const DERIVATION_ID: &str = "secret_message";
+const INPUT: &str = "secret_message";
 const SEED: [u8; 32] = [13; 32];
 
 fn setup(env: TestEnv) {
@@ -110,7 +110,7 @@ fn test(env: TestEnv) {
                 DerivedPublicKey::deserialize(&pub_key).expect("Failed to parse vetkd public key");
 
             let enc_msg =
-                IBECiphertext::encrypt(&pub_key, DERIVATION_ID.as_bytes(), MSG.as_bytes(), &SEED)
+                IBECiphertext::encrypt(&pub_key, INPUT.as_bytes(), MSG.as_bytes(), &SEED)
                     .expect("Failed to encrypt message");
 
             let transport_key = TransportSecretKey::from_seed(SEED.to_vec())
@@ -124,10 +124,10 @@ fn test(env: TestEnv) {
                 Duration::from_secs(120),
                 Duration::from_secs(2),
                 || {
-                    vetkd_derive_encrypted_key(
+                    vetkd_derive_key(
                         transport_key.public_key().try_into().unwrap(),
                         vetkd_key_id.clone(),
-                        DERIVATION_ID.as_bytes().to_vec(),
+                        INPUT.as_bytes().to_vec(),
                         &msg_can,
                         Cycles::zero(),
                     )
@@ -140,7 +140,7 @@ fn test(env: TestEnv) {
             .expect("Failed to derive encrypted key");
 
             let priv_key = transport_key
-                .decrypt(&encrypted_priv_key, &pub_key, DERIVATION_ID.as_bytes())
+                .decrypt(&encrypted_priv_key, &pub_key, INPUT.as_bytes())
                 .expect("Failed to decrypt derived key");
 
             let msg = enc_msg

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2957,7 +2957,7 @@ impl Payload<'_> for VetKdDeriveKeyResult {}
 /// ```text
 /// (record {
 ///   canister_id : opt canister_id;
-///   derivation_path : vec blob;
+///   context : blob;
 ///   key_id : record { curve : vetkd_curve; name : text };
 /// })
 /// ```

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -93,8 +93,8 @@ pub enum Method {
     // VetKd interface.
     #[strum(serialize = "vetkd_public_key")]
     VetKdPublicKey,
-    #[strum(serialize = "vetkd_derive_encrypted_key")]
-    VetKdDeriveEncryptedKey,
+    #[strum(serialize = "vetkd_derive_key")]
+    VetKdDeriveKey,
 
     // Bitcoin Interface.
     BitcoinGetBalance,
@@ -2917,27 +2917,27 @@ impl ComputeInitialIDkgDealingsResponse {
     }
 }
 
-// Represents the argument of the vetkd_derive_encrypted_key API.
+// Represents the argument of the vetkd_derive_key API.
 /// ```text
 /// (record {
-///   derivation_id: blob;
-///   derivation_path : vec blob;
+///   input: blob;
+///   context : blob;
+///   transport_public_key: blob;
 ///   key_id : record { curve : vetkd_curve; name : text };
-///   encryption_public_key: blob;
 /// })
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
-pub struct VetKdDeriveEncryptedKeyArgs {
+pub struct VetKdDeriveKeyArgs {
     #[serde(with = "serde_bytes")]
-    pub derivation_domain: Vec<u8>,
+    pub context: Vec<u8>,
     #[serde(with = "serde_bytes")]
-    pub derivation_id: Vec<u8>,
+    pub input: Vec<u8>,
     pub key_id: VetKdKeyId,
     #[serde(with = "serde_bytes")]
-    pub encryption_public_key: [u8; 48],
+    pub transport_public_key: [u8; 48],
 }
 
-impl Payload<'_> for VetKdDeriveEncryptedKeyArgs {}
+impl Payload<'_> for VetKdDeriveKeyArgs {}
 
 /// Struct used to return vet KD result.
 /// ```text
@@ -2946,12 +2946,12 @@ impl Payload<'_> for VetKdDeriveEncryptedKeyArgs {}
 /// })
 /// ```
 #[derive(Debug, CandidType, Deserialize)]
-pub struct VetKdDeriveEncryptedKeyResult {
+pub struct VetKdDeriveKeyResult {
     #[serde(with = "serde_bytes")]
     pub encrypted_key: Vec<u8>,
 }
 
-impl Payload<'_> for VetKdDeriveEncryptedKeyResult {}
+impl Payload<'_> for VetKdDeriveKeyResult {}
 
 /// Represents the argument of the vetkd_public_key API.
 /// ```text
@@ -2965,7 +2965,7 @@ impl Payload<'_> for VetKdDeriveEncryptedKeyResult {}
 pub struct VetKdPublicKeyArgs {
     pub canister_id: Option<CanisterId>,
     #[serde(with = "serde_bytes")]
-    pub derivation_domain: Vec<u8>,
+    pub context: Vec<u8>,
     pub key_id: VetKdKeyId,
 }
 

--- a/rs/types/types/src/consensus/idkg/common.rs
+++ b/rs/types/types/src/consensus/idkg/common.rs
@@ -1121,7 +1121,7 @@ impl ThresholdSigInputsRef {
         match self {
             ThresholdSigInputsRef::Ecdsa(inputs) => inputs.derivation_path.caller,
             ThresholdSigInputsRef::Schnorr(inputs) => inputs.derivation_path.caller,
-            ThresholdSigInputsRef::VetKd(inputs) => inputs.derivation_domain.caller,
+            ThresholdSigInputsRef::VetKd(inputs) => inputs.context.caller,
         }
     }
 

--- a/rs/types/types/src/crypto/vetkd.rs
+++ b/rs/types/types/src/crypto/vetkd.rs
@@ -14,22 +14,22 @@ mod test;
 #[derive(Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub struct VetKdArgs {
     pub ni_dkg_id: NiDkgId,
-    pub derivation_domain: VetKdDerivationDomain,
     #[serde(with = "serde_bytes")]
-    pub derivation_id: Vec<u8>,
+    pub input: Vec<u8>,
+    pub context: VetKdDerivationContext,
     #[serde(with = "serde_bytes")]
-    pub encryption_public_key: Vec<u8>,
+    pub transport_public_key: Vec<u8>,
 }
 
 impl fmt::Debug for VetKdArgs {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("VetKdArgs")
             .field("ni_dkg_id", &self.ni_dkg_id)
-            .field("derivation_domain", &self.derivation_domain)
-            .field("derivation_id", &HexEncoding::from(&self.derivation_id))
+            .field("input", &HexEncoding::from(&self.input))
+            .field("context", &self.context)
             .field(
-                "encryption_public_key",
-                &HexEncoding::from(&self.encryption_public_key),
+                "transport_public_key",
+                &HexEncoding::from(&self.transport_public_key),
             )
             .finish()
     }
@@ -89,21 +89,21 @@ impl_display_using_debug!(VetKdEncryptedKey);
 
 /// Metadata used to derive keys for vetKD.
 #[derive(Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
-pub struct VetKdDerivationDomain {
+pub struct VetKdDerivationContext {
     pub caller: PrincipalId,
     #[serde(with = "serde_bytes")]
-    pub domain: Vec<u8>,
+    pub context: Vec<u8>,
 }
 
-impl std::fmt::Debug for VetKdDerivationDomain {
+impl std::fmt::Debug for VetKdDerivationContext {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("VetKdDerivationDomain")
+        fmt.debug_struct("VetKdDerivationContext")
             .field("caller", &self.caller)
-            .field("domain", &HexEncoding::from(&self.domain))
+            .field("context", &HexEncoding::from(&self.context))
             .finish()
     }
 }
-impl_display_using_debug!(VetKdDerivationDomain);
+impl_display_using_debug!(VetKdDerivationContext);
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum VetKdKeyShareCreationError {

--- a/rs/types/types/src/crypto/vetkd/test.rs
+++ b/rs/types/types/src/crypto/vetkd/test.rs
@@ -31,10 +31,9 @@ mod display_and_debug {
         };
         let output = "VetKdArgs { \
             ni_dkg_id: NiDkgId { start_block_height: 7, dealer_subnet: ot5wk-sbkaa-aaaaa-aaaap-yai, dkg_tag: HighThreshold, target_subnet: Remote(0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a) }, \
-            context: VetKdDerivationContext { caller: 7xzs3-rqraa-aaaaa-aaaap-2ai, \
-            context: 0x646f6d61696e2d313233 }, \
-            input: 0x646964, \
-            transport_public_key: 0x656b \
+            input: 0x696e707574, \
+            context: VetKdDerivationContext { caller: 7xzs3-rqraa-aaaaa-aaaap-2ai, context: 0x636f6e746578742d313233 }, \
+            transport_public_key: 0x74706b \
         }"
         .to_string();
 

--- a/rs/types/types/src/crypto/vetkd/test.rs
+++ b/rs/types/types/src/crypto/vetkd/test.rs
@@ -7,7 +7,7 @@ use ic_base_types::PrincipalId;
 use ic_base_types::SubnetId;
 
 mod display_and_debug {
-    use crate::crypto::vetkd::VetKdDerivationDomain;
+    use crate::crypto::vetkd::VetKdDerivationContext;
 
     use super::*;
 
@@ -22,19 +22,19 @@ mod display_and_debug {
                     [42; NiDkgTargetId::SIZE],
                 )),
             },
-            derivation_domain: VetKdDerivationDomain {
+            context: VetKdDerivationContext {
                 caller: PrincipalId::new_node_test_id(17),
-                domain: b"domain-123".to_vec(),
+                context: b"context-123".to_vec(),
             },
-            derivation_id: b"did".to_vec(),
-            encryption_public_key: b"ek".to_vec(),
+            input: b"input".to_vec(),
+            transport_public_key: b"tpk".to_vec(),
         };
         let output = "VetKdArgs { \
             ni_dkg_id: NiDkgId { start_block_height: 7, dealer_subnet: ot5wk-sbkaa-aaaaa-aaaap-yai, dkg_tag: HighThreshold, target_subnet: Remote(0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a) }, \
-            derivation_domain: VetKdDerivationDomain { caller: 7xzs3-rqraa-aaaaa-aaaap-2ai, \
-            domain: 0x646f6d61696e2d313233 }, \
-            derivation_id: 0x646964, \
-            encryption_public_key: 0x656b \
+            context: VetKdDerivationContext { caller: 7xzs3-rqraa-aaaaa-aaaap-2ai, \
+            context: 0x646f6d61696e2d313233 }, \
+            input: 0x646964, \
+            transport_public_key: 0x656b \
         }"
         .to_string();
 

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -564,7 +564,7 @@ pub fn extract_effective_canister_id(
         | Ok(Method::SchnorrPublicKey)
         | Ok(Method::SignWithSchnorr)
         | Ok(Method::VetKdPublicKey)
-        | Ok(Method::VetKdDeriveEncryptedKey)
+        | Ok(Method::VetKdDeriveKey)
         | Ok(Method::BitcoinGetBalance)
         | Ok(Method::BitcoinGetUtxos)
         | Ok(Method::BitcoinGetBlockHeaders)

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -229,7 +229,7 @@ impl Request {
             | Ok(Method::SchnorrPublicKey)
             | Ok(Method::SignWithSchnorr)
             | Ok(Method::VetKdPublicKey)
-            | Ok(Method::VetKdDeriveEncryptedKey)
+            | Ok(Method::VetKdDeriveKey)
             | Ok(Method::BitcoinGetBalance)
             | Ok(Method::BitcoinGetUtxos)
             | Ok(Method::BitcoinGetBlockHeaders)

--- a/rs/universal_canister/impl/src/api.rs
+++ b/rs/universal_canister/impl/src/api.rs
@@ -84,12 +84,7 @@ mod ic0 {
         pub fn cost_http_request(request_size: u64, max_res_bytes: u64, dst: u32) -> ();
         pub fn cost_sign_with_ecdsa(src: u32, size: u32, ecdsa_curve: u32, dst: u32) -> u32;
         pub fn cost_sign_with_schnorr(src: u32, size: u32, algorithm: u32, dst: u32) -> u32;
-        pub fn cost_vetkd_derive_encrypted_key(
-            src: u32,
-            size: u32,
-            vetkd_curve: u32,
-            dst: u32,
-        ) -> u32;
+        pub fn cost_vetkd_derive_key(src: u32, size: u32, vetkd_curve: u32, dst: u32) -> u32;
 
     }
 }
@@ -500,10 +495,10 @@ pub fn cost_sign_with_schnorr(data: &[u8], algorithm: u32) -> Result<Vec<u8>, u3
         Err(result)
     }
 }
-pub fn cost_vetkd_derive_encrypted_key(data: &[u8], vetkd_curve: u32) -> Result<Vec<u8>, u32> {
+pub fn cost_vetkd_derive_key(data: &[u8], vetkd_curve: u32) -> Result<Vec<u8>, u32> {
     let mut bytes = vec![0u8; CYCLES_SIZE];
     let result = unsafe {
-        ic0::cost_vetkd_derive_encrypted_key(
+        ic0::cost_vetkd_derive_key(
             data.as_ptr() as u32,
             data.len() as u32,
             vetkd_curve,

--- a/rs/universal_canister/impl/src/lib.rs
+++ b/rs/universal_canister/impl/src/lib.rs
@@ -118,7 +118,7 @@ try_from_u8!(
         CostHttpRequest = 88,
         CostSignWithEcdsa = 89,
         CostSignWithSchnorr = 90,
-        CostVetkdDeriveEncryptedKey = 91,
+        CostVetkdDeriveKey = 91,
         LiquidCyclesBalance128 = 92,
         CallDataAppendCyclesAddMax = 93,
     }

--- a/rs/universal_canister/impl/src/main.rs
+++ b/rs/universal_canister/impl/src/main.rs
@@ -474,13 +474,13 @@ fn eval(ops_bytes: OpsBytes) {
                     )),
                 }
             }
-            Ops::CostVetkdDeriveEncryptedKey => {
+            Ops::CostVetkdDeriveKey => {
                 let vetkd_curve = stack.pop_int();
                 let key_name = stack.pop_blob();
-                match api::cost_vetkd_derive_encrypted_key(&key_name, vetkd_curve) {
+                match api::cost_vetkd_derive_key(&key_name, vetkd_curve) {
                     Ok(bytes) => stack.push_blob(bytes),
                     Err(err_code) => api::trap_with(&format!(
-                        "ic0.cost_vetkd_derive_encrypted_key failed with error code {}",
+                        "ic0.cost_vetkd_derive_key failed with error code {}",
                         err_code
                     )),
                 }

--- a/rs/universal_canister/lib/src/lib.rs
+++ b/rs/universal_canister/lib/src/lib.rs
@@ -721,10 +721,10 @@ impl PayloadBuilder {
         self
     }
 
-    pub fn cost_vetkd_derive_encrypted_key(mut self, data: &[u8], curve: u32) -> Self {
+    pub fn cost_vetkd_derive_key(mut self, data: &[u8], curve: u32) -> Self {
         self = self.push_bytes(data);
         self = self.push_int(curve);
-        self.0.push(Ops::CostVetkdDeriveEncryptedKey as u8);
+        self.0.push(Ops::CostVetkdDeriveKey as u8);
         self
     }
 


### PR DESCRIPTION
Performs the following renamings in the vetKD API in accordance with the [latest changes](https://github.com/dfinity/portal/pull/3763/commits/add1c7178212fd3b7881aecfdde67fbabe5a1a77) in the [spec PR](https://github.com/dfinity/portal/pull/3763):
* `derivation_id` --> `input`
  * The name `derivation_id` often caused confusion and `input` is a more standard name in the context of key derivation schemes.
* `derivation_domain` ([previously](https://github.com/dfinity/ic/pull/4049) `derivation_path`) --> `context`
  * The main use case for the derivation domain/path is to do domain separation, i.e., to specify the context in which the derived keys are to be used. Given this, directly calling it context seems beneficial in that it makes the meaning of the field more clear and intuitive, and thus the API easier to use.
* `vetkd_derive_encrypted_key` --> `vetkd_derive_key`
  * Although the fact that the returned key is encrypted is relevant in that it ensures that nodes cannot see the key in clear text, this can be considered an implementation detail. Also, the name `vetkd_derive_encrypted_key` is somewhat long. In any case, in the returned struct the (single) field is still called `encrypted_key`, so it is still explicit that the returned key is encrypted.
* `encryption_public_key` --> `transport_public_key`
  * Everyone everywhere (in publications, slides, demos, etc.) called this "transport public key". The reason this was not called transport_public_key in the API so far was because the containing API method was called `vetkd_derive_encrypted_key` and the name `encryption_public_key` should have made it clear that it is this very public key under which the _encrypted key_ is encrypted. Now that we are removing the part `encrypted_` from the API name, this reason is obsolete and we are free to call it `transport_public_key`.