### PR TITLE
chore: support test versions of external mainnet canisters

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -50,6 +50,7 @@ canisters(
         "sns_archive": "ic-icrc1-archive.wasm.gz",
         "sns_index": "ic-icrc1-index-ng.wasm.gz",
         "node-rewards": "node-rewards-canister.wasm.gz",
+        "internet_identity": "internet_identity_dev.wasm.gz",
         "cycles_ledger": "cycles-ledger.wasm.gz",
         "cycles_ledger_index": "ic-icrc1-index-ng-u256.wasm.gz",
     },
@@ -88,11 +89,13 @@ canisters(
         "sns_archive": "mainnet_ic-icrc1-archive",
         "sns_index": "mainnet_ic-icrc1-index-ng",
         "node-rewards": "mainnet_node-rewards-canister",
+        "internet_identity": "mainnet_internet_identity_canister",
         "cycles_ledger": "mainnet_cycles_ledger_canister",
         "cycles_ledger_index": "mainnet_cycles_ledger_index",
     },
     repositories = {
         "cycles_ledger": "dfinity/cycles-ledger",
+        "internet_identity": "dfinity/internet-identity",
     },
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -89,7 +89,7 @@ canisters(
         "sns_archive": "mainnet_ic-icrc1-archive",
         "sns_index": "mainnet_ic-icrc1-index-ng",
         "node-rewards": "mainnet_node-rewards-canister",
-        "internet_identity": "mainnet_internet_identity_canister",
+        "internet_identity": "internet_identity_dev_at_mainnet_commit",
         "cycles_ledger": "mainnet_cycles_ledger_canister",
         "cycles_ledger_index": "mainnet_cycles_ledger_index",
     },

--- a/mainnet-canister-revisions.json
+++ b/mainnet-canister-revisions.json
@@ -80,12 +80,16 @@
     "sha256": "10ced0fec20794640fe45d0e44960faeecaeda8b1b032a04082c758192f24ac6"
   },
   "governance-canister_test": {
-    "rev": "2f87fe95207dc6371a2f2dc273362ba03b41e0e9",
-    "sha256": "1676d35b79dc212f3f52be347f8072d7d2851d59f771da95f3b412f2b39a5439"
+    "rev": "65f66f13fe07b3266ac9d1b44413fd5f0e9b4463",
+    "sha256": "f24481801f2eacaa7ff877bef665492fb6e8151ea2b02af3b418344146ee15be"
   },
   "index": {
     "rev": "3ae3649a2366aaca83404b692fc58e4c6e604a25",
     "sha256": "b443df3315902404b142d60f3cfd2f580181683310f6e6321b52de297deffcda"
+  },
+  "internet_identity": {
+    "sha256": "e15181f27364ead69cc6657b08d35b69febc5500fa687da55155255a5aac8208",
+    "tag": "release-2025-07-18"
   },
   "ledger": {
     "rev": "73bb32695d703e4e36a3790e54f1715854233490",


### PR DESCRIPTION
This PR adds support for
- test versions of external mainnet canisters (e.g., `internet_identity_dev.wasm.gz`);
- finding a git tag of an external mainnet canister that does not contain a release asset of the form `{canister_name}.sha256` by downloading `{canister_name}` and computing its sha256.

The above features are tested on the II canister.

This PR  has been tested manually by running `bazel run //rs/nervous_system/tools/sync-with-released-nervous-system-wasms` and confirming that the file `mainnet-canister-revisions.json` is updated properly.