### PR TITLE
chore: update team name to governance-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,7 +93,7 @@ go_deps.bzl               @dfinity/idx
 /testnet/docs/                                             @dfinity/ic-support
 /testnet/env/                                              @dfinity/platform-operations
 /testnet/release/                                          @dfinity/dre
-/testnet/tools/nns-tools/                                  @dfinity/nns-team
+/testnet/tools/nns-tools/                                  @dfinity/governance-team
 
 # [Rust]
 /rs/                                                    @dfinity/ic-interface-owners
@@ -148,7 +148,7 @@ go_deps.bzl               @dfinity/idx
 /rs/interfaces/                                         @dfinity/ic-interface-owners
 /rs/interfaces/adapter_client/                          @dfinity/consensus
 /rs/interfaces/certified_stream_store/                  @dfinity/ic-message-routing-owners
-/rs/interfaces/registry/                                @dfinity/nns-team
+/rs/interfaces/registry/                                @dfinity/governance-team
 /rs/interfaces/src/canister_http.rs                     @dfinity/consensus
 /rs/interfaces/src/consensus.rs                         @dfinity/consensus
 /rs/interfaces/src/consensus_pool.rs                    @dfinity/consensus
@@ -168,9 +168,9 @@ go_deps.bzl               @dfinity/idx
 /rs/monitoring/                                         @dfinity/consensus
 /rs/monitoring/metrics                                  @dfinity/consensus @dfinity/ic-message-routing-owners
 /rs/monitoring/pprof/                                   @dfinity/consensus @dfinity/ic-message-routing-owners
-/rs/nervous_system/                                     @dfinity/nns-team
-/rs/nns/                                                @dfinity/nns-team
-/rs/node_rewards/                                       @dfinity/nns-team @dfinity/dre
+/rs/nervous_system/                                     @dfinity/governance-team
+/rs/nns/                                                @dfinity/governance-team
+/rs/node_rewards/                                       @dfinity/governance-team @dfinity/dre
 /rs/orchestrator/                                       @dfinity/consensus
 /rs/orchestrator/src/hostos_upgrade.rs                  @dfinity/consensus @dfinity/node
 /rs/p2p/                                                @dfinity/consensus
@@ -182,17 +182,17 @@ go_deps.bzl               @dfinity/idx
 /rs/protobuf/def/crypto/                                @dfinity/crypto-team
 /rs/protobuf/def/messaging/                             @dfinity/ic-message-routing-owners
 /rs/protobuf/def/p2p/                                   @dfinity/consensus
-/rs/protobuf/def/registry/                              @dfinity/nns-team
+/rs/protobuf/def/registry/                              @dfinity/governance-team
 /rs/protobuf/def/state/                                 @dfinity/execution @dfinity/ic-message-routing-owners
 /rs/protobuf/gen/bitcoin/                               @dfinity/execution
 /rs/protobuf/gen/crypto/                                @dfinity/crypto-team
 /rs/protobuf/gen/messaging/                             @dfinity/ic-message-routing-owners
 /rs/protobuf/gen/p2p/                                   @dfinity/consensus
-/rs/protobuf/gen/registry/                              @dfinity/nns-team
+/rs/protobuf/gen/registry/                              @dfinity/governance-team
 /rs/protobuf/gen/state/                                 @dfinity/execution @dfinity/ic-message-routing-owners
 /rs/query_stats/                                        @dfinity/execution @dfinity/consensus
 /rs/recovery/                                           @dfinity/consensus
-/rs/registry/                                           @dfinity/nns-team
+/rs/registry/                                           @dfinity/governance-team
 /rs/registry/helpers/src/crypto.rs                      @dfinity/crypto-team
 /rs/registry/helpers/src/crypto/                        @dfinity/crypto-team
 /rs/registry/helpers/src/firewall.rs                    @dfinity/consensus
@@ -211,7 +211,7 @@ go_deps.bzl               @dfinity/idx
 /rs/replicated_state/src/page_map.rs                    @dfinity/ic-message-routing-owners @dfinity/execution
 /rs/replicated_state/src/page_map/                      @dfinity/ic-message-routing-owners @dfinity/execution
 /rs/rosetta-api/                                        @dfinity/finint
-/rs/rust_canisters/                                     @dfinity/nns-team
+/rs/rust_canisters/                                     @dfinity/governance-team
 /rs/rust_canisters/backtrace_canister                   @dfinity/execution
 /rs/rust_canisters/call_loop_canister                   @dfinity/execution
 /rs/rust_canisters/memory_test/                         @dfinity/execution
@@ -226,7 +226,7 @@ go_deps.bzl               @dfinity/idx
 /rs/rust_canisters/xnet_test/                           @dfinity/ic-message-routing-owners
 /rs/rust_canisters/downstream_calls_test/               @dfinity/ic-message-routing-owners
 /rs/rust_canisters/random_traffic_test/                 @dfinity/ic-message-routing-owners
-/rs/sns/                                                @dfinity/nns-team
+/rs/sns/                                                @dfinity/governance-team
 /rs/starter/                                            @dfinity/consensus
 /rs/state_layout/                                       @dfinity/ic-message-routing-owners
 /rs/state_machine_tests/                                @dfinity/ic-message-routing-owners @dfinity/pocket-ic
@@ -261,7 +261,7 @@ go_deps.bzl               @dfinity/idx
 /rs/tests/message_routing/                              @dfinity/ic-message-routing-owners
 /rs/tests/nested/                                       @dfinity/node
 /rs/tests/networking/                                   @dfinity/consensus
-/rs/tests/nns/                                          @dfinity/nns-team
+/rs/tests/nns/                                          @dfinity/governance-team
 /rs/tests/node/                                         @dfinity/node
 /rs/tests/query_stats/                                  @dfinity/execution @dfinity/consensus
 /rs/tests/sdk/                                          @dfinity/sdk

--- a/.github/workflows/ci-pr-only-nns-team-reminder.yml
+++ b/.github/workflows/ci-pr-only-nns-team-reminder.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types:
       - review_requested
-      
+
 permissions:
   pull-requests: write
 
@@ -14,11 +14,11 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         id: mainStep
-        # If the PR requires nns-team to approve, GitHub will force nns-team to
+        # If the PR requires governance-team to approve, GitHub will force governance-team to
         # be in requested_teams. Therefore, the following condition is always
-        # met when nns-team must approve. (Further filtering takes place in the
+        # met when governance-team must approve. (Further filtering takes place in the
         # script itself.)
-        if: contains(github.event.pull_request.requested_teams.*.name, 'nns-team')
+        if: contains(github.event.pull_request.requested_teams.*.name, 'governance-team')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           retries: 3

--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -13,7 +13,7 @@
     "InfraSec": "eng-infrasec",
     "languages": "eng-motoko",
     "networking": "eng-networking",
-    "nns-team": "eng-nns-prs",
+    "governance-team": "eng-nns-prs",
     "node": "eng-node-prs",
     "Platform Operations": "eng-platform-ops",
     "pocket-ic": "pocket-ic",


### PR DESCRIPTION
# Motivation

The name of the [nns-team](https://github.com/orgs/dfinity/teams/nns-team) has changed to [governance-team](https://github.com/orgs/dfinity/teams/governance-team). More information can be found [here](https://dfinity.slack.com/archives/CGJND92DA/p1747828796597669?thread_ts=1747671441.856149&cid=CGJND92DA) and [here](https://dfinity.slack.com/archives/CGJND92DA/p1747740057505439).

# Changes

- Update references from the old team name to the new one.

# Tests

Not necessary.