### PR TITLE
refactor(consensus): make consensus metrics private to the `ic-consensus` trait

### DIFF
--- a/rs/consensus/src/consensus.rs
+++ b/rs/consensus/src/consensus.rs
@@ -57,7 +57,6 @@ use ic_types::{
     malicious_flags::MaliciousFlags, replica_config::ReplicaConfig,
     replica_version::ReplicaVersion, Time,
 };
-pub use metrics::ValidatorMetrics;
 use std::{
     cell::RefCell,
     collections::BTreeMap,
@@ -255,7 +254,7 @@ impl ConsensusImpl {
                 message_routing.clone(),
                 dkg_pool,
                 logger.clone(),
-                ValidatorMetrics::new(metrics_registry.clone()),
+                &metrics_registry,
                 Arc::clone(&time_source),
             ),
             aggregator: ShareAggregator::new(

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -45,8 +45,7 @@ use std::collections::BTreeMap;
 /// Deliver all finalized blocks from
 /// `message_routing.expected_batch_height` to `finalized_height` via
 /// `MessageRouting` and return the last delivered batch height.
-#[allow(clippy::too_many_arguments, clippy::type_complexity)]
-pub fn deliver_batches(
+pub fn deliver_batches_without_metrics(
     message_routing: &dyn MessageRouting,
     membership: &Membership,
     pool: &PoolReader<'_>,
@@ -57,7 +56,34 @@ pub fn deliver_batches(
     // deliver all batches until the finalized height. If it is set to `Some(h)`, we will
     // deliver all bathes up to the height `min(h, finalized_height)`.
     max_batch_height_to_deliver: Option<Height>,
-    result_processor: Option<&dyn Fn(&Result<(), MessageRoutingError>, BlockStats, BatchStats)>,
+) -> Result<Height, MessageRoutingError> {
+    deliver_batches(
+        message_routing,
+        membership,
+        pool,
+        registry_client,
+        subnet_id,
+        log,
+        max_batch_height_to_deliver,
+        |_, _, _| {},
+    )
+}
+
+/// Deliver all finalized blocks from
+/// `message_routing.expected_batch_height` to `finalized_height` via
+/// `MessageRouting` and return the last delivered batch height.
+pub(crate) fn deliver_batches(
+    message_routing: &dyn MessageRouting,
+    membership: &Membership,
+    pool: &PoolReader<'_>,
+    registry_client: &dyn RegistryClient,
+    subnet_id: SubnetId,
+    log: &ReplicaLogger,
+    // This argument should only be used by the ic-replay tool. If it is set to `None`, we will
+    // deliver all batches until the finalized height. If it is set to `Some(h)`, we will
+    // deliver all bathes up to the height `min(h, finalized_height)`.
+    max_batch_height_to_deliver: Option<Height>,
+    result_processor: impl Fn(&Result<(), MessageRoutingError>, BlockStats, BatchStats),
 ) -> Result<Height, MessageRoutingError> {
     let finalized_height = pool.get_finalized_height();
     // If `max_batch_height_to_deliver` is specified and smaller than
@@ -238,9 +264,7 @@ pub fn deliver_batches(
         };
 
         let result = message_routing.deliver_batch(batch);
-        if let Some(f) = result_processor {
-            f(&result, block_stats, batch_stats);
-        }
+        result_processor(&result, block_stats, batch_stats);
         if let Err(err) = result {
             warn!(every_n_seconds => 5, log, "Batch delivery failed: {:?}", err);
             return Err(err);
@@ -256,7 +280,7 @@ pub fn deliver_batches(
 /// - Initial NiDKG transcript creation, where a response may come from summary payloads.
 /// - Canister threshold signature creation, where a response may come from from data payloads.
 /// - CanisterHttpResponse handling, where a response to a canister http request may come from data payloads.
-pub fn generate_responses_to_subnet_calls(
+fn generate_responses_to_subnet_calls(
     block: &Block,
     stats: &mut BatchStats,
     log: &ReplicaLogger,

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -104,7 +104,7 @@ impl Finalizer {
             &*self.registry_client,
             self.replica_config.subnet_id,
             &self.log,
-            None,
+            /*max_batch_height_to_deliver=*/ None,
             |result, block_stats, batch_stats| {
                 self.process_batch_delivery_result(result, block_stats, batch_stats)
             },

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -105,9 +105,9 @@ impl Finalizer {
             self.replica_config.subnet_id,
             &self.log,
             None,
-            Some(&|result, block_stats, batch_stats| {
+            |result, block_stats, batch_stats| {
                 self.process_batch_delivery_result(result, block_stats, batch_stats)
-            }),
+            },
         );
 
         // Try to finalize rounds from finalized_height + 1 up to (and including)

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -54,7 +54,6 @@ pub struct Finalizer {
 }
 
 impl Finalizer {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         replica_config: ReplicaConfig,
         registry_client: Arc<dyn RegistryClient>,

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -118,7 +118,6 @@ impl Finalizer {
     }
 
     /// Write logs, report metrics depending on the batch deliver result.
-    #[allow(clippy::too_many_arguments)]
     fn process_batch_delivery_result(
         &self,
         result: &Result<(), MessageRoutingError>,

--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -38,7 +38,7 @@ pub(crate) struct BlockMakerMetrics {
 }
 
 impl BlockMakerMetrics {
-    pub fn new(metrics_registry: MetricsRegistry) -> Self {
+    pub(crate) fn new(metrics_registry: MetricsRegistry) -> Self {
         Self {
             get_payload_calls: metrics_registry.int_counter_vec(
                 "consensus_get_payload_calls",
@@ -57,7 +57,7 @@ impl BlockMakerMetrics {
     }
 
     /// Reports byte estimate metrics.
-    pub fn report_byte_estimate_metrics(&self, xnet_bytes: usize, ingress_bytes: usize) {
+    pub(crate) fn report_byte_estimate_metrics(&self, xnet_bytes: usize, ingress_bytes: usize) {
         self.block_size_bytes_estimate
             .with_label_values(&["xnet"])
             .set(xnet_bytes as i64);
@@ -67,16 +67,16 @@ impl BlockMakerMetrics {
     }
 }
 
-pub struct ConsensusMetrics {
-    pub on_state_change_duration: HistogramVec,
-    pub on_state_change_invocations: IntCounterVec,
-    pub on_state_change_change_set_size: HistogramVec,
-    pub time_since_last_invoked: GaugeVec,
-    pub starvation_counter: IntCounterVec,
+pub(crate) struct ConsensusMetrics {
+    pub(crate) on_state_change_duration: HistogramVec,
+    pub(crate) on_state_change_invocations: IntCounterVec,
+    pub(crate) on_state_change_change_set_size: HistogramVec,
+    pub(crate) time_since_last_invoked: GaugeVec,
+    pub(crate) starvation_counter: IntCounterVec,
 }
 
 impl ConsensusMetrics {
-    pub fn new(metrics_registry: MetricsRegistry) -> Self {
+    pub(crate) fn new(metrics_registry: MetricsRegistry) -> Self {
         Self {
             on_state_change_duration: metrics_registry.histogram_vec(
                 "consensus_on_state_change_duration_seconds",
@@ -113,12 +113,12 @@ impl ConsensusMetrics {
 }
 
 // Block related stats
-pub struct BlockStats {
-    pub block_hash: String,
-    pub block_height: u64,
-    pub block_time: Time,
-    pub block_context_certified_height: u64,
-    pub idkg_stats: Option<IDkgStats>,
+pub(crate) struct BlockStats {
+    pub(crate) block_hash: String,
+    pub(crate) block_height: u64,
+    pub(crate) block_time: Time,
+    pub(crate) block_context_certified_height: u64,
+    pub(crate) idkg_stats: Option<IDkgStats>,
 }
 
 impl From<&Block> for BlockStats {
@@ -135,13 +135,13 @@ impl From<&Block> for BlockStats {
 
 // Batch payload stats
 #[derive(Debug, Default)]
-pub struct BatchStats {
-    pub batch_height: u64,
-    pub ingress_messages_delivered: usize,
-    pub ingress_message_bytes_delivered: usize,
-    pub xnet_bytes_delivered: usize,
-    pub ingress_ids: Vec<ic_types::artifact::IngressMessageId>,
-    pub canister_http: CanisterHttpBatchStats,
+pub(crate) struct BatchStats {
+    pub(crate) batch_height: u64,
+    pub(crate) ingress_messages_delivered: usize,
+    pub(crate) ingress_message_bytes_delivered: usize,
+    pub(crate) xnet_bytes_delivered: usize,
+    pub(crate) ingress_ids: Vec<ic_types::artifact::IngressMessageId>,
+    pub(crate) canister_http: CanisterHttpBatchStats,
 }
 
 impl BatchStats {
@@ -162,13 +162,13 @@ impl BatchStats {
 }
 
 // IDkg payload stats
-pub struct IDkgStats {
-    pub signature_agreements: usize,
-    pub key_transcripts_created: CounterPerMasterPublicKeyId,
-    pub available_pre_signatures: CounterPerMasterPublicKeyId,
-    pub pre_signatures_in_creation: CounterPerMasterPublicKeyId,
-    pub ongoing_xnet_reshares: CounterPerMasterPublicKeyId,
-    pub xnet_reshare_agreements: CounterPerMasterPublicKeyId,
+pub(crate) struct IDkgStats {
+    pub(crate) signature_agreements: usize,
+    pub(crate) key_transcripts_created: CounterPerMasterPublicKeyId,
+    pub(crate) available_pre_signatures: CounterPerMasterPublicKeyId,
+    pub(crate) pre_signatures_in_creation: CounterPerMasterPublicKeyId,
+    pub(crate) ongoing_xnet_reshares: CounterPerMasterPublicKeyId,
+    pub(crate) xnet_reshare_agreements: CounterPerMasterPublicKeyId,
 }
 
 impl From<&IDkgPayload> for IDkgStats {
@@ -222,30 +222,30 @@ impl From<&IDkgPayload> for IDkgStats {
     }
 }
 
-pub struct FinalizerMetrics {
-    pub batches_delivered: IntCounterVec,
-    pub batch_height: IntGauge,
-    pub batch_delivery_interval: Histogram,
-    pub batch_delivery_latency: Histogram,
-    pub ingress_messages_delivered: Histogram,
-    pub ingress_message_bytes_delivered: Histogram,
-    pub xnet_bytes_delivered: Histogram,
-    pub finalization_certified_state_difference: IntGauge,
+pub(crate) struct FinalizerMetrics {
+    pub(crate) batches_delivered: IntCounterVec,
+    pub(crate) batch_height: IntGauge,
+    pub(crate) batch_delivery_interval: Histogram,
+    pub(crate) batch_delivery_latency: Histogram,
+    pub(crate) ingress_messages_delivered: Histogram,
+    pub(crate) ingress_message_bytes_delivered: Histogram,
+    pub(crate) xnet_bytes_delivered: Histogram,
+    pub(crate) finalization_certified_state_difference: IntGauge,
     // idkg payload related metrics
-    pub master_key_transcripts_created: IntCounterVec,
-    pub threshold_signature_agreements: IntCounter,
-    pub idkg_available_pre_signatures: IntGaugeVec,
-    pub idkg_pre_signatures_in_creation: IntGaugeVec,
-    pub idkg_ongoing_xnet_reshares: IntGaugeVec,
-    pub idkg_xnet_reshare_agreements: IntCounterVec,
+    pub(crate) master_key_transcripts_created: IntCounterVec,
+    pub(crate) threshold_signature_agreements: IntCounter,
+    pub(crate) idkg_available_pre_signatures: IntGaugeVec,
+    pub(crate) idkg_pre_signatures_in_creation: IntGaugeVec,
+    pub(crate) idkg_ongoing_xnet_reshares: IntGaugeVec,
+    pub(crate) idkg_xnet_reshare_agreements: IntCounterVec,
     // canister http payload metrics
-    pub canister_http_success_delivered: IntCounter,
-    pub canister_http_timeouts_delivered: IntCounter,
-    pub canister_http_divergences_delivered: IntCounter,
+    pub(crate) canister_http_success_delivered: IntCounter,
+    pub(crate) canister_http_timeouts_delivered: IntCounter,
+    pub(crate) canister_http_divergences_delivered: IntCounter,
 }
 
 impl FinalizerMetrics {
-    pub fn new(metrics_registry: MetricsRegistry) -> Self {
+    pub(crate) fn new(metrics_registry: MetricsRegistry) -> Self {
         Self {
             batches_delivered: metrics_registry.int_counter_vec(
                 "consensus_batches_delivered",
@@ -336,7 +336,7 @@ impl FinalizerMetrics {
         }
     }
 
-    pub fn process(&self, block_stats: &BlockStats, batch_stats: &BatchStats) {
+    pub(crate) fn process(&self, block_stats: &BlockStats, batch_stats: &BatchStats) {
         self.batches_delivered.with_label_values(&["success"]).inc();
         self.batch_height.set(batch_stats.batch_height as i64);
         self.ingress_messages_delivered
@@ -398,12 +398,12 @@ impl FinalizerMetrics {
     }
 }
 
-pub struct NotaryMetrics {
-    pub time_to_notary_sign: HistogramVec,
+pub(crate) struct NotaryMetrics {
+    pub(crate) time_to_notary_sign: HistogramVec,
 }
 
 impl NotaryMetrics {
-    pub fn new(metrics_registry: MetricsRegistry) -> Self {
+    pub(crate) fn new(metrics_registry: MetricsRegistry) -> Self {
         Self {
             time_to_notary_sign: metrics_registry.histogram_vec(
                 "consensus_time_to_notary_sign",
@@ -415,7 +415,7 @@ impl NotaryMetrics {
     }
 
     /// Report metrics after notarizing `block`
-    pub fn report_notarization(&self, block: &Block, elapsed: std::time::Duration) {
+    pub(crate) fn report_notarization(&self, block: &Block, elapsed: std::time::Duration) {
         let rank = block.rank().0 as usize;
         if rank < RANKS_TO_RECORD.len() {
             self.time_to_notary_sign
@@ -425,25 +425,25 @@ impl NotaryMetrics {
     }
 }
 
-pub struct PayloadBuilderMetrics {
-    pub get_payload_duration: Histogram,
-    pub validate_payload_duration: Histogram,
-    pub past_payloads_length: Histogram,
-    pub payload_size_bytes: Histogram,
-    pub payload_section_size_bytes: HistogramVec,
+pub(crate) struct PayloadBuilderMetrics {
+    pub(crate) get_payload_duration: Histogram,
+    pub(crate) validate_payload_duration: Histogram,
+    pub(crate) past_payloads_length: Histogram,
+    pub(crate) payload_size_bytes: Histogram,
+    pub(crate) payload_section_size_bytes: HistogramVec,
 
     /// Critical error for payloads above the maximum supported size
-    pub critical_error_payload_too_large: IntCounter,
+    pub(crate) critical_error_payload_too_large: IntCounter,
 
     /// Critical error for newly created payloads that do not pass their own validation function
-    pub critical_error_validation_not_passed: IntCounter,
+    pub(crate) critical_error_validation_not_passed: IntCounter,
 
     /// Critical error triggered if the subnet record contains entries that would not make sense to consensus
-    pub critical_error_subnet_record_data_issue: IntCounter,
+    pub(crate) critical_error_subnet_record_data_issue: IntCounter,
 }
 
 impl PayloadBuilderMetrics {
-    pub fn new(metrics_registry: MetricsRegistry) -> Self {
+    pub(crate) fn new(metrics_registry: MetricsRegistry) -> Self {
         Self {
             get_payload_duration: metrics_registry.histogram(
                 "consensus_get_payload_duration_seconds",
@@ -486,7 +486,7 @@ impl PayloadBuilderMetrics {
 }
 
 /// Metrics for a consensus validator.
-pub struct ValidatorMetrics {
+pub(crate) struct ValidatorMetrics {
     pub(crate) time_to_receive_block: HistogramVec,
     pub(crate) duplicate_artifact: IntCounterVec,
     pub(crate) validation_duration: HistogramVec,
@@ -503,7 +503,7 @@ pub struct ValidatorMetrics {
 
 impl ValidatorMetrics {
     /// The constructor creates a [`ValidatorMetrics`] instance.
-    pub fn new(metrics_registry: MetricsRegistry) -> Self {
+    pub(crate) fn new(metrics_registry: &MetricsRegistry) -> Self {
         Self {
             time_to_receive_block: metrics_registry.histogram_vec(
                 "consensus_time_to_receive_block",
@@ -609,16 +609,16 @@ impl ValidatorMetrics {
     }
 }
 
-pub struct PurgerMetrics {
-    pub unvalidated_pool_purge_height: IntGauge,
-    pub validated_pool_purge_height: IntGauge,
-    pub replicated_state_purge_height: IntGauge,
-    pub replicated_state_purge_height_disk: IntGauge,
-    pub validated_pool_bounds_exceeded: IntCounter,
+pub(crate) struct PurgerMetrics {
+    pub(crate) unvalidated_pool_purge_height: IntGauge,
+    pub(crate) validated_pool_purge_height: IntGauge,
+    pub(crate) replicated_state_purge_height: IntGauge,
+    pub(crate) replicated_state_purge_height_disk: IntGauge,
+    pub(crate) validated_pool_bounds_exceeded: IntCounter,
 }
 
 impl PurgerMetrics {
-    pub fn new(metrics_registry: MetricsRegistry) -> Self {
+    pub(crate) fn new(metrics_registry: MetricsRegistry) -> Self {
         Self {
             unvalidated_pool_purge_height: metrics_registry.int_gauge(
                 "unvalidated_pool_purge_height",

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -691,7 +691,6 @@ pub struct Validator {
 }
 
 impl Validator {
-    #[allow(clippy::too_many_arguments)]
     /// The constructor creates a new [`Validator`] instance.
     pub fn new(
         replica_config: ReplicaConfig,

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -31,6 +31,7 @@ use ic_interfaces::{
 use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::{StateHashError, StateManager, StateManagerError};
 use ic_logger::{trace, warn, ReplicaLogger};
+use ic_metrics::MetricsRegistry;
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
     batch::ValidationContext,
@@ -702,7 +703,7 @@ impl Validator {
         message_routing: Arc<dyn MessageRouting>,
         dkg_pool: Arc<RwLock<dyn DkgPool>>,
         log: ReplicaLogger,
-        metrics: ValidatorMetrics,
+        metrics_registry: &MetricsRegistry,
         time_source: Arc<dyn TimeSource>,
     ) -> Validator {
         Validator {
@@ -715,7 +716,7 @@ impl Validator {
             message_routing,
             dkg_pool,
             log,
-            metrics,
+            metrics: ValidatorMetrics::new(metrics_registry),
             schedule: RoundRobin::default(),
             time_source,
         }
@@ -1992,7 +1993,7 @@ pub mod test {
                 message_routing.clone(),
                 dependencies.dkg_pool.clone(),
                 no_op_logger(),
-                ValidatorMetrics::new(MetricsRegistry::new()),
+                &MetricsRegistry::new(),
                 Arc::clone(&dependencies.time_source) as Arc<_>,
             );
             Self {

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -9,7 +9,9 @@ use ic_artifact_pool::{
     consensus_pool::{ConsensusPoolImpl, UncachedConsensusPoolImpl},
 };
 use ic_config::{artifact_pool::ArtifactPoolConfig, subnet_config::SubnetConfig, Config};
-use ic_consensus::{certification::VerifierImpl, consensus::batch_delivery::deliver_batches};
+use ic_consensus::{
+    certification::VerifierImpl, consensus::batch_delivery::deliver_batches_without_metrics,
+};
 use ic_consensus_utils::{
     crypto_hashable_to_seed, lookup_replica_version, membership::Membership,
     pool_reader::PoolReader,
@@ -694,7 +696,7 @@ impl Player {
     ) -> Height {
         let expected_batch_height = message_routing.expected_batch_height();
         let last_batch_height = loop {
-            match deliver_batches(
+            match deliver_batches_without_metrics(
                 message_routing,
                 membership,
                 pool,
@@ -702,7 +704,6 @@ impl Player {
                 self.subnet_id,
                 &self.log,
                 replay_target_height,
-                None,
             ) {
                 Ok(h) => break h,
                 Err(MessageRoutingError::QueueIsFull) => std::thread::sleep(WAIT_DURATION),

--- a/rs/replay/src/validator.rs
+++ b/rs/replay/src/validator.rs
@@ -6,10 +6,7 @@ use std::{
 
 use ic_artifact_pool::{consensus_pool::ConsensusPoolImpl, dkg_pool::DkgPoolImpl};
 use ic_config::{artifact_pool::ArtifactPoolConfig, Config};
-use ic_consensus::{
-    certification::CertificationCrypto,
-    consensus::{validator::Validator, ValidatorMetrics},
-};
+use ic_consensus::{certification::CertificationCrypto, consensus::validator::Validator};
 use ic_consensus_dkg::DkgKeyManager;
 use ic_consensus_utils::{
     active_high_threshold_nidkg_id, crypto::ConsensusCrypto, membership::Membership,
@@ -132,7 +129,7 @@ impl ReplayValidator {
             message_routing,
             Arc::new(dkg_pool) as Arc<_>,
             log.clone(),
-            ValidatorMetrics::new(metrics_registry.clone()),
+            &metrics_registry,
             time_source.clone(),
         );
 


### PR DESCRIPTION
There is no reason to leak them to outside.

Also, changed the type of `result_processor` from `Option<Fn<_>>` to `Fn<_>` and pass a no-op function in place of `None`