### PR TITLE
fix: Use default value for SnapshotSource instead of failing. 

### DIFF
--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -2882,7 +2882,7 @@ impl TryFrom<pb_canister_snapshot_bits::CanisterSnapshotBits> for CanisterSnapsh
             OnLowWasmMemoryHookStatus::try_from(on_low_wasm_memory_hook_status).unwrap_or_default();
         let source =
             pb_canister_snapshot_bits::SnapshotSource::try_from(item.source).unwrap_or_default();
-        let source = SnapshotSource::try_from(source)?;
+        let source = SnapshotSource::try_from(source).unwrap_or_default();
         Ok(Self {
             snapshot_id: SnapshotId::from((canister_id, item.snapshot_id)),
             canister_id,

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -3780,8 +3780,9 @@ impl<'a> Payload<'a> for ReadCanisterSnapshotMetadataArgs {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Debug, CandidType, Deserialize, EnumIter)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, CandidType, Default, Deserialize, EnumIter)]
 pub enum SnapshotSource {
+    #[default]
     TakenFromCanister,
     UploadedManually,
 }
@@ -3807,10 +3808,7 @@ impl TryFrom<pb_canister_snapshot_bits::SnapshotSource> for SnapshotSource {
             pb_canister_snapshot_bits::SnapshotSource::Unspecified => {
                 Err(ProxyDecodeError::ValueOutOfRange {
                     typ: "SnapshotSource",
-                    err: format!(
-                        "Unexpected value of status of on low wasm memory hook: {:?}",
-                        value
-                    ),
+                    err: format!("Unexpected value of SnapshotSource: {:?}", value),
                 })
             }
             pb_canister_snapshot_bits::SnapshotSource::TakenFromCanister => {


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/4431/ introduced a bug when converting `pb::CanisterSnapshotBits` to `CanisterSnapshotBits`. This PR fixes that. `//rs/ledger_suite/icrc1:icrc_ledger_suite_integration_golden_state_upgrade_downgrade_test_u256` succeeds now. 

Upgrade/downgrade test in a follow-up. 