### PR TITLE
perf(download): Perform longest prefix matching in FileDownloader

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3841f6966cf5c5fcaeeb0a85cb7e9b7bd9fee5b078e19ac41171f6288de10214",
+  "checksum": "272ae7da0046954788cbd16b5ad1115d02ed1ca7ee5968378fa1f50e52541877",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20762,7 +20762,7 @@
               "target": "lmdb_sys"
             },
             {
-              "id": "local-ip-address 0.5.6",
+              "id": "local-ip-address 0.6.5",
               "target": "local_ip_address"
             },
             {
@@ -21330,6 +21330,10 @@
             {
               "id": "tower-request-id 0.3.0",
               "target": "tower_request_id"
+            },
+            {
+              "id": "tower-service 0.3.3",
+              "target": "tower_service"
             },
             {
               "id": "tower-test 0.4.0",
@@ -43542,14 +43546,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "local-ip-address 0.5.6": {
+    "local-ip-address 0.6.5": {
       "name": "local-ip-address",
-      "version": "0.5.6",
-      "package_url": "https://github.com/EstebanBorai/local-ip-address",
+      "version": "0.6.5",
+      "package_url": "https://github.com/LeoBorai/local-ip-address",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/local-ip-address/0.5.6/download",
-          "sha256": "66357e687a569abca487dc399a9c9ac19beb3f13991ed49f00c144e02cbd42ab"
+          "url": "https://static.crates.io/crates/local-ip-address/0.6.5/download",
+          "sha256": "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
         }
       },
       "targets": [
@@ -43574,7 +43578,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.68",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             }
           ],
@@ -43593,14 +43597,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.5.6"
+        "version": "0.6.5"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -92696,7 +92700,7 @@
     "little-loadshedder 0.2.0",
     "lmdb-rkv 0.14.99",
     "lmdb-rkv-sys 0.11.99",
-    "local-ip-address 0.5.6",
+    "local-ip-address 0.6.5",
     "lru 0.7.8",
     "macaddr 1.0.1",
     "maplit 1.0.2",
@@ -92845,6 +92849,7 @@
     "tower 0.5.2",
     "tower-http 0.6.4",
     "tower-request-id 0.3.0",
+    "tower-service 0.3.3",
     "tower-test 0.4.0",
     "tower_governor 0.7.0",
     "tracing 0.1.41",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -3718,6 +3718,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http 0.6.4",
  "tower-request-id",
+ "tower-service",
  "tower-test",
  "tower_governor",
  "tracing",
@@ -7513,14 +7514,14 @@ dependencies = [
 
 [[package]]
 name = "local-ip-address"
-version = "0.5.6"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66357e687a569abca487dc399a9c9ac19beb3f13991ed49f00c144e02cbd42ab"
+checksum = "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
 dependencies = [
  "libc",
  "neli",
- "thiserror 1.0.68",
- "windows-sys 0.48.0",
+ "thiserror 2.0.12",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "05d485921c31888d77218f9167a7b2740c9d733ae271a9db5c20c29fdc9a5672",
+  "checksum": "dfdc98ef8e9f5d29d5b185dae6876d643fb0f782332b44faf583bda311ea45e9",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20580,7 +20580,7 @@
               "target": "lmdb_sys"
             },
             {
-              "id": "local-ip-address 0.5.6",
+              "id": "local-ip-address 0.6.5",
               "target": "local_ip_address"
             },
             {
@@ -21148,6 +21148,10 @@
             {
               "id": "tower-request-id 0.3.0",
               "target": "tower_request_id"
+            },
+            {
+              "id": "tower-service 0.3.3",
+              "target": "tower_service"
             },
             {
               "id": "tower-test 0.4.0",
@@ -43374,14 +43378,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "local-ip-address 0.5.6": {
+    "local-ip-address 0.6.5": {
       "name": "local-ip-address",
-      "version": "0.5.6",
-      "package_url": "https://github.com/EstebanBorai/local-ip-address",
+      "version": "0.6.5",
+      "package_url": "https://github.com/LeoBorai/local-ip-address",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/local-ip-address/0.5.6/download",
-          "sha256": "66357e687a569abca487dc399a9c9ac19beb3f13991ed49f00c144e02cbd42ab"
+          "url": "https://static.crates.io/crates/local-ip-address/0.6.5/download",
+          "sha256": "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
         }
       },
       "targets": [
@@ -43406,7 +43410,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.68",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             }
           ],
@@ -43425,14 +43429,14 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.48.0",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.5.6"
+        "version": "0.6.5"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -92661,7 +92665,7 @@
     "little-loadshedder 0.2.0",
     "lmdb-rkv 0.14.99",
     "lmdb-rkv-sys 0.11.99",
-    "local-ip-address 0.5.6",
+    "local-ip-address 0.6.5",
     "lru 0.7.8",
     "macaddr 1.0.1",
     "maplit 1.0.2",
@@ -92810,6 +92814,7 @@
     "tower 0.5.2",
     "tower-http 0.6.4",
     "tower-request-id 0.3.0",
+    "tower-service 0.3.3",
     "tower-test 0.4.0",
     "tower_governor 0.7.0",
     "tracing 0.1.41",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3707,6 +3707,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http 0.6.4",
  "tower-request-id",
+ "tower-service",
  "tower-test",
  "tower_governor",
  "tracing",
@@ -7504,14 +7505,14 @@ dependencies = [
 
 [[package]]
 name = "local-ip-address"
-version = "0.5.6"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66357e687a569abca487dc399a9c9ac19beb3f13991ed49f00c144e02cbd42ab"
+checksum = "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
 dependencies = [
  "libc",
  "neli",
- "thiserror 1.0.68",
- "windows-sys 0.48.0",
+ "thiserror 2.0.12",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9411,15 +9411,18 @@ dependencies = [
  "flate2",
  "hex",
  "http 1.3.1",
+ "hyper-util",
  "ic-crypto-sha2",
  "ic-logger",
  "ic-test-utilities-in-memory-logger",
+ "local-ip-address",
  "mockito",
  "reqwest 0.12.15",
  "slog",
  "tar",
  "tempfile",
  "tokio",
+ "tower-service",
  "zstd",
 ]
 
@@ -16483,14 +16486,14 @@ dependencies = [
 
 [[package]]
 name = "local-ip-address"
-version = "0.5.7"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612ed4ea9ce5acfb5d26339302528a5e1e59dfed95e9e11af3c083236ff1d15d"
+checksum = "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
 dependencies = [
  "libc",
  "neli",
- "thiserror 1.0.69",
- "windows-sys 0.48.0",
+ "thiserror 2.0.12",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -631,7 +631,7 @@ leb128 = "0.2.5"
 libc = "0.2.158"
 libflate = "2.1.0"
 libnss = "0.5.0"
-local-ip-address = "0.5.6"
+local-ip-address = "0.6.5"
 macaddr = "1.0"
 memmap2 = "0.9.5"
 minicbor = { version = "0.19.1", features = ["alloc", "derive"] }
@@ -761,6 +761,7 @@ tower-http = { version = "0.6.4", features = [
     "compression-full",
     "tracing",
 ] }
+tower-service = "0.3.3"
 tracing = "0.1.41"
 tracing-appender = "0.2.3"
 tracing-opentelemetry = "0.28.0"

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -813,7 +813,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 default_features = False,
             ),
             "local-ip-address": crate.spec(
-                version = "^0.5.6",
+                version = "^0.6.5",
             ),
             "lru": crate.spec(
                 version = "^0.7.8",
@@ -1419,6 +1419,9 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
             ),
             "tower-request-id": crate.spec(
                 version = "^0.3.0",
+            ),
+            "tower-service": crate.spec(
+                version = "^0.3.3",
             ),
             "tower-test": crate.spec(
                 version = "^0.4.0",

--- a/rs/http_utils/BUILD.bazel
+++ b/rs/http_utils/BUILD.bazel
@@ -10,10 +10,13 @@ DEPENDENCIES = [
     "@crate_index//:flate2",
     "@crate_index//:hex",
     "@crate_index//:http",
+    "@crate_index//:hyper-util",
+    "@crate_index//:local-ip-address",
     "@crate_index//:reqwest",
     "@crate_index//:slog",
     "@crate_index//:tar",
     "@crate_index//:tokio",
+    "@crate_index//:tower-service",
     "@crate_index//:zstd",
 ]
 

--- a/rs/http_utils/Cargo.toml
+++ b/rs/http_utils/Cargo.toml
@@ -10,12 +10,15 @@ documentation.workspace = true
 flate2 = { workspace = true }
 hex = { workspace = true }
 http = { workspace = true }
+hyper-util = { workspace = true }
 ic-crypto-sha2 = { path = "../crypto/sha2" }
 ic-logger = { path = "../monitoring/logger" }
+local-ip-address = { workspace = true }
 reqwest = { workspace = true }
 slog = { workspace = true }
 tar = { workspace = true }
 tokio = { workspace = true }
+tower-service = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]

--- a/rs/http_utils/src/lib.rs
+++ b/rs/http_utils/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod file_downloader;
+mod prefix_match_resolver;

--- a/rs/http_utils/src/prefix_match_resolver.rs
+++ b/rs/http_utils/src/prefix_match_resolver.rs
@@ -1,0 +1,213 @@
+use hyper_util::client::legacy::connect::dns::GaiResolver;
+use reqwest::dns::{Name, Resolve, Resolving};
+use std::{
+    cmp,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+};
+use tower_service::Service;
+
+pub(crate) struct LongestPrefixMatchResolver(GaiResolver);
+
+impl LongestPrefixMatchResolver {
+    pub fn new() -> Self {
+        Self(GaiResolver::new())
+    }
+}
+
+/// This resolver is used to resolve domain names and sort the resulting IP addresses by longest
+/// prefix match. It first uses the default `GaiResolver` before applying the sorting logic. It
+/// prioritizes IPv6 addresses over IPv4 addresses.
+impl Resolve for LongestPrefixMatchResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let mut this = self.0.clone();
+
+        Box::pin(async move {
+            // Resolve with `GaiResolver`, which is the default resolver in reqwest.
+            let resolved_addrs = this
+                .call(name.as_str().parse()?)
+                .await?
+                .map(|saddr| saddr.ip())
+                .collect::<Vec<_>>();
+
+            let local_addrs = local_ip_address::list_afinet_netifas()?
+                .into_iter()
+                .map(|(_, ip)| ip)
+                .collect::<Vec<_>>();
+            // Sort the resolved addresses by longest prefix match, putting IPv6 addresses first
+            let sorted_sock_addrs = sort_by_longest_prefix_match(resolved_addrs, local_addrs)
+                .into_iter()
+                .map(|addr| SocketAddr::new(addr, 0));
+
+            Ok(Box::new(sorted_sock_addrs) as Box<dyn Iterator<Item = SocketAddr> + Send>)
+        })
+    }
+}
+
+/// Returns the same set of given resolved IP addresses, but with all IPv6 addresses first, then all
+/// IPv4 addresses each respectively sorted by longest prefix match, with respect to the given local
+/// IP addresses.
+fn sort_by_longest_prefix_match(
+    resolved_addrs: Vec<IpAddr>,
+    local_addrs: Vec<IpAddr>,
+) -> Vec<IpAddr> {
+    let (mut resolved_v4s, mut resolved_v6s) = grouped_by_prot(
+        resolved_addrs,
+        true, // Keep resolved loopback addresses (in case of localhost resolution, f.ex.)
+    );
+
+    let (local_v4s, local_v6s) = grouped_by_prot(
+        local_addrs,
+        false, // Do not match loopback addresses
+    );
+
+    resolved_v4s.sort_by_key(|resolved_v4| {
+        cmp::Reverse(
+            local_v4s
+                .iter()
+                .map(|client_v4| {
+                    nb_leading_matching_bits(&client_v4.octets(), &resolved_v4.octets())
+                })
+                .max(),
+        )
+    });
+    resolved_v6s.sort_by_key(|resolved_v6| {
+        cmp::Reverse(
+            local_v6s
+                .iter()
+                .map(|client_v6| {
+                    nb_leading_matching_bits(&client_v6.octets(), &resolved_v6.octets())
+                })
+                .max(),
+        )
+    });
+
+    // Return IPv6 then IPv4
+    resolved_v6s
+        .into_iter()
+        .map(IpAddr::V6)
+        .chain(resolved_v4s.into_iter().map(IpAddr::V4))
+        .collect()
+}
+
+/// Splits a vector of IP addresses by protocol, IPv4 and IPv6.
+fn grouped_by_prot(addrs: Vec<IpAddr>, keep_lo: bool) -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
+    let mut v4s = vec![];
+    let mut v6s = vec![];
+
+    for addr in addrs {
+        if !keep_lo && addr.is_loopback() {
+            continue;
+        }
+
+        match addr {
+            IpAddr::V4(v4) => v4s.push(v4),
+            IpAddr::V6(v6) => v6s.push(v6),
+        }
+    }
+
+    (v4s, v6s)
+}
+
+/// Counts the number of matching bits between two slices of bytes.
+fn nb_leading_matching_bits(a: &[u8], b: &[u8]) -> u32 {
+    let mut matching_bits = 0;
+    for (octet_a, octet_b) in a.iter().zip(b.iter()) {
+        let diff = octet_a ^ octet_b;
+        let mut mask = 0x80; // Start with the most significant bit
+
+        for _ in 0..8 {
+            if diff & mask == 0 {
+                matching_bits += 1; // Count matching bits
+            } else {
+                return matching_bits; // Stop at the first non-matching bit
+            }
+            mask >>= 1; // Move to the next bit
+        }
+    }
+
+    matching_bits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nb_leading_matching_bits() {
+        assert_eq!(
+            nb_leading_matching_bits(
+                &Ipv4Addr::new(192, 168, 1, 1).octets(),
+                &Ipv4Addr::new(192, 168, 1, 2).octets()
+            ),
+            30
+        );
+        assert_eq!(
+            nb_leading_matching_bits(
+                &Ipv4Addr::new(192, 168, 1, 1).octets(),
+                &Ipv4Addr::new(64, 168, 1, 1).octets()
+            ),
+            0
+        );
+        assert_eq!(
+            nb_leading_matching_bits(
+                &Ipv6Addr::new(0x2602, 0xfb2b, 0x100, 0x10, 0x0, 0x0, 0x0, 0x0).octets(),
+                &Ipv6Addr::new(0x2602, 0xfb2b, 0x110, 0x10, 0x0, 0x0, 0x0, 0x1).octets()
+            ),
+            43
+        );
+        assert_eq!(
+            nb_leading_matching_bits(
+                &Ipv6Addr::new(0x2a00, 0xfb01, 0x400, 0x42, 0x0, 0x0, 0x0, 0x0).octets(),
+                &Ipv6Addr::new(0x2a00, 0xfb01, 0x400, 0x42, 0xffff, 0x1, 0x2, 0x3).octets()
+            ),
+            64
+        );
+    }
+
+    #[test]
+    fn test_sort_by_longest_prefix_match() {
+        let resolved_addrs = vec![
+            IpAddr::V4(Ipv4Addr::new(13, 107, 246, 60)),
+            IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)),
+            IpAddr::V6(Ipv6Addr::new(0x2603, 0x1010, 0x3, 0x3, 0x0, 0x0, 0x0, 0x5b)),
+            IpAddr::V6(Ipv6Addr::new(
+                0x1234, 0x5678, 0x0, 0x0, 0x0, 0x0, 0x0, 0xabcd,
+            )),
+            IpAddr::V6(Ipv6Addr::new(
+                0x0, 0x0, 0x0, 0x0, 0x0, 0xffff, 0xc0a8, 0x0101,
+            )),
+            IpAddr::V6(Ipv6Addr::new(
+                0xfd12, 0x3456, 0x789a, 0x0, 0x0, 0x0, 0x0, 0x1,
+            )),
+        ];
+        let local_addrs = vec![
+            IpAddr::V4(Ipv4Addr::new(172, 17, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 0, 2, 2)),
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), // will be ignored (loopback)
+            IpAddr::V4(Ipv4Addr::new(192, 168, 122, 1)),
+            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0x1, 0x0, 0x0, 0x0, 0x0, 0x1)),
+            IpAddr::V6(Ipv6Addr::new(0xfd10, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x2)),
+            IpAddr::V6(Ipv6Addr::new(0xfe80, 0x0, 0x0, 0x0, 0xabcd, 0xef, 0x0, 0x1)),
+            IpAddr::V6(Ipv6Addr::new(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1)), // will be ignored
+                                                                               // (loopback)
+        ];
+
+        let sorted_addrs = sort_by_longest_prefix_match(resolved_addrs.clone(), local_addrs);
+
+        assert_eq!(sorted_addrs.len(), resolved_addrs.len());
+
+        // IPv6 addresses should come first
+        // fd12:3456:789a::1 with fd10:0:2::2 (14 bits match)
+        assert_eq!(sorted_addrs[0], resolved_addrs[5]);
+        // 2603:1010:3:3::5b with 2001:db8:1::1 (5 bits match)
+        assert_eq!(sorted_addrs[1], resolved_addrs[2]);
+        // 1234:5678::abcd with 2001:db8:1::1 (2 bits match)
+        assert_eq!(sorted_addrs[2], resolved_addrs[3]);
+        // ::ffff:c0a8:101 with 2001:db8:1::1 (2 bits match)
+        assert_eq!(sorted_addrs[3], resolved_addrs[4]);
+        // 172.16.0.1 with 172.17.0.1 (15 bits match)
+        assert_eq!(sorted_addrs[4], resolved_addrs[1]);
+        // 13.107.246.60 with 10.0.2.2 (5 bits match)
+        assert_eq!(sorted_addrs[5], resolved_addrs[0]);
+    }
+}


### PR DESCRIPTION
After observing increased flakiness in various tests that use `FileDownloader`, one solution that we would like to explore is to perform longest prefix matching in case we receive multiple IP addresses during a DNS resolution, to favour geographically closer upstreams.

This PR implements this. It first resolves the IP addresses using the default `reqwest` DNS resolver, and independently sort IPv6 and IPv4 addresses based on the maximum longest prefix match across all corresponding network interfaces.

Since the underlying code inside `reqwset` [iterates through them in order](https://github.com/hyperium/hyper-util/blob/d8919313fe78f9ec7a9ebb22121d66ab6f0f30a8/src/client/legacy/connect/http.rs#L767-L770), longer prefix matches will be favoured.

The screenshots below show the requests before and after my change. Both tests are the `//rs/tests/message_routing/xnet:xnet_compatibility`, both ran with `--set-required-host-features=dc=zh1`. The first request still contacts an upstream which is not in zh1 because it uses the [mainnet version](https://github.com/dfinity/ic/blob/00713b98279479d7f28a031fb8f8dff7731bd404/rs/tests/message_routing/xnet/xnet_compatibility.rs#L168) (which obviously does not include the change), but the second request this time correctly contacts an upstream in zh1 (`2a00:fb01:400:42:...`, [source](https://github.com/dfinity/ic/blob/00713b98279479d7f28a031fb8f8dff7731bd404/testnet/env/shared-config.yml#L31-L33)). I ran these tests multiple times. Before my change, the resolved IP is not always in the same DC (it varies). In contrast, after my change, the resolved IP is always in zh1.

Before:
<img width="874" alt="image" src="https://github.com/user-attachments/assets/78908c4f-3aa3-4eb6-a28e-8fb6063513a8" />

After (note that the first request, with the mainnet version, is the bottom one):
<img width="718" alt="image" src="https://github.com/user-attachments/assets/57f7fe1b-5888-482f-a0c2-fde2783cd9d8" />

