### PR TITLE
fix(consnesus): Fix reshare chain key validation

### DIFF
--- a/rs/consensus/idkg/src/payload_verifier.rs
+++ b/rs/consensus/idkg/src/payload_verifier.rs
@@ -551,7 +551,7 @@ fn decode_initial_dealings(data: &[u8]) -> Result<InitialIDkgDealings, InvalidID
                 ReshareChainKeyResponse::IDkg(initial_idkg_dealings) => initial_idkg_dealings,
                 ReshareChainKeyResponse::NiDkg(_) => {
                     return Err(InvalidIDkgPayloadReason::DecodingError(
-                        "Found an IDkg response".to_string(),
+                        "Found an NiDkg response".to_string(),
                     ))
                 }
             }


### PR DESCRIPTION
This PR fixes a an issue that was uncovered when testing to migrate the registry to the new`reshare_chain_key` endpoint.

The validation function still decodes the response and was not adapted to handle both possible decodings.