### PR TITLE
chore(nns): Add clarification on MINIMUM_DISBURSEMENT_E8S

### DIFF
--- a/rs/nns/governance/src/governance/disburse_maturity.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity.rs
@@ -40,8 +40,10 @@ const DISBURSEMENT_DELAY_SECONDS: u64 = ONE_DAY_SECONDS * 7;
 /// The maximum number of disbursements in a neuron. This makes it possible to do daily
 /// disbursements after every reward event (as 10 > 7).
 const MAX_NUM_DISBURSEMENTS: usize = 10;
-/// The minimum amount of ICP to disburse in a single transaction. The maturity disbursement amount
-/// after being adjusted for the worst case maturity modulation should be at least this amount.
+/// The minimum amount of ICP that need to be minted when disbursing maturity. A neuron can only
+/// disburse an amount of maturity that results in minting at least this many ICP (in e8) assuming
+/// the worst case maturity modulation. This limit is set to be consistent with the neuron spawning
+/// behavior (which maturity disbursement is designed to replace).
 pub const MINIMUM_DISBURSEMENT_E8S: u64 = E8;
 // We do not retry the task more frequently than once a minute, so that if there is anything wrong
 // with the task, we don't use too many resources. How this is chosen: assuming the task can max out


### PR DESCRIPTION
Clarify what the `MINIMUM_DISBURSEMENT_E8S` is used for