### PR TITLE
fix(PocketIC): do not add a new empty subnet if a subnet has already been specified

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - The module `management_canister` used to contain interface types of the IC management canister. Those types have since been published on crates.io as `ic-management-canister-types`, so PocketIC can depend on that and remove the redundant types.
 
+### Changed
+
+- The functions `PocketIcBuilder::with_nns_subnet`, `PocketIcBuilder::with_sns_subnet`, `PocketIcBuilder::with_ii_subnet`, `PocketIcBuilder::with_fiduciary_subnet`, and `PocketIcBuilder::with_bitcoin_subnet` do not add a new empty subnet if a subnet of the corresponding kind has already been specified (e.g., with state loaded from a given state directory).
+
 
 
 ## 7.0.0 - 2025-02-26

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -206,21 +206,21 @@ impl PocketIcBuilder {
         }
     }
 
-    /// Add an empty NNS subnet
+    /// Add an empty NNS subnet unless an NNS subnet has already been added.
     pub fn with_nns_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
-        config.nns = Some(SubnetSpec::default());
+        config.nns = Some(config.nns.unwrap_or_default());
         self.config = Some(config);
         self
     }
 
-    /// Add an NNS subnet loaded form the given state directory. Note that the provided path must
-    /// be accessible for the PocketIC server process.
+    /// Add an NNS subnet with state loaded from the given state directory.
+    /// Note that the provided path must be accessible for the PocketIC server process.
     ///
-    /// `path_to_nns_state` should lead to the `ic_state` directory which is expected to have
+    /// `path_to_state` should lead to a directory which is expected to have
     /// the following structure:
     ///
-    /// ic_state/
+    /// path_to_state/
     ///  |-- backups
     ///  |-- checkpoints
     ///  |-- diverged_checkpoints
@@ -241,7 +241,7 @@ impl PocketIcBuilder {
     /// ).unwrap().into();
     /// ```
     ///
-    /// The value can be obtained, e.g., via the following command:
+    /// The subnet ID of the NNS subnet can be obtained, e.g., via the following command:
     /// ```sh
     /// ic-regedit snapshot <path-to-ic_registry_local_store> | jq -r ".nns_subnet_id"
     /// ```
@@ -249,13 +249,13 @@ impl PocketIcBuilder {
         self.with_subnet_state(SubnetKind::NNS, nns_subnet_id, path_to_state)
     }
 
-    /// Add a subnet with state loaded form the given state directory.
+    /// Add a subnet with state loaded from the given state directory.
     /// Note that the provided path must be accessible for the PocketIC server process.
     ///
-    /// `state_dir` should point to a directory which is expected to have
+    /// `path_to_state` should point to a directory which is expected to have
     /// the following structure:
     ///
-    /// state_dir/
+    /// path_to_state/
     ///  |-- backups
     ///  |-- checkpoints
     ///  |-- diverged_checkpoints
@@ -271,10 +271,10 @@ impl PocketIcBuilder {
         mut self,
         subnet_kind: SubnetKind,
         subnet_id: Principal,
-        state_dir: PathBuf,
+        path_to_state: PathBuf,
     ) -> Self {
         let mut config = self.config.unwrap_or_default();
-        let subnet_spec = SubnetSpec::default().with_state_dir(state_dir, subnet_id);
+        let subnet_spec = SubnetSpec::default().with_state_dir(path_to_state, subnet_id);
         match subnet_kind {
             SubnetKind::NNS => config.nns = Some(subnet_spec),
             SubnetKind::SNS => config.sns = Some(subnet_spec),
@@ -289,39 +289,39 @@ impl PocketIcBuilder {
         self
     }
 
-    /// Add an empty sns subnet
+    /// Add an empty sns subnet unless an SNS subnet has already been added.
     pub fn with_sns_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
-        config.sns = Some(SubnetSpec::default());
+        config.sns = Some(config.sns.unwrap_or_default());
         self.config = Some(config);
         self
     }
 
-    /// Add an empty internet identity subnet
+    /// Add an empty II subnet unless an II subnet has already been added.
     pub fn with_ii_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
-        config.ii = Some(SubnetSpec::default());
+        config.ii = Some(config.ii.unwrap_or_default());
         self.config = Some(config);
         self
     }
 
-    /// Add an empty fiduciary subnet
+    /// Add an empty fiduciary subnet unless a fiduciary subnet has already been added.
     pub fn with_fiduciary_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
-        config.fiduciary = Some(SubnetSpec::default());
+        config.fiduciary = Some(config.fiduciary.unwrap_or_default());
         self.config = Some(config);
         self
     }
 
-    /// Add an empty bitcoin subnet
+    /// Add an empty bitcoin subnet unless a bitcoin subnet has already been added.
     pub fn with_bitcoin_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
-        config.bitcoin = Some(SubnetSpec::default());
+        config.bitcoin = Some(config.bitcoin.unwrap_or_default());
         self.config = Some(config);
         self
     }
 
-    /// Add an empty generic system subnet
+    /// Add an empty generic system subnet.
     pub fn with_system_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
         config.system.push(SubnetSpec::default());
@@ -329,7 +329,7 @@ impl PocketIcBuilder {
         self
     }
 
-    /// Add an empty generic application subnet
+    /// Add an empty generic application subnet.
     pub fn with_application_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
         config.application.push(SubnetSpec::default());
@@ -337,7 +337,7 @@ impl PocketIcBuilder {
         self
     }
 
-    /// Add an empty verified application subnet
+    /// Add an empty generic verified application subnet.
     pub fn with_verified_application_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
         config.verified_application.push(SubnetSpec::default());
@@ -345,6 +345,7 @@ impl PocketIcBuilder {
         self
     }
 
+    /// Add an empty generic application subnet with benchmarking instruction configuration.
     pub fn with_benchmarking_application_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
         config
@@ -354,6 +355,7 @@ impl PocketIcBuilder {
         self
     }
 
+    /// Add an empty generic system subnet with benchmarking instruction configuration.
     pub fn with_benchmarking_system_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
         config


### PR DESCRIPTION
This PR fixes the functions `PocketIcBuilder::with_nns_subnet`, `PocketIcBuilder::with_sns_subnet`, `PocketIcBuilder::with_ii_subnet`, `PocketIcBuilder::with_fiduciary_subnet`, and `PocketIcBuilder::with_bitcoin_subnet` to not add a new empty subnet if a subnet of the corresponding kind has already been specified (e.g., with state loaded from a given state directory).