### PR TITLE
chore: track NNS governance test canister in mainnet canisters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22374,9 +22374,11 @@ dependencies = [
  "ic-nervous-system-common-test-keys",
  "ic-nns-common",
  "ic-nns-constants",
+ "reqwest 0.12.15",
  "rgb",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
 ]

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -19,6 +19,7 @@ canisters(
     filenames = {
         "registry": "registry-canister.wasm.gz",
         "governance": "governance-canister.wasm.gz",
+        "governance-canister_test": "governance-canister_test.wasm.gz",
         "ledger": "ledger-canister_notify-method.wasm.gz",
         "archive": "ledger-archive-node-canister.wasm.gz",
         "index": "ic-icp-index-canister.wasm.gz",
@@ -54,6 +55,7 @@ canisters(
     reponames = {
         "registry": "mainnet_nns_registry_canister",
         "governance": "mainnet_nns_governance_canister",
+        "governance-canister_test": "mainnet_nns_governance_canister_test",
         "ledger": "mainnet_icp_ledger_canister",
         "archive": "mainnet_icp_ledger-archive-node-canister",
         "index": "mainnet_icp_index_canister",

--- a/mainnet-canister-revisions.json
+++ b/mainnet-canister-revisions.json
@@ -71,6 +71,10 @@
     "rev": "2f87fe95207dc6371a2f2dc273362ba03b41e0e9",
     "sha256": "f3e28dd6102fd0a9a959a4b0fecdd052b7391aab6ecd626e194e6afeeb36f07f"
   },
+  "governance-canister_test": {
+    "rev": "2f87fe95207dc6371a2f2dc273362ba03b41e0e9",
+    "sha256": "1676d35b79dc212f3f52be347f8072d7d2851d59f771da95f3b412f2b39a5439"
+  },
   "index": {
     "rev": "3ae3649a2366aaca83404b692fc58e4c6e604a25",
     "sha256": "b443df3315902404b142d60f3cfd2f580181683310f6e6321b52de297deffcda"

--- a/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/BUILD.bazel
+++ b/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/BUILD.bazel
@@ -17,9 +17,11 @@ DEPENDENCIES = [
     "@crate_index//:futures",
     "@crate_index//:ic-agent",
     "@crate_index//:ic-wasm__ic-wasm",
+    "@crate_index//:reqwest",
     "@crate_index//:rgb",
     "@crate_index//:serde",
     "@crate_index//:serde_json",
+    "@crate_index//:sha2",
     "@crate_index//:tempfile",
     "@crate_index//:tokio",
 ]

--- a/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/Cargo.toml
+++ b/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/Cargo.toml
@@ -22,8 +22,10 @@ ic-nervous-system-clients = { path = "../../clients" }
 ic-nervous-system-common-test-keys = { path = "../../common/test_keys" }
 ic-nns-common = { path = "../../../nns/common" }
 ic-nns-constants = { path = "../../../nns/constants" }
+reqwest = { workspace = true }
 rgb = "0.8.37"
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/src/main.rs
+++ b/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/src/main.rs
@@ -8,14 +8,16 @@ use ic_nns_constants::{
     LEDGER_CANISTER_ID, LIFELINE_CANISTER_ID, NODE_REWARDS_CANISTER_ID, REGISTRY_CANISTER_ID,
     ROOT_CANISTER_ID, SNS_WASM_CANISTER_ID,
 };
+use sha2::Digest;
 use std::env;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
-pub const NNS_CANISTER_NAME_TO_ID: [(&str, CanisterId); 9] = [
+pub const NNS_CANISTER_NAME_TO_ID: [(&str, CanisterId); 10] = [
     ("registry", REGISTRY_CANISTER_ID),
     ("governance", GOVERNANCE_CANISTER_ID),
+    ("governance-canister_test", GOVERNANCE_CANISTER_ID),
     ("ledger", LEDGER_CANISTER_ID),
     ("root", ROOT_CANISTER_ID),
     ("lifeline", LIFELINE_CANISTER_ID),
@@ -27,6 +29,7 @@ pub const NNS_CANISTER_NAME_TO_ID: [(&str, CanisterId); 9] = [
 
 async fn get_mainnet_canister_git_commit_id_and_module_hash(
     agent: &Agent,
+    canister_name: &str,
     canister_id: CanisterId,
 ) -> Result<(String, String)> {
     use std::fmt::Write;
@@ -41,15 +44,29 @@ async fn get_mainnet_canister_git_commit_id_and_module_hash(
         git_commit_id.pop();
     }
 
-    let module_hash = agent
-        .read_state_canister_info(canister_id, "module_hash")
-        .await?;
-    let module_hash = module_hash.iter().fold(String::new(), |mut output, x| {
+    let module_hash = if canister_name.ends_with("_test") {
+        // we get the module hash of a test canister from AWS
+        let module_url = format!(
+            "https://download.dfinity.systems/ic/{git_commit_id}/canisters/{canister_name}.wasm.gz"
+        );
+        let module_bytes = reqwest::get(module_url)
+            .await?
+            .error_for_status()?
+            .bytes()
+            .await?;
+        sha2::Sha256::digest(&module_bytes).to_vec()
+    } else {
+        // we get the module hash of a production canister from the ICP mainnet
+        agent
+            .read_state_canister_info(canister_id, "module_hash")
+            .await?
+    };
+    let module_hash_str = module_hash.iter().fold(String::new(), |mut output, x| {
         let _ = write!(output, "{:02x}", x);
         output
     });
 
-    Ok((git_commit_id, module_hash))
+    Ok((git_commit_id, module_hash_str))
 }
 
 #[tokio::main]
@@ -71,8 +88,12 @@ async fn main() -> Result<()> {
     let mut canister_updates = stream::iter(NNS_CANISTER_NAME_TO_ID.iter())
         .then(|(canister_name, canister_id)| async {
             let canister_name = canister_name.to_string();
-            let (new_git_hash, new_sha256) =
-                get_mainnet_canister_git_commit_id_and_module_hash(&agent, *canister_id).await?;
+            let (new_git_hash, new_sha256) = get_mainnet_canister_git_commit_id_and_module_hash(
+                &agent,
+                &canister_name,
+                *canister_id,
+            )
+            .await?;
             Ok(CanisterUpdate {
                 canister_name,
                 new_git_hash,


### PR DESCRIPTION
This PR adds the NNS governance test canister to be tracked in mainnet canisters. This way,
-  the NNS governance test canister built at the same commit as the currently deployed NNS governance production canister is now available as the bazel target `@mainnet_nns_governance_canister_test//file` (useful for bootstrapping system canisters in PocketIC in the future);
- the NNS governance test canister commit and module hash is automatically updated via `bazel run //rs/nervous_system/tools/sync-with-released-nervous-system-wasms` triggered by a periodic bot.