### PR TITLE
feat: Extra progress logging for response body streaming in `file_downloader.rs`

### DIFF
--- a/rs/http_utils/src/file_downloader.rs
+++ b/rs/http_utils/src/file_downloader.rs
@@ -277,7 +277,7 @@ impl FileDownloader {
                 .map_err(|e| FileDownloadError::file_write_error(file_path, e))?;
         }
         maybe_info!(
-            self,
+            self.logger,
             "Streamed {} chunks totalling {} bytes to file {:?}.",
             chunks_cnt,
             chunks_total_len,

--- a/rs/http_utils/src/file_downloader.rs
+++ b/rs/http_utils/src/file_downloader.rs
@@ -49,6 +49,11 @@ macro_rules! maybe_info {
 }
 
 macro_rules! maybe_warn {
+    (every_n_seconds => $seconds:expr, $logger:expr, $($arg:tt)+) => {
+        if let Some(logger) = $logger.as_ref() {
+            warn!(every_n_seconds => $seconds, logger, $($arg)+);
+        }
+    };
     ($logger:expr, $($arg:tt)+) => {
         maybe_log!($logger, Level::Warning, $($arg)+);
     };

--- a/rs/http_utils/src/file_downloader.rs
+++ b/rs/http_utils/src/file_downloader.rs
@@ -1,7 +1,7 @@
 use flate2::read::GzDecoder;
 use http::Method;
 use ic_crypto_sha2::Sha256;
-use ic_logger::{log, ReplicaLogger};
+use ic_logger::{info, log, ReplicaLogger};
 use reqwest::{Client, Response};
 use slog::Level;
 use std::error::Error;
@@ -38,6 +38,11 @@ macro_rules! maybe_log {
 }
 
 macro_rules! maybe_info {
+    (every_n_seconds => $seconds:expr, $logger:expr, $($arg:tt)+) => {
+        if let Some(logger) = $logger.as_ref() {
+            info!(every_n_seconds => $seconds, logger, $($arg)+);
+        }
+    };
     ($logger:expr, $($arg:tt)+) => {
         maybe_log!($logger, Level::Info, $($arg)+);
     };
@@ -241,6 +246,8 @@ impl FileDownloader {
         mut file: fs::File,
         file_path: &Path,
     ) -> FileDownloadResult<()> {
+        let mut chunks_cnt: i32 = 0;
+        let mut chunks_total_len: usize = 0;
         while let Some(chunk) = tokio::time::timeout(self.chunk_timeout, response.chunk())
             .await
             // This error comes from `tokio::time::timeout`
@@ -256,9 +263,26 @@ impl FileDownloader {
                 }
             })?
         {
+            chunks_cnt += 1;
+            chunks_total_len += chunk.len();
+            maybe_info!(
+                every_n_seconds => 1,
+                self.logger,
+                "Streaming {} bytes to {:?} (this is chunk #{} from the beginning).",
+                chunk.len(),
+                file_path,
+                chunks_cnt
+            );
             file.write_all(&chunk)
                 .map_err(|e| FileDownloadError::file_write_error(file_path, e))?;
         }
+        maybe_info!(
+            self,
+            "Streamed {} chunks totalling {} bytes to file {:?}.",
+            chunks_cnt,
+            chunks_total_len,
+            file_path
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
This change adds extra progress logging during response body streaming in `file_downloader.rs`, to help debug slow downloads in system tests involving replica version upgrades/downgrades.

A concrete use case is investigating flakiness in `//rs/tests/message_routing/xnet:xnet_compatibility`, where slow downloads still occasionally occur, even after recent DNS-related fixes. In these cases, connections are successfully established, but streaming is sluggish or stalls unpredictably. E.g., on July 9th, there was a run where one download took 345 seconds (which is 1-2 orders of magnitude over what's to be expected from normal runs):

<img width="5108" height="1854" alt="image" src="https://github.com/user-attachments/assets/544bf378-7d40-474e-b227-b34fec4a137a" />


