### PR TITLE
chore: Update code owners for lru cache

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -291,6 +291,7 @@ go_deps.bzl               @dfinity/idx
 /rs/types/wasm_types/                                   @dfinity/execution
 /rs/universal_canister/                                 @dfinity/execution
 /rs/utils/                                              @dfinity/ic-interface-owners
+/rs/utils/lru_cache                                     @dfinity/execution
 /rs/utils/thread/                                       @dfinity/ic-message-routing-owners
 /rs/utils/ensure/                                       @dfinity/finint
 /rs/validator/                                          @dfinity/crypto-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -291,7 +291,7 @@ go_deps.bzl               @dfinity/idx
 /rs/types/wasm_types/                                   @dfinity/execution
 /rs/universal_canister/                                 @dfinity/execution
 /rs/utils/                                              @dfinity/ic-interface-owners
-/rs/utils/lru_cache                                     @dfinity/execution
+/rs/utils/lru_cache/                                    @dfinity/execution
 /rs/utils/thread/                                       @dfinity/ic-message-routing-owners
 /rs/utils/ensure/                                       @dfinity/finint
 /rs/validator/                                          @dfinity/crypto-team


### PR DESCRIPTION
This crate is used only by the execution team so moving ownership to the team explictly.