### PR TITLE
feat(registry): Make Registry.create_subnet return the ID of the new subnet.

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -40,7 +40,7 @@ use registry_canister::{
         do_add_node_operator::AddNodeOperatorPayload,
         do_add_nodes_to_subnet::AddNodesToSubnetPayload,
         do_change_subnet_membership::ChangeSubnetMembershipPayload,
-        do_create_subnet::CreateSubnetPayload,
+        do_create_subnet::{CreateSubnetPayload, NewSubnet},
         do_deploy_guestos_to_all_subnet_nodes::DeployGuestosToAllSubnetNodesPayload,
         do_deploy_guestos_to_all_unassigned_nodes::DeployGuestosToAllUnassignedNodesPayload,
         do_recover_subnet::RecoverSubnetPayload,
@@ -588,10 +588,15 @@ fn create_subnet() {
     });
 }
 
+/// Currently, this does not return Err, but for the sake of consistency the
+/// return type is Result. Currently, if the operation cannot be completed, this
+/// panics instead of returning Err (ensuring any partial changes do not get
+/// committed).
 #[candid_method(update, rename = "create_subnet")]
-async fn create_subnet_(payload: CreateSubnetPayload) {
-    registry_mut().do_create_subnet(payload).await;
+async fn create_subnet_(payload: CreateSubnetPayload) -> Result<NewSubnet, String> {
+    let new_subnet = registry_mut().do_create_subnet(payload).await;
     recertify_registry();
+    Ok(new_subnet)
 }
 
 #[export_name = "canister_update add_nodes_to_subnet"]

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -103,6 +103,14 @@ type CreateSubnetPayload = record {
   gossip_retransmission_request_ms : nat32;
 };
 
+type CreateSubnetResponse = variant {
+  Ok : record {
+    new_subnet_id : opt principal;
+  };
+
+  Err: text;
+};
+
 type CanisterCyclesCostSchedule = variant {
   Normal;
   Free;
@@ -480,7 +488,7 @@ service : {
   change_subnet_membership : (ChangeSubnetMembershipPayload) -> ();
   clear_provisional_whitelist : () -> ();
   complete_canister_migration : (CompleteCanisterMigrationPayload) -> ();
-  create_subnet : (CreateSubnetPayload) -> ();
+  create_subnet : (CreateSubnetPayload) -> (CreateSubnetResponse);
   deploy_guestos_to_all_subnet_nodes : (
     DeployGuestosToAllSubnetNodesPayload
   ) -> ();

--- a/rs/registry/canister/canister/registry_test.did
+++ b/rs/registry/canister/canister/registry_test.did
@@ -103,6 +103,14 @@ type CreateSubnetPayload = record {
   gossip_retransmission_request_ms : nat32;
 };
 
+type CreateSubnetResponse = variant {
+  Ok : record {
+    new_subnet_id : opt principal;
+  };
+
+  Err: text;
+};
+
 type CanisterCyclesCostSchedule = variant {
   Normal;
   Free;
@@ -480,7 +488,7 @@ service : {
   change_subnet_membership : (ChangeSubnetMembershipPayload) -> ();
   clear_provisional_whitelist : () -> ();
   complete_canister_migration : (CompleteCanisterMigrationPayload) -> ();
-  create_subnet : (CreateSubnetPayload) -> ();
+  create_subnet : (CreateSubnetPayload) -> (CreateSubnetResponse);
   deploy_guestos_to_all_subnet_nodes : (
     DeployGuestosToAllSubnetNodesPayload
   ) -> ();

--- a/rs/registry/canister/src/mutations/do_create_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_create_subnet.rs
@@ -40,7 +40,10 @@ impl Registry {
     /// parameters populated by caller into registry. It is expected that
     /// the rest of the system will take the information from the registry
     /// to actually start the subnet.
-    pub async fn do_create_subnet(&mut self, payload: CreateSubnetPayload) {
+    ///
+    /// Returns the ID of the new subnet. The subnet probably isn't ready for
+    /// immediate use shortly after this returns.
+    pub async fn do_create_subnet(&mut self, payload: CreateSubnetPayload) -> NewSubnet {
         println!("{}do_create_subnet: {:?}", LOG_PREFIX, payload);
 
         self.validate_create_subnet_payload(&payload);
@@ -170,6 +173,11 @@ impl Registry {
 
         // Check invariants before applying mutations
         self.maybe_apply_mutation_internal(mutations);
+
+        let new_subnet_id = Some(subnet_id);
+        NewSubnet {
+            new_subnet_id,
+        }
     }
 
     /// Validates runtime payload values that aren't checked by invariants.
@@ -297,6 +305,11 @@ pub struct CreateSubnetPayload {
     pub gossip_pfn_evaluation_period_ms: u32,
     pub gossip_registry_poll_period_ms: u32,
     pub gossip_retransmission_request_ms: u32,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize, Serialize)]
+pub struct NewSubnet {
+    pub new_subnet_id: Option<SubnetId>,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize, Serialize)]

--- a/rs/registry/canister/src/mutations/do_create_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_create_subnet.rs
@@ -175,9 +175,7 @@ impl Registry {
         self.maybe_apply_mutation_internal(mutations);
 
         let new_subnet_id = Some(subnet_id);
-        NewSubnet {
-            new_subnet_id,
-        }
+        NewSubnet { new_subnet_id }
     }
 
     /// Validates runtime payload values that aren't checked by invariants.

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -11,6 +11,8 @@ on the process that this file is part of, see
 
 ## Changed
 
+* `create_subnet` now returns the new subnet's ID.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
It didn't return anything before. I don't think this was intentional. This is helpful for subnet rental, because Governance wants to tell the Subnet Rental canister about the subnet that was created for a rental.

# Unusual API Change

This changes a return type from being `()` (zero element tuple) to `(SomeResult)` (one elment tuple), which is pretty unusual. It is reasonable to question, "Wait, is that ok?". According to the following experiment, it is:

```
$ echo '
type Request = record {};

service : () -> {
  create_subnet : (Request) -> ();
}
' > previous.did

echo '
type Request = record {};

type Result = variant {
  Ok;
  Err;
};

service : () -> {
  create_subnet : (Request) -> (Result);
}
' > next.did

echo
echo -n "evolving from previous to next: "
if didc check next.did previous.did
then
    echo OK
else
    echo VERBOTEN
fi

rm previous.did next.did 2> /dev/null || true

evolving from previous to next: OK
```

# References

Working towards [NNS1-3925].

[NNS1-3925]: https://dfinity.atlassian.net/browse/NNS1-3925

[👈 Previous PR][prev] | [Next PR 👉][next]

[prev]: https://github.com/dfinity/ic/pull/5835
[next]: https://github.com/dfinity/ic/pull/5895