### PR TITLE
feat: Increase MAX_NEURON_CREATION_SPIKE to 20 hours worth of neurons

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -214,7 +214,11 @@ pub const MAX_SUSTAINED_NEURONS_PER_HOUR: u64 = 15;
 
 pub const MINIMUM_SECONDS_BETWEEN_ALLOWANCE_INCREASE: u64 = 3600 / MAX_SUSTAINED_NEURONS_PER_HOUR;
 
-pub const MAX_NEURON_CREATION_SPIKE: u64 = MAX_SUSTAINED_NEURONS_PER_HOUR * 8;
+/// The maximum number of neurons that can be created in a spike. Note that such rate of neuron
+/// creation is not sustainable as the allowance will be exhausted after creating this many neurons
+/// in a short period of time, and the allowance will only be increased according to
+/// `MINIMUM_SECONDS_BETWEEN_ALLOWANCE_INCREASE`.
+pub const MAX_NEURON_CREATION_SPIKE: u64 = MAX_SUSTAINED_NEURONS_PER_HOUR * 20;
 
 /// The maximum number results returned by the method `list_proposals`.
 pub const MAX_LIST_PROPOSAL_RESULTS: u32 = 100;

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,6 +11,8 @@ on the process that this file is part of, see
 
 ## Changed
 
+* `MAX_NEURON_CREATION_SPIKE` is increased from 120 to 300.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
# Why

Neuron creation is sometime spiky and from time to time the rate limiting is triggered. After neurons are moved to stable memory, such spike is less risky. Therefore, we'd like to allow such spike while still keeping the rate limiting in place until there is a more effective way of preventing the neuron limit from being reached quickly.

# What

* Increase `MAX_NEURON_CREATION_SPIKE` from 8x `MAX_SUSTAINED_NEURONS_PER_HOUR` to 20x `MAX_SUSTAINED_NEURONS_PER_HOUR`
* Add comments on the constant.