### PR TITLE
chore(consensus): add note on exclusive IPv6 guarantee on NetworkUnreachable

### DIFF
--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -433,7 +433,7 @@ impl HttpsOutcallsService for CanisterHttp {
             self.client
                 .request(http_req)
                 .await
-                .map_err(|e| format!("Failed to directly connect (Please note that only IPv6 access is guaranteed for applications): {:?}", e))
+                .map_err(|e| format!("Failed to directly connect (Please note that the canister HTTPS outcalls feature is an IPv6-only feature. For more information, please consult the Internet Computer developer documentation): {:?}", e))
         }
         .map_err(|err| {
             debug!(self.logger, "Failed to connect: {}", err);

--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -433,7 +433,7 @@ impl HttpsOutcallsService for CanisterHttp {
             self.client
                 .request(http_req)
                 .await
-                .map_err(|e| format!("Failed to directly connect: {:?}", e))
+                .map_err(|e| format!("Failed to directly connect (Please note that only IPv6 access is guaranteed for applications): {:?}", e))
         }
         .map_err(|err| {
             debug!(self.logger, "Failed to connect: {}", err);


### PR DESCRIPTION
This change is a simple error message change that aims to help external developers when facing issues due to lacking IPv4 access on application subnets. A sample error is the one pasted below:
```
Call failed:
Canister: y22am-qyaaa-aaaab-qbmtq-cai
Method: get_icp_usd_exchange (update)
"Request ID": "7a5763d80514e605c16c5088b3ae773fe220c8ea54770bd34bc1bc06397b0372"
"Error code": "IC0406"
"Reject code": "4"
"Reject message": "Connecting to asdf.com failed: Failed to directly connect: hyper_util::client::legacy::Error(Connect, ConnectError(\"tcp connect error\", Os { code: 101, kind: NetworkUnreachable, message: \"Network is unreachable\" }))"
```

It is a known issue that IPv4 network access is guaranteed only for system subnets. The reasons this change just adds verbosity to the error message are the following:
- https_outcalls uses hyper library which makes it difficult to understand whether the URL will be resolved to IPv4 or not; a separate dns lookup is not guaranteed to yield the same address as the one used by hyper
- building on the above bullet, assuming that somehow we manage in the error message to expose the resolved address then any such details will make it more difficult to reach a consensus on the response, which would lead to a divergent response.