### PR TITLE
chore: include target labels in bazel profiles

### DIFF
--- a/.github/actions/bazel/bin/bazel
+++ b/.github/actions/bazel/bin/bazel
@@ -76,7 +76,6 @@ if [[ $bazel_command == "build" ]] || [[ $bazel_command == "test" ]]; then
         # This helps analysis tools like https://github.com/EngFlow/bazel_invocation_analyzer
         # break down bottlenecks.
         --experimental_profile_include_target_label
-        --noslim_profile
     )
 
     if [ -n "${BUILDBUDDY_LINKS:-}" ]; then

--- a/.github/actions/bazel/bin/bazel
+++ b/.github/actions/bazel/bin/bazel
@@ -72,6 +72,11 @@ if [[ $bazel_command == "build" ]] || [[ $bazel_command == "test" ]]; then
         # Write build events to the dedicated tempdir
         --build_event_binary_file="$BAZEL_ACTION_METRICS_OUT/bazel-bep-$command_timestamp.pb"
         --profile="$BAZEL_ACTION_METRICS_OUT/profile-$command_timestamp.json"
+        # Associate each action in the profile with a target label.
+        # This helps analysis tools like https://github.com/EngFlow/bazel_invocation_analyzer
+        # break down bottlenecks.
+        --experimental_profile_include_target_label
+        --noslim_profile
     )
 
     if [ -n "${BUILDBUDDY_LINKS:-}" ]; then


### PR DESCRIPTION
Bazel profile analyzers like [EngFlow/bazel_invocation_analyzer](https://github.com/EngFlow/bazel_invocation_analyzer) work better if actions in the profile include target labels. So this enables [`--experimental_profile_include_target_label`](https://bazel.build/reference/command-line-reference#common_options-flag--experimental_profile_include_target_label).

The tool also recommends [`--noslim_profile`](https://bazel.build/reference/command-line-reference#common_options-flag--slim_profile) but that causes the `profile.json` to grow to ~948M which is a tad too excessive.

Running `bazel_invocation_analyzer` on the profile generated by this PR results in:

```
bas@devenv-bas:~/d/bazel_invocation_analyzer$ bazel run //cli -- --mode=all_data,used_data,suggestions ~/profile-1750342458.json
INFO: Analyzed target //cli:cli (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //cli:cli up-to-date:
  bazel-bin/cli/cli
  bazel-bin/cli/cli.jar
INFO: Elapsed time: 0.244s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/cli/cli <args omitted>

Bazel Invocation Analyzer by EngFlow

Analyzing /home/bas/profile-1750342458.json


Suggestion: "Break down bottleneck actions"
These actions are involved in a bottleneck preventing parallelization:
	- Action: "Testing //rs/tests/research:spec_compliance_group_01_system_subnet_test_colocate"
		Target: "//rs/tests/research:spec_compliance_group_01_system_subnet_test_colocate"
		Mnemonic: "TestRunner"
		Action duration: 4m 2s
	- Action: "Testing //rs/tests/consensus:cup_explorer_test"
		Target: "//rs/tests/consensus:cup_explorer_test"
		Mnemonic: "TestRunner"
		Action duration: 3m 58s
		Duration within bottleneck: 3m 58s
	- Action: "Testing //rs/tests/research:spec_compliance_group_02_application_subnet_test_colocate"
		Target: "//rs/tests/research:spec_compliance_group_02_application_subnet_test_colocate"
		Mnemonic: "TestRunner"
		Action duration: 3m 46s
	- Action: "Testing //rs/tests/research:spec_compliance_group_02_system_subnet_test_colocate"
		Target: "//rs/tests/research:spec_compliance_group_02_system_subnet_test_colocate"
		Mnemonic: "TestRunner"
		Action duration: 3m 42s
	- Action: "Testing //rs/tests/research:spec_compliance_application_subnet_test_colocate"
		Target: "//rs/tests/research:spec_compliance_application_subnet_test_colocate"
		Mnemonic: "TestRunner"
		Action duration: 3m 42s
Try breaking them down into smaller actions.
Potential improvement
The duration of the invocation can potentially be reduced by 41.52%.
[.............................XXXXXXXXXXXXXXXXXXXXX]
The initial build time was 9m 39s and could be reduced to 5m 38s.
Rationale
The profile includes a bottleneck lasting 9m 38s with an average action count of 37.80. That's only 58.2% of the estimated maximum of 65 actions that could have been executed in parallel.
Caveats
- Only the 5 longest actions out of 5341 were returned. Try running this tool with --verbose to get more data.


Suggestion: "Investigate remote cache misses"
The following actions with cache misses took the longest to execute:
	- Action: "Compiling Rust bin max_number_of_canisters_test_bin (1 files)"
		Target: "//rs/tests/execution:max_number_of_canisters_test_bin"
		Mnemonic: "Rustc"
		Action duration: 34s
	- Action: "Clippy //rs/tests/networking:canister_http_soak_test_bin"
		Target: "//rs/tests/networking:canister_http_soak_test_bin"
		Mnemonic: "Clippy"
		Action duration: 4536ms
	- Action: "Action bazel/version.txt"
		Target: "//bazel:version.txt"
		Mnemonic: "Action"
		Action duration: 295ms
	- Action: "Action ic-os/components/commit_timestamp_txt"
		Target: "//ic-os/components:commit_timestamp_txt"
		Mnemonic: "Action"
		Action duration: 321ms
Check https://bazel.build/remote/cache-remote#troubleshooting-cache-hits to learn more about how to debug remote cache misses. Increasing the cache hit rate can significantly speed up builds.


Suggestion: "Investigate actions that are not using remote caching"
Some actions did not check the remote cache. Likely the targets the actions were executed for include the tag `no-cache` or `no-remote-cache`. Investigate whether these tags can be removed:
	- Action: "Testing //rs/tests/research:spec_compliance_group_01_system_subnet_test_colocate"
		Target: "//rs/tests/research:spec_compliance_group_01_system_subnet_test_colocate"
		Mnemonic: "TestRunner"
		Action duration: 4m 2s
	- Action: "Testing //rs/tests/consensus:cup_explorer_test"
		Target: "//rs/tests/consensus:cup_explorer_test"
		Mnemonic: "TestRunner"
		Action duration: 3m 58s
	- Action: "Testing //rs/tests/research:spec_compliance_group_02_application_subnet_test_colocate"
		Target: "//rs/tests/research:spec_compliance_group_02_application_subnet_test_colocate"
		Mnemonic: "TestRunner"
		Action duration: 3m 46s
	- Action: "Testing //rs/tests/research:spec_compliance_group_02_system_subnet_test_colocate"
		Target: "//rs/tests/research:spec_compliance_group_02_system_subnet_test_colocate"
		Mnemonic: "TestRunner"
		Action duration: 3m 42s
	- Action: "Testing //rs/tests/research:spec_compliance_application_subnet_test_colocate"
		Target: "//rs/tests/research:spec_compliance_application_subnet_test_colocate"
		Mnemonic: "TestRunner"
		Action duration: 3m 42s
Rationale
The profile suggests remote caching was used, but some actions did not check the remote cache. In most cases, enabling remote caching for actions improves build performance. An example case where using remote caching might not be beneficial is when the outputs are very large and the the cost of downloading them is higher than locally building the target.
Caveats
- Only the 5 longest actions that did not check the remote cache of the 5268 found were listed. Try running this tool with --verbose to get more data.


Suggestion: "Disable merged events in the Bazel profile"
To disable Bazel's default behavior of potentially merging events in the Bazel profile, include the flag --noslim_profile when writing a profile. Run this tool on the new profile for a possibly improved analysis.
Also see https://bazel.build/reference/command-line-reference#flag--slim_profile
Rationale
The analyzed Bazel profile include merged events, which may hide data that this tool could leverage to produce additional or more specific suggestions.
Caveats
- Disabling merged events may increase the size of the Bazel profile significantly.


Data from analysis
ActionStats: A list of bottlenecks, each of which include timing information and a list of actions that prevent more parallelization. Extracted from the Bazel profile.
1 bottleneck found for a total duration of 9m 38s.
BazelPhaseDescriptions: The Bazel Profile's various phases and their timing information.
Duration	Timestamp (μs)	Description
    15ms	        -15000	Launch Blaze
   532ms	             0	Initialize command
   478ms	        532714	Evaluate target patterns
  9m 37s	       1011091	Load, analyze dependencies and build artifacts
    34ms	     578960296	Complete build
BazelProfile: The profile written by Bazel.
Bazel version:
release 7.6.1

Threads:
"Main Thread"       	CompleteEvents: 304	Counts: 6	Instants: 2
"Critical Path"     	CompleteEvents: 13
"Garbage Collector" 	CompleteEvents: 171
Other (aggregated)  	CompleteEvents: 39522

Critical Path:
Duration	Description
     1ms	action 'Writing script external/openssl/openssl_foreign_cc/wrapper_build_script.sh [for tool]'
     50s	action 'Foreign Cc - Configure: Building openssl [for tool]'
     0ms	runfiles for @@crate_index__openssl-sys-0.9.107//:_bs-
   725ms	action 'Running Cargo build script openssl-sys [for tool]'
     13s	action 'Running Cargo build script libssh2-sys [for tool]'
   351ms	action 'Compiling Rust rlib libssh2_sys v0.3.0 (2 files) [for tool]'
   928ms	action 'Compiling Rust rlib ssh2 v0.9.4 (15 files) [for tool]'
     36s	action 'Compiling Rust rlib ic-system-test-driver (57 files) [for tool]'
     32s	action 'Compiling Rust rlib utils (1 files) [for tool]'
   1m 3s	action 'Compiling Rust rlib utils (7 files) [for tool]'
     32s	action 'Compiling Rust bin cup_explorer_test_bin (1 files) [for tool]'
     0ms	runfiles for //rs/tests/consensus:cup_explorer_test
  3m 58s	action 'Testing //rs/tests/consensus:cup_explorer_test'
BazelVersion: The Bazel version used when the Bazel profile was generated. Extracted from the Bazel profile.
release 7.6.1
CachingAndExecutionMetrics: Metrics on the processed actions' caching and execution status.
Actions: ____________________________ 5341
    Remote cache hits: ______________  432      8.09% of all actions
    Remote cache misses: ____________    4      0.07% of all actions
        Executed locally:                4    100.00% of all cache misses
        Executed remotely:               0      0.00% of all cache misses
        Not reported:                    0      0.00% of all cache misses
    Remote cache not checked: _______ 4844     90.69% of all actions
        Executed locally:              623     12.86% of all cache skips
        Executed remotely:               0      0.00% of all cache skips
        Internal (not exhaustive):      61      1.26% of all cache skips
        Not reported                  4221     87.14% of all cache skips

    Executed locally: _______________  627     11.74% of all actions
    Executed remotely: ______________    0      0.00% of all actions
    Execution not reported: _________ 4714     88.26% of all actions
CriticalPathDuration: The duration of the Bazel profile's critical path.
7m 50s
CriticalPathQueuingDuration: The duration of queuing within the Bazel profile's critical path.
0ms
EstimatedCoresAvailable: The estimated number of cores available on the machine that ran the Bazel client, as well as how many numbers were skipped when naming skyframe-evaluators. Extracted from the Bazel profile.
61 cores (with 37 gaps)
EstimatedCoresUsed: The estimated number of cores used during execution, as well as how many numbers were skipped when naming skyframe-evaluators. Extracted from the Bazel profile.
65 cores (with 0 gaps)
EstimatedJobsFlagValue: Based on the Bazel profile, the estimated value that the Bazel flag `--jobs` was set to.
Lower bound of 65; --jobs flag is likely set
FlagValueExperimentalProfileIncludeTargetLabel: Whether the Bazel flag `--experimental_profile_include_target_label` was enabled when the Bazel profile was generated.
true
GarbageCollectionStats: The total duration of major garbage collection as extracted from the Bazel profile.
No major GC occurred
LocalActions: A collection of actions executed locally with the related events.
Found 5341 local actions
MergedEventsPresent: Whether the Bazel profile includes merged events.
true
QueuingObserved: Whether the Bazel profile includes queuing.
false
RemoteCacheMetrics: Metrics on the time spent interacting with a remote cache configured with `--remote_cache` or `--disk_cache`.
Remote cache checks:     1875ms
Downloading outputs:     15m 49s
Uploading outputs:       0ms
RemoteCachingUsed: Whether the Bazel Profile includes events indicating that remote caching was used.
true
RemoteExecutionUsed: Whether the Bazel Profile includes events indicating that remote execution was used.
false
SkymeldUsed: Whether the Bazel Profile includes events indicating that Skymeld was used.
true (analysis started: 1011091 μs, execution started: 1219913 μs)
TotalDuration: The duration of the invocation as extracted from the Bazel profile.
9m 39s
TotalQueuingDuration: The total time that was spent on queuing as extracted from the Bazel profile.
0ms


Help improve this tool
You can provide feedback on Bazel Invocation Analyzer as follows:
	https://github.com/EngFlow/bazel_invocation_analyzer/issues to file an issue
	analyzer@engflow.com to send us an email
Bazel Invocation Analyzer is open source. We welcome contributions!
```