### PR TITLE
fix: disable https in the proxy client if the http flag is true.

### DIFF
--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -137,11 +137,17 @@ impl CanisterHttp {
         http_connector
             .set_connect_timeout(Some(Duration::from_secs(self.http_connect_timeout_secs)));
 
+        let builder = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .expect("Failed to set native roots");
+
+        #[cfg(not(feature = "http"))]
+        let builder = builder.https_only();
+        #[cfg(feature = "http")]
+        let builder = builder.https_or_http();
+
         Client::builder(TokioExecutor::new()).build::<_, Full<Bytes>>(
-            HttpsConnectorBuilder::new()
-                .with_native_roots()
-                .expect("Failed to set native roots")
-                .https_only()
+            builder
                 .enable_all_versions()
                 .wrap_connector(SocksConnector {
                     proxy_addr,


### PR DESCRIPTION
This is how it should've been before. The only reason it worked was that `https_only` was not really enforced. See here:
https://github.com/rustls/hyper-rustls/pull/295