### PR TITLE
WIP: fixing SECFIND-935

### DIFF
--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -1120,7 +1120,7 @@ impl Swap {
     /// of ICP a buyer has contributed from the ICP ledger canister.
     ///
     /// It is assumed that prior to calling this method, tokens have
-    /// been transfer by the buyer to a subaccount of the swap
+    /// been transferred by the buyer to a subaccount of the swap
     /// canister (this canister) on the ICP ledger.
     /// Also, deletes an existing ticket if it has been fully executed
     /// (i.e. the requested increment is >= that the ticket amount).
@@ -1179,7 +1179,7 @@ impl Swap {
         // Once swap is OPEN, the Swap.params field is set. In light of validation performed
         // above, we should be able to `expect` this value without a panic.
         let params = &self.params.as_ref().expect("Expected params to be set");
-        // Subtraction safe because of the preceding if-statement.
+
         let max_increment_e8s = self.available_direct_participation_e8s();
 
         // Check that the maximum number of participants has not been reached yet.
@@ -1245,7 +1245,7 @@ impl Swap {
         // Limit the participation based on the maximum per participant.
         let new_balance_e8s = std::cmp::min(new_balance_e8s, max_participant_icp_e8s);
 
-        // Check that the new_balance_e8s is bigger than the minimum required for
+        // Check that the new_balance_e8s is bigger than or equal to the minimum required for
         // participating.
         if new_balance_e8s < params.min_participant_icp_e8s {
             return Err(format!(
@@ -1295,9 +1295,9 @@ impl Swap {
         self.buyers
             .entry(buyer.to_string())
             .or_insert_with(|| BuyerState::new(0))
-            .set_amount_icp_e8s(new_balance_e8s);
-        // We compute the current participation amounts once and store the result in Swap's state,
-        // for efficiency reasons.
+            .set_amount_icp_e8s(new_balance_e8s); // Shah-TODO redundant; could've set it in new()
+                                                  // We compute the current participation amounts once and store the result in Swap's state,
+                                                  // for efficiency reasons.
         self.update_total_participation_amounts();
 
         log!(
@@ -1314,6 +1314,8 @@ impl Swap {
                 self.max_direct_participation_e8s(),
             );
         }
+
+        // Shah-Question: why don't we enforce this constraint?
 
         Ok(RefreshBuyerTokensResponse {
             icp_accepted_participation_e8s: new_balance_e8s,


### PR DESCRIPTION
This PR mainly enforces a lower bound on `min_participant_icp_e8s` upon creation of a swap canister.