### PR TITLE
chore(EXC): Remove `Arc` on `WasmBinary`

### DIFF
--- a/rs/embedders/fuzz/src/wasm_executor.rs
+++ b/rs/embedders/fuzz/src/wasm_executor.rs
@@ -105,7 +105,7 @@ fn setup_wasm_execution_input(func_ref: FuncRef) -> WasmExecutionInput {
 
 #[inline(always)]
 fn setup_execution_state(
-    wasm_binary: Arc<WasmBinary>,
+    wasm_binary: WasmBinary,
     wasm_methods: BTreeSet<WasmMethod>,
     persisted_globals: Vec<Global>,
 ) -> ExecutionState {

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -1148,12 +1148,11 @@ fn switch_to_checkpoint(
                 tip_state.wasm_binary.binary.as_slice(),
                 wasm_binary.as_slice()
             );
-            tip_state.wasm_binary = Arc::new(
+            tip_state.wasm_binary = 
                 ic_replicated_state::canister_state::execution_state::WasmBinary {
                     binary: wasm_binary,
                     embedder_cache,
-                },
-            );
+                };
 
             // Reset the sandbox state to force full synchronization on the next message
             // execution because the checkpoint file of `tip` has changed.

--- a/rs/test_utilities/state/src/lib.rs
+++ b/rs/test_utilities/state/src/lib.rs
@@ -64,7 +64,7 @@ const EMPTY_WASM: &[u8] = &[
     0x01, 0x00,
 ];
 
-pub fn empty_wasm() -> Arc<WasmBinary> {
+pub fn empty_wasm() -> WasmBinary {
     WasmBinary::new(CanisterModule::new(EMPTY_WASM.to_vec()))
 }
 
@@ -597,7 +597,7 @@ impl ExecutionStateBuilder {
         self
     }
 
-    pub fn with_wasm_binary(mut self, wasm_binary: Arc<WasmBinary>) -> Self {
+    pub fn with_wasm_binary(mut self, wasm_binary: WasmBinary) -> Self {
         self.execution_state.wasm_binary = wasm_binary;
         self
     }


### PR DESCRIPTION
The `WasmBinary` field on `ExecutionState` is behind an `Arc` for cheap cloning and sharing of the `EmbedderCache`, but this isn't needed because all the fields are ultimately behind `Arc`s anyway (except for one `PathBuf` which this PR moves into an `Arc`).