### PR TITLE
test(registry): Do not decode Registry responses to non-high-capacity types in test helpers...

### DIFF
--- a/rs/nns/integration_tests/src/registry_get_changes_since.rs
+++ b/rs/nns/integration_tests/src/registry_get_changes_since.rs
@@ -2,10 +2,11 @@ use ic_base_types::{PrincipalId, PrincipalIdClass};
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     state_test_helpers::{
-        registry_get_changes_since, setup_nns_canisters, state_machine_builder_for_nns_tests,
+        registry_high_capacity_get_changes_since, setup_nns_canisters,
+        state_machine_builder_for_nns_tests,
     },
 };
-use ic_registry_transport::pb::v1::RegistryGetChangesSinceResponse;
+use ic_registry_transport::pb::v1::HighCapacityRegistryGetChangesSinceResponse;
 use std::str::FromStr;
 
 #[test]
@@ -25,10 +26,10 @@ fn test_allow_opaque_caller() {
     )
     .unwrap();
     assert_eq!(sender.class(), Ok(PrincipalIdClass::Opaque));
-    let response = registry_get_changes_since(&state_machine, sender, 0);
+    let response = registry_high_capacity_get_changes_since(&state_machine, sender, 0);
 
     // Step 3: Inspect results.
-    let RegistryGetChangesSinceResponse {
+    let HighCapacityRegistryGetChangesSinceResponse {
         error,
         version,
         deltas,
@@ -57,10 +58,10 @@ fn test_allow_self_authenticating_caller() {
         PrincipalId::from_str("ubktz-haghv-fqsdh-23fhi-3urex-bykoz-pvpfd-5rs6w-qpo3t-nf2dv-oae")
             .unwrap();
     assert_eq!(sender.class(), Ok(PrincipalIdClass::SelfAuthenticating));
-    let response = registry_get_changes_since(&state_machine, sender, 0);
+    let response = registry_high_capacity_get_changes_since(&state_machine, sender, 0);
 
     // Step 3: Inspect results.
-    let RegistryGetChangesSinceResponse {
+    let HighCapacityRegistryGetChangesSinceResponse {
         error,
         version,
         deltas,

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -62,7 +62,7 @@ use ic_registry_transport::{
     deserialize_get_latest_version_response,
     pb::v1::{
         HighCapacityRegistryGetChangesSinceResponse, HighCapacityRegistryGetValueResponse,
-        RegistryGetChangesSinceRequest, RegistryGetChangesSinceResponse, RegistryGetValueRequest,
+        RegistryGetChangesSinceRequest, RegistryGetValueRequest,
     },
 };
 use ic_sns_governance::pb::v1::{
@@ -149,17 +149,6 @@ pub fn registry_latest_version(state_machine: &StateMachine) -> Result<u64, Stri
     )?;
     deserialize_get_latest_version_response(response)
         .map_err(|e| format!("Could not decode response {e:?}"))
-}
-
-// TODO(NNS1-3679): Replace with high-capacity version.
-pub fn registry_get_changes_since(
-    state_machine: &StateMachine,
-    sender: PrincipalId,
-    version: u64,
-) -> RegistryGetChangesSinceResponse {
-    let result = registry_high_capacity_get_changes_since(state_machine, sender, version);
-
-    RegistryGetChangesSinceResponse::try_from(result).unwrap()
 }
 
 pub fn registry_high_capacity_get_changes_since(


### PR DESCRIPTION
... since Registry uses high-capacity types to encode responses.

# References

Partially addresses [NNS1-3679]

[NNS1-3679]: https://dfinity.atlassian.net/browse/NNS1-3679