### PR TITLE
chore: Update boot args key to `extra_boot_args_template`

### DIFF
--- a/ic-os/defs.bzl
+++ b/ic-os/defs.bzl
@@ -220,7 +220,7 @@ def icos_build(
         )
 
     # When boot_args are fixed, don't bother signing
-    if "boot_args_template" not in image_deps:
+    if "extra_boot_args_template" not in image_deps:
         native.alias(name = "partition-root.tzst", actual = ":partition-root-unsigned.tzst", tags = ["manual", "no-cache"])
         native.alias(name = "extra_boot_args", actual = image_deps["extra_boot_args"], tags = ["manual"])
 
@@ -228,7 +228,7 @@ def icos_build(
             native.alias(name = "partition-root-test.tzst", actual = ":partition-root-test-unsigned.tzst", tags = ["manual", "no-cache"])
             native.alias(name = "extra_boot_test_args", actual = image_deps["extra_boot_args"], tags = ["manual"])
     else:
-        native.alias(name = "extra_boot_args_template", actual = image_deps["boot_args_template"], tags = ["manual"])
+        native.alias(name = "extra_boot_args_template", actual = image_deps["extra_boot_args_template"], tags = ["manual"])
 
         native.genrule(
             name = "partition-root-sign",

--- a/ic-os/guestos/defs.bzl
+++ b/ic-os/guestos/defs.bzl
@@ -75,7 +75,7 @@ def image_deps(mode, malicious = False):
         # substitution) as a dependency so that changes to the template file are
         # reflected in the overall version hash (the root_hash must include the
         # version hash, it cannot be the other way around).
-        "boot_args_template": Label("//ic-os/guestos/context:extra_boot_args.template"),
+        "extra_boot_args_template": Label("//ic-os/guestos/context:extra_boot_args.template"),
     }
 
     dev_build_args = ["BUILD_TYPE=dev", "ROOT_PASSWORD=root"]


### PR DESCRIPTION
Renamed `boot_args_template` to `extra_boot_args_template` for consistency.