### PR TITLE
test(ICRC_Ledger): Remove migration-related checks in ICRC ledger suite golden state test

### DIFF
--- a/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
+++ b/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
@@ -21,11 +21,6 @@ use std::str::FromStr;
 
 mod common;
 
-/// The number of instructions that can be executed in a single canister upgrade.
-/// The limit (<https://internetcomputer.org/docs/current/developer-docs/smart-contracts/maintain/resource-limits#resource-constraints-and-limits>)
-/// is actually 300B, but in the ledger implementation we use a value slightly lower than the old
-/// limit 200B.
-const CANISTER_UPGRADE_INSTRUCTION_LIMIT: u64 = 199_950_000_000;
 const NUM_TRANSACTIONS_PER_TYPE: usize = 20;
 const MINT_MULTIPLIER: u64 = 10_000;
 const TRANSFER_MULTIPLIER: u64 = 1000;

--- a/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
+++ b/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
@@ -8,10 +8,10 @@ use ic_icrc1_index_ng::{IndexArg, UpgradeArg as IndexUpgradeArg};
 use ic_ledger_suite_state_machine_tests::in_memory_ledger::{
     BlockConsumer, BurnsWithoutSpender, InMemoryLedger,
 };
-use ic_ledger_suite_state_machine_tests::metrics::{parse_metric, retrieve_metrics};
+use ic_ledger_suite_state_machine_tests::metrics::retrieve_metrics;
 use ic_ledger_suite_state_machine_tests::{
     generate_transactions, get_all_ledger_and_archive_blocks, get_blocks, list_archives,
-    wait_ledger_ready, TransactionGenerationParameters,
+    TransactionGenerationParameters,
 };
 use ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_fiduciary_state_or_panic;
 use ic_state_machine_tests::{StateMachine, UserError};
@@ -155,12 +155,6 @@ struct LedgerSuiteConfig {
     master_wasms: &'static Wasms,
 }
 
-#[derive(Eq, PartialEq)]
-enum ExpectMigration {
-    Yes,
-    No,
-}
-
 impl LedgerSuiteConfig {
     fn new(
         canister_ids_and_name: (&'static str, &'static str, &'static str),
@@ -190,29 +184,6 @@ impl LedgerSuiteConfig {
             burns_without_spender,
             extended_testing,
             ..Self::new(canister_ids_and_name, mainnet_wasms, master_wasms)
-        }
-    }
-
-    /// Check if upgrading the ledger canister is expected to involve some migration to stable
-    /// structures, by checking the WASM module hash, and returing `ExpectMigration::No` in case
-    /// the ledger has already been migrated.
-    fn is_migration_expected(&self, state_machine: &StateMachine) -> ExpectMigration {
-        let canister_id =
-            CanisterId::unchecked_from_principal(PrincipalId::from_str(self.ledger_id).unwrap());
-        let controllers = state_machine
-            .get_controllers(canister_id)
-            .expect("canister should have controllers");
-        let canister_status = state_machine
-            .canister_status_as(controllers[0], canister_id)
-            .expect("should successfully request canister status")
-            .expect("should successfully retrieve canister status");
-        let deployed_module_hash = canister_status
-            .module_hash()
-            .expect("should have ledger canister module hash");
-        if deployed_module_hash.as_slice() == BLOCKS_MIGRATED_LEDGER_MODULE_HASH.as_slice() {
-            ExpectMigration::No
-        } else {
-            ExpectMigration::Yes
         }
     }
 
@@ -262,43 +233,13 @@ impl LedgerSuiteConfig {
         }
     }
 
-    fn check_ledger_metrics(
-        &self,
-        state_machine: &StateMachine,
-        expect_migration: ExpectMigration,
-    ) {
+    fn print_ledger_metrics(&self, state_machine: &StateMachine) {
         let ledger_id =
             CanisterId::unchecked_from_principal(PrincipalId::from_str(self.ledger_id).unwrap());
         let metrics = retrieve_metrics(state_machine, ledger_id);
         println!("Ledger metrics:");
         for metric in metrics {
             println!("  {}", metric);
-        }
-        if expect_migration == ExpectMigration::Yes {
-            let migration_steps = parse_metric(
-                state_machine,
-                ledger_id,
-                "ledger_stable_upgrade_migration_steps",
-            );
-            assert!(
-                migration_steps > 0u64,
-                "Migration steps ({}) should be greater than 0",
-                migration_steps
-            );
-            let upgrade_instructions = parse_metric(
-                state_machine,
-                ledger_id,
-                "ledger_total_upgrade_instructions_consumed",
-            );
-            // For now, only check number of upgrade instructions for migration, since due to a
-            // bug some old ledgers may report wild numbers coming from parsing a `u64` from
-            // uninitialized memory.
-            assert!(
-                upgrade_instructions < CANISTER_UPGRADE_INSTRUCTION_LIMIT,
-                "Upgrade instructions ({}) should be less than the instruction limit ({})",
-                upgrade_instructions,
-                CANISTER_UPGRADE_INSTRUCTION_LIMIT
-            );
         }
     }
 
@@ -336,12 +277,7 @@ impl LedgerSuiteConfig {
         println!("Upgraded {} index '{}'", self.canister_name, self.index_id);
     }
 
-    fn upgrade_ledger(
-        &self,
-        state_machine: &StateMachine,
-        wasm: &Wasm,
-        expect_migration: ExpectMigration,
-    ) -> Result<(), UserError> {
+    fn upgrade_ledger(&self, state_machine: &StateMachine, wasm: &Wasm) -> Result<(), UserError> {
         let canister_id =
             CanisterId::unchecked_from_principal(PrincipalId::from_str(self.ledger_id).unwrap());
         let args = ic_icrc1_ledger::LedgerArgument::Upgrade(None);
@@ -352,10 +288,7 @@ impl LedgerSuiteConfig {
                     "Upgraded {} ledger '{}'",
                     self.canister_name, self.ledger_id
                 );
-                if expect_migration == ExpectMigration::Yes {
-                    wait_ledger_ready(state_machine, canister_id, 100);
-                }
-                self.check_ledger_metrics(state_machine, expect_migration);
+                self.print_ledger_metrics(state_machine);
                 Ok(())
             }
             Err(e) => {
@@ -374,20 +307,13 @@ impl LedgerSuiteConfig {
         self.upgrade_index_or_panic(state_machine, &self.mainnet_wasms.index_wasm);
         let expected_downgrade_result =
             self.mainnet_wasms.ledger_version == self.master_wasms.ledger_version;
-        let ledger_upgrade_res = self.upgrade_ledger(
-            state_machine,
-            &self.mainnet_wasms.ledger_wasm,
-            ExpectMigration::No,
-        );
+        let ledger_upgrade_res =
+            self.upgrade_ledger(state_machine, &self.mainnet_wasms.ledger_wasm);
         match (expected_downgrade_result, ledger_upgrade_res) {
             (true, Ok(_)) => {
                 // Perform another downgrade to exercise the pre-upgrade
-                self.upgrade_ledger(
-                    state_machine,
-                    &self.mainnet_wasms.ledger_wasm,
-                    ExpectMigration::No,
-                )
-                .expect("should downgrade to mainnet ledger version");
+                self.upgrade_ledger(state_machine, &self.mainnet_wasms.ledger_wasm)
+                    .expect("should downgrade to mainnet ledger version");
             }
             (true, Err(e)) => {
                 panic!(
@@ -410,8 +336,7 @@ impl LedgerSuiteConfig {
         // Upgrade each canister twice to exercise pre-upgrade
         self.upgrade_index_or_panic(state_machine, &self.master_wasms.index_wasm);
         self.upgrade_index_or_panic(state_machine, &self.master_wasms.index_wasm);
-        let expect_migration = self.is_migration_expected(state_machine);
-        self.upgrade_ledger(state_machine, &self.master_wasms.ledger_wasm, expect_migration)
+        self.upgrade_ledger(state_machine, &self.master_wasms.ledger_wasm)
             .or_else(|e| {
                 match (
                     e.description().contains(
@@ -423,21 +348,17 @@ impl LedgerSuiteConfig {
                     // migration to stable structures, the ledger canister must be at least at V2,
                     // i.e., the ledger state must be managed by the memory manager.
                     (true, Some(wasm_v2)) => {
-                        self.upgrade_ledger(state_machine, wasm_v2, ExpectMigration::No)
+                        self.upgrade_ledger(state_machine, wasm_v2)
                             .expect("should successfully upgrade ledger to V2");
-                        self.upgrade_ledger(state_machine, &self.master_wasms.ledger_wasm, ExpectMigration::Yes)
+                        self.upgrade_ledger(state_machine, &self.master_wasms.ledger_wasm)
                     }
                     _ => Err(e)
                 }
             })
             .expect("should successfully upgrade ledger");
         // No migration expected in second upgrade to the same version
-        self.upgrade_ledger(
-            state_machine,
-            &self.master_wasms.ledger_wasm,
-            ExpectMigration::No,
-        )
-        .expect("should successfully upgrade ledger");
+        self.upgrade_ledger(state_machine, &self.master_wasms.ledger_wasm)
+            .expect("should successfully upgrade ledger");
         self.upgrade_archives_or_panic(state_machine, &self.master_wasms.archive_wasm);
         self.upgrade_archives_or_panic(state_machine, &self.master_wasms.archive_wasm);
     }


### PR DESCRIPTION
Since the migration to stable structures is complete, it shall again be possible to roll back to the previous ledger version. This PR proposes to remove the parameters and functionality that allowed for failed downgrades to not fail the test - since the downgrades tested here should now always be possible, any downgrade failure should also cause the test to fail.