### PR TITLE
chore: recalculate Cargo.Bazel files

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b3467e75440c7ea4661ccb7b5d1b21ca0e2b1b88429376ce9093da73dbfef608",
+  "checksum": "147da7fca815ff7c204bc43eec594aa317acd21acd18081ac0691489894b3edc",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20409,7 +20409,7 @@
               "target": "get_if_addrs"
             },
             {
-              "id": "getrandom 0.2.16",
+              "id": "getrandom 0.3.3",
               "target": "getrandom"
             },
             {
@@ -27809,7 +27809,6 @@
         ],
         "crate_features": {
           "common": [
-            "custom",
             "std"
           ],
           "selects": {
@@ -27853,6 +27852,15 @@
           }
         },
         "edition": "2018",
+        "rustc_flags": {
+          "common": [],
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "--cfg",
+              "getrandom_backend=\"custom\""
+            ]
+          }
+        },
         "version": "0.2.16"
       },
       "license": "MIT OR Apache-2.0",
@@ -27991,6 +27999,15 @@
           }
         },
         "edition": "2021",
+        "rustc_flags": {
+          "common": [],
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "--cfg",
+              "getrandom_backend=\"custom\""
+            ]
+          }
+        },
         "version": "0.3.3"
       },
       "build_script_attrs": {
@@ -91447,7 +91464,7 @@
     "futures 0.3.31",
     "futures-util 0.3.31",
     "get_if_addrs 0.5.3",
-    "getrandom 0.2.16",
+    "getrandom 0.3.3",
     "goldenfile 1.8.0",
     "group 0.13.0",
     "hashlink 0.8.4",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3486,7 +3486,7 @@ dependencies = [
  "futures",
  "futures-util",
  "get_if_addrs",
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "goldenfile",
  "group 0.13.0",
  "hashlink",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "2195b8e1fb20526ea13d9a2485b7cb0a67e7ffd82bc5ec3eecd65d9fbb78b80b",
+  "checksum": "43dadaddba32c306b61e8cd2139ea299b44518d57825c2d2002bd8c42df2da3c",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20294,7 +20294,7 @@
               "target": "get_if_addrs"
             },
             {
-              "id": "getrandom 0.2.16",
+              "id": "getrandom 0.3.3",
               "target": "getrandom"
             },
             {
@@ -27694,7 +27694,6 @@
         ],
         "crate_features": {
           "common": [
-            "custom",
             "std"
           ],
           "selects": {
@@ -27738,6 +27737,15 @@
           }
         },
         "edition": "2018",
+        "rustc_flags": {
+          "common": [],
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "--cfg",
+              "getrandom_backend=\"custom\""
+            ]
+          }
+        },
         "version": "0.2.16"
       },
       "license": "MIT OR Apache-2.0",
@@ -27876,6 +27884,15 @@
           }
         },
         "edition": "2021",
+        "rustc_flags": {
+          "common": [],
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "--cfg",
+              "getrandom_backend=\"custom\""
+            ]
+          }
+        },
         "version": "0.3.3"
       },
       "build_script_attrs": {
@@ -91286,7 +91303,7 @@
     "futures 0.3.31",
     "futures-util 0.3.31",
     "get_if_addrs 0.5.3",
-    "getrandom 0.2.16",
+    "getrandom 0.3.3",
     "goldenfile 1.8.0",
     "group 0.13.0",
     "hashlink 0.8.4",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3486,7 +3486,7 @@ dependencies = [
  "futures",
  "futures-util",
  "get_if_addrs",
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "goldenfile",
  "group 0.13.0",
  "hashlink",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8802,7 +8802,7 @@ dependencies = [
 name = "ic-dummy-getrandom-for-wasm"
 version = "0.1.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -19645,7 +19645,7 @@ dependencies = [
  "anyhow",
  "candid",
  "candid_parser",
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "ic-canister-log 0.2.0",
  "ic-cdk 0.17.2",
  "ic-cdk-timers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -562,7 +562,7 @@ ethnum = { version = "1.3.2", features = ["serde"] }
 flate2 = "1.0.31"
 futures = "0.3.31"
 futures-util = "0.3.31"
-getrandom = { version = "0.2", features = ["custom"] }
+getrandom = { version = "0.3" }
 goldenfile = "1.8.0"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "1.3.1"

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -165,6 +165,17 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
         "metrics-proxy": [crate.annotation(
             gen_binaries = True,
         )],
+        "getrandom": [crate.annotation(
+            rustc_flags = crate.select(
+                [],
+                {
+                    "wasm32-unknown-unknown": [
+                        "--cfg",
+                        "getrandom_backend=\"custom\"",
+                    ],
+                },
+            ),
+        )],
     }
     CRATE_ANNOTATIONS.update(sanitize_external_crates(sanitizers_enabled = sanitizers_enabled))
     crates_repository(
@@ -521,10 +532,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.5.3",
             ),
             "getrandom": crate.spec(
-                version = "^0.2",
-                features = [
-                    "custom",
-                ],
+                version = "^0.3",
             ),
             "goldenfile": crate.spec(
                 version = "^1.8",

--- a/packages/ic-dummy-getrandom-for-wasm/Cargo.toml
+++ b/packages/ic-dummy-getrandom-for-wasm/Cargo.toml
@@ -8,8 +8,5 @@ authors.workspace = true
 edition.workspace = true
 documentation.workspace = true
 
-[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", features = ["custom"] }
-
-[target.'cfg(not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))'.dependencies]
-getrandom = { version = "0.2" }
+[dependencies]
+getrandom = { workspace = true }

--- a/packages/ic-dummy-getrandom-for-wasm/src/lib.rs
+++ b/packages/ic-dummy-getrandom-for-wasm/src/lib.rs
@@ -1,7 +1,7 @@
-//! This crate exists to work around a problem with `getrandom` 0.2, which is a dependency
+//! This crate exists to work around a problem with `getrandom` 0.3, which is a dependency
 //! of `rand` 0.8
 //!
-//! For the `wasm32-unknown-unknown` target, `getrandom` 0.2 will refuse to compile. This is an
+//! For the `wasm32-unknown-unknown` target, `getrandom` 0.3 will refuse to compile. This is an
 //! intentional policy decision on the part of the getrandom developers. As a consequence, it
 //! would not be possible to compile anything which depends on `rand` 0.8 to wasm for use in
 //! canister code.
@@ -17,7 +17,7 @@
 //! different crates which included the workaround would fail to build due to the conflict.
 //!
 //! See the [getrandom
-//! documentation](https://docs.rs/getrandom/latest/getrandom/macro.register_custom_getrandom.html)
+//! documentation](https://docs.rs/getrandom/latest/getrandom/index.html#custom-backend)
 //! for more details on custom implementations.
 
 #[cfg(all(
@@ -26,13 +26,10 @@
     target_os = "unknown"
 ))]
 /// A getrandom implementation that always fails
-pub fn always_fail(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
+#[no_mangle]
+unsafe extern "Rust" fn __getrandom_v03_custom(
+    _dest: *mut u8,
+    _len: usize,
+) -> Result<(), getrandom::Error> {
     Err(getrandom::Error::UNSUPPORTED)
 }
-
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-))]
-getrandom::register_custom_getrandom!(always_fail);

--- a/rs/boundary_node/rate_limits/canister/add_config.rs
+++ b/rs/boundary_node/rate_limits/canister/add_config.rs
@@ -185,7 +185,7 @@ impl<A: CanisterApi> AddsConfig for ConfigAdder<A> {
 
 fn generate_random_uuid() -> Result<Uuid, anyhow::Error> {
     let mut buf = [0u8; 16];
-    getrandom::getrandom(&mut buf)
+    getrandom::fill(&mut buf)
         .map_err(|e| anyhow::anyhow!(e))
         .context("Failed to generate random bytes")?;
     let uuid = Uuid::from_slice(&buf).context("Failed to create UUID from bytes")?;

--- a/rs/boundary_node/rate_limits/canister/random.rs
+++ b/rs/boundary_node/rate_limits/canister/random.rs
@@ -19,18 +19,16 @@ thread_local! {
     target_os = "unknown"
 ))]
 /// A getrandom implementation that works in the IC.
-pub fn custom_getrandom_bytes_impl(dest: &mut [u8]) -> Result<(), getrandom::Error> {
+#[no_mangle]
+unsafe extern "Rust" fn __getrandom_v03_custom(
+    dest: *mut u8,
+    len: usize,
+) -> Result<(), getrandom::Error> {
     RNG.with(|rng| {
         let mut rng = rng.borrow_mut();
-        rng.fill_bytes(dest);
+        let slice = std::slice::from_raw_parts_mut(dest, len);
+        rng.fill_bytes(slice);
     });
 
     Ok(())
 }
-
-#[cfg(all(
-    target_arch = "wasm32",
-    target_vendor = "unknown",
-    target_os = "unknown"
-))]
-getrandom::register_custom_getrandom!(custom_getrandom_bytes_impl);


### PR DESCRIPTION
As preparation for fixing the `num-traits` [non-reproducibility](https://github.com/rust-num/num-traits/pull/355) due to `autocfg` I would like to update the `Cargo.Bazel.*` files so the eventual fix will result in a smaller diff. This commit was accomplished using:
```
for f in $(ls Cargo.Bazel.*); do echo > $f; done; bin/bazel-pin.sh --force
```