### PR TITLE
chore(IDX): make schedule-daily bazel commands explicit

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -92,11 +92,15 @@ jobs:
       - name: Set up backup pod access
         <<: *backup-pod-access
       - name: Run FI Tests Nightly
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200
-          BAZEL_TARGETS: //rs/ledger_suite/...
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=fi_tests_nightly \
+              //rs/ledger_suite/... \
+              --test_env=SSH_AUTH_SOCK \
+              --keep_going --test_timeout=43200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   nns-tests-nightly:
@@ -108,11 +112,15 @@ jobs:
       - name: Set up backup pod access
         <<: *backup-pod-access
       - name: Run NNS Tests Nightly
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all
-          BAZEL_TARGETS: //rs/nns/...
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=nns_tests_nightly \
+              //rs/nns/... \
+              --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
+              --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   system-tests-benchmarks-nightly:
@@ -121,18 +129,27 @@ jobs:
     timeout-minutes: 480
     steps:
       - <<: *checkout
-      - name: Set Benchmark Targets
-        shell: bash
-        run: |
-          set -xeuo pipefail
-          echo "BENCHMARK_TARGETS=$(bazel query 'attr(tags, system_test_benchmark, //rs/...)' | grep -v head_nns | tr '\n' ' ')" >> $GITHUB_ENV
       - name: Test System Test Benchmarks
         id: bazel-system-test-benchmarks
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          # note: there's just one performance cluster, so the job can't be parallelized
-          BAZEL_COMMAND: test --test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1
-          BAZEL_TARGETS: ${{ env.BENCHMARK_TARGETS }}
+          run: |
+            set -euo pipefail
+
+            target_pattern_file=$(mktemp)
+            bazel query 'attr(tags, system_test_benchmark, //rs/...)' | grep -v head_nns > "$target_pattern_file"
+
+            echo "inferred system test benchmark targets:"
+            cat "$target_pattern_file"
+
+            # note: there's just one performance cluster, so the job can't be parallelized (hence --jobs=1)
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=system_test_benchmark \
+              --//bazel:enable_upload_perf_systest_results=True \
+              --target_pattern_file="$target_pattern_file" \
+              --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
+              --keep_going --jobs=1
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Post Slack Notification
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -82,11 +82,15 @@ jobs:
           chmod 0700 ~/.ssh
           echo -e "Host *\nUser github-runner\n" > ~/.ssh/config
       - name: Run FI Tests Nightly
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=fi_tests_nightly --test_env=SSH_AUTH_SOCK --test_timeout=43200
-          BAZEL_TARGETS: //rs/ledger_suite/...
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=fi_tests_nightly \
+              //rs/ledger_suite/... \
+              --test_env=SSH_AUTH_SOCK \
+              --keep_going --test_timeout=43200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   nns-tests-nightly:
     name: Bazel Test NNS Nightly
@@ -116,11 +120,15 @@ jobs:
           chmod 0700 ~/.ssh
           echo -e "Host *\nUser github-runner\n" > ~/.ssh/config
       - name: Run NNS Tests Nightly
-        id: bazel-test-all
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: test --keep_going --test_tag_filters=nns_tests_nightly --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all
-          BAZEL_TARGETS: //rs/nns/...
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=nns_tests_nightly \
+              //rs/nns/... \
+              --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
+              --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   system-tests-benchmarks-nightly:
     name: Bazel System Test Benchmarks
@@ -134,18 +142,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set Benchmark Targets
-        shell: bash
-        run: |
-          set -xeuo pipefail
-          echo "BENCHMARK_TARGETS=$(bazel query 'attr(tags, system_test_benchmark, //rs/...)' | grep -v head_nns | tr '\n' ' ')" >> $GITHUB_ENV
       - name: Test System Test Benchmarks
         id: bazel-system-test-benchmarks
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          # note: there's just one performance cluster, so the job can't be parallelized
-          BAZEL_COMMAND: test --test_tag_filters=system_test_benchmark --//bazel:enable_upload_perf_systest_results=True --keep_going --jobs 1
-          BAZEL_TARGETS: ${{ env.BENCHMARK_TARGETS }}
+          run: |
+            set -euo pipefail
+
+            target_pattern_file=$(mktemp)
+            bazel query 'attr(tags, system_test_benchmark, //rs/...)' | grep -v head_nns > "$target_pattern_file"
+
+            echo "inferred system test benchmark targets:"
+            cat "$target_pattern_file"
+
+            # note: there's just one performance cluster, so the job can't be parallelized (hence --jobs=1)
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=system_test_benchmark \
+              --//bazel:enable_upload_perf_systest_results=True \
+              --target_pattern_file="$target_pattern_file" \
+              --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
+              --keep_going --jobs=1
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Post Slack Notification
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0


### PR DESCRIPTION
This changes the `schedule-daily` jobs to call bazel directly, with specific targets instead of calling `bazel-test-all`.