### PR TITLE
chore(IDX): don't validate on synchronize

### DIFF
--- a/.github/workflows/ci-pr-title-validation.yml
+++ b/.github/workflows/ci-pr-title-validation.yml
@@ -2,7 +2,7 @@ name: PR Title Validation
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, reopened, edited]
 
 # Copied & adapted (job name, version label) from
 # https://github.com/ytanikin/pr-conventional-commits?tab=readme-ov-file#usage-with-labeling-where-label-is-just-a-task-type


### PR DESCRIPTION
We don't need to trigger workflow for triggering title validation on every commit.