### PR TITLE
feat(nns): Add a staleness metric for voting power snapshots

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -148,10 +148,24 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  voting_power_snapshots_is_latest_snapshot_a_spike:
+  voting_power_snapshots_is_latest_snapshot_a_spike_false:
     total:
       calls: 1
-      instructions: 31207
+      instructions: 31190
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  voting_power_snapshots_is_latest_snapshot_a_spike_true:
+    total:
+      calls: 1
+      instructions: 31201
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+  voting_power_snapshots_latest_snapshot_timestamp_seconds:
+    total:
+      calls: 1
+      instructions: 7551
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rs/nns/governance/src/governance/voting_power_snapshots_benches.rs
+++ b/rs/nns/governance/src/governance/voting_power_snapshots_benches.rs
@@ -7,23 +7,59 @@ use ic_stable_structures::{
 };
 use std::collections::HashMap;
 
-#[bench(raw)]
-fn voting_power_snapshots_is_latest_snapshot_a_spike() -> BenchResult {
+fn set_up_snapshots() -> VotingPowerSnapshots {
     let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
-    let mut snapshots = VotingPowerSnapshots::new(
+    VotingPowerSnapshots::new(
         memory_manager.get(MemoryId::new(0)),
         memory_manager.get(MemoryId::new(1)),
-    );
+    )
+}
 
-    let voting_power_map: HashMap<u64, u64> = (0..100_000).map(|i| (i, 1)).collect();
+fn populate_snapshots(snapshots: &mut VotingPowerSnapshots, num_neurons: u64) {
+    let voting_power_map: HashMap<u64, u64> = (0..num_neurons).map(|i| (i, 1)).collect();
     for i in 0..MAX_VOTING_POWER_SNAPSHOTS {
         snapshots.record_voting_power_snapshot(
             i,
-            VotingPowerSnapshot::new_for_test(voting_power_map.clone(), 100_000),
+            VotingPowerSnapshot::new_for_test(voting_power_map.clone(), num_neurons),
         );
     }
+}
+
+// The following benchmarks make sure that more neurons does not cause the tested functionality
+// (based on voting power snapshots) to cost more.
+
+#[bench(raw)]
+fn voting_power_snapshots_is_latest_snapshot_a_spike_false() -> BenchResult {
+    let mut snapshots = set_up_snapshots();
+    populate_snapshots(&mut snapshots, 100_000);
 
     bench_fn(|| {
         snapshots.is_latest_snapshot_a_spike(MAX_VOTING_POWER_SNAPSHOTS);
+    })
+}
+
+#[bench(raw)]
+fn voting_power_snapshots_is_latest_snapshot_a_spike_true() -> BenchResult {
+    let mut snapshots = set_up_snapshots();
+    populate_snapshots(&mut snapshots, 100_000);
+
+    let voting_power_map_spike = (0..200_000).map(|i| (i, 1)).collect();
+    snapshots.record_voting_power_snapshot(
+        MAX_VOTING_POWER_SNAPSHOTS - 1,
+        VotingPowerSnapshot::new_for_test(voting_power_map_spike, 200_000),
+    );
+
+    bench_fn(|| {
+        snapshots.is_latest_snapshot_a_spike(MAX_VOTING_POWER_SNAPSHOTS);
+    })
+}
+
+#[bench(raw)]
+fn voting_power_snapshots_latest_snapshot_timestamp_seconds() -> BenchResult {
+    let mut snapshots = set_up_snapshots();
+    populate_snapshots(&mut snapshots, 100_000);
+
+    bench_fn(|| {
+        snapshots.latest_snapshot_timestamp_seconds();
     })
 }

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,6 +9,8 @@ on the process that this file is part of, see
 
 ## Added
 
+* Minor improvements on voting power spike detection mechanism.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
# Why

The voting power spike detection mechanism depends on a timer task which takes a snapshot of voting power every day. If the timer task fails silently, then the mechanism will not work correctly. Therefore we should be able to detect when the snapshots are getting stale.

# What

Expose a metric `governance_voting_power_snapshots_time_since_latest_snapshot_seconds`