### PR TITLE
fix(ckbtc): Ensure minimum fee per vbyte

### DIFF
--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -212,7 +212,8 @@ fn estimate_withdrawal_fee(arg: EstimateFeeArg) -> WithdrawalFee {
         ic_ckbtc_minter::estimate_retrieve_btc_fee(
             &s.available_utxos,
             arg.amount,
-            s.last_fee_per_vbyte[50],
+            s.estimate_median_fee_per_vbyte()
+                .expect("Bitcoin current fee percentiles not retrieved yet."),
         )
     })
 }

--- a/rs/bitcoin/ckbtc/minter/src/state.rs
+++ b/rs/bitcoin/ckbtc/minter/src/state.rs
@@ -1311,7 +1311,7 @@ impl CkBtcMinterState {
     }
 
     pub fn estimate_median_fee_per_vbyte(&self) -> Option<MillisatoshiPerByte> {
-        /// The default fee we use on regtest networks .
+        /// The default fee we use on regtest networks.
         const DEFAULT_REGTEST_FEE: MillisatoshiPerByte = 5_000;
 
         let median_fee = match &self.btc_network {

--- a/rs/bitcoin/ckbtc/minter/src/state.rs
+++ b/rs/bitcoin/ckbtc/minter/src/state.rs
@@ -20,10 +20,13 @@ use crate::lifecycle::upgrade::UpgradeArgs;
 use crate::logs::P0;
 use crate::state::invariants::{CheckInvariants, CheckInvariantsImpl};
 use crate::updates::update_balance::SuspendedUtxo;
-use crate::{address::BitcoinAddress, ECDSAPublicKey, GetUtxosCache, Network, Timestamp};
+use crate::{
+    address::BitcoinAddress, compute_min_withdrawal_amount, ECDSAPublicKey, GetUtxosCache, Network,
+    Timestamp,
+};
 use candid::{CandidType, Deserialize, Principal};
 use ic_base_types::CanisterId;
-use ic_btc_interface::{OutPoint, Txid, Utxo};
+use ic_btc_interface::{MillisatoshiPerByte, OutPoint, Txid, Utxo};
 use ic_canister_log::log;
 use ic_utils_ensure::ensure_eq;
 use icrc_ledger_types::icrc1::account::Account;
@@ -1305,6 +1308,54 @@ impl CkBtcMinterState {
                 None
             }
         })
+    }
+
+    pub fn estimate_median_fee_per_vbyte(&self) -> Option<MillisatoshiPerByte> {
+        /// The default fee we use on regtest networks .
+        const DEFAULT_REGTEST_FEE: MillisatoshiPerByte = 5_000;
+
+        let median_fee = match &self.btc_network {
+            Network::Mainnet | Network::Testnet => {
+                if self.last_fee_per_vbyte.len() < 100 {
+                    return None;
+                }
+                Some(self.last_fee_per_vbyte[50])
+            }
+            Network::Regtest => Some(DEFAULT_REGTEST_FEE),
+        };
+        median_fee.map(|f| f.max(self.minimum_fee_per_vbyte()))
+    }
+
+    pub fn update_median_fee_per_vbyte(
+        &mut self,
+        fees: Vec<MillisatoshiPerByte>,
+    ) -> Option<MillisatoshiPerByte> {
+        if fees.len() < 100 {
+            log!(
+                P0,
+                "[update_median_fee_per_vbyte]: not enough data points ({}) to compute the fee",
+                fees.len()
+            );
+            return None;
+        }
+        self.last_fee_per_vbyte = fees;
+        let median_fee = self
+            .estimate_median_fee_per_vbyte()
+            .expect("BUG: last_fee_per_vbyte set");
+        self.fee_based_retrieve_btc_min_amount =
+            compute_min_withdrawal_amount(median_fee, self.retrieve_btc_min_amount, self.check_fee);
+        Some(median_fee)
+    }
+
+    /// An estimated fee per vbyte of 142 millistatoshis per vbyte was selected around 2025.06.21 01:09:50 UTC
+    /// for Bitcoin Mainnet, whereas the median fee around that time should have been 2_000.
+    /// Until we know the root cause, we ensure that the estimated fee has a meaningful minimum value.
+    pub const fn minimum_fee_per_vbyte(&self) -> MillisatoshiPerByte {
+        match &self.btc_network {
+            Network::Mainnet => 1_500,
+            Network::Testnet => 1_000,
+            Network::Regtest => 0,
+        }
     }
 }
 


### PR DESCRIPTION
An estimated median fee of 142 millistatoshis per vbyte for Bitcoin Mainnet was used during approximatively 30min, from 2025.06.21 01:09:50 UTC until 2025.06.21 01:39:00 UTC. However, the median fee around that time should have been in the order of 2000 millistatoshis per vbyte. This extremely low fee led to several transactions not being mined and triggered the discovery of another bug fixed in #5713, which currently prevents transaction from being resubmitted.

<img width="1423" alt="Screenshot 2025-06-27 at 12 12 41" src="https://github.com/user-attachments/assets/d87509b8-dea2-4c43-87fe-6b2e24773a78" />

Until we know the root cause for this low fee, this PR ensures that the estimated median fee is at least 1500 millisatoshis per vbyte (for Bitcoin Mainnet). The current median fee per vbyte in the last 6 months shows that only in rare occurrences the median fee was lower than this value, therefore incurring only a minimal overcharging.

<img width="1538" alt="Screenshot 2025-06-27 at 10 46 45" src="https://github.com/user-attachments/assets/c2193a37-a8a0-4362-aba2-2813abcf9125" />

