### PR TITLE
fix: //ic-os/.../:disk.img targets

### DIFF
--- a/toolchains/sysimage/toolchain.bzl
+++ b/toolchains/sysimage/toolchain.bzl
@@ -454,7 +454,7 @@ def _disk_image_no_tar_impl(ctx):
     outputs.append(output_file)
 
     args.extend(["-p", ctx.files.layout[0].path])
-    inputs.append(ctx.files.layout)
+    inputs.extend(ctx.files.layout)
 
     if ctx.attr.expanded_size:
         args.extend(["-s", ctx.attr.expanded_size])


### PR DESCRIPTION
This fixes the following error:
```
$ bazel build //ic-os/setupos/envs/prod:disk.img --config=bes
INFO: Invocation ID: e57da46c-660c-466f-bb15-b03bfa8d18da
INFO: Streaming build results to: https://dash.idx.dfinity.network/invocation/e57da46c-660c-466f-bb15-b03bfa8d18da
ERROR: /ic/ic-os/setupos/envs/prod/BUILD.bazel:10:11: in disk_image_no_tar rule //ic-os/setupos/envs/prod:disk.img:
Traceback (most recent call last):
	File "/ic/toolchains/sysimage/toolchain.bzl", line 466, column 27, in _disk_image_no_tar_impl
		_run_with_icos_wrapper(
	File "/ic/toolchains/sysimage/toolchain.bzl", line 15, column 20, in _run_with_icos_wrapper
		ctx.actions.run(
Error in run: at index 0 of inputs, got element of type list, want File
```