### PR TITLE
chore: EXC: Make benchmarks scripts run in dev container

### DIFF
--- a/rs/execution_environment/benches/run-benchmark.sh
+++ b/rs/execution_environment/benches/run-benchmark.sh
@@ -8,7 +8,7 @@ set -ue
 ## some benchmarks.
 ##
 
-DEPENDENCIES="awk bash bazel rg sed tail tee"
+DEPENDENCIES="awk bash bazel egrep sed tail tee"
 which ${DEPENDENCIES} >/dev/null || (echo "Error checking dependencies: ${DEPENDENCIES}" >&2 && exit 1)
 
 printf "    %-12s := %s\n" \
@@ -25,10 +25,10 @@ TMP_FILE="${TMP_FILE:-${MIN_FILE%.*}.tmp}"
 # Run the benchmark and capture its output in the `LOG_FILE`.
 bash -c "set -o pipefail; \
     ${CMD} \
-        2>&1 | tee '${LOG_FILE}' | rg '^(test .* )?bench:' --line-buffered \
-        | awk '{
-                match(\$0, /^test (.+) ... bench: +([0-9]+) ns\/iter.*/, r)
-                printf \"> %s %.2f ms\n\", r[1], r[2] / 1000 / 1000; fflush();
+        2>&1 | tee '${LOG_FILE}' | egrep '^(test .* )?bench:' --line-buffered \
+        | awk -W interactive '{
+                split(\$0, r, /^test | ... bench: +| ns\/iter.*/)
+                printf \"> %s %.2f ms\n\", r[2], r[3] / 1000 / 1000; fflush();
             }'
         " \
     || (
@@ -40,18 +40,18 @@ bash -c "set -o pipefail; \
 
 if ! [ -s "${MIN_FILE}" ]; then
     echo "    Storing results in ${MIN_FILE}" >&2
-    cat "${LOG_FILE}" | rg "^test .* bench:" >"${MIN_FILE}" \
+    cat "${LOG_FILE}" | egrep "^test .* bench:" >"${MIN_FILE}" \
         || echo "    No results found in ${LOG_FILE}" >&2
 else
     echo "    Merging ${LOG_FILE} into ${MIN_FILE}" >&2
     rm -f "${TMP_FILE}"
-    cat "${LOG_FILE}" | rg "^test .* bench:" | while read new_bench; do
+    cat "${LOG_FILE}" | egrep "^test .* bench:" | while read new_bench; do
         name="${new_bench#test }"
         name="${name% ... bench:*}"
         new_result_ns="${new_bench#* ... bench: }"
         new_result_ns="${new_result_ns% ns/iter*}"
 
-        min_bench=$(rg -F "test ${name} ... bench:" "${MIN_FILE}" || true)
+        min_bench=$(egrep -F "test ${name} ... bench:" "${MIN_FILE}" || true)
         min_result_ns="${min_bench#* ... bench: }"
         min_result_ns="${min_result_ns% ns/iter*}"
 

--- a/rs/execution_environment/benches/summarize-results.sh
+++ b/rs/execution_environment/benches/summarize-results.sh
@@ -8,7 +8,7 @@ set -ue
 ## some benchmarks.
 ##
 
-DEPENDENCIES="awk rg sed"
+DEPENDENCIES="awk egrep sed"
 which ${DEPENDENCIES} >/dev/null || (echo "Error checking dependencies: ${DEPENDENCIES}" >&2 && exit 1)
 
 NOISE_THRESHOLD_PCT="${NOISE_THRESHOLD_PCT:-2}"
@@ -66,7 +66,7 @@ while read min_bench; do
     new_result_ns="${new_result_ns% ns/iter*}"
     total_ns=$((total_ns + new_result_ns))
 
-    baseline_bench=$(rg -F "test ${name} ... bench:" "${BASELINE_FILE}" || true)
+    baseline_bench=$(egrep -F "test ${name} ... bench:" "${BASELINE_FILE}" || true)
     baseline_result_ns="${baseline_bench#* ... bench: }"
     baseline_result_ns="${baseline_result_ns% ns/iter*}"
 
@@ -96,20 +96,20 @@ esac
 
 # Always produce top regressed/improved details.
 echo "  Top ${TOP_N} by time:"
-cat "${TMP_FILE}" | sort -rn | rg '^[1-9]' | head -${TOP_N} \
+cat "${TMP_FILE}" | sort -rn | egrep '^[1-9]' | head -${TOP_N} \
     | while read diff_ms diff_pct baseline_ms new_ms name; do
         echo "  + ${name} time regressed by ${diff_ms} ms (${baseline_ms} -> ${new_ms} ms)"
     done
-cat "${TMP_FILE}" | sort -n | rg '^-' | head -${TOP_N} \
+cat "${TMP_FILE}" | sort -n | egrep '^-' | head -${TOP_N} \
     | while read diff_ms diff_pct baseline_ms new_ms name; do
         echo "  - ${name} time improved by ${diff_ms} ms (${baseline_ms} -> ${new_ms} ms)"
     done
 echo "  Top ${TOP_N} by percentage:"
-cat "${TMP_FILE}" | sort -rnk 2 | rg '^[1-9]' | head -${TOP_N} \
+cat "${TMP_FILE}" | sort -rnk 2 | egrep '^[1-9]' | head -${TOP_N} \
     | while read diff_ms diff_pct baseline_ms new_ms name; do
         echo "  + ${name} time regressed by ${diff_pct}% (${baseline_ms} -> ${new_ms} ms)"
     done
-cat "${TMP_FILE}" | sort -nk 2 | rg '^-' | head -${TOP_N} \
+cat "${TMP_FILE}" | sort -nk 2 | egrep '^-' | head -${TOP_N} \
     | while read diff_ms diff_pct baseline_ms new_ms name; do
         echo "  - ${name} time improved by ${diff_pct}% (${baseline_ms} -> ${new_ms} ms)"
     done


### PR DESCRIPTION
This PR changes the benchmarks scripts so they use `mawk` syntax and `egrep` tool.