### PR TITLE
chore: improve checkpoint step duration metrics

### DIFF
--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -62,7 +62,7 @@ pub(crate) fn make_unvalidated_checkpoint(
     {
         let _timer = metrics
             .make_checkpoint_step_duration
-            .with_label_values(&["flush_page_map_deltas"])
+            .with_label_values(&["flush_page_map_deltas_preprocessing"])
             .start_timer();
         flush_canister_snapshots_and_page_maps(&mut state, height, tip_channel);
     }
@@ -84,7 +84,7 @@ pub(crate) fn make_unvalidated_checkpoint(
     {
         let _timer = metrics
             .make_checkpoint_step_duration
-            .with_label_values(&["tip_to_checkpoint"])
+            .with_label_values(&["wait_for_tip_to_checkpoint"])
             .start_timer();
         #[allow(clippy::disallowed_methods)]
         let (send, recv) = unbounded();


### PR DESCRIPTION
The checkpoint step duration metric "tip_to_checkpoint" is confusing as it includes part of the duration on previous tip requests. Renamed it for clarity.