### PR TITLE
feat(ICP-Ledger): FI-1795: add candid tip_of_chain endpoint

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -71,8 +71,8 @@ CANISTERS_MAX_SIZE_COMPRESSED_E5_BYTES = {
     "ic-icrc1-ledger.wasm.gz": 8,
     # The size is currently at 704585 bytes.
     "ic-icrc1-ledger-u256.wasm.gz": 8,
-    # Size when constraint addded: 841_234 bytes
-    "ledger-canister.wasm.gz": 9,
+    # Size when constraint addded: 901_184 bytes
+    "ledger-canister.wasm.gz": 10,
     # Size when constraint addded: 906_940 bytes
     "ledger-canister_notify-method.wasm.gz": 10,
 

--- a/rs/ledger_suite/icp/ledger.did
+++ b/rs/ledger_suite/icp/ledger.did
@@ -497,6 +497,11 @@ type Allowances = vec record {
     expires_at: opt nat64;
 };
 
+type TipOfChainRes = record {
+    certification: opt blob;
+    tip_index: BlockIndex;
+};
+
 service: (LedgerCanisterPayload) -> {
     // Transfers tokens from a subaccount of the caller to the destination address.
     // The source address is computed from the principal of the caller and the specified subaccount.
@@ -553,6 +558,8 @@ service: (LedgerCanisterPayload) -> {
     icrc10_supported_standards : () -> (vec record { name : text; url : text }) query;
 
     get_allowances : (GetAllowancesArgs) -> (Allowances) query;
+
+    tip_of_chain : () -> (TipOfChainRes) query;
 
     is_ledger_ready: () -> (bool) query;
 }

--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -1130,6 +1130,12 @@ fn tip_of_chain_() {
     reply_raw(&res)
 }
 
+#[query(name = "tip_of_chain")]
+#[candid_method(query, rename = "tip_of_chain")]
+fn tip_of_chain_candid() -> TipOfChainRes {
+    tip_of_chain()
+}
+
 #[export_name = "canister_query get_archive_index_pb"]
 fn get_archive_index_() {
     ic_cdk::setup();

--- a/rs/ledger_suite/icp/src/lib.rs
+++ b/rs/ledger_suite/icp/src/lib.rs
@@ -1087,6 +1087,7 @@ pub struct Archives {
 }
 
 /// Argument returned by the tip_of_chain endpoint
+#[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize, Serialize)]
 pub struct TipOfChainRes {
     pub certification: Option<Vec<u8>>,
     pub tip_index: BlockIndex,

--- a/rs/ledger_suite/icp/test_utils/src/state_machine_helpers/ledger.rs
+++ b/rs/ledger_suite/icp/test_utils/src/state_machine_helpers/ledger.rs
@@ -131,7 +131,7 @@ pub fn icp_ledger_tip(env: &StateMachine, ledger_id: CanisterId) -> u64 {
         .query(ledger_id, "tip_of_chain", req)
         .expect("Failed to send tip_of_chain request")
         .bytes();
-    let tip_candid = Decode!(&res, TipOfChainRes).expect("Failed to decode GetBlocksResponse");
+    let tip_candid = Decode!(&res, TipOfChainRes).expect("Failed to decode TipOfChainRes");
     assert_eq!(tip, tip_candid);
 
     tip.tip_index


### PR DESCRIPTION
The candid equivalent of the `tip_of_chain_pb` protocol buffer endpoint.