### PR TITLE
chore(IDX): move opts out of `--config=ci`

### DIFF
--- a/.github/actions/bazel/bin/bazel
+++ b/.github/actions/bazel/bin/bazel
@@ -58,6 +58,16 @@ fi
 if [[ $bazel_command == "build" ]] || [[ $bazel_command == "test" ]]; then
     command_timestamp=$(date +%s)
     bazel_args+=(
+        --verbose_failures=true
+
+        # enables BES upload (see config)
+        --config=bes
+        # additionally, upload build events asynchronously
+        --bes_upload_mode=fully_async
+
+        # Upload build results to cache
+        --remote_upload_local_results=true
+
         --color=yes # Nice CI output
 
         # Write build events to the dedicated tempdir

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -167,7 +167,20 @@ jobs:
           # Prepend tags with '-' and join them with commas for Bazel
           TEST_TAG_FILTERS=$(IFS=,; echo "${EXCLUDED_TEST_TAGS[*]/#/-}")
           # Determine BAZEL_EXTRA_ARGS based on event type or branch name
-          BAZEL_EXTRA_ARGS=( "--test_tag_filters=$TEST_TAG_FILTERS" )
+          BAZEL_EXTRA_ARGS=(
+            "--test_tag_filters=$TEST_TAG_FILTERS"
+
+            # default all tests to fail ...
+            #   ... after three attempts for tests marked as flaky
+            #   ... after three attempts for all tests in //rs/tests
+            #   ... after the first attempt for other tests
+            #   see also:
+            #     https://bazel.build/reference/command-line-reference#build-flag--flaky_test_attempts
+            --flaky_test_attempts=default
+            --flaky_test_attempts=//rs/tests/.*@3
+
+            --config=lint # enable lint checks
+            )
           if [[ "$CI_EVENT_NAME" == 'merge_group' ]]; then
               BAZEL_EXTRA_ARGS+=( --test_timeout_filters=short,moderate --flaky_test_attempts=3 )
           elif [[ $BRANCH_NAME =~ ^hotfix-.* ]]; then

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -137,7 +137,20 @@ jobs:
           # Prepend tags with '-' and join them with commas for Bazel
           TEST_TAG_FILTERS=$(IFS=,; echo "${EXCLUDED_TEST_TAGS[*]/#/-}")
           # Determine BAZEL_EXTRA_ARGS based on event type or branch name
-          BAZEL_EXTRA_ARGS=( "--test_tag_filters=$TEST_TAG_FILTERS" )
+          BAZEL_EXTRA_ARGS=(
+            "--test_tag_filters=$TEST_TAG_FILTERS"
+
+            # default all tests to fail ...
+            #   ... after three attempts for tests marked as flaky
+            #   ... after three attempts for all tests in //rs/tests
+            #   ... after the first attempt for other tests
+            #   see also:
+            #     https://bazel.build/reference/command-line-reference#build-flag--flaky_test_attempts
+            --flaky_test_attempts=default
+            --flaky_test_attempts=//rs/tests/.*@3
+
+            --config=lint # enable lint checks
+            )
           if [[ "$CI_EVENT_NAME" == 'merge_group' ]]; then
               BAZEL_EXTRA_ARGS+=( --test_timeout_filters=short,moderate --flaky_test_attempts=3 )
           elif [[ $BRANCH_NAME =~ ^hotfix-.* ]]; then

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -4,8 +4,6 @@
 # To require no rustfmt issues, pass --config=fmt.
 # To require no clippy issues, pass --config=clippy. Without this, warnings will still be generated.
 # To enable both of the above, pass --config=lint.
-# --config=ci implies --config=lint
-build:ci --config=lint
 # --config=lint implies both --config=fmt and --config=clippy.
 build:lint --config=fmt
 build:lint --config=clippy
@@ -59,7 +57,6 @@ test --test_tag_filters="-system_test,-fuzz_test"
 test:alltests --test_tag_filters=""
 test:paritytests --test_tag_filters="-system_test"
 build:ci --build_tag_filters="-system_test,-fuzz_test"
-build:ci --verbose_failures
 
 test --test_output=errors
 test --test_env=RUST_BACKTRACE=full
@@ -75,14 +72,13 @@ test:testnet --test_output=streamed --test_tag_filters=
 # TODO(IDX-2374): enable alltests in CI when we will have actual system tests.
 #test:ci --config=alltests
 
-# See the following for the exact semantics of --flaky_test_attempts:
-# https://bazel.build/reference/command-line-reference#flag--flaky_test_attempts
-# Locally we want a flaky test to fail explicitly on the first failure and not be retried.
-test    --flaky_test_attempts=1
-# On CI run tests marked as flaky up to 3 times.
-test:ci --flaky_test_attempts=default
-# On CI run all system-tests up to 3 times since they're known to be the most flaky since they require non-deterministic resources like the Internet.
-test:ci --flaky_test_attempts=//rs/tests/.*@3
+# Set all tests (including those marked as flaky) to fail explicitly on the
+# first try (can be overriden). This is useful when developing locally to
+# spot flakiness.
+#
+# see also:
+#   https://bazel.build/reference/command-line-reference#flag--flaky_test_attempts
+test --flaky_test_attempts=1
 
 # So that developers can build in debug mode.
 build:dev --compilation_mode=fastbuild

--- a/bazel/conf/.bazelrc.internal
+++ b/bazel/conf/.bazelrc.internal
@@ -6,17 +6,10 @@ build:bes --bes_backend=bes.idx.dfinity.network
 build:bes --bes_timeout=180s # Default is no timeout.
 build:bes --remote_build_event_upload=minimal
 
-# by default, only include build event upload on CI
-build:ci --config=bes
-# additionally, upload build events asynchronously on CI
-build:ci --bes_upload_mode=fully_async
-
 # DFINITY internal remote cache setup
 build --remote_cache=bazel-remote.idx.dfinity.network
 build --experimental_remote_cache_async
 build --experimental_remote_cache_compression # If enabled, compress/decompress cache blobs with zstd.
-build --remote_timeout=60s # Default is also 60s but we set it explicitly to remind ourselves of this timeout.
-build:ci --remote_timeout=5m # Default is 60s.
 # TODO: re-enable after fixing the error like this:
 # `Failed to fetch file with hash 'xxx' because it does not exist remotely. --remote_download_outputs=minimal does not work if your remote cache evicts files during builds.`
 # Probably disabling `--experimental_remote_cache_async` will help
@@ -27,9 +20,6 @@ build --experimental_remote_downloader=bazel-remote.idx.dfinity.network --experi
 build:local --experimental_remote_downloader=
 build --remote_local_fallback
 build    --remote_upload_local_results=false
-build:ci --remote_upload_local_results=true
-
-build:ci --noremote_local_fallback
 
 # Run `bazel build ... --config=local` to build targets without cache
 build:local --remote_cache=


### PR DESCRIPTION
This moves most of the `:ci` Bazel config out of the .bazelrc and into the CI jobs that require it. This streamlines the config to make it more portable and ensure the options are only set where required.