### PR TITLE
feat: add trait in `ic-metrics-assert` to perform async HTTP query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10437,11 +10437,14 @@ name = "ic-metrics-assert"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "futures",
+ "ic-http-types",
  "ic-management-canister-types",
  "pocket-ic",
  "regex",
  "serde",
  "serde_bytes",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10436,7 +10436,6 @@ dependencies = [
 name = "ic-metrics-assert"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "candid",
  "ic-http-types",
  "ic-management-canister-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10436,15 +10436,14 @@ dependencies = [
 name = "ic-metrics-assert"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "candid",
- "futures",
  "ic-http-types",
  "ic-management-canister-types",
  "pocket-ic",
  "regex",
  "serde",
  "serde_bytes",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10436,6 +10436,7 @@ dependencies = [
 name = "ic-metrics-assert"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "candid",
  "ic-http-types",
  "ic-management-canister-types",

--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -11,10 +11,13 @@ package(default_visibility = ["//visibility:public"])
         deps = [
             # Keep sorted.
             "@crate_index//:candid",
+            "@crate_index//:futures",
+            "@crate_index//:ic-http-types",
             "@crate_index//:ic-management-canister-types",
             "@crate_index//:regex",
             "@crate_index//:serde",
             "@crate_index//:serde_bytes",
+            "@crate_index//:tokio",
         ] + extra_deps,
     )
     for (name_suffix, features, extra_deps) in [

--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -8,6 +8,10 @@ package(default_visibility = ["//visibility:public"])
         srcs = glob(["src/**/*.rs"]),
         crate_features = features,
         crate_name = "ic_metrics_assert",
+        proc_macro_deps = [
+            # Keep sorted.
+            "@crate_index//:async-trait",
+        ],
         deps = [
             # Keep sorted.
             "//packages/ic-http-types",

--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -10,14 +10,13 @@ package(default_visibility = ["//visibility:public"])
         crate_name = "ic_metrics_assert",
         deps = [
             # Keep sorted.
+            "//packages/ic-http-types",
+            "@crate_index//:async-trait",
             "@crate_index//:candid",
-            "@crate_index//:futures",
-            "@crate_index//:ic-http-types",
             "@crate_index//:ic-management-canister-types",
             "@crate_index//:regex",
             "@crate_index//:serde",
             "@crate_index//:serde_bytes",
-            "@crate_index//:tokio",
         ] + extra_deps,
     )
     for (name_suffix, features, extra_deps) in [

--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -14,8 +14,8 @@ package(default_visibility = ["//visibility:public"])
         ],
         deps = [
             # Keep sorted.
-            "//packages/ic-http-types",
             "@crate_index//:candid",
+            "@crate_index//:ic-http-types",
             "@crate_index//:regex",
             "@crate_index//:serde",
             "@crate_index//:serde_bytes",

--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -8,6 +8,10 @@ package(default_visibility = ["//visibility:public"])
         srcs = glob(["src/**/*.rs"]),
         crate_features = features,
         crate_name = "ic_metrics_assert",
+        proc_macro_deps = [
+            # Keep sorted.
+            "@crate_index//:async-trait",
+        ],
         deps = [
             # Keep sorted.
             "//packages/ic-http-types",
@@ -16,10 +20,6 @@ package(default_visibility = ["//visibility:public"])
             "@crate_index//:serde",
             "@crate_index//:serde_bytes",
         ] + extra_deps,
-        proc_macro_deps = [
-            # Keep sorted.
-            "@crate_index//:async-trait",
-        ],
     )
     for (name_suffix, features, extra_deps) in [
         [

--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -12,7 +12,6 @@ package(default_visibility = ["//visibility:public"])
             # Keep sorted.
             "//packages/ic-http-types",
             "@crate_index//:candid",
-            "@crate_index//:ic-management-canister-types",
             "@crate_index//:regex",
             "@crate_index//:serde",
             "@crate_index//:serde_bytes",
@@ -31,7 +30,11 @@ package(default_visibility = ["//visibility:public"])
         [
             "_pocket_ic",
             ["pocket_ic"],
-            ["//packages/pocket-ic"],
+            [
+                # Keep sorted.
+                "//packages/pocket-ic",
+                "@crate_index//:ic-management-canister-types",
+            ],
         ],
     ]
 ]

--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -14,8 +14,8 @@ package(default_visibility = ["//visibility:public"])
         ],
         deps = [
             # Keep sorted.
+            "//packages/ic-http-types",
             "@crate_index//:candid",
-            "@crate_index//:ic-http-types",
             "@crate_index//:regex",
             "@crate_index//:serde",
             "@crate_index//:serde_bytes",

--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -11,13 +11,16 @@ package(default_visibility = ["//visibility:public"])
         deps = [
             # Keep sorted.
             "//packages/ic-http-types",
-            "@crate_index//:async-trait",
             "@crate_index//:candid",
             "@crate_index//:ic-management-canister-types",
             "@crate_index//:regex",
             "@crate_index//:serde",
             "@crate_index//:serde_bytes",
         ] + extra_deps,
+        proc_macro_deps = [
+            # Keep sorted.
+            "@crate_index//:async-trait",
+        ],
     )
     for (name_suffix, features, extra_deps) in [
         [

--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -8,10 +8,6 @@ package(default_visibility = ["//visibility:public"])
         srcs = glob(["src/**/*.rs"]),
         crate_features = features,
         crate_name = "ic_metrics_assert",
-        proc_macro_deps = [
-            # Keep sorted.
-            "@crate_index//:async-trait",
-        ],
         deps = [
             # Keep sorted.
             "//packages/ic-http-types",

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 documentation.workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
 candid = { workspace = true }
 ic-http-types = { version = "0.1.0", path = "../ic-http-types" }
 ic-management-canister-types = { workspace = true, optional = true }

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -13,7 +13,7 @@ documentation.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 candid = { workspace = true }
-ic-http-types = { path = "../../packages/ic-http-types" }
+ic-http-types = { version = "=0.1.0", path = "../ic-http-types" }
 ic-management-canister-types = { workspace = true, optional = true }
 pocket-ic = { path = "../../packages/pocket-ic", optional = true }
 regex = "1.11.0"

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -11,7 +11,6 @@ edition.workspace = true
 documentation.workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
 candid = { workspace = true }
 ic-http-types = { version = "0.1.0", path = "../ic-http-types" }
 ic-management-canister-types = { workspace = true, optional = true }

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -12,11 +12,19 @@ documentation.workspace = true
 
 [dependencies]
 candid = { workspace = true }
-pocket-ic = { path = "../../packages/pocket-ic", optional = true }
+futures = { workspace = true, optional = true }
+ic-http-types = { path = "../../packages/ic-http-types" }
 ic-management-canister-types = { workspace = true }
+pocket-ic = { path = "../../packages/pocket-ic", optional = true }
 regex = "1.11.0"
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+tokio = { workspace = true, optional = true }
 
 [features]
 pocket_ic = ["dep:pocket-ic"]
+pocket_ic_nonblocking = [
+    "dep:futures",
+    "dep:pocket-ic",
+    "dep:tokio",
+]

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -11,20 +11,14 @@ edition.workspace = true
 documentation.workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
 candid = { workspace = true }
-futures = { workspace = true, optional = true }
 ic-http-types = { path = "../../packages/ic-http-types" }
 ic-management-canister-types = { workspace = true }
 pocket-ic = { path = "../../packages/pocket-ic", optional = true }
 regex = "1.11.0"
 serde = { workspace = true }
 serde_bytes = { workspace = true }
-tokio = { workspace = true, optional = true }
 
 [features]
 pocket_ic = ["dep:pocket-ic"]
-pocket_ic_nonblocking = [
-    "dep:futures",
-    "dep:pocket-ic",
-    "dep:tokio",
-]

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -13,9 +13,9 @@ documentation.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 candid = { workspace = true }
-ic-http-types = { version = "=0.1.0", path = "../ic-http-types" }
+ic-http-types = { version = "0.1.0", path = "../ic-http-types" }
 ic-management-canister-types = { workspace = true, optional = true }
-pocket-ic = { path = "../../packages/pocket-ic", optional = true }
+pocket-ic = { version = "9.0.2", path = "../../packages/pocket-ic", optional = true }
 regex = "1.11.0"
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -14,11 +14,14 @@ documentation.workspace = true
 async-trait = { workspace = true }
 candid = { workspace = true }
 ic-http-types = { path = "../../packages/ic-http-types" }
-ic-management-canister-types = { workspace = true }
+ic-management-canister-types = { workspace = true, optional = true }
 pocket-ic = { path = "../../packages/pocket-ic", optional = true }
 regex = "1.11.0"
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 
 [features]
-pocket_ic = ["dep:pocket-ic"]
+pocket_ic = [
+    "dep:ic-management-canister-types",
+    "dep:pocket-ic",
+]

--- a/packages/ic-metrics-assert/src/lib.rs
+++ b/packages/ic-metrics-assert/src/lib.rs
@@ -152,10 +152,7 @@ pub trait CanisterHttpQuery<E: Debug> {
 
 /// Trait providing the ability to perform an async HTTP request to a canister.
 #[async_trait]
-pub trait AsyncCanisterHttpQuery<E>
-where
-    E: Debug,
-{
+pub trait AsyncCanisterHttpQuery<E: Debug> {
     /// Sends a serialized HTTP request to a canister and returns the serialized HTTP response.
     async fn http_query(&self, request: Vec<u8>) -> Result<Vec<u8>, E>;
 }
@@ -163,7 +160,9 @@ where
 #[cfg(feature = "pocket_ic")]
 mod pocket_ic_query_call {
     use super::*;
-    use pocket_ic::PocketIc;
+    use candid::Principal;
+    use ic_management_canister_types::CanisterId;
+    use pocket_ic::{PocketIc, RejectResponse};
 
     /// Provides an implementation of the [`CanisterHttpQuery`] trait in the case where the canister
     /// HTTP requests are made through an instance of [`PocketIc`].

--- a/packages/ic-metrics-assert/src/lib.rs
+++ b/packages/ic-metrics-assert/src/lib.rs
@@ -5,7 +5,7 @@
 use candid::{Decode, Encode};
 use ic_http_types::{HttpRequest, HttpResponse};
 #[cfg(feature = "pocket_ic")]
-pub use pocket_ic_query_call::PocketIcHttpQuery;
+pub use pocket_ic_query_call::{PocketIcAsyncHttpQuery, PocketIcHttpQuery};
 use regex::Regex;
 use std::fmt::Debug;
 use std::future::Future;

--- a/packages/ic-metrics-assert/src/lib.rs
+++ b/packages/ic-metrics-assert/src/lib.rs
@@ -1,5 +1,6 @@
 //! Fluent assertions for metrics.
 
+#![forbid(unsafe_code)]
 #![forbid(missing_docs)]
 
 use candid::{Decode, Encode};
@@ -7,9 +8,7 @@ use ic_http_types::{HttpRequest, HttpResponse};
 #[cfg(feature = "pocket_ic")]
 pub use pocket_ic_query_call::{PocketIcAsyncHttpQuery, PocketIcHttpQuery};
 use regex::Regex;
-use std::fmt::Debug;
-use std::future::Future;
-use std::pin::Pin;
+use std::{fmt::Debug, future::Future, pin::Pin};
 
 /// Provides fluent test assertions for metrics.
 ///
@@ -188,10 +187,11 @@ mod pocket_ic_query_call {
         }
     }
 
-    /// Provides an implementation of the [`CanisterHttpQuery`] trait in the case where the canister
-    /// HTTP requests are made through an instance of [`PocketIc`].
+    /// Provides an implementation of the [`AsyncCanisterHttpQuery`] trait in the case where the
+    /// canister HTTP requests are made through an instance of [`nonblocking::PocketIc`].
     pub trait PocketIcAsyncHttpQuery {
-        /// Returns a reference to the instance of [`PocketIc`] through which the HTTP requests are made.
+        /// Returns a reference to the instance of [`nonblocking::PocketIc`] through which the HTTP
+        /// requests are made.
         fn get_pocket_ic(&self) -> &nonblocking::PocketIc;
 
         /// Returns the ID of the canister to which HTTP requests will be made.


### PR DESCRIPTION
(XC-296) Add a new async trait in `ic-metrics-assert` to fetch metrics via an asynchronous HTTP query.