### PR TITLE
feat(sns): add `Root.register_extension`

### DIFF
--- a/rs/sns/root/canister/canister.rs
+++ b/rs/sns/root/canister/canister.rs
@@ -19,6 +19,7 @@ use ic_nervous_system_proto::pb::v1::{
 };
 use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nervous_system_runtime::{CdkRuntime, Runtime};
+use ic_sns_root::pb::v1::{RegisterExtensionRequest, RegisterExtensionResponse};
 use ic_sns_root::{
     logs::{ERROR, INFO},
     pb::v1::{
@@ -246,6 +247,27 @@ fn change_canister(request: ChangeCanisterRequest) {
             }
         };
     });
+}
+
+#[candid_method(update)]
+#[update]
+async fn register_extension(request: RegisterExtensionRequest) -> RegisterExtensionResponse {
+    log!(INFO, "register_extension");
+    assert_eq_governance_canister_id(PrincipalId(ic_cdk::api::caller()));
+
+    let canister_id = request.try_into()?;
+
+    let root_canister_id = PrincipalId(ic_cdk::api::id());
+
+    let result = SnsRootCanister::register_extension(
+        &STATE,
+        &ManagementCanisterClientImpl::<CanisterRuntime>::new(None),
+        root_canister_id,
+        canister_id,
+    )
+    .await;
+
+    RegisterExtensionResponse::from(result)
 }
 
 /// This function is deprecated, and `register_dapp_canisters` should be used

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -137,6 +137,15 @@ type ManageDappCanisterSettingsResponse = record {
   failure_reason : opt text;
 };
 
+type RegisterExtensionRequest = record {
+  canister_id : opt principal;
+};
+
+type RegisterExtensionResponse = variant {
+  Ok : record {};
+  Err : CanisterCallError;
+};
+
 type RegisterDappCanisterRequest = record {
   canister_id : opt principal;
 };
@@ -186,6 +195,7 @@ service : (SnsRootCanister) -> {
   manage_dapp_canister_settings : (ManageDappCanisterSettingsRequest) -> (
       ManageDappCanisterSettingsResponse,
     );
+  register_extension : (RegisterExtensionRequest) -> (RegisterExtensionResponse);
   register_dapp_canister : (RegisterDappCanisterRequest) -> (record {});
   register_dapp_canisters : (RegisterDappCanistersRequest) -> (record {});
   set_dapp_controllers : (SetDappControllersRequest) -> (

--- a/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
+++ b/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
@@ -26,6 +26,9 @@ message SnsRootCanister {
   // Dapp canister IDs.
   repeated ic_base_types.pb.v1.PrincipalId dapp_canister_ids = 3;
 
+  // Extension canister IDs.
+  repeated ic_base_types.pb.v1.PrincipalId extension_canister_ids = 11;
+
   // Required.
   //
   // The swap canister ID.
@@ -50,6 +53,19 @@ message SnsRootCanister {
 
   // Information about the timers that perform periodic tasks of this Root canister.
   optional ic_nervous_system.pb.v1.Timers timers = 10;
+}
+
+message RegisterExtensionRequest {
+  ic_base_types.pb.v1.PrincipalId canister_id = 1;
+}
+
+message RegisterExtensionResponse {
+  message Ok {}
+
+  oneof result {
+    Ok ok = 1;
+    CanisterCallError err = 2;
+  }
 }
 
 message RegisterDappCanisterRequest {
@@ -108,6 +124,7 @@ message ListSnsCanistersResponse {
   repeated ic_base_types.pb.v1.PrincipalId dapps = 5;
   repeated ic_base_types.pb.v1.PrincipalId archives = 6;
   ic_base_types.pb.v1.PrincipalId index = 7;
+  repeated ic_base_types.pb.v1.PrincipalId extensions = 8;
 }
 
 enum LogVisibility {

--- a/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
+++ b/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
@@ -28,6 +28,9 @@ pub struct SnsRootCanister {
     /// Dapp canister IDs.
     #[prost(message, repeated, tag = "3")]
     pub dapp_canister_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+    /// Extension canister IDs.
+    #[prost(message, repeated, tag = "11")]
+    pub extension_canister_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
     /// Required.
     ///
     /// The swap canister ID.
@@ -48,6 +51,57 @@ pub struct SnsRootCanister {
     /// Information about the timers that perform periodic tasks of this Root canister.
     #[prost(message, optional, tag = "10")]
     pub timers: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Timers>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct RegisterExtensionRequest {
+    #[prost(message, optional, tag = "1")]
+    pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct RegisterExtensionResponse {
+    #[prost(oneof = "register_extension_response::Result", tags = "1, 2")]
+    pub result: ::core::option::Option<register_extension_response::Result>,
+}
+/// Nested message and enum types in `RegisterExtensionResponse`.
+pub mod register_extension_response {
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        Copy,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct Ok {}
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Oneof,
+    )]
+    pub enum Result {
+        #[prost(message, tag = "1")]
+        Ok(Ok),
+        #[prost(message, tag = "2")]
+        Err(super::CanisterCallError),
+    }
 }
 #[derive(
     candid::CandidType,
@@ -210,6 +264,8 @@ pub struct ListSnsCanistersResponse {
     pub archives: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
     #[prost(message, optional, tag = "7")]
     pub index: ::core::option::Option<::ic_base_types::PrincipalId>,
+    #[prost(message, repeated, tag = "8")]
+    pub extensions: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
 }
 #[derive(
     candid::CandidType,


### PR DESCRIPTION
This PR adds a new function `Root.register_extension`, that allows registering SNS extensions. For context, the first SNS extension will be the [SNS Liquidity Pools extension](https://forum.dfinity.org/t/sns-liquidity-pools-design/50439).