### PR TITLE
fix(IDX): don't quote bazel targets

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -104,4 +104,4 @@ runs:
             echo "Building as user: $(whoami)"
             echo "Bazel version: $(bazel version)"
 
-            bazel ${{ inputs.BAZEL_COMMAND }} "$BAZEL_TARGETS" "${bazel_args[@]}"
+            bazel ${{ inputs.BAZEL_COMMAND }} $BAZEL_TARGETS "${bazel_args[@]}"


### PR DESCRIPTION
This breaks on the macOS intel job that expects the variable to be expanded.