### PR TITLE
chore(cross-chain): remove unused canister_client dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14235,7 +14235,6 @@ dependencies = [
  "futures",
  "hex-literal",
  "ic-base-types",
- "ic-canister-client",
  "ic-cketh-minter",
  "ic-ethereum-types",
  "ic-icrc1-index-ng",

--- a/rs/tests/cross_chain/BUILD.bazel
+++ b/rs/tests/cross_chain/BUILD.bazel
@@ -20,7 +20,6 @@ system_test_nns(
         CANISTER_RUNTIME_DEPS,
     deps = [
         # Keep sorted.
-        "//rs/canister_client",
         "//rs/ethereum/ledger-suite-orchestrator:ledger_suite_orchestrator",
         "//rs/ledger_suite/icrc1/index-ng",
         "//rs/nervous_system/clients",

--- a/rs/tests/cross_chain/Cargo.toml
+++ b/rs/tests/cross_chain/Cargo.toml
@@ -14,7 +14,6 @@ dfn_candid = { path = "../../rust_canisters/dfn_candid" }
 futures = { workspace = true }
 hex-literal = "0.4.1"
 ic-base-types = { path = "../../types/base_types" }
-ic-canister-client = { path = "../../canister_client" }
 ic_consensus_system_test_utils = { path = "../consensus/utils" }
 ic_consensus_threshold_sig_system_test_utils = { path = "../consensus/tecdsa/utils" }
 ic-ethereum-types = { path = "../../../packages/ic-ethereum-types" }


### PR DESCRIPTION
The `canister_client` crate is not very maintained anymore and we would like to avoid its use. The `ic-tests-cross-chain` crate still depends on it but does not actually use it.

This PR simply removes the dependency from the Cargo and Bazel files.