### PR TITLE
test(IDX): move //rs/execution_environment:execution_environment_misc_integration_tests/dts to its own target

### DIFF
--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -168,7 +168,6 @@ rust_ic_test(
     name = "dts_test",
     size = "large",
     srcs = ["tests/dts.rs"],
-    compile_data = glob(["tests/test-data/**"]),
     data = DATA + [
         "//rs/universal_canister/impl:universal_canister.wasm.gz",
     ],

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -134,7 +134,13 @@ rust_ic_test(
 rust_ic_test_suite(
     name = "execution_environment_misc_integration",
     size = "large",
-    srcs = glob(["tests/*.rs"]),
+    srcs = glob(
+        ["tests/*.rs"],
+        # Exclude the dts test, which has a separate dts_test target below
+        # because it suffered from long running times on CI
+        # so we want to experiment with different configuration options.
+        exclude = ["tests/dts.rs"],
+    ),
     aliases = ALIASES,
     compile_data = glob(["tests/test-data/**"]),
     data = DATA + [
@@ -150,6 +156,25 @@ rust_ic_test_suite(
         ("IMAGE_CLASSIFICATION_CANISTER_WASM_PATH", "$(rootpath //testnet/prebuilt-canisters:image-classification)"),
     ]),
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "test_macos_slow",
+    ],
+    deps = [":execution_environment"] + DEPENDENCIES + DEV_DEPENDENCIES,
+)
+
+# TODO: move this dts test back into the :execution_environment_misc_integration target above
+# when we get its P90 running time back under 5 minutes.
+rust_ic_test(
+    name = "dts_test",
+    size = "large",
+    srcs = ["tests/dts.rs"],
+    compile_data = glob(["tests/test-data/**"]),
+    data = DATA + [
+        "//rs/universal_canister/impl:universal_canister.wasm.gz",
+    ],
+    env = dict(ENV.items() + [
+        ("UNIVERSAL_CANISTER_WASM_PATH", "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)"),
+    ]),
     tags = [
         "test_macos_slow",
     ],


### PR DESCRIPTION
The P90 duration of the [//rs/execution_environment:execution_environment_misc_integration_tests/dts](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/execution_environment/tests/dts.rs) test [jumped up](https://superset.idx.dfinity.network/explore/?slice_id=108) starting in March 2024 and reached above the maximum of 5 minutes. We can't reproduce this locally so it's likely related to a load issue on CI.

To have more control over the resource usage of this test we move it to its own dedicated bazel target ` //rs/execution_environment:dts_test`. We don't change any CPU reservation or `RUST_TEST_THREADS` settings yet such that we can gather some data on the baseline durations.