### PR TITLE
revert: "chore: [MR-600] Enable incremental manifest computation on the NNS"

### DIFF
--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -2320,7 +2320,11 @@ impl StateManagerImpl {
             })
             .expect("Failed to send Validate request");
 
-        let manifest_delta = {
+        // On the NNS subnet we never allow incremental manifest computation
+        let is_nns = self.own_subnet_id == state.metadata.network_topology.nns_subnet_id;
+        let manifest_delta = if is_nns {
+            None
+        } else {
             let _timer = self
                 .metrics
                 .checkpoint_metrics


### PR DESCRIPTION
Reverts dfinity/ic#5573

This is breaking the nightly backup test, which is trying to detect a state divergence after modifying a checkpoint file: https://github.com/dfinity/ic/actions/runs/15697333995