### PR TITLE
fix: Fix the reboot behavior of GuestVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5220,6 +5220,7 @@ dependencies = [
  "sys-mount",
  "systemd",
  "tempfile",
+    "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5220,7 +5220,7 @@ dependencies = [
  "sys-mount",
  "systemd",
  "tempfile",
-    "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "url",

--- a/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
+++ b/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
@@ -19,6 +19,7 @@ DEPENDENCIES = [
     "@crate_index//:sys-mount",
     "@crate_index//:systemd",
     "@crate_index//:tempfile",
+    "@crate_index//:thiserror",
     "@crate_index//:tokio",
     "@crate_index//:tokio-util",
     "@crate_index//:uuid",

--- a/rs/ic_os/os_tools/guest_vm_runner/Cargo.toml
+++ b/rs/ic_os/os_tools/guest_vm_runner/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true }
 gpt = { workspace = true }
 macaddr = { workspace = true }
 regex = { workspace = true }
+thiserror = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_kvm.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_kvm.xml
@@ -36,9 +36,10 @@
     <timer name='pit' tickpolicy='delay'/>
     <timer name='hpet' present='no'/>
   </clock>
-  <on_poweroff>restart</on_poweroff>
-  <on_reboot>restart</on_reboot>
-  <on_crash>restart</on_crash>
+  <!-- Destroy the VM in all these cases and let the guest_vm_runner restart it -->
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>destroy</on_reboot>
+  <on_crash>destroy</on_crash>
   <pm>
     <suspend-to-mem enabled='no'/>
     <suspend-to-disk enabled='no'/>

--- a/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_qemu.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_qemu.xml
@@ -30,9 +30,10 @@
     <timer name='pit' tickpolicy='delay'/>
     <timer name='hpet' present='no'/>
   </clock>
-  <on_poweroff>restart</on_poweroff>
-  <on_reboot>restart</on_reboot>
-  <on_crash>restart</on_crash>
+  <!-- Destroy the VM in all these cases and let the guest_vm_runner restart it -->
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>destroy</on_reboot>
+  <on_crash>destroy</on_crash>
   <pm>
     <suspend-to-mem enabled='no'/>
     <suspend-to-disk enabled='no'/>

--- a/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_sev.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_sev.xml
@@ -46,9 +46,10 @@
     <timer name='pit' tickpolicy='delay'/>
     <timer name='hpet' present='no'/>
   </clock>
-  <on_poweroff>restart</on_poweroff>
-  <on_reboot>restart</on_reboot>
-  <on_crash>restart</on_crash>
+  <!-- Destroy the VM in all these cases and let the guest_vm_runner restart it -->
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>destroy</on_reboot>
+  <on_crash>destroy</on_crash>
   <pm>
     <suspend-to-mem enabled='no'/>
     <suspend-to-disk enabled='no'/>

--- a/rs/ic_os/os_tools/guest_vm_runner/golden/upgrade_guestos.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/upgrade_guestos.xml
@@ -38,9 +38,10 @@
     <timer name='pit' tickpolicy='delay'/>
     <timer name='hpet' present='no'/>
   </clock>
-  <on_poweroff>restart</on_poweroff>
-  <on_reboot>restart</on_reboot>
-  <on_crash>restart</on_crash>
+  <!-- Destroy the VM in all these cases and let the guest_vm_runner restart it -->
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>destroy</on_reboot>
+  <on_crash>destroy</on_crash>
   <pm>
     <suspend-to-mem enabled='no'/>
     <suspend-to-disk enabled='no'/>

--- a/rs/ic_os/os_tools/guest_vm_runner/templates/guestos_vm_template.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/templates/guestos_vm_template.xml
@@ -60,7 +60,7 @@
     <timer name='pit' tickpolicy='delay'/>
     <timer name='hpet' present='no'/>
   </clock>
-  <!-- Destroy the VM in all these cases and let the guest_vm_runner -->
+  <!-- Destroy the VM in all these cases and let the guest_vm_runner restart it -->
   <on_poweroff>destroy</on_poweroff>
   <on_reboot>destroy</on_reboot>
   <on_crash>destroy</on_crash>

--- a/rs/ic_os/os_tools/guest_vm_runner/templates/guestos_vm_template.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/templates/guestos_vm_template.xml
@@ -60,9 +60,10 @@
     <timer name='pit' tickpolicy='delay'/>
     <timer name='hpet' present='no'/>
   </clock>
-  <on_poweroff>restart</on_poweroff>
-  <on_reboot>restart</on_reboot>
-  <on_crash>restart</on_crash>
+  <!-- Destroy the VM in all these cases and let the guest_vm_runner -->
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>destroy</on_reboot>
+  <on_crash>destroy</on_crash>
   <pm>
     <suspend-to-mem enabled='no'/>
     <suspend-to-disk enabled='no'/>


### PR DESCRIPTION
With the "restart" libvirt setting, the VM is restarted using the same direct boot args as it was used to start with. This is obviously wrong and breaks upgrades where changing the boot params is necessary.

This fix doesn't allow QEMU to restart the VM but rather adds support in the guest_vm_runner to recreate the VM with a brand new configuration.