### PR TITLE
feat(registry): During upgrade, decodes using HighCapacityRegistryAtomicMutateRequest.

### DIFF
--- a/rs/nns/integration_tests/src/registry_get_chunk.rs
+++ b/rs/nns/integration_tests/src/registry_get_chunk.rs
@@ -1,7 +1,8 @@
+use canister_test::CanisterInstallMode;
 use ic_nervous_system_chunks::Chunks;
 use ic_nns_constants::REGISTRY_CANISTER_ID;
 use ic_nns_test_utils::{
-    common::NnsInitPayloadsBuilder,
+    common::{build_registry_wasm, NnsInitPayloadsBuilder},
     state_test_helpers::{
         registry_get_chunk, setup_nns_canisters, state_machine_builder_for_nns_tests,
     },
@@ -46,6 +47,14 @@ fn test_get_chunk() {
     // convert stable_memory to its inner Vec.
     let stable_memory = <RefCell<std::vec::Vec<u8>> as Clone>::clone(&stable_memory).into_inner();
     state_machine.set_stable_memory(REGISTRY_CANISTER_ID, &stable_memory);
+    state_machine
+        .install_wasm_in_mode(
+            REGISTRY_CANISTER_ID,
+            CanisterInstallMode::Upgrade,
+            build_registry_wasm().bytes(),
+            vec![],
+        )
+        .unwrap();
 
     // Step 2: Call code under test (i.e. get_chunk).
     let small_response = registry_get_chunk(&state_machine, &small_chunk_key);

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -240,7 +240,7 @@ impl Registry {
         // Populate self.store (this is secondary to self.changelog).
         with_chunks(|chunks| {
             for mutation in &composite_mutation.mutations {
-                // TODO( DO NOT MERGE - ticket): Switch to high capacity.
+                // TODO(NNS1-3683): Switch to high capacity.
                 let value = dechunkify_prime_mutation_value(mutation.clone(), chunks);
 
                 let (value, deletion_marker) = match value {
@@ -443,7 +443,6 @@ impl Registry {
                     }
                     // End code to fix ICSUP-2589
 
-                    // DO NOT MERGE - Flag.
                     let mutation = HighCapacityRegistryAtomicMutateRequest::decode(
                         &entry.encoded_mutation[..],
                     )

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -993,10 +993,10 @@ mod tests {
 
         let max_value = vec![0; max_mutation_value_size(version, key)];
         let mutations = vec![upsert(key, max_value)];
-        let req = RegistryAtomicMutateRequest {
+        let req = HighCapacityRegistryAtomicMutateRequest::from(RegistryAtomicMutateRequest {
             mutations,
             preconditions: vec![],
-        };
+        });
         registry.changelog_insert(version, req);
 
         // We should have one changelog entry.
@@ -1019,10 +1019,10 @@ mod tests {
 
         let too_large_value = vec![0; max_mutation_value_size(version, key) + 1];
         let mutations = vec![upsert(key, too_large_value)];
-        let req = RegistryAtomicMutateRequest {
+        let req = HighCapacityRegistryAtomicMutateRequest::from(RegistryAtomicMutateRequest {
             mutations,
             preconditions: vec![],
-        };
+        });
 
         registry.changelog_insert(1, req);
     }

--- a/rs/registry/canister/src/storage.rs
+++ b/rs/registry/canister/src/storage.rs
@@ -55,7 +55,7 @@ pub(crate) fn with_chunks<R>(f: impl FnOnce(&Chunks<VM>) -> R) -> R {
     })
 }
 
-/// Encodes the argument.
+/* DO NOT MERGE - /// Encodes the argument.
 ///
 /// If the input is too large, this "chunkifies" it. That is, instead of
 /// inlining value, it is replaced with a LargeValueChunkKeys, which points to
@@ -73,14 +73,19 @@ pub(crate) fn maybe_chunkify_and_encode(original_mutation: RegistryAtomicMutateR
 
     let upgraded_mutation = maybe_chunkify(original_mutation);
 
-    // TODO(Nikola.Milosavljevic@dfinity.org): Populate timestamp_seconds field.
-
     upgraded_mutation.encode_to_vec()
 }
+*/
 
-fn maybe_chunkify(
+/// DO NOT MERGE - Document.
+pub(crate) fn chunkify_composite_mutation_if_too_large(
     original_mutation: RegistryAtomicMutateRequest,
 ) -> HighCapacityRegistryAtomicMutateRequest {
+    // If chunking is not enabled, simply transcribe.
+    if !is_chunkifying_large_values_enabled() {
+        return HighCapacityRegistryAtomicMutateRequest::from(original_mutation);
+    }
+
     // Panic if the input is too large.
     if original_mutation.encoded_len() > MAX_CHUNKABLE_ATOMIC_MUTATION_LEN {
         let first_key = original_mutation

--- a/rs/registry/canister/src/storage.rs
+++ b/rs/registry/canister/src/storage.rs
@@ -55,29 +55,10 @@ pub(crate) fn with_chunks<R>(f: impl FnOnce(&Chunks<VM>) -> R) -> R {
     })
 }
 
-/* DO NOT MERGE - /// Encodes the argument.
+/// Converts to HighCapacity version of input.
 ///
-/// If the input is too large, this "chunkifies" it. That is, instead of
-/// inlining value, it is replaced with a LargeValueChunkKeys, which points to
-/// pieces of the original value, and each piece can be fetched via the
-/// `get_chunk` canister method.
-///
-/// Possible panic reasons include: input is hyper too large. See
-/// MAX_CHUNKABLE_ATOMIC_MUTATION_LEN.
-pub(crate) fn maybe_chunkify_and_encode(original_mutation: RegistryAtomicMutateRequest) -> Vec<u8> {
-    if !is_chunkifying_large_values_enabled() {
-        return original_mutation.encode_to_vec();
-    }
-    // In release builds, code bellow this line is not active. Instead, only the
-    // old behavior (implemented above) takes place.
-
-    let upgraded_mutation = maybe_chunkify(original_mutation);
-
-    upgraded_mutation.encode_to_vec()
-}
-*/
-
-/// DO NOT MERGE - Document.
+/// When the input is "too large", "large" blobs are stored into CHUNKS, rather
+/// than remaining inline.
 pub(crate) fn chunkify_composite_mutation_if_too_large(
     original_mutation: RegistryAtomicMutateRequest,
 ) -> HighCapacityRegistryAtomicMutateRequest {

--- a/rs/registry/canister/src/storage/tests.rs
+++ b/rs/registry/canister/src/storage/tests.rs
@@ -34,7 +34,7 @@ fn test_no_chunkify_small_mutation() {
     };
 
     // Step 2: Call the code under test.
-    let result = maybe_chunkify(original_mutation.clone());
+    let result = chunkify_composite_mutation_if_too_large(original_mutation.clone());
 
     // Step 3: Verify results. Since the input is small, the output is simply a
     // transcription of the input. In particular, there is no chunking.
@@ -61,7 +61,7 @@ fn test_chunkify_reasonably_large_mutation() {
     };
 
     // Step 2: Call the code under test.
-    let result = maybe_chunkify(original_mutation);
+    let result = chunkify_composite_mutation_if_too_large(original_mutation);
 
     // Step 3: Verify results.
 
@@ -111,7 +111,7 @@ fn test_panic_on_hyper_large_mutation() {
     };
 
     // Step 2: Call the code under test.
-    let _explode = maybe_chunkify(original_mutation);
+    let _explode = chunkify_composite_mutation_if_too_large(original_mutation);
 
     // Step 3: Verify results. The previous line is supposed to panic (and this
     // is verified at the top via should_panic).

--- a/rs/registry/canister/src/storage/tests.rs
+++ b/rs/registry/canister/src/storage/tests.rs
@@ -34,10 +34,10 @@ fn test_no_chunkify_small_mutation() {
     };
 
     // Step 2: Call the code under test.
-    let result = maybe_chunkify_and_encode(original_mutation.clone());
+    let result = maybe_chunkify(original_mutation.clone());
 
-    // Step 3: Verify results.
-    let result = HighCapacityRegistryAtomicMutateRequest::decode(result.as_slice()).unwrap();
+    // Step 3: Verify results. Since the input is small, the output is simply a
+    // transcription of the input. In particular, there is no chunking.
     assert_eq!(
         result,
         HighCapacityRegistryAtomicMutateRequest::from(original_mutation)
@@ -61,11 +61,9 @@ fn test_chunkify_reasonably_large_mutation() {
     };
 
     // Step 2: Call the code under test.
-    let result = maybe_chunkify_and_encode(original_mutation);
+    let result = maybe_chunkify(original_mutation);
 
     // Step 3: Verify results.
-
-    let result = HighCapacityRegistryAtomicMutateRequest::decode(result.as_slice()).unwrap();
 
     // Step 3.1: Assert that value has been replaced with LargeValueChunkKeys.
     let first_prime_mutation = result.mutations.first().unwrap().content.as_ref().unwrap();
@@ -113,7 +111,7 @@ fn test_panic_on_hyper_large_mutation() {
     };
 
     // Step 2: Call the code under test.
-    let _explode = maybe_chunkify_and_encode(original_mutation);
+    let _explode = maybe_chunkify(original_mutation);
 
     // Step 3: Verify results. The previous line is supposed to panic (and this
     // is verified at the top via should_panic).

--- a/rs/registry/transport/src/high_capacity.rs
+++ b/rs/registry/transport/src/high_capacity.rs
@@ -5,6 +5,9 @@
 //! feel free to add needed conversions that seem to be missing.) As such, this
 //! module can stay private (which is nice).
 //!
+//! Note that when converting to HighCapacity types, there is no chunking; the
+//! conversion is just a "transcription".
+//!
 //! Note that when converting TO HighCapacity the From trait is used, but when
 //! converting FROM HighCapacity, TryFrom should be used. This asymetry is for
 //! the usual reason(s): every non-HighCapacity object has an equivalent


### PR DESCRIPTION
In a recent PR, this high-capacity type was used to ENCODE changelog entries. This PR "completes that circle", so to speak.

# Secondary Change(s)

Doing this made me realize that I made a mistake in an earlier change.

Nothing that `from_serializable_form` calls (whether direct or indirect) should chunkify. Whereas, earlier, I made `changelog_insert` do chunkification (and `changelog_insert` is indirectly called by `from_serialized_form`). This change fixes that by moving chunkification "up" the call graph to `apply_mutations` (which is not called by `from_serializable_form`, not even indirectly). This actually turns out to be the right "choke point" where chunkification should be applied.

Fortunately, the new buggy `changelog_insert` behavior (i.e. chunkification) was never enabled in release builds (feature flags FTW!). Therefore, we need not issue any recalls.

# Background

There are a couple of reasons these things can be done in separate PRs:

1. The new way of encoding is behind a flag, and per our standard practice, is disabled by default (in release builds). Later, we will flip this flag so that this behavior is enabled in production.

2. Even if it were enabled, the result for all current data is equivalent. This is because the new type is "highly compatible" with the old type.

# References

Closes [NNS1-3767].

[NNS1-3767]: https://dfinity.atlassian.net/browse/NNS1-3767