### PR TITLE
feat(icrc-rosetta): add icrc rosetta release 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9508,7 +9508,7 @@ dependencies = [
 
 [[package]]
 name = "ic-icrc-rosetta"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "axum 0.8.1",

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -82,7 +82,7 @@ MACRO_DEV_DEPENDENCIES = [
 ALIASES = {
 }
 
-ROSETTA_VERSION = "1.2.0"
+ROSETTA_VERSION = "1.2.1"
 
 rust_library(
     name = "ic-icrc-rosetta",

--- a/rs/rosetta-api/icrc1/CHANGELOG.md
+++ b/rs/rosetta-api/icrc1/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.1] - 2025-05-10
+### Added
+- Token-specific metrics for multi-token instances - metrics now include token labels to help distinguish between different tokens ([#4790](https://github.com/dfinity/ic/pull/4790)).
+
+### Changed
+- Increased the sync thread watchdog timeout from 10 to 60 seconds to better handle IC instability cases ([#4863](https://github.com/dfinity/ic/pull/4863)).
+- Added more resources for icrc_multitoken_rosetta_system tests to address flakiness ([#4741](https://github.com/dfinity/ic/pull/4741)).
+- Always return ICRC-3 compliant certificate for consistency ([#4504](https://github.com/dfinity/ic/pull/4504)).
+
 ## [1.2.0] - 2025-04-04
 ### Added
 - Support for multiple tokens within a single instance.

--- a/rs/rosetta-api/icrc1/Cargo.toml
+++ b/rs/rosetta-api/icrc1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ic-icrc-rosetta"
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 default-run = "ic-icrc-rosetta"
-version = "1.2.0"
+version = "1.2.1"
 authors.workspace = true
 edition.workspace = true
 documentation.workspace = true

--- a/rs/rosetta-api/icrc1/src/common/constants.rs
+++ b/rs/rosetta-api/icrc1/src/common/constants.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 pub const DEFAULT_BLOCKCHAIN: &str = "Internet Computer";
-pub const ROSETTA_VERSION: &str = "1.2.0";
+pub const ROSETTA_VERSION: &str = "1.2.1";
 pub const NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const INGRESS_INTERVAL_SECS: u64 = 4 * 60;
 pub const BLOCK_SYNC_WAIT_SECS: u64 = 1;


### PR DESCRIPTION
This pull request updates the `ic-icrc-rosetta` project to version `1.2.1` and includes several improvements, bug fixes, and updates to maintain consistency across the codebase. Below are the most important changes:

### Version Updates:
* Updated the `ROSETTA_VERSION` to `1.2.1` in multiple files to reflect the new release:
  - `BUILD.bazel` (`MACRO_DEV_DEPENDENCIES`)
  - `Cargo.toml` (`version` field)
  - `constants.rs` (`ROSETTA_VERSION` constant)

### Changelog Updates:
* Added a new section for version `1.2.1` in `CHANGELOG.md` with the following highlights:
  - Added token-specific metrics for multi-token instances to distinguish between tokens ([#4790](https://github.com/dfinity/ic/pull/4790)).
  - Increased the sync thread watchdog timeout from 10 to 60 seconds to handle IC instability better ([#4863](https://github.com/dfinity/ic/pull/4863)).
  - Addressed test flakiness by adding more resources for `icrc_multitoken_rosetta_system` tests ([#4741](https://github.com/dfinity/ic/pull/4741)).
  - Ensured ICRC-3 compliant certificates are always returned for consistency ([#4504](https://github.com/dfinity/ic/pull/4504)).Release information for ICRC Rosetta 1.2.1 with the following changes:
