### PR TITLE
feat(PocketIC): ability to check if auto progress is enabled

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- The function `PocketIc::auto_progress_enabled` to determine whether the automatic progress was enabled for the PocketIC instance.
+
 ### Removed
 - The module `management_canister` used to contain interface types of the IC management canister. Those types have since been published on crates.io as `ic-management-canister-types`, so PocketIC can depend on that and remove the redundant types.
 - The subnet ID from the functions `SubnetSpec::with_state_dir`, `PocketIcBuilder::with_nns_state`, and `PocketIcBuilder::with_subnet_state`;
   the subnet ID from the type `SubnetStateConfig`; and the functions `SubnetSpec::get_subnet_id` and `SubnetStateConfig::get_subnet_id`.
 
 ### Changed
-
 - The functions `PocketIcBuilder::with_nns_subnet`, `PocketIcBuilder::with_sns_subnet`, `PocketIcBuilder::with_ii_subnet`, `PocketIcBuilder::with_fiduciary_subnet`, and `PocketIcBuilder::with_bitcoin_subnet` do not add a new empty subnet if a subnet of the corresponding kind has already been specified (e.g., with state loaded from a given state directory).
 
 

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -538,6 +538,13 @@ impl PocketIc {
         runtime.block_on(async { self.pocket_ic.auto_progress().await })
     }
 
+    /// Returns whether automatic progress is enabled on the PocketIC instance.
+    #[instrument(skip(self), fields(instance_id=self.pocket_ic.instance_id))]
+    pub fn auto_progress_enabled(&self) -> bool {
+        let runtime = self.runtime.clone();
+        runtime.block_on(async { self.pocket_ic.auto_progress_enabled().await })
+    }
+
     /// Stops automatic progress (see `auto_progress`) on the IC.
     #[instrument(skip(self), fields(instance_id=self.pocket_ic.instance_id))]
     pub fn stop_progress(&self) {

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -326,6 +326,12 @@ impl PocketIc {
         self.instance_url()
     }
 
+    /// Returns whether automatic progress is enabled on the PocketIC instance.
+    #[instrument(skip(self), fields(instance_id=self.instance_id))]
+    pub async fn auto_progress_enabled(&self) -> bool {
+        self.get("auto_progress").await
+    }
+
     pub(crate) fn instance_url(&self) -> Url {
         self.server_url
             .join("/instances/")

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Changed
+### Added
+- The `GET` endpoint `/instances/<instance_id>/auto_progress` that returns whether the automatic progress was enable for the PocketIC instance.
 
+### Changed
 - The II canister always belongs to the dedicated II subnet (the II canister used to belong to the NNS subnet if no II subnet was specified).
 
 

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -200,6 +200,8 @@ where
         // i.e., periodically update the time of the IC instance
         // to the real time and execute rounds on the subnets.
         .api_route("/{id}/auto_progress", post(auto_progress))
+        // Returns whether automatic progress is enabled for an IC instance.
+        .api_route("/{id}/auto_progress", get(get_auto_progress))
         //
         // Stop automatic progress (see endpoint `auto_progress`)
         // on an IC instance.
@@ -1280,6 +1282,14 @@ pub async fn auto_progress(
     } else {
         (StatusCode::OK, Json(ApiResponse::Success(())))
     }
+}
+
+pub async fn get_auto_progress(
+    State(AppState { api_state, .. }): State<AppState>,
+    Path(id): Path<InstanceId>,
+) -> (StatusCode, Json<ApiResponse<bool>>) {
+    let auto_progress = api_state.get_auto_progress(id).await;
+    (StatusCode::OK, Json(ApiResponse::Success(auto_progress)))
 }
 
 pub async fn stop_progress(

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -1061,6 +1061,12 @@ impl ApiState {
         }
     }
 
+    pub async fn get_auto_progress(&self, instance_id: InstanceId) -> bool {
+        let instances = self.instances.read().await;
+        let instance = instances[instance_id].lock().await;
+        instance.progress_thread.is_some()
+    }
+
     pub async fn stop_progress(&self, instance_id: InstanceId) {
         let instances = self.instances.read().await;
         let mut instance = instances[instance_id].lock().await;

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -1554,8 +1554,12 @@ fn auto_progress() {
 
     let t0 = pic.get_time();
 
+    assert!(!pic.auto_progress_enabled());
+
     // Starting auto progress on the IC => a corresponding log should be made and time should start incresing automatically now.
     pic.auto_progress();
+
+    assert!(pic.auto_progress_enabled());
 
     loop {
         let mut bytes = [0; 1000];
@@ -1577,6 +1581,8 @@ fn auto_progress() {
 
     // Stopping auto progress on the IC => a corresponding log should be made.
     pic.stop_progress();
+
+    assert!(!pic.auto_progress_enabled());
 
     loop {
         let mut bytes = [0; 1000];


### PR DESCRIPTION
This PR adds the ability to check if auto progress is enabled on a PocketIC instance. The implementation follows the work by Serokell in this [PR](https://github.com/dfinity/ic/pull/4067).