### PR TITLE
test(IDX): mark query_stats_above_threshold and query_stats_basic as long_tests

### DIFF
--- a/rs/tests/query_stats/BUILD.bazel
+++ b/rs/tests/query_stats/BUILD.bazel
@@ -8,6 +8,7 @@ system_test(
     env = UNIVERSAL_CANISTER_ENV,
     tags = [
         "k8s",
+        "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + UNIVERSAL_CANISTER_RUNTIME_DEPS,
@@ -40,6 +41,7 @@ system_test(
     env = UNIVERSAL_CANISTER_ENV,
     tags = [
         "k8s",
+        "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS + UNIVERSAL_CANISTER_RUNTIME_DEPS,


### PR DESCRIPTION
The P90 duratiion of the following tests is higher than the maximally allowed 5 minutes:
* `//rs/tests/query_stats:query_stats_above_threshold`: 7min 20s
* `//rs/tests/query_stats:query_stats_basic`: 6min 38s
So we mark them as `long_test` such that they're not automatically run on PRs but only when requested explicitly by tagging the PR with `CI_ALL_BAZEL_TARGETS` or when commits are pushed to `master`.