### PR TITLE
feat(registry): Large response API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11596,6 +11596,7 @@ dependencies = [
  "ic-registry-keys",
  "ic-registry-transport-protobuf-generator",
  "ic-test-utilities-compare-dirs",
+ "pretty_assertions",
  "prost 0.13.4",
  "serde",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19007,6 +19007,7 @@ dependencies = [
  "ic-test-utilities-types",
  "ic-types",
  "ic-types-test-utils",
+ "ic-utils 0.9.0",
  "idna 1.0.3",
  "ipnet",
  "itertools 0.12.1",

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -37,6 +37,7 @@ DEPENDENCIES = [
     "//rs/types/base_types",
     "//rs/types/management_canister_types",
     "//rs/types/types",
+    "//rs/utils",
     "@crate_index//:build-info",
     "@crate_index//:candid",
     "@crate_index//:futures",

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -44,6 +44,7 @@ ic-registry-transport = { path = "../transport" }
 ic-registry-node-provider-rewards = { path = "../node_provider_rewards" }
 ic-stable-structures = { workspace = true }
 ic-types = { path = "../../types/types" }
+ic-utils = { path = "../../utils" }
 idna = { workspace = true }
 lazy_static = { workspace = true }
 leb128 = "0.2.4"

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -73,8 +73,9 @@ use registry_canister::{
         reroute_canister_ranges::RerouteCanisterRangesPayload,
     },
     pb::v1::{
-        ApiBoundaryNodeIdRecord, GetApiBoundaryNodeIdsRequest, GetSubnetForCanisterRequest,
-        NodeProvidersMonthlyXdrRewards, RegistryCanisterStableStorage, SubnetForCanister,
+        ApiBoundaryNodeIdRecord, Chunk, GetApiBoundaryNodeIdsRequest, GetChunkRequest,
+        GetSubnetForCanisterRequest, NodeProvidersMonthlyXdrRewards, RegistryCanisterStableStorage,
+        SubnetForCanister,
     },
     proto_on_wire::protobuf,
     registry::{EncodedVersion, Registry, MAX_REGISTRY_DELTAS_SIZE},
@@ -385,6 +386,16 @@ fn atomic_mutate() {
 
     let bytes = serialize_atomic_mutate_response(response_pb).expect("Error serializing response");
     reply(&bytes)
+}
+
+#[export_name = "canister_query get_chunk"]
+fn get_chunk() {
+    over(candid_one, get_chunk_);
+}
+
+#[candid_method(query, rename = "get_chunk")]
+fn get_chunk_(_request: GetChunkRequest) -> Result<Chunk, String> {
+    todo!();
 }
 
 #[export_name = "canister_update revise_elected_guestos_versions"]

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -197,6 +197,19 @@ type ApiBoundaryNodeIdRecord = record {
   id : opt principal;
 };
 
+type GetChunkRequest = record {
+  content_sha256 : opt blob;
+};
+
+type GetChunkResponse = variant {
+  Ok : Chunk;
+  Err : text;
+};
+
+type Chunk = record {
+  content : opt blob;
+};
+
 type GetNodeOperatorsAndDcsOfNodeProviderResponse = variant {
   Ok : vec record { DataCenterRecord; NodeOperatorRecord };
   Err : text;
@@ -455,6 +468,7 @@ service : {
   deploy_hostos_to_some_nodes : (DeployHostosToSomeNodes) -> ();
   get_api_boundary_node_ids : (GetApiBoundaryNodeIdsRequest) -> (GetApiBoundaryNodeIdsResponse) query;
   get_build_metadata : () -> (text) query;
+  get_chunk : (GetChunkRequest) -> (GetChunkResponse) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
   get_node_providers_monthly_xdr_rewards : () -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
   get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (GetSubnetForCanisterResponse) query;

--- a/rs/registry/canister/proto/ic_registry_canister/pb/v1/registry.proto
+++ b/rs/registry/canister/proto/ic_registry_canister/pb/v1/registry.proto
@@ -106,6 +106,17 @@ message SubnetForCanister {
     ic_base_types.pb.v1.PrincipalId subnet_id = 1;
 }
 
+message GetChunkRequest {
+  optional bytes content_sha256 = 1;
+}
+
+// When an entry is too large to fit into a "normal" response, the response
+// references multiple chunks, which need to be fetched in follow-up get_chunk
+// requests. (This is the main part of `get_chunk` responses.)
+message Chunk {
+  optional bytes content = 1;
+}
+
 // API boundary nodes IDs request payload.
 message GetApiBoundaryNodeIdsRequest {
 

--- a/rs/registry/canister/protobuf_generator/src/lib.rs
+++ b/rs/registry/canister/protobuf_generator/src/lib.rs
@@ -39,6 +39,17 @@ pub fn generate_prost_files(proto: ProtoPaths<'_>, out: &Path) {
         );
     }
 
+    // Speed up deserialization of `opt blob`/`Option<Vec<u8>>` fields.
+    for option_blob_field_name in [
+        "GetChunkRequest.content_sha256", // This is small, but why not.
+        "Chunk.content",
+    ] {
+        config.field_attribute(
+            format!("ic_registry_canister.pb.v1.{}", option_blob_field_name),
+            r#"#[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]"#,
+        );
+    }
+
     std::fs::create_dir_all(out).expect("failed to create output directory");
     config.out_dir(out);
 

--- a/rs/registry/canister/protobuf_generator/src/lib.rs
+++ b/rs/registry/canister/protobuf_generator/src/lib.rs
@@ -24,26 +24,20 @@ pub fn generate_prost_files(proto: ProtoPaths<'_>, out: &Path) {
     );
     config.extern_path(".ic_base_types.pb.v1", "::ic-base-types");
 
-    config.type_attribute(
-        "ic_registry_canister.pb.v1.NodeProvidersMonthlyXdrRewards",
-        "#[derive(candid::CandidType, candid::Deserialize)]",
-    );
-    config.type_attribute(
-        "ic_registry_canister.pb.v1.GetSubnetForCanisterRequest",
-        "#[derive(candid::CandidType, candid::Deserialize)]",
-    );
-    config.type_attribute(
-        "ic_registry_canister.pb.v1.SubnetForCanister",
-        "#[derive(candid::CandidType, candid::Deserialize)]",
-    );
-    config.type_attribute(
-        "ic_registry_canister.pb.v1.GetApiBoundaryNodeIdsRequest",
-        "#[derive(candid::CandidType, candid::Deserialize)]",
-    );
-    config.type_attribute(
-        "ic_registry_canister.pb.v1.ApiBoundaryNodeIdRecord",
-        "#[derive(candid::CandidType, candid::Deserialize)]",
-    );
+    for type_name in [
+        "ApiBoundaryNodeIdRecord",
+        "Chunk",
+        "GetApiBoundaryNodeIdsRequest",
+        "GetChunkRequest",
+        "GetSubnetForCanisterRequest",
+        "NodeProvidersMonthlyXdrRewards",
+        "SubnetForCanister",
+    ] {
+        config.type_attribute(
+            format!("ic_registry_canister.pb.v1.{}", type_name),
+            "#[derive(candid::CandidType, candid::Deserialize)]",
+        );
+    }
 
     std::fs::create_dir_all(out).expect("failed to create output directory");
     config.out_dir(out);

--- a/rs/registry/canister/src/gen/ic_registry_canister.pb.v1.rs
+++ b/rs/registry/canister/src/gen/ic_registry_canister.pb.v1.rs
@@ -130,6 +130,19 @@ pub struct SubnetForCanister {
     #[prost(message, optional, tag = "1")]
     pub subnet_id: ::core::option::Option<::ic_base_types::PrincipalId>,
 }
+#[derive(candid::CandidType, candid::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct GetChunkRequest {
+    #[prost(bytes = "vec", optional, tag = "1")]
+    pub content_sha256: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+}
+/// When an entry is too large to fit into a "normal" response, the response
+/// references multiple chunks, which need to be fetched in follow-up get_chunk
+/// requests. (This is the main part of `get_chunk` responses.)
+#[derive(candid::CandidType, candid::Deserialize, Clone, PartialEq, ::prost::Message)]
+pub struct Chunk {
+    #[prost(bytes = "vec", optional, tag = "1")]
+    pub content: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+}
 /// API boundary nodes IDs request payload.
 #[derive(candid::CandidType, candid::Deserialize, Clone, Copy, PartialEq, ::prost::Message)]
 pub struct GetApiBoundaryNodeIdsRequest {}

--- a/rs/registry/canister/src/gen/ic_registry_canister.pb.v1.rs
+++ b/rs/registry/canister/src/gen/ic_registry_canister.pb.v1.rs
@@ -133,6 +133,7 @@ pub struct SubnetForCanister {
 #[derive(candid::CandidType, candid::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct GetChunkRequest {
     #[prost(bytes = "vec", optional, tag = "1")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
     pub content_sha256: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// When an entry is too large to fit into a "normal" response, the response
@@ -141,6 +142,7 @@ pub struct GetChunkRequest {
 #[derive(candid::CandidType, candid::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct Chunk {
     #[prost(bytes = "vec", optional, tag = "1")]
+    #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
     pub content: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
 }
 /// API boundary nodes IDs request payload.

--- a/rs/registry/transport/BUILD.bazel
+++ b/rs/registry/transport/BUILD.bazel
@@ -21,6 +21,7 @@ DEV_DEPENDENCIES = [
     # Keep sorted.
     "//rs/nervous_system/common/test_keys",
     "//rs/registry/keys",
+    "@crate_index//:pretty_assertions",
 ]
 
 rust_library(

--- a/rs/registry/transport/Cargo.toml
+++ b/rs/registry/transport/Cargo.toml
@@ -19,3 +19,4 @@ ic-registry-keys = { path = "../keys" }
 ic-registry-transport-protobuf-generator = { path = "./protobuf_generator" }
 ic-test-utilities-compare-dirs = { path = "../../test_utilities/compare_dirs" }
 tempfile = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
+++ b/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
@@ -153,26 +153,48 @@ message LargeValueChunkKeys {
   repeated bytes chunk_content_sha256s = 1;
 }
 
-// In the not too distant future, this will be used instead of
-// RegistryGetChangesSinceResponse. See the "Migrating to Large
-// Values/High-Capacity Types" section in the file-level comments.
-message HighCapacityRegistryGetChangesSinceResponse {
-  RegistryError error = 1;
+// In the not so distant future, this will be used instead of RegistryValue. See
+// the "Migrating to Large Values/High-Capacity Types" section in the file-level
+// comments.
+message HighCapacityRegistryValue {
+  // The version at which this mutation happened.
   uint64 version = 2;
-  repeated HighCapacityRegistryDelta deltas = 3;
+
+  oneof content {
+    // The value that was set in this mutation.
+    bytes value = 1;
+
+    // If true, this change represents a deletion.
+    bool deletion_marker = 3;
+
+    // If the value is too large, this is used instead of the `value` field.
+    LargeValueChunkKeys large_value_chunk_keys = 4;
+  }
 }
+
+// In the not so distant future, this will be used instead of RegistryDelta. See
+// the "Migrating to Large Values/High-Capacity Types" section in the file-level
+// comments.
 message HighCapacityRegistryDelta {
   bytes key = 1;
   repeated HighCapacityRegistryValue values = 2;
 }
-message HighCapacityRegistryValue {
+
+// In the not too distant future, this will be used instead of
+// RegistryGetChangesSinceResponse. See the "Migrating to Large
+// Values/High-Capacity Types" section in the file-level comments.
+message HighCapacityRegistryGetChangesSinceResponse {
+  // If anything went wrong, the registry canister
+  // will set this error.
+  RegistryError error = 1;
+
+  // The last version of the registry.
   uint64 version = 2;
 
-  oneof content {
-    bytes value = 1;
-    bool deletion_marker = 3;
-    LargeValueChunkKeys large_value_chunk_keys = 4;
-  }
+  // A list of all the keys and all the values that change
+  // and all the intermediate changes since the version
+  // requested.
+  repeated HighCapacityRegistryDelta deltas = 3;
 }
 
 // A single change made to a key in the registry.
@@ -233,10 +255,22 @@ message RegistryGetValueRequest {
 // RegistryGetValueResponse. See the "Migrating to Large Values/High-Capacity
 // Types" section in the file-level comments.
 message HighCapacityRegistryGetValueResponse {
+  // If anything went wrong, the registry canister
+  // will set this error.
   RegistryError error = 1;
+
+  // the version at which the value corresponding to the queried
+  // key was last mutated (inserted, updated, or deleted)
+  // before at or at the version specified
+  // in the RegistryGetValueRequest.
   uint64 version = 2;
+
   oneof content {
+    // The value retrieved from the registry.
     bytes value = 3;
+
+    // If the value is too large, this will be used instead of the `value`
+    // field.
     LargeValueChunkKeys large_value_chunk_keys = 4;
   }
 }
@@ -271,22 +305,43 @@ message RegistryGetLatestVersionResponse {
 }
 
 // In the not too distant future, the `get_certified_changes_since` canister
+// method will use this instead of RegistryMutation. However, there is no
+// intention for the `atomic_mutate` canister method to ever use this. See the
+// "Migrating to Large Values/High-Capacity Types" section in the file-level
+// comments.
+message HighCapacityRegistryMutation {
+  // The type of the mutation to apply to the registry.
+  // Always required.
+  RegistryMutation.Type mutation_type = 1;
+
+  // The key of the entry to mutate in the registry.
+  // Always required.
+  bytes key = 2;
+
+  oneof content {
+    // The value to mutate in the registry.
+    // Required for insert, update, but not for delete.
+    bytes value = 3;
+
+    // If the value is too large, this will be used instead of the `value`
+    // field.
+    LargeValueChunkKeys large_value_chunk_keys = 4;
+  }
+}
+
+// In the not too distant future, the `get_certified_changes_since` canister
 // method will use this instead of RegistryAtomicMutateRequest. However, there
 // is no intention for the `atomic_mutate` canister method to ever use this. See
 // the "Migrating to Large Values/High-Capacity Types" section in the file-level
 // comments.
 message HighCapacityRegistryAtomicMutateRequest {
+  // The set of mutations to apply to the registry.
   repeated HighCapacityRegistryMutation mutations = 1;
+
+  // Preconditions at the key level.
   repeated Precondition preconditions = 5;
+
   reserved 4;
-}
-message HighCapacityRegistryMutation {
-  RegistryMutation.Type mutation_type = 1;
-  bytes key = 2;
-  oneof content {
-    bytes value = 3;
-    LargeValueChunkKeys large_value_chunk_keys = 4;
-  }
 }
 
 // A single mutation in the registry.

--- a/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
+++ b/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
@@ -66,6 +66,15 @@ message RegistryError {
   bytes key = 3;
 }
 
+// When a "monolithic" blob is too large to fit in a single response, this is
+// used instead (in the ICP, messages can be at most 2 MiB in size). The
+// `get_chunk` canister method can then be called to fetch the original
+// monolithic blob in chunks (which can then be cancatenated to reconstitute the
+// original monolithic blob).
+message LargeValueChunkKeys {
+  repeated bytes chunk_content_sha256s = 1;
+}
+
 // A single change made to a key in the registry.
 message RegistryValue {
   // The value that was set in this mutation. If the

--- a/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
+++ b/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
@@ -151,6 +151,28 @@ message LargeValueChunkKeys {
   repeated bytes chunk_content_sha256s = 1;
 }
 
+// In the not too distant future, this will be used instead of
+// RegistryGetChangesSinceResponse. See the "Migrating to Large
+// Values/High-Capacity Types" section in the file-level comments.
+message HighCapacityRegistryGetChangesSinceResponse {
+  RegistryError error = 1;
+  uint64 version = 2;
+  repeated HighCapacityRegistryDelta deltas = 3;
+}
+message HighCapacityRegistryDelta {
+  bytes key = 1;
+  repeated HighCapacityRegistryValue values = 2;
+}
+message HighCapacityRegistryValue {
+  uint64 version = 2;
+
+  oneof content {
+    bytes value = 1;
+    bool deletion_marker = 3;
+    LargeValueChunkKeys large_value_chunk_keys = 4;
+  }
+}
+
 // A single change made to a key in the registry.
 message RegistryValue {
   // The value that was set in this mutation. If the
@@ -174,6 +196,10 @@ message RegistryDelta {
 // since 'version'.
 message RegistryGetChangesSinceRequest { uint64 version = 1; }
 
+// Deprecated; instead, use HighCapacityRegistryGetChangesSinceResponse. See the
+// "Migrating to Large Values/High-Capacity Types" section in the file-level
+// comments.
+//
 // Message corresponding to the response from the registry
 // canister to a get_latest_version() request.
 message RegistryGetChangesSinceResponse {

--- a/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
+++ b/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
@@ -201,6 +201,22 @@ message RegistryGetValueRequest {
   bytes key = 2;
 }
 
+// In the not too distant future, this will be used instead of
+// RegistryGetValueResponse. See the "Migrating to Large Values/High-Capacity
+// Types" section in the file-level comments.
+message HighCapacityRegistryGetValueResponse {
+  RegistryError error = 1;
+  uint64 version = 2;
+  oneof content {
+    bytes value = 3;
+    LargeValueChunkKeys large_value_chunk_keys = 4;
+  }
+}
+
+// Deprecated; instead, use HighCapacityRegistryGetValueResponse. See the
+// "Migrating to Large Values/High-Capacity Types" section in the file-level
+// comments.
+//
 // Message corresponding to the response from the canister
 // to a get_value() request.
 //

--- a/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
+++ b/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
@@ -24,6 +24,82 @@ syntax = "proto3";
 //
 // Note that registry versions are always strictly >= 0, a -1 value is used
 // to signal that no version was assigned.
+//
+// # Migrating to Large Values/High-Capacity Types
+//
+// Clients need to migrate if they fetch `CatchUpPackageContents`(s) via one (or
+// more) of the following methods:
+//
+//     1. get_certified_changes_since
+//     2. get_value
+//     3. get_changes_since
+//
+// (Such entries have keys of the form `catch_up_package_contents_${subnet_id}`.)
+//
+// Many types here have corresponding "high-capacity" types. E.g. we define both
+// RegistryValue and HighCapacityRegistryValue. We refer to the former as the
+// "legacy" type; whereas, we call the later the "high-capacity" type. We are
+// transitioning to the high-capacity types. Although clients need to do some
+// work, the migration will be "nice and gradual". This section explains what
+// clients can and must do, and when.
+//
+// The key observation is that as long as
+//
+//     1. the `large_value_chunk_keys` field is not populated, and
+//     2. whenever `deletion_marker` is true, `value` is empty
+//
+// then, it is possible to convert from a high-capacity object to a equivalent
+// legacy object by encoding, and then decoding. Furthermore, the other
+// direction also works. This allows a window during which clients can start
+// using high-capacity types at any time.
+//
+// Once the high-capacity type definitions are in the master branch of the ic
+// GitHub repo, the migration window has "opened". An announcement will be sent
+// shortly after this event. This will occur as soon as possible to give clients
+// as much time as possible to migrate.
+//
+// At this point, client CAN migrate. That is, they can (develop and) deploy
+// versions of their application that use high-capacity types instead of legacy
+// types. Once they do that, they will be ready for the Registry canister to
+// start emiting large data.
+//
+// During this time, Registry will also migrate to high-capacity types, but will
+// not actually start emitting large data right away.
+//
+// After clients have had a "reasonable" amount of time to migrate, large data
+// will start appearing in Registry. At that point, the migration window is
+// "closed", and clients will need to have migrated. An announcement will be
+// sent shortly before this event. The appearance of large data might be delayed
+// if clients need more time to migrate.
+//
+// After the migration window, the legacy types will be obsolete. Therefore, it
+// will be a bit silly for "HighCapacity" to be in the name of the types, and it
+// will be confusing for the legacy types to be retained. Therefore, what will
+// happen shortly after the migration window is that the legacy type definitions
+// will be replaced/modified with a copy of the high-capacity type definitions.
+// After a "long" time has passed, the "HighCapacity" names will go away.
+//
+// To ease this secondary/cleanup transition (where "HighCapacity" is deleted),
+// it is recommended that clients create some aliases. E.g. in Rust,
+//
+// ```rust
+// use ic_registry_transport::pb::v1::{
+//     HighCapacityRegistryValue as RegistryValue,
+// };
+// ```
+//
+// Then, when the legacy definitions are replaced, clients can change the above
+// line to this:
+//
+// ```rust
+// use ic_registry_transport::pb::v1::{
+//     RegistryValue,
+// };
+// ```
+//
+// Once all clients have made such changes, it will be possible to delete
+// "HighCapacity" definitions from this file. (Ofc, such clean up is not
+// strictly necessary, and can easily be deferred for a long time.)
 package ic_registry_transport.pb.v1;
 
 import "google/protobuf/wrappers.proto";

--- a/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
+++ b/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
@@ -100,6 +100,8 @@ syntax = "proto3";
 // Once all clients have made such changes, it will be possible to delete
 // "HighCapacity" definitions from this file. (Ofc, such clean up is not
 // strictly necessary, and can easily be deferred for a long time.)
+//
+// TODO(NNS1-3679): Delete this section once all the steps here are completed.
 package ic_registry_transport.pb.v1;
 
 import "google/protobuf/wrappers.proto";

--- a/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
+++ b/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
@@ -242,6 +242,25 @@ message RegistryGetLatestVersionResponse {
   uint64 version = 1;
 }
 
+// In the not too distant future, the `get_certified_changes_since` canister
+// method will use this instead of RegistryAtomicMutateRequest. However, there
+// is no intention for the `atomic_mutate` canister method to ever use this. See
+// the "Migrating to Large Values/High-Capacity Types" section in the file-level
+// comments.
+message HighCapacityRegistryAtomicMutateRequest {
+  repeated HighCapacityRegistryMutation mutations = 1;
+  repeated Precondition preconditions = 5;
+  reserved 4;
+}
+message HighCapacityRegistryMutation {
+  RegistryMutation.Type mutation_type = 1;
+  bytes key = 2;
+  oneof content {
+    bytes value = 3;
+    LargeValueChunkKeys large_value_chunk_keys = 4;
+  }
+}
+
 // A single mutation in the registry.
 message RegistryMutation {
   enum Type {
@@ -285,6 +304,12 @@ message Precondition {
   uint64 expected_version = 2;
 }
 
+// Deprecated for `get_certified_changes_since` responses; instead, use
+// HighCapacityRegistryAtomicMutateRequest. See the "Migrating to Large
+// Values/High-Capacity Types" section in the file-level comments.
+//
+// This is NOT deprecated for `atomic_mutate` requests though!
+//
 // Message corresponding to a list of mutations to apply, atomically, to the
 // registry canister. If any of the mutations fails, the whole operation will fail.
 message RegistryAtomicMutateRequest {

--- a/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
+++ b/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
@@ -140,6 +140,35 @@ pub struct RegistryGetValueRequest {
     #[prost(bytes = "vec", tag = "2")]
     pub key: ::prost::alloc::vec::Vec<u8>,
 }
+/// In the not too distant future, this will be used instead of
+/// RegistryGetValueResponse. See the "Migrating to Large Values/High-Capacity
+/// Types" section in the file-level comments.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HighCapacityRegistryGetValueResponse {
+    #[prost(message, optional, tag = "1")]
+    pub error: ::core::option::Option<RegistryError>,
+    #[prost(uint64, tag = "2")]
+    pub version: u64,
+    #[prost(
+        oneof = "high_capacity_registry_get_value_response::Content",
+        tags = "3, 4"
+    )]
+    pub content: ::core::option::Option<high_capacity_registry_get_value_response::Content>,
+}
+/// Nested message and enum types in `HighCapacityRegistryGetValueResponse`.
+pub mod high_capacity_registry_get_value_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Content {
+        #[prost(bytes, tag = "3")]
+        Value(::prost::alloc::vec::Vec<u8>),
+        #[prost(message, tag = "4")]
+        LargeValueChunkKeys(super::LargeValueChunkKeys),
+    }
+}
+/// Deprecated; instead, use HighCapacityRegistryGetValueResponse. See the
+/// "Migrating to Large Values/High-Capacity Types" section in the file-level
+/// comments.
+///
 /// Message corresponding to the response from the canister
 /// to a get_value() request.
 ///

--- a/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
+++ b/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
@@ -79,6 +79,44 @@ pub struct LargeValueChunkKeys {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub chunk_content_sha256s: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
+/// In the not too distant future, this will be used instead of
+/// RegistryGetChangesSinceResponse. See the "Migrating to Large
+/// Values/High-Capacity Types" section in the file-level comments.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HighCapacityRegistryGetChangesSinceResponse {
+    #[prost(message, optional, tag = "1")]
+    pub error: ::core::option::Option<RegistryError>,
+    #[prost(uint64, tag = "2")]
+    pub version: u64,
+    #[prost(message, repeated, tag = "3")]
+    pub deltas: ::prost::alloc::vec::Vec<HighCapacityRegistryDelta>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HighCapacityRegistryDelta {
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, repeated, tag = "2")]
+    pub values: ::prost::alloc::vec::Vec<HighCapacityRegistryValue>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HighCapacityRegistryValue {
+    #[prost(uint64, tag = "2")]
+    pub version: u64,
+    #[prost(oneof = "high_capacity_registry_value::Content", tags = "1, 3, 4")]
+    pub content: ::core::option::Option<high_capacity_registry_value::Content>,
+}
+/// Nested message and enum types in `HighCapacityRegistryValue`.
+pub mod high_capacity_registry_value {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Content {
+        #[prost(bytes, tag = "1")]
+        Value(::prost::alloc::vec::Vec<u8>),
+        #[prost(bool, tag = "3")]
+        DeletionMarker(bool),
+        #[prost(message, tag = "4")]
+        LargeValueChunkKeys(super::LargeValueChunkKeys),
+    }
+}
 /// A single change made to a key in the registry.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegistryValue {
@@ -108,6 +146,10 @@ pub struct RegistryGetChangesSinceRequest {
     #[prost(uint64, tag = "1")]
     pub version: u64,
 }
+/// Deprecated; instead, use HighCapacityRegistryGetChangesSinceResponse. See the
+/// "Migrating to Large Values/High-Capacity Types" section in the file-level
+/// comments.
+///
 /// Message corresponding to the response from the registry
 /// canister to a get_latest_version() request.
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
+++ b/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
@@ -198,6 +198,37 @@ pub struct RegistryGetLatestVersionResponse {
     #[prost(uint64, tag = "1")]
     pub version: u64,
 }
+/// In the not too distant future, the `get_certified_changes_since` canister
+/// method will use this instead of RegistryAtomicMutateRequest. However, there
+/// is no intention for the `atomic_mutate` canister method to ever use this. See
+/// the "Migrating to Large Values/High-Capacity Types" section in the file-level
+/// comments.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HighCapacityRegistryAtomicMutateRequest {
+    #[prost(message, repeated, tag = "1")]
+    pub mutations: ::prost::alloc::vec::Vec<HighCapacityRegistryMutation>,
+    #[prost(message, repeated, tag = "5")]
+    pub preconditions: ::prost::alloc::vec::Vec<Precondition>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HighCapacityRegistryMutation {
+    #[prost(enumeration = "registry_mutation::Type", tag = "1")]
+    pub mutation_type: i32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(oneof = "high_capacity_registry_mutation::Content", tags = "3, 4")]
+    pub content: ::core::option::Option<high_capacity_registry_mutation::Content>,
+}
+/// Nested message and enum types in `HighCapacityRegistryMutation`.
+pub mod high_capacity_registry_mutation {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Content {
+        #[prost(bytes, tag = "3")]
+        Value(::prost::alloc::vec::Vec<u8>),
+        #[prost(message, tag = "4")]
+        LargeValueChunkKeys(super::LargeValueChunkKeys),
+    }
+}
 /// A single mutation in the registry.
 #[derive(candid::CandidType, candid::Deserialize, Eq, Clone, PartialEq, ::prost::Message)]
 pub struct RegistryMutation {
@@ -271,6 +302,12 @@ pub struct Precondition {
     #[prost(uint64, tag = "2")]
     pub expected_version: u64,
 }
+/// Deprecated for `get_certified_changes_since` responses; instead, use
+/// HighCapacityRegistryAtomicMutateRequest. See the "Migrating to Large
+/// Values/High-Capacity Types" section in the file-level comments.
+///
+/// This is NOT deprecated for `atomic_mutate` requests though!
+///
 /// Message corresponding to a list of mutations to apply, atomically, to the
 /// registry canister. If any of the mutations fails, the whole operation will fail.
 #[derive(candid::CandidType, candid::Deserialize, Eq, Clone, PartialEq, ::prost::Message)]

--- a/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
+++ b/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
@@ -79,27 +79,12 @@ pub struct LargeValueChunkKeys {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub chunk_content_sha256s: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
-/// In the not too distant future, this will be used instead of
-/// RegistryGetChangesSinceResponse. See the "Migrating to Large
-/// Values/High-Capacity Types" section in the file-level comments.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HighCapacityRegistryGetChangesSinceResponse {
-    #[prost(message, optional, tag = "1")]
-    pub error: ::core::option::Option<RegistryError>,
-    #[prost(uint64, tag = "2")]
-    pub version: u64,
-    #[prost(message, repeated, tag = "3")]
-    pub deltas: ::prost::alloc::vec::Vec<HighCapacityRegistryDelta>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HighCapacityRegistryDelta {
-    #[prost(bytes = "vec", tag = "1")]
-    pub key: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, repeated, tag = "2")]
-    pub values: ::prost::alloc::vec::Vec<HighCapacityRegistryValue>,
-}
+/// In the not so distant future, this will be used instead of RegistryValue. See
+/// the "Migrating to Large Values/High-Capacity Types" section in the file-level
+/// comments.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HighCapacityRegistryValue {
+    /// The version at which this mutation happened.
     #[prost(uint64, tag = "2")]
     pub version: u64,
     #[prost(oneof = "high_capacity_registry_value::Content", tags = "1, 3, 4")]
@@ -109,13 +94,44 @@ pub struct HighCapacityRegistryValue {
 pub mod high_capacity_registry_value {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
+        /// The value that was set in this mutation.
         #[prost(bytes, tag = "1")]
         Value(::prost::alloc::vec::Vec<u8>),
+        /// If true, this change represents a deletion.
         #[prost(bool, tag = "3")]
         DeletionMarker(bool),
+        /// If the value is too large, this is used instead of the `value` field.
         #[prost(message, tag = "4")]
         LargeValueChunkKeys(super::LargeValueChunkKeys),
     }
+}
+/// In the not so distant future, this will be used instead of RegistryDelta. See
+/// the "Migrating to Large Values/High-Capacity Types" section in the file-level
+/// comments.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HighCapacityRegistryDelta {
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, repeated, tag = "2")]
+    pub values: ::prost::alloc::vec::Vec<HighCapacityRegistryValue>,
+}
+/// In the not too distant future, this will be used instead of
+/// RegistryGetChangesSinceResponse. See the "Migrating to Large
+/// Values/High-Capacity Types" section in the file-level comments.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HighCapacityRegistryGetChangesSinceResponse {
+    /// If anything went wrong, the registry canister
+    /// will set this error.
+    #[prost(message, optional, tag = "1")]
+    pub error: ::core::option::Option<RegistryError>,
+    /// The last version of the registry.
+    #[prost(uint64, tag = "2")]
+    pub version: u64,
+    /// A list of all the keys and all the values that change
+    /// and all the intermediate changes since the version
+    /// requested.
+    #[prost(message, repeated, tag = "3")]
+    pub deltas: ::prost::alloc::vec::Vec<HighCapacityRegistryDelta>,
 }
 /// A single change made to a key in the registry.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -187,8 +203,14 @@ pub struct RegistryGetValueRequest {
 /// Types" section in the file-level comments.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HighCapacityRegistryGetValueResponse {
+    /// If anything went wrong, the registry canister
+    /// will set this error.
     #[prost(message, optional, tag = "1")]
     pub error: ::core::option::Option<RegistryError>,
+    /// the version at which the value corresponding to the queried
+    /// key was last mutated (inserted, updated, or deleted)
+    /// before at or at the version specified
+    /// in the RegistryGetValueRequest.
     #[prost(uint64, tag = "2")]
     pub version: u64,
     #[prost(
@@ -201,8 +223,11 @@ pub struct HighCapacityRegistryGetValueResponse {
 pub mod high_capacity_registry_get_value_response {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
+        /// The value retrieved from the registry.
         #[prost(bytes, tag = "3")]
         Value(::prost::alloc::vec::Vec<u8>),
+        /// If the value is too large, this will be used instead of the `value`
+        /// field.
         #[prost(message, tag = "4")]
         LargeValueChunkKeys(super::LargeValueChunkKeys),
     }
@@ -241,21 +266,18 @@ pub struct RegistryGetLatestVersionResponse {
     pub version: u64,
 }
 /// In the not too distant future, the `get_certified_changes_since` canister
-/// method will use this instead of RegistryAtomicMutateRequest. However, there
-/// is no intention for the `atomic_mutate` canister method to ever use this. See
-/// the "Migrating to Large Values/High-Capacity Types" section in the file-level
+/// method will use this instead of RegistryMutation. However, there is no
+/// intention for the `atomic_mutate` canister method to ever use this. See the
+/// "Migrating to Large Values/High-Capacity Types" section in the file-level
 /// comments.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HighCapacityRegistryAtomicMutateRequest {
-    #[prost(message, repeated, tag = "1")]
-    pub mutations: ::prost::alloc::vec::Vec<HighCapacityRegistryMutation>,
-    #[prost(message, repeated, tag = "5")]
-    pub preconditions: ::prost::alloc::vec::Vec<Precondition>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HighCapacityRegistryMutation {
+    /// The type of the mutation to apply to the registry.
+    /// Always required.
     #[prost(enumeration = "registry_mutation::Type", tag = "1")]
     pub mutation_type: i32,
+    /// The key of the entry to mutate in the registry.
+    /// Always required.
     #[prost(bytes = "vec", tag = "2")]
     pub key: ::prost::alloc::vec::Vec<u8>,
     #[prost(oneof = "high_capacity_registry_mutation::Content", tags = "3, 4")]
@@ -265,11 +287,29 @@ pub struct HighCapacityRegistryMutation {
 pub mod high_capacity_registry_mutation {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
+        /// The value to mutate in the registry.
+        /// Required for insert, update, but not for delete.
         #[prost(bytes, tag = "3")]
         Value(::prost::alloc::vec::Vec<u8>),
+        /// If the value is too large, this will be used instead of the `value`
+        /// field.
         #[prost(message, tag = "4")]
         LargeValueChunkKeys(super::LargeValueChunkKeys),
     }
+}
+/// In the not too distant future, the `get_certified_changes_since` canister
+/// method will use this instead of RegistryAtomicMutateRequest. However, there
+/// is no intention for the `atomic_mutate` canister method to ever use this. See
+/// the "Migrating to Large Values/High-Capacity Types" section in the file-level
+/// comments.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HighCapacityRegistryAtomicMutateRequest {
+    /// The set of mutations to apply to the registry.
+    #[prost(message, repeated, tag = "1")]
+    pub mutations: ::prost::alloc::vec::Vec<HighCapacityRegistryMutation>,
+    /// Preconditions at the key level.
+    #[prost(message, repeated, tag = "5")]
+    pub preconditions: ::prost::alloc::vec::Vec<Precondition>,
 }
 /// A single mutation in the registry.
 #[derive(candid::CandidType, candid::Deserialize, Eq, Clone, PartialEq, ::prost::Message)]

--- a/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
+++ b/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
@@ -69,6 +69,16 @@ pub mod registry_error {
         }
     }
 }
+/// When a "monolithic" blob is too large to fit in a single response, this is
+/// used instead (in the ICP, messages can be at most 2 MiB in size). The
+/// `get_chunk` canister method can then be called to fetch the original
+/// monolithic blob in chunks (which can then be cancatenated to reconstitute the
+/// original monolithic blob).
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LargeValueChunkKeys {
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub chunk_content_sha256s: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
 /// A single change made to a key in the registry.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegistryValue {

--- a/rs/registry/transport/src/lib.rs
+++ b/rs/registry/transport/src/lib.rs
@@ -367,7 +367,15 @@ pub fn precondition(key: impl AsRef<[u8]>, version: u64) -> Precondition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pb::v1::RegistryAtomicMutateRequest;
+    use crate::pb::v1::{
+        high_capacity_registry_get_value_response, high_capacity_registry_mutation,
+        high_capacity_registry_value, registry_mutation, HighCapacityRegistryAtomicMutateRequest,
+        HighCapacityRegistryDelta, HighCapacityRegistryGetChangesSinceResponse,
+        HighCapacityRegistryGetValueResponse, HighCapacityRegistryMutation,
+        HighCapacityRegistryValue, RegistryAtomicMutateRequest, RegistryDelta,
+        RegistryGetChangesSinceResponse, RegistryGetValueResponse, RegistryValue,
+    };
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_serde_get_value_request() {
@@ -481,5 +489,275 @@ mod tests {
                 "5: You are not welcome here.".to_string()
             )),
         );
+    }
+
+    #[test]
+    fn test_get_changes_since_responses_compatible_happy() {
+        let value = b"Daniel".to_vec();
+        let version = 42;
+        let deletion_marker = false;
+
+        let legacy_registry_value = {
+            let value = value.clone();
+
+            RegistryValue {
+                value,
+                version,
+                deletion_marker,
+            }
+        };
+
+        let high_capacity_registry_value = HighCapacityRegistryValue {
+            content: Some(high_capacity_registry_value::Content::Value(value)),
+            version,
+        };
+
+        let version = 43;
+        let deletion_marker = true;
+
+        let legacy_delete = RegistryValue {
+            value: vec![],
+            version,
+            deletion_marker,
+        };
+
+        let high_capacity_delete = HighCapacityRegistryValue {
+            content: Some(high_capacity_registry_value::Content::DeletionMarker(
+                deletion_marker,
+            )),
+            version,
+        };
+
+        let key = b"name".to_vec();
+        let error = None;
+
+        let legacy_response = {
+            let error = error.clone();
+            let key = key.clone();
+
+            RegistryGetChangesSinceResponse {
+                version,
+                error,
+                deltas: vec![RegistryDelta {
+                    key,
+                    values: vec![legacy_registry_value, legacy_delete],
+                }],
+            }
+        };
+
+        let high_capacity_response = HighCapacityRegistryGetChangesSinceResponse {
+            version,
+            error,
+            deltas: vec![HighCapacityRegistryDelta {
+                key,
+                values: vec![high_capacity_registry_value, high_capacity_delete],
+            }],
+        };
+
+        // OK if client starts using HighCapacity before server.
+        let upgraded = {
+            let encoded: &[u8] = &legacy_response.encode_to_vec();
+            HighCapacityRegistryGetChangesSinceResponse::decode(encoded).unwrap()
+        };
+        assert_eq!(upgraded, high_capacity_response);
+
+        // OK if server starts using HighCapacity before client
+        // (as long as large_value_chunk_keys is not used, ofc).
+        let downgraded = {
+            let encoded: &[u8] = &high_capacity_response.encode_to_vec();
+            RegistryGetChangesSinceResponse::decode(encoded).unwrap()
+        };
+        assert_eq!(downgraded, legacy_response);
+    }
+
+    #[test]
+    fn test_get_changes_since_responses_compatible_sad() {
+        let error = Some(RegistryError {
+            code: 57,
+            key: b"Derp".to_vec(),
+            reason: "You fool!".to_string(),
+        });
+
+        let legacy_response = {
+            let error = error.clone();
+
+            RegistryGetChangesSinceResponse {
+                error,
+                ..Default::default()
+            }
+        };
+
+        let high_capacity_response = HighCapacityRegistryGetChangesSinceResponse {
+            error,
+            ..Default::default()
+        };
+
+        // OK if client starts using HighCapacity before server.
+        let upgraded = {
+            let encoded: &[u8] = &legacy_response.encode_to_vec();
+            HighCapacityRegistryGetChangesSinceResponse::decode(encoded).unwrap()
+        };
+        assert_eq!(upgraded, high_capacity_response);
+
+        // OK if server starts using HighCapacity before client
+        // (as long as large_value_chunk_keys is not used, ofc).
+        let downgraded = {
+            let encoded: &[u8] = &high_capacity_response.encode_to_vec();
+            RegistryGetChangesSinceResponse::decode(encoded).unwrap()
+        };
+        assert_eq!(downgraded, legacy_response);
+    }
+
+    #[test]
+    fn test_get_value_responses_compatible_happy() {
+        let error = None;
+        let version = 42;
+        let value = b"Daniel".to_vec();
+
+        let legacy_response = {
+            let error = error.clone();
+            let value = value.clone();
+
+            RegistryGetValueResponse {
+                error,
+                version,
+                value,
+            }
+        };
+
+        let high_capacity_response = HighCapacityRegistryGetValueResponse {
+            error,
+            version,
+            content: Some(high_capacity_registry_get_value_response::Content::Value(
+                value,
+            )),
+        };
+
+        // Ok if client starts using HighCapacity before server.
+        let upgraded = {
+            let encoded: &[u8] = &legacy_response.encode_to_vec();
+            HighCapacityRegistryGetValueResponse::decode(encoded).unwrap()
+        };
+        assert_eq!(upgraded, high_capacity_response);
+
+        // OK if server starts using HighCapacity before client.
+        let downgraded = {
+            let encoded: &[u8] = &high_capacity_response.encode_to_vec();
+            RegistryGetValueResponse::decode(encoded).unwrap()
+        };
+        assert_eq!(downgraded, legacy_response);
+    }
+
+    #[test]
+    fn test_get_value_responses_compatible_sad() {
+        let error = Some(RegistryError {
+            code: 57,
+            key: b"Derp".to_vec(),
+            reason: "You fool!".to_string(),
+        });
+
+        let legacy_response = {
+            let error = error.clone();
+
+            RegistryGetValueResponse {
+                error,
+                ..Default::default()
+            }
+        };
+
+        let high_capacity_response = HighCapacityRegistryGetValueResponse {
+            error,
+            ..Default::default()
+        };
+
+        // Ok if client starts using HighCapacity before server.
+        let upgraded = {
+            let encoded: &[u8] = &legacy_response.encode_to_vec();
+            HighCapacityRegistryGetValueResponse::decode(encoded).unwrap()
+        };
+        assert_eq!(upgraded, high_capacity_response);
+
+        // OK if server starts using HighCapacity before client.
+        let downgraded = {
+            let encoded: &[u8] = &high_capacity_response.encode_to_vec();
+            RegistryGetValueResponse::decode(encoded).unwrap()
+        };
+        assert_eq!(downgraded, legacy_response);
+    }
+
+    #[test]
+    fn test_atomic_mutate_requests_compatible() {
+        let mutation_types = [
+            registry_mutation::Type::Insert,
+            registry_mutation::Type::Update,
+            registry_mutation::Type::Delete,
+            registry_mutation::Type::Upsert,
+        ];
+
+        let preconditions = vec![
+            Precondition {
+                expected_version: 147,
+                key: b"herp".to_vec(),
+            },
+            Precondition {
+                expected_version: 950,
+                key: b"derp".to_vec(),
+            },
+        ];
+
+        let legacy_response = {
+            let preconditions = preconditions.clone();
+
+            RegistryAtomicMutateRequest {
+                preconditions,
+                mutations: mutation_types
+                    .iter()
+                    .map(|mutation_type| {
+                        let mutation_type = *mutation_type as i32;
+                        let key = format!("key_{}", mutation_type).into_bytes();
+                        let value = format!("value {}", mutation_type).into_bytes();
+
+                        RegistryMutation {
+                            mutation_type,
+                            key,
+                            value,
+                        }
+                    })
+                    .collect(),
+            }
+        };
+
+        let high_capacity_response = HighCapacityRegistryAtomicMutateRequest {
+            preconditions,
+            mutations: mutation_types
+                .iter()
+                .map(|mutation_type| {
+                    let mutation_type = *mutation_type as i32;
+                    let key = format!("key_{}", mutation_type).into_bytes();
+                    let value = format!("value {}", mutation_type).into_bytes();
+                    let content = Some(high_capacity_registry_mutation::Content::Value(value));
+
+                    HighCapacityRegistryMutation {
+                        mutation_type,
+                        key,
+                        content,
+                    }
+                })
+                .collect(),
+        };
+
+        // Ok if client starts using HighCapacity before server.
+        let upgraded = {
+            let encoded: &[u8] = &legacy_response.encode_to_vec();
+            HighCapacityRegistryAtomicMutateRequest::decode(encoded).unwrap()
+        };
+        assert_eq!(upgraded, high_capacity_response);
+
+        // OK if server starts using HighCapacity before client.
+        let downgraded = {
+            let encoded: &[u8] = &high_capacity_response.encode_to_vec();
+            RegistryAtomicMutateRequest::decode(encoded).unwrap()
+        };
+        assert_eq!(downgraded, legacy_response);
     }
 }


### PR DESCRIPTION
# Motivation

The motivating use case is vetKeys. However, knowledge of that feature is NOT required to understand this change (and future changes that will build on this).

The important thing to understand is that we want clients to be able to fetch "large" entries. Prior to this feature, this was not possible, due to the message size limit in the ICP (2 MiB). This feature will get around that by spreading the desired data over multiple canister calls.

The "large" value required by vetKeys is `CatchUpPackageContents` entries, which have keys of the form `catch_up_package_contents_${subnet_id}`.

# Changes

This just introduces the new interface, which consists of various `HighCapacity*` types (e.g. there was already `RegistryValue`, but now there is also `HighCapacityRegistryValue`). Clients can begin programming against these types, even though the Registry canister does not yet use them. The other way around also works: when Registry starts using the new `HighCapacity*` types, unmigrated clients will still work as long as there are no large entries, or clients never fetch large entries. The short explanation for how this is possible is that the new types are wire compatible. There is a more detailed explanation in the .proto file.

# References

Closes [NNS1-3672][tick].

[tick]: https://dfinity.atlassian.net/issues/NNS1-3672

[NNS1-3672]: https://dfinity.atlassian.net/browse/NNS1-3672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ