### PR TITLE
fix(sns): Avoid calling NNS Governance during swap finalization if Neuron's Fund participation was not requested

### DIFF
--- a/rs/sns/swap/src/swap.rs
+++ b/rs/sns/swap/src/swap.rs
@@ -2357,6 +2357,25 @@ impl Swap {
                 return SettleNeuronsFundParticipationResult::new_error(error_message);
             }
         };
+
+        // Check if the Neurons' Fund participation is requested by the SNS.
+        match init.neurons_fund_participation {
+            // If Neurons' Fund participation is specifically requested, keep going.
+            Some(neurons_fund_participation) if neurons_fund_participation => (),
+            Some(_) | None => {
+                log!(
+                    INFO,
+                    "settle_neurons_fund_participation has not been requested. \
+                     Returning successfully.",
+                );
+
+                return SettleNeuronsFundParticipationResult::new_ok(
+                    self.current_neurons_fund_participation_e8s(),
+                    self.cf_participants.len() as u64,
+                );
+            }
+        }
+
         // The following methods are safe to call since we validated Init in the above block
         let nns_proposal_id = init.nns_proposal_id();
         let sns_governance_canister_id = init.sns_governance_or_panic();

--- a/rs/sns/swap/unreleased_changelog.md
+++ b/rs/sns/swap/unreleased_changelog.md
@@ -17,4 +17,14 @@ on the process that this file is part of, see
 
 ## Fixed
 
+Fix an issue occurring when the NNS Governance cannot find proposals corresponding the creation
+of the SNS that requests Neurons' Fund participation during finalization. Note that currently,
+SNSs that do not even request Neurons' Fund participation are potentially risking that their
+finalization halts if the NNS proposal that created that SNS cannot be found (this recently
+happened due to an
+[unrelated problem in the NNS](https://forum.dfinity.org/t/nns-governance-bug-in-proposal-136693/48224)).
+
+The solution is to avoid calling the NNS Governance's `settle_neurons_fund_participation_result`
+function if the SNS does not specifically request Neurons' Fund participation.
+
 ## Security


### PR DESCRIPTION
This PR fixes an issue that could occur if the NNS Governance canister does not find proposals that correspond to the creation of the SNS that requests Neurons' Fund participation during finalization. Note that currently, the Neurons' Fund is disabled, and the SNSs that do not even request Neurons' Fund participation are potentially risking that their finalization halts if the NNS proposal that created that SNS cannot be found (this recently happened due to an unrelated problem in the NNS).

The solution is to avoid calling the NNS Governance's `settle_neurons_fund_participation_result` function is the SNS des not specifically request Neurons' Fund participation.