### PR TITLE
feat(registry): Implemented get_chunk method.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11206,6 +11206,7 @@ dependencies = [
  "ic-ledger-core",
  "ic-limits",
  "ic-management-canister-types-private",
+ "ic-nervous-system-chunks",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
  "ic-nervous-system-common-test-keys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19424,6 +19424,7 @@ dependencies = [
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",
+ "ic-nervous-system-chunks",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",

--- a/rs/nervous_system/BUILD.bazel
+++ b/rs/nervous_system/BUILD.bazel
@@ -1,9 +1,10 @@
 package_group(
     name = "default_visibility",
     packages = [
+        # Keep sorted.
         "//rs/nervous_system/...",
         "//rs/nns/...",
-        "//rs/registry/admin/...",
+        "//rs/registry/...",
         "//rs/sns/...",
         "//rs/tests/...",
     ],

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -9,7 +9,7 @@ BASE_DEPENDENCIES = [
     "//rs/ledger_suite/common/ledger_core",
     "//rs/ledger_suite/icp:icp_ledger",
     "//rs/limits",
-    "//rs/nervous_system/chunks", # TODO(NNS1-3682): Delete.
+    "//rs/nervous_system/chunks",  # TODO(NNS1-3682): Delete.
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/common/test_keys",

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -9,6 +9,7 @@ BASE_DEPENDENCIES = [
     "//rs/ledger_suite/common/ledger_core",
     "//rs/ledger_suite/icp:icp_ledger",
     "//rs/limits",
+    "//rs/nervous_system/chunks", # TODO(NNS1-3682): Delete.
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/common/test_keys",

--- a/rs/nns/integration_tests/Cargo.toml
+++ b/rs/nns/integration_tests/Cargo.toml
@@ -45,6 +45,7 @@ ic-cdk-macros = { workspace = true }
 ic-cdk-timers = { workspace = true }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
 ic-limits = { path = "../../limits" }
+ic-nervous-system-chunks = { path = "../../nervous_system/chunks" }
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-runtime = { path = "../../nervous_system/runtime" }

--- a/rs/nns/integration_tests/src/registry_get_chunk.rs
+++ b/rs/nns/integration_tests/src/registry_get_chunk.rs
@@ -90,5 +90,7 @@ fn test_get_chunk() {
         Err(ok) => ok,
         _ => panic!("{:#?}", garbage_response),
     };
-    assert!(err.to_lowercase().contains("not found"), "{:?}", err);
+    for key_word in ["no chunk", "sha256"] {
+        assert!(err.to_lowercase().contains(key_word), "{:?}", err);
+    }
 }

--- a/rs/nns/integration_tests/src/registry_get_chunk.rs
+++ b/rs/nns/integration_tests/src/registry_get_chunk.rs
@@ -55,6 +55,8 @@ fn test_get_chunk() {
         .map(|big_chunk_key| registry_get_chunk(&state_machine, big_chunk_key))
         .collect::<Vec<_>>();
 
+    let garbage_response = registry_get_chunk(&state_machine, b"garbage".as_ref());
+
     // Step 3: Verify result(s).
     assert_eq!(
         small_response,
@@ -83,4 +85,10 @@ fn test_get_chunk() {
     // assert_eq is not used here, because we do not want 5 MB of spam to be
     // dumped into the terminal.
     assert!(reconstructed_big_monolithic_blob == original_big_monolithic_blob);
+
+    let err: String = match garbage_response {
+        Err(ok) => ok,
+        _ => panic!("{:#?}", garbage_response),
+    };
+    assert!(err.to_lowercase().contains("not found"), "{:?}", err);
 }

--- a/rs/nns/integration_tests/src/registry_get_chunk.rs
+++ b/rs/nns/integration_tests/src/registry_get_chunk.rs
@@ -63,13 +63,13 @@ fn test_get_chunk() {
         })
     );
 
+    assert_eq!(big_responses.len(), 3, "{:?}", big_responses);
     let reconstructed_big_monolithic_blob = big_responses
         .into_iter()
-        .map(|big_response| -> Vec<u8> {
+        .flat_map(|big_response| -> Vec<u8> {
             let Chunk { content } = big_response.unwrap();
             content.unwrap()
         })
-        .flatten()
         .collect::<Vec<u8>>();
     assert_eq!(
         reconstructed_big_monolithic_blob[0..25],

--- a/rs/nns/integration_tests/src/registry_get_chunk.rs
+++ b/rs/nns/integration_tests/src/registry_get_chunk.rs
@@ -7,7 +7,7 @@ use ic_nns_test_utils::{
     },
 };
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
-use rand::{Rng, rngs::StdRng, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use registry_canister::pb::v1::Chunk;
 use std::{cell::RefCell, rc::Rc};
 
@@ -66,15 +66,19 @@ fn test_get_chunk() {
     let reconstructed_big_monolithic_blob = big_responses
         .into_iter()
         .map(|big_response| -> Vec<u8> {
-            let Chunk {
-                content
-            } = big_response.unwrap();
+            let Chunk { content } = big_response.unwrap();
             content.unwrap()
         })
         .flatten()
         .collect::<Vec<u8>>();
-    assert_eq!(reconstructed_big_monolithic_blob[0..25], original_big_monolithic_blob[0..25]);
-    assert_eq!(reconstructed_big_monolithic_blob[big_len-25..big_len], original_big_monolithic_blob[big_len-25..big_len]);
+    assert_eq!(
+        reconstructed_big_monolithic_blob[0..25],
+        original_big_monolithic_blob[0..25]
+    );
+    assert_eq!(
+        reconstructed_big_monolithic_blob[big_len - 25..big_len],
+        original_big_monolithic_blob[big_len - 25..big_len]
+    );
     assert_eq!(reconstructed_big_monolithic_blob.len(), big_len);
     // assert_eq is not used here, because we do not want 5 MB of spam to be
     // dumped into the terminal.

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -73,6 +73,7 @@ use icrc_ledger_types::icrc1::{
 };
 use num_traits::ToPrimitive;
 use prost::Message;
+use registry_canister::pb::v1::GetChunkRequest;
 use serde::Serialize;
 use std::{convert::TryInto, env, time::Duration};
 
@@ -123,6 +124,34 @@ pub fn registry_get_changes_since(
     };
 
     RegistryGetChangesSinceResponse::decode(&result[..]).unwrap()
+}
+
+pub fn registry_get_chunk(
+    state_machine: &StateMachine,
+    chunk_content_sha256: &Vec<u8>,
+) -> Result<registry_canister::pb::v1::Chunk, String> {
+    let content_sha256 = Some(chunk_content_sha256.clone());
+    let request = GetChunkRequest { content_sha256 };
+
+    let result = state_machine
+        .execute_ingress(
+            REGISTRY_CANISTER_ID,
+            "get_chunk",
+            Encode!(&request).unwrap(),
+        )
+        .unwrap();
+
+    let result = match result {
+        WasmResult::Reply(reply) => reply,
+        WasmResult::Reject(reject) => {
+            panic!(
+                "get chunk was rejected by the NNS registry canister: {:#?}",
+                reject
+            )
+        }
+    };
+
+    Decode!(&result, Result<registry_canister::pb::v1::Chunk, String>).unwrap()
 }
 
 /// Creates a canister with a wasm, payload, and optionally settings on a StateMachine

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -128,9 +128,9 @@ pub fn registry_get_changes_since(
 
 pub fn registry_get_chunk(
     state_machine: &StateMachine,
-    chunk_content_sha256: &Vec<u8>,
+    chunk_content_sha256: &[u8],
 ) -> Result<registry_canister::pb::v1::Chunk, String> {
-    let content_sha256 = Some(chunk_content_sha256.clone());
+    let content_sha256 = Some(chunk_content_sha256.to_vec());
     let request = GetChunkRequest { content_sha256 };
 
     let result = state_machine

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -17,6 +17,7 @@ DEPENDENCIES = [
     "//rs/crypto/sha2",
     "//rs/crypto/utils/basic_sig",
     "//rs/crypto/utils/ni_dkg",
+    "//rs/nervous_system/chunks",
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/string",

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -28,6 +28,7 @@ ic-crypto-utils-ni-dkg = { path = "../../crypto/utils/ni_dkg" }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }
 ic-metrics-encoder = "1"
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }
+ic-nervous-system-chunks = { path = "../../nervous_system/chunks" }
 ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -394,8 +394,8 @@ fn get_chunk() {
 }
 
 #[candid_method(query, rename = "get_chunk")]
-fn get_chunk_(_request: GetChunkRequest) -> Result<Chunk, String> {
-    todo!();
+fn get_chunk_(request: GetChunkRequest) -> Result<Chunk, String> {
+    registry().get_chunk(request)
 }
 
 #[export_name = "canister_update revise_elected_guestos_versions"]

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1,7 +1,8 @@
 use crate::{
     common::LOG_PREFIX,
     pb::v1::{
-        registry_stable_storage::Version as ReprVersion, ChangelogEntry, RegistryStableStorage,
+        registry_stable_storage::Version as ReprVersion, ChangelogEntry, Chunk, GetChunkRequest,
+        RegistryStableStorage,
     },
 };
 use ic_certified_map::RbTree;
@@ -147,6 +148,21 @@ impl Registry {
             return None;
         }
         Some(value)
+    }
+
+    pub fn get_chunk(&self, request: GetChunkRequest) -> Result<Chunk, String> {
+        let GetChunkRequest { content_sha256 } = request;
+
+        let Some(content_sha256) = content_sha256 else {
+            return Err("Request does not specify content_sha256.".to_string());
+        };
+
+        let content = crate::storage::with_chunks(|chunks| chunks.get_chunk(&content_sha256))
+            .ok_or_else(|| format!("No chunk with SHA256 = {:X?}", content_sha256))?;
+
+        Ok(Chunk {
+            content: Some(content),
+        })
     }
 
     /// Computes the number of deltas with version greater than `since_version`

--- a/rs/registry/canister/src/storage.rs
+++ b/rs/registry/canister/src/storage.rs
@@ -1,17 +1,24 @@
+use ic_nervous_system_chunks::Chunks;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::DefaultMemoryImpl;
 use std::cell::RefCell;
 
 const UPGRADES_MEMORY_ID: MemoryId = MemoryId::new(0);
+const CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(1);
 
 type VM = VirtualMemory<DefaultMemoryImpl>;
+
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
 
     static UPGRADES_MEMORY: RefCell<VM> = RefCell::new({
         MEMORY_MANAGER.with(|mm| mm.borrow().get(UPGRADES_MEMORY_ID))
-    })
+    });
+
+    static CHUNKS: RefCell<Chunks<VM>> = RefCell::new({
+        MEMORY_MANAGER.with(|mm| Chunks::init(mm.borrow().get(CHUNKS_MEMORY_ID)))
+    });
 }
 
 pub fn with_upgrades_memory<R>(f: impl FnOnce(&VM) -> R) -> R {
@@ -20,3 +27,12 @@ pub fn with_upgrades_memory<R>(f: impl FnOnce(&VM) -> R) -> R {
         f(upgrades_memory)
     })
 }
+
+pub(crate) fn with_chunks<R>(f: impl FnOnce(&Chunks<VM>) -> R) -> R {
+    CHUNKS.with(|chunks| {
+        let chunks = chunks.borrow();
+        f(&chunks)
+    })
+}
+
+// TODO(NNS1-3645): with_chunks_mut


### PR DESCRIPTION
(Still) does NOT make the `get_chunk` method do anything USEFUL yet, because there is no way to actually add chunks yet, but that will come later.

This just sets up the back end/stable memory, and makes it readable via canister calls.

This does cause a minor behavior change though: instead of panic, get_chunk actually returns. However, it's always "not found" (for now). This is hardly worth mentioning in release notes.

# References

Closes [NNS1-3680][jira]

[jira]: https://dfinity.atlassian.net/browse/NNS1-3680

[👈 Previous PR][prev]

[prev]: https://github.com/dfinity/ic/pull/4451

[NNS1-3680]: https://dfinity.atlassian.net/browse/NNS1-3680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ