### PR TITLE
feat(btc): initial support for dogecoin in ic-btc-adapter

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "27e6a0550c49829a71f7359e6509ba37ac377d089cc8821537beb01638dfe280",
+  "checksum": "4dbbba465a5db5cd2741d2404a9eaadf1fb545f8170303aeb0b4ac0352837cb2",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -8092,14 +8092,17 @@
       ],
       "license_file": null
     },
-    "bitcoin 0.32.5": {
+    "bitcoin 0.32.99": {
       "name": "bitcoin",
-      "version": "0.32.5",
-      "package_url": "https://github.com/rust-bitcoin/rust-bitcoin/",
+      "version": "0.32.99",
+      "package_url": "https://github.com/rust-dogecoin/rust-dogecoin/",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/bitcoin/0.32.5/download",
-          "sha256": "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+        "Git": {
+          "remote": "https://github.com/dfinity/rust-dogecoin",
+          "commitish": {
+            "Rev": "f1f900da0b193c43fd16f4598e614ed3eafbfd8f"
+          },
+          "strip_prefix": "bitcoin"
         }
       },
       "targets": [
@@ -8138,7 +8141,6 @@
             "actual-serde",
             "default",
             "rand",
-            "rand-std",
             "secp-recovery",
             "serde",
             "std"
@@ -8157,7 +8159,7 @@
               "target": "bech32"
             },
             {
-              "id": "bitcoin 0.32.5",
+              "id": "bitcoin 0.32.99",
               "target": "build_script_build"
             },
             {
@@ -8188,6 +8190,10 @@
             {
               "id": "hex_lit 0.1.1",
               "target": "hex_lit"
+            },
+            {
+              "id": "scrypt 0.11.0",
+              "target": "scrypt"
             },
             {
               "id": "secp256k1 0.29.0",
@@ -8225,7 +8231,7 @@
           ],
           "selects": {}
         },
-        "version": "0.32.5"
+        "version": "0.32.99"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -8799,7 +8805,7 @@
         "deps": {
           "common": [
             {
-              "id": "bitcoin 0.32.5",
+              "id": "bitcoin 0.32.99",
               "target": "bitcoin"
             },
             {
@@ -20316,7 +20322,7 @@
               "alias": "bitcoin_0_28"
             },
             {
-              "id": "bitcoin 0.32.5",
+              "id": "bitcoin 0.32.99",
               "target": "bitcoin"
             },
             {
@@ -52886,6 +52892,7 @@
         ],
         "crate_features": {
           "common": [
+            "default",
             "hmac"
           ],
           "selects": {}
@@ -66531,6 +66538,54 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "salsa20 0.10.2": {
+      "name": "salsa20",
+      "version": "0.10.2",
+      "package_url": "https://github.com/RustCrypto/stream-ciphers",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/salsa20/0.10.2/download",
+          "sha256": "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "salsa20",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "salsa20",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cipher 0.4.4",
+              "target": "cipher"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.10.2"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "same-file 1.0.6": {
       "name": "same-file",
       "version": "1.0.6",
@@ -67134,6 +67189,62 @@
         "ISC"
       ],
       "license_file": "LICENSE"
+    },
+    "scrypt 0.11.0": {
+      "name": "scrypt",
+      "version": "0.11.0",
+      "package_url": "https://github.com/RustCrypto/password-hashes/tree/master/scrypt",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/scrypt/0.11.0/download",
+          "sha256": "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "scrypt",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "scrypt",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "pbkdf2 0.12.2",
+              "target": "pbkdf2"
+            },
+            {
+              "id": "salsa20 0.10.2",
+              "target": "salsa20"
+            },
+            {
+              "id": "sha2 0.10.9",
+              "target": "sha2"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.11.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
     },
     "sct 0.7.0": {
       "name": "sct",
@@ -93009,7 +93120,7 @@
     "bip32 0.5.1",
     "bit-vec 0.6.3",
     "bitcoin 0.28.2",
-    "bitcoin 0.32.5",
+    "bitcoin 0.32.99",
     "bitcoincore-rpc 0.19.0",
     "bitcoind 0.32.0",
     "bitflags 1.3.2",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -1404,9 +1404,8 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+version = "0.32.99"
+source = "git+https://github.com/dfinity/rust-dogecoin?rev=f1f900da0b193c43fd16f4598e614ed3eafbfd8f#f1f900da0b193c43fd16f4598e614ed3eafbfd8f"
 dependencies = [
  "base58ck",
  "bech32 0.11.0",
@@ -1416,6 +1415,7 @@ dependencies = [
  "bitcoin_hashes 0.14.0",
  "hex-conservative",
  "hex_lit",
+ "scrypt",
  "secp256k1 0.29.0",
  "serde",
 ]
@@ -1500,7 +1500,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "serde",
  "serde_json",
 ]
@@ -3448,7 +3448,7 @@ dependencies = [
  "bip32 0.5.1",
  "bit-vec 0.6.3",
  "bitcoin 0.28.2",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "bitcoincore-rpc",
  "bitcoind",
  "bitflags 1.3.2",
@@ -11180,6 +11180,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11279,6 +11288,17 @@ dependencies = [
  "selectors",
  "smallvec",
  "tendril",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2 0.12.2",
+ "salsa20",
+ "sha2 0.10.9",
 ]
 
 [[package]]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "571e69b3e0b9fe5cc03fd27f4b5d4ee55349a72e2ebda493a3a0e02f2de57998",
+  "checksum": "8be221b4ab0c7efd14943d5d64a25a64452b25b534eaea7dc92f5a4909127556",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -8024,14 +8024,17 @@
       ],
       "license_file": null
     },
-    "bitcoin 0.32.5": {
+    "bitcoin 0.32.99": {
       "name": "bitcoin",
-      "version": "0.32.5",
-      "package_url": "https://github.com/rust-bitcoin/rust-bitcoin/",
+      "version": "0.32.99",
+      "package_url": "https://github.com/rust-dogecoin/rust-dogecoin/",
       "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/bitcoin/0.32.5/download",
-          "sha256": "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+        "Git": {
+          "remote": "https://github.com/dfinity/rust-dogecoin",
+          "commitish": {
+            "Rev": "f1f900da0b193c43fd16f4598e614ed3eafbfd8f"
+          },
+          "strip_prefix": "bitcoin"
         }
       },
       "targets": [
@@ -8070,7 +8073,6 @@
             "actual-serde",
             "default",
             "rand",
-            "rand-std",
             "secp-recovery",
             "serde",
             "std"
@@ -8089,7 +8091,7 @@
               "target": "bech32"
             },
             {
-              "id": "bitcoin 0.32.5",
+              "id": "bitcoin 0.32.99",
               "target": "build_script_build"
             },
             {
@@ -8122,6 +8124,10 @@
               "target": "hex_lit"
             },
             {
+              "id": "scrypt 0.11.0",
+              "target": "scrypt"
+            },
+            {
               "id": "secp256k1 0.29.0",
               "target": "secp256k1"
             },
@@ -8134,7 +8140,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.32.5"
+        "version": "0.32.99"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -8708,7 +8714,7 @@
         "deps": {
           "common": [
             {
-              "id": "bitcoin 0.32.5",
+              "id": "bitcoin 0.32.99",
               "target": "bitcoin"
             },
             {
@@ -20134,7 +20140,7 @@
               "alias": "bitcoin_0_28"
             },
             {
-              "id": "bitcoin 0.32.5",
+              "id": "bitcoin 0.32.99",
               "target": "bitcoin"
             },
             {
@@ -52717,6 +52723,7 @@
         ],
         "crate_features": {
           "common": [
+            "default",
             "hmac"
           ],
           "selects": {}
@@ -66401,6 +66408,54 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "salsa20 0.10.2": {
+      "name": "salsa20",
+      "version": "0.10.2",
+      "package_url": "https://github.com/RustCrypto/stream-ciphers",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/salsa20/0.10.2/download",
+          "sha256": "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "salsa20",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "salsa20",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cipher 0.4.4",
+              "target": "cipher"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.10.2"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "same-file 1.0.6": {
       "name": "same-file",
       "version": "1.0.6",
@@ -67004,6 +67059,62 @@
         "ISC"
       ],
       "license_file": "LICENSE"
+    },
+    "scrypt 0.11.0": {
+      "name": "scrypt",
+      "version": "0.11.0",
+      "package_url": "https://github.com/RustCrypto/password-hashes/tree/master/scrypt",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/scrypt/0.11.0/download",
+          "sha256": "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "scrypt",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "scrypt",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "pbkdf2 0.12.2",
+              "target": "pbkdf2"
+            },
+            {
+              "id": "salsa20 0.10.2",
+              "target": "salsa20"
+            },
+            {
+              "id": "sha2 0.10.9",
+              "target": "sha2"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.11.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
     },
     "sct 0.7.0": {
       "name": "sct",
@@ -92974,7 +93085,7 @@
     "bip32 0.5.1",
     "bit-vec 0.6.3",
     "bitcoin 0.28.2",
-    "bitcoin 0.32.5",
+    "bitcoin 0.32.99",
     "bitcoincore-rpc 0.19.0",
     "bitcoind 0.32.0",
     "bitflags 1.3.2",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -1405,9 +1405,8 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+version = "0.32.99"
+source = "git+https://github.com/dfinity/rust-dogecoin?rev=f1f900da0b193c43fd16f4598e614ed3eafbfd8f#f1f900da0b193c43fd16f4598e614ed3eafbfd8f"
 dependencies = [
  "base58ck",
  "bech32 0.11.0",
@@ -1417,6 +1416,7 @@ dependencies = [
  "bitcoin_hashes 0.14.0",
  "hex-conservative",
  "hex_lit",
+ "scrypt",
  "secp256k1 0.29.0",
  "serde",
 ]
@@ -1501,7 +1501,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "serde",
  "serde_json",
 ]
@@ -3437,7 +3437,7 @@ dependencies = [
  "bip32 0.5.1",
  "bit-vec 0.6.3",
  "bitcoin 0.28.2",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "bitcoincore-rpc",
  "bitcoind",
  "bitflags 1.3.2",
@@ -11176,6 +11176,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11275,6 +11284,17 @@ dependencies = [
  "selectors",
  "smallvec",
  "tendril",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2 0.12.2",
+ "salsa20",
+ "sha2 0.10.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,9 +1364,8 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+version = "0.32.99"
+source = "git+https://github.com/dfinity/rust-dogecoin?rev=f1f900da0b193c43fd16f4598e614ed3eafbfd8f#f1f900da0b193c43fd16f4598e614ed3eafbfd8f"
 dependencies = [
  "base58ck",
  "bech32 0.11.0",
@@ -1376,6 +1375,7 @@ dependencies = [
  "bitcoin_hashes 0.14.0",
  "hex-conservative",
  "hex_lit",
+ "scrypt",
  "secp256k1 0.29.1",
  "serde",
 ]
@@ -1457,7 +1457,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "serde",
  "serde_json",
 ]
@@ -6309,7 +6309,7 @@ name = "ic-bitcoin-canister-mock"
 version = "0.9.0"
 dependencies = [
  "bech32 0.9.1",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "candid",
  "candid_parser",
  "hex",
@@ -6546,7 +6546,7 @@ dependencies = [
 name = "ic-btc-adapter"
 version = "0.9.0"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "bitcoincore-rpc",
  "bitcoind",
  "clap 4.5.27",
@@ -6614,10 +6614,12 @@ dependencies = [
 name = "ic-btc-adapter-test-utils"
 version = "0.9.0"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "flate2",
  "hex",
+ "ic-btc-adapter",
  "rand 0.8.5",
+ "serde",
  "serde_json",
  "tokio",
 ]
@@ -6628,7 +6630,7 @@ version = "0.9.0"
 dependencies = [
  "askama",
  "base64 0.13.1",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "candid",
  "candid_parser",
  "ciborium",
@@ -6726,7 +6728,7 @@ dependencies = [
 name = "ic-btc-validation"
 version = "0.9.0"
 dependencies = [
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "csv",
  "hex",
  "proptest 0.9.6",
@@ -18655,7 +18657,7 @@ dependencies = [
  "axum-server",
  "backoff",
  "base64 0.13.1",
- "bitcoin 0.32.5",
+ "bitcoin 0.32.99",
  "bitcoincore-rpc",
  "bytes",
  "candid",
@@ -20921,6 +20923,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "salt-sharing-api"
 version = "0.9.0"
 dependencies = [
@@ -21074,6 +21085,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2 0.12.2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21161,7 +21183,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes 0.12.0",
  "rand 0.8.5",
  "secp256k1-sys 0.10.1",
  "serde",
@@ -23644,7 +23666,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -523,7 +523,7 @@ axum-server = { version = "0.7.2", features = ["tls-rustls-no-provider"] }
 backoff = "0.4"
 base64 = { version = "0.13.1" }
 bincode = "1.3.3"
-bitcoin = { version = "0.32.5", features = ["default", "rand", "serde"] }
+bitcoin ={ version = "0.32.99", features = [ "default", "rand", "serde" ]}
 bitcoincore-rpc = "0.19.0"
 # build-info and build-info-build MUST be kept in sync!
 build-info = { git = "https://github.com/dfinity-lab/build-info", rev = "701a696844fba5c87df162fbbc1ccef96f27c9d7" }
@@ -797,3 +797,6 @@ zstd = "0.13.2"
 default-features = false
 features = ["exe"]
 version = "^0.8.1"
+
+[patch.crates-io]
+bitcoin = { git = "https://github.com/dfinity/rust-dogecoin", rev = "f1f900da0b193c43fd16f4598e614ed3eafbfd8f" }

--- a/bazel/cargo.config
+++ b/bazel/cargo.config
@@ -1,1 +1,2 @@
 [patch.crates-io]
+bitcoin = { git = "https://github.com/dfinity/rust-dogecoin", rev = "f1f900da0b193c43fd16f4598e614ed3eafbfd8f" }

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -285,7 +285,7 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.6.3",
             ),
             "bitcoin": crate.spec(
-                version = "^0.32.5",
+                version = "^0.32.99",
                 features = [
                     "default",
                     "rand",

--- a/rs/bitcoin/adapter/BUILD.bazel
+++ b/rs/bitcoin/adapter/BUILD.bazel
@@ -60,7 +60,10 @@ rust_library(
     ),
     crate_name = "ic_btc_adapter",
     proc_macro_deps = MACRO_DEPENDENCIES,
-    visibility = ["//rs/pocket_ic_server:__subpackages__"],
+    visibility = [
+        "//rs/bitcoin/adapter/test_utils:__subpackages__",
+        "//rs/pocket_ic_server:__subpackages__",
+    ],
     deps = DEPENDENCIES,
 )
 

--- a/rs/bitcoin/adapter/benches/e2e.rs
+++ b/rs/bitcoin/adapter/benches/e2e.rs
@@ -1,6 +1,4 @@
-use bitcoin::{
-    block::Header as BlockHeader, blockdata::constants::genesis_block, BlockHash, Network,
-};
+use bitcoin::{block::Header as BlockHeader, BlockHash, Network};
 use criterion::{criterion_group, criterion_main, Criterion};
 use ic_btc_adapter::{start_server, Config, IncomingSource};
 use ic_btc_adapter_client::setup_bitcoin_adapter_clients;
@@ -63,12 +61,12 @@ fn prepare(
 
 fn e2e(criterion: &mut Criterion) {
     let mut config = Config {
-        network: Network::Regtest,
+        network: Network::Regtest.into(),
         ..Default::default()
     };
 
     let mut processed_block_hashes = vec![];
-    let genesis = genesis_block(config.network).header;
+    let genesis = config.network.genesis_block_header();
 
     prepare(&mut processed_block_hashes, genesis, 4, 2000, 1975);
 

--- a/rs/bitcoin/adapter/src/addressbook.rs
+++ b/rs/bitcoin/adapter/src/addressbook.rs
@@ -448,7 +448,7 @@ mod test {
     #[test]
     fn test_discard_address_no_seeds() {
         let config = ConfigBuilder::new()
-            .with_network(Network::Regtest)
+            .with_network(Network::Regtest.into())
             .with_nodes(vec![SocketAddr::from_str("127.0.0.1:8333").unwrap()])
             .build();
         let mut book = AddressBook::new(&config, no_op_logger());
@@ -468,7 +468,7 @@ mod test {
     #[test]
     fn test_pop_seed() {
         let config = ConfigBuilder::new()
-            .with_network(Network::Signet)
+            .with_network(Network::Signet.into())
             .with_dns_seeds(vec![String::from("127.0.0.1"), String::from("192.168.1.1")])
             .build();
         let mut book = AddressBook::new(&config, no_op_logger());
@@ -496,7 +496,7 @@ mod test {
     #[test]
     fn test_seeds_ipv6_only() {
         let config = ConfigBuilder::new()
-            .with_network(Network::Signet)
+            .with_network(Network::Signet.into())
             .with_dns_seeds(vec![
                 String::from("127.0.0.1"),
                 String::from("[2401:3f00:1000:23:5000:7bff:fe3d:b81d]"),

--- a/rs/bitcoin/adapter/src/cli.rs
+++ b/rs/bitcoin/adapter/src/cli.rs
@@ -55,7 +55,6 @@ impl Cli {
 pub mod test {
     use super::*;
     use crate::IncomingSource;
-    use bitcoin::Network;
     use std::io::Write;
     use std::path::PathBuf;
     use std::str::FromStr;
@@ -155,7 +154,7 @@ pub mod test {
         };
         let result = cli.get_config();
         let config = result.unwrap();
-        assert_eq!(config.network, Network::Bitcoin);
+        assert_eq!(config.network, bitcoin::Network::Bitcoin.into());
         assert_eq!(config.address_limits, (500, 2000));
         assert_eq!(config.dns_seeds.len(), 9);
         assert_eq!(config.socks_proxy, None);
@@ -171,7 +170,7 @@ pub mod test {
         };
         let result = cli.get_config();
         let config = result.unwrap();
-        assert_eq!(config.network, Network::Testnet);
+        assert_eq!(config.network, bitcoin::Network::Testnet.into());
         assert_eq!(config.address_limits, (100, 1000));
         assert_eq!(config.dns_seeds.len(), 4);
         assert_eq!(config.socks_proxy, None);

--- a/rs/bitcoin/adapter/src/common.rs
+++ b/rs/bitcoin/adapter/src/common.rs
@@ -1,3 +1,8 @@
+use bitcoin::consensus::{Decodable, Encodable};
+use bitcoin::p2p::Magic;
+use ic_btc_validation::{HeaderStore, ValidateHeaderError};
+use serde::{Deserialize, Serialize};
+
 /// This const represents the default version that the adapter will support.
 /// This value will be used to filter out Bitcoin nodes that the adapter deems
 /// to far behind to interact with.
@@ -15,6 +20,133 @@ pub const DEFAULT_CHANNEL_BUFFER_SIZE: usize = 64;
 
 /// This field contains the datatype used to store height of a Bitcoin block
 pub type BlockHeight = u32;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[allow(missing_docs)]
+pub enum Network {
+    Bitcoin(bitcoin::Network),
+    Dogecoin(bitcoin::dogecoin::Network),
+}
+
+impl From<bitcoin::Network> for Network {
+    fn from(network: bitcoin::Network) -> Self {
+        Self::Bitcoin(network)
+    }
+}
+
+impl From<bitcoin::dogecoin::Network> for Network {
+    fn from(network: bitcoin::dogecoin::Network) -> Self {
+        Self::Dogecoin(network)
+    }
+}
+
+#[allow(missing_docs)]
+impl Network {
+    pub fn name(&self) -> String {
+        match self {
+            Network::Bitcoin(bitcoin::Network::Bitcoin) => "bitcoin".to_string(),
+            Network::Bitcoin(network) => format!("bitcoin::{network}"),
+            Network::Dogecoin(bitcoin::dogecoin::Network::Dogecoin) => "dogecoin".to_string(),
+            Network::Dogecoin(network) => format!("bitcoin::{network}"),
+        }
+    }
+    pub fn magic(&self) -> Magic {
+        match self {
+            Network::Bitcoin(network) => network.magic(),
+            Network::Dogecoin(network) => network.magic(),
+        }
+    }
+    pub fn genesis_block_header(&self) -> bitcoin::block::Header {
+        match self {
+            Network::Bitcoin(network) => {
+                bitcoin::blockdata::constants::genesis_block(network).header
+            }
+            Network::Dogecoin(network) => {
+                bitcoin::dogecoin::constants::genesis_block(network).header
+            }
+        }
+    }
+    pub fn validate_header(
+        &self,
+        store: &impl HeaderStore,
+        header: &bitcoin::block::Header,
+    ) -> Result<(), ValidateHeaderError> {
+        match self {
+            Network::Bitcoin(network) => ic_btc_validation::validate_header(network, store, header),
+            Network::Dogecoin(_network) => {
+                unimplemented!()
+            }
+        }
+    }
+}
+
+impl Serialize for Network {
+    fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.name())
+    }
+}
+
+impl<'de> Deserialize<'de> for Network {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use std::str::FromStr;
+        let s = String::deserialize(deserializer)?;
+        // In deserialization, we give priority to bitcoin network names.
+        // So both "testnet" and "bitcoin:testnet" will be parsed as bitcoin::Network::Testnet.
+        if let Ok(network) = bitcoin::Network::from_str(&s) {
+            return Ok(network.into());
+        } else if s == "dogecoin" {
+            return Ok(bitcoin::dogecoin::Network::Dogecoin.into());
+        } else if let Some(s) = s.strip_prefix("dogecoin:") {
+            if let Ok(network) = bitcoin::dogecoin::Network::from_str(s) {
+                return Ok(network.into());
+            }
+        } else if let Some(s) = s.strip_prefix("bitcoin:") {
+            if let Ok(network) = bitcoin::dogecoin::Network::from_str(s) {
+                return Ok(network.into());
+            }
+        }
+        Err(serde::de::Error::custom(format!("unknown network {s}")))
+    }
+}
+
+/// A trait that contains the common methods of both Bitcoin and Dogecoin blocks.
+#[allow(missing_docs)]
+pub trait BlockLike: Decodable + Encodable + Clone {
+    fn block_hash(&self) -> bitcoin::BlockHash;
+    fn compute_merkle_root(&self) -> Option<bitcoin::TxMerkleNode>;
+    fn check_merkle_root(&self) -> bool;
+    fn header(&self) -> bitcoin::block::Header;
+}
+
+impl BlockLike for bitcoin::Block {
+    fn block_hash(&self) -> bitcoin::BlockHash {
+        bitcoin::Block::block_hash(self)
+    }
+    fn compute_merkle_root(&self) -> Option<bitcoin::TxMerkleNode> {
+        bitcoin::Block::compute_merkle_root(self)
+    }
+    fn check_merkle_root(&self) -> bool {
+        bitcoin::Block::check_merkle_root(self)
+    }
+    fn header(&self) -> bitcoin::block::Header {
+        self.header
+    }
+}
+
+impl BlockLike for bitcoin::dogecoin::Block {
+    fn block_hash(&self) -> bitcoin::BlockHash {
+        bitcoin::dogecoin::Block::block_hash(self)
+    }
+    fn compute_merkle_root(&self) -> Option<bitcoin::TxMerkleNode> {
+        bitcoin::dogecoin::Block::compute_merkle_root(self)
+    }
+    fn check_merkle_root(&self) -> bool {
+        bitcoin::dogecoin::Block::check_merkle_root(self)
+    }
+    fn header(&self) -> bitcoin::block::Header {
+        self.header
+    }
+}
 
 #[cfg(test)]
 pub mod test_common {
@@ -36,16 +168,16 @@ pub mod test_common {
     pub const BLOCK_2_ENCODED: &str = "010000004860eb18bf1b1620e37e9490fc8a427514416fd75159ab86688e9a8300000000d5fdcc541e25de1c7a5addedf24858b8bb665c9f36ef744ee42c316022c90f9bb0bc6649ffff001d08d2bd610101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d010bffffffff0100f2052a010000004341047211a824f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073dee6c89064984f03385237d92167c13e236446b417ab79a0fcae412ae3316b77ac00000000";
 
     /// This struct is used to capture Commands generated by managers.
-    pub struct TestChannel {
+    pub struct TestChannel<Network> {
         /// This field holds Commands that are generated by managers.
-        received_commands: VecDeque<Command>,
+        received_commands: VecDeque<Command<Network>>,
         /// The connections available for the test to interact with.
         available_connections: Vec<SocketAddr>,
         /// The addresses that disconnect was called on.
         disconnected_addresses: HashSet<SocketAddr>,
     }
 
-    impl TestChannel {
+    impl<Network> TestChannel<Network> {
         pub fn new(available_connections: Vec<SocketAddr>) -> Self {
             Self {
                 received_commands: VecDeque::new(),
@@ -55,16 +187,16 @@ pub mod test_common {
         }
     }
 
-    impl TestChannel {
+    impl<Network> TestChannel<Network> {
         pub fn command_count(&self) -> usize {
             self.received_commands.len()
         }
 
-        pub fn pop_front(&mut self) -> Option<Command> {
+        pub fn pop_front(&mut self) -> Option<Command<Network>> {
             self.received_commands.pop_front()
         }
 
-        pub fn pop_back(&mut self) -> Option<Command> {
+        pub fn pop_back(&mut self) -> Option<Command<Network>> {
             self.received_commands.pop_back()
         }
 
@@ -76,8 +208,8 @@ pub mod test_common {
         }
     }
 
-    impl Channel for TestChannel {
-        fn send(&mut self, command: Command) -> Result<(), ChannelError> {
+    impl<Network> Channel<Network> for TestChannel<Network> {
+        fn send(&mut self, command: Command<Network>) -> Result<(), ChannelError> {
             self.received_commands.push_back(command);
             Ok(())
         }

--- a/rs/bitcoin/adapter/src/lib.rs
+++ b/rs/bitcoin/adapter/src/lib.rs
@@ -51,6 +51,7 @@ mod transaction_store;
 // malicious fork can be prioritized by a DFS, thus potentially ignoring honest forks).
 mod get_successors_handler;
 
+pub use common::{BlockLike, Network};
 pub use config::{address_limits, Config, IncomingSource};
 
 use crate::{
@@ -61,12 +62,12 @@ use crate::{
 /// This struct is used to represent commands given to the adapter in order to interact
 /// with BTC nodes.
 #[derive(Clone, Eq, PartialEq, Debug)]
-struct Command {
+struct Command<Block> {
     /// This is the address of the Bitcoin node to which the message is supposed to be sent.
     /// If the address is None, then the message will be sent to all the peers.
     address: Option<SocketAddr>,
     /// This the network message to be sent to the above peer.
-    message: NetworkMessage,
+    message: NetworkMessage<Block>,
 }
 
 /// This enum is used to represent errors that could occur while dispatching an
@@ -83,10 +84,10 @@ enum ProcessBitcoinNetworkMessageError {
 enum ChannelError {}
 
 /// This trait is to provide an interface so that managers can communicate to BTC nodes.
-trait Channel {
+trait Channel<Block> {
     /// This method is used to send a message to a specific connection
     /// or to all connections based on the [Command](Command)'s fields.
-    fn send(&mut self, command: Command) -> Result<(), ChannelError>;
+    fn send(&mut self, command: Command<Block>) -> Result<(), ChannelError>;
 
     /// This method is used to retrieve a list of available connections
     /// that have completed the version handshake.
@@ -110,13 +111,13 @@ trait ProcessEvent {
 /// This trait provides an interface for processing messages coming from
 /// bitcoin peers.
 /// [StreamEvent](crate::stream::StreamEvent).
-trait ProcessBitcoinNetworkMessage {
+trait ProcessBitcoinNetworkMessage<Block> {
     /// This method is used to route an event in a component's internals and
     /// perform state updates.
     fn process_bitcoin_network_message(
         &mut self,
         addr: SocketAddr,
-        message: &NetworkMessage,
+        message: &NetworkMessage<Block>,
     ) -> Result<(), ProcessBitcoinNetworkMessageError>;
 }
 
@@ -222,13 +223,24 @@ pub fn start_server(
         metrics_registry,
     );
 
-    start_main_event_loop(
-        &config,
-        log.clone(),
-        blockchain_state,
-        transaction_manager_rx,
-        adapter_state,
-        blockchain_manager_rx,
-        metrics_registry,
-    );
+    match config.network {
+        common::Network::Bitcoin(_) => start_main_event_loop::<bitcoin::Block>(
+            &config,
+            log.clone(),
+            blockchain_state,
+            transaction_manager_rx,
+            adapter_state,
+            blockchain_manager_rx,
+            metrics_registry,
+        ),
+        common::Network::Dogecoin(_) => start_main_event_loop::<bitcoin::dogecoin::Block>(
+            &config,
+            log.clone(),
+            blockchain_state,
+            transaction_manager_rx,
+            adapter_state,
+            blockchain_manager_rx,
+            metrics_registry,
+        ),
+    }
 }

--- a/rs/bitcoin/adapter/src/stream.rs
+++ b/rs/bitcoin/adapter/src/stream.rs
@@ -1,6 +1,6 @@
 use bitcoin::io as bitcoin_io;
 use bitcoin::{
-    consensus::serialize,
+    consensus::{serialize, Decodable, Encodable},
     p2p::message::RawNetworkMessage,
     p2p::Magic,
     {consensus::encode, p2p::message::NetworkMessage},
@@ -64,7 +64,7 @@ pub enum StreamError {
 pub type StreamResult<T> = Result<T, StreamError>;
 
 /// This struct represents the configuration options for a Stream struct.
-pub struct StreamConfig {
+pub struct StreamConfig<Block> {
     /// This field represents the target address that the stream will connect to.
     pub address: SocketAddr,
     /// This field is used to provide an instance of the logger.
@@ -74,13 +74,13 @@ pub struct StreamConfig {
     pub magic: Magic,
     /// This field is used to receive network messages to send out to the connected
     /// BTC node.
-    pub network_message_receiver: UnboundedReceiver<NetworkMessage>,
+    pub network_message_receiver: UnboundedReceiver<NetworkMessage<Block>>,
     /// This field represents the address that the stream may use to proxy
     /// requests to the address field.
     pub socks_proxy: Option<String>,
     /// This field is used to send events from the stream back to the network and connection structs.
     pub stream_event_sender: Sender<StreamEvent>,
-    pub network_message_sender: Sender<(SocketAddr, NetworkMessage)>,
+    pub network_message_sender: Sender<(SocketAddr, NetworkMessage<Block>)>,
 }
 
 /// This struct is used to represent an event that has occurred within the Stream
@@ -109,7 +109,7 @@ pub enum StreamEventKind {
 /// This struct is used to provide an interface with the raw socket that will
 /// be connecting to the BTC node.
 #[derive(Debug)]
-pub struct Stream {
+pub struct Stream<Block> {
     /// This field is used to identity the node that the stream is connected to.
     address: SocketAddr,
     /// This field is used as the buffer for reading messages.
@@ -122,16 +122,19 @@ pub struct Stream {
     magic: Magic,
     /// This field contains the receiver used to intake messages that are to be
     /// sent to the connected node.
-    network_message_receiver: UnboundedReceiver<NetworkMessage>,
-    network_message_sender: Sender<(SocketAddr, NetworkMessage)>,
+    network_message_receiver: UnboundedReceiver<NetworkMessage<Block>>,
+    network_message_sender: Sender<(SocketAddr, NetworkMessage<Block>)>,
     /// This field is used as a buffer to contain unparsed message parts.
     unparsed: Vec<u8>,
 }
 
-impl Stream {
+impl<Block: Decodable + Encodable + Clone> Stream<Block> {
     /// Creates new SOCKS client. In case of missing proxy address we fall back to the direct TCP
     /// stream.
-    pub async fn connect(config: StreamConfig, logger: &ReplicaLogger) -> StreamResult<Stream> {
+    pub async fn connect(
+        config: StreamConfig<Block>,
+        logger: &ReplicaLogger,
+    ) -> StreamResult<Stream<Block>> {
         let StreamConfig {
             address,
             socks_proxy,
@@ -212,7 +215,7 @@ impl Stream {
     }
 
     /// This function reads a message from the inner TcpStream.
-    pub fn read_message(&mut self) -> StreamResult<RawNetworkMessage> {
+    pub fn read_message(&mut self) -> StreamResult<RawNetworkMessage<Block>> {
         loop {
             // This means that in the previous iteration we failed to decode a `RawNetworkMessage`
             // and it was larger than `MAX_RAW_MESSAGE_SIZE`. In that case we return an error and
@@ -222,7 +225,7 @@ impl Stream {
             }
             // The stream may only a message partial from the Bitcoin node.
             // Due to this, the stream must attempt to deserialize partial messages.
-            match encode::deserialize_partial::<RawNetworkMessage>(&self.unparsed) {
+            match encode::deserialize_partial::<RawNetworkMessage<Block>>(&self.unparsed) {
                 // If there was an I/O error found in the unparsed message and it was an unexpected
                 // end-of-file, then the stream should try to read again. If the read fails, the stream
                 // exits the read message with the error. The stream later looks at this error, if the
@@ -268,7 +271,7 @@ impl Stream {
 
     /// This function is used to write a network message to the connected Bitcoin
     /// node.
-    async fn write_message(&mut self, network_message: NetworkMessage) -> StreamResult<()> {
+    async fn write_message(&mut self, network_message: NetworkMessage<Block>) -> StreamResult<()> {
         let raw_network_message = RawNetworkMessage::new(self.magic, network_message);
         let bytes = serialize(&raw_network_message);
         self.write_half
@@ -303,7 +306,9 @@ impl Stream {
 
 /// This function is used to kick off a new stream that will be connected to a
 /// the Network struct and related connection struct via a set of channels.
-pub fn handle_stream(config: StreamConfig) -> tokio::task::JoinHandle<()> {
+pub fn handle_stream<Block: Encodable + Decodable + Send + Clone + 'static>(
+    config: StreamConfig<Block>,
+) -> tokio::task::JoinHandle<()> {
     tokio::task::spawn(async move {
         let address = config.address;
         let logger = config.logger.clone();
@@ -377,6 +382,9 @@ pub mod test {
     use super::*;
     use bitcoin::{consensus::Encodable, Network};
     use ic_logger::replica_logger::no_op_logger;
+
+    type StreamConfig = super::StreamConfig<bitcoin::Block>;
+    type NetworkMessage = super::NetworkMessage<bitcoin::Block>;
 
     /// Test that large messages get rejected and we disconnect as a consequence.
     #[allow(clippy::disallowed_methods)]

--- a/rs/bitcoin/adapter/src/transaction_store.rs
+++ b/rs/bitcoin/adapter/src/transaction_store.rs
@@ -125,7 +125,7 @@ impl TransactionStore {
     /// This method is used to broadcast known transaction IDs to connected peers.
     /// If the timeout period has passed for a transaction ID, it is broadcasted again.
     /// If the transaction has not been broadcasted, the transaction ID is broadcasted.
-    pub fn advertise_txids(&mut self, channel: &mut impl Channel) {
+    pub fn advertise_txids<Block>(&mut self, channel: &mut impl Channel<Block>) {
         self.remove_old_txns();
         for address in channel.available_connections() {
             let mut inventory = vec![];
@@ -170,11 +170,11 @@ impl TransactionStore {
     /// This function processes a `getdata` message from a BTC node.
     /// If there are messages for transactions, the transaction is sent to the
     /// requesting node. Transactions sent are then removed from the cache.
-    pub fn process_bitcoin_network_message(
+    pub fn process_bitcoin_network_message<Block>(
         &self,
-        channel: &mut impl Channel,
+        channel: &mut impl Channel<Block>,
         addr: SocketAddr,
-        message: &NetworkMessage,
+        message: &NetworkMessage<Block>,
     ) -> Result<(), ProcessBitcoinNetworkMessageError> {
         if let NetworkMessage::GetData(inventory) = message {
             if inventory.len() > MAXIMUM_TRANSACTION_PER_INV {
@@ -201,15 +201,16 @@ impl TransactionStore {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::common::test_common::TestChannel;
     use bitcoin::{
         absolute::{LockTime, LOCK_TIME_THRESHOLD},
         blockdata::constants::genesis_block,
         consensus::serialize,
-        Network, Transaction,
+        Block, Network, Transaction,
     };
     use ic_logger::replica_logger::no_op_logger;
     use std::str::FromStr;
+
+    type TestChannel = crate::common::test_common::TestChannel<Block>;
 
     /// This function creates a new transaction manager with a test logger.
     fn make_transaction_manager() -> TransactionStore {

--- a/rs/bitcoin/adapter/test_utils/BUILD.bazel
+++ b/rs/bitcoin/adapter/test_utils/BUILD.bazel
@@ -4,10 +4,12 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
+    "//rs/bitcoin/adapter",
     "@crate_index//:bitcoin",
     "@crate_index//:flate2",
     "@crate_index//:hex",
     "@crate_index//:rand",
+    "@crate_index//:serde",
     "@crate_index//:serde_json",
     "@crate_index//:tokio",
 ]

--- a/rs/bitcoin/adapter/test_utils/Cargo.toml
+++ b/rs/bitcoin/adapter/test_utils/Cargo.toml
@@ -7,9 +7,11 @@ description.workspace = true
 documentation.workspace = true
 
 [dependencies]
+ic-btc-adapter = { path = ".." }
 bitcoin = { workspace = true }
 flate2 = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/rs/bitcoin/adapter/tests/adapter_test.rs
+++ b/rs/bitcoin/adapter/tests/adapter_test.rs
@@ -97,7 +97,7 @@ fn start_adapter(
     network: bitcoin::Network,
 ) {
     let config = Config {
-        network,
+        network: network.into(),
         incoming_source: IncomingSource::Path(uds_path.to_path_buf()),
         nodes,
         ipv6_only: true,
@@ -1002,7 +1002,7 @@ fn test_mainnet_data() {
         .unwrap();
 
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let bitcoind_addr = ic_btc_adapter_test_utils::bitcoind::mock_bitcoin(
+    let bitcoind_addr = ic_btc_adapter_test_utils::bitcoind::mock_bitcoin::<bitcoin::Block>(
         rt.handle(),
         headers_data_path,
         blocks_data_path,
@@ -1041,7 +1041,7 @@ fn test_testnet_data() {
         .unwrap();
 
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let bitcoind_addr = ic_btc_adapter_test_utils::bitcoind::mock_bitcoin(
+    let bitcoind_addr = ic_btc_adapter_test_utils::bitcoind::mock_bitcoin::<bitcoin::Block>(
         rt.handle(),
         headers_data_path,
         blocks_data_path,

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -254,7 +254,7 @@ impl BitcoinAdapterParts {
         runtime: Arc<Runtime>,
     ) -> Self {
         let bitcoin_adapter_config = BitcoinAdapterConfig {
-            network: Network::Regtest,
+            network: Network::Regtest.into(),
             nodes: bitcoind_addr,
             socks_proxy: None,
             ipv6_only: false,


### PR DESCRIPTION
This is a first step towards a supporting dogecoin in ic-btc-adapter. Notable changes are:

1. Point rust bitcoin version to https://github.com/dfinity/rust-dogecoin, which supports both bitcoin and dogecoin. At the moment this is branched off the same 0.35.5 version used by ic-btc-canister, so there shouldn't be any breakage.
2. Because in this version `NetworkMessage` is parameterized by block type, the implementation of ic-btc-adapter has to be adapted to this change.
3. A new `Network` type is introduced in ic-btc-adapter to support both bitcoin and dogecoin network types. 
4. Address the difference between bitcoin and dogecoin in some parameters used by ic-btc-adapter.
5. Existing tests for ic-btc-adapter still only test bitcoin, and dogecoin related tests will be added in a separate PR.
