### PR TITLE
feat(governance): Add validation and fix display for reward_account

### DIFF
--- a/rs/nns/governance/src/governance/disburse_maturity.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity.rs
@@ -211,11 +211,9 @@ impl Destination {
         let account_identifer = self.try_into_account_identifier().ok()?;
         // Note we should not use `AccountIdentifierProto::from` directly here, since it simply
         // outputs a 28-byte hash without the 4-byte checksum. Instead, we should use the
-        // `AccountIdentifier::to_address` which computes and prepends the checksum.
-        let address = account_identifer.to_address();
-        Some(AccountIdentifierProto {
-            hash: address.to_vec(),
-        })
+        // `AccountIdentifier::to_vec` which computes and prepends the checksum.
+        let hash = account_identifer.to_vec();
+        Some(AccountIdentifierProto { hash })
     }
 }
 

--- a/rs/nns/governance/src/governance/tests/update_node_provider.rs
+++ b/rs/nns/governance/src/governance/tests/update_node_provider.rs
@@ -1,0 +1,152 @@
+use crate::governance::tests::{MockEnvironment, StubCMC, StubIcpLedger};
+use crate::test_utils::MockRandomness;
+use crate::{
+    governance::Governance,
+    pb::v1::{governance_error::ErrorType, GovernanceError, NetworkEconomics, UpdateNodeProvider},
+};
+use ic_base_types::PrincipalId;
+use ic_nervous_system_common::E8;
+use ic_nns_governance_api::NodeProvider;
+use icp_ledger::{AccountIdentifier, Subaccount};
+use std::sync::Arc;
+
+#[test]
+fn test_update_node_provider_with_valid_but_non_crc_account() {
+    // Arrange
+    let node_provider_id = PrincipalId::new_user_test_id(1);
+    let valid_account = AccountIdentifier::new(node_provider_id, None);
+
+    let mut governance = create_governance_with_node_provider(node_provider_id);
+
+    let update = UpdateNodeProvider {
+        reward_account: Some(valid_account.into()),
+    };
+
+    // Act
+    let result = governance.update_node_provider(&node_provider_id, update);
+
+    // Assert
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.error_type(), ErrorType::PreconditionFailed);
+    assert!(error.error_message.contains("Invalid reward_account"));
+    assert!(error.error_message.contains("must be 32 bytes long"));
+}
+
+#[test]
+fn test_update_node_provider_with_valid_reward_account_right_length() {
+    // Arrange
+    let node_provider_id = PrincipalId::new_user_test_id(1);
+    let valid_account = AccountIdentifier::new(node_provider_id, None);
+
+    let mut governance = create_governance_with_node_provider(node_provider_id);
+
+    let update = UpdateNodeProvider {
+        reward_account: Some(icp_ledger::protobuf::AccountIdentifier {
+            hash: valid_account.to_vec(),
+        }),
+    };
+
+    // Act
+    let result = governance.update_node_provider(&node_provider_id, update);
+
+    // Assert
+    assert!(result.is_ok(), "Expected update to succeed: {:?}", result);
+
+    // Verify the reward account was updated
+    let updated_node_provider = governance.get_node_provider(&node_provider_id).unwrap();
+    assert_eq!(
+        updated_node_provider.reward_account.unwrap().hash,
+        valid_account.to_vec()
+    );
+}
+
+#[test]
+fn test_update_node_provider_with_invalid_reward_account_bad_checksum() {
+    // Arrange
+    let node_provider_id = PrincipalId::new_user_test_id(1);
+    let mut governance = create_governance_with_node_provider(node_provider_id);
+
+    // Create an account identifier with wrong checksum
+    let invalid_account = icp_ledger::protobuf::AccountIdentifier {
+        hash: vec![0; 32], // Wrong checksum
+    };
+
+    let update = UpdateNodeProvider {
+        reward_account: Some(invalid_account),
+    };
+
+    // Act
+    let result = governance.update_node_provider(&node_provider_id, update);
+
+    // Assert
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.error_type(), ErrorType::PreconditionFailed);
+    assert!(error.error_message.contains("Invalid reward_account"));
+    assert!(error
+        .error_message
+        .contains("account identifier is not valid"));
+}
+
+#[test]
+fn test_update_node_provider_with_no_reward_account() {
+    // Arrange
+    let node_provider_id = PrincipalId::new_user_test_id(1);
+    let mut governance = create_governance_with_node_provider(node_provider_id);
+
+    let update = UpdateNodeProvider {
+        reward_account: None,
+    };
+
+    // Act
+    let result = governance.update_node_provider(&node_provider_id, update);
+
+    // Assert
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.error_type(), ErrorType::PreconditionFailed);
+    assert!(error.error_message.contains("reward_account not specified"));
+}
+
+#[test]
+fn test_update_node_provider_not_found() {
+    // Arrange
+    let node_provider_id = PrincipalId::new_user_test_id(1);
+    let unknown_node_provider_id = PrincipalId::new_user_test_id(999);
+    let mut governance = create_governance_with_node_provider(node_provider_id);
+
+    let valid_account = AccountIdentifier::new(unknown_node_provider_id, None);
+    let update = UpdateNodeProvider {
+        reward_account: Some(valid_account.into()),
+    };
+
+    // Act
+    let result = governance.update_node_provider(&unknown_node_provider_id, update);
+
+    // Assert
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.error_type(), ErrorType::NotFound);
+    assert!(error.error_message.contains("is not known by the NNS"));
+}
+
+// Helper function to create governance with a node provider
+fn create_governance_with_node_provider(node_provider_id: PrincipalId) -> Governance {
+    let node_provider = NodeProvider {
+        id: Some(node_provider_id),
+        reward_account: None,
+    };
+
+    let mut initial_governance = ic_nns_governance_api::Governance::default();
+
+    initial_governance.node_providers = vec![node_provider];
+
+    Governance::new(
+        initial_governance,
+        Arc::new(MockEnvironment::new(vec![], 0)),
+        Arc::new(StubIcpLedger {}),
+        Arc::new(StubCMC {}),
+        Box::new(MockRandomness::new()),
+    )
+}

--- a/rs/nns/governance/src/governance/tests/update_node_provider.rs
+++ b/rs/nns/governance/src/governance/tests/update_node_provider.rs
@@ -2,12 +2,11 @@ use crate::governance::tests::{MockEnvironment, StubCMC, StubIcpLedger};
 use crate::test_utils::MockRandomness;
 use crate::{
     governance::Governance,
-    pb::v1::{governance_error::ErrorType, GovernanceError, NetworkEconomics, UpdateNodeProvider},
+    pb::v1::{governance_error::ErrorType, UpdateNodeProvider},
 };
 use ic_base_types::PrincipalId;
-use ic_nervous_system_common::E8;
 use ic_nns_governance_api::NodeProvider;
-use icp_ledger::{AccountIdentifier, Subaccount};
+use icp_ledger::AccountIdentifier;
 use std::sync::Arc;
 
 #[test]

--- a/rs/nns/governance/src/pb/conversions.rs
+++ b/rs/nns/governance/src/pb/conversions.rs
@@ -4,6 +4,10 @@ use ic_nns_governance_api as pb_api;
 
 use crate::pb::proposal_conversions::convert_proposal;
 
+// TODO add validation for inputs
+// TODO Ensure reward_account always has checksum when turned into API response.
+// TODO - see if we can safely do data migration (how hard to test with confidence)
+
 impl From<pb::NodeProvider> for pb_api::NodeProvider {
     fn from(item: pb::NodeProvider) -> Self {
         Self {

--- a/rs/nns/governance/src/pb/conversions/tests.rs
+++ b/rs/nns/governance/src/pb/conversions/tests.rs
@@ -1,0 +1,68 @@
+use super::*;
+use ic_base_types::PrincipalId;
+use icp_ledger::protobuf::AccountIdentifier;
+
+#[test]
+fn test_node_provider_conversions_always_create_32_byte_account_identifier() {
+    // Arrange
+
+    let node_provider_id = PrincipalId::new_user_test_id(1);
+    let account_identifier = AccountIdentifier {
+        hash: vec![0; 28], // 32 bytes of zeros
+    };
+
+    let node_provider = pb::NodeProvider {
+        id: Some(node_provider_id),
+        reward_account: Some(account_identifier),
+    };
+
+    // Act
+    let converted_node_provider = pb_api::NodeProvider::from(node_provider);
+
+    // Assert the length is now 32 bytes
+    assert_eq!(
+        converted_node_provider
+            .reward_account
+            .as_ref()
+            .unwrap()
+            .hash
+            .len(),
+        32
+    );
+
+    // Assert when we convert reward_account into the non-protobuf format, it's 28 bytes (i.e. validates)
+    icp_ledger::AccountIdentifier::try_from(&converted_node_provider.reward_account.unwrap())
+        .expect("Should succeed!");
+}
+
+#[test]
+fn test_if_invalid_account_identifier_just_return_what_is_stored() {
+    // Arrange
+    let node_provider_id = PrincipalId::new_user_test_id(1);
+    let account_identifier = AccountIdentifier {
+        hash: vec![0; 27], // 28 bytes of zeros, which is invalid for our conversion
+    };
+
+    let node_provider = pb::NodeProvider {
+        id: Some(node_provider_id),
+        reward_account: Some(account_identifier),
+    };
+
+    // Act
+    let converted_node_provider = pb_api::NodeProvider::from(node_provider);
+
+    // Assert the length is still 28 bytes
+    assert_eq!(
+        converted_node_provider
+            .reward_account
+            .as_ref()
+            .unwrap()
+            .hash
+            .len(),
+        27
+    );
+
+    // Assert that the conversion does fail, even with an invalid length
+    icp_ledger::AccountIdentifier::try_from(&converted_node_provider.reward_account.unwrap())
+        .expect_err("Should fail!");
+}


### PR DESCRIPTION
This adds validation for node provider reward accounts to ensure they include checksums (i.e. are more likely to be valid accounts) and fixes the outputs to always display the 32 bit version with checksums, which match the normal account identifier display are more readily searched for in the dashboard and with other tools and APIs.