### PR TITLE
chore: Use tmpfs for icos tmpdirs

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -43,7 +43,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
         -v /cache:/cache
     timeout-minutes: 90
   dind-small-setup: &dind-small-setup

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -43,7 +43,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G
         -v /cache:/cache
     timeout-minutes: 90
   dind-small-setup: &dind-small-setup

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -43,7 +43,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
         -v /cache:/cache
     timeout-minutes: 90
   dind-small-setup: &dind-small-setup

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -35,7 +35,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
         -v /cache:/cache
     timeout-minutes: 180 # 3 hours
   checkout: &checkout

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -35,7 +35,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G
         -v /cache:/cache
     timeout-minutes: 180 # 3 hours
   checkout: &checkout

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -35,7 +35,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
         -v /cache:/cache
     timeout-minutes: 180 # 3 hours
   checkout: &checkout

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -24,7 +24,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
         -v /cache:/cache
     timeout-minutes: 120
   checkout: &checkout

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -24,7 +24,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G
         -v /cache:/cache
     timeout-minutes: 120
   checkout: &checkout

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -24,7 +24,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
         -v /cache:/cache
     timeout-minutes: 120
   checkout: &checkout

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -23,7 +23,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
         -v /cache:/cache
     timeout-minutes: 120
   checkout: &checkout

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -23,7 +23,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
         -v /cache:/cache
     timeout-minutes: 120
   checkout: &checkout

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -23,7 +23,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G
         -v /cache:/cache
     timeout-minutes: 120
   checkout: &checkout

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -96,7 +96,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 90
     runs-on:
       group: zh1
@@ -215,7 +215,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -236,7 +236,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -288,7 +288,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 90
     # keep options from dind-large-setup but run on dind-small-setup
     runs-on:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -96,7 +96,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 90
     runs-on:
       group: zh1
@@ -215,7 +215,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -236,7 +236,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -288,7 +288,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 90
     # keep options from dind-large-setup but run on dind-small-setup
     runs-on:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -96,7 +96,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 90
     runs-on:
       group: zh1
@@ -215,7 +215,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -236,7 +236,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -288,7 +288,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 90
     # keep options from dind-large-setup but run on dind-small-setup
     runs-on:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -31,7 +31,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout
@@ -53,7 +53,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout
@@ -75,7 +75,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -97,7 +97,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 60
     env:
       SHELL_WRAPPER: "/usr/bin/time"
@@ -139,7 +139,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     outputs:
       matrix: ${{ steps.generate.outputs.output }}
@@ -167,7 +167,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -31,7 +31,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout
@@ -53,7 +53,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout
@@ -75,7 +75,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -97,7 +97,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 60
     env:
       SHELL_WRAPPER: "/usr/bin/time"
@@ -139,7 +139,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     outputs:
       matrix: ${{ steps.generate.outputs.output }}
@@ -167,7 +167,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -31,7 +31,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout
@@ -53,7 +53,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout
@@ -75,7 +75,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -97,7 +97,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 60
     env:
       SHELL_WRAPPER: "/usr/bin/time"
@@ -139,7 +139,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     outputs:
       matrix: ${{ steps.generate.outputs.output }}
@@ -167,7 +167,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1
@@ -65,7 +65,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 720 # 12 hours
     steps:
       - name: Checkout
@@ -86,7 +86,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -107,7 +107,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 480
     steps:
       - name: Checkout
@@ -141,7 +141,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 60
     permissions:
       actions: write
@@ -193,7 +193,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1
@@ -65,7 +65,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 720 # 12 hours
     steps:
       - name: Checkout
@@ -86,7 +86,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -107,7 +107,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 480
     steps:
       - name: Checkout
@@ -141,7 +141,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 60
     permissions:
       actions: write
@@ -193,7 +193,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1
@@ -65,7 +65,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 720 # 12 hours
     steps:
       - name: Checkout
@@ -86,7 +86,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -107,7 +107,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 480
     steps:
       - name: Checkout
@@ -141,7 +141,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 60
     permissions:
       actions: write
@@ -193,7 +193,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1
@@ -58,7 +58,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1
@@ -58,7 +58,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1
@@ -58,7 +58,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:994bfcba2fa5efbb52c515bb01e6e8a5828878d6528603e7133fb195bd2a6c89
       options: >-
-        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G -v /cache:/cache
+        -e NODE_NAME --privileged --cgroupns host --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -54,7 +54,7 @@ jobs:
       options: >-
         -e NODE_NAME -e KUBECONFIG
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
         -v /cache:/cache
     timeout-minutes: 120
     steps:
@@ -119,7 +119,7 @@ jobs:
       options: >-
         -e NODE_NAME -e KUBECONFIG
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=8G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
         -v /cache:/cache
     timeout-minutes: 150
     #if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -54,7 +54,7 @@ jobs:
       options: >-
         -e NODE_NAME -e KUBECONFIG
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G
         -v /cache:/cache
     timeout-minutes: 120
     steps:
@@ -119,7 +119,7 @@ jobs:
       options: >-
         -e NODE_NAME -e KUBECONFIG
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=64G
         -v /cache:/cache
     timeout-minutes: 150
     #if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -54,7 +54,7 @@ jobs:
       options: >-
         -e NODE_NAME -e KUBECONFIG
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
         -v /cache:/cache
     timeout-minutes: 120
     steps:
@@ -119,7 +119,7 @@ jobs:
       options: >-
         -e NODE_NAME -e KUBECONFIG
         --privileged --cgroupns host
-        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=16G
+        --mount type=tmpfs,destination=/tmp/tmpfs,tmpfs-size=32G
         -v /cache:/cache
     timeout-minutes: 150
     #if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/ci/container/README.md
+++ b/ci/container/README.md
@@ -74,7 +74,6 @@ sudo podman run --pids-limit=-1 -it --rm --privileged --network=host --cgroupns=
   -u 1000:1001 -e HOSTUSER=john -e VERSION=8bb1564701c56424f77f16ef067599a1c1dc7c37 \
   --hostname=devenv-container --add-host devenv-container:127.0.0.1 \
   --entrypoint= --init --hostuser=john \
-  --mount type=tmpfs,destination=/var/sysimage \
   --mount type=bind,source=/home/john/dev/ic-ctr-run-usr-cfg,target=/ic \
   --mount type=bind,source=/home/john,target=/home/john \
   --mount type=bind,source=/home/john /.cache,target=/home/ubuntu/.cache \

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -116,7 +116,6 @@ PODMAN_RUN_ARGS+=(
     --mount type=bind,source="${HOME}/.aws",target="${CTR_HOME}/.aws"
     --mount type=bind,source="/var/lib/containers",target="/var/lib/containers"
     --mount type=bind,source="/tmp",target="/tmp"
-    --mount type=tmpfs,destination=/var/sysimage
 )
 
 if [ "$(id -u)" = "1000" ]; then

--- a/toolchains/sysimage/build_ext4_image.py
+++ b/toolchains/sysimage/build_ext4_image.py
@@ -166,6 +166,17 @@ def make_argparser():
     return parser
 
 
+def force_tmpfs(dir):
+    subprocess.run(["mkdir", dir + "/forced_tmpfs"], check=True)
+    subprocess.run(["sudo", "mount", "-t", "tmpfs", "forced_tmpfs", dir + "/forced_tmpfs"], check=True)
+
+    return dir + "/forced_tmpfs"
+
+
+def cleanup_forced_tmpfs(dir):
+    subprocess.run(["sudo", "umount", dir], check=True)
+
+
 def main():
     args = make_argparser().parse_args(sys.argv[1:])
 
@@ -180,6 +191,7 @@ def main():
         limit_prefix = limit_prefix[1:]
 
     tmpdir = os.getenv("ICOS_TMPDIR")
+    tmpdir = force_tmpfs(tmpdir)
     if not tmpdir:
         raise RuntimeError("ICOS_TMPDIR env variable not available, should be set in BUILD script.")
 
@@ -286,6 +298,8 @@ def main():
         ],
         check=True,
     )
+
+    cleanup_forced_tmpfs(tmpdir)
 
 
 if __name__ == "__main__":

--- a/toolchains/sysimage/build_ext4_image.py
+++ b/toolchains/sysimage/build_ext4_image.py
@@ -166,17 +166,6 @@ def make_argparser():
     return parser
 
 
-def force_tmpfs(dir):
-    subprocess.run(["mkdir", dir + "/forced_tmpfs"], check=True)
-    subprocess.run(["sudo", "mount", "-t", "tmpfs", "forced_tmpfs", dir + "/forced_tmpfs"], check=True)
-
-    return dir + "/forced_tmpfs"
-
-
-def cleanup_forced_tmpfs(dir):
-    subprocess.run(["sudo", "umount", dir], check=True)
-
-
 def main():
     args = make_argparser().parse_args(sys.argv[1:])
 
@@ -191,7 +180,6 @@ def main():
         limit_prefix = limit_prefix[1:]
 
     tmpdir = os.getenv("ICOS_TMPDIR")
-    tmpdir = force_tmpfs(tmpdir)
     if not tmpdir:
         raise RuntimeError("ICOS_TMPDIR env variable not available, should be set in BUILD script.")
 
@@ -298,8 +286,6 @@ def main():
         ],
         check=True,
     )
-
-    cleanup_forced_tmpfs(tmpdir)
 
 
 if __name__ == "__main__":

--- a/toolchains/sysimage/proc_wrapper.sh
+++ b/toolchains/sysimage/proc_wrapper.sh
@@ -6,6 +6,6 @@
 
 set -euo pipefail
 
-tmpdir=$(mktemp -d --tmpdir "icosbuildXXXX")
+tmpdir=$(mktemp -d --tmpdir=/tmp/tmpfs "icosbuildXXXX")
 trap 'sudo rm -rf "$tmpdir"' INT TERM EXIT
 ICOS_TMPDIR="$tmpdir" "$@"

--- a/toolchains/sysimage/verity_sign.py
+++ b/toolchains/sysimage/verity_sign.py
@@ -12,17 +12,6 @@ import sys
 root_hash_re = re.compile("Root hash:[ \t]+([a-f0-9]+).*")
 
 
-def force_tmpfs(dir):
-    subprocess.run(["mkdir", dir + "/forced_tmpfs"], check=True)
-    subprocess.run(["sudo", "mount", "-t", "tmpfs", "forced_tmpfs", dir + "/forced_tmpfs"], check=True)
-
-    return dir + "/forced_tmpfs"
-
-
-def cleanup_forced_tmpfs(dir):
-    subprocess.run(["sudo", "umount", dir], check=True)
-
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--input", help="Input (tzst) file of tree to operate in", type=str)
@@ -50,7 +39,6 @@ def main():
     args = parser.parse_args(sys.argv[1:])
 
     tmpdir = os.getenv("ICOS_TMPDIR")
-    tmpdir = force_tmpfs(tmpdir)
     if not tmpdir:
         raise RuntimeError("ICOS_TMPDIR env variable not available, should be set in BUILD script.")
     partition = os.path.join(tmpdir, "partition.img")
@@ -125,8 +113,6 @@ def main():
         ],
         check=True,
     )
-
-    cleanup_forced_tmpfs(tmpdir)
 
 
 if __name__ == "__main__":

--- a/toolchains/sysimage/verity_sign.py
+++ b/toolchains/sysimage/verity_sign.py
@@ -12,6 +12,17 @@ import sys
 root_hash_re = re.compile("Root hash:[ \t]+([a-f0-9]+).*")
 
 
+def force_tmpfs(dir):
+    subprocess.run(["mkdir", dir + "/forced_tmpfs"], check=True)
+    subprocess.run(["sudo", "mount", "-t", "tmpfs", "forced_tmpfs", dir + "/forced_tmpfs"], check=True)
+
+    return dir + "/forced_tmpfs"
+
+
+def cleanup_forced_tmpfs(dir):
+    subprocess.run(["sudo", "umount", dir], check=True)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--input", help="Input (tzst) file of tree to operate in", type=str)
@@ -39,6 +50,7 @@ def main():
     args = parser.parse_args(sys.argv[1:])
 
     tmpdir = os.getenv("ICOS_TMPDIR")
+    tmpdir = force_tmpfs(tmpdir)
     if not tmpdir:
         raise RuntimeError("ICOS_TMPDIR env variable not available, should be set in BUILD script.")
     partition = os.path.join(tmpdir, "partition.img")
@@ -113,6 +125,8 @@ def main():
         ],
         check=True,
     )
+
+    cleanup_forced_tmpfs(tmpdir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Create a new tmpfs based on https://github.com/dfinity/ic/pull/4579, and use it in icos build targets. A tmpfs should avoid the overhead of flushing large, or many small files, to disk.