### PR TITLE
fix: Remove readonly from guest_direct_boot mounts

### DIFF
--- a/rs/ic_os/os_tools/guest_vm_runner/src/guest_direct_boot.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/guest_direct_boot.rs
@@ -66,17 +66,18 @@ pub async fn prepare_direct_boot(
         .mount_partition(
             GRUB_PARTITION_UUID,
             MountOptions {
-                readonly: !should_refresh_grubenv,
                 file_system: GRUB_PARTITION_FS,
             },
         )
-        .await?;
+        .await
+        .context("Could not mount grub partition")?;
 
     let grubenv_path = grub_partition.mount_point().join("grubenv");
     let mut grubenv =
         GrubEnv::read_from(File::open(&grubenv_path).context("Could not open grubenv")?)?;
 
-    let grubenv_is_changing = should_refresh_grubenv && refresh_grubenv(&mut grubenv)?;
+    let grubenv_is_changing = should_refresh_grubenv
+        && refresh_grubenv(&mut grubenv).context("Failed to refresh grubenv")?;
 
     let boot_alternative = grubenv
         .boot_alternative
@@ -95,11 +96,11 @@ pub async fn prepare_direct_boot(
         .mount_partition(
             boot_partition_uuid,
             MountOptions {
-                readonly: true,
                 file_system: BOOT_PARTITION_FS,
             },
         )
-        .await?;
+        .await
+        .with_context(|| format!("Could not mount boot partition {boot_alternative}"))?;
 
     let boot_args_path = boot_partition.mount_point().join("boot_args");
     // Older GuestOS releases do not have the boot_args file. If the file exists, we have a modern

--- a/rs/ic_os/os_tools/guest_vm_runner/src/main.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/main.rs
@@ -230,7 +230,7 @@ impl GuestVmService {
     }
 
     async fn start_virtual_machine(&mut self) -> Result<VirtualMachine> {
-        let config_media = NamedTempFile::new()?;
+        let config_media = NamedTempFile::new().context("Failed to create config media file")?;
 
         let direct_boot = prepare_direct_boot(
             // TODO: We should not refresh in Upgrade VMs once we add them
@@ -238,9 +238,11 @@ impl GuestVmService {
             true,
             self.partition_provider.as_ref(),
         )
-        .await?;
+        .await
+        .context("Failed to prepare direct boot")?;
 
-        assemble_config_media(&self.hostos_config, config_media.path())?;
+        assemble_config_media(&self.hostos_config, config_media.path())
+            .context("Failed to assemble config media")?;
 
         let vm_config = generate_vm_config(
             &self.hostos_config,

--- a/rs/ic_os/os_tools/guest_vm_runner/src/mount.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/mount.rs
@@ -82,9 +82,6 @@ impl FileSystem {
 
 #[derive(Copy, Clone)]
 pub struct MountOptions {
-    /// Whether to mount the partition read-only
-    pub readonly: bool,
-
     pub file_system: FileSystem,
 }
 
@@ -176,18 +173,14 @@ impl Mounter for LoopDeviceMounter {
     ) -> Result<Box<dyn MountedPartition>> {
         let mount = tokio::task::spawn_blocking(move || {
             let tempdir = TempDir::new()?;
-            let target = tempdir.path();
+            let mount_point = tempdir.path();
             Ok::<LoopDeviceMount, Error>(LoopDeviceMount {
                 mount: Mount::builder()
                     .fstype(FilesystemType::Manual(options.file_system.as_str()))
                     .loopback_offset(offset_bytes)
-                    .flags(if options.readonly {
-                        MountFlags::RDONLY
-                    } else {
-                        MountFlags::empty()
-                    })
+                    .flags(MountFlags::empty())
                     .explicit_loopback()
-                    .mount_autodrop(device, target, UnmountFlags::empty())?,
+                    .mount_autodrop(device, mount_point, UnmountFlags::empty())?,
                 _tempdir: tempdir,
             })
         })
@@ -199,7 +192,7 @@ impl Mounter for LoopDeviceMounter {
 #[cfg(test)]
 pub mod testing {
     use super::*;
-    use anyhow::{ensure, Context};
+    use anyhow::Context;
     use partition_tools::ext::ExtPartition;
     use partition_tools::fat::FatPartition;
     use partition_tools::Partition;
@@ -207,7 +200,6 @@ pub mod testing {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use tempfile::TempDir;
-    use tokio::process::Command;
 
     /// Test partition provider that uses pre-populated directories
     pub struct MockPartitionProvider {
@@ -231,19 +223,6 @@ pub mod testing {
                 .partitions
                 .get(&partition_uuid)
                 .with_context(|| format!("Could not find partition {partition_uuid}"))?;
-
-            if options.readonly {
-                ensure!(
-                    Command::new("chmod")
-                        .arg("-R")
-                        .arg("-w")
-                        .arg(partition_dir.path())
-                        .status()
-                        .await?
-                        .success(),
-                    "Could not chmod directory"
-                );
-            }
 
             Ok(Box::new(MockMount {
                 mount_point: partition_dir.clone(),
@@ -311,19 +290,6 @@ pub mod testing {
                     .await?
                 }
             };
-
-            if options.readonly {
-                ensure!(
-                    Command::new("chmod")
-                        .arg("-R")
-                        .arg("-w")
-                        .arg(extraction_dir.path())
-                        .status()
-                        .await?
-                        .success(),
-                    "Could not chmod directory"
-                );
-            }
 
             Ok(Box::new(MockMount {
                 mount_point: Arc::new(extraction_dir),


### PR DESCRIPTION
Mounting in readonly mode can fail if the filesystem needs to be repaired or if the OS needs to write the partition for multi mount protection. Since the implementation ensures that the mount is cleaned up before the Guest VM is started, we don't really need to mount the guestos device in readonly mode.

Also, add more context messages for easier debugging.