### PR TITLE
chore(governance): Clean up more leftovers from merge_maturity

### DIFF
--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -1206,12 +1206,6 @@ pub mod manage_neuron_response {
             }
         }
 
-        pub fn merge_maturity_response(response: MergeMaturityResponse) -> Self {
-            ManageNeuronResponse {
-                command: Some(manage_neuron_response::Command::MergeMaturity(response)),
-            }
-        }
-
         pub fn stake_maturity_response(response: StakeMaturityResponse) -> Self {
             ManageNeuronResponse {
                 command: Some(manage_neuron_response::Command::StakeMaturity(response)),

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -97,7 +97,7 @@ use ic_nns_constants::{
 };
 use ic_nns_governance_api::{
     self as api,
-    manage_neuron_response::{self, MergeMaturityResponse, StakeMaturityResponse},
+    manage_neuron_response::{self, StakeMaturityResponse},
     proposal_validation,
     subnet_rental::SubnetRentalRequest,
     CreateServiceNervousSystem as ApiCreateServiceNervousSystem, ListNeurons, ListNeuronsResponse,
@@ -2999,7 +2999,7 @@ impl Governance {
         id: &NeuronId,
         caller: &PrincipalId,
         stake_maturity: &manage_neuron::StakeMaturity,
-    ) -> Result<(StakeMaturityResponse, MergeMaturityResponse), GovernanceError> {
+    ) -> Result<StakeMaturityResponse, GovernanceError> {
         let (neuron_state, is_neuron_controlled_by_caller, neuron_maturity_e8s_equivalent) =
             self.with_neuron(id, |neuron| {
                 (
@@ -3050,7 +3050,7 @@ impl Governance {
         let _neuron_lock = self.lock_neuron_for_command(id.id, in_flight_command)?;
 
         // Adjust the maturity of the neuron
-        let responses = self
+        let response = self
             .with_neuron_mut(id, |neuron| {
                 neuron.maturity_e8s_equivalent = neuron
                     .maturity_e8s_equivalent
@@ -3063,22 +3063,15 @@ impl Governance {
                         .saturating_add(maturity_to_stake),
                 );
                 let staked_maturity_e8s = neuron.staked_maturity_e8s_equivalent.unwrap_or(0);
-                let new_stake_e8s = neuron.cached_neuron_stake_e8s + staked_maturity_e8s;
 
-                (
-                    StakeMaturityResponse {
-                        maturity_e8s: neuron.maturity_e8s_equivalent,
-                        staked_maturity_e8s,
-                    },
-                    MergeMaturityResponse {
-                        merged_maturity_e8s: maturity_to_stake,
-                        new_stake_e8s,
-                    },
-                )
+                StakeMaturityResponse {
+                    maturity_e8s: neuron.maturity_e8s_equivalent,
+                    staked_maturity_e8s,
+                }
             })
             .expect("Expected the neuron to exist");
 
-        Ok(responses)
+        Ok(response)
     }
 
     /// Disburse part of the stake of a neuron into a new neuron, possibly
@@ -6239,7 +6232,7 @@ impl Governance {
             Some(Command::MergeMaturity(_)) => Self::merge_maturity_removed_error(),
             Some(Command::StakeMaturity(s)) => self
                 .stake_maturity_of_neuron(&id, caller, s)
-                .map(|(response, _)| ManageNeuronResponse::stake_maturity_response(response)),
+                .map(|response| ManageNeuronResponse::stake_maturity_response(response)),
             Some(Command::Split(s)) => self
                 .split_neuron(&id, caller, s)
                 .await

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6232,7 +6232,7 @@ impl Governance {
             Some(Command::MergeMaturity(_)) => Self::merge_maturity_removed_error(),
             Some(Command::StakeMaturity(s)) => self
                 .stake_maturity_of_neuron(&id, caller, s)
-                .map(|response| ManageNeuronResponse::stake_maturity_response(response)),
+                .map(ManageNeuronResponse::stake_maturity_response),
             Some(Command::Split(s)) => self
                 .split_neuron(&id, caller, s)
                 .await

--- a/rs/nns/governance/src/governance/tests/stake_maturity.rs
+++ b/rs/nns/governance/src/governance/tests/stake_maturity.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use ic_base_types::PrincipalId;
 use ic_nns_common::pb::v1::NeuronId;
-use ic_nns_governance_api::manage_neuron_response::{MergeMaturityResponse, StakeMaturityResponse};
+use ic_nns_governance_api::manage_neuron_response::StakeMaturityResponse;
 use maplit::btreemap;
 use std::sync::Arc;
 
@@ -42,24 +42,16 @@ fn test_stake_maturity() {
     let request = StakeMaturity {
         percentage_to_stake: Some(40),
     };
-    let responses = governance
+
+    let stake_maturity_response = governance
         .stake_maturity_of_neuron(&NeuronId { id: 1 }, &principal_1, &request)
         .expect("Expected call to succeed");
-
-    let (stake_maturity_response, legacy_merge_maturity_response) = responses;
 
     assert_eq!(
         stake_maturity_response,
         StakeMaturityResponse {
             maturity_e8s: 600,
             staked_maturity_e8s: 500
-        }
-    );
-    assert_eq!(
-        legacy_merge_maturity_response,
-        MergeMaturityResponse {
-            merged_maturity_e8s: 400,
-            new_stake_e8s: 523
         }
     );
 }

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -37,10 +37,7 @@ use ic_nns_governance::{
     },
     storage::reset_stable_memory,
 };
-use ic_nns_governance_api::{
-    manage_neuron_response::{self, MergeMaturityResponse},
-    ManageNeuronResponse,
-};
+use ic_nns_governance_api::{manage_neuron_response, ManageNeuronResponse};
 use icp_ledger::{AccountIdentifier, Subaccount, Tokens};
 use rand::{prelude::StdRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -863,36 +860,6 @@ impl NNS {
         summary: String,
     ) -> ProposalId {
         behavior.into().propose_and_vote(self, summary)
-    }
-
-    pub fn merge_maturity(
-        &mut self,
-        id: &NeuronId,
-        controller: &PrincipalId,
-        percentage_to_merge: u32,
-    ) -> Result<MergeMaturityResponse, GovernanceError> {
-        let result = self
-            .governance
-            .manage_neuron(
-                controller,
-                &ManageNeuron {
-                    id: None,
-                    neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(*id)),
-                    command: Some(Command::MergeMaturity(MergeMaturity {
-                        percentage_to_merge,
-                    })),
-                },
-            )
-            .now_or_never()
-            .unwrap()
-            .command
-            .unwrap();
-
-        match result {
-            manage_neuron_response::Command::Error(e) => Err(GovernanceError::from(e)),
-            manage_neuron_response::Command::MergeMaturity(response) => Ok(response),
-            _ => panic!("Merge maturity command returned unexpected response"),
-        }
     }
 
     pub fn merge_neurons(

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -8741,7 +8741,28 @@ fn test_merge_maturity_returns_expected_error() {
     let neuron = nns.get_neuron(&id);
     let controller = *neuron.controller.as_ref().unwrap();
 
-    let result = nns.merge_maturity(&id, &controller, 10);
+    // This is inlined because the method is removed, so we don't need a general purpose test method
+    let result1 = nns
+        .governance
+        .manage_neuron(
+            &controller,
+            &ManageNeuron {
+                id: None,
+                neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(id)),
+                command: Some(Command::MergeMaturity(MergeMaturity {
+                    percentage_to_merge: 10,
+                })),
+            },
+        )
+        .now_or_never()
+        .unwrap()
+        .command
+        .unwrap();
+    let result = match result1 {
+        manage_neuron_response::Command::Error(e) => Err(GovernanceError::from(e)),
+        manage_neuron_response::Command::MergeMaturity(response) => Ok(response),
+        _ => panic!("Merge maturity command returned unexpected response"),
+    };
     assert!(result.is_err());
 
     let error = result.unwrap_err();


### PR DESCRIPTION
This removes more vestiges of merge_maturity code (which has been non-functional for over 1 year), in governance.