### PR TITLE
fix(PocketIC): support mounting generic application subnets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18115,6 +18115,7 @@ dependencies = [
  "ic-replicated-state",
  "ic-starter",
  "ic-state-machine-tests",
+ "ic-state-manager",
  "ic-test-utilities",
  "ic-test-utilities-registry",
  "ic-types",

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -33,6 +33,7 @@ LIB_DEPENDENCIES = [
     "//rs/replicated_state",
     "//rs/starter:ic-starter-lib",
     "//rs/state_machine_tests",
+    "//rs/state_manager",
     "//rs/test_utilities",
     "//rs/test_utilities/registry",
     "//rs/types/management_canister_types",

--- a/rs/pocket_ic_server/Cargo.toml
+++ b/rs/pocket_ic_server/Cargo.toml
@@ -57,6 +57,7 @@ ic-registry-subnet-type = { path = "../registry/subnet_type" }
 ic-replicated-state = { path = "../replicated_state" }
 ic-starter = { path = "../starter" }
 ic-state-machine-tests = { path = "../state_machine_tests" }
+ic-state-manager = { path = "../state_manager" }
 ic-test-utilities = { path = "../test_utilities" }
 ic-test-utilities-registry = { path = "../test_utilities/registry" }
 ic-types = { path = "../types/types" }

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -744,6 +744,9 @@ impl PocketIc {
                             MaliciousFlags::default(),
                         );
                         let metadata = state_manager.get_latest_state().take().metadata.clone();
+                        // Shut down the temporary state manager to avoid race conditions.
+                        state_manager.flush_tip_channel();
+                        drop(state_manager);
                         let subnet_id = metadata.own_subnet_id;
                         let ranges: Vec<_> = metadata
                             .network_topology

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -776,7 +776,7 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
 
     // We create a counter canister on the application subnet.
     let app_subnet = initial_topology.get_app_subnets()[0];
-    let app_canister_id = deploy_counter_canister_to_subnet(&pic, nns_subnet, 1);
+    let app_canister_id = deploy_counter_canister_to_subnet(&pic, app_subnet, 1);
 
     // We create a counter canister with a "specified" canister ID that exists on the IC mainnet,
     // but belongs to the canister ranges of no subnet on the PocketIC instance.

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -81,6 +81,92 @@ pub fn start_server() -> Url {
     start_server_helper(Some(test_driver_pid), None, false, false).0
 }
 
+const COUNTER_WAT: &str = r#"
+;; Counter with global variable ;;
+(module
+  (import "ic0" "msg_reply" (func $msg_reply))
+  (import "ic0" "msg_reply_data_append"
+    (func $msg_reply_data_append (param i32 i32)))
+
+  (func $read
+    (i32.store
+      (i32.const 0)
+      (global.get 0)
+    )
+    (call $msg_reply_data_append
+      (i32.const 0)
+      (i32.const 4))
+    (call $msg_reply))
+
+  (func $write
+    (global.set 0
+      (i32.add
+        (global.get 0)
+        (i32.const 1)
+      )
+    )
+    (call $read)
+  )
+
+  (memory $memory 1)
+  (export "memory" (memory $memory))
+  (global (export "counter_global") (mut i32) (i32.const 0))
+  (export "canister_query read" (func $read))
+  (export "canister_query inc_read" (func $write))
+  (export "canister_update write" (func $write))
+)
+    "#;
+
+fn check_counter(pic: &PocketIc, canister_id: Principal, expected_ctr: u32) {
+    let res = pic
+        .query_call(canister_id, Principal::anonymous(), "read", vec![])
+        .unwrap();
+    assert_eq!(u32::from_le_bytes(res.try_into().unwrap()), expected_ctr);
+}
+
+fn deploy_counter_canister(pic: &PocketIc, canister_id: Principal, counter: u32) {
+    const INIT_CYCLES: u128 = 2_000_000_000_000;
+    pic.add_cycles(canister_id, INIT_CYCLES);
+    let counter_wasm = wat::parse_str(COUNTER_WAT).unwrap();
+    pic.install_canister(canister_id, counter_wasm, vec![], None);
+
+    // Bump the counter and check the counter value.
+    for _ in 0..counter {
+        pic.update_call(canister_id, Principal::anonymous(), "write", vec![])
+            .unwrap();
+    }
+    check_counter(pic, canister_id, counter);
+}
+
+fn deploy_counter_canister_to_any_subnet(pic: &PocketIc) -> Principal {
+    let canister_id = pic.create_canister();
+
+    deploy_counter_canister(pic, canister_id, 0);
+
+    canister_id
+}
+
+fn deploy_counter_canister_to_id(pic: &PocketIc, canister_id: Principal, counter: u32) {
+    let actual_canister_id = pic
+        .create_canister_with_id(None, None, canister_id)
+        .unwrap();
+    assert_eq!(actual_canister_id, canister_id);
+
+    deploy_counter_canister(pic, canister_id, counter);
+}
+
+fn deploy_counter_canister_to_subnet(
+    pic: &PocketIc,
+    subnet_id: Principal,
+    counter: u32,
+) -> Principal {
+    let canister_id = pic.create_canister_on_subnet(None, None, subnet_id);
+
+    deploy_counter_canister(pic, canister_id, counter);
+
+    canister_id
+}
+
 #[test]
 fn test_status() {
     let url = start_server();
@@ -588,49 +674,6 @@ fn canister_and_no_replica_logs() {
     assert!(stderr.contains("Logging works!"));
 }
 
-const COUNTER_WAT: &str = r#"
-;; Counter with global variable ;;
-(module
-  (import "ic0" "msg_reply" (func $msg_reply))
-  (import "ic0" "msg_reply_data_append"
-    (func $msg_reply_data_append (param i32 i32)))
-
-  (func $read
-    (i32.store
-      (i32.const 0)
-      (global.get 0)
-    )
-    (call $msg_reply_data_append
-      (i32.const 0)
-      (i32.const 4))
-    (call $msg_reply))
-
-  (func $write
-    (global.set 0
-      (i32.add
-        (global.get 0)
-        (i32.const 1)
-      )
-    )
-    (call $read)
-  )
-
-  (memory $memory 1)
-  (export "memory" (memory $memory))
-  (global (export "counter_global") (mut i32) (i32.const 0))
-  (export "canister_query read" (func $read))
-  (export "canister_query inc_read" (func $write))
-  (export "canister_update write" (func $write))
-)
-    "#;
-
-fn check_counter(pic: &PocketIc, canister_id: Principal, expected_ctr: u32) {
-    let res = pic
-        .query_call(canister_id, Principal::anonymous(), "read", vec![])
-        .unwrap();
-    assert_eq!(u32::from_le_bytes(res.try_into().unwrap()), expected_ctr);
-}
-
 /// Tests that the PocketIC topology and canister states
 /// can be successfully restored from a `state_dir`
 /// if a PocketIC instance is created with that `state_dir`,
@@ -703,8 +746,6 @@ fn kill_gateway_with_sigterm() {
 }
 
 fn canister_state_dir(shutdown_signal: Option<Signal>) {
-    const INIT_CYCLES: u128 = 2_000_000_000_000;
-
     // Create a temporary state directory persisted throughout the test.
     let state_dir = TempDir::new().unwrap();
     let state_dir_path_buf = state_dir.path().to_path_buf();
@@ -725,47 +766,23 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
     let registry_data_provider = ProtoRegistryDataProvider::load_from_file(registry_proto_path);
     assert_eq!(registry_data_provider.latest_version(), 2.into());
 
-    // Retrieve the NNS and app subnets from the topology.
-    let topology = pic.topology();
-    let nns_subnet = topology.get_nns().unwrap();
-    let app_subnet = topology.get_app_subnets()[0];
-    let default_effective_canister_id = topology.default_effective_canister_id;
+    // There is one application subnet in the initial topology.
+    let initial_topology = pic.topology();
+    assert_eq!(initial_topology.get_app_subnets().len(), 1);
 
     // We create a counter canister on the NNS subnet.
-    let nns_canister_id = pic.create_canister_on_subnet(None, None, nns_subnet);
-    pic.add_cycles(nns_canister_id, INIT_CYCLES);
-    let counter_wasm = wat::parse_str(COUNTER_WAT).unwrap();
-    pic.install_canister(nns_canister_id, counter_wasm, vec![], None);
-
-    // Bump the counter twice and check the counter value.
-    pic.update_call(nns_canister_id, Principal::anonymous(), "write", vec![])
-        .unwrap();
-    pic.update_call(nns_canister_id, Principal::anonymous(), "write", vec![])
-        .unwrap();
-    check_counter(&pic, nns_canister_id, 2);
+    let nns_subnet = initial_topology.get_nns().unwrap();
+    let nns_canister_id = deploy_counter_canister_to_subnet(&pic, nns_subnet, 2);
 
     // We create a counter canister on the application subnet.
-    let app_canister_id = pic.create_canister_on_subnet(None, None, app_subnet);
-    pic.add_cycles(app_canister_id, INIT_CYCLES);
-    let counter_wasm = wat::parse_str(COUNTER_WAT).unwrap();
-    pic.install_canister(app_canister_id, counter_wasm, vec![], None);
-
-    // Bump the counter once and check the counter value.
-    pic.update_call(app_canister_id, Principal::anonymous(), "write", vec![])
-        .unwrap();
-    check_counter(&pic, app_canister_id, 1);
+    let app_subnet = initial_topology.get_app_subnets()[0];
+    let app_canister_id = deploy_counter_canister_to_subnet(&pic, nns_subnet, 1);
 
     // We create a counter canister with a "specified" canister ID that exists on the IC mainnet,
     // but belongs to the canister ranges of no subnet on the PocketIC instance.
-    let specified_id = Principal::from_text("rimrc-piaaa-aaaao-aaljq-cai").unwrap();
-    assert!(pic.get_subnet(specified_id).is_none());
-    let spec_canister_id = pic
-        .create_canister_with_id(None, None, specified_id)
-        .unwrap();
-    assert_eq!(spec_canister_id, specified_id);
-    pic.add_cycles(spec_canister_id, INIT_CYCLES);
-    let counter_wasm = wat::parse_str(COUNTER_WAT).unwrap();
-    pic.install_canister(spec_canister_id, counter_wasm, vec![], None);
+    let spec_canister_id = Principal::from_text("rimrc-piaaa-aaaao-aaljq-cai").unwrap();
+    assert!(pic.get_subnet(spec_canister_id).is_none());
+    deploy_counter_canister_to_id(&pic, spec_canister_id, 3);
 
     // Check the registry version.
     // The registry version should be 3 as we have three subnets on the PocketIC instance now
@@ -774,14 +791,9 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
     let registry_data_provider = ProtoRegistryDataProvider::load_from_file(registry_proto_path);
     assert_eq!(registry_data_provider.latest_version(), 3.into());
 
-    // Bump the counter three times and check the counter value.
-    pic.update_call(spec_canister_id, Principal::anonymous(), "write", vec![])
-        .unwrap();
-    pic.update_call(spec_canister_id, Principal::anonymous(), "write", vec![])
-        .unwrap();
-    pic.update_call(spec_canister_id, Principal::anonymous(), "write", vec![])
-        .unwrap();
-    check_counter(&pic, spec_canister_id, 3);
+    // There are two application subnets in the final topology.
+    let final_topology = pic.topology();
+    assert_eq!(final_topology.get_app_subnets().len(), 2);
 
     send_signal_to_pic(pic, child, shutdown_signal);
 
@@ -795,16 +807,8 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
         .build();
 
     // Check that the topology has been properly restored.
-    let topology = pic.topology();
-    assert_eq!(topology.get_nns().unwrap(), nns_subnet);
-    assert_eq!(topology.get_app_subnets()[0], app_subnet);
-    // We created one app subnet and another one was created dynamically
-    // to host the canister with the "specified" canister ID.
-    assert_eq!(topology.get_app_subnets().len(), 2);
-    assert_eq!(
-        topology.default_effective_canister_id,
-        default_effective_canister_id
-    );
+    let restored_topology = pic.topology();
+    assert_eq!(restored_topology, final_topology);
 
     // Check that the canister states have been properly restored.
     check_counter(&pic, nns_canister_id, 2);
@@ -827,16 +831,16 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
     send_signal_to_pic(pic, child, shutdown_signal);
 
     // Start a new PocketIC server.
-    let (newest_server_url, _) = start_server_helper(None, None, false, false);
+    let (newest_server_url, child) = start_server_helper(None, None, false, false);
 
     // Create a PocketIC instance mounting the NNS and app state created so far.
-    let nns_subnet_seed = topology
+    let nns_subnet_seed = initial_topology
         .subnet_configs
         .get(&nns_subnet)
         .unwrap()
         .subnet_seed;
     let nns_state_dir = state_dir.path().join(hex::encode(nns_subnet_seed));
-    let app_subnet_seed = topology
+    let app_subnet_seed = initial_topology
         .subnet_configs
         .get(&app_subnet)
         .unwrap()
@@ -848,11 +852,17 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
         .with_subnet_state(SubnetKind::Application, app_state_dir)
         .build();
 
-    // Check that the topology has been properly restored.
-    let topology = pic.topology();
-    assert_eq!(topology.get_nns().unwrap(), nns_subnet);
     // We only specified to restore one app subnet.
-    assert_eq!(topology.get_app_subnets().len(), 1);
+    let restored_topology = pic.topology();
+    assert_eq!(restored_topology.get_app_subnets().len(), 1);
+
+    // Check that the topology has been properly restored.
+    let mut updated_final_topology = final_topology.clone();
+    // We remove the subnet that was not restored from the final topology.
+    updated_final_topology
+        .subnet_configs
+        .retain(|subnet_id, _| *subnet_id == nns_subnet || *subnet_id == app_subnet);
+    assert_eq!(restored_topology, updated_final_topology);
 
     // Check that the canister states have been properly restored.
     check_counter(&pic, nns_canister_id, 3);
@@ -867,14 +877,39 @@ fn canister_state_dir(shutdown_signal: Option<Signal>) {
     // Check that the counters have been properly updated.
     check_counter(&pic, nns_canister_id, 4);
     check_counter(&pic, app_canister_id, 3);
+
+    send_signal_to_pic(pic, child, shutdown_signal);
+
+    // Start a new PocketIC server.
+    let (new_server_url, child) = start_server_helper(None, None, false, false);
+
+    // Create a PocketIC instance mounting the state created so far.
+    let pic = PocketIcBuilder::new()
+        .with_server_url(new_server_url)
+        .with_state_dir(state_dir_path_buf.clone())
+        .build();
+
+    // Check that the topology has been properly restored.
+    let restored_topology = pic.topology();
+    assert_eq!(restored_topology, final_topology);
+
+    // Check that the canister states have not changed
+    // after mounting selected subnets individually.
+    check_counter(&pic, nns_canister_id, 3);
+    check_counter(&pic, app_canister_id, 2);
+    check_counter(&pic, spec_canister_id, 4);
+
+    send_signal_to_pic(pic, child, shutdown_signal);
 }
 
 /// The following test is similar to `canister_state_dir`,
 /// but creates two app subnets on the original PocketIC instance
 /// and then checks that each of the two app subnets
 /// can be separately restored from its state.
-/// No canisters are deployed to the app subnets
-/// as restoring such states is not supported yet.
+/// This way, the test ensures that PocketIC properly retrieves
+/// the subnet configuration from the state of the subnet
+/// (since using the default configuration won't work
+/// for at least one of the two subnets).
 #[test]
 fn with_subnet_state() {
     // Create a temporary state directory persisted throughout the test.
@@ -885,7 +920,7 @@ fn with_subnet_state() {
     let (server_url, _) = start_server_helper(None, None, false, false);
     let pic = PocketIcBuilder::new()
         .with_state_dir(state_dir_path_buf.clone())
-        .with_server_url(server_url)
+        .with_server_url(server_url.clone())
         .with_nns_subnet()
         .with_application_subnet()
         .with_application_subnet()
@@ -897,12 +932,16 @@ fn with_subnet_state() {
     let first_app_subnet = topology.get_app_subnets()[0];
     let second_app_subnet = topology.get_app_subnets()[1];
 
+    // We create a counter canister on each of the two app subnets.
+    let first_app_canister_id = deploy_counter_canister_to_subnet(&pic, first_app_subnet, 1);
+    let second_app_canister_id = deploy_counter_canister_to_subnet(&pic, second_app_subnet, 2);
+
     drop(pic);
 
-    for app_subnet in [first_app_subnet, second_app_subnet] {
-        // Start a new PocketIC server.
-        let (new_server_url, _) = start_server_helper(None, None, false, false);
-
+    for (app_subnet, app_canister_id, counter) in [
+        (first_app_subnet, first_app_canister_id, 1),
+        (second_app_subnet, second_app_canister_id, 2),
+    ] {
         // Create a PocketIC instance mounting the NNS and app state created so far.
         let nns_subnet_seed = topology
             .subnet_configs
@@ -917,17 +956,28 @@ fn with_subnet_state() {
             .subnet_seed;
         let app_state_dir = state_dir.path().join(hex::encode(app_subnet_seed));
         let pic = PocketIcBuilder::new()
-            .with_server_url(new_server_url)
+            .with_server_url(server_url.clone())
             .with_nns_state(nns_state_dir)
             .with_subnet_state(SubnetKind::Application, app_state_dir)
             .build();
 
-        // Check that the topology has been properly restored.
-        let topology = pic.topology();
-        assert_eq!(topology.get_nns().unwrap(), nns_subnet);
-        assert_eq!(topology.get_app_subnets()[0], app_subnet);
         // We only specified to restore one app subnet.
-        assert_eq!(topology.get_app_subnets().len(), 1);
+        let restored_topology = pic.topology();
+        assert_eq!(restored_topology.get_app_subnets().len(), 1);
+
+        // Check that the topology has been properly restored.
+        let mut updated_topology = topology.clone();
+        // We remove the subnet that was not restored from the topology.
+        updated_topology
+            .subnet_configs
+            .retain(|subnet_id, _| *subnet_id == nns_subnet || *subnet_id == app_subnet);
+        // The default effective canister ID can change if a subnet is not restored
+        // => update its value to be ignored in the comparison.
+        updated_topology.default_effective_canister_id =
+            restored_topology.default_effective_canister_id.clone();
+        assert_eq!(restored_topology, updated_topology);
+
+        check_counter(&pic, app_canister_id, counter);
     }
 }
 
@@ -993,16 +1043,11 @@ fn test_specified_id_call_v3() {
 /// Test that query stats are available via the management canister.
 #[test]
 fn test_query_stats() {
-    const INIT_CYCLES: u128 = 2_000_000_000_000;
-
     // Create PocketIC instance with a single app subnet.
     let pic = PocketIcBuilder::new().with_application_subnet().build();
 
     // We create a counter canister on the app subnet.
-    let canister_id = pic.create_canister();
-    pic.add_cycles(canister_id, INIT_CYCLES);
-    let counter_wasm = wat::parse_str(COUNTER_WAT).unwrap();
-    pic.install_canister(canister_id, counter_wasm, vec![], None);
+    let canister_id = deploy_counter_canister_to_any_subnet(&pic);
 
     // The query stats are still at zero.
     let query_stats = pic.canister_status(canister_id, None).unwrap().query_stats;
@@ -1049,8 +1094,6 @@ fn test_query_stats() {
 /// Test that query stats are available via the management canister in the live mode of PocketIC.
 #[test]
 fn test_query_stats_live() {
-    const INIT_CYCLES: u128 = 2_000_000_000_000;
-
     // Create PocketIC instance with one NNS subnet and one app subnet.
     let mut pic = PocketIcBuilder::new()
         .with_nns_subnet()
@@ -1062,10 +1105,7 @@ fn test_query_stats_live() {
     let app_subnet = topology.get_app_subnets()[0];
 
     // We create a counter canister on the app subnet.
-    let canister_id = pic.create_canister_on_subnet(None, None, app_subnet);
-    pic.add_cycles(canister_id, INIT_CYCLES);
-    let counter_wasm = wat::parse_str(COUNTER_WAT).unwrap();
-    pic.install_canister(canister_id, counter_wasm, vec![], None);
+    let canister_id = deploy_counter_canister_to_subnet(&pic, app_subnet, 0);
 
     // Query stats should be collected in the live mode.
     let endpoint = pic.make_live(None);
@@ -1120,8 +1160,6 @@ fn test_query_stats_live() {
 /// Tests subnet read state requests.
 #[test]
 fn test_subnet_read_state() {
-    const INIT_CYCLES: u128 = 2_000_000_000_000;
-
     // Create PocketIC instance with one NNS subnet and one app subnet.
     let mut pic = PocketIcBuilder::new()
         .with_nns_subnet()
@@ -1133,10 +1171,7 @@ fn test_subnet_read_state() {
     let app_subnet = topology.get_app_subnets()[0];
 
     // We create a counter canister on the app subnet.
-    let canister_id = pic.create_canister_on_subnet(None, None, app_subnet);
-    pic.add_cycles(canister_id, INIT_CYCLES);
-    let counter_wasm = wat::parse_str(COUNTER_WAT).unwrap();
-    pic.install_canister(canister_id, counter_wasm, vec![], None);
+    deploy_counter_canister_to_subnet(&pic, app_subnet, 0);
 
     let endpoint = pic.make_live(None);
 


### PR DESCRIPTION
This PR fixes PocketIC to support mounting (multiple) generic application subnets:
- do not distinguish the canister allocation range when deriving the subnet seed (as the separation is invisible when mounting a subnet state);
- use `StateManagerImpl` to derive the subnet ID and canister ranges from a given state;
- check that canister ranges are disjoint and fail instance creation with HTTP status code 400 if they are not disjoint. 