### PR TITLE
feat(nns): Enable node rewards from new canister

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -206,8 +206,7 @@ thread_local! {
 
     static IS_DISBURSE_MATURITY_ENABLED: Cell<bool> = const { Cell::new(cfg!(feature = "test")) };
 
-    static USE_NODE_PROVIDER_REWARD_CANISTER: Cell<bool>
-        = const { Cell::new(cfg!(feature = "test")) };
+    static USE_NODE_PROVIDER_REWARD_CANISTER: Cell<bool> = const { Cell::new(true) };
 }
 
 thread_local! {

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -4,12 +4,13 @@ In general, upcoming/unreleased behavior changes are described here. For details
 on the process that this file is part of, see
 `rs/nervous_system/changelog_process.md`.
 
-
 # Next Upgrade Proposal
 
 ## Added
 
 ## Changed
+
+* The Governance canister will fetch rewards from the new Node Rewards Canister instead of from Registry.
 
 ## Deprecated
 


### PR DESCRIPTION
# What

Enable fetching rewards from node rewards canister instead of registry.

# Why

This unblocks further changes to node provider rewards calculations.