### PR TITLE
chore: use ic-cdk 0.18.0-alpha.2

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "fe491b00db50f2e4e298fd67fb26c2f45ae7d9644aaed62a538b21e9cb6071a2",
+  "checksum": "c0e352a3fc3096231f51c6e54c1b202c91ac6bf8f12e4b5c3ecbf65087dae178",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "c0e352a3fc3096231f51c6e54c1b202c91ac6bf8f12e4b5c3ecbf65087dae178",
+  "checksum": "9ff61320857bd746ce4d3330820e8761dd7ba2c749dccb624d0ee5f034c7d541",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20462,7 +20462,7 @@
               "target": "ic_cdk"
             },
             {
-              "id": "ic-cdk 0.18.0",
+              "id": "ic-cdk 0.18.0-alpha.2",
               "target": "ic_cdk",
               "alias": "ic_cdk_next"
             },
@@ -33220,14 +33220,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-cdk 0.18.0": {
+    "ic-cdk 0.18.0-alpha.2": {
       "name": "ic-cdk",
-      "version": "0.18.0",
+      "version": "0.18.0-alpha.2",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk/0.18.0/download",
-          "sha256": "b11cc255410be6a7e47e1a756ea94c1f31a2397a79e696f6f7d207d5ebd3e144"
+          "url": "https://static.crates.io/crates/ic-cdk/0.18.0-alpha.2/download",
+          "sha256": "3c9c87d961de7d2935a0bf19f4d6afe76f3d508b853ff5267e999beadd7e9286"
         }
       },
       "targets": [
@@ -33290,13 +33290,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "ic-cdk-macros 0.18.0",
+              "id": "ic-cdk-macros 0.18.0-alpha.2",
               "target": "ic_cdk_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.18.0"
+        "version": "0.18.0-alpha.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -33509,14 +33509,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-cdk-macros 0.18.0": {
+    "ic-cdk-macros 0.18.0-alpha.2": {
       "name": "ic-cdk-macros",
-      "version": "0.18.0",
+      "version": "0.18.0-alpha.2",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk-macros/0.18.0/download",
-          "sha256": "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
+          "url": "https://static.crates.io/crates/ic-cdk-macros/0.18.0-alpha.2/download",
+          "sha256": "4987a4c05c25d2871f8a0dd4b726733fbf4c55b5a82656976333ddd79d8e1ce6"
         }
       },
       "targets": [
@@ -33568,7 +33568,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.18.0"
+        "version": "0.18.0-alpha.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -91536,7 +91536,7 @@
     "ic-canister-sig-creation 1.1.0",
     "ic-cbor 3.0.3",
     "ic-cdk 0.17.2",
-    "ic-cdk 0.18.0",
+    "ic-cdk 0.18.0-alpha.2",
     "ic-cdk-timers 0.11.0",
     "ic-certificate-verification 3.0.3",
     "ic-certification 3.0.3",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3497,7 +3497,7 @@ dependencies = [
  "ic-canister-sig-creation",
  "ic-cbor",
  "ic-cdk 0.17.2",
- "ic-cdk 0.18.0",
+ "ic-cdk 0.18.0-alpha.2",
  "ic-cdk-timers",
  "ic-certificate-verification",
  "ic-certification 3.0.3",
@@ -5760,12 +5760,12 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.18.0"
+version = "0.18.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11cc255410be6a7e47e1a756ea94c1f31a2397a79e696f6f7d207d5ebd3e144"
+checksum = "3c9c87d961de7d2935a0bf19f4d6afe76f3d508b853ff5267e999beadd7e9286"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.18.0",
+ "ic-cdk-macros 0.18.0-alpha.2",
  "ic-error-types",
  "ic-management-canister-types",
  "ic0 0.24.0",
@@ -5811,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.18.0"
+version = "0.18.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
+checksum = "4987a4c05c25d2871f8a0dd4b726733fbf4c55b5a82656976333ddd79d8e1ce6"
 dependencies = [
  "candid",
  "proc-macro2",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "254d0c54817ff4aae00b52d1572e6599461bbef5db4d6d0e39a3a13bf3943487",
+  "checksum": "069db4deada6ba0cfeffec21cefcb52d6e5d924b70cb1f8dc0a41bfc965833df",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20280,7 +20280,7 @@
               "target": "ic_cdk"
             },
             {
-              "id": "ic-cdk 0.18.0",
+              "id": "ic-cdk 0.18.0-alpha.2",
               "target": "ic_cdk",
               "alias": "ic_cdk_next"
             },
@@ -33068,14 +33068,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-cdk 0.18.0": {
+    "ic-cdk 0.18.0-alpha.2": {
       "name": "ic-cdk",
-      "version": "0.18.0",
+      "version": "0.18.0-alpha.2",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk/0.18.0/download",
-          "sha256": "b11cc255410be6a7e47e1a756ea94c1f31a2397a79e696f6f7d207d5ebd3e144"
+          "url": "https://static.crates.io/crates/ic-cdk/0.18.0-alpha.2/download",
+          "sha256": "3c9c87d961de7d2935a0bf19f4d6afe76f3d508b853ff5267e999beadd7e9286"
         }
       },
       "targets": [
@@ -33138,13 +33138,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "ic-cdk-macros 0.18.0",
+              "id": "ic-cdk-macros 0.18.0-alpha.2",
               "target": "ic_cdk_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.18.0"
+        "version": "0.18.0-alpha.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -33357,14 +33357,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "ic-cdk-macros 0.18.0": {
+    "ic-cdk-macros 0.18.0-alpha.2": {
       "name": "ic-cdk-macros",
-      "version": "0.18.0",
+      "version": "0.18.0-alpha.2",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-cdk-macros/0.18.0/download",
-          "sha256": "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
+          "url": "https://static.crates.io/crates/ic-cdk-macros/0.18.0-alpha.2/download",
+          "sha256": "4987a4c05c25d2871f8a0dd4b726733fbf4c55b5a82656976333ddd79d8e1ce6"
         }
       },
       "targets": [
@@ -33416,7 +33416,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.18.0"
+        "version": "0.18.0-alpha.2"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -91501,7 +91501,7 @@
     "ic-canister-sig-creation 1.1.0",
     "ic-cbor 3.0.3",
     "ic-cdk 0.17.2",
-    "ic-cdk 0.18.0",
+    "ic-cdk 0.18.0-alpha.2",
     "ic-cdk-timers 0.11.0",
     "ic-certificate-verification 3.0.3",
     "ic-certification 3.0.3",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "2a7e3bf92c0b0f1f54f8c9332ecc2357a5c1e4e1b89a0512bb0b22a66b2f240a",
+  "checksum": "254d0c54817ff4aae00b52d1572e6599461bbef5db4d6d0e39a3a13bf3943487",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3486,7 +3486,7 @@ dependencies = [
  "ic-canister-sig-creation",
  "ic-cbor",
  "ic-cdk 0.17.2",
- "ic-cdk 0.18.0",
+ "ic-cdk 0.18.0-alpha.2",
  "ic-cdk-timers",
  "ic-certificate-verification",
  "ic-certification 3.0.3",
@@ -5750,12 +5750,12 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.18.0"
+version = "0.18.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11cc255410be6a7e47e1a756ea94c1f31a2397a79e696f6f7d207d5ebd3e144"
+checksum = "3c9c87d961de7d2935a0bf19f4d6afe76f3d508b853ff5267e999beadd7e9286"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.18.0",
+ "ic-cdk-macros 0.18.0-alpha.2",
  "ic-error-types",
  "ic-management-canister-types",
  "ic0 0.24.0",
@@ -5801,9 +5801,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.18.0"
+version = "0.18.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
+checksum = "4987a4c05c25d2871f8a0dd4b726733fbf4c55b5a82656976333ddd79d8e1ce6"
 dependencies = [
  "candid",
  "proc-macro2",

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -625,7 +625,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             ),
             "ic-cdk-next": crate.spec(
                 package = "ic-cdk",
-                version = "^0.18.0",
+                version = "^0.18.0-alpha.2",
             ),
             "ic-cdk-timers": crate.spec(
                 version = "^0.11.0",

--- a/rs/rust_canisters/downstream_calls_test/Cargo.toml
+++ b/rs/rust_canisters/downstream_calls_test/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/main.rs"
 [dependencies]
 candid = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
-ic-cdk = "0.18.0"
+ic-cdk = "^0.18.0-alpha.2"
 serde = { workspace = true }

--- a/rs/rust_canisters/random_traffic_test/Cargo.toml
+++ b/rs/rust_canisters/random_traffic_test/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 candid = { workspace = true }
 futures = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
-ic-cdk = "0.18.0"
+ic-cdk = "^0.18.0-alpha.2"
 ic-error-types = { path = "../../../packages/ic-error-types" }
 ic-types = { path = "../../types/types" }
 proptest = { workspace = true }

--- a/rs/rust_canisters/xnet_test/Cargo.toml
+++ b/rs/rust_canisters/xnet_test/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 candid = { workspace = true }
 futures = { workspace = true }
-ic-cdk = "0.18.0"
+ic-cdk = "^0.18.0-alpha.2"
 ic-management-canister-types = { workspace = true }
 rand = { workspace = true }
 rand_pcg = "0.3"


### PR DESCRIPTION
Recalculating the `Cargo.Bazel.*` files by emptying them and running `bin/bazel-pin.sh --force` results in:
```
error: failed to select a version for the requirement `ic-cdk = "^0.18.0"`
  version 0.18.0 is yanked
  version 0.18.1 is yanked
  version 0.18.2 is yanked
```
This is because [the following targets](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/dfinity/ic%24+%27ic-cdk+%3D+%220.18.0%22%27&patternType=keyword&sm=0) were still depending on `ic-cdk = "^0.18.0"`:
* `//rs/rust_canisters/downstream_calls_test`
* `//rs/rust_canisters/random_traffic_test`
* `//rs/rust_canisters/xnet_test`

This is fixed by letting those targets depend on ic-cdk--0.18.0-alpha.2.