### PR TITLE
test(ICRC_Ledger): FI-1719: Skip FuelEV in ICRC SNS golden state test

### DIFF
--- a/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
+++ b/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
@@ -864,7 +864,7 @@ fn should_upgrade_icrc_sns_canisters_with_golden_state() {
         ELNAAI_LEDGER_SUITE,
         ESTATEDAO_LEDGER_SUITE,
         FOMOWELL_LEDGER_SUITE,
-        FUEL_EV_LEDGER_SUITE,
+        // FUEL_EV_LEDGER_SUITE, // Skipping FuelEV for now, as the index canister was uninstalled
         GOLDDAO_LEDGER_SUITE,
         ICGHOST_LEDGER_SUITE,
         ICLIGHTHOUSE_LEDGER_SUITE,

--- a/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
+++ b/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
@@ -730,11 +730,11 @@ fn should_upgrade_icrc_sns_canisters_with_golden_state() {
         "os3ua-lqaaa-aaaaq-aaefq-cai",
         "FomoWell",
     );
-    const FUEL_EV_LEDGER_SUITE: (&str, &str, &str) = (
-        "nfjys-2iaaa-aaaaq-aaena-cai",
-        "nxppl-wyaaa-aaaaq-aaeoa-cai",
-        "FuelEV",
-    );
+    // const FUEL_EV_LEDGER_SUITE: (&str, &str, &str) = (
+    //     "nfjys-2iaaa-aaaaq-aaena-cai",
+    //     "nxppl-wyaaa-aaaaq-aaeoa-cai",
+    //     "FuelEV",
+    // );
     const GOLDDAO_LEDGER_SUITE: (&str, &str, &str) = (
         "tyyy3-4aaaa-aaaaq-aab7a-cai",
         "efv5g-kqaaa-aaaaq-aacaa-cai",


### PR DESCRIPTION
Skip the FuelEV SNS in the ICRC golden state test since the ledger index canister ran out of cycles and was uninstalled.