### PR TITLE
perf(nns): Use a proper proposal payload in benchmarks

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -31,7 +31,7 @@ benches:
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 44534158
+      instructions: 42074044
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
@@ -43,7 +43,7 @@ benches:
     scopes: {}
   distribute_rewards_with_stable_neurons:
     total:
-      instructions: 7305416
+      instructions: 2721444
       heap_increase: 0
       stable_memory_increase: 256
     scopes: {}
@@ -103,7 +103,7 @@ benches:
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 2633954
+      instructions: 271542
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -1,6 +1,6 @@
 use crate::benches_util::check_projected_instructions;
 use crate::governance::REWARD_DISTRIBUTION_PERIOD_SECONDS;
-use crate::pb::v1::{RewardEvent, VotingPowerEconomics, WaitForQuietState};
+use crate::pb::v1::{Motion, RewardEvent, VotingPowerEconomics, WaitForQuietState};
 use crate::test_utils::MockRandomness;
 use crate::{
     governance::{
@@ -66,6 +66,14 @@ fn set_up<R: Rng>(
         1,
         ProposalData {
             id: Some(ProposalId { id: 1 }),
+            proposal: Some(Proposal {
+                summary: "Summary".to_string(),
+                url: "".to_string(),
+                title: Some("Title".to_string()),
+                action: Some(Action::Motion(Motion {
+                    motion_text: "Motion".to_string(),
+                })),
+            }),
             ..Default::default()
         },
     );
@@ -532,7 +540,15 @@ fn distribute_rewards_with_stable_neurons() -> BenchResult {
                 wait_for_quiet_state: Some(WaitForQuietState {current_deadline_timestamp_seconds: now_seconds - 200}),
                 decided_timestamp_seconds: now_seconds - 100,
                 executed_timestamp_seconds: now_seconds - 100,
-                ballots ,
+                ballots,
+                proposal: Some(Proposal {
+                    summary: "Summary".to_string(),
+                    url: "".to_string(),
+                    title: Some("Title".to_string()),
+                    action: Some(Action::Motion(Motion {
+                        motion_text: "Motion".to_string(),
+                    })),
+                }),
                 ..Default::default()
             }
         },


### PR DESCRIPTION
# Why

`ProposalData::topic` actually uses 2.5M instructions when topic is `Unspecified` as it prints the proposal. This distorts the benchmarks, especially for smaller ones. In a future PR, `ProposalData::topic` will simply use the topic stored at creation time, which makes the instructions go away. This PR prepares for that, so that the next PR doesn't introduce unnecessary benchmark updates which would make the next PR more difficult to understand.

# What

* Add motion action in proposals added for benchmark preparation
* Update canbench_results.yml