### PR TITLE
test(sns): Check that NNS Governance and SNS-W can be upgraded without each other

### DIFF
--- a/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_release_qualification.rs
@@ -55,6 +55,16 @@ async fn test_deployment_with_only_nns_upgrades() {
 }
 
 #[tokio::test]
+async fn test_deployment_with_only_nns_governnace_upgrade() {
+    test_sns_deployment(vec![GOVERNANCE_CANISTER_ID], vec![]).await;
+}
+
+#[tokio::test]
+async fn test_deployment_with_only_sns_wasm_upgrade() {
+    test_sns_deployment(vec![SNS_WASM_CANISTER_ID], vec![]).await;
+}
+
+#[tokio::test]
 async fn test_deployment_with_only_sns_upgrades() {
     let nns_canisters_to_upgrade = vec![];
 


### PR DESCRIPTION
There was an instance where an NNS Governance upgrade without SNS-W upgrade causing backward compatibility issue, where a field stops getting populated within the CreateServiceNervousSystem payload, while the corresponding change in SNS-W to validate this field is not released. On a high level, there is some message passing between NNS Governance and SNS-W for CSNS proposal execution, and we want to make sure the message passing is not broken if either of them is upgraded without each other.
