### PR TITLE
chore(ic-backup): remove backup lib as it's not used anywhere

### DIFF
--- a/rs/backup/BUILD.bazel
+++ b/rs/backup/BUILD.bazel
@@ -34,34 +34,21 @@ MACRO_DEPENDENCIES = []
 
 ALIASES = {}
 
-rust_library(
-    name = "backup",
-    srcs = glob(["src/**"]),
-    aliases = ALIASES,
-    crate_name = "ic_backup",
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "1.0.2",
-    visibility = [
-        "//rs:system-tests-pkg",
-    ],
-    deps = DEPENDENCIES,
-)
-
 rust_binary(
     name = "ic-backup",
-    srcs = ["src/main.rs"],
+    srcs = glob(["src/**"]),
     aliases = ALIASES,
     proc_macro_deps = MACRO_DEPENDENCIES,
     visibility = [
         "//rs:release-pkg",
         "//rs:system-tests-pkg",
     ],
-    deps = DEPENDENCIES + [":backup"],
+    deps = DEPENDENCIES,
 )
 
 rust_test(
     name = "backup_test",
     compile_data = ["test_data/fake_input_config.json.template"],
-    crate = ":backup",
+    crate = ":ic-backup",
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/backup/src/lib.rs
+++ b/rs/backup/src/lib.rs
@@ -1,6 +1,0 @@
-pub mod backup_helper;
-pub mod backup_manager;
-pub mod cmd;
-pub mod config;
-mod notification_client;
-mod util;

--- a/rs/backup/src/main.rs
+++ b/rs/backup/src/main.rs
@@ -1,8 +1,14 @@
+mod backup_helper;
+mod backup_manager;
+mod cmd;
+mod config;
+mod notification_client;
+mod util;
+
+use backup_manager::BackupManager;
+use cmd::{BackupArgs, SubCommand};
+
 use clap::Parser;
-use ic_backup::{
-    backup_manager::BackupManager,
-    cmd::{BackupArgs, SubCommand},
-};
 use slog::{o, Drain};
 use std::{io::stdin, sync::Arc};
 


### PR DESCRIPTION
It will be easier to detect dead code this way 