### PR TITLE
fix(rosetta): increase watchdog timeout

### DIFF
--- a/rs/rosetta-api/icp/src/main.rs
+++ b/rs/rosetta-api/icp/src/main.rs
@@ -66,6 +66,12 @@ struct Opt {
     not_whitelisted: bool,
     #[clap(long = "expose-metrics")]
     expose_metrics: bool,
+    #[clap(
+        long = "watchdog-timeout-seconds",
+        default_value = "60",
+        help = "Timeout in seconds for sync watchdog"
+    )]
+    watchdog_timeout_seconds: u64,
 
     #[cfg(feature = "rosetta-blocks")]
     #[clap(long = "enable-rosetta-blocks")]
@@ -231,6 +237,7 @@ async fn main() -> std::io::Result<()> {
         not_whitelisted,
         expose_metrics,
         blockchain,
+        watchdog_timeout_seconds,
         ..
     } = opt;
 
@@ -267,12 +274,17 @@ async fn main() -> std::io::Result<()> {
     let req_handler = RosettaRequestHandler::new(blockchain, ledger.clone());
 
     info!("Network id: {:?}", req_handler.network_id());
+    info!(
+        "Configuring watchdog with timeout of {} seconds",
+        watchdog_timeout_seconds
+    );
     let serv = RosettaApiServer::new(
         ledger,
         req_handler,
         addr,
         opt.listen_port_file,
         expose_metrics,
+        watchdog_timeout_seconds,
     )
     .expect("Error creating RosettaApiServer");
 

--- a/rs/rosetta-api/icp/src/rosetta_server.rs
+++ b/rs/rosetta-api/icp/src/rosetta_server.rs
@@ -31,10 +31,6 @@ use tokio::sync::Mutex;
 
 // Interval for syncing blocks from the ledger
 const BLOCK_SYNC_INTERVAL: Duration = Duration::from_secs(1);
-
-// Timeout for syncing blocks from the ledger. If no synchronization is attempted within this time, the sync thread will be restarted.
-const BLOCK_SYNC_TIMEOUT: Duration = Duration::from_secs(10);
-
 use tracing::{error, info};
 
 #[post("/account/balance")]
@@ -253,6 +249,7 @@ pub struct RosettaApiServer {
     ledger: Arc<dyn LedgerAccess + Send + Sync>,
     server: Mutex<ServerState>,
     server_handle: ServerHandle,
+    watchdog_timeout_seconds: u64,
 }
 
 impl RosettaApiServer {
@@ -262,6 +259,7 @@ impl RosettaApiServer {
         addr: String,
         listen_port_file: Option<PathBuf>,
         expose_metrics: bool,
+        watchdog_timeout_seconds: u64,
     ) -> io::Result<Self> {
         let stopped = Arc::new(AtomicBool::new(false));
         let http_metrics_wrapper = RosettaMetrics::http_metrics_wrapper(expose_metrics);
@@ -327,6 +325,7 @@ impl RosettaApiServer {
             ledger,
             server_handle: server.handle(),
             server: Mutex::new(ServerState::Unstarted(server)),
+            watchdog_timeout_seconds,
         })
     }
 
@@ -362,7 +361,7 @@ impl RosettaApiServer {
                         RosettaMetrics::inc_sync_thread_restarts();
                     }));
                 let mut watchdog_thread = WatchdogThread::new(
-                    BLOCK_SYNC_TIMEOUT,
+                    Duration::from_secs(self.watchdog_timeout_seconds),
                     on_restart_callback,
                     skip_first_heartbeat_check,
                     None,

--- a/rs/rosetta-api/icp/tests/rosetta_cli_tests.rs
+++ b/rs/rosetta-api/icp/tests/rosetta_cli_tests.rs
@@ -49,7 +49,8 @@ async fn rosetta_cli_data_test() {
     let serv_req_handler = req_handler.clone();
 
     let serv = Arc::new(
-        RosettaApiServer::new(serv_ledger, serv_req_handler, addr.clone(), None, false).unwrap(),
+        RosettaApiServer::new(serv_ledger, serv_req_handler, addr.clone(), None, false, 60)
+            .unwrap(),
     );
     let serv_run = serv.clone();
     let arbiter = actix_rt::Arbiter::new();
@@ -112,7 +113,8 @@ async fn rosetta_cli_construction_create_account_test() {
     let serv_req_handler = req_handler.clone();
 
     let serv = Arc::new(
-        RosettaApiServer::new(serv_ledger, serv_req_handler, addr.clone(), None, false).unwrap(),
+        RosettaApiServer::new(serv_ledger, serv_req_handler, addr.clone(), None, false, 60)
+            .unwrap(),
     );
     let serv_run = serv.clone();
     let arbiter = actix_rt::Arbiter::new();
@@ -194,7 +196,8 @@ async fn rosetta_cli_construction_test() {
     let serv_req_handler = req_handler.clone();
 
     let serv = Arc::new(
-        RosettaApiServer::new(serv_ledger, serv_req_handler, addr.clone(), None, false).unwrap(),
+        RosettaApiServer::new(serv_ledger, serv_req_handler, addr.clone(), None, false, 60)
+            .unwrap(),
     );
     let serv_run = serv.clone();
     let arbiter = actix_rt::Arbiter::new();


### PR DESCRIPTION
The sync thread watchdog thread only waits for 10 seconds before declaring the sync thread stale and restart it.

That timeout turns out to be too short for cases in which the IC is going through instability, in which cases the block read operations can take more than 10 seconds. 

After looking at the latency metrics, it seems that 60 seconds provide a good buffer for those cases. We're also making it configurable in case such change needs to happen again without doing another release.