### PR TITLE
chore: stabilize the highly flaky nns_dapp_test

### DIFF
--- a/rs/tests/nns/nns_dapp_test.rs
+++ b/rs/tests/nns/nns_dapp_test.rs
@@ -70,7 +70,7 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
             &log,
             secs(600),
             secs(30),
-            || async {
+            async || {
                 let client = reqwest::Client::builder()
                     .use_rustls_tls()
                     .https_only(true)
@@ -83,6 +83,7 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
                     .header("User-Agent", "systest") // to prevent getting the service worker
                     .send()
                     .await?;
+
                 let status = resp.status();
                 if !status.is_success() {
                     bail!(
@@ -91,6 +92,7 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
                         status
                     );
                 }
+
                 let body_bytes = resp.bytes().await?.to_vec();
                 if let Ok(body) = String::from_utf8(body_bytes.clone()) {
                     if body.contains("503 Service Temporarily Unavailable") {

--- a/rs/tests/nns/nns_dapp_test.rs
+++ b/rs/tests/nns/nns_dapp_test.rs
@@ -84,6 +84,13 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
                     .send()
                     .await?;
                 let status = resp.status();
+                if !status.is_success() {
+                    bail!(
+                        "Failed to get HTML from {}: status code {:?}",
+                        dapp_url,
+                        status
+                    );
+                }
                 let body_bytes = resp.bytes().await?.to_vec();
                 if let Ok(body) = String::from_utf8(body_bytes.clone()) {
                     if body.contains("503 Service Temporarily Unavailable") {
@@ -91,7 +98,7 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
                     } else if body.contains(dapp_anchor) {
                         return Ok(());
                     } else {
-                        bail!("Unexpected response from BN with status: {:?}!", status);
+                        panic!("Unexpected response from BN!");
                     }
                 };
 

--- a/rs/tests/nns/nns_dapp_test.rs
+++ b/rs/tests/nns/nns_dapp_test.rs
@@ -64,13 +64,13 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
     let ic_gateway_domain = ic_gateway_url.domain().unwrap();
     let dapp_url = format!("https://{canister_id}.{ic_gateway_domain}");
     let log = env.logger();
-    ic_system_test_driver::retry_with_msg!(
-        format!("get html from {}", dapp_url),
-        log.clone(),
-        secs(600),
-        secs(30),
-        || {
-            block_on(async {
+    block_on(async {
+        ic_system_test_driver::retry_with_msg_async!(
+            format!("get html from {}", dapp_url),
+            &log,
+            secs(600),
+            secs(30),
+            || async {
                 let client = reqwest::Client::builder()
                     .use_rustls_tls()
                     .https_only(true)
@@ -83,7 +83,7 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
                     .header("User-Agent", "systest") // to prevent getting the service worker
                     .send()
                     .await?;
-
+                let status = resp.status();
                 let body_bytes = resp.bytes().await?.to_vec();
                 if let Ok(body) = String::from_utf8(body_bytes.clone()) {
                     if body.contains("503 Service Temporarily Unavailable") {
@@ -91,7 +91,7 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
                     } else if body.contains(dapp_anchor) {
                         return Ok(());
                     } else {
-                        panic!("Unexpected response from BN!");
+                        bail!("Unexpected response from BN with status: {:?}!", status);
                     }
                 };
 
@@ -103,9 +103,10 @@ fn get_html(env: &TestEnv, ic_gateway_url: Url, canister_id: Principal, dapp_anc
                 assert!(body.contains(dapp_anchor));
 
                 Ok(())
-            })
-        }
-    )
+            }
+        )
+        .await
+    })
     .unwrap_or_else(|_| panic!("{} should deliver a proper HTML page!", dapp_url.as_str()));
 }
 


### PR DESCRIPTION
The `//rs/tests/nns:nns_dapp_test` is highly flaky (14%). When it fails it most often is because the BN returned an unexpected response when requesting an HTML page. Instead of immediately panicking we retry on a non-successful response status.