### PR TITLE
fix: Deploy dev version of hostos_tool in dev HostOS

### DIFF
--- a/ic-os/hostos/defs.bzl
+++ b/ic-os/hostos/defs.bzl
@@ -75,6 +75,7 @@ def image_deps(mode, _malicious = False):
     if "dev" in mode:
         deps["rootfs"].pop("//rs/ic_os/release:config", None)
         deps["rootfs"].update({"//rs/ic_os/release:config_dev": "/opt/ic/bin/config:0755"})
+        deps["rootfs"].pop("//rs/ic_os/release:hostos_tool", None)
         deps["rootfs"].update({"//rs/ic_os/release:hostos_tool_dev": "/opt/ic/bin/hostos_tool:0755"})
 
     return deps

--- a/ic-os/hostos/defs.bzl
+++ b/ic-os/hostos/defs.bzl
@@ -75,6 +75,7 @@ def image_deps(mode, _malicious = False):
     if "dev" in mode:
         deps["rootfs"].pop("//rs/ic_os/release:config", None)
         deps["rootfs"].update({"//rs/ic_os/release:config_dev": "/opt/ic/bin/config:0755"})
+        deps["rootfs"].update({"//rs/ic_os/release:hostos_tool_dev": "/opt/ic/bin/hostos_tool:0755"})
 
     return deps
 

--- a/rs/ic_os/os_tools/hostos_tool/BUILD.bazel
+++ b/rs/ic_os/os_tools/hostos_tool/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//rs:ic-os-pkg"])
 
 DEPENDENCIES = [
     # Keep sorted.
-    "//rs/ic_os/config:config_lib",
     "//rs/ic_os/config_types",
     "//rs/ic_os/deterministic_ips",
     "//rs/ic_os/metrics_tool",
@@ -39,7 +38,20 @@ rust_binary(
     target_compatible_with = [
         "@platforms//os:linux",
     ],
-    deps = DEPENDENCIES,
+    deps = DEPENDENCIES + ["//rs/ic_os/config:config_lib"],
+)
+
+rust_binary(
+    name = "hostos_tool_dev",
+    srcs = glob(["src/**/*.rs"]),
+    aliases = ALIASES,
+    crate_name = "hostos_tool",
+    features = ["dev"],
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    deps = DEPENDENCIES + ["//rs/ic_os/config:config_lib_dev"],
 )
 
 rust_test(

--- a/rs/ic_os/release/BUILD.bazel
+++ b/rs/ic_os/release/BUILD.bazel
@@ -6,6 +6,7 @@ OBJECTS = {
     "fstrim_tool": "//rs/ic_os/fstrim_tool:fstrim_tool_bin",
     "guestos_tool": "//rs/ic_os/os_tools/guestos_tool:guestos_tool",
     "hostos_tool": "//rs/ic_os/os_tools/hostos_tool:hostos_tool",
+    "hostos_tool_dev": "//rs/ic_os/os_tools/hostos_tool:hostos_tool_dev",
     "nft-exporter": "//rs/ic_os/nft_exporter:nft-exporter",
     "setupos_tool": "//rs/ic_os/os_tools/setupos_tool:setupos_tool",
     "config": "//rs/ic_os/config:config",


### PR DESCRIPTION
This is a temporary solution to fix some tests until we have a better solution that automatically pulls in dev binaries into dev images.