### PR TITLE
chore(IDX): drop unused icos targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -163,11 +163,8 @@ upload_artifacts(
         "//conditions:default": [
             "//publish/binaries:bundle-legacy",  # avoid overwriting legacy artifacts
             "//publish/canisters:bundle",
-            "//ic-os/guestos/envs/dev:bundle-disk",
-            "//ic-os/guestos/envs/dev:bundle-update",
-            "//ic-os/guestos/envs/prod:bundle-disk",
+            "//ic-os/guestos/envs/dev:bundle-disk",  # used by icos_deploy testnet script
             "//ic-os/guestos/envs/prod:bundle-update",
-            "//ic-os/hostos/envs/prod:bundle-disk",
             "//ic-os/hostos/envs/prod:bundle-update",
             "//ic-os/setupos/envs/prod:bundle",
         ],

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -200,16 +200,10 @@ fi
 
 if "$BUILD_IMG"; then
     echo_green "##### GUESTOS SHA256SUMS #####"
-    pushd "$DISK_DIR_FULL/guestos/disk" >/dev/null
-    cat SHA256SUMS
-    popd >/dev/null
     pushd "$DISK_DIR_FULL/guestos/update" >/dev/null
     cat SHA256SUMS
     popd >/dev/null
     echo_green "##### HOSTOS SHA256SUMS #####"
-    pushd "$DISK_DIR_FULL/hostos/disk" >/dev/null
-    cat SHA256SUMS
-    popd >/dev/null
     pushd "$DISK_DIR_FULL/hostos/update" >/dev/null
     cat SHA256SUMS
     popd >/dev/null

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -136,9 +136,7 @@ rm -rf "$DISK_DIR_FULL"
 if "$BUILD_BIN"; then BAZEL_TARGETS+=("//publish/binaries:bundle"); fi
 if "$BUILD_CAN"; then BAZEL_TARGETS+=("//publish/canisters:bundle"); fi
 if "$BUILD_IMG"; then BAZEL_TARGETS+=(
-    "//ic-os/guestos/envs/prod:bundle-disk"
     "//ic-os/guestos/envs/prod:bundle-update"
-    "//ic-os/hostos/envs/prod:bundle-disk"
     "//ic-os/hostos/envs/prod:bundle-update"
     "//ic-os/setupos/envs/prod:bundle"
 ); fi

--- a/ic-os/defs.bzl
+++ b/ic-os/defs.bzl
@@ -46,6 +46,11 @@ def icos_build(
       A struct containing the labels of the images that were built.
     """
 
+    # we "declare" lots of different image combinations, though most of
+    # them are not actually used. Because CI jobs make heavy use of '//...'
+    # we make sure that images aren't built unless explicitly depended on.
+    tags = ["manual"] + (tags if tags != None else [])
+
     if mode == None:
         mode = name
 

--- a/ic-os/guestos/envs/dev/BUILD.bazel
+++ b/ic-os/guestos/envs/dev/BUILD.bazel
@@ -24,11 +24,3 @@ artifact_bundle(
     prefix = "guest-os/disk-img-dev",
     visibility = ["//visibility:public"],
 )
-
-artifact_bundle(
-    name = "bundle-update",
-    testonly = True,
-    inputs = [icos_images.update_image],
-    prefix = "guest-os/update-img-dev",
-    visibility = ["//visibility:public"],
-)

--- a/ic-os/guestos/envs/prod/BUILD.bazel
+++ b/ic-os/guestos/envs/prod/BUILD.bazel
@@ -31,13 +31,6 @@ file_size_check(
 # Export checksums & build artifacts
 # (image is used for GuestOS upgrades)
 artifact_bundle(
-    name = "bundle-disk",
-    inputs = [icos_images.disk_image],
-    prefix = "guest-os/disk-img",
-    visibility = ["//visibility:public"],
-)
-
-artifact_bundle(
     name = "bundle-update",
     inputs = [
         icos_images.update_image,

--- a/ic-os/hostos/envs/prod/BUILD.bazel
+++ b/ic-os/hostos/envs/prod/BUILD.bazel
@@ -29,14 +29,6 @@ file_size_check(
 # Export checksums & build artifacts
 # (image is used for HostOS upgrades)
 artifact_bundle(
-    name = "bundle-disk",
-    testonly = True,
-    inputs = [icos_images.disk_image],
-    prefix = "host-os/disk-img",
-    visibility = ["//visibility:public"],
-)
-
-artifact_bundle(
     name = "bundle-update",
     testonly = True,
     inputs = [


### PR DESCRIPTION
This removes some IC-OS targets that were not being used and marks all `icos_build` targets as `manual` by default to avoid them being built with `bazel build //...`.