### PR TITLE
chore(IDX): Use simple action for fuzzers build

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -372,11 +372,12 @@ jobs:
     steps:
       - <<: *checkout
       - name: Run Bazel Build Fuzzers
-        id: bazel-build-fuzzers
-        uses:  ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: build --config=ci --keep_going --config=fuzzing --build_tag_filters=libfuzzer
-          BAZEL_TARGETS: //rs/...
+          run: |
+            bazel build //rs/... \
+              --config=ci --config=stamped --config=fuzzing --build_tag_filters=libfuzzer \
+              --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   bazel-build-fuzzers-afl:
@@ -385,11 +386,12 @@ jobs:
     steps:
       - <<: *checkout
       - name: Run Bazel Build Fuzzers AFL
-        id: bazel-build-fuzzers-afl
-        uses:  ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: build --config=ci --keep_going --config=afl
-          BAZEL_TARGETS: //rs/...
+          run: |
+            bazel build //rs/... \
+              --config=ci --config=stamped --config=afl \
+              --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   python-ci-tests:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -347,11 +347,12 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
       - name: Run Bazel Build Fuzzers
-        id: bazel-build-fuzzers
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: build --config=ci --keep_going --config=fuzzing --build_tag_filters=libfuzzer
-          BAZEL_TARGETS: //rs/...
+          run: |
+            bazel build //rs/... \
+              --config=ci --config=stamped --config=fuzzing --build_tag_filters=libfuzzer \
+              --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   bazel-build-fuzzers-afl:
     name: Bazel Build Fuzzers AFL
@@ -368,11 +369,12 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
       - name: Run Bazel Build Fuzzers AFL
-        id: bazel-build-fuzzers-afl
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: build --config=ci --keep_going --config=afl
-          BAZEL_TARGETS: //rs/...
+          run: |
+            bazel build //rs/... \
+              --config=ci --config=stamped --config=afl \
+              --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   python-ci-tests:
     name: Python CI Tests


### PR DESCRIPTION
This changes the CI jobs for fuzzers to be built with the simple `bazel` action instead of `bazel-test-all`. The fuzzers are only being built and don't actually run `bazel test`.

This does mean that the `diff` script is not being used and the full build will "run" every time, though in case of a cached build this only involves downloading ~20 targets and the whole job takes less than 2 minutes to run.