### PR TITLE
chore: require HostFeature::IoPerformance in the io_perf_benchmark

### DIFF
--- a/rs/tests/testnets/io_perf_benchmark.rs
+++ b/rs/tests/testnets/io_perf_benchmark.rs
@@ -136,7 +136,10 @@ pub fn setup(env: TestEnv, config: Config) {
         config.hosts
     );
     for host in config.hosts.iter() {
-        subnet = subnet.add_node_with_required_host_features(vec![HostFeature::Host(host.clone())]);
+        subnet = subnet.add_node_with_required_host_features(vec![
+            HostFeature::Host(host.clone()),
+            HostFeature::IoPerformance,
+        ]);
     }
     ic = ic.add_subnet(subnet);
 


### PR DESCRIPTION
The host feature `HostFeature::IoPerformance` will soon be mandatory for targetting I/O performance testing hosts on Farm. 