### PR TITLE
chore(node): update deployment-environment argument

### DIFF
--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -661,7 +661,7 @@ fn configure_setupos_image(
     cmd.arg("--image-path")
         .arg(&uncompressed_image)
         .arg("--deployment-environment")
-        .arg("Testnet")
+        .arg("testnet")
         .arg("--mgmt-mac")
         .arg(&mac)
         .arg("--ipv6-prefix")


### PR DESCRIPTION
The deployment-environment is used as an input to generate the node's IP address. Current node versions sanitize this deployment-environment input to be lowercase before deriving the IP address, but older versions do not. This change only effects the IP address generated by older IC image versions when run with a `testnet` deployment-environment.

