### PR TITLE
feat(sns): Add `RegisterExtension` proposal type

### DIFF
--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -480,6 +480,36 @@ pub struct RegisterDappCanisters {
     /// At least one canister ID is required.
     pub canister_ids: Vec<::ic_base_types::PrincipalId>,
 }
+
+#[derive(
+    candid::CandidType, candid::Deserialize, comparable::Comparable, Clone, Debug, PartialEq,
+)]
+pub enum PreciseValue {
+    Bool(bool),
+    Blob(Vec<u8>),
+    Text(String),
+    Nat(u64),
+    Int(i64),
+    Array(Vec<PreciseValue>),
+    Map(BTreeMap<String, PreciseValue>),
+}
+
+#[derive(
+    candid::CandidType, candid::Deserialize, comparable::Comparable, Clone, Debug, PartialEq,
+)]
+pub struct ExtensionInit {
+    pub value: Option<PreciseValue>,
+}
+
+#[derive(
+    candid::CandidType, candid::Deserialize, comparable::Comparable, Clone, Debug, PartialEq,
+)]
+pub struct RegisterExtension {
+    /// Where the extension canister Wasm can be found.
+    pub chunked_canister_wasm: Option<ChunkedCanisterWasm>,
+
+    pub extension_init: Option<ExtensionInit>,
+}
 /// A proposal to remove a list of dapps from the SNS and assign them to new controllers
 #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
 pub struct DeregisterDappCanisters {
@@ -648,6 +678,10 @@ pub mod proposal {
         ///
         /// Id = 16;
         SetTopicsForCustomProposals(super::SetTopicsForCustomProposals),
+        /// Register an SNS extension canister.
+        ///
+        /// Id = 17.
+        RegisterExtension(super::RegisterExtension),
     }
 }
 #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -12,6 +12,7 @@ type Action = variant {
   UpgradeSnsToNextVersion : record {};
   AdvanceSnsTargetVersion : AdvanceSnsTargetVersion;
   RegisterDappCanisters : RegisterDappCanisters;
+  RegisterExtension : RegisterExtension;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
   DeregisterDappCanisters : DeregisterDappCanisters;
@@ -661,6 +662,40 @@ type QueryStats = record {
 
 type RegisterDappCanisters = record {
   canister_ids : vec principal;
+};
+
+// This type is equivalant to `ICRC3Value`, but we give it another name since it is used here not
+// in the context of the ICRC-3 ledger standard. The justification is the same: The candid format
+// supports sharing information even when the client and the server involved do not have the same
+// schema (see the Upgrading and subtyping section of the candid spec). While this mechanism allows
+// to evolve services and clients independently without breaking them, it also means that a client
+// may not receive all the information that the server is sending, e.g. in case the client schema
+// lacks some fields that the server schema has.
+//
+// This loss of information is not an option for SNS voters deciding if an extension with particular
+// init args should be installed or if an extension function with particular arguments should be
+// called. The client must receive the same exact data the server sent in order to verify it.
+//
+// Verification of a priorly installed extension is done by hashing the extension's init arg data
+// and checking that the result is consistent with what has been certified by the SNS.
+type PreciseValue = variant {
+  Bool : bool;
+  Blob : blob;
+  Text : text;
+  Nat : nat64;
+  Int : int64;
+  Array : vec PreciseValue;
+  Map : vec record { text; PreciseValue };
+};
+
+type ExtensionInit = record {
+  value : opt PreciseValue;
+};
+
+type RegisterExtension = record {
+  chunked_canister_wasm : opt ChunkedCanisterWasm;
+
+  extension_init : opt ExtensionInit;
 };
 
 type RegisterVote = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -443,6 +443,36 @@ message RegisterDappCanisters {
   repeated ic_base_types.pb.v1.PrincipalId canister_ids = 1;
 }
 
+message PreciseValue {
+  oneof precise_value {
+    bool bool = 1;
+    bytes blob = 2;
+    string text = 3;
+    uint64 nat = 4;
+    int64 int = 5;
+    PreciseArray array = 6;
+    PreciseMap map = 7;
+  }
+}
+
+message PreciseArray {
+  repeated PreciseValue array = 1;
+}
+
+message PreciseMap {
+  map<string, PreciseValue> map = 7;
+}
+
+message ExtensionInit {
+  optional PreciseValue value = 1;
+}
+
+message RegisterExtension {
+  optional ChunkedCanisterWasm chunked_canister_wasm = 1;
+
+  optional ExtensionInit extension_init = 2;
+}
+
 // A proposal to remove a list of dapps from the SNS and assign them to new controllers
 message DeregisterDappCanisters {
   // The canister IDs to be deregistered (i.e. removed from the management of the SNS).
@@ -627,8 +657,13 @@ message Proposal {
 
     // Change the mapping from custom proposal types to topics.
     //
-    // Id = 16;
+    // Id = 16.
     SetTopicsForCustomProposals set_topics_for_custom_proposals = 20;
+
+    // Register an SNS extension canister.
+    //
+    // Id = 17.
+    RegisterExtension register_extension = 21;
   }
 }
 

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -644,6 +644,95 @@ pub struct RegisterDappCanisters {
     #[prost(message, repeated, tag = "1")]
     pub canister_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
 }
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct PreciseValue {
+    #[prost(oneof = "precise_value::PreciseValue", tags = "1, 2, 3, 4, 5, 6, 7")]
+    pub precise_value: ::core::option::Option<precise_value::PreciseValue>,
+}
+/// Nested message and enum types in `PreciseValue`.
+pub mod precise_value {
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Oneof,
+    )]
+    pub enum PreciseValue {
+        #[prost(bool, tag = "1")]
+        Bool(bool),
+        #[prost(bytes, tag = "2")]
+        Blob(::prost::alloc::vec::Vec<u8>),
+        #[prost(string, tag = "3")]
+        Text(::prost::alloc::string::String),
+        #[prost(uint64, tag = "4")]
+        Nat(u64),
+        #[prost(int64, tag = "5")]
+        Int(i64),
+        #[prost(message, tag = "6")]
+        Array(super::PreciseArray),
+        #[prost(message, tag = "7")]
+        Map(super::PreciseMap),
+    }
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct PreciseArray {
+    #[prost(message, repeated, tag = "1")]
+    pub array: ::prost::alloc::vec::Vec<PreciseValue>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct PreciseMap {
+    #[prost(btree_map = "string, message", tag = "7")]
+    pub map: ::prost::alloc::collections::BTreeMap<::prost::alloc::string::String, PreciseValue>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ExtensionInit {
+    #[prost(message, optional, tag = "1")]
+    pub value: ::core::option::Option<PreciseValue>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct RegisterExtension {
+    #[prost(message, optional, tag = "1")]
+    pub chunked_canister_wasm: ::core::option::Option<ChunkedCanisterWasm>,
+    #[prost(message, optional, tag = "2")]
+    pub extension_init: ::core::option::Option<ExtensionInit>,
+}
 /// A proposal to remove a list of dapps from the SNS and assign them to new controllers
 #[derive(
     candid::CandidType,
@@ -776,7 +865,7 @@ pub struct Proposal {
     /// of this mapping.
     #[prost(
         oneof = "proposal::Action",
-        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
+        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21"
     )]
     pub action: ::core::option::Option<proposal::Action>,
 }
@@ -888,9 +977,14 @@ pub mod proposal {
         AdvanceSnsTargetVersion(super::AdvanceSnsTargetVersion),
         /// Change the mapping from custom proposal types to topics.
         ///
-        /// Id = 16;
+        /// Id = 16.
         #[prost(message, tag = "20")]
         SetTopicsForCustomProposals(super::SetTopicsForCustomProposals),
+        /// Register an SNS extension canister.
+        ///
+        /// Id = 17.
+        #[prost(message, tag = "21")]
+        RegisterExtension(super::RegisterExtension),
     }
 }
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -2117,6 +2117,10 @@ impl Governance {
                 self.perform_register_dapp_canisters(register_dapp_canisters)
                     .await
             }
+            Action::RegisterExtension(_) => Err(GovernanceError::new_with_message(
+                ErrorType::InvalidProposal,
+                "RegisterExtension proposals are not supported yet.",
+            )),
             Action::DeregisterDappCanisters(deregister_dapp_canisters) => {
                 self.perform_deregister_dapp_canisters(deregister_dapp_canisters)
                     .await

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -1,4 +1,4 @@
-use crate::pb::v1 as pb;
+use crate::pb::v1::{self as pb};
 use crate::topics;
 use ic_sns_governance_api::pb::v1 as pb_api;
 
@@ -581,6 +581,126 @@ impl From<pb_api::RegisterDappCanisters> for pb::RegisterDappCanisters {
     }
 }
 
+impl From<pb::precise_value::PreciseValue> for pb_api::PreciseValue {
+    fn from(item: pb::precise_value::PreciseValue) -> Self {
+        match item {
+            pb::precise_value::PreciseValue::Bool(v) => Self::Bool(v),
+            pb::precise_value::PreciseValue::Blob(v) => Self::Blob(v),
+            pb::precise_value::PreciseValue::Text(v) => Self::Text(v),
+            pb::precise_value::PreciseValue::Nat(v) => Self::Nat(v),
+            pb::precise_value::PreciseValue::Int(v) => Self::Int(v),
+            pb::precise_value::PreciseValue::Array(pb::PreciseArray { array }) => {
+                let api_array = array
+                    .into_iter()
+                    .filter_map(|pb::PreciseValue { precise_value }| precise_value.map(Self::from))
+                    .collect();
+
+                Self::Array(api_array)
+            }
+            pb::precise_value::PreciseValue::Map(pb::PreciseMap { map }) => {
+                let api_map = map
+                    .into_iter()
+                    .filter_map(|(key, pb::PreciseValue { precise_value })| {
+                        precise_value.map(|value| (key, Self::from(value)))
+                    })
+                    .collect();
+
+                Self::Map(api_map)
+            }
+        }
+    }
+}
+
+impl From<pb_api::PreciseValue> for pb::PreciseValue {
+    fn from(item: pb_api::PreciseValue) -> Self {
+        let precise_value = Some(match item {
+            pb_api::PreciseValue::Bool(v) => pb::precise_value::PreciseValue::Bool(v),
+            pb_api::PreciseValue::Blob(v) => pb::precise_value::PreciseValue::Blob(v),
+            pb_api::PreciseValue::Text(v) => pb::precise_value::PreciseValue::Text(v),
+            pb_api::PreciseValue::Nat(v) => pb::precise_value::PreciseValue::Nat(v),
+            pb_api::PreciseValue::Int(v) => pb::precise_value::PreciseValue::Int(v),
+            pb_api::PreciseValue::Array(array) => {
+                let array = array.into_iter().map(Self::from).collect();
+                let array = pb::PreciseArray { array };
+                pb::precise_value::PreciseValue::Array(array)
+            }
+            pb_api::PreciseValue::Map(map) => {
+                let map = map
+                    .into_iter()
+                    .map(|(key, value)| {
+                        let value = Self::from(value);
+                        (key, value)
+                    })
+                    .collect();
+
+                let map = pb::PreciseMap { map };
+
+                pb::precise_value::PreciseValue::Map(map)
+            }
+        });
+
+        Self { precise_value }
+    }
+}
+
+impl From<pb::ExtensionInit> for pb_api::ExtensionInit {
+    fn from(item: pb::ExtensionInit) -> Self {
+        let pb::ExtensionInit { value } = item;
+
+        let value = value.and_then(|pb::PreciseValue { precise_value }| {
+            precise_value.map(pb_api::PreciseValue::from)
+        });
+
+        Self { value }
+    }
+}
+
+impl From<pb_api::ExtensionInit> for pb::ExtensionInit {
+    fn from(item: pb_api::ExtensionInit) -> Self {
+        let pb_api::ExtensionInit { value } = item;
+
+        let value = value.map(pb::PreciseValue::from);
+
+        Self { value }
+    }
+}
+
+impl From<pb::RegisterExtension> for pb_api::RegisterExtension {
+    fn from(item: pb::RegisterExtension) -> Self {
+        let pb::RegisterExtension {
+            chunked_canister_wasm,
+            extension_init,
+        } = item;
+
+        let chunked_canister_wasm = chunked_canister_wasm.map(pb_api::ChunkedCanisterWasm::from);
+
+        let extension_init = extension_init.map(pb_api::ExtensionInit::from);
+
+        Self {
+            chunked_canister_wasm,
+            extension_init,
+        }
+    }
+}
+
+impl From<pb_api::RegisterExtension> for pb::RegisterExtension {
+    fn from(item: pb_api::RegisterExtension) -> Self {
+        let pb_api::RegisterExtension {
+            chunked_canister_wasm,
+            extension_init,
+        } = item;
+
+        let chunked_canister_wasm = chunked_canister_wasm.map(pb::ChunkedCanisterWasm::from);
+
+        let extension_init = extension_init.map(pb::ExtensionInit::from);
+
+        Self {
+            chunked_canister_wasm,
+            extension_init,
+        }
+    }
+}
+
 impl From<pb::DeregisterDappCanisters> for pb_api::DeregisterDappCanisters {
     fn from(item: pb::DeregisterDappCanisters) -> Self {
         Self {
@@ -750,6 +870,9 @@ impl From<pb::proposal::Action> for pb_api::proposal::Action {
             pb::proposal::Action::RegisterDappCanisters(v) => {
                 pb_api::proposal::Action::RegisterDappCanisters(v.into())
             }
+            pb::proposal::Action::RegisterExtension(v) => {
+                pb_api::proposal::Action::RegisterExtension(v.into())
+            }
             pb::proposal::Action::DeregisterDappCanisters(v) => {
                 pb_api::proposal::Action::DeregisterDappCanisters(v.into())
             }
@@ -802,6 +925,9 @@ impl From<pb_api::proposal::Action> for pb::proposal::Action {
             }
             pb_api::proposal::Action::RegisterDappCanisters(v) => {
                 pb::proposal::Action::RegisterDappCanisters(v.into())
+            }
+            pb_api::proposal::Action::RegisterExtension(v) => {
+                pb::proposal::Action::RegisterExtension(v.into())
             }
             pb_api::proposal::Action::DeregisterDappCanisters(v) => {
                 pb::proposal::Action::DeregisterDappCanisters(v.into())

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -448,6 +448,9 @@ pub(crate) async fn validate_and_render_action(
                 &disallowed_target_canister_ids,
             )
         }
+        proposal::Action::RegisterExtension(_) => {
+            Err("RegisterExtension proposals are not supported yet.".to_string())
+        }
         proposal::Action::DeregisterDappCanisters(deregister_dapp_canisters) => {
             validate_and_render_deregister_dapp_canisters(
                 deregister_dapp_canisters,

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -137,6 +137,9 @@ pub mod native_action_ids {
     /// SetTopicsForCustomProposals Action.
     pub const SET_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION: u64 = 16;
 
+    /// RegisterExtension Action.
+    pub const REGISTER_EXTENSION: u64 = 17;
+
     // When adding something to this list, make sure to update the below function.
     pub fn nervous_system_functions() -> Vec<NervousSystemFunction> {
         vec![
@@ -1192,6 +1195,15 @@ impl NervousSystemFunction {
         }
     }
 
+    fn register_extension() -> NervousSystemFunction {
+        NervousSystemFunction {
+            id: native_action_ids::REGISTER_EXTENSION,
+            name: "Register SNS extension".to_string(),
+            description: Some("Proposal to register a new SNS extension.".to_string()),
+            function_type: Some(FunctionType::NativeNervousSystemFunction(Empty {})),
+        }
+    }
+
     fn deregister_dapp_canisters() -> NervousSystemFunction {
         NervousSystemFunction {
             id: native_action_ids::DEREGISTER_DAPP_CANISTERS,
@@ -1284,6 +1296,7 @@ impl From<Action> for NervousSystemFunction {
                 NervousSystemFunction::transfer_sns_treasury_funds()
             }
             Action::RegisterDappCanisters(_) => NervousSystemFunction::register_dapp_canisters(),
+            Action::RegisterExtension(_) => NervousSystemFunction::register_extension(),
             Action::DeregisterDappCanisters(_) => {
                 NervousSystemFunction::deregister_dapp_canisters()
             }
@@ -1869,6 +1882,7 @@ impl From<&Action> for u64 {
             }
             Action::ExecuteGenericNervousSystemFunction(proposal) => proposal.function_id,
             Action::RegisterDappCanisters(_) => native_action_ids::REGISTER_DAPP_CANISTERS,
+            Action::RegisterExtension(_) => native_action_ids::REGISTER_EXTENSION,
             Action::DeregisterDappCanisters(_) => native_action_ids::DEREGISTER_DAPP_CANISTERS,
             Action::ManageSnsMetadata(_) => native_action_ids::MANAGE_SNS_METADATA,
             Action::TransferSnsTreasuryFunds(_) => native_action_ids::TRANSFER_SNS_TREASURY_FUNDS,


### PR DESCRIPTION
This PR extends the SNS Governance API to support a new native proposal type, `RegisterExtension`.

This type of proposals will be used for creating SNS-controlled canisters that (unlike regular SNS dapp canisters) have certain capabilities to operate on behalf of the DAO. In particular, the first extension supported type will be for SNS treasury managers (not yet implemented in this PR).

Deregistering an extension may be implemented via the `DeregisterDappCanisters` proposal, or potentially via a new, dedicated proposal; this design decision does not have to be made in this PR.