### PR TITLE
fix: increase timeout for the {upgrade,downgrade}_app_subnet_tests

### DIFF
--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -82,6 +82,7 @@ system_test_nns(
 system_test_nns(
     name = "upgrade_app_subnet_test",
     env = MAINNET_ENV,
+    eternal = "eternal",  # the default 900 seconds (15 minutes) is not enough for this test, so we set it to 3600 seconds (1 hour).
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,  # flakiness rate of over 2.27% over the month from 2025-02-11 till 2025-03-11.
     tags = [
@@ -108,6 +109,7 @@ system_test_nns(
 system_test_nns(
     name = "downgrade_app_subnet_test",
     env = MAINNET_ENV,
+    eternal = "eternal",  # the default 900 seconds (15 minutes) is not enough for this test, so we set it to 3600 seconds (1 hour).
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,  # flakiness rate of over 2.97% over the month from 2025-02-11 till 2025-03-11.
     tags = [

--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -82,13 +82,13 @@ system_test_nns(
 system_test_nns(
     name = "upgrade_app_subnet_test",
     env = MAINNET_ENV,
-    eternal = "eternal",  # the default 900 seconds (15 minutes) is not enough for this test, so we set it to 3600 seconds (1 hour).
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,  # flakiness rate of over 2.27% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
+    test_timeout = "eternal",  # the default 900 seconds (15 minutes) is not enough for this test, so we set it to 3600 seconds (1 hour).
     uses_guestos_dev_test = True,
     runtime_deps =
         GUESTOS_RUNTIME_DEPS +
@@ -109,13 +109,13 @@ system_test_nns(
 system_test_nns(
     name = "downgrade_app_subnet_test",
     env = MAINNET_ENV,
-    eternal = "eternal",  # the default 900 seconds (15 minutes) is not enough for this test, so we set it to 3600 seconds (1 hour).
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,  # flakiness rate of over 2.97% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
+    test_timeout = "eternal",  # the default 900 seconds (15 minutes) is not enough for this test, so we set it to 3600 seconds (1 hour).
     uses_guestos_dev_test = True,
     runtime_deps =
         GUESTOS_RUNTIME_DEPS +


### PR DESCRIPTION
The `//rs/tests/consensus/upgrade:{upgrade,downgrade}_app_subnet_tests` are highly flaky because they timeout frequently. When looking at their Kibana logs we see that the node was in the process of rebooting to the upgraded version but then the test timed out. So giving it a bit more time will probably allow these tests to succeed. So we increase their bazel timeouts from `long` (15 minutes) to `eternal` (1 hour).