### PR TITLE
chore(IDX): bump timeout for ledger_test

### DIFF
--- a/rs/ledger_suite/icrc1/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/ledger/BUILD.bazel
@@ -269,6 +269,7 @@ package(default_visibility = ["//visibility:public"])
 [
     rust_ic_test(
         name = "ledger_test" + name_suffix,
+        timeout = "long",
         srcs = ["tests/tests.rs"],
         crate_features = features,
         data = [


### PR DESCRIPTION
We've seen this test timeout a couple times. Instead of marking it as flaky, increase the timeout.