### PR TITLE
feat(nns): Validate the maturity disbursement index

### DIFF
--- a/rs/nns/governance/src/maturity_disbursement_index.rs
+++ b/rs/nns/governance/src/maturity_disbursement_index.rs
@@ -29,6 +29,15 @@ impl<M: Memory> MaturityDisbursementIndex<M> {
         self.finalization_timestamp_neuron_id_to_null.len() as usize
     }
 
+    pub fn contains_entry(
+        &self,
+        neuron_id: NeuronId,
+        finalization_timestamp: TimestampSeconds,
+    ) -> bool {
+        self.finalization_timestamp_neuron_id_to_null
+            .contains_key(&(finalization_timestamp, neuron_id))
+    }
+
     /// Adds (finalization_timestamp, neuron_id) pairs to the index, returns a list of timestamps
     /// that are not added because of clobbering.
     pub fn add_neuron_id_finalization_timestamps(

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -1926,6 +1926,15 @@ impl NeuronBuilder {
         self
     }
 
+    #[cfg(test)]
+    pub fn with_maturity_disbursements_in_progress(
+        mut self,
+        maturity_disbursements_in_progress: Vec<MaturityDisbursement>,
+    ) -> Self {
+        self.maturity_disbursements_in_progress = maturity_disbursements_in_progress;
+        self
+    }
+
     pub fn build(self) -> Neuron {
         let NeuronBuilder {
             id,

--- a/rs/nns/governance/src/storage/neurons.rs
+++ b/rs/nns/governance/src/storage/neurons.rs
@@ -579,6 +579,7 @@ where
             hot_keys: self.hot_keys_map.len(),
             followees: self.followees_map.len(),
             known_neuron_data: self.known_neuron_data_map.len(),
+            maturity_disbursements: self.maturity_disbursements_map.len(),
         }
     }
 
@@ -751,6 +752,7 @@ pub struct NeuronStorageLens {
     pub hot_keys: u64,
     pub followees: u64,
     pub known_neuron_data: u64,
+    pub maturity_disbursements: u64,
 }
 
 use crate::{governance::MAX_NEURON_RECENT_BALLOTS, pb::v1::Vote};


### PR DESCRIPTION
# Why

The maturity disbursement index is used to find the maturity disbursement that are ready for finalization, as well as scheduling the timer to run at the correct time. We want to make sure the index is correct, by adding validation that the index is equivalent to the primary data as much as possible.

# What

* Implement `MaturityDisbursementIndexValidator`
* Run the validator when `is_disburse_maturity_enabled`
