### PR TITLE
chore: make `RegexString` and `RegexSubstitution` types public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "canlog"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "candid",
  "canlog_derive",

--- a/packages/canlog/CHANGELOG.md
+++ b/packages/canlog/CHANGELOG.md
@@ -5,4 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1] - 2025-06-23
+
+### Changed
+
+- Make `RegexString` and `RegexSubstitution` types public.
+
+## [0.1.0] - 2025-04-29
+
+### Added
+
+- Initial release of `canlog` crate.
+- Wraps `ic_canister_log` to provide a more ergonomic logging interface with native support for log priority levels.
+- `log!` macro to emit structured log messages associated with enum-based priority levels.
+- Support for custom log priority levels via the `LogPriorityLevels` trait.
+- Procedural macro `#[derive(LogPriorityLevels)]` (enabled with the `derive` feature) for automatic trait implementations.
+- Filtering of log entries via the `GetLogFilter` trait and `LogFilter` enum.
+- Regex-based filtering and substitution utilities via `RegexString` and `RegexSubstitution`.
+- Sorting of logs using `Sort::{Ascending, Descending}`.
+- `LogEntry` and `Log` types for capturing and serializing structured logs.

--- a/packages/canlog/Cargo.toml
+++ b/packages/canlog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canlog"
-version = "0.1.0"
+version = "0.1.1"
 description = "Crate for managing canister logs"
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/canlog/src/lib.rs
+++ b/packages/canlog/src/lib.rs
@@ -47,13 +47,12 @@
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
 
+extern crate self as canlog;
 #[cfg(test)]
 mod tests;
 mod types;
 
-extern crate self as canlog;
-
-pub use crate::types::{LogFilter, Sort};
+pub use crate::types::{LogFilter, RegexString, RegexSubstitution, Sort};
 
 pub use ic_canister_log::{
     declare_log_buffer, export as export_logs, log as raw_log, GlobalBuffer, Sink,


### PR DESCRIPTION
This PR makes the `RegexString` and `RegexSubstitution` types public. These types are required, for example, to instantiate `LogFilter::HidePattern` and `LogFilter::ShowPattern`.