### PR TITLE
feat(registry-client): get_routing_table uses canister_range_* records

### DIFF
--- a/rs/registry/helpers/src/routing_table.rs
+++ b/rs/registry/helpers/src/routing_table.rs
@@ -30,7 +30,7 @@ impl<T: RegistryClient + ?Sized> RoutingTableRegistry for T {
             .map(|key| deserialize_registry_value::<pb::RoutingTable>(self.get_value(key, version)))
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
-            .filter_map(|opt| opt)
+            .flatten()
             .collect::<Vec<_>>();
 
         Some(

--- a/rs/registry/routing_table/src/proto.rs
+++ b/rs/registry/routing_table/src/proto.rs
@@ -96,6 +96,15 @@ impl TryFrom<pb::RoutingTable> for RoutingTable {
     }
 }
 
+impl TryFrom<Vec<pb::RoutingTable>> for RoutingTable {
+    type Error = ProxyDecodeError;
+
+    fn try_from(src: Vec<pb::RoutingTable>) -> Result<Self, Self::Error> {
+        let entries = src.into_iter().flat_map(|table| table.entries).collect();
+        Self::try_from(pb::RoutingTable { entries })
+    }
+}
+
 impl From<CanisterMigrations> for pb::CanisterMigrations {
     fn from(src: CanisterMigrations) -> Self {
         Self::from(&src)


### PR DESCRIPTION
This migrates a RegistryClient helper to get the routing table from the sharded routing table records.

This should not be merged until the corresponding [Registry change](https://github.com/dfinity/ic/pull/5062)s have been deployed.