### PR TITLE
chore: bump pocket-ic test timeout

### DIFF
--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -69,7 +69,9 @@ rust_test(
 
 rust_test_suite(
     name = "test",
-    size = "medium",
+    # the test sometimes times out on CI with default timeout
+    # of "moderate" (5 minutes) - 2025-07-03
+    timeout = "long",
     srcs = ["tests/tests.rs"],
     data = [
         "//packages/pocket-ic/test_canister:test_canister.wasm.gz",


### PR DESCRIPTION
We've seen the test time out on CI and we suspect the test might be sensitive to machine load. Here we bump the timeout from 5mn to 15mn. Locally, the test seems to run in under 1mn.