### PR TITLE
test: Fix registry tests

### DIFF
--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -353,7 +353,7 @@ pub fn invariant_compliant_mutation_with_subnet_id(
             ..Default::default()
         }
     };
-    const MOCK_HASH: &str = "d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1";
+    const MOCK_HASH: &str = "abcc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7de12345";
     let release_package_url = "http://release_package.tar.zst".to_string();
     let replica_version_id = ReplicaVersion::default().to_string();
     let replica_version = ReplicaVersionRecord {
@@ -617,7 +617,7 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
     }
 
     let replica_version_id = ReplicaVersion::default().to_string();
-    const MOCK_HASH: &str = "d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1";
+    const MOCK_HASH: &str = "defc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1";
     let release_package_url = "http://release_package.tar.zst".to_string();
     let replica_version = ReplicaVersionRecord {
         release_package_sha256_hex: MOCK_HASH.into(),

--- a/rs/registry/canister/tests/update_subnet_and_bless_replica_version.rs
+++ b/rs/registry/canister/tests/update_subnet_and_bless_replica_version.rs
@@ -27,7 +27,7 @@ use registry_canister::{
     },
 };
 
-const MOCK_HASH: &str = "d1bc8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a1";
+const MOCK_HASH: &str = "098c8d3ba4afc7e109612cb73acbdddac052c93025aa1f82942edabb7deb82a0";
 
 #[test]
 fn test_the_anonymous_user_cannot_elect_a_version() {
@@ -166,6 +166,12 @@ fn test_accepted_proposal_mutates_the_registry() {
             ic_nns_constants::GOVERNANCE_CANISTER_ID
         );
 
+        let value = get_value_or_panic::<BlessedReplicaVersions>(
+            &registry,
+            make_blessed_replica_versions_key().as_bytes(),
+        )
+        .await;
+
         // We can bless a new version, the version already in the registry is 42
         let payload_v43 = ReviseElectedGuestosVersionsPayload {
             replica_version_to_elect: Some("version_43".into()),
@@ -219,7 +225,7 @@ fn test_accepted_proposal_mutates_the_registry() {
         assert_eq!(
             get_value_or_panic::<ReplicaVersionRecord>(
                 &registry,
-                make_replica_version_key(ReplicaVersion::default()).as_bytes()
+                make_replica_version_key("version_43".to_string()).as_bytes()
             )
             .await,
             ReplicaVersionRecord {


### PR DESCRIPTION
The test was erroneously querying `ReplicaVersion::default()` instead of `version_43` and passed because we reused the same `MOCK_HASH` value in multiple places. This PR fixes the test and replaces `MOCK_HASH` with different values in different files.