### PR TITLE
fix: Use correct arguments for stable_read in WatCanisterBuilder

### DIFF
--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -5138,11 +5138,7 @@ fn install_does_not_reserve_cycles_on_system_subnet() {
     test.install_canister(
         canister_id,
         wat_canister()
-            .init(
-                wat_fn()
-                    .stable_grow((USAGE / WASM_PAGE_SIZE_IN_BYTES) as i32 - 1)
-                    .stable_read(0, 42),
-            )
+            .init(wat_fn().stable_grow((USAGE / WASM_PAGE_SIZE_IN_BYTES) as i32 - 1))
             .build_wasm(),
     )
     .unwrap();

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -503,7 +503,7 @@ fn test_canister_log_record_index_increment_after_node_restart() {
 fn test_logging_in_trapped_wasm_execution() {
     let (env, canister_id, controller) = setup_with_controller(
         wat_canister()
-            .update("test", wat_fn().stable_grow(1).stable_read(0, 70_000))
+            .update("test", wat_fn().stable_grow(1).stable_read(0, 0, 70_000))
             .build_wasm(),
     );
     // advance time so that time does not grow implicitly when executing a round

--- a/rs/test_utilities/execution_environment/src/wat_canister.rs
+++ b/rs/test_utilities/execution_environment/src/wat_canister.rs
@@ -16,7 +16,7 @@ const MEMORY_LIMIT: i32 = 64 * 1_024;
 
 enum FnCall {
     StableGrow(i32),
-    StableRead(i32, i32),
+    StableRead(i32, i32, i32),
     GlobalTimerSet(i64),
     DebugPrint(Vec<u8>),
     Trap(Vec<u8>),
@@ -46,8 +46,8 @@ impl WatFnCode {
     }
 
     /// Call the `ic0.stable_read` function.
-    pub fn stable_read(mut self, offset: i32, size: i32) -> Self {
-        self.calls.push(FnCall::StableRead(offset, size));
+    pub fn stable_read(mut self, dst: i32, offset: i32, size: i32) -> Self {
+        self.calls.push(FnCall::StableRead(dst, offset, size));
         self
     }
 
@@ -112,14 +112,14 @@ impl WatCall {
         Self {
             func: "ic0_stable_grow".to_string(),
             params: vec![WatConst::I32(new_pages)],
-            drop_result: false,
+            drop_result: true,
         }
     }
 
-    fn stable_read(offset: i32, size: i32) -> Self {
+    fn stable_read(dst: i32, offset: i32, size: i32) -> Self {
         Self {
             func: "ic0_stable_read".to_string(),
-            params: vec![WatConst::I32(offset), WatConst::I32(size)],
+            params: vec![WatConst::I32(dst), WatConst::I32(offset), WatConst::I32(size)],
             drop_result: false,
         }
     }
@@ -473,7 +473,7 @@ impl WatCanisterBuilder {
             .iter()
             .map(|call| match call {
                 FnCall::StableGrow(new_pages) => WatCall::stable_grow(*new_pages),
-                FnCall::StableRead(offset, size) => WatCall::stable_read(*offset, *size),
+                FnCall::StableRead(dst, offset, size) => WatCall::stable_read(*dst, *offset, *size),
                 FnCall::GlobalTimerSet(timestamp) => WatCall::global_timer_set(*timestamp),
                 FnCall::DebugPrint(message) => {
                     WatCall::debug_print(self.get_memory_offset(message), message.len() as i32)
@@ -509,11 +509,11 @@ mod tests {
         let test_cases = vec![
             (
                 WatCall::stable_grow(7),
-                "(call $ic0_stable_grow (i32.const 7))",
+                "(drop (call $ic0_stable_grow (i32.const 7)))",
             ),
             (
-                WatCall::stable_read(4, 7),
-                "(call $ic0_stable_read (i32.const 4) (i32.const 7))",
+                WatCall::stable_read(0, 4, 7),
+                "(call $ic0_stable_read (i32.const 0) (i32.const 4) (i32.const 7))",
             ),
             (
                 WatCall::global_timer_set(42),
@@ -684,7 +684,7 @@ mod tests {
                 name: "test".to_string(),
                 calls: vec![
                     WatCall::stable_grow(1),
-                    WatCall::stable_read(4, 7),
+                    WatCall::stable_read(0, 4, 7),
                     WatCall::global_timer_set(1),
                     WatCall::debug_print(0, 4),
                     WatCall::trap(10, 4),
@@ -694,8 +694,8 @@ mod tests {
             .to_string(),
             r#"
             (func $test (export "canister_update test")
-                (call $ic0_stable_grow (i32.const 1))
-                (call $ic0_stable_read (i32.const 4) (i32.const 7))
+                (drop (call $ic0_stable_grow (i32.const 1)))
+                (call $ic0_stable_read (i32.const 0) (i32.const 4) (i32.const 7))
                 (drop (call $ic0_global_timer_set (i64.const 1)))
                 (call $ic0_debug_print (i32.const 0) (i32.const 4))
                 (call $ic0_trap (i32.const 10) (i32.const 4))

--- a/rs/test_utilities/execution_environment/src/wat_canister.rs
+++ b/rs/test_utilities/execution_environment/src/wat_canister.rs
@@ -119,7 +119,11 @@ impl WatCall {
     fn stable_read(dst: i32, offset: i32, size: i32) -> Self {
         Self {
             func: "ic0_stable_read".to_string(),
-            params: vec![WatConst::I32(dst), WatConst::I32(offset), WatConst::I32(size)],
+            params: vec![
+                WatConst::I32(dst),
+                WatConst::I32(offset),
+                WatConst::I32(size),
+            ],
             drop_result: false,
         }
     }


### PR DESCRIPTION
The arguments used for `stable_read` in WatCanisterBuilder were incorrect, basically missing the `dst` argument. This meant that `stable_read` actually depended on a `stable_grow` to exist before it so that it can use its return value as one of the arguments. While this may be acceptable (how can you read before growing your memory first?), it also creates the reverse dependency. If one uses a `stable_grow` only, it will leave one operand on the stack and the resulting wasm module would be invalid.

One fix (which is what this PR proposes) is to always drop the result of `stable_grow` -- in a test utility it's not particularly useful anyway, most of the time the test would expect to succeed and even if it wants to fail, this can (and should be) tested outside the Wasm module (e.g. by inspecting the canister's state in the test). This means that `stable_read` would also need to be fixed to accept 3 arguments as per the [interface spec](https://internetcomputer.org/docs/references/ic-interface-spec#system-api-stable-memory).