### PR TITLE
test: Extend `create_subnet_test` to create multiple subnets at the same time

### DIFF
--- a/rs/tests/driver/src/nns.rs
+++ b/rs/tests/driver/src/nns.rs
@@ -399,10 +399,7 @@ pub async fn vote_execute_proposal_assert_failed(
     );
 }
 
-pub async fn vote_and_execute_proposal(
-    governance_canister: &Canister<'_>,
-    proposal_id: ProposalId,
-) -> ProposalInfo {
+pub async fn vote_on_proposal(governance_canister: &Canister<'_>, proposal_id: ProposalId) {
     // Cast votes.
     let input = ManageNeuron {
         neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
@@ -425,6 +422,14 @@ pub async fn vote_and_execute_proposal(
         )
         .await
         .expect("Vote failed");
+}
+
+pub async fn vote_and_execute_proposal(
+    governance_canister: &Canister<'_>,
+    proposal_id: ProposalId,
+) -> ProposalInfo {
+    // Cast votes.
+    vote_on_proposal(governance_canister, proposal_id).await;
     wait_for_final_state(governance_canister, proposal_id).await
 }
 

--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -44,6 +44,8 @@ system_test(
     runtime_deps = GUESTOS_RUNTIME_DEPS + NNS_CANISTER_RUNTIME_DEPS + UNIVERSAL_CANISTER_RUNTIME_DEPS,
     deps = [
         # Keep sorted.
+        "//rs/nns/governance/api",
+        "//rs/nns/test_utils",
         "//rs/registry/nns_data_provider",
         "//rs/registry/subnet_type",
         "//rs/tests/driver:ic-system-test-driver",

--- a/rs/tests/nns/create_subnet_pre_master_test.rs
+++ b/rs/tests/nns/create_subnet_pre_master_test.rs
@@ -1,25 +1,26 @@
 /* tag::catalog[]
 Title:: Create Subnet
 
-Goal:: Ensure that a subnet can be created from unassigned nodes
+Goal:: Ensure that subnets can be created from unassigned nodes
 
 Runbook::
-. set up the NNS subnet and check that we have unassigned nodes
-. submit a proposal for creating a subnet based on those unassigned nodes
-. validate proposal execution by checking if the new subnet has been registered as expected
-. validate that the new subnet is operational by installing and querying a universal canister
+. set up the NNS subnet and unassigned nodes
+. submit and adopt multiple proposals for creating subnets at the same time
+. validate proposal execution by checking if the new subnets have been registered as expected
+. validate that all subnets are operational by installing and querying a universal canister
 
 Success::
 . subnet creation proposal is adopted and executed
-. registry subnet list equals OldSubnetIDs ∪ { new_subnet_id }
-. newly created subnet endpoint comes to life within 2 minutes
-. universal canister can be installed onto the new subnet
-. universal canister is responsive
+. registry subnet list equals OldSubnetIDs ∪ NewSubnetIDs
+. newly created subnet endpoints come to life within 2 minutes
+. universal canisters can be installed onto all subnets
+. universal canisters are responsive
 
 end::catalog[] */
 
 use anyhow::Result;
-use ic_base_types::{NodeId, SubnetId};
+use ic_nns_governance_api::ProposalStatus;
+use ic_nns_test_utils::governance::wait_for_final_state;
 use ic_registry_nns_data_provider::registry::RegistryCanister;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
@@ -28,16 +29,15 @@ use ic_system_test_driver::driver::test_env::TestEnv;
 use ic_system_test_driver::driver::test_env_api::{
     HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, NnsInstallationBuilder,
 };
-use ic_system_test_driver::nns::get_subnet_list_from_registry;
 use ic_system_test_driver::nns::{
     self, get_software_version_from_snapshot, submit_create_application_subnet_proposal,
-    vote_execute_proposal_assert_executed,
 };
+use ic_system_test_driver::nns::{get_subnet_list_from_registry, vote_on_proposal};
 use ic_system_test_driver::systest;
 use ic_system_test_driver::util::{
     assert_create_agent, block_on, runtime_from_url, UniversalCanister,
 };
-use ic_types::Height;
+use ic_types::{Height, RegistryVersion};
 use slog::info;
 use std::collections::HashSet;
 use std::iter::FromIterator;
@@ -45,6 +45,8 @@ use std::time::Duration;
 
 const NNS_PRE_MASTER: usize = 4;
 const APP_PRE_MASTER: usize = 4;
+const DKG_INTERVAL_LENGTH: u64 = 29;
+const APP_SUBNETS: usize = 5;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
@@ -59,9 +61,9 @@ pub fn setup(env: TestEnv) {
     InternetComputer::new()
         .add_subnet(
             Subnet::fast(SubnetType::System, NNS_PRE_MASTER)
-                .with_dkg_interval_length(Height::from(NNS_PRE_MASTER as u64 * 2)),
+                .with_dkg_interval_length(Height::from(DKG_INTERVAL_LENGTH)),
         )
-        .with_unassigned_nodes(APP_PRE_MASTER)
+        .with_unassigned_nodes(APP_PRE_MASTER * APP_SUBNETS)
         .setup_and_start(&env)
         .expect("failed to setup IC under test");
     env.topology_snapshot().subnets().for_each(|subnet| {
@@ -84,26 +86,18 @@ pub fn test(env: TestEnv) {
     let endpoint = subnet.nodes().next().unwrap();
 
     // get IDs of all unassigned nodes
-    let unassigned_nodes: Vec<NodeId> = topology_snapshot
+    let mut unassigned_nodes = topology_snapshot
         .unassigned_nodes()
-        .map(|n| n.node_id)
-        .collect();
+        .map(|node| node.node_id);
 
-    // check that there is at least one unassigned node
-    assert!(
-        !unassigned_nodes.is_empty(),
-        "there must be at least one unassigned node for creating a subnet"
-    );
-
-    // [Phase II] Execute and validate the testnet change
+    // [Phase II] Execute and validate the testnet changes
 
     let client = RegistryCanister::new_with_query_timeout(
         vec![endpoint.get_public_url()],
         Duration::from_secs(10),
     );
 
-    let new_subnet_id: SubnetId = block_on(async move {
-        // get original subnet ids
+    let (subnet_ids, topology_snapshot) = block_on(async move {
         let original_subnets = get_subnet_list_from_registry(&client).await;
         assert!(!original_subnets.is_empty(), "registry contains no subnets");
         info!(log, "original subnets: {:?}", original_subnets);
@@ -115,98 +109,102 @@ pub fn test(env: TestEnv) {
         let nns = runtime_from_url(endpoint.get_public_url(), endpoint.effective_canister_id());
         let governance = nns::get_governance_canister(&nns);
 
-        let proposal_id =
-            submit_create_application_subnet_proposal(&governance, unassigned_nodes, version).await;
+        // Submit and adopt the configured number of create subnet proposals
+        let mut proposal_ids = vec![];
+        for _ in 0..APP_SUBNETS {
+            let nodes = unassigned_nodes.by_ref().take(APP_PRE_MASTER).collect();
+            info!(
+                log,
+                "Submitting proposal to create subnet with nodes: {nodes:?}"
+            );
+            let proposal_id =
+                submit_create_application_subnet_proposal(&governance, nodes, version.clone())
+                    .await;
+            info!(log, "Voting on proposal {proposal_id}");
+            vote_on_proposal(&governance, proposal_id).await;
+            proposal_ids.push(proposal_id);
+        }
 
-        vote_execute_proposal_assert_executed(&governance, proposal_id).await;
+        // Wait until all proposals are executed
+        for proposal_id in proposal_ids {
+            info!(log, "Waiting on proposal {proposal_id}");
+            let proposal_info = wait_for_final_state(&governance, proposal_id).await;
+            assert_eq!(
+                proposal_info.status,
+                ProposalStatus::Executed as i32,
+                "proposal {proposal_id} did not execute: {proposal_info:?}"
+            );
+        }
+
+        let new_topology_snapshot = topology_snapshot
+            .block_for_min_registry_version(RegistryVersion::new(APP_SUBNETS as u64 + 1))
+            .await
+            .expect("Could not obtain updated registry.");
 
         // Check that the registry indeed contains the data
         let final_subnets = get_subnet_list_from_registry(&client).await;
         info!(log, "final subnets: {:?}", final_subnets);
 
-        // check that there is exactly one added subnet
-        assert_eq!(
-            original_subnets.len() + 1,
-            final_subnets.len(),
-            "final number of subnets should be one above number of original subnets"
-        );
         let original_subnet_set = set(&original_subnets);
         let final_subnet_set = set(&final_subnets);
+        // check that there are exactly APP_SUBNETS added subnets
+        assert_eq!(
+            original_subnet_set.len() + APP_SUBNETS,
+            final_subnet_set.len(),
+            "final number of subnets should be {APP_SUBNETS} above number of original subnets"
+        );
         assert!(
             original_subnet_set.is_subset(&final_subnet_set),
             "final number of subnets should be a superset of the set of original subnets"
         );
 
-        // Return the newly created subnet
-        original_subnet_set
-            .symmetric_difference(&final_subnet_set)
-            .collect::<HashSet<_>>()
-            .iter()
-            .next()
-            .unwrap()
-            .to_owned()
-            .to_owned()
+        // Return all subnet IDs
+        (final_subnets, new_topology_snapshot)
     });
 
-    info!(log, "created application subnet with ID {}", new_subnet_id);
-
-    // [Phase III] install a canister onto that subnet and check that it is
+    // [Phase III] install a canister onto ALL subnets and check that they are
     // operational
-    block_on(async move {
-        topology_snapshot
-            .block_for_newer_registry_version()
-            .await
-            .expect("Could not obtain updated registry.");
-    });
+    for subnet_id in subnet_ids {
+        info!(log, "Asserting healthy status of subnet {subnet_id}");
+        let subnet = topology_snapshot
+            .subnets()
+            .find(|subnet| subnet.subnet_id == subnet_id)
+            .expect("Could not find newly created subnet.");
+        subnet
+            .nodes()
+            .for_each(|node| node.await_status_is_healthy().unwrap());
+        let endpoint = subnet
+            .nodes()
+            .next()
+            .expect("Could not find any node in newly created subnet.");
 
-    let new_subnet = topology_snapshot
-        .subnets()
-        .find(|subnet| subnet.subnet_id == new_subnet_id)
-        .expect("Could not find newly created subnet.");
-    new_subnet
-        .nodes()
-        .for_each(|node| node.await_status_is_healthy().unwrap());
-    let newly_assigned_endpoint = new_subnet
-        .nodes()
-        .next()
-        .expect("Could not find any node in newly created subnet.");
+        block_on(async move {
+            let agent = assert_create_agent(endpoint.get_public_url().as_str()).await;
+            info!(
+                log,
+                "successfully created agent for endpoint of subnet node"
+            );
 
-    block_on(async move {
-        let agent = assert_create_agent(newly_assigned_endpoint.get_public_url().as_str()).await;
-        info!(
-            log,
-            "successfully created agent for endpoint of an originally unassigned node"
-        );
+            let universal_canister =
+                UniversalCanister::new_with_retries(&agent, endpoint.effective_canister_id(), log)
+                    .await;
+            info!(log, "successfully created a universal canister instance");
 
-        let universal_canister = UniversalCanister::new_with_retries(
-            &agent,
-            newly_assigned_endpoint.effective_canister_id(),
-            log,
-        )
-        .await;
-        info!(log, "successfully created a universal canister instance");
+            const UPDATE_MSG_1: &[u8] =
+                b"This beautiful prose should be persisted for future generations";
 
-        const UPDATE_MSG_1: &[u8] =
-            b"This beautiful prose should be persisted for future generations";
+            universal_canister.store_to_stable(0, UPDATE_MSG_1).await;
+            info!(log, "successfully saved message in the universal canister");
 
-        universal_canister.store_to_stable(0, UPDATE_MSG_1).await;
-        info!(log, "successfully saved message in the universal canister");
-
-        assert_eq!(
-            universal_canister
-                .try_read_stable(0, UPDATE_MSG_1.len() as u32)
-                .await,
-            UPDATE_MSG_1.to_vec(),
-            "could not validate that subnet is healthy: universal canister is broken"
-        );
-    });
-
-    info!(
-        log,
-        "Successfully created an app subnet of size {} from an NNS subnet of size {}",
-        APP_PRE_MASTER,
-        NNS_PRE_MASTER
-    );
+            assert_eq!(
+                universal_canister
+                    .try_read_stable(0, UPDATE_MSG_1.len() as u32)
+                    .await,
+                UPDATE_MSG_1.to_vec(),
+                "could not validate that subnet is healthy: universal canister is broken"
+            );
+        });
+    }
 }
 
 fn set<H: Clone + std::cmp::Eq + std::hash::Hash>(data: &[H]) -> HashSet<H> {


### PR DESCRIPTION
The existing test only covered the creation of a single subnet. However in practice, multiple create subnet proposals may be adopted at the same time.

Furthermore, after the subnets were created, we now also check the health of the NNS (in addition to the new subnet), to make sure it didn't run into any problems.