### PR TITLE
revert: "chore: Update Mainnet IC revisions file"

### DIFF
--- a/mainnet-icos-revisions.json
+++ b/mainnet-icos-revisions.json
@@ -1,14 +1,14 @@
 {
   "guestos": {
     "subnets": {
-      "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe": "16825c5cbff83a51983d849b60c9d26b3268bbb6",
-      "io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe": "ed3650da85f390130dedf55806da9337d796b799"
+      "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe": "2f52f298de53944209f550774505aa72a1a3ed17",
+      "io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe": "2f52f298de53944209f550774505aa72a1a3ed17"
     }
   },
   "hostos": {
     "latest_release": {
-      "version": "ed3650da85f390130dedf55806da9337d796b799",
-      "update_img_hash": "8e5b82daa1c0c1ea1b220211bb43d795622dd9d333689ebbcee99c8da6987e46"
+      "version": "2f52f298de53944209f550774505aa72a1a3ed17",
+      "update_img_hash": "e258e74394cf557a625b77bd0bb81bab16eddbfc5a2a43bc149a90258243ae87"
     }
   }
 }


### PR DESCRIPTION
Reverts dfinity/ic#5388 as it breaks some system tests.

![image](https://github.com/user-attachments/assets/a8046247-d75e-4e28-8114-7f0c3e3d4fca)

https://github.com/dfinity/ic/actions/runs/15412006467/job/43365935724
https://github.com/dfinity/ic/actions/runs/15413236439/job/43369922482
https://github.com/dfinity/ic/actions/runs/15414503722/job/43374032957
https://github.com/dfinity/ic/actions/runs/15415664772/job/43377741159