### PR TITLE
chore(IDX): rename checksum_rule to artifact_bundle

### DIFF
--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -133,12 +133,12 @@ rm -rf "$BINARIES_DIR_FULL"
 rm -rf "$CANISTERS_DIR_FULL"
 rm -rf "$DISK_DIR_FULL"
 
-if "$BUILD_BIN"; then BAZEL_TARGETS+=("//publish/binaries:compute_checksums"); fi
-if "$BUILD_CAN"; then BAZEL_TARGETS+=("//publish/canisters:compute_checksums"); fi
+if "$BUILD_BIN"; then BAZEL_TARGETS+=("//publish/binaries:bundle"); fi
+if "$BUILD_CAN"; then BAZEL_TARGETS+=("//publish/canisters:bundle"); fi
 if "$BUILD_IMG"; then BAZEL_TARGETS+=(
-    "//ic-os/guestos/envs/prod:compute_checksums"
-    "//ic-os/hostos/envs/prod:compute_checksums"
-    "//ic-os/setupos/envs/prod:compute_checksums"
+    "//ic-os/guestos/envs/prod:bundle"
+    "//ic-os/hostos/envs/prod:bundle"
+    "//ic-os/setupos/envs/prod:bundle"
 ); fi
 
 echo_blue "Bazel targets: ${BAZEL_TARGETS[*]}"

--- a/ic-os/guestos/envs/prod/BUILD.bazel
+++ b/ic-os/guestos/envs/prod/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/guestos:defs.bzl", "image_deps")
-load("//publish:defs.bzl", "checksum_rule")
+load("//publish:defs.bzl", "artifact_bundle")
 
 # The macro contains several targets.
 # Check
@@ -22,7 +22,7 @@ icos_build(
 )
 
 # Export checksums & build artifacts
-checksum_rule(
-    name = "compute_checksums",
+artifact_bundle(
+    name = "bundle",
     inputs = [":prod"],
 )

--- a/ic-os/hostos/envs/prod/BUILD.bazel
+++ b/ic-os/hostos/envs/prod/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/hostos:defs.bzl", "image_deps")
-load("//publish:defs.bzl", "checksum_rule")
+load("//publish:defs.bzl", "artifact_bundle")
 
 # The macro contains several targets.
 # Check
@@ -20,7 +20,7 @@ icos_build(
 )
 
 # Export checksums & build artifacts
-checksum_rule(
-    name = "compute_checksums",
+artifact_bundle(
+    name = "bundle",
     inputs = [":prod"],
 )

--- a/ic-os/setupos/envs/prod/BUILD.bazel
+++ b/ic-os/setupos/envs/prod/BUILD.bazel
@@ -1,7 +1,7 @@
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/dev-tools/bare_metal_deployment:tools.bzl", "launch_bare_metal")
 load("//ic-os/setupos:defs.bzl", "image_deps")
-load("//publish:defs.bzl", "checksum_rule")
+load("//publish:defs.bzl", "artifact_bundle")
 
 # The macro contains several targets.
 # Check
@@ -24,7 +24,7 @@ launch_bare_metal(
 )
 
 # Export checksums & build artifacts
-checksum_rule(
-    name = "compute_checksums",
+artifact_bundle(
+    name = "bundle",
     inputs = [":prod"],
 )

--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@os_info//:defs.bzl", "os_info")
 load("//bazel:defs.bzl", "gzip_compress")
 load("//ci/src/artifacts:upload.bzl", "upload_artifacts")
-load("//publish:defs.bzl", "checksum_rule", "release_nostrip_binary", "release_strip_binary", "release_strip_binary_test")
+load("//publish:defs.bzl", "artifact_bundle", "release_nostrip_binary", "release_strip_binary", "release_strip_binary_test")
 
 package(default_visibility = ["//rs:ic-os-pkg"])
 
@@ -118,8 +118,8 @@ filegroup(
     srcs = [name + ".gz" for name in ALL_BINARIES],
 )
 
-checksum_rule(
-    name = "compute_checksums",
+artifact_bundle(
+    name = "bundle",
     inputs = [":binaries"],
 )
 

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("//bazel:defs.bzl", "file_size_check")
 load("//ci/src/artifacts:upload.bzl", "upload_artifacts")
-load("//publish:defs.bzl", "checksum_rule")
+load("//publish:defs.bzl", "artifact_bundle")
 load("//rs/nns:nns.bzl", NNS_CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES = "CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES")
 load("//rs/sns:sns.bzl", SNS_CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES = "CANISTER_NAME_TO_MAX_COMPRESSED_WASM_SIZE_E5_BYTES")
 
@@ -131,8 +131,8 @@ filegroup(
 )
 
 # Export checksums & build artifacts
-checksum_rule(
-    name = "compute_checksums",
+artifact_bundle(
+    name = "bundle",
     inputs = [":canisters"],
 )
 

--- a/publish/defs.bzl
+++ b/publish/defs.bzl
@@ -121,15 +121,17 @@ malicious_binary = rule(
     },
 )
 
-def _checksum_rule_impl(ctx):
+def _artifact_bundle_impl(ctx):
     # List of input files
     input_files = ctx.files.inputs
 
+    bundle_dir = "{}_bundle".format(ctx.attr.name)
+
     # Declare output files (NOTE: not windows friendly)
-    out_checksums = ctx.actions.declare_file("_checksums/SHA256SUMS")
+    out_checksums = ctx.actions.declare_file(bundle_dir + "/SHA256SUMS")
 
     def make_symlink(target):
-        symlink = ctx.actions.declare_file("_checksums/" + target.basename)
+        symlink = ctx.actions.declare_file(bundle_dir + "/" + target.basename)
         ctx.actions.symlink(output = symlink, target_file = target)
         return symlink
 
@@ -171,8 +173,8 @@ def _checksum_rule_impl(ctx):
 
 # A rule that re-exports symlinks to all the inputs as well
 # as an extra file 'SHA256SUMS' containing the checksums of inputs.
-checksum_rule = rule(
-    implementation = _checksum_rule_impl,
+artifact_bundle = rule(
+    implementation = _artifact_bundle_impl,
     attrs = {
         "inputs": attr.label_list(
             allow_files = True,


### PR DESCRIPTION
This better represents what the rule does (creates a bundle of artifacts that can then be e.g. uploaded).