### PR TITLE
fix(sns): Ensure Candid decoding of `Nat` to `u64` correctly handles `0`

### DIFF
--- a/rs/sns/governance/canbench/canbench_results.yml
+++ b/rs/sns/governance/canbench/canbench_results.yml
@@ -2,7 +2,7 @@ benches:
   bench_example:
     total:
       calls: 1
-      instructions: 4740
+      instructions: 5640
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -2031,8 +2031,8 @@ impl Governance {
 
         Ok(Metrics {
             num_recently_submitted_proposals,
-            last_ledger_block_timestamp,
             num_recently_executed_proposals,
+            last_ledger_block_timestamp,
         })
     }
 

--- a/rs/sns/governance/src/icrc_ledger_helper.rs
+++ b/rs/sns/governance/src/icrc_ledger_helper.rs
@@ -108,9 +108,9 @@ fn decode_nat_to_u64(value: Nat) -> Result<u64, String> {
         [] => Ok(0),
         [val] => Ok(*val),
         vals => Err(format!(
-            "Error parsing a Nat value `{:?}` to u64: expected a unique u64 value, got {:?}",
+            "Nat value `{:?}` is too large, max supported value: {}",
             &value,
-            vals.len(),
+            u64::MAX,
         )),
     }
 }
@@ -123,7 +123,13 @@ fn test_decoding_nat() {
         (Nat::from(1234_u64), Ok(1234_u64)),
         (Nat::from(1_000_000_000_u64), Ok(1_000_000_000_u64)),
         (Nat::from(u64::MAX), Ok(u64::MAX)),
-        (Nat::from(u64::MAX) + Nat::from(1_u64), Err("Error parsing a Nat value `Nat(18446744073709551616)` to u64: expected a unique u64 value, got 2".to_string())),
+        (
+            Nat::from(u64::MAX) + Nat::from(1_u64),
+            Err(format!(
+                "Nat value `Nat(18446744073709551616)` is too large, max supported value: {}",
+                u64::MAX
+            )),
+        ),
     ];
 
     for (num_nat, expected) in test_cases {

--- a/rs/sns/governance/src/icrc_ledger_helper.rs
+++ b/rs/sns/governance/src/icrc_ledger_helper.rs
@@ -60,8 +60,8 @@ impl<'a> ICRCLedgerHelper<'a> {
             [block] => &block.block,
             blocks => {
                 return Err(format!(
-                    "Error parsing a Nat value `{:?}` to u64: expected a unique u64 value, \
-                     got {:?}.",
+                    "Error parsing response from {}.icrc3_get_blocks: expected a single block,
+                     got {} blocks.",
                     self.ledger.canister_id(),
                     blocks.len(),
                 ))

--- a/rs/sns/governance/src/icrc_ledger_helper.rs
+++ b/rs/sns/governance/src/icrc_ledger_helper.rs
@@ -59,11 +59,14 @@ impl<'a> ICRCLedgerHelper<'a> {
         let block = match &blocks[..] {
             [] => Ok(0),
             [block] => &block.block,
-            blocks => return Err(format!(
-                "Error parsing a Nat value `{:?}` to u64: expected a unique u64 value, got {:?}.",
-                self.ledger.canister_id(),
-                blocks.len(),
-            )),
+            blocks => {
+                return Err(format!(
+                    "Error parsing a Nat value `{:?}` to u64: expected a unique u64 value, \
+                     got {:?}.",
+                    self.ledger.canister_id(),
+                    blocks.len(),
+                ))
+            }
         };
 
         // We assume in each block we have 1 and only 1 transaction.

--- a/rs/sns/governance/src/icrc_ledger_helper.rs
+++ b/rs/sns/governance/src/icrc_ledger_helper.rs
@@ -107,7 +107,7 @@ fn decode_nat_to_u64(value: Nat) -> Result<u64, String> {
     match &u64_digit_components[..] {
         [] => Ok(0),
         [val] => Ok(*val),
-        vals => Err(format!(
+        _ => Err(format!(
             "Nat value `{:?}` is too large, max supported value: {}",
             &value,
             u64::MAX,

--- a/rs/sns/governance/src/icrc_ledger_helper.rs
+++ b/rs/sns/governance/src/icrc_ledger_helper.rs
@@ -123,13 +123,13 @@ fn test_decoding_nat() {
         (Nat::from(1234_u64), Ok(1234_u64)),
         (Nat::from(1_000_000_000_u64), Ok(1_000_000_000_u64)),
         (Nat::from(u64::MAX), Ok(u64::MAX)),
-        (Nat::from(u64::MAX) + Nat::from(1_u64), Err("hello".to_string())),
+        (Nat::from(u64::MAX) + Nat::from(1_u64), Err("Error parsing a Nat value `Nat(18446744073709551616)` to u64: expected a unique u64 value, got 2".to_string())),
     ];
 
     for (num_nat, expected) in test_cases {
         let decoding_result = decode_nat_to_u64(num_nat.clone());
-        assert!(
-            matches!(decoding_result, Ok(value) if value == expected),
+        assert_eq!(
+            decoding_result, expected,
             "Decoding {:?} to u64 failed",
             num_nat
         );

--- a/rs/sns/governance/src/icrc_ledger_helper.rs
+++ b/rs/sns/governance/src/icrc_ledger_helper.rs
@@ -57,15 +57,13 @@ impl<'a> ICRCLedgerHelper<'a> {
         let GetBlocksResult { blocks, .. } = call_icrc3_get_blocks(args).await?;
 
         let block = match &blocks[..] {
+            [] => Ok(0),
             [block] => &block.block,
-            blocks => {
-                return Err(format!(
-                    "Error parsing response from {}.icrc3_get_blocks: expected a single block,
-                 got {} blocks.",
-                    self.ledger.canister_id(),
-                    blocks.len(),
-                ))
-            }
+            blocks => return Err(format!(
+                "Error parsing a Nat value `{:?}` to u64: expected a unique u64 value, got {:?}.",
+                self.ledger.canister_id(),
+                blocks.len(),
+            )),
         };
 
         // We assume in each block we have 1 and only 1 transaction.

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -9,6 +9,9 @@ on the process that this file is part of, see
 
 ## Added
 
+The `get_metrics` function response now includes the number of *executed* proposal (in addition
+to the number of submitted proposals).
+
 ## Changed
 
 ## Deprecated
@@ -16,5 +19,7 @@ on the process that this file is part of, see
 ## Removed
 
 ## Fixed
+
+Fixed a bug in the decored of Candid `Nat` values as `u64`.
 
 ## Security

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -20,6 +20,6 @@ to the number of submitted proposals).
 
 ## Fixed
 
-Fixed a bug in the decored of Candid `Nat` values as `u64`.
+Fixed a bug in the decoder of Candid `Nat` values as `u64`.
 
 ## Security


### PR DESCRIPTION
This PR fixed a problem with Candid decoding of `Nat` to `u64` that didn't correctly handle `0`.

Also, release notes are edited.