### PR TITLE
fix(test): fix Rust SignerCanister API

### DIFF
--- a/rs/tests/consensus/tecdsa/tschnorr_message_sizes_test.rs
+++ b/rs/tests/consensus/tecdsa/tschnorr_message_sizes_test.rs
@@ -135,15 +135,14 @@ async fn gen_message_and_get_signature_depending_on_limit(
         LimitType::Local => {
             generate_dummy_schnorr_signature_with_logger(message.len(), 0, 0, key_id, sig_can, log)
                 .await
-                .map(|sig| sig.signature)?
+                .map(|sig| sig.signature)
         }
 
         LimitType::XNet => {
-            get_schnorr_signature_with_logger(message.clone(), cycles, key_id, msg_can, log)
-                .await
-                .map_err(|err| err.to_string())?
+            get_schnorr_signature_with_logger(message.clone(), cycles, key_id, msg_can, log).await
         }
-    };
+    }
+    .map_err(|err| err.to_string())?;
 
     Ok((message, signature))
 }

--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -824,7 +824,7 @@ pub async fn generate_dummy_ecdsa_signature_with_logger(
     key_id: &EcdsaKeyId,
     sig_can: &SignerCanister<'_>,
     logger: &Logger,
-) -> Result<SignWithEcdsaResponse, String> {
+) -> Result<SignWithEcdsaResponse, AgentError> {
     let signature_request = GenEcdsaParams {
         derivation_path_length,
         derivation_path_element_size,
@@ -869,7 +869,7 @@ pub async fn generate_dummy_schnorr_signature_with_logger(
     key_id: &SchnorrKeyId,
     sig_can: &SignerCanister<'_>,
     logger: &Logger,
-) -> Result<SignWithSchnorrResponse, String> {
+) -> Result<SignWithSchnorrResponse, AgentError> {
     let signature_request = GenSchnorrParams {
         message_size,
         derivation_path_length,
@@ -914,7 +914,7 @@ pub async fn generate_dummy_vetkd_key_with_logger(
     key_id: &VetKdKeyId,
     sig_can: &SignerCanister<'_>,
     logger: &Logger,
-) -> Result<VetKDDeriveKeyResult, String> {
+) -> Result<VetKDDeriveKeyResult, AgentError> {
     let key_request = GenVetkdParams {
         context_size,
         input_size,

--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -838,46 +838,37 @@ impl<'a> SignerCanister<'a> {
     pub async fn gen_ecdsa_sig(
         &self,
         params: GenEcdsaParams,
-    ) -> Result<SignWithEcdsaResponse, String> {
-        let bytes = self
-            .agent
+    ) -> Result<SignWithEcdsaResponse, AgentError> {
+        self.agent
             .update(&self.canister_id, "gen_ecdsa_sig")
             .with_arg(Encode!(&params).unwrap())
             .call_and_wait()
             .await
-            .map_err(|e| e.to_string())?;
-
-        Decode!(&bytes, Result<SignWithEcdsaResponse, String>).unwrap()
+            .map(|bytes| Decode!(&bytes, SignWithEcdsaResponse).unwrap())
     }
 
     pub async fn gen_schnorr_sig(
         &self,
         params: GenSchnorrParams,
-    ) -> Result<SignWithSchnorrResponse, String> {
-        let bytes = self
-            .agent
+    ) -> Result<SignWithSchnorrResponse, AgentError> {
+        self.agent
             .update(&self.canister_id, "gen_schnorr_sig")
             .with_arg(Encode!(&params).unwrap())
             .call_and_wait()
             .await
-            .map_err(|e| e.to_string())?;
-
-        Decode!(&bytes, Result<SignWithSchnorrResponse, String>).unwrap()
+            .map(|bytes| Decode!(&bytes, SignWithSchnorrResponse).unwrap())
     }
 
     pub async fn gen_vetkd_key(
         &self,
         params: GenVetkdParams,
-    ) -> Result<VetKDDeriveKeyResult, String> {
-        let bytes = self
-            .agent
+    ) -> Result<VetKDDeriveKeyResult, AgentError> {
+        self.agent
             .update(&self.canister_id, "gen_vetkd_key")
             .with_arg(Encode!(&params).unwrap())
             .call_and_wait()
             .await
-            .map_err(|e| e.to_string())?;
-
-        Decode!(&bytes, Result<VetKDDeriveKeyResult, String>).unwrap()
+            .map(|bytes| Decode!(&bytes, VetKDDeriveKeyResult).unwrap())
     }
 }
 


### PR DESCRIPTION
#5853 just got merged and led to a [regression](https://github.com/dfinity/ic/actions/runs/16197096606/job/45726302061). It fixed the signer canister interface to always return a signature, or reject the call if that is not possible, as opposed to returning an `Ok`/`Err` but I had forgotten to adapt the Rust `SignerCanister` API to reflect this change. I'll use `CI_ALL_BAZEL_TARGETS` next time...

This PR fixes this. Now the API of `MessageCanister` and `SignerCanister` are similar, since `SignerCanister` no longer returns a `Result` (i.e. `forward_to` and `gen_ecdsa_sig`/`gen_schnorr_sig`/`gen_vetkd_key` have the same function signatures).