### PR TITLE
chore: bump `ic-metrics-assert` to v0.1.1

### DIFF
--- a/packages/ic-metrics-assert/CHANGELOG.md
+++ b/packages/ic-metrics-assert/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-06-17
+
+### Changed
+
+- Expanded `README.md` with detailed crate description and feature overview.
+- Expanded `CHANGELOG.md` entry for v0.1.0.
+
 ## [0.1.0] - 2025-06-17
 
 ### Added

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-metrics-assert"
-version = "0.1.0"
+version = "0.1.1"
 description = "Fluent assertions for metrics"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
(XC-296) Bump `ic-metrics-assert` to v0.1.1 to publish updated `README.md` and `CHANGELOG.md`.