### PR TITLE
chore: increase cketh test timeout

### DIFF
--- a/rs/ethereum/cketh/minter/BUILD.bazel
+++ b/rs/ethereum/cketh/minter/BUILD.bazel
@@ -191,6 +191,9 @@ rust_binary(
 
 rust_ic_test_suite(
     name = "integration_tests",
+    # the test sometimes times out on CI with default timeout
+    # of "moderate" (5 minutes) - 2025-07-11
+    timeout = "long",
     srcs = glob(["tests/**/*.rs"]),
     data = [
         ":cketh_minter_debug.wasm.gz",


### PR DESCRIPTION
The test takes ~90s to run and sometimes times out on CI after 5mn if the machine is overloaded.