### PR TITLE
fix(IDX): make the num-traits crate reproducible

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ce7d0c30d4f393e00446d6319be3ad88cc0d3022d3205210bfec0aeecc0d6111",
+  "checksum": "8f13965610388163033c037722f7e93f98cdf86ddd14c36d8839198e8af88999",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -47530,7 +47530,13 @@
       "repository": {
         "Http": {
           "url": "https://static.crates.io/crates/num-traits/0.2.19/download",
-          "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+          "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@@//bazel:num-traits.patch"
+          ]
         }
       },
       "targets": [

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b3c512c2dba1d529cab0e1bfd89fd7ad4055f87d9be3eaf89996b69237dfb932",
+  "checksum": "ce7d0c30d4f393e00446d6319be3ad88cc0d3022d3205210bfec0aeecc0d6111",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -527,7 +527,7 @@ dependencies = [
  "askama_derive",
  "askama_escape",
  "humansize",
- "num-traits",
+ "num-traits 0.2.19",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -574,7 +574,7 @@ dependencies = [
  "asn1-rs-impl",
  "displaydoc",
  "nom",
- "num-traits",
+ "num-traits 0.2.19",
  "rusticata-macros",
  "thiserror 1.0.68",
  "time",
@@ -1703,7 +1703,7 @@ dependencies = [
  "bincode",
  "build-info-common",
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "proc-macro-error",
  "proc-macro-hack",
  "proc-macro2",
@@ -1945,7 +1945,7 @@ dependencies = [
  "ic_principal",
  "leb128",
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "paste",
  "pretty 0.12.3",
  "serde",
@@ -2123,7 +2123,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits",
+ "num-traits 0.2.19",
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
@@ -2774,7 +2774,7 @@ dependencies = [
  "futures",
  "is-terminal",
  "itertools 0.10.5",
- "num-traits",
+ "num-traits 0.2.19",
  "once_cell",
  "oorandom",
  "plotters",
@@ -3211,7 +3211,7 @@ dependencies = [
  "displaydoc",
  "nom",
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "rusticata-macros",
 ]
 
@@ -3549,7 +3549,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-bigint-dig",
  "num-rational 0.2.4",
- "num-traits",
+ "num-traits 0.2.19",
  "num_cpus",
  "once_cell",
  "openssh-keys",
@@ -4031,7 +4031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4452,7 +4452,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -4946,7 +4946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
  "byteorder",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8008,7 +8008,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational 0.4.2",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8019,7 +8019,7 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8029,7 +8029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
  "serde",
 ]
 
@@ -8044,7 +8044,7 @@ dependencies = [
  "libm",
  "num-integer",
  "num-iter",
- "num-traits",
+ "num-traits 0.2.19",
  "rand 0.8.5",
  "serde",
  "smallvec",
@@ -8057,7 +8057,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8082,7 +8082,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8093,7 +8093,7 @@ checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8105,7 +8105,7 @@ dependencies = [
  "autocfg 1.1.0",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8116,7 +8116,7 @@ checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8127,6 +8127,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg 1.1.0",
  "libm",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "git+https://github.com/basvandijk/num-traits?rev=8cb9d01e4f44e617ef8a94d4c1543559364e4e5d#8cb9d01e4f44e617ef8a94d4c1543559364e4e5d"
+dependencies = [
+ "autocfg 1.1.0",
+ "libm",
+ "tempfile",
 ]
 
 [[package]]
@@ -8564,7 +8574,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8573,7 +8583,7 @@ version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8582,7 +8592,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -9079,7 +9089,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -9481,7 +9491,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.6.0",
  "lazy_static",
- "num-traits",
+ "num-traits 0.2.19",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
@@ -9894,7 +9904,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
  "rand 0.8.5",
 ]
 
@@ -10001,7 +10011,7 @@ dependencies = [
  "nom",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
  "once_cell",
  "rasn-derive",
  "snafu 0.7.5",
@@ -10489,7 +10499,7 @@ dependencies = [
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -10562,7 +10572,7 @@ dependencies = [
  "arrayvec 0.7.4",
  "borsh",
  "bytes",
- "num-traits",
+ "num-traits 0.2.19",
  "rand 0.8.5",
  "rkyv",
  "serde",
@@ -11536,7 +11546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "thiserror 1.0.68",
  "time",
 ]
@@ -11559,7 +11569,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a4b144ad185430cd033299e2c93e465d5a7e65fbb858593dc57181fa13cd310"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4154c13c2fbfe871f941850b0698f8866f5687a2bb91c33e8209fe890b5d197b",
+  "checksum": "b04630293330091d46636ceb8884cf336dccc50199e7de38ad1b73887350cae3",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b04630293330091d46636ceb8884cf336dccc50199e7de38ad1b73887350cae3",
+  "checksum": "2691357477ac6c33dfa18b00ef02381fe99c53820bc7d8b89d2b3045794975f1",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -47361,7 +47361,13 @@
       "repository": {
         "Http": {
           "url": "https://static.crates.io/crates/num-traits/0.2.19/download",
-          "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+          "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@@//bazel:num-traits.patch"
+          ]
         }
       },
       "targets": [

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -528,7 +528,7 @@ dependencies = [
  "askama_derive",
  "askama_escape",
  "humansize",
- "num-traits",
+ "num-traits 0.2.19",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -575,7 +575,7 @@ dependencies = [
  "asn1-rs-impl",
  "displaydoc",
  "nom",
- "num-traits",
+ "num-traits 0.2.19",
  "rusticata-macros",
  "thiserror 1.0.68",
  "time",
@@ -1704,7 +1704,7 @@ dependencies = [
  "bincode",
  "build-info-common",
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "proc-macro-error",
  "proc-macro-hack",
  "proc-macro2",
@@ -1946,7 +1946,7 @@ dependencies = [
  "ic_principal",
  "leb128",
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "paste",
  "pretty 0.12.1",
  "serde",
@@ -2124,7 +2124,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits",
+ "num-traits 0.2.19",
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
@@ -2763,7 +2763,7 @@ dependencies = [
  "futures",
  "is-terminal",
  "itertools 0.10.5",
- "num-traits",
+ "num-traits 0.2.19",
  "once_cell",
  "oorandom",
  "plotters",
@@ -3200,7 +3200,7 @@ dependencies = [
  "displaydoc",
  "nom",
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "rusticata-macros",
 ]
 
@@ -3538,7 +3538,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-bigint-dig",
  "num-rational 0.2.4",
- "num-traits",
+ "num-traits 0.2.19",
  "num_cpus",
  "once_cell",
  "openssh-keys",
@@ -4020,7 +4020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4f76552f53cefc9a7f64987c3701b99d982f7690606fd67de1d09712fbf52f1"
 dependencies = [
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4441,7 +4441,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -4935,7 +4935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
  "byteorder",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -7999,7 +7999,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational 0.4.2",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8010,7 +8010,7 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8020,7 +8020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
  "serde",
 ]
 
@@ -8035,7 +8035,7 @@ dependencies = [
  "libm",
  "num-integer",
  "num-iter",
- "num-traits",
+ "num-traits 0.2.19",
  "rand 0.8.5",
  "serde",
  "smallvec",
@@ -8048,7 +8048,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8073,7 +8073,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8084,7 +8084,7 @@ checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8096,7 +8096,7 @@ dependencies = [
  "autocfg 1.1.0",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8107,7 +8107,7 @@ checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8118,6 +8118,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg 1.1.0",
  "libm",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "git+https://github.com/basvandijk/num-traits?rev=8cb9d01e4f44e617ef8a94d4c1543559364e4e5d#8cb9d01e4f44e617ef8a94d4c1543559364e4e5d"
+dependencies = [
+ "autocfg 1.1.0",
+ "libm",
+ "tempfile",
 ]
 
 [[package]]
@@ -8555,7 +8565,7 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8564,7 +8574,7 @@ version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -8573,7 +8583,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -9069,7 +9079,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
  "plotters-backend",
  "plotters-svg",
  "wasm-bindgen",
@@ -9471,7 +9481,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.6.0",
  "lazy_static",
- "num-traits",
+ "num-traits 0.2.19",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
@@ -9884,7 +9894,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
  "rand 0.8.5",
 ]
 
@@ -9991,7 +10001,7 @@ dependencies = [
  "nom",
  "num-bigint 0.4.6",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
  "once_cell",
  "rasn-derive",
  "snafu 0.7.5",
@@ -10485,7 +10495,7 @@ dependencies = [
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.19",
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -10558,7 +10568,7 @@ dependencies = [
  "arrayvec 0.7.4",
  "borsh",
  "bytes",
- "num-traits",
+ "num-traits 0.2.19",
  "rand 0.8.5",
  "rkyv",
  "serde",
@@ -11532,7 +11542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint 0.4.6",
- "num-traits",
+ "num-traits 0.2.19",
  "thiserror 1.0.68",
  "time",
 ]
@@ -11555,7 +11565,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a4b144ad185430cd033299e2c93e465d5a7e65fbb858593dc57181fa13cd310"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.19",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17304,11 +17304,11 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+source = "git+https://github.com/basvandijk/num-traits?rev=8cb9d01e4f44e617ef8a94d4c1543559364e4e5d#8cb9d01e4f44e617ef8a94d4c1543559364e4e5d"
 dependencies = [
  "autocfg 1.4.0",
  "libm",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -634,7 +634,9 @@ nftables = "0.4"
 nix = { version = "0.24.3", features = ["ptrace"] }
 num_cpus = "1.16.0"
 num-bigint = "0.4.6"
-num-traits = { version = "0.2.12", features = ["libm"] }
+num-traits = { git = "https://github.com/basvandijk/num-traits", rev = "8cb9d01e4f44e617ef8a94d4c1543559364e4e5d", features = [
+    "libm",
+] }
 opentelemetry = { version = "0.27.0", features = ["metrics", "trace"] }
 opentelemetry-otlp = { version = "0.27.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = { version = "0.27.0", features = ["trace", "rt-tokio"] }
@@ -781,3 +783,6 @@ zstd = "0.13.2"
 default-features = false
 features = ["exe"]
 version = "^0.8.1"
+
+[patch.crates-io]
+num-traits = { git = "https://github.com/basvandijk/num-traits", rev = "8cb9d01e4f44e617ef8a94d4c1543559364e4e5d" }

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -885,7 +885,8 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.2.2",
             ),
             "num-traits": crate.spec(
-                version = "^0.2.12",
+                git = "https://github.com/basvandijk/num-traits",
+                rev = "8cb9d01e4f44e617ef8a94d4c1543559364e4e5d",
                 features = [
                     "libm",
                 ],

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -165,6 +165,10 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
         "metrics-proxy": [crate.annotation(
             gen_binaries = True,
         )],
+        "num-traits": [crate.annotation(
+            patch_args = ["-p1"],
+            patches = ["@@//bazel:num-traits.patch"],
+        )],
     }
     CRATE_ANNOTATIONS.update(sanitize_external_crates(sanitizers_enabled = sanitizers_enabled))
     crates_repository(

--- a/bazel/num-traits.patch
+++ b/bazel/num-traits.patch
@@ -1,0 +1,34 @@
+From d0c058b39ee0e23451489489b33979cb19cef7ff Mon Sep 17 00:00:00 2001
+From: Bas van Dijk <bas@dfinity.org>
+Date: Wed, 14 May 2025 10:33:07 +0000
+Subject: [PATCH] Make the build reproducible
+
+---
+ Cargo.toml | 1 +
+ build.rs   | 3 ++-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 226d416..a5aab9e 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -32,3 +32,4 @@ i128 = []
+ 
+ [build-dependencies]
+ autocfg = "1"
++tempfile = "3"
+diff --git a/build.rs b/build.rs
+index 98b06be..b3e2958 100644
+--- a/build.rs
++++ b/build.rs
+@@ -1,5 +1,6 @@
+ fn main() {
+-    let ac = autocfg::new();
++    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
++    let ac = autocfg::AutoCfg::with_dir(temp_dir.path()).unwrap();
+ 
+     ac.emit_expression_cfg("1f64.total_cmp(&2f64)", "has_total_cmp"); // 1.62
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
The `num-traits` crate is non-reproducible. We fix this by using the fix as proposed in https://github.com/rust-num/num-traits/pull/355.