### PR TITLE
fix(IDX): use different zig cache for configs

### DIFF
--- a/bazel/hermetic_cc_toolchain.patch
+++ b/bazel/hermetic_cc_toolchain.patch
@@ -14,7 +14,7 @@ index 409d626..1265298 100644
      # wasm/wasi toolchains
      "@zig_sdk//toolchain:wasip1_wasm",
 +    "@zig_sdk//toolchain:none_wasm",
- 
+
      # These toolchains are only registered locally.
      dev_dependency = True,
 diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
@@ -37,12 +37,12 @@ index f6f613e..02d5597 100644
          host_platform_ext = host_platform_ext,
 +        extra_settings = extra_settings
      )
- 
+
  def _quote(s):
 @@ -110,6 +112,8 @@ def _zig_repository_impl(repository_ctx):
          "host_platform": host_platform,
      }
- 
+
 +    extra_settings = "[" + " ".join([_quote(str(setting)) for setting in repository_ctx.attr.extra_settings]) + "]"
 +
      # Fetch Label dependencies before doing download/extract.
@@ -57,7 +57,7 @@ index f6f613e..02d5597 100644
          "libc_aware/platform/BUILD": "//toolchain/libc_aware/platform:BUILD",
          "libc_aware/toolchain/BUILD": "//toolchain/libc_aware/toolchain:BUILD",
 @@ -126,6 +129,7 @@ def _zig_repository_impl(repository_ctx):
- 
+
      for dest, src in {
          "BUILD": "//toolchain:BUILD.sdk.bazel",
 +        "toolchain/BUILD": "//toolchain/toolchain:BUILD",
@@ -71,7 +71,7 @@ index f6f613e..02d5597 100644
 +                "{extra_settings}": extra_settings,
              },
          )
- 
+
 @@ -230,6 +235,7 @@ zig_repository = repository_rule(
          "host_platform_sha256": attr.string_dict(),
          "url_formats": attr.string_list(allow_empty = False),
@@ -86,14 +86,14 @@ index ebf0ff8..c2e8af3 100644
 +++ b/toolchain/ext.bzl
 @@ -1,6 +1,11 @@
  load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
- 
+
  def _toolchains_impl(ctx):
 -    zig_toolchains()
 +    extra_settings = []
 +    for mod in ctx.modules:
 +        for tag in mod.tags.extra_settings:
 +            extra_settings += tag.settings
- 
+
 -toolchains = module_extension(implementation = _toolchains_impl)
 +    zig_toolchains(extra_settings = extra_settings)
 +
@@ -103,11 +103,11 @@ index d4a8344..faafc5b 100644
 --- a/toolchain/platform/defs.bzl
 +++ b/toolchain/platform/defs.bzl
 @@ -16,6 +16,7 @@ def declare_platforms():
- 
+
      # We can support GOARCH=wasm32 after https://github.com/golang/go/issues/63131
      declare_platform("wasm", "wasm32", "wasi", "wasip1")
 +    declare_platform("wasm", "wasm32", "none", "none")
- 
+
  def declare_libc_aware_platforms():
      # create @zig_sdk//{os}_{arch}_platform entries with zig and go conventions
 diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
@@ -120,7 +120,7 @@ index 716a3a3..b88d082 100644
      ret.append(_target_wasm())
 +    ret.append(_target_wasm_no_wasi())
      return ret
- 
+
  def _target_macos(gocpu, zigcpu):
 @@ -222,3 +223,22 @@ def _target_wasm():
          ld_zig_subcmd = "wasm-ld",
@@ -145,19 +145,6 @@ index 716a3a3..b88d082 100644
 +        ld_zig_subcmd = "wasm-ld",
 +        artifact_name_patterns = [],
 +    )
-diff --git a/toolchain/zig-wrapper.zig b/toolchain/zig-wrapper.zig
-index d1d59f9..5e2984b 100644
---- a/toolchain/zig-wrapper.zig
-+++ b/toolchain/zig-wrapper.zig
-@@ -283,7 +283,7 @@ fn getRunMode(self_exe: []const u8, self_base_noexe: []const u8) error{BadParent
-         return error.BadParent;
- 
-     const got_os = it.next() orelse return error.BadParent;
--    if (mem.indexOf(u8, "linux,macos,windows,wasi", got_os) == null)
-+    if (mem.indexOf(u8, "linux,macos,windows,wasi,freestanding", got_os) == null)
-         return error.BadParent;
- 
-     // ABI triple is too much of a moving target
 diff --git a/toolchain/toolchain/BUILD b/toolchain/toolchain/BUILD
 index 552fcaa..8f7dba5 100644
 --- a/toolchain/toolchain/BUILD
@@ -165,7 +152,7 @@ index 552fcaa..8f7dba5 100644
 @@ -4,4 +4,4 @@ package(
      default_visibility = ["//visibility:public"],
  )
- 
+
 -declare_toolchains()
 +declare_toolchains(extra_settings = {extra_settings})
 diff --git a/toolchain/toolchain/defs.bzl b/toolchain/toolchain/defs.bzl
@@ -174,7 +161,7 @@ index 50cc881..0549c26 100644
 +++ b/toolchain/toolchain/defs.bzl
 @@ -1,6 +1,6 @@
  load("@hermetic_cc_toolchain//toolchain/private:defs.bzl", "target_structs")
- 
+
 -def declare_toolchains():
 +def declare_toolchains(extra_settings = []):
      for target_config in target_structs():
@@ -183,16 +170,16 @@ index 50cc881..0549c26 100644
 @@ -12,7 +12,7 @@ def declare_toolchains():
          if hasattr(target_config, "libc_constraint"):
              extra_constraints = ["@zig_sdk//libc:unconstrained"]
- 
+
 -        _declare_toolchain(gotarget, zigtarget, target_config.constraint_values + extra_constraints)
 +        _declare_toolchain(gotarget, zigtarget, target_config.constraint_values + extra_constraints, extra_settings)
- 
+
  def declare_libc_aware_toolchains():
      for target_config in target_structs():
 @@ -25,13 +25,14 @@ def declare_libc_aware_toolchains():
          if hasattr(target_config, "libc_constraint"):
              _declare_toolchain(gotarget, zigtarget, target_config.constraint_values + [target_config.libc_constraint])
- 
+
 -def _declare_toolchain(gotarget, zigtarget, target_compatible_with):
 +def _declare_toolchain(gotarget, zigtarget, target_compatible_with, extra_settings):
      # register two kinds of toolchain targets: Go and Zig conventions.
@@ -214,7 +201,7 @@ index 50cc881..0549c26 100644
          toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
      )
 diff --git a/toolchain/zig-wrapper.zig b/toolchain/zig-wrapper.zig
-index d1d59f9..f7ba2cd 100644
+index d1d59f9..4f471ee 100644
 --- a/toolchain/zig-wrapper.zig
 +++ b/toolchain/zig-wrapper.zig
 @@ -132,7 +132,7 @@ pub fn main() u8 {
@@ -226,10 +213,26 @@ index d1d59f9..f7ba2cd 100644
          },
      }
  }
-@@ -161,6 +161,55 @@ fn execUnix(arena: mem.Allocator, params: ExecParams) u8 {
+@@ -161,6 +161,71 @@ fn execUnix(arena: mem.Allocator, params: ExecParams) u8 {
      return 1;
  }
- 
+
++fn makeSuffix(allocator: std.mem.Allocator, pwd: []const u8) ![]const u8 {
++    var it = std.mem.tokenize(u8, pwd, "/");
++
++    while (it.next()) |segment| {
++        if (std.mem.startsWith(u8, segment, "k8-opt-")) {
++            var hasher = std.hash.Wyhash.init(0);
++            hasher.update(segment);
++            const hash_value = hasher.final();
++            return std.fmt.allocPrint(allocator, "config-{x}", .{hash_value});
++        }
++    }
++
++    // no "k8-opt-" found
++    return std.fmt.allocPrint(allocator, "config-catchall", .{});
++}
++
 +fn spawnAndStripUnix(arena: mem.Allocator, params: ExecParams) u8 {
 +    // Build a strip command
 +    const strip_cmd = blk: {
@@ -282,3 +285,34 @@ index d1d59f9..f7ba2cd 100644
  // argv_it is an object that has such method:
  //     fn next(self: *Self) ?[]const u8
  // in non-testing code it is *process.ArgIterator.
+@@ -217,9 +282,19 @@ fn parseArgs(
+     var env = process.getEnvMap(arena) catch |err|
+         return parseFatal(arena, "error getting env: {s}", .{@errorName(err)});
+
++    // Get the current working directory (PWD)
++    const allocator = std.heap.page_allocator;
++    const pwd = std.fs.cwd().realpathAlloc(allocator, ".") catch {
++        std.process.exit(1);
++    };
++    defer allocator.free(pwd);
++
++    const suffix = try makeSuffix(arena, pwd);
++    const cache_dir = try std.fmt.allocPrint(arena, "{s}/{s}", .{ CACHE_DIR, suffix });
++
+     try env.put("ZIG_LIB_DIR", zig_lib_dir);
+-    try env.put("ZIG_LOCAL_CACHE_DIR", CACHE_DIR);
+-    try env.put("ZIG_GLOBAL_CACHE_DIR", CACHE_DIR);
++    try env.put("ZIG_LOCAL_CACHE_DIR", cache_dir);
++    try env.put("ZIG_GLOBAL_CACHE_DIR", cache_dir);
+
+     // args is the path to the zig binary and args to it.
+     var args = ArrayListUnmanaged([]const u8){};
+@@ -283,7 +358,7 @@ fn getRunMode(self_exe: []const u8, self_base_noexe: []const u8) error{BadParent
+         return error.BadParent;
+
+     const got_os = it.next() orelse return error.BadParent;
+-    if (mem.indexOf(u8, "linux,macos,windows,wasi", got_os) == null)
++    if (mem.indexOf(u8, "linux,macos,windows,wasi,freestanding", got_os) == null)
+         return error.BadParent;
+
+     // ABI triple is too much of a moving target


### PR DESCRIPTION
This works around a [bug](https://github.com/ziglang/zig/issues/23993) in the zig cache. The bug is triggered when bazel tries to build several "almost" identical targets at the same time where only the config differs.

This is the case for us with jemalloc, where transitions set different _rustc_ flags for the build, but which bazel still interprets as different configs.

This causes concurrent builds of jemalloc and trips the zig cache.