### PR TITLE
fix: Use the OVMF shipped with the HostOS temporarily 

### DIFF
--- a/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_kvm.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_kvm.xml
@@ -24,6 +24,7 @@
   <os type='efi'>
     <type arch='x86_64' machine='pc-q35-9.2'>hvm</type>
     <boot dev='hd'/>
+
     <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
     <nvram>/var/lib/libvirt/qemu/nvram/guestos_VARS.fd</nvram>
   </os>

--- a/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_qemu.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_qemu.xml
@@ -16,7 +16,8 @@
   <os type='efi'>
     <type arch='x86_64' machine='pc-q35-9.2'>hvm</type>
     <boot dev='hd'/>
-    <loader readonly='yes'>/tmp/OVMF.fd</loader>
+    <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
+    <nvram>/var/lib/libvirt/qemu/nvram/guestos_VARS.fd</nvram>
     <kernel>/tmp/test-kernel</kernel>
     <initrd>/tmp/test-initrd</initrd>
     <cmdline>security=selinux selinux=1 enforcing=0</cmdline>

--- a/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_sev.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_sev.xml
@@ -32,7 +32,8 @@
   <os type='efi'>
     <type arch='x86_64' machine='pc-q35-9.2'>hvm</type>
     <boot dev='hd'/>
-    <loader readonly='yes'>/tmp/OVMF.fd</loader>
+    <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
+    <nvram>/var/lib/libvirt/qemu/nvram/guestos_VARS.fd</nvram>
     <kernel>/tmp/test-kernel</kernel>
     <initrd>/tmp/test-initrd</initrd>
     <cmdline>security=selinux selinux=1 enforcing=0</cmdline>

--- a/rs/ic_os/os_tools/guest_vm_runner/golden/upgrade_guestos.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/upgrade_guestos.xml
@@ -24,7 +24,8 @@
   <os type='efi'>
     <type arch='x86_64' machine='pc-q35-9.2'>hvm</type>
     <boot dev='hd'/>
-    <loader readonly='yes'>/tmp/OVMF.fd</loader>
+    <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
+    <nvram>/var/lib/libvirt/qemu/nvram/upgrade-guestos_VARS.fd</nvram>
     <kernel>/tmp/test-kernel</kernel>
     <initrd>/tmp/test-initrd</initrd>
     <cmdline>security=selinux selinux=1 enforcing=0</cmdline>

--- a/rs/ic_os/os_tools/guest_vm_runner/templates/guestos_vm_template.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/templates/guestos_vm_template.xml
@@ -41,8 +41,12 @@
   <os type='efi'>
     <type arch='x86_64' machine='pc-q35-9.2'>hvm</type>
     <boot dev='hd'/>
-    {%- if let Some(direct_boot) = direct_boot %}
-    <loader readonly='yes'>{{direct_boot.ovmf.display()}}</loader>
+    {% if let Some(direct_boot) = direct_boot -%}
+    {# TODO: Reenable custom OVMF once we know why it doesn't support direct boot -#}
+    {#-    <loader readonly='yes'>{{direct_boot.ovmf.display()}}</loader> -#}
+
+    <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
+    <nvram>/var/lib/libvirt/qemu/nvram/{{domain_name}}_VARS.fd</nvram>
     <kernel>{{direct_boot.kernel.display()}}</kernel>
     <initrd>{{direct_boot.initrd.display()}}</initrd>
     <cmdline>{{direct_boot.kernel_cmdline}}</cmdline>


### PR DESCRIPTION
The one added in #5776 does not correctly do direct boot