### PR TITLE
test(registry): More tests for large records/chunking.

### DIFF
--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1265,8 +1265,8 @@ mod tests {
 
     // This is like the previous test
     // (test_apply_mutations_delta_not_too_large_when_chunking_is_enabled),
-    // except that the mutation is approx 7.6x larger (closer to the 10 MiB
-    // limit, as opposed to 1.3 MiB).
+    // except that the mutation is approx close to 10 MiB limit, as opposed to
+    // 1.3 MiB.
     #[test]
     fn test_apply_mutations_delta_near_max_chunkable_len_when_chunking_is_enabled() {
         let _restore_on_drop = temporarily_enable_chunkifying_large_values();

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1342,9 +1342,10 @@ mod tests {
         test_from_serializable_form_impl(1)
     }
 
-    // This is a little more realistic than the previous two tests in the way
-    // that the original Registry gets populated. More precisely, instead of
-    // directly manipulating members, apply_mutations is called (via
+    // This is a little more realistic than the previous two tests
+    // (test_from_serializable_form_version1_(max_size_delta|delta_too_large))
+    // in the way that the original Registry gets populated. More precisely,
+    // instead of directly manipulating members, apply_mutations is called (via
     // apply_mutations_skip_invariant_checks, like many other tests).
     #[test]
     fn test_from_serializable_form_with_chunking() {

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1274,7 +1274,7 @@ mod tests {
         let mut registry = Registry::new();
 
         let key = b"key";
-        let too_large_value = vec![0; MAX_CHUNKABLE_ATOMIC_MUTATION_LEN - 100];
+        let too_large_value = vec![0; MAX_CHUNKABLE_ATOMIC_MUTATION_LEN - 150];
         let mutations = vec![upsert(key, too_large_value)];
 
         apply_mutations_skip_invariant_checks(&mut registry, mutations);

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1153,10 +1153,10 @@ mod tests {
         let req = HighCapacityRegistryAtomicMutateRequest {
             mutations,
             preconditions: vec![],
-            // Since the `too_large_value` is built with serializing maximum
-            // timestamp length to 10 bytes the tipping point of `+ 1` will be
-            // there only if we account the timestamp of full serialized 10
-            // bytes.
+            // max_mutation_value_size assumes that this field holds the maximum
+            // value. Therefore, in order for `req`'s encoded_len to be exactly
+            // 1 greater than what changelog_insert allows, we need this field
+            // to have the maximum value.
             timestamp_nanoseconds: u64::MAX,
         };
 

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -877,10 +877,7 @@ mod tests {
 
         let large_but_not_chunkified_mutation = upsert(key, max_value);
 
-        let not_large_mutation = upsert(
-            b"this_is_small_but_not_completely_negligible",
-            [44; 200],
-        );
+        let not_large_mutation = upsert(b"this_is_small_but_not_completely_negligible", [44; 200]);
 
         for mutation in [
             chunkified_mutation,

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -863,18 +863,24 @@ mod tests {
 
         let mut registry = Registry::new();
         let version = 1;
-        let key = b"key";
+        let key = b"this_is_large_but_not_chunkified";
 
-        let max_value = vec![0; max_mutation_value_size(version, key) - 50];
+        // The EXACT point when chunkification kicks in is not so precisely
+        // defined. Therefore, to COMFORTABLY avoid chunkification, ` - 50` is
+        // applied.
+        let max_value = vec![42; max_mutation_value_size(version, key) - 50];
 
         // This seems large, but this will get chunkified down to approximately
         // dozens of bytes. As a result, for the purposes of
         // count_fitting_deltas, this is actually small.
-        let chunkified_mutation = upsert([90; 50], [1; 2_000_000]);
+        let chunkified_mutation = upsert(b"this_is_chunkified", [43; 2_000_000]);
 
         let large_but_not_chunkified_mutation = upsert(key, max_value);
 
-        let not_large_mutation = upsert([89; 200], [1; 200]);
+        let not_large_mutation = upsert(
+            b"this_is_small_but_not_completely_negligible",
+            [44; 200],
+        );
 
         for mutation in [
             chunkified_mutation,

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1303,8 +1303,8 @@ mod tests {
                 high_capacity_registry_value::Content::Value(vec)
             }
             _garbage => panic!(
-                "Upgrading and then downgrading from HighCapacity somehow \
-                 did not result in an inline Value.",
+                "Transcribing to a HighCapacity object somehow  did not result in an \
+                 inline Value (which is impossible, unless of course, bugs)."
             ),
         };
         (*registry.store.entry(mutation.key).or_default()).push_back(HighCapacityRegistryValue {

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1426,9 +1426,10 @@ mod tests {
             vec![insert(b"no_need_for_chunking_here_57", vec![57; 1024])],
         );
 
-        // Step 2: Run the code under test: Do a serialize-deserialize
-        // round-trip, like the canister does during an upgrade (in pre- and
-        // post- upgrade).
+        // Step 2: Run the code under test: Serialize original_registry into a
+        // blob. Then, deserialize it into restored_registry, like what happens
+        // in a canister upgrade (during pre- and post- ugprade). In short, do a
+        // serialization+deserialization round trip.
         let mut restored_registry = Registry::new();
         restored_registry.from_serializable_form(original_registry.serializable_form());
 

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1169,8 +1169,9 @@ mod tests {
         let mut registry = Registry::new();
 
         // This is just (slightly) more elaborate+realistic version of the data
-        // in the previous test, but we are essentially doing the same thing:
-        // creating a mutation that should be rejected due to being too large.
+        // in the previous test (test_changelog_insert_delta_too_large), but we
+        // are essentially doing the same thing: creating a mutation that should
+        // be rejected due to being too large.
         let mutations = (0..1000)
             .map(|i| {
                 let i = i % (u8::MAX as u64 + 1);
@@ -1233,8 +1234,9 @@ mod tests {
         apply_mutations_skip_invariant_checks(&mut registry, mutations);
     }
 
-    // This is like the previous test, except that chunking is enabled. As a
-    // result, there is supposed to be no panic.
+    // This is like the previous test (test_apply_mutations_delta_too_large),
+    // except that chunking is enabled. As a result, there is supposed to be no
+    // panic.
     #[test]
     fn test_apply_mutations_delta_not_too_large_when_chunking_is_enabled() {
         let _restore_on_drop = temporarily_enable_chunkifying_large_values();
@@ -1248,8 +1250,10 @@ mod tests {
         apply_mutations_skip_invariant_checks(&mut registry, mutations);
     }
 
-    // This is like the previous test, except that the mutation is approx 7.6x
-    // larger (closer to the 10 MiB limit, as opposed to 1.3 MiB).
+    // This is like the previous test
+    // (test_apply_mutations_delta_not_too_large_when_chunking_is_enabled),
+    // except that the mutation is approx 7.6x larger (closer to the 10 MiB
+    // limit, as opposed to 1.3 MiB).
     #[test]
     fn test_apply_mutations_delta_near_max_chunkable_len_when_chunking_is_enabled() {
         let _restore_on_drop = temporarily_enable_chunkifying_large_values();

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1237,6 +1237,21 @@ mod tests {
         apply_mutations_skip_invariant_checks(&mut registry, mutations);
     }
 
+    // This is like the previous test, except that the mutation is approx 7.6x
+    // larger (closer to the 10 MiB limit, as opposed to 1.3 MiB).
+    #[test]
+    fn test_apply_mutations_delta_near_max_chunkable_len_when_chunking_is_enabled() {
+        let _restore_on_drop = temporarily_enable_chunkifying_large_values();
+
+        let mut registry = Registry::new();
+
+        let key = b"key";
+        let too_large_value = vec![0; MAX_CHUNKABLE_ATOMIC_MUTATION_LEN - 100];
+        let mutations = vec![upsert(key, too_large_value)];
+
+        apply_mutations_skip_invariant_checks(&mut registry, mutations);
+    }
+
     #[test]
     #[should_panic(expected = "Mutation too large. First key =")]
     fn test_apply_mutations_too_large_even_when_chunking_is_enabled() {

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1266,7 +1266,9 @@ mod tests {
     // This is like the previous test
     // (test_apply_mutations_delta_not_too_large_when_chunking_is_enabled),
     // except that the mutation is approx close to 10 MiB limit, as opposed to
-    // 1.3 MiB.
+    // 1.3 MiB. Since these numbers are in the same regime (i.e. they are both
+    // chunkable), the outcome should be (more or less) the same: the mutation
+    // gets successfully applied (or at least, without panic).
     #[test]
     fn test_apply_mutations_delta_near_max_chunkable_len_when_chunking_is_enabled() {
         let _restore_on_drop = temporarily_enable_chunkifying_large_values();

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -1413,7 +1413,9 @@ mod tests {
             vec![insert(b"no_need_for_chunking_here_57", vec![57; 1024])],
         );
 
-        // Step 2: Run the code under test: Do a round-trip.
+        // Step 2: Run the code under test: Do a serialize-deserialize
+        // round-trip, like the canister does during an upgrade (in pre- and
+        // post- upgrade).
         let mut restored_registry = Registry::new();
         restored_registry.from_serializable_form(original_registry.serializable_form());
 

--- a/rs/registry/canister/src/registry.rs
+++ b/rs/registry/canister/src/registry.rs
@@ -878,10 +878,8 @@ mod tests {
         // ` - 100` is applied here.
         let version = 1;
         let key = b"this_is_large_but_not_chunkified";
-        let large_but_not_chunkified_mutation = upsert(
-            key,
-            vec![42; max_mutation_value_size(version, key) - 100],
-        );
+        let large_but_not_chunkified_mutation =
+            upsert(key, vec![42; max_mutation_value_size(version, key) - 100]);
 
         let not_large_mutation = upsert(b"this_is_small_but_not_completely_negligible", [44; 200]);
 
@@ -900,10 +898,7 @@ mod tests {
         // because, that is how long a SHA-256 hash is, but it should not take
         // up much more space than that.
         assert_eq!(registry.count_fitting_deltas(0, 30), 0);
-        assert_eq!(
-            registry.count_fitting_deltas(0, 250),
-            1,
-        );
+        assert_eq!(registry.count_fitting_deltas(0, 250), 1);
 
         // The second mutation (large_but_not_chunkified_mutation) was
         // specifically engineered to take up exactly MAX_REGISTRY_DELTAS_SIZE -


### PR DESCRIPTION
This addresses all `TODO(NNS1-3746)`s by either adding more tests, or enhancing existing ones, now that we have chunking.

All tests ALSO pass [when I enable chunking][enabled] (by setting `IS_CHUNKIFYING_LARGE_VALUES_ENABLED` to `true`), so we should be able to simply flip the flag when the time comes.

[enabled]: https://github.com/dfinity/ic/actions/runs/15134222666?pr=5210

# Very Slightly More Chunking

Since chunking is still disabled in release builds, there is technically, no behavior change here, and so `unreleased_changelog.md` does not need to be updated. However, if chunking WERE enabled, there would be a (small) behavior change: the min chunkable size has been decreased by around 100 bytes.

We never promised that the previous value is EXACTLY EXACTLY EXACTLY when chunking would start happening. Rather, we just tried to avoid chunking as much as possible. With a slightly lower limit, we are still achieving the goal where we "avoid chunking as much as possible". This is because 100 bytes is an extremely small amount compared to the new value, which is (still) around 1_300_000 bytes.

# References

Closes [NNS1-3746].

[NNS1-3746]: https://dfinity.atlassian.net/browse/NNS1-3746