### PR TITLE
chore(PocketIC): no subnet ID required when mounting existing subnet state

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - The module `management_canister` used to contain interface types of the IC management canister. Those types have since been published on crates.io as `ic-management-canister-types`, so PocketIC can depend on that and remove the redundant types.
+- The subnet ID from the functions `SubnetSpec::with_state_dir`, `PocketIcBuilder::with_nns_state`, and `PocketIcBuilder::with_subnet_state`;
+  the subnet ID from the type `SubnetStateConfig`; and the functions `SubnetSpec::get_subnet_id` and `SubnetStateConfig::get_subnet_id`.
 
 ### Changed
 

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -554,8 +554,8 @@ pub struct SubnetSpec {
 }
 
 impl SubnetSpec {
-    pub fn with_state_dir(mut self, path: PathBuf, subnet_id: SubnetId) -> SubnetSpec {
-        self.state_config = SubnetStateConfig::FromPath(path, RawSubnetId::from(subnet_id));
+    pub fn with_state_dir(mut self, path: PathBuf) -> SubnetSpec {
+        self.state_config = SubnetStateConfig::FromPath(path);
         self
     }
 
@@ -566,14 +566,6 @@ impl SubnetSpec {
 
     pub fn get_state_path(&self) -> Option<PathBuf> {
         self.state_config.get_path()
-    }
-
-    pub fn get_subnet_id(&self) -> Option<RawSubnetId> {
-        match &self.state_config {
-            SubnetStateConfig::New => None,
-            SubnetStateConfig::FromPath(_, subnet_id) => Some(subnet_id.clone()),
-            SubnetStateConfig::FromBlobStore(_, subnet_id) => Some(subnet_id.clone()),
-        }
     }
 
     pub fn get_instruction_config(&self) -> SubnetInstructionConfig {
@@ -617,24 +609,17 @@ pub enum SubnetStateConfig {
     New,
     /// Load existing subnet state from the given path.
     /// The path must be on a filesystem accessible to the server process.
-    FromPath(PathBuf, RawSubnetId),
+    FromPath(PathBuf),
     /// Load existing subnet state from blobstore. Needs to be uploaded first!
     /// Not implemented!
-    FromBlobStore(BlobId, RawSubnetId),
+    FromBlobStore(BlobId),
 }
 
 impl SubnetStateConfig {
     pub fn get_path(&self) -> Option<PathBuf> {
         match self {
-            SubnetStateConfig::FromPath(path, _) => Some(path.clone()),
-            SubnetStateConfig::FromBlobStore(_, _) => None,
-            SubnetStateConfig::New => None,
-        }
-    }
-    pub fn get_subnet_id(&self) -> Option<RawSubnetId> {
-        match self {
-            SubnetStateConfig::FromPath(_, id) => Some(id.clone()),
-            SubnetStateConfig::FromBlobStore(_, id) => Some(id.clone()),
+            SubnetStateConfig::FromPath(path) => Some(path.clone()),
+            SubnetStateConfig::FromBlobStore(_) => None,
             SubnetStateConfig::New => None,
         }
     }
@@ -643,14 +628,7 @@ impl SubnetStateConfig {
 impl ExtendedSubnetConfigSet {
     // Return the configured named subnets in order.
     #[allow(clippy::type_complexity)]
-    pub fn get_named(
-        &self,
-    ) -> Vec<(
-        SubnetKind,
-        Option<PathBuf>,
-        Option<RawSubnetId>,
-        SubnetInstructionConfig,
-    )> {
+    pub fn get_named(&self) -> Vec<(SubnetKind, Option<PathBuf>, SubnetInstructionConfig)> {
         use SubnetKind::*;
         vec![
             (self.nns.clone(), NNS),
@@ -663,12 +641,7 @@ impl ExtendedSubnetConfigSet {
         .filter(|(mb, _)| mb.is_some())
         .map(|(mb, kind)| {
             let spec = mb.unwrap();
-            (
-                kind,
-                spec.get_state_path(),
-                spec.get_subnet_id(),
-                spec.get_instruction_config(),
-            )
+            (kind, spec.get_state_path(), spec.get_instruction_config())
         })
         .collect()
     }

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -230,23 +230,8 @@ impl PocketIcBuilder {
     ///  |-- states_metadata.pbuf
     ///  |-- tip
     ///  `-- tmp
-    ///
-    /// `nns_subnet_id` should be the subnet ID of the NNS subnet in the state under
-    /// `path_to_state`, e.g.:
-    /// ```rust
-    /// use pocket_ic::common::rest::SubnetId;
-    ///
-    /// let nns_subnet_id: SubnetId = candid::Principal::from_text(
-    ///     "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe",
-    /// ).unwrap().into();
-    /// ```
-    ///
-    /// The subnet ID of the NNS subnet can be obtained, e.g., via the following command:
-    /// ```sh
-    /// ic-regedit snapshot <path-to-ic_registry_local_store> | jq -r ".nns_subnet_id"
-    /// ```
-    pub fn with_nns_state(self, nns_subnet_id: SubnetId, path_to_state: PathBuf) -> Self {
-        self.with_subnet_state(SubnetKind::NNS, nns_subnet_id, path_to_state)
+    pub fn with_nns_state(self, path_to_state: PathBuf) -> Self {
+        self.with_subnet_state(SubnetKind::NNS, path_to_state)
     }
 
     /// Add a subnet with state loaded from the given state directory.
@@ -265,16 +250,9 @@ impl PocketIcBuilder {
     ///  |-- states_metadata.pbuf
     ///  |-- tip
     ///  `-- tmp
-    ///
-    /// `subnet_id` should be the subnet ID of the subnet in the state to be loaded
-    pub fn with_subnet_state(
-        mut self,
-        subnet_kind: SubnetKind,
-        subnet_id: Principal,
-        path_to_state: PathBuf,
-    ) -> Self {
+    pub fn with_subnet_state(mut self, subnet_kind: SubnetKind, path_to_state: PathBuf) -> Self {
         let mut config = self.config.unwrap_or_default();
-        let subnet_spec = SubnetSpec::default().with_state_dir(path_to_state, subnet_id);
+        let subnet_spec = SubnetSpec::default().with_state_dir(path_to_state);
         match subnet_kind {
             SubnetKind::NNS => config.nns = Some(subnet_spec),
             SubnetKind::SNS => config.sns = Some(subnet_spec),

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -633,10 +633,6 @@ impl PocketIc {
     ) -> Self {
         let mut range_gen = RangeGen::new();
         let mut routing_table = RoutingTable::new();
-        let mut nns_subnet_id = subnet_configs.nns.as_ref().and_then(|x| {
-            x.get_subnet_id()
-                .map(|y| SubnetId::new(PrincipalId(y.into())))
-        });
         let mut nns_subnet = None;
 
         let topology: Option<RawTopologyInternal> = if let Some(ref state_dir) = state_dir {
@@ -657,7 +653,6 @@ impl PocketIc {
                     state_machine_state_dir: Box::new(
                         state_dir.as_ref().unwrap().join(subnet_seed.clone()),
                     ),
-                    subnet_id: Some(config.subnet_config.subnet_id),
                     ranges: config.subnet_config.ranges,
                     alloc_range: config.subnet_config.alloc_range,
                     subnet_kind: config.subnet_config.subnet_kind,
@@ -673,7 +668,6 @@ impl PocketIc {
                     (
                         SubnetKind::System,
                         spec.get_state_path(),
-                        spec.get_subnet_id(),
                         spec.get_instruction_config(),
                     )
                 });
@@ -681,7 +675,6 @@ impl PocketIc {
                     (
                         SubnetKind::Application,
                         spec.get_state_path(),
-                        spec.get_subnet_id(),
                         spec.get_instruction_config(),
                     )
                 });
@@ -689,7 +682,6 @@ impl PocketIc {
                     (
                         SubnetKind::VerifiedApplication,
                         spec.get_state_path(),
-                        spec.get_subnet_id(),
                         spec.get_instruction_config(),
                     )
                 });
@@ -700,7 +692,7 @@ impl PocketIc {
 
             let ii_subnet_split = subnet_configs.ii.is_some();
 
-            for (subnet_kind, subnet_state_dir, subnet_id, instruction_config) in
+            for (subnet_kind, subnet_state_dir, instruction_config) in
                 fixed_range_subnets.into_iter().chain(flexible_subnets)
             {
                 let RangeConfig {
@@ -720,7 +712,6 @@ impl PocketIc {
 
                 subnet_config_info.push(SubnetConfigInfo {
                     state_machine_state_dir,
-                    subnet_id: subnet_id.map(|raw| SubnetId::new(PrincipalId(raw.into()))),
                     ranges,
                     alloc_range,
                     subnet_kind,
@@ -742,7 +733,6 @@ impl PocketIc {
         // Create all StateMachines and subnet configs from the subnet config infos.
         for SubnetConfigInfo {
             state_machine_state_dir,
-            subnet_id,
             ranges,
             alloc_range,
             subnet_kind,
@@ -773,10 +763,6 @@ impl PocketIc {
 
             if subnet_kind == SubnetKind::NNS {
                 builder = builder.with_root_subnet_config();
-            }
-
-            if let Some(subnet_id) = subnet_id {
-                builder = builder.with_subnet_id(subnet_id);
             }
 
             if subnet_kind == SubnetKind::II || subnet_kind == SubnetKind::Fiduciary {
@@ -814,11 +800,6 @@ impl PocketIc {
 
             let subnet_id = sm.get_subnet_id();
 
-            // Store the actual NNS subnet ID if none was provided by the client.
-            if let (SubnetKind::NNS, None) = (subnet_kind, nns_subnet_id) {
-                nns_subnet_id = Some(subnet_id);
-            };
-
             if let SubnetKind::NNS = subnet_kind {
                 nns_subnet = Some(sm.clone());
             }
@@ -848,7 +829,10 @@ impl PocketIc {
             .map(|config| config.subnet_id)
             .collect();
         finalize_registry(
-            nns_subnet_id.unwrap_or(subnet_configs.values().next().unwrap().subnet_id),
+            nns_subnet
+                .as_ref()
+                .map(|nns_subnet| nns_subnet.get_subnet_id())
+                .unwrap_or(subnet_configs.values().next().unwrap().subnet_id),
             routing_table.clone(),
             subnet_list,
             registry_data_provider.clone(),
@@ -1144,7 +1128,6 @@ struct RangeConfig {
 /// Internal struct used during initialization.
 struct SubnetConfigInfo {
     pub state_machine_state_dir: Box<dyn StateMachineStateDir>,
-    pub subnet_id: Option<SubnetId>,
     pub ranges: Vec<CanisterIdRange>,
     pub alloc_range: Option<CanisterIdRange>,
     pub subnet_kind: SubnetKind,

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -869,6 +869,68 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
     check_counter(&pic, app_canister_id, 3);
 }
 
+/// The following test is similar to `canister_state_dir`,
+/// but creates two app subnets on the original PocketIC instance
+/// and then checks that each of the two app subnets
+/// can be separately restored from its state.
+/// No canisters are deployed to the app subnets
+/// as restoring such states is not supported yet.
+#[test]
+fn with_subnet_state() {
+    // Create a temporary state directory persisted throughout the test.
+    let state_dir = TempDir::new().unwrap();
+    let state_dir_path_buf = state_dir.path().to_path_buf();
+
+    // Create a PocketIC instance with NNS and app subnets.
+    let (server_url, _) = start_server_helper(None, None, false, false);
+    let pic = PocketIcBuilder::new()
+        .with_state_dir(state_dir_path_buf.clone())
+        .with_server_url(server_url)
+        .with_nns_subnet()
+        .with_application_subnet()
+        .with_application_subnet()
+        .build();
+
+    // Retrieve the NNS and app subnets from the topology.
+    let topology = pic.topology();
+    let nns_subnet = topology.get_nns().unwrap();
+    let first_app_subnet = topology.get_app_subnets()[0];
+    let second_app_subnet = topology.get_app_subnets()[1];
+
+    drop(pic);
+
+    for app_subnet in [first_app_subnet, second_app_subnet] {
+        // Start a new PocketIC server.
+        let (new_server_url, _) = start_server_helper(None, None, false, false);
+
+        // Create a PocketIC instance mounting the NNS and app state created so far.
+        let nns_subnet_seed = topology
+            .subnet_configs
+            .get(&nns_subnet)
+            .unwrap()
+            .subnet_seed;
+        let nns_state_dir = state_dir.path().join(hex::encode(nns_subnet_seed));
+        let app_subnet_seed = topology
+            .subnet_configs
+            .get(&app_subnet)
+            .unwrap()
+            .subnet_seed;
+        let app_state_dir = state_dir.path().join(hex::encode(app_subnet_seed));
+        let pic = PocketIcBuilder::new()
+            .with_server_url(new_server_url)
+            .with_nns_state(nns_state_dir)
+            .with_subnet_state(SubnetKind::Application, app_state_dir)
+            .build();
+
+        // Check that the topology has been properly restored.
+        let topology = pic.topology();
+        assert_eq!(topology.get_nns().unwrap(), nns_subnet);
+        assert_eq!(topology.get_app_subnets()[0], app_subnet);
+        // We only specified to restore one app subnet.
+        assert_eq!(topology.get_app_subnets().len(), 1);
+    }
+}
+
 /// Test that PocketIC can handle synchronous update calls, i.e. `/api/v3/.../call`.
 #[test]
 fn test_specified_id_call_v3() {

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -844,8 +844,8 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
     let app_state_dir = state_dir.path().join(hex::encode(app_subnet_seed));
     let pic = PocketIcBuilder::new()
         .with_server_url(newest_server_url)
-        .with_nns_state(nns_subnet, nns_state_dir)
-        .with_subnet_state(SubnetKind::Application, app_subnet, app_state_dir)
+        .with_nns_state(nns_state_dir)
+        .with_subnet_state(SubnetKind::Application, app_state_dir)
         .build();
 
     // Check that the topology has been properly restored.

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -1551,19 +1551,6 @@ impl StateMachine {
             dummy_initial_dkg_transcript_with_master_key(&mut StdRng::from_seed(seed));
         let public_key = (&ni_dkg_transcript).try_into().unwrap();
         let public_key_der = threshold_sig_public_key_to_der(public_key).unwrap();
-        let subnet_id =
-            subnet_id.unwrap_or(PrincipalId::new_self_authenticating(&public_key_der).into());
-        let registry_client = make_nodes_registry(
-            subnet_id,
-            subnet_type,
-            &chain_keys_enabled_status,
-            features,
-            registry_data_provider.clone(),
-            &nodes,
-            is_root_subnet,
-            public_key,
-            ni_dkg_transcript,
-        );
 
         let mut sm_config = ic_config::state_manager::Config::new(state_dir.path().to_path_buf());
         if let Some(lsmt_override) = lsmt_override {
@@ -1576,12 +1563,9 @@ impl StateMachine {
             ..Default::default()
         };
 
-        let cycles_account_manager = Arc::new(CyclesAccountManager::new(
-            subnet_config.scheduler_config.max_instructions_per_message,
-            subnet_type,
-            subnet_id,
-            subnet_config.cycles_account_manager_config,
-        ));
+        // subnet ID used to bootstrap the initial state
+        let subnet_id =
+            subnet_id.unwrap_or(PrincipalId::new_self_authenticating(&public_key_der).into());
         let state_manager = Arc::new(StateManagerImpl::new(
             Arc::new(FakeVerifier),
             subnet_id,
@@ -1591,6 +1575,31 @@ impl StateMachine {
             &sm_config,
             None,
             malicious_flags.clone(),
+        ));
+        // override with the subnet ID stored in the state
+        let subnet_id = state_manager
+            .get_latest_state()
+            .take()
+            .metadata
+            .own_subnet_id;
+
+        let registry_client = make_nodes_registry(
+            subnet_id,
+            subnet_type,
+            &chain_keys_enabled_status,
+            features,
+            registry_data_provider.clone(),
+            &nodes,
+            is_root_subnet,
+            public_key,
+            ni_dkg_transcript,
+        );
+
+        let cycles_account_manager = Arc::new(CyclesAccountManager::new(
+            subnet_config.scheduler_config.max_instructions_per_message,
+            subnet_type,
+            subnet_id,
+            subnet_config.cycles_account_manager_config,
         ));
 
         // get the CUP from the registry


### PR DESCRIPTION
This PR simplifies PocketIC API for mounting existing subnet states: no subnet ID is required anymore as it can be extracted from the provided subnet state.