### PR TITLE
feat(nns): Add an index for maturity disbursement based on finalization timestamp

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -163,6 +163,7 @@ pub mod governance;
 pub mod governance_proto_builder;
 mod heap_governance_data;
 mod known_neuron_index;
+mod maturity_disbursement_index;
 mod network_economics;
 mod neuron;
 pub mod neuron_data_validation;
@@ -607,6 +608,7 @@ pub fn encode_metrics(
         following: following_index_len,
         known_neuron: known_neuron_index_len,
         account_id: account_id_index_len,
+        maturity_disbursement: maturity_disbursement_index_len,
     } = governance.neuron_store.stable_indexes_lens();
 
     w.encode_gauge(
@@ -634,6 +636,13 @@ pub fn encode_metrics(
         account_id_index_len as f64,
         "Total number of entries in the account_id index",
     )?;
+    if is_disburse_maturity_enabled() {
+        w.encode_gauge(
+            "governance_maturity_disbursement_index_len",
+            maturity_disbursement_index_len as f64,
+            "Total number of entries in the maturity disbursement index",
+        )?;
+    }
 
     let mut builder = w.gauge_vec(
         "governance_proposal_deadline_timestamp_seconds",

--- a/rs/nns/governance/src/maturity_disbursement_index.rs
+++ b/rs/nns/governance/src/maturity_disbursement_index.rs
@@ -1,0 +1,95 @@
+use std::collections::BTreeSet;
+
+use crate::storage::validate_stable_btree_map;
+
+use ic_stable_structures::{Memory, StableBTreeMap};
+
+type TimestampSeconds = u64;
+type NeuronId = u64;
+
+/// An index which stores (finalization_timestamp, neuron_id) pairs for maturity disbursement
+/// events. Used for quickly looking up the next finalization timestamp.
+pub struct MaturityDisbursementIndex<M: Memory> {
+    // Conceptually, it is possible to use StableMinHeap here. However, `impl NeuronIndex`  requires
+    // the index to be able to remove any entries associated with a neuron, which is a bit
+    // restrictive since we don't expect any disbursement to be removed. On the other hand, using
+    // StableBTreeMap achieves similar performance.
+    finalization_timestamp_neuron_id_to_null: StableBTreeMap<(TimestampSeconds, NeuronId), (), M>,
+}
+
+impl<M: Memory> MaturityDisbursementIndex<M> {
+    pub fn new(memory: M) -> Self {
+        Self {
+            finalization_timestamp_neuron_id_to_null: StableBTreeMap::init(memory),
+        }
+    }
+
+    pub fn num_entries(&self) -> usize {
+        self.finalization_timestamp_neuron_id_to_null.len() as usize
+    }
+
+    /// Adds (finalization_timestamp, neuron_id) pairs to the index, returns a list of timestamps
+    /// that are not added because of clobbering.
+    pub fn add_neuron_id_finalization_timestamps(
+        &mut self,
+        neuron_id: NeuronId,
+        finalization_timestamps: BTreeSet<TimestampSeconds>,
+    ) -> Vec<TimestampSeconds> {
+        let mut already_present_timestamps = Vec::new();
+        for finalization_timestamp in finalization_timestamps {
+            let already_present = self
+                .finalization_timestamp_neuron_id_to_null
+                .insert((finalization_timestamp, neuron_id), ())
+                .is_some();
+            if already_present {
+                already_present_timestamps.push(finalization_timestamp);
+            }
+        }
+        already_present_timestamps
+    }
+
+    /// Removes (finalization_timestamp, neuron_id) pairs from the index, returns a list of
+    /// timestamps that are not removed because of non-existence.
+    pub fn remove_neuron_id_finalization_timestamps(
+        &mut self,
+        neuron_id: NeuronId,
+        finalization_timestamps: BTreeSet<TimestampSeconds>,
+    ) -> Vec<TimestampSeconds> {
+        let mut already_absent_timestamps = Vec::new();
+        for finalization_timestamp in finalization_timestamps {
+            let already_absent = self
+                .finalization_timestamp_neuron_id_to_null
+                .remove(&(finalization_timestamp, neuron_id))
+                .is_none();
+            if already_absent {
+                already_absent_timestamps.push(finalization_timestamp);
+            }
+        }
+        already_absent_timestamps
+    }
+
+    /// Returns the neuron ids that are ready for maturity disbursement.
+    pub fn get_neuron_ids_ready_to_finalize(
+        &self,
+        now_seconds: TimestampSeconds,
+    ) -> BTreeSet<NeuronId> {
+        let max_key = (now_seconds, u64::MAX);
+        self.finalization_timestamp_neuron_id_to_null
+            .range(..=max_key)
+            .map(|((_, neuron_id), _)| neuron_id)
+            .collect()
+    }
+
+    /// Returns the next finalization timestamp for a neuron, if any.
+    pub fn get_next_finalization_timestamp(&self) -> Option<TimestampSeconds> {
+        self.finalization_timestamp_neuron_id_to_null
+            .first_key_value()
+            .map(|((finalization_timestamp, _neuron_id), _)| finalization_timestamp)
+    }
+
+    /// Validates that some of the data in stable storage can be read, in order to prevent broken
+    /// schema. Should only be called in post_upgrade.
+    pub fn validate(&self) {
+        validate_stable_btree_map(&self.finalization_timestamp_neuron_id_to_null);
+    }
+}

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -1145,6 +1145,17 @@ impl Neuron {
         self.maturity_disbursements_in_progress
             .push(maturity_disbursement);
     }
+
+    /// Pops the first maturity disbursement in progress.
+    #[cfg(test)]
+    pub fn pop_maturity_disbursement_in_progress(&mut self) -> Option<MaturityDisbursement> {
+        if self.maturity_disbursements_in_progress.is_empty() {
+            None
+        } else {
+            // This is safe because we know that the vector is not empty.
+            Some(self.maturity_disbursements_in_progress.remove(0))
+        }
+    }
 }
 
 impl From<Neuron> for NeuronProto {

--- a/rs/nns/governance/src/storage.rs
+++ b/rs/nns/governance/src/storage.rs
@@ -29,6 +29,7 @@ const NODE_PROVIDER_REWARDS_LOG_DATA_MEMORY_ID: MemoryId = MemoryId::new(15);
 const VOTING_STATE_MACHINES_MEMORY_ID: MemoryId = MemoryId::new(16);
 const REWARDS_DISTRIBUTION_STATE_MACHINE_MEMORY_ID: MemoryId = MemoryId::new(17);
 const MATURITY_DISBURSEMENTS_NEURONS_MEMORY_ID: MemoryId = MemoryId::new(18);
+const NEURON_MATURITY_DISBURSEMENT_INDEX_MEMORY_ID: MemoryId = MemoryId::new(19);
 
 pub mod neuron_indexes;
 pub mod neurons;
@@ -113,6 +114,8 @@ impl State {
                 following: memory_manager.get(NEURON_FOLLOWING_INDEX_MEMORY_ID),
                 known_neuron: memory_manager.get(NEURON_KNOWN_NEURON_INDEX_MEMORY_ID),
                 account_id: memory_manager.get(NEURON_ACCOUNT_ID_INDEX_MEMORY_ID),
+                maturity_disbursement: memory_manager
+                    .get(NEURON_MATURITY_DISBURSEMENT_INDEX_MEMORY_ID),
             }
             .build()
         });

--- a/rs/nns/governance/src/storage/neuron_indexes.rs
+++ b/rs/nns/governance/src/storage/neuron_indexes.rs
@@ -1,6 +1,8 @@
 use crate::{
     account_id_index::NeuronAccountIdIndex,
+    is_disburse_maturity_enabled,
     known_neuron_index::{AddKnownNeuronError, KnownNeuronIndex, RemoveKnownNeuronError},
+    maturity_disbursement_index::MaturityDisbursementIndex,
     neuron::Neuron,
     neuron_store::NeuronStoreError,
     pb::v1::Topic,
@@ -40,6 +42,7 @@ pub(crate) struct StableNeuronIndexesBuilder<Memory> {
     pub following: Memory,
     pub known_neuron: Memory,
     pub account_id: Memory,
+    pub maturity_disbursement: Memory,
 }
 
 impl<Memory> StableNeuronIndexesBuilder<Memory>
@@ -53,6 +56,7 @@ where
             following,
             known_neuron,
             account_id,
+            maturity_disbursement,
         } = self;
 
         StableNeuronIndexes {
@@ -61,6 +65,7 @@ where
             following: StableNeuronFollowingIndex::new(following),
             known_neuron: KnownNeuronIndex::new(known_neuron),
             account_id: NeuronAccountIdIndex::new(account_id),
+            maturity_disbursement: MaturityDisbursementIndex::new(maturity_disbursement),
         }
     }
 }
@@ -75,6 +80,7 @@ where
     following: StableNeuronFollowingIndex<NeuronId, Topic, Memory>,
     known_neuron: KnownNeuronIndex<Memory>,
     account_id: NeuronAccountIdIndex<Memory>,
+    maturity_disbursement: MaturityDisbursementIndex<Memory>,
 }
 
 #[cfg(feature = "test")]
@@ -114,6 +120,7 @@ pub enum NeuronIndexDefect {
     Following { reason: String },
     KnownNeuron { reason: String },
     AccountId { reason: String },
+    MaturityDisbursement { reason: String },
 }
 
 impl Display for NeuronIndexDefect {
@@ -133,6 +140,9 @@ impl Display for NeuronIndexDefect {
             }
             Self::AccountId { reason } => {
                 write!(f, "AccountId index is corrupted: {}", reason)
+            }
+            Self::MaturityDisbursement { reason } => {
+                write!(f, "Maturity disbursement index is corrupted: {}", reason)
             }
         }
     }
@@ -532,6 +542,116 @@ fn combine_index_defects(
     }
 }
 
+fn maturity_disbursement_finalization_timestamps(neuron: &Neuron) -> BTreeSet<u64> {
+    neuron
+        .maturity_disbursements_in_progress()
+        .iter()
+        .map(|disbursement| disbursement.finalize_disbursement_timestamp_seconds)
+        .collect()
+}
+
+fn already_present_finalization_timestamps_to_result(
+    already_present_finalization_timestamps: Vec<u64>,
+    neuron_id: NeuronId,
+) -> Result<(), NeuronIndexDefect> {
+    if already_present_finalization_timestamps.is_empty() {
+        Ok(())
+    } else {
+        Err(NeuronIndexDefect::MaturityDisbursement {
+            reason: format!(
+                "Finalization timestamps {:?} already present for neuron {}",
+                already_present_finalization_timestamps, neuron_id.id
+            ),
+        })
+    }
+}
+
+fn already_absent_finalization_timestamps_to_result(
+    already_absent_finalization_timestamps: Vec<u64>,
+    neuron_id: NeuronId,
+) -> Result<(), NeuronIndexDefect> {
+    if already_absent_finalization_timestamps.is_empty() {
+        Ok(())
+    } else {
+        Err(NeuronIndexDefect::MaturityDisbursement {
+            reason: format!(
+                "Finalization timestamps {:?} already absent for neuron {}",
+                already_absent_finalization_timestamps, neuron_id.id
+            ),
+        })
+    }
+}
+
+impl<Memory> NeuronIndex for MaturityDisbursementIndex<Memory>
+where
+    Memory: ic_stable_structures::Memory,
+{
+    fn add_neuron(&mut self, new_neuron: &Neuron) -> Result<(), NeuronIndexDefect> {
+        let finalization_timestamps_to_add =
+            maturity_disbursement_finalization_timestamps(new_neuron);
+        let already_present_finalization_timestamps = self.add_neuron_id_finalization_timestamps(
+            new_neuron.id().id,
+            finalization_timestamps_to_add,
+        );
+        already_present_finalization_timestamps_to_result(
+            already_present_finalization_timestamps,
+            new_neuron.id(),
+        )
+    }
+
+    fn remove_neuron(&mut self, existing_neuron: &Neuron) -> Result<(), NeuronIndexDefect> {
+        let finalization_timestamps_to_remove =
+            maturity_disbursement_finalization_timestamps(existing_neuron);
+        let already_absent_finalization_timestamps = self.remove_neuron_id_finalization_timestamps(
+            existing_neuron.id().id,
+            finalization_timestamps_to_remove,
+        );
+        already_absent_finalization_timestamps_to_result(
+            already_absent_finalization_timestamps,
+            existing_neuron.id(),
+        )
+    }
+
+    fn update_neuron(
+        &mut self,
+        old_neuron: &Neuron,
+        new_neuron: &Neuron,
+    ) -> Result<(), Vec<NeuronIndexDefect>> {
+        let old_finalization_timestamps = maturity_disbursement_finalization_timestamps(old_neuron);
+        let new_finalization_timestamps = maturity_disbursement_finalization_timestamps(new_neuron);
+
+        // Set differences are used for preventing excessive stable storage writes, which are expensive especially when they are scattered.
+        let finalization_timestamps_to_remove = old_finalization_timestamps
+            .difference(&new_finalization_timestamps)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let finalization_timestamps_to_add = new_finalization_timestamps
+            .difference(&old_finalization_timestamps)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+
+        let already_absent_finalization_timestamps = self.remove_neuron_id_finalization_timestamps(
+            old_neuron.id().id,
+            finalization_timestamps_to_remove,
+        );
+        let already_present_finalization_timestamps = self.add_neuron_id_finalization_timestamps(
+            new_neuron.id().id,
+            finalization_timestamps_to_add,
+        );
+
+        let defect_remove = already_absent_finalization_timestamps_to_result(
+            already_absent_finalization_timestamps,
+            old_neuron.id(),
+        );
+        let defect_add = already_present_finalization_timestamps_to_result(
+            already_present_finalization_timestamps,
+            new_neuron.id(),
+        );
+
+        combine_index_defects(defect_remove, defect_add)
+    }
+}
+
 impl<Memory> StableNeuronIndexes<Memory>
 where
     Memory: ic_stable_structures::Memory,
@@ -640,13 +760,17 @@ where
     }
 
     fn indexes_mut(&mut self) -> Vec<&mut dyn NeuronIndex> {
-        vec![
+        let mut indexes: Vec<&mut dyn NeuronIndex> = vec![
             &mut self.subaccount,
             &mut self.principal,
             &mut self.following,
             &mut self.known_neuron,
             &mut self.account_id,
-        ]
+        ];
+        if is_disburse_maturity_enabled() {
+            indexes.push(&mut self.maturity_disbursement);
+        }
+        indexes
     }
 
     // It's OK to expose read-only access to all the indexes.
@@ -670,6 +794,10 @@ where
         &self.account_id
     }
 
+    pub fn maturity_disbursement(&self) -> &MaturityDisbursementIndex<Memory> {
+        &self.maturity_disbursement
+    }
+
     /// Validates that some of the data in stable storage can be read, in order to prevent broken
     /// schema. Should only be called in post_upgrade.
     pub fn validate(&self) {
@@ -678,6 +806,9 @@ where
         self.following.validate();
         self.known_neuron.validate();
         self.account_id.validate();
+        if is_disburse_maturity_enabled() {
+            self.maturity_disbursement.validate();
+        }
     }
 }
 
@@ -692,6 +823,7 @@ pub(crate) fn new_heap_based() -> StableNeuronIndexes<VectorMemory> {
         following: VectorMemory::default(),
         known_neuron: VectorMemory::default(),
         account_id: VectorMemory::default(),
+        maturity_disbursement: VectorMemory::default(),
     }
     .build()
 }


### PR DESCRIPTION
# Why

To support finalizing maturity disbursement (asynchronous, as it's 7 days after initiation), a timer task is needed to find all the neurons eligible for finalization, as well as computing the next finalization timestamp. An index from finalization timestamp to neuron ids will help avoid unnecessary full neuron scans.

# What

* Define and implement `MaturityDisbursementIndex`
* Add it to `indexes_mut` behind feature flag so that updating neurons will cause the index to be updated
* Export `governance_maturity_disbursement_index_len` metric behind feature flag
* Validate the index map behind feature flag

# Why no behavior change

All 3 places modifying existing behaviors are behind feature flag: (1) updating indexes when updating neuron (2) encoding metric for size of the index (3) validating the index btree map