### PR TITLE
chore: extend mainnet_revisions.py to update hostos version

### DIFF
--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -192,11 +192,8 @@ def update_saved_hostos_revision(
     logger.info("Downloading hostos update image from %s", url)
     with tempfile.NamedTemporaryFile() as tmp_file:
         urllib.request.urlretrieve(url, tmp_file.name)
-        sha256 = hashlib.sha256()
         with open(tmp_file.name, "rb") as f:
-            for chunk in iter(lambda: f.read(8192), b""):
-                sha256.update(chunk)
-        update_img_hash = sha256.hexdigest()
+            update_img_hash = hashlib.file_digest(f, "sha256").hexdigest()
 
     data["hostos"] = {"latest_release": {"version": version, "update_img_hash": update_img_hash}}
     with open(full_path, "w", encoding="utf-8") as f:

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -172,10 +172,10 @@ def get_subnet_replica_version(subnet_id: str) -> str:
         return latest_replica_version
 
 
-def update_saved_hostos_revision(repo_root: pathlib.Path, logger: logging.Logger, file_path: pathlib.Path, version: str):
-    """
-    Download the hostos update image for the given version, compute its sha256 hash, and update the saved version
-    """
+def update_saved_hostos_revision(
+    repo_root: pathlib.Path, logger: logging.Logger, file_path: pathlib.Path, version: str
+):
+    """Download the hostos update image for the given version, compute its sha256 hash, and update the saved version"""
     url = f"https://download.dfinity.systems/ic/{version}/host-os/update-img/update-img.tar.zst"
     logger.info("Downloading hostos update image from %s", url)
     with tempfile.NamedTemporaryFile() as tmp_file:
@@ -189,12 +189,7 @@ def update_saved_hostos_revision(repo_root: pathlib.Path, logger: logging.Logger
     full_path = repo_root / file_path
     with open(full_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    data["hostos"] = {
-        "latest_release": {
-            "version": version,
-            "update_img_hash": update_img_hash
-        }
-    }
+    data["hostos"] = {"latest_release": {"version": version, "update_img_hash": update_img_hash}}
     with open(full_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
     logger.info("Updated hostos revision to version %s with image hash %s", version, update_img_hash)

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -36,7 +36,7 @@ def sync_main_branch_and_checkout_branch(
         raise Exception("Found uncommited work! Commit and then proceed. Uncommited work:\n%s", result.stdout.strip())
 
     if subprocess.call(["git", "checkout", branch_to_checkout], cwd=repo_root) == 0:
-        # The branch already exists, update the existing MR
+        # The branch already exists, update the existing PR
         logger.info("Found an already existing target branch")
     else:
         subprocess.check_call(["git", "checkout", "-b", branch_to_checkout], cwd=repo_root)
@@ -60,7 +60,7 @@ def commit_and_create_pr(
     paths_to_add = [path for path in check_for_updates_in_paths if path in git_modified_files]
 
     if len(paths_to_add) > 0:
-        logger.info("Creating/updating a MR that updates the saved icos revisions")
+        logger.info("Creating/updating a PR that updates the saved icos revisions")
         cmd = ["git", "add"] + paths_to_add
         logger.info("Running command '%s'", " ".join(cmd))
         subprocess.check_call(cmd, cwd=repo_root)

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -175,7 +175,8 @@ def get_subnet_replica_version(subnet_id: str) -> str:
 def update_saved_hostos_revision(
     repo_root: pathlib.Path, logger: logging.Logger, file_path: pathlib.Path, version: str
 ):
-    """Download the hostos update image for the given version, compute its sha256 hash, and update the saved version.
+    """
+    Download the hostos update image for the given version, compute its sha256 hash, and update the saved version.
     """
     full_path = repo_root / file_path
     # Check if the hostos revision is already up-to-date.

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -6,6 +6,8 @@ import os
 import pathlib
 import subprocess
 import urllib.request
+import tempfile
+import hashlib
 from enum import Enum
 from typing import List
 
@@ -58,7 +60,7 @@ def commit_and_create_pr(
     paths_to_add = [path for path in check_for_updates_in_paths if path in git_modified_files]
 
     if len(paths_to_add) > 0:
-        logger.info("Creating/updating a MR that updates the saved NNS subnet revision")
+        logger.info("Creating/updating a MR that updates the saved icos revisions")
         cmd = ["git", "add"] + paths_to_add
         logger.info("Running command '%s'", " ".join(cmd))
         subprocess.check_call(cmd, cwd=repo_root)
@@ -170,7 +172,35 @@ def get_subnet_replica_version(subnet_id: str) -> str:
         return latest_replica_version
 
 
-def update_mainnet_revisions_subnets_file(repo_root: pathlib.Path, logger: logging.Logger, file_path: pathlib.Path):
+def update_saved_hostos_revision(repo_root: pathlib.Path, logger: logging.Logger, file_path: pathlib.Path, version: str):
+    """
+    Download the hostos update image for the given version, compute its sha256 hash, and update the saved version
+    """
+    url = f"https://download.dfinity.systems/ic/{version}/host-os/update-img/update-img.tar.zst"
+    logger.info("Downloading hostos update image from %s", url)
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        urllib.request.urlretrieve(url, tmp_file.name)
+        sha256 = hashlib.sha256()
+        with open(tmp_file.name, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                sha256.update(chunk)
+        update_img_hash = sha256.hexdigest()
+
+    full_path = repo_root / file_path
+    with open(full_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    data["hostos"] = {
+        "latest_release": {
+            "version": version,
+            "update_img_hash": update_img_hash
+        }
+    }
+    with open(full_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    logger.info("Updated hostos revision to version %s with image hash %s", version, update_img_hash)
+
+
+def update_mainnet_icos_revisions_file(repo_root: pathlib.Path, logger: logging.Logger, file_path: pathlib.Path):
     current_nns_version = get_subnet_replica_version(nns_subnet_id)
     logger.info("Current NNS subnet (%s) revision: %s", nns_subnet_id, current_nns_version)
     current_app_subnet_version = get_subnet_replica_version(app_subnet_id)
@@ -182,6 +212,7 @@ def update_mainnet_revisions_subnets_file(repo_root: pathlib.Path, logger: loggi
     update_saved_subnet_version(
         subnet=app_subnet_id, version=current_app_subnet_version, repo_root=repo_root, file_path=file_path
     )
+    update_saved_hostos_revision(repo_root, logger, file_path, current_app_subnet_version)
 
 
 def update_mainnet_revisions_canisters_file(repo_root: pathlib.Path, logger: logging.Logger):
@@ -248,14 +279,14 @@ This PR is created automatically using [`mainnet_revisions.py`](https://github.c
     if args.command == Command.SUBNETS:
         branch = "ic-mainnet-revisions"
         sync_main_branch_and_checkout_branch(repo_root, main_branch, branch, logger)
-        update_mainnet_revisions_subnets_file(repo_root, logger, pathlib.Path(MAINNET_ICOS_REVISIONS_FILE))
+        update_mainnet_icos_revisions_file(repo_root, logger, pathlib.Path(MAINNET_ICOS_REVISIONS_FILE))
         commit_and_create_pr(
             repo,
             repo_root,
             branch,
             [MAINNET_ICOS_REVISIONS_FILE],
             logger,
-            "chore: Update Mainnet IC revisions subnets file",
+            "chore: Update Mainnet IC revisions file",
             pr_description.format(
                 description="Update mainnet revisions file to include the latest version released on the mainnet."
             ),

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -175,9 +175,7 @@ def get_subnet_replica_version(subnet_id: str) -> str:
 def update_saved_hostos_revision(
     repo_root: pathlib.Path, logger: logging.Logger, file_path: pathlib.Path, version: str
 ):
-    """
-    Download the hostos update image for the given version, compute its sha256 hash, and update the saved version.
-    """
+    """Download the hostos update image for the given version, compute its sha256 hash, and update the saved version."""
     full_path = repo_root / file_path
     # Check if the hostos revision is already up-to-date.
     with open(full_path, "r", encoding="utf-8") as f:

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 import argparse
+import hashlib
 import json
 import logging
 import os
 import pathlib
 import subprocess
-import urllib.request
 import tempfile
-import hashlib
+import urllib.request
 from enum import Enum
 from typing import List
 


### PR DESCRIPTION
[NODE-1578](https://dfinity.atlassian.net/browse/NODE-1578)

mainnet_revisions.py now updates the mainnet-icos-version.json hostos version and update_img_hash fields

[NODE-1578]: https://dfinity.atlassian.net/browse/NODE-1578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ