### PR TITLE
chore(IDX): don't specify CC for amd64-darwin builds

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -218,8 +218,6 @@ jobs:
         run: |
           echo "/usr/local/bin" >> $GITHUB_PATH
           echo "$HOME/.cargo/bin:" >> $GITHUB_PATH
-          # use llvm-clang instead of apple's
-          echo "CC=/usr/local/opt/llvm/bin/clang" >> "$GITHUB_ENV"
       - name: Infer macos intel build command
         id: cfg
         run: |


### PR DESCRIPTION
The CC toolchain is set via hermetic_cc_toolchain.