### PR TITLE
docs(governance-backend): Updated CHANGELOG.md files for 2025-03-21 release.

### DIFF
--- a/rs/nns/governance/CHANGELOG.md
+++ b/rs/nns/governance/CHANGELOG.md
@@ -10,6 +10,16 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 
 INSERT NEW RELEASES HERE
 
+
+# 2025-03-21: Proposal 135933
+
+http://dashboard.internetcomputer.org/proposal/135933
+
+## Changed
+
+* Refactor `prune_following` task to use the `timer_task` library, and therefore enables metrics to
+  be collected about its execution.
+
 # 2025-03-17: Proposal 135847
 
 https://dashboard.internetcomputer.org/proposal/135847

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,9 +11,6 @@ on the process that this file is part of, see
 
 ## Changed
 
-* Refactor `prune_following` task to use the `timer_task` library, and therefore enables metrics to
-  be collected about its execution.
-
 ## Deprecated
 
 ## Removed

--- a/rs/registry/canister/CHANGELOG.md
+++ b/rs/registry/canister/CHANGELOG.md
@@ -10,22 +10,25 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 
 INSERT NEW RELEASES HERE
 
-## Changed
+# 2025-03-21: Proposal 135934
 
-## Deprecated
+https://dashboard.internetcomputer.org/proposal/135934
+
+No "real" behavior changes. This is just a maintenance upgrade.
+
+Technically, there is a new get_chunk method, but it does not actually do anything useful yet. Watch this space.
+
+
+# 2025-02-13: Proposal 135300
+
+https://dashboard.internetcomputer.org/proposal/135300
 
 ## Fixed
 
-### Update the correct node operator ID in do_remove_node_directly
+### Disable replacement of nodes that are active in subnets
 
-Fix for the do_remove_node_directly function to update the correct node operator ID record.
-In the past the caller_id and the node_operator_id for the node were always the same.
-However, since #3285 the caller_id and the node_operator_id for the removed node may differ,
-and this introduces a bug in this edge case.
-
-The bug resulted in a node reward discrepancy for a few operator records, identified in the
-regular administrative checks before the reward distribution and [described in the forum](https://forum.dfinity.org/t/issue-with-node-provider-rewards/41109/2) and
-mitigated with a few NNS proposals referenced in the forum thread.
+Direct node replacements of nodes that are active in a subnet may result in unexpected behavior and potential problems in the current Consensus code.
+So to be on the safe side we need to disable the functionality on the Registry side until the rest of the core protocol can handle it safely.
 
 
 # 2025-02-07: Proposal 135207

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -17,9 +17,4 @@ on the process that this file is part of, see
 
 ## Fixed
 
-### Disable replacement of nodes that are active in subnets
-
-Direct node replacements of nodes that are active in a subnet may result in unexpected behavior and potential problems in the current Consensus code.
-So to be on the safe side we need to disable the functionality on the Registry side until the rest of the core protocol can handle it safely.
-
 ## Security

--- a/rs/sns/governance/CHANGELOG.md
+++ b/rs/sns/governance/CHANGELOG.md
@@ -10,6 +10,19 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 
 INSERT NEW RELEASES HERE
 
+
+# 2025-03-21: Proposal 135935
+
+http://dashboard.internetcomputer.org/proposal/135935
+
+## Added
+
+* Added `Neuron.topic_followees` to support the upcoming [SNS topics](https://forum.dfinity.org/t/sns-topics-design) feature.
+
+## Changed
+
+- `SetTopcisForCustomProposals` proposal is now under the `CriticalDappOperations` topic.
+
 # 2025-03-17: Proposal 135852
 
 https://dashboard.internetcomputer.org/proposal/135852

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -9,11 +9,7 @@ on the process that this file is part of, see
 
 ## Added
 
-* Added `Neuron.topic_followees` to support the upcoming [SNS topics](https://forum.dfinity.org/t/sns-topics-design) feature.
-
 ## Changed
-
-- `SetTopcisForCustomProposals` proposal is now under the `CriticalDappOperations` topic.
 
 ## Deprecated
 

--- a/rs/sns/swap/CHANGELOG.md
+++ b/rs/sns/swap/CHANGELOG.md
@@ -11,6 +11,13 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-03-21: Proposal 135936
+
+https://dashboard.internetcomputer.org/proposal/135936
+
+No behavior changes. This is just a maintenance upgrade.
+
+
 # 2025-02-15: Proposal 135316
 
 http://dashboard.internetcomputer.org/proposal/135316


### PR DESCRIPTION
Registry CHANGELOG.md needed some manual re-work, due to earlier mistakes.

In particular, [proposal 135286][p86] was rejected, and we forgot to add an entry for [proposal 135300][p00], which I guess was an emergency upgrade.

[p86]: https://dashboard.internetcomputer.org/proposal/135286
[p00]: https://dashboard.internetcomputer.org/proposal/135300