### PR TITLE
test(ckbtc): run minter and checker on app subnet in sys tests

### DIFF
--- a/rs/tests/ckbtc/ckbtc_minter_batching.rs
+++ b/rs/tests/ckbtc/ckbtc_minter_batching.rs
@@ -5,7 +5,7 @@ use bitcoincore_rpc::{
     RpcApi,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
-use ic_base_types::{CanisterId, PrincipalId};
+use ic_base_types::PrincipalId;
 use ic_ckbtc_agent::CkBtcMinterAgent;
 use ic_ckbtc_minter::state::RetrieveBtcStatus;
 use ic_ckbtc_minter::updates::get_withdrawal_account::compute_subaccount;
@@ -19,8 +19,8 @@ use ic_system_test_driver::{
     util::{assert_create_agent, block_on, runtime_from_url},
 };
 use ic_tests_ckbtc::{
-    activate_ecdsa_signature, create_canister_at_id, install_bitcoin_canister, install_btc_checker,
-    install_ledger, install_minter, setup, subnet_sys,
+    activate_ecdsa_signature, create_canister, install_bitcoin_canister, install_btc_checker,
+    install_ledger, install_minter, setup, subnet_app, subnet_sys,
     utils::{
         ensure_wallet, generate_blocks, get_btc_address, get_btc_client, retrieve_btc,
         send_to_btc_address, wait_for_finalization_no_new_blocks, wait_for_mempool_change,
@@ -57,7 +57,9 @@ pub struct HttpResponse {
 pub fn test_batching(env: TestEnv) {
     let logger = env.logger();
     let subnet_sys = subnet_sys(&env);
+    let subnet_app = subnet_app(&env);
     let sys_node = subnet_sys.nodes().next().expect("No node in sys subnet.");
+    let app_node = subnet_app.nodes().next().expect("No node in app subnet.");
     let btc_rpc = get_btc_client(&env);
     ensure_wallet(&btc_rpc, &logger);
 
@@ -74,20 +76,18 @@ pub fn test_batching(env: TestEnv) {
         .generate_to_address(101, &default_btc_address)
         .unwrap();
 
-    let minter_id = CanisterId::from_u64(200);
-    let ledger_id = CanisterId::from_u64(201);
-    let btc_checker_id = CanisterId::from_u64(203);
-
     block_on(async {
-        let runtime = runtime_from_url(sys_node.get_public_url(), sys_node.effective_canister_id());
-        install_bitcoin_canister(&runtime, &logger).await;
+        let sys_runtime =
+            runtime_from_url(sys_node.get_public_url(), sys_node.effective_canister_id());
+        let runtime = runtime_from_url(app_node.get_public_url(), app_node.effective_canister_id());
+        install_bitcoin_canister(&sys_runtime, &logger).await;
 
-        let mut ledger_canister = create_canister_at_id(&runtime, ledger_id.get()).await;
-        let mut minter_canister = create_canister_at_id(&runtime, minter_id.get()).await;
-        let mut btc_checker_canister = create_canister_at_id(&runtime, btc_checker_id.get()).await;
+        let mut ledger_canister = create_canister(&runtime).await;
+        let mut minter_canister = create_canister(&runtime).await;
+        let mut btc_checker_canister = create_canister(&runtime).await;
 
         let minting_user = minter_canister.canister_id().get();
-        let agent = assert_create_agent(sys_node.get_public_url().as_str()).await;
+        let agent = assert_create_agent(app_node.get_public_url().as_str()).await;
         let btc_checker_id = install_btc_checker(&mut btc_checker_canister, &env).await;
         let ledger_id = install_ledger(&mut ledger_canister, minting_user, &logger).await;
 

--- a/rs/tests/ckbtc/ckbtc_minter_checker.rs
+++ b/rs/tests/ckbtc/ckbtc_minter_checker.rs
@@ -21,7 +21,7 @@ use ic_system_test_driver::{
 };
 use ic_tests_ckbtc::{
     activate_ecdsa_signature, create_canister, install_bitcoin_canister, install_btc_checker,
-    install_ledger, install_minter, setup, subnet_sys, upgrade_btc_checker,
+    install_ledger, install_minter, setup, subnet_app, subnet_sys, upgrade_btc_checker,
     utils::{
         assert_account_balance, assert_mint_transaction, assert_no_new_utxo, assert_no_transaction,
         ensure_wallet, generate_blocks, get_btc_address, get_btc_client, send_to_btc_address,
@@ -41,7 +41,9 @@ use slog::debug;
 pub fn test_btc_checker(env: TestEnv) {
     let logger = env.logger();
     let subnet_sys = subnet_sys(&env);
+    let subnet_app = subnet_app(&env);
     let sys_node = subnet_sys.nodes().next().expect("No node in sys subnet.");
+    let app_node = subnet_app.nodes().next().expect("No node in app subnet.");
 
     // Get access to btc replica.
     let btc_rpc = get_btc_client(&env);
@@ -63,15 +65,17 @@ pub fn test_btc_checker(env: TestEnv) {
         .unwrap();
 
     block_on(async {
-        let runtime = runtime_from_url(sys_node.get_public_url(), sys_node.effective_canister_id());
-        install_bitcoin_canister(&runtime, &logger).await;
+        let sys_runtime =
+            runtime_from_url(sys_node.get_public_url(), sys_node.effective_canister_id());
+        let runtime = runtime_from_url(app_node.get_public_url(), app_node.effective_canister_id());
+        install_bitcoin_canister(&sys_runtime, &logger).await;
 
         let mut ledger_canister = create_canister(&runtime).await;
         let mut minter_canister = create_canister(&runtime).await;
         let mut btc_checker_canister = create_canister(&runtime).await;
 
         let minting_user = minter_canister.canister_id().get();
-        let agent = assert_create_agent(sys_node.get_public_url().as_str()).await;
+        let agent = assert_create_agent(app_node.get_public_url().as_str()).await;
         let btc_checker_id = install_btc_checker(&mut btc_checker_canister, &env).await;
         let ledger_id = install_ledger(&mut ledger_canister, minting_user, &logger).await;
         let minter_id =
@@ -80,7 +84,7 @@ pub fn test_btc_checker(env: TestEnv) {
 
         let ledger = Principal::from(ledger_id.get());
         let universal_canister =
-            UniversalCanister::new_with_retries(&agent, sys_node.effective_canister_id(), &logger)
+            UniversalCanister::new_with_retries(&agent, app_node.effective_canister_id(), &logger)
                 .await;
         activate_ecdsa_signature(sys_node, subnet_sys.subnet_id, TEST_KEY_LOCAL, &logger).await;
 

--- a/rs/tests/ckbtc/ckbtc_minter_retrieve_btc.rs
+++ b/rs/tests/ckbtc/ckbtc_minter_retrieve_btc.rs
@@ -25,7 +25,7 @@ use ic_system_test_driver::{
 };
 use ic_tests_ckbtc::{
     activate_ecdsa_signature, create_canister, install_bitcoin_canister, install_btc_checker,
-    install_ledger, install_minter, setup, subnet_sys, upgrade_btc_checker,
+    install_ledger, install_minter, setup, subnet_app, subnet_sys, upgrade_btc_checker,
     utils::{
         assert_account_balance, assert_burn_transaction, assert_mint_transaction, ensure_wallet,
         generate_blocks, get_btc_address, get_btc_client, update_balance,
@@ -41,7 +41,9 @@ use slog::{debug, info};
 pub fn test_retrieve_btc(env: TestEnv) {
     let logger = env.logger();
     let subnet_sys = subnet_sys(&env);
+    let subnet_app = subnet_app(&env);
     let sys_node = subnet_sys.nodes().next().expect("No node in sys subnet.");
+    let app_node = subnet_app.nodes().next().expect("No node in app subnet.");
     let btc_rpc = get_btc_client(&env);
     ensure_wallet(&btc_rpc, &logger);
 
@@ -60,15 +62,17 @@ pub fn test_retrieve_btc(env: TestEnv) {
         .unwrap();
 
     block_on(async {
-        let runtime = runtime_from_url(sys_node.get_public_url(), sys_node.effective_canister_id());
-        install_bitcoin_canister(&runtime, &logger).await;
+        let sys_runtime =
+            runtime_from_url(sys_node.get_public_url(), sys_node.effective_canister_id());
+        let runtime = runtime_from_url(app_node.get_public_url(), app_node.effective_canister_id());
+        install_bitcoin_canister(&sys_runtime, &logger).await;
 
         let mut ledger_canister = create_canister(&runtime).await;
         let mut minter_canister = create_canister(&runtime).await;
         let mut btc_checker_canister = create_canister(&runtime).await;
 
         let minting_user = minter_canister.canister_id().get();
-        let agent = assert_create_agent(sys_node.get_public_url().as_str()).await;
+        let agent = assert_create_agent(app_node.get_public_url().as_str()).await;
         let btc_checker_id = install_btc_checker(&mut btc_checker_canister, &env).await;
         let ledger_id = install_ledger(&mut ledger_canister, minting_user, &logger).await;
         let minter_id =
@@ -76,7 +80,7 @@ pub fn test_retrieve_btc(env: TestEnv) {
         let minter = Principal::from(minter_id.get());
         let ledger = Principal::from(ledger_id.get());
         let universal_canister =
-            UniversalCanister::new_with_retries(&agent, sys_node.effective_canister_id(), &logger)
+            UniversalCanister::new_with_retries(&agent, app_node.effective_canister_id(), &logger)
                 .await;
         activate_ecdsa_signature(sys_node, subnet_sys.subnet_id, TEST_KEY_LOCAL, &logger).await;
 

--- a/rs/tests/ckbtc/ckbtc_minter_update_balance.rs
+++ b/rs/tests/ckbtc/ckbtc_minter_update_balance.rs
@@ -25,7 +25,7 @@ use ic_system_test_driver::{
 };
 use ic_tests_ckbtc::{
     activate_ecdsa_signature, create_canister, install_bitcoin_canister, install_btc_checker,
-    install_ledger, install_minter, setup, subnet_sys, upgrade_btc_checker,
+    install_ledger, install_minter, setup, subnet_app, subnet_sys, upgrade_btc_checker,
     utils::{
         assert_mint_transaction, assert_no_new_utxo, assert_no_transaction,
         assert_temporarily_unavailable, ensure_wallet, generate_blocks, get_btc_address,
@@ -47,7 +47,9 @@ use slog::{debug, info};
 pub fn test_update_balance(env: TestEnv) {
     let logger = env.logger();
     let subnet_sys = subnet_sys(&env);
+    let subnet_app = subnet_app(&env);
     let sys_node = subnet_sys.nodes().next().expect("No node in sys subnet.");
+    let app_node = subnet_app.nodes().next().expect("No node in app subnet.");
 
     // Get access to btc replica.
     let btc_rpc = get_btc_client(&env);
@@ -69,15 +71,17 @@ pub fn test_update_balance(env: TestEnv) {
         .unwrap();
 
     block_on(async {
-        let runtime = runtime_from_url(sys_node.get_public_url(), sys_node.effective_canister_id());
-        install_bitcoin_canister(&runtime, &logger).await;
+        let sys_runtime =
+            runtime_from_url(sys_node.get_public_url(), sys_node.effective_canister_id());
+        let runtime = runtime_from_url(app_node.get_public_url(), app_node.effective_canister_id());
+        install_bitcoin_canister(&sys_runtime, &logger).await;
 
         let mut ledger_canister = create_canister(&runtime).await;
         let mut minter_canister = create_canister(&runtime).await;
         let mut btc_checker_canister = create_canister(&runtime).await;
 
         let minting_user = minter_canister.canister_id().get();
-        let agent = assert_create_agent(sys_node.get_public_url().as_str()).await;
+        let agent = assert_create_agent(app_node.get_public_url().as_str()).await;
         let btc_checker_id = install_btc_checker(&mut btc_checker_canister, &env).await;
         let ledger_id = install_ledger(&mut ledger_canister, minting_user, &logger).await;
         let minter_id =
@@ -86,7 +90,7 @@ pub fn test_update_balance(env: TestEnv) {
 
         let ledger = Principal::from(ledger_id.get());
         let universal_canister =
-            UniversalCanister::new_with_retries(&agent, sys_node.effective_canister_id(), &logger)
+            UniversalCanister::new_with_retries(&agent, app_node.effective_canister_id(), &logger)
                 .await;
         activate_ecdsa_signature(
             sys_node.clone(),

--- a/rs/tests/ckbtc/ckbtc_minter_update_balance.rs
+++ b/rs/tests/ckbtc/ckbtc_minter_update_balance.rs
@@ -280,8 +280,7 @@ pub fn test_update_balance(env: TestEnv) {
 
         // We create a new agent with a different identity
         // to have caller != new_caller
-        let agent = assert_create_agent(sys_node.get_public_url().as_str()).await;
-        let mut mutable_agent = agent;
+        let mut mutable_agent = assert_create_agent(app_node.get_public_url().as_str()).await;
         let mut rng = ChaChaRng::from_rng(OsRng).unwrap();
         let identity = Secp256k1Identity::from_private_key(SecretKey::random(&mut rng));
         mutable_agent.set_identity(identity);

--- a/rs/tests/ckbtc/src/lib.rs
+++ b/rs/tests/ckbtc/src/lib.rs
@@ -157,6 +157,11 @@ docker run  --name=bitcoind-node -d \
         .add_subnet(
             Subnet::new(SubnetType::System)
                 .with_dkg_interval_length(Height::from(10))
+                .add_nodes(1),
+        )
+        .add_subnet(
+            Subnet::new(SubnetType::Application)
+                .with_dkg_interval_length(Height::from(10))
                 .with_features(SubnetFeatures {
                     http_requests: true,
                     ..SubnetFeatures::default()
@@ -166,12 +171,6 @@ docker run  --name=bitcoind-node -d \
         .use_specified_ids_allocation_range()
         .setup_and_start(&env)
         .expect("failed to setup IC under test");
-
-    env.topology_snapshot().subnets().for_each(|subnet| {
-        subnet
-            .nodes()
-            .for_each(|node| node.await_status_is_healthy().unwrap())
-    });
 }
 
 pub fn setup(env: TestEnv) {
@@ -329,6 +328,13 @@ pub fn subnet_sys(env: &TestEnv) -> SubnetSnapshot {
     env.topology_snapshot()
         .subnets()
         .find(|s| s.subnet_type() == SubnetType::System)
+        .unwrap()
+}
+
+pub fn subnet_app(env: &TestEnv) -> SubnetSnapshot {
+    env.topology_snapshot()
+        .subnets()
+        .find(|s| s.subnet_type() == SubnetType::Application)
         .unwrap()
 }
 


### PR DESCRIPTION
XC-243

In ckBTC system tests, install and run the minter and bitcoin checker canisters on an application subnet so that it better matches what is in production.
