### PR TITLE
feat(sns): add recently executed proposals to the sns metrics

### DIFF
--- a/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/api/src/ic_sns_governance.pb.v1.rs
@@ -1691,6 +1691,7 @@ pub mod get_metrics_response {
     #[derive(Default, candid::CandidType, candid::Deserialize, Debug, Clone, PartialEq)]
     pub struct Metrics {
         pub num_recently_submitted_proposals: Option<u64>,
+        pub num_recently_executed_proposals: Option<u64>,
         pub last_ledger_block_timestamp: Option<u64>,
     }
 

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -255,6 +255,7 @@ type GetMetricsRequest = record {
 
 type Metrics = record {
   num_recently_submitted_proposals : opt nat64;
+  num_recently_executed_proposals: opt nat64,
   last_ledger_block_timestamp : opt nat64;
 };
 

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -264,6 +264,7 @@ type GetMetricsRequest = record {
 
 type Metrics = record {
   num_recently_submitted_proposals : opt nat64;
+  num_recently_executed_proposals: opt nat64,
   last_ledger_block_timestamp : opt nat64;
 };
 

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -1638,6 +1638,7 @@ message GetMetricsRequest {
 message Metrics {
   uint64 num_recently_submitted_proposals = 1;
   uint64 last_ledger_block_timestamp = 2;
+  uint64 num_recently_executed_proposals = 3;
 }
 
 // Request message for 'get_sns_initialization_parameters'

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -2341,6 +2341,8 @@ pub struct Metrics {
     pub num_recently_submitted_proposals: u64,
     #[prost(uint64, tag = "2")]
     pub last_ledger_block_timestamp: u64,
+    #[prost(uint64, tag = "3")]
+    pub num_recently_executed_proposals: u64,
 }
 /// Request message for 'get_sns_initialization_parameters'
 #[derive(

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -2015,7 +2015,11 @@ impl Governance {
         &self,
         request: GetMetricsRequest,
     ) -> Result<Metrics, GovernanceError> {
-        let num_recently_submitted_proposals = self.recent_proposals(request.time_window_seconds);
+        let num_recently_submitted_proposals =
+            self.recently_submitted_proposals(request.time_window_seconds);
+
+        let num_recently_executed_proposals =
+            self.recently_executed_proposals(request.time_window_seconds);
         let icrc_ledger_helper = ICRCLedgerHelper::with_ledger(self.ledger.as_ref());
 
         let last_ledger_block_timestamp = icrc_ledger_helper
@@ -2028,10 +2032,11 @@ impl Governance {
         Ok(Metrics {
             num_recently_submitted_proposals,
             last_ledger_block_timestamp,
+            num_recently_executed_proposals,
         })
     }
 
-    fn recent_proposals(&self, time_window_seconds: u64) -> u64 {
+    fn recently_submitted_proposals(&self, time_window_seconds: u64) -> u64 {
         self.proto
             .proposals
             .values()
@@ -2040,6 +2045,19 @@ impl Governance {
                 self.env
                     .now()
                     .saturating_sub(proposal.proposal_creation_timestamp_seconds)
+                    <= time_window_seconds
+            })
+            .count() as u64
+    }
+
+    fn recently_executed_proposals(&self, time_window_seconds: u64) -> u64 {
+        self.proto
+            .proposals
+            .values()
+            .filter(|proposal| {
+                self.env
+                    .now()
+                    .saturating_sub(proposal.executed_timestamp_seconds)
                     <= time_window_seconds
             })
             .count() as u64

--- a/rs/sns/governance/src/governance/get_metrics.rs
+++ b/rs/sns/governance/src/governance/get_metrics.rs
@@ -7,7 +7,7 @@ use ic_nervous_system_canisters::cmc::FakeCmc;
 use maplit::btreemap;
 
 #[test]
-fn test_recent_proposals() {
+fn test_recently_executed_proposals() {
     use maplit::btreemap;
     const ONE_MONTH: u64 = 30 * 24 * 3600;
 
@@ -57,9 +57,79 @@ fn test_recent_proposals() {
 
     for (lable, time_window, proposals) in test_cases {
         assert_eq!(
-            governance.recent_proposals(time_window),
+            governance.recently_submitted_proposals(time_window),
             proposals,
-            "Expected {} proposals for {}",
+            "Expected {} submitted proposals for {}",
+            proposals,
+            lable
+        );
+    }
+}
+
+#[test]
+fn test_recently_submitted_proposals() {
+    use maplit::btreemap;
+    const ONE_MONTH: u64 = 30 * 24 * 3600;
+    const ONE_WEEK: u64 = 7 * 24 * 3600;
+
+    let proposal1 = ProposalData {
+        proposal_creation_timestamp_seconds: NativeEnvironment::DEFAULT_TEST_START_TIMESTAMP_SECONDS
+            - 3 * ONE_MONTH,
+        executed_timestamp_seconds: NativeEnvironment::DEFAULT_TEST_START_TIMESTAMP_SECONDS
+            - 2 * ONE_MONTH,
+        ..Default::default()
+    };
+    #[allow(clippy::identity_op)]
+    let proposal2 = ProposalData {
+        proposal_creation_timestamp_seconds: NativeEnvironment::DEFAULT_TEST_START_TIMESTAMP_SECONDS
+            - 2 * ONE_MONTH,
+        executed_timestamp_seconds: NativeEnvironment::DEFAULT_TEST_START_TIMESTAMP_SECONDS
+            - 1 * ONE_MONTH,
+        ..Default::default()
+    };
+    #[allow(clippy::identity_op)]
+    let proposal3 = ProposalData {
+        proposal_creation_timestamp_seconds: NativeEnvironment::DEFAULT_TEST_START_TIMESTAMP_SECONDS
+            - 1 * ONE_MONTH,
+        executed_timestamp_seconds: NativeEnvironment::DEFAULT_TEST_START_TIMESTAMP_SECONDS
+            - 1 * ONE_WEEK,
+        ..Default::default()
+    };
+
+    let governance_proto = pb::Governance {
+        proposals: btreemap! {
+            1_u64 => proposal1,
+            2_u64 => proposal2,
+            3_u64 => proposal3
+        },
+        ..basic_governance_proto()
+    };
+    let governance_proto = ValidGovernanceProto::try_from(governance_proto).unwrap();
+    let governance = Governance::new(
+        governance_proto,
+        Box::<NativeEnvironment>::default(),
+        Box::new(DoNothingLedger {}),
+        Box::new(DoNothingLedger {}),
+        Box::new(FakeCmc::new()),
+    );
+
+    #[allow(clippy::identity_op)]
+    let test_cases = [
+        ("zero-size window", 0_u64, 0),
+        ("sub-week window", 1 * ONE_WEEK - 1, 0),
+        ("one-week window", 1 * ONE_WEEK, 1),
+        ("sub-month window", 1 * ONE_MONTH - 1, 1),
+        ("one-month window", 1 * ONE_MONTH, 2),
+        ("two-months window", 2 * ONE_MONTH, 3),
+        ("three-months window", 3 * ONE_MONTH, 3),
+        ("primeval", u64::MAX, 3),
+    ];
+
+    for (lable, time_window, proposals) in test_cases {
+        assert_eq!(
+            governance.recently_executed_proposals(time_window),
+            proposals,
+            "Expected {} executed proposals for {}",
             proposals,
             lable
         );

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -1,3 +1,5 @@
+use core::option::Option::Some;
+
 use crate::pb::v1::{self as pb};
 use crate::topics;
 use ic_sns_governance_api::pb::v1 as pb_api;
@@ -1952,9 +1954,12 @@ impl From<pb::Metrics> for pb_api::get_metrics_response::Metrics {
         let pb::Metrics {
             num_recently_submitted_proposals,
             last_ledger_block_timestamp,
+            num_recently_executed_proposals,
         } = item;
 
         let num_recently_submitted_proposals = Some(num_recently_submitted_proposals);
+        let num_recently_executed_proposals = Some(num_recently_executed_proposals);
+
         let last_ledger_block_timestamp = if last_ledger_block_timestamp == 0 {
             None
         } else {
@@ -1963,6 +1968,7 @@ impl From<pb::Metrics> for pb_api::get_metrics_response::Metrics {
 
         Self {
             num_recently_submitted_proposals,
+            num_recently_executed_proposals,
             last_ledger_block_timestamp,
         }
     }


### PR DESCRIPTION
This PR adds the number of recently executed proposals to the SNS metrics (see [this PR](https://github.com/dfinity/ic/pull/5079)). Please note that when a proposal gets executed, it can later get garbage collected and removed from the list of proposals by the governance. Tracking these garbage collected proposals is not implemented in this PR.