### PR TITLE
chore(IDX): remove cloud credentials from k8s tests

### DIFF
--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -74,14 +74,6 @@ jobs:
         env:
           TNET_KUBECONFIG: ${{ secrets.TNET_KUBECONFIG }}
 
-      - name: Write AWS credentials
-        shell: bash
-        if: inputs.CLOUD_CREDENTIALS_CONTENT != ''
-        run: |
-          AWS_CREDS="${HOME}/.aws/credentials"
-          mkdir -p "$(dirname "${AWS_CREDS}")"
-          echo '${{ inputs.CLOUD_CREDENTIALS_CONTENT }}' >"$AWS_CREDS"
-
       - name: Run System Tests on K8s
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
@@ -152,14 +144,6 @@ jobs:
 
           # Export to GitHub environment
           echo "TARGETS=$T" >> $GITHUB_ENV
-
-      - name: Write AWS credentials
-        shell: bash
-        if: inputs.CLOUD_CREDENTIALS_CONTENT != ''
-        run: |
-          AWS_CREDS="${HOME}/.aws/credentials"
-          mkdir -p "$(dirname "${AWS_CREDS}")"
-          echo '${{ inputs.CLOUD_CREDENTIALS_CONTENT }}' >"$AWS_CREDS"
 
       - name: Run System Tests on K8s
         id: bazel-test-all


### PR DESCRIPTION
The credentials were not being set (`inputs` is not set for workflows).