### PR TITLE
chore(IDX): Remove bazel ci config

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -199,7 +199,7 @@ jobs:
           diff-only: ${{ needs.config.outputs.diff_only }}
           stamp-build: ${{ needs.config.outputs.release-build }}
           upload-artifacts: ${{ needs.config.outputs.release-build }}
-          BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
+          BAZEL_COMMAND: test ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -224,9 +224,9 @@ jobs:
         id: cfg
         run: |
           if [[ '${{ needs.config.outputs.full_macos_build }}' == 'true' ]]; then
-            echo build-command='test --config=ci --config=macos_ci --test_tag_filters=test_macos' >> "$GITHUB_OUTPUT"
+            echo build-command='test --config=macos_ci --test_tag_filters=test_macos' >> "$GITHUB_OUTPUT"
           else
-            echo build-command='build --config=ci --config=macos_ci --test_tag_filters=test_macos --nobuild' >> "$GITHUB_OUTPUT"
+            echo build-command='build --config=macos_ci --test_tag_filters=test_macos --nobuild' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Bazel Checks on Darwin x86-64
@@ -266,7 +266,7 @@ jobs:
           bazel \
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
-            build --config=ci //rs/pocket_ic_server:pocket-ic-server
+            build //rs/pocket_ic_server:pocket-ic-server
 
           mkdir -p build
           cp \
@@ -301,7 +301,7 @@ jobs:
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
             test \
-            --config=ci --config=macos_ci \
+            --config=macos_ci \
             --test_tag_filters="test_macos,test_macos_slow" \
             //packages/pocket-ic/... //rs/... //publish/binaries/...
 
@@ -376,7 +376,7 @@ jobs:
         with:
           run: |
             bazel build //rs/... \
-              --config=ci --config=stamped --config=fuzzing --build_tag_filters=libfuzzer \
+              --config=stamped --config=fuzzing --build_tag_filters=libfuzzer \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -390,7 +390,7 @@ jobs:
         with:
           run: |
             bazel build //rs/... \
-              --config=ci --config=stamped --config=afl \
+              --config=stamped --config=afl \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -55,7 +55,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_nightly
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_nightly
           BAZEL_TARGETS: //rs/tests/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -68,7 +68,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_staging
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_staging
           BAZEL_TARGETS: //rs/tests/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -82,7 +82,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_hotfix
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_hotfix
           BAZEL_TARGETS: //rs/tests/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -150,7 +150,7 @@ jobs:
       - name: Run qualification for version ${{ matrix.version }} from the tip of the branch
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --config=systest --keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}
+          BAZEL_COMMAND: test --config=systest --keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}
           BAZEL_TARGETS: "//rs/tests/dre:guest_os_qualification"
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -42,7 +42,7 @@ jobs:
 
           launch_bare_metal() {
             # shellcheck disable=SC2046,SC2086
-            bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
+            bazel --output_base=/var/tmp/bazel-output run \
               //ic-os/setupos/envs/dev:launch_bare_metal -- \
                 --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
                 --csv_filename "$(realpath file1)" \
@@ -64,7 +64,6 @@ jobs:
 
           bazel clean
         env:
-          BAZEL_CI_CONFIG: "--config=ci"
           ZH2_DLL01_CSV_SECRETS: "${{ secrets.ZH2_DLL01_CSV_SECRETS }}"
           ZH2_FILE_SHARE_KEY: "${{ secrets.ZH2_FILE_SHARE_KEY }}"
 
@@ -78,7 +77,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200
           BAZEL_TARGETS: //rs/ledger_suite/...
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ secrets.SSH_PRIVATE_KEY_BACKUP_POD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -93,7 +92,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all
           BAZEL_TARGETS: //rs/nns/...
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ secrets.SSH_PRIVATE_KEY_BACKUP_POD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -114,7 +113,7 @@ jobs:
         uses: ./.github/actions/bazel-test-all/
         with:
           # note: there's just one performance cluster, so the job can't be parallelized
-          BAZEL_COMMAND: test --config=ci --test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1
+          BAZEL_COMMAND: test --test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1
           BAZEL_TARGETS: ${{ env.BENCHMARK_TARGETS }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Post Slack Notification

--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run Bazel Build All No Cache
         uses:  ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: build --config=ci --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA}
+          BAZEL_COMMAND: build --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -53,7 +53,7 @@ jobs:
         id: bazel-test-all
         uses:  ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_hourly
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_hourly
           BAZEL_TARGETS: //rs/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -169,7 +169,7 @@ jobs:
           diff-only: ${{ needs.config.outputs.diff_only }}
           stamp-build: ${{ needs.config.outputs.release-build }}
           upload-artifacts: ${{ needs.config.outputs.release-build }}
-          BAZEL_COMMAND: test --config=ci ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
+          BAZEL_COMMAND: test ${{ steps.bazel-extra-args.outputs.BAZEL_EXTRA_ARGS }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -196,9 +196,9 @@ jobs:
         id: cfg
         run: |
           if [[ '${{ needs.config.outputs.full_macos_build }}' == 'true' ]]; then
-            echo build-command='test --config=ci --config=macos_ci --test_tag_filters=test_macos' >> "$GITHUB_OUTPUT"
+            echo build-command='test --config=macos_ci --test_tag_filters=test_macos' >> "$GITHUB_OUTPUT"
           else
-            echo build-command='build --config=ci --config=macos_ci --test_tag_filters=test_macos --nobuild' >> "$GITHUB_OUTPUT"
+            echo build-command='build --config=macos_ci --test_tag_filters=test_macos --nobuild' >> "$GITHUB_OUTPUT"
           fi
       - name: Run Bazel Checks on Darwin x86-64
         id: bazel-test-darwin-x86-64
@@ -235,7 +235,7 @@ jobs:
           bazel \
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
-            build --config=ci //rs/pocket_ic_server:pocket-ic-server
+            build //rs/pocket_ic_server:pocket-ic-server
 
           mkdir -p build
           cp \
@@ -267,7 +267,7 @@ jobs:
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
             test \
-            --config=ci --config=macos_ci \
+            --config=macos_ci \
             --test_tag_filters="test_macos,test_macos_slow" \
             //packages/pocket-ic/... //rs/... //publish/binaries/...
 
@@ -351,7 +351,7 @@ jobs:
         with:
           run: |
             bazel build //rs/... \
-              --config=ci --config=stamped --config=fuzzing --build_tag_filters=libfuzzer \
+              --config=stamped --config=fuzzing --build_tag_filters=libfuzzer \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   bazel-build-fuzzers-afl:
@@ -373,7 +373,7 @@ jobs:
         with:
           run: |
             bazel build //rs/... \
-              --config=ci --config=stamped --config=afl \
+              --config=stamped --config=afl \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   python-ci-tests:

--- a/.github/workflows/rate-limits-backend-release.yml
+++ b/.github/workflows/rate-limits-backend-release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: build
         run: |
           TARGET='//rs/boundary_node/rate_limits:rate_limit_canister'
-          bazel build --config=ci ${TARGET}
+          bazel build ${TARGET}
 
           OUTPUT='bazel-bin/rs/boundary_node/rate_limits/rate_limit_canister.wasm.gz'
           mv ${OUTPUT} rate_limit_canister.wasm.gz

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -41,7 +41,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_nightly
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_nightly
           BAZEL_TARGETS: //rs/tests/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   bazel-system-test-staging:
@@ -62,7 +62,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_staging
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_staging
           BAZEL_TARGETS: //rs/tests/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   bazel-system-test-hotfix:
@@ -83,7 +83,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_hotfix
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_hotfix
           BAZEL_TARGETS: //rs/tests/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   dependency-scan-release-cut:
@@ -171,7 +171,7 @@ jobs:
       - name: Run qualification for version ${{ matrix.version }} from the tip of the branch
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --config=systest --keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}
+          BAZEL_COMMAND: test --config=systest --keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}
           BAZEL_TARGETS: "//rs/tests/dre:guest_os_qualification"
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   repro-check:

--- a/.github/workflows/salt-sharing-canister-release.yml
+++ b/.github/workflows/salt-sharing-canister-release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: build
         run: |
           TARGET='//rs/boundary_node/salt_sharing:salt_sharing_canister'
-          bazel build --config=ci ${TARGET}
+          bazel build ${TARGET}
 
           OUTPUT='bazel-bin/rs/boundary_node/salt_sharing/salt_sharing_canister.wasm.gz'
           mv ${OUTPUT} salt_sharing_canister.wasm.gz

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -30,7 +30,7 @@ jobs:
 
           launch_bare_metal() {
             # shellcheck disable=SC2046,SC2086
-            bazel --output_base=/var/tmp/bazel-output run ${BAZEL_CI_CONFIG} \
+            bazel --output_base=/var/tmp/bazel-output run \
               //ic-os/setupos/envs/dev:launch_bare_metal -- \
                 --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
                 --csv_filename "$(realpath file1)" \
@@ -52,7 +52,6 @@ jobs:
 
           bazel clean
         env:
-          BAZEL_CI_CONFIG: "--config=ci"
           ZH2_DLL01_CSV_SECRETS: "${{ secrets.ZH2_DLL01_CSV_SECRETS }}"
           ZH2_FILE_SHARE_KEY: "${{ secrets.ZH2_FILE_SHARE_KEY }}"
   fi-tests-nightly:
@@ -71,7 +70,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200
           BAZEL_TARGETS: //rs/ledger_suite/...
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ secrets.SSH_PRIVATE_KEY_BACKUP_POD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -91,7 +90,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all
           BAZEL_TARGETS: //rs/nns/...
           SSH_PRIVATE_KEY_BACKUP_POD: ${{ secrets.SSH_PRIVATE_KEY_BACKUP_POD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -117,7 +116,7 @@ jobs:
         uses: ./.github/actions/bazel-test-all/
         with:
           # note: there's just one performance cluster, so the job can't be parallelized
-          BAZEL_COMMAND: test --config=ci --test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1
+          BAZEL_COMMAND: test --test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1
           BAZEL_TARGETS: ${{ env.BENCHMARK_TARGETS }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Post Slack Notification

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run Bazel Build All No Cache
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: build --config=ci --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA}
+          BAZEL_COMMAND: build --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -48,7 +48,7 @@ jobs:
         id: bazel-test-all
         uses: ./.github/actions/bazel-test-all/
         with:
-          BAZEL_COMMAND: test --config=ci --keep_going --test_tag_filters=system_test_hourly
+          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_hourly
           BAZEL_TARGETS: //rs/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment

--- a/.github/workflows/schedule-rust-bench.yml
+++ b/.github/workflows/schedule-rust-bench.yml
@@ -59,7 +59,7 @@ jobs:
             echo -e "\e[34mRunning rust benchmarks on dedicated machine fr1-spm15!\e[0m"
 
             while IFS= read -r tgt; do
-                bazel run --config=ci "$tgt"
+                bazel run "$tgt"
             done < <(bazel query "attr(tags, 'rust_bench', ${{ matrix.target }})")
 
             while IFS= read -r bench_dir; do

--- a/.github/workflows/system-tests-k8s.yml
+++ b/.github/workflows/system-tests-k8s.yml
@@ -82,7 +82,6 @@ jobs:
         with:
           BAZEL_COMMAND: >-
             test
-              --config=ci
               --local_test_jobs=${{ env.JOBS }} --test_tag_filters=k8s,-manual,-colocated,-long_test,-system_test_hourly,-system_test_nightly --k8s
           BAZEL_TARGETS: ${{ env.TARGETS }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -150,7 +149,6 @@ jobs:
         with:
           BAZEL_COMMAND: >-
             test
-              --config=ci
               --local_test_jobs=${{ env.JOBS }} --test_tag_filters=k8s --k8s --flaky_test_attempts=3
           BAZEL_TARGETS: ${{ env.TARGETS }}
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -55,7 +55,6 @@ build --build_tag_filters="-system_test,-fuzz_test"
 test --test_tag_filters="-system_test,-fuzz_test"
 test:alltests --test_tag_filters=""
 test:paritytests --test_tag_filters="-system_test"
-build:ci --build_tag_filters="-system_test,-fuzz_test"
 
 test --test_output=errors
 
@@ -66,9 +65,6 @@ test:systest --test_output=streamed --test_tag_filters=
 
 build:testnet --build_tag_filters=
 test:testnet --test_output=streamed --test_tag_filters=
-
-# TODO(IDX-2374): enable alltests in CI when we will have actual system tests.
-#test:ci --config=alltests
 
 # Set all tests (including those marked as flaky) to fail explicitly on the
 # first try (can be overriden). This is useful when developing locally to

--- a/ci/scripts/bazel-coverage.sh
+++ b/ci/scripts/bazel-coverage.sh
@@ -8,7 +8,7 @@ bazel query --universe_scope=//... \
 # exclude the target below because of flaky builds - https://github.com/dfinity/ic/pull/2103
 sed -i '/minter:principal_to_bytes_test/d' cov_targets.txt
 # shellcheck disable=SC2046,SC2086
-bazel --output_base=/var/tmp/bazel-output/ coverage --config=ci --combined_report=lcov \
+bazel --output_base=/var/tmp/bazel-output/ coverage --combined_report=lcov \
     --test_timeout=3000 --combined_report=lcov $(<cov_targets.txt) || true
 # some tests may fail, but we still want to generate coverage report
 cp bazel-out/_coverage/_coverage_report.dat cov_report.dat

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -220,7 +220,6 @@ def update_mainnet_revisions_canisters_file(repo_root: pathlib.Path, logger: log
     cmd = [
         "bazel",
         "run",
-        "--config=ci",
     ]
     cmd.append("//rs/nervous_system/tools/sync-with-released-nervous-system-wasms")
 


### PR DESCRIPTION
This removes the `--config=ci` special config used by `build` commands. The only option set (ignoring system & fuzz tests) is already set in the top-level `build` command.