### PR TITLE
test: Refactor SshSession trait and add Guest SSH to NestedVm

### DIFF
--- a/rs/tests/driver/src/driver/nested.rs
+++ b/rs/tests/driver/src/driver/nested.rs
@@ -185,10 +185,6 @@ impl NestedVms for TestEnv {
 }
 
 impl SshSession for NestedVm {
-    fn get_env(&self) -> &TestEnv {
-        &self.env
-    }
-
     fn get_host_ip(&self) -> Result<IpAddr> {
         Ok(self.get_vm()?.ipv6.into())
     }
@@ -219,11 +215,13 @@ pub struct GuestSsh {
     ip: Ipv6Addr,
 }
 
-impl SshSession for GuestSsh {
-    fn get_env(&self) -> &TestEnv {
-        &self.env
+impl HasTestEnv for GuestSsh {
+    fn test_env(&self) -> TestEnv {
+        self.env.clone()
     }
+}
 
+impl SshSession for GuestSsh {
     fn get_host_ip(&self) -> Result<IpAddr> {
         Ok(self.ip.into())
     }

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -1497,7 +1497,7 @@ pub trait SshSession: HasTestEnv {
         let ip = self.get_host_ip()?;
         retry_with_msg!(
             format!("get_ssh_session to {ip}"),
-            self.get_env().logger(),
+            self.test_env().logger(),
             SSH_RETRY_TIMEOUT,
             RETRY_BACKOFF,
             || { self.get_ssh_session() }

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -151,7 +151,7 @@ use crate::{
     retry_with_msg, retry_with_msg_async,
     util::{block_on, create_agent},
 };
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use canister_test::{RemoteTestRuntime, Runtime};
 use ic_agent::{export::Principal, Agent, AgentError};
@@ -1483,11 +1483,29 @@ pub fn load_wasm<P: AsRef<Path>>(p: P) -> Vec<u8> {
 }
 
 pub trait SshSession {
+    /// Return the test environment associated with this object.
+    fn get_env(&self) -> &TestEnv;
+
+    /// Return the address of the SSH server to connect to.
+    fn get_host_ip(&self) -> Result<IpAddr>;
+
     /// Return an SSH session to the machine referenced from self authenticating with the given user.
-    fn get_ssh_session(&self) -> Result<Session>;
+    fn get_ssh_session(&self) -> Result<Session> {
+        get_ssh_session_from_env(self.get_env(), self.get_host_ip()?)
+            .context("Failed to get SSH session")
+    }
 
     /// Try a number of times to establish an SSH session to the machine referenced from self authenticating with the given user.
-    fn block_on_ssh_session(&self) -> Result<Session>;
+    fn block_on_ssh_session(&self) -> Result<Session> {
+        let ip = self.get_host_ip()?;
+        retry_with_msg!(
+            format!("get_ssh_session to {ip}"),
+            self.get_env().logger(),
+            SSH_RETRY_TIMEOUT,
+            RETRY_BACKOFF,
+            || { self.get_ssh_session() }
+        )
+    }
 
     fn block_on_bash_script(&self, script: &str) -> Result<String> {
         let session = self.block_on_ssh_session()?;
@@ -2060,24 +2078,14 @@ pub fn get_ssh_session_from_env(env: &TestEnv, ip: IpAddr) -> Result<Session> {
 }
 
 impl SshSession for IcNodeSnapshot {
-    fn get_ssh_session(&self) -> Result<Session> {
-        let node_record = self.raw_node_record();
-        let connection_endpoint = node_record.http.unwrap();
-        let ip_addr = IpAddr::from_str(&connection_endpoint.ip_addr)?;
-        get_ssh_session_from_env(&self.env, ip_addr)
+    fn get_env(&self) -> &TestEnv {
+        &self.env
     }
 
-    fn block_on_ssh_session(&self) -> Result<Session> {
+    fn get_host_ip(&self) -> Result<IpAddr> {
         let node_record = self.raw_node_record();
         let connection_endpoint = node_record.http.unwrap();
-        let ip_addr = IpAddr::from_str(&connection_endpoint.ip_addr)?;
-        retry_with_msg!(
-            format!("get_ssh_session to {}", ip_addr.to_string()),
-            self.env.logger(),
-            SSH_RETRY_TIMEOUT,
-            RETRY_BACKOFF,
-            || { self.get_ssh_session() }
-        )
+        IpAddr::from_str(&connection_endpoint.ip_addr).context("Failed to parse IP address")
     }
 }
 

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -1482,16 +1482,13 @@ pub fn load_wasm<P: AsRef<Path>>(p: P) -> Vec<u8> {
     wasm_bytes
 }
 
-pub trait SshSession {
-    /// Return the test environment associated with this object.
-    fn get_env(&self) -> &TestEnv;
-
+pub trait SshSession: HasTestEnv {
     /// Return the address of the SSH server to connect to.
     fn get_host_ip(&self) -> Result<IpAddr>;
 
     /// Return an SSH session to the machine referenced from self authenticating with the given user.
     fn get_ssh_session(&self) -> Result<Session> {
-        get_ssh_session_from_env(self.get_env(), self.get_host_ip()?)
+        get_ssh_session_from_env(&self.test_env(), self.get_host_ip()?)
             .context("Failed to get SSH session")
     }
 
@@ -2078,10 +2075,6 @@ pub fn get_ssh_session_from_env(env: &TestEnv, ip: IpAddr) -> Result<Session> {
 }
 
 impl SshSession for IcNodeSnapshot {
-    fn get_env(&self) -> &TestEnv {
-        &self.env
-    }
-
     fn get_host_ip(&self) -> Result<IpAddr> {
         let node_record = self.raw_node_record();
         let connection_endpoint = node_record.http.unwrap();

--- a/rs/tests/driver/src/driver/universal_vm.rs
+++ b/rs/tests/driver/src/driver/universal_vm.rs
@@ -379,10 +379,6 @@ impl DeployedUniversalVm {
 }
 
 impl SshSession for DeployedUniversalVm {
-    fn get_env(&self) -> &TestEnv {
-        &self.env
-    }
-
     fn get_host_ip(&self) -> Result<IpAddr> {
         Ok(self.get_vm()?.ipv6.into())
     }

--- a/rs/tests/driver/src/driver/universal_vm.rs
+++ b/rs/tests/driver/src/driver/universal_vm.rs
@@ -13,20 +13,17 @@ use crate::driver::resource::{
 use crate::driver::test_env::SshKeyGen;
 use crate::driver::test_env::{TestEnv, TestEnvAttribute};
 use crate::driver::test_env_api::{
-    get_dependency_path, get_ssh_session_from_env, HasTestEnv, HasVmName, RetrieveIpv4Addr,
-    SshSession, RETRY_BACKOFF, SSH_RETRY_TIMEOUT,
+    get_dependency_path, HasTestEnv, HasVmName, RetrieveIpv4Addr, SshSession,
 };
 use crate::driver::test_setup::{GroupSetup, InfraProvider};
 use crate::k8s::datavolume::DataVolumeContentType;
 use crate::k8s::images::upload_image;
 use crate::k8s::tnet::TNet;
-use crate::retry_with_msg;
 use crate::util::block_on;
 use anyhow::{bail, Result};
 use chrono::Duration;
 use chrono::Utc;
 use slog::info;
-use ssh2::Session;
 use std::fs::{self, File};
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr};
@@ -382,20 +379,12 @@ impl DeployedUniversalVm {
 }
 
 impl SshSession for DeployedUniversalVm {
-    fn get_ssh_session(&self) -> Result<Session> {
-        let vm = self.get_vm()?;
-        get_ssh_session_from_env(&self.env, IpAddr::V6(vm.ipv6))
+    fn get_env(&self) -> &TestEnv {
+        &self.env
     }
 
-    fn block_on_ssh_session(&self) -> Result<Session> {
-        let vm = self.get_vm()?;
-        retry_with_msg!(
-            format!("get_ssh_session to {}", vm.ipv6.to_string()),
-            self.env.logger(),
-            SSH_RETRY_TIMEOUT,
-            RETRY_BACKOFF,
-            || { self.get_ssh_session() }
-        )
+    fn get_host_ip(&self) -> Result<IpAddr> {
+        Ok(self.get_vm()?.ipv6.into())
     }
 }
 


### PR DESCRIPTION
`SshSession` implementations were quite repetitive, this PR refactors the trait and removes the duplication

In addition, it also adds a new method `get_guest_ssh` which allows sending SSH commands to the GuestVM in nested tests.