### PR TITLE
test(ICP_Rosetta): FI-1779: Mark ICP Rosetta system tests flaky

### DIFF
--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -196,6 +196,7 @@ rust_test_suite_with_extra_srcs(
         "tests/system_tests/common/*.rs",
         "tests/system_tests/test_cases/*.rs",
     ]),
+    flaky = True,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:4"],
     deps = DEV_DEPENDENCIES + DEPENDENCIES,


### PR DESCRIPTION
A [recent PR](https://github.com/dfinity/ic/pull/5592) introduced some flakiness to the `test_cases::search_transactions::test_search_transactions_by_account` test. While investigating the issue, mark the test as flaky.