### PR TITLE
chore: update ic-rosetta-api to version 2.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12677,7 +12677,7 @@ dependencies = [
 
 [[package]]
 name = "ic-rosetta-api"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -96,7 +96,7 @@ MACRO_DEV_DEPENDENCIES = []
 ALIASES = {
 }
 
-ROSETTA_VERSION = "2.1.5"
+ROSETTA_VERSION = "2.1.6"
 
 rust_library(
     name = "rosetta-api",

--- a/rs/rosetta-api/icp/CHANGELOG.md
+++ b/rs/rosetta-api/icp/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
+## [2.1.6] - 2025-06-27
+### Added
+- Enhanced transaction search capabilities with database indexing optimizations for improved performance ([#5739](https://github.com/dfinity/ic/pull/5739))
+- Extended search_transactions method in Rosetta client to support filtering by transaction_hash and operation_type ([#5739](https://github.com/dfinity/ic/pull/5739))
+- Optional CLI flag --optimize-search-indexes to enable database indexing optimizations for transaction search ([#5739](https://github.com/dfinity/ic/pull/5739))
+
+### Changed
+- Enhanced test framework to support transfer_from transactions in valid_transactions_strategy ([#5592](https://github.com/dfinity/ic/pull/5592))
+- Marked ICP Rosetta system tests as flaky to address test stability issues ([#5746](https://github.com/dfinity/ic/pull/5746))
+
 ## [2.1.5] - 2025-06-13
 ### Fixed
 - Fixed heartbeat during initial sync to prevent premature watchdog timeouts ([#5293](https://github.com/dfinity/ic/pull/5293))

--- a/rs/rosetta-api/icp/Cargo.toml
+++ b/rs/rosetta-api/icp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-rosetta-api"
-version = "2.1.5"
+version = "2.1.6"
 authors = ["The Internet Computer Project Developers"]
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 edition = "2021"


### PR DESCRIPTION
- Bump version to 2.1.6 in Cargo.lock, Cargo.toml, and BUILD.bazel
- Add new features for transaction search capabilities and database indexing optimizations
- Extend search_transactions method to support filtering by transaction_hash and operation_type
- Introduce optional CLI flag --optimize-search-indexes
- Enhance test framework for transfer_from transactions and mark ICP Rosetta system tests as flaky for stability