### PR TITLE
chore(NODE-1579): fix flakiness in nested systests by only running them in dm1

### DIFF
--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -52,7 +52,7 @@ system_test_nns(
     name = "registration",
     env = MAINNET_ENV,
     flaky = True,  # flakiness rate of over 2% over the month from 2025-02-11 till 2025-03-11.
-    tags = ["manual"],  # todo: add hourly tag after resolving flakiness
+    tags = ["system_test_hourly"],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",
     use_empty_image = True,
@@ -74,7 +74,7 @@ system_test_nns(
     name = "hostos_upgrade_smoke_test",
     env = MAINNET_ENV,
     flaky = True,
-    tags = ["manual"],  # todo: add hourly tag after resolving flakiness
+    tags = ["system_test_hourly"],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_driver_target = ":upgrade_test_bin",
     test_timeout = "eternal",
@@ -93,7 +93,7 @@ system_test_nns(
         "NODE_OPERATOR_PRIV_KEY_PATH": "$(rootpath //ic-os/setupos:config/node_operator_private_key.pem)",
     },
     flaky = True,  # flakiness rate of 5% over the month from 2025-02-11 till 2025-03-11.
-    tags = ["manual"],  # todo: add hourly tag after resolving flakiness
+    tags = ["system_test_hourly"],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_driver_target = ":upgrade_test_bin",
     test_timeout = "eternal",

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -7,7 +7,10 @@ use canister_test::PrincipalId;
 use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
-    driver::{ic::InternetComputer, nested::NestedVms, test_env::TestEnv, test_env_api::*},
+    driver::{
+        farm::HostFeature, ic::InternetComputer, nested::NestedVms, test_env::TestEnv,
+        test_env_api::*,
+    },
     util::block_on,
 };
 use ic_types::hostos_version::HostosVersion;
@@ -34,6 +37,12 @@ pub fn config(env: TestEnv) {
 
     // Setup "testnet"
     InternetComputer::new()
+        // The Farm hosts in the dm1 DC run:
+        // Ubuntu-24.04, libvirt-10.0.0 and QEMU-8.2.2 while the other (older) Farm hosts run
+        // Ubuntu-20.04, libvirt-6.6.0  and QEMU-5.0.0.
+        // If the host VM is allocated to these older hosts the nested guest VM often runs into soft CPU lockups.
+        // So we temporarily require that this test is hosted in dm1 until the other Farm hosts are upgraded to Ubuntu 24.04.
+        .with_required_host_features(vec![HostFeature::DC("dm1".to_string())])
         .add_fast_single_node_subnet(SubnetType::System)
         .with_mainnet_config()
         .with_api_boundary_nodes(1)


### PR DESCRIPTION
The Farm hosts in the dm1 DC run:
Ubuntu-24.04, libvirt-10.0.0 and QEMU-8.2.2 while the other (older) Farm hosts run 
Ubuntu-20.04, libvirt-6.6.0  and QEMU-5.0.0.
If the host VM in the nested system-tests is allocated to these older hosts the nested guest VM often runs into soft CPU lockups. So we temporarily require that this test is hosted in dm1 until the other Farm hosts are upgraded to Ubuntu 24.04.