### PR TITLE
refactor: Factor out generate_guestos_config into a library function and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
  "anyhow",
  "clap 4.5.27",
  "config_types",
+ "deterministic_ips",
  "ic-types",
  "macaddr",
  "network",

--- a/ic-os/components/hostos-scripts/generate-guestos-config/dev-generate-guestos-config.sh
+++ b/ic-os/components/hostos-scripts/generate-guestos-config/dev-generate-guestos-config.sh
@@ -73,8 +73,7 @@ function read_config_variables() {
 }
 
 function assemble_config_media() {
-    ipv6_address="$(/opt/ic/bin/hostos_tool generate-ipv6-address --node-type GuestOS)"
-    /opt/ic/bin/config generate-guestos-config --guestos-ipv6-address "$ipv6_address"
+    /opt/ic/bin/config generate-guestos-config
 
     cmd=(/opt/ic/bin/build-bootstrap-config-image.sh ${MEDIA})
     cmd+=(--guestos_config "/boot/config/config-guestos.json")

--- a/ic-os/components/hostos-scripts/generate-guestos-config/generate-guestos-config.sh
+++ b/ic-os/components/hostos-scripts/generate-guestos-config/generate-guestos-config.sh
@@ -72,8 +72,7 @@ function read_config_variables() {
 }
 
 function assemble_config_media() {
-    ipv6_address="$(/opt/ic/bin/hostos_tool generate-ipv6-address --node-type GuestOS)"
-    /opt/ic/bin/config generate-guestos-config --guestos-ipv6-address "$ipv6_address"
+    /opt/ic/bin/config generate-guestos-config
 
     cmd=(/opt/ic/bin/build-bootstrap-config-image.sh ${MEDIA})
     cmd+=(--guestos_config "/boot/config/config-guestos.json")

--- a/rs/ic_os/config/BUILD.bazel
+++ b/rs/ic_os/config/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//rs:ic-os-pkg"])
 DEPENDENCIES = [
     # Keep sorted.
     "//rs/ic_os/config_types",
+    "//rs/ic_os/deterministic_ips",
     "//rs/ic_os/network",
     "//rs/ic_os/utils",
     "//rs/types/types",

--- a/rs/ic_os/config/Cargo.toml
+++ b/rs/ic_os/config/Cargo.toml
@@ -16,6 +16,7 @@ serde_with = "1.6.2"
 regex = { workspace = true }
 config_types = { path = "../config_types" }
 network = { path = "../network" }           # Only required by bin
+deterministic_ips = { path = "../deterministic_ips" }
 
 [dev-dependencies]
 once_cell = "1.8"

--- a/rs/ic_os/config/src/guestos_config.rs
+++ b/rs/ic_os/config/src/guestos_config.rs
@@ -1,0 +1,128 @@
+use anyhow::Result;
+use config_types::{FixedIpv6Config, GuestOSConfig, HostOSConfig, Ipv6Config};
+use deterministic_ips::node_type::NodeType;
+use deterministic_ips::{calculate_deterministic_mac, IpVariant, MacAddr6Ext};
+use utils::to_cidr;
+
+/// Generate the GuestOS configuration based on the provided HostOS configuration.
+pub fn generate_guestos_config(hostos_config: &HostOSConfig) -> Result<GuestOSConfig> {
+    let hostos_config = hostos_config.clone();
+    let generated_mac = calculate_deterministic_mac(
+        &hostos_config.icos_settings.mgmt_mac,
+        hostos_config.icos_settings.deployment_environment,
+        IpVariant::V6,
+        NodeType::GuestOS, // TODO(NODE-1608): support UpgradeGuestOS
+    );
+    // TODO: We won't have to modify networking between the hostos and
+    // guestos config after completing the networking revamp (NODE-1327)
+    let mut guestos_network_settings = hostos_config.network_settings;
+    // Update the GuestOS networking if `guestos_ipv6_address` is provided
+    match &guestos_network_settings.ipv6_config {
+        Ipv6Config::Deterministic(deterministic_ipv6_config) => {
+            let guestos_ipv6_address =
+                generated_mac.calculate_slaac(&deterministic_ipv6_config.prefix)?;
+            guestos_network_settings.ipv6_config = Ipv6Config::Fixed(FixedIpv6Config {
+                address: to_cidr(
+                    guestos_ipv6_address,
+                    deterministic_ipv6_config.prefix_length,
+                ),
+                gateway: deterministic_ipv6_config.gateway,
+            });
+        }
+        _ => anyhow::bail!(
+            "HostOSConfig Ipv6Config should always be of type Deterministic. \
+             Cannot reassign GuestOS networking."
+        ),
+    }
+
+    let guestos_config = GuestOSConfig {
+        config_version: hostos_config.config_version,
+        network_settings: guestos_network_settings,
+        icos_settings: hostos_config.icos_settings,
+        guestos_settings: hostos_config.guestos_settings,
+    };
+
+    Ok(guestos_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config_types::{
+        DeploymentEnvironment, DeterministicIpv6Config, HostOSConfig, ICOSSettings, Ipv6Config,
+        NetworkSettings,
+    };
+    use std::net::Ipv6Addr;
+
+    fn hostos_config_for_test() -> HostOSConfig {
+        HostOSConfig {
+            config_version: "1.0.0".to_string(),
+            network_settings: NetworkSettings {
+                ipv6_config: Ipv6Config::RouterAdvertisement,
+                ipv4_config: None,
+                domain_name: None,
+            },
+            icos_settings: ICOSSettings {
+                node_reward_type: None,
+                mgmt_mac: Default::default(),
+                deployment_environment: DeploymentEnvironment::Testnet,
+                logging: Default::default(),
+                use_nns_public_key: false,
+                nns_urls: vec![],
+                use_node_operator_private_key: false,
+                use_ssh_authorized_keys: false,
+                icos_dev_settings: Default::default(),
+            },
+            hostos_settings: Default::default(),
+            guestos_settings: Default::default(),
+        }
+    }
+    #[test]
+    fn test_successful_conversion() {
+        let mut hostos_config = hostos_config_for_test();
+        hostos_config.network_settings.ipv6_config =
+            Ipv6Config::Deterministic(DeterministicIpv6Config {
+                prefix: "2001:db8::".to_string(),
+                prefix_length: 64,
+                gateway: "2001:db8::1".parse().unwrap(),
+            });
+
+        let guestos_config = generate_guestos_config(&hostos_config).unwrap();
+
+        assert_eq!(guestos_config.config_version, hostos_config.config_version);
+        assert_eq!(
+            guestos_config.network_settings.domain_name,
+            hostos_config.network_settings.domain_name
+        );
+        assert_eq!(
+            guestos_config.network_settings.ipv4_config,
+            hostos_config.network_settings.ipv4_config
+        );
+        assert_eq!(guestos_config.icos_settings, hostos_config.icos_settings);
+        assert_eq!(
+            guestos_config.guestos_settings,
+            hostos_config.guestos_settings
+        );
+
+        if let Ipv6Config::Fixed(fixed) = &guestos_config.network_settings.ipv6_config {
+            assert_eq!(fixed.address, "2001:db8::6801:94ff:feef:2978/64");
+            assert_eq!(fixed.gateway, "2001:db8::1".parse::<Ipv6Addr>().unwrap());
+        } else {
+            panic!("Unexpected Ipv6Config type");
+        }
+    }
+
+    #[test]
+    fn test_invalid_ipv6_configuration() {
+        let mut hostos_config = hostos_config_for_test();
+
+        hostos_config.network_settings.ipv6_config = Ipv6Config::Fixed(FixedIpv6Config {
+            address: "2001:db8::1/64".to_string(),
+            gateway: "2001:db8::1".parse().unwrap(),
+        });
+
+        let result = generate_guestos_config(&hostos_config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Deterministic"));
+    }
+}

--- a/rs/ic_os/config/src/guestos_config.rs
+++ b/rs/ic_os/config/src/guestos_config.rs
@@ -7,18 +7,17 @@ use utils::to_cidr;
 /// Generate the GuestOS configuration based on the provided HostOS configuration.
 pub fn generate_guestos_config(hostos_config: &HostOSConfig) -> Result<GuestOSConfig> {
     let hostos_config = hostos_config.clone();
-    let generated_mac = calculate_deterministic_mac(
-        &hostos_config.icos_settings.mgmt_mac,
-        hostos_config.icos_settings.deployment_environment,
-        IpVariant::V6,
-        NodeType::GuestOS, // TODO(NODE-1608): support UpgradeGuestOS
-    );
     // TODO: We won't have to modify networking between the hostos and
     // guestos config after completing the networking revamp (NODE-1327)
     let mut guestos_network_settings = hostos_config.network_settings;
-    // Update the GuestOS networking if `guestos_ipv6_address` is provided
     match &guestos_network_settings.ipv6_config {
         Ipv6Config::Deterministic(deterministic_ipv6_config) => {
+            let generated_mac = calculate_deterministic_mac(
+                &hostos_config.icos_settings.mgmt_mac,
+                hostos_config.icos_settings.deployment_environment,
+                IpVariant::V6,
+                NodeType::GuestOS, // TODO(NODE-1608): support UpgradeGuestOS
+            );
             let guestos_ipv6_address =
                 generated_mac.calculate_slaac(&deterministic_ipv6_config.prefix)?;
             guestos_network_settings.ipv6_config = Ipv6Config::Fixed(FixedIpv6Config {

--- a/rs/ic_os/config/src/lib.rs
+++ b/rs/ic_os/config/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config_ini;
 pub mod deployment_json;
 pub mod generate_testnet_config;
+pub mod guestos_config;
 pub mod update_config;
 
 use anyhow::{Context, Result};

--- a/rs/ic_os/config/src/main.rs
+++ b/rs/ic_os/config/src/main.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use config::generate_testnet_config::{
     generate_testnet_config, GenerateTestnetConfigArgs, Ipv6ConfigType,
 };
+use config::guestos_config::generate_guestos_config;
 use config_types::*;
 
 #[derive(Subcommand)]
@@ -42,8 +43,6 @@ pub enum Commands {
         hostos_config_json_path: PathBuf,
         #[arg(long, default_value = config::DEFAULT_HOSTOS_GUESTOS_CONFIG_OBJECT_PATH, value_name = "config-guestos.json")]
         guestos_config_json_path: PathBuf,
-        #[arg(long, value_name = "ipv6_address")]
-        guestos_ipv6_address: String,
     },
     /// Creates a GuestOSConfig object directly from GenerateTestnetConfigClapArgs. Only used for testing purposes.
     GenerateTestnetConfig(GenerateTestnetConfigClapArgs),
@@ -292,38 +291,12 @@ pub fn main() -> Result<()> {
         Some(Commands::GenerateGuestosConfig {
             hostos_config_json_path,
             guestos_config_json_path,
-            guestos_ipv6_address,
         }) => {
             let hostos_config_json_path = Path::new(&hostos_config_json_path);
-
             let hostos_config: HostOSConfig =
                 serde_json::from_reader(File::open(hostos_config_json_path)?)?;
 
-            // TODO: We won't have to modify networking between the hostos and
-            // guestos config after completing the networking revamp (NODE-1327)
-            let mut guestos_network_settings = hostos_config.network_settings;
-            // Update the GuestOS networking if `guestos_ipv6_address` is provided
-            match &guestos_network_settings.ipv6_config {
-                Ipv6Config::Deterministic(deterministic_ipv6_config) => {
-                    guestos_network_settings.ipv6_config = Ipv6Config::Fixed(FixedIpv6Config {
-                        address: guestos_ipv6_address,
-                        gateway: deterministic_ipv6_config.gateway,
-                    });
-                }
-                _ => {
-                    anyhow::bail!(
-                        "HostOSConfig Ipv6Config should always be of type Deterministic. Cannot reassign GuestOS networking."
-                    );
-                }
-            }
-
-            let guestos_config = GuestOSConfig {
-                config_version: hostos_config.config_version,
-                network_settings: guestos_network_settings,
-                icos_settings: hostos_config.icos_settings,
-                guestos_settings: hostos_config.guestos_settings,
-            };
-
+            let guestos_config = generate_guestos_config(&hostos_config)?;
             let guestos_config_json_path = Path::new(&guestos_config_json_path);
             serialize_and_write_config(guestos_config_json_path, &guestos_config)?;
 

--- a/rs/ic_os/config_types/src/lib.rs
+++ b/rs/ic_os/config_types/src/lib.rs
@@ -104,7 +104,7 @@ pub struct ICOSDevSettings {}
 pub struct SetupOSSettings;
 
 /// HostOS-specific settings.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 pub struct HostOSSettings {
     pub vm_memory: u32,
     pub vm_cpu: String,

--- a/rs/ic_os/deterministic_ips/src/lib.rs
+++ b/rs/ic_os/deterministic_ips/src/lib.rs
@@ -69,6 +69,7 @@ pub enum IpVariant {
 pub fn calculate_deterministic_mac(
     mgmt_mac: &MacAddr6,
     deployment_environment: DeploymentEnvironment,
+    // TODO(NODE-1609): consider removing IpVariant as it's always set to V6 in prod.
     ip_version: IpVariant,
     node_type: NodeType,
 ) -> MacAddr6 {


### PR DESCRIPTION
In addition, calculate IP address from the passed config instead of taking it as a separate argument.