### PR TITLE
test(CRP-2632): Extend registry unit tests to include vetkd cases

### DIFF
--- a/rs/registry/canister/tests/common/test_helpers.rs
+++ b/rs/registry/canister/tests/common/test_helpers.rs
@@ -353,7 +353,7 @@ pub async fn wait_for_chain_key_setup(
         MasterPublicKeyId::Schnorr(key_id) => {
             wait_for_schnorr_setup(runtime, calling_canister, key_id).await;
         }
-        MasterPublicKeyId::VetKd(_key_id) => {
+        MasterPublicKeyId::VetKd(key_id) => {
             wait_for_vetkd_setup(runtime, calling_canister, key_id).await;
         }
     }

--- a/rs/registry/canister/tests/create_subnet.rs
+++ b/rs/registry/canister/tests/create_subnet.rs
@@ -11,7 +11,8 @@ use ic_base_types::{PrincipalId, SubnetId};
 use ic_config::Config;
 use ic_interfaces_registry::RegistryClient;
 use ic_management_canister_types_private::{
-    EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId,
+    EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdCurve,
+    VetKdKeyId,
 };
 use ic_nns_test_utils::itest_helpers::try_call_via_universal_canister;
 use ic_nns_test_utils::{
@@ -366,6 +367,15 @@ fn test_accepted_proposal_with_ecdsa_gets_keys_from_other_subnet() {
 fn test_accepted_proposal_with_schnorr_gets_keys_from_other_subnet() {
     let key_id = MasterPublicKeyId::Schnorr(SchnorrKeyId {
         algorithm: SchnorrAlgorithm::Bip340Secp256k1,
+        name: "foo-bar".to_string(),
+    });
+    test_accepted_proposal_with_chain_key_gets_keys_from_other_subnet(key_id);
+}
+
+#[test]
+fn test_accepted_proposal_with_vetkd_gets_keys_from_other_subnet() {
+    let key_id = MasterPublicKeyId::VetKd(VetKdKeyId {
+        curve: VetKdCurve::Bls12_381_G2,
         name: "foo-bar".to_string(),
     });
     test_accepted_proposal_with_chain_key_gets_keys_from_other_subnet(key_id);

--- a/rs/registry/canister/tests/recover_subnet.rs
+++ b/rs/registry/canister/tests/recover_subnet.rs
@@ -5,7 +5,8 @@ use ic_config::Config;
 use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 use ic_interfaces_registry::RegistryClient;
 use ic_management_canister_types_private::{
-    EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId,
+    EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdCurve,
+    VetKdKeyId,
 };
 use ic_nns_test_utils::{
     itest_helpers::{
@@ -446,6 +447,15 @@ fn test_recover_subnet_gets_schnorr_keys_when_needed() {
     test_recover_subnet_gets_chain_keys_when_needed(key_id);
 }
 
+#[test]
+fn test_recover_subnet_gets_vetkd_keys_when_needed() {
+    let key_id = MasterPublicKeyId::VetKd(VetKdKeyId {
+        curve: VetKdCurve::Bls12_381_G2,
+        name: "foo-bar".to_string(),
+    });
+    test_recover_subnet_gets_chain_keys_when_needed(key_id);
+}
+
 fn test_recover_subnet_without_chain_key_removes_it_from_signing_list(key_id: MasterPublicKeyId) {
     let ic_config = get_ic_config();
     let (config, _tmpdir) = Config::temp_config();
@@ -661,6 +671,15 @@ fn test_recover_subnet_without_ecdsa_key_removes_it_from_signing_list() {
 fn test_recover_subnet_without_schnorr_removes_it_from_signing_list() {
     let key_id = MasterPublicKeyId::Schnorr(SchnorrKeyId {
         algorithm: SchnorrAlgorithm::Bip340Secp256k1,
+        name: "foo-bar".to_string(),
+    });
+    test_recover_subnet_without_chain_key_removes_it_from_signing_list(key_id)
+}
+
+#[test]
+fn test_recover_subnet_without_vetkd_removes_it_from_signing_list() {
+    let key_id = MasterPublicKeyId::VetKd(VetKdKeyId {
+        curve: VetKdCurve::Bls12_381_G2,
         name: "foo-bar".to_string(),
     });
     test_recover_subnet_without_chain_key_removes_it_from_signing_list(key_id)


### PR DESCRIPTION
This PR adds unit tests to the registry canister, which cover the vetkd functionality in `create_subnet.rs` and `recover_subnet.rs`.

In particular:
- It extends `wait_for_chain_key_setup` to also support vetkeys
- Introduces `test_accepted_proposal_with_vetkd_gets_keys_from_other_subnet` test
- Introduces `test_recover_subnet_gets_vetkd_keys_when_needed` test
- Introduces `test_recover_subnet_without_vetkd_removes_it_from_signing_list` test