### PR TITLE
fix: do not include See documentation without doc link

### DIFF
--- a/rs/types/wasm_types/src/errors.rs
+++ b/rs/types/wasm_types/src/errors.rs
@@ -20,9 +20,18 @@ pub enum ErrorHelp {
 impl std::fmt::Display for ErrorHelp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ErrorHelp::UserError { suggestion, doc_link } => { if !suggestion.is_empty() {
-                write!(f, "{} See documentation: {}", suggestion, doc_link)
-            } else { Ok(())}             },
+            ErrorHelp::UserError { suggestion, doc_link } => {
+                if !suggestion.is_empty() {
+                    write!(f, "{}", suggestion)?;
+                    if !doc_link.is_empty() {
+                        write!(f, " See documentation: {}", doc_link)
+                    } else {
+                        Ok(())
+                    }
+                } else {
+                    Ok(())
+                }
+            },
             ErrorHelp::ToolchainError => write!(f, "If you are running this canister in a test environment (e.g., dfx), make sure the test environment is up to date. Otherwise, this is likely an error with the compiler/CDK toolchain being used to build the canister. Please report the error to IC devs on the forum: https://forum.dfinity.org and include which language/CDK was used to create the canister."),
             ErrorHelp::InternalError => write!(f, "This is an internal error on the IC. Please report it to IC devs on the forum: https://forum.dfinity.org"),
         }


### PR DESCRIPTION
This PR fixes user error messages to not contain `See documentation` without a link to documentation, i.e., to not end with `See documentation: `.