### PR TITLE
chore: [MR-649] Drop `best_effort_responses` flag

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -1,10 +1,9 @@
 use std::time::Duration;
 
 use ic_base_types::NumBytes;
-use ic_registry_subnet_type::SubnetType;
 use ic_sys::PAGE_SIZE;
 use ic_types::{
-    NumInstructions, NumOsPages, SubnetId, MAX_STABLE_MEMORY_IN_BYTES, MAX_WASM64_MEMORY_IN_BYTES,
+    NumInstructions, NumOsPages, MAX_STABLE_MEMORY_IN_BYTES, MAX_WASM64_MEMORY_IN_BYTES,
     MAX_WASM_MEMORY_IN_BYTES,
 };
 use serde::{Deserialize, Serialize};
@@ -102,48 +101,7 @@ const STABLE_MEMORY_ACCESSED_PAGE_LIMIT_QUERY: NumOsPages =
 /// also used as the maximum size for the Wasm chunk store of each canister.
 pub const WASM_MAX_SIZE: NumBytes = NumBytes::new(100 * 1024 * 1024); // 100 MiB
 
-/// Best-effort responses feature rollout stage.
-///
-/// The intent is to incrementally release the feature, first to a limited
-/// subset of subnets; then to all application subnets; and finally everywhere;
-/// by rolling forward one stage at a time. Rolling back is also supported,
-/// including directly to stage 1.
-///
-/// Subnets where the feature is disabled silently fall back to guaranteed
-/// response calls; and best-effort requests to these subnets are rejected
-/// before routing. We choose this over trapping in order to avoid breaking
-/// canisters that have started using best-effort calls in case of a roll back.
-//
-// TODO(MR-649): Drop this once best-effort responses are fully rolled out.
-#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
-pub enum BestEffortResponsesFeature {
-    /// Stage 1: Feature is enabled on specific subnets subnets only. Other subnets
-    /// fall back to guaranteed responses; and best-effort requests to these subnets
-    /// are rejected before routing.
-    SpecificSubnets(Vec<SubnetId>),
-
-    /// Stage 2: Feature is enabled on application (and verified application)
-    /// subnets only. System subnets fall back to guaranteed responses; and
-    /// best-effort requests to system subnets are rejected before routing.
-    ApplicationSubnetsOnly,
-
-    /// Stage 3: Feature is enabled on all subnets.
-    Enabled,
-}
-
-impl BestEffortResponsesFeature {
-    /// Returns `true` if the feature is enabled on the given subnet, having the
-    /// given subnet type.
-    pub fn is_enabled_on(&self, subnet_id: &SubnetId, subnet_type: SubnetType) -> bool {
-        match self {
-            BestEffortResponsesFeature::SpecificSubnets(subnets) => subnets.contains(subnet_id),
-            BestEffortResponsesFeature::ApplicationSubnetsOnly => subnet_type != SubnetType::System,
-            BestEffortResponsesFeature::Enabled => true,
-        }
-    }
-}
-
-#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct FeatureFlags {
     /// If this flag is enabled, then the output of the `debug_print` system-api
     /// call will be skipped based on heuristics.
@@ -152,21 +110,24 @@ pub struct FeatureFlags {
     pub write_barrier: FlagStatus,
     /// Indicates whether the support for 64 bit main memory is enabled
     pub wasm64: FlagStatus,
-    /// Rollout stage of the best-effort responses feature.
-    pub best_effort_responses: BestEffortResponsesFeature,
     /// Collect a backtrace from the canister when it panics.
     pub canister_backtrace: FlagStatus,
 }
 
-impl Default for FeatureFlags {
-    fn default() -> Self {
+impl FeatureFlags {
+    const fn const_default() -> Self {
         Self {
             rate_limiting_of_debug_prints: FlagStatus::Enabled,
             write_barrier: FlagStatus::Disabled,
             wasm64: FlagStatus::Enabled,
-            best_effort_responses: BestEffortResponsesFeature::ApplicationSubnetsOnly,
             canister_backtrace: FlagStatus::Enabled,
         }
+    }
+}
+
+impl Default for FeatureFlags {
+    fn default() -> Self {
+        Self::const_default()
     }
 }
 
@@ -286,7 +247,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Config {
             query_execution_threads_per_canister: QUERY_EXECUTION_THREADS_PER_CANISTER,
             max_globals: MAX_GLOBALS,
@@ -298,7 +259,7 @@ impl Config {
             cost_to_compile_wasm_instruction: DEFAULT_COST_TO_COMPILE_WASM_INSTRUCTION,
             num_rayon_compilation_threads: DEFAULT_WASMTIME_RAYON_COMPILATION_THREADS,
             num_rayon_page_allocator_threads: DEFAULT_PAGE_ALLOCATOR_THREADS,
-            feature_flags: FeatureFlags::default(),
+            feature_flags: FeatureFlags::const_default(),
             metering_type: MeteringType::New,
             stable_memory_dirty_page_limit: StableMemoryPageLimit {
                 message: STABLE_MEMORY_DIRTY_PAGE_LIMIT_MESSAGE,
@@ -329,40 +290,5 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ic_types::PrincipalId;
-
-    const SUBNET_1: SubnetId = SubnetId::new(PrincipalId::new(1, [1; 29]));
-    const SUBNET_2: SubnetId = SubnetId::new(PrincipalId::new(1, [2; 29]));
-
-    #[test]
-    fn test_best_effort_responses_feature_specific_subnets() {
-        let best_effort_responses = BestEffortResponsesFeature::SpecificSubnets(vec![SUBNET_1]);
-
-        assert!(best_effort_responses.is_enabled_on(&SUBNET_1, SubnetType::Application));
-        assert!(best_effort_responses.is_enabled_on(&SUBNET_1, SubnetType::System));
-        assert!(!best_effort_responses.is_enabled_on(&SUBNET_2, SubnetType::Application));
-        assert!(!best_effort_responses.is_enabled_on(&SUBNET_2, SubnetType::System));
-    }
-
-    #[test]
-    fn test_best_effort_responses_feature_application_subnets_only() {
-        let best_effort_responses = BestEffortResponsesFeature::ApplicationSubnetsOnly;
-
-        assert!(best_effort_responses.is_enabled_on(&SUBNET_1, SubnetType::Application));
-        assert!(!best_effort_responses.is_enabled_on(&SUBNET_1, SubnetType::System));
-    }
-
-    #[test]
-    fn test_best_effort_responses_feature_enabled() {
-        let best_effort_responses = BestEffortResponsesFeature::Enabled;
-
-        assert!(best_effort_responses.is_enabled_on(&SUBNET_1, SubnetType::Application));
-        assert!(best_effort_responses.is_enabled_on(&SUBNET_1, SubnetType::System));
     }
 }

--- a/rs/drun/src/main.rs
+++ b/rs/drun/src/main.rs
@@ -4,9 +4,7 @@ use ic_canister_sandbox_backend_lib::{
     launcher::sandbox_launcher_main, RUN_AS_CANISTER_SANDBOX_FLAG, RUN_AS_COMPILER_SANDBOX_FLAG,
     RUN_AS_SANDBOX_LAUNCHER_FLAG,
 };
-use ic_config::{
-    embedders::BestEffortResponsesFeature, flag_status::FlagStatus, Config, ConfigSource,
-};
+use ic_config::{flag_status::FlagStatus, Config, ConfigSource};
 use ic_drun::{run_drun, DrunOptions};
 use ic_registry_subnet_type::SubnetType;
 use ic_types::NumBytes;
@@ -65,10 +63,6 @@ async fn drun_main() -> Result<(), String> {
         // For testing enhanced orthogonal persistence in Motoko,
         // enable Wasm Memory64 and re-configure the main memory capacity.
         hypervisor_config.embedders_config.feature_flags.wasm64 = FlagStatus::Enabled;
-        hypervisor_config
-            .embedders_config
-            .feature_flags
-            .best_effort_responses = BestEffortResponsesFeature::Enabled;
         hypervisor_config.embedders_config.max_wasm64_memory_size = MAIN_MEMORY_CAPACITY;
         hypervisor_config.max_canister_memory_size_wasm64 =
             hypervisor_config.embedders_config.max_wasm64_memory_size

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -271,7 +271,7 @@ impl WasmtimeEmbedder {
             WasmMemoryType::Wasm32 => {
                 linker::syscalls::<u32>(
                     &mut linker,
-                    self.config.feature_flags.clone(),
+                    self.config.feature_flags,
                     self.config.stable_memory_dirty_page_limit,
                     self.config.stable_memory_accessed_page_limit,
                     main_memory_type,
@@ -280,7 +280,7 @@ impl WasmtimeEmbedder {
             WasmMemoryType::Wasm64 => {
                 linker::syscalls::<u64>(
                     &mut linker,
-                    self.config.feature_flags.clone(),
+                    self.config.feature_flags,
                     self.config.stable_memory_dirty_page_limit,
                     self.config.stable_memory_accessed_page_limit,
                     main_memory_type,

--- a/rs/embedders/src/wasmtime_embedder/linker.rs
+++ b/rs/embedders/src/wasmtime_embedder/linker.rs
@@ -576,7 +576,6 @@ pub fn syscalls<
 
     linker
         .func_wrap("ic0", "debug_print", {
-            let feature_flags = feature_flags.clone();
             move |mut caller: Caller<'_, StoreData>, offset: I, length: I| {
                 let length: u64 = length.try_into().expect("Failed to convert I to u64");
                 let mut num_bytes = 0;

--- a/rs/embedders/tests/system_api.rs
+++ b/rs/embedders/tests/system_api.rs
@@ -1,8 +1,5 @@
 use ic_base_types::{NumBytes, NumSeconds, PrincipalIdBlobParseError};
-use ic_config::{
-    embedders::{BestEffortResponsesFeature, Config as EmbeddersConfig, FeatureFlags},
-    subnet_config::SchedulerConfig,
-};
+use ic_config::{embedders::Config as EmbeddersConfig, subnet_config::SchedulerConfig};
 use ic_cycles_account_manager::CyclesAccountManager;
 use ic_embedders::wasmtime_embedder::system_api::{
     sandbox_safe_system_state::SandboxSafeSystemState, ApiType, DefaultOutOfInstructionsHandler,
@@ -2084,74 +2081,53 @@ fn in_replicated_execution_works_correctly() {
 }
 
 #[test]
-fn ic0_call_with_best_effort_response_feature_stages() {
-    use BestEffortResponsesFeature::*;
-
+fn ic0_call_with_best_effort_response() {
     let own_subnet_id = subnet_test_id(0);
-    let other_subnet_id = subnet_test_id(1);
-    for best_effort_responses in [
-        SpecificSubnets(vec![]),
-        SpecificSubnets(vec![other_subnet_id]),
-        SpecificSubnets(vec![own_subnet_id, other_subnet_id]),
-        ApplicationSubnetsOnly,
-        Enabled,
-    ] {
-        for subnet_type in SubnetType::iter() {
-            let mut system_state = SystemStateBuilder::default().build();
-            let mut api = get_system_api_for_best_effort_response_feature_test(
+
+    for subnet_type in SubnetType::iter() {
+        let mut system_state = SystemStateBuilder::default().build();
+        let mut api =
+            get_system_api_for_best_effort_response(own_subnet_id, subnet_type, &system_state);
+
+        // Make a call to something that isn't `IC_00`.
+        api.ic0_call_new(0, 1, 0, 1, 0, 0, 0, 0, &[42; 128])
+            .unwrap();
+        api.ic0_call_with_best_effort_response(13).unwrap();
+        api.ic0_call_perform().unwrap();
+
+        // Propagate system state changes
+        let system_state_modifications = api.take_system_state_modifications();
+        system_state_modifications
+            .apply_changes(
+                UNIX_EPOCH,
+                &mut system_state,
+                &default_network_topology(),
                 own_subnet_id,
-                subnet_type,
-                &best_effort_responses,
-                &system_state,
-            );
+                &no_op_logger(),
+            )
+            .unwrap();
 
-            // Make a call to something that isn't `IC_00`.
-            api.ic0_call_new(0, 1, 0, 1, 0, 0, 0, 0, &[42; 128])
-                .unwrap();
-            api.ic0_call_with_best_effort_response(13).unwrap();
-            api.ic0_call_perform().unwrap();
+        let RequestOrResponse::Request(req) = system_state.output_into_iter().next().unwrap()
+        else {
+            unreachable!();
+        };
+        let callback = system_state
+            .call_context_manager()
+            .unwrap()
+            .callbacks()
+            .values()
+            .next()
+            .unwrap();
 
-            // Propagate system state changes
-            let system_state_modifications = api.take_system_state_modifications();
-            system_state_modifications
-                .apply_changes(
-                    UNIX_EPOCH,
-                    &mut system_state,
-                    &default_network_topology(),
-                    own_subnet_id,
-                    &no_op_logger(),
-                )
-                .unwrap();
-
-            let RequestOrResponse::Request(req) = system_state.output_into_iter().next().unwrap()
-            else {
-                unreachable!();
-            };
-            let callback = system_state
-                .call_context_manager()
-                .unwrap()
-                .callbacks()
-                .values()
-                .next()
-                .unwrap();
-
-            if best_effort_responses.is_enabled_on(&own_subnet_id, subnet_type) {
-                // An actual best-effort request.
-                assert_ne!(req.deadline, NO_DEADLINE);
-                assert_ne!(callback.deadline, NO_DEADLINE);
-            } else {
-                // Silently converted to a guaranteed response request.
-                assert_eq!(req.deadline, NO_DEADLINE);
-                assert_eq!(callback.deadline, NO_DEADLINE);
-            }
-        }
+        // Expect an actual best-effort request.
+        assert_ne!(req.deadline, NO_DEADLINE);
+        assert_ne!(callback.deadline, NO_DEADLINE);
     }
 }
 
-fn get_system_api_for_best_effort_response_feature_test(
+fn get_system_api_for_best_effort_response(
     subnet_id: SubnetId,
     subnet_type: SubnetType,
-    best_effort_responses: &BestEffortResponsesFeature,
     system_state: &SystemState,
 ) -> SystemApiImpl {
     const SUBNET_MEMORY_CAPACITY: i64 = i64::MAX / 2;
@@ -2174,13 +2150,6 @@ fn get_system_api_for_best_effort_response_feature_test(
         api_type.caller(),
         api_type.call_context_id(),
     );
-    let embedders_config = EmbeddersConfig {
-        feature_flags: FeatureFlags {
-            best_effort_responses: best_effort_responses.clone(),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
 
     SystemApiImpl::new(
         api_type,
@@ -2193,7 +2162,7 @@ fn get_system_api_for_best_effort_response_feature_test(
             SUBNET_MEMORY_CAPACITY,
             SUBNET_MEMORY_CAPACITY,
         ),
-        &embedders_config,
+        &EmbeddersConfig::default(),
         Memory::new_for_testing(),
         NumWasmPages::from(0),
         Rc::new(DefaultOutOfInstructionsHandler::default()),

--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -2,7 +2,7 @@
 /// Common System API benchmark functions, types, constants.
 ///
 use criterion::{BatchSize, Criterion};
-use ic_config::embedders::{BestEffortResponsesFeature, Config as EmbeddersConfig, FeatureFlags};
+use ic_config::embedders::{Config as EmbeddersConfig, FeatureFlags};
 use ic_config::execution_environment::{
     Config, CANISTER_GUARANTEED_CALLBACK_QUOTA, SUBNET_CALLBACK_SOFT_LIMIT,
 };
@@ -257,7 +257,6 @@ where
     ));
     let mut embedders_config = EmbeddersConfig {
         feature_flags: FeatureFlags {
-            best_effort_responses: BestEffortResponsesFeature::Enabled,
             wasm64: FlagStatus::Enabled,
             ..FeatureFlags::default()
         },

--- a/rs/execution_environment/src/execution/response/tests.rs
+++ b/rs/execution_environment/src/execution/response/tests.rs
@@ -1,8 +1,7 @@
 use assert_matches::assert_matches;
 use ic_base_types::{NumBytes, NumSeconds};
-use ic_config::embedders::BestEffortResponsesFeature;
 use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
-use ic_error_types::{ErrorCode, UserError};
+use ic_error_types::ErrorCode;
 use ic_management_canister_types_private::CanisterStatusType;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::NextExecution;
@@ -16,12 +15,14 @@ use ic_test_utilities_execution_environment::{
 };
 use ic_test_utilities_metrics::fetch_int_counter;
 use ic_test_utilities_types::messages::ResponseBuilder;
+use ic_types::messages::NO_DEADLINE;
 use ic_types::{
     ingress::{IngressState, IngressStatus, WasmResult},
-    messages::{CallbackId, MessageId, MAX_INTER_CANISTER_PAYLOAD_IN_BYTES, NO_DEADLINE},
-    CanisterId, ComputeAllocation, Cycles, MemoryAllocation, NumInstructions, SubnetId, Time,
+    messages::{CallbackId, MessageId},
+    CanisterId, Cycles, Time,
 };
-use ic_types_test_utils::ids::{SUBNET_1, SUBNET_42};
+use ic_types::{messages::MAX_INTER_CANISTER_PAYLOAD_IN_BYTES, NumInstructions};
+use ic_types::{ComputeAllocation, MemoryAllocation};
 use ic_universal_canister::{call_args, wasm};
 
 #[test]
@@ -3060,16 +3061,9 @@ fn test_call_context_performance_counter_correctly_reported_on_cleanup() {
     assert!(counters[1] < counters[2]);
 }
 
-const OWN_SUBNET_ID: SubnetId = SUBNET_1;
-const OTHER_SUBNET_ID: SubnetId = SUBNET_42;
-
-fn test_call_with_best_effort_response_feature_flag_impl(
-    flag: BestEffortResponsesFeature,
-) -> Result<WasmResult, UserError> {
-    let mut test = ExecutionTestBuilder::new()
-        .with_own_subnet_id(OWN_SUBNET_ID)
-        .with_best_effort_responses(flag)
-        .build();
+#[test]
+fn test_best_effort_responses() {
+    let mut test = ExecutionTestBuilder::new().build();
 
     let a_id = test
         .universal_canister_with_cycles(Cycles::new(10_000_000_000_000))
@@ -3078,7 +3072,7 @@ fn test_call_with_best_effort_response_feature_flag_impl(
         .universal_canister_with_cycles(Cycles::new(10_000_000_000_000))
         .unwrap();
 
-    test.ingress(
+    let result = test.ingress(
         b_id,
         "update",
         wasm()
@@ -3091,56 +3085,27 @@ fn test_call_with_best_effort_response_feature_flag_impl(
             )
             .reply()
             .build(),
-    )
+    );
+    assert_eq!(result, Ok(WasmResult::Reply(vec![])))
 }
 
 #[test]
-fn test_call_with_best_effort_response_feature_flag() {
-    for flag in &[
-        BestEffortResponsesFeature::SpecificSubnets(vec![]),
-        BestEffortResponsesFeature::SpecificSubnets(vec![OTHER_SUBNET_ID]),
-        BestEffortResponsesFeature::SpecificSubnets(vec![OWN_SUBNET_ID, OTHER_SUBNET_ID]),
-        BestEffortResponsesFeature::ApplicationSubnetsOnly,
-        BestEffortResponsesFeature::Enabled,
-    ] {
-        match test_call_with_best_effort_response_feature_flag_impl(flag.clone()) {
-            Ok(result) => assert_eq!(result, WasmResult::Reply(vec![])),
-            _ => panic!("Unexpected result"),
-        };
-    }
-}
-
-fn ic0_msg_deadline_best_effort_responses_feature_flag_impl(
-    flag: BestEffortResponsesFeature,
-) -> Result<WasmResult, UserError> {
-    let mut test = ExecutionTestBuilder::new()
-        .with_best_effort_responses(flag)
-        .build();
+fn test_ic0_msg_deadline_best_effort_responses() {
+    let mut test = ExecutionTestBuilder::new().build();
 
     let canister_id = test
         .universal_canister_with_cycles(Cycles::new(10_000_000_000_000))
         .unwrap();
 
-    test.ingress(
+    let result = test.ingress(
         canister_id,
         "update",
         wasm().msg_deadline().reply_int64().build(),
-    )
-}
+    );
 
-#[test]
-fn test_ic0_msg_deadline_best_effort_responses_feature_flag() {
     let no_deadline = Time::from(NO_DEADLINE).as_nanos_since_unix_epoch();
-    for flag in &[
-        BestEffortResponsesFeature::SpecificSubnets(vec![]),
-        BestEffortResponsesFeature::SpecificSubnets(vec![OTHER_SUBNET_ID]),
-        BestEffortResponsesFeature::SpecificSubnets(vec![OWN_SUBNET_ID, OTHER_SUBNET_ID]),
-        BestEffortResponsesFeature::ApplicationSubnetsOnly,
-        BestEffortResponsesFeature::Enabled,
-    ] {
-        assert_eq!(
-            ic0_msg_deadline_best_effort_responses_feature_flag_impl(flag.clone()).unwrap(),
-            WasmResult::Reply(no_deadline.to_le_bytes().into())
-        );
-    }
+    assert_eq!(
+        result,
+        Ok(WasmResult::Reply(no_deadline.to_le_bytes().into()))
+    );
 }

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -1,6 +1,5 @@
 use candid::{Decode, Encode};
 use ic_base_types::{NumBytes, NumSeconds};
-use ic_config::embedders::BestEffortResponsesFeature;
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_management_canister_types_private::{
     self as ic00, BitcoinGetUtxosArgs, BitcoinNetwork, BoundedHttpHeaders, CanisterChange,
@@ -400,7 +399,6 @@ fn output_best_effort_requests_on_application_subnets_update_subnet_available_me
         .with_subnet_execution_memory(ONE_GIB)
         .with_subnet_memory_reservation(0)
         .with_subnet_guaranteed_response_message_memory(ONE_GIB)
-        .with_best_effort_responses(BestEffortResponsesFeature::Enabled)
         .with_manual_execution()
         .build();
     let canister_id = test.canister_from_wat(CALL_BEST_EFFORT_WAT).unwrap();

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -338,10 +338,7 @@ const INSTALL_CODE_INGRESS_COST: u128 = 1_952_000;
 const INSTALL_CODE_EXECUTION_COST: u128 = 5_986_224;
 const NORMAL_INGRESS_COST: u128 = 1_224_000;
 const MAX_EXECUTION_COST: u128 = 6_000_000;
-
-fn actual_execution_cost() -> Cycles {
-    Cycles::new(5_985_224)
-}
+const ACTUAL_EXECUTION_COST: u128 = 5_985_224;
 
 #[test]
 fn dts_install_code_with_concurrent_ingress_sufficient_cycles() {
@@ -349,6 +346,7 @@ fn dts_install_code_with_concurrent_ingress_sufficient_cycles() {
     let install_code_execution_cost = Cycles::new(INSTALL_CODE_EXECUTION_COST);
     let normal_ingress_cost = Cycles::new(NORMAL_INGRESS_COST);
     let max_execution_cost = Cycles::new(MAX_EXECUTION_COST);
+    let actual_execution_cost = Cycles::new(ACTUAL_EXECUTION_COST);
 
     // The initial balance is sufficient to run `install_code` and to send an
     // ingress message concurrently.
@@ -425,7 +423,7 @@ fn dts_install_code_with_concurrent_ingress_sufficient_cycles() {
             - install_code_execution_cost
             - install_code_ingress_cost
             - normal_ingress_cost
-            - actual_execution_cost()
+            - actual_execution_cost
             - config.dirty_page_overhead_cycles(1))
         .get()
     );
@@ -436,6 +434,7 @@ fn dts_install_code_with_concurrent_ingress_insufficient_cycles() {
     let install_code_ingress_cost = Cycles::new(INSTALL_CODE_INGRESS_COST);
     let normal_ingress_cost = Cycles::new(NORMAL_INGRESS_COST);
     let max_execution_cost = Cycles::new(MAX_EXECUTION_COST);
+    let actual_execution_cost = Cycles::new(ACTUAL_EXECUTION_COST);
 
     // The initial balance is not sufficient for both execution and concurrent ingress message.
     let initial_balance = install_code_ingress_cost + normal_ingress_cost.max(max_execution_cost);
@@ -473,7 +472,7 @@ fn dts_install_code_with_concurrent_ingress_insufficient_cycles() {
         env.cycle_balance(canister_id),
         (initial_balance
             - install_code_ingress_cost
-            - actual_execution_cost()
+            - actual_execution_cost
             - config.dirty_page_overhead_cycles(1))
         .get()
     );
@@ -484,6 +483,7 @@ fn dts_install_code_with_concurrent_ingress_and_freezing_threshold_insufficient_
     let install_code_ingress_cost = Cycles::new(INSTALL_CODE_INGRESS_COST);
     let normal_ingress_cost = Cycles::new(NORMAL_INGRESS_COST);
     let max_execution_cost = Cycles::new(MAX_EXECUTION_COST);
+    let actual_execution_cost = Cycles::new(ACTUAL_EXECUTION_COST);
 
     // The initial balance is not sufficient for both execution and concurrent ingress message.
     let initial_balance = install_code_ingress_cost + normal_ingress_cost.max(max_execution_cost);
@@ -520,7 +520,7 @@ fn dts_install_code_with_concurrent_ingress_and_freezing_threshold_insufficient_
         env.cycle_balance(canister_id),
         (initial_balance
             - install_code_ingress_cost
-            - actual_execution_cost()
+            - actual_execution_cost
             - config.dirty_page_overhead_cycles(1))
         .get()
     );

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -3,7 +3,6 @@ use candid::Encode;
 use canister_test::CanisterInstallMode;
 use ic_base_types::PrincipalId;
 use ic_config::{
-    embedders::BestEffortResponsesFeature,
     execution_environment::{
         Config as HypervisorConfig, DEFAULT_WASM_MEMORY_LIMIT, MINIMUM_FREEZING_THRESHOLD,
     },
@@ -2268,17 +2267,12 @@ fn helper_best_effort_responses(
     expected_deadline_seconds: u32,
 ) {
     let subnet_config = SubnetConfig::new(SubnetType::Application);
-    let mut embedders_config = ic_config::embedders::Config::default();
-    embedders_config.feature_flags.best_effort_responses = BestEffortResponsesFeature::Enabled;
 
     let env = StateMachineBuilder::new()
         .with_time(Time::from_secs_since_unix_epoch(start_time_seconds as u64).unwrap())
         .with_config(Some(StateMachineConfig::new(
             subnet_config,
-            HypervisorConfig {
-                embedders_config,
-                ..Default::default()
-            },
+            HypervisorConfig::default(),
         )))
         .build();
 

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -1,10 +1,8 @@
 use assert_matches::assert_matches;
 use candid::{Decode, Encode};
 use ic_base_types::{NumSeconds, PrincipalId};
+use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
 use ic_config::subnet_config::SchedulerConfig;
-use ic_config::{
-    embedders::BestEffortResponsesFeature, execution_environment::MINIMUM_FREEZING_THRESHOLD,
-};
 use ic_cycles_account_manager::ResourceSaturation;
 use ic_embedders::{
     wasm_utils::instrumentation::{instruction_to_cost, WasmMemoryType},
@@ -5666,9 +5664,7 @@ fn cycles_correct_if_update_fails() {
 
 #[test]
 fn call_with_best_effort_response_succeeds() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_best_effort_responses(BestEffortResponsesFeature::Enabled)
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
 
     let canister_id = test.universal_canister().unwrap();
 
@@ -5690,9 +5686,7 @@ fn call_with_best_effort_response_succeeds() {
 
 #[test]
 fn call_with_best_effort_response_fails_when_timeout_is_set() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_best_effort_responses(BestEffortResponsesFeature::Enabled)
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
 
     let canister_id = test.universal_canister().unwrap();
 
@@ -5720,7 +5714,6 @@ fn call_with_best_effort_response_test_helper(
     timeout_seconds: u32,
 ) -> CoarseTime {
     let mut test = ExecutionTestBuilder::new()
-        .with_best_effort_responses(BestEffortResponsesFeature::Enabled)
         .with_manual_execution()
         .with_time(Time::from_secs_since_unix_epoch(start_time_seconds as u64).unwrap())
         .build();
@@ -5784,7 +5777,6 @@ fn ic0_msg_deadline_while_executing_ingress_message() {
     let start_time_seconds = 100;
 
     let mut test = ExecutionTestBuilder::new()
-        .with_best_effort_responses(BestEffortResponsesFeature::Enabled)
         .with_time(Time::from_secs_since_unix_epoch(start_time_seconds as u64).unwrap())
         .build();
 
@@ -5806,7 +5798,6 @@ fn ic0_msg_deadline_when_deadline_is_not_set() {
     let start_time_seconds = 100;
 
     let mut test = ExecutionTestBuilder::new()
-        .with_best_effort_responses(BestEffortResponsesFeature::Enabled)
         .with_time(Time::from_secs_since_unix_epoch(start_time_seconds as u64).unwrap())
         .build();
 
@@ -5844,7 +5835,6 @@ fn ic0_msg_deadline_when_deadline_is_set() {
     let timeout_seconds = 200;
 
     let mut test = ExecutionTestBuilder::new()
-        .with_best_effort_responses(BestEffortResponsesFeature::Enabled)
         .with_time(Time::from_secs_since_unix_epoch(start_time_seconds as u64).unwrap())
         .build();
 

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -2,7 +2,6 @@ use crate::{
     routing, scheduling,
     state_machine::{StateMachine, StateMachineImpl},
 };
-use ic_config::embedders::BestEffortResponsesFeature;
 use ic_config::execution_environment::{BitcoinConfig, Config as HypervisorConfig};
 use ic_config::message_routing::{MAX_STREAM_MESSAGES, TARGET_STREAM_SIZE_BYTES};
 use ic_cycles_account_manager::CyclesAccountManager;
@@ -669,11 +668,6 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             metrics_registry,
             &metrics,
             time_in_stream_metrics,
-            hypervisor_config
-                .embedders_config
-                .feature_flags
-                .best_effort_responses
-                .clone(),
             log.clone(),
         ));
         let state_machine = Box::new(StateMachineImpl::new(
@@ -1533,7 +1527,6 @@ impl MessageRoutingImpl {
             Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(
                 metrics_registry,
             ))),
-            BestEffortResponsesFeature::Enabled,
             log.clone(),
         ));
 

--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -1,7 +1,6 @@
 use crate::message_routing::{
     LatencyMetrics, MessageRoutingMetrics, CRITICAL_ERROR_INDUCT_RESPONSE_FAILED,
 };
-use ic_config::embedders::BestEffortResponsesFeature;
 use ic_error_types::RejectCode;
 use ic_limits::SYSTEM_SUBNET_STREAM_MSG_LIMIT;
 use ic_logger::{error, warn, ReplicaLogger};
@@ -16,7 +15,7 @@ use ic_replicated_state::{
 use ic_types::{
     messages::{
         Payload, RejectContext, Request, RequestOrResponse, Response,
-        MAX_INTER_CANISTER_PAYLOAD_IN_BYTES, MAX_REJECT_MESSAGE_LEN_BYTES, NO_DEADLINE,
+        MAX_INTER_CANISTER_PAYLOAD_IN_BYTES, MAX_REJECT_MESSAGE_LEN_BYTES,
     },
     CountBytes, SubnetId,
 };
@@ -171,10 +170,6 @@ pub(crate) struct StreamBuilderImpl {
     target_stream_size_bytes: usize,
     metrics: StreamBuilderMetrics,
     time_in_stream_metrics: Arc<Mutex<LatencyMetrics>>,
-
-    /// Rollout stage of the best-effort responses feature.
-    best_effort_responses: BestEffortResponsesFeature,
-
     log: ReplicaLogger,
 }
 
@@ -186,7 +181,6 @@ impl StreamBuilderImpl {
         metrics_registry: &MetricsRegistry,
         message_routing_metrics: &MessageRoutingMetrics,
         time_in_stream_metrics: Arc<Mutex<LatencyMetrics>>,
-        best_effort_responses: BestEffortResponsesFeature,
         log: ReplicaLogger,
     ) -> Self {
         Self {
@@ -195,7 +189,6 @@ impl StreamBuilderImpl {
             target_stream_size_bytes,
             metrics: StreamBuilderMetrics::new(metrics_registry, message_routing_metrics),
             time_in_stream_metrics,
-            best_effort_responses,
             log,
         }
     }
@@ -324,7 +317,6 @@ impl StreamBuilderImpl {
             .collect();
 
         let mut requests_to_reject = Vec::new();
-        let mut best_effort_requests_to_unsupported_subnets = Vec::new();
         let mut oversized_requests = Vec::new();
 
         let mut output_iter = state.output_into_iter();
@@ -355,14 +347,13 @@ impl StreamBuilderImpl {
             match routing_table.route(msg.receiver().get()) {
                 // Destination subnet found.
                 Some(dst_subnet_id) => {
-                    let destination_subnet_type = *subnet_types
-                        .get(&dst_subnet_id)
-                        .unwrap_or(&SubnetType::Application);
                     let dst_stream_entry = streams.entry(dst_subnet_id);
                     if is_at_limit(
                         &dst_stream_entry,
                         self.subnet_id == dst_subnet_id,
-                        destination_subnet_type,
+                        *subnet_types
+                            .get(&dst_subnet_id)
+                            .unwrap_or(&SubnetType::Application),
                     ) {
                         // Stream full, skip all other messages to this destination.
                         output_iter.exclude_queue();
@@ -372,8 +363,8 @@ impl StreamBuilderImpl {
                     // We will route (or reject) the message, pop it.
                     let mut msg = validated_next(&mut output_iter, &msg);
 
-                    // Reject messages with oversized payloads, as they may cause streams to
-                    // permanently stall. Also reject best-effort requests to unsupported subnets.
+                    // Reject messages with oversized payloads, as they may
+                    // cause streams to permanently stall.
                     match msg {
                         // Remote request above the payload size limit.
                         RequestOrResponse::Request(req)
@@ -392,24 +383,6 @@ impl StreamBuilderImpl {
                                 LABEL_VALUE_STATUS_PAYLOAD_TOO_LARGE,
                             );
                             oversized_requests.push(req);
-                        }
-
-                        // Best-effort request to unsupported subnet. Always route subnet-local requests
-                        // for consistency with scheduler routing.
-                        //
-                        // TODO(MR-649): Drop this once best-effort calls are fully deployed.
-                        RequestOrResponse::Request(req)
-                            if req.deadline != NO_DEADLINE
-                                && dst_subnet_id != self.subnet_id
-                                && !self
-                                    .best_effort_responses
-                                    .is_enabled_on(&dst_subnet_id, destination_subnet_type) =>
-                        {
-                            warn!(
-                                self.log,
-                                "Best-effort request to unsupported subnet from {}", req.sender
-                            );
-                            best_effort_requests_to_unsupported_subnets.push(req);
                         }
 
                         // Response above the payload size limit.
@@ -493,18 +466,6 @@ impl StreamBuilderImpl {
                 &req,
                 RejectCode::DestinationInvalid,
                 format!("No route to canister {}", dst_canister_id),
-            );
-        }
-
-        for req in best_effort_requests_to_unsupported_subnets {
-            self.reject_local_request(
-                &mut state,
-                &req,
-                RejectCode::DestinationInvalid,
-                format!(
-                    "Best-effort call to unsupported subnet: {} -> {}",
-                    req.sender, req.receiver
-                ),
             );
         }
 

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -662,7 +662,6 @@ fn build_streams_with_messages_targeted_to_other_subnets() {
 }
 
 fn build_streams_with_best_effort_messages_impl(
-    best_effort_responses: &BestEffortResponsesFeature,
     local_subnet_type: SubnetType,
     remote_subnet_type: SubnetType,
 ) {
@@ -685,8 +684,7 @@ fn build_streams_with_best_effort_messages_impl(
                 .build(),
         ];
 
-        let (mut stream_builder, mut provided_state, _) = new_fixture(&log);
-        stream_builder.best_effort_responses = best_effort_responses.clone();
+        let (stream_builder, mut provided_state, _) = new_fixture(&log);
 
         // Set the subnet types of the local and remote subnets.
         provided_state.metadata.network_topology.subnets = btreemap! {
@@ -707,7 +705,7 @@ fn build_streams_with_best_effort_messages_impl(
 
         let result_state = stream_builder.build_streams(provided_state);
 
-        // Local best-effort requests are always routed, regardless.
+        // Local best-effort reques was routed.
         assert!(
             !result_state
                 .streams()
@@ -715,85 +713,52 @@ fn build_streams_with_best_effort_messages_impl(
                 .unwrap()
                 .messages()
                 .is_empty(),
-            "Best-effort responses feature: {:?}, Local subnet type: {:?}, Remote subnet type: {:?}",
-            best_effort_responses,
+            "Local subnet type: {:?}, Remote subnet type: {:?}",
             local_subnet_type,
             remote_subnet_type,
         );
 
-        // Remote best-effort requests are only routed when enabled for the respective
-        // remote subnet type.
-        let remote_request_routed =
-            best_effort_responses.is_enabled_on(&REMOTE_SUBNET, remote_subnet_type);
-        assert_eq!(
-            remote_request_routed,
-            result_state.streams().contains_key(&REMOTE_SUBNET),
-            "Best-effort responses feature: {:?}, Local subnet type: {:?}, Remote subnet type: {:?}",
-            best_effort_responses,
+        // Remote best-effort requests was routed.
+        assert!(
+            !result_state
+                .streams()
+                .get(&REMOTE_SUBNET)
+                .unwrap()
+                .messages()
+                .is_empty(),
+            "Local subnet type: {:?}, Remote subnet type: {:?}",
             local_subnet_type,
             remote_subnet_type,
         );
 
+        // No reject response was enqueued.
         let maybe_reject_response = result_state
             .canister_state(&local_canister_id)
             .unwrap()
             .clone()
             .pop_input();
-        // If the remote request was not routed, a reject response was enqueued.
-        assert_eq!(
-            !remote_request_routed,
-            maybe_reject_response.is_some(),
-            "Best-effort responses feature: {:?}, Local subnet type: {:?}, Remote subnet type: {:?}",
-            best_effort_responses,
+        assert!(
+            maybe_reject_response.is_none(),
+            "Local subnet type: {:?}, Remote subnet type: {:?}",
             local_subnet_type,
             remote_subnet_type,
         );
-        if let Some(reject_respomse) = maybe_reject_response {
-            let expected_reject_response: RequestOrResponse = Response {
-                originator: local_canister_id,
-                respondent: remote_canister_id,
-                originator_reply_callback: CallbackId::from(2),
-                refund: Cycles::zero(),
-                response_payload: Payload::Reject(RejectContext::new(
-                    RejectCode::DestinationInvalid,
-                    format!(
-                        "Best-effort call to unsupported subnet: {} -> {}",
-                        local_canister_id, remote_canister_id
-                    ),
-                )),
-                deadline: SOME_DEADLINE,
-            }
-            .into();
-            assert_eq!(reject_respomse, expected_reject_response.into());
-        }
     });
 }
 
 #[test]
 fn build_streams_with_best_effort_messages() {
-    for best_effort_responses in &[
-        BestEffortResponsesFeature::SpecificSubnets(vec![]),
-        BestEffortResponsesFeature::SpecificSubnets(vec![REMOTE_SUBNET]),
-        BestEffortResponsesFeature::SpecificSubnets(vec![LOCAL_SUBNET, REMOTE_SUBNET]),
-        BestEffortResponsesFeature::ApplicationSubnetsOnly,
-        BestEffortResponsesFeature::Enabled,
+    for local_subnet_type in &[
+        SubnetType::Application,
+        SubnetType::System,
+        SubnetType::VerifiedApplication,
     ] {
-        for local_subnet_type in &[
+        for remote_subnet_type in &[
             SubnetType::Application,
             SubnetType::System,
             SubnetType::VerifiedApplication,
         ] {
-            for remote_subnet_type in &[
-                SubnetType::Application,
-                SubnetType::System,
-                SubnetType::VerifiedApplication,
-            ] {
-                build_streams_with_best_effort_messages_impl(
-                    best_effort_responses,
-                    *local_subnet_type,
-                    *remote_subnet_type,
-                );
-            }
+            build_streams_with_best_effort_messages_impl(*local_subnet_type, *remote_subnet_type);
         }
     }
 }
@@ -1024,7 +989,6 @@ fn new_fixture_with_limits(
         Arc::new(Mutex::new(LatencyMetrics::new_time_in_stream(
             &metrics_registry,
         ))),
-        BestEffortResponsesFeature::Enabled,
         log.clone(),
     );
 

--- a/rs/messaging/tests/common/mod.rs
+++ b/rs/messaging/tests/common/mod.rs
@@ -2,7 +2,6 @@ use candid::{Decode, Encode};
 use canister_test::Project;
 use ic_base_types::{CanisterId, NumBytes, SubnetId};
 use ic_config::{
-    embedders::{BestEffortResponsesFeature, Config as EmbeddersConfig, FeatureFlags},
     execution_environment::Config as HypervisorConfig,
     subnet_config::{CyclesAccountManagerConfig, SchedulerConfig, SubnetConfig},
 };
@@ -101,13 +100,6 @@ impl SubnetPairConfig {
             HypervisorConfig {
                 guaranteed_response_message_memory_capacity: subnet_message_memory_capacity.into(),
                 best_effort_message_memory_capacity: subnet_message_memory_capacity.into(),
-                embedders_config: EmbeddersConfig {
-                    feature_flags: FeatureFlags {
-                        best_effort_responses: BestEffortResponsesFeature::Enabled,
-                        ..FeatureFlags::default()
-                    },
-                    ..EmbeddersConfig::default()
-                },
                 ..HypervisorConfig::default()
             },
         )

--- a/rs/starter/src/lib.rs
+++ b/rs/starter/src/lib.rs
@@ -1,4 +1,4 @@
-use ic_config::embedders::{BestEffortResponsesFeature, FeatureFlags};
+use ic_config::embedders::FeatureFlags;
 use ic_config::flag_status::FlagStatus;
 use ic_config::{
     embedders::Config as EmbeddersConfig, execution_environment::Config as HypervisorConfig,
@@ -14,7 +14,6 @@ pub fn hypervisor_config(canister_sandboxing: bool) -> HypervisorConfig {
         embedders_config: EmbeddersConfig {
             feature_flags: FeatureFlags {
                 rate_limiting_of_debug_prints: FlagStatus::Disabled,
-                best_effort_responses: BestEffortResponsesFeature::Enabled,
                 wasm64: FlagStatus::Enabled,
                 canister_backtrace: FlagStatus::Enabled,
                 ..FeatureFlags::default()

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1,5 +1,5 @@
 use ic_base_types::{NumBytes, NumSeconds, PrincipalId, SubnetId};
-use ic_config::embedders::{BestEffortResponsesFeature, MeteringType, StableMemoryPageLimit};
+use ic_config::embedders::{MeteringType, StableMemoryPageLimit};
 use ic_config::subnet_config::CyclesAccountManagerConfig;
 use ic_config::{
     embedders::{Config as EmbeddersConfig, WASM_MAX_SIZE},
@@ -2145,14 +2145,6 @@ impl ExecutionTestBuilder {
 
     pub fn with_metering_type(mut self, metering_type: MeteringType) -> Self {
         self.execution_config.embedders_config.metering_type = metering_type;
-        self
-    }
-
-    pub fn with_best_effort_responses(mut self, stage: BestEffortResponsesFeature) -> Self {
-        self.execution_config
-            .embedders_config
-            .feature_flags
-            .best_effort_responses = stage;
         self
     }
 


### PR DESCRIPTION
With the rollout of best-effort messages complete, drop the `best_effort_responses` flag and `BestEffortResponsesFeature` type, restoring the various const functions (and functionality) of `EmbedderConfig`.

This is an approximate rollback of 513258a (retaining the tests and minor refactorings).