### PR TITLE
fix: full suffix for sha matching in tests

### DIFF
--- a/rs/tests/consensus/utils/src/upgrade.rs
+++ b/rs/tests/consensus/utils/src/upgrade.rs
@@ -71,7 +71,7 @@ pub async fn fetch_update_file_sha256(version_str: &str) -> Result<String, Strin
         .map_err(|err| format!("Something went wrong reading the file: {:?}", err))?;
     for line in contents.lines() {
         let words: Vec<&str> = line.split(char::is_whitespace).collect();
-        let suffix = "-img.tar.zst";
+        let suffix = "update-img.tar.zst";
         if words.len() == 2 && words[1].ends_with(suffix) {
             return Ok(words[0].to_string());
         }


### PR DESCRIPTION
We had an incident (fixed in #5305) where all of the artifacts were uploaded to the same SHA256SUMS file on our object storages. This causes the current test logic to assume and expect wrong SHA since the SHAs are sorted in an ascending order in the SHA256SUMS. 

In this logic we only download update images and this is just a stronger requirement that will prevent the explained bug from happening again. Currently this breaks our qualification system test since the node is constantly expecting a wrong SHA.

An example file that breaks the code and is fixed by this pr can be downloaded [here](http://download.proxy-global.dfinity.network:8080/ic/181968dd5f36af93590490802540caf7d2df915a/guest-os/update-img/SHA256SUMS) 