### PR TITLE
fix: revert "perf(idkg): [CON-1497] Performance improvement when building a transcript of a certain ID (#4999)"

### DIFF
--- a/rs/artifact_pool/src/lmdb_pool.rs
+++ b/rs/artifact_pool/src/lmdb_pool.rs
@@ -13,29 +13,28 @@ use ic_logger::{error, info, ReplicaLogger};
 use ic_metrics::MetricsRegistry;
 use ic_protobuf::proxy::ProxyDecodeError;
 use ic_protobuf::types::v1 as pb;
+use ic_types::consensus::certification::CertificationMessageHash;
+use ic_types::consensus::idkg::{
+    IDkgArtifactIdData, IDkgArtifactIdDataOf, SigShare, SigShareIdData, SigShareIdDataOf,
+    VetKdKeyShare,
+};
+use ic_types::consensus::{DataPayload, HasHash, SummaryPayload};
 use ic_types::{
     artifact::{CertificationMessageId, ConsensusMessageId, IDkgMessageId},
     batch::BatchPayload,
     consensus::{
-        certification::{
-            Certification, CertificationMessage, CertificationMessageHash, CertificationShare,
-        },
+        certification::{Certification, CertificationMessage, CertificationShare},
         dkg::{self, DkgDataPayload},
         idkg::{
-            EcdsaSigShare, IDkgArtifactId, IDkgArtifactIdData, IDkgArtifactIdDataOf, IDkgMessage,
-            IDkgMessageType, IDkgPrefix, IDkgPrefixOf, IterationPattern, SchnorrSigShare, SigShare,
-            SigShareIdData, SigShareIdDataOf, SignedIDkgComplaint, SignedIDkgOpening,
-            VetKdKeyShare,
+            EcdsaSigShare, IDkgArtifactId, IDkgMessage, IDkgMessageType, IDkgPrefix, IDkgPrefixOf,
+            SchnorrSigShare, SignedIDkgComplaint, SignedIDkgOpening,
         },
         BlockPayload, BlockProposal, CatchUpPackage, CatchUpPackageShare, ConsensusMessage,
-        ConsensusMessageHash, ConsensusMessageHashable, DataPayload, EquivocationProof,
-        Finalization, FinalizationShare, HasHash, HasHeight, Notarization, NotarizationShare,
-        Payload, PayloadType, RandomBeacon, RandomBeaconShare, RandomTape, RandomTapeShare,
-        SummaryPayload,
+        ConsensusMessageHash, ConsensusMessageHashable, EquivocationProof, Finalization,
+        FinalizationShare, HasHeight, Notarization, NotarizationShare, Payload, PayloadType,
+        RandomBeacon, RandomBeaconShare, RandomTape, RandomTapeShare,
     },
-    crypto::canister_threshold_sig::idkg::{
-        IDkgDealingSupport, IDkgTranscriptId, SignedIDkgDealing,
-    },
+    crypto::canister_threshold_sig::idkg::{IDkgDealingSupport, SignedIDkgDealing},
     crypto::{CryptoHash, CryptoHashOf, CryptoHashable},
     Height, Time,
 };
@@ -1642,18 +1641,11 @@ impl From<IDkgMessageId> for IDkgIdKey {
     }
 }
 
-impl From<IterationPattern> for IDkgIdKey {
-    fn from(pattern: IterationPattern) -> IDkgIdKey {
+impl From<IDkgPrefix> for IDkgIdKey {
+    fn from(prefix: IDkgPrefix) -> IDkgIdKey {
         let mut bytes = vec![];
-        match pattern {
-            IterationPattern::GroupTag(group_tag) => {
-                bytes.extend_from_slice(&u64::to_be_bytes(group_tag));
-            }
-            IterationPattern::Prefix(prefix) => {
-                bytes.extend_from_slice(&u64::to_be_bytes(prefix.group_tag()));
-                bytes.extend_from_slice(&u64::to_be_bytes(prefix.meta_hash()));
-            }
-        }
+        bytes.extend_from_slice(&u64::to_be_bytes(prefix.group_tag()));
+        bytes.extend_from_slice(&u64::to_be_bytes(prefix.meta_hash()));
         IDkgIdKey(bytes)
     }
 }
@@ -1832,18 +1824,16 @@ impl IDkgMessageDb {
         true
     }
 
-    /// Iterate over the pool for a given optional pattern. Start at the first key that matches the
-    /// pattern and stop at the first that does not. If no pattern is given, return all elements.
     fn iter<T: TryFrom<IDkgMessage>>(
         &self,
-        pattern: Option<IterationPattern>,
+        prefix: Option<IDkgPrefixOf<T>>,
     ) -> Box<dyn Iterator<Item = (IDkgMessageId, T)> + '_>
     where
         <T as TryFrom<IDkgMessage>>::Error: Debug,
     {
         let message_type = self.object_type;
         let log = self.log.clone();
-        let pattern_clone = pattern.clone();
+        let prefix_cl = prefix.as_ref().map(|p| p.as_ref().clone());
         let deserialize_fn = move |key: &[u8], bytes: &[u8]| {
             // Convert key bytes to IDkgMessageId
             let mut key_bytes = Vec::<u8>::new();
@@ -1862,12 +1852,11 @@ impl IDkgMessageDb {
                 }
             };
 
-            // Stop iterating if we hit a different pattern.
-            if pattern_clone.as_ref().is_some_and(|pattern| match pattern {
-                IterationPattern::GroupTag(group_tag) => group_tag != &id.prefix().group_tag(),
-                IterationPattern::Prefix(prefix) => prefix != &id.prefix(),
-            }) {
-                return None;
+            // Stop iterating if we hit a different prefix.
+            if let Some(prefix) = &prefix_cl {
+                if id.prefix() != *prefix {
+                    return None;
+                }
             }
 
             // Deserialize value bytes and convert to inner type
@@ -1906,7 +1895,7 @@ impl IDkgMessageDb {
             self.db_env.clone(),
             self.db,
             deserialize_fn,
-            pattern.map(IDkgIdKey::from),
+            prefix.map(|p| IDkgIdKey::from(p.get())),
             self.log.clone(),
         ))
     }
@@ -2031,15 +2020,7 @@ impl IDkgPoolSection for PersistentIDkgPoolSection {
         prefix: IDkgPrefixOf<SignedIDkgDealing>,
     ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgDealing)> + '_> {
         let message_db = self.get_message_db(IDkgMessageType::Dealing);
-        message_db.iter(Some(IterationPattern::Prefix(prefix.get())))
-    }
-
-    fn signed_dealings_by_transcript_id(
-        &self,
-        transcript_id: &IDkgTranscriptId,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgDealing)> + '_> {
-        let message_db = self.get_message_db(IDkgMessageType::Dealing);
-        message_db.iter(Some(IterationPattern::GroupTag(transcript_id.id())))
+        message_db.iter(Some(prefix))
     }
 
     fn dealing_support(
@@ -2054,15 +2035,7 @@ impl IDkgPoolSection for PersistentIDkgPoolSection {
         prefix: IDkgPrefixOf<IDkgDealingSupport>,
     ) -> Box<dyn Iterator<Item = (IDkgMessageId, IDkgDealingSupport)> + '_> {
         let message_db = self.get_message_db(IDkgMessageType::DealingSupport);
-        message_db.iter(Some(IterationPattern::Prefix(prefix.get())))
-    }
-
-    fn dealing_support_by_transcript_id(
-        &self,
-        transcript_id: &IDkgTranscriptId,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, IDkgDealingSupport)> + '_> {
-        let message_db = self.get_message_db(IDkgMessageType::DealingSupport);
-        message_db.iter(Some(IterationPattern::GroupTag(transcript_id.id())))
+        message_db.iter(Some(prefix))
     }
 
     fn ecdsa_signature_shares(
@@ -2077,7 +2050,7 @@ impl IDkgPoolSection for PersistentIDkgPoolSection {
         prefix: IDkgPrefixOf<EcdsaSigShare>,
     ) -> Box<dyn Iterator<Item = (IDkgMessageId, EcdsaSigShare)> + '_> {
         let message_db = self.get_message_db(IDkgMessageType::EcdsaSigShare);
-        message_db.iter(Some(IterationPattern::Prefix(prefix.get())))
+        message_db.iter(Some(prefix))
     }
 
     fn schnorr_signature_shares(
@@ -2092,7 +2065,7 @@ impl IDkgPoolSection for PersistentIDkgPoolSection {
         prefix: IDkgPrefixOf<SchnorrSigShare>,
     ) -> Box<dyn Iterator<Item = (IDkgMessageId, SchnorrSigShare)> + '_> {
         let message_db = self.get_message_db(IDkgMessageType::SchnorrSigShare);
-        message_db.iter(Some(IterationPattern::Prefix(prefix.get())))
+        message_db.iter(Some(prefix))
     }
 
     fn vetkd_key_shares(&self) -> Box<dyn Iterator<Item = (IDkgMessageId, VetKdKeyShare)> + '_> {
@@ -2105,7 +2078,7 @@ impl IDkgPoolSection for PersistentIDkgPoolSection {
         prefix: IDkgPrefixOf<VetKdKeyShare>,
     ) -> Box<dyn Iterator<Item = (IDkgMessageId, VetKdKeyShare)> + '_> {
         let message_db = self.get_message_db(IDkgMessageType::VetKdKeyShare);
-        message_db.iter(Some(IterationPattern::Prefix(prefix.get())))
+        message_db.iter(Some(prefix))
     }
 
     fn signature_shares(&self) -> Box<dyn Iterator<Item = (IDkgMessageId, SigShare)> + '_> {
@@ -2139,7 +2112,7 @@ impl IDkgPoolSection for PersistentIDkgPoolSection {
         prefix: IDkgPrefixOf<SignedIDkgComplaint>,
     ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgComplaint)> + '_> {
         let message_db = self.get_message_db(IDkgMessageType::Complaint);
-        message_db.iter(Some(IterationPattern::Prefix(prefix.get())))
+        message_db.iter(Some(prefix))
     }
 
     fn openings(&self) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgOpening)> + '_> {
@@ -2152,7 +2125,7 @@ impl IDkgPoolSection for PersistentIDkgPoolSection {
         prefix: IDkgPrefixOf<SignedIDkgOpening>,
     ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgOpening)> + '_> {
         let message_db = self.get_message_db(IDkgMessageType::Opening);
-        message_db.iter(Some(IterationPattern::Prefix(prefix.get())))
+        message_db.iter(Some(prefix))
     }
 }
 

--- a/rs/consensus/idkg/src/pre_signer.rs
+++ b/rs/consensus/idkg/src/pre_signer.rs
@@ -1061,38 +1061,34 @@ impl<'a> IDkgTranscriptBuilderImpl<'a> {
             || {
                 let mut transcript_state = TranscriptState::new();
                 // Walk the dealings to get the dealings belonging to the transcript
-                for (id, signed_dealing) in self
-                    .idkg_pool
-                    .validated()
-                    .signed_dealings_by_transcript_id(&transcript_id)
-                {
-                    if let Some(dealing_hash) = id.dealing_hash() {
-                        transcript_state.init_dealing_state(dealing_hash, signed_dealing);
-                    } else {
-                        self.metrics
-                            .transcript_builder_errors_inc("build_transcript_id_dealing_hash");
-                        warn!(
-                            self.log,
-                            "build_transcript(): Failed to get dealing hash: {:?}", id
-                        );
+                for (id, signed_dealing) in self.idkg_pool.validated().signed_dealings() {
+                    if signed_dealing.idkg_dealing().transcript_id == transcript_id {
+                        if let Some(dealing_hash) = id.dealing_hash() {
+                            transcript_state.init_dealing_state(dealing_hash, signed_dealing);
+                        } else {
+                            self.metrics
+                                .transcript_builder_errors_inc("build_transcript_id_dealing_hash");
+                            warn!(
+                                self.log,
+                                "build_transcript(): Failed to get dealing hash: {:?}", id
+                            );
+                        }
                     }
                 }
 
                 // Walk the support shares and assign to the corresponding dealing
-                for (_, support) in self
-                    .idkg_pool
-                    .validated()
-                    .dealing_support_by_transcript_id(&transcript_id)
-                {
-                    if let Err(err) = transcript_state.add_dealing_support(support) {
-                        warn!(
-                            self.log,
-                            "Failed to add support: transcript_id = {:?}, error = {:?}",
-                            transcript_id,
-                            err
-                        );
-                        self.metrics
-                            .transcript_builder_errors_inc("add_dealing_support");
+                for (_, support) in self.idkg_pool.validated().dealing_support() {
+                    if support.transcript_id == transcript_id {
+                        if let Err(err) = transcript_state.add_dealing_support(support) {
+                            warn!(
+                                self.log,
+                                "Failed to add support: transcript_id = {:?}, error = {:?}",
+                                transcript_id,
+                                err
+                            );
+                            self.metrics
+                                .transcript_builder_errors_inc("add_dealing_support");
+                        }
                     }
                 }
 

--- a/rs/interfaces/src/idkg.rs
+++ b/rs/interfaces/src/idkg.rs
@@ -5,9 +5,7 @@ use ic_types::consensus::idkg::{
     EcdsaSigShare, IDkgMessage, IDkgPrefixOf, IDkgStats, SchnorrSigShare, SigShare,
     SignedIDkgComplaint, SignedIDkgOpening, VetKdKeyShare,
 };
-use ic_types::crypto::canister_threshold_sig::idkg::{
-    IDkgDealingSupport, IDkgTranscriptId, SignedIDkgDealing,
-};
+use ic_types::crypto::canister_threshold_sig::idkg::{IDkgDealingSupport, SignedIDkgDealing};
 
 #[derive(Debug)]
 pub enum IDkgChangeAction {
@@ -60,13 +58,9 @@ pub trait IDkgPoolSection: Send + Sync {
     fn signed_dealings_by_prefix(
         &self,
         _prefix: IDkgPrefixOf<SignedIDkgDealing>,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgDealing)> + '_>;
-
-    /// Iterator for signed dealing objects matching the transcript id.
-    fn signed_dealings_by_transcript_id(
-        &self,
-        _transcript_id: &IDkgTranscriptId,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgDealing)> + '_>;
+    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgDealing)> + '_> {
+        unimplemented!()
+    }
 
     /// Iterator for dealing support objects.
     fn dealing_support(&self)
@@ -76,13 +70,9 @@ pub trait IDkgPoolSection: Send + Sync {
     fn dealing_support_by_prefix(
         &self,
         _prefix: IDkgPrefixOf<IDkgDealingSupport>,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, IDkgDealingSupport)> + '_>;
-
-    /// Iterator for dealing support objects matching the transcript id.
-    fn dealing_support_by_transcript_id(
-        &self,
-        _transcript_id: &IDkgTranscriptId,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, IDkgDealingSupport)> + '_>;
+    ) -> Box<dyn Iterator<Item = (IDkgMessageId, IDkgDealingSupport)> + '_> {
+        unimplemented!()
+    }
 
     /// Iterator for signature share objects.
     fn ecdsa_signature_shares(
@@ -93,7 +83,9 @@ pub trait IDkgPoolSection: Send + Sync {
     fn ecdsa_signature_shares_by_prefix(
         &self,
         _prefix: IDkgPrefixOf<EcdsaSigShare>,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, EcdsaSigShare)> + '_>;
+    ) -> Box<dyn Iterator<Item = (IDkgMessageId, EcdsaSigShare)> + '_> {
+        unimplemented!()
+    }
 
     /// Iterator for signature share objects.
     fn schnorr_signature_shares(
@@ -104,7 +96,9 @@ pub trait IDkgPoolSection: Send + Sync {
     fn schnorr_signature_shares_by_prefix(
         &self,
         _prefix: IDkgPrefixOf<SchnorrSigShare>,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SchnorrSigShare)> + '_>;
+    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SchnorrSigShare)> + '_> {
+        unimplemented!()
+    }
 
     /// Iterator for VetKd share objects.
     fn vetkd_key_shares(&self) -> Box<dyn Iterator<Item = (IDkgMessageId, VetKdKeyShare)> + '_>;
@@ -113,7 +107,9 @@ pub trait IDkgPoolSection: Send + Sync {
     fn vetkd_key_shares_by_prefix(
         &self,
         _prefix: IDkgPrefixOf<VetKdKeyShare>,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, VetKdKeyShare)> + '_>;
+    ) -> Box<dyn Iterator<Item = (IDkgMessageId, VetKdKeyShare)> + '_> {
+        unimplemented!()
+    }
 
     fn signature_shares(&self) -> Box<dyn Iterator<Item = (IDkgMessageId, SigShare)> + '_>;
 
@@ -124,7 +120,9 @@ pub trait IDkgPoolSection: Send + Sync {
     fn complaints_by_prefix(
         &self,
         _prefix: IDkgPrefixOf<SignedIDkgComplaint>,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgComplaint)> + '_>;
+    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgComplaint)> + '_> {
+        unimplemented!()
+    }
 
     /// Iterator for opening objects.
     fn openings(&self) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgOpening)> + '_>;
@@ -133,7 +131,9 @@ pub trait IDkgPoolSection: Send + Sync {
     fn openings_by_prefix(
         &self,
         _prefix: IDkgPrefixOf<SignedIDkgOpening>,
-    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgOpening)> + '_>;
+    ) -> Box<dyn Iterator<Item = (IDkgMessageId, SignedIDkgOpening)> + '_> {
+        unimplemented!()
+    }
 }
 
 /// The mutable interface for validated/unvalidated parts of the artifact pool.

--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -1084,16 +1084,6 @@ pub fn opening_prefix(
     IDkgPrefixOf::new(IDkgPrefix::new(transcript_id.id(), hasher.finish()))
 }
 
-/// Represent the different ways of iterating through entries that share a same pattern.
-///
-/// The pattern must be a prefix of the entry key as we leverage the fact that the keys are sorted
-/// when iterating.
-#[derive(Clone)]
-pub enum IterationPattern {
-    GroupTag(u64),
-    Prefix(IDkgPrefix),
-}
-
 pub type IDkgArtifactIdDataOf<T> = Id<T, IDkgArtifactIdData>;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This reverts commit 6b72db3f9dc004364c12dbdb900711134690397f because it causes non-reproducibility in 
`//rs/node_rewards/canister:node-rewards-canister` 
[starting](https://github.com/dfinity/ic/actions/runs/15000909972) from when that commit was merged into master.

I confirmed manually that this revert fixes the non-reproducibility.