### PR TITLE
chore: merge release-testing system tests

### DIFF
--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -9,9 +9,6 @@ inputs:
   execlogs-artifact-name:
     required: false
     description: "When provided, the execlogs will be uploaded as an artifact with the specified name."
-  bep-artifact-name:
-    required: false
-    description: "When provided, the build events will be uploaded as an artifact with the specified name. Default: <github.job>-bep"
   GPG_PASSPHRASE:
     required: true
     description: "GPG key to encrypt build events. Upload can be disabled by explicitly setting the input to an empty string."
@@ -68,7 +65,7 @@ runs:
       if: success() || failure()
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.bep-artifact-name || format('{0}-bep', github.job) }}
+        name: ${{ github.job }}-bep
         retention-days: 14
         if-no-files-found: ignore
         compression-level: 9

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -50,7 +50,7 @@ jobs:
   # Those test suites would overwhelm a runner, so each is run
   # as a separate job.
   release-system-tests:
-    name: Bazel System Tests
+    name: Release System Tests
     <<: *dind-large-setup
     steps:
       - <<: *checkout

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -50,14 +50,8 @@ jobs:
   # Those test suites would overwhelm a runner, so each is run
   # as a separate job.
   release-system-tests:
-    name: Bazel System Tests (${{ matrix.tag }})
+    name: Bazel System Tests
     <<: *dind-large-setup
-    strategy:
-      matrix:
-        tag:
-          - system_test_nightly
-          - system_test_staging
-          - system_test_hotfix
     steps:
       - <<: *checkout
       - name: Run Bazel System Tests
@@ -66,11 +60,9 @@ jobs:
           run: |
             bazel test \
               --config=stamped \
-              --test_tag_filters=${{ matrix.tag }} \
+              --test_tag_filters=system_test_nightly,system_test_staging,system_test_hotfix \
               //rs/tests/... \
               --keep_going
-          # prevent artifact name overlap
-          bep-artifact-name: ${{ github.job }}-${{ matrix.tag }}-bep
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   dependency-scan-release-cut:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -27,7 +27,7 @@ jobs:
   # Those test suites would overwhelm a runner, so each is run
   # as a separate job.
   release-system-tests:
-    name: Bazel System Tests
+    name: Release System Tests
     runs-on:
       labels: dind-large
     container:

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -27,7 +27,7 @@ jobs:
   # Those test suites would overwhelm a runner, so each is run
   # as a separate job.
   release-system-tests:
-    name: Bazel System Tests (${{ matrix.tag }})
+    name: Bazel System Tests
     runs-on:
       labels: dind-large
     container:
@@ -35,12 +35,6 @@ jobs:
       options: >-
         -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 180 # 3 hours
-    strategy:
-      matrix:
-        tag:
-          - system_test_nightly
-          - system_test_staging
-          - system_test_hotfix
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,11 +46,9 @@ jobs:
           run: |
             bazel test \
               --config=stamped \
-              --test_tag_filters=${{ matrix.tag }} \
+              --test_tag_filters=system_test_nightly,system_test_staging,system_test_hotfix \
               //rs/tests/... \
               --keep_going
-          # prevent artifact name overlap
-          bep-artifact-name: ${{ github.job }}-${{ matrix.tag }}-bep
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   dependency-scan-release-cut:
     name: Dependency Scan for Release


### PR DESCRIPTION
This drops the `matrix` and merges all 3 kinds of system tests into a single job. This means the codebase doesn't have to be built 3 times and simplifies the workflow.

Originally discussed here: https://github.com/dfinity/ic/pull/5655#discussion_r2161555423