### PR TITLE
Revert "chore(IDX): Extract artifact upload from build (#5274)"

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -7,9 +7,6 @@ inputs:
   release-build:
     required: false
     default: true
-  upload-artifacts:
-    required: false
-    default: false
   execlogs-artifact-name:
     required: false
     description: "When provided, the execlogs will be uploaded as an artifact with the specified name."
@@ -45,6 +42,14 @@ runs:
           chmod 0700 ~/.ssh
           echo -e "Host *\nUser github-runner\n" > ~/.ssh/config
 
+      - name: Write AWS credentials
+        shell: bash
+        if: inputs.CLOUD_CREDENTIALS_CONTENT != ''
+        run: |
+          AWS_CREDS="${HOME}/.aws/credentials"
+          mkdir -p "$(dirname "${AWS_CREDS}")"
+          echo '${{ inputs.CLOUD_CREDENTIALS_CONTENT }}' >"$AWS_CREDS"
+
       - name: Run Bazel Commands
         uses: ./.github/actions/bazel
         env:
@@ -71,8 +76,7 @@ runs:
             )
 
             if [[ $release_build == "true" ]]; then
-              # make sure the version is stamped in
-              bazel_args+=( --config=stamped )
+              bazel_args+=( --config=release )
             fi
 
             BAZEL_TARGETS='${{ inputs.BAZEL_TARGETS }}'
@@ -126,28 +130,3 @@ runs:
             echo "Bazel version: $(bazel version)"
 
             bazel ${{ inputs.BAZEL_COMMAND }} "${bazel_args[@]}"
-
-      - name: Upload to S3
-        uses: ./.github/actions/bazel
-        if: inputs.upload-artifacts == 'true' && inputs.CLOUD_CREDENTIALS_CONTENT != ''
-        with:
-          run: |
-            release_build='${{ inputs.release-build }}'
-
-            if [[ $release_build != "true" ]]; then
-              echo "refusing to upload non-release artifacts"
-              exit 1
-            fi
-
-            AWS_CREDS="${HOME}/.aws/credentials"
-            if ! [ -e "$AWS_CREDS" ]; then
-              echo writing remote storage credentials
-              mkdir -p "$(dirname "${AWS_CREDS}")"
-              echo '${{ inputs.CLOUD_CREDENTIALS_CONTENT }}' >"$AWS_CREDS"
-            fi
-
-            echo uploading artifacts to remote storage
-            # with --check_up_to_date Bazel will error out if the artifacts
-            # to be uploaded were not built in the build step above
-            # (this ensures that the exact artifacts built above are uploaded)
-            bazel run --check_up_to_date //:upload-artifacts

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -194,7 +194,6 @@ jobs:
           execlogs-artifact-name: execlogs-bazel-test-all
           diff-only: ${{ needs.config.outputs.diff_only }}
           release-build: ${{ needs.config.outputs.release_build }}
-          upload-artifacts: ${{ needs.config.outputs.release_build }}
           BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -36,13 +36,12 @@ jobs:
       - name: Run Bazel Build All No Cache
         uses:  ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: build --config=ci --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True
+          # --config=release is required for the BNs as they rely for both dev and prod deployment
+          # on images being uploaded to the S3 bucket
+          BAZEL_COMMAND: build --config=ci --config=release --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment
-          # on images being uploaded to the S3 bucket
-          upload-artifacts: true
 
   bazel-system-test-hourly:
     name: Bazel System Tests Hourly
@@ -56,12 +55,11 @@ jobs:
         id: bazel-test-all
         uses:  ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_hourly
+          # --config=release is required for the BNs as they rely for both dev and prod deployment
+          # on images being uploaded to the S3 bucket
+          BAZEL_COMMAND: test --config=ci --config=release --keep_going --test_tag_filters=system_test_hourly
           BAZEL_TARGETS: //rs/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment
-          # on images being uploaded to the S3 bucket
-          upload-artifacts: true
 
   bazel-run-fuzzers-hourly:
     name: Bazel Run Fuzzers Hourly

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -167,7 +167,6 @@ jobs:
           execlogs-artifact-name: execlogs-bazel-test-all
           diff-only: ${{ needs.config.outputs.diff_only }}
           release-build: ${{ needs.config.outputs.release_build }}
-          upload-artifacts: ${{ needs.config.outputs.release_build }}
           BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -25,13 +25,12 @@ jobs:
       - name: Run Bazel Build All No Cache
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: build --config=ci --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True
+          # --config=release is required for the BNs as they rely for both dev and prod deployment
+          # on images being uploaded to the S3 bucket
+          BAZEL_COMMAND: build --config=ci --config=release --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA} --@rules_rust//rust/settings:pipelined_compilation=True
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment
-          # on images being uploaded to the S3 bucket
-          upload-artifacts: true
   bazel-system-test-hourly:
     name: Bazel System Tests Hourly
     container:
@@ -49,12 +48,11 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_hourly
+          # --config=release is required for the BNs as they rely for both dev and prod deployment
+          # on images being uploaded to the S3 bucket
+          BAZEL_COMMAND: test --config=ci --config=release --keep_going --test_tag_filters=system_test_hourly
           BAZEL_TARGETS: //rs/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment
-          # on images being uploaded to the S3 bucket
-          upload-artifacts: true
   bazel-run-fuzzers-hourly:
     name: Bazel Run Fuzzers Hourly
     container:

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -43,11 +43,13 @@ build --experimental_repository_downloader_retries=3 # https://bazel.build/refer
 
 common --flag_alias=release_build=//bazel:release_build
 common --flag_alias=s3_endpoint=//ci/src/artifacts:s3_endpoint
+common --flag_alias=s3_upload=//ci/src/artifacts:s3_upload
 common --flag_alias=k8s=//rs/tests:k8s
 common --flag_alias=timeout_value=//bazel:timeout_value
 common --flag_alias=hermetic_cc=//bazel:hermetic_cc
 
 common:stamped --workspace_status_command='$(pwd)/bazel/workspace_status.sh --stamp'
+common:release --config=stamped --s3_upload=True
 
 # Exclude system tests by default
 # https://github.com/bazelbuild/bazel/issues/8439

--- a/ci/src/artifacts/BUILD.bazel
+++ b/ci/src/artifacts/BUILD.bazel
@@ -1,7 +1,19 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(
     [
         "upload.sh",
     ],
+)
+
+string_flag(
+    name = "s3_endpoint",
+    build_setting_default = "",
+)
+
+bool_flag(
+    name = "s3_upload",
+    build_setting_default = False,
 )

--- a/ci/src/artifacts/upload.bzl
+++ b/ci/src/artifacts/upload.bzl
@@ -2,48 +2,43 @@
 Rules to manipulate with artifacts: download, upload etc.
 """
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
 def _upload_artifact_impl(ctx):
     """
     Uploads an artifact to s3 and returns download link to it
     """
 
-    version_file = ctx.file._version_txt
-    rclone = ctx.file._rclone
+    s3_upload = ctx.attr._s3_upload[BuildSettingInfo].value
+    out = []
 
-    uploader = ctx.file._artifacts_uploader
-    exe = ctx.actions.declare_file("run-upload")
-    cmds = ["{uploader} {bundle}".format(uploader = uploader.path, bundle = bundle.short_path) for bundle in ctx.files.inputs]
-    ctx.actions.write(
-        output = exe,
-        content = """
-        #!/usr/bin/env bash
+    for f in ctx.files.inputs:
+        url = ctx.actions.declare_file("_" + f.path + ".urls")
+        ctx.actions.run(
+            executable = ctx.file._artifacts_uploader,
+            arguments = [f.path, url.path],
+            env = {
+                "RCLONE": ctx.file._rclone.path,
+                "VERSION_FILE": ctx.version_file.path,
+                "VERSION_TXT": ctx.file._version_txt.path,
+                "DRY_RUN": "1" if not s3_upload else "0",
+            },
+            inputs = [f, ctx.version_file, ctx.file._version_txt],
+            outputs = [url],
+            tools = [ctx.file._rclone],
+        )
+        out.append(url)
 
-        set -euo pipefail
-
-        VERSION_FILE={version_file}
-        export RCLONE={rclone}
-        export VERSION=$(cat $VERSION_FILE)
-        {cmds}
-
-        """.format(cmds = "\n".join(cmds), version_file = version_file.short_path, rclone = rclone.short_path),
-        is_executable = True,
-    )
-
-    deps = depset(ctx.files.inputs + [version_file, rclone])
-    runfiles = ctx.runfiles(files = [uploader, version_file, rclone] + ctx.files.inputs)
-
-    return [
-        DefaultInfo(executable = exe, files = deps, runfiles = runfiles),
-    ]
+    return [DefaultInfo(files = depset(out), runfiles = ctx.runfiles(files = out))]
 
 _upload_artifacts = rule(
     implementation = _upload_artifact_impl,
-    executable = True,
     attrs = {
         "inputs": attr.label_list(allow_files = True),
         "_rclone": attr.label(allow_single_file = True, default = "@rclone//:rclone"),
         "_artifacts_uploader": attr.label(allow_single_file = True, default = ":upload.sh"),
         "_version_txt": attr.label(allow_single_file = True, default = "//bazel:version.txt"),
+        "_s3_upload": attr.label(default = ":s3_upload"),
     },
 )
 
@@ -59,4 +54,9 @@ def upload_artifacts(**kwargs):
       **kwargs: all arguments to pass to _upload_artifacts
     """
 
+    tags = kwargs.get("tags", [])
+    for tag in ["requires-network"]:
+        if tag not in tags:
+            tags.append(tag)
+    kwargs["tags"] = tags
     _upload_artifacts(**kwargs)

--- a/ci/src/artifacts/upload.sh
+++ b/ci/src/artifacts/upload.sh
@@ -3,11 +3,20 @@
 set -eEuo pipefail
 
 BUNDLE="${1:?No bundle to upload}"
-DRY_RUN="${DRY_RUN:-}"
 
-echo "VERSION: $VERSION"
-echo "rclone version:"
-"$RCLONE" --version
+# ~/.aws/credentials is needed by rclone. If home is not set, expect
+# VERSION_FILE to contain the $HOME.
+if [ -z "${HOME:-}" ]; then
+    while read -r k v; do
+        case "$k" in
+            HOME)
+                export HOME="$v"
+                ;;
+        esac
+    done <"$VERSION_FILE"
+fi
+
+VERSION="$(cat $VERSION_TXT)"
 
 # Multipart upload does not work trough Cloudflare for some reason.
 # Just disabling it with `--s3-upload-cutoff` for now.


### PR DESCRIPTION
This reverts commit 831f9bce4134fe1ec5d77103a43118853bce6268.

There are some tests that (implicitely) assume that artifacts were uploaded by the time they run.