### PR TITLE
feat(nns): Expose maturity disbursements as part of neuron

### DIFF
--- a/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
@@ -323,6 +323,9 @@ pub struct Neuron {
     ///
     /// Per NNS policy, this is opt. Nevertheless, it will never be null.
     pub potential_voting_power: Option<u64>,
+
+    /// The maturity disbursements in progress for this neuron.
+    pub maturity_disbursements_in_progress: Option<Vec<MaturityDisbursement>>,
 }
 /// Nested message and enum types in `Neuron`.
 pub mod neuron {
@@ -4364,4 +4367,18 @@ pub struct ListNodeProviderRewardsRequest {
 pub struct ListNodeProviderRewardsResponse {
     /// The list of minted node provider rewards
     pub rewards: Vec<MonthlyNodeProviderRewards>,
+}
+
+#[derive(
+    candid::CandidType, candid::Deserialize, serde::Serialize, Debug, Default, Clone, PartialEq,
+)]
+pub struct MaturityDisbursement {
+    /// The amount of maturity being disbursed in e8s.
+    pub amount_e8s: Option<u64>,
+    /// The timestamp at which the maturity was disbursed.
+    pub timestamp_of_disbursement_seconds: Option<u64>,
+    /// The timestamp at which the maturity disbursement should be finalized.
+    pub finalize_disbursement_timestamp_seconds: Option<u64>,
+    /// The account to disburse the maturity to.
+    pub account_to_disburse_to: Option<Account>,
 }

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -732,6 +732,10 @@ type Neuron = record {
   //
   // Per NNS policy, this is opt. Nevertheless, it will never be null.
   potential_voting_power : opt nat64;
+
+  // The maturity disbursements in progress, i.e. the disbursements that are initiated but not
+  // finalized. The finalization happens 7 days after the disbursement is initiated.
+  maturity_disbursements_in_progress : opt vec MaturityDisbursement;
 };
 
 type NeuronBasketConstructionParameters = record {
@@ -1266,6 +1270,13 @@ type WaitForQuietState = record {
 type XdrConversionRate = record {
   xdr_permyriad_per_icp : opt nat64;
   timestamp_seconds : opt nat64;
+};
+
+type MaturityDisbursement = record {
+  amount_e8s : opt nat64;
+  timestamp_of_disbursement_seconds : opt nat64;
+  finalize_disbursement_timestamp_seconds : opt nat64;
+  account_to_disburse_to : opt Account;
 };
 
 service : (Governance) -> {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -641,6 +641,7 @@ type Neuron = record {
   voting_power_refreshed_timestamp_seconds : opt nat64;
   deciding_voting_power : opt nat64;
   potential_voting_power : opt nat64;
+  maturity_disbursements_in_progress : opt vec MaturityDisbursement;
 };
 
 type NeuronBasketConstructionParameters = record {
@@ -1153,6 +1154,13 @@ type WaitForQuietState = record {
 type XdrConversionRate = record {
   xdr_permyriad_per_icp : opt nat64;
   timestamp_seconds : opt nat64;
+};
+
+type MaturityDisbursement = record {
+  amount_e8s : opt nat64;
+  timestamp_of_disbursement_seconds : opt nat64;
+  finalize_disbursement_timestamp_seconds : opt nat64;
+  account_to_disburse_to : opt Account;
 };
 
 service : (Governance) -> {

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -3,6 +3,7 @@ use crate::{
         LOG_PREFIX, MAX_DISSOLVE_DELAY_SECONDS, MAX_NEURON_AGE_FOR_AGE_BONUS,
         MAX_NEURON_RECENT_BALLOTS, MAX_NUM_HOT_KEYS_PER_NEURON,
     },
+    is_disburse_maturity_enabled,
     neuron::{combine_aged_stakes, dissolve_state_and_age::DissolveStateAndAge, neuron_stake_e8s},
     neuron_store::NeuronStoreError,
     pb::v1::{
@@ -1394,7 +1395,7 @@ impl Neuron {
             known_neuron_data,
             neuron_type,
             voting_power_refreshed_timestamp_seconds,
-            maturity_disbursements_in_progress: _,
+            maturity_disbursements_in_progress,
 
             // Not used.
             visibility: _,
@@ -1427,6 +1428,17 @@ impl Neuron {
             .into_iter()
             .map(|(topic_id, followees)| (topic_id, api::neuron::Followees::from(followees)))
             .collect();
+
+        let maturity_disbursements_in_progress = if is_disburse_maturity_enabled() {
+            Some(
+                maturity_disbursements_in_progress
+                    .into_iter()
+                    .map(api::MaturityDisbursement::from)
+                    .collect(),
+            )
+        } else {
+            None
+        };
         api::Neuron {
             id,
             account,
@@ -1451,6 +1463,7 @@ impl Neuron {
             neuron_type,
             visibility,
             voting_power_refreshed_timestamp_seconds,
+            maturity_disbursements_in_progress,
 
             potential_voting_power,
             deciding_voting_power,

--- a/rs/nns/governance/src/neuron/types/tests.rs
+++ b/rs/nns/governance/src/neuron/types/tests.rs
@@ -114,6 +114,11 @@ fn test_neuron_into_api() {
             neuron_type: None,
             potential_voting_power,
             deciding_voting_power,
+            maturity_disbursements_in_progress: if cfg!(feature = "test") {
+                Some(vec![])
+            } else {
+                None
+            },
         },
     );
 

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -4000,3 +4000,16 @@ impl From<ic_nns_governance_api::test_api::TimeWarp> for crate::TimeWarp {
         }
     }
 }
+
+impl From<pb::MaturityDisbursement> for pb_api::MaturityDisbursement {
+    fn from(item: pb::MaturityDisbursement) -> Self {
+        Self {
+            amount_e8s: Some(item.amount_e8s),
+            account_to_disburse_to: item.account_to_disburse_to.map(|x| x.into()),
+            timestamp_of_disbursement_seconds: Some(item.timestamp_of_disbursement_seconds),
+            finalize_disbursement_timestamp_seconds: Some(
+                item.finalize_disbursement_timestamp_seconds,
+            ),
+        }
+    }
+}

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -5283,6 +5283,7 @@ fn create_mature_neuron(dissolved: bool) -> (fake::FakeDriver, Governance, Neuro
             voting_power_refreshed_timestamp_seconds: Some(START_TIMESTAMP_SECONDS),
             deciding_voting_power: Some(expected_voting_power),
             potential_voting_power: Some(expected_voting_power),
+            maturity_disbursements_in_progress: Some(vec![]),
             ..Default::default()
         }
     );
@@ -11385,6 +11386,7 @@ fn test_include_public_neurons_in_full_neurons() {
             voting_power_refreshed_timestamp_seconds: Some(START_TIMESTAMP_SECONDS),
             deciding_voting_power: Some(20 * E8),
             potential_voting_power: Some(20 * E8),
+            maturity_disbursements_in_progress: Some(vec![]),
 
             ..Default::default()
         }


### PR DESCRIPTION
# Why

As part of the disburse maturity functionality, after a disbursement is initiated, the user should be able to check on the disbursement in progress.

# What

* Define the maturity_disbursement_in_progress field within the neuron on the API layer.
* Convert from internal type to the API type for the disbursement
* Update .did files
* Update the state machine test to check disbursements through get_full_neuron