### PR TITLE
feat(nns): Always panic when pb methods are called

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -151,7 +151,7 @@ fn panic_with_probability(probability: f64, message: &str) {
     // state, which makes sure that the next time still panics, unless some other operation modifies
     // the `rng` successfully, such as spawning a neuron.
     let random = ChaCha20Rng::seed_from_u64(now_seconds()).next_u64();
-    let should_panic = (random as f64) / (u64::MAX as f64) < probability;
+    let should_panic = (random as f64) / (u64::MAX as f64) <= probability;
     if should_panic {
         panic!("{}", message);
     }
@@ -579,7 +579,7 @@ async fn heartbeat() {
 fn manage_neuron_pb() {
     debug_log("manage_neuron_pb");
     panic_with_probability(
-        0.9,
+        1.0,
         "manage_neuron_pb is deprecated. Please use manage_neuron instead.",
     );
 
@@ -614,7 +614,7 @@ fn list_proposals_pb() {
 fn list_neurons_pb() {
     debug_log("list_neurons_pb");
     panic_with_probability(
-        0.9,
+        1.0,
         "list_neurons_pb is deprecated. Please use list_neurons instead.",
     );
 

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,6 +11,8 @@ on the process that this file is part of, see
 
 ## Changed
 
+* The `_pb` methods now always panic.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
# Why

The `_pb` method in the NNS Governance are deprecated. This PR makes them always fail.

# What

Make the failure probability 100% for the `_pb` methods. We could simply panic. However, that will require us to remove branches of code, which might make it more difficult to rollback if needed if subsequent code is relying on the removal.