### PR TITLE
chore: bump guest vm runner test timeout

### DIFF
--- a/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
+++ b/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
@@ -78,6 +78,9 @@ rust_test(
 
 rust_test(
     name = "guest_vm_runner_integration_tests",
+    # the test sometimes times out on CI with default timeout
+    # of "moderate" (5 minutes) - 2025-07-04
+    timeout = "long",
     crate = ":guest_vm_runner_dev",
     crate_features = [
         "dev",


### PR DESCRIPTION
The test recently timed out on master:
https://github.com/dfinity/ic/actions/runs/16055897338

Until the test can be sped up or debugged, we bump the timeout from 5mn to 15mn.