### PR TITLE
fix(IDX): upload build events from all workflows

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -11,8 +11,8 @@ inputs:
   SSH_PRIVATE_KEY_BACKUP_POD:
     required: false
   GPG_PASSPHRASE:
-    required: false
-    description: "GPG key to encrypt build events. If the key is not set, events won't be uploaded."
+    required: true
+    description: "GPG key to encrypt build events. Upload can be disabled by explicitly setting the input to an empty string."
 
 runs:
   using: "composite"

--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -10,8 +10,8 @@ inputs:
     required: false
     description: Extra build metadata for buildbuddy
   GPG_PASSPHRASE:
-    required: false
-    description: "GPG key to encrypt build events. If the key is not set, events won't be uploaded."
+    required: true
+    description: "GPG key to encrypt build events. Upload can be disabled by explicitly setting the input to an empty string."
 
 runs:
   using: "composite"

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -154,6 +154,7 @@ jobs:
           BAZEL_COMMAND: test --config=ci --config=macos_ci --test_tag_filters=test_macos
           BAZEL_TARGETS: //rs/... //publish/binaries/...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Purge Bazel Output
         if: always()
         shell: bash

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -87,6 +87,7 @@ jobs:
         uses: ./.github/actions/bazel-test-all/
         env:
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         with:
           BAZEL_COMMAND: >-
             test


### PR DESCRIPTION
This marks the `GPG_PASSPHRASE` as required to ensure it's provided as an input for the `bazel-test-all` action. Upload can be disabled but this now has to be done explicitly by setting `GPG_PASSPHRASE` to an empty string.