### PR TITLE
chore(IDX): don't upload artifacts in schedule-hourly

### DIFF
--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -40,9 +40,6 @@ jobs:
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment
-          # on images being uploaded to the S3 bucket
-          upload-artifacts: true
 
   bazel-system-test-hourly:
     name: Bazel System Tests Hourly
@@ -56,9 +53,6 @@ jobs:
           BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_hourly
           BAZEL_TARGETS: //rs/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment
-          # on images being uploaded to the S3 bucket
-          upload-artifacts: true
 
   bazel-run-fuzzers-hourly:
     name: Bazel Run Fuzzers Hourly

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -29,9 +29,6 @@ jobs:
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment
-          # on images being uploaded to the S3 bucket
-          upload-artifacts: true
   bazel-system-test-hourly:
     name: Bazel System Tests Hourly
     runs-on:
@@ -51,9 +48,6 @@ jobs:
           BAZEL_COMMAND: test --keep_going --test_tag_filters=system_test_hourly
           BAZEL_TARGETS: //rs/...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          # 'upload-artifacts' is required for the BNs as they rely for both dev and prod deployment
-          # on images being uploaded to the S3 bucket
-          upload-artifacts: true
   bazel-run-fuzzers-hourly:
     name: Bazel Run Fuzzers Hourly
     runs-on:


### PR DESCRIPTION
The boundary nodes have a new way of uploading release artifacts and do not require the artifacts to be uploaded as part of the hourly pipeline anymore.