### PR TITLE
fix(governance-tools): Escape ` in the the "Governance Unreleased Changelog Reminder" script

### DIFF
--- a/.github/workflows/ci-pr-only-nns-team-reminder.yml
+++ b/.github/workflows/ci-pr-only-nns-team-reminder.yml
@@ -78,7 +78,7 @@ jobs:
 
               * Done.
 
-              * $REASON_WHY_NO_NEED. E.g. for `unreleased_changelog.md`, "No
+              * $REASON_WHY_NO_NEED. E.g. for \`unreleased_changelog.md\`, "No
                 canister behavior changes.", or for item 2, "Existing APIs
                 behave as before.".
 


### PR DESCRIPTION
Attempt 2 after #5752