### PR TITLE
fix(nns): Use StableBTreeMap::init instead of ::new for voting power snapshots

### DIFF
--- a/rs/nns/governance/src/governance/voting_power_snapshots.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots.rs
@@ -67,8 +67,8 @@ fn insert_and_truncate<Value: Storable>(
 impl VotingPowerSnapshots {
     pub fn new(maps_memory: DefaultMemory, totals_memory: DefaultMemory) -> Self {
         Self {
-            neuron_id_to_voting_power_maps: StableBTreeMap::new(maps_memory),
-            voting_power_totals: StableBTreeMap::new(totals_memory),
+            neuron_id_to_voting_power_maps: StableBTreeMap::init(maps_memory),
+            voting_power_totals: StableBTreeMap::init(totals_memory),
         }
     }
 

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -17,4 +17,6 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* Use `StableBTreeMap::init` instead of `::new` for voting power snapshots.
+
 ## Security


### PR DESCRIPTION
# Why

The `StableBTreeMap::new` initializes the BTreeMap as an empty map, we'd like the map to be preserved over upgrades.

# What

* Replace `StableBTreeMap::new` with `StableBTreeMap::init`