### PR TITLE
chore(node): Increase HostOS upgrade download timeout

### DIFF
--- a/rs/ic_os/vsock/vsock_lib/src/host/agent.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/host/agent.rs
@@ -73,6 +73,7 @@ fn notify(notify_data: &NotifyData) -> Response {
 
 fn create_hostos_upgrade_file(upgrade_url: &str, file_path: &str) -> Result<(), String> {
     let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
         .build()
         .map_err(|err| format!("Could not build download client: {}", err))?;
 


### PR DESCRIPTION
The default timeout for HostOS upgrade downloads was 30 seconds. This increases it to 120 seconds. 

If an upgrade fails, nodes loop trying to upgrade, so bumping the download timeout does not come with much drawback.