### PR TITLE
chore: Remove defrag_canisters_map step

### DIFF
--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -2234,7 +2234,7 @@ impl StateManagerImpl {
     // Creates a checkpoint and switches state to it.
     fn create_checkpoint_and_switch(
         &self,
-        mut state: ReplicatedState,
+        state: ReplicatedState,
         height: Height,
     ) -> CreateCheckpointResult {
         self.observe_num_loaded_pagemaps(&state);
@@ -2295,18 +2295,6 @@ impl StateManagerImpl {
                 })
         };
 
-        {
-            let _timer = self
-                .metrics
-                .checkpoint_metrics
-                .make_checkpoint_step_duration
-                .with_label_values(&["defrag_canisters_map"])
-                .start_timer();
-
-            // This step is a functional no-op, but results in a cleaner memory layout that is ultimately faster to iterate over.
-            let canisters = std::mem::take(&mut state.canister_states);
-            state.canister_states = canisters.into_iter().collect();
-        }
         let (state, cp_layout) = checkpoint::make_unvalidated_checkpoint(
             state,
             height,


### PR DESCRIPTION
The defrag_canisters_map step during checkpointing was initially intended to be a functional no-op, while improving performance. In particular, it was intended to combat the slight performance difference between a subnet that was recently upgraded, and one that has been running for a while. However, it turned out that the step never lead to the desired significant improvements.

Now that checkpointing has been optimized to the area of 1 second with asynchronous checkpointing, the defrag_canisters_map step contributes as much as 40% to the checkpointing time on some subnets, which makes it not worth it.

This PR removes the step without replacement.