### PR TITLE
test(replay): Integration test for `get_changes_since` in replay.

### DIFF
--- a/rs/replay/tests/player.rs
+++ b/rs/replay/tests/player.rs
@@ -1,17 +1,24 @@
 use async_trait::async_trait;
 use candid::{Encode, Principal};
 use ic_error_types::UserError;
+use ic_interfaces_registry::RegistryTransportRecord;
 use ic_nervous_system_agent::{pocketic_impl::PocketIcAgent, CallCanisters};
 use ic_nervous_system_chunks::test_data::{MegaBlob, MEGA_BLOB_CONTENT};
 use ic_nervous_system_integration_tests::pocket_ic_helpers::install_canister;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, REGISTRY_CANISTER_ID};
 use ic_nns_test_utils::common::{build_test_registry_wasm, NnsInitPayloadsBuilder};
 use ic_registry_canister_api::mutate_test_high_capacity_records;
+use ic_registry_transport::pb::v1::RegistryGetLatestVersionResponse;
 use ic_replay::player::{
-    public_only_for_test_registry_get_value as registry_get_value, PerformQuery, PerformQueryResult,
+    public_only_for_test_get_changes_since as get_changes_since,
+    public_only_for_test_registry_get_value as registry_get_value, PerformQuery,
+    PerformQueryResult,
 };
-use ic_types::{ingress::WasmResult, messages::Query, time::expiry_time_from_now, Time};
+use ic_types::{
+    ingress::WasmResult, messages::Query, time::expiry_time_from_now, RegistryVersion, Time,
+};
 use pocket_ic::{nonblocking::PocketIc, PocketIcBuilder};
+use prost::Message;
 use std::{convert::Infallible, time::SystemTime};
 use strum::IntoEnumIterator;
 
@@ -70,7 +77,7 @@ impl PerformQuery for PerformQueryImpl<'_> {
 }
 
 #[tokio::test]
-async fn test_registry_get_value() {
+async fn test_registry_get_value_and_changes_since() {
     // Step 1: Prepare the world.
 
     // Step 1.1: Create a simulated ICP (to wit, PocketIc).
@@ -104,18 +111,41 @@ async fn test_registry_get_value() {
         .await
         .unwrap();
 
+    // Step 1.4: Double check that Registry is at version 2, because the way
+    // that we call the code under test assumes this.
+    let version = pocket_ic
+        .query_call(
+            Principal::from(REGISTRY_CANISTER_ID),
+            Principal::anonymous(),
+            "get_latest_version",
+            vec![],
+        )
+        .await
+        .unwrap();
+    let version = RegistryGetLatestVersionResponse::decode(&*version).unwrap();
+    let RegistryGetLatestVersionResponse { version } = version;
+    assert_eq!(2, version);
+
     // Step 2: Call code under test.
 
     let perform_query = PerformQueryImpl {
         pocket_ic: &pocket_ic,
     };
+
+    // Step 2.1: Call registry_get_value.
     let observed_mega_blob: MegaBlob =
         registry_get_value("daniel_wong_42", expiry_time_from_now(), &perform_query)
             .await
             .unwrap();
 
+    // Step 2.2: Call get_changes_since.
+    let mut changes = get_changes_since(1, expiry_time_from_now(), &perform_query)
+        .await
+        .unwrap();
+
     // Step 3: Verify result(s).
 
+    // Step 3.1: Verify result of registry_get_value.
     // assert_eq is intentionally not used here, because that would create lots of spam.
     assert!(
         observed_mega_blob
@@ -126,4 +156,29 @@ async fn test_registry_get_value() {
         observed_mega_blob.content.len(),
         MEGA_BLOB_CONTENT.len(),
     );
+
+    // Step 3.2: Verify result of get_changes_since.
+    assert_eq!(changes.len(), 1);
+    {
+        let RegistryTransportRecord {
+            key,
+            version,
+            value,
+        } = changes.pop().unwrap();
+
+        assert_eq!(key, "daniel_wong_42".to_string());
+        assert_eq!(version, RegistryVersion::from(2));
+
+        let len = value.as_ref().unwrap().len();
+        let value = MegaBlob::decode(&*value.unwrap()).unwrap();
+        // To avoid spam, assert_eq is NOT used.
+        assert!(
+            value
+                == MegaBlob {
+                    content: MEGA_BLOB_CONTENT.clone()
+                },
+            "len={}",
+            len,
+        );
+    };
 }


### PR DESCRIPTION
This piggy backs off an existing test for a similar function (to wit, `registry_get_value`).

# Secondary Change(s)

I made `get_changes_since` be `async` instead of taking a `Runtime` (which was used to `block_on`). This is orthogonal, but it makes everything a little bit simpler, because tests do not then have to create a `Runtime`.