### PR TITLE
test(ckbtc): Add a test case when check_transaction returns NotEnoughCycles

### DIFF
--- a/rs/bitcoin/ckbtc/minter/BUILD.bazel
+++ b/rs/bitcoin/ckbtc/minter/BUILD.bazel
@@ -125,6 +125,7 @@ rust_test(
     crate = ":ckbtc_minter_lib",
     deps = [
         # Keep sorted.
+        "@crate_index//:assert_matches",
         "@crate_index//:bitcoin_0_28",
         "@crate_index//:maplit",
         "@crate_index//:mockall",

--- a/rs/bitcoin/ckbtc/minter/src/updates/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/tests.rs
@@ -693,18 +693,15 @@ mod update_balance {
     fn expect_check_transaction_returning_responses(
         runtime: &mut MockCanisterRuntime,
         utxo: Utxo,
-        responses: Vec<CheckTransactionResponse>,
+        mut responses: Vec<CheckTransactionResponse>,
     ) {
-        let mut count = 0;
         runtime
             .expect_check_transaction()
             .times(responses.len())
             .returning(move |btc_checker_principal, utxo_, _cycles| {
                 assert!(btc_checker_principal == BTC_CHECKER_CANISTER_ID && utxo_ == &utxo);
-                assert!(count < responses.len());
-                let response = responses[count].clone();
-                count = count + 1;
-                Ok(response)
+                assert!(!responses.is_empty());
+                Ok(responses.remove(0))
             });
     }
 


### PR DESCRIPTION
XC-241: test ckBTC minter needs to call check_transaction more than once

Add a test to make sure the minter will call check_transaction again when it returns NotEnoughCycles.