### PR TITLE
chore: increase sns_testing_ci timeout

### DIFF
--- a/rs/sns/testing/BUILD.bazel
+++ b/rs/sns/testing/BUILD.bazel
@@ -135,6 +135,9 @@ rust_test(
 
 rust_test(
     name = "sns_testing_ci",
+    # the test sometimes times out on CI with default timeout
+    # of "moderate" (5 minutes) - 2025-07-01
+    timeout = "long",
     srcs = ["tests/sns_testing_ci.rs"],
     data = DEV_DATA,
     env = DEV_ENV,


### PR DESCRIPTION
The test sometimes times out on CI with the default timeout of 5 minutes (moderate) so we bump it to 15 minutes (long).

Note: on a local Linux runner the test takes ~1mn to run which is not close to the timeout; the test might however be sensitive to machine load.