### PR TITLE
test(consensus): add https outcalls compliance tests for response headers

### DIFF
--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -52,11 +52,16 @@ use std::{collections::HashSet, convert::TryFrom};
 const MAX_REQUEST_BYTES_LIMIT: usize = 2_000_000;
 const MAX_MAX_RESPONSE_BYTES: usize = 2_000_000;
 const DEFAULT_MAX_RESPONSE_BYTES: u64 = 2_000_000;
-const MAX_CANISTER_HTTP_URL_SIZE: usize = 8192;
-const MAX_HEADER_NAME_LENGTH: usize = 8192;
-const MAX_HEADER_VALUE_LENGTH: usize = 8192;
+const MAX_CANISTER_HTTP_URL_SIZE: usize = 8 * 1024;
+const MAX_HEADER_NAME_LENGTH: usize = 8 * 1024;
+const MAX_HEADER_VALUE_LENGTH: usize = 8 * 1024;
+const TOTAL_HEADER_NAME_AND_VALUE_LENGTH: usize = 48 * 1024;
 const HTTP_HEADERS_MAX_NUMBER: usize = 64;
 const RESPONSE_OVERHEAD: u64 = 256;
+
+// httpbin-rs returns 5 headers in addition to the requested headers:
+// content-type, access-control-allow-origin, access-control-allow-credentials, date, content-length.
+const HTTPBIN_OVERHEAD_RESPONSE_HEADERS: usize = 5;
 
 struct Handlers<'a> {
     subnet_size: usize,
@@ -116,11 +121,21 @@ fn main() -> Result<()> {
                 .add_test(systest!(test_request_header_name_and_value_within_limits))
                 .add_test(systest!(test_request_header_name_too_long))
                 .add_test(systest!(test_request_header_value_too_long))
+                .add_test(systest!(test_response_header_name_within_limit))
+                .add_test(systest!(test_response_header_name_over_limit))
+                .add_test(systest!(test_response_header_value_within_limit))
+                .add_test(systest!(test_response_header_value_over_limit))
                 .add_test(systest!(
                     test_request_header_total_size_within_the_48_kib_limit
                 ))
                 .add_test(systest!(
                     test_request_header_total_size_over_the_48_kib_limit
+                ))
+                .add_test(systest!(
+                    test_response_header_total_size_within_the_48_kib_limit
+                ))
+                .add_test(systest!(
+                    test_response_header_total_size_over_the_48_kib_limit
                 ))
                 .add_test(systest!(test_non_existing_transform_function))
                 .add_test(systest!(test_post_request))
@@ -1113,11 +1128,11 @@ fn test_request_header_total_size_within_the_48_kib_limit(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    let header_count = 3;
+    // Header count is 3, as our current total limit is 48KiB and the tuple of header name and value is 16KiB.
+    let header_count =
+        TOTAL_HEADER_NAME_AND_VALUE_LENGTH / (MAX_HEADER_NAME_LENGTH + MAX_HEADER_VALUE_LENGTH);
     let mut headers = vec![];
 
-    // Each header is 8192 + 8192 = 16KiB bytes long
-    // All three headers will be 48KiB bytes, which is exactly the limit.
     for i in 0..header_count {
         headers.push(HttpHeader {
             name: format!("{}", i).repeat(MAX_HEADER_NAME_LENGTH),
@@ -1150,11 +1165,11 @@ fn test_request_header_total_size_over_the_48_kib_limit(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    let header_count = 3;
+    // Header count is 3, as our current total limit is 48KiB and the tuple of header name and value is 16KiB.
+    let header_count =
+        TOTAL_HEADER_NAME_AND_VALUE_LENGTH / (MAX_HEADER_NAME_LENGTH + MAX_HEADER_VALUE_LENGTH);
     let mut headers = vec![];
 
-    // Each header is 8192 + 8192 = 16KiB bytes long
-    // All three headers will be 48KiB bytes, which is exactly the limit.
     for i in 0..header_count {
         headers.push(HttpHeader {
             name: format!("{}", i).repeat(MAX_HEADER_NAME_LENGTH),
@@ -1188,6 +1203,89 @@ fn test_request_header_total_size_over_the_48_kib_limit(env: TestEnv) {
         response,
         Err(RejectResponse {
             reject_code: RejectCode::CanisterReject,
+            ..
+        })
+    );
+}
+
+fn test_response_header_total_size_within_the_48_kib_limit(env: TestEnv) {
+    let handlers = Handlers::new(&env);
+    let webserver_ipv6 = get_universal_vm_address(&env);
+
+    // We use the /large_response_headers_size endpoint which should return headers
+    // with the specified value length, after accounting also for the
+    // overhead headers (e.g. content-length, date, etc.)
+    let url = format!(
+        "https://[{}]:20443/large_response_total_header_size/{}/{}",
+        webserver_ipv6, MAX_HEADER_NAME_LENGTH, TOTAL_HEADER_NAME_AND_VALUE_LENGTH,
+    );
+
+    let response = block_on(submit_outcall(
+        &handlers,
+        RemoteHttpRequest {
+            request: UnvalidatedCanisterHttpRequestArgs {
+                url,
+                headers: vec![],
+                method: HttpMethod::GET,
+                body: None,
+                transform: None,
+                max_response_bytes: Some(DEFAULT_MAX_RESPONSE_BYTES),
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(&response, Ok(RemoteHttpResponse { status: 200, .. }));
+
+    // Compute exactly the size of the response headers to account also for overhead.
+    let total_header_size: usize = response
+        .unwrap()
+        .headers
+        .iter()
+        .map(|(name, value)| name.len() + value.len())
+        .sum();
+
+    // Ensure that the successful response contains the expected response headers.
+    assert!(
+        total_header_size <= 48 * 1024,
+        "Total header size ({} bytes) exceeds 48KiB limit",
+        total_header_size
+    );
+}
+
+fn test_response_header_total_size_over_the_48_kib_limit(env: TestEnv) {
+    let handlers = Handlers::new(&env);
+    let webserver_ipv6 = get_universal_vm_address(&env);
+
+    // We use the /large_response_total_header_size endpoint which should return headers
+    // with the specified value length, after accounting also for the
+    // overhead headers (e.g. content-length, date, etc.)
+    let url = format!(
+        "https://[{}]:20443/large_response_total_header_size/{}/{}",
+        webserver_ipv6,
+        MAX_HEADER_NAME_LENGTH,
+        TOTAL_HEADER_NAME_AND_VALUE_LENGTH + 1,
+    );
+
+    let response = block_on(submit_outcall(
+        &handlers,
+        RemoteHttpRequest {
+            request: UnvalidatedCanisterHttpRequestArgs {
+                url,
+                headers: vec![],
+                method: HttpMethod::GET,
+                body: None,
+                transform: None,
+                max_response_bytes: Some(DEFAULT_MAX_RESPONSE_BYTES),
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(
+        &response,
+        Err(RejectResponse {
+            reject_code: RejectCode::SysFatal,
             ..
         })
     );
@@ -1288,6 +1386,132 @@ fn test_request_header_value_too_long(env: TestEnv) {
         response,
         Err(RejectResponse {
             reject_code: RejectCode::CanisterReject,
+            ..
+        })
+    );
+}
+
+fn test_response_header_name_within_limit(env: TestEnv) {
+    let handlers = Handlers::new(&env);
+    let webserver_ipv6 = get_universal_vm_address(&env);
+
+    let url = format!(
+        "https://[{}]:20443/long_response_header_name/{}",
+        webserver_ipv6, MAX_HEADER_NAME_LENGTH,
+    );
+
+    let response = block_on(submit_outcall(
+        &handlers,
+        RemoteHttpRequest {
+            request: UnvalidatedCanisterHttpRequestArgs {
+                url,
+                headers: vec![],
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: None,
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(&response, Ok(RemoteHttpResponse { status: 200, .. }));
+}
+
+fn test_response_header_name_over_limit(env: TestEnv) {
+    let handlers = Handlers::new(&env);
+    let webserver_ipv6 = get_universal_vm_address(&env);
+
+    let url = format!(
+        "https://[{}]:20443/long_response_header_name/{}",
+        webserver_ipv6,
+        MAX_HEADER_NAME_LENGTH + 1,
+    );
+
+    let response = block_on(submit_outcall(
+        &handlers,
+        RemoteHttpRequest {
+            request: UnvalidatedCanisterHttpRequestArgs {
+                url,
+                headers: vec![],
+                method: HttpMethod::GET,
+                body: Some("".as_bytes().to_vec()),
+                transform: None,
+                max_response_bytes: None,
+            },
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(
+        response,
+        Err(RejectResponse {
+            reject_code: RejectCode::SysFatal,
+            ..
+        })
+    );
+}
+
+fn test_response_header_value_within_limit(env: TestEnv) {
+    let handlers = Handlers::new(&env);
+    let webserver_ipv6 = get_universal_vm_address(&env);
+
+    let url = format!(
+        "https://[{}]:20443/long_response_header_value/{}",
+        webserver_ipv6, MAX_HEADER_VALUE_LENGTH,
+    );
+
+    let request = UnvalidatedCanisterHttpRequestArgs {
+        url,
+        headers: vec![],
+        method: HttpMethod::GET,
+        body: Some("".as_bytes().to_vec()),
+        transform: None,
+        max_response_bytes: None,
+    };
+
+    let response = block_on(submit_outcall(
+        &handlers,
+        RemoteHttpRequest {
+            request: request.clone(),
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(&response, Ok(RemoteHttpResponse { status: 200, .. }));
+}
+
+fn test_response_header_value_over_limit(env: TestEnv) {
+    let handlers = Handlers::new(&env);
+    let webserver_ipv6 = get_universal_vm_address(&env);
+
+    let url = format!(
+        "https://[{}]:20443/long_response_header_value/{}",
+        webserver_ipv6,
+        MAX_HEADER_VALUE_LENGTH + 1,
+    );
+
+    let request = UnvalidatedCanisterHttpRequestArgs {
+        url,
+        headers: vec![],
+        method: HttpMethod::GET,
+        body: Some("".as_bytes().to_vec()),
+        transform: None,
+        max_response_bytes: None,
+    };
+
+    let response = block_on(submit_outcall(
+        &handlers,
+        RemoteHttpRequest {
+            request: request.clone(),
+            cycles: 500_000_000_000,
+        },
+    ));
+
+    assert_matches!(
+        response,
+        Err(RejectResponse {
+            reject_code: RejectCode::SysFatal,
             ..
         })
     );
@@ -1721,8 +1945,7 @@ fn test_max_number_of_response_headers(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    // HTTP server returns 5 headers in addition to the requested headers.
-    let response_headers = HTTP_HEADERS_MAX_NUMBER - 5;
+    let response_headers = HTTP_HEADERS_MAX_NUMBER - HTTPBIN_OVERHEAD_RESPONSE_HEADERS;
     let url = format!(
         "https://[{}]:20443/{}/{}",
         webserver_ipv6, "many_response_headers", response_headers
@@ -1759,8 +1982,7 @@ fn test_max_number_of_response_headers_exceeded(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
-    // HTTP server returns 5 headers in addition to the requested headers.
-    let response_headers = HTTP_HEADERS_MAX_NUMBER - 5 + 1;
+    let response_headers = HTTP_HEADERS_MAX_NUMBER - HTTPBIN_OVERHEAD_RESPONSE_HEADERS + 1;
     let url = format!(
         "https://[{}]:20443/{}/{}",
         webserver_ipv6, "many_response_headers", response_headers


### PR DESCRIPTION
This change adds in the context of http outcalls systems correctness tests, tests that focus on the response headers limitations. These tests are being migrated from our Haskell spec tests into Rust.