### PR TITLE
feat(EXC-2010): Disable canister backtrace when name section is missing

### DIFF
--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -73,19 +73,27 @@ fn demangle(func_name: &str) -> String {
     }
 }
 
-fn convert_backtrace(wasm: &wasmtime::WasmBacktrace) -> CanisterBacktrace {
+/// Convert a backtrace to our internal representation. Returns `None` if we
+/// can't get function names for any of the frames. This likely indicates that
+/// the `name` section is not present and the user won't want an error
+/// cluttered with a useless backtrace anyway.
+fn convert_backtrace(wasm: &wasmtime::WasmBacktrace) -> Option<CanisterBacktrace> {
     let funcs: Vec<_> = wasm
         .frames()
         .iter()
         .map(|f| (f.func_index(), f.func_name().map(demangle)))
         .collect();
-    CanisterBacktrace(funcs)
+    if funcs.iter().all(|(_, name)| name.is_none()) {
+        None
+    } else {
+        Some(CanisterBacktrace(funcs))
+    }
 }
 
 fn wasmtime_error_to_hypervisor_error(err: anyhow::Error) -> HypervisorError {
     let backtrace = err
         .downcast_ref::<wasmtime::WasmBacktrace>()
-        .map(convert_backtrace);
+        .and_then(convert_backtrace);
     match err.downcast::<wasmtime::Trap>() {
         Ok(trap) => trap_code_to_hypervisor_error(trap, backtrace),
         Err(err) => {

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -64,7 +64,7 @@ fn add_backtrace(e: &mut HypervisorError, store: impl AsContext<Data = StoreData
                 message: _,
                 backtrace,
             } => {
-                *backtrace = Some(convert_backtrace(&WasmBacktrace::capture(store)));
+                *backtrace = convert_backtrace(&WasmBacktrace::capture(store));
             }
             _ => {}
         }

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -140,12 +140,14 @@ rust_ic_test_suite(
     compile_data = glob(["tests/test-data/**"]),
     data = DATA + [
         "//rs/rust_canisters/backtrace_canister:backtrace-canister",
+        "//rs/rust_canisters/backtrace_canister:backtrace-canister-without-names",
         "//rs/universal_canister/impl:universal_canister.module",
         "//rs/universal_canister/impl:universal_canister.wasm.gz",
         "//testnet/prebuilt-canisters:image-classification",
     ],
     env = dict(ENV.items() + [
         ("BACKTRACE_CANISTER_WASM_PATH", "$(rootpath //rs/rust_canisters/backtrace_canister:backtrace-canister)"),
+        ("BACKTRACE_CANISTER_WITHOUT_NAMES_WASM_PATH", "$(rootpath //rs/rust_canisters/backtrace_canister:backtrace-canister-without-names)"),
         ("UNIVERSAL_CANISTER_WASM_PATH", "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)"),
         ("UNIVERSAL_CANISTER_SERIALIZED_MODULE_PATH", "$(rootpath //rs/universal_canister/impl:universal_canister.module)"),
         ("IMAGE_CLASSIFICATION_CANISTER_WASM_PATH", "$(rootpath //testnet/prebuilt-canisters:image-classification)"),

--- a/rs/interfaces/src/execution_environment/errors.rs
+++ b/rs/interfaces/src/execution_environment/errors.rs
@@ -126,6 +126,9 @@ pub enum HypervisorError {
         backtrace: Option<CanisterBacktrace>,
     },
     /// Canister explicitly called `ic.trap`.
+    /// The contained backtrace may be `None` if the canister does not include
+    /// suitable debug information or if the caller does not have permission to
+    /// view the backtrace.
     CalledTrap {
         message: String,
         backtrace: Option<CanisterBacktrace>,

--- a/rs/rust_canisters/backtrace_canister/BUILD.bazel
+++ b/rs/rust_canisters/backtrace_canister/BUILD.bazel
@@ -30,6 +30,18 @@ rust_canister(
     deps = DEPENDENCIES,
 )
 
+# The same canister, but without the name section. Used to test that we don't
+# clutter errors with useless backtraces when the name section is missing.
+rust_canister(
+    name = "backtrace-canister-without-names",
+    srcs = ["src/main.rs"],
+    aliases = ALIASES,
+    keep_name_section = False,
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    service_file = ":backtrace_canister.did",
+    deps = DEPENDENCIES,
+)
+
 rust_test(
     name = "backtrace_canister_test",
     srcs = ["src/main.rs"],


### PR DESCRIPTION
EXC-2010

If a Wasm module doesn't have the `name` custom section, then the canister backtrace we produce is pretty useless, so we might as well completely remove it in that case.