### PR TITLE
chore: don't set amd64-darwin PATH

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -212,10 +212,6 @@ jobs:
     if: github.repository == 'dfinity/ic'
     steps:
       - <<: *checkout
-      - name: Set PATH
-        run: |
-          echo "/usr/local/bin" >> $GITHUB_PATH
-          echo "$HOME/.cargo/bin:" >> $GITHUB_PATH
       - name: Infer macos intel build command
         id: cfg
         run: |

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -184,10 +184,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
-      - name: Set PATH
-        run: |
-          echo "/usr/local/bin" >> $GITHUB_PATH
-          echo "$HOME/.cargo/bin:" >> $GITHUB_PATH
       - name: Infer macos intel build command
         id: cfg
         run: |


### PR DESCRIPTION
The PATH doesn't need to be updated since all tools come from Bazel.