### PR TITLE
chore: bump wasm-tools to 1.233.0

### DIFF
--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d547c429b3b3bfddefc143b24c9fded10912b50b4cf75cc15c72f53ac6dce413",
+  "checksum": "82b9dc1b062e2f10c65f9e6226ef253310ebe9b68e9e3e55c7c6d387b030097b",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -2666,7 +2666,23 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "derive",
+            "derive_arbitrary"
+          ],
+          "selects": {}
+        },
         "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "derive_arbitrary 1.4.1",
+              "target": "derive_arbitrary"
+            }
+          ],
+          "selects": {}
+        },
         "version": "1.4.1"
       },
       "license": "MIT OR Apache-2.0",
@@ -19854,6 +19870,62 @@
       ],
       "license_file": "LICENSE"
     },
+    "derive_arbitrary 1.4.1": {
+      "name": "derive_arbitrary",
+      "version": "1.4.1",
+      "package_url": "https://github.com/rust-fuzz/arbitrary",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/derive_arbitrary/1.4.1/download",
+          "sha256": "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "derive_arbitrary",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "derive_arbitrary",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.95",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.40",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.101",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.4.1"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "derive_more 0.99.17": {
       "name": "derive_more",
       "version": "0.99.17",
@@ -21756,6 +21828,10 @@
             {
               "id": "wasm-encoder 0.233.0",
               "target": "wasm_encoder"
+            },
+            {
+              "id": "wasm-smith 0.233.0",
+              "target": "wasm_smith"
             },
             {
               "id": "wasmparser 0.233.0",
@@ -85712,6 +85788,76 @@
       ],
       "license_file": null
     },
+    "wasm-smith 0.233.0": {
+      "name": "wasm-smith",
+      "version": "0.233.0",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasm-smith/0.233.0/download",
+          "sha256": "2820810ea8e870fd5ae956750b457e0997099c806e4747d0abc4d5e608c4e59f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasm_smith",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasm_smith",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "wasmparser"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.98",
+              "target": "anyhow"
+            },
+            {
+              "id": "arbitrary 1.4.1",
+              "target": "arbitrary"
+            },
+            {
+              "id": "flagset 0.4.4",
+              "target": "flagset"
+            },
+            {
+              "id": "wasm-encoder 0.233.0",
+              "target": "wasm_encoder"
+            },
+            {
+              "id": "wasmparser 0.233.0",
+              "target": "wasmparser"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.233.0"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
     "wasm-streams 0.4.0": {
       "name": "wasm-streams",
       "version": "0.4.0",
@@ -93981,6 +94127,7 @@
     "warp 0.3.7",
     "wasm-bindgen 0.2.100",
     "wasm-encoder 0.233.0",
+    "wasm-smith 0.233.0",
     "wasmparser 0.233.0",
     "wasmprinter 0.233.0",
     "wasmtime 34.0.1",

--- a/Cargo.Bazel.Fuzzing.json.lock
+++ b/Cargo.Bazel.Fuzzing.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b3897231381416ac6a10988ae7f3279e33ecbef821897d618124e1ee8716c7b1",
+  "checksum": "d547c429b3b3bfddefc143b24c9fded10912b50b4cf75cc15c72f53ac6dce413",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -2666,23 +2666,7 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "derive",
-            "derive_arbitrary"
-          ],
-          "selects": {}
-        },
         "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "derive_arbitrary 1.4.1",
-              "target": "derive_arbitrary"
-            }
-          ],
-          "selects": {}
-        },
         "version": "1.4.1"
       },
       "license": "MIT OR Apache-2.0",
@@ -19870,62 +19854,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "derive_arbitrary 1.4.1": {
-      "name": "derive_arbitrary",
-      "version": "1.4.1",
-      "package_url": "https://github.com/rust-fuzz/arbitrary",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/derive_arbitrary/1.4.1/download",
-          "sha256": "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "derive_arbitrary",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "derive_arbitrary",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.95",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.40",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.101",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.4.1"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "derive_more 0.99.17": {
       "name": "derive_more",
       "version": "0.99.17",
@@ -21826,19 +21754,15 @@
               "target": "wasm_bindgen"
             },
             {
-              "id": "wasm-encoder 0.228.0",
+              "id": "wasm-encoder 0.233.0",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasm-smith 0.228.0",
-              "target": "wasm_smith"
-            },
-            {
-              "id": "wasmparser 0.228.0",
+              "id": "wasmparser 0.233.0",
               "target": "wasmparser"
             },
             {
-              "id": "wasmprinter 0.228.0",
+              "id": "wasmprinter 0.233.0",
               "target": "wasmprinter"
             },
             {
@@ -21850,7 +21774,7 @@
               "target": "wasmtime_environ"
             },
             {
-              "id": "wast 228.0.0",
+              "id": "wast 233.0.0",
               "target": "wast"
             },
             {
@@ -85618,14 +85542,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasm-encoder 0.228.0": {
+    "wasm-encoder 0.233.0": {
       "name": "wasm-encoder",
-      "version": "0.228.0",
+      "version": "0.233.0",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.228.0/download",
-          "sha256": "05d30290541f2d4242a162bbda76b8f2d8b1ac59eab3568ed6f2327d52c9b2c4"
+          "url": "https://static.crates.io/crates/wasm-encoder/0.233.0/download",
+          "sha256": "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
         }
       },
       "targets": [
@@ -85675,95 +85599,12 @@
               "target": "leb128fmt"
             },
             {
-              "id": "wasm-encoder 0.228.0",
-              "target": "build_script_build"
-            },
-            {
-              "id": "wasmparser 0.228.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.228.0"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasm-encoder 0.233.0": {
-      "name": "wasm-encoder",
-      "version": "0.233.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.233.0/download",
-          "sha256": "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_encoder",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasm_encoder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "leb128fmt 0.1.0",
-              "target": "leb128fmt"
-            },
-            {
               "id": "wasm-encoder 0.233.0",
               "target": "build_script_build"
+            },
+            {
+              "id": "wasmparser 0.233.0",
+              "target": "wasmparser"
             }
           ],
           "selects": {}
@@ -85863,76 +85704,6 @@
         "data_glob": [
           "**"
         ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasm-smith 0.228.0": {
-      "name": "wasm-smith",
-      "version": "0.228.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-smith/0.228.0/download",
-          "sha256": "8906f0848b81bd33103f0db54396c52db4c46518eb55bebf28eae45a442b47f1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_smith",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasm_smith",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "wasmparser"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "anyhow 1.0.98",
-              "target": "anyhow"
-            },
-            {
-              "id": "arbitrary 1.4.1",
-              "target": "arbitrary"
-            },
-            {
-              "id": "flagset 0.4.4",
-              "target": "flagset"
-            },
-            {
-              "id": "wasm-encoder 0.228.0",
-              "target": "wasm_encoder"
-            },
-            {
-              "id": "wasmparser 0.228.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.228.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -86212,14 +85983,14 @@
       ],
       "license_file": null
     },
-    "wasmparser 0.228.0": {
+    "wasmparser 0.233.0": {
       "name": "wasmparser",
-      "version": "0.228.0",
+      "version": "0.233.0",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.228.0/download",
-          "sha256": "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
+          "url": "https://static.crates.io/crates/wasmparser/0.233.0/download",
+          "sha256": "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
         }
       },
       "targets": [
@@ -86279,100 +86050,6 @@
             {
               "id": "indexmap 2.7.1",
               "target": "indexmap"
-            },
-            {
-              "id": "semver 1.0.22",
-              "target": "semver"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "wasmparser 0.228.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.228.0"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasmparser 0.233.0": {
-      "name": "wasmparser",
-      "version": "0.233.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.233.0/download",
-          "sha256": "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmparser",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmparser",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "features",
-            "serde",
-            "simd",
-            "std",
-            "validate"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 2.9.0",
-              "target": "bitflags"
             },
             {
               "id": "semver 1.0.22",
@@ -86477,69 +86154,6 @@
         "data_glob": [
           "**"
         ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasmprinter 0.228.0": {
-      "name": "wasmprinter",
-      "version": "0.228.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmprinter/0.228.0/download",
-          "sha256": "0df64bd38c14db359d02ce2024c64eb161aa2618ccee5f3bc5acbbd65c9a875c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmprinter",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmprinter",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "anyhow 1.0.98",
-              "target": "anyhow"
-            },
-            {
-              "id": "termcolor 1.4.1",
-              "target": "termcolor"
-            },
-            {
-              "id": "wasmparser 0.228.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.228.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -87591,14 +87205,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wast 228.0.0": {
+    "wast 233.0.0": {
       "name": "wast",
-      "version": "228.0.0",
+      "version": "233.0.0",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wast/228.0.0/download",
-          "sha256": "9e5aae124478cb51439f6587f074a3a5e835afd22751c59a87b2e2a882727c97"
+          "url": "https://static.crates.io/crates/wast/233.0.0/download",
+          "sha256": "2eaf4099d8d0c922b83bf3c90663f5666f0769db9e525184284ebbbdb1dd2180"
         }
       },
       "targets": [
@@ -87647,14 +87261,14 @@
               "target": "unicode_width"
             },
             {
-              "id": "wasm-encoder 0.228.0",
+              "id": "wasm-encoder 0.233.0",
               "target": "wasm_encoder"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "228.0.0"
+        "version": "233.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -94366,13 +93980,12 @@
     "walkdir 2.5.0",
     "warp 0.3.7",
     "wasm-bindgen 0.2.100",
-    "wasm-encoder 0.228.0",
-    "wasm-smith 0.228.0",
-    "wasmparser 0.228.0",
-    "wasmprinter 0.228.0",
+    "wasm-encoder 0.233.0",
+    "wasmparser 0.233.0",
+    "wasmprinter 0.233.0",
     "wasmtime 34.0.1",
     "wasmtime-environ 34.0.1",
-    "wast 228.0.0",
+    "wast 233.0.0",
     "wat 1.234.0",
     "wee_alloc 0.4.5",
     "which 4.4.2",

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -471,6 +471,9 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -3353,6 +3356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3800,6 +3814,7 @@ dependencies = [
  "warp",
  "wasm-bindgen",
  "wasm-encoder 0.233.0",
+ "wasm-smith",
  "wasmparser 0.233.0",
  "wasmprinter",
  "wasmtime",
@@ -14375,6 +14390,19 @@ checksum = "170a0157eef517a179f2d20ed7c68df9c3f7f6c1c047782d488bf5a464174684"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.234.0",
+]
+
+[[package]]
+name = "wasm-smith"
+version = "0.233.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2820810ea8e870fd5ae956750b457e0997099c806e4747d0abc4d5e608c4e59f"
+dependencies = [
+ "anyhow",
+ "arbitrary",
+ "flagset",
+ "wasm-encoder 0.233.0",
+ "wasmparser 0.233.0",
 ]
 
 [[package]]

--- a/Cargo.Bazel.Fuzzing.toml.lock
+++ b/Cargo.Bazel.Fuzzing.toml.lock
@@ -471,9 +471,6 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "arc-swap"
@@ -3356,17 +3353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,13 +3799,12 @@ dependencies = [
  "walkdir",
  "warp",
  "wasm-bindgen",
- "wasm-encoder 0.228.0",
- "wasm-smith",
- "wasmparser 0.228.0",
- "wasmprinter 0.228.0",
+ "wasm-encoder 0.233.0",
+ "wasmparser 0.233.0",
+ "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
- "wast 228.0.0",
+ "wast 233.0.0",
  "wat",
  "wee_alloc",
  "which",
@@ -14374,16 +14359,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d30290541f2d4242a162bbda76b8f2d8b1ac59eab3568ed6f2327d52c9b2c4"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.228.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.233.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
@@ -14400,19 +14375,6 @@ checksum = "170a0157eef517a179f2d20ed7c68df9c3f7f6c1c047782d488bf5a464174684"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.234.0",
-]
-
-[[package]]
-name = "wasm-smith"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8906f0848b81bd33103f0db54396c52db4c46518eb55bebf28eae45a442b47f1"
-dependencies = [
- "anyhow",
- "arbitrary",
- "flagset",
- "wasm-encoder 0.228.0",
- "wasmparser 0.228.0",
 ]
 
 [[package]]
@@ -14469,19 +14431,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
-dependencies = [
- "bitflags 2.9.0",
- "hashbrown 0.15.2",
- "indexmap 2.7.1",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.233.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
@@ -14502,17 +14451,6 @@ dependencies = [
  "bitflags 2.9.0",
  "indexmap 2.7.1",
  "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df64bd38c14db359d02ce2024c64eb161aa2618ccee5f3bc5acbbd65c9a875c"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.228.0",
 ]
 
 [[package]]
@@ -14624,7 +14562,7 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.233.0",
  "wasmparser 0.233.0",
- "wasmprinter 0.233.0",
+ "wasmprinter",
 ]
 
 [[package]]
@@ -14700,15 +14638,15 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "228.0.0"
+version = "233.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5aae124478cb51439f6587f074a3a5e835afd22751c59a87b2e2a882727c97"
+checksum = "2eaf4099d8d0c922b83bf3c90663f5666f0769db9e525184284ebbbdb1dd2180"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.228.0",
+ "wasm-encoder 0.233.0",
 ]
 
 [[package]]

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d1114bea2a9a6169fa4a262ce57666f5ba93106a608b960ff3814be3c86a8d99",
+  "checksum": "f866b74e821ad7c842b410ece8e299291e22031afc5e902fe426cac6e6151b23",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -2670,23 +2670,7 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "derive",
-            "derive_arbitrary"
-          ],
-          "selects": {}
-        },
         "edition": "2021",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "derive_arbitrary 1.4.1",
-              "target": "derive_arbitrary"
-            }
-          ],
-          "selects": {}
-        },
         "version": "1.4.1"
       },
       "license": "MIT OR Apache-2.0",
@@ -19688,62 +19672,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "derive_arbitrary 1.4.1": {
-      "name": "derive_arbitrary",
-      "version": "1.4.1",
-      "package_url": "https://github.com/rust-fuzz/arbitrary",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/derive_arbitrary/1.4.1/download",
-          "sha256": "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "derive_arbitrary",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "derive_arbitrary",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.95",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.40",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.101",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "1.4.1"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "derive_more 0.99.17": {
       "name": "derive_more",
       "version": "0.99.17",
@@ -21644,19 +21572,15 @@
               "target": "wasm_bindgen"
             },
             {
-              "id": "wasm-encoder 0.228.0",
+              "id": "wasm-encoder 0.233.0",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasm-smith 0.228.0",
-              "target": "wasm_smith"
-            },
-            {
-              "id": "wasmparser 0.228.0",
+              "id": "wasmparser 0.233.0",
               "target": "wasmparser"
             },
             {
-              "id": "wasmprinter 0.228.0",
+              "id": "wasmprinter 0.233.0",
               "target": "wasmprinter"
             },
             {
@@ -21668,7 +21592,7 @@
               "target": "wasmtime_environ"
             },
             {
-              "id": "wast 228.0.0",
+              "id": "wast 233.0.0",
               "target": "wast"
             },
             {
@@ -85488,14 +85412,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wasm-encoder 0.228.0": {
+    "wasm-encoder 0.233.0": {
       "name": "wasm-encoder",
-      "version": "0.228.0",
+      "version": "0.233.0",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.228.0/download",
-          "sha256": "05d30290541f2d4242a162bbda76b8f2d8b1ac59eab3568ed6f2327d52c9b2c4"
+          "url": "https://static.crates.io/crates/wasm-encoder/0.233.0/download",
+          "sha256": "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
         }
       },
       "targets": [
@@ -85545,95 +85469,12 @@
               "target": "leb128fmt"
             },
             {
-              "id": "wasm-encoder 0.228.0",
-              "target": "build_script_build"
-            },
-            {
-              "id": "wasmparser 0.228.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.228.0"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasm-encoder 0.233.0": {
-      "name": "wasm-encoder",
-      "version": "0.233.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.233.0/download",
-          "sha256": "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_encoder",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasm_encoder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "leb128fmt 0.1.0",
-              "target": "leb128fmt"
-            },
-            {
               "id": "wasm-encoder 0.233.0",
               "target": "build_script_build"
+            },
+            {
+              "id": "wasmparser 0.233.0",
+              "target": "wasmparser"
             }
           ],
           "selects": {}
@@ -85733,76 +85574,6 @@
         "data_glob": [
           "**"
         ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasm-smith 0.228.0": {
-      "name": "wasm-smith",
-      "version": "0.228.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-smith/0.228.0/download",
-          "sha256": "8906f0848b81bd33103f0db54396c52db4c46518eb55bebf28eae45a442b47f1"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_smith",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasm_smith",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "wasmparser"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "anyhow 1.0.98",
-              "target": "anyhow"
-            },
-            {
-              "id": "arbitrary 1.4.1",
-              "target": "arbitrary"
-            },
-            {
-              "id": "flagset 0.4.3",
-              "target": "flagset"
-            },
-            {
-              "id": "wasm-encoder 0.228.0",
-              "target": "wasm_encoder"
-            },
-            {
-              "id": "wasmparser 0.228.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.228.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -86082,14 +85853,14 @@
       ],
       "license_file": null
     },
-    "wasmparser 0.228.0": {
+    "wasmparser 0.233.0": {
       "name": "wasmparser",
-      "version": "0.228.0",
+      "version": "0.233.0",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.228.0/download",
-          "sha256": "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
+          "url": "https://static.crates.io/crates/wasmparser/0.233.0/download",
+          "sha256": "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
         }
       },
       "targets": [
@@ -86149,100 +85920,6 @@
             {
               "id": "indexmap 2.7.1",
               "target": "indexmap"
-            },
-            {
-              "id": "semver 1.0.22",
-              "target": "semver"
-            },
-            {
-              "id": "serde 1.0.217",
-              "target": "serde"
-            },
-            {
-              "id": "wasmparser 0.228.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.228.0"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasmparser 0.233.0": {
-      "name": "wasmparser",
-      "version": "0.233.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.233.0/download",
-          "sha256": "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmparser",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmparser",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "features",
-            "serde",
-            "simd",
-            "std",
-            "validate"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 2.9.0",
-              "target": "bitflags"
             },
             {
               "id": "semver 1.0.22",
@@ -86347,69 +86024,6 @@
         "data_glob": [
           "**"
         ]
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasmprinter 0.228.0": {
-      "name": "wasmprinter",
-      "version": "0.228.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmprinter/0.228.0/download",
-          "sha256": "0df64bd38c14db359d02ce2024c64eb161aa2618ccee5f3bc5acbbd65c9a875c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmprinter",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmprinter",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "anyhow 1.0.98",
-              "target": "anyhow"
-            },
-            {
-              "id": "termcolor 1.4.1",
-              "target": "termcolor"
-            },
-            {
-              "id": "wasmparser 0.228.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.228.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -87438,14 +87052,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wast 228.0.0": {
+    "wast 233.0.0": {
       "name": "wast",
-      "version": "228.0.0",
+      "version": "233.0.0",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wast/228.0.0/download",
-          "sha256": "9e5aae124478cb51439f6587f074a3a5e835afd22751c59a87b2e2a882727c97"
+          "url": "https://static.crates.io/crates/wast/233.0.0/download",
+          "sha256": "2eaf4099d8d0c922b83bf3c90663f5666f0769db9e525184284ebbbdb1dd2180"
         }
       },
       "targets": [
@@ -87494,14 +87108,14 @@
               "target": "unicode_width"
             },
             {
-              "id": "wasm-encoder 0.228.0",
+              "id": "wasm-encoder 0.233.0",
               "target": "wasm_encoder"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "228.0.0"
+        "version": "233.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -94331,13 +93945,12 @@
     "walkdir 2.5.0",
     "warp 0.3.7",
     "wasm-bindgen 0.2.100",
-    "wasm-encoder 0.228.0",
-    "wasm-smith 0.228.0",
-    "wasmparser 0.228.0",
-    "wasmprinter 0.228.0",
+    "wasm-encoder 0.233.0",
+    "wasmparser 0.233.0",
+    "wasmprinter 0.233.0",
     "wasmtime 34.0.1",
     "wasmtime-environ 34.0.1",
-    "wast 228.0.0",
+    "wast 233.0.0",
     "wat 1.234.0",
     "wee_alloc 0.4.5",
     "which 4.4.0",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f866b74e821ad7c842b410ece8e299291e22031afc5e902fe426cac6e6151b23",
+  "checksum": "8efe91d6d9dd00587adc269d2781b54200f548f49973453eb8998e9eb1a4f3e6",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -2670,7 +2670,23 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "derive",
+            "derive_arbitrary"
+          ],
+          "selects": {}
+        },
         "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "derive_arbitrary 1.4.1",
+              "target": "derive_arbitrary"
+            }
+          ],
+          "selects": {}
+        },
         "version": "1.4.1"
       },
       "license": "MIT OR Apache-2.0",
@@ -19672,6 +19688,62 @@
       ],
       "license_file": "LICENSE"
     },
+    "derive_arbitrary 1.4.1": {
+      "name": "derive_arbitrary",
+      "version": "1.4.1",
+      "package_url": "https://github.com/rust-fuzz/arbitrary",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/derive_arbitrary/1.4.1/download",
+          "sha256": "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "derive_arbitrary",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "derive_arbitrary",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "proc-macro2 1.0.95",
+              "target": "proc_macro2"
+            },
+            {
+              "id": "quote 1.0.40",
+              "target": "quote"
+            },
+            {
+              "id": "syn 2.0.101",
+              "target": "syn"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.4.1"
+      },
+      "license": "MIT/Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "derive_more 0.99.17": {
       "name": "derive_more",
       "version": "0.99.17",
@@ -21574,6 +21646,10 @@
             {
               "id": "wasm-encoder 0.233.0",
               "target": "wasm_encoder"
+            },
+            {
+              "id": "wasm-smith 0.233.0",
+              "target": "wasm_smith"
             },
             {
               "id": "wasmparser 0.233.0",
@@ -85582,6 +85658,76 @@
       ],
       "license_file": null
     },
+    "wasm-smith 0.233.0": {
+      "name": "wasm-smith",
+      "version": "0.233.0",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasm-smith/0.233.0/download",
+          "sha256": "2820810ea8e870fd5ae956750b457e0997099c806e4747d0abc4d5e608c4e59f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasm_smith",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasm_smith",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "wasmparser"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.98",
+              "target": "anyhow"
+            },
+            {
+              "id": "arbitrary 1.4.1",
+              "target": "arbitrary"
+            },
+            {
+              "id": "flagset 0.4.3",
+              "target": "flagset"
+            },
+            {
+              "id": "wasm-encoder 0.233.0",
+              "target": "wasm_encoder"
+            },
+            {
+              "id": "wasmparser 0.233.0",
+              "target": "wasmparser"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.233.0"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
     "wasm-streams 0.4.0": {
       "name": "wasm-streams",
       "version": "0.4.0",
@@ -93946,6 +94092,7 @@
     "warp 0.3.7",
     "wasm-bindgen 0.2.100",
     "wasm-encoder 0.233.0",
+    "wasm-smith 0.233.0",
     "wasmparser 0.233.0",
     "wasmprinter 0.233.0",
     "wasmtime 34.0.1",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -472,9 +472,6 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "arc-swap"
@@ -3345,17 +3342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3802,13 +3788,12 @@ dependencies = [
  "walkdir",
  "warp",
  "wasm-bindgen",
- "wasm-encoder 0.228.0",
- "wasm-smith",
- "wasmparser 0.228.0",
- "wasmprinter 0.228.0",
+ "wasm-encoder 0.233.0",
+ "wasmparser 0.233.0",
+ "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
- "wast 228.0.0",
+ "wast 233.0.0",
  "wat",
  "wee_alloc",
  "which",
@@ -14370,16 +14355,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d30290541f2d4242a162bbda76b8f2d8b1ac59eab3568ed6f2327d52c9b2c4"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.228.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.233.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
@@ -14396,19 +14371,6 @@ checksum = "170a0157eef517a179f2d20ed7c68df9c3f7f6c1c047782d488bf5a464174684"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.234.0",
-]
-
-[[package]]
-name = "wasm-smith"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8906f0848b81bd33103f0db54396c52db4c46518eb55bebf28eae45a442b47f1"
-dependencies = [
- "anyhow",
- "arbitrary",
- "flagset",
- "wasm-encoder 0.228.0",
- "wasmparser 0.228.0",
 ]
 
 [[package]]
@@ -14465,19 +14427,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
-dependencies = [
- "bitflags 2.9.0",
- "hashbrown 0.15.2",
- "indexmap 2.7.1",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.233.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
@@ -14498,17 +14447,6 @@ dependencies = [
  "bitflags 2.9.0",
  "indexmap 2.7.1",
  "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df64bd38c14db359d02ce2024c64eb161aa2618ccee5f3bc5acbbd65c9a875c"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.228.0",
 ]
 
 [[package]]
@@ -14620,7 +14558,7 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.233.0",
  "wasmparser 0.233.0",
- "wasmprinter 0.233.0",
+ "wasmprinter",
 ]
 
 [[package]]
@@ -14696,15 +14634,15 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "228.0.0"
+version = "233.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5aae124478cb51439f6587f074a3a5e835afd22751c59a87b2e2a882727c97"
+checksum = "2eaf4099d8d0c922b83bf3c90663f5666f0769db9e525184284ebbbdb1dd2180"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.228.0",
+ "wasm-encoder 0.233.0",
 ]
 
 [[package]]

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -472,6 +472,9 @@ name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -3342,6 +3345,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,6 +3803,7 @@ dependencies = [
  "warp",
  "wasm-bindgen",
  "wasm-encoder 0.233.0",
+ "wasm-smith",
  "wasmparser 0.233.0",
  "wasmprinter",
  "wasmtime",
@@ -14371,6 +14386,19 @@ checksum = "170a0157eef517a179f2d20ed7c68df9c3f7f6c1c047782d488bf5a464174684"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.234.0",
+]
+
+[[package]]
+name = "wasm-smith"
+version = "0.233.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2820810ea8e870fd5ae956750b457e0997099c806e4747d0abc4d5e608c4e59f"
+dependencies = [
+ "anyhow",
+ "arbitrary",
+ "flagset",
+ "wasm-encoder 0.233.0",
+ "wasmparser 0.233.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ dependencies = [
  "on_wire",
  "rand 0.8.5",
  "tokio",
- "wasmprinter 0.228.0",
+ "wasmprinter",
  "wat",
 ]
 
@@ -9011,7 +9011,7 @@ dependencies = [
  "slog-term",
  "tokio",
  "tower 0.5.2",
- "wasmparser 0.228.0",
+ "wasmparser 0.233.0",
 ]
 
 [[package]]
@@ -9101,12 +9101,12 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "wasm-encoder 0.228.0",
- "wasmparser 0.228.0",
- "wasmprinter 0.228.0",
+ "wasm-encoder 0.233.0",
+ "wasmparser 0.233.0",
+ "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
- "wast 228.0.0",
+ "wast 233.0.0",
  "wat",
 ]
 
@@ -9224,7 +9224,7 @@ dependencies = [
  "tokio",
  "tower 0.5.2",
  "tracing",
- "wasmparser 0.228.0",
+ "wasmparser 0.233.0",
  "wat",
 ]
 
@@ -14104,7 +14104,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower 0.5.2",
- "wasmprinter 0.228.0",
+ "wasmprinter",
  "wat",
 ]
 
@@ -14776,9 +14776,9 @@ dependencies = [
 name = "ic-wasm-transform"
 version = "0.9.0"
 dependencies = [
- "wasm-encoder 0.228.0",
- "wasmparser 0.228.0",
- "wasmprinter 0.228.0",
+ "wasm-encoder 0.233.0",
+ "wasmparser 0.233.0",
+ "wasmprinter",
  "wat",
 ]
 
@@ -16556,7 +16556,7 @@ dependencies = [
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-test-utils",
- "wasmprinter 0.228.0",
+ "wasmprinter",
 ]
 
 [[package]]
@@ -24349,16 +24349,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d30290541f2d4242a162bbda76b8f2d8b1ac59eab3568ed6f2327d52c9b2c4"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.228.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.233.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
@@ -24406,19 +24396,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
-dependencies = [
- "bitflags 2.9.0",
- "hashbrown 0.15.2",
- "indexmap 2.10.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.233.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
@@ -24439,17 +24416,6 @@ dependencies = [
  "bitflags 2.9.0",
  "indexmap 2.10.0",
  "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df64bd38c14db359d02ce2024c64eb161aa2618ccee5f3bc5acbbd65c9a875c"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.228.0",
 ]
 
 [[package]]
@@ -24561,7 +24527,7 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.233.0",
  "wasmparser 0.233.0",
- "wasmprinter 0.233.0",
+ "wasmprinter",
 ]
 
 [[package]]
@@ -24637,15 +24603,15 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "228.0.0"
+version = "233.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5aae124478cb51439f6587f074a3a5e835afd22751c59a87b2e2a882727c97"
+checksum = "2eaf4099d8d0c922b83bf3c90663f5666f0769db9e525184284ebbbdb1dd2180"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.228.0",
+ "wasm-encoder 0.233.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -790,11 +790,11 @@ uuid = { version = "=1.12.1", features = ["v4", "serde"] }
 virt = "0.4"
 walkdir = "2.3.3"
 walrus = "0.23.3"
-wasm-encoder = { version = "0.228.0", features = ["wasmparser"] }
-wasmparser = "0.228.0"
-wasmprinter = "0.228.0"
-wast = "228.0.0"
-wat = "1.228.0"
+wasm-encoder = { version = "0.233.0", features = ["wasmparser"] }
+wasmparser = "0.233.0"
+wasmprinter = "0.233.0"
+wast = "233.0.0"
+wat = "1.233.0"
 which = "6.0.3"
 x509-cert = { version = "0.2.5", features = ["builder", "hazmat"] }
 x509-parser = { version = "0.16.0" }

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1529,6 +1529,13 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                     "wasmparser",
                 ],
             ),
+            "wasm-smith": crate.spec(
+                version = "^0.233.0",
+                default_features = False,
+                features = [
+                    "wasmparser",
+                ],
+            ),
             "wasmparser": crate.spec(
                 version = "^0.233.0",
             ),

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -1524,23 +1524,16 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^0.2",
             ),
             "wasm-encoder": crate.spec(
-                version = "^0.228.0",
-                features = [
-                    "wasmparser",
-                ],
-            ),
-            "wasm-smith": crate.spec(
-                version = "^0.228.0",
-                default_features = False,
+                version = "^0.233.0",
                 features = [
                     "wasmparser",
                 ],
             ),
             "wasmparser": crate.spec(
-                version = "^0.228.0",
+                version = "^0.233.0",
             ),
             "wasmprinter": crate.spec(
-                version = "^0.228.0",
+                version = "^0.233.0",
             ),
             "wasmtime": crate.spec(
                 version = "^34.0.1",
@@ -1557,10 +1550,10 @@ def external_crates_repository(name, cargo_lockfile, lockfile, sanitizers_enable
                 version = "^34.0.1",
             ),
             "wast": crate.spec(
-                version = "^228.0.0",
+                version = "^233.0.0",
             ),
             "wat": crate.spec(
-                version = "^1.228.0",
+                version = "^1.233.0",
             ),
             "wee_alloc": crate.spec(
                 version = "^0.4.3",

--- a/rs/embedders/fuzz/BUILD.bazel
+++ b/rs/embedders/fuzz/BUILD.bazel
@@ -48,6 +48,7 @@ rust_library(
         "@crate_index//:tempfile",
         "@crate_index//:tokio",
         "@crate_index//:wasm-encoder",
+        "@crate_index//:wasm-smith",
         "@crate_index//:wasmparser",
         "@crate_index//:wasmtime",
     ],

--- a/rs/embedders/fuzz/BUILD.bazel
+++ b/rs/embedders/fuzz/BUILD.bazel
@@ -48,7 +48,6 @@ rust_library(
         "@crate_index//:tempfile",
         "@crate_index//:tokio",
         "@crate_index//:wasm-encoder",
-        "@crate_index//:wasm-smith",
         "@crate_index//:wasmparser",
         "@crate_index//:wasmtime",
     ],


### PR DESCRIPTION
This PR bumps crates from `bytecodealliance/wasm-tools` to the release 1.233.0 corresponding to the [versions](https://github.com/bytecodealliance/wasmtime/blob/ebdadc4e0d80c0692fe1d4baf628f081a34afefa/Cargo.toml#L303-L313) used in wasmtime version 0.34.1.