### PR TITLE
chore: inline dependencies in artifact_pool crates

### DIFF
--- a/rs/artifact_pool/BUILD.bazel
+++ b/rs/artifact_pool/BUILD.bazel
@@ -3,35 +3,6 @@ load("//bazel:defs.bzl", "rust_bench")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/config",
-    "//rs/interfaces",
-    "//rs/monitoring/logger",
-    "//rs/monitoring/metrics",
-    "//rs/protobuf",
-    "//rs/sys",
-    "//rs/types/types",
-    "@crate_index//:bincode",
-    "@crate_index//:byteorder",
-    "@crate_index//:lmdb-rkv",
-    "@crate_index//:lmdb-rkv-sys",
-    "@crate_index//:nix",
-    "@crate_index//:prometheus",
-    "@crate_index//:prost",
-    "@crate_index//:serde",
-    "@crate_index//:slog",
-    "@crate_index//:strum",
-    "@crate_index//:tempfile",
-] + select({
-    "@platforms//os:osx": [
-        "@crate_index//:rocksdb",
-        "@crate_index//:slog-envlogger",  # needed by rocksdb implem
-    ],
-    "//conditions:default": [
-    ],
-})
-
 MACRO_DEPENDENCIES = []
 
 DEV_DEPENDENCIES = [
@@ -58,14 +29,68 @@ rust_library(
     crate_name = "ic_artifact_pool",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/config",
+        "//rs/interfaces",
+        "//rs/monitoring/logger",
+        "//rs/monitoring/metrics",
+        "//rs/protobuf",
+        "//rs/sys",
+        "//rs/types/types",
+        "@crate_index//:bincode",
+        "@crate_index//:byteorder",
+        "@crate_index//:lmdb-rkv",
+        "@crate_index//:lmdb-rkv-sys",
+        "@crate_index//:nix",
+        "@crate_index//:prometheus",
+        "@crate_index//:prost",
+        "@crate_index//:serde",
+        "@crate_index//:slog",
+        "@crate_index//:strum",
+        "@crate_index//:tempfile",
+    ] + select({
+        "@platforms//os:osx": [
+            "@crate_index//:rocksdb",
+            "@crate_index//:slog-envlogger",  # needed by rocksdb implem
+        ],
+        "//conditions:default": [
+        ],
+    }),
 )
 
 rust_binary(
     name = "ic-consensus-pool-util",
     srcs = ["bin/consensus_pool_util.rs"],
     proc_macro_deps = MACRO_DEPENDENCIES,
-    deps = DEPENDENCIES + [
+    deps = [
+        # Keep sorted.
+        "//rs/config",
+        "//rs/interfaces",
+        "//rs/monitoring/logger",
+        "//rs/monitoring/metrics",
+        "//rs/protobuf",
+        "//rs/sys",
+        "//rs/types/types",
+        "@crate_index//:bincode",
+        "@crate_index//:byteorder",
+        "@crate_index//:lmdb-rkv",
+        "@crate_index//:lmdb-rkv-sys",
+        "@crate_index//:nix",
+        "@crate_index//:prometheus",
+        "@crate_index//:prost",
+        "@crate_index//:serde",
+        "@crate_index//:slog",
+        "@crate_index//:strum",
+        "@crate_index//:tempfile",
+    ] + select({
+        "@platforms//os:osx": [
+            "@crate_index//:rocksdb",
+            "@crate_index//:slog-envlogger",  # needed by rocksdb implem
+        ],
+        "//conditions:default": [
+        ],
+    }) + [
         ":artifact_pool",
         "@crate_index//:clap",
         "@crate_index//:serde-bytes-repr",
@@ -89,5 +114,32 @@ rust_bench(
     testonly = True,
     srcs = ["benches/load_blocks.rs"],
     proc_macro_deps = MACRO_DEPENDENCIES + DEV_MACRO_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + BENCH_DEPENDENCIES + [":artifact_pool"],
+    deps = [
+        # Keep sorted.
+        "//rs/config",
+        "//rs/interfaces",
+        "//rs/monitoring/logger",
+        "//rs/monitoring/metrics",
+        "//rs/protobuf",
+        "//rs/sys",
+        "//rs/types/types",
+        "@crate_index//:bincode",
+        "@crate_index//:byteorder",
+        "@crate_index//:lmdb-rkv",
+        "@crate_index//:lmdb-rkv-sys",
+        "@crate_index//:nix",
+        "@crate_index//:prometheus",
+        "@crate_index//:prost",
+        "@crate_index//:serde",
+        "@crate_index//:slog",
+        "@crate_index//:strum",
+        "@crate_index//:tempfile",
+    ] + select({
+        "@platforms//os:osx": [
+            "@crate_index//:rocksdb",
+            "@crate_index//:slog-envlogger",  # needed by rocksdb implem
+        ],
+        "//conditions:default": [
+        ],
+    }) + DEV_DEPENDENCIES + BENCH_DEPENDENCIES + [":artifact_pool"],
 )


### PR DESCRIPTION
This inlines `DEPENDENCIES` and other dep bundles in `BUILD.bazel` files for the crates under `rs/artifact_pool`. This makes the dependencies of each target more explicit and helps analysis tools.