### PR TITLE
chore: Remove unused orchestrator test dep

### DIFF
--- a/rs/orchestrator/BUILD.bazel
+++ b/rs/orchestrator/BUILD.bazel
@@ -110,7 +110,6 @@ rust_test(
         "//rs/test_utilities/in_memory_logger",
         "//rs/test_utilities/logger",
         "//rs/test_utilities/registry",
-        "//rs/test_utilities/time",
         "//rs/test_utilities/types",
         "@crate_index//:mockall",
     ],


### PR DESCRIPTION
The `ic_test_utilities_time` crate wasn't used.