### PR TITLE
refactor(nns): Stop validating heap neurons

### DIFF
--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -706,14 +706,6 @@ impl NeuronStore {
         self.heap_neurons.range(range).map(|(_, neuron)| neuron)
     }
 
-    // TODO remove this after we no longer need to validate neurons in heap.
-    /// Returns an iterator over all neurons in the heap. There is no guarantee that the active
-    /// neurons are all in the heap as they are being migrated to stable memory, so the caller
-    /// should be aware of different storage locations.
-    pub fn heap_neurons_iter(&self) -> impl Iterator<Item = &Neuron> {
-        self.heap_neurons.values()
-    }
-
     fn is_active_neurons_fund_neuron(neuron: &Neuron, now: u64) -> bool {
         !neuron.is_inactive(now) && neuron.is_a_neurons_fund_member()
     }


### PR DESCRIPTION
# Why

As heap_neurons no longer exist (migrated to stable memory), we can stop reading them in validation.

# What

* Stop checking heap neurons for cardinalities.
* Stop iterating through heap neurons when validating neurons in batch
* Clean up `NeuronStore::heap_neurons_iter()` 