### PR TITLE
chore: update codeowners for /rs/interfaces/src/execution_environment/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -155,6 +155,7 @@ go_deps.bzl               @dfinity/idx
 /rs/interfaces/src/crypto.rs                            @dfinity/crypto-team
 /rs/interfaces/src/crypto/                              @dfinity/crypto-team
 /rs/interfaces/src/dkg.rs                               @dfinity/consensus
+/rs/interfaces/src/execution_environment/               @dfinity/execution
 /rs/interfaces/src/execution_environment.rs             @dfinity/execution
 /rs/interfaces/src/messaging.rs                         @dfinity/ic-message-routing-owners
 /rs/interfaces/src/p2p.rs                               @dfinity/consensus


### PR DESCRIPTION
This PR specifies the execution team as code owners for the prefix `/rs/interfaces/src/execution_environment/` to complement the existing ownership rule for the file `/rs/interfaces/src/execution_environment.rs` already owned by the execution team.
