### PR TITLE
fix(node): hostos_upgrade_from_mainnet_to_mainnet

### DIFF
--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -121,7 +121,7 @@ system_test_nns(
     use_empty_image = True,
     uses_guestos_dev = True,
     uses_hostos_mainnet_update_img = True,
-    uses_setupos_dev = True,
+    uses_setupos_mainnet = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
     deps = RUNNER_DEPENDENCIES,
 )

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -100,6 +100,10 @@ pub fn upgrade_hostos(env: TestEnv) {
         HostosVersion::try_from(target_version_str.trim()).expect("Invalid mainnet hostos version");
 
     let update_image_url_str = std::env::var("ENV_DEPS__HOSTOS_UPDATE_IMG_URL").unwrap();
+    info!(
+        logger,
+        "HostOS update image URL: '{}'", update_image_url_str
+    );
     let update_image_url =
         Url::parse(update_image_url_str.trim()).expect("Invalid mainnet hostos update image URL");
     let update_image_sha256 = std::env::var("ENV_DEPS__HOSTOS_UPDATE_IMG_SHA").unwrap();

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -49,7 +49,7 @@ def _run_system_test(ctx):
               done
             fi
 
-            if [ -n "RUN_SCRIPT_HOSTOS_UPDATE_IMG_TEST" ]; then
+            if [ "${{RUN_SCRIPT_HOSTOS_UPDATE_IMG_TEST}}" = "true" ]; then
                 export ENV_DEPS__HOSTOS_UPDATE_IMG_VERSION="$(cat ${{ENV_DEPS__IC_VERSION_FILE}})-test"
                 export ENV_DEPS__HOSTOS_UPDATE_IMG_URL="${{ENV_DEPS__HOSTOS_UPDATE_IMG_TEST_URL:-}}"
                 export ENV_DEPS__HOSTOS_UPDATE_IMG_SHA="${{ENV_DEPS__HOSTOS_UPDATE_IMG_TEST_HASH:-}}"
@@ -278,8 +278,9 @@ def system_test(
         env["ENV_DEPS__HOSTOS_UPDATE_IMG_VERSION"] = mainnet_hostos_version
         env["ENV_DEPS__HOSTOS_UPDATE_IMG_URL"] = base_download_url(mainnet_hostos_version, "host-os", True, False) + "update-img.tar.zst"
         env["ENV_DEPS__HOSTOS_UPDATE_IMG_SHA"] = mainnet_icos_versions["hostos"]["latest_release"]["update_img_hash"]
+        env["RUN_SCRIPT_HOSTOS_UPDATE_IMG_TEST"] = "false"
     else:
-        env["RUN_SCRIPT_HOSTOS_UPDATE_IMG_TEST"] = "1"
+        env["RUN_SCRIPT_HOSTOS_UPDATE_IMG_TEST"] = "true"
 
     if uses_setupos_mainnet:
         # Note: SetupOS is still passed directly by path, as it needs some local processing.


### PR DESCRIPTION
`if [ -n "RUN_SCRIPT_HOSTOS_UPDATE_IMG_TEST" ]; then` was always resolving to true. 

Fixing the bug fixes the `hostos_upgrade_from_mainnet_to_mainnet` manual target