### PR TITLE
chore: [EXC-2066] Add a snapshot to upgrade/downgrade tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,6 +2718,7 @@ dependencies = [
  "ic-registry-subnet-type",
  "ic-system-test-driver",
  "ic-types",
+ "ic-utils 0.40.1",
  "ic_consensus_system_test_utils",
  "ic_consensus_threshold_sig_system_test_utils",
  "slog",

--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -51,6 +51,7 @@ system_test_nns(
         "//rs/types/types",
         "@crate_index//:anyhow",
         "@crate_index//:futures",
+        "@crate_index//:ic-utils",
         "@crate_index//:slog",
         "@crate_index//:tokio",
     ],

--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -20,6 +20,7 @@ rust_library(
         "@crate_index//:anyhow",
         "@crate_index//:candid",
         "@crate_index//:ic-agent",
+        "@crate_index//:ic-utils",
         "@crate_index//:slog",
     ],
 )
@@ -51,7 +52,6 @@ system_test_nns(
         "//rs/types/types",
         "@crate_index//:anyhow",
         "@crate_index//:futures",
-        "@crate_index//:ic-utils",
         "@crate_index//:slog",
         "@crate_index//:tokio",
     ],

--- a/rs/tests/consensus/upgrade/Cargo.toml
+++ b/rs/tests/consensus/upgrade/Cargo.toml
@@ -22,6 +22,7 @@ ic-registry-subnet-features = { path = "../../../registry/subnet_features" }
 ic-registry-subnet-type = { path = "../../../registry/subnet_type" }
 ic_consensus_system_test_utils = { path = "../utils" }
 ic_consensus_threshold_sig_system_test_utils = { path = "../tecdsa/utils" }
+ic-utils = { workspace = true }
 slog = { workspace = true }
 tokio = { workspace = true }
 

--- a/rs/tests/consensus/upgrade/common.rs
+++ b/rs/tests/consensus/upgrade/common.rs
@@ -25,11 +25,13 @@ use ic_consensus_system_test_utils::upgrade::{
 use ic_consensus_threshold_sig_system_test_utils::run_chain_key_signature_test;
 use ic_management_canister_types_private::MasterPublicKeyId;
 use ic_registry_subnet_type::SubnetType;
+use ic_system_test_driver::util::create_agent;
 use ic_system_test_driver::{
     driver::{test_env::TestEnv, test_env_api::*},
     util::{block_on, MessageCanister},
 };
 use ic_types::SubnetId;
+use ic_utils::interfaces::ManagementCanister;
 use slog::{info, Logger};
 use std::collections::BTreeMap;
 use std::time::Duration;
@@ -168,6 +170,15 @@ pub fn upgrade(
         msg
     ));
     info!(logger, "Could store and read message '{}'", msg);
+
+    // Create canister snapshot before upgrading.
+    block_on(async {
+        let agent = create_agent(subnet_node.get_public_url().as_str())
+            .await
+            .expect("Failed to create agent");
+        let mgr = ManagementCanister::create(&agent);
+        mgr.take_canister_snapshot(&can_id, None).await.unwrap();
+    });
 
     stop_node(&logger, &faulty_node);
 

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
@@ -32,7 +32,6 @@ use ic_system_test_driver::generic_workload_engine::metrics::{
 use ic_system_test_driver::systest;
 use ic_system_test_driver::util::{block_on, get_app_subnet_and_node, MessageCanister};
 use ic_types::Height;
-use ic_utils::interfaces::ManagementCanister;
 
 const SCHNORR_MSG_SIZE_BYTES: usize = 32;
 const DKG_INTERVAL: u64 = 9;
@@ -112,13 +111,6 @@ fn upgrade_downgrade_app_subnet(env: TestEnv) {
 
     rt.spawn(start_workload(app_subnet, requests, logger));
 
-    // create a snapshot of a canister in the base version
-    // (tests backwards compatibility of snapshot format)
-    rt.block_on(async {
-        let mgr = ManagementCanister::create(&app_agent);
-        mgr.take_canister_snapshot(&can_id, None).await.unwrap()
-    });
-
     let (faulty_node, can_id, msg) = upgrade(
         &env,
         &nns_node,
@@ -126,13 +118,6 @@ fn upgrade_downgrade_app_subnet(env: TestEnv) {
         SubnetType::Application,
         None,
     );
-
-    // create a snapshot of a canister in the future version
-    // (tests forwards compatibility of snapshot format)
-    rt.block_on(async {
-        let mgr = ManagementCanister::create(&app_agent);
-        mgr.take_canister_snapshot(&can_id, None).await.unwrap()
-    });
 
     let mainnet_version = get_mainnet_nns_revision();
     upgrade(

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
@@ -112,6 +112,13 @@ fn upgrade_downgrade_app_subnet(env: TestEnv) {
 
     rt.spawn(start_workload(app_subnet, requests, logger));
 
+    // create a snapshot of a canister in the base version
+    // (tests backwards compatibility of snapshot format)
+    rt.block_on(async {
+        let mgr = ManagementCanister::create(&app_agent);
+        mgr.take_canister_snapshot(&can_id, None).await.unwrap()
+    });
+
     let (faulty_node, can_id, msg) = upgrade(
         &env,
         &nns_node,
@@ -119,7 +126,9 @@ fn upgrade_downgrade_app_subnet(env: TestEnv) {
         SubnetType::Application,
         None,
     );
-    // create a snapshot of a canister
+
+    // create a snapshot of a canister in the future version
+    // (tests forwards compatibility of snapshot format)
     rt.block_on(async {
         let mgr = ManagementCanister::create(&app_agent);
         mgr.take_canister_snapshot(&can_id, None).await.unwrap()

--- a/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
@@ -118,7 +118,6 @@ fn upgrade_downgrade_app_subnet(env: TestEnv) {
         SubnetType::Application,
         None,
     );
-
     let mainnet_version = get_mainnet_nns_revision();
     upgrade(
         &env,


### PR DESCRIPTION
Downgrading a replica must always work. Prior to this PR, the downgrade test did not contain any canister snapshot, so any forwards-incompatibility in the snapshot format would not be detected. This PR fixes that gap. 