### PR TITLE
chore(icrc-ledger-client): FI-1790: Bump icrc-ledger-client version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15203,7 +15203,7 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "candid",

--- a/packages/icrc-ledger-client/CHANGELOG.md
+++ b/packages/icrc-ledger-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3
+
+- Remove unused dependencies.
+
 ## 0.1.2
 
 - Initial version of the ICRC Client library.

--- a/packages/icrc-ledger-client/Cargo.toml
+++ b/packages/icrc-ledger-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc-ledger-client"
-version = "0.1.2"
+version = "0.1.3"
 description = "ICRC-1 compliant client library."
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Bump the `icrc-ledger-client` version to `0.1.3`.