### PR TITLE
test(nns): Stop assuming voting with well known neurons must succeed as they might follow each other

### DIFF
--- a/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
+++ b/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
@@ -181,27 +181,17 @@ fn get_well_known_public_neurons() -> Vec<(NeuronId, PrincipalId)> {
 /// mechanism is in place to prevent this exact situation. Instead, here we use the super power
 /// given by the StateMachine test framework where any principal can be impersonated, which is
 /// clearly unavailable on the mainnet.
-fn vote_yes_with_well_known_public_neurons(
-    state_machine: &StateMachine,
-    proposal_id: u64,
-    check_vote_should_succeed: bool,
-) {
+fn vote_yes_with_well_known_public_neurons(state_machine: &StateMachine, proposal_id: u64) {
     for (voter_neuron_id, voter_controller) in get_well_known_public_neurons() {
         // Note that the voting can fail if the proposal already reaches absolute
         // majority and the NNS Governance starts to upgrade.
-        let result = nns_cast_vote(
+        let _ = nns_cast_vote(
             state_machine,
             voter_controller,
             voter_neuron_id,
             proposal_id,
             Vote::Yes,
         );
-        if check_vote_should_succeed {
-            result.unwrap().panic_if_error(&format!(
-                "Voting with well-known public neuron {:?} on proposal {} failed",
-                voter_neuron_id, proposal_id
-            ));
-        }
     }
 }
 
@@ -319,11 +309,7 @@ fn test_upgrade_canisters_with_golden_nns_state() {
                 // Impersonate some public neurons to vote on the proposal. Note that we do not
                 // check whether votes succeed, as the governance upgrade can start at any point
                 // which will make the canister unresponsive.
-                vote_yes_with_well_known_public_neurons(
-                    &state_machine,
-                    proposal_id.id,
-                    false, /* check_vote_should_succeed */
-                );
+                vote_yes_with_well_known_public_neurons(&state_machine, proposal_id.id);
 
                 // Step 3: Verify result(s): In a short while, the canister should
                 // be running the new code.
@@ -358,11 +344,7 @@ fn test_upgrade_canisters_with_golden_nns_state() {
         neuron_controller,
         neuron_id,
     );
-    vote_yes_with_well_known_public_neurons(
-        &state_machine,
-        proposal_id.id,
-        true, /* check_vote_should_succeed */
-    );
+    vote_yes_with_well_known_public_neurons(&state_machine, proposal_id.id);
     nns_wait_for_proposal_execution(&state_machine, proposal_id.id);
 
     perform_sequence_of_upgrades(&nns_canister_upgrade_sequence);


### PR DESCRIPTION
When simulating voting with multiple neurons in the test, we should not assume the voting all succeed since they might follow each other. On the other hand, not checking the voting result is OK since we will wait for the proposal execution anyway. The only downside of not checking is that when proposal does not execute, it's slightly more difficult to debug.