### PR TITLE
fix: revert removal of PocketIC server endpoint to await ingress message

### DIFF
--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -675,13 +675,9 @@ impl PocketIc {
 
     /// Await an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.
     pub async fn await_call(&self, message_id: RawMessageId) -> Result<Vec<u8>, RejectResponse> {
-        for _ in 0..100 {
-            self.tick().await;
-            if let Some(result) = self.ingress_status(message_id.clone()).await {
-                return result;
-            }
-        }
-        panic!("PocketIC did not complete the update call within 100 rounds")
+        let endpoint = "update/await_ingress_message";
+        let result: RawCanisterResult = self.post(endpoint, message_id).await;
+        result.into()
     }
 
     /// Fetch the status of an update call submitted previously by `submit_call` or `submit_call_with_effective_principal`.

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- The endpoint `/instances/<instance_id>/update/await_ingress_message` (execute rounds on the PocketIc instance until the message is executed): to fix a performance regression when using the two endpoints `/instances/<instance_id>/update/tick` and `/instances/<instance_id>/read/ingress_status` in a loop.
+
 
 
 ## 9.0.3 - 2025-06-06
@@ -19,12 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The endpoint `/instances/<instance_id>/auto_progress` sets the (certified) time of the PocketIC instance
   to the current system time before starting to execute rounds automatically.
 
+### Removed
+- The endpoint `/instances/<instance_id>/update/await_ingress_message`:
+  use the two endpoints `/instances/<instance_id>/update/tick` and `/instances/<instance_id>/read/ingress_status`
+  to execute a round and fetch the status of the update call instead.
+
 
 
 ## 9.0.2 - 2025-05-27
 
 ### Fixed
 - Crash when creating a canister with a specified id on a PocketIC instance created from an existing PocketIC state.
+
+
 
 ## 9.0.1 - 2025-04-30
 

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -19,19 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The endpoint `/instances/<instance_id>/auto_progress` sets the (certified) time of the PocketIC instance
   to the current system time before starting to execute rounds automatically.
 
-### Removed
-- The endpoint `/instances/<instance_id>/update/await_ingress_message`:
-  use the two endpoints `/instances/<instance_id>/update/tick` and `/instances/<instance_id>/read/ingress_status`
-  to execute a round and fetch the status of the update call instead.
-
 
 
 ## 9.0.2 - 2025-05-27
 
 ### Fixed
 - Crash when creating a canister with a specified id on a PocketIC instance created from an existing PocketIC state.
-
-
 
 ## 9.0.1 - 2025-04-30
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1944,6 +1944,54 @@ impl TryFrom<RawMessageId> for MessageId {
 }
 
 #[derive(Clone, Debug)]
+pub struct AwaitIngressMessage(pub MessageId);
+
+impl Operation for AwaitIngressMessage {
+    fn compute(&self, pic: &mut PocketIc) -> OpOut {
+        let subnet = route(pic, self.0.effective_principal.clone(), false);
+        match subnet {
+            Ok(subnet) => {
+                // Now, we execute on all subnets until we have the result
+                let max_rounds = 100;
+                for _i in 0..max_rounds {
+                    match subnet.ingress_status(&self.0.msg_id) {
+                        IngressStatus::Known {
+                            state: IngressState::Completed(result),
+                            ..
+                        } => {
+                            return OpOut::CanisterResult(wasm_result_to_canister_result(
+                                result, true,
+                            ));
+                        }
+                        IngressStatus::Known {
+                            state: IngressState::Failed(error),
+                            ..
+                        } => {
+                            return OpOut::CanisterResult(Err(user_error_to_reject_response(
+                                error, true,
+                            )));
+                        }
+                        _ => {}
+                    }
+                    for subnet_ in pic.subnets.get_all() {
+                        subnet_.state_machine.execute_round();
+                    }
+                }
+                OpOut::Error(PocketIcError::BadIngressMessage(format!(
+                    "Failed to answer to ingress {} after {} rounds.",
+                    self.0.msg_id, max_rounds
+                )))
+            }
+            Err(e) => OpOut::Error(PocketIcError::BadIngressMessage(e)),
+        }
+    }
+
+    fn id(&self) -> OpId {
+        OpId(format!("await_update_{}", self.0.msg_id))
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct IngressMessageStatus {
     pub message_id: MessageId,
     pub caller: Option<Principal>,


### PR DESCRIPTION
This PR reverts [PR](https://github.com/dfinity/ic/pull/5065) which introduced a performance regression: using the two endpoints `/instances/<instance_id>/update/tick` and `/instances/<instance_id>/read/ingress_status` in a loop instead of a single endpoint `/instances/<instance_id>/update/await_ingress_message` can lead to a performance penalty of 4x on some workloads.