### PR TITLE
chore(nervous-system): Update changelog for release 2025-04-15

### DIFF
--- a/rs/nns/governance/CHANGELOG.md
+++ b/rs/nns/governance/CHANGELOG.md
@@ -11,6 +11,19 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-04-15: Proposal 136285
+
+http://dashboard.internetcomputer.org/proposal/136285
+
+## Added
+
+* A timer task is added to take daily snapshots of voting power for standard proposals.
+
+## Fixed
+
+* Turned off `DisburseMaturity` that was incorrectly turned on before.
+
+
 # 2025-04-11: Proposal 136224
 
 http://dashboard.internetcomputer.org/proposal/136224

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,8 +9,6 @@ on the process that this file is part of, see
 
 ## Added
 
-* A timer task is added to take daily snapshots of voting power for standard proposals.
-
 ## Changed
 
 ## Deprecated
@@ -18,7 +16,5 @@ on the process that this file is part of, see
 ## Removed
 
 ## Fixed
-
-* Turned off `DisburseMaturity` that was incorrectly turned on before.
 
 ## Security


### PR DESCRIPTION
Update CHANGELOG.md for release on 2025-04-15.

## NNS 
  - [136285](https://dashboard.internetcomputer.org/proposal/136285)

## SNS 