### PR TITLE
feat (OBSOLETE): Add is_replicated as an optional param in the `CanisterHttpRequestArgs`

### DIFF
--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -1858,6 +1858,7 @@ fn http_request_bound_holds() {
             }),
             context: transform_context.clone(),
         }),
+        is_replicated: None,
     };
 
     // Create request to HTTP_REQUEST method.
@@ -2415,6 +2416,7 @@ fn execute_canister_http_request() {
             }),
             context: transform_context.clone(),
         }),
+        is_replicated: None,
     };
 
     // Create request to HTTP_REQUEST method.
@@ -2494,6 +2496,7 @@ fn execute_canister_http_request_disabled() {
             }),
             context: vec![0, 1, 2],
         }),
+        is_replicated: None,
     };
 
     // Create request to HTTP_REQUEST method.

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -3032,6 +3032,7 @@ fn canister_is_stopped_if_timeout_occurs_and_ready_to_stop() {
             body: None,
             transform: None,
             max_response_bytes: None,
+            is_replicated: None,
         })
         .unwrap();
 
@@ -4104,6 +4105,7 @@ fn consumed_cycles_http_outcalls_are_added_to_consumed_cycles_total() {
             }),
             context: transform_context,
         }),
+        is_replicated: None,
     };
 
     // Create request to `HttpRequest` method.

--- a/rs/execution_environment/tests/subnet_size_test.rs
+++ b/rs/execution_environment/tests/subnet_size_test.rs
@@ -532,6 +532,7 @@ fn simulate_http_request_cost(subnet_type: SubnetType, subnet_size: usize) -> Cy
                         }),
                         context: vec![],
                     }),
+                    is_replicated: None,
                 })
                 .unwrap(),
             ),

--- a/rs/rust_canisters/proxy_canister/src/lib.rs
+++ b/rs/rust_canisters/proxy_canister/src/lib.rs
@@ -51,6 +51,7 @@ impl From<UnvalidatedCanisterHttpRequestArgs>
             body: args.body,
             method: args.method,
             transform: args.transform,
+            is_replicated: None,
         }
     }
 }

--- a/rs/types/management_canister_types/src/http.rs
+++ b/rs/types/management_canister_types/src/http.rs
@@ -80,7 +80,7 @@ pub struct CanisterHttpRequestArgs {
     pub body: Option<Vec<u8>>,
     pub method: HttpMethod,
     pub transform: Option<TransformContext>,
-    pub is_replicated: Option<bool>
+    pub is_replicated: Option<bool>,
 }
 
 impl Payload<'_> for CanisterHttpRequestArgs {}

--- a/rs/types/management_canister_types/src/http.rs
+++ b/rs/types/management_canister_types/src/http.rs
@@ -80,6 +80,7 @@ pub struct CanisterHttpRequestArgs {
     pub body: Option<Vec<u8>>,
     pub method: HttpMethod,
     pub transform: Option<TransformContext>,
+    pub is_replicated: Option<bool>
 }
 
 impl Payload<'_> for CanisterHttpRequestArgs {}
@@ -114,6 +115,7 @@ fn test_http_headers_max_number() {
             body: None,
             method: HttpMethod::GET,
             transform: None,
+            is_replicated: None,
         };
 
         // Act.
@@ -167,6 +169,7 @@ fn test_http_headers_max_total_size() {
             body: None,
             method: HttpMethod::GET,
             transform: None,
+            is_replicated: None,
         };
 
         // Act.
@@ -214,6 +217,7 @@ fn test_http_headers_max_element_size() {
             body: None,
             method: HttpMethod::GET,
             transform: None,
+            is_replicated: None,
         };
 
         // Act.

--- a/rs/types/management_canister_types/src/http.rs
+++ b/rs/types/management_canister_types/src/http.rs
@@ -70,6 +70,7 @@ pub type BoundedHttpHeaders = BoundedVec<
 //       function : func (record {response : http_response; context : blob}) -> (http_response) query;
 //       context : blob;
 //     };
+//     is_replicated: opt bool;
 //   })`
 #[derive(Clone, PartialEq, Debug, CandidType, Deserialize)]
 pub struct CanisterHttpRequestArgs {

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -286,7 +286,7 @@ impl TryFrom<(Time, &Request, CanisterHttpRequestArgs)> for CanisterHttpRequestC
         };
 
         if let Some(false) = args.is_replicated {
-            return Err(CanisterHttpRequestContextError::NonReplicatedNotSupported)
+            return Err(CanisterHttpRequestContextError::NonReplicatedNotSupported);
         }
 
         let max_response_bytes = match args.max_response_bytes {

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -285,6 +285,10 @@ impl TryFrom<(Time, &Request, CanisterHttpRequestArgs)> for CanisterHttpRequestC
             }
         };
 
+        if let Some(false) = args.is_replicated {
+            return Err(CanisterHttpRequestContextError::NonReplicatedNotSupported)
+        }
+
         let max_response_bytes = match args.max_response_bytes {
             Some(max_response_bytes) => {
                 if max_response_bytes > MAX_CANISTER_HTTP_RESPONSE_BYTES {
@@ -385,6 +389,7 @@ pub enum CanisterHttpRequestContextError {
     TooLongHeaderValue(usize),
     TooLargeHeaders(usize),
     TooLargeRequest(usize),
+    NonReplicatedNotSupported,
 }
 
 impl From<CanisterHttpRequestContextError> for UserError {
@@ -443,6 +448,12 @@ impl From<CanisterHttpRequestContextError> for UserError {
                     total_request_size, MAX_CANISTER_HTTP_REQUEST_BYTES
                 ),
             ),
+            CanisterHttpRequestContextError::NonReplicatedNotSupported => {
+                UserError::new(
+                    ErrorCode::CanisterRejectedMessage,
+                    "Canister HTTP requests with is_replicated=false are not supported".to_string(),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
This param is currently unused. It will be used to decide during consensus whether a single replica should make the http request or whether all of them should try.