### PR TITLE
feat(orchestrator): [CON-1502] Include latest CUP time in orchestrator's dashboard

### DIFF
--- a/rs/orchestrator/src/dashboard.rs
+++ b/rs/orchestrator/src/dashboard.rs
@@ -175,6 +175,7 @@ impl OrchestratorDashboard {
                 let hash = cup.content.state_hash.get().0;
 
                 let unix_timestamp = cup.content.block.get_value().context.time;
+                // UNIX timestamp in nanoseconds followed by the human-readable representation
                 let timestamp_str = format!(
                     "{} ({})",
                     unix_timestamp.as_nanos_since_unix_epoch(),


### PR DESCRIPTION
During recoveries of subnets that stalled (or halted) at a CUP height, we can simply propose a recovery CUP without replaying any blocks. For that we need to determine Height, State Hash and Time of the recovery CUP to be submitted.

The height and hash of the current CUP is already present on the orchestrator dashboard. This PR includes the consensus time of the CUP.

Example of the dashboard when no CUPs are present (initialization):
<img width="776" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/5df256d5-a501-44ad-b455-3576b45a7433" />

Example of the dashboard with a CUP:
<img width="796" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/fa87d44d-c66c-4b08-bf84-0b22cfe95fea" />
