### PR TITLE
fix(IDX): set expected names for bep and profile

### DIFF
--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -51,7 +51,7 @@ runs:
       # only upload on success or failure but _not_ on canceled jobs
       if: (success() || failure()) && inputs.GPG_PASSPHRASE != ''
       run: |
-        for bep in $(find '${{ steps.metrics-tmpdir.outputs.dir }}' -name 'bazel-bep-*.pb'); do
+        for bep in $(find '${{ steps.metrics-tmpdir.outputs.dir }}' -name 'bazel-bep.pb'); do
             gpg --symmetric --cipher-algo AES256 -o "$bep.gpg" \
                 --passphrase '${{ inputs.GPG_PASSPHRASE }}' --batch --yes "$bep"
             rm -f "$bep"
@@ -68,8 +68,8 @@ runs:
         if-no-files-found: ignore
         compression-level: 9
         path: |
-          ${{ steps.metrics-tmpdir.outputs.dir }}/bazel-bep-*.pb.gpg
-          ${{ steps.metrics-tmpdir.outputs.dir }}/profile-*.json
+          ${{ steps.metrics-tmpdir.outputs.dir }}/bazel-bep.pb.gpg
+          ${{ steps.metrics-tmpdir.outputs.dir }}/profile.json
 
     - name: Cleanup
       shell: bash

--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -60,6 +60,7 @@ runs:
     - name: Upload bazel-bep
       # runs only if previous steps succeeded or failed;
       # we avoid collecting artifacts of jobs that were cancelled
+      # artifact name must end with `-bep` (expectation of github-stats service)
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/bazel/bin/bazel
+++ b/.github/actions/bazel/bin/bazel
@@ -59,13 +59,14 @@ fi
 
 # Add some options for build-like commands
 if [[ $bazel_command == "build" ]] || [[ $bazel_command == "test" ]]; then
-    command_timestamp=$(date +%s)
     bazel_args+=(
         --color=yes # Nice CI output
 
         # Write build events to the dedicated tempdir
-        --build_event_binary_file="$BAZEL_ACTION_METRICS_OUT/bazel-bep-$command_timestamp.pb"
-        --profile="$BAZEL_ACTION_METRICS_OUT/profile-$command_timestamp.json"
+        # GitHub Stats service collects compressed artifacts and expects
+        # to find`bazel-bep.pb` and `profile.json`!
+        --build_event_binary_file="$BAZEL_ACTION_METRICS_OUT/bazel-bep.pb"
+        --profile="$BAZEL_ACTION_METRICS_OUT/profile.json"
     )
 
     if [ -n "${BUILDBUDDY_LINKS:-}" ]; then


### PR DESCRIPTION
Github Stats service requires exact file names: `bazel-bep.pb.gpg` and `profile.json`.