### PR TITLE
fix(nns): Turn off disburse maturity which was incorrectly turned on

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -207,8 +207,7 @@ thread_local! {
     static DISABLE_NF_FUND_PROPOSALS: Cell<bool>
         = const { Cell::new(cfg!(not(any(feature = "canbench-rs", feature = "test")))) };
 
-    static IS_DISBURSE_MATURITY_ENABLED: Cell<bool>
-        = const { Cell::new(cfg!(not(any(feature = "canbench-rs", feature = "test")))) };
+    static IS_DISBURSE_MATURITY_ENABLED: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 
     static USE_NODE_PROVIDER_REWARD_CANISTER: Cell<bool>
         = const { Cell::new(cfg!(feature = "test")) };

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -19,4 +19,6 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* Turned off `DisburseMaturity` that was incorrectly turned on before.
+
 ## Security

--- a/rs/nns/nns.bzl
+++ b/rs/nns/nns.bzl
@@ -17,7 +17,7 @@ CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES = {
     "cycles-minting-canister.wasm.gz": 6,
     "genesis-token-canister.wasm.gz": 3,
     "governance-canister.wasm.gz": 17,
-    "governance-canister_test.wasm.gz": 18,
+    "governance-canister_test.wasm.gz": 19,
     "registry-canister.wasm.gz": 14,
     "root-canister.wasm.gz": 4,
 }


### PR DESCRIPTION
The condition to turn on disburse maturity was incorrectly copied from `DISABLE_NF_FUND_PROPOSALS` (which was on at the time). This PR correctly turns it back off.