### PR TITLE
chore(fuzzing): Switch to ExecutionTest framework from StateMachine

### DIFF
--- a/rs/execution_environment/fuzz/BUILD.bazel
+++ b/rs/execution_environment/fuzz/BUILD.bazel
@@ -51,8 +51,7 @@ SYSTEM_API_FUZZ_DEPENDENCIES = [
     # Keep sorted.
     "//rs/config",
     "//rs/embedders/fuzz:wasm_fuzzers",
-    "//rs/registry/subnet_type",
-    "//rs/state_machine_tests",
+    "//rs/test_utilities/execution_environment",
     "//rs/types/management_canister_types",
     "//rs/types/types",
     "@crate_index//:libfuzzer-sys",

--- a/rs/execution_environment/fuzz/BUILD.bazel
+++ b/rs/execution_environment/fuzz/BUILD.bazel
@@ -55,7 +55,6 @@ SYSTEM_API_FUZZ_DEPENDENCIES = [
     "//rs/types/management_canister_types",
     "//rs/types/types",
     "@crate_index//:libfuzzer-sys",
-    "@crate_index//:wat",
 ]
 
 rust_fuzz_test_binary(

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
@@ -1,7 +1,6 @@
-use ic_config::{execution_environment::Config as ExecutionConfig, subnet_config::SubnetConfig};
-use ic_management_canister_types_private::{CanisterInstallMode, CanisterSettingsArgsBuilder};
-use ic_registry_subnet_type::SubnetType;
-use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
+use ic_config::execution_environment::Config as ExecutionConfig;
+use ic_management_canister_types_private::CanisterSettingsArgsBuilder;
+use ic_test_utilities_execution_environment::{ExecutionTest, ExecutionTestBuilder};
 use ic_types::{CanisterId, Cycles, NumBytes};
 
 use libfuzzer_sys::fuzz_target;
@@ -9,8 +8,8 @@ use std::cell::RefCell;
 use wasm_fuzzers::ic_wasm::{ic_embedders_config, ICWasmModule};
 
 thread_local! {
-    static ENV_32: RefCell<(StateMachine, CanisterId)> = RefCell::new(setup_env(false));
-    static ENV_64: RefCell<(StateMachine, CanisterId)> = RefCell::new(setup_env(true));
+    static ENV_32: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(false));
+    static ENV_64: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(true));
 }
 
 const HELLO_WORLD_WAT: &str = r#"
@@ -32,13 +31,10 @@ fn main() {
 fuzz_target!(|data: ICWasmModule| {
     with_env(data.config.memory64_enabled, |env, canister_id| {
         let wasm = data.module.to_bytes();
-        if env
-            .install_wasm_in_mode(*canister_id, CanisterInstallMode::Reinstall, wasm, vec![])
-            .is_ok()
-        {
+        if env.reinstall_canister(*canister_id, wasm).is_ok() {
             // For determinism, all methods are executed.
             for wasm_method in &data.exported_functions {
-                let _ = env.execute_ingress(*canister_id, wasm_method.name(), vec![]);
+                let _ = env.ingress(*canister_id, wasm_method.name(), vec![]);
             }
         }
     });
@@ -46,49 +42,48 @@ fuzz_target!(|data: ICWasmModule| {
 
 fn with_env<F, R>(memory64_enabled: bool, f: F) -> R
 where
-    F: FnOnce(&StateMachine, &CanisterId) -> R,
+    F: FnOnce(&mut ExecutionTest, &CanisterId) -> R,
 {
     if memory64_enabled {
         ENV_64.with(|env| {
-            let env_ref = env.borrow();
-            f(&env_ref.0, &env_ref.1)
+            let canister_id = env.borrow().1;
+            let execution_test = &mut env.borrow_mut().0;
+            f(execution_test, &canister_id)
         })
     } else {
         ENV_32.with(|env| {
-            let env_ref = env.borrow();
-            f(&env_ref.0, &env_ref.1)
+            let canister_id = env.borrow().1;
+            let execution_test = &mut env.borrow_mut().0;
+            f(execution_test, &canister_id)
         })
     }
 }
 
-// A setup function to initialize StateMachine with a dummy canister and expose the cansiter_id.
-// The same canister_id and StateMachine reference is used in the fuzzing runs, where the
+// A setup function to initialize ExecutionTest with a dummy canister and expose the cansiter_id.
+// The same canister_id and ExecutionTest reference is used in the fuzzing runs, where the
 // canister is reinstalled under the same canister_id.
-fn setup_env(memory64_enabled: bool) -> (StateMachine, CanisterId) {
+fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {
     let exec_config = ExecutionConfig {
         embedders_config: ic_embedders_config(memory64_enabled),
         max_compilation_cache_size: NumBytes::new(10 * 1024 * 1024), // 10MiB
         ..Default::default()
     };
-    let subnet_type = SubnetType::System;
-    let config = StateMachineConfig::new(SubnetConfig::new(subnet_type), exec_config);
-    let env = StateMachineBuilder::new()
-        .with_config(Some(config))
-        .with_subnet_type(subnet_type)
-        .with_checkpoints_enabled(false)
-        .with_log_level(None)
+    let mut env = ExecutionTestBuilder::new()
+        .with_execution_config(exec_config)
+        .with_precompiled_universal_canister(false)
         .build();
-    let canister_id = env.create_canister_with_cycles(
-        None,
-        Cycles::from(u128::MAX / 2),
-        Some(
+
+    let canister_id = env
+        .create_canister_with_settings(
+            Cycles::from(u128::MAX / 2),
             CanisterSettingsArgsBuilder::new()
                 .with_wasm_memory_limit(100 * 1024 * 1024)
                 .build(),
-        ),
-    );
+        )
+        .unwrap();
+
     let wasm = wat::parse_str(HELLO_WORLD_WAT).unwrap();
-    env.install_wasm_in_mode(canister_id, CanisterInstallMode::Install, wasm, vec![])
+    env.install_canister(canister_id, wasm)
         .expect("Failed to install valid wasm");
     (env, canister_id)
 }

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
@@ -12,11 +12,17 @@ thread_local! {
     static ENV_64: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(true));
 }
 
-const HELLO_WORLD_WAT: &str = r#"
-(module
-    (func $hi)
-    (export "canister_query hi" (func $hi))
-)"#;
+// r#"
+// (module
+//     (func $hi)
+//     (export "canister_query hi" (func $hi))
+// )"#;
+const HELLO_WORLD_WAT: [u8; 61] = [
+    0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x03, 0x02,
+    0x01, 0x00, 0x07, 0x15, 0x01, 0x11, 0x63, 0x61, 0x6E, 0x69, 0x73, 0x74, 0x65, 0x72, 0x5F, 0x71,
+    0x75, 0x65, 0x72, 0x79, 0x20, 0x68, 0x69, 0x00, 0x00, 0x0A, 0x04, 0x01, 0x02, 0x00, 0x0B, 0x00,
+    0x0C, 0x04, 0x6E, 0x61, 0x6D, 0x65, 0x01, 0x05, 0x01, 0x00, 0x02, 0x68, 0x69,
+];
 
 // To run the fuzzer,
 // bazel run --config=sandbox_fuzzing //rs/execution_environment/fuzz:execute_with_wasm_executor_system_api_call
@@ -82,8 +88,7 @@ fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {
         )
         .unwrap();
 
-    let wasm = wat::parse_str(HELLO_WORLD_WAT).unwrap();
-    env.install_canister(canister_id, wasm)
+    env.install_canister(canister_id, HELLO_WORLD_WAT.to_vec())
         .expect("Failed to install valid wasm");
     (env, canister_id)
 }

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
@@ -65,7 +65,7 @@ where
     }
 }
 
-// A setup function to initialize ExecutionTest with a dummy canister and expose the cansiter_id.
+// A setup function to initialize ExecutionTest with a dummy canister and expose the canister_id.
 // The same canister_id and ExecutionTest reference is used in the fuzzing runs, where the
 // canister is reinstalled under the same canister_id.
 fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
@@ -12,11 +12,17 @@ thread_local! {
     static ENV_64: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(true));
 }
 
-const HELLO_WORLD_WAT: &str = r#"
-(module
-    (func $hi)
-    (export "canister_query hi" (func $hi))
-)"#;
+// r#"
+// (module
+//     (func $hi)
+//     (export "canister_query hi" (func $hi))
+// )"#;
+const HELLO_WORLD_WAT: [u8; 61] = [
+    0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x03, 0x02,
+    0x01, 0x00, 0x07, 0x15, 0x01, 0x11, 0x63, 0x61, 0x6E, 0x69, 0x73, 0x74, 0x65, 0x72, 0x5F, 0x71,
+    0x75, 0x65, 0x72, 0x79, 0x20, 0x68, 0x69, 0x00, 0x00, 0x0A, 0x04, 0x01, 0x02, 0x00, 0x0B, 0x00,
+    0x0C, 0x04, 0x6E, 0x61, 0x6D, 0x65, 0x01, 0x05, 0x01, 0x00, 0x02, 0x68, 0x69,
+];
 
 // To run the fuzzer,
 // bazel run --config=sandbox_fuzzing //rs/execution_environment/fuzz:execute_with_wasm_executor_system_api_call
@@ -82,8 +88,7 @@ fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {
         )
         .unwrap();
 
-    let wasm = wat::parse_str(HELLO_WORLD_WAT).unwrap();
-    env.install_canister(canister_id, wasm)
+    env.install_canister(canister_id, HELLO_WORLD_WAT.to_vec())
         .expect("Failed to install valid wasm");
     (env, canister_id)
 }

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
@@ -1,7 +1,6 @@
-use ic_config::{execution_environment::Config as ExecutionConfig, subnet_config::SubnetConfig};
-use ic_management_canister_types_private::{CanisterInstallMode, CanisterSettingsArgsBuilder};
-use ic_registry_subnet_type::SubnetType;
-use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
+use ic_config::execution_environment::Config as ExecutionConfig;
+use ic_management_canister_types_private::CanisterSettingsArgsBuilder;
+use ic_test_utilities_execution_environment::{ExecutionTest, ExecutionTestBuilder};
 use ic_types::{CanisterId, Cycles, NumBytes};
 
 use libfuzzer_sys::fuzz_target;
@@ -9,8 +8,8 @@ use std::cell::RefCell;
 use wasm_fuzzers::ic_wasm::{ic_embedders_config, SystemApiModule};
 
 thread_local! {
-    static ENV_32: RefCell<(StateMachine, CanisterId)> = RefCell::new(setup_env(false));
-    static ENV_64: RefCell<(StateMachine, CanisterId)> = RefCell::new(setup_env(true));
+    static ENV_32: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(false));
+    static ENV_64: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(true));
 }
 
 const HELLO_WORLD_WAT: &str = r#"
@@ -32,13 +31,10 @@ fn main() {
 fuzz_target!(|data: SystemApiModule| {
     with_env(data.memory64_enabled, |env, canister_id| {
         let wasm = data.module;
-        if env
-            .install_wasm_in_mode(*canister_id, CanisterInstallMode::Reinstall, wasm, vec![])
-            .is_ok()
-        {
+        if env.reinstall_canister(*canister_id, wasm).is_ok() {
             // For determinism, all methods are executed.
             for wasm_method in &data.exported_functions {
-                let _ = env.execute_ingress(*canister_id, wasm_method.name(), vec![]);
+                let _ = env.ingress(*canister_id, wasm_method.name(), vec![]);
             }
         }
     });
@@ -46,49 +42,48 @@ fuzz_target!(|data: SystemApiModule| {
 
 fn with_env<F, R>(memory64_enabled: bool, f: F) -> R
 where
-    F: FnOnce(&StateMachine, &CanisterId) -> R,
+    F: FnOnce(&mut ExecutionTest, &CanisterId) -> R,
 {
     if memory64_enabled {
         ENV_64.with(|env| {
-            let env_ref = env.borrow();
-            f(&env_ref.0, &env_ref.1)
+            let canister_id = env.borrow().1;
+            let execution_test = &mut env.borrow_mut().0;
+            f(execution_test, &canister_id)
         })
     } else {
         ENV_32.with(|env| {
-            let env_ref = env.borrow();
-            f(&env_ref.0, &env_ref.1)
+            let canister_id = env.borrow().1;
+            let execution_test = &mut env.borrow_mut().0;
+            f(execution_test, &canister_id)
         })
     }
 }
 
-// A setup function to initialize StateMachine with a dummy canister and expose the cansiter_id.
-// The same canister_id and StateMachine reference is used in the fuzzing runs, where the
+// A setup function to initialize ExecutionTest with a dummy canister and expose the cansiter_id.
+// The same canister_id and ExecutionTest reference is used in the fuzzing runs, where the
 // canister is reinstalled under the same canister_id.
-fn setup_env(memory64_enabled: bool) -> (StateMachine, CanisterId) {
+fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {
     let exec_config = ExecutionConfig {
         embedders_config: ic_embedders_config(memory64_enabled),
         max_compilation_cache_size: NumBytes::new(10 * 1024 * 1024), // 10MiB
         ..Default::default()
     };
-    let subnet_type = SubnetType::Application;
-    let config = StateMachineConfig::new(SubnetConfig::new(subnet_type), exec_config);
-    let env = StateMachineBuilder::new()
-        .with_config(Some(config))
-        .with_subnet_type(subnet_type)
-        .with_checkpoints_enabled(false)
-        .with_log_level(None)
+    let mut env = ExecutionTestBuilder::new()
+        .with_execution_config(exec_config)
+        .with_precompiled_universal_canister(false)
         .build();
-    let canister_id = env.create_canister_with_cycles(
-        None,
-        Cycles::from(u128::MAX / 2),
-        Some(
+
+    let canister_id = env
+        .create_canister_with_settings(
+            Cycles::from(u128::MAX / 2),
             CanisterSettingsArgsBuilder::new()
                 .with_wasm_memory_limit(100 * 1024 * 1024)
                 .build(),
-        ),
-    );
+        )
+        .unwrap();
+
     let wasm = wat::parse_str(HELLO_WORLD_WAT).unwrap();
-    env.install_wasm_in_mode(canister_id, CanisterInstallMode::Install, wasm, vec![])
+    env.install_canister(canister_id, wasm)
         .expect("Failed to install valid wasm");
     (env, canister_id)
 }

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
@@ -65,7 +65,7 @@ where
     }
 }
 
-// A setup function to initialize ExecutionTest with a dummy canister and expose the cansiter_id.
+// A setup function to initialize ExecutionTest with a dummy canister and expose the canister_id.
 // The same canister_id and ExecutionTest reference is used in the fuzzing runs, where the
 // canister is reinstalled under the same canister_id.
 fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1811,6 +1811,13 @@ impl ExecutionTestBuilder {
         Self::default()
     }
 
+    pub fn with_execution_config(self, execution_config: Config) -> Self {
+        Self {
+            execution_config,
+            ..self
+        }
+    }
+
     pub fn with_nns_subnet_id(self, nns_subnet_id: SubnetId) -> Self {
         Self {
             nns_subnet_id,


### PR DESCRIPTION
The current fuzzers don't leverage any additional features provided by `StateMachine` framework that `ExecutionTest` doesn't offer and we have very significant difference between the two in terms of fuzzing performance. 