### PR TITLE
test: add test for candid types of management canister types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10367,6 +10367,7 @@ version = "0.9.0"
 dependencies = [
  "arbitrary",
  "candid",
+ "candid_parser",
  "ic-base-types",
  "ic-btc-interface",
  "ic-btc-replica-types",

--- a/rs/execution_environment/Contributing.md
+++ b/rs/execution_environment/Contributing.md
@@ -14,7 +14,7 @@ The following steps outline the recommended approach to introduce a new Manageme
 
 4. [Motoko](https://github.com/dfinity/motoko) needs to be updated. Inform *@eng-motoko* of the work required.
 
-5. Add any new types or update existing ones in `types/management_canister_types`. If possible, stick to existing naming conventions. E.g., error variants tend to have a domain specific prefix and a clear suffix describing the error, e.g., `ErrorCode::CanisterNotFound`. 
+5. Add any new types or update existing ones in `types/management_canister_types` and update their candid types in `types/management_canister_types/tests/ic.did`. If possible, stick to existing naming conventions. E.g., error variants tend to have a domain specific prefix and a clear suffix describing the error, e.g., `ErrorCode::CanisterNotFound`. 
 
 6. Implement the new API in the `execution_environment` crate. Main parts that need to be updated are:
    - the core implementation in the `canister_manager` module;

--- a/rs/execution_environment/Contributing.md
+++ b/rs/execution_environment/Contributing.md
@@ -14,9 +14,11 @@ The following steps outline the recommended approach to introduce a new Manageme
 
 4. [Motoko](https://github.com/dfinity/motoko) needs to be updated. Inform *@eng-motoko* of the work required.
 
-5. Add any new types or update existing ones in `types/management_canister_types` and update their candid types in `types/management_canister_types/tests/ic.did`. If possible, stick to existing naming conventions. E.g., error variants tend to have a domain specific prefix and a clear suffix describing the error, e.g., `ErrorCode::CanisterNotFound`. 
+5. Add any new types or update existing ones in `types/management_canister_types`. If possible, stick to existing naming conventions. E.g., error variants tend to have a domain specific prefix and a clear suffix describing the error, e.g., `ErrorCode::CanisterNotFound`.
 
-6. Implement the new API in the `execution_environment` crate. Main parts that need to be updated are:
+6. Update the candid declarations in `types/management_canister_types/tests/ic.did`. If a new management canister API is introduced, add a placeholder for it in `types/management_canister_types/tests/candid_equality.rs`.
+
+7. Implement the new API in the `execution_environment` crate. Main parts that need to be updated are:
    - the core implementation in the `canister_manager` module;
    - wiring up the new API in `ExecutionEnvironment` to expose it externally.
 
@@ -26,10 +28,10 @@ The following steps outline the recommended approach to introduce a new Manageme
    - no changes are performed before that point (only `&self` access to the state);
    - no failure can happen after that point (the execution is guaranteed to succeed and return a reply).
 
-7. Write tests to cover the new or updated functionality:
+8. Write tests to cover the new or updated functionality:
    - Use the `ExecutionTest` framework by default.
    - Use the `StateMachine` framework if the feature involves inter-canister calls, canister HTTPS outcalls, threshold signatures, or checkpointing. These require mocked Consensus layer outputs or a full state manager.
 
-8. Once the *Interface Specification* change has been agreed on, the public Management Canister [types](https://crates.io/crates/ic-management-canister-types), [Motoko](https://github.com/dfinity/motoko), and [Rust CDK](https://github.com/dfinity/cdk-rs) can be updated to use the new API on a feature branch. Coordinate with *@eng-sdk* and *@eng-motoko* as needed. The new functionality is enabled for testing in PocketIC (on a PocketIC instance created with the `nonmainnet_features` enabled) by enabling the corresponding feature flags in `rs/starter/src/lib.rs`.
+9. Once the *Interface Specification* change has been agreed on, the public Management Canister [types](https://crates.io/crates/ic-management-canister-types), [Motoko](https://github.com/dfinity/motoko), and [Rust CDK](https://github.com/dfinity/cdk-rs) can be updated to use the new API on a feature branch. Coordinate with *@eng-sdk* and *@eng-motoko* as needed. The new functionality is enabled for testing in PocketIC (on a PocketIC instance created with the `nonmainnet_features` enabled) by enabling the corresponding feature flags in `rs/starter/src/lib.rs`.
 
-9. Once the implementation is rolled out fully on mainnet, the Interface Specification, public Management Canister types, Rust CDK, and Motoko changes can be merged to master.
+10. Once the implementation is rolled out fully on mainnet, the Interface Specification, public Management Canister types, Rust CDK, and Motoko changes can be merged to master.

--- a/rs/types/management_canister_types/BUILD.bazel
+++ b/rs/types/management_canister_types/BUILD.bazel
@@ -98,3 +98,16 @@ rust_test(
     name = "management_canister_types_test",
     crate = ":management_canister_types",
 )
+
+rust_test(
+    name = "candid_equality",
+    srcs = glob(["tests/candid_equality.rs"]),
+    data = ["tests/ic.did"],
+    env = {"IC_DID": "$(rootpath :tests/ic.did)"},
+    deps = [
+        # Keep sorted.
+        ":management_canister_types",
+        "@crate_index//:candid",
+        "@crate_index//:candid_parser",
+    ],
+)

--- a/rs/types/management_canister_types/BUILD.bazel
+++ b/rs/types/management_canister_types/BUILD.bazel
@@ -101,7 +101,7 @@ rust_test(
 
 rust_test(
     name = "candid_equality",
-    srcs = glob(["tests/candid_equality.rs"]),
+    srcs = ["tests/candid_equality.rs"],
     data = ["tests/ic.did"],
     env = {"IC_DID": "$(rootpath :tests/ic.did)"},
     deps = [

--- a/rs/types/management_canister_types/Cargo.toml
+++ b/rs/types/management_canister_types/Cargo.toml
@@ -22,5 +22,8 @@ serde_cbor = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 
+[dev-dependencies]
+candid_parser = { workspace = true }
+
 [features]
 fuzzing_code = ["dep:arbitrary"]

--- a/rs/types/management_canister_types/tests/candid_equality.rs
+++ b/rs/types/management_canister_types/tests/candid_equality.rs
@@ -2,10 +2,11 @@
 use candid::candid_method;
 use ic_management_canister_types_private::*;
 
+// The following types have different names in `ic-management-canister-types` and `ic-management-canister-types-private`:
 type CreateCanisterResult = CanisterIdRecord;
 type UploadChunkResult = UploadChunkReply;
 type StoredChunksResult = StoredChunksReply;
-//type InstallCodeArgs = InstallCodeArgsV2;
+//type InstallCodeArgs = InstallCodeArgsV2; // inlined due to clash with `ic_management_canister_types_private::InstallCodeArgs`
 type StartCanisterArgs = CanisterIdRecord;
 type StopCanisterArgs = CanisterIdRecord;
 type CanisterStatusArgs = CanisterIdRecord;

--- a/rs/types/management_canister_types/tests/candid_equality.rs
+++ b/rs/types/management_canister_types/tests/candid_equality.rs
@@ -1,0 +1,203 @@
+#![allow(unused)]
+use candid::candid_method;
+use ic_management_canister_types_private::*;
+
+type CreateCanisterResult = CanisterIdRecord;
+type UploadChunkResult = UploadChunkReply;
+type StoredChunksResult = StoredChunksReply;
+//type InstallCodeArgs = InstallCodeArgsV2;
+type StartCanisterArgs = CanisterIdRecord;
+type StopCanisterArgs = CanisterIdRecord;
+type CanisterStatusArgs = CanisterIdRecord;
+type CanisterStatusResult = CanisterStatusResultV2;
+type CanisterInfoArgs = CanisterInfoRequest;
+type CanisterInfoResult = CanisterInfoResponse;
+type SubnetInfoResult = SubnetInfoResponse;
+type DeleteCanisterArgs = CanisterIdRecord;
+type DepositCyclesArgs = CanisterIdRecord;
+type RawRandResult = Vec<u8>;
+type HttpRequestArgs = CanisterHttpRequestArgs;
+type HttpRequestResult = CanisterHttpResponsePayload;
+type EcdsaPublicKeyArgs = ECDSAPublicKeyArgs;
+type EcdsaPublicKeyResult = ECDSAPublicKeyResponse;
+type SignWithEcdsaArgs = SignWithECDSAArgs;
+type SignWithEcdsaResult = SignWithECDSAReply;
+type SchnorrPublicKeyResult = SchnorrPublicKeyResponse;
+type SignWithSchnorrResult = SignWithSchnorrReply;
+type NodeMetricsHistoryResult = Vec<NodeMetricsHistoryResponse>;
+type ProvisionalCreateCanisterWithCyclesResult = CanisterIdRecord;
+type TakeCanisterSnapshotResult = CanisterSnapshotResponse;
+type ListCanisterSnapshotsArgs = CanisterIdRecord;
+type ListCanisterSnapshotsResult = Vec<CanisterSnapshotResponse>;
+type FetchCanisterLogsArgs = FetchCanisterLogsRequest;
+type FetchCanisterLogsResult = FetchCanisterLogsResponse;
+
+#[candid_method(update)]
+fn create_canister(_: CreateCanisterArgs) -> CreateCanisterResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn update_settings(_: UpdateSettingsArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn upload_chunk(_: UploadChunkArgs) -> UploadChunkResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn clear_chunk_store(_: ClearChunkStoreArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn stored_chunks(_: StoredChunksArgs) -> StoredChunksResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn install_code(_: InstallCodeArgsV2) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn install_chunked_code(_: InstallChunkedCodeArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn uninstall_code(_: UninstallCodeArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn start_canister(_: StartCanisterArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn stop_canister(_: StopCanisterArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn canister_status(_: CanisterStatusArgs) -> CanisterStatusResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn canister_info(_: CanisterInfoArgs) -> CanisterInfoResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn subnet_info(_: SubnetInfoArgs) -> SubnetInfoResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn delete_canister(_: DeleteCanisterArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn deposit_cycles(_: DepositCyclesArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn raw_rand() -> RawRandResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn http_request(_: HttpRequestArgs) -> HttpRequestResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn ecdsa_public_key(_: EcdsaPublicKeyArgs) -> EcdsaPublicKeyResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn sign_with_ecdsa(_: SignWithEcdsaArgs) -> SignWithEcdsaResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn schnorr_public_key(_: SchnorrPublicKeyArgs) -> SchnorrPublicKeyResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn sign_with_schnorr(_: SignWithSchnorrArgs) -> SignWithSchnorrResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn node_metrics_history(_: NodeMetricsHistoryArgs) -> NodeMetricsHistoryResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn provisional_create_canister_with_cycles(
+    _: ProvisionalCreateCanisterWithCyclesArgs,
+) -> ProvisionalCreateCanisterWithCyclesResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn provisional_top_up_canister(_: ProvisionalTopUpCanisterArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn take_canister_snapshot(_: TakeCanisterSnapshotArgs) -> TakeCanisterSnapshotResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn load_canister_snapshot(_: LoadCanisterSnapshotArgs) {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn list_canister_snapshots(_: ListCanisterSnapshotsArgs) -> ListCanisterSnapshotsResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn delete_canister_snapshot(_: DeleteCanisterSnapshotArgs) {
+    unreachable!()
+}
+
+#[candid_method(query)]
+fn fetch_canister_logs(_: FetchCanisterLogsArgs) -> FetchCanisterLogsResult {
+    unreachable!()
+}
+
+#[cfg(test)]
+mod test {
+    use crate::*;
+    use candid_parser::utils::{service_equal, CandidSource};
+    use ic_management_canister_types_private::*;
+
+    #[test]
+    fn candid_equality_test() {
+        let ic_did_path =
+            std::env::var("IC_DID").expect("Failed to read IC_DID environment variable");
+        let declared_interface_str =
+            std::fs::read_to_string(ic_did_path).expect("Failed to read ic.did file");
+        let declared_interface = CandidSource::Text(&declared_interface_str);
+
+        candid::export_service!();
+        let implemented_interface_str = __export_service();
+        let implemented_interface = CandidSource::Text(&implemented_interface_str);
+
+        let result = service_equal(declared_interface, implemented_interface);
+        assert!(result.is_ok(), "{:?}", result.unwrap_err());
+    }
+}

--- a/rs/types/management_canister_types/tests/ic.did
+++ b/rs/types/management_canister_types/tests/ic.did
@@ -44,6 +44,7 @@ type change_origin = variant {
 type change_details = variant {
     creation : record {
         controllers : vec principal;
+        environment_variables_hash : opt blob;
     };
     code_uninstall;
     code_deployment : record {
@@ -57,6 +58,10 @@ type change_details = variant {
     };
     controllers_change : record {
         controllers : vec principal;
+    };
+    settings_change : record {
+        controllers : opt vec principal;
+        environment_variables_hash : opt blob;
     };
 };
 

--- a/rs/types/management_canister_types/tests/ic.did
+++ b/rs/types/management_canister_types/tests/ic.did
@@ -1,0 +1,512 @@
+type canister_id = principal;
+type wasm_module = blob;
+type snapshot_id = blob;
+
+type log_visibility = variant {
+    controllers;
+    public;
+    allowed_viewers : vec principal;
+};
+
+type canister_settings = record {
+    controllers : opt vec principal;
+    compute_allocation : opt nat;
+    memory_allocation : opt nat;
+    freezing_threshold : opt nat;
+    reserved_cycles_limit : opt nat;
+    log_visibility : opt log_visibility;
+    wasm_memory_limit : opt nat;
+    wasm_memory_threshold : opt nat;
+};
+
+type definite_canister_settings = record {
+    controllers : vec principal;
+    controller : principal;
+    compute_allocation : nat;
+    memory_allocation : nat;
+    freezing_threshold : nat;
+    reserved_cycles_limit : nat;
+    log_visibility : log_visibility;
+    wasm_memory_limit : nat;
+    wasm_memory_threshold: nat;
+};
+
+type change_origin = variant {
+    from_user : record {
+        user_id : principal;
+    };
+    from_canister : record {
+        canister_id : principal;
+        canister_version : opt nat64;
+    };
+};
+
+type change_details = variant {
+    creation : record {
+        controllers : vec principal;
+    };
+    code_uninstall;
+    code_deployment : record {
+        mode : variant { install; reinstall; upgrade };
+        module_hash : blob;
+    };
+    load_snapshot : record {
+      canister_version : nat64;
+      snapshot_id : snapshot_id;
+      taken_at_timestamp : nat64;
+    };
+    controllers_change : record {
+        controllers : vec principal;
+    };
+};
+
+type change = record {
+    timestamp_nanos : nat64;
+    canister_version : nat64;
+    origin : change_origin;
+    details : change_details;
+};
+
+type chunk_hash = record {
+  hash : blob;
+};
+
+type http_header = record {
+    name : text;
+    value : text;
+};
+
+type http_request_result = record {
+    status : nat;
+    headers : vec http_header;
+    body : blob;
+};
+
+type ecdsa_curve = variant {
+    secp256k1;
+};
+
+type vetkd_curve = variant {
+    bls12_381_g2;
+};
+
+type schnorr_algorithm = variant {
+    bip340secp256k1;
+    ed25519;
+};
+
+type satoshi = nat64;
+
+type bitcoin_network = variant {
+    mainnet;
+    testnet;
+};
+
+type bitcoin_address = text;
+
+type bitcoin_block_hash = blob;
+
+type bitcoin_block_header = blob;
+
+type millisatoshi_per_byte = nat64;
+
+type bitcoin_block_height = nat32;
+
+type outpoint = record {
+    txid : blob;
+    vout : nat32;
+};
+
+type utxo = record {
+    outpoint : outpoint;
+    value : satoshi;
+    height : nat32;
+};
+
+type bitcoin_get_utxos_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    filter : opt variant {
+        min_confirmations : nat32;
+        page : blob;
+    };
+};
+
+type bitcoin_get_utxos_result = record {
+    utxos : vec utxo;
+    tip_block_hash : bitcoin_block_hash;
+    tip_height : bitcoin_block_height;
+    next_page : opt blob;
+};
+
+type bitcoin_get_balance_args = record {
+    address : bitcoin_address;
+    network : bitcoin_network;
+    min_confirmations : opt nat32;
+};
+
+type bitcoin_get_balance_result = satoshi;
+
+type bitcoin_get_current_fee_percentiles_args = record {
+    network : bitcoin_network;
+};
+
+type bitcoin_get_current_fee_percentiles_result = vec millisatoshi_per_byte;
+
+type bitcoin_send_transaction_args = record {
+    transaction : blob;
+    network : bitcoin_network;
+};
+
+type bitcoin_get_block_headers_args = record {
+    start_height : bitcoin_block_height;
+    end_height : opt bitcoin_block_height;
+    network: bitcoin_network;
+};
+
+type bitcoin_get_block_headers_result = record {
+    tip_height : bitcoin_block_height;
+    block_headers : vec bitcoin_block_header;
+};
+
+type node_metrics = record {
+    node_id : principal;
+    num_blocks_proposed_total : nat64;
+    num_block_failures_total : nat64;
+};
+
+type create_canister_args = record {
+    settings : opt canister_settings;
+    sender_canister_version : opt nat64;
+};
+
+type create_canister_result = record {
+    canister_id : canister_id;
+};
+
+type update_settings_args = record {
+    canister_id : principal;
+    settings : canister_settings;
+    sender_canister_version : opt nat64;
+};
+
+type upload_chunk_args = record {
+    canister_id : principal;
+    chunk : blob;
+};
+
+type clear_chunk_store_args = record {
+    canister_id : canister_id;
+};
+
+type stored_chunks_args = record {
+    canister_id : canister_id;
+};
+
+type canister_install_mode = variant {
+    install;
+    reinstall;
+    upgrade : opt record {
+        skip_pre_upgrade : opt bool;
+        wasm_memory_persistence : opt variant {
+            keep;
+            replace;
+        };
+    };
+};
+
+type install_code_args = record {
+    mode : canister_install_mode;
+    canister_id : canister_id;
+    wasm_module : wasm_module;
+    arg : blob;
+    sender_canister_version : opt nat64;
+};
+
+type install_chunked_code_args = record {
+    mode : canister_install_mode;
+    target_canister : canister_id;
+    store_canister : opt canister_id;
+    chunk_hashes_list : vec chunk_hash;
+    wasm_module_hash : blob;
+    arg : blob;
+    sender_canister_version : opt nat64;
+};
+
+type uninstall_code_args = record {
+    canister_id : canister_id;
+    sender_canister_version : opt nat64;
+};
+
+type start_canister_args = record {
+    canister_id : canister_id;
+};
+
+type stop_canister_args = record {
+    canister_id : canister_id;
+};
+
+type canister_status_args = record {
+    canister_id : canister_id;
+};
+
+type canister_status_result = record {
+    status : variant { running; stopping; stopped };
+    settings : definite_canister_settings;
+    module_hash : opt blob;
+    memory_size : nat;
+    memory_metrics : record {
+        wasm_memory_size : nat;
+        stable_memory_size : nat;
+        global_memory_size : nat;
+        wasm_binary_size : nat;
+        custom_sections_size : nat;
+        canister_history_size : nat;
+        wasm_chunk_store_size : nat;
+        snapshots_size : nat;
+    };
+    controller : principal;
+    freezing_threshold : nat;
+    balance : vec record { blob; nat };
+    cycles : nat;
+    reserved_cycles : nat;
+    idle_cycles_burned_per_day : nat;
+    query_stats: record {
+        num_calls_total: nat;
+        num_instructions_total: nat;
+        request_payload_bytes_total: nat;
+        response_payload_bytes_total: nat;
+    };
+};
+
+type canister_info_args = record {
+    canister_id : canister_id;
+    num_requested_changes : opt nat64;
+};
+
+type canister_info_result = record {
+    total_num_changes : nat64;
+    recent_changes : vec change;
+    module_hash : opt blob;
+    controllers : vec principal;
+};
+
+type delete_canister_args = record {
+    canister_id : canister_id;
+};
+
+type deposit_cycles_args = record {
+    canister_id : canister_id;
+};
+
+type http_request_args = record {
+    url : text;
+    max_response_bytes : opt nat64;
+    method : variant { get; head; post };
+    headers : vec http_header;
+    body : opt blob;
+    transform : opt record {
+        function : func(record { response : http_request_result; context : blob }) -> (http_request_result) query;
+        context : blob;
+    };
+};
+
+type ecdsa_public_key_args = record {
+    canister_id : opt canister_id;
+    derivation_path : vec blob;
+    key_id : record { curve : ecdsa_curve; name : text };
+};
+
+type ecdsa_public_key_result = record {
+    public_key : blob;
+    chain_code : blob;
+};
+
+type sign_with_ecdsa_args = record {
+    message_hash : blob;
+    derivation_path : vec blob;
+    key_id : record { curve : ecdsa_curve; name : text };
+};
+
+type sign_with_ecdsa_result = record {
+    signature : blob;
+};
+
+type schnorr_public_key_args = record {
+    canister_id : opt canister_id;
+    derivation_path : vec blob;
+    key_id : record { algorithm : schnorr_algorithm; name : text };
+};
+
+type schnorr_public_key_result = record {
+    public_key : blob;
+    chain_code : blob;
+};
+
+type schnorr_aux = variant {
+    bip341: record {
+      merkle_root_hash: blob;
+   }
+};
+
+type sign_with_schnorr_args = record {
+    message : blob;
+    derivation_path : vec blob;
+    key_id : record { algorithm : schnorr_algorithm; name : text };
+    aux: opt schnorr_aux;
+};
+
+type sign_with_schnorr_result = record {
+    signature : blob;
+};
+
+type vetkd_public_key_args = record {
+    canister_id : opt canister_id;
+    context : blob;
+    key_id : record { curve : vetkd_curve; name : text };
+};
+
+type vetkd_public_key_result = record {
+    public_key : blob;
+};
+
+type vetkd_derive_key_args = record {
+    input : blob;
+    context : blob;
+    transport_public_key : blob;
+    key_id : record { curve : vetkd_curve; name : text };
+};
+
+type vetkd_derive_key_result = record {
+    encrypted_key : blob;
+};
+
+type node_metrics_history_args = record {
+    subnet_id : principal;
+    start_at_timestamp_nanos : nat64;
+};
+
+type node_metrics_history_result = vec record {
+    timestamp_nanos : nat64;
+    node_metrics : vec node_metrics;
+};
+
+type subnet_info_args = record {
+    subnet_id : principal;
+};
+
+type subnet_info_result = record {
+    replica_version : text;
+};
+
+type provisional_create_canister_with_cycles_args = record {
+    amount : opt nat;
+    settings : opt canister_settings;
+    specified_id : opt canister_id;
+    sender_canister_version : opt nat64;
+};
+
+type provisional_create_canister_with_cycles_result = record {
+    canister_id : canister_id;
+};
+
+type provisional_top_up_canister_args = record {
+    canister_id : canister_id;
+    amount : nat;
+};
+
+type raw_rand_result = blob;
+
+type stored_chunks_result = vec chunk_hash;
+
+type upload_chunk_result = chunk_hash;
+
+type snapshot = record {
+  id : snapshot_id;
+  taken_at_timestamp : nat64;
+  total_size : nat64;
+};
+
+type take_canister_snapshot_args = record {
+  canister_id : canister_id;
+  replace_snapshot : opt snapshot_id;
+};
+
+type take_canister_snapshot_result = snapshot;
+
+type load_canister_snapshot_args = record {
+  canister_id : canister_id;
+  snapshot_id : snapshot_id;
+  sender_canister_version : opt nat64;
+};
+
+type list_canister_snapshots_args = record {
+  canister_id : canister_id;
+};
+
+type list_canister_snapshots_result = vec snapshot;
+
+type delete_canister_snapshot_args = record {
+  canister_id : canister_id;
+  snapshot_id : snapshot_id;
+};
+
+type fetch_canister_logs_args = record {
+    canister_id : canister_id;
+};
+
+type canister_log_record = record {
+    idx: nat64;
+    timestamp_nanos: nat64;
+    content: blob;
+};
+
+type fetch_canister_logs_result = record {
+    canister_log_records: vec canister_log_record;
+};
+
+service ic : {
+    create_canister : (create_canister_args) -> (create_canister_result);
+    update_settings : (update_settings_args) -> ();
+    upload_chunk : (upload_chunk_args) -> (upload_chunk_result);
+    clear_chunk_store : (clear_chunk_store_args) -> ();
+    stored_chunks : (stored_chunks_args) -> (stored_chunks_result);
+    install_code : (install_code_args) -> ();
+    install_chunked_code : (install_chunked_code_args) -> ();
+    uninstall_code : (uninstall_code_args) -> ();
+    start_canister : (start_canister_args) -> ();
+    stop_canister : (stop_canister_args) -> ();
+    canister_status : (canister_status_args) -> (canister_status_result);
+    canister_info : (canister_info_args) -> (canister_info_result);
+    delete_canister : (delete_canister_args) -> ();
+    deposit_cycles : (deposit_cycles_args) -> ();
+    raw_rand : () -> (raw_rand_result);
+    http_request : (http_request_args) -> (http_request_result);
+
+    // Threshold ECDSA signature
+    ecdsa_public_key : (ecdsa_public_key_args) -> (ecdsa_public_key_result);
+    sign_with_ecdsa : (sign_with_ecdsa_args) -> (sign_with_ecdsa_result);
+
+    // Threshold Schnorr signature
+    schnorr_public_key : (schnorr_public_key_args) -> (schnorr_public_key_result);
+    sign_with_schnorr : (sign_with_schnorr_args) -> (sign_with_schnorr_result);
+
+    // metrics interface
+    node_metrics_history : (node_metrics_history_args) -> (node_metrics_history_result);
+
+    // subnet info
+    subnet_info : (subnet_info_args) -> (subnet_info_result);
+
+    // provisional interfaces for the pre-ledger world
+    provisional_create_canister_with_cycles : (provisional_create_canister_with_cycles_args) -> (provisional_create_canister_with_cycles_result);
+    provisional_top_up_canister : (provisional_top_up_canister_args) -> ();
+
+    // Canister snapshots
+    take_canister_snapshot : (take_canister_snapshot_args) -> (take_canister_snapshot_result);
+    load_canister_snapshot : (load_canister_snapshot_args) -> ();
+    list_canister_snapshots : (list_canister_snapshots_args) -> (list_canister_snapshots_result);
+    delete_canister_snapshot : (delete_canister_snapshot_args) -> ();
+
+    // canister logging
+    fetch_canister_logs : (fetch_canister_logs_args) -> (fetch_canister_logs_result) query;
+};


### PR DESCRIPTION
This PR ports the candid equality test from [cdk-rs](https://github.com/dfinity/cdk-rs/blob/5ef8e6ab2911e1dccceaaba9839999c7bbe15568/ic-management-canister-types/tests/candid_equality.rs) to this repository. This is supposed to prevent regressions like [this](https://github.com/dfinity/ic/pull/5662). The following missing management canister APIs are left for future work: VetKD, bitcoin, snapshot upload/download.