### PR TITLE
chore(node): clean up guestos-recovery-upgrader

### DIFF
--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
@@ -200,6 +200,10 @@ guestos_upgrade_cleanup() {
         umount "${grubdir}"
         echo "Unmounted ${grubdir}"
     fi
+    if [ -n "${lodev}" ]; then
+        losetup -d "${lodev}"
+        echo "Detached loop device ${lodev}"
+    fi
     if [ -n "${workdir}" ] && [ -d "${workdir}" ]; then
         rm -rf "${workdir}"
         echo "Removed temporary directory ${workdir}"


### PR DESCRIPTION
Removes dead code, removed redundant error checking, and improves cleanup