### PR TITLE
test(ICRC_Rosetta): FI-1725: Fix flaky test_deriving_gaps_from_storage test

### DIFF
--- a/rs/rosetta-api/icrc1/src/common/storage/storage_client.rs
+++ b/rs/rosetta-api/icrc1/src/common/storage/storage_client.rs
@@ -548,7 +548,7 @@ mod tests {
            }
 
           #[test]
-          fn test_deriving_gaps_from_storage(blockchain in valid_blockchain_with_gaps_strategy::<U256>(1000)){
+          fn test_deriving_gaps_from_storage(blockchain in valid_blockchain_with_gaps_strategy::<U256>(1000).no_shrink()){
               let storage_client_memory = StorageClient::new_in_memory().unwrap();
               let mut rosetta_blocks = vec![];
               for i in 0..blockchain.0.len() {


### PR DESCRIPTION
Some flakiness was observed for the `test_deriving_gaps_from_storage`. This seems to be because the `valid_blockchain_with_gaps_strategy` could generate some blockchains and corresponding block index values that actually did not contain gaps. This PR proposes to add some filters to the strategies, so that the valid blockchain that is generated is of at least length `2`, and so that the first gap occurs before the last block in the blockchain.