### PR TITLE
chore(node): fix iDRAC console 'no signal' regression

### DIFF
--- a/ic-os/bootloader/grub.cfg
+++ b/ic-os/bootloader/grub.cfg
@@ -78,7 +78,7 @@ if [ -f ${boot}/extra_boot_args ]; then
     echo Extra boot arguments $EXTRA_BOOT_ARGS
 fi
 
-linux /vmlinuz root=$linux_root console=ttyS0 nomodeset dfinity.system=$boot_alternative dfinity.boot_state=$BOOT_STATE $EXTRA_BOOT_ARGS
+linux /vmlinuz root=$linux_root console=ttyS0 nomodeset video=1024x768 dfinity.system=$boot_alternative dfinity.boot_state=$BOOT_STATE $EXTRA_BOOT_ARGS
 
 if [ -f ${boot}/initrd.img ] ; then
     echo Loading initial ram disk ${boot}/initrd.img

--- a/ic-os/hostos/grub.cfg
+++ b/ic-os/hostos/grub.cfg
@@ -78,7 +78,7 @@ if [ -f ${boot}/extra_boot_args ]; then
     echo Extra boot arguments $EXTRA_BOOT_ARGS
 fi
 
-linux /vmlinuz root=$linux_root console=ttyS0,115200 console=tty0 nomodeset dfinity.system=$boot_alternative dfinity.boot_state=$BOOT_STATE $EXTRA_BOOT_ARGS
+linux /vmlinuz root=$linux_root console=ttyS0,115200 console=tty0 nomodeset video=1024x768 dfinity.system=$boot_alternative dfinity.boot_state=$BOOT_STATE $EXTRA_BOOT_ARGS
 
 if [ -f ${boot}/initrd.img ]; then
     echo Loading initial ram disk ${boot}/initrd.img

--- a/ic-os/setupos/grub.cfg
+++ b/ic-os/setupos/grub.cfg
@@ -20,7 +20,7 @@ if [ -f ${boot}/extra_boot_args ]; then
     echo Extra boot arguments $EXTRA_BOOT_ARGS
 fi
 
-linux /vmlinuz root=$linux_root console=ttyS0,115200 console=tty0 nomodeset $EXTRA_BOOT_ARGS
+linux /vmlinuz root=$linux_root console=ttyS0,115200 console=tty0 nomodeset video=1024x768 $EXTRA_BOOT_ARGS
 
 if [ -f ${boot}/initrd.img ] ; then
     echo Loading initial ram disk ${boot}/initrd.img


### PR DESCRIPTION
[NODE-1587](https://dfinity.atlassian.net/browse/NODE-1587)

Added video=1024x768 to the kernel boot parameters to fix a regression in Linux 6.11 that causes the iDRAC console to show "no signal". This forces the framebuffer to stay within a resolution supported by iDRAC's virtual console when no physical monitor is attached.

[NODE-1587]: https://dfinity.atlassian.net/browse/NODE-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ