### PR TITLE
fix: Fix snapshot size calculation

### DIFF
--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -449,8 +449,8 @@ impl CanisterState {
         let execution_usage = self
             .execution_state
             .as_ref()
-            .map_or(NumBytes::new(0), |execution_snapshot| {
-                execution_snapshot.memory_usage()
+            .map_or(NumBytes::new(0), |execution_state| {
+                execution_state.memory_usage_in_snapshot()
             });
 
         execution_usage

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -511,6 +511,10 @@ impl ExecutionState {
     }
 
     /// Returns the `ExecutionState`'s contribution to the memory of a snapshot.
+    /// The difference to `memory_usage` is that the custom wasm section is not
+    /// stored explicitly in a snapshot, only implicitly in the wasm module,
+    /// whereas for the running canister, it's explicit and takes additional
+    /// memory.
     pub fn memory_usage_in_snapshot(&self) -> NumBytes {
         self.wasm_memory_usage()
             + self.stable_memory_usage()

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -510,6 +510,14 @@ impl ExecutionState {
             + self.custom_sections_memory_size()
     }
 
+    /// Returns the `ExecutionState`'s contribution to the memory of a snapshot.
+    pub fn memory_usage_in_snapshot(&self) -> NumBytes {
+        self.wasm_memory_usage()
+            + self.stable_memory_usage()
+            + self.global_memory_usage()
+            + self.wasm_binary_memory_usage()
+    }
+
     /// Returns the number of global variables in the Wasm module.
     pub fn num_wasm_globals(&self) -> usize {
         self.exported_globals.len()


### PR DESCRIPTION
The custom wasm section may contribute to a running canister's memory footprint, but it is not stored in a snapshot explicitly, so it should not be used in the snapshot size calculation. 