### PR TITLE
Use incompatible ic-cdk versions and see if compilation fails

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4154c13c2fbfe871f941850b0698f8866f5687a2bb91c33e8209fe890b5d197b",
+  "checksum": "fc8c65849d6ff65ef423ffbd55499a8c42296d9cc2366ae0c70e5aa000d17af2",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20143,7 +20143,7 @@
               "alias": "ic_cdk_0_17_1"
             },
             {
-              "id": "ic-cdk 0.18.0",
+              "id": "ic-cdk 0.18.2-alpha.1",
               "target": "ic_cdk"
             },
             {
@@ -20175,7 +20175,7 @@
               "target": "ic_http_gateway"
             },
             {
-              "id": "ic-management-canister-types 0.3.0",
+              "id": "ic-management-canister-types 0.3.1",
               "target": "ic_management_canister_types"
             },
             {
@@ -21060,7 +21060,7 @@
               "alias": "ic_cdk_macros_0_17_1"
             },
             {
-              "id": "ic-cdk-macros 0.18.0",
+              "id": "ic-cdk-macros 0.18.1",
               "target": "ic_cdk_macros"
             },
             {
@@ -32507,14 +32507,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-cdk 0.18.0": {
+    "ic-cdk 0.18.2-alpha.1": {
       "name": "ic-cdk",
-      "version": "0.18.0",
+      "version": "0.18.2-alpha.1",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk/0.18.0/download",
-          "sha256": "b11cc255410be6a7e47e1a756ea94c1f31a2397a79e696f6f7d207d5ebd3e144"
+          "url": "https://static.crates.io/crates/ic-cdk/0.18.2-alpha.1/download",
+          "sha256": "8f5e8b9bc42cc34f313e28f3887561debc399f1b67000d56aad3cfff7c5fc083"
         }
       },
       "targets": [
@@ -32543,15 +32543,19 @@
               "target": "candid"
             },
             {
+              "id": "ic-cdk-executor 1.0.0",
+              "target": "ic_cdk_executor"
+            },
+            {
               "id": "ic-error-types 0.1.0",
               "target": "ic_error_types"
             },
             {
-              "id": "ic-management-canister-types 0.3.0",
+              "id": "ic-management-canister-types 0.3.1",
               "target": "ic_management_canister_types"
             },
             {
-              "id": "ic0 0.24.0",
+              "id": "ic0 0.25.0",
               "target": "ic0"
             },
             {
@@ -32577,19 +32581,94 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "ic-cdk-macros 0.18.0",
+              "id": "ic-cdk-macros 0.18.1",
               "target": "ic_cdk_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.18.0"
+        "version": "0.18.2-alpha.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
         "Apache-2.0"
       ],
       "license_file": "LICENSE"
+    },
+    "ic-cdk-executor 1.0.0": {
+      "name": "ic-cdk-executor",
+      "version": "1.0.0",
+      "package_url": "https://github.com/dfinity/cdk-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ic-cdk-executor/1.0.0/download",
+          "sha256": "7f3586c51b6b3809b69c79e97de172b4649f56094e8c8bc1ce2e41a29f20ed5f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ic_cdk_executor",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ic_cdk_executor",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "ic-cdk-executor 1.0.0",
+              "target": "build_script_build"
+            },
+            {
+              "id": "slotmap 1.0.7",
+              "target": "slotmap"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.0.0"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "links": "ic-cdk async executor, see https://github.com/dfinity/cdk-rs/blob/links-pin/TROUBLESHOOTING.md"
+      },
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": null
     },
     "ic-cdk-macros 0.8.4": {
       "name": "ic-cdk-macros",
@@ -32725,14 +32804,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-cdk-macros 0.18.0": {
+    "ic-cdk-macros 0.18.1": {
       "name": "ic-cdk-macros",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk-macros/0.18.0/download",
-          "sha256": "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
+          "url": "https://static.crates.io/crates/ic-cdk-macros/0.18.1/download",
+          "sha256": "669681748d5ef717d712db2be1aba3b3bdeffb1bac87c9dd39ad22bc109e938e"
         }
       },
       "targets": [
@@ -32761,20 +32840,16 @@
               "target": "candid"
             },
             {
+              "id": "darling 0.20.11",
+              "target": "darling"
+            },
+            {
               "id": "proc-macro2 1.0.95",
               "target": "proc_macro2"
             },
             {
               "id": "quote 1.0.37",
               "target": "quote"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "serde_tokenstream 0.2.1",
-              "target": "serde_tokenstream"
             },
             {
               "id": "syn 2.0.101",
@@ -32784,7 +32859,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.18.0"
+        "version": "0.18.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -33743,14 +33818,14 @@
       ],
       "license_file": null
     },
-    "ic-management-canister-types 0.3.0": {
+    "ic-management-canister-types 0.3.1": {
       "name": "ic-management-canister-types",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-management-canister-types/0.3.0/download",
-          "sha256": "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+          "url": "https://static.crates.io/crates/ic-management-canister-types/0.3.1/download",
+          "sha256": "98554c2d8a30c00b6bfda18062fdcef21215cad07a52d8b8b1eb3130e51bfe71"
         }
       },
       "targets": [
@@ -33790,7 +33865,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.0"
+        "version": "0.3.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -34843,14 +34918,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic0 0.24.0": {
+    "ic0 0.25.0": {
       "name": "ic0",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic0/0.24.0/download",
-          "sha256": "673a6b846467547f3fc61f95d246aadff03e368b53c931655300b9d1bd05a55a"
+          "url": "https://static.crates.io/crates/ic0/0.25.0/download",
+          "sha256": "0ecd5c978846f2f917a899f5d644dca9a7f01b4cf7d16b361a5746c4f1922029"
         }
       },
       "targets": [
@@ -34873,7 +34948,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.24.0"
+        "version": "0.25.0"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -89048,9 +89123,9 @@
     "ic-canister-sig-creation 1.1.0",
     "ic-cbor 3.0.3",
     "ic-cdk 0.17.1",
-    "ic-cdk 0.18.0",
+    "ic-cdk 0.18.2-alpha.1",
     "ic-cdk-macros 0.17.1",
-    "ic-cdk-macros 0.18.0",
+    "ic-cdk-macros 0.18.1",
     "ic-cdk-timers 0.11.0",
     "ic-certificate-verification 3.0.3",
     "ic-certification 3.0.3",
@@ -89058,7 +89133,7 @@
     "ic-gateway 0.1.0",
     "ic-http-certification 3.0.3",
     "ic-http-gateway 0.2.0",
-    "ic-management-canister-types 0.3.0",
+    "ic-management-canister-types 0.3.1",
     "ic-metrics-encoder 1.1.1",
     "ic-response-verification 3.0.3",
     "ic-sha3 1.0.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3469,9 +3469,9 @@ dependencies = [
  "ic-canister-sig-creation",
  "ic-cbor",
  "ic-cdk 0.17.1",
- "ic-cdk 0.18.0",
+ "ic-cdk 0.18.2-alpha.1",
  "ic-cdk-macros 0.17.1",
- "ic-cdk-macros 0.18.0",
+ "ic-cdk-macros 0.18.1",
  "ic-cdk-timers",
  "ic-certificate-verification",
  "ic-certification 3.0.3",
@@ -5661,19 +5661,29 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.18.0"
+version = "0.18.2-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11cc255410be6a7e47e1a756ea94c1f31a2397a79e696f6f7d207d5ebd3e144"
+checksum = "8f5e8b9bc42cc34f313e28f3887561debc399f1b67000d56aad3cfff7c5fc083"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.18.0",
+ "ic-cdk-executor",
+ "ic-cdk-macros 0.18.1",
  "ic-error-types",
  "ic-management-canister-types",
- "ic0 0.24.0",
+ "ic0 0.25.0",
  "serde",
  "serde_bytes",
  "slotmap",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "ic-cdk-executor"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3586c51b6b3809b69c79e97de172b4649f56094e8c8bc1ce2e41a29f20ed5f"
+dependencies = [
+ "slotmap",
 ]
 
 [[package]]
@@ -5706,15 +5716,14 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
+checksum = "669681748d5ef717d712db2be1aba3b3bdeffb1bac87c9dd39ad22bc109e938e"
 dependencies = [
  "candid",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "serde",
- "serde_tokenstream 0.2.1",
  "syn 2.0.101",
 ]
 
@@ -5923,9 +5932,9 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+checksum = "98554c2d8a30c00b6bfda18062fdcef21215cad07a52d8b8b1eb3130e51bfe71"
 dependencies = [
  "candid",
  "serde",
@@ -6133,9 +6142,9 @@ checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
 
 [[package]]
 name = "ic0"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673a6b846467547f3fc61f95d246aadff03e368b53c931655300b9d1bd05a55a"
+checksum = "0ecd5c978846f2f917a899f5d644dca9a7f01b4cf7d16b361a5746c4f1922029"
 
 [[package]]
 name = "ic_bls12_381"

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -618,7 +618,8 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "3.0.3",
             ),
             "ic-cdk": crate.spec(
-                version = "^0.18.0",
+                package = "ic-cdk",
+                version = "0.18.2-alpha.1",
             ),
             "ic-cdk-0-17-1": crate.spec(
                 package = "ic-cdk",

--- a/rs/nns/integration_tests/BUILD.bazel
+++ b/rs/nns/integration_tests/BUILD.bazel
@@ -35,7 +35,7 @@ BASE_DEPENDENCIES = [
     "@crate_index//:futures",
     "@crate_index//:ic-cdk-timers",
     "@crate_index//:ic-stable-structures",
-    "@crate_index//:ic_cdk_0_17_1",
+    "@crate_index//:ic-cdk",
     "@crate_index//:lazy_static",
     "@crate_index//:prometheus-parse",
     "@crate_index//:prost",
@@ -218,7 +218,9 @@ rust_canister(
     aliases = ALIASES,
     proc_macro_deps = MACRO_DEPENDENCIES,
     service_file = ":test_canisters/empty.did",
-    deps = DEPENDENCIES,
+    deps = DEPENDENCIES + [
+        "//rs/nervous_system/runtime",
+    ],
 )
 
 rust_canister(

--- a/rs/nns/integration_tests/Cargo.toml
+++ b/rs/nns/integration_tests/Cargo.toml
@@ -36,7 +36,7 @@ dfn_json = { path = "../../rust_canisters/dfn_json" }
 dfn_protobuf = { path = "../../rust_canisters/dfn_protobuf" }
 futures = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
-ic-cdk = "0.17.1"
+ic-cdk = "0.18.2-alpha.1"
 ic-cdk-macros = "0.17.1"
 ic-cdk-timers = { workspace = true }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }

--- a/rs/nns/integration_tests/test_canisters/canister_playground_canister.rs
+++ b/rs/nns/integration_tests/test_canisters/canister_playground_canister.rs
@@ -1,47 +1,30 @@
-use dfn_candid::candid_one;
-use dfn_core::{over_async, println};
+// Example of ic_cdk canister - comment out the above to use
+use candid::Encode;
+use ic_base_types::{CanisterId, PrincipalId};
+use ic_cdk::println;
+use ic_cdk::{init, update};
+use ic_nervous_system_runtime::{CdkRuntime, Runtime};
 
-#[export_name = "canister_init"]
+#[init]
 fn canister_init() {
     println!("Playground Canister Init!");
 }
 
-#[export_name = "canister_update test"]
-fn test() {
-    over_async(candid_one, |_: ()| async move { test_().await })
+#[update]
+async fn test() {
+    println!("Playground test was called");
+    let _response = CdkRuntime::call_bytes_with_cleanup(
+        CanisterId::try_from(PrincipalId::from(ic_cdk::api::canister_self())).unwrap(),
+        "test_2",
+        &Encode!(&()).unwrap(),
+    )
+    .await
+    .unwrap();
 }
 
-async fn test_() {
-    println!("Playground canister was called");
+#[update]
+async fn test_2() {
+    println!("Playground canister test_2 was called");
 }
-
-// Example of ic_cdk canister - comment out the above to use
-// use ic_cdk::println;
-// use ic_cdk_macros::{init, update};
-// use std::time::Duration;
-//
-// #[init]
-// fn canister_init() {
-//     println!("Playground Canister Init!");
-// }
-//
-// #[update]
-// async fn test() {
-//     println!("Playground test was called");
-//     ic_cdk::spawn(async move {
-//         let _: () = ic_cdk::call(ic_cdk::api::id(), "test_2", ()).await.unwrap();
-//     });
-//     ic_cdk_timers::set_timer(Duration::from_millis(0), || {
-//         println!("Timer call worked!");
-//     });
-//     println!("Playground test - spawns were called");
-//     panic!("Panic at the disco!");
-// }
-//
-// #[update]
-// async fn test_2() {
-//     println!("Playground canister test_2 was called");
-// }
-//
 
 fn main() {}


### PR DESCRIPTION
Command: `CARGO_BAZEL_REPIN=true bazel test --test_output=streamed --test_arg=--nocapture  rs/nns/integration_tests:canister_playground`