### PR TITLE
test(registry): Set up sharded routing table in registry tests

### DIFF
--- a/rs/nns/integration_tests/src/registry_get_changes_since.rs
+++ b/rs/nns/integration_tests/src/registry_get_changes_since.rs
@@ -38,7 +38,7 @@ fn test_allow_opaque_caller() {
     assert_eq!(error, None);
     // The important thing is that deltas is not empty. The exact number of
     // elements is not so important.
-    assert_eq!(deltas.len(), 13);
+    assert_eq!(deltas.len(), 14);
     assert_eq!(version, 1);
 }
 
@@ -70,6 +70,6 @@ fn test_allow_self_authenticating_caller() {
     assert_eq!(error, None);
     // The important thing is that deltas is not empty. The exact number of
     // elements is not so important.
-    assert_eq!(deltas.len(), 13);
+    assert_eq!(deltas.len(), 14);
     assert_eq!(version, 1);
 }

--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -297,12 +297,12 @@ pub fn initial_routing_table_mutations(rt: &RoutingTable) -> Vec<RegistryMutatio
     let mut buf = vec![];
     rt_pb.encode(&mut buf).unwrap();
     vec![
+        // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
         RegistryMutation {
             mutation_type: Type::Upsert as i32,
             key: make_routing_table_record_key().into_bytes(),
             value: buf.clone(),
         },
-        // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
         RegistryMutation {
             mutation_type: Type::Upsert as i32,
             key: make_canister_ranges_key(CanisterId::from(0)).into_bytes(),

--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -31,7 +31,8 @@ use ic_protobuf::registry::{
 };
 use ic_registry_canister_api::{AddNodePayload, Chunk, GetChunkRequest};
 use ic_registry_keys::{
-    make_blessed_replica_versions_key, make_catch_up_package_contents_key, make_crypto_node_key,
+    make_blessed_replica_versions_key, make_canister_ranges_key,
+    make_catch_up_package_contents_key, make_crypto_node_key,
     make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key,
     make_data_center_record_key, make_node_operator_record_key, make_node_record_key,
     make_replica_version_key, make_routing_table_record_key, make_subnet_list_record_key,

--- a/rs/registry/canister/src/mutations/routing_table.rs
+++ b/rs/registry/canister/src/mutations/routing_table.rs
@@ -464,57 +464,6 @@ mod tests {
     }
 
     #[test]
-    fn test_routing_table_saves_as_canister_range_records_on_first_invocation_correctly() {
-        let mut registry = invariant_compliant_registry(0);
-        let system_subnet =
-            PrincipalId::try_from(registry.get_subnet_list_record().subnets.first().unwrap())
-                .unwrap();
-
-        let mut original = RoutingTable::new();
-        original
-            .insert(
-                CanisterIdRange {
-                    start: CanisterId::from(5000),
-                    end: CanisterId::from(6000),
-                },
-                system_subnet.into(),
-            )
-            .unwrap();
-        original
-            .insert(
-                CanisterIdRange {
-                    start: CanisterId::from(6001),
-                    end: CanisterId::from(7000),
-                },
-                system_subnet.into(),
-            )
-            .unwrap();
-
-        let new_routing_table = pb::RoutingTable::from(original.clone());
-        let mutations = vec![upsert(
-            make_routing_table_record_key().as_bytes(),
-            new_routing_table.encode_to_vec(),
-        )];
-        registry.maybe_apply_mutation_internal(mutations);
-
-        let recovered = registry
-            .get_routing_table_from_canister_range_records_or_panic(registry.latest_version());
-
-        assert_eq!(recovered, RoutingTable::new());
-
-        // Now we are in a situation where there is no difference between what's stored under the
-        // `routing_table` key and what's being saved BUT we should still generate canister_ranges_*
-        // records b/c they're empty
-        let mutations = routing_table_into_registry_mutation(&registry, original.clone());
-        registry.maybe_apply_mutation_internal(mutations);
-
-        let recovered = registry
-            .get_routing_table_from_canister_range_records_or_panic(registry.latest_version());
-
-        assert_eq!(recovered, original);
-    }
-
-    #[test]
     fn test_routing_table_updates_and_deletes_entries_as_expected() {
         let mut registry = invariant_compliant_registry(0);
         let system_subnet =

--- a/rs/registry/canister/tests/modify_canister_migrations.rs
+++ b/rs/registry/canister/tests/modify_canister_migrations.rs
@@ -5,7 +5,9 @@ use ic_nns_test_utils::{
         local_test_on_nns_subnet, set_up_registry_canister, set_up_universal_canister,
         try_call_via_universal_canister,
     },
-    registry::{get_value_or_panic, prepare_registry_with_two_node_sets, routing_table_mutation},
+    registry::{
+        get_value_or_panic, initial_routing_table_mutations, prepare_registry_with_two_node_sets,
+    },
 };
 use ic_protobuf::registry::routing_table::v1 as pb;
 use ic_registry_routing_table::{CanisterIdRange, CanisterMigrations, RoutingTable};
@@ -55,7 +57,7 @@ fn test_modify_canister_migrations() {
                     .expect("failed to update the routing table");
 
                 RegistryAtomicMutateRequest {
-                    mutations: vec![routing_table_mutation(&rt)],
+                    mutations: initial_routing_table_mutations(&rt),
                     preconditions: vec![],
                 }
             };

--- a/rs/registry/canister/tests/reroute_canister_ranges.rs
+++ b/rs/registry/canister/tests/reroute_canister_ranges.rs
@@ -4,7 +4,7 @@ use ic_nns_test_utils::{
         local_test_on_nns_subnet, set_up_registry_canister, set_up_universal_canister,
         try_call_via_universal_canister,
     },
-    registry::{prepare_registry_with_two_node_sets, routing_table_mutation},
+    registry::{initial_routing_table_mutations, prepare_registry_with_two_node_sets},
 };
 use ic_registry_routing_table::{CanisterIdRange, RoutingTable};
 use ic_registry_transport::pb::v1::RegistryAtomicMutateRequest;
@@ -45,7 +45,7 @@ fn test_reroute_canister_ranges() {
                     .expect("failed to update the routing table");
 
                 RegistryAtomicMutateRequest {
-                    mutations: vec![routing_table_mutation(&rt)],
+                    mutations: initial_routing_table_mutations(&rt),
                     preconditions: vec![],
                 }
             };

--- a/rs/registry/canister/tests/roll_back_canister_migration.rs
+++ b/rs/registry/canister/tests/roll_back_canister_migration.rs
@@ -4,7 +4,7 @@ use ic_nns_test_utils::{
         local_test_on_nns_subnet, set_up_registry_canister, set_up_universal_canister,
         try_call_via_universal_canister,
     },
-    registry::{prepare_registry_with_two_node_sets, routing_table_mutation},
+    registry::{initial_routing_table_mutations, prepare_registry_with_two_node_sets},
 };
 use ic_registry_routing_table::{CanisterIdRange, RoutingTable};
 use ic_registry_transport::pb::v1::RegistryAtomicMutateRequest;
@@ -45,7 +45,7 @@ fn test_roll_back_canister_migration() {
                     .expect("failed to update the routing table");
 
                 RegistryAtomicMutateRequest {
-                    mutations: vec![routing_table_mutation(&rt)],
+                    mutations: initial_routing_table_mutations(&rt),
                     preconditions: vec![],
                 }
             };


### PR DESCRIPTION
Routing table format is being changed from a single value to sharded values. This PR sets up the sharded routing table in addition to the single routing table.