### PR TITLE
chore: mark  //rs/nns/governance:governance_integration_test_tests:... as flaky

### DIFF
--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -389,6 +389,7 @@ rust_test_suite_with_extra_srcs(
     extra_srcs = glob([
         "tests/*/*.rs",
     ]) + ["tests/fake.rs"],
+    flaky = True,  # the governance test times out in over 2% of runs
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
     deps = [":governance--test_feature"] + DEPENDENCIES + DEV_DEPENDENCIES + [


### PR DESCRIPTION
The `//rs/nns/governance:governance_integration_test_tests/governance` test times out in over 2% of the runs requiring folks to manually restart the job on their PRs. So this commit marks all `//rs/nns/governance:governance_integration_test_tests/...` tests as flaky such that they're automatically retried and show up on our Flakiness Dashboards. The latter will help with prioritising fixing the flakiness.