### PR TITLE
fix: let test-namespace-darwin use the hermetic cc toolchain

### DIFF
--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -32,9 +32,9 @@ jobs:
       # Build and test, excluding 'upload' jobs that are not required on macOS (used in reproducibility tests)
       - name: Test
         run: |
-          # Until we have a hermetic CC toolchain, tell bazel to use the "real" clang
-          # (instead of Apple's, which sometimes breaks on wasm32)
-          export CC=/opt/homebrew/opt/llvm/bin/clang
+          # Setup zig-cache
+          mkdir -p /tmp/zig-cache
+
           bazel \
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \


### PR DESCRIPTION
CI sometimes runs into [the following error](https://github.com/dfinity/ic/actions/runs/14966115526/job/42037281951) on the workflow: Bazel Test macOS Apple Silicon:
```
ERROR: /Users/runner/work/ic/ic/rs/nns/handlers/lifeline/impl/BUILD.bazel:35:16: CopyIdlFiles 
rs/nns/handlers/lifeline/impl/actor_idl_path failed: I/O exception during sandboxed execution: 
/private/tmp/zig-cache (No such file or directory)
```

`.github/workflows/test-namespace-darwin.yaml` doesn't actually use `.github/actions/bazel` which creates the `/tmp/zig-cache` directory. So let's create it. 

It's unclear why this failure only happens sometimes and [didn't happen](https://github.com/dfinity/ic/actions/runs/14894656219/job/41834646820) on https://github.com/dfinity/ic/pull/4848 which re-introduced the hermetic CC toolchain.

This also drops:
```
          # Until we have a hermetic CC toolchain, tell bazel to use the "real" clang
          # (instead of Apple's, which sometimes breaks on wasm32)
          export CC=/opt/homebrew/opt/llvm/bin/clang
```
since we now have the hermetic CC toolchain available.