### PR TITLE
test: Let canbench download pocket ic server

### DIFF
--- a/bazel/canbench.bzl
+++ b/bazel/canbench.bzl
@@ -36,20 +36,17 @@ def rust_canbench(name, results_file, add_test = False, opt = "3", noise_thresho
 
     canbench_bin = "$(location @crate_index//:canbench__canbench)"
     wasm_path = "$(location :{name}_wasm)".format(name = name)
-    pocket_ic_bin = "$(rootpath //:pocket-ic-mainnet)"
     data = data + [
         ":{name}_wasm".format(name = name),
         "@crate_index//:canbench__canbench",
         results_file,
         "//:WORKSPACE.bazel",
-        "//:pocket-ic-mainnet",
     ]
     canbench_results_path = "$(rootpath {results_file})".format(results_file = results_file)
     env = env | {
         "CANBENCH_BIN": canbench_bin,
         "WASM_PATH": wasm_path,
         "CANBENCH_RESULTS_PATH": canbench_results_path,
-        "POCKET_IC_BIN": pocket_ic_bin,
         # Hack to escape the sandbox and update the actual repository
         "WORKSPACE": "$(rootpath //:WORKSPACE.bazel)",
     }
@@ -87,4 +84,7 @@ def rust_canbench(name, results_file, add_test = False, opt = "3", noise_thresho
             data = data,
             env = env,
             args = ["--test"],
+            tags = [
+                "requires-network",  # Because canbench needs to download the pocket ic server.
+            ],
         )

--- a/bazel/canbench.sh
+++ b/bazel/canbench.sh
@@ -48,10 +48,10 @@ fi
 
 if [ $# -eq 0 ]; then
     # Runs the benchmark without updating the results file.
-    ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN}
+    ${CANBENCH_BIN}
 elif [ "$1" = "--update" ]; then
     # Runs the benchmark while updating the results file.
-    ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} --persist
+    ${CANBENCH_BIN} --persist
 
     # Since we cannot specify an empty results file for the first time, we need to copy the default
     # results file to the desired location.
@@ -61,7 +61,7 @@ elif [ "$1" = "--update" ]; then
 else
     NOISE_THRESHOLD_ARG="${NOISE_THRESHOLD:+--noise-threshold ${NOISE_THRESHOLD}}"
     # Runs the benchmark test that fails if the diffs are new or above the threshold.
-    ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG} >$CANBENCH_OUTPUT
+    ${CANBENCH_BIN} ${NOISE_THRESHOLD_ARG} >$CANBENCH_OUTPUT
     if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then
         cat "$CANBENCH_OUTPUT"
         echo "**\`$REPO_RESULTS_PATH\` is not up to date ❌**


### PR DESCRIPTION
# Why

The current setup requires the `//:pocket-ic-mainnet` to match the pocket ic version used within canbench. Given that `//:pocket-ic-mainnet` is used for some other tests, if those tests need `//:pocket-ic-mainnet` to be bumped, it will require 2 version bumps: (1) pocket ic version within canbench (2) canbench version within the monorepo. Essentially, the pocket ic version used by canbench is a transitive dependency, but we are managing the transitive dependency manually.

The `//:pocket-ic-mainnet` dependency was added for `*_canbench_test`, as tests do not have access to the network by default. However, it seems possible to reqiuire network through the "requires-network" tag.

# What

* Remove the `//:pocket-ic-mainnet` from `canbench.bzl`
* Stop using `POCKET_IC_BIN ` within `canbench.sh`