### PR TITLE
test: make fast subnets actually fast

### DIFF
--- a/rs/tests/driver/src/driver/ic.rs
+++ b/rs/tests/driver/src/driver/ic.rs
@@ -529,7 +529,7 @@ impl Subnet {
         );
         Self::new(subnet_type)
             // Shorter block time.
-            .with_unit_delay(Duration::from_millis(100))
+            .with_unit_delay(Duration::from_millis(200))
             .with_initial_notary_delay(Duration::from_millis(200))
             .add_nodes(no_of_nodes)
     }

--- a/rs/tests/driver/src/driver/ic.rs
+++ b/rs/tests/driver/src/driver/ic.rs
@@ -529,8 +529,8 @@ impl Subnet {
         );
         Self::new(subnet_type)
             // Shorter block time.
-            .with_unit_delay(Duration::from_millis(200))
-            .with_initial_notary_delay(Duration::from_millis(500))
+            .with_unit_delay(Duration::from_millis(100))
+            .with_initial_notary_delay(Duration::from_millis(200))
             .add_nodes(no_of_nodes)
     }
 


### PR DESCRIPTION
Currently, "fast" subnets have notary delay set to `500ms`. Since https://github.com/dfinity/ic/pull/1508 and https://github.com/dfinity/ic/pull/2050 the default notary delay is `300ms` which means that "fast" subnets are slower than "normal" (i.e. using the default settings) subnets