### PR TITLE
chore(nns): Stop registering ballots in with_neuron_mut

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -129,13 +129,13 @@ benches:
     scopes: {}
   with_neuron_mut_all_sections_maximum_stable:
     total:
-      instructions: 5029879
+      instructions: 4367660
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_typical_stable:
     total:
-      instructions: 1080740
+      instructions: 837487
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -216,7 +216,6 @@ fn with_neuron_mut_benchmark(size: NeuronSize, f: impl FnOnce(&mut Neuron)) -> B
 fn modify_neuron_all_sections(neuron: &mut Neuron) {
     neuron.cached_neuron_stake_e8s += 1;
     neuron.hot_keys.push(PrincipalId::new_user_test_id(1));
-    neuron.register_recent_ballot(Topic::Governance, &ProposalId { id: 1 }, Vote::Yes);
     neuron.followees.insert(
         Topic::Governance as i32,
         Followees {


### PR DESCRIPTION
# Why

Registering neuron ballots are done through `NeuronStore::register_recent_neuron_ballot` and neither the heap (obsolete) and stable memory path use `with_neuron_mut`. Therefore the benchmark was not realistic.

# What

Stop modifying recent ballots in the `with_neuron_mut` benchmarks.