### PR TITLE
fix(IDX): use string comparison for arm64 upload

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -317,7 +317,7 @@ jobs:
     name: Upload arm64 linux artifacts
     <<: *dind-large-setup
     needs: [bazel-test-arm64-linux, config]
-    if: needs.config.outputs.release_build
+    if: ${{ needs.config.outputs.release_build == 'true' }} # GHA output quirk, 'true' is a string
     steps:
       - uses: actions/checkout@v4
       - name: Download pocket-ic-server

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -289,7 +289,7 @@ jobs:
         -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 90
     needs: [bazel-test-arm64-linux, config]
-    if: needs.config.outputs.release_build
+    if: ${{ needs.config.outputs.release_build == 'true' }} # GHA output quirk, 'true' is a string
     steps:
       - uses: actions/checkout@v4
       - name: Download pocket-ic-server


### PR DESCRIPTION
We set GHA outputs as string, and thus they need to be compared as such.