### PR TITLE
chore(IDX): add alerts for ic-private

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -6,6 +6,7 @@ on:
       - completed
     branches:
       - master
+      - master-private
       - rc--*
     tags:
       - release-*
@@ -19,6 +20,7 @@ on:
       - Publish Release
       - Container IC Base Images
       - PocketIC Windows
+      - Sync IC private from IC public
 
 jobs:
   slack-workflow-run:


### PR DESCRIPTION
This adds an alert for `Sync IC private from IC public` so we will be notified if it is broken (like it was last week).

This workflow will be triggered from `ic-private`, though because all workflows except for `Sync IC private from IC public` are disabled we should only receive alerts for this one.

If this alert fails and we start getting alerts every 10 minutes, we can always disable this `Slack Workflow Run` workflow in ic-private.