### PR TITLE
chore: simplify build-all-no-cache command

### DIFF
--- a/.github/workflows-source/schedule-hourly.yml
+++ b/.github/workflows-source/schedule-hourly.yml
@@ -34,11 +34,9 @@ jobs:
     steps:
       - <<: *checkout
       - name: Run Bazel Build All No Cache
-        uses:  ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: build --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA}
-          BAZEL_TARGETS: //...
-          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
+          run: bazel build --config=stamped --config=local //...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   bazel-run-fuzzers-hourly:

--- a/.github/workflows/schedule-hourly.yml
+++ b/.github/workflows/schedule-hourly.yml
@@ -23,11 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run Bazel Build All No Cache
-        uses: ./.github/actions/bazel-test-all/
+        uses: ./.github/actions/bazel
         with:
-          BAZEL_COMMAND: build --repository_cache= --disk_cache= --noremote_accept_cached --remote_instance_name=${CI_COMMIT_SHA}
-          BAZEL_TARGETS: //...
-          CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
+          run: bazel build --config=stamped --config=local //...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   bazel-run-fuzzers-hourly:
     name: Bazel Run Fuzzers Hourly


### PR DESCRIPTION
This changes the `build-all-no-cache` job to call bazel directly, instead of calling `bazel-test-all`.