### PR TITLE
fix(IDX): initialize ARGS var

### DIFF
--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -22,6 +22,8 @@ if [ "$TARGETS" == "//..." ]; then
     exit 0
 fi
 
+ARGS=()
+
 if [[ $TARGETS =~ ic-os ]]; then
     ARGS+=(-i)
 fi


### PR DESCRIPTION
This ensures the `ARGS` variable is set. Otherwise, if no changes are required, the variable is unset when the size is checked.