### PR TITLE
feat: Add "Cache-Control: no-store" to all canister /metrics endpoints

### DIFF
--- a/rs/bitcoin/checker/src/main.rs
+++ b/rs/bitcoin/checker/src/main.rs
@@ -292,6 +292,7 @@ fn http_request(req: http::HttpRequest) -> http::HttpResponse {
 
         http::HttpResponseBuilder::ok()
             .header("Content-Type", "text/plain; version=0.0.4")
+            .header("Cache-Control", "no-store")
             .with_body_and_content_length(writer.into_inner())
             .build()
     } else if req.path() == "/logs" {

--- a/rs/bitcoin/ckbtc/kyt/src/main.rs
+++ b/rs/bitcoin/ckbtc/kyt/src/main.rs
@@ -661,6 +661,7 @@ fn http_request(req: http::HttpRequest) -> http::HttpResponse {
 
         http::HttpResponseBuilder::ok()
             .header("Content-Type", "text/plain; version=0.0.4")
+            .header("Cache-Control", "no-store")
             .with_body_and_content_length(writer.into_inner())
             .build()
     } else if req.path() == "/dashboard" {

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -244,6 +244,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
         match encode_metrics(&mut writer) {
             Ok(()) => HttpResponseBuilder::ok()
                 .header("Content-Type", "text/plain; version=0.0.4")
+                .header("Cache-Control", "no-store")
                 .with_body_and_content_length(writer.into_inner())
                 .build(),
             Err(err) => {

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1023,6 +1023,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
         match encode_metrics(&mut writer) {
             Ok(()) => HttpResponseBuilder::ok()
                 .header("Content-Type", "text/plain; version=0.0.4")
+                .header("Cache-Control", "no-store")
                 .with_body_and_content_length(writer.into_inner())
                 .build(),
             Err(err) => {

--- a/rs/ethereum/ledger-suite-orchestrator/src/main.rs
+++ b/rs/ethereum/ledger-suite-orchestrator/src/main.rs
@@ -251,6 +251,7 @@ fn http_request(req: ic_http_types::HttpRequest) -> ic_http_types::HttpResponse 
             match encode_metrics(&mut writer) {
                 Ok(()) => HttpResponseBuilder::ok()
                     .header("Content-Type", "text/plain; version=0.0.4")
+                    .header("Cache-Control", "no-store")
                     .with_body_and_content_length(writer.into_inner())
                     .build(),
                 Err(err) => {

--- a/rs/ledger_suite/icp/archive/src/main.rs
+++ b/rs/ledger_suite/icp/archive/src/main.rs
@@ -448,6 +448,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
         match encode_metrics(&mut writer) {
             Ok(()) => HttpResponseBuilder::ok()
                 .header("Content-Type", "text/plain; version=0.0.4")
+                .header("Cache-Control", "no-store")
                 .with_body_and_content_length(writer.into_inner())
                 .build(),
             Err(err) => {

--- a/rs/ledger_suite/icp/index/src/main.rs
+++ b/rs/ledger_suite/icp/index/src/main.rs
@@ -669,6 +669,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
         match encode_metrics(&mut writer) {
             Ok(()) => HttpResponseBuilder::ok()
                 .header("Content-Type", "text/plain; version=0.0.4")
+                .header("Cache-Control", "no-store")
                 .with_body_and_content_length(writer.into_inner())
                 .build(),
             Err(err) => {

--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -1421,6 +1421,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
         match encode_metrics(&mut writer) {
             Ok(()) => HttpResponseBuilder::ok()
                 .header("Content-Type", "text/plain; version=0.0.4")
+                .header("Cache-Control", "no-store")
                 .with_body_and_content_length(writer.into_inner())
                 .build(),
             Err(err) => {

--- a/rs/ledger_suite/icrc1/archive/src/main.rs
+++ b/rs/ledger_suite/icrc1/archive/src/main.rs
@@ -403,6 +403,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
         match encode_metrics(&mut writer) {
             Ok(()) => HttpResponseBuilder::ok()
                 .header("Content-Type", "text/plain; version=0.0.4")
+                .header("Cache-Control", "no-store")
                 .with_body_and_content_length(writer.into_inner())
                 .build(),
             Err(err) => {

--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -1087,6 +1087,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
         match encode_metrics(&mut writer) {
             Ok(()) => HttpResponseBuilder::ok()
                 .header("Content-Type", "text/plain; version=0.0.4")
+                .header("Cache-Control", "no-store")
                 .with_body_and_content_length(writer.into_inner())
                 .build(),
             Err(err) => {

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -561,6 +561,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
         match encode_metrics(&mut writer) {
             Ok(()) => HttpResponseBuilder::ok()
                 .header("Content-Type", "text/plain; version=0.0.4")
+                .header("Cache-Control", "no-store")
                 .with_body_and_content_length(writer.into_inner())
                 .build(),
             Err(err) => {

--- a/rs/nervous_system/common/src/lib.rs
+++ b/rs/nervous_system/common/src/lib.rs
@@ -719,6 +719,7 @@ pub fn serve_metrics(
     match encode_metrics(&mut writer) {
         Ok(()) => HttpResponseBuilder::ok()
             .header("Content-Type", "text/plain; version=0.0.4")
+            .header("Cache-Control", "no-store")
             .with_body_and_content_length(writer.into_inner())
             .build(),
         Err(err) => {

--- a/rs/rosetta-api/common/rosetta_core/src/metrics.rs
+++ b/rs/rosetta-api/common/rosetta_core/src/metrics.rs
@@ -306,6 +306,7 @@ where
             // Build response
             let response = Response::builder()
                 .header("Content-Type", "text/plain; version=0.0.4")
+                .header("Cache-Control", "no-store")
                 .body(Body::from(buffer))
                 .unwrap();
 

--- a/rs/rust_canisters/canister_serve/src/lib.rs
+++ b/rs/rust_canisters/canister_serve/src/lib.rs
@@ -67,6 +67,10 @@ pub fn serve_metrics(
                         name: "Content-Length".to_string(),
                         value: content_body.len().to_string(),
                     },
+                    HttpHeader {
+                        name: "Cache-Control".to_string(),
+                        value: "no-store".to_string(),
+                    },
                 ],
                 body: content_body,
             }
@@ -96,7 +100,7 @@ pub fn serve_metrics(
 /// fn http_request(request: CanisterHttpRequestArgument) -> HttpResponse {
 ///     log!(INFO, "This is an INFO log");
 ///     log!(ERROR, "This is an ERROR log");
-///     
+///
 ///     let path = match request.url.find('?') {
 ///         None => &request.url[..],
 ///         Some(index) => &request.url[..index],

--- a/rs/rust_canisters/dfn_http_metrics/src/lib.rs
+++ b/rs/rust_canisters/dfn_http_metrics/src/lib.rs
@@ -30,6 +30,7 @@ pub fn serve_metrics(
                                     "text/plain; version=0.0.4".to_string(),
                                 ),
                                 ("Content-Length".to_string(), body.len().to_string()),
+                                ("Cache-Control".to_string(), "no-store".to_string()),
                             ],
                             body: ByteBuf::from(body),
                         }


### PR DESCRIPTION
IC HTTP gateways have recently started caching HTTP/1.1 query responses for 10 seconds (they were already doing it for HTTP/2.0). This causes Prometheus / Victoria Metrics scrapes (issued every 10 seconds) to only see fresh metrics every 20 seconds.

Add a "Cache-Control: no-store" header to all canister /metrics endpoints, to circumvent this default caching behavior.