### PR TITLE
revert: Bump --bes_timeout flag for sandbox_fuzzing builds to 600s (#4649)

### DIFF
--- a/bin/run-all-fuzzers.sh
+++ b/bin/run-all-fuzzers.sh
@@ -24,8 +24,7 @@ EOF
         done
         LIST_OF_FUZZERS=$(bazel query 'attr(tags, "sandbox_libfuzzer", //rs/...)')
         for FUZZER in $LIST_OF_FUZZERS; do
-            # Overriding 180s timeout from bes config as few artifact uploads were timing out for fuzzing
-            bazel run --config=bes --bes_timeout=600s --config=sandbox_fuzzing $FUZZER -- -runs=$MAX_EXECUTIONS
+            bazel run --config=bes --config=sandbox_fuzzing $FUZZER -- -runs=$MAX_EXECUTIONS
         done
         ;;
 


### PR DESCRIPTION
This reverts commit 539d2fb4907a1f1c7027aa1422f495a295e62a2d.