### PR TITLE
chore: EXC-2009: Make benchmark groups unique

### DIFF
--- a/rs/embedders/benches/compilation.rs
+++ b/rs/embedders/benches/compilation.rs
@@ -154,7 +154,7 @@ fn print_table(data: Vec<Vec<String>>) {
 /// on 2B instructions per second).
 fn compilation_cost(c: &mut Criterion) {
     let binaries = generate_binaries();
-    let group = c.benchmark_group("compilation-cost");
+    let group = c.benchmark_group("embedders:compilation/compilation-cost");
     let config = EmbeddersConfig::default();
 
     let mut table = vec![];
@@ -182,7 +182,7 @@ fn wasm_compilation(c: &mut Criterion) {
     set_production_rayon_threads();
 
     let binaries = generate_binaries();
-    let mut group = c.benchmark_group("compilation");
+    let mut group = c.benchmark_group("embedders:compilation/compilation");
     let config = EmbeddersConfig::default();
     for (name, wasm) in binaries {
         let embedder = WasmtimeEmbedder::new(config.clone(), no_op_logger());
@@ -206,7 +206,7 @@ fn wasm_deserialization(c: &mut Criterion) {
     set_production_rayon_threads();
 
     let binaries = generate_binaries();
-    let mut group = c.benchmark_group("deserialization");
+    let mut group = c.benchmark_group("embedders:compilation/deserialization");
     for (name, wasm) in binaries {
         let config = EmbeddersConfig::default();
         let embedder = WasmtimeEmbedder::new(config, no_op_logger());
@@ -234,7 +234,7 @@ fn wasm_validation_instrumentation(c: &mut Criterion) {
     set_production_rayon_threads();
 
     let binaries = generate_binaries();
-    let mut group = c.benchmark_group("validation-instrumentation");
+    let mut group = c.benchmark_group("embedders:compilation/validation-instrumentation");
     let config = EmbeddersConfig::default();
     for (name, wasm) in binaries {
         let embedder = WasmtimeEmbedder::new(config.clone(), no_op_logger());
@@ -260,6 +260,7 @@ fn execution(c: &mut Criterion) {
     for (name, wasm) in binaries {
         embedders_bench::query_bench(
             c,
+            "embedders:compilation/query",
             &name,
             wasm.as_slice(),
             &Encode!(&()).unwrap(),

--- a/rs/embedders/benches/embedders_bench/src/lib.rs
+++ b/rs/embedders/benches/embedders_bench/src/lib.rs
@@ -91,6 +91,7 @@ fn initialize_execution_test(
 
 pub fn update_bench(
     c: &mut Criterion,
+    group_name: &str,
     name: &str,
     wasm: &[u8],
     initialization_arg: &[u8],
@@ -101,7 +102,7 @@ pub fn update_bench(
 ) {
     let cell = RefCell::new(None);
 
-    let mut group = c.benchmark_group("update");
+    let mut group = c.benchmark_group(group_name);
     if let Some(throughput) = throughput {
         group.throughput(throughput);
     }
@@ -133,6 +134,7 @@ pub fn update_bench(
 
 pub fn update_bench_once(
     c: &mut Criterion,
+    group_name: &str,
     name: &str,
     wasm: &[u8],
     initialization_arg: &[u8],
@@ -141,7 +143,7 @@ pub fn update_bench_once(
     throughput: Option<Throughput>,
     setup_action: SetupAction,
 ) {
-    let mut group = c.benchmark_group("update");
+    let mut group = c.benchmark_group(group_name);
     if let Some(throughput) = throughput {
         group.throughput(throughput);
     }
@@ -166,6 +168,7 @@ pub fn update_bench_once(
 
 pub fn query_bench(
     c: &mut Criterion,
+    group_name: &str,
     name: &str,
     wasm: &[u8],
     initialization_arg: &[u8],
@@ -176,7 +179,7 @@ pub fn query_bench(
 ) {
     let cell = RefCell::new(None);
 
-    let mut group = c.benchmark_group("query");
+    let mut group = c.benchmark_group(group_name);
     if let Some(throughput) = throughput {
         group.throughput(throughput);
     }

--- a/rs/embedders/benches/heap.rs
+++ b/rs/embedders/benches/heap.rs
@@ -177,6 +177,7 @@ fn bench(c: &mut C, mem: Mem, call: Call, op: Op, dir: Dir, size: Size, step: St
     match call {
         Call::Query => embedders_bench::query_bench(
             c,
+            "embedders:heap/query",
             &name,
             &wasm,
             &[],
@@ -189,6 +190,7 @@ fn bench(c: &mut C, mem: Mem, call: Call, op: Op, dir: Dir, size: Size, step: St
             // Running checkpoint benchmarks once or multiple times yields the same results.
             Src::Checkpoint => embedders_bench::update_bench(
                 c,
+                "embedders:heap/update",
                 &name,
                 &wasm,
                 &[],
@@ -202,6 +204,7 @@ fn bench(c: &mut C, mem: Mem, call: Call, op: Op, dir: Dir, size: Size, step: St
             // New allocation benchmarks are only meaningful when run once.
             Src::PageDelta | Src::NewAllocation => embedders_bench::update_bench_once(
                 c,
+                "embedders:heap/update",
                 &name,
                 &wasm,
                 &[],

--- a/rs/embedders/benches/stable_memory.rs
+++ b/rs/embedders/benches/stable_memory.rs
@@ -136,6 +136,7 @@ fn query_bench(
 ) {
     embedders_bench::query_bench(
         c,
+        "embedders:stable_memory/query",
         name,
         wasm,
         &Encode!(&structure, &initial_count).unwrap(),
@@ -157,6 +158,7 @@ fn update_bench(
 ) {
     embedders_bench::update_bench(
         c,
+        "embedders:stable_memory/update",
         name,
         wasm,
         &Encode!(&structure, &initial_count).unwrap(),

--- a/rs/execution_environment/benches/system_api/execute_inspect_message.rs
+++ b/rs/execution_environment/benches/system_api/execute_inspect_message.rs
@@ -89,7 +89,7 @@ pub fn execute_inspect_message_bench(c: &mut Criterion) {
     ];
     common::run_benchmarks(
         c,
-        "inspect",
+        "execution_environment:inspect_message",
         &benchmarks,
         |id: &str,
          exec_env: &ExecutionEnvironment,

--- a/rs/execution_environment/benches/system_api/execute_query.rs
+++ b/rs/execution_environment/benches/system_api/execute_query.rs
@@ -81,7 +81,7 @@ pub fn execute_query_bench(c: &mut Criterion) {
     let sender = PrincipalId::new_node_test_id(common::REMOTE_CANISTER_ID);
     common::run_benchmarks(
         c,
-        "query",
+        "execution_environment:query",
         &benchmarks,
         |id: &str,
          exec_env: &ExecutionEnvironment,

--- a/rs/execution_environment/benches/system_api/execute_update.rs
+++ b/rs/execution_environment/benches/system_api/execute_update.rs
@@ -1092,7 +1092,7 @@ pub fn execute_update_bench(c: &mut Criterion) {
 
     common::run_benchmarks(
         c,
-        "update",
+        "execution_environment:update",
         &benchmarks,
         |id: &str,
          exec_env: &ExecutionEnvironment,

--- a/rs/execution_environment/benches/wasm_instructions/main.rs
+++ b/rs/execution_environment/benches/wasm_instructions/main.rs
@@ -34,7 +34,7 @@ pub fn wasm_instructions_bench(c: &mut Criterion) {
     // Benchmark function.
     common::run_benchmarks(
         c,
-        "wasm_instructions",
+        "execution_environment:wasm_instructions",
         &benchmarks,
         |_id: &str,
          exec_env: &ExecutionEnvironment,


### PR DESCRIPTION
This PR makes all Criterion benchmark groups unique, without functional changes.

Unique groups facilitate querying results.