### PR TITLE
refactor(nns): Move Governance API->Internal type conversion into Governance::new

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -73,14 +73,14 @@ benches:
     total:
       calls: 1
       instructions: 66319497
-      heap_increase: 3
+      heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
   list_neurons_stable:
     total:
       calls: 1
       instructions: 67632700
-      heap_increase: 4
+      heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
   list_proposals:

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -137,9 +137,8 @@ fn canister_init_(init_payload: ApiGovernanceProto) {
         init_payload.neurons.len()
     );
 
-    let governance_proto = InternalGovernanceProto::from(init_payload);
     set_governance(Governance::new(
-        governance_proto,
+        init_payload,
         Arc::new(CanisterEnv::new()),
         Arc::new(IcpLedgerCanister::<CdkRuntime>::new(LEDGER_CANISTER_ID)),
         Arc::new(CMCCanister::<CdkRuntime>::new()),

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1581,12 +1581,14 @@ impl Governance {
     /// Initializes Governance for the first time from init payload. When restoring after an upgrade
     /// with its persisted state, `Governance::new_restored` should be called instead.
     pub fn new(
-        mut governance_proto: GovernanceProto,
+        initial_governance: api::Governance,
         env: Arc<dyn Environment>,
         ledger: Arc<dyn IcpLedger>,
         cmc: Arc<dyn CMC>,
         randomness: Box<dyn RandomnessGenerator>,
     ) -> Self {
+        let mut governance_proto = GovernanceProto::from(initial_governance);
+
         // Step 1: Populate some fields governance_proto if they are blank.
 
         // Step 1.1: genesis_timestamp_seconds. 0 indicates it hasn't been set already.
@@ -1836,7 +1838,7 @@ impl Governance {
     /// - the maximum number of neurons has been reached, or
     /// - the given `neuron_id` already exists in `self.neuron_store.neurons`, or
     /// - the neuron's controller `PrincipalId` is not self-authenticating.
-    fn add_neuron(
+    pub(crate) fn add_neuron(
         &mut self,
         neuron_id: u64,
         neuron: Neuron,

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -1,6 +1,6 @@
 use crate::benches_util::check_projected_instructions;
 use crate::governance::REWARD_DISTRIBUTION_PERIOD_SECONDS;
-use crate::pb::v1::{Motion, RewardEvent, VotingPowerEconomics, WaitForQuietState};
+use crate::pb::v1::{Motion, VotingPowerEconomics};
 use crate::test_utils::MockRandomness;
 use crate::{
     governance::{
@@ -11,9 +11,8 @@ use crate::{
     neuron_store::NeuronStore,
     pb::v1::{
         install_code::CanisterInstallMode, neuron::Followees, proposal::Action, Ballot, BallotInfo,
-        CreateServiceNervousSystem, ExecuteNnsFunction, Governance as GovernanceProto, InstallCode,
-        KnownNeuron, ListProposalInfo, NetworkEconomics, Neuron as NeuronProto, NnsFunction,
-        Proposal, ProposalData, Topic, Vote,
+        CreateServiceNervousSystem, ExecuteNnsFunction, InstallCode, KnownNeuron, ListProposalInfo,
+        NnsFunction, Proposal, ProposalData, Topic, Vote,
     },
     test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
 };
@@ -28,12 +27,12 @@ use ic_nns_common::{
     types::NeuronId,
 };
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
-use ic_nns_governance_api::{list_neurons::NeuronSubaccount, ListNeurons};
+use ic_nns_governance_api as api;
 use icp_ledger::Subaccount;
 use maplit::{btreemap, hashmap};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 enum SetUpStrategy {
@@ -331,11 +330,8 @@ fn set_up_chain<R: Rng>(
 fn cast_vote_cascade_helper(strategy: SetUpStrategy, topic: Topic) -> BenchResult {
     let mut rng = ChaCha20Rng::seed_from_u64(0);
 
-    let governance_proto = GovernanceProto {
-        ..Default::default()
-    };
     let mut governance = Governance::new(
-        governance_proto,
+        Default::default(),
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
@@ -445,32 +441,28 @@ fn compute_ballots_for_new_proposal_with_stable_neurons() -> BenchResult {
     let now_seconds = 1732817584;
     let num_neurons = 100;
 
-    let neurons = (0..num_neurons)
-        .map(|id| {
-            (
-                id,
-                NeuronProto::from(make_neuron(
-                    id,
-                    PrincipalId::new_user_test_id(id),
-                    1_000_000_000,
-                    hashmap! {}, // get the default followees
-                )),
-            )
-        })
-        .collect::<BTreeMap<u64, NeuronProto>>();
-
-    let governance_proto = GovernanceProto {
-        neurons,
-        ..GovernanceProto::default()
-    };
-
     let mut governance = Governance::new(
-        governance_proto,
+        Default::default(),
         Arc::new(MockEnvironment::new(vec![], now_seconds)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
+
+    for id in 1..=num_neurons {
+        governance
+            .add_neuron(
+                id,
+                make_neuron(
+                    id,
+                    PrincipalId::new_user_test_id(id),
+                    1_000_000_000,
+                    hashmap! {}, // get the default followees
+                ),
+                false,
+            )
+            .unwrap();
+    }
 
     let bench_result = bench_fn(|| {
         governance
@@ -496,35 +488,32 @@ fn compute_ballots_for_new_proposal_with_stable_neurons() -> BenchResult {
 #[bench(raw)]
 fn distribute_rewards_with_stable_neurons() -> BenchResult {
     let now_seconds = 1732817584;
-    let neurons = (0..100)
+    let neurons = (1..=100)
         .map(|id| {
-            (
+            make_neuron(
                 id,
-                NeuronProto::from(make_neuron(
-                    id,
-                    PrincipalId::new_user_test_id(id),
-                    1_000_000_000,
-                    hashmap! {}, // get the default followees
-                )),
+                PrincipalId::new_user_test_id(id),
+                1_000_000_000,
+                hashmap! {}, // get the default followees
             )
         })
-        .collect::<BTreeMap<u64, NeuronProto>>();
+        .collect::<Vec<_>>();
 
     let ballots = neurons
         .iter()
         .map(|n| {
             (
-                *n.0,
-                Ballot {
+                n.id().id,
+                api::Ballot {
                     vote: Vote::Yes.into(),
-                    voting_power: n.1.cached_neuron_stake_e8s,
+                    voting_power: n.cached_neuron_stake_e8s,
                 },
             )
         })
         .collect();
-    let governance_proto = GovernanceProto {
+    let governance_api = api::Governance {
         genesis_timestamp_seconds: now_seconds - REWARD_DISTRIBUTION_PERIOD_SECONDS * 101,
-        latest_reward_event: Some(RewardEvent {
+        latest_reward_event: Some(api::RewardEvent {
             day_after_genesis: 100,
             actual_timestamp_seconds: now_seconds - REWARD_DISTRIBUTION_PERIOD_SECONDS - 1,
             settled_proposals: vec![],
@@ -533,70 +522,66 @@ fn distribute_rewards_with_stable_neurons() -> BenchResult {
             latest_round_available_e8s_equivalent: None,
             rounds_since_last_distribution: Some(0),
         }),
-        neurons,
         proposals: btreemap! {
-            1 => ProposalData {
+            1 => api::ProposalData {
                 id: Some(ProposalId { id: 1 }),
-                wait_for_quiet_state: Some(WaitForQuietState {current_deadline_timestamp_seconds: now_seconds - 200}),
+                wait_for_quiet_state: Some(api::WaitForQuietState {current_deadline_timestamp_seconds: now_seconds - 200}),
                 decided_timestamp_seconds: now_seconds - 100,
                 executed_timestamp_seconds: now_seconds - 100,
                 ballots,
-                proposal: Some(Proposal {
+                proposal: Some(api::Proposal {
                     summary: "Summary".to_string(),
                     url: "".to_string(),
                     title: Some("Title".to_string()),
-                    action: Some(Action::Motion(Motion {
+                    action: Some(api::proposal::Action::Motion(api::Motion {
                         motion_text: "Motion".to_string(),
                     })),
                 }),
                 ..Default::default()
             }
         },
-        ..GovernanceProto::default()
+        ..Default::default()
     };
 
     let mut governance = Governance::new(
-        governance_proto,
+        governance_api,
         Arc::new(MockEnvironment::new(vec![], now_seconds)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
+    for neuron in neurons {
+        governance
+            .add_neuron(neuron.id().id, neuron, false)
+            .unwrap();
+    }
+
     bench_fn(|| governance.distribute_rewards(Tokens::new(10_000_000, 0).unwrap()))
 }
 
 #[bench(raw)]
 fn list_neurons_stable() -> BenchResult {
-    let neurons = (0..100)
-        .map(|id| {
-            (id, {
-                let mut neuron = NeuronProto::from(make_neuron(
-                    id,
-                    PrincipalId::new_user_test_id(id),
-                    1_000_000_000,
-                    hashmap! {}, // get the default followees
-                ));
-                neuron.hot_keys = vec![PrincipalId::new_user_test_id(1)];
-                neuron
-            })
-        })
-        .collect::<BTreeMap<u64, NeuronProto>>();
-
-    let governance_proto = GovernanceProto {
-        neurons,
-        ..GovernanceProto::default()
-    };
-
-    let governance = Governance::new(
-        governance_proto,
+    let mut governance = Governance::new(
+        Default::default(),
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
-    let request = ListNeurons {
+    for id in 1..=100 {
+        let mut neuron = make_neuron(
+            id,
+            PrincipalId::new_user_test_id(id),
+            1_000_000_000,
+            hashmap! {}, // get the default followees
+        );
+        neuron.hot_keys = vec![PrincipalId::new_user_test_id(1)];
+        governance.add_neuron(id, neuron, false).unwrap();
+    }
+
+    let request = api::ListNeurons {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: true,
         include_empty_neurons_readable_by_caller: Some(false),
@@ -614,43 +599,41 @@ fn list_neurons_stable() -> BenchResult {
 #[bench(raw)]
 fn list_neurons_by_subaccount_stable() -> BenchResult {
     let num_neurons = 100;
-    let neurons = (0..num_neurons)
+    let neurons = (1..=num_neurons)
         .map(|id| {
-            (id, {
-                let mut neuron: NeuronProto = make_neuron(
-                    id,
-                    PrincipalId::new_user_test_id(id),
-                    1_000_000_000,
-                    hashmap! {}, // get the default followees
-                )
-                .into();
-                neuron.hot_keys = vec![PrincipalId::new_user_test_id(1)];
-                neuron
-            })
+            let mut neuron = make_neuron(
+                id,
+                PrincipalId::new_user_test_id(id),
+                1_000_000_000,
+                hashmap! {}, // get the default followees
+            );
+            neuron.hot_keys = vec![PrincipalId::new_user_test_id(1)];
+            neuron
         })
-        .collect::<BTreeMap<u64, NeuronProto>>();
+        .collect::<Vec<_>>();
 
     let subaccounts = neurons
-        .values()
-        .map(|neuron| NeuronSubaccount {
-            subaccount: neuron.account.clone(),
+        .iter()
+        .map(|neuron| api::list_neurons::NeuronSubaccount {
+            subaccount: neuron.subaccount().to_vec(),
         })
         .collect();
 
-    let governance_proto = GovernanceProto {
-        neurons,
-        ..GovernanceProto::default()
-    };
-
-    let governance = Governance::new(
-        governance_proto,
+    let mut governance = Governance::new(
+        Default::default(),
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
-    let request = ListNeurons {
+    for neuron in neurons {
+        governance
+            .add_neuron(neuron.id().id, neuron, false)
+            .unwrap();
+    }
+
+    let request = api::ListNeurons {
         neuron_ids: vec![],
         include_neurons_readable_by_caller: false,
         include_empty_neurons_readable_by_caller: Some(false),
@@ -679,33 +662,31 @@ fn create_service_nervous_system_action_with_large_payload() -> CreateServiceNer
 }
 
 fn list_proposals_benchmark() -> BenchResult {
-    let neurons = (1..=100)
-        .map(|id| {
-            (
-                id,
-                NeuronProto::from(make_neuron(
-                    id,
-                    PrincipalId::new_user_test_id(id),
-                    1_000_000_000,
-                    hashmap! {}, // get the default followees
-                )),
-            )
-        })
-        .collect::<BTreeMap<u64, NeuronProto>>();
-
-    let governance_proto = GovernanceProto {
-        neurons,
-        economics: Some(NetworkEconomics::with_default_values()),
-        ..Default::default()
-    };
-
     let mut governance = Governance::new(
-        governance_proto,
+        api::Governance {
+            economics: Some(api::NetworkEconomics::with_default_values()),
+            ..Default::default()
+        },
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
+
+    for id in 1..=100 {
+        governance
+            .add_neuron(
+                id,
+                make_neuron(
+                    id,
+                    PrincipalId::new_user_test_id(id),
+                    1_000_000_000,
+                    hashmap! {}, // get the default followees
+                ),
+                false,
+            )
+            .unwrap();
+    }
 
     let request = ListProposalInfo {
         limit: 100,

--- a/rs/nns/governance/src/governance/disburse_maturity_tests.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::{
     governance::Environment,
     neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
-    pb::v1::{Governance as GovernanceProto, Subaccount},
+    pb::v1::Subaccount,
     temporarily_enable_disburse_maturity,
     test_utils::{MockEnvironment, MockRandomness},
 };
@@ -11,6 +11,7 @@ use crate::{
 use futures::FutureExt;
 use ic_nervous_system_canisters::{cmc::MockCMC, ledger::MockIcpLedger};
 use ic_nervous_system_common::NervousSystemError;
+use ic_nns_governance_api::Governance as GovernanceApi;
 use ic_stable_structures::{storable::Bound, Storable};
 use icp_ledger::AccountIdentifier;
 use mockall::Sequence;
@@ -520,7 +521,7 @@ fn set_governance_for_test(
     maturity_modulation: i32,
 ) {
     let mut governance = Governance::new(
-        GovernanceProto {
+        GovernanceApi {
             cached_daily_maturity_modulation_basis_points: Some(maturity_modulation),
             ..Default::default()
         },

--- a/rs/nns/governance/src/governance/tests/list_neurons.rs
+++ b/rs/nns/governance/src/governance/tests/list_neurons.rs
@@ -1,12 +1,14 @@
+use crate::neuron::{DissolveStateAndAge, NeuronBuilder};
 use crate::test_utils::MockRandomness;
 use crate::{
     governance::Governance,
-    pb::v1::{neuron::DissolveState, NetworkEconomics, Neuron},
     test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
 };
 use ic_base_types::PrincipalId;
-use ic_nns_common::pb::v1::NeuronId;
-use ic_nns_governance_api::{list_neurons::NeuronSubaccount, ListNeurons};
+use ic_nns_governance_api::{
+    list_neurons::NeuronSubaccount, Governance as ApiGovernance, ListNeurons, NetworkEconomics,
+};
+use icp_ledger::Subaccount;
 use std::sync::Arc;
 
 #[test]
@@ -15,36 +17,37 @@ fn test_list_neurons_with_paging() {
 
     let neurons = (1..1000u64)
         .map(|id| {
-            let dissolve_state = DissolveState::DissolveDelaySeconds(100);
-            let account = crate::test_utils::test_subaccount_for_neuron_id(id);
-            (
+            NeuronBuilder::new_for_test(
                 id,
-                Neuron {
-                    id: Some(NeuronId::from_u64(id)),
-                    controller: Some(user_id),
-                    account,
-                    dissolve_state: Some(dissolve_state),
-                    // Fill in the rest as needed (stake, maturity, etc.)
-                    ..Default::default()
+                DissolveStateAndAge::NotDissolving {
+                    dissolve_delay_seconds: 100,
+                    aging_since_timestamp_seconds: 0,
                 },
             )
+            .with_controller(user_id)
+            .build()
         })
-        .collect();
+        .collect::<Vec<_>>();
 
-    let governance = Governance::new(
-        crate::pb::v1::Governance {
-            neurons,
+    let mut governance = Governance::new(
+        ApiGovernance {
             economics: Some(NetworkEconomics {
                 voting_power_economics: Some(Default::default()),
                 ..Default::default()
             }),
-            ..crate::pb::v1::Governance::default()
+            ..Default::default()
         },
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
+
+    for neuron in neurons {
+        governance
+            .add_neuron(neuron.id().id, neuron, false)
+            .unwrap();
+    }
 
     let mut request = ListNeurons {
         neuron_ids: vec![],
@@ -104,36 +107,43 @@ fn test_list_neurons_by_subaccounts_and_ids() {
 
     let neurons = (1..1000u64)
         .map(|id| {
-            let dissolve_state = DissolveState::DissolveDelaySeconds(100);
-            let account = crate::test_utils::test_subaccount_for_neuron_id(id);
-            (
+            NeuronBuilder::new_for_test(
                 id,
-                Neuron {
-                    id: Some(NeuronId::from_u64(id)),
-                    controller: Some(user_id),
-                    account,
-                    dissolve_state: Some(dissolve_state),
-                    // Fill in the rest as needed (stake, maturity, etc.)
-                    ..Default::default()
+                DissolveStateAndAge::NotDissolving {
+                    dissolve_delay_seconds: 100,
+                    aging_since_timestamp_seconds: 0,
                 },
             )
+            .with_subaccount(
+                Subaccount::try_from(
+                    crate::test_utils::test_subaccount_for_neuron_id(id).as_slice(),
+                )
+                .unwrap(),
+            )
+            .with_controller(user_id)
+            .build()
         })
-        .collect();
+        .collect::<Vec<_>>();
 
-    let governance = Governance::new(
-        crate::pb::v1::Governance {
-            neurons,
+    let mut governance = Governance::new(
+        ApiGovernance {
             economics: Some(NetworkEconomics {
                 voting_power_economics: Some(Default::default()),
                 ..Default::default()
             }),
-            ..crate::pb::v1::Governance::default()
+            ..Default::default()
         },
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
+
+    for neuron in neurons {
+        governance
+            .add_neuron(neuron.id().id, neuron, false)
+            .unwrap();
+    }
 
     let request = ListNeurons {
         neuron_ids: (1..501).collect(),

--- a/rs/nns/governance/src/governance/tests/list_proposals.rs
+++ b/rs/nns/governance/src/governance/tests/list_proposals.rs
@@ -8,9 +8,8 @@ use crate::{
         manage_neuron::{Command, NeuronIdOrSubaccount, RegisterVote},
         neuron::Followees,
         proposal::Action,
-        ExecuteNnsFunction, Governance as GovernanceProto, ListProposalInfo, ManageNeuron, Motion,
-        NetworkEconomics, NnsFunction, Proposal, ProposalRewardStatus, ProposalStatus, Topic,
-        WaitForQuietState,
+        ExecuteNnsFunction, ListProposalInfo, ManageNeuron, Motion, NetworkEconomics, NnsFunction,
+        Proposal, ProposalRewardStatus, ProposalStatus, Topic, WaitForQuietState,
     },
     test_utils::{MockEnvironment, MockRandomness, StubCMC, StubIcpLedger},
 };
@@ -21,7 +20,8 @@ use futures::FutureExt;
 use ic_nervous_system_common::{E8, ONE_YEAR_SECONDS};
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_governance_api::{
-    proposal::Action as ApiAction, ListProposalInfoResponse, ProposalInfo, Vote,
+    proposal::Action as ApiAction, Governance as ApiGovernance, ListProposalInfoResponse,
+    NetworkEconomics as ApiNetworkEconomics, ProposalInfo, Vote,
 };
 use ic_types::PrincipalId;
 use lazy_static::lazy_static;
@@ -37,8 +37,8 @@ lazy_static! {
 
 fn new_governance() -> Governance {
     Governance::new(
-        GovernanceProto {
-            economics: Some(NetworkEconomics::with_default_values()),
+        ApiGovernance {
+            economics: Some(ApiNetworkEconomics::with_default_values()),
             wait_for_quiet_threshold_seconds: *PROPOSAL_VOTING_PERIOD_SECONDS,
             ..Default::default()
         },

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::test_utils::MockRandomness;
 use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
-    pb::v1::{neuron::DissolveState, Neuron as NeuronProto},
     test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
 };
 use ic_base_types::PrincipalId;
@@ -18,7 +17,7 @@ use ic_sns_init::pb::v1::SnsInitPayload;
 #[cfg(feature = "test")]
 use ic_sns_init::pb::v1::{self as sns_init_pb};
 use lazy_static::lazy_static;
-use maplit::{btreemap, hashmap};
+use maplit::hashmap;
 use std::{convert::TryFrom, time::Duration};
 
 mod list_neurons;
@@ -837,21 +836,26 @@ mod convert_create_service_nervous_system_proposal_to_sns_init_payload_tests_wit
 
 mod metrics_tests {
     use ic_nns_common::pb::v1::ProposalId;
-    use maplit::btreemap;
     use std::sync::Arc;
 
     use crate::test_utils::MockRandomness;
     use crate::{
         encode_metrics,
         governance::Governance,
-        pb::v1::{
-            proposal, Governance as GovernanceProto, Motion, Proposal, ProposalData, Tally, Topic,
-        },
+        pb::v1::{proposal, Motion, Proposal, ProposalData, Tally, Topic},
         test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
     };
 
     #[test]
     fn test_metrics_total_voting_power() {
+        let mut governance = Governance::new(
+            Default::default(),
+            Arc::new(MockEnvironment::new(Default::default(), 0)),
+            Arc::new(StubIcpLedger {}),
+            Arc::new(StubCMC {}),
+            Box::new(MockRandomness::new()),
+        );
+
         let proposal_1 = ProposalData {
             id: Some(ProposalId { id: 1 }),
             proposal: Some(Proposal {
@@ -859,7 +863,7 @@ mod metrics_tests {
                 action: Some(proposal::Action::Motion(Motion {
                     motion_text: "Text for this motion".to_string(),
                 })),
-                ..Proposal::default()
+                ..Default::default()
             }),
             latest_tally: Some(Tally {
                 timestamp_seconds: 0,
@@ -868,7 +872,7 @@ mod metrics_tests {
                 total: 555,
             }),
             topic: Some(Topic::Governance as i32),
-            ..ProposalData::default()
+            ..Default::default()
         };
 
         let proposal_2 = ProposalData {
@@ -877,7 +881,7 @@ mod metrics_tests {
                 title: Some("Foo Foo Bar".to_string()),
                 action: Some(proposal::Action::ManageNeuron(Box::default())),
 
-                ..Proposal::default()
+                ..Default::default()
             }),
             latest_tally: Some(Tally {
                 timestamp_seconds: 0,
@@ -886,21 +890,11 @@ mod metrics_tests {
                 total: 1,
             }),
             topic: Some(Topic::NeuronManagement as i32),
-            ..ProposalData::default()
+            ..Default::default()
         };
-        let governance = Governance::new(
-            GovernanceProto {
-                proposals: btreemap! {
-                    1 =>  proposal_1,
-                    2 => proposal_2
-                },
-                ..GovernanceProto::default()
-            },
-            Arc::new(MockEnvironment::new(Default::default(), 0)),
-            Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
-            Box::new(MockRandomness::new()),
-        );
+
+        governance.heap_data.proposals.insert(1, proposal_1);
+        governance.heap_data.proposals.insert(2, proposal_2);
 
         let mut writer = ic_metrics_encoder::MetricsEncoder::new(vec![], 1000);
 
@@ -916,6 +910,14 @@ mod metrics_tests {
 
     #[test]
     fn test_metrics_proposal_deadline_timestamp_seconds() {
+        let mut governance = Governance::new(
+            Default::default(),
+            Arc::<MockEnvironment>::default(),
+            Arc::new(StubIcpLedger {}),
+            Arc::new(StubCMC {}),
+            Box::new(MockRandomness::new()),
+        );
+
         let manage_neuron_action = proposal::Action::ManageNeuron(Box::default());
         let motion_action = proposal::Action::Motion(Motion {
             motion_text: "Text for this motion".to_string(),
@@ -955,20 +957,15 @@ mod metrics_tests {
             ..ProposalData::default()
         };
 
-        let governance = Governance::new(
-            GovernanceProto {
-                proposals: btreemap! {
-                    1 =>  open_proposal.clone(),
-                    2 =>  rejected_proposal,
-                    3 =>  motion_proposal.clone(),
-                },
-                ..GovernanceProto::default()
-            },
-            Arc::<MockEnvironment>::default(),
-            Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
-            Box::new(MockRandomness::new()),
-        );
+        governance
+            .heap_data
+            .proposals
+            .insert(1, open_proposal.clone());
+        governance.heap_data.proposals.insert(2, rejected_proposal);
+        governance
+            .heap_data
+            .proposals
+            .insert(3, motion_proposal.clone());
 
         let mut writer = ic_metrics_encoder::MetricsEncoder::new(vec![], 10);
 
@@ -1142,38 +1139,24 @@ mod neuron_archiving_tests {
 
 #[test]
 fn test_pre_and_post_upgrade_first_time() {
-    let neuron1 = NeuronProto {
-        id: Some(NeuronId { id: 1 }),
-        controller: Some(PrincipalId::new_user_test_id(1)),
-        followees: hashmap! {
-            2 => Followees {
-                followees: vec![NeuronId { id : 3}]
-            }
-        },
-        account: vec![0; 32],
-        dissolve_state: Some(DissolveState::DissolveDelaySeconds(42)),
-        aging_since_timestamp_seconds: 1,
-        ..Default::default()
-    };
-    let neurons = btreemap! { 1 => neuron1 };
-
-    // This simulates the state of heap on first post_upgrade.
-    let governance_proto = GovernanceProto {
-        neurons,
-        ..Default::default()
-    };
-
-    // Precondition
-    assert_eq!(governance_proto.neurons.len(), 1);
-
     // Then Governance is instantiated during upgrade with proto
     let mut governance = Governance::new(
-        governance_proto,
+        Default::default(),
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
+
+    let neuron = NeuronBuilder::new_for_test(
+        1,
+        DissolveStateAndAge::NotDissolving {
+            dissolve_delay_seconds: 42,
+            aging_since_timestamp_seconds: 0,
+        },
+    )
+    .build();
+    governance.add_neuron(1, neuron, false).unwrap();
 
     // Simulate seeding the randomness in a running governance canister.
     governance.randomness.seed_rng([12; 32]);
@@ -1199,14 +1182,10 @@ fn test_pre_and_post_upgrade_first_time() {
 
 #[test]
 fn can_spawn_neurons_only_true_when_not_spawning_and_neurons_ready_to_spawn() {
-    let proto = GovernanceProto {
-        ..Default::default()
-    };
-
     let mock_env = MockEnvironment::new(vec![], 100);
 
     let mut governance = Governance::new(
-        proto,
+        Default::default(),
         Arc::new(mock_env),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
@@ -1247,9 +1226,9 @@ fn can_spawn_neurons_only_true_when_not_spawning_and_neurons_ready_to_spawn() {
 #[test]
 fn test_validate_execute_nns_function() {
     let governance = Governance::new(
-        GovernanceProto {
-            economics: Some(NetworkEconomics::with_default_values()),
-            node_providers: vec![NodeProvider {
+        api::Governance {
+            economics: Some(api::NetworkEconomics::with_default_values()),
+            node_providers: vec![api::NodeProvider {
                 id: Some(PrincipalId::new_node_test_id(1)),
                 ..Default::default()
             }],
@@ -1551,45 +1530,41 @@ fn topic_min_max_test() {
 #[cfg(feature = "test")]
 #[test]
 fn test_update_neuron_errors_out_expectedly() {
-    fn new_neuron(account: Vec<u8>) -> api::Neuron {
-        api::Neuron {
-            account,
-            id: Some(NeuronId { id: 1 }),
-            controller: Some(PrincipalId::new_user_test_id(1)),
-            followees: hashmap! {
-                2 => api::neuron::Followees {
-                    followees: vec![NeuronId { id : 3}]
-                }
+    fn new_neuron(account: Vec<u8>) -> Neuron {
+        NeuronBuilder::new_for_test(
+            1,
+            DissolveStateAndAge::NotDissolving {
+                dissolve_delay_seconds: 42,
+                aging_since_timestamp_seconds: 1,
             },
-            aging_since_timestamp_seconds: 1,
-            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(42)),
-            ..Default::default()
-        }
+        )
+        .with_subaccount(Subaccount::try_from(account.as_slice()).unwrap())
+        .with_followees(hashmap! {
+            2 => Followees {
+                followees: vec![NeuronId { id : 3}]
+            }
+        })
+        .build()
     }
 
-    let neuron1_subaccount_blob = vec![1; 32];
-    let neuron1_subaccount = Subaccount::try_from(neuron1_subaccount_blob.as_slice()).unwrap();
-    let neuron1 = NeuronProto::from(new_neuron(neuron1_subaccount_blob.clone()));
-    let neurons = btreemap! { 1 => neuron1 };
-    let governance_proto = GovernanceProto {
-        neurons,
-        ..Default::default()
-    };
     let mut governance = Governance::new(
-        governance_proto,
+        Default::default(),
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
+    let neuron = new_neuron(vec![1; 32]);
+    let neuron_subaccount = neuron.subaccount();
+    governance.add_neuron(1, neuron, false).unwrap();
 
     assert_eq!(
-        governance.update_neuron(new_neuron(vec![0; 32])),
+        governance.update_neuron(new_neuron(vec![0; 32]).into_api(0, &Default::default())),
         Err(GovernanceError::new_with_message(
             ErrorType::PreconditionFailed,
             format!(
                 "Cannot change the subaccount {} of a neuron.",
-                neuron1_subaccount
+                neuron_subaccount
             ),
         )),
     );
@@ -1600,53 +1575,49 @@ fn test_compute_ballots_for_new_proposal() {
     const CREATED_TIMESTAMP_SECONDS: u64 = 1729791574;
     let now_seconds = CREATED_TIMESTAMP_SECONDS + 999;
 
-    fn new_neuron(i: u64) -> NeuronProto {
-        let controller = PrincipalId::new_user_test_id(i);
-        let d = i / 10_u64.pow(i.ilog10());
-
-        let neuron = NeuronBuilder::new(
-            NeuronId { id: i },
-            Subaccount::try_from([d as u8; 32].as_slice()).unwrap(),
-            controller,
+    fn new_neuron_builder(id: u64) -> NeuronBuilder {
+        NeuronBuilder::new_for_test(
+            id,
             DissolveStateAndAge::NotDissolving {
                 dissolve_delay_seconds: 12 * ONE_MONTH_SECONDS,
                 aging_since_timestamp_seconds: CREATED_TIMESTAMP_SECONDS + 42,
             },
-            CREATED_TIMESTAMP_SECONDS,
         )
-        .with_cached_neuron_stake_e8s(i * E8)
-        .build();
-
-        NeuronProto::from(neuron)
+        .with_cached_neuron_stake_e8s(id * E8)
     }
 
-    let mut neuron_10 = new_neuron(10);
-    neuron_10.followees = hashmap! {
-        Topic::NeuronManagement as i32 => Followees {
-            followees: vec![
-                NeuronId { id: 10 },
-                NeuronId { id: 201 },
-                NeuronId { id: 202 },
-                NeuronId { id: 203 },
-                NeuronId { id: 204 },
-                NeuronId { id: 205 },
-                NeuronId { id: 206 },
-            ]
-        }
-    };
-    let neurons = btreemap! {10 => neuron_10, 200 => new_neuron(200), 3_000 => new_neuron(3_000)};
-    let governance_proto = GovernanceProto {
-        neurons,
-        ..Default::default()
-    };
+    let neuron_10 = new_neuron_builder(10)
+        .with_followees(hashmap! {
+            Topic::NeuronManagement as i32 => Followees {
+                followees: vec![
+                    NeuronId { id: 10 },
+                    NeuronId { id: 201 },
+                    NeuronId { id: 202 },
+                    NeuronId { id: 203 },
+                    NeuronId { id: 204 },
+                    NeuronId { id: 205 },
+                    NeuronId { id: 206 },
+                ]
+            }
+        })
+        .build();
 
     let mut governance = Governance::new(
-        governance_proto,
+        Default::default(),
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
+
+    governance.add_neuron(10, neuron_10, false).unwrap();
+    governance
+        .add_neuron(200, new_neuron_builder(200).build(), false)
+        .unwrap();
+    governance
+        .add_neuron(3_000, new_neuron_builder(3_000).build(), false)
+        .unwrap();
+
     let manage_neuron_action = Action::ManageNeuron(Box::new(ManageNeuron {
         id: Some(NeuronId { id: 10 }),
         neuron_id_or_subaccount: None,

--- a/rs/nns/governance/src/governance/tests/neurons_fund.rs
+++ b/rs/nns/governance/src/governance/tests/neurons_fund.rs
@@ -15,17 +15,17 @@ use test_data::CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING;
 fn proposal_passes_if_not_too_many_nf_neurons_can_occur() {
     let proposal_id = ProposalId { id: 123 };
     let create_service_nervous_system = CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING.clone();
-    let mut governance_proto = GovernanceCanisterInitPayloadBuilder::new()
+    let mut governance_init = GovernanceCanisterInitPayloadBuilder::new()
         .with_test_neurons_fund_neurons(500_000 * E8)
         .build();
-    governance_proto.proposals = btreemap! {
+    governance_init.proposals = btreemap! {
         123_u64 => ProposalData {
             id: Some(proposal_id),
             ..ProposalData::default()
         }.into()
     };
     let mut governance = Governance::new(
-        governance_proto.into(),
+        governance_init,
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
@@ -61,7 +61,7 @@ fn proposal_fails_if_too_many_nf_neurons_can_occur() {
             ..create_service_nervous_system
         }
     };
-    let mut governance_proto = {
+    let mut governance_init = {
         let proto_neuron = GovernanceCanisterInitPayloadBuilder::new()
             .with_test_neurons_fund_neurons(maturity_equivalent_icp_e8s)
             .build()
@@ -85,14 +85,14 @@ fn proposal_fails_if_too_many_nf_neurons_can_occur() {
             .with_additional_neurons(neurons)
             .build()
     };
-    governance_proto.proposals = btreemap! {
+    governance_init.proposals = btreemap! {
         123_u64 => ProposalData {
             id: Some(proposal_id),
             ..ProposalData::default()
         }.into()
     };
     let mut governance = Governance::new(
-        governance_proto.into(),
+        governance_init,
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
@@ -126,15 +126,15 @@ fn proposal_fails_if_too_many_nf_neurons_can_occur() {
 fn proposal_fails_if_no_nf_neurons_exist() {
     let proposal_id = ProposalId { id: 123 };
     let create_service_nervous_system = CREATE_SERVICE_NERVOUS_SYSTEM_WITH_MATCHED_FUNDING.clone();
-    let mut governance_proto = GovernanceCanisterInitPayloadBuilder::new().build();
-    governance_proto.proposals = btreemap! {
+    let mut governance_init = GovernanceCanisterInitPayloadBuilder::new().build();
+    governance_init.proposals = btreemap! {
         123_u64 => ProposalData {
             id: Some(proposal_id),
             ..ProposalData::default()
         }.into()
     };
     let mut governance = Governance::new(
-        governance_proto.into(),
+        governance_init,
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -2,7 +2,7 @@ use crate::test_utils::MockRandomness;
 use crate::{
     governance::Governance,
     node_provider_rewards::DateRangeFilter,
-    pb::v1::{Governance as GovernanceProto, MonthlyNodeProviderRewards},
+    pb::v1::MonthlyNodeProviderRewards,
     test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
 };
 use std::sync::Arc;
@@ -29,15 +29,16 @@ fn test_node_provider_rewards_read_from_correct_sources() {
         node_providers: vec![],
     };
     let mut governance = Governance::new(
-        GovernanceProto {
-            most_recent_monthly_node_provider_rewards: Some(rewards_1.clone()),
-            ..Default::default()
-        },
+        Default::default(),
         Arc::new(MockEnvironment::new(vec![], 100)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
+
+    governance
+        .heap_data
+        .most_recent_monthly_node_provider_rewards = Some(rewards_1.clone());
 
     let result_1 = governance.get_most_recent_monthly_node_provider_rewards();
 
@@ -79,9 +80,7 @@ fn test_list_node_provider_rewards_api() {
     };
 
     let mut governance = Governance::new(
-        GovernanceProto {
-            ..Default::default()
-        },
+        Default::default(),
         Arc::new(MockEnvironment::new(vec![], 100)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
@@ -100,9 +99,7 @@ fn test_list_node_provider_rewards_api() {
 #[test]
 fn test_list_node_provider_rewards_api_with_paging_and_filters() {
     let mut governance = Governance::new(
-        GovernanceProto {
-            ..Default::default()
-        },
+        Default::default(),
         Arc::new(MockEnvironment::new(vec![], 100)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),

--- a/rs/nns/governance/src/governance/tests/stake_maturity.rs
+++ b/rs/nns/governance/src/governance/tests/stake_maturity.rs
@@ -1,43 +1,41 @@
+use crate::neuron::{DissolveStateAndAge, NeuronBuilder};
 use crate::test_utils::MockRandomness;
 use crate::{
     governance::{
         tests::{MockEnvironment, StubCMC, StubIcpLedger},
         Governance,
     },
-    pb::v1::{manage_neuron::StakeMaturity, neuron, Governance as GovernanceProto, Neuron},
+    pb::v1::manage_neuron::StakeMaturity,
 };
 use ic_base_types::PrincipalId;
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance_api::manage_neuron_response::StakeMaturityResponse;
-use maplit::btreemap;
 use std::sync::Arc;
 
 #[test]
 fn test_stake_maturity() {
-    let principal_1 = PrincipalId::new_user_test_id(1);
-    let neuron_1 = Neuron {
-        id: Some(NeuronId { id: 1 }),
-        controller: Some(principal_1),
-        cached_neuron_stake_e8s: 23,
-        account: b"a__4___8__12__16__20__24__28__32".to_vec(),
-        // One year
-        dissolve_state: Some(neuron::DissolveState::DissolveDelaySeconds(31557600)),
-        maturity_e8s_equivalent: 1000,
-        staked_maturity_e8s_equivalent: Some(100),
-        ..Default::default()
-    };
     let mut governance = Governance::new(
-        GovernanceProto {
-            neurons: btreemap! {
-                1 => neuron_1
-            },
-            ..GovernanceProto::default()
-        },
+        Default::default(),
         Arc::new(MockEnvironment::new(vec![], 0)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
+
+    let principal_1 = PrincipalId::new_user_test_id(1);
+    let neuron = NeuronBuilder::new_for_test(
+        1,
+        DissolveStateAndAge::NotDissolving {
+            dissolve_delay_seconds: 31557600,
+            aging_since_timestamp_seconds: 0,
+        },
+    )
+    .with_controller(principal_1)
+    .with_cached_neuron_stake_e8s(23)
+    .with_maturity_e8s_equivalent(1000)
+    .with_staked_maturity_e8s_equivalent(100)
+    .build();
+    governance.add_neuron(1, neuron, false).unwrap();
 
     let request = StakeMaturity {
         percentage_to_stake: Some(40),

--- a/rs/nns/governance/src/governance_proto_builder.rs
+++ b/rs/nns/governance/src/governance_proto_builder.rs
@@ -1,11 +1,10 @@
-use crate::pb::v1::{
-    Governance as GovernancePb, NetworkEconomics as NetworkEconomicsPb, Neuron as NeuronPb,
-    NeuronsFundEconomics, ProposalData as ProposalPb, RewardEvent as RewardEventPb,
-    VotingPowerEconomics,
+use ic_nns_governance_api::{
+    Governance as ApiGovernance, NetworkEconomics, Neuron, NeuronsFundEconomics, ProposalData,
+    RewardEvent, VotingPowerEconomics,
 };
 
 pub struct GovernanceProtoBuilder {
-    governance_proto: GovernancePb,
+    governance: ApiGovernance,
 }
 
 impl Default for GovernanceProtoBuilder {
@@ -17,69 +16,68 @@ impl Default for GovernanceProtoBuilder {
 impl GovernanceProtoBuilder {
     /// Minimaly valid Governance proto.
     pub fn new() -> Self {
-        let mut governance_proto = GovernancePb {
+        let mut governance = ApiGovernance {
             wait_for_quiet_threshold_seconds: 1,
             short_voting_period_seconds: 30,
             neuron_management_voting_period_seconds: Some(30),
-            economics: Some(NetworkEconomicsPb::default()),
+            economics: Some(NetworkEconomics::default()),
             ..Default::default()
         };
 
         // Make economics valid. Ideally, we'd use
         // NetworkEconomics::with_default_values(), but many tests rely on
         // NetworkEconomics::default() (not the same!).
-        let economics = governance_proto.economics.as_mut().unwrap();
+        let economics = governance.economics.as_mut().unwrap();
         economics.max_proposals_to_keep_per_topic = 100;
         economics.neurons_fund_economics = Some(NeuronsFundEconomics::with_default_values());
         economics.voting_power_economics = Some(VotingPowerEconomics::with_default_values());
 
-        Self { governance_proto }
+        Self { governance }
     }
 
     /// Ensures that proposals can be decided and neurons can be managed instantly.
     pub fn with_instant_neuron_operations(mut self) -> Self {
-        self.governance_proto.wait_for_quiet_threshold_seconds = 0;
-        self.governance_proto.short_voting_period_seconds = 0;
-        self.governance_proto
-            .neuron_management_voting_period_seconds = None;
+        self.governance.wait_for_quiet_threshold_seconds = 0;
+        self.governance.short_voting_period_seconds = 0;
+        self.governance.neuron_management_voting_period_seconds = None;
         self
     }
 
-    pub fn with_latest_reward_event(mut self, reward_event: RewardEventPb) -> Self {
-        self.governance_proto.latest_reward_event = Some(reward_event);
+    pub fn with_latest_reward_event(mut self, reward_event: RewardEvent) -> Self {
+        self.governance.latest_reward_event = Some(reward_event);
         self
     }
 
-    pub fn with_neurons(mut self, neurons: Vec<NeuronPb>) -> Self {
+    pub fn with_neurons(mut self, neurons: Vec<Neuron>) -> Self {
         let neurons = neurons
             .into_iter()
             .map(|neuron| (neuron.id.unwrap().id, neuron))
             .collect();
-        self.governance_proto.neurons = neurons;
+        self.governance.neurons = neurons;
         self
     }
 
     pub fn with_genesis_timestamp(mut self, genesis_timestamp_seconds: u64) -> Self {
-        self.governance_proto.genesis_timestamp_seconds = genesis_timestamp_seconds;
+        self.governance.genesis_timestamp_seconds = genesis_timestamp_seconds;
         self
     }
 
-    pub fn with_proposals(mut self, proposals: Vec<ProposalPb>) -> Self {
+    pub fn with_proposals(mut self, proposals: Vec<ProposalData>) -> Self {
         let proposals = proposals
             .into_iter()
             .map(|proposal| (proposal.id.unwrap().id, proposal))
             .collect();
-        self.governance_proto.proposals = proposals;
+        self.governance.proposals = proposals;
         self
     }
 
-    pub fn with_economics(mut self, network_economics: NetworkEconomicsPb) -> Self {
-        self.governance_proto.economics = Some(network_economics);
+    pub fn with_economics(mut self, network_economics: NetworkEconomics) -> Self {
+        self.governance.economics = Some(network_economics);
         self
     }
 
     pub fn with_short_voting_period(mut self, short_voting_period_seconds: u64) -> Self {
-        self.governance_proto.short_voting_period_seconds = short_voting_period_seconds;
+        self.governance.short_voting_period_seconds = short_voting_period_seconds;
         self
     }
 
@@ -87,18 +85,17 @@ impl GovernanceProtoBuilder {
         mut self,
         neuron_management_voting_period_seconds: u64,
     ) -> Self {
-        self.governance_proto
-            .neuron_management_voting_period_seconds =
+        self.governance.neuron_management_voting_period_seconds =
             Some(neuron_management_voting_period_seconds);
         self
     }
 
     pub fn with_wait_for_quiet_threshold(mut self, wait_for_quiet_threshold_seconds: u64) -> Self {
-        self.governance_proto.wait_for_quiet_threshold_seconds = wait_for_quiet_threshold_seconds;
+        self.governance.wait_for_quiet_threshold_seconds = wait_for_quiet_threshold_seconds;
         self
     }
 
-    pub fn build(self) -> GovernancePb {
-        self.governance_proto
+    pub fn build(self) -> ApiGovernance {
+        self.governance
     }
 }

--- a/rs/nns/governance/src/neuron_lock_tests.rs
+++ b/rs/nns/governance/src/neuron_lock_tests.rs
@@ -1,10 +1,7 @@
 use super::*;
 
 use crate::{
-    pb::v1::{
-        governance::neuron_in_flight_command::SyncCommand, manage_neuron::Split,
-        Governance as GovernanceProto,
-    },
+    pb::v1::{governance::neuron_in_flight_command::SyncCommand, manage_neuron::Split},
     test_utils::{MockEnvironment, MockRandomness, StubCMC, StubIcpLedger},
 };
 
@@ -16,7 +13,7 @@ thread_local! {
 
 fn new_governance_for_test() -> Governance {
     Governance::new(
-        GovernanceProto::default(),
+        Default::default(),
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
         Arc::new(StubCMC {}),

--- a/rs/nns/governance/src/reward/distribution.rs
+++ b/rs/nns/governance/src/reward/distribution.rs
@@ -232,7 +232,7 @@ mod test {
     use super::*;
     use crate::governance::Governance;
     use crate::neuron::{DissolveStateAndAge, Neuron, NeuronBuilder};
-    use crate::pb::v1::{Governance as GovernanceProto, VotingPowerEconomics};
+    use crate::pb::v1::VotingPowerEconomics;
     use crate::test_utils::{
         test_subaccount_for_neuron_id, MockEnvironment, MockRandomness, StubCMC, StubIcpLedger,
     };
@@ -396,32 +396,24 @@ mod test {
     fn test_distribute_pending_rewards() {
         // We are testing recoverability of the system (i.e. it got stalled, but we didnt' lose data, and now
         // it is able to finish processing)
-
-        let mut neurons = BTreeMap::new();
-        for i in 0..5 {
-            neurons.insert(i, make_neuron(i, 1000, 1000));
-        }
-        for i in 5..10 {
-            let mut neuron = make_neuron(i, 1000, 1000);
-            neuron.auto_stake_maturity = Some(true);
-            neurons.insert(i, neuron);
-        }
-
-        let governance_proto = GovernanceProto {
-            neurons: neurons
-                .into_iter()
-                .map(|(id, neuron)| (id, crate::pb::v1::Neuron::from(neuron)))
-                .collect(),
-            ..Default::default()
-        };
-
-        let governance = Governance::new(
-            governance_proto,
+        let mut governance = Governance::new(
+            Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 0)),
             Arc::new(StubIcpLedger {}),
             Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
+
+        for i in 1..=5 {
+            governance
+                .add_neuron(i, make_neuron(i, 1000, 1000), false)
+                .unwrap();
+        }
+        for i in 6..=10 {
+            let mut neuron = make_neuron(i, 1000, 1000);
+            neuron.auto_stake_maturity = Some(true);
+            governance.add_neuron(i, neuron, false).unwrap();
+        }
 
         let mut distribution = RewardsDistribution::new();
         for id in 0..10 {

--- a/rs/nns/governance/src/seed_accounts/seed_accounts_tests.rs
+++ b/rs/nns/governance/src/seed_accounts/seed_accounts_tests.rs
@@ -2,7 +2,7 @@ use crate::{
     governance::{Governance, MockEnvironment, ONE_MONTH_SECONDS},
     pb::v1::{
         governance::{seed_accounts::SeedAccount, SeedAccounts},
-        Governance as GovernanceProto, Neuron, NeuronType,
+        Governance as GovernanceProto, NeuronType,
     },
     seed_accounts::{AccountState, SEED_NEURON_DISTRIBUTION_COUNT},
 };
@@ -10,6 +10,7 @@ use candid::Encode;
 use ic_base_types::PrincipalId;
 use ic_nervous_system_common::{cmc::MockCMC, ledger::MockIcpLedger, E8};
 use ic_nns_common::pb::v1::NeuronId;
+use ic_nns_governance_api as api;
 use icp_ledger::Subaccount;
 use maplit::btreemap;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -30,21 +31,22 @@ fn now_seconds() -> u64 {
 }
 
 fn neuron(id: u64, controller: PrincipalId, cached_neuron_stake_e8s: u64) -> Neuron {
-    Neuron {
-        id: Some(NeuronId { id }),
-        neuron_type: None,
-        controller: Some(controller),
-        cached_neuron_stake_e8s,
-        account: Subaccount::from(&controller).to_vec(),
-        ..Default::default()
-    }
+    NeuronBuilder::new_for_test(
+        id,
+        DissolveStateAndAge::DissolvingOrDissolved {
+            when_dissolved_timestamp_seconds: 0,
+        },
+    )
+    .with_controller(controller)
+    .with_cached_neuron_stake_e8s(cached_neuron_stake_e8s)
+    .build()
 }
 
 #[test]
 fn test_can_tag_seed_neurons_handles_corrupted_state() {
     // Setup
     let mut governance = Governance::new(
-        GovernanceProto::default(),
+        Default::default(),
         Arc::new(create_mock_environment(None)),
         Arc::<MockIcpLedger>::default(),
         Arc::<MockCMC>::default(),
@@ -107,7 +109,7 @@ fn test_can_tag_seed_neurons_transitions() {
 
     // Setup
     let mut governance = Governance::new(
-        GovernanceProto::default(),
+        Default::default(),
         Arc::new(create_mock_environment(None)),
         Arc::<MockIcpLedger>::default(),
         Arc::<MockCMC>::default(),
@@ -138,7 +140,7 @@ fn test_can_tag_seed_neurons_transitions() {
 fn test_can_tag_seed_neurons_exits_early_if_data_is_processed() {
     // Setup
     let mut governance = Governance::new(
-        GovernanceProto::default(),
+        Default::default(),
         Arc::new(create_mock_environment(None)),
         Arc::<MockIcpLedger>::default(),
         Arc::<MockCMC>::default(),
@@ -189,12 +191,7 @@ async fn test_tag_seed_neurons_happy() {
         .unwrap()));
 
     let mut governance = Governance::new(
-        GovernanceProto {
-            neurons: btreemap! {
-                1 =>  neuron(1, seed_neuron_controller, 10 * E8),
-                2 =>  neuron(2, seed_neuron_controller, E8),
-                3 =>  neuron(3, non_seed_neuron_controller, E8),
-            },
+        api::Governance {
             genesis_timestamp_seconds: now_timestamp_seconds - ONE_MONTH_SECONDS,
             ..Default::default()
         },
@@ -203,6 +200,16 @@ async fn test_tag_seed_neurons_happy() {
         Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
+
+    governance
+        .add_neuron(1, neuron(1, seed_neuron_controller, 10 * E8), false)
+        .unwrap();
+    governance
+        .add_neuron(2, neuron(2, seed_neuron_controller, E8), false)
+        .unwrap();
+    governance
+        .add_neuron(3, neuron(3, non_seed_neuron_controller, E8), false)
+        .unwrap();
 
     let expected_seed_account = SeedAccount {
         account_id: account_id.clone(),
@@ -276,12 +283,7 @@ async fn test_tag_neuron_sad() {
         .return_const(Err((Some(1), "Error from the replica".to_string())));
 
     let mut governance = Governance::new(
-        GovernanceProto {
-            neurons: btreemap! {
-                1 =>  neuron(1, seed_neuron_controller, 10 * E8),
-                2 =>  neuron(2, seed_neuron_controller, E8),
-                3 =>  neuron(3, non_seed_neuron_controller, E8),
-            },
+        api::Governance {
             genesis_timestamp_seconds: now_timestamp_seconds - ONE_MONTH_SECONDS,
             ..Default::default()
         },
@@ -290,6 +292,16 @@ async fn test_tag_neuron_sad() {
         Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
+
+    governance
+        .add_neuron(1, neuron(1, seed_neuron_controller, 10 * E8), false)
+        .unwrap();
+    governance
+        .add_neuron(2, neuron(2, seed_neuron_controller, E8), false)
+        .unwrap();
+    governance
+        .add_neuron(3, neuron(3, non_seed_neuron_controller, E8), false)
+        .unwrap();
 
     let expected_seed_account = SeedAccount {
         account_id: account_id.clone(),
@@ -369,11 +381,7 @@ async fn test_tag_seed_neurons_handles_neuron_splits() {
         .unwrap()));
 
     let mut governance = Governance::new(
-        GovernanceProto {
-            neurons: btreemap! {
-                1 =>  neuron(1, split_seed_neuron_controller, 10 * E8),
-                2 =>  neuron(2, split_seed_neuron_controller, E8),
-            },
+        api::Governance {
             // This indicates that no stake should have been vested and all
             // funds should be in the neurons
             genesis_timestamp_seconds: now_timestamp_seconds,
@@ -384,6 +392,13 @@ async fn test_tag_seed_neurons_handles_neuron_splits() {
         Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
+
+    governance
+        .add_neuron(1, neuron(1, split_seed_neuron_controller, 10 * E8), false)
+        .unwrap();
+    governance
+        .add_neuron(2, neuron(2, split_seed_neuron_controller, E8), false)
+        .unwrap();
 
     // Execute
 
@@ -437,11 +452,7 @@ async fn test_tag_seed_neurons_doesnt_over_tag_seed_neurons() {
         .unwrap()));
 
     let mut governance = Governance::new(
-        GovernanceProto {
-            neurons: btreemap! {
-                1 =>  neuron(1, split_seed_neuron_controller, 10 * E8),
-                2 =>  neuron(2, split_seed_neuron_controller, E8),
-            },
+        api::Governance {
             genesis_timestamp_seconds,
             ..Default::default()
         },
@@ -450,6 +461,12 @@ async fn test_tag_seed_neurons_doesnt_over_tag_seed_neurons() {
         Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
+    governance
+        .add_neuron(1, neuron(1, split_seed_neuron_controller, 10 * E8), false)
+        .unwrap();
+    governance
+        .add_neuron(2, neuron(2, split_seed_neuron_controller, E8), false)
+        .unwrap();
 
     // Execute
 
@@ -487,7 +504,7 @@ fn test_calculate_genesis_account_expected_stake_e8s() {
     let genesis_timestamp_seconds = 1;
 
     let governance = Governance::new(
-        GovernanceProto {
+        api::Governance {
             genesis_timestamp_seconds,
             ..Default::default()
         },

--- a/rs/nns/governance/src/timer_tasks/calculate_distributable_rewards.rs
+++ b/rs/nns/governance/src/timer_tasks/calculate_distributable_rewards.rs
@@ -86,6 +86,7 @@ mod tests {
     use crate::canister_state::{set_governance_for_tests, CanisterRandomnessGenerator};
     use crate::governance::Governance;
     use crate::test_utils::{MockEnvironment, StubCMC, StubIcpLedger};
+    use ic_nns_governance_api as api;
     use std::sync::Arc;
 
     fn test_delay_until_next_run(
@@ -164,17 +165,15 @@ mod tests {
         let genesis_timestamp_seconds = 10_000;
         let latest_reward_day_after_genesis = 5;
 
-        let governance_proto = crate::pb::v1::Governance {
-            genesis_timestamp_seconds,
-            latest_reward_event: Some(crate::pb::v1::RewardEvent {
-                day_after_genesis: latest_reward_day_after_genesis,
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
         let gov = Governance::new(
-            governance_proto,
+            api::Governance {
+                genesis_timestamp_seconds,
+                latest_reward_event: Some(api::RewardEvent {
+                    day_after_genesis: latest_reward_day_after_genesis,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
             Arc::new(MockEnvironment::new(vec![], now)),
             Arc::new(StubIcpLedger {}),
             Arc::new(StubCMC {}),

--- a/rs/nns/governance/src/timer_tasks/distribute_rewards.rs
+++ b/rs/nns/governance/src/timer_tasks/distribute_rewards.rs
@@ -73,10 +73,9 @@ mod tests {
         thread_local! {
             static METRICS_REGISTRY: RefCell<TimerTaskMetricsRegistry> = RefCell::new(TimerTaskMetricsRegistry::default());
         }
-        let governance_proto = crate::pb::v1::Governance::default();
 
         let governance = Governance::new(
-            governance_proto,
+            Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 0)),
             Arc::new(StubIcpLedger {}),
             Arc::new(StubCMC {}),

--- a/rs/nns/governance/src/timer_tasks/snapshot_voting_power.rs
+++ b/rs/nns/governance/src/timer_tasks/snapshot_voting_power.rs
@@ -92,9 +92,10 @@ mod tests {
     use icp_ledger::Subaccount;
     use std::sync::Arc;
 
+    use ic_nns_governance_api as api;
+
     use crate::{
         neuron::{DissolveStateAndAge, NeuronBuilder},
-        pb::v1::{Governance as GovernanceProto, NetworkEconomics, VotingPowerEconomics},
         test_utils::{MockEnvironment, MockRandomness, StubCMC, StubIcpLedger},
     };
 
@@ -117,9 +118,9 @@ mod tests {
 
     fn new_governance_for_test() -> Governance {
         let mut governance = Governance::new(
-            GovernanceProto {
-                economics: Some(NetworkEconomics {
-                    voting_power_economics: Some(VotingPowerEconomics::DEFAULT),
+            api::Governance {
+                economics: Some(api::NetworkEconomics {
+                    voting_power_economics: Some(api::VotingPowerEconomics::DEFAULT),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -130,7 +131,7 @@ mod tests {
             Box::new(MockRandomness::new()),
         );
         let dissolve_delay_seconds =
-            VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS;
+            api::VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS;
         governance
             .neuron_store
             .add_neuron(

--- a/rs/nns/governance/src/voting.rs
+++ b/rs/nns/governance/src/voting.rs
@@ -594,9 +594,8 @@ mod test {
         neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
         neuron_store::NeuronStore,
         pb::v1::{
-            self as pb, neuron::Followees, proposal::Action, Ballot, Governance as GovernanceProto,
-            Motion, Proposal, ProposalData, Tally, Topic, Vote, VotingPowerEconomics,
-            WaitForQuietState,
+            neuron::Followees, proposal::Action, Ballot, Motion, Proposal, ProposalData, Tally,
+            Topic, Vote, VotingPowerEconomics, WaitForQuietState,
         },
         storage::with_voting_state_machines_mut,
         test_utils::{
@@ -615,9 +614,10 @@ mod test {
     use ic_nervous_system_timers::test::run_pending_timers_every_interval_for_count;
     use ic_nns_common::pb::v1::{NeuronId, ProposalId};
     use ic_nns_constants::GOVERNANCE_CANISTER_ID;
+    use ic_nns_governance_api::Governance as ApiGovernance;
     use ic_stable_structures::DefaultMemoryImpl;
     use icp_ledger::Subaccount;
-    use maplit::{btreemap, hashmap};
+    use maplit::hashmap;
     use std::collections::{BTreeMap, BTreeSet, HashMap};
     use std::sync::Arc;
 
@@ -665,6 +665,13 @@ mod test {
     fn test_cast_vote_and_cascade_doesnt_cascade_neuron_management() {
         let now = 1000;
         let topic = Topic::NeuronManagement;
+        let mut governance = Governance::new(
+            Default::default(),
+            Arc::new(MockEnvironment::new(Default::default(), 0)),
+            Arc::new(StubIcpLedger {}),
+            Arc::new(StubCMC {}),
+            Box::new(MockRandomness::new()),
+        );
 
         let make_neuron = |id: u64, followees: Vec<u64>| {
             make_neuron(
@@ -676,7 +683,7 @@ mod test {
             )
         };
 
-        let add_neuron_with_ballot = |neuron_map: &mut BTreeMap<u64, Neuron>,
+        let add_neuron_with_ballot = |neuron_store: &mut NeuronStore,
                                       ballots: &mut HashMap<u64, Ballot>,
                                       id: u64,
                                       followees: Vec<u64>,
@@ -684,51 +691,45 @@ mod test {
             let neuron = make_neuron(id, followees);
             let deciding_voting_power =
                 neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now);
-            neuron_map.insert(id, neuron);
+            neuron_store.add_neuron(neuron).unwrap();
             ballots.insert(id, make_ballot(deciding_voting_power, vote));
         };
 
         let add_neuron_without_ballot =
-            |neuron_map: &mut BTreeMap<u64, Neuron>, id: u64, followees: Vec<u64>| {
+            |neuron_store: &mut NeuronStore, id: u64, followees: Vec<u64>| {
                 let neuron = make_neuron(id, followees);
-                neuron_map.insert(id, neuron);
+                neuron_store.add_neuron(neuron).unwrap();
             };
 
-        let mut neurons = BTreeMap::new();
-        let mut ballots = HashMap::new();
+        let mut proposal = ProposalData {
+            id: Some(ProposalId { id: 1 }),
+            ..Default::default()
+        };
         for id in 1..=5 {
             // Each neuron follows all neurons with a lower id
             let followees = (1..id).collect();
 
-            add_neuron_with_ballot(&mut neurons, &mut ballots, id, followees, Vote::Unspecified);
+            add_neuron_with_ballot(
+                &mut governance.neuron_store,
+                &mut proposal.ballots,
+                id,
+                followees,
+                Vote::Unspecified,
+            );
         }
         // Add another neuron that follows both a neuron with a ballot and without a ballot
-        add_neuron_with_ballot(&mut neurons, &mut ballots, 6, vec![1, 7], Vote::Unspecified);
+        add_neuron_with_ballot(
+            &mut governance.neuron_store,
+            &mut proposal.ballots,
+            6,
+            vec![1, 7],
+            Vote::Unspecified,
+        );
 
         // Add a neuron without a ballot for neuron 6 to follow.
-        add_neuron_without_ballot(&mut neurons, 7, vec![1]);
+        add_neuron_without_ballot(&mut governance.neuron_store, 7, vec![1]);
 
-        let governance_proto = crate::pb::v1::Governance {
-            neurons: neurons
-                .into_iter()
-                .map(|(id, neuron)| (id, pb::Neuron::from(neuron)))
-                .collect(),
-            proposals: btreemap! {
-                1 => ProposalData {
-                    id: Some(ProposalId {id: 1}),
-                    ballots,
-                    ..Default::default()
-                }
-            },
-            ..Default::default()
-        };
-        let mut governance = Governance::new(
-            governance_proto,
-            Arc::new(MockEnvironment::new(Default::default(), 0)),
-            Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
-            Box::new(MockRandomness::new()),
-        );
+        governance.heap_data.proposals.insert(1, proposal);
 
         governance
             .cast_vote_and_cascade_follow(
@@ -776,7 +777,7 @@ mod test {
             )
         };
 
-        let add_neuron_with_ballot = |neuron_map: &mut BTreeMap<u64, Neuron>,
+        let add_neuron_with_ballot = |neuron_store: &mut NeuronStore,
                                       ballots: &mut HashMap<u64, Ballot>,
                                       id: u64,
                                       followees: Vec<u64>,
@@ -784,51 +785,54 @@ mod test {
             let neuron = make_neuron(id, followees);
             let deciding_voting_power =
                 neuron.deciding_voting_power(&VotingPowerEconomics::DEFAULT, now);
-            neuron_map.insert(id, neuron);
+            neuron_store.add_neuron(neuron).unwrap();
             ballots.insert(id, make_ballot(deciding_voting_power, vote));
         };
 
         let add_neuron_without_ballot =
-            |neuron_map: &mut BTreeMap<u64, Neuron>, id: u64, followees: Vec<u64>| {
+            |neuron_store: &mut NeuronStore, id: u64, followees: Vec<u64>| {
                 let neuron = make_neuron(id, followees);
-                neuron_map.insert(id, neuron);
+                neuron_store.add_neuron(neuron).unwrap();
             };
 
-        let mut neurons = BTreeMap::new();
-        let mut ballots = HashMap::new();
-        for id in 1..=5 {
-            // Each neuron follows all neurons with a lower id
-            let followees = (1..id).collect();
-
-            add_neuron_with_ballot(&mut neurons, &mut ballots, id, followees, Vote::Unspecified);
-        }
-        // Add another neuron that follows both a neuron with a ballot and without a ballot
-        add_neuron_with_ballot(&mut neurons, &mut ballots, 6, vec![1, 7], Vote::Unspecified);
-
-        // Add a neuron without a ballot for neuron 6 to follow.
-        add_neuron_without_ballot(&mut neurons, 7, vec![1]);
-
-        let governance_proto = crate::pb::v1::Governance {
-            neurons: neurons
-                .into_iter()
-                .map(|(id, neuron)| (id, pb::Neuron::from(neuron)))
-                .collect(),
-            proposals: btreemap! {
-                1 => ProposalData {
-                    id: Some(ProposalId {id: 1}),
-                    ballots,
-                    ..Default::default()
-                }
-            },
-            ..Default::default()
-        };
         let mut governance = Governance::new(
-            governance_proto,
+            Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 234)),
             Arc::new(StubIcpLedger {}),
             Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
+
+        let mut proposal = ProposalData {
+            id: Some(ProposalId { id: 1 }),
+            ..Default::default()
+        };
+
+        for id in 1..=5 {
+            // Each neuron follows all neurons with a lower id
+            let followees = (1..id).collect();
+
+            add_neuron_with_ballot(
+                &mut governance.neuron_store,
+                &mut proposal.ballots,
+                id,
+                followees,
+                Vote::Unspecified,
+            );
+        }
+        // Add another neuron that follows both a neuron with a ballot and without a ballot
+        add_neuron_with_ballot(
+            &mut governance.neuron_store,
+            &mut proposal.ballots,
+            6,
+            vec![1, 7],
+            Vote::Unspecified,
+        );
+
+        // Add a neuron without a ballot for neuron 6 to follow.
+        add_neuron_without_ballot(&mut governance.neuron_store, 7, vec![1]);
+
+        governance.heap_data.proposals.insert(1, proposal);
 
         governance
             .cast_vote_and_cascade_follow(
@@ -878,13 +882,13 @@ mod test {
     }
 
     fn add_neuron_with_ballot(
-        neurons: &mut BTreeMap<u64, Neuron>,
+        neuron_store: &mut NeuronStore,
         ballots: &mut HashMap<u64, Ballot>,
         neuron: Neuron,
     ) {
         let cached_stake = neuron.cached_neuron_stake_e8s;
         let id = neuron.id().id;
-        neurons.insert(id, neuron);
+        neuron_store.add_neuron(neuron).unwrap();
         ballots.insert(
             id,
             Ballot {
@@ -929,11 +933,15 @@ mod test {
             ProposalVotingStateMachine::new(ProposalId { id: 0 }, Topic::NetworkEconomics);
 
         let mut ballots = HashMap::new();
-        let mut neurons = BTreeMap::new();
+        let mut neuron_store = NeuronStore::new(Default::default());
 
-        add_neuron_with_ballot(&mut neurons, &mut ballots, make_neuron(1, 101, hashmap! {}));
         add_neuron_with_ballot(
-            &mut neurons,
+            &mut neuron_store,
+            &mut ballots,
+            make_neuron(1, 101, hashmap! {}),
+        );
+        add_neuron_with_ballot(
+            &mut neuron_store,
             &mut ballots,
             make_neuron(
                 2,
@@ -943,7 +951,6 @@ mod test {
                 }},
             ),
         );
-        let mut neuron_store = NeuronStore::new(neurons);
 
         state_machine.cast_vote(&mut ballots, NeuronId { id: 1 }, Vote::Yes);
         state_machine.continue_processing(&mut neuron_store, &mut ballots, || false);
@@ -1040,10 +1047,10 @@ mod test {
             ProposalVotingStateMachine::new(ProposalId { id: 0 }, Topic::NetworkEconomics);
 
         let mut ballots = HashMap::new();
-        let mut neurons = BTreeMap::new();
+        let mut neuron_store = NeuronStore::new(Default::default());
 
         add_neuron_with_ballot(
-            &mut neurons,
+            &mut neuron_store,
             &mut ballots,
             make_neuron(
                 1,
@@ -1054,7 +1061,7 @@ mod test {
             ),
         );
         add_neuron_with_ballot(
-            &mut neurons,
+            &mut neuron_store,
             &mut ballots,
             make_neuron(
                 2,
@@ -1064,8 +1071,6 @@ mod test {
                 }},
             ),
         );
-
-        let mut neuron_store = NeuronStore::new(neurons);
 
         // We assert it is immediately done after casting an unspecified vote b/c there
         // is no work to do.
@@ -1084,8 +1089,19 @@ mod test {
     fn test_cast_vote_and_cascade_follow_always_finishes_processing_ballots() {
         let _a = temporarily_set_over_soft_message_limit(true);
         let topic = Topic::NetworkEconomics;
-        let mut neurons = BTreeMap::new();
-        let mut ballots = HashMap::new();
+        let mut governance = Governance::new(
+            Default::default(),
+            Arc::new(MockEnvironment::new(Default::default(), 0)),
+            Arc::new(StubIcpLedger {}),
+            Arc::new(StubCMC {}),
+            Box::new(MockRandomness::new()),
+        );
+
+        let mut proposal = ProposalData {
+            id: Some(ProposalId { id: 1 }),
+            ..Default::default()
+        };
+
         for i in 1..=100 {
             let mut followees = HashMap::new();
             if i != 1 {
@@ -1097,30 +1113,14 @@ mod test {
                     },
                 );
             }
-            add_neuron_with_ballot(&mut neurons, &mut ballots, make_neuron(i, 100, followees));
+            add_neuron_with_ballot(
+                &mut governance.neuron_store,
+                &mut proposal.ballots,
+                make_neuron(i, 100, followees),
+            );
         }
 
-        let governance_proto = GovernanceProto {
-            proposals: btreemap! {
-                1 => ProposalData {
-                    id: Some(ProposalId {id: 1}),
-                    ballots,
-                    ..Default::default()
-                }
-            },
-            neurons: neurons
-                .into_iter()
-                .map(|(id, neuron)| (id, pb::Neuron::from(neuron)))
-                .collect(),
-            ..Default::default()
-        };
-        let mut governance = Governance::new(
-            governance_proto,
-            Arc::new(MockEnvironment::new(Default::default(), 0)),
-            Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
-            Box::new(MockRandomness::new()),
-        );
+        governance.heap_data.proposals.insert(1, proposal);
 
         // In our test configuration, we always return "true" for is_over_instructions_limit()
         // So our logic is at least resilient to not having enough instructions, and is able
@@ -1160,8 +1160,19 @@ mod test {
     #[test]
     fn test_cast_vote_and_cascade_breaks_if_over_hard_limit() {
         let topic = Topic::NetworkEconomics;
-        let mut neurons = BTreeMap::new();
-        let mut ballots = HashMap::new();
+        let mut governance = Governance::new(
+            Default::default(),
+            Arc::new(MockEnvironment::new(Default::default(), 0)),
+            Arc::new(StubIcpLedger {}),
+            Arc::new(StubCMC {}),
+            Box::new(MockRandomness::new()),
+        );
+
+        let mut proposal = ProposalData {
+            id: Some(ProposalId { id: 1 }),
+            ..Default::default()
+        };
+
         for i in 1..=10 {
             let mut followees = HashMap::new();
             if i != 1 {
@@ -1173,30 +1184,14 @@ mod test {
                     },
                 );
             }
-            add_neuron_with_ballot(&mut neurons, &mut ballots, make_neuron(i, 100, followees));
+            add_neuron_with_ballot(
+                &mut governance.neuron_store,
+                &mut proposal.ballots,
+                make_neuron(i, 100, followees),
+            );
         }
 
-        let governance_proto = GovernanceProto {
-            proposals: btreemap! {
-                1 => ProposalData {
-                    id: Some(ProposalId {id: 1}),
-                    ballots,
-                    ..Default::default()
-                }
-            },
-            neurons: neurons
-                .into_iter()
-                .map(|(id, neuron)| (id, pb::Neuron::from(neuron)))
-                .collect(),
-            ..Default::default()
-        };
-        let mut governance = Governance::new(
-            governance_proto,
-            Arc::new(MockEnvironment::new(Default::default(), 0)),
-            Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
-            Box::new(MockRandomness::new()),
-        );
+        governance.heap_data.proposals.insert(1, proposal);
 
         let _e = temporarily_set_over_soft_message_limit(true);
         let _f = in_test_temporarily_set_call_context_over_threshold();
@@ -1220,8 +1215,18 @@ mod test {
     fn test_cast_vote_and_cascade_follow_doesnt_record_recent_ballots_after_first_soft_limit() {
         let _a = temporarily_set_over_soft_message_limit(true);
         let topic = Topic::NetworkEconomics;
-        let mut neurons = BTreeMap::new();
-        let mut ballots = HashMap::new();
+        let mut governance = Governance::new(
+            Default::default(),
+            Arc::new(MockEnvironment::new(Default::default(), 0)),
+            Arc::new(StubIcpLedger {}),
+            Arc::new(StubCMC {}),
+            Box::new(MockRandomness::new()),
+        );
+
+        let mut proposal = ProposalData {
+            id: Some(ProposalId { id: 1 }),
+            ..Default::default()
+        };
 
         for i in 1..=9 {
             let mut followees = HashMap::new();
@@ -1234,30 +1239,14 @@ mod test {
                     },
                 );
             }
-            add_neuron_with_ballot(&mut neurons, &mut ballots, make_neuron(i, 100, followees));
+            add_neuron_with_ballot(
+                &mut governance.neuron_store,
+                &mut proposal.ballots,
+                make_neuron(i, 100, followees),
+            );
         }
 
-        let governance_proto = GovernanceProto {
-            proposals: btreemap! {
-                1 => ProposalData {
-                    id: Some(ProposalId {id: 1}),
-                    ballots,
-                    ..Default::default()
-                }
-            },
-            neurons: neurons
-                .into_iter()
-                .map(|(id, neuron)| (id, pb::Neuron::from(neuron)))
-                .collect(),
-            ..Default::default()
-        };
-        let mut governance = Governance::new(
-            governance_proto,
-            Arc::new(MockEnvironment::new(Default::default(), 0)),
-            Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
-            Box::new(MockRandomness::new()),
-        );
+        governance.heap_data.proposals.insert(1, proposal);
 
         // In test mode, we are always saying we're over the soft-message limit, so we know that
         // this will hit that limit and not record any recent ballots.
@@ -1318,8 +1307,26 @@ mod test {
     #[test]
     fn test_process_voting_state_machines_processes_votes_and_executes_proposals() {
         let topic = Topic::Governance;
-        let mut neurons = BTreeMap::new();
-        let mut ballots = HashMap::new();
+        let mut governance = Governance::new(
+            Default::default(),
+            Arc::new(MockEnvironment::new(Default::default(), 1234)),
+            Arc::new(StubIcpLedger {}),
+            Arc::new(StubCMC {}),
+            Box::new(MockRandomness::new()),
+        );
+
+        let mut proposal = ProposalData {
+            id: Some(ProposalId { id: 1 }),
+            proposal: Some(Proposal {
+                title: Some("".to_string()),
+                summary: "".to_string(),
+                url: "".to_string(),
+                action: Some(Action::Motion(Motion {
+                    motion_text: "".to_string(),
+                })),
+            }),
+            ..Default::default()
+        };
 
         for i in 1..=9 {
             let mut followees = HashMap::new();
@@ -1332,41 +1339,14 @@ mod test {
                     },
                 );
             }
-            add_neuron_with_ballot(&mut neurons, &mut ballots, make_neuron(i, 100, followees));
+            add_neuron_with_ballot(
+                &mut governance.neuron_store,
+                &mut proposal.ballots,
+                make_neuron(i, 100, followees),
+            );
         }
 
-        let motion = Motion {
-            motion_text: "".to_string(),
-        };
-        let action = Action::Motion(motion);
-        let proposal = Proposal {
-            title: Some("".to_string()),
-            summary: "".to_string(),
-            url: "".to_string(),
-            action: Some(action),
-        };
-        let governance_proto = GovernanceProto {
-            proposals: btreemap! {
-                1 => ProposalData {
-                    id: Some(ProposalId {id: 1}),
-                    ballots,
-                    proposal: Some(proposal),
-                    ..Default::default()
-                }
-            },
-            neurons: neurons
-                .into_iter()
-                .map(|(id, neuron)| (id, pb::Neuron::from(neuron)))
-                .collect(),
-            ..Default::default()
-        };
-        let mut governance = Governance::new(
-            governance_proto,
-            Arc::new(MockEnvironment::new(Default::default(), 1234)),
-            Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
-            Box::new(MockRandomness::new()),
-        );
+        governance.heap_data.proposals.insert(1, proposal);
 
         governance.record_neuron_vote(ProposalId { id: 1 }, NeuronId { id: 1 }, Vote::Yes, topic);
 
@@ -1412,73 +1392,6 @@ mod test {
     fn test_rewards_distribution_is_blocked_on_votes_not_cast_in_state_machine() {
         let now = 1733433219;
         let topic = Topic::Governance;
-        let mut neurons = BTreeMap::new();
-        let mut ballots = HashMap::new();
-
-        for i in 1..=9 {
-            let mut followees = HashMap::new();
-            if i != 1 {
-                // cascading followees
-                followees.insert(
-                    topic as i32,
-                    Followees {
-                        followees: vec![NeuronId { id: i - 1 }],
-                    },
-                );
-            }
-            add_neuron_with_ballot(
-                &mut neurons,
-                &mut ballots,
-                make_neuron(i, 100_000_000, followees),
-            );
-        }
-
-        // Neurons should all get rewards.
-        for ballot in ballots.iter_mut() {
-            ballot.1.vote = Vote::Yes as i32;
-        }
-
-        add_neuron_with_ballot(
-            &mut neurons,
-            &mut ballots,
-            make_neuron(
-                100,
-                100_000_000,
-                hashmap! {
-                topic as i32 => Followees { followees: vec![NeuronId { id: 1 }] }},
-            ),
-        );
-
-        let motion = Motion {
-            motion_text: "".to_string(),
-        };
-        let action = Action::Motion(motion);
-        let proposal = Proposal {
-            title: Some("".to_string()),
-            summary: "".to_string(),
-            url: "".to_string(),
-            action: Some(action),
-        };
-        let governance_proto = GovernanceProto {
-            genesis_timestamp_seconds: now - REWARD_DISTRIBUTION_PERIOD_SECONDS,
-            proposals: btreemap! {
-                1 => ProposalData {
-                    id: Some(ProposalId {id: 1}),
-                    ballots,
-                    wait_for_quiet_state: Some(WaitForQuietState {
-                        current_deadline_timestamp_seconds: now - 100
-                    }),
-                    proposal: Some(proposal),
-                    decided_timestamp_seconds: now - 100,
-                    ..Default::default()
-                }
-            },
-            neurons: neurons
-                .into_iter()
-                .map(|(id, neuron)| (id, pb::Neuron::from(neuron)))
-                .collect(),
-            ..Default::default()
-        };
         let environment = MockEnvironment::new(
             vec![(
                 ExpectedCallCanisterMethodCallArguments::new(
@@ -1493,12 +1406,68 @@ mod test {
         let now_setter = environment.now_setter();
 
         let mut governance = Governance::new(
-            governance_proto,
+            ApiGovernance {
+                genesis_timestamp_seconds: now - REWARD_DISTRIBUTION_PERIOD_SECONDS,
+                ..Default::default()
+            },
             Arc::new(environment),
             Arc::new(StubIcpLedger {}),
             Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
+
+        let mut proposal = ProposalData {
+            id: Some(ProposalId { id: 1 }),
+            proposal: Some(Proposal {
+                title: Some("".to_string()),
+                summary: "".to_string(),
+                url: "".to_string(),
+                action: Some(Action::Motion(Motion {
+                    motion_text: "".to_string(),
+                })),
+            }),
+            wait_for_quiet_state: Some(WaitForQuietState {
+                current_deadline_timestamp_seconds: now - 100,
+            }),
+            decided_timestamp_seconds: now - 100,
+            ..Default::default()
+        };
+
+        for i in 1..=9 {
+            let mut followees = HashMap::new();
+            if i != 1 {
+                // cascading followees
+                followees.insert(
+                    topic as i32,
+                    Followees {
+                        followees: vec![NeuronId { id: i - 1 }],
+                    },
+                );
+            }
+            add_neuron_with_ballot(
+                &mut governance.neuron_store,
+                &mut proposal.ballots,
+                make_neuron(i, 100_000_000, followees),
+            );
+        }
+
+        // Neurons should all get rewards.
+        for ballot in proposal.ballots.iter_mut() {
+            ballot.1.vote = Vote::Yes as i32;
+        }
+
+        add_neuron_with_ballot(
+            &mut governance.neuron_store,
+            &mut proposal.ballots,
+            make_neuron(
+                100,
+                100_000_000,
+                hashmap! {
+                topic as i32 => Followees { followees: vec![NeuronId { id: 1 }] }},
+            ),
+        );
+
+        governance.heap_data.proposals.insert(1, proposal);
 
         assert_eq!(
             governance

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -22,12 +22,11 @@ use ic_nns_governance::{
             claim_or_refresh::{By, MemoAndController},
             ClaimOrRefresh, Command,
         },
-        neuron, proposal, ExecuteNnsFunction, Governance as GovernanceProto, GovernanceError,
-        InstallCode, ManageNeuron, Motion, NetworkEconomics, Neuron, Proposal,
+        proposal, ExecuteNnsFunction, GovernanceError, InstallCode, ManageNeuron, Motion, Proposal,
     },
 };
 use ic_nns_governance_api::{
-    manage_neuron_response::Command as CommandResponse, ManageNeuronResponse,
+    self as api, manage_neuron_response::Command as CommandResponse, ManageNeuronResponse,
 };
 use icp_ledger::{AccountIdentifier, Subaccount, Tokens};
 use icrc_ledger_types::icrc3::blocks::{GetBlocksRequest, GetBlocksResult};
@@ -108,26 +107,26 @@ fn principal(i: u64) -> PrincipalId {
 
 /// Constructs a fixture with 2 neurons of different stakes and no
 /// following. Neuron 2 has a greater stake.
-fn fixture_two_neurons_second_is_bigger() -> GovernanceProto {
-    GovernanceProto {
-        economics: Some(NetworkEconomics::default()),
+fn fixture_two_neurons_second_is_bigger() -> api::Governance {
+    api::Governance {
+        economics: Some(api::NetworkEconomics::default()),
         neurons: btreemap! {
-            1 => Neuron {
+            1 => api::Neuron {
                 id: Some(NeuronId {id: 1}),
                 controller: Some(principal(1)),
                 cached_neuron_stake_e8s: 23,
                 account: b"a__4___8__12__16__20__24__28__32".to_vec(),
                 // One year
-                dissolve_state: Some(neuron::DissolveState::DissolveDelaySeconds(31557600)),
+                dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(31557600)),
                 ..Default::default()
             },
-            2 => Neuron {
+            2 => api::Neuron {
                 id: Some(NeuronId {id: 2}),
                 controller: Some(principal(2)),
                 cached_neuron_stake_e8s: 5100,
                 account:  b"b__4___8__12__16__20__24__28__32".to_vec(),
                 // One year
-                dissolve_state: Some(neuron::DissolveState::DissolveDelaySeconds(31557600)),
+                dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(31557600)),
                 ..Default::default()
              },
         },

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -20,11 +20,11 @@ use ic_nns_governance::{
     governance::{Environment, Governance, HeapGrowthPotential, RngError},
     pb::v1::{
         manage_neuron, manage_neuron::NeuronIdOrSubaccount, proposal, ExecuteNnsFunction,
-        GovernanceError, ManageNeuron, Motion, NetworkEconomics, Neuron, NnsFunction, Proposal,
-        Vote,
+        GovernanceError, ManageNeuron, Motion, NetworkEconomics, NnsFunction, Proposal, Vote,
     },
     use_node_provider_reward_canister,
 };
+use ic_nns_governance_api::Neuron;
 use ic_nns_governance_api::{manage_neuron_response, ManageNeuronResponse};
 use ic_sns_root::{GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse};
 use ic_sns_swap::pb::v1 as sns_swap_pb;

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -37,7 +37,7 @@ use ic_nns_governance::{
     },
     storage::reset_stable_memory,
 };
-use ic_nns_governance_api::{manage_neuron_response, ManageNeuronResponse};
+use ic_nns_governance_api::{self as api, manage_neuron_response, ManageNeuronResponse};
 use icp_ledger::{AccountIdentifier, Subaccount, Tokens};
 use icrc_ledger_types::icrc3::blocks::{GetBlocksRequest, GetBlocksResult};
 use rand::{prelude::StdRng, RngCore, SeedableRng};
@@ -207,8 +207,8 @@ pub struct NeuronBuilder {
     maturity: u64,
     staked_maturity: u64,
     neuron_fees: u64,
-    dissolve_state: Option<neuron::DissolveState>,
-    followees: HashMap<i32, neuron::Followees>,
+    dissolve_state: Option<api::neuron::DissolveState>,
+    followees: HashMap<i32, api::neuron::Followees>,
     kyc_verified: bool,
     not_for_profit: bool,
     joined_community_fund: Option<u64>,
@@ -216,8 +216,8 @@ pub struct NeuronBuilder {
     neuron_type: Option<i32>,
 }
 
-impl From<Neuron> for NeuronBuilder {
-    fn from(neuron: Neuron) -> Self {
+impl From<api::Neuron> for NeuronBuilder {
+    fn from(neuron: api::Neuron) -> Self {
         NeuronBuilder {
             ident: 0,
             stake: neuron.cached_neuron_stake_e8s,
@@ -266,7 +266,7 @@ impl NeuronBuilder {
     }
 
     pub fn set_dissolve_delay(mut self, seconds: u64) -> Self {
-        self.dissolve_state = Some(DissolveState::DissolveDelaySeconds(seconds));
+        self.dissolve_state = Some(api::neuron::DissolveState::DissolveDelaySeconds(seconds));
         self
     }
 
@@ -311,13 +311,15 @@ impl NeuronBuilder {
 
     #[allow(dead_code)]
     pub fn start_dissolving(mut self, now: u64) -> Self {
-        if let Some(DissolveState::DissolveDelaySeconds(secs)) = self.dissolve_state {
-            self.dissolve_state = Some(DissolveState::WhenDissolvedTimestampSeconds(now + secs));
+        if let Some(api::neuron::DissolveState::DissolveDelaySeconds(secs)) = self.dissolve_state {
+            self.dissolve_state = Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(
+                now + secs,
+            ));
         }
         self
     }
 
-    pub fn set_dissolve_state(mut self, state: Option<DissolveState>) -> Self {
+    pub fn set_dissolve_state(mut self, state: Option<api::neuron::DissolveState>) -> Self {
         self.dissolve_state = state;
         self
     }
@@ -337,13 +339,13 @@ impl NeuronBuilder {
         self
     }
 
-    pub fn insert_managers(mut self, managers: neuron::Followees) -> Self {
+    pub fn insert_managers(mut self, managers: api::neuron::Followees) -> Self {
         self.followees
             .insert(Topic::NeuronManagement as i32, managers);
         self
     }
 
-    pub fn insert_followees(mut self, topic: Topic, followees: neuron::Followees) -> Self {
+    pub fn insert_followees(mut self, topic: Topic, followees: api::neuron::Followees) -> Self {
         self.followees.insert(topic as i32, followees);
         self
     }
@@ -361,12 +363,12 @@ impl NeuronBuilder {
         self
     }
 
-    pub fn create(self, now: u64, ledger: &mut LedgerBuilder) -> Neuron {
+    pub fn create(self, now: u64, ledger: &mut LedgerBuilder) -> api::Neuron {
         let subaccount = Self::subaccount(self.owner, self.ident);
         ledger.add_account(neuron_subaccount(subaccount), self.stake);
         subaccount.to_vec();
 
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: self.ident }),
             account: subaccount.to_vec(),
             controller: self.owner,
@@ -375,7 +377,7 @@ impl NeuronBuilder {
             neuron_fees_e8s: self.neuron_fees,
             created_timestamp_seconds: self.created_seconds.unwrap_or(now),
             aging_since_timestamp_seconds: match self.dissolve_state {
-                Some(DissolveState::WhenDissolvedTimestampSeconds(_)) => u64::MAX,
+                Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(_)) => u64::MAX,
                 _ => match self.age_timestamp {
                     None => now,
                     Some(secs) => secs,
@@ -394,8 +396,7 @@ impl NeuronBuilder {
             joined_community_fund_timestamp_seconds: self.joined_community_fund,
             spawn_at_timestamp_seconds: self.spawn_at_timestamp_seconds,
             neuron_type: self.neuron_type,
-            recent_ballots_next_entry_index: Some(0),
-            ..Neuron::default()
+            ..api::Neuron::default()
         }
     }
 
@@ -412,7 +413,7 @@ impl NeuronBuilder {
         })
     }
 
-    pub fn add_followees(mut self, index: i32, followees: neuron::Followees) -> Self {
+    pub fn add_followees(mut self, index: i32, followees: api::neuron::Followees) -> Self {
         self.followees.insert(index, followees);
         self
     }
@@ -1043,7 +1044,7 @@ pub type EnvironmentTransform = Box<dyn FnOnce(Arc<dyn Environment>) -> Arc<dyn 
 pub struct NNSBuilder {
     ledger_builder: LedgerBuilder,
     environment_builder: EnvironmentBuilder,
-    governance: GovernanceProto,
+    governance: api::Governance,
     ledger_transforms: Vec<LedgerTransform>,
     environment_transforms: Vec<EnvironmentTransform>,
 }
@@ -1104,6 +1105,11 @@ impl NNSBuilder {
     }
 
     pub fn set_economics(mut self, econ: NetworkEconomics) -> Self {
+        self.governance.economics = Some(econ.into());
+        self
+    }
+
+    pub fn set_economics_api(mut self, econ: api::NetworkEconomics) -> Self {
         self.governance.economics = Some(econ);
         self
     }
@@ -1146,7 +1152,7 @@ impl NNSBuilder {
         self
     }
 
-    pub fn add_neurons(self, neurons: impl IntoIterator<Item = (Neuron, u64)>) -> Self {
+    pub fn add_neurons(self, neurons: impl IntoIterator<Item = (api::Neuron, u64)>) -> Self {
         neurons.into_iter().fold(self, |b, (neuron, id)| {
             b.add_neuron(
                 NeuronBuilder::from(neuron)
@@ -1157,7 +1163,7 @@ impl NNSBuilder {
     }
 
     #[allow(dead_code)]
-    pub fn get_neuron(&self, ident: u64) -> Option<&Neuron> {
+    pub fn get_neuron(&self, ident: u64) -> Option<&api::Neuron> {
         self.governance.neurons.get(&ident)
     }
 
@@ -1174,7 +1180,7 @@ impl NNSBuilder {
         self
     }
 
-    pub fn add_proposal(mut self, proposal_data: ProposalData) -> Self {
+    pub fn add_proposal(mut self, proposal_data: api::ProposalData) -> Self {
         self.governance
             .proposals
             .insert(proposal_data.id.unwrap().id, proposal_data);

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -11,9 +11,7 @@ use assert_matches::assert_matches;
 use async_trait::async_trait;
 use candid::{Decode, Encode};
 use common::increase_dissolve_delay_raw;
-use comparable::{
-    Changed, I32Change, MapChange, OptionChange, StringChange, U32Change, U64Change, VecChange,
-};
+use comparable::{Changed, I32Change, MapChange, OptionChange, StringChange, U64Change, VecChange};
 use fixtures::{
     account, environment_fixture::CanisterCallReply, new_motion_proposal, principal, NNSBuilder,
     NNSStateChange, NeuronBuilder, ProposalNeuronBehavior, NNS,
@@ -78,18 +76,18 @@ use ic_nns_governance::{
             MergeMaturity, NeuronIdOrSubaccount, RefreshVotingPower, SetVisibility, Spawn, Split,
             StartDissolving,
         },
-        neuron::{self, DissolveState, Followees},
+        neuron::{DissolveState, Followees},
         neurons_fund_snapshot::NeuronsFundNeuronPortion,
         proposal::{self, Action, ActionDesc},
         reward_node_provider::{RewardMode, RewardToAccount, RewardToNeuron},
         settle_neurons_fund_participation_request, swap_background_information,
         AddOrRemoveNodeProvider, Ballot, BallotInfo, BallotInfoChange, CreateServiceNervousSystem,
-        Empty, ExecuteNnsFunction, Governance as GovernanceProto, GovernanceChange,
-        GovernanceError, IdealMatchedParticipationFunction, InstallCode, KnownNeuron,
-        KnownNeuronData, ManageNeuron, MonthlyNodeProviderRewards, Motion, NetworkEconomics,
-        Neuron, NeuronChange, NeuronType, NeuronsFundData, NeuronsFundEconomics,
-        NeuronsFundMatchedFundingCurveCoefficients, NeuronsFundParticipation, NeuronsFundSnapshot,
-        NnsFunction, NodeProvider, Proposal, ProposalChange, ProposalData, ProposalDataChange,
+        Empty, ExecuteNnsFunction, GovernanceChange, GovernanceError,
+        IdealMatchedParticipationFunction, InstallCode, KnownNeuron, KnownNeuronData, ManageNeuron,
+        MonthlyNodeProviderRewards, Motion, NetworkEconomics, Neuron, NeuronChange, NeuronType,
+        NeuronsFundData, NeuronsFundEconomics, NeuronsFundMatchedFundingCurveCoefficients,
+        NeuronsFundParticipation, NeuronsFundSnapshot, NnsFunction, NodeProvider, Proposal,
+        ProposalChange, ProposalData, ProposalDataChange,
         ProposalRewardStatus::{self, AcceptVotes, ReadyToSettle},
         ProposalStatus::{self, Rejected},
         RewardEvent, RewardNodeProvider, RewardNodeProviders,
@@ -176,7 +174,7 @@ const RANDOM_U64: u64 = 0_u64;
 const USUAL_REWARD_POT_E8S: u64 = 100;
 
 fn check_proposal_status_after_voting_and_after_expiration_new(
-    neurons: impl IntoIterator<Item = Neuron>,
+    neurons: impl IntoIterator<Item = api::Neuron>,
     behavior: impl Into<ProposalNeuronBehavior>,
     expected_after_voting: ProposalStatus,
     expected_after_expiration: ProposalStatus,
@@ -245,13 +243,13 @@ fn check_proposal_status_after_voting_and_after_expiration_new(
     nns
 }
 
-const NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE: Option<DissolveState> =
-    Some(DissolveState::DissolveDelaySeconds(
+const NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE: Option<api::neuron::DissolveState> =
+    Some(api::neuron::DissolveState::DissolveDelaySeconds(
         VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
     ));
 
-const NOTDISSOLVING_MAX_DISSOLVE_DELAY: Option<DissolveState> = Some(
-    DissolveState::DissolveDelaySeconds(MAX_DISSOLVE_DELAY_SECONDS),
+const NOTDISSOLVING_MAX_DISSOLVE_DELAY: Option<api::neuron::DissolveState> = Some(
+    api::neuron::DissolveState::DissolveDelaySeconds(MAX_DISSOLVE_DELAY_SECONDS),
 );
 
 // To avoid this failure, you need to run cargo test with --features test. The
@@ -268,10 +266,10 @@ fn tests_must_be_run_with_test_feature_enabled() {
 #[test]
 fn test_single_neuron_proposal_new() {
     let mut nns = check_proposal_status_after_voting_and_after_expiration_new(
-        vec![Neuron {
+        vec![api::Neuron {
             dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
             cached_neuron_stake_e8s: 1,
-            ..Neuron::default()
+            ..api::Neuron::default()
         }],
         "P",
         ProposalStatus::Executed,
@@ -307,7 +305,12 @@ fn test_single_neuron_proposal_new() {
                                 ),
                             ),
                         ),
-                        NeuronChange::RecentBallotsNextEntryIndex(OptionChange::BothSome(U32Change(0, 1,),),),
+                        NeuronChange::RecentBallotsNextEntryIndex(
+                            OptionChange::Different(
+                                None,
+                                Some(1),
+                            ),
+                        ),
                     ],
                 )]),
                 GovernanceChange::Proposals(vec![MapChange::Added(
@@ -590,24 +593,24 @@ fn test_single_neuron_proposal_new() {
 /// - all votes happen at proposal creation time.
 /// - uses an arbitrary duration for proposal expiration time.
 fn check_proposal_status_after_voting_and_after_expiration(
-    neurons: impl IntoIterator<Item = Neuron>,
+    neurons: impl IntoIterator<Item = api::Neuron>,
     behavior: impl Into<fake::ProposalNeuronBehavior>,
     expected_after_voting: ProposalStatus,
     expected_after_expiration: ProposalStatus,
 ) {
     reset_stable_memory();
     let expiration_seconds = 17; // Arbitrary duration
-    let network_economics = NetworkEconomics {
+    let network_economics = api::NetworkEconomics {
         reject_cost_e8s: 0,          // It's the default, but specify for emphasis
         neuron_minimum_stake_e8s: 0, // It's the default, but specify for emphasis
-        ..NetworkEconomics::with_default_values()
+        ..api::NetworkEconomics::with_default_values()
     };
     let mut fake_driver = fake::FakeDriver::default();
 
     let neurons = neurons
         .into_iter()
         .zip(0_u64..)
-        .map(|(neuron, i)| Neuron {
+        .map(|(neuron, i)| api::Neuron {
             id: Some(NeuronId { id: i }),
             controller: Some(principal(i)),
             account: fake_driver
@@ -669,10 +672,10 @@ fn check_proposal_status_after_voting_and_after_expiration(
 #[test]
 fn test_single_neuron_proposal() {
     check_proposal_status_after_voting_and_after_expiration(
-        vec![Neuron {
+        vec![api::Neuron {
             dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
             cached_neuron_stake_e8s: 1,
-            ..Neuron::default()
+            ..api::Neuron::default()
         }],
         "P",
         ProposalStatus::Executed,
@@ -686,15 +689,15 @@ fn test_single_neuron_proposal() {
 fn test_two_neuron_agreement_proposal_should_be_accepted() {
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 1,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 1,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "Py",
@@ -709,15 +712,15 @@ fn test_two_neuron_agreement_proposal_should_be_accepted() {
 fn test_two_neuron_disagree_identical_voting_power_proposal_should_be_rejected() {
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 1,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 1,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "Pn",
@@ -733,15 +736,15 @@ fn test_two_neuron_disagree_identical_voting_power_one_does_not_vote_proposal_sh
 ) {
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 1,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 40,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "P-",
@@ -756,15 +759,15 @@ fn test_two_neuron_disagree_identical_voting_power_one_does_not_vote_proposal_sh
 fn test_two_neuron_disagree_largest_stake_wins() {
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 8,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 7,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "P-",
@@ -773,15 +776,15 @@ fn test_two_neuron_disagree_largest_stake_wins() {
     );
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 400,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 7,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "nP",
@@ -790,15 +793,15 @@ fn test_two_neuron_disagree_largest_stake_wins() {
     );
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 400,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 7,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "-P",
@@ -813,15 +816,15 @@ fn test_two_neuron_disagree_largest_stake_wins() {
 fn test_two_neuron_disagree_identical_stake_longer_dissolve_wins() {
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MAX_DISSOLVE_DELAY,
                 cached_neuron_stake_e8s: 1,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 1,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "P-",
@@ -830,15 +833,15 @@ fn test_two_neuron_disagree_identical_stake_longer_dissolve_wins() {
     );
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MAX_DISSOLVE_DELAY,
                 cached_neuron_stake_e8s: 21,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 1,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "nP",
@@ -847,15 +850,15 @@ fn test_two_neuron_disagree_identical_stake_longer_dissolve_wins() {
     );
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MAX_DISSOLVE_DELAY,
                 cached_neuron_stake_e8s: 21,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 1,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "-P",
@@ -872,18 +875,18 @@ fn test_two_neuron_disagree_identical_stake_older_wins() {
     // powers, stakes need to be at least 4 e8s.
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 4,
                 aging_since_timestamp_seconds: DEFAULT_TEST_START_TIMESTAMP_SECONDS
                     - MAX_NEURON_AGE_FOR_AGE_BONUS,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 4,
                 aging_since_timestamp_seconds: DEFAULT_TEST_START_TIMESTAMP_SECONDS,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "P-",
@@ -892,18 +895,18 @@ fn test_two_neuron_disagree_identical_stake_older_wins() {
     );
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 200,
                 aging_since_timestamp_seconds: DEFAULT_TEST_START_TIMESTAMP_SECONDS
                     - MAX_NEURON_AGE_FOR_AGE_BONUS,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 4,
                 aging_since_timestamp_seconds: DEFAULT_TEST_START_TIMESTAMP_SECONDS,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "nP",
@@ -912,18 +915,18 @@ fn test_two_neuron_disagree_identical_stake_older_wins() {
     );
     check_proposal_status_after_voting_and_after_expiration(
         vec![
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 200,
                 aging_since_timestamp_seconds: DEFAULT_TEST_START_TIMESTAMP_SECONDS
                     - MAX_NEURON_AGE_FOR_AGE_BONUS,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
-            Neuron {
+            api::Neuron {
                 dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
                 cached_neuron_stake_e8s: 4,
                 aging_since_timestamp_seconds: DEFAULT_TEST_START_TIMESTAMP_SECONDS,
-                ..Neuron::default()
+                ..api::Neuron::default()
             },
         ],
         "-P",
@@ -945,37 +948,37 @@ fn test_two_neuron_disagree_identical_stake_older_wins() {
 ///   override
 ///
 /// - Neurons 1, 5, 6, 7, and 8 have a controller set and can vote.
-fn fixture_for_following() -> GovernanceProto {
+fn fixture_for_following() -> api::Governance {
     let mut driver = fake::FakeDriver::default();
     // A 'default' neuron, extended with additional fields below.
-    let mut neuron = move |id| Neuron {
+    let mut neuron = move |id| api::Neuron {
         id: Some(NeuronId { id }),
         controller: Some(principal(id)),
         cached_neuron_stake_e8s: 1_000_000_000, // 10 ICP
         // One year
-        dissolve_state: Some(neuron::DissolveState::DissolveDelaySeconds(31557600)),
+        dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(31557600)),
         account: driver
             .random_byte_array()
             .expect("Could not get random byte array")
             .to_vec(),
         ..Default::default()
     };
-    GovernanceProto {
-        economics: Some(NetworkEconomics::with_default_values()),
+    api::Governance {
+        economics: Some(api::NetworkEconomics::with_default_values()),
         wait_for_quiet_threshold_seconds: 1,
         neurons: btreemap! {
             1 => neuron(1),
-            2 => Neuron {
+            2 => api::Neuron {
                 followees: hashmap! {
-                    Topic::NetworkEconomics as i32 => neuron::Followees {
+                    Topic::NetworkEconomics as i32 => api::neuron::Followees {
                         followees: [NeuronId { id: 1 }, NeuronId { id: 3 }, NeuronId { id: 4 }].to_vec(),
                     },
                 },
                 ..neuron(2)
             },
-            3 => Neuron {
+            3 => api::Neuron {
                 followees: hashmap! {
-                    Topic::Unspecified as i32 => neuron::Followees {
+                    Topic::Unspecified as i32 => api::neuron::Followees {
                         followees: [NeuronId { id: 5 }, NeuronId { id: 6 }, NeuronId { id: 7 }].to_vec(),
                     },
                 },
@@ -1249,7 +1252,7 @@ async fn test_manage_network_economics_change_one_deep_subfield() {
     // The neuron will be used to make a ManageNetworkEconomics proposal.
 
     let controller = PrincipalId::new_user_test_id(519_572_717);
-    let neuron = Neuron {
+    let neuron = api::Neuron {
         id: Some(NeuronId { id: 1 }),
         controller: Some(controller),
         account: vec![42_u8; 32],
@@ -1260,8 +1263,8 @@ async fn test_manage_network_economics_change_one_deep_subfield() {
 
     let driver = fake::FakeDriver::default();
     let mut gov = Governance::new(
-        GovernanceProto {
-            economics: Some(NetworkEconomics::with_default_values()),
+        api::Governance {
+            economics: Some(api::NetworkEconomics::with_default_values()),
             neurons: btreemap! { 1 => neuron },
             ..Default::default()
         },
@@ -1363,7 +1366,7 @@ async fn test_manage_network_economics_reject_invalid() {
     // Step 1: Prepare the world. We only really need a super basic Governance.
 
     let controller = PrincipalId::new_user_test_id(519_572_717);
-    let neuron = Neuron {
+    let neuron = api::Neuron {
         id: Some(NeuronId { id: 1 }),
         controller: Some(controller),
         account: vec![42_u8; 32],
@@ -1374,8 +1377,8 @@ async fn test_manage_network_economics_reject_invalid() {
 
     let driver = fake::FakeDriver::default();
     let mut gov = Governance::new(
-        GovernanceProto {
-            economics: Some(NetworkEconomics::with_default_values()),
+        api::Governance {
+            economics: Some(api::NetworkEconomics::with_default_values()),
             neurons: btreemap! { 1 => neuron },
             ..Default::default()
         },
@@ -1591,7 +1594,7 @@ async fn test_manage_network_economics_revalidate_at_execution_time(
     //        concurrently).
 
     let controller = PrincipalId::new_user_test_id(519_572_717);
-    let proposer_neuron = Neuron {
+    let proposer_neuron = api::Neuron {
         id: Some(NeuronId { id: 1 }),
         controller: Some(controller),
         account: vec![42_u8; 32],
@@ -1599,7 +1602,7 @@ async fn test_manage_network_economics_revalidate_at_execution_time(
         cached_neuron_stake_e8s: 100 * E8,
         ..Default::default()
     };
-    let decider_neuron = Neuron {
+    let decider_neuron = api::Neuron {
         id: Some(NeuronId { id: 2 }),
         account: vec![57_u8; 32],
         cached_neuron_stake_e8s: E8 * E8, // Powerful!
@@ -1608,8 +1611,8 @@ async fn test_manage_network_economics_revalidate_at_execution_time(
 
     let driver = fake::FakeDriver::default();
     let mut gov = Governance::new(
-        GovernanceProto {
-            economics: Some(NetworkEconomics::with_default_values()),
+        api::Governance {
+            economics: Some(api::NetworkEconomics::with_default_values()),
             neurons: btreemap! {
                 1 => proposer_neuron,
                 2 => decider_neuron,
@@ -1771,10 +1774,8 @@ async fn test_mint_monthly_node_provider_rewards() {
     );
     let default_economics = NetworkEconomics::with_default_values();
     let mut gov = Governance::new(
-        GovernanceProto {
-            economics: Some(default_economics.clone()),
-            node_providers: vec![node_provider.clone()],
-            most_recent_monthly_node_provider_rewards: Some(MonthlyNodeProviderRewards {
+        api::Governance {
+            most_recent_monthly_node_provider_rewards: Some(api::MonthlyNodeProviderRewards {
                 timestamp: 0,
                 rewards: vec![],
                 xdr_conversion_rate: None,
@@ -1790,6 +1791,8 @@ async fn test_mint_monthly_node_provider_rewards() {
         driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
+    gov.heap_data.economics = Some(default_economics.clone());
+    gov.heap_data.node_providers = vec![node_provider.clone()];
 
     // Step 2: Run twice heartbeat so that minting rewards is reached.
     gov.run_periodic_tasks().now_or_never();
@@ -2285,13 +2288,11 @@ async fn test_no_voting_after_deadline() {
 /// - Neuron 1 follows 2, 3, and 4 on topic `ManageNeuron`.
 ///
 /// - Neurons 2, 3, 4, and 5 have a controller so they can vote.
-fn fixture_for_manage_neuron() -> GovernanceProto {
+fn fixture_for_manage_neuron() -> api::Governance {
     let mut driver = fake::FakeDriver::default();
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     // A 'default' neuron, extended with additional fields below.
-    let mut neuron = move |id| Neuron {
+    let mut neuron = move |id| api::Neuron {
         id: Some(NeuronId { id }),
         controller: Some(principal(id)),
         cached_neuron_stake_e8s: 1_000_000_000, // 10 ICP
@@ -2299,24 +2300,24 @@ fn fixture_for_manage_neuron() -> GovernanceProto {
             .random_byte_array()
             .expect("Could not get random byte array")
             .to_vec(),
-        dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+        dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
     };
 
     let neurons = vec![
-        Neuron {
+        api::Neuron {
             created_timestamp_seconds: 1066,
             hot_keys: vec![PrincipalId::try_from(b"HOT_SID1".to_vec()).unwrap()],
             followees: hashmap! {
-                Topic::NeuronManagement as i32 => neuron::Followees {
+                Topic::NeuronManagement as i32 => api::neuron::Followees {
                     followees: [NeuronId { id: 2 }, NeuronId { id: 3 }, NeuronId { id: 4 }]
                         .to_vec(),
                 },
             },
             ..neuron(1)
         },
-        Neuron {
+        api::Neuron {
             hot_keys: vec![PrincipalId::try_from(b"HOT_SID2".to_vec()).unwrap()],
             ..neuron(2)
         },
@@ -2328,7 +2329,7 @@ fn fixture_for_manage_neuron() -> GovernanceProto {
 
     GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .with_short_voting_period(1)
         .with_neuron_management_voting_period(1)
@@ -2792,11 +2793,11 @@ async fn test_sufficient_stake_for_manage_neuron() {
 
 /// Constructs a fixture with 2 neurons of different stakes and no
 /// following. Neuron 2 has a greater stake.
-fn fixture_two_neurons_second_is_bigger() -> GovernanceProto {
+fn fixture_two_neurons_second_is_bigger() -> api::Governance {
     let mut driver = fake::FakeDriver::default();
 
     let neurons = vec![
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: 1 }),
             controller: Some(principal(1)),
             cached_neuron_stake_e8s: 23,
@@ -2805,10 +2806,10 @@ fn fixture_two_neurons_second_is_bigger() -> GovernanceProto {
                 .expect("Could not get random byte array")
                 .to_vec(),
             // One year
-            dissolve_state: Some(neuron::DissolveState::DissolveDelaySeconds(31557600)),
+            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(31557600)),
             ..Default::default()
         },
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: 2 }),
             controller: Some(principal(2)),
             cached_neuron_stake_e8s: 951,
@@ -2817,7 +2818,7 @@ fn fixture_two_neurons_second_is_bigger() -> GovernanceProto {
                 .expect("Could not get random byte array")
                 .to_vec(),
             // One year
-            dissolve_state: Some(neuron::DissolveState::DissolveDelaySeconds(31557600)),
+            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(31557600)),
             ..Default::default()
         },
     ];
@@ -2881,7 +2882,7 @@ async fn test_compute_tally_while_open() {
     // Prepare the test with 2 neurons
     let fake_driver = fake::FakeDriver::default();
     let mut gov = Governance::new(
-        GovernanceProto {
+        api::Governance {
             wait_for_quiet_threshold_seconds: 5,
             ..fixture_two_neurons_second_is_bigger()
         },
@@ -2926,7 +2927,7 @@ async fn test_compute_tally_after_decided() {
     // Prepare the test with 2 neurons
     let fake_driver = fake::FakeDriver::default();
     let mut gov = Governance::new(
-        GovernanceProto {
+        api::Governance {
             wait_for_quiet_threshold_seconds: 5,
             ..fixture_two_neurons_second_is_bigger()
         },
@@ -2992,7 +2993,7 @@ async fn test_no_compute_tally_after_deadline() {
     // Prepare the test with 2 neurons
     let mut fake_driver = fake::FakeDriver::default();
     let mut gov = Governance::new(
-        GovernanceProto {
+        api::Governance {
             wait_for_quiet_threshold_seconds: 5,
             ..fixture_two_neurons_second_is_bigger()
         },
@@ -3593,15 +3594,15 @@ fn test_reward_distribution_skips_deleted_neurons() {
     let mut fixture = fixture_two_neurons_second_is_bigger();
     fixture.proposals.insert(
         1_u64,
-        ProposalData {
+        api::ProposalData {
             id: Some(ProposalId { id: 1 }),
             proposer: Some(NeuronId { id: 2 }),
             reject_cost_e8s: 0,
-            proposal: Some(Proposal {
+            proposal: Some(api::Proposal {
                 title: Some("Test motion proposal".to_string()),
                 summary: "A proposal voted on by a now-gone neuron".to_string(),
                 url: "https://oops".to_string(),
-                action: Some(Action::Motion(Motion {
+                action: Some(api::proposal::Action::Motion(api::Motion {
                     motion_text: "a motion".to_string(),
                 })),
             }),
@@ -3610,7 +3611,7 @@ fn test_reward_distribution_skips_deleted_neurons() {
                 (
                     // This is a ballot by neuron 2, which still exists
                     2,
-                    Ballot {
+                    api::Ballot {
                         vote: Vote::Yes as i32,
                         voting_power: 250,
                     },
@@ -3618,7 +3619,7 @@ fn test_reward_distribution_skips_deleted_neurons() {
                 (
                     // This is a ballot by neuron 999, which is not present in the neuron map.
                     999,
-                    Ballot {
+                    api::Ballot {
                         vote: Vote::Yes as i32,
                         voting_power: 750,
                     },
@@ -3980,7 +3981,7 @@ fn compute_maturities(
     let neurons = stakes_e8s
         .iter()
         .enumerate()
-        .map(|(i, stake_e8s)| Neuron {
+        .map(|(i, stake_e8s)| api::Neuron {
             id: Some(NeuronId { id: i as u64 }),
             controller: Some(principal(i as u64)),
             cached_neuron_stake_e8s: *stake_e8s,
@@ -4446,16 +4447,14 @@ fn test_reward_complex_scenario() {
     );
 }
 
-fn fixture_for_approve_kyc() -> GovernanceProto {
+fn fixture_for_approve_kyc() -> api::Governance {
     let mut driver = fake::FakeDriver::default();
     let principal1 = PrincipalId::new_self_authenticating(b"SID1");
     let principal2 = PrincipalId::new_self_authenticating(b"SID2");
     let principal3 = PrincipalId::new_self_authenticating(b"SID3");
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     let neurons = vec![
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: 1 }),
             controller: Some(principal1),
             cached_neuron_stake_e8s: 10 * E8,
@@ -4464,11 +4463,11 @@ fn fixture_for_approve_kyc() -> GovernanceProto {
                 .expect("Could not get random byte array")
                 .to_vec(),
             kyc_verified: false,
-            dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+            dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
             aging_since_timestamp_seconds: u64::MAX,
             ..Default::default()
         },
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: 2 }),
             controller: Some(principal2),
             cached_neuron_stake_e8s: 10 * E8,
@@ -4477,11 +4476,11 @@ fn fixture_for_approve_kyc() -> GovernanceProto {
                 .expect("Could not get random byte array")
                 .to_vec(),
             kyc_verified: false,
-            dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+            dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
             aging_since_timestamp_seconds: u64::MAX,
             ..Default::default()
         },
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: 3 }),
             controller: Some(principal2),
             cached_neuron_stake_e8s: 10 * E8,
@@ -4490,11 +4489,11 @@ fn fixture_for_approve_kyc() -> GovernanceProto {
                 .expect("Could not get random byte array")
                 .to_vec(),
             kyc_verified: false,
-            dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+            dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
             aging_since_timestamp_seconds: u64::MAX,
             ..Default::default()
         },
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: 4 }),
             controller: Some(principal3),
             cached_neuron_stake_e8s: 10 * E8,
@@ -4503,7 +4502,7 @@ fn fixture_for_approve_kyc() -> GovernanceProto {
                 .expect("Could not get random byte array")
                 .to_vec(),
             kyc_verified: false,
-            dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+            dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
             aging_since_timestamp_seconds: u64::MAX,
             ..Default::default()
         },
@@ -4511,7 +4510,7 @@ fn fixture_for_approve_kyc() -> GovernanceProto {
 
     GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .build()
 }
@@ -4534,7 +4533,7 @@ fn test_approve_kyc() {
                 .neurons
                 .values()
                 .cloned()
-                .collect::<Vec<Neuron>>(),
+                .collect::<Vec<api::Neuron>>(),
         )
         .with_supply(Tokens::from_tokens(1_000_000).unwrap());
     let mut gov = Governance::new(
@@ -4672,40 +4671,40 @@ fn test_get_neuron_ids_by_principal() {
     let principal4 = principal(4);
     let mut driver = fake::FakeDriver::default();
 
-    let neuron_a = Neuron {
+    let neuron_a = api::Neuron {
         id: Some(NeuronId { id: 1 }),
         controller: Some(principal1),
         account: driver
             .random_byte_array()
             .expect("Could not get random byte array")
             .to_vec(),
-        dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+        dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
     };
-    let neuron_b = Neuron {
+    let neuron_b = api::Neuron {
         id: Some(NeuronId { id: 2 }),
         controller: Some(principal2),
         account: driver
             .random_byte_array()
             .expect("Could not get random byte array")
             .to_vec(),
-        dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+        dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
     };
-    let neuron_c = Neuron {
+    let neuron_c = api::Neuron {
         id: Some(NeuronId { id: 3 }),
         controller: Some(principal2),
         account: driver
             .random_byte_array()
             .expect("Could not get random byte array")
             .to_vec(),
-        dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+        dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
     };
-    let neuron_d = Neuron {
+    let neuron_d = api::Neuron {
         id: Some(NeuronId { id: 4 }),
         controller: Some(principal2),
         hot_keys: vec![principal4],
@@ -4713,19 +4712,22 @@ fn test_get_neuron_ids_by_principal() {
             .random_byte_array()
             .expect("Could not get random byte array")
             .to_vec(),
-        dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+        dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
         aging_since_timestamp_seconds: u64::MAX,
         ..Default::default()
     };
 
-    let mut gov_proto = empty_fixture();
-    gov_proto.neurons = vec![(1, neuron_a), (2, neuron_b), (3, neuron_c), (4, neuron_d)]
-        .into_iter()
-        .collect();
+    let mut governance_init = empty_fixture();
+    governance_init.neurons = btreemap! {
+        1 => neuron_a,
+        2 => neuron_b,
+        3 => neuron_c,
+        4 => neuron_d,
+    };
 
     let driver = fake::FakeDriver::default();
     let gov = Governance::new(
-        gov_proto,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
@@ -4751,9 +4753,9 @@ fn test_get_neuron_ids_by_principal() {
     );
 }
 
-fn empty_fixture() -> GovernanceProto {
-    GovernanceProto {
-        economics: Some(NetworkEconomics::with_default_values()),
+fn empty_fixture() -> api::Governance {
+    api::Governance {
+        economics: Some(api::NetworkEconomics::with_default_values()),
         ..Default::default()
     }
 }
@@ -5586,7 +5588,7 @@ fn test_rate_limiting_neuron_creation() {
         .map(|i| {
             let controller = PrincipalId::new_user_test_id(i);
             let nonce = 1234u64;
-            Neuron {
+            api::Neuron {
                 id: Some(NeuronId::from_u64(i)),
                 account: ledger::compute_neuron_staking_subaccount(controller, nonce).into(),
                 controller: Some(controller),
@@ -5596,7 +5598,7 @@ fn test_rate_limiting_neuron_creation() {
                 aging_since_timestamp_seconds: 0,
                 maturity_e8s_equivalent: 10 * E8,
                 staked_maturity_e8s_equivalent: Some(10 * E8),
-                dissolve_state: Some(DissolveState::DissolveDelaySeconds(
+                dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
                     VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
                 )),
                 ..Default::default()
@@ -7165,7 +7167,7 @@ fn test_disburse_to_neuron() {
     assert_eq!(child_neuron.account, to_subaccount);
 }
 
-fn governance_with_neurons(neurons: &[Neuron]) -> (fake::FakeDriver, Governance) {
+fn governance_with_neurons(neurons: &[api::Neuron]) -> (fake::FakeDriver, Governance) {
     let accounts: Vec<fake::FakeAccount> = neurons
         .iter()
         .map(|n| fake::FakeAccount {
@@ -7182,15 +7184,15 @@ fn governance_with_neurons(neurons: &[Neuron]) -> (fake::FakeDriver, Governance)
         .with_ledger_accounts(accounts)
         .with_supply(Tokens::from_tokens(100_000_000_000).unwrap());
 
-    let mut proto = empty_fixture();
-    proto.neurons.extend(
+    let mut governance_init = empty_fixture();
+    governance_init.neurons.extend(
         neurons
             .iter()
             .map(|n| (n.id.as_ref().unwrap().id, n.clone())),
     );
 
     let gov = Governance::new(
-        proto,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
@@ -7222,10 +7224,11 @@ async fn test_not_for_profit_neurons() {
     );
 
     let (_, mut gov) = governance_with_neurons(
-        &init_neurons
+        init_neurons
             .values()
-            .map(|n| n.clone().into())
-            .collect::<Vec<Neuron>>(),
+            .cloned()
+            .collect::<Vec<_>>()
+            .as_slice(),
     );
 
     let not_for_profit_neuron = init_neurons[&25].clone();
@@ -7305,10 +7308,11 @@ fn test_hot_keys_cant_change_followees_of_manage_neuron_topic() {
         .push(*second_neuron.controller.as_ref().unwrap());
 
     let (_, mut gov) = governance_with_neurons(
-        &init_neurons
+        init_neurons
             .values()
-            .map(|n| n.clone().into())
-            .collect::<Vec<Neuron>>(),
+            .cloned()
+            .collect::<Vec<_>>()
+            .as_slice(),
     );
 
     let first_neuron = init_neurons[&25].clone();
@@ -7374,10 +7378,11 @@ fn test_add_and_remove_hot_key() {
     let init_neurons = &mut builder.add_all_neurons_from_csv_file(&p).proto.neurons;
 
     let (_, mut gov) = governance_with_neurons(
-        &init_neurons
+        init_neurons
             .values()
-            .map(|n| n.clone().into())
-            .collect::<Vec<Neuron>>(),
+            .cloned()
+            .collect::<Vec<_>>()
+            .as_slice(),
     );
 
     let neuron = init_neurons[&25].clone();
@@ -7465,10 +7470,11 @@ fn test_manage_and_reward_node_providers() {
     let np_pid = PrincipalId::new_self_authenticating(&[14]);
 
     let (driver, mut gov) = governance_with_neurons(
-        &init_neurons
+        init_neurons
             .values()
-            .map(|n| n.clone().into())
-            .collect::<Vec<Neuron>>(),
+            .cloned()
+            .collect::<Vec<_>>()
+            .as_slice(),
     );
 
     println!(
@@ -7822,10 +7828,11 @@ fn test_manage_and_reward_multiple_node_providers() {
     let np_pid_2 = PrincipalId::new_self_authenticating(&[16]);
 
     let (driver, mut gov) = governance_with_neurons(
-        &init_neurons
+        init_neurons
             .values()
-            .map(|n| n.clone().into())
-            .collect::<Vec<Neuron>>(),
+            .cloned()
+            .collect::<Vec<_>>()
+            .as_slice(),
     );
 
     println!(
@@ -8197,10 +8204,11 @@ fn test_network_economics_proposal() {
         .into(),
     );
     let (_, mut gov) = governance_with_neurons(
-        &init_neurons
+        init_neurons
             .values()
-            .map(|n| n.clone().into())
-            .collect::<Vec<Neuron>>(),
+            .cloned()
+            .collect::<Vec<_>>()
+            .as_slice(),
     );
 
     gov.heap_data.economics.as_mut().unwrap().reject_cost_e8s = 1234;
@@ -8325,24 +8333,26 @@ fn test_recompute_tally() {
 }
 
 // Creates a Governance store with one dummy ExecuteNnsFunction proposal
-fn fixture_for_proposals(proposal_id: ProposalId, payload: Vec<u8>) -> GovernanceProto {
-    let execute_nns_function = ExecuteNnsFunction {
+fn fixture_for_proposals(proposal_id: ProposalId, payload: Vec<u8>) -> api::Governance {
+    let execute_nns_function = api::ExecuteNnsFunction {
         nns_function: NnsFunction::ClearProvisionalWhitelist as i32,
         payload,
     };
-    let proposal = Proposal {
+    let proposal = api::Proposal {
         title: Some("A Reasonable Title".to_string()),
-        action: Some(proposal::Action::ExecuteNnsFunction(execute_nns_function)),
+        action: Some(api::proposal::Action::ExecuteNnsFunction(
+            execute_nns_function,
+        )),
         ..Default::default()
     };
-    let proposal_data = ProposalData {
+    let proposal_data = api::ProposalData {
         id: Some(proposal_id),
         proposal: Some(proposal),
         topic: Some(Topic::NetworkEconomics as i32),
         ..Default::default()
     };
-    GovernanceProto {
-        economics: Some(NetworkEconomics::with_default_values()),
+    api::Governance {
+        economics: Some(api::NetworkEconomics::with_default_values()),
         proposals: once((proposal_id.id, proposal_data)).collect(),
         ..Default::default()
     }
@@ -8391,17 +8401,17 @@ async fn test_make_proposal_message() {
         ..new_motion_proposal()
     };
 
-    let proto = GovernanceProto {
+    let governance_init = api::Governance {
         wait_for_quiet_threshold_seconds: 100,
-        economics: Some(NetworkEconomics::with_default_values()),
+        economics: Some(api::NetworkEconomics::with_default_values()),
         neurons: btreemap! {
-            1 => Neuron {
+            1 => api::Neuron {
                 id: Some(NeuronId { id: 1 }),
                 controller: Some(principal1),
                 hot_keys: vec![],
                 cached_neuron_stake_e8s: 10 * E8,
                 account: driver.random_byte_array().expect("Could not get random byte array").to_vec(),
-                dissolve_state: Some(DissolveState::DissolveDelaySeconds(VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS)),
+                dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS)),
                 ..Default::default()
             },
         },
@@ -8409,7 +8419,7 @@ async fn test_make_proposal_message() {
     };
 
     let mut gov = Governance::new(
-        proto,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
@@ -8443,7 +8453,7 @@ async fn test_make_proposal_message() {
 #[tokio::test]
 async fn test_max_number_of_proposals_with_ballots() {
     let mut fake_driver = fake::FakeDriver::default();
-    let proto = GovernanceProto {
+    let proto = api::Governance {
         wait_for_quiet_threshold_seconds: 5,
         ..fixture_two_neurons_second_is_bigger()
     };
@@ -8577,19 +8587,17 @@ async fn test_max_number_of_proposals_with_ballots() {
 
 #[test]
 fn test_proposal_gc() {
-    let props = (1..1000)
-        .collect::<Vec<u64>>()
-        .iter()
-        .map(|x| {
+    let proposals = (1..1000)
+        .map(|id| {
             (
-                *x,
+                id,
                 ProposalData {
-                    id: Some(ProposalId { id: *x }),
+                    id: Some(ProposalId { id }),
                     decided_timestamp_seconds: 60,
                     reward_event_round: 1,
                     proposal: Some(Proposal {
                         title: Some("A Reasonable Title".to_string()),
-                        action: Some(if x % 2 == 0 {
+                        action: Some(if id % 2 == 0 {
                             Action::ManageNeuron(Box::new(ManageNeuron {
                                 ..Default::default()
                             }))
@@ -8604,21 +8612,21 @@ fn test_proposal_gc() {
                 },
             )
         })
-        .collect::<BTreeMap<u64, ProposalData>>();
-    let proto = GovernanceProto {
-        economics: Some(NetworkEconomics::with_default_values()),
-        proposals: props.clone(),
+        .collect::<BTreeMap<u64, _>>();
+    let governance_init = api::Governance {
+        economics: Some(api::NetworkEconomics::with_default_values()),
         ..Default::default()
     };
     // Set timestamp to 30 days
     let mut driver = fake::FakeDriver::default().at(60 * 60 * 24 * 30);
     let mut gov = Governance::new(
-        proto,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
+    gov.heap_data.proposals = proposals.clone();
     assert_eq!(999, gov.heap_data.proposals.len());
     // First check GC does not take place if
     // latest_gc_{timestamp_seconds|num_proposals} are both close to
@@ -8643,7 +8651,7 @@ fn test_proposal_gc() {
     // Running again, nothing should change...
     assert!(!gov.maybe_gc());
     // Reset all proposals.
-    gov.heap_data.proposals = props;
+    gov.heap_data.proposals = proposals;
     gov.latest_gc_timestamp_seconds = driver.now() - 60;
     gov.latest_gc_num_proposals = gov.heap_data.proposals.len() - 10;
     assert!(!gov.maybe_gc());
@@ -8684,20 +8692,20 @@ fn test_gc_ignores_exempt_proposals() {
             )
         })
         .collect::<BTreeMap<u64, ProposalData>>();
-    let proto = GovernanceProto {
-        economics: Some(NetworkEconomics::with_default_values()),
-        proposals: props.clone(),
+    let governance_init = api::Governance {
+        economics: Some(api::NetworkEconomics::with_default_values()),
         ..Default::default()
     };
     // Set timestamp to 30 days
     let driver = fake::FakeDriver::default().at(60 * 60 * 24 * 30);
     let mut gov = Governance::new(
-        proto,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
+    gov.heap_data.proposals = props;
     assert_eq!(999, gov.heap_data.proposals.len());
     gov.latest_gc_timestamp_seconds = driver.now() - 60;
     // Garbage collection should run, but not remove any of the exempt proposals
@@ -8856,9 +8864,9 @@ fn test_manage_neuron_merge_maturity_returns_expected_error() {
     let fake_driver = fake::FakeDriver::default();
     let id: u64 = 1;
     // This fixture works well for us since we just need a single neuron to make this call with.
-    let fixture: GovernanceProto = fixture_for_dissolving_neuron_tests(
+    let fixture = fixture_for_dissolving_neuron_tests(
         id,
-        DissolveState::DissolveDelaySeconds(
+        api::neuron::DissolveState::DissolveDelaySeconds(
             VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
         ),
         DEFAULT_TEST_START_TIMESTAMP_SECONDS,
@@ -8903,19 +8911,19 @@ fn test_manage_neuron_merge_maturity_returns_expected_error() {
 /// a given dissolve_state.
 fn fixture_for_dissolving_neuron_tests(
     id: u64,
-    dissolve_state: DissolveState,
+    dissolve_state: api::neuron::DissolveState,
     aging_since_timestamp_seconds: u64,
-) -> GovernanceProto {
-    GovernanceProto {
-        economics: Some(NetworkEconomics::default()),
+) -> api::Governance {
+    api::Governance {
+        economics: Some(api::NetworkEconomics::default()),
         neurons: btreemap! {
-            1 => Neuron {
+            1 => api::Neuron {
                 id: Some(NeuronId { id }),
                 account: account(id),
                 controller: Some(principal(id)),
                 dissolve_state: Some(dissolve_state),
                 aging_since_timestamp_seconds,
-                ..Neuron::default()
+                ..Default::default()
             }
         },
         ..Default::default()
@@ -8929,9 +8937,9 @@ fn fixture_for_dissolving_neuron_tests(
 fn test_start_dissolving() {
     let mut fake_driver = fake::FakeDriver::default();
     let id: u64 = 1;
-    let fixture: GovernanceProto = fixture_for_dissolving_neuron_tests(
+    let fixture = fixture_for_dissolving_neuron_tests(
         id,
-        DissolveState::DissolveDelaySeconds(
+        api::neuron::DissolveState::DissolveDelaySeconds(
             VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
         ),
         DEFAULT_TEST_START_TIMESTAMP_SECONDS,
@@ -8989,9 +8997,11 @@ fn test_start_dissolving() {
 fn test_start_dissolving_panics() {
     let fake_driver = fake::FakeDriver::default();
     let id: u64 = 1;
-    let fixture: GovernanceProto = fixture_for_dissolving_neuron_tests(
+    let fixture = fixture_for_dissolving_neuron_tests(
         id,
-        DissolveState::WhenDissolvedTimestampSeconds(DEFAULT_TEST_START_TIMESTAMP_SECONDS),
+        api::neuron::DissolveState::WhenDissolvedTimestampSeconds(
+            DEFAULT_TEST_START_TIMESTAMP_SECONDS,
+        ),
         u64::MAX,
     );
     let mut gov = Governance::new(
@@ -9033,9 +9043,9 @@ fn test_start_dissolving_panics() {
 fn test_stop_dissolving() {
     let mut fake_driver = fake::FakeDriver::default();
     let id: u64 = 1;
-    let fixture: GovernanceProto = fixture_for_dissolving_neuron_tests(
+    let fixture = fixture_for_dissolving_neuron_tests(
         id,
-        DissolveState::WhenDissolvedTimestampSeconds(
+        api::neuron::DissolveState::WhenDissolvedTimestampSeconds(
             DEFAULT_TEST_START_TIMESTAMP_SECONDS
                 + VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
         ),
@@ -9097,9 +9107,9 @@ fn test_stop_dissolving() {
 fn test_stop_dissolving_panics() {
     let fake_driver = fake::FakeDriver::default();
     let id: u64 = 1;
-    let fixture: GovernanceProto = fixture_for_dissolving_neuron_tests(
+    let fixture = fixture_for_dissolving_neuron_tests(
         id,
-        DissolveState::DissolveDelaySeconds(
+        api::neuron::DissolveState::DissolveDelaySeconds(
             VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
         ),
         DEFAULT_TEST_START_TIMESTAMP_SECONDS,
@@ -9242,38 +9252,38 @@ fn increase_dissolve_delay(
 fn test_increase_dissolve_delay() {
     let principal_id = 1;
     let fake_driver = fake::FakeDriver::default();
-    let fixture: GovernanceProto = GovernanceProto {
-        economics: Some(NetworkEconomics::default()),
+    let fixture = api::Governance {
+        economics: Some(api::NetworkEconomics::default()),
         neurons: btreemap! {
-            1 => Neuron {
+            1 => api::Neuron {
                 id: Some(NeuronId { id: 1 }),
                 account: account(1),
                 controller: Some(principal(principal_id)),
-                dissolve_state: Some(DissolveState::DissolveDelaySeconds(
+                dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
                     VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
                 )),
-                ..Neuron::default()
+                ..Default::default()
             },
-            2 => Neuron {
+            2 => api::Neuron {
                 id: Some(NeuronId { id: 2 }),
                 account: account(2),
                 controller: Some(principal(principal_id)),
-                dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(
+                dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(
                     DEFAULT_TEST_START_TIMESTAMP_SECONDS
                         + VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
                 )),
                 aging_since_timestamp_seconds: u64::MAX,
-                ..Neuron::default()
+                ..Default::default()
             },
-            3 => Neuron {
+            3 => api::Neuron {
                 id: Some(NeuronId { id: 3 }),
                 account: account(3),
                 controller: Some(principal(principal_id)),
-                dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(
+                dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(
                     DEFAULT_TEST_START_TIMESTAMP_SECONDS - 1,
                 )),
                 aging_since_timestamp_seconds: u64::MAX,
-                ..Neuron::default()
+                ..Default::default()
             }
         },
         ..Default::default()
@@ -9390,35 +9400,35 @@ fn test_join_neurons_fund() {
     let now = 778899;
     let principal_a = 42;
     let principal_b = 128;
-    let fixture: GovernanceProto = GovernanceProto {
-        economics: Some(NetworkEconomics::default()),
+    let fixture = api::Governance {
+        economics: Some(api::NetworkEconomics::default()),
         neurons: btreemap! {
-            1 => Neuron {
+            1 => api::Neuron {
                 id: Some(NeuronId { id: 1 }),
                 account: account(1),
                 cached_neuron_stake_e8s: 10 * E8,
                 controller: Some(principal(principal_a)),
-                dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+                dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
-                ..Neuron::default()
+                ..Default::default()
             },
-            2 => Neuron {
+            2 => api::Neuron {
                 id: Some(NeuronId { id: 2 }),
                 account: account(2),
                 cached_neuron_stake_e8s: 20 * 100_000_000,
                 controller: Some(principal(principal_b)),
-                dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+                dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
-                ..Neuron::default()
+                ..Default::default()
             },
-            3 => Neuron {
+            3 => api::Neuron {
                 id: Some(NeuronId { id: 3 }),
                 account: account(3),
                 cached_neuron_stake_e8s: 100 * 100_000_000,
                 controller: Some(principal(principal_b)),
-                dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(0)),
+                dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(0)),
                 aging_since_timestamp_seconds: u64::MAX,
-                ..Neuron::default()
+                ..Default::default()
             }
         },
         ..Default::default()
@@ -9734,7 +9744,7 @@ fn test_neuron_set_visibility() {
 
     let controller = PrincipalId::new_user_test_id(1);
 
-    let typical_neuron = Neuron {
+    let typical_neuron = api::Neuron {
         // The last line in this block already has this effect, making this line
         // technically superfluous. However, since this is the operative field
         // to this test, we want to be explicit.
@@ -9744,27 +9754,31 @@ fn test_neuron_set_visibility() {
         account: account(1),
         cached_neuron_stake_e8s: 10 * E8,
         controller: Some(controller),
-        dissolve_state: Some(DissolveState::DissolveDelaySeconds(ONE_YEAR_SECONDS)),
+        dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
+            ONE_YEAR_SECONDS,
+        )),
         aging_since_timestamp_seconds: 1_721_727_936,
-        ..Neuron::default()
+        ..Default::default()
     };
 
     // The salient difference between this and typical_neuron is that this is a
     // known neuron. In particular, this has the same controller.
-    let known_neuron = Neuron {
-        known_neuron_data: Some(KnownNeuronData::default()),
+    let known_neuron = api::Neuron {
+        known_neuron_data: Some(api::KnownNeuronData::default()),
 
         id: Some(NeuronId { id: 2 }),
         account: account(2),
         cached_neuron_stake_e8s: 10 * E8,
         controller: Some(controller),
-        dissolve_state: Some(DissolveState::DissolveDelaySeconds(ONE_YEAR_SECONDS)),
+        dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
+            ONE_YEAR_SECONDS,
+        )),
         aging_since_timestamp_seconds: 1_721_727_936,
-        ..Neuron::default()
+        ..Default::default()
     };
 
-    let governance_proto = GovernanceProto {
-        economics: Some(NetworkEconomics::default()),
+    let governance_init = api::Governance {
+        economics: Some(api::NetworkEconomics::default()),
         neurons: btreemap! {
             1 => typical_neuron.clone(),
             2 => known_neuron.clone(),
@@ -9777,7 +9791,7 @@ fn test_neuron_set_visibility() {
         .at(60 * 60 * 24 * 30)
         .with_supply(total_icp_suppply);
     let mut governance = Governance::new(
-        governance_proto,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
@@ -9854,7 +9868,7 @@ fn test_neuron_set_visibility() {
 fn test_deciding_and_potential_voting_power() {
     // Step 1: Prepare the world.
 
-    let neuron = Neuron {
+    let neuron = api::Neuron {
         id: Some(NeuronId { id: 42 }),
         controller: Some(PrincipalId::new_user_test_id(42)),
         account: account(42),
@@ -9862,7 +9876,9 @@ fn test_deciding_and_potential_voting_power() {
         // Factors that affect POTENTIAL voting power.
         cached_neuron_stake_e8s: 10 * E8, // Base
         // Bonuses factors.
-        dissolve_state: Some(DissolveState::DissolveDelaySeconds(8 * ONE_YEAR_SECONDS)),
+        dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
+            8 * ONE_YEAR_SECONDS,
+        )),
         // (Remember, birth day does not change with time, but age does...)
         aging_since_timestamp_seconds: START_TIMESTAMP_SECONDS,
 
@@ -9874,8 +9890,8 @@ fn test_deciding_and_potential_voting_power() {
 
     let controller = neuron.controller.unwrap();
 
-    let governance_proto = GovernanceProto {
-        economics: Some(NetworkEconomics::with_default_values()),
+    let governance_init = api::Governance {
+        economics: Some(api::NetworkEconomics::with_default_values()),
         neurons: btreemap! {
             42 => neuron,
         },
@@ -9887,7 +9903,7 @@ fn test_deciding_and_potential_voting_power() {
         .with_supply(Tokens::new(200, 0).unwrap());
 
     let governance = Governance::new(
-        governance_proto,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
@@ -10080,14 +10096,14 @@ fn test_include_public_neurons_in_full_neurons() {
         ..legacy_neuron.clone()
     };
 
-    let governance_proto = GovernanceProto {
-        economics: Some(NetworkEconomics::default()),
+    let governance_init = api::Governance {
+        economics: Some(api::NetworkEconomics::default()),
         neurons: btreemap! {
-            1 => Neuron::from(legacy_neuron.clone()),
-            2 => Neuron::from(known_neuron.clone()),
-            3 => Neuron::from(explicitly_private_neuron.clone()),
-            4 => Neuron::from(explicitly_public_neuron.clone()),
-            5 => Neuron::from(caller_controlled_neuron.clone()),
+            1 => legacy_neuron.clone(),
+            2 => known_neuron.clone(),
+            3 => explicitly_private_neuron.clone(),
+            4 => explicitly_public_neuron.clone(),
+            5 => caller_controlled_neuron.clone(),
         },
         ..Default::default()
     };
@@ -10097,7 +10113,7 @@ fn test_include_public_neurons_in_full_neurons() {
         .at(START_TIMESTAMP_SECONDS)
         .with_supply(total_icp_suppply);
     let governance = Governance::new(
-        governance_proto,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
@@ -10161,21 +10177,23 @@ async fn test_refresh_voting_power() {
     let controller = PrincipalId::new_user_test_id(42);
     let hot_key = PrincipalId::new_user_test_id(43);
 
-    let neuron = Neuron {
+    let neuron = api::Neuron {
         id: Some(NeuronId { id: 42 }),
         account: account(42),
         hot_keys: vec![hot_key],
         cached_neuron_stake_e8s: 10 * E8,
         controller: Some(controller),
-        dissolve_state: Some(DissolveState::DissolveDelaySeconds(ONE_YEAR_SECONDS)),
+        dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
+            ONE_YEAR_SECONDS,
+        )),
         aging_since_timestamp_seconds: 1_721_727_936,
         voting_power_refreshed_timestamp_seconds: Some(START_TIMESTAMP_SECONDS),
 
         ..Default::default()
     };
 
-    let governance_proto = GovernanceProto {
-        economics: Some(NetworkEconomics::default()),
+    let governance_init = api::Governance {
+        economics: Some(api::NetworkEconomics::default()),
         neurons: btreemap! {
             42 => neuron,
         },
@@ -10188,7 +10206,7 @@ async fn test_refresh_voting_power() {
         .with_supply(total_icp_suppply);
 
     let mut governance = Governance::new(
-        governance_proto,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
@@ -10315,13 +10333,13 @@ fn wait_for_quiet_test_helper(
     let neurons = neuron_votes
         .iter()
         .enumerate()
-        .map(|(i, neuron_vote)| Neuron {
+        .map(|(i, neuron_vote)| api::Neuron {
             id: Some(NeuronId { id: i as u64 }),
             account: account(i as u64),
             dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
             controller: Some(principal(i as u64)),
             cached_neuron_stake_e8s: neuron_vote.stake,
-            ..Neuron::default()
+            ..api::Neuron::default()
         })
         .collect();
 
@@ -11196,10 +11214,8 @@ fn test_wfq_constant_flipping() {
 async fn test_known_neurons() {
     let mut driver = fake::FakeDriver::default();
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     let neurons = vec![
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: 1 }),
             account: driver
                 .random_byte_array()
@@ -11207,12 +11223,12 @@ async fn test_known_neurons() {
                 .to_vec(),
             controller: Some(principal(1)),
             cached_neuron_stake_e8s: 100_000_000,
-            dissolve_state: Some(DissolveState::DissolveDelaySeconds(
+            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
                 MAX_DISSOLVE_DELAY_SECONDS,
             )),
             ..Default::default()
         },
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: 2 }),
             account: driver
                 .random_byte_array()
@@ -11220,12 +11236,12 @@ async fn test_known_neurons() {
                 .to_vec(),
             controller: Some(principal(2)),
             cached_neuron_stake_e8s: 100_000_000,
-            dissolve_state: Some(DissolveState::DissolveDelaySeconds(
+            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
                 MAX_DISSOLVE_DELAY_SECONDS,
             )),
             ..Default::default()
         },
-        Neuron {
+        api::Neuron {
             id: Some(NeuronId { id: 3 }),
             account: driver
                 .random_byte_array()
@@ -11233,7 +11249,7 @@ async fn test_known_neurons() {
                 .to_vec(),
             controller: Some(principal(3)),
             cached_neuron_stake_e8s: 100_000_000_000,
-            dissolve_state: Some(DissolveState::DissolveDelaySeconds(
+            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
                 MAX_DISSOLVE_DELAY_SECONDS,
             )),
             ..Default::default()
@@ -11242,7 +11258,7 @@ async fn test_known_neurons() {
 
     let governance_proto = GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .build();
 
@@ -11584,17 +11600,17 @@ lazy_static! {
     // Collectively, the Neurons' Fund neurons have 100e-8 ICP in maturity.
     // Neurons 1 and 2 belong to principal(1); neuron 3 belongs to principal(2).
     // Neuron 4 also belongs to principal(1), but is NOT a Neurons' Fund neuron.
-    static ref SWAP_ID_TO_NEURON: Vec<Neuron> = {
-        let neuron_base = Neuron {
+    static ref SWAP_ID_TO_NEURON: Vec<api::Neuron> = {
+        let neuron_base = api::Neuron {
             cached_neuron_stake_e8s: 100_000 * E8,
-            dissolve_state: Some(DissolveState::DissolveDelaySeconds(
+            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
                 MAX_DISSOLVE_DELAY_SECONDS,
             )),
             ..Default::default()
         };
 
         vec![
-            Neuron {
+            api::Neuron {
                 id: Some(NeuronId { id: 1 }),
                 account: account(1),
                 controller: Some(principal(1)),
@@ -11602,7 +11618,7 @@ lazy_static! {
                 joined_community_fund_timestamp_seconds: Some(1),
                 ..neuron_base.clone()
             },
-            Neuron {
+            api::Neuron {
                 id: Some(NeuronId { id: 2 }),
                 account: account(2),
                 controller: Some(principal(1)),
@@ -11610,7 +11626,7 @@ lazy_static! {
                 joined_community_fund_timestamp_seconds: Some(1),
                 ..neuron_base.clone()
             },
-            Neuron {
+            api::Neuron {
                 id: Some(NeuronId { id: 3 }),
                 account: account(3),
                 controller: Some(principal(2)),
@@ -11620,7 +11636,7 @@ lazy_static! {
             },
 
             // Unlike the foregoing neurons, this one is NOT a CF neuron.
-            Neuron {
+            api::Neuron {
                 id: Some(NeuronId { id: 4 }),
                 account: account(4),
                 controller: Some(principal(1)),
@@ -12252,13 +12268,11 @@ async fn test_settle_neurons_fund_participation_restores_lifecycle_on_sns_w_fail
 
     // Step 1: Prepare the world.
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     let neurons = SWAP_ID_TO_NEURON.clone();
 
     let governance_proto = GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .build();
 
@@ -12385,13 +12399,11 @@ async fn test_settle_neurons_fund_participation_restores_lifecycle_on_ledger_fai
 
     // Step 1: Prepare the world.
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     let neurons = SWAP_ID_TO_NEURON.clone();
 
     let governance_proto = GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .build();
 
@@ -12512,7 +12524,7 @@ async fn test_settle_neurons_fund_participation_restores_lifecycle_on_ledger_fai
     assert_eq!(proposal.neurons_fund_data, *NEURONS_FUND_DATA_BEFORE_SETTLE);
 }
 
-fn assert_neurons_fund_unchanged(gov: &Governance, original_state: Vec<Neuron>) {
+fn assert_neurons_fund_unchanged(gov: &Governance, original_state: Vec<api::Neuron>) {
     for original_neuron in original_state {
         let id = original_neuron.id.unwrap().id;
         let current_neuron = gov
@@ -12530,13 +12542,11 @@ fn assert_neurons_fund_unchanged(gov: &Governance, original_state: Vec<Neuron>) 
 async fn test_create_service_nervous_system_failure_due_to_swap_deployment_error() {
     // Step 1: Prepare the world.
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     let neurons = SWAP_ID_TO_NEURON.clone();
 
     let governance_proto = GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .build();
 
@@ -12631,13 +12641,11 @@ async fn test_create_service_nervous_system_failure_due_to_swap_deployment_error
 async fn test_create_service_nervous_system_settles_neurons_fund_commit() {
     // Step 1: Prepare the world.
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     let neurons = SWAP_ID_TO_NEURON.clone();
 
     let governance_proto = GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .build();
 
@@ -12779,13 +12787,11 @@ async fn test_create_service_nervous_system_settles_neurons_fund_commit() {
 async fn test_create_service_nervous_system_settles_neurons_fund_abort() {
     // Step 1: Prepare the world.
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     let neurons = SWAP_ID_TO_NEURON.clone();
 
     let governance_proto = GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .build();
 
@@ -12927,13 +12933,11 @@ async fn test_create_service_nervous_system_settles_neurons_fund_abort() {
 async fn test_create_service_nervous_system_proposal_execution_fails() {
     // Step 1: Prepare the world.
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     let neurons = SWAP_ID_TO_NEURON.clone();
 
     let governance_proto = GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .build();
 
@@ -13036,14 +13040,12 @@ async fn test_create_service_nervous_system_proposal_execution_fails() {
 async fn test_settle_neurons_fund_is_idempotent_for_create_service_nervous_system() {
     use settle_neurons_fund_participation_request::{Committed, Result};
 
-    let network_economics = NetworkEconomics::with_default_values();
-
     let neurons = SWAP_ID_TO_NEURON.clone();
 
     // Step 1: Prepare the world.
     let governance_proto = GovernanceProtoBuilder::new()
         .with_instant_neuron_operations()
-        .with_economics(network_economics)
+        .with_economics(api::NetworkEconomics::with_default_values())
         .with_neurons(neurons)
         .build();
 
@@ -13226,17 +13228,19 @@ async fn distribute_rewards_test() {
     let neuron_range = 100..200;
     let neurons = neuron_range
         .clone()
-        .map(|id| Neuron {
+        .map(|id| api::Neuron {
             id: Some(NeuronId { id }),
             account: account(id),
             controller: Some(principal(id)),
             cached_neuron_stake_e8s: 1_000_000_000,
             maturity_e8s_equivalent: starting_maturity,
-            dissolve_state: Some(DissolveState::DissolveDelaySeconds(ONE_YEAR_SECONDS)),
+            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(
+                ONE_YEAR_SECONDS,
+            )),
             aging_since_timestamp_seconds: now - 1,
             ..Default::default()
         })
-        .collect::<Vec<Neuron>>();
+        .collect::<Vec<api::Neuron>>();
 
     // Step 1.2: Craft many ProposalData objects.
     let wait_for_quiet_threshold_seconds = 99;
@@ -13276,29 +13280,22 @@ async fn distribute_rewards_test() {
         .collect();
 
     // Step 1.3: Craft a Governance.
-    let proto = GovernanceProto {
+    let governance_init = api::Governance {
         genesis_timestamp_seconds,
         wait_for_quiet_threshold_seconds,
         short_voting_period_seconds: wait_for_quiet_threshold_seconds,
         neuron_management_voting_period_seconds: Some(wait_for_quiet_threshold_seconds),
-
-        proposals: proposal_data_list
-            .iter()
-            .map(|p| (p.id.unwrap().id, p.clone()))
-            .collect(),
+        economics: Some(api::NetworkEconomics {
+            max_proposals_to_keep_per_topic: 9999,
+            ..Default::default()
+        }),
         neurons: neurons
             .iter()
             .map(|n| (n.id.as_ref().unwrap().id, n.clone()))
             .collect(),
-
-        economics: Some(NetworkEconomics {
-            max_proposals_to_keep_per_topic: 9999,
-            ..Default::default()
-        }),
-
         // Last reward event was a "long time ago".
         // This should cause rewards to be distributed.
-        latest_reward_event: Some(RewardEvent {
+        latest_reward_event: Some(api::RewardEvent {
             day_after_genesis: 1,
             actual_timestamp_seconds: 1,
             settled_proposals: vec![],
@@ -13310,13 +13307,18 @@ async fn distribute_rewards_test() {
 
         ..Default::default()
     };
-    let governance = Governance::new(
-        proto,
+    let mut governance = Governance::new(
+        governance_init,
         helper.get_fake_env(),
         helper.get_fake_ledger(),
         helper.get_fake_cmc(),
         helper.get_fake_randomness_generator(),
     );
+    governance.heap_data.proposals = proposal_data_list
+        .iter()
+        .map(|p| (p.id.unwrap().id, p.clone()))
+        .collect();
+
     set_governance_for_tests(governance);
     let governance = governance_mut();
     schedule_tasks();
@@ -13450,17 +13452,17 @@ fn test_ready_to_be_settled_proposals_ids() {
     let end_of_reward_round_1_timestamp_seconds =
         genesis_timestamp_seconds + REWARD_DISTRIBUTION_PERIOD_SECONDS;
     // Enters reward_status == ReadyToSettle just before the end of round 1.
-    let proposal_1 = ProposalData {
+    let proposal_1 = api::ProposalData {
         id: Some(ProposalId { id: 1 }),
-        wait_for_quiet_state: Some(WaitForQuietState {
+        wait_for_quiet_state: Some(api::WaitForQuietState {
             current_deadline_timestamp_seconds: end_of_reward_round_1_timestamp_seconds - 5,
         }),
         ..Default::default()
     };
     // Enters reward_status == ReadyToSettle shortly after end of round 1.
-    let proposal_2 = ProposalData {
+    let proposal_2 = api::ProposalData {
         id: Some(ProposalId { id: 2 }),
-        wait_for_quiet_state: Some(WaitForQuietState {
+        wait_for_quiet_state: Some(api::WaitForQuietState {
             current_deadline_timestamp_seconds: end_of_reward_round_1_timestamp_seconds + 5,
         }),
         ..Default::default()
@@ -13528,53 +13530,53 @@ fn test_ready_to_be_settled_proposals_ids() {
 #[tokio::test]
 async fn test_metrics() {
     let now = 100;
-    let neurons: BTreeMap<u64, Neuron> = btreemap! {
+    let neurons = btreemap! {
         // Not Dissolving neurons: 100m + 200m.
-        1 => Neuron {
+        1 => api::Neuron {
             id: Some(NeuronId {
                 id: 1
             }),
             account: account(1),
             controller: Some(principal(1)),
             cached_neuron_stake_e8s: 100_000_000,
-            dissolve_state: Some(DissolveState::DissolveDelaySeconds(1)),
+            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(1)),
             neuron_type: Some(NeuronType::Seed as i32),
             ..Default::default()
         },
-        2 => Neuron {
+        2 => api::Neuron {
             id: Some(NeuronId {
                 id: 2
             }),
             account: account(2),
             controller: Some(principal(2)),
             cached_neuron_stake_e8s: 200_000_000,
-            dissolve_state: Some(DissolveState::DissolveDelaySeconds(ONE_YEAR_SECONDS)),
+            dissolve_state: Some(api::neuron::DissolveState::DissolveDelaySeconds(ONE_YEAR_SECONDS)),
             neuron_type: Some(NeuronType::Ect as i32),
             ..Default::default()
         },
         // Dissolving neurons: 300m.
-        3 => Neuron {
+        3 => api::Neuron {
             id: Some(NeuronId {
                 id: 3
             }),
             account: account(3),
             controller: Some(principal(3)),
             cached_neuron_stake_e8s: 300_000_000,
-            dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(
+            dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(
                 now + ONE_YEAR_SECONDS * 3,
             )),
             aging_since_timestamp_seconds: u64::MAX,
             ..Default::default()
         },
         // Dissolved neurons: 400m.
-        4 => Neuron {
+        4 => api::Neuron {
             id: Some(NeuronId {
                 id: 4
             }),
             account: account(4),
             controller: Some(principal(4)),
             cached_neuron_stake_e8s: 400_000_000,
-            dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(
+            dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(
                 0,
             )),
             aging_since_timestamp_seconds: u64::MAX,
@@ -13582,12 +13584,12 @@ async fn test_metrics() {
         }
     };
 
-    let economics = NetworkEconomics {
+    let economics = api::NetworkEconomics {
         neuron_minimum_stake_e8s: 100_000_000,
         ..Default::default()
     };
 
-    let gov = GovernanceProto {
+    let governance_init = api::Governance {
         economics: Some(economics),
         neurons,
         ..Default::default()
@@ -13649,7 +13651,7 @@ async fn test_metrics() {
 
     let driver = fake::FakeDriver::default().at(60 * 60 * 24 * 30);
     let mut gov = Governance::new(
-        gov,
+        governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
         driver.get_fake_cmc(),
@@ -13864,7 +13866,7 @@ fn swap_start_and_due_timestamps_if_start_time_is_when_swap_approved() {
 fn randomly_pick_swap_start() {
     let fake_driver = fake::FakeDriver::default();
     let mut gov = Governance::new(
-        GovernanceProto::default(),
+        Default::default(),
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
         fake_driver.get_fake_cmc(),
@@ -13917,9 +13919,8 @@ fn compute_closest_proposal_deadline_timestamp_seconds_no_wfq_fallback() {
     };
 
     let fake_driver = fake::FakeDriver::default();
-    let gov = Governance::new(
-        GovernanceProto {
-            proposals: btreemap! {1 => proposal_1},
+    let mut gov = Governance::new(
+        api::Governance {
             short_voting_period_seconds: 1,
             neuron_management_voting_period_seconds: Some(1),
             wait_for_quiet_threshold_seconds: proposal_voting_period,
@@ -13930,6 +13931,7 @@ fn compute_closest_proposal_deadline_timestamp_seconds_no_wfq_fallback() {
         fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
+    gov.heap_data.proposals.insert(1, proposal_1);
 
     // Check that the closest deadline is the one for the proposal we injected.
     // Since its wait_for_quiet_state is None, the deadline should default to
@@ -13968,9 +13970,8 @@ fn compute_closest_proposal_deadline_timestamp_seconds_incorporates_wfq() {
     };
 
     let fake_driver = fake::FakeDriver::default();
-    let gov = Governance::new(
-        GovernanceProto {
-            proposals: btreemap! {1 => proposal_1},
+    let mut gov = Governance::new(
+        api::Governance {
             short_voting_period_seconds: 1,
             neuron_management_voting_period_seconds: Some(1),
             wait_for_quiet_threshold_seconds: proposal_voting_period,
@@ -13981,6 +13982,7 @@ fn compute_closest_proposal_deadline_timestamp_seconds_incorporates_wfq() {
         fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
+    gov.heap_data.proposals.insert(1, proposal_1);
 
     // Check that the closest deadline is the one for the proposal we injected,
     // based on its wait_for_quiet period rather than its default deadline.
@@ -14071,16 +14073,14 @@ fn test_neuron_info_private_enforcement() {
     let base_neuron = {
         let controller = Some(controller);
         let hot_keys = vec![hot_key];
-        let recent_ballots = recent_ballots
-            .iter()
-            .cloned()
-            .map(BallotInfo::from)
-            .collect();
+        let recent_ballots = recent_ballots.clone();
 
-        let dissolve_state = Some(DissolveState::DissolveDelaySeconds(random.gen()));
+        let dissolve_state = Some(api::neuron::DissolveState::DissolveDelaySeconds(
+            random.gen(),
+        ));
         let cached_neuron_stake_e8s = random.gen();
 
-        Neuron {
+        api::Neuron {
             controller,
             hot_keys,
             recent_ballots,
@@ -14099,23 +14099,23 @@ fn test_neuron_info_private_enforcement() {
         let id = Some(NeuronId { id: random.gen() });
         let account = (0..32).map(|_| random.gen()).collect();
 
-        Neuron {
+        api::Neuron {
             id,
             account,
             ..base_neuron.clone()
         }
     };
     let no_explicit_visibility_neuron = new_neuron();
-    let private_neuron = Neuron {
+    let private_neuron = api::Neuron {
         visibility: Some(Visibility::Private as i32),
         ..new_neuron()
     };
-    let public_neuron = Neuron {
+    let public_neuron = api::Neuron {
         visibility: Some(Visibility::Public as i32),
         ..new_neuron()
     };
-    let known_neuron = Neuron {
-        known_neuron_data: Some(KnownNeuronData {
+    let known_neuron = api::Neuron {
+        known_neuron_data: Some(api::KnownNeuronData {
             name: "Hello, world!".to_string(),
             description: Some("All the best votes.".to_string()),
         }),

--- a/rs/nns/governance/tests/monitoring.rs
+++ b/rs/nns/governance/tests/monitoring.rs
@@ -1,8 +1,8 @@
 use crate::fake::FakeDriver;
 use ic_nns_governance::{
     encode_metrics, governance::Governance, governance_proto_builder::GovernanceProtoBuilder,
-    pb::v1::RewardEvent,
 };
+use ic_nns_governance_api::RewardEvent;
 
 // Using a `pub mod` works around spurious dead code warnings; see
 // https://github.com/rust-lang/rust/issues/46379
@@ -14,7 +14,7 @@ pub mod common;
 
 #[test]
 fn test_reward_event_amounts_metrics() {
-    let governance_proto = GovernanceProtoBuilder::new()
+    let governance_api = GovernanceProtoBuilder::new()
         .with_latest_reward_event(RewardEvent {
             total_available_e8s_equivalent: 100,
             ..Default::default()
@@ -24,7 +24,7 @@ fn test_reward_event_amounts_metrics() {
     let helpers = FakeDriver::default();
 
     let governance = Governance::new(
-        governance_proto,
+        governance_api,
         helpers.get_fake_env(),
         helpers.get_fake_ledger(),
         helpers.get_fake_cmc(),

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -7,12 +7,12 @@ use ic_nns_governance::timer_tasks::schedule_tasks;
 use ic_nns_governance::{
     governance::{Governance, REWARD_DISTRIBUTION_PERIOD_SECONDS},
     pb::v1::{
-        neuron::DissolveState, proposal::Action, Ballot, Governance as GovernanceProto,
-        NetworkEconomics, Neuron, Proposal, ProposalData, ProposalRewardStatus, Topic, Vote,
+        proposal::Action, Ballot, Proposal, ProposalData, ProposalRewardStatus, Topic, Vote,
         WaitForQuietState,
     },
     proposals::sum_weighted_voting_power,
 };
+use ic_nns_governance_api as api;
 use icp_ledger::Tokens;
 use lazy_static::lazy_static;
 use maplit::{btreemap, hashmap};
@@ -25,26 +25,26 @@ pub mod fake;
 const NOW_SECONDS: u64 = 1735689600;
 
 lazy_static! {
-    static ref NEURONS: BTreeMap<u64, Neuron> = {
-        let base = Neuron {
+    static ref NEURONS: BTreeMap<u64, api::Neuron> = {
+        let base = api::Neuron {
             controller: Some(PrincipalId::new_user_test_id(783_068_996)),
-            dissolve_state: Some(DissolveState::WhenDissolvedTimestampSeconds(NOW_SECONDS)),
+            dissolve_state: Some(api::neuron::DissolveState::WhenDissolvedTimestampSeconds(NOW_SECONDS)),
             aging_since_timestamp_seconds: u64::MAX,
             ..Default::default()
         };
 
         let result = btreemap! {
-            1042 => Neuron {
+            1042 => api::Neuron {
                 id: Some(NeuronId { id: 1042 }),
                 account: vec![42; 32],
                 ..base.clone()
             },
-            1043 => Neuron {
+            1043 => api::Neuron {
                 id: Some(NeuronId { id: 1043 }),
                 account: vec![43; 32],
                 ..base.clone()
             },
-            1044 => Neuron {
+            1044 => api::Neuron {
                 id: Some(NeuronId { id: 1044 }),
                 account: vec![44; 32],
                 ..base.clone()
@@ -169,14 +169,6 @@ lazy_static! {
 
         proposals
     };
-
-    static ref GOVERNANCE_PROTO: GovernanceProto = GovernanceProto {
-        neurons: NEURONS.clone(),
-        proposals: PROPOSALS.clone(),
-        genesis_timestamp_seconds: NOW_SECONDS - REWARD_DISTRIBUTION_PERIOD_SECONDS,
-        economics: Some(NetworkEconomics::with_default_values()),
-        ..Default::default()
-    };
 }
 
 #[test]
@@ -219,13 +211,20 @@ async fn test_distribute_rewards_with_total_potential_voting_power() {
         .at(NOW_SECONDS)
         .with_supply(Tokens::from_tokens(100).unwrap());
 
-    let governance = Governance::new(
-        GOVERNANCE_PROTO.clone(),
+    let governance_init = api::Governance {
+        neurons: NEURONS.clone(),
+        genesis_timestamp_seconds: NOW_SECONDS - REWARD_DISTRIBUTION_PERIOD_SECONDS,
+        economics: Some(api::NetworkEconomics::with_default_values()),
+        ..Default::default()
+    };
+    let mut governance = Governance::new(
+        governance_init,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
         fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
+    governance.heap_data.proposals = PROPOSALS.clone();
 
     set_governance_for_tests(governance);
     let governance = governance_mut();


### PR DESCRIPTION
# Why

The overall goal is to remove `GovernanceProto::neurons` as it's always empty in production (since neurons live in stable memory). However, the very field is often used in testing, where the field contains the "initial neurons" which then get passed to `NeuronStore::new`. 

In addition, it's unnecessary to have the exact same fields on the API type as the internal type, as some of the internal types should not be initialized from the outside. By having `Governance::new` take the API type directly, we can make it possible to gradually shrink down the fields on the API Governance type, especially those that should be considered internal (e.g. `making_sns_proposal`, `spawning_neurons`).

# What

* Inline the `api::Governance->GovernanceProto` conversion into `Governance::new`
* Fix all tests using `Governance::new`:
  * For most fields, use their API types instead
  * For neurons needed within the ic_nns_governace crate, use `add_neuron` method
  * For neurons needed outside of the ic_nns_governance crate, use the API types.
    * Ideally, we should have fewer of those tests whose setup involves manipulating the exact neuron fields. In fact, most of those tests should exist within the governance crate. However, such transition can be done gradually.

# Next Steps

* The `Governance::new` now calls the conversion and then fill in some default fields, those can be done together by destructure->fill defaults->construct.