### PR TITLE
feat(registry): Added `maybe_chunkify`...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19551,6 +19551,7 @@ dependencies = [
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-common-test-keys",
  "ic-nervous-system-string",
+ "ic-nervous-system-temporary",
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-test-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19557,6 +19557,7 @@ dependencies = [
  "ic-nns-test-utils-macros",
  "ic-protobuf",
  "ic-registry-canister-api",
+ "ic-registry-canister-chunkify",
  "ic-registry-client-fake",
  "ic-registry-keys",
  "ic-registry-nns-data-provider",

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -21,6 +21,7 @@ DEPENDENCIES = [
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
     "//rs/nervous_system/string",
+    "//rs/nervous_system/temporary",
     "//rs/nns/common",
     "//rs/nns/constants",
     "//rs/protobuf",

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -25,6 +25,7 @@ DEPENDENCIES = [
     "//rs/nns/constants",
     "//rs/protobuf",
     "//rs/registry/canister/api",
+    "//rs/registry/canister/chunkify",
     "//rs/registry/keys",
     "//rs/registry/node_provider_rewards",
     "//rs/registry/routing_table",

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -33,6 +33,7 @@ ic-nervous-system-clients = { path = "../../nervous_system/clients" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 ic-nervous-system-common-build-metadata = { path = "../../nervous_system/common/build_metadata" }
 ic-nervous-system-string = { path = "../../nervous_system/string" }
+ic-nervous-system-temporary = { path = "../../nervous_system/temporary" }
 ic-nns-common = { path = "../../nns/common" }
 ic-nns-constants = { path = "../../nns/constants" }
 ic-protobuf = { path = "../../protobuf" }

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -37,6 +37,7 @@ ic-nns-common = { path = "../../nns/common" }
 ic-nns-constants = { path = "../../nns/constants" }
 ic-protobuf = { path = "../../protobuf" }
 ic-registry-canister-api = { path = "../../registry/canister/api" }
+ic-registry-canister-chunkify = { path = "../../registry/canister/chunkify" }
 ic-registry-keys = { path = "../../registry/keys" }
 ic-registry-routing-table = { path = "../../registry/routing_table" }
 ic-registry-subnet-features = { path = "../../registry/subnet_features" }

--- a/rs/registry/canister/src/flags.rs
+++ b/rs/registry/canister/src/flags.rs
@@ -1,0 +1,22 @@
+use std::cell::Cell;
+
+#[cfg(test)]
+use ic_nervous_system_temporary::Temporary;
+
+thread_local! {
+    static IS_CHUNKIFYING_LARGE_VALUES_ENABLED: Cell<bool> = const { Cell::new(false) };
+}
+
+pub(crate) fn is_chunkifying_large_values_enabled() -> bool {
+    IS_CHUNKIFYING_LARGE_VALUES_ENABLED.get()
+}
+
+#[cfg(test)]
+pub(crate) fn temporarily_enable_chunkifying_large_values() -> Temporary {
+    Temporary::new(&IS_CHUNKIFYING_LARGE_VALUES_ENABLED, true)
+}
+
+#[cfg(test)]
+pub(crate) fn temporarily_disable_chunkifying_large_values() -> Temporary {
+    Temporary::new(&IS_CHUNKIFYING_LARGE_VALUES_ENABLED, false)
+}

--- a/rs/registry/canister/src/lib.rs
+++ b/rs/registry/canister/src/lib.rs
@@ -4,11 +4,13 @@ pub mod common;
 pub mod get_node_operators_and_dcs_of_node_provider;
 pub mod get_node_providers_monthly_xdr_rewards;
 pub mod init;
-mod invariants;
-mod missing_node_types_map;
 pub mod mutations;
 pub mod pb;
 pub mod proto_on_wire;
 pub mod registry;
 pub mod registry_lifecycle;
 pub mod storage;
+
+mod flags;
+mod invariants;
+mod missing_node_types_map;

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -491,6 +491,7 @@ impl Registry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::flags::temporarily_disable_chunkifying_large_values;
     use ic_registry_transport::{delete, insert, update, upsert};
     use rand::{Rng, SeedableRng};
     use rand_distr::{Alphanumeric, Distribution, Poisson, Uniform};
@@ -781,7 +782,7 @@ mod tests {
     #[test]
     fn test_count_fitting_deltas_max_size() {
         // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
-        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+        let _restore_on_drop = temporarily_disable_chunkifying_large_values();
 
         let mut registry = Registry::new();
         let version = 1;
@@ -1043,7 +1044,7 @@ mod tests {
     #[should_panic(expected = "[Registry] Transaction rejected because delta would be too large")]
     fn test_changelog_insert_delta_too_large() {
         // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
-        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+        let _restore_on_drop = temporarily_disable_chunkifying_large_values();
 
         let mut registry = Registry::new();
         let version = 1;
@@ -1084,7 +1085,7 @@ mod tests {
     #[should_panic(expected = "[Registry] Transaction rejected because delta would be too large")]
     fn test_apply_mutations_delta_too_large() {
         // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
-        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+        let _restore_on_drop = temporarily_disable_chunkifying_large_values();
 
         let mut registry = Registry::new();
         let version = 1;
@@ -1141,7 +1142,7 @@ mod tests {
     #[test]
     fn test_from_serializable_form_version_unspecified_max_size_delta() {
         // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
-        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+        let _restore_on_drop = temporarily_disable_chunkifying_large_values();
 
         test_from_serializable_form_impl(0, ReprVersion::Unspecified)
     }
@@ -1149,7 +1150,7 @@ mod tests {
     #[test]
     fn test_from_serializable_form_version1_max_size_delta() {
         // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
-        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+        let _restore_on_drop = temporarily_disable_chunkifying_large_values();
 
         test_from_serializable_form_impl(0, ReprVersion::Version1)
     }
@@ -1158,7 +1159,7 @@ mod tests {
     #[should_panic(expected = "[Registry] Transaction rejected because delta would be too large")]
     fn test_from_serializable_form_version_unspecified_delta_too_large() {
         // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
-        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+        let _restore_on_drop = temporarily_disable_chunkifying_large_values();
 
         test_from_serializable_form_impl(1, ReprVersion::Unspecified)
     }
@@ -1167,7 +1168,7 @@ mod tests {
     #[should_panic(expected = "[Registry] Transaction rejected because delta would be too large")]
     fn test_from_serializable_form_version1_delta_too_large() {
         // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
-        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+        let _restore_on_drop = temporarily_disable_chunkifying_large_values();
 
         test_from_serializable_form_impl(1, ReprVersion::Version1)
     }

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -780,6 +780,9 @@ mod tests {
 
     #[test]
     fn test_count_fitting_deltas_max_size() {
+        // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
+        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+
         let mut registry = Registry::new();
         let version = 1;
         let key = b"key";
@@ -1039,6 +1042,9 @@ mod tests {
     #[test]
     #[should_panic(expected = "[Registry] Transaction rejected because delta would be too large")]
     fn test_changelog_insert_delta_too_large() {
+        // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
+        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+
         let mut registry = Registry::new();
         let version = 1;
         let key = b"key";
@@ -1077,6 +1083,9 @@ mod tests {
     #[test]
     #[should_panic(expected = "[Registry] Transaction rejected because delta would be too large")]
     fn test_apply_mutations_delta_too_large() {
+        // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
+        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+
         let mut registry = Registry::new();
         let version = 1;
         let key = b"key";
@@ -1127,25 +1136,39 @@ mod tests {
         assert_eq!(deserialized, registry);
     }
 
+    // I think we can get rid of ReprVersion::Unspecified support? It's not
+    // doing much harm now; just a bit of detritus/dead code.
     #[test]
     fn test_from_serializable_form_version_unspecified_max_size_delta() {
+        // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
+        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+
         test_from_serializable_form_impl(0, ReprVersion::Unspecified)
     }
 
     #[test]
     fn test_from_serializable_form_version1_max_size_delta() {
+        // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
+        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+
         test_from_serializable_form_impl(0, ReprVersion::Version1)
     }
 
     #[test]
     #[should_panic(expected = "[Registry] Transaction rejected because delta would be too large")]
     fn test_from_serializable_form_version_unspecified_delta_too_large() {
+        // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
+        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+
         test_from_serializable_form_impl(1, ReprVersion::Unspecified)
     }
 
     #[test]
     #[should_panic(expected = "[Registry] Transaction rejected because delta would be too large")]
     fn test_from_serializable_form_version1_delta_too_large() {
+        // TODO(NNS1-3746): Make a version of this test where chunking is enabled.
+        let _restore_on_drop = crate::storage::temporarily_disable_chunkifying_large_values();
+
         test_from_serializable_form_impl(1, ReprVersion::Version1)
     }
 

--- a/rs/registry/canister/src/storage.rs
+++ b/rs/registry/canister/src/storage.rs
@@ -24,7 +24,7 @@ const CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(1);
 /// because if it were only a little bit larger, we are hardly enhancing our
 /// capabilities. At the same time, a higher limit is not needed (yet).
 /// Therefore, 5x the message size limit seems appropriate (for now).
-const MAX_CHUNKABLE_ATOMIC_MUTATION_LEN: usize = 10 * (1 << 20);
+const MAX_CHUNKABLE_ATOMIC_MUTATION_LEN: usize = 10 * (1024 * 1024);
 
 type VM = VirtualMemory<DefaultMemoryImpl>;
 

--- a/rs/registry/canister/src/storage.rs
+++ b/rs/registry/canister/src/storage.rs
@@ -1,10 +1,30 @@
+use crate::registry::MAX_REGISTRY_DELTAS_SIZE;
 use ic_nervous_system_chunks::Chunks;
+use ic_registry_canister_chunkify::chunkify_composite_mutation;
+use ic_registry_transport::pb::v1::{
+    HighCapacityRegistryAtomicMutateRequest, RegistryAtomicMutateRequest,
+};
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::DefaultMemoryImpl;
+use prost::Message;
 use std::cell::RefCell;
 
 const UPGRADES_MEMORY_ID: MemoryId = MemoryId::new(0);
 const CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(1);
+
+/// A RegistryAtomicMutateRequest that has an encoded size greater than this
+/// will cause a panic when it is passed to changelog_insert (or maybe_chunkify,
+/// which is called by changelog_insert).
+///
+/// The right to increase this later is reserved. Therefore, nothing should
+/// hinge on the current specific value.
+///
+/// How this value was chosen: The ICP currently has a 2 MiB message size limit.
+/// It would not make sense for this to be only a little bit larger than that,
+/// because if it were only a little bit larger, we are hardly enhancing our
+/// capabilities. At the same time, a higher limit is not needed (yet).
+/// Therefore, 5x the message size limit seems appropriate (for now).
+const MAX_CHUNKABLE_ATOMIC_MUTATION_LEN: usize = 10 * (1 << 20);
 
 type VM = VirtualMemory<DefaultMemoryImpl>;
 
@@ -35,4 +55,59 @@ pub(crate) fn with_chunks<R>(f: impl FnOnce(&Chunks<VM>) -> R) -> R {
     })
 }
 
-// TODO(NNS1-3645): with_chunks_mut
+/// Encodes the argument.
+///
+/// If the input is too large, this "chunkifies" it. That is, instead of
+/// inlining value, it is replaced with a LargeValueChunkKeys, which points to
+/// pieces of the original value, and each piece can be fetched via the
+/// `get_chunk` canister method.
+///
+/// Possible panic reasons include: input is too large. See
+/// MAX_CHUNKABLE_ATOMIC_MUTATION_LEN.
+pub(crate) fn maybe_chunkify_and_encode(
+    original_mutation: RegistryAtomicMutateRequest,
+) -> Vec<u8> {
+    if cfg!(not(test)) {
+        return original_mutation.encode_to_vec();
+    }
+    // In release builds, code bellow this line is not active. Instead, only the
+    // old behavior (implemented above) takes place.
+
+    let upgraded_mutation = maybe_chunkify(original_mutation);
+
+    // TODO(Nikola.Milosavljevic@dfinity.org): Populate timestamp_seconds field.
+
+    upgraded_mutation.encode_to_vec()
+}
+
+fn maybe_chunkify(
+    original_mutation: RegistryAtomicMutateRequest,
+) -> HighCapacityRegistryAtomicMutateRequest {
+    // Panic if the input is too large.
+    if original_mutation.encoded_len() > MAX_CHUNKABLE_ATOMIC_MUTATION_LEN {
+        let first_key = original_mutation
+            .mutations
+            .first()
+            .map(|prime_mutation| String::from_utf8_lossy(&prime_mutation.key));
+        panic!(
+            "Mutation too large. First key = {:?}. Encoded size = {}",
+            first_key,
+            original_mutation.encoded_len(),
+        );
+    }
+
+    // If the input is small, simply transcribe it.
+    const SIZE_OF_VERSION: usize = std::mem::size_of::<crate::registry::EncodedVersion>();
+    let is_small =
+        original_mutation.encoded_len() + SIZE_OF_VERSION < MAX_REGISTRY_DELTAS_SIZE;
+    if is_small {
+        return HighCapacityRegistryAtomicMutateRequest::from(original_mutation);
+    }
+
+    // Otherwise, if the input is "large", chunkify it.
+    CHUNKS.with(|chunks| {
+        let mut chunks = chunks.borrow_mut();
+        let chunks = &mut *chunks;
+        chunkify_composite_mutation(original_mutation, chunks)
+    })
+}

--- a/rs/registry/canister/src/storage/tests.rs
+++ b/rs/registry/canister/src/storage/tests.rs
@@ -1,0 +1,119 @@
+use super::*;
+use ic_registry_transport::pb::v1::{
+    high_capacity_registry_mutation, registry_mutation, LargeValueChunkKeys, Precondition,
+    RegistryMutation,
+};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref PRECONDITION: Precondition = Precondition {
+        key: b"precondition".to_vec(),
+        expected_version: 42,
+    };
+}
+
+fn new_monolithic_blob(size: u64) -> Vec<u8> {
+    const DIVISOR: u64 = u8::MAX as u64 + 1;
+
+    (0..size).map(|i| (i % DIVISOR) as u8).collect::<Vec<u8>>()
+}
+
+#[test]
+fn test_no_chunkify_small_mutation() {
+    // Step 1: Prepare the world.
+    let _restore_on_drop = temporarily_enable_chunkifying_large_values();
+
+    let original_mutation = RegistryAtomicMutateRequest {
+        mutations: vec![RegistryMutation {
+            key: b"name".to_vec(),
+            mutation_type: registry_mutation::Type::Insert as i32,
+            value: b"Daniel Wong".to_vec(),
+        }],
+        preconditions: vec![PRECONDITION.clone()],
+    };
+
+    // Step 2: Call the code under test.
+    let result = maybe_chunkify_and_encode(original_mutation.clone());
+
+    // Step 3: Verify results.
+    let result = HighCapacityRegistryAtomicMutateRequest::decode(result.as_slice()).unwrap();
+    assert_eq!(
+        result,
+        HighCapacityRegistryAtomicMutateRequest::from(original_mutation)
+    );
+}
+
+#[test]
+fn test_chunkify_reasonably_large_mutation() {
+    // Step 1: Prepare the world.
+    let _restore_on_drop = temporarily_enable_chunkifying_large_values();
+
+    let original_monolithic_blob = new_monolithic_blob(3_000_000);
+
+    let original_mutation = RegistryAtomicMutateRequest {
+        mutations: vec![RegistryMutation {
+            key: b"whale".to_vec(),
+            mutation_type: registry_mutation::Type::Insert as i32,
+            value: original_monolithic_blob.clone(),
+        }],
+        preconditions: vec![PRECONDITION.clone()],
+    };
+
+    // Step 2: Call the code under test.
+    let result = maybe_chunkify_and_encode(original_mutation);
+
+    // Step 3: Verify results.
+
+    let result = HighCapacityRegistryAtomicMutateRequest::decode(result.as_slice()).unwrap();
+
+    // Step 3.1: Assert that value has been replaced with LargeValueChunkKeys.
+    let first_prime_mutation = result.mutations.first().unwrap().content.as_ref().unwrap();
+    let high_capacity_registry_mutation::Content::LargeValueChunkKeys(LargeValueChunkKeys {
+        chunk_content_sha256s,
+    }) = first_prime_mutation
+    else {
+        panic!("{:?}", result);
+    };
+
+    // Step 3.2: Assert that reassembled blob is equal to the original.
+    let reassembled_monolitich_blob = with_chunks(|chunks| {
+        let mut result = vec![];
+        for key in chunk_content_sha256s {
+            result.append(&mut chunks.get_chunk(&key).unwrap());
+        }
+        result
+    });
+    assert_eq!(reassembled_monolitich_blob, original_monolithic_blob);
+
+    // Step 3.3: Finally, check other fields of result.
+    let expected_mutation = HighCapacityRegistryAtomicMutateRequest {
+        mutations: vec![result.mutations.first().unwrap().clone()],
+        preconditions: vec![PRECONDITION.clone()],
+        timestamp_seconds: 0,
+    };
+    assert_eq!(result, expected_mutation);
+}
+
+#[test]
+#[should_panic = "Mutation too large."]
+fn test_panic_on_hyper_large_mutation() {
+    // Step 1: Prepare the world.
+    let _restore_on_drop = temporarily_enable_chunkifying_large_values();
+
+    let monolithic_blob = new_monolithic_blob(100_000_000);
+
+    let original_mutation = RegistryAtomicMutateRequest {
+        mutations: vec![RegistryMutation {
+            key: b"absurd".to_vec(),
+            mutation_type: registry_mutation::Type::Insert as i32,
+            value: monolithic_blob.clone(),
+        }],
+        preconditions: vec![PRECONDITION.clone()],
+    };
+
+    // Step 2: Call the code under test.
+    let _explode = maybe_chunkify_and_encode(original_mutation);
+
+    // Step 3: Verify results. The previous line is supposed to panic (and this
+    // is verified at the top via should_panic).
+}

--- a/rs/registry/canister/src/storage/tests.rs
+++ b/rs/registry/canister/src/storage/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::flags::temporarily_enable_chunkifying_large_values;
 use ic_registry_transport::pb::v1::{
     high_capacity_registry_mutation, registry_mutation, LargeValueChunkKeys, Precondition,
     RegistryMutation,

--- a/rs/registry/canister/src/storage/tests.rs
+++ b/rs/registry/canister/src/storage/tests.rs
@@ -80,7 +80,7 @@ fn test_chunkify_reasonably_large_mutation() {
     let reassembled_monolitich_blob = with_chunks(|chunks| {
         let mut result = vec![];
         for key in chunk_content_sha256s {
-            result.append(&mut chunks.get_chunk(&key).unwrap());
+            result.append(&mut chunks.get_chunk(key).unwrap());
         }
         result
     });


### PR DESCRIPTION
... and have it be called from `changelog_insert`.

The new behavior is behind a flag, and as per usual, in release builds, it is disabled.

`maybe_chunkify` takes a `RegistryAtomicMutateRequest`, and converts it to an equivalent `HighCapacityRegistryAtomicMutateRequest`.

When the input is "too large" (and this feature is enabled), instead of having the value inlined, it is stored in stable memory, and the inline value is replaced with a "pointer" to the stable memory.

# References

[NNS1-3681]

[NNS1-3681]: https://dfinity.atlassian.net/browse/NNS1-3681

[👈 Previous PR][prev]

[prev]: https://github.com/dfinity/ic/pull/4761