### PR TITLE
test(IDX): unify the Nested VmType with Production

### DIFF
--- a/rs/ic_os/dev_test_tools/launch-single-vm/src/main.rs
+++ b/rs/ic_os/dev_test_tools/launch-single-vm/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
                 url: empty_disk_img_url,
                 sha256: empty_disk_img_sha256,
             },
-            VmType::Nested,
+            VmType::Production,
             Some(101.into()), // 101 GibiByte image
         )
     } else {

--- a/rs/tests/driver/src/driver/farm.rs
+++ b/rs/tests/driver/src/driver/farm.rs
@@ -628,7 +628,6 @@ impl CreateVmRequest {
 #[serde(rename_all = "camelCase")]
 pub enum VmType {
     Production,
-    Nested,
     Test,
     Sev,
 }

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -417,6 +417,6 @@ fn vm_spec_from_nested_node(
         has_ipv4: false,
         vm_allocation: None,
         required_host_features: Vec::new(),
-        alternate_template: Some(VmType::Nested),
+        alternate_template: Some(VmType::Production),
     }
 }


### PR DESCRIPTION
On Farm we copied the `nested.xml` libvirt domain template to `production.xml` which means we can remove `VmType::Nested` and thus simplify the `//rs/tests/nested:...` tests.