### PR TITLE
feat(nns): Use a previous snapshot for ballots if an unusually high voting power is detected

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -45,7 +45,7 @@ benches:
     total:
       instructions: 1780000
       heap_increase: 0
-      stable_memory_increase: 0
+      stable_memory_increase: 256
     scopes: {}
   distribute_rewards_with_stable_neurons:
     total:

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1189,6 +1189,12 @@ message ProposalData {
 
   // The topic of the proposal.
   optional Topic topic = 23;
+
+  // When a voting power spike is detected, ballots are created using a previous snapshot of the
+  // voting power, and this field indicates the timestamp at which the snapshot was taken. This
+  // field should not be set in normal circumstances, and if it is set, it is an indicator that a
+  // bug might have caused the voting power spike.
+  optional uint64 previous_ballots_timestamp_seconds = 24;
 }
 
 // This structure contains data for settling the Neurons' Fund participation in an SNS token swap.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -1445,6 +1445,12 @@ pub struct ProposalData {
     /// The topic of the proposal.
     #[prost(enumeration = "Topic", optional, tag = "23")]
     pub topic: ::core::option::Option<i32>,
+    /// When a voting power spike is detected, ballots are created using a previous snapshot of the
+    /// voting power, and this field indicates the timestamp at which the snapshot was taken. This
+    /// field should not be set in normal circumstances, and if it is set, it is an indicator that a
+    /// bug might have caused the voting power spike.
+    #[prost(uint64, optional, tag = "24")]
+    pub previous_ballots_timestamp_seconds: ::core::option::Option<u64>,
 }
 /// This structure contains data for settling the Neurons' Fund participation in an SNS token swap.
 #[derive(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -68,6 +68,7 @@ use crate::{
         },
     },
     proposals::{call_canister::CallCanister, sum_weighted_voting_power},
+    storage::VOTING_POWER_SNAPSHOTS,
 };
 use async_trait::async_trait;
 use candid::{Decode, Encode};
@@ -5341,7 +5342,7 @@ impl Governance {
             }
         }
 
-        let (ballots, total_potential_voting_power) =
+        let (ballots, total_potential_voting_power, previous_ballots_timestamp_seconds) =
             self.compute_ballots_for_new_proposal(&action, proposer_id, now_seconds)?;
 
         if ballots.is_empty() {
@@ -5412,6 +5413,7 @@ impl Governance {
             wait_for_quiet_state,
             total_potential_voting_power: Some(total_potential_voting_power),
             topic: Some(topic as i32),
+            previous_ballots_timestamp_seconds,
             ..Default::default()
         };
 
@@ -5469,13 +5471,21 @@ impl Governance {
     /// vote, and they all get 1 voting power, regardless of refresh. Also,
     /// these proposals have no rewards. Therefore, in the case of ManageNeuron,
     /// this returns ballots_len.
+    #[allow(clippy::type_complexity)]
     fn compute_ballots_for_new_proposal(
         &mut self,
         action: &Action,
         proposer_id: &NeuronId,
         now_seconds: u64,
-    ) -> Result<(HashMap<u64, Ballot>, u64 /*potential_voting_power*/), GovernanceError> {
-        let (ballots, potential_voting_power) = match *action {
+    ) -> Result<
+        (
+            HashMap<u64, Ballot>,
+            u64,         /*potential_voting_power*/
+            Option<u64>, /*previous_ballots_timestamp_seconds*/
+        ),
+        GovernanceError,
+    > {
+        match *action {
             // A neuron can be managed only by its followees on the
             // 'manage neuron' topic.
             Action::ManageNeuron(ref manage_neuron) => {
@@ -5523,25 +5533,54 @@ impl Governance {
                     .collect();
                 // Conversion is safe because usize is u32, and in far future perhaps u64
                 let potential_voting_power = ballots.len() as u64;
-                (ballots, potential_voting_power)
+                let previous_ballots_timestamp_seconds = None;
+                Ok((
+                    ballots,
+                    potential_voting_power,
+                    previous_ballots_timestamp_seconds,
+                ))
             }
-            // For normal proposals, every neuron with a
-            // dissolve delay over six months is allowed to
-            // vote, with a voting power determined at the
-            // time of the proposal (i.e., now).
+            // For normal proposals, every neuron with a dissolve delay over six months is allowed
+            // to vote, with a voting power determined at the time of the proposal (i.e., now).
             _ => {
-                let voting_power_snapshot = self
+                let current_voting_power_snapshot = self
                     .neuron_store
                     .compute_voting_power_snapshot_for_standard_proposal(
                         self.voting_power_economics(),
                         now_seconds,
                     )?;
 
-                voting_power_snapshot.create_ballots_and_total_potential_voting_power()
-            }
-        };
+                // Check if there is a voting power spike. If there is, then the return value here
+                // will be `Some(...)`.
+                let maybe_previous_ballots_if_voting_power_spike_detected = VOTING_POWER_SNAPSHOTS
+                    .with_borrow(|snapshots| {
+                        snapshots.previous_ballots_if_voting_power_spike_detected(
+                            current_voting_power_snapshot.total_potential_voting_power(),
+                            now_seconds,
+                        )
+                    });
 
-        Ok((ballots, potential_voting_power))
+                let (voting_power_snapshot, previous_ballots_timestamp_seconds) =
+                    match maybe_previous_ballots_if_voting_power_spike_detected {
+                        // This is the extraordinary case - we have a voting power spike, and we
+                        // need to use the previous snapshot.
+                        Some((previous_snapshot_timestamp, previous_snapshot)) => {
+                            (previous_snapshot, Some(previous_snapshot_timestamp))
+                        }
+                        // This is the normal case - we have no voting power spike, so we use the
+                        // current snapshot.
+                        None => (current_voting_power_snapshot, None),
+                    };
+
+                let (ballots, total_potential_voting_power) =
+                    voting_power_snapshot.create_ballots_and_total_potential_voting_power();
+                Ok((
+                    ballots,
+                    total_potential_voting_power,
+                    previous_ballots_timestamp_seconds,
+                ))
+            }
+        }
     }
 
     /// Calculate the reject_cost_e8s of a proposal. This value is set in `ProposalData` and

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1637,7 +1637,7 @@ fn test_compute_ballots_for_new_proposal() {
         neuron_id_or_subaccount: None,
         command: None,
     }));
-    let (ballots, tot_potential_voting_power) = governance
+    let (ballots, tot_potential_voting_power, _previous_ballots_timestamp_seconds) = governance
         .compute_ballots_for_new_proposal(&manage_neuron_action, &NeuronId { id: 10 }, now_seconds)
         .expect("Failed computing ballots for new proposal");
 
@@ -1657,7 +1657,7 @@ fn test_compute_ballots_for_new_proposal() {
     );
 
     let motion_action = Action::Motion(Default::default());
-    let (ballots, tot_potential_voting_power) = governance
+    let (ballots, tot_potential_voting_power, _previous_ballots_timestamp_seconds) = governance
         .compute_ballots_for_new_proposal(&motion_action, &NeuronId { id: 10 }, now_seconds)
         .expect("Failed computing ballots for new proposal");
     // Similar to previous; this time though, Action::ManageNeuron, the weird
@@ -1688,7 +1688,7 @@ fn test_compute_ballots_for_new_proposal() {
     // Not affected by refresh.
     let now_seconds = CREATED_TIMESTAMP_SECONDS + 20 * ONE_YEAR_SECONDS;
 
-    let (ballots, tot_potential_voting_power) = governance
+    let (ballots, tot_potential_voting_power, _previous_ballots_timestamp_seconds) = governance
         .compute_ballots_for_new_proposal(&motion_action, &NeuronId { id: 10 }, now_seconds)
         .expect("Failed computing ballots for new proposal");
     let expected: u64 = governance.neuron_store.with_active_neurons_iter(|iter| {

--- a/rs/nns/governance/src/governance/voting_power_snapshots.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 use crate::{
-    governance::LOG_PREFIX,
+    governance::{LOG_PREFIX, MAX_FOLLOWEES_PER_TOPIC},
     neuron_store::voting_power::VotingPowerSnapshot,
     pb::v1::{Ballot, NeuronIdToVotingPowerMap, VotingPowerTotal},
 };
@@ -79,7 +79,6 @@ impl VotingPowerSnapshots {
             return false;
         };
 
-        // If the latest snapshot is already considered a spike,
         self.totals_entry_with_minimum_total_potential_voting_power_if_voting_power_spiked(
             now_seconds,
             latest_totals.total_potential_voting_power,
@@ -96,6 +95,15 @@ impl VotingPowerSnapshots {
     ) {
         let (voting_power_map, voting_power_total) =
             <(NeuronIdToVotingPowerMap, VotingPowerTotal)>::from(snapshot);
+        // We are being defensive here to make sure that the voting power snapshot is not taken as a
+        // neuron management proposal, which is a special case where the ballots are created from
+        // NeuronManagement topic followees rather than all voting eligible neurons.
+        if voting_power_total.total_potential_voting_power <= MAX_FOLLOWEES_PER_TOPIC as u64 {
+            ic_cdk::println!(
+                "Voting power total is less than MAX_FOLLOWEES_PER_TOPIC. This should not happen."
+            );
+            return;
+        }
         insert_and_truncate(
             &mut self.neuron_id_to_voting_power_maps,
             timestamp_seconds,
@@ -151,7 +159,12 @@ impl VotingPowerSnapshots {
         total_potential_voting_power: u64,
         now_seconds: TimestampSeconds,
     ) -> Option<(TimestampSeconds, VotingPowerSnapshot)> {
-        // Step 1: find the voting power totals entry with the minimum total potential voting power,
+        // Step 1: check if there are enough snapshots to detect a spike.
+        if self.voting_power_totals.len() < MAX_VOTING_POWER_SNAPSHOTS {
+            return None;
+        }
+
+        // Step 2: find the voting power totals entry with the minimum total potential voting power,
         // if a spike is detected.
         let Some((
             timestamp_with_minimum_total_potential_voting_power,
@@ -168,7 +181,7 @@ impl VotingPowerSnapshots {
             return None;
         };
 
-        // Step 2: find the voting power map for the timestamp with the minimum potential voting power.
+        // Step 3: find the voting power map for the timestamp with the minimum potential voting power.
         let Some(voting_power_map) = self
             .neuron_id_to_voting_power_maps
             .get(&timestamp_with_minimum_total_potential_voting_power)
@@ -181,7 +194,8 @@ impl VotingPowerSnapshots {
             return None;
         };
 
-        // Step 3: returns the previous voting power map since a voting power spike is detected.
+        // Step 4: returns one of the previous voting power maps (with minimum total potential
+        // voting power) since a voting power spike is detected.
         let previous_voting_power_snapshot = VotingPowerSnapshot::from((
             voting_power_map,
             totals_with_minimum_total_potential_voting_power,

--- a/rs/nns/governance/src/governance/voting_power_snapshots_tests.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots_tests.rs
@@ -43,14 +43,6 @@ fn test_record_voting_power_snapshot() {
     assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), Some(1));
     // We should return previous ballots if the deciding voting power is more than 1.5 times the
     // minimum voting power in the first snapshot.
-    assert_eq!(
-        snapshots.previous_ballots_if_voting_power_spike_detected(149, 1),
-        None
-    );
-    assert_eq!(
-        snapshots.previous_ballots_if_voting_power_spike_detected(151, 1),
-        Some((1, voting_power_snapshot(vec![90], 100)))
-    );
     assert!(!snapshots.is_latest_snapshot_a_spike(1));
 
     for i in 0..6 {
@@ -63,14 +55,6 @@ fn test_record_voting_power_snapshot() {
         assert_eq!(
             snapshots.latest_snapshot_timestamp_seconds(),
             Some(timestamp_seconds)
-        );
-        assert_eq!(
-            snapshots.previous_ballots_if_voting_power_spike_detected(149, timestamp_seconds),
-            None
-        );
-        assert_eq!(
-            snapshots.previous_ballots_if_voting_power_spike_detected(151, timestamp_seconds),
-            Some((1, voting_power_snapshot(vec![90], 100)))
         );
         assert!(!snapshots.is_latest_snapshot_a_spike(timestamp_seconds));
     }

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -482,6 +482,18 @@ pub fn encode_metrics(
         "The total amount of potential voting power (in the most recent proposal).",
     )?;
 
+    let proposals_using_previous_voting_power_snapshots = governance
+        .heap_data
+        .proposals
+        .values()
+        .filter(|proposal| proposal.previous_ballots_timestamp_seconds.is_some())
+        .count();
+    w.encode_gauge(
+        "governance_proposals_using_previous_voting_power_snapshots",
+        proposals_using_previous_voting_power_snapshots as f64,
+        "The number of proposals that are using previous voting power snapshots.",
+    )?;
+
     // Neuron Indexes
 
     let neuron_store::NeuronIndexesLens {

--- a/rs/nns/governance/src/neuron_store/voting_power.rs
+++ b/rs/nns/governance/src/neuron_store/voting_power.rs
@@ -68,6 +68,10 @@ impl VotingPowerSnapshot {
 
         (ballots, total_potential_voting_power)
     }
+
+    pub fn total_potential_voting_power(&self) -> u64 {
+        self.total_potential_voting_power
+    }
 }
 
 impl From<VotingPowerSnapshot> for (NeuronIdToVotingPowerMap, VotingPowerTotal) {

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -1432,6 +1432,8 @@ impl From<pb_api::ProposalData> for pb::ProposalData {
             neurons_fund_data: item.neurons_fund_data.map(|x| x.into()),
             total_potential_voting_power: item.total_potential_voting_power,
             topic: item.topic,
+            // This is not intended to be initialized from outside of canister.
+            previous_ballots_timestamp_seconds: None,
         }
     }
 }

--- a/rs/nns/governance/src/storage.rs
+++ b/rs/nns/governance/src/storage.rs
@@ -282,6 +282,23 @@ pub fn reset_stable_memory() {
             })
         }
     });
+    REWARDS_DISTRIBUTION_STATE_MACHINE.with_borrow_mut(|rewards_distribution_state_machine| {
+        *rewards_distribution_state_machine =
+            RewardsDistributionStateMachine::new(MEMORY_MANAGER.with(|mm| {
+                mm.borrow()
+                    .get(REWARDS_DISTRIBUTION_STATE_MACHINE_MEMORY_ID)
+            }));
+    });
+    VOTING_POWER_SNAPSHOTS.with_borrow_mut(|snapshots| {
+        let (voting_power_maps_memory, voting_power_totals_memory) = MEMORY_MANAGER.with(|mm| {
+            let memory_manager = mm.borrow();
+            (
+                memory_manager.get(VOTING_POWER_MAPS_MEMORY_ID),
+                memory_manager.get(VOTING_POWER_TOTALS_MEMORY_ID),
+            )
+        });
+        *snapshots = VotingPowerSnapshots::new(voting_power_maps_memory, voting_power_totals_memory)
+    });
 }
 
 pub fn grow_upgrades_memory_to(target_pages: u64) {

--- a/rs/nns/governance/src/timer_tasks/snapshot_voting_power.rs
+++ b/rs/nns/governance/src/timer_tasks/snapshot_voting_power.rs
@@ -157,7 +157,7 @@ mod tests {
     fn test_execute() {
         TEST_VOTING_POWER_SNAPSHOTS.with_borrow(|snapshots| {
             // Before the first snapshot, the latest snapshot timestamp should be None, and we
-            // should not disable early adoption without any snapshots.
+            // should not return any previous ballots.
             assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), None);
             assert_eq!(
                 snapshots.previous_ballots_if_voting_power_spike_detected(u64::MAX, 0),
@@ -165,20 +165,29 @@ mod tests {
             )
         });
 
-        let task = SnapshotVotingPowerTask::new(&TEST_GOVERNANCE, &TEST_VOTING_POWER_SNAPSHOTS);
-        let (delay, task) = task.execute();
+        let mut task = SnapshotVotingPowerTask::new(&TEST_GOVERNANCE, &TEST_VOTING_POWER_SNAPSHOTS);
+        let mut now_seconds = 0;
 
-        assert_eq!(delay, VOTING_POWER_SNAPSHOT_INTERVAL);
+        for i in 0..7 {
+            now_seconds = i * ONE_DAY_SECONDS;
+            set_time(now_seconds);
+            let (delay, new_task) = task.execute();
+            assert_eq!(delay.as_secs(), ONE_DAY_SECONDS);
+            task = new_task;
+        }
+
         TEST_VOTING_POWER_SNAPSHOTS.with_borrow(|snapshots| {
             // After the first snapshot, the latest snapshot timestamp should be the current time,
             // and we should disable early adoption given a large deciding voting power.
-            assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), Some(0));
-            let (timestamp, previous_snapshot) = snapshots
-                .previous_ballots_if_voting_power_spike_detected(u64::MAX, 0)
+            assert_eq!(
+                snapshots.latest_snapshot_timestamp_seconds(),
+                Some(now_seconds)
+            );
+            let (_timestamp, previous_snapshot) = snapshots
+                .previous_ballots_if_voting_power_spike_detected(u64::MAX, now_seconds)
                 .unwrap();
 
             // We only do some sanity checks here to make sure the task is working as expected.
-            assert_eq!(timestamp, 0);
             let (ballots, total_potential_voting_power) =
                 previous_snapshot.create_ballots_and_total_potential_voting_power();
             assert!(ballots.get(&1).unwrap().voting_power > 0);
@@ -186,7 +195,8 @@ mod tests {
         });
 
         // Run the task again after a day, with a doubled voting power.
-        set_time(ONE_DAY_SECONDS);
+        now_seconds += ONE_DAY_SECONDS;
+        set_time(now_seconds);
         TEST_GOVERNANCE.with_borrow_mut(|governance| {
             governance
                 .neuron_store
@@ -199,17 +209,18 @@ mod tests {
         TEST_VOTING_POWER_SNAPSHOTS.with_borrow(|snapshots| {
             assert_eq!(
                 snapshots.latest_snapshot_timestamp_seconds(),
-                Some(ONE_DAY_SECONDS)
+                Some(now_seconds)
             );
         });
 
         // Run the task again after another day should not do anything since there is a spike in the snapshots.
-        set_time(2 * ONE_DAY_SECONDS);
+        now_seconds += ONE_DAY_SECONDS;
+        set_time(now_seconds);
         task.execute();
         TEST_VOTING_POWER_SNAPSHOTS.with_borrow(|snapshots| {
             assert_eq!(
                 snapshots.latest_snapshot_timestamp_seconds(),
-                Some(ONE_DAY_SECONDS)
+                Some(now_seconds - ONE_DAY_SECONDS)
             );
         });
     }

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -10,6 +10,7 @@ on the process that this file is part of, see
 ## Added
 
 * Add a metric for the nubmer of spawning neurons.
+* Use a previous voting power snapshot to create ballots if a voting power spike id detected.
 
 ## Changed
 

--- a/rs/nns/integration_tests/src/governance_proposals.rs
+++ b/rs/nns/integration_tests/src/governance_proposals.rs
@@ -1,0 +1,116 @@
+use ic_nervous_system_common_test_keys::{
+    TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL, TEST_NEURON_3_OWNER_PRINCIPAL,
+};
+use ic_nns_common::pb::v1::{NeuronId, ProposalId};
+use ic_nns_governance_api::{
+    manage_neuron_response::Command, MakeProposalRequest, Motion, ProposalActionRequest,
+};
+use ic_nns_test_utils::{
+    common::NnsInitPayloadsBuilder,
+    state_test_helpers::{
+        nns_create_super_powerful_neuron, nns_governance_get_proposal_info_as_anonymous,
+        nns_governance_make_proposal, setup_nns_canisters, state_machine_builder_for_nns_tests,
+    },
+};
+use ic_state_machine_tests::StateMachine;
+use ic_types::PrincipalId;
+use icp_ledger::Tokens;
+use std::time::Duration;
+
+fn make_motion_proposal(
+    state_machine: &StateMachine,
+    sender: PrincipalId,
+    neuron_id: NeuronId,
+) -> ProposalId {
+    let response = nns_governance_make_proposal(
+        state_machine,
+        sender,
+        neuron_id,
+        &MakeProposalRequest {
+            title: Some("Some title".to_string()),
+            summary: "Some summary".to_string(),
+            url: "".to_string(),
+            action: Some(ProposalActionRequest::Motion(Motion {
+                motion_text: "Motion text".to_string(),
+            })),
+        },
+    );
+    match response.command {
+        Some(Command::MakeProposal(make_proposal_response)) => {
+            make_proposal_response.proposal_id.unwrap()
+        }
+        _ => panic!("Failed to make motion proposal: {:?}", response),
+    }
+}
+
+fn is_proposal_executed(state_machine: &StateMachine, proposal_id: ProposalId) -> bool {
+    let proposal_info =
+        nns_governance_get_proposal_info_as_anonymous(state_machine, proposal_id.id);
+    proposal_info.executed_timestamp_seconds > 0
+}
+
+#[test]
+fn test_proposal_no_voting_power_spike() {
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    let nns_init_payloads = NnsInitPayloadsBuilder::new().with_test_neurons().build();
+    setup_nns_canisters(&state_machine, nns_init_payloads);
+
+    let proposal_id = make_motion_proposal(
+        &state_machine,
+        *TEST_NEURON_1_OWNER_PRINCIPAL,
+        NeuronId::from_u64(TEST_NEURON_1_ID),
+    );
+
+    // Because the neuron 1 has a lot of voting power, the proposal should be executed immediately.
+    assert!(is_proposal_executed(&state_machine, proposal_id));
+}
+
+#[test]
+fn test_proposal_with_voting_power_spike() {
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    let nns_init_payloads = NnsInitPayloadsBuilder::new().with_test_neurons().build();
+    setup_nns_canisters(&state_machine, nns_init_payloads);
+
+    // For a few days, proposals made by a neuron which wields a lot of voting power should be
+    // executed immediately.
+    for _ in 0..10 {
+        let proposal_id = make_motion_proposal(
+            &state_machine,
+            *TEST_NEURON_1_OWNER_PRINCIPAL,
+            NeuronId::from_u64(TEST_NEURON_1_ID),
+        );
+        assert!(is_proposal_executed(&state_machine, proposal_id));
+
+        state_machine.advance_time(Duration::from_secs(60 * 60 * 24));
+    }
+
+    // Now we create a super powerful neuron, which will cause a spike in voting power compared to
+    // previous days.
+    let super_powerful_neuron_id = nns_create_super_powerful_neuron(
+        &state_machine,
+        *TEST_NEURON_3_OWNER_PRINCIPAL,
+        Tokens::from_tokens(1_000_000).unwrap(),
+    );
+    let proposal_id = make_motion_proposal(
+        &state_machine,
+        *TEST_NEURON_3_OWNER_PRINCIPAL,
+        super_powerful_neuron_id,
+    );
+    assert!(!is_proposal_executed(&state_machine, proposal_id));
+
+    // Using the previous neuron, we create a proposal which should be executed immediately.
+    let proposal_id = make_motion_proposal(
+        &state_machine,
+        *TEST_NEURON_1_OWNER_PRINCIPAL,
+        NeuronId::from_u64(TEST_NEURON_1_ID),
+    );
+    assert!(is_proposal_executed(&state_machine, proposal_id));
+
+    // The neurons with a lot of voting power before the spike can still pass proposals.
+    let proposal_id = make_motion_proposal(
+        &state_machine,
+        *TEST_NEURON_1_OWNER_PRINCIPAL,
+        NeuronId::from_u64(TEST_NEURON_1_ID),
+    );
+    assert!(is_proposal_executed(&state_machine, proposal_id));
+}

--- a/rs/nns/integration_tests/src/lib.rs
+++ b/rs/nns/integration_tests/src/lib.rs
@@ -103,6 +103,9 @@ mod governance_neurons;
 mod governance_time_warp;
 
 #[cfg(test)]
+mod governance_proposals;
+
+#[cfg(test)]
 mod known_neurons;
 
 #[cfg(test)]


### PR DESCRIPTION
# Why

To prevent a sudden takeover of the NNS in the event of some party gaining illegitimate voting power (e.g. a bug in Governance, ICP Ledger, etc.), we aim at disabling the early adoption of NNS proposals if the voting power has a spike, which should give the network more time to react and recover in such cases.

# What

There are 3 PRs to achieve the above-mentioned goal:

- (#4404) Define VotingPowerSnapshot and a collection of snapshots
- (#4405) Add a timer task to record snapshots periodically
- (current PR) Use the previous snapshot if a voting power spike is detected

