### PR TITLE
test: tune the slow //rs/execution_environment:dts_test

### DIFF
--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -174,10 +174,12 @@ rust_ic_test(
     data = DATA + [
         "//rs/universal_canister/impl:universal_canister.wasm.gz",
     ],
-    env = dict(ENV.items() + [
-        ("UNIVERSAL_CANISTER_WASM_PATH", "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)"),
-    ]),
+    env = ENV | {
+        "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
+        "RUST_TEST_THREADS": "4",
+    },
     tags = [
+        "cpu:4",
         "test_macos_slow",
     ],
     deps = [":execution_environment"] + DEPENDENCIES + DEV_DEPENDENCIES,


### PR DESCRIPTION
The `//rs/execution_environment:dts_test` has a P90 of over ~8 minutes. See its [durations chart](https://superset.idx.dfinity.network/explore/?slice_id=112).

Note that [by default rust's libtest will use the amount of concurrency available on the hardware](https://doc.rust-lang.org/rustc/tests/index.html#--test-threads-num_threads) which in our case is 64 threads since our runners have 64 cores. One hypothesis why this test is slow is that it starts running all its 38 tests in parallel thereby hogging the CPUs who will also be doing a lot of other work of the whole `bazel test //...` invocation. 

So we try to optimise the test by both:
* reducing the number of tests executed in parallel to just 4 and by 
* increasing the number of CPUs that will be available to this test from 1 to 4.