### PR TITLE
feat: Added canister_cycles_cost_schedule to SubnetRecord.

### DIFF
--- a/rs/boundary_node/ic_boundary/src/test_utils.rs
+++ b/rs/boundary_node/ic_boundary/src/test_utils.rs
@@ -19,7 +19,7 @@ use ic_protobuf::registry::{
     crypto::v1::{PublicKey as PublicKeyProto, X509PublicKeyCert},
     node::v1::{ConnectionEndpoint, NodeRecord},
     routing_table::v1::RoutingTable as PbRoutingTable,
-    subnet::v1::{SubnetListRecord, SubnetRecord},
+    subnet::v1::{SubnetListRecord, SubnetRecord, CanisterCyclesCostSchedule},
 };
 use ic_registry_client_fake::FakeRegistryClient;
 use ic_registry_keys::{
@@ -124,6 +124,7 @@ pub fn test_subnet_record() -> SubnetRecord {
         ssh_readonly_access: vec![],
         ssh_backup_access: vec![],
         chain_key_config: None,
+        canister_cycles_cost_schedule: CanisterCyclesCostSchedule::Normal as i32,
     }
 }
 

--- a/rs/crypto/temp_crypto/src/lib.rs
+++ b/rs/crypto/temp_crypto/src/lib.rs
@@ -1,7 +1,7 @@
 use ic_crypto_internal_csp::Csp;
 use ic_interfaces::time_source::SysTimeSource;
 use ic_limits::INITIAL_NOTARY_DELAY;
-use ic_protobuf::registry::subnet::v1::{ChainKeyConfig, KeyConfig, SubnetRecord, SubnetType};
+use ic_protobuf::registry::subnet::v1::{ChainKeyConfig, KeyConfig, SubnetRecord, SubnetType, CanisterCyclesCostSchedule};
 use ic_protobuf::types::v1 as pb_types;
 use ic_types::{NodeId, ReplicaVersion, SubnetId};
 use rand::rngs::OsRng;
@@ -1112,6 +1112,7 @@ impl EcdsaSubnetConfig {
                     idkg_key_rotation_period_ms: key_rotation_period
                         .map(|key_rotation_period| key_rotation_period.as_millis() as u64),
                 }),
+                canister_cycles_cost_schedule: CanisterCyclesCostSchedule::Normal as i32,
             },
         }
     }

--- a/rs/prep/src/subnet_configuration.rs
+++ b/rs/prep/src/subnet_configuration.rs
@@ -18,7 +18,7 @@ use ic_crypto_utils_threshold_sig_der::threshold_sig_public_key_to_der;
 use ic_protobuf::registry::{
     crypto::v1::PublicKey,
     subnet::v1::{
-        CatchUpPackageContents, ChainKeyConfig, InitialNiDkgTranscriptRecord, SubnetRecord,
+        CatchUpPackageContents, ChainKeyConfig, InitialNiDkgTranscriptRecord, SubnetRecord, CanisterCyclesCostSchedule,
     },
 };
 use ic_registry_subnet_features::SubnetFeatures;
@@ -315,6 +315,7 @@ impl SubnetConfig {
             ssh_readonly_access: self.ssh_readonly_access,
             ssh_backup_access: self.ssh_backup_access,
             chain_key_config: self.chain_key_config,
+            canister_cycles_cost_schedule: CanisterCyclesCostSchedule::Normal as i32,
         };
 
         let dkg_dealing_encryption_pubkeys: BTreeMap<_, _> = initialized_nodes

--- a/rs/protobuf/def/registry/subnet/v1/subnet.proto
+++ b/rs/protobuf/def/registry/subnet/v1/subnet.proto
@@ -74,6 +74,10 @@ message SubnetRecord {
   // key. If the removed key is not held by another subnet, it will be lost.
   optional ChainKeyConfig chain_key_config = 29;
 
+  // When set to UNSPECIFIED, this field behaves the same as NORMAL, which just
+  // means to behave according to the `subnet_type` field.
+  CanisterCyclesCostSchedule canister_cycles_cost_schedule = 30;
+
   reserved 1, 2, 4, 6, 13, 20, 21, 22, 27;
   reserved "ic_version_id";
   reserved "initial_dkg_transcript";
@@ -333,4 +337,17 @@ message ChainKeyConfig {
   // Key rotation period of a single node in milliseconds.
   // If none is specified key rotation is disabled.
   optional uint64 idkg_key_rotation_period_ms = 3;
+}
+
+// How to charge canisters for their use of computational resources (such as
+// executing instructions, storing data, network, etc.)
+enum CanisterCyclesCostSchedule {
+  // This should be treated the same as NORMAL.
+  CANISTER_CYCLES_COST_SCHEDULE_UNSPECIFIED = 0;
+
+  // Behave according to SubnetType.
+  CANISTER_CYCLES_COST_SCHEDULE_NORMAL = 1;
+
+  // Canisters are not charged cycles.
+  CANISTER_CYCLES_COST_SCHEDULE_FREE = 2;
 }

--- a/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
@@ -70,6 +70,10 @@ pub struct SubnetRecord {
     /// key. If the removed key is not held by another subnet, it will be lost.
     #[prost(message, optional, tag = "29")]
     pub chain_key_config: ::core::option::Option<ChainKeyConfig>,
+    /// When set to UNSPECIFIED, this field behaves the same as NORMAL, which just
+    /// means to behave according to the `subnet_type` field.
+    #[prost(enumeration = "CanisterCyclesCostSchedule", tag = "30")]
+    pub canister_cycles_cost_schedule: i32,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, ::prost::Message)]
 pub struct EcdsaInitialization {
@@ -456,6 +460,52 @@ impl SubnetType {
             "SUBNET_TYPE_APPLICATION" => Some(Self::Application),
             "SUBNET_TYPE_SYSTEM" => Some(Self::System),
             "SUBNET_TYPE_VERIFIED_APPLICATION" => Some(Self::VerifiedApplication),
+            _ => None,
+        }
+    }
+}
+/// How to charge canisters for their use of computational resources (such as
+/// executing instructions, storing data, network, etc.)
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
+#[repr(i32)]
+pub enum CanisterCyclesCostSchedule {
+    /// This should be treated the same as NORMAL.
+    Unspecified = 0,
+    /// Behave according to SubnetType.
+    Normal = 1,
+    /// Canisters are not charged cycles.
+    Free = 2,
+}
+impl CanisterCyclesCostSchedule {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "CANISTER_CYCLES_COST_SCHEDULE_UNSPECIFIED",
+            Self::Normal => "CANISTER_CYCLES_COST_SCHEDULE_NORMAL",
+            Self::Free => "CANISTER_CYCLES_COST_SCHEDULE_FREE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CANISTER_CYCLES_COST_SCHEDULE_UNSPECIFIED" => Some(Self::Unspecified),
+            "CANISTER_CYCLES_COST_SCHEDULE_NORMAL" => Some(Self::Normal),
+            "CANISTER_CYCLES_COST_SCHEDULE_FREE" => Some(Self::Free),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/state/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/state/registry.subnet.v1.rs
@@ -70,6 +70,10 @@ pub struct SubnetRecord {
     /// key. If the removed key is not held by another subnet, it will be lost.
     #[prost(message, optional, tag = "29")]
     pub chain_key_config: ::core::option::Option<ChainKeyConfig>,
+    /// When set to UNSPECIFIED, this field behaves the same as NORMAL, which just
+    /// means to behave according to the `subnet_type` field.
+    #[prost(enumeration = "CanisterCyclesCostSchedule", tag = "30")]
+    pub canister_cycles_cost_schedule: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EcdsaInitialization {
@@ -421,6 +425,40 @@ impl SubnetType {
             "SUBNET_TYPE_APPLICATION" => Some(Self::Application),
             "SUBNET_TYPE_SYSTEM" => Some(Self::System),
             "SUBNET_TYPE_VERIFIED_APPLICATION" => Some(Self::VerifiedApplication),
+            _ => None,
+        }
+    }
+}
+/// How to charge canisters for their use of computational resources (such as
+/// executing instructions, storing data, network, etc.)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum CanisterCyclesCostSchedule {
+    /// This should be treated the same as NORMAL.
+    Unspecified = 0,
+    /// Behave according to SubnetType.
+    Normal = 1,
+    /// Canisters are not charged cycles.
+    Free = 2,
+}
+impl CanisterCyclesCostSchedule {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "CANISTER_CYCLES_COST_SCHEDULE_UNSPECIFIED",
+            Self::Normal => "CANISTER_CYCLES_COST_SCHEDULE_NORMAL",
+            Self::Free => "CANISTER_CYCLES_COST_SCHEDULE_FREE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CANISTER_CYCLES_COST_SCHEDULE_UNSPECIFIED" => Some(Self::Unspecified),
+            "CANISTER_CYCLES_COST_SCHEDULE_NORMAL" => Some(Self::Normal),
+            "CANISTER_CYCLES_COST_SCHEDULE_FREE" => Some(Self::Free),
             _ => None,
         }
     }

--- a/rs/protobuf/src/gen/types/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/types/registry.subnet.v1.rs
@@ -70,6 +70,10 @@ pub struct SubnetRecord {
     /// key. If the removed key is not held by another subnet, it will be lost.
     #[prost(message, optional, tag = "29")]
     pub chain_key_config: ::core::option::Option<ChainKeyConfig>,
+    /// When set to UNSPECIFIED, this field behaves the same as NORMAL, which just
+    /// means to behave according to the `subnet_type` field.
+    #[prost(enumeration = "CanisterCyclesCostSchedule", tag = "30")]
+    pub canister_cycles_cost_schedule: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EcdsaInitialization {
@@ -421,6 +425,40 @@ impl SubnetType {
             "SUBNET_TYPE_APPLICATION" => Some(Self::Application),
             "SUBNET_TYPE_SYSTEM" => Some(Self::System),
             "SUBNET_TYPE_VERIFIED_APPLICATION" => Some(Self::VerifiedApplication),
+            _ => None,
+        }
+    }
+}
+/// How to charge canisters for their use of computational resources (such as
+/// executing instructions, storing data, network, etc.)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum CanisterCyclesCostSchedule {
+    /// This should be treated the same as NORMAL.
+    Unspecified = 0,
+    /// Behave according to SubnetType.
+    Normal = 1,
+    /// Canisters are not charged cycles.
+    Free = 2,
+}
+impl CanisterCyclesCostSchedule {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "CANISTER_CYCLES_COST_SCHEDULE_UNSPECIFIED",
+            Self::Normal => "CANISTER_CYCLES_COST_SCHEDULE_NORMAL",
+            Self::Free => "CANISTER_CYCLES_COST_SCHEDULE_FREE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CANISTER_CYCLES_COST_SCHEDULE_UNSPECIFIED" => Some(Self::Unspecified),
+            "CANISTER_CYCLES_COST_SCHEDULE_NORMAL" => Some(Self::Normal),
+            "CANISTER_CYCLES_COST_SCHEDULE_FREE" => Some(Self::Free),
             _ => None,
         }
     }

--- a/rs/registry/canister/src/mutations/do_create_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_create_subnet.rs
@@ -12,7 +12,7 @@ use ic_protobuf::registry::{
     node::v1::NodeRecord,
     subnet::v1::{
         CatchUpPackageContents, ChainKeyConfig as ChainKeyConfigPb,
-        SubnetFeatures as SubnetFeaturesPb, SubnetRecord,
+        SubnetFeatures as SubnetFeaturesPb, SubnetRecord, CanisterCyclesCostSchedule as CanisterCyclesCostSchedulePb,
     },
 };
 use ic_registry_keys::{
@@ -485,6 +485,16 @@ pub enum CanisterCyclesCostSchedule {
     Free,
 }
 
+impl From<CanisterCyclesCostSchedule> for CanisterCyclesCostSchedulePb {
+    fn from(src: CanisterCyclesCostSchedule) -> Self {
+        type Src = CanisterCyclesCostSchedule;
+        match src {
+            Src::Normal => Self::Normal,
+            Src::Free => Self::Free,
+        }
+    }
+}
+
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize, Serialize)]
 pub struct EcdsaInitialConfig {
     pub quadruples_to_create_in_advance: u32,
@@ -537,6 +547,12 @@ impl From<CreateSubnetPayload> for SubnetRecord {
                         .expect("Invalid InitialChainKeyConfig")
                 })
                 .map(ChainKeyConfigPb::from),
+
+            canister_cycles_cost_schedule: val
+                .canister_cycles_cost_schedule
+                .map(CanisterCyclesCostSchedulePb::from)
+                .unwrap_or(CanisterCyclesCostSchedulePb::Normal)
+                as i32,
         }
     }
 }

--- a/rs/test_utilities/registry/src/lib.rs
+++ b/rs/test_utilities/registry/src/lib.rs
@@ -6,7 +6,7 @@ use ic_protobuf::registry::crypto::v1::PublicKey as PublicKeyProto;
 use ic_protobuf::registry::subnet::v1::chain_key_initialization::Initialization;
 use ic_protobuf::registry::subnet::v1::ChainKeyInitialization;
 use ic_protobuf::registry::subnet::v1::{
-    CatchUpPackageContents, InitialNiDkgTranscriptRecord, SubnetListRecord, SubnetRecord,
+    CatchUpPackageContents, InitialNiDkgTranscriptRecord, SubnetListRecord, SubnetRecord, CanisterCyclesCostSchedule,
 };
 use ic_protobuf::types::v1::master_public_key_id::KeyId;
 use ic_registry_client_fake::FakeRegistryClient;
@@ -232,6 +232,7 @@ pub fn test_subnet_record() -> SubnetRecord {
         ssh_readonly_access: vec![],
         ssh_backup_access: vec![],
         chain_key_config: None,
+        canister_cycles_cost_schedule: CanisterCyclesCostSchedule::Normal as i32,
     }
 }
 


### PR DESCRIPTION
Like how we did with CreateSubnetPayload in [PR 5777].

[PR 5777]: https://github.com/dfinity/ic/pull/5777

# References

Closes [NNS1-3924].

[NNS1-3924]: https://dfinity.atlassian.net/browse/NNS1-3924

[👈 Previous PR][PR 5777]