### PR TITLE
chore: EXC-1701: Add error doc link for canister snapshot limit error.

### DIFF
--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -648,8 +648,8 @@ impl AsErrorHelp for CanisterManagerError {
                 }
             }
             CanisterManagerError::CanisterSnapshotLimitExceeded { .. } => ErrorHelp::UserError {
-                suggestion: "".to_string(),
-                doc_link: "".to_string(),
+                suggestion: "Consider removing an unused snapshot of the specified canister before creating a new one.".to_string(),
+                doc_link: "canister-snapshot-limit-exceeded".to_string(),
             },
             CanisterManagerError::CanisterSnapshotNotEnoughCycles { .. } => ErrorHelp::UserError {
                 suggestion: "".to_string(),

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -648,7 +648,7 @@ impl AsErrorHelp for CanisterManagerError {
                 }
             }
             CanisterManagerError::CanisterSnapshotLimitExceeded { .. } => ErrorHelp::UserError {
-                suggestion: "Consider removing an unused snapshot of the specified canister before creating a new one.".to_string(),
+                suggestion: "Consider deleting an unused snapshot of the specified canister before creating a new one.".to_string(),
                 doc_link: "canister-snapshot-limit-exceeded".to_string(),
             },
             CanisterManagerError::CanisterSnapshotNotEnoughCycles { .. } => ErrorHelp::UserError {

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -648,7 +648,7 @@ impl AsErrorHelp for CanisterManagerError {
                 }
             }
             CanisterManagerError::CanisterSnapshotLimitExceeded { .. } => ErrorHelp::UserError {
-                suggestion: "Consider deleting an unused snapshot of the specified canister before creating a new one.".to_string(),
+                suggestion: "Consider deleting an unnecessary snapshot of the specified canister before creating a new one.".to_string(),
                 doc_link: "canister-snapshot-limit-exceeded".to_string(),
             },
             CanisterManagerError::CanisterSnapshotNotEnoughCycles { .. } => ErrorHelp::UserError {

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -460,13 +460,11 @@ fn take_canister_snapshot_fails_when_limit_is_reached() {
         .subnet_message("take_canister_snapshot", args.encode())
         .unwrap_err();
     assert_eq!(error.code(), ErrorCode::CanisterRejectedMessage);
-    assert_eq!(
-        error.description(),
-        format!(
-            "Canister {} has reached the maximum number of snapshots allowed: {}.",
-            canister_id, max_snapshots_per_canister,
-        )
+    let error_message = format!(
+        "Canister {} has reached the maximum number of snapshots allowed: {}.",
+        canister_id, max_snapshots_per_canister,
     );
+    assert!(error.description().contains(&error_message));
 }
 
 fn grow_stable_memory(


### PR DESCRIPTION
This PR links the Internet Computer specifications to the error: CanisterManagerError::SnapshotLimitExceeded. 

The interface spec changes are covered by [PR-5742](https://github.com/dfinity/portal/pull/5742)