### PR TITLE
feat(nns): Use timer_tasks library for some timer tasks

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -72,8 +72,6 @@ pub(crate) const LOG_PREFIX: &str = "[Governance] ";
 
 fn schedule_timers() {
     schedule_spawn_neurons();
-    schedule_unstake_maturity_of_dissolved_neurons();
-    schedule_neuron_data_validation();
     schedule_vote_processing();
     schedule_tasks();
 }
@@ -84,20 +82,6 @@ fn schedule_spawn_neurons() {
         spawn(async {
             governance_mut().maybe_spawn_neurons().await;
         });
-    });
-}
-
-const UNSTAKE_MATURITY_OF_DISSOLVED_NEURONS_INTERVAL: Duration = Duration::from_secs(60);
-fn schedule_unstake_maturity_of_dissolved_neurons() {
-    ic_cdk_timers::set_timer_interval(UNSTAKE_MATURITY_OF_DISSOLVED_NEURONS_INTERVAL, || {
-        governance_mut().unstake_maturity_of_dissolved_neurons();
-    });
-}
-
-const NEURON_DATA_VALIDATION_INTERNVAL: Duration = Duration::from_secs(5);
-fn schedule_neuron_data_validation() {
-    ic_cdk_timers::set_timer_interval(NEURON_DATA_VALIDATION_INTERNVAL, || {
-        governance_mut().maybe_run_validations();
     });
 }
 

--- a/rs/nns/governance/src/timer_tasks/mod.rs
+++ b/rs/nns/governance/src/timer_tasks/mod.rs
@@ -2,21 +2,25 @@ use calculate_distributable_rewards::CalculateDistributableRewardsTask;
 use finalize_maturity_disbursements::FinalizeMaturityDisbursementsTask;
 use ic_metrics_encoder::MetricsEncoder;
 use ic_nervous_system_timer_task::{
-    RecurringAsyncTask, RecurringSyncTask, TimerTaskMetricsRegistry,
+    PeriodicSyncTask, RecurringAsyncTask, RecurringSyncTask, TimerTaskMetricsRegistry,
 };
+use neuron_data_validation::NeuronDataValidationTask;
 use prune_following::PruneFollowingTask;
 use seeding::SeedingTask;
 use snapshot_voting_power::SnapshotVotingPowerTask;
 use std::cell::RefCell;
+use unstake_maturity_of_dissolved_neurons::UnstakeMaturityOfDissolvedNeuronsTask;
 
 use crate::{canister_state::GOVERNANCE, storage::VOTING_POWER_SNAPSHOTS};
 
 mod calculate_distributable_rewards;
 mod distribute_rewards;
 mod finalize_maturity_disbursements;
+mod neuron_data_validation;
 mod prune_following;
 mod seeding;
 mod snapshot_voting_power;
+mod unstake_maturity_of_dissolved_neurons;
 
 thread_local! {
     static METRICS_REGISTRY: RefCell<TimerTaskMetricsRegistry> = RefCell::new(TimerTaskMetricsRegistry::default());
@@ -28,6 +32,8 @@ pub fn schedule_tasks() {
     PruneFollowingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     SnapshotVotingPowerTask::new(&GOVERNANCE, &VOTING_POWER_SNAPSHOTS).schedule(&METRICS_REGISTRY);
     FinalizeMaturityDisbursementsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
+    UnstakeMaturityOfDissolvedNeuronsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
+    NeuronDataValidationTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
 
     run_distribute_rewards_periodic_task();
 }

--- a/rs/nns/governance/src/timer_tasks/neuron_data_validation.rs
+++ b/rs/nns/governance/src/timer_tasks/neuron_data_validation.rs
@@ -1,0 +1,28 @@
+use crate::governance::Governance;
+
+use ic_nervous_system_timer_task::PeriodicSyncTask;
+use std::{cell::RefCell, thread::LocalKey, time::Duration};
+
+const NEURON_DATA_VALIDATION_INTERNVAL: Duration = Duration::from_secs(5);
+
+#[derive(Copy, Clone)]
+pub(super) struct NeuronDataValidationTask {
+    governance: &'static LocalKey<RefCell<Governance>>,
+}
+
+impl NeuronDataValidationTask {
+    pub fn new(governance: &'static LocalKey<RefCell<Governance>>) -> Self {
+        Self { governance }
+    }
+}
+
+impl PeriodicSyncTask for NeuronDataValidationTask {
+    fn execute(self) {
+        self.governance.with_borrow_mut(|governance| {
+            governance.maybe_run_validations();
+        });
+    }
+
+    const NAME: &'static str = "neuron_data_validation";
+    const INTERVAL: Duration = NEURON_DATA_VALIDATION_INTERNVAL;
+}

--- a/rs/nns/governance/src/timer_tasks/unstake_maturity_of_dissolved_neurons.rs
+++ b/rs/nns/governance/src/timer_tasks/unstake_maturity_of_dissolved_neurons.rs
@@ -1,0 +1,32 @@
+use crate::governance::Governance;
+
+use ic_nervous_system_timer_task::PeriodicSyncTask;
+use std::{cell::RefCell, thread::LocalKey, time::Duration};
+
+/// The interval at which the maturity of dissolved neurons is unstaked. The value is chosen so that
+/// even if there is some bug with the task causing it to run out of instructions ever time (50B),
+/// given the 2B DTS slice and assuming 1 round per second, there should still be room for other
+/// tasks as it will only take 25 seconds to run through the task.
+const UNSTAKE_MATURITY_OF_DISSOLVED_NEURONS_INTERVAL: Duration = Duration::from_secs(60);
+
+#[derive(Copy, Clone)]
+pub(super) struct UnstakeMaturityOfDissolvedNeuronsTask {
+    governance: &'static LocalKey<RefCell<Governance>>,
+}
+
+impl UnstakeMaturityOfDissolvedNeuronsTask {
+    pub fn new(governance: &'static LocalKey<RefCell<Governance>>) -> Self {
+        Self { governance }
+    }
+}
+
+impl PeriodicSyncTask for UnstakeMaturityOfDissolvedNeuronsTask {
+    fn execute(self) {
+        self.governance.with_borrow_mut(|governance| {
+            governance.unstake_maturity_of_dissolved_neurons();
+        });
+    }
+
+    const NAME: &'static str = "unstake_maturity_of_dissolved_neurons";
+    const INTERVAL: Duration = UNSTAKE_MATURITY_OF_DISSOLVED_NEURONS_INTERVAL;
+}

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,6 +11,9 @@ on the process that this file is part of, see
 
 ## Changed
 
+* Task execution metrics are added for `neuron_data_validation` and
+  `unstake_maturity_of_dissolved_neurons` timer tasks.
+
 ## Deprecated
 
 ## Removed

--- a/rs/nns/integration_tests/src/governance_neurons.rs
+++ b/rs/nns/integration_tests/src/governance_neurons.rs
@@ -34,8 +34,8 @@ use ic_nns_test_utils::{
         nns_governance_get_full_neuron, nns_governance_get_neuron_info,
         nns_governance_make_proposal, nns_increase_dissolve_delay, nns_join_community_fund,
         nns_leave_community_fund, nns_remove_hot_key, nns_send_icp_to_claim_or_refresh_neuron,
-        nns_set_followees_for_neuron, nns_start_dissolving, setup_nns_canisters,
-        state_machine_builder_for_nns_tests,
+        nns_set_auto_stake_maturity, nns_set_followees_for_neuron, nns_start_dissolving,
+        setup_nns_canisters, state_machine_builder_for_nns_tests,
     },
 };
 use ic_state_machine_tests::StateMachine;
@@ -311,6 +311,7 @@ fn create_neuron_with_maturity(
     state_machine: &StateMachine,
     neuron_controller: PrincipalId,
     stake: Tokens,
+    auto_stake: bool,
 ) -> NeuronIdProto {
     let neuron_id = create_neuron_with_stake(state_machine, neuron_controller, stake);
     nns_increase_dissolve_delay(
@@ -320,6 +321,10 @@ fn create_neuron_with_maturity(
         ONE_YEAR_SECONDS * 7,
     )
     .unwrap();
+    if auto_stake {
+        nns_set_auto_stake_maturity(state_machine, neuron_controller, neuron_id, true)
+            .panic_if_error("Failed to set auto stake maturity to true");
+    }
     nns_governance_make_proposal(
         state_machine,
         neuron_controller,
@@ -332,7 +337,8 @@ fn create_neuron_with_maturity(
                 motion_text: "some motion text".to_string(),
             })),
         },
-    );
+    )
+    .panic_if_error("Failed to make proposal");
     state_machine.advance_time(Duration::from_secs(ONE_DAY_SECONDS * 5));
     for _ in 0..100 {
         state_machine.advance_time(Duration::from_secs(1));
@@ -341,7 +347,11 @@ fn create_neuron_with_maturity(
 
     let neuron = nns_governance_get_full_neuron(state_machine, neuron_controller, neuron_id.id)
         .expect("Failed to get neuron");
-    assert!(neuron.maturity_e8s_equivalent > 0);
+    if auto_stake {
+        assert!(neuron.staked_maturity_e8s_equivalent.unwrap() > 0);
+    } else {
+        assert!(neuron.maturity_e8s_equivalent > 0);
+    }
 
     neuron_id
 }
@@ -388,11 +398,13 @@ fn test_neuron_disburse_maturity() {
         &state_machine,
         neuron_1_controller,
         Tokens::from_tokens(1000).unwrap(),
+        false,
     );
     let neuron_id_2 = create_neuron_with_maturity(
         &state_machine,
         neuron_2_controller,
         Tokens::from_tokens(1000).unwrap(),
+        false,
     );
 
     // Step 1.3: check that both neurons have no maturity disbursement in progress, and record their
@@ -721,6 +733,7 @@ fn test_neuron_disburse_maturity_through_neuron_management_proposal() {
         &state_machine,
         managed_neuron_controller,
         Tokens::from_tokens(1000).unwrap(),
+        false,
     );
 
     // Step 1.3: check that the neuron has no maturity disbursement in progress, and record its
@@ -1008,6 +1021,71 @@ fn test_claim_neuron() {
     );
     assert_eq!(neuron_info.age_seconds, 0);
     assert_eq!(neuron_info.stake_e8s, 1_000_000_000);
+}
+
+#[test]
+fn test_unstake_maturity_of_dissolved_neurons() {
+    // Step 1: Prepare the world.
+    let controller = PrincipalId::new_self_authenticating(b"controller");
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    let nns_init_payloads = NnsInitPayloadsBuilder::new()
+        .with_ledger_account(
+            AccountIdentifier::new(controller, None),
+            Tokens::from_tokens(2000).unwrap(),
+        )
+        .build();
+    setup_nns_canisters(&state_machine, nns_init_payloads);
+
+    let neuron_id = create_neuron_with_maturity(
+        &state_machine,
+        controller,
+        Tokens::from_tokens(1000).unwrap(),
+        true,
+    );
+
+    // Step 2: Create a neuron with some staked maturity.
+    let full_neuron =
+        nns_governance_get_full_neuron(&state_machine, controller, neuron_id.id).unwrap();
+    assert_eq!(full_neuron.auto_stake_maturity, Some(true));
+    assert!(full_neuron.staked_maturity_e8s_equivalent.unwrap() > 0);
+    let dissolve_state = full_neuron.dissolve_state.unwrap();
+    let dissolve_delay = match dissolve_state {
+        DissolveState::DissolveDelaySeconds(dissolve_delay) => {
+            // The dissolve delay here should be around 7 years, but in the test we only want to make sure
+            // it's reasonably large enough for the test to continue.
+            assert!(
+                dissolve_delay > 3600,
+                "The dissolve delay should be much greater than 1 hour"
+            );
+            dissolve_delay
+        }
+        _ => panic!("Unexpected dissolve state: {:#?}", dissolve_state),
+    };
+
+    // Step 2: Start dissolving the neuron and advance time to be close to the dissolve delay.
+    nns_start_dissolving(&state_machine, controller, neuron_id).unwrap();
+    state_machine.advance_time(Duration::from_secs(dissolve_delay - 3600));
+    for _ in 0..20 {
+        state_machine.advance_time(Duration::from_secs(5));
+        state_machine.tick();
+    }
+
+    // Step 3: Check that the neuron still has some maturity staked.
+    let full_neuron =
+        nns_governance_get_full_neuron(&state_machine, controller, neuron_id.id).unwrap();
+    assert!(full_neuron.staked_maturity_e8s_equivalent.unwrap() > 0);
+
+    // Step 4: Advance time to be after the dissolve delay.
+    state_machine.advance_time(Duration::from_secs(3600));
+    for _ in 0..20 {
+        state_machine.advance_time(Duration::from_secs(5));
+        state_machine.tick();
+    }
+
+    // Step 5: Check that the neuron has no maturity staked.
+    let full_neuron =
+        nns_governance_get_full_neuron(&state_machine, controller, neuron_id.id).unwrap();
+    assert_eq!(full_neuron.staked_maturity_e8s_equivalent, None);
 }
 
 #[test]

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -43,9 +43,9 @@ use ic_nns_governance_api::{
         self,
         claim_or_refresh::{self, MemoAndController},
         configure::Operation,
-        AddHotKey, ClaimOrRefresh, Configure, Disburse, DisburseMaturity, Follow,
-        IncreaseDissolveDelay, JoinCommunityFund, LeaveCommunityFund, RegisterVote, RemoveHotKey,
-        Split, StakeMaturity,
+        AddHotKey, ChangeAutoStakeMaturity, ClaimOrRefresh, Configure, Disburse, DisburseMaturity,
+        Follow, IncreaseDissolveDelay, JoinCommunityFund, LeaveCommunityFund, RegisterVote,
+        RemoveHotKey, Split, StakeMaturity,
     },
     manage_neuron_response::{self, ClaimOrRefreshResponse},
     Empty, ExecuteNnsFunction, GetNeuronsFundAuditInfoRequest, GetNeuronsFundAuditInfoResponse,
@@ -1485,6 +1485,23 @@ pub fn nns_stake_maturity(
 ) -> ManageNeuronResponse {
     let command = ManageNeuronCommandRequest::StakeMaturity(StakeMaturity {
         percentage_to_stake,
+    });
+
+    manage_neuron_or_panic(state_machine, sender, neuron_id, command)
+}
+
+pub fn nns_set_auto_stake_maturity(
+    state_machine: &StateMachine,
+    sender: PrincipalId,
+    neuron_id: NeuronId,
+    auto_stake: bool,
+) -> ManageNeuronResponse {
+    let command = ManageNeuronCommandRequest::Configure(Configure {
+        operation: Some(Operation::ChangeAutoStakeMaturity(
+            ChangeAutoStakeMaturity {
+                requested_setting_for_auto_stake_maturity: auto_stake,
+            },
+        )),
     });
 
     manage_neuron_or_panic(state_machine, sender, neuron_id, command)


### PR DESCRIPTION
# Why

The timer_tasks library uses canonical patterns to schedule timers, while exposing metrics about task execution. This will make it easier to monitor the tasks. In addition, with the new pattern, the `governance_mut()` unsafe accessor is avoided.

# What 

* Create new `PeriodicSyncTask` for `neuron_data_validation` and `unstake_maturity_of_dissolved_neurons`
* Remove existing scheduling in `canister.rs`
* Add a state machine test for `unstake_maturity_of_dissolved_neurons`