### PR TITLE
fix(IDX): bep artifact name

### DIFF
--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -63,7 +63,7 @@ runs:
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ github.job }}-bep-${{ strategy.job-index }}
+        name: ${{ github.job }}-bep
         retention-days: 14
         if-no-files-found: ignore
         compression-level: 9


### PR DESCRIPTION
Our *github-stats* service relies on having `-bep` suffix.