### PR TITLE
feat(registry): Add canister migrations endpoint with no functionality

### DIFF
--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -239,6 +239,13 @@ type IPv4Config = record {
   ip_addr : text;
 };
 
+type MigrateCanistersPayload = record {
+  canister_ids : vec principal;
+  target_subnet_id : principal;
+};
+
+type MigrateCanistersResponse = record {};
+
 type NodeOperatorRecord = record {
   ipv6 : opt text;
   node_operator_principal_id : blob;
@@ -476,6 +483,7 @@ service : {
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
   get_node_providers_monthly_xdr_rewards : (opt GetNodeProvidersMonthlyXdrRewardsRequest) -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
   get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (GetSubnetForCanisterResponse) query;
+  migrate_canisters: (MigrateCanistersPayload) -> (MigrateCanistersResponse);
   prepare_canister_migration : (PrepareCanisterMigrationPayload) -> ();
   recover_subnet : (RecoverSubnetPayload) -> ();
   remove_api_boundary_nodes : (RemoveApiBoundaryNodesPayload) -> ();

--- a/rs/registry/canister/src/mutations/do_migrate_canisters.rs
+++ b/rs/registry/canister/src/mutations/do_migrate_canisters.rs
@@ -1,7 +1,6 @@
 use crate::registry::Registry;
 use candid::{CandidType, Deserialize};
 use ic_base_types::PrincipalId;
-use prost::Message;
 use serde::Serialize;
 
 impl Registry {
@@ -13,11 +12,11 @@ impl Registry {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, CandidType, Deserialize, Message, Serialize)]
+#[derive(Clone, Eq, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct MigrateCanistersPayload {
     canister_ids: Vec<PrincipalId>,
     target_subnet_id: PrincipalId,
 }
 
-#[derive(Clone, Eq, PartialEq, CandidType, Deserialize, Message, Serialize)]
+#[derive(Clone, Eq, PartialEq, CandidType, Deserialize, Serialize)]
 pub struct MigrateCanistersResponse {}

--- a/rs/registry/canister/src/mutations/do_migrate_canisters.rs
+++ b/rs/registry/canister/src/mutations/do_migrate_canisters.rs
@@ -1,0 +1,23 @@
+use crate::registry::Registry;
+use candid::{CandidType, Deserialize};
+use ic_base_types::PrincipalId;
+use prost::Message;
+use serde::Serialize;
+
+impl Registry {
+    pub fn do_migrate_canisters(
+        &mut self,
+        _payload: MigrateCanistersPayload,
+    ) -> MigrateCanistersResponse {
+        MigrateCanistersResponse {}
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, CandidType, Deserialize, Message, Serialize)]
+pub struct MigrateCanistersPayload {
+    canister_ids: Vec<PrincipalId>,
+    target_subnet_id: PrincipalId,
+}
+
+#[derive(Clone, Eq, PartialEq, CandidType, Deserialize, Message, Serialize)]
+pub struct MigrateCanistersResponse {}

--- a/rs/registry/canister/src/mutations/mod.rs
+++ b/rs/registry/canister/src/mutations/mod.rs
@@ -11,6 +11,7 @@ pub mod do_clear_provisional_whitelist;
 pub mod do_create_subnet;
 pub mod do_deploy_guestos_to_all_subnet_nodes;
 pub mod do_deploy_guestos_to_all_unassigned_nodes;
+pub mod do_migrate_canisters;
 pub mod do_recover_subnet;
 pub mod do_remove_api_boundary_nodes;
 pub mod do_remove_node_operators;

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -9,6 +9,9 @@ on the process that this file is part of, see
 
 ## Added
 
+* Added new endpoint for `migrate_canisters` which is only callable by governance, and currently has no functionality.
+  This will be used for the canister migrations feature.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
This adds a new endpoint that does nothing, but implements the canister migrations spec