### PR TITLE
feat: [EXC-1824] Use mint_cycles128 in CMC

### DIFF
--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -38,21 +38,25 @@ pub const DEFAULT_XDR_PERMYRIAD_PER_ICP_CONVERSION_RATE: u64 = 1_000_000; // 1 I
 #[cfg(target_arch = "wasm32")]
 #[link(wasm_import_module = "ic0")]
 extern "C" {
-    pub fn mint_cycles(amount: u64) -> u64;
+    pub fn mint_cycles128(amount_high: u64, amount_low: u64, dst: usize);
 }
 
 /// # Safety
 /// This function always panics outside of wasm32, but the wasm32 version is safe to call from CMC.
 #[cfg(not(target_arch = "wasm32"))]
-pub unsafe fn mint_cycles(_amount: u64) -> u64 {
-    panic!("mint_cycles should only be called inside canisters.");
+pub unsafe fn mint_cycles128(_amount_high: u64, _amount_low: u64, _dst: usize) {
+    panic!("mint_cycles128 should only be called inside canisters.");
 }
 
 // Not available in ic_cdk
 /// This function can only be called from the CMC canister, and this is the CMC canister.
 /// It is not exposed in ic-cdk because it can't be called from anywhere else.
-pub fn ic0_mint_cycles(amount: u64) -> u64 {
-    unsafe { mint_cycles(amount) }
+pub fn ic0_mint_cycles128(amount_high: u64, amount_low: u64) -> u128 {
+    let mut dst = 0u128;
+    unsafe {
+        mint_cycles128(amount_high, amount_low, &mut dst as *mut u128 as usize);
+    }
+    dst
 }
 
 /// caller that returns principalId instead of Principal

--- a/rs/nns/cmc/src/lib.rs
+++ b/rs/nns/cmc/src/lib.rs
@@ -51,12 +51,13 @@ pub unsafe fn mint_cycles128(_amount_high: u64, _amount_low: u64, _dst: usize) {
 // Not available in ic_cdk
 /// This function can only be called from the CMC canister, and this is the CMC canister.
 /// It is not exposed in ic-cdk because it can't be called from anywhere else.
-pub fn ic0_mint_cycles128(amount_high: u64, amount_low: u64) -> u128 {
+pub fn ic0_mint_cycles128(amount: Cycles) -> Cycles {
+    let (amount_high, amount_low) = amount.into_parts();
     let mut dst = 0u128;
     unsafe {
         mint_cycles128(amount_high, amount_low, &mut dst as *mut u128 as usize);
     }
-    dst
+    Cycles::new(dst)
 }
 
 /// caller that returns principalId instead of Principal

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -2463,7 +2463,7 @@ fn ensure_balance(cycles: Cycles) -> Result<(), String> {
     let (amount_high, amount_low) = cycles_to_mint.into_parts();
     // unused because of check above
     let _minted_cycles = ic0_mint_cycles128(amount_high, amount_low);
-    assert!(u128::from(ic_cdk::api::canister_balance128()) >= cycles.get());
+    assert!(ic_cdk::api::canister_balance128() >= cycles.get());
     Ok(())
 }
 

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -2460,9 +2460,8 @@ fn ensure_balance(cycles: Cycles) -> Result<(), String> {
         Ok(())
     })?;
 
-    let (amount_high, amount_low) = cycles_to_mint.into_parts();
     // unused because of check above
-    let _minted_cycles = ic0_mint_cycles128(amount_high, amount_low);
+    let _minted_cycles = ic0_mint_cycles128(cycles_to_mint);
     assert!(ic_cdk::api::canister_balance128() >= cycles.get());
     Ok(())
 }

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -2436,7 +2436,7 @@ async fn do_create_canister(
 fn ensure_balance(cycles: Cycles) -> Result<(), String> {
     let now = now_system_time();
 
-    let current_balance = Cycles::from(ic_cdk::api::canister_balance());
+    let current_balance = Cycles::from(ic_cdk::api::canister_balance128());
     let cycles_to_mint = cycles - current_balance;
 
     with_state_mut(|state| {
@@ -2460,13 +2460,10 @@ fn ensure_balance(cycles: Cycles) -> Result<(), String> {
         Ok(())
     })?;
 
-    ic0_mint_cycles(
-        cycles_to_mint
-            .get()
-            .try_into()
-            .map_err(|_| "Cycles u64 overflow".to_owned())?,
-    );
-    assert!(u128::from(ic_cdk::api::canister_balance()) >= cycles.get());
+    let (amount_high, amount_low) = cycles_to_mint.into_parts();
+    // unused because of check above
+    let _minted_cycles = ic0_mint_cycles128(amount_high, amount_low);
+    assert!(u128::from(ic_cdk::api::canister_balance128()) >= cycles.get());
     Ok(())
 }
 

--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -2256,11 +2256,11 @@ async fn deposit_cycles(
         ensure_balance(cycles)?;
     }
 
-    let res: CallResult<()> = ic_cdk::api::call::call_with_payment(
+    let res: CallResult<()> = ic_cdk::api::call::call_with_payment128(
         IC_00.get().0,
         &Method::DepositCycles.to_string(),
         (CanisterIdRecord::from(canister_id),),
-        u128::from(cycles) as u64,
+        u128::from(cycles),
     )
     .await;
 
@@ -2291,11 +2291,11 @@ async fn do_mint_cycles(
         memo: deposit_memo,
     };
 
-    let result: CallResult<(CyclesLedgerDepositResult,)> = ic_cdk::api::call::call_with_payment(
+    let result: CallResult<(CyclesLedgerDepositResult,)> = ic_cdk::api::call::call_with_payment128(
         cycles_ledger_canister_id.get().0,
         "deposit",
         (arg,),
-        u128::from(cycles) as u64,
+        u128::from(cycles),
     )
     .await;
 
@@ -2398,14 +2398,14 @@ async fn do_create_canister(
         });
 
     for subnet_id in subnets {
-        let result: CallResult<(CanisterIdRecord,)> = ic_cdk::api::call::call_with_payment(
+        let result: CallResult<(CanisterIdRecord,)> = ic_cdk::api::call::call_with_payment128(
             subnet_id.get().0,
             &Method::CreateCanister.to_string(),
             (CreateCanisterArgs {
                 settings: Some(Ic00CanisterSettingsArgs::from(canister_settings.clone())),
                 sender_canister_version: Some(ic_cdk::api::canister_version()),
             },),
-            cycles.get().try_into().unwrap(),
+            u128::from(cycles),
         )
         .await;
 

--- a/rs/nns/cmc/unreleased_changelog.md
+++ b/rs/nns/cmc/unreleased_changelog.md
@@ -11,6 +11,8 @@ on the process that this file is part of, see
 
 ## Changed
 
+- Use the mint_cycles128 system API, so larger amounts of cycles can now be minted. 
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
With this PR, the cycles minting canister uses the 128bit minting and balance API. 