### PR TITLE
chore: Remove wasm_native_stable_memory feature flag

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -148,7 +148,6 @@ pub struct FeatureFlags {
     pub rate_limiting_of_debug_prints: FlagStatus,
     /// Track dirty pages with a write barrier instead of the signal handler.
     pub write_barrier: FlagStatus,
-    pub wasm_native_stable_memory: FlagStatus,
     /// Indicates whether the support for 64 bit main memory is enabled
     pub wasm64: FlagStatus,
     /// Rollout stage of the best-effort responses feature.
@@ -162,7 +161,6 @@ impl Default for FeatureFlags {
         Self {
             rate_limiting_of_debug_prints: FlagStatus::Enabled,
             write_barrier: FlagStatus::Disabled,
-            wasm_native_stable_memory: FlagStatus::Enabled,
             wasm64: FlagStatus::Enabled,
             best_effort_responses: BestEffortResponsesFeature::ApplicationSubnetsOnly,
             canister_backtrace: FlagStatus::Enabled,

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -772,25 +772,12 @@ pub fn process(
                     ));
 
                     // Update the stable memory and serialize the delta.
-                    let stable_memory_delta =
-                        match embedder.config().feature_flags.wasm_native_stable_memory {
-                            FlagStatus::Enabled => {
-                                stable_memory.size = instance.heap_size(CanisterMemoryType::Stable);
-                                stable_memory.page_map.update(&compute_page_delta(
-                                    &mut instance,
-                                    &run_result.stable_memory_dirty_pages,
-                                    CanisterMemoryType::Stable,
-                                ))
-                            }
-                            FlagStatus::Disabled => {
-                                // unwrap should not fail, because we passed Some(system_api) when creating the instance
-                                let sys_api = instance.store_data_mut().system_api_mut().unwrap();
-                                stable_memory.size = sys_api.stable_memory_size();
-                                stable_memory
-                                    .page_map
-                                    .update(&sys_api.stable_memory_dirty_pages())
-                            }
-                        };
+                    stable_memory.size = instance.heap_size(CanisterMemoryType::Stable);
+                    let stable_memory_delta = stable_memory.page_map.update(&compute_page_delta(
+                        &mut instance,
+                        &run_result.stable_memory_dirty_pages,
+                        CanisterMemoryType::Stable,
+                    ));
                     // unwrap should not fail, because we passed Some(system_api) when creating the instance
                     let sys_api = instance.store_data().system_api().unwrap();
                     allocated_bytes = sys_api.get_allocated_bytes();

--- a/rs/embedders/src/wasm_utils.rs
+++ b/rs/embedders/src/wasm_utils.rs
@@ -218,7 +218,6 @@ fn validate_and_instrument(
         module,
         config.cost_to_compile_wasm_instruction,
         config.feature_flags.write_barrier,
-        config.feature_flags.wasm_native_stable_memory,
         config.metering_type,
         config.dirty_page_overhead,
         max_wasm_memory_size,

--- a/rs/embedders/src/wasm_utils/instrumentation.rs
+++ b/rs/embedders/src/wasm_utils/instrumentation.rs
@@ -163,12 +163,8 @@ pub(crate) enum InjectedImports {
 }
 
 impl InjectedImports {
-    fn count(wasm_native_stable_memory: FlagStatus) -> usize {
-        if wasm_native_stable_memory == FlagStatus::Enabled {
-            5
-        } else {
-            2
-        }
+    fn count() -> usize {
+        5
     }
 }
 
@@ -829,11 +825,7 @@ fn mutate_function_indices(module: &mut Module, f: impl Fn(u32) -> u32) {
 /// added as the last imports, we'd need to increment only non imported
 /// functions, since imported functions precede all others in the function index
 /// space, but this would be error-prone).
-fn inject_helper_functions(
-    mut module: Module,
-    wasm_native_stable_memory: FlagStatus,
-    mem_type: WasmMemoryType,
-) -> Module {
+fn inject_helper_functions(mut module: Module, mem_type: WasmMemoryType) -> Module {
     // insert types
     let ooi_type = FuncType::new([], []);
     let tgwm_type = match mem_type {
@@ -858,44 +850,41 @@ fn inject_helper_functions(
     };
 
     let mut old_imports = module.imports;
-    module.imports =
-        Vec::with_capacity(old_imports.len() + InjectedImports::count(wasm_native_stable_memory));
+    module.imports = Vec::with_capacity(old_imports.len() + InjectedImports::count());
     module.imports.push(ooi_imp);
     module.imports.push(tgwm_imp);
 
-    if wasm_native_stable_memory == FlagStatus::Enabled {
-        let tgsm_type = FuncType::new([ValType::I64, ValType::I64, ValType::I32], [ValType::I64]);
-        let tgsm_type_idx = add_func_type(&mut module, tgsm_type);
-        let tgsm_imp = Import {
-            module: INSTRUMENTED_FUN_MODULE,
-            name: TRY_GROW_STABLE_MEMORY_FUN_NAME,
-            ty: TypeRef::Func(tgsm_type_idx),
-        };
-        module.imports.push(tgsm_imp);
+    let tgsm_type = FuncType::new([ValType::I64, ValType::I64, ValType::I32], [ValType::I64]);
+    let tgsm_type_idx = add_func_type(&mut module, tgsm_type);
+    let tgsm_imp = Import {
+        module: INSTRUMENTED_FUN_MODULE,
+        name: TRY_GROW_STABLE_MEMORY_FUN_NAME,
+        ty: TypeRef::Func(tgsm_type_idx),
+    };
+    module.imports.push(tgsm_imp);
 
-        let it_type = FuncType::new([ValType::I32], []);
-        let it_type_idx = add_func_type(&mut module, it_type);
-        let it_imp = Import {
-            module: INSTRUMENTED_FUN_MODULE,
-            name: INTERNAL_TRAP_FUN_NAME,
-            ty: TypeRef::Func(it_type_idx),
-        };
-        module.imports.push(it_imp);
+    let it_type = FuncType::new([ValType::I32], []);
+    let it_type_idx = add_func_type(&mut module, it_type);
+    let it_imp = Import {
+        module: INSTRUMENTED_FUN_MODULE,
+        name: INTERNAL_TRAP_FUN_NAME,
+        ty: TypeRef::Func(it_type_idx),
+    };
+    module.imports.push(it_imp);
 
-        let fr_type = FuncType::new([ValType::I64, ValType::I64, ValType::I64], []);
-        let fr_type_idx = add_func_type(&mut module, fr_type);
-        let fr_imp = Import {
-            module: INSTRUMENTED_FUN_MODULE,
-            name: STABLE_READ_FIRST_ACCESS_NAME,
-            ty: TypeRef::Func(fr_type_idx),
-        };
-        module.imports.push(fr_imp);
-    }
+    let fr_type = FuncType::new([ValType::I64, ValType::I64, ValType::I64], []);
+    let fr_type_idx = add_func_type(&mut module, fr_type);
+    let fr_imp = Import {
+        module: INSTRUMENTED_FUN_MODULE,
+        name: STABLE_READ_FIRST_ACCESS_NAME,
+        ty: TypeRef::Func(fr_type_idx),
+    };
+    module.imports.push(fr_imp);
 
     module.imports.append(&mut old_imports);
 
     // now increment all function references by InjectedImports::Count
-    let cnt = InjectedImports::count(wasm_native_stable_memory) as u32;
+    let cnt = InjectedImports::count() as u32;
     mutate_function_indices(&mut module, |i| i + cnt);
 
     debug_assert!(
@@ -904,19 +893,16 @@ fn inject_helper_functions(
     debug_assert!(
         module.imports[InjectedImports::TryGrowWasmMemory as usize].name == "try_grow_wasm_memory"
     );
-    if wasm_native_stable_memory == FlagStatus::Enabled {
-        debug_assert!(
-            module.imports[InjectedImports::TryGrowStableMemory as usize].name
-                == "try_grow_stable_memory"
-        );
-        debug_assert!(
-            module.imports[InjectedImports::InternalTrap as usize].name == "internal_trap"
-        );
-        debug_assert!(
-            module.imports[InjectedImports::StableReadFirstAccess as usize].name
-                == "stable_read_first_access"
-        );
-    }
+
+    debug_assert!(
+        module.imports[InjectedImports::TryGrowStableMemory as usize].name
+            == "try_grow_stable_memory"
+    );
+    debug_assert!(module.imports[InjectedImports::InternalTrap as usize].name == "internal_trap");
+    debug_assert!(
+        module.imports[InjectedImports::StableReadFirstAccess as usize].name
+            == "stable_read_first_access"
+    );
 
     module
 }
@@ -943,7 +929,6 @@ pub(super) fn instrument(
     module: Module<'_>,
     cost_to_compile_wasm_instruction: NumInstructions,
     write_barrier: FlagStatus,
-    wasm_native_stable_memory: FlagStatus,
     metering_type: MeteringType,
     dirty_page_overhead: NumInstructions,
     max_wasm_memory_size: NumBytes,
@@ -951,12 +936,11 @@ pub(super) fn instrument(
 ) -> Result<InstrumentationOutput, WasmInstrumentationError> {
     let main_memory_type = main_memory_type(&module);
     let stable_memory_index;
-    let mut module = inject_helper_functions(module, wasm_native_stable_memory, main_memory_type);
+    let mut module = inject_helper_functions(module, main_memory_type);
     module = export_table(module);
     (module, stable_memory_index) = update_memories(
         module,
         write_barrier,
-        wasm_native_stable_memory,
         max_wasm_memory_size,
         max_stable_memory_size,
     );
@@ -981,21 +965,9 @@ pub(super) fn instrument(
     let num_functions = (module.functions.len() + num_imported_functions) as u32;
     let num_globals = (module.globals.len() + num_imported_globals) as u32;
 
-    let dirty_pages_counter_ix;
-    let accessed_pages_counter_ix;
-    let count_clean_pages_fn;
-    match wasm_native_stable_memory {
-        FlagStatus::Enabled => {
-            dirty_pages_counter_ix = Some(num_globals + 1);
-            accessed_pages_counter_ix = Some(num_globals + 2);
-            count_clean_pages_fn = Some(num_functions + 1);
-        }
-        FlagStatus::Disabled => {
-            dirty_pages_counter_ix = None;
-            accessed_pages_counter_ix = None;
-            count_clean_pages_fn = None;
-        }
-    };
+    let dirty_pages_counter_ix = Some(num_globals + 1);
+    let accessed_pages_counter_ix = Some(num_globals + 2);
+    let count_clean_pages_fn = Some(num_functions + 1);
 
     let special_indices = SpecialIndices {
         instructions_counter_ix: num_globals,
@@ -1053,17 +1025,15 @@ pub(super) fn instrument(
         }
     }
 
-    module = export_additional_symbols(module, &special_indices, wasm_native_stable_memory);
+    module = export_additional_symbols(module, &special_indices);
 
-    if wasm_native_stable_memory == FlagStatus::Enabled {
-        replace_system_api_functions(
-            &mut module,
-            special_indices,
-            dirty_page_overhead,
-            main_memory_type,
-            max_wasm_memory_size,
-        )
-    }
+    replace_system_api_functions(
+        &mut module,
+        special_indices,
+        dirty_page_overhead,
+        main_memory_type,
+        max_wasm_memory_size,
+    );
 
     let exported_functions = module
         .exports
@@ -1075,10 +1045,7 @@ pub(super) fn instrument(
         1 + match write_barrier {
             FlagStatus::Enabled => 1,
             FlagStatus::Disabled => 0,
-        } + match wasm_native_stable_memory {
-            FlagStatus::Enabled => 2,
-            FlagStatus::Disabled => 0,
-        };
+        } + 2;
     if module.memories.len() > expected_memories {
         return Err(WasmInstrumentationError::IncorrectNumberMemorySections {
             expected: expected_memories,
@@ -1184,7 +1151,6 @@ fn replace_system_api_functions(
 fn export_additional_symbols<'a>(
     mut module: Module<'a>,
     special_indices: &SpecialIndices,
-    wasm_native_stable_memory: FlagStatus,
 ) -> Module<'a> {
     // push function to decrement the instruction counter
 
@@ -1244,93 +1210,91 @@ fn export_additional_symbols<'a>(
     module.functions.push(type_idx);
     module.code_sections.push(func_body);
 
-    if wasm_native_stable_memory == FlagStatus::Enabled {
-        // function to count clean pages in a given range
-        // Arg 0 - start of the range
-        // Arg 1 - end of the range
-        // Return index 0 is the number of pages that haven't been written to in the given range
-        // Return index 1 is the number of pages that haven't been accessed in the given range.
-        let func_type = FuncType::new([ValType::I32, ValType::I32], [ValType::I32, ValType::I32]);
-        let it = 2; // iterator index
-        let tmp = 3;
-        let acc_w = 4; // accumulator index
-        let acc_a = 5; // accumulator index
-        let instructions = vec![
-            LocalGet { local_index: 0 },
-            LocalGet { local_index: 1 },
-            I32GeU,
-            If {
-                blockty: BlockType::Empty,
+    // function to count clean pages in a given range
+    // Arg 0 - start of the range
+    // Arg 1 - end of the range
+    // Return index 0 is the number of pages that haven't been written to in the given range
+    // Return index 1 is the number of pages that haven't been accessed in the given range.
+    let func_type = FuncType::new([ValType::I32, ValType::I32], [ValType::I32, ValType::I32]);
+    let it = 2; // iterator index
+    let tmp = 3;
+    let acc_w = 4; // accumulator index
+    let acc_a = 5; // accumulator index
+    let instructions = vec![
+        LocalGet { local_index: 0 },
+        LocalGet { local_index: 1 },
+        I32GeU,
+        If {
+            blockty: BlockType::Empty,
+        },
+        // If range is empty, return early
+        I32Const { value: 0 },
+        I32Const { value: 0 },
+        Return,
+        End,
+        LocalGet { local_index: 0 },
+        LocalSet { local_index: it },
+        Loop {
+            blockty: BlockType::Empty,
+        },
+        LocalGet { local_index: it },
+        // TODO read in bigger chunks (i64Load)
+        I32Load8U {
+            memarg: wasmparser::MemArg {
+                align: 0,
+                max_align: 0,
+                offset: 0,
+                // We assume the bytemap for stable memory is always
+                // inserted directly after the stable memory.
+                memory: special_indices.stable_memory_index + 1,
             },
-            // If range is empty, return early
-            I32Const { value: 0 },
-            I32Const { value: 0 },
-            Return,
-            End,
-            LocalGet { local_index: 0 },
-            LocalSet { local_index: it },
-            Loop {
-                blockty: BlockType::Empty,
-            },
-            LocalGet { local_index: it },
-            // TODO read in bigger chunks (i64Load)
-            I32Load8U {
-                memarg: wasmparser::MemArg {
-                    align: 0,
-                    max_align: 0,
-                    offset: 0,
-                    // We assume the bytemap for stable memory is always
-                    // inserted directly after the stable memory.
-                    memory: special_indices.stable_memory_index + 1,
-                },
-            },
-            LocalTee { local_index: tmp },
-            I32Const { value: 1 }, //write bit
-            I32And,
-            // update acc_w
-            LocalGet { local_index: acc_w },
-            I32Add,
-            LocalSet { local_index: acc_w },
-            // get access bit
-            LocalGet { local_index: tmp },
-            I32Const { value: 1 },
-            I32ShrU,
-            I32Const { value: 1 },
-            I32And,
-            // update acc_a
-            LocalGet { local_index: acc_a },
-            I32Add,
-            LocalSet { local_index: acc_a },
-            LocalGet { local_index: it },
-            I32Const { value: 1 },
-            I32Add,
-            LocalTee { local_index: it },
-            LocalGet { local_index: 1 },
-            I32LtU,
-            BrIf { relative_depth: 0 },
-            End,
-            // clean pages = len - dirty_count
-            LocalGet { local_index: 1 },
-            LocalGet { local_index: 0 },
-            I32Sub,
-            LocalGet { local_index: acc_w },
-            I32Sub,
-            // non-accessed pages
-            LocalGet { local_index: 1 },
-            LocalGet { local_index: 0 },
-            I32Sub,
-            LocalGet { local_index: acc_a },
-            I32Sub,
-            End,
-        ];
-        let func_body = ic_wasm_transform::Body {
-            locals: vec![(4, ValType::I32)],
-            instructions,
-        };
-        let type_idx = add_func_type(&mut module, func_type);
-        module.functions.push(type_idx);
-        module.code_sections.push(func_body);
-    }
+        },
+        LocalTee { local_index: tmp },
+        I32Const { value: 1 }, //write bit
+        I32And,
+        // update acc_w
+        LocalGet { local_index: acc_w },
+        I32Add,
+        LocalSet { local_index: acc_w },
+        // get access bit
+        LocalGet { local_index: tmp },
+        I32Const { value: 1 },
+        I32ShrU,
+        I32Const { value: 1 },
+        I32And,
+        // update acc_a
+        LocalGet { local_index: acc_a },
+        I32Add,
+        LocalSet { local_index: acc_a },
+        LocalGet { local_index: it },
+        I32Const { value: 1 },
+        I32Add,
+        LocalTee { local_index: it },
+        LocalGet { local_index: 1 },
+        I32LtU,
+        BrIf { relative_depth: 0 },
+        End,
+        // clean pages = len - dirty_count
+        LocalGet { local_index: 1 },
+        LocalGet { local_index: 0 },
+        I32Sub,
+        LocalGet { local_index: acc_w },
+        I32Sub,
+        // non-accessed pages
+        LocalGet { local_index: 1 },
+        LocalGet { local_index: 0 },
+        I32Sub,
+        LocalGet { local_index: acc_a },
+        I32Sub,
+        End,
+    ];
+    let func_body = ic_wasm_transform::Body {
+        locals: vec![(4, ValType::I32)],
+        instructions,
+    };
+    let type_idx = add_func_type(&mut module, func_type);
+    module.functions.push(type_idx);
+    module.code_sections.push(func_body);
 
     // globals must be exported to be accessible to hypervisor or persisted
     let counter_export = Export {
@@ -1382,26 +1346,24 @@ fn export_additional_symbols<'a>(
         init_expr: Operator::I64Const { value: 0 },
     });
 
-    if wasm_native_stable_memory == FlagStatus::Enabled {
-        // push the dirty page counter
-        module.globals.push(Global {
-            ty: GlobalType {
-                content_type: ValType::I64,
-                mutable: true,
-                shared: false,
-            },
-            init_expr: Operator::I64Const { value: 0 },
-        });
-        // push the accessed page counter
-        module.globals.push(Global {
-            ty: GlobalType {
-                content_type: ValType::I64,
-                mutable: true,
-                shared: false,
-            },
-            init_expr: Operator::I64Const { value: 0 },
-        });
-    }
+    // push the dirty page counter
+    module.globals.push(Global {
+        ty: GlobalType {
+            content_type: ValType::I64,
+            mutable: true,
+            shared: false,
+        },
+        init_expr: Operator::I64Const { value: 0 },
+    });
+    // push the accessed page counter
+    module.globals.push(Global {
+        ty: GlobalType {
+            content_type: ValType::I64,
+            mutable: true,
+            shared: false,
+        },
+        init_expr: Operator::I64Const { value: 0 },
+    });
 
     module
 }
@@ -1984,12 +1946,9 @@ fn export_table(mut module: Module) -> Module {
 fn update_memories(
     mut module: Module,
     write_barrier: FlagStatus,
-    wasm_native_stable_memory: FlagStatus,
     max_wasm_memory_size: NumBytes,
     max_stable_memory_size: NumBytes,
 ) -> (Module, u32) {
-    let mut stable_index = 0;
-
     if let Some(mem) = module.memories.first_mut() {
         if mem.memory64 {
             let max_wasm_memory_size_in_wasm_pages =
@@ -2042,38 +2001,36 @@ fn update_memories(
         });
     }
 
-    if wasm_native_stable_memory == FlagStatus::Enabled {
-        stable_index = module.memories.len() as u32;
-        module.memories.push(MemoryType {
-            memory64: true,
-            shared: false,
-            initial: 0,
-            maximum: Some(max_memory_size_in_wasm_pages(max_stable_memory_size)),
-            page_size_log2: None,
-        });
+    let stable_index = module.memories.len() as u32;
+    module.memories.push(MemoryType {
+        memory64: true,
+        shared: false,
+        initial: 0,
+        maximum: Some(max_memory_size_in_wasm_pages(max_stable_memory_size)),
+        page_size_log2: None,
+    });
 
-        module.exports.push(Export {
-            name: STABLE_MEMORY_NAME,
-            kind: ExternalKind::Memory,
-            index: stable_index,
-        });
+    module.exports.push(Export {
+        name: STABLE_MEMORY_NAME,
+        kind: ExternalKind::Memory,
+        index: stable_index,
+    });
 
-        let stable_bytemap_size_in_wasm_pages = bytemap_size_in_wasm_pages(max_stable_memory_size);
-        module.memories.push(MemoryType {
-            memory64: false,
-            shared: false,
-            initial: stable_bytemap_size_in_wasm_pages,
-            maximum: Some(stable_bytemap_size_in_wasm_pages),
-            page_size_log2: None,
-        });
+    let stable_bytemap_size_in_wasm_pages = bytemap_size_in_wasm_pages(max_stable_memory_size);
+    module.memories.push(MemoryType {
+        memory64: false,
+        shared: false,
+        initial: stable_bytemap_size_in_wasm_pages,
+        maximum: Some(stable_bytemap_size_in_wasm_pages),
+        page_size_log2: None,
+    });
 
-        module.exports.push(Export {
-            name: STABLE_BYTEMAP_MEMORY_NAME,
-            kind: ExternalKind::Memory,
-            // Bytemap for a memory needs to be placed at the next index after the memory
-            index: stable_index + 1,
-        })
-    }
+    module.exports.push(Export {
+        name: STABLE_BYTEMAP_MEMORY_NAME,
+        kind: ExternalKind::Memory,
+        // Bytemap for a memory needs to be placed at the next index after the memory
+        index: stable_index + 1,
+    });
 
     (module, stable_index)
 }

--- a/rs/embedders/src/wasm_utils/system_api_replacements.rs
+++ b/rs/embedders/src/wasm_utils/system_api_replacements.rs
@@ -35,9 +35,9 @@ pub(super) fn replacement_functions(
     main_memory_type: WasmMemoryType,
     max_wasm_memory_size: NumBytes,
 ) -> Vec<(SystemApiFunc, (FuncType, Body<'static>))> {
-    let count_clean_pages_fn_index = special_indices.count_clean_pages_fn.unwrap();
-    let dirty_pages_counter_index = special_indices.dirty_pages_counter_ix.unwrap();
-    let accessed_pages_counter_index = special_indices.accessed_pages_counter_ix.unwrap();
+    let count_clean_pages_fn_index = special_indices.count_clean_pages_fn;
+    let dirty_pages_counter_index = special_indices.dirty_pages_counter_ix;
+    let accessed_pages_counter_index = special_indices.accessed_pages_counter_ix;
     let stable_memory_index = special_indices.stable_memory_index;
     let decr_instruction_counter_fn = special_indices.decr_instruction_counter_fn;
 

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -153,12 +153,11 @@ fn get_exported_globals<T>(instance: &Instance, store: &mut Store<T>) -> Vec<was
         DIRTY_PAGES_COUNTER_GLOBAL_NAME,
         ACCESSED_PAGES_COUNTER_GLOBAL_NAME,
     ];
-    let globals_to_ignore = TO_IGNORE;
 
     instance
         .exports(store)
         .filter_map(|e| {
-            if globals_to_ignore.contains(&e.name()) {
+            if TO_IGNORE.contains(&e.name()) {
                 None
             } else {
                 e.into_global()
@@ -509,14 +508,22 @@ impl WasmtimeEmbedder {
             }
         }
 
-        instance.get_global(&mut store, DIRTY_PAGES_COUNTER_GLOBAL_NAME)
-                .expect("Counter for dirty pages global should have been added with native stable memory enabled.")
-                .set(&mut store, Val::I64(current_dirty_page_limit.get() as i64))
-                .expect("Couldn't set dirty page counter global");
-        instance.get_global(&mut store, ACCESSED_PAGES_COUNTER_GLOBAL_NAME)
-                .expect("Counter for accessed pages global should have been added with native stable memory enabled.")
-                .set(&mut store, Val::I64(current_accessed_limit.get() as i64))
-                .expect("Couldn't set dirty page counter global");
+        instance
+            .get_global(&mut store, DIRTY_PAGES_COUNTER_GLOBAL_NAME)
+            .expect(
+                "Counter for dirty pages global should have been added \
+                with native stable memory enabled.",
+            )
+            .set(&mut store, Val::I64(current_dirty_page_limit.get() as i64))
+            .expect("Couldn't set dirty page counter global");
+        instance
+            .get_global(&mut store, ACCESSED_PAGES_COUNTER_GLOBAL_NAME)
+            .expect(
+                "Counter for accessed pages global should have been added \
+                with native stable memory enabled.",
+            )
+            .set(&mut store, Val::I64(current_accessed_limit.get() as i64))
+            .expect("Couldn't set dirty page counter global");
 
         let mut memories = HashMap::new();
         for mem_info in self.list_memory_infos(modification_tracking, heap_memory, stable_memory) {

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -148,19 +148,12 @@ fn trap_code_to_hypervisor_error(
     }
 }
 
-fn get_exported_globals<T>(
-    wasm_native_stable_memory: FlagStatus,
-    instance: &Instance,
-    store: &mut Store<T>,
-) -> Vec<wasmtime::Global> {
+fn get_exported_globals<T>(instance: &Instance, store: &mut Store<T>) -> Vec<wasmtime::Global> {
     const TO_IGNORE: &[&str] = &[
         DIRTY_PAGES_COUNTER_GLOBAL_NAME,
         ACCESSED_PAGES_COUNTER_GLOBAL_NAME,
     ];
-    let globals_to_ignore = match wasm_native_stable_memory {
-        FlagStatus::Enabled => TO_IGNORE,
-        FlagStatus::Disabled => &[],
-    };
+    let globals_to_ignore = TO_IGNORE;
 
     instance
         .exports(store)
@@ -226,17 +219,8 @@ impl WasmtimeEmbedder {
     pub fn wasmtime_execution_config(embedder_config: &EmbeddersConfig) -> wasmtime::Config {
         let mut config = wasmtime_validation_config(embedder_config);
 
-        // Wasmtime features that differ between Wasm validation and execution.
-        // Currently these are multi-memories and the 64-bit memory needed for
-        // the Wasm-native stable memory implementation.
-        if embedder_config.feature_flags.write_barrier == FlagStatus::Enabled
-            || embedder_config.feature_flags.wasm_native_stable_memory == FlagStatus::Enabled
-        {
-            config.wasm_multi_memory(true);
-        }
-        if embedder_config.feature_flags.wasm_native_stable_memory == FlagStatus::Enabled {
-            config.wasm_memory64(true);
-        }
+        config.wasm_multi_memory(true);
+        config.wasm_memory64(true);
         config
     }
 
@@ -386,17 +370,16 @@ impl WasmtimeEmbedder {
             dirty_page_tracking,
         }];
 
-        if self.config.feature_flags.wasm_native_stable_memory == FlagStatus::Enabled {
-            result.push(WasmMemoryInfo {
-                name: STABLE_MEMORY_NAME,
-                bytemap_name: Some(STABLE_BYTEMAP_MEMORY_NAME),
-                memory: stable_memory.clone(),
-                memory_type: CanisterMemoryType::Stable,
-                // Wasm native stable memory will always be tracked by a
-                // bytemap within the wasm module.
-                dirty_page_tracking: DirtyPageTracking::Ignore,
-            });
-        }
+        result.push(WasmMemoryInfo {
+            name: STABLE_MEMORY_NAME,
+            bytemap_name: Some(STABLE_BYTEMAP_MEMORY_NAME),
+            memory: stable_memory.clone(),
+            memory_type: CanisterMemoryType::Stable,
+            // Wasm native stable memory will always be tracked by a
+            // bytemap within the wasm module.
+            dirty_page_tracking: DirtyPageTracking::Ignore,
+        });
+
         result
     }
 
@@ -472,11 +455,7 @@ impl WasmtimeEmbedder {
             instance.get_global(&mut store, INSTRUCTIONS_COUNTER_GLOBAL_NAME);
 
         if let Some(exported_globals) = exported_globals {
-            let instance_globals = get_exported_globals(
-                self.config.feature_flags.wasm_native_stable_memory,
-                &instance,
-                &mut store,
-            );
+            let instance_globals = get_exported_globals(&instance, &mut store);
 
             if exported_globals.len() != instance_globals.len() {
                 fatal!(
@@ -530,16 +509,14 @@ impl WasmtimeEmbedder {
             }
         }
 
-        if self.config.feature_flags.wasm_native_stable_memory == FlagStatus::Enabled {
-            instance.get_global(&mut store, DIRTY_PAGES_COUNTER_GLOBAL_NAME)
+        instance.get_global(&mut store, DIRTY_PAGES_COUNTER_GLOBAL_NAME)
                 .expect("Counter for dirty pages global should have been added with native stable memory enabled.")
                 .set(&mut store, Val::I64(current_dirty_page_limit.get() as i64))
                 .expect("Couldn't set dirty page counter global");
-            instance.get_global(&mut store, ACCESSED_PAGES_COUNTER_GLOBAL_NAME)
+        instance.get_global(&mut store, ACCESSED_PAGES_COUNTER_GLOBAL_NAME)
                 .expect("Counter for accessed pages global should have been added with native stable memory enabled.")
                 .set(&mut store, Val::I64(current_accessed_limit.get() as i64))
                 .expect("Couldn't set dirty page counter global");
-        }
 
         let mut memories = HashMap::new();
         for mem_info in self.list_memory_infos(modification_tracking, heap_memory, stable_memory) {
@@ -575,7 +552,6 @@ impl WasmtimeEmbedder {
             instance_stats: InstanceStats::default(),
             store,
             write_barrier: self.config.feature_flags.write_barrier,
-            wasm_native_stable_memory: self.config.feature_flags.wasm_native_stable_memory,
             canister_backtrace: self.config.feature_flags.canister_backtrace,
             modification_tracking,
             dirty_page_overhead,
@@ -832,7 +808,6 @@ pub struct WasmtimeInstance {
     instance_stats: InstanceStats,
     store: wasmtime::Store<StoreData>,
     write_barrier: FlagStatus,
-    wasm_native_stable_memory: FlagStatus,
     #[allow(unused)]
     canister_backtrace: FlagStatus,
     modification_tracking: ModificationTracking,
@@ -872,36 +847,17 @@ impl WasmtimeInstance {
     }
 
     fn page_accesses(&mut self) -> HypervisorResult<PageAccessResults> {
-        let (stable_dirty_pages, stable_accessed_pages) = if self.wasm_native_stable_memory
-            == FlagStatus::Enabled
-        {
-            let stable_dirty_pages = self.dirty_pages_from_bytemap(CanisterMemoryType::Stable)?;
+        let stable_dirty_pages = self.dirty_pages_from_bytemap(CanisterMemoryType::Stable)?;
 
-            // Get stable accessed pages from the global counter.
-            let stable_accessed_pages = self.stable_memory_page_access_limit.get() as i64
-                - self
-                    .instance
-                    .get_global(&mut self.store, ACCESSED_PAGES_COUNTER_GLOBAL_NAME)
-                    .unwrap()
-                    .get(&mut self.store)
-                    .i64()
-                    .unwrap();
-            (stable_dirty_pages, stable_accessed_pages as usize)
-        } else {
-            let stable_dirty_pages = self
-                .store
-                .data()
-                .system_api()
-                .map(|sys_api| {
-                    sys_api
-                        .stable_memory_dirty_pages()
-                        .into_iter()
-                        .map(|(i, _p)| i)
-                        .collect()
-                })
-                .unwrap_or_else(|_| Vec::new());
-            (stable_dirty_pages, 0)
-        };
+        // Get stable accessed pages from the global counter.
+        let stable_accessed_pages = (self.stable_memory_page_access_limit.get() as i64
+            - self
+                .instance
+                .get_global(&mut self.store, ACCESSED_PAGES_COUNTER_GLOBAL_NAME)
+                .unwrap()
+                .get(&mut self.store)
+                .i64()
+                .unwrap()) as usize;
 
         if !self.memory_trackers.contains_key(&CanisterMemoryType::Heap) {
             debug!(
@@ -1307,11 +1263,7 @@ impl WasmtimeInstance {
 
     /// Returns a list of exported globals.
     pub fn get_exported_globals(&mut self) -> HypervisorResult<Vec<Global>> {
-        let globals = get_exported_globals(
-            self.wasm_native_stable_memory,
-            &self.instance,
-            &mut self.store,
-        );
+        let globals = get_exported_globals(&self.instance, &mut self.store);
 
         globals
             .iter()

--- a/rs/embedders/tests/instrumentation.rs
+++ b/rs/embedders/tests/instrumentation.rs
@@ -297,15 +297,10 @@ fn new_instance(
 }
 
 #[allow(clippy::field_reassign_with_default)]
-fn new_instance_for_stable_write(
-    wat: &str,
-    instruction_limit: u64,
-    native_stable: FlagStatus,
-) -> WasmtimeInstance {
+fn new_instance_for_stable_write(wat: &str, instruction_limit: u64) -> WasmtimeInstance {
     let mut config = EmbeddersConfig::default();
     config.metering_type = MeteringType::New;
     config.dirty_page_overhead = SchedulerConfig::application_subnet().dirty_page_overhead;
-    config.feature_flags.wasm_native_stable_memory = native_stable;
     WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -828,7 +823,7 @@ fn charge_for_dirty_heap_wasm64() {
     run_charge_for_dirty_heap(WasmMemoryType::Wasm64);
 }
 
-fn run_charge_for_dirty_stable64_test(native_stable: FlagStatus) {
+fn run_charge_for_dirty_stable64_test() {
     let wat = r#"
         (module
             (import "ic0" "stable64_grow"
@@ -851,7 +846,7 @@ fn run_charge_for_dirty_stable64_test(native_stable: FlagStatus) {
             (memory (export "memory") 10)
         )"#;
 
-    let mut instance = new_instance_for_stable_write(wat, 10000, native_stable);
+    let mut instance = new_instance_for_stable_write(wat, 10000);
     let res = instance.run(func_ref("test")).unwrap();
 
     let g = &res.exported_globals;
@@ -899,34 +894,16 @@ fn run_charge_for_dirty_stable64_test(native_stable: FlagStatus) {
     let cd = SchedulerConfig::application_subnet()
         .dirty_page_overhead
         .get();
-    let csg;
-    let csw;
-    let csr;
 
-    match native_stable {
-        FlagStatus::Enabled => {
-            csg = system_api_complexity::overhead_native::STABLE_GROW.get();
-            csw = system_api_complexity::overhead_native::STABLE64_WRITE.get()
-                + system_api
-                    .get_num_instructions_from_bytes(NumBytes::from(1))
-                    .get();
-            csr = system_api_complexity::overhead_native::STABLE64_READ.get()
-                + system_api
-                    .get_num_instructions_from_bytes(NumBytes::from(1))
-                    .get();
-        }
-        FlagStatus::Disabled => {
-            csg = system_api_complexity::overhead::STABLE_GROW.get();
-            csw = system_api_complexity::overhead::STABLE64_WRITE.get()
-                + system_api
-                    .get_num_instructions_from_bytes(NumBytes::from(1))
-                    .get();
-            csr = system_api_complexity::overhead::STABLE64_READ.get()
-                + system_api
-                    .get_num_instructions_from_bytes(NumBytes::from(1))
-                    .get();
-        }
-    }
+    let csg = system_api_complexity::overhead_native::STABLE_GROW.get();
+    let csw = system_api_complexity::overhead_native::STABLE64_WRITE.get()
+        + system_api
+            .get_num_instructions_from_bytes(NumBytes::from(1))
+            .get();
+    let csr = system_api_complexity::overhead_native::STABLE64_READ.get()
+        + system_api
+            .get_num_instructions_from_bytes(NumBytes::from(1))
+            .get();
 
     let instructions_used = instr_used(&mut instance);
     // 2 dirty stable pages and one heap
@@ -939,22 +916,17 @@ fn run_charge_for_dirty_stable64_test(native_stable: FlagStatus) {
     // Now run the same with insufficient instructions
     // We should still succeed (to avoid potentially failing pre-upgrades
     // of canisters that did not adjust their code to new metering)
-    let mut instance = new_instance_for_stable_write(wat, instructions_used - 1, native_stable);
+    let mut instance = new_instance_for_stable_write(wat, instructions_used - 1);
 
     instance.run(func_ref("test")).unwrap();
 }
 
 #[test]
 fn charge_for_dirty_stable64_native() {
-    run_charge_for_dirty_stable64_test(FlagStatus::Enabled);
+    run_charge_for_dirty_stable64_test();
 }
 
-#[test]
-fn charge_for_dirty_stable64() {
-    run_charge_for_dirty_stable64_test(FlagStatus::Disabled);
-}
-
-fn run_charge_for_dirty_stable_test(native_stable: FlagStatus) {
+fn run_charge_for_dirty_stable_test() {
     let wat = r#"
         (module
             (import "ic0" "stable_grow"
@@ -977,7 +949,7 @@ fn run_charge_for_dirty_stable_test(native_stable: FlagStatus) {
             (memory (export "memory") 10)
         )"#;
 
-    let mut instance = new_instance_for_stable_write(wat, 10000, native_stable);
+    let mut instance = new_instance_for_stable_write(wat, 10000);
     let res = instance.run(func_ref("test")).unwrap();
 
     let g = &res.exported_globals;
@@ -1025,34 +997,16 @@ fn run_charge_for_dirty_stable_test(native_stable: FlagStatus) {
     let cd = SchedulerConfig::application_subnet()
         .dirty_page_overhead
         .get();
-    let csg;
-    let csw;
-    let csr;
 
-    match native_stable {
-        FlagStatus::Enabled => {
-            csg = system_api_complexity::overhead_native::STABLE_GROW.get();
-            csw = system_api_complexity::overhead_native::STABLE_WRITE.get()
-                + system_api
-                    .get_num_instructions_from_bytes(NumBytes::from(1))
-                    .get();
-            csr = system_api_complexity::overhead_native::STABLE_READ.get()
-                + system_api
-                    .get_num_instructions_from_bytes(NumBytes::from(1))
-                    .get();
-        }
-        FlagStatus::Disabled => {
-            csg = system_api_complexity::overhead::STABLE_GROW.get();
-            csw = system_api_complexity::overhead::STABLE_WRITE.get()
-                + system_api
-                    .get_num_instructions_from_bytes(NumBytes::from(1))
-                    .get();
-            csr = system_api_complexity::overhead::STABLE_READ.get()
-                + system_api
-                    .get_num_instructions_from_bytes(NumBytes::from(1))
-                    .get();
-        }
-    }
+    let csg = system_api_complexity::overhead_native::STABLE_GROW.get();
+    let csw = system_api_complexity::overhead_native::STABLE_WRITE.get()
+        + system_api
+            .get_num_instructions_from_bytes(NumBytes::from(1))
+            .get();
+    let csr = system_api_complexity::overhead_native::STABLE_READ.get()
+        + system_api
+            .get_num_instructions_from_bytes(NumBytes::from(1))
+            .get();
 
     let instructions_used = instr_used(&mut instance);
     // 2 dirty stable pages and one heap
@@ -1065,19 +1019,14 @@ fn run_charge_for_dirty_stable_test(native_stable: FlagStatus) {
     // Now run the same with insufficient instructions
     // We should still succeed (to avoid potentially failing pre-upgrades
     // of canisters that did not adjust their code to new metering)
-    let mut instance = new_instance_for_stable_write(wat, instructions_used - 1, native_stable);
+    let mut instance = new_instance_for_stable_write(wat, instructions_used - 1);
 
     instance.run(func_ref("test")).unwrap();
 }
 
 #[test]
 fn charge_for_dirty_stable_native() {
-    run_charge_for_dirty_stable_test(FlagStatus::Enabled);
-}
-
-#[test]
-fn charge_for_dirty_stable() {
-    run_charge_for_dirty_stable_test(FlagStatus::Disabled);
+    run_charge_for_dirty_stable_test();
 }
 
 /// Helper method to generate a wasm module with tables in both

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -669,8 +669,7 @@ fn stable_write_and_read() {
                 )
                 (memory (export "memory") 1)
             )"#;
-    let mut config = Config::default();
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
+    let config = Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -713,8 +712,7 @@ fn stable64_write_and_read() {
                 (table funcref (elem $test))
                 (memory (export "memory") 1)
             )"#;
-    let mut config = Config::default();
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
+    let config = Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -787,7 +785,7 @@ fn stable_read_accessed_pages_allowance() {
 
     use HypervisorError::*;
 
-    let mut config = Config {
+    let config = Config {
         stable_memory_accessed_page_limit: StableMemoryPageLimit {
             message: ic_types::NumOsPages::new(3),
             upgrade: ic_types::NumOsPages::new(3),
@@ -795,7 +793,6 @@ fn stable_read_accessed_pages_allowance() {
         },
         ..Default::default()
     };
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config.clone())
         .with_wat(wat)
@@ -882,7 +879,7 @@ fn stable64_read_accessed_pages_allowance() {
 
     use HypervisorError::*;
 
-    let mut config = Config {
+    let config = Config {
         stable_memory_accessed_page_limit: StableMemoryPageLimit {
             message: ic_types::NumOsPages::new(3),
             upgrade: ic_types::NumOsPages::new(3),
@@ -890,7 +887,6 @@ fn stable64_read_accessed_pages_allowance() {
         },
         ..Default::default()
     };
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config.clone())
         .with_wat(wat)
@@ -953,8 +949,7 @@ fn multiple_stable_write() {
                 (table funcref (elem $test))
                 (memory (export "memory") 5)
             )"#;
-    let mut config = Config::default();
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
+    let config = Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -1001,8 +996,7 @@ fn multiple_stable64_write() {
                 (table funcref (elem $test))
                 (memory (export "memory") 5)
             )"#;
-    let mut config = Config::default();
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
+    let config = Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -1097,10 +1091,7 @@ fn stable_read_out_of_bounds() {
     };
     assert_eq!(trap_code, StableMemoryOutOfBounds);
 
-    // native stable memory
-    let mut config = Config::default();
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
-
+    let config = Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config.clone())
         .with_wat(wat)
@@ -1249,10 +1240,7 @@ fn stable64_read_out_of_bounds() {
     };
     assert_eq!(trap_code, StableMemoryOutOfBounds);
 
-    // Native stable memory
-    let mut config = Config::default();
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
-
+    let config = Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config.clone())
         .with_wat(wat)
@@ -1397,10 +1385,7 @@ fn stable_write_out_of_bounds() {
     };
     assert_eq!(trap_code, StableMemoryOutOfBounds);
 
-    // native stable memory
-    let mut config = Config::default();
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
-
+    let config = Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config.clone())
         .with_wat(wat)
@@ -1549,9 +1534,7 @@ fn stable64_write_out_of_bounds() {
     };
     assert_eq!(trap_code, StableMemoryOutOfBounds);
 
-    // native stable memory
-    let mut config = Config::default();
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
+    let config = Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config.clone())
         .with_wat(wat)
@@ -3229,7 +3212,6 @@ fn large_wasm64_stable_read_write_test() {
 
     let mut config = ic_config::embedders::Config::default();
     config.feature_flags.wasm64 = FlagStatus::Enabled;
-    config.feature_flags.wasm_native_stable_memory = FlagStatus::Enabled;
     // Declare a large heap.
     config.max_wasm64_memory_size = NumBytes::from(10 * gb);
 

--- a/rs/execution_environment/src/execution/call_or_task/tests.rs
+++ b/rs/execution_environment/src/execution/call_or_task/tests.rs
@@ -607,20 +607,18 @@ fn hitting_page_delta_limit_fails_message_system_subnet() {
     );
 }
 
-fn hitting_page_delta_limit_fails_for_install_code_helper(with_native_stable_mem: bool) {
+#[test]
+fn hitting_page_delta_limit_fails_for_install_code() {
     let no_pages_upgrade = 10;
     // A large enough limit that will never be triggered.
     let no_pages_other_messages = no_pages_upgrade * 10_000_000;
-    let mut test =
-        ExecutionTestBuilder::new().with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
+    let mut test = ExecutionTestBuilder::new()
+        .with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
             upgrade: NumOsPages::new(no_pages_upgrade),
             message: NumOsPages::new(no_pages_other_messages),
             query: NumOsPages::new(no_pages_other_messages),
-        });
-    if with_native_stable_mem {
-        test = test.with_non_native_stable();
-    }
-    let mut test = test.build();
+        })
+        .build();
     let wat = wat_writing_to_each_stable_memory_page_long_execution(
         no_pages_upgrade * PAGE_SIZE as u64 + 1,
     );
@@ -629,87 +627,16 @@ fn hitting_page_delta_limit_fails_for_install_code_helper(with_native_stable_mem
     let result = test
         .install_canister(canister_id, wat::parse_str(wat).unwrap())
         .unwrap_err();
-    if with_native_stable_mem {
-        result.assert_contains(
-            ErrorCode::CanisterMemoryAccessLimitExceeded,
-            &format!(
-                "Error from Canister {canister_id}: Canister exceeded memory access \
-            limits: Exceeded the limit for the number of modified pages in the stable \
-            memory in a single message execution: limit: 40 KB."
-            ),
-        );
-    } else {
-        result.assert_contains(
-            ErrorCode::CanisterMemoryAccessLimitExceeded,
-            &format!(
-                "Error from Canister {canister_id}: Canister exceeded memory access \
-            limits: Exceeded the limit for the number of modified pages in the stable memory \
-            in a single execution: limit {} KB for regular messages, {} KB for upgrade \
-            messages and {} KB for queries.",
-                no_pages_other_messages * (PAGE_SIZE as u64 / 1024),
-                no_pages_upgrade * (PAGE_SIZE as u64 / 1024),
-                no_pages_other_messages * (PAGE_SIZE as u64 / 1024)
-            ),
-        );
-    }
-}
-
-#[test]
-fn hitting_page_delta_limit_fails_for_install_code() {
-    hitting_page_delta_limit_fails_for_install_code_helper(false)
-}
-
-#[test]
-#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
-fn hitting_page_delta_limit_fails_for_install_code_non_native_stable() {
-    hitting_page_delta_limit_fails_for_install_code_helper(true)
-}
-
-#[test]
-#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
-fn hitting_page_delta_limit_fails_message_non_native_stable() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
-            upgrade: NumOsPages::new(10),
-            message: NumOsPages::new(10),
-            query: NumOsPages::new(10),
-        })
-        .with_non_native_stable()
-        .build();
-    let wat = wat_writing_to_each_stable_memory_page(10 * PAGE_SIZE as u64 + 1);
-    let canister_id = test.canister_from_wat(wat).unwrap();
-    let result = test.ingress(canister_id, "go", vec![]).unwrap_err();
     result.assert_contains(
         ErrorCode::CanisterMemoryAccessLimitExceeded,
         &format!(
             "Error from Canister {canister_id}: Canister exceeded memory access \
         limits: Exceeded the limit for the number of modified pages in the stable memory \
-        in a single message execution: limit: 40 KB."
-        ),
-    );
-}
-
-#[test]
-#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
-fn hitting_page_delta_limit_fails_message_non_native_stable_system_subnet() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_stable_memory_dirty_page_limit(StableMemoryPageLimit {
-            upgrade: NumOsPages::new(10),
-            message: NumOsPages::new(10),
-            query: NumOsPages::new(10),
-        })
-        .with_non_native_stable()
-        .with_subnet_type(SubnetType::System)
-        .build();
-    let wat = wat_writing_to_each_stable_memory_page(10 * PAGE_SIZE as u64 + 1);
-    let canister_id = test.canister_from_wat(wat).unwrap();
-    let result = test.ingress(canister_id, "go", vec![]).unwrap_err();
-    result.assert_contains(
-        ErrorCode::CanisterMemoryAccessLimitExceeded,
-        &format!(
-            "Error from Canister {canister_id}: Canister exceeded memory access \
-        limits: Exceeded the limit for the number of modified pages in the stable memory \
-        in a single message execution: limit: 40 KB."
+        in a single execution: limit {} KB for regular messages, {} KB for upgrade \
+        messages and {} KB for queries.",
+            no_pages_other_messages * (PAGE_SIZE as u64 / 1024),
+            no_pages_upgrade * (PAGE_SIZE as u64 / 1024),
+            no_pages_other_messages * (PAGE_SIZE as u64 / 1024)
         ),
     );
 }

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -325,13 +325,7 @@ const NORMAL_INGRESS_COST: u128 = 1_224_000;
 const MAX_EXECUTION_COST: u128 = 6_000_000;
 
 fn actual_execution_cost() -> Cycles {
-    match EmbeddersConfig::new()
-        .feature_flags
-        .wasm_native_stable_memory
-    {
-        FlagStatus::Enabled => Cycles::new(5_985_224),
-        FlagStatus::Disabled => Cycles::new(5_685_230),
-    }
+    Cycles::new(5_985_224)
 }
 
 #[test]

--- a/rs/system_api/src/stable_memory.rs
+++ b/rs/system_api/src/stable_memory.rs
@@ -1,13 +1,7 @@
-use std::convert::TryInto;
-
 use ic_interfaces::execution_environment::{
-    HypervisorError, HypervisorResult,
-    TrapCode::{HeapOutOfBounds, StableMemoryOutOfBounds, StableMemoryTooBigFor32Bit},
+    HypervisorError, HypervisorResult, TrapCode::HeapOutOfBounds,
 };
-use ic_replicated_state::{canister_state::WASM_PAGE_SIZE_IN_BYTES, page_map, NumWasmPages};
-use ic_types::NumOsPages;
-
-const MAX_32_BIT_STABLE_MEMORY_IN_PAGES: usize = 64 * 1024; // 4GiB
+use ic_replicated_state::page_map;
 
 /// Essentially the same as a `page_map::Memory`, but we use a `Buffer` instead
 /// of a `PageMap`.
@@ -19,89 +13,13 @@ pub struct StableMemory {
     /// allows us to allocate a dirty page once and modify it in-place in
     /// subsequent calls.
     pub stable_memory_buffer: page_map::Buffer,
-    /// The size of the canister's stable memory.
-    pub stable_memory_size: NumWasmPages,
 }
 
 impl StableMemory {
     pub fn new(stable_memory: ic_replicated_state::Memory) -> Self {
         Self {
             stable_memory_buffer: page_map::Buffer::new(stable_memory.page_map),
-            stable_memory_size: stable_memory.size,
         }
-    }
-
-    /// Returns the stable memory size in Wasm pages after checking that it fits
-    /// into an unsigned 32-bit integer.
-    pub(super) fn stable_size(&self) -> HypervisorResult<u32> {
-        let size = self.stable_memory_size.get();
-        if size > MAX_32_BIT_STABLE_MEMORY_IN_PAGES {
-            return Err(HypervisorError::Trapped {
-                trap_code: StableMemoryTooBigFor32Bit,
-                backtrace: None,
-            });
-        }
-
-        // Safe as we confirmed above the value is small enough to fit into 32-bits.
-        Ok(size.try_into().unwrap())
-    }
-
-    /// Reads from stable memory back to heap.
-    pub(super) fn stable_read(
-        &self,
-        dst: u32,
-        offset: u32,
-        size: u32,
-        heap: &mut [u8],
-    ) -> HypervisorResult<()> {
-        let (dst, offset, size) = (dst as usize, offset as usize, size as usize);
-
-        if offset + size > (self.stable_size()? as usize * WASM_PAGE_SIZE_IN_BYTES) {
-            return Err(HypervisorError::Trapped {
-                trap_code: StableMemoryOutOfBounds,
-                backtrace: None,
-            });
-        }
-
-        if dst + size > heap.len() {
-            return Err(HypervisorError::Trapped {
-                trap_code: HeapOutOfBounds,
-                backtrace: None,
-            });
-        }
-        self.stable_memory_buffer
-            .read(&mut heap[dst..dst + size], offset);
-        Ok(())
-    }
-
-    /// Writes from heap to stable memory.
-    /// Returns the number of **new** dirty pages created by the write.
-    pub(super) fn stable_write(
-        &mut self,
-        offset: u32,
-        src: u32,
-        size: u32,
-        heap: &[u8],
-    ) -> HypervisorResult<()> {
-        let (src, offset, size) = (src as usize, offset as usize, size as usize);
-
-        if offset + size > (self.stable_size()? as usize * WASM_PAGE_SIZE_IN_BYTES) {
-            return Err(HypervisorError::Trapped {
-                trap_code: StableMemoryOutOfBounds,
-                backtrace: None,
-            });
-        }
-
-        if src + size > heap.len() {
-            return Err(HypervisorError::Trapped {
-                trap_code: HeapOutOfBounds,
-                backtrace: None,
-            });
-        }
-
-        self.stable_memory_buffer
-            .write(&heap[src..src + size], offset);
-        Ok(())
     }
 
     /// Same as `stable64_read`, but doesn't do any bounds checks on the stable
@@ -126,103 +44,5 @@ impl StableMemory {
         self.stable_memory_buffer
             .read(&mut heap[dst as usize..heap_end as usize], offset as usize);
         Ok(())
-    }
-
-    /// Reads from stable memory back to heap.
-    ///
-    /// Supports bigger stable memory indexed by 64 bit pointers.
-    pub(super) fn stable64_read(
-        &self,
-        dst: u64,
-        offset: u64,
-        size: u64,
-        heap: &mut [u8],
-    ) -> HypervisorResult<()> {
-        let (dst, offset, size) = (dst as usize, offset as usize, size as usize);
-
-        let (stable_memory_size_in_bytes, overflow) = self
-            .stable_memory_size
-            .get()
-            .overflowing_mul(WASM_PAGE_SIZE_IN_BYTES);
-        if overflow {
-            return Err(HypervisorError::Trapped {
-                trap_code: StableMemoryOutOfBounds,
-                backtrace: None,
-            });
-        }
-
-        let (stable_memory_end, overflow) = offset.overflowing_add(size);
-        if overflow || stable_memory_end > stable_memory_size_in_bytes {
-            return Err(HypervisorError::Trapped {
-                trap_code: StableMemoryOutOfBounds,
-                backtrace: None,
-            });
-        }
-
-        let (heap_end, overflow) = dst.overflowing_add(size);
-        if overflow || heap_end > heap.len() {
-            return Err(HypervisorError::Trapped {
-                trap_code: HeapOutOfBounds,
-                backtrace: None,
-            });
-        }
-        self.stable_memory_buffer
-            .read(&mut heap[dst..heap_end], offset);
-        Ok(())
-    }
-
-    /// Writes from heap to stable memory.
-    ///
-    /// Supports bigger stable memory indexed by 64 bit pointers.
-    /// Returns the number of **new** dirty pages created by the write.
-    pub(super) fn stable64_write(
-        &mut self,
-        offset: u64,
-        src: u64,
-        size: u64,
-        heap: &[u8],
-    ) -> HypervisorResult<()> {
-        let (src, offset, size) = (src as usize, offset as usize, size as usize);
-
-        let (stable_memory_size_in_bytes, overflow) = self
-            .stable_memory_size
-            .get()
-            .overflowing_mul(WASM_PAGE_SIZE_IN_BYTES);
-        if overflow {
-            return Err(HypervisorError::Trapped {
-                trap_code: StableMemoryOutOfBounds,
-                backtrace: None,
-            });
-        }
-
-        let (stable_memory_end, overflow) = offset.overflowing_add(size);
-        if overflow || stable_memory_end > stable_memory_size_in_bytes {
-            return Err(HypervisorError::Trapped {
-                trap_code: StableMemoryOutOfBounds,
-                backtrace: None,
-            });
-        }
-
-        let (heap_end, overflow) = src.overflowing_add(size);
-        if overflow || heap_end > heap.len() {
-            return Err(HypervisorError::Trapped {
-                trap_code: HeapOutOfBounds,
-                backtrace: None,
-            });
-        }
-
-        self.stable_memory_buffer
-            .write(&heap[src..heap_end], offset);
-        Ok(())
-    }
-
-    /// Calculates the number of new dirty pages that a given write would
-    /// create.
-    ///
-    /// No guarantee is made that such a write would succeed though (e.g. it
-    /// could exceed the current stable memory size).
-    pub(super) fn dirty_pages_from_write(&self, offset: u64, size: u64) -> NumOsPages {
-        self.stable_memory_buffer
-            .dirty_pages_from_write(offset, size)
     }
 }

--- a/rs/system_api/tests/system_api.rs
+++ b/rs/system_api/tests/system_api.rs
@@ -1,7 +1,6 @@
 use ic_base_types::{NumBytes, NumSeconds, PrincipalIdBlobParseError};
 use ic_config::{
     embedders::{BestEffortResponsesFeature, Config as EmbeddersConfig, FeatureFlags},
-    flag_status::FlagStatus,
     subnet_config::SchedulerConfig,
 };
 use ic_cycles_account_manager::CyclesAccountManager;
@@ -39,12 +38,7 @@ use ic_types::{
 };
 use maplit::btreemap;
 use more_asserts::assert_le;
-use std::{
-    collections::BTreeSet,
-    convert::From,
-    panic::{catch_unwind, UnwindSafe},
-    rc::Rc,
-};
+use std::{collections::BTreeSet, convert::From, rc::Rc};
 use strum::IntoEnumIterator;
 
 mod common;
@@ -101,66 +95,6 @@ fn assert_api_availability<T, F>(
         assert_api_supported(res)
     } else {
         assert_api_not_supported(res)
-    }
-}
-
-/// This struct is used in the following tests to move a `&mut SystemApiImpl`
-/// into a closure executed in `catch_unwind` so that we can assert certain
-/// system APIs panic. `SystemApiImpl` may not actually be `UnwindSafe`, but all
-/// the panicking APIs should panic immediately without modifying or reading any
-/// mutable state of the `SystemApiImpl`. So it's fine to pretend it's
-/// `UnwindSafe` for the purposes of this test.
-struct ForcedUnwindSafe<T>(T);
-impl<T> ForcedUnwindSafe<T> {
-    fn inner(&mut self) -> &mut T {
-        &mut self.0
-    }
-}
-impl<T> UnwindSafe for ForcedUnwindSafe<T> {}
-
-fn assert_stable_apis_panic(mut api: SystemApiImpl) {
-    let mut unwind_api = ForcedUnwindSafe(&mut api);
-    catch_unwind(move || unwind_api.inner().ic0_stable_size())
-        .expect_err("Stable API should panic");
-    let mut unwind_api = ForcedUnwindSafe(&mut api);
-    catch_unwind(move || unwind_api.inner().ic0_stable_grow(1))
-        .expect_err("Stable API should panic");
-    let mut unwind_api = ForcedUnwindSafe(&mut api);
-    catch_unwind(move || unwind_api.inner().ic0_stable_read(0, 0, 0, &mut []))
-        .expect_err("Stable API should panic");
-    let mut unwind_api = ForcedUnwindSafe(&mut api);
-    catch_unwind(move || unwind_api.inner().ic0_stable_write(0, 0, 0, &[]))
-        .expect_err("Stable API should panic");
-    let mut unwind_api = ForcedUnwindSafe(&mut api);
-    catch_unwind(move || unwind_api.inner().ic0_stable64_size())
-        .expect_err("Stable API should panic");
-    let mut unwind_api = ForcedUnwindSafe(&mut api);
-    catch_unwind(move || unwind_api.inner().ic0_stable64_grow(1))
-        .expect_err("Stable API should panic");
-    let mut unwind_api = ForcedUnwindSafe(&mut api);
-    catch_unwind(move || unwind_api.inner().ic0_stable64_read(0, 0, 0, &mut []))
-        .expect_err("Stable API should panic");
-    let mut unwind_api = ForcedUnwindSafe(&mut api);
-    catch_unwind(move || unwind_api.inner().ic0_stable64_write(0, 0, 0, &[]))
-        .expect_err("Stable API should panic");
-}
-
-fn check_stable_apis_support(mut api: SystemApiImpl) {
-    match EmbeddersConfig::default()
-        .feature_flags
-        .wasm_native_stable_memory
-    {
-        FlagStatus::Enabled => assert_stable_apis_panic(api),
-        FlagStatus::Disabled => {
-            assert_api_supported(api.ic0_stable_size());
-            assert_api_supported(api.ic0_stable_grow(1));
-            assert_api_supported(api.ic0_stable_read(0, 0, 0, &mut []));
-            assert_api_supported(api.ic0_stable_write(0, 0, 0, &[]));
-            assert_api_supported(api.ic0_stable64_size());
-            assert_api_supported(api.ic0_stable64_grow(1));
-            assert_api_supported(api.ic0_stable64_read(0, 0, 0, &mut []));
-            assert_api_supported(api.ic0_stable64_write(0, 0, 0, &[]));
-        }
     }
 }
 
@@ -873,13 +807,9 @@ fn system_api_availability() {
             ("F", inspect_message_api()),
             ("T", system_task_api()),
         ] {
-            // check stable API availability
-            let system_state = get_system_state();
             let cycles_account_manager = CyclesAccountManagerBuilder::new()
                 .with_subnet_type(subnet_type)
                 .build();
-            let api = get_system_api(api_type.clone(), &system_state, cycles_account_manager);
-            check_stable_apis_support(api);
 
             // check ic0.mint_cycles, ic0.mint_cycles128 API availability for CMC
             let cmc_system_state = get_cmc_system_state();

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2148,14 +2148,6 @@ impl ExecutionTestBuilder {
         self
     }
 
-    pub fn with_non_native_stable(mut self) -> Self {
-        self.execution_config
-            .embedders_config
-            .feature_flags
-            .wasm_native_stable_memory = FlagStatus::Disabled;
-        self
-    }
-
     pub fn with_best_effort_responses(mut self, stage: BestEffortResponsesFeature) -> Self {
         self.execution_config
             .embedders_config


### PR DESCRIPTION
This PR removes the `wasm_native_stable_memory` flag as the feature has been implemented since a long time ago. This allows to clean up a lot of unused code and simplify some of the logic across embedders/execution environment/system api.