### PR TITLE
refactor(nns): Remove topic_followee_index and USE_STABLE_MEMORY_FOLLOWING_INDEX

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -3080,10 +3080,6 @@ pub struct Governance {
     pub spawning_neurons: Option<bool>,
     #[prost(message, optional, tag = "20")]
     pub making_sns_proposal: Option<governance::MakingSnsProposal>,
-    /// A Structure used during upgrade to store the index of topics for neurons to their followers.
-    /// This is the inverse of what is stored in a Neuron (its followees).
-    #[prost(map = "int32, message", tag = "22")]
-    pub topic_followee_index: ::std::collections::HashMap<i32, governance::FollowersMap>,
     /// Local cache for XDR-related conversion rates (the source of truth is in the CMC canister).
     #[prost(message, optional, tag = "26")]
     pub xdr_conversion_rate: Option<XdrConversionRate>,
@@ -3325,31 +3321,6 @@ pub mod governance {
         pub caller: Option<PrincipalId>,
         #[prost(message, optional, tag = "3")]
         pub proposal: Option<super::Proposal>,
-    }
-    /// A map of followees to their followers.
-    #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]
-    #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct FollowersMap {
-        /// The key is the neuron ID of the followee.
-        #[prost(map = "fixed64, message", tag = "1")]
-        pub followers_map: ::std::collections::HashMap<u64, followers_map::Followers>,
-    }
-    /// Nested message and enum types in `FollowersMap`.
-    pub mod followers_map {
-        use super::*;
-
-        #[derive(
-            candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable,
-        )]
-        #[allow(clippy::derive_partial_eq_without_eq)]
-        #[derive(Clone, PartialEq, ::prost::Message)]
-        pub struct Followers {
-            /// The followers of the neuron with the given ID.
-            /// These values will be non-repeating, and order does not matter.
-            #[prost(message, repeated, tag = "1")]
-            pub followers: Vec<NeuronId>,
-        }
     }
 }
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, comparable::Comparable)]

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,8 +1,8 @@
 benches:
   add_neuron_active_maximum_heap:
     total:
-      instructions: 23774653
-      heap_increase: 1
+      instructions: 23280218
+      heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_maximum_stable:
@@ -37,25 +37,19 @@ benches:
     scopes: {}
   cascading_vote_all_heap:
     total:
-      instructions: 34881822
+      instructions: 46131104
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_heap_neurons_stable_index:
     total:
-      instructions: 49343392
+      instructions: 46131104
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 106655653
-      heap_increase: 0
-      stable_memory_increase: 128
-    scopes: {}
-  cascading_vote_stable_neurons_with_heap_index:
-    total:
-      instructions: 92065255
+      instructions: 108803089
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
@@ -79,7 +73,7 @@ benches:
     scopes: {}
   draw_maturity_from_neurons_fund_heap:
     total:
-      instructions: 7530460
+      instructions: 5801826
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -109,20 +103,20 @@ benches:
     scopes: {}
   list_neurons_by_subaccount_stable:
     total:
-      instructions: 64762990
-      heap_increase: 4
+      instructions: 65158559
+      heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   list_neurons_heap:
     total:
-      instructions: 4697992
-      heap_increase: 8
+      instructions: 4725863
+      heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
     total:
-      instructions: 66159773
-      heap_increase: 5
+      instructions: 66344175
+      heap_increase: 4
       stable_memory_increase: 0
     scopes: {}
   list_proposals:
@@ -181,7 +175,7 @@ benches:
     scopes: {}
   unstake_maturity_of_dissolved_neurons_heap:
     total:
-      instructions: 2644895
+      instructions: 2526970
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
@@ -190,7 +184,7 @@ benches:
         heap_increase: 0
         stable_memory_increase: 0
       unstake_maturity:
-        instructions: 2416125
+        instructions: 2296180
         heap_increase: 0
         stable_memory_increase: 0
   unstake_maturity_of_dissolved_neurons_stable:
@@ -215,19 +209,19 @@ benches:
     scopes: {}
   with_neuron_mut_all_sections_maximum_heap:
     total:
-      instructions: 1483303
+      instructions: 892271
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_maximum_stable:
     total:
-      instructions: 5536655
+      instructions: 5029879
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_typical_heap:
     total:
-      instructions: 247469
+      instructions: 225403
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -239,19 +233,19 @@ benches:
     scopes: {}
   with_neuron_mut_main_section_maximum_heap:
     total:
-      instructions: 1309322
+      instructions: 722379
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_maximum_stable:
     total:
-      instructions: 2955634
+      instructions: 2416827
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_typical_heap:
     total:
-      instructions: 74200
+      instructions: 57487
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -281,14 +281,6 @@ type Followees = record {
   followees : vec NeuronId;
 };
 
-type Followers = record {
-  followers : vec NeuronId;
-};
-
-type FollowersMap = record {
-  followers_map : vec record { nat64; Followers };
-};
-
 type GetNeuronsFundAuditInfoRequest = record {
   nns_proposal_id : opt ProposalId;
 };
@@ -317,7 +309,6 @@ type Governance = record {
   latest_reward_event : opt RewardEvent;
   to_claim_transfers : vec NeuronStakeTransfer;
   short_voting_period_seconds : nat64;
-  topic_followee_index : vec record { int32; FollowersMap };
   proposals : vec record { nat64; ProposalData };
   xdr_conversion_rate : opt XdrConversionRate;
   in_flight_commands : vec record { nat64; NeuronInFlightCommand };

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -278,16 +278,6 @@ type Followees = record {
   followees : vec NeuronId;
 };
 
-type Followers = record {
-  followers : vec NeuronId;
-};
-
-type FollowersMap = record {
-  followers_map : vec record {
-  nat64;
-  Followers;
-} };
-
 type GetNeuronsFundAuditInfoRequest = record {
   nns_proposal_id : opt ProposalId;
 };
@@ -316,7 +306,6 @@ type Governance = record {
   latest_reward_event : opt RewardEvent;
   to_claim_transfers : vec NeuronStakeTransfer;
   short_voting_period_seconds : nat64;
-  topic_followee_index : vec record { int32; FollowersMap };
   proposals : vec record { nat64; ProposalData };
   xdr_conversion_rate : opt XdrConversionRate;
   in_flight_commands : vec record { nat64; NeuronInFlightCommand };

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2281,21 +2281,6 @@ message Governance {
 
   MakingSnsProposal making_sns_proposal = 20;
 
-  // A map of followees to their followers.
-  message FollowersMap {
-    message Followers {
-      // The followers of the neuron with the given ID.
-      // These values will be non-repeating, and order does not matter.
-      repeated ic_nns_common.pb.v1.NeuronId followers = 1;
-    }
-    // The key is the neuron ID of the followee.
-    map<fixed64, Followers> followers_map = 1;
-  }
-
-  // A Structure used during upgrade to store the index of topics for neurons to their followers.
-  // This is the inverse of what is stored in a Neuron (its followees).
-  map<int32, FollowersMap> topic_followee_index = 22;
-
   // Local cache for XDR-related conversion rates (the source of truth is in the CMC canister).
   optional XdrConversionRate xdr_conversion_rate = 26;
 
@@ -2320,6 +2305,10 @@ message Governance {
   // Reserved id for deprecated `genesis_neuron_accounts`
   reserved 24;
   reserved "genesis_neuron_accounts";
+
+  // Reserved id for deprecated `topic_followee_index`
+  reserved 22;
+  reserved "topic_followee_index";
 }
 
 message XdrConversionRate {

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3011,10 +3011,6 @@ pub struct Governance {
     pub spawning_neurons: ::core::option::Option<bool>,
     #[prost(message, optional, tag = "20")]
     pub making_sns_proposal: ::core::option::Option<governance::MakingSnsProposal>,
-    /// A Structure used during upgrade to store the index of topics for neurons to their followers.
-    /// This is the inverse of what is stored in a Neuron (its followees).
-    #[prost(map = "int32, message", tag = "22")]
-    pub topic_followee_index: ::std::collections::HashMap<i32, governance::FollowersMap>,
     /// Local cache for XDR-related conversion rates (the source of truth is in the CMC canister).
     #[prost(message, optional, tag = "26")]
     pub xdr_conversion_rate: ::core::option::Option<XdrConversionRate>,
@@ -3276,39 +3272,6 @@ pub mod governance {
         pub caller: ::core::option::Option<::ic_base_types::PrincipalId>,
         #[prost(message, optional, tag = "3")]
         pub proposal: ::core::option::Option<super::Proposal>,
-    }
-    /// A map of followees to their followers.
-    #[derive(
-        candid::CandidType,
-        candid::Deserialize,
-        serde::Serialize,
-        comparable::Comparable,
-        Clone,
-        PartialEq,
-        ::prost::Message,
-    )]
-    pub struct FollowersMap {
-        /// The key is the neuron ID of the followee.
-        #[prost(map = "fixed64, message", tag = "1")]
-        pub followers_map: ::std::collections::HashMap<u64, followers_map::Followers>,
-    }
-    /// Nested message and enum types in `FollowersMap`.
-    pub mod followers_map {
-        #[derive(
-            candid::CandidType,
-            candid::Deserialize,
-            serde::Serialize,
-            comparable::Comparable,
-            Clone,
-            PartialEq,
-            ::prost::Message,
-        )]
-        pub struct Followers {
-            /// The followers of the neuron with the given ID.
-            /// These values will be non-repeating, and order does not matter.
-            #[prost(message, repeated, tag = "1")]
-            pub followers: ::prost::alloc::vec::Vec<::ic_nns_common::pb::v1::NeuronId>,
-        }
     }
 }
 #[derive(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1669,13 +1669,8 @@ impl Governance {
         // the rest live in heap.
 
         // Note: We do not carry over the RNG seed in new governance, only in restored governance.
-        let (neurons, topic_followee_index, heap_governance_proto, _maybe_rng_seed) =
+        let (neurons, heap_governance_proto, _maybe_rng_seed) =
             split_governance_proto(governance_proto);
-
-        assert!(
-            topic_followee_index.is_empty(),
-            "Topic followee index should be empty when initializing for the first time"
-        );
 
         // Step 3: Final assembly.
         Self {
@@ -1708,7 +1703,7 @@ impl Governance {
         cmc: Arc<dyn CMC>,
         mut randomness: Box<dyn RandomnessGenerator>,
     ) -> Self {
-        let (heap_neurons, topic_followee_map, heap_governance_proto, maybe_rng_seed) =
+        let (heap_neurons, heap_governance_proto, maybe_rng_seed) =
             split_governance_proto(governance_proto);
 
         // Carry over the previous rng seed to avoid race conditions in handling queued ingress
@@ -1719,7 +1714,7 @@ impl Governance {
 
         Self {
             heap_data: heap_governance_proto,
-            neuron_store: NeuronStore::new_restored((heap_neurons, topic_followee_map)),
+            neuron_store: NeuronStore::new_restored(heap_neurons),
             env,
             ledger,
             cmc,
@@ -1737,28 +1732,17 @@ impl Governance {
     /// becomes unusable, so it should only be called in pre_upgrade once.
     pub fn take_heap_proto(&mut self) -> GovernanceProto {
         let neuron_store = std::mem::take(&mut self.neuron_store);
-        let (neurons, heap_topic_followee_index) = neuron_store.take();
+        let neurons = neuron_store.take();
         let heap_governance_proto = std::mem::take(&mut self.heap_data);
         let rng_seed = self.randomness.get_rng_seed();
-        reassemble_governance_proto(
-            neurons,
-            heap_topic_followee_index,
-            heap_governance_proto,
-            rng_seed,
-        )
+        reassemble_governance_proto(neurons, heap_governance_proto, rng_seed)
     }
 
     pub fn __get_state_for_test(&self) -> GovernanceProto {
         let neurons = self.neuron_store.__get_neurons_for_tests();
-        let heap_topic_followee_index = self.neuron_store.clone_topic_followee_index();
         let heap_governance_proto = self.heap_data.clone();
         let rng_seed = self.randomness.get_rng_seed();
-        reassemble_governance_proto(
-            neurons,
-            heap_topic_followee_index,
-            heap_governance_proto,
-            rng_seed,
-        )
+        reassemble_governance_proto(neurons, heap_governance_proto, rng_seed)
     }
 
     pub fn seed_rng(&mut self, seed: [u8; 32]) {
@@ -2068,7 +2052,7 @@ impl Governance {
     /// Neurons that directly follow the `followees` w.r.t. the
     /// topic `NeuronManagement`.
     pub fn get_managed_neuron_ids_for(&self, followees: Vec<NeuronId>) -> Vec<NeuronId> {
-        // Tap into the `topic_followee_index` for followers of level zero neurons.
+        // Tap into the neuron followee index for followers of level zero neurons.
         let mut managed: Vec<NeuronId> = followees.clone();
         for followee in followees {
             managed.extend(
@@ -5857,10 +5841,6 @@ impl Governance {
         caller: &PrincipalId,
         follow_request: &manage_neuron::Follow,
     ) -> Result<(), GovernanceError> {
-        // The implementation of this method is complicated by the
-        // fact that we have to maintain a reverse index of all follow
-        // relationships, i.e., the `topic_followee_index`.
-
         // Find the neuron to modify.
         let (is_neuron_controlled_by_caller, is_caller_authorized_to_vote) =
             self.with_neuron(id, |neuron| {

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -17,10 +17,8 @@ use crate::{
     },
     temporarily_disable_allow_active_neurons_in_stable_memory,
     temporarily_disable_migrate_active_neurons_to_stable_memory,
-    temporarily_disable_stable_memory_following_index,
     temporarily_enable_allow_active_neurons_in_stable_memory,
     temporarily_enable_migrate_active_neurons_to_stable_memory,
-    temporarily_enable_stable_memory_following_index,
     test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
 };
 use canbench_rs::{bench, bench_fn, BenchResult};
@@ -413,24 +411,8 @@ fn make_neuron(
 }
 
 #[bench(raw)]
-fn cascading_vote_stable_neurons_with_heap_index() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_stable_memory_following_index();
-    let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
-
-    cast_vote_cascade_helper(
-        SetUpStrategy::Chain {
-            num_neurons: 151,
-            num_followees: 15,
-        },
-        Topic::NetworkEconomics,
-    )
-}
-
-#[bench(raw)]
 fn cascading_vote_stable_everything() -> BenchResult {
     let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_enable_stable_memory_following_index();
     let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
@@ -445,7 +427,6 @@ fn cascading_vote_stable_everything() -> BenchResult {
 #[bench(raw)]
 fn cascading_vote_all_heap() -> BenchResult {
     let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_stable_memory_following_index();
     let _c = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
@@ -460,7 +441,6 @@ fn cascading_vote_all_heap() -> BenchResult {
 #[bench(raw)]
 fn cascading_vote_heap_neurons_stable_index() -> BenchResult {
     let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_enable_stable_memory_following_index();
     let _c = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
@@ -475,7 +455,6 @@ fn cascading_vote_heap_neurons_stable_index() -> BenchResult {
 #[bench(raw)]
 fn single_vote_all_stable() -> BenchResult {
     let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_enable_stable_memory_following_index();
     let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
@@ -487,7 +466,6 @@ fn single_vote_all_stable() -> BenchResult {
 #[bench(raw)]
 fn centralized_following_all_stable() -> BenchResult {
     let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_enable_stable_memory_following_index();
     let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(

--- a/rs/nns/governance/src/heap_governance_data.rs
+++ b/rs/nns/governance/src/heap_governance_data.rs
@@ -1,5 +1,5 @@
 use crate::pb::v1::{
-    governance::{FollowersMap, GovernanceCachedMetrics, MakingSnsProposal, NeuronInFlightCommand},
+    governance::{GovernanceCachedMetrics, MakingSnsProposal, NeuronInFlightCommand},
     neuron::Followees,
     Governance as GovernanceProto, MonthlyNodeProviderRewards, NetworkEconomics, Neuron,
     NeuronStakeTransfer, NodeProvider, ProposalData, RestoreAgingSummary, RewardEvent,
@@ -94,12 +94,7 @@ fn vec_to_array(v: Vec<u8>) -> Result<[u8; 32], String> {
 #[allow(clippy::type_complexity)]
 pub fn split_governance_proto(
     governance_proto: GovernanceProto,
-) -> (
-    BTreeMap<u64, Neuron>,
-    HashMap<i32, FollowersMap>,
-    HeapGovernanceData,
-    Option<[u8; 32]>,
-) {
+) -> (BTreeMap<u64, Neuron>, HeapGovernanceData, Option<[u8; 32]>) {
     // DO NOT USE THE .. CATCH-ALL SYNTAX HERE.
     // OTHERWISE, YOU WILL ALMOST CERTAINLY EXPERIENCE
     //   **DATA LOSS**
@@ -124,7 +119,6 @@ pub fn split_governance_proto(
         maturity_modulation_last_updated_at_timestamp_seconds,
         spawning_neurons,
         making_sns_proposal,
-        topic_followee_index,
         xdr_conversion_rate,
         restore_aging_summary,
         rng_seed,
@@ -147,7 +141,6 @@ pub fn split_governance_proto(
 
     (
         neurons,
-        topic_followee_index,
         HeapGovernanceData {
             proposals,
             to_claim_transfers,
@@ -177,7 +170,6 @@ pub fn split_governance_proto(
 /// it can be serialized into UPGRADES_MEMORY.
 pub fn reassemble_governance_proto(
     neurons: BTreeMap<u64, Neuron>,
-    topic_followee_index: HashMap<i32, FollowersMap>,
     heap_governance_proto: HeapGovernanceData,
     rng_seed: Option<[u8; 32]>,
 ) -> GovernanceProto {
@@ -231,7 +223,6 @@ pub fn reassemble_governance_proto(
         maturity_modulation_last_updated_at_timestamp_seconds,
         spawning_neurons,
         making_sns_proposal,
-        topic_followee_index,
         xdr_conversion_rate: Some(xdr_conversion_rate),
         restore_aging_summary,
         rng_seed: rng_seed.map(|seed| seed.to_vec()),
@@ -242,9 +233,8 @@ pub fn reassemble_governance_proto(
 mod tests {
     use super::*;
 
-    use crate::pb::v1::{governance::followers_map::Followers, Neuron, ProposalData};
+    use crate::pb::v1::{Neuron, ProposalData};
 
-    use ic_nns_common::pb::v1::NeuronId;
     use maplit::{btreemap, hashmap};
 
     // The members are chosen to be the simplest form that's not their default().
@@ -272,15 +262,6 @@ mod tests {
             maturity_modulation_last_updated_at_timestamp_seconds: Some(7),
             spawning_neurons: Some(true),
             making_sns_proposal: Some(MakingSnsProposal::default()),
-            topic_followee_index: hashmap! {
-                1 => FollowersMap {
-                    followers_map: hashmap! {
-                        2 => Followers {
-                            followers: vec![NeuronId { id: 3 }],
-                        },
-                    },
-                }
-            },
             xdr_conversion_rate: Some(XdrConversionRatePb {
                 timestamp_seconds: Some(1),
                 xdr_permyriad_per_icp: Some(50_000),
@@ -294,15 +275,11 @@ mod tests {
     fn split_and_reassemble_equal() {
         let governance_proto = simple_governance_proto();
 
-        let (heap_neurons, topic_followee_index, heap_governance_data, rng_seed) =
+        let (heap_neurons, heap_governance_data, rng_seed) =
             split_governance_proto(governance_proto.clone());
 
-        let reassembled_governance_proto = reassemble_governance_proto(
-            heap_neurons,
-            topic_followee_index,
-            heap_governance_data,
-            rng_seed,
-        );
+        let reassembled_governance_proto =
+            reassemble_governance_proto(heap_neurons, heap_governance_data, rng_seed);
 
         assert_eq!(reassembled_governance_proto, governance_proto);
     }
@@ -314,14 +291,10 @@ mod tests {
             ..simple_governance_proto()
         };
 
-        let (heap_neurons, topic_followee_index, heap_governance_data, rng_seed) =
+        let (heap_neurons, heap_governance_data, rng_seed) =
             split_governance_proto(governance_proto.clone());
-        let reassembled_governance_proto = reassemble_governance_proto(
-            heap_neurons,
-            topic_followee_index,
-            heap_governance_data,
-            rng_seed,
-        );
+        let reassembled_governance_proto =
+            reassemble_governance_proto(heap_neurons, heap_governance_data, rng_seed);
 
         assert_eq!(
             reassembled_governance_proto,
@@ -339,7 +312,7 @@ mod tests {
             ..GovernanceProto::default()
         };
         // split_governance_proto should return a HeapGovernanceData where the neuron_management_voting_period_seconds is 0 when given a default input
-        let (_, _, heap_governance_proto, _) = split_governance_proto(governance_proto);
+        let (_, heap_governance_proto, _) = split_governance_proto(governance_proto);
         assert_eq!(
             heap_governance_proto.neuron_management_voting_period_seconds,
             48 * 60 * 60

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -205,8 +205,6 @@ thread_local! {
 
     static ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
 
-    static USE_STABLE_MEMORY_FOLLOWING_INDEX: Cell<bool> = const { Cell::new(true) };
-
     static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
 }
 
@@ -263,22 +261,6 @@ pub fn temporarily_enable_allow_active_neurons_in_stable_memory() -> Temporary {
 #[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_allow_active_neurons_in_stable_memory() -> Temporary {
     Temporary::new(&ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY, false)
-}
-
-pub fn use_stable_memory_following_index() -> bool {
-    USE_STABLE_MEMORY_FOLLOWING_INDEX.with(|ok| ok.get())
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_enable_stable_memory_following_index() -> Temporary {
-    Temporary::new(&USE_STABLE_MEMORY_FOLLOWING_INDEX, true)
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_disable_stable_memory_following_index() -> Temporary {
-    Temporary::new(&USE_STABLE_MEMORY_FOLLOWING_INDEX, false)
 }
 
 pub fn migrate_active_neurons_to_stable_memory() -> bool {

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -5,25 +5,21 @@ use crate::{
     neuron::types::Neuron,
     neurons_fund::neurons_fund_neuron::pick_most_important_hotkeys,
     pb::v1::{
-        governance::{followers_map::Followers, FollowersMap},
-        governance_error::ErrorType,
-        GovernanceError, Neuron as NeuronProto, Topic, VotingPowerEconomics,
+        governance_error::ErrorType, GovernanceError, Neuron as NeuronProto, Topic,
+        VotingPowerEconomics,
     },
     storage::{
-        neuron_indexes::{CorruptedNeuronIndexes, NeuronIndex},
-        neurons::NeuronSections,
+        neuron_indexes::CorruptedNeuronIndexes, neurons::NeuronSections,
         with_stable_neuron_indexes, with_stable_neuron_indexes_mut, with_stable_neuron_store,
         with_stable_neuron_store_mut,
     },
-    use_stable_memory_following_index, Clock, IcClock,
-    CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS,
+    Clock, IcClock, CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS,
 };
 use dyn_clone::DynClone;
 use ic_base_types::PrincipalId;
 use ic_cdk::println;
 use ic_nervous_system_governance::index::{
-    neuron_following::{HeapNeuronFollowingIndex, NeuronFollowingIndex},
-    neuron_principal::NeuronPrincipalIndex,
+    neuron_following::NeuronFollowingIndex, neuron_principal::NeuronPrincipalIndex,
 };
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use icp_ledger::{AccountIdentifier, Subaccount};
@@ -225,55 +221,6 @@ enum StorageLocation {
     Stable,
 }
 
-pub type NeuronStoreState = (BTreeMap<u64, NeuronProto>, HashMap<i32, FollowersMap>);
-
-fn proto_to_heap_topic_followee_index(
-    proto: HashMap<i32, FollowersMap>,
-) -> HeapNeuronFollowingIndex<NeuronId, Topic> {
-    let map = proto
-        .into_iter()
-        .map(|(topic_i32, followers_map)| {
-            // The potential panic is OK to be called in post_upgrade.
-            let topic = Topic::try_from(topic_i32).expect("Invalid topic");
-
-            let followers_map = followers_map
-                .followers_map
-                .into_iter()
-                .map(|(neuron_id, followers)| {
-                    let followers = followers.followers.into_iter().collect();
-                    (NeuronId { id: neuron_id }, followers)
-                })
-                .collect();
-            (topic, followers_map)
-        })
-        .collect();
-    HeapNeuronFollowingIndex::new(map)
-}
-
-fn heap_topic_followee_index_to_proto(
-    heap: HeapNeuronFollowingIndex<NeuronId, Topic>,
-) -> HashMap<i32, FollowersMap> {
-    heap.into_inner()
-        .into_iter()
-        .map(|(topic, followers_map)| {
-            let topic_i32 = topic as i32;
-            let followers_map = followers_map
-                .into_iter()
-                .map(|(followee, followers)| {
-                    let followers = Followers {
-                        followers: followers.into_iter().collect(),
-                    };
-                    (followee.id, followers)
-                })
-                .collect();
-
-            let followers_map = FollowersMap { followers_map };
-
-            (topic_i32, followers_map)
-        })
-        .collect()
-}
-
 /// This struct stores and provides access to all neurons within NNS Governance, which can live
 /// in either heap memory or stable memory.
 #[cfg_attr(test, derive(Clone, Debug))]
@@ -306,15 +253,6 @@ pub struct NeuronStore {
     ///   neurons must have maturity.
     heap_neurons: BTreeMap<u64, Neuron>,
 
-    /// Cached data structure that (for each topic) maps a followee to
-    /// the set of followers. This is the inverse of the mapping from
-    /// neuron (follower) to followees, in the neurons. This is a
-    /// cached index and will be removed and recreated when the state
-    /// is saved and restored.
-    ///
-    /// (Topic, Followee) -> set of followers.
-    topic_followee_index: HeapNeuronFollowingIndex<NeuronId, Topic>,
-
     // In non-test builds, Box would suffice. However, in test, the containing struct (to wit,
     // NeuronStore) implements additional traits. Therefore, more elaborate wrapping is needed.
     clock: Box<dyn PracticalClock>,
@@ -327,9 +265,6 @@ pub struct NeuronStore {
     /// mode of operation for the NeuronStore. Once all neurons are in stable memory, this will be
     /// removed.
     migrate_active_neurons_to_stable_memory: bool,
-
-    // Temporary flag to determine which following index to use
-    use_stable_following_index: bool,
 }
 
 /// Does not use clock, but other than that, behaves as you would expect.
@@ -340,14 +275,12 @@ impl PartialEq for NeuronStore {
     fn eq(&self, other: &Self) -> bool {
         let Self {
             heap_neurons,
-            topic_followee_index,
             clock: _,
             allow_active_neurons_in_stable_memory: _,
-            use_stable_following_index: _,
             migrate_active_neurons_to_stable_memory: _,
         } = self;
 
-        *heap_neurons == other.heap_neurons && *topic_followee_index == other.topic_followee_index
+        *heap_neurons == other.heap_neurons
     }
 }
 
@@ -355,10 +288,8 @@ impl Default for NeuronStore {
     fn default() -> Self {
         Self {
             heap_neurons: BTreeMap::new(),
-            topic_followee_index: HeapNeuronFollowingIndex::new(BTreeMap::new()),
             clock: Box::new(IcClock::new()),
             allow_active_neurons_in_stable_memory: false,
-            use_stable_following_index: false,
             migrate_active_neurons_to_stable_memory: false,
         }
     }
@@ -366,16 +297,14 @@ impl Default for NeuronStore {
 
 impl NeuronStore {
     // Initializes NeuronStore for the first time assuming no persisted data has been prepared (e.g.
-    // data in stable storage and those persisted through serialization/deserialization like
-    // topic_followee_index). If restoring after an upgrade, call NeuronStore::new_restored instead.
+    // data in stable storage). If restoring after an upgrade, call NeuronStore::new_restored
+    // instead.
     pub fn new(neurons: BTreeMap<u64, Neuron>) -> Self {
         // Initializes a neuron store with no neurons.
         let mut neuron_store = Self {
             heap_neurons: BTreeMap::new(),
-            topic_followee_index: HeapNeuronFollowingIndex::new(BTreeMap::new()),
             clock: Box::new(IcClock::new()),
             allow_active_neurons_in_stable_memory: allow_active_neurons_in_stable_memory(),
-            use_stable_following_index: use_stable_memory_following_index(),
             migrate_active_neurons_to_stable_memory: migrate_active_neurons_to_stable_memory(),
         };
 
@@ -394,34 +323,26 @@ impl NeuronStore {
     }
 
     // Restores NeuronStore after an upgrade, assuming data are already in the stable storage (e.g.
-    // neuron indexes and inactive neurons) and persisted data are already calculated (e.g.
-    // topic_followee_index).
-    pub fn new_restored(state: NeuronStoreState) -> Self {
+    // neuron indexes and inactive neurons).
+    pub fn new_restored(neurons: BTreeMap<u64, NeuronProto>) -> Self {
         let clock = Box::new(IcClock::new());
-        let (neurons, topic_followee_index) = state;
-
         Self {
             heap_neurons: neurons
                 .into_iter()
                 .map(|(id, proto)| (id, Neuron::try_from(proto).unwrap()))
                 .collect(),
-            topic_followee_index: proto_to_heap_topic_followee_index(topic_followee_index),
             clock,
             allow_active_neurons_in_stable_memory: allow_active_neurons_in_stable_memory(),
-            use_stable_following_index: use_stable_memory_following_index(),
             migrate_active_neurons_to_stable_memory: migrate_active_neurons_to_stable_memory(),
         }
     }
 
     /// Takes the neuron store state which should be persisted through upgrades.
-    pub fn take(self) -> NeuronStoreState {
-        (
-            self.heap_neurons
-                .into_iter()
-                .map(|(id, neuron)| (id, NeuronProto::from(neuron.clone())))
-                .collect(),
-            heap_topic_followee_index_to_proto(self.topic_followee_index),
-        )
+    pub fn take(self) -> BTreeMap<u64, NeuronProto> {
+        self.heap_neurons
+            .into_iter()
+            .map(|(id, neuron)| (id, NeuronProto::from(neuron)))
+            .collect()
     }
 
     /// If there is a bug (related to lock acquisition), this could return u64::MAX.
@@ -479,10 +400,6 @@ impl NeuronStore {
 
         stable_neurons.extend(heap_neurons);
         stable_neurons
-    }
-
-    pub fn clone_topic_followee_index(&self) -> HashMap<i32, FollowersMap> {
-        heap_topic_followee_index_to_proto(self.topic_followee_index.clone())
     }
 
     /// Returns if store contains a Neuron by id
@@ -558,18 +475,6 @@ impl NeuronStore {
                 LOG_PREFIX, error
             );
         }
-
-        if let Err(defects) = self.topic_followee_index.add_neuron(neuron) {
-            println!(
-                "{}WARNING: issues found when adding neuron to indexes, possibly because \
-                 neuron indexes are out-of-sync with neurons: {}",
-                LOG_PREFIX,
-                NeuronStoreError::CorruptedNeuronIndexes(CorruptedNeuronIndexes {
-                    neuron_id: neuron.id(),
-                    indexes: vec![defects],
-                })
-            );
-        };
     }
 
     /// Remove a Neuron by id
@@ -619,7 +524,6 @@ impl NeuronStore {
     }
 
     fn remove_neuron_from_indexes(&mut self, neuron: &Neuron) {
-        let neuron_id = neuron.id();
         if let Err(error) = with_stable_neuron_indexes_mut(|indexes| indexes.remove_neuron(neuron))
         {
             println!(
@@ -628,18 +532,6 @@ impl NeuronStore {
                 LOG_PREFIX, error
             );
         }
-
-        if let Err(defects) = self.topic_followee_index.remove_neuron(neuron) {
-            println!(
-                "{}WARNING: issues found when adding neuron to indexes, possibly because \
-                 neuron indexes are out-of-sync with neurons: {}",
-                LOG_PREFIX,
-                NeuronStoreError::CorruptedNeuronIndexes(CorruptedNeuronIndexes {
-                    neuron_id,
-                    indexes: vec![defects],
-                })
-            );
-        };
     }
 
     // Loads a neuron from either heap or stable storage and returns its primary storage location,
@@ -1108,21 +1000,6 @@ impl NeuronStore {
                 LOG_PREFIX, error
             );
         }
-
-        if let Err(defects) = self
-            .topic_followee_index
-            .update_neuron(old_neuron, new_neuron)
-        {
-            println!(
-                "{}WARNING: issues found when updating neuron indexes, possibly because of \
-                 neuron indexes are out-of-sync with neurons: {}",
-                LOG_PREFIX,
-                NeuronStoreError::CorruptedNeuronIndexes(CorruptedNeuronIndexes {
-                    neuron_id: old_neuron.id(),
-                    indexes: defects,
-                })
-            );
-        };
     }
 
     /// Execute a function with a reference to a neuron, returning the result of the function,
@@ -1244,16 +1121,11 @@ impl NeuronStore {
         followee: NeuronId,
         topic: Topic,
     ) -> Vec<NeuronId> {
-        if self.use_stable_following_index {
-            with_stable_neuron_indexes(|indexes| {
-                indexes
-                    .following()
-                    .get_followers_by_followee_and_category(&followee, topic)
-            })
-        } else {
-            self.topic_followee_index
+        with_stable_neuron_indexes(|indexes| {
+            indexes
+                .following()
                 .get_followers_by_followee_and_category(&followee, topic)
-        }
+        })
     }
 
     // Gets all neuron ids associated with the given principal id (hot-key or controller).

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -14,7 +14,6 @@ use crate::{
     temporarily_disable_migrate_active_neurons_to_stable_memory,
     temporarily_enable_allow_active_neurons_in_stable_memory,
     temporarily_enable_migrate_active_neurons_to_stable_memory,
-    temporarily_enable_stable_memory_following_index,
 };
 use canbench_rs::{bench, bench_fn, BenchResult};
 use ic_nervous_system_common::E8;
@@ -331,7 +330,6 @@ fn with_neuron_mut_main_section_maximum_stable() -> BenchResult {
 #[bench(raw)]
 fn update_recent_ballots_stable_memory() -> BenchResult {
     let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_enable_stable_memory_following_index();
     let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -284,9 +284,8 @@ fn test_neuron_store_new_then_restore() {
     );
 
     // Step 3: take its state and restore from it.
-    let (heap_neurons, heap_topic_followee_index) = neuron_store.take();
-    let restored_neuron_store =
-        NeuronStore::new_restored((heap_neurons, heap_topic_followee_index));
+    let heap_neurons = neuron_store.take();
+    let restored_neuron_store = NeuronStore::new_restored(heap_neurons);
 
     // Step 4: verify again the neurons and followee index are in the restored neuron store.
     for neuron in neurons.values() {

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -2675,11 +2675,6 @@ impl From<pb_api::Governance> for pb::Governance {
                 .maturity_modulation_last_updated_at_timestamp_seconds,
             spawning_neurons: item.spawning_neurons,
             making_sns_proposal: item.making_sns_proposal.map(|x| x.into()),
-            topic_followee_index: item
-                .topic_followee_index
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
             xdr_conversion_rate: item.xdr_conversion_rate.map(|x| x.into()),
             restore_aging_summary: item.restore_aging_summary.map(|x| x.into()),
             // This is not intended to be initialized from outside of canister.
@@ -2981,48 +2976,6 @@ impl From<pb_api::governance::MakingSnsProposal> for pb::governance::MakingSnsPr
             proposer_id: item.proposer_id,
             caller: item.caller,
             proposal: item.proposal.map(|x| x.into()),
-        }
-    }
-}
-
-impl From<pb::governance::FollowersMap> for pb_api::governance::FollowersMap {
-    fn from(item: pb::governance::FollowersMap) -> Self {
-        Self {
-            followers_map: item
-                .followers_map
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
-        }
-    }
-}
-impl From<pb_api::governance::FollowersMap> for pb::governance::FollowersMap {
-    fn from(item: pb_api::governance::FollowersMap) -> Self {
-        Self {
-            followers_map: item
-                .followers_map
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
-        }
-    }
-}
-
-impl From<pb::governance::followers_map::Followers>
-    for pb_api::governance::followers_map::Followers
-{
-    fn from(item: pb::governance::followers_map::Followers) -> Self {
-        Self {
-            followers: item.followers,
-        }
-    }
-}
-impl From<pb_api::governance::followers_map::Followers>
-    for pb::governance::followers_map::Followers
-{
-    fn from(item: pb_api::governance::followers_map::Followers) -> Self {
-        Self {
-            followers: item.followers,
         }
     }
 }

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -20,6 +20,9 @@ on the process that this file is part of, see
 
 ## Removed
 
+* The `topic_followee_index` in the heap is removed, along with the flag
+  `USE_STABLE_MEMORY_FOLLOWING_INDEX` that was set to true in the proposal 135063.
+
 ## Fixed
 
 ## Security


### PR DESCRIPTION
# Why

The `USE_STABLE_MEMORY_FOLLOWING_INDEX` flag has been set to true on Feb. 3, released with the proposal 135063. In this PR, the feature flag is removed while being replaced to `true`, and because of that, the `topic_followee_index` is no longer read, and it is also cleaned up in this PR.

# What

* `USE_STABLE_MEMORY_FOLLOWING_INDEX` is replaced with `true`, and code paths simplified (removing dead code, etc.)
* Benchmarks using `temporarily_disable_stable_memory_following_index` are removed
* Calls to `temporarily_enable_stable_memory_following_index` are removed since it's no longer necessary
* The init argument no longer has `topic_followee_index`, and the candid files are updated accordingly
* Remove `topic_followee_index` from the canister state, along with code to backup, restore, and maintain it (e.g. updating the index when there are changes to the neurons
* Update benchmarks (all improvements, mostly because the code to maintain the index is removed)

# Why it's safe

Here are the mainly reasons why it's safe to remove it from the API level and the state:

* On the API level, the `topic_followee_index` should not have been provided within the init argument in the first place. Any attempt to provide a `topic_followee_index` will likely cause some inconsistency. Also, the changes should not affect mainnet because init is not expected to be called there.
* As part of the state, protobuf serialization/deserialization still works when a field is removed. 