### PR TITLE
chore(nns): Rename a metric according to convention

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -589,7 +589,7 @@ pub fn encode_metrics(
     });
 
     w.encode_gauge(
-        "voting_power_snapshots_latest_snapshot_is_spike",
+        "governance_voting_power_snapshots_latest_snapshot_is_spike",
         if latest_snapshot_is_spike { 1.0 } else { 0.0 },
         "Indicates whether the latest voting power snapshot is a spike compared to previous snapshots.",
     )?;

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -14,6 +14,8 @@ on the process that this file is part of, see
 
 ## Changed
 
+* Rename a metric related to voting power spike according to convention.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
Metrics in NNS Governance should begin with `governance_` according to convention. This is a rather new metric (added  less than one month ago), so there shouldn't be dependencies on it. In addition, this is a boolean metric indicating something goes wrong, so it's extremely unlikely that some clients started to depend on it.