### PR TITLE
chore(IDX): enable auto-merge for mainnet revisions file

### DIFF
--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -94,7 +94,7 @@ def commit_and_create_pr(
             ["gh", "pr", "list", "--head", branch, "--repo", repo],
             cwd=repo_root,
         ).decode("utf8"):
-            pr_number = subprocess.check_call(
+            pr_number = subprocess.check_output(
                 [
                     "gh",
                     "pr",
@@ -110,10 +110,11 @@ def commit_and_create_pr(
                     "--json",
                     "number",
                     "-q",
-                    "'.number'"
+                    ".number"
                 ],
                 cwd=repo_root,
-            )
+                text=True
+            ).strip()
         if enable_auto_merge:
             subprocess.check_call(
                 [

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -94,7 +94,7 @@ def commit_and_create_pr(
             ["gh", "pr", "list", "--head", branch, "--repo", repo],
             cwd=repo_root,
         ).decode("utf8"):
-            pr_number = subprocess.check_output(
+            subprocess.check_call(
                 [
                     "gh",
                     "pr",
@@ -107,15 +107,15 @@ def commit_and_create_pr(
                     description,
                     "--title",
                     commit_message,
-                    "--json",
-                    "number",
-                    "-q",
-                    ".number"
                 ],
+                cwd=repo_root,
+            )
+        if enable_auto_merge:
+            pr_number = subprocess.check_output(
+                ["gh", "pr", "view", "--json", "number", "-q", ".number"],
                 cwd=repo_root,
                 text=True
             ).strip()
-        if enable_auto_merge:
             subprocess.check_call(
                 [
                     "gh",

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -57,21 +57,11 @@ def commit_and_create_pr(
 
     paths_to_add = [path for path in check_for_updates_in_paths if path in git_modified_files]
 
-    if len(paths_to_add) == 0:
-        logger.info("Creating/updating a PR that updates the saved NNS subnet revision")
-        # cmd = ["git", "add"] + paths_to_add
-        # logger.info("Running command '%s'", " ".join(cmd))
-        # subprocess.check_call(cmd, cwd=repo_root)
-        # cmd = [
-        #     "git",
-        #     "-c",
-        #     "user.name=CI Automation",
-        #     "-c",
-        #     "user.email=infra+github-automation@dfinity.org",
-        #     "commit",
-        #     "-m",
-        #     commit_message,
-        # ] + paths_to_add
+    if len(paths_to_add) > 0:
+        logger.info("Creating/updating a MR that updates the saved NNS subnet revision")
+        cmd = ["git", "add"] + paths_to_add
+        logger.info("Running command '%s'", " ".join(cmd))
+        subprocess.check_call(cmd, cwd=repo_root)
         cmd = [
             "git",
             "-c",
@@ -80,9 +70,8 @@ def commit_and_create_pr(
             "user.email=infra+github-automation@dfinity.org",
             "commit",
             "-m",
-            "test",
-            "--allow-empty",
-        ]
+            commit_message,
+        ] + paths_to_add
         logger.info("Running command '%s'", " ".join(cmd))
         subprocess.check_call(
             cmd,

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -57,11 +57,21 @@ def commit_and_create_pr(
 
     paths_to_add = [path for path in check_for_updates_in_paths if path in git_modified_files]
 
-    if len(paths_to_add) > 0:
-        logger.info("Creating/updating a MR that updates the saved NNS subnet revision")
-        cmd = ["git", "add"] + paths_to_add
-        logger.info("Running command '%s'", " ".join(cmd))
-        subprocess.check_call(cmd, cwd=repo_root)
+    if len(paths_to_add) == 0:
+        logger.info("Creating/updating a PR that updates the saved NNS subnet revision")
+        # cmd = ["git", "add"] + paths_to_add
+        # logger.info("Running command '%s'", " ".join(cmd))
+        # subprocess.check_call(cmd, cwd=repo_root)
+        # cmd = [
+        #     "git",
+        #     "-c",
+        #     "user.name=CI Automation",
+        #     "-c",
+        #     "user.email=infra+github-automation@dfinity.org",
+        #     "commit",
+        #     "-m",
+        #     commit_message,
+        # ] + paths_to_add
         cmd = [
             "git",
             "-c",
@@ -70,8 +80,9 @@ def commit_and_create_pr(
             "user.email=infra+github-automation@dfinity.org",
             "commit",
             "-m",
-            commit_message,
-        ] + paths_to_add
+            "test",
+            "--allow-empty",
+        ]
         logger.info("Running command '%s'", " ".join(cmd))
         subprocess.check_call(
             cmd,

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -103,16 +103,7 @@ def commit_and_create_pr(
             pr_number = subprocess.check_output(
                 ["gh", "pr", "view", "--json", "number", "-q", ".number"], cwd=repo_root, text=True
             ).strip()
-            subprocess.check_call(
-                [
-                    "gh",
-                    "pr",
-                    "merge",
-                    pr_number,
-                    "--auto",
-                ],
-                cwd=repo_root,
-            )
+            subprocess.check_call(["gh", "pr", "merge", pr_number, "--auto"], cwd=repo_root)
 
 
 def get_saved_versions(repo_root: pathlib.Path, file_path: pathlib.Path):

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -101,9 +101,7 @@ def commit_and_create_pr(
             )
         if enable_auto_merge:
             pr_number = subprocess.check_output(
-                ["gh", "pr", "view", "--json", "number", "-q", ".number"],
-                cwd=repo_root,
-                text=True
+                ["gh", "pr", "view", "--json", "number", "-q", ".number"], cwd=repo_root, text=True
             ).strip()
             subprocess.check_call(
                 [
@@ -112,9 +110,9 @@ def commit_and_create_pr(
                     "merge",
                     pr_number,
                     "--auto",
-                    ],
-                    cwd=repo_root,
-                )
+                ],
+                cwd=repo_root,
+            )
 
 
 def get_saved_versions(repo_root: pathlib.Path, file_path: pathlib.Path):


### PR DESCRIPTION
This PR enables auto-merge for the automatic PRs created for revisions made to the mainnet canister files. This is the first step in fully automating the approval process - the second step will be adding mergify to give the approval.

See test PR here where auto-merge is enabled: https://github.com/dfinity/ic/pull/4411