### PR TITLE
test: [CON-1144] modify `cup_compatibility_test` to also test the compatibility against the version deployed on the `io67a` subnet

### DIFF
--- a/rs/tests/consensus/orchestrator/cup_compatibility_test.rs
+++ b/rs/tests/consensus/orchestrator/cup_compatibility_test.rs
@@ -122,13 +122,24 @@ fn download_mainnet_binary(version: String, log: &Logger, target_dir: &Path) -> 
     .expect("Failed to Download")
 }
 
-fn test(env: TestEnv) {
+fn nns_version_test(env: TestEnv) {
+    test(env, get_mainnet_nns_revision())
+}
+
+fn application_subnet_version_test(env: TestEnv) {
+    test(env, get_mainnet_application_subnet_revision())
+}
+
+fn test(env: TestEnv, mainnet_version: String) {
     let log = env.logger();
 
-    let mainnet_version = get_mainnet_nns_revision();
     info!(log, "Continuing with mainnet version {mainnet_version}");
 
     let output_dir = PathBuf::from("cup_compatibility_test");
+    if output_dir.exists() {
+        // Remove potential left-overs from the other test runs
+        fs::remove_dir_all(&output_dir).expect("Failed to remove directory");
+    }
     let branch_test = get_dependency_path("rs/tests/cup_compatibility/binaries/types_test");
     let tmp_dir = tempfile::tempdir().unwrap();
     let mainnet_test = download_mainnet_binary(mainnet_version, &log, tmp_dir.path());
@@ -175,7 +186,8 @@ fn test(env: TestEnv) {
 fn main() -> Result<()> {
     SystemTestGroup::new()
         .with_setup(|_| ())
-        .add_test(systest!(test))
+        .add_test(systest!(nns_version_test))
+        .add_test(systest!(application_subnet_version_test))
         .execute_from_args()?;
     Ok(())
 }

--- a/rs/tests/consensus/orchestrator/cup_compatibility_test.rs
+++ b/rs/tests/consensus/orchestrator/cup_compatibility_test.rs
@@ -22,7 +22,11 @@ end::catalog[] */
 
 use anyhow::Result;
 use ic_recovery::file_sync_helper::download_binary;
-use ic_system_test_driver::driver::{group::SystemTestGroup, test_env::TestEnv, test_env_api::*};
+use ic_system_test_driver::driver::test_env_api::{
+    get_dependency_path, get_mainnet_application_subnet_revision, get_mainnet_nns_revision,
+    READY_WAIT_TIMEOUT, RETRY_BACKOFF,
+};
+use ic_system_test_driver::driver::{group::SystemTestGroup, test_env::TestEnv};
 use ic_system_test_driver::systest;
 use ic_system_test_driver::util::block_on;
 use ic_types::ReplicaVersion;
@@ -138,7 +142,8 @@ fn test(env: TestEnv, mainnet_version: String) {
     let output_dir = PathBuf::from("cup_compatibility_test");
     if output_dir.exists() {
         // Remove potential left-overs from the other test runs
-        fs::remove_dir_all(&output_dir).expect("Failed to remove directory");
+        fs::remove_dir_all(&output_dir)
+            .expect("Should have all the permissions to remove the existing directory");
     }
     let branch_test = get_dependency_path("rs/tests/cup_compatibility/binaries/types_test");
     let tmp_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Currently, we only test against the version deployed on the NNS subnet, which is the oldest deployed replica version.
With this change, we will also test against the newest deployed replica version, i.e., the one running on the `io67a` subnet