### PR TITLE
feat(nns): Change root proposal to call Registry::subnet_for_canister instead of reading from routing table

### DIFF
--- a/rs/nns/handlers/root/impl/BUILD.bazel
+++ b/rs/nns/handlers/root/impl/BUILD.bazel
@@ -27,6 +27,7 @@ BASE_DEPENDENCIES = [
     "//rs/nns/constants",
     "//rs/nns/handlers/root/interface",
     "//rs/protobuf",
+    "//rs/registry/canister",
     "//rs/registry/keys",
     "//rs/registry/routing_table",
     "//rs/registry/transport",

--- a/rs/nns/handlers/root/impl/BUILD.bazel
+++ b/rs/nns/handlers/root/impl/BUILD.bazel
@@ -79,7 +79,6 @@ DEV_DEPENDENCIES = [
         "//rs/types/types",
         "//rs/test_utilities",
         "//rs/test_utilities/compare_dirs",
-        "//rs/registry/canister",
         "@crate_index//:tempfile",
         "@crate_index//:assert_matches",
         "@crate_index//:hex",

--- a/rs/nns/handlers/root/impl/Cargo.toml
+++ b/rs/nns/handlers/root/impl/Cargo.toml
@@ -43,6 +43,7 @@ lazy_static = { workspace = true }
 maplit = "1.0.2"
 on_wire = { path = "../../../../rust_canisters/on_wire" }
 prost = { workspace = true }
+registry-canister = { path = "../../../../registry/canister" }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 
@@ -57,7 +58,6 @@ ic-test-utilities = { path = "../../../../test_utilities" }
 ic-test-utilities-compare-dirs = { path = "../../../../test_utilities/compare_dirs" }
 ic-types = { path = "../../../../types/types" }
 on_wire = { path = "../../../../rust_canisters/on_wire" }
-registry-canister = { path = "../../../../registry/canister" }
 tempfile = { workspace = true }
 
 [build-dependencies]

--- a/rs/nns/handlers/root/unreleased_changelog.md
+++ b/rs/nns/handlers/root/unreleased_changelog.md
@@ -4,12 +4,14 @@ In general, upcoming/unreleased behavior changes are described here. For details
 on the process that this file is part of, see
 `rs/nervous_system/changelog_process.md`.
 
-
 # Next Upgrade Proposal
 
 ## Added
 
 ## Changed
+
+* Root now gets the NNS subnet via `get_subnet_for_canister` instead of getting the routing table bytes from the
+  registry. This change is needed, as the routing table records will be sharded into multiple records moving forward.
 
 ## Deprecated
 


### PR DESCRIPTION
# Why

Routing table is changed from a single record in the registry to multiple sharded records. Therefore, it's no longer feasible to read a single registry value for the NNS Subnet id. Instead, call registry to look up the subnet id.

# What

Change `Registry::get_value` call to `Registry::get_subnet_for_canister`, to get the NNS subnet id.

# Testing

The test target `//rs/nns/integration_tests:integration_tests_src/root_proposals` fails if the NNS Subnet retrieved from registry is incorrect


