### PR TITLE
chore(BOUN-1188 BOUN-963): `ic-boundary`: improve caching a bit, cleanup dead code

### DIFF
--- a/rs/boundary_node/ic_boundary/src/cache.rs
+++ b/rs/boundary_node/ic_boundary/src/cache.rs
@@ -12,9 +12,9 @@ use axum::{
 use bytes::Bytes;
 use http::{
     header::{HeaderMap, CACHE_CONTROL},
-    response, Version,
+    response, Extensions, Version,
 };
-use ic_bn_lib::http::body::buffer_body;
+use ic_bn_lib::{http::body::buffer_body, types::RequestType};
 use moka::future::{Cache as MokaCache, CacheBuilder as MokaCacheBuilder};
 
 use crate::routes::{ApiError, RequestContext};
@@ -79,6 +79,7 @@ struct CacheItem {
     status: StatusCode,
     version: Version,
     headers: HeaderMap,
+    extensions: Extensions,
     body: Bytes,
 }
 
@@ -103,6 +104,8 @@ fn weigh_entry(k: &Arc<RequestContext>, v: &CacheItem) -> u32 {
         cost += k.as_str().len();
         cost += v.as_bytes().len();
     }
+
+    // TODO no way currently to estimate Extensions size
 
     cost as u32
 }
@@ -142,6 +145,7 @@ impl Cache {
             status: parts.status,
             version: parts.version,
             headers: parts.headers.clone(),
+            extensions: parts.extensions.clone(),
             body,
         };
 
@@ -161,6 +165,7 @@ impl Cache {
             .status(item.status)
             .version(item.version);
 
+        *builder.extensions_mut().unwrap() = item.extensions;
         *builder.headers_mut().unwrap() = item.headers;
 
         Some(builder.body(Body::from(item.body)).unwrap())
@@ -192,6 +197,11 @@ pub async fn cache_middleware(
     request: Request,
     next: Next,
 ) -> Result<impl IntoResponse, ApiError> {
+    // Just bypass if it's not Query
+    if ctx.request_type != RequestType::Query {
+        return Ok(next.run(request).await);
+    }
+
     let bypass_reason = (|| {
         // Skip cache if there's a nonce
         if ctx.nonce.is_some() {

--- a/rs/boundary_node/ic_boundary/src/cache.rs
+++ b/rs/boundary_node/ic_boundary/src/cache.rs
@@ -178,8 +178,7 @@ impl Cache {
         self.cache.run_pending_tasks().await;
     }
 
-    // For now stuff below is used only in tests, but belongs here
-    #[allow(dead_code)]
+    #[cfg(test)]
     async fn clear(&self) {
         self.cache.invalidate_all();
         self.housekeep().await;

--- a/rs/boundary_node/ic_boundary/src/cache/test.rs
+++ b/rs/boundary_node/ic_boundary/src/cache/test.rs
@@ -29,6 +29,7 @@ fn gen_request_with_params(
     let mut req = Request::post("/").body(Body::from("foobar")).unwrap();
 
     let mut ctx = RequestContext {
+        request_type: RequestType::Query,
         canister_id: Some(Principal::from_text(canister_id).unwrap()),
         sender: Some(if anonymous {
             ANONYMOUS_PRINCIPAL

--- a/rs/boundary_node/ic_boundary/src/core.rs
+++ b/rs/boundary_node/ic_boundary/src/core.rs
@@ -1069,12 +1069,6 @@ impl<T: Run> Run for WithMetrics<T> {
     }
 }
 
-#[allow(dead_code)]
-pub struct WithRetry<T>(
-    pub T,
-    pub Duration, // attempt_interval
-);
-
 pub struct ThrottleParams {
     pub throttle_duration: Duration,
     pub next_time: Option<Instant>,

--- a/rs/boundary_node/ic_boundary/src/core.rs
+++ b/rs/boundary_node/ic_boundary/src/core.rs
@@ -851,13 +851,9 @@ pub fn setup_router(
         proxy_router.clone() as Arc<dyn Health>,
     );
 
-    let query_route = Router::new()
-        .route(routes::PATH_QUERY, {
-            post(routes::handle_canister).with_state(proxy.clone())
-        })
-        .layer(option_layer(cache.map(|x| {
-            middleware::from_fn_with_state(x.clone(), cache_middleware)
-        })));
+    let query_route = Router::new().route(routes::PATH_QUERY, {
+        post(routes::handle_canister).with_state(proxy.clone())
+    });
 
     let call_route = {
         let mut route = Router::new()
@@ -1006,6 +1002,9 @@ pub fn setup_router(
         .layer(common_service_layers.clone())
         .layer(middleware_subnet_lookup.clone())
         .layer(middleware_generic_limiter.clone())
+        .layer(option_layer(cache.map(|x| {
+            middleware::from_fn_with_state(x.clone(), cache_middleware)
+        })))
         .layer(middleware_retry.clone());
 
     let service_subnet_read = ServiceBuilder::new()

--- a/rs/boundary_node/ic_boundary/src/metrics.rs
+++ b/rs/boundary_node/ic_boundary/src/metrics.rs
@@ -563,8 +563,8 @@ pub async fn metrics_middleware(
         .cloned()
         .unwrap_or_default();
 
-    // Actual canister id is the one the request was routed to
-    // Might be different because of e.g. Bitcoin middleware
+    // Actual canister id is the one the request was routed to.
+    // Might be different from request canister id
     let canister_id_actual = response.extensions().get::<CanisterId>().cloned();
     let error_cause = response.extensions().get::<ErrorCause>().cloned();
     let retry_result = response.extensions().get::<RetryResult>().cloned();

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
@@ -642,14 +642,14 @@ mod test {
         let mut snapshot = generate_stub_snapshot(vec![]);
         snapshot.api_bns = vec![
             ApiBoundaryNode {
-                id: principal!("3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe"),
-                addr: ip1,
-                port: 31337,
+                _id: principal!("3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe"),
+                _addr: ip1,
+                _port: 31337,
             },
             ApiBoundaryNode {
-                id: principal!("3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe"),
-                addr: ip2,
-                port: 31337,
+                _id: principal!("3hhby-wmtmw-umt4t-7ieyg-bbiig-xiylg-sblrt-voxgt-bqckd-a75bf-rqe"),
+                _addr: ip2,
+                _port: 31337,
             },
         ];
 

--- a/rs/boundary_node/ic_boundary/src/routes.rs
+++ b/rs/boundary_node/ic_boundary/src/routes.rs
@@ -571,7 +571,6 @@ pub async fn validate_subnet_request(
     request.extensions_mut().insert(subnet_id);
 
     let resp = next.run(request).await;
-
     Ok(resp)
 }
 

--- a/rs/boundary_node/ic_boundary/src/snapshot.rs
+++ b/rs/boundary_node/ic_boundary/src/snapshot.rs
@@ -88,11 +88,10 @@ impl Node {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct ApiBoundaryNode {
-    pub id: Principal,
-    pub addr: IpAddr,
-    pub port: u16,
+    pub _id: Principal,
+    pub _addr: IpAddr,
+    pub _port: u16,
 }
 
 #[derive(Clone, Debug)]
@@ -223,10 +222,10 @@ impl Snapshotter {
                 let http_endpoint = node.http.context("http endpoint not available")?;
 
                 Ok(ApiBoundaryNode {
-                    id: x.get().0,
-                    addr: IpAddr::from_str(http_endpoint.ip_addr.as_str())
+                    _id: x.get().0,
+                    _addr: IpAddr::from_str(http_endpoint.ip_addr.as_str())
                         .context("unable to parse IP address")?,
-                    port: http_endpoint.port as u16,
+                    _port: http_endpoint.port as u16,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;


### PR DESCRIPTION
* Caching middleware will now cache the response extensions so that the metrics can log e.g. proper node id etc.
* Move caching middleware a bit up the stack (before retry)