### PR TITLE
chore: remove duplicated and unused system test tags

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -159,7 +159,7 @@ jobs:
           set -xeuo pipefail
           # Determine which tests to skip
           EXCLUDED_TEST_TAGS=(
-              system_test_nightly
+              system_test_large
               system_test_benchmark
               fuzz_test
               fi_tests_nightly

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -60,7 +60,7 @@ jobs:
           run: |
             bazel test \
               --config=stamped \
-              --test_tag_filters=system_test_nightly \
+              --test_tag_filters=system_test_large \
               //rs/tests/... \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -129,7 +129,7 @@ jobs:
           set -xeuo pipefail
           # Determine which tests to skip
           EXCLUDED_TEST_TAGS=(
-              system_test_nightly
+              system_test_large
               system_test_benchmark
               fuzz_test
               fi_tests_nightly

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -46,7 +46,7 @@ jobs:
           run: |
             bazel test \
               --config=stamped \
-              --test_tag_filters=system_test_nightly \
+              --test_tag_filters=system_test_large \
               //rs/tests/... \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -244,7 +244,7 @@ system_test_nns(
     tags = [
         "experimental_system_test_colocation",
         "subnet_recovery",
-        "system_test_nightly",  # only run as part of release-testing since this test requires many resources.
+        "system_test_large",  # only run as part of release-testing since this test requires many resources.
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",

--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -88,7 +88,7 @@ system_test_nns(
     },
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
     tags = [
-        "system_test_nightly",
+        "system_test_large",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",
@@ -115,7 +115,7 @@ system_test_nns(
     malicious = True,
     tags = [
         "k8s",
-        "system_test_nightly",
+        "system_test_large",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",

--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -12,7 +12,7 @@ system_test_nns(
     tags = [
         #TODO: enable k8s when there's enough capacity
         # "k8s",
-        "system_test_nightly",
+        "system_test_large",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",
@@ -32,7 +32,7 @@ system_test_nns(
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
     tags = [
         "k8s",
-        "system_test_nightly",
+        "system_test_large",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "long",
@@ -52,7 +52,7 @@ system_test_nns(
     extra_head_nns_tags = ["manual"],  # only run this test with the mainnet NNS canisters.
     tags = [
         "k8s",
-        "system_test_nightly",
+        "system_test_large",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "long",
@@ -73,7 +73,7 @@ system_test_nns(
     tags = [
         #TODO: enable k8s when there's enough capacity
         # "k8s",
-        "system_test_nightly",
+        "system_test_large",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",
@@ -92,7 +92,7 @@ system_test(
     },
     malicious = True,
     tags = [
-        "system_test_nightly",
+        "system_test_large",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "long",

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -124,7 +124,7 @@ system_test_nns(
     tags = [
         # TODO(NET-1710): enable on CI again when the problematic firewall rule in the IC node has been removed.
         #"long_test",
-        #"system_test_nightly",
+        #"system_test_large",
         "manual",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
@@ -309,7 +309,7 @@ system_test_nns(
     flaky = True,  # flakiness rate of 20% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "k8s",
-        "system_test_nightly",
+        "system_test_large",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_timeout = "eternal",
@@ -328,7 +328,7 @@ system_test_nns(
     tags = [
         "experimental_system_test_colocation",
         "k8s",
-        "system_test_nightly",
+        "system_test_large",
     ],
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     runtime_deps = GUESTOS_RUNTIME_DEPS + COUNTER_CANISTER_RUNTIME_DEPS,

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -357,7 +357,7 @@ def system_test(
     )
     return struct(test_driver_target = test_driver_target)
 
-def system_test_nns(name, extra_head_nns_tags = ["system_test_nightly"], **kwargs):
+def system_test_nns(name, extra_head_nns_tags = ["system_test_large"], **kwargs):
     """Declares a system-test that uses the mainnet NNS and a variant that use the HEAD NNS.
 
     Declares two system-tests:
@@ -365,7 +365,7 @@ def system_test_nns(name, extra_head_nns_tags = ["system_test_nightly"], **kwarg
     * One with the given name which uses the NNS from mainnet as specified by mainnet-canisters.bzl.
     * One with the given name suffixed with "_head_nns" which uses the NNS from the HEAD of the repo.
 
-    The latter one is additionally tagged with "system_test_nightly" such that it only runs daily and not on PRs.
+    The latter one is additionally tagged with "system_test_large" so that it can be excluded.
     You can override the latter behaviour by specifying different `extra_head_nns_tags`.
     If you set `extra_head_nns_tags` to `[]` the head_nns variant will have the same tags as the default variant.
 


### PR DESCRIPTION
The tags `system_test_{hotfix,staging}` were handled the same way as `system_test_nightly` so now `system_test_nightly` is used directly instead.

The `system_test_nightly_nns` tag wasn't used so references to it are now removed.