### PR TITLE
chore: filter out head nns benchmarks by tag

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -134,20 +134,15 @@ jobs:
         uses: ./.github/actions/bazel
         with:
           run: |
-            set -euo pipefail
-
-            target_pattern_file=$(mktemp)
-            bazel query 'attr(tags, system_test_benchmark, //rs/...)' | grep -v head_nns > "$target_pattern_file"
-
-            echo "inferred system test benchmark targets:"
-            cat "$target_pattern_file"
-
-            # note: there's just one performance cluster, so the job can't be parallelized (hence --jobs=1)
+            # note: there's just one performance cluster, so the job can't be parallelized
+            # (hence --jobs=1)
+            # we exclude 'system_test_head_nns' tests to avoid running every benchmark
+            # effectively twice (we don't care about the different between mainnet & head NNS)
             bazel test \
               --config=stamped \
-              --test_tag_filters=system_test_benchmark \
+              --test_tag_filters="system_test_benchmark,-system_test_head_nns" \
+              //rs/... \
               --//bazel:enable_upload_perf_systest_results=True \
-              --target_pattern_file="$target_pattern_file" \
               --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
               --keep_going --jobs=1
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -147,20 +147,15 @@ jobs:
         uses: ./.github/actions/bazel
         with:
           run: |
-            set -euo pipefail
-
-            target_pattern_file=$(mktemp)
-            bazel query 'attr(tags, system_test_benchmark, //rs/...)' | grep -v head_nns > "$target_pattern_file"
-
-            echo "inferred system test benchmark targets:"
-            cat "$target_pattern_file"
-
-            # note: there's just one performance cluster, so the job can't be parallelized (hence --jobs=1)
+            # note: there's just one performance cluster, so the job can't be parallelized
+            # (hence --jobs=1)
+            # we exclude 'system_test_head_nns' tests to avoid running every benchmark
+            # effectively twice (we don't care about the different between mainnet & head NNS)
             bazel test \
               --config=stamped \
-              --test_tag_filters=system_test_benchmark \
+              --test_tag_filters="system_test_benchmark,-system_test_head_nns" \
+              //rs/... \
               --//bazel:enable_upload_perf_systest_results=True \
-              --target_pattern_file="$target_pattern_file" \
               --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
               --keep_going --jobs=1
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -395,12 +395,15 @@ def system_test_nns(name, extra_head_nns_tags = ["system_test_nightly"], **kwarg
     )
 
     original_tags = kwargs.pop("tags", [])
+    tags = extra_head_nns_tags
+    tags = tags + [tag for tag in original_tags if tag not in tags]
+    tags = tags + ["system_test_head_nns"]
     kwargs["test_driver_target"] = mainnet_nns_systest.test_driver_target
     system_test(
         name + "_head_nns",
         env = env | NNS_CANISTER_ENV,
         runtime_deps = runtime_deps + NNS_CANISTER_RUNTIME_DEPS,
-        tags = [tag for tag in original_tags if tag not in extra_head_nns_tags] + extra_head_nns_tags,
+        tags = tags,
         **kwargs
     )
     return struct(test_driver_target = mainnet_nns_systest.test_driver_target)


### PR DESCRIPTION
This replaces the `bazel query` previously used in daily/nightly benchmarks with test tag filters.