### PR TITLE
chore: Don't deliver ALREADY_EXISTS checkpoint in state sync

### DIFF
--- a/rs/state_manager/src/state_sync/chunkable.rs
+++ b/rs/state_manager/src/state_sync/chunkable.rs
@@ -1336,7 +1336,6 @@ impl Chunkable<StateSyncMessage> for IncompleteState {
                             &self.state_layout,
                         ) {
                             self.state = DownloadState::Complete;
-
                             return Ok(());
                         }
 
@@ -1347,7 +1346,6 @@ impl Chunkable<StateSyncMessage> for IncompleteState {
                             Arc::new(meta_manifest.clone()),
                         );
                         self.state = DownloadState::Complete;
-
                         self.state_sync_refs
                             .cache
                             .write()


### PR DESCRIPTION
If we try to deliver state synced state, but the execution has already created the same height checkpoint, we still deliver state sync and load the execution checkpoint to verify as if it was a state synced checkpoint.
This change aborts state sync if the destination height is already reached by execution.