### PR TITLE
chore: require build determinism for all targets except a few exclusions

### DIFF
--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -90,10 +90,10 @@ runs:
         # The goal is to have as few non-reproducible bazel targets as possible.
         # So we forbid all of them except for the following known ones:
         blacklist_patterns=(
-          @@crate_index__cranelift-assembler-x64 # has a non reproducible generated-files.rs in its OUT_DIR.
-          @@crate_index__cranelift-isle          # has a non reproducible isle_tests.rs in its OUT_DIR.
-          @@crate_index__secp256k1-sys           # has non reproducible object files, like lax_der_parsing.o, in it OUT_DIR.
-          @@crate_index__num-traits              # has non reproducible autcfg files in its OUT_DIR. See: https://github.com/rust-num/num-traits/pull/355.
+          ^@@crate_index__cranelift-assembler-x64 # has a non reproducible generated-files.rs in its OUT_DIR.
+          ^@@crate_index__cranelift-isle          # has a non reproducible isle_tests.rs in its OUT_DIR.
+          ^@@crate_index__secp256k1-sys           # has non reproducible object files, like lax_der_parsing.o, in it OUT_DIR.
+          ^@@crate_index__num-traits              # has non reproducible autcfg files in its OUT_DIR. See: https://github.com/rust-num/num-traits/pull/355.
         )
         for execlog_zst in $(find '${{ steps.metrics-tmpdir.outputs.dir }}' -name 'execlog-*.zst'); do
           zstd -f -d "$execlog_zst" -o "$execlog"

--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -89,7 +89,7 @@ runs:
         trap "rm -f $execlog" INT TERM EXIT
         # The goal is to have as few non-reproducible bazel targets as possible.
         # So we forbid all of them except for the following known ones:
-        blacklist_patterns=(
+        excludes=(
           ^@@crate_index__cranelift-assembler-x64 # has a non reproducible generated-files.rs in its OUT_DIR.
           ^@@crate_index__cranelift-isle          # has a non reproducible isle_tests.rs in its OUT_DIR.
           ^@@crate_index__secp256k1-sys           # has non reproducible object files, like lax_der_parsing.o, in it OUT_DIR.
@@ -97,10 +97,10 @@ runs:
         )
         for execlog_zst in $(find '${{ steps.metrics-tmpdir.outputs.dir }}' -name 'execlog-*.zst'); do
           zstd -f -d "$execlog_zst" -o "$execlog"
-          IFS='|'; bazel run //bazel:execution_log_compact_to_csv \
+          bazel run //bazel:execution_log_compact_to_csv \
             $([[ "$(uname)" == "Linux" ]] && echo '--repository_cache=/cache/bazel') -- \
             --input_execlog="$execlog" \
-            --blacklist_pat="(${blacklist_patterns[*]})"
+            --exclude ${excludes[*]}
         done > '${{ steps.metrics-tmpdir.outputs.dir }}/execlogs.csv'
 
     - name: Upload execution log

--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -92,7 +92,7 @@ runs:
           bazel run //bazel:execution_log_compact_to_csv \
             $([[ "$(uname)" == "Linux" ]] && echo '--repository_cache=/cache/bazel') -- \
             --input_execlog="$execlog" \
-            --blacklist_pat='(@@crate_index__cranelift-assembler-x64|@@crate_index__secp256k1-sys|@@crate_index__cranelift-isle)'
+            --blacklist_pat='(@@crate_index__cranelift-assembler-x64|@@crate_index__secp256k1-sys|@@crate_index__cranelift-isle|@@crate_index__num-traits)'
         done > '${{ steps.metrics-tmpdir.outputs.dir }}/execlogs.csv'
 
     - name: Upload execution log

--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -92,7 +92,7 @@ runs:
           bazel run //bazel:execution_log_compact_to_csv \
             $([[ "$(uname)" == "Linux" ]] && echo '--repository_cache=/cache/bazel') -- \
             --input_execlog="$execlog" \
-            --whitelist_pat='^//'
+            --blacklist_pat='(@@crate_index__cranelift-assembler-x64|@@crate_index__secp256k1-sys|@@crate_index__cranelift-isle)'
         done > '${{ steps.metrics-tmpdir.outputs.dir }}/execlogs.csv'
 
     - name: Upload execution log

--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -87,12 +87,20 @@ runs:
       run: |
         execlog="$(mktemp)"
         trap "rm -f $execlog" INT TERM EXIT
+        # The goal is to have as few non-reproducible bazel targets as possible.
+        # So we forbid all of them except for the following known ones:
+        blacklist_patterns=(
+          @@crate_index__cranelift-assembler-x64 # has a non reproducible generated-files.rs in its OUT_DIR.
+          @@crate_index__cranelift-isle          # has a non reproducible isle_tests.rs in its OUT_DIR.
+          @@crate_index__secp256k1-sys           # has non reproducible object files, like lax_der_parsing.o, in it OUT_DIR.
+          @@crate_index__num-traits              # has non reproducible autcfg files in its OUT_DIR. See: https://github.com/rust-num/num-traits/pull/355.
+        )
         for execlog_zst in $(find '${{ steps.metrics-tmpdir.outputs.dir }}' -name 'execlog-*.zst'); do
           zstd -f -d "$execlog_zst" -o "$execlog"
-          bazel run //bazel:execution_log_compact_to_csv \
+          IFS='|'; bazel run //bazel:execution_log_compact_to_csv \
             $([[ "$(uname)" == "Linux" ]] && echo '--repository_cache=/cache/bazel') -- \
             --input_execlog="$execlog" \
-            --blacklist_pat='(@@crate_index__cranelift-assembler-x64|@@crate_index__secp256k1-sys|@@crate_index__cranelift-isle|@@crate_index__num-traits)'
+            --blacklist_pat="(${blacklist_patterns[*]})"
         done > '${{ steps.metrics-tmpdir.outputs.dir }}/execlogs.csv'
 
     - name: Upload execution log

--- a/bazel/execution_log_compact_to_csv.py
+++ b/bazel/execution_log_compact_to_csv.py
@@ -92,8 +92,8 @@ def main():
                 id_to_entry[exec_log_entry.id] = exec_log_entry
             elif entry_type == "spawn":
                 label = exec_log_entry.spawn.target_label
-                if ((len(args.include) > 0 and all([not re.match(include, label) for include in args.include])) or
-                    (len(args.exclude) > 0 and any([re.match(exclude, label) for exclude in args.exclude]))
+                if (len(args.include) > 0 and all([not re.match(include, label) for include in args.include])) or (
+                    len(args.exclude) > 0 and any([re.match(exclude, label) for exclude in args.exclude])
                 ):
                     continue
                 for output in exec_log_entry.spawn.outputs:

--- a/bazel/execution_log_compact_to_csv.py
+++ b/bazel/execution_log_compact_to_csv.py
@@ -1,6 +1,6 @@
 # This Python script converts bazel's compact execution log (--execution_log_compact_file)
 # to a CSV file that contains a row per output file for every bazel target matching the given
-# --whitelist_pat regular expression and not matching the --blacklist_pat.
+# --include regular expressions and not matching the --exclude.
 # Each row contains the columns: target, path, and hash.
 #
 # Example usage:
@@ -18,7 +18,7 @@
 #   $ bazel build //bazel:execution_log_compact_to_csv && \
 #     bazel-bin/bazel/execution_log_compact_to_csv \
 #       --input_execlog=compact_execlog \
-#       --whitelist_pat='^//'
+#       --include ^//
 #
 #   //rs/http_endpoints/public:build_script_,bazel-out/k8-opt-exec-ST-d57f47055a04/bin/rs/http_endpoints/public/build_script_,4463251579c194bf83a24408a184da9a7f46d5777f753e33a77afa5c2287fd1d
 #   //rs/http_endpoints/public:build_script,bazel-out/k8-opt/bin/rs/http_endpoints/public/build_script.out_dir/dashboard.rs,f0ba2e4976ac312782190b6391ce945f57708b46126b741f6336b355968a8a84
@@ -45,14 +45,16 @@ def main():
         help="Path to the zstd _decompressed_ input file as generated with bazel's --execution_log_compact_file option.",
     )
     parser.add_argument(
-        "--whitelist_pat",
-        default=None,
-        help="Regex to match target labels to include in the CSV. If omitted, all targets are included.",
+        "--include",
+        default=[],
+        nargs="*",
+        help="A space separated list of regular expressions to match target labels to include in the CSV. If omitted, all targets are included.",
     )
     parser.add_argument(
-        "--blacklist_pat",
-        default=None,
-        help="Regex to match target labels to exclude from the CSV.",
+        "--exclude",
+        default=[],
+        nargs="*",
+        help="A space separated list of regular expressions to match target labels to exclude from the CSV.",
     )
     parser.add_argument(
         "--verbose",
@@ -90,8 +92,8 @@ def main():
                 id_to_entry[exec_log_entry.id] = exec_log_entry
             elif entry_type == "spawn":
                 label = exec_log_entry.spawn.target_label
-                if (args.whitelist_pat is not None and not re.match(args.whitelist_pat, label)) or (
-                    args.blacklist_pat is not None and re.match(args.blacklist_pat, label)
+                if ((len(args.include) > 0 and all([not re.match(include, label) for include in args.include])) or
+                    (len(args.exclude) > 0 and any([re.match(exclude, label) for exclude in args.exclude]))
                 ):
                     continue
                 for output in exec_log_entry.spawn.outputs:


### PR DESCRIPTION
The goal is to have as few non-reproducible bazel targets as possible because non-reproducible targets hurt cache utilisation and increase the risk of having non-reproducible final artifacts like guesOS images.

So we forbid all non-reproducible targets except for a few known ones which we can document and ideally link to an upstream ticket.