### PR TITLE
feat: CRP-2618 Allow zero `pre_signatures_to_create_in_advance` in vetKD `ChainKeyConfig`

### DIFF
--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -1575,7 +1575,7 @@ mod tests {
                         .with_chain_key_config(ChainKeyConfig {
                             key_configs: vec![KeyConfig {
                                 key_id: MasterPublicKeyId::VetKd(key_id.clone()),
-                                pre_signatures_to_create_in_advance: 20,
+                                pre_signatures_to_create_in_advance: 0,
                                 max_queue_size: 20,
                             }],
                             signature_request_timeout_ns: None,
@@ -2066,7 +2066,7 @@ mod tests {
         ChainKeyConfig {
             key_configs: vec![KeyConfig {
                 key_id: MasterPublicKeyId::VetKd(test_vet_key()),
-                pre_signatures_to_create_in_advance: 20,
+                pre_signatures_to_create_in_advance: 0,
                 max_queue_size: 20,
             }],
             signature_request_timeout_ns: None,

--- a/rs/consensus/dkg/src/utils.rs
+++ b/rs/consensus/dkg/src/utils.rs
@@ -197,7 +197,7 @@ mod tests {
                             curve: VetKdCurve::Bls12_381_G2,
                             name: String::from("first_vet_kd_key"),
                         }),
-                        pre_signatures_to_create_in_advance: 50,
+                        pre_signatures_to_create_in_advance: 0,
                         max_queue_size: 50,
                     },
                     KeyConfig {
@@ -205,7 +205,7 @@ mod tests {
                             curve: VetKdCurve::Bls12_381_G2,
                             name: String::from("second_vet_kd_key"),
                         }),
-                        pre_signatures_to_create_in_advance: 50,
+                        pre_signatures_to_create_in_advance: 0,
                         max_queue_size: 50,
                     },
                 ],

--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -70,7 +70,7 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
                 .iter()
                 .map(|key_id| KeyConfig {
                     key_id: key_id.clone(),
-                    pre_signatures_to_create_in_advance: 4,
+                    pre_signatures_to_create_in_advance: if key_id.is_idkg_key() { 4 } else { 0 },
                     max_queue_size: 40,
                 })
                 .collect(),

--- a/rs/consensus/tests/framework/mod.rs
+++ b/rs/consensus/tests/framework/mod.rs
@@ -70,7 +70,11 @@ pub fn setup_subnet<R: Rng + CryptoRng>(
                 .iter()
                 .map(|key_id| KeyConfig {
                     key_id: key_id.clone(),
-                    pre_signatures_to_create_in_advance: if key_id.is_idkg_key() { 4 } else { 0 },
+                    pre_signatures_to_create_in_advance: if key_id.requires_pre_signatures() {
+                        4
+                    } else {
+                        0
+                    },
                     max_queue_size: 40,
                 })
                 .collect(),

--- a/rs/consensus/vetkd/src/test_utils.rs
+++ b/rs/consensus/vetkd/src/test_utils.rs
@@ -87,14 +87,14 @@ pub(super) fn make_chain_key_config() -> ChainKeyConfig {
     };
     let key_config_1 = KeyConfig {
         key_id: MasterPublicKeyId::VetKd(VetKdKeyId::from_str("bls12_381_g2:some_key").unwrap()),
-        pre_signatures_to_create_in_advance: 1,
+        pre_signatures_to_create_in_advance: 0,
         max_queue_size: 3,
     };
     let key_config_2 = KeyConfig {
         key_id: MasterPublicKeyId::VetKd(
             VetKdKeyId::from_str("bls12_381_g2:some_other_key").unwrap(),
         ),
-        pre_signatures_to_create_in_advance: 1,
+        pre_signatures_to_create_in_advance: 0,
         max_queue_size: 3,
     };
 

--- a/rs/registry/canister/src/invariants/crypto.rs
+++ b/rs/registry/canister/src/invariants/crypto.rs
@@ -295,7 +295,9 @@ fn check_chain_key_configs(snapshot: &RegistrySnapshot) -> Result<(), InvariantC
         let mut key_ids = BTreeSet::new();
         for key_config in chain_key_config.key_configs {
             let key_id = key_config.key_id.clone();
-            if key_config.pre_signatures_to_create_in_advance == 0 && key_id.is_idkg_key() {
+            if key_config.pre_signatures_to_create_in_advance == 0
+                && key_id.requires_pre_signatures()
+            {
                 return Err(InvariantCheckError {
                     msg: format!(
                         "`pre_signatures_to_create_in_advance` for key {} of subnet {:} cannot be zero.",

--- a/rs/registry/canister/src/invariants/crypto.rs
+++ b/rs/registry/canister/src/invariants/crypto.rs
@@ -294,16 +294,17 @@ fn check_chain_key_configs(snapshot: &RegistrySnapshot) -> Result<(), InvariantC
 
         let mut key_ids = BTreeSet::new();
         for key_config in chain_key_config.key_configs {
-            if key_config.pre_signatures_to_create_in_advance == 0 {
+            let key_id = key_config.key_id.clone();
+            if key_config.pre_signatures_to_create_in_advance == 0 && key_id.is_idkg_key() {
                 return Err(InvariantCheckError {
                     msg: format!(
-                        "`pre_signatures_to_create_in_advance` of subnet {:} cannot be zero.",
-                        subnet_id,
+                        "`pre_signatures_to_create_in_advance` for key {} of subnet {:} cannot be zero.",
+                        key_id, subnet_id,
                     ),
                     source: None,
                 });
             }
-            if !key_ids.insert(key_config.key_id.clone()) {
+            if !key_ids.insert(key_id) {
                 return Err(InvariantCheckError {
                     msg: format!(
                         "ChainKeyConfig of subnet {:} contains multiple entries for key ID {}.",

--- a/rs/registry/canister/src/invariants/crypto/tests.rs
+++ b/rs/registry/canister/src/invariants/crypto/tests.rs
@@ -642,6 +642,16 @@ mod chain_key_enabled_subnet_lists {
                     pre_signatures_to_create_in_advance: Some(456),
                     max_queue_size: Some(100),
                 },
+                KeyConfigPb {
+                    key_id: Some(MasterPublicKeyIdPb {
+                        key_id: Some(master_public_key_id::KeyId::Vetkd(pb::VetKdKeyId {
+                            curve: 1,
+                            name: "vetkd_key".to_string(),
+                        })),
+                    }),
+                    pre_signatures_to_create_in_advance: Some(0),
+                    max_queue_size: Some(100),
+                },
             ],
             signature_request_timeout_ns: Some(10_000),
             idkg_key_rotation_period_ms: Some(20_000),
@@ -680,7 +690,7 @@ mod chain_key_enabled_subnet_lists {
 
     #[test]
     #[should_panic(
-        expected = "`pre_signatures_to_create_in_advance` of subnet ya35z-hhham-aaaaa-aaaap-yai cannot be zero."
+        expected = "`pre_signatures_to_create_in_advance` for key ecdsa:Secp256k1:ecdsa_key of subnet ya35z-hhham-aaaaa-aaaap-yai cannot be zero."
     )]
     fn should_fail_if_pre_signatures_is_zero() {
         let mut config = invariant_compliant_chain_key_config();
@@ -731,6 +741,19 @@ mod chain_key_enabled_subnet_lists {
     }
 
     #[test]
+    #[should_panic(expected = "Unable to convert 2 to a VetKdCurve")]
+    fn should_fail_if_unkown_vetkd_curve() {
+        let mut config = invariant_compliant_chain_key_config();
+        config.key_configs[1].key_id = Some(MasterPublicKeyIdPb {
+            key_id: Some(master_public_key_id::KeyId::Vetkd(pb::VetKdKeyId {
+                curve: 2,
+                name: "vetkd_key".to_string(),
+            })),
+        });
+        check_chain_key_config_invariant(config);
+    }
+
+    #[test]
     #[should_panic(expected = "Unable to convert Unspecified to an EcdsaCurve")]
     fn should_fail_if_unspecified_ecdsa_curve() {
         let mut config = invariant_compliant_chain_key_config();
@@ -751,6 +774,19 @@ mod chain_key_enabled_subnet_lists {
             key_id: Some(master_public_key_id::KeyId::Schnorr(pb::SchnorrKeyId {
                 algorithm: 0,
                 name: "schnorr_key".to_string(),
+            })),
+        });
+        check_chain_key_config_invariant(config);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unable to convert Unspecified to a VetKdCurve")]
+    fn should_fail_if_unspecified_vetkd_curve() {
+        let mut config = invariant_compliant_chain_key_config();
+        config.key_configs[1].key_id = Some(MasterPublicKeyIdPb {
+            key_id: Some(master_public_key_id::KeyId::Vetkd(pb::VetKdKeyId {
+                curve: 0,
+                name: "vetkd_key".to_string(),
             })),
         });
         check_chain_key_config_invariant(config);

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2578,6 +2578,14 @@ impl MasterPublicKeyId {
             Self::VetKd(_) => false,
         }
     }
+
+    /// Check whether this type of [`MasterPublicKeyId`] requires pre-signatures
+    pub fn requires_pre_signatures(&self) -> bool {
+        match self {
+            Self::Ecdsa(_) | Self::Schnorr(_) => true,
+            Self::VetKd(_) => false,
+        }
+    }
 }
 
 impl FromStr for MasterPublicKeyId {


### PR DESCRIPTION
VetKd does not use pre-signatures, and the corresponding config parameter is ignored. This PR adapts a registry invariant to allow chain keys that do not require pre-signatures to be configured with zero pre-signatures to create in advance.

Once this change is rolled out to the mainnet registry, we can update system tests to configure vetKD keys with zero pre-signatures.