### PR TITLE
refactor(nns): Clean up migrate_active_neurons_to_stable_memory

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -200,7 +200,6 @@ pub const DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS: u64 = 1725148800;
 // leave this here indefinitely, but it will just be clutter after a modest
 // amount of time.
 thread_local! {
-    static MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY: Cell<bool> = const { Cell::new(true) };
 
     static DISABLE_NF_FUND_PROPOSALS: Cell<bool>
         = const { Cell::new(cfg!(not(any(feature = "canbench-rs", feature = "test")))) };
@@ -216,22 +215,6 @@ thread_local! {
     // begun. (This occurs in one of the prune_some_following functions.)
     static CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS: Cell<u64> =
         const { Cell::new(0) };
-}
-
-pub fn migrate_active_neurons_to_stable_memory() -> bool {
-    MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY.get()
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_enable_migrate_active_neurons_to_stable_memory() -> Temporary {
-    Temporary::new(&MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY, true)
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_disable_migrate_active_neurons_to_stable_memory() -> Temporary {
-    Temporary::new(&MIGRATE_ACTIVE_NEURONS_TO_STABLE_MEMORY, false)
 }
 
 pub fn are_nf_fund_proposals_disabled() -> bool {

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -10,7 +10,6 @@ use crate::{
     neurons_fund::{NeuronsFund, NeuronsFundNeuronPortion, NeuronsFundSnapshot},
     now_seconds,
     pb::v1::{neuron::Followees, BallotInfo, KnownNeuronData, Vote},
-    temporarily_enable_migrate_active_neurons_to_stable_memory,
 };
 use canbench_rs::{bench, bench_fn, BenchResult};
 use ic_nervous_system_common::E8;
@@ -156,7 +155,6 @@ fn set_up_neuron_store(
 
 #[bench(raw)]
 fn add_neuron_active_typical_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron =
@@ -169,8 +167,6 @@ fn add_neuron_active_typical_stable() -> BenchResult {
 
 #[bench(raw)]
 fn add_neuron_active_maximum_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
-
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron =
@@ -239,31 +235,26 @@ fn modify_neuron_main_section(neuron: &mut Neuron) {
 
 #[bench(raw)]
 fn with_neuron_mut_all_sections_typical_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     with_neuron_mut_benchmark(NeuronSize::Typical, modify_neuron_all_sections)
 }
 
 #[bench(raw)]
 fn with_neuron_mut_all_sections_maximum_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     with_neuron_mut_benchmark(NeuronSize::Maximum, modify_neuron_all_sections)
 }
 
 #[bench(raw)]
 fn with_neuron_mut_main_section_typical_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     with_neuron_mut_benchmark(NeuronSize::Typical, modify_neuron_main_section)
 }
 
 #[bench(raw)]
 fn with_neuron_mut_main_section_maximum_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     with_neuron_mut_benchmark(NeuronSize::Maximum, modify_neuron_main_section)
 }
 
 #[bench(raw)]
 fn update_recent_ballots_stable_memory() -> BenchResult {
-    let _c = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron =
@@ -321,7 +312,6 @@ fn neuron_metrics_benchmark() -> BenchResult {
 
 #[bench(raw)]
 fn neuron_metrics_calculation_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     neuron_metrics_benchmark()
 }
 
@@ -367,7 +357,6 @@ fn list_ready_to_spawn_neuron_ids_benchmark() -> BenchResult {
 
 #[bench(raw)]
 fn list_ready_to_spawn_neuron_ids_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     list_ready_to_spawn_neuron_ids_benchmark()
 }
 
@@ -394,7 +383,6 @@ fn add_neuron_ready_to_unstake_maturity(
 
 #[bench(raw)]
 fn unstake_maturity_of_dissolved_neurons_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
     for _ in 0..100 {
@@ -454,7 +442,6 @@ fn draw_maturity_from_neurons_fund_benchmark() -> BenchResult {
 
 #[bench(raw)]
 fn draw_maturity_from_neurons_fund_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     draw_maturity_from_neurons_fund_benchmark()
 }
 
@@ -481,7 +468,6 @@ fn list_active_neurons_fund_neurons_benchmark() -> BenchResult {
 
 #[bench(raw)]
 fn list_active_neurons_fund_neurons_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     list_active_neurons_fund_neurons_benchmark()
 }
 
@@ -503,7 +489,6 @@ fn validate_all_neurons(neuron_store: &NeuronStore, validator: &mut NeuronDataVa
 
 #[bench(raw)]
 fn neuron_data_validation_stable() -> BenchResult {
-    let _b = temporarily_enable_migrate_active_neurons_to_stable_memory();
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let mut validator = NeuronDataValidator::new();

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -2,8 +2,6 @@ use super::*;
 use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::{KnownNeuronData, NeuronType},
-    temporarily_disable_migrate_active_neurons_to_stable_memory,
-    temporarily_enable_migrate_active_neurons_to_stable_memory,
 };
 use ic_base_types::PrincipalId;
 use ic_nervous_system_common::{E8, ONE_DAY_SECONDS, ONE_YEAR_SECONDS};
@@ -28,7 +26,8 @@ fn create_test_neuron_builder(
     )
 }
 
-fn test_compute_metrics_helper() {
+#[test]
+fn test_compute_metrics() {
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
     let now = neuron_store.now();
 
@@ -316,22 +315,6 @@ fn test_compute_metrics_helper() {
         },
         expected_metrics,
     );
-}
-
-// Migration stage 1: allow active neurons in stable memory, but not migrating yet.
-#[test]
-fn test_compute_metrics() {
-    let _t = temporarily_disable_migrate_active_neurons_to_stable_memory();
-
-    test_compute_metrics_helper();
-}
-
-// Migration stage 2: allow active neurons in stable memory and new active neurons are in stable memory.
-#[test]
-fn test_compute_metrics_migrate_active_neurons_to_stable_memory() {
-    let _t = temporarily_enable_migrate_active_neurons_to_stable_memory();
-
-    test_compute_metrics_helper();
 }
 
 #[test]

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -190,13 +190,8 @@ fn test_add_neurons() {
 
     // Step 3.1: verify that the active neuron is in the heap, not in the stable neuron store, and
     // can be read.
-    if migrate_active_neurons_to_stable_memory() {
-        assert!(is_neuron_in_stable(active_neuron.id()));
-        assert!(!is_neuron_in_heap(&neuron_store, active_neuron.id()));
-    } else {
-        assert!(!is_neuron_in_stable(active_neuron.id()));
-        assert!(is_neuron_in_heap(&neuron_store, active_neuron.id()));
-    }
+    assert!(is_neuron_in_stable(active_neuron.id()));
+    assert!(!is_neuron_in_heap(&neuron_store, active_neuron.id()));
     let active_neuron_read_result =
         neuron_store.with_neuron(&active_neuron.id(), |neuron| neuron.clone());
     assert_eq!(active_neuron_read_result, Ok(active_neuron.clone()));


### PR DESCRIPTION
# Why

The neuron migration to stable memory is completed. We want to remove the feature flags while preserving the behavior of flag being turned on.

# What

* Remove `migrate_active_neurons_to_stable_memory`
* Remove all branches where `migrate_active_neurons_to_stable_memory` is false, and simplify code afterwards