### PR TITLE
chore: check subnet kind canister ranges when loading subnet state

### DIFF
--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use strum_macros::EnumIter;
 
 pub type InstanceId = usize;
 
@@ -435,7 +436,18 @@ pub mod base64 {
 // ================================================================================================================= //
 
 #[derive(
-    Debug, Clone, Copy, Eq, Hash, PartialEq, Ord, PartialOrd, Serialize, Deserialize, JsonSchema,
+    Debug,
+    Clone,
+    Copy,
+    Eq,
+    Hash,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    EnumIter,
 )]
 pub enum SubnetKind {
     Application,


### PR DESCRIPTION
This PR checks the canister ranges of a subnet with state loaded from disk against the canister ranges of the expected subnet kind (which must be contained in them) and against the canister ranges of other subnet kinds (which must be disjoint from them).