### PR TITLE
fix(nns): Track the spawning state in the TLA model

### DIFF
--- a/rs/nns/governance/src/governance/tla/mod.rs
+++ b/rs/nns/governance/src/governance/tla/mod.rs
@@ -64,6 +64,18 @@ fn neuron_global(gov: &Governance) -> TlaValue {
                                 "maturity".to_string(),
                                 neuron.maturity_e8s_equivalent.to_tla_value(),
                             ),
+                            (
+                                ("state".to_string()),
+                                TlaValue::Variant {
+                                    tag: (if neuron.spawn_at_timestamp_seconds.is_some() {
+                                        "Spawning"
+                                    } else {
+                                        "NotSpawning"
+                                    })
+                                    .to_string(),
+                                    value: Box::new(TlaValue::Constant("UNIT".to_string())),
+                                },
+                            ),
                         ])),
                     )
                 })

--- a/rs/nns/governance/tla/Claim_Neuron.tla
+++ b/rs/nns/governance/tla/Claim_Neuron.tla
@@ -1,5 +1,5 @@
 ------------ MODULE Claim_Neuron ------------
-EXTENDS TLC, Sequences, Naturals, FiniteSets, Variants
+EXTENDS TLC, Sequences, Naturals, FiniteSets, Variants, Common
 
 CONSTANT
     FRESH_NEURON_ID(_)
@@ -15,15 +15,6 @@ CONSTANTS
     MIN_STAKE,
     \* The transfer fee charged by the ledger canister
     TRANSACTION_FEE
-
-DUMMY_ACCOUNT == ""
-
-\* @type: (a -> b, Set(a)) => a -> b;
-Remove_Arguments(f, S) == [ x \in (DOMAIN f \ S) |-> f[x]]
-
-request(caller, request_args) == [caller |-> caller, method_and_args |-> request_args]
-account_balance(account) == Variant("AccountBalance", [account |-> account])
-
 
 (* --algorithm Governance_Ledger_Claim_Neuron {
 
@@ -70,7 +61,7 @@ process ( Claim_Neuron \in Claim_Neuron_Process_Ids )
             assert neuron_id \notin locks;
             locks := locks \union {neuron_id};
             neuron_id_by_account := account :> neuron_id @@ neuron_id_by_account;
-            neuron := neuron_id :> [ cached_stake |-> 0, account |-> account, fees |-> 0, maturity |-> 0 ] @@ neuron;
+            neuron := neuron_id :> [ cached_stake |-> 0, account |-> account, fees |-> 0, maturity |-> 0, state |-> NOT_SPAWNING ] @@ neuron;
             \* send_request(self, OP_QUERY_BALANCE, balance_query(account));
             governance_to_ledger := Append(governance_to_ledger, request(self, account_balance(account)));
         };
@@ -99,11 +90,11 @@ process ( Claim_Neuron \in Claim_Neuron_Process_Ids )
 
 }
 *)
-\* BEGIN TRANSLATION (chksum(pcal) = "a7e1f417" /\ chksum(tla) = "ded8c980")
-VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger, 
+\* BEGIN TRANSLATION (chksum(pcal) = "2a7b6103" /\ chksum(tla) = "43341ae9")
+VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
           ledger_to_governance, spawning_neurons, account, neuron_id
 
-vars == << pc, neuron, neuron_id_by_account, locks, governance_to_ledger, 
+vars == << pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
            ledger_to_governance, spawning_neurons, account, neuron_id >>
 
 ProcSet == (Claim_Neuron_Process_Ids)
@@ -126,11 +117,11 @@ ClaimNeuron1(self) == /\ pc[self] = "ClaimNeuron1"
                          \/ /\ \E aid \in Governance_Account_Ids \ DOMAIN(neuron_id_by_account):
                                  /\ account' = [account EXCEPT ![self] = aid]
                                  /\ neuron_id' = [neuron_id EXCEPT ![self] = FRESH_NEURON_ID(DOMAIN(neuron))]
-                                 /\ Assert(neuron_id'[self] \notin locks, 
-                                           "Failure of assertion at line 70, column 13.")
+                                 /\ Assert(neuron_id'[self] \notin locks,
+                                           "Failure of assertion at line 61, column 13.")
                                  /\ locks' = (locks \union {neuron_id'[self]})
                                  /\ neuron_id_by_account' = (account'[self] :> neuron_id'[self] @@ neuron_id_by_account)
-                                 /\ neuron' = (neuron_id'[self] :> [ cached_stake |-> 0, account |-> account'[self], fees |-> 0, maturity |-> 0 ] @@ neuron)
+                                 /\ neuron' = (neuron_id'[self] :> [ cached_stake |-> 0, account |-> account'[self], fees |-> 0, maturity |-> 0, state |-> NOT_SPAWNING ] @@ neuron)
                                  /\ governance_to_ledger' = Append(governance_to_ledger, request(self, account_balance(account'[self])))
                             /\ pc' = [pc EXCEPT ![self] = "WaitForBalanceQuery"]
                       /\ UNCHANGED << ledger_to_governance, spawning_neurons >>
@@ -151,7 +142,7 @@ WaitForBalanceQuery(self) == /\ pc[self] = "WaitForBalanceQuery"
                              /\ account' = [account EXCEPT ![self] = DUMMY_ACCOUNT]
                              /\ neuron_id' = [neuron_id EXCEPT ![self] = 0]
                              /\ pc' = [pc EXCEPT ![self] = "Done"]
-                             /\ UNCHANGED << governance_to_ledger, 
+                             /\ UNCHANGED << governance_to_ledger,
                                              spawning_neurons >>
 
 Claim_Neuron(self) == ClaimNeuron1(self) \/ WaitForBalanceQuery(self)

--- a/rs/nns/governance/tla/Common.tla
+++ b/rs/nns/governance/tla/Common.tla
@@ -1,0 +1,20 @@
+---- MODULE Common ----
+EXTENDS Variants
+
+NOT_SPAWNING == Variant("NotSpawning", UNIT)
+SPAWNING == Variant("Spawning", UNIT)
+
+\* Initial value used for uninitialized accounts
+DUMMY_ACCOUNT == ""
+
+\* @type: (a -> b, Set(a)) => a -> b;
+Remove_Arguments(f, S) == [ x \in (DOMAIN f \ S) |-> f[x]]
+
+request(caller, request_args) == [caller |-> caller, method_and_args |-> request_args]
+account_balance(account) == Variant("AccountBalance", [account |-> account])
+transfer(from, to, amount, fee) == Variant("Transfer", [from |-> from, to |-> to, amount |-> amount, fee |-> fee])
+
+TRANSFER_OK == "Ok"
+TRANSFER_FAIL == "Err"
+
+====

--- a/rs/nns/governance/tla/Common_Apalache.tla
+++ b/rs/nns/governance/tla/Common_Apalache.tla
@@ -7,7 +7,8 @@ EXTENDS TLC
 @typeAlias: neuronId = Int;
 @typeAlias: methodCall = Transfer({ from: $account, to: $account, amount: Int, fee: Int}) | AccountBalance({ account: $account });
 @typeAlias: methodResponse = Fail(UNIT) | TransferOk(UNIT) | BalanceQueryOk(Int);
-@typeAlias: neurons = $neuronId -> {cached_stake: Int, account: $account, maturity: Int, fees: Int};
+@typeAlias: neuronState = NotSpawning(UNIT) | Spawning(UNIT);
+@typeAlias: neurons = $neuronId -> {cached_stake: Int, account: $account, maturity: Int, fees: Int, state: $neuronState};
 *)
 _type_alias_dummy == TRUE
 

--- a/rs/nns/governance/tla/Disburse_To_Neuron.tla
+++ b/rs/nns/governance/tla/Disburse_To_Neuron.tla
@@ -1,6 +1,6 @@
 ---- MODULE Disburse_To_Neuron ----
 
-EXTENDS TLC, Integers, FiniteSets, Sequences, Variants
+EXTENDS TLC, Integers, FiniteSets, Sequences, Variants, Common
 
 CONSTANTS
     Governance_Account_Ids
@@ -16,16 +16,6 @@ CONSTANTS
 
 CONSTANT
     FRESH_NEURON_ID(_)
-
-\* Initial value used for uninitialized accounts
-DUMMY_ACCOUNT == ""
-
-\* @type: (a -> b, Set(a)) => a -> b;
-Remove_Arguments(f, S) == [ x \in (DOMAIN f \ S) |-> f[x]]
-Max(x, y) == IF x < y THEN y ELSE x
-
-request(caller, request_args) == [caller |-> caller, method_and_args |-> request_args]
-transfer(from, to, amount, fee) == Variant("Transfer", [from |-> from, to |-> to, amount |-> amount, fee |-> fee])
 
 (* --algorithm Governance_Ledger_Disburse_To_Neuron {
 
@@ -74,7 +64,7 @@ process (Disburse_To_Neuron \in Disburse_To_Neuron_Process_Ids)
                 child_account_id := c_acc_id;
                 child_neuron_id := FRESH_NEURON_ID(DOMAIN(neuron));
                 neuron_id_by_account := child_account_id :> child_neuron_id @@ neuron_id_by_account;
-                neuron := child_neuron_id :> [ cached_stake |-> 0, account |-> child_account_id, fees |-> 0, maturity |-> 0 ] @@ neuron;
+                neuron := child_neuron_id :> [ cached_stake |-> 0, account |-> child_account_id, fees |-> 0, maturity |-> 0, state |-> NOT_SPAWNING ] @@ neuron;
                 \* The Rust code throws an error here if the parent neuron is locked. Instead, we prevent the Disburse_To_Neuron process from running.
                 \* This is OK since the Rust code doesn't change the canister's state before obtaining the parant lock (if it
                 \* did, the model wouldn't capture this state and we could miss behaviors).
@@ -106,13 +96,13 @@ process (Disburse_To_Neuron \in Disburse_To_Neuron_Process_Ids)
     }
 }
 *)
-\* BEGIN TRANSLATION (chksum(pcal) = "d03e80ed" /\ chksum(tla) = "60c4854a")
-VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger, 
-          ledger_to_governance, spawning_neurons, parent_neuron_id, 
+\* BEGIN TRANSLATION (chksum(pcal) = "ea49c10b" /\ chksum(tla) = "815c4175")
+VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
+          ledger_to_governance, spawning_neurons, parent_neuron_id,
           disburse_amount, child_account_id, child_neuron_id
 
-vars == << pc, neuron, neuron_id_by_account, locks, governance_to_ledger, 
-           ledger_to_governance, spawning_neurons, parent_neuron_id, 
+vars == << pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
+           ledger_to_governance, spawning_neurons, parent_neuron_id,
            disburse_amount, child_account_id, child_neuron_id >>
 
 ProcSet == (Disburse_To_Neuron_Process_Ids)
@@ -144,13 +134,13 @@ DisburseToNeuron(self) == /\ pc[self] = "DisburseToNeuron"
                                            /\ child_account_id' = [child_account_id EXCEPT ![self] = c_acc_id]
                                            /\ child_neuron_id' = [child_neuron_id EXCEPT ![self] = FRESH_NEURON_ID(DOMAIN(neuron))]
                                            /\ neuron_id_by_account' = (child_account_id'[self] :> child_neuron_id'[self] @@ neuron_id_by_account)
-                                           /\ neuron' = (child_neuron_id'[self] :> [ cached_stake |-> 0, account |-> child_account_id'[self], fees |-> 0, maturity |-> 0 ] @@ neuron)
-                                           /\ Assert(child_neuron_id'[self] \notin locks, 
-                                                     "Failure of assertion at line 81, column 17.")
+                                           /\ neuron' = (child_neuron_id'[self] :> [ cached_stake |-> 0, account |-> child_account_id'[self], fees |-> 0, maturity |-> 0, state |-> NOT_SPAWNING ] @@ neuron)
+                                           /\ Assert(child_neuron_id'[self] \notin locks,
+                                                     "Failure of assertion at line 71, column 17.")
                                            /\ locks' = (locks \union {parent_neuron_id'[self], child_neuron_id'[self]})
                                            /\ governance_to_ledger' = Append(governance_to_ledger, request(self, (transfer(parent_neuron.account, child_account_id'[self], disburse_amount'[self] - TRANSACTION_FEE, TRANSACTION_FEE))))
                                 /\ pc' = [pc EXCEPT ![self] = "DisburseToNeuron_WaitForTransfer"]
-                          /\ UNCHANGED << ledger_to_governance, 
+                          /\ UNCHANGED << ledger_to_governance,
                                           spawning_neurons >>
 
 DisburseToNeuron_WaitForTransfer(self) == /\ pc[self] = "DisburseToNeuron_WaitForTransfer"
@@ -168,7 +158,7 @@ DisburseToNeuron_WaitForTransfer(self) == /\ pc[self] = "DisburseToNeuron_WaitFo
                                                /\ child_account_id' = [child_account_id EXCEPT ![self] = DUMMY_ACCOUNT]
                                                /\ child_neuron_id' = [child_neuron_id EXCEPT ![self] = 0]
                                           /\ pc' = [pc EXCEPT ![self] = "Done"]
-                                          /\ UNCHANGED << governance_to_ledger, 
+                                          /\ UNCHANGED << governance_to_ledger,
                                                           spawning_neurons >>
 
 Disburse_To_Neuron(self) == DisburseToNeuron(self)

--- a/rs/nns/governance/tla/Refresh_Neuron.tla
+++ b/rs/nns/governance/tla/Refresh_Neuron.tla
@@ -1,5 +1,5 @@
 ------------ MODULE Refresh_Neuron ------------
-EXTENDS TLC, Sequences, Naturals, FiniteSets, Variants
+EXTENDS TLC, Sequences, Naturals, FiniteSets, Variants, Common
 
 CONSTANTS
     Governance_Account_Ids
@@ -12,15 +12,6 @@ CONSTANTS
     MIN_STAKE,
     \* The transfer fee charged by the ledger canister
     TRANSACTION_FEE
-
-DUMMY_ACCOUNT == ""
-
-\* @type: (a -> b, Set(a)) => a -> b;
-Remove_Arguments(f, S) == [ x \in (DOMAIN f \ S) |-> f[x]]
-
-request(caller, request_args) == [caller |-> caller, method_and_args |-> request_args]
-account_balance(account) == Variant("AccountBalance", [account |-> account])
-
 
 (* --algorithm Governance_Ledger_Refresh_Neuron {
 
@@ -85,10 +76,10 @@ process ( Refresh_Neuron \in Refresh_Neuron_Process_Ids )
 }
 *)
 \* BEGIN TRANSLATION (chksum(pcal) = "e3951dde" /\ chksum(tla) = "d922bb3e")
-VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger, 
+VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
           ledger_to_governance, spawning_neurons, neuron_id
 
-vars == << pc, neuron, neuron_id_by_account, locks, governance_to_ledger, 
+vars == << pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
            ledger_to_governance, spawning_neurons, neuron_id >>
 
 ProcSet == (Refresh_Neuron_Process_Ids)
@@ -112,7 +103,7 @@ RefreshNeuron1(self) == /\ pc[self] = "RefreshNeuron1"
                                    /\ locks' = (locks \union {neuron_id'[self]})
                                    /\ governance_to_ledger' = Append(governance_to_ledger, request(self, account_balance(neuron[nid].account)))
                               /\ pc' = [pc EXCEPT ![self] = "WaitForBalanceQuery"]
-                        /\ UNCHANGED << neuron, neuron_id_by_account, 
+                        /\ UNCHANGED << neuron, neuron_id_by_account,
                                         ledger_to_governance, spawning_neurons >>
 
 WaitForBalanceQuery(self) == /\ pc[self] = "WaitForBalanceQuery"
@@ -129,8 +120,8 @@ WaitForBalanceQuery(self) == /\ pc[self] = "WaitForBalanceQuery"
                                   /\ locks' = locks \ {neuron_id[self]}
                              /\ neuron_id' = [neuron_id EXCEPT ![self] = 0]
                              /\ pc' = [pc EXCEPT ![self] = "Done"]
-                             /\ UNCHANGED << neuron_id_by_account, 
-                                             governance_to_ledger, 
+                             /\ UNCHANGED << neuron_id_by_account,
+                                             governance_to_ledger,
                                              spawning_neurons >>
 
 Refresh_Neuron(self) == RefreshNeuron1(self) \/ WaitForBalanceQuery(self)

--- a/rs/nns/governance/tla/Spawn_Neuron.tla
+++ b/rs/nns/governance/tla/Spawn_Neuron.tla
@@ -1,5 +1,5 @@
 ---- MODULE Spawn_Neuron ----
-EXTENDS TLC, Sequences, Naturals, FiniteSets, Variants
+EXTENDS TLC, Sequences, Naturals, FiniteSets, Variants, Common
 
 CONSTANTS
     \* @type: Set($proc);
@@ -56,16 +56,14 @@ process (Spawn_Neuron \in Spawn_Neuron_Process_Ids)
                     maturity_to_spawn \in MIN_STAKE..neuron[parent_neuron_id].maturity;
                     child_neuron_id = FRESH_NEURON_ID(DOMAIN(neuron));
                 ) {
-                    \* In the absence of an explicit spawning state in the model, this serves as a poor man's check 
-                    \* that the parent isn't already spawning
-                    await(neuron[parent_neuron_id].cached_stake > 0);
+                    await(neuron[parent_neuron_id].state # SPAWNING);
 
                     \* The code takes a lock on the child neuron, but releases it in the same message handler,
                     \* effectively only checking that the lock isn't already taken.
                     await child_neuron_id \notin locks;
 
                     neuron_id_by_account := child_account_id :> child_neuron_id @@ neuron_id_by_account;
-                    neuron := child_neuron_id :> [ cached_stake |-> 0, account |-> child_account_id, fees |-> 0, maturity |-> maturity_to_spawn ]
+                    neuron := child_neuron_id :> [ cached_stake |-> 0, account |-> child_account_id, fees |-> 0, maturity |-> maturity_to_spawn, state |-> SPAWNING ]
                            @@ [ neuron EXCEPT ![parent_neuron_id].maturity = @ - maturity_to_spawn ];
                 };
             };
@@ -73,11 +71,11 @@ process (Spawn_Neuron \in Spawn_Neuron_Process_Ids)
     }
 
 } *)
-\* BEGIN TRANSLATION (chksum(pcal) = "17ce984d" /\ chksum(tla) = "60040455")
-VARIABLES neuron, neuron_id_by_account, locks, governance_to_ledger, 
+\* BEGIN TRANSLATION (chksum(pcal) = "d832f660" /\ chksum(tla) = "2b59e34a")
+VARIABLES neuron, neuron_id_by_account, locks, governance_to_ledger,
           ledger_to_governance, spawning_neurons
 
-vars == << neuron, neuron_id_by_account, locks, governance_to_ledger, 
+vars == << neuron, neuron_id_by_account, locks, governance_to_ledger,
            ledger_to_governance, spawning_neurons >>
 
 ProcSet == (Spawn_Neuron_Process_Ids)
@@ -96,12 +94,12 @@ Spawn_Neuron(self) == /\ \/ /\ TRUE
                                  \E child_account_id \in Governance_Account_Ids \ DOMAIN neuron_id_by_account:
                                    \E maturity_to_spawn \in MIN_STAKE..neuron[parent_neuron_id].maturity:
                                      LET child_neuron_id == FRESH_NEURON_ID(DOMAIN(neuron)) IN
-                                       /\ (neuron[parent_neuron_id].cached_stake > 0)
+                                       /\ (neuron[parent_neuron_id].state # SPAWNING)
                                        /\ child_neuron_id \notin locks
                                        /\ neuron_id_by_account' = (child_account_id :> child_neuron_id @@ neuron_id_by_account)
-                                       /\ neuron' = (   child_neuron_id :> [ cached_stake |-> 0, account |-> child_account_id, fees |-> 0, maturity |-> maturity_to_spawn ]
+                                       /\ neuron' = (   child_neuron_id :> [ cached_stake |-> 0, account |-> child_account_id, fees |-> 0, maturity |-> maturity_to_spawn, state |-> SPAWNING ]
                                                      @@ [ neuron EXCEPT ![parent_neuron_id].maturity = @ - maturity_to_spawn ])
-                      /\ UNCHANGED << locks, governance_to_ledger, 
+                      /\ UNCHANGED << locks, governance_to_ledger,
                                       ledger_to_governance, spawning_neurons >>
 
 Next == (\E self \in Spawn_Neuron_Process_Ids: Spawn_Neuron(self))

--- a/rs/nns/governance/tla/Split_Neuron.tla
+++ b/rs/nns/governance/tla/Split_Neuron.tla
@@ -1,5 +1,5 @@
 ------------ MODULE Split_Neuron ------------
-EXTENDS TLC, Sequences, Naturals, FiniteSets, Variants, FiniteSetsExt
+EXTENDS TLC, Sequences, Naturals, FiniteSets, Variants, FiniteSetsExt, Common
 
 CONSTANT
     FRESH_NEURON_ID(_)
@@ -16,17 +16,6 @@ CONSTANTS
     MIN_STAKE,
     \* The transfer fee charged by the ledger canister
     TRANSACTION_FEE
-
-OP_TRANSFER == "transfer"
-TRANSFER_OK == "Ok"
-TRANSFER_FAIL == "Err"
-DUMMY_ACCOUNT == ""
-
-\* @type: (a -> b, Set(a)) => a -> b;
-Remove_Arguments(f, S) == [ x \in (DOMAIN f \ S) |-> f[x]]
-
-request(caller, request_args) == [caller |-> caller, method_and_args |-> request_args]
-transfer(from, to, amount, fee) == Variant("Transfer", [from |-> from, to |-> to, amount |-> amount, fee |-> fee])
 
 (* --algorithm Governance_Ledger_Split_Neuron {
 
@@ -85,7 +74,7 @@ process ( Split_Neuron \in Split_Neuron_Process_Ids )
             \* as the locks are taken sequentially there; here, we're sure that these neuron IDs differ,
             \* so we omit the extra check.
             locks := locks \union {sn_parent_neuron_id, sn_child_neuron_id};
-            neuron := sn_child_neuron_id :> [ cached_stake |-> 0, account |-> sn_child_account_id, fees |-> 0, maturity |-> 0 ] @@
+            neuron := sn_child_neuron_id :> [ cached_stake |-> 0, account |-> sn_child_account_id, fees |-> 0, maturity |-> 0, state |-> NOT_SPAWNING ] @@
                 [neuron EXCEPT ![sn_parent_neuron_id] = [@ EXCEPT !.cached_stake = @ - sn_amount ] ];
             neuron_id_by_account := sn_child_account_id :> sn_child_neuron_id @@ neuron_id_by_account;
 
@@ -117,13 +106,13 @@ process ( Split_Neuron \in Split_Neuron_Process_Ids )
 
 }
 *)
-\* BEGIN TRANSLATION (chksum(pcal) = "8975482d" /\ chksum(tla) = "846a9ad0")
-VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger, 
-          ledger_to_governance, spawning_neurons, sn_parent_neuron_id, 
+\* BEGIN TRANSLATION (chksum(pcal) = "3e616a65" /\ chksum(tla) = "b4c96114")
+VARIABLES pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
+          ledger_to_governance, spawning_neurons, sn_parent_neuron_id,
           sn_amount, sn_child_neuron_id, sn_child_account_id
 
-vars == << pc, neuron, neuron_id_by_account, locks, governance_to_ledger, 
-           ledger_to_governance, spawning_neurons, sn_parent_neuron_id, 
+vars == << pc, neuron, neuron_id_by_account, locks, governance_to_ledger,
+           ledger_to_governance, spawning_neurons, sn_parent_neuron_id,
            sn_amount, sn_child_neuron_id, sn_child_account_id >>
 
 ProcSet == (Split_Neuron_Process_Ids)
@@ -152,11 +141,11 @@ SplitNeuron1(self) == /\ pc[self] = "SplitNeuron1"
                                      /\ sn_amount' = [sn_amount EXCEPT ![self] = amt]
                                      /\ sn_child_account_id' = [sn_child_account_id EXCEPT ![self] = fresh_account_id]
                                      /\ sn_child_neuron_id' = [sn_child_neuron_id EXCEPT ![self] = FRESH_NEURON_ID(DOMAIN(neuron))]
-                                     /\ Assert(sn_child_neuron_id'[self] \notin locks, 
-                                               "Failure of assertion at line 80, column 13.")
+                                     /\ Assert(sn_child_neuron_id'[self] \notin locks,
+                                               "Failure of assertion at line 69, column 13.")
                                      /\ (sn_amount'[self] >= MIN_STAKE + TRANSACTION_FEE /\ neuron[sn_parent_neuron_id'[self]].cached_stake - neuron[sn_parent_neuron_id'[self]].fees >= MIN_STAKE + sn_amount'[self])
                                      /\ locks' = (locks \union {sn_parent_neuron_id'[self], sn_child_neuron_id'[self]})
-                                     /\ neuron' = (      sn_child_neuron_id'[self] :> [ cached_stake |-> 0, account |-> sn_child_account_id'[self], fees |-> 0, maturity |-> 0 ] @@
+                                     /\ neuron' = (      sn_child_neuron_id'[self] :> [ cached_stake |-> 0, account |-> sn_child_account_id'[self], fees |-> 0, maturity |-> 0, state |-> NOT_SPAWNING ] @@
                                                    [neuron EXCEPT ![sn_parent_neuron_id'[self]] = [@ EXCEPT !.cached_stake = @ - sn_amount'[self] ] ])
                                      /\ neuron_id_by_account' = (sn_child_account_id'[self] :> sn_child_neuron_id'[self] @@ neuron_id_by_account)
                                      /\ governance_to_ledger' =                     Append(governance_to_ledger,
@@ -182,7 +171,7 @@ SplitNeuron1_WaitForTransfer(self) == /\ pc[self] = "SplitNeuron1_WaitForTransfe
                                       /\ sn_child_neuron_id' = [sn_child_neuron_id EXCEPT ![self] = 0]
                                       /\ sn_child_account_id' = [sn_child_account_id EXCEPT ![self] = DUMMY_ACCOUNT]
                                       /\ pc' = [pc EXCEPT ![self] = "Done"]
-                                      /\ UNCHANGED << governance_to_ledger, 
+                                      /\ UNCHANGED << governance_to_ledger,
                                                       spawning_neurons >>
 
 Split_Neuron(self) == SplitNeuron1(self)

--- a/rs/nns/governance/tla/Split_Neuron_Apalache.tla
+++ b/rs/nns/governance/tla/Split_Neuron_Apalache.tla
@@ -9,16 +9,7 @@ Apalache requires us to do this in a separate module.
 
 ---- MODULE Split_Neuron_Apalache ----
 
-EXTENDS TLC, Variants
-
-(*
-@typeAlias: proc = Str;
-@typeAlias: account = Str;
-@typeAlias: neuronId = Int;
-@typeAlias: methodCall = Transfer({ from: $account, to: $account, amount: Int, fee: Int}) | AccountBalance({ account_id: $account });
-@typeAlias: methodResponse = Fail(UNIT) | TransferOk(UNIT) | BalanceQueryOk(Int);
-*)
-_type_alias_dummy == TRUE
+EXTENDS TLC, Variants, Common_Apalache
 
 \* This marker is necessary for the code link tooling to insert the constants
 \* CODE_LINK_INSERT_CONSTANTS


### PR DESCRIPTION
This makes the TLA model track the spawning state of neurons. Previously, the model interpreted "has maturity but no stake" as equal to spawning. This was done as to avoid storing more state and thus potentially improve the scalability of model checking, but this is not a correct invariant, and it led to the model finding an issue where the cached stake would be reset when merging neurons while spawning, but this was a false positive. The model can still be checked successfully with this addition (i.e., it doesn't really blow up the model checking time).

I also took the opportunity to clean up the models by factoring some common bits out.