### PR TITLE
fix: mount back ict_testnets dir into the local container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   ],
   "workspaceMount": "source=${localWorkspaceFolder},target=/ic,type=bind",
   "workspaceFolder": "/ic",
-  "initializeCommand": "mkdir -p ~/.aws ~/.ssh ~/.cache/cargo ~/.cache/zig-cache ~/.local/share/fish && touch ~/.zsh_history ~/.bash_history",
+  "initializeCommand": "mkdir -p ~/.aws ~/.ssh ~/.cache/cargo ~/.cache/zig-cache ~/.local/share/fish && touch ~/.zsh_history ~/.bash_history /tmp/ict_testnets",
   "containerEnv": {
     "CARGO_TARGET_DIR": "/home/ubuntu/.cache/cargo",
     "USER": "${localEnv:USER}"
@@ -53,6 +53,11 @@
     {
       "source": "${localEnv:HOME}/.local/share/fish",
       "target": "/home/ubuntu/.local/share/fish",
+      "type": "bind"
+    },
+    {
+      "source": "/tmp/ict_testnets",
+      "target": "/tmp/ict_testnets",
       "type": "bind"
     }
   ],

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -126,7 +126,7 @@ PODMAN_RUN_ARGS+=(
     --mount type=bind,source="${REPO_ROOT}",target="${WORKDIR}"
     --mount type=bind,source="${CACHE_DIR}",target="${CTR_HOME}/.cache"
     --mount type=bind,source="${ZIG_CACHE}",target="/tmp/zig-cache"
-    --mount type=bind,source="${ICT_TESTNETS_DIR}",target="/tmp/ict_testnets"
+    --mount type=bind,source="${ICT_TESTNETS_DIR}",target="${ICT_TESTNETS_DIR}"
     --mount type=bind,source="${HOME}/.ssh",target="${CTR_HOME}/.ssh"
     --mount type=bind,source="${HOME}/.aws",target="${CTR_HOME}/.aws"
     --mount type=bind,source="/var/lib/containers",target="/var/lib/containers"

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -119,10 +119,14 @@ CACHE_DIR="${CACHE_DIR:-${HOME}/.cache}"
 ZIG_CACHE="${CACHE_DIR}/zig-cache"
 mkdir -p "${ZIG_CACHE}"
 
+ICT_TESTNETS_DIR="${ICT_TESTNETS_DIR:-/tmp/ict_testnets}"
+mkdir -p "${ICT_TESTNETS_DIR}"
+
 PODMAN_RUN_ARGS+=(
     --mount type=bind,source="${REPO_ROOT}",target="${WORKDIR}"
     --mount type=bind,source="${CACHE_DIR}",target="${CTR_HOME}/.cache"
     --mount type=bind,source="${ZIG_CACHE}",target="/tmp/zig-cache"
+    --mount type=bind,source="${ICT_TESTNETS_DIR}",target="/tmp/ict_testnets"
     --mount type=bind,source="${HOME}/.ssh",target="${CTR_HOME}/.ssh"
     --mount type=bind,source="${HOME}/.aws",target="${CTR_HOME}/.aws"
     --mount type=bind,source="/var/lib/containers",target="/var/lib/containers"

--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -119,7 +119,7 @@ CACHE_DIR="${CACHE_DIR:-${HOME}/.cache}"
 ZIG_CACHE="${CACHE_DIR}/zig-cache"
 mkdir -p "${ZIG_CACHE}"
 
-ICT_TESTNETS_DIR="${ICT_TESTNETS_DIR:-/tmp/ict_testnets}"
+ICT_TESTNETS_DIR="/tmp/ict_testnets"
 mkdir -p "${ICT_TESTNETS_DIR}"
 
 PODMAN_RUN_ARGS+=(


### PR DESCRIPTION
Previously we used to mount the whole `/tmp` dir into the container image which was pretty convenient for sharing files among containers. after #5601 we stopped doing that because it conflicts with other requirements. 

This PR mounts back at least `/tmp/ict_testnets` which is used as default dir for ict log output.