### PR TITLE
chore: log batch time

### DIFF
--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -1263,7 +1263,9 @@ impl BatchProcessor for BatchProcessorImpl {
         }
         self.observe_phase_duration(PHASE_LOAD_STATE, &since);
 
+        debug!(self.log, "Processing batch {}", batch.batch_number);
         info!(
+            every_n_seconds => 10,
             self.log,
             "Processing batch {} @ time {}", batch.batch_number, batch.time
         );

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -1263,7 +1263,10 @@ impl BatchProcessor for BatchProcessorImpl {
         }
         self.observe_phase_duration(PHASE_LOAD_STATE, &since);
 
-        debug!(self.log, "Processing batch {}", batch.batch_number);
+        info!(
+            self.log,
+            "Processing batch {} @ time {}", batch.batch_number, batch.time
+        );
         let commit_height = Height::from(batch.batch_number.get());
 
         let certification_scope = if batch.requires_full_state_hash {


### PR DESCRIPTION
This PR logs the batch time at the INFO level to facilitate debugging if the node system time is in sync with the batch time.