### PR TITLE
feat(nns): Consider neurons with maturity disbursements as non empty

### DIFF
--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -1136,6 +1136,11 @@ impl Neuron {
         self.known_neuron_data = None;
     }
 
+    /// Returns whether this neuron has a maturity disbursement in progress.
+    pub fn has_maturity_disbursement_in_progress(&self) -> bool {
+        !self.maturity_disbursements_in_progress.is_empty()
+    }
+
     /// Adds a maturity disbursement in progress at the end.
     pub fn add_maturity_disbursement_in_progress(
         &mut self,

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -1029,8 +1029,15 @@ impl NeuronStore {
         caller: PrincipalId,
     ) -> BTreeSet<NeuronId> {
         let is_non_empty = |neuron_id: &NeuronId| {
-            self.with_neuron_sections(neuron_id, NeuronSections::NONE, |neuron| neuron.is_funded())
-                .unwrap_or(false)
+            self.with_neuron_sections(
+                neuron_id,
+                NeuronSections {
+                    maturity_disbursements: true,
+                    ..NeuronSections::NONE
+                },
+                |neuron| neuron.is_funded() || neuron.has_maturity_disbursement_in_progress(),
+            )
+            .unwrap_or(false)
         };
 
         self.get_neuron_ids_readable_by_caller(caller)

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -711,24 +711,31 @@ fn test_get_non_empty_neuron_ids_readable_by_caller() {
     let neuron_with_staked_maturity = neuron_builder(5)
         .with_staked_maturity_e8s_equivalent(1)
         .build();
+    let neuron_with_maturity_disbursement = neuron_builder(6)
+        .with_maturity_disbursements_in_progress(vec![MaturityDisbursement {
+            finalize_disbursement_timestamp_seconds: 1,
+            ..Default::default()
+        }])
+        .build();
     let neuron_store = NeuronStore::new(btreemap! {
         1 => neuron_empty,
         2 => neuron_empty_with_fees,
         3 => neuron_with_stake,
         4 => neuron_with_maturity,
         5 => neuron_with_staked_maturity,
+        6 => neuron_with_maturity_disbursement,
     });
 
     assert_eq!(
         neuron_store.get_non_empty_neuron_ids_readable_by_caller(controller),
-        btreeset! { 3, 4, 5 }
+        btreeset! { 3, 4, 5, 6 }
             .into_iter()
             .map(NeuronId::from_u64)
             .collect()
     );
     assert_eq!(
         neuron_store.get_non_empty_neuron_ids_readable_by_caller(hot_key),
-        btreeset! { 3, 4, 5 }
+        btreeset! { 3, 4, 5, 6 }
             .into_iter()
             .map(NeuronId::from_u64)
             .collect()


### PR DESCRIPTION
When a neuron has maturity disbursement in progress, it should not be considered "empty" when listing neurons, since it still has some form of maturity in it.
