### PR TITLE
chore: drop reduce_state_machine_logging_unless_env_set

### DIFF
--- a/rs/nns/sns-wasm/tests/add_wasm.rs
+++ b/rs/nns/sns-wasm/tests/add_wasm.rs
@@ -6,7 +6,6 @@ use ic_nns_test_utils::{
     sns_wasm::{
         self, add_wasm, add_wasm_via_proposal, build_root_sns_wasm, get_wasm, get_wasm_metadata,
     },
-    state_test_helpers,
 };
 use ic_sns_wasm::pb::v1::{
     add_wasm_response, get_wasm_metadata_response, GetWasmMetadataResponse, GetWasmResponse,
@@ -47,7 +46,6 @@ fn test_add_wasm_cannot_be_called_directly() {
 
 #[test]
 fn test_add_wasm_can_be_called_directly_if_access_controls_are_disabled() {
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = StateMachine::new();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()
@@ -118,7 +116,6 @@ fn test_sns_w_saves_metadata_on_upgrade() {
         (root_hash, root_wasm, expected_metadata)
     };
 
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = StateMachine::new();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()

--- a/rs/nns/sns-wasm/tests/common/mod.rs
+++ b/rs/nns/sns-wasm/tests/common/mod.rs
@@ -5,7 +5,7 @@ use ic_nervous_system_common::ONE_TRILLION;
 use ic_nns_constants::SNS_WASM_CANISTER_ID;
 use ic_nns_test_utils::{
     common::{NnsInitPayloads, NnsInitPayloadsBuilder},
-    state_test_helpers::{self, create_canister, setup_nns_canisters, update_with_sender},
+    state_test_helpers::{create_canister, setup_nns_canisters, update_with_sender},
 };
 use ic_sns_wasm::pb::v1::{
     get_deployed_sns_by_proposal_id_response::GetDeployedSnsByProposalIdResult, DeployedSns,
@@ -18,7 +18,6 @@ pub const EXPECTED_SNS_CREATION_FEE: u128 = 180 * ONE_TRILLION as u128;
 /// Create a `StateMachine` with NNS installed
 pub fn set_up_state_machine_with_nns() -> StateMachine {
     // We don't want the underlying warnings of the StateMachine
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = StateMachineBuilder::new().with_current_time().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()

--- a/rs/nns/sns-wasm/tests/deploy_new_sns.rs
+++ b/rs/nns/sns-wasm/tests/deploy_new_sns.rs
@@ -13,7 +13,7 @@ use ic_nns_constants::{
 };
 use ic_nns_test_utils::{
     sns_wasm,
-    state_test_helpers::{self, set_controllers, set_up_universal_canister, update_with_sender},
+    state_test_helpers::{set_controllers, set_up_universal_canister, update_with_sender},
 };
 use ic_sns_init::pb::v1::{DappCanisters, SnsInitPayload};
 use ic_sns_root::{CanisterSummary, GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse};
@@ -32,7 +32,6 @@ pub mod common;
 #[test]
 fn test_canisters_are_created_and_installed() {
     // Step 1: Set up NNS
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let state_machine = set_up_state_machine_with_nns();
 
     // Step 2: Add cycles and canister WASMs to SNS-WASM.
@@ -166,7 +165,6 @@ fn test_canisters_are_created_and_installed() {
 /// simulate failures executing basic IC00 operations
 #[test]
 fn test_deploy_cleanup_on_wasm_install_failure() {
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = set_up_state_machine_with_nns();
 
     // Add cycles to the SNS-W canister to deploy an SNS.
@@ -253,7 +251,6 @@ fn test_deploy_cleanup_on_wasm_install_failure() {
 
 #[test]
 fn test_deploy_adds_cycles_to_target_canisters() {
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = set_up_state_machine_with_nns();
 
     // Add cycles to the SNS-W canister to deploy an SNS.
@@ -319,7 +316,6 @@ fn test_deploy_adds_cycles_to_target_canisters() {
 #[test]
 fn test_deploy_sns_and_transfer_dapps() {
     // Setup the state machine
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = set_up_state_machine_with_nns();
 
     // Add cycles to the SNS-W canister to deploy the SNS

--- a/rs/nns/sns-wasm/tests/get_deployed_sns_by_proposal_id.rs
+++ b/rs/nns/sns-wasm/tests/get_deployed_sns_by_proposal_id.rs
@@ -4,7 +4,7 @@ use ic_nervous_system_common::ONE_TRILLION;
 use ic_nns_constants::{
     GOVERNANCE_CANISTER_ID, NODE_REWARDS_CANISTER_INDEX_IN_NNS_SUBNET, SNS_WASM_CANISTER_ID,
 };
-use ic_nns_test_utils::{sns_wasm, state_test_helpers};
+use ic_nns_test_utils::sns_wasm;
 use ic_sns_init::pb::v1::{DappCanisters, SnsInitPayload};
 use ic_sns_wasm::pb::v1::{
     get_deployed_sns_by_proposal_id_response::GetDeployedSnsByProposalIdResult,
@@ -18,7 +18,6 @@ pub mod common;
 #[test]
 fn test_get_deployed_sns_by_proposal_id() {
     // Setup the state machine
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = set_up_state_machine_with_nns();
 
     // Add cycles to the SNS-W canister to deploy the SNS

--- a/rs/nns/sns-wasm/tests/update_sns_subnet_list.rs
+++ b/rs/nns/sns-wasm/tests/update_sns_subnet_list.rs
@@ -5,7 +5,7 @@ use ic_nns_constants::SNS_WASM_CANISTER_ID;
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     sns_wasm::{get_sns_subnet_ids, update_sns_subnet_list, update_sns_subnet_list_via_proposal},
-    state_test_helpers::{self, create_canister},
+    state_test_helpers::create_canister,
 };
 use ic_sns_wasm::pb::v1::UpdateSnsSubnetListRequest;
 use ic_state_machine_tests::StateMachine;
@@ -31,7 +31,6 @@ fn test_update_sns_subnet_list_can_be_called_via_nns_proposal() {
 #[test]
 fn test_update_sns_subnet_list_cannot_be_called_directly() {
     // We don't want the underlying warnings of the StateMachine
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = StateMachine::new();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new().build();

--- a/rs/nns/sns-wasm/tests/upgrade_sns_instance.rs
+++ b/rs/nns/sns-wasm/tests/upgrade_sns_instance.rs
@@ -62,7 +62,6 @@ fn upgrade_governance_sns_canister_via_sns_wasms() {
 fn test_governance_restarts_root_if_root_cannot_stop_during_upgrade() {
     let canister_type = SnsCanisterType::Root;
 
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = StateMachineBuilder::new().with_current_time().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()
@@ -208,7 +207,6 @@ fn test_governance_restarts_root_if_root_cannot_stop_during_upgrade() {
 }
 
 fn run_upgrade_test(canister_type: SnsCanisterType) {
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = StateMachineBuilder::new().with_current_time().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()
@@ -705,7 +703,6 @@ fn upgrade_archive_sns_canister_via_sns_wasms() {
 
 #[test]
 fn test_out_of_sync_version_still_allows_upgrade_to_succeed() {
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = StateMachineBuilder::new().with_current_time().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()
@@ -987,7 +984,6 @@ fn test_out_of_sync_version_still_allows_upgrade_to_succeed() {
 
 #[test]
 fn insert_upgrade_path_entries_only_callable_by_governance_when_access_controls_enabled() {
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = StateMachineBuilder::new().with_current_time().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()
@@ -1021,7 +1017,6 @@ fn insert_upgrade_path_entries_only_callable_by_governance_when_access_controls_
 
 #[test]
 fn insert_upgrade_path_entries_callable_by_anyone_when_access_controls_disabled() {
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let machine = StateMachineBuilder::new().with_current_time().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -87,7 +87,7 @@ use num_traits::ToPrimitive;
 use prost::Message;
 use registry_canister::init::RegistryCanisterInitPayload;
 use serde::Serialize;
-use std::{convert::TryInto, env, time::Duration};
+use std::{convert::TryInto, time::Duration};
 
 /// A `StateMachine` builder setting the IC time to the current time
 /// and using the canister ranges of both the NNS and II subnets.
@@ -101,14 +101,6 @@ pub fn state_machine_builder_for_nns_tests() -> StateMachineBuilder {
             CanisterId::from_u64(0x2100000),
             CanisterId::from_u64(0x21FFFFE),
         ))
-}
-
-/// Turn down state machine logging to just errors to reduce noise in tests where this is not relevant
-pub fn reduce_state_machine_logging_unless_env_set() {
-    match env::var("RUST_LOG") {
-        Ok(_) => {}
-        Err(_) => env::set_var("RUST_LOG", "ERROR"),
-    }
 }
 
 pub fn registry_latest_version(state_machine: &StateMachine) -> Result<u64, String> {

--- a/rs/sns/integration_tests/src/sns_treasury.rs
+++ b/rs/sns/integration_tests/src/sns_treasury.rs
@@ -15,7 +15,7 @@ use ic_nns_constants::{
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     state_test_helpers::{
-        self, icrc1_balance, query, setup_nns_canisters, sns_claim_staked_neuron, sns_get_proposal,
+        icrc1_balance, query, setup_nns_canisters, sns_claim_staked_neuron, sns_get_proposal,
         sns_make_proposal, sns_stake_neuron, sns_wait_for_proposal_executed_or_failed,
         sns_wait_for_proposal_execution,
     },
@@ -288,7 +288,6 @@ fn new_treasury_scenario(
 fn test_sns_treasury_can_transfer_funds_via_proposals() {
     // Step 1: Prepare the world.
 
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let state_machine = state_machine_builder_for_sns_tests().build();
 
     let (whale_neuron_id, sns_test_canister_ids) = new_treasury_scenario(&state_machine);
@@ -525,7 +524,6 @@ fn test_transfer_sns_treasury_funds_proposals_that_are_too_big_get_blocked_at_su
     // order to provoke a giant treasury valuation, which then puts a lower cap on the number of
     // tokens that proposals can transfer from the treasury.
 
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let state_machine = state_machine_builder_for_sns_tests().build();
 
     let (whale_neuron_id, sns_test_canister_ids) = new_treasury_scenario(&state_machine);
@@ -696,7 +694,6 @@ fn test_transfer_sns_treasury_funds_proposals_that_are_too_big_get_blocked_at_su
 fn test_transfer_sns_treasury_funds_upper_bound_is_enforced_at_execution() {
     // Step 1: Prepare the world.
 
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let state_machine = state_machine_builder_for_sns_tests().build();
 
     let (whale_neuron_id, sns_test_canister_ids) = new_treasury_scenario(&state_machine);
@@ -863,7 +860,6 @@ fn nns_ledger_balance(state_machine: &StateMachine, account: Account) -> Tokens 
 fn sns_can_mint_funds_via_proposals() {
     // Step 1: Prepare the world.
 
-    state_test_helpers::reduce_state_machine_logging_unless_env_set();
     let state_machine = state_machine_builder_for_sns_tests().build();
 
     let (whale_neuron_id, sns_test_canister_ids) = new_treasury_scenario(&state_machine);


### PR DESCRIPTION
This PR drops the function `reduce_state_machine_logging_unless_env_set` meant to reduce logging output in tests by setting the environment variable `RUST_LOG`.

The motivation for this change is that we want to deprecate `RUST_LOG` in StateMachine tests:
- setting environment variables in tests affects *all* tests running in the same process while `StateMachineBuilder::with_log_level` can (and should) be used to tune the log level for a *single* test;
- `RUST_LOG` can sometimes be set implicitly (e.g., in a test environment) resulting in unexpected log verbosity of StateMachine tests.

This PR has currently no effect on log output verbosity: the affected tests produce the same amount of output as validated by running
```
bazel test //rs/nns/sns-wasm:sns-wasm_integration_test --test_output=all --test_arg="--nocapture"
bazel test //rs/sns/integration_tests:integration_test_src/sns_treasury --test_output=all --test_arg="--nocapture"
```