### PR TITLE
feat(icrc-rosetta): add icrc rosetta release 1.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9568,7 +9568,7 @@ dependencies = [
 
 [[package]]
 name = "ic-icrc-rosetta"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "axum 0.8.4",

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -82,7 +82,7 @@ MACRO_DEV_DEPENDENCIES = [
 ALIASES = {
 }
 
-ROSETTA_VERSION = "1.2.2"
+ROSETTA_VERSION = "1.2.3"
 
 rust_library(
     name = "ic-icrc-rosetta",

--- a/rs/rosetta-api/icrc1/CHANGELOG.md
+++ b/rs/rosetta-api/icrc1/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.3] - 2025-05-27
+### Fixed
+- Fixed fee collector balance calculation for transfers using fee_collector_block_index ([#5304](https://github.com/dfinity/ic/pull/5304))
+
 ## [1.2.2] - 2025-06-15
 ### Fixed
 - Fixed timestamp overflow in blocks table for values exceeding i64::MAX ([#5249](https://github.com/dfinity/ic/pull/5249))

--- a/rs/rosetta-api/icrc1/Cargo.toml
+++ b/rs/rosetta-api/icrc1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ic-icrc-rosetta"
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 default-run = "ic-icrc-rosetta"
-version = "1.2.2"
+version = "1.2.3"
 authors.workspace = true
 edition.workspace = true
 documentation.workspace = true

--- a/rs/rosetta-api/icrc1/src/common/constants.rs
+++ b/rs/rosetta-api/icrc1/src/common/constants.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 pub const DEFAULT_BLOCKCHAIN: &str = "Internet Computer";
-pub const ROSETTA_VERSION: &str = "1.2.2";
+pub const ROSETTA_VERSION: &str = "1.2.3";
 pub const NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const INGRESS_INTERVAL_SECS: u64 = 4 * 60;
 pub const BLOCK_SYNC_WAIT_SECS: u64 = 1;


### PR DESCRIPTION
Release information for ICRC Rosetta 1.2.3 with the following changes:

- Fixed fee collector balance calculation for transfers using fee_collector_block_index

The balance calculation wasn't taking into account fees being sent to fee collectors defined in a different block, which led to fee collector accounts having wrong balances in the local Rosetta DB.

This release:
- Makes sure that fee collectors' balances are correctly modified in such cases
- Reconciles balances of DBs potentially affected by the bug at startup by recreating the balances table. We keep track when this fix has happened for a particular DB so we only do it once.