### PR TITLE
chore: let build-ic upload but not download from the bazel remote cache

### DIFF
--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -110,7 +110,7 @@ export VERSION="$(git rev-parse HEAD)"
 BAZEL_TARGETS=()
 
 BAZEL_COMMON_ARGS=(
-    --config=local
+    --noremote_accept_cached
     --color=yes
 )
 


### PR DESCRIPTION
To debug build determinism failures it's useful if the `build-ic` job would upload its bazel outputs to the cache so that we can later download them to compare them with the similar outputs from the `bazel-test-all` job in case there were failures.

So this commit stops using `--config=local` for `build-ic` (which disabled the cache completely: `build:local --remote_cache=`) and replaces it with [`--noremote_accept_cached`](https://bazel.build/reference/command-line-reference#build-flag--remote_accept_cached) to upload but not download from the cache.

