### PR TITLE
chore: Remove deprecated `EcdsaInitialConfig`

### DIFF
--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -161,20 +161,7 @@ type VetKdCurve = variant { bls12_381_g2 };
 
 type EcdsaCurve = variant { secp256k1 };
 
-type EcdsaInitialConfig = record {
-  quadruples_to_create_in_advance : nat32;
-  max_queue_size : opt nat32;
-  keys : vec EcdsaKeyRequest;
-  signature_request_timeout_ns : opt nat64;
-  idkg_key_rotation_period_ms : opt nat64;
-};
-
 type EcdsaKeyId = record { name : text; curve : EcdsaCurve };
-
-type EcdsaKeyRequest = record {
-  key_id : EcdsaKeyId;
-  subnet_id : opt principal;
-};
 
 type FirewallRule = record {
   ipv4_prefixes : vec text;

--- a/rs/registry/canister/canister/registry_test.did
+++ b/rs/registry/canister/canister/registry_test.did
@@ -161,20 +161,7 @@ type VetKdCurve = variant { bls12_381_g2 };
 
 type EcdsaCurve = variant { secp256k1 };
 
-type EcdsaInitialConfig = record {
-  quadruples_to_create_in_advance : nat32;
-  max_queue_size : opt nat32;
-  keys : vec EcdsaKeyRequest;
-  signature_request_timeout_ns : opt nat64;
-  idkg_key_rotation_period_ms : opt nat64;
-};
-
 type EcdsaKeyId = record { name : text; curve : EcdsaCurve };
-
-type EcdsaKeyRequest = record {
-  key_id : EcdsaKeyId;
-  subnet_id : opt principal;
-};
 
 type FirewallRule = record {
   ipv4_prefixes : vec text;

--- a/rs/registry/canister/src/mutations/do_create_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_create_subnet.rs
@@ -506,22 +506,6 @@ impl From<CanisterCyclesCostSchedule> for CanisterCyclesCostSchedulePb {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize, Serialize)]
-pub struct EcdsaInitialConfig {
-    pub quadruples_to_create_in_advance: u32,
-    pub keys: Vec<EcdsaKeyRequest>,
-    /// Must be optional for registry candid backwards compatibility.
-    pub max_queue_size: Option<u32>,
-    pub signature_request_timeout_ns: Option<u64>,
-    pub idkg_key_rotation_period_ms: Option<u64>,
-}
-
-#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize, Serialize)]
-pub struct EcdsaKeyRequest {
-    pub key_id: EcdsaKeyId,
-    pub subnet_id: Option<PrincipalId>,
-}
-
 impl From<CreateSubnetPayload> for SubnetRecord {
     fn from(val: CreateSubnetPayload) -> Self {
         SubnetRecord {

--- a/rs/registry/canister/src/mutations/do_recover_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_recover_subnet.rs
@@ -216,8 +216,8 @@ impl Registry {
         self.maybe_apply_mutation_internal(mutations)
     }
 
-    /// Ensures the requested ECDSA keys exist somewhere.
-    /// Ensures that a subnet_id is specified for EcdsaKeyRequests.
+    /// Ensures the requested Chain keys exist somewhere.
+    /// Ensures that a subnet_id is specified for ChainKeyRequests.
     /// Ensures that the requested key exists outside of the subnet being recovered.
     /// Ensures that the requested key exists on the specified subnet.
     /// This is similar to validation in do_create_subnet except for constraints to avoid requesting


### PR DESCRIPTION
These types are no longer in use since they were superseded by the `InitialChainKeyConfig`.