### PR TITLE
chore(nns): Clean up disburse maturity

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -11,7 +11,6 @@ use crate::{
         initialize_governance, reassemble_governance_proto, split_governance_proto,
         HeapGovernanceData, XdrConversionRate,
     },
-    is_disburse_maturity_enabled,
     neuron::{DissolveStateAndAge, Neuron, NeuronBuilder, Visibility},
     neuron_data_validation::{NeuronDataValidationSummary, NeuronDataValidator},
     neuron_store::{
@@ -3260,13 +3259,6 @@ impl Governance {
         caller: &PrincipalId,
         disburse_maturity: &manage_neuron::DisburseMaturity,
     ) -> Result<u64, GovernanceError> {
-        if !is_disburse_maturity_enabled() {
-            return Err(GovernanceError::new_with_message(
-                ErrorType::InvalidCommand,
-                "DisburseMaturity is not yet supported.",
-            ));
-        }
-
         self.check_heap_can_grow()?;
 
         let now_seconds = self.env.now();

--- a/rs/nns/governance/src/governance/disburse_maturity_tests.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity_tests.rs
@@ -4,7 +4,6 @@ use crate::{
     governance::Environment,
     neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
     pb::v1::Subaccount,
-    temporarily_enable_disburse_maturity,
     test_utils::{MockEnvironment, MockRandomness},
 };
 
@@ -12,11 +11,9 @@ use futures::FutureExt;
 use ic_nervous_system_canisters::{cmc::MockCMC, ledger::MockIcpLedger};
 use ic_nervous_system_common::NervousSystemError;
 use ic_nns_governance_api::Governance as GovernanceApi;
-use ic_stable_structures::{storable::Bound, Storable};
 use icp_ledger::AccountIdentifier;
 use mockall::Sequence;
-use prost::Message;
-use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 static NOW_SECONDS: u64 = 1_234_567_890;
 static CONTROLLER: PrincipalId = PrincipalId::new_user_test_id(1);
@@ -562,7 +559,6 @@ fn set_governance_for_test(
 #[tokio::test]
 async fn test_finalize_maturity_disbursement_successful() {
     // Step 1: Set up the test environment
-    let _t = temporarily_enable_disburse_maturity();
     set_governance_for_test(
         vec![create_neuron_builder().build()],
         mock_ledger(vec![MintIcpExpectation {
@@ -615,102 +611,9 @@ async fn test_finalize_maturity_disbursement_successful() {
     );
 }
 
-// TODO(NNS1-3851): clean this up after no old disbursement format is used anymore.
-/// The `MaturityDisbursement` prost type before changing `account_to_disburse_to` to `oneof
-/// destination` with either `account_to_disburse_to` or `account_identifier_to_disburse_to`. This
-/// type is used for testing whether the old disbursement format can be finalized correctly.
-#[derive(
-    candid::CandidType, candid::Deserialize, serde::Serialize, Clone, PartialEq, prost::Message,
-)]
-pub struct OldMaturityDisbursement {
-    #[prost(uint64, tag = "1")]
-    pub amount_e8s: u64,
-    #[prost(uint64, tag = "2")]
-    pub timestamp_of_disbursement_seconds: u64,
-    #[prost(message, optional, tag = "3")]
-    pub account_to_disburse_to: Option<Account>,
-    #[prost(uint64, tag = "4")]
-    pub finalize_disbursement_timestamp_seconds: u64,
-}
-
-impl Storable for OldMaturityDisbursement {
-    fn to_bytes(&self) -> Cow<'_, [u8]> {
-        Cow::from(self.encode_to_vec())
-    }
-
-    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
-        Self::decode(&bytes[..]).expect("Unable to deserialize MaturityDisbursement.")
-    }
-
-    const BOUND: Bound = Bound::Unbounded;
-}
-
-fn test_serialze_with_old_deserialize_with_new(
-    old: OldMaturityDisbursement,
-    expected_new: MaturityDisbursement,
-) {
-    // Serialize the old format
-    let serialized_old = old.to_bytes();
-
-    // Deserialize using the new format
-    let deserialized_new: MaturityDisbursement = MaturityDisbursement::from_bytes(serialized_old);
-
-    // Assert that the deserialized new format matches the expected new format
-    assert_eq!(deserialized_new, expected_new);
-}
-
-#[test]
-fn test_deserialize_maturity_disbursement_from_old_format() {
-    test_serialze_with_old_deserialize_with_new(
-        OldMaturityDisbursement {
-            amount_e8s: 1,
-            timestamp_of_disbursement_seconds: 2,
-            finalize_disbursement_timestamp_seconds: 3,
-            account_to_disburse_to: Some(Account {
-                owner: Some(CONTROLLER),
-                subaccount: None,
-            }),
-        },
-        MaturityDisbursement {
-            amount_e8s: 1,
-            timestamp_of_disbursement_seconds: 2,
-            finalize_disbursement_timestamp_seconds: 3,
-            destination: Some(Destination::AccountToDisburseTo(Account {
-                owner: Some(CONTROLLER),
-                subaccount: None,
-            })),
-        },
-    );
-    test_serialze_with_old_deserialize_with_new(
-        OldMaturityDisbursement {
-            amount_e8s: 1,
-            timestamp_of_disbursement_seconds: 2,
-            finalize_disbursement_timestamp_seconds: 3,
-            account_to_disburse_to: Some(Account {
-                owner: Some(CONTROLLER),
-                subaccount: Some(Subaccount {
-                    subaccount: vec![2u8; 32],
-                }),
-            }),
-        },
-        MaturityDisbursement {
-            amount_e8s: 1,
-            timestamp_of_disbursement_seconds: 2,
-            finalize_disbursement_timestamp_seconds: 3,
-            destination: Some(Destination::AccountToDisburseTo(Account {
-                owner: Some(CONTROLLER),
-                subaccount: Some(Subaccount {
-                    subaccount: vec![2u8; 32],
-                }),
-            })),
-        },
-    );
-}
-
 #[tokio::test]
 async fn test_finalize_maturity_disbursement_no_maturity_modulation() {
     // Step 1: Set up the test environment without maturity modulation.
-    let _t = temporarily_enable_disburse_maturity();
     set_governance_for_test(
         vec![create_neuron_builder().build()],
         MockIcpLedger::default(),
@@ -755,7 +658,6 @@ async fn test_finalize_maturity_disbursement_no_maturity_modulation() {
 async fn test_finalize_maturity_disbursement_ledger_failure() {
     // Step 1: Set up the test environment with a ledger which will fail the first minting attempt
     // but will succeed on the second.
-    let _t = temporarily_enable_disburse_maturity();
     set_governance_for_test(
         vec![create_neuron_builder().build()],
         mock_ledger(vec![

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -205,8 +205,6 @@ thread_local! {
     static DISABLE_NF_FUND_PROPOSALS: Cell<bool>
         = const { Cell::new(cfg!(not(any(feature = "canbench-rs", feature = "test")))) };
 
-    static IS_DISBURSE_MATURITY_ENABLED: Cell<bool> = const { Cell::new(true) };
-
     static USE_NODE_PROVIDER_REWARD_CANISTER: Cell<bool> = const { Cell::new(true) };
 }
 
@@ -231,22 +229,6 @@ pub fn temporarily_enable_nf_fund_proposals() -> Temporary {
 #[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_nf_fund_proposals() -> Temporary {
     Temporary::new(&DISABLE_NF_FUND_PROPOSALS, true)
-}
-
-pub fn is_disburse_maturity_enabled() -> bool {
-    IS_DISBURSE_MATURITY_ENABLED.get()
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_enable_disburse_maturity() -> Temporary {
-    Temporary::new(&IS_DISBURSE_MATURITY_ENABLED, true)
-}
-
-/// Only integration tests should use this.
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_disable_disburse_maturity() -> Temporary {
-    Temporary::new(&IS_DISBURSE_MATURITY_ENABLED, false)
 }
 
 pub fn use_node_provider_reward_canister() -> bool {
@@ -553,13 +535,11 @@ pub fn encode_metrics(
         account_id_index_len as f64,
         "Total number of entries in the account_id index",
     )?;
-    if is_disburse_maturity_enabled() {
-        w.encode_gauge(
-            "governance_maturity_disbursement_index_len",
-            maturity_disbursement_index_len as f64,
-            "Total number of entries in the maturity disbursement index",
-        )?;
-    }
+    w.encode_gauge(
+        "governance_maturity_disbursement_index_len",
+        maturity_disbursement_index_len as f64,
+        "Total number of entries in the maturity disbursement index",
+    )?;
 
     let mut builder = w.gauge_vec(
         "governance_proposal_deadline_timestamp_seconds",

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -3,7 +3,6 @@ use crate::{
         LOG_PREFIX, MAX_DISSOLVE_DELAY_SECONDS, MAX_NEURON_AGE_FOR_AGE_BONUS,
         MAX_NUM_HOT_KEYS_PER_NEURON,
     },
-    is_disburse_maturity_enabled,
     neuron::{combine_aged_stakes, dissolve_state_and_age::DissolveStateAndAge, neuron_stake_e8s},
     neuron_store::NeuronStoreError,
     pb::v1::{
@@ -1322,16 +1321,13 @@ impl Neuron {
             .map(|(topic_id, followees)| (topic_id, api::neuron::Followees::from(followees)))
             .collect();
 
-        let maturity_disbursements_in_progress = if is_disburse_maturity_enabled() {
-            Some(
-                maturity_disbursements_in_progress
-                    .into_iter()
-                    .map(api::MaturityDisbursement::from)
-                    .collect(),
-            )
-        } else {
-            None
-        };
+        let maturity_disbursements_in_progress = Some(
+            maturity_disbursements_in_progress
+                .into_iter()
+                .map(api::MaturityDisbursement::from)
+                .collect(),
+        );
+
         api::Neuron {
             id,
             account,

--- a/rs/nns/governance/src/neuron_data_validation.rs
+++ b/rs/nns/governance/src/neuron_data_validation.rs
@@ -1,5 +1,4 @@
 use crate::{
-    is_disburse_maturity_enabled,
     neuron::Neuron,
     neuron_store::NeuronStore,
     pb::v1::Topic,
@@ -228,14 +227,12 @@ impl ValidationInProgress {
         tasks.push_back(Box::new(CardinalitiesValidationTask::<
             KnownNeuronIndexValidator,
         >::new()));
-        if is_disburse_maturity_enabled() {
-            tasks.push_back(Box::new(NeuronRangeValidationTask::<
-                MaturityDisbursementIndexValidator,
-            >::new()));
-            tasks.push_back(Box::new(CardinalitiesValidationTask::<
-                MaturityDisbursementIndexValidator,
-            >::new()));
-        }
+        tasks.push_back(Box::new(NeuronRangeValidationTask::<
+            MaturityDisbursementIndexValidator,
+        >::new()));
+        tasks.push_back(Box::new(CardinalitiesValidationTask::<
+            MaturityDisbursementIndexValidator,
+        >::new()));
 
         Self {
             started_time_seconds: now,
@@ -867,10 +864,7 @@ mod tests {
         // data missing from indexes, and 2 issues for cardinality mismatches for subaccount and
         // known neuron, since those are checked for exact matches.
         let issue_groups = summary.current_issues_summary.unwrap().issue_groups;
-        assert_eq!(
-            issue_groups.len(),
-            if is_disburse_maturity_enabled() { 7 } else { 6 }
-        );
+        assert_eq!(issue_groups.len(), 7);
         assert!(
             issue_groups
                 .iter()
@@ -939,19 +933,17 @@ mod tests {
             "{:?}",
             issue_groups
         );
-        if is_disburse_maturity_enabled() {
-            assert!(
-                issue_groups
-                    .iter()
-                    .any(|issue_group| issue_group.issues_count == 2
-                        && matches!(
-                            issue_group.example_issues[0],
-                            ValidationIssue::MaturityDisbursementMissingFromIndex { .. }
-                        )),
-                "{:?}",
-                issue_groups
-            );
-        }
+        assert!(
+            issue_groups
+                .iter()
+                .any(|issue_group| issue_group.issues_count == 2
+                    && matches!(
+                        issue_group.example_issues[0],
+                        ValidationIssue::MaturityDisbursementMissingFromIndex { .. }
+                    )),
+            "{:?}",
+            issue_groups
+        );
     }
 
     #[test]
@@ -985,10 +977,7 @@ mod tests {
         // data missing from indexes, and 2 issues for cardinality mismatches for subaccount and
         // known neuron, since those are checked for exact matches.
         let issue_groups = summary.current_issues_summary.unwrap().issue_groups;
-        assert_eq!(
-            issue_groups.len(),
-            if is_disburse_maturity_enabled() { 5 } else { 4 }
-        );
+        assert_eq!(issue_groups.len(), 5);
         assert!(
             issue_groups
                 .iter()
@@ -1037,20 +1026,18 @@ mod tests {
             "{:?}",
             issue_groups
         );
-        if is_disburse_maturity_enabled() {
-            assert!(
-                issue_groups
-                    .iter()
-                    .any(|issue_group| issue_group.issues_count == 1
-                        && issue_group.example_issues[0]
-                            == ValidationIssue::MaturityDisbursementIndexCardinalityMismatch {
-                                primary: 0,
-                                index: 4
-                            }),
-                "{:?}",
-                issue_groups
-            );
-        }
+        assert!(
+            issue_groups
+                .iter()
+                .any(|issue_group| issue_group.issues_count == 1
+                    && issue_group.example_issues[0]
+                        == ValidationIssue::MaturityDisbursementIndexCardinalityMismatch {
+                            primary: 0,
+                            index: 4
+                        }),
+            "{:?}",
+            issue_groups
+        );
     }
 
     #[test]

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -3,7 +3,6 @@ use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::{Followees, MaturityDisbursement},
     storage::with_stable_neuron_indexes,
-    temporarily_enable_disburse_maturity,
 };
 use ic_nervous_system_common::ONE_MONTH_SECONDS;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
@@ -377,8 +376,6 @@ fn create_maturity_disbursement(
 
 #[test]
 fn test_maturity_disbursement_index() {
-    let _t = temporarily_enable_disburse_maturity();
-
     // Set up 2 neurons with no maturity disbursements.
     let mut neuron_store = NeuronStore::new(btreemap! {
         1 => simple_neuron_builder(1).build(),

--- a/rs/nns/governance/src/storage/neuron_indexes.rs
+++ b/rs/nns/governance/src/storage/neuron_indexes.rs
@@ -1,6 +1,5 @@
 use crate::{
     account_id_index::NeuronAccountIdIndex,
-    is_disburse_maturity_enabled,
     known_neuron_index::{AddKnownNeuronError, KnownNeuronIndex, RemoveKnownNeuronError},
     maturity_disbursement_index::MaturityDisbursementIndex,
     neuron::Neuron,
@@ -760,17 +759,14 @@ where
     }
 
     fn indexes_mut(&mut self) -> Vec<&mut dyn NeuronIndex> {
-        let mut indexes: Vec<&mut dyn NeuronIndex> = vec![
+        vec![
             &mut self.subaccount,
             &mut self.principal,
             &mut self.following,
             &mut self.known_neuron,
             &mut self.account_id,
-        ];
-        if is_disburse_maturity_enabled() {
-            indexes.push(&mut self.maturity_disbursement);
-        }
-        indexes
+            &mut self.maturity_disbursement,
+        ]
     }
 
     // It's OK to expose read-only access to all the indexes.
@@ -806,9 +802,7 @@ where
         self.following.validate();
         self.known_neuron.validate();
         self.account_id.validate();
-        if is_disburse_maturity_enabled() {
-            self.maturity_disbursement.validate();
-        }
+        self.maturity_disbursement.validate();
     }
 }
 

--- a/rs/nns/governance/src/timer_tasks/mod.rs
+++ b/rs/nns/governance/src/timer_tasks/mod.rs
@@ -9,9 +9,7 @@ use seeding::SeedingTask;
 use snapshot_voting_power::SnapshotVotingPowerTask;
 use std::cell::RefCell;
 
-use crate::{
-    canister_state::GOVERNANCE, is_disburse_maturity_enabled, storage::VOTING_POWER_SNAPSHOTS,
-};
+use crate::{canister_state::GOVERNANCE, storage::VOTING_POWER_SNAPSHOTS};
 
 mod calculate_distributable_rewards;
 mod distribute_rewards;
@@ -29,9 +27,7 @@ pub fn schedule_tasks() {
     CalculateDistributableRewardsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     PruneFollowingTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
     SnapshotVotingPowerTask::new(&GOVERNANCE, &VOTING_POWER_SNAPSHOTS).schedule(&METRICS_REGISTRY);
-    if is_disburse_maturity_enabled() {
-        FinalizeMaturityDisbursementsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
-    }
+    FinalizeMaturityDisbursementsTask::new(&GOVERNANCE).schedule(&METRICS_REGISTRY);
 
     run_distribute_rewards_periodic_task();
 }


### PR DESCRIPTION
# Why

Disburse maturity has been enabled for a while, clean up some code that's no longer needed

# What

* Clean up the `is_disburse_maturity_enabled` flag
* Clean up a test that asserts `OldMaturityDisbursement` (from a previous version) can be successfully deserialized to the new version.