### PR TITLE
chore(crypto): CRP-2636 adapt benchmarks to 34 instead 28 nodes

### DIFF
--- a/rs/crypto/benches/idkg.rs
+++ b/rs/crypto/benches/idkg.rs
@@ -43,7 +43,7 @@ criterion_main!(benches);
 criterion_group!(benches, crypto_idkg_benchmarks);
 
 fn crypto_idkg_benchmarks(criterion: &mut Criterion) {
-    let nums_of_nodes = [1, 4, 13, 28, 40];
+    let nums_of_nodes = [1, 4, 13, 34, 40];
     let test_cases = generate_test_cases(&nums_of_nodes);
 
     let rng = &mut ReproducibleRng::new();

--- a/rs/crypto/benches/ni_dkg.rs
+++ b/rs/crypto/benches/ni_dkg.rs
@@ -26,7 +26,7 @@ criterion_group!(benches, crypto_nidkg_benchmarks,);
 
 fn crypto_nidkg_benchmarks(criterion: &mut Criterion) {
     let rng = &mut reproducible_rng();
-    let test_cases = test_cases(&[13, 28, 40]);
+    let test_cases = test_cases(&[13, 34, 40]);
 
     for test_case in test_cases {
         let group = &mut criterion.benchmark_group(test_case.name().to_string());

--- a/rs/crypto/benches/tecdsa.rs
+++ b/rs/crypto/benches/tecdsa.rs
@@ -24,7 +24,7 @@ criterion_main!(benches);
 criterion_group!(benches, crypto_tecdsa_benchmarks);
 
 fn crypto_tecdsa_benchmarks(criterion: &mut Criterion) {
-    let number_of_nodes = [1, 4, 13, 28, 40];
+    let number_of_nodes = [1, 4, 13, 34, 40];
 
     let test_cases = generate_test_cases(&number_of_nodes);
 

--- a/rs/crypto/benches/threshold_sig.rs
+++ b/rs/crypto/benches/threshold_sig.rs
@@ -26,7 +26,7 @@ criterion_main!(benches);
 criterion_group!(
     benches,
     bench_threshold_sig_1_node_threshold_1,
-    bench_threshold_sig_28_nodes_threshold_10,
+    bench_threshold_sig_34_nodes_threshold_12,
     /* CRP-1176
      * bench_threshold_sig_100_nodes_threshold_34, */
 );
@@ -59,15 +59,15 @@ fn bench_threshold_sig_1_node_threshold_1(criterion: &mut Criterion) {
     }
 }
 
-fn bench_threshold_sig_28_nodes_threshold_10(criterion: &mut Criterion) {
+fn bench_threshold_sig_34_nodes_threshold_12(criterion: &mut Criterion) {
     for vault_type in VaultType::iter() {
         let group = &mut criterion.benchmark_group(format!(
-            "crypto_threshold_sig_28_nodes_threshold_10_{vault_type:?}"
+            "crypto_threshold_sig_34_nodes_threshold_12_{vault_type:?}"
         ));
         group.sample_size(25);
         group.measurement_time(Duration::from_secs(7));
         for message_size in [32, 1_000_000] {
-            bench_threshold_sig_n_nodes(group, 28, 10, message_size, vault_type);
+            bench_threshold_sig_n_nodes(group, 34, 12, message_size, vault_type);
         }
     }
 }

--- a/rs/crypto/benches/tschnorr.rs
+++ b/rs/crypto/benches/tschnorr.rs
@@ -19,7 +19,7 @@ criterion_main!(benches);
 criterion_group!(benches, crypto_tschnorr_benchmarks);
 
 fn crypto_tschnorr_benchmarks(criterion: &mut Criterion) {
-    let number_of_nodes = [1, 4, 13, 28, 40];
+    let number_of_nodes = [1, 4, 13, 34, 40];
 
     let test_cases = generate_test_cases(&number_of_nodes);
 


### PR DESCRIPTION
Adapts the crypto benchmarks from 28 nodes to 34 nodes, because all large subnets (Fiduciary, II, SNS) now [have 34 nodes](https://dashboard.internetcomputer.org/subnets?sort=desc-upNodes).