### PR TITLE
feat(sns): Add a new crate for SNS Governance API helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10278,6 +10278,7 @@ dependencies = [
  "ic-sns-root",
  "ic-sns-swap",
  "ic-sns-wasm",
+ "ic-state-machine-tests",
  "itertools 0.12.1",
  "pocket-ic",
  "registry-canister",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12577,6 +12577,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-sns-governance-api-helpers"
+version = "0.9.0"
+dependencies = [
+ "ic-nervous-system-common",
+ "ic-sns-governance-api",
+ "icrc-ledger-types",
+ "maplit",
+]
+
+[[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,6 +339,8 @@ members = [
     "rs/sns/audit",
     "rs/sns/cli",
     "rs/sns/governance",
+    "rs/sns/governance/api",
+    "rs/sns/governance/api_helpers",
     "rs/sns/governance/proposal_criticality",
     "rs/sns/governance/protobuf_generator",
     "rs/sns/governance/token_valuation",

--- a/rs/nervous_system/agent/BUILD.bazel
+++ b/rs/nervous_system/agent/BUILD.bazel
@@ -43,13 +43,12 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
-
 rust_library(
     name = "test_agent",
-    srcs = glob(["src/**/*.rs"]),
-    crate_name = "ic_nervous_system_agent",
-    crate_features = ["test"],
     testonly = True,
+    srcs = glob(["src/**/*.rs"]),
+    crate_features = ["test"],
+    crate_name = "ic_nervous_system_agent",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.0.1",
     deps = DEPENDENCIES + [

--- a/rs/nervous_system/agent/BUILD.bazel
+++ b/rs/nervous_system/agent/BUILD.bazel
@@ -43,6 +43,20 @@ rust_library(
     deps = DEPENDENCIES,
 )
 
+
+rust_library(
+    name = "test_agent",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "ic_nervous_system_agent",
+    crate_features = ["test"],
+    testonly = True,
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    version = "0.0.1",
+    deps = DEPENDENCIES + [
+        "//rs/state_machine_tests",
+    ],
+)
+
 rust_test(
     name = "agent_test",
     crate = ":agent",

--- a/rs/nervous_system/agent/Cargo.toml
+++ b/rs/nervous_system/agent/Cargo.toml
@@ -31,3 +31,6 @@ serde_cbor = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+
+[features]
+test = []

--- a/rs/nervous_system/agent/Cargo.toml
+++ b/rs/nervous_system/agent/Cargo.toml
@@ -24,6 +24,7 @@ pocket-ic = { path = "../../../packages/pocket-ic" }
 registry-canister = { path = "../../registry/canister" }
 ic-sns-root = { path = "../../sns/root" }
 ic-sns-swap = { path = "../../sns/swap" }
+ic-state-machine-tests = { path = "../../state_machine_tests" }
 itertools = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -9,6 +9,8 @@ pub mod nns;
 mod null_request;
 pub mod pocketic_impl;
 pub mod sns;
+#[cfg(feature = "test")]
+pub mod state_machine_impl;
 
 // This is used to "seal" the CallCanisters trait so that it cannot be implemented outside of this crate.
 // This is useful because it means we can modify the trait in the future without worrying about

--- a/rs/nervous_system/agent/src/state_machine_impl.rs
+++ b/rs/nervous_system/agent/src/state_machine_impl.rs
@@ -1,0 +1,128 @@
+use crate::{CallCanisters, CanisterInfo, Request};
+use candid::Principal;
+use ic_base_types::{CanisterId, PrincipalId};
+use ic_state_machine_tests::{StateMachine, UserError, WasmResult};
+use std::time::Duration;
+use thiserror::Error;
+
+pub struct StateMachineAgent<'a> {
+    state_machine: &'a StateMachine,
+    sender: Principal,
+}
+
+impl<'a> StateMachineAgent<'a> {
+    pub fn new(state_machine: &'a StateMachine, sender: impl Into<Principal>) -> Self {
+        let sender = sender.into();
+        Self {
+            state_machine,
+            sender,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum StateMachineCallError {
+    #[error("state machine ingress state error: {0}")]
+    IngressStateError(UserError),
+    #[error("the canister being called decides to reject the message: {0}")]
+    MessageRejected(String),
+    #[error("canister does not exist: {0}")]
+    CanisterDoesNotExist(Principal),
+    #[error("canister request could not be encoded: {0}")]
+    CandidEncode(candid::Error),
+    #[error("canister did not respond with the expected response type: {0}")]
+    CandidDecode(candid::Error),
+}
+
+impl crate::sealed::Sealed for StateMachine {}
+impl crate::sealed::Sealed for StateMachineAgent<'_> {}
+
+impl CallCanisters for StateMachineAgent<'_> {
+    type Error = StateMachineCallError;
+
+    fn caller(&self) -> Result<Principal, Self::Error> {
+        Ok(self.sender)
+    }
+
+    async fn call<R: Request>(
+        &self,
+        canister_id: impl Into<Principal> + Send,
+        request: R,
+    ) -> Result<R::Response, Self::Error> {
+        // This is to be backward compatible with the previous implementation from
+        // /rs/nns/test_utils/src/state_test_helpers.rs
+        self.state_machine.advance_time(Duration::from_secs(2));
+
+        let request_bytes = request.payload().map_err(Self::Error::CandidEncode)?;
+
+        let canister_id =
+            CanisterId::unchecked_from_principal(PrincipalId::from(canister_id.into()));
+
+        let sender = PrincipalId::from(self.sender);
+
+        let response = self
+            .state_machine
+            .execute_ingress_as(sender, canister_id, request.method(), request_bytes)
+            .map_err(Self::Error::IngressStateError)?;
+
+        let response_bytes = match response {
+            WasmResult::Reply(bytes) => bytes,
+            WasmResult::Reject(err) => {
+                return Err(Self::Error::MessageRejected(err));
+            }
+        };
+
+        candid::decode_one(response_bytes.as_slice()).map_err(Self::Error::CandidDecode)
+    }
+
+    async fn canister_info(
+        &self,
+        canister_id: impl Into<candid::Principal> + Send,
+    ) -> Result<CanisterInfo, Self::Error> {
+        let canister_id = CanisterId::unchecked_from_principal(PrincipalId(canister_id.into()));
+
+        let module_hash = self
+            .state_machine
+            .module_hash(canister_id)
+            .map(|hash| hash.to_vec());
+
+        let Some(controllers) = self.state_machine.get_controllers(canister_id) else {
+            return Err(Self::Error::CanisterDoesNotExist(canister_id.get().0));
+        };
+
+        Ok(CanisterInfo {
+            module_hash,
+            controllers: controllers
+                .into_iter()
+                .map(|controller| controller.0)
+                .collect(),
+        })
+    }
+}
+
+impl CallCanisters for StateMachine {
+    type Error = StateMachineCallError;
+
+    fn caller(&self) -> Result<Principal, Self::Error> {
+        Ok(Principal::anonymous())
+    }
+
+    async fn call<R: crate::Request>(
+        &self,
+        canister_id: impl Into<Principal> + Send,
+        request: R,
+    ) -> Result<R::Response, Self::Error> {
+        StateMachineAgent::new(self, Principal::anonymous())
+            .call(canister_id, request)
+            .await
+    }
+
+    async fn canister_info(
+        &self,
+        canister_id: impl Into<candid::Principal> + Send,
+    ) -> Result<CanisterInfo, Self::Error> {
+        StateMachineAgent::new(self, Principal::anonymous())
+            .canister_info(canister_id)
+            .await
+    }
+}

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -772,7 +772,7 @@ pub struct WaitForQuietState {
 }
 /// The ProposalData that contains everything related to a proposal:
 /// the proposal itself (immutable), as well as mutable data such as ballots.
-#[derive(candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
+#[derive(candid::CandidType, Default, candid::Deserialize, Debug, Clone, PartialEq)]
 pub struct ProposalData {
     /// The proposal's action.
     /// Types 0-999 are reserved for current (and future) core governance
@@ -2404,6 +2404,7 @@ pub struct Account {
     candid::Deserialize,
     Debug,
     clap::ValueEnum,
+    strum_macros::EnumIter,
     Clone,
     Copy,
     PartialEq,

--- a/rs/sns/governance/api_helpers/BUILD.bazel
+++ b/rs/sns/governance/api_helpers/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# See rs/nervous_system/feature_test.md
+DEPENDENCIES = [
+    # Keep sorted.
+    "//packages/icrc-ledger-types:icrc_ledger_types",
+    "//rs/nervous_system/common",
+    "//rs/sns/governance/api",
+    "@crate_index//:maplit",
+]
+
+MACRO_DEPENDENCIES = []
+
+ALIASES = {}
+
+rust_library(
+    name = "api_helpers",
+    srcs = glob(
+        ["src/**/*.rs"],
+    ),
+    aliases = ALIASES,
+    crate_name = "ic_sns_governance_api_helpers",
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    version = "0.9.0",
+    deps = DEPENDENCIES,
+)

--- a/rs/sns/governance/api_helpers/Cargo.toml
+++ b/rs/sns/governance/api_helpers/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ic-sns-governance-api-helpers"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+icrc-ledger-types = { path = "../../../../packages/icrc-ledger-types" }
+ic-nervous-system-common = { path = "../../../nervous_system/common" }
+ic-sns-governance-api = { path = "../api" }
+maplit = "1.0.2"

--- a/rs/sns/governance/api_helpers/src/lib.rs
+++ b/rs/sns/governance/api_helpers/src/lib.rs
@@ -1,0 +1,77 @@
+use ic_nervous_system_common::{
+    DEFAULT_TRANSFER_FEE, ONE_DAY_SECONDS, ONE_MONTH_SECONDS, ONE_YEAR_SECONDS,
+};
+use ic_sns_governance_api::pb::v1::{
+    governance_error::ErrorType, DefaultFollowees, GovernanceError, NervousSystemParameters,
+    Neuron, NeuronId, NeuronPermissionList, NeuronPermissionType, VotingRewardsParameters,
+};
+use icrc_ledger_types::icrc1::account::Subaccount;
+use maplit::btreemap;
+
+/// The number of e8s per governance token;
+pub const E8S_PER_TOKEN: u64 = 100_000_000;
+
+pub const DEFAULT_NEURON_CLAIMER_PERMISSIONS: &'static [NeuronPermissionType] = &[
+    NeuronPermissionType::ManagePrincipals,
+    NeuronPermissionType::Vote,
+    NeuronPermissionType::SubmitProposal,
+];
+
+pub fn default_nervous_system_parameters() -> NervousSystemParameters {
+    NervousSystemParameters {
+        reject_cost_e8s: Some(E8S_PER_TOKEN), // 1 governance token
+        neuron_minimum_stake_e8s: Some(E8S_PER_TOKEN), // 1 governance token
+        transaction_fee_e8s: Some(DEFAULT_TRANSFER_FEE.get_e8s()),
+        max_proposals_to_keep_per_action: Some(100),
+        initial_voting_period_seconds: Some(4 * ONE_DAY_SECONDS), // 4d
+        wait_for_quiet_deadline_increase_seconds: Some(ONE_DAY_SECONDS), // 1d
+        default_followees: Some(DefaultFollowees {
+            followees: btreemap! {},
+        }),
+        max_number_of_neurons: Some(200_000),
+        neuron_minimum_dissolve_delay_to_vote_seconds: Some(6 * ONE_MONTH_SECONDS), // 6m
+        max_followees_per_function: Some(15),
+        max_dissolve_delay_seconds: Some(8 * ONE_YEAR_SECONDS), // 8y
+        max_neuron_age_for_age_bonus: Some(4 * ONE_YEAR_SECONDS), // 4y
+        max_number_of_proposals_with_ballots: Some(700),
+        neuron_claimer_permissions: Some(NeuronPermissionList {
+            permissions: DEFAULT_NEURON_CLAIMER_PERMISSIONS
+                .iter()
+                .map(|p| *p as i32)
+                .collect(),
+        }),
+        neuron_grantable_permissions: Some(NeuronPermissionList::default()),
+        max_number_of_principals_per_neuron: Some(5),
+        voting_rewards_parameters: Some(VotingRewardsParameters {
+            round_duration_seconds: Some(ONE_DAY_SECONDS),
+            reward_rate_transition_duration_seconds: Some(0),
+            initial_reward_rate_basis_points: Some(0),
+            final_reward_rate_basis_points: Some(0),
+        }),
+        max_dissolve_delay_bonus_percentage: Some(100),
+        max_age_bonus_percentage: Some(25),
+        maturity_modulation_disabled: Some(false),
+        automatically_advance_target_version: Some(true),
+    }
+}
+
+pub fn neuron_id_subaccount_or_err(neuron_id: &NeuronId) -> Result<Subaccount, GovernanceError> {
+    let subaccount =
+        Subaccount::try_from(neuron_id.id.as_slice()).map_err(|err| GovernanceError {
+            error_type: i32::from(ErrorType::InvalidNeuronId),
+            error_message: format!("Could not convert NeuronId to Subaccount {}", err),
+        })?;
+
+    Ok(subaccount)
+}
+
+pub fn get_neuron_subaccount_or_err(neuron: &Neuron) -> Result<Subaccount, GovernanceError> {
+    let Some(neuron_id) = &neuron.id else {
+        return Err(GovernanceError {
+            error_type: i32::from(ErrorType::NotFound),
+            error_message: "Neuron must have a subaccount".to_string(),
+        });
+    };
+
+    neuron_id_subaccount_or_err(neuron_id)
+}

--- a/rs/sns/governance/api_helpers/src/lib.rs
+++ b/rs/sns/governance/api_helpers/src/lib.rs
@@ -11,7 +11,7 @@ use maplit::btreemap;
 /// The number of e8s per governance token;
 pub const E8S_PER_TOKEN: u64 = 100_000_000;
 
-pub const DEFAULT_NEURON_CLAIMER_PERMISSIONS: &'static [NeuronPermissionType] = &[
+pub const DEFAULT_NEURON_CLAIMER_PERMISSIONS: &[NeuronPermissionType] = &[
     NeuronPermissionType::ManagePrincipals,
     NeuronPermissionType::Vote,
     NeuronPermissionType::SubmitProposal,


### PR DESCRIPTION
This PR adds a new crate under `rs/sns/governance/api_helpers`. This crate is dedicated to helper functions defined on top of the SNS Governance API, which are extensively used by SNS integration tests.

| [Next PR](https://github.com/dfinity/ic/pull/4428) >