### PR TITLE
test: Reduce the number of nodes contributing to test IDKG transcripts

### DIFF
--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -754,7 +754,7 @@ fn make_key_ids() -> Vec<(MasterPublicKeyId, AlgorithmId)> {
 #[test]
 fn pre_signature_stash_roundtrip() {
     let rng = &mut reproducible_rng();
-    let env = CanisterThresholdSigTestEnvironment::new(34, rng);
+    let env = CanisterThresholdSigTestEnvironment::new(4, rng);
     let (dealers, receivers) =
         env.choose_dealers_and_receivers(&IDkgParticipants::AllNodesAsDealersAndReceivers, rng);
     let key_id_alg = make_key_ids();
@@ -811,7 +811,7 @@ fn pre_signature_stash_roundtrip() {
 #[test]
 fn sign_with_threshold_context_roundtrip() {
     let rng = &mut reproducible_rng();
-    let env = CanisterThresholdSigTestEnvironment::new(34, rng);
+    let env = CanisterThresholdSigTestEnvironment::new(4, rng);
     let (dealers, receivers) =
         env.choose_dealers_and_receivers(&IDkgParticipants::AllNodesAsDealersAndReceivers, rng);
     let transcripts = make_key_ids().into_iter().map(|(key_id, alg)| {


### PR DESCRIPTION
These tests occasionally time out. This could be caused by computationally expensive generation of IDKG transcripts. Reducing the number of nodes should reduce the amount of computation necessary.