### PR TITLE
chore: add flaky_retry bazel configuration

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -43,14 +43,7 @@ runs:
             stamp_build='${{ inputs.stamp-build }}'
 
             bazel_args=(
-                # default all tests to fail ...
-                #   ... after three attempts for tests marked as flaky
-                #   ... after three attempts for all tests in //rs/tests
-                #   ... after the first attempt for other tests
-                #   see also:
-                #     https://bazel.build/reference/command-line-reference#build-flag--flaky_test_attempts
-                --flaky_test_attempts=default
-                --flaky_test_attempts=//rs/tests/.*@3
+                --config=flaky_retry # auto retry eg systests
             )
 
             if [[ $stamp_build == "true" ]]; then

--- a/.github/workflows-source/release-testing.yml
+++ b/.github/workflows-source/release-testing.yml
@@ -60,6 +60,7 @@ jobs:
           run: |
             bazel test \
               --config=stamped \
+              --config=flaky_retry \
               --test_tag_filters=system_test_large \
               //rs/tests/... \
               --keep_going
@@ -132,6 +133,7 @@ jobs:
           run: |
             bazel test \
               --config=stamped \
+              --config=flaky_retry \
               --test_tag_filters= \
               //rs/tests/dre:guest_os_qualification \
               --test_env=OLD_VERSION=${{ matrix.version }} \

--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -46,6 +46,7 @@ jobs:
           run: |
             bazel test \
               --config=stamped \
+              --config=flaky_retry \
               --test_tag_filters=system_test_large \
               //rs/tests/... \
               --keep_going
@@ -138,6 +139,7 @@ jobs:
           run: |
             bazel test \
               --config=stamped \
+              --config=flaky_retry \
               --test_tag_filters= \
               //rs/tests/dre:guest_os_qualification \
               --test_env=OLD_VERSION=${{ matrix.version }} \

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -49,6 +49,18 @@ common --flag_alias=hermetic_cc=//bazel:hermetic_cc
 
 common:stamped --workspace_status_command='$(pwd)/bazel/workspace_status.sh --stamp'
 
+# configure some tests to retry automatically, best used unattened (not locally).
+# default all tests to fail ...
+#   ... after three attempts for tests marked as flaky
+#   ... after three attempts for all tests in //rs/tests
+#   ... after the first attempt for other tests
+#   see also:
+#     https://bazel.build/reference/command-line-reference#build-flag--flaky_test_attempts
+#
+# (NOTE: for convenience, applied to 'common' instead of just 'test' so that it doesn't
+# fail on 'bazel build')
+common:flaky_retry --flaky_test_attempts=default --flaky_test_attempts=//rs/tests/.*@3
+
 # Exclude system tests by default
 # https://github.com/bazelbuild/bazel/issues/8439
 build --build_tag_filters="-system_test,-fuzz_test"


### PR DESCRIPTION
This extracts some CLI arguments used in `bazel-test-all` into a new configuration option, `flake_retry`. When enabled, some tests known to be flaky (those explcitly marked as such and those in `//rs/tests`) to be retried automatically.

The configuration is also applied to the release testing workflow.