### PR TITLE
chore(IDX): pr title validaton event

### DIFF
--- a/.github/workflows/ci-pr-title-validation.yml
+++ b/.github/workflows/ci-pr-title-validation.yml
@@ -1,7 +1,7 @@
 name: PR Title Validation
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 # Copied & adapted (job name, version label) from
@@ -10,7 +10,6 @@ on:
 
 permissions:
   pull-requests: write
-  statuses: write
 
 jobs:
   validate-pr-title:

--- a/.github/workflows/ci-pr-title-validation.yml
+++ b/.github/workflows/ci-pr-title-validation.yml
@@ -9,7 +9,7 @@ on:
 # validates the title and adds a label based on the PR type
 
 permissions:
-  pull-requests: read
+  pull-requests: write
   statuses: write
 
 jobs:

--- a/.github/workflows/ci-pr-title-validation.yml
+++ b/.github/workflows/ci-pr-title-validation.yml
@@ -9,7 +9,8 @@ on:
 # validates the title and adds a label based on the PR type
 
 permissions:
-  pull-requests: write
+  pull-requests: read
+  statuses: write
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION
Having `pull_request_target` event allows this workflow to run on PRs from a forked repo.