### PR TITLE
fix: properly log the time-out in NNS delegation manager

### DIFF
--- a/rs/http_endpoints/public/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/public/src/nns_delegation_manager.rs
@@ -297,7 +297,7 @@ async fn try_fetch_delegation_from_nns(
     )
     .await
     .map_err(|_| {
-        String::from("Timed out while connecting to the nns node after {CONNECTION_TIMEOUT:?}")
+        format!("Timed out while connecting to the nns node after {CONNECTION_TIMEOUT:?}")
     })??;
 
     // any effective canister id can be used when invoking read_state here
@@ -320,7 +320,7 @@ async fn try_fetch_delegation_from_nns(
     )
     .await
     .map_err(|_| {
-        String::from(
+        format!(
             "Timed out while sending request to the nns \
             node after {NNS_DELEGATION_REQUEST_SEND_TIMEOUT:?}",
         )
@@ -344,7 +344,7 @@ async fn try_fetch_delegation_from_nns(
             )
             .into())
         }
-        Ok(Err(e)) => return Err(format!("Failed to read body from connection: {}", e).into()),
+        Ok(Err(err)) => return Err(format!("Failed to read body from connection: {err}").into()),
         Err(_) => {
             return Err(format!(
                 "Timed out while receiving http body after {NNS_DELEGATION_BODY_RECEIVE_TIMEOUT:?}"

--- a/rs/http_endpoints/public/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/public/src/nns_delegation_manager.rs
@@ -344,7 +344,7 @@ async fn try_fetch_delegation_from_nns(
             )
             .into())
         }
-        Ok(Err(err)) => return Err(format!("Failed to read body from connection: {err}").into()),
+        Ok(Err(e)) => return Err(format!("Failed to read body from connection: {}", e).into()),
         Err(_) => {
             return Err(format!(
                 "Timed out while receiving http body after {NNS_DELEGATION_BODY_RECEIVE_TIMEOUT:?}"


### PR DESCRIPTION
I've checked the logs on the test net and realized the log messages are bugged:

```
Fetching delegation from nns subnet failed. Retrying again in 14 seconds...
Error received: Timed out while connecting to the nns node after {CONNECTION_TIMEOUT:?}
```