### PR TITLE
feat(nns): Keep the voting power spike detection when the snapshots are not full

### DIFF
--- a/rs/nns/governance/src/governance/voting_power_snapshots.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots.rs
@@ -159,12 +159,14 @@ impl VotingPowerSnapshots {
         total_potential_voting_power: u64,
         now_seconds: TimestampSeconds,
     ) -> Option<(TimestampSeconds, VotingPowerSnapshot)> {
-        // Step 1: check if there are enough snapshots to detect a spike.
-        if self.voting_power_totals.len() < MAX_VOTING_POWER_SNAPSHOTS {
+        // Step 0: skip the check in test mode when the snapshots are not yet full. Otherwise it
+        // would be difficult to get around the spike detection in tests, and a lot of test setups
+        // involve creating a lot of voting power.
+        if cfg!(feature = "test") && self.voting_power_totals.len() < MAX_VOTING_POWER_SNAPSHOTS {
             return None;
         }
 
-        // Step 2: find the voting power totals entry with the minimum total potential voting power,
+        // Step 1: find the voting power totals entry with the minimum total potential voting power,
         // if a spike is detected.
         let Some((
             timestamp_with_minimum_total_potential_voting_power,
@@ -181,7 +183,7 @@ impl VotingPowerSnapshots {
             return None;
         };
 
-        // Step 3: find the voting power map for the timestamp with the minimum potential voting power.
+        // Step 2: find the voting power map for the timestamp with the minimum potential voting power.
         let Some(voting_power_map) = self
             .neuron_id_to_voting_power_maps
             .get(&timestamp_with_minimum_total_potential_voting_power)
@@ -194,7 +196,7 @@ impl VotingPowerSnapshots {
             return None;
         };
 
-        // Step 4: returns one of the previous voting power maps (with minimum total potential
+        // Step 3: returns one of the previous voting power maps (with minimum total potential
         // voting power) since a voting power spike is detected.
         let previous_voting_power_snapshot = VotingPowerSnapshot::from((
             voting_power_map,

--- a/rs/nns/governance/src/governance/voting_power_snapshots_tests.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots_tests.rs
@@ -47,6 +47,22 @@ fn test_record_voting_power_snapshot() {
 
     for i in 0..6 {
         let timestamp_seconds = 2 + i;
+
+        let use_previous_ballots = snapshots
+            .previous_ballots_if_voting_power_spike_detected(u64::MAX, timestamp_seconds)
+            .is_some();
+
+        if cfg!(feature = "test") {
+            // In the test environment, we do not use previous ballots when the snapshots are not full,
+            // since a lot of test setups involve creating a lot of voting power.
+            assert!(!use_previous_ballots);
+        } else {
+            // In the production environment, we use previous ballots as long as there is at least one
+            // snapshot, so that when we recover from a false positive (by removing some snapshots), we
+            // can still have the spike detection mechanism in place.
+            assert!(use_previous_ballots);
+        }
+
         // The minimum voting power in the snapshots is still 100 over the next 6
         snapshots.record_voting_power_snapshot(
             timestamp_seconds,

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,6 +9,9 @@ on the process that this file is part of, see
 
 ## Added
 
+* Minor improvement on voting power spike detection mechanism - the mechanism is kept in place even
+  when the voting power snapshot is not full.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
# Why

If the voting power spike detection mechanism has a false positive, we will need to remove most of the voting power snapshots so that new voting power will be considered normal. In that case, we don't want the detection mechanism to be inactive, which would be the case if we only detect spikes if the voting power snapshots are full. The "fullness" check was added to get around the check in tests, but as @andrew-lee-work pointed out, we can limit the check for tests.

# What

In production code, do not skip the voting power spike detection when the snapshots are not full.
