### PR TITLE
chore: pass `--keep-going` to `cargo clippy`

### DIFF
--- a/ci/scripts/rust-lint.sh
+++ b/ci/scripts/rust-lint.sh
@@ -3,7 +3,7 @@ set -xeuo pipefail
 
 cd "${CI_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 cargo fmt -- --check
-cargo clippy --locked --all-features --workspace --all-targets -- \
+cargo clippy --locked --all-features --workspace --all-targets --keep-going -- \
     -D warnings \
     -D clippy::all \
     -D clippy::mem_forget \


### PR DESCRIPTION
This passes `--keep-going` to `cargo clippy` causing it to check as much as possible and not fail on the first issue.