### PR TITLE
fix(nns): Prevent large manage neuron proposals

### DIFF
--- a/rs/nns/governance/CHANGELOG.md
+++ b/rs/nns/governance/CHANGELOG.md
@@ -10,6 +10,15 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 
 INSERT NEW RELEASES HERE
 
+# 2025-03-25: Proposal 135955
+
+https://dashboard.internetcomputer.org/proposal/135955
+
+## Security
+
+* Prevent large manage neuron proposals by making sure their proposal payloads are bounded, and
+  lower the maximum number of open manage neuron proposals. More details can be seen here:
+  https://forum.dfinity.org/t/nns-updates-2025-03-25-nns-governance-security-hotfix/42978.
 
 # 2025-03-21: Proposal 135933
 
@@ -19,6 +28,7 @@ http://dashboard.internetcomputer.org/proposal/135933
 
 * Refactor `prune_following` task to use the `timer_task` library, and therefore enables metrics to
   be collected about its execution.
+
 
 # 2025-03-17: Proposal 135847
 


### PR DESCRIPTION
The changes in this PR is already deployed as part of a security hotfix: 

* https://dashboard.internetcomputer.org/proposal/135955
* https://forum.dfinity.org/t/nns-updates-2025-03-25-nns-governance-security-hotfix/42978

Compared to the [original commit](https://github.com/dfinity/ic/commit/cbebf5d2d74bb97b616a8204df43d2ddfc3560aa), this PR also adds a CHANGELOG entry (not unreleased_changelog, since it's already released)

# Why

Manage Neuron proposals have low fees (0.01 ICP) and high limit for open proposals (100K). If they can be large (~2MiB), then it's easy to fill up the wasm memory with very low cost.

# What

## Prevent large fields in `Command`

When validating the manage neuron proposals (`validate_manage_neuron_proposal`), simply disallow problematic commands:

- MakeProposal can be large since they can (and are intended to) contain WASMs
- DisburseMaturity isn't intended to contain large data, but it has an `opt blob`. There is generally lack of validation on the content of manage neuron proposals at the time the manage neuron proposals are created, but rather the commands are validated at execution time. This needs to be improved in the future. In this PR (intended as a hotfix), we aim at making the attack impossible with as few lines as possible. Disabling DisburseMaturity in manage neuron proposals is OK since the command is still under development.
- Disburse/DisburseTo: they also have a blob (AccountIdentifier::hash), but they are not disabled if the neuron is `not_for_profit`, and only DFINITY neurons have this flag (at genesis)

## Lower the limit of open proposals

Change the limit of open neuron management proposals from 100K to 10K