### PR TITLE
test: Write the routing table entries in the new format in addition to the old

### DIFF
--- a/rs/boundary_node/ic_boundary/src/test_utils.rs
+++ b/rs/boundary_node/ic_boundary/src/test_utils.rs
@@ -23,9 +23,9 @@ use ic_protobuf::registry::{
 };
 use ic_registry_client_fake::FakeRegistryClient;
 use ic_registry_keys::{
-    make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key, make_node_record_key,
-    make_routing_table_record_key, make_subnet_list_record_key, make_subnet_record_key,
-    ROOT_SUBNET_ID_KEY,
+    make_canister_ranges_key, make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key,
+    make_node_record_key, make_routing_table_record_key, make_subnet_list_record_key,
+    make_subnet_record_key, ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_registry_routing_table::{CanisterIdRange, RoutingTable as RoutingTableIC};
@@ -235,6 +235,14 @@ pub fn create_fake_registry_client(
         .expect("could not add subnet list record");
 
     // Add routing table
+    data_provider
+        .add(
+            &make_canister_ranges_key(CanisterId::from_u64(0)),
+            reg_ver,
+            Some(PbRoutingTable::from(routing_table.clone())),
+        )
+        .expect("could not add routing table");
+    // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
     data_provider
         .add(
             &make_routing_table_record_key(),

--- a/rs/determinism_test/src/setup.rs
+++ b/rs/determinism_test/src/setup.rs
@@ -12,7 +12,8 @@ use ic_protobuf::types::v1::PrincipalId as PrincipalIdIdProto;
 use ic_protobuf::types::v1::SubnetId as SubnetIdProto;
 use ic_registry_client::client::RegistryClientImpl;
 use ic_registry_keys::{
-    make_provisional_whitelist_record_key, make_routing_table_record_key, ROOT_SUBNET_ID_KEY,
+    make_canister_ranges_key, make_provisional_whitelist_record_key, make_routing_table_record_key,
+    ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -25,8 +26,8 @@ use ic_test_utilities_registry::{
 };
 use ic_test_utilities_types::ids::subnet_test_id;
 use ic_types::{
-    malicious_flags::MaliciousFlags, replica_config::ReplicaConfig, NodeId, PrincipalId,
-    RegistryVersion, SubnetId,
+    malicious_flags::MaliciousFlags, replica_config::ReplicaConfig, CanisterId, NodeId,
+    PrincipalId, RegistryVersion, SubnetId,
 };
 use std::sync::Arc;
 
@@ -55,6 +56,14 @@ fn get_registry(
     let mut routing_table = RoutingTable::new();
     routing_table_insert_subnet(&mut routing_table, subnet_id).unwrap();
     let pb_routing_table = PbRoutingTable::from(routing_table);
+    data_provider
+        .add(
+            &make_canister_ranges_key(CanisterId::from_u64(0)),
+            registry_version,
+            Some(pb_routing_table.clone()),
+        )
+        .unwrap();
+    // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
     data_provider
         .add(
             &make_routing_table_record_key(),

--- a/rs/drun/src/lib.rs
+++ b/rs/drun/src/lib.rs
@@ -22,7 +22,8 @@ use ic_protobuf::types::v1::PrincipalId as PrincipalIdIdProto;
 use ic_protobuf::types::v1::SubnetId as SubnetIdProto;
 use ic_registry_client::client::RegistryClientImpl;
 use ic_registry_keys::{
-    make_provisional_whitelist_record_key, make_routing_table_record_key, ROOT_SUBNET_ID_KEY,
+    make_canister_ranges_key, make_provisional_whitelist_record_key, make_routing_table_record_key,
+    ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -132,6 +133,14 @@ fn get_registry(
     let mut routing_table = RoutingTable::new();
     routing_table_insert_subnet(&mut routing_table, subnet_id).unwrap();
     let pb_routing_table = PbRoutingTable::from(routing_table);
+    data_provider
+        .add(
+            &make_canister_ranges_key(CanisterId::from_u64(0)),
+            registry_version,
+            Some(pb_routing_table.clone()),
+        )
+        .unwrap();
+    // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
     data_provider
         .add(
             &make_routing_table_record_key(),

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -19,7 +19,9 @@ use ic_protobuf::registry::{
     node::v1::NodeRecord,
 };
 use ic_registry_client_fake::FakeRegistryClient;
-use ic_registry_keys::make_chain_key_enabled_subnet_list_key;
+use ic_registry_keys::{
+    make_canister_ranges_key, make_chain_key_enabled_subnet_list_key, make_routing_table_record_key,
+};
 use ic_registry_local_registry::LocalRegistry;
 use ic_registry_proto_data_provider::{ProtoRegistryDataProvider, ProtoRegistryDataProviderError};
 use ic_registry_routing_table::{routing_table_insert_subnet, CanisterMigrations, RoutingTable};
@@ -36,7 +38,6 @@ use ic_test_utilities_types::{
 };
 use ic_types::batch::BlockmakerMetrics;
 use ic_types::xnet::{StreamIndexedQueue, StreamSlice};
-use ic_types::ReplicaVersion;
 use ic_types::{
     batch::{Batch, BatchMessages},
     crypto::threshold_sig::ni_dkg::{NiDkgTag, NiDkgTranscript},
@@ -44,6 +45,7 @@ use ic_types::{
     time::Time,
     NodeId, PrincipalId, Randomness,
 };
+use ic_types::{CanisterId, ReplicaVersion};
 use maplit::{btreemap, btreeset};
 use std::{fmt::Debug, str::FromStr, sync::Arc, time::Duration};
 
@@ -430,8 +432,12 @@ impl RegistryFixture {
         routing_table: Integrity<&RoutingTable>,
     ) -> Result<(), ProtoRegistryDataProviderError> {
         use ic_protobuf::registry::routing_table::v1::RoutingTable as RoutingTableProto;
-        use ic_registry_keys::make_routing_table_record_key;
 
+        self.write_record(
+            &make_canister_ranges_key(CanisterId::from_u64(0)),
+            routing_table.map(RoutingTableProto::from),
+        )?;
+        // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
         self.write_record(
             &make_routing_table_record_key(),
             routing_table.map(RoutingTableProto::from),

--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -31,7 +31,8 @@ use ic_protobuf::registry::{
 };
 use ic_registry_canister_api::{AddNodePayload, Chunk, GetChunkRequest};
 use ic_registry_keys::{
-    make_blessed_replica_versions_key, make_catch_up_package_contents_key, make_crypto_node_key,
+    make_blessed_replica_versions_key, make_canister_ranges_key,
+    make_catch_up_package_contents_key, make_crypto_node_key,
     make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key,
     make_data_center_record_key, make_node_operator_record_key, make_node_record_key,
     make_replica_version_key, make_routing_table_record_key, make_subnet_list_record_key,
@@ -640,8 +641,13 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
             make_subnet_record_key(nns_subnet_id).as_bytes(),
             system_subnet.encode_to_vec(),
         ),
+        // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
         insert(
             make_routing_table_record_key().as_bytes(),
+            RoutingTablePB::from(routing_table.clone()).encode_to_vec(),
+        ),
+        insert(
+            make_canister_ranges_key(CanisterId::from_u64(0)).as_bytes(),
             RoutingTablePB::from(routing_table).encode_to_vec(),
         ),
         insert(

--- a/rs/registry/regedit/src/protobuf.rs
+++ b/rs/registry/regedit/src/protobuf.rs
@@ -92,7 +92,7 @@ fn get_transformer(key: &str) -> Transformers {
     } else if key.starts_with(&make_blessed_replica_versions_key()) {
         BlessedReplicaVersions::transformers()
     } else if key.starts_with(&make_routing_table_record_key()) {
-        // TODO: Remove this once the routing table is fully migrated to the new format and
+        // TODO(NNS1-3781): Remove this once the routing table is fully migrated to the new format and
         // there is no real reason to need to modify routing_table record.
         RoutingTable::transformers()
     } else if key.starts_with(CANISTER_RANGES_PREFIX) {


### PR DESCRIPTION
# Why

In the mainnet registry, the routing table is stored as both the old/monolithic format (key: "routing_table") and the new/sharded format (key: "canister_ranges_*"). Before switching reads to the new format, we want to make sure both formats are written in tests.

# What

In places (mostly test utils) where `make_routing_table_record_key()` is used to insert routing tables, write one with `make_canister_ranges_key(CanisterId::from_u64(0))` too. Note that the routing table with more than the shard size (20) can still be read correctly.
