### PR TITLE
fix(XC): path to wasm for SOL RPC canister for proposal-cli

### DIFF
--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -219,8 +219,8 @@ impl TargetCanister {
             }
             TargetCanister::EvmRpc
             | TargetCanister::CyclesLedger
-            | TargetCanister::ExchangeRateCanister
-            | TargetCanister::SolRpc => PathBuf::from(self.artifact_file_name()),
+            | TargetCanister::ExchangeRateCanister => PathBuf::from(self.artifact_file_name()),
+            TargetCanister::SolRpc => PathBuf::from("wasms").join(self.artifact_file_name()),
         }
     }
 


### PR DESCRIPTION
Follow-up on #5511 to fix the path to the built wasm artifact in the proposal-cli tool.