### PR TITLE
refactor(consensus): Merge Imports in consensus crate

### DIFF
--- a/rs/consensus/benches/validate_payload.rs
+++ b/rs/consensus/benches/validate_payload.rs
@@ -53,16 +53,17 @@ use ic_test_utilities_types::{
 };
 use ic_types::{
     batch::{BatchPayload, IngressPayload, ValidationContext},
-    consensus::certification::*,
-    consensus::*,
+    consensus::{certification::*, *},
     crypto::Signed,
     ingress::{IngressState, IngressStatus},
     signature::*,
     time::UNIX_EPOCH,
     Height, NumBytes, PrincipalId, RegistryVersion, Time, UserId,
 };
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 type SignedCertificationContent =
     Signed<CertificationContent, ThresholdSignature<CertificationContent>>;

--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -36,9 +36,7 @@ use ic_types::{
     replica_config::ReplicaConfig,
     Height,
 };
-use std::cell::RefCell;
-use std::sync::Arc;
-use std::time::Instant;
+use std::{cell::RefCell, sync::Arc, time::Instant};
 
 pub struct Finalizer {
     pub(crate) replica_config: ReplicaConfig,

--- a/rs/consensus/src/consensus/priority.rs
+++ b/rs/consensus/src/consensus/priority.rs
@@ -1,6 +1,8 @@
 use ic_consensus_utils::pool_reader::PoolReader;
-use ic_interfaces::consensus_pool::ConsensusPool;
-use ic_interfaces::p2p::consensus::{Bouncer, BouncerValue, BouncerValue::*};
+use ic_interfaces::{
+    consensus_pool::ConsensusPool,
+    p2p::consensus::{Bouncer, BouncerValue, BouncerValue::*},
+};
 use ic_types::{artifact::ConsensusMessageId, consensus::ConsensusMessageHash, Height};
 
 /// Return a bouncer function that matches the given consensus pool.

--- a/rs/consensus/src/consensus/purger.rs
+++ b/rs/consensus/src/consensus/purger.rs
@@ -35,8 +35,7 @@ use ic_types::{
     replica_config::ReplicaConfig,
     Height,
 };
-use std::collections::BTreeSet;
-use std::{cell::RefCell, sync::Arc};
+use std::{cell::RefCell, collections::BTreeSet, sync::Arc};
 
 pub(crate) const VALIDATED_POOL_BOUNDS_CHECK_FREQUENCY: u64 = 10;
 

--- a/rs/consensus/src/idkg.rs
+++ b/rs/consensus/src/idkg.rs
@@ -180,16 +180,14 @@
 //! Completed pre-signatures are delivered to the deterministic state machnine,
 //! where they are matched with incoming signature requests.
 
-use crate::idkg::complaints::{IDkgComplaintHandler, IDkgComplaintHandlerImpl};
-use crate::idkg::metrics::{
-    timed_call, IDkgClientMetrics, CRITICAL_ERROR_IDKG_RETAIN_ACTIVE_TRANSCRIPTS,
+use crate::idkg::{
+    complaints::{IDkgComplaintHandler, IDkgComplaintHandlerImpl},
+    metrics::{timed_call, IDkgClientMetrics, CRITICAL_ERROR_IDKG_RETAIN_ACTIVE_TRANSCRIPTS},
+    pre_signer::{IDkgPreSigner, IDkgPreSignerImpl},
+    signer::{ThresholdSigner, ThresholdSignerImpl},
+    utils::IDkgBlockReaderImpl,
 };
-use crate::idkg::pre_signer::{IDkgPreSigner, IDkgPreSignerImpl};
-use crate::idkg::signer::{ThresholdSigner, ThresholdSignerImpl};
-use crate::idkg::utils::IDkgBlockReaderImpl;
-use ic_consensus_utils::bouncer_metrics::BouncerMetrics;
-use ic_consensus_utils::crypto::ConsensusCrypto;
-use ic_consensus_utils::RoundRobin;
+use ic_consensus_utils::{bouncer_metrics::BouncerMetrics, crypto::ConsensusCrypto, RoundRobin};
 use ic_interfaces::{
     consensus_pool::ConsensusBlockCache,
     crypto::IDkgProtocol,
@@ -200,16 +198,18 @@ use ic_interfaces_state_manager::StateReader;
 use ic_logger::{error, warn, ReplicaLogger};
 use ic_metrics::MetricsRegistry;
 use ic_replicated_state::ReplicatedState;
-use ic_types::crypto::canister_threshold_sig::error::IDkgRetainKeysError;
 use ic_types::{
-    artifact::IDkgMessageId, consensus::idkg::IDkgBlockReader, malicious_flags::MaliciousFlags,
+    artifact::IDkgMessageId, consensus::idkg::IDkgBlockReader,
+    crypto::canister_threshold_sig::error::IDkgRetainKeysError, malicious_flags::MaliciousFlags,
     Height, NodeId, SubnetId,
 };
 
-use std::cell::RefCell;
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::{
+    cell::RefCell,
+    collections::HashSet,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 pub(crate) mod complaints;
 #[cfg(any(feature = "malicious_code", test))]
@@ -564,12 +564,12 @@ mod tests {
 
     use super::*;
     use ic_test_utilities::state_manager::RefMockStateManager;
-    use ic_types::consensus::idkg::{
-        complaint_prefix, dealing_prefix, dealing_support_prefix, ecdsa_sig_share_prefix,
-        opening_prefix, schnorr_sig_share_prefix, vetkd_key_share_prefix, IDkgArtifactIdData,
-    };
     use ic_types::{
-        consensus::idkg::{RequestId, SigShareIdData},
+        consensus::idkg::{
+            complaint_prefix, dealing_prefix, dealing_support_prefix, ecdsa_sig_share_prefix,
+            opening_prefix, schnorr_sig_share_prefix, vetkd_key_share_prefix, IDkgArtifactIdData,
+            RequestId, SigShareIdData,
+        },
         crypto::{canister_threshold_sig::idkg::IDkgTranscriptId, CryptoHash},
     };
     use ic_types_test_utils::ids::{NODE_1, NODE_2, SUBNET_1, SUBNET_2};

--- a/rs/consensus/src/idkg/complaints.rs
+++ b/rs/consensus/src/idkg/complaints.rs
@@ -1,30 +1,34 @@
 //! The complaint handling
 
-use crate::idkg::metrics::{timed_call, IDkgComplaintMetrics};
-use crate::idkg::utils::IDkgBlockReaderImpl;
-
-use ic_consensus_utils::crypto::ConsensusCrypto;
-use ic_consensus_utils::RoundRobin;
-use ic_interfaces::consensus_pool::ConsensusBlockCache;
-use ic_interfaces::crypto::{ErrorReproducibility, IDkgProtocol};
-use ic_interfaces::idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool};
+use crate::idkg::{
+    metrics::{timed_call, IDkgComplaintMetrics},
+    utils::{update_purge_height, IDkgBlockReaderImpl},
+};
+use ic_consensus_utils::{crypto::ConsensusCrypto, RoundRobin};
+use ic_interfaces::{
+    consensus_pool::ConsensusBlockCache,
+    crypto::{ErrorReproducibility, IDkgProtocol},
+    idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool},
+};
 use ic_logger::{debug, warn, ReplicaLogger};
 use ic_metrics::MetricsRegistry;
-use ic_types::artifact::IDkgMessageId;
-use ic_types::consensus::idkg::{
-    complaint_prefix, opening_prefix, IDkgBlockReader, IDkgComplaintContent, IDkgMessage,
-    IDkgOpeningContent, SignedIDkgComplaint, SignedIDkgOpening, TranscriptRef,
+use ic_types::{
+    artifact::IDkgMessageId,
+    consensus::idkg::{
+        complaint_prefix, opening_prefix, IDkgBlockReader, IDkgComplaintContent, IDkgMessage,
+        IDkgOpeningContent, SignedIDkgComplaint, SignedIDkgOpening, TranscriptRef,
+    },
+    crypto::canister_threshold_sig::{
+        error::IDkgLoadTranscriptError,
+        idkg::{IDkgComplaint, IDkgOpening, IDkgTranscript, IDkgTranscriptId},
+    },
+    Height, NodeId, RegistryVersion,
 };
-use ic_types::crypto::canister_threshold_sig::error::IDkgLoadTranscriptError;
-use ic_types::crypto::canister_threshold_sig::idkg::{
-    IDkgComplaint, IDkgOpening, IDkgTranscript, IDkgTranscriptId,
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
 };
-use ic_types::{Height, NodeId, RegistryVersion};
-use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
-
-use super::utils::update_purge_height;
 
 pub(crate) trait IDkgComplaintHandler: Send {
     /// The on_state_change() called from the main IDKG path.
@@ -974,8 +978,7 @@ impl<'a> Action<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::idkg::test_utils::*;
-    use crate::idkg::utils::algorithm_for_key_id;
+    use crate::idkg::{test_utils::*, utils::algorithm_for_key_id};
     use assert_matches::assert_matches;
     use ic_consensus_utils::crypto::SignVerify;
     use ic_crypto_test_utils_canister_threshold_sigs::CanisterThresholdSigTestEnvironment;
@@ -983,11 +986,12 @@ mod tests {
     use ic_interfaces::p2p::consensus::{MutablePool, UnvalidatedArtifact};
     use ic_test_utilities_logger::with_test_replica_logger;
     use ic_test_utilities_types::ids::{NODE_1, NODE_2, NODE_3, NODE_4};
-    use ic_types::consensus::idkg::IDkgMasterPublicKeyId;
-    use ic_types::consensus::idkg::{IDkgObject, TranscriptRef};
-    use ic_types::crypto::AlgorithmId;
-    use ic_types::time::UNIX_EPOCH;
-    use ic_types::Height;
+    use ic_types::{
+        consensus::idkg::{IDkgMasterPublicKeyId, IDkgObject, TranscriptRef},
+        crypto::AlgorithmId,
+        time::UNIX_EPOCH,
+        Height,
+    };
 
     // Tests the Action logic
     #[test]

--- a/rs/consensus/src/idkg/malicious_pre_signer.rs
+++ b/rs/consensus/src/idkg/malicious_pre_signer.rs
@@ -1,8 +1,8 @@
 //! The malicious pre signature process manager
 
-use crate::idkg::metrics::IDkgPreSignerMetrics;
 use crate::idkg::{
-    pre_signer::IDkgPreSignerImpl, utils::transcript_op_summary, IDkgBlockReaderImpl,
+    metrics::IDkgPreSignerMetrics, pre_signer::IDkgPreSignerImpl, utils::transcript_op_summary,
+    IDkgBlockReaderImpl,
 };
 use ic_interfaces::{
     crypto::BasicSigner,
@@ -12,8 +12,10 @@ use ic_logger::{warn, ReplicaLogger};
 use ic_registry_client_helpers::node::RegistryVersion;
 use ic_types::{
     consensus::idkg::{IDkgBlockReader, IDkgMessage},
-    crypto::canister_threshold_sig::idkg::{IDkgDealing, IDkgTranscriptParams, SignedIDkgDealing},
-    crypto::{BasicSigOf, CryptoResult},
+    crypto::{
+        canister_threshold_sig::idkg::{IDkgDealing, IDkgTranscriptParams, SignedIDkgDealing},
+        BasicSigOf, CryptoResult,
+    },
     malicious_flags::MaliciousFlags,
     NodeId,
 };

--- a/rs/consensus/src/idkg/payload_builder.rs
+++ b/rs/consensus/src/idkg/payload_builder.rs
@@ -1,14 +1,13 @@
 //! This module implements the IDKG payload builder.
-use super::pre_signer::{IDkgTranscriptBuilder, IDkgTranscriptBuilderImpl};
-use super::signer::{ThresholdSignatureBuilder, ThresholdSignatureBuilderImpl};
-use super::utils::{
-    block_chain_reader, get_idkg_chain_key_config_if_enabled, InvalidChainCacheError,
+use crate::idkg::{
+    metrics::{IDkgPayloadMetrics, CRITICAL_ERROR_MASTER_KEY_TRANSCRIPT_MISSING},
+    pre_signer::{IDkgTranscriptBuilder, IDkgTranscriptBuilderImpl},
+    signer::{ThresholdSignatureBuilder, ThresholdSignatureBuilderImpl},
+    utils::{block_chain_reader, get_idkg_chain_key_config_if_enabled, InvalidChainCacheError},
 };
-use crate::idkg::metrics::{IDkgPayloadMetrics, CRITICAL_ERROR_MASTER_KEY_TRANSCRIPT_MISSING};
 pub(super) use errors::IDkgPayloadError;
 use errors::MembershipError;
-use ic_consensus_utils::crypto::ConsensusCrypto;
-use ic_consensus_utils::pool_reader::PoolReader;
+use ic_consensus_utils::{crypto::ConsensusCrypto, pool_reader::PoolReader};
 use ic_crypto::retrieve_mega_public_key_from_registry;
 use ic_interfaces::idkg::IDkgPool;
 use ic_interfaces_registry::RegistryClient;
@@ -17,21 +16,25 @@ use ic_logger::{error, info, warn, ReplicaLogger};
 use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_features::ChainKeyConfig;
 use ic_replicated_state::{metadata_state::subnet_call_context_manager::*, ReplicatedState};
-use ic_types::consensus::idkg::{HasIDkgMasterPublicKeyId, IDkgMasterPublicKeyId};
 use ic_types::{
     batch::ValidationContext,
     consensus::{
-        idkg::{self, IDkgBlockReader, IDkgPayload, MasterKeyTranscript, TranscriptAttributes},
+        idkg::{
+            self, HasIDkgMasterPublicKeyId, IDkgBlockReader, IDkgMasterPublicKeyId, IDkgPayload,
+            MasterKeyTranscript, TranscriptAttributes,
+        },
         Block, HasHeight,
     },
     crypto::canister_threshold_sig::idkg::InitialIDkgDealings,
     messages::CallbackId,
     Height, NodeId, RegistryVersion, SubnetId, Time,
 };
-use std::collections::{BTreeMap, BTreeSet};
-use std::ops::Deref;
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Deref,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 mod errors;
 mod key_transcript;
@@ -735,17 +738,18 @@ pub(crate) fn create_data_payload_helper_2(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::consensus::batch_delivery::generate_responses_to_signature_request_contexts;
-    use crate::idkg::test_utils::*;
-    use crate::idkg::utils::algorithm_for_key_id;
-    use crate::idkg::utils::block_chain_reader;
+    use crate::{
+        consensus::batch_delivery::generate_responses_to_signature_request_contexts,
+        idkg::{
+            test_utils::*,
+            utils::{algorithm_for_key_id, block_chain_reader},
+        },
+    };
     use assert_matches::assert_matches;
     use ic_consensus_mocks::{dependencies, Dependencies};
-    use ic_crypto_test_utils_canister_threshold_sigs::dummy_values::dummy_initial_idkg_dealing_for_tests;
-    use ic_crypto_test_utils_canister_threshold_sigs::generate_tecdsa_protocol_inputs;
-    use ic_crypto_test_utils_canister_threshold_sigs::generate_tschnorr_protocol_inputs;
     use ic_crypto_test_utils_canister_threshold_sigs::{
-        CanisterThresholdSigTestEnvironment, IDkgParticipants,
+        dummy_values::dummy_initial_idkg_dealing_for_tests, generate_tecdsa_protocol_inputs,
+        generate_tschnorr_protocol_inputs, CanisterThresholdSigTestEnvironment, IDkgParticipants,
     };
     use ic_crypto_test_utils_reproducible_rng::{reproducible_rng, ReproducibleRng};
     use ic_interfaces_registry::RegistryValue;
@@ -758,29 +762,29 @@ mod tests {
     use ic_test_utilities_consensus::fake::{Fake, FakeContentSigner};
     use ic_test_utilities_registry::{add_subnet_record, SubnetRecordBuilder};
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id, user_test_id};
-    use ic_types::batch::BatchPayload;
-    use ic_types::consensus::dkg::{DkgDataPayload, Summary};
-    use ic_types::consensus::idkg::IDkgPayload;
-    use ic_types::consensus::idkg::PreSigId;
-    use ic_types::consensus::idkg::ReshareOfUnmaskedParams;
-    use ic_types::consensus::idkg::TranscriptRef;
-    use ic_types::consensus::idkg::UnmaskedTranscript;
-    use ic_types::consensus::idkg::UnmaskedTranscriptWithAttributes;
-    use ic_types::consensus::DataPayload;
-    use ic_types::consensus::{
-        BlockPayload, BlockProposal, HashedBlock, Payload, Rank, SummaryPayload,
+    use ic_types::{
+        batch::BatchPayload,
+        consensus::{
+            dkg::{DkgDataPayload, Summary},
+            idkg::{
+                IDkgPayload, PreSigId, ReshareOfUnmaskedParams, TranscriptRef, UnmaskedTranscript,
+                UnmaskedTranscriptWithAttributes,
+            },
+            BlockPayload, BlockProposal, DataPayload, HashedBlock, Payload, Rank, SummaryPayload,
+        },
+        crypto::{
+            canister_threshold_sig::{
+                idkg::IDkgTranscript, ThresholdEcdsaCombinedSignature,
+                ThresholdSchnorrCombinedSignature,
+            },
+            CryptoHash, CryptoHashOf, ExtendedDerivationPath,
+        },
+        messages::CallbackId,
+        time::UNIX_EPOCH,
+        Height, Randomness, RegistryVersion,
     };
-    use ic_types::crypto::canister_threshold_sig::idkg::IDkgTranscript;
-    use ic_types::crypto::canister_threshold_sig::ThresholdEcdsaCombinedSignature;
-    use ic_types::crypto::canister_threshold_sig::ThresholdSchnorrCombinedSignature;
-    use ic_types::crypto::ExtendedDerivationPath;
-    use ic_types::crypto::{CryptoHash, CryptoHashOf};
-    use ic_types::time::UNIX_EPOCH;
-    use ic_types::Randomness;
-    use ic_types::{messages::CallbackId, Height, RegistryVersion};
     use idkg::common::CombinedSignature;
-    use std::collections::BTreeSet;
-    use std::convert::TryInto;
+    use std::{collections::BTreeSet, convert::TryInto};
 
     fn create_summary_block_with_transcripts(
         key_id: IDkgMasterPublicKeyId,

--- a/rs/consensus/src/idkg/payload_builder/key_transcript.rs
+++ b/rs/consensus/src/idkg/payload_builder/key_transcript.rs
@@ -212,6 +212,15 @@ pub(super) fn update_next_key_transcript(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::idkg::{
+        test_utils::{
+            create_reshare_unmasked_transcript_param,
+            fake_master_public_key_ids_for_all_idkg_algorithms, set_up_idkg_payload,
+            IDkgPayloadTestHelper, TestIDkgBlockReader, TestIDkgTranscriptBuilder,
+        },
+        utils::algorithm_for_key_id,
+    };
     use ic_crypto_test_utils_canister_threshold_sigs::{
         dummy_values::dummy_initial_idkg_dealing_for_tests, generate_key_transcript, node::Nodes,
         CanisterThresholdSigTestEnvironment, IDkgParticipants,
@@ -226,17 +235,6 @@ mod tests {
         Height,
     };
     use std::str::FromStr;
-
-    use crate::idkg::{
-        test_utils::{
-            create_reshare_unmasked_transcript_param,
-            fake_master_public_key_ids_for_all_idkg_algorithms, set_up_idkg_payload,
-            IDkgPayloadTestHelper, TestIDkgBlockReader, TestIDkgTranscriptBuilder,
-        },
-        utils::algorithm_for_key_id,
-    };
-
-    use super::*;
 
     #[test]
     fn get_created_key_transcript_returns_some_test() {

--- a/rs/consensus/src/idkg/payload_builder/key_transcript.rs
+++ b/rs/consensus/src/idkg/payload_builder/key_transcript.rs
@@ -1,17 +1,17 @@
-use std::collections::BTreeSet;
-
-use crate::idkg::{pre_signer::IDkgTranscriptBuilder, utils::algorithm_for_key_id};
+use crate::idkg::{
+    payload_builder::IDkgPayloadError, pre_signer::IDkgTranscriptBuilder,
+    utils::algorithm_for_key_id,
+};
 use ic_logger::{info, ReplicaLogger};
-use ic_types::consensus::idkg::HasIDkgMasterPublicKeyId;
 use ic_types::{
     consensus::idkg::{
-        self, IDkgBlockReader, IDkgUIDGenerator, MasterKeyTranscript, TranscriptAttributes,
+        self, HasIDkgMasterPublicKeyId, IDkgBlockReader, IDkgUIDGenerator, MasterKeyTranscript,
+        TranscriptAttributes,
     },
     crypto::canister_threshold_sig::idkg::IDkgTranscript,
     Height, NodeId, RegistryVersion,
 };
-
-use super::IDkgPayloadError;
+use std::collections::BTreeSet;
 
 pub(super) fn get_created_key_transcript(
     key_transcript: &idkg::MasterKeyTranscript,
@@ -220,9 +220,8 @@ mod tests {
     use ic_logger::replica_logger::no_op_logger;
     use ic_management_canister_types_private::{EcdsaKeyId, MasterPublicKeyId};
     use ic_test_utilities_types::ids::subnet_test_id;
-    use ic_types::consensus::idkg::HasIDkgMasterPublicKeyId;
-    use ic_types::consensus::idkg::IDkgMasterPublicKeyId;
     use ic_types::{
+        consensus::idkg::{HasIDkgMasterPublicKeyId, IDkgMasterPublicKeyId},
         crypto::{canister_threshold_sig::idkg::IDkgTranscript, AlgorithmId},
         Height,
     };

--- a/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
@@ -536,7 +536,6 @@ pub(super) mod test_utils {
 #[cfg(test)]
 pub(super) mod tests {
     use super::{test_utils::*, *};
-
     use crate::idkg::test_utils::{
         create_available_pre_signature, create_available_pre_signature_with_key_transcript,
         fake_ecdsa_idkg_master_public_key_id, fake_master_public_key_ids_for_all_idkg_algorithms,
@@ -561,7 +560,6 @@ pub(super) mod tests {
         SubnetId,
     };
     use idkg::IDkgTranscriptOperationRef;
-
     use strum::IntoEnumIterator;
 
     fn set_up(

--- a/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
@@ -1,6 +1,7 @@
-use super::IDkgPayloadError;
-
-use crate::idkg::{pre_signer::IDkgTranscriptBuilder, utils::algorithm_for_key_id};
+use crate::idkg::{
+    payload_builder::IDkgPayloadError, pre_signer::IDkgTranscriptBuilder,
+    utils::algorithm_for_key_id,
+};
 use ic_logger::{debug, error, ReplicaLogger};
 use ic_management_canister_types_private::MasterPublicKeyId;
 use ic_registry_subnet_features::ChainKeyConfig;
@@ -534,8 +535,7 @@ pub(super) mod test_utils {
 
 #[cfg(test)]
 pub(super) mod tests {
-    use super::test_utils::*;
-    use super::*;
+    use super::{test_utils::*, *};
 
     use crate::idkg::test_utils::{
         create_available_pre_signature, create_available_pre_signature_with_key_transcript,

--- a/rs/consensus/src/idkg/payload_builder/resharing.rs
+++ b/rs/consensus/src/idkg/payload_builder/resharing.rs
@@ -1,5 +1,4 @@
-use super::IDkgDealingContext;
-use crate::idkg::pre_signer::IDkgTranscriptBuilder;
+use crate::idkg::{payload_builder::IDkgDealingContext, pre_signer::IDkgTranscriptBuilder};
 use ic_logger::{warn, ReplicaLogger};
 use ic_management_canister_types_private::{
     ComputeInitialIDkgDealingsResponse, ReshareChainKeyResponse,
@@ -193,11 +192,10 @@ mod tests {
     use ic_logger::replica_logger::no_op_logger;
     use ic_management_canister_types_private::ComputeInitialIDkgDealingsResponse;
     use ic_test_utilities_types::ids::subnet_test_id;
-    use ic_types::consensus::idkg::IDkgMasterPublicKeyId;
-    use ic_types::consensus::idkg::IDkgPayload;
+    use ic_types::consensus::idkg::{IDkgMasterPublicKeyId, IDkgPayload};
 
-    use crate::idkg::payload_builder::filter_idkg_reshare_chain_key_contexts;
     use crate::idkg::{
+        payload_builder::filter_idkg_reshare_chain_key_contexts,
         test_utils::{
             create_reshare_request, dealings_context_from_reshare_request,
             fake_ecdsa_idkg_master_public_key_id,

--- a/rs/consensus/src/idkg/payload_builder/resharing.rs
+++ b/rs/consensus/src/idkg/payload_builder/resharing.rs
@@ -183,17 +183,6 @@ fn reshare_request_from_dealings_context(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use assert_matches::assert_matches;
-    use ic_crypto_test_utils_canister_threshold_sigs::dummy_values::{
-        dummy_dealings, dummy_initial_idkg_dealing_for_tests,
-    };
-    use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
-    use ic_logger::replica_logger::no_op_logger;
-    use ic_management_canister_types_private::ComputeInitialIDkgDealingsResponse;
-    use ic_test_utilities_types::ids::subnet_test_id;
-    use ic_types::consensus::idkg::{IDkgMasterPublicKeyId, IDkgPayload};
-
     use crate::idkg::{
         payload_builder::filter_idkg_reshare_chain_key_contexts,
         test_utils::{
@@ -204,6 +193,15 @@ mod tests {
         },
         utils::algorithm_for_key_id,
     };
+    use assert_matches::assert_matches;
+    use ic_crypto_test_utils_canister_threshold_sigs::dummy_values::{
+        dummy_dealings, dummy_initial_idkg_dealing_for_tests,
+    };
+    use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
+    use ic_logger::replica_logger::no_op_logger;
+    use ic_management_canister_types_private::ComputeInitialIDkgDealingsResponse;
+    use ic_test_utilities_types::ids::subnet_test_id;
+    use ic_types::consensus::idkg::{IDkgMasterPublicKeyId, IDkgPayload};
 
     fn set_up(
         key_ids: Vec<IDkgMasterPublicKeyId>,

--- a/rs/consensus/src/idkg/payload_builder/signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/signatures.rs
@@ -160,6 +160,7 @@ pub(crate) fn update_signature_agreements(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::idkg::test_utils::{
         create_available_pre_signature, empty_idkg_payload_with_key_ids, empty_response,
         fake_ecdsa_idkg_master_public_key_id, fake_master_public_key_ids_for_all_idkg_algorithms,
@@ -180,8 +181,6 @@ mod tests {
         Height,
     };
     use std::collections::BTreeSet;
-
-    use super::*;
 
     fn set_up(
         should_create_key_transcript: bool,

--- a/rs/consensus/src/idkg/payload_builder/signatures.rs
+++ b/rs/consensus/src/idkg/payload_builder/signatures.rs
@@ -1,3 +1,4 @@
+use crate::idkg::{metrics::IDkgPayloadMetrics, signer::ThresholdSignatureBuilder};
 use ic_error_types::RejectCode;
 use ic_management_canister_types_private::{Payload, SignWithECDSAReply, SignWithSchnorrReply};
 use ic_replicated_state::metadata_state::subnet_call_context_manager::IDkgSignWithThresholdContext;
@@ -7,8 +8,6 @@ use ic_types::{
     Time,
 };
 use std::collections::{BTreeMap, BTreeSet};
-
-use crate::{idkg::metrics::IDkgPayloadMetrics, idkg::signer::ThresholdSignatureBuilder};
 
 /// Helper to create a reject response to the management canister
 /// with the given code and message

--- a/rs/consensus/src/idkg/payload_verifier.rs
+++ b/rs/consensus/src/idkg/payload_verifier.rs
@@ -21,51 +21,56 @@
 //! approach, similar to what we have been doing in verifying other kinds
 //! payloads.
 
-use super::payload_builder::IDkgPayloadError;
-use super::pre_signer::IDkgTranscriptBuilder;
-use super::signer::ThresholdSignatureBuilder;
-use super::utils::{
-    block_chain_cache, get_idkg_chain_key_config_if_enabled, BuildSignatureInputsError,
-    IDkgBlockReaderImpl, InvalidChainCacheError,
+use crate::idkg::{
+    metrics::timed_call,
+    payload_builder::IDkgPayloadError,
+    payload_builder::{create_data_payload_helper, create_summary_payload},
+    pre_signer::IDkgTranscriptBuilder,
+    signer::ThresholdSignatureBuilder,
+    utils::build_signature_inputs,
+    utils::{
+        block_chain_cache, get_idkg_chain_key_config_if_enabled, BuildSignatureInputsError,
+        IDkgBlockReaderImpl, InvalidChainCacheError,
+    },
 };
-use crate::idkg::metrics::timed_call;
-use crate::idkg::payload_builder::{create_data_payload_helper, create_summary_payload};
-use crate::idkg::utils::build_signature_inputs;
-use ic_consensus_utils::crypto::ConsensusCrypto;
-use ic_consensus_utils::pool_reader::PoolReader;
-use ic_interfaces::crypto::{ThresholdEcdsaSigVerifier, ThresholdSchnorrSigVerifier};
-use ic_interfaces::validation::{ValidationError, ValidationResult};
+use ic_consensus_utils::{crypto::ConsensusCrypto, pool_reader::PoolReader};
+use ic_interfaces::{
+    crypto::{ThresholdEcdsaSigVerifier, ThresholdSchnorrSigVerifier},
+    validation::{ValidationError, ValidationResult},
+};
 use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::{StateManager, StateManagerError};
 use ic_management_canister_types_private::{Payload, SignWithECDSAReply, SignWithSchnorrReply};
-use ic_replicated_state::metadata_state::subnet_call_context_manager::{
-    IDkgSignWithThresholdContext, SignWithThresholdContext,
+use ic_replicated_state::{
+    metadata_state::subnet_call_context_manager::{
+        IDkgSignWithThresholdContext, SignWithThresholdContext,
+    },
+    ReplicatedState,
 };
-use ic_replicated_state::ReplicatedState;
-use ic_types::consensus::idkg::common::{CombinedSignature, ThresholdSigInputsRef};
-use ic_types::crypto::canister_threshold_sig::error::ThresholdSchnorrVerifyCombinedSigError;
-use ic_types::crypto::canister_threshold_sig::ThresholdSchnorrCombinedSignature;
-use ic_types::messages::CallbackId;
 use ic_types::{
     batch::ValidationContext,
     consensus::{
-        idkg::{self, ecdsa, schnorr, IDkgBlockReader, TranscriptRef},
+        idkg::{
+            self,
+            common::{CombinedSignature, ThresholdSigInputsRef},
+            ecdsa, schnorr, IDkgBlockReader, TranscriptRef,
+        },
         Block, BlockPayload, HasHeight,
     },
     crypto::canister_threshold_sig::{
         error::{
             IDkgVerifyInitialDealingsError, IDkgVerifyTranscriptError,
-            ThresholdEcdsaVerifyCombinedSignatureError,
+            ThresholdEcdsaVerifyCombinedSignatureError, ThresholdSchnorrVerifyCombinedSigError,
         },
         idkg::{IDkgTranscript, IDkgTranscriptId, InitialIDkgDealings, SignedIDkgDealing},
-        ThresholdEcdsaCombinedSignature,
+        ThresholdEcdsaCombinedSignature, ThresholdSchnorrCombinedSignature,
     },
+    messages::CallbackId,
     registry::RegistryClientError,
     Height, SubnetId,
 };
 use prometheus::HistogramVec;
-use std::collections::BTreeMap;
-use std::convert::TryFrom;
+use std::{collections::BTreeMap, convert::TryFrom};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug)]
@@ -625,8 +630,9 @@ mod test {
         utils::algorithm_for_key_id,
     };
     use assert_matches::assert_matches;
-    use ic_crypto_test_utils_canister_threshold_sigs::dummy_values::dummy_dealings;
-    use ic_crypto_test_utils_canister_threshold_sigs::CanisterThresholdSigTestEnvironment;
+    use ic_crypto_test_utils_canister_threshold_sigs::{
+        dummy_values::dummy_dealings, CanisterThresholdSigTestEnvironment,
+    };
     use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
     use ic_interfaces_state_manager::CertifiedStateSnapshot;
     use ic_logger::replica_logger::no_op_logger;

--- a/rs/consensus/src/idkg/pre_signer.rs
+++ b/rs/consensus/src/idkg/pre_signer.rs
@@ -1,34 +1,44 @@
 //! The pre signature process manager
 
-use crate::idkg::complaints::IDkgTranscriptLoader;
-use crate::idkg::metrics::{timed_call, IDkgPayloadMetrics, IDkgPreSignerMetrics};
-use crate::idkg::utils::{load_transcripts, transcript_op_summary, IDkgBlockReaderImpl};
-use ic_consensus_utils::crypto::ConsensusCrypto;
-use ic_consensus_utils::RoundRobin;
-use ic_interfaces::consensus_pool::ConsensusBlockCache;
-use ic_interfaces::crypto::{ErrorReproducibility, IDkgProtocol};
-use ic_interfaces::idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool};
+use crate::idkg::{
+    complaints::IDkgTranscriptLoader,
+    metrics::{timed_call, IDkgPayloadMetrics, IDkgPreSignerMetrics},
+    utils::{load_transcripts, transcript_op_summary, update_purge_height, IDkgBlockReaderImpl},
+};
+use ic_consensus_utils::{crypto::ConsensusCrypto, RoundRobin};
+use ic_interfaces::{
+    consensus_pool::ConsensusBlockCache,
+    crypto::{ErrorReproducibility, IDkgProtocol},
+    idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool},
+};
 use ic_logger::{debug, warn, ReplicaLogger};
 use ic_metrics::MetricsRegistry;
-use ic_types::artifact::IDkgMessageId;
-use ic_types::consensus::idkg::{
-    dealing_prefix, dealing_support_prefix, IDkgBlockReader, IDkgMessage, IDkgStats,
-    IDkgTranscriptParamsRef,
+use ic_types::{
+    artifact::IDkgMessageId,
+    consensus::idkg::{
+        dealing_prefix, dealing_support_prefix, IDkgBlockReader, IDkgMessage, IDkgStats,
+        IDkgTranscriptParamsRef,
+    },
+    crypto::{
+        canister_threshold_sig::{
+            error::IDkgCreateDealingError,
+            idkg::{
+                BatchSignedIDkgDealing, BatchSignedIDkgDealings, IDkgDealingSupport,
+                IDkgTranscript, IDkgTranscriptId, IDkgTranscriptOperation, IDkgTranscriptParams,
+                SignedIDkgDealing,
+            },
+        },
+        CryptoHashOf,
+    },
+    signature::BasicSignatureBatch,
+    Height, NodeId,
 };
-use ic_types::crypto::canister_threshold_sig::error::IDkgCreateDealingError;
-use ic_types::crypto::canister_threshold_sig::idkg::{
-    BatchSignedIDkgDealing, BatchSignedIDkgDealings, IDkgDealingSupport, IDkgTranscript,
-    IDkgTranscriptId, IDkgTranscriptOperation, IDkgTranscriptParams, SignedIDkgDealing,
+use std::{
+    cell::RefCell,
+    collections::{btree_map::Entry, BTreeMap, BTreeSet},
+    fmt::{self, Debug, Formatter},
+    sync::Arc,
 };
-use ic_types::crypto::CryptoHashOf;
-use ic_types::signature::BasicSignatureBatch;
-use ic_types::{Height, NodeId};
-use std::cell::RefCell;
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
-use std::fmt::{self, Debug, Formatter};
-use std::sync::Arc;
-
-use super::utils::update_purge_height;
 
 pub(crate) trait IDkgPreSigner: Send {
     /// The on_state_change() called from the main IDKG path.
@@ -1346,8 +1356,7 @@ impl TranscriptState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::idkg::test_utils::*;
-    use crate::idkg::utils::algorithm_for_key_id;
+    use crate::idkg::{test_utils::*, utils::algorithm_for_key_id};
     use assert_matches::assert_matches;
     use ic_crypto_test_utils_canister_threshold_sigs::{
         setup_masked_random_params, CanisterThresholdSigTestEnvironment, IDkgParticipants,
@@ -1357,13 +1366,13 @@ mod tests {
     use ic_test_utilities_consensus::IDkgStatsNoOp;
     use ic_test_utilities_logger::with_test_replica_logger;
     use ic_test_utilities_types::ids::{NODE_1, NODE_2, NODE_3, NODE_4};
-    use ic_types::consensus::idkg::IDkgMasterPublicKeyId;
-    use ic_types::consensus::idkg::IDkgObject;
-    use ic_types::crypto::{BasicSig, BasicSigOf, CryptoHash};
-    use ic_types::time::UNIX_EPOCH;
-    use ic_types::{Height, RegistryVersion};
-    use std::collections::HashSet;
-    use std::ops::Deref;
+    use ic_types::{
+        consensus::idkg::{IDkgMasterPublicKeyId, IDkgObject},
+        crypto::{BasicSig, BasicSigOf, CryptoHash},
+        time::UNIX_EPOCH,
+        Height, RegistryVersion,
+    };
+    use std::{collections::HashSet, ops::Deref};
 
     // Tests the Action logic
     #[test]

--- a/rs/consensus/src/idkg/signer.rs
+++ b/rs/consensus/src/idkg/signer.rs
@@ -1,47 +1,51 @@
 //! The signature process manager
 
-use crate::idkg::complaints::IDkgTranscriptLoader;
-use crate::idkg::metrics::{timed_call, IDkgPayloadMetrics, ThresholdSignerMetrics};
-use crate::idkg::utils::{load_transcripts, IDkgBlockReaderImpl};
-use ic_consensus_utils::crypto::ConsensusCrypto;
-use ic_consensus_utils::RoundRobin;
-use ic_interfaces::consensus_pool::ConsensusBlockCache;
-use ic_interfaces::crypto::{
-    ErrorReproducibility, ThresholdEcdsaSigVerifier, ThresholdEcdsaSigner,
-    ThresholdSchnorrSigVerifier, ThresholdSchnorrSigner, VetKdProtocol,
+use crate::idkg::{
+    complaints::IDkgTranscriptLoader,
+    metrics::{timed_call, IDkgPayloadMetrics, ThresholdSignerMetrics},
+    utils::{build_signature_inputs, load_transcripts, update_purge_height, IDkgBlockReaderImpl},
 };
-use ic_interfaces::idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool};
+use ic_consensus_utils::{crypto::ConsensusCrypto, RoundRobin};
+use ic_interfaces::{
+    consensus_pool::ConsensusBlockCache,
+    crypto::{
+        ErrorReproducibility, ThresholdEcdsaSigVerifier, ThresholdEcdsaSigner,
+        ThresholdSchnorrSigVerifier, ThresholdSchnorrSigner, VetKdProtocol,
+    },
+    idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool},
+};
 use ic_interfaces_state_manager::{CertifiedStateSnapshot, StateReader};
 use ic_logger::{debug, warn, ReplicaLogger};
 use ic_metrics::MetricsRegistry;
-use ic_replicated_state::metadata_state::subnet_call_context_manager::{
-    SignWithThresholdContext, ThresholdArguments,
+use ic_replicated_state::{
+    metadata_state::subnet_call_context_manager::{SignWithThresholdContext, ThresholdArguments},
+    ReplicatedState,
 };
-use ic_replicated_state::ReplicatedState;
-use ic_types::artifact::IDkgMessageId;
-use ic_types::consensus::idkg::common::{
-    CombinedSignature, SignatureScheme, ThresholdSigInputs, ThresholdSigInputsRef,
+use ic_types::{
+    artifact::IDkgMessageId,
+    consensus::idkg::{
+        common::{CombinedSignature, SignatureScheme, ThresholdSigInputs, ThresholdSigInputsRef},
+        ecdsa_sig_share_prefix, schnorr_sig_share_prefix, vetkd_key_share_prefix, EcdsaSigShare,
+        IDkgBlockReader, IDkgMessage, IDkgStats, RequestId, SchnorrSigShare, SigShare,
+        VetKdKeyShare,
+    },
+    crypto::{
+        canister_threshold_sig::error::{
+            ThresholdEcdsaCombineSigSharesError, ThresholdEcdsaCreateSigShareError,
+            ThresholdEcdsaVerifySigShareError, ThresholdSchnorrCombineSigSharesError,
+            ThresholdSchnorrCreateSigShareError, ThresholdSchnorrVerifySigShareError,
+        },
+        vetkd::{VetKdKeyShareCreationError, VetKdKeyShareVerificationError},
+    },
+    messages::CallbackId,
+    Height, NodeId,
 };
-use ic_types::consensus::idkg::{
-    ecdsa_sig_share_prefix, vetkd_key_share_prefix, EcdsaSigShare, IDkgBlockReader, IDkgMessage,
-    IDkgStats, RequestId, VetKdKeyShare,
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet},
+    fmt::{self, Debug, Formatter},
+    sync::Arc,
 };
-use ic_types::consensus::idkg::{schnorr_sig_share_prefix, SchnorrSigShare, SigShare};
-use ic_types::crypto::canister_threshold_sig::error::ThresholdEcdsaCombineSigSharesError;
-use ic_types::crypto::canister_threshold_sig::error::{
-    ThresholdEcdsaCreateSigShareError, ThresholdEcdsaVerifySigShareError,
-    ThresholdSchnorrCombineSigSharesError, ThresholdSchnorrCreateSigShareError,
-    ThresholdSchnorrVerifySigShareError,
-};
-use ic_types::crypto::vetkd::{VetKdKeyShareCreationError, VetKdKeyShareVerificationError};
-use ic_types::messages::CallbackId;
-use ic_types::{Height, NodeId};
-use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::{self, Debug, Formatter};
-use std::sync::Arc;
-
-use super::utils::{build_signature_inputs, update_purge_height};
 
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
@@ -854,8 +858,7 @@ impl Debug for Action<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::idkg::test_utils::*;
-    use crate::idkg::utils::algorithm_for_key_id;
+    use crate::idkg::{test_utils::*, utils::algorithm_for_key_id};
     use assert_matches::assert_matches;
     use ic_crypto_test_utils_canister_threshold_sigs::{
         generate_key_transcript, generate_tecdsa_protocol_inputs,
@@ -871,16 +874,17 @@ mod tests {
     use ic_test_utilities::crypto::CryptoReturningOk;
     use ic_test_utilities_consensus::IDkgStatsNoOp;
     use ic_test_utilities_logger::with_test_replica_logger;
-    use ic_test_utilities_types::ids::{
-        canister_test_id, subnet_test_id, user_test_id, NODE_1, NODE_2, NODE_3,
+    use ic_test_utilities_types::{
+        ids::{canister_test_id, subnet_test_id, user_test_id, NODE_1, NODE_2, NODE_3},
+        messages::RequestBuilder,
     };
-    use ic_test_utilities_types::messages::RequestBuilder;
-    use ic_types::consensus::idkg::*;
-    use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
-    use ic_types::time::UNIX_EPOCH;
-    use ic_types::{Height, Randomness};
-    use std::ops::Deref;
-    use std::sync::RwLock;
+    use ic_types::{
+        consensus::idkg::*,
+        crypto::{AlgorithmId, ExtendedDerivationPath},
+        time::UNIX_EPOCH,
+        Height, Randomness,
+    };
+    use std::{ops::Deref, sync::RwLock};
 
     #[test]
     fn test_ecdsa_signer_action() {

--- a/rs/consensus/src/idkg/stats.rs
+++ b/rs/consensus/src/idkg/stats.rs
@@ -4,16 +4,20 @@ use crate::idkg::metrics::{
     IDkgPreSignatureMetrics, IDkgTranscriptMetrics, ThresholdSignatureMetrics,
 };
 use ic_management_canister_types_private::MasterPublicKeyId;
-use ic_types::consensus::idkg::{IDkgBlockReader, IDkgStats, PreSigId, RequestId};
-use ic_types::crypto::canister_threshold_sig::idkg::{
-    IDkgDealingSupport, IDkgTranscriptId, IDkgTranscriptParams,
+use ic_types::{
+    consensus::idkg::{IDkgBlockReader, IDkgStats, PreSigId, RequestId},
+    crypto::canister_threshold_sig::idkg::{
+        IDkgDealingSupport, IDkgTranscriptId, IDkgTranscriptParams,
+    },
 };
 
 use ic_metrics::MetricsRegistry;
 use prometheus::{Histogram, HistogramVec};
-use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Mutex,
+    time::{Duration, Instant},
+};
 
 /// Implementation of IDkgStats
 pub struct IDkgStatsImpl {

--- a/rs/consensus/src/idkg/test_utils.rs
+++ b/rs/consensus/src/idkg/test_utils.rs
@@ -1,17 +1,18 @@
-use crate::idkg::complaints::{
-    IDkgComplaintHandlerImpl, IDkgTranscriptLoader, TranscriptLoadStatus,
+use crate::idkg::{
+    complaints::{IDkgComplaintHandlerImpl, IDkgTranscriptLoader, TranscriptLoadStatus},
+    pre_signer::{IDkgPreSignerImpl, IDkgTranscriptBuilder},
+    signer::{ThresholdSignatureBuilder, ThresholdSignerImpl},
+    utils::algorithm_for_key_id,
 };
-use crate::idkg::pre_signer::{IDkgPreSignerImpl, IDkgTranscriptBuilder};
-use crate::idkg::signer::{ThresholdSignatureBuilder, ThresholdSignerImpl};
 use core::convert::TryInto;
 use ic_artifact_pool::idkg_pool::IDkgPoolImpl;
 use ic_config::artifact_pool::ArtifactPoolConfig;
 use ic_consensus_mocks::{dependencies, Dependencies};
 use ic_consensus_utils::crypto::ConsensusCrypto;
 use ic_crypto_temp_crypto::TempCryptoComponent;
-use ic_crypto_test_utils_canister_threshold_sigs::dummy_values::dummy_idkg_dealing_for_tests;
 use ic_crypto_test_utils_canister_threshold_sigs::{
-    setup_masked_random_params, CanisterThresholdSigTestEnvironment, IDkgParticipants, IntoBuilder,
+    dummy_values::dummy_idkg_dealing_for_tests, setup_masked_random_params,
+    CanisterThresholdSigTestEnvironment, IDkgParticipants, IntoBuilder,
 };
 use ic_crypto_test_utils_reproducible_rng::ReproducibleRng;
 use ic_crypto_tree_hash::{LabeledTree, MixedHashTree};
@@ -22,61 +23,74 @@ use ic_management_canister_types_private::{
     EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdKeyId,
 };
 use ic_metrics::MetricsRegistry;
-use ic_replicated_state::metadata_state::subnet_call_context_manager::{
-    EcdsaArguments, IDkgSignWithThresholdContext, ReshareChainKeyContext, SchnorrArguments,
-    SignWithThresholdContext, ThresholdArguments, VetKdArguments,
+use ic_replicated_state::{
+    metadata_state::subnet_call_context_manager::{
+        EcdsaArguments, IDkgSignWithThresholdContext, ReshareChainKeyContext, SchnorrArguments,
+        SignWithThresholdContext, ThresholdArguments, VetKdArguments,
+    },
+    ReplicatedState,
 };
-use ic_replicated_state::ReplicatedState;
 use ic_test_artifact_pool::consensus_pool::TestConsensusPool;
 use ic_test_utilities::state_manager::RefMockStateManager;
 use ic_test_utilities_consensus::{fake::*, IDkgStatsNoOp};
 use ic_test_utilities_state::ReplicatedStateBuilder;
-use ic_test_utilities_types::ids::{node_test_id, NODE_1, NODE_2};
-use ic_test_utilities_types::messages::RequestBuilder;
-use ic_types::artifact::IDkgMessageId;
-use ic_types::consensus::certification::Certification;
-use ic_types::consensus::idkg::{
-    self,
-    common::{CombinedSignature, PreSignatureRef, ThresholdSigInputsRef},
-    ecdsa::{PreSignatureQuadrupleRef, ThresholdEcdsaSigInputsRef},
-    schnorr::{PreSignatureTranscriptRef, ThresholdSchnorrSigInputsRef},
-    EcdsaSigShare, IDkgArtifactId, IDkgBlockReader, IDkgComplaintContent, IDkgMasterPublicKeyId,
-    IDkgMessage, IDkgOpeningContent, IDkgPayload, IDkgReshareRequest, IDkgTranscriptAttributes,
-    IDkgTranscriptOperationRef, IDkgTranscriptParamsRef, KeyTranscriptCreation, MaskedTranscript,
-    MasterKeyTranscript, PreSigId, RequestId, ReshareOfMaskedParams, SignedIDkgComplaint,
-    SignedIDkgOpening, TranscriptAttributes, TranscriptLookupError, TranscriptRef,
-    UnmaskedTranscript,
+use ic_test_utilities_types::{
+    ids::{node_test_id, NODE_1, NODE_2},
+    messages::RequestBuilder,
 };
-use ic_types::consensus::idkg::{HasIDkgMasterPublicKeyId, SchnorrSigShare, VetKdKeyShare};
-use ic_types::crypto::canister_threshold_sig::idkg::{
-    IDkgComplaint, IDkgDealing, IDkgDealingSupport, IDkgMaskedTranscriptOrigin, IDkgOpening,
-    IDkgReceivers, IDkgTranscript, IDkgTranscriptId, IDkgTranscriptOperation, IDkgTranscriptParams,
-    IDkgTranscriptType, IDkgUnmaskedTranscriptOrigin, SignedIDkgDealing,
+use ic_types::{
+    artifact::IDkgMessageId,
+    consensus::{
+        certification::Certification,
+        idkg::{
+            self,
+            common::{CombinedSignature, PreSignatureRef, ThresholdSigInputsRef},
+            ecdsa::{PreSignatureQuadrupleRef, ThresholdEcdsaSigInputsRef},
+            schnorr::{PreSignatureTranscriptRef, ThresholdSchnorrSigInputsRef},
+            EcdsaSigShare, HasIDkgMasterPublicKeyId, IDkgArtifactId, IDkgBlockReader,
+            IDkgComplaintContent, IDkgMasterPublicKeyId, IDkgMessage, IDkgOpeningContent,
+            IDkgPayload, IDkgReshareRequest, IDkgTranscriptAttributes, IDkgTranscriptOperationRef,
+            IDkgTranscriptParamsRef, KeyTranscriptCreation, MaskedTranscript, MasterKeyTranscript,
+            PreSigId, RequestId, ReshareOfMaskedParams, SchnorrSigShare, SignedIDkgComplaint,
+            SignedIDkgOpening, TranscriptAttributes, TranscriptLookupError, TranscriptRef,
+            UnmaskedTranscript, VetKdKeyShare,
+        },
+    },
+    crypto::{
+        canister_threshold_sig::{
+            idkg::{
+                IDkgComplaint, IDkgDealing, IDkgDealingSupport, IDkgMaskedTranscriptOrigin,
+                IDkgOpening, IDkgReceivers, IDkgTranscript, IDkgTranscriptId,
+                IDkgTranscriptOperation, IDkgTranscriptParams, IDkgTranscriptType,
+                IDkgUnmaskedTranscriptOrigin, SignedIDkgDealing,
+            },
+            ThresholdEcdsaSigInputs, ThresholdEcdsaSigShare, ThresholdSchnorrSigInputs,
+            ThresholdSchnorrSigShare,
+        },
+        threshold_sig::ni_dkg::{
+            NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
+        },
+        vetkd::{
+            VetKdArgs, VetKdDerivationContext, VetKdEncryptedKeyShare,
+            VetKdEncryptedKeyShareContent,
+        },
+        AlgorithmId, ExtendedDerivationPath,
+    },
+    messages::CallbackId,
+    signature::*,
+    time,
+    time::UNIX_EPOCH,
+    Height, NodeId, PrincipalId, Randomness, RegistryVersion, SubnetId,
 };
-use ic_types::crypto::canister_threshold_sig::{
-    ThresholdEcdsaSigInputs, ThresholdEcdsaSigShare, ThresholdSchnorrSigInputs,
-    ThresholdSchnorrSigShare,
-};
-use ic_types::crypto::threshold_sig::ni_dkg::{
-    NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
-};
-use ic_types::crypto::vetkd::{
-    VetKdArgs, VetKdDerivationContext, VetKdEncryptedKeyShare, VetKdEncryptedKeyShareContent,
-};
-use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
-use ic_types::messages::CallbackId;
-use ic_types::time::UNIX_EPOCH;
-use ic_types::{signature::*, time};
-use ic_types::{Height, NodeId, PrincipalId, Randomness, RegistryVersion, SubnetId};
 use ic_types_test_utils::ids::subnet_test_id;
 use rand::{CryptoRng, Rng};
-use std::collections::{BTreeMap, BTreeSet};
-use std::convert::TryFrom;
-use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::TryFrom,
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 use strum::IntoEnumIterator;
-
-use super::utils::algorithm_for_key_id;
 
 pub(crate) fn dealings_context_from_reshare_request(
     request: idkg::IDkgReshareRequest,

--- a/rs/consensus/src/idkg/utils.rs
+++ b/rs/consensus/src/idkg/utils.rs
@@ -1,11 +1,15 @@
 //! Common utils for the IDKG implementation.
 
-use crate::idkg::complaints::{IDkgTranscriptLoader, TranscriptLoadStatus};
-use crate::idkg::metrics::IDkgPayloadMetrics;
+use crate::idkg::{
+    complaints::{IDkgTranscriptLoader, TranscriptLoadStatus},
+    metrics::IDkgPayloadMetrics,
+};
 use ic_consensus_utils::pool_reader::PoolReader;
 use ic_crypto::get_master_public_key_from_transcript;
-use ic_interfaces::consensus_pool::ConsensusBlockChain;
-use ic_interfaces::idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool};
+use ic_interfaces::{
+    consensus_pool::ConsensusBlockChain,
+    idkg::{IDkgChangeAction, IDkgChangeSet, IDkgPool},
+};
 use ic_interfaces_registry::RegistryClient;
 use ic_logger::{warn, ReplicaLogger};
 use ic_management_canister_types_private::{
@@ -17,27 +21,29 @@ use ic_registry_subnet_features::ChainKeyConfig;
 use ic_replicated_state::metadata_state::subnet_call_context_manager::{
     SignWithThresholdContext, ThresholdArguments,
 };
-use ic_types::consensus::idkg::common::{PreSignatureRef, SignatureScheme, ThresholdSigInputsRef};
-use ic_types::consensus::idkg::ecdsa::ThresholdEcdsaSigInputsRef;
-use ic_types::consensus::idkg::schnorr::ThresholdSchnorrSigInputsRef;
-use ic_types::consensus::idkg::{HasIDkgMasterPublicKeyId, IDkgMasterPublicKeyId};
-use ic_types::consensus::Block;
-use ic_types::consensus::{
-    idkg::{
-        IDkgBlockReader, IDkgMessage, IDkgTranscriptParamsRef, PreSigId, RequestId,
-        TranscriptLookupError, TranscriptRef,
+use ic_types::{
+    consensus::{
+        idkg::{
+            common::{PreSignatureRef, SignatureScheme, ThresholdSigInputsRef},
+            ecdsa::ThresholdEcdsaSigInputsRef,
+            schnorr::ThresholdSchnorrSigInputsRef,
+            HasIDkgMasterPublicKeyId, IDkgBlockReader, IDkgMasterPublicKeyId, IDkgMessage,
+            IDkgTranscriptParamsRef, PreSigId, RequestId, TranscriptLookupError, TranscriptRef,
+        },
+        Block, HasHeight,
     },
-    HasHeight,
+    crypto::{
+        canister_threshold_sig::{
+            idkg::{IDkgTranscript, IDkgTranscriptOperation, InitialIDkgDealings},
+            MasterPublicKey,
+        },
+        vetkd::{VetKdArgs, VetKdDerivationContext},
+        AlgorithmId, ExtendedDerivationPath,
+    },
+    messages::CallbackId,
+    registry::RegistryClientError,
+    Height, RegistryVersion, SubnetId,
 };
-use ic_types::crypto::canister_threshold_sig::idkg::{
-    IDkgTranscript, IDkgTranscriptOperation, InitialIDkgDealings,
-};
-use ic_types::crypto::canister_threshold_sig::MasterPublicKey;
-use ic_types::crypto::vetkd::{VetKdArgs, VetKdDerivationContext};
-use ic_types::crypto::{AlgorithmId, ExtendedDerivationPath};
-use ic_types::messages::CallbackId;
-use ic_types::registry::RegistryClientError;
-use ic_types::{Height, RegistryVersion, SubnetId};
 use phantom_newtype::Id;
 use std::{
     cell::RefCell,

--- a/rs/consensus/tests/framework/delivery.rs
+++ b/rs/consensus/tests/framework/delivery.rs
@@ -2,8 +2,7 @@
 
 use super::types::*;
 use ic_logger::trace;
-use rand::seq::SliceRandom;
-use rand::Rng;
+use rand::{seq::SliceRandom, Rng};
 use std::time::Duration;
 
 fn get_instance_with_least_outgoing_message_timestamp<'a, 'b>(

--- a/rs/consensus/tests/framework/driver.rs
+++ b/rs/consensus/tests/framework/driver.rs
@@ -16,8 +16,10 @@ use ic_logger::{debug, ReplicaLogger};
 use ic_metrics::MetricsRegistry;
 use ic_test_artifact_pool::ingress_pool::TestIngressPool;
 use ic_types::{consensus::ConsensusMessage, NodeId};
-use std::cell::RefCell;
-use std::sync::{Arc, RwLock};
+use std::{
+    cell::RefCell,
+    sync::{Arc, RwLock},
+};
 
 /// A helper that drives consensus using a separate consensus artifact pool.
 impl<'a> ConsensusDriver<'a> {

--- a/rs/consensus/tests/framework/malicious.rs
+++ b/rs/consensus/tests/framework/malicious.rs
@@ -1,8 +1,10 @@
 //! Implementation of malicious behaviors in consensus.
 
 use super::ComponentModifier;
-use ic_consensus::consensus::ConsensusImpl;
-use ic_consensus::idkg::{malicious_pre_signer, IDkgImpl};
+use ic_consensus::{
+    consensus::ConsensusImpl,
+    idkg::{malicious_pre_signer, IDkgImpl},
+};
 use ic_consensus_utils::pool_reader::PoolReader;
 use ic_interfaces::{
     consensus_pool::{ChangeAction::*, ConsensusPool, Mutations, ValidatedConsensusArtifact},
@@ -10,9 +12,11 @@ use ic_interfaces::{
     p2p::consensus::PoolMutationsProducer,
 };
 use ic_protobuf::types::v1 as pb;
-use ic_types::consensus::{ConsensusMessageHashable, NotarizationShare};
-use ic_types::malicious_flags::MaliciousFlags;
-use ic_types::time::current_time;
+use ic_types::{
+    consensus::{ConsensusMessageHashable, NotarizationShare},
+    malicious_flags::MaliciousFlags,
+    time::current_time,
+};
 use std::cell::RefCell;
 
 /// Simulate a malicious notary that always produces a bad NotarizationShare

--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -23,8 +23,7 @@ use ic_management_canister_types_private::{
 };
 use ic_protobuf::registry::subnet::v1::{CatchUpPackageContents, InitialNiDkgTranscriptRecord};
 use ic_registry_client_fake::FakeRegistryClient;
-use ic_registry_client_helpers::crypto::CryptoRegistry;
-use ic_registry_client_helpers::subnet::SubnetRegistry;
+use ic_registry_client_helpers::{crypto::CryptoRegistry, subnet::SubnetRegistry};
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig};
 use ic_test_utilities_consensus::make_genesis;
@@ -39,8 +38,10 @@ use ic_types::{
 };
 use rand::{CryptoRng, Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 /// Setup a subnet of the given subnet_id and node_ids by creating an initial registry
 /// with required records, including subnet record, node record, node public keys,

--- a/rs/consensus/tests/framework/runner.rs
+++ b/rs/consensus/tests/framework/runner.rs
@@ -1,27 +1,23 @@
-use super::delivery::*;
-use super::execution::*;
-use super::types::*;
+use super::{delivery::*, execution::*, types::*};
 use ic_config::artifact_pool::ArtifactPoolConfig;
 use ic_consensus::idkg;
 use ic_consensus_certification::{CertificationCrypto, CertifierImpl};
 use ic_consensus_dkg::DkgKeyManager;
-use ic_consensus_utils::crypto::ConsensusCrypto;
-use ic_consensus_utils::membership::Membership;
-use ic_consensus_utils::pool_reader::PoolReader;
-use ic_interfaces::consensus_pool::ConsensusPoolCache;
-use ic_interfaces::time_source::TimeSource;
+use ic_consensus_utils::{
+    crypto::ConsensusCrypto, membership::Membership, pool_reader::PoolReader,
+};
+use ic_interfaces::{consensus_pool::ConsensusPoolCache, time_source::TimeSource};
 use ic_logger::{info, warn, ReplicaLogger};
 use ic_test_utilities_time::FastForwardTimeSource;
-use ic_types::malicious_flags::MaliciousFlags;
-use ic_types::Height;
-use ic_types::Time;
+use ic_types::{malicious_flags::MaliciousFlags, Height, Time};
 use rand::{thread_rng, Rng, RngCore};
 use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
 use slog::Drain;
-use std::cell::{RefCell, RefMut};
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::{
+    cell::{RefCell, RefMut},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 use tokio::sync::watch;
 
 fn stop_immediately(_: &ConsensusInstance<'_>) -> bool {

--- a/rs/consensus/tests/framework/types.rs
+++ b/rs/consensus/tests/framework/types.rs
@@ -44,13 +44,15 @@ use ic_types::{
     NodeId, SubnetId,
 };
 use rand_chacha::ChaChaRng;
-use std::cell::{RefCell, RefMut};
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
-use std::fmt;
-use std::rc::Rc;
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::{
+    cell::{RefCell, RefMut},
+    cmp::Ordering,
+    collections::BinaryHeap,
+    fmt,
+    rc::Rc,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 /// We use priority queues for input/output messages.
 pub type Queue<T> = Rc<RefCell<BinaryHeap<T>>>;

--- a/rs/consensus/tests/integration.rs
+++ b/rs/consensus/tests/integration.rs
@@ -7,18 +7,16 @@ use crate::framework::{
 };
 use framework::test_master_public_key_ids;
 use ic_consensus_utils::pool_reader::PoolReader;
-use ic_interfaces::consensus_pool::ConsensusPool;
-use ic_interfaces::messaging::MessageRouting;
+use ic_interfaces::{consensus_pool::ConsensusPool, messaging::MessageRouting};
 use ic_interfaces_registry::RegistryClient;
 use ic_test_utilities_time::FastForwardTimeSource;
 use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
-use ic_types::malicious_flags::MaliciousFlags;
-use ic_types::{crypto::CryptoHash, replica_config::ReplicaConfig, Height};
+use ic_types::{
+    crypto::CryptoHash, malicious_flags::MaliciousFlags, replica_config::ReplicaConfig, Height,
+};
 use rand::Rng;
 use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::sync::Arc;
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 #[test]
 fn multiple_nodes_are_live() -> Result<(), String> {

--- a/rs/consensus/tests/payload.rs
+++ b/rs/consensus/tests/payload.rs
@@ -21,8 +21,7 @@ use ic_test_utilities::{
     self_validating_payload_builder::FakeSelfValidatingPayloadBuilder,
     xnet_payload_builder::FakeXNetPayloadBuilder,
 };
-use ic_test_utilities_consensus::batch::MockBatchPayloadBuilder;
-use ic_test_utilities_consensus::{make_genesis, IDkgStatsNoOp};
+use ic_test_utilities_consensus::{batch::MockBatchPayloadBuilder, make_genesis, IDkgStatsNoOp};
 use ic_test_utilities_registry::{setup_registry, SubnetRecordBuilder};
 use ic_test_utilities_state::get_initial_state;
 use ic_test_utilities_time::FastForwardTimeSource;
@@ -34,8 +33,10 @@ use ic_types::{
     crypto::CryptoHash, malicious_flags::MaliciousFlags, replica_config::ReplicaConfig,
     CryptoHashOfState, Height,
 };
-use std::sync::{Arc, Mutex, RwLock};
-use std::time::Duration;
+use std::{
+    sync::{Arc, Mutex, RwLock},
+    time::Duration,
+};
 use tokio::sync::watch;
 
 /// Test that the batches that Consensus produces contain expected batch

--- a/rs/consensus/tests/types.rs
+++ b/rs/consensus/tests/types.rs
@@ -1,11 +1,10 @@
 use ic_protobuf::types::v1 as pb;
 use ic_sys::fs::write_protobuf_using_tmp_file;
 use ic_test_utilities_consensus::{fake::*, make_genesis};
-use ic_types::consensus::catchup::*;
-use ic_types::consensus::dkg;
-use ic_types::consensus::hashed::Hashed;
-use ic_types::crypto::Signable;
-use ic_types::crypto::{CryptoHash, CryptoHashOf};
+use ic_types::{
+    consensus::{catchup::*, dkg, hashed::Hashed},
+    crypto::{CryptoHash, CryptoHashOf, Signable},
+};
 use std::convert::TryFrom;
 use tempfile::Builder;
 

--- a/rs/orchestrator/src/utils.rs
+++ b/rs/orchestrator/src/utils.rs
@@ -1,7 +1,6 @@
 use ic_logger::{warn, ReplicaLogger};
 use ic_protobuf::registry::node::v1::ConnectionEndpoint;
-use std::net::IpAddr;
-use std::str::FromStr;
+use std::{net::IpAddr, str::FromStr};
 use url::Url;
 
 pub(crate) fn http_endpoint_to_url(http: &ConnectionEndpoint, log: &ReplicaLogger) -> Option<Url> {


### PR DESCRIPTION
This PR merges the imports in the consensus crate (mainly the currently not merged imports inside of `idkg`)