### PR TITLE
chore(node): don't check test image size

### DIFF
--- a/ic-os/guestos/envs/prod/BUILD.bazel
+++ b/ic-os/guestos/envs/prod/BUILD.bazel
@@ -29,12 +29,6 @@ file_size_check(
     max_file_size = 450 * 1000 * 1000,  # 416 MB on 2025-03-21
 )
 
-file_size_check(
-    name = "update_img_test_size_check",
-    file = icos_images.update_image_test,
-    max_file_size = 450 * 1000 * 1000,  # 416 MB on 2025-03-21
-)
-
 # Export checksums & build artifacts
 artifact_bundle(
     name = "bundle",

--- a/ic-os/hostos/envs/prod/BUILD.bazel
+++ b/ic-os/hostos/envs/prod/BUILD.bazel
@@ -27,12 +27,6 @@ file_size_check(
     max_file_size = 900 * 1000 * 1000,  # 837 MB on 2025-03-21
 )
 
-file_size_check(
-    name = "update_img_test_size_check",
-    file = icos_images.update_image_test,
-    max_file_size = 900 * 1000 * 1000,  # 835 MB on 2025-03-21
-)
-
 # Export checksums & build artifacts
 artifact_bundle(
     name = "bundle",


### PR DESCRIPTION
This drops the file size checks on test images. Those images are not distributed.