### PR TITLE
fix: Check input queue before canister migration

### DIFF
--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -749,7 +749,7 @@ impl ReplicatedState {
 
         let stopped = canister_state.system_state.status() == CanisterStatusType::Stopped;
 
-        stopped && !canister_state.has_output() && streams_flushed()
+        stopped && !canister_state.has_input() && !canister_state.has_output() && streams_flushed()
     }
 
     /// Computes the memory taken by different types of memory resources.

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -1175,9 +1175,13 @@ fn ready_for_migration() {
     fixture
         .push_input(best_effort_request_from(OTHER_CANISTER_ID).into())
         .unwrap();
+    fixture.stop_canister();
+
+    // Input queue is not empty, not ready for migration.
+    assert!(!fixture.state.ready_for_migration(&CANISTER_ID));
+
     fixture.pop_input().unwrap();
     fixture.push_output_response(best_effort_response_to(OTHER_CANISTER_ID));
-    fixture.stop_canister();
 
     // Output queue is not empty, not ready for migration.
     assert!(!fixture.state.ready_for_migration(&CANISTER_ID));


### PR DESCRIPTION
Before performing a canister migration, we check that the canister is ready for migration, i.e. it is stopped and has flushed all of the relevant messages. This PR fixes a bug by also checking that the input queue is empty, as it is possible for a canister to be both stopped and have a non-empty input queue.

This bug had no effect on production as canister migrations are not enabled yet.