### PR TITLE
fix(node): filebeat exec condition

### DIFF
--- a/ic-os/components/monitoring/filebeat/filebeat.service
+++ b/ic-os/components/monitoring/filebeat/filebeat.service
@@ -13,14 +13,25 @@ Wants=var.mount
 User=filebeat
 Group=filebeat
 Environment="GODEBUG='madvdontneed=1'"
+
 ExecStartPre=+/opt/ic/bin/setup-filebeat-permissions.sh
 ExecStartPre=+/opt/ic/bin/generate-filebeat-config.sh -i /etc/filebeat/filebeat.yml.template -o /run/ic-node/etc/filebeat/filebeat.yml
 
-# Only start Filebeat if configuration file is generated
-ExecCondition=/usr/bin/test -f /run/ic-node/etc/filebeat/filebeat.yml
 
-ExecStart=/usr/local/bin/filebeat --environment systemd -e --path.home /var/lib/filebeat --path.config /run/ic-node/etc/filebeat --path.data /var/lib/filebeat --path.logs /var/log/filebeat
-Restart=always
+# Only start Filebeat if configuration file is generated
+ExecStart=/bin/sh -c '\
+  if [ -f /run/ic-node/etc/filebeat/filebeat.yml ]; then \
+    exec /usr/local/bin/filebeat \
+      --environment systemd -e \
+      --path.home /var/lib/filebeat \
+      --path.config /run/ic-node/etc/filebeat \
+      --path.data /var/lib/filebeat \
+      --path.logs /var/log/filebeat; \
+  else \
+    exit 0; \
+  fi'
+
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
ExecCondition runs before ExecStartPre. Therefore, generate-filebeat-config.sh never has a chance to create the /run/ic-node/etc/filebeat/filebeat.yml file

Instead, we can move this conditional to the ExecStart call.

This service will be cleaner once we move all generate-*-config scripts into the main generate-ic-config script