### PR TITLE
chore(IDX): simplify vm_spec_from_nested_node

### DIFF
--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -417,6 +417,6 @@ fn vm_spec_from_nested_node(
         has_ipv4: false,
         vm_allocation: None,
         required_host_features: Vec::new(),
-        alternate_template: Some(VmType::Production),
+        alternate_template: None,
     }
 }


### PR DESCRIPTION
In `vm_spec_from_nested_node(...)` don't specify `alternate_template: Some(VmType::Production)` since that's the default.
 
Schedule Hourly: https://github.com/dfinity/ic/actions/runs/14043802093