### PR TITLE
chore(IDX): Simplify release-testing workflow

### DIFF
--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -9,6 +9,9 @@ inputs:
   execlogs-artifact-name:
     required: false
     description: "When provided, the execlogs will be uploaded as an artifact with the specified name."
+  bep-artifact-name:
+    required: false
+    description: "When provided, the build events will be uploaded as an artifact with the specified name. Default: <github.job>-bep"
   GPG_PASSPHRASE:
     required: true
     description: "GPG key to encrypt build events. Upload can be disabled by explicitly setting the input to an empty string."
@@ -65,7 +68,7 @@ runs:
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ github.job }}-bep
+        name: ${{ inputs.bep-artifact-name || format('{0}-bep', github.job) }}
         retention-days: 14
         if-no-files-found: ignore
         compression-level: 9

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -49,7 +49,7 @@ jobs:
   # Run some extra system tests that are skipped on CI Main.
   # Those test suites would overwhelm a runner, so each is run
   # as a separate job.
-  bazel-system-tests:
+  release-system-tests:
     name: Bazel System Tests (${{ matrix.tag }})
     <<: *dind-large-setup
     strategy:

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -69,6 +69,8 @@ jobs:
               --test_tag_filters=${{ matrix.tag }} \
               //rs/tests/... \
               --keep_going
+          # prevent artifact name overlap
+          bep-artifact-name: ${{ github.job }}-${{ matrix.tag }}-bep
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   dependency-scan-release-cut:

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -46,44 +46,29 @@ jobs:
     uses: ./.github/workflows/ci-main.yml
     secrets: inherit
 
-  bazel-system-test-nightly:
-    name: Bazel System Test Nightly
+  # Run some extra system tests that are skipped on CI Main.
+  # Those test suites would overwhelm a runner, so each is run
+  # as a separate job.
+  bazel-system-tests:
+    name: Bazel System Tests (${{ matrix.tag }})
     <<: *dind-large-setup
+    strategy:
+      matrix:
+        tag:
+          - system_test_nightly
+          - system_test_staging
+          - system_test_hotfix
     steps:
       - <<: *checkout
-      - name: Run Bazel System Test Nightly
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
+      - name: Run Bazel System Tests
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_nightly
-          BAZEL_TARGETS: //rs/tests/...
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-  bazel-system-test-staging:
-    name: Bazel System Test Staging
-    <<: *dind-large-setup
-    steps:
-      - <<: *checkout
-      - name: Run Bazel System Test Staging
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
-        with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_staging
-          BAZEL_TARGETS: //rs/tests/...
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-  bazel-system-test-hotfix:
-    name: Bazel System Test Hotfix
-    <<: *dind-large-setup
-    timeout-minutes: 90
-    steps:
-      - <<: *checkout
-      - name: Run Bazel Test All
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
-        with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_hotfix
-          BAZEL_TARGETS: //rs/tests/...
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=${{ matrix.tag }} \
+              //rs/tests/... \
+              --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   dependency-scan-release-cut:
@@ -148,10 +133,15 @@ jobs:
     steps:
       - <<: *checkout
       - name: Run qualification for version ${{ matrix.version }} from the tip of the branch
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: test --config=systest --keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}
-          BAZEL_TARGETS: "//rs/tests/dre:guest_os_qualification"
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters= \
+              //rs/tests/dre:guest_os_qualification \
+              --test_env=OLD_VERSION=${{ matrix.version }} \
+              --keep_going --test_timeout=7200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   repro-check:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -23,8 +23,11 @@ jobs:
     name: CI Main
     uses: ./.github/workflows/ci-main.yml
     secrets: inherit
-  bazel-system-test-nightly:
-    name: Bazel System Test Nightly
+  # Run some extra system tests that are skipped on CI Main.
+  # Those test suites would overwhelm a runner, so each is run
+  # as a separate job.
+  bazel-system-tests:
+    name: Bazel System Tests (${{ matrix.tag }})
     runs-on:
       labels: dind-large
     container:
@@ -32,59 +35,26 @@ jobs:
       options: >-
         -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 180 # 3 hours
+    strategy:
+      matrix:
+        tag:
+          - system_test_nightly
+          - system_test_staging
+          - system_test_hotfix
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Run Bazel System Test Nightly
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
+      - name: Run Bazel System Tests
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_nightly
-          BAZEL_TARGETS: //rs/tests/...
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-  bazel-system-test-staging:
-    name: Bazel System Test Staging
-    runs-on:
-      labels: dind-large
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:2e7a20ff226ac7c35227853804f13a2294e530e772a302504467bb4f5264b02a
-      options: >-
-        -e NODE_NAME --privileged --cgroupns host
-    timeout-minutes: 180 # 3 hours
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Run Bazel System Test Staging
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
-        with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_staging
-          BAZEL_TARGETS: //rs/tests/...
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-  bazel-system-test-hotfix:
-    name: Bazel System Test Hotfix
-    runs-on:
-      labels: dind-large
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:2e7a20ff226ac7c35227853804f13a2294e530e772a302504467bb4f5264b02a
-      options: >-
-        -e NODE_NAME --privileged --cgroupns host
-    timeout-minutes: 90
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Run Bazel Test All
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
-        with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_hotfix
-          BAZEL_TARGETS: //rs/tests/...
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=${{ matrix.tag }} \
+              //rs/tests/... \
+              --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   dependency-scan-release-cut:
     name: Dependency Scan for Release
@@ -169,10 +139,15 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
       - name: Run qualification for version ${{ matrix.version }} from the tip of the branch
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: test --config=systest --keep_going --test_timeout=7200 --test_env=OLD_VERSION=${{ matrix.version }}
-          BAZEL_TARGETS: "//rs/tests/dre:guest_os_qualification"
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters= \
+              //rs/tests/dre:guest_os_qualification \
+              --test_env=OLD_VERSION=${{ matrix.version }} \
+              --keep_going --test_timeout=7200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   repro-check:
     name: Repro check for ${{ github.sha }}

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -26,7 +26,7 @@ jobs:
   # Run some extra system tests that are skipped on CI Main.
   # Those test suites would overwhelm a runner, so each is run
   # as a separate job.
-  bazel-system-tests:
+  release-system-tests:
     name: Bazel System Tests (${{ matrix.tag }})
     runs-on:
       labels: dind-large

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -55,6 +55,8 @@ jobs:
               --test_tag_filters=${{ matrix.tag }} \
               //rs/tests/... \
               --keep_going
+          # prevent artifact name overlap
+          bep-artifact-name: ${{ github.job }}-${{ matrix.tag }}-bep
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   dependency-scan-release-cut:
     name: Dependency Scan for Release


### PR DESCRIPTION
This changes the `release-testing.yml` workflow to use the simpler `bazel` action, as the workflow does not require `bazel-test-all`'s bells and whistles. It also merges the system test jobs into one job, parametrized via build strategy. Finally, the jobs are changed to use the `stamped` config to ensure the actual to-be-released artifacts are used.