### PR TITLE
feat(crypto): CRP-2777 enhance vetKD key lifecycle system test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2722,6 +2722,8 @@ dependencies = [
  "anyhow",
  "canister-test",
  "futures",
+ "ic-config",
+ "ic-crypto-test-utils-reproducible-rng",
  "ic-management-canister-types-private",
  "ic-nns-constants",
  "ic-registry-subnet-type",
@@ -2730,6 +2732,7 @@ dependencies = [
  "ic-vetkd-utils",
  "ic_consensus_system_test_utils",
  "ic_consensus_threshold_sig_system_test_utils",
+ "rand 0.8.5",
  "slog",
  "tokio",
 ]

--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -934,7 +934,7 @@ pub fn verify_ecdsa_signature(pk: &[u8], sig: &[u8], msg: &[u8]) -> bool {
     pk.verify_prehash(msg, &signature).is_ok()
 }
 
-pub fn verify_vetkd(public_key: &[u8], encrypted_key: &[u8], input: &[u8]) -> bool {
+pub fn verify_vetkey(public_key: &[u8], encrypted_key: &[u8], input: &[u8]) -> bool {
     let dpk = DerivedPublicKey::deserialize(public_key).expect("Failed to deserialize public key");
 
     let transport_key = TransportSecretKey::from_seed(VETKD_TRANSPORT_SECRET_KEY_SEED.to_vec())
@@ -958,7 +958,7 @@ pub fn verify_signature(key_id: &MasterPublicKeyId, msg: &[u8], pk: &[u8], sig: 
             SchnorrAlgorithm::Ed25519 => verify_ed25519_signature(pk, sig, msg),
         },
         MasterPublicKeyId::VetKd(key_id) => match key_id.curve {
-            VetKdCurve::Bls12_381_G2 => verify_vetkd(pk, sig, msg),
+            VetKdCurve::Bls12_381_G2 => verify_vetkey(pk, sig, msg),
         },
     };
     assert!(res);

--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -34,7 +34,7 @@ use ic_system_test_driver::{
 };
 use ic_types::{Height, PrincipalId, ReplicaVersion};
 use ic_types_test_utils::ids::subnet_test_id;
-use ic_vetkd_utils::{DerivedPublicKey, EncryptedVetKey, IBECiphertext, TransportSecretKey};
+use ic_vetkd_utils::{DerivedPublicKey, EncryptedVetKey, TransportSecretKey};
 use k256::ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey};
 use registry_canister::mutations::{
     do_create_subnet::{
@@ -53,8 +53,7 @@ pub const DKG_INTERVAL: u64 = 19;
 
 pub const NUMBER_OF_NODES: usize = 4;
 
-const MSG: &str = "Secret message that is totally important";
-const SEED: [u8; 32] = [13; 32];
+const VETKD_TRANSPORT_SECRET_KEY_SEED: [u8; 32] = [13; 32];
 const GET_SIGNATURE_RETRIES: i32 = 10;
 
 pub fn make_key(name: &str) -> EcdsaKeyId {
@@ -230,6 +229,10 @@ pub fn empty_subnet_update() -> UpdateSubnetPayload {
 pub fn scale_cycles(cycles: Cycles) -> Cycles {
     // Subnet is constructed with `NUMBER_OF_NODES`, see `config()` and `config_without_ecdsa_on_nns()`.
     (cycles * NUMBER_OF_NODES) / SMALL_APP_SUBNET_MAX_SIZE
+}
+
+pub fn scale_cycles_to(number_of_nodes: usize, cycles: Cycles) -> Cycles {
+    (cycles * number_of_nodes) / SMALL_APP_SUBNET_MAX_SIZE
 }
 
 /// The signature test consists of getting the given canister's Chain key, comparing it to the existing key
@@ -583,7 +586,7 @@ pub async fn get_signature_with_logger(
             get_schnorr_signature_with_logger(message, cycles, key_id, msg_can, logger).await
         }
         MasterPublicKeyId::VetKd(key_id) => {
-            get_vetkd_with_logger(message, cycles, key_id, msg_can, logger).await
+            get_vetkd_with_logger(message, vec![], cycles, key_id, msg_can, logger).await
         }
     }
 }
@@ -701,12 +704,13 @@ pub async fn get_schnorr_signature_with_logger(
 
 pub async fn get_vetkd_with_logger(
     input: Vec<u8>,
+    context: Vec<u8>,
     cycles: Cycles,
     key_id: &VetKdKeyId,
     msg_can: &MessageCanister<'_>,
     logger: &Logger,
 ) -> Result<Vec<u8>, AgentError> {
-    let transport_key = TransportSecretKey::from_seed(SEED.to_vec())
+    let transport_key = TransportSecretKey::from_seed(VETKD_TRANSPORT_SECRET_KEY_SEED.to_vec())
         .expect("Failed to generate transport secret key");
     let transport_public_key = transport_key.public_key().try_into().unwrap();
 
@@ -714,7 +718,7 @@ pub async fn get_vetkd_with_logger(
         logger,
         "Sending a {} request of size: {}",
         key_id,
-        input.len(),
+        input.len() + context.len(),
     );
 
     let mut count = 0;
@@ -723,6 +727,7 @@ pub async fn get_vetkd_with_logger(
             transport_public_key,
             key_id.clone(),
             input.clone(),
+            context.clone(),
             msg_can,
             cycles,
         )
@@ -931,24 +936,16 @@ pub fn verify_ecdsa_signature(pk: &[u8], sig: &[u8], msg: &[u8]) -> bool {
 
 pub fn verify_vetkd(public_key: &[u8], encrypted_key: &[u8], input: &[u8]) -> bool {
     let dpk = DerivedPublicKey::deserialize(public_key).expect("Failed to deserialize public key");
-    let enc_msg = IBECiphertext::encrypt(&dpk, input, MSG.as_bytes(), &SEED)
-        .expect("Failed to encrypt message");
 
-    let transport_key = TransportSecretKey::from_seed(SEED.to_vec())
+    let transport_key = TransportSecretKey::from_seed(VETKD_TRANSPORT_SECRET_KEY_SEED.to_vec())
         .expect("Failed to generate transport secret key");
 
     let enc_key =
         EncryptedVetKey::deserialize(encrypted_key).expect("Failed to deserialize encrypted key");
 
-    let priv_key = enc_key
+    enc_key
         .decrypt_and_verify(&transport_key, &dpk, input)
-        .expect("Failed to decrypt derived key");
-
-    let msg = enc_msg
-        .decrypt(&priv_key)
-        .expect("Failed to decrypt the message");
-
-    msg == MSG.as_bytes()
+        .is_ok()
 }
 
 pub fn verify_signature(key_id: &MasterPublicKeyId, msg: &[u8], pk: &[u8], sig: &[u8]) {
@@ -1084,11 +1081,12 @@ pub async fn vetkd_derive_key(
     transport_public_key: [u8; 48],
     key_id: VetKdKeyId,
     input: Vec<u8>,
+    context: Vec<u8>,
     msg_can: &MessageCanister<'_>,
     cycles: Cycles,
 ) -> Result<Vec<u8>, AgentError> {
     let args = VetKdDeriveKeyArgs {
-        context: vec![],
+        context,
         input,
         key_id,
         transport_public_key,

--- a/rs/tests/consensus/vetkd/BUILD.bazel
+++ b/rs/tests/consensus/vetkd/BUILD.bazel
@@ -16,6 +16,7 @@ system_test_nns(
         # Keep sorted.
         "//packages/ic-vetkd-utils",
         "//rs/config",
+        "//rs/crypto/test_utils/reproducible_rng",
         "//rs/nns/constants",
         "//rs/registry/subnet_type",
         "//rs/rust_canisters/canister_test",
@@ -27,6 +28,7 @@ system_test_nns(
         "@crate_index//:anyhow",
         "@crate_index//:futures",
         "@crate_index//:ic-agent",
+        "@crate_index//:rand",
         "@crate_index//:slog",
     ],
 )

--- a/rs/tests/consensus/vetkd/Cargo.toml
+++ b/rs/tests/consensus/vetkd/Cargo.toml
@@ -8,6 +8,8 @@ documentation.workspace = true
 
 [dependencies]
 canister-test = { path = "../../../rust_canisters/canister_test" }
+ic-config = { path = "../../../config" }
+ic-crypto-test-utils-reproducible-rng = { path = "../../../crypto/test_utils/reproducible_rng" }
 ic-management-canister-types-private = { path = "../../../types/management_canister_types" }
 ic-nns-constants = { path = "../../../nns/constants" }
 ic-registry-subnet-type = { path = "../../../registry/subnet_type" }
@@ -18,6 +20,7 @@ ic_consensus_threshold_sig_system_test_utils = { path = "../tecdsa/utils" }
 ic-vetkd-utils = { path = "../../../../packages/ic-vetkd-utils" }
 anyhow = { workspace = true }
 futures = { workspace = true }
+rand = { workspace = true }
 slog = { workspace = true }
 tokio = { workspace = true }
 

--- a/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
+++ b/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
@@ -338,7 +338,7 @@ async fn derive_vetkey_with_canister<R: Rng>(
 
     EncryptedVetKey::deserialize(&encrypted_vetkey)
         .expect("Failed to deserialize encrypted key")
-        .decrypt_and_verify(&tsk, &verification_key, input)
+        .decrypt_and_verify(&tsk, verification_key, input)
         .expect("Failed to decrypt derived key")
 }
 

--- a/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
+++ b/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
@@ -120,10 +120,6 @@ fn test(env: TestEnv) {
         curve: VetKdCurve::Bls12_381_G2,
         name: String::from("key_1"),
     };
-    let key_id_2 = VetKdKeyId {
-        curve: VetKdCurve::Bls12_381_G2,
-        name: String::from("key_2"),
-    };
 
     block_on(async {
         // Create and enable vetKD chain key on Application subnet
@@ -220,11 +216,16 @@ fn test(env: TestEnv) {
         );
 
         // Create and enable vetKD chain key for a different key ID on Application subnet
+        let key_id_2 = VetKdKeyId {
+            curve: VetKdCurve::Bls12_381_G2,
+            name: String::from("key_2"),
+        };
         assert_ne!(key_id, key_id_2);
         enable_chain_key_signing(
             &governance,
             app_subnet.subnet_id,
             vec![
+                // Specify both key IDs, so that the existing one keeps working
                 MasterPublicKeyId::VetKd(key_id.clone()),
                 MasterPublicKeyId::VetKd(key_id_2.clone()),
             ],

--- a/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
+++ b/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
@@ -1,7 +1,12 @@
 /* tag::catalog[]
 Title:: vetKD end to end tests
 
-Goal:: Test vetkd_public_key and vetkd_derive_key APIs within and across subnets
+Goal:: Test vetkd_public_key and vetkd_derive_key APIs within and across subnets. In particular, ensure that
+  the following high-level properties are satisfied:
+  . Two executions of the vetKD protocol must yield the same (decrypted) vetKey for the same
+    input/context/keyID/canister combination, even if the key derivation happens on another subnet.
+  . Two executions of the vetKD protocol must yield different (decrypted) vetKeys if any of input,
+    context, keyID, canister are different.
 
 Runbook::
 . Setup::

--- a/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
+++ b/rs/tests/consensus/vetkd/vetkd_key_life_cycle_test.rs
@@ -1,29 +1,48 @@
 /* tag::catalog[]
-Title:: Creating, fetching and deleting a vetkey on a subnet
+Title:: vetKD end to end tests
 
-Goal:: Test whether the local DKG mechanism for vetkeys works
-
+Goal:: Test vetkd_public_key and vetkd_derive_key APIs within and across subnets
 
 Runbook::
 . Setup::
-. System subnet comprising N nodes, necessary NNS canisters
-. Wait one DKG interval
-. Enable vetkey on subnet
-. Wait until public key becomes available
-. Encrypt some data to an IBE key
-. Fetch the public key from a canister
-. Use it to decrypt the data from the IBE key
-. Check that data matches
+    . System subnet comprising 4 nodes, necessary NNS canisters
+    . Application subnet comprising 4 nodes
+. Create and enable vetKD chain key on the application subnet by means of update subnet proposals.
+. Create two canisters: one on the system subnet and one on the application subnet.
+. Retrieve each canister's vetKD master public key (so as to derive subkeys locally, i.e., without
+  having to call the vetkd_public_key API).
+. Derive and verify a vetKey with some canister for some input/context/keyID combination.
+. Derive and verify a vetKey with the same canister for a different input (same context as before).
+. Derive and verify a vetKey with the same canister for a different context (same input as before).
+. Derive and verify a vetKey with the same canister for a different keyID (same input/context as before).
+  To do so, first create/enable a second vetKD chain key on the application subnet and retrieve the
+  canister master public key for some canister.
+. Derive and verify a vetKey with a different canister for the same input/context combination. The canister
+  lives on a different subnet so as to test the vetKD API across subnets (i.e., the routing).
+. IBE-encrypt a message with one of the previously retrieved canister public keys.
+. IBE-decrypt the message with the previously retrieved vetKey that corresponds to the public key
+  used for encryption.
 
+Success::
+. The retrieved canister master public keys have a valid encoding.
+. The vetKey derived with the same parameters (input, context, keyID) by the same canister is the same.
+. The vetKey derived for a different input (with otherwise the same parameters) is NOT the same.
+. The vetKey derived for a different context (with otherwise the same parameters) is NOT the same.
+. The vetKey derived for a different key ID (with otherwise the same parameters) is NOT the same.
+. The vetKey derived with a different canister (with otherwise the same parameters) is NOT the same.
+. IBE-decryption succeeds with the correct vetKey and the decrypted message is correct.
+. IBE-decryption fails with the wrong vetKeys.
 
 end::catalog[] */
 
 use anyhow::{anyhow, Result};
 use canister_test::Canister;
 use futures::FutureExt;
+use ic_config::subnet_config::VETKD_FEE;
 use ic_consensus_threshold_sig_system_test_utils::{
-    enable_chain_key_signing, get_public_key_with_logger, vetkd_derive_key,
+    enable_chain_key_signing, get_public_key_with_logger, scale_cycles_to, vetkd_derive_key,
 };
+use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 use ic_management_canister_types_private::{MasterPublicKeyId, VetKdCurve, VetKdKeyId};
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_registry_subnet_type::SubnetType;
@@ -38,24 +57,28 @@ use ic_system_test_driver::{
         },
     },
     systest,
-    util::{block_on, runtime_from_url, MessageCanister},
+    util::{block_on, get_app_subnet_and_node, runtime_from_url, MessageCanister},
 };
 use ic_types::{Cycles, Height};
-use ic_vetkd_utils::{DerivedPublicKey, EncryptedVetKey, IBECiphertext, TransportSecretKey};
+use ic_vetkd_utils::{
+    DerivedPublicKey, EncryptedVetKey, IBECiphertext, TransportSecretKey, VetKey,
+};
+use rand::Rng;
 use slog::info;
 use std::time::Duration;
 
 const NODES_COUNT: usize = 4;
 const DKG_INTERVAL: u64 = 20;
 
-const MSG: &str = "Secret message that is totally important";
-const INPUT: &str = "secret_message";
-const SEED: [u8; 32] = [13; 32];
-
 fn setup(env: TestEnv) {
     InternetComputer::new()
         .add_subnet(
             Subnet::new(SubnetType::System)
+                .with_dkg_interval_length(Height::from(DKG_INTERVAL))
+                .add_nodes(NODES_COUNT),
+        )
+        .add_subnet(
+            Subnet::new(SubnetType::Application)
                 .with_dkg_interval_length(Height::from(DKG_INTERVAL))
                 .add_nodes(NODES_COUNT),
         )
@@ -81,77 +104,253 @@ fn setup(env: TestEnv) {
 
 fn test(env: TestEnv) {
     let log = env.logger();
-    let topology_snapshot = env.topology_snapshot();
+    let rng = &mut reproducible_rng();
+    let topology = env.topology_snapshot();
 
-    let nns_subnet = topology_snapshot.root_subnet();
+    let nns_subnet = topology.root_subnet();
     let nns_node = nns_subnet.nodes().next().unwrap();
     let nns_agent = nns_node.build_default_agent();
-
     let nns_runtime = runtime_from_url(nns_node.get_public_url(), nns_node.effective_canister_id());
-    let vetkd_key_id = VetKdKeyId {
-        curve: VetKdCurve::Bls12_381_G2,
-        name: String::from("some_vetkd_key"),
-    };
     let governance = Canister::new(&nns_runtime, GOVERNANCE_CANISTER_ID);
-    let key_ids = vec![MasterPublicKeyId::VetKd(vetkd_key_id.clone())];
+
+    let (app_subnet, app_node) = get_app_subnet_and_node(&topology);
+    let app_agent = app_node.build_default_agent();
+
+    let key_id = VetKdKeyId {
+        curve: VetKdCurve::Bls12_381_G2,
+        name: String::from("key_1"),
+    };
+    let key_id_2 = VetKdKeyId {
+        curve: VetKdCurve::Bls12_381_G2,
+        name: String::from("key_2"),
+    };
 
     block_on(async {
-        enable_chain_key_signing(&governance, nns_subnet.subnet_id, key_ids.clone(), &log).await;
-        let msg_can = MessageCanister::new(&nns_agent, nns_node.effective_canister_id()).await;
+        // Create and enable vetKD chain key on Application subnet
+        enable_chain_key_signing(
+            &governance,
+            app_subnet.subnet_id,
+            vec![MasterPublicKeyId::VetKd(key_id.clone())],
+            &log,
+        )
+        .await;
 
-        // Fetch public key from subnet
-        for key_id in &key_ids {
-            let pub_key = get_public_key_with_logger(key_id, &msg_can, &log)
-                .await
-                .expect("Should successfully retrieve the public key");
+        // Create canisters on different subnets (one system subnet, one application subnet)
+        let canister_nns = MessageCanister::new(&nns_agent, nns_node.effective_canister_id()).await;
+        let canister_app = MessageCanister::new(&app_agent, app_node.effective_canister_id()).await;
 
-            // Check that the key is well formed
-            let dpk =
-                DerivedPublicKey::deserialize(&pub_key).expect("Failed to parse vetkd public key");
+        // Retrieve the canisters' vetKD master public (verification) keys
+        let canister_master_pubkey_nns =
+            retrieve_public_key_with_canister(&canister_nns, &key_id, &log).await;
+        let canister_master_pubkey_app =
+            retrieve_public_key_with_canister(&canister_app, &key_id, &log).await;
+        assert_ne!(
+            canister_master_pubkey_nns.serialize(),
+            canister_master_pubkey_app.serialize()
+        );
 
-            let enc_msg = IBECiphertext::encrypt(&dpk, INPUT.as_bytes(), MSG.as_bytes(), &SEED)
-                .expect("Failed to encrypt message");
+        let input = b"test-input";
+        let context = b"test-context";
 
-            let transport_key = TransportSecretKey::from_seed(SEED.to_vec())
-                .expect("Failed to generate transport secret key");
+        let vetkey = derive_vetkey_with_canister(
+            &canister_app,
+            input,
+            context,
+            key_id.clone(),
+            &canister_master_pubkey_app.derive_sub_key(context),
+            scale_cycles_to(NODES_COUNT, VETKD_FEE),
+            &log,
+            rng,
+        )
+        .await;
 
-            info!(log, "Trying to fetch the key");
+        let vetkey_same = derive_vetkey_with_canister(
+            &canister_app,
+            input,
+            context,
+            key_id.clone(),
+            &canister_master_pubkey_app.derive_sub_key(context),
+            scale_cycles_to(NODES_COUNT, VETKD_FEE),
+            &log,
+            rng,
+        )
+        .await;
 
-            let encrypted_priv_key: Vec<u8> = retry_async(
-                "Trying to derive encrypted key",
-                &log,
-                Duration::from_secs(120),
-                Duration::from_secs(2),
-                || {
-                    vetkd_derive_key(
-                        transport_key.public_key().try_into().unwrap(),
-                        vetkd_key_id.clone(),
-                        INPUT.as_bytes().to_vec(),
-                        &msg_can,
-                        Cycles::zero(),
-                    )
-                    .map(|maybe_key| {
-                        maybe_key.map_err(|e| anyhow!("Failed to retrieve key: {e:?}"))
-                    })
-                },
-            )
-            .await
-            .expect("Failed to derive encrypted key");
+        // The vetKeys derived for the same input/context by the same canister MUST be the same
+        assert_eq!(vetkey.signature_bytes(), vetkey_same.signature_bytes());
 
-            let enc_key = EncryptedVetKey::deserialize(&encrypted_priv_key)
-                .expect("Failed to deserialize encrypted key");
+        let different_input = b"test-input-different";
+        assert_ne!(input.to_vec(), different_input.to_vec());
+        let vetkey_different_input = derive_vetkey_with_canister(
+            &canister_app,
+            different_input,
+            context,
+            key_id.clone(),
+            &canister_master_pubkey_app.derive_sub_key(context),
+            scale_cycles_to(NODES_COUNT, VETKD_FEE),
+            &log,
+            rng,
+        )
+        .await;
 
-            let priv_key = enc_key
-                .decrypt_and_verify(&transport_key, &dpk, INPUT.as_bytes())
-                .expect("Failed to decrypt derived key");
+        // The vetKeys derived for different inputs for the same context by the same canister MUST NOT be the same.
+        assert_ne!(
+            vetkey.signature_bytes(),
+            vetkey_different_input.signature_bytes()
+        );
 
-            let msg = enc_msg
-                .decrypt(&priv_key)
-                .expect("Failed to decrypt the message");
+        let different_context = b"test-context-different";
+        assert_ne!(context.to_vec(), different_context.to_vec());
+        let vetkey_different_context = derive_vetkey_with_canister(
+            &canister_app,
+            input,
+            different_context,
+            key_id.clone(),
+            &canister_master_pubkey_app.derive_sub_key(different_context),
+            scale_cycles_to(NODES_COUNT, VETKD_FEE),
+            &log,
+            rng,
+        )
+        .await;
 
-            assert_eq!(&msg, MSG.as_bytes());
-        }
+        // The vetKeys derived for different contexts for the same input by the same canister MUST NOT be the same.
+        assert_ne!(
+            vetkey.signature_bytes(),
+            vetkey_different_context.signature_bytes()
+        );
+
+        // Create and enable vetKD chain key for a different key ID on Application subnet
+        assert_ne!(key_id, key_id_2);
+        enable_chain_key_signing(
+            &governance,
+            app_subnet.subnet_id,
+            vec![
+                MasterPublicKeyId::VetKd(key_id.clone()),
+                MasterPublicKeyId::VetKd(key_id_2.clone()),
+            ],
+            &log,
+        )
+        .await;
+        // Retrieve the canisters' vetKD master public (verification) keys
+        let canister_master_pubkey_app_key_id_2 =
+            retrieve_public_key_with_canister(&canister_app, &key_id_2, &log).await;
+        let vetkey_different_key_id = derive_vetkey_with_canister(
+            &canister_app,
+            input,
+            context,
+            key_id_2.clone(),
+            &canister_master_pubkey_app_key_id_2.derive_sub_key(context),
+            scale_cycles_to(NODES_COUNT, VETKD_FEE),
+            &log,
+            rng,
+        )
+        .await;
+
+        // The vetKeys derived for the same input/context for different key IDs MUST NOT be the same.
+        assert_ne!(
+            vetkey_different_key_id.signature_bytes(),
+            vetkey.signature_bytes()
+        );
+
+        assert_ne!(canister_nns.canister_id(), canister_app.canister_id());
+        let vetkey_different_canister = derive_vetkey_with_canister(
+            &canister_nns,
+            input,
+            context,
+            key_id.clone(),
+            &canister_master_pubkey_nns.derive_sub_key(context),
+            Cycles::zero(),
+            &log,
+            rng,
+        )
+        .await;
+
+        // The vetKeys derived for the same input/context in different canisters MUST NOT be the same.
+        assert_ne!(
+            vetkey_different_canister.signature_bytes(),
+            vetkey.signature_bytes()
+        );
+
+        // IBE-encrypt a message with one of the previously retrieved canister public keys.
+        let secret_message = b"secret message";
+        let ibe_ciphertext = IBECiphertext::encrypt(
+            &canister_master_pubkey_app.derive_sub_key(context),
+            input,
+            secret_message,
+            &rng.gen::<[u8; 32]>(),
+        )
+        .expect("failed to IBE-encrypt");
+
+        // When using the correct vetKey (i.e., the one for the correct input/context combination), the message MUST IBE-decrypt to the correct value
+        assert_eq!(
+            &ibe_ciphertext
+                .decrypt(&vetkey)
+                .expect("failed to IBE-decrypt"),
+            secret_message
+        );
+        // When using the wrong vetKey, IBE-decryption must fail
+        assert!(ibe_ciphertext.decrypt(&vetkey_different_input).is_err());
+        assert!(ibe_ciphertext.decrypt(&vetkey_different_context).is_err());
+        assert!(ibe_ciphertext.decrypt(&vetkey_different_key_id).is_err());
+        assert!(ibe_ciphertext.decrypt(&vetkey_different_canister).is_err());
     });
+}
+
+async fn derive_vetkey_with_canister<R: Rng>(
+    msg_canister: &MessageCanister<'_>,
+    input: &[u8],
+    context: &[u8],
+    vetkd_key_id: VetKdKeyId,
+    verification_key: &DerivedPublicKey,
+    cycles: Cycles,
+    log: &slog::Logger,
+    rng: &mut R,
+) -> VetKey {
+    let tsk = TransportSecretKey::from_seed(rng.gen::<[u8; 32]>().to_vec())
+        .expect("Failed to generate transport secret key");
+
+    info!(log, "Deriving vetKey...");
+    let encrypted_vetkey: Vec<u8> = retry_async(
+        "derive vetKey",
+        log,
+        Duration::from_secs(120),
+        Duration::from_secs(2),
+        || {
+            vetkd_derive_key(
+                tsk.public_key().try_into().unwrap(),
+                vetkd_key_id.clone(),
+                input.to_vec(),
+                context.to_vec(),
+                msg_canister,
+                cycles,
+            )
+            .map(|maybe_key| maybe_key.map_err(|e| anyhow!("Failed to retrieve key: {e:?}")))
+        },
+    )
+    .await
+    .expect("failed to derive vetKey");
+
+    EncryptedVetKey::deserialize(&encrypted_vetkey)
+        .expect("Failed to deserialize encrypted key")
+        .decrypt_and_verify(&tsk, &verification_key, input)
+        .expect("Failed to decrypt derived key")
+}
+
+async fn retrieve_public_key_with_canister(
+    msg_canister: &MessageCanister<'_>,
+    vetkd_key_id: &VetKdKeyId,
+    log: &slog::Logger,
+) -> DerivedPublicKey {
+    info!(log, "Fetching vetKD public key...");
+    let pubkey_bytes = get_public_key_with_logger(
+        &MasterPublicKeyId::VetKd(vetkd_key_id.clone()),
+        msg_canister,
+        log,
+    )
+    .await
+    .expect("should retrieve vetKD public key");
+
+    DerivedPublicKey::deserialize(&pubkey_bytes).expect("failed to parse vetKD public key")
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
Enhances the vetKD system test so that many key properties of the vetKD API are tested that were not tested before. For example:
* Two executions of the vetKD protocol must yield the same (decrypted) vetKey for the same input/context/keyID/canister combination, even if the key derivation happens on another subnet.
* Two executions of the vetKD protocol must yield different (decrypted) vetKeys if any of input, context, keyID, canister are different.