### PR TITLE
fix: clear canister logs before instantiating new canister during reinstall

### DIFF
--- a/rs/execution_environment/src/execution/install.rs
+++ b/rs/execution_environment/src/execution/install.rs
@@ -28,7 +28,7 @@ use ic_types::methods::{FuncRef, SystemMethod, WasmMethod};
 
 /// Installs a new code in canister. The algorithm consists of five stages:
 /// - Stage 0: validate input.
-/// - Stage 1: create a new execution state based on the new Wasm code, clear certified data, deactivate global timer, and bump canister version.
+/// - Stage 1: create a new execution state based on the new Wasm code, clear certified data and canister logs, deactivate global timer, and bump canister version.
 /// - Stage 2: invoke the `start()` method (if present).
 /// - Stage 3: invoke the `canister_init()` method (if present).
 /// - Stage 4: finalize execution and refund execution cycles.
@@ -44,7 +44,7 @@ use ic_types::methods::{FuncRef, SystemMethod, WasmMethod};
 ///   │
 ///   │
 ///   ▼
-/// [create new execution state, clear certified data, deactivate global timer, and bump canister version]
+/// [create new execution state, clear certified data and canister logs, deactivate global timer, and bump canister version]
 ///   │
 ///   │
 ///   │                   exceeded slice
@@ -94,7 +94,7 @@ pub(crate) fn execute_install(
         );
     }
 
-    // Stage 1: create a new execution state based on the new Wasm binary, clear certified data, deactivate global timer, and bump canister version.
+    // Stage 1: create a new execution state based on the new Wasm binary, clear certified data and canister logs, deactivate global timer, and bump canister version.
     let canister_id = helper.canister().canister_id();
     let layout = canister_layout(&original.canister_layout_path, &canister_id);
     let context_sender = context.sender();
@@ -142,6 +142,7 @@ pub(crate) fn execute_install(
         );
     }
     helper.clear_certified_data();
+    helper.clear_log();
     helper.deactivate_global_timer();
     helper.bump_canister_version();
     helper.add_canister_change(round.time, context.origin, context.mode, module_hash.into());

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -77,6 +77,7 @@ pub(crate) enum InstallCodeStep {
         memory_handling: CanisterMemoryHandling,
     },
     ClearCertifiedData,
+    ClearLog,
     DeactivateGlobalTimer,
     BumpCanisterVersion,
     AddCanisterChange {
@@ -146,6 +147,11 @@ impl InstallCodeHelper {
     pub fn clear_certified_data(&mut self) {
         self.steps.push(InstallCodeStep::ClearCertifiedData);
         self.canister.system_state.certified_data = Vec::new();
+    }
+
+    pub fn clear_log(&mut self) {
+        self.steps.push(InstallCodeStep::ClearLog);
+        self.canister.clear_log();
     }
 
     pub fn deactivate_global_timer(&mut self) {
@@ -475,10 +481,6 @@ impl InstallCodeHelper {
                 self.total_heap_delta.get() as usize / PAGE_SIZE,
                 instructions_used,
             );
-        }
-
-        if original.mode == CanisterInstallModeV2::Reinstall {
-            self.canister.clear_log();
         }
 
         DtsInstallCodeResult::Finished {
@@ -835,6 +837,10 @@ impl InstallCodeHelper {
             ),
             InstallCodeStep::ClearCertifiedData => {
                 self.clear_certified_data();
+                Ok(())
+            }
+            InstallCodeStep::ClearLog => {
+                self.clear_log();
                 Ok(())
             }
             InstallCodeStep::DeactivateGlobalTimer => {

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -684,6 +684,7 @@ fn test_deleting_logs_on_reinstall() {
     );
 
     // Reinstall canister to version #2.
+    let timestamp_2_reinstall = system_time_to_nanos(env.time());
     env.install_wasm_in_mode(
         canister_id,
         CanisterInstallMode::Reinstall,
@@ -706,7 +707,11 @@ fn test_deleting_logs_on_reinstall() {
     let result = fetch_canister_logs(&env, controller, canister_id);
     assert_eq!(
         FetchCanisterLogsResponse::decode(&get_reply(result)).unwrap(),
-        canister_log_response(vec![(5, timestamp_2_update, b"test_2".to_vec())])
+        canister_log_response(vec![
+            (3, timestamp_2_reinstall, b"start_2".to_vec()),
+            (4, timestamp_2_reinstall, b"init_2".to_vec()),
+            (5, timestamp_2_update, b"test_2".to_vec())
+        ])
     );
 }
 


### PR DESCRIPTION
This PR clears canister logs before instantiating the new canister when reinstalling the canister. Before the canister logs were only cleared after the canister init hook completed and thus the logs produced during the canister start and init hooks were lost. This fix is also in line with the [specification](https://internetcomputer.org/docs/references/ic-interface-spec#ic-management-canister-code-installation).