### PR TITLE
fix(node): grub syntax error

### DIFF
--- a/ic-os/bootloader/grub.cfg
+++ b/ic-os/bootloader/grub.cfg
@@ -47,7 +47,7 @@ elif [ "${boot_cycle}" = "first_boot" ]; then
     save_env boot_alternative boot_cycle
     BOOT_STATE=upgrade
 elif [ "${boot_cycle}" = "failsafe_check" ]; then
-    if [ "${boot_alternative}" = "A"]; then
+    if [ "${boot_alternative}" = "A" ]; then
         set boot_alternative=B
     else
         set boot_alternative=A

--- a/ic-os/hostos/grub.cfg
+++ b/ic-os/hostos/grub.cfg
@@ -47,7 +47,7 @@ elif [ "${boot_cycle}" = "first_boot" ]; then
     save_env boot_alternative boot_cycle
     BOOT_STATE=upgrade
 elif [ "${boot_cycle}" = "failsafe_check" ]; then
-    if [ "${boot_alternative}" = "A"]; then
+    if [ "${boot_alternative}" = "A" ]; then
         set boot_alternative=B
     else
         set boot_alternative=A


### PR DESCRIPTION
NODE-1603

We encountered a case where a node was supposed to be rolling back from A to B, but it instead "rolled back" from A to A. This PR resolves the syntax error causing this.