### PR TITLE
chore(CRP-2613): Remove deprecated compute_initial_i_dkg_dealings endpoint Pt. 2

### DIFF
--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -489,7 +489,7 @@ fn generate_dkg_response_payload(
     }
 }
 
-/// Creates responses to `ComputeInitialIDkgDealingsArgs` system calls with the initial
+/// Creates responses to `ReshareChainKeyArgs` system calls with the initial
 /// dealings.
 fn generate_responses_to_initial_dealings_calls(
     idkg_payload: &idkg::IDkgPayload,


### PR DESCRIPTION
This is Part 2 of the `compute_initial_i_dkg_dealings` endpoint removal, following #5866.

This PR:
- Removes `ComputeInitialIDkgDealingsResponse` and the special cases regarding it's decoding
- Removes the `ComputeInitialIDkgDealignsArgs`, which are no longer in use
- Adapts 2 tests, which were still not migrated