### PR TITLE
feat(registry): A binary that populates a directory that you can then pass to `ic-admin update-registry-local-store`.

### DIFF
--- a/rs/bootstrap_registry_local_store/BUILD.bazel
+++ b/rs/bootstrap_registry_local_store/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:private"])
+
+DEPENDENCIES = [
+    # Keep sorted.
+    "//rs/crypto/utils/threshold_sig_der",
+    "//rs/protobuf",
+    "//rs/registry/local_store",
+    "//rs/types/base_types",
+    "//rs/types/types",
+    "@crate_index//:base64",
+    "@crate_index//:prost",
+]
+
+rust_binary(
+    name = "bootstrap-registry-local-store",
+    srcs = glob(["src/**"]),
+    deps = DEPENDENCIES,
+)

--- a/rs/bootstrap_registry_local_store/src/main.rs
+++ b/rs/bootstrap_registry_local_store/src/main.rs
@@ -1,0 +1,47 @@
+use ic_crypto_utils_threshold_sig_der::parse_threshold_sig_key_from_der;
+use ic_protobuf::types::v1 as pb;
+use ic_registry_local_store::{LocalStoreImpl, LocalStoreWriter, KeyMutation};
+use ic_base_types::{PrincipalId, SubnetId};
+use ic_types::RegistryVersion;
+use prost::Message;
+use std::str::FromStr;
+
+fn main() {
+    let local_store = LocalStoreImpl::new("/Users/daniel.wong/Desktop/registry-local-store");
+
+    let nns_subnet_id = PrincipalId::from_str(
+        // I got this from dashboard.internetcomputer.org.
+        "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe",
+    )
+    .unwrap();
+    let root_public_key = {
+        // I ripped this off from rs/registry/admin/src/main.rs.
+        const IC_ROOT_PUBLIC_KEY_BASE64: &str = r#"MIGCMB0GDSsGAQQBgtx8BQMBAgEGDCsGAQQBgtx8BQMCAQNhAIFMDm7HH6tYOwi9gTc8JVw8NxsuhIY8mKTx4It0I10U+12cDNVG2WhfkToMCyzFNBWDv0tDkuRn25bWW5u0y3FxEvhHLg1aTRRQX/10hLASkQkcX4e5iINGP5gJGguqrg=="#;
+        let decoded_nns_mainnet_key = base64::decode(IC_ROOT_PUBLIC_KEY_BASE64)
+            .expect("Failed to decode mainnet public key from base64.");
+        parse_threshold_sig_key_from_der(&decoded_nns_mainnet_key)
+            .expect("Failed to decode mainnet public key.")
+    };
+
+    let entry = vec![
+        KeyMutation {
+            key: "nns_subnet_id".to_string(),
+            value: Some(
+                pb::SubnetId {
+                    principal_id: Some(pb::PrincipalId::from(nns_subnet_id)),
+                }
+                .encode_to_vec(),
+            ),
+        },
+        KeyMutation {
+            key: format!("crypto_threshold_signing_public_key_{}", SubnetId::from(nns_subnet_id)),
+            value: Some(
+                ic_protobuf::registry::crypto::v1::PublicKey::from(root_public_key)
+                .encode_to_vec(),
+            ),
+        },
+    ];
+    local_store.store(RegistryVersion::from(1), entry).unwrap();
+
+    println!("STORED!");
+}


### PR DESCRIPTION
Without this initial information, `ic-admin update-registry-local-store` does not know how to proceed (which is pretty stupid. It should just default to these values if the local store is initially empty!).

Anyway, I propose that we add this functionality to `ic-admin update-registry-local-store`. To be more precise, when you pass it `--init`, it does this before doing what it otherwise does.

There is no intention to merge in this binary. This is just a "proof of concept", and something that I wrote for myself to get `ic-admin update-registry-local-store` working, but after doing this, I realized it could just be part of `ic-admin update-registry-local-store` itself (per the proposal in the previous paragraph).