### PR TITLE
chore: remove bazel's check config

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -83,18 +83,6 @@ test --flaky_test_attempts=1
 build:dev --compilation_mode=fastbuild
 build:macos_ci --build_tag_filters="-system_test,-fuzz_test"
 
-# A config to get faster compilation feedback by skipping code generation.
-# We aim to do essentially the same thing as cargo check (https://doc.rust-lang.org/cargo/commands/cargo-check.html), which is to only emit metadata(.rmeta) files.
-# We do this by combining pipelined compilation and requesting only metadata files via --output_groups.
-#
-# pipelined_compilation=True means that we now build and depend on metadata files(`.rmeta`s)
-#   For more information on what pipelined compilation is, see https://internals.rust-lang.org/t/evaluating-pipelined-rustc-compilation/10199
-# TODO: consider always enabling this once we've confirmed it deterministically doesn't fail
-build:check --@rules_rust//rust/settings:pipelined_compilation=True
-# By requesting only the output group containing the metadata files, we don't run actions that do full compilation (e.g. codegen, linking)
-# and instead only run the ones that output metadata files
-build:check --output_groups=build_metadata
-
 # Fuzzing configuration
 build:fuzzing --action_env="SANITIZERS_ENABLED=1"
 # sanitizers are only supported in nightly


### PR DESCRIPTION
We don't use `bazel --config=check` anywhere anymore so we can remove the `check` config from `.bazelrc.build`.