### PR TITLE
feat(nns): Process the finalization of maturity disbursements

### DIFF
--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1103,11 +1103,12 @@ message ManageNeuron {
   // fields in Neuron.
   message RefreshVotingPower {}
 
-  // Disburse the maturity of a neuron to any ledger account. If an account
-  // is not specified, the caller's account will be used. The caller can choose
-  // a percentage of the current maturity to disburse to the ledger account. The
-  // resulting amount to disburse must be greater than or equal to the
-  // transaction fee.
+  // Disburse the maturity of a neuron to any ledger account. If an account is not specified, the
+  // controller's account will be used. The controller can choose a percentage of the current
+  // maturity to disburse to the ledger account. The resulting amount to disburse must be at least 1
+  // ICP. The disbursement has a 7-day delay before it is finalized. At the finalization time, the
+  // maturity modulation will be applied to the amount, which can make the amount [95%, 105%] of the
+  // original amount.
   message DisburseMaturity {
     // The percentage to disburse, from 1 to 100
     uint32 percentage_to_disburse = 1;
@@ -2754,14 +2755,14 @@ message VotingPowerTotal {
 
 message FinalizeDisburseMaturity {
   // The finalization timestamp of the disbursement.
-  uint64 finalization_timestamp_seconds = 1;
+  uint64 finalize_disbursement_timestamp_seconds = 1;
 
   // The amount of ICPs to be disbursed in e8s.
-  uint64 amount_to_be_disbursed_e8s = 2;
+  uint64 amount_to_mint_e8s = 2;
 
   // The account to which to transfer the ICPs.
   Account to_account = 3;
 
   // The original amount of maturity to be disbursed (before maturity modulation).
-  uint64 original_maturity_e8s = 4;
+  uint64 original_maturity_e8s_equivalent = 4;
 }

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2098,8 +2098,12 @@ message Governance {
       ManageNeuron.ClaimOrRefresh claim_or_refresh_neuron = 8;
       ManageNeuron.Configure configure = 9;
       ManageNeuron.Merge merge = 10;
+
+      // Below are not really `ManageNeuron` commands but determined by the context of where the
+      // neuron lock is needed. Ideally, we'd like to rename from `command` to `lock`
       ic_nns_common.pb.v1.NeuronId spawn = 20;
       SyncCommand sync_command = 21;
+      FinalizeDisburseMaturity finalize_disburse_maturity = 22;
     }
   }
 
@@ -2746,4 +2750,18 @@ message VotingPowerTotal {
 
   // The total potential voting power.
   uint64 total_potential_voting_power = 2;
+}
+
+message FinalizeDisburseMaturity {
+  // The finalization timestamp of the disbursement.
+  uint64 finalization_timestamp_seconds = 1;
+
+  // The amount of ICPs to be disbursed in e8s.
+  uint64 amount_to_be_disbursed_e8s = 2;
+
+  // The account to which to transfer the ICPs.
+  Account to_account = 3;
+
+  // The original amount of maturity to be disbursed (before maturity modulation).
+  uint64 original_maturity_e8s = 4;
 }

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3041,7 +3041,7 @@ pub mod governance {
         pub timestamp: u64,
         #[prost(
             oneof = "neuron_in_flight_command::Command",
-            tags = "2, 3, 5, 7, 8, 9, 10, 20, 21"
+            tags = "2, 3, 5, 7, 8, 9, 10, 20, 21, 22"
         )]
         pub command: ::core::option::Option<neuron_in_flight_command::Command>,
     }
@@ -3089,10 +3089,14 @@ pub mod governance {
             Configure(super::super::manage_neuron::Configure),
             #[prost(message, tag = "10")]
             Merge(super::super::manage_neuron::Merge),
+            /// Below are not really `ManageNeuron` commands but determined by the context of where the
+            /// neuron lock is needed. Ideally, we'd like to rename from `command` to `lock`
             #[prost(message, tag = "20")]
             Spawn(::ic_nns_common::pb::v1::NeuronId),
             #[prost(message, tag = "21")]
             SyncCommand(SyncCommand),
+            #[prost(message, tag = "22")]
+            FinalizeDisburseMaturity(super::super::FinalizeDisburseMaturity),
         }
     }
     /// Stores metrics that are too costly to compute each time metrics are
@@ -4207,6 +4211,29 @@ pub struct VotingPowerTotal {
     /// The total potential voting power.
     #[prost(uint64, tag = "2")]
     pub total_potential_voting_power: u64,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct FinalizeDisburseMaturity {
+    /// The finalization timestamp of the disbursement.
+    #[prost(uint64, tag = "1")]
+    pub finalization_timestamp_seconds: u64,
+    /// The amount of ICPs to be disbursed in e8s.
+    #[prost(uint64, tag = "2")]
+    pub amount_to_be_disbursed_e8s: u64,
+    /// The account to which to transfer the ICPs.
+    #[prost(message, optional, tag = "3")]
+    pub to_account: ::core::option::Option<Account>,
+    /// The amount of maturity to be disbursed (before maturity modulation).
+    #[prost(uint64, tag = "4")]
+    pub original_maturity_e8s: u64,
 }
 /// Proposal types are organized into topics. Neurons can automatically
 /// vote based on following other neurons, and these follow

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -1273,11 +1273,12 @@ pub mod manage_neuron {
         ::prost::Message,
     )]
     pub struct RefreshVotingPower {}
-    /// Disburse the maturity of a neuron to any ledger account. If an account
-    /// is not specified, the caller's account will be used. The caller can choose
-    /// a percentage of the current maturity to disburse to the ledger account. The
-    /// resulting amount to disburse must be greater than or equal to the
-    /// transaction fee.
+    /// Disburse the maturity of a neuron to any ledger account. If an account is not specified, the
+    /// controller's account will be used. The controller can choose a percentage of the current
+    /// maturity to disburse to the ledger account. The resulting amount to disburse must be at least 1
+    /// ICP. The disbursement has a 7-day delay before it is finalized. At the finalization time, the
+    /// maturity modulation will be applied to the amount, which can make the amount \[95%, 105%\] of the
+    /// original amount.
     #[derive(
         candid::CandidType,
         candid::Deserialize,
@@ -4224,16 +4225,16 @@ pub struct VotingPowerTotal {
 pub struct FinalizeDisburseMaturity {
     /// The finalization timestamp of the disbursement.
     #[prost(uint64, tag = "1")]
-    pub finalization_timestamp_seconds: u64,
+    pub finalize_disbursement_timestamp_seconds: u64,
     /// The amount of ICPs to be disbursed in e8s.
     #[prost(uint64, tag = "2")]
-    pub amount_to_be_disbursed_e8s: u64,
+    pub amount_to_mint_e8s: u64,
     /// The account to which to transfer the ICPs.
     #[prost(message, optional, tag = "3")]
     pub to_account: ::core::option::Option<Account>,
-    /// The amount of maturity to be disbursed (before maturity modulation).
+    /// The original amount of maturity to be disbursed (before maturity modulation).
     #[prost(uint64, tag = "4")]
-    pub original_maturity_e8s: u64,
+    pub original_maturity_e8s_equivalent: u64,
 }
 /// Proposal types are organized into topics. Neurons can automatically
 /// vote based on following other neurons, and these follow

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -138,7 +138,7 @@ use std::{
 };
 
 pub mod disburse_maturity;
-pub mod ledger_helper;
+mod ledger_helper;
 mod merge_neurons;
 mod split_neuron;
 pub mod test_data;

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -137,8 +137,8 @@ use std::{
     string::ToString,
 };
 
-mod disburse_maturity;
-mod ledger_helper;
+pub mod disburse_maturity;
+pub mod ledger_helper;
 mod merge_neurons;
 mod split_neuron;
 pub mod test_data;

--- a/rs/nns/governance/src/governance/disburse_maturity.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity.rs
@@ -1,8 +1,12 @@
 use crate::{
+    governance::{ledger_helper::MintIcpOperation, Governance},
     neuron_store::NeuronStore,
     pb::v1::{
-        governance_error::ErrorType, manage_neuron::DisburseMaturity, Account, GovernanceError,
-        MaturityDisbursement, NeuronState,
+        governance::{neuron_in_flight_command::Command, NeuronInFlightCommand},
+        governance_error::ErrorType,
+        manage_neuron::DisburseMaturity,
+        Account, FinalizeDisburseMaturity, GovernanceError, MaturityDisbursement, NeuronState,
+        Subaccount,
     },
 };
 
@@ -12,11 +16,11 @@ use ic_nervous_system_governance::maturity_modulation::{
 };
 use ic_nns_common::pb::v1::NeuronId;
 use ic_types::PrincipalId;
-use icp_ledger::AccountIdentifier;
 use icrc_ledger_types::icrc1::account::Account as Icrc1Account;
+use std::{cell::RefCell, collections::HashMap, fmt::Display, thread::LocalKey, time::Duration};
 
 /// The delay in seconds between initiating a maturity disbursement and the actual disbursement.
-const DISBURSEMENT_DELAY_SECONDS: u64 = ONE_DAY_SECONDS * 7;
+pub const DISBURSEMENT_DELAY_SECONDS: u64 = ONE_DAY_SECONDS * 7;
 /// The maximum number of disbursements in a neuron. This makes it possible to do daily
 /// disbursements after every reward event (as 10 > 7).
 const MAX_NUM_DISBURSEMENTS: usize = 10;
@@ -105,7 +109,7 @@ impl From<InitiateMaturityDisbursementError> for GovernanceError {
 
 // There is no reason to put the conversion here other than the fact that it is
 // only needed in this file. It's OK to move it to a different file if needed.
-impl TryFrom<Account> for AccountIdentifier {
+impl TryFrom<Account> for Icrc1Account {
     type Error = String;
 
     fn try_from(account: Account) -> Result<Self, Self::Error> {
@@ -118,11 +122,23 @@ impl TryFrom<Account> for AccountIdentifier {
             .transpose()
             .map_err(|_| "Subaccount must be 32 bytes".to_string())?;
 
-        let icrc1_account = Icrc1Account {
+        Ok(Icrc1Account {
             owner: owner.0,
             subaccount,
-        };
-        Ok(AccountIdentifier::from(icrc1_account))
+        })
+    }
+}
+
+// This conversion is needed for neuron lock.
+impl From<Icrc1Account> for Account {
+    fn from(account: Icrc1Account) -> Self {
+        let Icrc1Account { owner, subaccount } = account;
+
+        let owner = Some(PrincipalId::from(owner));
+        let subaccount = subaccount.map(|s| Subaccount {
+            subaccount: s.to_vec(),
+        });
+        Account { owner, subaccount }
     }
 }
 
@@ -189,7 +205,7 @@ pub fn initiate_maturity_disbursement(
     if let Some(to_account) = to_account {
         // Even though the conversion result is not used when initiating, we still want to validate
         // the account identifier so that we only store valid account identifiers in the neuron.
-        let _ = AccountIdentifier::try_from(to_account.clone())
+        let _ = Icrc1Account::try_from(to_account.clone())
             .map_err(|reason| InitiateMaturityDisbursementError::InvalidDestination { reason })?;
     }
 
@@ -259,6 +275,328 @@ pub fn initiate_maturity_disbursement(
     Ok(disbursement_maturity_e8s)
 }
 
+#[derive(Debug, Clone)]
+pub struct MaturityDisbursementFinalization {
+    pub neuron_id: NeuronId,
+    pub account: Icrc1Account,
+    pub amount_e8s: u64,
+    pub original_maturity_e8s: u64,
+    pub finalization_timestamp_seconds: u64,
+}
+
+/// Errors that can occur when finalizing a maturity disbursement. The error is just for logging
+/// purposes since all user errors should be caught when initiating the disbursement.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum FinalizeMaturityDisbursementError {
+    NoMaturityModulation,
+    NeuronNotFound(NeuronId),
+    NoMaturityDisbursement(NeuronId),
+    NotTimeToFinalizeMaturityDisbursement {
+        neuron_id: NeuronId,
+        finalize_disbursement_timestamp_seconds: u64,
+        now_seconds: u64,
+    },
+    MaturityModulationFailure {
+        maturity_before_modulation_e8s: u64,
+        maturity_modulation_basis_points: i32,
+        reason: String,
+    },
+    NoAccountToDisburseTo(NeuronId),
+    AccountConversionFailure {
+        reason: String,
+    },
+    FailToAcquireNeuronLock(NeuronId),
+    FailToPopMaturityDisbursement(NeuronId),
+    FailToMintIcp {
+        neuron_id: NeuronId,
+        reason: String,
+    },
+    FailToReverseNeuronMutation {
+        neuron_id: NeuronId,
+        reason: String,
+    },
+}
+
+impl Display for FinalizeMaturityDisbursementError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FinalizeMaturityDisbursementError::NoMaturityModulation => {
+                write!(f, "No maturity modulation")
+            }
+            FinalizeMaturityDisbursementError::NeuronNotFound(neuron_id) => {
+                write!(f, "Neuron not found: {:?}", neuron_id)
+            }
+            FinalizeMaturityDisbursementError::NoMaturityDisbursement(neuron_id) => {
+                write!(
+                    f,
+                    "No maturity disbursement found for neuron: {:?}",
+                    neuron_id
+                )
+            }
+            FinalizeMaturityDisbursementError::NotTimeToFinalizeMaturityDisbursement {
+                neuron_id,
+                finalize_disbursement_timestamp_seconds,
+                now_seconds,
+            } => write!(
+                f,
+                "Not time to finalize maturity disbursement for neuron {:?}: \
+                finalize_disbursement_timestamp_seconds: {}, now_seconds: {}",
+                neuron_id, finalize_disbursement_timestamp_seconds, now_seconds
+            ),
+            FinalizeMaturityDisbursementError::MaturityModulationFailure {
+                maturity_before_modulation_e8s,
+                maturity_modulation_basis_points,
+                reason,
+            } => write!(
+                f,
+                "Failed to apply maturity modulation of {} basis points to {} e8s: {}",
+                maturity_modulation_basis_points, maturity_before_modulation_e8s, reason
+            ),
+            FinalizeMaturityDisbursementError::NoAccountToDisburseTo(neuron_id) => {
+                write!(f, "No account to disburse to for neuron: {:?}", neuron_id)
+            }
+            FinalizeMaturityDisbursementError::AccountConversionFailure { reason } => {
+                write!(f, "Failed to convert account identifier: {}", reason)
+            }
+            FinalizeMaturityDisbursementError::FailToAcquireNeuronLock(neuron_id) => {
+                write!(
+                    f,
+                    "Failed to acquire neuron lock for neuron: {:?} even though we just \
+                    checked the neuron is not locked",
+                    neuron_id
+                )
+            }
+            FinalizeMaturityDisbursementError::FailToPopMaturityDisbursement(neuron_id) => {
+                write!(
+                    f,
+                    "Failed to pop maturity disbursement in progress for neuron id {:?} \
+                    even though we just found it",
+                    neuron_id
+                )
+            }
+            FinalizeMaturityDisbursementError::FailToMintIcp { neuron_id, reason } => write!(
+                f,
+                "Failed to mint ICP for neuron id {:?}: {}",
+                neuron_id, reason
+            ),
+            FinalizeMaturityDisbursementError::FailToReverseNeuronMutation {
+                neuron_id,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "Maturity disbursement was removed from the neuron {:?}, ICP minting failed \
+                    but the disbursement cannot be reversed because of {}. Neuron lock is retained.", 
+                    neuron_id,
+                    reason
+                )
+            }
+        }
+    }
+}
+
+/// Returns the next maturity disbursement to finalize. When the function returns
+/// `Some(finalization)`, the finalization corresponds to the first disbursement of the neuron with
+/// `finalization.neuron_id`.
+fn next_maturity_disbursement_to_finalize(
+    neuron_store: &NeuronStore,
+    in_flight_commands: &HashMap<u64, NeuronInFlightCommand>,
+    maturity_modulation_basis_points: Option<i32>,
+    now_seconds: u64,
+) -> Result<Option<MaturityDisbursementFinalization>, FinalizeMaturityDisbursementError> {
+    let maturity_modulation_basis_points = maturity_modulation_basis_points
+        .ok_or(FinalizeMaturityDisbursementError::NoMaturityModulation)?;
+
+    let Some(neuron_id) = neuron_store
+        .get_neuron_ids_ready_to_finalize_maturity_disbursement(now_seconds)
+        .into_iter()
+        .find(|neuron_id| !in_flight_commands.contains_key(&neuron_id.id))
+    else {
+        // If all neurons are locked, we don't need to finalize anything.
+        println!("All neurons are locked");
+        return Ok(None);
+    };
+    // Either of the errors below
+    let maturity_disbursement_in_progress = neuron_store
+        .with_neuron(&neuron_id, |neuron| {
+            neuron.maturity_disbursements_in_progress().first().cloned()
+        })
+        .map_err(|_| FinalizeMaturityDisbursementError::NeuronNotFound(neuron_id))?
+        .ok_or(FinalizeMaturityDisbursementError::NoMaturityDisbursement(
+            neuron_id,
+        ))?;
+
+    let MaturityDisbursement {
+        amount_e8s: original_maturity_e8s,
+        account_to_disburse_to,
+        finalize_disbursement_timestamp_seconds,
+        timestamp_of_disbursement_seconds: _,
+    } = maturity_disbursement_in_progress;
+
+    // Make sure the disbursement is ready to be finalized. Failure at this step probably means the
+    // maturity disbursement index is wrong.
+    if now_seconds < finalize_disbursement_timestamp_seconds {
+        return Err(
+            FinalizeMaturityDisbursementError::NotTimeToFinalizeMaturityDisbursement {
+                neuron_id,
+                finalize_disbursement_timestamp_seconds,
+                now_seconds,
+            },
+        );
+    }
+
+    let maturity_to_disburse_after_modulation_e8s =
+        apply_maturity_modulation(original_maturity_e8s, maturity_modulation_basis_points)
+            .map_err(
+                |reason| FinalizeMaturityDisbursementError::MaturityModulationFailure {
+                    maturity_before_modulation_e8s: original_maturity_e8s,
+                    maturity_modulation_basis_points,
+                    reason,
+                },
+            )?;
+
+    let account = account_to_disburse_to.ok_or(
+        FinalizeMaturityDisbursementError::NoAccountToDisburseTo(neuron_id),
+    )?;
+    let account = Icrc1Account::try_from(account)
+        .map_err(|reason| FinalizeMaturityDisbursementError::AccountConversionFailure { reason })?;
+
+    Ok(Some(MaturityDisbursementFinalization {
+        neuron_id,
+        account,
+        amount_e8s: maturity_to_disburse_after_modulation_e8s,
+        finalization_timestamp_seconds: finalize_disbursement_timestamp_seconds,
+        original_maturity_e8s,
+    }))
+}
+
+/// Finalizes the maturity disbursement for a neuron.
+pub async fn finalize_maturity_disbursement(
+    governance: &'static LocalKey<RefCell<Governance>>,
+) -> Result<(), FinalizeMaturityDisbursementError> {
+    let (maturity_disbursement_finalization, now_seconds) = governance.with_borrow(|governance| {
+        let now_seconds = governance.env.now();
+        let maturity_disbursement_finalization = next_maturity_disbursement_to_finalize(
+            &governance.neuron_store,
+            &governance.heap_data.in_flight_commands,
+            governance
+                .heap_data
+                .cached_daily_maturity_modulation_basis_points,
+            now_seconds,
+        );
+        (maturity_disbursement_finalization, now_seconds)
+    });
+
+    let Some(MaturityDisbursementFinalization {
+        neuron_id,
+        account,
+        amount_e8s,
+        original_maturity_e8s,
+        finalization_timestamp_seconds,
+    }) = maturity_disbursement_finalization?
+    else {
+        // No disbursement to finalize.
+        return Ok(());
+    };
+
+    // Step 1: acquire a lock on the neuron, before any mutation is performed.
+    let Ok(mut neuron_lock) = Governance::acquire_neuron_async_lock(
+        governance,
+        neuron_id,
+        now_seconds,
+        Command::FinalizeDisburseMaturity(FinalizeDisburseMaturity {
+            amount_to_be_disbursed_e8s: amount_e8s,
+            to_account: Some(Account::from(account)),
+            finalization_timestamp_seconds,
+            original_maturity_e8s,
+        }),
+    ) else {
+        return Err(FinalizeMaturityDisbursementError::FailToAcquireNeuronLock(
+            neuron_id,
+        ));
+    };
+
+    // Step 2: pop the maturity disbursement in progress. If this fails, no inconsistency is
+    // introduced, since no mutation has been performed yet.
+    let Ok(Some(maturity_disbursement_in_progress)) = governance.with_borrow_mut(|governance| {
+        governance.with_neuron_mut(&neuron_id, |neuron| {
+            neuron.pop_maturity_disbursement_in_progress()
+        })
+    }) else {
+        return Err(FinalizeMaturityDisbursementError::FailToPopMaturityDisbursement(neuron_id));
+    };
+
+    // Step 3: call ledger to perform the minting. If this fails, the neuron mutation needs to
+    // be reversed.
+    let mint_icp_operation = MintIcpOperation::new(account, amount_e8s);
+    println!("About to mint icp: {:?}", mint_icp_operation);
+    let ledger = governance.with_borrow(|governance| governance.get_ledger());
+    let Err(mint_error) = mint_icp_operation
+        .mint_icp_with_ledger(ledger.as_ref(), now_seconds)
+        .await
+    else {
+        // Happy case: the minting was successful so we can exit here.
+        return Ok(());
+    };
+
+    // Reaching this point means the minting failed and we need to reverse the neuron mutation
+    // for consistency.
+    let Err(reverse_neuron_result) = governance.with_borrow_mut(|governance| {
+        governance.with_neuron_mut(&neuron_id, |neuron| {
+            neuron.push_front_maturity_disbursement_in_progress(maturity_disbursement_in_progress);
+        })
+    }) else {
+        // The neuron mutation was successfully reversed and it will be re-tried later.
+        return Err(FinalizeMaturityDisbursementError::FailToMintIcp {
+            neuron_id,
+            reason: mint_error.error_message,
+        });
+    };
+
+    // Reaching this point means the neuron mutation was performed, the ledger operation failed
+    // and the neuron mutation could not be reversed. The best we can do at this point is to
+    // retain the neuron lock.
+    neuron_lock.retain();
+    Err(
+        FinalizeMaturityDisbursementError::FailToReverseNeuronMutation {
+            neuron_id,
+            reason: reverse_neuron_result.error_message,
+        },
+    )
+}
+
+/// Returns the number of seconds until the next maturity disbursement finalization should be run.
+pub fn get_delay_until_next_finalization(
+    governance: &Governance,
+    retry_delay: Duration,
+) -> Duration {
+    let next_maturity_disbursement_finalization_timestamp =
+        governance.neuron_store.get_next_maturity_disbursement();
+    let Some((next_maturity_disbursement_finalization_timestamp, neuron_id)) =
+        next_maturity_disbursement_finalization_timestamp
+    else {
+        // If there are no disbursements yet, then we can wait at least `DISBURSEMENT_DELAY_SECONDS`
+        // since new disbursements will be scheduled after this delay.
+        return Duration::from_secs(DISBURSEMENT_DELAY_SECONDS);
+    };
+
+    if governance
+        .heap_data
+        .in_flight_commands
+        .contains_key(&neuron_id.id)
+    {
+        // The first neuron eligible for finalization is locked. We should not ignore it since it
+        // can be unlocked any time, but we also don't want to retry immediately as it can be locked
+        // indefinitely. Therefore, we allow the caller to specify a retry delay.
+        retry_delay
+    } else {
+        // This is the normal case - the absolute time of the next disbursement is known, and we
+        // calculate the delay based on the current time.
+        Duration::from_secs(
+            next_maturity_disbursement_finalization_timestamp.saturating_sub(governance.env.now()),
+        )
+    }
+}
 #[path = "disburse_maturity_tests.rs"]
 #[cfg(test)]
 mod tests;

--- a/rs/nns/governance/src/maturity_disbursement_index.rs
+++ b/rs/nns/governance/src/maturity_disbursement_index.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 
 use crate::storage::validate_stable_btree_map;
 
+use ic_nns_common::pb::v1::NeuronId as NeuronIdProto;
 use ic_stable_structures::{Memory, StableBTreeMap};
 
 type TimestampSeconds = u64;
@@ -80,11 +81,13 @@ impl<M: Memory> MaturityDisbursementIndex<M> {
             .collect()
     }
 
-    /// Returns the next finalization timestamp for a neuron, if any.
-    pub fn get_next_finalization_timestamp(&self) -> Option<TimestampSeconds> {
+    /// Returns the next entry of the index.
+    pub fn get_next_entry(&self) -> Option<(TimestampSeconds, NeuronIdProto)> {
         self.finalization_timestamp_neuron_id_to_null
             .first_key_value()
-            .map(|((finalization_timestamp, _neuron_id), _)| finalization_timestamp)
+            .map(|((finalization_timestamp, neuron_id), _)| {
+                (finalization_timestamp, NeuronIdProto::from_u64(neuron_id))
+            })
     }
 
     /// Validates that some of the data in stable storage can be read, in order to prevent broken

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -1135,6 +1135,7 @@ impl Neuron {
         self.known_neuron_data = None;
     }
 
+    /// Adds a maturity disbursement in progress at the end.
     pub fn add_maturity_disbursement_in_progress(
         &mut self,
         maturity_disbursement: MaturityDisbursement,
@@ -1144,7 +1145,6 @@ impl Neuron {
     }
 
     /// Pops the first maturity disbursement in progress.
-    #[cfg(test)]
     pub fn pop_maturity_disbursement_in_progress(&mut self) -> Option<MaturityDisbursement> {
         if self.maturity_disbursements_in_progress.is_empty() {
             None
@@ -1152,6 +1152,16 @@ impl Neuron {
             // This is safe because we know that the vector is not empty.
             Some(self.maturity_disbursements_in_progress.remove(0))
         }
+    }
+
+    /// Pushes a maturity disbursement in progress at the front. This should only be used if the
+    /// ledger operation fails and the disbursement needs to be put back in the queue.
+    pub fn push_front_maturity_disbursement_in_progress(
+        &mut self,
+        maturity_disbursement: MaturityDisbursement,
+    ) {
+        self.maturity_disbursements_in_progress
+            .insert(0, maturity_disbursement);
     }
 }
 

--- a/rs/nns/governance/src/neuron_lock.rs
+++ b/rs/nns/governance/src/neuron_lock.rs
@@ -33,7 +33,6 @@ use std::{cell::RefCell, collections::hash_map::Entry, thread::LocalKey};
 
 /// A lock for a neuron that is being updated. This lock can be used in asynchronous methods where a
 /// `'static LocalKey<RefCell<Governance>>` is available instead of a `&'static mut Governance`.
-#[allow(unused)]
 pub(crate) struct NeuronAsyncLock {
     neuron_id: NeuronId,
     governance: &'static LocalKey<RefCell<Governance>>,
@@ -62,7 +61,6 @@ impl Drop for NeuronAsyncLock {
 
 impl NeuronAsyncLock {
     /// Retains the lock even on drop.
-    #[allow(unused)]
     pub(crate) fn retain(&mut self) {
         self.retain = true;
     }
@@ -144,7 +142,6 @@ impl Governance {
     /// let _my_lock = acquire_neuron_async_lock(...);
     /// ```
     /// will retain the lock for the entire scope.
-    #[allow(unused)]
     pub(crate) fn acquire_neuron_async_lock(
         governance: &'static LocalKey<RefCell<Self>>,
         neuron_id: NeuronId,

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -1146,14 +1146,10 @@ impl NeuronStore {
         })
     }
 
-    /// Returns the finalization timestamp of the next maturity disbursement. Returns `None` if
-    /// there is no maturity disbursement at all.
-    pub fn get_next_maturity_disbursement_finalization_timestamp(&self) -> Option<u64> {
-        with_stable_neuron_indexes(|indexes| {
-            indexes
-                .maturity_disbursement()
-                .get_next_finalization_timestamp()
-        })
+    /// Returns the finalization timestamp and the neuron id of the next maturity disbursement.
+    /// Returns `None` if there is no maturity disbursement at all.
+    pub fn get_next_maturity_disbursement(&self) -> Option<(u64, NeuronId)> {
+        with_stable_neuron_indexes(|indexes| indexes.maturity_disbursement().get_next_entry())
     }
 
     /// Validates a batch of neurons in stable neuron store are all inactive.

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -674,10 +674,7 @@ fn test_maturity_disbursement_index() {
         neuron_store.get_neuron_ids_ready_to_finalize_maturity_disbursement(0),
         btreeset! {}
     );
-    assert_eq!(
-        neuron_store.get_next_maturity_disbursement_finalization_timestamp(),
-        None
-    );
+    assert_eq!(neuron_store.get_next_maturity_disbursement(), None);
 
     // Add 2 disbursements for neuron 1 (finalizing at t = 1 and t = 2), and add 1 disbursement for
     // neuron 2 finalizing at t = 2.
@@ -700,8 +697,8 @@ fn test_maturity_disbursement_index() {
         btreeset! {}
     );
     assert_eq!(
-        neuron_store.get_next_maturity_disbursement_finalization_timestamp(),
-        Some(1)
+        neuron_store.get_next_maturity_disbursement(),
+        Some((1, NeuronId::from_u64(1)))
     );
 
     // At t = 1, neuron 1 is ready to finalize maturity disbursement, and the next maturity.
@@ -732,8 +729,8 @@ fn test_maturity_disbursement_index() {
         btreeset! {NeuronId::from_u64(1), NeuronId::from_u64(2)}
     );
     assert_eq!(
-        neuron_store.get_next_maturity_disbursement_finalization_timestamp(),
-        Some(2)
+        neuron_store.get_next_maturity_disbursement(),
+        Some((2, NeuronId::from_u64(1)))
     );
 
     // After removing the second disbursement for neuron 2, neuron 1 is the only one ready to
@@ -759,10 +756,7 @@ fn test_maturity_disbursement_index() {
         neuron_store.get_neuron_ids_ready_to_finalize_maturity_disbursement(2),
         btreeset! {}
     );
-    assert_eq!(
-        neuron_store.get_next_maturity_disbursement_finalization_timestamp(),
-        None
-    );
+    assert_eq!(neuron_store.get_next_maturity_disbursement(), None);
 }
 
 #[test]

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -2683,14 +2683,6 @@ impl From<pb_api::Governance> for pb::Governance {
     }
 }
 
-impl From<pb::governance::NeuronInFlightCommand> for pb_api::governance::NeuronInFlightCommand {
-    fn from(item: pb::governance::NeuronInFlightCommand) -> Self {
-        Self {
-            timestamp: item.timestamp,
-            command: item.command.map(|x| x.into()),
-        }
-    }
-}
 impl From<pb_api::governance::NeuronInFlightCommand> for pb::governance::NeuronInFlightCommand {
     fn from(item: pb_api::governance::NeuronInFlightCommand) -> Self {
         Self {
@@ -2715,43 +2707,6 @@ impl From<pb_api::governance::neuron_in_flight_command::SyncCommand>
     }
 }
 
-impl From<pb::governance::neuron_in_flight_command::Command>
-    for pb_api::governance::neuron_in_flight_command::Command
-{
-    fn from(item: pb::governance::neuron_in_flight_command::Command) -> Self {
-        match item {
-            pb::governance::neuron_in_flight_command::Command::Disburse(v) => {
-                pb_api::governance::neuron_in_flight_command::Command::Disburse(v.into())
-            }
-            pb::governance::neuron_in_flight_command::Command::Split(v) => {
-                pb_api::governance::neuron_in_flight_command::Command::Split(v.into())
-            }
-            pb::governance::neuron_in_flight_command::Command::DisburseToNeuron(v) => {
-                pb_api::governance::neuron_in_flight_command::Command::DisburseToNeuron(v.into())
-            }
-            pb::governance::neuron_in_flight_command::Command::MergeMaturity(v) => {
-                pb_api::governance::neuron_in_flight_command::Command::MergeMaturity(v.into())
-            }
-            pb::governance::neuron_in_flight_command::Command::ClaimOrRefreshNeuron(v) => {
-                pb_api::governance::neuron_in_flight_command::Command::ClaimOrRefreshNeuron(
-                    v.into(),
-                )
-            }
-            pb::governance::neuron_in_flight_command::Command::Configure(v) => {
-                pb_api::governance::neuron_in_flight_command::Command::Configure(v.into())
-            }
-            pb::governance::neuron_in_flight_command::Command::Merge(v) => {
-                pb_api::governance::neuron_in_flight_command::Command::Merge(v.into())
-            }
-            pb::governance::neuron_in_flight_command::Command::Spawn(v) => {
-                pb_api::governance::neuron_in_flight_command::Command::Spawn(v)
-            }
-            pb::governance::neuron_in_flight_command::Command::SyncCommand(v) => {
-                pb_api::governance::neuron_in_flight_command::Command::SyncCommand(v.into())
-            }
-        }
-    }
-}
 impl From<pb_api::governance::neuron_in_flight_command::Command>
     for pb::governance::neuron_in_flight_command::Command
 {

--- a/rs/nns/governance/src/timer_tasks/finalize_maturity_disbursements.rs
+++ b/rs/nns/governance/src/timer_tasks/finalize_maturity_disbursements.rs
@@ -1,0 +1,53 @@
+use crate::governance::{
+    disburse_maturity::{finalize_maturity_disbursement, get_delay_until_next_finalization},
+    Governance,
+};
+
+use async_trait::async_trait;
+use ic_nervous_system_timer_task::RecurringAsyncTask;
+use std::{cell::RefCell, thread::LocalKey, time::Duration};
+
+pub(super) struct FinalizeMaturityDisbursementsTask {
+    governance: &'static LocalKey<RefCell<Governance>>,
+}
+
+impl FinalizeMaturityDisbursementsTask {
+    pub fn new(governance: &'static LocalKey<RefCell<Governance>>) -> Self {
+        Self { governance }
+    }
+}
+
+// We do not retry the task more frequently than once a minute, so that if there is anything wrong
+// with the task, we don't use too many resources. How this is chosen: assuming the task can max out
+// the 50B instruction limit and it takes 2B instructions per DTS slice, then the task can run for
+// 25 rounds; with 1.5 rounds per second, it will take ~ 16 seconds to run. The minimum task
+// interval is chosen to be larger than 16 seconds so that the canister would be able to do other
+// work in the meantime.
+const RETRY_INTERVAL: Duration = Duration::from_secs(60);
+
+#[async_trait]
+impl RecurringAsyncTask for FinalizeMaturityDisbursementsTask {
+    async fn execute(self) -> (Duration, Self) {
+        match finalize_maturity_disbursement(self.governance).await {
+            Ok(_) => (self.delay_until_next_run(), self),
+            Err(err) => {
+                ic_cdk::println!("FinalizeMaturityDisbursementsTask failed: {}", err);
+                (RETRY_INTERVAL, self)
+            }
+        }
+    }
+
+    fn initial_delay(&self) -> Duration {
+        self.delay_until_next_run()
+    }
+
+    const NAME: &'static str = "finalize_maturity_disbursements";
+}
+
+impl FinalizeMaturityDisbursementsTask {
+    /// Returns the time until the next maturity disbursement is due.
+    fn delay_until_next_run(&self) -> Duration {
+        self.governance
+            .with_borrow(|governance| get_delay_until_next_finalization(governance, RETRY_INTERVAL))
+    }
+}

--- a/rs/nns/governance/src/timer_tasks/finalize_maturity_disbursements.rs
+++ b/rs/nns/governance/src/timer_tasks/finalize_maturity_disbursements.rs
@@ -17,37 +17,17 @@ impl FinalizeMaturityDisbursementsTask {
     }
 }
 
-// We do not retry the task more frequently than once a minute, so that if there is anything wrong
-// with the task, we don't use too many resources. How this is chosen: assuming the task can max out
-// the 50B instruction limit and it takes 2B instructions per DTS slice, then the task can run for
-// 25 rounds; with 1.5 rounds per second, it will take ~ 16 seconds to run. The minimum task
-// interval is chosen to be larger than 16 seconds so that the canister would be able to do other
-// work in the meantime.
-const RETRY_INTERVAL: Duration = Duration::from_secs(60);
-
 #[async_trait]
 impl RecurringAsyncTask for FinalizeMaturityDisbursementsTask {
     async fn execute(self) -> (Duration, Self) {
-        match finalize_maturity_disbursement(self.governance).await {
-            Ok(_) => (self.delay_until_next_run(), self),
-            Err(err) => {
-                ic_cdk::println!("FinalizeMaturityDisbursementsTask failed: {}", err);
-                (RETRY_INTERVAL, self)
-            }
-        }
+        let delay = finalize_maturity_disbursement(self.governance).await;
+        (delay, self)
     }
 
     fn initial_delay(&self) -> Duration {
-        self.delay_until_next_run()
+        self.governance
+            .with_borrow(get_delay_until_next_finalization)
     }
 
     const NAME: &'static str = "finalize_maturity_disbursements";
-}
-
-impl FinalizeMaturityDisbursementsTask {
-    /// Returns the time until the next maturity disbursement is due.
-    fn delay_until_next_run(&self) -> Duration {
-        self.governance
-            .with_borrow(|governance| get_delay_until_next_finalization(governance, RETRY_INTERVAL))
-    }
 }

--- a/rs/nns/governance/src/timer_tasks/mod.rs
+++ b/rs/nns/governance/src/timer_tasks/mod.rs
@@ -1,4 +1,5 @@
 use calculate_distributable_rewards::CalculateDistributableRewardsTask;
+use finalize_maturity_disbursements::FinalizeMaturityDisbursementsTask;
 use ic_metrics_encoder::MetricsEncoder;
 use ic_nervous_system_timer_task::{
     RecurringAsyncTask, RecurringSyncTask, TimerTaskMetricsRegistry,
@@ -12,6 +13,7 @@ use crate::{canister_state::GOVERNANCE, storage::VOTING_POWER_SNAPSHOTS};
 
 mod calculate_distributable_rewards;
 mod distribute_rewards;
+mod finalize_maturity_disbursements;
 mod prune_following;
 mod seeding;
 mod snapshot_voting_power;
@@ -25,6 +27,7 @@ pub fn schedule_tasks() {
     CalculateDistributableRewardsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     PruneFollowingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     SnapshotVotingPowerTask::new(&GOVERNANCE, &VOTING_POWER_SNAPSHOTS).schedule(&METRICS_REGISTRY);
+    FinalizeMaturityDisbursementsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
 
     run_distribute_rewards_periodic_task();
 }

--- a/rs/nns/governance/src/timer_tasks/mod.rs
+++ b/rs/nns/governance/src/timer_tasks/mod.rs
@@ -9,7 +9,9 @@ use seeding::SeedingTask;
 use snapshot_voting_power::SnapshotVotingPowerTask;
 use std::cell::RefCell;
 
-use crate::{canister_state::GOVERNANCE, storage::VOTING_POWER_SNAPSHOTS};
+use crate::{
+    canister_state::GOVERNANCE, is_disburse_maturity_enabled, storage::VOTING_POWER_SNAPSHOTS,
+};
 
 mod calculate_distributable_rewards;
 mod distribute_rewards;
@@ -27,7 +29,9 @@ pub fn schedule_tasks() {
     CalculateDistributableRewardsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     PruneFollowingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     SnapshotVotingPowerTask::new(&GOVERNANCE, &VOTING_POWER_SNAPSHOTS).schedule(&METRICS_REGISTRY);
-    FinalizeMaturityDisbursementsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
+    if is_disburse_maturity_enabled() {
+        FinalizeMaturityDisbursementsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
+    }
 
     run_distribute_rewards_periodic_task();
 }

--- a/rs/nns/integration_tests/src/governance_neurons.rs
+++ b/rs/nns/integration_tests/src/governance_neurons.rs
@@ -5,35 +5,39 @@ use dfn_candid::candid_one;
 use dfn_protobuf::protobuf;
 use ic_base_types::PrincipalId;
 use ic_canister_client_sender::Sender;
-use ic_nervous_system_common::ledger::compute_neuron_staking_subaccount_bytes;
+use ic_nervous_system_common::{
+    ledger::compute_neuron_staking_subaccount_bytes, ONE_DAY_SECONDS, ONE_YEAR_SECONDS,
+};
 use ic_nervous_system_common_test_keys::{
     TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR, TEST_NEURON_1_OWNER_PRINCIPAL, TEST_NEURON_2_ID,
     TEST_NEURON_2_OWNER_PRINCIPAL,
 };
 use ic_nns_common::pb::v1::NeuronId as NeuronIdProto;
+use ic_nns_constants::LEDGER_CANISTER_ID;
 use ic_nns_governance::governance::INITIAL_NEURON_DISSOLVE_DELAY;
 use ic_nns_governance_api::pb::v1::{
     governance_error::ErrorType,
     list_neurons::NeuronSubaccount,
     manage_neuron::{Command, Merge, NeuronIdOrSubaccount, Spawn},
-    manage_neuron_response::{
-        Command as CommandResponse, {self},
-    },
+    manage_neuron_response::{self, Command as CommandResponse},
     neuron::DissolveState,
-    GovernanceError, ListNeurons, ManageNeuron, ManageNeuronResponse, Neuron, NeuronState,
+    Account as GovernanceAccount, GovernanceError, ListNeurons, MakeProposalRequest, ManageNeuron,
+    ManageNeuronResponse, Motion, Neuron, NeuronState, ProposalActionRequest,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     itest_helpers::{state_machine_test_on_nns_subnet, NnsCanisters},
     state_test_helpers::{
-        list_neurons, list_neurons_by_principal, nns_add_hot_key, nns_claim_or_refresh_neuron,
-        nns_disburse_neuron, nns_governance_get_full_neuron, nns_governance_get_neuron_info,
-        nns_join_community_fund, nns_leave_community_fund, nns_remove_hot_key,
-        nns_send_icp_to_claim_or_refresh_neuron, nns_start_dissolving, setup_nns_canisters,
-        state_machine_builder_for_nns_tests,
+        icrc1_balance, list_neurons, list_neurons_by_principal, nns_add_hot_key,
+        nns_claim_or_refresh_neuron, nns_disburse_maturity, nns_disburse_neuron,
+        nns_governance_get_full_neuron, nns_governance_get_neuron_info,
+        nns_governance_make_proposal, nns_increase_dissolve_delay, nns_join_community_fund,
+        nns_leave_community_fund, nns_remove_hot_key, nns_send_icp_to_claim_or_refresh_neuron,
+        nns_start_dissolving, setup_nns_canisters, state_machine_builder_for_nns_tests,
     },
 };
 use icp_ledger::{tokens_from_proto, AccountBalanceArgs, AccountIdentifier, Tokens};
+use icrc_ledger_types::icrc1::account::Account;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[test]
@@ -279,6 +283,110 @@ fn test_spawn_neuron() {
 
         Err("Spawned neuron's stake did not show up.".to_string())
     });
+}
+
+#[test]
+fn test_neuron_disburse_maturity() {
+    // Step 1.1: Prepare the world by setting up NNS canisters with 2000 ICP in a ledger account.
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    let test_user_principal = *TEST_NEURON_1_OWNER_PRINCIPAL;
+    let nns_init_payloads = NnsInitPayloadsBuilder::new()
+        .with_ledger_account(
+            AccountIdentifier::new(test_user_principal, None),
+            Tokens::from_e8s(200_000_000_000),
+        )
+        .build();
+    setup_nns_canisters(&state_machine, nns_init_payloads);
+
+    // Step 1.2: Create a neuron with 100 ICP and make sure it has enough dissolve delay.
+    let nonce = 123_456;
+    nns_send_icp_to_claim_or_refresh_neuron(
+        &state_machine,
+        test_user_principal,
+        Tokens::from_e8s(100_000_000_000),
+        nonce,
+    );
+    let test_neuron_id = nns_claim_or_refresh_neuron(&state_machine, test_user_principal, nonce);
+    nns_increase_dissolve_delay(
+        &state_machine,
+        test_user_principal,
+        test_neuron_id,
+        ONE_YEAR_SECONDS * 7,
+    )
+    .unwrap();
+
+    // Step 1.3: Make a proposal and wait for rewards distribution so that the neuron has some maturity.
+    nns_governance_make_proposal(
+        &state_machine,
+        test_user_principal,
+        test_neuron_id,
+        &MakeProposalRequest {
+            title: Some("some title".to_string()),
+            url: "".to_string(),
+            summary: "some summary".to_string(),
+            action: Some(ProposalActionRequest::Motion(Motion {
+                motion_text: "some motion text".to_string(),
+            })),
+        },
+    );
+    state_machine.advance_time(Duration::from_secs(ONE_DAY_SECONDS * 5));
+    for _ in 0..100 {
+        state_machine.advance_time(Duration::from_secs(1));
+        state_machine.tick();
+    }
+    let neuron =
+        nns_governance_get_full_neuron(&state_machine, test_user_principal, test_neuron_id.id)
+            .expect("Failed to get neuron");
+    assert!(neuron.maturity_e8s_equivalent > 0, "{:#?}", neuron);
+    println!("{:#?}", neuron);
+
+    // Step 3: Call the code under test - disburse maturity.
+    let disburse_destination = PrincipalId::new_self_authenticating(&[1u8]);
+    let disburse_response = nns_disburse_maturity(
+        &state_machine,
+        test_user_principal,
+        test_neuron_id,
+        100,
+        Some(GovernanceAccount {
+            owner: Some(disburse_destination),
+            subaccount: None,
+        }),
+    )
+    .panic_if_error("Failed to disburse maturity");
+
+    let Some(CommandResponse::DisburseMaturity(disburse_maturity_response)) =
+        disburse_response.command
+    else {
+        panic!("Failed to disburse maturity: {:#?}", disburse_response)
+    };
+    assert!(disburse_maturity_response.amount_disbursed_e8s() > 0);
+
+    // Sanity check: the destination account should be empty before the disbursement is finalized.
+    let balance = icrc1_balance(
+        &state_machine,
+        LEDGER_CANISTER_ID,
+        Account {
+            owner: disburse_destination.0,
+            subaccount: None,
+        },
+    );
+    assert!(balance.get_e8s() == 0, "{}", balance);
+
+    // Step 4: Wait for 7 days and check that the disbursement was successful.
+    state_machine.advance_time(Duration::from_secs(ONE_DAY_SECONDS * 7));
+    for _ in 0..100 {
+        state_machine.advance_time(Duration::from_secs(1));
+        state_machine.tick();
+    }
+    let balance = icrc1_balance(
+        &state_machine,
+        LEDGER_CANISTER_ID,
+        Account {
+            owner: disburse_destination.0,
+            subaccount: None,
+        },
+    );
+    assert!(balance.get_e8s() > 0, "{}", balance);
 }
 
 /// If a neuron's controller is added as a hot key and then removed, assert that Governance

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -43,16 +43,17 @@ use ic_nns_governance_api::pb::v1::{
         self,
         claim_or_refresh::{self, MemoAndController},
         configure::Operation,
-        AddHotKey, ClaimOrRefresh, Configure, Disburse, Follow, IncreaseDissolveDelay,
-        JoinCommunityFund, LeaveCommunityFund, RegisterVote, RemoveHotKey, Split, StakeMaturity,
+        AddHotKey, ClaimOrRefresh, Configure, Disburse, DisburseMaturity, Follow,
+        IncreaseDissolveDelay, JoinCommunityFund, LeaveCommunityFund, RegisterVote, RemoveHotKey,
+        Split, StakeMaturity,
     },
     manage_neuron_response::{self, ClaimOrRefreshResponse},
-    Empty, ExecuteNnsFunction, GetNeuronsFundAuditInfoRequest, GetNeuronsFundAuditInfoResponse,
-    Governance, GovernanceError, InstallCodeRequest, ListNeurons, ListNeuronsResponse,
-    ListNodeProviderRewardsRequest, ListNodeProviderRewardsResponse, ListProposalInfo,
-    ListProposalInfoResponse, MakeProposalRequest, ManageNeuronCommandRequest, ManageNeuronRequest,
-    ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, NnsFunction,
-    ProposalActionRequest, ProposalInfo, RewardNodeProviders, Topic, Vote,
+    Account as GovernanceAccount, Empty, ExecuteNnsFunction, GetNeuronsFundAuditInfoRequest,
+    GetNeuronsFundAuditInfoResponse, Governance, GovernanceError, InstallCodeRequest, ListNeurons,
+    ListNeuronsResponse, ListNodeProviderRewardsRequest, ListNodeProviderRewardsResponse,
+    ListProposalInfo, ListProposalInfoResponse, MakeProposalRequest, ManageNeuronCommandRequest,
+    ManageNeuronRequest, ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics,
+    NnsFunction, ProposalActionRequest, ProposalInfo, RewardNodeProviders, Topic, Vote,
 };
 use ic_nns_gtc::pb::v1::Gtc;
 use ic_nns_handler_root::init::RootCanisterInitPayload;
@@ -1109,6 +1110,24 @@ pub fn nns_start_dissolving(
         sender,
         neuron_id,
         Operation::StartDissolving(nns_governance_pb::manage_neuron::StartDissolving {}),
+    )
+}
+
+pub fn nns_disburse_maturity(
+    state_machine: &StateMachine,
+    sender: PrincipalId,
+    neuron_id: NeuronId,
+    percentage_to_disburse: u32,
+    to_account: Option<GovernanceAccount>,
+) -> ManageNeuronResponse {
+    manage_neuron(
+        state_machine,
+        sender,
+        neuron_id,
+        ManageNeuronCommandRequest::DisburseMaturity(DisburseMaturity {
+            percentage_to_disburse,
+            to_account,
+        }),
     )
 }
 


### PR DESCRIPTION
# Why

For the DisburseMaturity feature, the initiation of the disbursement has been implemented. This PR implements the finalization of the disbursement where ICPs are minted from maturity.

# What

* Define a timer task to finalize the maturity disbursement and scheduling for the next finalization
* Implement the finalization logic:
  * Validation
  * Acquire neuron lock
  * Pop existing disbursement
  * Mint ICP
  * Error handling

Note that the timer task is behind a feature flag, and the timer task is the entry point. In other words, this PR does not change the production behavior.