### PR TITLE
chore: add more logs to nns delegation manager

### DIFF
--- a/rs/http_endpoints/public/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/public/src/nns_delegation_manager.rs
@@ -276,7 +276,7 @@ async fn try_fetch_delegation_from_nns(
     let tls_connector = TlsConnector::from(Arc::new(tls_client_config));
     let irrelevant_domain = "domain.is-irrelevant-as-hostname-verification-is.disabled";
 
-    info!(log, "Establishing a TLS stream to {peer_id} @ {addr}");
+    info!(log, "Establishing TLS stream to {peer_id} @ {addr}");
     let tls_stream = tls_connector
         .connect(
             irrelevant_domain

--- a/rs/http_endpoints/public/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/public/src/nns_delegation_manager.rs
@@ -276,7 +276,7 @@ async fn try_fetch_delegation_from_nns(
     let tls_connector = TlsConnector::from(Arc::new(tls_client_config));
     let irrelevant_domain = "domain.is-irrelevant-as-hostname-verification-is.disabled";
 
-    info!(log, "Initializing a TLS handshake to {peer_id} @ {addr}");
+    info!(log, "Establishing a TLS stream to {peer_id} @ {addr}");
     let tls_stream = tls_connector
         .connect(
             irrelevant_domain

--- a/rs/http_endpoints/public/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/public/src/nns_delegation_manager.rs
@@ -220,17 +220,16 @@ async fn try_fetch_delegation_from_nns(
     registry_client: &dyn RegistryClient,
     tls_config: &(dyn TlsConfig + Send + Sync),
 ) -> Result<CertificateDelegation, BoxError> {
-    let (peer_id, node) =
-        match get_random_node_from_nns_subnet(registry_client, *nns_subnet_id).await {
-            Ok(node_topology) => node_topology,
-            Err(err) => {
-                fatal!(
-                    log,
-                    "Could not find a node from the root subnet to talk to. Error :{}",
-                    err
-                );
-            }
-        };
+    let (peer_id, node) = match get_random_node_from_nns_subnet(registry_client, *nns_subnet_id) {
+        Ok(node_topology) => node_topology,
+        Err(err) => {
+            fatal!(
+                log,
+                "Could not find a node from the root subnet to talk to. Error :{}",
+                err
+            );
+        }
+    };
 
     let envelope = HttpRequestEnvelope {
         content: HttpReadStateContent::ReadState {
@@ -269,12 +268,15 @@ async fn try_fetch_delegation_from_nns(
         .client_config(peer_id, registry_version)
         .map_err(|err| format!("Retrieving TLS client config failed: {:?}.", err))?;
 
+    info!(log, "Establishing TCP connection to {peer_id} @ {addr}");
     let tcp_stream: TcpStream = TcpStream::connect(addr)
         .await
         .map_err(|err| format!("Could not connect to node {}. {:?}.", addr, err))?;
 
     let tls_connector = TlsConnector::from(Arc::new(tls_client_config));
     let irrelevant_domain = "domain.is-irrelevant-as-hostname-verification-is.disabled";
+
+    info!(log, "Initializing a TLS handshake to {peer_id} @ {addr}");
     let tls_stream = tls_connector
         .connect(
             irrelevant_domain
@@ -291,6 +293,7 @@ async fn try_fetch_delegation_from_nns(
             )
         })?;
 
+    info!(log, "Establishing HTTP connection to {peer_id} @ {addr}");
     let (mut request_sender, connection) =
         hyper::client::conn::http1::handshake(TokioIo::new(tls_stream)).await?;
 
@@ -416,7 +419,7 @@ async fn try_fetch_delegation_from_nns(
     Ok(delegation)
 }
 
-async fn get_random_node_from_nns_subnet(
+fn get_random_node_from_nns_subnet(
     registry_client: &dyn RegistryClient,
     nns_subnet_id: SubnetId,
 ) -> Result<(NodeId, ConnectionEndpoint), String> {

--- a/rs/http_endpoints/public/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/public/src/nns_delegation_manager.rs
@@ -276,7 +276,10 @@ async fn try_fetch_delegation_from_nns(
     let tls_connector = TlsConnector::from(Arc::new(tls_client_config));
     let irrelevant_domain = "domain.is-irrelevant-as-hostname-verification-is.disabled";
 
-    info!(log, "Establishing TLS stream to {peer_id} @ {addr}");
+    info!(
+        log,
+        "Establishing TLS stream to {peer_id}. Tcp stream: {tcp_stream:?}"
+    );
     let tls_stream = tls_connector
         .connect(
             irrelevant_domain
@@ -293,7 +296,10 @@ async fn try_fetch_delegation_from_nns(
             )
         })?;
 
-    info!(log, "Establishing HTTP connection to {peer_id} @ {addr}");
+    info!(
+        log,
+        "Establishing HTTP connection to {peer_id}. Tls stream: {tls_stream:?}"
+    );
     let (mut request_sender, connection) =
         hyper::client::conn::http1::handshake(TokioIo::new(tls_stream)).await?;
 

--- a/rs/p2p/quic_transport/src/connection_manager.rs
+++ b/rs/p2p/quic_transport/src/connection_manager.rs
@@ -454,6 +454,7 @@ impl ConnectionManager {
         let quinn_client_config = QuicClientConfig::try_from(rustls_client_config).expect("Conversion from RustTls config to Quinn config must succeed as long as this library and quinn use the same RustTls versions.");
         let mut client_config = quinn::ClientConfig::new(Arc::new(quinn_client_config));
         client_config.transport_config(transport_config);
+        let logger = self.log.clone();
         let conn_fut = async move {
             // 'connect_with' is placed inside the async block so the event loop retries on failure.
             let connecting = endpoint
@@ -470,6 +471,7 @@ impl ConnectionManager {
                         cause,
                     })?;
 
+            info!(logger, "Connected to node {:?}", peer_id);
             Ok::<_, ConnectionEstablishError>(established)
         };
 


### PR DESCRIPTION
This will assist with debugging flaky test. Example of logs:
```
Fetching delegation from the nns subnet. Attempts: 1.
Establishing TCP connection to rbuft-7b2ng-tiz5n-uqpqb-tdkxx-5t2d4-h7lft-nq5em-6o3ou-nw5vw-aae @ [--REDACTED--]:8080
Establishing TLS stream to rbuft-7b2ng-tiz5n-uqpqb-tdkxx-5t2d4-h7lft-nq5em-6o3ou-nw5vw-aae. Tcp stream: PollEvented { io: Some(TcpStream { addr: [--REDACTED--]:43904, peer: [--REDACTED--]:8080, fd: 31 }) }
Establishing HTTP connection to rbuft-7b2ng-tiz5n-uqpqb-tdkxx-5t2d4-h7lft-nq5em-6o3ou-nw5vw-aae. Tls stream: TlsStream { io: PollEvented { io: Some(TcpStream { addr: [--REDACTED--]:43904, peer: [--REDACTED--]:8080, fd: 31 }) }, session: ClientConnection, state: Stream }
Attempt to fetch HTTPS delegation from root subnet node with addr = `[--REDACTED--]:8080`, uri = `/api/v2/canister/aaaaa-aa/read_state`.
Setting NNS delegation to: CertificateDelegation {...}
```