### PR TITLE
chore: Environment Variables hash return value from vec to [u8, 32]

### DIFF
--- a/rs/execution_environment/src/canister_settings.rs
+++ b/rs/execution_environment/src/canister_settings.rs
@@ -3,7 +3,7 @@ use ic_crypto_sha2::Sha256;
 use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
 use ic_error_types::{ErrorCode, UserError};
 use ic_interfaces::execution_environment::SubnetAvailableMemory;
-use ic_management_canister_types_private::{CanisterSettingsArgs, LogVisibilityV2};
+use ic_management_canister_types_private::{CanisterSettingsArgs, LogVisibilityV2, HASH_LENGTH};
 use ic_replicated_state::MessageMemoryUsage;
 use ic_types::{
     ComputeAllocation, Cycles, InvalidComputeAllocationError, InvalidMemoryAllocationError,
@@ -434,7 +434,7 @@ impl EnvironmentVariables {
         }
     }
 
-    pub fn hash(&self) -> Vec<u8> {
+    pub fn hash(&self) -> [u8; HASH_LENGTH] {
         // Create a vector to store the hashes of key-value pairs
         let mut hashes: Vec<Vec<u8>> = Vec::new();
 
@@ -454,7 +454,7 @@ impl EnvironmentVariables {
             hasher.write(&hash);
         }
 
-        hasher.finish().to_vec()
+        hasher.finish()
     }
 
     pub fn get_environment_variables(&self) -> BTreeMap<String, String> {

--- a/rs/execution_environment/src/canister_settings/tests.rs
+++ b/rs/execution_environment/src/canister_settings/tests.rs
@@ -23,7 +23,7 @@ fn test_environment_variables_hash_empty_env_vars() {
     let env_vars = BTreeMap::new();
     let hash = EnvironmentVariables::new(env_vars).hash();
     // SHA256 of empty input.
-    let expected = Sha256::hash(&[]).to_vec();
+    let expected = Sha256::hash(&[]);
     assert_eq!(hash, expected);
 }
 
@@ -38,7 +38,7 @@ fn test_environment_variables_hash_single_pair() {
     let mut hasher = Sha256::new();
     hasher.write(&key_hash);
     hasher.write(&value_hash);
-    let expected = hasher.finish().to_vec();
+    let expected = hasher.finish();
 
     assert_eq!(hash, expected);
 }
@@ -80,7 +80,7 @@ fn test_environment_variables_hash_output() {
     for pair_hash in &intermediate_hashes {
         hasher.write(pair_hash);
     }
-    let expected = hasher.finish().to_vec();
+    let expected = hasher.finish();
 
     // Verify that the actual hash matches the expected hash.
     let actual = EnvironmentVariables::new(env_vars).hash();

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -146,7 +146,7 @@ fn test_encode_decode_non_empty_history() {
         CanisterChangeOrigin::from_user(user_test_id(42).get()),
         CanisterChangeDetails::canister_creation(
             vec![canister_test_id(777).get(), user_test_id(42).get()],
-            Some(vec![4; 32]),
+            Some([4; 32]),
         ),
     ));
     canister_history.add_canister_change(CanisterChange::new(

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -420,7 +420,7 @@ pub enum CanisterChangeDetails {
 impl CanisterChangeDetails {
     pub fn canister_creation(
         controllers: Vec<PrincipalId>,
-        environment_variables_hash: Option< [u8; HASH_LENGTH]>,
+        environment_variables_hash: Option<[u8; HASH_LENGTH]>,
     ) -> CanisterChangeDetails {
         CanisterChangeDetails::CanisterCreation(CanisterCreationRecord {
             controllers,
@@ -690,7 +690,8 @@ impl From<&CanisterChangeDetails> for pb_canister_state_bits::canister_change::C
                             .map(|c| (*c).into())
                             .collect::<Vec<ic_protobuf::types::v1::PrincipalId>>(),
                         environment_variables_hash: canister_creation
-                            .environment_variables_hash.map(|hash| hash.to_vec()),
+                            .environment_variables_hash
+                            .map(|hash| hash.to_vec()),
                     },
                 )
             }
@@ -758,19 +759,20 @@ impl TryFrom<pb_canister_state_bits::canister_change::ChangeDetails> for Caniste
             pb_canister_state_bits::canister_change::ChangeDetails::CanisterCreation(
                 canister_creation,
             ) => {
-                let environment_variables_hash = match canister_creation.environment_variables_hash {
+                let environment_variables_hash = match canister_creation.environment_variables_hash
+                {
                     Some(bytes) => Some(try_decode_hash(bytes)?),
                     None => None,
                 };
                 Ok(CanisterChangeDetails::canister_creation(
-                canister_creation
-                    .controllers
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .collect::<Result<Vec<PrincipalId>, _>>()?,
+                    canister_creation
+                        .controllers
+                        .into_iter()
+                        .map(TryInto::try_into)
+                        .collect::<Result<Vec<PrincipalId>, _>>()?,
                     environment_variables_hash,
-            ))
-        },
+                ))
+            }
             pb_canister_state_bits::canister_change::ChangeDetails::CanisterCodeUninstall(_) => {
                 Ok(CanisterChangeDetails::CanisterCodeUninstall)
             }

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -44,7 +44,7 @@ use strum_macros::{Display, EnumCount, EnumIter, EnumString};
 /// The id of the management canister.
 pub const IC_00: CanisterId = CanisterId::ic_00();
 pub const MAX_CONTROLLERS: usize = 10;
-const WASM_HASH_LENGTH: usize = 32;
+pub const HASH_LENGTH: usize = 32;
 /// The maximum length of a BIP32 derivation path
 ///
 /// The extended public key format uses a byte to represent the derivation
@@ -264,7 +264,7 @@ impl CanisterChangeOrigin {
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct CanisterCreationRecord {
     controllers: Vec<PrincipalId>,
-    environment_variables_hash: Option<Vec<u8>>,
+    environment_variables_hash: Option<[u8; HASH_LENGTH]>,
 }
 
 impl CanisterCreationRecord {
@@ -272,8 +272,8 @@ impl CanisterCreationRecord {
         &self.controllers
     }
 
-    pub fn environment_variables_hash(&self) -> Option<Vec<u8>> {
-        self.environment_variables_hash.clone()
+    pub fn environment_variables_hash(&self) -> Option<[u8; HASH_LENGTH]> {
+        self.environment_variables_hash
     }
 }
 
@@ -287,14 +287,14 @@ impl CanisterCreationRecord {
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct CanisterCodeDeploymentRecord {
     mode: CanisterInstallMode,
-    module_hash: [u8; WASM_HASH_LENGTH],
+    module_hash: [u8; HASH_LENGTH],
 }
 
 impl CanisterCodeDeploymentRecord {
     pub fn mode(&self) -> CanisterInstallMode {
         self.mode
     }
-    pub fn module_hash(&self) -> [u8; WASM_HASH_LENGTH] {
+    pub fn module_hash(&self) -> [u8; HASH_LENGTH] {
         self.module_hash
     }
 }
@@ -420,7 +420,7 @@ pub enum CanisterChangeDetails {
 impl CanisterChangeDetails {
     pub fn canister_creation(
         controllers: Vec<PrincipalId>,
-        environment_variables_hash: Option<Vec<u8>>,
+        environment_variables_hash: Option< [u8; HASH_LENGTH]>,
     ) -> CanisterChangeDetails {
         CanisterChangeDetails::CanisterCreation(CanisterCreationRecord {
             controllers,
@@ -430,7 +430,7 @@ impl CanisterChangeDetails {
 
     pub fn code_deployment(
         mode: CanisterInstallMode,
-        module_hash: [u8; WASM_HASH_LENGTH],
+        module_hash: [u8; HASH_LENGTH],
     ) -> CanisterChangeDetails {
         CanisterChangeDetails::CanisterCodeDeployment(CanisterCodeDeploymentRecord {
             mode,
@@ -690,8 +690,7 @@ impl From<&CanisterChangeDetails> for pb_canister_state_bits::canister_change::C
                             .map(|c| (*c).into())
                             .collect::<Vec<ic_protobuf::types::v1::PrincipalId>>(),
                         environment_variables_hash: canister_creation
-                            .environment_variables_hash
-                            .clone(),
+                            .environment_variables_hash.map(|hash| hash.to_vec()),
                     },
                 )
             }
@@ -758,14 +757,20 @@ impl TryFrom<pb_canister_state_bits::canister_change::ChangeDetails> for Caniste
         match item {
             pb_canister_state_bits::canister_change::ChangeDetails::CanisterCreation(
                 canister_creation,
-            ) => Ok(CanisterChangeDetails::canister_creation(
+            ) => {
+                let environment_variables_hash = match canister_creation.environment_variables_hash {
+                    Some(bytes) => Some(try_decode_hash(bytes)?),
+                    None => None,
+                };
+                Ok(CanisterChangeDetails::canister_creation(
                 canister_creation
                     .controllers
                     .into_iter()
                     .map(TryInto::try_into)
                     .collect::<Result<Vec<PrincipalId>, _>>()?,
-                canister_creation.environment_variables_hash.clone(),
-            )),
+                    environment_variables_hash,
+            ))
+        },
             pb_canister_state_bits::canister_change::ChangeDetails::CanisterCodeUninstall(_) => {
                 Ok(CanisterChangeDetails::CanisterCodeUninstall)
             }


### PR DESCRIPTION
Modified the hash function of environment variables to return a [u8; 32] array instead of a Vec<u8> for fixed-size output.