### PR TITLE
chore: add more logs to nns delegation manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17592,6 +17592,8 @@ name = "orchestrator"
 version = "0.9.0"
 dependencies = [
  "async-trait",
+ "axum 0.8.1",
+ "axum-server",
  "backoff",
  "candid",
  "clap 4.5.27",
@@ -17616,6 +17618,7 @@ dependencies = [
  "ic-crypto-test-utils-reproducible-rng",
  "ic-crypto-test-utils-tls",
  "ic-crypto-tls-interfaces",
+ "ic-crypto-tls-interfaces-mocks",
  "ic-dashboard",
  "ic-http-endpoints-async-utils",
  "ic-http-endpoints-metrics",
@@ -17652,6 +17655,8 @@ dependencies = [
  "prometheus",
  "prost 0.13.4",
  "rand 0.8.5",
+ "rcgen",
+ "rustls 0.23.22",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/rs/http_endpoints/public/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/public/src/nns_delegation_manager.rs
@@ -276,7 +276,10 @@ async fn try_fetch_delegation_from_nns(
     let tls_connector = TlsConnector::from(Arc::new(tls_client_config));
     let irrelevant_domain = "domain.is-irrelevant-as-hostname-verification-is.disabled";
 
-    info!(log, "Initializing a TLS handshake to {peer_id} @ {addr}");
+    info!(
+        log,
+        "Establishing TLS stream to {peer_id}. Tcp stream: {tcp_stream:?}"
+    );
     let tls_stream = tls_connector
         .connect(
             irrelevant_domain
@@ -293,7 +296,10 @@ async fn try_fetch_delegation_from_nns(
             )
         })?;
 
-    info!(log, "Establishing HTTP connection to {peer_id} @ {addr}");
+    info!(
+        log,
+        "Establishing HTTP connection to {peer_id}. Tls stream: {tls_stream:?}"
+    );
     let (mut request_sender, connection) =
         hyper::client::conn::http1::handshake(TokioIo::new(tls_stream)).await?;
 

--- a/rs/http_endpoints/public/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/public/src/nns_delegation_manager.rs
@@ -220,17 +220,16 @@ async fn try_fetch_delegation_from_nns(
     registry_client: &dyn RegistryClient,
     tls_config: &(dyn TlsConfig + Send + Sync),
 ) -> Result<CertificateDelegation, BoxError> {
-    let (peer_id, node) =
-        match get_random_node_from_nns_subnet(registry_client, *nns_subnet_id).await {
-            Ok(node_topology) => node_topology,
-            Err(err) => {
-                fatal!(
-                    log,
-                    "Could not find a node from the root subnet to talk to. Error :{}",
-                    err
-                );
-            }
-        };
+    let (peer_id, node) = match get_random_node_from_nns_subnet(registry_client, *nns_subnet_id) {
+        Ok(node_topology) => node_topology,
+        Err(err) => {
+            fatal!(
+                log,
+                "Could not find a node from the root subnet to talk to. Error :{}",
+                err
+            );
+        }
+    };
 
     let envelope = HttpRequestEnvelope {
         content: HttpReadStateContent::ReadState {
@@ -269,12 +268,15 @@ async fn try_fetch_delegation_from_nns(
         .client_config(peer_id, registry_version)
         .map_err(|err| format!("Retrieving TLS client config failed: {:?}.", err))?;
 
+    info!(log, "Establishing TCP connection to {peer_id} @ {addr}");
     let tcp_stream: TcpStream = TcpStream::connect(addr)
         .await
         .map_err(|err| format!("Could not connect to node {}. {:?}.", addr, err))?;
 
     let tls_connector = TlsConnector::from(Arc::new(tls_client_config));
     let irrelevant_domain = "domain.is-irrelevant-as-hostname-verification-is.disabled";
+
+    info!(log, "Initializing a TLS handshake to {peer_id} @ {addr}");
     let tls_stream = tls_connector
         .connect(
             irrelevant_domain
@@ -291,6 +293,7 @@ async fn try_fetch_delegation_from_nns(
             )
         })?;
 
+    info!(log, "Establishing HTTP connection to {peer_id} @ {addr}");
     let (mut request_sender, connection) =
         hyper::client::conn::http1::handshake(TokioIo::new(tls_stream)).await?;
 
@@ -416,7 +419,7 @@ async fn try_fetch_delegation_from_nns(
     Ok(delegation)
 }
 
-async fn get_random_node_from_nns_subnet(
+fn get_random_node_from_nns_subnet(
     registry_client: &dyn RegistryClient,
     nns_subnet_id: SubnetId,
 ) -> Result<(NodeId, ConnectionEndpoint), String> {

--- a/rs/orchestrator/BUILD.bazel
+++ b/rs/orchestrator/BUILD.bazel
@@ -102,6 +102,7 @@ rust_test(
         "//rs/crypto/test_utils/ni-dkg",
         "//rs/crypto/test_utils/reproducible_rng",
         "//rs/crypto/test_utils/tls",
+        "//rs/crypto/tls_interfaces/mocks",
         "//rs/registry/fake",
         "//rs/registry/proto_data_provider",
         "//rs/registry/subnet_type",
@@ -112,6 +113,10 @@ rust_test(
         "//rs/test_utilities/registry",
         "//rs/test_utilities/time",
         "//rs/test_utilities/types",
+        "@crate_index//:axum",
+        "@crate_index//:axum-server",
         "@crate_index//:mockall",
+        "@crate_index//:rcgen",
+        "@crate_index//:rustls",
     ],
 )

--- a/rs/orchestrator/Cargo.toml
+++ b/rs/orchestrator/Cargo.toml
@@ -64,11 +64,14 @@ tokio = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+axum = { workspace = true }
+axum-server = { workspace = true }
 ic-crypto-temp-crypto = { path = "../crypto/temp_crypto" }
 ic-crypto-test-utils-canister-threshold-sigs = { path = "../crypto/test_utils/canister_threshold_sigs" }
 ic-crypto-test-utils-ni-dkg = { path = "../crypto/test_utils/ni-dkg" }
 ic-crypto-test-utils-reproducible-rng = { path = "../crypto/test_utils/reproducible_rng" }
 ic-crypto-test-utils-tls = { path = "../crypto/test_utils/tls" }
+ic-crypto-tls-interfaces-mocks = { path = "../crypto/tls_interfaces/mocks" }
 ic-registry-client-fake = { path = "../registry/fake" }
 ic-registry-subnet-type = { path = "../registry/subnet_type" }
 ic-registry-proto-data-provider = { path = "../registry/proto_data_provider" }
@@ -80,3 +83,5 @@ ic-test-utilities-registry = { path = "../test_utilities/registry" }
 ic-test-utilities-time = { path = "../test_utilities/time" }
 ic-test-utilities-types = { path = "../test_utilities/types" }
 mockall = { workspace = true }
+rcgen = { workspace = true }
+rustls = { workspace = true }

--- a/rs/orchestrator/src/registration.rs
+++ b/rs/orchestrator/src/registration.rs
@@ -513,10 +513,13 @@ impl NodeRegistration {
         let mut urls: Vec<Url> = t_infos
             .iter()
             .filter_map(|(_nid, n_record)| {
-                n_record
-                    .http
-                    .as_ref()
-                    .and_then(|h| http_endpoint_to_url(h, &self.log))
+                n_record.http.as_ref().and_then(|h| {
+                    http_endpoint_to_url(h)
+                        .inspect_err(|err| {
+                            warn!(self.log, "failed to convert http endpoint to url {err}")
+                        })
+                        .ok()
+                })
             })
             .collect();
 

--- a/rs/orchestrator/src/utils.rs
+++ b/rs/orchestrator/src/utils.rs
@@ -1,9 +1,8 @@
-use ic_logger::{warn, ReplicaLogger};
 use ic_protobuf::registry::node::v1::ConnectionEndpoint;
 use std::{net::IpAddr, str::FromStr};
 use url::Url;
 
-pub(crate) fn http_endpoint_to_url(http: &ConnectionEndpoint, log: &ReplicaLogger) -> Option<Url> {
+pub(crate) fn http_endpoint_to_url(http: &ConnectionEndpoint) -> Result<Url, String> {
     let host_str = match IpAddr::from_str(&http.ip_addr.clone()) {
         Ok(v) => {
             if v.is_ipv6() {
@@ -19,11 +18,5 @@ pub(crate) fn http_endpoint_to_url(http: &ConnectionEndpoint, log: &ReplicaLogge
     };
 
     let url = format!("http://{}:{}/", host_str, http.port);
-    match Url::parse(&url) {
-        Ok(v) => Some(v),
-        Err(e) => {
-            warn!(log, "Invalid url: {}: {:?}", url, e);
-            None
-        }
-    }
+    Url::parse(&url).map_err(|err| format!("Invalid url: {url}: {err:?}"))
 }


### PR DESCRIPTION
```
Fetching delegation from the nns subnet. Attempts: 1.
Establishing TCP connection to rbuft-7b2ng-tiz5n-uqpqb-tdkxx-5t2d4-h7lft-nq5em-6o3ou-nw5vw-aae @ [--REDACTED--]:8080
Establishing TLS stream to rbuft-7b2ng-tiz5n-uqpqb-tdkxx-5t2d4-h7lft-nq5em-6o3ou-nw5vw-aae. Tcp stream: PollEvented { io: Some(TcpStream { addr: [--REDACTED--]:43904, peer: [--REDACTED--]:8080, fd: 31 }) }
Establishing HTTP connection to rbuft-7b2ng-tiz5n-uqpqb-tdkxx-5t2d4-h7lft-nq5em-6o3ou-nw5vw-aae. Tls stream: TlsStream { io: PollEvented { io: Some(TcpStream { addr: [--REDACTED--]:43904, peer: [--REDACTED--]:8080, fd: 31 }) }, session: ClientConnection, state: Stream }
Attempt to fetch HTTPS delegation from root subnet node with addr = `[--REDACTED--]:8080`, uri = `/api/v2/canister/aaaaa-aa/read_state`.
Setting NNS delegation to: CertificateDelegation {...}
```