### PR TITLE
test(crypto): CRP-2731: Relax criteria for detecting SKS file change

### DIFF
--- a/rs/tests/crypto/ic_crypto_csp_umask_test.rs
+++ b/rs/tests/crypto/ic_crypto_csp_umask_test.rs
@@ -129,8 +129,10 @@ impl From<String> for SecretKeyStoreMetadata {
 }
 
 impl SecretKeyStoreMetadata {
+    /// Treats the metadata to have been updated if either the timestamp or the inode number has
+    /// changed.
     fn has_been_updated(&self, previous: &SecretKeyStoreMetadata) -> bool {
-        self.timestamp > previous.timestamp && self.inode != previous.inode
+        self.timestamp != previous.timestamp || self.inode != previous.inode
     }
 
     fn has_correct_permissions(&self) -> bool {


### PR DESCRIPTION
Treat any change in the modification time or inode number as an indicator that the SKS file has changed in the crypto CSP umask test.