### PR TITLE
chore: PocketIC server v9.0.3 and PocketIC library v9.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18456,7 +18456,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "9.0.1"
+version = "9.0.2"
 dependencies = [
  "backoff",
  "base64 0.13.1",
@@ -18496,7 +18496,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic-server"
-version = "9.0.2"
+version = "9.0.3"
 dependencies = [
  "aide",
  "askama",

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -51,7 +51,7 @@ rust_library(
     name = "pocket-ic",
     srcs = glob(["src/**/*.rs"]),
     proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "9.0.1",
+    version = "9.0.2",
     deps = DEPENDENCIES,
 )
 

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 9.0.1 - 2025-05-16
+## 9.0.2 - 2025-05-30
+
+(Only PocketIC server version bump to v9.0.3.)
+
+
+
+## 9.0.1 - 2025-05-27
+
+(Only PocketIC server version bump to v9.0.2.)
+
+
 
 ## 9.0.0 - 2025-04-30
 

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-ic"
-version = "9.0.1"
+version = "9.0.2"
 license = "Apache-2.0"
 description = "PocketIC: A Canister Smart Contract Testing Platform"
 repository = "https://github.com/dfinity/ic"

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -98,7 +98,7 @@ use wslpath::windows_to_wsl;
 pub mod common;
 pub mod nonblocking;
 
-pub const EXPECTED_SERVER_VERSION: &str = "9.0.2";
+pub const EXPECTED_SERVER_VERSION: &str = "9.0.3";
 
 // the default timeout of a PocketIC operation
 const DEFAULT_MAX_REQUEST_TIME_MS: u64 = 300_000;

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -164,7 +164,7 @@ rust_library(
     ]),
     crate_name = "pocket_ic_server",
     proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "9.0.2",
+    version = "9.0.3",
     deps = LIB_DEPENDENCIES + [":build_script"],
 )
 

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+
+## 9.0.3 - 2025-05-30
+
 ### Changed
 - The endpoint `/instances/<instance_id>/auto_progress` sets the (certified) time of the PocketIC instance
   to the current system time before starting to execute rounds automatically.
@@ -22,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## 9.0.2 - 2025-05-16
+## 9.0.2 - 2025-05-27
 
 ### Fixed
 - Crash when creating a canister with a specified id on a PocketIC instance created from an existing PocketIC state.

--- a/rs/pocket_ic_server/Cargo.toml
+++ b/rs/pocket_ic_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-ic-server"
-version = "9.0.2"
+version = "9.0.3"
 edition = "2021"
 
 [dependencies]

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -57,7 +57,7 @@ const LOG_DIR_PATH_ENV_NAME: &str = "POCKET_IC_LOG_DIR";
 const LOG_DIR_LEVELS_ENV_NAME: &str = "POCKET_IC_LOG_DIR_LEVELS";
 
 #[derive(Parser)]
-#[clap(version = "9.0.2")]
+#[clap(version = "9.0.3")]
 struct Args {
     /// The IP address to which the PocketIC server should bind (defaults to 127.0.0.1)
     #[clap(long, short)]


### PR DESCRIPTION
This PR releases PocketIC server v9.0.3 and PocketIC library v9.0.2.