### PR TITLE
perf(registry): Benchmark for canister migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20052,6 +20052,7 @@ dependencies = [
  "on_wire",
  "prost 0.13.4",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_distr",
  "registry-canister-protobuf-generator",
  "serde",

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -143,6 +143,8 @@ rust_library(
     deps = DEPENDENCIES + [
         ":build_script",
         "@crate_index//:canbench-rs",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
     ],
 )
 

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -60,6 +60,8 @@ prost = { workspace = true }
 serde = { workspace = true }
 url = { workspace = true }
 canbench-rs = { version = "0.1.7", optional = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["custom"] }
@@ -82,7 +84,6 @@ ic-test-utilities = { path = "../../test_utilities" }
 ic-test-utilities-types = { path = "../../test_utilities/types" }
 ic-types-test-utils = { path = "../../types/types_test_utils" }
 lazy_static = { workspace = true }
-rand = { workspace = true }
 rand_distr = "0.4.0"
 serde_json = { workspace = true }
 

--- a/rs/registry/canister/canbench/canbench_results.yml
+++ b/rs/registry/canister/canbench/canbench_results.yml
@@ -1,37 +1,130 @@
 benches:
+  get_subnet_for_canister_100_times_100:
+    total:
+      calls: 1
+      instructions: 30572231
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  get_subnet_for_canister_100_times_10k:
+    total:
+      calls: 1
+      instructions: 688493245
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  get_subnet_for_canister_100_times_1k:
+    total:
+      calls: 1
+      instructions: 90236075
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
   measure_routing_table_invariant_checks_shards_and_unsharded:
     total:
       calls: 1
-      instructions: 563027802
-      heap_increase: 69
+      instructions: 263440048
+      heap_increase: 81
       stable_memory_increase: 0
     scopes: {}
   measure_snapshot_creation_with_1000_individual_entries:
     total:
       calls: 1
-      instructions: 20601263
+      instructions: 20665386
       heap_increase: 2
       stable_memory_increase: 0
     scopes: {}
   measure_snapshot_creation_with_100_000_individual_entries:
     total:
       calls: 1
-      instructions: 3576644589
+      instructions: 3578418142
       heap_increase: 177
       stable_memory_increase: 0
     scopes: {}
   measure_snapshot_creation_with_100_segments_of_1000_entries:
     total:
       calls: 1
-      instructions: 6424399
+      instructions: 6434310
       heap_increase: 30
       stable_memory_increase: 0
     scopes: {}
   measure_snapshot_creation_with_1_segment_of_1000_entries:
     total:
       calls: 1
-      instructions: 53559
+      instructions: 53754
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
+  migrate_canisters_10_times_100:
+    total:
+      calls: 1
+      instructions: 153215392
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  migrate_canisters_10_times_10k:
+    total:
+      calls: 1
+      instructions: 10234206067
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  migrate_canisters_10_times_1k:
+    total:
+      calls: 1
+      instructions: 1015902550
+      heap_increase: 3
+      stable_memory_increase: 0
+    scopes: {}
+  upgrade_with_routing_table_100:
+    total:
+      calls: 1
+      instructions: 184765435
+      heap_increase: 7
+      stable_memory_increase: 0
+    scopes:
+      post_upgrade:
+        calls: 1
+        instructions: 183886284
+        heap_increase: 4
+        stable_memory_increase: 0
+      pre_upgrade:
+        calls: 1
+        instructions: 667239
+        heap_increase: 3
+        stable_memory_increase: 0
+  upgrade_with_routing_table_10k:
+    total:
+      calls: 1
+      instructions: 5576202603
+      heap_increase: 342
+      stable_memory_increase: 0
+    scopes:
+      post_upgrade:
+        calls: 1
+        instructions: 5553981928
+        heap_increase: 217
+        stable_memory_increase: 0
+      pre_upgrade:
+        calls: 1
+        instructions: 16603059
+        heap_increase: 125
+        stable_memory_increase: 0
+  upgrade_with_routing_table_1k:
+    total:
+      calls: 1
+      instructions: 698692556
+      heap_increase: 40
+      stable_memory_increase: 0
+    scopes:
+      post_upgrade:
+        calls: 1
+        instructions: 695801334
+        heap_increase: 25
+        stable_memory_increase: 0
+      pre_upgrade:
+        calls: 1
+        instructions: 2201557
+        heap_increase: 15
+        stable_memory_increase: 0
 version: 0.1.15

--- a/rs/registry/canister/src/certification.rs
+++ b/rs/registry/canister/src/certification.rs
@@ -74,7 +74,11 @@ pub fn recertify_registry(registry: &Registry) {
         &labeled_hash(b"delta", &registry.changelog().root_hash()),
     );
 
-    set_certified_data(&root_hash);
+    // For benchmarks, we still want the above to execute, except that we cannot actually set the
+    // certified data as the benchmarks are executed within a query call.
+    if !cfg!(feature = "canbench-rs") {
+        set_certified_data(&root_hash);
+    }
 }
 
 #[cfg(all(not(target_arch = "wasm32"), not(test)))]

--- a/rs/registry/canister/src/flags.rs
+++ b/rs/registry/canister/src/flags.rs
@@ -5,6 +5,8 @@ use ic_nervous_system_temporary::Temporary;
 
 thread_local! {
     static IS_CHUNKIFYING_LARGE_VALUES_ENABLED: Cell<bool> = const { Cell::new(true) };
+
+    static IS_ROUTING_TABLE_SINGLE_ENTRY_OBSOLETE: Cell<bool> = const { Cell::new(cfg!(feature = "canbench-rs")) };
 }
 
 pub(crate) fn is_chunkifying_large_values_enabled() -> bool {
@@ -19,4 +21,8 @@ pub fn temporarily_enable_chunkifying_large_values() -> Temporary {
 #[cfg(test)]
 pub(crate) fn temporarily_disable_chunkifying_large_values() -> Temporary {
     Temporary::new(&IS_CHUNKIFYING_LARGE_VALUES_ENABLED, false)
+}
+
+pub(crate) fn is_routing_table_single_entry_obsolete() -> bool {
+    IS_ROUTING_TABLE_SINGLE_ENTRY_OBSOLETE.get()
 }

--- a/rs/registry/canister/src/invariants/subnet.rs
+++ b/rs/registry/canister/src/invariants/subnet.rs
@@ -98,8 +98,11 @@ pub(crate) fn check_subnet_invariants(
             system_subnet_count += 1;
         }
     }
-    // There is at least one system subnet
-    if system_subnet_count < 1 {
+    // There is at least one system subnet. Note that we disable this invariant for benchmarks, as
+    // the code to set up "invariants compliant" registry mostly depends on "test-only" code, and
+    // it's very difficult to conform canbench benchmarks to test-only code. It's also risky to move
+    // those "test-only" code towards "non-test-only" code.
+    if system_subnet_count < 1 && !cfg!(feature = "canbench-rs") {
         return Err(InvariantCheckError {
             msg: "no system subnet".to_string(),
             source: None,

--- a/rs/registry/canister/src/mutations/routing_table_benches.rs
+++ b/rs/registry/canister/src/mutations/routing_table_benches.rs
@@ -1,0 +1,172 @@
+use crate::{
+    pb::v1::RegistryCanisterStableStorage, registry::Registry,
+    registry_lifecycle::canister_post_upgrade,
+};
+
+use canbench_rs::{bench, bench_fn, bench_scope, BenchResult};
+use ic_base_types::{CanisterId, PrincipalId, SubnetId};
+use ic_protobuf::registry::routing_table::v1::RoutingTable;
+use ic_registry_keys::make_routing_table_record_key;
+use ic_registry_routing_table::CANISTER_IDS_PER_SUBNET;
+use ic_registry_transport::upsert;
+use prost::Message;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+
+/// Currently there are 37 subnets. We will use 100 subnets for the benchmark.
+const NUM_SUBNETS: u64 = 100;
+const MAX_CANISTER_ID_U64: u64 = CANISTER_IDS_PER_SUBNET * NUM_SUBNETS;
+
+fn setup_empty_routing_table(registry: &mut Registry) {
+    let routing_table_mutation = upsert(
+        make_routing_table_record_key(),
+        RoutingTable { entries: vec![] }.encode_to_vec(),
+    );
+    registry.apply_mutations_for_test(vec![routing_table_mutation]);
+}
+
+fn setup_subnets(registry: &mut Registry) {
+    for id in 0..NUM_SUBNETS {
+        let subnet_id = SubnetId::from(PrincipalId::new_subnet_test_id(id));
+        let mutations = registry.add_subnet_to_routing_table(registry.latest_version(), subnet_id);
+        registry.apply_mutations_for_test(mutations);
+    }
+}
+
+fn migrate_canisters_to_subnets(registry: &mut Registry, num_migrations: u64, rng: &mut impl Rng) {
+    assert!(
+        num_migrations % NUM_SUBNETS == 0,
+        "Please choose a number of migrations that is divisible by the number of subnets"
+    );
+    let num_canisters_per_subnet = num_migrations / NUM_SUBNETS;
+
+    for subnet_id in 0..NUM_SUBNETS {
+        let canister_ids = (0..num_canisters_per_subnet)
+            .map(|_| CanisterId::from_u64(rng.gen_range(0..MAX_CANISTER_ID_U64)))
+            .collect::<Vec<_>>();
+
+        let subnet_id = SubnetId::from(PrincipalId::new_subnet_test_id(subnet_id));
+        let migration_mutation = registry.migrate_canisters_to_subnet(
+            registry.latest_version(),
+            canister_ids,
+            subnet_id,
+        );
+        registry.apply_mutations_for_test(migration_mutation);
+    }
+}
+
+fn migrate_canisters(num_existing_migrations: u64, num_calls: u64) -> BenchResult {
+    let mut registry = Registry::new();
+
+    setup_empty_routing_table(&mut registry);
+    setup_subnets(&mut registry);
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+    migrate_canisters_to_subnets(&mut registry, num_existing_migrations, &mut rng);
+
+    bench_fn(|| {
+        for _ in 0..num_calls {
+            let canister_id = CanisterId::from_u64(rng.gen_range(0..MAX_CANISTER_ID_U64));
+            let subnet_id = SubnetId::from(PrincipalId::new_subnet_test_id(0));
+            let migration_mutation = registry.migrate_canisters_to_subnet(
+                registry.latest_version(),
+                vec![canister_id],
+                subnet_id,
+            );
+            registry.maybe_apply_mutation_internal(migration_mutation);
+        }
+    })
+}
+
+#[bench(raw)]
+fn migrate_canisters_10_times_100() -> BenchResult {
+    migrate_canisters(100, 10)
+}
+
+#[bench(raw)]
+fn migrate_canisters_10_times_1k() -> BenchResult {
+    migrate_canisters(1_000, 10)
+}
+
+#[bench(raw)]
+fn migrate_canisters_10_times_10k() -> BenchResult {
+    migrate_canisters(10_000, 10)
+}
+
+fn upgrade_with_routing_table(num_canisters: u64) -> BenchResult {
+    let mut registry = Registry::new();
+
+    setup_empty_routing_table(&mut registry);
+    setup_subnets(&mut registry);
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+    migrate_canisters_to_subnets(&mut registry, num_canisters, &mut rng);
+
+    bench_fn(|| {
+        let bytes = {
+            let _s1 = bench_scope("pre_upgrade");
+            let registry_storage = RegistryCanisterStableStorage {
+                registry: Some(registry.serializable_form()),
+                pre_upgrade_version: Some(registry.latest_version()),
+            };
+            registry_storage.encode_to_vec()
+        };
+
+        let new_registry = {
+            let _s2 = bench_scope("post_upgrade");
+            let registry_storage = RegistryCanisterStableStorage::decode(bytes.as_slice())
+                .expect("Error decoding from stable.");
+            let mut new_registry = Registry::new();
+            canister_post_upgrade(&mut new_registry, registry_storage);
+            new_registry
+        };
+
+        new_registry
+    })
+}
+
+#[bench(raw)]
+fn upgrade_with_routing_table_100() -> BenchResult {
+    upgrade_with_routing_table(100)
+}
+
+#[bench(raw)]
+fn upgrade_with_routing_table_1k() -> BenchResult {
+    upgrade_with_routing_table(1_000)
+}
+
+#[bench(raw)]
+fn upgrade_with_routing_table_10k() -> BenchResult {
+    upgrade_with_routing_table(10_000)
+}
+
+fn get_subnet_for_canister(num_canisters: u64, num_calls: u64) -> BenchResult {
+    let mut registry = Registry::new();
+
+    setup_empty_routing_table(&mut registry);
+    setup_subnets(&mut registry);
+    let mut rng = ChaCha20Rng::seed_from_u64(0);
+    migrate_canisters_to_subnets(&mut registry, num_canisters, &mut rng);
+
+    bench_fn(|| {
+        for _ in 0..num_calls {
+            let canister_id = CanisterId::from_u64(rng.gen_range(0..MAX_CANISTER_ID_U64));
+            let _subnet_id = registry
+                .get_subnet_for_canister(canister_id.get_ref())
+                .unwrap();
+        }
+    })
+}
+
+#[bench(raw)]
+fn get_subnet_for_canister_100_times_100() -> BenchResult {
+    get_subnet_for_canister(100, 100)
+}
+
+#[bench(raw)]
+fn get_subnet_for_canister_100_times_1k() -> BenchResult {
+    get_subnet_for_canister(1_000, 100)
+}
+
+#[bench(raw)]
+fn get_subnet_for_canister_100_times_10k() -> BenchResult {
+    get_subnet_for_canister(10_000, 100)
+}


### PR DESCRIPTION
# Why

In order to determine the number of canister migrations we can allow as well as making sure whatever capacity we allow won't degrade unexpectedly, we add benchmarks for each of the constraints limiting the number of canister migrations we can have: (1) canister upgrade instruction limit (2) migrate canister as an update call (3) routing table lookup as query call

# What

* Avoid performing certain operations when benchmarking
  * Do not set certified data
  * Do not fail invariants check when there are no system subnet
* Add a flag for deprecating the old routing table record and set it to true in benchmarks
* (main) Add benchmarks for the 3 operations mentioned above, for 100|1000|10000 canister migrations.