### PR TITLE
feat(PSEC-2502): move dep-scan periodic job to different repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,6 +78,7 @@ go_deps.bzl               @dfinity/idx
 /.github/workflows/rosetta-release.yml                                   @dfinity/finint @dfinity/idx
 /.github/CODEOWNERS                                                      @dfinity/ic-owners-owners
 /ci/                                                                     @dfinity/idx
+/ci/actions/dependencies/                                                @dfinity/product-security
 /ci/src/dependencies/                                                    @dfinity/product-security
 /ci/src/dependencies/resources/container_scanner_finding_failover_ignore_list_guestos.txt @dfinity/node
 /ci/tools/repro-check                                                    @dfinity/dre

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -134,6 +134,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
 
   dependency-scan-nightly:
+    if: false
     name: Dependency Scan Nightly
     <<: *dind-large-setup
     timeout-minutes: 60

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -133,6 +133,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
   dependency-scan-nightly:
+    if: false
     name: Dependency Scan Nightly
     runs-on:
       group: zh1

--- a/ci/actions/dependencies/periodic/action.yml
+++ b/ci/actions/dependencies/periodic/action.yml
@@ -1,0 +1,47 @@
+name: 'Dependency Scan Nightly'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Setup environment deps
+      id: setup-environment-deps
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../../..
+      run: |
+        # this is needed to get more free space on the runner, otherwise might run OOM when building icOS
+        rm -rf /opt/hostedtoolcache
+        # Ignore externally-managed-environment pip error, install packages system-wide.
+        PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --ignore-installed -r requirements.txt
+        cargo install cargo-audit --version "${CARGO_AUDIT_VERSION}"
+        cargo install wasm-pack --version "${CARGO_WASMPACK_VERSION}"
+        source "${NVM_DIR}/nvm.sh"
+        nvm install ${NNS_NODE_VERSION}
+        nvm install ${DEFAULT_NODE_VERSION}
+        nvm install ${OISY_NODE_VERSION}
+        nvm use ${DEFAULT_NODE_VERSION}
+        node --version
+        npm --version
+      env:
+        CARGO_AUDIT_VERSION: "0.21.0"
+        CARGO_WASMPACK_VERSION: "0.12.1"
+        NNS_NODE_VERSION: "18.20.5"
+        DEFAULT_NODE_VERSION: "20"
+        OISY_NODE_VERSION: "22.11.0"
+    - name: Run Dependency Scan Nightly
+      id: dependency-scan-nightly
+      shell: bash
+      working-directory: ${{ github.action_path }}/../../../..
+      run: |
+        set -euo pipefail
+        export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
+        cd ci/src/dependencies/
+        cp -a $GITHUB_WORKSPACE/config/. config/
+        $SHELL_WRAPPER python3 job/bazel_rust_ic_scanner_periodic_job.py
+        $SHELL_WRAPPER python3 job/npm_scanner_periodic_job.py
+        $SHELL_WRAPPER python3 job/bazel_trivy_container_ic_scanner_periodic_job.py
+      env:
+        SHELL_WRAPPER: "/usr/bin/time"
+        CI_PIPELINE_ID: ${{ github.run_id }}

--- a/ci/src/dependencies/config/bazel_rust_periodic.py
+++ b/ci/src/dependencies/config/bazel_rust_periodic.py
@@ -1,0 +1,1 @@
+REPOS_TO_SCAN = []

--- a/ci/src/dependencies/config/bazel_trivy_periodic.py
+++ b/ci/src/dependencies/config/bazel_trivy_periodic.py
@@ -1,0 +1,1 @@
+REPOS_TO_SCAN = []

--- a/ci/src/dependencies/config/npm_periodic.py
+++ b/ci/src/dependencies/config/npm_periodic.py
@@ -1,0 +1,1 @@
+REPOS_TO_SCAN = []

--- a/ci/src/dependencies/job/bazel_rust_ic_scanner_periodic_job.py
+++ b/ci/src/dependencies/job/bazel_rust_ic_scanner_periodic_job.py
@@ -1,80 +1,20 @@
 import logging
 
+from config.bazel_rust_periodic import REPOS_TO_SCAN
 from data_source.jira_finding_data_source import JiraFindingDataSource
 from model.ic import (
     get_ic_repo_ci_pipeline_base_url,
-    get_ic_repo_for_rust,
     get_ic_repo_merge_request_base_url,
-    is_env_for_periodic_job,
 )
-from model.project import Project
-from model.repository import Repository
-from model.team import Team
 from notification.notification_config import NotificationConfig
 from notification.notification_creator import NotificationCreator
 from scanner.dependency_scanner import DependencyScanner
 from scanner.manager.bazel_rust_dependency_manager import BazelRustDependencyManager
 from scanner.scanner_job_type import ScannerJobType
 
-REPOS_TO_SCAN = [
-    Repository(
-        "nns-dapp",
-        "https://github.com/dfinity/nns-dapp",
-        [Project(name="nns-dapp", path="nns-dapp", owner=Team.NNS_TEAM)],
-    ),
-    Repository(
-        "internet-identity",
-        "https://github.com/dfinity/internet-identity",
-        [Project(name="internet-identity", path="internet-identity", owner=Team.IDENTITY_TEAM)],
-    ),
-    Repository(
-        "response-verification",
-        "https://github.com/dfinity/response-verification",
-        [Project(name="response-verification", path="response-verification", owner=Team.TRUST_TEAM)],
-    ),
-    Repository(
-        "canfund",
-        "https://github.com/dfinity/canfund",
-        [Project(name="canfund", path="canfund", owner=Team.TRUST_TEAM)],
-    ),
-    Repository(
-        "agent-rs",
-        "https://github.com/dfinity/agent-rs",
-        [Project(name="agent-rs", path="agent-rs", owner=Team.SDK_TEAM)],
-    ),
-    Repository(
-        "ic-canister-sig-creation",
-        "https://github.com/dfinity/ic-canister-sig-creation",
-        [Project(name="ic-canister-sig-creation", path="ic-canister-sig-creation", owner=Team.GIX_TEAM)],
-    ),
-    Repository(
-        "ic-gateway",
-        "https://github.com/dfinity/ic-gateway",
-        [Project(name="ic-gateway", path="ic-gateway", owner=Team.BOUNDARY_NODE_TEAM)],
-    ),
-    Repository(
-        "papi",
-        "https://github.com/dfinity/papi",
-        [Project(name="papi", path="papi", owner=Team.GIX_TEAM)],
-    ),
-    Repository(
-        "oisy-wallet",
-        "https://github.com/dfinity/oisy-wallet",
-        [Project(name="oisy-wallet", path="oisy-wallet", owner=Team.GIX_TEAM)],
-    ),
-    Repository(
-        "chain-fusion-signer",
-        "https://github.com/dfinity/chain-fusion-signer",
-        [Project(name="chain-fusion-signer", path="chain-fusion-signer", owner=Team.GIX_TEAM)],
-    ),
-]
-
 
 def main():
     logging.basicConfig(level=logging.WARNING)
-    if not is_env_for_periodic_job():
-        logging.warning("skipping periodic RUST job because it is run in the wrong environment")
-        return
 
     scanner_job = ScannerJobType.PERIODIC_SCAN
     notify_on_scan_job_succeeded, notify_on_scan_job_failed = {}, {}
@@ -103,7 +43,7 @@ def main():
         JiraFindingDataSource(finding_data_source_subscribers, app_owner_msg_subscriber=notifier),
         scanner_subscribers,
     )
-    scanner_job.do_periodic_scan([get_ic_repo_for_rust()] + REPOS_TO_SCAN)
+    scanner_job.do_periodic_scan(REPOS_TO_SCAN)
 
 
 if __name__ == "__main__":

--- a/ci/src/dependencies/job/bazel_trivy_container_ic_scanner_periodic_job.py
+++ b/ci/src/dependencies/job/bazel_trivy_container_ic_scanner_periodic_job.py
@@ -1,46 +1,20 @@
 import logging
 
+from config.bazel_trivy_periodic import REPOS_TO_SCAN
 from data_source.jira_finding_data_source import JiraFindingDataSource
 from data_source.slack_findings_failover_data_store import SlackFindingsFailoverDataStore
 from integration.slack.slack_default_notification_handler import SlackDefaultNotificationHandler
 from integration.slack.slack_trivy_finding_notification_handler import SlackTrivyFindingNotificationHandler
-from model.ic import get_ic_repo_ci_pipeline_base_url, get_ic_repo_merge_request_base_url, is_env_for_periodic_job
-from model.project import Project
-from model.repository import Repository
-from model.team import Team
+from model.ic import get_ic_repo_ci_pipeline_base_url, get_ic_repo_merge_request_base_url
 from notification.notification_config import NotificationConfig
 from notification.notification_creator import NotificationCreator
 from scanner.dependency_scanner import DependencyScanner
 from scanner.manager.bazel_trivy_dependency_manager import BazelTrivyContainer
 from scanner.scanner_job_type import ScannerJobType
 
-REPOS_TO_SCAN = [
-    Repository(
-        "ic",
-        "https://github.com/dfinity/ic",
-        [
-            Project(
-                name="boundary-guestos",
-                path="ic/ic-os/boundary-guestos/envs/prod",
-                link="https://github.com/dfinity/ic/tree/master/ic-os/boundary-guestos/context",
-                owner=Team.BOUNDARY_NODE_TEAM,
-            ),
-            Project(
-                name="guestos",
-                path="ic/ic-os/guestos/envs/prod",
-                link="https://github.com/dfinity/ic/tree/master/ic-os/guestos/context",
-                owner=Team.NODE_TEAM,
-            ),
-        ],
-    )
-]
-
 
 def main():
     logging.basicConfig(level=logging.WARNING)
-    if not is_env_for_periodic_job():
-        logging.warning("skipping periodic TRIVY job because it is run in the wrong environment")
-        return
 
     scanner_job = ScannerJobType.PERIODIC_SCAN
     notify_on_scan_job_succeeded, notify_on_scan_job_failed = {}, {}

--- a/ci/src/dependencies/job/npm_scanner_periodic_job.py
+++ b/ci/src/dependencies/job/npm_scanner_periodic_job.py
@@ -1,138 +1,17 @@
 import logging
 
+from config.npm_periodic import REPOS_TO_SCAN
 from data_source.jira_finding_data_source import JiraFindingDataSource
-from model.ic import get_ic_repo_ci_pipeline_base_url, get_ic_repo_merge_request_base_url, is_env_for_periodic_job
-from model.project import Project
-from model.repository import Repository
-from model.team import Team
+from model.ic import get_ic_repo_ci_pipeline_base_url, get_ic_repo_merge_request_base_url
 from notification.notification_config import NotificationConfig
 from notification.notification_creator import NotificationCreator
 from scanner.dependency_scanner import DependencyScanner
 from scanner.manager.npm_dependency_manager import NPMDependencyManager
 from scanner.scanner_job_type import ScannerJobType
 
-# node version used by default
-DEFAULT_NODE_VERSION = "20"
-
-REPOS_TO_SCAN = [
-    Repository(
-        "nns-dapp",
-        "https://github.com/dfinity/nns-dapp",
-        [
-            Project(
-                name="frontend",
-                path="nns-dapp/frontend",
-                owner=Team.NNS_TEAM,
-            )
-        ],
-        "18.20.5",
-    ),
-    Repository(
-        "internet-identity",
-        "https://github.com/dfinity/internet-identity",
-        [
-            Project(
-                name="internet-identity",
-                path="internet-identity",
-                owner=Team.IDENTITY_TEAM,
-            )
-        ],
-        DEFAULT_NODE_VERSION,
-    ),
-    Repository(
-        "ic-js",
-        "https://github.com/dfinity/ic-js",
-        [
-            Project(
-                name="ic-js",
-                path="ic-js",
-                owner=Team.GIX_TEAM,
-            )
-        ],
-        DEFAULT_NODE_VERSION,
-    ),
-    Repository(
-        "agent-js",
-        "https://github.com/dfinity/agent-js",
-        [
-            Project(
-                name="agent-js",
-                path="agent-js",
-                owner=Team.SDK_TEAM,
-            )
-        ],
-        DEFAULT_NODE_VERSION,
-    ),
-    Repository(
-        "hardware-wallet-cli",
-        "https://github.com/dfinity/hardware-wallet-cli",
-        [
-            Project(
-                name="hardware-wallet-cli",
-                path="hardware-wallet-cli",
-                owner=Team.IDENTITY_TEAM,
-            )
-        ],
-        DEFAULT_NODE_VERSION,
-    ),
-    Repository(
-        "gix-components",
-        "https://github.com/dfinity/gix-components",
-        [
-            Project(
-                name="gix-components",
-                path="gix-components",
-                owner=Team.GIX_TEAM,
-            )
-        ],
-        "18.20.5",
-    ),
-    Repository(
-        "oisy-wallet",
-        "https://github.com/dfinity/oisy-wallet",
-        [
-            Project(
-                name="oisy-wallet",
-                path="oisy-wallet",
-                owner=Team.GIX_TEAM,
-            )
-        ],
-        "22.11.0",
-    ),
-    Repository(
-        "chain-fusion-signer",
-        "https://github.com/dfinity/chain-fusion-signer",
-        [
-            Project(
-                name="chain-fusion-signer",
-                path="chain-fusion-signer",
-                owner=Team.GIX_TEAM,
-            )
-        ],
-        DEFAULT_NODE_VERSION,
-    ),
-    # Removing ic-docutrack temporarily since it supports
-    # only pnpm and not npm
-    # Repository(
-    #     "ic-docutrack",
-    #     "https://github.com/dfinity/ic-docutrack",
-    #     [
-    #         Project(
-    #             name="frontend",
-    #             path="ic-docutrack/frontend",
-    #             owner=Team.EXECUTION_TEAM,
-    #         )
-    #     ],
-    #     DEFAULT_NODE_VERSION,
-    # ),
-]
-
 
 def main():
     logging.basicConfig(level=logging.WARNING)
-    if not is_env_for_periodic_job():
-        logging.warning("skipping periodic NPM job because it is run in the wrong environment")
-        return
 
     scanner_job = ScannerJobType.PERIODIC_SCAN
     notify_on_scan_job_succeeded, notify_on_scan_job_failed = {}, {}

--- a/ci/src/dependencies/model/ic.py
+++ b/ci/src/dependencies/model/ic.py
@@ -4,21 +4,7 @@ from model.project import Project
 from model.repository import Repository
 from model.team import Team
 
-CI_PROJECT_PATH = os.environ.get("CI_PROJECT_PATH", "dfinity/ic")
-GITHUB_REF = os.environ.get("GITHUB_REF", "refs/heads/master")
 REPO_NAME = os.environ.get("REPO_NAME", "dfinity/ic")
-
-
-def is_running_in_ic_repo() -> bool:
-    return CI_PROJECT_PATH == "dfinity/ic"
-
-
-def is_running_on_main_branch() -> bool:
-    return GITHUB_REF == "refs/heads/master"
-
-
-def is_env_for_periodic_job() -> bool:
-    return is_running_in_ic_repo() and is_running_on_main_branch()
 
 
 def get_ic_repo_for_rust() -> Repository:

--- a/ci/src/dependencies/model/repository.py
+++ b/ci/src/dependencies/model/repository.py
@@ -23,5 +23,6 @@ class Repository:
         assert isinstance(self.projects, list) and len(self.projects) > 0
         assert self.engine_version is None or len(self.engine_version) > 0
 
-        for project in self.projects:
-            assert project.path.startswith(self.name)
+        if self.name != "ic":
+            for project in self.projects:
+                assert project.path.startswith(self.name)


### PR DESCRIPTION
We want to move the periodic dependency scan job to a private repo including the list of repositories which should be scanned. This allows us to securely scan private DFINITY repos such as caffeine.

The idea is to leave all code in the `ic` repo and define a composite action there, which can be invoked from another repo. The MR and release scan jobs will continue to run in the `ic` repo.

This PR makes the required adjustments to the `ic` repo:

- disable "Dependency Scan Nightly" (will be removed later)
- define a composite action under `ci/actions/dependencies/periodic/action.yml`
- remove the list of repositories which should be scanned