### PR TITLE
test(ICP_Rosetta): FI-1803: Mark ICP Rosetta system tests as flaky

### DIFF
--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -196,6 +196,7 @@ rust_test_suite_with_extra_srcs(
         "tests/system_tests/common/*.rs",
         "tests/system_tests/test_cases/*.rs",
     ]),
+    flaky = True,
     proc_macro_deps = MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:4"],
     deps = DEV_DEPENDENCIES + DEPENDENCIES,


### PR DESCRIPTION
Mark the ICP Rosetta system tests as flaky due to `test_neuron_voting` being flaky.