### PR TITLE
fix: renaming timestamps to reflect actual units

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -311,7 +311,7 @@ fn get_value() {
                     let HighCapacityRegistryValue {
                         version,
                         content,
-                        timestamp_seconds,
+                        timestamp_nanoseconds,
                     } = result;
 
                     let content = content.map(|content| {
@@ -328,7 +328,7 @@ fn get_value() {
                     HighCapacityRegistryGetValueResponse {
                         version,
                         content,
-                        timestamp_seconds,
+                        timestamp_nanoseconds,
 
                         error: None,
                     }
@@ -348,7 +348,7 @@ fn get_value() {
                     // since the moment we did this read.
                     version,
                     content: None,
-                    timestamp_seconds: 0,
+                    timestamp_nanoseconds: 0,
                 },
             }
         }
@@ -360,7 +360,7 @@ fn get_value() {
             }),
             version: 0,
             content: None,
-            timestamp_seconds: 0,
+            timestamp_nanoseconds: 0,
         },
     };
     let bytes = serialize_get_value_response(response_pb).expect("Error serializing response");

--- a/rs/registry/canister/chunkify/src/lib.rs
+++ b/rs/registry/canister/chunkify/src/lib.rs
@@ -39,12 +39,12 @@ pub fn chunkify_composite_mutation<M: Memory>(
         .map(|mutation| chunkify_prime_mutation(mutation, chunks))
         .collect::<Vec<_>>();
 
-    let timestamp_seconds = 0;
+    let timestamp_nanoseconds = 0;
 
     HighCapacityRegistryAtomicMutateRequest {
         mutations,
         preconditions,
-        timestamp_seconds,
+        timestamp_nanoseconds,
     }
 }
 

--- a/rs/registry/canister/chunkify/src/tests.rs
+++ b/rs/registry/canister/chunkify/src/tests.rs
@@ -207,12 +207,12 @@ fn test_decode_high_capacity_registry_value() {
         ),
     ] {
         version += 1;
-        let timestamp_seconds = version + 123_000_000;
+        let timestamp_nanoseconds = version + 123_000_000;
 
         let input = HighCapacityRegistryValue {
             version,
             content,
-            timestamp_seconds,
+            timestamp_nanoseconds,
         };
 
         let observed_output: Option<Precondition> =

--- a/rs/registry/canister/src/storage/tests.rs
+++ b/rs/registry/canister/src/storage/tests.rs
@@ -88,7 +88,7 @@ fn test_chunkify_reasonably_large_mutation() {
     let expected_mutation = HighCapacityRegistryAtomicMutateRequest {
         mutations: vec![result.mutations.first().unwrap().clone()],
         preconditions: vec![PRECONDITION.clone()],
-        timestamp_seconds: 0,
+        timestamp_nanoseconds: 0,
     };
     assert_eq!(result, expected_mutation);
 }

--- a/rs/registry/nns_data_provider/src/certification/tests.rs
+++ b/rs/registry/nns_data_provider/src/certification/tests.rs
@@ -397,7 +397,7 @@ fn test_honest_chunked() {
                 ),
             }],
             preconditions: vec![],
-            timestamp_seconds: 1735689600, // Jan 1, 2025 midnight UTC
+            timestamp_nanoseconds: 1735689600000000000, // Jan 1, 2025 midnight UTC
         }],
         1..=1,
         GarbleResponse::LeaveAsIs,
@@ -473,7 +473,7 @@ fn test_evil_chunked() {
                 ),
             }],
             preconditions: vec![],
-            timestamp_seconds: 1735689600, // Jan 1, 2025 midnight UTC
+            timestamp_nanoseconds: 1735689600000000000, // Jan 1, 2025 midnight UTC
         }],
         1..=1,
         GarbleResponse::LeaveAsIs,

--- a/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
+++ b/rs/registry/transport/proto/ic_registry_transport/pb/v1/transport.proto
@@ -172,7 +172,7 @@ message HighCapacityRegistryValue {
   }
 
   // The timestamp at which the registry mutation happened.
-  uint64 timestamp_seconds = 5;
+  uint64 timestamp_nanoseconds = 5;
 }
 
 // In the not so distant future, this will be used instead of RegistryDelta. See
@@ -278,7 +278,7 @@ message HighCapacityRegistryGetValueResponse {
   }
 
   // The timestamp at which the registry mutation happened.
-  uint64 timestamp_seconds = 5;
+  uint64 timestamp_nanoseconds = 5;
 }
 
 // Deprecated; instead, use HighCapacityRegistryGetValueResponse. See the
@@ -350,7 +350,7 @@ message HighCapacityRegistryAtomicMutateRequest {
   reserved 4;
 
   // The timestamp at which the registry atomic mutate request happened.
-  uint64 timestamp_seconds = 6;
+  uint64 timestamp_nanoseconds = 6;
 }
 
 // A single mutation in the registry.

--- a/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
+++ b/rs/registry/transport/src/gen/ic_registry_transport.pb.v1.rs
@@ -89,7 +89,7 @@ pub struct HighCapacityRegistryValue {
     pub version: u64,
     /// The timestamp at which the registry mutation happened.
     #[prost(uint64, tag = "5")]
-    pub timestamp_seconds: u64,
+    pub timestamp_nanoseconds: u64,
     #[prost(oneof = "high_capacity_registry_value::Content", tags = "1, 3, 4")]
     pub content: ::core::option::Option<high_capacity_registry_value::Content>,
 }
@@ -218,7 +218,7 @@ pub struct HighCapacityRegistryGetValueResponse {
     pub version: u64,
     /// The timestamp at which the registry mutation happened.
     #[prost(uint64, tag = "5")]
-    pub timestamp_seconds: u64,
+    pub timestamp_nanoseconds: u64,
     #[prost(
         oneof = "high_capacity_registry_get_value_response::Content",
         tags = "3, 4"
@@ -318,7 +318,7 @@ pub struct HighCapacityRegistryAtomicMutateRequest {
     pub preconditions: ::prost::alloc::vec::Vec<Precondition>,
     /// The timestamp at which the registry atomic mutate request happened.
     #[prost(uint64, tag = "6")]
-    pub timestamp_seconds: u64,
+    pub timestamp_nanoseconds: u64,
 }
 /// A single mutation in the registry.
 #[derive(candid::CandidType, candid::Deserialize, Eq, Clone, PartialEq, ::prost::Message)]

--- a/rs/registry/transport/src/high_capacity.rs
+++ b/rs/registry/transport/src/high_capacity.rs
@@ -80,7 +80,7 @@ mod downgrade_get_changes_since_response {
                 content,
 
                 // This gets dropped.
-                timestamp_seconds: _,
+                timestamp_nanoseconds: _,
             } = original;
 
             let (value, deletion_marker) = match content {
@@ -119,12 +119,12 @@ impl From<RegistryAtomicMutateRequest> for HighCapacityRegistryAtomicMutateReque
             .map(HighCapacityRegistryMutation::from)
             .collect::<Vec<_>>();
 
-        let timestamp_seconds = 0;
+        let timestamp_nanoseconds = 0;
 
         HighCapacityRegistryAtomicMutateRequest {
             mutations,
             preconditions,
-            timestamp_seconds,
+            timestamp_nanoseconds,
         }
     }
 }

--- a/rs/registry/transport/src/high_capacity_tests.rs
+++ b/rs/registry/transport/src/high_capacity_tests.rs
@@ -52,7 +52,7 @@ fn test_convert_to_high_capacity_registry_atomic_mutate_request() {
                 },
             ],
             preconditions,
-            timestamp_seconds: 0,
+            timestamp_nanoseconds: 0,
         }
     );
 }

--- a/rs/registry/transport/src/lib.rs
+++ b/rs/registry/transport/src/lib.rs
@@ -576,7 +576,7 @@ mod tests {
         let high_capacity_registry_value = HighCapacityRegistryValue {
             content: Some(high_capacity_registry_value::Content::Value(value)),
             version,
-            timestamp_seconds: 0,
+            timestamp_nanoseconds: 0,
         };
 
         let version = 43;
@@ -593,7 +593,7 @@ mod tests {
                 deletion_marker,
             )),
             version,
-            timestamp_seconds: 0,
+            timestamp_nanoseconds: 0,
         };
 
         let key = b"name".to_vec();
@@ -702,7 +702,7 @@ mod tests {
             content: Some(high_capacity_registry_get_value_response::Content::Value(
                 value,
             )),
-            timestamp_seconds: 0,
+            timestamp_nanoseconds: 0,
         };
 
         // Ok if client starts using HighCapacity before server.
@@ -816,7 +816,7 @@ mod tests {
                     }
                 })
                 .collect(),
-            timestamp_seconds: 0,
+            timestamp_nanoseconds: 0,
         };
 
         // Ok if client starts using HighCapacity before server.


### PR DESCRIPTION
This PR renames `timestamp_seconds` to `timestamp_nanoseconds` to reflect their actual units. It is the part of #5076 and should be merged together.