### PR TITLE
chore: bump governance integration test timeout

### DIFF
--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -363,6 +363,9 @@ filegroup(
 
 rust_test_suite_with_extra_srcs(
     name = "governance_integration_test",
+    # the test sometimes times out on CI with default timeout
+    # of "moderate" (5 minutes) - 2025-07-04
+    timeout = "long",
     srcs = glob(
         ["tests/*.rs"],
         exclude = [


### PR DESCRIPTION
The test recently timed out on master.

Until the test can be sped up or debugged, we bump the timeout from 5mn to 15mn.