### PR TITLE
chore(crypto): CRP-2831 Modify VetKD to be robust about duplicated node shares

### DIFF
--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/benches/vetkd.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/benches/vetkd.rs
@@ -55,7 +55,7 @@ fn vetkd_bench(c: &mut Criterion) {
             });
         }
 
-        let mut node_info = Vec::with_capacity(nodes);
+        let mut node_info = std::collections::BTreeMap::new();
 
         for node in 0..nodes {
             let node_sk = poly.evaluate_at(&Scalar::from_node_index(node as u32));
@@ -63,7 +63,7 @@ fn vetkd_bench(c: &mut Criterion) {
 
             let eks = EncryptedKeyShare::create(rng, &master_pk, &node_sk, &tpk, &context, &input);
 
-            node_info.push((node as u32, node_pk, eks));
+            node_info.insert(node as u32, (node_pk, eks));
         }
 
         group.bench_function(

--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/src/lib.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/src/lib.rs
@@ -231,6 +231,8 @@ impl EncryptedKey {
             return Err(EncryptedKeyCombinationError::InsufficientShares);
         }
 
+        // TODO(CRP-2854) This cannot happen because the keys of a BTreeMap are unique
+        // Modify this to use a new infalliable interface once that is created
         let l = LagrangeCoefficients::at_zero(
             &nodes.iter().map(|(k, _v)| *k).collect::<Vec<NodeIndex>>(),
         )

--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/src/lib.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/src/lib.rs
@@ -305,7 +305,9 @@ impl EncryptedKey {
         let mut valid_shares = Vec::with_capacity(reconstruction_threshold);
 
         for (node_index, node_pk, node_eks) in nodes.iter() {
-            if node_eks.is_valid(master_pk, node_pk, context, input, tpk) && !node_ids_seen.contains(node_index) {
+            if node_eks.is_valid(master_pk, node_pk, context, input, tpk)
+                && !node_ids_seen.contains(node_index)
+            {
                 node_ids_seen.insert(*node_index);
                 valid_shares.push((*node_index, node_eks.clone()));
 

--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
@@ -292,7 +292,7 @@ fn remove_public_keys(
     for (index, (_pk, eks)) in node_info {
         ek.insert(*index, eks.clone());
     }
-    return ek;
+    ek
 }
 
 fn random_subset<R: rand::Rng, T: Clone>(
@@ -393,7 +393,7 @@ fn test_protocol_execution() {
         // Avoid using a duplicate index for this test
         let random_unused_idx = loop {
             let idx = (rng.gen::<usize>() % node_eks_wrong_input.len()) as u32;
-            if !shares.iter().map(|(i, _eks)| *i).any(|x| x == idx) {
+            if !shares.keys().map(|i| *i).any(|x| x == idx) {
                 break idx;
             }
         };

--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
@@ -221,7 +221,7 @@ impl<'a> VetkdTestProtocolExecution<'a> {
         &self,
         rng: &mut R,
         input: Option<&[u8]>,
-    ) -> BTreeMap<u32, (G2Affine, EncryptedKeyShare)> {
+    ) -> BTreeMap<NodeIndex, (G2Affine, EncryptedKeyShare)> {
         let mut node_info = BTreeMap::new();
 
         let input = input.unwrap_or(&self.input);
@@ -249,7 +249,7 @@ impl<'a> VetkdTestProtocolExecution<'a> {
             let eks2 = EncryptedKeyShare::deserialize(&eks_bytes).unwrap();
             assert_eq!(eks, eks2);
 
-            node_info.insert(node_idx as u32, (node_pk.clone(), eks.clone()));
+            node_info.insert(node_idx as NodeIndex, (node_pk.clone(), eks.clone()));
         }
 
         node_info
@@ -392,8 +392,8 @@ fn test_protocol_execution() {
 
         // Avoid using a duplicate index for this test
         let random_unused_idx = loop {
-            let idx = (rng.gen::<usize>() % node_eks_wrong_input.len()) as u32;
-            if !shares.keys().any(|x| *x == idx) {
+            let idx = (rng.gen::<usize>() % node_eks_wrong_input.len()) as NodeIndex;
+            if !shares.contains_key(&idx) {
                 break idx;
             }
         };

--- a/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
+++ b/rs/crypto/internal/crypto_lib/bls12_381/vetkd/tests/tests.rs
@@ -393,7 +393,7 @@ fn test_protocol_execution() {
         // Avoid using a duplicate index for this test
         let random_unused_idx = loop {
             let idx = (rng.gen::<usize>() % node_eks_wrong_input.len()) as u32;
-            if !shares.keys().map(|i| *i).any(|x| x == idx) {
+            if !shares.keys().any(|x| *x == idx) {
                 break idx;
             }
         };

--- a/rs/crypto/test_utils/vetkd/src/lib.rs
+++ b/rs/crypto/test_utils/vetkd/src/lib.rs
@@ -58,7 +58,10 @@ impl PrivateKey {
             input,
         );
 
-        let ek = EncryptedKey::combine_all(&[(0, eks)], 1, &self.public_point, &tpk, &dc, input)
+        let mut shares = std::collections::BTreeMap::new();
+        shares.insert(0, eks);
+
+        let ek = EncryptedKey::combine_all(&shares, 1, &self.public_point, &tpk, &dc, input)
             .expect("Failed to combine single EncryptedKeyShare to an EncryptedKey");
 
         ek.serialize().to_vec()


### PR DESCRIPTION
This condition cannot occur due to how our callers are implemented, but it is worth being resilient to the issue in case the vault implementation changes in the future.