### PR TITLE
fix(IDX): Remove outdated reference to CI_MACOS_INTEL

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -207,7 +207,6 @@ jobs:
     runs-on:
       labels: macOS
     # Run on protected branches, but only on public repo
-    # Allow running if CI_MACOS_INTEL label is used
     if: github.repository == 'dfinity/ic'
 
     steps:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -179,7 +179,6 @@ jobs:
     runs-on:
       labels: macOS
     # Run on protected branches, but only on public repo
-    # Allow running if CI_MACOS_INTEL label is used
     if: github.repository == 'dfinity/ic'
     steps:
       - name: Checkout


### PR DESCRIPTION
The comment doesn't apply anymore.