### PR TITLE
refactor(nns): Remove legacy options using protobuf for NNS Governance init

### DIFF
--- a/testnet/ansible/roles/ic_guest/tasks/install.yml
+++ b/testnet/ansible/roles/ic_guest/tasks/install.yml
@@ -78,19 +78,9 @@
 
       echo "Installing NNS"
 
-      GOVERNANCE_PB=""
-      {% if governance_pb_file is defined %}
-        GOVERNANCE_PB="--governance-pb-file {{ governance_pb_file }}"
-      {% else %}
-        if [[ -r "{{ inventory_file | dirname }}/initial-governance.pb" ]]; then
-          GOVERNANCE_PB="--governance-pb-file '{{ inventory_file | dirname }}/initial-governance.pb'"
-        fi
-      {% endif %}
-
       timeout 600 "{{ ic_media_path }}/bin/ic-nns-init" \
           --url "$NNS_URL" \
           --registry-local-store-dir "{{ ic_media_path }}/ic_registry_local_store" \
-          $GOVERNANCE_PB \
           {% if initial_neurons is defined %} --initial-neurons "{{ initial_neurons }}" {% endif %} \
           {% if test_ledger_accounts is defined %}
           {% for principal in test_ledger_accounts %}


### PR DESCRIPTION
Remove 2 legacy options in `ic_nns_init`:

- `governance_pb_file`: using a pb file to instantiate NNS Governance. There doesn't seem to be anyone using it. There are also better options: `initial_neurons` allow arbitrary neurons and the default initializes 3 neurons.
- `output_initial_state_candid_only`: this supposedly creates "candid files" (although 2 out of 4 are protobuf). However, the functionalities to use those files seem incomplete.

Overall, the removals don't affect production code. We can easily revert if it turns out they are used.