### PR TITLE
chore(PocketIC): comprehensible error for clearly invalid subnet state directory

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1746,7 +1746,7 @@ pub enum IngressStatusResult {
 }
 
 #[cfg(windows)]
-fn wsl_path(path: &PathBuf, desc: &str) -> String {
+pub fn wsl_path(path: &PathBuf, desc: &str) -> String {
     windows_to_wsl(
         path.as_os_str()
             .to_str()

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1746,7 +1746,7 @@ pub enum IngressStatusResult {
 }
 
 #[cfg(windows)]
-pub fn wsl_path(path: &PathBuf, desc: &str) -> String {
+fn wsl_path(path: &PathBuf, desc: &str) -> String {
     windows_to_wsl(
         path.as_os_str()
             .to_str()

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -2799,7 +2799,7 @@ fn with_subnet_state_file() {
 }
 
 #[test]
-#[should_panic(expected = "Provided an empty state dir at path")]
+#[should_panic(expected = "Provided an empty state directory at path")]
 fn with_empty_subnet_state() {
     let state_dir = TempDir::new().unwrap();
     #[cfg(not(windows))]

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -2789,7 +2789,7 @@ fn with_subnet_state_file() {
     #[cfg(not(windows))]
     let state_file_path_buf = state_file.path().to_path_buf();
     #[cfg(windows)]
-    let state_file_path_buf = windows_to_wsl(state_file_path_buf.as_os_str().to_str().unwrap())
+    let state_file_path_buf = windows_to_wsl(state_file.path().as_os_str().to_str().unwrap())
         .unwrap()
         .into();
 
@@ -2805,7 +2805,7 @@ fn with_empty_subnet_state() {
     #[cfg(not(windows))]
     let state_dir_path_buf = state_dir.path().to_path_buf();
     #[cfg(windows)]
-    let state_dir_path_buf = windows_to_wsl(state_dir_path_buf.as_os_str().to_str().unwrap())
+    let state_dir_path_buf = windows_to_wsl(state_dir.path().as_os_str().to_str().unwrap())
         .unwrap()
         .into();
 

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -2787,10 +2787,11 @@ fn test_specified_id_on_resumed_state() {
 fn with_subnet_state_file() {
     let state_file = NamedTempFile::new().unwrap();
     #[cfg(not(windows))]
-    let state_dir_path_buf = state_dir.path().to_path_buf();
+    let state_file_path_buf = state_file.path().to_path_buf();
     #[cfg(windows)]
-    let state_dir_path_buf =
-        windows_to_wsl(state_dir_path_buf.as_os_str().to_str().unwrap()).unwrap();
+    let state_file_path_buf = windows_to_wsl(state_file_path_buf.as_os_str().to_str().unwrap())
+        .unwrap()
+        .into();
 
     let _pic = PocketIcBuilder::new()
         .with_subnet_state(SubnetKind::Application, state_file_path_buf)
@@ -2804,8 +2805,9 @@ fn with_empty_subnet_state() {
     #[cfg(not(windows))]
     let state_dir_path_buf = state_dir.path().to_path_buf();
     #[cfg(windows)]
-    let state_dir_path_buf =
-        windows_to_wsl(state_dir_path_buf.as_os_str().to_str().unwrap()).unwrap();
+    let state_dir_path_buf = windows_to_wsl(state_dir_path_buf.as_os_str().to_str().unwrap())
+        .unwrap()
+        .into();
 
     let _pic = PocketIcBuilder::new()
         .with_subnet_state(SubnetKind::Application, state_dir_path_buf)

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -27,6 +27,8 @@ use sha2::{Digest, Sha256};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::{io::Read, sync::OnceLock, time::SystemTime};
 use tempfile::{NamedTempFile, TempDir};
+#[cfg(windows)]
+use wslpath::windows_to_wsl;
 
 // 2T cycles
 const INIT_CYCLES: u128 = 2_000_000_000_000;
@@ -2784,7 +2786,11 @@ fn test_specified_id_on_resumed_state() {
 #[should_panic(expected = "is not a (subnet state) directory")]
 fn with_subnet_state_file() {
     let state_file = NamedTempFile::new().unwrap();
-    let state_file_path_buf = state_file.path().to_path_buf();
+    #[cfg(not(windows))]
+    let state_dir_path_buf = state_dir.path().to_path_buf();
+    #[cfg(windows)]
+    let state_dir_path_buf =
+        windows_to_wsl(state_dir_path_buf.as_os_str().to_str().unwrap()).unwrap();
 
     let _pic = PocketIcBuilder::new()
         .with_subnet_state(SubnetKind::Application, state_file_path_buf)
@@ -2795,7 +2801,11 @@ fn with_subnet_state_file() {
 #[should_panic(expected = "Provided an empty state dir at path")]
 fn with_empty_subnet_state() {
     let state_dir = TempDir::new().unwrap();
+    #[cfg(not(windows))]
     let state_dir_path_buf = state_dir.path().to_path_buf();
+    #[cfg(windows)]
+    let state_dir_path_buf =
+        windows_to_wsl(state_dir_path_buf.as_os_str().to_str().unwrap()).unwrap();
 
     let _pic = PocketIcBuilder::new()
         .with_subnet_state(SubnetKind::Application, state_dir_path_buf)

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -26,7 +26,7 @@ use sha2::{Digest, Sha256};
 #[cfg(windows)]
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::{io::Read, sync::OnceLock, time::SystemTime};
-use tempfile::TempDir;
+use tempfile::{NamedTempFile, TempDir};
 
 // 2T cycles
 const INIT_CYCLES: u128 = 2_000_000_000_000;
@@ -2778,6 +2778,17 @@ fn test_specified_id_on_resumed_state() {
     let pic = PocketIcBuilder::new().with_state(state).build();
 
     test_specified_id(&pic);
+}
+
+#[test]
+#[should_panic(expected = "is not a (subnet state) directory")]
+fn with_subnet_state_file() {
+    let state_file = NamedTempFile::new().unwrap();
+    let state_file_path_buf = state_file.path().to_path_buf();
+
+    let _pic = PocketIcBuilder::new()
+        .with_subnet_state(SubnetKind::Application, state_file_path_buf)
+        .build();
 }
 
 #[test]

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -26,6 +26,7 @@ use sha2::{Digest, Sha256};
 #[cfg(windows)]
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::{io::Read, sync::OnceLock, time::SystemTime};
+use tempfile::TempDir;
 
 // 2T cycles
 const INIT_CYCLES: u128 = 2_000_000_000_000;
@@ -2777,4 +2778,15 @@ fn test_specified_id_on_resumed_state() {
     let pic = PocketIcBuilder::new().with_state(state).build();
 
     test_specified_id(&pic);
+}
+
+#[test]
+#[should_panic(expected = "Provided an empty state dir at path")]
+fn with_empty_subnet_state() {
+    let state_dir = TempDir::new().unwrap();
+    let state_dir_path_buf = state_dir.path().to_path_buf();
+
+    let _pic = PocketIcBuilder::new()
+        .with_subnet_state(SubnetKind::Application, state_dir_path_buf)
+        .build();
 }

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1001,7 +1001,7 @@ impl PocketIc {
                             // Return a comprehensible error if the provided state directory is empty.
                             if dir.next().is_none() {
                                 return Err(format!(
-                                    "Provided an empty state dir at path {}.",
+                                    "Provided an empty state directory at path {}.",
                                     subnet_state_dir.display()
                                 ));
                             }

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -988,12 +988,18 @@ impl PocketIc {
                 let (ranges, alloc_range, subnet_id, time) = if let Some(ref subnet_state_dir) =
                     subnet_state_dir
                 {
+                    // Return a comprehensible error if the provided state directory is not a directory.
+                    if !subnet_state_dir.is_dir() {
+                        return Err(format!(
+                            "The path {} is not a (subnet state) directory.",
+                            subnet_state_dir.display()
+                        ));
+                    }
                     // Return a comprehensible error if the provided state directory is empty.
-                    let is_nonempty = subnet_state_dir.is_dir()
-                        && std::fs::read_dir(subnet_state_dir)
-                            .map(|mut f| f.next().is_some())
-                            .unwrap_or(false);
-                    if !is_nonempty {
+                    let is_empty = std::fs::read_dir(subnet_state_dir)
+                        .map(|mut f| f.next().is_none())
+                        .unwrap_or(true);
+                    if is_empty {
                         return Err(format!(
                             "Provided an empty state dir at path {}.",
                             subnet_state_dir.display()

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -988,6 +988,18 @@ impl PocketIc {
                 let (ranges, alloc_range, subnet_id, time) = if let Some(ref subnet_state_dir) =
                     subnet_state_dir
                 {
+                    // Return a comprehensible error if the provided state directory is empty.
+                    let is_nonempty = subnet_state_dir.is_dir()
+                        && std::fs::read_dir(subnet_state_dir)
+                            .map(|mut f| f.next().is_some())
+                            .unwrap_or(false);
+                    if !is_nonempty {
+                        return Err(format!(
+                            "Provided an empty state dir at path {}.",
+                            subnet_state_dir.display()
+                        ));
+                    }
+
                     let metadata = {
                         // We create a temporary state manager used to read the given state metadata.
                         // We first copy the subnet state directory into a temporary directory

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -988,23 +988,25 @@ impl PocketIc {
                 let (ranges, alloc_range, subnet_id, time) = if let Some(ref subnet_state_dir) =
                     subnet_state_dir
                 {
-                    // Return a comprehensible error if the provided state directory is not a directory.
-                    if !subnet_state_dir.is_dir() {
-                        return Err(format!(
-                            "The path {} is not a (subnet state) directory.",
-                            subnet_state_dir.display()
-                        ));
-                    }
-                    // Return a comprehensible error if the provided state directory is empty.
-                    let is_empty = std::fs::read_dir(subnet_state_dir)
-                        .map(|mut f| f.next().is_none())
-                        .unwrap_or(true);
-                    if is_empty {
-                        return Err(format!(
-                            "Provided an empty state dir at path {}.",
-                            subnet_state_dir.display()
-                        ));
-                    }
+                    match std::fs::read_dir(subnet_state_dir) {
+                        // Return a comprehensible error if the provided state directory is not a (readable) directory.
+                        Err(err) => {
+                            return Err(format!(
+                                "The path {} is not a (subnet state) directory: {}",
+                                subnet_state_dir.display(),
+                                err,
+                            ));
+                        }
+                        Ok(mut dir) => {
+                            // Return a comprehensible error if the provided state directory is empty.
+                            if dir.next().is_none() {
+                                return Err(format!(
+                                    "Provided an empty state dir at path {}.",
+                                    subnet_state_dir.display()
+                                ));
+                            }
+                        }
+                    };
 
                     let metadata = {
                         // We create a temporary state manager used to read the given state metadata.


### PR DESCRIPTION
This PR makes PocketIC return a comprehensible error if the provided subnet state directory is clearly invalid, i.e., not a directory or an empty directory.