### PR TITLE
fix(IDX): Fix trivy comment

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -235,7 +235,7 @@ load("//bazel:rclone.bzl", "rclone_repository")
 
 rclone_repository(name = "rclone")
 
-# trivy binary for upload_artifacts
+# trivy binary for vulnerability scanning
 load("//bazel:trivy.bzl", "trivy_scan")
 
 trivy_scan(name = "trivy")


### PR DESCRIPTION
The `trivy` binary is used for vulnerability scanning, and not for uploading artifacts.