### PR TITLE
chore: EXC-2033: Add benchmark readme and comments

### DIFF
--- a/rs/embedders/benches/compilation.rs
+++ b/rs/embedders/benches/compilation.rs
@@ -1,3 +1,12 @@
+//! This benchmark runs nightly in CI, and the results are available in Grafana.
+//! See: `schedule-rust-bench.yml`
+//!
+//! To run the benchmark locally:
+//!
+//! ```shell
+//! bazel run //rs/embedders:compilation_bench
+//! ```
+
 use candid::Encode;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 

--- a/rs/embedders/benches/heap.rs
+++ b/rs/embedders/benches/heap.rs
@@ -1,4 +1,4 @@
-//! This benchmark runs periodically in CI, and the results are available in Grafana.
+//! This benchmark runs nightly in CI, and the results are available in Grafana.
 //! See: `schedule-rust-bench.yml`
 //!
 //! To run the benchmark locally:
@@ -6,6 +6,7 @@
 //! ```shell
 //! bazel run //rs/embedders:heap_bench
 //! ```
+
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use embedders_bench::SetupAction;
 use ic_replicated_state::canister_state::WASM_PAGE_SIZE_IN_BYTES;

--- a/rs/embedders/benches/stable_memory.rs
+++ b/rs/embedders/benches/stable_memory.rs
@@ -1,3 +1,12 @@
+//! This benchmark runs nightly in CI, and the results are available in Grafana.
+//! See: `schedule-rust-bench.yml`
+//!
+//! To run the benchmark locally:
+//!
+//! ```shell
+//! bazel run //rs/embedders:stable_memory_bench
+//! ```
+
 use candid::Encode;
 use criterion::{criterion_group, criterion_main, Criterion};
 use embedders_bench::SetupAction;

--- a/rs/execution_environment/benches/README.md
+++ b/rs/execution_environment/benches/README.md
@@ -1,46 +1,111 @@
 Execution Benchmarks
 ====================
 
+This directory contains Execution Environment benchmarks, along with scripts
+to run them and baseline results for comparing new changes.
+
 Quick Start
 -----------
 
 1. To run all benchmarks and compare them to the committed baseline:
 
-    ```sh
-    ./rs/execution_environment/benches/run-all-benchmarks.sh | tee summary.txt
-    ```
+   ```sh
+   ./rs/execution_environment/benches/run-all-benchmarks.sh | tee summary.txt
+   ```
 
-    The summary will be generated in the `summary.txt` file.
+   The summary will be generated in the `summary.txt` file.
+
+   To run only the Embedders Heap benchmarks for `wasm32` query reads:
+
+   ```sh
+   INCLUDE=heap FILTER=wasm32_query_read ./rs/execution_environment/benches/run-all-benchmarks.sh
+   ```
 
 2. To update the baseline:
 
-    ```sh
-    cp *.min rs/execution_environment/benches/baseline
-    git add rs/execution_environment/benches/baseline/*
-    git commit -m "Update benches baseline"
-    ```
+   ```sh
+   ls *.min | while read name; do cp -v ${name} rs/execution_environment/benches/baseline/${name%@*.min}.min; done
+   git add rs/execution_environment/benches/baseline/*
+   git commit -m "Update benches baseline"
+   ```
 
-Adding a New Benchmark
-----------------------
+Which benchmarks to run?
+------------------------
+
+The Execution Environment benchmarks cover the following:
+
+1. Embedders Compilation: `//rs/embedders:compilation_bench`
+
+   Benchmarks for compiling and running synthetic and real-world canisters.
+   Useful for assessing compilation-related changes and real-world application performance.
+
+2. Embedders Heap: `//rs/embedders:heap_bench`
+
+   Benchmarks for heavy memory operations on the heap.
+   Useful for assessing memory subsystem changes.
+
+3. Embedders Stable Memory: `//rs/embedders:stable_memory_bench`
+
+   Benchmarks for heavy stable memory operations.
+   Useful for assessing stable memory changes.
+
+4. System API benchmarks: `//rs/execution_environment:execute_update_bench`, etc.
+
+   Several benchmark suites to assess System API performance in various execution modes.
+   Useful for assessing System API-related changes.
+
+5. Wasm Instructions: `//rs/execution_environment:wasm_instructions_bench`
+
+   Benchmarks to assign a cost for each Wasm instruction.
+   Should be run after every wasmtime upgrade and when adding new Wasm instructions.
+
+6. Load simulator canister benchmarks: `//rs/execution_environment:load_simulator_canisters_bench`
+
+   Simulates load on a subnet by running many Rust `load_simulator_canister`s.
+   Benchmark's throughput roughly corresponds to the subnet finalization rate.
+   Useful for assessing scheduler changes, canister sandbox improvements, etc.
+
+All of these are primarily micro-benchmarks, allowing for quick development iterations.
+However, it's important to run final benchmarks on a testnet.
+
+The [subnet-load-tester](https://github.com/dfinity/subnet-load-tester) can be used
+to run scenarios on a production-like testnet.
+
+Where to run the benchmarks?
+----------------------------
+
+Both the baseline results and new change benchmarks should be run on the same host.
+The benchmark scripts enforce this and will not compare results produced on
+different hosts.
+
+The best candidates for running the benchmarks are the `zh1-spm34` or `dm1-dll46` hosts.
+
+Adding New Benchmarks
+---------------------
 
 1. Create a new benchmark and test it with `bazel run ...`.
 
-2. To integrate the new benchmark into the CI pipeline:
+2. To test the new benchmark in every CI pipeline run:
 
-    ```Starlark
-    rust_ic_bench(
-        name = "my_new_bench",
-        with_test = True,
-        [...]
-    )
-    ```
+   ```Starlark
+   rust_ic_bench(
+      name = "my_new_bench",
+      with_test = True,
+      [...]
+   )
+   ```
 
-    Note, a single benchmark iteration should run in a reasonable amount of time:
+   Note: a single benchmark iteration should run in a reasonable amount of time:
 
-    ```sh
-    bazel run //rs/execution_environment:my_new_bench -- --test
-    ```
+   ```sh
+   bazel run //rs/execution_environment:my_new_bench -- --test
+   ```
 
 3. To include the new benchmark in the comparison:
 
-   Edit script: `rs/execution_environment/benches/run-all-benchmarks.sh`
+   Edit the script: `rs/execution_environment/benches/run-all-benchmarks.sh`
+
+4. To run the benchmark nightly in CI and track the results in Grafana:
+
+   Edit the file: `.github/workflows/schedule-rust-bench.yml`
+   Add a Grafana dashboard: [example PR](https://github.com/dfinity-ops/k8s/pull/1100)

--- a/rs/execution_environment/benches/run-benchmark.sh
+++ b/rs/execution_environment/benches/run-benchmark.sh
@@ -4,6 +4,9 @@ set -ue
 ## Helper script to run the specified `BENCH`
 ## and store the best (minimum) results in the `MIN_FILE`.
 ##
+## Please use the top-level `run-all-benchmarks.sh` to run all or just
+## some benchmarks.
+##
 
 DEPENDENCIES="awk bash bazel rg sed tail tee"
 which ${DEPENDENCIES} >/dev/null || (echo "Error checking dependencies: ${DEPENDENCIES}" >&2 && exit 1)

--- a/rs/execution_environment/benches/summarize-results.sh
+++ b/rs/execution_environment/benches/summarize-results.sh
@@ -4,6 +4,9 @@ set -ue
 ## Helper script to summarize the results in the `MIN_FILE`
 ## comparing them to the `BASELINE_DIR` results.
 ##
+## Please use the top-level `run-all-benchmarks.sh` to run all or just
+## some benchmarks.
+##
 
 DEPENDENCIES="awk rg sed"
 which ${DEPENDENCIES} >/dev/null || (echo "Error checking dependencies: ${DEPENDENCIES}" >&2 && exit 1)

--- a/rs/execution_environment/benches/system_api/execute_inspect_message.rs
+++ b/rs/execution_environment/benches/system_api/execute_inspect_message.rs
@@ -1,6 +1,14 @@
-///
-/// Benchmark System API performance in `execute_inspect_message()`
-///
+//! Benchmark System API performance in `execute_inspect_message()`.
+//!
+//! This benchmark runs nightly in CI, and the results are available in Grafana.
+//! See: `schedule-rust-bench.yml`
+//!
+//! To run the benchmark locally:
+//!
+//! ```shell
+//! bazel run //rs/execution_environment:execute_inspect_message_bench
+//! ```
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use execution_environment_bench::{common, wat::*};
 use ic_execution_environment::execution::inspect_message;

--- a/rs/execution_environment/benches/system_api/execute_query.rs
+++ b/rs/execution_environment/benches/system_api/execute_query.rs
@@ -1,6 +1,14 @@
-///
-/// Benchmark System API performance in `execute_query()`
-///
+//! Benchmark System API performance in `execute_query()`.
+//!
+//! This benchmark runs nightly in CI, and the results are available in Grafana.
+//! See: `schedule-rust-bench.yml`
+//!
+//! To run the benchmark locally:
+//!
+//! ```shell
+//! bazel run //rs/execution_environment:execute_query_bench
+//! ```
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use execution_environment_bench::{common, wat::*};
 use ic_execution_environment::{

--- a/rs/execution_environment/benches/system_api/execute_update.rs
+++ b/rs/execution_environment/benches/system_api/execute_update.rs
@@ -1,6 +1,14 @@
-///
-/// Benchmark System API performance in `execute_update()`.
-///
+//! Benchmark System API performance in `execute_update()`.
+//!
+//! This benchmark runs nightly in CI, and the results are available in Grafana.
+//! See: `schedule-rust-bench.yml`
+//!
+//! To run the benchmark locally:
+//!
+//! ```shell
+//! bazel run //rs/execution_environment:execute_update_bench
+//! ```
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use execution_environment_bench::{common, wat::*};
 use ic_error_types::ErrorCode;

--- a/rs/execution_environment/benches/wasm_instructions/main.rs
+++ b/rs/execution_environment/benches/wasm_instructions/main.rs
@@ -1,10 +1,14 @@
 //!
 //! Benchmark Wasm instructions using `execute_update()`.
 //!
+//! This benchmark runs nightly in CI, and the results are available in Grafana.
+//! See: `schedule-rust-bench.yml`
+//!
 //! To run a specific benchmark:
 //!
-//!     bazel run //rs/execution_environment:wasm_instructions_bench -- --sample-size 10 i32.div
-//!
+//! ```shell
+//! bazel run //rs/execution_environment:wasm_instructions_bench -- --sample-size 10 i32.div
+//! ```
 
 use std::time::Duration;
 


### PR DESCRIPTION
This PR updated execution environment benchmarks in the `README.md` file and adds a few comments. No functional changes.