### PR TITLE
chore: Bump tempfile version to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -734,7 +734,7 @@ subtle = "2.6.1"
 syn = { version = "1.0.109", features = ["fold", "full"] }
 systemd = "0.10"
 tar = "0.4.39"
-tempfile = "3.12.0"
+tempfile = "3.20"
 thiserror = "2.0.3"
 threadpool = "1.8.1"
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1318,7 +1318,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 ],
             ),
             "tempfile": crate.spec(
-                version = "^3.12.0",
+                version = "3.20",
             ),
             "tester": crate.spec(
                 version = "^0.7.0",

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -138,7 +138,7 @@ impl PocketIcState {
     pub fn into_path(self) -> PathBuf {
         match self.state {
             PocketIcStateKind::StateDir(state_dir) => state_dir,
-            PocketIcStateKind::TempDir(temp_dir) => temp_dir.into_path(),
+            PocketIcStateKind::TempDir(temp_dir) => temp_dir.keep(),
         }
     }
 

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -2593,7 +2593,7 @@ fn state_handle() {
     assert!(pic.canister_exists(canister_id));
     let state = pic.drop_and_take_state().unwrap();
 
-    let path = state.into_path();
+    let path = state.keep();
     let state = PocketIcState::new_from_path(path);
 
     let pic1 = PocketIcBuilder::new().with_read_only_state(&state).build();
@@ -2619,7 +2619,7 @@ async fn state_handle_async() {
     assert!(pic.canister_exists(canister_id).await);
     let state = pic.drop_and_take_state().await.unwrap();
 
-    let path = state.into_path();
+    let path = state.keep();
     let state = PocketIcState::new_from_path(path);
 
     let pic1 = PocketIcBuilder::new()

--- a/rs/orchestrator/src/registration.rs
+++ b/rs/orchestrator/src/registration.rs
@@ -990,7 +990,7 @@ mod tests {
                 }
 
                 let local_store = Arc::new(LocalStoreImpl::new(temp_dir.as_ref()));
-                let node_config = Config::new(temp_dir.into_path());
+                let node_config = Config::new(temp_dir.keep());
 
                 let node_registration = NodeRegistration::new(
                     self.logger.unwrap_or_else(no_op_logger),

--- a/rs/orchestrator/src/upgrade.rs
+++ b/rs/orchestrator/src/upgrade.rs
@@ -351,7 +351,7 @@ impl Upgrade {
                 let downloader = FileDownloader::new(Some(self.logger.clone()));
                 let local_store_location = tempfile::tempdir()
                     .expect("temporary location for local store download could not be created")
-                    .into_path();
+                    .keep();
                 downloader
                     .download_and_extract_tar(
                         &registry_store_uri.uri,

--- a/rs/registry/admin/src/main.rs
+++ b/rs/registry/admin/src/main.rs
@@ -3905,7 +3905,7 @@ async fn main() {
             let mut success = true;
 
             eprintln!("Download IC-OS .. ");
-            let tmp_dir = tempfile::tempdir().unwrap().into_path();
+            let tmp_dir = tempfile::tempdir().unwrap().keep();
             let mut tmp_file = tmp_dir.clone();
             tmp_file.push("temp-image");
 
@@ -5637,7 +5637,7 @@ async fn download_wasm_module(url: &Url) -> PathBuf {
         panic!("Wasm module urls must use https");
     }
 
-    let tmp_dir = tempfile::tempdir().unwrap().into_path();
+    let tmp_dir = tempfile::tempdir().unwrap().keep();
     let mut tmp_file = tmp_dir.clone();
     tmp_file.push("wasm_module.tar.gz");
 

--- a/rs/replicated_state/src/page_map/storage/tests.rs
+++ b/rs/replicated_state/src/page_map/storage/tests.rs
@@ -716,7 +716,7 @@ pub fn write_overlays_and_verify(instructions: Vec<Instruction>) {
 #[doc(hidden)]
 #[cfg(feature = "fuzzing_code")]
 fn remove_tempdir(tdir: TempDir) {
-    let tmp_path = tdir.into_path();
+    let tmp_path = tdir.keep();
     std::fs::remove_dir_all(tmp_path).expect("Unable to delete temporary directoy");
 }
 

--- a/rs/sns/testing/src/bin/init.rs
+++ b/rs/sns/testing/src/bin/init.rs
@@ -19,7 +19,7 @@ async fn nns_init(args: NnsInitArgs) {
             "Using temporary PocketIC state directory: {}",
             tempdir.path().display()
         );
-        tempdir.into_path()
+        tempdir.keep()
     };
     let mut pocket_ic = PocketIcBuilder::new()
         .with_server_url(args.server_url)

--- a/rs/tests/consensus/utils/src/upgrade.rs
+++ b/rs/tests/consensus/utils/src/upgrade.rs
@@ -58,7 +58,7 @@ pub async fn fetch_update_file_sha256_with_retry(log: &Logger, version_str: &str
 
 pub async fn fetch_update_file_sha256(version_str: &str) -> Result<String, String> {
     let sha_url = get_public_update_image_sha_url(version_str);
-    let tmp_dir = tempfile::tempdir().unwrap().into_path();
+    let tmp_dir = tempfile::tempdir().unwrap().keep();
     let mut tmp_file = tmp_dir.clone();
     tmp_file.push("SHA256.txt");
 

--- a/rs/tests/idx/test_driver_tests.rs
+++ b/rs/tests/idx/test_driver_tests.rs
@@ -53,7 +53,7 @@ fn create_unique_working_dir() -> PathBuf {
         .prefix(prefix_path.as_os_str())
         .tempdir()
         .unwrap()
-        .into_path();
+        .keep();
     // Test driver assumes that "root_env" dir already exists prior to starting execution.
     std::fs::create_dir(path.join("root_env")).unwrap();
     path


### PR DESCRIPTION
There were different version specs in `Cargo.toml` and `external_crates.bzl` which led to different versions being used by clippy and Bazel. `TempDir::into_path` got deprecated in recent versions while the replacement `TempDir::keep` was not available in older versions. Because of this, one would get compile errors / clippy warnings no matter which method was used.