### PR TITLE
test(ICP_Rosetta): FI-1507: Add debugging information to assert in flaky test

### DIFF
--- a/rs/rosetta-api/icp/tests/system_tests/test_cases/neuron_management.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/test_cases/neuron_management.rs
@@ -356,7 +356,9 @@ fn test_start_and_stop_neuron_dissolve() {
         // The neuron should now be in DISSOLVING state
         assert_eq!(
             start_dissolving_response.operations.first().unwrap().status,
-            Some("COMPLETED".to_owned())
+            Some("COMPLETED".to_owned()),
+            "Expected the operation to be completed but got: {:?}",
+            start_dissolving_response
         );
         let neuron = list_neurons(&agent).await.full_neurons[0].to_owned();
         match neuron.dissolve_state.unwrap() {


### PR DESCRIPTION
Add debugging information to an `assert!` in a flaky ICP Rosetta system test.