### PR TITLE
refactor(registry): There is no `gen` directory in `registry/canister`.

### DIFF
--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -106,10 +106,7 @@ BUILD_DEPENDENCIES = [
 ALIASES = {}
 
 LIB_SRCS = glob(
-    [
-        "gen/**/*.rs",
-        "src/**/*.rs",
-    ],
+    ["src/**/*.rs"],
     exclude = ["**/*tests*/**"],
 )
 
@@ -159,10 +156,7 @@ rust_ic_test(
 
 rust_test(
     name = "registry_canister_test",
-    srcs = glob([
-        "gen/**",
-        "src/**",
-    ]),
+    srcs = glob(["src/**"]),
     proc_macro_deps = DEV_MACRO_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )


### PR DESCRIPTION
Therefore, stop telling bazel to look there.