### PR TITLE
fix: new memory bytes if no change of memory allocation is requested

### DIFF
--- a/rs/execution_environment/src/canister_settings.rs
+++ b/rs/execution_environment/src/canister_settings.rs
@@ -455,7 +455,7 @@ pub(crate) fn validate_canister_settings(
 ) -> Result<ValidatedCanisterSettings, CanisterManagerError> {
     let old_memory_bytes = canister_memory_allocation.allocated_bytes(canister_memory_usage);
     let new_memory_bytes = match settings.memory_allocation {
-        None => canister_memory_usage,
+        None => old_memory_bytes,
         Some(new_memory_allocation) => {
             // The new memory allocation cannot be lower than the current canister
             // memory usage.


### PR DESCRIPTION
If the memory allocation field in canister settings is `None`, then the memory allocation does not change and thus the new memory bytes should be equal to the old memory bytes (instead of the actual memory usage which is only accurate if the canister has best-effort memory allocation).

Given how the value of `new_memory_bytes` is used, this fix does not change the current behavior of canister settings validation. But it still makes sense to fix the value to make the code more robust for future refactorings.

Justification.
- For canisters with best-effort memory allocation, this PR does not change the value of `new_memory_bytes`.
- For canisters with reserved memory allocation and memory usage not exceeding the reserved memory allocation, this PR increases the value of `new_memory_bytes` and `new_memory_bytes` becomes equal to `old_memory_bytes`. Consequently, the following condition could never be satisfied before this PR and is not satisified after this PR either.
```
    let subnet_available_memory = subnet_available_memory.get_execution_memory().max(0) as u64;
    let subnet_available_memory = subnet_available_memory.saturating_add(old_memory_bytes.get());
    if new_memory_bytes.get() > subnet_available_memory {
        return Err(CanisterManagerError::SubnetMemoryCapacityOverSubscribed {
            requested: new_memory_bytes,
            available: NumBytes::from(subnet_available_memory),
        });
    }
```
The following expression `let allocated_bytes = new_memory_bytes.saturating_sub(&old_memory_bytes);` was equal to zero before this PR and is still equal to zero after this PR.
- For canisters with reserved memory allocation and memory usage exceeding the reserved memory allocation (only supposed to happen due to a bug or due to the canister history memory usage), this PR does not change the value of `new_memory_bytes` (because `old_memory_bytes` is equal to the canister memory usage in this case).