### PR TITLE
chore(IDX): Remove unnecessary bind mounts

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -41,9 +41,7 @@ anchors:
     container:
       <<: *image
       options: >-
-        -e NODE_NAME
-        --privileged --cgroupns host
-        -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp -v /ceph-s3-info:/ceph-s3-info
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 90
   dind-small-setup: &dind-small-setup
     runs-on:

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -35,7 +35,7 @@ anchors:
       options: >-
         -e NODE_NAME
         --privileged --cgroupns host
-        -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -v /cache:/cache
     timeout-minutes: 180 # 3 hours
   checkout: &checkout
     name: Checkout

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -22,9 +22,7 @@ anchors:
     container:
       <<: *image
       options: >-
-        -e NODE_NAME
-        --privileged --cgroupns host
-        -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 120
   checkout: &checkout
     name: Checkout

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -21,9 +21,7 @@ anchors:
     container:
       <<: *image
       options: >-
-        -e NODE_NAME
-        --privileged --cgroupns host
-        -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 120
   checkout: &checkout
     name: Checkout

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -108,7 +108,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp -v /ceph-s3-info:/ceph-s3-info
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 90
     runs-on:
       group: zh1
@@ -231,7 +231,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp -v /ceph-s3-info:/ceph-s3-info
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -252,7 +252,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp -v /ceph-s3-info:/ceph-s3-info
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -304,7 +304,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp -v /ceph-s3-info:/ceph-s3-info
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 90
     # keep options from dind-large-setup but run on dind-small-setup
     runs-on:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -31,7 +31,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout
@@ -53,7 +53,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout
@@ -75,7 +75,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -97,7 +97,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 60
     env:
       SHELL_WRAPPER: "/usr/bin/time"
@@ -139,7 +139,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     outputs:
       matrix: ${{ steps.generate.outputs.output }}
@@ -167,7 +167,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 180 # 3 hours
     steps:
       - name: Checkout

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1
@@ -64,7 +64,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 720 # 12 hours
     steps:
       - name: Checkout
@@ -85,7 +85,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -106,7 +106,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 480
     steps:
       - name: Checkout
@@ -141,7 +141,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 60
     permissions:
       actions: write
@@ -193,7 +193,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1
@@ -58,7 +58,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 120
     runs-on:
       group: zh1

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -54,7 +54,7 @@ jobs:
       options: >-
         -e NODE_NAME -e KUBECONFIG
         --privileged --cgroupns host
-        -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -v /cache:/cache
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -116,9 +116,7 @@ jobs:
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
-        -e NODE_NAME -e KUBECONFIG
-        --privileged --cgroupns host
-        -v /cache:/cache -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp
+        -e NODE_NAME -e KUBECONFIG --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 150
     #if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     # Disabling until we have data confirming stability of non-hourly system tests


### PR DESCRIPTION
This removes some bind mounts for the build container that are not strictly necessary anymore.

Some, like `/var/tmp`, introduce determinism issues by storing references across builds -- though the root cause is not clear yet.