### PR TITLE
chore: Improve checkpointing metrics

### DIFF
--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -2252,7 +2252,7 @@ impl StateManagerImpl {
                 .metrics
                 .checkpoint_metrics
                 .make_checkpoint_step_duration
-                .with_label_values(&["wait_for_manifest_and_flush"])
+                .with_label_values(&["wait_for_manifest_merge_and_flush"])
                 .start_timer();
             // We need the previous manifest computation to complete because:
             //   1) We need it to speed up the next manifest computation using ManifestDelta

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -348,7 +348,7 @@ pub(crate) fn spawn_tip_thread(
                             checkpoint_layout,
                             pagemaptypes,
                         } => {
-                            let _timer = request_timer(&metrics, "reset_tip_to");
+                            let timer = request_timer(&metrics, "reset_tip_to");
                             tip_state.tip_folder_state = Default::default();
                             tip_state.tip_folder_state.page_maps_height =
                                 tip_state.latest_checkpoint_state.page_maps_height;
@@ -367,6 +367,9 @@ pub(crate) fn spawn_tip_thread(
                                         err
                                     );
                                 });
+                            drop(timer);
+
+                            let _timer = request_timer(&metrics, "merge");
                             merge(
                                 &mut tip_handler,
                                 &pagemaptypes,
@@ -389,7 +392,7 @@ pub(crate) fn spawn_tip_thread(
                             states,
                             persist_metadata_guard,
                         } => {
-                            let _timer = request_timer(&metrics, "compute_manifest");
+                            let _timer = request_timer(&metrics, "compute_manifest_total");
                             if let Some(manifest_delta) = &manifest_delta {
                                 info!(
                                     log,
@@ -426,7 +429,8 @@ pub(crate) fn spawn_tip_thread(
                             own_subnet_type,
                             fd_factory,
                         } => {
-                            let _timer = request_timer(&metrics, "validate_replicated_state");
+                            let _timer =
+                                request_timer(&metrics, "validate_replicated_state_and_finalize");
                             let start = Instant::now();
                             debug_assert_eq!(
                                 tip_state.latest_checkpoint_state.page_maps_height,

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -1231,7 +1231,7 @@ fn validate_replicated_state_is_called() {
             "state_manager_tip_handler_request_duration_seconds",
         );
         for (label, _stats) in request_duration.iter() {
-            if label.get("request") == Some(&"validate_replicated_state".to_string()) {
+            if label.get("request") == Some(&"validate_replicated_state_and_finalize".to_string()) {
                 return true;
             }
         }


### PR DESCRIPTION
This PR splits `reset_tip_to` and `merge` into individual metrics and renames some metrics to reflect the code changes.