### PR TITLE
chore: Remove artifact_pool from whitelist of private mananagement types

### DIFF
--- a/rs/types/management_canister_types/BUILD.bazel
+++ b/rs/types/management_canister_types/BUILD.bazel
@@ -43,7 +43,6 @@ temporary_whitelist = [
     "//rs/replica_tests:__subpackages__",
     "//rs/replicated_state:__subpackages__",  # permanent?
     "//rs/rust_canisters:__subpackages__",
-    "//rs/artifact_pool:__subpackages__",
     "//rs/sns:__subpackages__",
     "//rs/starter:__subpackages__",
     "//rs/state_layout:__subpackages__",  # permanent?


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/4020 removed the actual dependency of private management types from `artifact_pool` but it missed that there were 2 mentions of `//rs/artifact_pool` in the bazel dependency whitelist. This PR removes the mentions from the whitelist completely.