### PR TITLE
fix: disable the pocket-ic-server tests on x86_64-darwin

### DIFF
--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -211,8 +211,7 @@ rust_test(
         "requires-network",
         "test_macos",
     ],
-    # We temporarily disable the test on x86_64-darwin because the HTTP server of the pocket-ic-server on that platform
-    # returns an unexpected 400 Bad Request error on the /instances endpoint.
+    # We temporarily disable the test on x86_64-darwin because the hyper HTTP client runs into issues on that platform.
     target_compatible_with = select({
         "@platforms//os:osx": ["@platforms//cpu:arm64"],
         "//conditions:default": [],
@@ -274,8 +273,7 @@ rust_test(
         "requires-network",
         "test_macos",
     ],
-    # We temporarily disable the test on x86_64-darwin because the HTTP server of the pocket-ic-server on that platform
-    # returns an unexpected 400 Bad Request error on the /instances endpoint.
+    # We temporarily disable the test on x86_64-darwin because the hyper HTTP client runs into issues on that platform.
     target_compatible_with = select({
         "@platforms//os:osx": ["@platforms//cpu:arm64"],
         "//conditions:default": [],


### PR DESCRIPTION
This temporarily disables the pocket-ic-server tests on x86_64-darwin because the hyper HTTP client runs into issues on that platform under bazel with rust-1.86.0 (not with cargo and not with older rusts). An issue is being filed at https://github.com/hyperium/hyper with a minimal reproducible case.