### PR TITLE
chore: log transform function result size if max_response_size_bytes exceeded

### DIFF
--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -220,7 +220,7 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                               Err((_, msg)) => msg.len(),
                             };
                             if transform_result_size as u64 > max_response_size_bytes {
-                              info!(log, "Canister http transform result size {} exceeds the `max_response_size` of {}.", transform_result_size, max_response_size_bytes);
+                              info!(log, "Canister http transform result size {} on canister {} exceeds the `max_response_size` of {}.", transform_result_size, request_sender, max_response_size_bytes);
                             }
                             transform_result?
                         }

--- a/rs/https_outcalls/client/src/lib.rs
+++ b/rs/https_outcalls/client/src/lib.rs
@@ -78,6 +78,7 @@ pub fn setup_canister_http_client(
                         metrics_registry.clone(),
                         subnet_type,
                         delegation_from_nns,
+                        log,
                     ))
                 }
                 Err(e) => {

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1624,6 +1624,7 @@ fn process_mock_canister_https_response(
                 MetricsRegistry::new(),
                 subnet.get_subnet_type(),
                 delegation_rx.clone(),
+                subnet.replica_logger.clone(),
             );
             client
                 .send(AdapterCanisterHttpRequest {


### PR DESCRIPTION
This PR logs canister http transform function result size if it exceeds the value of `max_response_size_bytes`.