### PR TITLE
test(nns): Use empty blob for upgrade args in golden nns tests

### DIFF
--- a/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
+++ b/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
@@ -61,8 +61,10 @@ impl NnsCanisterUpgrade {
                 }))
             )
             .unwrap()
-        } else {
+        } else if nns_canister_name == "ledger" {
             Encode!(&()).unwrap()
+        } else {
+            vec![]
         };
 
         let nns_canister_name = nns_canister_name.to_string();


### PR DESCRIPTION
When an NNS canister does not have an upgrade arg, the proposals are prepared using empty blobs (`vec![]`). Therefore the tests should be too.