### PR TITLE
chore: run pocket-ic tests on arm64-darwin

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -307,6 +307,8 @@ jobs:
 
             # necessary artifacts & tests for pocket -ic
             //packages/pocket-ic:all \
+            # NOTE: technically covered by //rs/... above, but
+            # added explicitly for clarity
             //rs/pocket_ic_server:test \
             //rs/pocket_ic_server:gateway \
             //rs/pocket_ic_server:pocket-ic-server

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -300,12 +300,24 @@ jobs:
           # Setup zig-cache
           mkdir -p /tmp/zig-cache
 
+          bazel_targets=(
+            # make sure codebase builds for local development
+            //rs/...
+            //publish/binaries/...
+
+            # necessary artifacts & tests for pocket -ic
+            //packages/pocket-ic:all \
+            //rs/pocket_ic_server:test \
+            //rs/pocket_ic_server:gateway \
+            //rs/pocket_ic_server:pocket-ic-server
+          )
+
           bazel \
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
             test \
             --test_tag_filters="test_macos,test_macos_slow" \
-            //packages/pocket-ic/... //rs/... //publish/binaries/...
+            "${bazel_targets[@]}"
 
           mkdir -p build
           cp \

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -269,6 +269,8 @@ jobs:
 
             # necessary artifacts & tests for pocket -ic
             //packages/pocket-ic:all \
+            # NOTE: technically covered by //rs/... above, but
+            # added explicitly for clarity
             //rs/pocket_ic_server:test \
             //rs/pocket_ic_server:gateway \
             //rs/pocket_ic_server:pocket-ic-server

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -262,12 +262,24 @@ jobs:
           # Setup zig-cache
           mkdir -p /tmp/zig-cache
 
+          bazel_targets=(
+            # make sure codebase builds for local development
+            //rs/...
+            //publish/binaries/...
+
+            # necessary artifacts & tests for pocket -ic
+            //packages/pocket-ic:all \
+            //rs/pocket_ic_server:test \
+            //rs/pocket_ic_server:gateway \
+            //rs/pocket_ic_server:pocket-ic-server
+          )
+
           bazel \
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
             test \
             --test_tag_filters="test_macos,test_macos_slow" \
-            //packages/pocket-ic/... //rs/... //publish/binaries/...
+            "${bazel_targets[@]}"
 
           mkdir -p build
           cp \


### PR DESCRIPTION
This adds some test targets to the arm64-darwin build to align it with the arm64-linux pocket IC CI builds.