### PR TITLE
fix(IDX): set BUILDBUDDY_LINKS for all jobs

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -55,7 +55,6 @@ runs:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
-          BUILDBUDDY_LINKS: "[CI Job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}
           run: |
 

--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -6,9 +6,6 @@ inputs:
     required: true
     description: |
       The commands to run. Will be evaluated with bash.
-  BUILDBUDDY_LINKS:
-    required: false
-    description: Extra build metadata for buildbuddy
   GPG_PASSPHRASE:
     required: false
     description: "GPG key to encrypt build events. If the key is not set, events won't be uploaded."
@@ -28,6 +25,9 @@ runs:
     # Run the specified commands
     - name: Run bazel commands
       shell: bash
+      env:
+        # Used by the bazel wrapper
+        BUILDBUDDY_LINKS: '[CI Job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
       run: |
         set -euo pipefail
 
@@ -39,8 +39,7 @@ runs:
         PATH="$PWD/.github/actions/bazel/bin:$BAZEL_ACTION_OLDPATH"
         hash -r
 
-        # Some exports used by the bazel wrapper
-        export BUILDBUDDY_LINKS='${{ inputs.BUILDBUDDY_LINKS }}'
+        # Used by the bazel wrapper
         export BAZEL_ACTION_METRICS_OUT='${{ steps.metrics-tmpdir.outputs.dir }}'
 
         ${{ inputs.run }}

--- a/.github/workflows/schedule-rust-bench.yml
+++ b/.github/workflows/schedule-rust-bench.yml
@@ -44,7 +44,6 @@ jobs:
         env:
           RUST_BACKTRACE: "full"
         with:
-          BUILDBUDDY_LINKS: "[CI Job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           run: |
             while IFS= read -r tgt; do
                 bazel run --config=ci "$tgt"


### PR DESCRIPTION
This inlines the `BUILDBUDDY_LINKS` value in the bazel action instead of providing it as an input. This ensure it is used everywhere and simplify the workflow definitions.