### PR TITLE
fix: re-enable `ic_xc_cketh_test`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -132,7 +132,7 @@ use_repo(oci, "bitcoind", "bitcoind_linux_amd64")
 # foundry container used in test
 oci.pull(
     name = "foundry",
-    image = "ghcr.io/foundry-rs/foundry@sha256:d12a373ec950de170d5461014ef9320ba0fb6e0db6f87835999d0fcf3820370e",  # v1.0.0
+    image = "ghcr.io/foundry-rs/foundry@sha256:8f9dd6d4c498538b3aa3999758520bca24a41273163b0c7295ed53b1a6062f30",  # v0.3.0 https://github.com/foundry-rs/foundry/pkgs/container/foundry/391862899?tag=v0.3.0
     platforms = [
         "linux/amd64",
     ],

--- a/rs/tests/cross_chain/BUILD.bazel
+++ b/rs/tests/cross_chain/BUILD.bazel
@@ -53,10 +53,7 @@ system_test_nns(
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister_u256.wasm.gz)",
         "LEDGER_SUITE_ORCHESTRATOR_WASM_PATH": "$(rootpath //rs/ethereum/ledger-suite-orchestrator:ledger_suite_orchestrator_canister.wasm.gz)",
     },
-    # TODO: Replace the `manual` tag with `long_test` once this test is fixed.
-    tags = [
-        "manual",
-    ],
+    tags = ["long_test"],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps =
         BOUNDARY_NODE_GUESTOS_RUNTIME_DEPS +

--- a/rs/tests/cross_chain/ic_xc_cketh_test.rs
+++ b/rs/tests/cross_chain/ic_xc_cketh_test.rs
@@ -815,7 +815,12 @@ fn deploy_smart_contract(
     logger: &slog::Logger,
 ) -> (Address, BlockNumber) {
     let sender_private_key = sender.private_key();
-    let json_output = foundry.block_on_bash_script(&format!(r#"docker run --net {DOCKER_NETWORK_NAME} --rm -v /config/{filename}:/contracts/{filename} foundry "forge create --json --rpc-url http://anvil:{FOUNDRY_PORT} --broadcast --private-key {sender_private_key} /contracts/{filename}:{contract_name} --constructor-args {constructor_args}""#)).unwrap();
+    let cmd = format!("\
+        docker run --net {DOCKER_NETWORK_NAME} --rm \
+        -v /config/{filename}:/contracts/{filename} \
+        foundry \"forge create --json --rpc-url http://anvil:{FOUNDRY_PORT} --broadcast --private-key {sender_private_key} /contracts/{filename}:{contract_name} --constructor-args {constructor_args}\"\
+    ");
+    let json_output = foundry.block_on_bash_script(&cmd).unwrap();
     info!(
         logger,
         "Deployed {filename} with constructor args {constructor_args}: {}", json_output

--- a/rs/tests/cross_chain/ic_xc_cketh_test.rs
+++ b/rs/tests/cross_chain/ic_xc_cketh_test.rs
@@ -815,7 +815,7 @@ fn deploy_smart_contract(
     logger: &slog::Logger,
 ) -> (Address, BlockNumber) {
     let sender_private_key = sender.private_key();
-    let json_output = foundry.block_on_bash_script(&format!(r#"docker run --net {DOCKER_NETWORK_NAME} --rm -v /config/{filename}:/contracts/{filename} foundry "forge create --json --rpc-url http://anvil:{FOUNDRY_PORT} --private-key {sender_private_key} /contracts/{filename}:{contract_name} --constructor-args {constructor_args}""#)).unwrap();
+    let json_output = foundry.block_on_bash_script(&format!(r#"docker run --net {DOCKER_NETWORK_NAME} --rm -v /config/{filename}:/contracts/{filename} foundry "forge create --json --rpc-url http://anvil:{FOUNDRY_PORT} --broadcast --private-key {sender_private_key} /contracts/{filename}:{contract_name} --constructor-args {constructor_args}""#)).unwrap();
     info!(
         logger,
         "Deployed {filename} with constructor args {constructor_args}: {}", json_output


### PR DESCRIPTION
Use foundry [v0.3.0](https://github.com/foundry-rs/foundry/pkgs/container/foundry/391862899?tag=v0.3.0) to re-enable the system test `ic_xc_cketh_test`. 

That test was disabled with #4775 due to a failed attempt to upgrade foundry to the last version in #4764 that was blocking the CI pipeline.
