### PR TITLE
feat(nns): Add a metric for the number of spawning neurons

### DIFF
--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -2791,6 +2791,7 @@ pub mod governance {
         pub dissolving_neurons_e8s_buckets_ect: ::std::collections::HashMap<u64, f64>,
         pub not_dissolving_neurons_e8s_buckets_seed: ::std::collections::HashMap<u64, f64>,
         pub not_dissolving_neurons_e8s_buckets_ect: ::std::collections::HashMap<u64, f64>,
+        pub spawning_neurons_count: u64,
         /// Deprecated. Use non_self_authenticating_controller_neuron_subset_metrics instead.
         pub total_voting_power_non_self_authenticating_controller: Option<u64>,
         pub total_staked_e8s_non_self_authenticating_controller: Option<u64>,

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -375,6 +375,7 @@ type GovernanceCachedMetrics = record {
   not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
+  spawning_neurons_count : nat64;
 
   non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   public_neuron_subset_metrics : opt NeuronSubsetMetrics;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -372,6 +372,7 @@ type GovernanceCachedMetrics = record {
   not_dissolving_neurons_e8s_buckets_seed : vec record { nat64; float64 };
   timestamp_seconds : nat64;
   seed_neuron_count : nat64;
+  spawning_neurons_count : nat64;
 
   non_self_authenticating_controller_neuron_subset_metrics : opt NeuronSubsetMetrics;
   public_neuron_subset_metrics : opt NeuronSubsetMetrics;

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2037,6 +2037,7 @@ message Governance {
     map<uint64, double> dissolving_neurons_e8s_buckets_ect = 33;
     map<uint64, double> not_dissolving_neurons_e8s_buckets_seed = 34;
     map<uint64, double> not_dissolving_neurons_e8s_buckets_ect = 35;
+    uint64 spawning_neurons_count = 42;
 
     // Deprecated. Use non_self_authenticating_controller_neuron_subset_metrics instead.
     optional uint64 total_voting_power_non_self_authenticating_controller = 36;

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3002,6 +3002,8 @@ pub mod governance {
         pub not_dissolving_neurons_e8s_buckets_seed: ::std::collections::HashMap<u64, f64>,
         #[prost(map = "uint64, double", tag = "35")]
         pub not_dissolving_neurons_e8s_buckets_ect: ::std::collections::HashMap<u64, f64>,
+        #[prost(uint64, tag = "42")]
+        pub spawning_neurons_count: u64,
         /// Deprecated. Use non_self_authenticating_controller_neuron_subset_metrics instead.
         #[prost(uint64, optional, tag = "36")]
         pub total_voting_power_non_self_authenticating_controller: ::core::option::Option<u64>,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -7835,6 +7835,7 @@ impl Governance {
             dissolving_neurons_e8s_buckets_ect,
             not_dissolving_neurons_e8s_buckets_seed,
             not_dissolving_neurons_e8s_buckets_ect,
+            spawning_neurons_count,
             non_self_authenticating_controller_neuron_subset_metrics,
             public_neuron_subset_metrics,
             declining_voting_power_neuron_subset_metrics,
@@ -7898,6 +7899,7 @@ impl Governance {
             dissolving_neurons_e8s_buckets_ect,
             not_dissolving_neurons_e8s_buckets_seed,
             not_dissolving_neurons_e8s_buckets_ect,
+            spawning_neurons_count,
             total_staked_e8s_non_self_authenticating_controller,
             total_voting_power_non_self_authenticating_controller,
 

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -621,6 +621,7 @@ pub fn encode_metrics(
             dissolving_neurons_e8s_buckets_ect,
             not_dissolving_neurons_e8s_buckets_seed,
             not_dissolving_neurons_e8s_buckets_ect,
+            spawning_neurons_count,
 
             // Non-self-authenticating neurons.
             total_voting_power_non_self_authenticating_controller: _,
@@ -883,6 +884,12 @@ pub fn encode_metrics(
                 w,
             )?;
         }
+
+        w.encode_gauge(
+            "governance_spawning_neurons_count",
+            *spawning_neurons_count as f64,
+            "The number of neurons that are in the \"spawning\" state.",
+        )?;
     }
 
     Ok(())

--- a/rs/nns/governance/src/neuron_store/metrics.rs
+++ b/rs/nns/governance/src/neuron_store/metrics.rs
@@ -56,6 +56,7 @@ pub(crate) struct NeuronMetrics {
     pub(crate) dissolving_neurons_e8s_buckets_ect: HashMap<u64, f64>,
     pub(crate) not_dissolving_neurons_e8s_buckets_seed: HashMap<u64, f64>,
     pub(crate) not_dissolving_neurons_e8s_buckets_ect: HashMap<u64, f64>,
+    pub(crate) spawning_neurons_count: u64,
 
     // Much of the above could also be done like this, but we leave such refactoring as an exercise
     // to the reader.
@@ -330,7 +331,9 @@ impl NeuronStore {
                 let bucket = dissolve_delay_seconds / (6 * ONE_MONTH_SECONDS);
                 match neuron.state(now_seconds) {
                     NeuronState::Unspecified => (),
-                    NeuronState::Spawning => (),
+                    NeuronState::Spawning => {
+                        metrics.spawning_neurons_count += 1;
+                    }
                     NeuronState::Dissolved => {
                         metrics.dissolved_neurons_count += 1;
                         metrics.dissolved_neurons_e8s += neuron.cached_neuron_stake_e8s;

--- a/rs/nns/governance/src/neuron_store/metrics/tests.rs
+++ b/rs/nns/governance/src/neuron_store/metrics/tests.rs
@@ -11,21 +11,6 @@ use maplit::{btreemap, hashmap};
 use pretty_assertions::assert_eq;
 use std::{collections::BTreeMap, str::FromStr};
 
-fn create_test_neuron_builder(
-    id: u64,
-    dissolve_state_and_age: DissolveStateAndAge,
-) -> NeuronBuilder {
-    // Among the required neuron fields, only the id and dissolve state and age are meaningful
-    // for neuron metrics tests.
-    NeuronBuilder::new(
-        NeuronId { id },
-        Subaccount::try_from([0u8; 32].as_ref()).unwrap(),
-        PrincipalId::new_user_test_id(123),
-        dissolve_state_and_age,
-        123_456_789,
-    )
-}
-
 #[test]
 fn test_compute_metrics() {
     let mut neuron_store = NeuronStore::new(BTreeMap::new());
@@ -33,7 +18,7 @@ fn test_compute_metrics() {
 
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 1,
                 DissolveStateAndAge::NotDissolving {
                     dissolve_delay_seconds: 1,
@@ -47,7 +32,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 2,
                 DissolveStateAndAge::NotDissolving {
                     dissolve_delay_seconds: ONE_YEAR_SECONDS,
@@ -63,7 +48,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 3,
                 DissolveStateAndAge::NotDissolving {
                     dissolve_delay_seconds: ONE_YEAR_SECONDS * 4,
@@ -76,7 +61,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 4,
                 DissolveStateAndAge::NotDissolving {
                     dissolve_delay_seconds: ONE_YEAR_SECONDS * 4,
@@ -89,7 +74,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 5,
                 DissolveStateAndAge::NotDissolving {
                     dissolve_delay_seconds: ONE_YEAR_SECONDS * 8,
@@ -102,7 +87,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 6,
                 DissolveStateAndAge::NotDissolving {
                     dissolve_delay_seconds: 5,
@@ -115,7 +100,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 7,
                 DissolveStateAndAge::NotDissolving {
                     dissolve_delay_seconds: 5,
@@ -128,7 +113,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 8,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now + ONE_YEAR_SECONDS,
@@ -142,7 +127,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 9,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now + ONE_YEAR_SECONDS * 3,
@@ -156,7 +141,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 10,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now + ONE_YEAR_SECONDS * 5,
@@ -168,7 +153,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 11,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now + ONE_YEAR_SECONDS * 5,
@@ -180,7 +165,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 12,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now + ONE_YEAR_SECONDS * 7,
@@ -192,7 +177,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 13,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now - ONE_YEAR_SECONDS,
@@ -204,7 +189,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 14,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now - ONE_YEAR_SECONDS,
@@ -216,7 +201,7 @@ fn test_compute_metrics() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 15,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: 1,
@@ -229,13 +214,27 @@ fn test_compute_metrics() {
     // This neuron is inactive - not founded and dissolved "long ago".
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 16,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now - ONE_YEAR_SECONDS,
                 },
             )
             .with_cached_neuron_stake_e8s(0)
+            .build(),
+        )
+        .unwrap();
+    // This neuron is spawning.
+    neuron_store
+        .add_neuron(
+            NeuronBuilder::new_for_test(
+                17,
+                DissolveStateAndAge::DissolvingOrDissolved {
+                    when_dissolved_timestamp_seconds: now + 1,
+                },
+            )
+            .with_cached_neuron_stake_e8s(100_000_000)
+            .with_spawn_at_timestamp_seconds(now + 1)
             .build(),
         )
         .unwrap();
@@ -263,13 +262,13 @@ fn test_compute_metrics() {
         dissolved_neurons_e8s: 5770000000,
         garbage_collectable_neurons_count: 1,
         neurons_with_invalid_stake_count: 1,
-        total_staked_e8s: 39_894_000_100,
-        neurons_with_less_than_6_months_dissolve_delay_count: 7,
-        neurons_with_less_than_6_months_dissolve_delay_e8s: 5870000100,
+        total_staked_e8s: 39_994_000_100,
+        neurons_with_less_than_6_months_dissolve_delay_count: 8,
+        neurons_with_less_than_6_months_dissolve_delay_e8s: 5970000100,
         community_fund_total_staked_e8s: 234_000_000,
         community_fund_total_maturity_e8s_equivalent: 450_988_012,
         neurons_fund_total_active_neurons: 1,
-        total_locked_e8s: 34_124_000_100,
+        total_locked_e8s: 34_224_000_100,
         total_maturity_e8s_equivalent: 450_988_012,
         total_staked_maturity_e8s_equivalent: 200_000_000_u64,
         dissolving_neurons_staked_maturity_e8s_equivalent_buckets: hashmap! {
@@ -296,6 +295,7 @@ fn test_compute_metrics() {
         dissolving_neurons_e8s_buckets_ect: hashmap! { 6 => 568000000.0 },
         not_dissolving_neurons_e8s_buckets_seed: hashmap! { 0 => 100000000.0 },
         not_dissolving_neurons_e8s_buckets_ect: hashmap! { 2 => 234000000.0 },
+        spawning_neurons_count: 1,
         // Some garbage values, because this test was written before this feature.
         non_self_authenticating_controller_neuron_subset_metrics: NeuronSubsetMetrics::default(),
         public_neuron_subset_metrics: NeuronSubsetMetrics::default(),
@@ -326,7 +326,7 @@ fn test_compute_metrics_inactive_neuron_in_heap() {
 
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 1,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now - ONE_DAY_SECONDS,
@@ -338,7 +338,7 @@ fn test_compute_metrics_inactive_neuron_in_heap() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 2,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now - 13 * ONE_DAY_SECONDS,
@@ -350,7 +350,7 @@ fn test_compute_metrics_inactive_neuron_in_heap() {
         .unwrap();
     neuron_store
         .add_neuron(
-            create_test_neuron_builder(
+            NeuronBuilder::new_for_test(
                 3,
                 DissolveStateAndAge::DissolvingOrDissolved {
                     when_dissolved_timestamp_seconds: now - 30 * ONE_DAY_SECONDS,

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -2731,6 +2731,7 @@ impl From<pb::governance::GovernanceCachedMetrics> for pb_api::governance::Gover
                 .total_voting_power_non_self_authenticating_controller,
             total_staked_e8s_non_self_authenticating_controller: item
                 .total_staked_e8s_non_self_authenticating_controller,
+            spawning_neurons_count: item.spawning_neurons_count,
             non_self_authenticating_controller_neuron_subset_metrics: item
                 .non_self_authenticating_controller_neuron_subset_metrics
                 .map(|x| x.into()),
@@ -2794,6 +2795,7 @@ impl From<pb_api::governance::GovernanceCachedMetrics> for pb::governance::Gover
                 .total_voting_power_non_self_authenticating_controller,
             total_staked_e8s_non_self_authenticating_controller: item
                 .total_staked_e8s_non_self_authenticating_controller,
+            spawning_neurons_count: item.spawning_neurons_count,
             non_self_authenticating_controller_neuron_subset_metrics: item
                 .non_self_authenticating_controller_neuron_subset_metrics
                 .map(|x| x.into()),

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -13238,6 +13238,7 @@ async fn test_metrics() {
         // Garbage values, because this test was written before this feature.
         total_voting_power_non_self_authenticating_controller: Some(0xDEAD),
         total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),
+        spawning_neurons_count: 0,
         non_self_authenticating_controller_neuron_subset_metrics: None,
         public_neuron_subset_metrics: None,
         declining_voting_power_neuron_subset_metrics: None,
@@ -13334,6 +13335,7 @@ async fn test_metrics() {
         dissolving_neurons_e8s_buckets_ect: Default::default(),
         not_dissolving_neurons_e8s_buckets_seed: hashmap! { 0 => 100000000.0 },
         not_dissolving_neurons_e8s_buckets_ect: hashmap! { 2 => 200000000.0 },
+        spawning_neurons_count: 0,
         // Garbage values, because this test was written before this feature.
         total_voting_power_non_self_authenticating_controller: Some(0xDEAD),
         total_staked_e8s_non_self_authenticating_controller: Some(0xBEEF),

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,6 +9,8 @@ on the process that this file is part of, see
 
 ## Added
 
+* Add a metric for the nubmer of spawning neurons.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
# Why

As NNS Dap switches from spawning neurons to disbursing maturity, it would be interesting to monitor its impact on the number of spawning neurons.

# What

* Aggregate `spawning_neurons_count` when iterating through neurons in `compute_cached_metrics`
* Add `spawning_neurons_count` to both cached metrics and metrics, and pass the cached metric to metric
* Encode `governance_spawning_neurons_count` in the metrics endpoint