### PR TITLE
feat(IDX): Add prefix to artifact bundles

### DIFF
--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -172,7 +172,10 @@ for artifact in $(bazel cquery "${BAZEL_COMMON_ARGS[@]}" --output=files "$query"
     esac
 
     mkdir -p "$target_dir"
-    cp "$artifact" "$target_dir"
+
+    # We use -L so that find dereferences symlinks (artifacts are not
+    # necessarily duplicated in the build)
+    find -L "$artifact" -type f -exec cp {} "$target_dir" \;
 done
 
 if "$BUILD_BIN"; then

--- a/ic-os/guestos/envs/prod/BUILD.bazel
+++ b/ic-os/guestos/envs/prod/BUILD.bazel
@@ -39,12 +39,13 @@ file_size_check(
 artifact_bundle(
     name = "bundle",
     inputs = [":prod"],
+    prefix = "guest-os/update-img",
 )
 
 # This image is used for GuestOS upgrades
 upload_artifacts(
     name = "upload_update-img",
     inputs = [icos_images.update_image],
-    remote_subdir = "guestos-os/update-img",
+    remote_subdir = "guest-os/update-img",
     visibility = ["//visibility:public"],  # testnet deploy tools use this
 )

--- a/ic-os/hostos/envs/prod/BUILD.bazel
+++ b/ic-os/hostos/envs/prod/BUILD.bazel
@@ -37,6 +37,7 @@ file_size_check(
 artifact_bundle(
     name = "bundle",
     inputs = [":prod"],
+    prefix = "host-os/update-img",
 )
 
 # This image is used for HostOS upgrades

--- a/ic-os/setupos/envs/prod/BUILD.bazel
+++ b/ic-os/setupos/envs/prod/BUILD.bazel
@@ -31,6 +31,7 @@ launch_bare_metal(
 artifact_bundle(
     name = "bundle",
     inputs = [":prod"],
+    prefix = "setup-os/disk-img",
 )
 
 # This image is used as the IC-OS installation image downloaded by Node Providers

--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -121,6 +121,13 @@ filegroup(
 artifact_bundle(
     name = "bundle",
     inputs = [":binaries"],
+    prefix = "binaries/" + os_info,
+)
+
+artifact_bundle(
+    name = "bundle-legacy",
+    inputs = [":binaries"],
+    prefix = "release",
 )
 
 upload_artifacts(

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -135,6 +135,7 @@ filegroup(
 artifact_bundle(
     name = "bundle",
     inputs = [":canisters"],
+    prefix = "canisters",
 )
 
 # the further targets are all testonly for simplicity because if a target was


### PR DESCRIPTION
This adds a `prefix` option when creating artifact bundles. This will allow us to use the bundles directly when uploading artifacts to the CDN, instead of duplicating the logic of listing artifacts & computing checksums.

This also makes the necessary changes in `build-ic.sh` to support nested build artifacts as well as fixes a typo in the guestos directory name.

The implementation of `artifact_bundle` is also simplified to avoid creating symlinks from Bazel; moreover the output of `artifact_bundle` is now a _directory_ instead of a list of artifacts.

Prefixes are also added to all artifact bundles to reflect the file structure on the CDN.