### PR TITLE
fix: don't assume the current UID is 1001 to fix the schedule-rust-bench workflow

### DIFF
--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         if [ -e /cache ]; then
-          sudo find /cache \( -not -user 1001 -or -not -group 1001 \) -exec chown 1001:1001 {} +
+          sudo find /cache \( -not -user $(id -u) -or -not -group $(id -g) \) -exec chown $(id -u):$(id -g) {} +
         fi
 
     # Create a known tempdir where build events will be written


### PR DESCRIPTION
On 2025-05-15, after https://github.com/dfinity/ic/commit/1a0559dfaf00591d5e82e99ea5d59d3eb59460f3 the Schedule Rust Benchmarks [started failing](https://github.com/dfinity/ic/actions/runs/15034578789/job/42253845722#step:4:125) with:
```
ERROR: Error computing the main repository mapping: 
Error accessing registry https://bcr.bazel.build/: 
Failed to fetch registry file https://bcr.bazel.build/modules/rules_oci/2.0.0/MODULE.bazel: 
/cache/bazel/content_addressable/sha256/5d5cf1932238b009f874d5a9f214bbedf5d8cec8e5028e083f1147726876572f/tmp-b5ead0e6-c6a7-4c74-b416-919d96c41b1a 
(Permission denied)
```

This was because the owner of the `/cache` directory got recursively changed to 1001:1001 every time the jobs ran. On `fr1-spm15`, where the rust benchmarks run, 1001 maps to the `dfnadmin` user which is different than the `ubuntu` user with UID 1000 as which the job runs.

It's still unclear to me why we need to change the ownership of `/cache` in the first place but this fix seems like a good stop-gap until we understand the full picture.

Schedule Rust Benchmarks : https://github.com/dfinity/ic/actions/runs/15675767651