### PR TITLE
fix: correct the hash of liblmdb

### DIFF
--- a/third_party/lmdb/repository.bzl
+++ b/third_party/lmdb/repository.bzl
@@ -8,7 +8,7 @@ def lmdb_repository():
         http_archive,
         name = "lmdb",
         build_file = Label("//third_party/lmdb:BUILD.lmdb.bazel"),
-        sha256 = "657307ba28abbf6d926b24d568098a34de5888e165d1cb0c434ef6c9f2ec392d",
+        sha256 = "9f8e4f1fa8c0996043ef35db0d0d52b9cbd314572263cf2e5961912b0410fa72",
         strip_prefix = "openldap-55fd54dae6f90080b770dbc9dbcee5044976b7bf/libraries/liblmdb",
         urls = [
             "https://git.openldap.org/openldap/openldap/-/archive/55fd54dae6f90080b770dbc9dbcee5044976b7bf/openldap-55fd54dae6f90080b770dbc9dbcee5044976b7bf.zip",


### PR DESCRIPTION
We started running into [the following error](https://github.com/dfinity/ic/actions/runs/14573057064/job/40914741275#step:4:71):
```
WARNING: Download from 
https://git.openldap.org/openldap/openldap/-/archive/55fd54dae6f90080b770dbc9dbcee5044976b7bf/openldap-55fd54dae6f90080b770dbc9dbcee5044976b7bf.zip 
failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException 
Checksum was 9f8e4f1fa8c0996043ef35db0d0d52b9cbd314572263cf2e5961912b0410fa72 
but wanted 657307ba28abbf6d926b24d568098a34de5888e165d1cb0c434ef6c9f2ec392d
```

which means the content of the URL changed and the hash has to be updated.