### PR TITLE
chore(sns): Publish sns-testing bundle

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -584,6 +584,7 @@ http_file(
 
 http_file(
     name = "cycles-ledger.wasm.gz",
+    downloaded_file_path = "cycles-ledger.wasm.gz",
     sha256 = "d2aacbd214f20d752fd1696c2e36d7eceaafe07b932b3ae9e7e5564d1bda0178",
     url = "https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-v1.0.3/cycles-ledger.wasm.gz",
 )

--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -40,10 +40,12 @@ ALL_BINARIES = {
     "pocket-ic": "//rs/pocket_ic_server:pocket-ic-server",
     "types-test": "//rs/types/types:types_test",
     "replicated-state-test": "//rs/replicated_state:replicated_state_test_binary",
+    "sns_testing_bundle": "//rs/sns/testing:sns_testing_bundle",
 }
 
 # test binaries or binaries using test utils
 TESTONLY_BINARIES = [
+    # Keep sorted
     "drun",
     "e2e-test-driver",
     "ic-admin",
@@ -55,8 +57,9 @@ TESTONLY_BINARIES = [
     "ic-starter",
     "ic-test-state-machine",
     "pocket-ic",
-    "types-test",
     "replicated-state-test",
+    "sns_testing_bundle",
+    "types-test",
 ]
 
 # We don't strip the more complex binaries

--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -40,7 +40,6 @@ ALL_BINARIES = {
     "pocket-ic": "//rs/pocket_ic_server:pocket-ic-server",
     "types-test": "//rs/types/types:types_test",
     "replicated-state-test": "//rs/replicated_state:replicated_state_test_binary",
-    "sns_testing_bundle": "//rs/sns/testing:sns_testing_bundle",
 }
 
 # test binaries or binaries using test utils
@@ -58,7 +57,6 @@ TESTONLY_BINARIES = [
     "ic-test-state-machine",
     "pocket-ic",
     "replicated-state-test",
-    "sns_testing_bundle",
     "types-test",
 ]
 
@@ -143,6 +141,13 @@ upload_artifacts(
     remote_subdir = "release",
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//testnet/tools:__pkg__"],
+)
+
+upload_artifacts(
+    name = "upload_sns_testing_bundle",
+    testonly = True,
+    inputs = ["//rs/sns/testing:sns_testing_bundle"],
+    remote_subdir = "binaries/" + os_info,
 )
 
 BINS_TO_TEST = [":" + name for name in ALL_BINARIES]

--- a/rs/sns/testing/BUILD.bazel
+++ b/rs/sns/testing/BUILD.bazel
@@ -187,6 +187,7 @@ pkg_tar(
     srcs = [
         ":sns-testing",
         ":sns-testing-init",
+        "dfx.json",
     ],
     extension = "tar",
 )

--- a/rs/sns/testing/BUILD.bazel
+++ b/rs/sns/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//bazel:canisters.bzl", "rust_canister")
 
 package(default_visibility = ["//visibility:public"])
@@ -152,4 +153,52 @@ rust_canister(
         "@crate_index//:ic_cdk_0_17_1",
         "@crate_index//:serde",
     ],
+)
+
+genrule(
+    name = "_sns_testing_env",
+    testonly = True,
+    srcs = DEV_DATA,  # Include the dependencies to be resolved by rootpath in DEV_ENV.
+    outs = ["sns_testing_env.sh"],
+    cmd = "\n".join([
+    'echo \'%s="%s"\' >> $@' % (key, value)
+    for key, value in DEV_ENV.items()
+]),
+)
+
+pkg_tar(
+    name = "sns_testing_env",
+    testonly = True,
+    srcs = ["_sns_testing_env"],
+    extension = "tar",
+)
+
+pkg_tar(
+    name = "sns_testing_dependencies",
+    testonly = True,
+    srcs = DEV_DATA,
+    extension = "tar",
+    strip_prefix = "/",
+)
+
+pkg_tar(
+    name = "sns_testing_bin",
+    testonly = True,
+    srcs = [
+        ":sns-testing",
+        ":sns-testing-init",
+    ],
+    extension = "tar",
+)
+
+pkg_tar(
+    name = "sns_testing_bundle",
+    testonly = True,
+    deps = [
+        ":sns_testing_bin",
+        ":sns_testing_dependencies",
+        ":sns_testing_env",
+    ],
+    extension = "tar.gz",
+    strip_prefix = "/",
 )

--- a/rs/sns/testing/BUILD.bazel
+++ b/rs/sns/testing/BUILD.bazel
@@ -161,7 +161,7 @@ genrule(
     srcs = DEV_DATA,  # Include the dependencies to be resolved by rootpath in DEV_ENV.
     outs = ["sns_testing_env.sh"],
     cmd = "\n".join([
-        'echo \'%s="%s"\' >> $@' % (key, value)
+        'echo \'export %s="%s"\' >> $@' % (key, value)
         for key, value in DEV_ENV.items()
     ]),
 )
@@ -188,6 +188,8 @@ pkg_tar(
         ":sns-testing",
         ":sns-testing-init",
         "dfx.json",
+        # TODO: Add the README.md file to the tarball once if is re-written in terms of the bundle.
+        # "README.md",
     ],
     extension = "tar",
 )

--- a/rs/sns/testing/BUILD.bazel
+++ b/rs/sns/testing/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("//bazel:canisters.bzl", "rust_canister")
 
 package(default_visibility = ["//visibility:public"])
@@ -161,9 +161,9 @@ genrule(
     srcs = DEV_DATA,  # Include the dependencies to be resolved by rootpath in DEV_ENV.
     outs = ["sns_testing_env.sh"],
     cmd = "\n".join([
-    'echo \'%s="%s"\' >> $@' % (key, value)
-    for key, value in DEV_ENV.items()
-]),
+        'echo \'%s="%s"\' >> $@' % (key, value)
+        for key, value in DEV_ENV.items()
+    ]),
 )
 
 pkg_tar(
@@ -194,11 +194,11 @@ pkg_tar(
 pkg_tar(
     name = "sns_testing_bundle",
     testonly = True,
+    extension = "tar.gz",
+    strip_prefix = "/",
     deps = [
         ":sns_testing_bin",
         ":sns_testing_dependencies",
         ":sns_testing_env",
     ],
-    extension = "tar.gz",
-    strip_prefix = "/",
 )


### PR DESCRIPTION
This PR adds a new Bazel target `//rs/sns/testing:sns_testing_bundle` that bundles all the files required for running sns-testing, including the binaries and canister wasms. This target's artifact is a single sns_testing_bundle.tar.gz file that should be published to the CDN (the size is around 100 MB).