### PR TITLE
feat(nns): Add a timer task to perform voting power snapshots

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -5580,30 +5580,14 @@ impl Governance {
             // vote, with a voting power determined at the
             // time of the proposal (i.e., now).
             _ => {
-                let (ballots, total_deciding_power, potential_voting_power) =
-                    self.neuron_store.create_ballots_for_standard_proposal(
+                let voting_power_snapshot = self
+                    .neuron_store
+                    .compute_voting_power_snapshot_for_standard_proposal(
                         self.voting_power_economics(),
                         now_seconds,
-                    );
+                    )?;
 
-                if total_deciding_power >= (u64::MAX as u128) {
-                    // The way the neurons are configured, the total voting
-                    // power on this proposal would overflow a u64!
-                    return Err(GovernanceError::new_with_message(
-                        ErrorType::PreconditionFailed,
-                        "Voting power overflow.",
-                    ));
-                }
-                if potential_voting_power >= (u64::MAX as u128) {
-                    // The way the neurons are configured, the potential voting
-                    // power on this proposal would overflow a u64!
-                    return Err(GovernanceError::new_with_message(
-                        ErrorType::PreconditionFailed,
-                        "Potential voting power overflow.",
-                    ));
-                }
-
-                (ballots, potential_voting_power as u64)
+                voting_power_snapshot.create_ballots_and_total_potential_voting_power()
             }
         };
 

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -32,6 +32,7 @@ use std::{
 
 pub mod metrics;
 pub mod voting_power;
+
 use crate::governance::RandomnessGenerator;
 use crate::pb::v1::{Ballot, Vote};
 pub(crate) use metrics::NeuronMetrics;
@@ -67,6 +68,8 @@ pub enum NeuronStoreError {
     InvalidOperation {
         reason: String,
     },
+    TotalPotentialVotingPowerOverflow,
+    TotalDecidingVotingPowerOverflow,
 }
 
 impl NeuronStoreError {
@@ -174,6 +177,12 @@ impl Display for NeuronStoreError {
             NeuronStoreError::InvalidOperation { reason } => {
                 write!(f, "Invalid operation: {}", reason)
             }
+            NeuronStoreError::TotalPotentialVotingPowerOverflow => {
+                write!(f, "Total potential voting power overflow")
+            }
+            NeuronStoreError::TotalDecidingVotingPowerOverflow => {
+                write!(f, "Total deciding voting power overflow")
+            }
         }
     }
 }
@@ -192,6 +201,8 @@ impl From<NeuronStoreError> for GovernanceError {
             NeuronStoreError::NotAuthorizedToGetFullNeuron { .. } => ErrorType::NotAuthorized,
             NeuronStoreError::NeuronIdGenerationUnavailable => ErrorType::Unavailable,
             NeuronStoreError::InvalidOperation { .. } => ErrorType::PreconditionFailed,
+            NeuronStoreError::TotalPotentialVotingPowerOverflow => ErrorType::PreconditionFailed,
+            NeuronStoreError::TotalDecidingVotingPowerOverflow => ErrorType::PreconditionFailed,
         };
         GovernanceError::new_with_message(error_type, value.to_string())
     }
@@ -831,55 +842,6 @@ impl NeuronStore {
             },
             NeuronSections::NONE,
         )
-    }
-
-    pub fn create_ballots_for_standard_proposal(
-        &self,
-        voting_power_economics: &VotingPowerEconomics,
-        now_seconds: u64,
-    ) -> (
-        HashMap<u64, Ballot>,
-        u128, /*deciding_voting_power*/
-        u128, /*potential_voting_power*/
-    ) {
-        let mut ballots = HashMap::<u64, Ballot>::new();
-        let mut deciding_voting_power: u128 = 0;
-        let mut potential_voting_power: u128 = 0;
-
-        let min_dissolve_delay_seconds = voting_power_economics
-            .neuron_minimum_dissolve_delay_to_vote_seconds
-            .unwrap_or(VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS);
-
-        let mut process_neuron = |neuron: &Neuron| {
-            if neuron.is_inactive(now_seconds)
-                || neuron.dissolve_delay_seconds(now_seconds) < min_dissolve_delay_seconds
-            {
-                return;
-            }
-
-            let voting_power = neuron.deciding_voting_power(voting_power_economics, now_seconds);
-            deciding_voting_power += voting_power as u128;
-            potential_voting_power += neuron.potential_voting_power(now_seconds) as u128;
-            ballots.insert(
-                neuron.id().id,
-                Ballot {
-                    vote: Vote::Unspecified as i32,
-                    voting_power,
-                },
-            );
-        };
-
-        // Active neurons iterator already makes distinctions between stable and heap neurons.
-        self.with_active_neurons_iter_sections(
-            |iter| {
-                for neuron in iter {
-                    process_neuron(neuron.as_ref());
-                }
-            },
-            NeuronSections::NONE,
-        );
-
-        (ballots, deciding_voting_power, potential_voting_power)
     }
 
     /// When a neuron is finally dissolved, if there is any staked maturity it is moved to regular maturity

--- a/rs/nns/governance/src/neuron_store/voting_power.rs
+++ b/rs/nns/governance/src/neuron_store/voting_power.rs
@@ -1,4 +1,12 @@
-use crate::pb::v1::{NeuronIdToVotingPowerMap, VotingPowerTotal};
+use ic_nns_governance_api::pb::v1::Vote;
+
+use super::{NeuronStore, NeuronStoreError};
+
+use crate::{
+    neuron::Neuron,
+    pb::v1::{Ballot, NeuronIdToVotingPowerMap, VotingPowerEconomics, VotingPowerTotal},
+    storage::neurons::NeuronSections,
+};
 
 use std::collections::HashMap;
 
@@ -15,10 +23,10 @@ pub struct VotingPowerSnapshot {
     total_potential_voting_power: u64,
 }
 
-#[cfg(any(test, feature = "canbench-rs"))]
 impl VotingPowerSnapshot {
     /// Although the snapshot should only be computed by the neuron store, we need to
     /// create it for testing purposes.
+    #[cfg(any(test, feature = "canbench-rs"))]
     pub fn new_for_test(
         voting_power_map: HashMap<u64, u64>,
         total_potential_voting_power: u64,
@@ -29,6 +37,36 @@ impl VotingPowerSnapshot {
             total_deciding_voting_power,
             total_potential_voting_power,
         }
+    }
+
+    /// Constructs ballots from the snapshot. Returns both the ballots and
+    /// total_potential_voting_power.
+    pub fn create_ballots_and_total_potential_voting_power(
+        self,
+    ) -> (
+        HashMap<u64, Ballot>,
+        u64, /* total_potential_voting_power */
+    ) {
+        let VotingPowerSnapshot {
+            voting_power_map,
+            total_deciding_voting_power: _,
+            total_potential_voting_power,
+        } = self;
+
+        let ballots = voting_power_map
+            .into_iter()
+            .map(|(neuron_id, voting_power)| {
+                (
+                    neuron_id,
+                    Ballot {
+                        voting_power,
+                        vote: Vote::Unspecified as i32,
+                    },
+                )
+            })
+            .collect();
+
+        (ballots, total_potential_voting_power)
     }
 }
 
@@ -65,5 +103,70 @@ impl From<(NeuronIdToVotingPowerMap, VotingPowerTotal)> for VotingPowerSnapshot 
             total_deciding_voting_power,
             total_potential_voting_power,
         }
+    }
+}
+
+fn get_voting_power_as_u64(
+    voting_power: u128,
+    error: NeuronStoreError,
+) -> Result<u64, NeuronStoreError> {
+    if voting_power > (u64::MAX as u128) {
+        return Err(error);
+    }
+    Ok(voting_power as u64)
+}
+
+impl NeuronStore {
+    /// Computes the voting power snapshot for a standard proposal.
+    pub fn compute_voting_power_snapshot_for_standard_proposal(
+        &self,
+        voting_power_economics: &VotingPowerEconomics,
+        now_seconds: u64,
+    ) -> Result<VotingPowerSnapshot, NeuronStoreError> {
+        let mut voting_power_map = HashMap::new();
+        let mut total_deciding_voting_power: u128 = 0;
+        let mut total_potential_voting_power: u128 = 0;
+
+        let min_dissolve_delay_seconds = voting_power_economics
+            .neuron_minimum_dissolve_delay_to_vote_seconds
+            .unwrap_or(VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS);
+
+        let mut process_neuron = |neuron: &Neuron| {
+            if neuron.is_inactive(now_seconds)
+                || neuron.dissolve_delay_seconds(now_seconds) < min_dissolve_delay_seconds
+            {
+                return;
+            }
+
+            let voting_power = neuron.deciding_voting_power(voting_power_economics, now_seconds);
+            total_deciding_voting_power += voting_power as u128;
+            total_potential_voting_power += neuron.potential_voting_power(now_seconds) as u128;
+            voting_power_map.insert(neuron.id().id, voting_power);
+        };
+
+        // Active neurons iterator already makes distinctions between stable and heap neurons.
+        self.with_active_neurons_iter_sections(
+            |iter| {
+                for neuron in iter {
+                    process_neuron(neuron.as_ref());
+                }
+            },
+            NeuronSections::NONE,
+        );
+
+        let total_deciding_voting_power = get_voting_power_as_u64(
+            total_deciding_voting_power,
+            NeuronStoreError::TotalDecidingVotingPowerOverflow,
+        )?;
+        let total_potential_voting_power = get_voting_power_as_u64(
+            total_potential_voting_power,
+            NeuronStoreError::TotalPotentialVotingPowerOverflow,
+        )?;
+
+        Ok(VotingPowerSnapshot {
+            voting_power_map,
+            total_deciding_voting_power,
+            total_potential_voting_power,
+        })
     }
 }

--- a/rs/nns/governance/src/storage.rs
+++ b/rs/nns/governance/src/storage.rs
@@ -1,7 +1,10 @@
-use crate::{governance::LOG_PREFIX, pb::v1::AuditEvent};
+use crate::{
+    governance::{voting_power_snapshots::VotingPowerSnapshots, LOG_PREFIX},
+    pb::v1::{ArchivedMonthlyNodeProviderRewards, AuditEvent},
+    reward::distribution::RewardsDistributionStateMachine,
+    voting::VotingStateMachines,
+};
 
-use crate::reward::distribution::RewardsDistributionStateMachine;
-use crate::{pb::v1::ArchivedMonthlyNodeProviderRewards, voting::VotingStateMachines};
 use ic_cdk::println;
 use ic_stable_structures::{
     memory_manager::{MemoryId, MemoryManager, VirtualMemory},
@@ -30,6 +33,8 @@ const VOTING_STATE_MACHINES_MEMORY_ID: MemoryId = MemoryId::new(16);
 const REWARDS_DISTRIBUTION_STATE_MACHINE_MEMORY_ID: MemoryId = MemoryId::new(17);
 const MATURITY_DISBURSEMENTS_NEURONS_MEMORY_ID: MemoryId = MemoryId::new(18);
 const NEURON_MATURITY_DISBURSEMENT_INDEX_MEMORY_ID: MemoryId = MemoryId::new(19);
+const VOTING_POWER_MAPS_MEMORY_ID: MemoryId = MemoryId::new(20);
+const VOTING_POWER_TOTALS_MEMORY_ID: MemoryId = MemoryId::new(21);
 
 pub mod neuron_indexes;
 pub mod neurons;
@@ -55,6 +60,15 @@ thread_local! {
         MEMORY_MANAGER.with(|memory_manager| {
             let memory = memory_manager.borrow().get(REWARDS_DISTRIBUTION_STATE_MACHINE_MEMORY_ID);
             RewardsDistributionStateMachine::new(memory)
+        })
+    });
+
+    pub(crate) static VOTING_POWER_SNAPSHOTS: RefCell<VotingPowerSnapshots> = RefCell::new({
+        MEMORY_MANAGER.with_borrow(|memory_manager| {
+            VotingPowerSnapshots::new(
+                memory_manager.get(VOTING_POWER_MAPS_MEMORY_ID),
+                memory_manager.get(VOTING_POWER_TOTALS_MEMORY_ID),
+            )
         })
     });
 }

--- a/rs/nns/governance/src/timer_tasks/mod.rs
+++ b/rs/nns/governance/src/timer_tasks/mod.rs
@@ -5,14 +5,18 @@ use ic_nervous_system_timer_task::{
 };
 use prune_following::PruneFollowingTask;
 use seeding::SeedingTask;
+use snapshot_voting_power::SnapshotVotingPowerTask;
 use std::cell::RefCell;
 
-use crate::{canister_state::GOVERNANCE, is_prune_following_enabled};
+use crate::{
+    canister_state::GOVERNANCE, is_prune_following_enabled, storage::VOTING_POWER_SNAPSHOTS,
+};
 
 mod calculate_distributable_rewards;
 mod distribute_rewards;
 mod prune_following;
 mod seeding;
+mod snapshot_voting_power;
 
 thread_local! {
     static METRICS_REGISTRY: RefCell<TimerTaskMetricsRegistry> = RefCell::new(TimerTaskMetricsRegistry::default());
@@ -24,6 +28,7 @@ pub fn schedule_tasks() {
     if is_prune_following_enabled() {
         PruneFollowingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     }
+    SnapshotVotingPowerTask::new(&GOVERNANCE, &VOTING_POWER_SNAPSHOTS).schedule(&METRICS_REGISTRY);
     run_distribute_rewards_periodic_task();
 }
 

--- a/rs/nns/governance/src/timer_tasks/snapshot_voting_power.rs
+++ b/rs/nns/governance/src/timer_tasks/snapshot_voting_power.rs
@@ -1,0 +1,209 @@
+use crate::governance::voting_power_snapshots::VotingPowerSnapshots;
+use crate::governance::Governance;
+
+use ic_nervous_system_timer_task::RecurringSyncTask;
+use std::cell::RefCell;
+use std::thread::LocalKey;
+use std::time::Duration;
+
+/// A task to snapshot the voting power every day, so that the snapshot can be used to disable
+/// early adoption of proposals if such proposals have unusually high voting power.
+pub(super) struct SnapshotVotingPowerTask {
+    governance: &'static LocalKey<RefCell<Governance>>,
+    snapshots: &'static LocalKey<RefCell<VotingPowerSnapshots>>,
+}
+
+const VOTING_POWER_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24);
+
+impl SnapshotVotingPowerTask {
+    pub fn new(
+        governance: &'static LocalKey<RefCell<Governance>>,
+        snapshots: &'static LocalKey<RefCell<VotingPowerSnapshots>>,
+    ) -> Self {
+        Self {
+            governance,
+            snapshots,
+        }
+    }
+}
+
+impl RecurringSyncTask for SnapshotVotingPowerTask {
+    fn execute(self) -> (Duration, Self) {
+        let (now_seconds, voting_power_snapshot) = self.governance.with_borrow_mut(|governance| {
+            let now_seconds = governance.env.now();
+            let voting_power_economics = governance.voting_power_economics();
+            let voting_power_snapshot = governance
+                .neuron_store
+                .compute_voting_power_snapshot_for_standard_proposal(
+                    voting_power_economics,
+                    now_seconds,
+                )
+                .expect("Voting power snapshot failed");
+
+            (now_seconds, voting_power_snapshot)
+        });
+
+        self.snapshots.with_borrow_mut(|snapshots| {
+            snapshots.record_voting_power_snapshot(now_seconds, voting_power_snapshot);
+        });
+
+        (VOTING_POWER_SNAPSHOT_INTERVAL, self)
+    }
+
+    fn initial_delay(&self) -> Duration {
+        let now_seconds = self
+            .governance
+            .with_borrow(|governance| governance.env.now());
+        let last_snapshot_timestamp_seconds = self
+            .snapshots
+            .with_borrow(|snapshots| snapshots.latest_snapshot_timestamp_seconds());
+        match last_snapshot_timestamp_seconds {
+            Some(last_snapshot_timestamp_seconds) => {
+                let next_snapshot_timestamp_seconds =
+                    last_snapshot_timestamp_seconds + VOTING_POWER_SNAPSHOT_INTERVAL.as_secs();
+                let delay_seconds = next_snapshot_timestamp_seconds.saturating_sub(now_seconds);
+                Duration::from_secs(delay_seconds)
+            }
+            None => Duration::from_secs(0),
+        }
+    }
+
+    const NAME: &'static str = "snapshot_voting_power";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ic_nns_common::pb::v1::NeuronId;
+    use ic_stable_structures::{
+        memory_manager::{MemoryId, MemoryManager},
+        DefaultMemoryImpl,
+    };
+    use ic_types::PrincipalId;
+    use icp_ledger::Subaccount;
+    use std::sync::Arc;
+
+    use crate::{
+        neuron::{DissolveStateAndAge, NeuronBuilder},
+        pb::v1::{Governance as GovernanceProto, NetworkEconomics, VotingPowerEconomics},
+        test_utils::{MockEnvironment, MockRandomness, StubCMC, StubIcpLedger},
+    };
+
+    thread_local! {
+        static MOCK_ENVIRONMENT: Arc<MockEnvironment> = Arc::new(
+            MockEnvironment::new(Default::default(), 0));
+        static TEST_GOVERNANCE: RefCell<Governance> = RefCell::new(new_governance_for_test());
+        static TEST_MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+            RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+        static TEST_VOTING_POWER_SNAPSHOTS: RefCell<VotingPowerSnapshots> = RefCell::new({
+            TEST_MEMORY_MANAGER.with_borrow(|memory_manager| {
+                VotingPowerSnapshots::new(memory_manager.get(MemoryId::new(0)), memory_manager.get(MemoryId::new(1)))
+            })
+        });
+    }
+
+    fn set_time(now: u64) {
+        MOCK_ENVIRONMENT.with(|env| env.now_setter()(now));
+    }
+
+    fn new_governance_for_test() -> Governance {
+        let mut governance = Governance::new(
+            GovernanceProto {
+                economics: Some(NetworkEconomics {
+                    voting_power_economics: Some(VotingPowerEconomics::DEFAULT),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            MOCK_ENVIRONMENT.with(|env| env.clone()),
+            Arc::new(StubIcpLedger {}),
+            Arc::new(StubCMC {}),
+            Box::new(MockRandomness::new()),
+        );
+        let dissolve_delay_seconds =
+            VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS;
+        governance
+            .neuron_store
+            .add_neuron(
+                NeuronBuilder::new(
+                    NeuronId { id: 1 },
+                    Subaccount::try_from([1u8; 32].as_slice()).unwrap(),
+                    PrincipalId::new_self_authenticating(b"neuron-id"),
+                    DissolveStateAndAge::NotDissolving {
+                        dissolve_delay_seconds,
+                        aging_since_timestamp_seconds: governance.env.now(),
+                    },
+                    123_456_789,
+                )
+                .with_cached_neuron_stake_e8s(1_000_000_000)
+                .build(),
+            )
+            .unwrap();
+
+        governance
+    }
+
+    #[test]
+    fn test_execute() {
+        TEST_VOTING_POWER_SNAPSHOTS.with_borrow(|snapshots| {
+            // Before the first snapshot, the latest snapshot timestamp should be None, and we
+            // should not disable early adoption without any snapshots.
+            assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), None);
+            assert_eq!(
+                snapshots.previous_ballots_if_voting_power_spike_detected(u64::MAX, 0),
+                None
+            )
+        });
+
+        let task = SnapshotVotingPowerTask::new(&TEST_GOVERNANCE, &TEST_VOTING_POWER_SNAPSHOTS);
+        let (delay, _) = task.execute();
+
+        assert_eq!(delay, VOTING_POWER_SNAPSHOT_INTERVAL);
+        let now_seconds = TEST_GOVERNANCE.with_borrow(|governance| governance.env.now());
+        TEST_VOTING_POWER_SNAPSHOTS.with_borrow(|snapshots| {
+            // After the first snapshot, the latest snapshot timestamp should be the current time,
+            // and we should disable early adoption given a large deciding voting power.
+            assert_eq!(
+                snapshots.latest_snapshot_timestamp_seconds(),
+                Some(now_seconds)
+            );
+            let (timestamp, previous_snapshot) = snapshots
+                .previous_ballots_if_voting_power_spike_detected(u64::MAX, 0)
+                .unwrap();
+
+            // We only do some sanity checks here to make sure the task is working as expected.
+            assert_eq!(timestamp, now_seconds);
+            let (ballots, total_potential_voting_power) =
+                previous_snapshot.create_ballots_and_total_potential_voting_power();
+            assert!(ballots.get(&1).unwrap().voting_power > 0);
+            assert!(total_potential_voting_power > 0);
+        });
+    }
+
+    #[test]
+    fn test_initial_delay() {
+        let task = SnapshotVotingPowerTask::new(&TEST_GOVERNANCE, &TEST_VOTING_POWER_SNAPSHOTS);
+        let one_day_seconds = 60 * 60 * 24;
+
+        // Initially, the task should run immediately.
+        set_time(one_day_seconds);
+        assert_eq!(task.initial_delay(), Duration::from_secs(0));
+
+        // After execution and a half day, the task should run after a half day.
+        let (new_delay, task) = task.execute();
+        assert_eq!(new_delay, VOTING_POWER_SNAPSHOT_INTERVAL);
+        set_time(one_day_seconds + one_day_seconds / 2);
+        assert_eq!(
+            task.initial_delay(),
+            Duration::from_secs(one_day_seconds / 2)
+        );
+
+        // After execution and 1.5 days (for some reason the task wasn't run), the task should run
+        // immediately.
+        let (new_delay, task) = task.execute();
+        assert_eq!(new_delay, VOTING_POWER_SNAPSHOT_INTERVAL);
+        set_time(3 * one_day_seconds);
+        assert_eq!(task.initial_delay(), Duration::from_secs(0));
+    }
+}

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,6 +9,8 @@ on the process that this file is part of, see
 
 ## Added
 
+* A timer task is added to take daily snapshots of voting power for standard proposals.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
# Why

To prevent a sudden takeover of the NNS in the event of some party gaining illegitimate voting power (e.g. a bug in Governance, ICP Ledger, etc.), we aim at disabling the early adoption of NNS proposals if the voting power has a spike, which should give the network more time to react and recover in such cases.

# Related PRs

There are 3 PRs to achieve the above-mentioned goal:

- (#4404) Define VotingPowerSnapshot and a collection of snapshots
- (current PR) Add a timer task to record snapshots periodically
- (#4798) Use the previous snapshot if a voting power spike is detected

# What

* Refactor the existing function `create_ballots_for_standard_proposal` to be used for snapshots too
* Define how to store the snapshots in stable storage
* Define a timer task for taking snapshots