### PR TITLE
refactor(nns): Initialize NNS Governance with candid

### DIFF
--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -1,4 +1,5 @@
 use assert_matches::assert_matches;
+use candid::Encode;
 use ic_base_types::PrincipalId;
 use ic_nervous_system_common::{E8, ONE_MONTH_SECONDS};
 use ic_nervous_system_integration_tests::pocket_ic_helpers::{install_canister, nns};
@@ -29,7 +30,6 @@ use itertools::Itertools;
 use maplit::hashmap;
 use pocket_ic::{nonblocking::PocketIc, PocketIcBuilder};
 use pretty_assertions::assert_eq;
-use prost::Message;
 use std::time::{Duration, SystemTime};
 
 const VALID_TOPIC: i32 = Topic::ParticipantManagement as i32;
@@ -483,7 +483,7 @@ async fn test_prune_some_following() {
         &pocket_ic,
         "NNS Governance",
         GOVERNANCE_CANISTER_ID,
-        governance_proto.encode_to_vec(),
+        Encode!(&governance_proto).unwrap(),
         build_governance_wasm(),
         Some(ROOT_CANISTER_ID.get()),
     )

--- a/rs/nns/integration_tests/src/reinstall_and_upgrade.rs
+++ b/rs/nns/integration_tests/src/reinstall_and_upgrade.rs
@@ -8,7 +8,7 @@ use ic_nervous_system_common_test_keys::{
 };
 use ic_nns_common::types::{NeuronId, UpdateIcpXdrConversionRatePayload};
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, LIFELINE_CANISTER_ID};
-use ic_nns_governance_api::pb::v1::{Governance as GovernanceProto, NnsFunction};
+use ic_nns_governance_api::pb::v1::NnsFunction;
 use ic_nns_gtc::{
     pb::v1::{AccountState, Gtc as GtcProto},
     test_constants::{TEST_IDENTITY_1, TEST_IDENTITY_2, TEST_IDENTITY_3, TEST_IDENTITY_4},
@@ -222,8 +222,7 @@ fn encode_init_state(init_state: NnsInitPayloads) -> Vec<Vec<u8>> {
     GtcProto::encode(&init_state.genesis_token, &mut gtc_init_vec).unwrap();
     let cmc_init_vec = Encode!(&init_state.cycles_minting).unwrap();
     let lifeline_init_vec = Encode!(&init_state.lifeline).unwrap();
-    let mut governance_init_vec = Vec::new();
-    GovernanceProto::encode(&init_state.governance, &mut governance_init_vec).unwrap();
+    let governance_init_vec = Encode!(&init_state.governance).unwrap();
     let root_init_vec = Encode!(&init_state.root).unwrap();
     let registry_init_vec = Encode!(&init_state.registry).unwrap();
 

--- a/rs/nns/test_utils/src/itest_helpers.rs
+++ b/rs/nns/test_utils/src/itest_helpers.rs
@@ -444,10 +444,7 @@ pub async fn install_rust_canister_from_path<P: AsRef<Path>>(
 /// Compiles the governance canister, builds it's initial payload and installs
 /// it
 pub async fn install_governance_canister(canister: &mut Canister<'_>, init_payload: Governance) {
-    let mut serialized = Vec::new();
-    init_payload
-        .encode(&mut serialized)
-        .expect("Couldn't serialize init payload.");
+    let serialized = Encode!(&init_payload).expect("Couldn't serialize init payload.");
     install_rust_canister(canister, "governance-canister", &["test"], Some(serialized)).await;
 }
 

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -606,7 +606,7 @@ pub fn setup_nns_governance_with_correct_canister_id(
         machine,
         GOVERNANCE_CANISTER_INDEX_IN_NNS_SUBNET,
         build_governance_wasm_with_features(features),
-        init_payload.encode_to_vec(),
+        Encode!(&init_payload).unwrap(),
     );
 }
 


### PR DESCRIPTION
We are moving towards using candid as the only API interface in the NNS Governance. Currently, the NNS Governance supports initializing with either of candid or protobuf. This PR switches tests to use candid.