### PR TITLE
test(CON-1472): Enable VetKD in upgrade/downgrade & backup tests

### DIFF
--- a/rs/tests/consensus/backup/common.rs
+++ b/rs/tests/consensus/backup/common.rs
@@ -40,7 +40,7 @@ use ic_consensus_system_test_utils::{
     },
 };
 use ic_consensus_threshold_sig_system_test_utils::{
-    get_master_public_key, make_key_ids_for_all_idkg_schemes, run_chain_key_signature_test,
+    get_master_public_key, make_key_ids_for_all_schemes, run_chain_key_signature_test,
 };
 use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig};
 use ic_registry_subnet_type::SubnetType;
@@ -73,7 +73,7 @@ fn setup_common() -> InternetComputer {
         Subnet::new(SubnetType::System)
             .add_nodes(SUBNET_SIZE)
             .with_chain_key_config(ChainKeyConfig {
-                key_configs: make_key_ids_for_all_idkg_schemes()
+                key_configs: make_key_ids_for_all_schemes()
                     .into_iter()
                     .map(|key_id| KeyConfig {
                         max_queue_size: 20,
@@ -228,7 +228,7 @@ fn test(env: TestEnv, binary_version: String, target_version: String) {
         nns_node.effective_canister_id(),
     ));
 
-    for key_id in make_key_ids_for_all_idkg_schemes() {
+    for key_id in make_key_ids_for_all_schemes() {
         let public_key = get_master_public_key(&nns_canister, &key_id, &log);
         run_chain_key_signature_test(&nns_canister, &log, &key_id, public_key);
     }

--- a/rs/tests/consensus/upgrade/downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/downgrade_app_subnet_test.rs
@@ -6,7 +6,7 @@ use ic_consensus_system_test_upgrade_common::{
     bless_mainnet_version, get_chain_key_canister_and_public_key, upgrade,
 };
 use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
-use ic_consensus_threshold_sig_system_test_utils::make_key_ids_for_all_idkg_schemes;
+use ic_consensus_threshold_sig_system_test_utils::make_key_ids_for_all_schemes;
 use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig, DEFAULT_ECDSA_MAX_QUEUE_SIZE};
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
@@ -29,7 +29,7 @@ fn setup(env: TestEnv) {
         .add_nodes(SUBNET_SIZE)
         .with_dkg_interval_length(Height::from(DKG_INTERVAL))
         .with_chain_key_config(ChainKeyConfig {
-            key_configs: make_key_ids_for_all_idkg_schemes()
+            key_configs: make_key_ids_for_all_schemes()
                 .into_iter()
                 .map(|key_id| KeyConfig {
                     max_queue_size: DEFAULT_ECDSA_MAX_QUEUE_SIZE,
@@ -60,7 +60,7 @@ fn downgrade_app_subnet(env: TestEnv) {
         &nns_node,
         &agent,
         SubnetType::Application,
-        make_key_ids_for_all_idkg_schemes(),
+        make_key_ids_for_all_schemes(),
     );
 
     upgrade(

--- a/rs/tests/consensus/upgrade/upgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_app_subnet_test.rs
@@ -6,7 +6,7 @@ use ic_consensus_system_test_upgrade_common::{
     bless_branch_version, get_chain_key_canister_and_public_key, upgrade,
 };
 use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
-use ic_consensus_threshold_sig_system_test_utils::make_key_ids_for_all_idkg_schemes;
+use ic_consensus_threshold_sig_system_test_utils::make_key_ids_for_all_schemes;
 use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig, DEFAULT_ECDSA_MAX_QUEUE_SIZE};
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
@@ -29,7 +29,7 @@ fn setup(env: TestEnv) {
         .add_nodes(SUBNET_SIZE)
         .with_dkg_interval_length(Height::from(DKG_INTERVAL))
         .with_chain_key_config(ChainKeyConfig {
-            key_configs: make_key_ids_for_all_idkg_schemes()
+            key_configs: make_key_ids_for_all_schemes()
                 .into_iter()
                 .map(|key_id| KeyConfig {
                     max_queue_size: DEFAULT_ECDSA_MAX_QUEUE_SIZE,
@@ -61,7 +61,7 @@ fn upgrade_app_subnet(env: TestEnv) {
         &nns_node,
         &agent,
         SubnetType::Application,
-        make_key_ids_for_all_idkg_schemes(),
+        make_key_ids_for_all_schemes(),
     );
 
     upgrade(

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
@@ -12,7 +12,7 @@ use ic_consensus_system_test_utils::rw_message::{
     can_read_msg_with_retries, install_nns_and_check_progress,
 };
 use ic_consensus_threshold_sig_system_test_utils::{
-    make_key_ids_for_all_idkg_schemes, ChainSignatureRequest,
+    make_key_ids_for_all_schemes, ChainSignatureRequest,
 };
 use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig, DEFAULT_ECDSA_MAX_QUEUE_SIZE};
 use ic_registry_subnet_type::SubnetType;
@@ -46,7 +46,7 @@ fn setup(env: TestEnv) {
         .add_nodes(SUBNET_SIZE)
         .with_dkg_interval_length(Height::from(DKG_INTERVAL))
         .with_chain_key_config(ChainKeyConfig {
-            key_configs: make_key_ids_for_all_idkg_schemes()
+            key_configs: make_key_ids_for_all_schemes()
                 .into_iter()
                 .map(|key_id| KeyConfig {
                     max_queue_size: DEFAULT_ECDSA_MAX_QUEUE_SIZE,
@@ -73,7 +73,7 @@ fn upgrade_downgrade_app_subnet(env: TestEnv) {
     let nns_node = env.get_first_healthy_system_node_snapshot();
     let branch_version = bless_branch_version(&env, &nns_node);
     let agent = nns_node.with_default_agent(|agent| async move { agent });
-    let key_ids = make_key_ids_for_all_idkg_schemes();
+    let key_ids = make_key_ids_for_all_schemes();
     get_chain_key_canister_and_public_key(
         &env,
         &nns_node,


### PR DESCRIPTION
This PR enables the the VetKD keys in the upgrade / downgrade and backup tests.