### PR TITLE
feat(IDX): export node name to step annotation

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -50,13 +50,12 @@ runs:
         env:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          NODE_NAME: ${{ env.NODE_NAME || 'unknown' }}
         with:
           GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}
           execlogs-artifact-name: ${{ inputs.execlogs-artifact-name }}
           run: |
             set -euo pipefail
-            echo "::notice::Node Name: ${{ inputs.NODE_NAME }}"
+            echo "::notice::Node Name: ${NODE_NAME}"
 
             diff_only='${{ inputs.diff-only }}'
             release_build='${{ inputs.release-build }}'

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -50,6 +50,7 @@ runs:
         env:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          NODE_NAME: ${{ env.NODE_NAME || 'unknown' }}
         with:
           GPG_PASSPHRASE: ${{ inputs.GPG_PASSPHRASE }}
           execlogs-artifact-name: ${{ inputs.execlogs-artifact-name }}

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -56,7 +56,7 @@ runs:
           execlogs-artifact-name: ${{ inputs.execlogs-artifact-name }}
           run: |
             set -euo pipefail
-            echo "| Node Name | ${NODE_NAME} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "::notice::Node Name: ${{ inputs.NODE_NAME }}"
 
             diff_only='${{ inputs.diff-only }}'
             release_build='${{ inputs.release-build }}'

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -55,6 +55,7 @@ runs:
           execlogs-artifact-name: ${{ inputs.execlogs-artifact-name }}
           run: |
             set -euo pipefail
+            echo "| Node Name | ${NODE_NAME} |" >> "$GITHUB_STEP_SUMMARY"
 
             diff_only='${{ inputs.diff-only }}'
             release_build='${{ inputs.release-build }}'

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -369,6 +369,11 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
+      - name: Test NODE NAME
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          echo "Node Name: $NODE_NAME"
       - name: Run Bazel Build Fuzzers
         id: bazel-build-fuzzers
         uses:  ./.github/actions/bazel-test-all/

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -369,11 +369,6 @@ jobs:
     <<: *dind-large-setup
     steps:
       - <<: *checkout
-      - name: Test NODE NAME
-        shell: bash
-        run: |
-          set -xeuo pipefail
-          echo "Node Name: $NODE_NAME"
       - name: Run Bazel Build Fuzzers
         id: bazel-build-fuzzers
         uses:  ./.github/actions/bazel-test-all/

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -211,7 +211,8 @@ jobs:
       labels: macOS
     # Run on protected branches, but only on public repo
     if: github.repository == 'dfinity/ic'
-
+    env:
+      NODE_NAME: ${{ runner.name }}
     steps:
       - <<: *checkout
       - name: Set PATH

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -211,8 +211,6 @@ jobs:
       labels: macOS
     # Run on protected branches, but only on public repo
     if: github.repository == 'dfinity/ic'
-    env:
-      NODE_NAME: ${{ runner.name }}
     steps:
       - <<: *checkout
       - name: Set PATH
@@ -233,6 +231,8 @@ jobs:
       - name: Run Bazel Checks on Darwin x86-64
         id: bazel-test-darwin-x86-64
         uses:  ./.github/actions/bazel-test-all/
+        env:
+          NODE_NAME: ${{ runner.name }}
         with:
           upload-artifacts: ${{ needs.config.outputs.release_build && needs.config.outputs.full_macos_build }}
           BAZEL_COMMAND: ${{ steps.cfg.outputs.build-command }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -180,6 +180,8 @@ jobs:
       labels: macOS
     # Run on protected branches, but only on public repo
     if: github.repository == 'dfinity/ic'
+    env:
+      NODE_NAME: ${{ runner.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -343,6 +343,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
+      - name: Test NODE NAME
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          echo "Node Name: $NODE_NAME"
       - name: Run Bazel Build Fuzzers
         id: bazel-build-fuzzers
         uses: ./.github/actions/bazel-test-all/

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -343,11 +343,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
-      - name: Test NODE NAME
-        shell: bash
-        run: |
-          set -xeuo pipefail
-          echo "Node Name: $NODE_NAME"
       - name: Run Bazel Build Fuzzers
         id: bazel-build-fuzzers
         uses: ./.github/actions/bazel-test-all/

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -180,8 +180,6 @@ jobs:
       labels: macOS
     # Run on protected branches, but only on public repo
     if: github.repository == 'dfinity/ic'
-    env:
-      NODE_NAME: ${{ runner.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -204,6 +202,8 @@ jobs:
       - name: Run Bazel Checks on Darwin x86-64
         id: bazel-test-darwin-x86-64
         uses: ./.github/actions/bazel-test-all/
+        env:
+          NODE_NAME: ${{ runner.name }}
         with:
           upload-artifacts: ${{ needs.config.outputs.release_build && needs.config.outputs.full_macos_build }}
           BAZEL_COMMAND: ${{ steps.cfg.outputs.build-command }}


### PR DESCRIPTION
This adds the node names as annotations to the job steps. See example: https://github.com/dfinity/ic/actions/runs/15612912580?pr=5526

Please let me know if there's a better format so that we can query these later on.