### PR TITLE
feat: [EXC-1941] Introduce feature flags for canister snapshot import and export

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -320,6 +320,14 @@ pub struct Config {
 
     /// The maximum number of snapshots allowed per canister.
     pub max_number_of_snapshots_per_canister: usize,
+
+    /// Whether canister snapshot metadata and data can be downloaded
+    /// by controllers.
+    pub canister_snapshot_download: FlagStatus,
+
+    /// Whether canister snapshot metadata and data can be uploaded
+    /// by controllers.
+    pub canister_snapshot_upload: FlagStatus,
 }
 
 impl Default for Config {
@@ -399,6 +407,8 @@ impl Default for Config {
             max_canister_http_requests_in_flight: MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT,
             default_wasm_memory_limit: DEFAULT_WASM_MEMORY_LIMIT,
             max_number_of_snapshots_per_canister: MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER,
+            canister_snapshot_download: FlagStatus::Disabled,
+            canister_snapshot_upload: FlagStatus::Disabled,
         }
     }
 }


### PR DESCRIPTION
The flags will be used once the current no-op implementations in rs/execution_environment/src/execution_environment.rs are replaced by a real code path. 