### PR TITLE
fix(IDX): make sure MERGE_BASE_SHA and BRANCH_HEAD_SHA are set

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -53,7 +53,7 @@ runs:
         uses: ./.github/actions/bazel
         env:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          RANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           BUILDBUDDY_LINKS: "[CI Job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -51,6 +51,9 @@ runs:
 
       - name: Run Bazel Commands
         uses: ./.github/actions/bazel
+        env:
+          MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          RANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           BUILDBUDDY_LINKS: "[CI Job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}


### PR DESCRIPTION
The `diff.sh` [requires](https://sourcegraph.com/github.com/dfinity/ic/-/blob/ci/bazel-scripts/diff.sh?L16-L18) the `MERGE_BASE_SHA` and `BRANCH_HEAD_SHA` to be set. Otherwise CI won't run any bazel tests. However these env vars were removed in [#4493](https://github.com/dfinity/ic/pull/4493/files#diff-15b4f1d6b5ce255f735126a9b2abd404d43f09db12771399482afef58cdfcfcbL60). This adds them back.