### PR TITLE
chore: force Dell Farm hosts for tecdsa performance tests

### DIFF
--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -156,8 +156,10 @@ pub fn setup(env: TestEnv) {
     let key_ids = make_key_ids();
     info!(env.logger(), "Running the test with key ids: {:?}", key_ids);
 
+    let required_host_features = vec![HostFeature::Performance, HostFeature::Dell];
+
     PrometheusVm::default()
-        .with_required_host_features(vec![HostFeature::Performance])
+        .with_required_host_features(required_host_features.clone())
         .start(&env)
         .expect("Failed to start prometheus VM");
 
@@ -168,7 +170,7 @@ pub fn setup(env: TestEnv) {
     };
 
     InternetComputer::new()
-        .with_required_host_features(vec![HostFeature::Performance])
+        .with_required_host_features(required_host_features)
         .add_subnet(
             Subnet::new(SubnetType::System)
                 .with_default_vm_resources(vm_resources)


### PR DESCRIPTION
At the moment we use two models of performance Farm hosts in our dm1 DC: Dell (dll) and Supermicro (spm). These models have different performance characteristics so it's important that we target a specific model when running a performance system-test. So this configures all the `//rs/tests/consensus/tecdsa:..._performance_test` to use Dell hosts.

Unfortunately, at the moment, we only have 20 Dell Farm hosts in dm1 which is not enough to run the `tecdsa_performance_test` since it requires 27 hosts. So we'll keep this in draft until we've added more Dell hosts.