### PR TITLE
feat(registry): enforce presence of node_reward_type

### DIFF
--- a/rs/registry/canister/src/mutations/node_management/do_add_node.rs
+++ b/rs/registry/canister/src/mutations/node_management/do_add_node.rs
@@ -117,12 +117,8 @@ impl Registry {
             .transpose()?
             .map(|node_reward_type| node_reward_type as i32);
 
-        // 4a.  Conditionally enforce node_reward_type presence if reward_table exists
-        if self
-            .get(NODE_REWARDS_TABLE_KEY.as_bytes(), self.latest_version())
-            .is_some()
-            && node_reward_type.is_none()
-        {
+        // 4a.  Conditionally enforce node_reward_type presence if node rewards are enabled
+        if self.are_node_rewards_enabled() && node_reward_type.is_none() {
             return Err(format!(
                 "{}do_add_node: Node reward type is required.",
                 LOG_PREFIX
@@ -195,6 +191,13 @@ impl Registry {
         println!("{}do_add_node finished: {:?}", LOG_PREFIX, payload);
 
         Ok(node_id)
+    }
+
+    /// Currently, we know that node rewards are enabled based on the presence of the table in the
+    /// registry.
+    fn are_node_rewards_enabled(&self) -> bool {
+        self.get(NODE_REWARDS_TABLE_KEY.as_bytes(), self.latest_version())
+            .is_some()
     }
 }
 

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -11,6 +11,9 @@ on the process that this file is part of, see
 
 ## Changed
 
+* The field `node_reward_type` in AddNodePayload is now required to be populated with a valid node_reward_type when
+  adding a node (in `do_add_node`) if a node_rewards table record is present in the registry.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
This turns on enforcement that new node registrations will have a valid node_reward_type.  This is for the sake of accurately calculating node provider rewards based on the actual nodes that are registered and their types.