### PR TITLE
chore: disable composite query as canister http transform

### DIFF
--- a/rs/execution_environment/src/query_handler/query_context.rs
+++ b/rs/execution_environment/src/query_handler/query_context.rs
@@ -226,6 +226,10 @@ impl<'a> QueryContext<'a> {
                         self.log,
                         "Running composite canister http transform on canister {}.", query.receiver
                     );
+                    return Err(UserError::new(
+                        ErrorCode::CompositeQueryCalledInReplicatedMode,
+                        "Composite query cannot be used as transform in canister http outcalls.",
+                    ));
                 }
             }
             QuerySource::User { .. } => (),

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -153,7 +153,7 @@ fn main() -> Result<()> {
                 .add_test(systest!(test_max_url_length_exceeded))
                 // This section tests the transform function scenarios
                 .add_test(systest!(test_transform_function_is_executed))
-                .add_test(systest!(test_composite_transform_function_is_executed))
+                .add_test(systest!(test_composite_transform_function_is_not_allowed))
                 .add_test(systest!(check_caller_id_on_transform_function))
                 .add_test(systest!(
                     test_transform_that_bloats_response_above_2mb_limit
@@ -312,7 +312,7 @@ fn test_non_existent_transform_function(env: TestEnv) {
     );
 }
 
-fn test_composite_transform_function_is_executed(env: TestEnv) {
+fn test_composite_transform_function_is_not_allowed(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
@@ -337,13 +337,12 @@ fn test_composite_transform_function_is_executed(env: TestEnv) {
         },
     ));
 
-    let response = response.expect("Http call should succeed");
-
-    assert_eq!(response.headers.len(), 2, "Headers: {:?}", response.headers);
-    assert_eq!(response.headers[0].0, "hello");
-    assert_eq!(response.headers[0].1, "bonjour");
-    assert_eq!(response.headers[1].0, "caller");
-    assert_eq!(response.headers[1].1, "aaaaa-aa");
+    let err = response.unwrap_err();
+    assert_eq!(err.reject_code, RejectCode::CanisterError);
+    assert_eq!(
+        err.reject_message,
+        "Composite query cannot be used as transform in canister http outcalls."
+    );
 }
 
 fn test_no_cycles_attached(env: TestEnv) {

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -339,10 +339,9 @@ fn test_composite_transform_function_is_not_allowed(env: TestEnv) {
 
     let err = response.unwrap_err();
     assert_eq!(err.reject_code, RejectCode::CanisterError);
-    assert_eq!(
-        err.reject_message,
-        "Composite query cannot be used as transform in canister http outcalls."
-    );
+    assert!(err
+        .reject_message
+        .contains("Composite query cannot be used as transform in canister http outcalls."));
 }
 
 fn test_no_cycles_attached(env: TestEnv) {


### PR DESCRIPTION
Composite queries have only been used as canister http transforms by the canister `whele-paaaa-aaaab-qbkmq-cai` ([logs](https://kibana.mainnet.dfinity.network/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-30d%2Fd,to:now))&_a=(columns:!(),filters:!(),hideChart:!f,index:ic-logs-mainnet,interval:auto,query:(language:kuery,query:'%22Running%20composite%20canister%20http%20transform%20on%20canister%22'),sort:!(!(timestamp,desc))))) which was upgraded to no longer use them and thus this PR disables them (they have never been specified as enabled by the [Interface Specification](https://internetcomputer.org/docs/references/ic-interface-spec#ic-candid)).