### PR TITLE
chore(IDX): remove zh1 pin from daily jobs

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -17,7 +17,7 @@ anchors:
     image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
   dind-large-setup: &dind-large-setup
     runs-on:
-      group: zh1
+      group: dm1
       labels: dind-large
     container:
       <<: *image
@@ -33,10 +33,6 @@ jobs:
   bazel-test-bare-metal:
     name: Bazel Test Bare Metal
     <<: *dind-large-setup
-    timeout-minutes: 120
-    runs-on:
-      group: zh1
-      labels: dind-large
     steps:
       - <<: *checkout
       - name: Run Bazel Launch Bare Metal

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -87,7 +87,7 @@ jobs:
   nns-tests-nightly:
     name: Bazel Test NNS Nightly
     <<: *dind-large-setup
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - <<: *checkout
       - name: Run NNS Tests Nightly

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -17,7 +17,6 @@ anchors:
     image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
   dind-large-setup: &dind-large-setup
     runs-on:
-      group: dm1
       labels: dind-large
     container:
       <<: *image

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -86,7 +86,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
         -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -12,14 +12,14 @@ env:
 jobs:
   bazel-test-bare-metal:
     name: Bazel Test Bare Metal
+    runs-on:
+      group: dm1
+      labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
       options: >-
         -e NODE_NAME --privileged --cgroupns host -v /cache:/cache
     timeout-minutes: 120
-    runs-on:
-      group: zh1
-      labels: dind-large
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
   fi-tests-nightly:
     name: Bazel Test FI Nightly
     runs-on:
-      group: zh1
+      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
@@ -80,7 +80,7 @@ jobs:
   nns-tests-nightly:
     name: Bazel Test NNS Nightly
     runs-on:
-      group: zh1
+      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
@@ -101,7 +101,7 @@ jobs:
   system-tests-benchmarks-nightly:
     name: Bazel System Test Benchmarks
     runs-on:
-      group: zh1
+      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
@@ -136,7 +136,7 @@ jobs:
     if: false
     name: Dependency Scan Nightly
     runs-on:
-      group: zh1
+      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
@@ -188,7 +188,7 @@ jobs:
   bazel-test-coverage:
     name: Bazel Test Coverage
     runs-on:
-      group: zh1
+      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -13,7 +13,6 @@ jobs:
   bazel-test-bare-metal:
     name: Bazel Test Bare Metal
     runs-on:
-      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
@@ -59,7 +58,6 @@ jobs:
   fi-tests-nightly:
     name: Bazel Test FI Nightly
     runs-on:
-      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
@@ -80,7 +78,6 @@ jobs:
   nns-tests-nightly:
     name: Bazel Test NNS Nightly
     runs-on:
-      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
@@ -101,7 +98,6 @@ jobs:
   system-tests-benchmarks-nightly:
     name: Bazel System Test Benchmarks
     runs-on:
-      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
@@ -136,7 +132,6 @@ jobs:
     if: false
     name: Dependency Scan Nightly
     runs-on:
-      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e
@@ -188,7 +183,6 @@ jobs:
   bazel-test-coverage:
     name: Bazel Test Coverage
     runs-on:
-      group: dm1
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:797497ee4e9e5f06466eafa85cf8882ad9522d4fe27e9d97bfccee98e346065e


### PR DESCRIPTION
All CI jobs succeeded, except for `Bazel Test NNS Nightly` which first timed out, then failed when I bumped the timeout up to 30min. However, it has also been failing on regular runs, so it's difficult to identify if this is related to it being run in dm1.

See failed run here: https://dash.dm1-idx1.dfinity.network/invocation/a1d7914e-e0ee-4657-b492-39383df7b73a