### PR TITLE
feat(nns): Add MaturityDisbursement to neuron internal data model

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -110,13 +110,13 @@ benches:
   list_neurons_by_subaccount_stable:
     total:
       instructions: 64762990
-      heap_increase: 5
+      heap_increase: 4
       stable_memory_increase: 0
     scopes: {}
   list_neurons_heap:
     total:
       instructions: 4697992
-      heap_increase: 9
+      heap_increase: 8
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -412,6 +412,9 @@ message Neuron {
   // to overwrite next.
   optional uint32 recent_ballots_next_entry_index = 25;
 
+  // The maturity disbursements that are in progress for this neuron.
+  repeated MaturityDisbursement maturity_disbursements_in_progress = 28;
+
   reserved "deciding_voting_power";
   reserved 26;
 
@@ -2725,4 +2728,15 @@ message Account {
 // messages.
 message RewardsDistributionInProgress {
   map<uint64, uint64> neuron_ids_to_e8_amounts = 1;
+}
+
+message MaturityDisbursement {
+  // The amount of maturity being disbursed in e8s.
+  uint64 amount_e8s = 1;
+  // The timestamp at which the maturity was disbursed.
+  uint64 timestamp_of_disbursement_seconds = 2;
+  // The account to disburse the maturity to.
+  Account account_to_disburse_to = 3;
+  // The timestamp at which the maturity disbursement should be finalized.
+  uint64 finalize_disbursement_timestamp_seconds = 4;
 }

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -237,6 +237,9 @@ pub struct Neuron {
     /// to overwrite next.
     #[prost(uint32, optional, tag = "25")]
     pub recent_ballots_next_entry_index: ::core::option::Option<u32>,
+    /// The maturity disbursements that are in progress for this neuron.
+    #[prost(message, repeated, tag = "28")]
+    pub maturity_disbursements_in_progress: ::prost::alloc::vec::Vec<MaturityDisbursement>,
     /// At any time, at most one of `when_dissolved` and
     /// `dissolve_delay` are specified.
     ///
@@ -4181,6 +4184,29 @@ pub struct Account {
 pub struct RewardsDistributionInProgress {
     #[prost(map = "uint64, uint64", tag = "1")]
     pub neuron_ids_to_e8_amounts: ::std::collections::HashMap<u64, u64>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct MaturityDisbursement {
+    /// The amount of maturity being disbursed in e8s.
+    #[prost(uint64, tag = "1")]
+    pub amount_e8s: u64,
+    /// The timestamp at which the maturity was disbursed.
+    #[prost(uint64, tag = "2")]
+    pub timestamp_of_disbursement_seconds: u64,
+    /// The account to disburse the maturity to.
+    #[prost(message, optional, tag = "3")]
+    pub account_to_disburse_to: ::core::option::Option<Account>,
+    /// The timestamp at which the maturity disbursement should be finalized.
+    #[prost(uint64, tag = "4")]
+    pub finalize_disbursement_timestamp_seconds: u64,
 }
 /// Proposal types are organized into topics. Neurons can automatically
 /// vote based on following other neurons, and these follow

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -112,6 +112,8 @@ impl From<pb_api::Neuron> for pb::Neuron {
             voting_power_refreshed_timestamp_seconds: item.voting_power_refreshed_timestamp_seconds,
             // This field is internal only and should not be read from API types.
             recent_ballots_next_entry_index: None,
+            // TODO(NNS1-3607): Expose this field in the API.
+            maturity_disbursements_in_progress: vec![],
         }
     }
 }


### PR DESCRIPTION
# Why

To support the DisburseMaturity neuron command, the disbursements need to be stored.

# What

Add `MaturityDisbursement` into the internal data model. The neuron API type isn't changed yet, nor is the stable structures representation.

