### PR TITLE
fix(PocketIC): canister creation with specified id on resumed instance

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 9.0.1 - 2025-05-15
+## 9.0.1 - 2025-05-16
 
 ## 9.0.0 - 2025-04-30
 

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -2741,3 +2741,40 @@ fn stack_overflow() {
         .reject_message
         .contains("Canister trapped: stack overflow"));
 }
+
+fn test_specified_id(pic: &PocketIc) {
+    // We define a "specified" canister ID that exists on the IC mainnet,
+    // but belongs to the canister ranges of no subnet on the PocketIC instance.
+    let specified_id = Principal::from_text("rimrc-piaaa-aaaao-aaljq-cai").unwrap();
+
+    let canister_id = pic
+        .create_canister_with_id(None, None, specified_id)
+        .unwrap();
+    assert_eq!(canister_id, specified_id);
+}
+
+#[test]
+fn test_specified_id_on_fresh_instance() {
+    // create a fresh PocketIC instance
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+
+    test_specified_id(&pic);
+}
+
+#[test]
+fn test_specified_id_on_resumed_state() {
+    // create an empty PocketIC state to be set up later
+    let state = PocketIcState::new();
+    // create a PocketIC instance used to set up the state
+    let pic = PocketIcBuilder::new()
+        .with_application_subnet()
+        .with_state(state)
+        .build();
+    // serialize the state
+    let state = pic.drop_and_take_state().unwrap();
+
+    // create a PocketIC instance resuming from the existing state
+    let pic = PocketIcBuilder::new().with_state(state).build();
+
+    test_specified_id(&pic);
+}

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 9.0.2 - 2025-05-15
+## 9.0.2 - 2025-05-16
+
+### Fixed
+- Crash when creating a canister with a specified id on a PocketIC instance created from an existing PocketIC state.
 
 ## 9.0.1 - 2025-04-30
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -923,14 +923,22 @@ impl PocketIc {
             topology
                 .subnet_configs
                 .into_values()
-                .map(|config| SubnetConfigInfo {
-                    ranges: config.subnet_config.ranges,
-                    alloc_range: config.subnet_config.alloc_range,
-                    subnet_id: Some(config.subnet_config.subnet_id),
-                    subnet_state_dir: None,
-                    subnet_kind: config.subnet_config.subnet_kind,
-                    instruction_config: config.subnet_config.instruction_config,
-                    time: config.time,
+                .map(|config| {
+                    range_gen
+                        .add_assigned(config.subnet_config.ranges.clone())
+                        .unwrap();
+                    if let Some(allocation_range) = config.subnet_config.alloc_range {
+                        range_gen.add_assigned(vec![allocation_range]).unwrap();
+                    }
+                    SubnetConfigInfo {
+                        ranges: config.subnet_config.ranges,
+                        alloc_range: config.subnet_config.alloc_range,
+                        subnet_id: Some(config.subnet_config.subnet_id),
+                        subnet_state_dir: None,
+                        subnet_kind: config.subnet_config.subnet_kind,
+                        instruction_config: config.subnet_config.instruction_config,
+                        time: config.time,
+                    }
                 })
                 .collect()
         } else {


### PR DESCRIPTION
This PR fixes a crash when creating a canister with a specified id on a PocketIC instance created from an existing PocketIC state. The issue was caused by not adding the canister ranges of subnets in the existing PocketIC state to `PocketIc::range_gen`.