### PR TITLE
chore(IDX): upload artifacts on CI_ALL_BAZEL_TARGETS

### DIFF
--- a/ci/bazel-scripts/main.sh
+++ b/ci/bazel-scripts/main.sh
@@ -33,6 +33,8 @@ fi
 if [[ "${RUN_ON_DIFF_ONLY:-}" == "true" ]]; then
     # get bazel targets that changed within the MR
     BAZEL_TARGETS=$("${CI_PROJECT_DIR:-}"/ci/bazel-scripts/diff.sh)
+else
+    release_build="true"
 fi
 
 # if bazel targets is empty we don't need to run any tests


### PR DESCRIPTION
We used to have the logic when a PR was labelled with `CI_ALL_BAZEL_TARGETS` that besides testing all bazel targets (`//...`) the artifacts were also uploaded to our CDNs. This logic was removed in  41d5409c024dfb6e83f840f03e33b88f61ee8b1c but users still expect it. So this reintroduced this logic.

One consequence of this change is that since [we set `RUN_ON_DIFF_ONLY` to `false` on merge groups](https://github.com/dfinity/ic/pull/4477/files#diff-5c2fff2ad5fe9711aa24b06fc8959c5568d883acdc4927a6035159253b5ffb98L29-L31) this will cause artifacts to be published for every merge group. Note that this was the old logic but I'm not sure we want to have this.