### PR TITLE
feat(CRP-2702): Log the chain keys on every CUP height

### DIFF
--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -162,6 +162,14 @@ pub fn deliver_batches(
         let (mut ni_dkg_subnet_public_keys, ni_dkg_ids) = get_vetkey_public_keys(dkg_summary, log);
         chain_key_subnet_public_keys.append(&mut ni_dkg_subnet_public_keys);
 
+        // If the subnet contains chain keys, log them on every summary block
+        if !chain_key_subnet_public_keys.is_empty() && block.payload.is_summary() {
+            info!(
+                log,
+                "Subnet {} contains chain keys: {:?}", subnet_id, chain_key_subnet_public_keys
+            );
+        }
+
         let mut batch_stats = BatchStats::new(height);
 
         // Compute consensus' responses to subnet calls.


### PR DESCRIPTION
This PR adds a log message on every CUP height, that simply prints the existing public keys of the Subnet as a INFO message.

The Ticket states, that this should only happen for VetKD keys, but I found it very convenient to simply log all chain keys.
The log message only appears, if there are any chain keys  present on the subnet and only on CUP heights, so the log should not be too spammy