### PR TITLE
fix: update registry client when initializing local store

### DIFF
--- a/rs/boundary_node/ic_boundary/src/core.rs
+++ b/rs/boundary_node/ic_boundary/src/core.rs
@@ -44,7 +44,7 @@ use ic_protobuf::registry::crypto::v1::{AlgorithmId, PublicKey};
 use ic_registry_client::client::{RegistryClient, RegistryClientImpl};
 use ic_registry_client_helpers::{crypto::CryptoRegistry, subnet::SubnetRegistry};
 use ic_registry_local_store::{LocalStore, LocalStoreImpl};
-use ic_registry_replicator::RegistryReplicator;
+use ic_registry_replicator::{PollableRegistryClient, RegistryReplicator};
 use ic_types::messages::MessageId;
 use nix::unistd::{getpgid, setpgid, Pid};
 use rustls::client::danger::ServerCertVerifier;
@@ -648,7 +648,7 @@ async fn create_agent(
 fn setup_registry(
     cli: &Cli,
     local_store: Arc<dyn LocalStore>,
-    registry_client: Arc<dyn RegistryClient>,
+    registry_client: Arc<dyn PollableRegistryClient>,
     registry_snapshot: Arc<ArcSwapOption<RegistrySnapshot>>,
     persister: WithMetricsPersist<Persister>,
     http_client_check: Arc<dyn bnhttp::Client>,


### PR DESCRIPTION
When the registry replicator is created, it creates a registry client that instantly starts polling the local store to update its cache ([source](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/orchestrator/registry_replicator/src/lib.rs?L108-110)). It is only when calling `start_polling()` that the underlying data (the local store) is initialized ([source](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/orchestrator/registry_replicator/src/lib.rs?L316-319)). When building the orchestrator, we create a registry replicator, start its polling and then instantly start node registration. Since the registry client is initialized to poll before the local store is initialized, it will observe the initial data with a delay of 5 seconds. This has the effect that the orchestrator cannot fetch the [NNS URL](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/orchestrator/src/registration.rs?L151) and [NNS public key](https://github.com/dfinity/ic/pull/5841/files#diff-00e9e0b99bcca5d89b4d5f4de6dff1fa34a8e457bd8158c06ad38357a06bb6c6R190) from the registry during node registration, we need to use the values from the configuration instead.

To make up for this, this PR implements a quick fix (compared to #5909 which introduces a complete refactor). When initializing the local store in `start_polling()`, we ask the underlying registry client to poll such that its cache is updated and correctly reflects the initial state.