### PR TITLE
feat(PocketIC): PocketIC can recover from a state directory after being killed

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -617,13 +617,8 @@ impl PocketIc {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .unwrap();
-        let url = runtime.block_on(async {
-            start_or_reuse_server(None)
-                .await
-                .1
-                .join("instances")
-                .unwrap()
-        });
+        let url = runtime
+            .block_on(async { start_or_reuse_server(None).await.join("instances").unwrap() });
         let instances: Vec<String> = reqwest::blocking::Client::new()
             .get(url)
             .send()
@@ -1825,7 +1820,12 @@ async fn download_pocketic_server(
 }
 
 /// Attempt to start a new PocketIC server if it's not already running.
-pub async fn start_or_reuse_server(server_binary: Option<PathBuf>) -> (Child, Url) {
+pub async fn start_or_reuse_server(server_binary: Option<PathBuf>) -> Url {
+    start_or_reuse_server_impl(server_binary).await.1
+}
+
+/// Attempt to start a new PocketIC server if it's not already running.
+pub async fn start_or_reuse_server_impl(server_binary: Option<PathBuf>) -> (Child, Url) {
     let default_bin_dir =
         std::env::temp_dir().join(format!("pocket-ic-server-{}", EXPECTED_SERVER_VERSION));
     let default_bin_path = default_bin_dir.join("pocket-ic");

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -144,7 +144,7 @@ impl PocketIc {
         let server_url = if let Some(server_url) = server_url {
             server_url
         } else {
-            start_or_reuse_server(server_binary).await.1
+            start_or_reuse_server(server_binary).await
         };
 
         let subnet_config_set = subnet_config_set
@@ -314,11 +314,7 @@ impl PocketIc {
     /// List all instances and their status.
     #[instrument(ret)]
     pub async fn list_instances() -> Vec<String> {
-        let url = start_or_reuse_server(None)
-            .await
-            .1
-            .join("instances")
-            .unwrap();
+        let url = start_or_reuse_server(None).await.join("instances").unwrap();
         let instances: Vec<String> = reqwest::Client::new()
             .get(url)
             .send()

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -144,7 +144,7 @@ impl PocketIc {
         let server_url = if let Some(server_url) = server_url {
             server_url
         } else {
-            start_or_reuse_server(server_binary).await
+            start_or_reuse_server(server_binary).await.1
         };
 
         let subnet_config_set = subnet_config_set
@@ -314,7 +314,11 @@ impl PocketIc {
     /// List all instances and their status.
     #[instrument(ret)]
     pub async fn list_instances() -> Vec<String> {
-        let url = start_or_reuse_server(None).await.join("instances").unwrap();
+        let url = start_or_reuse_server(None)
+            .await
+            .1
+            .join("instances")
+            .unwrap();
         let instances: Vec<String> = reqwest::Client::new()
             .get(url)
             .send()

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -461,7 +461,7 @@ fn time_on_resumed_instance() {
 }
 
 #[tokio::test]
-async fn time_on_killed_instance() {
+async fn killed_instance() {
     let (mut server, server_url) = start_or_reuse_server_impl(None).await;
     let temp_dir = TempDir::new().unwrap();
 

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -447,11 +447,12 @@ fn time_on_resumed_instance() {
     pic.set_certified_time(now.into());
 
     let time = pic.get_time();
+    assert_eq!(time, now.into());
     let state = pic.drop_and_take_state().unwrap();
 
     let pic = PocketIcBuilder::new().with_state(state).build();
 
-    // the time on the resumed instances increases by 2ns:
+    // The time on the resumed instances increases by 2ns:
     // - 1ns due to executing a checkpointed round before dropping the original instance;
     // - 1ns due to bumping time when creating a new instance to ensure strict time monotonicity.
     let resumed_time = pic.get_time();

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -18,8 +18,9 @@ use pocket_ic::{
         BlobCompression, CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse,
         RawEffectivePrincipal, RawMessageId, SubnetKind,
     },
-    query_candid, start_or_reuse_server, update_candid, DefaultEffectiveCanisterIdError, ErrorCode,
-    IngressStatusResult, PocketIc, PocketIcBuilder, PocketIcState, RejectCode, Time,
+    query_candid, start_or_reuse_server, start_or_reuse_server_impl, update_candid,
+    DefaultEffectiveCanisterIdError, ErrorCode, IngressStatusResult, PocketIc, PocketIcBuilder,
+    PocketIcState, RejectCode, Time,
 };
 use reqwest::blocking::Client;
 use reqwest::header::CONTENT_LENGTH;
@@ -461,7 +462,7 @@ fn time_on_resumed_instance() {
 
 #[tokio::test]
 async fn time_on_killed_instance() {
-    let (mut server, server_url) = start_or_reuse_server(None).await;
+    let (mut server, server_url) = start_or_reuse_server_impl(None).await;
     let temp_dir = TempDir::new().unwrap();
 
     let state = PocketIcState::new_from_path(temp_dir.path().to_path_buf());
@@ -3224,7 +3225,7 @@ async fn with_all_icp_features_and_nns_subnet_state() {
         .unwrap()
         .into();
 
-    let url = start_or_reuse_server(None).await.1;
+    let url = start_or_reuse_server(None).await;
     let client = reqwest::Client::new();
     let instance_config = InstanceConfig {
         subnet_config_set: ExtendedSubnetConfigSet {

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -501,6 +501,9 @@ async fn killed_instance() {
     assert!(!pic.canister_exists(another_canister_id).await);
     let resumed_time = pic.get_time().await;
     assert!(resumed_time < now.into());
+
+    // Drop instance explicitly to prevent data races in the StateManager.
+    pic.drop().await;
 }
 
 #[test]


### PR DESCRIPTION
This PR makes PocketIC able to recover from a state directory after being killed:
- the time is loaded from the latest state (checkpoint) instead of PocketIC metadata (which might not be updated due to a crash);
- PocketIC metadata (topology) is eagerly stored on disk after every topology change (subnet creation).