### PR TITLE
chore(governance): Fix order of SNS canisters and double quote some bash variables in release scripts

### DIFF
--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -185,7 +185,7 @@ fn run_determine_targets(cmd: DetermineTargets) -> Result<()> {
         "Genesis-Token",
         "Node-Rewards",
     ];
-    let sns_candidates = ["Root", "Governance", "Swap", "Ledger", "Archive", "Index"];
+    let sns_candidates = ["Root", "Governance", "Swap", "Index", "Ledger", "Archive"];
 
     // Prepare vectors for selected releases.
     let mut nns_canisters: Vec<String> = Vec::new();

--- a/testnet/tools/nns-tools/lib/sns_upgrades.sh
+++ b/testnet/tools/nns-tools/lib/sns_upgrades.sh
@@ -50,11 +50,11 @@ sns_wasm_hash_to_git_commit() {
 
     __dfx -q canister --network $NNS_URL \
         call --candid "$SNS_W_DID" \
-        ${SNS_W} get_wasm "(record { hash = vec ${BYTE_ARRAY_HASH}: vec nat8})" \
+        "${SNS_W}" get_wasm "(record { hash = vec ${BYTE_ARRAY_HASH}: vec nat8})" \
         | $IDL2JSON | jq -r .wasm[0].wasm[] | wasm_bytes_write_to_binary "${WASM_FILE}.gz"
     gzip -d "${WASM_FILE}.gz"
-    GIT_COMMIT_ID=$($IC_WASM ${WASM_FILE} metadata git_commit_id)
-    rm -rf ${WASM_FILE}
+    GIT_COMMIT_ID=$("$IC_WASM" "${WASM_FILE}" metadata git_commit_id)
+    rm -rf "${WASM_FILE}"
 
     echo $GIT_COMMIT_ID
 }


### PR DESCRIPTION
The order of SNS ledger suite canisters should be Index, Ledger, Archive. That is the intended order of upgrades for those canisters.

