### PR TITLE
feat(icp-rosetta): add icp rosetta release 2.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12446,7 +12446,7 @@ dependencies = [
 
 [[package]]
 name = "ic-rosetta-api"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -97,7 +97,7 @@ MACRO_DEV_DEPENDENCIES = []
 ALIASES = {
 }
 
-ROSETTA_VERSION = "2.1.3"
+ROSETTA_VERSION = "2.1.4"
 
 rust_library(
     name = "rosetta-api",

--- a/rs/rosetta-api/icp/CHANGELOG.md
+++ b/rs/rosetta-api/icp/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
+## [2.1.4] - 2025-05-10
+### Added
+- Token-specific metrics for better monitoring in multi-token environments ([#4790](https://github.com/dfinity/ic/pull/4790))
+- New PocketIC Time type for improved testing ([#4864](https://github.com/dfinity/ic/pull/4864))
+
+### Changed
+- Replaced imports from ic_canisters_http_types to new ic_http_types crate ([#4866](https://github.com/dfinity/ic/pull/4866))
+- Increased the sync thread watchdog timeout from 10 to 60 seconds to better handle IC instability ([#4863](https://github.com/dfinity/ic/pull/4863))
+- Refactored and augmented Rosetta ICP metrics for better observability ([#3642](https://github.com/dfinity/ic/pull/3642))
+- Migrated from dfn to cdk architecture ([#4436](https://github.com/dfinity/ic/pull/4436))
+
+### Fixed
+- Write ICP Rosetta port file atomically to fix flaky test issues ([#4760](https://github.com/dfinity/ic/pull/4760))
+- Removed canister client library dependency for better architecture ([#4530](https://github.com/dfinity/ic/pull/4530))
+
 ## [2.1.3] - 2025-03-12
 ### Fixes
 - Potential source of deadlock when accessing the database client. [#4147](https://github.com/dfinity/ic/pull/4147)

--- a/rs/rosetta-api/icp/Cargo.toml
+++ b/rs/rosetta-api/icp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-rosetta-api"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["The Internet Computer Project Developers"]
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 edition = "2021"


### PR DESCRIPTION
This pull request updates the `ic-rosetta-api` package to version 2.1.4, introducing new features, improvements, and fixes. The most notable changes include enhancements to metrics, architectural migrations, and bug fixes to improve reliability and observability.

### Version Update:
* Updated `ROSETTA_VERSION` and `Cargo.toml` to reflect the new version `2.1.4`. [[1]](diffhunk://#diff-7c8bbf3cd57fe84e5547fbbe9524a822dd0b2009b12e565f3d502f7e696aefdbL100-R100) [[2]](diffhunk://#diff-b6a799ae48d36b40e8c0d283cce4a7f6c0dfa04b51471ae5c23bde38ed36297aL3-R3)

### Changelog Updates:
* Added a detailed changelog entry for version 2.1.4:
  - **Added**: Token-specific metrics and a new PocketIC Time type for testing. ([#4790](https://github.com/dfinity/ic/pull/4790), [#4864](https://github.com/dfinity/ic/pull/4864))
  - **Changed**: Migrated to `ic_http_types`, increased watchdog timeout, refactored metrics, and transitioned to the `cdk` architecture. ([#4866](https://github.com/dfinity/ic/pull/4866), [#4863](https://github.com/dfinity/ic/pull/4863), [#3642](https://github.com/dfinity/ic/pull/3642), [#4436](https://github.com/dfinity/ic/pull/4436))
  - **Fixed**: Addressed flaky test issues and removed unnecessary dependencies for better architecture. ([#4760](https://github.com/dfinity/ic/pull/4760), [#4530](https://github.com/dfinity/ic/pull/4530))