### PR TITLE
feat(sns): Ensure legacy and topic-based following are exclusive relations

### DIFF
--- a/rs/sns/governance/src/following.rs
+++ b/rs/sns/governance/src/following.rs
@@ -21,7 +21,7 @@ pub const MAX_FOLLOWEES_PER_TOPIC: usize = 15;
 lazy_static! {
     /// All topics that are available for following.
     // One enum value is reserved for the unspecified topic.
-    static ref TOPICS: Vec<Topic> = Topic::iter().skip(1).collect::<Vec<_>>();
+    pub(crate) static ref TOPICS: BTreeSet<Topic> = Topic::iter().skip(1).collect();
 
     /// Number of topics that are available for following.
     static ref NUM_TOPICS: usize = TOPICS.len();


### PR DESCRIPTION
This PR adds a validation step to both the legacy and the new following neuron commands, so legacy following cannot be added (but can be removed) if there is some topic-based following, and topic-based following must be added for all topics if there was any legacy following.