### PR TITLE
feat(nns): Stop recording new snapshots when there is a spike

### DIFF
--- a/rs/nns/governance/src/governance/voting_power_snapshots.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots.rs
@@ -72,6 +72,21 @@ impl VotingPowerSnapshots {
         }
     }
 
+    /// Returns whether the latest snapshot is a voting power spike.
+    pub fn is_latest_snapshot_a_spike(&self, now_seconds: TimestampSeconds) -> bool {
+        // If there are no snapshots, then there is no spike.
+        let Some((_, latest_totals)) = self.voting_power_totals.last_key_value() else {
+            return false;
+        };
+
+        // If the latest snapshot is already considered a spike,
+        self.totals_entry_with_minimum_total_potential_voting_power_if_voting_power_spiked(
+            now_seconds,
+            latest_totals.total_potential_voting_power,
+        )
+        .is_some()
+    }
+
     /// Records a voting power snapshot at the given timestamp. Oldest snapshots are removed
     /// if the number of snapshots exceeds the maximum allowed.
     pub(crate) fn record_voting_power_snapshot(
@@ -93,24 +108,58 @@ impl VotingPowerSnapshots {
         );
     }
 
+    /// Given a total potential voting power, checks if there is a voting power spike. If a spike is
+    /// detected, it returns the timestamp and totals of the snapshot with the minimum total
+    /// potential voting power. If no spike is detected, it returns None.
+    fn totals_entry_with_minimum_total_potential_voting_power_if_voting_power_spiked(
+        &self,
+        now_seconds: TimestampSeconds,
+        current_total_potential_voting_power: u64,
+    ) -> Option<(TimestampSeconds, VotingPowerTotal)> {
+        let (
+            timestamp_with_minimum_total_potential_voting_power,
+            totals_with_minimum_total_potential_voting_power,
+        ) = self
+            .voting_power_totals
+            .iter()
+            .filter(|(created_at, _)| {
+                let age = now_seconds - created_at;
+                age <= MAXIMUM_STALENESS_SECONDS
+            })
+            .min_by_key(|(_, snapshot)| snapshot.total_potential_voting_power)?;
+
+        let voting_power_spike_detected = (current_total_potential_voting_power as f64)
+            > (totals_with_minimum_total_potential_voting_power.total_potential_voting_power
+                as f64)
+                * MULTIPLIER_THRESHOLD_FOR_VOTING_POWER_SPIKE;
+        if voting_power_spike_detected {
+            Some((
+                timestamp_with_minimum_total_potential_voting_power,
+                totals_with_minimum_total_potential_voting_power,
+            ))
+        } else {
+            None
+        }
+    }
+
     /// Given a total potential voting power, checks if there is a voting power spike and returns
     /// the previous voting power map if a spike is detected along with the snapshot timestamp. If
-    /// no spike is detected, it returns None.
+    /// no spike is detected, it returns None. The definition of a spike is based on the constant
+    /// `MULTIPLIER_THRESHOLD_FOR_VOTING_POWER_SPIKE`.
     pub(crate) fn previous_ballots_if_voting_power_spike_detected(
         &self,
         total_potential_voting_power: u64,
         now_seconds: TimestampSeconds,
     ) -> Option<(TimestampSeconds, VotingPowerSnapshot)> {
-        // Step 1: find the timestamp with the minimum potential voting power. Exit if there are no
-        // snapshots yet.
+        // Step 1: find the voting power totals entry with the minimum total potential voting power,
+        // if a spike is detected.
         let Some((
             timestamp_with_minimum_total_potential_voting_power,
             totals_with_minimum_total_potential_voting_power,
-        )) = self
-            .voting_power_totals
-            .iter()
-            .filter(|(timestamp, _)| *timestamp + MAXIMUM_STALENESS_SECONDS > now_seconds)
-            .min_by_key(|(_, snapshot)| snapshot.total_potential_voting_power)
+        )) = self.totals_entry_with_minimum_total_potential_voting_power_if_voting_power_spiked(
+            now_seconds,
+            total_potential_voting_power,
+        )
         else {
             ic_cdk::eprintln!(
                 "{}Voting power totals are empty. No voting power spike detected.",
@@ -119,16 +168,7 @@ impl VotingPowerSnapshots {
             return None;
         };
 
-        // Step 2: determine whether there is a voting power spike. Exit if a spike is not detected.
-        let voting_power_spike_detected = (total_potential_voting_power as f64)
-            > (totals_with_minimum_total_potential_voting_power.total_potential_voting_power
-                as f64)
-                * MULTIPLIER_THRESHOLD_FOR_VOTING_POWER_SPIKE;
-        if !voting_power_spike_detected {
-            return None;
-        }
-
-        // Step 3: find the voting power map for the timestamp with the minimum potential voting power.
+        // Step 2: find the voting power map for the timestamp with the minimum potential voting power.
         let Some(voting_power_map) = self
             .neuron_id_to_voting_power_maps
             .get(&timestamp_with_minimum_total_potential_voting_power)
@@ -142,7 +182,7 @@ impl VotingPowerSnapshots {
             return None;
         };
 
-        // Step 4: returns the previous voting power map since a voting power spike is detected.
+        // Step 3: returns the previous voting power map since a voting power spike is detected.
         let previous_voting_power_snapshot = VotingPowerSnapshot::from((
             voting_power_map,
             totals_with_minimum_total_potential_voting_power,

--- a/rs/nns/governance/src/governance/voting_power_snapshots_tests.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots_tests.rs
@@ -29,8 +29,8 @@ fn test_record_voting_power_snapshot() {
         memory_manager.get(MemoryId::new(1)),
     );
 
-    // Initially, there are no snapshots, so the latest snapshot timestamp is None, and we
-    // should not disable early adoption since there is no data.
+    // Initially, there are no snapshots, so the latest snapshot timestamp is None, and we do not
+    // return previous ballots since there is no data.
     assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), None);
     assert_eq!(
         snapshots.previous_ballots_if_voting_power_spike_detected(u64::MAX, 0),
@@ -39,60 +39,72 @@ fn test_record_voting_power_snapshot() {
 
     // After making a snapshot, the latest snapshot timestamp should be the timestamp of the
     // snapshot.
-    snapshots.record_voting_power_snapshot(1, voting_power_snapshot(vec![9], 10));
+    snapshots.record_voting_power_snapshot(1, voting_power_snapshot(vec![90], 100));
     assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), Some(1));
-    // We should disable early adoption if the deciding voting power is more than 2 times the
+    // We should return previous ballots if the deciding voting power is more than 1.5 times the
     // minimum voting power in the first snapshot.
     assert_eq!(
-        snapshots.previous_ballots_if_voting_power_spike_detected(10, 1),
+        snapshots.previous_ballots_if_voting_power_spike_detected(149, 1),
         None
     );
     assert_eq!(
-        snapshots.previous_ballots_if_voting_power_spike_detected(14, 1),
-        None
+        snapshots.previous_ballots_if_voting_power_spike_detected(151, 1),
+        Some((1, voting_power_snapshot(vec![90], 100)))
     );
-    assert_eq!(
-        snapshots.previous_ballots_if_voting_power_spike_detected(16, 1),
-        Some((1, voting_power_snapshot(vec![9], 10)))
-    );
+    assert!(!snapshots.is_latest_snapshot_a_spike(1));
 
     for i in 0..6 {
         let timestamp_seconds = 2 + i;
-        // The minimum voting power in the snapshots is still 10 over the next 6
+        // The minimum voting power in the snapshots is still 100 over the next 6
         snapshots.record_voting_power_snapshot(
             timestamp_seconds,
-            voting_power_snapshot(vec![9, 10 + i], 20 + i),
+            voting_power_snapshot(vec![90, 10 + i], 110 + i),
         );
         assert_eq!(
             snapshots.latest_snapshot_timestamp_seconds(),
             Some(timestamp_seconds)
         );
         assert_eq!(
-            snapshots.previous_ballots_if_voting_power_spike_detected(14, timestamp_seconds),
+            snapshots.previous_ballots_if_voting_power_spike_detected(149, timestamp_seconds),
             None
         );
         assert_eq!(
-            snapshots.previous_ballots_if_voting_power_spike_detected(16, timestamp_seconds),
-            Some((1, voting_power_snapshot(vec![9], 10)))
+            snapshots.previous_ballots_if_voting_power_spike_detected(151, timestamp_seconds),
+            Some((1, voting_power_snapshot(vec![90], 100)))
         );
+        assert!(!snapshots.is_latest_snapshot_a_spike(timestamp_seconds));
     }
 
     // After the 7th snapshot, the first snapshot is removed, and the minimum total potential voting
     // power in the retained snapshots is now 20 on the timestamp 2.
-    snapshots.record_voting_power_snapshot(8, voting_power_snapshot(vec![9, 16], 26));
+    snapshots.record_voting_power_snapshot(8, voting_power_snapshot(vec![90, 16], 116));
     assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), Some(8));
     assert_eq!(
-        snapshots.previous_ballots_if_voting_power_spike_detected(14, 8),
+        snapshots.previous_ballots_if_voting_power_spike_detected(151, 8),
         None
     );
     assert_eq!(
-        snapshots.previous_ballots_if_voting_power_spike_detected(29, 8),
+        snapshots.previous_ballots_if_voting_power_spike_detected(164, 8),
         None
     );
     assert_eq!(
-        snapshots.previous_ballots_if_voting_power_spike_detected(31, 8),
-        Some((2, voting_power_snapshot(vec![9, 10], 20)))
+        snapshots.previous_ballots_if_voting_power_spike_detected(166, 8),
+        Some((2, voting_power_snapshot(vec![90, 10], 110)))
     );
+    assert!(!snapshots.is_latest_snapshot_a_spike(8));
+
+    // The 9th snapshot is a spike, and `is_latest_snapshot_a_spike` should return true.
+    snapshots.record_voting_power_snapshot(9, voting_power_snapshot(vec![90, 90], 200));
+    assert_eq!(snapshots.latest_snapshot_timestamp_seconds(), Some(9));
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(166, 9),
+        None
+    );
+    assert_eq!(
+        snapshots.previous_ballots_if_voting_power_spike_detected(177, 9),
+        Some((3, voting_power_snapshot(vec![90, 11], 111)))
+    );
+    assert!(snapshots.is_latest_snapshot_a_spike(9));
 
     // After 4 months, the snapshots are considered stale, and the voting power spike
     // detection is disabled.


### PR DESCRIPTION
# Why

When there is a voting power spike detected in the snapshots themselves, we don't want to add new snapshots since they would make the voting power look normal after some time.

# What

* Refactor the voting power spike detection logic into `totals_entry_with_minimum_total_potential_voting_power_if_voting_power_spiked`
* Early return on in the `SnapshotVotingPowerTask::execute` when `is_latest_snapshot_a_spike`.

