### PR TITLE
fix: Consolidate how caller is extracted from System API

### DIFF
--- a/rs/embedders/tests/common/mod.rs
+++ b/rs/embedders/tests/common/mod.rs
@@ -11,7 +11,6 @@ use ic_embedders::wasmtime_embedder::system_api::{
 };
 use ic_interfaces::execution_environment::{ExecutionMode, SubnetAvailableMemory};
 use ic_logger::replica_logger::no_op_logger;
-use ic_management_canister_types_private::IC_00;
 use ic_nns_constants::CYCLES_MINTING_CANISTER_ID;
 use ic_registry_routing_table::{CanisterIdRange, RoutingTable};
 use ic_registry_subnet_type::SubnetType;
@@ -94,7 +93,6 @@ impl ApiTypeBuilder {
 
     pub fn build_system_task_api() -> ApiType {
         ApiType::system_task(
-            IC_00.get(),
             SystemMethod::CanisterHeartbeat,
             UNIX_EPOCH,
             CallContextId::from(1),

--- a/rs/execution_environment/src/execution/call_or_task.rs
+++ b/rs/execution_environment/src/execution/call_or_task.rs
@@ -21,7 +21,6 @@ use ic_interfaces::execution_environment::{
     CanisterOutOfCyclesError, HypervisorError, WasmExecutionOutput,
 };
 use ic_logger::{info, ReplicaLogger};
-use ic_management_canister_types_private::IC_00;
 use ic_replicated_state::{
     canister_state::execution_state::WasmExecutionMode, num_bytes_try_from, CallContextAction,
     CallOrigin, CanisterState,
@@ -178,19 +177,16 @@ pub fn execute_call_or_task(
             helper.call_context_id(),
         ),
         CanisterCallOrTask::Task(CanisterTask::Heartbeat) => ApiType::system_task(
-            IC_00.get(),
             SystemMethod::CanisterHeartbeat,
             time,
             helper.call_context_id(),
         ),
         CanisterCallOrTask::Task(CanisterTask::GlobalTimer) => ApiType::system_task(
-            IC_00.get(),
             SystemMethod::CanisterGlobalTimer,
             time,
             helper.call_context_id(),
         ),
         CanisterCallOrTask::Task(CanisterTask::OnLowWasmMemory) => ApiType::system_task(
-            IC_00.get(),
             SystemMethod::CanisterOnLowWasmMemory,
             time,
             helper.call_context_id(),


### PR DESCRIPTION
This PR consolidates how caller is extracted from System API, forcing to go through `ApiType::caller` for all cases. There used to be a second method in `SystemApiImpl` which would actually return a slightly different result than `ApiType::caller` (a miss in an older change https://github.com/dfinity/ic/commit/e2ea0f12e3e4465d3dccd44d1e4988fc499dc2d0 that adjusted when `ic0.msg_caller*` is available).

With this fix consistency is ensured when the caller needs to be extracted from the System API and `ApiType::caller` is covered now through our usual system api availability tests for future proofing.