### PR TITLE
fix: Pass ic-ref-test directly

### DIFF
--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -222,6 +222,7 @@ rust_test(
     ],
     data = [
         ":pocket-ic-server",
+        "//hs/spec_compliance:ic-ref-test",
         "//rs/tests/httpbin-rs:httpbin",
         "//rs/tests/research:ic-hs",
         "//rs/universal_canister/impl:universal_canister.wasm.gz",
@@ -230,6 +231,7 @@ rust_test(
         "HTTPBIN_BIN": "$(rootpath //rs/tests/httpbin-rs:httpbin)",
         "POCKET_IC_BIN": "$(rootpath :pocket-ic-server)",
         "IC_REF_TEST_ROOT": "rs/tests/research/ic-hs",
+        "IC_REF_TEST_BIN": "$(rootpath //hs/spec_compliance:ic-ref-test)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
     tags = [

--- a/rs/pocket_ic_server/tests/spec_test.rs
+++ b/rs/pocket_ic_server/tests/spec_test.rs
@@ -134,7 +134,8 @@ fn setup_and_run_ic_ref_test(
     let ic_ref_test_path = std::env::var_os("IC_REF_TEST_BIN")
         .expect("Missing ic-ref-test")
         .into_string()
-        .unwrap();
+        .unwrap()
+        .into();
 
     // derive artifact paths
     let ic_ref_test_root = std::env::var_os("IC_REF_TEST_ROOT")

--- a/rs/pocket_ic_server/tests/spec_test.rs
+++ b/rs/pocket_ic_server/tests/spec_test.rs
@@ -131,15 +131,17 @@ fn setup_and_run_ic_ref_test(
         .map(|n| Principal::from_slice(&n.node_id))
         .collect();
 
+    let ic_ref_test_path = std::env::var_os("IC_REF_TEST_BIN")
+        .expect("Missing ic-ref-test")
+        .into_string()
+        .unwrap();
+
     // derive artifact paths
     let ic_ref_test_root = std::env::var_os("IC_REF_TEST_ROOT")
         .expect("Missing ic-hs directory")
         .into_string()
         .unwrap();
     let root_dir = std::path::PathBuf::from(ic_ref_test_root);
-    let mut ic_ref_test_path = root_dir.clone();
-    ic_ref_test_path.push("bin");
-    ic_ref_test_path.push("ic-ref-test");
     let mut ic_test_data_path = root_dir.clone();
     ic_test_data_path.push("test-data");
 
@@ -189,7 +191,7 @@ fn setup_and_run_ic_ref_test(
     run_ic_ref_test(
         httpbin_proto,
         Some(httpbin_url),
-        ic_ref_test_path.into_os_string().into_string().unwrap(),
+        ic_ref_test_path,
         ic_test_data_path,
         endpoint.to_string(),
         test_subnet_config,

--- a/rs/tests/research/BUILD.bazel
+++ b/rs/tests/research/BUILD.bazel
@@ -10,10 +10,14 @@ package(default_visibility = ["//rs:system-tests-pkg"])
         colocated_test_driver_vm_resources = {
             "vcpus": 16,
         },
+        env = {
+            "IC_REF_TEST_BIN": "$(rootpath //hs/spec_compliance:ic-ref-test)",
+        },
         tags = ["experimental_system_test_colocation"],
         target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
         runtime_deps = BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS + GUESTOS_RUNTIME_DEPS + UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
             ":ic-hs",
+            "//hs/spec_compliance:ic-ref-test",
             "//ic-os/components:networking/dev-certs/canister_http_test_ca.cert",
         ],
         deps = [
@@ -39,7 +43,6 @@ symlink_dirs(
     name = "ic-hs",
     target_compatible_with = ["@platforms//os:linux"],
     targets = {
-        "//hs/spec_compliance:ic-ref-test": "bin",
         "//rs/universal_canister/impl:universal_canister_no_heartbeat.wasm.gz": "test-data",
         "//rs/tests:wabt-tests": "test-data",
     },

--- a/rs/tests/research/spec_compliance/spec_compliance.rs
+++ b/rs/tests/research/spec_compliance/spec_compliance.rs
@@ -271,10 +271,6 @@ pub fn test_subnet(
     } else {
         None
     };
-    let ic_ref_test_path = get_dependency_path("rs/tests/research/ic-hs/bin/ic-ref-test")
-        .into_os_string()
-        .into_string()
-        .unwrap();
     let mut all_excluded_tests = excluded_tests;
     all_excluded_tests.append(&mut EXCLUDED.to_vec());
     with_endpoint(
@@ -284,7 +280,6 @@ pub fn test_subnet(
         use_bn,
         httpbin_proto,
         httpbin,
-        ic_ref_test_path,
         log,
         all_excluded_tests,
         included_tests,
@@ -326,7 +321,7 @@ fn subnet_config(subnet: &SubnetSnapshot) -> String {
 pub fn run_ic_ref_test(
     httpbin_proto: Option<String>,
     httpbin: Option<String>,
-    ic_ref_test_path: String,
+    ic_ref_test_path: PathBuf,
     ic_test_data_path: PathBuf,
     endpoint: String,
     test_subnet_config: String,
@@ -372,7 +367,6 @@ pub fn with_endpoint(
     use_bn: bool,
     httpbin_proto: Option<String>,
     httpbin: Option<String>,
-    ic_ref_test_path: String,
     log: Logger,
     excluded_tests: Vec<&str>,
     included_tests: Vec<&str>,
@@ -396,11 +390,16 @@ pub fn with_endpoint(
     let peer_subnet_config = subnet_config(&peer_subnet);
     info!(log, "test-subnet-config: {}", test_subnet_config);
     info!(log, "peer-subnet-config: {}", peer_subnet_config);
+
+    let ic_ref_test_path =
+        get_dependency_path(std::env::var("IC_REF_TEST_BIN").expect("Missing ic-ref-test"));
+    let ic_test_data_path = get_dependency_path("rs/tests/research/ic-hs/test-data");
+
     run_ic_ref_test(
         httpbin_proto,
         httpbin,
         ic_ref_test_path,
-        get_dependency_path("rs/tests/research/ic-hs/test-data"),
+        ic_test_data_path,
         endpoint,
         test_subnet_config,
         peer_subnet_config,


### PR DESCRIPTION
In https://github.com/dfinity/ic/pull/3508 we change the name of the underlying `ic-ref-test` binary, but keep the target the same. This breaks tests that have been depending on the binary name directly.

This change uses the target path to reference the binary, instead.