### PR TITLE
fix(node_rewards): Use StableBTreeMap::init instead of ::new

### DIFF
--- a/rs/node_rewards/canister/src/storage.rs
+++ b/rs/node_rewards/canister/src/storage.rs
@@ -15,7 +15,7 @@ thread_local! {
 
     static REGISTRY_DATA_STORE_BTREE_MAP: RefCell<StableBTreeMap<StorableRegistryKey, StorableRegistryValue, VM>>
         = RefCell::new(MEMORY_MANAGER.with_borrow(|mm|
-            StableBTreeMap::new(mm.get(REGISTRY_STORE_MEMORY_ID))
+            StableBTreeMap::init(mm.get(REGISTRY_STORE_MEMORY_ID))
         ));
 }
 

--- a/rs/node_rewards/canister/unreleased_changelog.md
+++ b/rs/node_rewards/canister/unreleased_changelog.md
@@ -18,5 +18,6 @@ on the process that this file is part of, see
 
 * Fixed a bug with the registry client that prevented the canister from reading registry data when there were deletions.
 * Limit 'get_node_providers_monthly_xdr_rewards' to only be callable from NNS Governance.
+* Use `StableBTreeMap::init` instead of `::new` for registry state.
 
 ## Security


### PR DESCRIPTION
# Why

The `StableBTreeMap::new` initializes the BTreeMap as an empty map, we'd like the map to be preserved over upgrades.

# What

* Replace `StableBTreeMap::new` with `StableBTreeMap::init`