### PR TITLE
feat: support for external mainnet canisters in the bazel workspace

### DIFF
--- a/.github/workflows/update-mainnet-revisions.yaml
+++ b/.github/workflows/update-mainnet-revisions.yaml
@@ -49,6 +49,8 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:02165696a5201b1a347a28e548c32dc9590d60975c22be26ac1ea7e72573523d
       options: >-
         -e NODE_NAME --privileged --cgroupns host -v /var/sysimage:/var/sysimage -v /var/tmp:/var/tmp -v /ceph-s3-info:/ceph-s3-info
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22375,6 +22375,7 @@ dependencies = [
  "ic-nervous-system-common-test-keys",
  "ic-nns-common",
  "ic-nns-constants",
+ "reqwest 0.12.15",
  "rgb",
  "serde",
  "serde_json",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -49,6 +49,7 @@ canisters(
         "sns_archive": "ic-icrc1-archive.wasm.gz",
         "sns_index": "ic-icrc1-index-ng.wasm.gz",
         "node-rewards": "node-rewards-canister.wasm.gz",
+        "cycles_ledger": "cycles-ledger.wasm.gz",
     },
     path = "//:mainnet-canister-revisions.json",
     reponames = {
@@ -84,6 +85,10 @@ canisters(
         "sns_archive": "mainnet_ic-icrc1-archive",
         "sns_index": "mainnet_ic-icrc1-index-ng",
         "node-rewards": "mainnet_node-rewards-canister",
+        "cycles_ledger": "mainnet_cycles_ledger_canister",
+    },
+    repositories = {
+        "cycles_ledger": "dfinity/cycles-ledger",
     },
 )
 

--- a/bazel/mainnet-canisters.bzl
+++ b/bazel/mainnet-canisters.bzl
@@ -7,6 +7,7 @@ The repository contains the canister module.
 
 def _canisters_impl(repository_ctx):
     reponames = dict(repository_ctx.attr.reponames)
+    repositories = dict(repository_ctx.attr.repositories)
     filenames = dict(repository_ctx.attr.filenames)
 
     # Read and decode mainnet canister data
@@ -27,7 +28,12 @@ def canister_deps():
 
         rev = canisterinfo.get("rev", None)
         if rev == None:
-            fail("no rev for canister: " + canister_key)
+            repository = repositories.pop(canister_key, None)
+            if repository == None:
+                fail("no rev and repository for canister: " + canister_key)
+            tag = canisterinfo.get("tag", None)
+            if tag == None:
+                fail("no rev and tag for canister: " + canister_key)
 
         sha256 = canisterinfo.get("sha256", None)
         if sha256 == None:
@@ -41,22 +47,30 @@ def canister_deps():
         if reponame == None:
             fail("no reponame for canister: " + canister_key)
 
+        if rev == None:
+            url = "https://github.com/{repository}/releases/download/{tag}/{filename}".format(repository = repository, tag = tag, filename = filename)
+        else:
+            url = "https://download.dfinity.systems/ic/{rev}/canisters/{filename}".format(rev = rev, filename = filename)
+
         content += '''
 
     http_file(
         name = "{reponame}",
         downloaded_file_path = "{filename}",
         sha256 = "{sha256}",
-        url = "https://download.dfinity.systems/ic/{rev}/canisters/{filename}",
+        url = "{url}",
 )
 
-        '''.format(rev = rev, filename = filename, sha256 = sha256, reponame = reponame)
+        '''.format(rev = rev, filename = filename, sha256 = sha256, reponame = reponame, url = url)
 
     if len(cans.keys()) != 0:
         fail("unused canisters: " + ", ".join(cans.keys()))
 
     if len(reponames.keys()) != 0:
         fail("unused reponames: " + ", ".join(reponames.keys()))
+
+    if len(repositories.keys()) != 0:
+        fail("unused repositories: " + ", ".join(repositories.keys()))
 
     if len(filenames.keys()) != 0:
         fail("unused filenames: " + ", ".join(filenames.keys()))
@@ -73,9 +87,10 @@ _canisters = repository_rule(
     attrs = {
         "path": attr.label(mandatory = True, doc = "path to mainnet canister data"),
         "reponames": attr.string_dict(mandatory = True, doc = "mapping from canister key to generated Bazel repository name"),
+        "repositories": attr.string_dict(mandatory = True, doc = "mapping from canister key to GitHub repository name"),
         "filenames": attr.string_dict(mandatory = True, doc = "mapping from canister key to filename as per the DFINITY CDN"),
     },
 )
 
-def canisters(name, path, reponames, filenames):
-    _canisters(name = name, path = path, reponames = reponames, filenames = filenames)
+def canisters(name, path, reponames, repositories, filenames):
+    _canisters(name = name, path = path, reponames = reponames, repositories = repositories, filenames = filenames)

--- a/bazel/mainnet-canisters.bzl
+++ b/bazel/mainnet-canisters.bzl
@@ -34,6 +34,9 @@ def canister_deps():
             tag = canisterinfo.get("tag", None)
             if tag == None:
                 fail("no rev and tag for canister: " + canister_key)
+        else:
+            repository = None
+            tag = None
 
         sha256 = canisterinfo.get("sha256", None)
         if sha256 == None:

--- a/mainnet-canister-revisions.json
+++ b/mainnet-canister-revisions.json
@@ -63,6 +63,10 @@
     "rev": "250daf4dd0cf7ea74c496b45457dd47ced16368c",
     "sha256": "28df08368379862ee17f69542b0779670deec200a08f23540c3e6168c07cc9aa"
   },
+  "cycles_ledger": {
+    "sha256": "a2a0c65a94559aed373801a149bf4a31b176cb8cbabf77465eb25143ae880f37",
+    "tag": "cycles-ledger-v1.0.5"
+  },
   "genesis-token": {
     "rev": "02571e8215fa3e77da791e693cc238b2de3beae9",
     "sha256": "f897870b7b6d6c15f657496bc731b0e341c34468ddbb8fa0722ec7beb6b51cee"

--- a/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/BUILD.bazel
+++ b/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/BUILD.bazel
@@ -17,6 +17,7 @@ DEPENDENCIES = [
     "@crate_index//:futures",
     "@crate_index//:ic-agent",
     "@crate_index//:ic-wasm__ic-wasm",
+    "@crate_index//:reqwest",
     "@crate_index//:rgb",
     "@crate_index//:serde",
     "@crate_index//:serde_json",

--- a/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/Cargo.toml
+++ b/rs/nervous_system/tools/sync-with-released-nervous-system-wasms/Cargo.toml
@@ -22,6 +22,7 @@ ic-nervous-system-clients = { path = "../../clients" }
 ic-nervous-system-common-test-keys = { path = "../../common/test_keys" }
 ic-nns-common = { path = "../../../nns/common" }
 ic-nns-constants = { path = "../../../nns/constants" }
+reqwest = { workspace = true }
 rgb = "0.8.37"
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
This PR adds support for external mainnet canisters in the bazel workspace.

In more detail, this PR
- represents external mainnet canisters by their git tag in the mainnet canister json file;
- updates that git tag automatically using the existing bot for NNS canisters extended to
  - crawl all git tags of the corresponding (hard-coded) external repository (e.g., `dfinity/cycles-ledger`);
  - for every git tag, list all release assets;
  - look for a release asset whose name has the form `{canister_name}.sha256` where `canister_name` is hard-coded (e.g., `cycles-ledger.wasm.gz`);
  - if that release asset starts with the expected module hash of the external canister (as fetched from the ICP mainnet using an IC agent), then the corresponding tag is updated in the mainnet canister json file;
- uses `GITHUB_TOKEN` to prevent rate-limiting;
- adds the mainnet cycles ledger canister to demonstrate how external mainnet canisters are handled.

This PR has been tested manually by changing the module hash and tag of the mainnet cycles ledger canister in the json file and running `bazel run //rs/nervous_system/tools/sync-with-released-nervous-system-wasms` to confirm that the json file is properly regenerated.

Follow up improvements of the NNS bot are tracked in this [ticket](https://dfinity.atlassian.net/browse/NNS1-3981).