### PR TITLE
chore: Unify message class label values

### DIFF
--- a/rs/execution_environment/src/metrics.rs
+++ b/rs/execution_environment/src/metrics.rs
@@ -19,8 +19,8 @@ pub(crate) const SYSTEM_API_CANISTER_CYCLE_BALANCE128: &str = "canister_cycle_ba
 pub(crate) const SYSTEM_API_TIME: &str = "time";
 
 const LABEL_CLASS: &str = "class";
-const LABEL_VALUE_BEST_EFFORT: &str = "best_effort";
-const LABEL_VALUE_GUARANTEED_RESPONSE: &str = "guaranteed_response";
+const LABEL_VALUE_BEST_EFFORT: &str = "best-effort";
+const LABEL_VALUE_GUARANTEED_RESPONSE: &str = "guaranteed response";
 
 pub const SUCCESS_STATUS_LABEL: &str = "success";
 

--- a/rs/messaging/tests/call_tree_tests.rs
+++ b/rs/messaging/tests/call_tree_tests.rs
@@ -95,7 +95,7 @@ impl CallTreeTestFixture {
 
             assert_eq!(
                 metric_vec(&[(
-                    &[("class", "guaranteed_response")],
+                    &[("class", "guaranteed response")],
                     HistogramStats {
                         count: state.call_count,
                         sum: state.depth_total as f64


### PR DESCRIPTION
Use the same `class` label values ("best-effort" and "guaranteed response") across MR and Execution metrics.