### PR TITLE
chore: refactor QuerySource

### DIFF
--- a/rs/drun/src/message.rs
+++ b/rs/drun/src/message.rs
@@ -457,7 +457,7 @@ mod tests {
         let ingress_expiry = match &parsed_message {
             Message::Query(query) => match query.source {
                 QuerySource::User { ingress_expiry, .. } => ingress_expiry,
-                QuerySource::System => panic!("Expected a user query but got an anonymous one"),
+                QuerySource::System => panic!("Expected a user query but got a system one"),
             },
             _ => panic!(
                 "parse_message() returned an unexpected message type: {:?}",

--- a/rs/drun/src/message.rs
+++ b/rs/drun/src/message.rs
@@ -457,7 +457,7 @@ mod tests {
         let ingress_expiry = match &parsed_message {
             Message::Query(query) => match query.source {
                 QuerySource::User { ingress_expiry, .. } => ingress_expiry,
-                QuerySource::Anonymous => panic!("Expected a user query but got an anonymous one"),
+                QuerySource::System => panic!("Expected a user query but got an anonymous one"),
             },
             _ => panic!(
                 "parse_message() returned an unexpected message type: {:?}",

--- a/rs/execution_environment/src/query_handler/query_cache.rs
+++ b/rs/execution_environment/src/query_handler/query_cache.rs
@@ -155,7 +155,7 @@ impl From<&Query> for EntryKey {
         Self {
             source: match query.source {
                 QuerySource::User { user_id, .. } => user_id,
-                QuerySource::Anonymous => UserId::from(PrincipalId::default()),
+                QuerySource::System => UserId::from(PrincipalId::default()),
             },
             receiver: query.receiver,
             method_name: query.method_name.clone(),

--- a/rs/execution_environment/src/query_handler/query_cache.rs
+++ b/rs/execution_environment/src/query_handler/query_cache.rs
@@ -5,10 +5,7 @@ use ic_metrics::MetricsRegistry;
 use ic_query_stats::QueryStatsCollector;
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
-    batch::QueryStats,
-    ingress::WasmResult,
-    messages::{Query, QuerySource},
-    Cycles, MemoryDiskBytes, PrincipalId, Time, UserId,
+    batch::QueryStats, ingress::WasmResult, messages::Query, Cycles, MemoryDiskBytes, Time, UserId,
 };
 use ic_utils_lru_cache::LruCache;
 use prometheus::{Histogram, IntCounter, IntGauge};
@@ -153,10 +150,7 @@ impl MemoryDiskBytes for EntryKey {
 impl From<&Query> for EntryKey {
     fn from(query: &Query) -> Self {
         Self {
-            source: match query.source {
-                QuerySource::User { user_id, .. } => user_id,
-                QuerySource::System => UserId::from(PrincipalId::default()),
-            },
+            source: query.source.user_id(),
             receiver: query.receiver,
             method_name: query.method_name.clone(),
             method_payload: query.method_payload.clone(),

--- a/rs/execution_environment/src/query_handler/query_context.rs
+++ b/rs/execution_environment/src/query_handler/query_context.rs
@@ -219,13 +219,16 @@ impl<'a> QueryContext<'a> {
             }
         };
 
-        if let QuerySource::Anonymous = query.source {
-            if let WasmMethod::CompositeQuery(_) = &method {
-                info!(
-                    self.log,
-                    "Running composite canister http transform on canister {}.", query.receiver
-                );
+        match query.source {
+            QuerySource::System => {
+                if let WasmMethod::CompositeQuery(_) = &method {
+                    info!(
+                        self.log,
+                        "Running composite canister http transform on canister {}.", query.receiver
+                    );
+                }
             }
+            QuerySource::User { .. } => (),
         }
 
         let instructions_before = self.round_limits.instructions;
@@ -276,16 +279,19 @@ impl<'a> QueryContext<'a> {
             }
         };
 
-        if let QuerySource::Anonymous = query.source {
-            let instructions_consumed = instructions_before - self.round_limits.instructions;
-            if instructions_consumed >= RoundInstructions::from(100_000_000) {
-                info!(
-                    self.log,
-                    "Canister http transform on canister {} consumed {} instructions.",
-                    canister_id,
-                    instructions_consumed
-                );
+        match query.source {
+            QuerySource::System => {
+                let instructions_consumed = instructions_before - self.round_limits.instructions;
+                if instructions_consumed >= RoundInstructions::from(100_000_000) {
+                    info!(
+                        self.log,
+                        "Canister http transform on canister {} consumed {} instructions.",
+                        canister_id,
+                        instructions_consumed
+                    );
+                }
             }
+            QuerySource::User { .. } => (),
         }
 
         result

--- a/rs/execution_environment/src/query_handler/query_scheduler.rs
+++ b/rs/execution_environment/src/query_handler/query_scheduler.rs
@@ -26,7 +26,7 @@ pub(crate) enum QuerySchedulerFlag {
 }
 
 /// The query scheduler accepts and executes non-replicated queries (user
-/// queries, anonymous queries, and ingress filter queries). It currently
+/// queries, system queries, and ingress filter queries). It currently
 /// schedules each canister that has queries in a round-robin fashion.
 /// When a canister is scheduled and starts executing, it is allowed to execute
 /// multiple queries until it reaches the `time_slice_per_canister` limit.

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -3823,9 +3823,9 @@ fn ic0_trap_preserves_some_cycles() {
     );
 }
 
-// If method is not exported, `execute_anonymous_query` fails.
+// If method is not exported, `execute_system_query` fails.
 #[test]
-fn canister_anonymous_query_method_not_exported() {
+fn canister_system_query_method_not_exported() {
     let mut test = ExecutionTestBuilder::new().build();
     let wat = r#"
         (module
@@ -3833,7 +3833,7 @@ fn canister_anonymous_query_method_not_exported() {
             (export "memory" (memory $memory))
         )"#;
     let canister_id = test.canister_from_wat(wat).unwrap();
-    let result = test.anonymous_query(canister_id, "http_transform", vec![], vec![]);
+    let result = test.system_query(canister_id, "http_transform", vec![], vec![]);
     assert_eq!(
         result,
         Err(
@@ -3843,9 +3843,9 @@ fn canister_anonymous_query_method_not_exported() {
     );
 }
 
-// Using `execute_anonymous_query` to execute transform function on a http response succeeds.
+// Using `execute_system_query` to execute transform function on a http response succeeds.
 #[test]
-fn canister_anonymous_query_transform_http_response() {
+fn canister_system_query_transform_http_response() {
     let mut test = ExecutionTestBuilder::new().build();
     let wat = r#"
         (module
@@ -3881,7 +3881,7 @@ fn canister_anonymous_query_transform_http_response() {
         body: vec![0, 1, 2],
     };
     let payload = Encode!(&canister_http_response).unwrap();
-    let result = test.anonymous_query(canister_id, "http_transform", payload, vec![]);
+    let result = test.system_query(canister_id, "http_transform", payload, vec![]);
     let transformed_canister_http_response = Decode!(
         result.unwrap().bytes().as_slice(),
         CanisterHttpResponsePayload

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -303,7 +303,7 @@ async fn transform_adapter_response(
 
     // Query to execution.
     let query = Query {
-        source: QuerySource::Anonymous,
+        source: QuerySource::System,
         receiver: transform_canister,
         method_name: transform.method_name.to_string(),
         method_payload,
@@ -500,7 +500,7 @@ mod tests {
         }
     }
 
-    fn setup_anonymous_query_mock() -> (
+    fn setup_system_query_mock() -> (
         QueryExecutionService,
         Handle<(Query, Option<CertificateDelegation>), QueryExecutionResponse>,
     ) {
@@ -555,7 +555,7 @@ mod tests {
         .await;
 
         // Asynchronous query handler mock setup. Does not serve any purpose in this test case.
-        let (svc, mut handle) = setup_anonymous_query_mock();
+        let (svc, mut handle) = setup_system_query_mock();
 
         tokio::spawn(async move {
             let (_, rsp) = handle.next_request().await.unwrap();
@@ -610,7 +610,7 @@ mod tests {
         let mock_grpc_channel =
             setup_adapter_mock(Err((Code::Unavailable, "adapter unavailable".to_string()))).await;
         // Asynchronous query handler mock setup. Does not serve any purpose in this test case.
-        let (svc, mut handle) = setup_anonymous_query_mock();
+        let (svc, mut handle) = setup_system_query_mock();
 
         tokio::spawn(async move {
             let (_, rsp) = handle.next_request().await.unwrap();
@@ -664,7 +664,7 @@ mod tests {
         }))
         .await;
         // Asynchronous query handler mock setup. Does not serve any purpose in this test case.
-        let (svc, mut handle) = setup_anonymous_query_mock();
+        let (svc, mut handle) = setup_system_query_mock();
 
         tokio::spawn(async move {
             let (req, rsp) = handle.next_request().await.unwrap();
@@ -734,7 +734,7 @@ mod tests {
         )))
         .await;
         // Asynchronous query handler mock setup. Does not serve any purpose in this test case.
-        let (svc, mut handle) = setup_anonymous_query_mock();
+        let (svc, mut handle) = setup_system_query_mock();
 
         tokio::spawn(async move {
             let (_, rsp) = handle.next_request().await.unwrap();
@@ -802,7 +802,7 @@ mod tests {
         }))
         .await;
         // Asynchronous query handler mock setup. Does not serve any purpose in this test case.
-        let (svc, mut handle) = setup_anonymous_query_mock();
+        let (svc, mut handle) = setup_system_query_mock();
 
         let adapter_h = adapter_headers.clone();
         let adapter_b = adapter_body.clone();
@@ -841,7 +841,7 @@ mod tests {
             rx,
         );
 
-        // Specify a transform_method name such that the client calls the anonymous query handler.
+        // Specify a transform_method name such that the client calls the system query handler.
         assert_eq!(
             client.send(build_mock_canister_http_request(
                 420,
@@ -873,7 +873,7 @@ mod tests {
         assert_eq!(client.try_receive(), Err(TryReceiveError::Empty));
     }
 
-    // Test case for anonymous query rejection. The client should pass through the rejection received from the query handler.
+    // Test case for system query rejection. The client should pass through the rejection received from the query handler.
     #[tokio::test]
     async fn test_client_transform_reject() {
         let adapter_body = "<html>
@@ -897,7 +897,7 @@ mod tests {
         }))
         .await;
         // Asynchronous query handler mock setup. Does not serve any purpose in this test case.
-        let (svc, mut handle) = setup_anonymous_query_mock();
+        let (svc, mut handle) = setup_system_query_mock();
 
         tokio::spawn(async move {
             let (_, rsp) = handle.next_request().await.unwrap();
@@ -916,7 +916,7 @@ mod tests {
             rx,
         );
 
-        // Specify a transform_method name such that the client calls the anonymous query handler.
+        // Specify a transform_method name such that the client calls the system query handler.
         assert_eq!(
             client.send(build_mock_canister_http_request(
                 420,
@@ -953,7 +953,7 @@ mod tests {
         let mock_grpc_channel =
             setup_adapter_mock(Err((Code::Unavailable, "adapter unavailable".to_string()))).await;
         // Asynchronous query handler mock setup. Does not serve any purpose in this test case.
-        let (svc, mut handle) = setup_anonymous_query_mock();
+        let (svc, mut handle) = setup_system_query_mock();
 
         tokio::spawn(async move {
             let (_, rsp) = handle.next_request().await.unwrap();

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1124,8 +1124,8 @@ impl ExecutionTest {
         );
     }
 
-    /// Executes an anonymous query in the given canister.
-    pub fn anonymous_query<S: ToString>(
+    /// Executes a query sent by the system in the given canister.
+    pub fn system_query<S: ToString>(
         &mut self,
         canister_id: CanisterId,
         method_name: S,
@@ -1135,7 +1135,7 @@ impl ExecutionTest {
         let state = Arc::new(self.state.take().unwrap());
 
         let query = Query {
-            source: QuerySource::Anonymous,
+            source: QuerySource::System,
             receiver: canister_id,
             method_name: method_name.to_string(),
             method_payload,

--- a/rs/types/types/src/messages/http.rs
+++ b/rs/types/types/src/messages/http.rs
@@ -335,10 +335,7 @@ impl HttpRequestContent for Query {
     }
 
     fn sender(&self) -> UserId {
-        match self.source {
-            QuerySource::User { user_id, .. } => user_id,
-            QuerySource::System => UserId::from(PrincipalId::default()),
-        }
+        self.source.user_id()
     }
 
     fn ingress_expiry(&self) -> u64 {

--- a/rs/types/types/src/messages/http.rs
+++ b/rs/types/types/src/messages/http.rs
@@ -337,21 +337,21 @@ impl HttpRequestContent for Query {
     fn sender(&self) -> UserId {
         match self.source {
             QuerySource::User { user_id, .. } => user_id,
-            QuerySource::Anonymous => UserId::from(PrincipalId::default()),
+            QuerySource::System => UserId::from(PrincipalId::default()),
         }
     }
 
     fn ingress_expiry(&self) -> u64 {
         match self.source {
             QuerySource::User { ingress_expiry, .. } => ingress_expiry,
-            QuerySource::Anonymous => 0,
+            QuerySource::System => 0,
         }
     }
 
     fn nonce(&self) -> Option<Vec<u8>> {
         match &self.source {
             QuerySource::User { nonce, .. } => nonce.clone(),
-            QuerySource::Anonymous => None,
+            QuerySource::System => None,
         }
     }
 }

--- a/rs/types/types/src/messages/query.rs
+++ b/rs/types/types/src/messages/query.rs
@@ -21,6 +21,16 @@ pub enum QuerySource {
     },
 }
 
+impl QuerySource {
+    pub fn user_id(&self) -> UserId {
+        let principal_id = match self {
+            QuerySource::User { user_id, .. } => user_id.get(),
+            QuerySource::System => IC_00.get(),
+        };
+        UserId::from(principal_id)
+    }
+}
+
 /// Represents a Query that is sent by an end user to a canister.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Query {
@@ -32,10 +42,7 @@ pub struct Query {
 
 impl Query {
     pub fn source(&self) -> PrincipalId {
-        match &self.source {
-            QuerySource::User { user_id, .. } => user_id.get(),
-            QuerySource::System => IC_00.get(),
-        }
+        self.source.user_id().get()
     }
 
     pub fn id(&self) -> MessageId {

--- a/rs/types/types/src/messages/query.rs
+++ b/rs/types/types/src/messages/query.rs
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum QuerySource {
     /// A query sent by the IC to itself.
-    Anonymous,
+    System,
     /// A query sent by an end user.
     User {
         user_id: UserId,
@@ -34,7 +34,7 @@ impl Query {
     pub fn source(&self) -> PrincipalId {
         match &self.source {
             QuerySource::User { user_id, .. } => user_id.get(),
-            QuerySource::Anonymous => IC_00.get(),
+            QuerySource::System => IC_00.get(),
         }
     }
 
@@ -53,17 +53,15 @@ impl Query {
                 user_id.get().into_vec(),
                 nonce.as_deref(),
             )),
-            QuerySource::Anonymous => {
-                MessageId::from(representation_independent_hash_call_or_query(
-                    CallOrQuery::Query,
-                    self.receiver.get().into_vec(),
-                    &self.method_name,
-                    self.method_payload.clone(),
-                    0,
-                    IC_00.get().into_vec(),
-                    None,
-                ))
-            }
+            QuerySource::System => MessageId::from(representation_independent_hash_call_or_query(
+                CallOrQuery::Query,
+                self.receiver.get().into_vec(),
+                &self.method_name,
+                self.method_payload.clone(),
+                0,
+                IC_00.get().into_vec(),
+                None,
+            )),
         }
     }
 }

--- a/rs/validator/ingress_message/tests/validate_request.rs
+++ b/rs/validator/ingress_message/tests/validate_request.rs
@@ -292,7 +292,7 @@ mod ingress_expiry {
     }
 
     #[test]
-    fn should_not_error_when_anonymous_query_expired() {
+    fn should_not_error_when_system_query_expired() {
         let verifier = verifier_at_time(CURRENT_TIME).build();
         let request = HttpRequestBuilder::new_query()
             .with_authentication(AuthenticationScheme::Anonymous)


### PR DESCRIPTION
This PR
- renames `QuerySource::Anonymous` to `QuerySource::System` since the caller of such a query is the management canister (rather than the anonymous principal) and queries with such a source are triggered by the protocol (system) for canister http outcalls;
- introduces a function `QuerySource::user_id` that is used to avoid code duplication.