### PR TITLE
feat(sns): neuron `SetFollowing` command is validated in isolation 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12623,6 +12623,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-test",
 ]

--- a/rs/sns/governance/BUILD.bazel
+++ b/rs/sns/governance/BUILD.bazel
@@ -66,6 +66,7 @@ DEPENDENCIES = [
     "@crate_index//:serde_bytes",
     "@crate_index//:serde_json",
     "@crate_index//:strum",
+    "@crate_index//:thiserror",
 ]
 
 MACRO_DEPENDENCIES = [

--- a/rs/sns/governance/Cargo.toml
+++ b/rs/sns/governance/Cargo.toml
@@ -84,6 +84,7 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 canbench-rs = { version = "0.1.7", optional = true }
+thiserror = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 ic-types = { path = "../../types/types" }

--- a/rs/sns/governance/protobuf_generator/src/lib.rs
+++ b/rs/sns/governance/protobuf_generator/src/lib.rs
@@ -56,7 +56,12 @@ pub fn generate_prost_files(proto: ProtoPaths<'_>, out: &Path) {
     };
     apply_attribute(
         "#[derive(strum_macros::EnumIter)]",
-        vec!["Governance.Mode", "NeuronPermissionType", "Proposal.action"],
+        vec![
+            "Governance.Mode",
+            "NeuronPermissionType",
+            "Proposal.action",
+            "Topic",
+        ],
     );
     apply_attribute(
         "#[derive(serde::Serialize)]",

--- a/rs/sns/governance/src/following.rs
+++ b/rs/sns/governance/src/following.rs
@@ -119,7 +119,7 @@ impl fmt::Debug for ValidatedFollowee {
 }
 
 /// Represents followees grouped by neuron ID.
-pub(crate) type FolloweeGroups = BTreeMap<Topic, BTreeMap<NeuronId, Vec<ValidatedFollowee>>>;
+type FolloweeGroups = BTreeMap<Topic, BTreeMap<NeuronId, Vec<ValidatedFollowee>>>;
 
 /// Helper function to aid checking the invariant: **Followees on a given topic must have
 /// unique neuron IDs.**
@@ -141,7 +141,7 @@ pub(crate) type FolloweeGroups = BTreeMap<Topic, BTreeMap<NeuronId, Vec<Validate
 ///
 /// The implementation of this function relies on the fact that `ValidatedFollowee` instances are
 /// ordered by topic and *then* neuron ID, which is enforced by the `PartialOrd` implementation.
-pub(crate) fn get_duplicate_followee_groups(
+fn get_duplicate_followee_groups(
     followees: &BTreeSet<ValidatedFollowee>,
 ) -> FolloweeGroups {
     followees
@@ -207,7 +207,7 @@ fn fmt_neuron_groups(followee_groups: &FolloweeGroups) -> String {
 /// and the topics are associated with each neuron ID for auditability, i.e., if followee aliases
 /// are inconsistent, it should be possible to report which exact topics are misconfigured (since
 /// the same followee can appear under multiple topics).
-pub(crate) type FolloweeAliasGroups = BTreeMap<NeuronId, BTreeSet<ValidatedFollowee>>;
+type FolloweeAliasGroups = BTreeMap<NeuronId, BTreeSet<ValidatedFollowee>>;
 
 /// Helper function to aid checking the invariant: **followees with the same alias must have
 /// the same neuron ID.**
@@ -227,7 +227,7 @@ pub(crate) type FolloweeAliasGroups = BTreeMap<NeuronId, BTreeSet<ValidatedFollo
 ///
 /// The implementation of this function relies on the fact that `ValidatedFollowee` instances are
 /// ordered by neuron ID and *then* alias, which is enforced by the `PartialOrd` implementation.
-pub(crate) fn get_inconsistent_aliases(
+fn get_inconsistent_aliases(
     followees: &BTreeSet<ValidatedFollowee>,
 ) -> FolloweeAliasGroups {
     followees

--- a/rs/sns/governance/src/following.rs
+++ b/rs/sns/governance/src/following.rs
@@ -91,7 +91,7 @@ impl fmt::Debug for ValidatedFollowee {
 }
 
 /// Represents followees grouped by neuron ID.
-type FolloweeGroups = BTreeMap<Topic, BTreeMap<NeuronId, Vec<ValidatedFollowee>>>;
+type FolloweeGroups = BTreeMap<NeuronId, Vec<ValidatedFollowee>>;
 
 /// Helper function to aid checking the invariant: **Followees on a given topic must have
 /// unique neuron IDs.**
@@ -106,38 +106,26 @@ type FolloweeGroups = BTreeMap<Topic, BTreeMap<NeuronId, Vec<ValidatedFollowee>>
 /// }
 /// ```
 ///
-/// Returns the nested map from topics to duplicate neuron IDs (from `followees`). The map values
-/// are the actual followee instances for the corresponding neuron IDs.
+/// Returns the map from neuron IDs (from `followees`) to the actual followee instances
+/// for the corresponding neuron IDs.
 ///
 /// Assumption: `followees` all correspond to the same topic.
 ///
 /// The implementation of this function relies on the fact that `ValidatedFollowee` instances are
 /// ordered by topic and *then* neuron ID, which is enforced by the `PartialOrd` implementation.
+///
+/// This function assumes that all followees correspond to the same topic.
 fn get_duplicate_followee_groups(followees: &BTreeSet<ValidatedFollowee>) -> FolloweeGroups {
     followees
         .iter()
-        .sorted_by_key(|followee| followee.topic)
-        .group_by(|followee| followee.topic)
+        .sorted_by_key(|followee| followee.neuron_id.clone())
+        .group_by(|followee| followee.neuron_id.clone())
         .into_iter()
-        .filter_map(|(topic, group_for_this_topic)| {
-            let duplicates_for_this_topic = group_for_this_topic
-                .into_iter()
-                .sorted_by_key(|followee| followee.neuron_id.clone())
-                .group_by(|followee| followee.neuron_id.clone())
-                .into_iter()
-                .filter_map(|(neuron_id, group)| {
-                    let followees_with_this_neuron_id = group.cloned().collect::<Vec<_>>();
+        .filter_map(|(neuron_id, group)| {
+            let followees_with_this_neuron_id = group.into_iter().cloned().collect::<Vec<_>>();
 
-                    if followees_with_this_neuron_id.len() > 1 {
-                        Some((neuron_id, followees_with_this_neuron_id))
-                    } else {
-                        None
-                    }
-                })
-                .collect::<BTreeMap<NeuronId, _>>();
-
-            if !duplicates_for_this_topic.is_empty() {
-                Some((topic, duplicates_for_this_topic))
+            if followees_with_this_neuron_id.len() > 1 {
+                Some((neuron_id, followees_with_this_neuron_id))
             } else {
                 None
             }
@@ -148,37 +136,23 @@ fn get_duplicate_followee_groups(followees: &BTreeSet<ValidatedFollowee>) -> Fol
 /// Formats an instance of `FolloweeGroups` into a string.
 ///
 /// Need this since `Display for Vec<ValidatedFollowee>` cannot be implemented in this crate.
-fn fmt_neuron_groups(followee_groups: &FolloweeGroups) -> String {
+fn fmt_followee_groups(followee_groups: &FolloweeGroups) -> String {
     followee_groups
         .iter()
-        .map(|(topic, neuron_ids_to_followees)| {
-            let neuron_ids_to_followees = neuron_ids_to_followees
+        .map(|(neuron_id, followees)| {
+            let followees = followees
                 .iter()
-                .map(|(neuron_id, followees)| {
-                    let followees = followees
-                        .iter()
-                        .map(|followee| format!("{}", followee))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-
-                    format!("{}: {}", neuron_id, followees)
-                })
+                .map(|followee| format!("{}", followee))
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            format!("{}: [{}]", topic, neuron_ids_to_followees)
+            format!("{}: {}", neuron_id, followees)
         })
         .collect::<Vec<_>>()
         .join(", ")
 }
 
-/// Represents followee-related data grouped by alias.
-///
-/// Normally, followees are represented by `ValidatedFollowee` instances, but in this case, we need
-/// to group them by alias to check for inconsistencies (as defined in `get_inconsistent_aliases`),
-/// and the topics are associated with each neuron ID for auditability, i.e., if followee aliases
-/// are inconsistent, it should be possible to report which exact topics are misconfigured (since
-/// the same followee can appear under multiple topics).
+/// Represents followee-related data grouped by neuron ID.
 type FolloweeAliasGroups = BTreeMap<NeuronId, BTreeSet<ValidatedFollowee>>;
 
 /// Helper function to aid checking the invariant: **followees with the same alias must have
@@ -296,7 +270,7 @@ pub(crate) enum FolloweesForTopicValidationError {
     #[error("some followees were not specified correctly: {:?}", .0)]
     FolloweeValidationError(Vec<FolloweeValidationError>),
 
-    #[error("followees on a given topic must have unique neuron IDs, got: {}", fmt_neuron_groups(.0))]
+    #[error("followees on a given topic must have unique neuron IDs, got: {}", fmt_followee_groups(.0))]
     DuplicateFolloweeNeuronId(FolloweeGroups),
 }
 
@@ -417,8 +391,6 @@ impl TryFrom<SetFollowing> for ValidatedSetFollowing {
             .iter()
             .flat_map(|followees_for_topic| followees_for_topic.followees.iter().cloned())
             .collect();
-
-        println!(">>> all_followees {:?}", all_followees);
 
         let inconsistent_aliases = get_inconsistent_aliases(&all_followees);
 

--- a/rs/sns/governance/src/following.rs
+++ b/rs/sns/governance/src/following.rs
@@ -1,0 +1,434 @@
+use crate::pb::v1::{
+    manage_neuron::SetFollowing, neuron::FolloweesForTopic, Followee, NeuronId, Topic,
+};
+use itertools::{Either, Itertools};
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
+use strum::IntoEnumIterator;
+use thiserror::Error;
+
+/// Maximum number of bytes that a neuron alias can have.
+pub const MAX_NEURON_ALIAS_BYTES: usize = 128;
+
+/// Maximum number of followees that a neuron can have for a given topic.
+pub const MAX_FOLLOWEES_PER_TOPIC: usize = 15;
+
+#[derive(Clone, Eq, PartialEq, Ord)]
+pub(crate) struct ValidatedFollowee {
+    topic: Topic,
+    alias: Option<String>,
+    neuron_id: NeuronId,
+}
+
+impl fmt::Display for ValidatedFollowee {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(alias) = &self.alias {
+            write!(
+                f,
+                "Followee(topic: {}, neuron_id: {}, alias: {})",
+                self.topic, self.neuron_id, alias
+            )
+        } else {
+            write!(
+                f,
+                "Followee(topic: {}, neuron_id: {})",
+                self.topic, self.neuron_id
+            )
+        }
+    }
+}
+
+/// Defines lexicographic ordering for `ValidatedFollowee` instances. This ordering is helpful for
+/// grouping followees by topic or alias first, and then by neuron ID, which is helpful
+/// for detecting inconsistencies across multiple followees.
+impl PartialOrd for ValidatedFollowee {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.topic.partial_cmp(&other.topic) {
+            Some(Ordering::Equal) => {}
+            ord => return ord,
+        }
+        match self.alias.partial_cmp(&other.alias) {
+            Some(Ordering::Equal) => {}
+            ord => return ord,
+        }
+        self.neuron_id.partial_cmp(&other.neuron_id)
+    }
+}
+
+impl fmt::Debug for ValidatedFollowee {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", format!("{}", self))
+    }
+}
+
+/// Represents followees grouped by neuron ID.
+pub(crate) type FolloweeGroups = BTreeMap<Topic, BTreeMap<NeuronId, Vec<ValidatedFollowee>>>;
+
+/// Helper function to aid checking the invariant: Followees on a given topic must have
+/// unique neuron IDs. Example pattern:
+///
+/// ```
+/// let duplicate_followee_groups = get_duplicate_followee_groups(&followees_for_this_topic);
+///
+/// if !duplicate_followee_groups.is_empty() {
+///     return Err(Error(duplicate_followee_groups));
+/// }
+/// ```
+///
+/// To that end, this function returns the map of neuron IDs (from `followees`) that have duplicate
+/// neuron IDs. The map values are the actual followee instances for the corresponding neuron IDs.
+///
+/// Assumption: `followees` all correspond to the same topic.
+pub(crate) fn get_duplicate_followee_groups(
+    followees: &BTreeSet<ValidatedFollowee>,
+) -> FolloweeGroups {
+    followees
+        .iter()
+        .group_by(|followee| followee.topic)
+        .into_iter()
+        .filter_map(|(topic, group_for_this_topic)| {
+            let duplicates_for_this_topic = group_for_this_topic
+                .into_iter()
+                .group_by(|followee| followee.neuron_id.clone())
+                .into_iter()
+                .filter_map(|(neuron_id, group)| {
+                    let followees_with_this_neuron_id = group.cloned().collect::<Vec<_>>();
+
+                    if followees_with_this_neuron_id.len() > 1 {
+                        Some((neuron_id, followees_with_this_neuron_id))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<BTreeMap<NeuronId, _>>();
+
+            if !duplicates_for_this_topic.is_empty() {
+                Some((topic, duplicates_for_this_topic))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Formats an instance of `FolloweeGroups` into a string.
+///
+/// Need this since `Display for Vec<ValidatedFollowee>` cannot be implemented in this crate.
+fn fmt_neuron_groups(followee_groups: &FolloweeGroups) -> String {
+    followee_groups
+        .iter()
+        .map(|(topic, neuron_ids_to_followees)| {
+            let neuron_ids_to_followees = neuron_ids_to_followees
+                .iter()
+                .map(|(neuron_id, followees)| {
+                    let followees = followees
+                        .iter()
+                        .map(|followee| format!("{}", followee))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+
+                    format!("{}: {}", neuron_id, followees)
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            format!("{}: [{}]", topic, neuron_ids_to_followees)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Represents followee-related data grouped by alias.
+///
+/// Normally, followees are represented by `ValidatedFollowee` instances, but in this case, we need
+/// to group them by alias to check for inconsistencies (as defined in `get_inconsistent_aliases`),
+/// and the topics are associated with each neuron ID for auditability, i.e., if followee aliases
+/// are inconsistent, it should be possible to report which exact topics are misconfigured (since
+/// the same followee can appear under multiple topics).
+pub(crate) type FolloweeAliasGroups = BTreeMap<String, BTreeMap<NeuronId, Vec<ValidatedFollowee>>>;
+
+/// Helper function to aid checking the invariant: followees with the same alias must have
+/// the same neuron ID.
+///
+/// To that end, this function returns the map of followee aliases (from `followees`) that have
+/// multiple neuron IDs. The map values represent the corresponding sets of `(neuron_id, topic)`
+/// pairs.
+pub(crate) fn get_inconsistent_aliases(
+    followees: &BTreeSet<ValidatedFollowee>,
+) -> FolloweeAliasGroups {
+    followees
+        .into_iter()
+        // Aliases are optional, and only the ones that are *present* may cause inconsistencies.
+        // Thus, we filter out the followees that do not have an alias.
+        .filter_map(|followee| followee.clone().alias.map(|alias| (alias, followee)))
+        .group_by(|(alias, _)| alias.clone())
+        .into_iter()
+        .filter_map(|(alias, group_for_this_alias)| {
+            let followees_for_this_alias = group_for_this_alias
+                .into_iter()
+                .map(|(_, followees)| followees);
+
+            let duplicate_followees_for_this_alias = followees_for_this_alias
+                .group_by(|followee| followee.neuron_id.clone())
+                .into_iter()
+                .filter_map(|(neuron_id, group_for_this_neuron_id)| {
+                    let followees_with_this_neuron_id = group_for_this_neuron_id
+                        .into_iter()
+                        .cloned()
+                        .collect::<Vec<_>>();
+
+                    if followees_with_this_neuron_id.len() > 1 {
+                        Some((neuron_id, followees_with_this_neuron_id))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<BTreeMap<NeuronId, Vec<ValidatedFollowee>>>();
+
+            if duplicate_followees_for_this_alias.len() > 1 {
+                Some((alias.clone(), duplicate_followees_for_this_alias))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn fmt_alias_groups(followees: &FolloweeAliasGroups) -> String {
+    followees
+        .iter()
+        .map(|(alias, neuron_ids_to_followees)| {
+            let neuron_ids_to_followees = neuron_ids_to_followees
+                .iter()
+                .map(|(neuron_id, followees_for_this_neuron_id)| {
+                    let followees_for_this_neuron_id = followees_for_this_neuron_id
+                        .iter()
+                        .map(|followee| format!("{}", followee))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+
+                    format!("{}: [{}]", neuron_id, followees_for_this_neuron_id)
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            format!("{}: [{}]", alias, neuron_ids_to_followees)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum FolloweeValidationError {
+    #[error("field neuron_id must be specified")]
+    NeuronIdNotSpecified,
+
+    #[error("alias cannot be the empty string")]
+    AliasCannotBeEmptyString,
+
+    #[error("alias cannot exceed {} bytes", MAX_NEURON_ALIAS_BYTES)]
+    AliasTooLong,
+}
+
+impl TryFrom<(Followee, Topic)> for ValidatedFollowee {
+    type Error = FolloweeValidationError;
+
+    fn try_from(value: (Followee, Topic)) -> Result<Self, Self::Error> {
+        let (Followee { neuron_id, alias }, topic) = value;
+
+        let Some(neuron_id) = neuron_id else {
+            return Err(Self::Error::NeuronIdNotSpecified);
+        };
+
+        if let Some(alias) = &alias {
+            if alias.is_empty() {
+                return Err(Self::Error::AliasCannotBeEmptyString);
+            }
+
+            if alias.len() > MAX_NEURON_ALIAS_BYTES {
+                return Err(Self::Error::AliasTooLong);
+            }
+        }
+
+        Ok(Self {
+            topic,
+            neuron_id,
+            alias,
+        })
+    }
+}
+
+pub(crate) struct ValidatedFolloweesForTopic {
+    pub followees: BTreeSet<ValidatedFollowee>,
+    pub topic: Topic,
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum FolloweesForTopicValidationError {
+    #[error("topic must be set to one from SnsGov.list_topics()")]
+    UnspecifiedTopic,
+
+    #[error("a neuron can only follow up to {} other neurons on a given topic (requested {})", MAX_FOLLOWEES_PER_TOPIC, .0)]
+    TooManyFollowees(usize),
+
+    #[error("some followees were not specified correctly: {:?}", .0)]
+    FolloweeValidationError(Vec<FolloweeValidationError>),
+
+    #[error("followees on a given topic must have unique neuron IDs, got: {}", fmt_neuron_groups(.0))]
+    DuplicateFolloweeNeuronId(FolloweeGroups),
+
+    #[error("followees with the same alias must have the same neuron ID, got: {}", fmt_alias_groups(.0))]
+    InconsistentFolloweeAliases(FolloweeAliasGroups),
+}
+
+impl TryFrom<FolloweesForTopic> for ValidatedFolloweesForTopic {
+    type Error = FolloweesForTopicValidationError;
+
+    fn try_from(value: FolloweesForTopic) -> Result<Self, Self::Error> {
+        let FolloweesForTopic { followees, topic } = value;
+
+        let Some(Ok(topic)) = topic.map(Topic::try_from) else {
+            return Err(Self::Error::UnspecifiedTopic);
+        };
+
+        if followees.len() > MAX_FOLLOWEES_PER_TOPIC {
+            return Err(Self::Error::TooManyFollowees(followees.len()));
+        }
+
+        let (followees, errors): (Vec<_>, Vec<_>) =
+            followees.into_iter().partition_map(|followee| {
+                match ValidatedFollowee::try_from((followee, topic)) {
+                    Ok(followee) => Either::Left(followee),
+                    Err(err) => Either::Right(err),
+                }
+            });
+
+        if !errors.is_empty() {
+            return Err(Self::Error::FolloweeValidationError(errors));
+        }
+
+        let followees = followees.into_iter().collect();
+
+        let duplicate_neuron_ids = get_duplicate_followee_groups(&followees);
+
+        if !duplicate_neuron_ids.is_empty() {
+            return Err(Self::Error::DuplicateFolloweeNeuronId(duplicate_neuron_ids));
+        }
+
+        let inconsistent_aliases = get_inconsistent_aliases(&followees);
+
+        if !inconsistent_aliases.is_empty() {
+            return Err(Self::Error::InconsistentFolloweeAliases(
+                inconsistent_aliases,
+            ));
+        }
+
+        Ok(Self { followees, topic })
+    }
+}
+
+// #[error("topics must be unique, but found a duplicate: {:?}", .0)]
+//     DuplicateTopics(Topic),
+
+pub(crate) struct ValidatedSetFollowing {
+    pub topic_following: BTreeMap<Topic, BTreeSet<ValidatedFollowee>>,
+}
+
+fn fmt_topics(topics: &Vec<Topic>) -> String {
+    topics
+        .iter()
+        .map(|topic| format!("{} ({})", topic, *topic as i32))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum SetFollowingValidationError {
+    #[error("topic_following must contain at least one element")]
+    NoTopicFollowsSpecified,
+
+    #[error("topic_followees cannot contain more than {} elements (got {})", Topic::iter().count(), .0)]
+    TooManyTopicFollows(usize),
+
+    #[error("some followees were not specified correctly: {:?}", .0)]
+    FolloweesForTopicValidationError(Vec<FolloweesForTopicValidationError>),
+
+    #[error("topics must be unique, but the following topics had duplicates: {}", fmt_topics(.0))]
+    DuplicateTopics(Vec<Topic>),
+
+    #[error("followees with the same alias must have the same neuron ID, got: {}", fmt_alias_groups(.0))]
+    InconsistentFolloweeAliases(FolloweeAliasGroups),
+}
+
+impl TryFrom<SetFollowing> for ValidatedSetFollowing {
+    type Error = SetFollowingValidationError;
+
+    fn try_from(value: SetFollowing) -> Result<Self, Self::Error> {
+        let SetFollowing { topic_following } = value;
+
+        if topic_following.is_empty() {
+            return Err(Self::Error::NoTopicFollowsSpecified);
+        }
+
+        if topic_following.len() > Topic::iter().count() {
+            return Err(Self::Error::TooManyTopicFollows(topic_following.len()));
+        }
+
+        let (topic_following, errors): (Vec<_>, Vec<_>) =
+            topic_following.into_iter().partition_map(|topic_follow| {
+                match ValidatedFolloweesForTopic::try_from(topic_follow) {
+                    Ok(topic_follow) => Either::Left(topic_follow),
+                    Err(err) => Either::Right(err),
+                }
+            });
+
+        if !errors.is_empty() {
+            return Err(Self::Error::FolloweesForTopicValidationError(errors));
+        }
+
+        let duplicate_topics = topic_following
+            .iter()
+            .group_by(|topic_following| topic_following.topic.clone())
+            .into_iter()
+            .filter_map(
+                |(topic, group)| {
+                    if group.count() > 1 {
+                        Some(topic)
+                    } else {
+                        None
+                    }
+                },
+            )
+            .collect::<Vec<_>>();
+
+        if !duplicate_topics.is_empty() {
+            return Err(Self::Error::DuplicateTopics(duplicate_topics));
+        }
+
+        let inconsistent_aliases = get_inconsistent_aliases(
+            &topic_following
+                .iter()
+                .flat_map(|followees_for_topic| followees_for_topic.followees.iter().cloned())
+                .collect(),
+        );
+
+        if !inconsistent_aliases.is_empty() {
+            return Err(Self::Error::InconsistentFolloweeAliases(
+                inconsistent_aliases,
+            ));
+        }
+
+        let topic_following = topic_following
+            .into_iter()
+            .map(|ValidatedFolloweesForTopic { followees, topic }| (topic, followees))
+            .collect();
+
+        Ok(Self { topic_following })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rs/sns/governance/src/following/tests.rs
+++ b/rs/sns/governance/src/following/tests.rs
@@ -92,3 +92,620 @@ fn test_get_duplicate_followee_groups() {
         assert_eq!(observed, expected, "{}", label);
     }
 }
+
+#[test]
+fn test_get_inconsistent_aliases() {
+    let test_cases = [
+        (
+            "Trivial case.",
+            btreeset! {},
+            btreemap! {},
+        ),
+        (
+            "Rudimentary case I: can't have inconsistent aliases in a singleton collection.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+            },
+            btreemap! {},
+        ),
+        (
+            "Rudimentary case II: can't have alias inconsistent aliases if aliases are not set.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: None },
+            },
+            btreemap! {},
+        ),
+        (
+            "Rudimentary case III: the same followee can have aliases specified in some cases and \
+             not in others (within the same topic and across topics).",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: Some("Bob".to_string()) },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: None },
+            },
+            btreemap! {},
+        ),
+        (
+            "Happy case I: Aliases are consistent across all followees (ordering should be ignored).",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: Some("Bob".to_string()) },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: Some("Bob".to_string()) },
+            },
+            btreemap! {},
+        ),
+        (
+            "Happy case II: Aliases can be reused for different neuron IDs.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: Some("Alice".to_string()) },
+            },
+            btreemap! {},
+        ),
+        (
+            "Problem I: Inconsistent aliases within the same topic.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Bob".to_string()) },
+            },
+            btreemap! {
+                nid(0) => btreeset! {
+                    ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                    ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Bob".to_string()) },
+                },
+            },
+        ),
+        (
+            "Problem II: Inconsistent aliases across multiple topics.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(0), alias: Some("Bob".to_string()) },
+            },
+            btreemap! {
+                nid(0) => btreeset! {
+                    ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                    ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(0), alias: Some("Bob".to_string()) },
+                },
+            },
+        ),
+        (
+            "Problem III: Complex scenario with multiple inconsistencies (but not all followees \
+             are inconsistent).",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: None },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(2), alias: Some("Bob".to_string()) },
+                ValidatedFollowee { topic: Topic::ApplicationBusinessLogic, neuron_id: nid(1), alias: Some("Alice (1)".to_string()) },
+                ValidatedFollowee { topic: Topic::ApplicationBusinessLogic, neuron_id: nid(2), alias: Some("Robert".to_string()) },
+            },
+            btreemap! {
+                nid(1) => btreeset! {
+                    ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: Some("Alice".to_string()) },
+                    ValidatedFollowee { topic: Topic::ApplicationBusinessLogic, neuron_id: nid(1), alias: Some("Alice (1)".to_string()) },
+                },
+                nid(2) => btreeset! {
+                    ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(2), alias: Some("Bob".to_string()) },
+                    ValidatedFollowee { topic: Topic::ApplicationBusinessLogic, neuron_id: nid(2), alias: Some("Robert".to_string()) },
+                },
+            },
+        ),
+    ];
+    for (label, followees, expected) in test_cases {
+        let observed = get_inconsistent_aliases(&followees);
+        assert_eq!(observed, expected, "{}", label);
+    }
+}
+
+#[test]
+fn test_validate_followees() {
+    // Topic do not affect this function (they are added as a field of `ValidatedFollowee` just for
+    // convenience), so we can use the same topic for test cases.
+    let topic = Topic::DappCanisterManagement;
+
+    let test_cases = [
+        (
+            "Happy case I: Followee without an alias.",
+            (
+                Followee {
+                    neuron_id: Some(nid(111)),
+                    alias: None,
+                },
+                topic,
+            ),
+            Ok(ValidatedFollowee {
+                topic,
+                neuron_id: nid(111),
+                alias: None,
+            }),
+        ),
+        (
+            "Happy case II: Followee has an alias (which is very long, but still passes).",
+            (
+                Followee {
+                    neuron_id: Some(nid(111)),
+                    alias: Some("a".repeat(128)),
+                },
+                topic,
+            ),
+            Ok(ValidatedFollowee {
+                topic,
+                neuron_id: nid(111),
+                alias: Some("a".repeat(128)),
+            }),
+        ),
+        (
+            "Problem I: Followee has an alias that is too long.",
+            (
+                Followee {
+                    neuron_id: Some(nid(111)),
+                    alias: Some("a".repeat(129)),
+                },
+                topic,
+            ),
+            Err(FolloweeValidationError::AliasTooLong(129)),
+        ),
+        (
+            "Problem II: Followee has an alias that is the empty string.",
+            (
+                Followee {
+                    neuron_id: Some(nid(111)),
+                    alias: Some("".to_string()),
+                },
+                topic,
+            ),
+            Err(FolloweeValidationError::AliasCannotBeEmptyString),
+        ),
+        (
+            "Problem III: Followee without an alias is missing an ID.",
+            (
+                Followee {
+                    neuron_id: None,
+                    alias: None,
+                },
+                topic,
+            ),
+            Err(FolloweeValidationError::NeuronIdNotSpecified),
+        ),
+        (
+            "Problem IV: Followee has an alias is missing an ID.",
+            (
+                Followee {
+                    neuron_id: None,
+                    alias: Some("Alice".to_string()),
+                },
+                topic,
+            ),
+            Err(FolloweeValidationError::NeuronIdNotSpecified),
+        ),
+    ];
+
+    for (label, followee_and_topic, expected) in test_cases {
+        let observed = ValidatedFollowee::try_from(followee_and_topic);
+        assert_eq!(observed, expected, "{}", label);
+    }
+}
+
+#[test]
+fn test_validate_followees_for_topic() {
+    let test_cases = [
+        (
+            "Happy case I: Empty list of followees (used to unset following on a given topic).",
+            FolloweesForTopic {
+                followees: vec![],
+                topic: Some(Topic::DappCanisterManagement as i32),
+            },
+            Ok(ValidatedFolloweesForTopic {
+                followees: btreeset! {},
+                topic: Topic::DappCanisterManagement,
+            }),
+        ),
+        (
+            "Happy case II: Literal followees are deduped.",
+            FolloweesForTopic {
+                followees: vec![
+                    Followee {
+                        neuron_id: Some(nid(42)),
+                        alias: Some("Alice".to_string()),
+                    },
+                    Followee {
+                        neuron_id: Some(nid(42)),
+                        alias: Some("Alice".to_string()),
+                    },
+                ],
+                topic: Some(Topic::DappCanisterManagement as i32),
+            },
+            Ok(ValidatedFolloweesForTopic {
+                followees: btreeset! {
+                    ValidatedFollowee {
+                        topic: Topic::DappCanisterManagement,
+                        neuron_id: nid(42),
+                        alias: Some("Alice".to_string()),
+                    },
+                },
+                topic: Topic::DappCanisterManagement,
+            }),
+        ),
+        (
+            "Happy case III: Complex scenario with multiple followees.",
+            FolloweesForTopic {
+                followees: vec![
+                    Followee {
+                        neuron_id: Some(nid(42)),
+                        alias: None,
+                    },
+                    Followee {
+                        neuron_id: Some(nid(43)),
+                        alias: Some("Alice".to_string()),
+                    },
+                    Followee {
+                        neuron_id: Some(nid(44)),
+                        alias: Some("Alice".to_string()),
+                    },
+                ],
+                topic: Some(Topic::DappCanisterManagement as i32),
+            },
+            Ok(ValidatedFolloweesForTopic {
+                followees: btreeset! {
+                    ValidatedFollowee {
+                        topic: Topic::DappCanisterManagement,
+                        neuron_id: nid(42),
+                        alias: None,
+                    },
+                    ValidatedFollowee {
+                        topic: Topic::DappCanisterManagement,
+                        neuron_id: nid(43),
+                        alias: Some("Alice".to_string()),
+                    },
+                    ValidatedFollowee {
+                        topic: Topic::DappCanisterManagement,
+                        neuron_id: nid(44),
+                        alias: Some("Alice".to_string()),
+                    },
+                },
+                topic: Topic::DappCanisterManagement,
+            }),
+        ),
+        (
+            "Happy scenario IV: Maximum possible number of followees for a topic.",
+            FolloweesForTopic {
+                followees: (0..15)
+                    .into_iter()
+                    .map(|i| Followee {
+                        neuron_id: Some(nid(i)),
+                        alias: None,
+                    })
+                    .collect(),
+                topic: Some(Topic::DappCanisterManagement as i32),
+            },
+            Ok(ValidatedFolloweesForTopic {
+                followees: (0..15)
+                    .into_iter()
+                    .map(|i| ValidatedFollowee {
+                        topic: Topic::DappCanisterManagement,
+                        neuron_id: nid(i),
+                        alias: None,
+                    })
+                    .collect(),
+                topic: Topic::DappCanisterManagement,
+            }),
+        ),
+        (
+            "Problem I: Too many followees for a topic.",
+            FolloweesForTopic {
+                followees: (0..16)
+                    .into_iter()
+                    .map(|i| Followee {
+                        neuron_id: Some(nid(i)),
+                        alias: None,
+                    })
+                    .collect(),
+                topic: Some(Topic::DappCanisterManagement as i32),
+            },
+            Err(FolloweesForTopicValidationError::TooManyFollowees(16)),
+        ),
+        (
+            "Problem II: No topics specified.",
+            FolloweesForTopic {
+                followees: vec![Followee {
+                    neuron_id: Some(nid(42)),
+                    alias: Some("Alice".to_string()),
+                }],
+                topic: None,
+            },
+            Err(FolloweesForTopicValidationError::UnspecifiedTopic),
+        ),
+        (
+            "Problem III: The zero-topic is specified.",
+            FolloweesForTopic {
+                followees: vec![Followee {
+                    neuron_id: Some(nid(42)),
+                    alias: Some("Alice".to_string()),
+                }],
+                topic: Some(Topic::Unspecified as i32),
+            },
+            Err(FolloweesForTopicValidationError::UnspecifiedTopic),
+        ),
+        (
+            "Problem IV: Some followees are inconsistent.",
+            FolloweesForTopic {
+                followees: vec![
+                    Followee {
+                        neuron_id: Some(nid(41)),
+                        alias: Some("Alice".to_string()),
+                    },
+                    Followee {
+                        neuron_id: None,
+                        alias: Some("Alice".to_string()),
+                    },
+                    Followee {
+                        neuron_id: Some(nid(43)),
+                        alias: Some("".to_string()),
+                    },
+                ],
+                topic: Some(Topic::DappCanisterManagement as i32),
+            },
+            Err(FolloweesForTopicValidationError::FolloweeValidationError(
+                vec![
+                    FolloweeValidationError::NeuronIdNotSpecified,
+                    FolloweeValidationError::AliasCannotBeEmptyString,
+                ],
+            )),
+        ),
+        (
+            "Problem V: Followees share neuron IDs.",
+            FolloweesForTopic {
+                followees: vec![
+                    Followee {
+                        neuron_id: Some(nid(42)),
+                        alias: Some("Alice".to_string()),
+                    },
+                    Followee {
+                        neuron_id: Some(nid(42)),
+                        alias: None,
+                    },
+                ],
+                topic: Some(Topic::DappCanisterManagement as i32),
+            },
+            Err(FolloweesForTopicValidationError::DuplicateFolloweeNeuronId(
+                btreemap! {
+                    Topic::DappCanisterManagement => btreemap! {
+                        nid(42) => vec![
+                            ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(42), alias: None },
+                            ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(42), alias: Some("Alice".to_string()) },
+                        ],
+                    }
+                },
+            )),
+        ),
+    ];
+
+    for (label, followees_for_topic, expected) in test_cases {
+        let observed = ValidatedFolloweesForTopic::try_from(followees_for_topic);
+        assert_eq!(observed, expected, "{}", label);
+    }
+}
+
+#[test]
+fn test_validate_set_following() {
+    let test_cases = [
+        (
+            "Happy case I: Complex scenario with multiple topics and followees.",
+            SetFollowing {
+                topic_following: vec![
+                    FolloweesForTopic {
+                        followees: vec![
+                            Followee {
+                                neuron_id: Some(nid(40)),
+                                alias: Some("Bob".to_string()),
+                            },
+                            Followee {
+                                neuron_id: Some(nid(41)),
+                                alias: Some("Alice".to_string()),
+                            },
+                            Followee {
+                                neuron_id: Some(nid(42)),
+                                alias: None,
+                            },
+                        ],
+                        topic: Some(Topic::DappCanisterManagement as i32),
+                    },
+                    FolloweesForTopic {
+                        followees: vec![
+                            Followee {
+                                neuron_id: Some(nid(42)),
+                                alias: Some("Bob".to_string()),
+                            },
+                            Followee {
+                                neuron_id: Some(nid(43)),
+                                alias: Some("Bob".to_string()),
+                            },
+                        ],
+                        topic: Some(Topic::CriticalDappOperations as i32),
+                    },
+                ],
+            },
+            Ok(ValidatedSetFollowing {
+                topic_following: vec![
+                    ValidatedFolloweesForTopic {
+                        followees: btreeset! {
+                            ValidatedFollowee {
+                                topic: Topic::DappCanisterManagement,
+                                neuron_id: nid(40),
+                                alias: Some("Bob".to_string()),
+                            },
+                            ValidatedFollowee {
+                                topic: Topic::DappCanisterManagement,
+                                neuron_id: nid(41),
+                                alias: Some("Alice".to_string()),
+                            },
+                            ValidatedFollowee {
+                                topic: Topic::DappCanisterManagement,
+                                neuron_id: nid(42),
+                                alias: None,
+                            },
+                        },
+                        topic: Topic::DappCanisterManagement,
+                    },
+                    ValidatedFolloweesForTopic {
+                        followees: btreeset! {
+                            ValidatedFollowee {
+                                topic: Topic::CriticalDappOperations,
+                                neuron_id: nid(42),
+                                alias: Some("Bob".to_string()),
+                            },
+                            ValidatedFollowee {
+                                topic: Topic::CriticalDappOperations,
+                                neuron_id: nid(43),
+                                alias: Some("Bob".to_string()),
+                            },
+                        },
+                        topic: Topic::CriticalDappOperations,
+                    },
+                ],
+            }),
+        ),
+        (
+            "Happy case II: Maximum number of followees for a topic.",
+            SetFollowing {
+                topic_following: (0..7)
+                    .into_iter()
+                    .map(|i| FolloweesForTopic {
+                        followees: vec![Followee {
+                            neuron_id: Some(nid(i)),
+                            alias: None,
+                        }],
+                        topic: Some(Topic::DappCanisterManagement as i32),
+                    })
+                    .collect(),
+            },
+            Ok(ValidatedSetFollowing {
+                topic_following: (0..7)
+                    .into_iter()
+                    .map(|i| {
+                        let followees_for_topic = ValidatedFolloweesForTopic {
+                            followees: btreeset! {
+                                ValidatedFollowee {
+                                    topic: Topic::DappCanisterManagement,
+                                    neuron_id: nid(i),
+                                    alias: None,
+                                }
+                            },
+                            topic: Topic::DappCanisterManagement,
+                        };
+                        (Topic::DappCanisterManagement, followees_for_topic)
+                    })
+                    .collect(),
+            }),
+        ),
+        (
+            "Problem I: Too many followees for a topic.",
+            SetFollowing {
+                topic_following: (0..8)
+                    .into_iter()
+                    .map(|i| FolloweesForTopic {
+                        followees: vec![Followee {
+                            neuron_id: Some(nid(i)),
+                            alias: None,
+                        }],
+                        topic: Some(Topic::DappCanisterManagement as i32),
+                    })
+                    .collect(),
+            },
+            Err(SetFollowingValidationError::TooManyTopicFollows(8)),
+        ),
+        (
+            "Problem II: No topic followings specified.",
+            SetFollowing {
+                topic_following: vec![],
+            },
+            Err(SetFollowingValidationError::NoTopicFollowingSpecified),
+        ),
+        (
+            "Problem III: Some followees are invalid (errors are deduped).",
+            SetFollowing {
+                topic_following: vec![
+                    FolloweesForTopic {
+                        followees: vec![],
+                        topic: None,
+                    },
+                    FolloweesForTopic {
+                        followees: vec![],
+                        topic: None,
+                    },
+                ],
+            },
+            Err(
+                SetFollowingValidationError::FolloweesForTopicValidationError(
+                    btreeset! { FolloweesForTopicValidationError::UnspecifiedTopic },
+                ),
+            ),
+        ),
+        (
+            "Problem IV: Duplicate topics.",
+            SetFollowing {
+                topic_following: vec![
+                    FolloweesForTopic {
+                        followees: vec![],
+                        topic: Some(Topic::DappCanisterManagement as i32),
+                    },
+                    FolloweesForTopic {
+                        followees: vec![],
+                        topic: Some(Topic::DappCanisterManagement as i32),
+                    },
+                ],
+            },
+            Err(SetFollowingValidationError::DuplicateTopics(vec![
+                Topic::DappCanisterManagement,
+            ])),
+        ),
+        (
+            "Problem V: Some followees have inconsistent aliases.",
+            SetFollowing {
+                topic_following: vec![
+                    FolloweesForTopic {
+                        followees: vec![
+                            Followee {
+                                neuron_id: Some(nid(41)),
+                                alias: Some("Alice".to_string()),
+                            },
+                            Followee {
+                                neuron_id: Some(nid(42)),
+                                alias: None,
+                            },
+                        ],
+                        topic: Some(Topic::DappCanisterManagement as i32),
+                    },
+                    FolloweesForTopic {
+                        followees: vec![
+                            Followee {
+                                neuron_id: Some(nid(41)),
+                                alias: Some("Bob".to_string()),
+                            },
+                            Followee {
+                                neuron_id: Some(nid(42)),
+                                alias: Some("Bob".to_string()),
+                            },
+                        ],
+                        topic: Some(Topic::CriticalDappOperations as i32),
+                    },
+                ],
+            },
+            Err(SetFollowingValidationError::InconsistentFolloweeAliases(
+                btreemap! {
+                    nid(42) => btreeset! {
+                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(41), alias: Some("Alice".to_string()) },
+                        ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(41), alias: Some("Bob".to_string()) },
+                    }
+                },
+            )),
+        ),
+    ];
+    for (label, followees_for_topic, expected) in test_cases {
+        let observed = ValidatedSetFollowing::try_from(followees_for_topic);
+        assert_eq!(observed, expected, "{}", label);
+    }
+}

--- a/rs/sns/governance/src/following/tests.rs
+++ b/rs/sns/governance/src/following/tests.rs
@@ -42,12 +42,10 @@ fn test_get_duplicate_followee_groups() {
                 ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
             },
             btreemap! {
-                Topic::DappCanisterManagement => btreemap! {
-                    nid(0) => vec![
-                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
-                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
-                    ],
-                },
+                nid(0) => vec![
+                    ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
+                    ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ],
             },
         ),
         (
@@ -60,18 +58,14 @@ fn test_get_duplicate_followee_groups() {
                 ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: None },
             },
             btreemap! {
-                Topic::DappCanisterManagement => btreemap! {
-                    nid(0) => vec![
-                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
-                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
-                    ],
-                },
-                Topic::CriticalDappOperations => btreemap! {
-                    nid(1) => vec![
-                        ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: None },
-                        ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: Some("Bob".to_string()) },
-                    ],
-                },
+                nid(0) => vec![
+                    ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
+                    ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ],
+                nid(1) => vec![
+                    ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: None },
+                    ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: Some("Bob".to_string()) },
+                ],
             },
         ),
         (
@@ -470,12 +464,10 @@ fn test_validate_followees_for_topic() {
             },
             Err(FolloweesForTopicValidationError::DuplicateFolloweeNeuronId(
                 btreemap! {
-                    Topic::DappCanisterManagement => btreemap! {
-                        nid(42) => vec![
-                            ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(42), alias: None },
-                            ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(42), alias: Some("Alice".to_string()) },
-                        ],
-                    }
+                    nid(42) => vec![
+                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(42), alias: None },
+                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(42), alias: Some("Alice".to_string()) },
+                    ],
                 },
             )),
         ),

--- a/rs/sns/governance/src/following/tests.rs
+++ b/rs/sns/governance/src/following/tests.rs
@@ -1,0 +1,94 @@
+use super::*;
+use maplit::{btreemap, btreeset};
+use pretty_assertions::assert_eq;
+
+fn nid(n: u8) -> NeuronId {
+    NeuronId { id: vec![n] }
+}
+
+#[test]
+fn test_get_duplicate_followee_groups() {
+    // In the following test cases, the followee aliases do not actually matter, but we set them to
+    // some realistic values to make the test cases more readable.
+    let test_cases = [
+        ("Trivial case.", btreeset! {}, btreemap! {}),
+        (
+            "Rudimentary case: can't have duplicates in a singleton collection.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+            },
+            btreemap! {},
+        ),
+        (
+            "Same topic, different neuron IDs.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: None },
+            },
+            btreemap! {},
+        ),
+        (
+            "Different topics, same neuron ID.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(0), alias: None },
+            },
+            btreemap! {},
+        ),
+        (
+            "Duplicate neuron ID under the same topic.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
+            },
+            btreemap! {
+                Topic::DappCanisterManagement => btreemap! {
+                    nid(0) => vec![
+                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
+                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                    ],
+                },
+            },
+        ),
+        (
+            "Multiple duplicates; function under test should be agnostic to the (shuffled) \
+             followee order.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: Some("Bob".to_string()) },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: None },
+            },
+            btreemap! {
+                Topic::DappCanisterManagement => btreemap! {
+                    nid(0) => vec![
+                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
+                        ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                    ],
+                },
+                Topic::CriticalDappOperations => btreemap! {
+                    nid(1) => vec![
+                        ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: None },
+                        ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: Some("Bob".to_string()) },
+                    ],
+                },
+            },
+        ),
+        (
+            "Fixed the above configuration by making sure Alice's and Bob's neurons aren't \
+             duplicate for the same topic.",
+            btreeset! {
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: Some("Bob".to_string()) },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(0), alias: None },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: None },
+            },
+            btreemap! {},
+        ),
+    ];
+
+    for (label, followees, expected) in test_cases {
+        let observed = get_duplicate_followee_groups(&followees);
+        assert_eq!(observed, expected, "{}", label);
+    }
+}

--- a/rs/sns/governance/src/following/tests.rs
+++ b/rs/sns/governance/src/following/tests.rs
@@ -8,8 +8,8 @@ fn nid(n: u8) -> NeuronId {
 
 #[test]
 fn test_get_duplicate_followee_groups() {
-    // In the following test cases, the followee aliases do not actually matter, but we set them to
-    // some realistic values to make the test cases more readable.
+    // The function under test should ignore aliases and topics; vary them to check for
+    // unexpected behavior.
     let test_cases = [
         ("Trivial case.", btreeset! {}, btreemap! {}),
         (
@@ -33,7 +33,12 @@ fn test_get_duplicate_followee_groups() {
                 ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
                 ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(0), alias: None },
             },
-            btreemap! {},
+            btreemap! {
+                nid(0) => vec![
+                    ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
+                    ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(0), alias: None },
+                ]
+            },
         ),
         (
             "Duplicate neuron ID under the same topic.",
@@ -49,13 +54,13 @@ fn test_get_duplicate_followee_groups() {
             },
         ),
         (
-            "Multiple duplicates; function under test should be agnostic to the (shuffled) \
-             followee order.",
+            "Multiple duplicates with some unique followees.",
             btreeset! {
                 ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
-                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: Some("Bob".to_string()) },
                 ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: None },
+                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: Some("Bob".to_string()) },
                 ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: None },
+                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(42), alias: None },
             },
             btreemap! {
                 nid(0) => vec![
@@ -67,17 +72,6 @@ fn test_get_duplicate_followee_groups() {
                     ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: Some("Bob".to_string()) },
                 ],
             },
-        ),
-        (
-            "Fixed the above configuration by making sure Alice's and Bob's neurons aren't \
-             duplicate for the same topic.",
-            btreeset! {
-                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(0), alias: Some("Alice".to_string()) },
-                ValidatedFollowee { topic: Topic::DappCanisterManagement, neuron_id: nid(1), alias: Some("Bob".to_string()) },
-                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(0), alias: None },
-                ValidatedFollowee { topic: Topic::CriticalDappOperations, neuron_id: nid(1), alias: None },
-            },
-            btreemap! {},
         ),
     ];
 

--- a/rs/sns/governance/src/following/tests.rs
+++ b/rs/sns/governance/src/following/tests.rs
@@ -374,7 +374,6 @@ fn test_validate_followees_for_topic() {
             "Happy scenario IV: Maximum possible number of followees for a topic.",
             FolloweesForTopic {
                 followees: (0..15)
-                    .into_iter()
                     .map(|i| Followee {
                         neuron_id: Some(nid(i)),
                         alias: None,
@@ -384,7 +383,6 @@ fn test_validate_followees_for_topic() {
             },
             Ok(ValidatedFolloweesForTopic {
                 followees: (0..15)
-                    .into_iter()
                     .map(|i| ValidatedFollowee {
                         topic: Topic::DappCanisterManagement,
                         neuron_id: nid(i),
@@ -398,7 +396,6 @@ fn test_validate_followees_for_topic() {
             "Problem I: Too many followees for a topic.",
             FolloweesForTopic {
                 followees: (0..16)
-                    .into_iter()
                     .map(|i| Followee {
                         neuron_id: Some(nid(i)),
                         alias: None,

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -4323,6 +4323,7 @@ impl ClaimSwapNeuronsError {
     candid::CandidType,
     candid::Deserialize,
     comparable::Comparable,
+    strum_macros::EnumIter,
     Clone,
     Copy,
     Debug,

--- a/rs/sns/governance/src/lib.rs
+++ b/rs/sns/governance/src/lib.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 
 mod cached_upgrade_steps;
 pub mod canister_control;
+pub mod following;
 pub mod governance;
 pub mod init;
 pub mod logs;

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1815,19 +1815,6 @@ fn validate_and_render_advance_sns_target_version_proposal(
     ))
 }
 
-fn topic_to_str(topic: &Topic) -> &'static str {
-    match topic {
-        Topic::Unspecified => "Unspecified",
-        Topic::DaoCommunitySettings => "DaoCommunitySettings",
-        Topic::SnsFrameworkManagement => "SnsFrameworkManagement",
-        Topic::DappCanisterManagement => "DappCanisterManagement",
-        Topic::ApplicationBusinessLogic => "ApplicationBusinessLogic",
-        Topic::Governance => "Governance",
-        Topic::TreasuryAssetManagement => "TreasuryAssetManagement",
-        Topic::CriticalDappOperations => "CriticalDappOperations",
-    }
-}
-
 pub(crate) fn validate_and_render_set_topics_for_custom_proposals(
     set_topics_for_custom_proposals: &SetTopicsForCustomProposals,
     existing_custom_functions: &BTreeMap<u64, (String, Option<Topic>)>,
@@ -1868,20 +1855,16 @@ pub(crate) fn validate_and_render_set_topics_for_custom_proposals(
             continue;
         };
 
-        let proposed_topic_str = topic_to_str(&proposed_topic);
-
         let topic_change_str = if let Some(current_topic) = current_topic {
             // Is this proposal trying to modify a previously set topic?
 
             if proposed_topic == *current_topic {
-                format!("{proposed_topic_str} (keeping unchanged)")
+                format!("{proposed_topic} (keeping unchanged)")
             } else {
-                let existing_topic_str = topic_to_str(current_topic);
-
-                format!("{proposed_topic_str} (changing from {existing_topic_str})")
+                format!("{proposed_topic} (changing from {current_topic})")
             }
         } else {
-            format!("{proposed_topic_str} (topic not currently set)")
+            format!("{proposed_topic} (topic not currently set)")
         };
 
         table.push(format!("{function_name} under topic {topic_change_str}"));

--- a/rs/sns/governance/src/topics.rs
+++ b/rs/sns/governance/src/topics.rs
@@ -7,6 +7,7 @@ use ic_sns_governance_api::pb::v1::topics::Topic;
 use ic_sns_governance_proposal_criticality::ProposalCriticality;
 use itertools::Itertools;
 use std::collections::{BTreeMap, HashMap};
+use std::fmt;
 
 /// Each topic has some information associated with it. This information is for the benefit of the user but has
 /// no effect on the behavior of the SNS.
@@ -328,6 +329,22 @@ impl pb::Topic {
                     .find(|native_function| action_code == *native_function)
                     .map(|_| Self::from(topic_info.topic))
             })
+    }
+}
+
+impl fmt::Display for pb::Topic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let topic_str = match self {
+            Self::Unspecified => "Unspecified",
+            Self::DaoCommunitySettings => "DaoCommunitySettings",
+            Self::SnsFrameworkManagement => "SnsFrameworkManagement",
+            Self::DappCanisterManagement => "DappCanisterManagement",
+            Self::ApplicationBusinessLogic => "ApplicationBusinessLogic",
+            Self::Governance => "Governance",
+            Self::TreasuryAssetManagement => "TreasuryAssetManagement",
+            Self::CriticalDappOperations => "CriticalDappOperations",
+        };
+        write!(f, "{}", topic_str)
     }
 }
 

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -1454,6 +1454,14 @@ impl ManageNeuronResponse {
         }
     }
 
+    pub fn set_following_response() -> Self {
+        ManageNeuronResponse {
+            command: Some(manage_neuron_response::Command::SetFollowing(
+                manage_neuron_response::SetFollowingResponse {},
+            )),
+        }
+    }
+
     pub fn make_proposal_response(proposal_id: ProposalId) -> Self {
         let proposal_id = Some(proposal_id);
         ManageNeuronResponse {


### PR DESCRIPTION
This PR adds validation for the recently added neuron `SetFollowing` command (which is still disabled). The validation is based on global topic following invariants, but does not yet take into potential account existing topic-based following that a neuron might have; that will be added in a follow-up PR.

| [Next PR](https://github.com/dfinity/ic/pull/4563) >