### PR TITLE
chore: log canister http transform taking more than 10M instructions

### DIFF
--- a/rs/execution_environment/src/query_handler/query_context.rs
+++ b/rs/execution_environment/src/query_handler/query_context.rs
@@ -282,7 +282,7 @@ impl<'a> QueryContext<'a> {
         match query.source {
             QuerySource::System => {
                 let instructions_consumed = instructions_before - self.round_limits.instructions;
-                if instructions_consumed >= RoundInstructions::from(100_000_000) {
+                if instructions_consumed >= RoundInstructions::from(10_000_000) {
                     info!(
                         self.log,
                         "Canister http transform on canister {} consumed {} instructions.",


### PR DESCRIPTION
This PR reduces the instruction threshold for logging canister http transform functions from 100M to 10M instructions. According to existing [metrics](https://grafana.mainnet.dfinity.network/d/execution-metrics/execution-metrics?var-heatmap_period=$__auto&from=now-24h&to=now&timezone=utc&var-datasource=PE62C54679EC3C073&var-ic=mercury&var-ic_subnet=$__all&var-instance=$__all&var-node_instance=$__all&viewPanel=panel-121), this should not result in an excessive amount of logs being produced since the majority of non-replicated queries take 5-10M instructions.