### PR TITLE
docs(governance): Enhance the CHANGELOG nag bot message.

### DIFF
--- a/.github/workflows/ci-pr-only-nns-team-reminder.yml
+++ b/.github/workflows/ci-pr-only-nns-team-reminder.yml
@@ -35,7 +35,7 @@ jobs:
               .data
               .some(review => review
                 .body
-                .startsWith("If this pull request affects the behavior of any canister owned by")
+                .startsWith("If this pull request changes the behavior")
               );
             console.log("alreadyRemindedAboutUnreleasedChangelog = " + alreadyRemindedAboutUnreleasedChangelog);
             if (alreadyRemindedAboutUnreleasedChangelog) {
@@ -46,9 +46,9 @@ jobs:
             // TODO: Figure out how to post in such a way that there is a "Resolve" button nearby.
             console.log("Adding reminder to update unreleased_changelog.md...");
             const reminderText = `
-              If this pull request changes behavior of any canister owned by the
-              Governance team in an externally visible way, remember to update
-              the corresponding unreleased_changelog.md file(s).
+              If this pull request changes the behavior of any canister owned by
+              the Governance team in an externally visible way, remember to
+              update the corresponding unreleased_changelog.md file(s).
 
               To acknowldge this reminder (and unblock the PR), dismiss this
               code review by going to the bottom of the pull request page, look


### PR DESCRIPTION
# Changes

1. It should say `unreleased_changelog.md`, not `unreleased_changes.md`.
2. Instead of just "behavior change", it says "externally visible behavior change".
3. Explains in more detail what "externally visible behavior change" means.
4. More precise instructions for how to satisfy the nag bot.