### PR TITLE
fix(IDX): set test_env for common build profile

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -58,7 +58,6 @@ test:paritytests --test_tag_filters="-system_test"
 build:ci --build_tag_filters="-system_test,-fuzz_test"
 
 test --test_output=errors
-test --test_env=RUST_BACKTRACE=full
 
 test:precommit --build_tests_only --test_tag_filters="smoke"
 
@@ -129,7 +128,10 @@ common --noexperimental_inmemory_dotd_files
 # This is particularly helpful for canbench, but other tests that follow this
 # convention would also benefit. If the test does not support this, this "almost
 # certainly" does no harm.
-test --test_env=CLICOLOR_FORCE=true
+common --test_env=CLICOLOR_FORCE=true
+
+# Show full backtrack on failure
+common --test_env=RUST_BACKTRACE=full
 
 # Give canceled actions some more time to cleanup
 common --local_termination_grace_seconds=90


### PR DESCRIPTION
This ensures that `--test_env` is also set in the `build`. While `--test_env` sets environment variables for test runners, it actually impacts the build/cache key. Because of this, having `--test_env` only set in `test` will thrash the analysis and potentially lead to rebuilds.