### PR TITLE
chore(ckbtc/cketh): add upgrade proposals for BTC Checker and ckETH minter canisters

### DIFF
--- a/rs/bitcoin/ckbtc/mainnet/btc_checker_upgrade_2025_05_30.md
+++ b/rs/bitcoin/ckbtc/mainnet/btc_checker_upgrade_2025_05_30.md
@@ -1,0 +1,54 @@
+# Proposal to upgrade the BTC Checker canister
+
+Repository: `https://github.com/dfinity/ic.git`
+
+Git hash: `bb6e758c739768ef6713f9f3be2df47884544900`
+
+New compressed Wasm hash: `a90ed5c89939147cbb58a915343c114787d35835f33609c13be2d802c309b3d9`
+
+Upgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`
+
+Target canister: `oltsj-fqaaa-aaaar-qal5q-cai`
+
+Previous BTC Checker proposal: https://dashboard.internetcomputer.org/proposal/136101
+
+---
+
+## Motivation
+
+Update the Bitcoin checker canister to include the latest code changes, notably:
+
+* Update the OFAC checklist.
+* Avoid caching metrics to have more reliable alerts.
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' eecacca6c05871f00e674dcc4bfcf548fa0c2f63..bb6e758c739768ef6713f9f3be2df47884544900 -- rs/bitcoin/checker
+9c4e4500ea chore(ckbtc/cketh): update ckBTC/ckETH OFAC blocklists 05.2025 (#5203)
+b0a3d6dc4c feat: Add "Cache-Control: no-store" to all canister /metrics endpoints (#5124)
+830f4caa90 refactor: remove direct dependency on ic-cdk-macros (#5144)
+2949c97ba3 chore: Revert ic-cdk to 0.17.2 (#5139)
+d1dc4c2dc8 chore: Update Rust to 1.86.0 (#5059)
+3490ef2a07 chore: bump the monorepo version of ic-cdk to 0.18.0 (#5005)
+c2d5684360 refactor(ic): update imports from ic_canisters_http_types to newly published ic_http_types crate (#4866)
+ ```
+
+## Upgrade args
+
+```
+git fetch
+git checkout bb6e758c739768ef6713f9f3be2df47884544900
+didc encode '()' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout bb6e758c739768ef6713f9f3be2df47884544900
+"./ci/container/build-ic.sh" "--canisters"
+sha256sum ./artifacts/canisters/ic-btc-checker.wasm.gz
+```

--- a/rs/ethereum/cketh/mainnet/minter_upgrade_2025_05_30.md
+++ b/rs/ethereum/cketh/mainnet/minter_upgrade_2025_05_30.md
@@ -1,0 +1,62 @@
+# Proposal to upgrade the ckETH minter canister
+
+Repository: `https://github.com/dfinity/ic.git`
+
+Git hash: `bb6e758c739768ef6713f9f3be2df47884544900`
+
+New compressed Wasm hash: `6256368e2a6a39a3ee5e122054c1179e262e49ed11d2fa5744132418a4225d95`
+
+Upgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`
+
+Target canister: `sv3dd-oaaaa-aaaar-qacoa-cai`
+
+Previous ckETH minter proposal: https://dashboard.internetcomputer.org/proposal/135547
+
+---
+
+## Motivation
+
+Update the ckETH minter canister to include the latest code changes:
+
+* Update the OFAC checklist.
+* Avoid caching metrics to have more reliable alerts
+
+## Release Notes
+
+```
+git log --format='%C(auto) %h %s' e96ff00c35856d11d5cce98fd2f969dd9afe797f..bb6e758c739768ef6713f9f3be2df47884544900 -- rs/ethereum/cketh/minter
+9c4e4500ea chore(ckbtc/cketh): update ckBTC/ckETH OFAC blocklists 05.2025 (#5203)
+32584f0e81 refactor(cketh): ensure the EthRpcClient always gets an evm_rpc_id (#5055)
+785eb8efe6 refactor(cketh): clean up eth_send_raw_transaction call (#5015)
+7b6552c434 refactor(cketh): clean up eth_get_block_by_number call (#4964)
+32b4df476a refactor(cketh): clean up eth_fee_history call (#5000)
+b0a3d6dc4c feat: Add "Cache-Control: no-store" to all canister /metrics endpoints (#5124)
+830f4caa90 refactor: remove direct dependency on ic-cdk-macros (#5144)
+2949c97ba3 chore: Revert ic-cdk to 0.17.2 (#5139)
+d1dc4c2dc8 chore: Update Rust to 1.86.0 (#5059)
+d6323ec599 refactor(cketh): clean up eth_get_finalized_transaction_count, eth_get_latest_transaction_count, and eth_get_logs call (#5021)
+7d987a28af refactor(cketh): remove retry counts histograms (#5035)
+3490ef2a07 chore: bump the monorepo version of ic-cdk to 0.18.0 (#5005)
+79370a23e1 refactor(cketh): remove direct https outcalls (#4926)
+c2d5684360 refactor(ic): update imports from ic_canisters_http_types to newly published ic_http_types crate (#4866)
+4d40e10c75 chore(IDX): use correct .gz name for canisters (#4300)
+ ```
+
+## Upgrade args
+
+```
+git fetch
+git checkout bb6e758c739768ef6713f9f3be2df47884544900
+didc encode '()' | xxd -r -p | sha256sum
+```
+
+## Wasm Verification
+
+Verify that the hash of the gzipped WASM matches the proposed hash.
+
+```
+git fetch
+git checkout bb6e758c739768ef6713f9f3be2df47884544900
+"./ci/container/build-ic.sh" "--canisters"
+sha256sum ./artifacts/canisters/ic-cketh-minter.wasm.gz
+```


### PR DESCRIPTION
[XC-369](https://dfinity.atlassian.net/browse/XC-369?atlOrigin=eyJpIjoiY2I1MGJhMzdmMGIxNDgyZDgxYjVkMWE1ZDA5NTVjNDEiLCJwIjoiaiJ9): Upgrade the BTC checker and ckETH minter canister to include the latest code changes, notably:
- Update the [OFAC](https://sanctionslist.ofac.treas.gov/Home/SdnList) checklist to May 2025 version.
- Avoid caching metrics to have more reliable alerts.