### PR TITLE
chore: Remove redundant allow clippy

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -406,7 +406,6 @@ impl ApiType {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn update(
         time: Time,
         incoming_payload: Vec<u8>,


### PR DESCRIPTION
This seems to be a leftover from when the function accepted more parameters. It is not needed anymore.