### PR TITLE
fix: rename the orchestrator binary crate from `ic_state_tool` to `orchestrator`

### DIFF
--- a/rs/orchestrator/BUILD.bazel
+++ b/rs/orchestrator/BUILD.bazel
@@ -76,7 +76,6 @@ rust_library(
 rust_binary(
     name = "orchestrator",
     srcs = ["src/main.rs"],
-    crate_name = "ic_state_tool",
     deps = [
         # Keep sorted.
         ":lib",


### PR DESCRIPTION
In another PR I'm adding a log message to the orchstrator's `main.rs` and noticed that the reported crate name is wrong:

`Apr 04 11:39:55 uwt2y-k7rvs-mrmr7-dkc6f-nq3yi-snjri-al2ez-hofgy-fvbed-2ofrn-nae orchestrator[2040]: {"log_entry":{"level":"INFO","utc_time":"2025-04-04T11:39:55.869Z","message":"Shutting down orchestrator...","crate_":"ic_state_tool","module":"ic_state_tool","line":21,"node_id":"","subnet_id":""}}
`

This PR fixes it