### PR TITLE
chore(boundary): increase polling timeout in `acme` challenge

### DIFF
--- a/rs/boundary_node/certificate_issuance/certificate_issuer/src/acme.rs
+++ b/rs/boundary_node/certificate_issuance/certificate_issuer/src/acme.rs
@@ -1,7 +1,4 @@
-use std::{
-    cmp::min,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Error};
 use async_trait::async_trait;


### PR DESCRIPTION
- Implement exponential backoff for polling, doubling the interval up to `max_poll_interval=10s`
- Increase poll timeout to `500s`, which is below canister's job `retry_delay=600s`