### PR TITLE
feat(sns): add `Root.register_extension`

### DIFF
--- a/rs/nervous_system/agent/src/sns/root.rs
+++ b/rs/nervous_system/agent/src/sns/root.rs
@@ -51,7 +51,11 @@ impl TryFrom<ListSnsCanistersResponse> for SnsCanisters {
             archive: archives.into_iter().map(ArchiveCanister::new).collect(),
         };
 
-        Ok(Self { sns, dapps, extensions })
+        Ok(Self {
+            sns,
+            dapps,
+            extensions,
+        })
     }
 }
 

--- a/rs/nervous_system/agent/src/sns/root.rs
+++ b/rs/nervous_system/agent/src/sns/root.rs
@@ -51,6 +51,9 @@ impl TryFrom<ListSnsCanistersResponse> for SnsCanisters {
             archive: archives.into_iter().map(ArchiveCanister::new).collect(),
         };
 
+        let extensions =
+            extensions.map_or_else(Vec::new, |extensions| extensions.extension_canister_ids);
+
         Ok(Self {
             sns,
             dapps,

--- a/rs/nervous_system/agent/src/sns/root.rs
+++ b/rs/nervous_system/agent/src/sns/root.rs
@@ -21,6 +21,7 @@ pub struct RootCanister {
 pub struct SnsCanisters {
     pub sns: Sns,
     pub dapps: Vec<PrincipalId>,
+    pub extensions: Vec<PrincipalId>,
 }
 
 impl TryFrom<ListSnsCanistersResponse> for SnsCanisters {
@@ -35,6 +36,7 @@ impl TryFrom<ListSnsCanistersResponse> for SnsCanisters {
             index: Some(index_canister_id),
             archives,
             dapps,
+            extensions,
         } = src
         else {
             return Err(format!("Some SNS canisters were missing: {:?}", src));
@@ -49,7 +51,7 @@ impl TryFrom<ListSnsCanistersResponse> for SnsCanisters {
             archive: archives.into_iter().map(ArchiveCanister::new).collect(),
         };
 
-        Ok(Self { sns, dapps })
+        Ok(Self { sns, dapps, extensions })
     }
 }
 

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -652,11 +652,15 @@ impl SnsInitPayload {
                 .collect(),
         };
 
+        // TODO: Support specifying extensions at SNS initialization.
+        let extension_canister_ids = vec![];
+
         SnsRootCanister {
             governance_canister_id: Some(sns_canister_ids.governance),
             ledger_canister_id: Some(sns_canister_ids.ledger),
             swap_canister_id: Some(sns_canister_ids.swap),
             dapp_canister_ids,
+            extension_canister_ids,
             archive_canister_ids: vec![],
             index_canister_id: Some(sns_canister_ids.index),
             testflight,

--- a/rs/sns/init/src/lib.rs
+++ b/rs/sns/init/src/lib.rs
@@ -653,14 +653,14 @@ impl SnsInitPayload {
         };
 
         // TODO: Support specifying extensions at SNS initialization.
-        let extension_canister_ids = vec![];
+        let extensions = Some(vec![].into());
 
         SnsRootCanister {
             governance_canister_id: Some(sns_canister_ids.governance),
             ledger_canister_id: Some(sns_canister_ids.ledger),
             swap_canister_id: Some(sns_canister_ids.swap),
             dapp_canister_ids,
-            extension_canister_ids,
+            extensions,
             archive_canister_ids: vec![],
             index_canister_id: Some(sns_canister_ids.index),
             testflight,

--- a/rs/sns/integration_tests/src/root.rs
+++ b/rs/sns/integration_tests/src/root.rs
@@ -13,7 +13,8 @@ use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_nns_test_utils::state_test_helpers::{get_controllers, set_controllers, update_with_sender};
 use ic_sns_root::{
-    pb::v1::SnsRootCanister, GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse,
+    pb::v1::{Extensions, SnsRootCanister},
+    GetSnsCanistersSummaryRequest, GetSnsCanistersSummaryResponse,
 };
 use ic_sns_test_utils::{
     itest_helpers::{
@@ -40,7 +41,9 @@ fn test_get_status() {
                 ledger_canister_id: Some(PrincipalId::new_user_test_id(43)),
                 swap_canister_id: Some(PrincipalId::new_user_test_id(44)),
                 dapp_canister_ids: vec![],
-                extension_canister_ids: vec![],
+                extensions: Some(Extensions {
+                    extension_canister_ids: vec![],
+                }),
                 archive_canister_ids: vec![],
                 index_canister_id: Some(PrincipalId::new_user_test_id(45)),
                 testflight: false,

--- a/rs/sns/integration_tests/src/root.rs
+++ b/rs/sns/integration_tests/src/root.rs
@@ -40,6 +40,7 @@ fn test_get_status() {
                 ledger_canister_id: Some(PrincipalId::new_user_test_id(43)),
                 swap_canister_id: Some(PrincipalId::new_user_test_id(44)),
                 dapp_canister_ids: vec![],
+                extension_canister_ids: vec![],
                 archive_canister_ids: vec![],
                 index_canister_id: Some(PrincipalId::new_user_test_id(45)),
                 testflight: false,

--- a/rs/sns/integration_tests/src/timers.rs
+++ b/rs/sns/integration_tests/src/timers.rs
@@ -6,7 +6,7 @@ use ic_nervous_system_proto::pb::v1::{
 use ic_nns_test_utils::sns_wasm::{build_governance_sns_wasm, build_root_sns_wasm};
 use ic_sns_governance::pb::v1::governance::GovernanceCachedMetrics;
 use ic_sns_governance::{init::GovernanceCanisterInitPayloadBuilder, pb::v1::Governance};
-use ic_sns_root::pb::v1::SnsRootCanister;
+use ic_sns_root::pb::v1::{Extensions, SnsRootCanister};
 use ic_sns_swap::pb::v1::{
     GetStateRequest, GetStateResponse, Init, Lifecycle, NeuronBasketConstructionParameters,
 };
@@ -80,7 +80,9 @@ fn root_init() -> SnsRootCanister {
         index_canister_id: Some(PrincipalId::new_anonymous()),
         archive_canister_ids: vec![],
         dapp_canister_ids: vec![],
-        extension_canister_ids: vec![],
+        extensions: Some(Extensions {
+            extension_canister_ids: vec![],
+        }),
         testflight: false,
         timers: None,
     }

--- a/rs/sns/integration_tests/src/timers.rs
+++ b/rs/sns/integration_tests/src/timers.rs
@@ -80,6 +80,7 @@ fn root_init() -> SnsRootCanister {
         index_canister_id: Some(PrincipalId::new_anonymous()),
         archive_canister_ids: vec![],
         dapp_canister_ids: vec![],
+        extension_canister_ids: vec![],
         testflight: false,
         timers: None,
     }

--- a/rs/sns/root/canister/canister.rs
+++ b/rs/sns/root/canister/canister.rs
@@ -19,6 +19,7 @@ use ic_nervous_system_proto::pb::v1::{
 };
 use ic_nervous_system_root::change_canister::ChangeCanisterRequest;
 use ic_nervous_system_runtime::{CdkRuntime, Runtime};
+use ic_sns_root::pb::v1::{RegisterExtensionRequest, RegisterExtensionResponse};
 use ic_sns_root::{
     logs::{ERROR, INFO},
     pb::v1::{
@@ -246,6 +247,27 @@ fn change_canister(request: ChangeCanisterRequest) {
             }
         };
     });
+}
+
+#[candid_method(update)]
+#[update]
+async fn register_extension(request: RegisterExtensionRequest) -> RegisterExtensionResponse {
+    log!(INFO, "register_extension");
+    assert_eq_governance_canister_id(PrincipalId(ic_cdk::api::caller()));
+
+    let canister_id = request.try_into()?;
+
+    let root_canister_id = PrincipalId(ic_cdk::api::id());
+
+    let result = SnsRootCanister::register_extension(
+        &STATE,
+        &ManagementCanisterClientImpl::<CanisterRuntime>::new(None),
+        root_canister_id,
+        canister_id,
+    )
+    .await;
+
+    RegisterExtensionResponse::from(result)
 }
 
 /// This function is deprecated, and `register_dapp_canisters` should be used

--- a/rs/sns/root/canister/canister.rs
+++ b/rs/sns/root/canister/canister.rs
@@ -204,7 +204,7 @@ fn list_sns_canisters(_request: ListSnsCanistersRequest) -> ListSnsCanistersResp
     STATE.with(|sns_root_canister| {
         sns_root_canister
             .borrow()
-            .list_sns_canisters(ic_cdk::api::id())
+            .list_sns_canisters(PrincipalId(ic_cdk::api::id()))
     })
 }
 
@@ -255,7 +255,12 @@ async fn register_extension(request: RegisterExtensionRequest) -> RegisterExtens
     log!(INFO, "register_extension");
     assert_eq_governance_canister_id(PrincipalId(ic_cdk::api::caller()));
 
-    let canister_id = request.try_into()?;
+    let canister_id = match PrincipalId::try_from(request) {
+        Ok(canister_id) => canister_id,
+        Err(err) => {
+            return RegisterExtensionResponse::from(Err(err));
+        }
+    };
 
     let root_canister_id = PrincipalId(ic_cdk::api::id());
 
@@ -299,7 +304,7 @@ async fn register_dapp_canister(
     let RegisterDappCanistersResponse {} = SnsRootCanister::register_dapp_canisters(
         &STATE,
         &ManagementCanisterClientImpl::<CanisterRuntime>::new(None),
-        ic_cdk::api::id(),
+        PrincipalId(ic_cdk::api::id()),
         request,
     )
     .await;
@@ -326,7 +331,7 @@ async fn register_dapp_canisters(
     SnsRootCanister::register_dapp_canisters(
         &STATE,
         &ManagementCanisterClientImpl::<CanisterRuntime>::new(None),
-        ic_cdk::api::id(),
+        PrincipalId(ic_cdk::api::id()),
         request,
     )
     .await
@@ -355,7 +360,7 @@ async fn set_dapp_controllers(request: SetDappControllersRequest) -> SetDappCont
     SnsRootCanister::set_dapp_controllers(
         &STATE,
         &ManagementCanisterClientImpl::<CanisterRuntime>::new(None),
-        ic_cdk::api::id(),
+        PrincipalId(ic_cdk::api::id()),
         PrincipalId(ic_cdk::api::caller()),
         &request,
     )

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -113,7 +113,7 @@ type ListSnsCanistersResponse = record {
   index : opt principal;
   governance : opt principal;
   dapps : vec principal;
-  extensions : vec principal;
+  extensions : opt Extensions;
   archives : vec principal;
 };
 
@@ -168,9 +168,13 @@ type SetDappControllersResponse = record {
   failed_updates : vec FailedUpdate;
 };
 
+type Extensions = record {
+  extension_canister_ids : vec principal;
+};
+
 type SnsRootCanister = record {
   dapp_canister_ids : vec principal;
-  extension_canister_ids : vec principal;
+  extensions : opt Extensions;
   testflight : bool;
   archive_canister_ids : vec principal;
   governance_canister_id : opt principal;

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -137,6 +137,15 @@ type ManageDappCanisterSettingsResponse = record {
   failure_reason : opt text;
 };
 
+type RegisterExtensionRequest = record {
+  canister_id : opt principal;
+};
+
+type RegisterExtensionResponse = variant {
+  Ok : record {};
+  Err : CanisterCallError;
+};
+
 type RegisterDappCanisterRequest = record {
   canister_id : opt principal;
 };
@@ -186,6 +195,7 @@ service : (SnsRootCanister) -> {
   manage_dapp_canister_settings : (ManageDappCanisterSettingsRequest) -> (
       ManageDappCanisterSettingsResponse,
     );
+  register_extension : (RegisterExtensionRequest) -> (RegisterExtensionResponse);
   register_dapp_canister : (RegisterDappCanisterRequest) -> (record {});
   register_dapp_canisters : (RegisterDappCanistersRequest) -> (record {});
   set_dapp_controllers : (SetDappControllersRequest) -> (

--- a/rs/sns/root/canister/root.did
+++ b/rs/sns/root/canister/root.did
@@ -113,6 +113,7 @@ type ListSnsCanistersResponse = record {
   index : opt principal;
   governance : opt principal;
   dapps : vec principal;
+  extensions : vec principal;
   archives : vec principal;
 };
 
@@ -141,9 +142,13 @@ type RegisterExtensionRequest = record {
   canister_id : opt principal;
 };
 
-type RegisterExtensionResponse = variant {
+type RegisterExtensionResult = variant {
   Ok : record {};
   Err : CanisterCallError;
+};
+
+type RegisterExtensionResponse = record {
+  result : opt RegisterExtensionResult;
 };
 
 type RegisterDappCanisterRequest = record {
@@ -165,6 +170,7 @@ type SetDappControllersResponse = record {
 
 type SnsRootCanister = record {
   dapp_canister_ids : vec principal;
+  extension_canister_ids : vec principal;
   testflight : bool;
   archive_canister_ids : vec principal;
   governance_canister_id : opt principal;

--- a/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
+++ b/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
@@ -27,7 +27,7 @@ message SnsRootCanister {
   repeated ic_base_types.pb.v1.PrincipalId dapp_canister_ids = 3;
 
   // Extension canister IDs.
-  repeated ic_base_types.pb.v1.PrincipalId extension_canister_ids = 11;
+  optional Extensions extensions = 11;
 
   // Required.
   //
@@ -113,6 +113,10 @@ message ListSnsCanistersRequest {
   // This struct intentionally left blank (for now).
 }
 
+message Extensions {
+  repeated ic_base_types.pb.v1.PrincipalId extension_canister_ids = 1;
+}
+
 // Response struct for the ListSnsCanisters API on the
 // SNS Root canister. ListSnsCanisters will return Principals
 // of all the associated canisters in an SNS.
@@ -124,7 +128,7 @@ message ListSnsCanistersResponse {
   repeated ic_base_types.pb.v1.PrincipalId dapps = 5;
   repeated ic_base_types.pb.v1.PrincipalId archives = 6;
   ic_base_types.pb.v1.PrincipalId index = 7;
-  repeated ic_base_types.pb.v1.PrincipalId extensions = 8;
+  optional Extensions extensions = 8;
 }
 
 enum LogVisibility {

--- a/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
+++ b/rs/sns/root/proto/ic_sns_root/pb/v1/root.proto
@@ -26,6 +26,9 @@ message SnsRootCanister {
   // Dapp canister IDs.
   repeated ic_base_types.pb.v1.PrincipalId dapp_canister_ids = 3;
 
+  // Extension canister IDs.
+  repeated ic_base_types.pb.v1.PrincipalId extension_canister_ids = 11;
+
   // Required.
   //
   // The swap canister ID.
@@ -50,6 +53,19 @@ message SnsRootCanister {
 
   // Information about the timers that perform periodic tasks of this Root canister.
   optional ic_nervous_system.pb.v1.Timers timers = 10;
+}
+
+message RegisterExtensionRequest {
+  ic_base_types.pb.v1.PrincipalId canister_id = 1;
+}
+
+message RegisterExtensionResponse {
+  message Ok {}
+
+  oneof result {
+    Ok ok = 1;
+    CanisterCallError err = 2;
+  }
 }
 
 message RegisterDappCanisterRequest {
@@ -108,6 +124,7 @@ message ListSnsCanistersResponse {
   repeated ic_base_types.pb.v1.PrincipalId dapps = 5;
   repeated ic_base_types.pb.v1.PrincipalId archives = 6;
   ic_base_types.pb.v1.PrincipalId index = 7;
+  repeated ic_base_types.pb.v1.PrincipalId extensions = 8;
 }
 
 enum LogVisibility {

--- a/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
+++ b/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
@@ -28,6 +28,9 @@ pub struct SnsRootCanister {
     /// Dapp canister IDs.
     #[prost(message, repeated, tag = "3")]
     pub dapp_canister_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+    /// Extension canister IDs.
+    #[prost(message, repeated, tag = "11")]
+    pub extension_canister_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
     /// Required.
     ///
     /// The swap canister ID.
@@ -48,6 +51,57 @@ pub struct SnsRootCanister {
     /// Information about the timers that perform periodic tasks of this Root canister.
     #[prost(message, optional, tag = "10")]
     pub timers: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Timers>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct RegisterExtensionRequest {
+    #[prost(message, optional, tag = "1")]
+    pub canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct RegisterExtensionResponse {
+    #[prost(oneof = "register_extension_response::Result", tags = "1, 2")]
+    pub result: ::core::option::Option<register_extension_response::Result>,
+}
+/// Nested message and enum types in `RegisterExtensionResponse`.
+pub mod register_extension_response {
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        Copy,
+        PartialEq,
+        ::prost::Message,
+    )]
+    pub struct Ok {}
+    #[derive(
+        candid::CandidType,
+        candid::Deserialize,
+        comparable::Comparable,
+        Clone,
+        PartialEq,
+        ::prost::Oneof,
+    )]
+    pub enum Result {
+        #[prost(message, tag = "1")]
+        Ok(Ok),
+        #[prost(message, tag = "2")]
+        Err(super::CanisterCallError),
+    }
 }
 #[derive(
     candid::CandidType,
@@ -210,6 +264,8 @@ pub struct ListSnsCanistersResponse {
     pub archives: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
     #[prost(message, optional, tag = "7")]
     pub index: ::core::option::Option<::ic_base_types::PrincipalId>,
+    #[prost(message, repeated, tag = "8")]
+    pub extensions: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
 }
 #[derive(
     candid::CandidType,

--- a/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
+++ b/rs/sns/root/src/gen/ic_sns_root.pb.v1.rs
@@ -29,8 +29,8 @@ pub struct SnsRootCanister {
     #[prost(message, repeated, tag = "3")]
     pub dapp_canister_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
     /// Extension canister IDs.
-    #[prost(message, repeated, tag = "11")]
-    pub extension_canister_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+    #[prost(message, optional, tag = "11")]
+    pub extensions: ::core::option::Option<Extensions>,
     /// Required.
     ///
     /// The swap canister ID.
@@ -238,6 +238,18 @@ pub struct CanisterCallError {
     ::prost::Message,
 )]
 pub struct ListSnsCanistersRequest {}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct Extensions {
+    #[prost(message, repeated, tag = "1")]
+    pub extension_canister_ids: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+}
 /// Response struct for the ListSnsCanisters API on the
 /// SNS Root canister. ListSnsCanisters will return Principals
 /// of all the associated canisters in an SNS.
@@ -264,8 +276,8 @@ pub struct ListSnsCanistersResponse {
     pub archives: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
     #[prost(message, optional, tag = "7")]
     pub index: ::core::option::Option<::ic_base_types::PrincipalId>,
-    #[prost(message, repeated, tag = "8")]
-    pub extensions: ::prost::alloc::vec::Vec<::ic_base_types::PrincipalId>,
+    #[prost(message, optional, tag = "8")]
+    pub extensions: ::core::option::Option<Extensions>,
 }
 #[derive(
     candid::CandidType,

--- a/rs/sns/root/src/lib.rs
+++ b/rs/sns/root/src/lib.rs
@@ -457,7 +457,7 @@ impl SnsRootCanister {
         let mut errors = Vec::new();
 
         for canister_to_register in canisters_to_register {
-            let result = Self::register_canister(
+            let result = Self::register_dapp_canister(
                 self_ref,
                 management_canister_client,
                 root_canister_id,
@@ -606,7 +606,7 @@ impl SnsRootCanister {
     }
 
     /// Register a single canister.
-    async fn register_canister(
+    async fn register_dapp_canister(
         self_ref: &'static LocalKey<RefCell<SnsRootCanister>>,
         management_canister_client: &impl ManagementCanisterClient,
         root_canister_id: PrincipalId,
@@ -686,10 +686,9 @@ impl SnsRootCanister {
             }
         }
         // Add canister_to_register to self.dapp_canister_ids.
-        self_ref.with(|s| {
-            let mut s = s.borrow_mut();
+        self_ref.with_borrow_mut(|state| {
             let canister_to_register = PrincipalId::from(canister_to_register);
-            s.dapp_canister_ids.push(canister_to_register);
+            state.dapp_canister_ids.push(canister_to_register);
         });
         Ok(())
     }

--- a/rs/sns/root/src/types.rs
+++ b/rs/sns/root/src/types.rs
@@ -5,7 +5,7 @@ use ic_base_types::{CanisterId, PrincipalId};
 use serde::{Deserialize, Serialize};
 
 use crate::pb::v1::{
-    register_extension_response, CanisterCallError, RegisterExtensionRequest,
+    register_extension_response, CanisterCallError, Extensions, RegisterExtensionRequest,
     RegisterExtensionResponse,
 };
 
@@ -98,6 +98,20 @@ impl From<Result<(), CanisterCallError>> for RegisterExtensionResponse {
             Err(err) => RegisterExtensionResponse {
                 result: Some(Result::Err(err)),
             },
+        }
+    }
+}
+
+// impl Default for Extensions {
+//     fn default() -> Self {
+//         Self { extension_canister_ids: vec![] }
+//     }
+// }
+
+impl From<Vec<PrincipalId>> for Extensions {
+    fn from(extension_canister_ids: Vec<PrincipalId>) -> Self {
+        Self {
+            extension_canister_ids,
         }
     }
 }

--- a/rs/sns/root/src/types.rs
+++ b/rs/sns/root/src/types.rs
@@ -27,10 +27,7 @@ pub trait Environment: Send + Sync {
         canister_id: CanisterId,
         method_name: &str,
         arg: Vec<u8>,
-    ) -> get_open_ticket_response::Result<
-        /* reply: */ Vec<u8>,
-        (/* error_code: */ i32, /* message: */ String),
-    >;
+    ) -> Result</* reply: */ Vec<u8>, (/* error_code: */ i32, /* message: */ String)>;
 }
 
 /// Different from the SnsCanisterType in SNS-W because it includes Dap
@@ -59,6 +56,19 @@ impl Display for SnsCanisterType {
     }
 }
 
+pub(crate) enum RejectCode {
+    #[allow(unused)]
+    SysFatal = 1,
+    #[allow(unused)]
+    SysTransient = 2,
+    DestinationInvalid = 3,
+    CanisterReject = 4,
+    #[allow(unused)]
+    CanisterError = 5,
+    #[allow(unused)]
+    SysUnknown = 6,
+}
+
 impl TryFrom<RegisterExtensionRequest> for PrincipalId {
     type Error = CanisterCallError;
 
@@ -66,8 +76,7 @@ impl TryFrom<RegisterExtensionRequest> for PrincipalId {
         let RegisterExtensionRequest { canister_id } = value;
 
         let Some(canister_id) = canister_id else {
-            // RejectCode::DestinationInvalid
-            let code = Some(3);
+            let code = Some(RejectCode::DestinationInvalid as i32);
             let description = "RegisterExtensionRequest.canister_id must be set.".to_string();
 
             let err = CanisterCallError { code, description };

--- a/rs/sns/root/unreleased_changelog.md
+++ b/rs/sns/root/unreleased_changelog.md
@@ -9,6 +9,17 @@ on the process that this file is part of, see
 
 ## Added
 
+SNS Root now has a function called `register_extension` that is similar to `register_dapp_canister`,
+but different in the following ways:
+
+* The controllers of an SNS extension are the Root and the Governance canisters of the SNS (as
+  opposed to just Root). This allows SNS Governance to call functions of the extension that can
+  be called only by an extension's controller.
+* Extensions are listed separately in the respone of `list_sns_canisters`.
+
+Similar to `register_dapp_canister` and `register_dapp_canisters`, `register_extension` can be
+called only by the SNS Governance.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
This PR adds a new function `Root.register_extension`, that allows registering SNS extensions. For context, the first SNS extension will be the [SNS Liquidity Pools extension](https://forum.dfinity.org/t/sns-liquidity-pools-design/50439).