### PR TITLE
fix: guest_vm_runner build rules

### DIFF
--- a/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
+++ b/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
@@ -51,14 +51,14 @@ rust_binary(
     target_compatible_with = [
         "@platforms//os:linux",
     ],
-    deps = DEPENDENCIES + ["//rs/ic_os/config:config_lib_dev"],
+    deps = DEPENDENCIES + ["//rs/ic_os/config:config_lib"],
 )
 
 rust_binary(
     name = "guest_vm_runner_dev",
     srcs = glob(["src/**/*.rs"]),
+    crate_features = ["dev"],
     crate_name = "guest_vm_runner",
-    features = ["dev"],
     proc_macro_deps = MACRO_DEPENDENCIES,
     target_compatible_with = [
         "@platforms//os:linux",


### PR DESCRIPTION
Two mistakes slipped in into the guest_vm_runner BUILD rule config, this PR fixes them.