### PR TITLE
chore(nns): Fail the pb methods in governance with 90%

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -563,7 +563,7 @@ async fn heartbeat() {
 fn manage_neuron_pb() {
     debug_log("manage_neuron_pb");
     panic_with_probability(
-        0.7,
+        0.9,
         "manage_neuron_pb is deprecated. Please use manage_neuron instead.",
     );
 
@@ -598,7 +598,7 @@ fn list_proposals_pb() {
 fn list_neurons_pb() {
     debug_log("list_neurons_pb");
     panic_with_probability(
-        0.7,
+        0.9,
         "list_neurons_pb is deprecated. Please use list_neurons instead.",
     );
 

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,6 +11,8 @@ on the process that this file is part of, see
 
 ## Changed
 
+* Increased the probability of failure from 70% to 90% for the deprecated _pb methods.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
Increase the probability of failure from 70% to 90% for the deprecated _pb methods