### PR TITLE
feat(nns): Use a previous snapshot for ballots if an unusually high voting power is detected

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -63,7 +63,7 @@ benches:
     total:
       instructions: 1790506
       heap_increase: 0
-      stable_memory_increase: 0
+      stable_memory_increase: 128
     scopes: {}
   distribute_rewards_with_stable_neurons:
     total:

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1358,6 +1358,12 @@ message ProposalData {
   // amount of voting power that it exercised (so called "deciding" voting
   // power) in proportion to this.
   optional uint64 total_potential_voting_power = 22;
+
+  // When a voting power spike is detected, ballots are created using a previous snapshot of the
+  // voting power, and this field indicates the timestamp at which the snapshot was taken. This
+  // field should not be set in normal circumstances, and if it is set, it is an indicator that a
+  // bug might have caused the voting power spike.
+  optional uint64 previous_ballots_timestamp_seconds = 23;
 }
 
 // This structure contains data for settling the Neurons' Fund participation in an SNS token swap.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -1618,6 +1618,12 @@ pub struct ProposalData {
     /// power) in proportion to this.
     #[prost(uint64, optional, tag = "22")]
     pub total_potential_voting_power: ::core::option::Option<u64>,
+    /// When a voting power spike is detected, ballots are created using a previous snapshot of the
+    /// voting power, and this field indicates the timestamp at which the snapshot was taken. This
+    /// field should not be set in normal circumstances, and if it is set, it is an indicator that a
+    /// bug might have caused the voting power spike.
+    #[prost(uint64, optional, tag = "23")]
+    pub previous_ballots_timestamp_seconds: ::core::option::Option<u64>,
 }
 /// This structure contains data for settling the Neurons' Fund participation in an SNS token swap.
 #[derive(

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1646,7 +1646,7 @@ fn test_compute_ballots_for_new_proposal() {
         neuron_id_or_subaccount: None,
         command: None,
     }));
-    let (ballots, tot_potential_voting_power) = governance
+    let (ballots, tot_potential_voting_power, _previous_ballots_timestamp_seconds) = governance
         .compute_ballots_for_new_proposal(&manage_neuron_action, &NeuronId { id: 10 }, now_seconds)
         .expect("Failed computing ballots for new proposal");
 
@@ -1666,7 +1666,7 @@ fn test_compute_ballots_for_new_proposal() {
     );
 
     let motion_action = Action::Motion(Default::default());
-    let (ballots, tot_potential_voting_power) = governance
+    let (ballots, tot_potential_voting_power, _previous_ballots_timestamp_seconds) = governance
         .compute_ballots_for_new_proposal(&motion_action, &NeuronId { id: 10 }, now_seconds)
         .expect("Failed computing ballots for new proposal");
     // Similar to previous; this time though, Action::ManageNeuron, the weird
@@ -1697,7 +1697,7 @@ fn test_compute_ballots_for_new_proposal() {
     // Not affected by refresh.
     let now_seconds = CREATED_TIMESTAMP_SECONDS + 20 * ONE_YEAR_SECONDS;
 
-    let (ballots, tot_potential_voting_power) = governance
+    let (ballots, tot_potential_voting_power, _previous_ballots_timestamp_seconds) = governance
         .compute_ballots_for_new_proposal(&motion_action, &NeuronId { id: 10 }, now_seconds)
         .expect("Failed computing ballots for new proposal");
     let expected: u64 = governance.neuron_store.with_active_neurons_iter(|iter| {

--- a/rs/nns/governance/src/neuron_store/voting_power.rs
+++ b/rs/nns/governance/src/neuron_store/voting_power.rs
@@ -23,10 +23,10 @@ pub struct VotingPowerSnapshot {
     total_potential_voting_power: u64,
 }
 
-#[cfg(any(test, feature = "canbench-rs"))]
 impl VotingPowerSnapshot {
     /// Although the snapshot should only be computed by the neuron store, we need to
     /// create it for testing purposes.
+    #[cfg(any(test, feature = "canbench-rs"))]
     pub fn new_for_test(
         voting_power_map: HashMap<u64, u64>,
         total_potential_voting_power: u64,
@@ -37,6 +37,10 @@ impl VotingPowerSnapshot {
             total_deciding_voting_power,
             total_potential_voting_power,
         }
+    }
+
+    pub fn total_potential_voting_power(&self) -> u64 {
+        self.total_potential_voting_power
     }
 }
 

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -1441,6 +1441,8 @@ impl From<pb_api::ProposalData> for pb::ProposalData {
             derived_proposal_information: item.derived_proposal_information.map(|x| x.into()),
             neurons_fund_data: item.neurons_fund_data.map(|x| x.into()),
             total_potential_voting_power: item.total_potential_voting_power,
+            // This is not intended to be initialized from outside of canister.
+            previous_ballots_timestamp_seconds: None,
         }
     }
 }

--- a/rs/nns/integration_tests/src/governance_proposals.rs
+++ b/rs/nns/integration_tests/src/governance_proposals.rs
@@ -1,0 +1,119 @@
+use ic_nervous_system_common_test_keys::{
+    TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL, TEST_NEURON_3_OWNER_PRINCIPAL,
+};
+use ic_nns_common::pb::v1::{NeuronId, ProposalId};
+use ic_nns_governance_api::pb::v1::{
+    manage_neuron_response::Command, MakeProposalRequest, Motion, ProposalActionRequest,
+};
+use ic_nns_test_utils::{
+    common::NnsInitPayloadsBuilder,
+    state_test_helpers::{
+        nns_create_super_powerful_neuron, nns_governance_get_proposal_info_as_anonymous,
+        nns_governance_make_proposal, setup_nns_canisters, state_machine_builder_for_nns_tests,
+    },
+};
+use ic_state_machine_tests::StateMachine;
+use ic_types::PrincipalId;
+use std::time::Duration;
+
+fn make_motion_proposal(
+    state_machine: &StateMachine,
+    sender: PrincipalId,
+    neuron_id: NeuronId,
+) -> ProposalId {
+    let response = nns_governance_make_proposal(
+        state_machine,
+        sender,
+        neuron_id,
+        &MakeProposalRequest {
+            title: Some("Some title".to_string()),
+            summary: "Some summary".to_string(),
+            url: "".to_string(),
+            action: Some(ProposalActionRequest::Motion(Motion {
+                motion_text: "Motion text".to_string(),
+            })),
+        },
+    );
+    match response.command {
+        Some(Command::MakeProposal(make_proposal_response)) => {
+            make_proposal_response.proposal_id.unwrap()
+        }
+        _ => panic!("Failed to make motion proposal: {:?}", response),
+    }
+}
+
+fn is_proposal_executed(state_machine: &StateMachine, proposal_id: ProposalId) -> bool {
+    let proposal_info =
+        nns_governance_get_proposal_info_as_anonymous(state_machine, proposal_id.id);
+    proposal_info.executed_timestamp_seconds > 0
+}
+
+#[test]
+fn test_proposal_no_voting_power_spike() {
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    let nns_init_payloads = NnsInitPayloadsBuilder::new().with_test_neurons().build();
+    setup_nns_canisters(&state_machine, nns_init_payloads);
+
+    let proposal_id = make_motion_proposal(
+        &state_machine,
+        *TEST_NEURON_1_OWNER_PRINCIPAL,
+        NeuronId::from_u64(TEST_NEURON_1_ID),
+    );
+
+    // Because the neuron 1 has a lot of voting power, the proposal should be executed immediately.
+    assert!(is_proposal_executed(&state_machine, proposal_id));
+}
+
+#[test]
+fn test_proposal_with_voting_power_spike() {
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    let nns_init_payloads = NnsInitPayloadsBuilder::new().with_test_neurons().build();
+    setup_nns_canisters(&state_machine, nns_init_payloads);
+
+    // For a few days, proposals made by a neuron which wields a lot of voting power should be
+    // executed immediately.
+    for _ in 0..10 {
+        let proposal_id = make_motion_proposal(
+            &state_machine,
+            *TEST_NEURON_1_OWNER_PRINCIPAL,
+            NeuronId::from_u64(TEST_NEURON_1_ID),
+        );
+        assert!(is_proposal_executed(&state_machine, proposal_id));
+
+        state_machine.advance_time(Duration::from_secs(60 * 60 * 24));
+    }
+
+    // Now we create a super powerful neuron, which will cause a spike in voting power compared to
+    // previous days.
+    let super_powerful_neuron_id =
+        nns_create_super_powerful_neuron(&state_machine, *TEST_NEURON_3_OWNER_PRINCIPAL);
+    let proposal_id = make_motion_proposal(
+        &state_machine,
+        *TEST_NEURON_3_OWNER_PRINCIPAL,
+        super_powerful_neuron_id,
+    );
+    assert!(!is_proposal_executed(&state_machine, proposal_id));
+
+    // Using the previous neuron, we create a proposal which should be executed immediately.
+    let proposal_id = make_motion_proposal(
+        &state_machine,
+        *TEST_NEURON_1_OWNER_PRINCIPAL,
+        NeuronId::from_u64(TEST_NEURON_1_ID),
+    );
+    assert!(is_proposal_executed(&state_machine, proposal_id));
+
+    // After a certain amount of time, the voting power spike will be considered normal, and a
+    // proposal created by the super powerful neuron can be executed immediately.
+    for _ in 0..10 {
+        state_machine.advance_time(Duration::from_secs(60 * 60 * 24));
+        for _ in 0..10 {
+            state_machine.tick();
+        }
+    }
+    let proposal_id = make_motion_proposal(
+        &state_machine,
+        *TEST_NEURON_3_OWNER_PRINCIPAL,
+        super_powerful_neuron_id,
+    );
+    assert!(is_proposal_executed(&state_machine, proposal_id));
+}

--- a/rs/nns/integration_tests/src/lib.rs
+++ b/rs/nns/integration_tests/src/lib.rs
@@ -109,6 +109,9 @@ mod governance_neurons;
 mod governance_time_warp;
 
 #[cfg(test)]
+mod governance_proposals;
+
+#[cfg(test)]
 mod known_neurons;
 
 #[cfg(test)]


### PR DESCRIPTION
# Why

To prevent a sudden takeover of the NNS in the event of some party gaining illegitimate voting power (e.g. a bug in Governance, ICP Ledger, etc.), we aim at disabling the early adoption of NNS proposals if the voting power has a spike, which should give the network more time to react and recover in such cases.

# What

There are 3 PRs to achieve the above-mentioned goal:

- (#4404) Define VotingPowerSnapshot and a collection of snapshots
- (#4404) Add a timer task to record snapshots periodically
- (current PR) Use the previous snapshot if a voting power spike is detected

