### PR TITLE
chore: do a release_build on a workflow_call

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -87,8 +87,9 @@ jobs:
               fi
           done
 
-          if [[ "${is_protected_branch:-}" == "true" ]]; then
-              # if we are on a "protected" branch or targeting an rc branch we
+          if [[ "${is_protected_branch:-}" == "true" || '${{ github.event_name }}' == 'workflow_call' ]]; then
+              # if we are on a "protected" branch, targeting an rc branch or
+              # we're called from another workflow (i.e. release-testing) we
               # upload all artifacts and run a release build (with versioning)
               release_build="true"
               diff_only="false"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -52,8 +52,9 @@ jobs:
               fi
           done
 
-          if [[ "${is_protected_branch:-}" == "true" ]]; then
-              # if we are on a "protected" branch or targeting an rc branch we
+          if [[ "${is_protected_branch:-}" == "true" || '${{ github.event_name }}' == 'workflow_call' ]]; then
+              # if we are on a "protected" branch, targeting an rc branch or
+              # we're called from another workflow (i.e. release-testing) we
               # upload all artifacts and run a release build (with versioning)
               release_build="true"
               diff_only="false"


### PR DESCRIPTION
Make sure that when the `CI Main` workfow is called from the `Release Testing` workflow `release_build` will be enabled to ensure the `Repro check` job in the `Release Testing` workflow can download the expected artifacts from the CDN.

Note that we implement this by enabling `release_build` when `'${{ github.event_name }}' == 'workflow_call'`. This means that when `CI Main` is called from `Release Testing` artifacts will be uploaded. However it also means that artifacts will be uploaded if `CI Main` is called from *any other* workflows. We don't do that currently but it could be a surprise when we do. A way to prevent this is to pass a `caller_workflow: "Release Testing"` argument when calling `CI Main` from `Release Testing` and check for that. However, I don't think it's worth the complexity, but I'm happy to be convinced otherwise.