### PR TITLE
feat(MR): [MR-649] Enable best-effort calls everywhere

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -164,7 +164,7 @@ impl Default for FeatureFlags {
             rate_limiting_of_debug_prints: FlagStatus::Enabled,
             write_barrier: FlagStatus::Disabled,
             wasm64: FlagStatus::Enabled,
-            best_effort_responses: BestEffortResponsesFeature::ApplicationSubnetsOnly,
+            best_effort_responses: BestEffortResponsesFeature::Enabled,
             canister_backtrace: FlagStatus::Enabled,
         }
     }


### PR DESCRIPTION
Switch from best-effort calls only being enabled on application subnets to best-effort calls enabled everywhere (including system subnets and NNS).

Best-effort calls have been enabled on selected application subnets for 4+ weeks now; and on all other application subnets for 2+ weeks. Metrics don't show anything out of the ordinary (such as e.g. leaked resources) and the feedback from canister developers is also positive in terms of correct behavior. The vast majority of the underlying code (message pooling, references, including dangling ones) has been running for many months as the basis of guaranteed response calls.

In conclusion, we believe it is safe to enable best-effort calls on system subnets.