### PR TITLE
fix(ICP_Rosetta): FI-1507: Write ICP Rosetta port file atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12445,6 +12445,7 @@ dependencies = [
  "ic-nns-handler-root",
  "ic-nns-test-utils",
  "ic-rosetta-test-utils",
+ "ic-sys",
  "ic-types",
  "icp-ledger",
  "icrc-ledger-agent",

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -27,6 +27,7 @@ DEPENDENCIES = [
     "//rs/rosetta-api/icp/ledger_canister_blocks_synchronizer:ledger_canister_blocks_synchronizer_lib",
     "//rs/rust_canisters/dfn_protobuf",
     "//rs/rust_canisters/on_wire",
+    "//rs/sys",
     "//rs/types/types",
     "@crate_index//:actix-rt",
     "@crate_index//:actix-web",

--- a/rs/rosetta-api/icp/Cargo.toml
+++ b/rs/rosetta-api/icp/Cargo.toml
@@ -29,6 +29,7 @@ ic-management-canister-types = { workspace = true }
 ic-nns-common = { path = "../../nns/common" }
 ic-nns-constants = { path = "../../nns/constants" }
 ic-nns-governance-api = { path = "../../nns/governance/api" }
+ic-sys = { path = "../../sys" }
 ic-types = { path = "../../types/types" }
 icp-ledger = { path = "../../ledger_suite/icp" }
 lazy_static = { workspace = true }

--- a/rs/rosetta-api/icp/src/rosetta_server.rs
+++ b/rs/rosetta-api/icp/src/rosetta_server.rs
@@ -313,9 +313,9 @@ impl RosettaApiServer {
                     e
                 )
             });
-            std::fs::write(
-                listen_port_file,
-                server.addrs().first().unwrap().port().to_string(),
+            ic_sys::fs::write_string_using_tmp_file(
+                &listen_port_file,
+                &server.addrs().first().unwrap().port().to_string(),
             )
             .unwrap_or_else(|e| panic!("Unable to write to listen_port_file! Error: {}", e));
         }


### PR DESCRIPTION
One recent source of ICP Rosetta test flakiness is the fact that the file with the port number where Rosetta is listening is not written atomically. E.g., in [this test](https://github.com/dfinity/ic/blob/8db45d0ad972479dd99a80720dc98c2401dbb48a/rs/rosetta-api/icp/tests/integration_tests/src/lib.rs#L106-L107), the client tries to read the port number from the file, but panics on line 107 with a `Expected port in port file: ParseIntError { kind: Empty }` error. This is because ICP Rosetta creates the port file, and then writes to it, and the client reads the file before anything has been written to it. This PR proposes to make the port file writing atomic in [the same way that it is currently done in the ICRC Rosetta](https://github.com/dfinity/ic/blob/8db45d0ad972479dd99a80720dc98c2401dbb48a/rs/rosetta-api/icrc1/src/main.rs#L536-L539).