### PR TITLE
fix: repro-check formatting issues

### DIFF
--- a/ci/tools/repro-check
+++ b/ci/tools/repro-check
@@ -220,7 +220,7 @@ def progress(
         done_width = size - progress_width
         if prev_progress_width != progress_width:
             print(
-                f"{pre}[{'█'*progress_width}{('.'*done_width)}]{post}",
+                f"{pre}[{'█' * progress_width}{('.' * done_width)}]{post}",
                 end="\r",
                 file=out,
                 flush=True,
@@ -230,7 +230,7 @@ def progress(
     def callme(progress: float) -> None:
         if sys.stderr.isatty() and len(progress_hidden) == 0:
             if progress >= 1.0:
-                print(f"\r{' '*(termsize())}", end="\r", flush=True, file=out)
+                print(f"\r{' ' * (termsize())}", end="\r", flush=True, file=out)
             else:
                 show(progress)
 
@@ -263,11 +263,7 @@ def fetch_url_to_file(url: str, dest_path: Path) -> Path:
                         return Path
         if length is not None and length != sofar:
             raise RuntimeError(
-                "Error downloading %s -> %s. File is supposed to be %s bytes, is %s bytes.",
-                url,
-                dest_path,
-                length,
-                sofar,
+                f"Error downloading {url} -> {dest_path}. File is supposed to be {length} bytes, is {sofar} bytes."
             )
         tmp_file.rename(dest_path)
         logger.info("Downloaded %s to %s", url, dest_path)
@@ -275,7 +271,7 @@ def fetch_url_to_file(url: str, dest_path: Path) -> Path:
     except Exception as e:
         if tmp_file.is_file():
             tmp_file.unlink()
-        raise RuntimeError("Could not download %s -> %s. Error: %s", url, dest_path, e)
+        raise RuntimeError(f"Could not download {url} -> {dest_path}. Error: {e}")
 
 
 # ------------------------------------------------------------------------------
@@ -637,6 +633,7 @@ class ReproducibilityVerifier:
             if not keep_temp and tmpdir.exists():
                 logger.debug("Cleaning up temporary directory.")
                 shutil.rmtree(tmpdir)
+
         out_dir = tmpdir / "disk-images" / self.git_hash
 
         yield Dirs(


### PR DESCRIPTION
This PR aligns formatting logic in python repro check script. On top of that it fixes the issue of message formatting in case of an error.

Before this fix the formatting looked like:
```bash
##### GUESTOS SHA256SUMS #####
8d4b680b40db56e909f17fbabf26a15f66b144c46f47efb4cf8c2a0285bb8faf disk-img.tar.zst
f35e46220f30def12ab42404a84b6e42a355db08aacb6bb568b3638b722e98e9 update-img-test.tar.zst
2e88687e9f7f45b35f2aec88520ab9417eb21237b9eb5f9083fde4f607085e92 update-img.tar.zst
##### HOSTOS SHA256SUMS #####
dbf44296c2c2067cbcef7426a292ab80b5da471f95dd02d0e16904944969f1c0 disk-img.tar.zst
96c73b9996a5ef8acaa3c4379b286cd0c676ae8cee0203c1c16fcae82c3969e2 update-img-test.tar.zst
6a2e6dfb7ec02a65755ed7fd283df64f5a717a157d666f1a09575d30332efabf update-img.tar.zst
##### SETUPOS SHA256SUMS #####
00ab0cd45d9634eb8b8cdfc1b882b3016d781569cb685e41b446f02249d6fdd6 disk-img.tar.zst
Build complete for revision 23a9496f7eb6d2be9c66a1f994d3b8721dfb3a80
2025/05/19 | 09:12:07 | 1747645927 [ℹ️] IC-OS build complete.
2025/05/19 | 09:12:07 | 1747645927 [ℹ️] Verifying locally built artifacts against remote CDN artifacts.
2025/05/19 | 09:12:07 | 1747645927 [💥] ('Could not download %s -> %s. Error: %s', 'https://download.dfinity.systems/ic/23a9496f7eb6d2be9c66a1f994d3b8721dfb3a80/guest-os/update-img/update-img.tar.zst', PosixPath('/home/nicolas/.cache/repro-check/23a9496f7eb6d2be9c66a1f994d3b8721dfb3a80/download.dfinity.systems/guest-os/update-img.tar.zst'), <HTTPError 404: 'Not Found'>)
```