### PR TITLE
feat(crypto): CRP-2733 run vetKD benches for more subnet sizes

### DIFF
--- a/rs/crypto/benches/vetkd.rs
+++ b/rs/crypto/benches/vetkd.rs
@@ -48,7 +48,9 @@ fn vetkd_bench(criterion: &mut Criterion) {
         bench_create_encrypted_key_share(group, &config, &env, rng);
         bench_verify_encrypted_key_share(group, &config, &env, rng);
         bench_combine_encrypted_key_shares(group, &config, subnet_size, &env, rng);
-        bench_combine_encrypted_key_shares(group, &config, threshold, &env, rng);
+        if threshold != subnet_size {
+            bench_combine_encrypted_key_shares(group, &config, threshold, &env, rng);
+        }
         bench_verify_encrypted_key(group, &config, &env, rng);
     }
 }

--- a/rs/crypto/benches/vetkd.rs
+++ b/rs/crypto/benches/vetkd.rs
@@ -33,7 +33,7 @@ fn vetkd_bench(criterion: &mut Criterion) {
         name: "dummy_key_name".to_string(),
     }));
 
-    for subnet_size in [13, 34] {
+    for subnet_size in [1, 4, 13, 34, 40] {
         let threshold = dkg_tag.threshold_for_subnet_of_size(subnet_size);
 
         let group = &mut criterion.benchmark_group(format!(


### PR DESCRIPTION
Adapts the vetKD benchmarks so that they don't only run for subnet sizes of `[13, 34]`, but for `[1, 4, 13, 34, 40]`, which is the same set we use for tECDSA, tSchnorr, and iDKG.