### PR TITLE
chore: ramp up the new socks proxy discovery to 100%

### DIFF
--- a/rs/https_outcalls/adapter/src/rpc_server.rs
+++ b/rs/https_outcalls/adapter/src/rpc_server.rs
@@ -50,8 +50,8 @@ const MAX_HEADER_LIST_SIZE: u32 = 52 * 1024;
 /// The maximum number of times we will try to connect to a SOCKS proxy.
 const MAX_SOCKS_PROXY_TRIES: usize = 2;
 
-/// TODO(NET-1765): Make this 100.
-const NEW_SOCKS_PROXY_ROLLOUT: u32 = 50;
+/// TODO(NET-1765): Inline this constant into the code and remove the feature flag.
+const NEW_SOCKS_PROXY_ROLLOUT: u32 = 100;
 
 type OutboundRequestBody = Full<Bytes>;
 


### PR DESCRIPTION
![Screenshot 2025-05-21 at 13 26 37](https://github.com/user-attachments/assets/86fd1a07-e8a3-445c-8be9-49d763ba9739)
![Screenshot 2025-05-21 at 13 26 53](https://github.com/user-attachments/assets/a75410bd-a658-40d3-8622-46168347b5bb)

This PR makes all http requests from system subnets that fail via the direct path go via the an API BN as a socks proxy.

The 50% data is looking stable, with constant QPS, very low failures, and overall performance similar to the old gateways