### PR TITLE
chore(ICRC_Ledger): FI-1726: Use test_strategy instead of proptest macro for ICRC1 ledger suite tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9679,6 +9679,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_bytes",
+ "test-strategy 0.4.0",
  "thiserror 2.0.12",
 ]
 
@@ -9789,6 +9790,7 @@ dependencies = [
  "proptest 1.6.0",
  "serde",
  "serde_bytes",
+ "test-strategy 0.4.0",
 ]
 
 [[package]]
@@ -9830,6 +9832,7 @@ dependencies = [
  "num-traits",
  "proptest 1.6.0",
  "serde",
+ "test-strategy 0.4.0",
 ]
 
 [[package]]
@@ -9844,6 +9847,7 @@ dependencies = [
  "num-traits",
  "proptest 1.6.0",
  "serde",
+ "test-strategy 0.4.0",
 ]
 
 [[package]]

--- a/rs/ledger_suite/icrc1/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/BUILD.bazel
@@ -42,6 +42,7 @@ DEV_DEPENDENCIES = [
 MACRO_DEV_DEPENDENCIES = [
     # Keep sorted.
     "@crate_index//:proptest-derive",
+    "@crate_index//:test-strategy",
 ]
 
 rust_library(

--- a/rs/ledger_suite/icrc1/Cargo.toml
+++ b/rs/ledger_suite/icrc1/Cargo.toml
@@ -40,6 +40,7 @@ lazy_static = { workspace = true }
 leb128 = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
+test-strategy = "0.4.0"
 
 [features]
 default = []

--- a/rs/ledger_suite/icrc1/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/ledger/BUILD.bazel
@@ -17,6 +17,7 @@ package(default_visibility = ["//visibility:public"])
         proc_macro_deps = [
             # Keep sorted.
             "@crate_index//:async-trait",
+            "@crate_index//:test-strategy",
         ],
         rustc_env = {
             "IC_ICRC1_ARCHIVE_WASM_PATH": "$(execpath //rs/ledger_suite/icrc1/archive:archive_canister" + archive_name_suffix + ")",

--- a/rs/ledger_suite/icrc1/ledger/Cargo.toml
+++ b/rs/ledger_suite/icrc1/ledger/Cargo.toml
@@ -54,6 +54,7 @@ ic-state-machine-tests = { path = "../../../state_machine_tests" }
 ic-test-utilities-load-wasm = { path = "../../../test_utilities/load_wasm" }
 num-bigint = { workspace = true }
 proptest = { workspace = true }
+test-strategy = "0.4.0"
 
 [features]
 default = []

--- a/rs/ledger_suite/icrc1/ledger/src/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/tests.rs
@@ -9,7 +9,7 @@ use ic_ledger_core::timestamp::TimeStamp;
 use ic_stable_structures::Storable;
 use icrc_ledger_types::icrc::generic_metadata_value::MetadataValue as Value;
 use icrc_ledger_types::icrc1::account::Account;
-use proptest::prelude::{any, prop_assert_eq, proptest};
+use proptest::prelude::*;
 use proptest::strategy::Strategy;
 
 use ic_ledger_suite_state_machine_tests::{
@@ -642,31 +642,31 @@ fn arb_token() -> impl Strategy<Value = Tokens> {
     (any::<u128>(), any::<u128>()).prop_map(|(hi, lo)| Tokens::from_words(hi, lo))
 }
 
-#[test]
-fn allowance_serialization() {
-    fn arb_timestamp() -> impl Strategy<Value = TimeStamp> {
-        any::<u64>().prop_map(TimeStamp::from_nanos_since_unix_epoch)
-    }
-    fn arb_opt_expiration() -> impl Strategy<Value = Option<TimeStamp>> {
-        proptest::option::of(any::<u64>().prop_map(TimeStamp::from_nanos_since_unix_epoch))
-    }
-    fn arb_allowance() -> impl Strategy<Value = Allowance<Tokens>> {
-        (arb_token(), arb_opt_expiration(), arb_timestamp()).prop_map(
-            |(amount, expires_at, arrived_at)| Allowance {
-                amount,
-                expires_at,
-                arrived_at,
-            },
-        )
-    }
-    proptest!(|(allowance in arb_allowance())| {
-        let storable_allowance: StorableAllowance = allowance.clone().into();
-        let new_allowance: Allowance<Tokens> = StorableAllowance::from_bytes(storable_allowance.to_bytes()).into();
-        prop_assert_eq!(new_allowance.amount, allowance.amount);
-        prop_assert_eq!(new_allowance.expires_at, allowance.expires_at);
-        prop_assert_eq!(
-            new_allowance.arrived_at,
-            TimeStamp::from_nanos_since_unix_epoch(0)
-        );
-    })
+#[test_strategy::proptest]
+fn allowance_serialization(#[strategy(arb_allowance())] allowance: Allowance<Tokens>) {
+    let storable_allowance: StorableAllowance = allowance.clone().into();
+    let new_allowance: Allowance<Tokens> =
+        StorableAllowance::from_bytes(storable_allowance.to_bytes()).into();
+    prop_assert_eq!(new_allowance.amount, allowance.amount);
+    prop_assert_eq!(new_allowance.expires_at, allowance.expires_at);
+    prop_assert_eq!(
+        new_allowance.arrived_at,
+        TimeStamp::from_nanos_since_unix_epoch(0)
+    );
+}
+
+fn arb_timestamp() -> impl Strategy<Value = TimeStamp> {
+    any::<u64>().prop_map(TimeStamp::from_nanos_since_unix_epoch)
+}
+fn arb_opt_expiration() -> impl Strategy<Value = Option<TimeStamp>> {
+    proptest::option::of(any::<u64>().prop_map(TimeStamp::from_nanos_since_unix_epoch))
+}
+fn arb_allowance() -> impl Strategy<Value = Allowance<Tokens>> {
+    (arb_token(), arb_opt_expiration(), arb_timestamp()).prop_map(
+        |(amount, expires_at, arrived_at)| Allowance {
+            amount,
+            expires_at,
+            arrived_at,
+        },
+    )
 }

--- a/rs/ledger_suite/icrc1/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/tests/tests.rs
@@ -84,75 +84,89 @@ fn check_block_hash<T: TokensType>(block: Block<T>) -> Result<(), TestCaseError>
     Ok(())
 }
 
-proptest! {
-    #[test]
-    fn test_generic_block_to_encoded_block_conversion(block in blocks_strategy(arb_small_amount())) {
-        check_block_conversion::<U64>(block)?;
-    }
-
-    #[test]
-    fn test_generic_block_to_encoded_block_conversion_u128(block in blocks_strategy(large_u128_amount())) {
-        check_block_conversion::<U256>(block)?;
-    }
-
-    #[test]
-    fn test_generic_block_to_encoded_block_conversion_u256(block in blocks_strategy(large_u256_amount())) {
-        check_block_conversion::<U256>(block)?;
-    }
-
-    #[test]
-    fn test_generic_transaction_hash(block in blocks_strategy(arb_small_amount())) {
-        check_tx_hash::<U64>(block)?;
-    }
-
-    #[test]
-    fn test_generic_transaction_hash_u256(block in blocks_strategy(arb_u256())) {
-        check_tx_hash::<U256>(block)?;
-    }
-
-    #[test]
-    fn test_generic_block_and_encoded_block_hash_parity(block in blocks_strategy(arb_u256())) {
-        check_block_hash::<U256>(block)?;
-    }
-
-    #[test]
-    fn test_generic_block_and_encoded_block_hash_parity_u64(block in blocks_strategy(arb_amount())) {
-        check_block_hash::<U64>(block)?;
-    }
-
-    #[test]
-    fn test_generic_block_and_encoded_block_hash_parity_u128(block in blocks_strategy(large_u128_amount())) {
-        check_block_hash::<U256>(block)?;
-    }
-
-    #[test]
-    fn test_generic_block_and_encoded_block_hash_parity_u256(block in blocks_strategy(large_u256_amount())) {
-        check_block_hash::<U256>(block)?;
-    }
+#[test_strategy::proptest]
+fn test_generic_block_to_encoded_block_conversion(
+    #[strategy(blocks_strategy(arb_small_amount()))] block: Block<U64>,
+) {
+    check_block_conversion::<U64>(block)?;
 }
 
-#[test]
-fn test_encoding_decoding_block_u64() {
-    fn arb_token() -> impl Strategy<Value = Tokens> {
-        any::<u64>().prop_map(Tokens::from_e8s)
-    }
-    proptest!(|(block in arb_block(arb_token, 32))| {
-        let mut bytes = vec![];
-        ciborium::into_writer(&block, &mut bytes).unwrap();
-        let decoded: Block<Tokens> = ciborium::from_reader(&bytes[..]).unwrap();
-        prop_assert_eq!(block, decoded);
-    })
+#[test_strategy::proptest]
+fn test_generic_block_to_encoded_block_conversion_u128(
+    #[strategy(blocks_strategy(large_u128_amount()))] block: Block<U256>,
+) {
+    check_block_conversion::<U256>(block)?;
 }
 
-#[test]
-fn test_encoding_decoding_block_u254() {
-    fn arb_token() -> impl Strategy<Value = U256> {
-        (any::<u128>(), any::<u128>()).prop_map(|(hi, lo)| U256::from_words(hi, lo))
-    }
-    proptest!(|(block in arb_block(arb_token, 32))| {
-        let mut bytes = vec![];
-        ciborium::into_writer(&block, &mut bytes).unwrap();
-        let decoded: Block<U256> = ciborium::from_reader(&bytes[..]).unwrap();
-        prop_assert_eq!(block, decoded);
-    })
+#[test_strategy::proptest]
+fn test_generic_block_to_encoded_block_conversion_u256(
+    #[strategy(blocks_strategy(large_u256_amount()))] block: Block<U256>,
+) {
+    check_block_conversion::<U256>(block)?;
+}
+
+#[test_strategy::proptest]
+fn test_generic_transaction_hash(
+    #[strategy(blocks_strategy(arb_small_amount()))] block: Block<U64>,
+) {
+    check_tx_hash::<U64>(block)?;
+}
+
+#[test_strategy::proptest]
+fn test_generic_transaction_hash_u256(#[strategy(blocks_strategy(arb_u256()))] block: Block<U256>) {
+    check_tx_hash::<U256>(block)?;
+}
+
+#[test_strategy::proptest]
+fn test_generic_block_and_encoded_block_hash_parity(
+    #[strategy(blocks_strategy(arb_u256()))] block: Block<U256>,
+) {
+    check_block_hash::<U256>(block)?;
+}
+
+#[test_strategy::proptest]
+fn test_generic_block_and_encoded_block_hash_parity_u64(
+    #[strategy(blocks_strategy(arb_amount()))] block: Block<U64>,
+) {
+    check_block_hash::<U64>(block)?;
+}
+
+#[test_strategy::proptest]
+fn test_generic_block_and_encoded_block_hash_parity_u128(
+    #[strategy(blocks_strategy(large_u128_amount()))] block: Block<U256>,
+) {
+    check_block_hash::<U256>(block)?;
+}
+
+#[test_strategy::proptest]
+fn test_generic_block_and_encoded_block_hash_parity_u256(
+    #[strategy(blocks_strategy(large_u256_amount()))] block: Block<U256>,
+) {
+    check_block_hash::<U256>(block)?;
+}
+
+#[test_strategy::proptest]
+fn test_encoding_decoding_block_u64(#[strategy(arb_block(arb_token, 32))] block: Block<Tokens>) {
+    let mut bytes = vec![];
+    ciborium::into_writer(&block, &mut bytes).unwrap();
+    let decoded: Block<Tokens> = ciborium::from_reader(&bytes[..]).unwrap();
+    prop_assert_eq!(block, decoded);
+}
+
+fn arb_token() -> impl Strategy<Value = Tokens> {
+    any::<u64>().prop_map(Tokens::from_e8s)
+}
+
+#[test_strategy::proptest]
+fn test_encoding_decoding_block_u256(
+    #[strategy(arb_block(arb_token_u256, 32))] block: Block<U256>,
+) {
+    let mut bytes = vec![];
+    ciborium::into_writer(&block, &mut bytes).unwrap();
+    let decoded: Block<U256> = ciborium::from_reader(&bytes[..]).unwrap();
+    prop_assert_eq!(block, decoded);
+}
+
+fn arb_token_u256() -> impl Strategy<Value = U256> {
+    (any::<u128>(), any::<u128>()).prop_map(|(hi, lo)| U256::from_words(hi, lo))
 }

--- a/rs/ledger_suite/icrc1/tokens_u256/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/tokens_u256/BUILD.bazel
@@ -12,6 +12,11 @@ COMMON_DEPS = [
     "@crate_index//:serde",
 ]
 
+MACRO_DEV_DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:test-strategy",
+]
+
 rust_library(
     name = "tokens_u256",
     srcs = [
@@ -30,6 +35,7 @@ rust_library(
 rust_test(
     name = "test",
     srcs = ["tests/tests.rs"],
+    proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     deps = COMMON_DEPS + [
         ":tokens_u256",
         "@crate_index//:hex",

--- a/rs/ledger_suite/icrc1/tokens_u256/Cargo.toml
+++ b/rs/ledger_suite/icrc1/tokens_u256/Cargo.toml
@@ -21,3 +21,4 @@ serde = { workspace = true }
 [dev-dependencies]
 hex = { workspace = true }
 proptest = { workspace = true }
+test-strategy = "0.4.0"

--- a/rs/ledger_suite/icrc1/tokens_u256/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/tokens_u256/tests/tests.rs
@@ -7,34 +7,32 @@ fn arb_u256() -> impl Strategy<Value = U256> {
     (any::<u128>(), any::<u128>()).prop_map(|(x, y)| U256::from_words(x, y))
 }
 
-proptest! {
-    #[test]
-    fn nat_round_trip(v in arb_u256()) {
-        prop_assert_eq!(Ok(v), Nat::from(v).try_into());
-    }
+#[test_strategy::proptest]
+fn nat_round_trip(#[strategy(arb_u256())] v: U256) {
+    prop_assert_eq!(Ok(v), Nat::from(v).try_into());
+}
 
-    #[test]
-    fn storable_round_trip(v in arb_u256()) {
-        let encoded_v = v.to_bytes();
-        prop_assert_eq!(U256::BOUND.max_size() as usize, encoded_v.len());
-        prop_assert_eq!(v, U256::from_bytes(encoded_v));
-    }
+#[test_strategy::proptest]
+fn storable_round_trip(#[strategy(arb_u256())] v: U256) {
+    let encoded_v = v.to_bytes();
+    prop_assert_eq!(U256::BOUND.max_size() as usize, encoded_v.len());
+    prop_assert_eq!(v, U256::from_bytes(encoded_v));
+}
 
-    #[test]
-    fn cbor_roundtrip(v in arb_u256()) {
-        let mut buf = vec![];
-        ciborium::into_writer(&v, &mut buf).unwrap();
-        let n: U256 = ciborium::from_reader(&buf[..]).unwrap();
-        prop_assert_eq!(v, n);
-    }
+#[test_strategy::proptest]
+fn cbor_roundtrip(#[strategy(arb_u256())] v: U256) {
+    let mut buf = vec![];
+    ciborium::into_writer(&v, &mut buf).unwrap();
+    let n: U256 = ciborium::from_reader(&buf[..]).unwrap();
+    prop_assert_eq!(v, n);
+}
 
-    #[test]
-    fn cbor_u64_compact(v in any::<u64>()) {
-        let mut buf = vec![];
-        ciborium::into_writer(&v, &mut buf).unwrap();
-        let n: U256 = ciborium::from_reader(&buf[..]).unwrap();
-        prop_assert_eq!(Some(v), n.try_as_u64());
-    }
+#[test_strategy::proptest]
+fn cbor_u64_compact(#[strategy(any::<u64>())] v: u64) {
+    let mut buf = vec![];
+    ciborium::into_writer(&v, &mut buf).unwrap();
+    let n: U256 = ciborium::from_reader(&buf[..]).unwrap();
+    prop_assert_eq!(Some(v), n.try_as_u64());
 }
 
 #[test]

--- a/rs/ledger_suite/icrc1/tokens_u64/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/tokens_u64/BUILD.bazel
@@ -2,6 +2,11 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
+MACRO_DEV_DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:test-strategy",
+]
+
 rust_library(
     name = "tokens_u64",
     srcs = ["src/lib.rs"],
@@ -21,6 +26,7 @@ rust_library(
 rust_test(
     name = "test",
     srcs = ["tests/tests.rs"],
+    proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     deps = [
         # Keep sorted.
         ":tokens_u64",

--- a/rs/ledger_suite/icrc1/tokens_u64/Cargo.toml
+++ b/rs/ledger_suite/icrc1/tokens_u64/Cargo.toml
@@ -17,3 +17,4 @@ serde = { workspace = true }
 [dev-dependencies]
 ciborium = { workspace = true }
 proptest = { workspace = true }
+test-strategy = "0.4.0"

--- a/rs/ledger_suite/icrc1/tokens_u64/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/tokens_u64/tests/tests.rs
@@ -2,20 +2,18 @@ use ic_icrc1_tokens_u64::U64;
 use ic_ledger_core::tokens::Tokens;
 use proptest::prelude::*;
 
-proptest! {
-    #[test]
-    fn decode_u64_amounts(value in any::<u64>()) {
-        let mut buf = vec![];
-        ciborium::into_writer(&value, &mut buf).unwrap();
-        let amount: U64 = ciborium::de::from_reader(&buf[..]).expect("failed to decode U64");
-        prop_assert_eq!(U64::new(value), amount);
-    }
+#[test_strategy::proptest]
+fn decode_u64_amounts(#[strategy(any::<u64>())] value: u64) {
+    let mut buf = vec![];
+    ciborium::into_writer(&value, &mut buf).unwrap();
+    let amount: U64 = ciborium::de::from_reader(&buf[..]).expect("failed to decode U64");
+    prop_assert_eq!(U64::new(value), amount);
+}
 
-    #[test]
-    fn decode_legacy_token_amounts(value in any::<u64>()) {
-        let mut buf = vec![];
-        ciborium::into_writer(&Tokens::from_e8s(value), &mut buf).unwrap();
-        let amount: U64 = ciborium::de::from_reader(&buf[..]).expect("failed to decode U64");
-        prop_assert_eq!(U64::new(value), amount);
-    }
+#[test_strategy::proptest]
+fn decode_legacy_token_amounts(#[strategy(any::<u64>())] value: u64) {
+    let mut buf = vec![];
+    ciborium::into_writer(&Tokens::from_e8s(value), &mut buf).unwrap();
+    let amount: U64 = ciborium::de::from_reader(&buf[..]).expect("failed to decode U64");
+    prop_assert_eq!(U64::new(value), amount);
 }


### PR DESCRIPTION
Use `test_strategy` annotations instead of the `proptest!` macro for ICRC1 ledger suite tests. Using the annotations instead of the macro allows `rustfmt` to format the code. This PR is inspired by [this earlier PR](https://github.com/dfinity/ic/pull/4163) for the `xnet/payload_builder` tests.