### PR TITLE
feat(nns): Define VotingPowerSnapshot and a collection of snapshots

### DIFF
--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2729,3 +2729,21 @@ message MaturityDisbursement {
   // The timestamp at which the maturity disbursement should be finalized.
   uint64 finalize_disbursement_timestamp_seconds = 4;
 }
+
+// A map of neuron voting powers at a certain point in time. It can be used to initialize ballots of
+// a proposal.
+message NeuronIdToVotingPowerMap {
+  // Map from neuron id to the voting power of the neuron.
+  map<fixed64, uint64> voting_power_map = 1;
+}
+
+// Total voting power (deciding and potential) at a certain point in time. A history of the totals
+// can be used to detect voting power spikes. See `Neuron::deciding_voting_power` and
+// `Neuron::potential_voting_power` for more information.
+message VotingPowerTotal {
+  // The total deciding voting power.
+  uint64 total_deciding_voting_power = 1;
+
+  // The total potential voting power.
+  uint64 total_potential_voting_power = 2;
+}

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -4171,6 +4171,43 @@ pub struct MaturityDisbursement {
     #[prost(uint64, tag = "4")]
     pub finalize_disbursement_timestamp_seconds: u64,
 }
+/// A map of neuron voting powers at a certain point in time. It can be used to initialize ballots of
+/// a proposal.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct NeuronIdToVotingPowerMap {
+    /// Map from neuron id to the voting power of the neuron.
+    #[prost(map = "fixed64, uint64", tag = "1")]
+    pub voting_power_map: ::std::collections::HashMap<u64, u64>,
+}
+/// Total voting power (deciding and potential) at a certain point in time. A history of the totals
+/// can be used to detect voting power spikes. See `Neuron::deciding_voting_power` and
+/// `Neuron::potential_voting_power` for more information.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct VotingPowerTotal {
+    /// The total deciding voting power.
+    #[prost(uint64, tag = "1")]
+    pub total_deciding_voting_power: u64,
+    /// The total potential voting power.
+    #[prost(uint64, tag = "2")]
+    pub total_potential_voting_power: u64,
+}
 /// Proposal types are organized into topics. Neurons can automatically
 /// vote based on following other neurons, and these follow
 /// relationships are defined per topic.

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -144,6 +144,7 @@ mod split_neuron;
 pub mod test_data;
 #[cfg(test)]
 mod tests;
+pub mod voting_power_snapshots;
 
 #[cfg(feature = "canbench-rs")]
 mod benches;

--- a/rs/nns/governance/src/governance/voting_power_snapshots.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots.rs
@@ -1,0 +1,190 @@
+#![allow(unused)]
+use crate::{
+    governance::LOG_PREFIX,
+    neuron_store::voting_power::VotingPowerSnapshot,
+    pb::v1::{Ballot, NeuronIdToVotingPowerMap, VotingPowerTotal},
+};
+
+use ic_nervous_system_common::ONE_MONTH_SECONDS;
+use ic_stable_structures::{
+    memory_manager::VirtualMemory, storable::Bound, DefaultMemoryImpl, StableBTreeMap, Storable,
+};
+use prost::Message;
+use std::{borrow::Cow, collections::HashMap};
+
+/// The maximum number of voting power snapshots to keep.
+const MAX_VOTING_POWER_SNAPSHOTS: u64 = 7;
+/// The multiplier used to define what is a "voting power spike": if the current total voting
+/// power is more than this multiplier times the minimum total voting power in the snapshots,
+/// then we consider it a spike.
+const MULTIPLIER_THRESHOLD_FOR_VOTING_POWER_SPIKE: f64 = 1.5;
+/// The maximum staleness of a voting power snapshot. This is usually not needed since
+/// the snapshots should be added frequently. However, we do not want to use a snapshot that is too
+/// old, in the event of a failure in taking the snapshots.
+const MAXIMUM_STALENESS_SECONDS: u64 = ONE_MONTH_SECONDS * 3;
+
+type DefaultMemory = VirtualMemory<DefaultMemoryImpl>;
+type TimestampSeconds = u64;
+
+/// A collection of voting power snapshots, each associated with a timestamp. The totals are used to
+/// detect whether there is a spike of total voting power, and the voting power per neuron is used
+/// to create ballots if a spike is detected. Note that a snapshot is stored in 2 separate
+/// `StableBTreeMap` so that the totals can be checked without having to load the entire
+/// `NeuronIdToVotingPowerMap` into memory.
+pub(crate) struct VotingPowerSnapshots {
+    neuron_id_to_voting_power_maps:
+        StableBTreeMap<TimestampSeconds, NeuronIdToVotingPowerMap, DefaultMemory>,
+    voting_power_totals: StableBTreeMap<TimestampSeconds, VotingPowerTotal, DefaultMemory>,
+}
+
+fn insert_and_truncate<Value: Storable>(
+    map: &mut StableBTreeMap<TimestampSeconds, Value, DefaultMemory>,
+    timestamp_seconds: TimestampSeconds,
+    value: Value,
+) {
+    let existing_value = map.insert(timestamp_seconds, value);
+
+    // Log if we just clobbered an existing entry, because it is a exceedingly unlikely
+    // that this would happen in practice.
+    if let Some(existing_value) = existing_value {
+        ic_cdk::eprintln!(
+            "{}Somehow the voting power snapshot is taken multiple times at \
+	            the same timestamp {}",
+            LOG_PREFIX,
+            timestamp_seconds,
+        );
+    }
+
+    // Drop earlier entries from map.
+    while map.len() > MAX_VOTING_POWER_SNAPSHOTS {
+        let (first_key, _) = map
+            .first_key_value()
+            .expect("No first key value even though the length is checked right before.");
+        map.remove(&first_key);
+    }
+}
+
+impl VotingPowerSnapshots {
+    pub fn new(maps_memory: DefaultMemory, totals_memory: DefaultMemory) -> Self {
+        Self {
+            neuron_id_to_voting_power_maps: StableBTreeMap::new(maps_memory),
+            voting_power_totals: StableBTreeMap::new(totals_memory),
+        }
+    }
+
+    /// Records a voting power snapshot at the given timestamp. Oldest snapshots are removed
+    /// if the number of snapshots exceeds the maximum allowed.
+    pub(crate) fn record_voting_power_snapshot(
+        &mut self,
+        timestamp_seconds: TimestampSeconds,
+        snapshot: VotingPowerSnapshot,
+    ) {
+        let (voting_power_map, voting_power_total) =
+            <(NeuronIdToVotingPowerMap, VotingPowerTotal)>::from(snapshot);
+        insert_and_truncate(
+            &mut self.neuron_id_to_voting_power_maps,
+            timestamp_seconds,
+            voting_power_map,
+        );
+        insert_and_truncate(
+            &mut self.voting_power_totals,
+            timestamp_seconds,
+            voting_power_total,
+        );
+    }
+
+    /// Given a total potential voting power, checks if there is a voting power spike and returns
+    /// the previous voting power map if a spike is detected along with the snapshot timestamp. If
+    /// no spike is detected, it returns None.
+    pub(crate) fn previous_ballots_if_voting_power_spike_detected(
+        &self,
+        total_potential_voting_power: u64,
+        now_seconds: TimestampSeconds,
+    ) -> Option<(TimestampSeconds, VotingPowerSnapshot)> {
+        // Step 1: find the timestamp with the minimum potential voting power. Exit if there are no
+        // snapshots yet.
+        let Some((
+            timestamp_with_minimum_total_potential_voting_power,
+            totals_with_minimum_total_potential_voting_power,
+        )) = self
+            .voting_power_totals
+            .iter()
+            .filter(|(timestamp, _)| *timestamp + MAXIMUM_STALENESS_SECONDS > now_seconds)
+            .min_by_key(|(_, snapshot)| snapshot.total_potential_voting_power)
+        else {
+            ic_cdk::eprintln!(
+                "{}Voting power totals are empty. No voting power spike detected.",
+                LOG_PREFIX,
+            );
+            return None;
+        };
+
+        // Step 2: determine whether there is a voting power spike. Exit if a spike is not detected.
+        let voting_power_spike_detected = (total_potential_voting_power as f64)
+            > (totals_with_minimum_total_potential_voting_power.total_potential_voting_power
+                as f64)
+                * MULTIPLIER_THRESHOLD_FOR_VOTING_POWER_SPIKE;
+        if !voting_power_spike_detected {
+            return None;
+        }
+
+        // Step 3: find the voting power map for the timestamp with the minimum potential voting power.
+        let Some(voting_power_map) = self
+            .neuron_id_to_voting_power_maps
+            .get(&timestamp_with_minimum_total_potential_voting_power)
+        else {
+            ic_cdk::eprintln!(
+                "{}Voting power map not found for timestamp {} while the totals \
+                are found. This should not happen.",
+                LOG_PREFIX,
+                timestamp_with_minimum_total_potential_voting_power,
+            );
+            return None;
+        };
+
+        // Step 4: returns the previous voting power map since a voting power spike is detected.
+        let previous_voting_power_snapshot = VotingPowerSnapshot::from((
+            voting_power_map,
+            totals_with_minimum_total_potential_voting_power,
+        ));
+        Some((
+            timestamp_with_minimum_total_potential_voting_power,
+            previous_voting_power_snapshot,
+        ))
+    }
+
+    /// Returns the latest snapshot timestamp in seconds. If there are no snapshots, it returns None.
+    pub(crate) fn latest_snapshot_timestamp_seconds(&self) -> Option<TimestampSeconds> {
+        self.voting_power_totals
+            .last_key_value()
+            .map(|(timestamp, _)| timestamp)
+    }
+}
+
+impl Storable for NeuronIdToVotingPowerMap {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::from(self.encode_to_vec())
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        Self::decode(&bytes[..]).expect("Unable to deserialize NeuronIdToVotingPowerMap.")
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+impl Storable for VotingPowerTotal {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::from(self.encode_to_vec())
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        Self::decode(&bytes[..]).expect("Unable to deserialize VotingPowerTotal.")
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+#[path = "voting_power_snapshots_tests.rs"]
+#[cfg(test)]
+mod tests;

--- a/rs/nns/governance/src/governance/voting_power_snapshots_tests.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots_tests.rs
@@ -1,0 +1,103 @@
+use super::*;
+use crate::{neuron_store::voting_power, pb::v1::Vote};
+use ic_stable_structures::{
+    memory_manager::{MemoryId, MemoryManager},
+    VectorMemory,
+};
+
+fn voting_power_map(voting_powers: Vec<u64>) -> HashMap<u64, u64> {
+    voting_powers
+        .into_iter()
+        .enumerate()
+        .map(|(i, vp)| (i as u64, vp))
+        .collect()
+}
+
+fn voting_power_snapshot(
+    voting_powers: Vec<u64>,
+    total_potential_voting_power: u64,
+) -> VotingPowerSnapshot {
+    let voting_power_map = voting_power_map(voting_powers);
+    VotingPowerSnapshot::new_for_test(voting_power_map, total_potential_voting_power)
+}
+
+#[test]
+fn test_record_voting_power_snapshot() {
+    let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
+    let mut snapshots = VotingPowerSnapshots::new(
+        memory_manager.get(MemoryId::new(0)),
+        memory_manager.get(MemoryId::new(1)),
+    );
+
+    // Initially, there are no snapshots, so the latest snapshot timestamp is None, and we
+    // should not disable early adoption since there is no data.
+    assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), None);
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(u64::MAX, 0),
+        None
+    );
+
+    // After making a snapshot, the latest snapshot timestamp should be the timestamp of the
+    // snapshot.
+    snapshots.record_voting_power_snapshot(1, voting_power_snapshot(vec![9], 10));
+    assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), Some(1));
+    // We should disable early adoption if the deciding voting power is more than 2 times the
+    // minimum voting power in the first snapshot.
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(10, 1),
+        None
+    );
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(14, 1),
+        None
+    );
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(16, 1),
+        Some((1, voting_power_snapshot(vec![9], 10)))
+    );
+
+    for i in 0..6 {
+        let timestamp_seconds = 2 + i;
+        // The minimum voting power in the snapshots is still 10 over the next 6
+        snapshots.record_voting_power_snapshot(
+            timestamp_seconds,
+            voting_power_snapshot(vec![9, 10 + i], 20 + i),
+        );
+        assert_eq!(
+            snapshots.latest_snapshot_timestamp_seconds(),
+            Some(timestamp_seconds)
+        );
+        assert_eq!(
+            snapshots.previous_ballots_if_voting_power_spike_detected(14, timestamp_seconds),
+            None
+        );
+        assert_eq!(
+            snapshots.previous_ballots_if_voting_power_spike_detected(16, timestamp_seconds),
+            Some((1, voting_power_snapshot(vec![9], 10)))
+        );
+    }
+
+    // After the 7th snapshot, the first snapshot is removed, and the minimum total potential voting
+    // power in the retained snapshots is now 20 on the timestamp 2.
+    snapshots.record_voting_power_snapshot(8, voting_power_snapshot(vec![9, 16], 26));
+    assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), Some(8));
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(14, 8),
+        None
+    );
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(29, 8),
+        None
+    );
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(31, 8),
+        Some((2, voting_power_snapshot(vec![9, 10], 20)))
+    );
+
+    // After 4 months, the snapshots are considered stale, and the voting power spike
+    // detection is disabled.
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(u64::MAX, ONE_MONTH_SECONDS * 4),
+        None,
+    );
+}

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -31,6 +31,7 @@ use std::{
 };
 
 pub mod metrics;
+pub mod voting_power;
 use crate::governance::RandomnessGenerator;
 use crate::pb::v1::{Ballot, Vote};
 pub(crate) use metrics::NeuronMetrics;

--- a/rs/nns/governance/src/neuron_store/voting_power.rs
+++ b/rs/nns/governance/src/neuron_store/voting_power.rs
@@ -1,0 +1,69 @@
+use crate::pb::v1::{NeuronIdToVotingPowerMap, VotingPowerTotal};
+
+use std::collections::HashMap;
+
+/// The snapshot of voting power for all eligible neurons at a given time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VotingPowerSnapshot {
+    /// A map of neuron ID to its voting power.
+    voting_power_map: HashMap<u64, u64>,
+
+    /// The total deciding voting power of all eligible neurons.
+    total_deciding_voting_power: u64,
+
+    /// The total potential voting power of all eligible neurons.
+    total_potential_voting_power: u64,
+}
+
+#[cfg(any(test, feature = "canbench-rs"))]
+impl VotingPowerSnapshot {
+    /// Although the snapshot should only be computed by the neuron store, we need to
+    /// create it for testing purposes.
+    pub fn new_for_test(
+        voting_power_map: HashMap<u64, u64>,
+        total_potential_voting_power: u64,
+    ) -> Self {
+        let total_deciding_voting_power = voting_power_map.values().sum();
+        Self {
+            voting_power_map,
+            total_deciding_voting_power,
+            total_potential_voting_power,
+        }
+    }
+}
+
+impl From<VotingPowerSnapshot> for (NeuronIdToVotingPowerMap, VotingPowerTotal) {
+    fn from(snapshot: VotingPowerSnapshot) -> Self {
+        let VotingPowerSnapshot {
+            voting_power_map,
+            total_deciding_voting_power,
+            total_potential_voting_power,
+        } = snapshot;
+
+        (
+            NeuronIdToVotingPowerMap { voting_power_map },
+            VotingPowerTotal {
+                total_deciding_voting_power,
+                total_potential_voting_power,
+            },
+        )
+    }
+}
+
+impl From<(NeuronIdToVotingPowerMap, VotingPowerTotal)> for VotingPowerSnapshot {
+    fn from(
+        (voting_power_map, voting_power_total): (NeuronIdToVotingPowerMap, VotingPowerTotal),
+    ) -> Self {
+        let NeuronIdToVotingPowerMap { voting_power_map } = voting_power_map;
+        let VotingPowerTotal {
+            total_deciding_voting_power,
+            total_potential_voting_power,
+        } = voting_power_total;
+
+        Self {
+            voting_power_map,
+            total_deciding_voting_power,
+            total_potential_voting_power,
+        }
+    }
+}


### PR DESCRIPTION
# Why

To prevent a sudden takeover of the NNS in the event of some party gaining illegitimate voting power (e.g. a bug in Governance, ICP Ledger, etc.), we aim at reverting the voting power to an earlier snapshot, so that neurons don't gain voting power immediately if a spike is detected.

# Related PRs

There are 3 PRs to achieve the above-mentioned goal:

- (current PR) Define VotingPowerSnapshot and a collection of snapshots
- (#4405) Add a timer task to record snapshots periodically
- (#4406) Use the previous snapshot if a voting power spike is detected

# What

* Define a VotingPowerSnapshot to represent the voting power calculated at a certain point of time
  * One key decision is to also snapshot the voting power of each neuron, which then can be used to create ballots later, if (in an extremely unlikely event) a voting power spike is detected
* Implement how the snapshot can be used:
  * Add a snapshot
  * Check the last time the snapshot is added (for scheduling tasks to add snapshots)
  * Check if the voting power has a spike
