### PR TITLE
feat(sns): Add new neuron command `SetFollowingForTopics`

### DIFF
--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -16,6 +16,7 @@ pub struct NeuronPermission {
     Default,
     candid::CandidType,
     candid::Deserialize,
+    comparable::Comparable,
     Debug,
     Eq,
     std::hash::Hash,
@@ -27,6 +28,25 @@ pub struct NeuronPermission {
 pub struct NeuronId {
     #[serde(with = "serde_bytes")]
     pub id: Vec<u8>,
+}
+/// Neuron whose voting decisions are being followed.
+#[derive(
+    Default,
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Debug,
+    Eq,
+    std::hash::Hash,
+    Clone,
+    PartialEq,
+    PartialOrd,
+    Ord,
+)]
+pub struct Followee {
+    pub neuron_id: Option<NeuronId>,
+    /// Human-readable alias that helps identify this followee among other neurons.
+    pub alias: Option<String>,
 }
 /// A sequence of NeuronIds, which is used to get prost to generate a type isomorphic to Option<Vec<NeuronId>>.
 #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
@@ -163,14 +183,24 @@ pub mod neuron {
     }
 
     /// A list of a neuron's followees for a specific function.
-    #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
+    #[derive(
+        Default,
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Debug,
+        Clone,
+        PartialEq,
+    )]
     pub struct FolloweesForTopic {
-        pub followees: Vec<super::NeuronId>,
+        pub followees: Vec<super::Followee>,
         pub topic: Option<topics::Topic>,
     }
 
     // A collection of a neuron's followees (per topic).
-    #[derive(candid::CandidType, candid::Deserialize, Clone, Debug, PartialEq)]
+    #[derive(
+        candid::CandidType, candid::Deserialize, Clone, comparable::Comparable, Debug, PartialEq,
+    )]
     pub struct TopicFollowees {
         pub topic_id_to_followees: BTreeMap<u64, FolloweesForTopic>,
     }
@@ -1371,6 +1401,7 @@ pub mod governance {
             RemoveNeuronPermissions(super::super::manage_neuron::RemoveNeuronPermissions),
             Configure(super::super::manage_neuron::Configure),
             Follow(super::super::manage_neuron::Follow),
+            SetFollowingForTopics(super::super::manage_neuron::SetFollowingForTopics),
             MakeProposal(super::super::Proposal),
             RegisterVote(super::super::manage_neuron::RegisterVote),
             FinalizeDisburseMaturity(super::super::manage_neuron::FinalizeDisburseMaturity),
@@ -1818,6 +1849,13 @@ pub mod manage_neuron {
         pub function_id: u64,
         /// The list of followee neurons, specified by their neuron ID.
         pub followees: Vec<super::NeuronId>,
+    }
+    #[derive(
+        candid::CandidType, candid::Deserialize, comparable::Comparable, Clone, Debug, PartialEq,
+    )]
+    pub struct SetFollowingForTopics {
+        /// The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
+        pub topic_followees: ::core::option::Option<super::neuron::TopicFollowees>,
     }
     /// The operation that registers a given vote from the neuron for a given
     /// proposal (a directly cast vote as opposed to a vote that is cast as

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -97,7 +97,7 @@ type ClaimedSwapNeurons = record {
 type Command = variant {
   Split : Split;
   Follow : Follow;
-  FollowOnTopics : FollowOnTopics;
+  SetFollowingForTopics : SetFollowingForTopics;
   DisburseMaturity : DisburseMaturity;
   ClaimOrRefresh : ClaimOrRefresh;
   Configure : Configure;
@@ -114,7 +114,7 @@ type Command_1 = variant {
   Error : GovernanceError;
   Split : SplitResponse;
   Follow : record {};
-  FollowOnTopics : record {};
+  SetFollowingForTopics : record {};
   DisburseMaturity : DisburseMaturityResponse;
   ClaimOrRefresh : ClaimOrRefreshResponse;
   Configure : record {};
@@ -130,7 +130,7 @@ type Command_1 = variant {
 type Command_2 = variant {
   Split : Split;
   Follow : Follow;
-  FollowOnTopics : FollowOnTopics;
+  SetFollowingForTopics : SetFollowingForTopics;
   DisburseMaturity : DisburseMaturity;
   Configure : Configure;
   RegisterVote : RegisterVote;
@@ -216,13 +216,10 @@ type Follow = record {
   followees : vec NeuronId;
 };
 
-type Topics = record {
-  topics : vec Topic;
-};
-
-type FollowOnTopics = record {
-  topics : opt Topics;
-  followees : vec NeuronId;
+type SetFollowingForTopics = record {
+  topic_followees : opt record {
+    topic_id_to_followees : vec record { nat64; FolloweesForTopic };
+  };
 };
 
 type Followees = record {
@@ -504,7 +501,7 @@ type NervousSystemParameters = record {
 };
 
 type FolloweesForTopic = record {
-  followees : vec NeuronId;
+  followees : vec Followee;
   topic : opt Topic;
 };
 
@@ -531,6 +528,11 @@ type Neuron = record {
 
 type NeuronId = record {
   id : blob;
+};
+
+type Followee = record {
+  neuron_id : opt NeuronId;
+  alias : opt text;
 };
 
 type NeuronIds = record {

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -97,6 +97,7 @@ type ClaimedSwapNeurons = record {
 type Command = variant {
   Split : Split;
   Follow : Follow;
+  FollowOnTopics : FollowOnTopics;
   DisburseMaturity : DisburseMaturity;
   ClaimOrRefresh : ClaimOrRefresh;
   Configure : Configure;
@@ -113,6 +114,7 @@ type Command_1 = variant {
   Error : GovernanceError;
   Split : SplitResponse;
   Follow : record {};
+  FollowOnTopics : record {};
   DisburseMaturity : DisburseMaturityResponse;
   ClaimOrRefresh : ClaimOrRefreshResponse;
   Configure : record {};
@@ -128,6 +130,7 @@ type Command_1 = variant {
 type Command_2 = variant {
   Split : Split;
   Follow : Follow;
+  FollowOnTopics : FollowOnTopics;
   DisburseMaturity : DisburseMaturity;
   Configure : Configure;
   RegisterVote : RegisterVote;
@@ -210,6 +213,15 @@ type FinalizeDisburseMaturity = record {
 
 type Follow = record {
   function_id : nat64;
+  followees : vec NeuronId;
+};
+
+type Topics = record {
+  topics : vec Topic;
+};
+
+type FollowOnTopics = record {
+  topics : opt Topics;
   followees : vec NeuronId;
 };
 

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -106,6 +106,7 @@ type ClaimedSwapNeurons = record {
 type Command = variant {
   Split : Split;
   Follow : Follow;
+  SetFollowingForTopics : SetFollowingForTopics;
   DisburseMaturity : DisburseMaturity;
   ClaimOrRefresh : ClaimOrRefresh;
   Configure : Configure;
@@ -122,6 +123,7 @@ type Command_1 = variant {
   Error : GovernanceError;
   Split : SplitResponse;
   Follow : record {};
+  SetFollowingForTopics : record {};
   DisburseMaturity : DisburseMaturityResponse;
   ClaimOrRefresh : ClaimOrRefreshResponse;
   Configure : record {};
@@ -137,6 +139,7 @@ type Command_1 = variant {
 type Command_2 = variant {
   Split : Split;
   Follow : Follow;
+  SetFollowingForTopics : SetFollowingForTopics;
   DisburseMaturity : DisburseMaturity;
   Configure : Configure;
   RegisterVote : RegisterVote;
@@ -221,6 +224,13 @@ type Follow = record {
   function_id : nat64;
   followees : vec NeuronId;
 };
+
+type SetFollowingForTopics = record {
+  topic_followees : opt record {
+    topic_id_to_followees : vec record { nat64; FolloweesForTopic };
+  };
+};
+
 
 type Followees = record {
   followees : vec NeuronId;
@@ -506,7 +516,7 @@ type NervousSystemParameters = record {
 };
 
 type FolloweesForTopic = record {
-  followees : vec NeuronId;
+  followees : vec Followee;
   topic : opt Topic;
 };
 
@@ -533,6 +543,11 @@ type Neuron = record {
 
 type NeuronId = record {
   id : blob;
+};
+
+type Followee = record {
+  neuron_id : opt NeuronId;
+  alias : opt text;
 };
 
 type NeuronIds = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -68,6 +68,13 @@ message NeuronId {
   bytes id = 1;
 }
 
+// Neuron whose voting decisions are being followed.
+message Followee {
+  NeuronId neuron_id = 1;
+  // Human-readable alias that helps identify this followee among other neurons.
+  optional string alias = 2;
+}
+
 // A sequence of NeuronIds, which is used to get prost to generate a type isomorphic to Option<Vec<NeuronId>>.
 message NeuronIds {
   repeated NeuronId neuron_ids = 1;
@@ -166,7 +173,7 @@ message Neuron {
 
   // A list of a neuron's followees, possibly associated with a given topic.
   message FolloweesForTopic {
-    repeated NeuronId followees = 1;
+    repeated Followee followees = 1;
     optional Topic topic = 2;
   }
 
@@ -1324,6 +1331,7 @@ message Governance {
       ManageNeuron.RemoveNeuronPermissions remove_neuron_permissions = 8;
       ManageNeuron.Configure configure = 9;
       ManageNeuron.Follow follow = 10;
+      ManageNeuron.SetFollowingForTopics set_following_for_topics = 14;
       Proposal make_proposal = 11;
       ManageNeuron.RegisterVote register_vote = 12;
       ManageNeuron.FinalizeDisburseMaturity finalize_disburse_maturity = 13;
@@ -1781,6 +1789,11 @@ message ManageNeuron {
 
     // The list of followee neurons, specified by their neuron ID.
     repeated NeuronId followees = 2;
+  }
+
+  message SetFollowingForTopics {
+    // The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
+    optional Neuron.TopicFollowees topic_followees = 1;
   }
 
   // The operation that registers a given vote from the neuron for a given

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -33,6 +33,22 @@ pub struct NeuronId {
     #[serde(with = "serde_bytes")]
     pub id: ::prost::alloc::vec::Vec<u8>,
 }
+/// Neuron whose voting decisions are being followed.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct Followee {
+    #[prost(message, optional, tag = "1")]
+    pub neuron_id: ::core::option::Option<NeuronId>,
+    /// Human-readable alias that helps identify this followee among other neurons.
+    #[prost(string, optional, tag = "2")]
+    pub alias: ::core::option::Option<::prost::alloc::string::String>,
+}
 /// A sequence of NeuronIds, which is used to get prost to generate a type isomorphic to Option<Vec<NeuronId>>.
 #[derive(
     candid::CandidType,
@@ -215,7 +231,7 @@ pub mod neuron {
     )]
     pub struct FolloweesForTopic {
         #[prost(message, repeated, tag = "1")]
-        pub followees: ::prost::alloc::vec::Vec<super::NeuronId>,
+        pub followees: ::prost::alloc::vec::Vec<super::Followee>,
         #[prost(enumeration = "super::Topic", optional, tag = "2")]
         pub topic: ::core::option::Option<i32>,
     }
@@ -1826,7 +1842,7 @@ pub mod governance {
         pub timestamp: u64,
         #[prost(
             oneof = "neuron_in_flight_command::Command",
-            tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 20"
+            tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 14, 11, 12, 13, 20"
         )]
         pub command: ::core::option::Option<neuron_in_flight_command::Command>,
     }
@@ -1876,6 +1892,8 @@ pub mod governance {
             Configure(super::super::manage_neuron::Configure),
             #[prost(message, tag = "10")]
             Follow(super::super::manage_neuron::Follow),
+            #[prost(message, tag = "14")]
+            SetFollowingForTopics(super::super::manage_neuron::SetFollowingForTopics),
             #[prost(message, tag = "11")]
             MakeProposal(super::super::Proposal),
             #[prost(message, tag = "12")]
@@ -2619,6 +2637,19 @@ pub mod manage_neuron {
         /// The list of followee neurons, specified by their neuron ID.
         #[prost(message, repeated, tag = "2")]
         pub followees: ::prost::alloc::vec::Vec<super::NeuronId>,
+    }
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct SetFollowingForTopics {
+        /// The neuron's followees, specified as a map of proposal topics IDs to followees neuron IDs.
+        #[prost(message, optional, tag = "1")]
+        pub topic_followees: ::core::option::Option<super::neuron::TopicFollowees>,
     }
     /// The operation that registers a given vote from the neuron for a given
     /// proposal (a directly cast vote as opposed to a vote that is cast as


### PR DESCRIPTION
This PR adds a new neuron management command, `SetFollowingForTopics`. This command is not currently implemented and cannot be used; we just introduce the required API level changes.