### PR TITLE
fix(IDX): use --no-release for build-ic on PRs

### DIFF
--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -39,4 +39,4 @@ if [[ ${#ARGS[@]} -eq 0 ]]; then
     exit 0
 fi
 
-ci/container/build-ic.sh "${ARGS[@]}"
+ci/container/build-ic.sh "${ARGS[@]}" --no-release


### PR DESCRIPTION
This ensures both full build and partial builds in `run-build-ic.sh` are consistent and both use `--no-release`. This does not affect builds on "protected" branches like `master` and releases.