### PR TITLE
fix(recovery): use zstd instead of gzip

### DIFF
--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
@@ -75,13 +75,13 @@ fi
 echo "Recovery artifact verified successfully"
 
 echo "Extracting recovery artifact..."
-tar zxf "recovery.tar.zst"
+tar --zstd -xf "recovery.tar.zst"
 
 echo "Preparing recovery artifacts..."
 TARGET_PERMS=$(sudo stat -c '%a' /var/lib/ic/data/ic_registry_local_store)
 
 mkdir ic_registry_local_store
-tar zxf "ic_registry_local_store.tar.zst" -C ic_registry_local_store
+tar --zstd -xf "ic_registry_local_store.tar.zst" -C ic_registry_local_store
 
 OWNER_UID=$(sudo stat -c '%u' /var/lib/ic/data/cups)
 GROUP_UID=$(sudo stat -c '%g' /var/lib/ic/data/cups)

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
@@ -75,13 +75,13 @@ fi
 echo "Recovery artifact verified successfully"
 
 echo "Extracting recovery artifact..."
-tar --zstd -xf "recovery.tar.zst"
+tar -xf "recovery.tar.zst"
 
 echo "Preparing recovery artifacts..."
 TARGET_PERMS=$(sudo stat -c '%a' /var/lib/ic/data/ic_registry_local_store)
 
 mkdir ic_registry_local_store
-tar --zstd -xf "ic_registry_local_store.tar.zst" -C ic_registry_local_store
+tar -xf "ic_registry_local_store.tar.zst" -C ic_registry_local_store
 
 OWNER_UID=$(sudo stat -c '%u' /var/lib/ic/data/cups)
 GROUP_UID=$(sudo stat -c '%g' /var/lib/ic/data/cups)

--- a/ic-os/guestos/envs/recovery-dev/defs.bzl
+++ b/ic-os/guestos/envs/recovery-dev/defs.bzl
@@ -45,10 +45,10 @@ def generate_dummy_recovery_archive(name):
             head -c $$((250 * 1024 * 1024)) < <(yes "$$DATA") > ic_registry_local_store/08090a0b0c/0d/0e/0f.pb
 
             # Archive the local store
-            tar zcf ic_registry_local_store.tar.zst -C ic_registry_local_store .
+            tar --zstd -cf ic_registry_local_store.tar.zst -C ic_registry_local_store .
 
             # Final archive
-            tar zcf recovery.tar.zst cup.proto ic_registry_local_store.tar.zst
+            tar --zstd -cf recovery.tar.zst cup.proto ic_registry_local_store.tar.zst
 
             base64 -w 0 cup.proto > cup.proto.b64
             base64 -w 0 ic_registry_local_store/0001020304/05/06/07.pb > ic_registry_local_store_1.b64

--- a/rs/recovery/src/lib.rs
+++ b/rs/recovery/src/lib.rs
@@ -848,7 +848,8 @@ impl Recovery {
         let mut tar = Command::new("tar");
         tar.arg("-C")
             .arg(self.work_dir.join("data").join(IC_REGISTRY_LOCAL_STORE))
-            .arg("-zcvf")
+            .arg("--zstd")
+            .arg("-cvf")
             .arg(
                 self.work_dir
                     .join(format!("{}.tar.zst", IC_REGISTRY_LOCAL_STORE)),

--- a/rs/recovery/src/steps.rs
+++ b/rs/recovery/src/steps.rs
@@ -964,7 +964,7 @@ cd {};
 OWNER_UID=$(sudo stat -c '%u' /var/lib/ic/data/ic_registry_local_store);
 GROUP_UID=$(sudo stat -c '%g' /var/lib/ic/data/ic_registry_local_store);
 mkdir ic_registry_local_store;
-tar zxf ic_registry_local_store.tar.zst -C ic_registry_local_store;
+tar --zstd -xf ic_registry_local_store.tar.zst -C ic_registry_local_store;
 sudo chown -R "$OWNER_UID:$GROUP_UID" ic_registry_local_store;
 OWNER_UID=$(sudo stat -c '%u' /var/lib/ic/data/cups);
 GROUP_UID=$(sudo stat -c '%g' /var/lib/ic/data/cups);

--- a/rs/recovery/src/steps.rs
+++ b/rs/recovery/src/steps.rs
@@ -964,7 +964,7 @@ cd {};
 OWNER_UID=$(sudo stat -c '%u' /var/lib/ic/data/ic_registry_local_store);
 GROUP_UID=$(sudo stat -c '%g' /var/lib/ic/data/ic_registry_local_store);
 mkdir ic_registry_local_store;
-tar --zstd -xf ic_registry_local_store.tar.zst -C ic_registry_local_store;
+tar -xf ic_registry_local_store.tar.zst -C ic_registry_local_store;
 sudo chown -R "$OWNER_UID:$GROUP_UID" ic_registry_local_store;
 OWNER_UID=$(sudo stat -c '%u' /var/lib/ic/data/cups);
 GROUP_UID=$(sudo stat -c '%g' /var/lib/ic/data/cups);


### PR DESCRIPTION
`tar -z` actually uses gzip ([source](https://man7.org/linux/man-pages/man1/tar.1.html#:~:text=%2Dz%2C%20%2D%2Dgzip%2C%20%2D%2Dgunzip%2C%20%2D%2Dungzip%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20Filter%20the%20archive%20through%20gzip(1).)).
`tar --zstd` was the one we wanted ([source](https://man7.org/linux/man-pages/man1/tar.1.html#:~:text=%2D%2Dzstd%20Filter%20the%20archive%20through%20zstd(1).)).