### PR TITLE
chore: [NODE-1580] export hostos config as metric

### DIFF
--- a/ic-os/components/hostos-scripts/monitoring/custom-metrics.sh
+++ b/ic-os/components/hostos-scripts/monitoring/custom-metrics.sh
@@ -8,6 +8,7 @@ source /opt/ic/bin/logging.sh
 source /opt/ic/bin/metrics.sh
 
 MICROCODE_FILE="/sys/devices/system/cpu/cpu0/microcode/version"
+HOSTOS_CONFIG_FILE="/boot/config/config.json"
 
 function update_microcode_metric() {
     if [[ ! -r "${MICROCODE_FILE}" ]]; then
@@ -24,8 +25,25 @@ function update_microcode_metric() {
         "gauge"
 }
 
+function update_config_version_metric() {
+    if [[ ! -r "${HOSTOS_CONFIG_FILE}" ]]; then
+        write_log "ERROR: Cannot read HostOS config object file: ${HOSTOS_CONFIG_FILE}"
+        return 1
+    fi
+
+    config_version=$(jq -r '.config_version' ${HOSTOS_CONFIG_FILE})
+    write_log "Found HostOS config version: ${config_version}"
+    write_metric_attr "hostos_config_version" \
+        "{version=\"${config_version}\"}" \
+        "1" \
+        "HostOS config version" \
+        "gauge"
+
+}
+
 function main() {
     update_microcode_metric
+    update_config_version_metric
 }
 
 main


### PR DESCRIPTION
Output:
```
# HELP hostos_config_version HostOS config version
# TYPE hostos_config_version gauge
hostos_config_version{version="1.1.0"} 1
```