### PR TITLE
chore(nns): Cleanup USE_NODE_PROVIDER_REWARD_CANISTER flag and code

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -67,7 +67,6 @@ use crate::{
         },
     },
     proposals::{call_canister::CallCanister, sum_weighted_voting_power},
-    use_node_provider_reward_canister,
 };
 use async_trait::async_trait;
 use candid::{Decode, Encode};
@@ -116,12 +115,9 @@ use ic_stable_structures::{storable::Bound, Storable};
 use icp_ledger::{AccountIdentifier, Subaccount, Tokens, TOKEN_SUBDIVIDABLE_BY};
 use itertools::Itertools;
 use maplit::hashmap;
-use registry_canister::{
-    mutations::do_add_node_operator::AddNodeOperatorPayload, pb::v1::NodeProvidersMonthlyXdrRewards,
-};
+use registry_canister::mutations::do_add_node_operator::AddNodeOperatorPayload;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::{
     borrow::Cow,
@@ -7579,18 +7575,6 @@ impl Governance {
     async fn get_node_providers_monthly_xdr_rewards(
         &self,
     ) -> Result<(BTreeMap<PrincipalId, u64>, Option<u64>), GovernanceError> {
-        if use_node_provider_reward_canister() {
-            self.get_node_providers_monthly_xdr_rewards_from_node_provider_reward_canister()
-                .await
-        } else {
-            self.get_node_providers_monthly_xdr_rewards_from_registry()
-                .await
-        }
-    }
-
-    async fn get_node_providers_monthly_xdr_rewards_from_node_provider_reward_canister(
-        &self,
-    ) -> Result<(BTreeMap<PrincipalId, u64>, Option<u64>), GovernanceError> {
         let response: Vec<u8> = self.env.call_canister_method(
             NODE_REWARDS_CANISTER_ID,
             "get_node_providers_monthly_xdr_rewards",
@@ -7647,62 +7631,6 @@ impl Governance {
             "get_node_providers_monthly_xdr_rewards returned empty response, \
                 which should be impossible.",
         ))
-    }
-
-    /// A helper to get the node provider rewards from registry (instead of Node Provider Reward Canister)
-    /// This will be removed once the Node Provider Reward Canister is in use.
-    async fn get_node_providers_monthly_xdr_rewards_from_registry(
-        &self,
-    ) -> Result<(BTreeMap<PrincipalId, u64>, Option<u64>), GovernanceError> {
-        let registry_response:
-            Vec<u8> = self
-            .env
-            .call_canister_method(
-                REGISTRY_CANISTER_ID,
-                "get_node_providers_monthly_xdr_rewards",
-                Encode!().unwrap(),
-            )
-            .await
-            .map_err(|(code, msg)| {
-                GovernanceError::new_with_message(
-                    ErrorType::External,
-                    format!(
-                        "Error calling 'get_node_providers_monthly_xdr_rewards': code: {:?}, message: {}",
-                        code, msg
-                    ),
-                )
-            })?;
-
-        Decode!(&registry_response, Result<NodeProvidersMonthlyXdrRewards, String>)
-            .map_err(|err| {
-                GovernanceError::new_with_message(
-                    ErrorType::External,
-                    format!(
-                        "Cannot decode return type from get_node_providers_monthly_xdr_rewards'. Error: {}",
-                        err,
-                    ),
-                )
-            })?
-            .map_err(|msg| GovernanceError::new_with_message(ErrorType::External, msg))
-            .map(|response| {
-                let NodeProvidersMonthlyXdrRewards {
-                    rewards,
-                    registry_version,
-                } = response;
-
-                let rewards = rewards
-                    .into_iter()
-                    .map(|(principal_str, amount)| {
-                        (
-                            PrincipalId::from_str(&principal_str)
-                                .expect("Could not get principal from string"),
-                            amount,
-                        )
-                    })
-                    .collect();
-
-                (rewards, registry_version)
-            })
     }
 
     /// A helper for the CMC's get_average_icp_xdr_conversion_rate method

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -201,11 +201,8 @@ pub const DEFAULT_VOTING_POWER_REFRESHED_TIMESTAMP_SECONDS: u64 = 1725148800;
 // leave this here indefinitely, but it will just be clutter after a modest
 // amount of time.
 thread_local! {
-
     static DISABLE_NF_FUND_PROPOSALS: Cell<bool>
         = const { Cell::new(cfg!(not(any(feature = "canbench-rs", feature = "test")))) };
-
-    static USE_NODE_PROVIDER_REWARD_CANISTER: Cell<bool> = const { Cell::new(true) };
 }
 
 thread_local! {
@@ -229,20 +226,6 @@ pub fn temporarily_enable_nf_fund_proposals() -> Temporary {
 #[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_nf_fund_proposals() -> Temporary {
     Temporary::new(&DISABLE_NF_FUND_PROPOSALS, true)
-}
-
-pub fn use_node_provider_reward_canister() -> bool {
-    USE_NODE_PROVIDER_REWARD_CANISTER.get()
-}
-
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_enable_node_provider_reward_canister() -> Temporary {
-    Temporary::new(&USE_NODE_PROVIDER_REWARD_CANISTER, true)
-}
-
-#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
-pub fn temporarily_disable_node_provider_reward_canister() -> Temporary {
-    Temporary::new(&USE_NODE_PROVIDER_REWARD_CANISTER, false)
 }
 
 pub fn decoder_config() -> DecoderConfig {

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -14,7 +14,7 @@ use ic_nns_common::{
 };
 use ic_nns_constants::{
     CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID,
-    NODE_REWARDS_CANISTER_ID, REGISTRY_CANISTER_ID, SNS_WASM_CANISTER_ID,
+    NODE_REWARDS_CANISTER_ID, SNS_WASM_CANISTER_ID,
 };
 use ic_nns_governance::{
     governance::{Environment, Governance, HeapGrowthPotential, RngError},
@@ -31,10 +31,9 @@ use ic_sns_wasm::pb::v1::{DeployedSns, ListDeployedSnsesRequest, ListDeployedSns
 use icp_ledger::{AccountIdentifier, Subaccount, Tokens};
 use icrc_ledger_types::icrc3::blocks::{GetBlocksRequest, GetBlocksResult};
 use lazy_static::lazy_static;
-use maplit::{btreemap, hashmap};
+use maplit::btreemap;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use registry_canister::pb::v1::NodeProvidersMonthlyXdrRewards;
 use std::{
     collections::{hash_map::Entry, BTreeMap, HashMap},
     convert::{TryFrom, TryInto},

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -22,7 +22,6 @@ use ic_nns_governance::{
         manage_neuron, manage_neuron::NeuronIdOrSubaccount, proposal, ExecuteNnsFunction,
         GovernanceError, ManageNeuron, Motion, NetworkEconomics, NnsFunction, Proposal, Vote,
     },
-    use_node_provider_reward_canister,
 };
 use ic_nns_governance_api::Neuron;
 use ic_nns_governance_api::{manage_neuron_response, ManageNeuronResponse};
@@ -578,32 +577,20 @@ impl Environment for FakeDriver {
         }
 
         if method_name == "get_node_providers_monthly_xdr_rewards" {
-            if use_node_provider_reward_canister() {
-                assert_eq!(PrincipalId::from(target), NODE_REWARDS_CANISTER_ID.get());
+            assert_eq!(PrincipalId::from(target), NODE_REWARDS_CANISTER_ID.get());
 
-                return Ok(Encode!(&GetNodeProvidersMonthlyXdrRewardsResponse {
-                    rewards: Some(ic_node_rewards_canister_api::monthly_rewards::NodeProvidersMonthlyXdrRewards {
+            return Ok(Encode!(&GetNodeProvidersMonthlyXdrRewardsResponse {
+                rewards: Some(
+                    ic_node_rewards_canister_api::monthly_rewards::NodeProvidersMonthlyXdrRewards {
                         rewards: btreemap! {
                             PrincipalId::new_user_test_id(1).0 => NODE_PROVIDER_REWARD,
                         },
                         registry_version: Some(5)
-                    }),
-                    error: None
-                })
-                .unwrap());
-            } else {
-                assert_eq!(PrincipalId::from(target), REGISTRY_CANISTER_ID.get());
-
-                return Ok(Encode!(&Ok::<NodeProvidersMonthlyXdrRewards, String>(
-                    NodeProvidersMonthlyXdrRewards {
-                        rewards: hashmap! {
-                            PrincipalId::new_user_test_id(1).to_string() => NODE_PROVIDER_REWARD,
-                        },
-                        registry_version: Some(5)
                     }
-                ))
-                .unwrap());
-            }
+                ),
+                error: None
+            })
+            .unwrap());
         }
 
         if method_name == "get_average_icp_xdr_conversion_rate" {

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -70,14 +70,13 @@ impl NodeInfo {
 
 #[test]
 fn test_list_node_provider_rewards() {
-    let features = &[];
     let state_machine = state_machine_builder_for_nns_tests().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()
         .with_initial_invariant_compliant_mutations()
         .with_test_neurons()
         .build();
-    setup_nns_canisters_with_features(&state_machine, nns_init_payload, features);
+    setup_nns_canisters_with_features(&state_machine, nns_init_payload, &[]);
 
     add_data_centers(&state_machine);
     add_node_rewards_table(&state_machine);
@@ -284,14 +283,13 @@ fn test_list_node_provider_rewards() {
 
 #[test]
 fn test_automated_node_provider_remuneration() {
-    let features = &[];
     let state_machine = state_machine_builder_for_nns_tests().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()
         .with_initial_invariant_compliant_mutations()
         .with_test_neurons()
         .build();
-    setup_nns_canisters_with_features(&state_machine, nns_init_payload, features);
+    setup_nns_canisters_with_features(&state_machine, nns_init_payload, &[]);
 
     add_data_centers(&state_machine);
     add_node_rewards_table(&state_machine);

--- a/rs/nns/integration_tests/src/node_provider_remuneration.rs
+++ b/rs/nns/integration_tests/src/node_provider_remuneration.rs
@@ -70,16 +70,7 @@ impl NodeInfo {
 
 #[test]
 fn test_list_node_provider_rewards() {
-    do_test_list_node_provider_rewards(&[]);
-}
-
-// TODO(NNS1-3763) after Node Reward Canister is by-default enabled, remove this test.
-#[test]
-fn test_list_node_provider_rewards_with_node_reward_canister() {
-    do_test_list_node_provider_rewards(&["test"]);
-}
-
-fn do_test_list_node_provider_rewards(features: &[&str]) {
+    let features = &[];
     let state_machine = state_machine_builder_for_nns_tests().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()
@@ -293,18 +284,7 @@ fn do_test_list_node_provider_rewards(features: &[&str]) {
 
 #[test]
 fn test_automated_node_provider_remuneration() {
-    do_test_automated_node_provider_remuneration(&[]);
-}
-
-// TODO(NNS1-3763) after Node Reward Canister is by-default enabled, remove this test.
-#[test]
-fn test_automated_node_provider_remuneration_with_node_reward_canister() {
-    do_test_automated_node_provider_remuneration(&["test"]);
-}
-
-// This test cannot depend on any specific "test" features to function, as
-// only one calling version uses the test feature flag.
-fn do_test_automated_node_provider_remuneration(features: &[&str]) {
+    let features = &[];
     let state_machine = state_machine_builder_for_nns_tests().build();
 
     let nns_init_payload = NnsInitPayloadsBuilder::new()


### PR DESCRIPTION
This removes the feature flag for a feature that has run successfully, and no longer needs to be gated behind a feature flag.