### PR TITLE
fix: Remove short argument name (-h) for hostos_config_object_path

### DIFF
--- a/rs/ic_os/os_tools/hostos_tool/src/main.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/main.rs
@@ -33,7 +33,7 @@ pub enum Commands {
 
 #[derive(Parser)]
 struct HostOSArgs {
-    #[arg(short, long, default_value_t = DEFAULT_HOSTOS_CONFIG_OBJECT_PATH.to_string(), value_name = "FILE")]
+    #[arg(long, default_value_t = DEFAULT_HOSTOS_CONFIG_OBJECT_PATH.to_string(), value_name = "FILE")]
     hostos_config_object_path: String,
 
     #[command(subcommand)]


### PR DESCRIPTION
We never use it and it overlaps with help.