### PR TITLE
chore: Flush state manager more often in state machine tests

### DIFF
--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1098,7 +1098,6 @@ pub struct PocketIc {
 impl Drop for PocketIc {
     fn drop(&mut self) {
         if let Some(ref state_dir) = self.subnets.state_dir {
-            println!("dropping");
             let subnets = self.subnets.get_all();
             for subnet in &subnets {
                 subnet.state_machine.checkpointed_tick();


### PR DESCRIPTION
With more asynchronous components in the state manager, tests tend to trip up as they might not expect it. This small change makes sure that when a test waits for the latest manifest, it also finishes all other asynchronous operations. This should help with some flakiness in tests when state machine tests are restarted or their directories reused.