### PR TITLE
feat(EXC): Skip compilation charge when Wasm is in cache

### DIFF
--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -4073,6 +4073,8 @@ fn cycles_correct_if_upgrade_succeeds() {
 
     let cycles_before = test.canister_state(id).system_state.balance();
     let execution_cost_before = test.canister_execution_cost(id);
+    // Clear `expected_compiled_wasms` so that the full execution cost is applied
+    test.state_mut().metadata.expected_compiled_wasms.clear();
     test.upgrade_canister(id, wasm.clone()).unwrap();
     let execution_cost = test.canister_execution_cost(id) - execution_cost_before;
     assert_eq!(

--- a/rs/execution_environment/src/execution/install_code/tests.rs
+++ b/rs/execution_environment/src/execution/install_code/tests.rs
@@ -2327,6 +2327,9 @@ fn successful_install_chunked_charges_for_wasm_assembly() {
         initial_cycles - final_cycles
     };
 
+    // Clear `expected_compiled_wasms` so that the full execution cost is applied
+    test.state_mut().metadata.expected_compiled_wasms.clear();
+
     let canister_id = test.create_canister(CYCLES);
 
     let hash = UploadChunkReply::decode(&get_reply(

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -169,10 +169,10 @@ impl Hypervisor {
                         self.compilation_cache.disk_bytes(),
                     );
                 }
-                round_limits.instructions -= as_round_instructions(
-                    compilation_cost_handling.adjusted_compilation_cost(compilation_cost),
-                );
-                (compilation_cost, Ok(execution_state))
+                let adjusted_compilation_cost =
+                    compilation_cost_handling.adjusted_compilation_cost(compilation_cost);
+                round_limits.instructions -= as_round_instructions(adjusted_compilation_cost);
+                (adjusted_compilation_cost, Ok(execution_state))
             }
             Err(err) => {
                 round_limits.instructions -= as_round_instructions(compilation_cost);

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -381,6 +381,10 @@ fn dts_install_code_with_concurrent_ingress_sufficient_cycles() {
     )
     .unwrap();
 
+    // Trigger a checkpoint so that the full execution cost is
+    // applied to the subsequent call to `install_code`.
+    env.checkpointed_tick();
+
     let install_code_ingress_id = env.send_ingress(
         PrincipalId::new_anonymous(),
         IC_00,

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -3361,6 +3361,8 @@ fn upgrade_without_pre_and_post_upgrade_succeeds() {
     let mut test = ExecutionTestBuilder::new().build();
     let wat = "(module)";
     let canister_id = test.canister_from_wat(wat).unwrap();
+    // Clear `expected_compiled_wasms` so that the full execution cost is applied.
+    test.state_mut().metadata.expected_compiled_wasms.clear();
     let result = test.upgrade_canister(canister_id, wat::parse_str(wat).unwrap());
     assert_eq!(Ok(()), result);
     // Compilation occurs once for original installation and again for upgrade.


### PR DESCRIPTION
Skip charging a canister the full compilation amount if the canister's Wasm code is expected to be in the compilation cache.

Patch taken from
https://github.com/hpeebles/ic/commit/6a21822a1fc7ba49c83b0c8780a321f95c0230a7