### PR TITLE
feat(ICP_Ledger): FI-1729: Burn funds of the anonymous principal

### DIFF
--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -861,7 +861,27 @@ fn post_upgrade(args: Option<LedgerCanisterPayload>) {
                 if let Some(upgrade_args) = upgrade_args {
                     ledger.upgrade(upgrade_args);
                 }
-        }
+                // FIXME(FI-1729): Remove this burn once a ledger version allowing the anonymous principal
+                //  to perform transactions has been released.
+                let anonymous_account = AccountIdentifier::from(PrincipalId::new_anonymous());
+                let anonymous_balance = ledger.balances().account_balance(&anonymous_account);
+                if anonymous_balance > Tokens::ZERO {
+                    ledger.add_payment(
+                        Memo::default(),
+                        Operation::Burn {
+                            from: anonymous_account,
+                            amount: anonymous_balance,
+                            spender: None,
+                        },
+                        None,
+                    )
+                        .expect("Burning tokens during upgrade failed");
+                    print(format!(
+                        "[ledger] post_upgrade(): burned {} from default account of the anonymous principal ({})",
+                        anonymous_balance, anonymous_account
+                    ));
+                }
+            }
     }
         }
         set_certified_data(

--- a/rs/ledger_suite/icp/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icp/ledger/tests/tests.rs
@@ -1871,3 +1871,168 @@ mod metrics {
         );
     }
 }
+
+mod anonymous_burn {
+    use super::*;
+
+    #[test]
+    fn test_burning_anonymous_funds() {
+        const INITIAL_BALANCE: u64 = 100_000;
+
+        let mainnet_wasm = ledger_wasm_mainnet();
+        let ledger_wasm = ledger_wasm();
+
+        let anonymous = PrincipalId::new_anonymous();
+        let p1 = PrincipalId::new_user_test_id(1);
+
+        let env = StateMachine::new();
+        let mut initial_balances = HashMap::new();
+        initial_balances.insert(
+            AccountIdentifier::from(Account::from(anonymous.0)),
+            Tokens::from_e8s(INITIAL_BALANCE),
+        );
+        initial_balances.insert(
+            AccountIdentifier::from(Account::from(p1.0)),
+            Tokens::from_e8s(INITIAL_BALANCE),
+        );
+        let payload = LedgerCanisterInitPayload::builder()
+            .minting_account(MINTER.into())
+            .icrc1_minting_account(MINTER)
+            .initial_values(initial_balances)
+            .transfer_fee(Tokens::from_e8s(10_000))
+            .token_symbol_and_name("ICP", "Internet Computer")
+            .build()
+            .unwrap();
+        let canister_id = env
+            .install_canister(mainnet_wasm.clone(), Encode!(&payload).unwrap(), None)
+            .expect("Unable to install the mainnet Ledger canister");
+
+        let anonymous_balance = balance_of(&env, canister_id, anonymous.0);
+        assert_eq!(anonymous_balance, INITIAL_BALANCE);
+
+        // Verify that only the two mint blocks are present in the ledger.
+        let query_blocks_response = query_blocks(&env, anonymous.0, canister_id, 0, 10u64);
+        let chain_length = query_blocks_response.chain_length;
+        assert_eq!(chain_length, 2);
+
+        // Verify that the anonymous account cannot transfer funds using the mainnet ledger version.
+        // If this check fails, it means that the mainnet ledger has been upgraded to a version that
+        // allows anonymous transfers - in addition to fixing this check, we should also clean up the
+        // burning of funds from the default anonymous account in the ledger post_upgrade.
+        let transfer_arg = TransferArg {
+            from_subaccount: None,
+            to: Account::from(p1.0),
+            fee: None,
+            created_at_time: None,
+            amount: icrc_ledger_types::icrc1::transfer::NumTokens::from(INITIAL_BALANCE - FEE),
+            memo: None,
+        };
+        let response = env
+            .execute_ingress_as(
+                anonymous,
+                canister_id,
+                "icrc1_transfer",
+                Encode!(&transfer_arg).unwrap(),
+            )
+            .expect_err("Transfer from the default account of the anonymous principal should fail");
+        assert!(response
+            .description()
+            .contains("Anonymous principal cannot hold tokens on the ledger."));
+        assert_eq!(response.code(), ErrorCode::CanisterCalledTrap);
+
+        // Upgrade to the latest ledger version that burns the funds in the default subaccount of
+        // the anonymous principal.
+        env.upgrade_canister(
+            canister_id,
+            ledger_wasm.clone(),
+            Encode!(&LedgerCanisterPayload::Upgrade(None)).unwrap(),
+        )
+        .unwrap();
+
+        // Expect the funds in the default subaccount of the anonymous principal to have been burned.
+        let anonymous_balance = balance_of(&env, canister_id, anonymous.0);
+        assert_eq!(anonymous_balance, 0u64);
+        // Verify that a new Burn block was created.
+        let query_blocks_response = query_blocks(
+            &env,
+            anonymous.0,
+            canister_id,
+            query_blocks_response.chain_length,
+            1u64,
+        );
+        assert_eq!(query_blocks_response.chain_length, 3);
+        let actual_burn = query_blocks_response
+            .blocks
+            .last()
+            .expect("Should have a last block")
+            .transaction
+            .operation
+            .as_ref()
+            .expect("Should have an operation");
+        let expected_burn = CandidOperation::Burn {
+            from: AccountIdentifier::from(anonymous.0).to_address(),
+            amount: Tokens::from_e8s(INITIAL_BALANCE),
+            spender: None,
+        };
+        assert_eq!(actual_burn, &expected_burn);
+    }
+
+    #[test]
+    fn test_upgrade_with_no_anonymous_funds_to_burn() {
+        const INITIAL_BALANCE: u64 = 100_000;
+
+        let mainnet_wasm = ledger_wasm_mainnet();
+        let ledger_wasm = ledger_wasm();
+
+        let anonymous = PrincipalId::new_anonymous();
+        let p1 = PrincipalId::new_user_test_id(1);
+
+        let env = StateMachine::new();
+        let mut initial_balances = HashMap::new();
+        initial_balances.insert(
+            AccountIdentifier::from(Account::from(p1.0)),
+            Tokens::from_e8s(INITIAL_BALANCE),
+        );
+        let payload = LedgerCanisterInitPayload::builder()
+            .minting_account(MINTER.into())
+            .icrc1_minting_account(MINTER)
+            .initial_values(initial_balances)
+            .transfer_fee(Tokens::from_e8s(10_000))
+            .token_symbol_and_name("ICP", "Internet Computer")
+            .build()
+            .unwrap();
+        let canister_id = env
+            .install_canister(mainnet_wasm.clone(), Encode!(&payload).unwrap(), None)
+            .expect("Unable to install the mainnet Ledger canister");
+
+        let anonymous_balance = balance_of(&env, canister_id, anonymous.0);
+        assert_eq!(anonymous_balance, 0u64);
+
+        // Verify that only the single mint block is present in the ledger.
+        let query_blocks_response = query_blocks(&env, anonymous.0, canister_id, 0, 10u64);
+        let chain_length = query_blocks_response.chain_length;
+        assert_eq!(chain_length, 1);
+
+        // Upgrade to the latest ledger version that burns the funds in the default subaccount of
+        // the anonymous principal.
+        env.upgrade_canister(
+            canister_id,
+            ledger_wasm.clone(),
+            Encode!(&LedgerCanisterPayload::Upgrade(None)).unwrap(),
+        )
+        .unwrap();
+
+        // Expect the default subaccount of the anonymous principal to still be empty.
+        let anonymous_balance = balance_of(&env, canister_id, anonymous.0);
+        assert_eq!(anonymous_balance, 0u64);
+        // Verify that a no new blocks were created.
+        let query_blocks_response = query_blocks(
+            &env,
+            anonymous.0,
+            canister_id,
+            query_blocks_response.chain_length,
+            1u64,
+        );
+        assert_eq!(query_blocks_response.chain_length, 1);
+    }
+}

--- a/rs/ledger_suite/icp/tests/golden_nns_state.rs
+++ b/rs/ledger_suite/icp/tests/golden_nns_state.rs
@@ -1,6 +1,6 @@
-use candid::{Decode, Encode};
+use candid::{Decode, Encode, Nat};
 use canister_test::Wasm;
-use ic_base_types::CanisterId;
+use ic_base_types::{CanisterId, PrincipalId};
 use ic_ledger_core::block::BlockType;
 use ic_ledger_core::Tokens;
 use ic_ledger_suite_state_machine_tests::in_memory_ledger::{
@@ -24,6 +24,7 @@ use ic_state_machine_tests::{ErrorCode, StateMachine, UserError};
 use icp_ledger::{
     AccountIdentifier, Archives, Block, FeatureFlags, LedgerCanisterPayload, UpgradeArgs,
 };
+use icrc_ledger_types::icrc1::account::Account;
 use std::time::Instant;
 
 /// The number of instructions that can be executed in a single canister upgrade as per
@@ -235,6 +236,9 @@ impl LedgerState {
 fn should_create_state_machine_with_golden_nns_state() {
     let mut setup = Setup::new();
 
+    // Check the balance of the default account of the anonymous principal
+    setup.check_balance_of_anonymous_account(false);
+
     // Perform upgrade and downgrade testing
     // (verify ledger balances and allowances, parity between ledger+archives and index)
     // Verifying the balances requires the ledger having the (currently test-only) allowance
@@ -246,6 +250,17 @@ fn should_create_state_machine_with_golden_nns_state() {
     setup.upgrade_to_master();
     // Upgrade again to test the pre-upgrade
     setup.upgrade_to_master();
+
+    // Check the balance of the default account of the anonymous principal again
+    setup.check_balance_of_anonymous_account(true);
+    // Ingest the burn block from the ledger into the in-memory ledger
+    let mut previous_ledger_state = setup.previous_ledger_state.take().unwrap();
+    previous_ledger_state.fetch_and_ingest_next_ledger_and_archive_blocks(
+        &setup.state_machine,
+        LEDGER_CANISTER_ID,
+        None,
+    );
+    setup.previous_ledger_state = Some(previous_ledger_state);
 
     // Perform upgrade and downgrade testing
     setup.perform_upgrade_downgrade_testing(true);
@@ -356,6 +371,40 @@ impl Setup {
             self.previous_ledger_state.take(),
             should_verify_balances_and_allowances,
         ));
+    }
+
+    fn check_balance_of_anonymous_account(&self, should_be_zero: bool) -> Nat {
+        let anonymous = PrincipalId::new_anonymous();
+        let anonymous_default_account = Account {
+            owner: anonymous.0,
+            subaccount: None,
+        };
+        let balance = Decode!(
+            &self
+                .state_machine
+                .query(
+                    LEDGER_CANISTER_ID,
+                    "icrc1_balance_of",
+                    Encode!(&anonymous_default_account).unwrap()
+                )
+                .expect("failed to query balance")
+                .bytes(),
+            Nat
+        )
+        .expect("failed to decode balance_of response");
+        println!(
+            "Balance of anonymous principal's default account: {}",
+            balance
+        );
+        let modifier = if should_be_zero { "not " } else { "" };
+        assert_eq!(
+            should_be_zero,
+            balance == Nat::from(0u64),
+            "Balance of anonymous principal's default account should {}be zero, but is {}",
+            modifier,
+            balance
+        );
+        balance
     }
 
     fn check_ledger_metrics(&self) {


### PR DESCRIPTION
Burn the funds in the default subaccount of the anonymous principal in the ICP ledger post upgrade.