### PR TITLE
feat: [MR-606] Break out dropped message metrics by kind / context / class

### DIFF
--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -81,8 +81,12 @@ const STATUS_SUCCESS: &str = "success";
 const PHASE_LOAD_STATE: &str = "load_state";
 const PHASE_COMMIT: &str = "commit";
 
+/// Label for message kind: "request" or "response".
 pub(crate) const LABEL_KIND: &str = "kind";
+/// Label for message context" "inbound" (in an input queue) or "outbound" (in
+/// an output queue).
 pub(crate) const LABEL_CONTEXT: &str = "context";
+/// Label for message class: "guaranteed response" or "best-effort".
 pub(crate) const LABEL_CLASS: &str = "class";
 
 const METRIC_RECEIVE_BATCH_LATENCY: &str = "mr_receive_batch_latency_seconds";

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -1,16 +1,14 @@
-use crate::{
-    routing, scheduling,
-    state_machine::{StateMachine, StateMachineImpl},
-};
+use crate::state_machine::{StateMachine, StateMachineImpl};
+use crate::{routing, scheduling};
 use ic_config::embedders::BestEffortResponsesFeature;
 use ic_config::execution_environment::{BitcoinConfig, Config as HypervisorConfig};
 use ic_config::message_routing::{MAX_STREAM_MESSAGES, TARGET_STREAM_SIZE_BYTES};
 use ic_cycles_account_manager::CyclesAccountManager;
-use ic_interfaces::{crypto::ErrorReproducibility, execution_environment::ChainKeySettings};
-use ic_interfaces::{
-    execution_environment::{IngressHistoryWriter, RegistryExecutionSettings, Scheduler},
-    messaging::{MessageRouting, MessageRoutingError},
+use ic_interfaces::execution_environment::{
+    IngressHistoryWriter, RegistryExecutionSettings, Scheduler,
 };
+use ic_interfaces::messaging::{MessageRouting, MessageRoutingError};
+use ic_interfaces::{crypto::ErrorReproducibility, execution_environment::ChainKeySettings};
 use ic_interfaces_certified_stream_store::CertifiedStreamStore;
 use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::{CertificationScope, StateManager, StateManagerError};
@@ -20,27 +18,28 @@ use ic_metrics::buckets::{add_bucket, decimal_buckets, decimal_buckets_with_zero
 use ic_metrics::MetricsRegistry;
 use ic_protobuf::proxy::{try_from_option_field, ProxyDecodeError};
 use ic_query_stats::QueryStatsAggregatorMetrics;
-use ic_registry_client_helpers::{
-    api_boundary_node::ApiBoundaryNodeRegistry,
-    chain_keys::ChainKeysRegistry,
-    crypto::CryptoRegistry,
-    node::NodeRegistry,
-    provisional_whitelist::ProvisionalWhitelistRegistry,
-    routing_table::RoutingTableRegistry,
-    subnet::{get_node_ids_from_subnet_record, SubnetListRegistry, SubnetRegistry},
+use ic_registry_client_helpers::api_boundary_node::ApiBoundaryNodeRegistry;
+use ic_registry_client_helpers::chain_keys::ChainKeysRegistry;
+use ic_registry_client_helpers::crypto::CryptoRegistry;
+use ic_registry_client_helpers::node::NodeRegistry;
+use ic_registry_client_helpers::provisional_whitelist::ProvisionalWhitelistRegistry;
+use ic_registry_client_helpers::routing_table::RoutingTableRegistry;
+use ic_registry_client_helpers::subnet::{
+    get_node_ids_from_subnet_record, SubnetListRegistry, SubnetRegistry,
 };
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
 use ic_registry_subnet_features::{ChainKeyConfig, SubnetFeatures};
 use ic_registry_subnet_type::SubnetType;
+use ic_replicated_state::metadata_state::ApiBoundaryNodeEntry;
 use ic_replicated_state::{
-    metadata_state::ApiBoundaryNodeEntry, NetworkTopology, ReplicatedState, SubnetTopology,
+    DroppedMessageMetrics, NetworkTopology, ReplicatedState, SubnetTopology,
 };
+use ic_types::batch::{Batch, BatchSummary};
+use ic_types::crypto::{threshold_sig::ThresholdSigPublicKey, KeyPurpose};
+use ic_types::malicious_flags::MaliciousFlags;
+use ic_types::registry::RegistryClientError;
+use ic_types::xnet::{StreamHeader, StreamIndex};
 use ic_types::{
-    batch::{Batch, BatchSummary},
-    crypto::{threshold_sig::ThresholdSigPublicKey, KeyPurpose},
-    malicious_flags::MaliciousFlags,
-    registry::RegistryClientError,
-    xnet::{StreamHeader, StreamIndex},
     Height, NodeId, NumBytes, PrincipalIdBlobParseError, RegistryVersion, SubnetId, Time,
 };
 use ic_utils_thread::JoinOnDrop;
@@ -81,6 +80,10 @@ const STATUS_SUCCESS: &str = "success";
 
 const PHASE_LOAD_STATE: &str = "load_state";
 const PHASE_COMMIT: &str = "commit";
+
+pub(crate) const LABEL_KIND: &str = "kind";
+pub(crate) const LABEL_CONTEXT: &str = "context";
+pub(crate) const LABEL_CLASS: &str = "class";
 
 const METRIC_RECEIVE_BATCH_LATENCY: &str = "mr_receive_batch_latency_seconds";
 const METRIC_INDUCT_BATCH_LATENCY: &str = "mr_induct_batch_latency_seconds";
@@ -290,13 +293,13 @@ pub(crate) struct MessageRoutingMetrics {
     /// Batch processing phase durations, by phase.
     pub(crate) process_batch_phase_duration: HistogramVec,
     /// Number of timed out messages.
-    pub(crate) timed_out_messages_total: IntCounter,
+    pub(crate) timed_out_messages_total: IntCounterVec,
     /// Number of timed out callbacks.
     pub(crate) timed_out_callbacks_total: IntCounter,
     /// Number of shed best-effort messages.
-    pub(crate) shed_messages_total: IntCounter,
+    pub(crate) shed_messages_total: IntCounterVec,
     /// Byte size of shed best-effort messages.
-    pub(crate) shed_message_bytes_total: IntCounter,
+    pub(crate) shed_message_bytes_total: IntCounterVec,
     /// Height at which the subnet last split (if during the lifetime of this
     /// replica process; otherwise zero).
     pub(crate) subnet_split_height: IntGaugeVec,
@@ -406,21 +409,24 @@ impl MessageRoutingMetrics {
                 "Most recently observed remote subnet certified heights.",
                 &[LABEL_REMOTE],
             ),
-            timed_out_messages_total: metrics_registry.int_counter(
+            timed_out_messages_total: metrics_registry.int_counter_vec(
                 METRIC_TIMED_OUT_MESSAGES_TOTAL,
-                "Count of timed out messages.",
+                "Count of timed out messages, by kind, context and class.",
+                &[LABEL_KIND, LABEL_CONTEXT, LABEL_CLASS],
             ),
             timed_out_callbacks_total: metrics_registry.int_counter(
                 METRIC_TIMED_OUT_CALLBACKS_TOTAL,
                 "Count of expired best-effort callbacks.",
             ),
-            shed_messages_total: metrics_registry.int_counter(
+            shed_messages_total: metrics_registry.int_counter_vec(
                 METRIC_SHED_MESSAGES_TOTAL,
-                "Count of shed messages.",
+                "Count of shed best-effort messages, by kind and context.",
+                &[LABEL_KIND, LABEL_CONTEXT],
             ),
-            shed_message_bytes_total: metrics_registry.int_counter(
+            shed_message_bytes_total: metrics_registry.int_counter_vec(
                 METRIC_SHED_MESSAGE_BYTES_TOTAL,
-                "Total byte size of shed messages.",
+                "Total byte size of shed best-effort messages, by kind and context.",
+                &[LABEL_KIND, LABEL_CONTEXT],
             ),
             subnet_split_height: metrics_registry.int_gauge_vec(
                 METRIC_SUBNET_SPLIT_HEIGHT,
@@ -531,6 +537,23 @@ impl MessageRoutingMetrics {
             state_time,
             batch_time
         );
+    }
+}
+
+impl DroppedMessageMetrics for MessageRoutingMetrics {
+    fn observe_timed_out_message(&self, kind: &str, context: &str, class: &str) {
+        self.timed_out_messages_total
+            .with_label_values(&[kind, context, class])
+            .inc();
+    }
+
+    fn observe_shed_message(&self, kind: &str, context: &str, size_bytes: usize) {
+        self.shed_messages_total
+            .with_label_values(&[kind, context])
+            .inc();
+        self.shed_message_bytes_total
+            .with_label_values(&[kind, context])
+            .inc_by(size_bytes as u64);
     }
 }
 

--- a/rs/messaging/src/state_machine.rs
+++ b/rs/messaging/src/state_machine.rs
@@ -123,10 +123,7 @@ impl StateMachine for StateMachineImpl {
         }
 
         // Time out expired messages.
-        let (timed_out_messages, lost_cycles) = state.time_out_messages();
-        self.metrics
-            .timed_out_messages_total
-            .inc_by(timed_out_messages as u64);
+        let lost_cycles = state.time_out_messages(&self.metrics);
         state
             .metadata
             .subnet_metrics
@@ -214,12 +211,10 @@ impl StateMachine for StateMachineImpl {
 
         let since = Instant::now();
         // Shed enough messages to stay below the best-effort message memory limit.
-        let (shed_messages, shed_message_bytes, lost_cycles) = state_after_stream_builder
-            .enforce_best_effort_message_limit(self.best_effort_message_memory_capacity);
-        self.metrics.shed_messages_total.inc_by(shed_messages);
-        self.metrics
-            .shed_message_bytes_total
-            .inc_by(shed_message_bytes.get());
+        let lost_cycles = state_after_stream_builder.enforce_best_effort_message_limit(
+            self.best_effort_message_memory_capacity,
+            &self.metrics,
+        );
         state_after_stream_builder
             .metadata
             .subnet_metrics

--- a/rs/replicated_state/src/canister_state/queues/message_pool.rs
+++ b/rs/replicated_state/src/canister_state/queues/message_pool.rs
@@ -1,5 +1,9 @@
 use super::CanisterInput;
 use crate::page_map::int_map::{AsInt, MutableIntMap};
+use crate::{
+    CLASS_BEST_EFFORT, CLASS_GUARANTEED_RESPONSE, CONTEXT_INBOUND, CONTEXT_OUTBOUND, KIND_REQUEST,
+    KIND_RESPONSE,
+};
 use ic_protobuf::proxy::{try_from_option_field, ProxyDecodeError};
 use ic_protobuf::state::queues::v1 as pb_queues;
 use ic_types::messages::{
@@ -31,8 +35,16 @@ pub(super) enum Kind {
 }
 
 impl Kind {
-    // Message kind bit (request or response).
+    /// Message kind bit (request or response).
     const BIT: u64 = 1;
+
+    /// Returns a string representation to be used as metric label value.
+    pub(super) fn to_label_value(self) -> &'static str {
+        match self {
+            Self::Request => KIND_REQUEST,
+            Self::Response => KIND_RESPONSE,
+        }
+    }
 }
 
 impl From<&RequestOrResponse> for Kind {
@@ -53,8 +65,16 @@ pub(super) enum Context {
 }
 
 impl Context {
-    // Message context bit (inbound or outbound).
+    /// Message context bit (inbound or outbound).
     const BIT: u64 = 1 << 1;
+
+    /// Returns a string representation to be used as metric label value.
+    pub(super) fn to_label_value(self) -> &'static str {
+        match self {
+            Self::Inbound => CONTEXT_INBOUND,
+            Self::Outbound => CONTEXT_OUTBOUND,
+        }
+    }
 }
 
 /// Bit encoding the message class (guaranteed response vs best-effort).
@@ -66,8 +86,16 @@ pub(super) enum Class {
 }
 
 impl Class {
-    // Message class bit (guaranteed response vs best-effort).
+    /// Message class bit (guaranteed response vs best-effort).
     const BIT: u64 = 1 << 2;
+
+    /// Returns a string representation to be used as metric label value.
+    pub(super) fn to_label_value(self) -> &'static str {
+        match self {
+            Self::GuaranteedResponse => CLASS_GUARANTEED_RESPONSE,
+            Self::BestEffort => CLASS_BEST_EFFORT,
+        }
+    }
 }
 
 impl From<&RequestOrResponse> for Class {
@@ -280,6 +308,27 @@ impl ToContext for RequestOrResponse {
 pub(super) enum SomeReference {
     Inbound(InboundReference),
     Outbound(OutboundReference),
+}
+
+impl SomeReference {
+    fn id(&self) -> Id {
+        match self {
+            Self::Inbound(reference) => reference.into(),
+            Self::Outbound(reference) => reference.into(),
+        }
+    }
+
+    pub(super) fn kind(&self) -> Kind {
+        self.id().kind()
+    }
+
+    pub(super) fn context(&self) -> Context {
+        self.id().context()
+    }
+
+    pub(super) fn class(&self) -> Class {
+        self.id().class()
+    }
 }
 
 impl From<Id> for SomeReference {

--- a/rs/replicated_state/src/lib.rs
+++ b/rs/replicated_state/src/lib.rs
@@ -61,11 +61,6 @@ pub(crate) mod hash;
 pub mod metadata_state;
 pub mod page_map;
 pub mod replicated_state;
-pub mod testing {
-    pub use super::canister_state::system_state::testing::SystemStateTesting;
-    pub use super::canister_state::testing::CanisterQueuesTesting;
-    pub use super::replicated_state::testing::ReplicatedStateTesting;
-}
 pub use canister_state::{
     execution_state::Memory,
     num_bytes_try_from,
@@ -90,4 +85,76 @@ pub use replicated_state::{
 /// to record metrics from there.
 pub trait CheckpointLoadingMetrics {
     fn observe_broken_soft_invariant(&self, msg: String);
+}
+
+pub const KIND_REQUEST: &str = "request";
+pub const KIND_RESPONSE: &str = "response";
+pub const CONTEXT_INBOUND: &str = "inbound";
+pub const CONTEXT_OUTBOUND: &str = "outbound";
+pub const CLASS_GUARANTEED_RESPONSE: &str = "guaranteed response";
+pub const CLASS_BEST_EFFORT: &str = "best-effort";
+
+/// Exposes methods for observing timed out and shed messages.
+pub trait DroppedMessageMetrics {
+    /// Observes a timed out message with the given kind, context and class.
+    fn observe_timed_out_message(
+        &self,
+        kind: &'static str,
+        context: &'static str,
+        class: &'static str,
+    );
+
+    /// Observes a shed message with the given kind and context,
+    fn observe_shed_message(&self, kind: &'static str, context: &'static str, size_bytes: usize);
+}
+
+pub mod testing {
+    pub use super::canister_state::system_state::testing::SystemStateTesting;
+    pub use super::canister_state::testing::CanisterQueuesTesting;
+    pub use super::replicated_state::testing::ReplicatedStateTesting;
+
+    use super::DroppedMessageMetrics;
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
+
+    #[derive(Default, Debug)]
+    pub struct FakeDropMessageMetrics {
+        pub timed_out_messages:
+            RefCell<BTreeMap<(&'static str, &'static str, &'static str), usize>>,
+        pub shed_messages: RefCell<BTreeMap<(&'static str, &'static str), usize>>,
+        pub shed_message_bytes: RefCell<BTreeMap<(&'static str, &'static str), usize>>,
+    }
+
+    impl DroppedMessageMetrics for FakeDropMessageMetrics {
+        fn observe_timed_out_message(
+            &self,
+            kind: &'static str,
+            context: &'static str,
+            class: &'static str,
+        ) {
+            *self
+                .timed_out_messages
+                .borrow_mut()
+                .entry((kind, context, class))
+                .or_default() += 1;
+        }
+
+        fn observe_shed_message(
+            &self,
+            kind: &'static str,
+            context: &'static str,
+            size_bytes: usize,
+        ) {
+            *self
+                .shed_messages
+                .borrow_mut()
+                .entry((kind, context))
+                .or_default() += 1;
+            *self
+                .shed_message_bytes
+                .borrow_mut()
+                .entry((kind, context))
+                .or_default() += size_bytes;
+        }
+    }
 }

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -11,7 +11,7 @@ use crate::{
         queues::{CanisterInput, CanisterQueuesLoopDetector},
         system_state::{push_input, CanisterOutputQueuesIterator},
     },
-    CanisterQueues,
+    CanisterQueues, DroppedMessageMetrics,
 };
 use ic_base_types::{PrincipalId, SnapshotId};
 use ic_btc_replica_types::BitcoinAdapterResponse;
@@ -1069,11 +1069,11 @@ impl ReplicatedState {
     }
 
     /// Times out all messages with expired deadlines (given the state time) in all
-    /// canister (but not subnet) queues. Returns the number of timed out messages
-    /// and the total amount of attached cycles that was lost.
+    /// canister (but not subnet) queues. Returns the total amount of attached
+    /// cycles that was lost.
     ///
     /// See `CanisterQueues::time_out_messages` for further details.
-    pub fn time_out_messages(&mut self) -> (usize, Cycles) {
+    pub fn time_out_messages(&mut self, metrics: &impl DroppedMessageMetrics) -> Cycles {
         let current_time = self.metadata.time();
         // Because the borrow checker requires us to remove each canister before
         // calling `time_out_messages()` on it and replace it afterwards; and removing
@@ -1091,30 +1091,30 @@ impl ReplicatedState {
             .map(|(canister_id, _)| *canister_id)
             .collect::<Vec<_>>();
 
-        let mut timed_out_messages_count = 0;
         let mut cycles_lost = Cycles::zero();
         for canister_id in canister_ids_with_expired_deadlines {
             let mut canister = self.canister_states.remove(&canister_id).unwrap();
-            let (canister_timed_out_messages, canister_cycles_lost) = canister
-                .system_state
-                .time_out_messages(current_time, &canister_id, &self.canister_states);
-            timed_out_messages_count += canister_timed_out_messages;
+            let canister_cycles_lost = canister.system_state.time_out_messages(
+                current_time,
+                &canister_id,
+                &self.canister_states,
+                metrics,
+            );
             cycles_lost += canister_cycles_lost;
             self.canister_states.insert(canister_id, canister);
         }
 
         if self.subnet_queues.has_expired_deadlines(current_time) {
-            let (subnet_timed_out_messages, subnet_cycles_lost) =
-                self.subnet_queues.time_out_messages(
-                    current_time,
-                    &self.metadata.own_subnet_id.into(),
-                    &self.canister_states,
-                );
-            timed_out_messages_count += subnet_timed_out_messages;
+            let subnet_cycles_lost = self.subnet_queues.time_out_messages(
+                current_time,
+                &self.metadata.own_subnet_id.into(),
+                &self.canister_states,
+                metrics,
+            );
             cycles_lost += subnet_cycles_lost;
         }
 
-        (timed_out_messages_count, cycles_lost)
+        cycles_lost
     }
 
     /// Times out all callbacks with expired deadlines (given the state time) that
@@ -1160,21 +1160,21 @@ impl ReplicatedState {
     /// best-effort message of the canister with the highest best-effort message
     /// memory usage until the total memory usage drops below the limit.
     ///
-    /// Returns the number of messages and message bytes that were shed; along with
-    /// the total amount of attached cycles that was lost.
+    /// Returns the total amount of attached cycles that was lost.
     ///
     /// Time complexity: `O(n * log(n))`.
     pub fn enforce_best_effort_message_limit(
         &mut self,
         limit: NumBytes,
-    ) -> (u64, NumBytes, Cycles) {
+        metrics: &impl DroppedMessageMetrics,
+    ) -> Cycles {
         const ZERO_BYTES: NumBytes = NumBytes::new(0);
 
         // Check if we need to do anything at all before constructing a priority queue.
         let mut memory_usage = self.best_effort_message_memory_taken();
         if memory_usage <= limit {
             // No need to do anything.
-            return (0, 0.into(), Cycles::zero());
+            return Cycles::zero();
         }
 
         // Construct a priority queue of canisters by best-effort message memory usage.
@@ -1198,8 +1198,6 @@ impl ReplicatedState {
             ));
         }
 
-        let mut shed_messages = 0;
-        let mut shed_message_bytes = 0.into();
         let mut cycles_lost = Cycles::zero();
 
         // Shed messages from the canisters with the largest memory usage until we are
@@ -1210,27 +1208,27 @@ impl ReplicatedState {
         while memory_usage > limit && !priority_queue.is_empty() {
             let (memory_usage_before, canister_id) = priority_queue.pop_last().unwrap();
 
-            let (message_shed, memory_usage_after, message_cycles_lost) = if canister_id.get()
-                == self.metadata.own_subnet_id.get()
-            {
-                // Shed from the subnet queues.
-                let (message_shed, message_cycles_lost) = self
-                    .subnet_queues
-                    .shed_largest_message(&canister_id, &self.canister_states);
-                let memory_usage_after =
-                    (self.subnet_queues.best_effort_message_memory_usage() as u64).into();
-                (message_shed, memory_usage_after, message_cycles_lost)
-            } else {
-                // Shed from a canister's queues: remove the canister, shed its largest message,
-                // replace it.
-                let mut canister = self.canister_states.remove(&canister_id).unwrap();
-                let (message_shed, message_cycles_lost) = canister
-                    .system_state
-                    .shed_largest_message(&canister_id, &self.canister_states);
-                let memory_usage_after = canister.system_state.best_effort_message_memory_usage();
-                self.canister_states.insert(canister_id, canister);
-                (message_shed, memory_usage_after, message_cycles_lost)
-            };
+            let (message_shed, memory_usage_after, message_cycles_lost) =
+                if canister_id.get() == self.metadata.own_subnet_id.get() {
+                    // Shed from the subnet queues.
+                    let (message_shed, message_cycles_lost) = self
+                        .subnet_queues
+                        .shed_largest_message(&canister_id, &self.canister_states, metrics);
+                    let memory_usage_after =
+                        (self.subnet_queues.best_effort_message_memory_usage() as u64).into();
+                    (message_shed, memory_usage_after, message_cycles_lost)
+                } else {
+                    // Shed from a canister's queues: remove the canister, shed its largest message,
+                    // replace it.
+                    let mut canister = self.canister_states.remove(&canister_id).unwrap();
+                    let (message_shed, message_cycles_lost) = canister
+                        .system_state
+                        .shed_largest_message(&canister_id, &self.canister_states, metrics);
+                    let memory_usage_after =
+                        canister.system_state.best_effort_message_memory_usage();
+                    self.canister_states.insert(canister_id, canister);
+                    (message_shed, memory_usage_after, message_cycles_lost)
+                };
             debug_assert!(message_shed);
 
             // Replace the canister in the priority queue iff its memory usage is still
@@ -1243,13 +1241,11 @@ impl ReplicatedState {
             debug_assert!(memory_usage_before > memory_usage_after);
             let memory_usage_delta = memory_usage_before - memory_usage_after;
             memory_usage -= memory_usage_delta;
-
-            shed_messages += message_shed as u64;
-            shed_message_bytes += memory_usage_delta;
-            cycles_lost += message_cycles_lost;
             debug_assert_eq!(self.best_effort_message_memory_taken(), memory_usage);
+
+            cycles_lost += message_cycles_lost;
         }
-        (shed_messages, shed_message_bytes, cycles_lost)
+        cycles_lost
     }
 
     /// Adds a new snapshot to the list of snapshots.

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -22,7 +22,9 @@ use ic_replicated_state::replicated_state::testing::ReplicatedStateTesting;
 use ic_replicated_state::replicated_state::{
     MemoryTaken, PeekableOutputIterator, ReplicatedStateMessageRouting,
 };
-use ic_replicated_state::testing::{CanisterQueuesTesting, SystemStateTesting};
+use ic_replicated_state::testing::{
+    CanisterQueuesTesting, FakeDropMessageMetrics, SystemStateTesting,
+};
 use ic_replicated_state::{
     CanisterState, IngressHistoryState, InputSource, ReplicatedState, SchedulerState, StateError,
     SystemState,
@@ -102,6 +104,13 @@ fn best_effort_response_to(canister_id: CanisterId) -> Response {
         .originator(canister_id)
         .deadline(SOME_DEADLINE)
         .build()
+}
+
+fn time_out_messages(state: &mut ReplicatedState) -> (usize, Cycles) {
+    let metrics = FakeDropMessageMetrics::default();
+    let lost_cycles = state.time_out_messages(&metrics);
+    let timed_out_messages = metrics.timed_out_messages.borrow().values().sum();
+    (timed_out_messages, lost_cycles)
 }
 
 /// Fixture using `SUBNET_ID` as its own subnet id and `CANISTER_ID` as the id
@@ -246,6 +255,24 @@ impl ReplicatedStateFixture {
             .system_state
             .queues()
             .local_sender_schedule()
+    }
+
+    fn time_out_messages(&mut self) -> (usize, Cycles) {
+        time_out_messages(&mut self.state)
+    }
+
+    fn enforce_best_effort_message_limit(&mut self, limit: NumBytes) -> (usize, NumBytes, Cycles) {
+        let metrics = FakeDropMessageMetrics::default();
+        let lost_cycles = self
+            .state
+            .enforce_best_effort_message_limit(limit, &metrics);
+        let shed_messages = metrics.shed_messages.borrow().values().sum();
+        let shed_message_bytes: usize = metrics.shed_message_bytes.borrow().values().sum();
+        (
+            shed_messages,
+            (shed_message_bytes as u64).into(),
+            lost_cycles,
+        )
     }
 }
 
@@ -842,7 +869,7 @@ fn time_out_messages_updates_subnet_input_schedules_correctly() {
 
     // Time out everything, then check that subnet input schedules are as expected.
     fixture.state.metadata.batch_time = Time::from_nanos_since_unix_epoch(u64::MAX);
-    assert_eq!((3, Cycles::zero()), fixture.state.time_out_messages());
+    assert_eq!((3, Cycles::zero()), fixture.time_out_messages());
 
     assert_eq!(2, fixture.local_subnet_input_schedule(&CANISTER_ID).len());
     for canister_id in [CANISTER_ID, OTHER_CANISTER_ID] {
@@ -873,7 +900,7 @@ fn time_out_messages_in_subnet_queues() {
     // Time out the first request.
     let second_request_deadline = CoarseTime::from_secs_since_unix_epoch(1001);
     fixture.state.metadata.batch_time = second_request_deadline.into();
-    assert_eq!((1, Cycles::new(13)), fixture.state.time_out_messages());
+    assert_eq!((1, Cycles::new(13)), fixture.time_out_messages());
 
     // Second request should still be in the queue.
     assert_matches!(
@@ -906,17 +933,13 @@ fn enforce_best_effort_message_limit() {
 
     assert_eq!(
         (0, 0.into(), Cycles::zero()),
-        fixture
-            .state
-            .enforce_best_effort_message_limit(u64::MAX.into()),
+        fixture.enforce_best_effort_message_limit(u64::MAX.into()),
     );
 
     let best_effort_memory_usage = fixture.state.best_effort_message_memory_taken();
     assert_eq!(
         (0, 0.into(), Cycles::zero()),
-        fixture
-            .state
-            .enforce_best_effort_message_limit(best_effort_memory_usage),
+        fixture.enforce_best_effort_message_limit(best_effort_memory_usage),
     );
 
     // Enforce a limit equal to the mean message size. This should shed everything
@@ -928,17 +951,13 @@ fn enforce_best_effort_message_limit() {
             message_sizes[1] + message_sizes[2] + message_sizes[3],
             Cycles::new((1 << 1) + (1 << 2) + (1 << 3))
         ),
-        fixture
-            .state
-            .enforce_best_effort_message_limit(mean_message_size),
+        fixture.enforce_best_effort_message_limit(mean_message_size),
     );
 
     // A second identical call should be a no-op.
     assert_eq!(
         (0, 0.into(), Cycles::zero()),
-        fixture
-            .state
-            .enforce_best_effort_message_limit(mean_message_size),
+        fixture.enforce_best_effort_message_limit(mean_message_size),
     );
 
     // Pop the remaining message.
@@ -1436,7 +1455,7 @@ fn iter_with_stale_entries_terminates(
     const NANOS_PER_SEC: u64 = 1_000_000_000;
     replicated_state.metadata.batch_time =
         Time::from_nanos_since_unix_epoch(batch_time_seconds as u64 * NANOS_PER_SEC);
-    let timed_out_messages = replicated_state.time_out_messages().0;
+    let timed_out_messages = time_out_messages(&mut replicated_state).0;
 
     // Just consume all output messages.
     //
@@ -1464,7 +1483,7 @@ fn peek_next_loop_with_stale_entries_terminates(
     const NANOS_PER_SEC: u64 = 1_000_000_000;
     replicated_state.metadata.batch_time =
         Time::from_nanos_since_unix_epoch(batch_time_seconds as u64 * NANOS_PER_SEC);
-    let timed_out_messages = replicated_state.time_out_messages().0;
+    let timed_out_messages = time_out_messages(&mut replicated_state).0;
 
     let mut output_iter = replicated_state.output_into_iter();
 


### PR DESCRIPTION
Add `kind` / `context` / `class` labels as appropriate to timed out and and shed message metrics, to better track where and when messages are being dropped.