### PR TITLE
fix: flaky //rs/tests/consensus:replica_determinism_test

### DIFF
--- a/rs/tests/consensus/replica_determinism_test.rs
+++ b/rs/tests/consensus/replica_determinism_test.rs
@@ -27,7 +27,7 @@ use ic_system_test_driver::{
 use ic_types::{malicious_behaviour::MaliciousBehaviour, Height};
 use ic_universal_canister::wasm;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use slog::info;
 use std::time::Duration;
 
@@ -79,7 +79,7 @@ fn test(env: TestEnv) {
                     match malicious_node.try_build_default_agent_async().await {
                         Ok(agent) => Ok(agent),
                         Err(e) => {
-                            panic!("Failed to create agent: {}", e);
+                            bail!("Failed to create agent: {}", e)
                         }
                     }
                 }

--- a/rs/tests/consensus/replica_determinism_test.rs
+++ b/rs/tests/consensus/replica_determinism_test.rs
@@ -74,7 +74,7 @@ fn test(env: TestEnv) {
                 "Creating an agent for the malicious node",
                 &log,
                 Duration::from_secs(300),
-                Duration::from_secs(5),
+                Duration::from_secs(10),
                 || async {
                     match malicious_node.try_build_default_agent_async().await {
                         Ok(agent) => Ok(agent),

--- a/rs/tests/consensus/replica_determinism_test.rs
+++ b/rs/tests/consensus/replica_determinism_test.rs
@@ -79,7 +79,7 @@ fn test(env: TestEnv) {
                     match malicious_node.try_build_default_agent_async().await {
                         Ok(agent) => Ok(agent),
                         Err(e) => {
-                            bail!("Failed to create agent: {}", e)
+                            bail!("Failed to create agent: {}. This is okay as the malicious node is expected to eventually panic due to divergence.", e)
                         }
                     }
                 }


### PR DESCRIPTION
The `//rs/tests/consensus:replica_determinism_test` was flaky because the malicious node could turn malicious and crash the replica just after the health check but before creating the agent. If this happened creating the agent would fail with:
```
2025-05-08 10:06:44.846 INFO[test:StdErr] Could not create agent: TransportError(reqwest::Error 
  { kind: Request, url: "http://[2602:fb2b:100:10:501e:e3ff:fefe:d2e5]:8080/api/v2/status", 
    source: hyper_util::client::legacy::Error(Connect, ConnectError(
      "tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })) })
```
This is fixed by retrying creating the agent because the crashed replica should come back online after a while.