### PR TITLE
chore(nns): Minor refactoring and documentation for NnsGov.register_vote

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -5674,7 +5674,7 @@ impl Governance {
             .map(|p| p.topic())
             .unwrap_or(Topic::Unspecified);
 
-        let vote = Vote::try_from(vote).unwrap_or(Vote::Unspecified);
+        let vote = Vote::try_from(*vote).unwrap_or(Vote::Unspecified);
         if vote == Vote::Unspecified {
             // Invalid vote specified, i.e., not yes or no.
             return Err(GovernanceError::new_with_message(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -5632,7 +5632,7 @@ impl Governance {
     /// 2. `register_vote.vote` must not be `Vote::Unspecified`.
     /// 3. The neuron has not already cast its vote.
     ///
-    /// Practically, neurons that have already dissolved cannto vote, so long as the minimal
+    /// Practically, neurons that have already dissolved cannot vote, as long as the minimal
     /// possible dissolve delay is greated than the maximum possible voting period. Refer to:
     /// - `VotingPowerEconomics.NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS_BOUNDS`
     /// - `ProposalData.evaluate_wait_for_quiet`

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -5627,10 +5627,12 @@ impl Governance {
 
     /// Preconditions:
     /// 0. `register_vote.proposal` is a proposal ID of a proposal that still accepts votes.
-    /// 1. Neuron identified by `neuron_id` is authorized to vote on that proposal
-    ///    (either due to being the controller or a hotkey of a neuron that has a ballot).
-    /// 2. `register_vote.vote` must not be `Vote::Unspecified`.
-    /// 3. The neuron has not already cast its vote.
+    /// 1. `neuron_id` identifies an existing neuron that is eligible to vote on that proposal
+    ///    (i.e., it has a corresponding ballot).
+    /// 2. `caller` is authorized to vote on behalf of `neuron_id` (either due to being its
+    ///    controller or a hotkey).
+    /// 3. `register_vote.vote` must not be `Vote::Unspecified`.
+    /// 4. The neuron has not already cast its vote.
     ///
     /// Practically, neurons that have already dissolved cannot vote, as long as the minimal
     /// possible dissolve delay is greated than the maximum possible voting period. Refer to:

--- a/rs/nns/governance/src/network_economics.rs
+++ b/rs/nns/governance/src/network_economics.rs
@@ -287,7 +287,13 @@ impl VotingPowerEconomics {
     pub const DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS: u64 = 6 * ONE_MONTH_SECONDS;
 
     /// A proposal to set `VotingPowerEconomics.min_dissolve_delay_seconds` must specify a value
-    /// for this field that falls within this range.
+    /// for this field that falls within this range. Changing the lower bound of this parameter
+    /// requires manually checking how it might interact with other aspects of the NNS.
+    /// In particular, it is not currently possible for a dissolved neuron to cast a vote, as
+    /// the minimal dissolve delay to be eligible for voting exceeds the maximal voting period.
+    /// Thus, there may be implicit dependencies of the NNS itself or its clients on this aspect,
+    /// which originate from the time when the minimum dissolve delay to vote was an internal NNS
+    /// constant.
     pub const NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS_BOUNDS: RangeInclusive<u64> =
         (3 * ONE_MONTH_SECONDS)..=(6 * ONE_MONTH_SECONDS);
 


### PR DESCRIPTION
This PR offers a minor refactoring for the `register_vote` function in the NNS, and adds a doc comment to explain the preconditions of that function.