### PR TITLE
chore: add the IoPerformance HostFeature to the system-testing driver

### DIFF
--- a/rs/tests/driver/src/driver/farm.rs
+++ b/rs/tests/driver/src/driver/farm.rs
@@ -512,6 +512,7 @@ pub enum HostFeature {
     AmdSevSnp,
     SnsLoadTest,
     Performance,
+    IoPerformance,
     Dell,
     Supermicro,
 }
@@ -535,6 +536,7 @@ impl Serialize for HostFeature {
             HostFeature::AmdSevSnp => serializer.serialize_str(AMD_SEV_SNP),
             HostFeature::SnsLoadTest => serializer.serialize_str(SNS_LOAD_TEST),
             HostFeature::Performance => serializer.serialize_str(PERFORMANCE),
+            HostFeature::IoPerformance => serializer.serialize_str(IO_PERFORMANCE),
             HostFeature::Dell => serializer.serialize_str(DLL),
             HostFeature::Supermicro => serializer.serialize_str(SPM),
         }
@@ -544,6 +546,7 @@ impl Serialize for HostFeature {
 const AMD_SEV_SNP: &str = "AMD-SEV-SNP";
 const SNS_LOAD_TEST: &str = "SNS-load-test";
 const PERFORMANCE: &str = "performance";
+const IO_PERFORMANCE: &str = "io-performance";
 const DLL: &str = "dll";
 const SPM: &str = "spm";
 
@@ -560,6 +563,7 @@ impl<'de> Deserialize<'de> for HostFeature {
                 AMD_SEV_SNP => Ok(HostFeature::AmdSevSnp),
                 SNS_LOAD_TEST => Ok(HostFeature::SnsLoadTest),
                 PERFORMANCE => Ok(HostFeature::Performance),
+                IO_PERFORMANCE => Ok(HostFeature::IoPerformance),
                 DLL => Ok(HostFeature::Dell),
                 SPM => Ok(HostFeature::Supermicro),
                 _ => Err(Error::unknown_variant(


### PR DESCRIPTION
To implement [this suggestion](https://github.com/dfinity/ic/pull/6011#discussion_r2222826085) the I/O performance testing Farm hosts [now support](https://github.com/dfinity-lab/farm/pull/235) the `io-performance` feature. So this adds the corresponding `HostFeature::IoPerformance` variant to the system-testing driver such that the upcoming I/O performance tests in https://github.com/dfinity/ic/pull/6011 and https://github.com/dfinity/ic/pull/6005 can start requiring that to automate VM allocation.