### PR TITLE
perf: EXC: Run more execution benchmarks periodically

### DIFF
--- a/.github/workflows/schedule-rust-bench.yml
+++ b/.github/workflows/schedule-rust-bench.yml
@@ -34,7 +34,13 @@ jobs:
           - "//rs/artifact_pool/..."
           - "//rs/consensus/..."
           - "//rs/ingress_manager/..."
+          - "//rs/embedders:compilation_bench"
           - "//rs/embedders:heap_bench"
+          - "//rs/embedders:stable_memory_bench"
+          - "//rs/execution_environment:execute_inspect_message_bench"
+          - "//rs/execution_environment:execute_query_bench"
+          - "//rs/execution_environment:execute_update_bench"
+          - "//rs/execution_environment:wasm_instructions_bench"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
* //rs/embedders:compilation_bench runs for ~5 min, adds 28 benchmarks
* //rs/embedders:stable_memory_bench runs for ~10 min, adds 14 benchmarks
* //rs/execution_environment:execute_inspect_message_bench runs for ~2 min, adds 8 benchmarks
* //rs/execution_environment:execute_query_bench runs for ~2 min, adds 6 benchmarks
* //rs/execution_environment:execute_update_bench runs for ~23 min, adds 116 benchmarks
* //rs/execution_environment:wasm_instructions_bench runs for ~80 min, adds 1704 benchmarks