### PR TITLE
chore: set default ingress expiry to 3 mins in HS tests

### DIFF
--- a/hs/spec_compliance/src/IC/Test/Agent.hs
+++ b/hs/spec_compliance/src/IC/Test/Agent.hs
@@ -369,11 +369,11 @@ addNonce =
 getRand8Bytes :: IO BS.ByteString
 getRand8Bytes = BS.pack <$> replicateM 8 randomIO
 
--- Adds expiry 5 minutes
+-- Adds expiry 3 minutes
 addExpiry :: GenR -> IO GenR
 addExpiry = addIfNotThere "ingress_expiry" $ do
   t <- getPOSIXTime
-  return $ GNat $ round ((t + 60 * 5) * 1000_000_000)
+  return $ GNat $ round ((t + 60 * 3) * 1000_000_000)
 
 envelope :: SecretKey -> GenR -> IO GenR
 envelope sk = delegationEnv sk []
@@ -383,7 +383,7 @@ delegationEnv sk1 dels content = do
   let sks = sk1 : map fst dels
 
   t <- getPOSIXTime
-  let expiry = round ((t + 5 * 60) * 1000_000_000)
+  let expiry = round ((t + 3 * 60) * 1000_000_000)
   delegations <- for (zip sks dels) $ \(sk1, (sk2, targets)) -> do
     let delegation =
           rec $

--- a/hs/spec_compliance/src/IC/Test/Spec.hs
+++ b/hs/spec_compliance/src/IC/Test/Spec.hs
@@ -2748,7 +2748,7 @@ icTests my_sub other_sub conf =
                                                                                                                  let userKey = genId cid "Hello!"
 
                                                                                                                  t <- getPOSIXTime
-                                                                                                                 let expiry = round ((t + 5 * 60) * 1000_000_000)
+                                                                                                                 let expiry = round ((t + 3 * 60) * 1000_000_000)
                                                                                                                  let delegation =
                                                                                                                        rec
                                                                                                                          [ "pubkey" =: GBlob (toPublicKey otherSK),
@@ -2765,7 +2765,7 @@ icTests my_sub other_sub conf =
                                                                                                                  let userKey = genId cid "Hello!"
 
                                                                                                                  t <- getPOSIXTime
-                                                                                                                 let expiry = round ((t + 5 * 60) * 1000_000_000)
+                                                                                                                 let expiry = round ((t + 3 * 60) * 1000_000_000)
                                                                                                                  let delegation =
                                                                                                                        rec
                                                                                                                          [ "pubkey" =: GBlob userKey,


### PR DESCRIPTION
This PR sets the default ingress expiry in Haskell spec compliance tests to 3 minutes, analogously to the IC agent's [expiry](https://github.com/dfinity/agent-rs/blob/6a10ba7bb43bb471591adce517487419dba56cf2/ic-agent/src/agent/agent_config.rs#L48). This setting should mitigate invalid ingress expiry errors.