### PR TITLE
fix(fuzzing): Bump `--bes_timeout` flag for sandbox_fuzzing builds to 600s

### DIFF
--- a/bin/run-all-fuzzers.sh
+++ b/bin/run-all-fuzzers.sh
@@ -24,7 +24,8 @@ EOF
         done
         LIST_OF_FUZZERS=$(bazel query 'attr(tags, "sandbox_libfuzzer", //rs/...)')
         for FUZZER in $LIST_OF_FUZZERS; do
-            bazel run --config=bes --config=sandbox_fuzzing $FUZZER -- -runs=$MAX_EXECUTIONS
+            # Overriding 180s timeout from bes config as few artifact uploads were timing out for fuzzing
+            bazel run --config=bes --bes_timeout=600s --config=sandbox_fuzzing $FUZZER -- -runs=$MAX_EXECUTIONS
         done
         ;;
 


### PR DESCRIPTION
The hourly pipeline for fuzzing have been erroring out since yesterday because of this [issue](https://www.buildbuddy.io/docs/troubleshooting-slow-upload/#the-build-event-protocol-upload-timed-out) and hence, we are bumping the timeout value only for `sandbox_fuzzing` builds