### PR TITLE
chore(IDX): Extract artifact upload from build

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -121,3 +121,11 @@ runs:
             echo "Bazel version: $(bazel version)"
 
             bazel ${{ inputs.BAZEL_COMMAND }} "${bazel_args[@]}"
+
+      - name: Upload to S3
+        uses: ./.github/actions/bazel
+        if: inputs.release-build == 'true'
+        with:
+          run: |
+            echo uploading artifacts to CDN
+            bazel run --check_up_to_date //:upload-artifacts

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -43,13 +43,12 @@ build --experimental_repository_downloader_retries=3 # https://bazel.build/refer
 
 common --flag_alias=release_build=//bazel:release_build
 common --flag_alias=s3_endpoint=//ci/src/artifacts:s3_endpoint
-common --flag_alias=s3_upload=//ci/src/artifacts:s3_upload
 common --flag_alias=k8s=//rs/tests:k8s
 common --flag_alias=timeout_value=//bazel:timeout_value
 common --flag_alias=hermetic_cc=//bazel:hermetic_cc
 
 common:stamped --workspace_status_command='$(pwd)/bazel/workspace_status.sh --stamp'
-common:release --config=stamped --s3_upload=True
+common:release --config=stamped # alias
 
 # Exclude system tests by default
 # https://github.com/bazelbuild/bazel/issues/8439

--- a/ci/src/artifacts/BUILD.bazel
+++ b/ci/src/artifacts/BUILD.bazel
@@ -1,19 +1,7 @@
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
-
 package(default_visibility = ["//visibility:public"])
 
 exports_files(
     [
         "upload.sh",
     ],
-)
-
-string_flag(
-    name = "s3_endpoint",
-    build_setting_default = "",
-)
-
-bool_flag(
-    name = "s3_upload",
-    build_setting_default = False,
 )

--- a/ci/src/artifacts/upload.bzl
+++ b/ci/src/artifacts/upload.bzl
@@ -2,43 +2,49 @@
 Rules to manipulate with artifacts: download, upload etc.
 """
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-
 def _upload_artifact_impl(ctx):
     """
     Uploads an artifact to s3 and returns download link to it
     """
 
-    s3_upload = ctx.attr._s3_upload[BuildSettingInfo].value
-    out = []
+    version_file = ctx.file._version_txt
 
-    for f in ctx.files.inputs:
-        url = ctx.actions.declare_file("_" + f.path + ".urls")
-        ctx.actions.run(
-            executable = ctx.file._artifacts_uploader,
-            arguments = [f.path, url.path],
-            env = {
-                "RCLONE": ctx.file._rclone.path,
-                "VERSION_FILE": ctx.version_file.path,
-                "VERSION_TXT": ctx.file._version_txt.path,
-                "DRY_RUN": "1" if not s3_upload else "0",
-            },
-            inputs = [f, ctx.version_file, ctx.file._version_txt],
-            outputs = [url],
-            tools = [ctx.file._rclone],
-        )
-        out.append(url)
+    uploader = ctx.file._artifacts_uploader
+    exe = ctx.actions.declare_file("run-upload")
+    cmds = ["{uploader} {bundle}".format(uploader = uploader.path, bundle = bundle.short_path) for bundle in ctx.files.inputs]
+    ctx.actions.write(
+        output = exe,
+        content = """
+        #!/usr/bin/env bash
 
-    return [DefaultInfo(files = depset(out), runfiles = ctx.runfiles(files = out))]
+        set -euo pipefail
+
+        export DRY_RUN=1 # TODO: remove this
+        VERSION_FILE={version_file}
+        export VERSION=$(cat $VERSION_FILE)
+        echo "$VERSION"
+        {cmds}
+
+        """.format(cmds = "\n".join(cmds), version_file = version_file.short_path),
+        is_executable = True,
+    )
+
+    # TODO: check this
+    deps = depset(ctx.files.inputs + [version_file])
+    runfiles = ctx.runfiles(files = [uploader, version_file] + ctx.files.inputs)
+
+    return [
+        DefaultInfo(executable = exe, files = deps, runfiles = runfiles),
+    ]
 
 _upload_artifacts = rule(
     implementation = _upload_artifact_impl,
+    executable = True,
     attrs = {
         "inputs": attr.label_list(allow_files = True),
         "_rclone": attr.label(allow_single_file = True, default = "@rclone//:rclone"),
         "_artifacts_uploader": attr.label(allow_single_file = True, default = ":upload.sh"),
         "_version_txt": attr.label(allow_single_file = True, default = "//bazel:version.txt"),
-        "_s3_upload": attr.label(default = ":s3_upload"),
     },
 )
 
@@ -54,9 +60,4 @@ def upload_artifacts(**kwargs):
       **kwargs: all arguments to pass to _upload_artifacts
     """
 
-    tags = kwargs.get("tags", [])
-    for tag in ["requires-network"]:
-        if tag not in tags:
-            tags.append(tag)
-    kwargs["tags"] = tags
     _upload_artifacts(**kwargs)

--- a/ci/src/artifacts/upload.sh
+++ b/ci/src/artifacts/upload.sh
@@ -4,19 +4,7 @@ set -eEuo pipefail
 
 BUNDLE="${1:?No bundle to upload}"
 
-# ~/.aws/credentials is needed by rclone. If home is not set, expect
-# VERSION_FILE to contain the $HOME.
-if [ -z "${HOME:-}" ]; then
-    while read -r k v; do
-        case "$k" in
-            HOME)
-                export HOME="$v"
-                ;;
-        esac
-    done <"$VERSION_FILE"
-fi
-
-VERSION="$(cat $VERSION_TXT)"
+echo "VERSION: $VERSION"
 
 # Multipart upload does not work trough Cloudflare for some reason.
 # Just disabling it with `--s3-upload-cutoff` for now.


### PR DESCRIPTION
This turns the `upload_artifact` into an executable rule that can be `bazel run` after the build. This means the AWS credentials don't have to be set in the build, and separates build & release (upload) concerns.