### PR TITLE
feat(governance): Added `use ic_cdk::println;` to files that lack it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10913,6 +10913,7 @@ name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
 dependencies = [
  "ic-base-types",
+ "ic-cdk 0.17.2",
  "maplit",
  "pretty_assertions",
  "tokio",
@@ -11025,6 +11026,7 @@ name = "ic-neurons-fund"
 version = "0.0.1"
 dependencies = [
  "assert_matches",
+ "ic-cdk 0.17.2",
  "ic-nervous-system-common",
  "lazy_static",
  "proptest 1.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12163,6 +12163,7 @@ name = "ic-registry-node-provider-rewards"
 version = "0.9.0"
 dependencies = [
  "ic-base-types",
+ "ic-cdk 0.17.2",
  "ic-protobuf",
  "maplit",
  "pretty_assertions",

--- a/rs/nervous_system/neurons_fund/BUILD.bazel
+++ b/rs/nervous_system/neurons_fund/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 DEPENDENCIES = [
     # Keep sorted.
     "//rs/nervous_system/common",
+    "@crate_index//:ic-cdk",
     "@crate_index//:lazy_static",
     "@crate_index//:rust_decimal",
     "@crate_index//:serde",

--- a/rs/nervous_system/neurons_fund/Cargo.toml
+++ b/rs/nervous_system/neurons_fund/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 name = "ic_neurons_fund"
 
 [dependencies]
+ic-cdk = { workspace = true }
 ic-nervous-system-common = { path = "../../nervous_system/common" }
 lazy_static = { workspace = true }
 rust_decimal = "1.36.0"

--- a/rs/nervous_system/neurons_fund/src/lib.rs
+++ b/rs/nervous_system/neurons_fund/src/lib.rs
@@ -8,6 +8,7 @@
 
 use std::num::NonZeroU64;
 
+use ic_cdk::println;
 use ic_nervous_system_common::{binary_search, E8};
 use rust_decimal::{
     prelude::{FromPrimitive, ToPrimitive},

--- a/rs/nervous_system/neurons_fund/src/polynomial_matching_function_tests.rs
+++ b/rs/nervous_system/neurons_fund/src/polynomial_matching_function_tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::{DeserializableFunction, SerializableFunction, E8};
 use assert_matches::assert_matches;
-use ic_nervous_system_common::WIDE_RANGE_OF_U64_VALUES;
 use ic_cdk::println;
+use ic_nervous_system_common::WIDE_RANGE_OF_U64_VALUES;
 use lazy_static::lazy_static;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;

--- a/rs/nervous_system/neurons_fund/src/polynomial_matching_function_tests.rs
+++ b/rs/nervous_system/neurons_fund/src/polynomial_matching_function_tests.rs
@@ -1,7 +1,7 @@
+use self::println;
 use super::*;
 use crate::{DeserializableFunction, SerializableFunction, E8};
 use assert_matches::assert_matches;
-use ic_cdk::println;
 use ic_nervous_system_common::WIDE_RANGE_OF_U64_VALUES;
 use lazy_static::lazy_static;
 use rust_decimal::Decimal;

--- a/rs/nervous_system/neurons_fund/src/polynomial_matching_function_tests.rs
+++ b/rs/nervous_system/neurons_fund/src/polynomial_matching_function_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{DeserializableFunction, SerializableFunction, E8};
 use assert_matches::assert_matches;
 use ic_nervous_system_common::WIDE_RANGE_OF_U64_VALUES;
+use ic_cdk::println;
 use lazy_static::lazy_static;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;

--- a/rs/nervous_system/proxied_canister_calls_tracker/BUILD.bazel
+++ b/rs/nervous_system/proxied_canister_calls_tracker/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//rs/nervous_system:default_visibility"])
 DEPENDENCIES = [
     # Keep sorted.
     "//rs/types/base_types",
+    "@crate_index//:ic-cdk",
 ]
 
 DEV_DEPENDENCIES = [

--- a/rs/nervous_system/proxied_canister_calls_tracker/Cargo.toml
+++ b/rs/nervous_system/proxied_canister_calls_tracker/Cargo.toml
@@ -8,6 +8,7 @@ documentation.workspace = true
 
 [dependencies]
 ic-base-types = { path = "../../types/base_types" }
+ic-cdk = { workspace = true }
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/rs/nervous_system/proxied_canister_calls_tracker/src/lib.rs
+++ b/rs/nervous_system/proxied_canister_calls_tracker/src/lib.rs
@@ -1,4 +1,5 @@
 use ic_base_types::{CanisterId, PrincipalId};
+use ic_cdk::println;
 use std::{
     cell::RefCell,
     collections::BTreeMap,

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -6,8 +6,10 @@ use environment::Environment;
 use exchange_rate_canister::{
     RealExchangeRateCanisterClient, UpdateExchangeRateError, UpdateExchangeRateState,
 };
-use ic_cdk::api::call::{arg_data_raw, reply_raw, CallResult, ManualReply};
-use ic_cdk::{heartbeat, init, post_upgrade, pre_upgrade, query, spawn, update};
+use ic_cdk::{
+    api::call::{arg_data_raw, reply_raw, CallResult, ManualReply},
+    heartbeat, init, post_upgrade, pre_upgrade, println, query, spawn, update,
+};
 use ic_crypto_tree_hash::{
     flatmap, HashTreeBuilder, HashTreeBuilderImpl, Label, LabeledTree, WitnessGenerator,
     WitnessGeneratorImpl,

--- a/rs/nns/governance/src/garbage_collection.rs
+++ b/rs/nns/governance/src/garbage_collection.rs
@@ -2,6 +2,7 @@ use crate::{
     governance::{Governance, LOG_PREFIX},
     pb::v1::{ProposalData, Topic},
 };
+use ic_cdk::println;
 use lazy_static::lazy_static;
 use maplit::hashset;
 use std::collections::{HashMap, HashSet};

--- a/rs/nns/governance/src/governance/disburse_maturity.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity.rs
@@ -10,6 +10,7 @@ use crate::{
     },
 };
 
+use ic_cdk::println;
 use ic_nervous_system_common::{E8, ONE_DAY_SECONDS};
 use ic_nervous_system_governance::maturity_modulation::{
     apply_maturity_modulation, MIN_MATURITY_MODULATION_PERMYRIAD,
@@ -499,7 +500,7 @@ pub async fn finalize_maturity_disbursement(
     match try_finalize_maturity_disbursement(governance).await {
         Ok(_) => governance.with_borrow(get_delay_until_next_finalization),
         Err(err) => {
-            ic_cdk::println!("FinalizeMaturityDisbursementTask failed: {}", err);
+            println!("FinalizeMaturityDisbursementTask failed: {}", err);
             RETRY_INTERVAL
         }
     }

--- a/rs/nns/governance/src/governance/tla/mod.rs
+++ b/rs/nns/governance/src/governance/tla/mod.rs
@@ -16,6 +16,7 @@ pub use tla_instrumentation::checker::{check_tla_code_link, PredicateDescription
 
 use std::path::PathBuf;
 
+use ic_cdk::println;
 use icp_ledger::Subaccount;
 mod common;
 mod store;

--- a/rs/nns/governance/src/governance/voting_power_snapshots.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots.rs
@@ -51,8 +51,7 @@ fn insert_and_truncate<Value: Storable>(
         eprintln!(
             "{}Somehow the voting power snapshot is taken multiple times at \
 	            the same timestamp {}",
-            LOG_PREFIX,
-            timestamp_seconds,
+            LOG_PREFIX, timestamp_seconds,
         );
     }
 
@@ -177,8 +176,7 @@ impl VotingPowerSnapshots {
             eprintln!(
                 "{}Voting power map not found for timestamp {} while the totals \
                 are found. This should not happen.",
-                LOG_PREFIX,
-                timestamp_with_minimum_total_potential_voting_power,
+                LOG_PREFIX, timestamp_with_minimum_total_potential_voting_power,
             );
             return None;
         };

--- a/rs/nns/governance/src/governance/voting_power_snapshots.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots.rs
@@ -5,6 +5,7 @@ use crate::{
     pb::v1::{Ballot, NeuronIdToVotingPowerMap, VotingPowerTotal},
 };
 
+use ic_cdk::eprintln;
 use ic_nervous_system_common::ONE_MONTH_SECONDS;
 use ic_stable_structures::{
     memory_manager::VirtualMemory, storable::Bound, DefaultMemoryImpl, StableBTreeMap, Storable,
@@ -47,7 +48,7 @@ fn insert_and_truncate<Value: Storable>(
     // Log if we just clobbered an existing entry, because it is a exceedingly unlikely
     // that this would happen in practice.
     if let Some(existing_value) = existing_value {
-        ic_cdk::eprintln!(
+        eprintln!(
             "{}Somehow the voting power snapshot is taken multiple times at \
 	            the same timestamp {}",
             LOG_PREFIX,
@@ -161,7 +162,7 @@ impl VotingPowerSnapshots {
             total_potential_voting_power,
         )
         else {
-            ic_cdk::eprintln!(
+            eprintln!(
                 "{}Voting power totals are empty. No voting power spike detected.",
                 LOG_PREFIX,
             );
@@ -173,7 +174,7 @@ impl VotingPowerSnapshots {
             .neuron_id_to_voting_power_maps
             .get(&timestamp_with_minimum_total_potential_voting_power)
         else {
-            ic_cdk::eprintln!(
+            eprintln!(
                 "{}Voting power map not found for timestamp {} while the totals \
                 are found. This should not happen.",
                 LOG_PREFIX,

--- a/rs/nns/governance/src/neuron_lock.rs
+++ b/rs/nns/governance/src/neuron_lock.rs
@@ -28,6 +28,7 @@ use crate::{
     },
 };
 
+use ic_cdk::println;
 use ic_nns_common::pb::v1::NeuronId;
 use std::{cell::RefCell, collections::hash_map::Entry, thread::LocalKey};
 

--- a/rs/nns/governance/src/neurons_fund.rs
+++ b/rs/nns/governance/src/neurons_fund.rs
@@ -1,6 +1,7 @@
 //! Implementation of NNS Governance-specific functions for Matched Funding.
 
 use ic_base_types::PrincipalId;
+use ic_cdk::println;
 use ic_nervous_system_governance::maturity_modulation::BASIS_POINTS_PER_UNITY;
 use ic_nervous_system_proto::pb::v1::{Decimal as DecimalPb, Percentage as PercentagePb};
 use ic_neurons_fund::{

--- a/rs/nns/governance/src/neurons_fund/neurons_fund_participation_tests.rs
+++ b/rs/nns/governance/src/neurons_fund/neurons_fund_participation_tests.rs
@@ -1,3 +1,4 @@
+use self::println;
 use super::*;
 use ic_neurons_fund::test_functions::SimpleLinearFunction;
 

--- a/rs/nns/governance/src/neurons_fund/neurons_fund_participation_tests.rs
+++ b/rs/nns/governance/src/neurons_fund/neurons_fund_participation_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ic_cdk::println;
 use ic_neurons_fund::test_functions::SimpleLinearFunction;
 
 fn nid(id: u64) -> NeuronId {

--- a/rs/nns/governance/src/neurons_fund/neurons_fund_participation_tests.rs
+++ b/rs/nns/governance/src/neurons_fund/neurons_fund_participation_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use ic_cdk::println;
 use ic_neurons_fund::test_functions::SimpleLinearFunction;
 
 fn nid(id: u64) -> NeuronId {

--- a/rs/nns/governance/src/proposals/mod.rs
+++ b/rs/nns/governance/src/proposals/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     pb::v1::{governance_error::ErrorType, GovernanceError, ProposalData, Topic, Vote},
 };
 use ic_base_types::CanisterId;
+use ic_cdk::println;
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_constants::{PROTOCOL_CANISTER_IDS, SNS_AGGREGATOR_CANISTER_ID, SNS_WASM_CANISTER_ID};
 use std::collections::HashMap;

--- a/rs/nns/governance/src/reward/distribution.rs
+++ b/rs/nns/governance/src/reward/distribution.rs
@@ -4,6 +4,7 @@ use crate::pb::v1::RewardsDistributionInProgress;
 use crate::storage::with_rewards_distribution_state_machine_mut;
 #[cfg(not(feature = "canbench-rs"))]
 use crate::timer_tasks::run_distribute_rewards_periodic_task;
+use ic_cdk::println;
 use ic_nervous_system_long_message::is_message_over_threshold;
 use ic_nns_common::pb::v1::NeuronId;
 use ic_stable_structures::storable::Bound;

--- a/rs/nns/governance/src/timer_tasks/calculate_distributable_rewards.rs
+++ b/rs/nns/governance/src/timer_tasks/calculate_distributable_rewards.rs
@@ -1,6 +1,7 @@
 use crate::governance::{Governance, LOG_PREFIX, REWARD_DISTRIBUTION_PERIOD_SECONDS};
 use crate::pb::v1::GovernanceError;
 use async_trait::async_trait;
+use ic_cdk::println;
 use ic_nervous_system_timer_task::RecurringAsyncTask;
 use std::cell::RefCell;
 use std::thread::LocalKey;
@@ -60,7 +61,7 @@ impl RecurringAsyncTask for CalculateDistributableRewardsTask {
                 });
             }
             Err(err) => {
-                ic_cdk::println!(
+                println!(
                     "{}Error when getting total ICP supply: {}",
                     LOG_PREFIX,
                     GovernanceError::from(err)

--- a/rs/nns/governance/src/timer_tasks/seeding.rs
+++ b/rs/nns/governance/src/timer_tasks/seeding.rs
@@ -1,6 +1,7 @@
 use crate::governance::{Governance, LOG_PREFIX};
 use async_trait::async_trait;
 use candid::{Decode, Encode};
+use ic_cdk::println;
 use ic_management_canister_types_private::IC_00;
 use ic_nervous_system_timer_task::RecurringAsyncTask;
 use std::{cell::RefCell, thread::LocalKey, time::Duration};

--- a/rs/nns/governance/src/voting.rs
+++ b/rs/nns/governance/src/voting.rs
@@ -4,6 +4,7 @@ use crate::{
     pb::v1::{Ballot, ProposalData, Topic, Topic::NeuronManagement, Vote},
     storage::with_voting_state_machines_mut,
 };
+use ic_cdk::{eprintln, println};
 #[cfg(not(any(test, feature = "canbench-rs")))]
 use ic_nervous_system_long_message::is_message_over_threshold;
 #[cfg(test)]

--- a/rs/registry/canister-client/src/stable_canister_client.rs
+++ b/rs/registry/canister-client/src/stable_canister_client.rs
@@ -175,8 +175,7 @@ impl<S: RegistryDataStableMemory> CanisterRegistryClient for StableCanisterRegis
                 Ordering::Less => {
                     println!(
                         "Registry version local {} < remote {}",
-                        current_local_version,
-                        remote_latest_version
+                        current_local_version, remote_latest_version
                     );
                 }
                 Ordering::Equal => {

--- a/rs/registry/canister-client/src/stable_canister_client.rs
+++ b/rs/registry/canister-client/src/stable_canister_client.rs
@@ -1,6 +1,7 @@
 use crate::stable_memory::{RegistryDataStableMemory, StorableRegistryKey, StorableRegistryValue};
 use crate::CanisterRegistryClient;
 use async_trait::async_trait;
+use ic_cdk::println;
 use ic_interfaces_registry::{
     empty_zero_registry_record, RegistryClientResult, RegistryClientVersionedResult,
     RegistryTransportRecord, ZERO_REGISTRY_VERSION,
@@ -172,14 +173,14 @@ impl<S: RegistryDataStableMemory> CanisterRegistryClient for StableCanisterRegis
 
             match current_local_version.cmp(&remote_latest_version) {
                 Ordering::Less => {
-                    ic_cdk::println!(
+                    println!(
                         "Registry version local {} < remote {}",
                         current_local_version,
                         remote_latest_version
                     );
                 }
                 Ordering::Equal => {
-                    ic_cdk::println!(
+                    println!(
                         "Local Registry version {} is up to date",
                         current_local_version
                     );

--- a/rs/registry/canister/src/certification.rs
+++ b/rs/registry/canister/src/certification.rs
@@ -19,6 +19,7 @@
 
 #[cfg(target_arch = "wasm32")]
 use dfn_core::api::set_certified_data;
+#[cfg(all(not(target_arch = "wasm32"), test))]
 use ic_cdk::println;
 use ic_certified_map::{labeled, HashTree};
 use ic_protobuf::messaging::xnet::v1 as pb;

--- a/rs/registry/canister/src/certification.rs
+++ b/rs/registry/canister/src/certification.rs
@@ -19,6 +19,7 @@
 
 #[cfg(target_arch = "wasm32")]
 use dfn_core::api::set_certified_data;
+use ic_cdk::println;
 use ic_certified_map::{labeled, HashTree};
 use ic_protobuf::messaging::xnet::v1 as pb;
 

--- a/rs/registry/canister/src/mutations/do_update_node_rewards_table.rs
+++ b/rs/registry/canister/src/mutations/do_update_node_rewards_table.rs
@@ -1,5 +1,6 @@
 use crate::{common::LOG_PREFIX, registry::Registry};
 
+use ic_cdk::println;
 use ic_protobuf::registry::node_rewards::v2::{
     NodeRewardsTable, UpdateNodeRewardsTableProposalPayload,
 };

--- a/rs/registry/canister/src/mutations/subnet.rs
+++ b/rs/registry/canister/src/mutations/subnet.rs
@@ -9,6 +9,7 @@ use dfn_core::call;
 use ic_base_types::{
     subnet_id_into_protobuf, CanisterId, NodeId, PrincipalId, RegistryVersion, SubnetId,
 };
+use ic_cdk::println;
 use ic_management_canister_types_private::{
     MasterPublicKeyId, ReshareChainKeyArgs, ReshareChainKeyResponse,
 };

--- a/rs/registry/node_provider_rewards/BUILD.bazel
+++ b/rs/registry/node_provider_rewards/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 DEPENDENCIES = [
     "//rs/types/base_types",
     "//rs/protobuf",
+    "@crate_index//:ic-cdk",
 ]
 
 DEV_DEPENDENCIES = [

--- a/rs/registry/node_provider_rewards/Cargo.toml
+++ b/rs/registry/node_provider_rewards/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 
 [dependencies]
 ic-base-types = { path = "../../types/base_types/" }
+ic-cdk = { workspace = true }
 ic-protobuf = { path = "../../protobuf" }
 
 [dev-dependencies]

--- a/rs/registry/node_provider_rewards/src/logs.rs
+++ b/rs/registry/node_provider_rewards/src/logs.rs
@@ -1,4 +1,5 @@
 use ic_base_types::PrincipalId;
+use ic_cdk::println;
 use std::fmt::Write;
 
 pub type RegionNodeTypeCategory = (String, String);

--- a/rs/sns/audit/BUILD.bazel
+++ b/rs/sns/audit/BUILD.bazel
@@ -26,8 +26,8 @@ DEPENDENCIES = [
 
 rust_library(
     name = "audit",
-    crate_name = "ic_sns_audit",
     srcs = ["src/lib.rs"],
+    crate_name = "ic_sns_audit",
     deps = DEPENDENCIES,
 )
 

--- a/rs/sns/audit/BUILD.bazel
+++ b/rs/sns/audit/BUILD.bazel
@@ -25,7 +25,7 @@ DEPENDENCIES = [
 ]
 
 rust_library(
-    name = "ic-sns-audit",
+    name = "audit",
     srcs = ["src/lib.rs"],
     deps = DEPENDENCIES,
 )
@@ -34,7 +34,7 @@ rust_binary(
     name = "sns-audit",
     srcs = ["src/main.rs"],
     deps = DEPENDENCIES + [
-        ":ic-sns-audit",
+        ":audit",
         "@crate_index//:anyhow",
     ],
 )

--- a/rs/sns/audit/BUILD.bazel
+++ b/rs/sns/audit/BUILD.bazel
@@ -26,6 +26,7 @@ DEPENDENCIES = [
 
 rust_library(
     name = "audit",
+    crate_name = "ic_sns_audit",
     srcs = ["src/lib.rs"],
     deps = DEPENDENCIES,
 )

--- a/rs/sns/root/src/lib.rs
+++ b/rs/sns/root/src/lib.rs
@@ -13,7 +13,6 @@ use candid::{Decode, Encode, Nat};
 use futures::{future::join_all, join};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_canister_log::log;
-use ic_cdk::eprintln;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
     canister_status::CanisterStatusResultV2,
@@ -880,6 +879,7 @@ async fn get_owned_canister_summary(
 mod tests {
     use super::*;
     use crate::pb::v1::{set_dapp_controllers_request::CanisterIds, ListSnsCanistersResponse};
+    use ic_cdk::eprintln;
     use ic_nervous_system_clients::{
         canister_status::CanisterStatusResultFromManagementCanister,
         management_canister_client::{

--- a/rs/sns/root/src/lib.rs
+++ b/rs/sns/root/src/lib.rs
@@ -879,7 +879,6 @@ async fn get_owned_canister_summary(
 mod tests {
     use super::*;
     use crate::pb::v1::{set_dapp_controllers_request::CanisterIds, ListSnsCanistersResponse};
-    use ic_cdk::eprintln;
     use ic_nervous_system_clients::{
         canister_status::CanisterStatusResultFromManagementCanister,
         management_canister_client::{

--- a/rs/sns/root/src/lib.rs
+++ b/rs/sns/root/src/lib.rs
@@ -13,6 +13,7 @@ use candid::{Decode, Encode, Nat};
 use futures::{future::join_all, join};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_canister_log::log;
+use ic_cdk::eprintln;
 use ic_nervous_system_clients::{
     canister_id_record::CanisterIdRecord,
     canister_status::CanisterStatusResultV2,
@@ -1373,7 +1374,7 @@ mod tests {
         .await;
 
         // Step 3: Inspect results.
-        ic_cdk::eprintln!(
+        eprintln!(
             "Should have panicked: {result:#?}, {:#?}",
             SNS_ROOT_CANISTER.with(|c| c.clone())
         );


### PR DESCRIPTION
Ditto for `eprintln`.

The effect of this is that logging from canisters does NOT go into a black hole.

# Resolving `println` Ambiguity

In `tests` modules, our usual thing is to do

```
use super::*;
```

If the parent module does `use whatever::println;`, and the `tests` module calls `println`, Rust says that it does not know which version of `println` we are trying to call. To disambiguate, the `tests` module can do

```
use self::println;
```

to say that it wants the normal version of `println`. This is done in some of the `tests` modules here.

# Adding Dependencies

In some cases, this also required adding `ic-cdk` to `DEPENDENCIES` (ditto for `Cargo.toml`, ofc).

# Identifying Affected Files

How I figured out which files should be changed:

```
grep -rl println! rs/nns rs/nervous_system rs/sns \
  | xargs grep -L "use .*println" \
  | grep -v tests \
  | sort
```

Ofc, this is imperfect. In particular, if a file does (something like) this:

```
use ic_cdk::{
    println,
};
```

then, the above command will think that the file needs to be changed when actually, it's already ok.

Another case that the above command does handle super well:

```
ic_cdk::println!("Hello, world!");
```

In this case, it is not strictly necessary to change the file, but since the above command identifies these cases as problemmatic, I took the opportunity to normalize these as well. That is, I changed such cases to

```
use ic_cdk::println;

...

println!("Hello, world!");
```