### PR TITLE
chore: Critical error for non-empty page delta at SerializeToTip

### DIFF
--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -105,6 +105,10 @@ pub(crate) const CRITICAL_ERROR_CHECKPOINT_SOFT_INVARIANT_BROKEN: &str =
 const CRITICAL_ERROR_REPLICATED_STATE_ALTERED_AFTER_CHECKPOINT: &str =
     "state_manager_replicated_state_altered_after_checkpoint";
 
+/// Critical error tracking non-empty PageDelta at SerializeToTip
+const CRITICAL_ERROR_NON_EMPTY_PAGE_DELTA_AT_SERIALIZE_TO_TIP: &str =
+    "state_manager_non_empty_page_delta_at_serialize_to_tip";
+
 /// How long to keep archived and diverged states.
 const ARCHIVED_DIVERGED_CHECKPOINT_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60); // 30 days
 
@@ -191,6 +195,7 @@ pub struct CheckpointMetrics {
     replicated_state_altered_after_checkpoint: IntCounter,
     tip_handler_request_duration: HistogramVec,
     num_page_maps_by_load_status: IntGaugeVec,
+    non_empty_page_delta_at_serialize_to_tip_critical: IntCounter,
     log: ReplicaLogger,
 }
 
@@ -246,6 +251,8 @@ impl CheckpointMetrics {
             replicated_state_altered_after_checkpoint,
             tip_handler_request_duration,
             num_page_maps_by_load_status,
+            non_empty_page_delta_at_serialize_to_tip_critical: metrics_registry
+                .error_counter(CRITICAL_ERROR_NON_EMPTY_PAGE_DELTA_AT_SERIALIZE_TO_TIP),
             log: replica_logger,
         }
     }

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -839,7 +839,7 @@ fn serialize_to_tip(
                 canister_snapshot.0,
                 canister_snapshot.1,
                 tip,
-                &metrics,
+                metrics,
                 lsmt_config,
             )
         },


### PR DESCRIPTION
We call FlushPageMapDelta before SerializeToTip, so page map deltas should be empty.
In SerializeToTip we still try to flush them, which should always be a noop. This code is not well tested in production and doesn't truncate, which could lead to bugs if it ever triggers.
This PR is a first stage in phasing it out: making sure it never triggers indeed.