### PR TITLE
feat(nns): Persist topic throughout proposal lifecycle

### DIFF
--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -1597,6 +1597,8 @@ pub struct ProposalData {
     /// amount of voting power that it exercised (so called "deciding" voting
     /// power) in proportion to this.
     pub total_potential_voting_power: ::core::option::Option<u64>,
+    /// The topic of the proposal.
+    pub topic: ::core::option::Option<i32>,
 }
 /// This structure contains data for settling the Neurons' Fund participation in an SNS token swap.
 #[derive(

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -73,7 +73,7 @@ benches:
     scopes: {}
   list_proposals:
     total:
-      instructions: 91895
+      instructions: 76293
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -999,6 +999,7 @@ type ProposalData = record {
   executed_timestamp_seconds : nat64;
   original_total_community_fund_maturity_e8s_equivalent : opt nat64;
   total_potential_voting_power : opt nat64;
+  topic: opt int32;
 };
 
 type ProposalInfo = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -883,6 +883,7 @@ type ProposalData = record {
   executed_timestamp_seconds : nat64;
   original_total_community_fund_maturity_e8s_equivalent : opt nat64;
   total_potential_voting_power : opt nat64;
+  topic: opt int32;
 };
 
 type ProposalInfo = record {

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1359,6 +1359,9 @@ message ProposalData {
   // amount of voting power that it exercised (so called "deciding" voting
   // power) in proportion to this.
   optional uint64 total_potential_voting_power = 22;
+
+  // The topic of the proposal.
+  optional Topic topic = 23;
 }
 
 // This structure contains data for settling the Neurons' Fund participation in an SNS token swap.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -1619,6 +1619,9 @@ pub struct ProposalData {
     /// power) in proportion to this.
     #[prost(uint64, optional, tag = "22")]
     pub total_potential_voting_power: ::core::option::Option<u64>,
+    /// The topic of the proposal.
+    #[prost(enumeration = "Topic", optional, tag = "23")]
+    pub topic: ::core::option::Option<i32>,
 }
 /// This structure contains data for settling the Neurons' Fund participation in an SNS token swap.
 #[derive(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -586,12 +586,6 @@ impl NnsFunction {
 }
 
 impl Proposal {
-    /// Whether this proposal is restricted, that is, whether neuron voting
-    /// eligibility depends on the content of this proposal.
-    pub fn is_manage_neuron(&self) -> bool {
-        self.topic() == Topic::NeuronManagement
-    }
-
     /// If this is a [ManageNeuron] proposal, this returns the ID of
     /// the managed neuron.
     pub fn managed_neuron(&self) -> Option<NeuronIdOrSubaccount> {
@@ -604,10 +598,9 @@ impl Proposal {
         }
     }
 
-    /// Compute the topic that a given proposal belongs to. The topic
-    /// of a proposal governs what followers that are taken into
-    /// account when the proposal is voted on.
-    pub(crate) fn topic(&self) -> Topic {
+    /// Computes a topic to a given proposal at the creation time. The topic of a proposal governs
+    /// what followers that are taken into account when the proposal is voted on.
+    pub(crate) fn compute_topic_at_creation(&self) -> Topic {
         if let Some(action) = &self.action {
             match action {
                 Action::ManageNeuron(_) => Topic::NeuronManagement,
@@ -814,18 +807,6 @@ impl Action {
 }
 
 impl ProposalData {
-    pub fn topic(&self) -> Topic {
-        if let Some(proposal) = &self.proposal {
-            proposal.topic()
-        } else {
-            println!(
-                "{}ERROR: ProposalData has no proposal! {:#?}",
-                LOG_PREFIX, self
-            );
-            Topic::Unspecified
-        }
-    }
-
     /// Compute the 'status' of a proposal. See [ProposalStatus] for
     /// more information.
     pub fn status(&self) -> ProposalStatus {
@@ -847,9 +828,7 @@ impl ProposalData {
     /// Whether this proposal is restricted, that is, whether neuron voting
     /// eligibility depends on the content of this proposal.
     pub fn is_manage_neuron(&self) -> bool {
-        self.proposal
-            .as_ref()
-            .is_some_and(Proposal::is_manage_neuron)
+        self.topic() == Topic::NeuronManagement
     }
 
     pub fn reward_status(
@@ -3384,7 +3363,7 @@ impl Governance {
         match self.heap_data.proposals.get_mut(&pid) {
             Some(proposal_data) => {
                 // The proposal has to be adopted before it is executed.
-                assert!(proposal_data.status() == ProposalStatus::Adopted);
+                assert_eq!(proposal_data.status(), ProposalStatus::Adopted);
                 match result {
                     Ok(_) => {
                         println!(
@@ -3881,15 +3860,10 @@ impl Governance {
 
         // Stops borrowing proposal before mutating neurons.
         let action = proposal.proposal.as_ref().and_then(|x| x.action.clone());
-        let is_manage_neuron = proposal
-            .proposal
-            .as_ref()
-            .map(|x| x.is_manage_neuron())
-            .unwrap_or(false);
 
         // The proposal was adopted, return the rejection fee for non-ManageNeuron
         // proposals.
-        if !is_manage_neuron {
+        if !proposal.is_manage_neuron() {
             if let Some(nid) = proposal.proposer {
                 let rejection_cost = proposal.reject_cost_e8s;
                 self.with_neuron_mut(&nid, |neuron| {
@@ -4963,7 +4937,7 @@ impl Governance {
             }
         }
 
-        if proposal.topic() == Topic::Unspecified {
+        if proposal.compute_topic_at_creation() == Topic::Unspecified {
             Err(format!("Topic not specified. proposal: {:#?}", proposal))?;
         }
 
@@ -5244,7 +5218,7 @@ impl Governance {
         caller: &PrincipalId,
         proposal: &Proposal,
     ) -> Result<ProposalId, GovernanceError> {
-        let topic = proposal.topic();
+        let topic = proposal.compute_topic_at_creation();
         let now_seconds = self.env.now();
 
         // Validate proposal
@@ -5422,6 +5396,7 @@ impl Governance {
             ballots,
             wait_for_quiet_state,
             total_potential_voting_power: Some(total_potential_voting_power),
+            topic: Some(topic as i32),
             ..Default::default()
         };
 
@@ -5636,11 +5611,7 @@ impl Governance {
             .ok_or_else(||
             // Proposal not found.
             GovernanceError::new_with_message(ErrorType::NotFound, "Can't find proposal."))?;
-        let topic = proposal
-            .proposal
-            .as_ref()
-            .map(|p| p.topic())
-            .unwrap_or(Topic::Unspecified);
+        let topic = proposal.topic();
 
         let vote = Vote::try_from(*vote).unwrap_or(Vote::Unspecified);
         if vote == Vote::Unspecified {

--- a/rs/nns/governance/src/governance/merge_neurons.rs
+++ b/rs/nns/governance/src/governance/merge_neurons.rs
@@ -1409,6 +1409,7 @@ mod tests {
                 }))),
                 ..Default::default()
             }),
+            topic: Some(Topic::NeuronManagement as i32),
             ..Default::default()
         };
         let managed_neuron_proposal_by_subaccount = ProposalData {
@@ -1423,6 +1424,7 @@ mod tests {
                 }))),
                 ..Default::default()
             }),
+            topic: Some(Topic::NeuronManagement as i32),
             ..Default::default()
         };
         // The proposer is a neuron 'not involved', which is OK because the proposal is decided.

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -867,6 +867,7 @@ mod metrics_tests {
                 no: 0,
                 total: 555,
             }),
+            topic: Some(Topic::Governance as i32),
             ..ProposalData::default()
         };
 
@@ -884,6 +885,7 @@ mod metrics_tests {
                 no: 0,
                 total: 1,
             }),
+            topic: Some(Topic::NeuronManagement as i32),
             ..ProposalData::default()
         };
         let governance = Governance::new(
@@ -926,6 +928,7 @@ mod metrics_tests {
                 action: Some(manage_neuron_action.clone()),
                 ..Proposal::default()
             }),
+            topic: Some(Topic::NeuronManagement as i32),
             ..ProposalData::default()
         };
 
@@ -937,6 +940,7 @@ mod metrics_tests {
                 ..Proposal::default()
             }),
             decided_timestamp_seconds: 1,
+            topic: Some(Topic::NeuronManagement as i32),
             ..ProposalData::default()
         };
 
@@ -947,6 +951,7 @@ mod metrics_tests {
                 action: Some(motion_action.clone()),
                 ..Proposal::default()
             }),
+            topic: Some(Topic::Governance as i32),
             ..ProposalData::default()
         };
 

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -483,13 +483,7 @@ pub fn encode_metrics(
         .proposals
         .values()
         // Exclude ManageNeuron proposals.
-        .filter(|proposal_data| {
-            proposal_data
-                .proposal
-                .as_ref()
-                .map(|proposal| !proposal.is_manage_neuron())
-                .unwrap_or_default()
-        })
+        .filter(|proposal_data| !proposal_data.is_manage_neuron())
         .next_back();
     let mut total_deciding_voting_power = 0.0;
     let mut total_potential_voting_power = 0.0;

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -1412,6 +1412,7 @@ impl From<pb::ProposalData> for pb_api::ProposalData {
             derived_proposal_information: item.derived_proposal_information.map(|x| x.into()),
             neurons_fund_data: item.neurons_fund_data.map(|x| x.into()),
             total_potential_voting_power: item.total_potential_voting_power,
+            topic: item.topic,
         }
     }
 }
@@ -1441,6 +1442,7 @@ impl From<pb_api::ProposalData> for pb::ProposalData {
             derived_proposal_information: item.derived_proposal_information.map(|x| x.into()),
             neurons_fund_data: item.neurons_fund_data.map(|x| x.into()),
             total_potential_voting_power: item.total_potential_voting_power,
+            topic: item.topic,
         }
     }
 }

--- a/rs/nns/governance/src/pb/proposal_conversions.rs
+++ b/rs/nns/governance/src/pb/proposal_conversions.rs
@@ -242,7 +242,6 @@ pub fn proposal_data_to_info(
     voting_period_seconds: impl Fn(pb::Topic) -> u64,
 ) -> pb_api::ProposalInfo {
     // Calculate derived fields
-    let topic = data.topic() as i32;
     let status = data.status() as i32;
     let reward_status = data.reward_status(now_seconds, voting_period_seconds(data.topic())) as i32;
     let deadline_timestamp_seconds =
@@ -251,6 +250,7 @@ pub fn proposal_data_to_info(
     // Trivially convert fields
     let id = data.id;
     let proposer = data.proposer;
+    let topic = data.topic() as i32;
     let reject_cost_e8s = data.reject_cost_e8s;
     let proposal_timestamp_seconds = data.proposal_timestamp_seconds;
     let latest_tally = data.latest_tally.map(|x| x.into());

--- a/rs/nns/governance/src/test_utils.rs
+++ b/rs/nns/governance/src/test_utils.rs
@@ -239,7 +239,7 @@ impl Environment for MockEnvironment {
         _proposal_id: u64,
         _update: &ExecuteNnsFunction,
     ) -> Result<(), GovernanceError> {
-        unimplemented!();
+        Ok(())
     }
 
     fn heap_growth_potential(&self) -> HeapGrowthPotential {

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -366,6 +366,10 @@ fn test_single_neuron_proposal_new() {
                             None,
                             Some(1),
                         )),
+                        ProposalDataChange::Topic(OptionChange::Different(
+                            None,
+                            Some(Topic::NetworkEconomics as i32),
+                        ))
                     ],
                 )]),
                 GovernanceChange::Metrics(OptionChange::Different(
@@ -8127,6 +8131,7 @@ fn fixture_for_proposals(proposal_id: ProposalId, payload: Vec<u8>) -> Governanc
     let proposal_data = ProposalData {
         id: Some(proposal_id),
         proposal: Some(proposal),
+        topic: Some(Topic::NetworkEconomics as i32),
         ..Default::default()
     };
     GovernanceProto {
@@ -8466,6 +8471,7 @@ fn test_gc_ignores_exempt_proposals() {
                         )),
                         ..Default::default()
                     }),
+                    topic: Some(Topic::SnsAndCommunityFund as i32),
                     ..Default::default()
                 },
             )

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -8,7 +8,7 @@ use ic_nns_governance::{
     governance::{Governance, REWARD_DISTRIBUTION_PERIOD_SECONDS},
     pb::v1::{
         neuron::DissolveState, proposal::Action, Ballot, Governance as GovernanceProto,
-        NetworkEconomics, Neuron, Proposal, ProposalData, ProposalRewardStatus, Vote,
+        NetworkEconomics, Neuron, Proposal, ProposalData, ProposalRewardStatus, Topic, Vote,
         WaitForQuietState,
     },
     proposals::sum_weighted_voting_power,
@@ -98,6 +98,7 @@ lazy_static! {
             wait_for_quiet_state: Some(WaitForQuietState {
                 current_deadline_timestamp_seconds: NOW_SECONDS - 5 * ONE_DAY_SECONDS,
             }),
+            topic: Some(Topic::ParticipantManagement as i32),
             ..Default::default()
         };
 
@@ -134,6 +135,7 @@ lazy_static! {
             79 => {
                 let mut proposal_data = proposal_data;
                 proposal_data.id = Some(ProposalId { id: 79 });
+                proposal_data.topic = Some(Topic::Governance as i32);
 
                 let proposal = proposal_data.proposal.as_mut().unwrap();
                 proposal.action = Some(Action::Motion(Default::default()));

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -13,6 +13,8 @@ on the process that this file is part of, see
 
 ## Changed
 
+* Proposal topics are persisted throughout its lifecycle instead of being recomputed every time.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
# Why

Sometimes the `Proposal::topic` might change, especially when some canisters start to be considered as protocol cansiters. In this cases, we want the proposal to retain the topic at creation.

# What

* Define `ProposalData::topic` field
* Rename `Proposal::topic` to `Proposal::assign_topic_at_creation`
* Set `ProposalData::topic` at creation time
* Change `ProposalData::topic()` to use the `Proposal::topic`
* Change `ProposalData::is_manage_neuron` to use `ProposalData::topic`
* Delete `Proposal::is_manage_neuron` in favor of `ProposalData::is_manage_neuron`
* Update benchmark for `list_proposals`. It is very lightweight so it's affected by not calling `Proposal::topic`