### PR TITLE
perf: EXC-2033: Add more heap benchmarks

### DIFF
--- a/rs/embedders/benches/embedders_bench/src/lib.rs
+++ b/rs/embedders/benches/embedders_bench/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
 #[derive(Copy, Clone)]
 pub enum SetupAction {
     PerformCheckpoint,
+    PerformCheckpointCallSetup,
     None,
 }
 
@@ -78,6 +79,11 @@ fn initialize_execution_test(
         SetupAction::PerformCheckpoint => {
             test.checkpoint_canister_memories();
         }
+        SetupAction::PerformCheckpointCallSetup => {
+            test.checkpoint_canister_memories();
+            test.ingress(canister_id, "setup", Encode!(&()).unwrap())
+                .unwrap();
+        }
         SetupAction::None => {}
     }
 
@@ -122,6 +128,11 @@ pub fn update_bench(
                 match setup_action {
                     SetupAction::PerformCheckpoint => {
                         test.checkpoint_canister_memories();
+                    }
+                    SetupAction::PerformCheckpointCallSetup => {
+                        panic!(
+                            "Error executing `update_bench()`, use `update_bench_once()` instead"
+                        );
                     }
                     SetupAction::None => {}
                 }

--- a/rs/embedders/benches/heap.rs
+++ b/rs/embedders/benches/heap.rs
@@ -97,7 +97,7 @@ fn setup_action(src: Src) -> SetupAction {
 
 /// Generates a Wasm code snippet for the specified operation and memory type.
 ///
-/// The operation is suppose to read or write a single byte from the heap memory
+/// The operation is intended to read or write a single byte from heap memory
 /// using a predefined 64-bit local variable `$address`.
 fn heap_op(op: Op, mem: Mem) -> String {
     match (op, mem) {
@@ -234,11 +234,13 @@ fn bench(c: &mut C, mem: Mem, call: Call, op: Op, dir: Dir, size: Size, step: St
     let bench_setup_body = bench_setup_body(mem, dir, size, src);
     let memory_body = heap_memory_body(mem, size, src);
     // The overall benchmark structure is:
-    // 1. `canister_init` function is executed during the canister installation.
-    // 2. `canister_update setup` function is executed before the benchmark call.
-    // 3. `canister_update update_empty` function is executed to sync the memory.
-    // 4. `canister_{call} {name}` benchmark function is executed and its total
-    //     execution time is the benchmark result.
+    // 1. The `canister_init` function is executed during canister installation.
+    // 2. Optionally: A checkpoint is created.
+    // 3. Optionally: The `canister_update setup` function is executed.
+    // 4. The `canister_update update_empty` function is executed to sync the memory
+    //    between the replica and the sandbox process.
+    // 5. The `canister_{call} {name}` benchmark function is executed, and its total
+    //    execution time is the benchmark result.
     let wat = format!(
         r#"
         (module

--- a/rs/embedders/benches/heap.rs
+++ b/rs/embedders/benches/heap.rs
@@ -117,6 +117,11 @@ fn heap_func_init_body(mem: Mem, size: Size, src: Src) -> String {
     }
 }
 
+/// Wraps an operation `op` into a loop body that iterates over the heap memory
+/// of the specified size. The first iteration starts at the `offset` from
+/// the beginning or the end of the memory depending on the direction.
+/// Then each iteration is performed every `step` until the end or the beginning
+/// of the memory is reached.
 fn loop_body(op: &str, dir: Dir, offset: usize, size: Size, step: Step) -> String {
     let step = step as usize;
     match dir {

--- a/rs/embedders/benches/heap.rs
+++ b/rs/embedders/benches/heap.rs
@@ -1,3 +1,11 @@
+//! This benchmark runs periodically in CI, and the results are available in Grafana.
+//! See: `schedule-rust-bench.yml`
+//!
+//! To run the benchmark locally:
+//!
+//! ```shell
+//! bazel run //rs/embedders:heap_bench
+//! ```
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use embedders_bench::SetupAction;
 use ic_replicated_state::canister_state::WASM_PAGE_SIZE_IN_BYTES;
@@ -28,27 +36,36 @@ enum Op {
 }
 
 #[derive(Copy, Clone, Display, EnumIter)]
+#[strum(serialize_all = "snake_case")]
 enum Dir {
-    #[strum(serialize = "fwd")]
-    Forward,
-    #[strum(serialize = "bwd")]
-    Backward,
+    Fwd,
+    Bwd,
 }
 
 #[derive(Copy, Clone, Display, EnumIter)]
 enum Size {
-    #[strum(serialize = "1gb")]
-    Gigabyte = 1024 * 1024 * 1024,
+    // One tenth of a gigabyte.
+    // The results do not scale linearly 10x to 1 GiB. Some benchmarks regress ~15x,
+    // while others regress ~5x. Yet, it is still a good approximation for the sake of
+    // benchmarking speed.
+    #[strum(serialize = "102m")]
+    Gigabyte = 102 * 1024 * 1024,
 }
 
 #[derive(Copy, Clone, Display, EnumIter)]
 enum Step {
-    #[strum(serialize = "step_8")]
-    Small = 8,
-    #[strum(serialize = "step_4kb")]
-    Page = 4096,
-    #[strum(serialize = "step_16kb")]
-    FourPages = 16384,
+    #[strum(serialize = "step_4k")]
+    Page = PAGE_SIZE as isize,
+    #[strum(serialize = "step_8k")]
+    TwoPages = 2 * PAGE_SIZE as isize,
+    #[strum(serialize = "step_64k")]
+    WasmPage = WASM_PAGE_SIZE_IN_BYTES as isize,
+    #[strum(serialize = "step_128k")]
+    TwoWasmPages = 2 * WASM_PAGE_SIZE_IN_BYTES as isize,
+    #[strum(serialize = "step_2m")]
+    HugePage = 2 * 1024 * 1024,
+    #[strum(serialize = "step_4m")]
+    TwoHugePages = 2 * 2 * 1024 * 1024,
 }
 
 #[derive(Copy, Clone, Display, EnumIter)]
@@ -56,6 +73,7 @@ enum Step {
 enum Src {
     Checkpoint,
     PageDelta,
+    Mix,
     NewAllocation,
 }
 
@@ -72,57 +90,69 @@ fn throughput(size: Size, step: Step) -> Option<Throughput> {
 fn setup_action(src: Src) -> SetupAction {
     match src {
         Src::Checkpoint => SetupAction::PerformCheckpoint,
+        Src::Mix => SetupAction::PerformCheckpointCallSetup,
         Src::PageDelta | Src::NewAllocation => SetupAction::None,
     }
 }
 
-fn heap_op(op: Op) -> String {
-    match op {
-        Op::Read => "(drop (i64.load (local.get $address)))".into(),
-        Op::Write => "(i64.store (local.get $address) (global.get $counter))".into(),
+fn heap_op(op: Op, mem: Mem) -> String {
+    match (op, mem) {
+        (Op::Read, Mem::Wasm32) => {
+            "(global.set $data (i64.load8_u (i32.wrap_i64 (local.get $address))))"
+        }
+        (Op::Read, Mem::Wasm64) => "(global.set $data (i64.load8_u (local.get $address)))",
+        (Op::Write, Mem::Wasm32) => {
+            "(i64.store8 (i32.wrap_i64 (local.get $address)) (global.get $counter))"
+        }
+        (Op::Write, Mem::Wasm64) => "(i64.store8 (local.get $address) (global.get $counter))",
     }
+    .into()
 }
 
 fn heap_func_init_body(mem: Mem, size: Size, src: Src) -> String {
     let wasm_pages = (size as usize).div_ceil(WASM_PAGE_SIZE_IN_BYTES);
     match src {
-        Src::Checkpoint | Src::PageDelta => String::new(),
+        Src::Checkpoint | Src::PageDelta | Src::Mix => String::new(),
         Src::NewAllocation => format!("(drop (memory.grow (i{mem}.const {wasm_pages})))"),
     }
 }
 
-fn loop_body(op: &str, mem: Mem, dir: Dir, size: Size, step: Step) -> String {
-    let size = size as usize;
+fn loop_body(op: &str, dir: Dir, initial_offset: usize, size: Size, step: Step) -> String {
     let step = step as usize;
+    let end = size as usize - 1;
     match dir {
-        Dir::Forward => format!(
-            r#"
-                (local.set $address (i{mem}.const 0))
+        Dir::Fwd => {
+            format!(
+                r#"
+                (local.set $address (i64.const {initial_offset}))
                 (loop $loop
                     {op}
-                    (local.set $address (i{mem}.add (local.get $address) (i{mem}.const {step})))
-                    (br_if $loop (i{mem}.lt_u (local.get $address) (i{mem}.const {size})))
+                    (local.set $address (i64.add (local.get $address) (i64.const {step})))
+                    (br_if $loop (i64.le_s (local.get $address) (i64.const {end})))
                 )
             "#
-        ),
-        Dir::Backward => format!(
-            r#"
-                (local.set $address (i{mem}.const {size}))
+            )
+        }
+        Dir::Bwd => {
+            format!(
+                r#"
+                (local.set $address (i64.const {end}))
                 (loop $loop
-                    (local.set $address (i{mem}.sub (local.get $address) (i{mem}.const {step})))
                     {op}
-                    (br_if $loop (i{mem}.gt_s (local.get $address) (i{mem}.const 0)))
+                    (local.set $address (i64.sub (local.get $address) (i64.const {step})))
+                    (br_if $loop (i64.ge_s (local.get $address) (i64.const {initial_offset})))
                 )
             "#
-        ),
+            )
+        }
     }
 }
 
 fn heap_canister_init_body(mem: Mem, size: Size, src: Src) -> String {
-    let op = "(i64.store (local.get $address) (i64.const 1))";
-    let loop_body = loop_body(op, mem, Dir::Forward, size, Step::Page);
+    let op = heap_op(Op::Write, mem);
+    let loop_body = loop_body(&op, Dir::Fwd, 4096, size, Step::TwoPages);
     match src {
-        Src::Checkpoint | Src::PageDelta => format!(
+        Src::Checkpoint | Src::PageDelta | Src::Mix => format!(
             r#"
                 {loop_body}
             "#
@@ -131,10 +161,23 @@ fn heap_canister_init_body(mem: Mem, size: Size, src: Src) -> String {
     }
 }
 
+fn heap_canister_setup_body(mem: Mem, size: Size, src: Src) -> String {
+    let op = heap_op(Op::Write, mem);
+    let loop_body = loop_body(&op, Dir::Fwd, PAGE_SIZE, size, Step::TwoPages);
+    match src {
+        Src::Mix => format!(
+            r#"
+                {loop_body}
+            "#
+        ),
+        Src::Checkpoint | Src::PageDelta | Src::NewAllocation => String::new(),
+    }
+}
+
 fn heap_memory_body(mem: Mem, size: Size, src: Src) -> String {
     let wasm_pages = (size as usize).div_ceil(WASM_PAGE_SIZE_IN_BYTES);
     match src {
-        Src::Checkpoint | Src::PageDelta => format!("i{mem} {wasm_pages}"),
+        Src::Checkpoint | Src::PageDelta | Src::Mix => format!("i{mem} {wasm_pages}"),
         Src::NewAllocation => format!("i{mem} 0"),
     }
 }
@@ -146,34 +189,44 @@ fn bench(c: &mut C, mem: Mem, call: Call, op: Op, dir: Dir, size: Size, step: St
     let throughput = throughput(size, step);
     let setup_action = setup_action(src);
 
-    let op = heap_op(op);
     let func_init_body = heap_func_init_body(mem, size, src);
-    let loop_body = loop_body(&op, mem, dir, size, step);
+    let op = heap_op(op, mem);
+    let loop_body = loop_body(&op, dir, 0, size, step);
     let canister_init_body = heap_canister_init_body(mem, size, src);
+    let canister_setup_body = heap_canister_setup_body(mem, size, src);
     let memory_body = heap_memory_body(mem, size, src);
     let wat = format!(
         r#"
         (module
-            (import "ic0" "msg_reply" (func $ic0_msg_reply))
+            (import "ic0" "msg_reply" (func $msg_reply))
             (global $counter (mut i64) (i64.const 42))
+            (global $data (mut i64) (i64.const 0))
             (func (export "canister_update update_empty")
-                (call $ic0_msg_reply)
+                (call $msg_reply)
+            )
+            (func (export "canister_init")
+                (local $address i64)
+                (global.set $counter (i64.add (global.get $counter) (i64.const 1)))
+                {canister_init_body}
+            )
+            (func (export "canister_update setup")
+                (local $address i64)
+                (global.set $counter (i64.add (global.get $counter) (i64.const 1)))
+                {canister_setup_body}
+                (call $msg_reply)
             )
             (func (export "canister_{call} {name}")
-                (local $address i{mem})
+                (local $address i64)
                 (global.set $counter (i64.add (global.get $counter) (i64.const 1)))
                 {func_init_body}
                 {loop_body}
-                (call $ic0_msg_reply)
-            )
-            (func (export "canister_init")
-                (local $address i{mem})
-                {canister_init_body}
+                (call $msg_reply)
             )
             (memory {memory_body})
         )"#
     );
-    let wasm = wat::parse_str(&wat).unwrap_or_else(|_| panic!("Error parsing WAT: {wat}"));
+    let wasm =
+        wat::parse_str(&wat).unwrap_or_else(|err| panic!("Error parsing WAT: {err}\nWAT: {wat}"));
     match call {
         Call::Query => embedders_bench::query_bench(
             c,
@@ -202,7 +255,7 @@ fn bench(c: &mut C, mem: Mem, call: Call, op: Op, dir: Dir, size: Size, step: St
             // Executing page delta benchmarks only once yields more consistent results,
             // as they depend on the page delta size.
             // New allocation benchmarks are only meaningful when run once.
-            Src::PageDelta | Src::NewAllocation => embedders_bench::update_bench_once(
+            Src::PageDelta | Src::Mix | Src::NewAllocation => embedders_bench::update_bench_once(
                 c,
                 "embedders:heap/update",
                 &name,


### PR DESCRIPTION
This PR introduces additional heap benchmark dimensions:

1. One OS page step (4 KiB)
2. Two OS pages step (8 KiB).
3. One Wasm page step (64 KiB)
4. Two Wasm pages step (128 KiB)
5. One huge page step (2 MiB)
6. Two huge pages step (4 MiB)
7. A new mixed source of pages: a combination of checkpoint and heap delta.

The 8-byte step benchmark has been removed as its behavior is effectively
the same as a page step (with potentially a few more instructions to access
the same page).

Furthermore, this PR aims to resolve all memory access corner cases
by consistently using 64-bit addresses and converting them to 32-bit
only immediately before accessing the page. This approach should address
all previous issues related to verifying if an address falls within
the working set range.

Also, the PR reduces the working set by 10x, so the benchmarks run 5x faster.