### PR TITLE
chore(IDX): Remove bazel macos-ci config

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -224,9 +224,9 @@ jobs:
         id: cfg
         run: |
           if [[ '${{ needs.config.outputs.full_macos_build }}' == 'true' ]]; then
-            echo build-command='test --config=macos_ci --test_tag_filters=test_macos' >> "$GITHUB_OUTPUT"
+            echo build-command='test --test_tag_filters=test_macos' >> "$GITHUB_OUTPUT"
           else
-            echo build-command='build --config=macos_ci --test_tag_filters=test_macos --nobuild' >> "$GITHUB_OUTPUT"
+            echo build-command='build --test_tag_filters=test_macos --nobuild' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Bazel Checks on Darwin x86-64
@@ -301,7 +301,6 @@ jobs:
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
             test \
-            --config=macos_ci \
             --test_tag_filters="test_macos,test_macos_slow" \
             //packages/pocket-ic/... //rs/... //publish/binaries/...
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -196,9 +196,9 @@ jobs:
         id: cfg
         run: |
           if [[ '${{ needs.config.outputs.full_macos_build }}' == 'true' ]]; then
-            echo build-command='test --config=macos_ci --test_tag_filters=test_macos' >> "$GITHUB_OUTPUT"
+            echo build-command='test --test_tag_filters=test_macos' >> "$GITHUB_OUTPUT"
           else
-            echo build-command='build --config=macos_ci --test_tag_filters=test_macos --nobuild' >> "$GITHUB_OUTPUT"
+            echo build-command='build --test_tag_filters=test_macos --nobuild' >> "$GITHUB_OUTPUT"
           fi
       - name: Run Bazel Checks on Darwin x86-64
         id: bazel-test-darwin-x86-64
@@ -267,7 +267,6 @@ jobs:
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
             test \
-            --config=macos_ci \
             --test_tag_filters="test_macos,test_macos_slow" \
             //packages/pocket-ic/... //rs/... //publish/binaries/...
 

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -76,7 +76,6 @@ test --flaky_test_attempts=1
 
 # So that developers can build in debug mode.
 build:dev --compilation_mode=fastbuild
-build:macos_ci --build_tag_filters="-system_test,-fuzz_test"
 
 # Fuzzing configuration
 build:fuzzing --action_env="SANITIZERS_ENABLED=1"


### PR DESCRIPTION
Similarly to #5642, this removes the `--config=macos_ci` special config used by `build` commands.

The only option set (ignoring system & fuzz tests) is already set in the top-level `build` command.