### PR TITLE
chore: build all targets on aarch64-darwin

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -299,7 +299,7 @@ jobs:
             test \
             --config=ci --config=macos_ci \
             --test_tag_filters="test_macos,test_macos_slow" \
-            //packages/pocket-ic/... //rs/... //publish/binaries/...
+            //...
 
           mkdir -p build
           cp \

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -267,7 +267,7 @@ jobs:
             test \
             --config=ci --config=macos_ci \
             --test_tag_filters="test_macos,test_macos_slow" \
-            //packages/pocket-ic/... //rs/... //publish/binaries/...
+            //...
 
           mkdir -p build
           cp \


### PR DESCRIPTION
To be consistent with `bazel-test-all` and `bazel-test-macos-intel` we run `bazel test` on `//...` instead of a subset of targets on aarch64-darwin. This should also be less error prone.