### PR TITLE
chore(IDX): Improve build determinism summary legibility

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -150,4 +150,8 @@ runs:
             # with --check_up_to_date Bazel will error out if the artifacts
             # to be uploaded were not built in the build step above
             # (this ensures that the exact artifacts built above are uploaded)
-            bazel run --check_up_to_date //:upload-artifacts >>"$GITHUB_STEP_SUMMARY"
+            {
+              echo '<details><summary>Build Reproducibility Summary</summary>';
+              bazel run --check_up_to_date //:upload-artifacts
+              echo '</details>';
+            } >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This adds a `<details><summary>...` section for the build determinism step "summary" which can be pretty lengthy.