### PR TITLE
fix(IDX): add missing images and upload suffix

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -164,6 +164,7 @@ upload_artifacts(
         "//ic-os/boundary-guestos/envs/prod:bundle",
         "//ic-os/guestos/envs/dev:bundle-disk",
         "//ic-os/guestos/envs/dev:bundle-update",
+        "//ic-os/guestos/envs/prod:bundle",
         "//ic-os/hostos/envs/prod:bundle",
         "//ic-os/setupos/envs/prod:bundle",
     ],

--- a/ic-os/guestos/envs/dev/BUILD.bazel
+++ b/ic-os/guestos/envs/dev/BUILD.bazel
@@ -21,7 +21,7 @@ artifact_bundle(
     name = "bundle-disk",
     testonly = True,
     inputs = [icos_images.disk_image],
-    prefix = "guest-os/disk-img",
+    prefix = "guest-os/disk-img-dev",
     visibility = ["//visibility:public"],
 )
 
@@ -29,6 +29,6 @@ artifact_bundle(
     name = "bundle-update",
     testonly = True,
     inputs = [icos_images.update_image],
-    prefix = "guest-os/update-img",
+    prefix = "guest-os/update-img-dev",
     visibility = ["//visibility:public"],
 )

--- a/ic-os/guestos/envs/prod/BUILD.bazel
+++ b/ic-os/guestos/envs/prod/BUILD.bazel
@@ -34,4 +34,5 @@ artifact_bundle(
     name = "bundle",
     inputs = [":prod"],
     prefix = "guest-os/update-img",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This fixes the ic-os image upload:

* Adds the `prod` variant of the `guestos`
* Adds a suffix for `dev` images

Without those, the `prod` guestos was not uploaded, and `dev` images might override `prod` images -- although those never got uploaded.