### PR TITLE
test: don't use API BN in nested systests

### DIFF
--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -48,7 +48,6 @@ pub fn config(env: TestEnv) {
         .with_required_host_features(vec![HostFeature::DC("dm1".to_string())])
         .add_fast_single_node_subnet(SubnetType::System)
         // .with_mainnet_config() TODO: uncomment in NODE-1518
-        .with_api_boundary_nodes(1)
         .with_node_provider(principal)
         .with_node_operator(principal)
         .setup_and_start(&env)

--- a/rs/tests/nested/src/util.rs
+++ b/rs/tests/nested/src/util.rs
@@ -22,7 +22,6 @@ use ic_system_test_driver::{
 use ic_types::{hostos_version::HostosVersion, NodeId};
 
 use slog::info;
-use url::Url;
 
 /// Use an SSH channel to check the version on the running HostOS.
 pub(crate) fn check_hostos_version(node: &NestedVm) -> String {

--- a/rs/tests/nested/src/util.rs
+++ b/rs/tests/nested/src/util.rs
@@ -113,26 +113,19 @@ pub(crate) fn setup_nested_vm(env: TestEnv, name: &str) {
             .expect("Unable to write nested VM.");
     }
 
-    let api_boundary_node = env
+    let nns_url = env
         .topology_snapshot()
-        .api_boundary_nodes()
+        .root_subnet()
+        .nodes()
         .next()
-        .expect("No API BN present");
-    let api_bn_url = Url::parse(&format!("https://[{}]/", api_boundary_node.get_ip_addr()))
-        .expect("Could not parse Url");
+        .expect("No NNS node present")
+        .get_public_url();
 
     let nns_public_key =
         std::fs::read_to_string(env.prep_dir("").unwrap().root_public_key_path()).unwrap();
 
-    setup_nested_vms(
-        &nodes,
-        &env,
-        &farm,
-        &group_name,
-        &api_bn_url,
-        &nns_public_key,
-    )
-    .expect("Unable to setup nested VMs.");
+    setup_nested_vms(&nodes, &env, &farm, &group_name, &nns_url, &nns_public_key)
+        .expect("Unable to setup nested VMs.");
 }
 
 pub(crate) fn start_nested_vm(env: TestEnv) {


### PR DESCRIPTION
In production IC nodes connect directly to NNS nodes instead of going via API BNs. Let's reflect this in the nested system-tests as well.