### PR TITLE
chore(nns): Remove incorrect memory_allocation_of function

### DIFF
--- a/rs/ledger_suite/icp/test_utils/src/pocket_ic_helpers/mod.rs
+++ b/rs/ledger_suite/icp/test_utils/src/pocket_ic_helpers/mod.rs
@@ -1,7 +1,6 @@
-use candid::{CandidType, Decode, Encode, Nat, Principal};
+use candid::{CandidType, Decode, Encode, Principal};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_management_canister_types::CanisterSettings;
-use ic_nns_constants::ALL_NNS_CANISTER_IDS;
 use pocket_ic::PocketIc;
 use serde::Deserialize;
 

--- a/rs/ledger_suite/icp/test_utils/src/pocket_ic_helpers/mod.rs
+++ b/rs/ledger_suite/icp/test_utils/src/pocket_ic_helpers/mod.rs
@@ -19,14 +19,7 @@ pub fn install_canister(
     controller: Option<PrincipalId>,
 ) {
     let controller_principal = controller.map(|c| c.0);
-    let memory_allocation = if ALL_NNS_CANISTER_IDS.contains(&&canister_id) {
-        let memory_allocation_bytes = ic_nns_constants::memory_allocation_of(canister_id);
-        Some(Nat::from(memory_allocation_bytes))
-    } else {
-        None
-    };
     let settings = Some(CanisterSettings {
-        memory_allocation,
         ..Default::default()
     });
     let canister_id = pocket_ic

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -15,9 +15,9 @@ use ic_nervous_system_common::{E8, ONE_DAY_SECONDS};
 use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL};
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
-    self, ALL_NNS_CANISTER_IDS, CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID,
-    LEDGER_CANISTER_ID, LEDGER_INDEX_CANISTER_ID, LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID,
-    ROOT_CANISTER_ID, SNS_WASM_CANISTER_ID,
+    self, CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID,
+    LEDGER_INDEX_CANISTER_ID, LIFELINE_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID,
+    SNS_WASM_CANISTER_ID,
 };
 use ic_nns_governance_api::{
     install_code::CanisterInstallMode, CreateServiceNervousSystem, GetNeuronsFundAuditInfoResponse,

--- a/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
+++ b/rs/nervous_system/integration_tests/src/pocket_ic_helpers.rs
@@ -157,14 +157,7 @@ pub async fn install_canister_with_controllers(
 ) {
     let controllers = controllers.into_iter().map(|c| c.0).collect::<Vec<_>>();
     let controller_principal = controllers.first().cloned();
-    let memory_allocation = if ALL_NNS_CANISTER_IDS.contains(&&canister_id) {
-        let memory_allocation_bytes = ic_nns_constants::memory_allocation_of(canister_id);
-        Some(Nat::from(memory_allocation_bytes))
-    } else {
-        None
-    };
     let settings = Some(CanisterSettings {
-        memory_allocation,
         controllers: Some(controllers),
         ..Default::default()
     });

--- a/rs/nns/constants/src/lib.rs
+++ b/rs/nns/constants/src/lib.rs
@@ -167,17 +167,6 @@ pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 17] = [
     &NODE_REWARDS_CANISTER_ID,
 ];
 
-// The memory allocation for the ledger, governance and registry canisters
-// (4GiB)
-const NNS_MAX_CANISTER_MEMORY_ALLOCATION_IN_BYTES: u64 = 4 * 1024 * 1024 * 1024;
-
-// We preallocate 10GB stable memory for NNS governance so that pre_upgrade never fails trying to
-// grow stable memory, and we might also have some other data occupying stable memory.
-const NNS_GOVERNANCE_CANISTER_MEMORY_ALLOCATION_IN_BYTES: u64 = 10 * 1024 * 1024 * 1024;
-
-// The default memory allocation to set for the remaining NNS canister (1GiB)
-const NNS_DEFAULT_CANISTER_MEMORY_ALLOCATION_IN_BYTES: u64 = 1024 * 1024 * 1024;
-
 /// The current value is 4 GiB, s.t. the SNS governance canister never hits the soft memory limit.
 /// This mitigates the risk that an SNS Governance canister runs out of memory and proposals cannot
 /// be passed anymore.
@@ -185,17 +174,6 @@ pub const DEFAULT_SNS_GOVERNANCE_CANISTER_WASM_MEMORY_LIMIT: u64 = 1 << 32;
 
 /// This value is 3GiB, which will leave a comfortable buffer in the situation when a canister runs out of memory
 pub const DEFAULT_SNS_NON_GOVERNANCE_CANISTER_WASM_MEMORY_LIMIT: u64 = 3 * (1 << 30);
-
-/// Returns the memory allocation of the given nns canister.
-pub fn memory_allocation_of(canister_id: CanisterId) -> u64 {
-    if canister_id == GOVERNANCE_CANISTER_ID {
-        NNS_GOVERNANCE_CANISTER_MEMORY_ALLOCATION_IN_BYTES
-    } else if [LEDGER_CANISTER_ID, REGISTRY_CANISTER_ID].contains(&canister_id) {
-        NNS_MAX_CANISTER_MEMORY_ALLOCATION_IN_BYTES
-    } else {
-        NNS_DEFAULT_CANISTER_MEMORY_ALLOCATION_IN_BYTES
-    }
-}
 
 pub fn canister_id_to_nns_canister_name(canister_id: CanisterId) -> String {
     let id_to_name = btreemap! { // TODO: Make this const. btreemap does not support this.

--- a/rs/nns/integration_tests/src/root_proposals.rs
+++ b/rs/nns/integration_tests/src/root_proposals.rs
@@ -91,9 +91,6 @@ fn test_upgrade_governance_through_root_proposal() {
         // Build and submit a root proposal
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 // Note that we upgrade the governance canister to the universal
                 // canister (effectively breaking governance). This is needed so
                 // that we can be sure that the upgrade actually went through.
@@ -193,9 +190,6 @@ fn test_unauthorized_user_cant_submit_on_root_proposals() {
         // Build and submit a root proposal
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let response: Result<(), String> = nns_canisters
@@ -233,9 +227,6 @@ fn test_cant_submit_root_proposal_with_wrong_sha() {
         // Build and submit a root proposal
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let empty_wasm_sha =
@@ -279,9 +270,6 @@ fn test_enough_no_votes_rejects_the_proposal() {
         // Build and submit a root proposal
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 // Note that we upgrade the governance canister to the universal
                 // canister (effectively breaking governance). This is needed so
                 // that we can be sure that the upgrade actually went through.
@@ -358,9 +346,6 @@ fn test_changing_the_sha_invalidates_the_proposal() {
         // Build and submit a root proposal
         let change_canister_request1 =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 // Note that we upgrade the governance canister to the empty
                 // canister (effectively breaking governance). This is needed so
                 // that we can be sure that the upgrade actually went through.

--- a/rs/nns/integration_tests/src/root_proposals.rs
+++ b/rs/nns/integration_tests/src/root_proposals.rs
@@ -377,9 +377,6 @@ fn test_changing_the_sha_invalidates_the_proposal() {
         // Build and submit a second root proposal
         let change_canister_request2 =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(ic_nns_constants::memory_allocation_of(
-                    GOVERNANCE_CANISTER_ID,
-                ))
                 .with_wasm(ic_test_utilities::empty_wasm::EMPTY_WASM.to_vec());
 
         let response: Result<(), String> = nns_canisters

--- a/rs/nns/test_utils/src/itest_helpers.rs
+++ b/rs/nns/test_utils/src/itest_helpers.rs
@@ -417,7 +417,7 @@ pub async fn install_rust_canister(
         binary_name,
         cargo_features,
         canister_init_payload,
-        memory_allocation_of(canister.canister_id()),
+        0, // DO NOT MERGE - is this equivalent to None?
     )
     .await
 }
@@ -433,7 +433,7 @@ pub async fn install_rust_canister_from_path<P: AsRef<Path>>(
         canister,
         path_to_wasm,
         canister_init_payload,
-        memory_allocation_of(canister.canister_id()),
+        0,
     )
     .await
 }
@@ -567,11 +567,7 @@ pub async fn install_lifeline_canister(
     // Use the env var if we have one, otherwise use the embedded binary.
     Wasm::from_location_specified_by_env_var("lifeline_canister", &[])
         .unwrap_or_else(|| Wasm::from_bytes(LIFELINE_CANISTER_WASM))
-        .install_with_retries_onto_canister(
-            canister,
-            None,
-            Some(memory_allocation_of(canister.canister_id())),
-        )
+        .install_with_retries_onto_canister(canister, None, None)
         .await
         .unwrap();
     println!(

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -27,10 +27,9 @@ use ic_nervous_system_common::{
 use ic_nns_common::init::LifelineCanisterInitPayload;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
-    canister_id_to_nns_canister_name, memory_allocation_of, CYCLES_LEDGER_CANISTER_ID,
-    CYCLES_MINTING_CANISTER_ID, CYCLES_MINTING_CANISTER_INDEX_IN_NNS_SUBNET,
-    GENESIS_TOKEN_CANISTER_INDEX_IN_NNS_SUBNET, GOVERNANCE_CANISTER_ID,
-    GOVERNANCE_CANISTER_INDEX_IN_NNS_SUBNET, LEDGER_CANISTER_ID,
+    canister_id_to_nns_canister_name, CYCLES_LEDGER_CANISTER_ID, CYCLES_MINTING_CANISTER_ID,
+    CYCLES_MINTING_CANISTER_INDEX_IN_NNS_SUBNET, GENESIS_TOKEN_CANISTER_INDEX_IN_NNS_SUBNET,
+    GOVERNANCE_CANISTER_ID, GOVERNANCE_CANISTER_INDEX_IN_NNS_SUBNET, LEDGER_CANISTER_ID,
     LEDGER_CANISTER_INDEX_IN_NNS_SUBNET, LIFELINE_CANISTER_ID,
     LIFELINE_CANISTER_INDEX_IN_NNS_SUBNET, NODE_REWARDS_CANISTER_INDEX_IN_NNS_SUBNET,
     REGISTRY_CANISTER_ID, REGISTRY_CANISTER_INDEX_IN_NNS_SUBNET, ROOT_CANISTER_ID,
@@ -654,7 +653,6 @@ fn setup_nns_canister_at_position(
         vec![ROOT_CANISTER_ID.get()]
     };
     let args = CanisterSettingsArgsBuilder::new()
-        .with_memory_allocation(memory_allocation_of(CanisterId::from_u64(index)))
         .with_controllers(controllers)
         .build();
 
@@ -2295,7 +2293,6 @@ pub fn setup_subnet_rental_canister_with_correct_canister_id(state_machine: &Sta
         Some(
             CanisterSettingsArgsBuilder::new()
                 .with_controllers(vec![ROOT_CANISTER_ID.get()])
-                .with_memory_allocation(memory_allocation_of(SUBNET_RENTAL_CANISTER_ID))
                 .build(),
         ),
     );

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -37,7 +37,7 @@ use ic_nervous_system_root::change_canister::{
     AddCanisterRequest, CanisterAction, ChangeCanisterRequest, StopOrStartCanisterRequest,
 };
 use ic_nns_common::types::{NeuronId, ProposalId, UpdateIcpXdrConversionRatePayload};
-use ic_nns_constants::{memory_allocation_of, GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID};
+use ic_nns_constants::{GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::{
     add_or_remove_node_provider::Change,
     bitcoin::{BitcoinNetwork, BitcoinSetConfigProposal},
@@ -6188,7 +6188,6 @@ impl RootCanisterClient {
         .await;
         let change_canister_request =
             ChangeCanisterRequest::new(true, CanisterInstallMode::Upgrade, GOVERNANCE_CANISTER_ID)
-                .with_memory_allocation(memory_allocation_of(GOVERNANCE_CANISTER_ID))
                 .with_wasm(wasm_module);
 
         let serialized = Encode!(&CanisterIdRecord::from(GOVERNANCE_CANISTER_ID)).unwrap();


### PR DESCRIPTION
This removes a function that sets memory_allocation for NNS canister, which no longer is used in mainnet.  This results in an incorrect test setup.