### PR TITLE
Revert "chore(IDX): rules_rust: 0.56.0 -> 0.61.0 (#4574)"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.9.0")
 
 # CC dependencies (for C libs like miracl-core, etc)
 bazel_dep(name = "rules_cc", version = "0.0.13")
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.1")
 archive_override(
     module_name = "hermetic_cc_toolchain",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -109,21 +109,18 @@ sol_register_toolchains(
 
 http_archive(
     name = "rules_rust",
-    integrity = "sha256-U8G6x+xI985IxMHGqgBvJ1Fa3SrrBXJZNyJObgDsfOo=",
+    integrity = "sha256-8TBqrAsli3kN8BrZq8arsN8LZUFsdLTvJ/Sqsph4CmQ=",
     patch_args = ["-p1"],
     patches = ["//bazel:rules_rust.patch"],
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.61.0/rules_rust-0.61.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.56.0/rules_rust-0.56.0.tar.gz"],
 )
 
-load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
 load("@rules_rust//tools/rust_analyzer:deps.bzl", "rust_analyzer_dependencies")
 
 rules_rust_dependencies()
 
 rust_analyzer_dependencies()
-
-crate_universe_dependencies()
 
 rust_register_toolchains(
     edition = "2021",


### PR DESCRIPTION
This reverts commit 7443f1e1c7f4ee75ae8802ec5dac9be78144d07e.

This update causes x86-darwin rust target to be skipped during the build.