### PR TITLE
docs(governance): Update CHANGELOG files for 2025-05-02 Governance team release.

### DIFF
--- a/rs/nns/governance/CHANGELOG.md
+++ b/rs/nns/governance/CHANGELOG.md
@@ -11,6 +11,20 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-05-02: Proposal 136427
+
+http://dashboard.internetcomputer.org/proposal/136427
+
+## Changed
+
+* The Governance canister will fetch rewards from the new Node Rewards Canister instead of from Registry.
+
+## Removed
+
+* All the `_pb` methods are removed as they already always panic, as well as decoding the init arg
+  as protobuf.
+
+
 # 2025-04-25: Proposal 136370
 
 http://dashboard.internetcomputer.org/proposal/136370

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -4,20 +4,16 @@ In general, upcoming/unreleased behavior changes are described here. For details
 on the process that this file is part of, see
 `rs/nervous_system/changelog_process.md`.
 
+
 # Next Upgrade Proposal
 
 ## Added
 
 ## Changed
 
-* The Governance canister will fetch rewards from the new Node Rewards Canister instead of from Registry.
-
 ## Deprecated
 
 ## Removed
-
-* All the `_pb` methods are removed as they already always panic, as well as decoding the init arg
-  as protobuf.
 
 ## Fixed
 

--- a/rs/nns/handlers/root/CHANGELOG.md
+++ b/rs/nns/handlers/root/CHANGELOG.md
@@ -11,6 +11,12 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-05-02: Proposal 136429
+
+No behavior change.
+
+Code for new behavior is inactive (behind a flag).
+
 # 2025-02-14: Proposal 135313
 
 http://dashboard.internetcomputer.org/proposal/135313

--- a/rs/nns/sns-wasm/CHANGELOG.md
+++ b/rs/nns/sns-wasm/CHANGELOG.md
@@ -10,6 +10,14 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 
 INSERT NEW RELEASES HERE
 
+
+# 2025-05-02: Proposal 136430
+
+https://dashboard.internetcomputer.org/proposal/136430
+
+No behavior change. This is just a "maintenance" upgrade; that is, this is to
+avoid too much unreleased code piling up.
+
 # 2025-03-13: Proposal 135773
 
 https://dashboard.internetcomputer.org/proposal/135773

--- a/rs/registry/canister/CHANGELOG.md
+++ b/rs/registry/canister/CHANGELOG.md
@@ -11,6 +11,16 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-05-02: Proposal 136428
+
+https://dashboard.internetcomputer.org/proposal/136428
+
+No behavior changes. When there are large registry records, then, the new code
+here will behave differently (per [this forum post]), but there is currently no
+way to generate such records.
+
+[this forum post]: https://forum.dfinity.org/t/breaking-registry-changes-for-large-records/42893
+
 # 2025-04-25: Proposal 136371
 
 http://dashboard.internetcomputer.org/proposal/136371


### PR DESCRIPTION
Some of our canisters did not have anything in unreleased_changelog.

Also, ledger suite in SNS does not follow our CHANGELOG process, so there are no changes for those.

Affected canisters:

NNS:
  * Governance
  * Registry
  * Root
  * SNS-WASM

SNS: **_NONE_**