### PR TITLE
test(Multitoken_Rosetta): FI-1699: Add more resources for icrc_multitoken_rosetta_system test

### DIFF
--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -189,12 +189,14 @@ rust_test_suite_with_extra_srcs(
     env = LOCAL_REPLICA_ENV | {
         "CARGO_MANIFEST_DIR": "rs/rosetta-api/icrc1/",
         "ROSETTA_CLI": "$(rootpath @rosetta-cli//:rosetta-cli)",
+        "RUST_TEST_THREADS": "4",
     },
     extra_srcs = glob([
         "tests/common/*.rs",
     ]),
     flaky = True,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
+    tags = ["cpu:4"],
     deps = DEV_DEPENDENCIES + DEPENDENCIES,
 )
 


### PR DESCRIPTION
Add more resources for the `icrc_multitoken_rosetta_system` test, since it has been flaky, and the errors seem to indicate this could be due to not enough resources available to run the test.