### PR TITLE
chore(IDX): don't use pipelined build for schedule hourly

### DIFF
--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run Bazel Build All No Cache
         uses:  ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: build --config=ci --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True
+          BAZEL_COMMAND: build --config=ci --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run Bazel Build All No Cache
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: build --config=ci --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True
+          BAZEL_COMMAND: build --config=ci --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
The `pipelined_compilation` creates a different config from Bazel's point of view, leading to `--check_up_to_date` assuming that the artifacts are not up to date.