### PR TITLE
chore(nns): Use the correct icrc1 index candid file

### DIFF
--- a/rs/sns/cli/dfx.json
+++ b/rs/sns/cli/dfx.json
@@ -43,7 +43,7 @@
         "cargo build --manifest-path ../../Cargo.toml --target wasm32-unknown-unknown --profile canister-release --bin ic-icrc1-index-ng",
         "ic-cdk-optimizer ../../target/wasm32-unknown-unknown/canister-release/ic-icrc1-index-ng.wasm -o ../../target/wasm32-unknown-unknown/canister-release/ic-icrc1-index-ng-opt.wasm"
       ],
-      "candid": "../../ledger_suite/icrc1/index/index.did",
+      "candid": "../../ledger_suite/icrc1/index-ng/index-ng.did",
       "wasm": "../../target/wasm32-unknown-unknown/canister-release/ic-icrc1-index-ng-opt.wasm",
       "type": "custom"
     }

--- a/rs/sns/dfx.json
+++ b/rs/sns/dfx.json
@@ -80,7 +80,7 @@
     "dragginz-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -135,7 +135,7 @@
     "openchat-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -190,7 +190,7 @@
     "kinic-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -245,7 +245,7 @@
     "hotornot-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -300,7 +300,7 @@
     "icghost-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -355,7 +355,7 @@
     "modclub-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -410,7 +410,7 @@
     "boomdao-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -465,7 +465,7 @@
     "catalyze-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -520,7 +520,7 @@
     "icx-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -575,7 +575,7 @@
     "nuance-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -630,7 +630,7 @@
     "sonic-sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom",
       "remote": {
         "id": {
@@ -647,7 +647,7 @@
     "sns-index": {
       "build": "",
       "wasm": "",
-      "candid": "../ledger_suite/icrc1/index/index.did",
+      "candid": "../ledger_suite/icrc1/index-ng/index-ng.did",
       "type": "custom"
     },
     "sns-ledger": {


### PR DESCRIPTION
# Why

Those dfx.json files are used by the dfx sns extension, and the `index.did` has been deleted in favor of `index-ng.did`. Therefore, the dfx nns extension wouldn't be able to advance the ic commit pass the point where `index.did` was deleted.

# What

Replace `index/index.did` with `index-ng/index-ng.did`

