### PR TITLE
test(nns): Fix the golden NNS state test by voting the ManageNetworkEconomics proposal with well-known public neurons

### DIFF
--- a/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
+++ b/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
@@ -14,7 +14,8 @@ use ic_nns_governance_api::{
     MonthlyNodeProviderRewards, NetworkEconomics, Vote, VotingPowerEconomics,
 };
 use ic_nns_test_utils::state_test_helpers::{
-    nns_get_most_recent_monthly_node_provider_rewards, scrape_metrics,
+    nns_get_most_recent_monthly_node_provider_rewards, nns_wait_for_proposal_execution,
+    scrape_metrics,
 };
 use ic_nns_test_utils::{
     common::modify_wasm_bytes,
@@ -151,6 +152,8 @@ impl Debug for NnsCanisterUpgrade {
     }
 }
 
+/// Returns a list of well-known public neurons. Impersonating these neurons to vote a certain way
+/// should be able to make the proposals pass instantly.
 fn get_well_known_public_neurons() -> Vec<(NeuronId, PrincipalId)> {
     [
         (
@@ -169,6 +172,36 @@ fn get_well_known_public_neurons() -> Vec<(NeuronId, PrincipalId)> {
         (id, principal)
     })
     .collect()
+}
+
+/// Votes yes on the proposal with the given ID using well-known public neurons. Note that this is
+/// needed because we should no longer be able to create a neuron with a huge stake and pass
+/// proposals using this new neuron, as voting power spikes are automatically detected and a defense
+/// mechanism is in place to prevent this exact situation. Instead, here we use the super power
+/// given by the StateMachine test framework where any principal can be impersonated, which is
+/// clearly unavailable on the mainnet.
+fn vote_yes_with_well_known_public_neurons(
+    state_machine: &StateMachine,
+    proposal_id: u64,
+    check_vote_should_succeed: bool,
+) {
+    for (voter_neuron_id, voter_controller) in get_well_known_public_neurons() {
+        // Note that the voting can fail if the proposal already reaches absolute
+        // majority and the NNS Governance starts to upgrade.
+        let result = nns_cast_vote(
+            state_machine,
+            voter_controller,
+            voter_neuron_id,
+            proposal_id,
+            Vote::Yes,
+        );
+        if check_vote_should_succeed {
+            result.unwrap().panic_if_error(&format!(
+                "Voting with well-known public neuron {:?} on proposal {} failed",
+                voter_neuron_id, proposal_id
+            ));
+        }
+    }
 }
 
 #[test]
@@ -218,6 +251,9 @@ fn test_upgrade_canisters_with_golden_nns_state() {
     let neuron_id = nns_create_super_powerful_neuron(
         &state_machine,
         neuron_controller,
+        // Note that this number is chosen so that such an increase in voting power does not reach
+        // 50% of the current voting power, which would be considered a spike and triggers a defense
+        // mechanism designed to prevent a sudden takeover of the NNS.
         Tokens::from_tokens(100_000_000).unwrap(),
     );
     println!("Done creating super powerful Neuron.");
@@ -279,18 +315,14 @@ fn test_upgrade_canisters_with_golden_nns_state() {
                     module_arg.clone(),
                 );
 
-                // Impersonate some public neurons to vote on the proposal.
-                for (voter_neuron_id, voter_controller) in get_well_known_public_neurons() {
-                    // Note that the voting can fail if the proposal already reaches absolute
-                    // majority and the NNS Governance starts to upgrade.
-                    let _result = nns_cast_vote(
-                        &state_machine,
-                        voter_controller,
-                        voter_neuron_id,
-                        proposal_id.id,
-                        Vote::Yes,
-                    );
-                }
+                // Impersonate some public neurons to vote on the proposal. Note that we do not
+                // check whether votes succeed, as the governance upgrade can start at any point
+                // which will make the canister unresponsive.
+                vote_yes_with_well_known_public_neurons(
+                    &state_machine,
+                    proposal_id.id,
+                    false, /* check_vote_should_succeed */
+                );
 
                 // Step 3: Verify result(s): In a short while, the canister should
                 // be running the new code.
@@ -311,7 +343,7 @@ fn test_upgrade_canisters_with_golden_nns_state() {
 
     // TODO[NNS1-3790]: Remove this once the mainnet NNS has initialized the
     // TODO[NNS1-3790]: `neuron_minimum_dissolve_delay_to_vote_seconds` field.
-    manage_network_economics(
+    let proposal_id = manage_network_economics(
         &state_machine,
         NetworkEconomics {
             voting_power_economics: Some(VotingPowerEconomics {
@@ -325,6 +357,12 @@ fn test_upgrade_canisters_with_golden_nns_state() {
         neuron_controller,
         neuron_id,
     );
+    vote_yes_with_well_known_public_neurons(
+        &state_machine,
+        proposal_id.id,
+        true, /* check_vote_should_succeed */
+    );
+    nns_wait_for_proposal_execution(&state_machine, proposal_id.id);
 
     perform_sequence_of_upgrades(&nns_canister_upgrade_sequence);
 

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -2231,7 +2231,7 @@ pub fn manage_network_economics(
     network_economics: NetworkEconomics,
     sender: PrincipalId,
     neuron_id: NeuronId,
-) {
+) -> ProposalId {
     let proposal = MakeProposalRequest {
         title: Some("manage network economics".to_string()),
         summary: "manage network economics".to_string(),
@@ -2243,12 +2243,10 @@ pub fn manage_network_economics(
 
     let propose_response = nns_governance_make_proposal(machine, sender, neuron_id, &proposal);
 
-    let proposal_id = match propose_response.command.unwrap() {
+    match propose_response.command.unwrap() {
         manage_neuron_response::Command::MakeProposal(response) => response.proposal_id.unwrap(),
         _ => panic!("Propose didn't return MakeProposal"),
-    };
-
-    nns_wait_for_proposal_execution(machine, proposal_id.id);
+    }
 }
 
 pub fn setup_cycles_ledger(state_machine: &StateMachine) {


### PR DESCRIPTION
# Changes

* Use the same mechanism as voting through the upgrade proposals
* Add comments to explain why voting with well-known public neurons instead of minting more ICPs.