### PR TITLE
chore: Upload the pocket-ic-server artifact.

### DIFF
--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -42,3 +42,14 @@ jobs:
             --config=ci --config=macos_ci \
             --test_tag_filters="test_macos,test_macos_slow" \
             //packages/pocket-ic/... //rs/... //publish/binaries/...
+
+          mkdir -p build
+          cp \
+            ./bazel-bin/rs/pocket_ic_server/pocket-ic-server \
+            ./build/pocket-ic-server-arm64-darwin
+
+      - name: Upload pocket-ic-server
+        uses: actions/upload-artifact@v4
+        with:
+          name: pocket-ic-server-arm64-darwin
+          path: ./build/pocket-ic-server-arm64-darwin


### PR DESCRIPTION
Upload the pocket-ic-server artifact for Arm64-Darwin.