### PR TITLE
fix(node): Disable hostos_upgrade_from_latest_release_to_current

### DIFF
--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -96,7 +96,7 @@ system_test_nns(
     },
     extra_head_nns_tags = [],
     flaky = True,  # flakiness rate of 5% over the month from 2025-02-11 till 2025-03-11.
-    tags = ["manual"], # TODO: remove after next release that includes the deployment.json changes
+    tags = ["manual"],  # TODO: remove after next release that includes the deployment.json changes
     target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
     test_driver_target = ":upgrade_test_bin",
     test_timeout = "eternal",


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/5407 updated the SetupOS config files, which in turn updated the injected config onto the latest_release image, thereby breaking the hostos_upgrade_from_latest_release_to_current test.

This PR disables the hostos_upgrade_from_latest_release_to_current test until the next release that includes the deloyment.json changes