### PR TITLE
fix(IDX): run versions workflow every 2 hours

### DIFF
--- a/.github/workflows/update-mainnet-revisions.yaml
+++ b/.github/workflows/update-mainnet-revisions.yaml
@@ -2,7 +2,7 @@ name: Update IC versions file
 
 on:
   schedule:
-    - cron: "10 * * * *"
+    - cron: "0 */2 * * *"
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Because `bazel-test-all` sometimes takes longer than 1 hour to run, it keeps kicking off a new run, preventing the PR from being merged. This changes the job to run every 2 hours instead.