### PR TITLE
feat(sns): Fall back to making SNS proposals critical in the unlikely event of proposals not having a topic  

### DIFF
--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -185,7 +185,7 @@ fn run_determine_targets(cmd: DetermineTargets) -> Result<()> {
         "Genesis-Token",
         "Node-Rewards",
     ];
-    let sns_candidates = ["Root", "Governance", "Swap", "Index", "Ledger", "Archive"];
+    let sns_candidates = ["Root", "Governance", "Swap", "Ledger", "Archive", "Index"];
 
     // Prepare vectors for selected releases.
     let mut nns_canisters: Vec<String> = Vec::new();


### PR DESCRIPTION
This PR changes the default SNS proposal criticality from non-critical to critical. The reasoning is explained in the code comment.