### PR TITLE
fix: use correct release-build output

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -230,7 +230,7 @@ jobs:
         env:
           NODE_NAME: ${{ runner.name }}
         with:
-          upload-artifacts: ${{ needs.config.outputs.release_build && needs.config.outputs.full_macos_build }}
+          upload-artifacts: ${{ needs.config.outputs.release-build && needs.config.outputs.full_macos_build }}
           BAZEL_COMMAND: ${{ steps.cfg.outputs.build-command }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
@@ -315,7 +315,7 @@ jobs:
     name: Upload external artifacts
     <<: *dind-large-setup
     needs: [bazel-test-arm64-linux, bazel-test-arm64-darwin, config]
-    if: ${{ needs.config.outputs.release_build == 'true' }} # GHA output quirk, 'true' is a string
+    if: ${{ needs.config.outputs.release-build == 'true' }} # GHA output quirk, 'true' is a string
     steps:
       - uses: actions/checkout@v4
       - name: Download pocket-ic-server (arm64-linux)
@@ -357,7 +357,7 @@ jobs:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ON_DIFF_ONLY: ${{ needs.config.outputs.diff_only }}
-          RELEASE_BUILD: ${{ needs.config.outputs.release_build }}
+          RELEASE_BUILD: ${{ needs.config.outputs.release-build }}
 
   bazel-build-fuzzers:
     name: Bazel Build Fuzzers

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -201,7 +201,7 @@ jobs:
         env:
           NODE_NAME: ${{ runner.name }}
         with:
-          upload-artifacts: ${{ needs.config.outputs.release_build && needs.config.outputs.full_macos_build }}
+          upload-artifacts: ${{ needs.config.outputs.release-build && needs.config.outputs.full_macos_build }}
           BAZEL_COMMAND: ${{ steps.cfg.outputs.build-command }}
           BAZEL_TARGETS: //...
           CLOUD_CREDENTIALS_CONTENT: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
@@ -285,7 +285,7 @@ jobs:
         -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 90
     needs: [bazel-test-arm64-linux, bazel-test-arm64-darwin, config]
-    if: ${{ needs.config.outputs.release_build == 'true' }} # GHA output quirk, 'true' is a string
+    if: ${{ needs.config.outputs.release-build == 'true' }} # GHA output quirk, 'true' is a string
     steps:
       - uses: actions/checkout@v4
       - name: Download pocket-ic-server (arm64-linux)
@@ -324,7 +324,7 @@ jobs:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_ON_DIFF_ONLY: ${{ needs.config.outputs.diff_only }}
-          RELEASE_BUILD: ${{ needs.config.outputs.release_build }}
+          RELEASE_BUILD: ${{ needs.config.outputs.release-build }}
   bazel-build-fuzzers:
     name: Bazel Build Fuzzers
     runs-on:


### PR DESCRIPTION
In https://github.com/dfinity/ic/pull/5626 the `release_build` was renamed to `release-build`, though all occurrences were not replaced correctly. This fixes it, and ensures artifacts are uploaded.