### PR TITLE
chore(icrc-ledger-types): create a new version for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15146,7 +15146,7 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-types"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "assert_matches",
  "base32",

--- a/packages/icrc-ledger-types/CHANGELOG.md
+++ b/packages/icrc-ledger-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.1.10
+
+### Changed
+
+- Remove unneeded dependency on `ic-cdk`.
+
 ## 0.1.9
 
 ### Added

--- a/packages/icrc-ledger-types/Cargo.toml
+++ b/packages/icrc-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc-ledger-types"
-version = "0.1.9"
+version = "0.1.10"
 description = "Types for interacting with DFINITY's implementation of the ICRC-1 fungible token standard."
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
The version includes the change to remove the unneeded dependency to `ic-cdk`.