### PR TITLE
feat(icrc-rosetta): add icrc rosetta release 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9623,7 +9623,7 @@ dependencies = [
 
 [[package]]
 name = "ic-icrc-rosetta"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "axum 0.8.4",

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -82,7 +82,7 @@ MACRO_DEV_DEPENDENCIES = [
 ALIASES = {
 }
 
-ROSETTA_VERSION = "1.2.1"
+ROSETTA_VERSION = "1.2.2"
 
 rust_library(
     name = "ic-icrc-rosetta",

--- a/rs/rosetta-api/icrc1/CHANGELOG.md
+++ b/rs/rosetta-api/icrc1/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.2] - 2025-06-15
+### Fixed
+- Fixed timestamp overflow in blocks table for values exceeding i64::MAX (#5249)
+- Fixed watchdog for initial sync to avoid killing the synchronization process (#5250)
+- Improved synchronization progress logs to show progress in relation to the full chain size (#5250)
+- Fixed flaky test_deriving_gaps_from_storage test (#5024)
+- Increased transaction search timeout from 10s to 30s for system tests (#4446)
+
 ## [1.2.1] - 2025-05-10
 ### Added
 - Token-specific metrics for multi-token instances - metrics now include token labels to help distinguish between different tokens ([#4790](https://github.com/dfinity/ic/pull/4790)).

--- a/rs/rosetta-api/icrc1/Cargo.toml
+++ b/rs/rosetta-api/icrc1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ic-icrc-rosetta"
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 default-run = "ic-icrc-rosetta"
-version = "1.2.1"
+version = "1.2.2"
 authors.workspace = true
 edition.workspace = true
 documentation.workspace = true

--- a/rs/rosetta-api/icrc1/src/common/constants.rs
+++ b/rs/rosetta-api/icrc1/src/common/constants.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 pub const DEFAULT_BLOCKCHAIN: &str = "Internet Computer";
-pub const ROSETTA_VERSION: &str = "1.2.1";
+pub const ROSETTA_VERSION: &str = "1.2.2";
 pub const NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const INGRESS_INTERVAL_SECS: u64 = 4 * 60;
 pub const BLOCK_SYNC_WAIT_SECS: u64 = 1;


### PR DESCRIPTION
Release information for ICRC Rosetta 1.2.2 with the following changes:

- Fixed timestamp overflow in blocks table for values exceeding i64::MAX
- Fixed watchdog for initial sync to avoid killing the synchronization process
- Improved synchronization progress logs
- Fixed flaky test_deriving_gaps_from_storage test
- Increased transaction search timeout from 10s to 30s for system tests