### PR TITLE
chore: Remove arc from snapshot collection

### DIFF
--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1255,7 +1255,7 @@ impl ReplicatedState {
     pub fn take_snapshot(
         &mut self,
         snapshot_id: SnapshotId,
-        snapshot: Arc<CanisterSnapshot>,
+        snapshot: CanisterSnapshot,
     ) -> SnapshotId {
         self.metadata
             .unflushed_checkpoint_ops
@@ -1267,7 +1267,7 @@ impl ReplicatedState {
     pub fn create_snapshot_from_metadata(
         &mut self,
         snapshot_id: SnapshotId,
-        snapshot: Arc<CanisterSnapshot>,
+        snapshot: CanisterSnapshot,
     ) {
         self.metadata
             .unflushed_checkpoint_ops
@@ -1283,7 +1283,7 @@ impl ReplicatedState {
     }
 
     /// Delete a snapshot from the list of snapshots.
-    pub fn delete_snapshot(&mut self, snapshot_id: SnapshotId) -> Option<Arc<CanisterSnapshot>> {
+    pub fn delete_snapshot(&mut self, snapshot_id: SnapshotId) -> Option<CanisterSnapshot> {
         let result = self.canister_snapshots.remove(snapshot_id);
         if result.is_some() {
             self.metadata

--- a/rs/state_manager/src/split/tests.rs
+++ b/rs/state_manager/src/split/tests.rs
@@ -386,7 +386,7 @@ fn new_state_layout(log: ReplicaLogger) -> (TempDir, Time) {
     let snapshot =
         CanisterSnapshot::from_canister(state.canister_state(&CANISTER_1).unwrap(), state.time())
             .unwrap();
-    state.take_snapshot(snapshot_id, Arc::new(snapshot));
+    state.take_snapshot(snapshot_id, snapshot);
 
     // Make subnet_queues non-empty
     state

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -573,7 +573,7 @@ fn switch_to_checkpoint(
     }
 
     for (tip_id, tip_snapshot) in tip.canister_snapshots.iter_mut() {
-        let new_snapshot = Arc::make_mut(tip_snapshot);
+        let new_snapshot = tip_snapshot;
         let snapshot_layout = layout.snapshot(tip_id).unwrap();
 
         new_snapshot

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -6158,7 +6158,7 @@ fn can_create_and_delete_canister_snapshot() {
         .unwrap();
         let snapshot_id = SnapshotId::from((canister_test_id(100), 0));
 
-        state.take_snapshot(snapshot_id, Arc::new(new_snapshot));
+        state.take_snapshot(snapshot_id, new_snapshot);
 
         state_manager.commit_and_certify(state, height(1), CertificationScope::Full, None);
         state_manager.flush_tip_channel();
@@ -6235,7 +6235,7 @@ fn wasm_binaries_can_be_correctly_switched_from_memory_to_checkpoint() {
         )
         .unwrap();
         let snapshot_id = SnapshotId::from((canister_id, 0));
-        state.take_snapshot(snapshot_id, Arc::new(new_snapshot));
+        state.take_snapshot(snapshot_id, new_snapshot);
 
         let canister_wasm_binary = &state
             .canister_state(&canister_id)
@@ -6342,7 +6342,7 @@ fn wasm_binaries_can_be_correctly_switched_from_checkpoint_to_checkpoint() {
         )
         .unwrap();
         let snapshot_id = SnapshotId::from((canister_id, 0));
-        state.take_snapshot(snapshot_id, Arc::new(new_snapshot));
+        state.take_snapshot(snapshot_id, new_snapshot);
 
         state_manager.commit_and_certify(state, height(2), CertificationScope::Full, None);
         state_manager.flush_tip_channel();
@@ -6426,7 +6426,7 @@ fn can_create_and_restore_snapshot() {
             )
             .unwrap();
             let snapshot_id = SnapshotId::from((canister_id, 0));
-            state.take_snapshot(snapshot_id, Arc::new(new_snapshot));
+            state.take_snapshot(snapshot_id, new_snapshot);
             state_manager.commit_and_certify(state, height(2), certification_scope.clone(), None);
 
             // Modify the canister.
@@ -6875,7 +6875,7 @@ fn can_rename_canister() {
             )
             .unwrap();
             let snapshot_id = SnapshotId::from((new_canister_id, 0));
-            state.take_snapshot(snapshot_id, Arc::new(new_snapshot));
+            state.take_snapshot(snapshot_id, new_snapshot);
 
             // Trigger a flush either at the checkpoint or by committing exactly
             // `NUM_ROUNDS_BEFORE_CHECKPOINT_TO_WRITE_OVERLAY` rounds before the checkpoint.


### PR DESCRIPTION
Presumably, the `Arc`s were introduced for cheap cloning, but no cloning seems to occur. The compiler is also accepting the regular `&` references, so there is no shared ownership issue that needs to be solved. 

_Moving_ `Snapshot`s could potentially be more expensive now, but since all large data is either on the heap or in file-backed `PageMaps`, I think the cost of moving should be negligible. Consider also that without `Arc`s, we save on atomic operations.

This PR is intended to simplify an upcoming PR which should work without `Arc`s as well. 