### PR TITLE
chore: log the size of the file to be uploaded to Farm

### DIFF
--- a/rs/tests/driver/src/driver/farm.rs
+++ b/rs/tests/driver/src/driver/farm.rs
@@ -162,9 +162,7 @@ impl Farm {
         path: P,
         filename: &str,
     ) -> FarmResult<FileId> {
-        let size = std::fs::metadata(&path)
-            .map_err(|e| FarmError::IoError(e))?
-            .len();
+        let size = std::fs::metadata(&path).map_err(FarmError::IoError)?.len();
         info!(
             self.logger,
             "Uploading file: {} of size {} bytes ...", filename, size

--- a/rs/tests/driver/src/driver/farm.rs
+++ b/rs/tests/driver/src/driver/farm.rs
@@ -15,6 +15,7 @@ use ic_crypto_sha2::Sha256;
 use reqwest::blocking::{multipart, Client, RequestBuilder};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use slog::info;
 use slog::{error, warn, Logger};
 use std::fmt;
 use std::io::Write;
@@ -161,6 +162,13 @@ impl Farm {
         path: P,
         filename: &str,
     ) -> FarmResult<FileId> {
+        let size = std::fs::metadata(&path)
+            .map_err(|e| FarmError::IoError(e))?
+            .len();
+        info!(
+            self.logger,
+            "Uploading file: {} of size {} bytes ...", filename, size
+        );
         let rb = self
             .post(&format!("group/{}/file", group_name))
             .timeout(TIMEOUT_SETTINGS_LONG.max_http_timeout);


### PR DESCRIPTION
The `//rs/tests/nested:...` tests currently upload large files which sometimes cause Farm to run out of disk space. I would like to know how much is being uploaded so this logs the file size before uploading which looks like:

```
$ bazel test //rs/tests/nested:registration --config=systest
...
2025-05-08 14:36:56.779 INFO[setup:rs/tests/driver/src/driver/farm.rs:166:0] Uploading file: config_disk.img.zst of size 41060 bytes ...
...
2025-05-08 14:36:56.830 INFO[setup:rs/tests/driver/src/driver/farm.rs:166:0] Uploading file: config_disk.img.zst of size 43713 bytes ...
...
2025-05-08 14:38:58.843 INFO[setup:rs/tests/driver/src/driver/farm.rs:166:0] Uploading file: config.img.zst of size 2370645843 bytes ...
```