### PR TITLE
test: Re-enable Consensus hourly tests

### DIFF
--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -88,7 +88,6 @@ system_test_nns(
     tags = [
         "experimental_system_test_colocation",
         "k8s",
-        "manual",  # the test is not reliable
         "subnet_recovery",
         "system_test_hourly",
     ],

--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -60,7 +60,6 @@ system_test_nns(
     name = "upgrade_downgrade_nns_subnet_test",
     env = MAINNET_ENV,
     tags = [
-        "manual",  # the test is not reliable
         "system_test_hourly",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS


### PR DESCRIPTION
These tests were temporarily disabled because of DNS resolution issues when attempting to download the upgrade images in the testing environment. It seems that this was fixed by updating related DNS records.

I [ran](https://github.com/dfinity/ic/actions/runs/15711630457) the hourly tests three times and they succeeded always.