### PR TITLE
test(Ledgers): FI-1459: Add transfer_from to valid_transactions_strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9822,6 +9822,7 @@ dependencies = [
  "rosetta-core",
  "serde_bytes",
  "serde_json",
+ "strum 0.26.3",
 ]
 
 [[package]]

--- a/rs/ledger_suite/icrc1/test_utils/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/test_utils/BUILD.bazel
@@ -21,6 +21,12 @@ DEV_DEPENDENCIES = [
     "@crate_index//:rand_chacha",
     "@crate_index//:serde_bytes",
     "@crate_index//:serde_json",
+    "@crate_index//:strum",
+]
+
+MACRO_DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:strum_macros",
 ]
 
 rust_library(
@@ -28,6 +34,7 @@ rust_library(
     testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_icrc1_test_utils",
+    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.8.0",
     deps = DEV_DEPENDENCIES,
 )

--- a/rs/ledger_suite/icrc1/test_utils/Cargo.toml
+++ b/rs/ledger_suite/icrc1/test_utils/Cargo.toml
@@ -24,3 +24,4 @@ rand_chacha = { workspace = true }
 rosetta-core = { path = "../../../rosetta-api/common/rosetta_core" }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
+strum = "0.26.3"

--- a/rs/ledger_suite/icrc1/test_utils/src/lib.rs
+++ b/rs/ledger_suite/icrc1/test_utils/src/lib.rs
@@ -601,7 +601,7 @@ impl TransactionsAndBalances {
                 Included((account, MIN_ACCOUNT)),
                 Included((account, MAX_ACCOUNT)),
             ))
-            .any(|((from, _), allowance)| *from == account && allowance.get_e8s() >= default_fee);
+            .any(|((_from, _spender), allowance)| allowance.get_e8s() >= default_fee);
 
         if has_valid_allowances
             && self

--- a/rs/ledger_suite/icrc1/test_utils/src/lib.rs
+++ b/rs/ledger_suite/icrc1/test_utils/src/lib.rs
@@ -606,7 +606,7 @@ impl TransactionsAndBalances {
             && self
                 .balances
                 .get(&account)
-                .map_or(false, |&balance| balance >= default_fee)
+                .is_some_and(|&balance| balance >= default_fee)
         {
             // There is at least one valid allowance for this account, and the account has a
             // non-dust balance - make sure it exists in `valid_allowance_from`.

--- a/rs/ledger_suite/icrc1/test_utils/src/lib.rs
+++ b/rs/ledger_suite/icrc1/test_utils/src/lib.rs
@@ -1045,8 +1045,8 @@ pub fn valid_transactions_strategy(
                                 .boxed();
                         }
 
-                        // Select from valid amounts (1 to max_amount)
-                        (1..=max_amount)
+                        // Select from valid amounts (0 to max_amount)
+                        (0..=max_amount)
                             .prop_flat_map(move |amount| {
                                 let tx_hash_set = tx_hash_set_ptr2.clone();
                                 let account_to_basic_identity =

--- a/rs/ledger_suite/icrc1/test_utils/src/lib.rs
+++ b/rs/ledger_suite/icrc1/test_utils/src/lib.rs
@@ -1500,7 +1500,7 @@ mod tests {
 
     #[test]
     fn test_valid_transactions_strategy_respects_weights() {
-        let size = 500;
+        let size = 300;
         let minter_identity_arc = Arc::new(minter_identity());
         let strategy = valid_transactions_strategy(
             minter_identity_arc.clone(),

--- a/rs/ledger_suite/tests/sm-tests/src/in_memory_ledger.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/in_memory_ledger.rs
@@ -666,6 +666,22 @@ where
                     )
                 }
             }
+            LedgerEndpointArg::TransferFromArg(transfer_from_arg) => {
+                let owner = arg.caller.sender().unwrap();
+                let spender = AccountId::from(Account {
+                    owner,
+                    subaccount: transfer_from_arg.spender_subaccount,
+                });
+                let from = &AccountId::from(transfer_from_arg.from);
+                let to = &AccountId::from(transfer_from_arg.to);
+                self.process_transfer(
+                    from,
+                    to,
+                    &Some(spender),
+                    &Tokens::try_from(transfer_from_arg.amount.clone()).unwrap(),
+                    &fee,
+                )
+            }
         }
         self.validate_invariants();
     }

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -2448,7 +2448,6 @@ pub fn test_upgrade_serialization<Tokens>(
 
                 let mut add_tx_and_verify = || {
                     while tx_index < tx_index_target {
-                        apply_arg_with_caller(&env, ledger_id, &transactions[tx_index]);
                         in_memory_ledger.apply_arg_with_caller(
                             &transactions[tx_index],
                             TimeStamp::from_nanos_since_unix_epoch(system_time_to_nanos(
@@ -2457,6 +2456,7 @@ pub fn test_upgrade_serialization<Tokens>(
                             minter_principal,
                             Some(FEE.into()),
                         );
+                        apply_arg_with_caller(&env, ledger_id, &transactions[tx_index]);
                         tx_index += 1;
                     }
                     tx_index_target += ADDITIONAL_TX_BATCH_SIZE;

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -2406,10 +2406,13 @@ fn apply_arg_with_caller(
             send_transfer(env, ledger_id, arg.caller.sender().unwrap(), transfer_arg)
                 .expect("transfer failed")
         }
-        LedgerEndpointArg::TransferFromArg(transfer_from_arg) => {
-            send_transfer_from(env, ledger_id, arg.caller.sender().unwrap(), transfer_from_arg)
-                .expect("transfer_from failed")
-        }
+        LedgerEndpointArg::TransferFromArg(transfer_from_arg) => send_transfer_from(
+            env,
+            ledger_id,
+            arg.caller.sender().unwrap(),
+            transfer_from_arg,
+        )
+        .expect("transfer_from failed"),
     }
 }
 

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -2406,6 +2406,10 @@ fn apply_arg_with_caller(
             send_transfer(env, ledger_id, arg.caller.sender().unwrap(), transfer_arg)
                 .expect("transfer failed")
         }
+        LedgerEndpointArg::TransferFromArg(transfer_from_arg) => {
+            send_transfer_from(env, ledger_id, arg.caller.sender().unwrap(), transfer_from_arg)
+                .expect("transfer_from failed")
+        }
     }
 }
 

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -136,7 +136,7 @@ rust_test(
 )
 
 rust_test_suite_with_extra_srcs(
-    name = "rosetta-api-tests",
+    name = "rosetta-api-cli-tests",
     srcs = glob(["tests/rosetta_cli_tests.rs"]),
     aliases = ALIASES,
     data = glob([

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -137,7 +137,7 @@ rust_test(
 
 rust_test_suite_with_extra_srcs(
     name = "rosetta-api-tests",
-    srcs = glob(["tests/*.rs"]),
+    srcs = glob(["tests/rosetta_cli_tests.rs"]),
     aliases = ALIASES,
     data = glob([
         "tests/*.json",
@@ -151,6 +151,7 @@ rust_test_suite_with_extra_srcs(
     },
     extra_srcs = ["tests/test_utils/mod.rs"],
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    target_compatible_with = ["@platforms//os:linux"],  # rosetta-cli is not available on MacOS
     version = ROSETTA_VERSION,
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -137,7 +137,9 @@ rust_test(
 
 rust_test_suite_with_extra_srcs(
     name = "rosetta-api-cli-tests",
-    srcs = glob(["tests/rosetta_cli_tests.rs"]),
+    srcs = [
+        "tests/rosetta_cli_tests.rs",
+    ],
     aliases = ALIASES,
     data = glob([
         "tests/*.json",

--- a/rs/rosetta-api/icp/tests/system_tests/common/system_test_environment.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/common/system_test_environment.rs
@@ -75,13 +75,19 @@ impl RosettaTestingEnvironment {
                     approve_arg.spender.subaccount = None;
                     arg_with_caller.arg = LedgerEndpointArg::ApproveArg(approve_arg);
                 }
+                LedgerEndpointArg::TransferFromArg(mut transfer_from_arg) => {
+                    transfer_from_arg.spender_subaccount = None;
+                    transfer_from_arg.from.subaccount = None;
+                    transfer_from_arg.to.subaccount = None;
+                    arg_with_caller.arg = LedgerEndpointArg::TransferFromArg(transfer_from_arg);
+                }
             };
 
-            // Rosetta does not support mint, burn or approve operations
+            // Rosetta does not support mint, burn, approve, or transfer_from operations
             // To keep the balances in sync we need to call the ledger agent directly and then go to the next iteration of args with caller
             if !matches!(
                 icrc1_transaction.operation,
-                ic_icrc1::Operation::Transfer { .. }
+                ic_icrc1::Operation::Transfer { spender: None, .. }
             ) {
                 let caller_agent = Icrc1Agent {
                     agent: get_custom_agent(arg_with_caller.caller.clone(), replica_port).await,
@@ -98,6 +104,14 @@ impl RosettaTestingEnvironment {
                         .unwrap(),
                     LedgerEndpointArg::TransferArg(transfer_arg) => caller_agent
                         .transfer(transfer_arg.clone())
+                        .await
+                        .unwrap()
+                        .unwrap()
+                        .0
+                        .to_u64()
+                        .unwrap(),
+                    LedgerEndpointArg::TransferFromArg(transfer_from_arg) => caller_agent
+                        .transfer_from(transfer_from_arg.clone())
                         .await
                         .unwrap()
                         .unwrap()
@@ -398,6 +412,14 @@ impl RosettaTestingEnvironmentBuilder {
                         .unwrap(),
                     LedgerEndpointArg::TransferArg(transfer_arg) => caller_agent
                         .transfer(transfer_arg.clone())
+                        .await
+                        .unwrap()
+                        .unwrap()
+                        .0
+                        .to_u64()
+                        .unwrap(),
+                    LedgerEndpointArg::TransferFromArg(transfer_from_arg) => caller_agent
+                        .transfer_from(transfer_from_arg.clone())
                         .await
                         .unwrap()
                         .unwrap()

--- a/rs/rosetta-api/icp/tests/system_tests/test_cases/account_balances.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/test_cases/account_balances.rs
@@ -108,6 +108,17 @@ fn test_account_balances() {
                                 };
                                 (block_idx, from_account, transfer_arg.to)
                             }
+                            LedgerEndpointArg::TransferFromArg(transfer_from_arg) => {
+                                let block_idx = caller_agent
+                                    .transfer_from(transfer_from_arg.clone())
+                                    .await
+                                    .unwrap()
+                                    .unwrap()
+                                    .0
+                                    .to_u64()
+                                    .unwrap();
+                                (block_idx, transfer_from_arg.from, transfer_from_arg.to)
+                            }
                         };
 
                         // Store the current balance of the involved accounts and add them to the list of accounts if not already present

--- a/rs/rosetta-api/icrc1/src/construction_api/services.rs
+++ b/rs/rosetta-api/icrc1/src/construction_api/services.rs
@@ -550,6 +550,7 @@ mod tests {
                         let args = match arg_with_caller.arg {
                             LedgerEndpointArg::TransferArg(arg) => Encode!(&arg),
                             LedgerEndpointArg::ApproveArg(arg) => Encode!(&arg),
+                            LedgerEndpointArg::TransferFromArg(arg) => Encode!(&arg),
                         }
                         .unwrap();
 

--- a/rs/rosetta-api/icrc1/src/construction_api/utils.rs
+++ b/rs/rosetta-api/icrc1/src/construction_api/utils.rs
@@ -574,6 +574,10 @@ mod test {
                             LedgerEndpointArg::ApproveArg(args) => {
                                 (CanisterMethodName::Icrc2Approve, Encode!(&args).unwrap())
                             }
+                            LedgerEndpointArg::TransferFromArg(args) => (
+                                CanisterMethodName::Icrc2TransferFrom,
+                                Encode!(&args).unwrap(),
+                            ),
                         };
 
                         let icrc1_transaction = build_icrc1_transaction_from_canister_method_args(
@@ -640,6 +644,28 @@ mod test {
                                         assert_eq!(
                                             icrc1_transaction.created_at_time,
                                             args.created_at_time
+                                        );
+                                    }
+                                    _ => panic!("Operation type mismatch"),
+                                }
+                            }
+                            LedgerEndpointArg::TransferFromArg(args) => {
+                                match icrc1_transaction.operation {
+                                    crate::common::storage::types::IcrcOperation::Transfer {
+                                        to,
+                                        amount,
+                                        from,
+                                        fee,
+                                        ..
+                                    } => {
+                                        assert_eq!(to, args.to);
+                                        assert_eq!(args.amount, amount);
+                                        assert_eq!(from, args.from);
+                                        assert_eq!(fee, args.fee);
+                                        assert_eq!(args.memo, icrc1_transaction.memo);
+                                        assert_eq!(
+                                            args.created_at_time,
+                                            icrc1_transaction.created_at_time
                                         );
                                     }
                                     _ => panic!("Operation type mismatch"),

--- a/rs/rosetta-api/icrc1/tests/integration_test_components/storage/storing_blockchain_data_test.rs
+++ b/rs/rosetta-api/icrc1/tests/integration_test_components/storage/storing_blockchain_data_test.rs
@@ -115,6 +115,10 @@ proptest! {
                         let from_account = Account{owner:caller.clone().sender().unwrap(),subaccount: transfer_arg.from_subaccount};
                         (block_idx,from_account,transfer_arg.to)
                     }
+                    LedgerEndpointArg::TransferFromArg(transfer_from_arg) => {
+                        let block_idx = caller_agent.transfer_from(transfer_from_arg.clone()).await.unwrap().unwrap().0.to_u64().unwrap();
+                        (block_idx,transfer_from_arg.from,transfer_from_arg.to)
+                    }
                 };
 
                 // Store the current balance of the involved accounts and add them to the list of accounts if not already present

--- a/rs/rosetta-api/icrc1/tests/multitoken_system_tests.rs
+++ b/rs/rosetta-api/icrc1/tests/multitoken_system_tests.rs
@@ -2186,7 +2186,7 @@ fn test_cli_data() {
                         0,
                     )
                     .await;
-                    let output = process::Command::new(rosetta_cli())
+                    let output = std::process::Command::new(rosetta_cli())
                         .args([
                             "check:data",
                             "--configuration-file",

--- a/rs/rosetta-api/icrc1/tests/multitoken_system_tests.rs
+++ b/rs/rosetta-api/icrc1/tests/multitoken_system_tests.rs
@@ -35,6 +35,7 @@ use icrc_ledger_agent::Icrc1Agent;
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc1::transfer::TransferArg;
 use icrc_ledger_types::icrc2::approve::ApproveArgs;
+use icrc_ledger_types::icrc2::transfer_from::TransferFromArgs;
 use lazy_static::lazy_static;
 use num_traits::cast::ToPrimitive;
 use pocket_ic::{PocketIc, PocketIcBuilder};
@@ -56,7 +57,6 @@ use std::str::FromStr;
 use std::time::Instant;
 use std::{
     path::PathBuf,
-    process::Command,
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -90,24 +90,6 @@ fn rosetta_bin() -> PathBuf {
 
 fn rosetta_client_bin() -> PathBuf {
     path_from_env("ROSETTA_CLIENT_BIN_PATH")
-}
-
-fn rosetta_cli() -> String {
-    match std::env::var("ROSETTA_CLI").ok() {
-        Some(binary) => binary,
-        None => String::from("rosetta-cli"),
-    }
-}
-
-fn local(file: &str) -> String {
-    match std::env::var("CARGO_MANIFEST_DIR") {
-        Ok(path) => std::path::PathBuf::from(path)
-            .join(file)
-            .into_os_string()
-            .into_string()
-            .unwrap(),
-        Err(_) => String::from(file),
-    }
 }
 
 /// Represents an ICRC-1 ledger canister with its configuration and agent
@@ -443,6 +425,14 @@ async fn generate_block_indices(
                     .unwrap(),
                 LedgerEndpointArg::TransferArg(transfer_arg) => caller_agent
                     .transfer(transfer_arg.clone())
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .0
+                    .to_u64()
+                    .unwrap(),
+                LedgerEndpointArg::TransferFromArg(transfer_from_arg) => caller_agent
+                    .transfer_from(transfer_from_arg.clone())
                     .await
                     .unwrap()
                     .unwrap()
@@ -1398,6 +1388,29 @@ fn test_account_balance() {
                                     involved_accounts.push(*to);
                                 }
                             }
+                            LedgerEndpointArg::TransferFromArg(TransferFromArgs {
+                                from,
+                                to,
+                                amount,
+                                ..
+                            }) => {
+                                // For TransferFrom we always deduct the transfer fee. TransferFrom
+                                // from or to the minter account is not allowed, so we do not need
+                                // to check for it.
+                                accounts_balances.entry(*from).and_modify(|balance| {
+                                    *balance -= amount.0.to_u64().unwrap();
+                                    *balance -= DEFAULT_TRANSFER_FEE;
+                                });
+                                involved_accounts.push(*from);
+
+                                accounts_balances
+                                    .entry(*to)
+                                    .and_modify(|balance| {
+                                        *balance += amount.0.to_u64().unwrap();
+                                    })
+                                    .or_insert(amount.0.to_u64().unwrap());
+                                involved_accounts.push(*to);
+                            }
                         };
 
                         for account in involved_accounts {
@@ -2111,8 +2124,27 @@ fn test_search_transactions() {
         .unwrap()
 }
 
+#[cfg(not(target_os = "macos"))]
 #[test]
 fn test_cli_data() {
+    fn rosetta_cli() -> String {
+        match std::env::var("ROSETTA_CLI").ok() {
+            Some(binary) => binary,
+            None => String::from("rosetta-cli"),
+        }
+    }
+
+    fn local(file: &str) -> String {
+        match std::env::var("CARGO_MANIFEST_DIR") {
+            Ok(path) => std::path::PathBuf::from(path)
+                .join(file)
+                .into_os_string()
+                .into_string()
+                .unwrap(),
+            Err(_) => String::from(file),
+        }
+    }
+
     let mut runner = TestRunner::new(TestRunnerConfig {
         max_shrink_iters: 0,
         cases: *NUM_TEST_CASES,
@@ -2154,7 +2186,7 @@ fn test_cli_data() {
                         0,
                     )
                     .await;
-                    let output = Command::new(rosetta_cli())
+                    let output = process::Command::new(rosetta_cli())
                         .args([
                             "check:data",
                             "--configuration-file",


### PR DESCRIPTION
Currently, the `valid_transaction_strategy` proptest helper has generated `mint`, `burn`, `transfer`, and `approve` transactions. This PR proposes to enhance it to also generate `transfer_from` transactions.