### PR TITLE
chore: renaming mentions of ch1-obsdev1 into testnet

### DIFF
--- a/.github/workflows/schedule-rust-bench.yml
+++ b/.github/workflows/schedule-rust-bench.yml
@@ -79,7 +79,7 @@ jobs:
                 .revCount = 1' \
                     >report.json
                 curl --fail --retry 2 -sS -o /dev/null -X POST -H 'Content-Type: application/json' --data @report.json \
-                    "https://elasticsearch.ch1-obsdev1.dfinity.network/ci-performance-test/_doc"
+                    "https://elasticsearch.testnet.dfinity.network/ci-performance-test/_doc"
             done < <(find -L ./bazel-out -type d -path '*/new')
 
             echo -e "\e[34mRust benchmarks on dedicated machine fr1-spm15 finished.\e[0m"

--- a/rs/ic_os/config/src/lib.rs
+++ b/rs/ic_os/config/src/lib.rs
@@ -154,7 +154,7 @@ mod tests {
             "mgmt_mac": "EC:2A:72:31:A2:0C",
             "deployment_environment": "Mainnet",
             "logging": {
-                "elasticsearch_hosts": "elasticsearch.ch1-obsdev1.dfinity.network:443",
+                "elasticsearch_hosts": "elasticsearch.testnet.dfinity.network:443",
                 "elasticsearch_tags": "tag1 tag2"
             },
             "use_nns_public_key": true,

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -359,7 +359,7 @@ pub fn tecdsa_performance_test(
         if cfg!(feature = "upload_perf_systest_results") {
             // elastic search url
             const ES_URL: &str =
-                "https://elasticsearch.ch1-obsdev1.dfinity.network/ci-performance-test/_doc";
+                "https://elasticsearch.testnet.dfinity.network/ci-performance-test/_doc";
             const NUM_UPLOAD_ATTEMPS: usize = 3;
             info!(
                 log,

--- a/rs/tests/consensus/utils/src/performance.rs
+++ b/rs/tests/consensus/utils/src/performance.rs
@@ -351,7 +351,7 @@ pub async fn persist_metrics(
 ) {
     // elastic search url
     const ES_URL: &str =
-        "https://elasticsearch.ch1-obsdev1.dfinity.network/ci-consensus-performance-test/_doc";
+        "https://elasticsearch.testnet.dfinity.network/ci-consensus-performance-test/_doc";
 
     let timestamp =
         chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::now()).to_rfc3339();

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -1173,7 +1173,7 @@ impl<T: HasTestEnv> HasIcDependencies for T {
 pub fn get_elasticsearch_hosts() -> Result<Vec<String>> {
     let dep_rel_path = "elasticsearch_hosts";
     let hosts = read_dependency_to_string(dep_rel_path)
-        .unwrap_or_else(|_| "elasticsearch.ch1-obsdev1.dfinity.network:443".to_string());
+        .unwrap_or_else(|_| "elasticsearch.testnet.dfinity.network:443".to_string());
     parse_elasticsearch_hosts(Some(hosts))
 }
 

--- a/testnet/env/shared-config.yml
+++ b/testnet/env/shared-config.yml
@@ -68,7 +68,7 @@ nodes:
     orchestrator_metrics_listen_addr: "[{{ orchestrator_metrics_listen_ip }}]:{{ orchestrator_metrics_listen_port }}"
 
     elasticsearch_hosts:
-      - "elasticsearch.ch1-obsdev1.dfinity.network:443"
+      - "elasticsearch.testnet.dfinity.network:443"
 
 api:
   vars:
@@ -87,7 +87,7 @@ boundary:
   vars:
     api_listen_port: 443
     api_listen_protocol: https
-    elasticsearch_url: "https://elasticsearch.ch1-obsdev1.dfinity.network"
+    elasticsearch_url: "https://elasticsearch.testnet.dfinity.network"
     ipv4_http_ips: # See: https://www.cloudflare.com/ips-v4
       - "103.21.244.0/22" # Cloudflare: https://www.cloudflare.com/ips/
       - "103.22.200.0/22" # Cloudflare: https://www.cloudflare.com/ips/


### PR DESCRIPTION
This PR finishes the long awaited transition from development clusters for kibana and elasticsearch to a production cluster in dm1. 