### PR TITLE
feat: system API ic0.root_key_size and ic0.root_key_copy

### DIFF
--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -480,6 +480,26 @@ fn get_valid_system_apis_common(I: ValType) -> HashMap<String, HashMap<String, F
             )],
         ),
         (
+            "root_key_size",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![],
+                    return_type: vec![I],
+                },
+            )],
+        ),
+        (
+            "root_key_copy",
+            vec![(
+                API_VERSION_IC0,
+                FunctionSignature {
+                    param_types: vec![I, I, I],
+                    return_type: vec![],
+                },
+            )],
+        ),
+        (
             "certified_data_set",
             vec![(
                 API_VERSION_IC0,

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1157,6 +1157,38 @@ pub fn syscalls<
         .unwrap();
 
     linker
+        .func_wrap("ic0", "root_key_size", {
+            move |mut caller: Caller<'_, StoreData>| {
+                charge_for_cpu(&mut caller, overhead::ROOT_KEY_SIZE)?;
+                with_system_api(&mut caller, |s| s.ic0_root_key_size()).and_then(|s| {
+                    I::try_from(s).map_err(|e| {
+                        anyhow::Error::msg(format!("ic0::root_key_size failed: {}", e))
+                    })
+                })
+            }
+        })
+        .unwrap();
+
+    linker
+        .func_wrap("ic0", "root_key_copy", {
+            move |mut caller: Caller<'_, StoreData>, dst: I, offset: I, size: I| {
+                let dst: usize = dst.try_into().expect("Failed to convert I to usize");
+                let offset: usize = offset.try_into().expect("Failed to convert I to usize");
+                let size: usize = size.try_into().expect("Failed to convert I to usize");
+                charge_for_cpu_and_mem(&mut caller, overhead::ROOT_KEY_COPY, size)?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_root_key_copy(dst, offset, size, memory)
+                })?;
+                if feature_flags.write_barrier == FlagStatus::Enabled {
+                    mark_writes_on_bytemap(&mut caller, dst, size)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+
+    linker
         .func_wrap("ic0", "certified_data_set", {
             move |mut caller: Caller<'_, StoreData>, src: I, size: I| {
                 let src: usize = src.try_into().expect("Failed to convert I to usize");

--- a/rs/embedders/src/wasmtime_embedder/system_api_complexity.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api_complexity.rs
@@ -33,6 +33,8 @@ pub mod overhead {
     pub const CANISTER_SELF_SIZE: NumInstructions = NumInstructions::new(500);
     pub const CANISTER_STATUS: NumInstructions = NumInstructions::new(500);
     pub const CANISTER_VERSION: NumInstructions = NumInstructions::new(500);
+    pub const ROOT_KEY_SIZE: NumInstructions = NumInstructions::new(500);
+    pub const ROOT_KEY_COPY: NumInstructions = NumInstructions::new(500);
     pub const CERTIFIED_DATA_SET: NumInstructions = NumInstructions::new(500);
     pub const CONTROLLER_COPY: NumInstructions = NumInstructions::new(500);
     pub const CONTROLLER_SIZE: NumInstructions = NumInstructions::new(500);

--- a/rs/execution_environment/src/query_handler/query_cache/tests.rs
+++ b/rs/execution_environment/src/query_handler/query_cache/tests.rs
@@ -1479,6 +1479,8 @@ fn query_cache_future_proof_test() {
         | SystemApiCallId::CanisterSelfSize
         | SystemApiCallId::CanisterStatus
         | SystemApiCallId::CanisterVersion
+        | SystemApiCallId::RootKeySize
+        | SystemApiCallId::RootKeyCopy
         | SystemApiCallId::CertifiedDataSet
         | SystemApiCallId::CostCall
         | SystemApiCallId::CostCreateCanister

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -820,6 +820,8 @@ impl SchedulerTestBuilder {
 
         state.metadata.network_topology.subnets = generate_subnets(
             vec![self.own_subnet_id, self.nns_subnet_id],
+            self.nns_subnet_id,
+            None,
             self.own_subnet_id,
             self.subnet_type,
             registry_settings.subnet_size,

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -32,6 +32,7 @@ use ic_test_utilities_execution_environment::{
 use ic_test_utilities_metrics::{
     fetch_histogram_vec_stats, fetch_int_counter, metric_vec, HistogramStats,
 };
+use ic_test_utilities_types::ids::subnet_test_id;
 use ic_types::messages::{
     CanisterMessage, CanisterTask, MAX_INTER_CANISTER_PAYLOAD_IN_BYTES, NO_DEADLINE,
 };
@@ -1970,6 +1971,63 @@ fn ic0_msg_reject_msg_copy_called_with_length_that_exceeds_message_length() {
         "Unexpected error message: {}",
         err.description()
     );
+}
+
+fn ic0_root_key_works(test: &mut ExecutionTest, root_key: Vec<u8>) {
+    let wat = r#"
+        (module
+            (import "ic0" "root_key_size"
+                (func $root_key_size (result i32)))
+            (import "ic0" "root_key_copy"
+                (func $root_key_copy (param i32 i32 i32)))
+            (import "ic0" "msg_reply" (func $msg_reply))
+            (import "ic0" "msg_reply_data_append"
+                (func $msg_reply_data_append (param i32 i32)))
+            (func (export "canister_update test")
+                ;; heap[0..4] = root_key_size
+                (i32.store (i32.const 0) (call $root_key_size))
+                ;; heap[4..6] = root_key_bytes[0..6]
+                (call $root_key_copy (i32.const 4) (i32.const 0) (i32.const 2))
+                ;; heap[6..(4 + n)] = subnet_id_bytes[2..n]
+                (call $root_key_copy (i32.const 6) (i32.const 2) (i32.sub (i32.load (i32.const 0)) (i32.const 2)))
+                ;; return heap[0..(4 + n)]
+                (call $msg_reply_data_append (i32.const 0) (i32.add (i32.const 4) (i32.load (i32.const 0))))
+                (call $msg_reply)
+            )
+            (memory 1 1)
+        )"#;
+    let canister_id = test.canister_from_wat(wat).unwrap();
+    let result = test.ingress(canister_id, "test", vec![]).unwrap();
+    let raw = match result {
+        WasmResult::Reply(data) => data,
+        WasmResult::Reject(msg) => panic!("Unexpected reject: {}", msg),
+    };
+    let n: u32 = u32::from_le_bytes(raw[0..4].try_into().unwrap());
+    assert_eq!(raw.len() as u32, 4 + n);
+    let actual_root_key: Vec<u8> = raw[4..].to_vec();
+    assert_eq!(actual_root_key, root_key);
+}
+
+#[test]
+fn ic0_root_key_works_on_nns_subnet() {
+    let root_key = vec![42, 43, 44, 45, 46, 47];
+    let mut test = ExecutionTestBuilder::new()
+        .with_nns_subnet_id(subnet_test_id(2))
+        .with_root_key(root_key.clone())
+        .with_own_subnet_id(subnet_test_id(2))
+        .build();
+    ic0_root_key_works(&mut test, root_key);
+}
+
+#[test]
+fn ic0_root_key_works_on_non_nns_subnet() {
+    let root_key = vec![42, 43, 44, 45, 46, 47];
+    let mut test = ExecutionTestBuilder::new()
+        .with_nns_subnet_id(subnet_test_id(2))
+        .with_root_key(root_key.clone())
+        .with_own_subnet_id(subnet_test_id(1))
+        .build();
+    ic0_root_key_works(&mut test, root_key);
 }
 
 #[test]

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -1986,9 +1986,9 @@ fn ic0_root_key_works(test: &mut ExecutionTest, root_key: Vec<u8>) {
             (func (export "canister_update test")
                 ;; heap[0..4] = root_key_size
                 (i32.store (i32.const 0) (call $root_key_size))
-                ;; heap[4..6] = root_key_bytes[0..6]
+                ;; heap[4..6] = root_key_bytes[0..2]
                 (call $root_key_copy (i32.const 4) (i32.const 0) (i32.const 2))
-                ;; heap[6..(4 + n)] = subnet_id_bytes[2..n]
+                ;; heap[6..(4 + n)] = root_key_bytes[2..n]
                 (call $root_key_copy (i32.const 6) (i32.const 2) (i32.sub (i32.load (i32.const 0)) (i32.const 2)))
                 ;; return heap[0..(4 + n)]
                 (call $msg_reply_data_append (i32.const 0) (i32.add (i32.const 4) (i32.load (i32.const 0))))

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -163,6 +163,10 @@ pub enum SystemApiCallId {
     CanisterStatus,
     /// Tracker for `ic0.canister_version()`
     CanisterVersion,
+    /// Tracker for `ic0.root_key_size()`
+    RootKeySize,
+    /// Tracker for `ic0.root_key_copy()`
+    RootKeyCopy,
     /// Tracker for `ic0.certified_data_set()`
     CertifiedDataSet,
     /// Tracker for `ic0.cost_call()`
@@ -1133,6 +1137,19 @@ pub trait SystemApi {
         &mut self,
         max_amount: Cycles,
         dst: usize,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()>;
+
+    /// Used to look up the size of the root key.
+    fn ic0_root_key_size(&self) -> HypervisorResult<usize>;
+
+    /// Used to copy the root key to the calling canister's heap
+    /// at the location specified by `dst` and `offset`.
+    fn ic0_root_key_copy(
+        &self,
+        dst: usize,
+        offset: usize,
+        size: usize,
         heap: &mut [u8],
     ) -> HypervisorResult<()>;
 

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -1143,8 +1143,8 @@ pub trait SystemApi {
     /// Used to look up the size of the root key.
     fn ic0_root_key_size(&self) -> HypervisorResult<usize>;
 
-    /// Used to copy the root key to the calling canister's heap
-    /// at the location specified by `dst` and `offset`.
+    /// Used to copy the root key (starting at `offset` and copying `size` bytes)
+    /// to the calling canister's heap at the location specified by `dst`.
     fn ic0_root_key_copy(
         &self,
         dst: usize,

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -3226,6 +3226,92 @@ impl SystemApi for SystemApiImpl {
         result
     }
 
+    fn ic0_root_key_size(&self) -> HypervisorResult<usize> {
+        let method_name = "ic0_root_key_size";
+        let result = match &self.api_type {
+            ApiType::Start { .. }
+            | ApiType::NonReplicatedQuery { .. }
+            | ApiType::InspectMessage { .. } => Err(self.error_for(method_name)),
+            ApiType::Init { .. }
+            | ApiType::SystemTask { .. }
+            | ApiType::Cleanup { .. }
+            | ApiType::Update { .. }
+            | ApiType::ReplicatedQuery { .. }
+            | ApiType::ReplyCallback { .. }
+            | ApiType::RejectCallback { .. }
+            | ApiType::PreUpgrade { .. } => {
+                // Reply and reject callbacks can be executed in non-replicated mode
+                // iff from within a composite query call. Always disallow in that case.
+                if self.execution_parameters.execution_mode == ExecutionMode::NonReplicated {
+                    return Err(self.error_for(method_name));
+                }
+
+                let root_key = self.sandbox_safe_system_state.get_root_key();
+                Ok(root_key.as_slice().len())
+            }
+        };
+
+        trace_syscall!(self, RootKeySize, result);
+        result
+    }
+
+    fn ic0_root_key_copy(
+        &self,
+        dst: usize,
+        offset: usize,
+        size: usize,
+        heap: &mut [u8],
+    ) -> HypervisorResult<()> {
+        let method_name = "ic0.root_key_copy";
+        let result = match &self.api_type {
+            ApiType::Start { .. }
+            | ApiType::NonReplicatedQuery { .. }
+            | ApiType::InspectMessage { .. } => Err(self.error_for(method_name)),
+            ApiType::Init { .. }
+            | ApiType::SystemTask { .. }
+            | ApiType::Cleanup { .. }
+            | ApiType::Update { .. }
+            | ApiType::ReplicatedQuery { .. }
+            | ApiType::ReplyCallback { .. }
+            | ApiType::RejectCallback { .. }
+            | ApiType::PreUpgrade { .. } => {
+                // Reply and reject callbacks can be executed in non-replicated mode
+                // iff from within a composite query call. Always disallow in that case.
+                if self.execution_parameters.execution_mode == ExecutionMode::NonReplicated {
+                    return Err(self.error_for(method_name));
+                }
+
+                valid_subslice(
+                    "ic0.root_key_copy heap",
+                    InternalAddress::new(dst),
+                    InternalAddress::new(size),
+                    heap,
+                )?;
+                let root_key = self.sandbox_safe_system_state.get_root_key();
+                let root_key_bytes = root_key.as_slice();
+                let slice = valid_subslice(
+                    "ic0.root_key_copy id",
+                    InternalAddress::new(offset),
+                    InternalAddress::new(size),
+                    root_key_bytes,
+                )?;
+                deterministic_copy_from_slice(&mut heap[dst..dst + size], slice);
+
+                Ok(())
+            }
+        };
+        trace_syscall!(
+            self,
+            RootKeyCopy,
+            dst,
+            offset,
+            size,
+            summarize(heap, dst, size)
+        );
+
+        result
+    }
+
     fn ic0_data_certificate_present(&self) -> HypervisorResult<i32> {
         let result = match &self.api_type {
             ApiType::Start { .. } => Err(self.error_for("ic0_data_certificate_present")),

--- a/rs/system_api/src/lib.rs
+++ b/rs/system_api/src/lib.rs
@@ -3290,7 +3290,7 @@ impl SystemApi for SystemApiImpl {
                 let root_key = self.sandbox_safe_system_state.get_root_key();
                 let root_key_bytes = root_key.as_slice();
                 let slice = valid_subslice(
-                    "ic0.root_key_copy id",
+                    "ic0.root_key_copy bytes",
                     InternalAddress::new(offset),
                     InternalAddress::new(size),
                     root_key_bytes,

--- a/rs/system_api/src/sandbox_safe_system_state.rs
+++ b/rs/system_api/src/sandbox_safe_system_state.rs
@@ -35,6 +35,9 @@ use std::str::FromStr;
 
 use crate::{cycles_balance_change::CyclesBalanceChange, routing, CERTIFIED_DATA_MAX_LENGTH};
 
+/// The ICP mainnet root key.
+const IC_ROOT_KEY: &[u8; 133] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00\x81\x4c\x0e\x6e\xc7\x1f\xab\x58\x3b\x08\xbd\x81\x37\x3c\x25\x5c\x3c\x37\x1b\x2e\x84\x86\x3c\x98\xa4\xf1\xe0\x8b\x74\x23\x5d\x14\xfb\x5d\x9c\x0c\xd5\x46\xd9\x68\x5f\x91\x3a\x0c\x0b\x2c\xc5\x34\x15\x83\xbf\x4b\x43\x92\xe4\x67\xdb\x96\xd6\x5b\x9b\xb4\xcb\x71\x71\x12\xf8\x47\x2e\x0d\x5a\x4d\x14\x50\x5f\xfd\x74\x84\xb0\x12\x91\x09\x1c\x5f\x87\xb9\x88\x83\x46\x3f\x98\x09\x1a\x0b\xaa\xae";
+
 /// The information that canisters can see about their own status.
 #[derive(Copy, Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub enum CanisterStatusView {
@@ -1392,6 +1395,15 @@ impl SandboxSafeSystemState {
         } else {
             false
         }
+    }
+
+    pub fn get_root_key(&self) -> Vec<u8> {
+        let root_subnet_id = self.network_topology.nns_subnet_id;
+        self.network_topology
+            .subnets
+            .get(&root_subnet_id)
+            .map(|subnet_topology| subnet_topology.public_key.clone())
+            .unwrap_or(IC_ROOT_KEY.to_vec())
     }
 
     pub fn get_subnet_id(&self) -> SubnetId {

--- a/rs/system_api/tests/system_api.rs
+++ b/rs/system_api/tests/system_api.rs
@@ -290,6 +290,8 @@ fn is_supported(api_type: SystemApiCallId, context: &str) -> bool {
         SystemApiCallId::Stable64Grow => vec!["*", "s"],
         SystemApiCallId::Stable64Write => vec!["*", "s"],
         SystemApiCallId::Stable64Read => vec!["*", "s"],
+        SystemApiCallId::RootKeySize => vec!["I", "G", "U", "RQ", "Ry", "Rt", "C", "T"],
+        SystemApiCallId::RootKeyCopy => vec!["I", "G", "U", "RQ", "Ry", "Rt", "C", "T"],
         SystemApiCallId::CertifiedDataSet => vec!["I", "G", "U", "Ry", "Rt", "T"],
         SystemApiCallId::DataCertificatePresent => vec!["*"],
         SystemApiCallId::DataCertificateSize => vec!["NRQ", "CQ"],
@@ -740,6 +742,26 @@ fn api_availability_test(
         SystemApiCallId::DataCertificateCopy => {
             assert_api_availability(
                 |mut api| api.ic0_data_certificate_copy(0, 0, 0, &mut [42; 128]),
+                api_type,
+                &system_state,
+                cycles_account_manager,
+                api_type_enum,
+                context,
+            );
+        }
+        SystemApiCallId::RootKeySize => {
+            assert_api_availability(
+                |api| api.ic0_root_key_size(),
+                api_type,
+                &system_state,
+                cycles_account_manager,
+                api_type_enum,
+                context,
+            );
+        }
+        SystemApiCallId::RootKeyCopy => {
+            assert_api_availability(
+                |api| api.ic0_root_key_copy(0, 0, 0, &mut [42; 128]),
                 api_type,
                 &system_state,
                 cycles_account_manager,

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -93,6 +93,8 @@ const INITIAL_CANISTER_CYCLES: Cycles = Cycles::new(1_000_000_000_000);
 /// A helper to create subnets.
 pub fn generate_subnets(
     subnet_ids: Vec<SubnetId>,
+    nns_subnet_id: SubnetId,
+    root_key: Option<Vec<u8>>,
     own_subnet_id: SubnetId,
     own_subnet_type: SubnetType,
     own_subnet_size: usize,
@@ -108,10 +110,15 @@ pub fn generate_subnets(
                 nodes.insert(node_test_id(i as u64));
             }
         }
+        let public_key = if subnet_id == nns_subnet_id {
+            root_key.clone().unwrap_or(vec![1, 2, 3, 4])
+        } else {
+            vec![1, 2, 3, 4]
+        };
         result.insert(
             subnet_id,
             SubnetTopology {
-                public_key: vec![1, 2, 3, 4],
+                public_key,
                 nodes,
                 subnet_type,
                 subnet_features: SubnetFeatures::default(),
@@ -132,7 +139,7 @@ pub fn generate_network_topology(
 ) -> NetworkTopology {
     NetworkTopology {
         nns_subnet_id,
-        subnets: generate_subnets(subnets, own_subnet_id, own_subnet_type, subnet_size),
+        subnets: generate_subnets(subnets, nns_subnet_id, None, own_subnet_id, own_subnet_type, subnet_size),
         routing_table: match routing_table {
             Some(routing_table) => Arc::new(routing_table),
             None => {
@@ -1730,6 +1737,7 @@ impl ExecutionTest {
 pub struct ExecutionTestBuilder {
     execution_config: Config,
     nns_subnet_id: SubnetId,
+    root_key: Option<Vec<u8>>,
     own_subnet_id: SubnetId,
     caller_subnet_id: Option<SubnetId>,
     subnet_type: SubnetType,
@@ -1772,6 +1780,7 @@ impl Default for ExecutionTestBuilder {
                 ..Config::default()
             },
             nns_subnet_id: subnet_test_id(2),
+            root_key: None,
             own_subnet_id: subnet_test_id(1),
             caller_subnet_id: None,
             subnet_type,
@@ -1818,6 +1827,12 @@ impl ExecutionTestBuilder {
         }
     }
 
+    pub fn with_root_key(self, root_key: Vec<u8>) -> Self {
+        Self {
+            root_key: Some(root_key),
+            ..self
+        }
+    }
     pub fn with_own_subnet_id(self, own_subnet_id: SubnetId) -> Self {
         Self {
             own_subnet_id,
@@ -2230,6 +2245,8 @@ impl ExecutionTestBuilder {
         subnets.extend(self.caller_subnet_id.iter().copied());
         state.metadata.network_topology.subnets = generate_subnets(
             subnets,
+            self.nns_subnet_id,
+            self.root_key,
             self.own_subnet_id,
             self.subnet_type,
             self.registry_settings.subnet_size,

--- a/rs/tests/execution/general_execution_test.rs
+++ b/rs/tests/execution/general_execution_test.rs
@@ -8,6 +8,7 @@ use general_execution_tests::api_tests::test_controller;
 use general_execution_tests::api_tests::test_cycles_burn;
 use general_execution_tests::api_tests::test_in_replicated_execution;
 use general_execution_tests::api_tests::test_raw_rand_api;
+use general_execution_tests::api_tests::{root_key_on_nns_subnet, root_key_on_non_nns_subnet};
 use general_execution_tests::big_stable_memory::*;
 use general_execution_tests::canister_heartbeat::*;
 use general_execution_tests::canister_lifecycle::*;
@@ -100,7 +101,9 @@ fn main() -> Result<()> {
                 .add_test(systest!(install_large_wasm_with_other_store))
                 .add_test(systest!(
                     install_large_wasm_with_other_store_fails_cross_subnet
-                )),
+                ))
+                .add_test(systest!(root_key_on_nns_subnet))
+                .add_test(systest!(root_key_on_non_nns_subnet)),
         )
         .execute_from_args()?;
 

--- a/rs/universal_canister/impl/src/api.rs
+++ b/rs/universal_canister/impl/src/api.rs
@@ -61,6 +61,8 @@ mod ic0 {
         pub fn stable64_grow(additional_pages: u64) -> u64;
         pub fn stable64_read(dst: u64, offset: u64, size: u64) -> ();
         pub fn stable64_write(offset: u64, src: u64, size: u64) -> ();
+        pub fn root_key_size() -> u32;
+        pub fn root_key_copy(dst: u32, offset: u32, size: u32) -> ();
         pub fn certified_data_set(src: u32, size: u32) -> ();
         pub fn data_certificate_present() -> u32;
         pub fn data_certificate_size() -> u32;
@@ -343,6 +345,23 @@ pub fn stable64_write(offset: u64, data: &[u8]) {
     unsafe {
         ic0::stable64_write(offset, data.as_ptr() as u64, data.len() as u64);
     }
+}
+
+pub fn root_key_size() -> u32 {
+    unsafe { ic0::root_key_size() }
+}
+
+pub fn root_key_copy(offset: u32, size: u32) -> Vec<u8> {
+    let mut bytes = vec![0; size as usize];
+    unsafe {
+        ic0::root_key_copy(bytes.as_mut_ptr() as u32, offset, size);
+    }
+    bytes
+}
+
+/// Returns the root key.
+pub fn root_key() -> Vec<u8> {
+    root_key_copy(0, root_key_size())
 }
 
 pub fn certified_data_set(data: &[u8]) {

--- a/rs/universal_canister/impl/src/lib.rs
+++ b/rs/universal_canister/impl/src/lib.rs
@@ -121,5 +121,6 @@ try_from_u8!(
         CostVetkdDeriveKey = 91,
         LiquidCyclesBalance128 = 92,
         CallDataAppendCyclesAddMax = 93,
+        RootKey = 94,
     }
 );

--- a/rs/universal_canister/impl/src/main.rs
+++ b/rs/universal_canister/impl/src/main.rs
@@ -503,6 +503,9 @@ fn eval(ops_bytes: OpsBytes) {
                 let amount_high = (balance >> 64) as u64;
                 api::call_cycles_add128(amount_high, amount_low)
             }
+            Ops::RootKey => {
+                stack.push_blob(api::root_key());
+            }
         }
     }
 }

--- a/rs/universal_canister/lib/src/lib.rs
+++ b/rs/universal_canister/lib/src/lib.rs
@@ -659,6 +659,11 @@ impl PayloadBuilder {
         self
     }
 
+    pub fn root_key(mut self) -> Self {
+        self.0.push(Ops::RootKey as u8);
+        self
+    }
+
     pub fn certified_data_set(mut self, data: &[u8]) -> Self {
         self = self.push_bytes(data);
         self.0.push(Ops::CertifiedDataSet as u8);


### PR DESCRIPTION
This PR implements new system API `ic0.root_key_size` and `ic0.root_key_copy` for fetching the public key of the IC root key. This API can only be called in replicated execution to make canisters refrain from fetching the public key of the IC root key in an untrustworthy way.