### PR TITLE
test(sns): Fix awaiting in set-topics tests

### DIFF
--- a/rs/nervous_system/integration_tests/tests/sns_topics.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_topics.rs
@@ -207,14 +207,15 @@ async fn set_custom_sns_topics_test() {
             .await
             .unwrap();
 
-        let proposal_id = SubmittedProposal::try_from(response)
-            .unwrap()
-            .proposal_id
-            .id;
+        let proposal_id = SubmittedProposal::try_from(response).unwrap().proposal_id;
 
-        nns::governance::wait_for_proposal_execution(&pocket_ic, proposal_id)
-            .await
-            .unwrap();
+        sns::governance::wait_for_proposal_execution(
+            &pocket_ic,
+            sns.governance.canister_id,
+            proposal_id,
+        )
+        .await
+        .unwrap();
     }
 
     // Assert that the proposal is originally under the `CriticalDappOperations` topic.
@@ -308,14 +309,17 @@ async fn set_custom_sns_topics_test() {
             .await
             .unwrap();
 
-        let proposal_id = SubmittedProposal::try_from(response)
-            .unwrap()
-            .proposal_id
-            .id;
+        let proposal_id = SubmittedProposal::try_from(response).unwrap().proposal_id;
 
-        nns::governance::wait_for_proposal_execution(&pocket_ic, proposal_id)
-            .await
-            .unwrap();
+        let proposal_data = sns::governance::wait_for_proposal_execution(
+            &pocket_ic,
+            sns.governance.canister_id,
+            proposal_id,
+        )
+        .await
+        .unwrap();
+
+        panic!("proposal_data = {:#?}", proposal_data);
     }
 
     // Assert that the intended changes took place in the list of topics.


### PR DESCRIPTION
This PR contains a simple fix for awaiting SNS proposal execution in set-topics tests.