### PR TITLE
test(IDX): have a 30s timeout for creating the Universal and Message Canisters

### DIFF
--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -9,7 +9,7 @@ use crate::{
     retry_with_msg, retry_with_msg_async,
     types::*,
 };
-use anyhow::bail;
+use anyhow::{anyhow, bail};
 use candid::{Decode, Encode};
 use canister_test::{Canister, RemoteTestRuntime, Runtime, Wasm};
 use dfn_protobuf::{protobuf, ProtoBuf};
@@ -70,6 +70,7 @@ use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines},
     net::{TcpSocket, TcpStream},
     runtime::{Builder, Handle as THandle},
+    time::timeout,
 };
 use url::Url;
 
@@ -78,6 +79,7 @@ pub mod delegations;
 pub const CANISTER_FREEZE_BALANCE_RESERVE: Cycles = Cycles::new(5_000_000_000_000);
 pub const CYCLES_LIMIT_PER_CANISTER: Cycles = Cycles::new(100_000_000_000_000);
 pub const AGENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+pub const CANISTER_CREATE_TIMEOUT: Duration = Duration::from_secs(30);
 pub const IDENTITY_PEM:&str = "-----BEGIN PRIVATE KEY-----\nMFMCAQEwBQYDK2VwBCIEILhMGpmYuJ0JEhDwocj6pxxOmIpGAXZd40AjkNhuae6q\noSMDIQBeXC6ae2dkJ8QC50bBjlyLqsFQFsMsIThWB21H6t6JRA==\n-----END PRIVATE KEY-----";
 /// A short wasm module that is a legal canister binary.
 pub const _EMPTY_WASM: &[u8] = &[0, 97, 115, 109, 1, 0, 0, 0];
@@ -149,7 +151,7 @@ impl<'a> UniversalCanister<'a> {
         agent: &'a Agent,
         effective_canister_id: PrincipalId,
     ) -> UniversalCanister<'a> {
-        Self::new_with_params(agent, effective_canister_id, None, None, None)
+        Self::new_with_params_with_timeout(agent, effective_canister_id, None, None, None)
             .await
             .expect("Could not create universal canister.")
     }
@@ -158,7 +160,7 @@ impl<'a> UniversalCanister<'a> {
         agent: &'a Agent,
         effective_canister_id: PrincipalId,
     ) -> Result<UniversalCanister<'a>, String> {
-        Self::new_with_params(agent, effective_canister_id, None, None, None).await
+        Self::new_with_params_with_timeout(agent, effective_canister_id, None, None, None).await
     }
 
     pub async fn new_with_retries(
@@ -175,10 +177,9 @@ impl<'a> UniversalCanister<'a> {
             READY_WAIT_TIMEOUT,
             RETRY_BACKOFF,
             || async {
-                match Self::new_with_params(agent, effective_canister_id, None, None, None).await {
-                    Ok(c) => Ok(c),
-                    Err(e) => anyhow::bail!(e),
-                }
+                Self::new_with_params_with_timeout(agent, effective_canister_id, None, None, None)
+                    .await
+                    .map_err(|e| anyhow!(e))
             }
         )
         .await
@@ -201,10 +202,9 @@ impl<'a> UniversalCanister<'a> {
             READY_WAIT_TIMEOUT,
             RETRY_BACKOFF,
             || async {
-                match Self::new_with_cycles(agent, effective_canister_id, c).await {
-                    Ok(c) => Ok(c),
-                    Err(e) => anyhow::bail!(e),
-                }
+                Self::new_with_cycles(agent, effective_canister_id, c)
+                    .await
+                    .map_err(|e| anyhow!(e))
             }
         )
         .await
@@ -228,7 +228,7 @@ impl<'a> UniversalCanister<'a> {
             READY_WAIT_TIMEOUT,
             RETRY_BACKOFF,
             || async {
-                match Self::new_with_params(
+                Self::new_with_params_with_timeout(
                     agent,
                     effective_canister_id,
                     compute_allocation,
@@ -236,14 +236,36 @@ impl<'a> UniversalCanister<'a> {
                     pages,
                 )
                 .await
-                {
-                    Ok(c) => Ok(c),
-                    Err(e) => anyhow::bail!(e),
-                }
+                .map_err(|e| anyhow!(e))
             }
         )
         .await
         .expect("Could not create universal canister with params.")
+    }
+
+    pub async fn new_with_params_with_timeout(
+        agent: &'a Agent,
+        effective_canister_id: PrincipalId,
+        compute_allocation: Option<u64>,
+        cycles: Option<u128>,
+        pages: Option<u32>,
+    ) -> Result<UniversalCanister<'a>, String> {
+        match timeout(
+            CANISTER_CREATE_TIMEOUT,
+            Self::new_with_params(
+                agent,
+                effective_canister_id,
+                compute_allocation,
+                cycles,
+                pages,
+            ),
+        )
+        .await
+        {
+            Ok(Ok(canister)) => Ok(canister),
+            Ok(Err(err)) => Err(format!("Could not create universal canister: {:?}", err)),
+            Err(_elasped) => Err("Timeout while creating universal canister".to_string()),
+        }
     }
 
     pub async fn new_with_params(
@@ -400,16 +422,12 @@ impl<'a> UniversalCanister<'a> {
 
     /// Try to store `msg` in stable memory starting at `offset` bytes.
     pub async fn try_store_to_stable(&self, offset: u32, msg: &[u8]) -> Result<(), AgentError> {
-        let res = self
-            .agent
+        self.agent
             .update(&self.canister_id, "update")
             .with_arg(Self::stable_writer(offset, msg))
             .call_and_wait()
-            .await;
-        match res {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+            .await
+            .map(|_| ())
     }
 
     /// Stores `msg` in stable memory starting at `offset` bytes.
@@ -574,7 +592,7 @@ pub struct MessageCanister<'a> {
 impl<'a> MessageCanister<'a> {
     /// Initializes a [MessageCanister] using the provided [Agent].
     pub async fn new(agent: &'a Agent, effective_canister_id: PrincipalId) -> MessageCanister<'a> {
-        Self::new_with_params(agent, effective_canister_id, None, None)
+        Self::new_with_params_with_timeout(agent, effective_canister_id, None, None)
             .await
             .expect("Could not create message canister.")
     }
@@ -583,7 +601,7 @@ impl<'a> MessageCanister<'a> {
         agent: &'a Agent,
         effective_canister_id: PrincipalId,
     ) -> Result<MessageCanister<'a>, String> {
-        Self::new_with_params(agent, effective_canister_id, None, None).await
+        Self::new_with_params_with_timeout(agent, effective_canister_id, None, None).await
     }
 
     pub async fn new_with_retries(
@@ -595,21 +613,38 @@ impl<'a> MessageCanister<'a> {
     ) -> MessageCanister<'a> {
         retry_with_msg_async!(
             format!(
-                "install UniversalCanister {}",
+                "install MessageCanister {}",
                 effective_canister_id.to_string()
             ),
             log,
             timeout,
             backoff,
             || async {
-                match Self::new_with_params(agent, effective_canister_id, None, None).await {
-                    Ok(c) => Ok(c),
-                    Err(e) => anyhow::bail!(e),
-                }
+                Self::new_with_params_with_timeout(agent, effective_canister_id, None, None)
+                    .await
+                    .map_err(|e| anyhow!(e))
             }
         )
         .await
         .expect("Could not create message canister.")
+    }
+
+    pub async fn new_with_params_with_timeout(
+        agent: &'a Agent,
+        effective_canister_id: PrincipalId,
+        compute_allocation: Option<u64>,
+        cycles: Option<u128>,
+    ) -> Result<MessageCanister<'a>, String> {
+        match timeout(
+            CANISTER_CREATE_TIMEOUT,
+            Self::new_with_params(agent, effective_canister_id, compute_allocation, cycles),
+        )
+        .await
+        {
+            Ok(Ok(canister)) => Ok(canister),
+            Ok(Err(err)) => Err(format!("Could not create message canister: {:?}", err)),
+            Err(_elasped) => Err("Timeout while creating message canister".to_string()),
+        }
     }
 
     pub async fn new_with_params(
@@ -1314,14 +1349,11 @@ pub fn to_principal_id(principal: &Principal) -> PrincipalId {
 }
 
 pub async fn agent_observes_canister_module(agent: &Agent, canister_id: &Principal) -> bool {
-    let status = ManagementCanister::create(agent)
+    ManagementCanister::create(agent)
         .canister_status(canister_id)
         .call_and_wait()
-        .await;
-    match status {
-        Ok(s) => s.0.module_hash.is_some(),
-        Err(_) => false,
-    }
+        .await
+        .is_ok_and(|s| s.0.module_hash.is_some())
 }
 
 pub async fn assert_canister_counter_with_retries(
@@ -1618,10 +1650,10 @@ async fn assert_nodes_malicious_parallel(
                 .await
         });
     }
-    let result = join_all(futures).await.iter().all(|x| x.is_ok());
-    match result {
-        true => Ok(()),
-        false => Err("Not all malicious nodes produced logs containing the malicious signal."),
+    if join_all(futures).await.iter().all(|x| x.is_ok()) {
+        Ok(())
+    } else {
+        Err("Not all malicious nodes produced logs containing the malicious signal.")
     }
 }
 


### PR DESCRIPTION
We occasionally observe that the first attempt of installing a UniversalCanister in a system-test takes a long time and eventually times out after 5 minutes. A subsequent attempt usually succeeds quickly as show in the following example:
```
2025-03-14 10:21:50.735 DEBG[query_stats_above_threshold:rs/tests/driver/src/driver/test_env_api.rs:2056:0] Func="install UniversalCanister 5v3p4-iyaaa-aaaaa-qaaaa-cai [rs/tests/driver/src/util.rs:169]" is being retried for the maximum of 500s with a constant backoff of 5s
2025-03-14 10:27:00.319 DEBG[query_stats_above_threshold:rs/tests/driver/src/driver/test_env_api.rs:2078:0] Func="install UniversalCanister 5v3p4-iyaaa-aaaaa-qaaaa-cai [rs/tests/driver/src/util.rs:169]" failed on attempt 1. Error: Couldn't create canister with provisional API: The request timed out....
2025-03-14 10:27:07.556 DEBG[query_stats_above_threshold:rs/tests/driver/src/driver/test_env_api.rs:2063:0] Func="install UniversalCanister 5v3p4-iyaaa-aaaaa-qaaaa-cai [rs/tests/driver/src/util.rs:169]" succeeded after 316.820980418s on attempt 2
2025-03-14 10:27:07.556 INFO[query_stats_above_threshold:rs/tests/query_stats/lib/src/aggregation.rs:59:0] Installed Universal Canister
```

Instead of waiting for the full 5 minutes this change will install a half minute timeout for creating a Universal or Message Canister. The hypothesis is that with this change we'll have to wait less than 5 minutes.

Whether 30 seconds is a good timeout has to be determined experimentally. We'll do some analysis after a week over having this merged.