### PR TITLE
test(nns): Within the golden state test, vote on proposals by impersonating well-known neurons

### DIFF
--- a/rs/nns/integration_tests/src/lifeline.rs
+++ b/rs/nns/integration_tests/src/lifeline.rs
@@ -16,7 +16,7 @@ use ic_nns_governance_api::pb::v1::{
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     state_test_helpers::{
-        get_pending_proposals, get_root_canister_status, nns_cast_vote,
+        get_pending_proposals, get_root_canister_status, nns_cast_vote_or_panic,
         nns_governance_get_proposal_info_as_anonymous, nns_governance_make_proposal,
         nns_wait_for_proposal_execution, setup_nns_canisters, state_machine_builder_for_nns_tests,
         update_with_sender,
@@ -106,7 +106,7 @@ fn test_submit_and_accept_root_canister_upgrade_proposal() {
     assert_eq!(pending_proposals.len(), 1);
 
     // Cast votes.
-    nns_cast_vote(
+    nns_cast_vote_or_panic(
         &state_machine,
         *TEST_NEURON_1_OWNER_PRINCIPAL,
         ic_nns_common::pb::v1::NeuronId {
@@ -208,7 +208,7 @@ fn test_submit_and_accept_forced_root_canister_upgrade_proposal() {
     assert_eq!(pending_proposals.len(), 1);
 
     // Cast votes.
-    nns_cast_vote(
+    nns_cast_vote_or_panic(
         &state_machine,
         *TEST_NEURON_1_OWNER_PRINCIPAL,
         ic_nns_common::pb::v1::NeuronId {

--- a/rs/nns/integration_tests/src/neuron_following.rs
+++ b/rs/nns/integration_tests/src/neuron_following.rs
@@ -19,7 +19,7 @@ use ic_nns_test_utils::{
         submit_proposal, TestNeuronOwner,
     },
     state_test_helpers::{
-        get_neuron_ids, nns_cast_vote, nns_governance_get_full_neuron,
+        get_neuron_ids, nns_cast_vote_or_panic, nns_governance_get_full_neuron,
         nns_governance_get_proposal_info, nns_governance_get_proposal_info_as_anonymous,
         nns_set_followees_for_neuron, nns_split_neuron, setup_nns_canisters,
         state_machine_builder_for_nns_tests,
@@ -234,7 +234,7 @@ fn vote_propagation_with_following() {
     assert_eq!(ballot_n2, (VOTING_POWER_NEURON_2, Vote::Yes));
 
     // re-vote explicitly, still no change
-    nns_cast_vote(
+    nns_cast_vote_or_panic(
         &state_machine,
         n2.principal_id,
         n2.neuron_id,
@@ -245,7 +245,7 @@ fn vote_propagation_with_following() {
     assert_eq!(votes, VOTING_POWER_NEURON_2);
 
     // n1 needs to vote explicitly
-    nns_cast_vote(
+    nns_cast_vote_or_panic(
         &state_machine,
         n1.principal_id,
         n1.neuron_id,

--- a/rs/nns/integration_tests/src/neuron_voting.rs
+++ b/rs/nns/integration_tests/src/neuron_voting.rs
@@ -16,7 +16,7 @@ use ic_nns_test_utils::{
         get_unauthorized_neuron, submit_proposal,
     },
     state_test_helpers::{
-        get_pending_proposals, list_all_neurons_and_combine_responses, nns_cast_vote,
+        get_pending_proposals, list_all_neurons_and_combine_responses, nns_cast_vote_or_panic,
         nns_governance_get_full_neuron, nns_governance_make_proposal, setup_nns_canisters,
         state_machine_builder_for_nns_tests,
     },
@@ -59,7 +59,7 @@ fn unauthorized_neuron_cannot_vote_on_nonexistent_proposal() {
     let state_machine = setup_state_machine_with_nns_canisters();
     let unauthorized_neuron = get_unauthorized_neuron();
 
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         unauthorized_neuron.principal_id,
         unauthorized_neuron.neuron_id,
@@ -78,7 +78,7 @@ fn anonymous_principal_cannot_vote_on_nonexistent_proposal() {
     let state_machine = setup_state_machine_with_nns_canisters();
     let n1 = get_neuron_1();
 
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         PrincipalId::new_anonymous(),
         n1.neuron_id,
@@ -98,7 +98,7 @@ fn anonymous_principal_cannot_vote_on_existent_proposal() {
     let n1 = get_neuron_1();
     let proposal_id = submit_proposal(&state_machine, &n1);
 
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         PrincipalId::new_anonymous(),
         n1.neuron_id,
@@ -117,7 +117,7 @@ fn neuron_cannot_vote_on_nonexistent_proposal() {
     let state_machine = setup_state_machine_with_nns_canisters();
     let n1 = get_neuron_1();
 
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
@@ -138,7 +138,7 @@ fn propose_and_vote_with_other_neuron() {
     let n2 = get_neuron_2();
     let proposal_id = submit_proposal(&state_machine, &n1);
 
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         n2.principal_id,
         n2.neuron_id,
@@ -159,7 +159,7 @@ fn proposer_neuron_cannot_vote_explicitly() {
     let proposal_id = submit_proposal(&state_machine, &n1);
 
     // neuron 1 already implicitly voted when submitting the proposal
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
@@ -181,7 +181,7 @@ fn neuron_cannot_vote_twice() {
     let proposal_id = submit_proposal(&state_machine, &n1);
 
     // vote once with neuron 2
-    let response_1 = nns_cast_vote(
+    let response_1 = nns_cast_vote_or_panic(
         &state_machine,
         n2.principal_id,
         n2.neuron_id,
@@ -194,7 +194,7 @@ fn neuron_cannot_vote_twice() {
     assert_eq!(response_1, Command::RegisterVote(RegisterVoteResponse {}));
 
     // vote again with neuron 2
-    let response_2 = nns_cast_vote(
+    let response_2 = nns_cast_vote_or_panic(
         &state_machine,
         n2.principal_id,
         n2.neuron_id,
@@ -215,7 +215,7 @@ fn nonexistent_neuron_cannot_vote() {
     let nonexistent_neuron = get_nonexistent_neuron();
     let proposal_id = submit_proposal(&state_machine, &n1);
 
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         nonexistent_neuron.principal_id,
         nonexistent_neuron.neuron_id,
@@ -253,7 +253,7 @@ fn can_vote_on_proposal_with_insufficient_funds() {
 
     // however, proposal can be voted on even when the voting neuron has insufficient funds for submitting proposals
     let proposal_id = submit_proposal(&state_machine, &n2);
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         n3.principal_id,
         n3.neuron_id,
@@ -280,7 +280,7 @@ fn failed_proposal_causes_reject_cost_deduction_for_proposer() {
     let proposal_id = submit_proposal(&state_machine, &n2);
 
     // vote "no" with heavy neuron 1 to cause the proposal to fail
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         n1.principal_id,
         n1.neuron_id,
@@ -307,7 +307,7 @@ fn cannot_vote_on_future_proposal() {
     let n2 = get_neuron_2();
     let future_proposal_id = ProposalId(1);
 
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         n1.principal_id,
         n1.neuron_id,

--- a/rs/nns/integration_tests/src/subnet_rental_canister.rs
+++ b/rs/nns/integration_tests/src/subnet_rental_canister.rs
@@ -14,7 +14,7 @@ use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     neuron_helpers::{get_neuron_1, get_neuron_2},
     state_test_helpers::{
-        create_canister_at_specified_id, ledger_account_balance, nns_cast_vote,
+        create_canister_at_specified_id, ledger_account_balance, nns_cast_vote_or_panic,
         nns_governance_get_proposal_info_as_anonymous, nns_governance_make_proposal,
         nns_wait_for_proposal_execution, nns_wait_for_proposal_failure, setup_nns_canisters,
         setup_subnet_rental_canister_with_correct_canister_id, state_machine_builder_for_nns_tests,
@@ -292,7 +292,7 @@ fn subnet_rental_request_lifecycle() {
     assert_eq!(proposal_info.decided_timestamp_seconds, 0);
 
     // large neuron votes and thus the proposal should be executed now
-    let response = nns_cast_vote(
+    let response = nns_cast_vote_or_panic(
         &state_machine,
         large_neuron.principal_id,
         large_neuron.neuron_id,

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -889,13 +889,12 @@ pub fn nns_send_icp_to_claim_or_refresh_neuron(
     .unwrap();
 }
 
-#[must_use]
 fn manage_neuron(
     state_machine: &StateMachine,
     sender: PrincipalId,
     neuron_id: NeuronId,
     command: nns_governance_pb::ManageNeuronCommandRequest,
-) -> ManageNeuronResponse {
+) -> Result<ManageNeuronResponse, String> {
     let result = state_machine
         .execute_ingress_as(
             sender,
@@ -908,14 +907,25 @@ fn manage_neuron(
             })
             .unwrap(),
         )
-        .unwrap();
+        .map_err(|e| e.to_string())?;
 
     let result = match result {
         WasmResult::Reply(result) => result,
-        WasmResult::Reject(s) => panic!("Call to manage_neuron failed: {:#?}", s),
+        WasmResult::Reject(s) => return Err(s),
     };
+    let response = Decode!(&result, ManageNeuronResponse).unwrap();
 
-    Decode!(&result, ManageNeuronResponse).unwrap()
+    Ok(response)
+}
+
+#[must_use]
+fn manage_neuron_or_panic(
+    state_machine: &StateMachine,
+    sender: PrincipalId,
+    neuron_id: NeuronId,
+    command: nns_governance_pb::ManageNeuronCommandRequest,
+) -> ManageNeuronResponse {
+    manage_neuron(state_machine, sender, neuron_id, command).expect("manage_neuron failed")
 }
 
 trait NnsManageNeuronConfigureOperation {
@@ -948,7 +958,7 @@ fn nns_configure_neuron(
     nns_governance_pb::manage_neuron_response::ConfigureResponse,
     nns_governance_pb::GovernanceError,
 > {
-    let result = manage_neuron(
+    let result = manage_neuron_or_panic(
         state_machine,
         sender,
         neuron_id,
@@ -972,6 +982,7 @@ fn nns_configure_neuron(
 pub fn nns_create_super_powerful_neuron(
     state_machine: &StateMachine,
     controller: PrincipalId,
+    tokens: Tokens,
 ) -> NeuronId {
     let memo = 0xCAFE_F00D;
 
@@ -981,8 +992,7 @@ pub fn nns_create_super_powerful_neuron(
         Some(compute_neuron_staking_subaccount(controller, memo)),
     );
     // "Overwhelmingly" large, but still small enough to avoid addition overflow.
-    let amount = Tokens::from_e8s(u64::MAX / 4);
-    mint_icp(state_machine, destination, amount);
+    mint_icp(state_machine, destination, tokens);
 
     // Create the Neuron.
     let neuron_id = nns_claim_or_refresh_neuron(state_machine, controller, memo);
@@ -1054,7 +1064,7 @@ pub fn nns_disburse_neuron(
     amount_e8s: Option<u64>,
     to_account: Option<AccountIdentifier>,
 ) -> ManageNeuronResponse {
-    manage_neuron(
+    manage_neuron_or_panic(
         state_machine,
         sender,
         neuron_id,
@@ -1112,7 +1122,7 @@ pub fn nns_disburse_maturity(
     percentage_to_disburse: u32,
     to_account: Option<GovernanceAccount>,
 ) -> ManageNeuronResponse {
-    manage_neuron(
+    manage_neuron_or_panic(
         state_machine,
         sender,
         neuron_id,
@@ -1249,13 +1259,23 @@ pub fn nns_cast_vote(
     neuron_id: NeuronId,
     proposal_id: u64,
     vote: Vote,
-) -> ManageNeuronResponse {
+) -> Result<ManageNeuronResponse, String> {
     let command = ManageNeuronCommandRequest::RegisterVote(RegisterVote {
         proposal: Some(ic_nns_common::pb::v1::ProposalId { id: proposal_id }),
         vote: vote as i32,
     });
 
     manage_neuron(state_machine, sender, neuron_id, command)
+}
+
+pub fn nns_cast_vote_or_panic(
+    state_machine: &StateMachine,
+    sender: PrincipalId,
+    neuron_id: NeuronId,
+    proposal_id: u64,
+    vote: Vote,
+) -> ManageNeuronResponse {
+    nns_cast_vote(state_machine, sender, neuron_id, proposal_id, vote).expect("Failed to cast vote")
 }
 
 pub fn nns_split_neuron(
@@ -1266,7 +1286,7 @@ pub fn nns_split_neuron(
 ) -> ManageNeuronResponse {
     let command = ManageNeuronCommandRequest::Split(Split { amount_e8s: amount });
 
-    manage_neuron(state_machine, sender, neuron_id, command)
+    manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }
 
 pub fn get_neuron_ids(state_machine: &StateMachine, sender: PrincipalId) -> Vec<u64> {
@@ -1311,7 +1331,7 @@ pub fn nns_join_community_fund(
         operation: Some(Operation::JoinCommunityFund(JoinCommunityFund {})),
     });
 
-    manage_neuron(state_machine, sender, neuron_id, command)
+    manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }
 
 pub fn nns_leave_community_fund(
@@ -1323,7 +1343,7 @@ pub fn nns_leave_community_fund(
         operation: Some(Operation::LeaveCommunityFund(LeaveCommunityFund {})),
     });
 
-    manage_neuron(state_machine, sender, neuron_id, command)
+    manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }
 
 pub fn nns_governance_make_proposal(
@@ -1334,7 +1354,7 @@ pub fn nns_governance_make_proposal(
 ) -> ManageNeuronResponse {
     let command = ManageNeuronCommandRequest::MakeProposal(Box::new(proposal.clone()));
 
-    manage_neuron(state_machine, sender, neuron_id, command)
+    manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }
 
 pub fn nns_add_hot_key(
@@ -1349,7 +1369,7 @@ pub fn nns_add_hot_key(
         })),
     });
 
-    manage_neuron(state_machine, sender, neuron_id, command)
+    manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }
 
 pub fn nns_set_followees_for_neuron(
@@ -1367,7 +1387,7 @@ pub fn nns_set_followees_for_neuron(
             .collect(),
     });
 
-    manage_neuron(state_machine, sender, neuron_id, command)
+    manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }
 
 pub fn nns_remove_hot_key(
@@ -1382,7 +1402,7 @@ pub fn nns_remove_hot_key(
         })),
     });
 
-    manage_neuron(state_machine, sender, neuron_id, command)
+    manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }
 
 pub fn nns_stake_maturity(
@@ -1395,7 +1415,7 @@ pub fn nns_stake_maturity(
         percentage_to_stake,
     });
 
-    manage_neuron(state_machine, sender, neuron_id, command)
+    manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }
 
 pub fn nns_list_proposals(


### PR DESCRIPTION
# Why

The previous approach of minting u64::MAX/4 ICPs within the golden NNS state tests will stop working if we are able to detect a voting power spike and use previous ballots in such an event. Therefore, the only way to pass for testing upgrades would be to vote with existing neurons.

# What

* Create versions of `nns_cast_vote` and `manage_neuron` without panics
* Create "super powerful neuron" with a smaller (but more realistic) number of tokens
* Vote on upgrade proposals with well-known public neurons