### PR TITLE
feat(node_rewards): limit caller to governance for xdr rewards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11460,6 +11460,7 @@ dependencies = [
  "ic-cdk-timers",
  "ic-interfaces-registry",
  "ic-nervous-system-canisters",
+ "ic-nns-constants",
  "ic-nns-test-utils",
  "ic-node-rewards-canister-api",
  "ic-protobuf",

--- a/rs/nns/integration_tests/src/node_provider_remuneration_migration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration_migration.rs
@@ -230,10 +230,9 @@ fn get_rewards_at_version_with_node_rewards_canister(
         machine,
         NODE_REWARDS_CANISTER_ID,
         "get_node_providers_monthly_xdr_rewards",
-        Encode!(&GetNodeProvidersMonthlyXdrRewardsRequest {
+        GetNodeProvidersMonthlyXdrRewardsRequest {
             registry_version: version,
-        })
-        .unwrap(),
+        },
         GOVERNANCE_CANISTER_ID.get(),
     )
     .and_then(|response| {

--- a/rs/nns/integration_tests/src/node_provider_remuneration_migration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration_migration.rs
@@ -6,7 +6,7 @@ use ic_nns_test_utils::common::{
 };
 use ic_nns_test_utils::state_test_helpers::{
     registry_latest_version, setup_nns_canisters_with_features,
-    state_machine_builder_for_nns_tests, update, update_with_sender_bytes,
+    state_machine_builder_for_nns_tests, update_with_sender, update_with_sender_bytes,
 };
 use ic_nns_test_utils_golden_nns_state::new_state_machine_with_golden_nns_state_or_panic;
 use ic_node_rewards_canister_api::monthly_rewards::{
@@ -226,7 +226,7 @@ fn get_rewards_at_version_with_node_rewards_canister(
     machine: &StateMachine,
     version: Option<u64>,
 ) -> Result<(BTreeMap<PrincipalId, u64>, Option<u64>), String> {
-    update(
+    update_with_sender(
         machine,
         NODE_REWARDS_CANISTER_ID,
         "get_node_providers_monthly_xdr_rewards",
@@ -234,10 +234,8 @@ fn get_rewards_at_version_with_node_rewards_canister(
             registry_version: version,
         })
         .unwrap(),
+        GOVERNANCE_CANISTER_ID.get(),
     )
-    .and_then(|r| {
-        Decode!(&r, GetNodeProvidersMonthlyXdrRewardsResponse).map_err(|e| format!("{}", e))
-    })
     .and_then(|response| {
         let GetNodeProvidersMonthlyXdrRewardsResponse { rewards, error } = response;
 

--- a/rs/node_rewards/canister/BUILD.bazel
+++ b/rs/node_rewards/canister/BUILD.bazel
@@ -8,6 +8,7 @@ DEPENDENCIES = [
     # Keep sorted.
     "//rs/interfaces/registry",
     "//rs/nervous_system/canisters",
+    "//rs/nns/constants",
     "//rs/node_rewards/canister/api",
     "//rs/protobuf",
     "//rs/registry/canister-client",

--- a/rs/node_rewards/canister/Cargo.toml
+++ b/rs/node_rewards/canister/Cargo.toml
@@ -19,6 +19,7 @@ ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
 ic-interfaces-registry = { path = "../../interfaces/registry" }
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }
+ic-nns-constants = { path = "../../nns/constants" }
 ic-node-rewards-canister-api = { path = "./api" }
 ic-registry-canister-client = { path = "../../registry/canister-client" }
 ic-registry-keys = { path = "../../registry/keys" }

--- a/rs/node_rewards/canister/api/src/monthly_rewards.rs
+++ b/rs/node_rewards/canister/api/src/monthly_rewards.rs
@@ -1,7 +1,7 @@
 use candid::{CandidType, Deserialize, Principal};
 use std::collections::BTreeMap;
 
-#[derive(CandidType, Deserialize)]
+#[derive(CandidType, Clone, Deserialize)]
 pub struct GetNodeProvidersMonthlyXdrRewardsRequest {
     pub registry_version: Option<u64>,
 }

--- a/rs/node_rewards/canister/src/main.rs
+++ b/rs/node_rewards/canister/src/main.rs
@@ -1,7 +1,9 @@
+use candid::Principal;
 #[cfg(any(feature = "test", test))]
 use ic_cdk::query;
 use ic_cdk::{init, post_upgrade, pre_upgrade, spawn, update};
 use ic_nervous_system_canisters::registry::RegistryCanister;
+use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_node_rewards_canister::canister::NodeRewardsCanister;
 use ic_node_rewards_canister::storage::RegistryStoreStableMemoryBorrower;
 use ic_node_rewards_canister_api::monthly_rewards::{
@@ -12,7 +14,6 @@ use ic_registry_canister_client::StableCanisterRegistryClient;
 use std::cell::RefCell;
 use std::sync::Arc;
 use std::time::Duration;
-use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 
 fn main() {}
 
@@ -27,6 +28,23 @@ thread_local! {
             store.clone()
         })))
     };
+}
+
+#[cfg(any(feature = "test", test))]
+thread_local! {
+    static TEST_CALLER: RefCell<Principal> = {
+        RefCell::new(Principal::from_text("aaaaa-aa").unwrap())
+    };
+}
+
+#[cfg(any(feature = "test", test))]
+fn caller() -> Principal {
+    TEST_CALLER.with_borrow(|p| *p)
+}
+
+#[cfg(not(any(feature = "test", test)))]
+fn caller() -> Principal {
+    ic_cdk::caller()
 }
 
 #[init]
@@ -66,7 +84,7 @@ fn schedule_registry_sync() {
 }
 
 fn panic_if_not_governance() {
-    if ic_cdk::caller() != GOVERNANCE_CANISTER_ID.get().0 {
+    if caller() != GOVERNANCE_CANISTER_ID.get().0 {
         panic!("Only the governance canister can call this method");
     }
 }
@@ -89,6 +107,8 @@ async fn get_node_providers_monthly_xdr_rewards(
 mod tests {
     use super::*;
     use candid_parser::utils::{service_equal, CandidSource};
+    use futures_util::FutureExt;
+
     #[test]
     fn test_implemented_interface_matches_declared_interface_exactly() {
         let declared_interface = CandidSource::Text(include_str!("../node-rewards-canister.did"));
@@ -103,11 +123,31 @@ mod tests {
         let result = service_equal(declared_interface, implemented_interface);
         assert!(result.is_ok(), "{:?}\n\n", result.unwrap_err());
     }
-   // Test only governance can call get_monthly_xdr_rewards
-   #[test]
-   #[should_panic(expected = "Only the governance canister can call this method")]
-   fn test_get_monthly_xdr_rewards_only_governance_can_call() {
-      let request = GetNodeProvidersMonthlyXdrRewardsRequest {registry_version: None};
-      get_node_providers_monthly_xdr_rewards(request);
-   }
+    // Test only governance can call get_monthly_xdr_rewards
+    #[test]
+    #[should_panic(expected = "Only the governance canister can call this method")]
+    fn test_get_monthly_xdr_rewards_not_governance_panics() {
+        let request = GetNodeProvidersMonthlyXdrRewardsRequest {
+            registry_version: None,
+        };
+        get_node_providers_monthly_xdr_rewards(request)
+            .now_or_never()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_get_monthly_xdr_rewards_is_callable_by_governance() {
+        TEST_CALLER.with_borrow_mut(|p| {
+            *p = GOVERNANCE_CANISTER_ID.get().0;
+        });
+
+        let request = GetNodeProvidersMonthlyXdrRewardsRequest {
+            registry_version: None,
+        };
+        let response = get_node_providers_monthly_xdr_rewards(request)
+            .now_or_never()
+            .unwrap();
+
+        assert!(response.error.is_some());
+    }
 }

--- a/rs/node_rewards/canister/src/main.rs
+++ b/rs/node_rewards/canister/src/main.rs
@@ -12,6 +12,7 @@ use ic_registry_canister_client::StableCanisterRegistryClient;
 use std::cell::RefCell;
 use std::sync::Arc;
 use std::time::Duration;
+use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 
 fn main() {}
 
@@ -64,6 +65,12 @@ fn schedule_registry_sync() {
     });
 }
 
+fn panic_if_not_governance() {
+    if ic_cdk::caller() != GOVERNANCE_CANISTER_ID.get().0 {
+        panic!("Only the governance canister can call this method");
+    }
+}
+
 #[cfg(any(feature = "test", test))]
 #[query(hidden = true)]
 fn get_registry_value(key: String) -> Result<Option<Vec<u8>>, String> {
@@ -74,6 +81,7 @@ fn get_registry_value(key: String) -> Result<Option<Vec<u8>>, String> {
 async fn get_node_providers_monthly_xdr_rewards(
     request: GetNodeProvidersMonthlyXdrRewardsRequest,
 ) -> GetNodeProvidersMonthlyXdrRewardsResponse {
+    panic_if_not_governance();
     NodeRewardsCanister::get_node_providers_monthly_xdr_rewards(&CANISTER, request).await
 }
 
@@ -95,4 +103,11 @@ mod tests {
         let result = service_equal(declared_interface, implemented_interface);
         assert!(result.is_ok(), "{:?}\n\n", result.unwrap_err());
     }
+   // Test only governance can call get_monthly_xdr_rewards
+   #[test]
+   #[should_panic(expected = "Only the governance canister can call this method")]
+   fn test_get_monthly_xdr_rewards_only_governance_can_call() {
+      let request = GetNodeProvidersMonthlyXdrRewardsRequest {registry_version: None};
+      get_node_providers_monthly_xdr_rewards(request);
+   }
 }

--- a/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
+++ b/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
@@ -1,0 +1,53 @@
+use ic_nns_constants::NODE_REWARDS_CANISTER_ID;
+use ic_nns_test_utils::state_test_helpers::{
+    setup_nns_node_rewards_with_correct_canister_id, state_machine_builder_for_nns_tests,
+    update_with_sender,
+};
+use ic_node_rewards_canister_api::monthly_rewards::{
+    GetNodeProvidersMonthlyXdrRewardsRequest, GetNodeProvidersMonthlyXdrRewardsResponse,
+};
+use ic_types::PrincipalId;
+
+#[test]
+fn get_node_providers_monthly_xdr_rewards_is_only_callable_by_governance() {
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    setup_nns_node_rewards_with_correct_canister_id(&state_machine);
+
+    let request = GetNodeProvidersMonthlyXdrRewardsRequest {
+        registry_version: None,
+    };
+
+    let attempt_with_bad_caller: Result<GetNodeProvidersMonthlyXdrRewardsResponse, String> =
+        update_with_sender(
+            &state_machine,
+            NODE_REWARDS_CANISTER_ID,
+            "get_node_providers_monthly_xdr_rewards",
+            request.clone(),
+            PrincipalId::new_user_test_id(1),
+        );
+    let actual_error = attempt_with_bad_caller.unwrap_err();
+
+    assert!(
+        actual_error.contains("Only the governance canister can call this method"),
+        "Expected error message not found, was {}",
+        actual_error
+    );
+
+    let attempt_with_governance: Result<GetNodeProvidersMonthlyXdrRewardsResponse, String> =
+        update_with_sender(
+            &state_machine,
+            NODE_REWARDS_CANISTER_ID,
+            "get_node_providers_monthly_xdr_rewards",
+            request,
+            ic_nns_constants::GOVERNANCE_CANISTER_ID.get(),
+        );
+
+    let error = attempt_with_governance.unwrap().error.unwrap();
+
+    // Registry canister isn't installed, so this is the expected error when you use the right caller.
+    assert!(
+        error.contains("Could not sync registry store to latest version, please try again later"),
+        "Expected error response not found, was {}",
+        error
+    );
+}

--- a/rs/node_rewards/canister/unreleased_changelog.md
+++ b/rs/node_rewards/canister/unreleased_changelog.md
@@ -17,5 +17,6 @@ on the process that this file is part of, see
 ## Fixed
 
 * Fixed a bug with the registry client that prevented the canister from reading registry data when there were deletions.
+* Limit 'get_node_providers_monthly_xdr_rewards' to only be callable from NNS Governance.
 
 ## Security


### PR DESCRIPTION
# What 

Limit callers to Node Reward canister to only be governance

# Why 

Reduce unnecessary traffic to the canister and avoid making the API publicly utilized and hard to evolve during the next phase of changes.