### PR TITLE
fix: Make the Heartbeat Counter on the Random Traffic Canister increment only for substantial Heartbeats.

### DIFF
--- a/rs/rust_canisters/random_traffic_test/src/main.rs
+++ b/rs/rust_canisters/random_traffic_test/src/main.rs
@@ -335,7 +335,7 @@ async fn pulse(calls_count: u32) -> u32 {
     calls_success_counter
 }
 
-/// Calls `pulse(calls_per_heartbeat)` each round; increments `SUCCESSFUL_HEARTBEAT_INVOCATION`
+/// Calls `pulse(calls_per_heartbeat)` each round; increments `SUCCESSFUL_HEARTBEAT_INVOCATIONS`
 /// for heartbeats that try to make at least 1 call.
 #[heartbeat]
 async fn heartbeat() {

--- a/rs/rust_canisters/random_traffic_test/src/main.rs
+++ b/rs/rust_canisters/random_traffic_test/src/main.rs
@@ -339,7 +339,8 @@ async fn pulse(calls_count: u32) -> u32 {
 /// for heartbeats that try to make at least 1 call.
 #[heartbeat]
 async fn heartbeat() {
-    if let calls_count @ 1.. = CONFIG.with_borrow(|config| config.calls_per_heartbeat) {
+    let calls_count = CONFIG.with_borrow(|config| config.calls_per_heartbeat);
+    if calls_count > 0 {
         pulse(calls_count).await;
         SUCCESSFUL_HEARTBEAT_INVOCATIONS
             .replace(SUCCESSFUL_HEARTBEAT_INVOCATIONS.get() + calls_count);


### PR DESCRIPTION
This counter is supposed to protect against no-op heartbeats due to silent rollbacks. For checks that this be non-zero, the counter should not be included for heartbeats that didn't try to make any calls.