### PR TITLE
chore(icrc-ledger-types): FI-1790: Remove unused dependencies from icrc-ledger-client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,7 @@ go_deps.bzl               @dfinity/idx
 /packages/canlog_derive/                @dfinity/cross-chain-team
 /packages/icrc-cbor/                    @dfinity/finint @dfinity/cross-chain-team
 /packages/icrc-ledger-agent/            @dfinity/finint
+/packages/icrc-ledger-client/           @dfinity/finint
 /packages/icrc-ledger-types/            @dfinity/finint
 /packages/ic-ledger-hash-of/            @dfinity/finint
 /packages/pocket-ic/                    @dfinity/pocket-ic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15207,9 +15207,7 @@ version = "0.1.2"
 dependencies = [
  "async-trait",
  "candid",
- "ic-cdk 0.17.2",
  "icrc-ledger-types",
- "serde",
 ]
 
 [[package]]

--- a/packages/icrc-ledger-client/BUILD.bazel
+++ b/packages/icrc-ledger-client/BUILD.bazel
@@ -15,7 +15,5 @@ rust_library(
         # Keep sorted.
         "//packages/icrc-ledger-types:icrc_ledger_types",
         "@crate_index//:candid",
-        "@crate_index//:ic-cdk",
-        "@crate_index//:serde",
     ],
 )

--- a/packages/icrc-ledger-client/Cargo.toml
+++ b/packages/icrc-ledger-client/Cargo.toml
@@ -16,5 +16,3 @@ documentation.workspace = true
 async-trait = { workspace = true }
 candid = { workspace = true }
 icrc-ledger-types = { path = "../icrc-ledger-types", version = "0.1.2" }
-serde = { workspace = true }
-ic-cdk = { workspace = true }


### PR DESCRIPTION
Remove the unused dependencies from the `icrc-ledger-client` crate. In particular, the unused `ic-cdk` dependency is troublesome, since it prevents users from upgrading: https://forum.dfinity.org/t/ic-cdk-v0-18-2-release-important-update-on-version-compatibility/47963

Also set the FI team as the owner of the `icrc-ledger-client`.