### PR TITLE
feat(nns): Support initializing NNS Governance by candid

### DIFF
--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,6 +9,9 @@ on the process that this file is part of, see
 
 ## Added
 
+* The `init` method now supports candid decoding in addition to protobuf. Protobuf decoding will be
+  removed in the future, giving clients time to migrate.
+
 ## Changed
 
 * Increased the probability of failure from 70% to 90% for the deprecated _pb methods.

--- a/rs/nns/nns.bzl
+++ b/rs/nns/nns.bzl
@@ -17,7 +17,7 @@ CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES = {
     "cycles-minting-canister.wasm.gz": 6,
     "genesis-token-canister.wasm.gz": 3,
     "governance-canister.wasm.gz": 17,
-    "governance-canister_test.wasm.gz": 17,
+    "governance-canister_test.wasm.gz": 18,
     "registry-canister.wasm.gz": 14,
     "root-canister.wasm.gz": 4,
 }


### PR DESCRIPTION
# Why

NNS Governance almost use candid everywhere, except for 2 _pb methods (being deprecated) and init. We would like to switch init to candid as well.

# What

* Support candid parsing in init