### PR TITLE
fix: switch to checkpoint for wasm binaries in canister snapshots

### DIFF
--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -1123,6 +1123,15 @@ fn switch_to_checkpoint(
                 layout.height(),
                 Arc::clone(fd_factory),
             )?);
+
+        let wasm_binary = snapshot_layout.wasm().deserialize(Some(
+            new_snapshot
+                .execution_snapshot()
+                .wasm_binary
+                .module_hash()
+                .into(),
+        ))?;
+        new_snapshot.execution_snapshot_mut().wasm_binary = wasm_binary;
     }
 
     for (tip_id, tip_canister) in tip.canister_states.iter_mut() {


### PR DESCRIPTION
During checkpointing, we switch to the files in the new checkpoint to back data structures like pagemaps and wasm binaries. This approach should also apply to the wasm binaries of canister snapshots and this PR fixes it.