### PR TITLE
feat(icrc-rosetta): FI-1792: Add ICRC Rosetta release 1.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9702,7 +9702,7 @@ dependencies = [
 
 [[package]]
 name = "ic-icrc-rosetta"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "axum 0.8.4",

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -82,7 +82,7 @@ MACRO_DEV_DEPENDENCIES = [
 ALIASES = {
 }
 
-ROSETTA_VERSION = "1.2.3"
+ROSETTA_VERSION = "1.2.4"
 
 rust_library(
     name = "ic-icrc-rosetta",

--- a/rs/rosetta-api/icrc1/CHANGELOG.md
+++ b/rs/rosetta-api/icrc1/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.4] - 2025-07-07
+### Added
+- Allow retrieving the aggregate balance of a ICRC1 token account ([#5773](https://github.com/dfinity/ic/pull/5773))
+
 ## [1.2.3] - 2025-05-27
 ### Fixed
 - Fixed fee collector balance calculation for transfers using fee_collector_block_index ([#5304](https://github.com/dfinity/ic/pull/5304))
@@ -63,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.2] - 2024-05-08
 ### Fixes
-- Replacing internal crypto library `ic_canister_client_sender` with `ic_crypto_ed25519` 
+- Replacing internal crypto library `ic_canister_client_sender` with `ic_crypto_ed25519`
   and `ic_crypto_ecdsa_secp256k1`.
 ### Changed
 - `/block` endpoint is changed to return the latest block if no index or hash is provided.

--- a/rs/rosetta-api/icrc1/Cargo.toml
+++ b/rs/rosetta-api/icrc1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ic-icrc-rosetta"
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 default-run = "ic-icrc-rosetta"
-version = "1.2.3"
+version = "1.2.4"
 authors.workspace = true
 edition.workspace = true
 documentation.workspace = true

--- a/rs/rosetta-api/icrc1/src/common/constants.rs
+++ b/rs/rosetta-api/icrc1/src/common/constants.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 pub const DEFAULT_BLOCKCHAIN: &str = "Internet Computer";
-pub const ROSETTA_VERSION: &str = "1.2.3";
+pub const ROSETTA_VERSION: &str = "1.2.4";
 pub const NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const INGRESS_INTERVAL_SECS: u64 = 4 * 60;
 pub const BLOCK_SYNC_WAIT_SECS: u64 = 1;


### PR DESCRIPTION
Release information for ICRC Rosetta 1.2.4 with the following changes:

- Allow retrieving the aggregate balance of a ICRC1 token account (that is, the sum of balances of all sub-accounts of a particular principal).