### PR TITLE
test(nervous_system): Add a test-only, state machine-based implementation for `ic-nervous-system-agent`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10278,6 +10278,7 @@ dependencies = [
  "ic-sns-root",
  "ic-sns-swap",
  "ic-sns-wasm",
+ "ic-state-machine-tests",
  "itertools 0.12.1",
  "pocket-ic",
  "registry-canister",

--- a/rs/nervous_system/agent/BUILD.bazel
+++ b/rs/nervous_system/agent/BUILD.bazel
@@ -43,13 +43,12 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-
 rust_library(
     name = "test_agent",
-    srcs = glob(["src/**/*.rs"]),
-    crate_name = "ic_nervous_system_agent",
-    crate_features = ["test"],
     testonly = True,
+    srcs = glob(["src/**/*.rs"]),
+    crate_features = ["test"],
+    crate_name = "ic_nervous_system_agent",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.0.1",
     deps = DEPENDENCIES + [

--- a/rs/nervous_system/agent/BUILD.bazel
+++ b/rs/nervous_system/agent/BUILD.bazel
@@ -43,6 +43,20 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
+
+rust_library(
+    name = "test_agent",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "ic_nervous_system_agent",
+    crate_features = ["test"],
+    testonly = True,
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    version = "0.0.1",
+    deps = DEPENDENCIES + [
+        "//rs/state_machine_tests",
+    ],
+)
+
 rust_test(
     name = "agent_test",
     crate = ":agent",

--- a/rs/nervous_system/agent/Cargo.toml
+++ b/rs/nervous_system/agent/Cargo.toml
@@ -31,3 +31,6 @@ serde_cbor = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+
+[features]
+test = []

--- a/rs/nervous_system/agent/Cargo.toml
+++ b/rs/nervous_system/agent/Cargo.toml
@@ -24,6 +24,7 @@ pocket-ic = { path = "../../../packages/pocket-ic" }
 registry-canister = { path = "../../registry/canister" }
 ic-sns-root = { path = "../../sns/root" }
 ic-sns-swap = { path = "../../sns/swap" }
+ic-state-machine-tests = { path = "../../state_machine_tests" }
 itertools = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -9,6 +9,8 @@ pub mod nns;
 mod null_request;
 pub mod pocketic_impl;
 pub mod sns;
+#[cfg(feature = "test")]
+pub mod state_machine_impl;
 
 // This is used to "seal" the CallCanisters trait so that it cannot be implemented outside of this crate.
 // This is useful because it means we can modify the trait in the future without worrying about

--- a/rs/nervous_system/agent/src/state_machine_impl.rs
+++ b/rs/nervous_system/agent/src/state_machine_impl.rs
@@ -1,0 +1,128 @@
+use crate::{CallCanisters, CanisterInfo, Request};
+use candid::Principal;
+use ic_base_types::{CanisterId, PrincipalId};
+use ic_state_machine_tests::{StateMachine, UserError, WasmResult};
+use std::time::Duration;
+use thiserror::Error;
+
+pub struct StateMachineAgent<'a> {
+    state_machine: &'a StateMachine,
+    sender: Principal,
+}
+
+impl<'a> StateMachineAgent<'a> {
+    pub fn new(state_machine: &'a StateMachine, sender: impl Into<Principal>) -> Self {
+        let sender = sender.into();
+        Self {
+            state_machine,
+            sender,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum StateMachineCallError {
+    #[error("state machine ingress state error: {0}")]
+    IngressStateError(UserError),
+    #[error("the canister being called decides to reject the message: {0}")]
+    MessageRejected(String),
+    #[error("canister does not exist: {0}")]
+    CanisterDoesNotExist(Principal),
+    #[error("canister request could not be encoded: {0}")]
+    CandidEncode(candid::Error),
+    #[error("canister did not respond with the expected response type: {0}")]
+    CandidDecode(candid::Error),
+}
+
+impl crate::sealed::Sealed for StateMachine {}
+impl crate::sealed::Sealed for StateMachineAgent<'_> {}
+
+impl CallCanisters for StateMachineAgent<'_> {
+    type Error = StateMachineCallError;
+
+    fn caller(&self) -> Result<Principal, Self::Error> {
+        Ok(self.sender)
+    }
+
+    async fn call<R: Request>(
+        &self,
+        canister_id: impl Into<Principal> + Send,
+        request: R,
+    ) -> Result<R::Response, Self::Error> {
+        // This is to be backward compatible with the previous implementation from
+        // /rs/nns/test_utils/src/state_test_helpers.rs
+        self.state_machine.advance_time(Duration::from_secs(2));
+
+        let request_bytes = request.payload().map_err(Self::Error::CandidEncode)?;
+
+        let canister_id =
+            CanisterId::unchecked_from_principal(PrincipalId::from(canister_id.into()));
+
+        let sender = PrincipalId::from(self.sender);
+
+        let response = self
+            .state_machine
+            .execute_ingress_as(sender, canister_id, request.method(), request_bytes)
+            .map_err(Self::Error::IngressStateError)?;
+
+        let response_bytes = match response {
+            WasmResult::Reply(bytes) => bytes,
+            WasmResult::Reject(err) => {
+                return Err(Self::Error::MessageRejected(err));
+            }
+        };
+
+        candid::decode_one(response_bytes.as_slice()).map_err(Self::Error::CandidDecode)
+    }
+
+    async fn canister_info(
+        &self,
+        canister_id: impl Into<candid::Principal> + Send,
+    ) -> Result<CanisterInfo, Self::Error> {
+        let canister_id = CanisterId::unchecked_from_principal(PrincipalId(canister_id.into()));
+
+        let module_hash = self
+            .state_machine
+            .module_hash(canister_id)
+            .map(|hash| hash.to_vec());
+
+        let Some(controllers) = self.state_machine.get_controllers(canister_id) else {
+            return Err(Self::Error::CanisterDoesNotExist(canister_id.get().0));
+        };
+
+        Ok(CanisterInfo {
+            module_hash,
+            controllers: controllers
+                .into_iter()
+                .map(|controller| controller.0)
+                .collect(),
+        })
+    }
+}
+
+impl CallCanisters for StateMachine {
+    type Error = StateMachineCallError;
+
+    fn caller(&self) -> Result<Principal, Self::Error> {
+        Ok(Principal::anonymous())
+    }
+
+    async fn call<R: crate::Request>(
+        &self,
+        canister_id: impl Into<Principal> + Send,
+        request: R,
+    ) -> Result<R::Response, Self::Error> {
+        StateMachineAgent::new(self, Principal::anonymous())
+            .call(canister_id, request)
+            .await
+    }
+
+    async fn canister_info(
+        &self,
+        canister_id: impl Into<candid::Principal> + Send,
+    ) -> Result<CanisterInfo, Self::Error> {
+        StateMachineAgent::new(self, Principal::anonymous())
+            .canister_info(canister_id)
+            .await
+    }
+}


### PR DESCRIPTION
This PR adds a test-only, state machine-based implementation for `ic-nervous-system-agent`. This is analogous to the existing PocketIC implementation. The state machine agent will be used in a follow-up PR to port SNS Governance tests to API types.