### PR TITLE
chore: Update CODEOWNERS for protobuf generated files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -185,12 +185,12 @@ go_deps.bzl               @dfinity/idx
 /rs/protobuf/def/p2p/                                   @dfinity/consensus
 /rs/protobuf/def/registry/                              @dfinity/governance-team
 /rs/protobuf/def/state/                                 @dfinity/execution @dfinity/ic-message-routing-owners
-/rs/protobuf/gen/bitcoin/                               @dfinity/execution
-/rs/protobuf/gen/crypto/                                @dfinity/crypto-team
-/rs/protobuf/gen/messaging/                             @dfinity/ic-message-routing-owners
-/rs/protobuf/gen/p2p/                                   @dfinity/consensus
-/rs/protobuf/gen/registry/                              @dfinity/governance-team
-/rs/protobuf/gen/state/                                 @dfinity/execution @dfinity/ic-message-routing-owners
+/rs/protobuf/src/gen/bitcoin/                           @dfinity/execution
+/rs/protobuf/src/gen/crypto/                            @dfinity/crypto-team
+/rs/protobuf/src/gen/messaging/                         @dfinity/ic-message-routing-owners
+/rs/protobuf/src/gen/p2p/                               @dfinity/consensus
+/rs/protobuf/src/gen/registry/                          @dfinity/governance-team
+/rs/protobuf/src/gen/state/                             @dfinity/execution @dfinity/ic-message-routing-owners
 /rs/query_stats/                                        @dfinity/execution @dfinity/consensus
 /rs/recovery/                                           @dfinity/consensus
 /rs/registry/                                           @dfinity/governance-team


### PR DESCRIPTION
We previously designated specific teams as code owners for their respective sections of the protobuf-generated files. However, due to changes in the output paths some time ago, the mappings broke and review requests fall back to ic-interface-owners.

This PR updates the CODEOWNERS file to reflect the new paths. Teams can review and approve changes in their part.