### PR TITLE
chore(ICRC_Ledger): FI-1770: Remove unused ic-cdk dependency from icrc-ledger-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15080,7 +15080,6 @@ dependencies = [
  "candid",
  "crc32fast",
  "hex",
- "ic-cdk 0.17.2",
  "ic-stable-structures",
  "icrc-cbor",
  "itertools 0.12.1",

--- a/packages/icrc-ledger-types/BUILD.bazel
+++ b/packages/icrc-ledger-types/BUILD.bazel
@@ -22,7 +22,6 @@ rust_library(
         "@crate_index//:candid",
         "@crate_index//:crc32fast",
         "@crate_index//:hex",
-        "@crate_index//:ic-cdk",
         "@crate_index//:ic-stable-structures",
         "@crate_index//:itertools",
         "@crate_index//:minicbor",

--- a/packages/icrc-ledger-types/Cargo.toml
+++ b/packages/icrc-ledger-types/Cargo.toml
@@ -15,7 +15,6 @@ base32 = "0.4.0"
 candid = { workspace = true }
 crc32fast = "1.2.0"
 hex = { workspace = true }
-ic-cdk = { workspace = true }
 ic-stable-structures = { workspace = true }
 icrc-cbor = { path = "../icrc-cbor", version = "0.1.0" }
 itertools = { workspace = true }


### PR DESCRIPTION
Remove unused `ic-cdk` dependency from `icrc-ledger-types`.