### PR TITLE
test: fix vetKD recovery tests by increasing DKG interval length

### DIFF
--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -44,7 +44,8 @@ use ic_consensus_system_test_utils::{
     },
 };
 use ic_consensus_threshold_sig_system_test_utils::{
-    create_new_subnet_with_keys, make_key_ids_for_all_schemes, run_chain_key_signature_test,
+    create_new_subnet_with_keys, make_key_ids_for_all_idkg_schemes, make_key_ids_for_all_schemes,
+    run_chain_key_signature_test,
 };
 use ic_management_canister_types_private::MasterPublicKeyId;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
@@ -74,7 +75,7 @@ use std::{io::Read, time::Duration};
 use std::{io::Write, path::Path};
 use url::Url;
 
-const DKG_INTERVAL: u64 = 9;
+const DKG_INTERVAL: u64 = 19;
 const NNS_NODES: usize = 4;
 const APP_NODES: usize = 4;
 const UNASSIGNED_NODES: usize = 4;
@@ -98,7 +99,13 @@ pub fn setup(
         .with_dkg_interval_length(Height::from(dkg_interval))
         .add_nodes(nns_nodes);
 
-    let key_ids = make_key_ids_for_all_schemes();
+    // TODO(CON-1471): Enable vetKD in large subnet recovery test once
+    // large registry deltas are supported.
+    let key_ids = if nns_nodes == NNS_NODES_LARGE {
+        make_key_ids_for_all_idkg_schemes()
+    } else {
+        make_key_ids_for_all_schemes()
+    };
 
     let key_configs = key_ids
         .into_iter()
@@ -277,7 +284,13 @@ fn app_subnet_recovery_test(env: TestEnv, cfg: Config) {
         .any(|s| s.subnet_type() == SubnetType::Application);
     assert!(cfg.chain_key >= create_new_subnet);
 
-    let key_ids = make_key_ids_for_all_schemes();
+    // TODO(CON-1471): Enable vetKD in large subnet recovery test once
+    // large registry deltas are supported.
+    let key_ids = if topology_snapshot.root_subnet().nodes().count() == NNS_NODES {
+        make_key_ids_for_all_idkg_schemes()
+    } else {
+        make_key_ids_for_all_schemes()
+    };
     let chain_key_pub_keys = cfg.chain_key.then(|| {
         info!(logger, "Chain key flag set, creating key on NNS.");
         if create_new_subnet {

--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -75,7 +75,7 @@ use std::{io::Read, time::Duration};
 use std::{io::Write, path::Path};
 use url::Url;
 
-const DKG_INTERVAL: u64 = 19;
+const DKG_INTERVAL: u64 = 24;
 const NNS_NODES: usize = 4;
 const APP_NODES: usize = 4;
 const UNASSIGNED_NODES: usize = 4;


### PR DESCRIPTION
The DKG interval of recovery tests is currently set to 9 blocks. After enabling vetKD on NNS we need to perform 6 rounds of DKG however (local/remote DKGs for high/low/vetKD transcripts), with 4 dealings each. Since we include at most one dealing per block, some of these DKG instances are currently failing, leading to flaky or failing tests.

This PR therefore increases the DKG interval to 24. This may be reduced again after we deploy chainkeys on a different subnet other than the NNS (CON-1500).

We additionally disable vetKD on the large recovery test, which can only be re-enabled after large registry deltas are supported.