### PR TITLE
fix: make upload_chunk idempotent

### DIFF
--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -101,7 +101,7 @@ ENV = {}
 
 rust_library(
     name = "execution_environment",
-    srcs = glob(["src/**"]),
+    srcs = glob(["src/**/*.rs"]),
     aliases = ALIASES,
     compile_data = glob(["tests/test-data/**"]),
     crate_name = "ic_execution_environment",

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -101,7 +101,7 @@ ENV = {}
 
 rust_library(
     name = "execution_environment",
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob(["src/**"]),
     aliases = ALIASES,
     compile_data = glob(["tests/test-data/**"]),
     crate_name = "ic_execution_environment",

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1257,7 +1257,7 @@ impl CanisterManager {
 
         round_limits.instructions -= as_round_instructions(instructions);
 
-        let hash = validated_chunk.hash.to_vec();
+        let hash = validated_chunk.hash().to_vec();
         canister
             .system_state
             .wasm_chunk_store

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -2919,6 +2919,8 @@ fn uninstall_code_can_be_invoked_by_governance_canister() {
         .build();
 
     // Insert data to the chunk store to verify it is cleared on uninstall.
+    let chunk = [0x41, 200];
+    let hash = ic_crypto_sha2::Sha256::hash(&chunk);
     state
         .canister_state_mut(&canister_test_id(0))
         .unwrap()
@@ -2926,9 +2928,9 @@ fn uninstall_code_can_be_invoked_by_governance_canister() {
         .wasm_chunk_store
         .insert_chunk(
             canister_manager.config.wasm_chunk_store_max_size,
-            &[0x41; 200],
-        )
-        .unwrap();
+            &chunk,
+            &hash,
+        );
 
     assert!(state
         .canister_state(&canister_test_id(0))
@@ -6006,6 +6008,14 @@ fn upload_chunk_fails_when_allocation_exceeded() {
     assert!(result.is_ok());
     let initial_subnet_available_memory = test.subnet_available_memory();
 
+    // Uploading the same chunk again succeeds.
+    let result = test.subnet_message("upload_chunk", upload_args.encode());
+    assert!(result.is_ok());
+    assert_eq!(
+        test.subnet_available_memory(),
+        initial_subnet_available_memory
+    );
+
     // Second chunk upload fails
     let chunk = vec![4, 4];
     let upload_args = UploadChunkArgs {
@@ -6047,6 +6057,14 @@ fn upload_chunk_fails_when_subnet_memory_exceeded() {
     assert!(result.is_ok());
     let initial_subnet_available_memory = test.subnet_available_memory();
 
+    // Uploading the same chunk again succeeds.
+    let result = test.subnet_message("upload_chunk", upload_args.encode());
+    assert!(result.is_ok());
+    assert_eq!(
+        test.subnet_available_memory(),
+        initial_subnet_available_memory
+    );
+
     // Second chunk upload fails
     let chunk = vec![4, 4];
     let upload_args = UploadChunkArgs {
@@ -6081,6 +6099,18 @@ fn upload_chunk_counts_to_memory_usage() {
         canister_id: canister_id.into(),
         chunk,
     };
+    let result = test.subnet_message("upload_chunk", upload_args.encode());
+    assert!(result.is_ok());
+    assert_eq!(
+        test.canister_state(canister_id).memory_usage(),
+        chunk_size + initial_memory_usage
+    );
+    assert_eq!(
+        test.subnet_available_memory().get_execution_memory(),
+        initial_subnet_available_memory - chunk_size.get() as i64
+    );
+
+    // Check memory usage after uploading the same chunk again.
     let result = test.subnet_message("upload_chunk", upload_args.encode());
     assert!(result.is_ok());
     assert_eq!(
@@ -6310,6 +6340,21 @@ fn upload_chunk_reserves_cycles() {
             "Reserved balance {} should be positive",
             reserved_balance
         );
+
+        // Uploading the same chunk again should not reserve any further cycles.
+        let _hash = test
+            .subnet_message("upload_chunk", upload_args.encode())
+            .unwrap();
+        let new_reserved_balance = test
+            .canister_state(canister_id)
+            .system_state
+            .reserved_balance()
+            .get();
+        assert_eq!(
+            new_reserved_balance, reserved_balance,
+            "The current reserved balance {} should match the previous reserved balance {}",
+            new_reserved_balance, reserved_balance
+        );
     });
 }
 
@@ -6484,6 +6529,11 @@ fn upload_chunk_fails_when_heap_delta_rate_limited() {
         .subnet_message("upload_chunk", upload_args.encode())
         .unwrap();
 
+    // Uploading the same chunk again will succeed
+    let _hash = test
+        .subnet_message("upload_chunk", upload_args.encode())
+        .unwrap();
+
     // Uploading the second chunk will fail because of rate limiting.
     let initial_subnet_available_memory = test.subnet_available_memory();
     let upload_args = UploadChunkArgs {
@@ -6525,6 +6575,16 @@ fn upload_chunk_increases_subnet_heap_delta() {
         test.state().metadata.heap_delta_estimate,
         wasm_chunk_store::chunk_size()
     );
+
+    // Uploading the same chunk again will not increase the delta.
+    let _hash = test
+        .subnet_message("upload_chunk", upload_args.encode())
+        .unwrap();
+
+    assert_eq!(
+        test.state().metadata.heap_delta_estimate,
+        wasm_chunk_store::chunk_size()
+    );
 }
 
 #[test]
@@ -6548,11 +6608,22 @@ fn upload_chunk_charges_canister_cycles() {
         test.subnet_size(),
         test.canister_wasm_execution_mode(canister_id),
     );
-    let _hash = test.subnet_message("upload_chunk", payload).unwrap();
+    let _hash = test
+        .subnet_message("upload_chunk", payload.clone())
+        .unwrap();
 
     assert_eq!(
         test.canister_state(canister_id).system_state.balance(),
         initial_balance - expected_charge,
+    );
+
+    // Uploading the same chunk again will decrease balance by the cycles corresponding to
+    // the instructions for uploading.
+    let _hash = test.subnet_message("upload_chunk", payload).unwrap();
+
+    assert_eq!(
+        test.canister_state(canister_id).system_state.balance(),
+        initial_balance - expected_charge - expected_charge,
     );
 }
 
@@ -6684,7 +6755,7 @@ fn chunk_store_counts_against_subnet_memory_in_initial_round_computation() {
     // a second.
     let payload = UploadChunkArgs {
         canister_id: canister_id.into(),
-        chunk: vec![0x42; 1024 * 1024],
+        chunk: vec![0x43; 1024 * 1024],
     }
     .encode();
     let error = env

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -2258,7 +2258,7 @@ impl ExecutionEnvironment {
             .upload_chunk(
                 sender,
                 canister,
-                &args.chunk,
+                args.chunk,
                 round_limits,
                 subnet_size,
                 resource_saturation,

--- a/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
@@ -39,8 +39,14 @@ struct ChunkInfo {
 /// Struct wrapping a validated chunk with its hash to be inserted into the chunk store.
 #[derive(Debug)]
 pub struct ValidatedChunk {
-    pub chunk: Vec<u8>,
-    pub hash: WasmChunkHash,
+    chunk: Vec<u8>,
+    hash: WasmChunkHash,
+}
+
+impl ValidatedChunk {
+    pub fn hash(&self) -> WasmChunkHash {
+        self.hash
+    }
 }
 
 /// The result of validating a chunk before it is inserted into the chunk store:

--- a/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
@@ -44,8 +44,8 @@ pub struct ValidatedChunk {
 }
 
 /// The result of validating a chunk before it is inserted into the chunk store:
-/// - the chunk already exists (its hash is returned to be included in the management canister call response);
 /// - the chunk is validated and supposed to be inserted later (after further checks, e.g., subnet available memory);
+/// - the chunk already exists (its hash is returned to be included in the management canister call response);
 /// - a validation error.
 #[derive(Debug)]
 pub enum ChunkValidationResult {

--- a/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/wasm_chunk_store.rs
@@ -45,7 +45,8 @@ pub struct ValidatedChunk {
 
 /// The result of validating a chunk before it is inserted into the chunk store:
 /// - the chunk already exists (its hash is returned to be included in the management canister call response);
-/// - the chunk is validated and supposed to be inserted later (after further checks, e.g., subnet available memory).
+/// - the chunk is validated and supposed to be inserted later (after further checks, e.g., subnet available memory);
+/// - a validation error.
 #[derive(Debug)]
 pub enum ChunkValidationResult {
     Insert(ValidatedChunk),


### PR DESCRIPTION
This PR makes the management canister endpoint `upload_chunk` idempotent, i.e., uploading an existing chunk is a no-op (except for charging cycles).

Additionally, this PR refactors
- charging cycles to use the method `consume_cycles_for_instructions` of the cycles account manager;
- the method `insert_chunk` of the wasm chunk store to take the chunk hash as input and assume that the chunk does not exist and can be inserted.