### PR TITLE
fix(node): Remove vm_nr_of_vcpus default value

### DIFF
--- a/ic-os/components/hostos-scripts/generate-guestos-config/dev-generate-guestos-config.sh
+++ b/ic-os/components/hostos-scripts/generate-guestos-config/dev-generate-guestos-config.sh
@@ -132,7 +132,7 @@ EOF
     if [ ! -f "${OUTPUT}" ]; then
         mkdir -p "$(dirname "$OUTPUT")"
         sed -e "s@{{ resources_memory }}@${vm_memory}@" \
-            -e "s@{{ nr_of_vcpus }}@${vm_nr_of_vcpus:-64}@" \
+            -e "s@{{ nr_of_vcpus }}@${vm_nr_of_vcpus}@" \
             -e "s@{{ mac_address }}@${MAC_ADDRESS}@" \
             -e "s@{{ cpu_domain }}@${CPU_DOMAIN}@" \
             -e "/{{ cpu_spec }}/{r ${CPU_SPEC}" -e "d" -e "}" \

--- a/ic-os/components/hostos-scripts/generate-guestos-config/generate-guestos-config.sh
+++ b/ic-os/components/hostos-scripts/generate-guestos-config/generate-guestos-config.sh
@@ -128,7 +128,7 @@ EOF
     if [ ! -f "${OUTPUT}" ]; then
         mkdir -p "$(dirname "$OUTPUT")"
         sed -e "s@{{ resources_memory }}@${vm_memory}@" \
-            -e "s@{{ nr_of_vcpus }}@${vm_nr_of_vcpus:-64}@" \
+            -e "s@{{ nr_of_vcpus }}@${vm_nr_of_vcpus}@" \
             -e "s@{{ mac_address }}@${MAC_ADDRESS}@" \
             -e "s@{{ cpu_domain }}@${CPU_DOMAIN}@" \
             -e "/{{ cpu_spec }}/{r ${CPU_SPEC}" -e "d" -e "}" \


### PR DESCRIPTION
All nodes have a vm_nr_of_vcpus field in their config object, thanks to update_config.rs

This field was added recently, and we updated update_config.rs to create the default value rather than put the default value in generate-guestos-config (or, rather than put the default value _everywhere_ in generate-guestos-config). So it is not optional for new deployments (despite what the default value in generate-guestos-config may suggest) and all nodes deployed have the value.

We can remove the 64 default value in generate-guestos-config.sh, which will make the code less confusing.