### PR TITLE
chore: use HTTP gateway for nested registration test

### DIFF
--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
-load("//rs/tests:common.bzl", "GUESTOS_RUNTIME_DEPS", "MAINNET_ENV")
+load("//rs/tests:common.bzl", "GUESTOS_RUNTIME_DEPS", "IC_GATEWAY_RUNTIME_DEPS", "MAINNET_ENV")
 load("//rs/tests:system_tests.bzl", "system_test_nns")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
@@ -59,7 +59,7 @@ system_test_nns(
     use_empty_image = True,
     uses_guestos_dev = True,
     uses_setupos_dev = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS,
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -84,7 +84,7 @@ system_test_nns(
     uses_guestos_dev = True,
     uses_hostos_dev_test = True,
     uses_setupos_dev = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS,
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -104,7 +104,7 @@ system_test_nns(
     uses_guestos_dev = True,
     uses_hostos_dev_test = True,
     uses_setupos_mainnet = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -126,6 +126,6 @@ system_test_nns(
     uses_guestos_dev = True,
     uses_hostos_mainnet_update_img = True,
     uses_setupos_mainnet = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
     deps = RUNNER_DEPENDENCIES,
 )

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -7,7 +7,13 @@ use canister_test::PrincipalId;
 use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
-    driver::{ic::InternetComputer, nested::NestedVms, test_env::TestEnv, test_env_api::*},
+    driver::{
+        ic::InternetComputer,
+        ic_gateway_vm::{IcGatewayVm, IC_GATEWAY_VM_NAME},
+        nested::NestedVms,
+        test_env::TestEnv,
+        test_env_api::*,
+    },
     retry_with_msg,
     util::block_on,
 };
@@ -38,14 +44,18 @@ pub fn config(env: TestEnv) {
     // Setup "testnet"
     InternetComputer::new()
         .add_fast_single_node_subnet(SubnetType::System)
-        .with_mainnet_config()
         .with_api_boundary_nodes(1)
+        .with_mainnet_config()
         .with_node_provider(principal)
         .with_node_operator(principal)
         .setup_and_start(&env)
         .expect("failed to setup IC under test");
 
     install_nns_and_check_progress(env.topology_snapshot());
+
+    IcGatewayVm::new(IC_GATEWAY_VM_NAME)
+        .start(&env)
+        .expect("failed to setup ic-gateway");
 
     setup_nested_vm(env, HOST_VM_NAME);
 }


### PR DESCRIPTION
Make the node go through an HTTP gateway when trying to submit the join request to the NNS. This reflects the mainnet behavior. 