### PR TITLE
test(NODE-1579): nested systests: increase resources for host VM

### DIFF
--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -405,12 +405,9 @@ fn vm_spec_from_nested_node(
 ) -> VmSpec {
     VmSpec {
         name: node.name.clone(),
-        vcpus: default_vm_resources
-            .and_then(|vm_resources| vm_resources.vcpus)
-            .unwrap_or(DEFAULT_VCPUS_PER_VM),
-        memory_kibibytes: default_vm_resources
-            .and_then(|vm_resources| vm_resources.memory_kibibytes)
-            .unwrap_or(DEFAULT_MEMORY_KIB_PER_VM),
+        // Note that the nested GuestOS VM also uses 64 vCPUs so we match that in the host:
+        vcpus: NrOfVCPUs::new(64),
+        memory_kibibytes: AmountOfMemoryKiB::new(480 << 20),
         boot_image: BootImage::GroupDefault,
         boot_image_minimal_size_gibibytes: default_vm_resources
             .and_then(|vm_resources| vm_resources.boot_image_minimal_size_gibibytes),


### PR DESCRIPTION
What
===

Increase the vCPUs (and memory) of the host VM in the nested system-tests (`//rs/tests/nested:...`)  to match the number of vCPUs of its nested guest VM. So from 6 to 64.

Why
===

The nested system-tests are very flaky. By SSHing into the host VMs we noticed that their nested GuestOS VMs are often running into soft CPU lockups. See the following log from a host VM:

```
$ cat /var/log/libvirt/qemu/guestos-serial.log:
...
[ 1145.028103] watchdog: BUG: soft lockup - CPU#1 stuck for 1066s! [cpuhp/1:212] 
[ 1145.028103] Modules linked in: 
[ 1145.028103] CPU: 1 UID: 0 PID: 212 Comm: cpuhp/1 Tainted: G L 6.11.0-21-generic #21~24.04.1-Ubuntu 
[ 1145.028103] Tainted: [L]=SOFTLOCKUP 
[ 1145.028103] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 2024.02-2ubuntu0.1 10/25/2024 
[ 1145.028103] RIP: 0010:smp_call_function_many_cond+0x140/0x570 
```

A soft CPU lockup could occur when the system is under excessive load or because of overcommitted resources. 

Now, the nested GuestOS VM is configured to use 64 vCPUs. However the host VM was only using 6 vCPUs. This PR increases the vCPUs of the host VM to 64 as well so that we have a 1:1 mapping.

Tests
===
Unfortunately the Schedule Hourly runs doesn't show this really helps: 
* https://github.com/dfinity/ic/actions/runs/14179562046/job/39722312094 ✅ 
* https://github.com/dfinity/ic/actions/runs/14179562046/job/39724847614 ❌ 
* https://github.com/dfinity/ic/actions/runs/14180624169/job/39725715262 ❌ 
* https://github.com/dfinity/ic/actions/runs/14180976574/job/39726783814 ❌ 

NODE-1579