### PR TITLE
fix(icp-rosetta): fix heartbeat during initial sync

### DIFF
--- a/rs/rosetta-api/icp/src/rosetta_server.rs
+++ b/rs/rosetta-api/icp/src/rosetta_server.rs
@@ -441,6 +441,7 @@ fn start_sync_thread(
         info!("Starting blockchain sync thread");
         let mut interval = interval(BLOCK_SYNC_INTERVAL);
         let mut synced_at = std::time::Instant::now();
+        let mut first_sync_successful = false;
         let rosetta_metrics =
             RosettaMetrics::new("ICP".to_string(), "ryjl3-tyaaa-aaaaa-aaaba-cai".to_string());
         while !stopped.load(Relaxed) {
@@ -459,8 +460,13 @@ fn start_sync_thread(
                 let t = Instant::now().duration_since(synced_at).as_secs_f64();
                 rosetta_metrics.set_out_of_sync_time(t);
                 synced_at = std::time::Instant::now();
+                first_sync_successful = true;
             }
-            heartbeat_fn();
+            
+            // Only call heartbeat after the first successful sync
+            if first_sync_successful {
+                heartbeat_fn();
+            }
 
             if exit_on_sync {
                 info!("Blockchain synced, exiting");

--- a/rs/rosetta-api/icp/src/rosetta_server.rs
+++ b/rs/rosetta-api/icp/src/rosetta_server.rs
@@ -462,7 +462,7 @@ fn start_sync_thread(
                 synced_at = std::time::Instant::now();
                 first_sync_successful = true;
             }
-            
+
             // Only call heartbeat after the first successful sync
             if first_sync_successful {
                 heartbeat_fn();


### PR DESCRIPTION
This pull request introduces a new mechanism to ensure that the `heartbeat_fn` is only invoked after the first successful blockchain synchronization in the `start_sync_thread` function. This change improves the logic for handling synchronization and ensures that the heartbeat is not prematurely triggered.

Without this, if there's any failure during the initial sync, the watchdog thread will think the initial sync is done and only wait up to 60 seconds per cycle, leading to multiple sync thread restarts.