### PR TITLE
revert: "fix(IDX): don't cache jemalloc build (#5174)"

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -83,15 +83,6 @@ runs:
               bazel_targets+=( "$tgt" )
             done
 
-            # jemalloc -- or rather, the "hermetic" zig toolchain -- has issues when too
-            # many targets are built concurrently (leads to determinism issues & linking
-            # errors).
-            #
-            # To work around this, we build jemalloc separately.
-            if [ $(uname -o) != "Darwin" ]; then
-              bazel build "${bazel_args[@]}" @@jemalloc//:libjemalloc
-            fi
-
             if [[ $diff_only == "true" ]]; then
                 target_pattern_file=$(mktemp)
                 trap "rm $target_pattern_file" INT TERM EXIT

--- a/third_party/jemalloc/BUILD.jemalloc.bazel
+++ b/third_party/jemalloc/BUILD.jemalloc.bazel
@@ -50,13 +50,6 @@ configure_make(
     # Specify the name for the static archive instead of defaulting to <rulename>.a
     out_static_libs = ["libjemalloc.a"],
 
-    # The jemalloc build (most likely rules_foreign_cc) sometimes creates corrupt artifacts
-    # which can pollute the cache -- so we build it locally.
-    tags = [
-        "manual",
-        "no-cache",
-    ],
-
     # Ensures only the static archive is built. Otherwise (make) targets (including jemalloc.sh) cause
     # non-determinism in the build and aren't necessary for us.
     targets = [


### PR DESCRIPTION
This reverts commit 0dba014c1883d02346e273bd59a4f61073f8ad08.

Because we use a different zig-cache for each bazel config, we do not expect jemalloc build failures.