### PR TITLE
chore(IDX): remove alerts for ic version workflow

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -18,7 +18,6 @@ on:
       - Release Testing
       - Publish Release
       - Container IC Base Images
-      - Update IC versions file
 
 jobs:
   slack-workflow-run:


### PR DESCRIPTION
Some of the tests are flaky and therefore alerts are unnecessary. Since this is run once an hour it will be retried automatically if it fails.