### PR TITLE
revert: "feat: [NODE-1574] Upgrade components to SEV-SNP compatible versions"

### DIFF
--- a/ic-os/hostos/context/Dockerfile.base
+++ b/ic-os/hostos/context/Dockerfile.base
@@ -31,6 +31,12 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y --no-install-recommend
     curl \
     perl
 
+# Download and verify QEMU
+RUN cd /tmp/ && \
+    curl -L -O https://download.qemu.org/qemu-6.2.0.tar.xz && \
+    echo "68e15d8e45ac56326e0b9a4afa8b49a3dfe8aba3488221d098c84698bca65b45  qemu-6.2.0.tar.xz" > qemu.sha256 && \
+    shasum -c qemu.sha256
+
 # Download and verify node_exporter
 RUN cd /tmp/ && \
     curl -L -O https://github.com/prometheus/node_exporter/releases/download/v1.8.1/node_exporter-1.8.1.linux-amd64.tar.gz && \
@@ -40,6 +46,38 @@ RUN cd /tmp/ && \
 
 #
 # Second build stage:
+# - Compile downloaded archives from first build stage
+#
+FROM ubuntu:24.04 AS build
+
+USER root:root
+
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+# Install QEMU build dependencies
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y --no-install-recommends install \
+    ca-certificates \
+    build-essential \
+    libglib2.0-dev \
+    libpixman-1-dev \
+    libusb-1.0-0-dev \
+    ninja-build \
+    pkg-config \
+    python3 \
+    python3-setuptools
+
+# Configure and compile QEMU
+COPY --from=download /tmp/qemu-6.2.0.tar.xz /tmp/qemu-6.2.0.tar.xz
+RUN cd /tmp/ && \
+    tar xJf qemu-6.2.0.tar.xz && \
+    cd /tmp/qemu-6.2.0 && \
+    ./configure --target-list=x86_64-softmmu --enable-kvm --enable-libusb && \
+    echo "Compiling qemu..." && \
+    make -j 2 >/dev/null 2>&1 && \
+    DESTDIR="/out" ninja -C build install
+
+#
+# Third build stage:
 # - Download and cache minimal Ubuntu Server 20.04 LTS Docker image.
 # - Install and cache upstream packages from built-in Ubuntu repositories.
 # - Install compiled packages from the second stage.
@@ -53,16 +91,6 @@ ENV SOURCE_DATE_EPOCH=0
 ENV TZ=UTC
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Add future release, as opt-in targets
-RUN echo "deb http://archive.ubuntu.com/ubuntu oracular main universe restricted multiverse" >> /etc/apt/sources.list.d/future.list && \
-    echo "deb http://archive.ubuntu.com/ubuntu plucky main universe restricted multiverse" >> /etc/apt/sources.list.d/future.list && \
-    echo "Package: *" >> /etc/apt/preferences && \
-    echo "Pin: release n=oracular" >> /etc/apt/preferences && \
-    echo "Pin-Priority: -10" >> /etc/apt/preferences && \
-    echo "" >> /etc/apt/preferences && \
-    echo "Package: *" >> /etc/apt/preferences && \
-    echo "Pin: release n=plucky" >> /etc/apt/preferences && \
-    echo "Pin-Priority: -10" >> /etc/apt/preferences
 
 # For the prod image, just use packages.common to define the packages installed
 # on target.
@@ -75,6 +103,10 @@ RUN apt-get -y update && \
     apt-get -y upgrade && \
     apt-get -y --no-install-recommends install $(for P in ${PACKAGE_FILES}; do cat /tmp/$P | sed -e "s/#.*//" ; done) && \
     rm /tmp/packages.*
+
+# Install QEMU
+COPY --from=build /out/usr/local/bin/qemu-system-x86_64 /usr/local/bin/
+COPY --from=build /out/usr/local/share/qemu /usr/local/share/qemu
 
 # Install node_exporter
 COPY --from=download /tmp/node_exporter-1.8.1.linux-amd64.tar.gz /tmp/node_exporter-1.8.1.linux-amd64.tar.gz

--- a/ic-os/hostos/context/packages.common
+++ b/ic-os/hostos/context/packages.common
@@ -61,27 +61,43 @@ ethtool
 ipmitool
 libarchive-zip-perl
 libusb-1.0-0
+libvirt-daemon-system 
+libvirt-dev
 locales
 moreutils
 mtools
 nvme-cli
+ovmf
 pciutils
 python3-libvirt
 python3-requests
 xxd
 
-# Install select components from future releases
-# Install >=9.1 qemu
-qemu-system-x86/plucky # Top level
-
-# Install >=2024-05-24 OVMF
-ovmf/oracular # Top level
-
-# Install >=10.5.0 libvirt
-libvirt-daemon-system/oracular # Top level
-libvirt-dev/oracular # Top level
-libvirt-daemon-system-systemd/oracular # Dependency
-libvirt-daemon-config-nwfilter/oracular # Dependency
-libvirt-daemon-config-network/oracular # Dependency
-libvirt-daemon/oracular # Dependency
-libvirt-clients/oracular # Dependency
+# QEMU required dependencies for version 6.2
+ipxe-qemu
+ipxe-qemu-256k-compat-efi-roms
+libaio1t64
+libatomic1
+libc6
+libfdt1
+libfuse3-3
+libgcc-s1
+libglib2.0-0
+libgnutls30
+libibverbs1
+libjpeg8
+# libnettle8    - Not available in Ubuntu 20.04
+libnuma1
+libpixman-1-0
+libpmem1
+libpng16-16
+librdmacm1
+libsasl2-2
+libseccomp2
+libslirp0
+libstdc++6
+libudev1
+# liburing2     - Not available in Ubuntu 20.04
+libzstd1
+seabios
+zlib1g


### PR DESCRIPTION
Reverts dfinity/ic#4320. This is a NOOP for the actual image builds. Now that new base images have been built and published, this switches them back to the previous changes, while they are being tested on https://github.com/dfinity/ic/pull/4321.