### PR TITLE
fix: Bump the expected mean latency of the xnet_compatibility test

### DIFF
--- a/rs/tests/message_routing/xnet/xnet_compatibility.rs
+++ b/rs/tests/message_routing/xnet/xnet_compatibility.rs
@@ -162,7 +162,7 @@ pub async fn test_async(env: TestEnv) {
         // while the long running test is running we are generous
         // with error thresholds.
         75.0,
-        60,
+        120,
     );
 
     let mainnet_version = get_mainnet_nns_revision();


### PR DESCRIPTION
Due to doing two subnet upgrades during the test; and these upgrades sometimes taking multiple minutes to complete; the mean latency measured by the subnet that is running throughout can exceed the currently expected 60 seconds. Until we figure out the root cause of the slow upgrades, double the target latency.