### PR TITLE
chore(IDX): chown in bazel action

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -26,14 +26,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Prepare worker cache
-        shell: bash
-        run: |
-          # freshly deployed k8s machines require ownership correctly set
-          if [ -e /cache ]; then
-            sudo find /cache \( -not -user 1001 -or -not -group 1001 \) -exec chown 1001:1001 {} +
-          fi
-
       - name: Set up backup pod access
         shell: bash
         if: inputs.SSH_PRIVATE_KEY_BACKUP_POD != ''

--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -16,6 +16,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Freshly deployed k8s machines require ownership correctly set
+    # Avoiding: 'Failed to fetch registry file ... /cache/bazel/content_addressable/sha256 (Permission denied)'
+    - name: Prepare worker cache
+      shell: bash
+      run: |
+        if [ -e /cache ]; then
+          sudo find /cache \( -not -user 1001 -or -not -group 1001 \) -exec chown 1001:1001 {} +
+        fi
 
     # Create a known tempdir where build events will be written
     - id: metrics-tmpdir


### PR DESCRIPTION
Addressing issue encountered [here](https://github.com/dfinity/ic/actions/runs/15015811313/job/42193404782).

This makes sure that any CI job that doesn't uses *bazel-test-all* action but uses *bazel* action doesn't encounter this issue.