### PR TITLE
fix: update parsing of power measurements via IPMI tool

### DIFF
--- a/ic-os/components/hostos-scripts/monitoring/monitor-power.sh
+++ b/ic-os/components/hostos-scripts/monitoring/monitor-power.sh
@@ -38,7 +38,7 @@ write_line() {
     #    Minimum during sampling period:                132 Watts
     #    Maximum during sampling period:                384 Watts
     #    Average power reading over sample period:      204 Watts
-    #    IPMI timestamp:                           03/06/2025 07:40:35 PM UTC    Sampling period:                          00000001 Seconds.
+    #    IPMI timestamp:                           03/06/2025 07:40:35 UTC    Sampling period:                          00000001 Seconds.
     #    Power reading state is:                   activated
 
     ipmi_output="$(ipmitool dcmi power reading 2>/dev/null)"
@@ -57,7 +57,7 @@ write_line() {
         "Average power reading, Watts" \
         "gauge"
 
-    value=$(echo "${ipmi_output}" | grep "Sampling period:" | awk '{print $9}')
+    value=$(echo "${ipmi_output}" | grep "Sampling period:" | awk '{print $8}')
     value=${value:-"-1"}
     write_line "sampling_period_seconds" \
         "${value}" \


### PR DESCRIPTION
Deployed to bare-metal test machine and scraped the metrics:
```
# HELP power_average_watts Average power reading, Watts
# TYPE power_average_watts gauge
power_average_watts 143
# HELP power_instantaneous_watts Instantaneous power reading, Watts
# TYPE power_instantaneous_watts gauge
power_instantaneous_watts 143
# HELP power_sampling_period_seconds Power sampling period, seconds
# TYPE power_sampling_period_seconds gauge
power_sampling_period_seconds 1
```
The issue was that when the timer runs, the output of the IPMI tool is slightly different from when it is run manually. Manually, it includes "AM"/"PM" with the time. Hence, the offset by 1 in the `awk` expression.