### PR TITLE
fix(crypto): use production subnet size and threshold in vetKD crypto library tests

### DIFF
--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
@@ -300,7 +300,7 @@ fn test_protocol_execution() {
     let rng = &mut reproducible_rng();
 
     let nodes = 31;
-    let threshold = 11;
+    let threshold = 21;
 
     let setup = VetkdTestProtocolSetup::new(rng, nodes, threshold);
     let proto = VetkdTestProtocolExecution::new(rng, &setup);

--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
@@ -299,8 +299,8 @@ fn random_subset<R: rand::Rng, T: Clone>(rng: &mut R, items: &[T], include: usiz
 fn test_protocol_execution() {
     let rng = &mut reproducible_rng();
 
-    let nodes = 31;
-    let threshold = 21;
+    let nodes = 34;
+    let threshold = 23;
 
     let setup = VetkdTestProtocolSetup::new(rng, nodes, threshold);
     let proto = VetkdTestProtocolExecution::new(rng, &setup);


### PR DESCRIPTION
Adapts the integration tests of the vetKD crypto library (`ic-crypto-internal-bls12-381-vetkd`) to use
* the size of the subnet on which the vetKD produciton key will be deployed (34 nodes)
* the threshold that is used in production (high threshold: 2/3 of 34, i.e., 23)

This is to address an informational finding of an internal security review.