### PR TITLE
chore(IDX): run all bazel targets on mainnet revision PRs

### DIFF
--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -105,8 +105,7 @@ def commit_and_create_pr(
             ["gh", "pr", "view", "--json", "number", "-q", ".number"], cwd=repo_root, text=True
         ).strip()
         subprocess.check_call(
-            ["gh", "pr", "edit", pr_number, "--add-label", "CI_ALL_BAZEL_TARGETS", "--repo", repo],
-            cwd=repo_root,
+            ["gh", "pr", "edit", pr_number, "--add-label", "CI_ALL_BAZEL_TARGETS"], cwd=repo_root,
         )
         if enable_auto_merge:
             subprocess.check_call(["gh", "pr", "merge", pr_number, "--auto"], cwd=repo_root)

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -289,7 +289,7 @@ This PR is created automatically using [`mainnet_revisions.py`](https://github.c
             branch,
             [MAINNET_ICOS_REVISIONS_FILE],
             logger,
-            "chore: Update Mainnet IC revisions file",
+            "chore: Update Mainnet ICOS revisions file",
             pr_description.format(
                 description="Update mainnet revisions file to include the latest version released on the mainnet."
             ),

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -105,7 +105,8 @@ def commit_and_create_pr(
             ["gh", "pr", "view", "--json", "number", "-q", ".number"], cwd=repo_root, text=True
         ).strip()
         subprocess.check_call(
-            ["gh", "pr", "edit", pr_number, "--add-label", "CI_ALL_BAZEL_TARGETS"], cwd=repo_root,
+            ["gh", "pr", "edit", pr_number, "--add-label", "CI_ALL_BAZEL_TARGETS"],
+            cwd=repo_root,
         )
         if enable_auto_merge:
             subprocess.check_call(["gh", "pr", "merge", pr_number, "--auto"], cwd=repo_root)

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -102,7 +102,7 @@ def commit_and_create_pr(
                 cwd=repo_root,
             )
             subprocess.check_call(
-                ["gh", "pr", "edit", "--add-label", "CI_ALL_BAZEL_TARGETS", "--repo", repo, "--head", branch],
+                ["gh", "pr", "edit", "--add-label", "CI_ALL_BAZEL_TARGETS", "--repo", repo],
                 cwd=repo_root,
             )
         if enable_auto_merge:

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -101,6 +101,10 @@ def commit_and_create_pr(
                 ],
                 cwd=repo_root,
             )
+            subprocess.check_call(
+                ["gh", "pr", "edit", "--add-label", "CI_ALL_BAZEL_TARGETS", "--repo", repo, "--head", branch],
+                cwd=repo_root,
+            )
         if enable_auto_merge:
             pr_number = subprocess.check_output(
                 ["gh", "pr", "view", "--json", "number", "-q", ".number"], cwd=repo_root, text=True

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -101,14 +101,14 @@ def commit_and_create_pr(
                 ],
                 cwd=repo_root,
             )
-            subprocess.check_call(
-                ["gh", "pr", "edit", "--add-label", "CI_ALL_BAZEL_TARGETS", "--repo", repo],
-                cwd=repo_root,
-            )
+        pr_number = subprocess.check_output(
+            ["gh", "pr", "view", "--json", "number", "-q", ".number"], cwd=repo_root, text=True
+        ).strip()
+        subprocess.check_call(
+            ["gh", "pr", "edit", pr_number, "--add-label", "CI_ALL_BAZEL_TARGETS", "--repo", repo],
+            cwd=repo_root,
+        )
         if enable_auto_merge:
-            pr_number = subprocess.check_output(
-                ["gh", "pr", "view", "--json", "number", "-q", ".number"], cwd=repo_root, text=True
-            ).strip()
             subprocess.check_call(["gh", "pr", "merge", pr_number, "--auto"], cwd=repo_root)
 
 


### PR DESCRIPTION
This will hopefully prevent regressions from getting merged to master.