### PR TITLE
fix: orchestrator uses correct IC root key in testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17981,6 +17981,7 @@ dependencies = [
  "ic-crypto-test-utils-reproducible-rng",
  "ic-crypto-test-utils-tls",
  "ic-crypto-tls-interfaces",
+ "ic-crypto-utils-threshold-sig-der",
  "ic-dashboard",
  "ic-ed25519",
  "ic-http-endpoints-async-utils",

--- a/rs/orchestrator/BUILD.bazel
+++ b/rs/orchestrator/BUILD.bazel
@@ -25,6 +25,7 @@ rust_library(
         "//rs/crypto",
         "//rs/crypto/node_key_generation",
         "//rs/crypto/tls_interfaces",
+        "//rs/crypto/utils/threshold_sig_der",
         "//rs/http_endpoints/async_utils",
         "//rs/http_endpoints/metrics",
         "//rs/http_utils",

--- a/rs/orchestrator/Cargo.toml
+++ b/rs/orchestrator/Cargo.toml
@@ -26,6 +26,7 @@ ic-consensus-dkg = { path = "../consensus/dkg" }
 ic-crypto = { path = "../crypto" }
 ic-crypto-node-key-generation = { path = "../crypto/node_key_generation" }
 ic-crypto-tls-interfaces = { path = "../crypto/tls_interfaces" }
+ic-crypto-utils-threshold-sig-der = { path = "../crypto/utils/threshold_sig_der" }
 ic-dashboard = { path = "./dashboard" }
 ic-ed25519 = { path = "../../packages/ic-ed25519" }
 ic-http-endpoints-async-utils = { path = "../http_endpoints/async_utils" }

--- a/rs/orchestrator/src/registration.rs
+++ b/rs/orchestrator/src/registration.rs
@@ -150,11 +150,21 @@ impl NodeRegistration {
                     let nns_url = self
                         .get_random_nns_url_from_config()
                         .expect("no NNS urls available");
-                    let agent = Agent::builder()
+                    let agent = match Agent::builder()
                         .with_url(nns_url)
                         .with_identity(signer)
                         .build()
-                        .expect("Failed to create IC agent");
+                    {
+                        Ok(agent) => agent,
+                        Err(e) => {
+                            warn!(self.log, "Failed to create IC agent: {}", e);
+                            UtilityCommand::notify_host(
+                                format!("Failed to create IC agent: {}", e).as_str(),
+                                1,
+                            );
+                            continue;
+                        }
+                    };
                     let add_node_encoded = Encode!(&add_node_payload)
                         .expect("Could not encode payload for the registration request");
 


### PR DESCRIPTION
The orchestrator uses `ic-agent` since #5686. By default, the agent uses the mainnet's root key to verify responses. This means that the orchestrator could not verify responses in testnet. All tests still pass because the requests actually go through, just that the orchestrator cannot verify the responses.

This PR fixes this by fetching the current root key from the registry and set it in the client. It also removes an avoidable panic.