### PR TITLE
chore(IDX): flatten upload.sh

### DIFF
--- a/ci/src/artifacts/upload.sh
+++ b/ci/src/artifacts/upload.sh
@@ -2,20 +2,23 @@
 
 set -eEuo pipefail
 
-while read -r k v; do
-    case "$k" in
-        HOME)
-            # Required by rclone to get credentials from $HOME/.aws/credentials
-            export HOME="$v"
-            ;;
-    esac
-done <"$VERSION_FILE"
+# ~/.aws/credentials is needed by rclone. If home is not set, expect
+# VERSION_FILE to contain the $HOME.
+if [ -z "${HOME:-}" ]; then
+    while read -r k v; do
+        case "$k" in
+            HOME)
+                export HOME="$v"
+                ;;
+        esac
+    done <"$VERSION_FILE"
+fi
 
 VERSION="$(cat $VERSION_TXT)"
 
 # rclone reads the $(dirname $f) to get file attributes.
 # Therefore symlink should be resolved.
-f="$1"
+f="${1:?No file to upload}"
 if [ -L "$f" ]; then
     f=$(readlink "$f")
 fi
@@ -34,33 +37,34 @@ rclone_common_flags=(
     --s3-upload-cutoff=5G
 )
 
-if [ "${UPLOAD_BUILD_ARTIFACTS:-}" == "1" ]; then
-    echo "uploading $f to AWS" >&2
-    AWS_PROFILE=default "$RCLONE" \
-        "${rclone_common_flags[@]}" \
-        --s3-provider=AWS \
-        --s3-region=eu-central-1 \
-        --s3-env-auth \
-        copy \
-        "$f" \
-        ":s3:dfinity-download-public/ic/${VERSION}/$REMOTE_SUBDIR/"
-    echo "done uploading to AWS" >&2
+REMOTE_SUBDIR="${REMOTE_SUBDIR:?Remote subdirectory not set}"
 
-    # Upload to Cloudflare's R2 (S3)
-    # using profile 'cf' to look up the right creds in ~/.aws/credentials
-    echo "uploading $f to Cloudflare" >&2
-    echo AWS_PROFILE=cf "$RCLONE" -v \
-        "${rclone_common_flags[@]}" \
-        --s3-provider=Cloudflare \
-        --s3-endpoint=https://64059940cc95339fc7e5888f431876ee.r2.cloudflarestorage.com \
-        --s3-env-auth \
-        copy \
-        "$f" \
-        ":s3:dfinity-download-public/ic/${VERSION}/$REMOTE_SUBDIR/"
-    echo "done uploading to Cloudflare" >&2
-else
-    echo "dry run for $f"
-fi
+echo "uploading $f to AWS" >&2
+AWS_PROFILE=default "$RCLONE" \
+    "${rclone_common_flags[@]}" \
+    --s3-provider=AWS \
+    --s3-region=eu-central-1 \
+    --s3-env-auth \
+    copy \
+    "$f" \
+    ":s3:dfinity-download-public/ic/${VERSION}/$REMOTE_SUBDIR/"
+echo "done uploading to AWS" >&2
+
+# Upload to Cloudflare's R2 (S3)
+# using profile 'cf' to look up the right creds in ~/.aws/credentials
+echo "uploading $f to Cloudflare" >&2
+echo AWS_PROFILE=cf "$RCLONE" -v \
+    "${rclone_common_flags[@]}" \
+    --s3-provider=Cloudflare \
+    --s3-endpoint=https://64059940cc95339fc7e5888f431876ee.r2.cloudflarestorage.com \
+    --s3-env-auth \
+    copy \
+    "$f" \
+    ":s3:dfinity-download-public/ic/${VERSION}/$REMOTE_SUBDIR/"
+echo "done uploading to Cloudflare" >&2
 
 URL_PATH="ic/${VERSION}/$REMOTE_SUBDIR/$(basename $f)"
-echo "https://download.dfinity.systems/${URL_PATH}" >"$2"
+echo "https://download.dfinity.systems/${URL_PATH}" >&2
+if [ -n "${2:-}" ]; then
+    echo "https://download.dfinity.systems/${URL_PATH}" >"$2"
+fi


### PR DESCRIPTION
This moves the "skip" logic out of `upload.sh` and into `upload.bzl`. This allows us to reuse `upload.sh` wherever necessary without the script needed to figure out if it needs to run or not.

This'll allow us to move the upload out of the build and into a new CI step.