### PR TITLE
chore: Implement `From<MasterPublicKeyId>` for `AlgorithmId`

### DIFF
--- a/rs/consensus/idkg/src/complaints.rs
+++ b/rs/consensus/idkg/src/complaints.rs
@@ -977,7 +977,7 @@ impl<'a> Action<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_utils::*, utils::algorithm_for_key_id};
+    use crate::test_utils::*;
     use assert_matches::assert_matches;
     use ic_consensus_utils::crypto::SignVerify;
     use ic_crypto_test_utils_canister_threshold_sigs::CanisterThresholdSigTestEnvironment;
@@ -1915,7 +1915,7 @@ mod tests {
             with_test_replica_logger(|logger| {
                 let env = CanisterThresholdSigTestEnvironment::new(3, &mut rng);
                 let (_, _, transcript) =
-                    create_corrupted_transcript(&env, &mut rng, algorithm_for_key_id(&key_id));
+                    create_corrupted_transcript(&env, &mut rng, AlgorithmId::from(key_id.inner()));
 
                 let crypto = env
                     .nodes

--- a/rs/consensus/idkg/src/payload_builder.rs
+++ b/rs/consensus/idkg/src/payload_builder.rs
@@ -752,10 +752,7 @@ mod tests {
     use super::*;
     use crate::{
         test_utils::*,
-        utils::{
-            algorithm_for_key_id, block_chain_reader,
-            generate_responses_to_signature_request_contexts,
-        },
+        utils::{block_chain_reader, generate_responses_to_signature_request_contexts},
     };
     use assert_matches::assert_matches;
     use ic_consensus_mocks::{dependencies, Dependencies};
@@ -792,7 +789,7 @@ mod tests {
                 idkg::IDkgTranscript, ThresholdEcdsaCombinedSignature,
                 ThresholdSchnorrCombinedSignature,
             },
-            CryptoHash, CryptoHashOf, ExtendedDerivationPath,
+            AlgorithmId, CryptoHash, CryptoHashOf, ExtendedDerivationPath,
         },
         messages::CallbackId,
         time::UNIX_EPOCH,
@@ -1423,7 +1420,7 @@ mod tests {
                 assert_eq!(request.key_id(), key_id.clone());
                 assert_eq!(
                     reshare_params.as_ref().algorithm_id,
-                    algorithm_for_key_id(&key_id.clone())
+                    AlgorithmId::from(key_id.inner())
                 );
                 for transcript_ref in reshare_params.as_ref().get_refs() {
                     assert_ne!(transcript_ref.height, new_summary_height);
@@ -1475,7 +1472,7 @@ mod tests {
                 assert_eq!(request.key_id(), key_id.clone());
                 assert_eq!(
                     reshare_params.as_ref().algorithm_id,
-                    algorithm_for_key_id(&key_id.clone())
+                    AlgorithmId::from(key_id.inner())
                 );
                 for transcript_ref in reshare_params.as_ref().get_refs() {
                     assert_eq!(transcript_ref.height, new_summary_height);
@@ -1486,7 +1483,7 @@ mod tests {
             // have been resolved/copied into the summary block
             assert_eq!(summary.idkg_transcripts.len(), expected_transcripts.len());
             for (id, transcript) in &summary.idkg_transcripts {
-                assert_eq!(transcript.algorithm_id, algorithm_for_key_id(&key_id));
+                assert_eq!(transcript.algorithm_id, AlgorithmId::from(key_id.inner()));
                 assert!(expected_transcripts.contains(id));
             }
         })
@@ -1996,7 +1993,7 @@ mod tests {
                 caller: user_test_id(1).get(),
                 derivation_path: vec![],
             };
-            let algorithm = algorithm_for_key_id(&key_id);
+            let algorithm = AlgorithmId::from(key_id.inner());
             let test_inputs = match key_id.inner() {
                 MasterPublicKeyId::Ecdsa(_) => {
                     TestSigInputs::from(&generate_tecdsa_protocol_inputs(
@@ -2462,7 +2459,7 @@ mod tests {
 
             // Generate initial dealings
             let initial_dealings =
-                dummy_initial_idkg_dealing_for_tests(algorithm_for_key_id(&key_id), &mut rng);
+                dummy_initial_idkg_dealing_for_tests(AlgorithmId::from(key_id.inner()), &mut rng);
             let init_tid = initial_dealings.params().transcript_id();
 
             // Step 1: initial bootstrap payload should be created successfully

--- a/rs/consensus/idkg/src/payload_builder/key_transcript.rs
+++ b/rs/consensus/idkg/src/payload_builder/key_transcript.rs
@@ -1,14 +1,11 @@
-use crate::{
-    payload_builder::IDkgPayloadError, pre_signer::IDkgTranscriptBuilder,
-    utils::algorithm_for_key_id,
-};
+use crate::{payload_builder::IDkgPayloadError, pre_signer::IDkgTranscriptBuilder};
 use ic_logger::{info, ReplicaLogger};
 use ic_types::{
     consensus::idkg::{
         self, HasIDkgMasterPublicKeyId, IDkgBlockReader, IDkgUIDGenerator, MasterKeyTranscript,
         TranscriptAttributes,
     },
-    crypto::canister_threshold_sig::idkg::IDkgTranscript,
+    crypto::{canister_threshold_sig::idkg::IDkgTranscript, AlgorithmId},
     Height, NodeId, RegistryVersion,
 };
 use std::collections::BTreeSet;
@@ -126,7 +123,7 @@ pub(super) fn update_next_key_transcript(
                     dealers_set,
                     receivers_set,
                     registry_version,
-                    algorithm_for_key_id(&key_transcript.key_id()),
+                    AlgorithmId::from(key_transcript.key_id().inner()),
                 ),
             );
         }
@@ -213,12 +210,9 @@ pub(super) fn update_next_key_transcript(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        test_utils::{
-            create_reshare_unmasked_transcript_param, set_up_idkg_payload, IDkgPayloadTestHelper,
-            TestIDkgBlockReader, TestIDkgTranscriptBuilder,
-        },
-        utils::algorithm_for_key_id,
+    use crate::test_utils::{
+        create_reshare_unmasked_transcript_param, set_up_idkg_payload, IDkgPayloadTestHelper,
+        TestIDkgBlockReader, TestIDkgTranscriptBuilder,
     };
     use ic_crypto_test_utils_canister_threshold_sigs::{
         dummy_values::dummy_initial_idkg_dealing_for_tests, generate_key_transcript, node::Nodes,
@@ -474,7 +468,7 @@ mod tests {
         }
         assert_eq!(
             completed_transcript.algorithm_id,
-            algorithm_for_key_id(&key_id)
+            AlgorithmId::from(key_id.inner())
         );
         assert_eq!(payload.single_key_transcript().key_id(), key_id);
     }
@@ -612,7 +606,7 @@ mod tests {
             &unmasked_transcript,
             &target_subnet_nodes_ids,
             registry_version,
-            algorithm_for_key_id(&key_id),
+            AlgorithmId::from(key_id.inner()),
         );
         let (params, transcript) =
             idkg::unpack_reshare_of_unmasked_params(cur_height, &reshare_params).unwrap();
@@ -623,7 +617,7 @@ mod tests {
         payload.single_key_transcript_mut().next_in_creation =
             idkg::KeyTranscriptCreation::XnetReshareOfUnmaskedParams((
                 Box::new(dummy_initial_idkg_dealing_for_tests(
-                    algorithm_for_key_id(&key_id),
+                    AlgorithmId::from(key_id.inner()),
                     &mut rng,
                 )),
                 params,

--- a/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
+++ b/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
@@ -1,7 +1,4 @@
-use crate::{
-    payload_builder::IDkgPayloadError, pre_signer::IDkgTranscriptBuilder,
-    utils::algorithm_for_key_id,
-};
+use crate::{payload_builder::IDkgPayloadError, pre_signer::IDkgTranscriptBuilder};
 use ic_logger::{debug, error, ReplicaLogger};
 use ic_management_canister_types_private::MasterPublicKeyId;
 use ic_registry_subnet_features::ChainKeyConfig;
@@ -15,7 +12,7 @@ use ic_types::{
         HasIDkgMasterPublicKeyId, IDkgMasterPublicKeyId, IDkgUIDGenerator, PreSigId,
         TranscriptAttributes, UnmaskedTranscriptWithAttributes,
     },
-    crypto::canister_threshold_sig::idkg::IDkgTranscript,
+    crypto::{canister_threshold_sig::idkg::IDkgTranscript, AlgorithmId},
     messages::CallbackId,
     Height, NodeId, RegistryVersion,
 };
@@ -426,7 +423,7 @@ fn new_random_config(
         dealers,
         receivers,
         summary_registry_version,
-        algorithm_for_key_id(key_id),
+        AlgorithmId::from(key_id.inner()),
     )
 }
 
@@ -447,7 +444,7 @@ pub fn new_random_unmasked_config(
         dealers,
         receivers,
         summary_registry_version,
-        algorithm_for_key_id(key_id),
+        AlgorithmId::from(key_id.inner()),
     )
 }
 
@@ -533,7 +530,7 @@ pub(super) mod test_utils {
 
 #[cfg(test)]
 pub(super) mod tests {
-    use super::{algorithm_for_key_id, test_utils::*, *};
+    use super::{test_utils::*, *};
     use crate::test_utils::{
         create_available_pre_signature, create_available_pre_signature_with_key_transcript,
         into_idkg_contexts, set_up_idkg_payload, IDkgPayloadTestHelper, TestIDkgBlockReader,
@@ -628,7 +625,7 @@ pub(super) mod tests {
                     MasterPublicKeyId::Schnorr(transcript.key_id.clone())
                 );
                 let config = transcript.blinder_unmasked_config.as_ref();
-                assert_eq!(config.algorithm_id, algorithm_for_key_id(key_id));
+                assert_eq!(config.algorithm_id, AlgorithmId::from(key_id.inner()));
                 assert_eq!(config.registry_version, registry_version);
                 assert_eq!(config.dealers, config.receivers);
                 assert_eq!(config.dealers, BTreeSet::from(*nodes));
@@ -1043,7 +1040,7 @@ pub(super) mod tests {
             .expect("Translating should succeed");
         assert_eq!(
             translated.blinder_unmasked().algorithm_id,
-            algorithm_for_key_id(&key_id)
+            AlgorithmId::from(key_id.inner())
         );
     }
 
@@ -1078,7 +1075,7 @@ pub(super) mod tests {
             &env,
             &dealers,
             &receivers,
-            algorithm_for_key_id(&key_id),
+            AlgorithmId::from(key_id.inner()),
             &mut rng,
         );
         let key_transcript2 =
@@ -1185,7 +1182,7 @@ pub(super) mod tests {
             &env,
             &dealers,
             &receivers,
-            algorithm_for_key_id(&key_id),
+            AlgorithmId::from(key_id.inner()),
             &mut rng,
         );
         let other_key_transcript =

--- a/rs/consensus/idkg/src/payload_builder/resharing.rs
+++ b/rs/consensus/idkg/src/payload_builder/resharing.rs
@@ -189,7 +189,6 @@ mod tests {
             create_reshare_request, set_up_idkg_payload, TestIDkgBlockReader,
             TestIDkgTranscriptBuilder,
         },
-        utils::algorithm_for_key_id,
     };
     use assert_matches::assert_matches;
     use ic_crypto_test_utils_canister_threshold_sigs::dummy_values::{
@@ -200,7 +199,10 @@ mod tests {
     use ic_management_canister_types_private::ComputeInitialIDkgDealingsResponse;
     use ic_test_utilities_consensus::idkg::*;
     use ic_test_utilities_types::ids::subnet_test_id;
-    use ic_types::consensus::idkg::{IDkgMasterPublicKeyId, IDkgPayload};
+    use ic_types::{
+        consensus::idkg::{IDkgMasterPublicKeyId, IDkgPayload},
+        crypto::AlgorithmId,
+    };
 
     fn set_up(
         key_ids: Vec<IDkgMasterPublicKeyId>,
@@ -248,7 +250,7 @@ mod tests {
             initial_dealings.insert(
                 i,
                 dummy_initial_idkg_dealing_for_tests(
-                    algorithm_for_key_id(key_id),
+                    AlgorithmId::from(key_id.inner()),
                     &mut reproducible_rng(),
                 ),
             );
@@ -324,7 +326,10 @@ mod tests {
                 .ongoing_xnet_reshares
                 .get(&request)
                 .expect("should exist");
-            assert_eq!(params.as_ref().algorithm_id, algorithm_for_key_id(&key_id));
+            assert_eq!(
+                params.as_ref().algorithm_id,
+                AlgorithmId::from(key_id.inner())
+            );
 
             assert!(payload.xnet_reshare_agreements.is_empty());
         }
@@ -348,14 +353,17 @@ mod tests {
                 .ongoing_xnet_reshares
                 .get(&request)
                 .expect("should exist");
-            assert_eq!(params.as_ref().algorithm_id, algorithm_for_key_id(&key_id));
+            assert_eq!(
+                params.as_ref().algorithm_id,
+                AlgorithmId::from(key_id.inner())
+            );
             let params_2 = payload
                 .ongoing_xnet_reshares
                 .get(&request_2)
                 .expect("should exist");
             assert_eq!(
                 params_2.as_ref().algorithm_id,
-                algorithm_for_key_id(&key_id)
+                AlgorithmId::from(key_id.inner())
             );
             assert!(payload.xnet_reshare_agreements.is_empty());
         }
@@ -426,7 +434,10 @@ mod tests {
             .unwrap()
             .as_ref()
             .clone();
-        assert_eq!(reshare_params_1.algorithm_id, algorithm_for_key_id(&key_id));
+        assert_eq!(
+            reshare_params_1.algorithm_id,
+            AlgorithmId::from(key_id.inner())
+        );
         let dealings_1 = dummy_dealings(reshare_params_1.transcript_id, &reshare_params_1.dealers);
         transcript_builder.add_dealings(reshare_params_1.transcript_id, dealings_1.clone());
         update_completed_reshare_requests(
@@ -460,7 +471,10 @@ mod tests {
             .unwrap()
             .as_ref()
             .clone();
-        assert_eq!(reshare_params_2.algorithm_id, algorithm_for_key_id(&key_id));
+        assert_eq!(
+            reshare_params_2.algorithm_id,
+            AlgorithmId::from(key_id.inner())
+        );
         let dealings_2 = dummy_dealings(reshare_params_2.transcript_id, &reshare_params_2.dealers);
         transcript_builder.add_dealings(reshare_params_2.transcript_id, dealings_2.clone());
         update_completed_reshare_requests(

--- a/rs/consensus/idkg/src/payload_verifier.rs
+++ b/rs/consensus/idkg/src/payload_verifier.rs
@@ -645,7 +645,6 @@ mod test {
             signatures::update_signature_agreements,
         },
         test_utils::*,
-        utils::algorithm_for_key_id,
     };
     use assert_matches::assert_matches;
     use ic_crypto_test_utils_canister_threshold_sigs::{
@@ -730,7 +729,7 @@ mod test {
                 env.nodes.ids(),
                 env.nodes.ids(),
                 registry_version,
-                algorithm_for_key_id(&key_id),
+                AlgorithmId::from(key_id.inner()),
             ));
         curr_payload.single_key_transcript_mut().next_in_creation =
             idkg::KeyTranscriptCreation::Created(transcript_ref_0);
@@ -830,7 +829,10 @@ mod test {
 
         // Create completed dealings for request 1.
         let reshare_params = payload.ongoing_xnet_reshares.get(&req_1).unwrap().as_ref();
-        assert_eq!(reshare_params.algorithm_id, algorithm_for_key_id(&key_id));
+        assert_eq!(
+            reshare_params.algorithm_id,
+            AlgorithmId::from(key_id.inner())
+        );
         let dealings = dummy_dealings(reshare_params.transcript_id, &reshare_params.dealers);
         transcript_builder.add_dealings(reshare_params.transcript_id, dealings);
         update_completed_reshare_requests(
@@ -864,7 +866,10 @@ mod test {
 
         // Create another request and dealings
         let reshare_params = payload.ongoing_xnet_reshares.get(&req_2).unwrap().as_ref();
-        assert_eq!(reshare_params.algorithm_id, algorithm_for_key_id(&key_id));
+        assert_eq!(
+            reshare_params.algorithm_id,
+            AlgorithmId::from(key_id.inner())
+        );
         let dealings = dummy_dealings(reshare_params.transcript_id, &reshare_params.dealers);
         transcript_builder.add_dealings(reshare_params.transcript_id, dealings);
         let mut prev_payload = payload.clone();
@@ -1271,7 +1276,7 @@ mod test {
                 dealers,
                 receivers,
                 registry_version,
-                algorithm_for_key_id(&master_public_key_id),
+                AlgorithmId::from(master_public_key_id.inner()),
             );
             env.nodes.run_idkg_and_create_and_verify_transcript(
                 &param.as_ref().translate(&block_reader).unwrap(),

--- a/rs/consensus/idkg/src/pre_signer.rs
+++ b/rs/consensus/idkg/src/pre_signer.rs
@@ -1360,7 +1360,7 @@ impl TranscriptState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_utils::*, utils::algorithm_for_key_id};
+    use crate::test_utils::*;
     use assert_matches::assert_matches;
     use ic_crypto_test_utils_canister_threshold_sigs::{
         setup_masked_random_params, CanisterThresholdSigTestEnvironment, IDkgParticipants,
@@ -1372,7 +1372,7 @@ mod tests {
     use ic_test_utilities_types::ids::{NODE_1, NODE_2, NODE_3, NODE_4};
     use ic_types::{
         consensus::idkg::{IDkgMasterPublicKeyId, IDkgObject},
-        crypto::{BasicSig, BasicSigOf, CryptoHash},
+        crypto::{AlgorithmId, BasicSig, BasicSigOf, CryptoHash},
         time::UNIX_EPOCH,
         Height, RegistryVersion,
     };
@@ -2770,7 +2770,7 @@ mod tests {
         );
         let params = setup_masked_random_params(
             &env,
-            algorithm_for_key_id(&key_id),
+            AlgorithmId::from(key_id.inner()),
             &dealers,
             &receivers,
             &mut rng,

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -897,7 +897,7 @@ impl Debug for Action<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_utils::*, utils::algorithm_for_key_id};
+    use crate::test_utils::*;
     use assert_matches::assert_matches;
     use ic_crypto_test_utils_canister_threshold_sigs::{
         generate_key_transcript, generate_tecdsa_protocol_inputs,
@@ -1410,7 +1410,7 @@ mod tests {
                     &env,
                     &dealers,
                     &receivers,
-                    algorithm_for_key_id(&key_id),
+                    AlgorithmId::from(key_id.inner()),
                     &mut rng,
                 );
                 let derivation_path = ExtendedDerivationPath {
@@ -1427,7 +1427,7 @@ mod tests {
                             &[0; 32],
                             Randomness::from([0; 32]),
                             &derivation_path,
-                            algorithm_for_key_id(&key_id),
+                            AlgorithmId::from(key_id.inner()),
                             &mut rng,
                         );
 
@@ -1446,7 +1446,7 @@ mod tests {
                             Randomness::from([0; 32]),
                             None,
                             &derivation_path,
-                            algorithm_for_key_id(&key_id),
+                            AlgorithmId::from(key_id.inner()),
                             &mut rng,
                         );
                         (

--- a/rs/consensus/idkg/src/test_utils.rs
+++ b/rs/consensus/idkg/src/test_utils.rs
@@ -2,7 +2,6 @@ use crate::{
     complaints::{IDkgComplaintHandlerImpl, IDkgTranscriptLoader, TranscriptLoadStatus},
     pre_signer::{IDkgPreSignerImpl, IDkgTranscriptBuilder},
     signer::{ThresholdSignatureBuilder, ThresholdSignerImpl},
-    utils::algorithm_for_key_id,
 };
 use ic_artifact_pool::idkg_pool::IDkgPoolImpl;
 use ic_config::artifact_pool::ArtifactPoolConfig;
@@ -639,7 +638,7 @@ pub(crate) fn create_transcript(
         registry_version: RegistryVersion::from(1),
         verified_dealings: BTreeMap::new(),
         transcript_type: IDkgTranscriptType::Masked(IDkgMaskedTranscriptOrigin::Random),
-        algorithm_id: algorithm_for_key_id(key_id),
+        algorithm_id: AlgorithmId::from(key_id.inner()),
         internal_transcript_raw: vec![],
     }
 }
@@ -685,7 +684,7 @@ pub(crate) fn create_transcript_param_with_registry_version(
     idkg_transcripts.insert(*random_masked.as_ref(), random_transcript);
 
     let attrs =
-        IDkgTranscriptAttributes::new(dealers, algorithm_for_key_id(key_id), registry_version);
+        IDkgTranscriptAttributes::new(dealers, AlgorithmId::from(key_id.inner()), registry_version);
 
     // The transcript that points to the random transcript
     let transcript_params_ref = ReshareOfMaskedParams::new(
@@ -825,7 +824,7 @@ pub(crate) fn create_dealing_with_payload<R: Rng + CryptoRng>(
         env.choose_dealers_and_receivers(&IDkgParticipants::AllNodesAsDealersAndReceivers, rng);
     let params = setup_masked_random_params(
         &env,
-        algorithm_for_key_id(key_id),
+        AlgorithmId::from(key_id.inner()),
         &dealers,
         &receivers,
         rng,
@@ -1231,7 +1230,7 @@ pub(crate) fn generate_key_transcript(
         env,
         &dealers,
         &receivers,
-        algorithm_for_key_id(key_id),
+        AlgorithmId::from(key_id.inner()),
         rng,
     );
     let key_transcript_ref = idkg::UnmaskedTranscript::try_from((height, &key_transcript)).unwrap();

--- a/rs/test_utilities/consensus/src/idkg.rs
+++ b/rs/test_utilities/consensus/src/idkg.rs
@@ -6,8 +6,7 @@ use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 use ic_crypto_tree_hash::{LabeledTree, MixedHashTree};
 use ic_interfaces_state_manager::{CertifiedStateSnapshot, Labeled};
 use ic_management_canister_types_private::{
-    EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdCurve,
-    VetKdKeyId,
+    EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdKeyId,
 };
 use ic_replicated_state::{
     metadata_state::subnet_call_context_manager::{

--- a/rs/types/types/src/crypto.rs
+++ b/rs/types/types/src/crypto.rs
@@ -13,6 +13,10 @@ pub use hash::DOMAIN_IC_REQUEST;
 
 mod sign;
 
+use ic_management_canister_types_private::EcdsaCurve;
+use ic_management_canister_types_private::MasterPublicKeyId;
+use ic_management_canister_types_private::SchnorrAlgorithm;
+use ic_management_canister_types_private::VetKdCurve;
 pub use sign::{Signable, SignableMock};
 
 pub mod error;
@@ -259,6 +263,41 @@ impl From<i32> for AlgorithmId {
             19 => AlgorithmId::ThresholdEd25519,
             20 => AlgorithmId::VetKD,
             _ => AlgorithmId::Placeholder,
+        }
+    }
+}
+
+impl From<EcdsaCurve> for AlgorithmId {
+    fn from(curve: EcdsaCurve) -> Self {
+        match curve {
+            EcdsaCurve::Secp256k1 => AlgorithmId::ThresholdEcdsaSecp256k1,
+        }
+    }
+}
+
+impl From<SchnorrAlgorithm> for AlgorithmId {
+    fn from(schnorr_algorithm: SchnorrAlgorithm) -> Self {
+        match schnorr_algorithm {
+            SchnorrAlgorithm::Bip340Secp256k1 => AlgorithmId::ThresholdSchnorrBip340,
+            SchnorrAlgorithm::Ed25519 => AlgorithmId::ThresholdEd25519,
+        }
+    }
+}
+
+impl From<VetKdCurve> for AlgorithmId {
+    fn from(curve: VetKdCurve) -> Self {
+        match curve {
+            VetKdCurve::Bls12_381_G2 => AlgorithmId::VetKD,
+        }
+    }
+}
+
+impl From<&MasterPublicKeyId> for AlgorithmId {
+    fn from(key_id: &MasterPublicKeyId) -> Self {
+        match key_id {
+            MasterPublicKeyId::Ecdsa(ecdsa) => AlgorithmId::from(ecdsa.curve),
+            MasterPublicKeyId::Schnorr(schnorr) => AlgorithmId::from(schnorr.algorithm),
+            MasterPublicKeyId::VetKd(vetkd) => AlgorithmId::from(vetkd.curve),
         }
     }
 }


### PR DESCRIPTION
This is cleaner and avoids some duplication of `algorithm_for_key_id` functions.