### PR TITLE
fix: properly make fully qualified target from a suffix

### DIFF
--- a/rs/tests/ict/cmd/helpers.go
+++ b/rs/tests/ict/cmd/helpers.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -124,12 +125,19 @@ func make_fully_qualified_target(target string) (string, error) {
 	if err != nil {
 		return "", nil
 	}
-	target_prefix := strings.Split(all_targets[0], ":")
-	return target_prefix[0] + ":" + target, nil
+
+	target_suffix := ":" + target
+	for _, s := range all_targets {
+		if strings.HasSuffix(s, target_suffix) {
+			return s, nil
+		}
+	}
+
+	return "", errors.New("No testnet targets ends with: \"" + target_suffix + "\"")
 }
 
 func get_all_testnets() ([]string, error) {
-	command := []string{"bazel", "query", "attr(tags, 'dynamic_testnet', tests(//rs/tests/testnets/...))"}
+	command := []string{"bazel", "query", "attr(tags, 'dynamic_testnet', tests(//rs/tests/...))"}
 	queryCmd := exec.Command(command[0], command[1:]...)
 	outputBuffer := &bytes.Buffer{}
 	stdErrBuffer := &bytes.Buffer{}


### PR DESCRIPTION
Previously, all of our testnets were placed in the `tests/testnets` directory. Since that is no longer the case, this PR adapts logic to properly discover the correct target by looking for `:<target>` in the response of:
```bash
bazel query attr(tags, 'dynamic_testnet', tests(//rs/tests/...)
```

This results in the following:
```bash
ict testnet create small --lifetime-mins 10 # Valid, will match //rs/tests/testnets:small
ict testnet create canister_http_soak_test --lifetime-mins 10 # Valid, will match //rs/tests/networking:canister_http_soak_test`
ict testnet create blahblahblah --lifetime-mins 10 # Invalid, will not match anything.
```