### PR TITLE
fix(PSEC-2557): Improve error handling of periodic job

### DIFF
--- a/ci/src/dependencies/scanner/dependency_scanner.py
+++ b/ci/src/dependencies/scanner/dependency_scanner.py
@@ -175,7 +175,10 @@ class DependencyScanner:
                 )
                 for subscriber in self.subscribers:
                     subscriber.on_scan_job_failed(
-                        self.dependency_manager.get_scanner_id() + f"_{repository.name}", ScannerJobType.PERIODIC_SCAN, self.job_id, str(err)
+                        self.dependency_manager.get_scanner_id() + f"_{repository.name}",
+                        ScannerJobType.PERIODIC_SCAN,
+                        self.job_id,
+                        str(err),
                     )
         for subscriber in self.subscribers:
             subscriber.on_scan_job_succeeded(

--- a/ci/src/dependencies/scanner/dependency_scanner_test.py
+++ b/ci/src/dependencies/scanner/dependency_scanner_test.py
@@ -342,7 +342,7 @@ def test_on_periodic_job_failure(jira_lib_mock):
 
     fake_bazel = Mock()
     fake_bazel.get_findings.side_effect = OSError("Call failed")
-    fake_bazel.get_scanner_id.return_value = 'BAZEL_RUST'
+    fake_bazel.get_scanner_id.return_value = "BAZEL_RUST"
 
     scanner_job = DependencyScanner(fake_bazel, jira_lib_mock, [sub1, sub2])
     repos = [Repository("ic", "https://github.com/dfinity/ic", [Project("ic", __test_get_ic_path())])]


### PR DESCRIPTION
Currently the periodic job fails if scanning of a single repo fails. This should be improved such that scanning continues.