### PR TITLE
fix: remove /tmp mount in container-run.sh to prevent shadowing

### DIFF
--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -121,7 +121,6 @@ PODMAN_RUN_ARGS+=(
     --mount type=bind,source="${HOME}/.ssh",target="${CTR_HOME}/.ssh"
     --mount type=bind,source="${HOME}/.aws",target="${CTR_HOME}/.aws"
     --mount type=bind,source="/var/lib/containers",target="/var/lib/containers"
-    --mount type=bind,source="/tmp",target="/tmp"
     --mount type=tmpfs,destination=/var/sysimage
 )
 


### PR DESCRIPTION
`ci/container/container-run.sh` called `podman` with the following bind mounts:
* `--mount type=bind,source="${ZIG_CACHE}",target="/tmp/zig-cache"` where `${ZIG_CACHE} = ~/.cache/zig-cache`
* `--mount type=bind,source="/tmp",target="/tmp"`

This causes an issue on `zh1-spm{22,34}` which is exemplified by the following: 

```
# Let's make sure  /tmp/zig-cache/ doesn't exist on the host: 
bas@zh1-spm22:~/d/ic/ic$ sudo rm -rf /tmp/zig-cache/

# Let's enter the container. 
# My initial assumption was that ~/.cache/zig-cache on the host would get mounted to /tmp/zig-cache in the container
# and that /tmp/zig-cache wouldn't get created on the host: 
bas@zh1-spm22:~/d/ic/ic$ ci/container/container-run.sh echo
+ exec sudo podman run --pids-limit=-1 -i -t --log-driver=none --rm --privileged --network=host --cgroupns=host -w /ic -u 1017:1017 -e HOSTUSER=bas -e VERSION=ac7ff452684f84ea0cfc3fd0a27228220a368b33 --hostname=devenv-container --add-host devenv-container:127.0.0.1 --entrypoint= --init --pull=missing --mount type=bind,source=/home/bas/d/ic/ic,target=/ic --mount type=bind,source=/home/bas/.cache,target=/ic/.cache --mount type=bind,source=/home/bas/.cache/zig-cache,target=/tmp/zig-cache --mount type=bind,source=/home/bas/.ssh,target=/ic/.ssh --mount type=bind,source=/home/bas/.aws,target=/ic/.aws --mount type=bind,source=/var/lib/containers,target=/var/lib/containers --mount type=bind,source=/tmp,target=/tmp --mount type=tmpfs,destination=/var/sysimage -v /tmp/ssh-2A6d8KWqZu/agent.3687891:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent -w /ic ghcr.io/dfinity/ic-build:e92ea104fcd4e5c24a1ac90cfcf270a9bb55a35b0c681e179ac2deebb4f9db3f echo

# However it seems it does get created!
bas@zh1-spm22:~/d/ic/ic$ ls -la /tmp/zig-cache/
total 3924
drwxr-xr-t   2 root root    4096 Jun 17 16:23 .
drwxrwxrwt 465 root root 4005888 Jun 17 16:23 ..
```

This behaviour in turn causes an AccessDenied error in the hermetic CC toolchain.

**Why is it ok to remove the /tmp bind mount?** The dev container on devenvs is already using `/hoststorage` as its root so `/tmp` in the container should already be fast. 