### PR TITLE
chore(IDX): extract file size checks from icos_build

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -403,20 +403,23 @@ write_info_file_var = rule(
 
 def file_size_check(
         name,
+        file,
         max_file_size):
     """
     A check to make sure the given file is below the specified size.
 
     Args:
-      name: Name of the file.
+      name: Name of the test.
+      file: File to check (label).
       max_file_size: Max accepted size in bytes.
     """
+
     native.sh_test(
-        name = "%s_size_test" % name,
+        name = name,
         srcs = ["//bazel:file_size_test.sh"],
-        data = [name],
+        data = [file],
         env = {
-            "FILE": "$(rootpath %s)" % name,
+            "FILE": "$(rootpath %s)" % file,
             "MAX_SIZE": str(max_file_size),
         },
     )

--- a/ic-os/guestos/envs/prod/BUILD.bazel
+++ b/ic-os/guestos/envs/prod/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//bazel:defs.bzl", "file_size_check")
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/guestos:defs.bzl", "image_deps")
 load("//publish:defs.bzl", "artifact_bundle")
@@ -6,19 +7,32 @@ load("//publish:defs.bzl", "artifact_bundle")
 # Check
 #       //ic-os/guestos/BUILD.bazel for examples
 #    or //ic-os/defs.bzl for the full list of targets.
-icos_build(
+icos_images = icos_build(
     name = "prod",
     image_deps_func = image_deps,
-    max_file_sizes = {
-        "disk-img.tar.zst": 450 * 1000 * 1000,  # 419 MB on 2025-03-21
-        "update-img.tar.zst": 450 * 1000 * 1000,  # 416 MB on 2025-03-21
-        "update-img-test.tar.zst": 450 * 1000 * 1000,  # 416 MB on 2025-03-21
-    },
     upload_prefix = "guest-os",
     visibility = [
         "//rs:ic-os-pkg",
         "//testnet/tools:icos_deploy-pkg",
     ],
+)
+
+file_size_check(
+    name = "disk_img_size_check",
+    file = icos_images.disk_image,
+    max_file_size = 450 * 1000 * 1000,  # 419 MB on 2025-03-21
+)
+
+file_size_check(
+    name = "update_img_size_check",
+    file = icos_images.update_image,
+    max_file_size = 450 * 1000 * 1000,  # 416 MB on 2025-03-21
+)
+
+file_size_check(
+    name = "update_img_test_size_check",
+    file = icos_images.update_image_test,
+    max_file_size = 450 * 1000 * 1000,  # 416 MB on 2025-03-21
 )
 
 # Export checksums & build artifacts

--- a/ic-os/hostos/envs/prod/BUILD.bazel
+++ b/ic-os/hostos/envs/prod/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//bazel:defs.bzl", "file_size_check")
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/hostos:defs.bzl", "image_deps")
 load("//publish:defs.bzl", "artifact_bundle")
@@ -6,17 +7,30 @@ load("//publish:defs.bzl", "artifact_bundle")
 # Check
 #       //ic-os/hostos/BUILD.bazel for examples
 #    or //ic-os/defs.bzl for the full list of targets.
-icos_build(
+icos_images = icos_build(
     name = "prod",
     image_deps_func = image_deps,
-    max_file_sizes = {
-        "disk-img.tar.zst": 900 * 1000 * 1000,  # 837 MB on 2025-03-21
-        "update-img.tar.zst": 900 * 1000 * 1000,  # 835 MB on 2025-03-21
-        "update-img-test.tar.zst": 900 * 1000 * 1000,  # 835 MB on 2025-03-21
-    },
     upload_prefix = "host-os",
     visibility = ["//rs:ic-os-pkg"],
     vuln_scan = False,
+)
+
+file_size_check(
+    name = "update_img_size_check",
+    file = icos_images.update_image,
+    max_file_size = 900 * 1000 * 1000,  # 835 MB on 2025-03-21
+)
+
+file_size_check(
+    name = "disk_img_size_check",
+    file = icos_images.disk_image,
+    max_file_size = 900 * 1000 * 1000,  # 837 MB on 2025-03-21
+)
+
+file_size_check(
+    name = "update_img_test_size_check",
+    file = icos_images.update_image_test,
+    max_file_size = 900 * 1000 * 1000,  # 835 MB on 2025-03-21
 )
 
 # Export checksums & build artifacts

--- a/ic-os/setupos/envs/prod/BUILD.bazel
+++ b/ic-os/setupos/envs/prod/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//bazel:defs.bzl", "file_size_check")
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/dev-tools/bare_metal_deployment:tools.bzl", "launch_bare_metal")
 load("//ic-os/setupos:defs.bzl", "image_deps")
@@ -7,15 +8,18 @@ load("//publish:defs.bzl", "artifact_bundle")
 # Check
 #       //ic-os/setupos/BUILD.bazel for examples
 #    or //ic-os/defs.bzl for the full list of targets.
-icos_build(
+icos_images = icos_build(
     name = "prod",
     image_deps_func = image_deps,
-    max_file_sizes = {
-        "disk-img.tar.zst": 2100 * 1000 * 1000,  # 2.1 GB on 2025-03-21
-    },
     upgrades = False,
     upload_prefix = "setup-os",
     vuln_scan = False,
+)
+
+file_size_check(
+    name = "disk_img_size_check",
+    file = icos_images.disk_image,
+    max_file_size = 2100 * 1000 * 1000,  # 2.1 GB on 2025-03-21
 )
 
 launch_bare_metal(

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -104,13 +104,14 @@ CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES.update(SNS_CANISTER_NAME_TO_MAX_COMPRESSE
 
 [
     file_size_check(
-        name = name,
+        name = file + "_size_check",
+        file = file,
         max_file_size = CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES.get(
-            name,
+            file,
             DEFAULT_CANISTERS_MAX_SIZE_E5_BYTES,
         ) * 100000,
     )
-    for (name, size) in CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES.items()
+    for (file, size) in CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES.items()
 ]
 
 # `bazel cquery --output=files` that is used by build-ic script does not show external sources of `filegroup` targets.


### PR DESCRIPTION
This brings the file size checks to the BUILD files for visibility, and also reduces some of the logic in the `icos_build` macro.

This file check macro is also modified so that its gets named according to the `name` passed in.