### PR TITLE
chore: Reenable large subnet recovery test

### DIFF
--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -244,7 +244,6 @@ system_test_nns(
     flaky = True,  # flakiness rate of over 2.21% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "experimental_system_test_colocation",
-        "manual",  # the test is not reliable
         "subnet_recovery",
         "system_test_hourly",
     ],


### PR DESCRIPTION
The mainnet version of test should now pass as well, after the registry was upgraded to support chunking with proposal [136988](https://dashboard.internetcomputer.org/proposal/136988)