### PR TITLE
feat(sns): Add `Neuron.topic_followees`

### DIFF
--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -88,9 +88,12 @@ pub struct Neuron {
     /// dissolving neurons always has age zero. The canonical value of
     /// this field for a dissolving neuron is `u64::MAX`.
     pub aging_since_timestamp_seconds: u64,
-    /// The neuron's followees, specified as a map of proposal functions IDs to followees neuron IDs.
-    /// The map's keys are represented by integers as Protobuf does not support enum keys in maps.
+    /// The neuron's legacy followees (per proposal type), specified as a map of
+    /// proposal functions IDs. The map's keys are represented by integers as Protobuf does
+    /// not support enum keys in maps.
     pub followees: BTreeMap<u64, neuron::Followees>,
+    /// The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
+    pub topic_followees: Option<BTreeMap<topics::Topic, neuron::Followees>>,
     /// The accumulated unstaked maturity of the neuron, measured in "e8s equivalent", i.e., in equivalent of
     /// 10E-8 of a governance token.
     ///

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -93,7 +93,7 @@ pub struct Neuron {
     /// not support enum keys in maps.
     pub followees: BTreeMap<u64, neuron::Followees>,
     /// The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
-    pub topic_followees: Option<BTreeMap<topics::Topic, neuron::Followees>>,
+    pub topic_followees: Option<BTreeMap<u64, neuron::Followees>>,
     /// The accumulated unstaked maturity of the neuron, measured in "e8s equivalent", i.e., in equivalent of
     /// 10E-8 of a governance token.
     ///

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -93,7 +93,7 @@ pub struct Neuron {
     /// not support enum keys in maps.
     pub followees: BTreeMap<u64, neuron::Followees>,
     /// The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
-    pub topic_followees: Option<BTreeMap<u64, neuron::Followees>>,
+    pub topic_followees: Option<neuron::TopicFollowees>,
     /// The accumulated unstaked maturity of the neuron, measured in "e8s equivalent", i.e., in equivalent of
     /// 10E-8 of a governance token.
     ///
@@ -155,11 +155,20 @@ pub struct Neuron {
 }
 /// Nested message and enum types in `Neuron`.
 pub mod neuron {
+    use std::collections::BTreeMap;
+
     /// A list of a neuron's followees for a specific function.
     #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
     pub struct Followees {
         pub followees: Vec<super::NeuronId>,
     }
+
+    // A collection of a neuron's followees (per topic).
+    #[derive(candid::CandidType, candid::Deserialize, Clone, Debug, PartialEq)]
+    pub struct TopicFollowees {
+        pub topic_id_to_followees: BTreeMap<u64, Followees>,
+    }
+
     /// The neuron's dissolve state, specifying whether the neuron is dissolving,
     /// non-dissolving, or dissolved.
     ///

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -506,7 +506,7 @@ type Neuron = record {
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;
   followees : vec record { nat64; Followees };
-  topic_followees : opt vec record { Topic; Followees };
+  topic_followees : opt vec record { nat64; Followees };
   neuron_fees_e8s : nat64;
 };
 

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -506,6 +506,7 @@ type Neuron = record {
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;
   followees : vec record { nat64; Followees };
+  topic_followees : opt vec record { Topic; Followees };
   neuron_fees_e8s : nat64;
 };
 
@@ -520,16 +521,6 @@ type NeuronIds = record {
 type NeuronInFlightCommand = record {
   command : opt Command_2;
   timestamp : nat64;
-};
-
-type NeuronParameters = record {
-  controller : opt principal;
-  dissolve_delay_seconds : opt nat64;
-  source_nns_neuron_id : opt nat64;
-  stake_e8s : opt nat64;
-  followees : vec NeuronId;
-  hotkey : opt principal;
-  neuron_id : opt NeuronId;
 };
 
 type NeuronPermission = record {

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -506,7 +506,9 @@ type Neuron = record {
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;
   followees : vec record { nat64; Followees };
-  topic_followees : opt vec record { nat64; Followees };
+  topic_followees : opt record {
+    topic_id_to_followees : vec record { nat64; Followees };
+  };
   neuron_fees_e8s : nat64;
 };
 

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -520,6 +520,7 @@ type Neuron = record {
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;
   followees : vec record { nat64; Followees };
+  topic_followees : opt vec record { Topic; Followees };
   neuron_fees_e8s : nat64;
 };
 
@@ -534,16 +535,6 @@ type NeuronIds = record {
 type NeuronInFlightCommand = record {
   command : opt Command_2;
   timestamp : nat64;
-};
-
-type NeuronParameters = record {
-  controller : opt principal;
-  dissolve_delay_seconds : opt nat64;
-  source_nns_neuron_id : opt nat64;
-  stake_e8s : opt nat64;
-  followees : vec NeuronId;
-  hotkey : opt principal;
-  neuron_id : opt NeuronId;
 };
 
 type NeuronPermission = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -520,7 +520,7 @@ type Neuron = record {
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;
   followees : vec record { nat64; Followees };
-  topic_followees : opt vec record { Topic; Followees };
+  topic_followees : opt vec record { nat64; Followees };
   neuron_fees_e8s : nat64;
 };
 

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -520,7 +520,9 @@ type Neuron = record {
   vesting_period_seconds : opt nat64;
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;
   followees : vec record { nat64; Followees };
-  topic_followees : opt vec record { nat64; Followees };
+  topic_followees : opt record {
+    topic_id_to_followees : vec record { nat64; Followees };
+  };
   neuron_fees_e8s : nat64;
 };
 

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -164,13 +164,18 @@ message Neuron {
     repeated NeuronId followees = 1;
   }
 
+  // A collection of a neuron's followees (per topic).
+  message TopicFollowees {
+    map<uint64, Followees> topic_id_to_followees = 1;
+  }
+
   // The neuron's legacy followees (per proposal type), specified as a map of proposal functions IDs
   // to followees neuron IDs. The map's keys are represented by integers as Protobuf does not
   // support enum keys in maps.
   map<uint64, Followees> followees = 11;
 
   // The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
-  map<uint64, Followees> topic_followees = 19;
+  optional TopicFollowees topic_followees = 19;
 
   // The accumulated unstaked maturity of the neuron, measured in "e8s equivalent", i.e., in equivalent of
   // 10E-8 of a governance token.

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -164,9 +164,13 @@ message Neuron {
     repeated NeuronId followees = 1;
   }
 
-  // The neuron's followees, specified as a map of proposal functions IDs to followees neuron IDs.
-  // The map's keys are represented by integers as Protobuf does not support enum keys in maps.
+  // The neuron's legacy followees (per proposal type), specified as a map of proposal functions IDs
+  // to followees neuron IDs. The map's keys are represented by integers as Protobuf does not
+  // support enum keys in maps.
   map<uint64, Followees> followees = 11;
+
+  // The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
+  map<int32, Followees> topic_followees = 19;
 
   // The accumulated unstaked maturity of the neuron, measured in "e8s equivalent", i.e., in equivalent of
   // 10E-8 of a governance token.
@@ -2074,8 +2078,7 @@ message GetModeResponse {
 
 // The request for the `claim_swap_neurons` method.
 message ClaimSwapNeuronsRequest {
-  // Replacement for NeuronParameters. Contains the information needed to set up
-  // a neuron for a swap participant.
+  // Contains the information needed to set up a neuron for a swap participant.
   message NeuronRecipe {
     // The info that for a participant in the Neurons' Fund
     message NeuronsFund {
@@ -2100,6 +2103,7 @@ message ClaimSwapNeuronsRequest {
 
     // The duration in seconds that the neuron's dissolve delay will be set to.
     optional uint64 dissolve_delay_seconds = 4;
+
     // The neurons this neuron should follow
     optional NeuronIds followees = 5;
 

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -170,7 +170,7 @@ message Neuron {
   map<uint64, Followees> followees = 11;
 
   // The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
-  map<int32, Followees> topic_followees = 19;
+  map<uint64, Followees> topic_followees = 19;
 
   // The accumulated unstaked maturity of the neuron, measured in "e8s equivalent", i.e., in equivalent of
   // 10E-8 of a governance token.

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -114,10 +114,14 @@ pub struct Neuron {
     /// this field for a dissolving neuron is `u64::MAX`.
     #[prost(uint64, tag = "6")]
     pub aging_since_timestamp_seconds: u64,
-    /// The neuron's followees, specified as a map of proposal functions IDs to followees neuron IDs.
-    /// The map's keys are represented by integers as Protobuf does not support enum keys in maps.
+    /// The neuron's legacy followees (per proposal type), specified as a map of proposal functions IDs
+    /// to followees neuron IDs. The map's keys are represented by integers as Protobuf does not
+    /// support enum keys in maps.
     #[prost(btree_map = "uint64, message", tag = "11")]
     pub followees: ::prost::alloc::collections::BTreeMap<u64, neuron::Followees>,
+    /// The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
+    #[prost(btree_map = "int32, message", tag = "19")]
+    pub topic_followees: ::prost::alloc::collections::BTreeMap<i32, neuron::Followees>,
     /// The accumulated unstaked maturity of the neuron, measured in "e8s equivalent", i.e., in equivalent of
     /// 10E-8 of a governance token.
     ///
@@ -3248,8 +3252,7 @@ pub struct ClaimSwapNeuronsRequest {
 }
 /// Nested message and enum types in `ClaimSwapNeuronsRequest`.
 pub mod claim_swap_neurons_request {
-    /// Replacement for NeuronParameters. Contains the information needed to set up
-    /// a neuron for a swap participant.
+    /// Contains the information needed to set up a neuron for a swap participant.
     #[derive(
         candid::CandidType,
         candid::Deserialize,

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -120,8 +120,8 @@ pub struct Neuron {
     #[prost(btree_map = "uint64, message", tag = "11")]
     pub followees: ::prost::alloc::collections::BTreeMap<u64, neuron::Followees>,
     /// The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
-    #[prost(btree_map = "uint64, message", tag = "19")]
-    pub topic_followees: ::prost::alloc::collections::BTreeMap<u64, neuron::Followees>,
+    #[prost(message, optional, tag = "19")]
+    pub topic_followees: ::core::option::Option<neuron::TopicFollowees>,
     /// The accumulated unstaked maturity of the neuron, measured in "e8s equivalent", i.e., in equivalent of
     /// 10E-8 of a governance token.
     ///
@@ -203,6 +203,19 @@ pub mod neuron {
     pub struct Followees {
         #[prost(message, repeated, tag = "1")]
         pub followees: ::prost::alloc::vec::Vec<super::NeuronId>,
+    }
+    /// A collection of a neuron's followees (per topic).
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct TopicFollowees {
+        #[prost(btree_map = "uint64, message", tag = "1")]
+        pub topic_id_to_followees: ::prost::alloc::collections::BTreeMap<u64, Followees>,
     }
     /// The neuron's dissolve state, specifying whether the neuron is dissolving,
     /// non-dissolving, or dissolved.

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -120,8 +120,8 @@ pub struct Neuron {
     #[prost(btree_map = "uint64, message", tag = "11")]
     pub followees: ::prost::alloc::collections::BTreeMap<u64, neuron::Followees>,
     /// The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
-    #[prost(btree_map = "int32, message", tag = "19")]
-    pub topic_followees: ::prost::alloc::collections::BTreeMap<i32, neuron::Followees>,
+    #[prost(btree_map = "uint64, message", tag = "19")]
+    pub topic_followees: ::prost::alloc::collections::BTreeMap<u64, neuron::Followees>,
     /// The accumulated unstaked maturity of the neuron, measured in "e8s equivalent", i.e., in equivalent of
     /// 10E-8 of a governance token.
     ///

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -103,7 +103,7 @@ use ic_sns_governance_token_valuation::Valuation;
 use icp_ledger::DEFAULT_TRANSFER_FEE as NNS_DEFAULT_TRANSFER_FEE;
 use icrc_ledger_types::icrc1::account::{Account, Subaccount};
 use lazy_static::lazy_static;
-use maplit::hashset;
+use maplit::{btreemap, hashset};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::{
@@ -1372,6 +1372,7 @@ impl Governance {
             created_timestamp_seconds: creation_timestamp_seconds,
             aging_since_timestamp_seconds: parent_neuron.aging_since_timestamp_seconds,
             followees: parent_neuron.followees.clone(),
+            topic_followees: parent_neuron.topic_followees.clone(),
             maturity_e8s_equivalent: 0,
             dissolve_state: parent_neuron.dissolve_state,
             voting_power_percentage_multiplier: parent_neuron.voting_power_percentage_multiplier,
@@ -4111,6 +4112,7 @@ impl Governance {
             created_timestamp_seconds: now,
             aging_since_timestamp_seconds: now,
             followees: self.default_followees_or_panic().followees,
+            topic_followees: btreemap! {},
             maturity_e8s_equivalent: 0,
             dissolve_state: Some(DissolveState::DissolveDelaySeconds(0)),
             // A neuron created through the `claim_or_refresh` ManageNeuron command will
@@ -4277,6 +4279,7 @@ impl Governance {
                 created_timestamp_seconds: now,
                 aging_since_timestamp_seconds: now,
                 followees: neuron_recipe.construct_followees(),
+                topic_followees: neuron_recipe.construct_topic_followees(),
                 maturity_e8s_equivalent: 0,
                 dissolve_state: Some(DissolveState::DissolveDelaySeconds(
                     neuron_recipe.get_dissolve_delay_seconds_or_panic(),

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -33,7 +33,7 @@ use crate::{
                 DisburseMaturityResponse, MergeMaturityResponse, StakeMaturityResponse,
             },
             nervous_system_function::FunctionType,
-            neuron::{DissolveState, Followees},
+            neuron::{DissolveState, Followees, TopicFollowees},
             proposal::Action,
             proposal_data::ActionAuxiliary as ActionAuxiliaryPb,
             transfer_sns_treasury_funds::TransferFrom,
@@ -4112,7 +4112,9 @@ impl Governance {
             created_timestamp_seconds: now,
             aging_since_timestamp_seconds: now,
             followees: self.default_followees_or_panic().followees,
-            topic_followees: btreemap! {},
+            topic_followees: Some(TopicFollowees {
+                topic_id_to_followees: btreemap! {},
+            }),
             maturity_e8s_equivalent: 0,
             dissolve_state: Some(DissolveState::DissolveDelaySeconds(0)),
             // A neuron created through the `claim_or_refresh` ManageNeuron command will
@@ -4279,7 +4281,7 @@ impl Governance {
                 created_timestamp_seconds: now,
                 aging_since_timestamp_seconds: now,
                 followees: neuron_recipe.construct_followees(),
-                topic_followees: neuron_recipe.construct_topic_followees(),
+                topic_followees: Some(neuron_recipe.construct_topic_followees()),
                 maturity_e8s_equivalent: 0,
                 dissolve_state: Some(DissolveState::DissolveDelaySeconds(
                     neuron_recipe.get_dissolve_delay_seconds_or_panic(),

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -77,8 +77,35 @@ impl From<pb_api::DisburseMaturityInProgress> for pb::DisburseMaturityInProgress
     }
 }
 
+/// Converts an internal encoding of a topic into an optional `pb_api::Topic` instance.
+fn topic_id_to_api(topic_id: i32) -> Option<pb_api::topics::Topic> {
+    let Ok(topic) = pb::Topic::try_from(topic_id) else {
+        // The topic ID is invalid; this could happen in a highly unexpected situation, e.g.,
+        // if Governance is downgraded from a version that had new topics to an older version
+        // with fewer topics.
+        return None;
+    };
+    let Ok(topic) = pb_api::topics::Topic::try_from(topic) else {
+        // This is `pb::Topic::Unspecified`, which should be a forbidden value throughout
+        // the implementation of Governance. This case is there because of Prost's encoding
+        // of enumerations, which always starts with a special `0_i32` value.
+        return None;
+    };
+    Some(topic)
+}
+
 impl From<pb::Neuron> for pb_api::Neuron {
     fn from(item: pb::Neuron) -> Self {
+        let topic_followees = Some(
+            item.topic_followees
+                .into_iter()
+                .filter_map(|(topic_id, followees)| {
+                    let followees = pb_api::neuron::Followees::from(followees);
+                    topic_id_to_api(topic_id).map(|topic| (topic, followees))
+                })
+                .collect(),
+        );
+
         Self {
             id: item.id.map(|x| x.into()),
             permissions: item.permissions.into_iter().map(|x| x.into()).collect(),
@@ -91,6 +118,7 @@ impl From<pb::Neuron> for pb_api::Neuron {
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
+            topic_followees,
             maturity_e8s_equivalent: item.maturity_e8s_equivalent,
             voting_power_percentage_multiplier: item.voting_power_percentage_multiplier,
             source_nns_neuron_id: item.source_nns_neuron_id,
@@ -108,6 +136,17 @@ impl From<pb::Neuron> for pb_api::Neuron {
 }
 impl From<pb_api::Neuron> for pb::Neuron {
     fn from(item: pb_api::Neuron) -> Self {
+        let topic_followees = item
+            .topic_followees
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(topic, followees)| {
+                let topic = i32::from(pb::Topic::from(topic));
+                let followees = pb::neuron::Followees::from(followees);
+                (topic, followees)
+            })
+            .collect();
+
         Self {
             id: item.id.map(|x| x.into()),
             permissions: item.permissions.into_iter().map(|x| x.into()).collect(),
@@ -120,6 +159,7 @@ impl From<pb_api::Neuron> for pb::Neuron {
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
+            topic_followees,
             maturity_e8s_equivalent: item.maturity_e8s_equivalent,
             voting_power_percentage_multiplier: item.voting_power_percentage_multiplier,
             source_nns_neuron_id: item.source_nns_neuron_id,
@@ -203,12 +243,8 @@ impl From<pb::nervous_system_function::GenericNervousSystemFunction>
     for pb_api::nervous_system_function::GenericNervousSystemFunction
 {
     fn from(item: pb::nervous_system_function::GenericNervousSystemFunction) -> Self {
-        let topic = item
-            .topic
-            .and_then(|topic| pb::Topic::try_from(topic).ok())
-            .and_then(|topic| pb_api::topics::Topic::try_from(topic).ok());
         Self {
-            topic,
+            topic: item.topic.and_then(topic_id_to_api),
             target_canister_id: item.target_canister_id,
             target_method_name: item.target_method_name,
             validator_canister_id: item.validator_canister_id,
@@ -593,16 +629,8 @@ impl From<pb::SetTopicsForCustomProposals> for pb_api::SetTopicsForCustomProposa
         let custom_function_id_to_topic = item
             .custom_function_id_to_topic
             .into_iter()
-            .filter_map(|(custom_function_id, topic)| {
-                let Ok(topic) = pb::Topic::try_from(topic) else {
-                    return None;
-                };
-
-                let Ok(topic) = pb_api::topics::Topic::try_from(topic) else {
-                    return None;
-                };
-
-                Some((custom_function_id, topic))
+            .filter_map(|(custom_function_id, topic_id)| {
+                topic_id_to_api(topic_id).map(|topic| (custom_function_id, topic))
             })
             .collect();
 
@@ -968,12 +996,7 @@ impl From<pb::ProposalData> for pb_api::ProposalData {
             minimum_yes_proportion_of_total: item.minimum_yes_proportion_of_total,
             minimum_yes_proportion_of_exercised: item.minimum_yes_proportion_of_exercised,
             action_auxiliary: item.action_auxiliary.map(|x| x.into()),
-            topic: item.topic.and_then(|topic| {
-                let Ok(topic) = pb::Topic::try_from(topic) else {
-                    return None;
-                };
-                pb_api::topics::Topic::try_from(topic).ok()
-            }),
+            topic: item.topic.and_then(topic_id_to_api),
         }
     }
 }

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -79,14 +79,21 @@ impl From<pb_api::DisburseMaturityInProgress> for pb::DisburseMaturityInProgress
 
 impl From<pb::Neuron> for pb_api::Neuron {
     fn from(item: pb::Neuron) -> Self {
-        let topic_followees = Some(
-            item.topic_followees
-                .into_iter()
-                .map(|(topic, followees)| {
-                    let followees = pb_api::neuron::Followees::from(followees);
-                    (topic, followees)
-                })
-                .collect(),
+        let topic_followees = item.topic_followees.map(
+            |pb::neuron::TopicFollowees {
+                 topic_id_to_followees,
+             }| {
+                let topic_id_to_followees = topic_id_to_followees
+                    .into_iter()
+                    .map(|(topic, followees)| {
+                        let followees = pb_api::neuron::Followees::from(followees);
+                        (topic, followees)
+                    })
+                    .collect();
+                pb_api::neuron::TopicFollowees {
+                    topic_id_to_followees,
+                }
+            },
         );
 
         Self {
@@ -119,15 +126,22 @@ impl From<pb::Neuron> for pb_api::Neuron {
 }
 impl From<pb_api::Neuron> for pb::Neuron {
     fn from(item: pb_api::Neuron) -> Self {
-        let topic_followees = item
-            .topic_followees
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(topic, followees)| {
-                let followees = pb::neuron::Followees::from(followees);
-                (topic, followees)
-            })
-            .collect();
+        let topic_followees = item.topic_followees.map(
+            |pb_api::neuron::TopicFollowees {
+                 topic_id_to_followees,
+             }| {
+                let topic_id_to_followees = topic_id_to_followees
+                    .into_iter()
+                    .map(|(topic, followees)| {
+                        let followees = pb::neuron::Followees::from(followees);
+                        (topic, followees)
+                    })
+                    .collect();
+                pb::neuron::TopicFollowees {
+                    topic_id_to_followees,
+                }
+            },
+        );
 
         Self {
             id: item.id.map(|x| x.into()),

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -2304,7 +2304,7 @@ impl NeuronRecipe {
 
     // TODO[NNS1-3676]: Provide a proper implementation for this function once new SNSs are
     // TODO[NNS1-3676]: to begin using topics-based following.
-    pub(crate) fn construct_topic_followees(&self) -> BTreeMap<i32, Followees> {
+    pub(crate) fn construct_topic_followees(&self) -> BTreeMap<u64, Followees> {
         btreemap! {}
     }
 

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -2302,6 +2302,12 @@ impl NeuronRecipe {
         }
     }
 
+    // TODO[NNS1-3676]: Provide a proper implementation for this function once new SNSs are
+    // TODO[NNS1-3676]: to begin using topics-based following.
+    pub(crate) fn construct_topic_followees(&self) -> BTreeMap<i32, Followees> {
+        btreemap! {}
+    }
+
     pub(crate) fn construct_auto_staking_maturity(&self) -> Option<bool> {
         if self.is_neurons_fund_neuron() {
             Some(true)

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -24,7 +24,7 @@ use crate::{
                 self, DisburseMaturityResponse, MergeMaturityResponse, StakeMaturityResponse,
             },
             nervous_system_function::FunctionType,
-            neuron::Followees,
+            neuron::{Followees, TopicFollowees},
             proposal::Action,
             ChunkedCanisterWasm, ClaimSwapNeuronsError, ClaimSwapNeuronsResponse,
             ClaimedSwapNeuronStatus, DefaultFollowees, DeregisterDappCanisters, Empty,
@@ -2304,8 +2304,10 @@ impl NeuronRecipe {
 
     // TODO[NNS1-3676]: Provide a proper implementation for this function once new SNSs are
     // TODO[NNS1-3676]: to begin using topics-based following.
-    pub(crate) fn construct_topic_followees(&self) -> BTreeMap<u64, Followees> {
-        btreemap! {}
+    pub(crate) fn construct_topic_followees(&self) -> TopicFollowees {
+        TopicFollowees {
+            topic_id_to_followees: btreemap! {},
+        }
     }
 
     pub(crate) fn construct_auto_staking_maturity(&self) -> Option<bool> {

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -9,6 +9,8 @@ on the process that this file is part of, see
 
 ## Added
 
+* Added `Neuron.topic_followees` to support the upcoming [SNS topics](https://forum.dfinity.org/t/sns-topics-design) feature
+
 ## Changed
 
 * Proposal criticality is now defined based on topics. This makes the following two native proposal

--- a/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
+++ b/rs/sns/swap/proto/ic_sns_swap/pb/v1/swap.proto
@@ -769,8 +769,7 @@ message SnsNeuronRecipe {
     CLAIMED_STATUS_FAILED = 3;
 
     // The Neuron is invalid and was not created in SNS Governance. This neuron
-    // cannot be retried without manual intervention to update its
-    // `NeuronParameters`.
+    // cannot be retried without manual intervention to update its `NeuronRecipe`.
     CLAIMED_STATUS_INVALID = 4;
   }
 }

--- a/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
+++ b/rs/sns/swap/src/gen/ic_sns_swap.pb.v1.rs
@@ -896,8 +896,7 @@ pub mod sns_neuron_recipe {
         /// be retried in the future.
         Failed = 3,
         /// The Neuron is invalid and was not created in SNS Governance. This neuron
-        /// cannot be retried without manual intervention to update its
-        /// `NeuronParameters`.
+        /// cannot be retried without manual intervention to update its `NeuronRecipe`.
         Invalid = 4,
     }
     impl ClaimedStatus {


### PR DESCRIPTION
This PR adds `Neuron.topic_followees` to support the upcoming SNS topics feature.

Additionally, this PR
- Adds a forward reference to NNS1-3676 in which we plan to implement `construct_topic_followees` for neurons newly created after a swap.
- Removes the unused API type `NeuronParameters`
- Factors out the `topic_id_to_api` function to support type mappings in rs/sns/governance/src/pb/conversions.rs
- Cleans up some code docs.

| [Next PR](https://github.com/dfinity/ic/pull/4442) >