### PR TITLE
chore: bump pocket-ic server spec_test timeout

### DIFF
--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -234,7 +234,9 @@ rust_library(
 
 rust_test(
     name = "spec_test",
-    size = "medium",
+    # the test sometimes times out on CI with default timeout
+    # of "moderate" (5 minutes) - 2025-07-03
+    timeout = "long",
     srcs = [
         "tests/common.rs",
         "tests/spec_test.rs",


### PR DESCRIPTION
The test recently timed out on master.

Until the test can be sped up or debugged, we bump the timeout from 5mn to 15mn.