### PR TITLE
Fix: disable https in the proxy client if the http flag is true.

### DIFF
--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -137,11 +137,17 @@ impl CanisterHttp {
         http_connector
             .set_connect_timeout(Some(Duration::from_secs(self.http_connect_timeout_secs)));
 
+        let builder = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .expect("Failed to set native roots");
+
+        #[cfg(not(feature = "http"))]
+        let builder = builder.https_only();
+        #[cfg(feature = "http")]
+        let builder = builder.https_or_http();
+
         Client::builder(TokioExecutor::new()).build::<_, Full<Bytes>>(
-            HttpsConnectorBuilder::new()
-                .with_native_roots()
-                .expect("Failed to set native roots")
-                .https_only()
+            builder
                 .enable_all_versions()
                 .wrap_connector(SocksConnector {
                     proxy_addr,

--- a/rs/rust_canisters/proxy_canister/BUILD.bazel
+++ b/rs/rust_canisters/proxy_canister/BUILD.bazel
@@ -13,6 +13,7 @@ rust_library(
         "//rs/types/management_canister_types",
         "@crate_index//:candid",
         "@crate_index//:serde",
+        "@crate_index//:ic_cdk_0_17_1",
     ],
 )
 

--- a/rs/rust_canisters/proxy_canister/BUILD.bazel
+++ b/rs/rust_canisters/proxy_canister/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "lib",
+    testonly = True,
     srcs = ["src/lib.rs"],
     crate_name = "proxy_canister",
     version = "0.1.0",
@@ -12,13 +13,14 @@ rust_library(
         # Keep sorted.
         "//rs/types/management_canister_types",
         "@crate_index//:candid",
-        "@crate_index//:serde",
         "@crate_index//:ic_cdk_0_17_1",
+        "@crate_index//:serde",
     ],
 )
 
 rust_canister(
     name = "proxy_canister",
+    testonly = True,
     srcs = ["src/main.rs"],
     proc_macro_deps = ["@crate_index//:ic_cdk_macros_0_17_1"],
     service_file = ":empty.did",

--- a/rs/rust_canisters/proxy_canister/src/lib.rs
+++ b/rs/rust_canisters/proxy_canister/src/lib.rs
@@ -8,6 +8,7 @@
 use std::time::Duration;
 
 use candid::{CandidType, Deserialize};
+use ic_cdk::api::call::RejectionCode;
 use ic_management_canister_types_private::{
     BoundedHttpHeaders, HttpHeader, HttpMethod, Payload, TransformContext,
 };
@@ -59,6 +60,24 @@ pub struct RemoteHttpResponse {
     pub status: u128,
     pub headers: Vec<(String, String)>,
     pub body: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct ResponseWithRefundedCycles {
+    pub result: Result<RemoteHttpResponse, (RejectionCode, String)>,
+    pub refunded_cycles: u64,
+}
+
+impl ResponseWithRefundedCycles {
+    pub fn new(
+        result: Result<RemoteHttpResponse, (RejectionCode, String)>,
+        refunded_cycles: u64,
+    ) -> Self {
+        Self {
+            result,
+            refunded_cycles,
+        }
+    }
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]

--- a/rs/rust_canisters/proxy_canister/src/lib.rs
+++ b/rs/rust_canisters/proxy_canister/src/lib.rs
@@ -68,18 +68,6 @@ pub struct ResponseWithRefundedCycles {
     pub refunded_cycles: u64,
 }
 
-impl ResponseWithRefundedCycles {
-    pub fn new(
-        result: Result<RemoteHttpResponse, (RejectionCode, String)>,
-        refunded_cycles: u64,
-    ) -> Self {
-        Self {
-            result,
-            refunded_cycles,
-        }
-    }
-}
-
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct RemoteHttpStressResponse {
     pub response: RemoteHttpResponse,

--- a/rs/rust_canisters/proxy_canister/src/main.rs
+++ b/rs/rust_canisters/proxy_canister/src/main.rs
@@ -180,8 +180,8 @@ async fn send_request(
 async fn send_request_and_retrieve_refund(
     request: RemoteHttpRequest,
 ) -> ResponseWithRefundedCycles {
-    let (result, cycles) = make_http_request_with_refund_callback(request).await;
-    ResponseWithRefundedCycles::new(result, cycles)
+    let (result, refunded_cycles) = make_http_request_with_refund_callback(request).await;
+    ResponseWithRefundedCycles{result, refunded_cycles}
 }
 
 #[query]

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -304,9 +304,8 @@ fn test_non_existent_transform_function(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -470,9 +469,8 @@ fn test_max_possible_request_size_exceeded(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded == HTTP_REQUEST_CYCLE_PAYMENT
+    assert_eq!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -658,9 +656,8 @@ fn test_max_response_bytes_too_large(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded == HTTP_REQUEST_CYCLE_PAYMENT
+    assert_eq!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -724,9 +721,8 @@ fn test_transform_that_bloats_response_above_2mb_limit(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1038,9 +1034,8 @@ fn test_invalid_domain_name(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1075,9 +1070,8 @@ fn test_invalid_ip(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1113,9 +1107,8 @@ fn test_get_hello_world_call(env: TestEnv) {
     let response = response.expect("Request is successful.");
 
     assert_matches!(&response, RemoteHttpResponse {body, status: 200, ..} if body == expected_body);
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
     assert_http_response(&response);
 }
@@ -1155,9 +1148,8 @@ fn test_request_header_total_size_within_the_48_kib_limit(env: TestEnv) {
     let response = response.expect("Request succeeds.");
 
     assert_matches!(&response, RemoteHttpResponse { status: 200, .. });
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1206,9 +1198,8 @@ fn test_request_header_total_size_over_the_48_kib_limit(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded == HTTP_REQUEST_CYCLE_PAYMENT
+    assert_eq!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1240,9 +1231,8 @@ fn test_response_header_total_size_within_the_48_kib_limit(env: TestEnv) {
     ));
 
     assert_matches!(&response, Ok(RemoteHttpResponse { status: 200, .. }));
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 
     // Compute exactly the size of the response headers to account also for overhead.
@@ -1297,9 +1287,8 @@ fn test_response_header_total_size_over_the_48_kib_limit(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1366,9 +1355,8 @@ fn test_request_header_name_too_long(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded == HTTP_REQUEST_CYCLE_PAYMENT
+    assert_eq!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1405,9 +1393,8 @@ fn test_request_header_value_too_long(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded == HTTP_REQUEST_CYCLE_PAYMENT
+    assert_eq!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1471,9 +1458,8 @@ fn test_response_header_name_over_limit(env: TestEnv) {
         })
     );
 
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1540,9 +1526,8 @@ fn test_response_header_value_over_limit(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1723,9 +1708,8 @@ fn test_only_headers_with_custom_max_response_bytes_exceeded(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1766,9 +1750,8 @@ fn test_non_ascii_url_is_rejected(env: TestEnv) {
         })
     );
 
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1840,9 +1823,8 @@ fn test_max_url_length_exceeded(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded == HTTP_REQUEST_CYCLE_PAYMENT
+    assert_eq!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -1968,9 +1950,8 @@ fn test_max_number_of_response_headers_exceeded(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded < HTTP_REQUEST_CYCLE_PAYMENT
+    assert_ne!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -2048,9 +2029,8 @@ fn test_max_number_of_request_headers_exceeded(env: TestEnv) {
             ..
         })
     );
-    assert_matches!(
-        refunded_cycles,
-        RefundedCycles::Cycles(refunded) if refunded == HTTP_REQUEST_CYCLE_PAYMENT
+    assert_eq!(
+        refunded_cycles, RefundedCycles::Cycles(HTTP_REQUEST_CYCLE_PAYMENT) 
     );
 }
 
@@ -2232,13 +2212,17 @@ fn assert_http_json_response(
     );
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 enum RefundedCycles {
     NotApplicable,
     Cycles(u64),
 }
 
 type ProxyCanisterResponseWithRefund = ResponseWithRefundedCycles;
+
+// This type represents the result of an IC http_request and the refunded cycles.
+// The refund is returned regardless of whether the outcall succeeded (Ok) or failed (Err),
+// allowing tests to verify proper cycle refund behavior in both success and error cases.
 type OutcallsResponseWithRefund = (Result<RemoteHttpResponse, RejectResponse>, RefundedCycles);
 
 async fn submit_outcall<Request>(
@@ -2268,6 +2252,7 @@ where
                 }
                 _ => panic!("Unexpected error: {:?}", agent_error),
             };
+            // The 
             (Err(err_resp), RefundedCycles::NotApplicable)
         }
         Ok(serialized_bytes) => {


### PR DESCRIPTION
This is how it should've been before. The only reason it worked was that `https_only` was not really enforced. See here:
https://github.com/rustls/hyper-rustls/pull/295