### PR TITLE
refactor(nns): Make ExchangeRate proposals obsolete

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -87,10 +87,7 @@ use ic_nervous_system_common::{
 };
 use ic_nervous_system_governance::maturity_modulation::apply_maturity_modulation;
 use ic_nervous_system_proto::pb::v1::{GlobalTimeOfDay, Principals};
-use ic_nns_common::{
-    pb::v1::{NeuronId, ProposalId},
-    types::UpdateIcpXdrConversionRatePayload,
-};
+use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
     CYCLES_MINTING_CANISTER_ID, GENESIS_TOKEN_CANISTER_ID, GOVERNANCE_CANISTER_ID,
     LIFELINE_CANISTER_ID, NODE_REWARDS_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID,
@@ -460,6 +457,11 @@ impl NnsFunction {
                 "NNS_FUNCTION_UPDATE_ALLOWED_PRINCIPALS is only used for the old SNS \
                 initialization mechanism, which is now obsolete. Use \
                 CREATE_SERVICE_NERVOUS_SYSTEM instead."
+                    .to_string(),
+            ),
+            NnsFunction::IcpXdrConversionRate => Err(
+                "NNS_FUNCTION_ICP_XDR_CONVERSION_RATE is obsolete as conversion rates \
+                are now provided by the exchange rate canister automatically."
                     .to_string(),
             ),
             _ => Ok(()),
@@ -5036,17 +5038,6 @@ impl Governance {
                 self.validate_subnet_rental_proposal(&update.payload)
                     .map_err(invalid_proposal_error)?;
             }
-            NnsFunction::IcpXdrConversionRate => {
-                Self::validate_icp_xdr_conversion_rate_payload(
-                    &update.payload,
-                    self.heap_data
-                        .economics
-                        .as_ref()
-                        .ok_or_else(|| GovernanceError::new(ErrorType::Unavailable))?
-                        .minimum_icp_xdr_rate,
-                )
-                .map_err(invalid_proposal_error)?;
-            }
             NnsFunction::AssignNoid => {
                 Self::validate_assign_noid_payload(&update.payload, &self.heap_data.node_providers)
                     .map_err(invalid_proposal_error)?;
@@ -5080,31 +5071,6 @@ impl Governance {
                 "There is another open SubnetRentalRequest proposal: {:?}",
                 other_proposal_ids,
             ));
-        }
-
-        Ok(())
-    }
-
-    fn validate_icp_xdr_conversion_rate_payload(
-        payload: &[u8],
-        minimum_icp_xdr_rate: u64,
-    ) -> Result<(), String> {
-        let decoded_payload = match Decode!([decoder_config()]; payload, UpdateIcpXdrConversionRatePayload)
-        {
-            Ok(payload) => payload,
-            Err(e) => {
-                return Err(format!(
-                    "The payload could not be decoded into a UpdateIcpXdrConversionRatePayload: {}",
-                    e
-                ));
-            }
-        };
-
-        if decoded_payload.xdr_permyriad_per_icp < minimum_icp_xdr_rate {
-            return Err(format!(
-                "The proposed rate {} is below the minimum allowable rate",
-                decoded_payload.xdr_permyriad_per_icp
-            ))?;
         }
 
         Ok(())

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1290,20 +1290,9 @@ fn test_validate_execute_nns_function() {
                 nns_function: NnsFunction::IcpXdrConversionRate as i32,
                 payload: vec![],
             },
-            "The payload could not be decoded into a UpdateIcpXdrConversionRatePayload: \
-             Cannot parse header "
+            "Proposal is obsolete because NNS_FUNCTION_ICP_XDR_CONVERSION_RATE is obsolete as \
+            conversion rates are now provided by the exchange rate canister automatically."
                 .to_string(),
-        ),
-        (
-            ExecuteNnsFunction {
-                nns_function: NnsFunction::IcpXdrConversionRate as i32,
-                payload: Encode!(&UpdateIcpXdrConversionRatePayload {
-                    xdr_permyriad_per_icp: 0,
-                    ..Default::default()
-                })
-                .unwrap(),
-            },
-            "The proposed rate 0 is below the minimum allowable rate".to_string(),
         ),
         (
             ExecuteNnsFunction {
@@ -1427,14 +1416,6 @@ fn test_validate_execute_nns_function() {
         ExecuteNnsFunction {
             nns_function: NnsFunction::CreateSubnet as i32,
             payload: vec![1u8; PROPOSAL_EXECUTE_NNS_FUNCTION_PAYLOAD_BYTES_MAX],
-        },
-        ExecuteNnsFunction {
-            nns_function: NnsFunction::IcpXdrConversionRate as i32,
-            payload: Encode!(&UpdateIcpXdrConversionRatePayload {
-                xdr_permyriad_per_icp: 101,
-                ..Default::default()
-            })
-            .unwrap(),
         },
         ExecuteNnsFunction {
             nns_function: NnsFunction::AssignNoid as i32,

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -8,10 +8,7 @@ use ic_nervous_system_canisters::cmc::CMC;
 use ic_nervous_system_canisters::ledger::IcpLedger;
 use ic_nervous_system_common::NervousSystemError;
 use ic_nervous_system_timers::test::{advance_time_for_timers, set_time_for_timers};
-use ic_nns_common::{
-    pb::v1::{NeuronId, ProposalId},
-    types::UpdateIcpXdrConversionRatePayload,
-};
+use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
     CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID,
     NODE_REWARDS_CANISTER_ID, SNS_WASM_CANISTER_ID,
@@ -20,7 +17,7 @@ use ic_nns_governance::{
     governance::{Environment, Governance, HeapGrowthPotential, RngError},
     pb::v1::{
         manage_neuron, manage_neuron::NeuronIdOrSubaccount, proposal, ExecuteNnsFunction,
-        GovernanceError, ManageNeuron, Motion, NetworkEconomics, NnsFunction, Proposal, Vote,
+        GovernanceError, ManageNeuron, Motion, NetworkEconomics, Proposal, Vote,
     },
 };
 use ic_nns_governance_api::Neuron;
@@ -685,7 +682,6 @@ pub fn register_vote_assert_success(
 pub enum ProposalTopicBehavior {
     Governance,
     NetworkEconomics,
-    ExchangeRate,
 }
 
 /// A struct to help setting up tests concisely thanks to a concise format to
@@ -715,18 +711,6 @@ impl ProposalNeuronBehavior {
             ProposalTopicBehavior::NetworkEconomics => {
                 proposal::Action::ManageNetworkEconomics(NetworkEconomics {
                     ..Default::default()
-                })
-            }
-            ProposalTopicBehavior::ExchangeRate => {
-                proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                    nns_function: NnsFunction::IcpXdrConversionRate as i32,
-                    payload: Encode!(&UpdateIcpXdrConversionRatePayload {
-                        xdr_permyriad_per_icp: 1000000,
-                        data_source: "".to_string(),
-                        timestamp_seconds: 0,
-                        reason: None,
-                    })
-                    .unwrap(),
                 })
             }
         };
@@ -774,11 +758,11 @@ impl From<&str> for ProposalNeuronBehavior {
     /// 'NetworkEconomics', or 'IcpXdrConversionRate'.
     ///
     /// Example:
-    /// "--yP-nyE" means:
+    /// "--yP-nyG" means:
     ///
     /// neuron 3 proposes, neurons 2 and 6 votes yes, neuron 5 votes
     /// no, neurons 0, 1, and 4 do not vote; the proposal topic is
-    /// ExchangeRate.
+    /// Governance.
     fn from(str: &str) -> ProposalNeuronBehavior {
         // Look at the last letter to figure out if it specifies a proposal type.
         let chr = if str.is_empty() {
@@ -786,14 +770,13 @@ impl From<&str> for ProposalNeuronBehavior {
         } else {
             str.chars().last().unwrap()
         };
-        let (str, proposal_topic) = match "NEG".find(chr) {
+        let (str, proposal_topic) = match "NG".find(chr) {
             None => (str, ProposalTopicBehavior::NetworkEconomics),
             Some(x) => (
                 &str[0..str.len() - 1],
                 match x {
                     0 => ProposalTopicBehavior::NetworkEconomics,
-                    1 => ProposalTopicBehavior::ExchangeRate,
-                    // Must be 2, but using _ for a complete match.
+                    // Must be 1, but using _ for a complete match.
                     _ => ProposalTopicBehavior::Governance,
                 },
             ),

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -33,10 +33,7 @@ use ic_nervous_system_timers::test::{
 use ic_neurons_fund::{
     NeuronsFundParticipationLimits, PolynomialMatchingFunction, SerializableFunction,
 };
-use ic_nns_common::{
-    pb::v1::{NeuronId, ProposalId},
-    types::UpdateIcpXdrConversionRatePayload,
-};
+use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
     GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID as ICP_LEDGER_CANISTER_ID, SNS_WASM_CANISTER_ID,
 };
@@ -737,75 +734,6 @@ async fn test_cascade_following() {
             .expect("Neuron not found"),
         0
     );
-}
-
-/// In this scenario, we simply test that you cannot make a proposal
-/// to set the conversion rate below the minimum allowable rate.
-#[tokio::test]
-async fn test_minimum_icp_xdr_conversion_rate() {
-    let driver = fake::FakeDriver::default();
-    let mut gov = Governance::new(
-        fixture_for_following(),
-        driver.get_fake_env(),
-        driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
-        driver.get_fake_randomness_generator(),
-    );
-    // Set minimum conversion rate.
-    gov.heap_data
-        .economics
-        .as_mut()
-        .unwrap()
-        .minimum_icp_xdr_rate = 100_000;
-    // This should fail.
-    assert_eq!(
-        ErrorType::InvalidProposal as i32,
-        gov.make_proposal(
-            &NeuronId { id: 1 },
-            // Must match neuron 1's serialized_id.
-            &PrincipalId::try_from(b"SID1".to_vec()).unwrap(),
-            &Proposal {
-                summary: "test".to_string(),
-                action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                    nns_function: NnsFunction::IcpXdrConversionRate as i32,
-                    payload: Encode!(&UpdateIcpXdrConversionRatePayload {
-                        xdr_permyriad_per_icp: 0,
-                        data_source: "".to_string(),
-                        timestamp_seconds: 0,
-                        reason: None,
-                    })
-                    .unwrap(),
-                })),
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap_err()
-        .error_type
-    );
-    // This should succeed
-    gov.make_proposal(
-        &NeuronId { id: 1 },
-        // Must match neuron 1's serialized_id.
-        &PrincipalId::try_from(b"SID1".to_vec()).unwrap(),
-        &Proposal {
-            title: Some("A Reasonable Title".to_string()),
-            summary: "test".to_string(),
-            action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                nns_function: NnsFunction::IcpXdrConversionRate as i32,
-                payload: Encode!(&UpdateIcpXdrConversionRatePayload {
-                    xdr_permyriad_per_icp: 100_000_000,
-                    data_source: "".to_string(),
-                    timestamp_seconds: 0,
-                    reason: None,
-                })
-                .unwrap(),
-            })),
-            ..Default::default()
-        },
-    )
-    .await
-    .unwrap();
 }
 
 #[tokio::test]
@@ -3371,29 +3299,6 @@ async fn test_genesis_in_the_future_in_supported() {
         )
         .await
         .unwrap();
-    let short_proposal_pid = gov
-        .make_proposal(
-            &NeuronId { id: 1 },
-            // Must match neuron 1's serialized_id.
-            &principal(1),
-            &Proposal {
-                title: Some("A Reasonable Title".to_string()),
-                summary: "proposal 2 (short)".to_string(),
-                action: Some(proposal::Action::ExecuteNnsFunction(ExecuteNnsFunction {
-                    nns_function: NnsFunction::IcpXdrConversionRate as i32,
-                    payload: Encode!(&UpdateIcpXdrConversionRatePayload {
-                        xdr_permyriad_per_icp: 9256,
-                        data_source: "the data source".to_string(),
-                        timestamp_seconds: 111_222_333,
-                        reason: None,
-                    })
-                    .unwrap(),
-                })),
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
 
     fake_driver.advance_time_by(REWARD_DISTRIBUTION_PERIOD_SECONDS);
     run_pending_timers();
@@ -3411,20 +3316,6 @@ async fn test_genesis_in_the_future_in_supported() {
             rounds_since_last_distribution: Some(0),
             latest_round_available_e8s_equivalent: Some(0)
         }
-    );
-    // ... even though the short proposal is ready to settle
-    let short_info = gov
-        .get_proposal_info(&PrincipalId::new_anonymous(), short_proposal_pid)
-        .unwrap();
-    assert_eq!(
-        short_info.reward_status, ReadyToSettle as i32,
-        "Proposal info for the 'short' proposal: {:#?}",
-        short_info
-    );
-    assert_eq!(
-        short_info.reward_event_round, 0,
-        "Proposal info for the 'short' proposal: {:#?}",
-        short_info
     );
 
     // The long proposal, however, is still open for voting
@@ -3508,7 +3399,7 @@ async fn test_genesis_in_the_future_in_supported() {
         RewardEvent {
             day_after_genesis: 1,
             actual_timestamp_seconds: fake_driver.now(),
-            settled_proposals: vec![long_early_proposal_pid, short_proposal_pid],
+            settled_proposals: vec![long_early_proposal_pid],
             distributed_e8s_equivalent: 2,
             total_available_e8s_equivalent: 100,
             rounds_since_last_distribution: Some(1),
@@ -3541,12 +3432,6 @@ async fn test_genesis_in_the_future_in_supported() {
     // At this point, all proposals have been rewarded
     assert_eq!(
         gov.get_proposal_info(&PrincipalId::new_anonymous(), long_early_proposal_pid)
-            .unwrap()
-            .reward_event_round,
-        1
-    );
-    assert_eq!(
-        gov.get_proposal_info(&PrincipalId::new_anonymous(), short_proposal_pid)
             .unwrap()
             .reward_event_round,
         1
@@ -3602,7 +3487,6 @@ fn compute_maturities(
     let governance_proto = GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
         .with_neurons(neurons)
-        .with_short_voting_period(10)
         .with_neuron_management_voting_period(10)
         .with_wait_for_quiet_threshold(10)
         .build();
@@ -3694,19 +3578,7 @@ proptest! {
 fn test_topic_weights(stake in 1u64..1_000_000_000) {
     // Check that voting on
     // 1. a governance proposal yields 20 times the voting power
-    // 2. an exchange rate proposal yields 0.01 times the voting power
     // 3. other proposals yield 1 time the voting power
-
-    // Test alloacting 100 maturity to two neurons with equal stake where
-    // 1. first neuron voting on a network proposal (1x) and
-    // 2. second neuron voting on an exchange proposal (0.01x).
-    // Overall reward weights are 2 * (1+0.01) = 2.02
-    // First neuron gets 1/2.02 * 100 = 49.5 truncated to 49.
-    // Second neuron gets 0.01/2.02 * 100 = 0.495 truncated to 0.
-    assert_eq!(
-        compute_maturities(vec![stake, stake], vec!["P-N", "-PE"], USUAL_REWARD_POT_E8S),
-        vec![49, 0]
-    );
 
     // Test alloacting 100 maturity to two neurons with equal stake where
     // 1. first neuron voting on a gov proposal (20x) and
@@ -3761,7 +3633,6 @@ fn test_random_voting_rewards_scenarios() {
             match proposal_topic {
                 fake::ProposalTopicBehavior::Governance => 20_00,
                 fake::ProposalTopicBehavior::NetworkEconomics => 1_00,
-                fake::ProposalTopicBehavior::ExchangeRate => 1,
             }
         }
 
@@ -3794,7 +3665,6 @@ fn test_random_voting_rewards_scenarios() {
             let proposal_topic = *[
                 fake::ProposalTopicBehavior::Governance,
                 fake::ProposalTopicBehavior::NetworkEconomics,
-                fake::ProposalTopicBehavior::ExchangeRate,
             ]
             .iter()
             .choose(&mut rng)

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -15,6 +15,8 @@ on the process that this file is part of, see
 
 ## Removed
 
+* The `IcpXdrConversionRate` proposal is now obsolete and cannot be submitted.
+
 ## Fixed
 
 ## Security

--- a/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister_with_exchange_rate_canister.rs
@@ -5,24 +5,14 @@ use ic_base_types::CanisterId;
 use ic_cbor::CertificateToCbor;
 use ic_certificate_verification::VerifyCertificate;
 use ic_certification::{Certificate, HashTree, LookupResult};
-use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL};
-use ic_nns_common::{
-    pb::v1::NeuronId,
-    types::{UpdateIcpXdrConversionRatePayload, UpdateIcpXdrConversionRatePayloadReason},
-};
 use ic_nns_constants::{
     CYCLES_MINTING_CANISTER_ID, EXCHANGE_RATE_CANISTER_ID, EXCHANGE_RATE_CANISTER_INDEX,
-};
-use ic_nns_governance_api::{
-    manage_neuron_response, ExecuteNnsFunction, MakeProposalRequest, NnsFunction,
-    ProposalActionRequest,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     state_test_helpers::{
         create_canister_at_specified_id, get_average_icp_xdr_conversion_rate,
-        get_icp_xdr_conversion_rate, nns_governance_make_proposal, nns_wait_for_proposal_execution,
-        setup_nns_canisters, state_machine_builder_for_nns_tests,
+        get_icp_xdr_conversion_rate, setup_nns_canisters, state_machine_builder_for_nns_tests,
     },
 };
 use ic_state_machine_tests::StateMachine;
@@ -55,54 +45,6 @@ fn reinstall_mock_exchange_rate_canister(
     machine
         .reinstall_canister(canister_id, wasm.bytes(), Encode!(&payload).unwrap())
         .expect("Failed to reinstall mock XRC canister");
-}
-
-// Creates an ICP/XDR conversion rate proposal.
-fn propose_icp_xdr_rate(
-    machine: &StateMachine,
-    xdr_permyriad_per_icp: u64,
-    timestamp_seconds: u64,
-    reason: Option<UpdateIcpXdrConversionRatePayloadReason>,
-) -> u64 {
-    let payload = UpdateIcpXdrConversionRatePayload {
-        data_source: "".to_string(),
-        timestamp_seconds,
-        xdr_permyriad_per_icp,
-        reason,
-    };
-
-    // Use TEST_NEURON_1_ID as it is loaded with tokens.
-    let neuron_id = NeuronId {
-        id: TEST_NEURON_1_ID,
-    };
-
-    let proposal = MakeProposalRequest {
-        title: Some(format!("Update ICP/XDR rate to {}", xdr_permyriad_per_icp)),
-        summary: "".to_string(),
-        url: "".to_string(),
-        action: Some(ProposalActionRequest::ExecuteNnsFunction(
-            ExecuteNnsFunction {
-                nns_function: NnsFunction::IcpXdrConversionRate as i32,
-                payload: Encode!(&payload).unwrap(),
-            },
-        )),
-    };
-
-    let response = nns_governance_make_proposal(
-        machine,
-        *TEST_NEURON_1_OWNER_PRINCIPAL,
-        neuron_id,
-        &proposal,
-    );
-    match response.command {
-        Some(manage_neuron_response::Command::MakeProposal(make_proposal_response)) => {
-            match make_proposal_response.proposal_id {
-                Some(proposal_id) => proposal_id.id,
-                None => panic!("Unable to find proposal ID!"),
-            }
-        }
-        _ => panic!("Unable to submit the proposal: {:?}", response),
-    }
 }
 
 fn new_icp_cxdr_mock_exchange_rate_canister_init_payload(
@@ -330,165 +272,6 @@ fn test_enable_retrieving_rate_from_exchange_rate_canister() {
         cmc_first_rate_timestamp_seconds + (FIVE_MINUTES_SECONDS * 4) + 22
     );
     assert_eq!(response.data.xdr_permyriad_per_icp, 210_000);
-}
-
-#[test]
-fn test_disabling_and_reenabling_exchange_rate_canister_calling_via_exchange_rate_proposal() {
-    // Step 1: Prepare the world.
-    let state_machine = state_machine_builder_for_nns_tests()
-        .with_time(GENESIS)
-        .build();
-
-    // Set up NNS.
-    let nns_init_payload = NnsInitPayloadsBuilder::new()
-        .with_test_neurons()
-        .with_exchange_rate_canister(EXCHANGE_RATE_CANISTER_ID)
-        .build();
-    setup_nns_canisters(&state_machine, nns_init_payload);
-
-    // Install exchange rate canister.
-    setup_mock_exchange_rate_canister(
-        &state_machine,
-        new_icp_cxdr_mock_exchange_rate_canister_init_payload(25_000_000_000, None, None),
-    );
-
-    // Check that the canister is initialized with the default rate.
-    let cmc_first_rate_timestamp_seconds: u64 = 1620633600; // 10 May 2021 10:00:00 AM CEST
-    let response = get_icp_xdr_conversion_rate(&state_machine);
-    assert_eq!(
-        response.data.timestamp_seconds,
-        cmc_first_rate_timestamp_seconds
-    );
-    assert_eq!(response.data.xdr_permyriad_per_icp, 1_000_000);
-
-    // Step 2: Verify that the rate has been set by calling the cycles minting canister.
-
-    // The CMC will not call the exchange rate canister, as
-    // the current time is set to genesis. We need to advance the time
-    // to the CMC's first rate then add five minutes to ensure the heartbeat
-    // is triggered (the CMC only calls the exchange rate canister
-    // every five minutes: :05, :10, :15 and so on).
-    let genesis_seconds = GENESIS.as_millis_since_unix_epoch() / 1_000;
-    let seconds_diff =
-        cmc_first_rate_timestamp_seconds.abs_diff(genesis_seconds) + FIVE_MINUTES_SECONDS;
-    state_machine.advance_time(Duration::from_secs(seconds_diff));
-
-    // Start testing. Advance the state machine so the heartbeat triggers
-    // at the new time.
-    state_machine.tick();
-
-    // Step 3: Verify that the rate has been set by calling the cycles minting canister.
-    let response = get_icp_xdr_conversion_rate(&state_machine);
-
-    // The rate's timestamp should be the CMC's first rate timestamp + five minutes + 8 secs.
-    // Note on the 8 secs:
-    // The mock exchange rate canister takes the current time and adds 6 seconds
-    // to differentiate the timestamps between canisters. An additional 2 is
-    // added for retrieving the rate initially.
-    assert_eq!(
-        response.data.timestamp_seconds,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS + 8
-    );
-    assert_eq!(response.data.xdr_permyriad_per_icp, 250_000);
-
-    // Step 3: Send in a proposal with a diverged rate reason. Ensure that the CMC
-    // stops calling the mock exchange rate canister.
-    let proposal_id = propose_icp_xdr_rate(
-        &state_machine,
-        210_000,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS + ONE_MINUTE_SECONDS,
-        Some(UpdateIcpXdrConversionRatePayloadReason::DivergedRate),
-    );
-    nns_wait_for_proposal_execution(&state_machine, proposal_id);
-
-    // Check if proposal has set the rate.
-    let response = get_icp_xdr_conversion_rate(&state_machine);
-    assert_eq!(
-        response.data.timestamp_seconds,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS + ONE_MINUTE_SECONDS
-    );
-    assert_eq!(response.data.xdr_permyriad_per_icp, 210_000);
-
-    // Advance the time by 5 minutes and attempt to trigger a
-    // call to the exchange rate canister.
-    state_machine.advance_time(Duration::from_secs(FIVE_MINUTES_SECONDS));
-    // Trigger the heartbeat.
-    state_machine.tick();
-
-    // Retrieve the current rate. It should still be 210_000.
-    let response = get_icp_xdr_conversion_rate(&state_machine);
-    assert_eq!(
-        response.data.timestamp_seconds,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS + ONE_MINUTE_SECONDS
-    );
-    assert_eq!(response.data.xdr_permyriad_per_icp, 210_000);
-
-    // Ensure that a proposal with a OldRate reason does not reactivate the
-    // update cycle.
-    let proposal_id = propose_icp_xdr_rate(
-        &state_machine,
-        200_000,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS * 2,
-        Some(UpdateIcpXdrConversionRatePayloadReason::OldRate),
-    );
-    nns_wait_for_proposal_execution(&state_machine, proposal_id);
-
-    let response = get_icp_xdr_conversion_rate(&state_machine);
-    assert_eq!(
-        response.data.timestamp_seconds,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS * 2
-    );
-    assert_eq!(response.data.xdr_permyriad_per_icp, 200_000);
-
-    // Advance the time again and trigger the heartbeat.
-    state_machine.advance_time(Duration::from_secs(FIVE_MINUTES_SECONDS));
-    state_machine.tick();
-
-    let response = get_icp_xdr_conversion_rate(&state_machine);
-    assert_eq!(
-        response.data.timestamp_seconds,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS * 2
-    );
-    assert_eq!(response.data.xdr_permyriad_per_icp, 200_000);
-
-    // Re-enable calls to the exchange rate canister.
-    let proposal_id = propose_icp_xdr_rate(
-        &state_machine,
-        220_000,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS * 3,
-        Some(UpdateIcpXdrConversionRatePayloadReason::EnableAutomaticExchangeRateUpdates),
-    );
-    nns_wait_for_proposal_execution(&state_machine, proposal_id);
-
-    let response = get_icp_xdr_conversion_rate(&state_machine);
-    assert_eq!(
-        response.data.timestamp_seconds,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS * 3
-    );
-    assert_eq!(response.data.xdr_permyriad_per_icp, 220_000);
-
-    let response = get_icp_xdr_conversion_rate(&state_machine);
-    assert_eq!(response.data.xdr_permyriad_per_icp, 220_000);
-    assert_eq!(
-        response.data.timestamp_seconds,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS * 3
-    );
-
-    // Advance the time again and trigger the heartbeat.
-    state_machine.advance_time(Duration::from_secs(FIVE_MINUTES_SECONDS));
-    state_machine.tick();
-
-    let response = get_icp_xdr_conversion_rate(&state_machine);
-    assert_eq!(response.data.xdr_permyriad_per_icp, 250_000);
-    // The rate's timestamp should be the CMC's first rate timestamp + twenty minutes + 22 secs.
-    // Note on the 22 secs:
-    // The mock exchange rate canister takes the current time and adds 6 seconds
-    // to differentiate the timestamps between canisters. An additional 2 is
-    // added for retrieving the rate initially.
-    assert_eq!(
-        response.data.timestamp_seconds,
-        cmc_first_rate_timestamp_seconds + FIVE_MINUTES_SECONDS * 4 + 22
-    );
 }
 
 fn verify_cmc_certified_data<Data>(

--- a/rs/nns/integration_tests/src/reinstall_and_upgrade.rs
+++ b/rs/nns/integration_tests/src/reinstall_and_upgrade.rs
@@ -6,7 +6,7 @@ use ic_management_canister_types_private::CanisterInstallMode;
 use ic_nervous_system_common_test_keys::{
     TEST_NEURON_2_ID, TEST_NEURON_2_OWNER_KEYPAIR, TEST_NEURON_2_OWNER_PRINCIPAL,
 };
-use ic_nns_common::types::{NeuronId, UpdateIcpXdrConversionRatePayload};
+use ic_nns_common::types::NeuronId;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, LIFELINE_CANISTER_ID};
 use ic_nns_governance_api::NnsFunction;
 use ic_nns_gtc::{
@@ -18,7 +18,7 @@ use ic_nns_test_utils::{
     governance::{
         bump_gzip_timestamp, get_pending_proposals, reinstall_nns_canister_by_proposal,
         submit_external_update_proposal, upgrade_nns_canister_by_proposal,
-        upgrade_nns_canister_with_arg_by_proposal,
+        upgrade_nns_canister_with_arg_by_proposal, HardResetNnsRootToVersionPayload,
     },
     itest_helpers::{state_machine_test_on_nns_subnet, NnsCanisters},
 };
@@ -110,13 +110,11 @@ fn test_reinstall_and_upgrade_canisters_with_state_changes() {
             Sender::from_keypair(&TEST_NEURON_2_OWNER_KEYPAIR),
             NeuronId(TEST_NEURON_2_ID),
             // Random proposal type
-            NnsFunction::IcpXdrConversionRate,
+            NnsFunction::HardResetNnsRootToVersion,
             // Payload itself doesn't matter
-            UpdateIcpXdrConversionRatePayload {
-                data_source: "".to_string(),
-                timestamp_seconds: 1,
-                xdr_permyriad_per_icp: 100,
-                reason: None,
+            HardResetNnsRootToVersionPayload {
+                wasm_module: vec![],
+                init_arg: vec![],
             },
             "<proposal created by test_reinstall_and_upgrade_canisters_with_state_changes>"
                 .to_string(),
@@ -166,13 +164,11 @@ fn test_reinstall_and_upgrade_canisters_with_state_changes() {
             Sender::from_keypair(&TEST_NEURON_2_OWNER_KEYPAIR),
             NeuronId(TEST_NEURON_2_ID),
             // Random proposal type
-            NnsFunction::IcpXdrConversionRate,
+            NnsFunction::HardResetNnsRootToVersion,
             // Payload itself doesn't matter
-            UpdateIcpXdrConversionRatePayload {
-                data_source: "".to_string(),
-                timestamp_seconds: 1,
-                xdr_permyriad_per_icp: 100,
-                reason: None,
+            HardResetNnsRootToVersionPayload {
+                wasm_module: vec![],
+                init_arg: vec![],
             },
             "<proposal created by test_reinstall_and_upgrade_canisters_with_state_changes>"
                 .to_string(),

--- a/rs/tests/driver/src/nns.rs
+++ b/rs/tests/driver/src/nns.rs
@@ -154,30 +154,6 @@ pub async fn get_software_version_from_snapshot(
     }
 }
 
-pub async fn update_xdr_per_icp(
-    nns_api: &'_ Runtime,
-    timestamp_seconds: u64,
-    xdr_permyriad_per_icp: u64,
-) -> Result<(), String> {
-    let governance_canister = get_governance_canister(nns_api);
-    let proposal_payload = ic_nns_common::types::UpdateIcpXdrConversionRatePayload {
-        data_source: "".to_string(),
-        timestamp_seconds,
-        xdr_permyriad_per_icp,
-        reason: None,
-    };
-
-    let proposal_id = submit_external_proposal_with_test_id(
-        &governance_canister,
-        NnsFunction::IcpXdrConversionRate,
-        proposal_payload,
-    )
-    .await;
-
-    vote_execute_proposal_assert_executed(&governance_canister, proposal_id).await;
-    Ok(())
-}
-
 pub async fn set_authorized_subnetwork_list(
     nns_api: &'_ Runtime,
     who: Option<PrincipalId>,

--- a/rs/tests/nns/nns_cycles_minting_multi_app_subnets_test.rs
+++ b/rs/tests/nns/nns_cycles_minting_multi_app_subnets_test.rs
@@ -20,7 +20,7 @@ use ic_system_test_driver::{
     nns::{
         change_subnet_type_assignment, change_subnet_type_assignment_with_failure,
         set_authorized_subnetwork_list, set_authorized_subnetwork_list_with_failure,
-        update_subnet_type, update_xdr_per_icp,
+        update_subnet_type,
     },
     util::{block_on, runtime_from_url},
 };
@@ -77,19 +77,6 @@ pub fn create_canister_on_specific_subnet_type(env: TestEnv) {
             LEDGER_CANISTER_ID,
             CYCLES_MINTING_CANISTER_ID,
         );
-
-        let xdr_permyriad_per_icp = 5_000; // = 0.5 XDR/ICP
-
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        // Set the XDR-to-cycles conversion rate.
-        info!(logger, "setting CYCLES_PER_XDR");
-        update_xdr_per_icp(&nns, timestamp, xdr_permyriad_per_icp)
-            .await
-            .unwrap();
 
         // The first attempt to create a canister should fail because we
         // haven't registered any subnets with the cycles minting canister.
@@ -167,7 +154,7 @@ pub fn create_canister_on_specific_subnet_type(env: TestEnv) {
         //  - a specific subnet of another type
         // and confirm the canisters are created on the expected subnet on each case.
         info!(logger, "creating canisters");
-        let initial_amount = Tokens::new(10_000, 0).unwrap();
+        let initial_amount = Tokens::new(50, 0).unwrap();
 
         let canister_on_authorized_subnet = user1
             .create_canister_cmc(initial_amount, None, &controller_user, None, None)

--- a/rs/tests/nns/nns_cycles_minting_test.rs
+++ b/rs/tests/nns/nns_cycles_minting_test.rs
@@ -1,47 +1,33 @@
 use anyhow::Result;
 use canister_test::{Canister, Project, Wasm};
 use cycles_minting::{make_user_ed25519, TestAgent, UserHandle};
-use cycles_minting_canister::{
-    IcpXdrConversionRateCertifiedResponse, TokensToCycles, CREATE_CANISTER_REFUND_FEE,
-    DEFAULT_CYCLES_PER_XDR,
-};
+use cycles_minting_canister::{TokensToCycles, CREATE_CANISTER_REFUND_FEE, DEFAULT_CYCLES_PER_XDR};
 use dfn_candid::{candid_one, CandidOne};
 use ic_canister_client::{HttpClient, Sender};
-use ic_certification::verify_certified_data;
 use ic_config::subnet_config::CyclesAccountManagerConfig;
-use ic_crypto_tree_hash::MixedHashTree;
-use ic_crypto_utils_threshold_sig_der::threshold_sig_public_key_from_der;
 use ic_ledger_core::tokens::CheckedAdd;
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
 use ic_management_canister_types_private::{CanisterIdRecord, CanisterStatusResultV2};
 use ic_nervous_system_clients::canister_status::CanisterStatusResult as RootCanisterStatusResult;
 use ic_nervous_system_common_test_keys::{
-    TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR, TEST_USER1_KEYPAIR, TEST_USER1_PRINCIPAL,
-    TEST_USER2_KEYPAIR,
+    TEST_USER1_KEYPAIR, TEST_USER1_PRINCIPAL, TEST_USER2_KEYPAIR,
 };
-use ic_nns_common::types::{NeuronId, UpdateIcpXdrConversionRatePayload};
 use ic_nns_constants::{
     CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID, ROOT_CANISTER_ID,
 };
-use ic_nns_governance_api::NnsFunction;
-use ic_nns_test_utils::governance::{
-    submit_external_update_proposal_allowing_error, upgrade_nns_canister_by_proposal,
-};
+use ic_nns_test_utils::governance::upgrade_nns_canister_by_proposal;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::ic::InternetComputer;
 use ic_system_test_driver::systest;
 use ic_system_test_driver::{
     driver::{
-        test_env::{HasIcPrepDir, TestEnv},
+        test_env::TestEnv,
         test_env_api::{
             HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, NnsInstallationBuilder,
         },
     },
-    nns::{
-        get_governance_canister, set_authorized_subnetwork_list,
-        submit_external_proposal_with_test_id, update_xdr_per_icp,
-    },
+    nns::set_authorized_subnetwork_list,
     util::{block_on, runtime_from_url},
 };
 use ic_types::Cycles;
@@ -113,57 +99,11 @@ pub fn test(env: TestEnv) {
             CYCLES_MINTING_CANISTER_ID,
         );
 
-        let xdr_permyriad_per_icp = 5_000; // = 0.5 XDR/ICP
+        let xdr_permyriad_per_icp = 1_000_000; // = 100 XDR/ICP
         let icpts_to_cycles = TokensToCycles {
             xdr_permyriad_per_icp,
             cycles_per_xdr: DEFAULT_CYCLES_PER_XDR.into(),
         };
-
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        // Set the XDR-to-cycles conversion rate.
-        info!(logger, "setting CYCLES_PER_XDR");
-        update_xdr_per_icp(&nns, timestamp, xdr_permyriad_per_icp)
-            .await
-            .unwrap();
-
-        // Set the XDR-to-cycles conversion rate, but expect it to fail
-        info!(logger, "setting conversion rate to 0, failure expected");
-        let governance_canister = get_governance_canister(&nns);
-        let proposal_payload = UpdateIcpXdrConversionRatePayload {
-            timestamp_seconds: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-            xdr_permyriad_per_icp: 0,
-            ..Default::default()
-        };
-
-        submit_external_update_proposal_allowing_error(
-            &governance_canister,
-            Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
-            NeuronId(TEST_NEURON_1_ID),
-            NnsFunction::IcpXdrConversionRate,
-            proposal_payload,
-            "Test Title".to_string(),
-            "Test Summary".to_string(),
-        )
-        .await
-        .unwrap_err();
-
-        let canister = Canister::new(&nns, CYCLES_MINTING_CANISTER_ID);
-        /* Test getting the conversion rate */
-        let mut conversion_rate_response = canister
-            .query_(
-                "get_icp_xdr_conversion_rate",
-                candid_one::<IcpXdrConversionRateCertifiedResponse, ()>,
-                (),
-            )
-            .await
-            .unwrap();
 
         let cmc_canister_status: RootCanisterStatusResult = Canister::new(&nns, ROOT_CANISTER_ID)
             .update_from_sender(
@@ -176,70 +116,11 @@ pub fn test(env: TestEnv) {
             .unwrap();
         let cmc_initial_cycles_balance = cmc_canister_status.cycles.0.to_u64().unwrap();
 
-        let icp_xdr_conversion_rate = conversion_rate_response.data;
-        // Check that the first call changed the value but not the second one
-        assert_eq!(
-            icp_xdr_conversion_rate.xdr_permyriad_per_icp,
-            xdr_permyriad_per_icp
-        );
-
-        let pk_bytes = env
-            .prep_dir("")
-            .unwrap()
-            .root_public_key()
-            .expect("failed to read threshold sig PK bytes");
-        let pk = threshold_sig_public_key_from_der(&pk_bytes[..])
-            .expect("failed to decode threshold sig PK");
-
-        let mixed_hash_tree: MixedHashTree =
-            serde_cbor::from_slice(&conversion_rate_response.hash_tree).unwrap();
-        // Verify the authenticity of the root hash stored by the canister in the
-        // certified_data field
-        verify_certified_data(
-            &conversion_rate_response.certificate[..],
-            &CYCLES_MINTING_CANISTER_ID,
-            &pk,
-            mixed_hash_tree.digest().as_bytes(),
-        )
-        .unwrap();
-
-        let proposal_payload = UpdateIcpXdrConversionRatePayload {
-            timestamp_seconds: timestamp,
-            xdr_permyriad_per_icp: xdr_permyriad_per_icp + 1234,
-            ..Default::default()
-        };
-
-        // Set the XDR-to-cycles conversion rate again but with the same timestamp.
-        // No change expected.
-        info!(logger, "setting CYCLES_PER_XDR");
-        submit_external_proposal_with_test_id(
-            &governance_canister,
-            NnsFunction::IcpXdrConversionRate,
-            proposal_payload,
-        )
-        .await;
-
-        conversion_rate_response = canister
-            .query_(
-                "get_icp_xdr_conversion_rate",
-                candid_one::<IcpXdrConversionRateCertifiedResponse, ()>,
-                (),
-            )
-            .await
-            .unwrap();
-
-        let icp_xdr_conversion_rate = conversion_rate_response.data;
-        // Check rate hasn't changed
-        assert_eq!(
-            icp_xdr_conversion_rate.xdr_permyriad_per_icp,
-            xdr_permyriad_per_icp
-        );
-
         /* The first attempt to create a canister should fail because we
          * haven't registered subnets with the cycles minting canister. */
         info!(logger, "creating canister (no subnets)");
 
-        let send_amount = Tokens::new(2, 0).unwrap();
+        let send_amount = Tokens::new(0, 1_000_000).unwrap();
 
         let (err, refund_block) = user1
             .create_canister_cmc(send_amount, None, &controller_user, None, None)
@@ -299,62 +180,12 @@ pub fn test(env: TestEnv) {
             .unwrap();
 
         /* Create with funds < the canister creation fee. */
-        info!(logger, "creating canister (not enough funds 1)");
+        info!(logger, "creating canister (not enough funds)");
 
-        let small_amount = Tokens::new(0, 500_000).unwrap();
-
-        let (err, refund_block) = user1
-            .create_canister_cmc(small_amount, None, &controller_user, None, None)
-            .await
-            .unwrap_err();
-
-        info!(logger, "error: {}", err);
-        assert!(err.contains("Creating a canister requires a fee of"));
-
-        let refund_block = refund_block.unwrap();
-        tst.check_refund(
-            refund_block,
-            small_amount,
-            CREATE_CANISTER_REFUND_FEE,
-            *TEST_USER1_PRINCIPAL,
-        )
-        .await;
-
-        // remove when ledger notify goes away
-        {
-            user1
-                .transfer(
-                    Tokens::from_e8s(small_amount.get_e8s() + DEFAULT_TRANSFER_FEE.get_e8s()),
-                    controller_user.principal_id(),
-                )
-                .await;
-            let (err, refund_block) = controller_user
-                .create_canister_ledger(small_amount)
-                .await
-                .unwrap_err();
-
-            info!(logger, "error: {}", err);
-            assert!(err.contains("Creating a canister requires a fee of"));
-
-            let refund_block = refund_block.unwrap();
-            tst.check_refund(
-                refund_block,
-                small_amount,
-                CREATE_CANISTER_REFUND_FEE,
-                controller_user.principal_id(),
-            )
-            .await;
-        }
-
-        /* Create with funds < the refund fee. */
-        info!(logger, "creating canister (not enough funds 2)");
-
-        let tiny_amount = DEFAULT_TRANSFER_FEE
-            .checked_add(&Tokens::from_e8s(10_000))
-            .unwrap();
+        let small_amount = Tokens::new(0, 30_000).unwrap();
 
         let (err, no_refund_block) = user1
-            .create_canister_cmc(tiny_amount, None, &controller_user, None, None)
+            .create_canister_cmc(small_amount, None, &controller_user, None, None)
             .await
             .unwrap_err();
 
@@ -373,7 +204,7 @@ pub fn test(env: TestEnv) {
                 amount,
                 spender,
             } => {
-                assert_eq!(tiny_amount, amount);
+                assert_eq!(small_amount, amount);
                 assert_eq!(tst.get_balance(from).await, Tokens::ZERO);
                 assert_eq!(spender, None);
             }
@@ -384,12 +215,12 @@ pub fn test(env: TestEnv) {
         {
             user1
                 .transfer(
-                    Tokens::from_e8s(tiny_amount.get_e8s() + DEFAULT_TRANSFER_FEE.get_e8s()),
+                    Tokens::from_e8s(small_amount.get_e8s() + DEFAULT_TRANSFER_FEE.get_e8s()),
                     controller_user.principal_id(),
                 )
                 .await;
             let (err, no_refund_block) = controller_user
-                .create_canister_ledger(tiny_amount)
+                .create_canister_ledger(small_amount)
                 .await
                 .unwrap_err();
 
@@ -408,7 +239,7 @@ pub fn test(env: TestEnv) {
                     amount,
                     spender,
                 } => {
-                    assert_eq!(tiny_amount, amount);
+                    assert_eq!(small_amount, amount);
                     assert_eq!(tst.get_balance(from).await, Tokens::ZERO);
                     assert_eq!(spender, None);
                 }
@@ -419,7 +250,7 @@ pub fn test(env: TestEnv) {
         /* Create with sufficient funds. */
         info!(logger, "creating canister");
 
-        let initial_amount = Tokens::new(10_000, 0).unwrap();
+        let initial_amount = Tokens::new(50, 0).unwrap();
 
         let bh = user1
             .pay_for_canister(initial_amount, None, &controller_pid)
@@ -464,9 +295,9 @@ pub fn test(env: TestEnv) {
 
         info!(logger, "topping up");
 
-        let topup1 = Tokens::new(1000, 0).unwrap();
-        let topup2 = Tokens::new(1000, 0).unwrap();
-        let topup3 = Tokens::new(3000, 0).unwrap();
+        let topup1 = Tokens::new(5, 0).unwrap();
+        let topup2 = Tokens::new(5, 0).unwrap();
+        let topup3 = Tokens::new(15, 0).unwrap();
         let top_up_amount = topup1
             .checked_add(&topup2)
             .unwrap()
@@ -619,7 +450,7 @@ pub fn test(env: TestEnv) {
 
             info!(logger, "topping up");
 
-            let top_up_amount = Tokens::new(5_000, 0).unwrap();
+            let top_up_amount = Tokens::new(25, 0).unwrap();
 
             user1
                 .top_up_canister_ledger(top_up_amount, None, &new_canister_id)
@@ -690,7 +521,7 @@ pub fn test(env: TestEnv) {
 
         info!(logger, "creating NNS canister");
 
-        let nns_amount = Tokens::new(2, 0).unwrap();
+        let nns_amount = Tokens::new(0, 1_000_000).unwrap();
 
         let new_canister_id = user1
             .create_canister_cmc(nns_amount, None, &controller_user, None, None)
@@ -717,7 +548,7 @@ pub fn test(env: TestEnv) {
 
         // remove when ledger notify goes away
         {
-            let nns_amount = Tokens::new(2, 0).unwrap();
+            let nns_amount = Tokens::new(0, 1_000_000).unwrap();
             user1
                 .transfer(
                     Tokens::from_e8s(nns_amount.get_e8s() + DEFAULT_TRANSFER_FEE.get_e8s()),
@@ -851,7 +682,7 @@ pub fn test(env: TestEnv) {
         /* Exceed the daily cycles minting limit. */
         info!(logger, "creating canister (exceeding daily limit)");
 
-        let amount = Tokens::new(300_000, 0).unwrap();
+        let amount = Tokens::new(1_500, 0).unwrap();
 
         let (err, refund_block) = user1
             .create_canister_cmc(amount, None, &controller_user, None, None)
@@ -873,7 +704,7 @@ pub fn test(env: TestEnv) {
 
         // remove when ledger notify goes away
         {
-            let amount = Tokens::new(300_000, 0).unwrap();
+            let amount = Tokens::new(1_500, 0).unwrap();
             user1
                 .transfer(
                     Tokens::from_e8s(amount.get_e8s() + DEFAULT_TRANSFER_FEE.get_e8s()),

--- a/rs/tests/nns/nns_dapp/nns_dapp.rs
+++ b/rs/tests/nns/nns_dapp/nns_dapp.rs
@@ -12,7 +12,7 @@ use ic_system_test_driver::driver::{
         NnsCustomizations,
     },
 };
-use ic_system_test_driver::nns::{set_authorized_subnetwork_list, update_xdr_per_icp};
+use ic_system_test_driver::nns::set_authorized_subnetwork_list;
 use ic_system_test_driver::sns_client::add_subnet_to_sns_deploy_whitelist;
 use ic_system_test_driver::util::{
     block_on, create_canister, install_canister, runtime_from_url, set_controller,
@@ -206,21 +206,6 @@ pub fn install_ii_nns_dapp_and_subnet_rental(
         );
         (ii_canister_id, nns_dapp_canister_id)
     })
-}
-
-pub fn set_icp_xdr_exchange_rate(env: &TestEnv, xdr_permyriad_per_icp: u64) {
-    let topology = env.topology_snapshot();
-    let nns_node = topology.root_subnet().nodes().next().unwrap();
-    let nns = runtime_from_url(nns_node.get_public_url(), nns_node.effective_canister_id());
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    block_on(async move {
-        update_xdr_per_icp(&nns, timestamp, xdr_permyriad_per_icp)
-            .await
-            .unwrap();
-    });
 }
 
 pub fn set_authorized_subnets(env: &TestEnv) {

--- a/rs/tests/testnets/io_perf_benchmark.rs
+++ b/rs/tests/testnets/io_perf_benchmark.rs
@@ -60,7 +60,7 @@ use ic_system_test_driver::driver::{
     test_env::TestEnv,
     test_env_api::{HasTopologySnapshot, IcNodeContainer},
 };
-use nns_dapp::{nns_dapp_customizations, set_authorized_subnets, set_icp_xdr_exchange_rate};
+use nns_dapp::{nns_dapp_customizations, set_authorized_subnets};
 use slog::{info, Logger};
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
@@ -292,9 +292,6 @@ pub fn setup(env: TestEnv, config: Config) {
         topology_snapshot,
         nns_dapp_customizations(),
     );
-
-    // sets the exchange rate to 12 XDR per 1 ICP
-    set_icp_xdr_exchange_rate(&env, 12_0000);
 
     set_authorized_subnets(&env);
 

--- a/rs/tests/testnets/large.rs
+++ b/rs/tests/testnets/large.rs
@@ -55,7 +55,7 @@ use ic_system_test_driver::driver::{
 use ic_system_test_driver::sns_client::add_all_wasms_to_sns_wasm;
 use nns_dapp::{
     install_ii_nns_dapp_and_subnet_rental, install_sns_aggregator, nns_dapp_customizations,
-    set_authorized_subnets, set_icp_xdr_exchange_rate, set_sns_subnet,
+    set_authorized_subnets, set_sns_subnet,
 };
 
 const NUM_FULL_CONSENSUS_APP_SUBNETS: u64 = 1;
@@ -99,10 +99,6 @@ pub fn setup(env: TestEnv) {
         nns_dapp_customizations(),
     );
 
-    // sets the exchange rate to 12 XDR per 1 ICP
-    set_icp_xdr_exchange_rate(&env, 12_0000);
-
-    // sets the exchange rate to 12 XDR per 1 ICP
     set_authorized_subnets(&env);
 
     // deploys the ic-gateway/s

--- a/rs/tests/testnets/src_testing.rs
+++ b/rs/tests/testnets/src_testing.rs
@@ -57,7 +57,6 @@ use ic_system_test_driver::util::{block_on, create_canister};
 use ic_xrc_types::{Asset, AssetClass, ExchangeRateMetadata};
 use nns_dapp::{
     install_ii_nns_dapp_and_subnet_rental, nns_dapp_customizations, set_authorized_subnets,
-    set_icp_xdr_exchange_rate,
 };
 use std::env;
 use std::str::FromStr;
@@ -130,9 +129,6 @@ pub fn setup(env: TestEnv) {
         env.topology_snapshot(),
         nns_dapp_customizations(),
     );
-
-    // sets the exchange rate to 12 XDR per 1 ICP
-    set_icp_xdr_exchange_rate(&env, 12_0000);
 
     // sets the application subnets as "authorized" for canister creation by CMC
     set_authorized_subnets(&env);


### PR DESCRIPTION
This is the second try after #5011 (which had to be reverted in #5163)

# Why

The exchange rate proposals are no longer needed because the rates are set by the exchange rate canister.

# What

* Make the exchange rate proposal type obsolete
* Stop making such proposals for static testnets
* Delete the test `test_minimum_icp_xdr_conversion_rate` as it explicitly tests that the proposal 