### PR TITLE
chore(IDX): mark all jemalloc targets as manual

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -82,15 +82,6 @@ runs:
               bazel_targets+=( "$tgt" )
             done
 
-            # jemalloc -- or rather, the "hermetic" zig toolchain -- has issues when too
-            # many targets are built concurrently (leads to determinism issues & linking
-            # errors).
-            #
-            # To work around this, we build jemalloc separately.
-            if [ $(uname -o) != "Darwin" ]; then
-              bazel build "${bazel_args[@]}" @@jemalloc//:libjemalloc
-            fi
-
             if [[ $diff_only == "true" ]]; then
                 target_pattern_file=$(mktemp)
                 trap "rm $target_pattern_file" INT TERM EXIT

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "810e1cedfbe2974258947d7bdf173d3438cadc60f0abeb72e51f1435f17fe842",
+  "checksum": "57270950c21f27a9229522c727f42f7a146079035adee3b789ade74f8e89131e",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -75862,7 +75862,7 @@
           "common": {},
           "selects": {
             "x86_64-unknown-linux-gnu": {
-              "JEMALLOC_OVERRIDE": "$(location @jemalloc//:libjemalloc)"
+              "JEMALLOC_OVERRIDE": "$(execpath @jemalloc//:libjemalloc)"
             }
           }
         },

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5063d0cb0c55333e16aad0a7cf3d2fee586026f58e4483b205c4598585892172",
+  "checksum": "7d0fc88a501688ebf1a86aac30fb12b500d36208e8cc966a0cf02fa6c7510670",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -75732,7 +75732,7 @@
           "common": {},
           "selects": {
             "x86_64-unknown-linux-gnu": {
-              "JEMALLOC_OVERRIDE": "$(location @jemalloc//:libjemalloc)"
+              "JEMALLOC_OVERRIDE": "$(execpath @jemalloc//:libjemalloc)"
             }
           }
         },

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -115,7 +115,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             build_script_env = crate.select(
                 {},
                 {
-                    "x86_64-unknown-linux-gnu": {"JEMALLOC_OVERRIDE": "$(location @jemalloc//:libjemalloc)"},
+                    "x86_64-unknown-linux-gnu": {"JEMALLOC_OVERRIDE": "$(execpath @jemalloc//:libjemalloc)"},
                 },
             ),
         )],

--- a/third_party/jemalloc/BUILD.jemalloc.bazel
+++ b/third_party/jemalloc/BUILD.jemalloc.bazel
@@ -5,10 +5,18 @@ rebuilds when rules_rust, rustc or tikv-jemalloc-sys change.
 
 load("@rules_foreign_cc//foreign_cc:configure.bzl", "configure_make")
 
+# NOTE: we mark all the targets as "manual" because we don't actually care about building
+# jemalloc, and instead let targets that depend on it drive the build (with whatever config
+# they require).
+
 # Used in make build
 filegroup(
     name = "all",
     srcs = glob(["**"]),
+    tags = [
+        "manual",
+        "no-cache",
+    ],
 )
 
 # A copy of just the static archive, which can be used with `$(location ...)` in build (tikv-jemalloc-sys) that
@@ -27,6 +35,10 @@ genrule(
         fi
     done
     """,
+    tags = [
+        "manual",
+        "no-cache",
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This ensures that we don't build jemalloc more than necessary. The targets that depend on jemalloc will trigger a build anyway. Moreover said targets require jemalloc in exec config, so the build from `//...` can't even be reused.