### PR TITLE
feat: Support SEV config and direct boot in the VM runner

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "0ea617267a44bc8220ba6aef3d38b42a4517fbc372abbf0af7912239943e328a",
+  "checksum": "90804ed271ce9f4cc1bd31f0568f42f552a73bc5e50556cd6778cbea255d1883",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -16388,6 +16388,93 @@
       ],
       "license_file": null
     },
+    "crc 3.3.0": {
+      "name": "crc",
+      "version": "3.3.0",
+      "package_url": "https://github.com/mrhooray/crc-rs.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crc/3.3.0/download",
+          "sha256": "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "crc-catalog 2.4.0",
+              "target": "crc_catalog"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "3.3.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "crc-catalog 2.4.0": {
+      "name": "crc-catalog",
+      "version": "2.4.0",
+      "package_url": "https://github.com/akhilles/crc-catalog.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crc-catalog/2.4.0/download",
+          "sha256": "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc_catalog",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crc_catalog",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "2.4.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSES"
+    },
     "crc32fast 1.3.2": {
       "name": "crc32fast",
       "version": "1.3.2",
@@ -20473,6 +20560,10 @@
               "target": "goldenfile"
             },
             {
+              "id": "gpt 4.1.0",
+              "target": "gpt"
+            },
+            {
               "id": "group 0.13.0",
               "target": "group"
             },
@@ -21218,6 +21309,10 @@
               "id": "syn 2.0.101",
               "target": "syn",
               "alias": "syn2"
+            },
+            {
+              "id": "sys-mount 3.0.1",
+              "target": "sys_mount"
             },
             {
               "id": "syscalls 0.6.18",
@@ -23972,6 +24067,7 @@
         ],
         "crate_features": {
           "common": [
+            "default",
             "std"
           ],
           "selects": {}
@@ -28672,6 +28768,65 @@
         "MIT"
       ],
       "license_file": null
+    },
+    "gpt 4.1.0": {
+      "name": "gpt",
+      "version": "4.1.0",
+      "package_url": "https://github.com/Quyzi/gpt",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/gpt/4.1.0/download",
+          "sha256": "3696fafb1ecdcc2ae3ce337de73e9202806068594b77d22fdf2f3573c5ec2219"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "gpt",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "gpt",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "crc 3.3.0",
+              "target": "crc"
+            },
+            {
+              "id": "simple-bytes 0.2.14",
+              "target": "simple_bytes"
+            },
+            {
+              "id": "uuid 1.12.1",
+              "target": "uuid"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "4.1.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "group 0.12.1": {
       "name": "group",
@@ -44081,6 +44236,93 @@
         "MIT"
       ],
       "license_file": null
+    },
+    "loopdev-3 0.5.1": {
+      "name": "loopdev-3",
+      "version": "0.5.1",
+      "package_url": "https://github.com/stratis-storage/loopdev-3",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/loopdev-3/0.5.1/download",
+          "sha256": "90a97d7a5124296ee9124a815acdc3dc4a91f577b72812b3f1f99bb959b46e8d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "loopdev",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "loopdev",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "errno 0.3.10",
+              "target": "errno"
+            },
+            {
+              "id": "libc 0.2.172",
+              "target": "libc"
+            },
+            {
+              "id": "loopdev-3 0.5.1",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.5.1"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bindgen 0.69.4",
+              "target": "bindgen"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "lru 0.7.8": {
       "name": "lru",
@@ -70565,6 +70807,45 @@
       ],
       "license_file": "LICENSE"
     },
+    "simple-bytes 0.2.14": {
+      "name": "simple-bytes",
+      "version": "0.2.14",
+      "package_url": "https://github.com/soerenmeier/simple-bytes",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/simple-bytes/0.2.14/download",
+          "sha256": "c11532d9d241904f095185f35dcdaf930b1427a94d5b01d7002d74ba19b44cc4"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "simple_bytes",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "simple_bytes",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.2.14"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "simple_asn1 0.6.2": {
       "name": "simple_asn1",
       "version": "0.6.2",
@@ -71601,6 +71882,61 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "smart-default 0.7.1": {
+      "name": "smart-default",
+      "version": "0.7.1",
+      "package_url": "https://github.com/idanarye/rust-smart-default",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/smart-default/0.7.1/download",
+          "sha256": "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "smart_default",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "smart_default",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.95",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.40",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.101",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.7.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "snafu 0.7.5": {
       "name": "snafu",
@@ -74078,6 +74414,87 @@
       },
       "license": "MIT",
       "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "sys-mount 3.0.1": {
+      "name": "sys-mount",
+      "version": "3.0.1",
+      "package_url": "https://github.com/pop-os/sys-mount",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/sys-mount/3.0.1/download",
+          "sha256": "a6acb8bb63826062d5a44b68298cf2e25b84bc151bc0c31c35a83b61f818682a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "sys_mount",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "sys_mount",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "loop",
+            "loopdev"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "libc 0.2.172",
+              "target": "libc"
+            },
+            {
+              "id": "loopdev-3 0.5.1",
+              "target": "loopdev"
+            },
+            {
+              "id": "thiserror 1.0.68",
+              "target": "thiserror"
+            },
+            {
+              "id": "tracing 0.1.41",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "smart-default 0.7.1",
+              "target": "smart_default"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "3.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE"
@@ -92651,6 +93068,7 @@
     "get_if_addrs 0.5.3",
     "getrandom 0.2.10",
     "goldenfile 1.8.0",
+    "gpt 4.1.0",
     "group 0.13.0",
     "hashlink 0.8.4",
     "hex 0.4.3",
@@ -92844,6 +93262,7 @@
     "subtle 2.6.1",
     "syn 1.0.109",
     "syn 2.0.101",
+    "sys-mount 3.0.1",
     "syscalls 0.6.18",
     "systemd 0.10.0",
     "tar 0.4.39",

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d38992385177cb9a58950ed78e8c16f599d761f4d92aeaf010a99206a468b789",
+  "checksum": "a3bebc49b6a75ff6e741a164589790fdf50be734647c02af65534824e99a1e86",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3841f6966cf5c5fcaeeb0a85cb7e9b7bd9fee5b078e19ac41171f6288de10214",
+  "checksum": "d38992385177cb9a58950ed78e8c16f599d761f4d92aeaf010a99206a468b789",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -16388,6 +16388,93 @@
       ],
       "license_file": null
     },
+    "crc 3.3.0": {
+      "name": "crc",
+      "version": "3.3.0",
+      "package_url": "https://github.com/mrhooray/crc-rs.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crc/3.3.0/download",
+          "sha256": "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "crc-catalog 2.4.0",
+              "target": "crc_catalog"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "3.3.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "crc-catalog 2.4.0": {
+      "name": "crc-catalog",
+      "version": "2.4.0",
+      "package_url": "https://github.com/akhilles/crc-catalog.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crc-catalog/2.4.0/download",
+          "sha256": "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc_catalog",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crc_catalog",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "2.4.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSES"
+    },
     "crc32fast 1.3.2": {
       "name": "crc32fast",
       "version": "1.3.2",
@@ -20473,6 +20560,10 @@
               "target": "goldenfile"
             },
             {
+              "id": "gpt 4.1.0",
+              "target": "gpt"
+            },
+            {
               "id": "group 0.13.0",
               "target": "group"
             },
@@ -21218,6 +21309,10 @@
               "id": "syn 2.0.101",
               "target": "syn",
               "alias": "syn2"
+            },
+            {
+              "id": "sys-mount 3.0.1",
+              "target": "sys_mount"
             },
             {
               "id": "syscalls 0.6.18",
@@ -23972,6 +24067,7 @@
         ],
         "crate_features": {
           "common": [
+            "default",
             "std"
           ],
           "selects": {}
@@ -28672,6 +28768,65 @@
         "MIT"
       ],
       "license_file": null
+    },
+    "gpt 4.1.0": {
+      "name": "gpt",
+      "version": "4.1.0",
+      "package_url": "https://github.com/Quyzi/gpt",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/gpt/4.1.0/download",
+          "sha256": "3696fafb1ecdcc2ae3ce337de73e9202806068594b77d22fdf2f3573c5ec2219"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "gpt",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "gpt",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "crc 3.3.0",
+              "target": "crc"
+            },
+            {
+              "id": "simple-bytes 0.2.14",
+              "target": "simple_bytes"
+            },
+            {
+              "id": "uuid 1.12.1",
+              "target": "uuid"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "4.1.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "group 0.12.1": {
       "name": "group",
@@ -44081,6 +44236,93 @@
         "MIT"
       ],
       "license_file": null
+    },
+    "loopdev-3 0.5.1": {
+      "name": "loopdev-3",
+      "version": "0.5.1",
+      "package_url": "https://github.com/stratis-storage/loopdev-3",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/loopdev-3/0.5.1/download",
+          "sha256": "90a97d7a5124296ee9124a815acdc3dc4a91f577b72812b3f1f99bb959b46e8d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "loopdev",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "loopdev",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "errno 0.3.10",
+              "target": "errno"
+            },
+            {
+              "id": "libc 0.2.172",
+              "target": "libc"
+            },
+            {
+              "id": "loopdev-3 0.5.1",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.5.1"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bindgen 0.69.4",
+              "target": "bindgen"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "lru 0.7.8": {
       "name": "lru",
@@ -70564,6 +70806,45 @@
       ],
       "license_file": "LICENSE"
     },
+    "simple-bytes 0.2.14": {
+      "name": "simple-bytes",
+      "version": "0.2.14",
+      "package_url": "https://github.com/soerenmeier/simple-bytes",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/simple-bytes/0.2.14/download",
+          "sha256": "c11532d9d241904f095185f35dcdaf930b1427a94d5b01d7002d74ba19b44cc4"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "simple_bytes",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "simple_bytes",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.2.14"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "simple_asn1 0.6.2": {
       "name": "simple_asn1",
       "version": "0.6.2",
@@ -71600,6 +71881,61 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "smart-default 0.7.1": {
+      "name": "smart-default",
+      "version": "0.7.1",
+      "package_url": "https://github.com/idanarye/rust-smart-default",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/smart-default/0.7.1/download",
+          "sha256": "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "smart_default",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "smart_default",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.95",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.40",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.101",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.7.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "snafu 0.7.5": {
       "name": "snafu",
@@ -74077,6 +74413,87 @@
       },
       "license": "MIT",
       "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "sys-mount 3.0.1": {
+      "name": "sys-mount",
+      "version": "3.0.1",
+      "package_url": "https://github.com/pop-os/sys-mount",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/sys-mount/3.0.1/download",
+          "sha256": "a6acb8bb63826062d5a44b68298cf2e25b84bc151bc0c31c35a83b61f818682a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "sys_mount",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "sys_mount",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "loop",
+            "loopdev"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "libc 0.2.172",
+              "target": "libc"
+            },
+            {
+              "id": "loopdev-3 0.5.1",
+              "target": "loopdev"
+            },
+            {
+              "id": "thiserror 1.0.68",
+              "target": "thiserror"
+            },
+            {
+              "id": "tracing 0.1.41",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "smart-default 0.7.1",
+              "target": "smart_default"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "3.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE"
@@ -92623,6 +93040,7 @@
     "get_if_addrs 0.5.3",
     "getrandom 0.2.10",
     "goldenfile 1.8.0",
+    "gpt 4.1.0",
     "group 0.13.0",
     "hashlink 0.8.4",
     "hex 0.4.3",
@@ -92816,6 +93234,7 @@
     "subtle 2.6.1",
     "syn 1.0.109",
     "syn 2.0.101",
+    "sys-mount 3.0.1",
     "syscalls 0.6.18",
     "systemd 0.10.0",
     "tar 0.4.39",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -2760,6 +2760,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85256fac1519a7d25a040c1d850fba67478f3f021ad5fdf738ba4425ee862dbf"
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,6 +3511,7 @@ dependencies = [
  "get_if_addrs",
  "getrandom 0.2.10",
  "goldenfile",
+ "gpt",
  "group 0.13.0",
  "hashlink",
  "hex",
@@ -3689,6 +3705,7 @@ dependencies = [
  "subtle",
  "syn 1.0.109",
  "syn 2.0.101",
+ "sys-mount",
  "syscalls",
  "systemd",
  "tar",
@@ -4913,6 +4930,18 @@ dependencies = [
  "smallvec",
  "spinning_top",
  "web-time",
+]
+
+[[package]]
+name = "gpt"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3696fafb1ecdcc2ae3ce337de73e9202806068594b77d22fdf2f3573c5ec2219"
+dependencies = [
+ "bitflags 2.9.0",
+ "crc",
+ "simple-bytes",
+ "uuid",
 ]
 
 [[package]]
@@ -7598,6 +7627,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
 dependencies = [
  "logos-codegen",
+]
+
+[[package]]
+name = "loopdev-3"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a97d7a5124296ee9124a815acdc3dc4a91f577b72812b3f1f99bb959b46e8d"
+dependencies = [
+ "bindgen 0.69.4",
+ "errno 0.3.10",
+ "libc",
 ]
 
 [[package]]
@@ -11852,6 +11892,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-bytes"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11532d9d241904f095185f35dcdaf930b1427a94d5b01d7002d74ba19b44cc4"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12010,6 +12056,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12417,6 +12474,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "sys-mount"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6acb8bb63826062d5a44b68298cf2e25b84bc151bc0c31c35a83b61f818682a"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "loopdev-3",
+ "smart-default",
+ "thiserror 1.0.68",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5e6446d7191f132a8a03f7eaa7686c487aa0bf067d0c82cc1f69d0f93e61dccd",
+  "checksum": "4ed7397b9cbe4318405d88e7609ca88c24c41771f72edd278e535ec25f3547e1",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -16206,6 +16206,93 @@
       ],
       "license_file": null
     },
+    "crc 3.3.0": {
+      "name": "crc",
+      "version": "3.3.0",
+      "package_url": "https://github.com/mrhooray/crc-rs.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crc/3.3.0/download",
+          "sha256": "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "crc-catalog 2.4.0",
+              "target": "crc_catalog"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "3.3.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "crc-catalog 2.4.0": {
+      "name": "crc-catalog",
+      "version": "2.4.0",
+      "package_url": "https://github.com/akhilles/crc-catalog.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crc-catalog/2.4.0/download",
+          "sha256": "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc_catalog",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crc_catalog",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "2.4.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSES"
+    },
     "crc32fast 1.3.2": {
       "name": "crc32fast",
       "version": "1.3.2",
@@ -20291,6 +20378,10 @@
               "target": "goldenfile"
             },
             {
+              "id": "gpt 4.1.0",
+              "target": "gpt"
+            },
+            {
               "id": "group 0.13.0",
               "target": "group"
             },
@@ -21036,6 +21127,10 @@
               "id": "syn 2.0.101",
               "target": "syn",
               "alias": "syn2"
+            },
+            {
+              "id": "sys-mount 3.0.1",
+              "target": "sys_mount"
             },
             {
               "id": "syscalls 0.6.18",
@@ -23817,6 +23912,7 @@
         ],
         "crate_features": {
           "common": [
+            "default",
             "std"
           ],
           "selects": {}
@@ -28516,6 +28612,65 @@
         "MIT"
       ],
       "license_file": null
+    },
+    "gpt 4.1.0": {
+      "name": "gpt",
+      "version": "4.1.0",
+      "package_url": "https://github.com/Quyzi/gpt",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/gpt/4.1.0/download",
+          "sha256": "3696fafb1ecdcc2ae3ce337de73e9202806068594b77d22fdf2f3573c5ec2219"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "gpt",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "gpt",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "crc 3.3.0",
+              "target": "crc"
+            },
+            {
+              "id": "simple-bytes 0.2.14",
+              "target": "simple_bytes"
+            },
+            {
+              "id": "uuid 1.12.1",
+              "target": "uuid"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "4.1.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "group 0.12.1": {
       "name": "group",
@@ -43913,6 +44068,93 @@
         "MIT"
       ],
       "license_file": null
+    },
+    "loopdev-3 0.5.1": {
+      "name": "loopdev-3",
+      "version": "0.5.1",
+      "package_url": "https://github.com/stratis-storage/loopdev-3",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/loopdev-3/0.5.1/download",
+          "sha256": "90a97d7a5124296ee9124a815acdc3dc4a91f577b72812b3f1f99bb959b46e8d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "loopdev",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "loopdev",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "errno 0.3.10",
+              "target": "errno"
+            },
+            {
+              "id": "libc 0.2.172",
+              "target": "libc"
+            },
+            {
+              "id": "loopdev-3 0.5.1",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.5.1"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bindgen 0.69.4",
+              "target": "bindgen"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "lru 0.7.8": {
       "name": "lru",
@@ -70435,6 +70677,45 @@
       ],
       "license_file": "LICENSE"
     },
+    "simple-bytes 0.2.14": {
+      "name": "simple-bytes",
+      "version": "0.2.14",
+      "package_url": "https://github.com/soerenmeier/simple-bytes",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/simple-bytes/0.2.14/download",
+          "sha256": "c11532d9d241904f095185f35dcdaf930b1427a94d5b01d7002d74ba19b44cc4"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "simple_bytes",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "simple_bytes",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.2.14"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "simple_asn1 0.6.2": {
       "name": "simple_asn1",
       "version": "0.6.2",
@@ -71471,6 +71752,61 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "smart-default 0.7.1": {
+      "name": "smart-default",
+      "version": "0.7.1",
+      "package_url": "https://github.com/idanarye/rust-smart-default",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/smart-default/0.7.1/download",
+          "sha256": "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "smart_default",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "smart_default",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.95",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.40",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.101",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.7.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "snafu 0.7.5": {
       "name": "snafu",
@@ -73948,6 +74284,87 @@
       },
       "license": "MIT",
       "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "sys-mount 3.0.1": {
+      "name": "sys-mount",
+      "version": "3.0.1",
+      "package_url": "https://github.com/pop-os/sys-mount",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/sys-mount/3.0.1/download",
+          "sha256": "a6acb8bb63826062d5a44b68298cf2e25b84bc151bc0c31c35a83b61f818682a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "sys_mount",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "sys_mount",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "loop",
+            "loopdev"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "libc 0.2.172",
+              "target": "libc"
+            },
+            {
+              "id": "loopdev-3 0.5.1",
+              "target": "loopdev"
+            },
+            {
+              "id": "thiserror 1.0.68",
+              "target": "thiserror"
+            },
+            {
+              "id": "tracing 0.1.41",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "smart-default 0.7.1",
+              "target": "smart_default"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "3.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE"
@@ -92616,6 +93033,7 @@
     "get_if_addrs 0.5.3",
     "getrandom 0.2.10",
     "goldenfile 1.8.0",
+    "gpt 4.1.0",
     "group 0.13.0",
     "hashlink 0.8.3",
     "hex 0.4.3",
@@ -92809,6 +93227,7 @@
     "subtle 2.6.1",
     "syn 1.0.109",
     "syn 2.0.101",
+    "sys-mount 3.0.1",
     "syscalls 0.6.18",
     "systemd 0.10.0",
     "tar 0.4.39",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "05d485921c31888d77218f9167a7b2740c9d733ae271a9db5c20c29fdc9a5672",
+  "checksum": "085e3150b8aa905802c0f795bb7bfc8dfa7c9528b1d2a9f28061c24200c39c0b",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -16206,6 +16206,93 @@
       ],
       "license_file": null
     },
+    "crc 3.3.0": {
+      "name": "crc",
+      "version": "3.3.0",
+      "package_url": "https://github.com/mrhooray/crc-rs.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crc/3.3.0/download",
+          "sha256": "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "crc-catalog 2.4.0",
+              "target": "crc_catalog"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "3.3.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "crc-catalog 2.4.0": {
+      "name": "crc-catalog",
+      "version": "2.4.0",
+      "package_url": "https://github.com/akhilles/crc-catalog.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/crc-catalog/2.4.0/download",
+          "sha256": "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "crc_catalog",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "crc_catalog",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "2.4.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSES"
+    },
     "crc32fast 1.3.2": {
       "name": "crc32fast",
       "version": "1.3.2",
@@ -20291,6 +20378,10 @@
               "target": "goldenfile"
             },
             {
+              "id": "gpt 4.1.0",
+              "target": "gpt"
+            },
+            {
               "id": "group 0.13.0",
               "target": "group"
             },
@@ -21036,6 +21127,10 @@
               "id": "syn 2.0.101",
               "target": "syn",
               "alias": "syn2"
+            },
+            {
+              "id": "sys-mount 3.0.1",
+              "target": "sys_mount"
             },
             {
               "id": "syscalls 0.6.18",
@@ -23817,6 +23912,7 @@
         ],
         "crate_features": {
           "common": [
+            "default",
             "std"
           ],
           "selects": {}
@@ -28516,6 +28612,65 @@
         "MIT"
       ],
       "license_file": null
+    },
+    "gpt 4.1.0": {
+      "name": "gpt",
+      "version": "4.1.0",
+      "package_url": "https://github.com/Quyzi/gpt",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/gpt/4.1.0/download",
+          "sha256": "3696fafb1ecdcc2ae3ce337de73e9202806068594b77d22fdf2f3573c5ec2219"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "gpt",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "gpt",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "crc 3.3.0",
+              "target": "crc"
+            },
+            {
+              "id": "simple-bytes 0.2.14",
+              "target": "simple_bytes"
+            },
+            {
+              "id": "uuid 1.12.1",
+              "target": "uuid"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "4.1.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "group 0.12.1": {
       "name": "group",
@@ -43913,6 +44068,93 @@
         "MIT"
       ],
       "license_file": null
+    },
+    "loopdev-3 0.5.1": {
+      "name": "loopdev-3",
+      "version": "0.5.1",
+      "package_url": "https://github.com/stratis-storage/loopdev-3",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/loopdev-3/0.5.1/download",
+          "sha256": "90a97d7a5124296ee9124a815acdc3dc4a91f577b72812b3f1f99bb959b46e8d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "loopdev",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "loopdev",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "errno 0.3.10",
+              "target": "errno"
+            },
+            {
+              "id": "libc 0.2.172",
+              "target": "libc"
+            },
+            {
+              "id": "loopdev-3 0.5.1",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.5.1"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "bindgen 0.69.4",
+              "target": "bindgen"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "lru 0.7.8": {
       "name": "lru",
@@ -70434,6 +70676,45 @@
       ],
       "license_file": "LICENSE"
     },
+    "simple-bytes 0.2.14": {
+      "name": "simple-bytes",
+      "version": "0.2.14",
+      "package_url": "https://github.com/soerenmeier/simple-bytes",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/simple-bytes/0.2.14/download",
+          "sha256": "c11532d9d241904f095185f35dcdaf930b1427a94d5b01d7002d74ba19b44cc4"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "simple_bytes",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "simple_bytes",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.2.14"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "simple_asn1 0.6.2": {
       "name": "simple_asn1",
       "version": "0.6.2",
@@ -71470,6 +71751,61 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "smart-default 0.7.1": {
+      "name": "smart-default",
+      "version": "0.7.1",
+      "package_url": "https://github.com/idanarye/rust-smart-default",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/smart-default/0.7.1/download",
+          "sha256": "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "smart_default",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "smart_default",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.95",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.40",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.101",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.7.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "snafu 0.7.5": {
       "name": "snafu",
@@ -73947,6 +74283,87 @@
       },
       "license": "MIT",
       "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "sys-mount 3.0.1": {
+      "name": "sys-mount",
+      "version": "3.0.1",
+      "package_url": "https://github.com/pop-os/sys-mount",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/sys-mount/3.0.1/download",
+          "sha256": "a6acb8bb63826062d5a44b68298cf2e25b84bc151bc0c31c35a83b61f818682a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "sys_mount",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "sys_mount",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "loop",
+            "loopdev"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "libc 0.2.172",
+              "target": "libc"
+            },
+            {
+              "id": "loopdev-3 0.5.1",
+              "target": "loopdev"
+            },
+            {
+              "id": "thiserror 1.0.68",
+              "target": "thiserror"
+            },
+            {
+              "id": "tracing 0.1.41",
+              "target": "tracing"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "smart-default 0.7.1",
+              "target": "smart_default"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "3.0.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
         "MIT"
       ],
       "license_file": "LICENSE"
@@ -92588,6 +93005,7 @@
     "get_if_addrs 0.5.3",
     "getrandom 0.2.10",
     "goldenfile 1.8.0",
+    "gpt 4.1.0",
     "group 0.13.0",
     "hashlink 0.8.3",
     "hex 0.4.3",
@@ -92781,6 +93199,7 @@
     "subtle 2.6.1",
     "syn 1.0.109",
     "syn 2.0.101",
+    "sys-mount 3.0.1",
     "syscalls 0.6.18",
     "systemd 0.10.0",
     "tar 0.4.39",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "085e3150b8aa905802c0f795bb7bfc8dfa7c9528b1d2a9f28061c24200c39c0b",
+  "checksum": "b1f51bfbab9ad1d454b7a9611c0b860afa5b55847e6092c94ab342f1caf38684",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -2749,6 +2749,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85256fac1519a7d25a040c1d850fba67478f3f021ad5fdf738ba4425ee862dbf"
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +3500,7 @@ dependencies = [
  "get_if_addrs",
  "getrandom 0.2.10",
  "goldenfile",
+ "gpt",
  "group 0.13.0",
  "hashlink",
  "hex",
@@ -3678,6 +3694,7 @@ dependencies = [
  "subtle",
  "syn 1.0.109",
  "syn 2.0.101",
+ "sys-mount",
  "syscalls",
  "systemd",
  "tar",
@@ -4902,6 +4919,18 @@ dependencies = [
  "smallvec",
  "spinning_top",
  "web-time",
+]
+
+[[package]]
+name = "gpt"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3696fafb1ecdcc2ae3ce337de73e9202806068594b77d22fdf2f3573c5ec2219"
+dependencies = [
+ "bitflags 2.9.0",
+ "crc",
+ "simple-bytes",
+ "uuid",
 ]
 
 [[package]]
@@ -7589,6 +7618,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
 dependencies = [
  "logos-codegen",
+]
+
+[[package]]
+name = "loopdev-3"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a97d7a5124296ee9124a815acdc3dc4a91f577b72812b3f1f99bb959b46e8d"
+dependencies = [
+ "bindgen 0.69.4",
+ "errno 0.3.10",
+ "libc",
 ]
 
 [[package]]
@@ -11848,6 +11888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-bytes"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11532d9d241904f095185f35dcdaf930b1427a94d5b01d7002d74ba19b44cc4"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12006,6 +12052,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12413,6 +12470,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "sys-mount"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6acb8bb63826062d5a44b68298cf2e25b84bc151bc0c31c35a83b61f818682a"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "loopdev-3",
+ "smart-default",
+ "thiserror 1.0.68",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,6 +1228,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.0",
+ "shlex",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "binread"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3063,21 @@ name = "cranelift-srcgen"
 version = "0.120.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85256fac1519a7d25a040c1d850fba67478f3f021ad5fdf738ba4425ee862dbf"
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -5125,6 +5160,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpt"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3696fafb1ecdcc2ae3ce337de73e9202806068594b77d22fdf2f3573c5ec2219"
+dependencies = [
+ "bitflags 2.9.0",
+ "crc",
+ "simple-bytes",
+ "uuid",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,19 +5618,25 @@ name = "hostos_tool"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap 4.5.27",
  "config",
  "config_types",
  "deterministic_ips",
+ "gpt",
+ "grub",
  "ic-metrics-tool",
  "network",
  "nix 0.24.3",
+ "partition_tools",
  "regex",
+ "sys-mount",
  "systemd",
  "tempfile",
  "tokio",
  "tokio-util",
  "utils",
+ "uuid",
  "virt",
 ]
 
@@ -16591,6 +16644,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "loopdev-3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c48e069775cb94ff50e9cd572544e439c65d5856207119fef992a09ce8f2517"
+dependencies = [
+ "bindgen 0.71.1",
+ "errno 0.3.10",
+ "libc",
+]
+
+[[package]]
 name = "lru"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21638,6 +21702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-bytes"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11532d9d241904f095185f35dcdaf930b1427a94d5b01d7002d74ba19b44cc4"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21790,6 +21860,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -22318,6 +22399,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-mount"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6acb8bb63826062d5a44b68298cf2e25b84bc151bc0c31c35a83b61f818682a"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "loopdev-3",
+ "smart-default",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22490,15 +22585,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if 1.0.0",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix 0.38.44",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -23031,16 +23125,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "pin-project-lite",
  "slab",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -565,6 +565,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 getrandom = { version = "0.2", features = ["custom"] }
 goldenfile = "1.8.0"
+gpt = "4.1"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "1.3.1"
 http-body = "1.0.1"
@@ -732,6 +733,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
 subtle = "2.6.1"
 syn = { version = "1.0.109", features = ["fold", "full"] }
+sys-mount = "3.0"
 systemd = "0.10"
 tar = "0.4.39"
 tempfile = "3.12.0"

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -531,6 +531,9 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                     "custom",
                 ],
             ),
+            "gpt": crate.spec(
+                version = "4.1",
+            ),
             "goldenfile": crate.spec(
                 version = "^1.8",
             ),
@@ -1307,6 +1310,9 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             ),
             "systemd": crate.spec(
                 version = "0.10",
+            ),
+            "sys-mount": crate.spec(
+                version = "3.0",
             ),
             "tar": crate.spec(
                 version = "^0.4.38",

--- a/ic-os/defs.bzl
+++ b/ic-os/defs.bzl
@@ -307,6 +307,7 @@ def icos_build(
         expanded_size = image_deps.get("expanded_size", default = None),
         tags = ["manual", "no-cache"],
         target_compatible_with = ["@platforms//os:linux"],
+        visibility = visibility,
     )
 
     zstd_compress(

--- a/ic-os/tests/BUILD.bazel
+++ b/ic-os/tests/BUILD.bazel
@@ -1,0 +1,4 @@
+test_suite(
+    name = "integration_tests",
+    tests = ["//rs/ic_os/os_tools/hostos_tool:hostos_tool_integration_tests"],
+)

--- a/rs/ic_os/config/build.rs
+++ b/rs/ic_os/config/build.rs
@@ -22,12 +22,6 @@ fn main() {
     f.write_all(
         format!(
             r#"
-pub struct DirectBootProps {{
-    kernel: String,
-    initrd: String,
-    kernel_cmdline: String
-}}
-
 #[derive(Template)]
 #[template(escape = "xml", source = {:?}, ext = "xml")]
 pub struct GuestOSTemplateProps {{
@@ -37,7 +31,7 @@ pub struct GuestOSTemplateProps {{
     pub mac_address: macaddr::MacAddr6,
     pub config_media: String,
     pub enable_sev: bool,
-    pub direct_boot: Option<DirectBootProps>
+    pub direct_boot: Option<DirectBootConfig>
 }}
     "#,
             std::fs::read_to_string("templates/guestos_vm_template.xml").unwrap()

--- a/rs/ic_os/config/build.rs
+++ b/rs/ic_os/config/build.rs
@@ -22,14 +22,22 @@ fn main() {
     f.write_all(
         format!(
             r#"
+pub struct DirectBootProps {{
+    kernel: String,
+    initrd: String,
+    kernel_cmdline: String
+}}
+
 #[derive(Template)]
 #[template(escape = "xml", source = {:?}, ext = "xml")]
-pub struct GuestOSTemplateProps<'a> {{
-    pub cpu_domain: &'a str,
+pub struct GuestOSTemplateProps {{
+    pub cpu_domain: String,
     pub vm_memory: u32,
     pub nr_of_vcpus: u32,
     pub mac_address: macaddr::MacAddr6,
-    pub config_media: &'a str,
+    pub config_media: String,
+    pub enable_sev: bool,
+    pub direct_boot: Option<DirectBootProps>
 }}
     "#,
             std::fs::read_to_string("templates/guestos_vm_template.xml").unwrap()

--- a/rs/ic_os/config/golden/guestos_vm_kvm.xml
+++ b/rs/ic_os/config/golden/guestos_vm_kvm.xml
@@ -50,7 +50,7 @@
       <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
     </disk>
     <disk type='file' device='disk'>
-      <source file='/tmp/config.img' />
+      <source file='/tmp/config.img'/>
       <target dev='sda' bus='usb' removable='on'/>
     </disk>
     <controller type='usb' index='0' model='ich9-ehci1'>

--- a/rs/ic_os/config/golden/guestos_vm_sev.xml
+++ b/rs/ic_os/config/golden/guestos_vm_sev.xml
@@ -19,6 +19,9 @@
     <reducedPhysBits>1</reducedPhysBits>
     <policy>30000</policy>
   </launchSecurity>
+  <memoryBacking>
+    <locked/>
+  </memoryBacking>
   <resource>
     <partition>/machine</partition>
   </resource>

--- a/rs/ic_os/config/golden/guestos_vm_sev.xml
+++ b/rs/ic_os/config/golden/guestos_vm_sev.xml
@@ -1,4 +1,4 @@
-<domain type='qemu' id='1'>
+<domain type='kvm' id='1'>
   <name>guestos</name>
   <uuid>fd897da5-8017-41c8-8575-a706dba30766</uuid>
   <metadata>
@@ -9,7 +9,16 @@
   <memory unit='GiB'>490</memory>
   <currentMemory unit='GiB'>490</currentMemory>
   <vcpu placement='static'>56</vcpu>
-  <cpu mode='host-model'/>
+  <cpu mode='host-passthrough' migratable='off'>
+    <cache mode='passthrough'/>
+    <topology sockets='2' cores='14' threads='2'/>
+    <feature policy='require' name='topoext'/>
+  </cpu>
+  <launchSecurity type='sev-snp' kernelHashes='yes'>
+    <cbitpos>51</cbitpos>
+    <reducedPhysBits>1</reducedPhysBits>
+    <policy>30000</policy>
+  </launchSecurity>
   <resource>
     <partition>/machine</partition>
   </resource>

--- a/rs/ic_os/config/src/guest_vm_config.rs
+++ b/rs/ic_os/config/src/guest_vm_config.rs
@@ -67,7 +67,7 @@ fn make_bootstrap_options(
 pub fn generate_vm_config(
     config: &HostOSConfig,
     media_path: &Path,
-    direct_boot: &Option<DirectBootConfig>,
+    direct_boot: Option<DirectBootConfig>,
 ) -> Result<String> {
     let mac_address = calculate_deterministic_mac(
         &config.icos_settings.mgmt_mac,
@@ -82,30 +82,13 @@ pub fn generate_vm_config(
         "kvm"
     };
 
-    let mut direct_boot_props = None;
-    if let Some(direct_boot) = direct_boot {
-        direct_boot_props = Some(DirectBootProps {
-            kernel: direct_boot
-                .kernel
-                .to_str()
-                .context("Kernel path is not UTF-8")?
-                .to_string(),
-            initrd: direct_boot
-                .initrd
-                .to_str()
-                .context("Initrd path is not UTF-8")?
-                .to_string(),
-            kernel_cmdline: direct_boot.kernel_cmdline.clone(),
-        })
-    }
-
     GuestOSTemplateProps {
         cpu_domain: cpu_domain.to_string(),
         vm_memory: config.hostos_settings.vm_memory,
         nr_of_vcpus: config.hostos_settings.vm_nr_of_vcpus,
         mac_address,
         config_media: media_path.display().to_string(),
-        direct_boot: direct_boot_props,
+        direct_boot,
         enable_sev: config.icos_settings.enable_trusted_execution_environment,
     }
     .render()
@@ -223,7 +206,7 @@ mod tests {
         };
 
         let vm_config =
-            generate_vm_config(&config, Path::new("/tmp/config.img"), &direct_boot).unwrap();
+            generate_vm_config(&config, Path::new("/tmp/config.img"), direct_boot).unwrap();
         std::fs::write(mint.new_goldenpath(filename).unwrap(), vm_config).unwrap();
     }
 

--- a/rs/ic_os/config/src/guest_vm_config.rs
+++ b/rs/ic_os/config/src/guest_vm_config.rs
@@ -10,6 +10,16 @@ use std::path::{Path, PathBuf};
 // See build.rs
 include!(concat!(env!("OUT_DIR"), "/guestos_vm_template.rs"));
 
+#[derive(Debug)]
+pub struct DirectBootConfig {
+    /// The kernel file
+    pub kernel: PathBuf,
+    /// The initrd file
+    pub initrd: PathBuf,
+    /// Kernel command line parameters
+    pub kernel_cmdline: String,
+}
+
 pub fn assemble_config_media(hostos_config: &HostOSConfig, media_path: &Path) -> Result<()> {
     let guestos_config =
         generate_guestos_config(hostos_config).context("Failed to generate GuestOS config")?;
@@ -54,7 +64,11 @@ fn make_bootstrap_options(
 }
 
 /// Generate the GuestOS VM libvirt XML configuration and return it as String.
-pub fn generate_vm_config(config: &HostOSConfig, media_path: &Path) -> Result<String> {
+pub fn generate_vm_config(
+    config: &HostOSConfig,
+    media_path: &Path,
+    direct_boot: &Option<DirectBootConfig>,
+) -> Result<String> {
     let mac_address = calculate_deterministic_mac(
         &config.icos_settings.mgmt_mac,
         config.icos_settings.deployment_environment,
@@ -68,12 +82,31 @@ pub fn generate_vm_config(config: &HostOSConfig, media_path: &Path) -> Result<St
         "kvm"
     };
 
+    let mut direct_boot_props = None;
+    if let Some(direct_boot) = direct_boot {
+        direct_boot_props = Some(DirectBootProps {
+            kernel: direct_boot
+                .kernel
+                .to_str()
+                .context("Kernel path is not UTF-8")?
+                .to_string(),
+            initrd: direct_boot
+                .initrd
+                .to_str()
+                .context("Initrd path is not UTF-8")?
+                .to_string(),
+            kernel_cmdline: direct_boot.kernel_cmdline.clone(),
+        })
+    }
+
     GuestOSTemplateProps {
-        cpu_domain,
+        cpu_domain: cpu_domain.to_string(),
         vm_memory: config.hostos_settings.vm_memory,
         nr_of_vcpus: config.hostos_settings.vm_nr_of_vcpus,
         mac_address,
-        config_media: &media_path.display().to_string(),
+        config_media: media_path.display().to_string(),
+        direct_boot: direct_boot_props,
+        enable_sev: config.icos_settings.enable_trusted_execution_environment,
     }
     .render()
     .context("Failed to render GuestOS VM XML template")
@@ -166,29 +199,77 @@ mod tests {
         path
     }
 
-    fn test_vm_config(cpu_type: &str, filename: &str) {
+    fn test_vm_config(
+        hostos_settings: HostOSSettings,
+        enable_trusted_execution_environment: bool,
+        enable_direct_boot: bool,
+        filename: &str,
+    ) {
         let mut mint = Mint::new(goldenfiles_path());
         let mut config = create_test_hostos_config();
+        config.icos_settings.enable_trusted_execution_environment =
+            enable_trusted_execution_environment;
 
-        config.hostos_settings = HostOSSettings {
-            vm_memory: 490,
-            vm_cpu: cpu_type.to_string(),
-            vm_nr_of_vcpus: 56,
-            verbose: false,
+        config.hostos_settings = hostos_settings;
+
+        let direct_boot = if enable_direct_boot {
+            Some(DirectBootConfig {
+                kernel: PathBuf::from("/tmp/test-kernel"),
+                initrd: PathBuf::from("/tmp/test-initrd"),
+                kernel_cmdline: "security=selinux selinux=1 enforcing=0".to_string(),
+            })
+        } else {
+            None
         };
 
-        let vm_config = generate_vm_config(&config, Path::new("/tmp/config.img")).unwrap();
+        let vm_config =
+            generate_vm_config(&config, Path::new("/tmp/config.img"), &direct_boot).unwrap();
         std::fs::write(mint.new_goldenpath(filename).unwrap(), vm_config).unwrap();
     }
 
     #[test]
     fn test_generate_vm_config_qemu() {
-        test_vm_config("qemu", "guestos_vm_qemu.xml");
+        test_vm_config(
+            HostOSSettings {
+                vm_memory: 490,
+                vm_cpu: "qemu".to_string(),
+                vm_nr_of_vcpus: 56,
+                ..HostOSSettings::default()
+            },
+            /*enable_trusted_execution_environment=*/ false,
+            /*enable_direct_boot=*/ true,
+            "guestos_vm_qemu.xml",
+        );
     }
 
     #[test]
     fn test_generate_vm_config_kvm() {
-        test_vm_config("kvm", "guestos_vm_kvm.xml");
+        test_vm_config(
+            HostOSSettings {
+                vm_memory: 490,
+                vm_cpu: "kvm".to_string(),
+                vm_nr_of_vcpus: 56,
+                ..HostOSSettings::default()
+            },
+            /*enable_trusted_execution_environment=*/ false,
+            /*enable_direct_boot=*/ false,
+            "guestos_vm_kvm.xml",
+        );
+    }
+
+    #[test]
+    fn test_generate_vm_config_sev() {
+        test_vm_config(
+            HostOSSettings {
+                vm_memory: 490,
+                vm_cpu: "kvm".to_string(),
+                vm_nr_of_vcpus: 56,
+                ..HostOSSettings::default()
+            },
+            /*enable_trusted_execution_environment=*/ true,
+            /*enable_direct_boot=*/ true,
+            "guestos_vm_sev.xml",
+        );
     }
 
     #[test]

--- a/rs/ic_os/config/templates/guestos_vm_template.xml
+++ b/rs/ic_os/config/templates/guestos_vm_template.xml
@@ -26,6 +26,9 @@
     <reducedPhysBits>1</reducedPhysBits>
     <policy>30000</policy>
   </launchSecurity>
+  <memoryBacking>
+    <locked/>
+  </memoryBacking>
   {% endif -%}
 
   <resource>

--- a/rs/ic_os/config/templates/guestos_vm_template.xml
+++ b/rs/ic_os/config/templates/guestos_vm_template.xml
@@ -37,8 +37,8 @@
     <nvram>/var/lib/libvirt/qemu/nvram/guestos_VARS.fd</nvram>
     <boot dev='hd'/>
     {%- if let Some(direct_boot) = direct_boot %}
-    <kernel>{{direct_boot.kernel}}</kernel>
-    <initrd>{{direct_boot.initrd}}</initrd>
+    <kernel>{{direct_boot.kernel.display()}}</kernel>
+    <initrd>{{direct_boot.initrd.display()}}</initrd>
     <cmdline>{{direct_boot.kernel_cmdline}}</cmdline>
     {%- endif %}
   </os>

--- a/rs/ic_os/config/templates/guestos_vm_template.xml
+++ b/rs/ic_os/config/templates/guestos_vm_template.xml
@@ -20,6 +20,14 @@
   </cpu>
   {% endif -%}
 
+  {%- if enable_sev -%}
+  <launchSecurity type='sev-snp' kernelHashes='yes'>
+    <cbitpos>51</cbitpos>
+    <reducedPhysBits>1</reducedPhysBits>
+    <policy>30000</policy>
+  </launchSecurity>
+  {% endif -%}
+
   <resource>
     <partition>/machine</partition>
   </resource>
@@ -28,6 +36,11 @@
     <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
     <nvram>/var/lib/libvirt/qemu/nvram/guestos_VARS.fd</nvram>
     <boot dev='hd'/>
+    {%- if let Some(direct_boot) = direct_boot %}
+    <kernel>{{direct_boot.kernel}}</kernel>
+    <initrd>{{direct_boot.initrd}}</initrd>
+    <cmdline>{{direct_boot.kernel_cmdline}}</cmdline>
+    {%- endif %}
   </os>
   <features>
     <acpi/>
@@ -56,7 +69,7 @@
       <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
     </disk>
     <disk type='file' device='disk'>
-      <source file='{{config_media}}' />
+      <source file='{{config_media}}'/>
       <target dev='sda' bus='usb' removable='on'/>
     </disk>
     <controller type='usb' index='0' model='ich9-ehci1'>

--- a/rs/ic_os/os_tools/hostos_tool/BUILD.bazel
+++ b/rs/ic_os/os_tools/hostos_tool/BUILD.bazel
@@ -7,26 +7,33 @@ DEPENDENCIES = [
     "//rs/ic_os/config:config_lib",
     "//rs/ic_os/config_types",
     "//rs/ic_os/deterministic_ips",
+    "//rs/ic_os/grub",
     "//rs/ic_os/metrics_tool",
     "//rs/ic_os/network",
     "//rs/ic_os/utils",
     "@crate_index//:anyhow",
     "@crate_index//:clap",
+    "@crate_index//:gpt",
+    "@crate_index//:regex",
+    "@crate_index//:sys-mount",
     "@crate_index//:systemd",
     "@crate_index//:tempfile",
     "@crate_index//:tokio",
     "@crate_index//:tokio-util",
+    "@crate_index//:uuid",
     "@crate_index//:virt",
     "@libvirt",
 ]
 
 DEV_DEPENDENCIES = [
     # Keep sorted.
+    "//rs/ic_os/build_tools/partition_tools",
     "@crate_index//:nix",
-    "@crate_index//:regex",
 ]
 
-MACRO_DEPENDENCIES = []
+MACRO_DEPENDENCIES = [
+    "@crate_index//:async-trait",
+]
 
 ALIASES = {}
 
@@ -45,5 +52,7 @@ rust_binary(
 rust_test(
     name = "hostos_tool_test",
     crate = ":hostos_tool",
+    data = ["//ic-os/guestos/envs/prod:disk-img.tar.zst"],
+    env = {"ICOS_IMAGE": "$(rootpath //ic-os/guestos/envs/prod:disk-img.tar.zst)"},
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/ic_os/os_tools/hostos_tool/BUILD.bazel
+++ b/rs/ic_os/os_tools/hostos_tool/BUILD.bazel
@@ -52,7 +52,16 @@ rust_binary(
 rust_test(
     name = "hostos_tool_test",
     crate = ":hostos_tool",
+    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+)
+
+rust_test(
+    name = "hostos_tool_integration_tests",
+    crate = ":hostos_tool",
+    crate_features = ["integration_tests"],
     data = ["//ic-os/guestos/envs/prod:disk-img.tar.zst"],
     env = {"ICOS_IMAGE": "$(rootpath //ic-os/guestos/envs/prod:disk-img.tar.zst)"},
+    # Mark it manual here and expose it in //ic-os/tests:integration_tests
+    tags = ["manual"],
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )

--- a/rs/ic_os/os_tools/hostos_tool/Cargo.toml
+++ b/rs/ic_os/os_tools/hostos_tool/Cargo.toml
@@ -34,3 +34,6 @@ virt = { workspace = true }
 [dev-dependencies]
 partition_tools = { path = "../../build_tools/partition_tools" }
 regex = { workspace = true }
+
+[features]
+integration_tests = []

--- a/rs/ic_os/os_tools/hostos_tool/Cargo.toml
+++ b/rs/ic_os/os_tools/hostos_tool/Cargo.toml
@@ -9,21 +9,28 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 clap = { workspace = true }
 config = { path = "../../config" }
 config_types = { path = "../../config_types" }
 deterministic_ips = { path = "../../deterministic_ips" }
+gpt = { workspace = true }
+grub = { path = "../../grub" }
 ic-metrics-tool = { path = "../../metrics_tool" }
 network = { path = "../../network" }
 nix = { workspace = true }
-utils = { path = "../../utils" }
+regex = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
-virt = { workspace = true }
+utils = { path = "../../utils" }
 tokio-util = { workspace = true }
+uuid = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 systemd = { workspace = true }
+sys-mount = { workspace = true }
+virt = { workspace = true }
 
 [dev-dependencies]
+partition_tools = { path = "../../build_tools/partition_tools" }
 regex = { workspace = true }

--- a/rs/ic_os/os_tools/hostos_tool/src/boot_args.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/boot_args.rs
@@ -1,0 +1,294 @@
+use anyhow::bail;
+use anyhow::Result;
+use regex::Regex;
+use std::path::Path;
+use std::sync::LazyLock;
+
+/// Extracts the value of `boot_args_var_name` from the given config file.
+///
+/// Supported config format:
+/// VARIABLE1=value
+/// VARIABLE2="other value" # some comment
+/// VARIABLE3='third value'
+///
+/// read_boot_args(config_path, "VARIABLE2") returns Ok("other value")
+pub fn read_boot_args(config: &Path, boot_args_var_name: &str) -> Result<String> {
+    let config_contents = std::fs::read_to_string(config)?;
+    for line in config_contents.lines().rev() {
+        if let Some(result) = try_parse(line, boot_args_var_name) {
+            return Ok(result);
+        }
+    }
+
+    bail!("Variable {boot_args_var_name} not found");
+}
+
+fn try_parse(line: &str, boot_args_var_name: &str) -> Option<String> {
+    static BOOT_ARGS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?x)                # Enable verbose mode
+        ^                          # Start of line
+        \s*                        # Optional whitespace
+        (\w+)                      # Capture group 1: variable name
+        =                          # Equals sign
+        (?:                        # Value alternatives:
+            "                      #   Double-quoted string
+            ((?:[^"\\]|\\.)*)      #   Capture group 2: content with escapes (each token is either none of " or \ or it's an escaped character)
+            "                      #   Closing quote
+            |                      # OR
+            '                      #   Single-quoted string
+            ((?:[^'\\]|\\.)*)      #   Capture group 3: content with escapes
+            '                      #   Closing quote
+            |                      # OR
+            ((?:[^\#'"\\\s]|\\.)*)  #   Capture group 4: unquoted until comment or whitespace
+        )                          # End value alternatives
+        \s*                        # Optional trailing whitespace
+        (?:\#.*)?                  # Optional comment
+        $                          # End of line
+        "#
+        ).unwrap()
+    });
+
+    let caps = BOOT_ARGS_REGEX.captures(line)?;
+
+    // Verify variable name matches
+    if caps.get(1)?.as_str() != boot_args_var_name {
+        return None;
+    }
+
+    // Extract value: try double-quoted, single-quoted, then unquoted
+    let raw_value = caps
+        .get(2)
+        .or_else(|| caps.get(3))
+        .or_else(|| caps.get(4))
+        .map(|m| m.as_str())?;
+
+    Some(process_escapes(raw_value))
+}
+
+/// Replaces escape sequences: \n, \t, \", \', \\, etc. with their corresponding characters.
+fn process_escapes(s: &str) -> String {
+    let mut result = String::new();
+    let mut chars = s.chars();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => match chars.next() {
+                Some('n') => result.push('\n'),
+                Some('t') => result.push('\t'),
+                Some(other) => result.push(other),
+                None => result.push('\\'),
+            },
+            _ => result.push(c),
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_try_parse_simple_value() {
+        assert_eq!(
+            try_parse("BOOT_ARGS=simple_value", "BOOT_ARGS"),
+            Some("simple_value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_with_double_quotes() {
+        assert_eq!(
+            try_parse(r#"BOOT_ARGS="quoted value""#, "BOOT_ARGS"),
+            Some("quoted value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_with_single_quotes() {
+        assert_eq!(
+            try_parse("BOOT_ARGS='single quoted'", "BOOT_ARGS"),
+            Some("single quoted".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_with_escaped_quotes() {
+        assert_eq!(
+            try_parse(r#"BOOT_ARGS="value with \"escaped\" quotes""#, "BOOT_ARGS"),
+            Some(r#"value with "escaped" quotes"#.to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_with_comment() {
+        assert_eq!(
+            try_parse("BOOT_ARGS=value # this is a comment", "BOOT_ARGS"),
+            Some("value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_with_comment_in_quotes() {
+        assert_eq!(
+            try_parse(r#"BOOT_ARGS="value # not a comment""#, "BOOT_ARGS"),
+            Some("value # not a comment".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_with_whitespace() {
+        assert_eq!(try_parse("  BOOT_ARGS=  value  ", "BOOT_ARGS"), None);
+    }
+
+    #[test]
+    fn test_try_parse_empty_value() {
+        assert_eq!(try_parse("BOOT_ARGS=", "BOOT_ARGS"), Some("".to_string()));
+    }
+
+    #[test]
+    fn test_try_parse_only_whitespaces() {
+        assert_eq!(try_parse("BOOT_ARGS=  ", "BOOT_ARGS"), Some("".to_string()));
+    }
+
+    #[test]
+    fn test_try_parse_empty_quoted_value() {
+        assert_eq!(
+            try_parse(r#"BOOT_ARGS="""#, "BOOT_ARGS"),
+            Some("".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_empty_unquoted_escape_char() {
+        assert_eq!(
+            try_parse(r#"BOOT_ARGS=hello\\world"#, "BOOT_ARGS"),
+            Some("hello\\world".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_empty_unquoted_whitespace() {
+        assert_eq!(
+            try_parse(r#"BOOT_ARGS=hello\ dear\ world"#, "BOOT_ARGS"),
+            Some("hello dear world".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_wrong_variable() {
+        assert_eq!(try_parse("OTHER_VAR=value", "BOOT_ARGS"), None);
+    }
+
+    #[test]
+    fn test_try_parse_partial_match() {
+        assert_eq!(try_parse("BOOT_ARGS_EXTRA=value", "BOOT_ARGS"), None);
+    }
+
+    #[test]
+    fn test_try_parse_no_equals() {
+        assert_eq!(try_parse("BOOT_ARGS", "BOOT_ARGS"), None);
+    }
+
+    #[test]
+    fn test_try_parse_unclosed_quotes() {
+        assert_eq!(try_parse("BOOT_ARGS=\"unclosed quote", "BOOT_ARGS"), None);
+    }
+
+    #[test]
+    fn test_try_parse_mixed_quotes() {
+        assert_eq!(try_parse("BOOT_ARGS=\"value'", "BOOT_ARGS"), None);
+    }
+
+    #[test]
+    fn test_try_parse_with_comment_and_spaces() {
+        assert_eq!(
+            try_parse("BOOT_ARGS=value with spaces   # comment", "BOOT_ARGS"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_try_parse_with_comment_no_spaces() {
+        assert_eq!(
+            try_parse("BOOT_ARGS=value# comment", "BOOT_ARGS"),
+            Some("value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_quoted_whitespace() {
+        assert_eq!(
+            try_parse(r#"BOOT_ARGS=" whitespace ""#, "BOOT_ARGS"),
+            Some(" whitespace ".to_string())
+        );
+    }
+
+    #[test]
+    fn test_try_parse_with_backslash_escapes() {
+        assert_eq!(
+            try_parse(
+                r#"BOOT_ARGS="value\nwith\tescapes \"x\"=\"y\"""#,
+                "BOOT_ARGS"
+            ),
+            Some("value\nwith\tescapes \"x\"=\"y\"".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_boot_args_success() -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let content = r#"# Configuration file
+SOME_OTHER_VAR=other_value
+BOOT_ARGS="kernel params here"
+# Comment
+"#;
+        fs::write(temp_file.path(), content)?;
+
+        let result = read_boot_args(temp_file.path(), "BOOT_ARGS")?;
+        assert_eq!(result, "kernel params here");
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_boot_args_multiple_lines() -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let content = r#"BOOT_ARGS=first_value
+BOOT_ARGS="second_value"
+BOOT_ARGS=third_value
+"#;
+        fs::write(temp_file.path(), content)?;
+
+        // Should return the last match
+        let result = read_boot_args(temp_file.path(), "BOOT_ARGS")?;
+        assert_eq!(result, "third_value");
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_boot_args_not_found() -> anyhow::Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let content = r#"# Configuration file
+SOME_OTHER_VAR=other_value
+DIFFERENT_VAR="some value"
+"#;
+        fs::write(temp_file.path(), content)?;
+
+        let result = read_boot_args(temp_file.path(), "BOOT_ARGS");
+        assert!(result
+            .expect_err("Missing var should be error")
+            .to_string()
+            .contains("Variable BOOT_ARGS not found"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_boot_args_file_not_found() {
+        let result = read_boot_args(Path::new("nonexistent_file.txt"), "BOOT_ARGS");
+        assert!(result.is_err());
+    }
+}

--- a/rs/ic_os/os_tools/hostos_tool/src/guest_direct_boot.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/guest_direct_boot.rs
@@ -1,0 +1,524 @@
+use crate::boot_args::read_boot_args;
+use crate::mount::{MountOptions, PartitionProvider};
+use anyhow::Context;
+use anyhow::Result;
+use config::guest_vm_config::DirectBootConfig;
+use grub::{BootAlternative, BootCycle, GrubEnv, WithDefault};
+use std::fs::File;
+use tempfile::NamedTempFile;
+use uuid::Uuid;
+
+const fn const_unwrap(result: std::result::Result<Uuid, uuid::Error>) -> Uuid {
+    match result {
+        Ok(value) => value,
+        Err(_) => panic!("Could not unwrap"),
+    }
+}
+
+const GRUB_PARTITION_UUID: Uuid =
+    const_unwrap(Uuid::try_parse("6788E4CF-F456-104E-9A34-A2C58CFB0EE6"));
+const A_BOOT_PARTITION_UUID: Uuid =
+    const_unwrap(Uuid::try_parse("DDF618FE-7244-B446-A175-3296E6B9D02E"));
+const B_BOOT_PARTITION_UUID: Uuid =
+    const_unwrap(Uuid::try_parse("D5214E4F-F7B0-B945-9A9B-52B9188DF4C5"));
+
+/// Direct boot configuration extracted from the GuestOS
+#[derive(Debug)]
+pub struct DirectBoot {
+    /// The kernel file
+    pub kernel: NamedTempFile,
+    /// The initrd file
+    pub initrd: NamedTempFile,
+    /// Kernel command line parameters
+    pub kernel_cmdline: String,
+}
+
+impl DirectBoot {
+    pub fn to_config(&self) -> DirectBootConfig {
+        DirectBootConfig {
+            kernel: self.kernel.path().to_path_buf(),
+            initrd: self.initrd.path().to_path_buf(),
+            kernel_cmdline: self.kernel_cmdline.clone(),
+        }
+    }
+}
+
+/// Prepares a direct boot configuration by reading the GRUB environment and boot partition.
+///
+/// # Arguments
+/// * `should_refresh_grubenv` - Whether the code should refresh the GRUB environment based on the
+///   boot state transition rules
+/// * `guest_partition_provider` - Provider for accessing partitions of the Guest
+///
+/// # Returns
+/// * `Ok(Some(DirectBoot))` - Success
+/// * `Ok(None)` - If direct boot is not supported because the necessary files are not available
+///   (old GuestOS)
+/// * `Err` - If any error occurs during preparation
+pub async fn prepare_direct_boot(
+    should_refresh_grubenv: bool,
+    guest_partition_provider: &dyn PartitionProvider,
+) -> Result<Option<DirectBoot>> {
+    let grub_partition = guest_partition_provider
+        .mount_partition(
+            GRUB_PARTITION_UUID,
+            MountOptions {
+                readonly: !should_refresh_grubenv,
+            },
+        )
+        .await?;
+
+    let grubenv_path = grub_partition.mount_point().join("grubenv");
+    let mut grubenv =
+        GrubEnv::read_from(File::open(&grubenv_path).context("Could not open grubenv")?)?;
+
+    let grubenv_is_changing = should_refresh_grubenv && refresh_grubenv(&mut grubenv)?;
+
+    let boot_alternative = grubenv
+        .boot_alternative
+        .clone()
+        .context("Failed to read boot_alternative from grubenv")?;
+
+    // The variable name inside 'boot_args' that contains the kernel command line parameters.
+    // Note that this depends on the boot alternative since they contain the root partition and
+    // other boot alternative-specific parameters.
+    let (boot_partition_uuid, boot_args_var_name) = match boot_alternative {
+        BootAlternative::A => (A_BOOT_PARTITION_UUID, "BOOT_ARGS_A"),
+        BootAlternative::B => (B_BOOT_PARTITION_UUID, "BOOT_ARGS_B"),
+    };
+
+    let boot_partition = guest_partition_provider
+        .mount_partition(boot_partition_uuid, MountOptions { readonly: true })
+        .await?;
+
+    let boot_args_path = boot_partition.mount_point().join("boot_args");
+    // Older GuestOS releases do not have the boot_args file. If the file exists, we have a modern
+    // enough GuestOS that supports direct boot. If not, abandon direct boot by returning None.
+    // Also note that we decide about abandoning direct boot before writing out grubenv below since
+    // booting with GRUB will also try to refresh the grubenv and it's *not* an idempotent
+    // operation. Therefore, we don't write out grubenv until we can ensure that we'll do a direct
+    // boot.
+    if !boot_args_path.exists() {
+        return Ok(None);
+    }
+
+    let boot_args =
+        read_boot_args(&boot_args_path, boot_args_var_name).context("Failed to read boot args")?;
+
+    let kernel = NamedTempFile::new()?;
+    let initrd = NamedTempFile::new()?;
+
+    tokio::fs::copy(boot_partition.mount_point().join("vmlinuz"), &kernel)
+        .await
+        .context("Could not copy vmlinuz")?;
+    tokio::fs::copy(boot_partition.mount_point().join("initrd.img"), &initrd)
+        .await
+        .context("Could not copy initrd.img")?;
+
+    // We defer writing out the updated grubenv until we can ensure that the direct boot preparation
+    // was successful.
+    if grubenv_is_changing {
+        grubenv
+            .write_to_file(&grubenv_path)
+            .context("Failed to upgrade grubenv")?;
+    }
+
+    Ok(Some(DirectBoot {
+        kernel,
+        initrd,
+        kernel_cmdline: boot_args,
+    }))
+}
+
+/// Refreshes the boot cycle and boot alternative in `grub_env`.
+/// Returns true if `grub_env` changed.
+fn refresh_grubenv(grub_env: &mut GrubEnv) -> Result<bool> {
+    let mut boot_alternative = grub_env
+        .boot_alternative
+        .clone()
+        .with_default_if_undefined(BootAlternative::A)
+        .context("Invalid boot_alternative")?;
+    let mut boot_cycle = grub_env
+        .boot_cycle
+        .clone()
+        .with_default_if_undefined(BootCycle::Stable)
+        .context("Invalid boot_cycle")?;
+
+    match boot_cycle {
+        BootCycle::Stable => {}
+        BootCycle::Install => boot_cycle = BootCycle::Stable,
+        BootCycle::FirstBoot => boot_cycle = BootCycle::FailsafeCheck,
+        BootCycle::FailsafeCheck => {
+            boot_cycle = BootCycle::Stable;
+            boot_alternative = boot_alternative.get_opposite();
+        }
+    };
+    let changed =
+        grub_env.boot_alternative != Ok(boot_alternative) || grub_env.boot_cycle != Ok(boot_cycle);
+
+    grub_env.boot_alternative = Ok(boot_alternative);
+    grub_env.boot_cycle = Ok(boot_cycle);
+    Ok(changed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mount::testing::MockPartitionProvider;
+    use grub::GrubEnvVariableError;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::io::Write;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    /// Builder for creating test setups with fluent interface
+    struct TestSetupBuilder {
+        boot_alternative: Option<BootAlternative>,
+        boot_cycle: Option<BootCycle>,
+        boot_args_a: String,
+        boot_args_b: String,
+        create_boot_args_files: bool,
+        create_kernel_files: bool,
+    }
+
+    impl TestSetupBuilder {
+        fn new() -> Self {
+            Self {
+                boot_alternative: None,
+                boot_cycle: None,
+                boot_args_a: "args_a".to_string(),
+                boot_args_b: "args_b".to_string(),
+                create_boot_args_files: true,
+                create_kernel_files: true,
+            }
+        }
+
+        fn with_grubenv(
+            mut self,
+            boot_alternative: BootAlternative,
+            boot_cycle: BootCycle,
+        ) -> Self {
+            self.boot_alternative = Some(boot_alternative);
+            self.boot_cycle = Some(boot_cycle);
+            self
+        }
+
+        fn with_boot_args(mut self, args_a: &str, args_b: &str) -> Self {
+            self.boot_args_a = args_a.to_string();
+            self.boot_args_b = args_b.to_string();
+            self
+        }
+
+        fn without_boot_args_files(mut self) -> Self {
+            self.create_boot_args_files = false;
+            self
+        }
+
+        fn without_kernel_files(mut self) -> Self {
+            self.create_kernel_files = false;
+            self
+        }
+
+        fn build(self) -> TestSetup {
+            let grub_partition = create_grub_partition(self.boot_alternative, self.boot_cycle);
+
+            let a_boot_partition = create_boot_partition(
+                &self.boot_args_a,
+                "SHOULD NOT BE USED",
+                self.create_boot_args_files,
+                self.create_kernel_files,
+            );
+            let b_boot_partition = create_boot_partition(
+                "SHOULD NOT BE USED",
+                &self.boot_args_b,
+                self.create_boot_args_files,
+                self.create_kernel_files,
+            );
+
+            let mut partitions = HashMap::new();
+            partitions.insert(GRUB_PARTITION_UUID, grub_partition.clone());
+            partitions.insert(A_BOOT_PARTITION_UUID, a_boot_partition);
+            partitions.insert(B_BOOT_PARTITION_UUID, b_boot_partition);
+
+            TestSetup {
+                partition_provider: MockPartitionProvider::new(partitions),
+                grub_partition,
+            }
+        }
+    }
+
+    /// Test helper to create a complete test setup with GRUB and boot partitions
+    struct TestSetup {
+        partition_provider: MockPartitionProvider,
+        grub_partition: Arc<TempDir>,
+    }
+
+    impl TestSetup {
+        async fn prepare_direct_boot(
+            &self,
+            should_refresh_grubenv: bool,
+        ) -> Result<Option<DirectBoot>> {
+            prepare_direct_boot(should_refresh_grubenv, &self.partition_provider).await
+        }
+
+        fn get_grubenv(&self) -> GrubEnv {
+            let grubenv_path = self.grub_partition.path().join("grubenv");
+            GrubEnv::read_from(File::open(grubenv_path).unwrap()).unwrap()
+        }
+
+        fn assert_grub_state(
+            &self,
+            expected_alternative: BootAlternative,
+            expected_cycle: BootCycle,
+        ) {
+            let grubenv = self.get_grubenv();
+            assert_eq!(grubenv.boot_cycle.unwrap(), expected_cycle);
+            assert_eq!(grubenv.boot_alternative.unwrap(), expected_alternative);
+        }
+    }
+
+    fn create_grub_partition(
+        boot_alternative: Option<BootAlternative>,
+        boot_cycle: Option<BootCycle>,
+    ) -> Arc<TempDir> {
+        let grub_dir = Arc::new(TempDir::new().expect("Failed to create temp dir"));
+        let grubenv_path = grub_dir.path().join("grubenv");
+
+        let grubenv = GrubEnv {
+            boot_alternative: boot_alternative.ok_or(GrubEnvVariableError::Undefined),
+            boot_cycle: boot_cycle.ok_or(GrubEnvVariableError::Undefined),
+            ..GrubEnv::default()
+        };
+        grubenv
+            .write_to_file(&grubenv_path)
+            .expect("Failed to write grubenv");
+
+        grub_dir
+    }
+
+    fn create_boot_partition(
+        boot_args_a: &str,
+        boot_args_b: &str,
+        create_boot_args: bool,
+        create_kernel_files: bool,
+    ) -> Arc<TempDir> {
+        let boot_dir = Arc::new(TempDir::new().expect("Failed to create temp dir"));
+
+        if create_boot_args {
+            let mut boot_args_file = File::create(boot_dir.path().join("boot_args")).unwrap();
+            writeln!(boot_args_file, "BOOT_ARGS_A=\"{boot_args_a}\"").unwrap();
+            writeln!(boot_args_file, "BOOT_ARGS_B=\"{boot_args_b}\"").unwrap();
+        }
+
+        if create_kernel_files {
+            fs::write(boot_dir.path().join("vmlinuz"), b"fake kernel").unwrap();
+            fs::write(boot_dir.path().join("initrd.img"), b"fake initrd").unwrap();
+        }
+
+        boot_dir
+    }
+
+    #[tokio::test]
+    async fn test_boot_alternative_a() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::A, BootCycle::Stable)
+            .build();
+
+        let direct_boot = setup
+            .prepare_direct_boot(true)
+            .await
+            .expect("prepare_direct_boot failed")
+            .expect("prepare_direct_boot returned None");
+
+        assert_eq!(direct_boot.kernel_cmdline, "args_a");
+        assert_eq!(fs::read(&direct_boot.kernel).unwrap(), b"fake kernel");
+        assert_eq!(fs::read(&direct_boot.initrd).unwrap(), b"fake initrd");
+    }
+
+    #[tokio::test]
+    async fn test_boot_alternative_b() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::B, BootCycle::Stable)
+            .with_boot_args("args_a", "args_b extra")
+            .build();
+
+        let direct_boot = setup
+            .prepare_direct_boot(true)
+            .await
+            .expect("prepare_direct_boot failed")
+            .expect("prepare_direct_boot returned None");
+
+        assert_eq!(direct_boot.kernel_cmdline, "args_b extra");
+    }
+
+    // Test empty grubenv (happens on the very first boot)
+    #[tokio::test]
+    async fn test_empty_grubenv() {
+        let setup = TestSetupBuilder::new().build();
+
+        let direct_boot = setup
+            .prepare_direct_boot(true)
+            .await
+            .expect("prepare_direct_boot failed")
+            .expect("prepare_direct_boot returned None");
+
+        setup.assert_grub_state(BootAlternative::A, BootCycle::Stable);
+        assert_eq!(direct_boot.kernel_cmdline, "args_a");
+    }
+
+    #[tokio::test]
+    async fn test_grubenv_refresh_stable_no_change() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::A, BootCycle::Stable)
+            .build();
+
+        setup
+            .prepare_direct_boot(true)
+            .await
+            .expect("prepare_direct_boot failed")
+            .expect("prepare_direct_boot returned None");
+
+        setup.assert_grub_state(BootAlternative::A, BootCycle::Stable);
+    }
+
+    #[tokio::test]
+    async fn test_grubenv_refresh_install_to_stable() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::A, BootCycle::Install)
+            .build();
+
+        setup
+            .prepare_direct_boot(true)
+            .await
+            .expect("prepare_direct_boot failed")
+            .expect("prepare_direct_boot returned None");
+
+        setup.assert_grub_state(BootAlternative::A, BootCycle::Stable);
+    }
+
+    #[tokio::test]
+    async fn test_grubenv_refresh_firstboot_to_failsafecheck() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::B, BootCycle::FirstBoot)
+            .build();
+
+        setup
+            .prepare_direct_boot(true)
+            .await
+            .expect("prepare_direct_boot failed")
+            .expect("prepare_direct_boot returned None");
+
+        setup.assert_grub_state(BootAlternative::B, BootCycle::FailsafeCheck);
+    }
+
+    #[tokio::test]
+    async fn test_grubenv_refresh_failsafecheck_to_stable_opposite() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::A, BootCycle::FailsafeCheck)
+            .build();
+
+        setup
+            .prepare_direct_boot(true)
+            .await
+            .expect("prepare_direct_boot failed")
+            .expect("prepare_direct_boot returned None");
+
+        setup.assert_grub_state(BootAlternative::B, BootCycle::Stable);
+    }
+
+    #[tokio::test]
+    async fn test_grubenv_refresh_failsafecheck_b_to_stable_a() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::B, BootCycle::FailsafeCheck)
+            .build();
+
+        setup
+            .prepare_direct_boot(true)
+            .await
+            .expect("prepare_direct_boot failed")
+            .expect("prepare_direct_boot returned None");
+
+        setup.assert_grub_state(BootAlternative::A, BootCycle::Stable);
+    }
+
+    #[tokio::test]
+    async fn test_no_grubenv_refresh() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::A, BootCycle::FirstBoot)
+            .build();
+
+        setup
+            .prepare_direct_boot(false)
+            .await
+            .expect("prepare_direct_boot failed")
+            .expect("prepare_direct_boot returned None");
+
+        // Grubenv should remain unchanged
+        let grubenv = setup.get_grubenv();
+        assert_eq!(grubenv.boot_alternative.unwrap(), BootAlternative::A);
+        assert_eq!(grubenv.boot_cycle.unwrap(), BootCycle::FirstBoot);
+    }
+
+    #[tokio::test]
+    async fn test_missing_grub_partition() {
+        let provider = MockPartitionProvider::new(HashMap::new());
+
+        let result = prepare_direct_boot(false, &provider).await;
+
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Could not find partition"));
+    }
+
+    #[tokio::test]
+    async fn test_missing_boot_partition() {
+        let grub_partition =
+            create_grub_partition(Some(BootAlternative::A), Some(BootCycle::Stable));
+        let mut partitions = HashMap::new();
+        partitions.insert(GRUB_PARTITION_UUID, grub_partition);
+        let provider = MockPartitionProvider::new(partitions);
+
+        let result = prepare_direct_boot(false, &provider).await;
+
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Could not find partition"));
+    }
+
+    #[tokio::test]
+    async fn test_missing_boot_args_file() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::B, BootCycle::FailsafeCheck)
+            .without_boot_args_files()
+            .build();
+
+        let result = setup
+            .prepare_direct_boot(true)
+            .await
+            .expect("prepare_direct_boot failed");
+        assert!(result.is_none());
+
+        // Grubenv should remain unchanged
+        let grubenv = setup.get_grubenv();
+        assert_eq!(grubenv.boot_alternative.unwrap(), BootAlternative::B);
+        assert_eq!(grubenv.boot_cycle.unwrap(), BootCycle::FailsafeCheck);
+    }
+
+    #[tokio::test]
+    async fn test_missing_kernel_file() {
+        let setup = TestSetupBuilder::new()
+            .with_grubenv(BootAlternative::B, BootCycle::Stable)
+            .without_kernel_files()
+            .build();
+
+        assert!(setup
+            .prepare_direct_boot(false)
+            .await
+            .expect_err("prepare_direct_boot should fail")
+            .to_string()
+            .contains("vmlinuz"));
+    }
+}

--- a/rs/ic_os/os_tools/hostos_tool/src/guest_vm.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/guest_vm.rs
@@ -1,3 +1,5 @@
+use crate::guest_direct_boot::{prepare_direct_boot, DirectBoot};
+use crate::mount::PartitionProvider;
 use crate::systemd_notifier::SystemdNotifier;
 use anyhow::{anyhow, Context, Error, Result};
 use config::guest_vm_config::{assemble_config_media, generate_vm_config};
@@ -24,14 +26,16 @@ const CONSOLE_LOG_PATH: &str = "/var/log/libvirt/qemu/guestos-serial.log";
 const METRICS_FILE_PATH: &str = "/run/node_exporter/collector_textfile/hostos_guestos_service.prom";
 const CONSOLE_TTY_PATH: &str = "/dev/tty1";
 const GUESTOS_SERVICE_NAME: &str = "guestos.service";
+const DEFAULT_GUESTOS_DEVICE: &str = "/dev/hostlvm/guestos";
 
 /// Manages a libvirt-based virtual machine
 pub struct VirtualMachine {
     domain_id: u32,
     libvirt_connect: Connect,
-    // The config media is used by the virtual machine and must be kept alive until the virtual
-    // machine is destroyed.
+    // These fields hold resources (files) that are used by the virtual machine and must be kept
+    // alive until the virtual machine is destroyed.
     _config_media: NamedTempFile,
+    _direct_boot: Option<DirectBoot>,
 }
 
 impl VirtualMachine {
@@ -41,6 +45,7 @@ impl VirtualMachine {
         libvirt_connect: &Connect,
         xml_config: &str,
         config_media: NamedTempFile,
+        direct_boot: Option<DirectBoot>,
     ) -> Result<Self> {
         let mut retries = 3;
         let domain = loop {
@@ -64,6 +69,7 @@ impl VirtualMachine {
             domain_id: domain.get_id().context("Domain does not have id")?,
             libvirt_connect: libvirt_connect.clone(),
             _config_media: config_media,
+            _direct_boot: direct_boot,
         })
     }
 
@@ -133,6 +139,7 @@ pub struct GuestVmService {
     hostos_config: HostOSConfig,
     systemd_notifier: Arc<dyn SystemdNotifier>,
     console_tty: Box<dyn Write + Send + Sync>,
+    partition_provider: Box<dyn PartitionProvider>,
 }
 
 impl GuestVmService {
@@ -159,6 +166,9 @@ impl GuestVmService {
             hostos_config,
             systemd_notifier: Arc::new(crate::systemd_notifier::DefaultSystemdNotifier),
             console_tty: Box::new(console_tty),
+            partition_provider: Box::new(crate::mount::GptPartitionProvider::new(
+                DEFAULT_GUESTOS_DEVICE.into(),
+            )?),
         })
     }
 
@@ -193,16 +203,33 @@ impl GuestVmService {
 
     async fn start_virtual_machine(&mut self) -> Result<VirtualMachine> {
         let config_media = NamedTempFile::new()?;
+
+        let direct_boot = prepare_direct_boot(
+            // TODO: We should not refresh in Upgrade VMs once we add them
+            /*should_refresh_grubenv=*/
+            true,
+            self.partition_provider.as_ref(),
+        )
+        .await?;
+
         assemble_config_media(&self.hostos_config, config_media.path())?;
 
-        let vm_config = generate_vm_config(&self.hostos_config, config_media.path())
-            .context("Failed to generate GuestOS VM config")?;
+        let vm_config = generate_vm_config(
+            &self.hostos_config,
+            config_media.path(),
+            &direct_boot.as_ref().map(DirectBoot::to_config),
+        )
+        .context("Failed to generate GuestOS VM config")?;
 
         println!("Creating GuestOS virtual machine");
 
-        let virtual_machine =
-            VirtualMachine::new(&self.libvirt_connection, &vm_config, config_media)
-                .context("Failed to define GuestOS virtual machine")?;
+        let virtual_machine = VirtualMachine::new(
+            &self.libvirt_connection,
+            &vm_config,
+            config_media,
+            direct_boot,
+        )
+        .context("Failed to define GuestOS virtual machine")?;
 
         // Notify systemd that we're ready
         self.systemd_notifier.notify_ready()?;
@@ -404,6 +431,7 @@ pub async fn run_guest_vm() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mount;
     use crate::systemd_notifier::testing::MockSystemdNotifier;
     use config_types::{
         DeploymentEnvironment, DeterministicIpv6Config, HostOSSettings, ICOSSettings,
@@ -413,6 +441,7 @@ mod tests {
     use regex::Regex;
     use std::fs::File;
     use std::path::PathBuf;
+    use tempfile::TempDir;
     use tokio::task::JoinHandle;
     use virt::sys::VIR_DOMAIN_RUNNING_BOOTED;
 
@@ -429,12 +458,12 @@ mod tests {
     impl TestServiceInstance {
         async fn wait_for_systemd_ready(&mut self) {
             tokio::select! {
-                    biased;
+                biased;
                     _ = self.systemd_notifier.await_ready() => {/*success*/},
                     result = &mut self.task => {
-                        panic!("Service stopped before becoming ready. Status: {result:?}");
+                    panic!("Service stopped before becoming ready. Status: {result:?}");
                 }
-            }
+            };
         }
 
         async fn wait_for_systemd_stopping(&mut self) {
@@ -443,7 +472,7 @@ mod tests {
                 _ = self.systemd_notifier.await_stopping() => {/*success*/},
                 result = &mut self.task => {
                     panic!("Service stopped before notifying about stopping. Status: {result:?}");
-            }
+                }
             };
         }
 
@@ -501,6 +530,18 @@ mod tests {
             config_media_path
         }
 
+        fn get_kernel_path(&self) -> PathBuf {
+            let domain = self.get_domain();
+            let vm_config = domain.get_xml_desc(0).unwrap();
+            let kernel_path = PathBuf::from(
+                &Regex::new("<kernel>([^']+)</kernel>")
+                    .unwrap()
+                    .captures(&vm_config)
+                    .expect("Kernel path not found in VM config")[1],
+            );
+            kernel_path
+        }
+
         async fn assert_no_systemd_stopping_notification(&mut self) {
             tokio::select! {
                 _ = self.systemd_notifier.await_stopping() => {
@@ -522,12 +563,15 @@ mod tests {
     struct TestFixture {
         libvirt_connection: Connect,
         hostos_config: HostOSConfig,
+        guestos_device: NamedTempFile,
         /// Fake libvirt host definition that backs `libvirt_connection`.
         _libvirt_definition: NamedTempFile,
     }
 
     impl TestFixture {
         fn new(hostos_config: HostOSConfig) -> TestFixture {
+            let guestos_device = extract_guestos_image();
+
             let libvirt_definition =
                 NamedTempFile::new().expect("Failed to create libvirt connection");
             std::fs::write(&libvirt_definition, "<node/>").unwrap();
@@ -541,6 +585,7 @@ mod tests {
             TestFixture {
                 libvirt_connection,
                 hostos_config,
+                guestos_device,
                 _libvirt_definition: libvirt_definition,
             }
         }
@@ -559,6 +604,13 @@ mod tests {
                 hostos_config: self.hostos_config.clone(),
                 systemd_notifier: systemd_notifier.clone(),
                 console_tty: Box::new(File::create(console_file.path()).unwrap()),
+                partition_provider: Box::new(
+                    mount::GptPartitionProvider::with_mounter(
+                        self.guestos_device.path().to_path_buf(),
+                        Box::new(mount::testing::ExtractingFilesystemMounter),
+                    )
+                    .unwrap(),
+                ),
             };
 
             // Start the service in the background
@@ -616,6 +668,29 @@ mod tests {
         hostos_config
     }
 
+    fn extract_guestos_image() -> NamedTempFile {
+        let guestos_image_dir = TempDir::new().unwrap();
+        let icos_image_path =
+            std::env::var("ICOS_IMAGE").expect("Could not find ICOS_IMAGE environment variable");
+        assert!(
+            std::process::Command::new("tar")
+                .args(["-xaf", &icos_image_path, "-C"])
+                .arg(guestos_image_dir.path())
+                .status()
+                .unwrap()
+                .success(),
+            "Could not untar image"
+        );
+
+        let guestos_device = NamedTempFile::new().unwrap();
+        std::fs::rename(
+            guestos_image_dir.path().join("disk.img"),
+            guestos_device.path(),
+        )
+        .expect("Could not open guestos device");
+        guestos_device
+    }
+
     #[tokio::test]
     async fn test_run_guest_vm() {
         let fixture = TestFixture::new(valid_hostos_config());
@@ -638,9 +713,11 @@ mod tests {
             "2001:db8::6800:d8ff:fecb:f597",
         ]);
 
-        // Ensure that the config media exists
+        // Ensure that the config media and kernel exist
         let config_media_path = service.get_config_media_path();
         assert!(config_media_path.exists());
+        let kernel_path = service.get_kernel_path();
+        assert!(kernel_path.exists());
 
         nix::sys::signal::raise(SIGTERM).expect("Failed to send SIGTERM");
 

--- a/rs/ic_os/os_tools/hostos_tool/src/guest_vm.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/guest_vm.rs
@@ -217,7 +217,7 @@ impl GuestVmService {
         let vm_config = generate_vm_config(
             &self.hostos_config,
             config_media.path(),
-            &direct_boot.as_ref().map(DirectBoot::to_config),
+            direct_boot.as_ref().map(DirectBoot::to_config),
         )
         .context("Failed to generate GuestOS VM config")?;
 

--- a/rs/ic_os/os_tools/hostos_tool/src/guest_vm.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/guest_vm.rs
@@ -428,7 +428,7 @@ pub async fn run_guest_vm() -> Result<()> {
     service.run(termination_token).await
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "integration_tests"))]
 mod tests {
     use super::*;
     use crate::mount;

--- a/rs/ic_os/os_tools/hostos_tool/src/main.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/main.rs
@@ -9,7 +9,11 @@ use network::systemd::DEFAULT_SYSTEMD_NETWORK_DIR;
 use std::path::Path;
 use utils::to_cidr;
 
+mod boot_args;
+mod guest_direct_boot;
+#[cfg(target_os = "linux")]
 mod guest_vm;
+mod mount;
 mod systemd_notifier;
 
 #[derive(Subcommand)]
@@ -40,14 +44,15 @@ struct HostOSArgs {
     command: Option<Commands>,
 }
 
-#[tokio::main]
-pub async fn main() -> Result<()> {
-    #[cfg(not(target_os = "linux"))]
-    {
-        eprintln!("ERROR: this only runs on Linux.");
-        std::process::exit(1)
-    }
+#[cfg(not(target_os = "linux"))]
+pub fn main() -> Result<()> {
+    eprintln!("ERROR: this only runs on Linux.");
+    std::process::exit(1)
+}
 
+#[tokio::main]
+#[cfg(target_os = "linux")]
+pub async fn main() -> Result<()> {
     let opts = HostOSArgs::parse();
 
     match opts.command {

--- a/rs/ic_os/os_tools/hostos_tool/src/mount.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/mount.rs
@@ -1,0 +1,316 @@
+use anyhow::{Context, Error, Result};
+use async_trait::async_trait;
+use gpt::GptDisk;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use sys_mount::{Mount, MountFlags, UnmountDrop, UnmountFlags};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+// There are two traits here:
+// 1. PartitionProvider (high level): provides access to partitions by UUID
+//    Real implementation: GptPartitionProvider
+//    Mock implementation: MockPartitionProvider
+// 2. Mounter (low level): mounts raw device ranges (offset + length) to filesystem paths
+//    Real implementation: LoopDeviceMounter
+//    Mock implementation: ExtractingFilesystemMounter
+//
+// This separation allows for mocking at different levels.
+// For example, an integration test may want to use the prod GptPartitionProvider with a mock
+// Mounter (to minimize the use of mocks) while a unit-test may want to use MockPartitionProvider
+// (to allow for more fine-grained control).
+
+/// Trait for accessing partitions by UUID from a device
+#[async_trait]
+pub trait PartitionProvider: Send + Sync {
+    /// Mounts a partition by its UUID with specified mount options.
+    ///
+    /// # Arguments
+    /// * `partition_uuid` - UUID of the partition to mount
+    /// * `options` - Mount options like read-only flag
+    ///
+    /// # Returns
+    /// A boxed MountedPartition trait object that provides access to the mounted filesystem.
+    /// The mount is automatically cleaned up when the returned object is dropped.
+    async fn mount_partition(
+        &self,
+        partition_uuid: Uuid,
+        options: MountOptions,
+    ) -> Result<Box<dyn MountedPartition>>;
+}
+
+/// Handles mounting raw device ranges (offset + length) to filesystem paths
+#[async_trait]
+pub trait Mounter: Send + Sync {
+    /// Mounts a range of bytes from a block device to a filesystem path.
+    ///
+    /// # Arguments
+    /// * `device` - Path to the block device containing the filesystem
+    /// * `offset_bytes` - Offset in bytes where the filesystem starts within the device
+    /// * `len_bytes` - Length of the filesystem in bytes
+    /// * `options` - Mount options like read-only flag
+    ///
+    /// # Returns
+    /// A boxed MountedPartition trait object that provides access to the mounted filesystem.
+    /// The mount is automatically cleaned up when the returned object is dropped.
+    async fn mount_range(
+        &self,
+        device: PathBuf,
+        offset_bytes: u64,
+        len_bytes: u64,
+        options: MountOptions,
+    ) -> Result<Box<dyn MountedPartition>>;
+}
+
+#[derive(Copy, Clone)]
+pub struct MountOptions {
+    /// Whether to mount the partition read-only
+    pub readonly: bool,
+}
+
+/// Represents a mounted partition with access to its filesystem.
+/// `MountedPartition` uses RAII to represent the mount. Dropping the object cleans up the mount.
+pub trait MountedPartition: Send + Sync {
+    fn mount_point(&self) -> &Path;
+}
+
+/// GPT-aware partition provider that can mount partitions by UUID
+pub struct GptPartitionProvider {
+    device: PathBuf,
+    gpt: GptDisk<File>,
+    mounter: Box<dyn Mounter>,
+}
+
+impl GptPartitionProvider {
+    pub fn new(device: PathBuf) -> Result<Self> {
+        #[cfg(target_os = "linux")]
+        return Self::with_mounter(device, Box::new(LoopDeviceMounter));
+
+        #[cfg(not(target_os = "linux"))]
+        anyhow::bail!("This only works on Linux.")
+    }
+
+    pub fn with_mounter(device: PathBuf, mounter: Box<dyn Mounter>) -> Result<Self> {
+        let gpt = gpt::disk::read_disk(&device).context("Could not read GPT from device")?;
+        Ok(Self {
+            device,
+            gpt,
+            mounter,
+        })
+    }
+}
+
+#[async_trait]
+impl PartitionProvider for GptPartitionProvider {
+    async fn mount_partition(
+        &self,
+        partition_uuid: Uuid,
+        options: MountOptions,
+    ) -> Result<Box<dyn MountedPartition>> {
+        let partition = self
+            .gpt
+            .partitions()
+            .iter()
+            .map(|(_, partition)| partition)
+            .find(|partition| partition.part_guid == partition_uuid)
+            .with_context(|| format!("Could not find partition {partition_uuid}"))?;
+
+        let offset_bytes = partition.bytes_start(*self.gpt.logical_block_size())?;
+        let len_bytes = partition.bytes_len(*self.gpt.logical_block_size())?;
+
+        self.mounter
+            .mount_range(self.device.clone(), offset_bytes, len_bytes, options)
+            .await
+    }
+}
+
+/// Real filesystem mount using system mount with loop device
+#[cfg(target_os = "linux")]
+struct LoopDeviceMount {
+    // Field order matters: mount must be dropped before tempdir
+    // According to the Rust spec, fields are dropped in the order of declaration.
+    mount: UnmountDrop<Mount>,
+    _tempdir: TempDir,
+}
+
+#[cfg(target_os = "linux")]
+impl MountedPartition for LoopDeviceMount {
+    fn mount_point(&self) -> &Path {
+        self.mount.target_path()
+    }
+}
+
+/// Production filesystem mounter using real system mounts
+#[cfg(target_os = "linux")]
+pub struct LoopDeviceMounter;
+
+#[cfg(target_os = "linux")]
+#[async_trait]
+impl Mounter for LoopDeviceMounter {
+    async fn mount_range(
+        &self,
+        device: PathBuf,
+        offset_bytes: u64,
+        _len_bytes: u64,
+        options: MountOptions,
+    ) -> Result<Box<dyn MountedPartition>> {
+        let mount = tokio::task::spawn_blocking(move || {
+            let tempdir = TempDir::new()?;
+            let target = tempdir.path();
+            Ok::<LoopDeviceMount, Error>(LoopDeviceMount {
+                mount: Mount::builder()
+                    .loopback_offset(offset_bytes)
+                    .flags(if options.readonly {
+                        MountFlags::RDONLY
+                    } else {
+                        MountFlags::empty()
+                    })
+                    .explicit_loopback()
+                    .mount_autodrop(device, target, UnmountFlags::empty())?,
+                _tempdir: tempdir,
+            })
+        })
+        .await??;
+        Ok(Box::new(mount))
+    }
+}
+
+#[cfg(test)]
+pub mod testing {
+    use super::*;
+    use anyhow::{bail, ensure, Context};
+    use partition_tools::ext::ExtPartition;
+    use partition_tools::fat::FatPartition;
+    use partition_tools::Partition;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::process::Command;
+
+    /// Test partition provider that uses pre-populated directories
+    pub struct MockPartitionProvider {
+        pub partitions: HashMap<Uuid, Arc<TempDir>>,
+    }
+
+    impl MockPartitionProvider {
+        pub fn new(partitions: HashMap<Uuid, Arc<TempDir>>) -> Self {
+            Self { partitions }
+        }
+    }
+
+    #[async_trait]
+    impl PartitionProvider for MockPartitionProvider {
+        async fn mount_partition(
+            &self,
+            partition_uuid: Uuid,
+            options: MountOptions,
+        ) -> Result<Box<dyn MountedPartition>> {
+            let partition_dir = self
+                .partitions
+                .get(&partition_uuid)
+                .with_context(|| format!("Could not find partition {partition_uuid}"))?;
+
+            if options.readonly {
+                ensure!(
+                    Command::new("chmod")
+                        .arg("-R")
+                        .arg("-w")
+                        .arg(partition_dir.path())
+                        .status()
+                        .await?
+                        .success(),
+                    "Could not chmod directory"
+                );
+            }
+
+            Ok(Box::new(MockMount {
+                mount_point: partition_dir.clone(),
+            }))
+        }
+    }
+
+    /// Mock mounted partition backed by a temporary directory
+    struct MockMount {
+        mount_point: Arc<TempDir>,
+    }
+
+    impl MountedPartition for MockMount {
+        fn mount_point(&self) -> &Path {
+            self.mount_point.path()
+        }
+    }
+
+    /// Filesystem mounter for testing that extracts partition contents to temp directories.
+    /// This is an alternative to real filesystem mounts when mounts are not possible (e.g. limited
+    /// permissions in tests).
+    pub struct ExtractingFilesystemMounter;
+
+    #[async_trait]
+    impl Mounter for ExtractingFilesystemMounter {
+        async fn mount_range(
+            &self,
+            device: PathBuf,
+            offset_bytes: u64,
+            len_bytes: u64,
+            options: MountOptions,
+        ) -> Result<Box<dyn MountedPartition>> {
+            async fn extract_partition<P: Partition>(
+                device: &Path,
+                offset_bytes: u64,
+                len_bytes: u64,
+                target: &Path,
+            ) -> Result<()> {
+                P::open_range(device.to_path_buf(), offset_bytes, len_bytes)
+                    .await?
+                    .copy_files_to(target)
+                    .await
+                    .context("Could not copy files to tempdir")
+            }
+
+            let extraction_dir = TempDir::new().context("Could not create tempdir")?;
+
+            // Try to extract as FAT first, then EXT
+            if let Err(fat_err) = extract_partition::<FatPartition>(
+                &device,
+                offset_bytes,
+                len_bytes,
+                extraction_dir.path(),
+            )
+            .await
+            {
+                if let Err(ext_err) = extract_partition::<ExtPartition>(
+                    &device,
+                    offset_bytes,
+                    len_bytes,
+                    extraction_dir.path(),
+                )
+                .await
+                {
+                    bail!(
+                        "Could not open device as either FAT or EXT partition. \
+                         FAT error: {fat_err}, EXT error: {ext_err}"
+                    )
+                }
+            }
+
+            if options.readonly {
+                ensure!(
+                    Command::new("chmod")
+                        .arg("-R")
+                        .arg("-w")
+                        .arg(extraction_dir.path())
+                        .status()
+                        .await?
+                        .success(),
+                    "Could not chmod directory"
+                );
+            }
+
+            Ok(Box::new(MockMount {
+                mount_point: Arc::new(extraction_dir),
+            }))
+        }
+    }
+}

--- a/rs/ic_os/os_tools/hostos_tool/src/systemd_notifier.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/systemd_notifier.rs
@@ -32,7 +32,7 @@ impl SystemdNotifier for DefaultSystemdNotifier {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "integration_tests"))]
 pub(crate) mod testing {
     use super::*;
     use tokio::sync::watch::{channel, Receiver, Sender};

--- a/rs/ic_os/os_tools/hostos_tool/src/systemd_notifier.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/systemd_notifier.rs
@@ -66,12 +66,18 @@ pub(crate) mod testing {
 
     impl SystemdNotifier for MockSystemdNotifier {
         fn notify_ready(&self) -> Result<()> {
-            self.ready.0.send(true).unwrap();
+            self.ready
+                .0
+                .send(true)
+                .expect("Failed to send ready notification");
             Ok(())
         }
 
         fn notify_stopping(&self, _status: &str) -> Result<()> {
-            self.stopping.0.send(true).unwrap();
+            self.stopping
+                .0
+                .send(true)
+                .expect("Failed to send stopping notification");
             Ok(())
         }
     }


### PR DESCRIPTION
This PR adds support for QEMU direct boot and adds SEV config options to the VM XML config when SEV is enabled in the HostOSConfig. QEMU direct boot is enabled regardless of the config.

Since direct boot will skip the GRUB bootloader, the logic from the existing GuestOS grub.cfg was moved into the HostOS VM runner (`prepare_direct_boot` in `guest_direct_boot.rs`). The code mounts the grub and boot partitions of the guest, updates the grubenv, extracts the necessary files and kernel command line and returns these.

An interesting complication is that older GuestOS releases don't have the boot_args file and so don't support direct boot. In this case we need to fall back to booting with GRUB. In this case, we must not update the grubenv, since the GRUB bootloader will update it again and it's a not idempotent.

To support testing, there is a `mount` module which contains abstractions for mounting and mocking the contents of the GuestOS disk.
