### PR TITLE
refactor: Downgrade `panic` to `debug_assert` in `Payload::take_prefix`, part 2

### DIFF
--- a/rs/xnet/payload_builder/src/certified_slice_pool.rs
+++ b/rs/xnet/payload_builder/src/certified_slice_pool.rs
@@ -425,10 +425,14 @@ impl Payload {
         }
 
         // If we got here, we have at least one message.
-        let messages = self
-            .messages
-            .as_ref()
-            .expect("Non-zero byte size for empty `messages`.");
+        let messages = match self.messages.as_ref() {
+            Some(messages) => messages,
+            None => {
+                debug_assert!(false, "Non-zero byte size for empty `messages`.");
+                // Bail out.
+                return Ok((None, Some(self)));
+            }
+        };
 
         // Find the rightmost cutoff point that respects the provided limits.
         let mut byte_size = NON_EMPTY_PAYLOAD_FIXED_BYTES + self.header.count_bytes();


### PR DESCRIPTION
Replace `panic` with `debug_assert` plus returning an empty slice if, after having checked that an empty slice would fit; and that the slice we have won't fit; it turns out we somehow still have an empty slice. The slice will eventually be replaced in the pool; or the payload builder will call us with a higher limit; so this cannot lead to stalling the stream.