### PR TITLE
chore: bind mount ~/.cache/zig-cache to /tmp/zig-cache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   ],
   "workspaceMount": "source=${localWorkspaceFolder},target=/ic,type=bind",
   "workspaceFolder": "/ic",
-  "initializeCommand": "mkdir -p ~/.aws ~/.ssh ~/.cache/cargo ~/.local/share/fish && touch ~/.zsh_history ~/.bash_history",
+  "initializeCommand": "mkdir -p ~/.aws ~/.ssh ~/.cache/cargo ~/.cache/zig-cache ~/.local/share/fish && touch ~/.zsh_history ~/.bash_history",
   "containerEnv": {
     "CARGO_TARGET_DIR": "/home/ubuntu/.cache/cargo",
     "USER": "${localEnv:USER}"
@@ -23,6 +23,11 @@
     {
       "source": "${localEnv:HOME}/.cache",
       "target": "/home/ubuntu/.cache",
+      "type": "bind"
+    },
+    {
+      "source": "${localEnv:HOME}/.cache/zig-cache",
+      "target": "/tmp/zig-cache",
       "type": "bind"
     },
     {

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -109,6 +109,9 @@ else
     CTR_HOME="/ic"
 fi
 
+PER_USER_ZIG_CACHE="/tmp/$(whoami)/zig-cache"
+mkdir -p "$PER_USER_ZIG_CACHE"
+
 PODMAN_RUN_ARGS+=(
     --mount type=bind,source="${REPO_ROOT}",target="${WORKDIR}"
     --mount type=bind,source="${CACHE_DIR:-${HOME}/.cache}",target="${CTR_HOME}/.cache"
@@ -116,7 +119,7 @@ PODMAN_RUN_ARGS+=(
     --mount type=bind,source="${HOME}/.aws",target="${CTR_HOME}/.aws"
     --mount type=bind,source="/var/lib/containers",target="/var/lib/containers"
     --mount type=bind,source="/tmp",target="/tmp"
-    --mount type=volume,chown=true,destination=/tmp/zig-cache
+    --mount type=bind,source="$PER_USER_ZIG_CACHE",target="/tmp/zig-cache"
     --mount type=tmpfs,destination=/var/sysimage
 )
 

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -109,17 +109,19 @@ else
     CTR_HOME="/ic"
 fi
 
-PER_USER_ZIG_CACHE="/tmp/$(whoami)/zig-cache"
-mkdir -p "$PER_USER_ZIG_CACHE"
+CACHE_DIR="${CACHE_DIR:-${HOME}/.cache}"
+
+ZIG_CACHE="${CACHE_DIR}/zig-cache"
+mkdir -p "${ZIG_CACHE}"
 
 PODMAN_RUN_ARGS+=(
     --mount type=bind,source="${REPO_ROOT}",target="${WORKDIR}"
-    --mount type=bind,source="${CACHE_DIR:-${HOME}/.cache}",target="${CTR_HOME}/.cache"
+    --mount type=bind,source="${CACHE_DIR}",target="${CTR_HOME}/.cache"
+    --mount type=bind,source="${ZIG_CACHE}",target="/tmp/zig-cache"
     --mount type=bind,source="${HOME}/.ssh",target="${CTR_HOME}/.ssh"
     --mount type=bind,source="${HOME}/.aws",target="${CTR_HOME}/.aws"
     --mount type=bind,source="/var/lib/containers",target="/var/lib/containers"
     --mount type=bind,source="/tmp",target="/tmp"
-    --mount type=bind,source="$PER_USER_ZIG_CACHE",target="/tmp/zig-cache"
     --mount type=tmpfs,destination=/var/sysimage
 )
 


### PR DESCRIPTION
On `zh-spm34` and `zh1-spm22` when running `ci/container/container-run.sh` the podman option:
```
--mount type=volume,chown=true,destination=/tmp/zig-cache
```
causes:
```
Error: 'overlay' is not supported over zfs
```
and 
```
Error: chown: invalid mount option
```
So instead of using a volume to mount `/tmp/zig-cache` we bind mount `~/.cache/zig-cache` to  `/tmp/zig-cache`  in both `ci/container/container-run.sh` and `.devcontainer/devcontainer.json`.