### PR TITLE
fix(crypto: CRP-2794 disable vetKD canister public key equality check

### DIFF
--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -249,7 +249,12 @@ pub fn run_chain_key_signature_test(
         let public_key = get_public_key_with_retries(key_id, canister, logger, 100)
             .await
             .unwrap();
-        assert_eq!(existing_key, public_key);
+        // TODO(CRP-2789): Re-enable vetKD public key equality check
+        if let MasterPublicKeyId::VetKd(vetkd_key_id) = key_id {
+            // skip canister public key equality check because of https://github.com/dfinity/ic/pull/5088
+        } else {
+            assert_eq!(existing_key, public_key);
+        }
         let signature = get_signature_with_logger(
             message_hash.clone(),
             ECDSA_SIGNATURE_FEE,


### PR DESCRIPTION
Temporarily disables the vetKD canister public key equality check in the system tests because https://github.com/dfinity/ic/pull/5088 changes the way vetKD canister public keys are derived from the master public key.

The check can be re-enabled once this change is deployed on the NNS subnet (CRP-2789).