### PR TITLE
chore(IDX): use catchall subdirectory for zig wrapper build

### DIFF
--- a/bazel/hermetic_cc_toolchain.patch
+++ b/bazel/hermetic_cc_toolchain.patch
@@ -18,7 +18,7 @@ index 409d626..1265298 100644
      # These toolchains are only registered locally.
      dev_dependency = True,
 diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
-index f6f613e..02d5597 100644
+index f6f613e..3f45d85 100644
 --- a/toolchain/defs.bzl
 +++ b/toolchain/defs.bzl
 @@ -60,7 +60,8 @@ def toolchains(
@@ -72,7 +72,27 @@ index f6f613e..02d5597 100644
              },
          )
 
-@@ -230,6 +235,7 @@ zig_repository = repository_rule(
+@@ -148,7 +153,7 @@ def _zig_repository_impl(repository_ctx):
+     cache_prefix = repository_ctx.os.environ.get("HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX", "")
+     if cache_prefix == "":
+         if os == "windows":
+-            cache_prefix = "C:\\\\Temp\\\\zig-cache"
++            fail("windows is not supported")
+         elif os == "macos":
+             cache_prefix = "/var/tmp/zig-cache"
+         elif os == "linux":
+@@ -156,6 +161,10 @@ def _zig_repository_impl(repository_ctx):
+         else:
+             fail("unknown os: {}".format(os))
+
++    # use the catchall config to ensure all builds use a `zig-cache/config-FOO/`
++    # subdirectory, including the zig-wrapper itself
++    cache_prefix = cache_prefix + "/config-catchall"
++
+     repository_ctx.template(
+         "tools/zig-wrapper.zig",
+         Label("//toolchain:zig-wrapper.zig"),
+@@ -230,6 +239,7 @@ zig_repository = repository_rule(
          "host_platform_sha256": attr.string_dict(),
          "url_formats": attr.string_list(allow_empty = False),
          "host_platform_ext": attr.string_dict(),


### PR DESCRIPTION
This modifies our hermetic_cc_toolchain patch to have the zig-wrapper be built with `/tmp/zig-cache/config-catchall` instead of `/tmp/zig-cache`. This prevents the build using different levels of directories and ensures the cache is always nested under `/tmp/zig-cache/config-FOO`.