### PR TITLE
chore: bump crossbeam-channel to 0.5.15 (#4767)

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a19f55602c933ed19f74373cf271fae7927c3afa4e38b687586ae806f8cc3811",
+  "checksum": "25c10e6215d471775ff9fb7eb0d5eb6cebc749601e7fc80fbd4d2065fcdba76f",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -16914,7 +16914,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -16946,14 +16946,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "crossbeam-channel 0.5.13": {
+    "crossbeam-channel 0.5.15": {
       "name": "crossbeam-channel",
-      "version": "0.5.13",
+      "version": "0.5.15",
       "package_url": "https://github.com/crossbeam-rs/crossbeam",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/crossbeam-channel/0.5.13/download",
-          "sha256": "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+          "url": "https://static.crates.io/crates/crossbeam-channel/0.5.15/download",
+          "sha256": "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
         }
       },
       "targets": [
@@ -16992,7 +16992,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.5.13"
+        "version": "0.5.15"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -20743,7 +20743,7 @@
               "target": "crossbeam"
             },
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -37931,7 +37931,7 @@
               "target": "clap"
             },
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -46642,7 +46642,7 @@
               "target": "async_lock"
             },
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -50828,7 +50828,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -51024,7 +51024,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -73176,7 +73176,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -82043,7 +82043,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -94440,7 +94440,7 @@
     "crc32fast 1.3.2",
     "criterion 0.5.1",
     "crossbeam 0.8.4",
-    "crossbeam-channel 0.5.13",
+    "crossbeam-channel 0.5.15",
     "csv 1.3.0",
     "ctrlc 3.4.5",
     "curve25519-dalek 4.1.3",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -2803,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "01abee1004cda795a1e7afabea0db4e41d95d02f5e4482262c69550734d59555",
+  "checksum": "524ebf9b29523b17ea8de0a2e99be8e72f3b574a1fbf397edf7fb1a49d6c6856",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -16742,7 +16742,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -16774,14 +16774,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "crossbeam-channel 0.5.13": {
+    "crossbeam-channel 0.5.15": {
       "name": "crossbeam-channel",
-      "version": "0.5.13",
+      "version": "0.5.15",
       "package_url": "https://github.com/crossbeam-rs/crossbeam",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/crossbeam-channel/0.5.13/download",
-          "sha256": "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+          "url": "https://static.crates.io/crates/crossbeam-channel/0.5.15/download",
+          "sha256": "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
         }
       },
       "targets": [
@@ -16820,7 +16820,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.5.13"
+        "version": "0.5.15"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -20571,7 +20571,7 @@
               "target": "crossbeam"
             },
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -37765,7 +37765,7 @@
               "target": "clap"
             },
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -46482,7 +46482,7 @@
               "target": "async_lock"
             },
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -50668,7 +50668,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -50864,7 +50864,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -73055,7 +73055,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -81922,7 +81922,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-channel 0.5.13",
+              "id": "crossbeam-channel 0.5.15",
               "target": "crossbeam_channel"
             },
             {
@@ -94353,7 +94353,7 @@
     "crc32fast 1.3.2",
     "criterion 0.5.1",
     "crossbeam 0.8.4",
-    "crossbeam-channel 0.5.13",
+    "crossbeam-channel 0.5.15",
     "csv 1.2.2",
     "ctrlc 3.4.5",
     "curve25519-dalek 4.1.3",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -2792,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,9 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -538,7 +538,7 @@ clap = { version = "4.5.20", features = ["derive", "string"] }
 # - https://github.com/cloudflare/cloudflare-rs/issues/236
 cloudflare = { git = "https://github.com/dfinity/cloudflare-rs.git", rev = "a6538a036926bd756986c9c0a5de356daef48881", default-features = false }
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
-crossbeam-channel = "0.5.13"
+crossbeam-channel = "0.5.15"
 curve25519-dalek = { version = "4.1.3", features = [
     "group",
     "precomputed-tables",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -423,7 +423,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.8.4",
             ),
             "crossbeam-channel": crate.spec(
-                version = "^0.5.13",
+                version = "^0.5.15",
             ),
             "csv": crate.spec(
                 version = "^1.1",


### PR DESCRIPTION
(cherry picked from commit 2fbdb88dc8fe2918cf3e313de6eeb358f0e3b345)