### PR TITLE
fix(fuzzing): Remove docker creds from the weekly fuzzing job

### DIFF
--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -5,10 +5,6 @@ on:
     - cron: "0 8 * * 3"
   workflow_dispatch:
 
-env:
-  DOCKER_HUB_USER: ${{ vars.DOCKER_HUB_USER }}
-  DOCKER_HUB_PASSWORD_RO: ${{ secrets.DOCKER_HUB_PASSWORD_RO }}
-
 jobs:
   bazel-build-fuzzers-weekly:
     runs-on:


### PR DESCRIPTION
These credentials should no longer be needed as we migrated to ghcr