### PR TITLE
fix(IDX): Extract CI build config

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -1,6 +1,12 @@
 name: 'Bazel-Test-All'
 description: 'Run Bazel Test'
 inputs:
+  diff-only:
+    required: false
+    default: false
+  release-build:
+    required: false
+    default: true
   BAZEL_COMMAND:
     required: true
     default: 'test'
@@ -58,37 +64,8 @@ runs:
           GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}
           run: |
 
-            # default behavior is to build targets specified in BAZEL_TARGETS and not upload to s3
-            release_build="false"
-            diff_only="false"
-
-            # List of "protected" branches, i.e. branches (not necessarily "protected" in the GitHub sense) where we need
-            # the full build to occur (including versioning)
-            protected_branches=("^master$" "^rc--" "^hotfix-" "^master-private$")
-            for pattern in "${protected_branches[@]}"; do
-                if [[ "$BRANCH_NAME" =~ $pattern ]]; then
-                    IS_PROTECTED_BRANCH="true"
-                    break
-                fi
-            done
-
-            if [[ "${IS_PROTECTED_BRANCH:-}" == "true" ]]; then
-                # if we are on a "protected" branch or targeting an rc branch we
-                # upload all artifacts and run a release build (with versioning)
-                release_build="true"
-                diff_only="false"
-            elif [[ "${CI_EVENT_NAME:-}" == "merge_group" ]]; then
-                # on a merge group, we don't upload the artifacts (i.e. no release
-                # build) but we ensure all targets are built (no diff)
-                release_build="false"
-                diff_only="false"
-            elif [[ "${RUN_ON_DIFF_ONLY:-}" == "false" ]]; then
-                # if "RUN_ON_DIFF_ONLY" is false, assume it means
-                # "CI_ALL_BAZEL_TARGETS" is set and act as if we're on a protected
-                # branch
-                release_build="true"
-                diff_only="false"
-            fi
+            diff_only='${{ inputs.diff-only }}'
+            release_build='${{ inputs.release-build }}'
 
             # Some environment variables needed by diff.sh
             export BAZEL_TARGETS='${{ inputs.BAZEL_TARGETS }}'

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -154,7 +154,7 @@ jobs:
               nns_tests_nightly
           )
 
-          if [[ '${{ needs.config.outputs.config.skip_long_tests }}' ]]; then
+          if [[ '${{ needs.config.outputs.config.skip_long_tests }}' == 'true' ]]; then
             EXCLUDED_TEST_TAGS+=(long_test)
           fi
 

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -66,6 +66,10 @@ jobs:
   config:
     name: Set Config
     runs-on: ubuntu-latest
+    outputs:
+      release_build: ${{ steps.config.outputs.release_build }}
+      diff_only: ${{ steps.config.outputs.diff_only }}
+      skip_long_tests: ${{ steps.config.outputs.skip_long_tests }}
     steps:
       - name: Infer build config
         id: config
@@ -154,7 +158,7 @@ jobs:
               nns_tests_nightly
           )
 
-          if [[ '${{ needs.config.outputs.config.skip_long_tests }}' == 'true' ]]; then
+          if [[ '${{ needs.config.outputs.skip_long_tests }}' == 'true' ]]; then
             EXCLUDED_TEST_TAGS+=(long_test)
           fi
 
@@ -176,8 +180,8 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          diff-only: ${{ needs.config.outputs.config.diff_only }}
-          release-build: ${{ needs.config.outputs.config.release_build }}
+          diff-only: ${{ needs.config.outputs.diff_only }}
+          release-build: ${{ needs.config.outputs.release_build }}
           BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
@@ -289,8 +293,8 @@ jobs:
           BAZEL_TARGETS: //...
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_ON_DIFF_ONLY: ${{ needs.config.outputs.config.diff_only }}
-          RELEASE_BUILD: ${{ needs.config.outputs.config.release_build }}
+          RUN_ON_DIFF_ONLY: ${{ needs.config.outputs.diff_only }}
+          RELEASE_BUILD: ${{ needs.config.outputs.release_build }}
       - name: Upload SHA256SUMS (nocache)
         uses: ./.github/actions/bazel-upload-checksums/
         with:

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -64,6 +64,7 @@ anchors:
 
 jobs:
   config:
+    name: Set Config
     runs-on: ubuntu-latest
     steps:
       - name: Infer build config

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -63,8 +63,68 @@ anchors:
       python-version: '3.12'
 
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Infer build config
+        id: config
+        run: |
+          set -euo pipefail
+
+          # List of "protected" branches, i.e. branches (not necessarily "protected" in the GitHub sense) where we need
+          # the full build to occur (including versioning)
+          protected_branches=("^master$" "^rc--" "^hotfix-" "^master-private$")
+          for pattern in "${protected_branches[@]}"; do
+              if [[ "$BRANCH_NAME" =~ $pattern ]]; then
+                  is_protected_branch="true"
+                  break
+              fi
+          done
+
+          if [[ "${is_protected_branch:-}" == "true" ]]; then
+              # if we are on a "protected" branch or targeting an rc branch we
+              # upload all artifacts and run a release build (with versioning)
+              release_build="true"
+              diff_only="false"
+              skip_long_tests="false"
+          elif [[ '${{ github.event_name }}' == "merge_group" ]]; then
+              # on a merge group, we don't upload the artifacts (i.e. no release
+              # build) but we ensure all targets are built (no diff)
+              release_build="false"
+              diff_only="false"
+              skip_long_tests="true"
+          elif [[ '${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}' == 'true' ]]; then
+              # "CI_ALL_BAZEL_TARGETS" is set and act as if we're on a protected
+              # branch
+              release_build="true"
+              diff_only="false"
+              skip_long_tests="false"
+          else
+              # default behavior is to build targets specified in BAZEL_TARGETS and not upload to s3
+              release_build="false"
+              diff_only="true"
+              skip_long_tests="true"
+          fi
+
+          echo "| config | value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | --- |" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "release_build: $release_build"
+          echo "release_build=$release_build" >> "$GITHUB_OUTPUT"
+          echo "| \`release_build\` | \`$release_build\` |" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "diff_only: $diff_only"
+          echo "diff_only=$diff_only" >> "$GITHUB_OUTPUT"
+          echo "| \`diff_only\` | \`$diff_only\` |" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "skip_long_tests: $skip_long_tests"
+          echo "skip_long_tests=$skip_long_tests" >> "$GITHUB_OUTPUT"
+          echo "| \`skip_long_tests\` | \`$skip_long_tests\` |" >> "$GITHUB_STEP_SUMMARY"
+
+
   bazel-test-all:
     name: Bazel Test All
+    needs: [ config ]
     <<: *dind-large-setup
     runs-on:
       group: zh1
@@ -73,7 +133,6 @@ jobs:
       # Only run ci/bazel-scripts/diff.sh on PRs that are not labeled with "CI_ALL_BAZEL_TARGETS".
       OVERRIDE_DIDC_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_DIDC_CHECK') }}
       CI_OVERRIDE_BUF_BREAKING: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_BUF_BREAKING') }}
-      RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
     steps:
       - <<: *checkout
       - name: Set BAZEL_EXTRA_ARGS
@@ -81,7 +140,7 @@ jobs:
         id: bazel-extra-args
         run: |
           set -xeuo pipefail
-          # Determine which tests to skip and append 'long_test' for pull requests, merge groups or push on dev-gh-*
+          # Determine which tests to skip
           EXCLUDED_TEST_TAGS=(
               system_test_hourly
               system_test_nightly
@@ -93,13 +152,11 @@ jobs:
               fi_tests_nightly
               nns_tests_nightly
           )
-          if [[ "$CI_EVENT_NAME" =~ ^(pull_request|merge_group)$ ]]; then
-              if [[ "$CI_EVENT_NAME" == "merge_group" || "${RUN_ON_DIFF_ONLY:-}" == "true" ]]; then
-                  EXCLUDED_TEST_TAGS+=(long_test)
-              fi
-          elif [[ "$CI_EVENT_NAME" == "push" ]] && [[ "$BRANCH_NAME" =~ ^dev-gh-.* ]]; then
-              EXCLUDED_TEST_TAGS+=(long_test)
+
+          if [[ '${{ needs.config.outputs.config.skip_long_tests }}' ]]; then
+            EXCLUDED_TEST_TAGS+=(long_test)
           fi
+
           # Export excluded tags as environment variable for ci/bazel-scripts/diff.sh
           echo "EXCLUDED_TEST_TAGS=${EXCLUDED_TEST_TAGS[*]}" >> $GITHUB_ENV
           # Prepend tags with '-' and join them with commas for Bazel
@@ -118,6 +175,8 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
+          diff-only: ${{ needs.config.outputs.config.diff_only }}
+          release-build: ${{ needs.config.outputs.config.release_build }}
           BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
@@ -212,6 +271,7 @@ jobs:
           REPO_NAME: ${{ github.repository }}
 
   build-ic:
+    needs: [ config ]
     name: Build IC
     <<: *dind-large-setup
     # keep options from dind-large-setup but run on dind-small-setup
@@ -228,7 +288,8 @@ jobs:
           BAZEL_TARGETS: //...
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
+          RUN_ON_DIFF_ONLY: ${{ needs.config.outputs.config.diff_only }}
+          RELEASE_BUILD: ${{ needs.config.outputs.config.release_build }}
       - name: Upload SHA256SUMS (nocache)
         uses: ./.github/actions/bazel-upload-checksums/
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -29,6 +29,7 @@ env:
   CI_RUN_ID: ${{ github.run_id }}
 jobs:
   config:
+    name: Set Config
     runs-on: ubuntu-latest
     steps:
       - name: Infer build config

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -31,6 +31,10 @@ jobs:
   config:
     name: Set Config
     runs-on: ubuntu-latest
+    outputs:
+      release_build: ${{ steps.config.outputs.release_build }}
+      diff_only: ${{ steps.config.outputs.diff_only }}
+      skip_long_tests: ${{ steps.config.outputs.skip_long_tests }}
     steps:
       - name: Infer build config
         id: config
@@ -124,7 +128,7 @@ jobs:
               nns_tests_nightly
           )
 
-          if [[ '${{ needs.config.outputs.config.skip_long_tests }}' ]]; then
+          if [[ '${{ needs.config.outputs.skip_long_tests }}' == 'true' ]]; then
             EXCLUDED_TEST_TAGS+=(long_test)
           fi
 
@@ -146,8 +150,8 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          diff-only: ${{ needs.config.outputs.config.diff_only }}
-          release-build: ${{ needs.config.outputs.config.release_build }}
+          diff-only: ${{ needs.config.outputs.diff_only }}
+          release-build: ${{ needs.config.outputs.release_build }}
           BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
@@ -290,8 +294,8 @@ jobs:
           BAZEL_TARGETS: //...
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_ON_DIFF_ONLY: ${{ needs.config.outputs.config.diff_only }}
-          RELEASE_BUILD: ${{ needs.config.outputs.config.release_build }}
+          RUN_ON_DIFF_ONLY: ${{ needs.config.outputs.diff_only }}
+          RELEASE_BUILD: ${{ needs.config.outputs.release_build }}
       - name: Upload SHA256SUMS (nocache)
         uses: ./.github/actions/bazel-upload-checksums/
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -28,8 +28,66 @@ env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   CI_RUN_ID: ${{ github.run_id }}
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Infer build config
+        id: config
+        run: |
+          set -euo pipefail
+
+          # List of "protected" branches, i.e. branches (not necessarily "protected" in the GitHub sense) where we need
+          # the full build to occur (including versioning)
+          protected_branches=("^master$" "^rc--" "^hotfix-" "^master-private$")
+          for pattern in "${protected_branches[@]}"; do
+              if [[ "$BRANCH_NAME" =~ $pattern ]]; then
+                  is_protected_branch="true"
+                  break
+              fi
+          done
+
+          if [[ "${is_protected_branch:-}" == "true" ]]; then
+              # if we are on a "protected" branch or targeting an rc branch we
+              # upload all artifacts and run a release build (with versioning)
+              release_build="true"
+              diff_only="false"
+              skip_long_tests="false"
+          elif [[ '${{ github.event_name }}' == "merge_group" ]]; then
+              # on a merge group, we don't upload the artifacts (i.e. no release
+              # build) but we ensure all targets are built (no diff)
+              release_build="false"
+              diff_only="false"
+              skip_long_tests="true"
+          elif [[ '${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}' == 'true' ]]; then
+              # "CI_ALL_BAZEL_TARGETS" is set and act as if we're on a protected
+              # branch
+              release_build="true"
+              diff_only="false"
+              skip_long_tests="false"
+          else
+              # default behavior is to build targets specified in BAZEL_TARGETS and not upload to s3
+              release_build="false"
+              diff_only="true"
+              skip_long_tests="true"
+          fi
+
+          echo "| config | value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | --- |" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "release_build: $release_build"
+          echo "release_build=$release_build" >> "$GITHUB_OUTPUT"
+          echo "| \`release_build\` | \`$release_build\` |" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "diff_only: $diff_only"
+          echo "diff_only=$diff_only" >> "$GITHUB_OUTPUT"
+          echo "| \`diff_only\` | \`$diff_only\` |" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "skip_long_tests: $skip_long_tests"
+          echo "skip_long_tests=$skip_long_tests" >> "$GITHUB_OUTPUT"
+          echo "| \`skip_long_tests\` | \`$skip_long_tests\` |" >> "$GITHUB_STEP_SUMMARY"
   bazel-test-all:
     name: Bazel Test All
+    needs: [config]
     container:
       image: ghcr.io/dfinity/ic-build@sha256:2c855bb374d797860852f24b3387cc59278236d92beb8eb3308d0d16df8d9821
       options: >-
@@ -42,7 +100,6 @@ jobs:
       # Only run ci/bazel-scripts/diff.sh on PRs that are not labeled with "CI_ALL_BAZEL_TARGETS".
       OVERRIDE_DIDC_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_DIDC_CHECK') }}
       CI_OVERRIDE_BUF_BREAKING: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_BUF_BREAKING') }}
-      RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,7 +110,7 @@ jobs:
         id: bazel-extra-args
         run: |
           set -xeuo pipefail
-          # Determine which tests to skip and append 'long_test' for pull requests, merge groups or push on dev-gh-*
+          # Determine which tests to skip
           EXCLUDED_TEST_TAGS=(
               system_test_hourly
               system_test_nightly
@@ -65,13 +122,11 @@ jobs:
               fi_tests_nightly
               nns_tests_nightly
           )
-          if [[ "$CI_EVENT_NAME" =~ ^(pull_request|merge_group)$ ]]; then
-              if [[ "$CI_EVENT_NAME" == "merge_group" || "${RUN_ON_DIFF_ONLY:-}" == "true" ]]; then
-                  EXCLUDED_TEST_TAGS+=(long_test)
-              fi
-          elif [[ "$CI_EVENT_NAME" == "push" ]] && [[ "$BRANCH_NAME" =~ ^dev-gh-.* ]]; then
-              EXCLUDED_TEST_TAGS+=(long_test)
+
+          if [[ '${{ needs.config.outputs.config.skip_long_tests }}' ]]; then
+            EXCLUDED_TEST_TAGS+=(long_test)
           fi
+
           # Export excluded tags as environment variable for ci/bazel-scripts/diff.sh
           echo "EXCLUDED_TEST_TAGS=${EXCLUDED_TEST_TAGS[*]}" >> $GITHUB_ENV
           # Prepend tags with '-' and join them with commas for Bazel
@@ -90,6 +145,8 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
+          diff-only: ${{ needs.config.outputs.config.diff_only }}
+          release-build: ${{ needs.config.outputs.config.release_build }}
           BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
@@ -208,6 +265,7 @@ jobs:
           CI_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           REPO_NAME: ${{ github.repository }}
   build-ic:
+    needs: [config]
     name: Build IC
     container:
       image: ghcr.io/dfinity/ic-build@sha256:2c855bb374d797860852f24b3387cc59278236d92beb8eb3308d0d16df8d9821
@@ -231,7 +289,8 @@ jobs:
           BAZEL_TARGETS: //...
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_ON_DIFF_ONLY: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI_ALL_BAZEL_TARGETS') }}
+          RUN_ON_DIFF_ONLY: ${{ needs.config.outputs.config.diff_only }}
+          RELEASE_BUILD: ${{ needs.config.outputs.config.release_build }}
       - name: Upload SHA256SUMS (nocache)
         uses: ./.github/actions/bazel-upload-checksums/
         with:

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 cd "$CI_PROJECT_DIR"
 
 # run full release build on "protected" branches
-if [[ $BRANCH_NAME =~ ^master$|^rc--|^hotfix-|^master-private$ ]]; then
+if [[ $RELEASE_BUILD == "true" ]]; then
     ci/container/build-ic.sh -i -c -b
     exit 0
 fi


### PR DESCRIPTION
This extracts the CI build config (whether to diff the targets, to run a release build, etc) into a new job so that it is centralized and so that other jobs (`bazel-test-all`, `build-ic`) can depend on it.

This also adds a job summary so that the build config can be checked easily.