### PR TITLE
chore: add date to `ic-metrics-assert` change log

### DIFF
--- a/packages/ic-metrics-assert/CHANGELOG.md
+++ b/packages/ic-metrics-assert/CHANGELOG.md
@@ -5,4 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] - 2025-06-17
+
+Initial release.

--- a/packages/ic-metrics-assert/CHANGELOG.md
+++ b/packages/ic-metrics-assert/CHANGELOG.md
@@ -7,4 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2025-06-17
 
-Initial release.
+### Added
+
+- Initial release of the crate providing fluent assertions for metrics in Rust, designed for use with Internet Computer (IC) canisters.
+- Core struct `MetricsAssert<T>` enabling Regex-based test assertions using:
+    - `.assert_contains_metric_matching(...)`
+    - `.assert_does_not_contain_metric_matching(...)`
+- Support for both synchronous and asynchronous querying of canister metrics via:
+    - `CanisterHttpQuery` (trait for sync HTTP querying)
+    - `AsyncCanisterHttpQuery` (trait for async HTTP querying)
+- `MetricsAssert::from_http_query(...)` and `from_async_http_query(...)` constructors to retrieve metrics from the `/metrics` endpoint and assert on their contents.
+- Optional **`pocket_ic` feature**:
+    - Adds support for integration testing with [`PocketIc`](https://docs.rs/pocket-ic).
+    - Provides implementations of `CanisterHttpQuery` and `AsyncCanisterHttpQuery` for types that implement:
+        - `PocketIcHttpQuery` (trait for sync HTTP querying using `PocketIc`)
+        - `PocketIcAsyncHttpQuery` (trait for async HTTP querying using `PocketIc`)

--- a/packages/ic-metrics-assert/README.md
+++ b/packages/ic-metrics-assert/README.md
@@ -1,3 +1,12 @@
 # IC Metrics Assert
 
-This package defines test utilities to perform assertions on canister metrics collected by Prometheus.
+> Fluent assertions for Prometheus-style metrics exposed by Internet Computer (IC) canisters.
+
+`ic-metrics-assert` provides regex-based assertions for testing metrics endpoints of IC canisters. It supports both synchronous and asynchronous contexts, and integrates with [`PocketIc`](https://docs.rs/pocket-ic) for local canister testing.
+
+## Features
+
+- Query metrics from canister `/metrics` HTTP endpoint
+- Fluent regex-based assertions on canister metrics
+- Support for both sync and async test flows
+- Optional `pocket_ic` feature for use with `PocketIc` environments


### PR DESCRIPTION
(XC-296) Add release date for v0.1.0 in `ic-metrics-assert` `CHANGELOG.md`.