### PR TITLE
chore(IDX): deduplicate checksum upload

### DIFF
--- a/.github/actions/bazel-upload-checksums/action.yaml
+++ b/.github/actions/bazel-upload-checksums/action.yaml
@@ -1,0 +1,34 @@
+name: 'Bazel-Upload-Checksums'
+description: 'Upload SHA256SUMS files found in bazel-out'
+inputs:
+  artifact-name:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+      # List and aggregate all SHA256SUMS files (if bazel-out exists)
+      - name: Create SHA256SUMS
+        shell: bash
+        run: |
+          if ! [ -e ./bazel-out ]; then
+            touch SHA256SUMS
+            exit 0
+          fi
+
+          while IFS= read -r -d '' shafile; do
+            if [ -f "$shafile" ]; then
+              echo "$shafile"
+            fi
+          done \
+            < <(find -L ./bazel-out -name SHA256SUMS -print0) \
+            | xargs cat | sort | uniq >SHA256SUMS
+
+          echo "checksums:"
+          wc -l ./SHA256SUMS
+
+      - name: Upload SHA256SUMS (${{ inputs.artifact-name }})
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: SHA256SUMS

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -140,10 +140,9 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Upload SHA256SUMS (cache)
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/bazel-upload-checksums/
         with:
-          name: shasums-cache
-          path: SHA256SUMS
+          artifact-name: shasums-cache
       - <<: *bazel-bep
 
   bazel-test-macos-intel:
@@ -256,13 +255,6 @@ jobs:
           "$CI_PROJECT_DIR"/ci/scripts/run-build-ic.sh
           rm -rf "/cache/job/${CI_JOB_NAME}/${CI_RUN_ID}"
 
-          # List and aggregate all SHA256SUMS files (if bazel-out exists)
-          if [ -e bazel-out]; then
-            find -L bazel-out -name SHA256SUMS | xargs cat | sort | uniq > SHA256SUMS
-          else
-            touch SHA256SUMS
-          fi
-
         env:
           BAZEL_COMMAND: build --config=ci
           BAZEL_TARGETS: //...
@@ -270,10 +262,9 @@ jobs:
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
       - name: Upload SHA256SUMS (nocache)
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/bazel-upload-checksums/
         with:
-          name: shasums-nocache
-          path: SHA256SUMS
+          artifact-name: shasums-nocache
 
   build-determinism:
     name: Build Determinism

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -97,10 +97,9 @@ jobs:
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload SHA256SUMS (cache)
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/bazel-upload-checksums/
         with:
-          name: shasums-cache
-          path: SHA256SUMS
+          artifact-name: shasums-cache
       - name: Upload bazel-bep
         # runs only if previous step succeeded or failed;
         # we avoid collecting artifacts of jobs that were cancelled
@@ -291,13 +290,6 @@ jobs:
           ln -s "/cache/job/${CI_JOB_NAME}/${CI_RUN_ID}/artifacts" /__w/$REPO_NAME/$REPO_NAME/artifacts
           "$CI_PROJECT_DIR"/ci/scripts/run-build-ic.sh
           rm -rf "/cache/job/${CI_JOB_NAME}/${CI_RUN_ID}"
-
-          # List and aggregate all SHA256SUMS files (if bazel-out exists)
-          if [ -e bazel-out]; then
-            find -L bazel-out -name SHA256SUMS | xargs cat | sort | uniq > SHA256SUMS
-          else
-            touch SHA256SUMS
-          fi
         env:
           BAZEL_COMMAND: build --config=ci
           BAZEL_TARGETS: //...
@@ -305,10 +297,9 @@ jobs:
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
       - name: Upload SHA256SUMS (nocache)
-        uses: actions/upload-artifact@v4
+        uses: ./.github/actions/bazel-upload-checksums/
         with:
-          name: shasums-nocache
-          path: SHA256SUMS
+          artifact-name: shasums-nocache
   build-determinism:
     name: Build Determinism
     runs-on: ubuntu-latest

--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -38,9 +38,6 @@ fi
 # if bazel targets is empty we don't need to run any tests
 if [ -z "${BAZEL_TARGETS:-}" ]; then
     echo "No bazel targets to build"
-    # create empty SHA256SUMS for build determinism
-    # (not ideal but temporary until we can improve or get rid of diff.sh)
-    touch SHA256SUMS
     exit 0
 fi
 
@@ -96,17 +93,5 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "BuildBuddy [$invocation]($(<"$url_out"))" >>"$GITHUB_STEP_SUMMARY"
 fi
 rm "$url_out"
-
-# List and aggregate all SHA256SUMS files.
-if [ -e ./bazel-out/ ]; then
-    for shafile in $(find bazel-out/ -name SHA256SUMS); do
-        if [ -f "$shafile" ]; then
-            echo "$shafile"
-        fi
-    done | xargs cat | sort | uniq >SHA256SUMS
-else
-    # if no bazel-out, assume no targets were built
-    touch SHA256SUMS
-fi
 
 exit "$bazel_exitcode"


### PR DESCRIPTION
This deduplicates the logic for finding checksums and uploading checksums as a GitHub artifacts. The implementation was duplicated (though not exactly identical) between `main.sh` and the `Build IC` build step.