### PR TITLE
chore: [NODE-1591] add power metrics test

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -47,41 +47,28 @@ jobs:
           echo "$ZH2_DLL01_CSV_SECRETS" > file1
           echo "$ZH2_FILE_SHARE_KEY" > file2 && chmod 400 file2
 
+          launch_bare_metal() {
+            # shellcheck disable=SC2046,SC2086
+            bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
+              //ic-os/setupos/envs/dev:launch_bare_metal -- \
+                --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
+                --csv_filename "$(realpath file1)" \
+                --file_share_ssh_key "$(realpath file2)" \
+                --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
+                --file_share_username ci_interim \
+                --ci_mode \
+                $@
+          }
+
           # Run bare metal installation test
-          # shellcheck disable=SC2046,SC2086
-          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
-            //ic-os/setupos/envs/dev:launch_bare_metal -- \
-              --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
-              --csv_filename "$(realpath file1)" \
-              --file_share_ssh_key "$(realpath file2)" \
-              --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
-              --file_share_username ci_interim \
-              --hsm \
-              --ci_mode
+          launch_bare_metal --hsm
 
           # Run bare metal node performance benchmarks
-          # shellcheck disable=SC2046,SC2086
-          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
-            //ic-os/setupos/envs/dev:launch_bare_metal -- \
-              --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
-              --csv_filename "$(realpath file1)" \
-              --file_share_ssh_key "$(realpath file2)" \
-              --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
-              --file_share_username ci_interim \
-              --ci_mode \
-              --benchmark
+          launch_bare_metal --benchmark
 
           # Run bare metal node hostOS metrics check
-          # shellcheck disable=SC2046,SC2086
-          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
-            //ic-os/setupos/envs/dev:launch_bare_metal -- \
-              --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
-              --csv_filename "$(realpath file1)" \
-              --file_share_ssh_key "$(realpath file2)" \
-              --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
-              --file_share_username ci_interim \
-              --ci_mode \
-              --check_hostos_metrics
+          launch_bare_metal --check_hostos_metrics
+
           bazel clean
         env:
           BAZEL_CI_CONFIG: "--config=ci"

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -70,6 +70,18 @@ jobs:
               --file_share_username ci_interim \
               --ci_mode \
               --benchmark
+
+          # Run bare metal node hostOS metrics check
+          # shellcheck disable=SC2046,SC2086
+          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
+            //ic-os/setupos/envs/dev:launch_bare_metal -- \
+              --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
+              --csv_filename "$(realpath file1)" \
+              --file_share_ssh_key "$(realpath file2)" \
+              --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
+              --file_share_username ci_interim \
+              --ci_mode \
+              --check_hostos_metrics
           bazel clean
         env:
           BAZEL_CI_CONFIG: "--config=ci"

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -29,41 +29,28 @@ jobs:
           echo "$ZH2_DLL01_CSV_SECRETS" > file1
           echo "$ZH2_FILE_SHARE_KEY" > file2 && chmod 400 file2
 
+          launch_bare_metal() {
+            # shellcheck disable=SC2046,SC2086
+            bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
+              //ic-os/setupos/envs/dev:launch_bare_metal -- \
+                --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
+                --csv_filename "$(realpath file1)" \
+                --file_share_ssh_key "$(realpath file2)" \
+                --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
+                --file_share_username ci_interim \
+                --ci_mode \
+                $@
+          }
+
           # Run bare metal installation test
-          # shellcheck disable=SC2046,SC2086
-          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
-            //ic-os/setupos/envs/dev:launch_bare_metal -- \
-              --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
-              --csv_filename "$(realpath file1)" \
-              --file_share_ssh_key "$(realpath file2)" \
-              --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
-              --file_share_username ci_interim \
-              --hsm \
-              --ci_mode
+          launch_bare_metal --hsm
 
           # Run bare metal node performance benchmarks
-          # shellcheck disable=SC2046,SC2086
-          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
-            //ic-os/setupos/envs/dev:launch_bare_metal -- \
-              --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
-              --csv_filename "$(realpath file1)" \
-              --file_share_ssh_key "$(realpath file2)" \
-              --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
-              --file_share_username ci_interim \
-              --ci_mode \
-              --benchmark
+          launch_bare_metal --benchmark
 
           # Run bare metal node hostOS metrics check
-          # shellcheck disable=SC2046,SC2086
-          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
-            //ic-os/setupos/envs/dev:launch_bare_metal -- \
-              --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
-              --csv_filename "$(realpath file1)" \
-              --file_share_ssh_key "$(realpath file2)" \
-              --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
-              --file_share_username ci_interim \
-              --ci_mode \
-              --check_hostos_metrics
+          launch_bare_metal --check_hostos_metrics
+
           bazel clean
         env:
           BAZEL_CI_CONFIG: "--config=ci"

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -52,6 +52,18 @@ jobs:
               --file_share_username ci_interim \
               --ci_mode \
               --benchmark
+
+          # Run bare metal node hostOS metrics check
+          # shellcheck disable=SC2046,SC2086
+          bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
+            //ic-os/setupos/envs/dev:launch_bare_metal -- \
+              --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
+              --csv_filename "$(realpath file1)" \
+              --file_share_ssh_key "$(realpath file2)" \
+              --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
+              --file_share_username ci_interim \
+              --ci_mode \
+              --check_hostos_metrics
           bazel clean
         env:
           BAZEL_CI_CONFIG: "--config=ci"

--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -724,7 +724,11 @@ def main():
             args.inject_image_domain,
         )
 
-    # Benchmark these nodes, rather than deploy them.
+    if args.benchmark and args.check_hostos_metrics:
+        log.error("Cannot run both benchmark and check_hostos_metrics at the same time. Please choose one.")
+        sys.exit(1)
+
+    # Benchmark the nodes (no deployment)
     if args.benchmark:
         success = benchmark_nodes(
             bmc_infos=bmc_infos,
@@ -740,7 +744,7 @@ def main():
 
         sys.exit(0)
 
-    # Check that all important hostos metrics are available.
+    # Check that all important hostos metrics are available (no deployment)
     if args.check_hostos_metrics:
         success = check_nodes_hostos_metrics(
             bmc_infos=bmc_infos,

--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -115,6 +115,9 @@ class Args:
     # Run benchmarks if True
     benchmark: bool = flag(default=False)
 
+    # Run HostOS metrics check if True
+    check_hostos_metrics: bool = flag(default=False)
+
     # Check HSM capability if True
     hsm: bool = flag(default=False)
 
@@ -164,6 +167,7 @@ class BMCInfo:
     password: str
     network_image_url: str
     guestos_ipv6_address: Optional[IPv6Address] = None
+    hostos_ipv6_address: Optional[IPv6Address] = None
 
     def __post_init__(self):
         def assert_not_empty(name: str, x: Any) -> None:
@@ -175,7 +179,7 @@ class BMCInfo:
 
     # Don't print secrets
     def __str__(self):
-        return f"BMCInfo(ip_address={self.ip_address}, username={self.username}, password=<redacted>, network_image_url={self.network_image_url}, guestos_ipv6_address={self.guestos_ipv6_address})"
+        return f"BMCInfo(ip_address={self.ip_address}, username={self.username}, password=<redacted>, network_image_url={self.network_image_url}, hostos_ipv6_address={self.hostos_ipv6_address}), guestos_ipv6_address={self.guestos_ipv6_address})"
 
     def __repr__(self):
         return self.__str__()
@@ -206,12 +210,15 @@ def parse_from_row(row: List[str], network_image_url: str) -> BMCInfo:
 
     if len(row) == 4:
         ip_address, username, password, guestos_ipv6_address = row
+        hostos_ipv6_address = guestos_ipv6_address.replace("6801", "6800", 1)
+
         return BMCInfo(
             ip_address,
             username,
             password,
             network_image_url,
             IPv6Address(guestos_ipv6_address),
+            IPv6Address(hostos_ipv6_address),
         )
 
     assert False, f"Invalid csv row found. Must be 3 or 4 items: {row}"
@@ -241,6 +248,24 @@ def get_url_content(url: str, timeout_secs: int = 1) -> Optional[str]:
         log.warning(f"Timed out while connecting to {url}")
         return None
 
+def check_hostos_power_metrics(ip_address: IPv6Address, timeout_secs: int) -> bool:
+    metrics_endpoint = f"https://[{ip_address.exploded}]:9100/metrics"
+    log.info(f"Attempting GET on metrics at {metrics_endpoint}...")
+    metrics_output = get_url_content(metrics_endpoint, timeout_secs)
+    if not metrics_output:
+        log.warning(f"Request to {metrics_endpoint} failed.")
+        return False
+
+    log.info("Got metrics result from HostOS")
+    try:
+        power_metric_line = next(
+            line for line in metrics_output.splitlines() if not line.startswith("#") and "power_average_watts" in line
+        )
+        log.info(f"power consumption metric: {power_metric_line}")
+        return True
+    except StopIteration:
+        log.warning("power_average_watts metric not found in HostOS metrics")
+        return False
 
 def check_guestos_ping_connectivity(ip_address: IPv6Address, timeout_secs: int) -> bool:
     # Ping target with count of 1, STRICT timeout of `timeout_secs`.
@@ -262,11 +287,15 @@ def check_guestos_metrics_version(ip_address: IPv6Address, timeout_secs: int) ->
         return False
 
     log.info("Got metrics result from GuestOS")
-    guestos_version_line = next(
-        line for line in metrics_output.splitlines() if not line.startswith("#") and "guestos_version{" in line
-    )
-    log.info(f"GuestOS version metric: {guestos_version_line}")
-    return True
+    try:
+        guestos_version_line = next(
+            line for line in metrics_output.splitlines() if not line.startswith("#") and "guestos_version{" in line
+        )
+        log.info(f"GuestOS version metric: {guestos_version_line}")
+        return True
+    except StopIteration:
+        log.warning("guestos_version metric not found in GuestOS metrics")
+        return False
 
 
 def check_guestos_hsm_capability(ip_address: IPv6Address, ssh_key_file: Optional[str] = None) -> bool:
@@ -532,6 +561,37 @@ def benchmark_nodes(
         log.info("All benchmarks completed successfully.")
         return True
 
+def check_node_hostos_metrics(
+    bmc_info: BMCInfo
+):
+    log.info("Checking HostOS metrics.")
+    timeout_secs = 5
+    result = check_hostos_power_metrics(bmc_info.hostos_ipv6_address, timeout_secs)
+    return OperationResult(bmc_info, success=result)
+
+def check_nodes_hostos_metrics(
+    bmc_infos: List[BMCInfo],
+    parallelism: int,
+):
+    results: List[OperationResult] = []
+
+    with Pool(parallelism) as p:
+        results = p.map(check_node_hostos_metrics, bmc_infos)
+
+    log.info("HostOS metrics check summary:")
+    metrics_check_failure = False
+    for res in results:
+        log.info(res)
+        if not res.success:
+            metrics_check_failure = True
+
+    if metrics_check_failure:
+        log.error("The metrics check failed on one or more nodes.")
+        return False
+    else:
+        log.info("All nodes correctly export the hostOS metrics.")
+        return True
+
 
 def create_file_share_endpoint(file_share_url: str, file_share_username: Optional[str]) -> str:
     return file_share_url if file_share_username is None else f"{file_share_username}@{file_share_url}"
@@ -671,6 +731,18 @@ def main():
             benchmark_runner_script=args.benchmark_runner_script,
             benchmark_tools=args.benchmark_tools,
             file_share_ssh_key=args.file_share_ssh_key,
+        )
+
+        if not success:
+            sys.exit(1)
+
+        sys.exit(0)
+
+    # Check that all important hostos metrics are available.
+    if args.check_hostos_metrics:
+        success = check_nodes_hostos_metrics(
+            bmc_infos=bmc_infos,
+            parallelism=args.parallel,
         )
 
         if not success:

--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -248,6 +248,7 @@ def get_url_content(url: str, timeout_secs: int = 1) -> Optional[str]:
         log.warning(f"Timed out while connecting to {url}")
         return None
 
+
 def check_hostos_power_metrics(ip_address: IPv6Address, timeout_secs: int) -> bool:
     metrics_endpoint = f"https://[{ip_address.exploded}]:9100/metrics"
     log.info(f"Attempting GET on metrics at {metrics_endpoint}...")
@@ -266,6 +267,7 @@ def check_hostos_power_metrics(ip_address: IPv6Address, timeout_secs: int) -> bo
     except StopIteration:
         log.warning("power_average_watts metric not found in HostOS metrics")
         return False
+
 
 def check_guestos_ping_connectivity(ip_address: IPv6Address, timeout_secs: int) -> bool:
     # Ping target with count of 1, STRICT timeout of `timeout_secs`.
@@ -561,13 +563,13 @@ def benchmark_nodes(
         log.info("All benchmarks completed successfully.")
         return True
 
-def check_node_hostos_metrics(
-    bmc_info: BMCInfo
-):
+
+def check_node_hostos_metrics(bmc_info: BMCInfo):
     log.info("Checking HostOS metrics.")
     timeout_secs = 5
     result = check_hostos_power_metrics(bmc_info.hostos_ipv6_address, timeout_secs)
     return OperationResult(bmc_info, success=result)
+
 
 def check_nodes_hostos_metrics(
     bmc_infos: List[BMCInfo],


### PR DESCRIPTION
For now, the test just makes sure that the `power_average_watts` metric is available. We can add more metrics (if they are critical) in the future.

Just replace `USERNAME` and `MACHINE` and you are good to go:
```
bazel run \
  //ic-os/setupos/envs/dev:launch_bare_metal -- \
    --file_share_username USERNAME \
    --config_path $(realpath ./ic-os/dev-tools/bare_metal_deployment/MACHINEyaml) \
    --csv_filename $(realpath ./MACHINE.csv) \
    --check_hostos_metrics
```