### PR TITLE
chore: Clarify some checkpointing log messages

### DIFF
--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -2377,7 +2377,10 @@ impl StateManagerImpl {
         };
 
         let elapsed = start.elapsed();
-        info!(self.log, "Created checkpoint @{} in {:?}", height, elapsed);
+        info!(
+            self.log,
+            "Created unverified checkpoint @{} in {:?}", height, elapsed
+        );
         self.metrics
             .checkpoint_op_duration
             .with_label_values(&["create"])

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -423,6 +423,7 @@ pub(crate) fn spawn_tip_thread(
                             fd_factory,
                         } => {
                             let _timer = request_timer(&metrics, "validate_replicated_state");
+                            let start = Instant::now();
                             debug_assert_eq!(
                                 tip_state.latest_checkpoint_state.page_maps_height,
                                 checkpoint_layout.height()
@@ -450,6 +451,12 @@ pub(crate) fn spawn_tip_thread(
                                     err
                                 )
                             }
+                            info!(
+                                log,
+                                "Validated checkpoint @{} in {:?}",
+                                checkpoint_layout.height(),
+                                start.elapsed()
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
This PR changes some log messages to better reflect that we first create an unverified checkpoint.