### PR TITLE
fix: revert "chore: unifying downloading logic (#4805)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23268,8 +23268,6 @@ name = "vsock_lib"
 version = "1.0.0"
 dependencies = [
  "anyhow",
- "futures",
- "ic-http-utils",
  "regex",
  "reqwest 0.12.12",
  "rusb",

--- a/rs/ic_os/vsock/vsock_lib/BUILD.bazel
+++ b/rs/ic_os/vsock/vsock_lib/BUILD.bazel
@@ -4,13 +4,13 @@ package(default_visibility = ["//rs:ic-os-pkg"])
 
 DEPENDENCIES = [
     # Keep sorted.
-    "//rs/http_utils",
     "@crate_index//:anyhow",
-    "@crate_index//:futures",
     "@crate_index//:regex",
+    "@crate_index//:reqwest",
     "@crate_index//:rusb",
     "@crate_index//:serde",
     "@crate_index//:serde_json",
+    "@crate_index//:sha2",
     "@crate_index//:tempfile",
     "@crate_index//:vsock",
 ]

--- a/rs/ic_os/vsock/vsock_lib/Cargo.toml
+++ b/rs/ic_os/vsock/vsock_lib/Cargo.toml
@@ -15,5 +15,3 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
 vsock = "0.4"
-ic-http-utils = { path = "../../../http_utils" }
-futures = { workspace = true }

--- a/rs/ic_os/vsock/vsock_lib/src/host/agent.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/host/agent.rs
@@ -1,19 +1,16 @@
 use crate::host::command_utilities::handle_command_output;
 use crate::host::hsm::{attach_hsm, detach_hsm};
 use crate::protocol::{Command, HostOSVsockVersion, NotifyData, Payload, Response, UpgradeData};
-use futures::executor::block_on;
-use ic_http_utils::file_downloader::FileDownloader;
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::Path;
-use std::time::Duration;
+use sha2::Digest;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
 
 pub fn dispatch(command: &Command) -> Response {
     use Command::*;
     match command {
         AttachHSM => attach_hsm(),
         DetachHSM => detach_hsm(),
-        Upgrade(upgrade_data) => block_on(upgrade_hostos(upgrade_data)),
+        Upgrade(upgrade_data) => upgrade_hostos(upgrade_data),
         Notify(notify_data) => notify(notify_data),
         GetVsockProtocol => get_hostos_vsock_version(),
         GetHostOSVersion => get_hostos_version(),
@@ -74,21 +71,65 @@ fn notify(notify_data: &NotifyData) -> Response {
     Ok(Payload::NoPayload)
 }
 
-async fn create_hostos_upgrade_file(
-    upgrade_url: &str,
-    file_path: &str,
-    target_hash: &str,
-) -> Result<(), String> {
-    let file_downloader = FileDownloader::new_with_timeout(None, Duration::from_secs(120));
+fn create_hostos_upgrade_file(upgrade_url: &str, file_path: &str) -> Result<(), String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .map_err(|err| format!("Could not build download client: {}", err))?;
 
-    file_downloader
-        .download_file(
-            upgrade_url,
-            Path::new(file_path),
-            Some(target_hash.to_string()),
-        )
-        .await
-        .map_err(|e| e.to_string())
+    let mut response = client
+        .get(upgrade_url)
+        .send()
+        .map_err(|err| format!("Could not download url: {}", err))?;
+
+    let mut upgrade_file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(file_path)
+        .map_err(|err| format!("Could not open upgrade file: {}", err))?;
+
+    if let Err(copy_err) = std::io::copy(&mut response, &mut upgrade_file) {
+        // Report on file download progress
+        match upgrade_file.metadata() {
+            Ok(metadata) => println!("Write error, '{}' bytes written", metadata.len()),
+            Err(metadata_err) => println!("Could not check file metadata: {}", metadata_err),
+        }
+
+        return Err(format!("Could not write upgrade file: {}", copy_err));
+    }
+
+    Ok(())
+}
+
+fn verify_hash(target_hash: &str) -> Result<bool, String> {
+    let mut upgrade_file = File::open(UPGRADE_FILE_PATH)
+        .map_err(|err| format!("Error opening upgrade file: {}", err))?;
+
+    let mut hasher = sha2::Sha256::new();
+    let mut buffer = [0; 65536];
+
+    loop {
+        let bytes_read = upgrade_file
+            .read(&mut buffer)
+            .map_err(|err| format!("Error reading upgrade file: {}", err))?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    let computed_hash = format!("{:x}", hasher.finalize());
+
+    if computed_hash == target_hash {
+        Ok(true)
+    } else {
+        Err(format!(
+            "Target hash does not equal computed hash.
+Target hash: {target_hash}
+Computed hash: {computed_hash}"
+        ))
+    }
 }
 
 fn run_upgrade() -> Response {
@@ -106,17 +147,16 @@ fn run_upgrade() -> Response {
     handle_command_output(command_output)
 }
 
-async fn upgrade_hostos(upgrade_data: &UpgradeData) -> Response {
-    println!(
-        "Trying to fetch hostOS upgrade file from request: {:?}",
-        upgrade_data
-    );
-    create_hostos_upgrade_file(
-        &upgrade_data.url,
-        UPGRADE_FILE_PATH,
-        &upgrade_data.target_hash,
-    )
-    .await?;
+fn upgrade_hostos(upgrade_data: &UpgradeData) -> Response {
+    // Attempt to re-use any previously downloaded upgrades, so long as the
+    // hash matches.
+    if verify_hash(&upgrade_data.target_hash).is_err() {
+        println!("Creating hostos upgrade file...");
+        create_hostos_upgrade_file(&upgrade_data.url, UPGRADE_FILE_PATH)?;
+
+        println!("Verifying hostos upgrade file hash...");
+        verify_hash(&upgrade_data.target_hash)?;
+    }
 
     println!("Starting upgrade...");
     run_upgrade()


### PR DESCRIPTION
This reverts commit 943d3bf19c888185650a53075e1f5ee6157662f5 because it breaks the `//rs/tests/nested:hostos_upgrade_smoke_test`.

Schedule Hourly: https://github.com/dfinity/ic/actions/runs/14490678316 ✅ .