### PR TITLE
chore: Revert "feat: Introduce low bound for canister's freezing threshold (#4401)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12871,7 +12871,6 @@ dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
  "ic-canisters-http-types",
- "ic-config",
  "ic-crypto",
  "ic-crypto-sha2",
  "ic-icrc1",

--- a/hs/spec_compliance/src/IC/Test/Spec/CanisterHistory.hs
+++ b/hs/spec_compliance/src/IC/Test/Spec/CanisterHistory.hs
@@ -112,7 +112,7 @@ canister_history_tests ecid =
                   return (),
                 simpleTestCase "does not track all update_settings calls" ecid $ \unican -> do
                   cid <- ic_provisional_create ic00 ecid Nothing Nothing Nothing
-                  ic_set_freezing_threshold ic00 cid (30 * 86400) -- not stored in canister history; canister version still bumped
+                  ic_set_freezing_threshold ic00 cid (2 ^ 10) -- not stored in canister history; canister version still bumped
                   ic_install ic00 (enum #install) cid trivialWasmModule ""
 
                   info <- get_canister_info unican cid (Just 2)

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -163,9 +163,6 @@ pub const MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT: usize = 3000;
 ///   - use the maximum of `default_wasm_memory_limit` and `halfway_to_max`.
 pub const DEFAULT_WASM_MEMORY_LIMIT: NumBytes = NumBytes::new(3 * GIB);
 
-/// The minimum allowed value for freezing threshold in seconds.
-pub const MINIMUM_FREEZING_THRESHOLD: u64 = 604800; // 1 week in seconds.
-
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {

--- a/rs/execution_environment/src/canister_settings.rs
+++ b/rs/execution_environment/src/canister_settings.rs
@@ -1,5 +1,4 @@
 use ic_base_types::{NumBytes, NumSeconds};
-use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
 use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
 use ic_error_types::{ErrorCode, UserError};
 use ic_interfaces::execution_environment::SubnetAvailableMemory;
@@ -108,24 +107,9 @@ impl TryFrom<CanisterSettingsArgs> for CanisterSettings {
         };
 
         let freezing_threshold = match input.freezing_threshold {
-            Some(ft) => match ft.0.to_u64() {
-                Some(num) => {
-                    if num < MINIMUM_FREEZING_THRESHOLD {
-                        return Err(UpdateSettingsError::FreezingThresholdOutOfRange {
-                            provided: ft,
-                            minimum: candid::Nat::from(MINIMUM_FREEZING_THRESHOLD),
-                        });
-                    }
-                    Some(NumSeconds::from(num))
-                }
-                // Value cannot fit in a 64-bit integer.
-                None => {
-                    return Err(UpdateSettingsError::FreezingThresholdOutOfRange {
-                        provided: ft,
-                        minimum: candid::Nat::from(MINIMUM_FREEZING_THRESHOLD),
-                    });
-                }
-            },
+            Some(ft) => Some(NumSeconds::from(ft.0.to_u64().ok_or(
+                UpdateSettingsError::FreezingThresholdOutOfRange { provided: ft },
+            )?)),
             None => None,
         };
 
@@ -288,19 +272,10 @@ impl CanisterSettingsBuilder {
 pub enum UpdateSettingsError {
     ComputeAllocation(InvalidComputeAllocationError),
     MemoryAllocation(InvalidMemoryAllocationError),
-    FreezingThresholdOutOfRange {
-        provided: candid::Nat,
-        minimum: candid::Nat,
-    },
-    ReservedCyclesLimitOutOfRange {
-        provided: candid::Nat,
-    },
-    WasmMemoryLimitOutOfRange {
-        provided: candid::Nat,
-    },
-    WasmMemoryThresholdOutOfRange {
-        provided: candid::Nat,
-    },
+    FreezingThresholdOutOfRange { provided: candid::Nat },
+    ReservedCyclesLimitOutOfRange { provided: candid::Nat },
+    WasmMemoryLimitOutOfRange { provided: candid::Nat },
+    WasmMemoryThresholdOutOfRange { provided: candid::Nat },
 }
 
 impl From<UpdateSettingsError> for UserError {
@@ -322,15 +297,13 @@ impl From<UpdateSettingsError> for UserError {
                     err.min, err.max, err.given
                 ),
             ),
-            UpdateSettingsError::FreezingThresholdOutOfRange { provided, minimum } => {
-                UserError::new(
-                    ErrorCode::CanisterContractViolation,
-                    format!(
-                        "Freezing threshold expected to be in the range of [{}..2^64-1], got {}",
-                        minimum, provided
-                    ),
-                )
-            }
+            UpdateSettingsError::FreezingThresholdOutOfRange { provided } => UserError::new(
+                ErrorCode::CanisterContractViolation,
+                format!(
+                    "Freezing threshold expected to be in the range of [0..2^64-1], got {}",
+                    provided
+                ),
+            ),
             UpdateSettingsError::ReservedCyclesLimitOutOfRange { provided } => UserError::new(
                 ErrorCode::CanisterContractViolation,
                 format!(

--- a/rs/execution_environment/src/execution/response/tests.rs
+++ b/rs/execution_environment/src/execution/response/tests.rs
@@ -1,18 +1,13 @@
 use assert_matches::assert_matches;
 use ic_base_types::{NumBytes, NumSeconds};
 use ic_config::embedders::BestEffortResponsesFeature;
-use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
 use ic_error_types::{ErrorCode, UserError};
 use ic_management_canister_types_private::CanisterStatusType;
-use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::NextExecution;
 use ic_replicated_state::testing::SystemStateTesting;
 use ic_replicated_state::{MessageMemoryUsage, NumWasmPages};
 use ic_test_utilities_execution_environment::{
     check_ingress_status, ExecutionResponse, ExecutionTest, ExecutionTestBuilder,
-};
-use ic_test_utilities_execution_environment::{
-    filtered_subnet_config, DropFeesFilter, ExecutionFeesFilter,
 };
 use ic_test_utilities_metrics::fetch_int_counter;
 use ic_test_utilities_types::messages::ResponseBuilder;
@@ -1245,9 +1240,7 @@ fn dts_response_concurrent_cycles_change_succeeds() {
         .with_manual_execution()
         .build();
 
-    let a_id = test
-        .universal_canister_with_cycles(Cycles::new(10_000_000_000_000))
-        .unwrap();
+    let a_id = test.universal_canister().unwrap();
     let b_id = test.universal_canister().unwrap();
 
     let transferred_cycles = Cycles::new(1000);
@@ -1280,7 +1273,7 @@ fn dts_response_concurrent_cycles_change_succeeds() {
     test.execute_message(b_id);
     test.induct_messages();
 
-    test.update_freezing_threshold(a_id, NumSeconds::from(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(a_id, NumSeconds::from(1))
         .unwrap();
     test.canister_update_allocations_settings(a_id, Some(1), None)
         .unwrap();
@@ -1292,7 +1285,7 @@ fn dts_response_concurrent_cycles_change_succeeds() {
     // The memory usage of the canister increases during the message execution.
     // `ic0.call_perform()` used the current freezing threshold. This value is
     // an upper bound on the additional freezing threshold.
-    let additional_freezing_threshold = Cycles::new(500 * MINIMUM_FREEZING_THRESHOLD as u128);
+    let additional_freezing_threshold = Cycles::new(500);
 
     let max_execution_cost = test.cycles_account_manager().execution_cost(
         NumInstructions::from(instruction_limit),
@@ -1360,14 +1353,9 @@ fn dts_response_concurrent_cycles_change_fails() {
     // 6. The response callback fails because there are not enough cycles
     //    in the canister balance to cover both the call and cycles debit.
     let instruction_limit = 100_000_000;
-    let subnet_config = filtered_subnet_config(
-        SubnetType::Application,
-        ExecutionFeesFilter::Drop(DropFeesFilter::IdleResources),
-    );
     let mut test = ExecutionTestBuilder::new()
         .with_instruction_limit(instruction_limit)
         .with_slice_instruction_limit(1_000_000)
-        .with_cycles_account_manager_config(subnet_config.cycles_account_manager_config)
         .with_manual_execution()
         .build();
 
@@ -1404,7 +1392,7 @@ fn dts_response_concurrent_cycles_change_fails() {
     test.execute_message(b_id);
     test.induct_messages();
 
-    test.update_freezing_threshold(a_id, NumSeconds::from(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(a_id, NumSeconds::from(1))
         .unwrap();
     test.canister_update_allocations_settings(a_id, Some(1), None)
         .unwrap();
@@ -1499,14 +1487,9 @@ fn dts_response_with_cleanup_concurrent_cycles_change_succeeds() {
     // 9. The cleanup callback resumes and succeeds because it cannot change the
     //    cycles balance of the canister.
     let instruction_limit = 100_000_000;
-    let subnet_config = filtered_subnet_config(
-        SubnetType::Application,
-        ExecutionFeesFilter::Drop(DropFeesFilter::IdleResources),
-    );
     let mut test = ExecutionTestBuilder::new()
         .with_instruction_limit(instruction_limit)
         .with_slice_instruction_limit(1_000_000)
-        .with_cycles_account_manager_config(subnet_config.cycles_account_manager_config)
         .with_manual_execution()
         .build();
 
@@ -1551,7 +1534,7 @@ fn dts_response_with_cleanup_concurrent_cycles_change_succeeds() {
     test.execute_message(b_id);
     test.induct_messages();
 
-    test.update_freezing_threshold(a_id, NumSeconds::from(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(a_id, NumSeconds::from(1))
         .unwrap();
     test.canister_update_allocations_settings(a_id, Some(1), None)
         .unwrap();
@@ -1650,9 +1633,7 @@ fn dts_response_with_cleanup_concurrent_cycles_change_is_capped() {
         .with_manual_execution()
         .build();
 
-    let a_id = test
-        .universal_canister_with_cycles(Cycles::new(10_000_000_000_000))
-        .unwrap();
+    let a_id = test.universal_canister().unwrap();
     let b_id = test.universal_canister().unwrap();
 
     let transferred_cycles = Cycles::new(1_000);
@@ -1688,7 +1669,7 @@ fn dts_response_with_cleanup_concurrent_cycles_change_is_capped() {
     test.execute_message(b_id);
     test.induct_messages();
 
-    test.update_freezing_threshold(a_id, NumSeconds::from(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(a_id, NumSeconds::from(1))
         .unwrap();
     test.canister_update_allocations_settings(a_id, Some(1), None)
         .unwrap();

--- a/rs/execution_environment/src/execution_environment/tests/canister_task.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_task.rs
@@ -1,6 +1,5 @@
 use assert_matches::assert_matches;
 use ic_base_types::NumSeconds;
-use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
 use ic_config::{execution_environment::Config as HypervisorConfig, subnet_config::SubnetConfig};
 use ic_error_types::RejectCode;
 use ic_management_canister_types_private::{
@@ -838,7 +837,7 @@ fn global_timer_resumes_after_canister_is_being_frozen_and_unfrozen_again() {
     };
     let unfreeze = |env: &StateMachine, canister_id: CanisterId| {
         let args = CanisterSettingsArgsBuilder::new()
-            .with_freezing_threshold(MINIMUM_FREEZING_THRESHOLD)
+            .with_freezing_threshold(0)
             .build();
         let result = env.update_settings(&canister_id, args);
         assert_matches!(result, Ok(_));
@@ -980,7 +979,7 @@ fn on_low_wasm_memory_hook_is_run_after_freezing() {
     );
 
     // We update `freezing_threshold` unfreezing canister.
-    test.update_freezing_threshold(canister_id, NumSeconds::new(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(canister_id, NumSeconds::new(100))
         .unwrap();
 
     // The hook is executed.

--- a/rs/execution_environment/src/query_handler/query_cache/tests.rs
+++ b/rs/execution_environment/src/query_handler/query_cache/tests.rs
@@ -5,7 +5,6 @@ use crate::{
     InternalHttpQueryHandler,
 };
 use ic_base_types::CanisterId;
-use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
 use ic_error_types::ErrorCode;
 use ic_interfaces::execution_environment::{SystemApiCallCounters, SystemApiCallId};
 use ic_registry_subnet_type::SubnetType;
@@ -1340,9 +1339,9 @@ fn query_cache_returns_different_results_on_canister_going_above_freezing_thresh
         assert_eq!(1, m.misses.get());
         assert_eq!(1, m.invalidated_entries_by_transient_error.get());
 
-        // Decrease the freezing threshold, so the query should be successful.
+        // Remove the freezing threshold.
         // The update setting message, so it invalidates the cache entry.
-        test.update_freezing_threshold(b_id, MINIMUM_FREEZING_THRESHOLD.into())
+        test.update_freezing_threshold(b_id, 0.into())
             .expect("The settings update must succeed.");
 
         // Run the same query for the second time.

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use assert_matches::assert_matches;
 use candid::Encode;
 use ic_base_types::{CanisterId, PrincipalId};
-use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
 use ic_config::{
     embedders::{Config as EmbeddersConfig, MeteringType},
     execution_environment::Config as HypervisorConfig,
@@ -23,9 +22,6 @@ use ic_management_canister_types_private::{
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::{execution_state::NextScheduledMethod, NextExecution};
 use ic_state_machine_tests::{ErrorCode, StateMachine, StateMachineConfig};
-use ic_test_utilities_execution_environment::{
-    filtered_subnet_config, DropFeesFilter, ExecutionFeesFilter,
-};
 use ic_types::ingress::{IngressState, IngressStatus};
 use ic_types::messages::MessageId;
 use ic_types::{ingress::WasmResult, CryptoHashOfState, Cycles, NumInstructions};
@@ -181,33 +177,22 @@ fn dts_install_code_env(
     message_instruction_limit: NumInstructions,
     slice_instruction_limit: NumInstructions,
 ) -> (StateMachine, DtsEnvConfig) {
-    let mut subnet_config = filtered_subnet_config(
-        SubnetType::Application,
-        ExecutionFeesFilter::Drop(DropFeesFilter::IdleResources),
-    );
-
-    subnet_config
-        .scheduler_config
-        .max_instructions_per_install_code = message_instruction_limit;
-    subnet_config
-        .scheduler_config
-        .max_instructions_per_install_code_slice = slice_instruction_limit;
-    subnet_config.scheduler_config.max_instructions_per_round =
-        message_instruction_limit + message_instruction_limit;
-    subnet_config.scheduler_config.max_instructions_per_message = message_instruction_limit;
-    subnet_config
-        .scheduler_config
-        .max_instructions_per_message_without_dts = slice_instruction_limit;
-    subnet_config.scheduler_config.max_instructions_per_slice = message_instruction_limit;
-    subnet_config
-        .scheduler_config
-        .instruction_overhead_per_execution = NumInstructions::from(0);
-    subnet_config
-        .scheduler_config
-        .instruction_overhead_per_canister = NumInstructions::from(0);
-
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let config = DtsEnvConfig::new(
-        subnet_config,
+        SubnetConfig {
+            scheduler_config: SchedulerConfig {
+                max_instructions_per_install_code: message_instruction_limit,
+                max_instructions_per_install_code_slice: slice_instruction_limit,
+                max_instructions_per_round: message_instruction_limit + message_instruction_limit,
+                max_instructions_per_message: message_instruction_limit,
+                max_instructions_per_message_without_dts: slice_instruction_limit,
+                max_instructions_per_slice: message_instruction_limit,
+                instruction_overhead_per_execution: NumInstructions::from(0),
+                instruction_overhead_per_canister: NumInstructions::from(0),
+                ..subnet_config.scheduler_config
+            },
+            ..subnet_config
+        },
         HypervisorConfig {
             deterministic_time_slicing: FlagStatus::Enabled,
             ..Default::default()
@@ -291,7 +276,7 @@ struct DtsInstallCode {
 ///    complete.
 fn setup_dts_install_code(
     initial_balance: Cycles,
-    freezing_threshold_in_seconds: u64,
+    freezing_threshold_in_seconds: usize,
 ) -> DtsInstallCode {
     let (env, config) = dts_install_code_env(
         NumInstructions::from(1_000_000),
@@ -304,7 +289,7 @@ fn setup_dts_install_code(
         Some(
             CanisterSettingsArgsBuilder::new()
                 .with_compute_allocation(1)
-                .with_freezing_threshold(freezing_threshold_in_seconds)
+                .with_freezing_threshold(freezing_threshold_in_seconds as u64)
                 .build(),
         ),
     );
@@ -369,7 +354,7 @@ fn dts_install_code_with_concurrent_ingress_sufficient_cycles() {
         Some(
             CanisterSettingsArgsBuilder::new()
                 .with_compute_allocation(1)
-                .with_freezing_threshold(MINIMUM_FREEZING_THRESHOLD)
+                .with_freezing_threshold(0)
                 .build(),
         ),
     );
@@ -445,7 +430,7 @@ fn dts_install_code_with_concurrent_ingress_insufficient_cycles() {
         canister_id,
         install_code_ingress_id,
         config,
-    } = setup_dts_install_code(initial_balance, MINIMUM_FREEZING_THRESHOLD);
+    } = setup_dts_install_code(initial_balance, 0);
 
     // Start execution of `install_code`.
     env.tick();
@@ -484,16 +469,19 @@ fn dts_install_code_with_concurrent_ingress_and_freezing_threshold_insufficient_
     let install_code_ingress_cost = Cycles::new(INSTALL_CODE_INGRESS_COST);
     let normal_ingress_cost = Cycles::new(NORMAL_INGRESS_COST);
     let max_execution_cost = Cycles::new(MAX_EXECUTION_COST);
+    let freezing_threshold = Cycles::new(10000000);
 
     // The initial balance is not sufficient for both execution and concurrent ingress message.
-    let initial_balance = install_code_ingress_cost + normal_ingress_cost.max(max_execution_cost);
+    let initial_balance = freezing_threshold
+        + install_code_ingress_cost
+        + normal_ingress_cost.max(max_execution_cost);
 
     let DtsInstallCode {
         env,
         canister_id,
         install_code_ingress_id,
         config,
-    } = setup_dts_install_code(initial_balance, MINIMUM_FREEZING_THRESHOLD);
+    } = setup_dts_install_code(initial_balance, 1);
 
     // Start execution of `install_code`.
     env.tick();
@@ -509,7 +497,7 @@ fn dts_install_code_with_concurrent_ingress_and_freezing_threshold_insufficient_
             "Canister {} is out of cycles: \
              please top up the canister with at least {} additional cycles",
             canister_id,
-            normal_ingress_cost
+            (freezing_threshold + normal_ingress_cost)
                 - (initial_balance - install_code_ingress_cost - max_execution_cost),
         )
     );

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -4,9 +4,7 @@ use canister_test::CanisterInstallMode;
 use ic_base_types::PrincipalId;
 use ic_config::{
     embedders::BestEffortResponsesFeature,
-    execution_environment::{
-        Config as HypervisorConfig, DEFAULT_WASM_MEMORY_LIMIT, MINIMUM_FREEZING_THRESHOLD,
-    },
+    execution_environment::{Config as HypervisorConfig, DEFAULT_WASM_MEMORY_LIMIT},
     subnet_config::{CyclesAccountManagerConfig, SubnetConfig},
 };
 use ic_embedders::wasmtime_embedder::system_api::MAX_CALL_TIMEOUT_SECONDS;
@@ -1271,9 +1269,10 @@ fn canister_with_memory_allocation_does_not_fail_when_growing_wasm_memory() {
         Some(
             CanisterSettingsArgsBuilder::new()
                 .with_memory_allocation(50_000_000)
+                .with_freezing_threshold(0)
                 .build(),
         ),
-        Cycles::new(u128::MAX),
+        INITIAL_CYCLES_BALANCE,
     );
     let _b_id = create_canister_with_cycles(
         &env,
@@ -1281,9 +1280,10 @@ fn canister_with_memory_allocation_does_not_fail_when_growing_wasm_memory() {
         Some(
             CanisterSettingsArgsBuilder::new()
                 .with_memory_allocation(45_000_000)
+                .with_freezing_threshold(0)
                 .build(),
         ),
-        Cycles::new(u128::MAX),
+        INITIAL_CYCLES_BALANCE,
     );
 
     let res = env.execute_ingress(a_id, "update", vec![]);
@@ -1367,9 +1367,10 @@ fn canister_with_memory_allocation_cannot_grow_wasm_memory_above_allocation() {
         Some(
             CanisterSettingsArgsBuilder::new()
                 .with_memory_allocation(300 * 64 * 1024)
+                .with_freezing_threshold(0)
                 .build(),
         ),
-        Cycles::new(u128::MAX),
+        INITIAL_CYCLES_BALANCE,
     );
 
     let err = env.execute_ingress(a_id, "update", vec![]).unwrap_err();
@@ -1414,9 +1415,10 @@ fn canister_with_memory_allocation_cannot_grow_wasm_memory_above_allocation_wasm
         Some(
             CanisterSettingsArgsBuilder::new()
                 .with_memory_allocation(300 * 64 * 1024)
+                .with_freezing_threshold(0)
                 .build(),
         ),
-        Cycles::new(u128::MAX),
+        INITIAL_CYCLES_BALANCE,
     );
 
     let err = env.execute_ingress(a_id, "update", vec![]).unwrap_err();
@@ -1550,18 +1552,13 @@ fn canister_with_reserved_balance_is_not_uninstalled_too_early() {
         HypervisorConfig::default(),
     ));
 
-    let memory_allocation = 100_000_000;
-    // Give the canister enough cycles to be able to be installed and then pay
-    // for its resources for the freezing period.
-    let initial_cycles =
-        Cycles::new(301 * B) + Cycles::from(MINIMUM_FREEZING_THRESHOLD * memory_allocation);
+    let initial_cycles = Cycles::new(301 * B);
     let canister_a = create_universal_canister_with_cycles(
         &env,
         Some(
             CanisterSettingsArgsBuilder::new()
-                .with_memory_allocation(memory_allocation)
-                .with_freezing_threshold(MINIMUM_FREEZING_THRESHOLD)
-                .with_reserved_cycles_limit(70 * T)
+                .with_memory_allocation(100_000_000)
+                .with_freezing_threshold(0)
                 .build(),
         ),
         initial_cycles,
@@ -1570,9 +1567,8 @@ fn canister_with_reserved_balance_is_not_uninstalled_too_early() {
         &env,
         Some(
             CanisterSettingsArgsBuilder::new()
-                .with_memory_allocation(memory_allocation)
-                .with_freezing_threshold(MINIMUM_FREEZING_THRESHOLD)
-                .with_reserved_cycles_limit(70 * T)
+                .with_memory_allocation(100_000_000)
+                .with_freezing_threshold(0)
                 .build(),
         ),
         initial_cycles,

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -1,10 +1,8 @@
 use assert_matches::assert_matches;
 use candid::{Decode, Encode};
 use ic_base_types::{NumSeconds, PrincipalId};
+use ic_config::embedders::BestEffortResponsesFeature;
 use ic_config::subnet_config::SchedulerConfig;
-use ic_config::{
-    embedders::BestEffortResponsesFeature, execution_environment::MINIMUM_FREEZING_THRESHOLD,
-};
 use ic_cycles_account_manager::ResourceSaturation;
 use ic_embedders::{
     wasm_utils::instrumentation::{instruction_to_cost, WasmMemoryType},
@@ -1060,7 +1058,7 @@ fn ic0_canister_version_returns_correct_value() {
         WasmResult::Reply(expected_ctr.to_le_bytes().to_vec())
     );
 
-    test.update_freezing_threshold(canister_id, NumSeconds::from(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(canister_id, NumSeconds::from(1))
         .unwrap();
     let result = test.ingress(canister_id, "update", ctr.clone()).unwrap();
     // Plus 5 for the previous ingress messages.
@@ -6968,7 +6966,7 @@ fn stable_memory_grow_reserves_cycles() {
             .canister_from_cycles_and_binary(CYCLES, UNIVERSAL_CANISTER_WASM.to_vec())
             .unwrap();
 
-        test.update_freezing_threshold(canister_id, NumSeconds::new(MINIMUM_FREEZING_THRESHOLD))
+        test.update_freezing_threshold(canister_id, NumSeconds::new(0))
             .unwrap();
         test.canister_update_reserved_cycles_limit(canister_id, CYCLES)
             .unwrap();
@@ -7072,7 +7070,7 @@ fn wasm_memory_grow_reserves_cycles() {
 
         let canister_id = test.canister_from_cycles_and_binary(CYCLES, wasm).unwrap();
 
-        test.update_freezing_threshold(canister_id, NumSeconds::new(MINIMUM_FREEZING_THRESHOLD))
+        test.update_freezing_threshold(canister_id, NumSeconds::new(0))
             .unwrap();
         test.canister_update_reserved_cycles_limit(canister_id, CYCLES)
             .unwrap();
@@ -7150,7 +7148,7 @@ fn set_reserved_cycles_limit_below_existing_fails() {
 
     let canister_id = test.canister_from_cycles_and_binary(CYCLES, wasm).unwrap();
 
-    test.update_freezing_threshold(canister_id, NumSeconds::new(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(canister_id, NumSeconds::new(0))
         .unwrap();
     test.canister_update_reserved_cycles_limit(canister_id, CYCLES)
         .unwrap();
@@ -7289,7 +7287,7 @@ fn resource_saturation_scaling_works_in_regular_execution() {
 
     let canister_id = test.canister_from_cycles_and_binary(CYCLES, wasm).unwrap();
 
-    test.update_freezing_threshold(canister_id, NumSeconds::new(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(canister_id, NumSeconds::new(0))
         .unwrap();
     test.canister_update_reserved_cycles_limit(canister_id, CYCLES)
         .unwrap();
@@ -7355,7 +7353,7 @@ fn wasm_memory_grow_respects_reserved_cycles_limit() {
 
     let canister_id = test.canister_from_cycles_and_binary(CYCLES, wasm).unwrap();
 
-    test.update_freezing_threshold(canister_id, NumSeconds::new(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(canister_id, NumSeconds::new(0))
         .unwrap();
 
     test.canister_state_mut(canister_id)
@@ -7392,7 +7390,7 @@ fn stable_memory_grow_respects_reserved_cycles_limit() {
         .canister_from_cycles_and_binary(CYCLES, UNIVERSAL_CANISTER_WASM.to_vec())
         .unwrap();
 
-    test.update_freezing_threshold(canister_id, NumSeconds::new(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(canister_id, NumSeconds::new(0))
         .unwrap();
 
     test.canister_state_mut(canister_id)
@@ -7436,7 +7434,7 @@ fn stable_memory_grow_does_not_reserve_cycles_on_out_of_memory() {
     let canister_id = test
         .canister_from_cycles_and_binary(CYCLES, UNIVERSAL_CANISTER_WASM.to_vec())
         .unwrap();
-    test.update_freezing_threshold(canister_id, NumSeconds::new(MINIMUM_FREEZING_THRESHOLD))
+    test.update_freezing_threshold(canister_id, NumSeconds::new(0))
         .unwrap();
 
     let reserved_cycles_before = test

--- a/rs/execution_environment/tests/subnet_size_test.rs
+++ b/rs/execution_environment/tests/subnet_size_test.rs
@@ -1,7 +1,8 @@
 use candid::{Decode, Encode};
 use ic_config::{
-    embedders::Config as EmbeddersConfig, execution_environment::Config as HypervisorConfig,
-    subnet_config::CyclesAccountManagerConfig,
+    embedders::Config as EmbeddersConfig,
+    execution_environment::Config as HypervisorConfig,
+    subnet_config::{CyclesAccountManagerConfig, SubnetConfig},
 };
 use ic_management_canister_types_private::{
     self as ic00, BoundedHttpHeaders, CanisterHttpRequestArgs, CanisterIdRecord,
@@ -12,9 +13,6 @@ use ic_registry_subnet_features::SubnetFeatures;
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
 use ic_test_utilities::universal_canister::{call_args, wasm, UNIVERSAL_CANISTER_WASM};
-use ic_test_utilities_execution_environment::{
-    filtered_subnet_config, ExecutionFeesFilter, KeepFeesFilter,
-};
 use ic_test_utilities_types::messages::SignedIngressBuilder;
 use ic_types::canister_http::MAX_CANISTER_HTTP_RESPONSE_BYTES;
 use ic_types::ingress::WasmResult;
@@ -270,9 +268,10 @@ fn simulate_one_gib_per_second_cost(
         .build();
     let canister_id = env.create_canister_with_cycles(
         None,
-        Cycles::new(u128::MAX),
+        DEFAULT_CYCLES_PER_NODE * subnet_size,
         Some(
             CanisterSettingsArgsBuilder::new()
+                .with_freezing_threshold(1)
                 .with_compute_allocation(compute_allocation.as_percent())
                 .with_memory_allocation(one_gib)
                 .build(),
@@ -295,6 +294,57 @@ fn simulate_one_gib_per_second_cost(
     Cycles::from(one_second_cost)
 }
 
+/// Specifies fees to keep in `CyclesAccountManagerConfig` for specific operations,
+/// eg. `ingress induction cost`, `execution cost` etc.
+enum KeepFeesFilter {
+    Execution,
+    IngressInduction,
+    XnetCall,
+}
+
+/// Helps to distinguish different costs that are withdrawn within the same execution round.
+/// All irrelevant fees in `CyclesAccountManagerConfig` are dropped to zero.
+/// This hack allows to calculate operation cost by comparing canister's balance before and after
+/// execution round.
+fn apply_filter(
+    initial_config: CyclesAccountManagerConfig,
+    filter: KeepFeesFilter,
+) -> CyclesAccountManagerConfig {
+    let mut filtered_config = CyclesAccountManagerConfig::system_subnet();
+    match filter {
+        KeepFeesFilter::Execution => {
+            filtered_config.update_message_execution_fee =
+                initial_config.update_message_execution_fee;
+            filtered_config.ten_update_instructions_execution_fee =
+                initial_config.ten_update_instructions_execution_fee;
+            filtered_config.ten_update_instructions_execution_fee_wasm64 =
+                initial_config.ten_update_instructions_execution_fee_wasm64;
+            filtered_config
+        }
+        KeepFeesFilter::IngressInduction => {
+            filtered_config.ingress_message_reception_fee =
+                initial_config.ingress_message_reception_fee;
+            filtered_config.ingress_byte_reception_fee = initial_config.ingress_byte_reception_fee;
+            filtered_config
+        }
+        KeepFeesFilter::XnetCall => {
+            filtered_config.xnet_call_fee = initial_config.xnet_call_fee;
+            filtered_config.xnet_byte_transmission_fee = initial_config.xnet_byte_transmission_fee;
+            filtered_config
+        }
+    }
+}
+
+/// Create a `SubnetConfig` with a redacted `CyclesAccountManagerConfig` to have only the fees
+/// for specific operation.
+fn filtered_subnet_config(subnet_type: SubnetType, filter: KeepFeesFilter) -> SubnetConfig {
+    let mut subnet_config = SubnetConfig::new(subnet_type);
+    subnet_config.cycles_account_manager_config =
+        apply_filter(subnet_config.cycles_account_manager_config, filter);
+
+    subnet_config
+}
+
 /// Simulates `execute_round` to get the cost of installing code,
 /// including charging and refunding execution cycles.
 /// Filtered `CyclesAccountManagerConfig` is used to avoid irrelevant costs,
@@ -304,10 +354,7 @@ fn simulate_execute_install_code_cost(subnet_type: SubnetType, subnet_size: usiz
         .with_subnet_type(subnet_type)
         .with_subnet_size(subnet_size)
         .with_config(Some(StateMachineConfig::new(
-            filtered_subnet_config(
-                subnet_type,
-                ExecutionFeesFilter::Keep(KeepFeesFilter::Execution),
-            ),
+            filtered_subnet_config(subnet_type, KeepFeesFilter::Execution),
             HypervisorConfig {
                 embedders_config: EmbeddersConfig {
                     cost_to_compile_wasm_instruction: NumInstructions::from(0),
@@ -338,7 +385,7 @@ fn simulate_execute_install_code_cost(subnet_type: SubnetType, subnet_size: usiz
 fn simulate_execute_ingress_cost(
     subnet_type: SubnetType,
     subnet_size: usize,
-    filter: ExecutionFeesFilter,
+    filter: KeepFeesFilter,
 ) -> Cycles {
     let env = StateMachineBuilder::new()
         .with_subnet_type(subnet_type)
@@ -362,19 +409,11 @@ fn simulate_execute_ingress_cost(
 }
 
 fn simulate_ingress_induction_cost(subnet_type: SubnetType, subnet_size: usize) -> Cycles {
-    simulate_execute_ingress_cost(
-        subnet_type,
-        subnet_size,
-        ExecutionFeesFilter::Keep(KeepFeesFilter::IngressInduction),
-    )
+    simulate_execute_ingress_cost(subnet_type, subnet_size, KeepFeesFilter::IngressInduction)
 }
 
 fn simulate_execute_message_cost(subnet_type: SubnetType, subnet_size: usize) -> Cycles {
-    simulate_execute_ingress_cost(
-        subnet_type,
-        subnet_size,
-        ExecutionFeesFilter::Keep(KeepFeesFilter::Execution),
-    )
+    simulate_execute_ingress_cost(subnet_type, subnet_size, KeepFeesFilter::Execution)
 }
 
 /// Simulates `execute_round` to get the cost of executing a heartbeat,
@@ -529,10 +568,7 @@ fn simulate_xnet_call_cost(subnet_type: SubnetType, subnet_size: usize) -> Cycle
         .with_subnet_type(subnet_type)
         .with_subnet_size(subnet_size)
         .with_config(Some(StateMachineConfig::new(
-            filtered_subnet_config(
-                subnet_type,
-                ExecutionFeesFilter::Keep(KeepFeesFilter::XnetCall),
-            ),
+            filtered_subnet_config(subnet_type, KeepFeesFilter::XnetCall),
             HypervisorConfig::default(),
         )))
         .build();

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -5,10 +5,7 @@ use candid::{CandidType, Decode, Encode, Int, Nat, Principal};
 use ic_agent::identity::{BasicIdentity, Identity};
 use ic_base_types::CanisterId;
 use ic_base_types::PrincipalId;
-use ic_config::{
-    execution_environment::Config as HypervisorConfig,
-    execution_environment::MINIMUM_FREEZING_THRESHOLD, subnet_config::SubnetConfig,
-};
+use ic_config::{execution_environment::Config as HypervisorConfig, subnet_config::SubnetConfig};
 use ic_error_types::UserError;
 use ic_icrc1::blocks::encoded_block_to_generic_block;
 use ic_icrc1::{endpoints::StandardRecord, hash::Hash, Block, Operation, Transaction};
@@ -3173,7 +3170,7 @@ pub fn test_migration_resumes_from_frozen<T>(
     };
     let unfreeze = |env: &StateMachine, canister_id: CanisterId| {
         let args = CanisterSettingsArgsBuilder::new()
-            .with_freezing_threshold(MINIMUM_FREEZING_THRESHOLD)
+            .with_freezing_threshold(0)
             .build();
         let result = env.update_settings(&canister_id, args);
         assert_matches!(result, Ok(_));

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -11,7 +11,6 @@ use cycles_minting_canister::{
 use dfn_candid::candid_one;
 use dfn_protobuf::protobuf;
 use ic_canister_client_sender::Sender;
-use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
 use ic_ledger_core::tokens::{CheckedAdd, CheckedSub};
 // TODO(EXC-1687): remove temporary alias `Ic00CanisterSettingsArgs`.
 use ic_management_canister_types_private::{
@@ -440,7 +439,7 @@ fn test_cmc_notify_create_with_settings() {
         &state_machine,
         Some(
             CanisterSettingsArgsBuilder::new()
-                .with_freezing_threshold(MINIMUM_FREEZING_THRESHOLD)
+                .with_freezing_threshold(7)
                 .build(),
         ),
     );
@@ -448,7 +447,7 @@ fn test_cmc_notify_create_with_settings() {
     assert_eq!(status.controllers(), vec![*TEST_USER1_PRINCIPAL]);
     assert_eq!(status.compute_allocation(), 0);
     assert_eq!(status.memory_allocation(), 0);
-    assert_eq!(status.freezing_threshold(), MINIMUM_FREEZING_THRESHOLD);
+    assert_eq!(status.freezing_threshold(), 7);
 
     //specify memory allocation
     let canister = notify_create_canister(
@@ -689,7 +688,7 @@ fn test_cmc_cycles_create_with_settings() {
         Some(
             CanisterSettingsArgsBuilder::new()
                 .with_controllers(vec![*TEST_USER1_PRINCIPAL])
-                .with_freezing_threshold(MINIMUM_FREEZING_THRESHOLD)
+                .with_freezing_threshold(7)
                 .build(),
         ),
         None,
@@ -700,7 +699,7 @@ fn test_cmc_cycles_create_with_settings() {
     assert_eq!(status.controllers(), vec![*TEST_USER1_PRINCIPAL]);
     assert_eq!(status.compute_allocation(), 0);
     assert_eq!(status.memory_allocation(), 0);
-    assert_eq!(status.freezing_threshold(), MINIMUM_FREEZING_THRESHOLD);
+    assert_eq!(status.freezing_threshold(), 7);
 
     //specify memory allocation
     let canister = cmc_create_canister_with_cycles(

--- a/rs/nns/integration_tests/src/update_canister_settings.rs
+++ b/rs/nns/integration_tests/src/update_canister_settings.rs
@@ -35,7 +35,7 @@ fn test_update_canister_settings_proposal(
     ];
     let target_memory_allocation = 1u64 << 33;
     let target_compute_allocation = 10u64;
-    let target_freezing_threshold = 700_000u64;
+    let target_freezing_threshold = 100_000u64;
     let target_wasm_memory_limit = 1u64 << 36;
     let target_wasm_memory_threshold = 1u64 << 34;
     let target_log_visibility = Some(LogVisibility::Public);

--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -62,7 +62,6 @@ MACRO_DEPENDENCIES = [
 BASE_DEV_DEPENDENCIES = [
     # Keep sorted.
     "//rs/canister_client/sender",
-    "//rs/config",
     "//rs/crypto",
     "//rs/ledger_suite/icp:icp_ledger",
     "//rs/nervous_system/clients",

--- a/rs/sns/integration_tests/Cargo.toml
+++ b/rs/sns/integration_tests/Cargo.toml
@@ -56,7 +56,6 @@ assert_matches = { workspace = true }
 canister-test = { path = "../../rust_canisters/canister_test" }
 ic-base-types = { path = "../../types/base_types" }
 ic-canister-client-sender = { path = "../../canister_client/sender" }
-ic-config = { path = "../../config" }
 ic-crypto = { path = "../../crypto" }
 ic-crypto-sha2 = { path = "../../crypto/sha2" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }

--- a/rs/sns/integration_tests/src/manage_dapp_canister_settings.rs
+++ b/rs/sns/integration_tests/src/manage_dapp_canister_settings.rs
@@ -1,7 +1,6 @@
 use candid::Encode;
 use canister_test::Wasm;
 use ic_base_types::PrincipalId;
-use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
 use ic_ledger_core::Tokens;
 use ic_management_canister_types_private::CanisterSettingsArgsBuilder;
 use ic_nervous_system_clients::canister_status::DefiniteCanisterSettingsArgs;
@@ -60,7 +59,7 @@ fn test_manage_dapp_canister_settings_successful() {
                 .with_controllers(vec![canister_ids.root_canister_id.get()])
                 .with_compute_allocation(50)
                 .with_memory_allocation(1 << 30)
-                .with_freezing_threshold(700_000)
+                .with_freezing_threshold(100_000)
                 .with_reserved_cycles_limit(1_000_000_000_000)
                 .with_log_visibility(ic_management_canister_types_private::LogVisibilityV2::Public)
                 .with_wasm_memory_limit(1_000_000_000)
@@ -105,7 +104,7 @@ fn test_manage_dapp_canister_settings_successful() {
             vec![canister_ids.root_canister_id.get()],
             50,
             Some(1 << 30),
-            700_000,
+            100_000,
             Some(1_000_000_000),
             Some(0),
         ),
@@ -119,7 +118,7 @@ fn test_manage_dapp_canister_settings_successful() {
                 canister_ids: vec![dapp_canister_id.get()],
                 compute_allocation: Some(0),
                 memory_allocation: Some(0),
-                freezing_threshold: Some(MINIMUM_FREEZING_THRESHOLD),
+                freezing_threshold: Some(0),
                 reserved_cycles_limit: Some(0),
                 log_visibility: Some(LogVisibility::Controllers as i32),
                 wasm_memory_limit: Some(2_000_000_000),
@@ -158,7 +157,7 @@ fn test_manage_dapp_canister_settings_successful() {
             vec![canister_ids.root_canister_id.get()],
             0,
             Some(0),
-            MINIMUM_FREEZING_THRESHOLD,
+            0,
             Some(2_000_000_000),
             Some(0),
         ),
@@ -197,7 +196,7 @@ fn test_manage_dapp_canister_settings_failure() {
                 .with_controllers(vec![canister_ids.root_canister_id.get()])
                 .with_compute_allocation(50)
                 .with_memory_allocation(1 << 30)
-                .with_freezing_threshold(700_000)
+                .with_freezing_threshold(100_000)
                 .with_reserved_cycles_limit(1_000_000_000_000)
                 .with_wasm_memory_limit(1_000_000_000)
                 .with_log_visibility(ic_management_canister_types_private::LogVisibilityV2::Public)
@@ -234,7 +233,7 @@ fn test_manage_dapp_canister_settings_failure() {
             vec![canister_ids.root_canister_id.get()],
             50,
             Some(1 << 30),
-            700_000,
+            100_000,
             Some(1_000_000_000),
             Some(0),
         ),
@@ -306,7 +305,7 @@ fn test_manage_dapp_canister_settings_failure() {
             vec![canister_ids.root_canister_id.get()],
             50,
             Some(1 << 30),
-            700_000,
+            100_000,
             Some(1_000_000_000),
             Some(0),
         ),

--- a/rs/tests/execution/general_execution_tests/canister_lifecycle.rs
+++ b/rs/tests/execution/general_execution_tests/canister_lifecycle.rs
@@ -30,7 +30,6 @@ end::catalog[] */
 
 use candid::{Decode, Encode};
 use ic_agent::{agent::RejectCode, export::Principal, identity::Identity};
-use ic_config::execution_environment::MINIMUM_FREEZING_THRESHOLD;
 use ic_management_canister_types_private::{
     CanisterSettingsArgs, CanisterSettingsArgsBuilder, CanisterStatusResultV2, CreateCanisterArgs,
     EmptyBlob, Payload,
@@ -1105,7 +1104,7 @@ pub fn create_canister_with_freezing_threshold(env: TestEnv) {
                 UniversalCanister::new_with_retries(&agent, node.effective_canister_id(), &logger)
                     .await;
 
-            for valid_value in [u64::MAX, MINIMUM_FREEZING_THRESHOLD].iter() {
+            for valid_value in [u64::MAX, 0].iter() {
                 // Create the canister with the freezing threshold set.
                 let new_canister_id = canister
                     .forward_with_cycles_to(


### PR DESCRIPTION
This reverts commit 2c64388af33d97e64254d68955807b048e7a0286. After user feedback that this breaking change affects certain workflows, the decision is to revert it and instead introduce some warnings in dfx when users try to set very low freezing threshold values.