### PR TITLE
fix(ic-backup): always wait until the most recent checkpoint has been created and verified, and manifest created 

### DIFF
--- a/bazel/hermetic_cc_toolchain.patch
+++ b/bazel/hermetic_cc_toolchain.patch
@@ -18,7 +18,7 @@ index 409d626..1265298 100644
      # These toolchains are only registered locally.
      dev_dependency = True,
 diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
-index f6f613e..02d5597 100644
+index f6f613e..3f45d85 100644
 --- a/toolchain/defs.bzl
 +++ b/toolchain/defs.bzl
 @@ -60,7 +60,8 @@ def toolchains(
@@ -72,7 +72,27 @@ index f6f613e..02d5597 100644
              },
          )
 
-@@ -230,6 +235,7 @@ zig_repository = repository_rule(
+@@ -148,7 +153,7 @@ def _zig_repository_impl(repository_ctx):
+     cache_prefix = repository_ctx.os.environ.get("HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX", "")
+     if cache_prefix == "":
+         if os == "windows":
+-            cache_prefix = "C:\\\\Temp\\\\zig-cache"
++            fail("windows is not supported")
+         elif os == "macos":
+             cache_prefix = "/var/tmp/zig-cache"
+         elif os == "linux":
+@@ -156,6 +161,10 @@ def _zig_repository_impl(repository_ctx):
+         else:
+             fail("unknown os: {}".format(os))
+
++    # use the catchall config to ensure all builds use a `zig-cache/config-FOO/`
++    # subdirectory, including the zig-wrapper itself
++    cache_prefix = cache_prefix + "/config-catchall"
++
+     repository_ctx.template(
+         "tools/zig-wrapper.zig",
+         Label("//toolchain:zig-wrapper.zig"),
+@@ -230,6 +239,7 @@ zig_repository = repository_rule(
          "host_platform_sha256": attr.string_dict(),
          "url_formats": attr.string_list(allow_empty = False),
          "host_platform_ext": attr.string_dict(),

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -623,31 +623,11 @@ impl Player {
 
             std::thread::sleep(WAIT_DURATION);
         }
+        info!(self.log, "Executed the state at height {height}.");
 
-        if let Some(consensus_pool) = self.consensus_pool.as_ref() {
-            let latest_summary_block_height = consensus_pool.get_cache().summary_block().height;
-            info!(
-                self.log,
-                "Waiting until the checkpoint at the latest summary height \
-                @{latest_summary_block_height} has been created and verified, \
-                and the manifest computed."
-            );
+        // Wait until the checkpoint is created and verified.
+        self.state_manager.flush_tip_channel();
 
-            if let Some(hash) = self.get_state_hash(latest_summary_block_height) {
-                info!(
-                    self.log,
-                    "Latest checkpoint height: {latest_summary_block_height}, \
-                    state hash: {}.",
-                    hex::encode(hash.get().0)
-                );
-            };
-        }
-
-        info!(
-            self.log,
-            "Latest state height is {}",
-            self.state_manager.latest_state_height()
-        );
         assert_eq!(
             height,
             self.state_manager.latest_state_height(),

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -623,10 +623,18 @@ impl Player {
 
             std::thread::sleep(WAIT_DURATION);
         }
-        info!(self.log, "Executed the state at height {height}.");
+        info!(self.log, "The state at height {height} has been executed.");
 
-        // Wait until the checkpoint is created and verified.
+        info!(
+            self.log,
+            "Waiting until the latest checkpoint is created and verified."
+        );
         self.state_manager.flush_tip_channel();
+        info!(
+            self.log,
+            "The latest checkpoint at height {:?} has been created and verified.",
+            self.state_manager.checkpoint_heights().iter().max()
+        );
 
         assert_eq!(
             height,

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -618,7 +618,9 @@ impl Player {
             info!(
                 self.log,
                 "State at height {height} hasn't been yet executed. \
-                Retrying in {WAIT_DURATION:?}."
+                Current state height = {}. \
+                Retrying in {WAIT_DURATION:?}.",
+                self.state_manager.latest_state_height()
             );
 
             std::thread::sleep(WAIT_DURATION);


### PR DESCRIPTION
To achieve this we modify the `wait_for_state` which instead of waiting until the hash of the state at the given height is computed, we now call the [StateManager::flush_tip_channel](https://github.com/dfinity/ic/blob/9734b186d658df38dabdfaf356b5fcccae668de5/rs/state_manager/src/lib.rs#L1156-L1158) function which blocks until the most recent checkpoint is created and verified. Previously we were waiting for the hash of the _latest_ state, but if the latest state height was not a checkpoint height, the function would return early without waiting for a checkpoint to be computed (https://github.com/dfinity/ic/blob/66dc6048dd854d3215e9097802f688afc56ef4c9/rs/replay/src/player.rs#L1610-L1622). 

Sample logs:
```
(...)
Validated artifacts up to new finalized height: 291
Validated artifacts up to new finalized height: 292
Validated artifacts up to new finalized height: 293
Validated artifacts up to new finalized height: 294
Validated artifacts up to new finalized height: 295
Validated artifacts up to new finalized height: 296
Validated artifacts up to new finalized height: 297
Validated artifacts up to new finalized height: 298
Validated artifacts up to new finalized height: 299
Validated artifacts up to new finalized height: 300
Found a CUP at height 300, finalized at height 300
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:10.979Z","message":"Delivering finalized batch at CUP height of 300","crate_":"ic_consensus","module":"batch_delivery","line":112,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:10.980Z","message":"Delivered 10 batches up to the height 300.","crate_":"ic_replay","module":"player","line":732,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:10.980Z","message":"Waiting for the state at height 300.","crate_":"ic_replay","module":"player","line":616,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:10.980Z","message":"State at height 300 hasn't been yet executed. Retrying in 500ms.","crate_":"ic_replay","module":"player","line":618,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.032Z","message":"Created unverified checkpoint @300 in 8.482363ms","crate_":"ic_state_manager","module":"ic_state_manager","line":2380,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.042Z","message":"Validated checkpoint @300 in 7.845823ms","crate_":"ic_state_manager","module":"tip","line":454,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.042Z","message":"Computing manifest for checkpoint @300 from scratch","crate_":"ic_state_manager","module":"tip","line":399,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.058Z","message":"Computed manifest version V3 for state @300 in 16.523454ms","crate_":"ic_state_manager","module":"tip","line":1410,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.058Z","message":"Computed root hash CryptoHash(0x0a67651930864ff453a80647dcb91ca655670437c5c939a4b4ddcccfd6383cbd) of state @300","crate_":"ic_state_manager","module":"tip","line":1448,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.480Z","message":"Executed the state at height 300.","crate_":"ic_replay","module":"player","line":626,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.480Z","message":"Waiting until the latest checkpoint is created and verified.","crate_":"ic_replay","module":"player","line":628,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.480Z","message":"The latest checkpoint at height Some(300) has been created and verified.","crate_":"ic_replay","module":"player","line":633,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.480Z","message":"Loading the CUP at height 300 from the disk, adding it to the consensus pool, and validating it","crate_":"ic_replay","module":"player","line":1033,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.485Z","message":"Verifying CUP at height 300","crate_":"ic_replay","module":"player","line":1127,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.488Z","message":"Polling the state manager for height: 300.","crate_":"ic_replay","module":"player","line":1626,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.488Z","message":"Waiting for the state at height 300.","crate_":"ic_replay","module":"player","line":616,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.488Z","message":"Executed the state at height 300.","crate_":"ic_replay","module":"player","line":626,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.488Z","message":"Waiting until the latest checkpoint is created and verified.","crate_":"ic_replay","module":"player","line":628,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.488Z","message":"The latest checkpoint at height Some(300) has been created and verified.","crate_":"ic_replay","module":"player","line":633,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.488Z","message":"Removing all states below height 300","crate_":"ic_replay","module":"player","line":1096,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.490Z","message":"Async checkpoint removal operation moves checkpoint @290 to tmp path and returns in 550.969µs","crate_":"ic_state_layout","module":"state_layout","line":1025,"node_id":"","subnet_id":""}}
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.492Z","message":"Asynchronously removed checkpoint from tmp path /home/ubuntu/.cache/bazel/_bazel_ubuntu/6d065581cce7ad9076e3b8db2b3afaf0/sandbox/linux-sandbox/163/execroot/_main/bazel-out/k8-opt/testlogs/rs/tests/consensus/backup/backup_manager_downgrade_test/test.outputs/backup/data/yinwu-grzzu-d6cq3-ijlzs-4yrh7-ubskd-624v7-uaxhs-4pg5p-i45l3-pqe/ic_state/fs_tmp/0000000000000122_1750349171490396273_async in 1.521702ms. Number of remaining 
(...)
Validated artifacts up to new finalized height: 301
Validated artifacts up to new finalized height: 302
Validated artifacts up to new finalized height: 303
Validated artifacts up to new finalized height: 304
Validated artifacts up to new finalized height: 305
Validated artifacts up to new finalized height: 306
Validated artifacts up to new finalized height: 307
Validated artifacts up to new finalized height: 308
Validated artifacts up to new finalized height: 309
Stopping deserialization at height 310 as this height contains no proposals.
(...)
{"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.658Z","message":"Delivered 9 batches up to the height 309.","crate_":"ic_replay","module":"player","line":732,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.658Z","message":"Waiting for the state at height 309.","crate_":"ic_replay","module":"player","line":616,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:11.658Z","message":"State at height 309 hasn't been yet executed. Retrying in 500ms.","crate_":"ic_replay","module":"player","line":618,"node_id":"","subnet_id":""}}
(...)
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:12.158Z","message":"Executed the state at height 309.","crate_":"ic_replay","module":"player","line":626,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:12.158Z","message":"Waiting until the latest checkpoint is created and verified.","crate_":"ic_replay","module":"player","line":628,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:12.158Z","message":"The latest checkpoint at height Some(300) has been created and verified.","crate_":"ic_replay","module":"player","line":633,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:12.158Z","message":"Waiting for the state at height 309.","crate_":"ic_replay","module":"player","line":616,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:12.158Z","message":"Executed the state at height 309.","crate_":"ic_replay","module":"player","line":626,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:12.158Z","message":"Waiting until the latest checkpoint is created and verified.","crate_":"ic_replay","module":"player","line":628,"node_id":"","subnet_id":""}}
>>> {"log_entry":{"level":"INFO","utc_time":"2025-06-19T16:06:12.158Z","message":"The latest checkpoint at height Some(300) has been created and verified.","crate_":"ic_replay","module":"player","line":633,"node_id":"","subnet_id":""}}
```