### PR TITLE
fix(PocketIC): TTL for long-running requests

### DIFF
--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -26,7 +26,7 @@ use ic_crypto_iccsa::{public_key_bytes_from_der, types::SignatureBytes, verify};
 use ic_crypto_sha2::Sha256;
 use ic_crypto_utils_threshold_sig_der::parse_threshold_sig_key_from_der;
 use pocket_ic::common::rest::{BinaryBlob, BlobCompression, BlobId, RawVerifyCanisterSigArg};
-use pocket_ic_server::state_api::routes::{handler_read_graph, timeout_or_default};
+use pocket_ic_server::state_api::routes::handler_read_graph;
 use pocket_ic_server::state_api::{
     routes::{http_gateway_routes, instances_routes, status, AppState, RouterExt},
     state::{ApiState, PocketIcApiStateBuilder},
@@ -36,6 +36,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc::channel;
@@ -147,6 +148,7 @@ async fn start(runtime: Arc<Runtime>) {
     let min_alive_until = Arc::new(RwLock::new(Instant::now()));
     let app_state = AppState {
         api_state,
+        pending_requests: Arc::new(AtomicU64::new(0)),
         min_alive_until,
         runtime,
         blob_store: Arc::new(InMemoryBlobStore::new()),
@@ -210,8 +212,9 @@ async fn start(runtime: Arc<Runtime>) {
     // This is a safeguard against orphaning this child process.
     tokio::spawn(async move {
         loop {
+            let pending_requests = app_state.pending_requests.load(Ordering::Relaxed);
             let guard = app_state.min_alive_until.read().await;
-            if guard.elapsed() > Duration::from_secs(args.ttl) {
+            if pending_requests == 0 && guard.elapsed() > Duration::from_secs(args.ttl) {
                 break;
             }
             drop(guard);
@@ -344,24 +347,27 @@ fn create_file<P: AsRef<std::path::Path>>(file_path: P) -> std::io::Result<File>
 
 async fn bump_last_request_timestamp(
     State(AppState {
-        min_alive_until, ..
+        pending_requests,
+        min_alive_until,
+        ..
     }): State<AppState>,
-    headers: HeaderMap,
     request: http::Request<axum::body::Body>,
     next: Next,
 ) -> impl IntoApiResponse {
-    // TTL should not decrease: If now + header_timeout is later
+    pending_requests.fetch_add(1, Ordering::Relaxed);
+    let resp = next.run(request).await;
+    // TTL should not decrease: If now is later
     // than the current TTL (from previous requests), reset it.
     // Otherwise, a previous request set a larger TTL and we don't
     // touch it.
-    let timeout = timeout_or_default(headers).unwrap_or(Duration::from_secs(1));
-    let alive_until = Instant::now().checked_add(timeout).unwrap();
+    let alive_until = Instant::now();
     let mut min_alive_until = min_alive_until.write().await;
     if *min_alive_until < alive_until {
         *min_alive_until = alive_until;
     }
     drop(min_alive_until);
-    next.run(request).await
+    pending_requests.fetch_sub(1, Ordering::Relaxed);
+    resp
 }
 
 async fn get_blob_store_entry(

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -366,6 +366,8 @@ async fn bump_last_request_timestamp(
         *min_alive_until = alive_until;
     }
     drop(min_alive_until);
+    // Only mark the pending request as completed (by subtracting the counter)
+    // *after* updating TTL!
     pending_requests.fetch_sub(1, Ordering::Relaxed);
     resp
 }

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -46,7 +46,7 @@ use pocket_ic::RejectResponse;
 use serde::Serialize;
 use slog::Level;
 use std::str::FromStr;
-use std::{collections::BTreeMap, fs::File, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, fs::File, sync::atomic::AtomicU64, sync::Arc, time::Duration};
 use tokio::{runtime::Runtime, sync::RwLock, time::Instant};
 use tower_http::limit::RequestBodyLimitLayer;
 use tracing::trace;
@@ -61,6 +61,7 @@ const RETRY_TIMEOUT_S: u64 = 300;
 #[derive(Clone)]
 pub struct AppState {
     pub api_state: Arc<ApiState>,
+    pub pending_requests: Arc<AtomicU64>,
     pub min_alive_until: Arc<RwLock<Instant>>,
     pub runtime: Arc<Runtime>,
     pub blob_store: Arc<dyn BlobStore>,
@@ -1074,9 +1075,8 @@ pub async fn handler_add_cycles(
 pub async fn handler_set_stable_memory(
     State(AppState {
         api_state,
-        min_alive_until: _,
-        runtime: _,
         blob_store,
+        ..
     }): State<AppState>,
     Path(instance_id): Path<InstanceId>,
     headers: HeaderMap,
@@ -1140,10 +1140,7 @@ fn contains_unimplemented(config: ExtendedSubnetConfigSet) -> bool {
 /// The new InstanceId will be returned.
 pub async fn create_instance(
     State(AppState {
-        api_state,
-        min_alive_until: _,
-        runtime,
-        blob_store: _,
+        api_state, runtime, ..
     }): State<AppState>,
     extract::Json(instance_config): extract::Json<InstanceConfig>,
 ) -> (StatusCode, Json<rest::CreateInstanceResponse>) {


### PR DESCRIPTION
This PR fixes TTL in PocketIC for long-running requests by
- not terminating the PocketIC server while a request is pending;
- refreshing TTL *after* processing request.