### PR TITLE
chore: simplify rust dependencies of the universal canister

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14070,11 +14070,10 @@ name = "ic-universal-canister"
 version = "0.9.0"
 dependencies = [
  "candid",
- "ic-crypto-sha2",
- "ic-embedders",
  "ic-types",
  "lazy_static",
  "serde",
+ "sha2 0.10.8",
  "universal-canister",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14070,7 +14070,6 @@ name = "ic-universal-canister"
 version = "0.9.0"
 dependencies = [
  "candid",
- "ic-types",
  "lazy_static",
  "serde",
  "sha2 0.10.8",

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -1029,7 +1029,7 @@ fn dts_aborted_execution_does_not_block_subnet_messages() {
             .on_reply(wasm().reply_data(&[43]));
 
         let subnet_message = wasm()
-            .call_with_cycles(IC_00, method, args, 100_000_000_000_u128.into())
+            .call_with_cycles(IC_00, method, args, 100_000_000_000_u128)
             .build();
 
         let subnet_message_id =
@@ -1308,7 +1308,7 @@ fn dts_paused_execution_blocks_deposit_cycles() {
                 .other_side(args)
                 .on_reject(wasm().reject_message().reject())
                 .on_reply(wasm().reply_data(&[43])),
-            1_u128.into(),
+            1_u128,
         )
         .build();
 

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -3092,12 +3092,7 @@ fn test_canister_liquid_cycle_balance() {
                     callee,
                     "update",
                     call_args()
-                        .other_side(
-                            wasm()
-                                .accept_cycles(u128::MAX)
-                                .append_and_reply()
-                                .build(),
-                        )
+                        .other_side(wasm().accept_cycles(u128::MAX).append_and_reply().build())
                         .on_reject(wasm().reject_message().trap())
                         .on_reply(wasm().message_payload().append_and_reply()),
                 )

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -3094,7 +3094,7 @@ fn test_canister_liquid_cycle_balance() {
                     call_args()
                         .other_side(
                             wasm()
-                                .accept_cycles(u128::MAX.into())
+                                .accept_cycles(u128::MAX)
                                 .append_and_reply()
                                 .build(),
                         )

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -325,7 +325,7 @@ fn canister_info(
             CanisterId::ic_00(),
             "canister_info",
             call_args().other_side(Encode!(&CanisterIdRecord::from(target)).unwrap()),
-            0_u128.into(),
+            0_u128,
         )
         .build();
 
@@ -1146,7 +1146,7 @@ fn cmc_create_canister_with_cycles(
             CYCLES_MINTING_CANISTER_ID,
             "create_canister",
             call_args().other_side(create_args),
-            cycles.into(),
+            cycles,
         )
         .build();
 

--- a/rs/replica_tests/tests/canister_lifecycle.rs
+++ b/rs/replica_tests/tests/canister_lifecycle.rs
@@ -36,7 +36,7 @@ fn can_create_canister_from_another_canister() {
         // Call method "create_canister" on ic:00. This should create a canister
         // with the auto-generated id above.
         assert_eq!(
-            canister.update(wasm().call(management::create_canister(num_cycles.into_parts()))),
+            canister.update(wasm().call(management::create_canister(num_cycles))),
             Ok(WasmResult::Reply(expected_response_payload))
         );
     });
@@ -52,7 +52,7 @@ fn full_canister_lifecycle_from_another_canister() {
 
         // Create a new canister from within a canister.
         assert_eq!(
-            canister.update(wasm().call(management::create_canister(num_cycles.into_parts()))),
+            canister.update(wasm().call(management::create_canister(num_cycles))),
             Ok(WasmResult::Reply(canister_id_record,)),
         );
 
@@ -975,7 +975,7 @@ fn test_canister_skip_upgrade() {
 
         // Create a new canister from within a canister.
         let reply = match canister
-            .update(wasm().call(management::create_canister(num_cycles.into_parts())))
+            .update(wasm().call(management::create_canister(num_cycles)))
             .unwrap()
         {
             WasmResult::Reply(reply) => reply,

--- a/rs/tests/execution/compute_allocation_test.rs
+++ b/rs/tests/execution/compute_allocation_test.rs
@@ -116,9 +116,9 @@ pub fn total_compute_allocation_cannot_be_exceeded(env: TestEnv) {
             reply_data: &[u8],
         ) -> Result<(Principal, Vec<u8>), AgentError> {
             let created_canister = universal_canister
-                .update(wasm().call(management::create_canister(
-                    Cycles::from(10_000_000_000_000_000u128).into_parts(),
-                )))
+                .update(wasm().call(management::create_canister(Cycles::from(
+                    10_000_000_000_000_000u128,
+                ))))
                 .await
                 .map(|res| {
                     Decode!(res.as_slice(), CreateCanisterResult)

--- a/rs/tests/execution/general_execution_tests/canister_lifecycle.rs
+++ b/rs/tests/execution/general_execution_tests/canister_lifecycle.rs
@@ -245,10 +245,8 @@ pub fn create_canister_with_one_controller(env: TestEnv) {
             let canister_b = canister_a
                 .update(
                     wasm().call(
-                        management::create_canister(
-                            Cycles::from(2_000_000_000_000u64).into_parts(),
-                        )
-                        .with_controllers(vec![canister_a.canister_id()]),
+                        management::create_canister(Cycles::from(2_000_000_000_000u64))
+                            .with_controllers(vec![canister_a.canister_id()]),
                     ),
                 )
                 .await
@@ -300,9 +298,9 @@ pub fn update_settings_multiple_controllers(env: TestEnv) {
             // A creates C
             info!(logger, "Canister A attempts to create canister C.");
             let canister_c = canister_a
-                .update(wasm().call(management::create_canister(
-                    Cycles::from(2_000_000_000_000u64).into_parts(),
-                )))
+                .update(wasm().call(management::create_canister(Cycles::from(
+                    2_000_000_000_000u64,
+                ))))
                 .await
                 .map(|res| {
                     Decode!(res.as_slice(), CreateCanisterResult)
@@ -445,10 +443,8 @@ pub fn create_canister_with_no_controllers(env: TestEnv) {
             let canister_b = canister_a
                 .update(
                     wasm().call(
-                        management::create_canister(
-                            Cycles::from(2_000_000_000_000u64).into_parts(),
-                        )
-                        .with_controllers(Vec::<Principal>::new()), // No controllers
+                        management::create_canister(Cycles::from(2_000_000_000_000u64))
+                            .with_controllers(Vec::<Principal>::new()), // No controllers
                     ),
                 )
                 .await
@@ -489,10 +485,8 @@ pub fn create_canister_with_multiple_controllers(env: TestEnv) {
             let canister_c = canister_a
                 .update(
                     wasm().call(
-                        management::create_canister(
-                            Cycles::from(2_000_000_000_000u64).into_parts(),
-                        )
-                        .with_controllers(controllers.clone()),
+                        management::create_canister(Cycles::from(2_000_000_000_000u64))
+                            .with_controllers(controllers.clone()),
                     ),
                 )
                 .await
@@ -578,10 +572,8 @@ pub fn create_canister_with_too_many_controllers_fails(env: TestEnv) {
             let response = canister_a
                 .update(
                     wasm().call(
-                        management::create_canister(
-                            Cycles::from(2_000_000_000_000u64).into_parts(),
-                        )
-                        .with_controllers(controllers),
+                        management::create_canister(Cycles::from(2_000_000_000_000u64))
+                            .with_controllers(controllers),
                     ),
                 )
                 .await;
@@ -831,9 +823,9 @@ pub fn canister_can_manage_other_canister(env: TestEnv) {
             .await;
 
             let canister_b = canister_a
-                .update(wasm().call(management::create_canister(
-                    Cycles::from(2_000_000_000_000u64).into_parts(),
-                )))
+                .update(wasm().call(management::create_canister(Cycles::from(
+                    2_000_000_000_000u64,
+                ))))
                 .await
                 .map(|res| {
                     Decode!(res.as_slice(), CreateCanisterResult)
@@ -881,9 +873,9 @@ pub fn canister_can_manage_other_canister_batched(env: TestEnv) {
             )
             .await;
             let canister_b = canister_a
-                .update(wasm().call(management::create_canister(
-                    Cycles::from(2_000_000_000_000u64).into_parts(),
-                )))
+                .update(wasm().call(management::create_canister(Cycles::from(
+                    2_000_000_000_000u64,
+                ))))
                 .await
                 .map(|res| {
                     Decode!(res.as_slice(), CreateCanisterResult)
@@ -1183,10 +1175,8 @@ pub fn create_canister_with_invalid_freezing_threshold_fails(env: TestEnv) {
                     canister
                         .update(
                             wasm().call(
-                                management::create_canister(
-                                    Cycles::from(2_000_000_000_000u64).into_parts(),
-                                )
-                                .with_freezing_threshold(invalid_value.clone()),
+                                management::create_canister(Cycles::from(2_000_000_000_000u64))
+                                    .with_freezing_threshold(invalid_value.clone()),
                             ),
                         )
                         .await,

--- a/rs/tests/execution/max_number_of_canisters_test.rs
+++ b/rs/tests/execution/max_number_of_canisters_test.rs
@@ -73,9 +73,9 @@ pub fn creating_canisters_fails_if_limit_of_allowed_canisters_is_reached(env: Te
             // limit.
             assert_reject(
                 canister
-                    .update(wasm().call(management::create_canister(
-                        Cycles::from(100_000_000_000u64).into_parts(),
-                    )))
+                    .update(wasm().call(management::create_canister(Cycles::from(
+                        100_000_000_000u64,
+                    ))))
                     .await,
                 RejectCode::CanisterReject,
             );

--- a/rs/tests/nns/sns/lib/src/sns_deployment.rs
+++ b/rs/tests/nns/sns/lib/src/sns_deployment.rs
@@ -1327,7 +1327,7 @@ impl<'a> DappCanister<'a> {
         let dapp_canister = original_controller_canister
             .update(
                 wasm().call(
-                    management::create_canister(Cycles::from(2_000_000_000_000u64).into_parts())
+                    management::create_canister(Cycles::from(2_000_000_000_000u64))
                         .with_controllers(controllers.clone()),
                 ),
             )

--- a/rs/universal_canister/lib/BUILD.bazel
+++ b/rs/universal_canister/lib/BUILD.bazel
@@ -7,8 +7,8 @@ DEPENDENCIES = [
     "//rs/universal_canister/impl:lib",
     "@crate_index//:candid",
     "@crate_index//:lazy_static",
-    "@crate_index//:sha2",
     "@crate_index//:serde",
+    "@crate_index//:sha2",
 ]
 
 DEV_DEPENDENCIES = [

--- a/rs/universal_canister/lib/BUILD.bazel
+++ b/rs/universal_canister/lib/BUILD.bazel
@@ -4,18 +4,15 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
-    "//rs/crypto/sha2",
-    "//rs/embedders",
-    "//rs/types/types",
     "//rs/universal_canister/impl:lib",
     "@crate_index//:candid",
     "@crate_index//:lazy_static",
+    "@crate_index//:sha2",
     "@crate_index//:serde",
 ]
 
 DEV_DEPENDENCIES = [
     # Keep sorted.
-    "//rs/types/types",
 ]
 
 rust_library(
@@ -32,8 +29,6 @@ rust_doc_test(
     crate = ":lib",
     deps = [
         # Keep sorted.
-        "//rs/crypto/sha2",
-        "//rs/types/types",
     ],
 )
 

--- a/rs/universal_canister/lib/Cargo.toml
+++ b/rs/universal_canister/lib/Cargo.toml
@@ -8,11 +8,9 @@ documentation.workspace = true
 
 [dependencies]
 candid = { workspace = true }
-ic-crypto-sha2 = { path = "../../crypto/sha2" }
-ic-embedders = { path = "../../embedders" }
-ic-types = { path = "../../types/types" }
 lazy_static = { workspace = true }
 serde = { workspace = true }
+sha2 = { workspace = true }
 universal-canister = { path = "../impl" }
 
 [dev-dependencies]

--- a/rs/universal_canister/lib/Cargo.toml
+++ b/rs/universal_canister/lib/Cargo.toml
@@ -12,6 +12,3 @@ lazy_static = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
 universal-canister = { path = "../impl" }
-
-[dev-dependencies]
-ic-types = { path = "../../types/types" }

--- a/rs/universal_canister/lib/src/management.rs
+++ b/rs/universal_canister/lib/src/management.rs
@@ -9,7 +9,6 @@ use std::convert::TryFrom;
 ///
 /// ```
 /// use ic_universal_canister::{wasm, management, CallInterface};
-/// use ic_types::Cycles;
 ///
 /// // Create a new canister with some cycles.
 /// wasm().call(management::create_canister(Cycles::from(2_000_000_000_000u64).into_parts()));

--- a/rs/universal_canister/lib/src/management.rs
+++ b/rs/universal_canister/lib/src/management.rs
@@ -11,21 +11,23 @@ use std::convert::TryFrom;
 /// use ic_universal_canister::{wasm, management, CallInterface};
 ///
 /// // Create a new canister with some cycles.
-/// wasm().call(management::create_canister(Cycles::from(2_000_000_000_000u64).into_parts()));
+/// wasm().call(management::create_canister(2_000_000_000_000u64));
 ///
 /// // Create a new canister with a specific freezing threshold.
 /// wasm().call(
-///   management::create_canister(Cycles::from(2_000_000_000_000u64).into_parts())
+///   management::create_canister(2_000_000_000_000u64)
 ///      .with_freezing_threshold(1234_u16)
 /// );
 ///
 /// // Create a new canister with custom callbacks.
-/// wasm().call(management::create_canister(Cycles::from(2_000_000_000_000u64).into_parts())
+/// wasm().call(management::create_canister(2_000_000_000_000u64)
 ///   .on_reply(wasm().noop()) // custom on_reply
 ///   .on_reject(wasm().noop()) // custom on_reject
 ///   .on_cleanup(wasm().noop())); // custom on_cleanup
 /// ```
-pub fn create_canister(cycles: (u64, u64)) -> CandidCallBuilder<CreateCanisterArgs> {
+pub fn create_canister<Cycles: Into<u128>>(
+    cycles: Cycles,
+) -> CandidCallBuilder<CreateCanisterArgs> {
     CandidCallBuilder {
         args: CreateCanisterArgs { settings: None },
         call: Call::new(Principal::management_canister(), "create_canister").cycles(cycles),
@@ -159,7 +161,7 @@ pub fn bitcoin_get_balance(
             min_confirmations,
         },
         call: Call::new(Principal::management_canister(), "bitcoin_get_balance")
-            .cycles((0, 100_000_000))
+            .cycles(100_000_000u64)
             .on_reject(wasm().reject_message().reject()),
     }
 }


### PR DESCRIPTION
Remove universal canister's dependency on internal crates to make it easier to use by non-ic repos.