### PR TITLE
refactor: Use generics and `impl trait` instead of `dyn trait`

### DIFF
--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -25,8 +25,7 @@ use ic_base_types::PrincipalId;
 use ic_config::{execution_environment::Config, subnet_config::SchedulerConfig};
 use ic_cycles_account_manager::CyclesAccountManager;
 use ic_interfaces::execution_environment::{
-    IngressFilterService, IngressHistoryReader, IngressHistoryWriter, QueryExecutionService,
-    Scheduler,
+    IngressFilterService, IngressHistoryReader, QueryExecutionService, Scheduler,
 };
 use ic_interfaces_state_manager::StateReader;
 use ic_logger::ReplicaLogger;
@@ -81,7 +80,7 @@ pub enum NonReplicatedQueryKind {
 // This struct holds public facing components that are created by Execution.
 pub struct ExecutionServices {
     pub ingress_filter: IngressFilterService,
-    pub ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState>>,
+    pub ingress_history_writer: Arc<IngressHistoryWriterImpl>,
     pub ingress_history_reader: Box<dyn IngressHistoryReader>,
     pub query_execution_service: QueryExecutionService,
     pub https_outcalls_service: QueryExecutionService,
@@ -215,24 +214,5 @@ impl ExecutionServices {
             scheduler,
             query_stats_payload_builder,
         }
-    }
-
-    #[allow(clippy::type_complexity)]
-    pub fn into_parts(
-        self,
-    ) -> (
-        IngressFilterService,
-        Arc<dyn IngressHistoryWriter<State = ReplicatedState>>,
-        Box<dyn IngressHistoryReader>,
-        QueryExecutionService,
-        Box<dyn Scheduler<State = ReplicatedState>>,
-    ) {
-        (
-            self.ingress_filter,
-            self.ingress_history_writer,
-            self.ingress_history_reader,
-            self.query_execution_service,
-            self.scheduler,
-        )
     }
 }

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -215,4 +215,23 @@ impl ExecutionServices {
             query_stats_payload_builder,
         }
     }
+
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        IngressFilterService,
+        Arc<IngressHistoryWriterImpl>,
+        Box<dyn IngressHistoryReader>,
+        QueryExecutionService,
+        Box<dyn Scheduler<State = ReplicatedState>>,
+    ) {
+        (
+            self.ingress_filter,
+            self.ingress_history_writer,
+            self.ingress_history_reader,
+            self.query_execution_service,
+            self.scheduler,
+        )
+    }
 }

--- a/rs/http_endpoints/xnet/src/lib.rs
+++ b/rs/http_endpoints/xnet/src/lib.rs
@@ -121,13 +121,26 @@ const API_URL_STREAMS: &str = "/api/v1/streams";
 const API_URL_STREAM_PREFIX: &str = "/api/v1/stream/";
 
 /// Struct passed to each request handled by `enqueue_task`.
-#[derive(Clone)]
-struct Context {
+struct Context<CertifiedStreamStore_: CertifiedStreamStore + 'static> {
     log: ReplicaLogger,
     semaphore: Arc<Semaphore>,
     metrics: Arc<XNetEndpointMetrics>,
-    certified_stream_store: Arc<dyn CertifiedStreamStore>,
+    certified_stream_store: Arc<CertifiedStreamStore_>,
     base_url: Url,
+}
+
+impl<CertifiedStreamStore_: CertifiedStreamStore + 'static> Clone
+    for Context<CertifiedStreamStore_>
+{
+    fn clone(&self) -> Self {
+        Self {
+            log: self.log.clone(),
+            semaphore: Arc::clone(&self.semaphore),
+            metrics: Arc::clone(&self.metrics),
+            certified_stream_store: Arc::clone(&self.certified_stream_store),
+            base_url: self.base_url.clone(),
+        }
+    }
 }
 
 fn ok<T>(t: T) -> Result<T, Infallible> {
@@ -137,7 +150,7 @@ fn ok<T>(t: T) -> Result<T, Infallible> {
 /// Handles an incoming HTTP request by taking a permit from the semaphore, parsing the URL,
 /// handing over to `route_request()` and replying with the produced response.
 async fn handle_xnet_request(
-    State(ctx): State<Context>,
+    State(ctx): State<Context<impl CertifiedStreamStore>>,
     request: Request<Body>,
 ) -> impl IntoResponse {
     let owned_permit = match ctx.semaphore.try_acquire_owned() {
@@ -183,10 +196,10 @@ async fn handle_xnet_request(
 fn start_server(
     address: SocketAddr,
     metrics: Arc<XNetEndpointMetrics>,
-    certified_stream_store: Arc<dyn CertifiedStreamStore>,
+    certified_stream_store: Arc<impl CertifiedStreamStore + 'static>,
     runtime_handle: runtime::Handle,
-    tls: Arc<dyn TlsConfig + Send + Sync>,
-    registry_client: Arc<dyn RegistryClient + Send + Sync>,
+    tls: Arc<impl TlsConfig + Send + Sync + 'static>,
+    registry_client: Arc<impl RegistryClient + 'static>,
     log: ReplicaLogger,
     shutdown_notify: Arc<Notify>,
 ) -> SocketAddr {
@@ -294,9 +307,9 @@ impl XNetEndpoint {
     /// Creates and starts an `XNetEndpoint` to publish XNet `Streams`.
     pub fn new(
         runtime_handle: runtime::Handle,
-        certified_stream_store: Arc<dyn CertifiedStreamStore>,
-        tls: Arc<dyn TlsConfig + Send + Sync>,
-        registry_client: Arc<dyn RegistryClient + Send + Sync>,
+        certified_stream_store: Arc<impl CertifiedStreamStore + 'static>,
+        tls: Arc<impl TlsConfig + Send + Sync + 'static>,
+        registry_client: Arc<impl RegistryClient + 'static>,
         config: Config,
         metrics: &MetricsRegistry,
         log: ReplicaLogger,
@@ -344,7 +357,7 @@ impl XNetEndpoint {
 /// HTTP 404 Not Found response if the URL doesn't match any handler.
 fn route_request(
     url: Url,
-    certified_stream_store: &dyn CertifiedStreamStore,
+    certified_stream_store: &impl CertifiedStreamStore,
     metrics: &XNetEndpointMetrics,
 ) -> Response<Body> {
     let since = Instant::now();
@@ -414,7 +427,7 @@ fn route_request(
 
 /// Returns a list of all subnets with available streams.
 fn handle_streams(
-    certified_stream_store: &dyn CertifiedStreamStore,
+    certified_stream_store: &impl CertifiedStreamStore,
     metrics: &XNetEndpointMetrics,
 ) -> Response<Body> {
     let subnets: Vec<_> = certified_stream_store
@@ -433,7 +446,7 @@ fn handle_stream(
     msg_begin: Option<StreamIndex>,
     msg_limit: Option<usize>,
     byte_limit: Option<usize>,
-    certified_stream_store: &dyn CertifiedStreamStore,
+    certified_stream_store: &impl CertifiedStreamStore,
     metrics: &XNetEndpointMetrics,
 ) -> Response<Body> {
     let witness_begin = witness_begin.or(msg_begin);

--- a/rs/http_endpoints/xnet/src/tests.rs
+++ b/rs/http_endpoints/xnet/src/tests.rs
@@ -32,7 +32,7 @@ pub(crate) struct EndpointTestFixture {
     pub state_manager: Arc<FakeStateManager>,
     pub registry_client: Arc<MockRegistryClient>,
     pub metrics: MetricsRegistry,
-    pub tls_handshake: Arc<dyn TlsConfig + Send + Sync>,
+    pub tls_handshake: Arc<MockTlsConfig>,
 }
 
 impl EndpointTestFixture {

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -555,10 +555,13 @@ trait BatchProcessor: Send {
 }
 
 /// Implementation of [`BatchProcessor`].
-struct BatchProcessorImpl {
+struct BatchProcessorImpl<RegistryClient_>
+where
+    RegistryClient_: RegistryClient,
+{
     state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
     state_machine: Box<dyn StateMachine>,
-    registry: Arc<dyn RegistryClient>,
+    registry: Arc<RegistryClient_>,
     bitcoin_config: BitcoinConfig,
     metrics: MessageRoutingMetrics,
     log: ReplicaLogger,
@@ -616,12 +619,12 @@ pub(crate) type NodePublicKeys = BTreeMap<NodeId, Vec<u8>>;
 /// A mapping from node IDs to ApiBoundaryNodeEntry.
 pub(crate) type ApiBoundaryNodes = BTreeMap<NodeId, ApiBoundaryNodeEntry>;
 
-impl BatchProcessorImpl {
+impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
     #[allow(clippy::too_many_arguments)]
     fn new(
         state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
         certified_stream_store: Arc<dyn CertifiedStreamStore>,
-        ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState> + 'static>,
+        ingress_history_writer: Arc<impl IngressHistoryWriter<State = ReplicatedState> + 'static>,
         scheduler: Box<dyn Scheduler<State = ReplicatedState>>,
         hypervisor_config: HypervisorConfig,
         cycles_account_manager: Arc<CyclesAccountManager>,
@@ -631,9 +634,9 @@ impl BatchProcessorImpl {
         metrics: MessageRoutingMetrics,
         metrics_registry: &MetricsRegistry,
         log: ReplicaLogger,
-        registry: Arc<dyn RegistryClient>,
+        registry: Arc<RegistryClient_>,
         malicious_flags: MaliciousFlags,
-    ) -> BatchProcessorImpl {
+    ) -> Self {
         let time_in_stream_metrics = Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(
             metrics_registry,
         )));
@@ -1209,7 +1212,7 @@ impl BatchProcessorImpl {
     }
 }
 
-impl BatchProcessor for BatchProcessorImpl {
+impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<RegistryClient_> {
     #[instrument(skip_all)]
     fn process_batch(&self, batch: Batch) {
         let _process_batch_start = Instant::now();
@@ -1478,14 +1481,14 @@ impl MessageRoutingImpl {
     pub fn new(
         state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
         certified_stream_store: Arc<dyn CertifiedStreamStore>,
-        ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState> + 'static>,
+        ingress_history_writer: Arc<impl IngressHistoryWriter<State = ReplicatedState> + 'static>,
         scheduler: Box<dyn Scheduler<State = ReplicatedState>>,
         hypervisor_config: HypervisorConfig,
         cycles_account_manager: Arc<CyclesAccountManager>,
         subnet_id: SubnetId,
         metrics_registry: &MetricsRegistry,
         log: ReplicaLogger,
-        registry: Arc<dyn RegistryClient>,
+        registry: Arc<impl RegistryClient + 'static>,
         malicious_flags: MaliciousFlags,
     ) -> Self {
         let metrics = MessageRoutingMetrics::new(metrics_registry);
@@ -1623,7 +1626,7 @@ impl SyncMessageRouting {
     pub fn new(
         state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
         certified_stream_store: Arc<dyn CertifiedStreamStore>,
-        ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState> + 'static>,
+        ingress_history_writer: Arc<impl IngressHistoryWriter<State = ReplicatedState> + 'static>,
         scheduler: Box<dyn Scheduler<State = ReplicatedState>>,
         hypervisor_config: HypervisorConfig,
         cycles_account_manager: Arc<CyclesAccountManager>,
@@ -1632,7 +1635,7 @@ impl SyncMessageRouting {
         target_stream_size_bytes: usize,
         metrics_registry: &MetricsRegistry,
         log: ReplicaLogger,
-        registry: Arc<dyn RegistryClient>,
+        registry: Arc<impl RegistryClient + 'static>,
         malicious_flags: MaliciousFlags,
     ) -> Self {
         let metrics = MessageRoutingMetrics::new(metrics_registry);

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -652,11 +652,11 @@ impl StateMachine for FakeStateMachine {
 /// Generates an instance of `BatchProcessorImpl` along with an `Arc` to its metrics;
 /// an `Arc` to the underlying state manager; and an `Arc` to the registry settings
 /// which are stored by the fake state machine.
-fn make_batch_processor(
-    registry: Arc<impl RegistryClient + 'static>,
+fn make_batch_processor<RegistryClient_: RegistryClient + 'static>(
+    registry: Arc<RegistryClient_>,
     log: ReplicaLogger,
 ) -> (
-    BatchProcessorImpl,
+    BatchProcessorImpl<RegistryClient_>,
     MessageRoutingMetrics,
     Arc<FakeStateManager>,
     Arc<Mutex<RegistryExecutionSettings>>,

--- a/rs/messaging/src/scheduling/valid_set_rule.rs
+++ b/rs/messaging/src/scheduling/valid_set_rule.rs
@@ -107,8 +107,10 @@ pub(crate) trait ValidSetRule: Send {
     fn induct_messages(&self, state: &mut ReplicatedState, msgs: Vec<SignedIngressContent>);
 }
 
-pub(crate) struct ValidSetRuleImpl {
-    ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState>>,
+pub(crate) struct ValidSetRuleImpl<
+    IngressHistoryWriter_: IngressHistoryWriter<State = ReplicatedState>,
+> {
+    ingress_history_writer: Arc<IngressHistoryWriter_>,
     ingress_history_max_messages: usize,
     cycles_account_manager: Arc<CyclesAccountManager>,
     own_subnet_id: SubnetId,
@@ -116,9 +118,11 @@ pub(crate) struct ValidSetRuleImpl {
     log: ReplicaLogger,
 }
 
-impl ValidSetRuleImpl {
+impl<IngressHistoryWriter_: IngressHistoryWriter<State = ReplicatedState>>
+    ValidSetRuleImpl<IngressHistoryWriter_>
+{
     pub(crate) fn new(
-        ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState>>,
+        ingress_history_writer: Arc<IngressHistoryWriter_>,
         cycles_account_manager: Arc<CyclesAccountManager>,
         metrics_registry: &MetricsRegistry,
         own_subnet_id: SubnetId,
@@ -327,7 +331,9 @@ impl ValidSetRuleImpl {
     }
 }
 
-impl ValidSetRule for ValidSetRuleImpl {
+impl<IngressHistoryWriter_: IngressHistoryWriter<State = ReplicatedState>> ValidSetRule
+    for ValidSetRuleImpl<IngressHistoryWriter_>
+{
     fn induct_messages(&self, state: &mut ReplicatedState, msgs: Vec<SignedIngressContent>) {
         let subnet_size = state
             .metadata

--- a/rs/replica/src/setup_ic_stack.rs
+++ b/rs/replica/src/setup_ic_stack.rs
@@ -15,7 +15,6 @@ use ic_interfaces::{
     execution_environment::QueryExecutionService, p2p::artifact_manager::JoinGuard,
     time_source::SysTimeSource,
 };
-use ic_interfaces_certified_stream_store::CertifiedStreamStore;
 use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::StateReader;
 use ic_logger::{info, ReplicaLogger};
@@ -67,7 +66,7 @@ pub fn construct_ic_stack(
     config: Config,
     node_id: NodeId,
     subnet_id: SubnetId,
-    registry: Arc<dyn RegistryClient + Send + Sync>,
+    registry: Arc<impl RegistryClient + 'static>,
     crypto: Arc<CryptoComponent>,
     catch_up_package: Option<pb::CatchUpPackage>,
     tracing_handle: ReloadHandles,
@@ -207,8 +206,7 @@ pub fn construct_ic_stack(
         &state_manager.state_layout().tmp(),
     );
     // ---------- MESSAGE ROUTING DEPS FOLLOW ----------
-    let certified_stream_store: Arc<dyn CertifiedStreamStore> =
-        Arc::clone(&state_manager) as Arc<_>;
+    let certified_stream_store = Arc::clone(&state_manager);
     let message_router = if config
         .malicious_behaviour
         .malicious_flags

--- a/rs/replica_tests/src/lib.rs
+++ b/rs/replica_tests/src/lib.rs
@@ -298,7 +298,7 @@ where
         let data_provider = Arc::new(data_provider);
         let fake_registry_client = Arc::new(FakeRegistryClient::new(data_provider.clone()));
         fake_registry_client.update_to_latest_version();
-        let registry = fake_registry_client.clone() as Arc<dyn RegistryClient + Send + Sync>;
+        let registry = fake_registry_client.clone();
         let crypto = setup_crypto_provider(
             &config.crypto,
             rt.handle().clone(),


### PR DESCRIPTION
Where used a lot (such as e.g. the `RegistryClient` within `BatchProcessorImpl`), it is likely more efficient to use concrete types (via `impl trait` or generic types) instead of dynamic types.

I had an earlier version of this change that tried to replace all `dyn trait` uses in Message Routing with generics, but the resulting types became exceedingly complex; and these were mostly pointers that were used once per round (e.g. to call `process_batch()`).