### PR TITLE
test: ic-prep Add the data center records to the registry

### DIFF
--- a/rs/prep/src/internet_computer.rs
+++ b/rs/prep/src/internet_computer.rs
@@ -26,11 +26,10 @@ use x509_cert::spki; // re-export of spki crate
 use ic_interfaces_registry::{
     RegistryDataProvider, RegistryTransportRecord, ZERO_REGISTRY_VERSION,
 };
-use ic_protobuf::registry::firewall::v1::{
-    FirewallAction, FirewallRule, FirewallRuleDirection, FirewallRuleSet,
-};
+
 use ic_protobuf::registry::{
     api_boundary_node::v1::ApiBoundaryNodeRecord,
+    dc::v1::DataCenterRecord,
     node_operator::v1::NodeOperatorRecord,
     provisional_whitelist::v1::ProvisionalWhitelist as PbProvisionalWhitelist,
     replica_version::v1::{BlessedReplicaVersions, ReplicaVersionRecord},
@@ -38,11 +37,15 @@ use ic_protobuf::registry::{
     subnet::v1::SubnetListRecord,
     unassigned_nodes_config::v1::UnassignedNodesConfigRecord,
 };
+use ic_protobuf::registry::{
+    dc::v1::Gps,
+    firewall::v1::{FirewallAction, FirewallRule, FirewallRuleDirection, FirewallRuleSet},
+};
 use ic_protobuf::types::v1::{PrincipalId as PrincipalIdProto, SubnetId as SubnetIdProto};
 use ic_registry_client::client::RegistryDataProviderError;
 use ic_registry_keys::{
     make_api_boundary_node_record_key, make_blessed_replica_versions_key,
-    make_firewall_rules_record_key, make_node_operator_record_key,
+    make_data_center_record_key, make_firewall_rules_record_key, make_node_operator_record_key,
     make_provisional_whitelist_record_key, make_replica_version_key, make_routing_table_record_key,
     make_subnet_list_record_key, make_unassigned_nodes_config_record_key, FirewallRulesScope,
     ROOT_SUBNET_ID_KEY,
@@ -266,6 +269,9 @@ pub struct IcConfig {
     /// The index of the NNS subnet, if any.
     nns_subnet_index: Option<u64>,
 
+    // Initial set of data center records to populate the registry with.
+    initial_dc_records: Vec<DataCenterRecord>,
+
     /// Vector of node operator records
     initial_registry_node_operator_entries: Vec<NodeOperatorEntry>,
 
@@ -394,6 +400,7 @@ impl IcConfig {
             initial_release_package_url: release_package_url,
             initial_release_package_sha256_hex: release_package_sha256_hex,
             initial_registry_node_operator_entries: Vec::new(),
+            initial_dc_records: Vec::new(),
             provisional_whitelist,
             initial_mutations: Vec::new(),
             initial_node_operator,
@@ -639,6 +646,16 @@ impl IcConfig {
             PbProvisionalWhitelist::from(provisional_whitelist),
         );
 
+        for dc_record in self.initial_dc_records {
+            write_registry_entry(
+                &data_provider,
+                self.target_dir.as_path(),
+                make_data_center_record_key(dc_record.id.as_str()).as_ref(),
+                version,
+                dc_record,
+            );
+        }
+
         for node_operator_entry in self.initial_registry_node_operator_entries {
             let id = node_operator_entry.principal_id;
             let node_operator_record: NodeOperatorRecord = node_operator_entry.into();
@@ -735,13 +752,27 @@ impl IcConfig {
     /// >   provider_keys/
     /// >     np.der
     ///
-    /// > "dc_A": { "node_allowance" : 3,
+    /// > "dc_A": {
+    /// >   "node_allowance" : 3,
     /// >   "node_provider": "provider_keys/np.der",
     /// > }
     ///
     /// *Note* that in case of the provider key, the filename *must* include the
     /// extension. If the path is not absolute, the directory containing the
     /// meta.json is used as a basis.
+    ///
+    /// Extra data center information can be added to the meta.json file, such as
+    /// region, owner, and gps coordinates. The gps coordinates should be in the
+    /// format of a 2-element array, where the first element is the latitude
+    /// and the second element is the longitude. For example:
+    ///
+    /// > "dc_A": {
+    /// >   "node_allowance" : 3,
+    /// >   "node_provider": "provider_keys/np.der",
+    /// >   "region": "us-west-1",
+    /// >   "owner": "example_owner",
+    /// >   "gps": [37.7749, -122.4194]
+    /// > }
     pub fn load_registry_node_operator_records_from_dir(
         mut self,
         der_dir: &Path,
@@ -773,6 +804,8 @@ impl IcConfig {
         //and push them into the node_operator_entries vector. We don't use a map
         // because there are too many '?' in there.
         let mut node_operator_entries = Vec::new();
+        let mut data_center_entries = Vec::new();
+
         for fname in der_files {
             let name = fname
                 .file_name()
@@ -850,12 +883,49 @@ impl IcConfig {
                 None
             };
 
+            let dcr = DataCenterRecord {
+                id: name.to_string(),
+                region: match obj["region"].as_str() {
+                    Some(region) => region.to_string(),
+                    None => String::from(""),
+                },
+                owner: match obj["owner"].as_str() {
+                    Some(owner) => owner.to_string(),
+                    None => String::from(""),
+                },
+                gps: match obj["gps"].as_array() {
+                    Some(gps) => {
+                        if gps.len() != 2 {
+                            return Err(InitializeError::NotString {
+                                key: "gps".to_string(),
+                                value: obj["gps"].to_string(),
+                            });
+                        }
+                        let lat = gps[0].as_f64().ok_or_else(|| InitializeError::NotString {
+                            key: "gps".to_string(),
+                            value: obj["gps"].to_string(),
+                        })?;
+                        let lon = gps[1].as_f64().ok_or_else(|| InitializeError::NotString {
+                            key: "gps".to_string(),
+                            value: obj["gps"].to_string(),
+                        })?;
+                        Some(Gps {
+                            latitude: lat as f32,
+                            longitude: lon as f32,
+                        })
+                    }
+                    None => None,
+                },
+            };
+
+            data_center_entries.push(dcr);
+
             node_operator_entries.push(NodeOperatorEntry {
                 _name: String::from(name),
                 principal_id: PrincipalId::new_self_authenticating(&operator_buf),
                 node_provider_principal_id,
                 node_allowance,
-                dc_id: "".into(),
+                dc_id: name.into(),
                 rewardable_nodes: BTreeMap::new(),
                 ipv6: None,
             });
@@ -863,6 +933,8 @@ impl IcConfig {
 
         self.initial_registry_node_operator_entries
             .extend(node_operator_entries);
+
+        self.initial_dc_records.extend(data_center_entries);
         Ok(self)
     }
 }


### PR DESCRIPTION
# Summary

Add the dc entries to the initial registry

# Detail
Prior to this change, the ic-prep could generate initial node operators and node providers by looking into a `meta.json` definition.

However, the NO generated out of that definition had an empty value for the DC.
Furthermore, the DC entries were missing altogether.

This change allows for extra configuration inside the meta.json
```json
  "dc_A": {
      "node_allowance" : 3,
       "node_provider": "provider_keys/np.der",
       "region": "us-west-1",
       "owner": "example_owner",
       "gps": [37.7749, -122.4194]
    }
```

# Test
On UTOPIA setup, the ic-prep is used to generate initial config. The dre tool now shows the correct config.
```bash
dre --nns-urls http://localhost:8050 registry | jq .dcs
 2025-04-08T06:50:12.373Z INFO  dre > Running version 0.6.2-eb63b8842af6c2967ce9ca94f5c876a6095ba270
 2025-04-08T06:50:12.377Z INFO  dre::store > Using local registry path for network mainnet: /home/cylon/.cache/dre-store/local_registry/mainnet
 2025-04-08T06:50:14.057Z WARN  dre::commands::registry > Failed to get Node Rewards Table for mainnet
[
  {
    "id": "dc1",
    "region": "us-west-1",
    "owner": "example_owner",
    "gps": null
  }
]
```
Similarly, ic-admin shows the same info:
```bash
ic-admin --nns-urls http://localhost:8080 get-data-center dc1
Using NNS URLs: ["http://localhost:8080/"]
Fetching the most recent value for key: data_center_record_dc1
Most recent version is 1. Value:
DataCenterRecord { id: "dc1", region: "us-west-1", owner: "example_owner", gps: None }
```

Note: ignore the gps field as I didn't set them in my test.