### PR TITLE
feat(canbench): Pass along CANBENCH_PATTERN for running a subset of canbench benchmarks

### DIFF
--- a/bazel/canbench.sh
+++ b/bazel/canbench.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 # Runs canbench for benchmarking. Should only be invoked by bazel rules defined in canbench.bzl.
-# Usage ./canbench.sh [--update]
-# When --update is specified, the results file will be updated.
+# Usage ./canbench.sh [--update|--test|--debug]
+# - When `--update` is specified, the results file will be updated.
+# - When `--test` is specified, significant changes will cause the script to exit with an error.
+# - When `--debug` is specified, the benchmark will be run with instruction tracing.
+#
 # Environment variables:
 # - CANBENCH_BIN: Path to the canbench binary.
 # - CANBENCH_RESULTS_PATH: Path to the results file, which will be:
@@ -11,6 +14,9 @@
 # - WASM_PATH: Path to the wasm file to be benchmarked.
 # - NOISE_THRESHOLD: The noise threshold in percentage. If the difference between the current
 #     benchmark and the results file is above this threshold, the benchmark test will fail.
+# - CANBENCH_STABLE_MEMORY_FILE: The file to use for the stable memory.
+# - CANBENCH_PATTERN: The pattern to use for the benchmark. Only benchmarks matching this pattern
+#   (name of the benchmark *contains* this string) will be run. Not applicable for `--update`.
 
 set -eEuo pipefail
 
@@ -19,6 +25,7 @@ REPO_PATH="$(dirname "$(readlink "$WORKSPACE")")"
 REPO_RESULTS_PATH="${REPO_PATH}/${CANBENCH_RESULTS_PATH}"
 CANBENCH_OUTPUT="$(mktemp -t canbench_output.txt.XXXX)"
 NOISE_THRESHOLD_ARG="${NOISE_THRESHOLD:+--noise-threshold ${NOISE_THRESHOLD}}"
+PATTERN_ARG="${CANBENCH_PATTERN:+${CANBENCH_PATTERN}}"
 
 # Generates a canbench.yml dynamically to be used by canbench.
 CANBENCH_YML="${RUNFILES}/canbench.yml"
@@ -49,7 +56,7 @@ fi
 
 if [ $# -eq 0 ]; then
     # Runs the benchmark without updating the results file.
-    ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG}
+    ${CANBENCH_BIN} ${PATTERN_ARG} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG}
 elif [ "$1" = "--update" ]; then
     # Runs the benchmark while updating the results file.
     ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG} --persist
@@ -61,7 +68,7 @@ elif [ "$1" = "--update" ]; then
     fi
 elif [ "$1" = "--test" ]; then
     # Runs the benchmark test that fails if the diffs are new or above the threshold.
-    ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG} >$CANBENCH_OUTPUT
+    ${CANBENCH_BIN} ${PATTERN_ARG} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG} >$CANBENCH_OUTPUT
     if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then
         cat "$CANBENCH_OUTPUT"
         echo "**\`$REPO_RESULTS_PATH\` is not up to date ❌**
@@ -73,7 +80,7 @@ elif [ "$1" = "--test" ]; then
         exit 0
     fi
 elif [ "$1" = "--debug" ]; then
-    ${CANBENCH_BIN} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG} --instruction-tracing
+    ${CANBENCH_BIN} ${PATTERN_ARG} --no-runtime-integrity-check --runtime-path ${POCKET_IC_BIN} ${NOISE_THRESHOLD_ARG} --instruction-tracing
 else
     echo "Unknown command: $1"
     exit 1


### PR DESCRIPTION
# Why

When running/debugging/testing (not updating) the benchmarks, running a subset of the benchmarks can be a lot faster.

# What

* Pass through a pattern argument for running/debugging/testing
* Update documentation