### PR TITLE
fix(node): remove config tool dependency for dev variants

### DIFF
--- a/ic-os/guestos/defs.bzl
+++ b/ic-os/guestos/defs.bzl
@@ -110,7 +110,6 @@ def image_deps(mode, malicious = False):
     deps.update(image_variants[mode])
 
     if "dev" in mode:
-        # Remove the original config tool and add the dev version
         deps["rootfs"].pop("//rs/ic_os/release:config", None)
         deps["rootfs"].update({"//rs/ic_os/release:config_dev": "/opt/ic/bin/config:0755"})
 

--- a/ic-os/guestos/defs.bzl
+++ b/ic-os/guestos/defs.bzl
@@ -110,6 +110,8 @@ def image_deps(mode, malicious = False):
     deps.update(image_variants[mode])
 
     if "dev" in mode:
+        # Remove the original config tool and add the dev version
+        deps["rootfs"].pop("//rs/ic_os/release:config", None)
         deps["rootfs"].update({"//rs/ic_os/release:config_dev": "/opt/ic/bin/config:0755"})
 
     # Add extra files depending on image variant

--- a/ic-os/hostos/defs.bzl
+++ b/ic-os/hostos/defs.bzl
@@ -79,7 +79,6 @@ def image_deps(mode, _malicious = False):
     deps.update(image_variants[mode])
 
     if "dev" in mode:
-        # Remove the original config tool and add the dev version
         deps["rootfs"].pop("//rs/ic_os/release:config", None)
         deps["rootfs"].update({"//rs/ic_os/release:config_dev": "/opt/ic/bin/config:0755"})
 

--- a/ic-os/hostos/defs.bzl
+++ b/ic-os/hostos/defs.bzl
@@ -79,6 +79,8 @@ def image_deps(mode, _malicious = False):
     deps.update(image_variants[mode])
 
     if "dev" in mode:
+        # Remove the original config tool and add the dev version
+        deps["rootfs"].pop("//rs/ic_os/release:config", None)
         deps["rootfs"].update({"//rs/ic_os/release:config_dev": "/opt/ic/bin/config:0755"})
 
     return deps

--- a/ic-os/setupos/defs.bzl
+++ b/ic-os/setupos/defs.bzl
@@ -74,7 +74,6 @@ def image_deps(mode, _malicious = False):
     deps.update(image_variants[mode])
 
     if "dev" in mode:
-        # Remove the original config tool and add the dev version
         deps["rootfs"].pop("//rs/ic_os/release:config", None)
         deps["rootfs"].update({"//rs/ic_os/release:config_dev": "/opt/ic/bin/config:0755"})
 

--- a/ic-os/setupos/defs.bzl
+++ b/ic-os/setupos/defs.bzl
@@ -74,6 +74,8 @@ def image_deps(mode, _malicious = False):
     deps.update(image_variants[mode])
 
     if "dev" in mode:
+        # Remove the original config tool and add the dev version
+        deps["rootfs"].pop("//rs/ic_os/release:config", None)
         deps["rootfs"].update({"//rs/ic_os/release:config_dev": "/opt/ic/bin/config:0755"})
 
     return deps


### PR DESCRIPTION
`$ bazel query 'deps("//ic-os/hostos/envs/dev")' | grep //rs/ic_os/release:config
//rs/ic_os/release:config_dev
//rs/ic_os/release:config_dev_cleaned
//rs/ic_os/release:config_dev_stripped`


Context: https://github.com/dfinity/ic/pull/5325#discussion_r2112651100