### PR TITLE
test: Increase subnet size to 4 nodes in recovery tests

### DIFF
--- a/rs/tests/consensus/orchestrator/rotate_ecdsa_idkg_key_test.rs
+++ b/rs/tests/consensus/orchestrator/rotate_ecdsa_idkg_key_test.rs
@@ -48,7 +48,7 @@ use ic_types::Height;
 use slog::{info, warn, Logger};
 
 const DKG_INTERVAL: u64 = 9;
-const SUBNET_SIZE: usize = 3;
+const SUBNET_SIZE: usize = 4;
 
 fn setup(env: TestEnv) {
     InternetComputer::new()

--- a/rs/tests/consensus/orchestrator/rotate_ecdsa_idkg_key_test.rs
+++ b/rs/tests/consensus/orchestrator/rotate_ecdsa_idkg_key_test.rs
@@ -48,7 +48,7 @@ use ic_types::Height;
 use slog::{info, warn, Logger};
 
 const DKG_INTERVAL: u64 = 9;
-const SUBNET_SIZE: usize = 4;
+const SUBNET_SIZE: usize = 3;
 
 fn setup(env: TestEnv) {
     InternetComputer::new()

--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -96,7 +96,7 @@ pub fn setup(
     let nns_nodes = nns_nodes.unwrap_or(4);
     let mut nns = Subnet::new(SubnetType::System)
         .with_dkg_interval_length(Height::from(dkg_interval))
-        .add_nodes(4);
+        .add_nodes(nns_nodes);
 
     // TODO(CON-1471): Add a VetKD key ID
     let key_ids = make_key_ids_for_all_idkg_schemes();

--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -75,9 +75,9 @@ use std::{io::Write, path::Path};
 use url::Url;
 
 const DKG_INTERVAL: u64 = 9;
-const NNS_NODES: usize = 3;
-const APP_NODES: usize = 3;
-const UNASSIGNED_NODES: usize = 3;
+const NNS_NODES: usize = 4;
+const APP_NODES: usize = 4;
+const UNASSIGNED_NODES: usize = 4;
 
 const DKG_INTERVAL_LARGE: u64 = 99;
 const NNS_NODES_LARGE: usize = 40;
@@ -88,13 +88,12 @@ pub const CHAIN_KEY_SUBNET_RECOVERY_TIMEOUT: Duration = Duration::from_secs(15 *
 /// Setup an IC with the given number of unassigned nodes and
 /// an app subnet with the given number of nodes
 pub fn setup(
-    nns_nodes: Option<usize>,
+    nns_nodes: usize,
     app_nodes: usize,
     unassigned_nodes: usize,
     dkg_interval: u64,
     env: TestEnv,
 ) {
-    let nns_nodes = nns_nodes.unwrap_or(NNS_NODES);
     let mut nns = Subnet::new(SubnetType::System)
         .with_dkg_interval_length(Height::from(dkg_interval))
         .add_nodes(nns_nodes);
@@ -132,29 +131,29 @@ pub fn setup(
 }
 
 pub fn setup_large_tecdsa(env: TestEnv) {
+    setup(NNS_NODES_LARGE, 0, APP_NODES_LARGE, DKG_INTERVAL_LARGE, env);
+}
+
+pub fn setup_same_nodes_tecdsa(env: TestEnv) {
+    setup(NNS_NODES, 0, APP_NODES, DKG_INTERVAL, env);
+}
+
+pub fn setup_failover_nodes_tecdsa(env: TestEnv) {
     setup(
-        Some(NNS_NODES_LARGE),
+        NNS_NODES,
         0,
-        APP_NODES_LARGE,
-        DKG_INTERVAL_LARGE,
+        APP_NODES + UNASSIGNED_NODES,
+        DKG_INTERVAL,
         env,
     );
 }
 
-pub fn setup_same_nodes_tecdsa(env: TestEnv) {
-    setup(None, 0, APP_NODES, DKG_INTERVAL, env);
-}
-
-pub fn setup_failover_nodes_tecdsa(env: TestEnv) {
-    setup(None, 0, APP_NODES + UNASSIGNED_NODES, DKG_INTERVAL, env);
-}
-
 pub fn setup_same_nodes(env: TestEnv) {
-    setup(None, APP_NODES, 0, DKG_INTERVAL, env);
+    setup(NNS_NODES, APP_NODES, 0, DKG_INTERVAL, env);
 }
 
 pub fn setup_failover_nodes(env: TestEnv) {
-    setup(None, APP_NODES, UNASSIGNED_NODES, DKG_INTERVAL, env);
+    setup(NNS_NODES, APP_NODES, UNASSIGNED_NODES, DKG_INTERVAL, env);
 }
 
 struct Config {

--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -75,8 +75,8 @@ use std::{io::Write, path::Path};
 use url::Url;
 
 const DKG_INTERVAL: u64 = 9;
-const APP_NODES: usize = 3;
-const UNASSIGNED_NODES: usize = 3;
+const APP_NODES: usize = 4;
+const UNASSIGNED_NODES: usize = 4;
 
 const DKG_INTERVAL_LARGE: u64 = 99;
 const NNS_NODES_LARGE: usize = 40;
@@ -93,14 +93,11 @@ pub fn setup(
     dkg_interval: u64,
     env: TestEnv,
 ) {
-    let mut nns = if let Some(nns_nodes) = nns_nodes {
-        Subnet::new(SubnetType::System)
-            .with_dkg_interval_length(Height::from(dkg_interval))
-            .add_nodes(nns_nodes)
-    } else {
-        Subnet::fast_single_node(SubnetType::System)
-            .with_dkg_interval_length(Height::from(dkg_interval))
-    };
+    let nns_nodes = nns_nodes.unwrap_or(4);
+    let mut nns = Subnet::new(SubnetType::System)
+        .with_dkg_interval_length(Height::from(dkg_interval))
+        .add_nodes(4);
+
     // TODO(CON-1471): Add a VetKD key ID
     let key_ids = make_key_ids_for_all_idkg_schemes();
     let key_configs = key_ids

--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -75,8 +75,9 @@ use std::{io::Write, path::Path};
 use url::Url;
 
 const DKG_INTERVAL: u64 = 9;
-const APP_NODES: usize = 4;
-const UNASSIGNED_NODES: usize = 4;
+const NNS_NODES: usize = 3;
+const APP_NODES: usize = 3;
+const UNASSIGNED_NODES: usize = 3;
 
 const DKG_INTERVAL_LARGE: u64 = 99;
 const NNS_NODES_LARGE: usize = 40;
@@ -93,7 +94,7 @@ pub fn setup(
     dkg_interval: u64,
     env: TestEnv,
 ) {
-    let nns_nodes = nns_nodes.unwrap_or(4);
+    let nns_nodes = nns_nodes.unwrap_or(NNS_NODES);
     let mut nns = Subnet::new(SubnetType::System)
         .with_dkg_interval_length(Height::from(dkg_interval))
         .add_nodes(nns_nodes);

--- a/rs/tests/consensus/subnet_recovery/sr_nns_failover_nodes_test.rs
+++ b/rs/tests/consensus/subnet_recovery/sr_nns_failover_nodes_test.rs
@@ -52,7 +52,7 @@ use std::fs;
 use url::Url;
 
 const DKG_INTERVAL: u64 = 9;
-const SUBNET_SIZE: usize = 3;
+const SUBNET_SIZE: usize = 4;
 pub const UNIVERSAL_VM_NAME: &str = "httpbin";
 
 fn main() -> Result<()> {

--- a/rs/tests/consensus/subnet_recovery/sr_nns_failover_nodes_test.rs
+++ b/rs/tests/consensus/subnet_recovery/sr_nns_failover_nodes_test.rs
@@ -52,7 +52,7 @@ use std::fs;
 use url::Url;
 
 const DKG_INTERVAL: u64 = 9;
-const SUBNET_SIZE: usize = 4;
+const SUBNET_SIZE: usize = 3;
 pub const UNIVERSAL_VM_NAME: &str = "httpbin";
 
 fn main() -> Result<()> {

--- a/rs/tests/consensus/subnet_recovery/sr_nns_same_nodes_test.rs
+++ b/rs/tests/consensus/subnet_recovery/sr_nns_same_nodes_test.rs
@@ -40,7 +40,7 @@ use slog::info;
 use std::convert::TryFrom;
 
 const DKG_INTERVAL: u64 = 9;
-const SUBNET_SIZE: usize = 4;
+const SUBNET_SIZE: usize = 3;
 
 pub fn setup(env: TestEnv) {
     InternetComputer::new()

--- a/rs/tests/consensus/subnet_recovery/sr_nns_same_nodes_test.rs
+++ b/rs/tests/consensus/subnet_recovery/sr_nns_same_nodes_test.rs
@@ -40,7 +40,7 @@ use slog::info;
 use std::convert::TryFrom;
 
 const DKG_INTERVAL: u64 = 9;
-const SUBNET_SIZE: usize = 3;
+const SUBNET_SIZE: usize = 4;
 
 pub fn setup(env: TestEnv) {
     InternetComputer::new()


### PR DESCRIPTION
Using only one node may hide subtle bugs, for instance in payload validation. This PR increases the subnet size of all subnets in recovery tests to at least 4 nodes.