### PR TITLE
chore: run IC nodes in tecdsa performance tests on Dells

### DIFF
--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -326,7 +326,10 @@ system_test_nns(
     additional_colocate_tags = [
         "system_test_benchmark",
     ],
-    colocated_test_driver_vm_required_host_features = ["performance"],
+    colocated_test_driver_vm_required_host_features = [
+        "performance",
+        "spm",
+    ],
     colocated_test_driver_vm_resources = {
         "vcpus": 64,
         "memory_kibibytes": 512142680,
@@ -351,7 +354,10 @@ system_test_nns(
     additional_colocate_tags = [
         "system_test_benchmark",
     ],
-    colocated_test_driver_vm_required_host_features = ["performance"],
+    colocated_test_driver_vm_required_host_features = [
+        "performance",
+        "spm",
+    ],
     colocated_test_driver_vm_resources = {
         "vcpus": 64,
         "memory_kibibytes": 512142680,
@@ -376,7 +382,10 @@ system_test_nns(
     additional_colocate_tags = [
         "system_test_benchmark",
     ],
-    colocated_test_driver_vm_required_host_features = ["performance"],
+    colocated_test_driver_vm_required_host_features = [
+        "performance",
+        "spm",
+    ],
     colocated_test_driver_vm_resources = {
         "vcpus": 64,
         "memory_kibibytes": 512142680,
@@ -401,7 +410,10 @@ system_test_nns(
     additional_colocate_tags = [
         "system_test_benchmark",
     ],
-    colocated_test_driver_vm_required_host_features = ["performance"],
+    colocated_test_driver_vm_required_host_features = [
+        "performance",
+        "spm",
+    ],
     colocated_test_driver_vm_resources = {
         "vcpus": 64,
         "memory_kibibytes": 512142680,

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -157,7 +157,7 @@ pub fn setup(env: TestEnv) {
     info!(env.logger(), "Running the test with key ids: {:?}", key_ids);
 
     PrometheusVm::default()
-        .with_required_host_features(vec![HostFeature::Performance])
+        .with_required_host_features(vec![HostFeature::Performance, HostFeature::Supermicro])
         .start(&env)
         .expect("Failed to start prometheus VM");
 
@@ -168,7 +168,7 @@ pub fn setup(env: TestEnv) {
     };
 
     InternetComputer::new()
-        .with_required_host_features(vec![HostFeature::Performance])
+        .with_required_host_features(vec![HostFeature::Performance, , HostFeature::Dell])
         .add_subnet(
             Subnet::new(SubnetType::System)
                 .with_default_vm_resources(vm_resources)

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -168,7 +168,7 @@ pub fn setup(env: TestEnv) {
     };
 
     InternetComputer::new()
-        .with_required_host_features(vec![HostFeature::Performance, , HostFeature::Dell])
+        .with_required_host_features(vec![HostFeature::Performance, HostFeature::Dell])
         .add_subnet(
             Subnet::new(SubnetType::System)
                 .with_default_vm_resources(vm_resources)


### PR DESCRIPTION
To ensure consistent performance we configure the IC nodes in the tecdsa performance tests to be only allocated to Dell Farm hosts in dm1 (of which we have 34). The rest of the VMs (for the colocated test driver and for the PrometheusVM) will be allocated to Supermicros (of which we have 9) to leave as much room as possible for IC nodes.

Running `ict test tecdsa_performance_test_colocate` indeed results in the expected VM allocation:
```
farm=# 
  SELECT
    vms.hostname      AS host, 
    vms.display_name  AS vm, 
    vms.spec->'vCPUs' AS vcpus 
  FROM 
    vms, 
    groups 
  WHERE 
    vms.group_id = groups.id 
    AND groups.display_name LIKE 'tecdsa_performance_test%';
             host              |                               vm                                | vcpus
-------------------------------+-----------------------------------------------------------------+-------
 dm1-spm08.dm1.dfinity.network | test-driver                                                     | 64
 dm1-spm43.dm1.dfinity.network | prometheus                                                      | 2
 dm1-dll50.dm1.dfinity.network | r5qey-mjuzw-szgpw-njsgd-m7dtp-72dvl-dolsa-ooapu-2xbwj-vjkph-oqe | 64
 dm1-dll01.dm1.dfinity.network | ydfcd-tio7d-ofxr7-q5yj4-7cbaz-ssoms-6ckm6-qzpoq-eontz-fwrb4-xae | 64
 dm1-dll12.dm1.dfinity.network | aahxg-bxico-midej-utzwv-kkx5v-dme5p-7tdlz-x346g-nvsot-e3emo-5qe | 64
 dm1-dll08.dm1.dfinity.network | 5txqs-n3whf-szjhv-yxdyq-3iqfl-x4gmb-px336-tntbg-vbrbs-vtv5z-dqe | 64
 dm1-dll41.dm1.dfinity.network | a7mif-dbjvi-u2dmc-x5lg6-225ur-6mhvp-kb3nd-y4ffm-qwsfa-peyna-dqe | 64
 dm1-dll17.dm1.dfinity.network | uhigq-xr6xt-mgqmx-wtkni-4uyeb-u3mxd-b6n6m-bauze-ac4rl-e7mzj-jqe | 64
 dm1-dll54.dm1.dfinity.network | 734r3-rmai5-2z5fy-3nmhh-wvlyb-7xqqg-r56wy-dznda-xgc35-xgh6f-wqe | 64
 dm1-dll04.dm1.dfinity.network | 4raxp-avpbi-75etb-pcjbz-ghtrd-ho2nw-dl24i-qjhq2-o7tez-ortmf-tae | 64
 dm1-dll16.dm1.dfinity.network | hij4i-4wi2m-vi6nv-pb6ch-6d2iw-i6ygx-5kipr-wpeml-lmdur-75ccd-iae | 64
 dm1-dll52.dm1.dfinity.network | mduhe-ez3zx-gmzwn-42ba2-e2lqo-2fm6e-tvm2a-fgqna-hudzs-e26ju-hqe | 64
 dm1-dll76.dm1.dfinity.network | eccyw-azygj-kxtb4-cs2wp-dhbv5-6zqbd-7buhn-qdsfu-7fhre-bgsvs-cae | 64
 dm1-dll02.dm1.dfinity.network | gpduf-f7c6s-hdm5o-aznl6-svpkk-p5woy-an5tw-fvdpv-wcmai-foh7b-bqe | 64
 dm1-dll37.dm1.dfinity.network | s73nv-rbpqd-vm26m-wokoj-laswv-v53pa-cc6gh-knswn-w573l-xieks-nqe | 64
 dm1-dll09.dm1.dfinity.network | jfojf-gdwd7-suoy3-hkiig-dxr67-cu2hh-brnr6-eizno-bqbsr-dr2q5-nqe | 64
 dm1-dll13.dm1.dfinity.network | 6suu7-rcxdr-lho2l-jmqkk-k6jra-y5hmh-frgpu-q3fr4-ymykj-bfbv5-gae | 64
 dm1-dll36.dm1.dfinity.network | 23xu5-dthx6-glt7n-7vthp-qyyyb-ywwcc-fjxzv-e5zhg-p7esn-2rk7s-aae | 64
 dm1-dll39.dm1.dfinity.network | jrdxz-otnl3-w5wal-isanr-sun3a-pgcz2-ktxyl-kveet-ps7ga-blzf4-xae | 64
 dm1-dll07.dm1.dfinity.network | qrsf3-6src5-55ncl-lw3dp-kpmcl-montb-wmvqm-rrn4n-hflcl-iglrw-eqe | 64
 dm1-dll15.dm1.dfinity.network | jrshc-lox5j-373v2-zizh2-lts5b-c766h-a6jgv-l5mff-r2ee5-jll2p-iae | 64
 dm1-dll11.dm1.dfinity.network | tmhdd-jf4ys-wvzcj-cxsxi-flawz-ymqj4-qy5zp-iachr-2sv73-dr47m-qae | 64
 dm1-dll35.dm1.dfinity.network | vaotr-xlxhv-4dn6q-dmqe7-d2tcp-mjome-d5dst-ifbae-ev45q-riijh-kqe | 64
 dm1-dll40.dm1.dfinity.network | nlntp-fhdl3-hwpsc-rgwpo-tnin4-fxntl-mv2ab-muio5-2vnxe-xc4er-eae | 64
 dm1-dll74.dm1.dfinity.network | ed5jc-qe4us-gcm6i-7vle7-n2qrj-kzi4v-d3g5m-dyta3-kqg4f-nhnx3-7ae | 64
 dm1-dll05.dm1.dfinity.network | cusl5-3updk-lspae-n5o5v-6j6qm-uth6y-unx2x-4emda-ckd3m-aumr2-rqe | 64
 dm1-dll53.dm1.dfinity.network | dp2yn-7n6zx-tk6es-5muz6-datxa-rt3ap-wufxa-betw3-xqgtk-5gr7o-dae | 64
 dm1-dll51.dm1.dfinity.network | agspp-n5o5k-naa3p-34t3t-qtkib-dhju3-p7gkf-trkgd-atwmv-tz5cd-gqe | 64
(28 rows)
```