### PR TITLE
fix(registry-canister-client): Only version-bump after deltas are applied.

### DIFF
--- a/rs/registry/canister-client/src/stable_canister_client.rs
+++ b/rs/registry/canister-client/src/stable_canister_client.rs
@@ -199,9 +199,9 @@ impl<S: RegistryDataStableMemory> CanisterRegistryClient for StableCanisterRegis
                     .unwrap_or(current_local_version.get()),
             );
 
+            self.add_deltas(remote_deltas)?;
             self.latest_version
                 .store(current_local_version.get(), AtomicOrdering::SeqCst);
-            self.add_deltas(remote_deltas)?;
         }
         Ok(current_local_version)
     }

--- a/rs/registry/canister-client/src/stable_canister_client.rs
+++ b/rs/registry/canister-client/src/stable_canister_client.rs
@@ -40,10 +40,14 @@ impl<S: RegistryDataStableMemory> StableCanisterRegistryClient<S> {
     fn add_deltas(&self, deltas: Vec<RegistryDelta>) -> Result<(), String> {
         for delta in deltas {
             let string_key = std::str::from_utf8(&delta.key[..]).map_err(|e| format!("{e:?}"))?;
+            let mut highest_version_inserted = self.get_latest_version();
 
             S::with_registry_map_mut(|local_registry| {
                 for v in delta.values {
                     let registry_version = RegistryVersion::from(v.version);
+                    highest_version_inserted =
+                        std::cmp::max(highest_version_inserted, registry_version);
+
                     let key =
                         StorableRegistryKey::new(string_key.to_string(), registry_version.get());
                     let value = StorableRegistryValue(if v.deletion_marker {
@@ -55,6 +59,11 @@ impl<S: RegistryDataStableMemory> StableCanisterRegistryClient<S> {
                     local_registry.insert(key, value);
                 }
             });
+            // Update the latest version if the inserted version is higher than the current one.
+            if highest_version_inserted > self.get_latest_version() {
+                self.latest_version
+                    .store(highest_version_inserted.get(), AtomicOrdering::SeqCst);
+            }
         }
         Ok(())
     }
@@ -190,18 +199,9 @@ impl<S: RegistryDataStableMemory> CanisterRegistryClient for StableCanisterRegis
                 .await
                 .map_err(|e| format!("{:?}", e))?;
 
-            // Update the local version to the latest remote version for this iteration.
-            current_local_version = RegistryVersion::new(
-                remote_deltas
-                    .iter()
-                    .flat_map(|delta| delta.values.iter().map(|v| v.version))
-                    .max()
-                    .unwrap_or(current_local_version.get()),
-            );
-
             self.add_deltas(remote_deltas)?;
-            self.latest_version
-                .store(current_local_version.get(), AtomicOrdering::SeqCst);
+            // add_deltas updates latest version based on what was inserted.
+            current_local_version = self.get_latest_version();
         }
         Ok(current_local_version)
     }


### PR DESCRIPTION
An edge case was detected through code analysis where the version could be bumped but the application of deltas failed.  This could lead to a gap in Registry data.