### PR TITLE
test: use correct constant in large subnet recovery test

### DIFF
--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -286,7 +286,7 @@ fn app_subnet_recovery_test(env: TestEnv, cfg: Config) {
 
     // TODO(CON-1471): Enable vetKD in large subnet recovery test once
     // large registry deltas are supported.
-    let key_ids = if topology_snapshot.root_subnet().nodes().count() == NNS_NODES {
+    let key_ids = if topology_snapshot.root_subnet().nodes().count() == NNS_NODES_LARGE {
         make_key_ids_for_all_idkg_schemes()
     } else {
         make_key_ids_for_all_schemes()


### PR DESCRIPTION
The large recovery test is currently broken, as it tries to enable a vetKey that doesn't exist. This is because we were using the wrong constant to determine if vetKeys should be enabled or not. (They should not be enabled if we are in a large subnet recovery scenario).