### PR TITLE
fix(IDX): Re-enable x86-darwin builds

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "efefdad09818d3e4b172910c5505c55eb87fdb87e3d398d8d3aee7c9e4944cf4",
+  "checksum": "4744c873b3c4211ffacd29096555433c7e4c407d5ecba66cb0d4023e4ad9d838",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -1831,13 +1831,10 @@
             "aarch64-unknown-linux-gnu": [
               "default"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "default"
             ],
             "x86_64-unknown-linux-gnu": [
-              "default"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "default"
             ]
           }
@@ -2342,14 +2339,7 @@
               "target": "utf8parse"
             }
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "anstyle-wincon 3.0.1",
-                "target": "anstyle_wincon"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
         "version": "0.6.15"
@@ -12279,13 +12269,10 @@
             "aarch64-unknown-linux-gnu": [
               "parallel"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "parallel"
             ],
             "x86_64-unknown-linux-gnu": [
-              "parallel"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "parallel"
             ]
           }
@@ -12318,13 +12305,7 @@
                 "target": "libc"
               }
             ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "jobserver 0.1.32",
-                "target": "jobserver"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "jobserver 0.1.32",
                 "target": "jobserver"
@@ -12334,7 +12315,7 @@
                 "target": "libc"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "jobserver 0.1.32",
                 "target": "jobserver"
@@ -12521,29 +12502,13 @@
                 "target": "wasm_bindgen"
               }
             ],
-            "wasm32-wasip1": [
-              {
-                "id": "serde-wasm-bindgen 0.5.0",
-                "target": "serde_wasm_bindgen"
-              },
-              {
-                "id": "wasm-bindgen 0.2.100",
-                "target": "wasm_bindgen"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "crossterm 0.27.0",
                 "target": "crossterm"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "crossterm 0.27.0",
-                "target": "crossterm"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "crossterm 0.27.0",
                 "target": "crossterm"
@@ -12992,19 +12957,13 @@
                 "target": "wasm_bindgen"
               }
             ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "windows-targets 0.52.6",
-                "target": "windows_targets"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "iana-time-zone 0.1.59",
                 "target": "iana_time_zone"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "iana-time-zone 0.1.59",
                 "target": "iana_time_zone"
@@ -14616,12 +14575,6 @@
               {
                 "id": "winapi 0.3.9",
                 "target": "winapi"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "winapi-util 0.1.6",
-                "target": "winapi_util"
               }
             ]
           }
@@ -17117,81 +17070,27 @@
               "target": "bitflags"
             },
             {
+              "id": "mio 0.8.10",
+              "target": "mio"
+            },
+            {
               "id": "parking_lot 0.12.1",
               "target": "parking_lot"
+            },
+            {
+              "id": "signal-hook 0.3.17",
+              "target": "signal_hook"
+            },
+            {
+              "id": "signal-hook-mio 0.2.3",
+              "target": "signal_hook_mio"
             }
           ],
           "selects": {
-            "aarch64-apple-darwin": [
-              {
-                "id": "mio 0.8.10",
-                "target": "mio"
-              },
-              {
-                "id": "signal-hook 0.3.17",
-                "target": "signal_hook"
-              },
-              {
-                "id": "signal-hook-mio 0.2.3",
-                "target": "signal_hook_mio"
-              }
-            ],
-            "aarch64-unknown-linux-gnu": [
-              {
-                "id": "mio 0.8.10",
-                "target": "mio"
-              },
-              {
-                "id": "signal-hook 0.3.17",
-                "target": "signal_hook"
-              },
-              {
-                "id": "signal-hook-mio 0.2.3",
-                "target": "signal_hook_mio"
-              }
-            ],
             "cfg(unix)": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "crossterm_winapi 0.9.1",
-                "target": "crossterm_winapi"
-              },
-              {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "mio 0.8.10",
-                "target": "mio"
-              },
-              {
-                "id": "signal-hook 0.3.17",
-                "target": "signal_hook"
-              },
-              {
-                "id": "signal-hook-mio 0.2.3",
-                "target": "signal_hook_mio"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              {
-                "id": "mio 0.8.10",
-                "target": "mio"
-              },
-              {
-                "id": "signal-hook 0.3.17",
-                "target": "signal_hook"
-              },
-              {
-                "id": "signal-hook-mio 0.2.3",
-                "target": "signal_hook_mio"
               }
             ]
           }
@@ -23146,13 +23045,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "edition": "2015",
         "version": "0.3.6"
       },
@@ -24721,19 +24613,13 @@
                 "target": "parking"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "parking 2.1.1",
                 "target": "parking"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "parking 2.1.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "parking 2.1.1",
                 "target": "parking"
@@ -24812,19 +24698,13 @@
                 "target": "parking"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "parking 2.1.1",
                 "target": "parking"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "parking 2.1.1",
-                "target": "parking"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "parking 2.1.1",
                 "target": "parking"
@@ -30173,14 +30053,7 @@
               "target": "tracing"
             }
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "ipconfig 0.3.2",
-                "target": "ipconfig"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
         "version": "0.24.4"
@@ -30299,14 +30172,7 @@
               "target": "webpki_roots"
             }
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "ipconfig 0.3.2",
-                "target": "ipconfig"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
         "version": "0.25.2"
@@ -31792,15 +31658,11 @@
               "webpki-roots",
               "webpki-tokio"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "webpki-roots",
               "webpki-tokio"
             ],
             "x86_64-unknown-linux-gnu": [
-              "webpki-roots",
-              "webpki-tokio"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "webpki-roots",
               "webpki-tokio"
             ]
@@ -31867,19 +31729,13 @@
                 "target": "webpki_roots"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "webpki-roots 0.26.8",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "webpki-roots 0.26.8",
-                "target": "webpki_roots"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "webpki-roots 0.26.8",
                 "target": "webpki_roots"
@@ -38579,23 +38435,11 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "computer",
-            "default",
-            "winreg"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
               "id": "ipconfig 0.3.2",
               "target": "build_script_build"
-            },
-            {
-              "id": "winreg 0.50.0",
-              "target": "winreg"
             }
           ],
           "selects": {
@@ -39159,15 +39003,11 @@
               "default",
               "use_std"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "default",
               "use_std"
             ],
             "x86_64-unknown-linux-gnu": [
-              "default",
-              "use_std"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "default",
               "use_std"
             ]
@@ -40277,27 +40117,13 @@
                 "target": "linux_keyutils"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
-                "id": "byteorder 1.5.0",
-                "target": "byteorder"
-              },
-              {
-                "id": "windows-sys 0.59.0",
-                "target": "windows_sys"
+                "id": "security-framework 3.0.1",
+                "target": "security_framework"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "dbus-secret-service 4.0.3",
-                "target": "dbus_secret_service"
-              },
-              {
-                "id": "linux-keyutils 0.2.4",
-                "target": "linux_keyutils"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "dbus-secret-service 4.0.3",
                 "target": "dbus_secret_service"
@@ -41202,15 +41028,11 @@
               "lexer",
               "regex"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "lexer",
               "regex"
             ],
             "x86_64-unknown-linux-gnu": [
-              "lexer",
-              "regex"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "lexer",
               "regex"
             ]
@@ -41231,19 +41053,13 @@
                 "target": "regex"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "regex 1.11.1",
                 "target": "regex"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "regex 1.11.1",
-                "target": "regex"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "regex 1.11.1",
                 "target": "regex"
@@ -41304,15 +41120,11 @@
               "lexer",
               "regex"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "lexer",
               "regex"
             ],
             "x86_64-unknown-linux-gnu": [
-              "lexer",
-              "regex"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "lexer",
               "regex"
             ]
@@ -41333,19 +41145,13 @@
                 "target": "regex"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "regex 1.11.1",
                 "target": "regex"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "regex 1.11.1",
-                "target": "regex"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "regex 1.11.1",
                 "target": "regex"
@@ -46392,10 +46198,10 @@
             "aarch64-unknown-linux-gnu": [
               "os-ext"
             ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               "os-ext"
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               "os-ext"
             ]
           }
@@ -48696,10 +48502,6 @@
               "std"
             ],
             "x86_64-unknown-linux-gnu": [
-              "i128",
-              "std"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "i128",
               "std"
             ]
@@ -57189,12 +56991,6 @@
                 "id": "procfs 0.16.0",
                 "target": "procfs"
               }
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              {
-                "id": "procfs 0.16.0",
-                "target": "procfs"
-              }
             ]
           }
         },
@@ -59537,13 +59333,13 @@
                 "target": "libc"
               }
             ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -62395,7 +62191,7 @@
                 "target": "winreg"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "async-compression 0.4.4",
                 "target": "async_compression"
@@ -62426,36 +62222,6 @@
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "async-compression 0.4.4",
-                "target": "async_compression"
-              },
-              {
-                "id": "hyper-rustls 0.24.2",
-                "target": "hyper_rustls"
-              },
-              {
-                "id": "rustls 0.21.12",
-                "target": "rustls"
-              },
-              {
-                "id": "rustls-pemfile 1.0.3",
-                "target": "rustls_pemfile"
-              },
-              {
-                "id": "tokio-rustls 0.24.1",
-                "target": "tokio_rustls"
-              },
-              {
-                "id": "tokio-util 0.7.13",
-                "target": "tokio_util"
-              },
-              {
-                "id": "webpki-roots 0.25.2",
-                "target": "webpki_roots"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "async-compression 0.4.4",
                 "target": "async_compression"
@@ -62793,13 +62559,7 @@
                 "target": "wasm_streams"
               }
             ],
-            "wasm32-wasip1": [
-              {
-                "id": "wasm-streams 0.4.0",
-                "target": "wasm_streams"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "encoding_rs 0.8.33",
                 "target": "encoding_rs"
@@ -62835,6 +62595,10 @@
               {
                 "id": "rustls-pki-types 1.12.0",
                 "target": "rustls_pki_types"
+              },
+              {
+                "id": "system-configuration 0.6.1",
+                "target": "system_configuration"
               },
               {
                 "id": "tokio-rustls 0.26.0",
@@ -62854,60 +62618,6 @@
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "encoding_rs 0.8.33",
-                "target": "encoding_rs"
-              },
-              {
-                "id": "futures-channel 0.3.31",
-                "target": "futures_channel"
-              },
-              {
-                "id": "h2 0.4.4",
-                "target": "h2"
-              },
-              {
-                "id": "hickory-resolver 0.24.4",
-                "target": "hickory_resolver"
-              },
-              {
-                "id": "hyper-rustls 0.27.3",
-                "target": "hyper_rustls"
-              },
-              {
-                "id": "rustls 0.23.27",
-                "target": "rustls"
-              },
-              {
-                "id": "rustls-native-certs 0.8.0",
-                "target": "rustls_native_certs"
-              },
-              {
-                "id": "rustls-pemfile 2.2.0",
-                "target": "rustls_pemfile"
-              },
-              {
-                "id": "rustls-pki-types 1.12.0",
-                "target": "rustls_pki_types"
-              },
-              {
-                "id": "tokio-rustls 0.26.0",
-                "target": "tokio_rustls"
-              },
-              {
-                "id": "tokio-socks 0.5.2",
-                "target": "tokio_socks"
-              },
-              {
-                "id": "tokio-util 0.7.13",
-                "target": "tokio_util"
-              },
-              {
-                "id": "webpki-roots 0.26.8",
-                "target": "webpki_roots"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "encoding_rs 0.8.33",
                 "target": "encoding_rs"
@@ -63294,12 +63004,6 @@
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "once_cell 1.21.3",
-                "target": "once_cell"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "once_cell 1.21.3",
                 "target": "once_cell"
@@ -64866,24 +64570,16 @@
               "time",
               "use-libc-auxv"
             ],
-            "wasm32-wasip1": [
-              "default",
-              "termios",
-              "use-libc-auxv"
-            ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               "default",
               "event",
-              "param",
               "pipe",
               "process",
-              "system",
               "termios",
-              "thread",
               "time",
               "use-libc-auxv"
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               "default",
               "event",
               "param",
@@ -64965,7 +64661,7 @@
                 "target": "libc"
               }
             ],
-            "wasm32-wasip1": [
+            "x86_64-apple-darwin": [
               {
                 "id": "errno 0.3.10",
                 "target": "errno",
@@ -64974,13 +64670,6 @@
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "errno 0.3.10",
-                "target": "errno",
-                "alias": "libc_errno"
               }
             ]
           }
@@ -65112,6 +64801,17 @@
                 "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "errno 0.3.10",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "libc 0.2.170",
+                "target": "libc"
+              }
             ]
           }
         },
@@ -65191,13 +64891,10 @@
             "aarch64-unknown-linux-gnu": [
               "dangerous_configuration"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "dangerous_configuration"
             ],
             "x86_64-unknown-linux-gnu": [
-              "dangerous_configuration"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "dangerous_configuration"
             ]
           }
@@ -73822,17 +73519,12 @@
               "visit",
               "visit-mut"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "extra-traits",
               "visit",
               "visit-mut"
             ],
             "x86_64-unknown-linux-gnu": [
-              "extra-traits",
-              "visit",
-              "visit-mut"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "extra-traits",
               "visit",
               "visit-mut"
@@ -73931,15 +73623,11 @@
               "fold",
               "visit"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "fold",
               "visit"
             ],
             "x86_64-unknown-linux-gnu": [
-              "fold",
-              "visit"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "fold",
               "visit"
             ]
@@ -74737,13 +74425,13 @@
                 "target": "libc"
               }
             ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "xattr 0.2.3",
                 "target": "xattr"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "xattr 0.2.3",
                 "target": "xattr"
@@ -76486,7 +76174,7 @@
                 "target": "num_threads"
               }
             ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -76496,7 +76184,7 @@
                 "target": "num_threads"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -76783,13 +76471,10 @@
             "aarch64-unknown-linux-gnu": [
               "sha3"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "sha3"
             ],
             "x86_64-unknown-linux-gnu": [
-              "sha3"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "sha3"
             ]
           }
@@ -77197,11 +76882,7 @@
             "tokio-macros",
             "tracing"
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              "windows-sys"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -77257,17 +76938,7 @@
                 "target": "backtrace"
               }
             ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "socket2 0.5.7",
-                "target": "socket2"
-              },
-              {
-                "id": "windows-sys 0.52.0",
-                "target": "windows_sys"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -77281,7 +76952,7 @@
                 "target": "socket2"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -80535,14 +80206,7 @@
               "target": "trust_dns_proto"
             }
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "ipconfig 0.3.2",
-                "target": "ipconfig"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2018",
         "version": "0.22.0"
@@ -83152,13 +82816,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "0.11.0+wasi-snapshot-preview1"
       },
@@ -84542,23 +84199,17 @@
                 "target": "rustix"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
-                "id": "windows-sys 0.59.0",
-                "target": "windows_sys"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "memfd 0.6.4",
-                "target": "memfd"
+                "id": "mach2 0.4.2",
+                "target": "mach2"
               },
               {
                 "id": "rustix 1.0.5",
                 "target": "rustix"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "memfd 0.6.4",
                 "target": "memfd"
@@ -85580,10 +85231,20 @@
             "AbortSignal",
             "Blob",
             "BlobPropertyBag",
+            "CanvasRenderingContext2d",
+            "Crypto",
+            "Document",
+            "DomRect",
+            "DomRectReadOnly",
+            "Element",
             "EventTarget",
             "File",
             "FormData",
             "Headers",
+            "HtmlCanvasElement",
+            "HtmlElement",
+            "Node",
+            "Performance",
             "QueuingStrategy",
             "ReadableByteStreamController",
             "ReadableStream",
@@ -85614,20 +85275,7 @@
             "WritableStreamDefaultController",
             "WritableStreamDefaultWriter"
           ],
-          "selects": {
-            "wasm32-unknown-unknown": [
-              "CanvasRenderingContext2d",
-              "Crypto",
-              "Document",
-              "DomRect",
-              "DomRectReadOnly",
-              "Element",
-              "HtmlCanvasElement",
-              "HtmlElement",
-              "Node",
-              "Performance"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -86031,14 +85679,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "version": "1.0.2"
       },
@@ -86128,44 +85768,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "consoleapi",
-            "errhandlingapi",
-            "fibersapi",
-            "fileapi",
-            "handleapi",
-            "impl-default",
-            "knownfolders",
-            "libloaderapi",
-            "memoryapi",
-            "minwinbase",
-            "minwindef",
-            "ntdef",
-            "ntsecapi",
-            "ntstatus",
-            "objbase",
-            "pdh",
-            "processenv",
-            "processthreadsapi",
-            "profileapi",
-            "psapi",
-            "shlobj",
-            "std",
-            "synchapi",
-            "sysinfoapi",
-            "winbase",
-            "wincon",
-            "winerror",
-            "winnt",
-            "winuser",
-            "ws2def",
-            "ws2ipdef",
-            "ws2tcpip",
-            "wtypesbase"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86540,16 +86142,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_System",
-            "Win32_System_SystemInformation",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86602,12 +86194,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86712,13 +86298,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86767,13 +86346,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86826,21 +86398,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_UI",
-            "Win32_UI_Input",
-            "Win32_UI_Input_KeyboardAndMouse",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [],
           "selects": {
@@ -86891,37 +86448,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_NetworkManagement",
-            "Win32_NetworkManagement_IpHelper",
-            "Win32_NetworkManagement_Ndis",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Security_Authentication",
-            "Win32_Security_Authentication_Identity",
-            "Win32_Security_Credentials",
-            "Win32_Security_Cryptography",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_System_Diagnostics",
-            "Win32_System_Diagnostics_Debug",
-            "Win32_System_IO",
-            "Win32_System_Memory",
-            "Win32_System_Registry",
-            "Win32_System_Time",
-            "Win32_System_WindowsProgramming",
-            "Win32_UI",
-            "Win32_UI_Shell",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86970,32 +86496,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Wdk",
-            "Wdk_Foundation",
-            "Wdk_Storage",
-            "Wdk_Storage_FileSystem",
-            "Wdk_System",
-            "Wdk_System_IO",
-            "Win32",
-            "Win32_Foundation",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_System_IO",
-            "Win32_System_Pipes",
-            "Win32_System_SystemServices",
-            "Win32_System_Threading",
-            "Win32_System_WindowsProgramming",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -87044,38 +86544,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Wdk",
-            "Wdk_Foundation",
-            "Wdk_Storage",
-            "Wdk_Storage_FileSystem",
-            "Win32",
-            "Win32_Foundation",
-            "Win32_NetworkManagement",
-            "Win32_NetworkManagement_IpHelper",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Security_Credentials",
-            "Win32_Security_Cryptography",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_System_Diagnostics",
-            "Win32_System_Diagnostics_Debug",
-            "Win32_System_IO",
-            "Win32_System_Kernel",
-            "Win32_System_LibraryLoader",
-            "Win32_System_Memory",
-            "Win32_System_SystemInformation",
-            "Win32_System_Threading",
-            "Win32_System_WindowsProgramming",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -90928,9 +90396,7 @@
       "aarch64-unknown-linux-gnu"
     ],
     "aarch64-uwp-windows-msvc": [],
-    "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
@@ -90938,33 +90404,29 @@
     ],
     "cfg(all(any(target_os = \"linux\", target_os = \"android\"), not(any(getrandom_backend = \"custom\", getrandom_backend = \"rdrand\", getrandom_backend = \"rndr\"))))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(curve25519_dalek_backend = \"fiat\"), not(curve25519_dalek_backend = \"serial\"), target_arch = \"x86_64\"))": [
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-apple-darwin",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1"
+      "x86_64-apple-darwin"
     ],
     "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-apple-darwin",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1"
+      "x86_64-apple-darwin"
     ],
     "cfg(all(target_arch = \"aarch64\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
@@ -90980,9 +90442,7 @@
     "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))": [
       "wasm32-unknown-unknown"
     ],
-    "cfg(all(target_arch = \"wasm32\", target_os = \"wasi\"))": [
-      "wasm32-wasip1"
-    ],
+    "cfg(all(target_arch = \"wasm32\", target_os = \"wasi\"))": [],
     "cfg(all(target_arch = \"wasm32\", target_os = \"wasi\", target_env = \"p2\"))": [],
     "cfg(all(target_arch = \"wasm32\", target_vendor = \"unknown\", target_os = \"unknown\", target_env = \"\"))": [
       "wasm32-unknown-unknown"
@@ -90991,77 +90451,63 @@
     "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"x86\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
-    "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(target_family = \"wasm\", target_os = \"unknown\"))": [
       "wasm32-unknown-unknown"
     ],
     "cfg(all(unix, not(target_arch = \"wasm32\")))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(unix, not(target_os = \"android\"), not(target_vendor = \"apple\"), not(target_arch = \"wasm32\")))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(unix, not(target_os = \"macos\")))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
-    "cfg(all(windows, not(target_vendor = \"win7\")))": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(all(windows, not(target_vendor = \"win7\")))": [],
     "cfg(any())": [],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"arm\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"s390x\", target_arch = \"riscv64\"))": [],
     "cfg(any(target_arch = \"x86\", target_arch = \"x86_64\"))": [
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"x86\", target_arch = \"x86_64\", all(any(target_arch = \"aarch64\", target_arch = \"arm\"), any(target_os = \"android\", target_os = \"fuchsia\", target_os = \"linux\"))))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"x86_64\", target_arch = \"x86\"))": [
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"android\", target_os = \"linux\"))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"hurd\", target_os = \"illumos\", all(target_os = \"horizon\", target_arch = \"arm\")))": [],
     "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"illumos\", target_os = \"netbsd\", target_os = \"openbsd\", target_os = \"solaris\"))": [],
@@ -91069,122 +90515,112 @@
     "cfg(any(target_os = \"ios\", target_os = \"visionos\", target_os = \"watchos\", target_os = \"tvos\"))": [],
     "cfg(any(target_os = \"linux\", target_os = \"android\"))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "wasm32-wasip1",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"linux\", target_vendor = \"apple\", target_os = \"freebsd\", target_os = \"android\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"macos\", target_os = \"ios\"))": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(any(target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\"))": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(any(target_os = \"macos\", target_os = \"openbsd\", target_os = \"vita\", target_os = \"emscripten\"))": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(any(target_vendor = \"apple\"))": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(any(unix, target_os = \"fuchsia\", target_os = \"vxworks\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(unix, target_os = \"redox\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(unix, target_os = \"wasi\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "wasm32-wasip1",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(windows, unix, target_os = \"redox\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(curve25519_dalek_backend = \"fiat\")": [],
     "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(all(windows, target_env = \"msvc\", not(target_vendor = \"uwp\"))))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(any(target_os = \"windows\", target_arch = \"wasm32\")))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "wasm32-wasip1",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(target_arch = \"wasm32\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(target_family = \"wasm\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(windows))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(windows_raw_dylib))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(rustver)": [],
     "cfg(target_arch = \"aarch64\")": [
@@ -91192,18 +90628,14 @@
       "aarch64-unknown-linux-gnu"
     ],
     "cfg(target_arch = \"wasm32\")": [
-      "wasm32-unknown-unknown",
-      "wasm32-wasip1"
+      "wasm32-unknown-unknown"
     ],
     "cfg(target_arch = \"x86\")": [],
     "cfg(target_arch = \"x86_64\")": [
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
-    "cfg(target_env = \"msvc\")": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(target_env = \"msvc\")": [],
     "cfg(target_env = \"sgx\")": [],
     "cfg(target_feature = \"atomics\")": [],
     "cfg(target_os = \"android\")": [],
@@ -91214,32 +90646,26 @@
     "cfg(target_os = \"hermit\")": [],
     "cfg(target_os = \"linux\")": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(target_os = \"macos\")": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(target_os = \"netbsd\")": [],
     "cfg(target_os = \"redox\")": [],
     "cfg(target_os = \"solaris\")": [],
     "cfg(target_os = \"vxworks\")": [],
-    "cfg(target_os = \"wasi\")": [
-      "wasm32-wasip1"
-    ],
-    "cfg(target_os = \"windows\")": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(target_os = \"wasi\")": [],
+    "cfg(target_os = \"windows\")": [],
     "cfg(tokio_taskdump)": [],
     "cfg(unix)": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
-    "cfg(windows)": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(windows)": [],
     "i686-pc-windows-gnu": [],
     "i686-pc-windows-gnullvm": [],
     "i686-pc-windows-msvc": [],
@@ -91248,20 +90674,14 @@
     "wasm32-unknown-unknown": [
       "wasm32-unknown-unknown"
     ],
-    "wasm32-wasip1": [
-      "wasm32-wasip1"
+    "x86_64-apple-darwin": [
+      "x86_64-apple-darwin"
     ],
     "x86_64-pc-windows-gnu": [],
     "x86_64-pc-windows-gnullvm": [],
-    "x86_64-pc-windows-msvc": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "x86_64-pc-windows-msvc": [],
     "x86_64-unknown-linux-gnu": [
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
-    ],
-    "x86_64-unknown-nixos-gnu": [
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "x86_64-uwp-windows-gnu": [],
     "x86_64-uwp-windows-msvc": []

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "50823ddd928fb9a269db76573e1845e609dcfa9c8ab8dab6d91f7482e13ecfc4",
+  "checksum": "a5bfcf1a2c8db7c3c937e33ac0fa0fea5c517236025a4dd07111c80795febbdc",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -1835,13 +1835,10 @@
             "aarch64-unknown-linux-gnu": [
               "default"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "default"
             ],
             "x86_64-unknown-linux-gnu": [
-              "default"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "default"
             ]
           }
@@ -2346,14 +2343,7 @@
               "target": "utf8parse"
             }
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "anstyle-wincon 3.0.1",
-                "target": "anstyle_wincon"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
         "version": "0.6.15"
@@ -12165,13 +12155,10 @@
             "aarch64-unknown-linux-gnu": [
               "parallel"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "parallel"
             ],
             "x86_64-unknown-linux-gnu": [
-              "parallel"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "parallel"
             ]
           }
@@ -12204,13 +12191,7 @@
                 "target": "libc"
               }
             ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "jobserver 0.1.32",
-                "target": "jobserver"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "jobserver 0.1.32",
                 "target": "jobserver"
@@ -12220,7 +12201,7 @@
                 "target": "libc"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "jobserver 0.1.32",
                 "target": "jobserver"
@@ -12407,29 +12388,13 @@
                 "target": "wasm_bindgen"
               }
             ],
-            "wasm32-wasip1": [
-              {
-                "id": "serde-wasm-bindgen 0.5.0",
-                "target": "serde_wasm_bindgen"
-              },
-              {
-                "id": "wasm-bindgen 0.2.100",
-                "target": "wasm_bindgen"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "crossterm 0.27.0",
                 "target": "crossterm"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "crossterm 0.27.0",
-                "target": "crossterm"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "crossterm 0.27.0",
                 "target": "crossterm"
@@ -12878,19 +12843,13 @@
                 "target": "wasm_bindgen"
               }
             ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "windows-targets 0.52.6",
-                "target": "windows_targets"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "iana-time-zone 0.1.59",
                 "target": "iana_time_zone"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "iana-time-zone 0.1.59",
                 "target": "iana_time_zone"
@@ -14502,12 +14461,6 @@
               {
                 "id": "winapi 0.3.9",
                 "target": "winapi"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "winapi-util 0.1.5",
-                "target": "winapi_util"
               }
             ]
           }
@@ -16935,81 +16888,27 @@
               "target": "bitflags"
             },
             {
+              "id": "mio 0.8.10",
+              "target": "mio"
+            },
+            {
               "id": "parking_lot 0.12.1",
               "target": "parking_lot"
+            },
+            {
+              "id": "signal-hook 0.3.17",
+              "target": "signal_hook"
+            },
+            {
+              "id": "signal-hook-mio 0.2.3",
+              "target": "signal_hook_mio"
             }
           ],
           "selects": {
-            "aarch64-apple-darwin": [
-              {
-                "id": "mio 0.8.10",
-                "target": "mio"
-              },
-              {
-                "id": "signal-hook 0.3.17",
-                "target": "signal_hook"
-              },
-              {
-                "id": "signal-hook-mio 0.2.3",
-                "target": "signal_hook_mio"
-              }
-            ],
-            "aarch64-unknown-linux-gnu": [
-              {
-                "id": "mio 0.8.10",
-                "target": "mio"
-              },
-              {
-                "id": "signal-hook 0.3.17",
-                "target": "signal_hook"
-              },
-              {
-                "id": "signal-hook-mio 0.2.3",
-                "target": "signal_hook_mio"
-              }
-            ],
             "cfg(unix)": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "crossterm_winapi 0.9.1",
-                "target": "crossterm_winapi"
-              },
-              {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "mio 0.8.10",
-                "target": "mio"
-              },
-              {
-                "id": "signal-hook 0.3.17",
-                "target": "signal_hook"
-              },
-              {
-                "id": "signal-hook-mio 0.2.3",
-                "target": "signal_hook_mio"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              {
-                "id": "mio 0.8.10",
-                "target": "mio"
-              },
-              {
-                "id": "signal-hook 0.3.17",
-                "target": "signal_hook"
-              },
-              {
-                "id": "signal-hook-mio 0.2.3",
-                "target": "signal_hook_mio"
               }
             ]
           }
@@ -22964,13 +22863,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "edition": "2015",
         "version": "0.3.6"
       },
@@ -24565,19 +24457,13 @@
                 "target": "parking"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "parking 2.1.0",
                 "target": "parking"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "parking 2.1.0",
-                "target": "parking"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "parking 2.1.0",
                 "target": "parking"
@@ -24656,19 +24542,13 @@
                 "target": "parking"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "parking 2.1.0",
                 "target": "parking"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "parking 2.1.0",
-                "target": "parking"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "parking 2.1.0",
                 "target": "parking"
@@ -30021,14 +29901,7 @@
               "target": "tracing"
             }
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "ipconfig 0.3.2",
-                "target": "ipconfig"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
         "version": "0.24.4"
@@ -30147,14 +30020,7 @@
               "target": "webpki_roots"
             }
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "ipconfig 0.3.2",
-                "target": "ipconfig"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2021",
         "version": "0.25.2"
@@ -31640,15 +31506,11 @@
               "webpki-roots",
               "webpki-tokio"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "webpki-roots",
               "webpki-tokio"
             ],
             "x86_64-unknown-linux-gnu": [
-              "webpki-roots",
-              "webpki-tokio"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "webpki-roots",
               "webpki-tokio"
             ]
@@ -31715,19 +31577,13 @@
                 "target": "webpki_roots"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "webpki-roots 0.26.8",
                 "target": "webpki_roots"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "webpki-roots 0.26.8",
-                "target": "webpki_roots"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "webpki-roots 0.26.8",
                 "target": "webpki_roots"
@@ -38404,23 +38260,11 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "computer",
-            "default",
-            "winreg"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
               "id": "ipconfig 0.3.2",
               "target": "build_script_build"
-            },
-            {
-              "id": "winreg 0.50.0",
-              "target": "winreg"
             }
           ],
           "selects": {
@@ -38984,15 +38828,11 @@
               "default",
               "use_std"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "default",
               "use_std"
             ],
             "x86_64-unknown-linux-gnu": [
-              "default",
-              "use_std"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "default",
               "use_std"
             ]
@@ -40102,27 +39942,13 @@
                 "target": "linux_keyutils"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
-                "id": "byteorder 1.5.0",
-                "target": "byteorder"
-              },
-              {
-                "id": "windows-sys 0.59.0",
-                "target": "windows_sys"
+                "id": "security-framework 3.0.1",
+                "target": "security_framework"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "dbus-secret-service 4.0.3",
-                "target": "dbus_secret_service"
-              },
-              {
-                "id": "linux-keyutils 0.2.4",
-                "target": "linux_keyutils"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "dbus-secret-service 4.0.3",
                 "target": "dbus_secret_service"
@@ -41027,15 +40853,11 @@
               "lexer",
               "regex"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "lexer",
               "regex"
             ],
             "x86_64-unknown-linux-gnu": [
-              "lexer",
-              "regex"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "lexer",
               "regex"
             ]
@@ -41056,19 +40878,13 @@
                 "target": "regex"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "regex 1.11.1",
                 "target": "regex"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "regex 1.11.1",
-                "target": "regex"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "regex 1.11.1",
                 "target": "regex"
@@ -41129,15 +40945,11 @@
               "lexer",
               "regex"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "lexer",
               "regex"
             ],
             "x86_64-unknown-linux-gnu": [
-              "lexer",
-              "regex"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "lexer",
               "regex"
             ]
@@ -41158,19 +40970,13 @@
                 "target": "regex"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "regex 1.11.1",
                 "target": "regex"
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "regex 1.11.1",
-                "target": "regex"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "regex 1.11.1",
                 "target": "regex"
@@ -46223,10 +46029,10 @@
             "aarch64-unknown-linux-gnu": [
               "os-ext"
             ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               "os-ext"
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               "os-ext"
             ]
           }
@@ -48527,10 +48333,6 @@
               "std"
             ],
             "x86_64-unknown-linux-gnu": [
-              "i128",
-              "std"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "i128",
               "std"
             ]
@@ -57015,12 +56817,6 @@
                 "id": "procfs 0.16.0",
                 "target": "procfs"
               }
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              {
-                "id": "procfs 0.16.0",
-                "target": "procfs"
-              }
             ]
           }
         },
@@ -59363,13 +59159,13 @@
                 "target": "libc"
               }
             ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -62265,7 +62061,7 @@
                 "target": "winreg"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "async-compression 0.4.3",
                 "target": "async_compression"
@@ -62296,36 +62092,6 @@
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "async-compression 0.4.3",
-                "target": "async_compression"
-              },
-              {
-                "id": "hyper-rustls 0.24.2",
-                "target": "hyper_rustls"
-              },
-              {
-                "id": "rustls 0.21.12",
-                "target": "rustls"
-              },
-              {
-                "id": "rustls-pemfile 1.0.3",
-                "target": "rustls_pemfile"
-              },
-              {
-                "id": "tokio-rustls 0.24.1",
-                "target": "tokio_rustls"
-              },
-              {
-                "id": "tokio-util 0.7.13",
-                "target": "tokio_util"
-              },
-              {
-                "id": "webpki-roots 0.25.2",
-                "target": "webpki_roots"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "async-compression 0.4.3",
                 "target": "async_compression"
@@ -62663,13 +62429,7 @@
                 "target": "wasm_streams"
               }
             ],
-            "wasm32-wasip1": [
-              {
-                "id": "wasm-streams 0.4.0",
-                "target": "wasm_streams"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
                 "id": "encoding_rs 0.8.32",
                 "target": "encoding_rs"
@@ -62705,6 +62465,10 @@
               {
                 "id": "rustls-pki-types 1.12.0",
                 "target": "rustls_pki_types"
+              },
+              {
+                "id": "system-configuration 0.6.1",
+                "target": "system_configuration"
               },
               {
                 "id": "tokio-rustls 0.26.0",
@@ -62724,60 +62488,6 @@
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "encoding_rs 0.8.32",
-                "target": "encoding_rs"
-              },
-              {
-                "id": "futures-channel 0.3.31",
-                "target": "futures_channel"
-              },
-              {
-                "id": "h2 0.4.4",
-                "target": "h2"
-              },
-              {
-                "id": "hickory-resolver 0.24.4",
-                "target": "hickory_resolver"
-              },
-              {
-                "id": "hyper-rustls 0.27.3",
-                "target": "hyper_rustls"
-              },
-              {
-                "id": "rustls 0.23.27",
-                "target": "rustls"
-              },
-              {
-                "id": "rustls-native-certs 0.8.0",
-                "target": "rustls_native_certs"
-              },
-              {
-                "id": "rustls-pemfile 2.2.0",
-                "target": "rustls_pemfile"
-              },
-              {
-                "id": "rustls-pki-types 1.12.0",
-                "target": "rustls_pki_types"
-              },
-              {
-                "id": "tokio-rustls 0.26.0",
-                "target": "tokio_rustls"
-              },
-              {
-                "id": "tokio-socks 0.5.2",
-                "target": "tokio_socks"
-              },
-              {
-                "id": "tokio-util 0.7.13",
-                "target": "tokio_util"
-              },
-              {
-                "id": "webpki-roots 0.26.8",
-                "target": "webpki_roots"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "encoding_rs 0.8.32",
                 "target": "encoding_rs"
@@ -63164,12 +62874,6 @@
               }
             ],
             "x86_64-unknown-linux-gnu": [
-              {
-                "id": "once_cell 1.21.3",
-                "target": "once_cell"
-              }
-            ],
-            "x86_64-unknown-nixos-gnu": [
               {
                 "id": "once_cell 1.21.3",
                 "target": "once_cell"
@@ -64736,24 +64440,16 @@
               "time",
               "use-libc-auxv"
             ],
-            "wasm32-wasip1": [
-              "default",
-              "termios",
-              "use-libc-auxv"
-            ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               "default",
               "event",
-              "param",
               "pipe",
               "process",
-              "system",
               "termios",
-              "thread",
               "time",
               "use-libc-auxv"
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               "default",
               "event",
               "param",
@@ -64835,7 +64531,7 @@
                 "target": "libc"
               }
             ],
-            "wasm32-wasip1": [
+            "x86_64-apple-darwin": [
               {
                 "id": "errno 0.3.10",
                 "target": "errno",
@@ -64844,13 +64540,6 @@
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
-              }
-            ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "errno 0.3.10",
-                "target": "errno",
-                "alias": "libc_errno"
               }
             ]
           }
@@ -64982,6 +64671,17 @@
                 "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
+            ],
+            "x86_64-apple-darwin": [
+              {
+                "id": "errno 0.3.10",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "libc 0.2.170",
+                "target": "libc"
+              }
             ]
           }
         },
@@ -65061,13 +64761,10 @@
             "aarch64-unknown-linux-gnu": [
               "dangerous_configuration"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "dangerous_configuration"
             ],
             "x86_64-unknown-linux-gnu": [
-              "dangerous_configuration"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "dangerous_configuration"
             ]
           }
@@ -73692,17 +73389,12 @@
               "visit",
               "visit-mut"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "extra-traits",
               "visit",
               "visit-mut"
             ],
             "x86_64-unknown-linux-gnu": [
-              "extra-traits",
-              "visit",
-              "visit-mut"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "extra-traits",
               "visit",
               "visit-mut"
@@ -73801,15 +73493,11 @@
               "fold",
               "visit"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "fold",
               "visit"
             ],
             "x86_64-unknown-linux-gnu": [
-              "fold",
-              "visit"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "fold",
               "visit"
             ]
@@ -74607,13 +74295,13 @@
                 "target": "libc"
               }
             ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "xattr 0.2.3",
                 "target": "xattr"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "xattr 0.2.3",
                 "target": "xattr"
@@ -76356,7 +76044,7 @@
                 "target": "num_threads"
               }
             ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -76366,7 +76054,7 @@
                 "target": "num_threads"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -76653,13 +76341,10 @@
             "aarch64-unknown-linux-gnu": [
               "sha3"
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               "sha3"
             ],
             "x86_64-unknown-linux-gnu": [
-              "sha3"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "sha3"
             ]
           }
@@ -77067,11 +76752,7 @@
             "tokio-macros",
             "tracing"
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              "windows-sys"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -77127,17 +76808,7 @@
                 "target": "backtrace"
               }
             ],
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "socket2 0.5.7",
-                "target": "socket2"
-              },
-              {
-                "id": "windows-sys 0.52.0",
-                "target": "windows_sys"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
+            "x86_64-apple-darwin": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -77151,7 +76822,7 @@
                 "target": "socket2"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "libc 0.2.170",
                 "target": "libc"
@@ -80405,14 +80076,7 @@
               "target": "trust_dns_proto"
             }
           ],
-          "selects": {
-            "x86_64-pc-windows-msvc": [
-              {
-                "id": "ipconfig 0.3.2",
-                "target": "ipconfig"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2018",
         "version": "0.22.0"
@@ -83022,13 +82686,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "0.11.0+wasi-snapshot-preview1"
       },
@@ -84412,23 +84069,17 @@
                 "target": "rustix"
               }
             ],
-            "x86_64-pc-windows-msvc": [
+            "x86_64-apple-darwin": [
               {
-                "id": "windows-sys 0.59.0",
-                "target": "windows_sys"
-              }
-            ],
-            "x86_64-unknown-linux-gnu": [
-              {
-                "id": "memfd 0.6.4",
-                "target": "memfd"
+                "id": "mach2 0.4.2",
+                "target": "mach2"
               },
               {
                 "id": "rustix 1.0.5",
                 "target": "rustix"
               }
             ],
-            "x86_64-unknown-nixos-gnu": [
+            "x86_64-unknown-linux-gnu": [
               {
                 "id": "memfd 0.6.4",
                 "target": "memfd"
@@ -85427,10 +85078,20 @@
             "AbortSignal",
             "Blob",
             "BlobPropertyBag",
+            "CanvasRenderingContext2d",
+            "Crypto",
+            "Document",
+            "DomRect",
+            "DomRectReadOnly",
+            "Element",
             "EventTarget",
             "File",
             "FormData",
             "Headers",
+            "HtmlCanvasElement",
+            "HtmlElement",
+            "Node",
+            "Performance",
             "QueuingStrategy",
             "ReadableByteStreamController",
             "ReadableStream",
@@ -85461,20 +85122,7 @@
             "WritableStreamDefaultController",
             "WritableStreamDefaultWriter"
           ],
-          "selects": {
-            "wasm32-unknown-unknown": [
-              "CanvasRenderingContext2d",
-              "Crypto",
-              "Document",
-              "DomRect",
-              "DomRectReadOnly",
-              "Element",
-              "HtmlCanvasElement",
-              "HtmlElement",
-              "Node",
-              "Performance"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -85872,14 +85520,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "version": "1.0.2"
       },
@@ -85969,44 +85609,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "consoleapi",
-            "errhandlingapi",
-            "fibersapi",
-            "fileapi",
-            "handleapi",
-            "impl-default",
-            "knownfolders",
-            "libloaderapi",
-            "memoryapi",
-            "minwinbase",
-            "minwindef",
-            "ntdef",
-            "ntsecapi",
-            "ntstatus",
-            "objbase",
-            "pdh",
-            "processenv",
-            "processthreadsapi",
-            "profileapi",
-            "psapi",
-            "shlobj",
-            "std",
-            "synchapi",
-            "sysinfoapi",
-            "winbase",
-            "wincon",
-            "winerror",
-            "winnt",
-            "winuser",
-            "ws2def",
-            "ws2ipdef",
-            "ws2tcpip",
-            "wtypesbase"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86381,16 +85983,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_System",
-            "Win32_System_SystemInformation",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86443,12 +86035,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86553,13 +86139,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86608,13 +86187,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86667,21 +86239,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_UI",
-            "Win32_UI_Input",
-            "Win32_UI_Input_KeyboardAndMouse",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [],
           "selects": {
@@ -86732,35 +86289,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_NetworkManagement",
-            "Win32_NetworkManagement_IpHelper",
-            "Win32_NetworkManagement_Ndis",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Security_Authentication",
-            "Win32_Security_Authentication_Identity",
-            "Win32_Security_Credentials",
-            "Win32_Security_Cryptography",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_System_Diagnostics",
-            "Win32_System_Diagnostics_Debug",
-            "Win32_System_IO",
-            "Win32_System_Memory",
-            "Win32_System_Registry",
-            "Win32_System_Time",
-            "Win32_System_WindowsProgramming",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86809,35 +86337,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Wdk",
-            "Wdk_Foundation",
-            "Wdk_Storage",
-            "Wdk_Storage_FileSystem",
-            "Wdk_System",
-            "Wdk_System_IO",
-            "Win32",
-            "Win32_Foundation",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Com",
-            "Win32_System_Console",
-            "Win32_System_IO",
-            "Win32_System_Pipes",
-            "Win32_System_SystemServices",
-            "Win32_System_Threading",
-            "Win32_System_WindowsProgramming",
-            "Win32_UI",
-            "Win32_UI_Shell",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -86886,38 +86385,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Wdk",
-            "Wdk_Foundation",
-            "Wdk_Storage",
-            "Wdk_Storage_FileSystem",
-            "Win32",
-            "Win32_Foundation",
-            "Win32_NetworkManagement",
-            "Win32_NetworkManagement_IpHelper",
-            "Win32_Networking",
-            "Win32_Networking_WinSock",
-            "Win32_Security",
-            "Win32_Security_Credentials",
-            "Win32_Security_Cryptography",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_System_Diagnostics",
-            "Win32_System_Diagnostics_Debug",
-            "Win32_System_IO",
-            "Win32_System_Kernel",
-            "Win32_System_LibraryLoader",
-            "Win32_System_Memory",
-            "Win32_System_SystemInformation",
-            "Win32_System_Threading",
-            "Win32_System_WindowsProgramming",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -90911,9 +90378,7 @@
       "aarch64-unknown-linux-gnu"
     ],
     "aarch64-uwp-windows-msvc": [],
-    "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [],
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
@@ -90921,33 +90386,29 @@
     ],
     "cfg(all(any(target_os = \"linux\", target_os = \"android\"), not(any(getrandom_backend = \"custom\", getrandom_backend = \"rdrand\", getrandom_backend = \"rndr\"))))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(curve25519_dalek_backend = \"fiat\"), not(curve25519_dalek_backend = \"serial\"), target_arch = \"x86_64\"))": [
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-apple-darwin",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1"
+      "x86_64-apple-darwin"
     ],
     "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-apple-darwin",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1"
+      "x86_64-apple-darwin"
     ],
     "cfg(all(target_arch = \"aarch64\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
@@ -90963,9 +90424,7 @@
     "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))": [
       "wasm32-unknown-unknown"
     ],
-    "cfg(all(target_arch = \"wasm32\", target_os = \"wasi\"))": [
-      "wasm32-wasip1"
-    ],
+    "cfg(all(target_arch = \"wasm32\", target_os = \"wasi\"))": [],
     "cfg(all(target_arch = \"wasm32\", target_os = \"wasi\", target_env = \"p2\"))": [],
     "cfg(all(target_arch = \"wasm32\", target_vendor = \"unknown\", target_os = \"unknown\", target_env = \"\"))": [
       "wasm32-unknown-unknown"
@@ -90974,72 +90433,59 @@
     "cfg(all(target_arch = \"x86\", target_env = \"gnu\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"x86\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
-    "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(target_family = \"wasm\", target_os = \"unknown\"))": [
       "wasm32-unknown-unknown"
     ],
     "cfg(all(unix, not(target_arch = \"wasm32\")))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(unix, not(target_os = \"android\"), not(target_vendor = \"apple\"), not(target_arch = \"wasm32\")))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(unix, not(target_os = \"macos\")))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
-    "cfg(all(windows, not(target_vendor = \"win7\")))": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(all(windows, not(target_vendor = \"win7\")))": [],
     "cfg(any())": [],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"arm\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"s390x\", target_arch = \"riscv64\"))": [],
     "cfg(any(target_arch = \"x86\", target_arch = \"x86_64\", all(any(target_arch = \"aarch64\", target_arch = \"arm\"), any(target_os = \"android\", target_os = \"fuchsia\", target_os = \"linux\"))))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"x86_64\", target_arch = \"x86\"))": [
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"android\", target_os = \"linux\"))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"hurd\", target_os = \"illumos\", all(target_os = \"horizon\", target_arch = \"arm\")))": [],
     "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"illumos\", target_os = \"netbsd\", target_os = \"openbsd\", target_os = \"solaris\"))": [],
@@ -91047,107 +90493,99 @@
     "cfg(any(target_os = \"ios\", target_os = \"visionos\", target_os = \"watchos\", target_os = \"tvos\"))": [],
     "cfg(any(target_os = \"linux\", target_os = \"android\"))": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "wasm32-wasip1",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"linux\", target_vendor = \"apple\", target_os = \"freebsd\", target_os = \"android\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_os = \"macos\", target_os = \"ios\"))": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(any(target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\"))": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(any(target_os = \"macos\", target_os = \"openbsd\", target_os = \"vita\", target_os = \"emscripten\"))": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(any(target_vendor = \"apple\"))": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(any(unix, target_os = \"fuchsia\", target_os = \"vxworks\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(unix, target_os = \"redox\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(unix, target_os = \"wasi\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "wasm32-wasip1",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(curve25519_dalek_backend = \"fiat\")": [],
     "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(any(target_os = \"windows\", target_arch = \"wasm32\")))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "wasm32-wasip1",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(target_arch = \"wasm32\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(target_family = \"wasm\"))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(windows))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(windows_raw_dylib))": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "wasm32-unknown-unknown",
-      "wasm32-wasip1",
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(rustver)": [],
     "cfg(target_arch = \"aarch64\")": [
@@ -91155,18 +90593,14 @@
       "aarch64-unknown-linux-gnu"
     ],
     "cfg(target_arch = \"wasm32\")": [
-      "wasm32-unknown-unknown",
-      "wasm32-wasip1"
+      "wasm32-unknown-unknown"
     ],
     "cfg(target_arch = \"x86\")": [],
     "cfg(target_arch = \"x86_64\")": [
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
-    "cfg(target_env = \"msvc\")": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(target_env = \"msvc\")": [],
     "cfg(target_env = \"sgx\")": [],
     "cfg(target_feature = \"atomics\")": [],
     "cfg(target_os = \"android\")": [],
@@ -91177,32 +90611,26 @@
     "cfg(target_os = \"hermit\")": [],
     "cfg(target_os = \"linux\")": [
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(target_os = \"macos\")": [
-      "aarch64-apple-darwin"
+      "aarch64-apple-darwin",
+      "x86_64-apple-darwin"
     ],
     "cfg(target_os = \"netbsd\")": [],
     "cfg(target_os = \"redox\")": [],
     "cfg(target_os = \"solaris\")": [],
     "cfg(target_os = \"vxworks\")": [],
-    "cfg(target_os = \"wasi\")": [
-      "wasm32-wasip1"
-    ],
-    "cfg(target_os = \"windows\")": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(target_os = \"wasi\")": [],
+    "cfg(target_os = \"windows\")": [],
     "cfg(tokio_taskdump)": [],
     "cfg(unix)": [
       "aarch64-apple-darwin",
       "aarch64-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-gnu"
     ],
-    "cfg(windows)": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "cfg(windows)": [],
     "i686-pc-windows-gnu": [],
     "i686-pc-windows-gnullvm": [],
     "i686-pc-windows-msvc": [],
@@ -91211,20 +90639,14 @@
     "wasm32-unknown-unknown": [
       "wasm32-unknown-unknown"
     ],
-    "wasm32-wasip1": [
-      "wasm32-wasip1"
+    "x86_64-apple-darwin": [
+      "x86_64-apple-darwin"
     ],
     "x86_64-pc-windows-gnu": [],
     "x86_64-pc-windows-gnullvm": [],
-    "x86_64-pc-windows-msvc": [
-      "x86_64-pc-windows-msvc"
-    ],
+    "x86_64-pc-windows-msvc": [],
     "x86_64-unknown-linux-gnu": [
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
-    ],
-    "x86_64-unknown-nixos-gnu": [
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "x86_64-uwp-windows-gnu": [],
     "x86_64-uwp-windows-msvc": []

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1560,4 +1560,12 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
         splicing_config = splicing_config(
             resolver_version = "2",
         ),
+        supported_platform_triples =
+            [
+                "aarch64-apple-darwin",
+                "aarch64-unknown-linux-gnu",
+                "wasm32-unknown-unknown",
+                "x86_64-apple-darwin",
+                "x86_64-unknown-linux-gnu",
+            ],
     )


### PR DESCRIPTION
This lists x86-darwin as a platform supported by rules_rust. This seems to have been removed [upstream](https://github.com/bazelbuild/rules_rust/pull/3239).