### PR TITLE
fix(node): HostOS upgrade failure

### DIFF
--- a/ic-os/components/hostos-scripts/generate-guestos-config/generate-guestos-config.service
+++ b/ic-os/components/hostos-scripts/generate-guestos-config/generate-guestos-config.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Generate GuestOS configuration
 Before=systemd-networkd.service
+# TODO: Remove update-config references in NODE-1518
+After=update-config.service
+Wants=update-config.service
 RequiresMountsFor=/var
 
 [Service]


### PR DESCRIPTION
https://dfinity.atlassian.net/browse/NODE-1592

The value of `vm_nr_of_vcpus` is set in update-config. But because the `vm_nr_of_vcpus` field was added after the last rollout, the update-config service must rerun to write the new-_new_ config version to disk. 

Without this new ordering, the update-config service runs after generate-guestos-config.service, causing generate-guestos.sh to fail as it didn’t have the default value for vm_nr_of_vcpus.

