### PR TITLE
feat(ICP_Ledger): FI-1772: Add ICRC-106 support to the ICP ledger

### DIFF
--- a/rs/ledger_suite/icp/ledger.did
+++ b/rs/ledger_suite/icp/ledger.did
@@ -126,7 +126,7 @@ type Operation = variant {
     };
 };
 
- 
+
 
 type Block = record {
     parent_hash : opt blob;
@@ -184,7 +184,7 @@ type QueryArchiveFn = func (GetBlocksArgs) -> (QueryArchiveResult) query;
 // not have all the blocks that the caller requested: One or more "archive" canisters might
 // store some of the requested blocks.
 //
-// Note: as of Q4 2021 when this interface is authored, the IC doesn't support making nested 
+// Note: as of Q4 2021 when this interface is authored, the IC doesn't support making nested
 // query calls within a query call.
 type QueryBlocksResponse = record {
     // The total number of blocks in the chain.
@@ -302,6 +302,7 @@ type InitArgs = record {
     token_symbol: opt text;
     token_name: opt text;
     feature_flags : opt FeatureFlags;
+    index_principal : opt principal;
 };
 
 type Icrc1BlockIndex = nat;
@@ -350,6 +351,7 @@ type Value = variant {
 type UpgradeArgs = record {
   icrc1_minting_account : opt Account;
   feature_flags : opt FeatureFlags;
+  index_principal : opt principal;
 };
 
 type LedgerCanisterPayload = variant {
@@ -479,6 +481,21 @@ type icrc21_consent_message_response = variant {
     Err: icrc21_error;
 };
 
+type GetIndexPrincipalResult = variant {
+    Ok : principal;
+    Err : GetIndexPrincipalError;
+};
+
+type GetIndexPrincipalError = variant {
+    IndexPrincipalNotSet;
+
+    // Any error not covered by the above variants.
+    GenericError: record {
+       error_code: nat;
+       description: text;
+   };
+};
+
 service: (LedgerCanisterPayload) -> {
     // Transfers tokens from a subaccount of the caller to the destination address.
     // The source address is computed from the principal of the caller and the specified subaccount.
@@ -499,7 +516,7 @@ service: (LedgerCanisterPayload) -> {
 
     // Queries encoded blocks in the specified range
     query_encoded_blocks : (GetBlocksArgs) -> (QueryEncodedBlocksResponse) query;
-    
+
     // Returns token symbol.
     symbol : () -> (record { symbol: text }) query;
 
@@ -533,6 +550,8 @@ service: (LedgerCanisterPayload) -> {
 
     icrc21_canister_call_consent_message: (icrc21_consent_message_request) -> (icrc21_consent_message_response);
     icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
+
+    icrc106_get_index_principal: () -> (GetIndexPrincipalResult) query;
 
     is_ledger_ready: () -> (bool) query;
 }

--- a/rs/ledger_suite/icp/ledger/src/lib.rs
+++ b/rs/ledger_suite/icp/ledger/src/lib.rs
@@ -1,3 +1,4 @@
+use candid::Principal;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_cdk::{api::time, trap};
 use ic_ledger_canister_core::archive::ArchiveCanisterWasm;
@@ -229,6 +230,9 @@ pub struct Ledger {
 
     #[serde(default)]
     pub ledger_version: u64,
+
+    #[serde(default)]
+    pub index_principal: Option<Principal>,
 }
 
 impl LedgerContext for Ledger {
@@ -347,6 +351,7 @@ impl Default for Ledger {
             token_name: unknown_token(),
             feature_flags: FeatureFlags::default(),
             ledger_version: LEDGER_VERSION,
+            index_principal: None,
         }
     }
 }
@@ -449,6 +454,7 @@ impl Ledger {
         token_symbol: Option<String>,
         token_name: Option<String>,
         feature_flags: Option<FeatureFlags>,
+        index_principal: Option<Principal>,
     ) {
         self.token_symbol = token_symbol.unwrap_or_else(|| "ICP".to_string());
         self.token_name = token_name.unwrap_or_else(|| "Internet Computer".to_string());
@@ -476,6 +482,7 @@ impl Ledger {
         if let Some(feature_flags) = feature_flags {
             self.feature_flags = feature_flags;
         }
+        self.index_principal = index_principal;
     }
 
     pub fn change_notification_state(
@@ -559,6 +566,9 @@ impl Ledger {
         }
         if let Some(feature_flags) = args.feature_flags {
             self.feature_flags = feature_flags;
+        }
+        if let Some(index_principal) = args.index_principal {
+            self.index_principal = Some(index_principal);
         }
     }
 }

--- a/rs/ledger_suite/icp/ledger/src/tests.rs
+++ b/rs/ledger_suite/icp/ledger/src/tests.rs
@@ -200,6 +200,7 @@ fn serialize() {
         Some("ICP".into()),
         Some("icp".into()),
         None,
+        None,
     );
 
     let txn = Transaction::new(
@@ -610,6 +611,7 @@ fn test_purge() {
         None,
         Some("ICP".into()),
         Some("icp".into()),
+        None,
         None,
     );
     let little_later = genesis + Duration::from_millis(1);

--- a/rs/ledger_suite/icp/src/lib.rs
+++ b/rs/ledger_suite/icp/src/lib.rs
@@ -1,4 +1,4 @@
-use candid::CandidType;
+use candid::{CandidType, Principal};
 use dfn_protobuf::ProtoBuf;
 use dfn_protobuf::ToProto;
 use ic_base_types::{CanisterId, PrincipalId};
@@ -460,6 +460,9 @@ pub struct UpgradeArgs {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub feature_flags: Option<FeatureFlags>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index_principal: Option<Principal>,
 }
 
 // This is how we pass arguments to 'init' in main.rs
@@ -476,6 +479,7 @@ pub struct InitArgs {
     pub token_symbol: Option<String>,
     pub token_name: Option<String>,
     pub feature_flags: Option<FeatureFlags>,
+    pub index_principal: Option<Principal>,
 }
 
 impl LedgerCanisterInitPayload {
@@ -508,6 +512,7 @@ pub struct LedgerCanisterInitPayloadBuilder {
     token_symbol: Option<String>,
     token_name: Option<String>,
     feature_flags: Option<FeatureFlags>,
+    index_principal: Option<Principal>,
 }
 
 impl LedgerCanisterInitPayloadBuilder {
@@ -524,6 +529,7 @@ impl LedgerCanisterInitPayloadBuilder {
             token_symbol: None,
             token_name: None,
             feature_flags: None,
+            index_principal: None,
         }
     }
 
@@ -578,6 +584,11 @@ impl LedgerCanisterInitPayloadBuilder {
         self
     }
 
+    pub fn index_principal(mut self, index_principal: Principal) -> Self {
+        self.index_principal = Some(index_principal);
+        self
+    }
+
     pub fn build(self) -> Result<LedgerCanisterInitPayload, String> {
         let minting_account = self
             .minting_account
@@ -611,6 +622,7 @@ impl LedgerCanisterInitPayloadBuilder {
                 token_symbol: self.token_symbol,
                 token_name: self.token_name,
                 feature_flags: self.feature_flags,
+                index_principal: self.index_principal,
             },
         )))
     }
@@ -619,6 +631,7 @@ impl LedgerCanisterInitPayloadBuilder {
 pub struct LedgerCanisterUpgradePayloadBuilder {
     icrc1_minting_account: Option<Account>,
     feature_flags: Option<FeatureFlags>,
+    index_principal: Option<Principal>,
 }
 
 impl LedgerCanisterUpgradePayloadBuilder {
@@ -626,6 +639,7 @@ impl LedgerCanisterUpgradePayloadBuilder {
         Self {
             icrc1_minting_account: None,
             feature_flags: None,
+            index_principal: None,
         }
     }
 
@@ -634,11 +648,17 @@ impl LedgerCanisterUpgradePayloadBuilder {
         self
     }
 
+    pub fn index_principal(mut self, index_principal: Principal) -> Self {
+        self.index_principal = Some(index_principal);
+        self
+    }
+
     pub fn build(self) -> Result<LedgerCanisterUpgradePayload, String> {
         Ok(LedgerCanisterUpgradePayload(
             LedgerCanisterPayload::Upgrade(Some(UpgradeArgs {
                 icrc1_minting_account: self.icrc1_minting_account,
                 feature_flags: self.feature_flags,
+                index_principal: self.index_principal,
             })),
         ))
     }

--- a/rs/ledger_suite/icp/tests/golden_nns_state.rs
+++ b/rs/ledger_suite/icp/tests/golden_nns_state.rs
@@ -413,6 +413,7 @@ impl Setup {
             LedgerCanisterPayload::Upgrade(Some(UpgradeArgs {
                 icrc1_minting_account: None,
                 feature_flags: Some(FeatureFlags { icrc2: true }),
+                index_principal: None,
             }));
 
         self.state_machine.upgrade_canister(

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -598,7 +598,7 @@ fn encode_icrc106_upgrade_args(index_principal: Option<Principal>) -> LedgerArgu
 }
 
 #[test]
-fn test_icrc106_unsupported_if_index_not_set() {
+fn test_icrc106_supported_even_if_index_not_set() {
     ic_ledger_suite_state_machine_tests::icrc_106::test_icrc106_supported_even_if_index_not_set(
         ledger_wasm(),
         encode_init_args,

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -1035,7 +1035,7 @@ where
         standards.push(standard.name);
     }
     standards.sort();
-    assert_eq!(standards, vec!["ICRC-1", "ICRC-2", "ICRC-21"]);
+    assert_eq!(standards, vec!["ICRC-1", "ICRC-106", "ICRC-2", "ICRC-21"]);
 }
 pub fn test_metadata<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
 where
@@ -4199,8 +4199,9 @@ pub fn expect_icrc2_disabled(
         "ICRC-2 features are not enabled on the ledger.",
     );
     let standards = supported_standards(env, canister_id);
-    assert_eq!(standards.len(), 2);
-    assert_eq!(standards[0].name, "ICRC-1");
+    for standard in standards {
+        assert_ne!(standard.name, "ICRC-2");
+    }
 }
 
 pub fn test_feature_flags<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)


### PR DESCRIPTION
Add ICP ledger support for the ICRC-106 standard for including the principal of the ledger's associated index canister.