### PR TITLE
test: Resurrect `system_api` tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8808,6 +8808,7 @@ dependencies = [
  "mach2",
  "maplit",
  "memory_tracker",
+ "more-asserts",
  "nix 0.24.3",
  "num-traits",
  "pretty_assertions",

--- a/rs/embedders/BUILD.bazel
+++ b/rs/embedders/BUILD.bazel
@@ -69,6 +69,7 @@ DEV_DEPENDENCIES = [
     "@crate_index//:insta",
     "@crate_index//:lazy_static",
     "@crate_index//:maplit",
+    "@crate_index//:more-asserts",
     "@crate_index//:pretty_assertions",
     "@crate_index//:proptest",
     "@crate_index//:strum",
@@ -152,6 +153,8 @@ rust_ic_test_suite_with_extra_srcs(
         exclude = [
             "tests/wasmtime_simple.rs",
             "tests/instrumentation.rs",
+            "tests/system_api.rs",
+            "tests/sandbox_safe_system_state.rs",
         ],
     ),
     aliases = ALIASES,
@@ -180,6 +183,26 @@ rust_ic_test_suite_with_extra_srcs(
         "tests/instrumentation.rs",
     ],
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    deps = [":embedders"] + DEPENDENCIES + DEV_DEPENDENCIES,
+)
+
+rust_test(
+    name = "system_api_integration_test",
+    srcs = [
+        "tests/common/mod.rs",
+        "tests/system_api.rs",
+    ],
+    crate_root = "tests/system_api.rs",
+    deps = [":embedders"] + DEPENDENCIES + DEV_DEPENDENCIES,
+)
+
+rust_test(
+    name = "sandbox_safe_system_state_test",
+    srcs = [
+        "tests/common/mod.rs",
+        "tests/sandbox_safe_system_state.rs",
+    ],
+    crate_root = "tests/sandbox_safe_system_state.rs",
     deps = [":embedders"] + DEPENDENCIES + DEV_DEPENDENCIES,
 )
 

--- a/rs/embedders/Cargo.toml
+++ b/rs/embedders/Cargo.toml
@@ -79,6 +79,7 @@ ic-test-utilities-types = { path = "../test_utilities/types" }
 insta = "1.8.0"
 lazy_static = { workspace = true }
 maplit = "1.0.2"
+more-asserts = "0.3.1"
 pretty_assertions = { workspace = true }
 proptest = { workspace = true }
 slog = { workspace = true }

--- a/rs/embedders/tests/common/mod.rs
+++ b/rs/embedders/tests/common/mod.rs
@@ -5,6 +5,10 @@ use ic_config::{
     embedders::Config as EmbeddersConfig, flag_status::FlagStatus, subnet_config::SchedulerConfig,
 };
 use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
+use ic_embedders::wasmtime_embedder::system_api::{
+    sandbox_safe_system_state::SandboxSafeSystemState, ApiType, DefaultOutOfInstructionsHandler,
+    ExecutionParameters, InstructionLimits, NonReplicatedQueryKind, SystemApiImpl,
+};
 use ic_interfaces::execution_environment::{ExecutionMode, SubnetAvailableMemory};
 use ic_logger::replica_logger::no_op_logger;
 use ic_management_canister_types_private::IC_00;
@@ -14,10 +18,6 @@ use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     CallOrigin, Memory, MessageMemoryUsage, NetworkTopology, NumWasmPages, SubnetTopology,
     SystemState,
-};
-use ic_system_api::{
-    sandbox_safe_system_state::SandboxSafeSystemState, ApiType, DefaultOutOfInstructionsHandler,
-    ExecutionParameters, InstructionLimits, NonReplicatedQueryKind, SystemApiImpl,
 };
 use ic_test_utilities_state::SystemStateBuilder;
 use ic_test_utilities_types::ids::{

--- a/rs/embedders/tests/sandbox_safe_system_state.rs
+++ b/rs/embedders/tests/sandbox_safe_system_state.rs
@@ -1,6 +1,7 @@
 use ic_base_types::{CanisterId, NumBytes, NumSeconds, SubnetId};
 use ic_config::execution_environment::SUBNET_CALLBACK_SOFT_LIMIT;
 use ic_config::subnet_config::SchedulerConfig;
+use ic_embedders::wasmtime_embedder::system_api::sandbox_safe_system_state::SandboxSafeSystemState;
 use ic_interfaces::execution_environment::SystemApi;
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
 use ic_logger::replica_logger::no_op_logger;
@@ -13,7 +14,6 @@ use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::system_state::CyclesUseCase;
 use ic_replicated_state::testing::SystemStateTesting;
 use ic_replicated_state::{MessageMemoryUsage, NetworkTopology, SystemState};
-use ic_system_api::sandbox_safe_system_state::SandboxSafeSystemState;
 use ic_test_utilities::cycles_account_manager::CyclesAccountManagerBuilder;
 use ic_test_utilities_state::SystemStateBuilder;
 use ic_test_utilities_types::{

--- a/rs/embedders/tests/system_api.rs
+++ b/rs/embedders/tests/system_api.rs
@@ -4,6 +4,10 @@ use ic_config::{
     subnet_config::SchedulerConfig,
 };
 use ic_cycles_account_manager::CyclesAccountManager;
+use ic_embedders::wasmtime_embedder::system_api::{
+    sandbox_safe_system_state::SandboxSafeSystemState, ApiType, DefaultOutOfInstructionsHandler,
+    NonReplicatedQueryKind, SystemApiImpl,
+};
 use ic_error_types::RejectCode;
 use ic_interfaces::execution_environment::{
     CanisterOutOfCyclesError, ExecutionMode, HypervisorError, HypervisorResult,
@@ -16,10 +20,6 @@ use ic_management_canister_types_private::OnLowWasmMemoryHookStatus;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     testing::CanisterQueuesTesting, CallOrigin, Memory, NetworkTopology, NumWasmPages, SystemState,
-};
-use ic_system_api::{
-    sandbox_safe_system_state::SandboxSafeSystemState, ApiType, DefaultOutOfInstructionsHandler,
-    SystemApiImpl,
 };
 use ic_test_utilities::cycles_account_manager::CyclesAccountManagerBuilder;
 use ic_test_utilities_state::SystemStateBuilder;
@@ -1144,7 +1144,7 @@ fn data_certificate_copy() {
             subnet_test_id(1),
             vec![],
             Some(vec![1, 2, 3, 4, 5, 6]),
-            ic_system_api::NonReplicatedQueryKind::Pure,
+            NonReplicatedQueryKind::Pure,
         ),
         &system_state,
         cycles_account_manager,

--- a/rs/embedders/tests/system_api_tracking.rs
+++ b/rs/embedders/tests/system_api_tracking.rs
@@ -1,5 +1,5 @@
+use ic_embedders::wasmtime_embedder::system_api::{ApiType, NonReplicatedQueryKind};
 use ic_interfaces::execution_environment::SystemApiCallCounters;
-use ic_system_api::NonReplicatedQueryKind;
 use ic_test_utilities_embedders::WasmtimeInstanceBuilder;
 use ic_test_utilities_types::ids::{subnet_test_id, user_test_id};
 use ic_types::time::UNIX_EPOCH;
@@ -7,7 +7,7 @@ use ic_types::time::UNIX_EPOCH;
 fn call_counters_on_ok_call(wat: &str) -> SystemApiCallCounters {
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_wat(wat)
-        .with_api_type(ic_system_api::ApiType::non_replicated_query(
+        .with_api_type(ApiType::non_replicated_query(
             UNIX_EPOCH,
             user_test_id(0).get(),
             subnet_test_id(1),
@@ -31,7 +31,7 @@ fn call_counters_on_ok_call(wat: &str) -> SystemApiCallCounters {
 fn call_counters_on_err_call(wat: &str) -> SystemApiCallCounters {
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_wat(wat)
-        .with_api_type(ic_system_api::ApiType::start(UNIX_EPOCH))
+        .with_api_type(ApiType::start(UNIX_EPOCH))
         .build();
     instance
         .run(ic_types::methods::FuncRef::Method(


### PR DESCRIPTION
When `//rs/system_api` got moved under `//rs/embedders` (commit 9662ae2), the integration tests in `//rs/system_api/tests` accidentally ended up under `//rs/embedders/src` and thus became inactive. Move them to `//rs/embedders/tests` and tweak the build files to revive them.