### PR TITLE
test(nns): Remove (prop_)assert_changes

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1641,13 +1641,6 @@ impl Governance {
         reassemble_governance_proto(BTreeMap::new(), heap_governance_proto, rng_seed)
     }
 
-    pub fn __get_state_for_test(&self) -> GovernanceProto {
-        let neurons = self.neuron_store.__get_neurons_for_tests();
-        let heap_governance_proto = self.heap_data.clone();
-        let rng_seed = self.randomness.get_rng_seed();
-        reassemble_governance_proto(neurons, heap_governance_proto, rng_seed)
-    }
-
     pub fn seed_rng(&mut self, seed: [u8; 32]) {
         self.randomness.seed_rng(seed);
     }

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -2,10 +2,7 @@ use crate::{
     governance::{TimeWarp, LOG_PREFIX},
     neuron::types::Neuron,
     neurons_fund::neurons_fund_neuron::pick_most_important_hotkeys,
-    pb::v1::{
-        governance_error::ErrorType, GovernanceError, Neuron as NeuronProto, Topic,
-        VotingPowerEconomics,
-    },
+    pb::v1::{governance_error::ErrorType, GovernanceError, Topic, VotingPowerEconomics},
     storage::{
         neuron_indexes::CorruptedNeuronIndexes, neurons::NeuronSections,
         with_stable_neuron_indexes, with_stable_neuron_indexes_mut, with_stable_neuron_store,
@@ -301,17 +298,6 @@ impl NeuronStore {
                 neuron_id,
             );
         }
-    }
-
-    /// Clones all the neurons. This is only used for testing.
-    /// TODO(NNS-2474) clean it up after NNSState stop using GovernanceProto.
-    pub fn __get_neurons_for_tests(&self) -> BTreeMap<u64, NeuronProto> {
-        with_stable_neuron_store(|stable_store| {
-            stable_store
-                .range_neurons(..)
-                .map(|neuron| (neuron.id().id, NeuronProto::from(neuron.clone())))
-                .collect::<BTreeMap<u64, NeuronProto>>()
-        })
     }
 
     /// Returns if store contains a Neuron by id

--- a/rs/nns/governance/src/storage/neurons.rs
+++ b/rs/nns/governance/src/storage/neurons.rs
@@ -440,6 +440,7 @@ where
         self.main.len().min(usize::MAX as u64) as usize
     }
 
+    #[cfg(any(test, feature = "canbench-rs", feature = "tla"))]
     pub fn range_neurons<R>(&self, range: R) -> impl Iterator<Item = Neuron> + '_
     where
         R: RangeBounds<NeuronId> + Clone,

--- a/rs/nns/governance/tests/README.md
+++ b/rs/nns/governance/tests/README.md
@@ -19,9 +19,6 @@ Basically, each test has three or four basic parts:
    level interface to governance, such as `NNS::merge_maturity`. You can also
    directly manipulate the `nns.governance` object within the fixture.
 
-4. After each operation, or at the end of the test, call `nns.assert_changes`,
-   which takes a vector of expected changes to the NNS since either the
-   fixture was created or `assert_changes` was called.
 
 ## Notes
 
@@ -52,14 +49,3 @@ builds in certain assumptions. For example, `NNS::get_neuron` will assert if
 the neuron does not exist, while `Governance::get_neuron` returns a `Result`
 that must be checked for errors.
 
-### Change lists
-
-Throughout the test, or at its end, `comparable::assert_changes` should be
-used to confirm that the resulting state of the NNS is exactly what you think
-it is, and nothing more or less. This is done by asserting the list of changes
-the test should expect to see. The types used for this generally follow the
-exact same data types found within the NNS, but using a predictable pattern.
-
-For more information, see the crate documentation for `comparable` here:
-
-https://docs.rs/comparable

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -753,7 +753,6 @@ impl From<&str> for ProposalNeuronBehavior {
 pub struct NNS {
     pub fixture: NNSFixture,
     pub governance: Governance,
-    pub(crate) initial_state: Option<NNSState>,
 }
 
 impl NNS {
@@ -766,30 +765,6 @@ impl NNS {
             .environment
             .advance_time_by(delta_seconds);
         self
-    }
-
-    pub fn capture_state(&mut self) -> &mut Self {
-        self.initial_state = Some(self.get_state());
-        self
-    }
-
-    // Must be mut because clone_proto must be mut, but should not affect state
-    pub(crate) fn get_state(&self) -> NNSState {
-        let accounts = self
-            .fixture
-            .nns_state
-            .try_lock()
-            .unwrap()
-            .ledger
-            .accounts
-            .clone();
-        let governance_proto = self.governance.__get_state_for_test();
-        NNSState {
-            now: self.now(),
-            accounts,
-            governance_proto,
-            latest_gc_num_proposals: self.governance.latest_gc_num_proposals,
-        }
     }
 
     pub fn run_periodic_tasks(&mut self) -> &mut Self {
@@ -1084,13 +1059,10 @@ impl NNSBuilder {
             environment = t(environment);
         }
         let randomness = Box::new(fixture.clone());
-        let mut nns = NNS {
+        NNS {
             fixture: fixture.clone(),
             governance: Governance::new(self.governance, environment, ledger, cmc, randomness),
-            initial_state: None,
-        };
-        nns.capture_state();
-        nns
+        }
     }
 
     pub fn set_start_time(mut self, seconds: u64) -> Self {
@@ -1104,12 +1076,7 @@ impl NNSBuilder {
         self
     }
 
-    pub fn set_economics(mut self, econ: NetworkEconomics) -> Self {
-        self.governance.economics = Some(econ.into());
-        self
-    }
-
-    pub fn set_economics_api(mut self, econ: api::NetworkEconomics) -> Self {
+    pub fn set_economics(mut self, econ: api::NetworkEconomics) -> Self {
         self.governance.economics = Some(econ);
         self
     }
@@ -1186,34 +1153,4 @@ impl NNSBuilder {
             .insert(proposal_data.id.unwrap().id, proposal_data);
         self
     }
-}
-
-#[macro_export]
-macro_rules! assert_changes {
-    ($nns:expr, $expected:expr) => {{
-        let new_state = $nns.get_state();
-        comparable::pretty_assert_changes!(
-            $nns.initial_state
-                .as_ref()
-                .expect("initial_state was never set"),
-            &new_state,
-            $expected,
-        );
-        $nns.initial_state = Some(new_state);
-    }};
-}
-
-#[macro_export]
-macro_rules! prop_assert_changes {
-    ($nns:expr, $expected:expr) => {{
-        let new_state = $nns.get_state();
-        comparable::prop_pretty_assert_changes!(
-            $nns.initial_state
-                .as_ref()
-                .expect("initial_state was never set"),
-            &new_state,
-            $expected,
-        );
-        $nns.initial_state = Some(new_state);
-    }};
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -11,11 +11,7 @@ use assert_matches::assert_matches;
 use async_trait::async_trait;
 use candid::{Decode, Encode};
 use common::increase_dissolve_delay_raw;
-use comparable::{Changed, I32Change, MapChange, OptionChange, StringChange, U64Change, VecChange};
-use fixtures::{
-    account, environment_fixture::CanisterCallReply, new_motion_proposal, principal, NNSBuilder,
-    NNSStateChange, NeuronBuilder, ProposalNeuronBehavior, NNS,
-};
+use fixtures::{account, new_motion_proposal, principal, NNSBuilder, NeuronBuilder};
 use futures::future::FutureExt;
 use ic_base_types::{CanisterId, NumBytes, PrincipalId};
 use ic_crypto_sha2::Sha256;
@@ -61,7 +57,7 @@ use ic_nns_governance::{
     governance_proto_builder::GovernanceProtoBuilder,
     pb::v1::{
         add_or_remove_node_provider::Change,
-        governance::{GovernanceCachedMetrics, GovernanceCachedMetricsChange},
+        governance::GovernanceCachedMetrics,
         governance_error::ErrorType::{
             self, InsufficientFunds, NotAuthorized, NotFound, ResourceExhausted,
         },
@@ -78,22 +74,21 @@ use ic_nns_governance::{
         },
         neuron::{DissolveState, Followees},
         neurons_fund_snapshot::NeuronsFundNeuronPortion,
-        proposal::{self, Action, ActionDesc},
+        proposal::{self, Action},
         reward_node_provider::{RewardMode, RewardToAccount, RewardToNeuron},
         settle_neurons_fund_participation_request, swap_background_information,
-        AddOrRemoveNodeProvider, Ballot, BallotInfo, BallotInfoChange, CreateServiceNervousSystem,
-        Empty, ExecuteNnsFunction, GovernanceChange, GovernanceError,
-        IdealMatchedParticipationFunction, InstallCode, KnownNeuron, KnownNeuronData, ManageNeuron,
-        MonthlyNodeProviderRewards, Motion, NetworkEconomics, Neuron, NeuronChange, NeuronType,
-        NeuronsFundData, NeuronsFundEconomics, NeuronsFundMatchedFundingCurveCoefficients,
-        NeuronsFundParticipation, NeuronsFundSnapshot, NnsFunction, NodeProvider, Proposal,
-        ProposalChange, ProposalData, ProposalDataChange,
+        AddOrRemoveNodeProvider, Ballot, BallotInfo, CreateServiceNervousSystem, Empty,
+        ExecuteNnsFunction, GovernanceError, IdealMatchedParticipationFunction, InstallCode,
+        KnownNeuron, KnownNeuronData, ManageNeuron, MonthlyNodeProviderRewards, Motion,
+        NetworkEconomics, Neuron, NeuronType, NeuronsFundData, NeuronsFundEconomics,
+        NeuronsFundMatchedFundingCurveCoefficients, NeuronsFundParticipation, NeuronsFundSnapshot,
+        NnsFunction, NodeProvider, Proposal, ProposalData,
         ProposalRewardStatus::{self, AcceptVotes, ReadyToSettle},
         ProposalStatus::{self, Rejected},
         RewardEvent, RewardNodeProvider, RewardNodeProviders,
         SettleNeuronsFundParticipationRequest, SwapBackgroundInformation, SwapParticipationLimits,
         Tally, Topic, UpdateNodeProvider, Visibility, Vote, VotingPowerEconomics,
-        WaitForQuietState, WaitForQuietStateDesc,
+        WaitForQuietState,
     },
     DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS,
 };
@@ -173,76 +168,6 @@ const RANDOM_U64: u64 = 0_u64;
 
 const USUAL_REWARD_POT_E8S: u64 = 100;
 
-fn check_proposal_status_after_voting_and_after_expiration_new(
-    neurons: impl IntoIterator<Item = api::Neuron>,
-    behavior: impl Into<ProposalNeuronBehavior>,
-    expected_after_voting: ProposalStatus,
-    expected_after_expiration: ProposalStatus,
-) -> NNS {
-    let expiration_seconds = 17; // Arbitrary duration
-    let mut nns = NNSBuilder::new()
-        .set_wait_for_quiet_threshold_seconds(expiration_seconds)
-        .set_economics(NetworkEconomics {
-            reject_cost_e8s: 0,          // It's the default, but specify for emphasis
-            neuron_minimum_stake_e8s: 0, // It's the default, but specify for emphasis
-            ..NetworkEconomics::with_default_values()
-        })
-        .add_neurons(neurons.into_iter().zip(0_u64..))
-        .create();
-
-    let pid = nns.propose_and_vote(behavior, "the unique proposal".to_string());
-    let after_voting = nns.governance.get_proposal_data(pid).unwrap().clone();
-
-    assert_eq!(
-        after_voting.status(),
-        expected_after_voting,
-        "After voting: {:?}",
-        after_voting
-    );
-
-    nns.push_mocked_canister_reply(CanisterCallReply::Response(
-        Encode!(
-            &"get_build_metadata returns a string for consumption by humans, not machines."
-                .to_string()
-        )
-        .unwrap(),
-    ));
-    nns.advance_time_by(expiration_seconds - 1)
-        .run_periodic_tasks();
-    // The proposal should still be open for voting, so nothing should have changed
-    assert_eq!(
-        *nns.governance.get_proposal_data(pid).unwrap(),
-        after_voting
-    );
-
-    // One more second brings us to proposal expiration
-    nns.advance_time_by(1);
-    nns.push_mocked_canister_reply(CanisterCallReply::Response(
-        Encode!(
-            &"get_build_metadata returns a string for consumption by humans, not machines."
-                .to_string()
-        )
-        .unwrap(),
-    ));
-    nns.governance.run_periodic_tasks().now_or_never();
-    // We need to process the timer to make sure recent ballots record.
-    nns.governance
-        .process_voting_state_machines()
-        .now_or_never()
-        .unwrap();
-
-    let after_expiration = nns.governance.get_proposal_data(pid).unwrap();
-
-    assert_eq!(
-        after_expiration.status(),
-        expected_after_expiration,
-        "After expiration: {:?}",
-        after_expiration
-    );
-
-    nns
-}
-
 const NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE: Option<api::neuron::DissolveState> =
     Some(api::neuron::DissolveState::DissolveDelaySeconds(
         VotingPowerEconomics::DEFAULT_NEURON_MINIMUM_DISSOLVE_DELAY_TO_VOTE_SECONDS,
@@ -261,327 +186,6 @@ const NOTDISSOLVING_MAX_DISSOLVE_DELAY: Option<api::neuron::DissolveState> = Som
 #[test]
 fn tests_must_be_run_with_test_feature_enabled() {
     assert!(false);
-}
-
-#[test]
-fn test_single_neuron_proposal_new() {
-    let mut nns = check_proposal_status_after_voting_and_after_expiration_new(
-        vec![api::Neuron {
-            dissolve_state: NOTDISSOLVING_MIN_DISSOLVE_DELAY_TO_VOTE,
-            cached_neuron_stake_e8s: 1,
-            ..api::Neuron::default()
-        }],
-        "P",
-        ProposalStatus::Executed,
-        ProposalStatus::Executed,
-    );
-    assert_changes!(
-        nns,
-        Changed::Changed(vec![
-            NNSStateChange::Now(U64Change(999111000, 999111017)),
-            NNSStateChange::GovernanceProto(vec![
-                GovernanceChange::Neurons(vec![MapChange::Changed(
-                    0,
-                    vec![
-                        NeuronChange::RecentBallots(vec![VecChange::Added(
-                            0,
-                            vec![
-                                BallotInfoChange::ProposalId(OptionChange::Different(
-                                    None,
-                                    Some(ProposalId { id: 1 }),
-                                )),
-                                BallotInfoChange::Vote(I32Change(0, 1)),
-                            ],
-                        )]),
-                        // Neuron's voting power was refreshed, because it directly votes (i.e. not
-                        // as a result of following), but implicitly voted (by virtue of being the
-                        // proposer). (Normally, the amount would increase, but for testing
-                        // purposes, it is enough to show that the value changed.)
-                        NeuronChange::VotingPowerRefreshedTimestampSeconds(
-                            OptionChange::BothSome(
-                                U64Change(
-                                    DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS,
-                                    DEFAULT_TEST_START_TIMESTAMP_SECONDS,
-                                ),
-                            ),
-                        ),
-                        NeuronChange::RecentBallotsNextEntryIndex(
-                            OptionChange::Different(
-                                None,
-                                Some(1),
-                            ),
-                        ),
-                    ],
-                )]),
-                GovernanceChange::Proposals(vec![MapChange::Added(
-                    1,
-                    vec![
-                        ProposalDataChange::Id(OptionChange::Different(
-                            None,
-                            Some(ProposalId { id: 1 }),
-                        )),
-                        ProposalDataChange::Proposer(OptionChange::Different(
-                            None,
-                            Some(NeuronId { id: 0 }),
-                        )),
-                        ProposalDataChange::Proposal(OptionChange::Different(
-                            None,
-                            Some(vec![
-                                ProposalChange::Title(OptionChange::Different(
-                                    None,
-                                    Some("A Reasonable Title".to_string())
-                                )),
-                                ProposalChange::Summary(StringChange(
-                                    "".to_string(),
-                                    "the unique proposal".to_string(),
-                                )),
-                                ProposalChange::Action(OptionChange::Different(
-                                    None,
-                                    Some(ActionDesc::ManageNetworkEconomics(NetworkEconomics {
-                                        ..Default::default()
-                                    })),
-                                )),
-                            ]),
-                        )),
-                        ProposalDataChange::ProposalTimestampSeconds(U64Change(0, 999111000)),
-                        ProposalDataChange::Ballots(vec![MapChange::Added(
-                            0,
-                            Ballot {
-                                vote: Vote::Yes as i32,
-                                voting_power: 1,
-                            },
-                        )]),
-                        ProposalDataChange::LatestTally(OptionChange::Different(
-                            None,
-                            Some(Tally {
-                                timestamp_seconds: 999111000,
-                                yes: 1,
-                                no: 0,
-                                total: 1,
-                            }),
-                        )),
-                        ProposalDataChange::DecidedTimestampSeconds(U64Change(0, 999111000)),
-                        ProposalDataChange::ExecutedTimestampSeconds(U64Change(0, 999111000)),
-                        ProposalDataChange::WaitForQuietState(OptionChange::Different(
-                            None,
-                            Some(WaitForQuietStateDesc {
-                                current_deadline_timestamp_seconds: 999111017,
-                            }),
-                        )),
-                        ProposalDataChange::TotalPotentialVotingPower(OptionChange::Different(
-                            None,
-                            Some(1),
-                        )),
-                        ProposalDataChange::Topic(OptionChange::Different(
-                            None,
-                            Some(Topic::NetworkEconomics as i32),
-                        ))
-                    ],
-                )]),
-                GovernanceChange::Metrics(OptionChange::Different(
-                    None,
-                    Some(vec![
-                        GovernanceCachedMetricsChange::TimestampSeconds(U64Change(0, 999111016)),
-                        GovernanceCachedMetricsChange::NotDissolvingNeuronsCount(U64Change(0, 1)),
-                        GovernanceCachedMetricsChange::NotDissolvingNeuronsE8SBuckets(vec![
-                            MapChange::Added(1, 1.0),
-                        ]),
-                        GovernanceCachedMetricsChange::NotDissolvingNeuronsCountBuckets(vec![
-                            MapChange::Added(1, 1),
-                        ]),
-                        GovernanceCachedMetricsChange::TotalStakedE8S(U64Change(0, 1)),
-                        GovernanceCachedMetricsChange::TotalLockedE8S(U64Change(0, 1)),
-                        GovernanceCachedMetricsChange::NotDissolvingNeuronsStakedMaturityE8SEquivalentBuckets(vec![
-                            MapChange::Added(
-                                1,
-                                0.0,
-                            ),
-                        ]),
-                        GovernanceCachedMetricsChange::TotalVotingPowerNonSelfAuthenticatingController(
-                            comparable::OptionChange::Different(None, Some(1)),
-                        ),
-                        GovernanceCachedMetricsChange::TotalStakedE8SNonSelfAuthenticatingController(
-                            comparable::OptionChange::Different(None, Some(1)),
-                        ),
-                        GovernanceCachedMetricsChange::NonSelfAuthenticatingControllerNeuronSubsetMetrics(
-                            comparable::OptionChange::Different(
-                                None,
-                                Some(
-                                    ic_nns_governance::pb::v1::governance::governance_cached_metrics::NeuronSubsetMetricsDesc {
-                                        count: Some(
-                                            1,
-                                        ),
-                                        total_staked_e8s: Some(
-                                            1,
-                                        ),
-                                        total_staked_maturity_e8s_equivalent: Some(
-                                            0,
-                                        ),
-                                        total_maturity_e8s_equivalent: Some(
-                                            0,
-                                        ),
-                                        total_voting_power: Some(
-                                            1,
-                                        ),
-                                        total_deciding_voting_power: Some(
-                                            1,
-                                        ),
-                                        total_potential_voting_power: Some(
-                                            1,
-                                        ),
-                                        count_buckets: btreemap! {
-                                            1 => 1,
-                                        },
-                                        staked_e8s_buckets: btreemap! {
-                                            1 => 1,
-                                        },
-                                        staked_maturity_e8s_equivalent_buckets: btreemap! {
-                                            1 => 0,
-                                        },
-                                        maturity_e8s_equivalent_buckets: btreemap! {
-                                            1 => 0,
-                                        },
-                                        voting_power_buckets: btreemap! {
-                                            1 => 1,
-                                        },
-                                        deciding_voting_power_buckets: btreemap! {
-                                            1 => 1,
-                                        },
-                                        potential_voting_power_buckets: btreemap! {
-                                            1 => 1,
-                                        },
-                                    },
-                                ),
-                            ),
-                        ),
-                        GovernanceCachedMetricsChange::PublicNeuronSubsetMetrics(
-                            comparable::OptionChange::Different(
-                                None,
-                                Some(
-                                    ic_nns_governance::pb::v1::governance::governance_cached_metrics::NeuronSubsetMetricsDesc {
-                                        count: Some(
-                                            0,
-                                        ),
-                                        total_staked_e8s: Some(
-                                            0,
-                                        ),
-                                        total_staked_maturity_e8s_equivalent: Some(
-                                            0,
-                                        ),
-                                        total_maturity_e8s_equivalent: Some(
-                                            0,
-                                        ),
-                                        total_voting_power: Some(
-                                            0,
-                                        ),
-                                        total_deciding_voting_power: Some(
-                                            0,
-                                        ),
-                                        total_potential_voting_power: Some(
-                                            0,
-                                        ),
-                                        count_buckets: btreemap! {},
-                                        staked_e8s_buckets: btreemap! {},
-                                        staked_maturity_e8s_equivalent_buckets: btreemap! {},
-                                        maturity_e8s_equivalent_buckets: btreemap! {},
-                                        voting_power_buckets: btreemap! {},
-                                        deciding_voting_power_buckets: btreemap! {},
-                                        potential_voting_power_buckets: btreemap! {},
-                                    },
-                                ),
-                            ),
-                        ),
-                        GovernanceCachedMetricsChange::DecliningVotingPowerNeuronSubsetMetrics(
-                            comparable::OptionChange::Different(
-                                None,
-                                Some(
-                                    ic_nns_governance::pb::v1::governance::governance_cached_metrics::NeuronSubsetMetricsDesc {
-                                        count: Some(
-                                            0,
-                                        ),
-                                        total_staked_e8s: Some(
-                                            0,
-                                        ),
-                                        total_staked_maturity_e8s_equivalent: Some(
-                                            0,
-                                        ),
-                                        total_maturity_e8s_equivalent: Some(
-                                            0,
-                                        ),
-                                        total_voting_power: Some(
-                                            0,
-                                        ),
-                                        total_deciding_voting_power: Some(
-                                            0,
-                                        ),
-                                        total_potential_voting_power: Some(
-                                            0,
-                                        ),
-                                        count_buckets: btreemap! {},
-                                        staked_e8s_buckets: btreemap! {},
-                                        staked_maturity_e8s_equivalent_buckets: btreemap! {},
-                                        maturity_e8s_equivalent_buckets: btreemap! {},
-                                        voting_power_buckets: btreemap! {},
-                                        deciding_voting_power_buckets: btreemap! {},
-                                        potential_voting_power_buckets: btreemap! {},
-                                    },
-                                ),
-                            ),
-                        ),
-                        GovernanceCachedMetricsChange::FullyLostVotingPowerNeuronSubsetMetrics(
-                            comparable::OptionChange::Different(
-                                None,
-                                Some(
-                                    ic_nns_governance::pb::v1::governance::governance_cached_metrics::NeuronSubsetMetricsDesc {
-                                        count: Some(
-                                            0,
-                                        ),
-                                        total_staked_e8s: Some(
-                                            0,
-                                        ),
-                                        total_staked_maturity_e8s_equivalent: Some(
-                                            0,
-                                        ),
-                                        total_maturity_e8s_equivalent: Some(
-                                            0,
-                                        ),
-                                        total_voting_power: Some(
-                                            0,
-                                        ),
-                                        total_deciding_voting_power: Some(
-                                            0,
-                                        ),
-                                        total_potential_voting_power: Some(
-                                            0,
-                                        ),
-                                        count_buckets: btreemap! {},
-                                        staked_e8s_buckets: btreemap! {},
-                                        staked_maturity_e8s_equivalent_buckets: btreemap! {},
-                                        maturity_e8s_equivalent_buckets: btreemap! {},
-                                        voting_power_buckets: btreemap! {},
-                                        deciding_voting_power_buckets: btreemap! {},
-                                        potential_voting_power_buckets: btreemap! {},
-                                    },
-                                ),
-                            ),
-                        ),
-                    ]),
-                )),
-                GovernanceChange::CachedDailyMaturityModulationBasisPoints(
-                    OptionChange::Different(None, Some(100),)
-                ),
-                GovernanceChange::MaturityModulationLastUpdatedAtTimestampSeconds(
-                    OptionChange::Different(None, Some(999111017),)
-                ),
-            ]),
-            NNSStateChange::LatestGcNumProposals(
-                comparable::UsizeChange(
-                    0,
-                    1,
-                ),
-            ),
-        ])
-    );
 }
 
 /// Submits a proposal, votes on it as instructed, and then verifies:

--- a/rs/nns/governance/tests/interleaving_tests.rs
+++ b/rs/nns/governance/tests/interleaving_tests.rs
@@ -67,7 +67,7 @@ fn test_cant_increase_dissolve_delay_while_disbursing() {
         .add_ledger_transform(Box::new(move |l| {
             Arc::new(InterleavingTestLedger::new(l, tx))
         }))
-        .set_economics_api(NetworkEconomics::default())
+        .set_economics(NetworkEconomics::default())
         .create();
 
     let neuron_1 = nns
@@ -266,7 +266,7 @@ fn test_cant_interleave_calls_to_settle_neurons_fund() {
         .add_ledger_transform(Box::new(move |l| {
             Arc::new(InterleavingTestLedger::new(l, tx))
         }))
-        .set_economics_api(NetworkEconomics::default())
+        .set_economics(NetworkEconomics::default())
         .create();
     let sns_wasm_response = ic_sns_wasm::pb::v1::ListDeployedSnsesResponse {
         instances: vec![DeployedSns {

--- a/rs/nns/governance/tests/merge_neurons.rs
+++ b/rs/nns/governance/tests/merge_neurons.rs
@@ -3,8 +3,7 @@
 //! complex/weird configurations of neurons and proposals against which several
 //! tests are run.
 
-use comparable::{Changed, U64Change};
-use fixtures::{NNSBuilder, NNSStateChange, NeuronBuilder};
+use fixtures::{NNSBuilder, NeuronBuilder};
 use futures::future::FutureExt;
 use ic_base_types::PrincipalId;
 use ic_nervous_system_common::ONE_YEAR_SECONDS;
@@ -13,10 +12,13 @@ use ic_nns_governance::{
     governance::MAX_DISSOLVE_DELAY_SECONDS,
     pb::v1::{
         manage_neuron::{Command, Merge},
-        ManageNeuron, NetworkEconomics,
+        ManageNeuron,
     },
 };
-use ic_nns_governance_api::manage_neuron_response::{Command as CommandResponse, MergeResponse};
+use ic_nns_governance_api::{
+    manage_neuron_response::{Command as CommandResponse, MergeResponse},
+    NetworkEconomics,
+};
 use proptest::prelude::{proptest, TestCaseError};
 
 #[cfg(feature = "tla")]
@@ -89,15 +91,6 @@ fn do_test_merge_neurons(
                 source_neuron_id: Some(NeuronId { id: 1 }),
             })),
         },
-    );
-
-    // Assert no changes (except time) after simulate.
-    prop_assert_changes!(
-        nns,
-        Changed::Changed(vec![NNSStateChange::Now(U64Change(
-            epoch,
-            epoch + ONE_YEAR_SECONDS
-        ))])
     );
 
     let merge_neuron_response = nns


### PR DESCRIPTION
# Why

The ability to assert on the entirety of the NNS Governance state was OK before, but as we have more and more data in stable storage, it becomes less feasible to do so. In particular now neurons live in the stable storage, so we won't be able assert on the neurons anyway.

# What

* Remove (prop_)assert_changes and its invocations
* For `check_proposal_status_after_voting_and_after_expiration_new`, there is already a test `check_proposal_status_after_voting_and_after_expiration` which does the same thing except for asserting the global state changes.