### PR TITLE
fix(ICRC_Ledger): FI-1709: Recompute ICRC ledger certified data in post upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9695,6 +9695,7 @@ dependencies = [
  "ic-base-types",
  "ic-canister-log 0.2.0",
  "ic-canisters-http-types",
+ "ic-cbor",
  "ic-cdk 0.17.1",
  "ic-cdk-macros 0.17.1",
  "ic-cdk-timers",

--- a/rs/ledger_suite/icrc1/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/ledger/BUILD.bazel
@@ -309,6 +309,7 @@ rust_test(
             "@crate_index//:ciborium",
             "@crate_index//:hex",
             "@crate_index//:ic-agent",
+            "@crate_index//:ic-cbor",
             "@crate_index//:ic-certification",
             "@crate_index//:ic-metrics-encoder",
             "@crate_index//:leb128",

--- a/rs/ledger_suite/icrc1/ledger/Cargo.toml
+++ b/rs/ledger_suite/icrc1/ledger/Cargo.toml
@@ -46,6 +46,7 @@ candid_parser = { workspace = true }
 cddl = "0.9.4"
 ciborium = { workspace = true }
 ic-agent = { workspace = true }
+ic-cbor = { workspace = true }
 ic-certification = { workspace = true }
 ic-ledger-suite-state-machine-tests = { path = "../../tests/sm-tests" }
 ic-icrc1-test-utils = { path = "../test_utils" }

--- a/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/benches/mod.rs
@@ -1,4 +1,4 @@
-use crate::{balances_len, execute_transfer_not_async, post_upgrade, pre_upgrade, Tokens};
+use crate::{balances_len, execute_transfer_not_async, post_upgrade_internal, pre_upgrade, Tokens};
 use assert_matches::assert_matches;
 use candid::{Nat, Principal};
 use ic_canister_log::Sink;
@@ -18,7 +18,7 @@ pub const NUM_GET_BLOCKS: u32 = 100;
 pub fn upgrade() {
     let _p = canbench_rs::bench_scope("upgrade");
     pre_upgrade();
-    post_upgrade(None);
+    post_upgrade_internal(None);
 }
 
 pub fn icrc_transfer(

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -271,10 +271,10 @@ fn post_upgrade(args: Option<LedgerArgument>) {
         migrate_next_part(
             MAX_INSTRUCTIONS_PER_UPGRADE.saturating_sub(pre_upgrade_instructions_consumed),
         );
+    } else {
+        // Set the certified data to the root hash of the ledger state, using the correct ICRC-3 labels.
+        ic_cdk::api::set_certified_data(&Access::with_ledger(Ledger::root_hash));
     }
-
-    // Set the certified data to the root hash of the ledger state, using the correct ICRC-3 labels.
-    ic_cdk::api::set_certified_data(&Access::with_ledger(Ledger::root_hash));
 
     let end = ic_cdk::api::instruction_counter();
     let instructions_consumed = end - start;
@@ -351,6 +351,8 @@ fn migrate_next_part(instruction_limit: u64) {
             });
         } else {
             log_message(format!("Migration completed! {msg}").as_str());
+            // Set the certified data to the root hash of the ledger state, using the correct ICRC-3 labels.
+            ic_cdk::api::set_certified_data(&ledger.root_hash());
         }
     });
 }

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -273,6 +273,9 @@ fn post_upgrade(args: Option<LedgerArgument>) {
         );
     }
 
+    // Set the certified data to the root hash of the ledger state, using the correct ICRC-3 labels.
+    ic_cdk::api::set_certified_data(&Access::with_ledger(Ledger::root_hash));
+
     let end = ic_cdk::api::instruction_counter();
     let instructions_consumed = end - start;
     POST_UPGRADE_INSTRUCTIONS_CONSUMED.with(|n| *n.borrow_mut() = instructions_consumed);

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -1705,18 +1705,16 @@ fn test_icrc3_certificate_ledger_upgrade() {
     // Compare the certified data of the new certificate with the digest of the old hash tree.
     // These should be different, since the new certified data uses the new labels, which are not
     // present in the old hash tree.
-    // However, due to the bug, the certified data corresponds to the old hash tree.
     assert!(
-        is_valid_root_hash(&new_certificate, &old_hash_tree.digest(), ledger_id),
-        "New certified data does not match old root hash after upgrade before transaction"
+        !is_valid_root_hash(&new_certificate, &old_hash_tree.digest(), ledger_id),
+        "New certified data matches old root hash after upgrade before transaction"
     );
     // Compare the certified data of the new certificate with the digest of the new hash tree.
     // These should be the same, since the new certified data, as well as the new hash tree, both
     // use the new labels.
-    // However, due to the bug, the certified data does not correspond to the new hash tree.
     assert!(
-        !is_valid_root_hash(&new_certificate, &new_hash_tree.digest(), ledger_id),
-        "New certified data matches new root hash after upgrade before transaction"
+        is_valid_root_hash(&new_certificate, &new_hash_tree.digest(), ledger_id),
+        "New certified data does not match new root hash after upgrade before transaction"
     );
 
     // Send a transaction, which will update the certified data.

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -1612,10 +1612,10 @@ fn test_icrc3_certificate_ledger_upgrade() {
         }
     }
 
-    // Verify that the legacy label is present in the old hash tree.
+    // Verify that the new label for the last block hash is not present in the old hash tree.
     assert!(lookup_hashtree(old_icrc3_certificate.hash_tree.clone(), "last_block_hash").is_err());
 
-    // Verify that the new label for the last block hash is not present in the old hash tree.
+    // Verify that the legacy label is present in the old hash tree.
     icrc_ledger_types::icrc::generic_value::Hash::try_from(
         lookup_hashtree(old_icrc3_certificate.hash_tree.clone(), "tip_hash").unwrap(),
     )

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -1,6 +1,9 @@
 use candid::{CandidType, Decode, Encode, Nat};
 use ic_agent::identity::Identity;
 use ic_base_types::{CanisterId, PrincipalId};
+use ic_cbor::CertificateToCbor;
+use ic_certification::hash_tree::{HashTreeNode, SubtreeLookupResult};
+use ic_certification::{Certificate, HashTree, LookupResult};
 use ic_icrc1::{Block, Operation, Transaction};
 use ic_icrc1_ledger::{
     ChangeFeeCollector, FeatureFlags, InitArgs, InitArgsBuilder as LedgerInitArgsBuilder,
@@ -21,7 +24,7 @@ use ic_ledger_suite_state_machine_tests::{
 };
 use ic_state_machine_tests::StateMachine;
 use icrc_ledger_types::icrc::generic_metadata_value::MetadataValue;
-use icrc_ledger_types::icrc::generic_value::Value;
+use icrc_ledger_types::icrc::generic_value::{Hash, Value};
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc1::transfer::{TransferArg, TransferError};
 use icrc_ledger_types::icrc2::allowance::Allowance;
@@ -30,6 +33,7 @@ use icrc_ledger_types::icrc2::transfer_from::{TransferFromArgs, TransferFromErro
 use icrc_ledger_types::icrc3::archive::{GetArchivesArgs, GetArchivesResult, QueryArchiveFn};
 use icrc_ledger_types::icrc3::blocks::{
     ArchivedBlocks, BlockWithId, GetBlocksRequest, GetBlocksResponse, GetBlocksResult,
+    ICRC3DataCertificate,
 };
 use num_traits::ToPrimitive;
 use std::collections::BTreeMap;
@@ -115,6 +119,10 @@ fn ledger_mainnet_u64_wasm() -> Vec<u8> {
         .unwrap()
 }
 
+fn ledger_mainnet_sns_wasm() -> Vec<u8> {
+    std::fs::read(std::env::var("IC_ICRC1_LEDGER_DEPLOYED_VERSION_WASM_PATH").unwrap()).unwrap()
+}
+
 #[cfg(not(feature = "u256-tokens"))]
 fn ledger_mainnet_v2_u64_wasm() -> Vec<u8> {
     std::fs::read(std::env::var("CKBTC_IC_ICRC1_LEDGER_V2_VERSION_WASM_PATH").unwrap()).unwrap()
@@ -176,18 +184,6 @@ fn ledger_wasm() -> Vec<u8> {
 
 fn ledger_wasm_lowupgradeinstructionlimits() -> Vec<u8> {
     std::fs::read(std::env::var("IC_ICRC1_LEDGER_WASM_INSTR_LIMITS_PATH").unwrap()).unwrap()
-}
-
-pub fn icrc_ledger_new_icrc3_certificate_wasm() -> Vec<u8> {
-    let ledger_wasm_path = std::env::var("IC_ICRC1_LEDGER_ICRC3_COMPATIBLE_DATA_CERTIFICATE_WASM_PATH").expect(
-        "The Ledger wasm path must be set using the env variable IC_ICRC1_LEDGER_ICRC3_COMPATIBLE_DATA_CERTIFICATE_WASM_PATH",
-    );
-    std::fs::read(&ledger_wasm_path).unwrap_or_else(|e| {
-        panic!(
-            "failed to load Wasm file from path {} (env var IC_ICRC1_LEDGER_ICRC3_COMPATIBLE_DATA_CERTIFICATE_WASM_PATH): {}",
-            ledger_wasm_path, e
-        )
-    })
 }
 
 fn ledger_wasm_nextledgerversion() -> Vec<u8> {
@@ -1533,7 +1529,7 @@ fn test_icrc3_get_blocks_number_of_blocks_limit() {
 }
 
 #[test]
-fn test_icrc3_certificate() {
+fn test_icrc3_certificate_ledger_upgrade() {
     const NUM_BLOCKS: u64 = 10;
 
     let env = StateMachine::new();
@@ -1541,12 +1537,15 @@ fn test_icrc3_certificate() {
 
     let init_args = ic_icrc1_ledger::InitArgsBuilder::for_tests()
         .with_minting_account(minting_account)
+        // We need an initial balance so the block certificate is not None
+        .with_initial_balance(account(1), 1_000_000u64)
         .with_transfer_fee(FEE)
         .build();
 
+    // Install the ledger with a version serving the non-compliant ICRC-3 certificate.
     let ledger_id = env
         .install_canister(
-            ledger_wasm(),
+            ledger_mainnet_sns_wasm(),
             Encode!(&(LedgerArgument::Init(init_args.clone()))).unwrap(),
             None,
         )
@@ -1569,14 +1568,14 @@ fn test_icrc3_certificate() {
         .expect("mint should succeed");
     }
 
-    let legacy_certificate = Decode!(
+    let old_legacy_certificate = Decode!(
         &env.query(ledger_id, "get_data_certificate", Encode!(&()).unwrap())
             .unwrap()
             .bytes(),
         icrc_ledger_types::icrc3::blocks::DataCertificate
     )
     .unwrap();
-    let icrc3_certificate = Decode!(
+    let old_icrc3_certificate = Decode!(
         &env.query(
             ledger_id,
             "icrc3_get_tip_certificate",
@@ -1584,25 +1583,27 @@ fn test_icrc3_certificate() {
         )
         .unwrap()
         .bytes(),
-        Option<icrc_ledger_types::icrc3::blocks::ICRC3DataCertificate>
+        Option<ICRC3DataCertificate>
     )
     .unwrap()
     .unwrap();
     assert_eq!(
-        legacy_certificate.certificate.clone().unwrap(),
-        icrc3_certificate.certificate
+        old_legacy_certificate.certificate.clone().unwrap(),
+        old_icrc3_certificate.certificate
     );
-    assert_eq!(legacy_certificate.hash_tree, icrc3_certificate.hash_tree);
+    assert_eq!(
+        old_legacy_certificate.hash_tree,
+        old_icrc3_certificate.hash_tree
+    );
 
     fn lookup_hashtree(
         hash_tree: serde_bytes::ByteBuf,
         leaf_name: &str,
     ) -> Result<Vec<u8>, String> {
-        let hash_tree: ic_certification::HashTree =
-            ciborium::de::from_reader(hash_tree.as_slice()).unwrap();
+        let hash_tree: HashTree = ciborium::de::from_reader(hash_tree.as_slice()).unwrap();
         match hash_tree.lookup_subtree([leaf_name.as_bytes()]) {
-            ic_certification::hash_tree::SubtreeLookupResult::Found(tree) => match tree.as_ref() {
-                ic_certification::hash_tree::HashTreeNode::Leaf(result) => Ok(result.clone()),
+            SubtreeLookupResult::Found(tree) => match tree.as_ref() {
+                HashTreeNode::Leaf(result) => Ok(result.clone()),
                 _ => Err("Expected a leaf node".to_string()),
             },
             _ => Err(format!(
@@ -1613,21 +1614,170 @@ fn test_icrc3_certificate() {
         }
     }
 
+    // Verify that the legacy label is present in the old hash tree.
+    assert!(lookup_hashtree(old_icrc3_certificate.hash_tree.clone(), "last_block_hash").is_err());
+
+    // Verify that the new label for the last block hash is not present in the old hash tree.
+    icrc_ledger_types::icrc::generic_value::Hash::try_from(
+        lookup_hashtree(old_icrc3_certificate.hash_tree.clone(), "tip_hash").unwrap(),
+    )
+    .unwrap();
+
+    // Verify that the label for the last block index is incorrectly encoded in the old hash tree.
+    let old_last_block_index = u64::from_be_bytes(
+        lookup_hashtree(old_icrc3_certificate.hash_tree.clone(), "last_block_index")
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    );
+    assert_eq!(NUM_BLOCKS, old_last_block_index);
+
+    // Upgrade to the ledger that serves the correct ICRC-3 certificate.
+    let upgrade_args = Encode!(&LedgerArgument::Upgrade(None)).unwrap();
+    env.upgrade_canister(ledger_id, ledger_wasm(), upgrade_args)
+        .expect("Unable to upgrade the ledger canister");
+
+    let new_legacy_certificate = Decode!(
+        &env.query(ledger_id, "get_data_certificate", Encode!(&()).unwrap())
+            .unwrap()
+            .bytes(),
+        icrc_ledger_types::icrc3::blocks::DataCertificate
+    )
+    .unwrap();
+    let new_icrc3_certificate = Decode!(
+        &env.query(
+            ledger_id,
+            "icrc3_get_tip_certificate",
+            Encode!(&()).unwrap()
+        )
+        .unwrap()
+        .bytes(),
+        Option<ICRC3DataCertificate>
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        new_legacy_certificate.certificate.clone().unwrap(),
+        new_icrc3_certificate.certificate
+    );
+
     // Verify that the legacy label is not present in the hash tree.
-    assert!(lookup_hashtree(icrc3_certificate.hash_tree.clone(), "tip_hash").is_err());
+    assert!(lookup_hashtree(new_icrc3_certificate.hash_tree.clone(), "tip_hash").is_err());
 
     // Verify that the new label for the last block hash is present in the hash tree.
     icrc_ledger_types::icrc::generic_value::Hash::try_from(
-        lookup_hashtree(icrc3_certificate.hash_tree.clone(), "last_block_hash").unwrap(),
+        lookup_hashtree(new_icrc3_certificate.hash_tree.clone(), "last_block_hash").unwrap(),
     )
     .unwrap();
 
     // Verify that the label for the last block index is correctly encoded in the hash tree.
     let new_last_block_index = leb128::read::unsigned(&mut std::io::Cursor::new(
-        lookup_hashtree(icrc3_certificate.hash_tree.clone(), "last_block_index").unwrap(),
+        lookup_hashtree(new_icrc3_certificate.hash_tree.clone(), "last_block_index").unwrap(),
     ))
     .unwrap();
-    assert_eq!(NUM_BLOCKS - 1, new_last_block_index);
+    assert_eq!(NUM_BLOCKS, new_last_block_index);
+
+    // Verify that the hash tree is different after the ledger was upgraded.
+    assert_ne!(
+        old_icrc3_certificate.hash_tree,
+        new_icrc3_certificate.hash_tree
+    );
+
+    let old_certificate = Certificate::from_cbor(old_icrc3_certificate.certificate.as_slice())
+        .expect("Unable to deserialize CBOR encoded Certificate");
+    let old_hash_tree: HashTree =
+        ciborium::de::from_reader(old_icrc3_certificate.hash_tree.as_slice())
+            .expect("Unable to deserialize CBOR encoded hash_tree");
+    let new_certificate = Certificate::from_cbor(new_icrc3_certificate.certificate.as_slice())
+        .expect("Unable to deserialize CBOR encoded Certificate");
+    let new_hash_tree: HashTree =
+        ciborium::de::from_reader(new_icrc3_certificate.hash_tree.as_slice())
+            .expect("Unable to deserialize CBOR encoded hash_tree");
+    assert!(
+        is_valid_root_hash(&old_certificate, &old_hash_tree.digest(), ledger_id),
+        "Certified data does not match root hash for old certificate before transaction"
+    );
+
+    // Compare the certified data of the new certificate with the digest of the old hash tree.
+    // These should be different, since the new certified data uses the new labels, which are not
+    // present in the old hash tree.
+    // However, due to the bug, the certified data corresponds to the old hash tree.
+    assert!(
+        is_valid_root_hash(&new_certificate, &old_hash_tree.digest(), ledger_id),
+        "New certified data does not match old root hash after upgrade before transaction"
+    );
+    // Compare the certified data of the new certificate with the digest of the new hash tree.
+    // These should be the same, since the new certified data, as well as the new hash tree, both
+    // use the new labels.
+    // However, due to the bug, the certified data does not correspond to the new hash tree.
+    assert!(
+        !is_valid_root_hash(&new_certificate, &new_hash_tree.digest(), ledger_id),
+        "New certified data matches new root hash after upgrade before transaction"
+    );
+
+    // Send a transaction, which will update the certified data.
+    send_transfer(
+        &env,
+        ledger_id,
+        minting_account.owner,
+        &TransferArg {
+            from_subaccount: None,
+            to: account(1),
+            fee: None,
+            created_at_time: None,
+            memo: None,
+            amount: 1_000_000u64.into(),
+        },
+    )
+    .expect("mint should succeed");
+
+    let new_icrc3_certificate = Decode!(
+        &env.query(
+            ledger_id,
+            "icrc3_get_tip_certificate",
+            Encode!(&()).unwrap()
+        )
+        .unwrap()
+        .bytes(),
+        Option<ICRC3DataCertificate>
+    )
+    .unwrap()
+    .unwrap();
+
+    let new_certificate = Certificate::from_cbor(new_icrc3_certificate.certificate.as_slice())
+        .expect("Unable to deserialize CBOR encoded Certificate");
+    let new_hash_tree: HashTree =
+        ciborium::de::from_reader(new_icrc3_certificate.hash_tree.as_slice())
+            .expect("Unable to deserialize CBOR encoded hash_tree");
+    assert!(
+        is_valid_root_hash(&new_certificate, &new_hash_tree.digest(), ledger_id),
+        "Certified data does not match root hash "
+    );
+}
+
+/// Check whether the certified data at path ["canister", ledger_canister_id, "certified_data"] is equal to root_hash.
+fn is_valid_root_hash(
+    certificate: &Certificate,
+    root_hash: &Hash,
+    ledger_canister_id: CanisterId,
+) -> bool {
+    let certified_data_path: [ic_certification::hash_tree::Label<Vec<u8>>; 3] = [
+        "canister".into(),
+        ledger_canister_id.get().0.as_slice().into(),
+        "certified_data".into(),
+    ];
+
+    let cert_hash = match certificate.tree.lookup_path(&certified_data_path) {
+        LookupResult::Found(v) => v,
+        _ => {
+            panic!(
+                "could not find certified_data for canister: {}",
+                ledger_canister_id
+            )
+        }
+    };
+
+    cert_hash == root_hash
 }
 
 mod verify_written_blocks {

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -116,11 +116,6 @@ fn ledger_mainnet_u64_wasm() -> Vec<u8> {
 }
 
 #[cfg(not(feature = "u256-tokens"))]
-fn ledger_mainnet_sns_wasm() -> Vec<u8> {
-    std::fs::read(std::env::var("IC_ICRC1_LEDGER_DEPLOYED_VERSION_WASM_PATH").unwrap()).unwrap()
-}
-
-#[cfg(not(feature = "u256-tokens"))]
 fn ledger_mainnet_v2_u64_wasm() -> Vec<u8> {
     std::fs::read(std::env::var("CKBTC_IC_ICRC1_LEDGER_V2_VERSION_WASM_PATH").unwrap()).unwrap()
 }
@@ -1525,7 +1520,6 @@ fn test_icrc3_get_blocks_number_of_blocks_limit() {
     check_icrc3_get_block_limit(vec![(0, 1), (0, 100)]);
 }
 
-#[cfg(not(feature = "u256-tokens"))]
 #[test]
 fn test_icrc3_certificate_ledger_upgrade() {
     use ic_cbor::CertificateToCbor;
@@ -1549,7 +1543,7 @@ fn test_icrc3_certificate_ledger_upgrade() {
     // Install the ledger with a version serving the non-compliant ICRC-3 certificate.
     let ledger_id = env
         .install_canister(
-            ledger_mainnet_sns_wasm(),
+            ledger_mainnet_wasm(),
             Encode!(&(LedgerArgument::Init(init_args.clone()))).unwrap(),
             None,
         )
@@ -1758,7 +1752,6 @@ fn test_icrc3_certificate_ledger_upgrade() {
 }
 
 /// Check whether the certified data at path ["canister", ledger_canister_id, "certified_data"] is equal to root_hash.
-#[cfg(not(feature = "u256-tokens"))]
 fn is_valid_root_hash(
     certificate: &ic_certification::Certificate,
     root_hash: &icrc_ledger_types::icrc::generic_value::Hash,

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -1740,6 +1740,13 @@ fn test_icrc3_certificate_ledger_upgrade() {
     .unwrap()
     .unwrap();
 
+    // Verify that the label for the last block index is correctly encoded in the hash tree.
+    let new_last_block_index = leb128::read::unsigned(&mut std::io::Cursor::new(
+        lookup_hashtree(new_icrc3_certificate.hash_tree.clone(), "last_block_index").unwrap(),
+    ))
+    .unwrap();
+    assert_eq!(NUM_BLOCKS + 1, new_last_block_index);
+
     let new_certificate = Certificate::from_cbor(new_icrc3_certificate.certificate.as_slice())
         .expect("Unable to deserialize CBOR encoded Certificate");
     let new_hash_tree: HashTree =


### PR DESCRIPTION
Recompute the certified data in the post upgrade of the ICRC ledger.

The certified data is currently only updated during ledger init, and after a transaction. This means that, without this fix, with the ICRC-3 certificate update that fixes the non-compliant labels, the ledger will return an invalid certificate until it process its first transaction after the canister upgrade.