### PR TITLE
refactor(nns): Clean up the timer task AdjustNeuronStorage

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6901,13 +6901,6 @@ impl Governance {
         })
     }
 
-    pub fn batch_adjust_neurons_storage(
-        &mut self,
-        next: std::ops::Bound<NeuronId>,
-    ) -> std::ops::Bound<NeuronId> {
-        self.neuron_store.batch_adjust_neurons_storage(next)
-    }
-
     /// Recompute cached metrics once per day
     pub fn should_compute_cached_metrics(&self) -> bool {
         if let Some(metrics) = self.heap_data.metrics.as_ref() {

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -484,21 +484,6 @@ impl NeuronStore {
         self.remove_neuron_from_indexes(&neuron_to_remove);
     }
 
-    /// Adjusts the storage location of neurons, since active neurons might become inactive due to
-    /// passage of time.
-    pub fn batch_adjust_neurons_storage(&mut self, next: Bound<NeuronId>) -> Bound<NeuronId> {
-        #[cfg(target_arch = "wasm32")]
-        static MAX_NUM_INSTRUCTIONS_PER_BATCH: u64 = 1_000_000_000;
-
-        #[cfg(target_arch = "wasm32")]
-        let carry_on = || ic_cdk::api::instruction_counter() < MAX_NUM_INSTRUCTIONS_PER_BATCH;
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let carry_on = || true;
-
-        groom_some_neurons(self, |_| {}, next, carry_on)
-    }
-
     fn remove_neuron_from_indexes(&mut self, neuron: &Neuron) {
         if let Err(error) = with_stable_neuron_indexes_mut(|indexes| indexes.remove_neuron(neuron))
         {


### PR DESCRIPTION
# Why

The neuron migration to stable memory is completed, therefore the timer task to move neurons between the 2 storage is no longer needed.

# What

* Stop scheduling the task (remove `schedule_adjust_neurons_storage`)
* Delete dead code