### PR TITLE
test(IDX): add 10 extra minutes to the NODE_REGISTRATION_TIMEOUT

### DIFF
--- a/rs/tests/nested/registration.rs
+++ b/rs/tests/nested/registration.rs
@@ -6,8 +6,8 @@ fn main() -> Result<()> {
     SystemTestGroup::new()
         .with_setup(nested::config)
         .add_test(systest!(nested::registration))
-        .with_timeout_per_test(Duration::from_secs(30 * 60))
-        .with_overall_timeout(Duration::from_secs(40 * 60))
+        .with_timeout_per_test(Duration::from_secs(40 * 60))
+        .with_overall_timeout(Duration::from_secs(50 * 60))
         .execute_from_args()?;
 
     Ok(())

--- a/rs/tests/nested/registration.rs
+++ b/rs/tests/nested/registration.rs
@@ -6,8 +6,8 @@ fn main() -> Result<()> {
     SystemTestGroup::new()
         .with_setup(nested::config)
         .add_test(systest!(nested::registration))
-        .with_timeout_per_test(Duration::from_secs(20 * 60))
-        .with_overall_timeout(Duration::from_secs(30 * 60))
+        .with_timeout_per_test(Duration::from_secs(30 * 60))
+        .with_overall_timeout(Duration::from_secs(40 * 60))
         .execute_from_args()?;
 
     Ok(())

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -24,7 +24,7 @@ use util::{check_hostos_version, elect_hostos_version, update_nodes_hostos_versi
 
 const HOST_VM_NAME: &str = "host-1";
 
-const NODE_REGISTRATION_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const NODE_REGISTRATION_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 const NODE_REGISTRATION_BACKOFF: Duration = Duration::from_secs(5);
 
 /// Prepare the environment for nested tests.

--- a/rs/tests/nested/upgrade.rs
+++ b/rs/tests/nested/upgrade.rs
@@ -6,8 +6,8 @@ fn main() -> Result<()> {
     SystemTestGroup::new()
         .with_setup(nested::config)
         .add_test(systest!(nested::upgrade))
-        .with_timeout_per_test(Duration::from_secs(30 * 60))
-        .with_overall_timeout(Duration::from_secs(40 * 60))
+        .with_timeout_per_test(Duration::from_secs(40 * 60))
+        .with_overall_timeout(Duration::from_secs(50 * 60))
         .execute_from_args()?;
 
     Ok(())


### PR DESCRIPTION
The nested system-tests (`//rs/tests/nested:...`) most often fail because [waiting for the guestOS to join the subnet](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/tests/nested/src/lib.rs?L109-L118) times out after 10 minutes. So we try fixing this by increasing the timeout to 20 minutes.

Schedule Hourly: https://github.com/dfinity/ic/actions/runs/14170985617.