### PR TITLE
feat(registry): Node Rewards can target a specific version

### DIFF
--- a/rs/registry/canister/api/src/lib.rs
+++ b/rs/registry/canister/api/src/lib.rs
@@ -160,6 +160,11 @@ impl fmt::Display for IPv4Config {
     }
 }
 
+#[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize)]
+pub struct GetNodeProvidersMonthlyXdrRewardsRequest {
+    pub registry_version: Option<u64>,
+}
+
 /// The payload of an update request to add a new node.
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct AddNodePayload {

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -14,8 +14,8 @@ use ic_protobuf::registry::{
     node_rewards::v2::UpdateNodeRewardsTableProposalPayload,
 };
 use ic_registry_canister_api::{
-    AddNodePayload, Chunk, GetChunkRequest, UpdateNodeDirectlyPayload,
-    UpdateNodeIPv4ConfigDirectlyPayload,
+    AddNodePayload, Chunk, GetChunkRequest, GetNodeProvidersMonthlyXdrRewardsRequest,
+    UpdateNodeDirectlyPayload, UpdateNodeIPv4ConfigDirectlyPayload,
 };
 use ic_registry_transport::{
     deserialize_atomic_mutate_request, deserialize_get_changes_since_request,
@@ -912,15 +912,17 @@ fn get_node_providers_monthly_xdr_rewards() {
     check_caller_is_governance_and_log("get_node_providers_monthly_xdr_rewards");
     over(
         candid_one,
-        |()| -> Result<NodeProvidersMonthlyXdrRewards, String> {
-            get_node_providers_monthly_xdr_rewards_()
+        |request: Option<GetNodeProvidersMonthlyXdrRewardsRequest>| -> Result<NodeProvidersMonthlyXdrRewards, String> {
+            get_node_providers_monthly_xdr_rewards_(request)
         },
     )
 }
 
 #[candid_method(query, rename = "get_node_providers_monthly_xdr_rewards")]
-fn get_node_providers_monthly_xdr_rewards_() -> Result<NodeProvidersMonthlyXdrRewards, String> {
-    registry().get_node_providers_monthly_xdr_rewards()
+fn get_node_providers_monthly_xdr_rewards_(
+    arg: Option<GetNodeProvidersMonthlyXdrRewardsRequest>,
+) -> Result<NodeProvidersMonthlyXdrRewards, String> {
+    registry().get_node_providers_monthly_xdr_rewards(arg.unwrap_or_default())
 }
 
 #[export_name = "canister_query get_api_boundary_node_ids"]

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -227,6 +227,10 @@ type GetSubnetForCanisterResponse = variant {
   Err : text;
 };
 
+type GetNodeProvidersMonthlyXdrRewardsRequest = record {
+    registry_version: opt nat64;
+};
+
 type Gps = record { latitude : float32; longitude : float32 };
 
 type IPv4Config = record {
@@ -470,7 +474,7 @@ service : {
   get_build_metadata : () -> (text) query;
   get_chunk : (GetChunkRequest) -> (GetChunkResponse) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
-  get_node_providers_monthly_xdr_rewards : () -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
+  get_node_providers_monthly_xdr_rewards : (opt GetNodeProvidersMonthlyXdrRewardsRequest) -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
   get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (GetSubnetForCanisterResponse) query;
   prepare_canister_migration : (PrepareCanisterMigrationPayload) -> ();
   recover_subnet : (RecoverSubnetPayload) -> ();

--- a/rs/registry/canister/src/get_node_providers_monthly_xdr_rewards.rs
+++ b/rs/registry/canister/src/get_node_providers_monthly_xdr_rewards.rs
@@ -290,6 +290,9 @@ mod tests {
             Some(registry.latest_version())
         );
 
+        // Store this version to test specific version requests later.
+        let version_without_rewards_table = registry.latest_version();
+
         ///////////////////////////////
         // Now add the reward table for type0 and type2 nodes and check that the values are properly used
         ///////////////////////////////
@@ -353,6 +356,22 @@ mod tests {
         assert_eq!(
             *monthly_rewards.rewards.get(&np2.to_string()).unwrap(),
             (11 * 68) + (7 * 11)
+        );
+
+        ///////////////////////////////
+        // Test getting a previous version's rewards works
+        ///////////////////////////////
+        let monthly_rewards = registry
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: Some(version_without_rewards_table),
+            })
+            .unwrap();
+        let np1 = TEST_USER1_PRINCIPAL.to_string();
+        let np1_rewards = monthly_rewards.rewards.get(&np1).unwrap();
+        assert_eq!(*np1_rewards, 5); // 5 nodes at 1 XDR/month/node
+        assert_eq!(
+            monthly_rewards.registry_version,
+            Some(version_without_rewards_table)
         );
     }
 

--- a/rs/registry/canister/src/get_node_providers_monthly_xdr_rewards.rs
+++ b/rs/registry/canister/src/get_node_providers_monthly_xdr_rewards.rs
@@ -1,12 +1,10 @@
-use crate::{
-    mutations::node_management::common::{get_key_family, get_key_family_iter},
-    pb::v1::NodeProvidersMonthlyXdrRewards,
-    registry::Registry,
-};
+use crate::mutations::node_management::common::get_key_family_iter_at_version;
+use crate::{pb::v1::NodeProvidersMonthlyXdrRewards, registry::Registry};
 use ic_protobuf::registry::{
     dc::v1::DataCenterRecord, node_operator::v1::NodeOperatorRecord,
     node_rewards::v2::NodeRewardsTable,
 };
+use ic_registry_canister_api::GetNodeProvidersMonthlyXdrRewardsRequest;
 use ic_registry_keys::{
     DATA_CENTER_KEY_PREFIX, NODE_OPERATOR_RECORD_KEY_PREFIX, NODE_REWARDS_TABLE_KEY,
 };
@@ -20,22 +18,33 @@ impl Registry {
     /// Computer for the month.
     pub fn get_node_providers_monthly_xdr_rewards(
         &self,
+        request: GetNodeProvidersMonthlyXdrRewardsRequest,
     ) -> Result<NodeProvidersMonthlyXdrRewards, String> {
         let mut rewards = NodeProvidersMonthlyXdrRewards::default();
 
+        let version = request.registry_version.unwrap_or(self.latest_version());
+
         let rewards_table_bytes = self
-            .get(NODE_REWARDS_TABLE_KEY.as_bytes(), self.latest_version())
+            .get(NODE_REWARDS_TABLE_KEY.as_bytes(), version)
             .ok_or_else(|| "Node Rewards Table was not found in the Registry".to_string())?
             .value
             .clone();
 
         let rewards_table = NodeRewardsTable::decode(rewards_table_bytes.as_slice()).unwrap();
 
-        let node_operators =
-            get_key_family::<NodeOperatorRecord>(self, NODE_OPERATOR_RECORD_KEY_PREFIX);
+        let node_operators = get_key_family_iter_at_version::<NodeOperatorRecord>(
+            self,
+            NODE_OPERATOR_RECORD_KEY_PREFIX,
+            version,
+        )
+        .collect::<Vec<_>>();
 
-        let data_centers = get_key_family_iter::<DataCenterRecord>(self, DATA_CENTER_KEY_PREFIX)
-            .collect::<BTreeMap<String, DataCenterRecord>>();
+        let data_centers = get_key_family_iter_at_version::<DataCenterRecord>(
+            self,
+            DATA_CENTER_KEY_PREFIX,
+            version,
+        )
+        .collect::<BTreeMap<String, DataCenterRecord>>();
 
         let reward_values = calculate_rewards_v0(&rewards_table, &node_operators, &data_centers)?;
 
@@ -45,7 +54,7 @@ impl Registry {
             .map(|(k, v)| (k.to_string(), v))
             .collect();
 
-        rewards.registry_version = Some(self.latest_version());
+        rewards.registry_version = Some(version);
 
         Ok(rewards)
     }
@@ -109,7 +118,9 @@ mod tests {
 
         assert_eq!(
             registry
-                .get_node_providers_monthly_xdr_rewards()
+                .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                    registry_version: None
+                })
                 .unwrap()
                 .rewards,
             std::collections::HashMap::new()
@@ -123,7 +134,9 @@ mod tests {
         // Assert get_node_providers_monthly_xdr_rewards fails because no rewards table
         // exists in the Registry
         let err = registry
-            .get_node_providers_monthly_xdr_rewards()
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: None,
+            })
             .unwrap_err();
         assert_eq!(&err, "Node Rewards Table was not found in the Registry");
 
@@ -142,7 +155,9 @@ mod tests {
     ) -> Registry {
         // Assert get_node_providers_monthly_xdr_rewards fails because the DC is not yet in the Registry
         let err = registry
-            .get_node_providers_monthly_xdr_rewards()
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: None,
+            })
             .unwrap_err();
         assert!(err.contains(&format!(
             "has data center ID '{}' not found in the Registry",
@@ -199,7 +214,11 @@ mod tests {
 
         // Assert get_node_providers_monthly_xdr_rewards defaults to 1 XDR per month per node
         // because there rewards table does not have an entry for the DC's region
-        let monthly_rewards = registry.get_node_providers_monthly_xdr_rewards().unwrap();
+        let monthly_rewards = registry
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: None,
+            })
+            .unwrap();
         let np_monthly_rewards = monthly_rewards
             .rewards
             .get(&np_principal.to_string())
@@ -258,7 +277,11 @@ mod tests {
         ///////////////////////////////
         // Assert get_node_providers_monthly_xdr_rewards still provides default values
         ///////////////////////////////
-        let monthly_rewards = registry.get_node_providers_monthly_xdr_rewards().unwrap();
+        let monthly_rewards = registry
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: None,
+            })
+            .unwrap();
         let np1 = TEST_USER1_PRINCIPAL.to_string();
         let np1_rewards = monthly_rewards.rewards.get(&np1).unwrap();
         assert_eq!(*np1_rewards, 5); // 5 nodes at 1 XDR/month/node
@@ -282,7 +305,11 @@ mod tests {
         let node_rewards_payload = UpdateNodeRewardsTableProposalPayload::from(map);
         registry.do_update_node_rewards_table(node_rewards_payload);
 
-        let monthly_rewards = registry.get_node_providers_monthly_xdr_rewards().unwrap();
+        let monthly_rewards = registry
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: None,
+            })
+            .unwrap();
 
         // NP1: 4 'type0' nodes in 'North America,US,NY' + 1 'type2' node in 'North America,US'
         assert_eq!(
@@ -311,7 +338,11 @@ mod tests {
         let node_rewards_payload = UpdateNodeRewardsTableProposalPayload::from(map);
         registry.do_update_node_rewards_table(node_rewards_payload);
 
-        let monthly_rewards = registry.get_node_providers_monthly_xdr_rewards().unwrap();
+        let monthly_rewards = registry
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: None,
+            })
+            .unwrap();
 
         // NP1: 4 'type0' nodes in 'North America,US,NY' + 1 'type2' node in 'North America,US'
         assert_eq!(
@@ -373,7 +404,11 @@ mod tests {
         let node_rewards_payload = UpdateNodeRewardsTableProposalPayload::from(map);
         registry.do_update_node_rewards_table(node_rewards_payload);
 
-        let monthly_rewards = registry.get_node_providers_monthly_xdr_rewards().unwrap();
+        let monthly_rewards = registry
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: None,
+            })
+            .unwrap();
 
         assert_eq!(
             monthly_rewards.registry_version,
@@ -421,7 +456,11 @@ mod tests {
             node_reward_de *= 0.7;
         }
 
-        let monthly_rewards = registry.get_node_providers_monthly_xdr_rewards().unwrap();
+        let monthly_rewards = registry
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: None,
+            })
+            .unwrap();
         assert_eq!(
             *monthly_rewards.rewards.get(&np2.to_string()).unwrap(),
             np2_expected_reward_ch + np2_expected_reward_de
@@ -447,7 +486,11 @@ mod tests {
             node_reward_ch *= 0.7;
         }
 
-        let monthly_rewards = registry.get_node_providers_monthly_xdr_rewards().unwrap();
+        let monthly_rewards = registry
+            .get_node_providers_monthly_xdr_rewards(GetNodeProvidersMonthlyXdrRewardsRequest {
+                registry_version: None,
+            })
+            .unwrap();
         assert_eq!(
             *monthly_rewards.rewards.get(&np2.to_string()).unwrap(),
             np2_expected_reward_ch + np2_expected_reward_de

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -11,6 +11,9 @@ on the process that this file is part of, see
 
 ## Changed
 
+* `get_node_providers_monthly_xdr_rewards` can now take an optional paramter to specify the Registry version to use when
+  calculating the rewards.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
# What
This allows the function in Registry that calculates rewards to take a particular version.

# Why

This is needed for fully testing historical data against the Registry and the new Node Rewards canister to ensure parity.