### PR TITLE
feat(sns_cli): Add topics info to json output

### DIFF
--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use serde::Serialize;
+
 pub mod topics;
 
 /// A principal with a particular set of permissions over a neuron.
@@ -204,7 +206,7 @@ pub mod neuron {
 ///
 /// Note that the target, validator and rendering methods can all coexist in
 /// the same canister or be on different canisters.
-#[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
+#[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq, Serialize)]
 pub struct NervousSystemFunction {
     /// The unique id of this function.
     ///
@@ -219,9 +221,13 @@ pub struct NervousSystemFunction {
 }
 /// Nested message and enum types in `NervousSystemFunction`.
 pub mod nervous_system_function {
+    use serde::Serialize;
+
     use super::*;
 
-    #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
+    #[derive(
+        Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq, Serialize,
+    )]
     pub struct GenericNervousSystemFunction {
         /// The id of the target canister that will be called to execute the proposal.
         pub target_canister_id: Option<::ic_base_types::PrincipalId>,
@@ -240,7 +246,7 @@ pub mod nervous_system_function {
         /// The topic this function belongs to
         pub topic: Option<topics::Topic>,
     }
-    #[derive(candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
+    #[derive(candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq, Serialize)]
     pub enum FunctionType {
         /// Whether this is a native function (i.e. a Action::Motion or
         /// Action::UpgradeSnsControlledCanister) or one of user-defined

--- a/rs/sns/governance/api/src/topics.rs
+++ b/rs/sns/governance/api/src/topics.rs
@@ -1,20 +1,23 @@
+use serde::Serialize;
+
 use crate::pb::v1::NervousSystemFunction;
 
 /// Functions are categorized into topics.
 /// (As a reminder, a function is either a built-in proposal type, or a generic function that has been added via an
 /// AddGenericNervousSystemFunction proposal)
 #[derive(
-    Debug,
     candid::CandidType,
     candid::Deserialize,
     comparable::Comparable,
-    Ord,
-    PartialOrd,
-    Eq,
     Clone,
-    PartialEq,
-    Hash,
     Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
 )]
 pub enum Topic {
     DaoCommunitySettings = 1, // Start at 1 to match the proto type
@@ -27,7 +30,7 @@ pub enum Topic {
 }
 /// Each topic has some information associated with it. This information is for the benefit of the user but has
 /// no effect on the behavior of the SNS.
-#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq)]
+#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq, Serialize)]
 pub struct TopicInfo {
     pub topic: Option<Topic>,
     pub name: Option<String>,
@@ -40,7 +43,7 @@ pub struct TopicInfo {
 #[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq)]
 pub struct ListTopicsRequest {}
 
-#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq)]
+#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq, Serialize)]
 pub struct ListTopicsResponse {
     pub topics: Option<Vec<TopicInfo>>,
     pub uncategorized_functions: Option<Vec<NervousSystemFunction>>,


### PR DESCRIPTION
This PR adds SNS topic-related info for each SNS in the output of `sns health --json`. Not adding it to the default (human-readable) output, as the data is too large. 