### PR TITLE
fix(EXC-2011): Speed up wasm64 check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8851,7 +8851,6 @@ dependencies = [
  "ic-utils 0.9.0",
  "ic-utils-lru-cache",
  "ic-utils-thread",
- "ic-wasm-transform",
  "ic-wasm-types",
  "itertools 0.12.1",
  "lazy_static",

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -37,7 +37,6 @@ DEPENDENCIES = [
     "//rs/utils",
     "//rs/utils/lru_cache",
     "//rs/utils/thread",
-    "//rs/wasm_transform",
     "@crate_index//:candid",
     "@crate_index//:hex",
     "@crate_index//:ic-btc-interface",
@@ -58,6 +57,7 @@ DEPENDENCIES = [
     "@crate_index//:tokio",
     "@crate_index//:tower",
     "@crate_index//:tracing",
+    "@crate_index//:wasmparser",
 ]
 
 MACRO_DEPENDENCIES = []
@@ -84,7 +84,6 @@ DEV_DEPENDENCIES = [
     "@crate_index//:proptest",
     "@crate_index//:regex",
     "@crate_index//:rstest",
-    "@crate_index//:wasmparser",
     "@crate_index//:wat",
 ]
 

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -40,7 +40,6 @@ ic-types = { path = "../types/types" }
 ic-utils = { path = "../utils" }
 ic-utils-lru-cache = { path = "../utils/lru_cache" }
 ic-utils-thread = { path = "../utils/thread" }
-ic-wasm-transform = { path = "../wasm_transform" }
 ic-wasm-types = { path = "../types/wasm_types" }
 lazy_static = { workspace = true }
 memory_tracker = { path = "../memory_tracker" }
@@ -61,6 +60,7 @@ threadpool = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
+wasmparser = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
@@ -86,7 +86,6 @@ proptest = { workspace = true }
 regex = { workspace = true }
 rstest = { workspace = true }
 test-strategy = "0.3.1"
-wasmparser = { workspace = true }
 wat = { workspace = true }
 
 [build-dependencies]

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -484,13 +484,17 @@ impl CanisterManager {
             }
         };
 
-        let module = match Module::parse(decoded_wasm_module.as_slice(), false) {
-            Ok(module) => module,
-            Err(_err) => {
-                return false;
+        let parser = wasmparser::Parser::new(0);
+        for section in parser.parse_all(decoded_wasm_module.as_slice()) {
+            if let Ok(wasmparser::Payload::MemorySection(reader)) = section {
+                for memory in reader {
+                    if let Ok(ty) = memory {
+                        return ty.memory64;
+                    }
+                }
             }
-        };
-        module.memories.first().is_some_and(|m| m.memory64)
+        }
+        false
     }
 
     /// Installs code to a canister.


### PR DESCRIPTION
EXC-2011

Instead of parsing the entire Wasm module to check if a canister is using 64-bit mode, we can just parse the memory section. This can speed up the check by 5x in some cases.