### PR TITLE
feat(sns): Move `SetTopcisForCustomProposals` under the `CriticalDappOperations` topic.

### DIFF
--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -5019,18 +5019,6 @@ fn test_list_topics() {
                             ),
                         ),
                     },
-                    NervousSystemFunction {
-                        id: 16,
-                        name: "Set topics for custom proposals".to_string(),
-                        description: Some(
-                            "Proposal to set the topics for custom SNS proposals.".to_string(),
-                        ),
-                        function_type: Some(
-                            FunctionType::NativeNervousSystemFunction(
-                                Empty {},
-                            ),
-                        ),
-                    },
                 ],
                 custom_functions: vec![
                     function_2
@@ -5188,6 +5176,18 @@ fn test_list_topics() {
                         name: "Remove nervous system function".to_string(),
                         description: Some(
                             "Proposal to remove a user-defined nervous system function, which will be no longer executable by proposal.".to_string(),
+                        ),
+                        function_type: Some(
+                            FunctionType::NativeNervousSystemFunction(
+                                Empty {},
+                            ),
+                        ),
+                    },
+                    NervousSystemFunction {
+                        id: 16,
+                        name: "Set topics for custom proposals".to_string(),
+                        description: Some(
+                            "Proposal to set the topics for custom SNS proposals.".to_string(),
                         ),
                         function_type: Some(
                             FunctionType::NativeNervousSystemFunction(

--- a/rs/sns/governance/src/governance/proposal_topics_tests.rs
+++ b/rs/sns/governance/src/governance/proposal_topics_tests.rs
@@ -105,13 +105,6 @@ fn test_all_topics() {
                 ProposalCriticality::Normal,
             )),
         ),
-        (
-            pb::proposal::Action::SetTopicsForCustomProposals(Default::default()),
-            Ok((
-                Some(pb::Topic::SnsFrameworkManagement),
-                ProposalCriticality::Normal,
-            )),
-        ),
         // DappCanisterManagement
         (
             pb::proposal::Action::UpgradeSnsControlledCanister(Default::default()),
@@ -173,6 +166,13 @@ fn test_all_topics() {
         ),
         (
             pb::proposal::Action::RemoveGenericNervousSystemFunction(Default::default()),
+            Ok((
+                Some(pb::Topic::CriticalDappOperations),
+                ProposalCriticality::Critical,
+            )),
+        ),
+        (
+            pb::proposal::Action::SetTopicsForCustomProposals(Default::default()),
             Ok((
                 Some(pb::Topic::CriticalDappOperations),
                 ProposalCriticality::Critical,

--- a/rs/sns/governance/src/topics.rs
+++ b/rs/sns/governance/src/topics.rs
@@ -1,6 +1,6 @@
 use crate::logs::ERROR;
 use crate::pb::v1::{self as pb, NervousSystemFunction};
-use crate::types::native_action_ids::{self, SET_CUSTOM_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION};
+use crate::types::native_action_ids::{self, SET_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION};
 use crate::{governance::Governance, pb::v1::nervous_system_function::FunctionType};
 use ic_canister_log::log;
 use ic_sns_governance_api::pb::v1::topics::Topic;
@@ -74,7 +74,6 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
                 native_functions: vec![
                     UPGRADE_SNS_TO_NEXT_VERSION,
                     ADVANCE_SNS_TARGET_VERSION,
-                    SET_CUSTOM_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION,
                 ],
             },
             is_critical: false,
@@ -131,6 +130,7 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
                     DEREGISTER_DAPP_CANISTERS,
                     ADD_GENERIC_NERVOUS_SYSTEM_FUNCTION,
                     REMOVE_GENERIC_NERVOUS_SYSTEM_FUNCTION,
+                    SET_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION,
                 ],
             },
             is_critical: true,

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -134,7 +134,7 @@ pub mod native_action_ids {
     pub const ADVANCE_SNS_TARGET_VERSION: u64 = 15;
 
     /// SetTopicsForCustomProposals Action.
-    pub const SET_CUSTOM_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION: u64 = 16;
+    pub const SET_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION: u64 = 16;
 
     // When adding something to this list, make sure to update the below function.
     pub fn nervous_system_functions() -> Vec<NervousSystemFunction> {
@@ -1244,7 +1244,7 @@ impl NervousSystemFunction {
 
     fn set_topics_for_custom_proposals() -> NervousSystemFunction {
         NervousSystemFunction {
-            id: native_action_ids::SET_CUSTOM_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION,
+            id: native_action_ids::SET_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION,
             name: "Set topics for custom proposals".to_string(),
             description: Some("Proposal to set the topics for custom SNS proposals.".to_string()),
             function_type: Some(FunctionType::NativeNervousSystemFunction(Empty {})),
@@ -1868,7 +1868,7 @@ impl From<&Action> for u64 {
             }
             Action::AdvanceSnsTargetVersion(_) => native_action_ids::ADVANCE_SNS_TARGET_VERSION,
             Action::SetTopicsForCustomProposals(_) => {
-                native_action_ids::SET_CUSTOM_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION
+                native_action_ids::SET_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION
             }
         }
     }

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -11,6 +11,8 @@ on the process that this file is part of, see
 
 ## Changed
 
+- `SetTopcisForCustomProposals` proposal is now under the `CriticalDappOperations` topic.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
This PR implements the last phase of the new SNS proposal criticality feature that shifted the source of truth from a hard coded function to the topics configuration of a given SNS.

Recently added `SetTopcisForCustomProposals` proposals enabled categorizing custom proposals under a critical topic to become critical for the first time. However, now that the initial batches are categorized, its time to make the `SetTopcisForCustomProposals` proposal critical itself, as right now it is possible to circumvent proposal criticality by changing a proposal's topic without involving the grand majority of votes.