### PR TITLE
chore(nervous-system-agent): Support `effective_canister_id` in `trait Request` to enable routing management canister calls

### DIFF
--- a/rs/nervous_system/agent/src/agent_impl.rs
+++ b/rs/nervous_system/agent/src/agent_impl.rs
@@ -1,5 +1,6 @@
-use crate::{CallCanisters, CallCanistersWithStoppedCanisterError, ProgressNetwork};
-use crate::{CanisterInfo, Request};
+use crate::{
+    CallCanisters, CallCanistersWithStoppedCanisterError, CanisterInfo, ProgressNetwork, Request,
+};
 use candid::Principal;
 use ic_agent::agent::{RejectCode, RejectResponse};
 use ic_agent::{Agent, AgentError};

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -32,6 +32,8 @@ pub trait Request: Send {
     fn method(&self) -> &'static str;
     fn update(&self) -> bool;
     fn payload(&self) -> Result<Vec<u8>, candid::Error>;
+
+    /// See https://internetcomputer.org/docs/references/ic-interface-spec#http-interface
     fn effective_canister_id(&self) -> Option<Principal> {
         None
     }

--- a/rs/nervous_system/agent/src/lib.rs
+++ b/rs/nervous_system/agent/src/lib.rs
@@ -32,6 +32,9 @@ pub trait Request: Send {
     fn method(&self) -> &'static str;
     fn update(&self) -> bool;
     fn payload(&self) -> Result<Vec<u8>, candid::Error>;
+    fn effective_canister_id(&self) -> Option<Principal> {
+        None
+    }
     type Response: CandidType + DeserializeOwned + Send;
 }
 

--- a/rs/nervous_system/agent/src/management_canister/requests.rs
+++ b/rs/nervous_system/agent/src/management_canister/requests.rs
@@ -42,6 +42,10 @@ impl Request for UploadChunkArgs {
         candid::encode_one(self)
     }
 
+    fn effective_canister_id(&self) -> Option<Principal> {
+        Some(self.canister_id)
+    }
+
     type Response = UploadChunksResult;
 }
 
@@ -74,6 +78,10 @@ impl Request for StoredChunksArgs {
 
     fn payload(&self) -> Result<Vec<u8>, candid::Error> {
         candid::encode_one(self)
+    }
+
+    fn effective_canister_id(&self) -> Option<Principal> {
+        Some(self.canister_id)
     }
 
     type Response = StoredChunksResult;
@@ -177,6 +185,10 @@ impl Request for CanisterStatusArgs {
         candid::encode_one(self)
     }
 
+    fn effective_canister_id(&self) -> Option<Principal> {
+        Some(self.canister_id)
+    }
+
     type Response = CanisterStatusResult;
 }
 
@@ -203,6 +215,10 @@ impl Request for StopCanisterArgs {
         candid::encode_one(self)
     }
 
+    fn effective_canister_id(&self) -> Option<Principal> {
+        Some(self.canister_id)
+    }
+
     type Response = ();
 }
 
@@ -227,6 +243,10 @@ impl Request for DeleteCanisterArgs {
 
     fn payload(&self) -> Result<Vec<u8>, candid::Error> {
         candid::encode_one(self)
+    }
+
+    fn effective_canister_id(&self) -> Option<Principal> {
+        Some(self.canister_id)
     }
 
     type Response = ();

--- a/rs/nervous_system/agent/src/pocketic_impl.rs
+++ b/rs/nervous_system/agent/src/pocketic_impl.rs
@@ -1,8 +1,3 @@
-use std::time::Duration;
-
-use crate::management_canister::requests::{
-    CanisterStatusArgs, DeleteCanisterArgs, StopCanisterArgs, StoredChunksArgs, UploadChunkArgs,
-};
 use crate::{AgentFor, CallCanisters, CanisterInfo, ProgressNetwork};
 use crate::{CallCanistersWithStoppedCanisterError, Request};
 use candid::Principal;
@@ -10,6 +5,7 @@ use ic_management_canister_types::{CanisterStatusResult, DefiniteCanisterSetting
 use pocket_ic::common::rest::RawEffectivePrincipal;
 use pocket_ic::nonblocking::PocketIc;
 use pocket_ic::ErrorCode;
+use std::time::Duration;
 use thiserror::Error;
 
 /// A wrapper around PocketIc that specifies a sender for the requests.
@@ -43,78 +39,6 @@ pub enum PocketIcCallError {
 impl crate::sealed::Sealed for PocketIc {}
 impl crate::sealed::Sealed for PocketIcAgent<'_> {}
 
-impl PocketIcAgent<'_> {
-    async fn get_subnet(
-        &self,
-        canister_id: Principal,
-    ) -> Result<RawEffectivePrincipal, PocketIcCallError> {
-        let Some(subnet_id) = self.pocket_ic.get_subnet(canister_id).await else {
-            return Err(PocketIcCallError::CanisterSubnetNotFound(canister_id));
-        };
-
-        Ok(RawEffectivePrincipal::CanisterId(
-            subnet_id.as_slice().to_vec(),
-        ))
-    }
-
-    async fn management_canister_call<R: Request>(
-        &self,
-        request: R,
-    ) -> Result<R::Response, PocketIcCallError> {
-        let payload = request.payload().map_err(PocketIcCallError::CandidEncode)?;
-
-        let canister_id = match request.method() {
-            "upload_chunk" => {
-                candid::decode_one::<UploadChunkArgs>(payload.as_slice())
-                    .map_err(PocketIcCallError::CandidDecode)?
-                    .canister_id
-            }
-            "stored_chunks" => {
-                candid::decode_one::<StoredChunksArgs>(payload.as_slice())
-                    .map_err(PocketIcCallError::CandidDecode)?
-                    .canister_id
-            }
-            "canister_status" => {
-                candid::decode_one::<CanisterStatusArgs>(payload.as_slice())
-                    .map_err(PocketIcCallError::CandidDecode)?
-                    .canister_id
-            }
-            "stop_canister" => {
-                candid::decode_one::<StopCanisterArgs>(payload.as_slice())
-                    .map_err(PocketIcCallError::CandidDecode)?
-                    .canister_id
-            }
-            "delete_canister" => {
-                candid::decode_one::<DeleteCanisterArgs>(payload.as_slice())
-                    .map_err(PocketIcCallError::CandidDecode)?
-                    .canister_id
-            }
-            mathod_name => {
-                unimplemented!(
-                    "PocketIcAgent does not currently implement IC00.{}",
-                    mathod_name
-                );
-            }
-        };
-
-        let effective_principal = self.get_subnet(canister_id).await?;
-
-        let response = self
-            .pocket_ic
-            .update_call_with_effective_principal(
-                Principal::management_canister(),
-                effective_principal,
-                self.sender,
-                request.method(),
-                payload,
-            )
-            .await
-            .map_err(PocketIcCallError::PocketIc)?;
-
-        candid::decode_one(response.as_slice()).map_err(PocketIcCallError::CandidDecode)
-    }
-}
-
 impl CallCanisters for PocketIcAgent<'_> {
     type Error = PocketIcCallError;
     async fn call<R: Request>(
@@ -124,17 +48,25 @@ impl CallCanisters for PocketIcAgent<'_> {
     ) -> Result<R::Response, Self::Error> {
         let canister_id = canister_id.into();
 
-        // Currently, PocketIc does not route calls to aaaaa-aa, saying that it does not belong
-        // to any subnet. So we need to explicitly treat this case.
-        if canister_id == Principal::management_canister() {
-            return self.management_canister_call(request).await;
-        }
-
         let request_bytes = request.payload().map_err(PocketIcCallError::CandidEncode)?;
         let response = if request.update() {
-            self.pocket_ic
-                .update_call(canister_id, self.sender, request.method(), request_bytes)
-                .await
+            if let Some(effective_canister_id) = request.effective_canister_id() {
+                let effective_canister_id =
+                    RawEffectivePrincipal::CanisterId(effective_canister_id.as_slice().to_vec());
+                self.pocket_ic
+                    .update_call_with_effective_principal(
+                        canister_id,
+                        effective_canister_id,
+                        self.sender,
+                        request.method(),
+                        request_bytes,
+                    )
+                    .await
+            } else {
+                self.pocket_ic
+                    .update_call(canister_id, self.sender, request.method(), request_bytes)
+                    .await
+            }
         } else {
             self.pocket_ic
                 .query_call(canister_id, self.sender, request.method(), request_bytes)

--- a/rs/nervous_system/agent/src/pocketic_impl.rs
+++ b/rs/nervous_system/agent/src/pocketic_impl.rs
@@ -1,5 +1,7 @@
-use crate::{AgentFor, CallCanisters, CanisterInfo, ProgressNetwork};
-use crate::{CallCanistersWithStoppedCanisterError, Request};
+use crate::{
+    AgentFor, CallCanisters, CallCanistersWithStoppedCanisterError, CanisterInfo, ProgressNetwork,
+    Request,
+};
 use candid::Principal;
 use ic_management_canister_types::{CanisterStatusResult, DefiniteCanisterSettings};
 use pocket_ic::common::rest::RawEffectivePrincipal;
@@ -72,22 +74,20 @@ impl CallCanisters for PocketIcAgent<'_> {
                     .update_call(canister_id, self.sender, request.method(), request_bytes)
                     .await
             }
+        } else if let Some(effective_canister_id) = effective_canister_id {
+            self.pocket_ic
+                .query_call_with_effective_principal(
+                    canister_id,
+                    effective_canister_id,
+                    self.sender,
+                    request.method(),
+                    request_bytes,
+                )
+                .await
         } else {
-            if let Some(effective_canister_id) = effective_canister_id {
-                self.pocket_ic
-                    .query_call_with_effective_principal(
-                        canister_id,
-                        effective_canister_id,
-                        self.sender,
-                        request.method(),
-                        request_bytes,
-                    )
-                    .await
-            } else {
-                self.pocket_ic
-                    .query_call(canister_id, self.sender, request.method(), request_bytes)
-                    .await
-            }
+            self.pocket_ic
+                .query_call(canister_id, self.sender, request.method(), request_bytes)
+                .await
         }
         .map_err(PocketIcCallError::PocketIc)?;
 


### PR DESCRIPTION
This PR adds an optional function `effective_canister_id` to `trait Request`, so that implementations can rely on the effective canister IDs to route special requests (e.g., those to the management canister) that cannot always be routed automatically.