### PR TITLE
feat(EXC-1993): Increase sandbox limit

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -75,10 +75,10 @@ const SANDBOX_PROCESSES_TO_EVICT: usize = 200;
 /// The RSS to evict in one go in order to amortize for the eviction cost (1 GiB).
 const SANDBOX_PROCESSES_RSS_TO_EVICT: NumBytes = NumBytes::new(1024 * 1024 * 1024);
 
-/// By default, assume each sandbox process consumes 50 MiB of RSS.
+/// By default, assume each sandbox process consumes 5 MiB of RSS.
 /// The actual memory usage is updated asynchronously.
 /// See `monitor_and_evict_sandbox_processes`
-const DEFAULT_SANDBOX_PROCESS_RSS: NumBytes = NumBytes::new(50 * 1024 * 1024);
+const DEFAULT_SANDBOX_PROCESS_RSS: NumBytes = NumBytes::new(5 * 1024 * 1024);
 
 /// To speedup synchronous operations, the sandbox RSS-based eviction
 /// is triggered only when the system's available memory falls below

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -55,8 +55,8 @@ pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 10_000;
 /// duration and sandbox process eviction is activated.
 pub(crate) const DEFAULT_MAX_SANDBOX_IDLE_TIME: Duration = Duration::from_secs(30 * 60);
 
-/// Sandbox processes may be evicted if their total RSS exceeds 70 GiB.
-pub(crate) const DEFAULT_MAX_SANDBOXES_RSS: NumBytes = NumBytes::new(70 * 1024 * 1024 * 1024);
+/// Sandbox processes may be evicted if their total RSS exceeds 50 GiB.
+pub(crate) const DEFAULT_MAX_SANDBOXES_RSS: NumBytes = NumBytes::new(50 * 1024 * 1024 * 1024);
 
 /// The maximum number of pages that a message dirties without optimizing dirty
 /// page copying by triggering a new execution slice for copying pages.

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -46,8 +46,10 @@ const DEFAULT_WASMTIME_RAYON_COMPILATION_THREADS: usize = 10;
 const DEFAULT_PAGE_ALLOCATOR_THREADS: usize = 8;
 
 /// Sandbox process eviction ensures that the number of sandbox processes is
-/// always below this threshold.
-pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 7_000;
+/// always below this threshold. Idle sandboxes should be using at most ~5MiB
+/// resident memory with the on-disk compilation cache, so 10,000 sandboxes
+/// shouldn't be more than 50 GiB.
+pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 10_000;
 
 /// A sandbox process may be evicted after it has been idle for this
 /// duration and sandbox process eviction is activated.

--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -55,8 +55,8 @@ pub(crate) const DEFAULT_MAX_SANDBOX_COUNT: usize = 10_000;
 /// duration and sandbox process eviction is activated.
 pub(crate) const DEFAULT_MAX_SANDBOX_IDLE_TIME: Duration = Duration::from_secs(30 * 60);
 
-/// Sandbox processes may be evicted if their total RSS exceeds 50 GiB.
-pub(crate) const DEFAULT_MAX_SANDBOXES_RSS: NumBytes = NumBytes::new(50 * 1024 * 1024 * 1024);
+/// Sandbox processes may be evicted if their total RSS exceeds 70 GiB.
+pub(crate) const DEFAULT_MAX_SANDBOXES_RSS: NumBytes = NumBytes::new(70 * 1024 * 1024 * 1024);
 
 /// The maximum number of pages that a message dirties without optimizing dirty
 /// page copying by triggering a new execution slice for copying pages.


### PR DESCRIPTION
EXC-1993

Increase the maximum number of canister sandboxes. This allows us to keep more sandboxes hot which will improve latency and throughput.