### PR TITLE
test: Introduce new IC-OS image target that can be used in tests

### DIFF
--- a/ic-os/defs.bzl
+++ b/ic-os/defs.bzl
@@ -299,6 +299,21 @@ def icos_build(
         target_compatible_with = ["@platforms//os:linux"],
     )
 
+    disk_image(
+        name = "disk-img-for-tests.tar",
+        layout = image_deps["partition_table"],
+        partitions = partitions,
+        expanded_size = image_deps.get("expanded_size", default = None),
+        populate_b_partitions = True,
+        tags = ["manual", "no-cache"],
+        testonly = True,
+        target_compatible_with = ["@platforms//os:linux"],
+        visibility = [
+            "//ic-os:__subpackages__",
+            "//rs/ic_os:__subpackages__",
+        ],
+    )
+
     # Disk images just for testing.
     disk_image_no_tar(
         name = "disk.img",

--- a/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
+++ b/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
@@ -83,8 +83,8 @@ rust_test(
         "dev",
         "integration_tests",
     ],
-    data = glob(["golden/*"]) + ["//ic-os/guestos/envs/prod:disk-img.tar.zst"],
-    env = {"ICOS_IMAGE": "$(rootpath //ic-os/guestos/envs/prod:disk-img.tar.zst)"},
+    data = glob(["golden/*"]) + ["//ic-os/guestos/envs/prod:disk-img-for-tests.tar"],
+    env = {"ICOS_IMAGE": "$(rootpath //ic-os/guestos/envs/prod:disk-img-for-tests.tar)"},
     # Mark it manual here and expose it in //ic-os/tests:integration_tests
     tags = ["manual"],
     deps = DEV_DEPENDENCIES,

--- a/toolchains/sysimage/build_disk_image.py
+++ b/toolchains/sysimage/build_disk_image.py
@@ -136,9 +136,11 @@ def main():
     parser.add_argument("-o", "--out", help="Target (tar) file to write disk image to", type=str)
     parser.add_argument("-p", "--partition_table", help="CSV file describing the partition table", type=str)
     parser.add_argument("-s", "--expanded-size", help="Optional size to grow the image to", required=False, type=str)
-    parser.add_argument("--populate-b-partitions",
-                        help="Whether to populate the B partition set with the same content as the A partition set "
-                             "(mostly for testing). The default behavior is to leave the B partitions empty.")
+    parser.add_argument(
+        "--populate-b-partitions",
+        help="Whether to populate the B partition set with the same content as the A partition set "
+        "(mostly for testing). The default behavior is to leave the B partitions empty.",
+    )
     parser.add_argument(
         "partitions",
         metavar="partition",
@@ -180,7 +182,7 @@ def main():
         # Remove the prefix from any partitions before doing a lookup.
         for prefix in ("A_", "B_"):
             if name.startswith(prefix):
-                name = name[len(prefix):]
+                name = name[len(prefix) :]
 
         partition_file = select_partition_file(name, partition_files)
 

--- a/toolchains/sysimage/build_disk_image.py
+++ b/toolchains/sysimage/build_disk_image.py
@@ -136,6 +136,9 @@ def main():
     parser.add_argument("-o", "--out", help="Target (tar) file to write disk image to", type=str)
     parser.add_argument("-p", "--partition_table", help="CSV file describing the partition table", type=str)
     parser.add_argument("-s", "--expanded-size", help="Optional size to grow the image to", required=False, type=str)
+    parser.add_argument("--populate-b-partitions",
+                        help="Whether to populate the B partition set with the same content as the A partition set "
+                             "(mostly for testing). The default behavior is to leave the B partitions empty.")
     parser.add_argument(
         "partitions",
         metavar="partition",
@@ -170,14 +173,14 @@ def main():
         # Skip over any partitions starting with "B_". These are empty in our
         # published images, and stay this way until a live system upgrades
         # into them.
-        if entry["name"].startswith("B_"):
+        if not args.populate_b_partitions and entry["name"].startswith("B_"):
             continue
 
-        # Remove the "A_" prefix from any partitions before doing a lookup.
-        prefix = "A_"
         name = entry["name"]
-        if name.startswith(prefix):
-            name = name[len(prefix) :]
+        # Remove the prefix from any partitions before doing a lookup.
+        for prefix in ("A_", "B_"):
+            if name.startswith(prefix):
+                name = name[len(prefix):]
 
         partition_file = select_partition_file(name, partition_files)
 

--- a/toolchains/sysimage/toolchain.bzl
+++ b/toolchains/sysimage/toolchain.bzl
@@ -400,6 +400,9 @@ def _disk_image_impl(ctx):
     if ctx.attr.expanded_size:
         args.extend(["-s", ctx.attr.expanded_size])
 
+    if ctx.attr.populate_b_partitions:
+        args.extend(["--populate-b-partitions"])
+
     for partition_file in ctx.files.partitions:
         args.append(partition_file.path)
     inputs.extend(ctx.files.partitions)
@@ -426,6 +429,7 @@ disk_image = _icos_build_rule(
             allow_files = True,
         ),
         "expanded_size": attr.string(),
+        "populate_b_partitions": attr.bool(default = False),
         "_tool": attr.label(
             default = "//toolchains/sysimage:build_disk_image",
             executable = True,
@@ -459,6 +463,9 @@ def _disk_image_no_tar_impl(ctx):
     if ctx.attr.expanded_size:
         args.extend(["-s", ctx.attr.expanded_size])
 
+    if ctx.attr.populate_b_partitions:
+        args.extend(["--populate-b-partitions"])
+
     for partition_file in ctx.files.partitions:
         args.append(partition_file.path)
     inputs.extend(ctx.files.partitions)
@@ -485,6 +492,7 @@ disk_image_no_tar = _icos_build_rule(
             allow_files = True,
         ),
         "expanded_size": attr.string(),
+        "populate_b_partitions": attr.bool(default = False),
         "_tool": attr.label(
             default = "//toolchains/sysimage:build_disk_image",
             executable = True,


### PR DESCRIPTION
The difference between this image and the regular published image is that we populate the B partitions which are otherwise empty (to reduce the file size of the target).