### PR TITLE
feat(sns): Implement topic following index

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,8 @@
         "editor.formatOnSave": true
     },
     "bazel.buildifierExecutable": "@buildifier",
+    "cSpell.words": [
+        "followee",
+        "followees"
+    ],
 }

--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -204,7 +204,7 @@ pub mod neuron {
         candid::CandidType, candid::Deserialize, Clone, comparable::Comparable, Debug, PartialEq,
     )]
     pub struct TopicFollowees {
-        pub topic_id_to_followees: BTreeMap<u64, FolloweesForTopic>,
+        pub topic_id_to_followees: BTreeMap<i32, FolloweesForTopic>,
     }
 
     /// The neuron's dissolve state, specifying whether the neuron is dissolving,

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -519,7 +519,7 @@ type Neuron = record {
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;
   followees : vec record { nat64; Followees };
   topic_followees : opt record {
-    topic_id_to_followees : vec record { nat64; FolloweesForTopic };
+    topic_id_to_followees : vec record { int32; FolloweesForTopic };
   };
   neuron_fees_e8s : nat64;
 };

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -533,7 +533,7 @@ type Neuron = record {
   disburse_maturity_in_progress : vec DisburseMaturityInProgress;
   followees : vec record { nat64; Followees };
   topic_followees : opt record {
-    topic_id_to_followees : vec record { nat64; FolloweesForTopic };
+    topic_id_to_followees : vec record { int32; FolloweesForTopic };
   };
   neuron_fees_e8s : nat64;
 };

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -179,7 +179,7 @@ message Neuron {
 
   // A collection of a neuron's followees (per topic).
   message TopicFollowees {
-    map<uint64, FolloweesForTopic> topic_id_to_followees = 1;
+    map<int32, FolloweesForTopic> topic_id_to_followees = 1;
   }
 
   // The neuron's legacy followees (per proposal type), specified as a map of proposal functions IDs

--- a/rs/sns/governance/src/follower_index.rs
+++ b/rs/sns/governance/src/follower_index.rs
@@ -1,0 +1,214 @@
+use ic_canister_log::log;
+
+use crate::{
+    logs::ERROR,
+    pb::v1::{neuron::FolloweesForTopic, Followee, Neuron, NeuronId, Topic},
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(crate) type FollowerIndex = BTreeMap<Topic, BTreeMap<String, BTreeSet<NeuronId>>>;
+
+/// This is analogous to the legacy `remove_neuron_from_function_followee_index` function, but for
+/// topic following.
+pub fn remove_neuron_from_follower_index(index: &mut FollowerIndex, neuron: &Neuron) {
+    let Some(follower_id) = &neuron.id else {
+        log!(ERROR, "Neuron {:?} does not have an ID!", neuron);
+        return;
+    };
+
+    let Some(topic_followees) = &neuron.topic_followees else {
+        return;
+    };
+
+    for (topic, FolloweesForTopic { followees, .. }) in &topic_followees.topic_id_to_followees {
+        let Ok(topic) = Topic::try_from(*topic) else {
+            log!(
+                ERROR,
+                "Neuron {} has followees for an invalid topic ID: {}",
+                follower_id,
+                topic
+            );
+            continue;
+        };
+
+        if let Some(topic_index) = index.get_mut(&topic) {
+            for Followee {
+                neuron_id: followee_id,
+                alias,
+            } in followees
+            {
+                let Some(followee_id) = followee_id else {
+                    let alias = alias
+                        .as_ref()
+                        .map(|alias| format!(" ({})", alias))
+                        .unwrap_or_default();
+                    log!(
+                        ERROR,
+                        "Neuron with ID {:?} has a followee{} with no ID!",
+                        follower_id,
+                        alias
+                    );
+                    continue;
+                };
+
+                let key = followee_id.to_string();
+                if let Some(followers) = topic_index.get_mut(&key) {
+                    if !followers.remove(follower_id) {
+                        log!(
+                            ERROR,
+                            "Following index was missing an edge from followee with ID {:?} \
+                                to follower with ID {:?} in topic {:?}.",
+                            followee_id,
+                            follower_id,
+                            topic,
+                        );
+                    };
+                    if followers.is_empty() {
+                        topic_index.remove(&key);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// This is analogous to the legacy `add_neuron_to_function_followee_index` function, but for
+/// topic following.
+pub fn add_neuron_to_follower_index(
+    index: &mut BTreeMap<Topic, BTreeMap<String, BTreeSet<NeuronId>>>,
+    follower: &Neuron,
+) {
+    let Some(follower_id) = &follower.id else {
+        log!(ERROR, "Neuron {:?} does not have an ID!", follower);
+        return;
+    };
+
+    let Some(topic_followees) = &follower.topic_followees else {
+        return;
+    };
+
+    for (topic, FolloweesForTopic { followees, .. }) in &topic_followees.topic_id_to_followees {
+        let Ok(topic) = Topic::try_from(*topic) else {
+            log!(
+                ERROR,
+                "Neuron {} has followees for an invalid topic ID: {}",
+                follower_id,
+                topic
+            );
+            continue;
+        };
+        let topic_index = index.entry(topic).or_default();
+
+        for Followee {
+            neuron_id: followee_id,
+            alias,
+        } in followees
+        {
+            let Some(followee_id) = followee_id else {
+                let alias = alias
+                    .as_ref()
+                    .map(|alias| format!(" ({})", alias))
+                    .unwrap_or_default();
+                log!(
+                    ERROR,
+                    "Neuron with ID {:?} has a followee{} with no ID!",
+                    follower_id,
+                    alias
+                );
+                continue;
+            };
+
+            let key = followee_id.to_string();
+            topic_index
+                .entry(key)
+                .or_default()
+                .insert(follower_id.clone());
+        }
+    }
+}
+
+/// This is analogous to the legacy `build_function_followee_index` function, but for topic
+/// following.
+pub fn build_follower_index(
+    neurons: &BTreeMap<String, Neuron>,
+) -> BTreeMap<Topic, BTreeMap<String, BTreeSet<NeuronId>>> {
+    let mut function_followee_index = BTreeMap::new();
+    for neuron in neurons.values() {
+        add_neuron_to_follower_index(&mut function_followee_index, neuron);
+    }
+    function_followee_index
+}
+
+pub(crate) mod legacy {
+    use crate::{pb::v1::NervousSystemFunction, types::is_registered_function_id};
+
+    use super::*;
+
+    pub(crate) type FollowerIndex = BTreeMap<u64, BTreeMap<String, BTreeSet<NeuronId>>>;
+
+    /// Builds an index that maps proposal sns functions to (followee) neuron IDs to these neuron's
+    /// followers. The resulting index is a map
+    /// Function Id -> (followee's neuron ID) -> set of followers' neuron IDs.
+    ///
+    /// The index is built from the `neurons` in the `Governance` struct, which map followers
+    /// (the neuron ID) to a set of followees per function.
+    pub fn build_function_followee_index(
+        id_to_nervous_system_functions: &BTreeMap<u64, NervousSystemFunction>,
+        neurons: &BTreeMap<String, Neuron>,
+    ) -> BTreeMap<u64, BTreeMap<String, BTreeSet<NeuronId>>> {
+        let mut function_followee_index = BTreeMap::new();
+        for neuron in neurons.values() {
+            add_neuron_to_function_followee_index(
+                &mut function_followee_index,
+                id_to_nervous_system_functions,
+                neuron,
+            );
+        }
+        function_followee_index
+    }
+
+    /// Adds a neuron to the function_followee_index.
+    pub(crate) fn add_neuron_to_function_followee_index(
+        index: &mut FollowerIndex,
+        id_to_nervous_system_functions: &BTreeMap<u64, NervousSystemFunction>,
+        neuron: &Neuron,
+    ) {
+        for (function_id, followees) in neuron.followees.iter() {
+            if !is_registered_function_id(*function_id, id_to_nervous_system_functions) {
+                continue;
+            }
+
+            let followee_index = index.entry(*function_id).or_default();
+            for followee in followees.followees.iter() {
+                followee_index
+                    .entry(followee.to_string())
+                    .or_default()
+                    .insert(
+                        neuron
+                            .id
+                            .as_ref()
+                            .expect("Neuron must have a NeuronId")
+                            .clone(),
+                    );
+            }
+        }
+    }
+
+    /// Removes a neuron from the function_followee_index.
+    pub fn remove_neuron_from_function_followee_index(index: &mut FollowerIndex, neuron: &Neuron) {
+        for (function, followees) in neuron.followees.iter() {
+            if let Some(followee_index) = index.get_mut(function) {
+                for followee in followees.followees.iter() {
+                    let nid = followee.to_string();
+                    if let Some(followee_set) = followee_index.get_mut(&nid) {
+                        followee_set
+                            .remove(neuron.id.as_ref().expect("Neuron must have a NeuronId"));
+                        if followee_set.is_empty() {
+                            followee_index.remove(&nid);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -245,8 +245,8 @@ pub mod neuron {
         ::prost::Message,
     )]
     pub struct TopicFollowees {
-        #[prost(btree_map = "uint64, message", tag = "1")]
-        pub topic_id_to_followees: ::prost::alloc::collections::BTreeMap<u64, FolloweesForTopic>,
+        #[prost(btree_map = "int32, message", tag = "1")]
+        pub topic_id_to_followees: ::prost::alloc::collections::BTreeMap<i32, FolloweesForTopic>,
     }
     /// The neuron's dissolve state, specifying whether the neuron is dissolving,
     /// non-dissolving, or dissolved.

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3,6 +3,14 @@ use crate::{
         get_canister_id, perform_execute_generic_nervous_system_function_call,
         upgrade_canister_directly,
     },
+    follower_index::{
+        add_neuron_to_follower_index, build_follower_index,
+        legacy::{
+            self, add_neuron_to_function_followee_index, build_function_followee_index,
+            remove_neuron_from_function_followee_index,
+        },
+        remove_neuron_from_follower_index, FollowerIndex,
+    },
     following::ValidatedSetFollowing,
     logs::{ERROR, INFO},
     neuron::{
@@ -34,7 +42,7 @@ use crate::{
                 DisburseMaturityResponse, MergeMaturityResponse, StakeMaturityResponse,
             },
             nervous_system_function::FunctionType,
-            neuron::{DissolveState, Followees, FolloweesForTopic, TopicFollowees},
+            neuron::{DissolveState, Followees, TopicFollowees},
             proposal::Action,
             proposal_data::ActionAuxiliary as ActionAuxiliaryPb,
             transfer_sns_treasury_funds::TransferFrom,
@@ -43,7 +51,7 @@ use crate::{
             ClaimSwapNeuronsError, ClaimSwapNeuronsRequest, ClaimSwapNeuronsResponse,
             ClaimedSwapNeuronStatus, DefaultFollowees, DeregisterDappCanisters,
             DisburseMaturityInProgress, Empty, ExecuteGenericNervousSystemFunction,
-            FailStuckUpgradeInProgressRequest, FailStuckUpgradeInProgressResponse, Followee,
+            FailStuckUpgradeInProgressRequest, FailStuckUpgradeInProgressResponse,
             GetMaturityModulationRequest, GetMaturityModulationResponse, GetMetadataRequest,
             GetMetadataResponse, GetMode, GetModeResponse, GetNeuron, GetNeuronResponse,
             GetProposal, GetProposalResponse, GetSnsInitializationParametersRequest,
@@ -54,7 +62,7 @@ use crate::{
             MintTokensRequest, MintTokensResponse, NervousSystemFunction, NervousSystemParameters,
             Neuron, NeuronId, NeuronPermission, NeuronPermissionList, NeuronPermissionType,
             Proposal, ProposalData, ProposalDecisionStatus, ProposalId, ProposalRewardStatus,
-            RegisterDappCanisters, RewardEvent, SetTopicsForCustomProposals, Tally, Topic,
+            RegisterDappCanisters, RewardEvent, SetTopicsForCustomProposals, Tally,
             TransferSnsTreasuryFunds, UpgradeSnsControlledCanister, Vote, WaitForQuietState,
         },
     },
@@ -235,210 +243,6 @@ impl NeuronPermission {
 }
 
 impl GovernanceProto {
-    /// Builds an index that maps proposal sns functions to (followee) neuron IDs to these neuron's
-    /// followers. The resulting index is a map
-    /// Function Id -> (followee's neuron ID) -> set of followers' neuron IDs.
-    ///
-    /// The index is built from the `neurons` in the `Governance` struct, which map followers
-    /// (the neuron ID) to a set of followees per function.
-    pub fn build_function_followee_index(
-        &self,
-        neurons: &BTreeMap<String, Neuron>,
-    ) -> BTreeMap<u64, BTreeMap<String, BTreeSet<NeuronId>>> {
-        let mut function_followee_index = BTreeMap::new();
-        for neuron in neurons.values() {
-            GovernanceProto::add_neuron_to_function_followee_index(
-                &mut function_followee_index,
-                &self.id_to_nervous_system_functions,
-                neuron,
-            );
-        }
-        function_followee_index
-    }
-
-    /// This is analogous to the legacy `build_function_followee_index` function, but for topic
-    /// following.
-    pub fn build_following_index(
-        &self,
-        neurons: &BTreeMap<String, Neuron>,
-    ) -> BTreeMap<Topic, BTreeMap<String, BTreeSet<NeuronId>>> {
-        let mut function_followee_index = BTreeMap::new();
-        for neuron in neurons.values() {
-            GovernanceProto::add_neuron_to_following_index(&mut function_followee_index, neuron);
-        }
-        function_followee_index
-    }
-
-    /// This is analogous to the legacy `add_neuron_to_function_followee_index` function, but for
-    /// topic following.
-    pub fn add_neuron_to_following_index(
-        index: &mut BTreeMap<Topic, BTreeMap<String, BTreeSet<NeuronId>>>,
-        neuron: &Neuron,
-    ) {
-        let Some(follower_id) = &neuron.id else {
-            log!(ERROR, "Neuron {:?} does not have an ID!", neuron);
-            return;
-        };
-
-        let Some(topic_followees) = &neuron.topic_followees else {
-            return;
-        };
-
-        for (topic, FolloweesForTopic { followees, .. }) in &topic_followees.topic_id_to_followees {
-            let Ok(topic) = Topic::try_from(*topic) else {
-                log!(
-                    ERROR,
-                    "Neuron {} has followees for an invalid topic ID: {}",
-                    follower_id,
-                    topic
-                );
-                continue;
-            };
-            let topoc_index = index.entry(topic).or_default();
-
-            for Followee {
-                neuron_id: followee_id,
-                alias,
-            } in followees
-            {
-                let Some(followee_id) = followee_id else {
-                    let alias = alias
-                        .as_ref()
-                        .map(|alias| format!(" ({})", alias))
-                        .unwrap_or_default();
-                    log!(
-                        ERROR,
-                        "Neuron with ID {:?} has a followee{} with no ID!",
-                        follower_id,
-                        alias
-                    );
-                    continue;
-                };
-
-                let key = followee_id.to_string();
-                topoc_index
-                    .entry(key)
-                    .or_default()
-                    .insert(follower_id.clone());
-            }
-        }
-    }
-
-    /// This is analogous to the legacy `remove_neuron_from_function_followee_index` function, but for
-    /// topic following.
-    pub fn remove_neuron_from_following_index(
-        index: &mut BTreeMap<Topic, BTreeMap<String, BTreeSet<NeuronId>>>,
-        neuron: &Neuron,
-    ) {
-        let Some(follower_id) = &neuron.id else {
-            log!(ERROR, "Neuron {:?} does not have an ID!", neuron);
-            return;
-        };
-
-        let Some(topic_followees) = &neuron.topic_followees else {
-            return;
-        };
-
-        for (topic, FolloweesForTopic { followees, .. }) in &topic_followees.topic_id_to_followees {
-            let Ok(topic) = Topic::try_from(*topic) else {
-                log!(
-                    ERROR,
-                    "Neuron {} has followees for an invalid topic ID: {}",
-                    follower_id,
-                    topic
-                );
-                continue;
-            };
-
-            if let Some(topoc_index) = index.get_mut(&topic) {
-                for Followee {
-                    neuron_id: followee_id,
-                    alias,
-                } in followees
-                {
-                    let Some(followee_id) = followee_id else {
-                        let alias = alias
-                            .as_ref()
-                            .map(|alias| format!(" ({})", alias))
-                            .unwrap_or_default();
-                        log!(
-                            ERROR,
-                            "Neuron with ID {:?} has a followee{} with no ID!",
-                            follower_id,
-                            alias
-                        );
-                        continue;
-                    };
-
-                    let key = followee_id.to_string();
-                    if let Some(followee_set) = topoc_index.get_mut(&key) {
-                        if !followee_set.remove(follower_id) {
-                            log!(
-                                ERROR,
-                                "Following index was missing an edge from followee with ID {:?} \
-                                 to follower with ID {:?} in topic {:?}.",
-                                followee_id,
-                                follower_id,
-                                topic,
-                            );
-                        };
-                        if followee_set.is_empty() {
-                            topoc_index.remove(&key);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /// Adds a neuron to the function_followee_index.
-    pub fn add_neuron_to_function_followee_index(
-        index: &mut BTreeMap<u64, BTreeMap<String, BTreeSet<NeuronId>>>,
-        registered_functions: &BTreeMap<u64, NervousSystemFunction>,
-        neuron: &Neuron,
-    ) {
-        for (function_id, followees) in neuron.followees.iter() {
-            if !is_registered_function_id(*function_id, registered_functions) {
-                continue;
-            }
-
-            let followee_index = index.entry(*function_id).or_default();
-            for followee in followees.followees.iter() {
-                followee_index
-                    .entry(followee.to_string())
-                    .or_default()
-                    .insert(
-                        neuron
-                            .id
-                            .as_ref()
-                            .expect("Neuron must have a NeuronId")
-                            .clone(),
-                    );
-            }
-        }
-    }
-
-    /// Removes a neuron from the function_followee_index.
-    pub fn remove_neuron_from_function_followee_index(
-        index: &mut BTreeMap<u64, BTreeMap<String, BTreeSet<NeuronId>>>,
-        neuron: &Neuron,
-    ) {
-        for (function, followees) in neuron.followees.iter() {
-            if let Some(followee_index) = index.get_mut(function) {
-                for followee in followees.followees.iter() {
-                    let nid = followee.to_string();
-                    if let Some(followee_set) = followee_index.get_mut(&nid) {
-                        followee_set
-                            .remove(neuron.id.as_ref().expect("Neuron must have a NeuronId"));
-                        if followee_set.is_empty() {
-                            followee_index.remove(&nid);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     /// Iterate through one neuron and add all the principals that have some permission on this
     /// neuron to the index that maps principalIDs to a set of neurons for which the principal
     /// has some permissions.
@@ -826,7 +630,7 @@ pub struct Governance {
     /// is saved and restored.
     ///
     /// Function ID -> (followee's neuron ID) -> set of followers' neuron IDs.
-    pub function_followee_index: BTreeMap<u64, BTreeMap<String, BTreeSet<NeuronId>>>,
+    pub function_followee_index: legacy::FollowerIndex,
 
     /// Cached data structure that (for each topic) maps a followee to
     /// the set of its followers. It is the inverse of the mapping from follower
@@ -836,7 +640,7 @@ pub struct Governance {
     /// is saved and restored.
     ///
     /// Topic -> (followee's neuron ID) -> set of followers' neuron IDs.
-    pub topic_following_index: BTreeMap<Topic, BTreeMap<String, BTreeSet<NeuronId>>>,
+    pub topic_follower_index: FollowerIndex,
 
     /// Maps Principals to the Neuron IDs of all Neurons for which this principal
     /// has some permissions, i.e., all neurons that have this principal associated
@@ -941,7 +745,7 @@ impl Governance {
             nns_ledger,
             cmc,
             function_followee_index: BTreeMap::new(),
-            topic_following_index: BTreeMap::new(),
+            topic_follower_index: BTreeMap::new(),
             principal_to_neuron_ids_index: BTreeMap::new(),
             closest_proposal_deadline_timestamp_seconds: 0,
             latest_gc_timestamp_seconds: 0,
@@ -1008,9 +812,13 @@ impl Governance {
     /// Must be called after the state has been externally changed (e.g. by
     /// setting a new proto).
     fn initialize_indices(&mut self) {
-        self.function_followee_index = self
-            .proto
-            .build_function_followee_index(&self.proto.neurons);
+        self.function_followee_index = build_function_followee_index(
+            &self.proto.id_to_nervous_system_functions,
+            &self.proto.neurons,
+        );
+
+        self.topic_follower_index = build_follower_index(&self.proto.neurons);
+
         self.principal_to_neuron_ids_index = self
             .proto
             .build_principal_to_neuron_ids_index(&self.proto.neurons);
@@ -1151,13 +959,13 @@ impl Governance {
             &neuron,
         );
 
-        GovernanceProto::add_neuron_to_function_followee_index(
+        add_neuron_to_function_followee_index(
             &mut self.function_followee_index,
             &self.proto.id_to_nervous_system_functions,
             &neuron,
         );
 
-        GovernanceProto::add_neuron_to_following_index(&mut self.topic_following_index, &neuron);
+        add_neuron_to_follower_index(&mut self.topic_follower_index, &neuron);
 
         self.proto.neurons.insert(neuron_id.to_string(), neuron);
 
@@ -1189,15 +997,9 @@ impl Governance {
             &neuron,
         );
 
-        GovernanceProto::remove_neuron_from_function_followee_index(
-            &mut self.function_followee_index,
-            &neuron,
-        );
+        remove_neuron_from_function_followee_index(&mut self.function_followee_index, &neuron);
 
-        GovernanceProto::remove_neuron_from_following_index(
-            &mut self.topic_following_index,
-            &neuron,
-        );
+        remove_neuron_from_follower_index(&mut self.topic_follower_index, &neuron);
 
         self.proto.neurons.remove(&neuron_id.to_string());
 
@@ -3734,7 +3536,7 @@ impl Governance {
         voting_neuron_id: &NeuronId,
         vote_of_neuron: Vote,
         function_id: u64,
-        function_followee_index: &BTreeMap<u64, BTreeMap<String, BTreeSet<NeuronId>>>,
+        function_followee_index: &legacy::FollowerIndex,
         neurons: &BTreeMap<String, Neuron>,
         // As of Dec, 2023 (52eec5c), the next parameter is only used to populate Ballots. In
         // particular, this has no impact on how the implications of following are deduced.

--- a/rs/sns/governance/src/lib.rs
+++ b/rs/sns/governance/src/lib.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 
 mod cached_upgrade_steps;
 pub mod canister_control;
+pub(crate) mod follower_index;
 pub mod following;
 pub mod governance;
 pub mod init;


### PR DESCRIPTION
This PR implements a dynamic index for the topic-based follower index relation. The index will be used to implement the new, topic-based following. Note that the neurons themselves store the "follows" relation which is the inverse of "is-followed-by".

This PR also fixes a small mistake in the new API (switching from `uint64` to `int32` indices). This is safe because the API corresponds to a command that has not yet been enabled in production.