### PR TITLE
test(node): reenable hostos_upgrade_from_latest_release_to_current

### DIFF
--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -124,7 +124,7 @@ system_test_nns(
     },
     extra_head_nns_tags = [],
     flaky = True,  # flakiness rate of 5% over the month from 2025-02-11 till 2025-03-11.
-    tags = ["manual"],  # TODO: remove after next release that includes the deployment.json changes
+    tags = ["long_test"],
     test_driver_target = ":hostos_upgrade_test_bin",
     test_timeout = "eternal",
     use_empty_image = True,


### PR DESCRIPTION
Reverts: https://github.com/dfinity/ic/pull/5722

Test was temporarily broken. It's now fixed again 👍 