### PR TITLE
chore: bump ic-management-canister-types to 0.3.1

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5e28c1de0af6e84f24865ae66dd1471bc2527274516e0e8a6c44110ad1328ca2",
+  "checksum": "64c49509d47ed140ddc08b3efc7bfa814c2266d019d75d0e2e5c8b07861b577e",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20507,7 +20507,7 @@
               "target": "ic_http_gateway"
             },
             {
-              "id": "ic-management-canister-types 0.3.0",
+              "id": "ic-management-canister-types 0.3.1",
               "target": "ic_management_canister_types"
             },
             {
@@ -33204,7 +33204,7 @@
               "target": "ic_error_types"
             },
             {
-              "id": "ic-management-canister-types 0.3.0",
+              "id": "ic-management-canister-types 0.3.1",
               "target": "ic_management_canister_types"
             },
             {
@@ -34293,14 +34293,14 @@
       ],
       "license_file": null
     },
-    "ic-management-canister-types 0.3.0": {
+    "ic-management-canister-types 0.3.1": {
       "name": "ic-management-canister-types",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-management-canister-types/0.3.0/download",
-          "sha256": "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+          "url": "https://static.crates.io/crates/ic-management-canister-types/0.3.1/download",
+          "sha256": "98554c2d8a30c00b6bfda18062fdcef21215cad07a52d8b8b1eb3130e51bfe71"
         }
       },
       "targets": [
@@ -34340,7 +34340,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.0"
+        "version": "0.3.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -54404,7 +54404,7 @@
               "target": "ic_certification"
             },
             {
-              "id": "ic-management-canister-types 0.3.0",
+              "id": "ic-management-canister-types 0.3.1",
               "target": "ic_management_canister_types"
             },
             {
@@ -91561,7 +91561,7 @@
     "ic-gateway 0.2.0",
     "ic-http-certification 3.0.3",
     "ic-http-gateway 0.3.0",
-    "ic-management-canister-types 0.3.0",
+    "ic-management-canister-types 0.3.1",
     "ic-metrics-encoder 1.1.1",
     "ic-response-verification 3.0.3",
     "ic-sha3 1.0.0",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -5981,9 +5981,9 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+checksum = "98554c2d8a30c00b6bfda18062fdcef21215cad07a52d8b8b1eb3130e51bfe71"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "e283d0da52d8293db5dba34ed3c309d49c830b81a3e6c3edba891e98c34e5e63",
+  "checksum": "21430b16e8a299a0a20d265771513910a8fa53d6b3b1030a86ad10485eda72d8",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20325,7 +20325,7 @@
               "target": "ic_http_gateway"
             },
             {
-              "id": "ic-management-canister-types 0.3.0",
+              "id": "ic-management-canister-types 0.3.1",
               "target": "ic_management_canister_types"
             },
             {
@@ -33052,7 +33052,7 @@
               "target": "ic_error_types"
             },
             {
-              "id": "ic-management-canister-types 0.3.0",
+              "id": "ic-management-canister-types 0.3.1",
               "target": "ic_management_canister_types"
             },
             {
@@ -34141,14 +34141,14 @@
       ],
       "license_file": null
     },
-    "ic-management-canister-types 0.3.0": {
+    "ic-management-canister-types 0.3.1": {
       "name": "ic-management-canister-types",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "package_url": "https://github.com/dfinity/cdk-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ic-management-canister-types/0.3.0/download",
-          "sha256": "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+          "url": "https://static.crates.io/crates/ic-management-canister-types/0.3.1/download",
+          "sha256": "98554c2d8a30c00b6bfda18062fdcef21215cad07a52d8b8b1eb3130e51bfe71"
         }
       },
       "targets": [
@@ -34188,7 +34188,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.0"
+        "version": "0.3.1"
       },
       "license": "Apache-2.0",
       "license_ids": [
@@ -54230,7 +54230,7 @@
               "target": "ic_certification"
             },
             {
-              "id": "ic-management-canister-types 0.3.0",
+              "id": "ic-management-canister-types 0.3.1",
               "target": "ic_management_canister_types"
             },
             {
@@ -91526,7 +91526,7 @@
     "ic-gateway 0.2.0",
     "ic-http-certification 3.0.3",
     "ic-http-gateway 0.3.0",
-    "ic-management-canister-types 0.3.0",
+    "ic-management-canister-types 0.3.1",
     "ic-metrics-encoder 1.1.1",
     "ic-response-verification 3.0.3",
     "ic-sha3 1.0.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -5971,9 +5971,9 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+checksum = "98554c2d8a30c00b6bfda18062fdcef21215cad07a52d8b8b1eb3130e51bfe71"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10283,9 +10283,9 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90253c6ac92f9a0b548a53a02c2d29dfa0f04a6c1ae919b86a6f54d4767d78b9"
+checksum = "98554c2d8a30c00b6bfda18062fdcef21215cad07a52d8b8b1eb3130e51bfe71"
 dependencies = [
  "candid",
  "serde",

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -29,7 +29,7 @@ package with native package managers such as apt get, homebrew, etc..
 
 To build Rust and IC-OS code will require a minimal set of packages. On a Linux
 host the
-`[Dockerfile](https://github.com/dfinity/ic/blob/master/ci/container/Dockerfile)`
+[`Dockerfile`](https://github.com/dfinity/ic/blob/master/ci/container/Dockerfile)
 serves as a reference for the minimal apt installation set. Developers may
 develop inside the build and development container with
 `./ci/container/container-run.sh`.
@@ -40,7 +40,7 @@ bazel test //rs/crypto/sha2:all
 
 Most targets should build on the host machine. However, the IC-OS image only
 builds inside the canonical container (`ic-build-bazel:$TAG`). To enter this
-docker container run `./ci/container/conatiner-run.sh`. This container
+docker container run `./ci/container/container-run.sh`. This container
 is only available in x86-64 environments.
 
 # Building Blocks
@@ -74,7 +74,7 @@ the directory `crypto`.
 
 Builds an executable test binary [or binaries] and runs them, outputting and
 caching the results. Cached results will not be rerun. Bazel only caches passed
-test results. The flag  `--cache_test_results=no` will make Bazel rerun cached
+test results. The flag `--cache_test_results=no` will make Bazel rerun cached
 tests.
 
 To see log output from failed tests add `--test_output=errors`. To see all log
@@ -243,7 +243,7 @@ Example absolute path `bazel build //rs/crypto/sha:sha`
 Example current working dir: `cd rs/crypto/sha; bazel build :sha`
 
 Targets external to the workspace [e.g. third party crates] need to include the
-repository name. For exam-ple `bazel build @crate_index//:openssl`
+repository name. For example `bazel build @crate_index//:openssl`
 
 See
 [https://docs.bazel.build/versions/main/build-ref.html#labels](https://docs.bazel.build/versions/main/build-ref.html#labels)
@@ -271,7 +271,7 @@ test`, also build all targets including those not referenced by any test.
 # Example Cargo to Bazel Conversion MRs
 
 Take a look at the following example migration. It is instructive to compare and
-contrast the  the  `Cargo.toml` file with its associated `BAZEL.build` file.
+contrast the `Cargo.toml` file with its associated `BAZEL.build` file.
 
 - [Criterion Times](https://github.com/dfinity/ic/commit/83bafb9c102eb91b0afde7c5d2260532bc6874d5)
 - [Log Analyzer](https://github.com/dfinity/ic/commit/63b176839c61ebe028cf93ed058f81d5b552efc8)
@@ -533,7 +533,7 @@ shell scripts, Python codebases eventually become more difficult to read,
 maintain and extend.
 
 Therefore, IDX strongly recommends **Golang** over Python for CLIs,
-infrastructure tools and  scripting tasks. The Bazel build infrastructure
+infrastructure tools and scripting tasks. The Bazel build infrastructure
 provides seamless Golang integration into the CI and build system - automation
 tools handles the heavy lifting to generate BUILD files and manage external
 dependencies.

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -654,7 +654,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^1.1.1",
             ),
             "ic-management-canister-types": crate.spec(
-                version = "0.3.0",
+                version = "0.3.1",
             ),
             "ic_principal": crate.spec(
                 version = "^0.1.1",


### PR DESCRIPTION
This PR bumps ic-management-canister-types from 0.3.0 to 0.3.1, which [introduces](https://github.com/dfinity/cdk-rs/blob/66b85a31bd0e93e10b35ee3246a4ce6b790a7056/ic-management-canister-types/CHANGELOG.md) new types for VetKD operations.

I also found a few typos in bazel/README.md.