### PR TITLE
feat: add bazel command to diff script

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -64,7 +64,7 @@ runs:
                 # get bazel targets that changed in the commit range and take the union with
                 # the targets that are expected to be built.
                 comm -12 \
-                  <("${CI_PROJECT_DIR:-}"/ci/bazel-scripts/diff.sh "$commit_range" | sort) \
+                  <("${CI_PROJECT_DIR:-}"/ci/bazel-scripts/diff.sh test "$commit_range" | sort) \
                   <(IFS='+'; bazel query "//... except attr(tags, \"manual\", //...)" | sort; ) > "$target_pattern_file"
 
                 # if bazel targets is empty we don't need to run any tests

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -17,7 +17,7 @@ fi
 
 # otherwise, infer targets to build
 targets=$(mktemp)
-ci/bazel-scripts/diff.sh "${MERGE_BASE_SHA:-HEAD}..${BRANCH_HEAD_SHA:-}" >"$targets"
+ci/bazel-scripts/diff.sh build "${MERGE_BASE_SHA:-HEAD}..${BRANCH_HEAD_SHA:-}" >"$targets"
 
 ARGS=()
 


### PR DESCRIPTION
This makes the `diff.sh` script (used to shortcut builds) aware of the bazel command being executed. This means that it will only return `test` targets if the command is `test`, as `bazel test <targets>` will fail if called with exclusively `build` targets.

PRs might still skip the build if no _test_ needs to be rebuilt, even though some build targets should be rebuilt. This is however not a new issue.