### PR TITLE
chore(ICP-Archive): add missing ic_cdk setup

### DIFF
--- a/rs/ledger_suite/icp/archive/src/main.rs
+++ b/rs/ledger_suite/icp/archive/src/main.rs
@@ -135,6 +135,7 @@ fn get_block(block_height: BlockIndex) -> BlockRes {
 
 #[export_name = "canister_query get_block_pb"]
 fn get_block_() {
+    ic_cdk::setup();
     let arg: BlockIndex =
         from_proto_bytes(arg_data_raw()).expect("failed to decode get_block_pb argument");
     let res = to_proto_bytes(get_block(arg)).expect("failed to encode get_block_pb response");
@@ -174,6 +175,7 @@ fn append_blocks_() {
 /// 100.
 #[export_name = "canister_query iter_blocks_pb"]
 fn iter_blocks_() {
+    ic_cdk::setup();
     let IterBlocksArgs { start, length } =
         from_proto_bytes(arg_data_raw()).expect("failed to decode iter_blocks_pb argument");
     let archive_state = ARCHIVE_STATE.read().unwrap();
@@ -190,6 +192,7 @@ fn iter_blocks_() {
 /// range stored in the Node the result is an error.
 #[export_name = "canister_query get_blocks_pb"]
 fn get_blocks_() {
+    ic_cdk::setup();
     let GetBlocksArgs { start, length } =
         from_proto_bytes(arg_data_raw()).expect("failed to decode get_blocks_pb argument");
     let archive_state = ARCHIVE_STATE.read().unwrap();


### PR DESCRIPTION
While migrating to from dfn to cdk, I did not add `ic_cdk::setup();` at the beginning of some endpoints. There are still some endpoints that are missing the setup call, but they were not touched by the migration.