### PR TITLE
fix(governance-tools): Fix release scripts for situations where there are no releases for NNS/SNS

### DIFF
--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -509,7 +509,7 @@ fn run_create_forum_post(cmd: CreateForumPost) -> Result<()> {
     let ic = ic_dir();
 
     // --- Generate NNS forum post ---
-    {
+    if !nns_proposal_text_paths.is_empty() {
         let script = ic.join("testnet/tools/nns-tools/cmd.sh");
         let mut args = vec!["generate_forum_post_nns_upgrades"];
         let path_strs: Vec<&str> = nns_proposal_text_paths
@@ -552,7 +552,7 @@ fn run_create_forum_post(cmd: CreateForumPost) -> Result<()> {
     }
 
     // --- Generate SNS forum post ---
-    {
+    if !sns_proposal_text_paths.is_empty() {
         let script = ic.join("testnet/tools/nns-tools/cmd.sh");
         let mut args = vec!["generate_forum_post_sns_wasm_publish"];
         let path_strs: Vec<&str> = sns_proposal_text_paths

--- a/testnet/tools/nns-tools/lib/proposals.sh
+++ b/testnet/tools/nns-tools/lib/proposals.sh
@@ -464,6 +464,11 @@ EOF
 ## Example: $1 directory_with_new_proposals/*
 ## Example: $1 proposal_1.md proposal_2.md
 generate_forum_post_nns_upgrades() {
+    if [ $# -eq 0 ]; then
+        echo "No proposal files provided"
+        exit 1
+    fi
+
     PROPOSAL_FILES=$(ls "$@")
 
     THIS_FRIDAY=$(date -d "next Friday" +'%Y-%m-%d' 2>/dev/null || date -v+Fri +%Y-%m-%d)
@@ -498,6 +503,11 @@ EOF
 ## Example: $1 directory_with_new_proposals/*
 ## Example: $1 proposal_1.md proposal_2.md
 generate_forum_post_sns_wasm_publish() {
+    if [ $# -eq 0 ]; then
+        echo "No proposal files provided"
+        exit 1
+    fi
+
     PROPOSAL_FILES=$(ls "$@")
 
     THIS_FRIDAY=$(date -d "next Friday" +'%Y-%m-%d' 2>/dev/null || date -v+Fri +%Y-%m-%d)


### PR DESCRIPTION
# Why

When a release script run only has NNS canisters, or only has SNS canisters, the script should still work correctly at the step of generating forum post. Currently, `PROPOSAL_FILES=$(ls "$@")` will cause `$PROPOSAL_FILES` to be all the files in the current directory.

# What

* Skip release script steps when there is nothing to be done
* Early return in `generate_forum_post_nns_upgrades`/`generate_forum_post_sns_wasm_publish` if there are no arguments. This is not needed if the user only uses the `//rs/nervous_system/tools/release-runscript` (given the first fix), but  `//rs/nervous_system/tools/release-runscript` is not robust enough yet.
