### PR TITLE
chore(IDX): build all bazel targets on mac

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           upload-artifacts: ${{ needs.config.outputs.release_build && needs.config.outputs.full_macos_build }}
           BAZEL_COMMAND: ${{ steps.cfg.outputs.build-command }}
-          BAZEL_TARGETS: //rs/... //:upload-artifacts
+          BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ''
       - name: Purge Bazel Output

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -206,7 +206,7 @@ jobs:
         with:
           upload-artifacts: ${{ needs.config.outputs.release_build && needs.config.outputs.full_macos_build }}
           BAZEL_COMMAND: ${{ steps.cfg.outputs.build-command }}
-          BAZEL_TARGETS: //rs/... //:upload-artifacts
+          BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ''
       - name: Purge Bazel Output

--- a/.github/workflows/test-namespace-darwin.yaml
+++ b/.github/workflows/test-namespace-darwin.yaml
@@ -41,7 +41,7 @@ jobs:
             test \
             --config=ci --config=macos_ci \
             --test_tag_filters="test_macos,test_macos_slow" \
-            //packages/pocket-ic/... //rs/... //publish/binaries/...
+            //...
 
           mkdir -p build
           cp \


### PR DESCRIPTION
We recently had some bugs that would have been caught if we would build all targets (`//...`) on Mac.