### PR TITLE
refactor(FI-1784): Group Rosetta CLI parameters

### DIFF
--- a/rs/rosetta-api/icp/src/main.rs
+++ b/rs/rosetta-api/icp/src/main.rs
@@ -65,7 +65,7 @@ struct NetworkConfig {
 struct CanisterConfig {
     /// Id of the ICP ledger canister.
     #[clap(short = 'c', long = "canister-id")]
-    canister_id: Option<String>,
+    ledger_canister_id: Option<String>,
     #[clap(short = 't', long = "token-symbol")]
     token_symbol: Option<String>,
     /// Id of the governance canister to use for neuron management.
@@ -210,7 +210,7 @@ async fn main() -> std::io::Result<()> {
             }
         };
 
-        let canister_id = match opt.canister.canister_id {
+        let canister_id = match opt.canister.ledger_canister_id {
             Some(cid) => {
                 CanisterId::unchecked_from_principal(PrincipalId::from_str(&cid[..]).unwrap())
             }
@@ -234,7 +234,7 @@ async fn main() -> std::io::Result<()> {
             }
         };
 
-        let canister_id = match opt.canister.canister_id {
+        let canister_id = match opt.canister.ledger_canister_id {
             Some(cid) => {
                 CanisterId::unchecked_from_principal(PrincipalId::from_str(&cid[..]).unwrap())
             }

--- a/rs/rosetta-api/icp/src/main.rs
+++ b/rs/rosetta-api/icp/src/main.rs
@@ -61,6 +61,19 @@ struct NetworkConfig {
 }
 
 #[derive(Debug, Parser)]
+#[clap(next_help_heading = "Canister Configuration")]
+struct CanisterConfig {
+    /// Id of the ICP ledger canister.
+    #[clap(short = 'c', long = "canister-id")]
+    canister_id: Option<String>,
+    #[clap(short = 't', long = "token-symbol")]
+    token_symbol: Option<String>,
+    /// Id of the governance canister to use for neuron management.
+    #[clap(short = 'g', long = "governance-canister-id")]
+    governance_canister_id: Option<String>,
+}
+
+#[derive(Debug, Parser)]
 #[clap(version)]
 struct Opt {
     #[clap(flatten)]
@@ -72,14 +85,9 @@ struct Opt {
     #[clap(flatten)]
     network: NetworkConfig,
     
-    /// Id of the ICP ledger canister.
-    #[clap(short = 'c', long = "canister-id")]
-    ic_canister_id: Option<String>,
-    #[clap(short = 't', long = "token-sybol")]
-    token_symbol: Option<String>,
-    /// Id of the governance canister to use for neuron management.
-    #[clap(short = 'g', long = "governance-canister-id")]
-    governance_canister_id: Option<String>,
+    #[clap(flatten)]
+    canister: CanisterConfig,
+    
     #[clap(short = 'l', long = "log-config-file")]
     log_config_file: Option<PathBuf>,
     #[clap(short = 'L', long = "log-level", default_value = "INFO")]
@@ -202,14 +210,14 @@ async fn main() -> std::io::Result<()> {
             }
         };
 
-        let canister_id = match opt.ic_canister_id {
+        let canister_id = match opt.canister.canister_id {
             Some(cid) => {
                 CanisterId::unchecked_from_principal(PrincipalId::from_str(&cid[..]).unwrap())
             }
             None => ic_nns_constants::LEDGER_CANISTER_ID,
         };
 
-        let governance_canister_id = match opt.governance_canister_id {
+        let governance_canister_id = match opt.canister.governance_canister_id {
             Some(cid) => {
                 CanisterId::unchecked_from_principal(PrincipalId::from_str(&cid[..]).unwrap())
             }
@@ -226,14 +234,14 @@ async fn main() -> std::io::Result<()> {
             }
         };
 
-        let canister_id = match opt.ic_canister_id {
+        let canister_id = match opt.canister.canister_id {
             Some(cid) => {
                 CanisterId::unchecked_from_principal(PrincipalId::from_str(&cid[..]).unwrap())
             }
             None => ic_nns_constants::LEDGER_CANISTER_ID,
         };
 
-        let governance_canister_id = match opt.governance_canister_id {
+        let governance_canister_id = match opt.canister.governance_canister_id {
             Some(cid) => {
                 CanisterId::unchecked_from_principal(PrincipalId::from_str(&cid[..]).unwrap())
             }
@@ -244,6 +252,7 @@ async fn main() -> std::io::Result<()> {
     };
 
     let token_symbol = opt
+        .canister
         .token_symbol
         .unwrap_or_else(|| DEFAULT_TOKEN_SYMBOL.to_string());
     info!("Token symbol set to {}", token_symbol);


### PR DESCRIPTION
The ICP Rosetta API has 20+ CLI params, which can be a bit hard to parse both by the user when looking at the `--help` dialogue as well as internally in the codebase. This commit groups some CLI parameters together for more readability both internally in the codebase as well as in the --help.

Note that this change doesn't change any of the parameter names, so it's 100% backward-compatible.

Here's the grouping with --help:

```
Usage: ic-rosetta-api [OPTIONS]

Options:
  -h, --help     Print help
  -V, --version  Print version

Server Configuration:
  -a, --address <ADDRESS>      [default: 0.0.0.0]
  -p, --port <PORT>            The listen port of Rosetta. If not set then the port used will be 8081 unless --port-file is defined in which case a random port is used
  -P, --port-file <PORT_FILE>  File where the port will be written. Useful when the port is set to 0 because a random port will be picked

Storage Configuration:
      --store-type <STORE_TYPE>        Supported options: sqlite, sqlite-in-memory [default: sqlite]
      --store-location <LOCATION>      [default: /data]
      --store-max-blocks <MAX_BLOCKS>  
      --optimize-search-indexes        Create additional indexes to optimize transaction search performance. May increase the database size by ~30%.

Network Configuration:
      --ic-url <IC_URL>      The URL of the replica to connect to
      --root-key <ROOT_KEY>  

Canister Configuration:
  -c, --canister-id <LEDGER_CANISTER_ID>
          Id of the ICP ledger canister
  -t, --token-symbol <TOKEN_SYMBOL>
          
  -g, --governance-canister-id <GOVERNANCE_CANISTER_ID>
          Id of the governance canister to use for neuron management
  -l, --log-config-file <LOG_CONFIG_FILE>
          
  -L, --log-level <LOG_LEVEL>
          [default: INFO]
      --exit-on-sync
          
      --offline
          
      --mainnet
          Connect to the Internet Computer Mainnet
      --blockchain <BLOCKCHAIN>
          The name of the blockchain reported in the network identifier [default: "Internet Computer"]
      --not-whitelisted
          
      --expose-metrics
          
      --watchdog-timeout-seconds <WATCHDOG_TIMEOUT_SECONDS>
          Timeout in seconds for sync watchdog [default: 60]
```