### PR TITLE
chore(IDX): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,7 +91,7 @@ go_deps.bzl               @dfinity/idx
 /testnet/env/                                              @dfinity/platform-operations
 /testnet/release/                                          @dfinity/dre
 /testnet/tools/nns-tools/                                  @dfinity/nns-team
-/mainnet-subnet-revisions.json                             @dfinity/consensus @dfinity/dre
+/mainnet-icos-revisions.json                               @dfinity/consensus @dfinity/dre
 
 # [Rust]
 /rs/                                                    @dfinity/ic-interface-owners


### PR DESCRIPTION
When the file was renamed, codeowners was not updated.