### PR TITLE
fix(ic-backup): [CON-1493] Only replay blocks until a CUP height during a backup

### DIFF
--- a/rs/replay/src/backup.rs
+++ b/rs/replay/src/backup.rs
@@ -232,6 +232,8 @@ where
 /// Deserializes consensus artifacts, reading them from the backup spool height
 /// by height and inserting them into the consensus pool. It stops at certain
 /// points which require the execution state to catch up.
+// TODO(CON-1494): change the return type of this function. Most variants of ExitPoint
+// are not result of errors.
 pub(crate) fn deserialize_consensus_artifacts(
     registry_client: Arc<dyn RegistryClient>,
     crypto: Arc<dyn CryptoComponentForVerificationOnly>,

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -1222,8 +1222,8 @@ impl Player {
                 self.log,
                 "The state height {} is strictly above the CUP height {}. \
                 Skipping the rest of CUP verification.",
-                last_cup.height(),
-                self.state_manager.latest_state_height()
+                self.state_manager.latest_state_height(),
+                last_cup.height()
             );
             return Ok(());
         }

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -1073,11 +1073,19 @@ impl Player {
                 &mut invalid_artifacts,
             );
 
+            // We don't want to replay heights strictly above the next CUP.
+            let replay_target_height = match result {
+                Err(backup::ExitPoint::CUPHeightWasFinalized(cup_height)) => {
+                    Some(target_height.unwrap_or(cup_height).min(cup_height))
+                }
+                _ => target_height,
+            };
+
             let last_batch_height = self.deliver_batches(
                 self.message_routing.as_ref(),
                 &PoolReader::new(self.consensus_pool.as_ref().unwrap()),
                 self.membership.as_ref().unwrap(),
-                self.replay_target_height.map(Height::from),
+                replay_target_height,
             );
             self.wait_for_state(last_batch_height);
             if let Some(height) = target_height {


### PR DESCRIPTION
Currently we don’t verify the state hash in a CUP if the CUP’s height is below the latest state’s height: [click](https://sourcegraph.com/github.com/dfinity/ic@23abac5891de0ebde5c49c0fe91a1aab39c6241f/-/blob/rs/replay/src/player.rs?L1197-1202).

When replaying blocks for the backup purposes, we start with a checkpoint height `h`, we execute blocks until we reach the next CUP height `h'`, and continue executing blocks until we reach the smallest height `h'' >= h'` which is explicitly finalized: [click](https://sourcegraph.com/github.com/dfinity/ic@23abac5891de0ebde5c49c0fe91a1aab39c6241f/-/blob/rs/replay/src/backup.rs?L460-468). Only then we verify the CUP: [click](https://sourcegraph.com/github.com/dfinity/ic@23abac5891de0ebde5c49c0fe91a1aab39c6241f/-/blob/rs/replay/src/player.rs?L1092-1104).

This means that if `h''` is strictly larger than `h'`, i.e., if the CUP height was not explicitly finalized, we will not verify the state hash in the CUP.

With this change we will stop executing blocks once we reach a CUP height and as a consequence we will do the full CUP verification.

Note: this change only affects the code path in ic-replay which is executed during backups.