### PR TITLE
chore: Upgrade canbench to 0.15.0

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "7a55c4477a7651e560f00f390617f581a0fcaf13694117cded41332e155ec33d",
+  "checksum": "5e28c1de0af6e84f24865ae66dd1471bc2527274516e0e8a6c44110ad1328ca2",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -11522,14 +11522,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "canbench 0.1.9": {
+    "canbench 0.1.15": {
       "name": "canbench",
-      "version": "0.1.9",
+      "version": "0.1.15",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench/0.1.9/download",
-          "sha256": "c3eba78c84aa78e67f27c5c5a7d6c3d33cc301f95886171748e8f6ed8a31b258"
+          "url": "https://static.crates.io/crates/canbench/0.1.15/download",
+          "sha256": "5c346cb41bf01bac3c8494eef82943d4dc49267981c8bcb548ba8f4cc69f3161"
         }
       },
       "targets": [
@@ -11566,7 +11566,7 @@
         "deps": {
           "common": [
             {
-              "id": "canbench-rs 0.1.9",
+              "id": "canbench-rs 0.1.15",
               "target": "canbench_rs"
             },
             {
@@ -11590,12 +11590,20 @@
               "target": "hex"
             },
             {
-              "id": "pocket-ic 6.0.0",
+              "id": "inferno 0.11.19",
+              "target": "inferno"
+            },
+            {
+              "id": "pocket-ic 9.0.1",
               "target": "pocket_ic"
             },
             {
               "id": "reqwest 0.11.27",
               "target": "reqwest"
+            },
+            {
+              "id": "rustc-demangle 0.1.23",
+              "target": "rustc_demangle"
             },
             {
               "id": "semver 1.0.22",
@@ -11618,6 +11626,10 @@
               "target": "tempfile"
             },
             {
+              "id": "walrus 0.23.3",
+              "target": "walrus"
+            },
+            {
               "id": "wasmparser 0.119.0",
               "target": "wasmparser"
             }
@@ -11625,7 +11637,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.9"
+        "version": "0.1.15"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -11633,14 +11645,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs 0.1.9": {
+    "canbench-rs 0.1.15": {
       "name": "canbench-rs",
-      "version": "0.1.9",
+      "version": "0.1.15",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs/0.1.9/download",
-          "sha256": "588701e2d05679b79603acca6a6f8b78fe0d21f5f7a9c06fe689f769ae797008"
+          "url": "https://static.crates.io/crates/canbench-rs/0.1.15/download",
+          "sha256": "c1c560e37bb75c6900e18e7d37174efaff09e266d138d9926e34f489d9d2f6a0"
         }
       },
       "targets": [
@@ -11669,7 +11681,7 @@
               "target": "candid"
             },
             {
-              "id": "ic-cdk 0.12.2",
+              "id": "ic-cdk 0.17.2",
               "target": "ic_cdk"
             },
             {
@@ -11683,13 +11695,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "canbench-rs-macros 0.1.9",
+              "id": "canbench-rs-macros 0.1.15",
               "target": "canbench_rs_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.9"
+        "version": "0.1.15"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -11697,14 +11709,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs-macros 0.1.9": {
+    "canbench-rs-macros 0.1.15": {
       "name": "canbench-rs-macros",
-      "version": "0.1.9",
+      "version": "0.1.15",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.9/download",
-          "sha256": "e05fe21a7dfc85c3be8e40edbbcb3fe23b4c070fac4741eff18129f1d0f11aa9"
+          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.15/download",
+          "sha256": "866a310ae95dfd273c2f1d17c8382d0d893c35851e9252cca98bd3a80a7e5635"
         }
       },
       "targets": [
@@ -11744,7 +11756,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.9"
+        "version": "0.1.15"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -20174,11 +20186,11 @@
               "target": "cached"
             },
             {
-              "id": "canbench 0.1.9",
+              "id": "canbench 0.1.15",
               "target": "canbench"
             },
             {
-              "id": "canbench-rs 0.1.9",
+              "id": "canbench-rs 0.1.15",
               "target": "canbench_rs"
             },
             {
@@ -33080,74 +33092,6 @@
       ],
       "license_file": null
     },
-    "ic-cdk 0.12.2": {
-      "name": "ic-cdk",
-      "version": "0.12.2",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk/0.12.2/download",
-          "sha256": "0e908da565d9e304e83732500069ebb959e3d2cad80f894889ea37207112c7a0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_cdk",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_cdk",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "candid 0.10.13",
-              "target": "candid"
-            },
-            {
-              "id": "ic0 0.21.1",
-              "target": "ic0"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "serde_bytes 0.11.15",
-              "target": "serde_bytes"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "ic-cdk-macros 0.8.4",
-              "target": "ic_cdk_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.12.2"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
     "ic-cdk 0.17.2": {
       "name": "ic-cdk",
       "version": "0.17.2",
@@ -33374,73 +33318,6 @@
         "Apache-2.0"
       ],
       "license_file": null
-    },
-    "ic-cdk-macros 0.8.4": {
-      "name": "ic-cdk-macros",
-      "version": "0.8.4",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk-macros/0.8.4/download",
-          "sha256": "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "ic_cdk_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_cdk_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "candid 0.10.13",
-              "target": "candid"
-            },
-            {
-              "id": "proc-macro2 1.0.95",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.40",
-              "target": "quote"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "serde_tokenstream 0.1.7",
-              "target": "serde_tokenstream"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.8.4"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
     },
     "ic-cdk-macros 0.17.2": {
       "name": "ic-cdk-macros",
@@ -33729,73 +33606,6 @@
         "Apache-2.0"
       ],
       "license_file": null
-    },
-    "ic-certification 2.6.0": {
-      "name": "ic-certification",
-      "version": "2.6.0",
-      "package_url": "https://github.com/dfinity/response-verification",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-certification/2.6.0/download",
-          "sha256": "e64ee3d8b6e81b51f245716d3e0badb63c283c00f3c9fb5d5219afc30b5bf821"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_certification",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_certification",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "serde",
-            "serde_bytes"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "serde_bytes 0.11.15",
-              "target": "serde_bytes"
-            },
-            {
-              "id": "sha2 0.10.9",
-              "target": "sha2"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.6.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
     },
     "ic-certification 3.0.3": {
       "name": "ic-certification",
@@ -34910,14 +34720,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-transport-types 0.37.1": {
+    "ic-transport-types 0.39.3": {
       "name": "ic-transport-types",
-      "version": "0.37.1",
+      "version": "0.39.3",
       "package_url": "https://github.com/dfinity/agent-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-transport-types/0.37.1/download",
-          "sha256": "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
+          "url": "https://static.crates.io/crates/ic-transport-types/0.39.3/download",
+          "sha256": "979ee7bee5a67150a4c090fb012c93c294a528b4a867bad9a15cc6d01cb4227f"
         }
       },
       "targets": [
@@ -34950,7 +34760,7 @@
               "target": "hex"
             },
             {
-              "id": "ic-certification 2.6.0",
+              "id": "ic-certification 3.0.3",
               "target": "ic_certification"
             },
             {
@@ -34966,11 +34776,15 @@
               "target": "serde_bytes"
             },
             {
+              "id": "serde_cbor 0.11.2",
+              "target": "serde_cbor"
+            },
+            {
               "id": "sha2 0.10.9",
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.68",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             }
           ],
@@ -34986,7 +34800,7 @@
           ],
           "selects": {}
         },
-        "version": "0.37.1"
+        "version": "0.39.3"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -35662,44 +35476,6 @@
         ],
         "edition": "2021",
         "version": "0.18.11"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "ic0 0.21.1": {
-      "name": "ic0",
-      "version": "0.21.1",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic0/0.21.1/download",
-          "sha256": "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic0",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic0",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "0.21.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -37701,7 +37477,11 @@
         ],
         "crate_features": {
           "common": [
+            "crossbeam-channel",
+            "crossbeam-utils",
+            "dashmap",
             "indexmap",
+            "multithreaded",
             "nameattr"
           ],
           "selects": {}
@@ -37711,6 +37491,18 @@
             {
               "id": "ahash 0.8.11",
               "target": "ahash"
+            },
+            {
+              "id": "crossbeam-channel 0.5.15",
+              "target": "crossbeam_channel"
+            },
+            {
+              "id": "crossbeam-utils 0.8.19",
+              "target": "crossbeam_utils"
+            },
+            {
+              "id": "dashmap 5.5.3",
+              "target": "dashmap"
             },
             {
               "id": "indexmap 2.7.1",
@@ -54556,14 +54348,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "pocket-ic 6.0.0": {
+    "pocket-ic 9.0.1": {
       "name": "pocket-ic",
-      "version": "6.0.0",
+      "version": "9.0.1",
       "package_url": "https://github.com/dfinity/ic",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pocket-ic/6.0.0/download",
-          "sha256": "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
+          "url": "https://static.crates.io/crates/pocket-ic/9.0.1/download",
+          "sha256": "bc8ef97f44d4a20b43695690f478f6bfc4058f3ead7d51aff79be29bcfd810c5"
         }
       },
       "targets": [
@@ -54588,6 +54380,10 @@
         "deps": {
           "common": [
             {
+              "id": "backoff 0.4.0",
+              "target": "backoff"
+            },
+            {
               "id": "base64 0.13.1",
               "target": "base64"
             },
@@ -54596,15 +54392,23 @@
               "target": "candid"
             },
             {
+              "id": "flate2 1.0.31",
+              "target": "flate2"
+            },
+            {
               "id": "hex 0.4.3",
               "target": "hex"
             },
             {
-              "id": "ic-certification 2.6.0",
+              "id": "ic-certification 3.0.3",
               "target": "ic_certification"
             },
             {
-              "id": "ic-transport-types 0.37.1",
+              "id": "ic-management-canister-types 0.3.0",
+              "target": "ic_management_canister_types"
+            },
+            {
+              "id": "ic-transport-types 0.39.3",
               "target": "ic_transport_types"
             },
             {
@@ -54644,7 +54448,11 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.68",
+              "id": "tempfile 3.12.0",
+              "target": "tempfile"
+            },
+            {
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             },
             {
@@ -54683,7 +54491,7 @@
           ],
           "selects": {}
         },
-        "version": "6.0.0"
+        "version": "9.0.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -68660,61 +68468,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_tokenstream 0.1.7": {
-      "name": "serde_tokenstream",
-      "version": "0.1.7",
-      "package_url": "https://github.com/oxidecomputer/serde_tokenstream",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/serde_tokenstream/0.1.7/download",
-          "sha256": "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "serde_tokenstream",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "serde_tokenstream",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.95",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.7"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
     "serde_tokenstream 0.2.1": {
       "name": "serde_tokenstream",
       "version": "0.2.1",
@@ -82527,6 +82280,87 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "walrus 0.23.3": {
+      "name": "walrus",
+      "version": "0.23.3",
+      "package_url": "https://github.com/rustwasm/walrus",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/walrus/0.23.3/download",
+          "sha256": "6481311b98508f4bc2d0abbfa5d42172e7a54b4b24d8f15e28b0dc650be0c59f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "walrus",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "walrus",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.98",
+              "target": "anyhow"
+            },
+            {
+              "id": "gimli 0.26.2",
+              "target": "gimli"
+            },
+            {
+              "id": "id-arena 2.2.1",
+              "target": "id_arena"
+            },
+            {
+              "id": "leb128 0.2.5",
+              "target": "leb128"
+            },
+            {
+              "id": "log 0.4.20",
+              "target": "log"
+            },
+            {
+              "id": "wasm-encoder 0.214.0",
+              "target": "wasm_encoder"
+            },
+            {
+              "id": "wasmparser 0.214.0",
+              "target": "wasmparser"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "walrus-macro 0.22.0",
+              "target": "walrus_macro"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.23.3"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "walrus-macro 0.19.0": {
       "name": "walrus-macro",
       "version": "0.19.0",
@@ -82579,6 +82413,66 @@
         },
         "edition": "2018",
         "version": "0.19.0"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "walrus-macro 0.22.0": {
+      "name": "walrus-macro",
+      "version": "0.22.0",
+      "package_url": "https://github.com/rustwasm/walrus/tree/crates/macro",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/walrus-macro/0.22.0/download",
+          "sha256": "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "walrus_macro",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "walrus_macro",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "heck 0.5.0",
+              "target": "heck"
+            },
+            {
+              "id": "proc-macro2 1.0.95",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.40",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.101",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.22.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -83340,6 +83234,53 @@
       ],
       "license_file": "LICENSE"
     },
+    "wasm-encoder 0.214.0": {
+      "name": "wasm-encoder",
+      "version": "0.214.0",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasm-encoder/0.214.0/download",
+          "sha256": "ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasm_encoder",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasm_encoder",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "leb128 0.2.5",
+              "target": "leb128"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.214.0"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
+    },
     "wasm-encoder 0.228.0": {
       "name": "wasm-encoder",
       "version": "0.228.0",
@@ -83768,6 +83709,82 @@
         },
         "edition": "2021",
         "version": "0.212.0"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": null
+    },
+    "wasmparser 0.214.0": {
+      "name": "wasmparser",
+      "version": "0.214.0",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasmparser/0.214.0/download",
+          "sha256": "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasmparser",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasmparser",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "serde",
+            "std",
+            "validate"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "ahash 0.8.11",
+              "target": "ahash"
+            },
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "hashbrown 0.14.5",
+              "target": "hashbrown"
+            },
+            {
+              "id": "indexmap 2.7.1",
+              "target": "indexmap"
+            },
+            {
+              "id": "semver 1.0.22",
+              "target": "semver"
+            },
+            {
+              "id": "serde 1.0.217",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.214.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -91115,7 +91132,7 @@
     }
   },
   "binary_crates": [
-    "canbench 0.1.9",
+    "canbench 0.1.15",
     "ic-wasm 0.8.4",
     "metrics-proxy 0.1.0"
   ],
@@ -91462,8 +91479,8 @@
     "byteorder 1.5.0",
     "bytes 1.10.1",
     "cached 0.49.2",
-    "canbench 0.1.9",
-    "canbench-rs 0.1.9",
+    "canbench 0.1.15",
+    "canbench-rs 0.1.15",
     "candid 0.10.13",
     "candid_parser 0.1.4",
     "cargo_metadata 0.14.2",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -1950,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "canbench"
-version = "0.1.9"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eba78c84aa78e67f27c5c5a7d6c3d33cc301f95886171748e8f6ed8a31b258"
+checksum = "5c346cb41bf01bac3c8494eef82943d4dc49267981c8bcb548ba8f4cc69f3161"
 dependencies = [
  "canbench-rs",
  "candid",
@@ -1960,33 +1960,36 @@ dependencies = [
  "colored",
  "flate2",
  "hex",
+ "inferno 0.11.19",
  "pocket-ic",
  "reqwest 0.11.27",
+ "rustc-demangle",
  "semver",
  "serde",
  "serde_yaml 0.9.34+deprecated",
  "sha256",
  "tempfile",
+ "walrus 0.23.3",
  "wasmparser 0.119.0",
 ]
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.9"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588701e2d05679b79603acca6a6f8b78fe0d21f5f7a9c06fe689f769ae797008"
+checksum = "c1c560e37bb75c6900e18e7d37174efaff09e266d138d9926e34f489d9d2f6a0"
 dependencies = [
  "canbench-rs-macros",
  "candid",
- "ic-cdk 0.12.2",
+ "ic-cdk 0.17.2",
  "serde",
 ]
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.9"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05fe21a7dfc85c3be8e40edbbcb3fe23b4c070fac4741eff18129f1d0f11aa9"
+checksum = "866a310ae95dfd273c2f1d17c8382d0d893c35851e9252cca98bd3a80a7e5635"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3500,7 +3503,7 @@ dependencies = [
  "ic-cdk 0.18.0-alpha.2",
  "ic-cdk-timers",
  "ic-certificate-verification",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-certified-map",
  "ic-gateway",
  "ic-http-certification",
@@ -5592,7 +5595,7 @@ dependencies = [
  "hex",
  "http 1.3.1",
  "http-body 1.0.1",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-transport-types 0.40.1",
  "ic-verify-bls-signature 0.5.0",
  "k256 0.13.4",
@@ -5708,7 +5711,7 @@ dependencies = [
  "candid",
  "hex",
  "ic-cdk 0.17.2",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-representation-independent-hash",
  "lazy_static",
  "serde",
@@ -5725,23 +5728,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0efada960a6c9fb023f45ed95801b757a033dafba071e4f386c6c112ca186d9"
 dependencies = [
  "candid",
- "ic-certification 3.0.3",
+ "ic-certification",
  "leb128",
  "nom",
  "thiserror 1.0.68",
-]
-
-[[package]]
-name = "ic-cdk"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e908da565d9e304e83732500069ebb959e3d2cad80f894889ea37207112c7a0"
-dependencies = [
- "candid",
- "ic-cdk-macros 0.8.4",
- "ic0 0.21.1",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -5783,20 +5773,6 @@ checksum = "903057edd3d4ff4b3fe44a64eaee1ceb73f579ba29e3ded372b63d291d7c16c2"
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
-dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ic-cdk-macros"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84cbaa50fa36d3e0616114becf81faa95a099e0d60948ed6978f30f1c77399fd"
@@ -5805,7 +5781,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "serde_tokenstream 0.2.1",
+ "serde_tokenstream",
  "syn 2.0.101",
 ]
 
@@ -5819,7 +5795,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "serde_tokenstream 0.2.1",
+ "serde_tokenstream",
  "syn 2.0.101",
 ]
 
@@ -5846,7 +5822,7 @@ dependencies = [
  "cached 0.54.0",
  "candid",
  "ic-cbor",
- "ic-certification 3.0.3",
+ "ic-certification",
  "lazy_static",
  "leb128",
  "miracl_core_bls12381",
@@ -5854,18 +5830,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "sha2 0.10.9",
  "thiserror 1.0.68",
-]
-
-[[package]]
-name = "ic-certification"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64ee3d8b6e81b51f245716d3e0badb63c283c00f3c9fb5d5219afc30b5bf821"
-dependencies = [
- "hex",
- "serde",
- "serde_bytes",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5974,7 +5938,7 @@ dependencies = [
  "base64 0.22.1",
  "candid",
  "http 1.3.1",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-representation-independent-hash",
  "serde",
  "serde_cbor",
@@ -6055,7 +6019,7 @@ dependencies = [
  "http 1.3.1",
  "ic-cbor",
  "ic-certificate-verification",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-http-certification",
  "ic-representation-independent-hash",
  "leb128",
@@ -6098,19 +6062,20 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.37.1"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
+checksum = "979ee7bee5a67150a4c090fb012c93c294a528b4a867bad9a15cc6d01cb4227f"
 dependencies = [
  "candid",
  "hex",
- "ic-certification 2.6.0",
+ "ic-certification",
  "leb128",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_repr",
  "sha2 0.10.9",
- "thiserror 1.0.68",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6121,7 +6086,7 @@ checksum = "a2e7706e55836e8104c98149ec0796d20d5213fef972ac01b544657d410f1883"
 dependencies = [
  "candid",
  "hex",
- "ic-certification 3.0.3",
+ "ic-certification",
  "leb128",
  "serde",
  "serde_bytes",
@@ -6223,7 +6188,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.68",
- "walrus",
+ "walrus 0.21.1",
 ]
 
 [[package]]
@@ -6241,12 +6206,6 @@ name = "ic0"
 version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
-
-[[package]]
-name = "ic0"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
 
 [[package]]
 name = "ic0"
@@ -6592,6 +6551,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
  "ahash 0.8.11",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap 5.5.3",
  "indexmap 2.7.1",
  "is-terminal",
  "itoa",
@@ -9299,15 +9261,18 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "6.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
+checksum = "bc8ef97f44d4a20b43695690f478f6bfc4058f3ead7d51aff79be29bcfd810c5"
 dependencies = [
+ "backoff",
  "base64 0.13.1",
  "candid",
+ "flate2",
  "hex",
- "ic-certification 2.6.0",
- "ic-transport-types 0.37.1",
+ "ic-certification",
+ "ic-management-canister-types",
+ "ic-transport-types 0.39.3",
  "reqwest 0.12.15",
  "schemars",
  "serde",
@@ -9318,7 +9283,8 @@ dependencies = [
  "slog",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 1.0.68",
+ "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -11521,17 +11487,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "serde_tokenstream"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
-dependencies = [
- "proc-macro2",
- "serde",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -13830,9 +13785,25 @@ dependencies = [
  "id-arena",
  "leb128",
  "log",
- "walrus-macro",
+ "walrus-macro 0.19.0",
  "wasm-encoder 0.212.0",
  "wasmparser 0.212.0",
+]
+
+[[package]]
+name = "walrus"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6481311b98508f4bc2d0abbfa5d42172e7a54b4b24d8f15e28b0dc650be0c59f"
+dependencies = [
+ "anyhow",
+ "gimli 0.26.2",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro 0.22.0",
+ "wasm-encoder 0.214.0",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -13845,6 +13816,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13983,6 +13966,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.228.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d30290541f2d4242a162bbda76b8f2d8b1ac59eab3568ed6f2327d52c9b2c4"
@@ -14043,6 +14035,20 @@ name = "wasmparser"
 version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+dependencies = [
+ "ahash 0.8.11",
+ "bitflags 2.9.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.7.1",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.9.0",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "689ec8971e40782477aa5d698d60aaec116a2b3f7b683c83ec6797f9bd1d8387",
+  "checksum": "e283d0da52d8293db5dba34ed3c309d49c830b81a3e6c3edba891e98c34e5e63",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -11431,14 +11431,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "canbench 0.1.9": {
+    "canbench 0.1.15": {
       "name": "canbench",
-      "version": "0.1.9",
+      "version": "0.1.15",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench/0.1.9/download",
-          "sha256": "c3eba78c84aa78e67f27c5c5a7d6c3d33cc301f95886171748e8f6ed8a31b258"
+          "url": "https://static.crates.io/crates/canbench/0.1.15/download",
+          "sha256": "5c346cb41bf01bac3c8494eef82943d4dc49267981c8bcb548ba8f4cc69f3161"
         }
       },
       "targets": [
@@ -11475,7 +11475,7 @@
         "deps": {
           "common": [
             {
-              "id": "canbench-rs 0.1.9",
+              "id": "canbench-rs 0.1.15",
               "target": "canbench_rs"
             },
             {
@@ -11499,12 +11499,20 @@
               "target": "hex"
             },
             {
-              "id": "pocket-ic 6.0.0",
+              "id": "inferno 0.11.19",
+              "target": "inferno"
+            },
+            {
+              "id": "pocket-ic 9.0.1",
               "target": "pocket_ic"
             },
             {
               "id": "reqwest 0.11.27",
               "target": "reqwest"
+            },
+            {
+              "id": "rustc-demangle 0.1.23",
+              "target": "rustc_demangle"
             },
             {
               "id": "semver 1.0.22",
@@ -11527,6 +11535,10 @@
               "target": "tempfile"
             },
             {
+              "id": "walrus 0.23.3",
+              "target": "walrus"
+            },
+            {
               "id": "wasmparser 0.119.0",
               "target": "wasmparser"
             }
@@ -11534,7 +11546,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.9"
+        "version": "0.1.15"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -11542,14 +11554,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs 0.1.9": {
+    "canbench-rs 0.1.15": {
       "name": "canbench-rs",
-      "version": "0.1.9",
+      "version": "0.1.15",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs/0.1.9/download",
-          "sha256": "588701e2d05679b79603acca6a6f8b78fe0d21f5f7a9c06fe689f769ae797008"
+          "url": "https://static.crates.io/crates/canbench-rs/0.1.15/download",
+          "sha256": "c1c560e37bb75c6900e18e7d37174efaff09e266d138d9926e34f489d9d2f6a0"
         }
       },
       "targets": [
@@ -11578,7 +11590,7 @@
               "target": "candid"
             },
             {
-              "id": "ic-cdk 0.12.2",
+              "id": "ic-cdk 0.17.2",
               "target": "ic_cdk"
             },
             {
@@ -11592,13 +11604,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "canbench-rs-macros 0.1.9",
+              "id": "canbench-rs-macros 0.1.15",
               "target": "canbench_rs_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.9"
+        "version": "0.1.15"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -11606,14 +11618,14 @@
       ],
       "license_file": null
     },
-    "canbench-rs-macros 0.1.9": {
+    "canbench-rs-macros 0.1.15": {
       "name": "canbench-rs-macros",
-      "version": "0.1.9",
+      "version": "0.1.15",
       "package_url": "https://github.com/dfinity/canbench",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.9/download",
-          "sha256": "e05fe21a7dfc85c3be8e40edbbcb3fe23b4c070fac4741eff18129f1d0f11aa9"
+          "url": "https://static.crates.io/crates/canbench-rs-macros/0.1.15/download",
+          "sha256": "866a310ae95dfd273c2f1d17c8382d0d893c35851e9252cca98bd3a80a7e5635"
         }
       },
       "targets": [
@@ -11653,7 +11665,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.9"
+        "version": "0.1.15"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -19992,11 +20004,11 @@
               "target": "cached"
             },
             {
-              "id": "canbench 0.1.9",
+              "id": "canbench 0.1.15",
               "target": "canbench"
             },
             {
-              "id": "canbench-rs 0.1.9",
+              "id": "canbench-rs 0.1.15",
               "target": "canbench_rs"
             },
             {
@@ -32928,74 +32940,6 @@
       ],
       "license_file": null
     },
-    "ic-cdk 0.12.2": {
-      "name": "ic-cdk",
-      "version": "0.12.2",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk/0.12.2/download",
-          "sha256": "0e908da565d9e304e83732500069ebb959e3d2cad80f894889ea37207112c7a0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_cdk",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_cdk",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "candid 0.10.13",
-              "target": "candid"
-            },
-            {
-              "id": "ic0 0.21.1",
-              "target": "ic0"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "serde_bytes 0.11.15",
-              "target": "serde_bytes"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "ic-cdk-macros 0.8.4",
-              "target": "ic_cdk_macros"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.12.2"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
     "ic-cdk 0.17.2": {
       "name": "ic-cdk",
       "version": "0.17.2",
@@ -33222,73 +33166,6 @@
         "Apache-2.0"
       ],
       "license_file": null
-    },
-    "ic-cdk-macros 0.8.4": {
-      "name": "ic-cdk-macros",
-      "version": "0.8.4",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk-macros/0.8.4/download",
-          "sha256": "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "ic_cdk_macros",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_cdk_macros",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "candid 0.10.13",
-              "target": "candid"
-            },
-            {
-              "id": "proc-macro2 1.0.95",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.40",
-              "target": "quote"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "serde_tokenstream 0.1.7",
-              "target": "serde_tokenstream"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.8.4"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
     },
     "ic-cdk-macros 0.17.2": {
       "name": "ic-cdk-macros",
@@ -33577,73 +33454,6 @@
         "Apache-2.0"
       ],
       "license_file": null
-    },
-    "ic-certification 2.6.0": {
-      "name": "ic-certification",
-      "version": "2.6.0",
-      "package_url": "https://github.com/dfinity/response-verification",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic-certification/2.6.0/download",
-          "sha256": "e64ee3d8b6e81b51f245716d3e0badb63c283c00f3c9fb5d5219afc30b5bf821"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic_certification",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic_certification",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "serde",
-            "serde_bytes"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "hex 0.4.3",
-              "target": "hex"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "serde_bytes 0.11.15",
-              "target": "serde_bytes"
-            },
-            {
-              "id": "sha2 0.10.9",
-              "target": "sha2"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.6.0"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
     },
     "ic-certification 3.0.3": {
       "name": "ic-certification",
@@ -34735,14 +34545,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-transport-types 0.37.1": {
+    "ic-transport-types 0.39.3": {
       "name": "ic-transport-types",
-      "version": "0.37.1",
+      "version": "0.39.3",
       "package_url": "https://github.com/dfinity/agent-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-transport-types/0.37.1/download",
-          "sha256": "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
+          "url": "https://static.crates.io/crates/ic-transport-types/0.39.3/download",
+          "sha256": "979ee7bee5a67150a4c090fb012c93c294a528b4a867bad9a15cc6d01cb4227f"
         }
       },
       "targets": [
@@ -34775,7 +34585,7 @@
               "target": "hex"
             },
             {
-              "id": "ic-certification 2.6.0",
+              "id": "ic-certification 3.0.3",
               "target": "ic_certification"
             },
             {
@@ -34791,11 +34601,15 @@
               "target": "serde_bytes"
             },
             {
+              "id": "serde_cbor 0.11.2",
+              "target": "serde_cbor"
+            },
+            {
               "id": "sha2 0.10.9",
               "target": "sha2"
             },
             {
-              "id": "thiserror 1.0.68",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             }
           ],
@@ -34811,7 +34625,7 @@
           ],
           "selects": {}
         },
-        "version": "0.37.1"
+        "version": "0.39.3"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -35487,44 +35301,6 @@
         ],
         "edition": "2021",
         "version": "0.18.11"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
-    "ic0 0.21.1": {
-      "name": "ic0",
-      "version": "0.21.1",
-      "package_url": "https://github.com/dfinity/cdk-rs",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ic0/0.21.1/download",
-          "sha256": "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ic0",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ic0",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "0.21.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -37526,7 +37302,11 @@
         ],
         "crate_features": {
           "common": [
+            "crossbeam-channel",
+            "crossbeam-utils",
+            "dashmap",
             "indexmap",
+            "multithreaded",
             "nameattr"
           ],
           "selects": {}
@@ -37536,6 +37316,18 @@
             {
               "id": "ahash 0.8.11",
               "target": "ahash"
+            },
+            {
+              "id": "crossbeam-channel 0.5.15",
+              "target": "crossbeam_channel"
+            },
+            {
+              "id": "crossbeam-utils 0.8.19",
+              "target": "crossbeam_utils"
+            },
+            {
+              "id": "dashmap 5.5.0",
+              "target": "dashmap"
             },
             {
               "id": "indexmap 2.7.1",
@@ -54382,14 +54174,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "pocket-ic 6.0.0": {
+    "pocket-ic 9.0.1": {
       "name": "pocket-ic",
-      "version": "6.0.0",
+      "version": "9.0.1",
       "package_url": "https://github.com/dfinity/ic",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pocket-ic/6.0.0/download",
-          "sha256": "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
+          "url": "https://static.crates.io/crates/pocket-ic/9.0.1/download",
+          "sha256": "bc8ef97f44d4a20b43695690f478f6bfc4058f3ead7d51aff79be29bcfd810c5"
         }
       },
       "targets": [
@@ -54414,6 +54206,10 @@
         "deps": {
           "common": [
             {
+              "id": "backoff 0.4.0",
+              "target": "backoff"
+            },
+            {
               "id": "base64 0.13.1",
               "target": "base64"
             },
@@ -54422,15 +54218,23 @@
               "target": "candid"
             },
             {
+              "id": "flate2 1.0.31",
+              "target": "flate2"
+            },
+            {
               "id": "hex 0.4.3",
               "target": "hex"
             },
             {
-              "id": "ic-certification 2.6.0",
+              "id": "ic-certification 3.0.3",
               "target": "ic_certification"
             },
             {
-              "id": "ic-transport-types 0.37.1",
+              "id": "ic-management-canister-types 0.3.0",
+              "target": "ic_management_canister_types"
+            },
+            {
+              "id": "ic-transport-types 0.39.3",
               "target": "ic_transport_types"
             },
             {
@@ -54470,7 +54274,11 @@
               "target": "strum"
             },
             {
-              "id": "thiserror 1.0.68",
+              "id": "tempfile 3.12.0",
+              "target": "tempfile"
+            },
+            {
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             },
             {
@@ -54509,7 +54317,7 @@
           ],
           "selects": {}
         },
-        "version": "6.0.0"
+        "version": "9.0.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -68530,61 +68338,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_tokenstream 0.1.7": {
-      "name": "serde_tokenstream",
-      "version": "0.1.7",
-      "package_url": "https://github.com/oxidecomputer/serde_tokenstream",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/serde_tokenstream/0.1.7/download",
-          "sha256": "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "serde_tokenstream",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "serde_tokenstream",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.95",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "syn 1.0.109",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.7"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
     "serde_tokenstream 0.2.1": {
       "name": "serde_tokenstream",
       "version": "0.2.1",
@@ -82397,6 +82150,87 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "walrus 0.23.3": {
+      "name": "walrus",
+      "version": "0.23.3",
+      "package_url": "https://github.com/rustwasm/walrus",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/walrus/0.23.3/download",
+          "sha256": "6481311b98508f4bc2d0abbfa5d42172e7a54b4b24d8f15e28b0dc650be0c59f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "walrus",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "walrus",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.98",
+              "target": "anyhow"
+            },
+            {
+              "id": "gimli 0.26.2",
+              "target": "gimli"
+            },
+            {
+              "id": "id-arena 2.2.1",
+              "target": "id_arena"
+            },
+            {
+              "id": "leb128 0.2.5",
+              "target": "leb128"
+            },
+            {
+              "id": "log 0.4.20",
+              "target": "log"
+            },
+            {
+              "id": "wasm-encoder 0.214.0",
+              "target": "wasm_encoder"
+            },
+            {
+              "id": "wasmparser 0.214.0",
+              "target": "wasmparser"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "walrus-macro 0.22.0",
+              "target": "walrus_macro"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.23.3"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "walrus-macro 0.19.0": {
       "name": "walrus-macro",
       "version": "0.19.0",
@@ -82449,6 +82283,66 @@
         },
         "edition": "2018",
         "version": "0.19.0"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "walrus-macro 0.22.0": {
+      "name": "walrus-macro",
+      "version": "0.22.0",
+      "package_url": "https://github.com/rustwasm/walrus/tree/crates/macro",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/walrus-macro/0.22.0/download",
+          "sha256": "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "walrus_macro",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "walrus_macro",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "heck 0.5.0",
+              "target": "heck"
+            },
+            {
+              "id": "proc-macro2 1.0.95",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.40",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.101",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.22.0"
       },
       "license": "MIT/Apache-2.0",
       "license_ids": [
@@ -83210,6 +83104,53 @@
       ],
       "license_file": "LICENSE"
     },
+    "wasm-encoder 0.214.0": {
+      "name": "wasm-encoder",
+      "version": "0.214.0",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasm-encoder/0.214.0/download",
+          "sha256": "ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasm_encoder",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasm_encoder",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "leb128 0.2.5",
+              "target": "leb128"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.214.0"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
+    },
     "wasm-encoder 0.228.0": {
       "name": "wasm-encoder",
       "version": "0.228.0",
@@ -83638,6 +83579,82 @@
         },
         "edition": "2021",
         "version": "0.212.0"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": null
+    },
+    "wasmparser 0.214.0": {
+      "name": "wasmparser",
+      "version": "0.214.0",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasmparser/0.214.0/download",
+          "sha256": "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasmparser",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasmparser",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "serde",
+            "std",
+            "validate"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "ahash 0.8.11",
+              "target": "ahash"
+            },
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "hashbrown 0.14.5",
+              "target": "hashbrown"
+            },
+            {
+              "id": "indexmap 2.7.1",
+              "target": "indexmap"
+            },
+            {
+              "id": "semver 1.0.22",
+              "target": "semver"
+            },
+            {
+              "id": "serde 1.0.217",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.214.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception",
       "license_ids": [
@@ -91097,7 +91114,7 @@
     }
   },
   "binary_crates": [
-    "canbench 0.1.9",
+    "canbench 0.1.15",
     "ic-wasm 0.8.4",
     "metrics-proxy 0.1.0"
   ],
@@ -91427,8 +91444,8 @@
     "byteorder 1.5.0",
     "bytes 1.10.1",
     "cached 0.49.2",
-    "canbench 0.1.9",
-    "canbench-rs 0.1.9",
+    "canbench 0.1.15",
+    "canbench-rs 0.1.15",
     "candid 0.10.13",
     "candid_parser 0.1.4",
     "cargo_metadata 0.14.2",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "canbench"
-version = "0.1.9"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eba78c84aa78e67f27c5c5a7d6c3d33cc301f95886171748e8f6ed8a31b258"
+checksum = "5c346cb41bf01bac3c8494eef82943d4dc49267981c8bcb548ba8f4cc69f3161"
 dependencies = [
  "canbench-rs",
  "candid",
@@ -1961,33 +1961,36 @@ dependencies = [
  "colored",
  "flate2",
  "hex",
+ "inferno 0.11.19",
  "pocket-ic",
  "reqwest 0.11.27",
+ "rustc-demangle",
  "semver",
  "serde",
  "serde_yaml 0.9.34+deprecated",
  "sha256",
  "tempfile",
+ "walrus 0.23.3",
  "wasmparser 0.119.0",
 ]
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.9"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588701e2d05679b79603acca6a6f8b78fe0d21f5f7a9c06fe689f769ae797008"
+checksum = "c1c560e37bb75c6900e18e7d37174efaff09e266d138d9926e34f489d9d2f6a0"
 dependencies = [
  "canbench-rs-macros",
  "candid",
- "ic-cdk 0.12.2",
+ "ic-cdk 0.17.2",
  "serde",
 ]
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.9"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05fe21a7dfc85c3be8e40edbbcb3fe23b4c070fac4741eff18129f1d0f11aa9"
+checksum = "866a310ae95dfd273c2f1d17c8382d0d893c35851e9252cca98bd3a80a7e5635"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3489,7 +3492,7 @@ dependencies = [
  "ic-cdk 0.18.0-alpha.2",
  "ic-cdk-timers",
  "ic-certificate-verification",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-certified-map",
  "ic-gateway",
  "ic-http-certification",
@@ -5582,7 +5585,7 @@ dependencies = [
  "hex",
  "http 1.3.1",
  "http-body 1.0.1",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-transport-types 0.40.1",
  "ic-verify-bls-signature 0.5.0",
  "k256 0.13.4",
@@ -5698,7 +5701,7 @@ dependencies = [
  "candid",
  "hex",
  "ic-cdk 0.17.2",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-representation-independent-hash",
  "lazy_static",
  "serde",
@@ -5715,23 +5718,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0efada960a6c9fb023f45ed95801b757a033dafba071e4f386c6c112ca186d9"
 dependencies = [
  "candid",
- "ic-certification 3.0.3",
+ "ic-certification",
  "leb128",
  "nom",
  "thiserror 1.0.68",
-]
-
-[[package]]
-name = "ic-cdk"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e908da565d9e304e83732500069ebb959e3d2cad80f894889ea37207112c7a0"
-dependencies = [
- "candid",
- "ic-cdk-macros 0.8.4",
- "ic0 0.21.1",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -5773,20 +5763,6 @@ checksum = "903057edd3d4ff4b3fe44a64eaee1ceb73f579ba29e3ded372b63d291d7c16c2"
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
-dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ic-cdk-macros"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84cbaa50fa36d3e0616114becf81faa95a099e0d60948ed6978f30f1c77399fd"
@@ -5795,7 +5771,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "serde_tokenstream 0.2.1",
+ "serde_tokenstream",
  "syn 2.0.101",
 ]
 
@@ -5809,7 +5785,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "serde_tokenstream 0.2.1",
+ "serde_tokenstream",
  "syn 2.0.101",
 ]
 
@@ -5836,7 +5812,7 @@ dependencies = [
  "cached 0.54.0",
  "candid",
  "ic-cbor",
- "ic-certification 3.0.3",
+ "ic-certification",
  "lazy_static",
  "leb128",
  "miracl_core_bls12381",
@@ -5844,18 +5820,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "sha2 0.10.9",
  "thiserror 1.0.68",
-]
-
-[[package]]
-name = "ic-certification"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64ee3d8b6e81b51f245716d3e0badb63c283c00f3c9fb5d5219afc30b5bf821"
-dependencies = [
- "hex",
- "serde",
- "serde_bytes",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5964,7 +5928,7 @@ dependencies = [
  "base64 0.22.1",
  "candid",
  "http 1.3.1",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-representation-independent-hash",
  "serde",
  "serde_cbor",
@@ -6045,7 +6009,7 @@ dependencies = [
  "http 1.3.1",
  "ic-cbor",
  "ic-certificate-verification",
- "ic-certification 3.0.3",
+ "ic-certification",
  "ic-http-certification",
  "ic-representation-independent-hash",
  "leb128",
@@ -6088,19 +6052,20 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.37.1"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
+checksum = "979ee7bee5a67150a4c090fb012c93c294a528b4a867bad9a15cc6d01cb4227f"
 dependencies = [
  "candid",
  "hex",
- "ic-certification 2.6.0",
+ "ic-certification",
  "leb128",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_repr",
  "sha2 0.10.9",
- "thiserror 1.0.68",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6111,7 +6076,7 @@ checksum = "a2e7706e55836e8104c98149ec0796d20d5213fef972ac01b544657d410f1883"
 dependencies = [
  "candid",
  "hex",
- "ic-certification 3.0.3",
+ "ic-certification",
  "leb128",
  "serde",
  "serde_bytes",
@@ -6213,7 +6178,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.68",
- "walrus",
+ "walrus 0.21.1",
 ]
 
 [[package]]
@@ -6231,12 +6196,6 @@ name = "ic0"
 version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
-
-[[package]]
-name = "ic0"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
 
 [[package]]
 name = "ic0"
@@ -6582,6 +6541,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
  "ahash 0.8.11",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap 5.5.0",
  "indexmap 2.7.1",
  "is-terminal",
  "itoa",
@@ -9289,15 +9251,18 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "6.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
+checksum = "bc8ef97f44d4a20b43695690f478f6bfc4058f3ead7d51aff79be29bcfd810c5"
 dependencies = [
+ "backoff",
  "base64 0.13.1",
  "candid",
+ "flate2",
  "hex",
- "ic-certification 2.6.0",
- "ic-transport-types 0.37.1",
+ "ic-certification",
+ "ic-management-canister-types",
+ "ic-transport-types 0.39.3",
  "reqwest 0.12.15",
  "schemars",
  "serde",
@@ -9308,7 +9273,8 @@ dependencies = [
  "slog",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 1.0.68",
+ "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -11517,17 +11483,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "serde_tokenstream"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
-dependencies = [
- "proc-macro2",
- "serde",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -13826,9 +13781,25 @@ dependencies = [
  "id-arena",
  "leb128",
  "log",
- "walrus-macro",
+ "walrus-macro 0.19.0",
  "wasm-encoder 0.212.0",
  "wasmparser 0.212.0",
+]
+
+[[package]]
+name = "walrus"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6481311b98508f4bc2d0abbfa5d42172e7a54b4b24d8f15e28b0dc650be0c59f"
+dependencies = [
+ "anyhow",
+ "gimli 0.26.2",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro 0.22.0",
+ "wasm-encoder 0.214.0",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -13841,6 +13812,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13979,6 +13962,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.228.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d30290541f2d4242a162bbda76b8f2d8b1ac59eab3568ed6f2327d52c9b2c4"
@@ -14039,6 +14031,20 @@ name = "wasmparser"
 version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+dependencies = [
+ "ahash 0.8.11",
+ "bitflags 2.9.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.7.1",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.9.0",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -824,8 +824,8 @@ http_file(
     # ci/container/container-run.sh
     # bazel build //publish/binaries:pocket-ic.gz
     # sha256sum bazel-bin/publish/binaries/pocket-ic.gz
-    sha256 = "0935ee6ece312719aae4eabddec2dfc6af34d5edbddf4d3af53bccd1b3636044",
-    url = "https://download.dfinity.systems/ic/172f8c78653c93ad101af75b94251439b4ccf098/binaries/x86_64-linux/pocket-ic.gz",
+    sha256 = "399596330c40a76effbbd20660ce8e892d5d74f3de6380cad4aac1598b9d6394",
+    url = "https://download.dfinity.systems/ic/c36a05a9d367bb6ba9068444e6d6f53e7911f1b0/binaries/x86_64-linux/pocket-ic.gz",
 )
 
 # Management canister candid interface

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -345,10 +345,10 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 default_features = False,
             ),
             "canbench": crate.spec(
-                version = "^0.1.9",
+                version = "^0.1.15",
             ),
             "canbench-rs": crate.spec(
-                version = "^0.1.9",
+                version = "^0.1.15",
             ),
             "candid": crate.spec(
                 version = "^0.10.13",

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
@@ -1,58 +1,71 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 54027045541
-      heap_increase: 262
+      calls: 1
+      instructions: 54208424997
+      heap_increase: 264
       stable_memory_increase: 256
     scopes:
       icrc103_get_allowances:
-        instructions: 6513874
+        calls: 1
+        instructions: 6483457
         heap_increase: 0
         stable_memory_increase: 0
       icrc1_transfer:
-        instructions: 12897862680
+        calls: 1
+        instructions: 12963223748
         heap_increase: 31
         stable_memory_increase: 0
       icrc2_approve:
-        instructions: 19155195559
-        heap_increase: 28
+        calls: 1
+        instructions: 19300687184
+        heap_increase: 29
         stable_memory_increase: 128
       icrc2_transfer_from:
-        instructions: 21263842034
-        heap_increase: 3
+        calls: 1
+        instructions: 21236203907
+        heap_increase: 4
         stable_memory_increase: 0
       icrc3_get_blocks:
-        instructions: 8983783
+        calls: 1
+        instructions: 9190204
         heap_increase: 0
         stable_memory_increase: 0
       post_upgrade:
-        instructions: 350426789
+        calls: 1
+        instructions: 352007549
         heap_increase: 71
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 149396410
+        calls: 1
+        instructions: 149185789
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 499825415
+        calls: 1
+        instructions: 501196007
         heap_increase: 200
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
-      instructions: 8682175
-      heap_increase: 258
+      calls: 1
+      instructions: 8682162
+      heap_increase: 129
       stable_memory_increase: 128
     scopes:
       post_upgrade:
-        instructions: 8604482
-        heap_increase: 129
+        calls: 1
+        instructions: 8603917
+        heap_increase: 0
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 75292
+        calls: 1
+        instructions: 75356
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 8681489
-        heap_increase: 258
+        calls: 1
+        instructions: 8681238
+        heap_increase: 129
         stable_memory_increase: 128
-version: 0.1.9
+version: 0.1.15

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
@@ -1,58 +1,71 @@
 benches:
   bench_icrc1_transfers:
     total:
-      instructions: 52661370086
+      calls: 1
+      instructions: 52219592379
       heap_increase: 264
       stable_memory_increase: 256
     scopes:
       icrc103_get_allowances:
-        instructions: 5817853
+        calls: 1
+        instructions: 5777551
         heap_increase: 0
         stable_memory_increase: 0
       icrc1_transfer:
-        instructions: 12317221820
-        heap_increase: 34
+        calls: 1
+        instructions: 12317346166
+        heap_increase: 31
         stable_memory_increase: 0
       icrc2_approve:
-        instructions: 18655136234
-        heap_increase: 25
+        calls: 1
+        instructions: 18526480608
+        heap_increase: 29
         stable_memory_increase: 128
       icrc2_transfer_from:
-        instructions: 20982015561
+        calls: 1
+        instructions: 20671784720
         heap_increase: 3
         stable_memory_increase: 0
       icrc3_get_blocks:
-        instructions: 8503312
+        calls: 1
+        instructions: 8587147
         heap_increase: 0
         stable_memory_increase: 0
       post_upgrade:
-        instructions: 354587778
-        heap_increase: 73
+        calls: 1
+        instructions: 352225413
+        heap_increase: 72
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 149065496
+        calls: 1
+        instructions: 149186048
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 503655490
-        heap_increase: 202
+        calls: 1
+        instructions: 501414271
+        heap_increase: 201
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
-      instructions: 8685360
-      heap_increase: 258
+      calls: 1
+      instructions: 8683032
+      heap_increase: 129
       stable_memory_increase: 128
     scopes:
       post_upgrade:
-        instructions: 8606707
-        heap_increase: 129
+        calls: 1
+        instructions: 8603759
+        heap_increase: 0
         stable_memory_increase: 0
       pre_upgrade:
-        instructions: 76252
+        calls: 1
+        instructions: 76384
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
-        instructions: 8684674
-        heap_increase: 258
+        calls: 1
+        instructions: 8682108
+        heap_increase: 129
         stable_memory_increase: 128
-version: 0.1.9
+version: 0.1.15

--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,160 +1,187 @@
 benches:
   add_neuron_active_maximum_stable:
     total:
-      instructions: 59096802
+      calls: 1
+      instructions: 61868406
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_active_typical_stable:
     total:
-      instructions: 4241546
+      calls: 1
+      instructions: 4434418
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_maximum:
     total:
-      instructions: 59096915
+      calls: 1
+      instructions: 61868519
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   add_neuron_inactive_typical:
     total:
-      instructions: 4241659
+      calls: 1
+      instructions: 4434531
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   cascading_vote_stable_everything:
     total:
-      instructions: 106436328
+      calls: 1
+      instructions: 108525112
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   centralized_following_all_stable:
     total:
-      instructions: 41239824
+      calls: 1
+      instructions: 42002784
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   compute_ballots_for_new_proposal_with_stable_neurons:
     total:
-      instructions: 1811743
+      calls: 1
+      instructions: 1781426
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   distribute_rewards_with_stable_neurons:
     total:
-      instructions: 2719796
+      calls: 1
+      instructions: 2769799
       heap_increase: 0
       stable_memory_increase: 256
     scopes: {}
   draw_maturity_from_neurons_fund_stable:
     total:
-      instructions: 7371310
+      calls: 1
+      instructions: 7576878
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_active_neurons_fund_neurons_stable:
     total:
-      instructions: 2208279
+      calls: 1
+      instructions: 2243478
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_neurons_by_subaccount_stable:
     total:
-      instructions: 65094430
+      calls: 1
+      instructions: 66319497
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
     total:
-      instructions: 66350224
+      calls: 1
+      instructions: 67632700
       heap_increase: 4
       stable_memory_increase: 0
     scopes: {}
   list_proposals:
     total:
-      instructions: 76392
+      calls: 1
+      instructions: 75889
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   list_ready_to_spawn_neuron_ids_stable:
     total:
-      instructions: 36704609
+      calls: 1
+      instructions: 37436771
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_data_validation_stable:
     total:
-      instructions: 205253203
+      calls: 1
+      instructions: 207749441
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   neuron_metrics_calculation_stable:
     total:
-      instructions: 2694578
+      calls: 1
+      instructions: 2718705
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   range_neurons_performance:
     total:
-      instructions: 54272730
+      calls: 1
+      instructions: 55414913
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   single_vote_all_stable:
     total:
-      instructions: 273775
+      calls: 1
+      instructions: 279950
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   unstake_maturity_of_dissolved_neurons_stable:
     total:
-      instructions: 63266688
+      calls: 1
+      instructions: 64676407
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       list_neuron_ids:
-        instructions: 38052515
+        calls: 1
+        instructions: 38802158
         heap_increase: 0
         stable_memory_increase: 0
       unstake_maturity:
-        instructions: 25212382
+        calls: 1
+        instructions: 25872066
         heap_increase: 0
         stable_memory_increase: 0
   update_recent_ballots_stable_memory:
     total:
-      instructions: 139815
+      calls: 1
+      instructions: 143951
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   voting_power_snapshots_is_latest_snapshot_a_spike:
     total:
-      instructions: 31253
+      calls: 1
+      instructions: 31207
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_maximum_stable:
     total:
-      instructions: 4347082
+      calls: 1
+      instructions: 4469524
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_all_sections_typical_stable:
     total:
-      instructions: 833750
+      calls: 1
+      instructions: 855886
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_maximum_stable:
     total:
-      instructions: 2408666
+      calls: 1
+      instructions: 2448005
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   with_neuron_mut_main_section_typical_stable:
     total:
-      instructions: 401301
+      calls: 1
+      instructions: 410342
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-version: 0.1.9
+version: 0.1.15


### PR DESCRIPTION
 Note that canbench 0.15.0 uses the pocket-ic (client 9.0.0) [here](https://github.com/dfinity/canbench/pull/95). The `pocket-ic-mainnet-gz` is updated accordingly.