### PR TITLE
chore(nns): Clean up migration code for canister ranges

### DIFF
--- a/rs/registry/canister/src/mutations/routing_table.rs
+++ b/rs/registry/canister/src/mutations/routing_table.rs
@@ -40,8 +40,7 @@ impl std::fmt::Display for GetSubnetForCanisterError {
 const MAX_RANGES_PER_CANISTER_RANGES: u16 = 20;
 
 /// Complexity O(n)
-// TODO after migration runs in registry_lifecycle.rs, make this function private to this module again.
-pub(crate) fn mutations_for_canister_ranges(
+fn mutations_for_canister_ranges(
     registry: &Registry,
     new_rt: &RoutingTable,
 ) -> Vec<RegistryMutation> {

--- a/rs/registry/canister/src/registry_lifecycle.rs
+++ b/rs/registry/canister/src/registry_lifecycle.rs
@@ -1,4 +1,3 @@
-use crate::mutations::routing_table::mutations_for_canister_ranges;
 use crate::{
     certification::recertify_registry, missing_node_types_map::MISSING_NODE_TYPES_MAP,
     mutations::node_management::common::get_key_family, pb::v1::RegistryCanisterStableStorage,
@@ -26,18 +25,18 @@ pub fn canister_post_upgrade(
     );
 
     // Registry data migrations should be implemented as follows:
-    let mutation_batches_due_to_data_migrations = {
-        let mutations = maybe_write_routing_table_to_canister_ranges(registry);
-        if mutations.is_empty() {
-            0 // No mutations required for this data migration.
-        } else {
-            registry.maybe_apply_mutation_internal(mutations);
-            1 // Single batch of mutations due to this data migration.
-        }
-    };
-
+    // let mutation_batches_due_to_data_migrations = {
+    //     let mutations = registry.compute_mutations_from_my_data_migration();
+    //     if mutations.is_empty() {
+    //         0 // No mutations required for this data migration.
+    //     } else {
+    //         registry.maybe_apply_mutation_internal(mutations);
+    //         1 // Single batch of mutations due to this data migration.
+    //     }
+    // };
+    //
     // When there are no migrations, `mutation_batches_due_to_data_migrations` should be set to `0`.
-    // let mutation_batches_due_to_data_migrations = 0;
+    let mutation_batches_due_to_data_migrations = 0;
 
     registry.check_global_state_invariants(&[]);
     // Registry::from_serializable_from guarantees this always passes in this function
@@ -60,17 +59,6 @@ pub fn canister_post_upgrade(
             pre_upgrade_version,
             registry.latest_version()
         );
-    }
-}
-
-// TODO(NNS1-3781): Delete this migration before removing routing_table key from registry.
-fn maybe_write_routing_table_to_canister_ranges(registry: &Registry) -> Vec<RegistryMutation> {
-    // In some test cases, there is no routing table, and this panics, which is not desired since
-    // that case will later be caught by the invariant check.  This breaks tests for no reason, so
-    // we do a match here.
-    match registry.get_routing_table(registry.latest_version()) {
-        Ok(active_rt) => mutations_for_canister_ranges(registry, &active_rt),
-        Err(_) => vec![],
     }
 }
 
@@ -113,10 +101,9 @@ mod test {
         registry::{EncodedVersion, Version},
         registry_lifecycle::Registry,
     };
-    use ic_base_types::{CanisterId, NodeId, PrincipalId};
-    use ic_registry_keys::{make_node_record_key, make_routing_table_record_key};
-    use ic_registry_routing_table::{CanisterIdRange, RoutingTable};
-    use ic_registry_transport::{insert, upsert};
+    use ic_base_types::{NodeId, PrincipalId};
+    use ic_registry_keys::make_node_record_key;
+    use ic_registry_transport::insert;
 
     fn stable_storage_from_registry(
         registry: &Registry,
@@ -287,65 +274,5 @@ mod test {
                 id
             );
         }
-    }
-
-    #[test]
-    fn test_migration_for_routing_table() {
-        use ic_protobuf::registry::routing_table::v1 as pb;
-
-        let mut registry = invariant_compliant_registry(0);
-        let system_subnet =
-            PrincipalId::try_from(registry.get_subnet_list_record().subnets.first().unwrap())
-                .unwrap();
-
-        let mut routing_table = RoutingTable::new();
-        routing_table
-            .insert(
-                CanisterIdRange {
-                    start: CanisterId::from(5000),
-                    end: CanisterId::from(6000),
-                },
-                system_subnet.into(),
-            )
-            .unwrap();
-        routing_table
-            .insert(
-                CanisterIdRange {
-                    start: CanisterId::from(6001),
-                    end: CanisterId::from(7000),
-                },
-                system_subnet.into(),
-            )
-            .unwrap();
-
-        let new_routing_table = pb::RoutingTable::from(routing_table.clone());
-        let mutations = vec![upsert(
-            make_routing_table_record_key().as_bytes(),
-            new_routing_table.encode_to_vec(),
-        )];
-        registry.maybe_apply_mutation_internal(mutations);
-
-        let recovered = registry
-            .get_routing_table_from_canister_range_records_or_panic(registry.latest_version());
-
-        assert_eq!(recovered, RoutingTable::new());
-
-        // Now we are in a situation where there is no difference between what's stored in routing_table
-        // and what's being saved BUT we should still generate canister_range_* records b/c they're empty
-        let mutations = maybe_write_routing_table_to_canister_ranges(&registry);
-        registry.maybe_apply_mutation_internal(mutations);
-
-        let recovered = registry
-            .get_routing_table_from_canister_range_records_or_panic(registry.latest_version());
-
-        assert_eq!(recovered, routing_table);
-
-        // Simulate running it again, should produce no mutations
-        let mutations = maybe_write_routing_table_to_canister_ranges(&registry);
-        assert!(
-            mutations.is_empty(),
-            "Expected no mutations, got: {:?}",
-            mutations
-        );
     }
 }


### PR DESCRIPTION
The migration code is one-off and has been run. Therefore we can clean it up.