### PR TITLE
fix: error message for OutOfMemory

### DIFF
--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -5557,7 +5557,7 @@ fn system_state_apply_change_fails() {
         WasmResult::Reply(_) => unreachable!("Expected the canister to reject the message"),
         WasmResult::Reject(err) => {
             assert!(
-                err.contains("exceeded its allowed memory allocation"),
+                err.contains("Canister cannot grow its memory usage"),
                 "{}",
                 err
             );

--- a/rs/interfaces/src/execution_environment/errors.rs
+++ b/rs/interfaces/src/execution_environment/errors.rs
@@ -136,8 +136,7 @@ pub enum HypervisorError {
     /// An attempt was made to execute a message on a canister that does not
     /// contain a Wasm module.
     WasmModuleNotFound,
-    /// An attempt was made to grow the canister's memory above its memory
-    /// allocation.
+    /// The canister cannot grow its memory usage.
     OutOfMemory,
     /// The principal ID specified by the canister is invalid.
     InvalidPrincipalId(PrincipalIdBlobParseError),
@@ -433,9 +432,8 @@ impl AsErrorHelp for HypervisorError {
                 doc_link: doc_ref("wasm-module-not-found"),
             },
             Self::OutOfMemory => ErrorHelp::UserError {
-                suggestion: "Check the canister's memory usage against its allocation \
-                and the system wide limits to determine why more memory cannot be \
-                allocated."
+                suggestion: "Check the canister's memory usage against the system-wide limits \
+                to determine why more memory cannot be used."
                     .to_string(),
                 doc_link: doc_ref("out-of-memory"),
             },

--- a/rs/interfaces/src/execution_environment/errors.rs
+++ b/rs/interfaces/src/execution_environment/errors.rs
@@ -432,8 +432,9 @@ impl AsErrorHelp for HypervisorError {
                 doc_link: doc_ref("wasm-module-not-found"),
             },
             Self::OutOfMemory => ErrorHelp::UserError {
-                suggestion: "Check the canister's memory usage against the system-wide limits \
-                to determine why more memory cannot be used."
+                suggestion: "Check the canister's memory usage against its allocation \
+                and the system wide limits to determine why more memory cannot be \
+                allocated."
                     .to_string(),
                 doc_link: doc_ref("out-of-memory"),
             },

--- a/rs/interfaces/src/execution_environment/errors.rs
+++ b/rs/interfaces/src/execution_environment/errors.rs
@@ -278,7 +278,7 @@ impl std::fmt::Display for HypervisorError {
                 f,
                 "Attempted to execute a message, but the canister contains no Wasm module.",
             ),
-            Self::OutOfMemory => write!(f, "Canister exceeded its allowed memory allocation.",),
+            Self::OutOfMemory => write!(f, "Canister cannot grow its memory usage.",),
             Self::InvalidPrincipalId(_) => {
                 write!(f, "Canister provided invalid principal id")
             }


### PR DESCRIPTION
This PR changes the error message "Canister exceeded its allowed memory allocation." for `OutOfMemory` to "Canister cannot grow its memory usage." since the error condition is not specific to "memory allocation".