### PR TITLE
refactor: Downgrade `panic` to `debug_assert` in `Payload::take_prefix`

### DIFF
--- a/rs/xnet/payload_builder/src/certified_slice_pool.rs
+++ b/rs/xnet/payload_builder/src/certified_slice_pool.rs
@@ -454,11 +454,14 @@ impl Payload {
         let cutoff = cutoff.unwrap_or_else(|| {
             // `count_bytes()` returned a value above `byte_limit`, but
             // `byte_size` (computed the same way) is below `byte_limit`.
-            panic!(
+            debug_assert!(
+                false,
                 "Invalid `messages_count_bytes`: was {}, expecting {}",
                 messages.count_bytes(),
                 byte_size
-            )
+            );
+            // Cut off before the last message.
+            messages.iter().rev().next().unwrap().0.clone()
         });
 
         // Take the messages prefix, expect non-empty leftover postfix.

--- a/rs/xnet/payload_builder/src/certified_slice_pool.rs
+++ b/rs/xnet/payload_builder/src/certified_slice_pool.rs
@@ -461,7 +461,7 @@ impl Payload {
                 byte_size
             );
             // Cut off before the last message.
-            messages.iter().rev().next().unwrap().0.clone()
+            messages.iter().next_back().unwrap().0.clone()
         });
 
         // Take the messages prefix, expect non-empty leftover postfix.


### PR DESCRIPTION
While the check is technically safe (`Payload::count_bytes()` returns the size of the header plus the size of all messages; and `take_prefix` starts with the header size and computes a running total of message sizes), it is safer to use a `debug_assert` instead of the `panic` and to continue, cutting off the `Payload` just before the last message.