### PR TITLE
chore: EXC: Reduce number of benchmark samples

### DIFF
--- a/rs/embedders/benches/compilation.rs
+++ b/rs/embedders/benches/compilation.rs
@@ -271,12 +271,10 @@ fn execution(c: &mut Criterion) {
     }
 }
 
-criterion_group!(
-    benchmarks,
-    compilation_cost,
-    wasm_compilation,
-    wasm_deserialization,
-    wasm_validation_instrumentation,
-    execution,
-);
+criterion_group! {
+    name = benchmarks;
+    config = Criterion::default().sample_size(10);
+    targets = compilation_cost, wasm_compilation, wasm_deserialization,
+        wasm_validation_instrumentation, execution
+}
 criterion_main!(benchmarks);

--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -225,7 +225,7 @@ fn run_benchmark<G, I, W, R>(
                             expected_ops,
                             expected_ops / 1_000_000
                         );
-                        println!("    WAT: {}", wat.as_ref());
+                        // println!("    WAT: {}", wat.as_ref());
                         bench_args = Some(get_execution_args(exec_env, wat.as_ref()));
                     }
                     bench_args.as_ref().unwrap().clone()

--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -225,7 +225,6 @@ fn run_benchmark<G, I, W, R>(
                             expected_ops,
                             expected_ops / 1_000_000
                         );
-                        // println!("    WAT: {}", wat.as_ref());
                         bench_args = Some(get_execution_args(exec_env, wat.as_ref()));
                     }
                     bench_args.as_ref().unwrap().clone()

--- a/rs/execution_environment/benches/system_api/execute_query.rs
+++ b/rs/execution_environment/benches/system_api/execute_query.rs
@@ -132,5 +132,9 @@ pub fn execute_query_bench(c: &mut Criterion) {
     );
 }
 
-criterion_group!(benchmarks, execute_query_bench);
+criterion_group! {
+    name = benchmarks;
+    config = Criterion::default().sample_size(10);
+    targets = execute_query_bench
+}
 criterion_main!(benchmarks);

--- a/rs/execution_environment/benches/system_api/execute_update.rs
+++ b/rs/execution_environment/benches/system_api/execute_update.rs
@@ -1152,5 +1152,9 @@ pub fn execute_update_bench(c: &mut Criterion) {
     );
 }
 
-criterion_group!(benchmarks, execute_update_bench);
+criterion_group! {
+    name = benchmarks;
+    config = Criterion::default().sample_size(10);
+    targets = execute_update_bench
+}
 criterion_main!(benchmarks);

--- a/rs/execution_environment/benches/wasm_instructions/main.rs
+++ b/rs/execution_environment/benches/wasm_instructions/main.rs
@@ -6,6 +6,8 @@
 //!     bazel run //rs/execution_environment:wasm_instructions_bench -- --sample-size 10 i32.div
 //!
 
+use std::time::Duration;
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use execution_environment_bench::common;
 use ic_error_types::ErrorCode;
@@ -87,5 +89,12 @@ pub fn wasm_instructions_bench(c: &mut Criterion) {
     );
 }
 
-criterion_group!(benchmarks, wasm_instructions_bench);
+criterion_group! {
+    name = benchmarks;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(1))
+        .sample_size(10);
+    targets = wasm_instructions_bench
+}
 criterion_main!(benchmarks);


### PR DESCRIPTION
This reduces the default runtime to speed up running the benchmarks in CI.