### PR TITLE
feat(ircrc-rosetta): add token-specific metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19909,6 +19909,7 @@ version = "0.9.0"
 dependencies = [
  "actix-web-prom",
  "anyhow",
+ "axum 0.8.1",
  "candid",
  "hex",
  "ic-agent",
@@ -19926,6 +19927,8 @@ dependencies = [
  "serde_json",
  "serde_with 1.14.0",
  "tokio",
+ "tower 0.5.2",
+ "tower-http 0.6.2",
  "tracing",
 ]
 

--- a/rs/rosetta-api/common/rosetta_core/BUILD.bazel
+++ b/rs/rosetta-api/common/rosetta_core/BUILD.bazel
@@ -11,8 +11,13 @@ DEPENDENCIES = [
     "//rs/types/types",
     "@crate_index//:actix-web-prom",
     "@crate_index//:anyhow",
+    "@crate_index//:axum",
+    "@crate_index//:bytes",
     "@crate_index//:candid",
     "@crate_index//:hex",
+    "@crate_index//:http-body",
+    "@crate_index//:http-body-util",
+    "@crate_index//:hyper",
     "@crate_index//:ic-agent",
     "@crate_index//:lazy_static",
     "@crate_index//:num-bigint",
@@ -22,6 +27,8 @@ DEPENDENCIES = [
     "@crate_index//:serde_json",
     "@crate_index//:serde_with",
     "@crate_index//:tokio",
+    "@crate_index//:tower",
+    "@crate_index//:tower-http",
     "@crate_index//:tracing",
 ]
 

--- a/rs/rosetta-api/common/rosetta_core/Cargo.toml
+++ b/rs/rosetta-api/common/rosetta_core/Cargo.toml
@@ -12,6 +12,7 @@ documentation.workspace = true
 [dependencies]
 actix-web-prom = { workspace = true }
 anyhow = { workspace = true }
+axum = { workspace = true }
 candid = { workspace = true }
 hex = { workspace = true }
 ic-agent = { workspace = true }
@@ -27,6 +28,8 @@ serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 tokio = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
 tracing = { workspace = true }
 icp-ledger = { path = "../../../ledger_suite/icp" }
 

--- a/rs/rosetta-api/common/rosetta_core/src/metrics.rs
+++ b/rs/rosetta-api/common/rosetta_core/src/metrics.rs
@@ -1,55 +1,75 @@
 use actix_web_prom::{PrometheusMetrics, PrometheusMetricsBuilder};
-use prometheus::{
-    register_gauge, register_histogram, register_histogram_vec, register_int_counter,
-    register_int_counter_vec, register_int_gauge, Gauge, Histogram, HistogramTimer, HistogramVec,
-    IntCounter, IntCounterVec, IntGauge,
+use axum::{
+    body::{to_bytes, Body},
+    extract::Request,
+    response::Response,
 };
+use bytes::Bytes;
+use prometheus::{
+    register_gauge_vec, register_histogram_vec, register_int_counter_vec, register_int_gauge_vec,
+    Encoder, GaugeVec, HistogramTimer, HistogramVec, IntCounterVec, IntGaugeVec,
+};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Mutex;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
 
 use lazy_static::lazy_static;
 
 lazy_static! {
     static ref ENDPOINTS_METRICS: RosettaEndpointsMetrics = RosettaEndpointsMetrics::new();
 
-    static ref VERIFIED_HEIGHT: IntGauge =
-        register_int_gauge!("rosetta_verified_block_height", "Verified block height").unwrap();
-    static ref SYNCED_HEIGHT: IntGauge =
-        register_int_gauge!("rosetta_synched_block_height", "Synced block height").unwrap();
-    static ref TARGET_HEIGHT: IntGauge =
-        register_int_gauge!("rosetta_target_block_height", "Target height (tip)").unwrap();
-    static ref SYNC_ERR_COUNTER: IntCounter = register_int_counter!(
+    static ref VERIFIED_HEIGHT: IntGaugeVec =
+        register_int_gauge_vec!("rosetta_verified_block_height", "Verified block height", &["token_display_name"]).unwrap();
+    static ref SYNCED_HEIGHT: IntGaugeVec =
+        register_int_gauge_vec!("rosetta_synched_block_height", "Synced block height", &["token_display_name"]).unwrap();
+    static ref TARGET_HEIGHT: IntGaugeVec =
+        register_int_gauge_vec!("rosetta_target_block_height", "Target height (tip)", &["token_display_name"]).unwrap();
+    static ref SYNC_ERR_COUNTER: IntCounterVec = register_int_counter_vec!(
         "blockchain_sync_errors_total",
-        "Number of times synchronization failed"
+        "Number of times synchronization failed",
+        &["token_display_name"],
     )
     .unwrap();
-    static ref OUT_OF_SYNC_TIME: Gauge = register_gauge!(
+    static ref OUT_OF_SYNC_TIME: GaugeVec = register_gauge_vec!(
         "ledger_sync_attempt_duration_seconds",
-        "Number of seconds since the last successful sync"
+        "Number of seconds since the last successful sync",
+        &["token_display_name"],
     )
     .unwrap();
-    static ref OUT_OF_SYNC_TIME_HIST: Histogram = register_histogram!(
+    static ref OUT_OF_SYNC_TIME_HIST: HistogramVec = register_histogram_vec!(
         "ledger_sync_attempt_duration_seconds_hist",
         "Number of seconds since last successful sync",
-        vec![0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 5.0, 10.0, 15.0]
+        &["token_display_name"],
+        vec![0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 5.0, 10.0, 15.0],
     )
     .unwrap();
-    static ref BLOCKS_FETCHED_COUNTER: IntCounter = register_int_counter!(
+    static ref BLOCKS_FETCHED_COUNTER: IntCounterVec = register_int_counter_vec!(
         "ledger_sync_blocks_fetched_total",
-        "Number of blocks fetched from the ledger"
+        "Number of blocks fetched from the ledger",
+        &["token_display_name"],
     ).unwrap();
     // Counter for number of retries when fetching blocks from the canister.
-    static ref BLOCKS_FETCH_RETRIES_COUNTER: IntCounter = register_int_counter!(
+    static ref BLOCKS_FETCH_RETRIES_COUNTER: IntCounterVec = register_int_counter_vec!(
         "ledger_sync_blocks_fetch_retries_total",
-        "Number of retries when fetching blocks from the ledger"
+        "Number of retries when fetching blocks from the ledger",
+        &["token_display_name"],
     ).unwrap();
 
-    pub static ref SYNC_THREAD_RESTARTS: IntCounter = register_int_counter!(
+    pub static ref SYNC_THREAD_RESTARTS: IntCounterVec = register_int_counter_vec!(
         "blockchain_sync_thread_restarts_total",
-        "Number of times the sync thread has been restarted"
+        "Number of times the sync thread has been restarted",
+        &["token_display_name"],
     )
     .unwrap();
 
     static ref METRICS: Mutex<Option<PrometheusMetrics>> = Mutex::new(None);
+
+    // Map that associates canister ID strings with their display names
+    static ref CANISTER_DISPLAY_NAMES: Mutex<HashMap<String, String>> = Mutex::new(HashMap::new());
 }
 
 struct RosettaEndpointsMetrics {
@@ -61,72 +81,136 @@ impl RosettaEndpointsMetrics {
     pub fn new() -> Self {
         Self {
             request_duration: register_histogram_vec!(
-                "http_request_duration",
-                "HTTP request latency in seconds indexed by endpoint",
-                &["endpoint"]
+                "rosetta_http_request_duration_seconds",
+                "HTTP request latency in seconds",
+                &["token_display_name", "endpoint", "method", "status"]
             )
             .unwrap(),
             rosetta_api_status_total: register_int_counter_vec!(
                 "rosetta_api_status_total",
                 "Response status for ic-rosetta-api endpoints",
-                &["status_code"]
+                &["token_display_name", "status_code"]
             )
             .unwrap(),
         }
     }
 }
 
-// Metrics accessor for the Rosetta endpoints.
-pub struct RosettaMetrics {}
+/// Metrics accessor for the Rosetta endpoints.
+/// This format is consistent across both Axum and Actix middleware implementations.
+#[derive(Clone, Debug)]
+pub struct RosettaMetrics {
+    token_display_name: String,
+    canister_id: String,
+}
 
 impl RosettaMetrics {
-    pub fn inc_api_status_count(status: &str) {
-        let labels = &[status];
+    pub fn new(token_display_name: String, canister_id: String) -> Self {
+        // Add entry to map associating the canister ID with the display name
+        let mut map = CANISTER_DISPLAY_NAMES.lock().unwrap();
+        map.insert(canister_id.clone(), token_display_name.clone());
+
+        Self {
+            token_display_name,
+            canister_id,
+        }
+    }
+
+    pub fn token_display_name(&self) -> &str {
+        &self.token_display_name
+    }
+
+    pub fn canister_id(&self) -> &str {
+        &self.canister_id
+    }
+
+    pub fn inc_api_status_count(&self, status: &str) {
+        let labels = &[self.token_display_name.as_str(), status];
         ENDPOINTS_METRICS
             .rosetta_api_status_total
             .with_label_values(labels)
             .inc();
     }
 
-    pub fn start_request_duration_timer(endpoint: &str) -> HistogramTimer {
-        let labels = &[endpoint];
+    // This method is deprecated and will be removed in a future version
+    // It's kept for backward compatibility with existing code
+    pub fn start_request_duration_timer(&self, endpoint: &str) -> HistogramTimer {
+        let labels = &[
+            self.token_display_name.as_str(),
+            endpoint,
+            "unknown",
+            "unknown",
+        ];
         ENDPOINTS_METRICS
             .request_duration
             .with_label_values(labels)
             .start_timer()
     }
 
-    pub fn set_target_height(height: u64) {
-        TARGET_HEIGHT.set(height.try_into().unwrap());
+    // New method to record request duration directly
+    pub fn observe_request_duration(
+        &self,
+        endpoint: &str,
+        method: &str,
+        status: &str,
+        duration: f64,
+    ) {
+        let labels = &[self.token_display_name.as_str(), endpoint, method, status];
+        ENDPOINTS_METRICS
+            .request_duration
+            .with_label_values(labels)
+            .observe(duration);
     }
 
-    pub fn set_synced_height(height: u64) {
-        SYNCED_HEIGHT.set(height.try_into().unwrap());
+    pub fn set_target_height(&self, height: u64) {
+        TARGET_HEIGHT
+            .with_label_values(&[self.token_display_name.as_str()])
+            .set(height.try_into().unwrap());
     }
 
-    pub fn set_verified_height(height: u64) {
-        VERIFIED_HEIGHT.set(height.try_into().unwrap());
+    pub fn set_synced_height(&self, height: u64) {
+        SYNCED_HEIGHT
+            .with_label_values(&[self.token_display_name.as_str()])
+            .set(height.try_into().unwrap());
     }
 
-    pub fn set_out_of_sync_time(seconds: f64) {
-        OUT_OF_SYNC_TIME.set(seconds);
-        OUT_OF_SYNC_TIME_HIST.observe(seconds);
+    pub fn set_verified_height(&self, height: u64) {
+        VERIFIED_HEIGHT
+            .with_label_values(&[self.token_display_name.as_str()])
+            .set(height.try_into().unwrap());
     }
 
-    pub fn add_blocks_fetched(count: u64) {
-        BLOCKS_FETCHED_COUNTER.inc_by(count);
+    pub fn set_out_of_sync_time(&self, seconds: f64) {
+        OUT_OF_SYNC_TIME
+            .with_label_values(&[self.token_display_name.as_str()])
+            .set(seconds);
+        OUT_OF_SYNC_TIME_HIST
+            .with_label_values(&[self.token_display_name.as_str()])
+            .observe(seconds);
     }
 
-    pub fn inc_fetch_retries() {
-        BLOCKS_FETCH_RETRIES_COUNTER.inc();
+    pub fn add_blocks_fetched(&self, count: u64) {
+        BLOCKS_FETCHED_COUNTER
+            .with_label_values(&[self.token_display_name.as_str()])
+            .inc_by(count);
     }
 
-    pub fn inc_sync_errors() {
-        SYNC_ERR_COUNTER.inc();
+    pub fn inc_fetch_retries(&self) {
+        BLOCKS_FETCH_RETRIES_COUNTER
+            .with_label_values(&[self.token_display_name.as_str()])
+            .inc();
     }
 
-    pub fn inc_sync_thread_restarts() {
-        SYNC_THREAD_RESTARTS.inc();
+    pub fn inc_sync_errors(&self) {
+        SYNC_ERR_COUNTER
+            .with_label_values(&[self.token_display_name.as_str()])
+            .inc();
+    }
+
+    pub fn inc_sync_thread_restarts(&self) {
+        SYNC_THREAD_RESTARTS
+            .with_label_values(&[self.token_display_name.as_str()])
+            .inc();
     }
 
     pub fn http_metrics_wrapper(expose: bool) -> PrometheusMetrics {
@@ -135,8 +219,8 @@ impl RosettaMetrics {
             return metrics.clone();
         }
 
-        let metrics = PrometheusMetricsBuilder::new("rosetta")
-            .registry(prometheus::default_registry().clone());
+        let registry = prometheus::default_registry().clone();
+        let metrics = PrometheusMetricsBuilder::new("rosetta").registry(registry);
 
         let metrics = if expose {
             metrics.endpoint("/metrics").build().unwrap()
@@ -147,4 +231,167 @@ impl RosettaMetrics {
         *metrics_guard = Some(metrics.clone());
         metrics
     }
+
+    /// Creates a metrics middleware layer
+    pub fn metrics_layer(&self) -> RosettaMetricsLayer {
+        RosettaMetricsLayer {
+            default_metrics: self.clone(),
+        }
+    }
+
+    /// Gets a display name for a canister ID from the global registry.
+    /// Returns the canister ID itself if no mapping exists.
+    pub fn get_display_name_from_canister_id(canister_id: &str) -> String {
+        let map = CANISTER_DISPLAY_NAMES.lock().unwrap();
+        map.get(canister_id)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| canister_id.to_string())
+    }
+
+    /// Registers a mapping between canister ID and display name in the global registry.
+    /// This can be used to associate readable names with canister IDs for metrics.
+    pub fn register_canister_display_name(canister_id: String, display_name: String) {
+        let mut map = CANISTER_DISPLAY_NAMES.lock().unwrap();
+        map.insert(canister_id, display_name);
+    }
+}
+
+// Axum middleware implementation for Rosetta metrics
+#[derive(Clone)]
+pub struct RosettaMetricsLayer {
+    default_metrics: RosettaMetrics,
+}
+
+impl<S> Layer<S> for RosettaMetricsLayer {
+    type Service = RosettaMetricsMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RosettaMetricsMiddleware {
+            inner,
+            default_metrics: self.default_metrics.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RosettaMetricsMiddleware<S> {
+    inner: S,
+    default_metrics: RosettaMetrics,
+}
+
+impl<S> Service<Request<Body>> for RosettaMetricsMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response> + Send + 'static + Clone,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        // If this is a metrics request, handle it directly
+        if req.uri().path() == "/metrics" {
+            // Gather metrics from the default registry which includes our metrics
+            let encoder = prometheus::TextEncoder::new();
+            let metric_families = prometheus::default_registry().gather();
+            let mut buffer = Vec::new();
+            encoder
+                .encode(&metric_families, &mut buffer)
+                .unwrap_or_default();
+
+            // Build response
+            let response = Response::builder()
+                .header("Content-Type", "text/plain; version=0.0.4")
+                .body(Body::from(buffer))
+                .unwrap();
+
+            // Return the metrics response
+            return Box::pin(async { Ok(response) });
+        }
+
+        let path = req.uri().path().to_owned();
+        let method = req.method().to_string();
+        let default_metrics = self.default_metrics.clone();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            // Need to buffer the body to extract the canister ID
+            let (parts, body) = req.into_parts();
+
+            // Extract canister ID from body if possible
+            let (canister_id, reconstructed_body) = match extract_canister_id(body).await {
+                Ok((canister_id, body_bytes)) => (canister_id, Body::from(body_bytes)),
+                Err(_) => (None, Body::empty()),
+            };
+
+            // Use display name from map or default
+            let metrics = match canister_id {
+                Some(id) => {
+                    let display_name = RosettaMetrics::get_display_name_from_canister_id(&id);
+                    RosettaMetrics::new(display_name, id)
+                }
+                None => default_metrics,
+            };
+
+            // Reconstruct request with the buffered body
+            let req = Request::from_parts(parts, reconstructed_body);
+
+            // Track start time
+            let start_time = std::time::Instant::now();
+
+            // Process the request
+            let result = inner.call(req).await;
+
+            // Calculate duration
+            let duration = start_time.elapsed().as_secs_f64();
+
+            // Record status in metrics
+            match &result {
+                Ok(response) => {
+                    let status = response.status().as_u16().to_string();
+                    metrics.inc_api_status_count(&status);
+
+                    // Record request duration with status
+                    metrics.observe_request_duration(&path, &method, &status, duration);
+                }
+                Err(_) => {
+                    metrics.inc_api_status_count("error");
+
+                    // Record request duration with error status
+                    metrics.observe_request_duration(&path, &method, "error", duration);
+                }
+            }
+
+            result
+        })
+    }
+}
+
+// Helper function to extract canister ID from request body
+async fn extract_canister_id(
+    body: Body,
+) -> Result<(Option<String>, Bytes), Box<dyn std::error::Error + Send + Sync>> {
+    // Read body bytes
+    let bytes = to_bytes(body, usize::MAX).await?;
+
+    // Don't attempt to parse if empty
+    if bytes.is_empty() {
+        return Ok((None, bytes));
+    }
+
+    // Try to parse as JSON
+    let canister_id = match serde_json::from_slice::<Value>(&bytes) {
+        Ok(json) => json
+            .get("network_identifier")
+            .and_then(|ni| ni.get("network"))
+            .and_then(|n| n.as_str())
+            .map(|s| s.to_string()),
+        Err(_) => None,
+    };
+
+    Ok((canister_id, bytes))
 }

--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/ledger_blocks_sync.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/ledger_blocks_sync.rs
@@ -48,6 +48,7 @@ where
     blocks_access: Option<Arc<B>>,
     store_max_blocks: Option<u64>,
     verification_info: Option<VerificationInfo>,
+    rosetta_metrics: RosettaMetrics,
 }
 
 impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
@@ -58,6 +59,8 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
         verification_info: Option<VerificationInfo>,
         enable_rosetta_blocks: bool,
     ) -> Result<LedgerBlocksSynchronizer<B>, Error> {
+        let rosetta_metrics =
+            RosettaMetrics::new("ICP".to_string(), "ryjl3-tyaaa-aaaaa-aaaba-cai".to_string());
         let mut blocks = match store_location {
             Some(loc) => Blocks::new_persistent(loc, enable_rosetta_blocks)?,
             None => Blocks::new_in_memory(enable_rosetta_blocks)?,
@@ -90,10 +93,10 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
         }
 
         if let Ok(x) = last_block {
-            RosettaMetrics::set_synced_height(x.index);
+            rosetta_metrics.set_synced_height(x.index);
         }
         if let Ok(x) = blocks.get_latest_verified_hashed_block() {
-            RosettaMetrics::set_verified_height(x.index);
+            rosetta_metrics.set_verified_height(x.index);
         }
 
         blocks.try_prune(&store_max_blocks, PRUNE_DELAY)?;
@@ -103,6 +106,7 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
             blocks_access,
             store_max_blocks,
             verification_info,
+            rosetta_metrics,
         })
     }
 
@@ -265,7 +269,7 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
                 "Received tip_index == u64::MAX".to_string(),
             ));
         }
-        RosettaMetrics::set_target_height(tip.index);
+        self.rosetta_metrics.set_target_height(tip.index);
 
         let mut blockchain = self.blockchain.write().await;
 
@@ -371,10 +375,11 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
                     .await
                     .map_err(Error::InternalError);
                 if batch.is_ok() || retry == MAX_RETRY {
-                    RosettaMetrics::add_blocks_fetched(batch.as_ref().unwrap().len() as u64);
+                    self.rosetta_metrics
+                        .add_blocks_fetched(batch.as_ref().unwrap().len() as u64);
                     break batch;
                 }
-                RosettaMetrics::inc_fetch_retries();
+                self.rosetta_metrics.inc_fetch_retries();
                 retry += 1;
             }
             .map_err(|e| {
@@ -411,7 +416,7 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
                 block_batch.push(hb);
                 i += 1;
             }
-            RosettaMetrics::set_synced_height(i - 1);
+            self.rosetta_metrics.set_synced_height(i - 1);
             if (i - range.start) % DATABASE_WRITE_BLOCKS_BATCH_SIZE == 0 {
                 blockchain.push_batch(block_batch)?;
                 if print_progress {
@@ -423,7 +428,7 @@ impl<B: BlocksAccess> LedgerBlocksSynchronizer<B> {
         blockchain.push_batch(block_batch)?;
         info!("Synced took {} seconds", t_total.elapsed().as_secs_f64());
         blockchain.set_hashed_block_to_verified(&(range.end - 1))?;
-        RosettaMetrics::set_verified_height(range.end - 1);
+        self.rosetta_metrics.set_verified_height(range.end - 1);
         Ok(())
     }
 }

--- a/rs/rosetta-api/icp/src/main.rs
+++ b/rs/rosetta-api/icp/src/main.rs
@@ -6,6 +6,7 @@ use ic_rosetta_api::request_handler::RosettaRequestHandler;
 use ic_rosetta_api::rosetta_server::{RosettaApiServer, RosettaApiServerOpt};
 use ic_rosetta_api::{ledger_client, DEFAULT_BLOCKCHAIN, DEFAULT_TOKEN_SYMBOL};
 use ic_types::{CanisterId, PrincipalId};
+use rosetta_core::metrics::RosettaMetrics;
 use std::{path::Path, path::PathBuf, str::FromStr, sync::Arc};
 use tracing::level_filters::LevelFilter;
 use tracing::{error, info, warn, Level};
@@ -264,7 +265,9 @@ async fn main() -> std::io::Result<()> {
     .unwrap_or_else(|(e, is_403)| panic!("Failed to initialize ledger client{}: {:?}", is_403, e));
 
     let ledger = Arc::new(client);
-    let req_handler = RosettaRequestHandler::new(blockchain, ledger.clone());
+    let canister_id_str = canister_id.to_string();
+    let rosetta_metrics = RosettaMetrics::new("ICP".to_string(), canister_id_str);
+    let req_handler = RosettaRequestHandler::new(blockchain, ledger.clone(), rosetta_metrics);
 
     info!("Network id: {:?}", req_handler.network_id());
     let serv = RosettaApiServer::new(

--- a/rs/rosetta-api/icp/src/request_handler.rs
+++ b/rs/rosetta-api/icp/src/request_handler.rs
@@ -46,6 +46,8 @@ use std::{
 };
 use strum::IntoEnumIterator;
 
+use rosetta_core::metrics::RosettaMetrics;
+
 /// The maximum amount of blocks to retrieve in a single search.
 const MAX_SEARCH_LIMIT: usize = 10_000;
 
@@ -53,6 +55,7 @@ const MAX_SEARCH_LIMIT: usize = 10_000;
 pub struct RosettaRequestHandler {
     blockchain: String,
     ledger: Arc<dyn LedgerAccess + Send + Sync>,
+    rosetta_metrics: RosettaMetrics,
 }
 
 // construction requests are implemented in their own module.
@@ -60,20 +63,35 @@ impl RosettaRequestHandler {
     pub fn new<T: 'static + LedgerAccess + Send + Sync>(
         blockchain: String,
         ledger: Arc<T>,
+        rosetta_metrics: RosettaMetrics,
     ) -> Self {
-        Self { blockchain, ledger }
+        Self {
+            blockchain,
+            ledger,
+            rosetta_metrics,
+        }
     }
 
     pub fn new_with_default_blockchain<T: 'static + LedgerAccess + Send + Sync>(
         ledger: Arc<T>,
     ) -> Self {
-        Self::new(crate::DEFAULT_BLOCKCHAIN.to_string(), ledger)
+        let canister_id = ledger.ledger_canister_id();
+        let canister_id_str = hex::encode(canister_id.get().into_vec());
+        Self::new(
+            crate::DEFAULT_BLOCKCHAIN.to_string(),
+            ledger,
+            RosettaMetrics::new(crate::DEFAULT_TOKEN_SYMBOL.to_string(), canister_id_str),
+        )
     }
 
     pub fn network_id(&self) -> NetworkIdentifier {
         let canister_id = self.ledger.ledger_canister_id();
         let net_id = hex::encode(canister_id.get().into_vec());
         NetworkIdentifier::new(self.blockchain.clone(), net_id)
+    }
+
+    pub fn rosetta_metrics(&self) -> RosettaMetrics {
+        self.rosetta_metrics.clone()
     }
 
     /// Get an Account Balance

--- a/rs/rosetta-api/icp/src/request_handler/construction_parse.rs
+++ b/rs/rosetta-api/icp/src/request_handler/construction_parse.rs
@@ -646,6 +646,7 @@ mod tests {
         prop_assert, prop_assert_eq, proptest, strategy::Strategy, test_runner::TestCaseError,
     };
     use rand_chacha::rand_core::OsRng;
+    use rosetta_core::metrics::RosettaMetrics;
     use std::{str::FromStr, time::SystemTime};
     use url::Url;
 
@@ -676,7 +677,13 @@ mod tests {
             false,
         ))
         .unwrap();
-        let handler = RosettaRequestHandler::new("Internet Computer".into(), ledger_client.into());
+        // Create a mock canister ID for testing
+        let mock_canister_id_hex = "00000000000000000101";
+        let handler = RosettaRequestHandler::new(
+            "Internet Computer".into(),
+            ledger_client.into(),
+            RosettaMetrics::new("TKN".into(), mock_canister_id_hex.into()),
+        );
 
         // get the nextwork identifier
         let network_identifier = handler.network_id();

--- a/rs/rosetta-api/icp/src/rosetta_server.rs
+++ b/rs/rosetta-api/icp/src/rosetta_server.rs
@@ -42,9 +42,11 @@ async fn account_balance(
     msg: web::Json<AccountBalanceRequest>,
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
-    let _timer = RosettaMetrics::start_request_duration_timer("account/balance");
+    let _timer = req_handler
+        .rosetta_metrics()
+        .start_request_duration_timer("account/balance");
     let res = req_handler.account_balance(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/call")]
@@ -53,7 +55,7 @@ async fn call(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.call(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/block")]
@@ -61,9 +63,11 @@ async fn block(
     msg: web::Json<BlockRequest>,
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
-    let _timer = RosettaMetrics::start_request_duration_timer("block");
+    let _timer = req_handler
+        .rosetta_metrics()
+        .start_request_duration_timer("block");
     let res = req_handler.block(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/block/transaction")]
@@ -72,7 +76,7 @@ async fn block_transaction(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.block_transaction(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/construction/combine")]
@@ -81,7 +85,7 @@ async fn construction_combine(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.construction_combine(msg.into_inner());
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/construction/derive")]
@@ -90,7 +94,7 @@ async fn construction_derive(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.construction_derive(msg.into_inner());
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/construction/hash")]
@@ -99,7 +103,7 @@ async fn construction_hash(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.construction_hash(msg.into_inner());
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/construction/metadata")]
@@ -108,7 +112,7 @@ async fn construction_metadata(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.construction_metadata(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/construction/parse")]
@@ -117,7 +121,7 @@ async fn construction_parse(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.construction_parse(msg.into_inner());
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/construction/payloads")]
@@ -126,7 +130,7 @@ async fn construction_payloads(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.construction_payloads(msg.into_inner());
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/construction/preprocess")]
@@ -135,7 +139,7 @@ async fn construction_preprocess(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.construction_preprocess(msg.into_inner());
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/construction/submit")]
@@ -143,15 +147,17 @@ async fn construction_submit(
     msg: web::Json<ConstructionSubmitRequest>,
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
-    let _timer = RosettaMetrics::start_request_duration_timer("construction/submit");
+    let _timer = req_handler
+        .rosetta_metrics()
+        .start_request_duration_timer("construction/submit");
     let res = req_handler.construction_submit(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/network/list")]
 async fn network_list(req_handler: web::Data<RosettaRequestHandler>) -> HttpResponse {
     let res = req_handler.network_list().await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/network/options")]
@@ -160,7 +166,7 @@ async fn network_options(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.network_options(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/network/status")]
@@ -169,7 +175,7 @@ async fn network_status(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.network_status(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/mempool")]
@@ -178,7 +184,7 @@ async fn mempool(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.mempool(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/mempool/transaction")]
@@ -187,7 +193,7 @@ async fn mempool_transaction(
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
     let res = req_handler.mempool_transaction(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
 #[post("/search/transactions")]
@@ -195,39 +201,54 @@ async fn search_transactions(
     msg: web::Json<SearchTransactionsRequest>,
     req_handler: web::Data<RosettaRequestHandler>,
 ) -> HttpResponse {
-    let _timer = RosettaMetrics::start_request_duration_timer("search/transactions");
+    let _timer = req_handler
+        .rosetta_metrics()
+        .start_request_duration_timer("search/transactions");
     let res = req_handler.search_transactions(msg.into_inner()).await;
-    to_rosetta_response(res)
+    to_rosetta_response(res, &req_handler.rosetta_metrics())
 }
 
-fn internal_error_response(e: impl std::fmt::Debug, resp: String) -> HttpResponse {
+fn internal_error_response(
+    e: impl std::fmt::Debug,
+    resp: String,
+    rosetta_metrics: &RosettaMetrics,
+) -> HttpResponse {
     error!("Internal error: {:?}", e);
-    RosettaMetrics::inc_api_status_count("700");
+    rosetta_metrics.inc_api_status_count("700");
     HttpResponse::InternalServerError()
         .content_type("application/json")
         .body(resp)
 }
 
-fn to_rosetta_response<S: serde::Serialize>(result: Result<S, ApiError>) -> HttpResponse {
+fn to_rosetta_response<S: serde::Serialize>(
+    result: Result<S, ApiError>,
+    rosetta_metrics: &RosettaMetrics,
+) -> HttpResponse {
     match result {
         Ok(x) => match serde_json::to_string(&x) {
             Ok(resp) => {
-                RosettaMetrics::inc_api_status_count("200");
+                rosetta_metrics.inc_api_status_count("200");
                 HttpResponse::Ok()
                     .content_type("application/json")
                     .body(resp)
             }
-            Err(e) => internal_error_response(e, Error::serialization_error_json_str()),
+            Err(e) => {
+                internal_error_response(e, Error::serialization_error_json_str(), rosetta_metrics)
+            }
         },
         Err(api_err) => {
             let converted = errors::convert_to_error(&api_err);
             match serde_json::to_string(&converted) {
                 Ok(resp) => {
                     let err_code = format!("{}", converted.0.code);
-                    RosettaMetrics::inc_api_status_count(&err_code);
-                    internal_error_response(converted, resp)
+                    rosetta_metrics.inc_api_status_count(&err_code);
+                    internal_error_response(converted, resp, rosetta_metrics)
                 }
-                Err(e) => internal_error_response(e, Error::serialization_error_json_str()),
+                Err(e) => internal_error_response(
+                    e,
+                    Error::serialization_error_json_str(),
+                    rosetta_metrics,
+                ),
             }
         }
     }
@@ -236,9 +257,12 @@ fn to_rosetta_response<S: serde::Serialize>(result: Result<S, ApiError>) -> Http
 #[get("/status")]
 async fn status(req_handler: web::Data<RosettaRequestHandler>) -> HttpResponse {
     let rosetta_blocks_mode = req_handler.rosetta_blocks_mode().await;
-    to_rosetta_response(Ok(RosettaStatus {
-        rosetta_blocks_mode,
-    }))
+    to_rosetta_response(
+        Ok(RosettaStatus {
+            rosetta_blocks_mode,
+        }),
+        &req_handler.rosetta_metrics(),
+    )
 }
 
 enum ServerState {
@@ -357,9 +381,13 @@ impl RosettaApiServer {
             }
             ServerState::Unstarted(server) => {
                 let skip_first_heartbeat_check = true;
+                let rosetta_metrics = RosettaMetrics::new(
+                    "ICP".to_string(),
+                    "ryjl3-tyaaa-aaaaa-aaaba-cai".to_string(),
+                );
                 let on_restart_callback: Option<Arc<dyn Fn() + Send + Sync>> =
-                    Some(Arc::new(|| {
-                        RosettaMetrics::inc_sync_thread_restarts();
+                    Some(Arc::new(move || {
+                        rosetta_metrics.inc_sync_thread_restarts();
                     }));
                 let mut watchdog_thread = WatchdogThread::new(
                     BLOCK_SYNC_TIMEOUT,
@@ -414,6 +442,8 @@ fn start_sync_thread(
         info!("Starting blockchain sync thread");
         let mut interval = interval(BLOCK_SYNC_INTERVAL);
         let mut synced_at = std::time::Instant::now();
+        let rosetta_metrics =
+            RosettaMetrics::new("ICP".to_string(), "ryjl3-tyaaa-aaaaa-aaaba-cai".to_string());
         while !stopped.load(Relaxed) {
             interval.tick().await;
             if let Err(err) = ledger.sync_blocks(stopped.clone()).await {
@@ -423,13 +453,12 @@ fn start_sync_thread(
                     ""
                 };
                 error!("Error in syncing blocks{}: {:?}", msg_403, err);
-                RosettaMetrics::inc_sync_errors();
-                RosettaMetrics::set_out_of_sync_time(
-                    Instant::now().duration_since(synced_at).as_secs_f64(),
-                );
+                rosetta_metrics.inc_sync_errors();
+                rosetta_metrics
+                    .set_out_of_sync_time(Instant::now().duration_since(synced_at).as_secs_f64());
             } else {
                 let t = Instant::now().duration_since(synced_at).as_secs_f64();
-                RosettaMetrics::set_out_of_sync_time(t);
+                rosetta_metrics.set_out_of_sync_time(t);
                 synced_at = std::time::Instant::now();
             }
             heartbeat_fn();

--- a/rs/rosetta-api/icrc1/src/lib.rs
+++ b/rs/rosetta-api/icrc1/src/lib.rs
@@ -34,16 +34,7 @@ pub struct AppState {
 impl AppState {
     // The ledger_display_name is the token symbol followed by the first 5 characters of the ledger_id.
     pub fn ledger_display_name(&self) -> String {
-        format!(
-            "{}-{}",
-            self.metadata.symbol.clone(),
-            self.ledger_id
-                .to_string()
-                .as_str()
-                .chars()
-                .take(5)
-                .collect::<String>()
-        )
+        self.storage.get_token_display_name()
     }
 }
 

--- a/rs/rosetta-api/icrc1/src/main.rs
+++ b/rs/rosetta-api/icrc1/src/main.rs
@@ -9,6 +9,7 @@ use axum::{
 use clap::{Parser, ValueEnum};
 use ic_agent::{identity::AnonymousIdentity, Agent};
 use ic_base_types::{CanisterId, PrincipalId};
+use ic_icrc_rosetta::common::storage::storage_client::TokenInfo;
 use ic_icrc_rosetta::{
     common::constants::{BLOCK_SYNC_WAIT_SECS, MAX_BLOCK_SYNC_WAIT_SECS},
     common::storage::{storage_client::StorageClient, types::MetadataEntry},
@@ -22,6 +23,7 @@ use ic_icrc_rosetta::{
 use ic_sys::fs::write_string_using_tmp_file;
 use icrc_ledger_agent::{CallMode, Icrc1Agent};
 use lazy_static::lazy_static;
+use rosetta_core::metrics::RosettaMetrics;
 use rosetta_core::watchdog::WatchdogThread;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -391,19 +393,14 @@ async fn main() -> Result<()> {
 
     let _guard = init_logs(args.log_level, &args.log_file)?;
 
+    // Initialize rosetta metrics with a default canister ID
+    // This will be updated for specific token operations but is required for middleware setup
+    let rosetta_metrics = RosettaMetrics::new("icrc1".to_string(), "icrc1_default".to_string());
+
     let token_defs = extract_token_defs(&args)?;
     let mut token_states = HashMap::new();
 
     for token_def in token_defs.iter() {
-        let storage = Arc::new(match args.store_type {
-            StoreType::InMemory => StorageClient::new_in_memory()?,
-            StoreType::File => {
-                let mut path = args.multi_tokens_store_dir.clone();
-                path.push(format!("{}.db", PrincipalId::from(token_def.ledger_id)));
-                StorageClient::new_persistent(&path).unwrap()
-            }
-        });
-
         let network_url = args.effective_network_url();
 
         let ic_agent = Agent::builder()
@@ -433,6 +430,15 @@ async fn main() -> Result<()> {
             ledger_canister_id: token_def.ledger_id.into(),
         });
 
+        let mut storage = match args.store_type {
+            StoreType::InMemory => StorageClient::new_in_memory()?,
+            StoreType::File => {
+                let mut path = args.multi_tokens_store_dir.clone();
+                path.push(format!("{}.db", PrincipalId::from(token_def.ledger_id)));
+                StorageClient::new_persistent(&path).unwrap()
+            }
+        };
+
         let metadata = load_metadata(token_def, &icrc1_agent, &storage, args.offline).await?;
 
         if token_def.icrc1_symbol.is_some()
@@ -453,11 +459,19 @@ async fn main() -> Result<()> {
             metadata.symbol
         );
 
+        let storage_metadata = metadata.clone();
+
+        storage.initialize(TokenInfo::new(
+            storage_metadata.symbol,
+            storage_metadata.decimals,
+            token_def.ledger_id,
+        ));
+
         let shared_state = Arc::new(AppState {
             icrc1_agent: icrc1_agent.clone(),
             ledger_id: token_def.ledger_id,
             synched: Arc::new(Mutex::new(None)),
-            storage: storage.clone(),
+            storage: Arc::new(storage),
             archive_canister_ids: Arc::new(AsyncMutex::new(vec![])),
             metadata,
         });
@@ -499,6 +513,9 @@ async fn main() -> Result<()> {
         process::exit(0);
     }
 
+    // Create metrics middleware for Axum
+    let metrics_layer = rosetta_metrics.metrics_layer();
+
     let app = Router::new()
         .route("/ready", get(ready))
         .route("/health", get(health))
@@ -520,6 +537,8 @@ async fn main() -> Result<()> {
         .route("/construction/hash", post(construction_hash))
         .route("/construction/payloads", post(construction_payloads))
         .route("/construction/parse", post(construction_parse))
+        // Apply the metrics middleware
+        .layer(metrics_layer)
         // This layer creates a span for each http request and attaches
         // the request_id, HTTP Method and path to it.
         .layer(add_request_span())
@@ -553,9 +572,11 @@ async fn main() -> Result<()> {
                     // so we skip it to avoid the watchdog thread to restart the sync thread
                     // during the initial synchronization.
                     let skip_first_hearbeat = true;
+                    let local_state = Arc::clone(&shared_state);
                     let mut watchdog = WatchdogThread::new(
                         Duration::from_secs(MAX_BLOCK_SYNC_WAIT_SECS),
-                        Some(Arc::new(|| {
+                        Some(Arc::new(move || {
+                            local_state.storage.get_metrics().inc_sync_thread_restarts();
                             info!("Watchdog triggered restart for a sync thread");
                         })),
                         skip_first_hearbeat,


### PR DESCRIPTION
This introduces a token-specific contextualized metrics class, used to emit metrics associated with a particular token when running multi-token rosetta.

Metrics now look like this, with token labels associated with the metrics:

```
# HELP ledger_sync_blocks_fetched_total Number of blocks fetched from the ledger
# TYPE ledger_sync_blocks_fetched_total counter
ledger_sync_blocks_fetched_total{token_display_name="ckBTC-mxzaz"} 47047
ledger_sync_blocks_fetched_total{token_display_name="ckETH-ss2fx"} 16
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 10
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1048576
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 21
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 46743552
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1744382003
# HELP process_threads Number of OS threads in the process.
# TYPE process_threads gauge
process_threads 18
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1213968384
# HELP rosetta_api_status_total Response status for ic-rosetta-api endpoints
# TYPE rosetta_api_status_total counter
rosetta_api_status_total{status_code="200",token_display_name="ckETH-ss2fx"} 1
# HELP rosetta_http_request_duration_seconds HTTP request latency in seconds
# TYPE rosetta_http_request_duration_seconds histogram
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="0.005"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="0.01"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="0.025"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="0.05"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="0.1"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="0.25"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="0.5"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="1"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="2.5"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="5"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="10"} 1
rosetta_http_request_duration_seconds_bucket{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx",le="+Inf"} 1
rosetta_http_request_duration_seconds_sum{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx"} 0.000276049
rosetta_http_request_duration_seconds_count{endpoint="/block",method="POST",status="200",token_display_name="ckETH-ss2fx"} 1
# HELP rosetta_verified_block_height Verified block height
# TYPE rosetta_verified_block_height gauge
rosetta_verified_block_height{token_display_name="ckETH-ss2fx"} 805409
```