### PR TITLE
chore: Refactor `take_canister_snapshot` 

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1447,75 +1447,39 @@ impl CanisterManager {
         state: &mut ReplicatedState,
         round_limits: &mut RoundLimits,
         resource_saturation: &ResourceSaturation,
-    ) -> (
-        Result<CanisterSnapshotResponse, CanisterManagerError>,
-        NumInstructions,
-    ) {
+    ) -> Result<(CanisterSnapshotResponse, NumInstructions), CanisterManagerError> {
         // Check sender is a controller.
-        if let Err(err) = validate_controller(canister, &sender) {
-            return (Err(err), NumInstructions::new(0));
-        };
+        validate_controller(canister, &sender)?;
 
         let replace_snapshot_size = match replace_snapshot {
-            // Check that replace snapshot ID exists if provided.
-            Some(replace_snapshot) => {
-                match state.canister_snapshots.get(replace_snapshot) {
-                    None => {
-                        // If not found, the operation fails due to invalid parameters.
-                        return (
-                            Err(CanisterManagerError::CanisterSnapshotNotFound {
-                                canister_id: canister.canister_id(),
-                                snapshot_id: replace_snapshot,
-                            }),
-                            NumInstructions::new(0),
-                        );
-                    }
-                    Some(snapshot) => {
-                        // Verify the provided replacement snapshot belongs to this canister.
-                        if snapshot.canister_id() != canister.canister_id() {
-                            return (
-                                Err(CanisterManagerError::CanisterSnapshotInvalidOwnership {
-                                    canister_id: canister.canister_id(),
-                                    snapshot_id: replace_snapshot,
-                                }),
-                                NumInstructions::new(0),
-                            );
-                        }
-                        snapshot.size()
-                    }
-                }
+            Some(replace_snapshot_id) => {
+                self.get_replace_snapshot_size(canister, replace_snapshot_id, state)?
             }
-            // No replace snapshot ID provided, check whether the maximum number of snapshots
-            // has been reached.
             None => {
+                // No replace snapshot ID provided, check whether the maximum number of snapshots
+                // has been reached.
                 if state
                     .canister_snapshots
                     .count_by_canister(&canister.canister_id())
                     >= self.config.max_number_of_snapshots_per_canister
                 {
-                    return (
-                        Err(CanisterManagerError::CanisterSnapshotLimitExceeded {
-                            canister_id: canister.canister_id(),
-                            limit: self.config.max_number_of_snapshots_per_canister,
-                        }),
-                        NumInstructions::new(0),
-                    );
+                    return Err(CanisterManagerError::CanisterSnapshotLimitExceeded {
+                        canister_id: canister.canister_id(),
+                        limit: self.config.max_number_of_snapshots_per_canister,
+                    });
                 }
-                0.into()
+                NumBytes::new(0)
             }
         };
 
         if self.config.rate_limiting_of_heap_delta == FlagStatus::Enabled
             && canister.scheduler_state.heap_delta_debit >= self.config.heap_delta_rate_limit
         {
-            return (
-                Err(CanisterManagerError::CanisterHeapDeltaRateLimited {
-                    canister_id: canister.canister_id(),
-                    value: canister.scheduler_state.heap_delta_debit,
-                    limit: self.config.heap_delta_rate_limit,
-                }),
-                NumInstructions::new(0),
-            );
+            return Err(CanisterManagerError::CanisterHeapDeltaRateLimited {
+                canister_id: canister.canister_id(),
+                value: canister.scheduler_state.heap_delta_debit,
+                limit: self.config.heap_delta_rate_limit,
+            });
         }
 
         let new_snapshot_size = canister.snapshot_size_bytes();
@@ -1525,19 +1489,14 @@ impl CanisterManager {
             .memory_usage()
             .saturating_add(&new_snapshot_size)
             .saturating_sub(&replace_snapshot_size);
-        let validated_memory_usage = match self.memory_usage_checks(
+        let validated_memory_usage = self.memory_usage_checks(
             subnet_size,
             canister,
             round_limits,
             new_memory_usage,
             old_memory_usage,
             resource_saturation,
-        ) {
-            Ok(validated_memory_usage) => validated_memory_usage,
-            Err(err) => {
-                return (Err(err), NumInstructions::from(0));
-            }
-        };
+        )?;
 
         // Charge for taking a snapshot of the canister.
         let instructions = self
@@ -1545,47 +1504,27 @@ impl CanisterManager {
             .canister_snapshot_baseline_instructions
             .saturating_add(&new_snapshot_size.get().into());
 
-        if let Err(err) = self.cycles_account_manager.consume_cycles_for_instructions(
-            &sender,
-            canister,
-            instructions,
-            subnet_size,
-            // For the `take_canister_snapshot` operation, it does not matter if this is a Wasm64 or Wasm32 module
-            // since the number of instructions charged depends on constant set fee and snapshot size
-            // and Wasm64 does not bring any additional overhead for this operation.
-            // The only overhead is during execution time.
-            WasmExecutionMode::Wasm32,
-        ) {
-            return (
-                Err(CanisterManagerError::CanisterSnapshotNotEnoughCycles(err)),
-                0.into(),
-            );
-        };
+        // TODO [EXC-2046]: Split into 'check' and 'perform'
+        self.cycles_account_manager
+            .consume_cycles_for_instructions(
+                &sender,
+                canister,
+                instructions,
+                subnet_size,
+                // For the `take_canister_snapshot` operation, it does not matter if this is a Wasm64 or Wasm32 module
+                // since the number of instructions charged depends on constant set fee and snapshot size
+                // and Wasm64 does not bring any additional overhead for this operation.
+                // The only overhead is during execution time.
+                WasmExecutionMode::Wasm32,
+            )
+            .map_err(CanisterManagerError::CanisterSnapshotNotEnoughCycles)?;
 
         // Create new snapshot.
-        let new_snapshot = match CanisterSnapshot::from_canister(canister, state.time())
-            .map_err(CanisterManagerError::from)
-        {
-            Ok(s) => s,
-            Err(err) => return (Err(err), instructions),
-        };
+        let new_snapshot = CanisterSnapshot::from_canister(canister, state.time())
+            .map_err(CanisterManagerError::from)?;
 
-        // Delete old snapshot identified by `replace_snapshot` ID.
         if let Some(replace_snapshot) = replace_snapshot {
-            state.delete_snapshot(replace_snapshot);
-            canister.system_state.snapshots_memory_usage = canister
-                .system_state
-                .snapshots_memory_usage
-                .get()
-                .saturating_sub(replace_snapshot_size.get())
-                .into();
-            // Confirm that `snapshots_memory_usage` is updated correctly.
-            debug_assert_eq!(
-                canister.system_state.snapshots_memory_usage,
-                state
-                    .canister_snapshots
-                    .compute_memory_usage_by_canister(canister.canister_id()),
-            );
+            self.remove_snapshot(canister, replace_snapshot, state, replace_snapshot_size);
         }
 
         self.memory_usage_updates(canister, round_limits, validated_memory_usage);
@@ -1608,14 +1547,46 @@ impl CanisterManager {
             .system_state
             .snapshots_memory_usage
             .saturating_add(&new_snapshot_size);
-        (
-            Ok(CanisterSnapshotResponse::new(
+
+        Ok((
+            CanisterSnapshotResponse::new(
                 &snapshot_id,
                 state.time().as_nanos_since_unix_epoch(),
                 new_snapshot_size,
-            )),
+            ),
             instructions,
-        )
+        ))
+    }
+
+    /// Returns the size of the snapshot that is to be replaced.
+    /// Returns an error if the snapshot given by the snapshot ID does not
+    /// belong to this canister.
+    fn get_replace_snapshot_size(
+        &self,
+        canister: &mut CanisterState,
+        replace_snapshot: SnapshotId,
+        state: &mut ReplicatedState,
+    ) -> Result<NumBytes, CanisterManagerError> {
+        // Check that replace snapshot ID exists if provided.
+        match state.canister_snapshots.get(replace_snapshot) {
+            None => {
+                // If not found, the operation fails due to invalid parameters.
+                Err(CanisterManagerError::CanisterSnapshotNotFound {
+                    canister_id: canister.canister_id(),
+                    snapshot_id: replace_snapshot,
+                })
+            }
+            Some(snapshot) => {
+                // Verify the provided replacement snapshot belongs to this canister.
+                if snapshot.canister_id() != canister.canister_id() {
+                    return Err(CanisterManagerError::CanisterSnapshotInvalidOwnership {
+                        canister_id: canister.canister_id(),
+                        snapshot_id: replace_snapshot,
+                    });
+                }
+                Ok(snapshot.size())
+            }
+        }
     }
 
     pub(crate) fn load_canister_snapshot(
@@ -2057,6 +2028,31 @@ impl CanisterManager {
             }
         };
         res.map(ReadCanisterSnapshotDataResponse::new)
+    }
+
+    /// Remove the snapshot to be replaced and increase the subnet's available memory.
+    fn remove_snapshot(
+        &self,
+        canister: &mut CanisterState,
+        snapshot_id: SnapshotId,
+        state: &mut ReplicatedState,
+        snapshot_size: NumBytes,
+    ) {
+        // Delete old snapshot identified by `replace_snapshot` ID.
+        state.delete_snapshot(snapshot_id);
+        canister.system_state.snapshots_memory_usage = canister
+            .system_state
+            .snapshots_memory_usage
+            .get()
+            .saturating_sub(snapshot_size.get())
+            .into();
+        // Confirm that `snapshots_memory_usage` is updated correctly.
+        debug_assert_eq!(
+            canister.system_state.snapshots_memory_usage,
+            state
+                .canister_snapshots
+                .compute_memory_usage_by_canister(canister.canister_id()),
+        );
     }
 }
 

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -2328,7 +2328,7 @@ impl ExecutionEnvironment {
         let resource_saturation =
             self.subnet_memory_saturation(&round_limits.subnet_available_memory);
         let replace_snapshot = args.replace_snapshot();
-        let (result, instructions_used) = self.canister_manager.take_canister_snapshot(
+        let result = self.canister_manager.take_canister_snapshot(
             subnet_size,
             sender,
             &mut canister,
@@ -2341,8 +2341,8 @@ impl ExecutionEnvironment {
         state.put_canister_state(canister);
 
         match result {
-            Ok(response) => (Ok(response.encode()), instructions_used),
-            Err(err) => (Err(err.into()), instructions_used),
+            Ok((response, instructions_used)) => (Ok(response.encode()), instructions_used),
+            Err(err) => (Err(err.into()), NumInstructions::new(0)),
         }
     }
 


### PR DESCRIPTION
This PR refactors some code, preparing for the snapshot up/download PR which reuses some of this code. 
The PR also simplifies error handling, because on Error, we can just not charge instructions. Previously, there was one code path that lead to instruction charging on error, but since that returns very early without significant computation, it's fine to also charge zero instructions there (`CanisterSnapshot::from_canister`).