### PR TITLE
fix(fuzzing): Fix path for GCP key

### DIFF
--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           FUZZING_GCP_SERVICE_KEY: ${{ secrets.FUZZING_GCP_SERVICE_KEY }}
         run: |
-          echo $FUZZING_GCP_SERVICE_KEY | base64 --decode > bin/fuzzing_service_account.json
+          echo $FUZZING_GCP_SERVICE_KEY | base64 --decode > bin/fuzzing/fuzzing_service_account.json
       - name: Build and Push Fuzzers to GCP
         shell: bash
         run: |


### PR DESCRIPTION
In #4744, all fuzzing scripts were moved from `bin` to `bin/fuzzing`. However, the GCP key path wasn't properly adapted for it and has caused the schedule-weekly job to fail for a [while](https://github.com/dfinity/ic/actions/workflows/schedule-weekly.yml)