### PR TITLE
chore: embed README in pocket-ic crate docs

### DIFF
--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::test_attr_in_doctest)]
+#![doc = include_str!("../README.md")]
 /// # PocketIC: A Canister Testing Platform
 ///
 /// PocketIC is the local canister smart contract testing platform for the [Internet Computer](https://internetcomputer.org/).


### PR DESCRIPTION
This PR embeds the README of the `pocket-ic` crate in its docs as served by [docs.rs](https://docs.rs/pocket-ic/latest/pocket_ic/). It does so [analogously](https://github.com/dfinity/stable-structures/blob/0dc72fa3d9029038b125973994f685181d1218fe/src/lib.rs#L1) to the `ic-stable-structures` crate.

(Reported internally on [slack](https://dfinity.slack.com/archives/C0527QACNJC/p1753046149546109).)