### PR TITLE
feat(BOUN-1436): `ic-boundary`: add health metric

### DIFF
--- a/rs/boundary_node/ic_boundary/src/core.rs
+++ b/rs/boundary_node/ic_boundary/src/core.rs
@@ -82,7 +82,7 @@ use crate::{
         MetricParamsSnapshot, MetricsCache, MetricsRunner, WithMetricsCheck, WithMetricsPersist,
         WithMetricsSnapshot,
     },
-    persist::{Persist, Persister, Routes},
+    persist::{Persist, Persister},
     rate_limiting::{generic, RateLimit},
     routes::{self, Health, Lookup, Proxy, ProxyRouter, RootKey},
     salt_fetcher::AnonymizationSaltFetcher,
@@ -366,17 +366,24 @@ pub async fn main(mut cli: Cli) -> Result<(), Error> {
     // HTTP Logs Anonymization
     let anonymization_salt = Arc::new(ArcSwapOption::<Vec<u8>>::empty());
 
+    // Proxy Router
+    let proxy_router = Arc::new(ProxyRouter::new(
+        http_client.clone(),
+        routing_table.clone(),
+        registry_snapshot.clone(),
+        cli.health.health_subnets_alive_threshold,
+        cli.health.health_nodes_per_subnet_alive_threshold,
+    ));
+
     // Prepare Axum Router
     let router = setup_router(
-        registry_snapshot.clone(),
-        routing_table.clone(),
-        http_client,
         bouncer,
         generic_limiter.clone(),
         &cli,
         &metrics_registry,
         cache_state.clone(),
         anonymization_salt.clone(),
+        proxy_router.clone(),
     );
 
     // HTTP server metrics
@@ -469,6 +476,7 @@ pub async fn main(mut cli: Cli) -> Result<(), Error> {
         metrics_registry.clone(),
         cache_state,
         Arc::clone(&registry_snapshot),
+        proxy_router,
     ));
     tasks.add_interval("metrics_runner", metrics_runner, 5 * SECOND);
 
@@ -863,28 +871,16 @@ impl TypeExtractor for RequestTypeExtractor {
 
 /// Creates an Axum router that is ready to be served over HTTP
 pub fn setup_router(
-    registry_snapshot: Arc<ArcSwapOption<RegistrySnapshot>>,
-    routing_table: Arc<ArcSwapOption<Routes>>,
-    http_client: Arc<dyn bnhttp::Client>,
     bouncer: Option<Arc<bouncer::Bouncer>>,
     generic_limiter: Option<Arc<generic::GenericLimiter>>,
     cli: &Cli,
     metrics_registry: &Registry,
     cache_state: Option<Arc<CacheState>>,
     anonymization_salt: Arc<ArcSwapOption<Vec<u8>>>,
+    proxy_router: Arc<ProxyRouter>,
 ) -> Router {
     // Init it early to avoid race conditions
     lazy_static::initialize(&UUID_REGEX);
-
-    let proxy_router = ProxyRouter::new(
-        http_client.clone(),
-        Arc::clone(&routing_table),
-        Arc::clone(&registry_snapshot),
-        cli.health.health_subnets_alive_threshold,
-        cli.health.health_nodes_per_subnet_alive_threshold,
-    );
-
-    let proxy_router = Arc::new(proxy_router);
 
     let (proxy, lookup, root_key, health) = (
         proxy_router.clone() as Arc<dyn Proxy>,

--- a/rs/boundary_node/ic_boundary/src/http/handlers.rs
+++ b/rs/boundary_node/ic_boundary/src/http/handlers.rs
@@ -336,7 +336,7 @@ mod test {
                 .await
                 .unwrap();
 
-        let (mut socket3, _) =
+        let (socket3, _) =
             tokio_tungstenite::connect_async(format!("ws://{addr}/logs/canister/aaaaa-aa"))
                 .await
                 .unwrap();
@@ -347,6 +347,14 @@ mod test {
                 .await
                 .is_err()
         );
+
+        // Make sure we can subscribe again if we disconnect one of the subscribers
+        drop(socket3);
+
+        let (mut socket3, _) =
+            tokio_tungstenite::connect_async(format!("ws://{addr}/logs/canister/aaaaa-aa"))
+                .await
+                .unwrap();
 
         // But we can subscribe to another canister
         let (mut socket4, _) =

--- a/rs/boundary_node/ic_boundary/src/routes.rs
+++ b/rs/boundary_node/ic_boundary/src/routes.rs
@@ -120,7 +120,7 @@ pub trait RootKey: Sync + Send {
 #[derive(Clone, derive_new::new)]
 pub struct ProxyRouter {
     http_client: Arc<dyn HttpClient>,
-    published_routes: Arc<ArcSwapOption<Routes>>,
+    routing_table: Arc<ArcSwapOption<Routes>>,
     published_registry_snapshot: Arc<ArcSwapOption<RegistrySnapshot>>,
     subnets_alive_threshold: f64,
     nodes_per_subnet_alive_threshold: f64,
@@ -145,7 +145,7 @@ impl Lookup for ProxyRouter {
         canister_id: &CanisterId,
     ) -> Result<Arc<RouteSubnet>, ErrorCause> {
         let subnet = self
-            .published_routes
+            .routing_table
             .load_full()
             .ok_or(ErrorCause::NoRoutingTable)? // No routing table present
             .lookup_by_canister_id(canister_id.get_ref().0)
@@ -156,7 +156,7 @@ impl Lookup for ProxyRouter {
 
     fn lookup_subnet_by_id(&self, subnet_id: &SubnetId) -> Result<Arc<RouteSubnet>, ErrorCause> {
         let subnet = self
-            .published_routes
+            .routing_table
             .load_full()
             .ok_or(ErrorCause::NoRoutingTable)? // No routing table present
             .lookup_by_id(subnet_id.get_ref().0)
@@ -177,7 +177,7 @@ impl RootKey for ProxyRouter {
 impl Health for ProxyRouter {
     fn health(&self) -> ReplicaHealthStatus {
         match (
-            self.published_routes.load_full(),
+            self.routing_table.load_full(),
             self.published_registry_snapshot.load_full(),
         ) {
             (Some(rt), Some(snap)) => {
@@ -330,15 +330,15 @@ pub(crate) mod test {
 
     #[tokio::test]
     async fn test_health() -> Result<(), Error> {
-        let published_routes = Arc::new(ArcSwapOption::empty());
+        let routing_table = Arc::new(ArcSwapOption::empty());
         let published_registry_snapshot = Arc::new(ArcSwapOption::empty());
 
-        let persister = Persister::new(published_routes.clone());
+        let persister = Persister::new(routing_table.clone());
 
         let http_client = Arc::new(TestHttpClient(1));
         let proxy_router = Arc::new(ProxyRouter::new(
             http_client,
-            published_routes,
+            routing_table,
             published_registry_snapshot.clone(),
             0.51,
             0.6666,
@@ -521,10 +521,10 @@ pub(crate) mod test {
             44, 183, 41, 121, 43, 119, 84, 128, 45, 105, 10,
         ];
 
-        let published_routes = Arc::new(ArcSwapOption::empty());
+        let routing_table = Arc::new(ArcSwapOption::empty());
         let published_registry_snapshot = Arc::new(ArcSwapOption::empty());
 
-        let persister = Persister::new(published_routes.clone());
+        let persister = Persister::new(routing_table.clone());
         let (mut snapshot, _, _) = test_registry_snapshot(5, 3);
         snapshot.nns_public_key = ROOT_KEY.into();
         published_registry_snapshot.store(Some(Arc::new(snapshot.clone())));
@@ -532,7 +532,7 @@ pub(crate) mod test {
         let http_client = Arc::new(TestHttpClient(1));
         let proxy_router = Arc::new(ProxyRouter::new(
             http_client,
-            published_routes,
+            routing_table,
             published_registry_snapshot,
             0.51,
             0.6666,


### PR DESCRIPTION
The metric is called `ic_boundary_healthy` and is 1 when the service is healthy and 0 otherwise.

Also:
+ some cosmetic renames
+ sideload tiny websocket test improvement