### PR TITLE
chore(IDX): don't use a config file for rclone

### DIFF
--- a/ci/src/artifacts/upload.sh
+++ b/ci/src/artifacts/upload.sh
@@ -13,6 +13,7 @@ rclone_common_flags=(
     --immutable
     --s3-upload-cutoff=5G
     --s3-no-check-bucket
+    --config /dev/null # don't use a config file
 )
 
 log() {


### PR DESCRIPTION
This explicitly tells `rclone` to not use a config file, avoiding unnecessary warnings when `rclone` is run.