### PR TITLE
chore(IDX): remove wasm.wasm.gz

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -59,7 +59,6 @@ jobs:
             "sns-root-canister.wasm"
             "sns-swap-canister.wasm"
             "sns-wasm-canister.wasm"
-            "wasm.wasm"
           )
 
           mkdir canisters && pushd canisters

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           set -euxo pipefail
 
-          DOWNLOAD_PREFIX="http://download.dfinity.systems/ic/$GITHUB_SHA"
+          DOWNLOAD_PREFIX="https://download.dfinity.systems/ic/$GITHUB_SHA"
 
           curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/setup-os/disk-img/disk-img.tar.zst" -o setup-os-img.tar.zst
           curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/guest-os/update-img/update-img.tar.zst" -o update-os-img.tar.zst


### PR DESCRIPTION
Canister was removed in #5069. See [related failure](https://github.com/dfinity/ic/actions/runs/15204705042/job/42765131789). Directly use https despite "curl -L/301".