### PR TITLE
feat(ic-admin): Use canister_ranges_ keys to read routing table

### DIFF
--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -79,7 +79,9 @@ use ic_protobuf::registry::{
     node_rewards::v2::{NodeRewardRate, UpdateNodeRewardsTableProposalPayload},
     provisional_whitelist::v1::ProvisionalWhitelist as ProvisionalWhitelistProto,
     replica_version::v1::{BlessedReplicaVersions, ReplicaVersionRecord},
-    routing_table::v1::{CanisterMigrations, RoutingTable},
+    routing_table::v1::{
+        routing_table::Entry as RoutingTableEntry, CanisterMigrations, RoutingTable,
+    },
     subnet::v1::{SubnetListRecord, SubnetRecord as SubnetRecordProto},
     unassigned_nodes_config::v1::UnassignedNodesConfigRecord,
 };
@@ -95,20 +97,17 @@ use ic_registry_keys::{
     make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key,
     make_data_center_record_key, make_firewall_config_record_key, make_firewall_rules_record_key,
     make_node_operator_record_key, make_node_record_key, make_provisional_whitelist_record_key,
-    make_replica_version_key, make_routing_table_record_key, make_subnet_list_record_key,
-    make_subnet_record_key, make_unassigned_nodes_config_record_key, FirewallRulesScope,
-    API_BOUNDARY_NODE_RECORD_KEY_PREFIX, NODE_OPERATOR_RECORD_KEY_PREFIX, NODE_RECORD_KEY_PREFIX,
-    NODE_REWARDS_TABLE_KEY, ROOT_SUBNET_ID_KEY,
+    make_replica_version_key, make_subnet_list_record_key, make_subnet_record_key,
+    make_unassigned_nodes_config_record_key, FirewallRulesScope,
+    API_BOUNDARY_NODE_RECORD_KEY_PREFIX, CANISTER_RANGES_PREFIX, NODE_OPERATOR_RECORD_KEY_PREFIX,
+    NODE_RECORD_KEY_PREFIX, NODE_REWARDS_TABLE_KEY, ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_local_store::{
     Changelog, ChangelogEntry, KeyMutation, LocalStoreImpl, LocalStoreWriter,
 };
 use ic_registry_nns_data_provider::registry::RegistryCanister;
 use ic_registry_nns_data_provider_wrappers::{CertifiedNnsDataProvider, NnsDataProvider};
-use ic_registry_routing_table::{
-    CanisterIdRange, CanisterMigrations as OtherCanisterMigrations,
-    RoutingTable as OtherRoutingTable,
-};
+use ic_registry_routing_table::{CanisterIdRange, CanisterMigrations as OtherCanisterMigrations};
 use ic_registry_transport::Error;
 use ic_sns_init::pb::v1::SnsInitPayload; // To validate CreateServiceNervousSystem.
 use ic_sns_wasm::pb::v1::{
@@ -117,7 +116,7 @@ use ic_sns_wasm::pb::v1::{
 };
 use ic_types::{
     crypto::{threshold_sig::ThresholdSigPublicKey, KeyPurpose},
-    CanisterId, NodeId, PrincipalId, RegistryVersion, SubnetId,
+    subnet_id_try_from_protobuf, CanisterId, NodeId, PrincipalId, RegistryVersion, SubnetId,
 };
 use indexmap::IndexMap;
 use itertools::izip;
@@ -3966,12 +3965,7 @@ async fn main() {
             .await;
         }
         SubCommand::GetRoutingTable => {
-            print_and_get_last_value::<RoutingTable>(
-                make_routing_table_record_key().as_bytes().to_vec(),
-                &registry_canister,
-                opts.json,
-            )
-            .await;
+            print_routing_table(reachable_nns_urls);
         }
         SubCommand::GetEcdsaSigningSubnets => {
             let registry_client = make_registry_client(
@@ -5029,25 +5023,6 @@ async fn print_and_get_last_value<T: Message + Default + serde::Serialize>(
                 registry.records.push(record);
 
                 println!("{}", serde_json::to_string_pretty(&registry).unwrap());
-            } else if key == b"routing_table" {
-                let value = OtherRoutingTable::try_from(
-                    RoutingTable::decode(&bytes[..]).expect("Error decoding value from registry."),
-                )
-                .unwrap();
-                println!("Routing table. Most recent version is {:?}.\n", version);
-                for (range, subnet) in value.into_iter() {
-                    println!("Subnet: {}", subnet);
-                    println!(
-                        "    Range start: {} (0x{})",
-                        range.start,
-                        hex::encode(range.start.get_ref().as_slice())
-                    );
-                    println!(
-                        "    Range end:   {} (0x{})",
-                        range.end,
-                        hex::encode(range.end.get_ref().as_slice())
-                    );
-                }
             } else if key == b"canister_migrations" {
                 let value = OtherCanisterMigrations::try_from(
                     CanisterMigrations::decode(&bytes[..])
@@ -5702,6 +5677,82 @@ fn get_api_boundary_node_ids(nns_url: Vec<Url>) -> Vec<String> {
         })
         .collect::<Vec<_>>();
     records
+}
+
+fn print_routing_table(nns_urls: Vec<Url>) -> Vec<(SubnetId, CanisterIdRange)> {
+    let registry_client = RegistryClientImpl::new(
+        Arc::new(NnsDataProvider::new(
+            tokio::runtime::Handle::current(),
+            nns_urls,
+        )),
+        None,
+    );
+
+    registry_client
+        .try_polling_latest_version(usize::MAX)
+        .unwrap();
+
+    let latest_version = registry_client.get_latest_version();
+
+    println!("Routing table. Most recent version is {}", latest_version);
+
+    let keys = registry_client
+        .get_key_family(CANISTER_RANGES_PREFIX, latest_version)
+        .unwrap();
+
+    for routing_table_key in keys.iter() {
+        let routing_table_value = registry_client
+            .get_versioned_value(routing_table_key, latest_version)
+            .unwrap()
+            .value
+            .unwrap();
+        let routing_table = RoutingTable::decode(&routing_table_value[..]).unwrap();
+
+        for RoutingTableEntry { range, subnet_id } in routing_table.entries {
+            let subnet_id = subnet_id_try_from_protobuf(
+                subnet_id.expect("subnet_id is missing from routing table entry"),
+            )
+            .unwrap();
+            println!("Subnet: {}", subnet_id);
+            let range = CanisterIdRange::try_from(
+                range.expect("range is missing from routing table entry"),
+            )
+            .expect("failed to parse range");
+            println!(
+                "    Range start: {} (0x{})",
+                range.start,
+                hex::encode(range.start.get_ref().as_slice())
+            );
+            println!(
+                "    Range end:   {} (0x{})",
+                range.end,
+                hex::encode(range.end.get_ref().as_slice())
+            );
+        }
+    }
+
+    keys.iter()
+        .flat_map(|key| {
+            let value = registry_client
+                .get_versioned_value(key, latest_version)
+                .unwrap()
+                .value
+                .unwrap();
+            let routing_table = RoutingTable::decode(&value[..]).unwrap();
+            routing_table.entries
+        })
+        .map(|RoutingTableEntry { range, subnet_id }| {
+            let subnet_id = subnet_id_try_from_protobuf(
+                subnet_id.expect("subnet_id is missing from routing table entry"),
+            )
+            .unwrap();
+            let range = CanisterIdRange::try_from(
+                range.expect("range is missing from routing table entry"),
+            )
+            .expect("failed to parse range");
+            (subnet_id, range)
+        })
+        .collect()
 }
 
 /// Writes a threshold signing public key to the given path.


### PR DESCRIPTION
# Why

We are switching from a monolithic routing table to multiple smaller registry entries. This PR changes ic-admin from reading to the old value to the new ones.

# What

* Use `NnsDataProvider` to poll registry entries, select the keys through `get_key_family`, and read the values based on the keys.

# Tested

The `ic-admin get-routing-table` yields the exact same result before and after the change.
