### PR TITLE
feat: Make CanisterModule writable for snapshot upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14447,6 +14447,7 @@ dependencies = [
  "ic-validate-eq",
  "ic-validate-eq-derive",
  "serde",
+ "tempfile",
 ]
 
 [[package]]

--- a/rs/types/wasm_types/BUILD.bazel
+++ b/rs/types/wasm_types/BUILD.bazel
@@ -19,5 +19,6 @@ rust_library(
         "//rs/utils",
         "//rs/utils/validate_eq",
         "@crate_index//:serde",
+        "@crate_index//:tempfile",
     ],
 )

--- a/rs/types/wasm_types/Cargo.toml
+++ b/rs/types/wasm_types/Cargo.toml
@@ -14,3 +14,4 @@ ic-utils = { path = "../../utils" }
 ic-validate-eq = { path = "../../utils/validate_eq" }
 ic-validate-eq-derive = { path = "../../utils/validate_eq_derive" }
 serde = { workspace = true }
+tempfile = { workspace = true }

--- a/rs/types/wasm_types/src/lib.rs
+++ b/rs/types/wasm_types/src/lib.rs
@@ -12,6 +12,7 @@ use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;
 use std::{
     fmt,
+    io::Write,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -308,4 +309,17 @@ fn test_chunk_write_to_module() {
     module
         .write(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0)
         .unwrap_err();
+}
+
+#[test]
+fn test_write_module_file() {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&[0x00, 0x61, 0x73, 0x6d, 0x00, 0x00, 0x00, 0x00])
+        .unwrap();
+    let mut module = CanisterModule::new_from_file(tmp.path().into(), WasmHash([0; 32])).unwrap();
+    module.write(&[9], 5).unwrap();
+    assert_eq!(
+        &[0x00, 0x61, 0x73, 0x6d, 0x00, 0x09, 0x00, 0x00],
+        module.as_slice()
+    );
 }

--- a/rs/types/wasm_types/src/lib.rs
+++ b/rs/types/wasm_types/src/lib.rs
@@ -12,7 +12,6 @@ use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;
 use std::{
     fmt,
-    io::Write,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -313,6 +312,7 @@ fn test_chunk_write_to_module() {
 
 #[test]
 fn test_write_module_file() {
+    use std::io::Write;
     let mut tmp = tempfile::NamedTempFile::new().unwrap();
     tmp.write_all(&[0x00, 0x61, 0x73, 0x6d, 0x00, 0x00, 0x00, 0x00])
         .unwrap();

--- a/rs/types/wasm_types/src/lib.rs
+++ b/rs/types/wasm_types/src/lib.rs
@@ -301,11 +301,11 @@ fn test_chunk_write_to_module() {
     assert_eq!(&original_module, module.as_slice());
     assert_eq!(original_hash, module.module_hash());
 
-    module.write(&vec![1, 2, 3], 999).unwrap_err();
+    module.write(&[1, 2, 3], 999).unwrap_err();
     module
-        .write(&vec![1, 2, 3], original_module.len() - 1)
+        .write(&[1, 2, 3], original_module.len() - 1)
         .unwrap_err();
     module
-        .write(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0)
+        .write(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0)
         .unwrap_err();
 }

--- a/rs/types/wasm_types/src/lib.rs
+++ b/rs/types/wasm_types/src/lib.rs
@@ -92,11 +92,7 @@ impl CanisterModule {
     /// chunk by chunk.
     /// Returns an error if `offset` + `buf.len()` > `module.len()`.
     pub fn write(&mut self, buf: &[u8], offset: usize) -> Result<(), String> {
-        let CanisterModule {
-            module,
-            module_hash: _,
-        } = self;
-        match module.clone().write(buf, offset) {
+        match self.module.clone().write(buf, offset) {
             Ok(module) => {
                 self.module_hash = ic_crypto_sha2::Sha256::hash(module.as_slice());
                 self.module = module;

--- a/rs/types/wasm_types/src/lib.rs
+++ b/rs/types/wasm_types/src/lib.rs
@@ -90,7 +90,7 @@ impl CanisterModule {
     /// Overwrite the module at `offset` with `buf`. This may invalidate the
     /// module, and will change its hash. It's useful for uploading a module
     /// chunk by chunk.
-    /// Returns the original module if `offset` + `buf.len()` > `module.len()`.
+    /// Returns an error if `offset` + `buf.len()` > `module.len()`.
     pub fn write(&mut self, buf: &[u8], offset: usize) -> Result<(), String> {
         let CanisterModule {
             module,


### PR DESCRIPTION
This PR adds a `write` method to the `CanisterModule` type, such that this binary data can be uploaded and written in slices via the snapshot data upload endpoints. 

Using the write method may make the `CanisterModule` invalid. But this type seems to have no validity guarantees in existing code: E.g., [here](https://sourcegraph.com/github.com/dfinity/ic@mwe/module_write/-/blob/rs/execution_environment/src/canister_manager/types.rs?L213), it's composed from user-provided wasm chunks. Also, the canister module will only be compiled when put in the compilation cache, and only at that point does the replica know if the module is valid. 

When the user is done uploading slices, they may load the snapshot. At this point, the snapshot's content, including the `CanisterModule`, must be validated (in a follow-up PR).

The alternative considered was to change the `CanisterSnapshot` struct into an enum which can represent both `Valid` and `Partial` canister snapshots. However, the blast radius of this would be significant. 



