### PR TITLE
chore: Consolidate and standardize sysimage tools

### DIFF
--- a/ic-os/components/defs.bzl
+++ b/ic-os/components/defs.bzl
@@ -1,0 +1,26 @@
+""" Rules for working with components. """
+
+def _tree_hash_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name)
+    input_paths = []
+    for src in sorted(ctx.attr.src.items(), key = lambda v: v[1]):
+        input_paths.append(src[0].files.to_list()[0].path)
+    input_paths = " ".join(input_paths)
+
+    ctx.actions.run_shell(
+        inputs = ctx.files.src,
+        outputs = [out],
+        command = "cat {} | sha256sum | sed -e 's/ \\+-//' > {}".format(input_paths, out.path),
+    )
+
+    return [DefaultInfo(files = depset([out]))]
+
+tree_hash = rule(
+    implementation = _tree_hash_impl,
+    attrs = {
+        "src": attr.label_keyed_string_dict(
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+)

--- a/toolchains/sysimage/BUILD.bazel
+++ b/toolchains/sysimage/BUILD.bazel
@@ -3,50 +3,83 @@ load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files([
-    "build_container_base_image.py",
-    "build_disk_image.py",
-    "build_ext4_image.py",
-    "build_fat32_image.py",
-    "build_lvm_image.py",
-    "build_upgrade_image.py",
-    "build_vfat_image.py",
-    "verity_sign.py",
-])
+# Process wrapper for commands that are run as part of the ic-os build.
+sh_binary(
+    name = "proc_wrapper",
+    srcs = ["proc_wrapper.sh"],
+)
+
+# Common libs
+py_library(
+    name = "crc",
+    srcs = ["crc.py"],
+)
 
 py_library(
-    name = "container_utils",
-    srcs = ["container_utils.py"],
+    name = "utils",
+    srcs = ["utils.py"],
     deps = [
         requirement("invoke"),
+        requirement("loguru"),
     ],
 )
 
-# Creates a tar file as output
+# Build tools
 py_binary(
     name = "build_container_base_image",
-    srcs = [
-        "build_container_base_image.py",
-    ],
+    srcs = ["build_container_base_image.py"],
     deps = [
-        ":container_utils",
+        ":utils",
         requirement("loguru"),
+        requirement("invoke"),
         requirement("simple_parsing"),
     ],
 )
 
 py_binary(
     name = "build_container_filesystem_tar",
-    srcs = [
-        "build_container_filesystem_tar.py",
-    ],
+    srcs = ["build_container_filesystem_tar.py"],
     deps = [
-        ":container_utils",
+        requirement("invoke"),
+        requirement("loguru"),
+        ":utils",
     ],
 )
 
-# Process wrapper for commands that are run as part of the ic-os build.
-sh_binary(
-    name = "proc_wrapper",
-    srcs = ["proc_wrapper.sh"],
+py_binary(
+    name = "build_disk_image",
+    srcs = ["build_disk_image.py"],
+)
+
+py_binary(
+    name = "build_ext4_image",
+    srcs = ["build_ext4_image.py"],
+)
+
+py_binary(
+    name = "build_fat32_image",
+    srcs = ["build_fat32_image.py"],
+    deps = [":utils"],
+)
+
+py_binary(
+    name = "build_lvm_image",
+    srcs = ["build_lvm_image.py"],
+    deps = [":crc"],
+)
+
+py_binary(
+    name = "build_upgrade_image",
+    srcs = ["build_upgrade_image.py"],
+)
+
+py_binary(
+    name = "build_vfat_image",
+    srcs = ["build_vfat_image.py"],
+    deps = [":utils"],
+)
+
+py_binary(
+    name = "verity_sign",
+    srcs = ["verity_sign.py"],
 )

--- a/toolchains/sysimage/build_container_base_image.py
+++ b/toolchains/sysimage/build_container_base_image.py
@@ -17,8 +17,9 @@ import invoke
 from loguru import logger as log
 from simple_parsing import ArgumentParser, field
 
-from toolchains.sysimage.container_utils import (
+from toolchains.sysimage.utils import (
     path_owned_by_root,
+    purge_podman,
     remove_image,
     take_ownership_of_file,
 )
@@ -57,11 +58,6 @@ def build_image(container_cmd: str, image_tag: str, dockerfile: str, context_dir
     cmd = f"{container_cmd} build --squash-all --no-cache --tag {image_tag} {build_arg_strings_joined} --file {dockerfile} {context_dir}"
     invoke.run(cmd)
     log.info("Image built successfully")
-
-
-def purge_podman(container_cmd: str):
-    cmd = f"{container_cmd} system prune --all --volumes --force"
-    invoke.run(cmd)
 
 
 def save_image(container_cmd: str, image_tag: str, output_file: str):

--- a/toolchains/sysimage/build_fat32_image.py
+++ b/toolchains/sysimage/build_fat32_image.py
@@ -14,6 +14,8 @@ import sys
 import tarfile
 import tempfile
 
+from toolchains.sysimage.utils import parse_size
+
 
 def untar_to_fat32(tf, fs_basedir, out_file, path_transform):
     """
@@ -78,17 +80,6 @@ def install_extra_files(out_file, extra_files, path_transform):
             ],
             check=True,
         )
-
-
-def parse_size(s):
-    if s[-1] == "k" or s[-1] == "K":
-        return 1024 * int(s[:-1])
-    elif s[-1] == "m" or s[-1] == "M":
-        return 1024 * 1024 * int(s[:-1])
-    elif s[-1] == "g" or s[-1] == "G":
-        return 1024 * 1024 * 1024 * int(s[:-1])
-    else:
-        return int(s)
 
 
 def main():

--- a/toolchains/sysimage/build_lvm_image.py
+++ b/toolchains/sysimage/build_lvm_image.py
@@ -16,7 +16,7 @@ import sys
 import tarfile
 import tempfile
 
-from crc import INITIAL_CRC, calc_crc
+from toolchains.sysimage.crc import INITIAL_CRC, calc_crc
 
 LVM_HEADER_SIZE_BYTES = int(2048 * 512)
 BYTES_PER_MEBIBYTE = int(2**20)

--- a/toolchains/sysimage/build_vfat_image.py
+++ b/toolchains/sysimage/build_vfat_image.py
@@ -14,6 +14,8 @@ import sys
 import tarfile
 import tempfile
 
+from toolchains.sysimage.utils import parse_size
+
 
 def untar_to_vfat(tf, fs_basedir, out_file, path_transform):
     """
@@ -78,17 +80,6 @@ def install_extra_files(out_file, extra_files, path_transform):
             ],
             check=True,
         )
-
-
-def parse_size(s):
-    if s[-1] == "k" or s[-1] == "K":
-        return 1024 * int(s[:-1])
-    elif s[-1] == "m" or s[-1] == "M":
-        return 1024 * 1024 * int(s[:-1])
-    elif s[-1] == "g" or s[-1] == "G":
-        return 1024 * 1024 * 1024 * int(s[:-1])
-    else:
-        return int(s)
 
 
 def main():

--- a/toolchains/sysimage/toolchain.bzl
+++ b/toolchains/sysimage/toolchain.bzl
@@ -39,25 +39,23 @@ def _build_container_base_image_impl(ctx):
     outputs = []
 
     # Output file is the name given to the target
-    output_tar_file = ctx.actions.declare_file(ctx.label.name)
-    args.extend(["--output", output_tar_file.path])
-    outputs.append(output_tar_file)
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    args.extend(["--output", output_file.path])
+    outputs.append(output_file)
 
-    inputs += ctx.files.context_files
     for context_file in ctx.files.context_files:
         args.extend(["--context-file", context_file.path])
+    inputs.extend(ctx.files.context_files)
 
     args.extend(["--image_tag", ctx.attr.image_tag])
 
-    inputs.append(ctx.file.dockerfile)
     args.extend(["--dockerfile", ctx.file.dockerfile.path])
+    inputs.append(ctx.file.dockerfile)
 
     if ctx.attr.build_args:
         args.extend(["--build_args"])
         for build_arg in ctx.attr.build_args:
             args.extend([build_arg])
-
-    tool = ctx.attr._tool
 
     _run_with_icos_wrapper(
         ctx,
@@ -65,15 +63,12 @@ def _build_container_base_image_impl(ctx):
         arguments = args,
         inputs = inputs,
         outputs = outputs,
-        tools = [tool.files_to_run],
+        tools = [ctx.attr._tool.files_to_run],
         # Base image is NOT reproducible (because `apt install`)
         execution_requirements = {"no-remote-cache": "1"},
     )
 
-    return [DefaultInfo(
-        files = depset(outputs),
-        runfiles = ctx.runfiles(outputs),
-    )]
+    return [DefaultInfo(files = depset(outputs))]
 
 build_container_base_image = _icos_build_rule(
     implementation = _build_container_base_image_impl,
@@ -83,6 +78,7 @@ build_container_base_image = _icos_build_rule(
         ),
         "dockerfile": attr.label(
             allow_single_file = True,
+            mandatory = True,
         ),
         "image_tag": attr.string(mandatory = True),
         "build_args": attr.string_list(),
@@ -99,37 +95,35 @@ def _build_container_filesystem_impl(ctx):
     inputs = []
     outputs = []
 
-    output_tar_file = ctx.actions.declare_file(ctx.label.name)
-    args.extend(["--output", output_tar_file.path])
-    outputs.append(output_tar_file)
+    # Output file is the name given to the target
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    args.extend(["--output", output_file.path])
+    outputs.append(output_file)
 
-    inputs += ctx.files.context_files
     for context_file in ctx.files.context_files:
         args.extend(["--context-file", context_file.path])
+    inputs.extend(ctx.files.context_files)
 
     for input_target, install_target in ctx.attr.component_files.items():
         args.extend(["--component-file", input_target.files.to_list()[0].path + ":" + install_target])
-        inputs += input_target.files.to_list()
+        inputs.extend(input_target.files.to_list())
 
     if ctx.file.dockerfile:
-        inputs.append(ctx.file.dockerfile)
         args.extend(["--dockerfile", ctx.file.dockerfile.path])
+        inputs.append(ctx.file.dockerfile)
 
-    build_args = ctx.attr.build_args
-    for build_arg in build_args:
+    for build_arg in ctx.attr.build_args:
         args.extend(["--build-arg", build_arg])
 
     if ctx.attr.file_build_arg:
         args.extend(["--file-build-arg", ctx.attr.file_build_arg])
 
     if ctx.file.base_image_tar_file:
-        inputs.append(ctx.file.base_image_tar_file)
         args.extend(["--base-image-tar-file", ctx.file.base_image_tar_file.path])
         args.extend(["--base-image-tar-file-tag", ctx.attr.base_image_tar_file_tag])
+        inputs.append(ctx.file.base_image_tar_file)
 
     args.extend(["--no-cache"])
-
-    tool = ctx.attr._tool
 
     _run_with_icos_wrapper(
         ctx,
@@ -137,13 +131,10 @@ def _build_container_filesystem_impl(ctx):
         arguments = args,
         inputs = inputs,
         outputs = outputs,
-        tools = [tool.files_to_run],
+        tools = [ctx.attr._tool.files_to_run],
     )
 
-    return [DefaultInfo(
-        files = depset(outputs),
-        runfiles = ctx.runfiles(outputs),
-    )]
+    return [DefaultInfo(files = depset(outputs))]
 
 build_container_filesystem = _icos_build_rule(
     implementation = _build_container_filesystem_impl,
@@ -162,7 +153,7 @@ build_container_filesystem = _icos_build_rule(
         "base_image_tar_file": attr.label(
             allow_single_file = True,
         ),
-        "base_image_tar_file_tag": attr.string(mandatory = False),
+        "base_image_tar_file_tag": attr.string(),
         "_tool": attr.label(
             default = "//toolchains/sysimage:build_container_filesystem_tar",
             executable = True,
@@ -172,42 +163,42 @@ build_container_filesystem = _icos_build_rule(
 )
 
 def _vfat_image_impl(ctx):
-    tool = ctx.files._build_vfat_image[0]
-    dflate = ctx.files._dflate[0]
+    args = []
+    inputs = []
+    outputs = []
 
-    if len(ctx.files.src) > 0:
-        args = ["-i", ctx.files.src[0].path]
-        inputs = [ctx.files.src[0]]
-    else:
-        args = []
-        inputs = []
-    out = ctx.actions.declare_file(ctx.label.name)
+    # Output file is the name given to the target
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    args.extend(["-o", output_file.path])
+    outputs.append(output_file)
 
-    args += [
-        "-o",
-        out.path,
+    for src_file in ctx.files.src:
+        args.extend(["-i", src_file.path])
+    inputs.extend(ctx.files.src)
+
+    args.extend([
         "-s",
         ctx.attr.partition_size,
         "-p",
         ctx.attr.subdir,
         "--dflate",
-        dflate.path,
-    ]
+        ctx.executable._dflate.path,
+    ])
 
     for input_target, install_target in ctx.attr.extra_files.items():
         args.append(input_target.files.to_list()[0].path + ":" + install_target)
-        inputs += input_target.files.to_list()
+        inputs.extend(input_target.files.to_list())
 
     _run_with_icos_wrapper(
         ctx,
-        executable = tool.path,
+        executable = ctx.executable._tool.path,
         arguments = args,
         inputs = inputs,
-        outputs = [out],
-        tools = [tool, dflate],
+        outputs = outputs,
+        tools = [ctx.attr._tool.files_to_run, ctx.attr._dflate.files_to_run],
     )
 
-    return [DefaultInfo(files = depset([out]))]
+    return [DefaultInfo(files = depset(outputs))]
 
 vfat_image = _icos_build_rule(
     implementation = _vfat_image_impl,
@@ -217,7 +208,6 @@ vfat_image = _icos_build_rule(
         ),
         "extra_files": attr.label_keyed_string_dict(
             allow_files = True,
-            mandatory = False,
         ),
         "partition_size": attr.string(
             mandatory = True,
@@ -225,57 +215,59 @@ vfat_image = _icos_build_rule(
         "subdir": attr.string(
             default = "/",
         ),
-        "_build_vfat_image": attr.label(
-            allow_files = True,
-            default = ":build_vfat_image.py",
+        "_tool": attr.label(
+            default = "//toolchains/sysimage:build_vfat_image",
+            executable = True,
+            cfg = "exec",
         ),
         "_dflate": attr.label(
-            allow_files = True,
             default = "//rs/ic_os/build_tools/dflate",
+            executable = True,
+            cfg = "exec",
         ),
     },
 )
 
 def _fat32_image_impl(ctx):
-    tool = ctx.files._build_fat32_image[0]
-    dflate = ctx.files._dflate[0]
+    args = []
+    inputs = []
+    outputs = []
 
-    if len(ctx.files.src) > 0:
-        args = ["-i", ctx.files.src[0].path]
-        inputs = [ctx.files.src[0]]
-    else:
-        args = []
-        inputs = []
-    out = ctx.actions.declare_file(ctx.label.name)
+    # Output file is the name given to the target
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    args.extend(["-o", output_file.path])
+    outputs.append(output_file)
 
-    args += [
-        "-o",
-        out.path,
+    for src_file in ctx.files.src:
+        args.extend(["-i", src_file.path])
+    inputs.extend(ctx.files.src)
+
+    args.extend([
         "-s",
         ctx.attr.partition_size,
         "-p",
         ctx.attr.subdir,
         "--dflate",
-        dflate.path,
-    ]
+        ctx.executable._dflate.path,
+    ])
 
     for input_target, install_target in ctx.attr.extra_files.items():
         args.append(input_target.files.to_list()[0].path + ":" + install_target)
-        inputs += input_target.files.to_list()
+        inputs.extend(input_target.files.to_list())
 
     if ctx.attr.label:
-        args += ["-l", ctx.attr.label]
+        args.extend(["-l", ctx.attr.label])
 
     _run_with_icos_wrapper(
         ctx,
-        executable = tool.path,
+        executable = ctx.executable._tool.path,
         arguments = args,
         inputs = inputs,
-        outputs = [out],
-        tools = [tool, dflate],
+        outputs = outputs,
+        tools = [ctx.attr._tool.files_to_run, ctx.attr._dflate.files_to_run],
     )
 
-    return [DefaultInfo(files = depset([out]))]
+    return [DefaultInfo(files = depset(outputs))]
 
 fat32_image = _icos_build_rule(
     implementation = _fat32_image_impl,
@@ -285,7 +277,6 @@ fat32_image = _icos_build_rule(
         ),
         "extra_files": attr.label_keyed_string_dict(
             allow_files = True,
-            mandatory = False,
         ),
         "partition_size": attr.string(
             mandatory = True,
@@ -294,65 +285,67 @@ fat32_image = _icos_build_rule(
         "subdir": attr.string(
             default = "/",
         ),
-        "_build_fat32_image": attr.label(
-            allow_files = True,
-            default = ":build_fat32_image.py",
+        "_tool": attr.label(
+            default = "//toolchains/sysimage:build_fat32_image",
+            executable = True,
+            cfg = "exec",
         ),
         "_dflate": attr.label(
-            allow_files = True,
             default = "//rs/ic_os/build_tools/dflate",
+            executable = True,
+            cfg = "exec",
         ),
     },
 )
 
 def _ext4_image_impl(ctx):
-    tool = ctx.files._build_ext4_image[0]
-    diroid = ctx.files._diroid[0]
-    dflate = ctx.files._dflate[0]
-
-    out = ctx.actions.declare_file(ctx.label.name)
-
-    inputs = []
     args = []
+    inputs = []
+    outputs = []
 
-    if len(ctx.files.src) > 0:
-        args += ["-i", ctx.files.src[0].path]
-        inputs += ctx.files.src
-    args += [
-        "-o",
-        out.path,
+    # Output file is the name given to the target
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    args.extend(["-o", output_file.path])
+    outputs.append(output_file)
+
+    for src_file in ctx.files.src:
+        args.extend(["-i", src_file.path])
+    inputs.extend(ctx.files.src)
+
+    args.extend([
         "-s",
         ctx.attr.partition_size,
         "-p",
         ctx.attr.subdir,
         "--diroid",
-        diroid.path,
+        ctx.executable._diroid.path,
         "--dflate",
-        dflate.path,
-    ]
-    if len(ctx.files.file_contexts) > 0:
-        args += ["-S", ctx.files.file_contexts[0].path]
-        inputs += ctx.files.file_contexts
+        ctx.executable._dflate.path,
+    ])
 
-    if len(ctx.attr.strip_paths) > 0:
-        args += ["--strip-paths"] + ctx.attr.strip_paths
+    if ctx.attr.file_contexts:
+        args.extend(["-S", ctx.files.file_contexts[0].path])
+        inputs.extend(ctx.files.file_contexts)
 
-    if ctx.attr.extra_files.items():
+    if ctx.attr.strip_paths:
+        args.extend(["--strip-paths"] + ctx.attr.strip_paths)
+
+    if ctx.attr.extra_files:
         args.append("--extra-files")
     for input_target, install_target in ctx.attr.extra_files.items():
         args.append(input_target.files.to_list()[0].path + ":" + install_target)
-        inputs += input_target.files.to_list()
+        inputs.extend(input_target.files.to_list())
 
     _run_with_icos_wrapper(
         ctx,
-        executable = tool.path,
+        executable = ctx.executable._tool.path,
         arguments = args,
         inputs = inputs,
-        outputs = [out],
-        tools = [tool, diroid, dflate],
+        outputs = outputs,
+        tools = [ctx.attr._tool.files_to_run, ctx.attr._diroid.files_to_run, ctx.attr._dflate.files_to_run],
     )
 
-    return [DefaultInfo(files = depset([out]))]
+    return [DefaultInfo(files = depset(outputs))]
 
 ext4_image = _icos_build_rule(
     implementation = _ext4_image_impl,
@@ -361,8 +354,7 @@ ext4_image = _icos_build_rule(
             allow_files = True,
         ),
         "file_contexts": attr.label(
-            allow_files = True,
-            mandatory = False,
+            allow_single_file = True,
         ),
         "strip_paths": attr.string_list(),
         "partition_size": attr.string(
@@ -373,72 +365,76 @@ ext4_image = _icos_build_rule(
         ),
         "extra_files": attr.label_keyed_string_dict(
             allow_files = True,
-            mandatory = False,
         ),
-        "_build_ext4_image": attr.label(
-            allow_files = True,
-            default = ":build_ext4_image.py",
+        "_tool": attr.label(
+            default = "//toolchains/sysimage:build_ext4_image",
+            executable = True,
+            cfg = "exec",
         ),
         "_diroid": attr.label(
-            allow_files = True,
             default = "//rs/ic_os/build_tools/diroid",
+            executable = True,
+            cfg = "exec",
         ),
         "_dflate": attr.label(
-            allow_files = True,
             default = "//rs/ic_os/build_tools/dflate",
+            executable = True,
+            cfg = "exec",
         ),
     },
 )
 
 def _disk_image_impl(ctx):
-    tool_file = ctx.files._build_disk_image_tool[0]
-    dflate = ctx.files._dflate[0]
+    args = []
+    inputs = []
+    outputs = []
 
-    in_layout = ctx.files.layout[0]
-    partitions = ctx.files.partitions
-    out = ctx.actions.declare_file(ctx.label.name)
-    expanded_size = ctx.attr.expanded_size
+    # Output file is the name given to the target
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    args.extend(["-o", output_file.path])
+    outputs.append(output_file)
 
-    partition_files = []
-    for p in partitions:
-        partition_files.append(p.path)
+    args.extend(["-p", ctx.files.layout[0].path, "--dflate", ctx.executable._dflate.path])
+    inputs.extend(ctx.files.layout)
 
-    args = ["-p", in_layout.path, "-o", out.path, "--dflate", dflate.path]
+    if ctx.attr.expanded_size:
+        args.extend(["-s", ctx.attr.expanded_size])
 
-    if expanded_size:
-        args += ["-s", expanded_size]
-
-    args += partition_files
+    for partition_file in ctx.files.partitions:
+        args.append(partition_file.path)
+    inputs.extend(ctx.files.partitions)
 
     _run_with_icos_wrapper(
         ctx,
-        executable = tool_file.path,
+        executable = ctx.executable._tool.path,
         arguments = args,
-        inputs = [in_layout] + partitions,
-        outputs = [out],
-        tools = [tool_file, dflate],
+        inputs = inputs,
+        outputs = outputs,
+        tools = [ctx.attr._tool.files_to_run, ctx.attr._dflate.files_to_run],
     )
 
-    return [DefaultInfo(files = depset([out]))]
+    return [DefaultInfo(files = depset(outputs))]
 
 disk_image = _icos_build_rule(
     implementation = _disk_image_impl,
     attrs = {
         "layout": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "partitions": attr.label_list(
             allow_files = True,
         ),
         "expanded_size": attr.string(),
-        "_build_disk_image_tool": attr.label(
-            allow_files = True,
-            default = ":build_disk_image.py",
+        "_tool": attr.label(
+            default = "//toolchains/sysimage:build_disk_image",
+            executable = True,
+            cfg = "exec",
         ),
         "_dflate": attr.label(
-            allow_files = True,
             default = "//rs/ic_os/build_tools/dflate",
+            executable = True,
+            cfg = "exec",
         ),
     },
 )
@@ -448,242 +444,177 @@ disk_image = _icos_build_rule(
 # this really shouldn't be two separate things, but rather one
 # thing that produces the image and another that tars it.
 def _disk_image_no_tar_impl(ctx):
-    tool_file = ctx.files._build_disk_image_tool[0]
+    args = []
+    inputs = []
+    outputs = []
 
-    in_layout = ctx.files.layout[0]
-    partitions = ctx.files.partitions
-    out = ctx.actions.declare_file(ctx.label.name)
-    expanded_size = ctx.attr.expanded_size
+    # Output file is the name given to the target
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    args.extend(["-o", output_file.path])
+    outputs.append(output_file)
 
-    partition_files = []
-    for p in partitions:
-        partition_files.append(p.path)
+    args.extend(["-p", ctx.files.layout[0].path])
+    inputs.append(ctx.files.layout)
 
-    args = ["-p", in_layout.path, "-o", out.path]
+    if ctx.attr.expanded_size:
+        args.extend(["-s", ctx.attr.expanded_size])
 
-    if expanded_size:
-        args += ["-s", expanded_size]
-
-    args += partition_files
+    for partition_file in ctx.files.partitions:
+        args.append(partition_file.path)
+    inputs.extend(ctx.files.partitions)
 
     _run_with_icos_wrapper(
         ctx,
-        executable = tool_file.path,
+        executable = ctx.executable._tool.path,
         arguments = args,
-        inputs = [in_layout] + partitions,
-        outputs = [out],
-        tools = [tool_file],
+        inputs = inputs,
+        outputs = outputs,
+        tools = [ctx.attr._tool.files_to_run],
     )
 
-    return [DefaultInfo(files = depset([out]))]
+    return [DefaultInfo(files = depset(outputs))]
 
 disk_image_no_tar = _icos_build_rule(
     implementation = _disk_image_no_tar_impl,
     attrs = {
         "layout": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "partitions": attr.label_list(
             allow_files = True,
         ),
         "expanded_size": attr.string(),
-        "_build_disk_image_tool": attr.label(
-            allow_files = True,
-            default = ":build_disk_image.py",
+        "_tool": attr.label(
+            default = "//toolchains/sysimage:build_disk_image",
+            executable = True,
+            cfg = "exec",
         ),
     },
 )
 
 def _lvm_image_impl(ctx):
-    tool_file = ctx.files._build_lvm_image_tool[0]
-    dflate = ctx.files._dflate[0]
+    args = []
+    inputs = []
+    outputs = []
 
-    in_layout = ctx.files.layout[0]
-    vg_name = ctx.attr.vg_name
-    vg_uuid = ctx.attr.vg_uuid
-    pv_uuid = ctx.attr.pv_uuid
-    partitions = ctx.files.partitions
-    out = ctx.actions.declare_file(ctx.label.name)
+    # Output file is the name given to the target
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    args.extend(["-o", output_file.path])
+    outputs.append(output_file)
 
-    partition_files = []
-    for p in partitions:
-        partition_files.append(p.path)
+    args.extend([
+        "-v",
+        ctx.files.layout[0].path,
+        "-n",
+        ctx.attr.vg_name,
+        "-u",
+        ctx.attr.vg_uuid,
+        "-p",
+        ctx.attr.pv_uuid,
+        "--dflate",
+        ctx.executable._dflate.path,
+    ])
+    inputs.extend(ctx.files.layout)
 
-    args = ["-v", in_layout.path, "-n", vg_name, "-u", vg_uuid, "-p", pv_uuid, "-o", out.path, "--dflate", dflate.path]
-
-    args += partition_files
+    for partition_file in ctx.files.partitions:
+        args.append(partition_file.path)
+    inputs.extend(ctx.files.partitions)
 
     _run_with_icos_wrapper(
         ctx,
-        executable = tool_file.path,
+        executable = ctx.executable._tool.path,
         arguments = args,
-        inputs = [in_layout] + partitions,
-        outputs = [out],
-        tools = [tool_file, dflate],
+        inputs = inputs,
+        outputs = outputs,
+        tools = [ctx.attr._tool.files_to_run, ctx.attr._dflate.files_to_run],
     )
 
-    return [DefaultInfo(files = depset([out]))]
+    return [DefaultInfo(files = depset(outputs))]
 
 lvm_image = _icos_build_rule(
     implementation = _lvm_image_impl,
     attrs = {
         "layout": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "partitions": attr.label_list(
             allow_files = True,
         ),
-        "vg_name": attr.string(),
-        "vg_uuid": attr.string(),
-        "pv_uuid": attr.string(),
-        "_build_lvm_image_tool": attr.label(
-            allow_files = True,
-            default = ":build_lvm_image.py",
+        "vg_name": attr.string(mandatory = True),
+        "vg_uuid": attr.string(mandatory = True),
+        "pv_uuid": attr.string(mandatory = True),
+        "_tool": attr.label(
+            default = "//toolchains/sysimage:build_lvm_image",
+            executable = True,
+            cfg = "exec",
         ),
         "_dflate": attr.label(
-            allow_files = True,
             default = "//rs/ic_os/build_tools/dflate",
+            executable = True,
+            cfg = "exec",
         ),
     },
 )
 
 def _upgrade_image_impl(ctx):
-    tool_file = ctx.files._build_upgrade_image_tool[0]
-    dflate = ctx.files._dflate[0]
+    args = []
+    inputs = []
+    outputs = []
 
-    in_boot_partition = ctx.files.boot_partition[0]
-    in_root_partition = ctx.files.root_partition[0]
-    in_version_file = ctx.files.version_file[0]
-    out = ctx.actions.declare_file(ctx.label.name)
+    # Output file is the name given to the target
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    args.extend(["-o", output_file.path])
+    outputs.append(output_file)
+
+    args.extend([
+        "-b",
+        ctx.files.boot_partition[0].path,
+        "-r",
+        ctx.files.root_partition[0].path,
+        "-v",
+        ctx.files.version_file[0].path,
+        "--dflate",
+        ctx.executable._dflate.path,
+    ])
+    inputs.extend(ctx.files.boot_partition + ctx.files.root_partition + ctx.files.version_file)
 
     _run_with_icos_wrapper(
         ctx,
-        executable = "python3",
-        inputs = [in_boot_partition, in_root_partition, in_version_file],
-        outputs = [out],
-        arguments = [
-            tool_file.path,
-            "-b",
-            in_boot_partition.path,
-            "-r",
-            in_root_partition.path,
-            "-v",
-            in_version_file.path,
-            "-o",
-            out.path,
-            "--dflate",
-            dflate.path,
-        ],
+        executable = ctx.executable._tool.path,
+        arguments = args,
+        inputs = inputs,
+        outputs = outputs,
+        tools = [ctx.attr._tool.files_to_run, ctx.attr._dflate.files_to_run],
     )
 
-    return [DefaultInfo(files = depset([out]))]
+    return [DefaultInfo(files = depset(outputs))]
 
 upgrade_image = _icos_build_rule(
     implementation = _upgrade_image_impl,
     attrs = {
         "boot_partition": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "root_partition": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         "version_file": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             mandatory = True,
         ),
-        "_build_upgrade_image_tool": attr.label(
-            allow_files = True,
-            default = ":build_upgrade_image.py",
+        "_tool": attr.label(
+            default = "//toolchains/sysimage:build_upgrade_image",
+            executable = True,
+            cfg = "exec",
         ),
         "_dflate": attr.label(
-            allow_files = True,
             default = "//rs/ic_os/build_tools/dflate",
-        ),
-    },
-)
-
-def _tar_extract_impl(ctx):
-    in_tar = ctx.files.src[0]
-    out = ctx.actions.declare_file(ctx.label.name)
-
-    ctx.actions.run_shell(
-        inputs = [in_tar],
-        outputs = [out],
-        command = "tar xOf %s --occurrence=1 %s > %s" % (
-            in_tar.path,
-            ctx.attr.path,
-            out.path,
-        ),
-    )
-
-    return [DefaultInfo(files = depset([out]))]
-
-tar_extract = rule(
-    implementation = _tar_extract_impl,
-    attrs = {
-        "src": attr.label(
-            allow_files = True,
-            mandatory = True,
-        ),
-        "path": attr.string(
-            mandatory = True,
-        ),
-    },
-)
-
-def _sha256sum_impl(ctx):
-    out = ctx.actions.declare_file(ctx.label.name)
-    input_paths = []
-    for src in ctx.files.srcs:
-        input_paths.append(src.path)
-    input_paths = " ".join(input_paths)
-
-    ctx.actions.run_shell(
-        inputs = ctx.files.srcs,
-        outputs = [out],
-        command = "cat {} | sha256sum | sed -e 's/ \\+-/{}/' > {}".format(input_paths, ctx.attr.suffix, out.path),
-    )
-
-    return [DefaultInfo(files = depset([out]), runfiles = ctx.runfiles([out]))]
-
-sha256sum = rule(
-    implementation = _sha256sum_impl,
-    attrs = {
-        "srcs": attr.label_list(
-            allow_files = True,
-            mandatory = True,
-        ),
-        "suffix": attr.string(
-            default = "",
-        ),
-    },
-)
-
-def _tree_hash_impl(ctx):
-    out = ctx.actions.declare_file(ctx.label.name)
-    input_paths = []
-    for src in sorted(ctx.attr.src.items(), key = lambda v: v[1]):
-        input_paths.append(src[0].files.to_list()[0].path)
-    input_paths = " ".join(input_paths)
-
-    ctx.actions.run_shell(
-        inputs = ctx.files.src,
-        outputs = [out],
-        command = "cat {} | sha256sum | sed -e 's/ \\+-//' > {}".format(input_paths, out.path),
-    )
-
-    return [DefaultInfo(files = depset([out]), runfiles = ctx.runfiles([out]))]
-
-tree_hash = rule(
-    implementation = _tree_hash_impl,
-    attrs = {
-        "src": attr.label_keyed_string_dict(
-            allow_files = True,
-            mandatory = True,
+            executable = True,
+            cfg = "exec",
         ),
     },
 )

--- a/toolchains/sysimage/utils.py
+++ b/toolchains/sysimage/utils.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 #
-# Utilities common to container functionality
+# Common utilities
 #
-
 import os
 from pathlib import Path
 
 import invoke
+from loguru import logger as log
 
 
 def path_owned_by_root(p: Path) -> bool:
@@ -24,3 +24,20 @@ def take_ownership_of_file(file: Path):
 
 def remove_image(container_cmd: str, image_tag: str):
     invoke.run(f"{container_cmd} image rm -f {image_tag}")
+
+
+def purge_podman(container_cmd: str):
+    log.info("Cleaning up...")
+    cmd = f"{container_cmd} system prune --all --volumes --force"
+    invoke.run(cmd)
+
+
+def parse_size(s):
+    if s[-1] == "k" or s[-1] == "K":
+        return 1024 * int(s[:-1])
+    elif s[-1] == "m" or s[-1] == "M":
+        return 1024 * 1024 * int(s[:-1])
+    elif s[-1] == "g" or s[-1] == "G":
+        return 1024 * 1024 * 1024 * int(s[:-1])
+    else:
+        return int(s)

--- a/toolchains/sysimage/utils.py
+++ b/toolchains/sysimage/utils.py
@@ -27,7 +27,7 @@ def remove_image(container_cmd: str, image_tag: str):
 
 
 def purge_podman(container_cmd: str):
-    log.info("Cleaning up...")
+    log.info("Cleaning up podman...")
     cmd = f"{container_cmd} system prune --all --volumes --force"
     invoke.run(cmd)
 


### PR DESCRIPTION
All sysimage tools now use the same format. Each is a bazel rule wrapped around a `py_binary`, with as much consistency as possible.