### PR TITLE
test(nns): Trying to deflake governance_time_warp.

### DIFF
--- a/rs/nns/integration_tests/src/governance_time_warp.rs
+++ b/rs/nns/integration_tests/src/governance_time_warp.rs
@@ -184,7 +184,7 @@ fn test_time_warp() {
                     .update_from_sender(
                         "get_neuron_info",
                         candid_one,
-                        neuron_id_4,
+                        neuron_id_4.id,
                         &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
                     )
                     .await

--- a/rs/nns/integration_tests/src/governance_time_warp.rs
+++ b/rs/nns/integration_tests/src/governance_time_warp.rs
@@ -103,7 +103,7 @@ fn test_time_warp() {
         // disbursal.
         let duration_since_start_s = get_timestamp_s() - start_timestamp_s;
         println!("duration_since_start_s = {duration_since_start_s}");
-        let mut delta_s = (TWELVE_MONTHS_SECONDS - duration_since_start_s - 100) as i64;
+        let delta_s = (TWELVE_MONTHS_SECONDS - duration_since_start_s - 100) as i64;
         () = nns_canisters
             .governance
             .update_("set_time_warp", candid_one, TimeWarp { delta_s })
@@ -150,7 +150,7 @@ fn test_time_warp() {
         }
 
         // Advance time slightly such that the neuron would be considered dissolved.
-        delta_s += 1000;
+        let delta_s = (TWELVE_MONTHS_SECONDS + 1000) as i64;
         () = nns_canisters
             .governance
             .update_("set_time_warp", candid_one, TimeWarp { delta_s })

--- a/rs/nns/integration_tests/src/governance_time_warp.rs
+++ b/rs/nns/integration_tests/src/governance_time_warp.rs
@@ -12,7 +12,8 @@ use ic_nns_governance_api::{
         manage_neuron::{Disburse, NeuronIdOrSubaccount},
         manage_neuron_response,
         neuron::DissolveState,
-        ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, Neuron,
+        GovernanceError, ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse,
+        Neuron, NeuronInfo,
     },
     test_api::TimeWarp,
 };
@@ -64,6 +65,8 @@ fn test_time_warp() {
         let nns_init_payload = nns_builder.build();
         // Very slow...
         let nns_canisters = NnsCanisters::set_up(&runtime, nns_init_payload).await;
+        let nns_up_timestamp_s = get_timestamp_s();
+        println!("setup time (s): {}", nns_up_timestamp_s - start_timestamp_s);
 
         // Make sure that neuron cannot be disbursed yet.
         let disburse_result: ManageNeuronResponse = nns_canisters
@@ -99,6 +102,7 @@ fn test_time_warp() {
         // Fast forward in time to right before the neuron-held funds becomes eligible for
         // disbursal.
         let duration_since_start_s = get_timestamp_s() - start_timestamp_s;
+        println!("duration_since_start_s = {duration_since_start_s}");
         let mut delta_s = (TWELVE_MONTHS_SECONDS - duration_since_start_s - 100) as i64;
         () = nns_canisters
             .governance
@@ -134,10 +138,19 @@ fn test_time_warp() {
             "{:?}",
             governance_error
         );
+        let error_message = governance_error.error_message.to_lowercase();
+        {
+            let key_word = "dissolve";
+            assert!(
+                error_message.contains(key_word),
+                "{:?} not in {:?}",
+                key_word,
+                error_message
+            );
+        }
 
-        // Advance time slightly (200 s) such that that the neuron should be fully
-        // dissolved.
-        delta_s += 200;
+        // Advance time slightly such that the neuron would be considered dissolved.
+        delta_s += 1000;
         () = nns_canisters
             .governance
             .update_("set_time_warp", candid_one, TimeWarp { delta_s })
@@ -163,9 +176,24 @@ fn test_time_warp() {
             .await?;
         let command = disburse_result.command.unwrap();
         match command {
-            manage_neuron_response::Command::Disburse(disburse) => disburse,
-            _ => panic!("\n\n{:?}\n\n", command),
-        };
+            manage_neuron_response::Command::Disburse(_) => (),
+
+            _ => {
+                let neuron_info: Result<NeuronInfo, GovernanceError> = nns_canisters
+                    .governance
+                    .update_from_sender(
+                        "get_neuron_info",
+                        candid_one,
+                        neuron_id_4,
+                        &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
+                    )
+                    .await
+                    .unwrap();
+                let neuron_info = neuron_info.unwrap();
+
+                panic!("\n\n{:?}\n\n{:#?}", command, neuron_info);
+            }
+        }
 
         Ok(())
     });


### PR DESCRIPTION
Relaxed an assert by advancing time more (via set_time_warp).

Hard to verify whether this correctly deflakes, because even with `--runs_per_test=317` I am not able to provoke a flake (without this change). FWIW, with these changes, `--runs_per_test=317` still works.

Also, added some diagnostics. If this fix does not work, diagnostics will probably help with future deflaking efforts.