### PR TITLE
chore: allow running the nested system-tests on all farm hosts

### DIFF
--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -8,7 +8,7 @@ use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
-        farm::HostFeature, ic::InternetComputer, nested::NestedVms, test_env::TestEnv,
+        ic::InternetComputer, nested::NestedVms, test_env::TestEnv,
         test_env_api::*,
     },
     retry_with_msg,

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -7,10 +7,7 @@ use canister_test::PrincipalId;
 use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
-    driver::{
-        ic::InternetComputer, nested::NestedVms, test_env::TestEnv,
-        test_env_api::*,
-    },
+    driver::{ic::InternetComputer, nested::NestedVms, test_env::TestEnv,test_env_api::*},
     retry_with_msg,
     util::block_on,
 };

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -7,7 +7,7 @@ use canister_test::PrincipalId;
 use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
-    driver::{ic::InternetComputer, nested::NestedVms, test_env::TestEnv,test_env_api::*},
+    driver::{ic::InternetComputer, nested::NestedVms, test_env::TestEnv, test_env_api::*},
     retry_with_msg,
     util::block_on,
 };

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -40,12 +40,6 @@ pub fn config(env: TestEnv) {
 
     // Setup "testnet"
     InternetComputer::new()
-        // The Farm hosts in the dm1 DC run:
-        // Ubuntu-24.04, libvirt-10.0.0 and QEMU-8.2.2 while the other (older) Farm hosts run
-        // Ubuntu-20.04, libvirt-6.6.0  and QEMU-5.0.0.
-        // If the host VM is allocated to these older hosts the nested guest VM often runs into soft CPU lockups.
-        // So we temporarily require that this test is hosted in dm1 until the other Farm hosts are upgraded to Ubuntu 24.04.
-        .with_required_host_features(vec![HostFeature::DC("dm1".to_string())])
         .add_fast_single_node_subnet(SubnetType::System)
         // .with_mainnet_config() TODO: uncomment in NODE-1518
         .with_api_boundary_nodes(1)


### PR DESCRIPTION
All Farm hosts have been upgraded to Ubuntu-24.04 which means all of them could now successfully host nested VMs. This means we no longer need to limit these tests to the `dm1` DC.