### PR TITLE
Set DKG interval to 20 in Subnet recovery tests

### DIFF
--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -75,7 +75,7 @@ use std::{io::Read, time::Duration};
 use std::{io::Write, path::Path};
 use url::Url;
 
-const DKG_INTERVAL: u64 = 14;
+const DKG_INTERVAL: u64 = 20;
 const NNS_NODES: usize = 4;
 const APP_NODES: usize = 4;
 const UNASSIGNED_NODES: usize = 4;


### PR DESCRIPTION
This PR sets the DKG interval in (small) recovery tests to 20, to make them less flaky.