### PR TITLE
Add: balance_discrepancy field to BalanceBook

### DIFF
--- a/rs/sns/treasury_manager/src/lib.rs
+++ b/rs/sns/treasury_manager/src/lib.rs
@@ -32,6 +32,7 @@ pub struct BalanceBook {
     pub fee_collector: Option<Balance>,
     pub payees: Option<Balance>,
     pub payers: Option<Balance>,
+    pub balance_discrepancy: Option<Balance>,
 }
 
 #[derive(CandidType, Clone, Debug, Default, Deserialize, PartialEq)]

--- a/rs/sns/treasury_manager/treasury_manager.did
+++ b/rs/sns/treasury_manager/treasury_manager.did
@@ -140,6 +140,7 @@ type BalanceBook = record {
   fee_collector : opt Balance;
   payees : opt Balance;
   payers : opt Balance;
+  balance_discrepancy: opt Balance;
 };
 
 type Balance = record {


### PR DESCRIPTION
We have decided to add a field into the treasury balance messages to indicate whether there is a discrepancy between the actual and the expected balance in the following cases:

1. When withdrawing from DEX, if we receive less than what DEX claims to have given us, we can mark this discrepancy to become visible to the users.
2. When depositing to DEX, if DEX takes more than what it is supposed to take.

In general, whenever there is a discrepancy against the user (SNS treasury), it gets accumulated in the newly introduced field `balance_discrepancy`