### PR TITLE
chore(IDX): add os_info repository rule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -833,3 +833,7 @@ mainnet_icos_versions(
     name = "mainnet_icos_versions",
     path = "//:mainnet-icos-revisions.json",
 )
+
+os_info = use_repo_rule("//bazel:os_info.bzl", "os_info")
+
+os_info(name = "os_info")

--- a/bazel/os_info.bzl
+++ b/bazel/os_info.bzl
@@ -1,0 +1,28 @@
+"""
+The module exports information on the OS in like "x86_64-linux"
+"""
+
+def _os_info_impl(repository_ctx):
+    # Figure out the arch
+    os_arch = repository_ctx.os.arch
+    is_x86_64 = os_arch == "x86" or os_arch == "x86_64" or os_arch == "amd64"
+    is_arm_64 = os_arch == "arm" or os_arch == "arm64" or os_arch == "aarch64"
+
+    # Figure out the OS
+    os_name = repository_ctx.os.name
+    is_linux = os_name.lower().startswith("linux")
+    is_darwin = os_name.lower().startswith("mac")
+
+    os_arch = "x86_64" if is_x86_64 else "arm64" if is_arm_64 else "unknown"
+    os_name = "linux" if is_linux else "darwin" if is_darwin else "unknown"
+
+    os_info = os_arch + "-" + os_name
+
+    # Create a minimal BUILD.bazel file (Bazel requires it)
+    repository_ctx.file("BUILD.bazel", content = "\n")
+    repository_ctx.file("defs.bzl", "os_info = \"{}\"".format(os_info))
+
+os_info = repository_rule(
+    implementation = _os_info_impl,
+    attrs = {},
+)

--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@os_info//:defs.bzl", "os_info")
 load("//bazel:defs.bzl", "gzip_compress")
 load("//ci/src/artifacts:upload.bzl", "upload_artifacts")
 load("//publish:defs.bzl", "checksum_rule", "release_nostrip_binary", "release_strip_binary", "release_strip_binary_test")
@@ -126,15 +127,7 @@ upload_artifacts(
     name = "upload",
     testonly = True,
     inputs = [":binaries"],
-    remote_subdir = "binaries/" + select({
-        "@platforms//cpu:x86_64": "x86_64",
-        "@platforms//cpu:arm64": "arm64",
-        "//conditions:default": "unknown",
-    }) + "-" + select({
-        "@platforms//os:linux": "linux",
-        "@platforms//os:osx": "darwin",
-        "//conditions:default": "unknown",
-    }),
+    remote_subdir = "binaries/" + os_info,
 )
 
 # https://dfinity.atlassian.net/browse/IDX-2599


### PR DESCRIPTION
This adds a new repository rule that reads the OS info and exports it as `os_info`. By doing this we can be more flexible in how we provide the `remote_subdir` when uploading artifacts and are not limited to rules only, but can also use a macro. This is part of the work for extracting the upload step from the build itself.