### PR TITLE
fix: build fuzzers with bazel action

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -381,11 +381,13 @@ jobs:
     steps:
       - <<: *checkout
       - name: Run Libfuzzer targets
-        shell: bash
-        run: ./bin/fuzzing/run-all-fuzzers.sh --libfuzzer 100
+        uses: ./.github/actions/bazel
+        with:
+          run: ./bin/fuzzing/run-all-fuzzers.sh --libfuzzer 100
       - name: Run AFL targets
-        shell: bash
-        run: ./bin/fuzzing/run-all-fuzzers.sh --afl 100
+        uses: ./.github/actions/bazel
+        with:
+          run: ./bin/fuzzing/run-all-fuzzers.sh --afl 100
 
   python-ci-tests:
     name: Python CI Tests

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -352,11 +352,13 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
       - name: Run Libfuzzer targets
-        shell: bash
-        run: ./bin/fuzzing/run-all-fuzzers.sh --libfuzzer 100
+        uses: ./.github/actions/bazel
+        with:
+          run: ./bin/fuzzing/run-all-fuzzers.sh --libfuzzer 100
       - name: Run AFL targets
-        shell: bash
-        run: ./bin/fuzzing/run-all-fuzzers.sh --afl 100
+        uses: ./.github/actions/bazel
+        with:
+          run: ./bin/fuzzing/run-all-fuzzers.sh --afl 100
   python-ci-tests:
     name: Python CI Tests
     runs-on:

--- a/bin/fuzzing/run-all-fuzzers.sh
+++ b/bin/fuzzing/run-all-fuzzers.sh
@@ -24,7 +24,7 @@ EOF
         done
         LIST_OF_FUZZERS=$(bazel query 'attr(tags, "sandbox_libfuzzer", //rs/...)')
         for FUZZER in $LIST_OF_FUZZERS; do
-            bazel run --config=bes --config=sandbox_fuzzing $FUZZER -- -runs=$MAX_EXECUTIONS
+            bazel run --config=sandbox_fuzzing $FUZZER -- -runs=$MAX_EXECUTIONS
         done
         ;;
 


### PR DESCRIPTION
This updates the Run Fuzzers workflow to use the bazel action, which ensures build artifacts are uploaded to the Bazel cache.

This seems to have been overlooked when the job was ported from the hourly pipeline to the main workflow.