### PR TITLE
Allow JSON dump of the topology in ic-prep tool

### DIFF
--- a/rs/prep/src/bin/prep.rs
+++ b/rs/prep/src/bin/prep.rs
@@ -163,6 +163,10 @@ struct CliArgs {
     /// commas. Port 8080 is always included.
     #[clap(long)]
     whitelisted_ports: Option<String>,
+
+    /// If true, the registry will be printed as JSON (along with protobuf).
+    #[clap(long)]
+    topology_as_json: bool,
 }
 
 fn main() -> Result<()> {
@@ -246,7 +250,7 @@ fn main() -> Result<()> {
         None => ic_config0,
     };
 
-    let _ = ic_config.initialize()?;
+    let _ = ic_config.initialize(valid_args.topology_as_json)?;
     Ok(())
 }
 
@@ -274,6 +278,7 @@ struct ValidatedArgs {
     pub use_specified_ids_allocation_range: bool,
     pub whitelisted_prefixes: Option<String>,
     pub whitelisted_ports: Option<String>,
+    pub topology_as_json: bool,
 }
 
 impl CliArgs {
@@ -418,6 +423,7 @@ impl CliArgs {
             use_specified_ids_allocation_range: self.use_specified_ids_allocation_range,
             whitelisted_prefixes: self.whitelisted_prefixes,
             whitelisted_ports: self.whitelisted_ports,
+            topology_as_json: self.topology_as_json,
         })
     }
 }

--- a/rs/prep/src/initialized_subnet.rs
+++ b/rs/prep/src/initialized_subnet.rs
@@ -15,6 +15,7 @@ use ic_registry_keys::{
 };
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_types::{subnet_id_into_protobuf, RegistryVersion, SubnetId};
+use serde::Serialize;
 
 use crate::{node::InitializedNode, util::write_registry_entry};
 use crate::{
@@ -24,7 +25,7 @@ use crate::{
 
 /// Represents a subnet for which all initial state (node crypto keys, initial
 /// dkg transcript) was generated.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct InitializedSubnet {
     pub subnet_index: u64,
 

--- a/rs/prep/src/node.rs
+++ b/rs/prep/src/node.rs
@@ -40,7 +40,7 @@ const STATE_DIR: &str = "state";
 pub type SubnetIndex = u64;
 pub type NodeIndex = u64;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct InitializedNode {
     pub node_id: NodeId,
 

--- a/rs/prep/src/subnet_configuration.rs
+++ b/rs/prep/src/subnet_configuration.rs
@@ -35,12 +35,12 @@ use ic_types::{
     },
     Height, NodeId, PrincipalId, ReplicaVersion, SubnetId,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub type SubnetIndex = u64;
 
-#[derive(Copy, Clone, PartialEq, Debug, Default, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Deserialize, Serialize)]
 pub enum SubnetRunningState {
     #[default]
     Active,
@@ -49,7 +49,7 @@ pub enum SubnetRunningState {
 
 /// This represents the initial configuration of an NNS subnetwork of an IC
 /// instance.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Serialize)]
 pub struct SubnetConfig {
     /// The subnet id of this subnetwork.
     pub subnet_index: SubnetIndex,


### PR DESCRIPTION
# Summary
Allow ic-prep tool to dump the topology as JSON.
This is required for UTOPIA tools to easily extract certain records.

# Test
```
~/dfinity/ic/target/debug/ic-prep --working-dir /tmp/mine --allow-empty-update-image --require-node-provider-key  --node idx:0,subnet_idx:0,xnet_api:\"[2001:beef::fe01]:2497\",public_api:\"[2001:beef::fe01]:8080\",node_operator_principal_id:\"6zcr2-ixu5h-z3pir-agiys-fgwvk-zuvf4-uxng7-pwc4l-bcocb-y3wph-vqe\" --topology-as-json
```

#test