### PR TITLE
chore(EXC-1802): Remove old sandbox rpc calls

### DIFF
--- a/rs/canister_sandbox/BUILD.bazel
+++ b/rs/canister_sandbox/BUILD.bazel
@@ -123,7 +123,10 @@ rust_binary(
     srcs = ["bin/test_controller.rs"],
     aliases = ALIASES,
     proc_macro_deps = MACRO_DEPENDENCIES,
-    deps = DEPENDENCIES + [":backend_lib"],
+    deps = DEPENDENCIES + [
+        ":backend_lib",
+        "@crate_index//:tempfile",
+    ],
 )
 
 rust_binary(
@@ -131,7 +134,10 @@ rust_binary(
     srcs = ["bin/test_sandbox.rs"],
     aliases = ALIASES,
     proc_macro_deps = MACRO_DEPENDENCIES,
-    deps = DEPENDENCIES + [":backend_lib"],
+    deps = DEPENDENCIES + [
+        ":backend_lib",
+        "@crate_index//:tempfile",
+    ],
 )
 
 rust_binary(

--- a/rs/canister_sandbox/Cargo.toml
+++ b/rs/canister_sandbox/Cargo.toml
@@ -42,6 +42,7 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true }
+tempfile = { workspace = true }
 threadpool = { workspace = true }
 which = "4.2.2"
 
@@ -61,7 +62,6 @@ rand = { workspace = true }
 rstest = { workspace = true }
 slog-async = { workspace = true }
 slog-term = { workspace = true }
-tempfile = { workspace = true }
 wat = { workspace = true }
 
 [features]

--- a/rs/canister_sandbox/bin/test_controller.rs
+++ b/rs/canister_sandbox/bin/test_controller.rs
@@ -4,8 +4,10 @@ use ic_canister_sandbox_backend_lib::{
     protocol::{ctlsvc, id::WasmId, logging::LogRequest, sbxsvc},
     rpc,
 };
-use ic_embedders::SerializedModuleBytes;
-use std::sync::{atomic::AtomicBool, Arc};
+use std::{
+    os::fd::AsRawFd,
+    sync::{atomic::AtomicBool, Arc},
+};
 
 struct DummyControllerService {}
 
@@ -45,9 +47,10 @@ fn main() {
 
     println!("Controller: Sending 'open_wasm' request");
     let wasm_id = WasmId::new();
-    sbx.open_wasm_serialized(sbxsvc::OpenWasmSerializedRequest {
+    let file = tempfile::tempfile().unwrap();
+    sbx.open_wasm(sbxsvc::OpenWasmRequest {
         wasm_id,
-        serialized_module: Arc::new(SerializedModuleBytes::empty()),
+        serialized_module: file.as_raw_fd(),
     })
     .sync()
     .unwrap();

--- a/rs/canister_sandbox/bin/test_sandbox.rs
+++ b/rs/canister_sandbox/bin/test_sandbox.rs
@@ -20,18 +20,7 @@ impl sandbox_service::SandboxService for DummySandboxService {
         rpc::Call::new_resolved(Ok(sbxsvc::TerminateReply {}))
     }
 
-    fn open_wasm_serialized(
-        &self,
-        _req: sbxsvc::OpenWasmSerializedRequest,
-    ) -> rpc::Call<sbxsvc::OpenWasmSerializedReply> {
-        println!("Sandbox: Received 'open_wasm_serialized' request");
-        rpc::Call::new_resolved(Ok(sbxsvc::OpenWasmSerializedReply(Ok(()))))
-    }
-
-    fn open_wasm_via_file(
-        &self,
-        _req: sbxsvc::OpenWasmViaFileRequest,
-    ) -> rpc::Call<sbxsvc::OpenWasmSerializedReply> {
+    fn open_wasm(&self, _req: sbxsvc::OpenWasmRequest) -> rpc::Call<sbxsvc::OpenWasmReply> {
         unimplemented!()
     }
 
@@ -71,17 +60,10 @@ impl sandbox_service::SandboxService for DummySandboxService {
         unimplemented!()
     }
 
-    fn create_execution_state_serialized(
+    fn create_execution_state(
         &self,
-        _req: sbxsvc::CreateExecutionStateSerializedRequest,
-    ) -> rpc::Call<sbxsvc::CreateExecutionStateSerializedReply> {
-        unimplemented!()
-    }
-
-    fn create_execution_state_via_file(
-        &self,
-        _req: sbxsvc::CreateExecutionStateViaFileRequest,
-    ) -> rpc::Call<sbxsvc::CreateExecutionStateSerializedReply> {
+        _req: sbxsvc::CreateExecutionStateRequest,
+    ) -> rpc::Call<sbxsvc::CreateExecutionStateReply> {
         unimplemented!()
     }
 }

--- a/rs/canister_sandbox/src/protocol/sbxsvc.rs
+++ b/rs/canister_sandbox/src/protocol/sbxsvc.rs
@@ -1,11 +1,10 @@
 //! This defines the RPC service methods offered by the sandbox process
 //! (used by the controller) as well as the expected replies.
 
-use std::{os::fd::RawFd, sync::Arc, time::Duration};
+use std::{os::fd::RawFd, time::Duration};
 
 use crate::fdenum::EnumerateInnerFileDescriptors;
 use crate::protocol::structs;
-use ic_embedders::{SerializedModule, SerializedModuleBytes};
 use ic_interfaces::execution_environment::HypervisorResult;
 use ic_management_canister_types_private::Global;
 use ic_replicated_state::{
@@ -17,7 +16,6 @@ use ic_replicated_state::{
     NumWasmPages,
 };
 use ic_types::CanisterId;
-use ic_utils;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -43,26 +41,7 @@ pub struct TerminateReply {}
 /// support multiple code states e.g. during upgrades). A single wasm
 /// instance can be used concurrently for multiple executions.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub struct OpenWasmSerializedRequest {
-    /// Id used to later refer to this canister runner. Must be unique
-    /// per sandbox instance.
-    pub wasm_id: WasmId,
-
-    /// The serialization of a previously compiled `wasmtime::Module`.
-    /// This types in just an `Arc` reference to a vector of bytes and the only
-    /// reason it is `Arc` is so that we can cheaply create the
-    /// `OpenWasmSerializedRequest` before sending it to the sandbox.
-    #[serde(serialize_with = "ic_utils::serde_arc::serialize_arc")]
-    #[serde(deserialize_with = "ic_utils::serde_arc::deserialize_arc")]
-    pub serialized_module: Arc<SerializedModuleBytes>,
-}
-
-/// Reply to an `OpenWasmRequest`.
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub struct OpenWasmSerializedReply(pub HypervisorResult<()>);
-
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub struct OpenWasmViaFileRequest {
+pub struct OpenWasmRequest {
     /// Id used to later refer to this canister runner. Must be unique
     /// per sandbox instance.
     pub wasm_id: WasmId,
@@ -71,7 +50,11 @@ pub struct OpenWasmViaFileRequest {
     pub serialized_module: RawFd,
 }
 
-impl EnumerateInnerFileDescriptors for OpenWasmViaFileRequest {
+/// Reply to an `OpenWasmRequest`.
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct OpenWasmReply(pub HypervisorResult<()>);
+
+impl EnumerateInnerFileDescriptors for OpenWasmRequest {
     fn enumerate_fds<'a>(&'a mut self, fds: &mut Vec<&'a mut std::os::unix::io::RawFd>) {
         fds.push(&mut self.serialized_module);
     }
@@ -248,43 +231,7 @@ pub struct AbortExecutionReply {
 }
 
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub struct CreateExecutionStateSerializedRequest {
-    pub wasm_id: WasmId,
-    /// The serialization of a previously compiled `wasmtime::Module`.
-    /// This types in just an `Arc` reference to a vector of bytes and the only
-    /// reason it is `Arc` is so that we can cheaply create the
-    /// `CreateExecutionStateSerializedRequest` before sending it to the sandbox.
-    #[serde(serialize_with = "ic_utils::serde_arc::serialize_arc")]
-    #[serde(deserialize_with = "ic_utils::serde_arc::deserialize_arc")]
-    pub serialized_module: Arc<SerializedModule>,
-    pub wasm_page_map: PageMapSerialization,
-    pub next_wasm_memory_id: MemoryId,
-    pub canister_id: CanisterId,
-    pub stable_memory_page_map: PageMapSerialization,
-}
-
-impl EnumerateInnerFileDescriptors for CreateExecutionStateSerializedRequest {
-    fn enumerate_fds<'a>(&'a mut self, fds: &mut Vec<&'a mut std::os::unix::io::RawFd>) {
-        self.wasm_page_map.enumerate_fds(fds);
-        self.stable_memory_page_map.enumerate_fds(fds);
-    }
-}
-
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub struct CreateExecutionStateSerializedSuccessReply {
-    pub wasm_memory_modifications: MemoryModifications,
-    pub exported_globals: Vec<Global>,
-    pub deserialization_time: Duration,
-    pub total_sandbox_time: Duration,
-}
-
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub struct CreateExecutionStateSerializedReply(
-    pub HypervisorResult<CreateExecutionStateSerializedSuccessReply>,
-);
-
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub struct CreateExecutionStateViaFileRequest {
+pub struct CreateExecutionStateRequest {
     pub wasm_id: WasmId,
     pub bytes: RawFd,
     pub initial_state_data: RawFd,
@@ -294,7 +241,18 @@ pub struct CreateExecutionStateViaFileRequest {
     pub stable_memory_page_map: PageMapSerialization,
 }
 
-impl EnumerateInnerFileDescriptors for CreateExecutionStateViaFileRequest {
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct CreateExecutionStateSuccessReply {
+    pub wasm_memory_modifications: MemoryModifications,
+    pub exported_globals: Vec<Global>,
+    pub deserialization_time: Duration,
+    pub total_sandbox_time: Duration,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct CreateExecutionStateReply(pub HypervisorResult<CreateExecutionStateSuccessReply>);
+
+impl EnumerateInnerFileDescriptors for CreateExecutionStateRequest {
     fn enumerate_fds<'a>(&'a mut self, fds: &mut Vec<&'a mut std::os::unix::io::RawFd>) {
         fds.push(&mut self.bytes);
         fds.push(&mut self.initial_state_data);
@@ -308,27 +266,23 @@ impl EnumerateInnerFileDescriptors for CreateExecutionStateViaFileRequest {
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub enum Request {
     Terminate(TerminateRequest),
-    OpenWasmSerialized(OpenWasmSerializedRequest),
-    OpenWasmViaFile(OpenWasmViaFileRequest),
+    OpenWasm(OpenWasmRequest),
     CloseWasm(CloseWasmRequest),
     OpenMemory(OpenMemoryRequest),
     CloseMemory(CloseMemoryRequest),
     StartExecution(StartExecutionRequest),
     ResumeExecution(ResumeExecutionRequest),
     AbortExecution(AbortExecutionRequest),
-    CreateExecutionStateSerialized(CreateExecutionStateSerializedRequest),
-    CreateExecutionStateViaFile(CreateExecutionStateViaFileRequest),
+    CreateExecutionState(CreateExecutionStateRequest),
 }
 
 impl EnumerateInnerFileDescriptors for Request {
     fn enumerate_fds<'a>(&'a mut self, fds: &mut Vec<&'a mut std::os::unix::io::RawFd>) {
         match self {
             Request::OpenMemory(request) => request.enumerate_fds(fds),
-            Request::CreateExecutionStateSerialized(request) => request.enumerate_fds(fds),
-            Request::OpenWasmViaFile(request) => request.enumerate_fds(fds),
-            Request::CreateExecutionStateViaFile(request) => request.enumerate_fds(fds),
+            Request::OpenWasm(request) => request.enumerate_fds(fds),
+            Request::CreateExecutionState(request) => request.enumerate_fds(fds),
             Request::Terminate(_)
-            | Request::OpenWasmSerialized(_)
             | Request::CloseWasm(_)
             | Request::CloseMemory(_)
             | Request::StartExecution(_)
@@ -343,18 +297,14 @@ impl EnumerateInnerFileDescriptors for Request {
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub enum Reply {
     Terminate(TerminateReply),
-    OpenWasmSerialized(OpenWasmSerializedReply),
-    /// Reuse the same reply as for Serialized requests.
-    OpenWasmViaFile(OpenWasmSerializedReply),
+    OpenWasm(OpenWasmReply),
     CloseWasm(CloseWasmReply),
     OpenMemory(OpenMemoryReply),
     CloseMemory(CloseMemoryReply),
     StartExecution(StartExecutionReply),
     ResumeExecution(ResumeExecutionReply),
     AbortExecution(AbortExecutionReply),
-    CreateExecutionStateSerialized(CreateExecutionStateSerializedReply),
-    /// Reuse the same reply as for Serialized requests.
-    CreateExecutionStateViaFile(CreateExecutionStateSerializedReply),
+    CreateExecutionState(CreateExecutionStateReply),
 }
 
 impl EnumerateInnerFileDescriptors for Reply {
@@ -365,24 +315,16 @@ impl EnumerateInnerFileDescriptors for Reply {
 mod tests {
     use super::*;
 
-    use std::{sync::Arc, time::Duration};
+    use std::time::Duration;
 
     use ic_base_types::NumSeconds;
-    use ic_config::{
-        embedders::Config as EmbeddersConfig, flag_status::FlagStatus,
-        subnet_config::CyclesAccountManagerConfig,
-    };
+    use ic_config::{flag_status::FlagStatus, subnet_config::CyclesAccountManagerConfig};
     use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
-    use ic_embedders::{
-        wasm_utils,
-        wasmtime_embedder::system_api::{
-            sandbox_safe_system_state::SandboxSafeSystemState, ApiType, ExecutionParameters,
-            InstructionLimits,
-        },
-        CompilationResult, SerializedModule, WasmtimeEmbedder,
+    use ic_embedders::wasmtime_embedder::system_api::{
+        sandbox_safe_system_state::SandboxSafeSystemState, ApiType, ExecutionParameters,
+        InstructionLimits,
     };
     use ic_interfaces::execution_environment::{ExecutionMode, SubnetAvailableMemory};
-    use ic_logger::no_op_logger;
     use ic_registry_subnet_type::SubnetType;
     use ic_replicated_state::{
         Memory, MessageMemoryUsage, NetworkTopology, NumWasmPages, PageMap, SystemState,
@@ -393,7 +335,6 @@ mod tests {
         methods::{FuncRef, WasmMethod},
         ComputeAllocation, Cycles, MemoryAllocation, NumBytes, NumInstructions, SubnetId, Time,
     };
-    use ic_wasm_types::BinaryEncodedWasm;
 
     use crate::protocol::{
         id::{ExecId, MemoryId, WasmId},
@@ -401,22 +342,6 @@ mod tests {
     };
 
     const IS_WASM64_EXECUTION: bool = false;
-
-    fn wasm_module() -> (CompilationResult, SerializedModule) {
-        let wat = r#"
-            (module
-                (func (export "canister_init")
-                    (drop (memory.grow (i32.const 160)))
-                )
-                (memory 1)
-            )"#;
-        let embedder = WasmtimeEmbedder::new(EmbeddersConfig::default(), no_op_logger());
-        let wasm = wat::parse_str(wat).unwrap();
-
-        wasm_utils::compile(&embedder, &BinaryEncodedWasm::new(wasm))
-            .1
-            .unwrap()
-    }
 
     fn round_trip_request(msg: &Request) -> Request {
         let ser = bincode::serialize(&msg).unwrap();
@@ -441,17 +366,8 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_open_wasm_serialized_request() {
-        let msg = Request::OpenWasmSerialized(OpenWasmSerializedRequest {
-            wasm_id: WasmId::new(),
-            serialized_module: wasm_module().1.bytes,
-        });
-        assert_eq!(round_trip_request(&msg), msg);
-    }
-
-    #[test]
-    fn round_trip_open_wasm_via_file_request() {
-        let msg = Request::OpenWasmViaFile(OpenWasmViaFileRequest {
+    fn round_trip_open_wasm_request() {
+        let msg = Request::OpenWasm(OpenWasmRequest {
             wasm_id: WasmId::new(),
             serialized_module: RawFd::from(35),
         });
@@ -459,8 +375,8 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_open_wasm_serialized_reply() {
-        let msg = Reply::OpenWasmSerialized(OpenWasmSerializedReply(Ok(())));
+    fn round_trip_open_wasm_reply() {
+        let msg = Reply::OpenWasm(OpenWasmReply(Ok(())));
         assert_eq!(round_trip_reply(&msg), msg);
     }
 
@@ -621,21 +537,8 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_create_execution_state_serialized_request() {
-        let msg = Request::CreateExecutionStateSerialized(CreateExecutionStateSerializedRequest {
-            wasm_id: WasmId::new(),
-            serialized_module: Arc::new(wasm_module().1),
-            wasm_page_map: PageMap::new_for_testing().serialize(),
-            next_wasm_memory_id: MemoryId::new(),
-            canister_id: canister_test_id(1),
-            stable_memory_page_map: PageMap::new_for_testing().serialize(),
-        });
-        assert_eq!(round_trip_request(&msg), msg);
-    }
-
-    #[test]
-    fn round_trip_create_execution_state_via_file_request() {
-        let msg = Request::CreateExecutionStateViaFile(CreateExecutionStateViaFileRequest {
+    fn round_trip_create_execution_state_request() {
+        let msg = Request::CreateExecutionState(CreateExecutionStateRequest {
             wasm_id: WasmId::new(),
             bytes: RawFd::from(10),
             initial_state_data: RawFd::from(11),
@@ -648,8 +551,8 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_create_execution_state_serialized_reply() {
-        let reply = CreateExecutionStateSerializedSuccessReply {
+    fn round_trip_create_execution_state_reply() {
+        let reply = CreateExecutionStateSuccessReply {
             wasm_memory_modifications: MemoryModifications {
                 page_delta: PageMap::new_for_testing().serialize_delta(&[]),
                 size: NumWasmPages::new(10),
@@ -664,8 +567,7 @@ mod tests {
             deserialization_time: Duration::from_secs(1),
             total_sandbox_time: Duration::from_secs(2),
         };
-        let msg =
-            Reply::CreateExecutionStateSerialized(CreateExecutionStateSerializedReply(Ok(reply)));
+        let msg = Reply::CreateExecutionState(CreateExecutionStateReply(Ok(reply)));
         assert_eq!(round_trip_reply(&msg), msg);
     }
 }

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -1088,14 +1088,14 @@ impl WasmExecutor for SandboxedExecutionController {
                                 compilation_cache.insert_ok(&wasm_binary.binary, serialized_module);
 
                             sandbox_process.history.record(format!(
-                                "CreateExecutionStateViaFile(wasm_id={}, \
+                                "CreateExecutionState(wasm_id={}, \
                                         next_wasm_memory_id={})",
                                 wasm_id, next_wasm_memory_id
                             ));
                             let sandbox_result = sandbox_process
                                 .sandbox_service
-                                .create_execution_state_via_file(
-                                    protocol::sbxsvc::CreateExecutionStateViaFileRequest {
+                                .create_execution_state(
+                                    protocol::sbxsvc::CreateExecutionStateRequest {
                                         wasm_id,
                                         bytes: serialized_module.bytes.as_raw_fd(),
                                         initial_state_data: serialized_module
@@ -1137,25 +1137,21 @@ impl WasmExecutor for SandboxedExecutionController {
                         .sandboxed_execution_replica_create_exe_state_wait_deserialize_duration
                         .start_timer();
                     sandbox_process.history.record(format!(
-                        "CreateExecutionStateViaFile(wasm_id={}, \
+                        "CreateExecutionState(wasm_id={}, \
                                 next_wasm_memory_id={})",
                         wasm_id, next_wasm_memory_id
                     ));
                     let sandbox_result = sandbox_process
                         .sandbox_service
-                        .create_execution_state_via_file(
-                            protocol::sbxsvc::CreateExecutionStateViaFileRequest {
-                                wasm_id,
-                                bytes: serialized_module.bytes.as_raw_fd(),
-                                initial_state_data: serialized_module
-                                    .initial_state_data
-                                    .as_raw_fd(),
-                                wasm_page_map: wasm_page_map.serialize(),
-                                next_wasm_memory_id,
-                                canister_id,
-                                stable_memory_page_map: stable_memory_page_map.serialize(),
-                            },
-                        )
+                        .create_execution_state(protocol::sbxsvc::CreateExecutionStateRequest {
+                            wasm_id,
+                            bytes: serialized_module.bytes.as_raw_fd(),
+                            initial_state_data: serialized_module.initial_state_data.as_raw_fd(),
+                            wasm_page_map: wasm_page_map.serialize(),
+                            next_wasm_memory_id,
+                            canister_id,
+                            stable_memory_page_map: stable_memory_page_map.serialize(),
+                        })
                         .sync()
                         .unwrap()
                         .0?;
@@ -1883,7 +1879,7 @@ fn open_wasm(
             observe_metrics(metrics, &serialized_module.imports_details);
             sandbox_process
                 .history
-                .record(format!("OpenWasmViaFile(wasm_id={})", wasm_id));
+                .record(format!("OpenWasm(wasm_id={})", wasm_id));
             // The IPC message may be sent later on a background thread
             // and it's possible this entry has been dropped from the
             // cache in the mean time. In order to keep the file
@@ -1892,7 +1888,7 @@ fn open_wasm(
             let copy = Arc::clone(&serialized_module);
             sandbox_process
                 .sandbox_service
-                .open_wasm_via_file(protocol::sbxsvc::OpenWasmViaFileRequest {
+                .open_wasm(protocol::sbxsvc::OpenWasmRequest {
                     wasm_id,
                     serialized_module: serialized_module.bytes.as_raw_fd(),
                 })

--- a/rs/canister_sandbox/src/sandbox_client_stub.rs
+++ b/rs/canister_sandbox/src/sandbox_client_stub.rs
@@ -24,26 +24,11 @@ impl SandboxService for SandboxClientStub {
         Call::new(cell)
     }
 
-    fn open_wasm_serialized(
-        &self,
-        req: OpenWasmSerializedRequest,
-    ) -> Call<OpenWasmSerializedReply> {
-        let cell = self
-            .channel
-            .call(Request::OpenWasmSerialized(req), |rep| match rep {
-                Reply::OpenWasmSerialized(rep) => Ok(rep),
-                _ => Err(Error::ServerError),
-            });
-        Call::new(cell)
-    }
-
-    fn open_wasm_via_file(&self, req: OpenWasmViaFileRequest) -> Call<OpenWasmSerializedReply> {
-        let cell = self
-            .channel
-            .call(Request::OpenWasmViaFile(req), |rep| match rep {
-                Reply::OpenWasmSerialized(rep) => Ok(rep),
-                _ => Err(Error::ServerError),
-            });
+    fn open_wasm(&self, req: OpenWasmRequest) -> Call<OpenWasmReply> {
+        let cell = self.channel.call(Request::OpenWasm(req), |rep| match rep {
+            Reply::OpenWasm(rep) => Ok(rep),
+            _ => Err(Error::ServerError),
+        });
         Call::new(cell)
     }
 
@@ -105,28 +90,14 @@ impl SandboxService for SandboxClientStub {
         Call::new(cell)
     }
 
-    fn create_execution_state_serialized(
+    fn create_execution_state(
         &self,
-        req: CreateExecutionStateSerializedRequest,
-    ) -> Call<CreateExecutionStateSerializedReply> {
-        let cell = self.channel.call(
-            Request::CreateExecutionStateSerialized(req),
-            |rep| match rep {
-                Reply::CreateExecutionStateSerialized(rep) => Ok(rep),
-                _ => Err(Error::ServerError),
-            },
-        );
-        Call::new(cell)
-    }
-
-    fn create_execution_state_via_file(
-        &self,
-        req: CreateExecutionStateViaFileRequest,
-    ) -> Call<CreateExecutionStateSerializedReply> {
+        req: CreateExecutionStateRequest,
+    ) -> Call<CreateExecutionStateReply> {
         let cell = self
             .channel
-            .call(Request::CreateExecutionStateViaFile(req), |rep| match rep {
-                Reply::CreateExecutionStateSerialized(rep) => Ok(rep),
+            .call(Request::CreateExecutionState(req), |rep| match rep {
+                Reply::CreateExecutionState(rep) => Ok(rep),
                 _ => Err(Error::ServerError),
             });
         Call::new(cell)

--- a/rs/canister_sandbox/src/sandbox_server.rs
+++ b/rs/canister_sandbox/src/sandbox_server.rs
@@ -32,21 +32,7 @@ impl SandboxService for SandboxServer {
         std::process::exit(0);
     }
 
-    fn open_wasm_serialized(
-        &self,
-        req: OpenWasmSerializedRequest,
-    ) -> rpc::Call<OpenWasmSerializedReply> {
-        let result = self
-            .manager
-            .open_wasm_serialized(req.wasm_id, &req.serialized_module)
-            .map(|_| ());
-        rpc::Call::new_resolved(Ok(OpenWasmSerializedReply(result)))
-    }
-
-    fn open_wasm_via_file(
-        &self,
-        req: OpenWasmViaFileRequest,
-    ) -> rpc::Call<OpenWasmSerializedReply> {
+    fn open_wasm(&self, req: OpenWasmRequest) -> rpc::Call<OpenWasmReply> {
         let result = self
             .manager
             // SAFETY: The IPC guarantees we get valid file descriptors.
@@ -54,7 +40,7 @@ impl SandboxService for SandboxServer {
                 File::from_raw_fd(req.serialized_module)
             })
             .map(|_| ());
-        rpc::Call::new_resolved(Ok(OpenWasmSerializedReply(result)))
+        rpc::Call::new_resolved(Ok(OpenWasmReply(result)))
     }
 
     fn close_wasm(&self, req: CloseWasmRequest) -> rpc::Call<CloseWasmReply> {
@@ -107,26 +93,11 @@ impl SandboxService for SandboxServer {
         })
     }
 
-    fn create_execution_state_serialized(
+    fn create_execution_state(
         &self,
-        req: CreateExecutionStateSerializedRequest,
-    ) -> rpc::Call<CreateExecutionStateSerializedReply> {
-        let result = self.manager.create_execution_state_serialized(
-            req.wasm_id,
-            req.serialized_module,
-            req.wasm_page_map,
-            req.next_wasm_memory_id,
-            req.canister_id,
-            req.stable_memory_page_map,
-        );
-        rpc::Call::new_resolved(Ok(CreateExecutionStateSerializedReply(result)))
-    }
-
-    fn create_execution_state_via_file(
-        &self,
-        req: CreateExecutionStateViaFileRequest,
-    ) -> rpc::Call<CreateExecutionStateSerializedReply> {
-        let result = self.manager.create_execution_state_via_file(
+        req: CreateExecutionStateRequest,
+    ) -> rpc::Call<CreateExecutionStateReply> {
+        let result = self.manager.create_execution_state(
             req.wasm_id,
             // SAFETY: The IPC guarantees that we get valid file descriptors.
             unsafe { File::from_raw_fd(req.bytes) },
@@ -136,7 +107,7 @@ impl SandboxService for SandboxServer {
             req.canister_id,
             req.stable_memory_page_map,
         );
-        rpc::Call::new_resolved(Ok(CreateExecutionStateSerializedReply(result)))
+        rpc::Call::new_resolved(Ok(CreateExecutionStateReply(result)))
     }
 }
 
@@ -183,9 +154,13 @@ mod tests {
     };
     use ic_wasm_types::BinaryEncodedWasm;
     use mockall::*;
-    use std::collections::{BTreeMap, BTreeSet};
-    use std::convert::TryFrom;
     use std::sync::{Arc, Condvar, Mutex};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        io::Write,
+        os::fd::AsRawFd,
+    };
+    use std::{convert::TryFrom, os::fd::RawFd};
 
     const INSTRUCTION_LIMIT: u64 = 100_000;
     const IS_WASM64_EXECUTION: bool = false;
@@ -603,6 +578,19 @@ mod tests {
             .bytes
     }
 
+    /// Mocks what would happen in the compilation cache where we get a handle
+    /// to a deleted file. The resulting RawFd should be closed by the caller to
+    /// properly clean up temporary files.
+    fn write_to_deleted_file(bytes: &SerializedModuleBytes) -> RawFd {
+        let mut tmpfile = tempfile::tempfile().unwrap();
+        tmpfile.write_all(bytes.as_slice()).unwrap();
+        let fd = tmpfile.as_raw_fd();
+        // Can't drop the file because the fd must remain valid.
+        #[allow(clippy::mem_forget)]
+        std::mem::forget(tmpfile);
+        fd
+    }
+
     /// Verifies that we can create a simple canister and run something on
     /// it.
     #[test]
@@ -618,8 +606,9 @@ mod tests {
 
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_counter_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })
@@ -705,8 +694,9 @@ mod tests {
 
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_memory_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })
@@ -770,8 +760,9 @@ mod tests {
 
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_memory_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })
@@ -860,8 +851,9 @@ mod tests {
 
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_counter_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })
@@ -991,8 +983,9 @@ mod tests {
 
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_memory_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })
@@ -1056,8 +1049,9 @@ mod tests {
 
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_memory_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })
@@ -1130,8 +1124,9 @@ mod tests {
 
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_memory_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })
@@ -1240,8 +1235,9 @@ mod tests {
 
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_memory_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })
@@ -1375,8 +1371,9 @@ mod tests {
         // Compile the wasm code.
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_long_running_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })
@@ -1496,8 +1493,9 @@ mod tests {
         // Compile the wasm code.
         let wasm_id = WasmId::new();
         let serialized_module = compile_module(make_long_running_canister_wasm());
+        let serialized_module = write_to_deleted_file(&serialized_module);
         let rep = srv
-            .open_wasm_serialized(OpenWasmSerializedRequest {
+            .open_wasm(OpenWasmRequest {
                 wasm_id,
                 serialized_module,
             })

--- a/rs/canister_sandbox/src/sandbox_service.rs
+++ b/rs/canister_sandbox/src/sandbox_service.rs
@@ -8,10 +8,7 @@ pub trait SandboxService: Send + Sync {
 
     /// Creates a canister Wasm code object. The already compiled Wasm module is
     /// passed in the request.
-    fn open_wasm_serialized(&self, req: OpenWasmSerializedRequest)
-        -> Call<OpenWasmSerializedReply>;
-
-    fn open_wasm_via_file(&self, req: OpenWasmViaFileRequest) -> Call<OpenWasmSerializedReply>;
+    fn open_wasm(&self, req: OpenWasmRequest) -> Call<OpenWasmReply>;
 
     /// Close the indicated canister Wasm code object. Code cannot be
     /// used anymore.
@@ -41,15 +38,10 @@ pub trait SandboxService: Send + Sync {
 
     /// Perform deserialization of a serialized module needed to create the
     /// starting execution state.
-    fn create_execution_state_serialized(
+    fn create_execution_state(
         &self,
-        req: CreateExecutionStateSerializedRequest,
-    ) -> Call<CreateExecutionStateSerializedReply>;
-
-    fn create_execution_state_via_file(
-        &self,
-        req: CreateExecutionStateViaFileRequest,
-    ) -> Call<CreateExecutionStateSerializedReply>;
+        req: CreateExecutionStateRequest,
+    ) -> Call<CreateExecutionStateReply>;
 }
 
 impl<Svc: SandboxService + Send + Sync> DemuxServer<Request, Reply> for Svc {
@@ -58,12 +50,7 @@ impl<Svc: SandboxService + Send + Sync> DemuxServer<Request, Reply> for Svc {
     fn dispatch(&self, req: Request) -> Call<Reply> {
         match req {
             Request::Terminate(req) => Call::new_wrap(self.terminate(req), Reply::Terminate),
-            Request::OpenWasmSerialized(req) => {
-                Call::new_wrap(self.open_wasm_serialized(req), Reply::OpenWasmSerialized)
-            }
-            Request::OpenWasmViaFile(req) => {
-                Call::new_wrap(self.open_wasm_via_file(req), Reply::OpenWasmSerialized)
-            }
+            Request::OpenWasm(req) => Call::new_wrap(self.open_wasm(req), Reply::OpenWasm),
             Request::CloseWasm(req) => Call::new_wrap(self.close_wasm(req), Reply::CloseWasm),
             Request::OpenMemory(req) => Call::new_wrap(self.open_memory(req), Reply::OpenMemory),
             Request::CloseMemory(req) => Call::new_wrap(self.close_memory(req), Reply::CloseMemory),
@@ -76,13 +63,9 @@ impl<Svc: SandboxService + Send + Sync> DemuxServer<Request, Reply> for Svc {
             Request::AbortExecution(req) => {
                 Call::new_wrap(self.abort_execution(req), Reply::AbortExecution)
             }
-            Request::CreateExecutionStateSerialized(req) => Call::new_wrap(
-                self.create_execution_state_serialized(req),
-                Reply::CreateExecutionStateSerialized,
-            ),
-            Request::CreateExecutionStateViaFile(req) => Call::new_wrap(
-                self.create_execution_state_via_file(req),
-                Reply::CreateExecutionStateSerialized,
+            Request::CreateExecutionState(req) => Call::new_wrap(
+                self.create_execution_state(req),
+                Reply::CreateExecutionState,
             ),
         }
     }


### PR DESCRIPTION
EXC-1802

There were two copies of the sandbox `OpenWasm` and `CreateExecutionState` RPC calls to handle the in-memory and on-disk compilation caches. Now that we've switched to the on-disk version we can remove the extra version.