### PR TITLE
feat(sns): Introduce ManageSnsExtensionCapabilities proposals

### DIFF
--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -697,7 +697,11 @@ type TreasuryManagerFunction = variant {
 
 type ExecuteCapabilityBasedFunction = record {
   dapp_canister_id : opt principal;
-  function : opt TreasuryManagerFunction;
+  function : opt CapabilityBasedFunction;
+};
+
+type CapabilityBasedFunction = variant {
+  TreasuryManagerFunction : TreasuryManagerFunction;
 };
 
 type Capability = variant {
@@ -706,7 +710,7 @@ type Capability = variant {
   // Granting this capability will register the following capability-based functions:
   // - deposit()
   // - withdraw()
-  TreasuryManager : record {};
+  TreasuryManagerCapability : record {};
 };
 
 type Capabilities = record {

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -690,11 +690,18 @@ type Capabilities = record {
   capabilities : vec Capability;
 }
 
+type Extension = record {
+  canister_id : opt principal;
+
+  // Each capability has a list of supported SNS extension versions.
+  module_hash : opt blob;
+};
+
 type ManageSnsExtensionCapabilities = record {
-  // Which of the dapp canisters is being promoted to have some capabilities?
+  // Which SNS extension (dapp canister) is being managed?
   extension : opt Extension;
 
-  // The SNS should set these treasury allowances while registering the treasury manager.
+  // Which SNS extension (dapp canister) should this extension have?
   capabilities : opt Capabilities;
 };
 

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -12,7 +12,7 @@ type Action = variant {
   UpgradeSnsToNextVersion : record {};
   AdvanceSnsTargetVersion : AdvanceSnsTargetVersion;
   RegisterDappCanisters : RegisterDappCanisters;
-  ManageSnsExtensionCapabilities : ManageSnsExtensionCapabilities;
+  ManageRegisterDappCapabilities : ManageRegisterDappCapabilities;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
   DeregisterDappCanisters : DeregisterDappCanisters;
@@ -20,6 +20,7 @@ type Action = variant {
   Unspecified : record {};
   ManageSnsMetadata : ManageSnsMetadata;
   ExecuteGenericNervousSystemFunction : ExecuteGenericNervousSystemFunction;
+  ExecuteCapabilityBasedFunction : ExecuteCapabilityBasedFunction;
   ManageLedgerParameters : ManageLedgerParameters;
   Motion : Motion;
 };
@@ -204,6 +205,11 @@ type DissolveState = variant {
 
 type ExecuteGenericNervousSystemFunction = record {
   function_id : nat64;
+  payload : blob;
+};
+
+type ExecuteCustomProposal = record {
+  proposal_id : opt ProposalId;
   payload : blob;
 };
 
@@ -678,30 +684,48 @@ type Allowances = record {
   icrc2_allowances : opt vec Icrc2Allowance;
 };
 
-type TreasuryManagerArgs = record {
+type Deposit = record {
   allowances : opt Allowances;
 };
 
+type Withdraw = record {};
+
+type TreasuryManagerFunction = variant {
+  Deposit : Deposit;
+  Withdraw : Withdraw;
+};
+
+type ExecuteCapabilityBasedFunction = record {
+  dapp_canister_id : opt principal;
+  function : opt TreasuryManagerFunction;
+};
+
 type Capability = variant {
-  TreasuryManager : TreasuryManagerArgs;
+  // This capability enabled a dapp canister to manage some treasury tokens on behalf of the DAO.
+  //
+  // Granting this capability will register the following capability-based functions:
+  // - deposit()
+  // - withdraw()
+  TreasuryManager : record {};
 };
 
 type Capabilities = record {
   capabilities : vec Capability;
 }
 
-type Extension = record {
-  canister_id : opt principal;
+type ManageRegisterDappCapabilities = record {
+  // Which dapp canister is being managed?
+  dapp_canister_id : opt principal;
 
-  // Each capability has a list of supported SNS extension versions.
+  // This field is used to specify the intended version of the dapp canister module for which
+  // the capabilities are being registered. Some capabilities may be granted only for specific
+  // canister versions modules, e.g., to ensure compatibility and safety. For these capabilities,
+  // the SNS will check the module hash of the dapp canister against this value. If it matches,
+  // the SNS will render the proposal text to indicate the most important aspects required for
+  // the voters to make a decision, e.g., the declared purpose, and where to find the source code.
   module_hash : opt blob;
-};
 
-type ManageSnsExtensionCapabilities = record {
-  // Which SNS extension (dapp canister) is being managed?
-  extension : opt Extension;
-
-  // Which SNS extension (dapp canister) should this extension have?
+  // Which capabilities should this dapp canister have?
   capabilities : opt Capabilities;
 };
 

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -12,6 +12,7 @@ type Action = variant {
   UpgradeSnsToNextVersion : record {};
   AdvanceSnsTargetVersion : AdvanceSnsTargetVersion;
   RegisterDappCanisters : RegisterDappCanisters;
+  ManageSnsExtensionCapabilities : ManageSnsExtensionCapabilities;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
   DeregisterDappCanisters : DeregisterDappCanisters;
@@ -661,6 +662,40 @@ type QueryStats = record {
 
 type RegisterDappCanisters = record {
   canister_ids : vec principal;
+};
+
+type Icrc2Token = variant {
+  NativeSnsToken : record {};
+  Icp : record {};
+};
+
+type Icrc2Allowance = record {
+    token : opt Icrc2Token;
+    amount_e8s : opt nat64;
+};
+
+type Allowances = record {
+  icrc2_allowances : opt vec Icrc2Allowance;
+};
+
+type TreasuryManagerArgs = record {
+  allowances : opt Allowances;
+};
+
+type Capability = variant {
+  TreasuryManager : TreasuryManagerArgs;
+};
+
+type Capabilities = record {
+  capabilities : vec Capability;
+}
+
+type ManageSnsExtensionCapabilities = record {
+  // Which of the dapp canisters is being promoted to have some capabilities?
+  extension : opt Extension;
+
+  // The SNS should set these treasury allowances while registering the treasury manager.
+  capabilities : opt Capabilities;
 };
 
 type RegisterVote = record {

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -208,11 +208,6 @@ type ExecuteGenericNervousSystemFunction = record {
   payload : blob;
 };
 
-type ExecuteCustomProposal = record {
-  proposal_id : opt ProposalId;
-  payload : blob;
-};
-
 type FinalizeDisburseMaturity = record {
   amount_to_be_disbursed_e8s : nat64;
   to_account : opt Account;
@@ -234,6 +229,7 @@ type Followees = record {
 type FunctionType = variant {
   NativeNervousSystemFunction : record {};
   GenericNervousSystemFunction : GenericNervousSystemFunction;
+  CapabilityBasedFunction : CapabilityBasedFunctionDescription;
 };
 
 type GenericNervousSystemFunction = record {
@@ -241,6 +237,14 @@ type GenericNervousSystemFunction = record {
   target_canister_id : opt principal;
   validator_method_name : opt text;
   target_method_name : opt text;
+  topic : opt Topic;
+};
+
+type CapabilityBasedFunctionDescription = record {
+  dapp_canister_id : opt principal;
+  function_name : opt text;
+  capability_name : opt text;
+  description : opt text;
   topic : opt Topic;
 };
 

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -12,7 +12,7 @@ type Action = variant {
   UpgradeSnsToNextVersion : record {};
   AdvanceSnsTargetVersion : AdvanceSnsTargetVersion;
   RegisterDappCanisters : RegisterDappCanisters;
-  ManageRegisterDappCapabilities : ManageRegisterDappCapabilities;
+  ManageDappCanisterCapabilities : ManageDappCanisterCapabilities;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
   DeregisterDappCanisters : DeregisterDappCanisters;
@@ -704,20 +704,25 @@ type CapabilityBasedFunction = variant {
   TreasuryManagerFunction : TreasuryManagerFunction;
 };
 
+type TreasuryManager = record {
+  initial_deposit : opt Deposit;
+};
+
 type Capability = variant {
-  // This capability enabled a dapp canister to manage some treasury tokens on behalf of the DAO.
+  // This capability enabled a dapp canister to manage some treasury tokens on behalf of the SNS.
+  // The initial allowances can be set 
   //
   // Granting this capability will register the following capability-based functions:
   // - deposit()
   // - withdraw()
-  TreasuryManagerCapability : record {};
+  TreasuryManager : TreasuryManager;
 };
 
 type Capabilities = record {
   capabilities : vec Capability;
 }
 
-type ManageRegisterDappCapabilities = record {
+type ManageDappCanisterCapabilities = record {
   // Which dapp canister is being managed?
   dapp_canister_id : opt principal;
 


### PR DESCRIPTION
This PR introduces the API granting and revoking capabilities to SNS controlled dapp canisters. 