### PR TITLE
chore: do not change allocation when installing code

### DIFF
--- a/rs/nervous_system/root/src/change_canister.rs
+++ b/rs/nervous_system/root/src/change_canister.rs
@@ -71,11 +71,6 @@ pub struct ChangeCanisterRequest {
     /// The new canister args
     #[serde(with = "serde_bytes")]
     pub arg: Vec<u8>,
-
-    #[serde(serialize_with = "serialize_optional_nat")]
-    pub compute_allocation: Option<candid::Nat>,
-    #[serde(serialize_with = "serialize_optional_nat")]
-    pub memory_allocation: Option<candid::Nat>,
 }
 
 impl ChangeCanisterRequest {
@@ -94,8 +89,6 @@ impl ChangeCanisterRequest {
             .field("wasm_module_sha256", &format!("{:x?}", wasm_sha))
             .field("chunked_canister_wasm", &self.chunked_canister_wasm)
             .field("arg_sha256", &format!("{:x?}", arg_sha))
-            .field("compute_allocation", &self.compute_allocation)
-            .field("memory_allocation", &self.memory_allocation)
             .finish()
     }
 }
@@ -125,14 +118,7 @@ impl ChangeCanisterRequest {
             wasm_module: Vec::new(),
             chunked_canister_wasm: None,
             arg: Encode!().unwrap(),
-            compute_allocation: None,
-            memory_allocation: None,
         }
-    }
-
-    pub fn with_memory_allocation(mut self, n: u64) -> Self {
-        self.memory_allocation = Some(candid::Nat::from(n));
-        self
     }
 
     pub fn with_wasm(mut self, wasm_module: Vec<u8>) -> Self {
@@ -295,9 +281,6 @@ async fn install_code(request: ChangeCanisterRequest) -> ic_cdk::api::call::Call
         wasm_module,
         chunked_canister_wasm,
         arg,
-        compute_allocation,
-        memory_allocation,
-
         stop_before_installing: _,
     } = request;
 
@@ -338,8 +321,8 @@ async fn install_code(request: ChangeCanisterRequest) -> ic_cdk::api::call::Call
             canister_id,
             wasm_module,
             arg,
-            compute_allocation,
-            memory_allocation,
+            compute_allocation: None,
+            memory_allocation: None,
             sender_canister_version,
         };
         ic_cdk::api::call::call(

--- a/rs/nns/governance/src/proposals/install_code.rs
+++ b/rs/nns/governance/src/proposals/install_code.rs
@@ -99,8 +99,6 @@ impl InstallCode {
         let canister_id = self.valid_canister_id()?;
         let wasm_module = self.valid_wasm_module()?.clone();
         let arg = self.valid_arg()?.clone();
-        let compute_allocation = None;
-        let memory_allocation = None;
 
         Encode!(&ChangeCanisterRequest {
             stop_before_installing,
@@ -108,8 +106,6 @@ impl InstallCode {
             canister_id,
             wasm_module,
             arg,
-            compute_allocation,
-            memory_allocation,
             chunked_canister_wasm: None,
         })
         .map_err(|e| invalid_proposal_error(&format!("Failed to encode payload: {}", e)))
@@ -311,8 +307,6 @@ mod tests {
                 canister_id: REGISTRY_CANISTER_ID,
                 wasm_module: vec![1, 2, 3],
                 arg: vec![4, 5, 6],
-                compute_allocation: None,
-                memory_allocation: None,
                 chunked_canister_wasm: None,
             }
         );
@@ -384,8 +378,6 @@ mod tests {
                 canister_id: SNS_WASM_CANISTER_ID,
                 wasm_module: vec![1, 2, 3],
                 arg: vec![],
-                compute_allocation: None,
-                memory_allocation: None,
                 chunked_canister_wasm: None,
             }
         );

--- a/rs/nns/handlers/root/impl/canister/root.did
+++ b/rs/nns/handlers/root/impl/canister/root.did
@@ -82,8 +82,6 @@ type ChangeCanisterRequest = record {
   stop_before_installing : bool;
   mode : CanisterInstallMode;
   canister_id : principal;
-  memory_allocation : opt nat;
-  compute_allocation : opt nat;
 };
 
 type DefiniteCanisterSettings = record {

--- a/rs/nns/handlers/root/unreleased_changelog.md
+++ b/rs/nns/handlers/root/unreleased_changelog.md
@@ -14,6 +14,8 @@ on the process that this file is part of, see
 ## Deprecated
 
 ## Removed
+- The fields `compute_allocation` and `memory_allocation` in the input type `ChangeCanisterRequest`
+  of the endpoint `change_nns_canister`.
 
 ## Fixed
 

--- a/rs/nns/integration_tests/src/governance_upgrade.rs
+++ b/rs/nns/integration_tests/src/governance_upgrade.rs
@@ -129,8 +129,6 @@ fn test_root_restarts_canister_during_upgrade_canister_with_stop_canister_timeou
         canister_id: GOVERNANCE_CANISTER_ID,
         wasm_module,
         arg: vec![],
-        compute_allocation: None,
-        memory_allocation: None,
         chunked_canister_wasm: None,
     };
 

--- a/rs/nns/integration_tests/src/root_proposals.rs
+++ b/rs/nns/integration_tests/src/root_proposals.rs
@@ -91,9 +91,6 @@ fn test_upgrade_governance_through_root_proposal() {
         // Build and submit a root proposal
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 // Note that we upgrade the governance canister to the universal
                 // canister (effectively breaking governance). This is needed so
                 // that we can be sure that the upgrade actually went through.
@@ -193,9 +190,6 @@ fn test_unauthorized_user_cant_submit_on_root_proposals() {
         // Build and submit a root proposal
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let response: Result<(), String> = nns_canisters
@@ -233,9 +227,6 @@ fn test_cant_submit_root_proposal_with_wrong_sha() {
         // Build and submit a root proposal
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let empty_wasm_sha =
@@ -279,9 +270,6 @@ fn test_enough_no_votes_rejects_the_proposal() {
         // Build and submit a root proposal
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 // Note that we upgrade the governance canister to the universal
                 // canister (effectively breaking governance). This is needed so
                 // that we can be sure that the upgrade actually went through.
@@ -358,9 +346,6 @@ fn test_changing_the_sha_invalidates_the_proposal() {
         // Build and submit a root proposal
         let change_canister_request1 =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 // Note that we upgrade the governance canister to the empty
                 // canister (effectively breaking governance). This is needed so
                 // that we can be sure that the upgrade actually went through.
@@ -392,9 +377,6 @@ fn test_changing_the_sha_invalidates_the_proposal() {
         // Build and submit a second root proposal
         let change_canister_request2 =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let response: Result<(), String> = nns_canisters

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -37,7 +37,7 @@ use ic_nervous_system_root::change_canister::{
     AddCanisterRequest, CanisterAction, ChangeCanisterRequest, StopOrStartCanisterRequest,
 };
 use ic_nns_common::types::{NeuronId, ProposalId, UpdateIcpXdrConversionRatePayload};
-use ic_nns_constants::{memory_allocation_of, GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID};
+use ic_nns_constants::{GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::{
     add_or_remove_node_provider::Change,
     bitcoin::{BitcoinNetwork, BitcoinSetConfigProposal},
@@ -1017,15 +1017,6 @@ struct ProposeToChangeNnsCanisterCmd {
     /// The sha256 of the arg binary file.
     #[clap(long)]
     arg_sha256: Option<String>,
-
-    #[clap(long)]
-    /// If set, it will update the canister's compute allocation to this value.
-    /// See `ComputeAllocation` for the semantics of this field.
-    compute_allocation: Option<u64>,
-    #[clap(long)]
-    /// If set, it will update the canister's memory allocation to this value.
-    /// See `MemoryAllocation` for the semantics of this field.
-    memory_allocation: Option<u64>,
 }
 
 #[async_trait]
@@ -1075,8 +1066,6 @@ impl ProposalPayload<ChangeCanisterRequest> for ProposeToChangeNnsCanisterCmd {
             canister_id: self.canister_id,
             wasm_module,
             arg,
-            compute_allocation: self.compute_allocation.map(candid::Nat::from),
-            memory_allocation: self.memory_allocation.map(candid::Nat::from),
             chunked_canister_wasm: None,
         }
     }
@@ -6188,7 +6177,6 @@ impl RootCanisterClient {
         .await;
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(memory_allocation_of(GOVERNANCE_CANISTER_ID))
                 .with_wasm(wasm_module);
 
         let serialized = Encode!(&CanisterIdRecord::from(GOVERNANCE_CANISTER_ID)).unwrap();

--- a/rs/sns/integration_tests/src/root.rs
+++ b/rs/sns/integration_tests/src/root.rs
@@ -315,8 +315,6 @@ fn test_root_restarts_governance_on_stop_canister_timeout() {
         canister_id: GOVERNANCE_CANISTER_ID,
         wasm_module,
         arg: vec![],
-        compute_allocation: None,
-        memory_allocation: None,
         chunked_canister_wasm: None,
     };
 

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -58,8 +58,6 @@ type ChangeCanisterRequest = record {
   stop_before_installing : bool;
   mode : CanisterInstallMode;
   canister_id : principal;
-  memory_allocation : opt nat;
-  compute_allocation : opt nat;
 };
 
 type DefiniteCanisterSettings = record {

--- a/rs/sns/root/unreleased_changelog.md
+++ b/rs/sns/root/unreleased_changelog.md
@@ -14,6 +14,8 @@ on the process that this file is part of, see
 ## Deprecated
 
 ## Removed
+- The fields `compute_allocation` and `memory_allocation` in the input type `ChangeCanisterRequest`
+  of the endpoint `change_canister`.
 
 ## Fixed
 


### PR DESCRIPTION
This PR prevents setting the compute or memory allocation when installing canister code in NNS tooling:
- compute and memory allocation are dropped from the input type `ChangeCanisterRequest` of NNS and SNS root canister endpoints;
- memory allocation is not set in root proposals to upgrade the governance canister (ic-admin, tests);
- compute and memory allocation is not set in change NNS canister requests (ic-admin).