### PR TITLE
chore(IDX): Fail if icos upload_prefix is None

### DIFF
--- a/ic-os/defs.bzl
+++ b/ic-os/defs.bzl
@@ -408,26 +408,28 @@ def icos_build(
     if malicious:
         upload_suffix += "-malicious"
 
-    if upload_prefix != None:
+    if upload_prefix == None:
+        fail("icos_build expects an upload prefix")
+
+    upload_artifacts(
+        name = "upload_disk-img",
+        inputs = [
+            ":disk-img.tar.zst",
+        ],
+        remote_subdir = upload_prefix + "/disk-img" + upload_suffix,
+        visibility = visibility,
+    )
+
+    if upgrades:
         upload_artifacts(
-            name = "upload_disk-img",
+            name = "upload_update-img",
             inputs = [
-                ":disk-img.tar.zst",
+                ":update-img.tar.zst",
+                ":update-img-test.tar.zst",
             ],
-            remote_subdir = upload_prefix + "/disk-img" + upload_suffix,
+            remote_subdir = upload_prefix + "/update-img" + upload_suffix,
             visibility = visibility,
         )
-
-        if upgrades:
-            upload_artifacts(
-                name = "upload_update-img",
-                inputs = [
-                    ":update-img.tar.zst",
-                    ":update-img-test.tar.zst",
-                ],
-                remote_subdir = upload_prefix + "/update-img" + upload_suffix,
-                visibility = visibility,
-            )
 
     # end if upload_prefix != None
 

--- a/ic-os/guestos/envs/local-base-dev/BUILD.bazel
+++ b/ic-os/guestos/envs/local-base-dev/BUILD.bazel
@@ -13,6 +13,5 @@ icos_build(
         "manual",
         "no-cache",
     ],
-    upload_prefix = None,  # Do not upload locally built base images
     visibility = ["//rs:ic-os-pkg"],
 )

--- a/ic-os/guestos/envs/local-base-prod/BUILD.bazel
+++ b/ic-os/guestos/envs/local-base-prod/BUILD.bazel
@@ -13,6 +13,5 @@ icos_build(
         "manual",
         "no-cache",
     ],
-    upload_prefix = None,  # Do not upload locally built base images
     visibility = ["//rs:ic-os-pkg"],
 )

--- a/ic-os/hostos/envs/local-base-dev/BUILD.bazel
+++ b/ic-os/hostos/envs/local-base-dev/BUILD.bazel
@@ -13,7 +13,6 @@ icos_build(
         "manual",
         "no-cache",
     ],
-    upload_prefix = None,  # Do not upload locally built base images
     visibility = ["//rs:ic-os-pkg"],
     vuln_scan = False,
 )

--- a/ic-os/hostos/envs/local-base-prod/BUILD.bazel
+++ b/ic-os/hostos/envs/local-base-prod/BUILD.bazel
@@ -13,7 +13,6 @@ icos_build(
         "manual",
         "no-cache",
     ],
-    upload_prefix = None,  # Do not upload locally built base images
     visibility = ["//rs:ic-os-pkg"],
     vuln_scan = False,
 )

--- a/ic-os/setupos/envs/local-base-dev/BUILD.bazel
+++ b/ic-os/setupos/envs/local-base-dev/BUILD.bazel
@@ -15,7 +15,6 @@ icos_build(
         "no-cache",
     ],
     upgrades = False,
-    upload_prefix = None,  # Do not upload locally built base images
     visibility = ["//rs:ic-os-pkg"],
     vuln_scan = False,
 )

--- a/ic-os/setupos/envs/local-base-prod/BUILD.bazel
+++ b/ic-os/setupos/envs/local-base-prod/BUILD.bazel
@@ -15,7 +15,6 @@ icos_build(
         "no-cache",
     ],
     upgrades = False,
-    upload_prefix = None,  # Do not upload locally built base images
     vuln_scan = False,
 )
 


### PR DESCRIPTION
This simplifies the icos image upload by making sure the upload_prefix is always set. The upload itself is already controlled by the `--s3_upload` flag.