### PR TITLE
refactor(nns): Clean up allow_active_neurons_in_stable_memory

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,19 +1,7 @@
 benches:
-  add_neuron_active_maximum_heap:
-    total:
-      instructions: 23280218
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
   add_neuron_active_maximum_stable:
     total:
       instructions: 60061051
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
-  add_neuron_active_typical_heap:
-    total:
-      instructions: 1183126
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -34,18 +22,6 @@ benches:
       instructions: 4322793
       heap_increase: 0
       stable_memory_increase: 0
-    scopes: {}
-  cascading_vote_all_heap:
-    total:
-      instructions: 46131104
-      heap_increase: 0
-      stable_memory_increase: 128
-    scopes: {}
-  cascading_vote_heap_neurons_stable_index:
-    total:
-      instructions: 46131104
-      heap_increase: 0
-      stable_memory_increase: 128
     scopes: {}
   cascading_vote_stable_everything:
     total:
@@ -71,21 +47,9 @@ benches:
       heap_increase: 0
       stable_memory_increase: 256
     scopes: {}
-  draw_maturity_from_neurons_fund_heap:
-    total:
-      instructions: 5801826
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
   draw_maturity_from_neurons_fund_stable:
     total:
       instructions: 7081729
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
-  list_active_neurons_fund_neurons_heap:
-    total:
-      instructions: 427791
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -95,22 +59,10 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  list_neurons_by_subaccount_heap:
-    total:
-      instructions: 5840597
-      heap_increase: 8
-      stable_memory_increase: 0
-    scopes: {}
   list_neurons_by_subaccount_stable:
     total:
       instructions: 65158559
       heap_increase: 3
-      stable_memory_increase: 0
-    scopes: {}
-  list_neurons_heap:
-    total:
-      instructions: 4725863
-      heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
@@ -125,33 +77,15 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  list_ready_to_spawn_neuron_ids_heap:
-    total:
-      instructions: 132310
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
   list_ready_to_spawn_neuron_ids_stable:
     total:
       instructions: 35189841
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  neuron_data_validation_heap:
-    total:
-      instructions: 227735829
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
   neuron_data_validation_stable:
     total:
       instructions: 199983153
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
-  neuron_metrics_calculation_heap:
-    total:
-      instructions: 1485558
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -173,20 +107,6 @@ benches:
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
-  unstake_maturity_of_dissolved_neurons_heap:
-    total:
-      instructions: 2526970
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes:
-      list_neuron_ids:
-        instructions: 226922
-        heap_increase: 0
-        stable_memory_increase: 0
-      unstake_maturity:
-        instructions: 2296180
-        heap_increase: 0
-        stable_memory_increase: 0
   unstake_maturity_of_dissolved_neurons_stable:
     total:
       instructions: 61147456
@@ -207,21 +127,9 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  with_neuron_mut_all_sections_maximum_heap:
-    total:
-      instructions: 892271
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
   with_neuron_mut_all_sections_maximum_stable:
     total:
       instructions: 5029879
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
-  with_neuron_mut_all_sections_typical_heap:
-    total:
-      instructions: 225403
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -231,21 +139,9 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  with_neuron_mut_main_section_maximum_heap:
-    total:
-      instructions: 722379
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
   with_neuron_mut_main_section_maximum_stable:
     total:
       instructions: 2416827
-      heap_increase: 0
-      stable_memory_increase: 0
-    scopes: {}
-  with_neuron_mut_main_section_typical_heap:
-    total:
-      instructions: 57487
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -15,9 +15,6 @@ use crate::{
         KnownNeuron, ListProposalInfo, NetworkEconomics, Neuron as NeuronProto, NnsFunction,
         Proposal, ProposalData, Topic, Vote,
     },
-    temporarily_disable_allow_active_neurons_in_stable_memory,
-    temporarily_disable_migrate_active_neurons_to_stable_memory,
-    temporarily_enable_allow_active_neurons_in_stable_memory,
     temporarily_enable_migrate_active_neurons_to_stable_memory,
     test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
 };
@@ -412,36 +409,7 @@ fn make_neuron(
 
 #[bench(raw)]
 fn cascading_vote_stable_everything() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
-
-    cast_vote_cascade_helper(
-        SetUpStrategy::Chain {
-            num_neurons: 151,
-            num_followees: 15,
-        },
-        Topic::NetworkEconomics,
-    )
-}
-
-#[bench(raw)]
-fn cascading_vote_all_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _c = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    cast_vote_cascade_helper(
-        SetUpStrategy::Chain {
-            num_neurons: 151,
-            num_followees: 15,
-        },
-        Topic::NetworkEconomics,
-    )
-}
-
-#[bench(raw)]
-fn cascading_vote_heap_neurons_stable_index() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _c = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
         SetUpStrategy::Chain {
@@ -454,7 +422,6 @@ fn cascading_vote_heap_neurons_stable_index() -> BenchResult {
 
 #[bench(raw)]
 fn single_vote_all_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
@@ -465,7 +432,6 @@ fn single_vote_all_stable() -> BenchResult {
 
 #[bench(raw)]
 fn centralized_following_all_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     cast_vote_cascade_helper(
@@ -479,7 +445,6 @@ fn compute_ballots_for_new_proposal_with_stable_neurons() -> BenchResult {
     let now_seconds = 1732817584;
     let num_neurons = 100;
 
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let neurons = (0..num_neurons)
         .map(|id| {
@@ -533,7 +498,6 @@ fn compute_ballots_for_new_proposal_with_stable_neurons() -> BenchResult {
 fn distribute_rewards_with_stable_neurons() -> BenchResult {
     let now_seconds = 1732817584;
 
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let neurons = (0..100)
         .map(|id| {
@@ -697,32 +661,14 @@ fn list_neurons_benchmark() -> BenchResult {
 /// Benchmark list_neurons
 #[bench(raw)]
 fn list_neurons_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
-    list_neurons_benchmark()
-}
-
-/// Benchmark list_neurons
-#[bench(raw)]
-fn list_neurons_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     list_neurons_benchmark()
 }
 
 /// Benchmark list_neurons
 #[bench(raw)]
 fn list_neurons_by_subaccount_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
-    list_neurons_by_subaccount_benchmark()
-}
-
-/// Benchmark list_neurons
-#[bench(raw)]
-fn list_neurons_by_subaccount_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
     list_neurons_by_subaccount_benchmark()
 }
 

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -200,8 +200,6 @@ pub const DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS: u64 = 1725148800;
 // leave this here indefinitely, but it will just be clutter after a modest
 // amount of time.
 thread_local! {
-    static ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
-
     static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
 
     static DISABLE_NF_FUND_PROPOSALS: Cell<bool>
@@ -218,22 +216,6 @@ thread_local! {
     // begun. (This occurs in one of the prune_some_following functions.)
     static CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS: Cell<u64> =
         const { Cell::new(0) };
-}
-
-pub fn allow_active_neurons_in_stable_memory() -> bool {
-    ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY.get()
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_enable_allow_active_neurons_in_stable_memory() -> Temporary {
-    Temporary::new(&ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY, true)
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_disable_allow_active_neurons_in_stable_memory() -> Temporary {
-    Temporary::new(&ALLOW_ACTIVE_NEURONS_IN_STABLE_MEMORY, false)
 }
 
 pub fn migrate_active_neurons_to_stable_memory() -> bool {

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -1,5 +1,4 @@
 use crate::{
-    allow_active_neurons_in_stable_memory,
     governance::{TimeWarp, LOG_PREFIX},
     migrate_active_neurons_to_stable_memory,
     neuron::types::Neuron,
@@ -269,10 +268,6 @@ pub struct NeuronStore {
     // NeuronStore) implements additional traits. Therefore, more elaborate wrapping is needed.
     clock: Box<dyn PracticalClock>,
 
-    // Whether to allow active neurons in stable memory. When this is true, when finding/iterating
-    // through active neurons, we need to check both heap and stable memory.
-    allow_active_neurons_in_stable_memory: bool,
-
     /// Whether to migrate active neurons to stable memory. This is a temporary flag to change the
     /// mode of operation for the NeuronStore. Once all neurons are in stable memory, this will be
     /// removed.
@@ -288,7 +283,6 @@ impl PartialEq for NeuronStore {
         let Self {
             heap_neurons,
             clock: _,
-            allow_active_neurons_in_stable_memory: _,
             migrate_active_neurons_to_stable_memory: _,
         } = self;
 
@@ -301,7 +295,6 @@ impl Default for NeuronStore {
         Self {
             heap_neurons: BTreeMap::new(),
             clock: Box::new(IcClock::new()),
-            allow_active_neurons_in_stable_memory: false,
             migrate_active_neurons_to_stable_memory: false,
         }
     }
@@ -316,7 +309,6 @@ impl NeuronStore {
         let mut neuron_store = Self {
             heap_neurons: BTreeMap::new(),
             clock: Box::new(IcClock::new()),
-            allow_active_neurons_in_stable_memory: allow_active_neurons_in_stable_memory(),
             migrate_active_neurons_to_stable_memory: migrate_active_neurons_to_stable_memory(),
         };
 
@@ -344,7 +336,6 @@ impl NeuronStore {
                 .map(|(id, proto)| (id, Neuron::try_from(proto).unwrap()))
                 .collect(),
             clock,
-            allow_active_neurons_in_stable_memory: allow_active_neurons_in_stable_memory(),
             migrate_active_neurons_to_stable_memory: migrate_active_neurons_to_stable_memory(),
         }
     }
@@ -694,23 +685,18 @@ impl NeuronStore {
         callback: impl for<'b> FnOnce(Box<dyn Iterator<Item = Cow<Neuron>> + 'b>) -> R,
         sections: NeuronSections,
     ) -> R {
-        if self.allow_active_neurons_in_stable_memory {
-            // Note, during migration, we still need heap_neurons, so we chain them onto the iterator
-            with_stable_neuron_store(|stable_store| {
-                let now = self.now();
-                let iter = Box::new(
-                    stable_store
-                        .range_neurons_sections(.., sections)
-                        .filter(|n| !n.is_inactive(now))
-                        .map(Cow::Owned)
-                        .chain(self.heap_neurons.values().map(Cow::Borrowed)),
-                );
-                callback(iter)
-            })
-        } else {
-            let iter = Box::new(self.heap_neurons.values().map(Cow::Borrowed));
+        // Note, during migration, we still need heap_neurons, so we chain them onto the iterator
+        with_stable_neuron_store(|stable_store| {
+            let now = self.now();
+            let iter = Box::new(
+                stable_store
+                    .range_neurons_sections(.., sections)
+                    .filter(|n| !n.is_inactive(now))
+                    .map(Cow::Owned)
+                    .chain(self.heap_neurons.values().map(Cow::Borrowed)),
+            );
             callback(iter)
-        }
+        })
     }
 
     /// Returns the smallest neuron ID that is in range and in self.
@@ -1035,42 +1021,30 @@ impl NeuronStore {
         neuron_id: &NeuronId,
         modify: impl FnOnce(u64) -> Result<u64, String>,
     ) -> Result<(), NeuronStoreError> {
-        // When `allow_active_neurons_in_stable_memory` is true, all the neurons SHOULD be in the stable
-        // neuron store. Therefore, there is no need to move the neuron between heap/stable as it
-        // might become active/inactive due to the change of maturity.
-        if self.allow_active_neurons_in_stable_memory {
-            // The validity of this approach is based on the assumption that none of the neuron
-            // indexes can be affected by its maturity.
-            if self.heap_neurons.contains_key(&neuron_id.id) {
-                self.heap_neurons
-                    .get_mut(&neuron_id.id)
-                    .map(|neuron| -> Result<(), String> {
+        // The validity of this approach is based on the assumption that none of the neuron
+        // indexes can be affected by its maturity.
+        if self.heap_neurons.contains_key(&neuron_id.id) {
+            self.heap_neurons
+                .get_mut(&neuron_id.id)
+                .map(|neuron| -> Result<(), String> {
+                    let new_maturity = modify(neuron.maturity_e8s_equivalent)?;
+                    neuron.maturity_e8s_equivalent = new_maturity;
+                    Ok(())
+                })
+                .transpose()
+                .map_err(|e| NeuronStoreError::InvalidData { reason: e })?
+                .ok_or_else(|| NeuronStoreError::not_found(*neuron_id))
+        } else {
+            with_stable_neuron_store_mut(|stable_neuron_store| {
+                stable_neuron_store
+                    .with_main_part_mut(*neuron_id, |neuron| -> Result<(), String> {
                         let new_maturity = modify(neuron.maturity_e8s_equivalent)?;
                         neuron.maturity_e8s_equivalent = new_maturity;
                         Ok(())
-                    })
-                    .transpose()
-                    .map_err(|e| NeuronStoreError::InvalidData { reason: e })?
-                    .ok_or_else(|| NeuronStoreError::not_found(*neuron_id))
-            } else {
-                with_stable_neuron_store_mut(|stable_neuron_store| {
-                    stable_neuron_store
-                        .with_main_part_mut(*neuron_id, |neuron| -> Result<(), String> {
-                            let new_maturity = modify(neuron.maturity_e8s_equivalent)?;
-                            neuron.maturity_e8s_equivalent = new_maturity;
-                            Ok(())
-                        })?
-                        .map_err(|e| NeuronStoreError::InvalidData { reason: e })?;
-                    Ok(())
-                })
-            }
-        } else {
-            self.with_neuron_mut(neuron_id, |neuron| {
-                let new_maturity = modify(neuron.maturity_e8s_equivalent)
-                    .map_err(|reason| NeuronStoreError::InvalidData { reason })?;
-                neuron.maturity_e8s_equivalent = new_maturity;
+                    })?
+                    .map_err(|e| NeuronStoreError::InvalidData { reason: e })?;
                 Ok(())
-            })?
+            })
         }
     }
 
@@ -1150,42 +1124,6 @@ impl NeuronStore {
     /// Returns `None` if there is no maturity disbursement at all.
     pub fn get_next_maturity_disbursement(&self) -> Option<(u64, NeuronId)> {
         with_stable_neuron_indexes(|indexes| indexes.maturity_disbursement().get_next_entry())
-    }
-
-    /// Validates a batch of neurons in stable neuron store are all inactive.
-    ///
-    /// The batch is defined as the `next_neuron_id` to start and the `batch_size` for the upper
-    /// bound of the number of neurons to validate.
-    ///
-    /// Returns the neuron id the next batch will start with (the neuron id last validated + 1). If
-    /// no neuron is validated in this batch, returns None.
-    pub fn batch_validate_neurons_in_stable_store_are_inactive(
-        &self,
-        next_neuron_id: NeuronId,
-        batch_size: usize,
-    ) -> (Vec<NeuronId>, Option<NeuronId>) {
-        let mut neuron_id_for_next_batch = None;
-        let active_neurons_in_stable_store = with_stable_neuron_store(|stable_neuron_store| {
-            stable_neuron_store
-                .range_neurons(next_neuron_id..)
-                .take(batch_size)
-                .flat_map(|neuron| {
-                    let current_neuron_id = neuron.id();
-                    neuron_id_for_next_batch = current_neuron_id.next();
-
-                    let is_neuron_inactive = neuron.is_inactive(self.now());
-
-                    if self.allow_active_neurons_in_stable_memory || is_neuron_inactive {
-                        None
-                    } else {
-                        // An active neuron in stable neuron store is invalid.
-                        Some(current_neuron_id)
-                    }
-                })
-                .collect()
-        });
-
-        (active_neurons_in_stable_store, neuron_id_for_next_batch)
     }
 
     // Census

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -10,9 +10,6 @@ use crate::{
     neurons_fund::{NeuronsFund, NeuronsFundNeuronPortion, NeuronsFundSnapshot},
     now_seconds,
     pb::v1::{neuron::Followees, BallotInfo, KnownNeuronData, Vote},
-    temporarily_disable_allow_active_neurons_in_stable_memory,
-    temporarily_disable_migrate_active_neurons_to_stable_memory,
-    temporarily_enable_allow_active_neurons_in_stable_memory,
     temporarily_enable_migrate_active_neurons_to_stable_memory,
 };
 use canbench_rs::{bench, bench_fn, BenchResult};
@@ -158,22 +155,7 @@ fn set_up_neuron_store(
 }
 
 #[bench(raw)]
-fn add_neuron_active_typical_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    let mut rng = new_rng();
-    let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
-    let neuron =
-        new_neuron_builder(&mut rng, NeuronActiveness::Active, NeuronSize::Typical).build();
-
-    bench_fn(|| {
-        neuron_store.add_neuron(neuron).unwrap();
-    })
-}
-
-#[bench(raw)]
 fn add_neuron_active_typical_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
@@ -186,23 +168,7 @@ fn add_neuron_active_typical_stable() -> BenchResult {
 }
 
 #[bench(raw)]
-fn add_neuron_active_maximum_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    let mut rng = new_rng();
-    let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
-    let neuron =
-        new_neuron_builder(&mut rng, NeuronActiveness::Active, NeuronSize::Maximum).build();
-
-    bench_fn(|| {
-        neuron_store.add_neuron(neuron).unwrap();
-    })
-}
-
-#[bench(raw)]
 fn add_neuron_active_maximum_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     let mut rng = new_rng();
@@ -272,64 +238,31 @@ fn modify_neuron_main_section(neuron: &mut Neuron) {
 }
 
 #[bench(raw)]
-fn with_neuron_mut_all_sections_typical_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    with_neuron_mut_benchmark(NeuronSize::Typical, modify_neuron_all_sections)
-}
-
-#[bench(raw)]
 fn with_neuron_mut_all_sections_typical_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     with_neuron_mut_benchmark(NeuronSize::Typical, modify_neuron_all_sections)
-}
-
-#[bench(raw)]
-fn with_neuron_mut_all_sections_maximum_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    with_neuron_mut_benchmark(NeuronSize::Maximum, modify_neuron_all_sections)
 }
 
 #[bench(raw)]
 fn with_neuron_mut_all_sections_maximum_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     with_neuron_mut_benchmark(NeuronSize::Maximum, modify_neuron_all_sections)
 }
 
 #[bench(raw)]
-fn with_neuron_mut_main_section_typical_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    with_neuron_mut_benchmark(NeuronSize::Typical, modify_neuron_main_section)
-}
-
-#[bench(raw)]
 fn with_neuron_mut_main_section_typical_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     with_neuron_mut_benchmark(NeuronSize::Typical, modify_neuron_main_section)
 }
 
 #[bench(raw)]
-fn with_neuron_mut_main_section_maximum_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    with_neuron_mut_benchmark(NeuronSize::Maximum, modify_neuron_main_section)
-}
-
-#[bench(raw)]
 fn with_neuron_mut_main_section_maximum_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     with_neuron_mut_benchmark(NeuronSize::Maximum, modify_neuron_main_section)
 }
 
 #[bench(raw)]
 fn update_recent_ballots_stable_memory() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
@@ -387,15 +320,7 @@ fn neuron_metrics_benchmark() -> BenchResult {
 }
 
 #[bench(raw)]
-fn neuron_metrics_calculation_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    neuron_metrics_benchmark()
-}
-
-#[bench(raw)]
 fn neuron_metrics_calculation_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     neuron_metrics_benchmark()
 }
@@ -441,15 +366,7 @@ fn list_ready_to_spawn_neuron_ids_benchmark() -> BenchResult {
 }
 
 #[bench(raw)]
-fn list_ready_to_spawn_neuron_ids_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    list_ready_to_spawn_neuron_ids_benchmark()
-}
-
-#[bench(raw)]
 fn list_ready_to_spawn_neuron_ids_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     list_ready_to_spawn_neuron_ids_benchmark()
 }
@@ -476,21 +393,7 @@ fn add_neuron_ready_to_unstake_maturity(
 }
 
 #[bench(raw)]
-fn unstake_maturity_of_dissolved_neurons_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    let mut rng = new_rng();
-    let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
-    for _ in 0..100 {
-        add_neuron_ready_to_unstake_maturity(now_seconds(), &mut rng, &mut neuron_store);
-    }
-
-    bench_fn(|| neuron_store.unstake_maturity_of_dissolved_neurons(now_seconds(), 100))
-}
-
-#[bench(raw)]
 fn unstake_maturity_of_dissolved_neurons_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
@@ -550,15 +453,7 @@ fn draw_maturity_from_neurons_fund_benchmark() -> BenchResult {
 }
 
 #[bench(raw)]
-fn draw_maturity_from_neurons_fund_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    draw_maturity_from_neurons_fund_benchmark()
-}
-
-#[bench(raw)]
 fn draw_maturity_from_neurons_fund_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     draw_maturity_from_neurons_fund_benchmark()
 }
@@ -585,15 +480,7 @@ fn list_active_neurons_fund_neurons_benchmark() -> BenchResult {
 }
 
 #[bench(raw)]
-fn list_active_neurons_fund_neurons_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    list_active_neurons_fund_neurons_benchmark()
-}
-
-#[bench(raw)]
 fn list_active_neurons_fund_neurons_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     list_active_neurons_fund_neurons_benchmark()
 }
@@ -615,21 +502,7 @@ fn validate_all_neurons(neuron_store: &NeuronStore, validator: &mut NeuronDataVa
 }
 
 #[bench(raw)]
-fn neuron_data_validation_heap() -> BenchResult {
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-    let mut rng = new_rng();
-    let neuron_store = set_up_neuron_store(&mut rng, 100, 200);
-    let mut validator = NeuronDataValidator::new();
-
-    bench_fn(|| {
-        validate_all_neurons(&neuron_store, &mut validator);
-    })
-}
-
-#[bench(raw)]
 fn neuron_data_validation_stable() -> BenchResult {
-    let _a = temporarily_enable_allow_active_neurons_in_stable_memory();
     let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 200);

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -253,27 +253,14 @@ impl NeuronStore {
         voting_power_economics: &VotingPowerEconomics,
         now_seconds: u64,
     ) -> NeuronMetrics {
-        let mut metrics = if self.allow_active_neurons_in_stable_memory {
-            NeuronMetrics::default()
-        } else {
-            // If we are not using stable memory for all neurons, we still assume
-            // these base level metrics
-            NeuronMetrics {
-                garbage_collectable_neurons_count: with_stable_neuron_store(
-                    |stable_neuron_store| stable_neuron_store.len() as u64,
-                ),
-                ..Default::default()
-            }
-        };
+        let mut metrics = NeuronMetrics::default();
 
-        if self.allow_active_neurons_in_stable_memory {
-            self.compute_neuron_metrics_all_stable(
-                &mut metrics,
-                neuron_minimum_stake_e8s,
-                voting_power_economics,
-                now_seconds,
-            );
-        }
+        self.compute_neuron_metrics_all_stable(
+            &mut metrics,
+            neuron_minimum_stake_e8s,
+            voting_power_economics,
+            now_seconds,
+        );
         // During migration, some neurons may be in the heap, so we need to compute
         // metrics for them as well.
         self.compute_neuron_metrics_current(

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -1,11 +1,8 @@
 use super::*;
 use crate::{
-    allow_active_neurons_in_stable_memory,
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::{KnownNeuronData, NeuronType},
-    temporarily_disable_allow_active_neurons_in_stable_memory,
     temporarily_disable_migrate_active_neurons_to_stable_memory,
-    temporarily_enable_allow_active_neurons_in_stable_memory,
     temporarily_enable_migrate_active_neurons_to_stable_memory,
 };
 use ic_base_types::PrincipalId;
@@ -263,29 +260,12 @@ fn test_compute_metrics_helper() {
             16 => 6087000000.0,
         },
         not_dissolving_neurons_count_buckets: hashmap! {0 => 3, 2 => 1, 8 => 2, 16 => 1},
-        dissolved_neurons_count: if allow_active_neurons_in_stable_memory() {
-            // This is accurate.
-            4
-        } else {
-            // This is the incorrect behavior when inactive neurons are migrated to stable
-            // memory, which will be fixed once `allow_active_neurons_in_stable_memory` is
-            // turned on.
-            3
-        },
+        dissolved_neurons_count: 4,
         dissolved_neurons_e8s: 5770000000,
         garbage_collectable_neurons_count: 1,
         neurons_with_invalid_stake_count: 1,
         total_staked_e8s: 39_894_000_100,
-        neurons_with_less_than_6_months_dissolve_delay_count:
-            if allow_active_neurons_in_stable_memory() {
-                // This is accurate.
-                7
-            } else {
-                // This is the incorrect behavior when inactive neurons are migrated to stable
-                // memory, which will be fixed once `allow_active_neurons_in_stable_memory` is
-                // turned on.
-                6
-            },
+        neurons_with_less_than_6_months_dissolve_delay_count: 7,
         neurons_with_less_than_6_months_dissolve_delay_e8s: 5870000100,
         community_fund_total_staked_e8s: 234_000_000,
         community_fund_total_maturity_e8s_equivalent: 450_988_012,
@@ -338,20 +318,10 @@ fn test_compute_metrics_helper() {
     );
 }
 
-// In this stage, no active neurons can be in stable memory.
-#[test]
-fn test_compute_metrics() {
-    let _t1 = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _t2 = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    test_compute_metrics_helper();
-}
-
 // Migration stage 1: allow active neurons in stable memory, but not migrating yet.
 #[test]
-fn test_compute_metrics_allow_active_neurons_in_stable_memory() {
-    let _t1 = temporarily_enable_allow_active_neurons_in_stable_memory();
-    let _t2 = temporarily_disable_migrate_active_neurons_to_stable_memory();
+fn test_compute_metrics() {
+    let _t = temporarily_disable_migrate_active_neurons_to_stable_memory();
 
     test_compute_metrics_helper();
 }
@@ -359,8 +329,7 @@ fn test_compute_metrics_allow_active_neurons_in_stable_memory() {
 // Migration stage 2: allow active neurons in stable memory and new active neurons are in stable memory.
 #[test]
 fn test_compute_metrics_migrate_active_neurons_to_stable_memory() {
-    let _t1 = temporarily_enable_allow_active_neurons_in_stable_memory();
-    let _t2 = temporarily_enable_migrate_active_neurons_to_stable_memory();
+    let _t = temporarily_enable_migrate_active_neurons_to_stable_memory();
 
     test_compute_metrics_helper();
 }

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -3,16 +3,12 @@ use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::{neuron::Followees, MaturityDisbursement},
     storage::with_stable_neuron_indexes,
-    temporarily_disable_allow_active_neurons_in_stable_memory,
-    temporarily_disable_migrate_active_neurons_to_stable_memory,
     temporarily_enable_disburse_maturity,
 };
-use ic_nervous_system_common::{ONE_DAY_SECONDS, ONE_MONTH_SECONDS};
+use ic_nervous_system_common::ONE_MONTH_SECONDS;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use maplit::{btreemap, btreeset, hashmap, hashset};
-use num_traits::bounds::LowerBounded;
 use pretty_assertions::assert_eq;
-use std::cell::Cell;
 
 // Value is 6 months ahead of when this code was written. For realism, and to
 // make sure this is "long" after we release periodic confirmation.
@@ -305,70 +301,6 @@ fn test_neuron_store_new_then_restore() {
     );
 }
 
-#[test]
-fn test_batch_validate_neurons_in_stable_store_are_inactive() {
-    // Create a neuron store with 80 neurons.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-    for i in 1..=80 {
-        // The dissolve state timestamp is chosen so that it meets the inactive neuron criteria.
-        neuron_store
-            .add_neuron(inactive_neuron_builder(i).build())
-            .unwrap();
-    }
-
-    // Validate 8 batches with 10 each batch.
-    let mut next_neuron_id = NeuronId::min_value();
-    for _ in 0..8 {
-        let (invalid_neuron_ids, neuron_id_for_next_batch) =
-            neuron_store.batch_validate_neurons_in_stable_store_are_inactive(next_neuron_id, 10);
-
-        // No invalid neuron ids should be found.
-        assert_eq!(invalid_neuron_ids, vec![]);
-
-        // There should always be the next neuron id.
-        next_neuron_id = neuron_id_for_next_batch.unwrap();
-    }
-
-    // Validate one more time and there shouldn't be any validation done for this round.
-    let (invalid_neuron_ids, neuron_id_for_next_batch) =
-        neuron_store.batch_validate_neurons_in_stable_store_are_inactive(next_neuron_id, 10);
-    assert_eq!(invalid_neuron_ids, vec![]);
-    assert_eq!(neuron_id_for_next_batch, None);
-}
-
-#[test]
-fn test_batch_validate_neurons_in_stable_store_are_inactive_invalid() {
-    // Step 1.1: set up 1 inactive neuron.
-    let neuron = inactive_neuron_builder(1).build();
-
-    // Step 1.2: create neuron store with no neurons.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-
-    // Step 1.3: add the inactive neuron into neuron store.
-    neuron_store.add_neuron(neuron.clone()).unwrap();
-
-    // Step 1.4: modify the inactive in stable neuron store to make it actually active.
-    let mut neuron_made_active = neuron.clone();
-    neuron_made_active.cached_neuron_stake_e8s = 1;
-
-    with_stable_neuron_store_mut(|stable_neuron_store| {
-        stable_neuron_store
-            .update(&neuron, neuron_made_active)
-            .unwrap()
-    });
-
-    // Step 2: calls `batch_validate_neurons_in_stable_store_are_inactive` to validate.
-    let (invalid_neuron_ids, _) =
-        neuron_store.batch_validate_neurons_in_stable_store_are_inactive(NeuronId::min_value(), 10);
-
-    // Step 3: verifies the results - the active neuron in stable storage should be found as invalid.
-    if allow_active_neurons_in_stable_memory() {
-        assert_eq!(invalid_neuron_ids, vec![]);
-    } else {
-        assert_eq!(invalid_neuron_ids, vec![neuron.id()]);
-    }
-}
-
 // Below are tests related to how the neurons are stored, which look at the internals of the neuron
 // store. They should probably be cleaned up after the inactive neuron migration since it's better
 // to test through its public API.
@@ -389,216 +321,12 @@ fn inactive_neuron_builder(id: u64) -> NeuronBuilder {
         })
 }
 
-fn warp_time_to_make_neuron_inactive(neuron_store: &mut NeuronStore) {
-    // Set enough time warp to make sure the active neuron becomes inactive.
-    neuron_store.set_time_warp(TimeWarp {
-        delta_s: 15 * ONE_DAY_SECONDS as i64,
-    });
-}
-
 fn is_neuron_in_heap(neuron_store: &NeuronStore, neuron_id: NeuronId) -> bool {
     neuron_store.heap_neurons.contains_key(&neuron_id.id)
 }
 
 fn is_neuron_in_stable(neuron_id: NeuronId) -> bool {
     with_stable_neuron_store(|stable_neuron_store| stable_neuron_store.contains(neuron_id))
-}
-
-fn assert_neuron_in_neuron_store_eq(neuron_store: &NeuronStore, neuron: &Neuron) {
-    assert_eq!(
-        neuron_store
-            .with_neuron(&neuron.id(), |neuron| neuron.clone())
-            .unwrap(),
-        *neuron
-    );
-}
-
-#[test]
-fn test_from_active_to_active() {
-    // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    // Step 1.1: set up an empty neuron store with an active neuron.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-    let neuron = active_neuron_builder(1, neuron_store.now()).build();
-    let neuron_id = neuron.id();
-    neuron_store.add_neuron(neuron.clone()).unwrap();
-
-    // Step 1.2: verifies that the neuron is only in heap
-    assert_neuron_in_neuron_store_eq(&neuron_store, &neuron);
-    assert!(is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(!is_neuron_in_stable(neuron_id));
-
-    // Step 2: modifies the neuron to be still active.
-    let mut modified_neuron = neuron.clone();
-    modified_neuron.cached_neuron_stake_e8s = 2;
-    neuron_store
-        .with_neuron_mut(&neuron_id, |neuron| *neuron = modified_neuron.clone())
-        .unwrap();
-
-    // Step 3: verifies that the neuron is still only in heap.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &modified_neuron);
-    assert!(is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(!is_neuron_in_stable(neuron_id));
-}
-
-#[test]
-fn test_from_active_to_inactive() {
-    // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    // Step 1.1: set up an empty neuron store with an active neuron which would be inactive if there
-    // is no fund.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-    let mut neuron = inactive_neuron_builder(1).build();
-    neuron.cached_neuron_stake_e8s = 1;
-    let neuron_id = neuron.id();
-    neuron_store.add_neuron(neuron.clone()).unwrap();
-
-    // Step 1.2: verifies that the neuron is only in heap
-    assert_neuron_in_neuron_store_eq(&neuron_store, &neuron);
-    assert!(is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(!is_neuron_in_stable(neuron_id));
-
-    // Step 2: modifies the neuron to be inactive by removing its stake
-    let mut modified_neuron = neuron.clone();
-    modified_neuron.cached_neuron_stake_e8s = 0;
-    neuron_store
-        .with_neuron_mut(&neuron_id, |neuron| *neuron = modified_neuron.clone())
-        .unwrap();
-
-    // Step 3: verifies that the neuron is only in stable.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &modified_neuron);
-    assert!(!is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(is_neuron_in_stable(neuron_id));
-}
-
-#[test]
-fn test_from_inactive_to_active() {
-    // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    // Step 1.1: set up an empty neuron store with an inactive neuron.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-    let neuron = inactive_neuron_builder(1).build();
-    let neuron_id = neuron.id();
-    neuron_store.add_neuron(neuron.clone()).unwrap();
-
-    // Step 1.2: verifies that the neuron is in both stable and heap.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &neuron);
-    // Whether the inactive neuron can be found in heap depends on whether we want to store inactive neurons
-    // only in stable memory.
-    assert!(!is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(is_neuron_in_stable(neuron_id));
-
-    // Step 2: modifies the neuron to be active by funding it.
-    let mut modified_neuron = neuron.clone();
-    modified_neuron.cached_neuron_stake_e8s = 1;
-    neuron_store
-        .with_neuron_mut(&neuron_id, |neuron| *neuron = modified_neuron.clone())
-        .unwrap();
-
-    // Step 3: verifies that the neuron is only in heap.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &modified_neuron);
-    assert!(is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(!is_neuron_in_stable(neuron_id));
-}
-
-#[test]
-fn test_from_inactive_to_inactive() {
-    // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    // Step 1.1: set up an empty neuron store with an inactive neuron.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-    let neuron = inactive_neuron_builder(1).build();
-    let neuron_id = neuron.id();
-    neuron_store.add_neuron(neuron.clone()).unwrap();
-
-    // Step 1.2: verifies that the neuron is in both stable and heap.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &neuron);
-    // Whether the inactive neuron can be found in heap depends on whether we want to store inactive neurons
-    // only in stable memory.
-    assert!(!is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(is_neuron_in_stable(neuron_id));
-
-    // Step 2: modifies the neuron to be still inactive.
-    let mut modified_neuron = neuron.clone();
-    modified_neuron.auto_stake_maturity = Some(true);
-    neuron_store
-        .with_neuron_mut(&neuron_id, |neuron| *neuron = modified_neuron.clone())
-        .unwrap();
-
-    // Step 3: verifies that the neuron is modified and is only in stable.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &modified_neuron);
-    assert!(!is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(is_neuron_in_stable(neuron_id));
-}
-
-#[test]
-fn test_from_stale_inactive_to_inactive() {
-    // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    // Step 1.1: set up an empty neuron store with an active neuron.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-    let neuron = active_neuron_builder(1, neuron_store.now()).build();
-    let neuron_id = neuron.id();
-    neuron_store.add_neuron(neuron.clone()).unwrap();
-
-    // Step 1.2: verifies that the neuron is only in heap.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &neuron);
-    assert!(is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(!is_neuron_in_stable(neuron_id));
-
-    // Step 1.3: warp time so that the neuron becomes inactive without modification.
-    warp_time_to_make_neuron_inactive(&mut neuron_store);
-
-    // Step 2: call with_neuron_mut without modification.
-    neuron_store.with_neuron_mut(&neuron_id, |_| {}).unwrap();
-
-    // Step 3: verifies that the neuron is not modified but now only in stable.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &neuron);
-    assert!(!is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(is_neuron_in_stable(neuron_id));
-}
-
-#[test]
-fn test_from_stale_inactive_to_active() {
-    // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    // Step 1.1: set up an empty neuron store with an active neuron.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-    let neuron = active_neuron_builder(1, neuron_store.now()).build();
-    let neuron_id = neuron.id();
-    neuron_store.add_neuron(neuron.clone()).unwrap();
-
-    // Step 1.2: verifies that the neuron is only in heap.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &neuron);
-    assert!(is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(!is_neuron_in_stable(neuron_id));
-
-    // Step 1.3: warp time so that the neuron becomes inactive without modification.
-    warp_time_to_make_neuron_inactive(&mut neuron_store);
-
-    // Step 2: modify the neuron to be active again
-    let mut modified_neuron = neuron.clone();
-    modified_neuron.cached_neuron_stake_e8s = 1;
-    neuron_store
-        .with_neuron_mut(&neuron_id, |neuron| *neuron = modified_neuron.clone())
-        .unwrap();
-
-    // Step 3: verifies that the neuron is modified and still only on heap.
-    assert_neuron_in_neuron_store_eq(&neuron_store, &modified_neuron);
-    assert!(is_neuron_in_heap(&neuron_store, neuron_id));
-    assert!(!is_neuron_in_stable(neuron_id));
 }
 
 #[test]
@@ -1017,55 +745,6 @@ fn test_get_non_empty_neuron_ids_readable_by_caller() {
 }
 
 #[test]
-fn test_batch_adjust_neurons_storage() {
-    // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    // Step 1.1: set up an empty neuron store.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-
-    // Step 1.2: set up 5 active neurons with stake
-    for i in 1..=5 {
-        let neuron = simple_neuron_builder(i)
-            .with_cached_neuron_stake_e8s(1)
-            .with_dissolve_state_and_age(DissolveStateAndAge::DissolvingOrDissolved {
-                when_dissolved_timestamp_seconds: neuron_store.now(),
-            })
-            .build();
-        neuron_store.add_neuron(neuron).unwrap();
-    }
-
-    // Step 1.3: set up 5 active neurons without stake, which will become inactive when the time is
-    // advanced.
-    for i in 6..=10 {
-        let neuron = active_neuron_builder(i, neuron_store.now()).build();
-        neuron_store.add_neuron(neuron).unwrap();
-    }
-
-    // Step 1.4: warp time so that the neuron becomes inactive without modification.
-    warp_time_to_make_neuron_inactive(&mut neuron_store);
-
-    // Step 1.5: define a lambda which always returns false, for checking instructions.
-    let always_true = || true;
-
-    // Step 1.6: make sure the counts of neurons in heap and stable are expected.
-    assert_eq!(neuron_store.heap_neuron_store_len(), 10);
-    assert_eq!(neuron_store.stable_neuron_store_len(), 0);
-
-    // Step 2: adjust the storage of neurons and verifies the counts.
-    let next_neuron_id = groom_some_neurons(
-        &mut neuron_store,
-        |_| {},
-        Bound::Excluded(NeuronId { id: 0 }),
-        always_true,
-    );
-    assert_eq!(next_neuron_id, Bound::Unbounded);
-    assert_eq!(neuron_store.heap_neuron_store_len(), 5);
-    assert_eq!(neuron_store.stable_neuron_store_len(), 5);
-}
-
-#[test]
 fn test_unstake_maturity() {
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     let now_seconds = neuron_store.now();
@@ -1110,62 +789,6 @@ fn test_unstake_maturity() {
     for id in 1..=5 {
         assert!(!neuron_has_staked_maturity(&neuron_store, id));
     }
-}
-
-#[test]
-fn test_batch_adjust_neurons_storage_exceeds_instructions_limit() {
-    // This test doesn't make sense after neurons are migrated completely to stable memory.
-    let _a = temporarily_disable_allow_active_neurons_in_stable_memory();
-    let _b = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    // Step 1.1: set up an empty neuron store.
-    let mut neuron_store = NeuronStore::new(BTreeMap::new());
-
-    // Step 1.2: set up 5 active neurons without stake, which will become inactive when the time is
-    // advanced.
-    for i in 1..=5 {
-        let neuron = active_neuron_builder(i, neuron_store.now()).build();
-        neuron_store.add_neuron(neuron).unwrap();
-    }
-
-    // Step 1.4: warp time so that the neuron becomes inactive without modification.
-    warp_time_to_make_neuron_inactive(&mut neuron_store);
-
-    // Step 1.5: make sure the counts of neurons in heap and stable are expected.
-    assert_eq!(neuron_store.heap_neuron_store_len(), 5);
-    assert_eq!(neuron_store.stable_neuron_store_len(), 0);
-
-    // Step 2: adjust the storage of neurons for the first 10 neurons, however, the `carry_on`
-    // returns false for the 3rd time it's called, allowing `groom_some_neurons` continue 2 times,
-    // moving only 3 neurons.
-    let counter = Cell::new(0);
-    let next_neuron_id = groom_some_neurons(
-        &mut neuron_store,
-        |_| {},
-        Bound::Excluded(NeuronId { id: 0 }),
-        || {
-            counter.set(counter.get() + 1);
-            counter.get() <= 2
-        },
-    );
-    assert_eq!(next_neuron_id, Bound::Excluded(NeuronId { id: 3 }));
-    assert_eq!(neuron_store.heap_neuron_store_len(), 2);
-    assert_eq!(neuron_store.stable_neuron_store_len(), 3);
-
-    // Step 3: adjust the storage of neurons for the rest of 4 neurons and verifies the counts.
-    let counter = Cell::new(0);
-    let next_neuron_id = groom_some_neurons(
-        &mut neuron_store,
-        |_| {},
-        Bound::Excluded(NeuronId { id: 3 }),
-        || {
-            counter.set(counter.get() + 1);
-            counter.get() <= 2
-        },
-    );
-    assert_eq!(next_neuron_id, Bound::Unbounded);
-    assert_eq!(neuron_store.heap_neuron_store_len(), 0);
-    assert_eq!(neuron_store.stable_neuron_store_len(), 5);
 }
 
 #[test]


### PR DESCRIPTION
# Why

All neurons are migrated to stable memory ,and the feature `allow_active_neurons_in_stable_memory` has been turned on for a long time. There is no reason to turn it back off.

# What

* Remove `allow_active_neurons_in_stable_memory`
* Remove all branches where `allow_active_neurons_in_stable_memory` is false, and simplify code afterwards
* Remove all `temporarily_enable_allow_active_neurons_in_stable_memory` calls since it does nothing.
* Remove all tests/benchmarks with `temporarily_disable_allow_active_neurons_in_stable_memory` since the condition is no longer possible.