### PR TITLE
refactor(registry): Stop updating old routing table

### DIFF
--- a/rs/registry/canister/canbench/canbench_results.yml
+++ b/rs/registry/canister/canbench/canbench_results.yml
@@ -23,8 +23,8 @@ benches:
   measure_routing_table_invariant_checks_shards_and_unsharded:
     total:
       calls: 1
-      instructions: 263440048
-      heap_increase: 81
+      instructions: 264040963
+      heap_increase: 138
       stable_memory_increase: 0
     scopes: {}
   measure_snapshot_creation_with_1000_individual_entries:
@@ -113,13 +113,13 @@ benches:
   upgrade_with_routing_table_1k:
     total:
       calls: 1
-      instructions: 698692556
+      instructions: 681079660
       heap_increase: 40
       stable_memory_increase: 0
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 695801334
+        instructions: 678200881
         heap_increase: 25
         stable_memory_increase: 0
       pre_upgrade:

--- a/rs/registry/canister/src/flags.rs
+++ b/rs/registry/canister/src/flags.rs
@@ -5,8 +5,6 @@ use ic_nervous_system_temporary::Temporary;
 
 thread_local! {
     static IS_CHUNKIFYING_LARGE_VALUES_ENABLED: Cell<bool> = const { Cell::new(true) };
-
-    static IS_ROUTING_TABLE_SINGLE_ENTRY_OBSOLETE: Cell<bool> = const { Cell::new(cfg!(feature = "canbench-rs")) };
 }
 
 pub(crate) fn is_chunkifying_large_values_enabled() -> bool {
@@ -21,8 +19,4 @@ pub fn temporarily_enable_chunkifying_large_values() -> Temporary {
 #[cfg(test)]
 pub(crate) fn temporarily_disable_chunkifying_large_values() -> Temporary {
     Temporary::new(&IS_CHUNKIFYING_LARGE_VALUES_ENABLED, false)
-}
-
-pub(crate) fn is_routing_table_single_entry_obsolete() -> bool {
-    IS_ROUTING_TABLE_SINGLE_ENTRY_OBSOLETE.get()
 }

--- a/rs/registry/canister/src/invariants/checks.rs
+++ b/rs/registry/canister/src/invariants/checks.rs
@@ -191,7 +191,7 @@ mod tests {
     };
     use ic_registry_keys::{
         make_canister_migrations_record_key, make_canister_ranges_key,
-        make_node_operator_record_key, make_routing_table_record_key,
+        make_node_operator_record_key,
     };
     use ic_registry_routing_table::{CanisterIdRange, CanisterMigrations, RoutingTable};
     use ic_registry_transport::{
@@ -273,25 +273,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "No routing table in snapshot")]
-    fn routing_table_invariants_do_not_hold() {
-        let key = make_node_operator_record_key(*TEST_USER1_PRINCIPAL);
-        let value = NodeOperatorRecord {
-            node_operator_principal_id: (*TEST_USER1_PRINCIPAL).to_vec(),
-            node_allowance: 0,
-            node_provider_principal_id: (*TEST_USER1_PRINCIPAL).to_vec(),
-            dc_id: "".into(),
-            rewardable_nodes: BTreeMap::new(),
-            ipv6: None,
-            max_rewardable_nodes: BTreeMap::new(),
-        }
-        .encode_to_vec();
-        let registry = Registry::new();
-        let mutation = vec![insert(key.as_bytes(), value)];
-        registry.check_global_state_invariants(&mutation);
-    }
-
-    #[test]
     #[should_panic(expected = "not hosted by any subnet")]
     fn invalid_canister_migrations_invariants_check_panic() {
         let routing_table = RoutingTable::try_from(btreemap! {
@@ -301,7 +282,6 @@ mod tests {
         }).unwrap();
 
         let routing_table = PbRoutingTable::from(routing_table);
-        let routing_table_key = make_routing_table_record_key();
         let routing_table_shard_key = make_canister_ranges_key(CanisterId::from(0));
         let routing_table_value = routing_table.encode_to_vec();
 
@@ -315,7 +295,6 @@ mod tests {
         let canister_migrations_value = canister_migrations.encode_to_vec();
 
         let mutations = vec![
-            insert(routing_table_key.as_bytes(), &routing_table_value),
             insert(routing_table_shard_key.as_bytes(), &routing_table_value),
             insert(
                 canister_migrations_key.as_bytes(),
@@ -329,7 +308,6 @@ mod tests {
 
     #[test]
     fn snapshot_reflects_latest_registry_state() {
-        let routing_table_key = make_routing_table_record_key();
         let routing_table_shard_key = make_canister_ranges_key(CanisterId::from(0));
         let routing_table_value = PbRoutingTable { entries: vec![] }.encode_to_vec();
 
@@ -346,13 +324,12 @@ mod tests {
         .encode_to_vec();
 
         let mutations = vec![
-            insert(routing_table_key.as_bytes(), &routing_table_value),
             insert(routing_table_shard_key.as_bytes(), &routing_table_value),
             insert(node_operator_key.as_bytes(), &node_operator_value),
         ];
         let snapshot = Registry::new().take_latest_snapshot_with_mutations(&mutations);
 
-        let snapshot_data = snapshot.get(routing_table_key.as_bytes());
+        let snapshot_data = snapshot.get(routing_table_shard_key.as_bytes());
         assert!(snapshot_data.is_some());
         assert_eq!(snapshot_data.unwrap(), &routing_table_value);
 

--- a/rs/registry/canister/src/invariants/checks/benches.rs
+++ b/rs/registry/canister/src/invariants/checks/benches.rs
@@ -5,7 +5,7 @@ use canbench_rs::{bench, bench_fn, BenchResult};
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
 use ic_protobuf::registry::routing_table::v1::routing_table::Entry;
 use ic_protobuf::registry::routing_table::v1::RoutingTable;
-use ic_registry_keys::{make_canister_ranges_key, make_routing_table_record_key};
+use ic_registry_keys::make_canister_ranges_key;
 use ic_registry_routing_table::CanisterIdRange;
 use ic_registry_transport::upsert;
 use prost::Message;
@@ -97,14 +97,7 @@ fn measure_snapshot_creation_with_100_segments_of_1000_entries() -> BenchResult 
 #[bench(raw)]
 fn measure_routing_table_invariant_checks_shards_and_unsharded() -> BenchResult {
     let _feature = temporarily_enable_chunkifying_large_values();
-    let mut registry = setup_registry_with_rt_segments_with_x_entries_each(1000, 20);
-
-    let rt = registry.get_routing_table_or_panic(registry.latest_version());
-    let rt_mutation = upsert(
-        make_routing_table_record_key(),
-        RoutingTable::from(rt).encode_to_vec(),
-    );
-    registry.apply_mutations_for_test(vec![rt_mutation]);
+    let registry = setup_registry_with_rt_segments_with_x_entries_each(1000, 20);
 
     let snapshot = registry.take_latest_snapshot();
 

--- a/rs/registry/canister/src/invariants/routing_table.rs
+++ b/rs/registry/canister/src/invariants/routing_table.rs
@@ -1,7 +1,4 @@
-use crate::{
-    flags::is_routing_table_single_entry_obsolete,
-    invariants::common::{InvariantCheckError, RegistrySnapshot},
-};
+use crate::invariants::common::{InvariantCheckError, RegistrySnapshot};
 
 use std::convert::TryFrom;
 
@@ -9,9 +6,7 @@ use ic_base_types::CanisterId;
 use ic_protobuf::registry::routing_table::v1::{
     CanisterMigrations as pbCanisterMigrations, RoutingTable as pbRoutingTable,
 };
-use ic_registry_keys::{
-    make_canister_migrations_record_key, make_canister_ranges_key, make_routing_table_record_key,
-};
+use ic_registry_keys::{make_canister_migrations_record_key, make_canister_ranges_key};
 use ic_registry_routing_table::{CanisterMigrations, RoutingTable};
 use prost::Message;
 
@@ -27,26 +22,7 @@ pub(crate) fn check_routing_table_invariants(
 fn get_routing_table(snapshot: &RegistrySnapshot) -> RoutingTable {
     // If there are shards, they should match the routing table record.
     let shards = get_routing_table_shards(snapshot);
-    let rt_from_shards = RoutingTable::try_from(shards).unwrap();
-
-    if !is_routing_table_single_entry_obsolete() {
-        // TODO(NNS1-3781): Remove this once we have sharded table supported by all clients.
-        let rt_from_routing_table_record =
-            match snapshot.get(make_routing_table_record_key().as_bytes()) {
-                Some(routing_table_bytes) => {
-                    let routing_table_proto =
-                        pbRoutingTable::decode(routing_table_bytes.as_slice()).unwrap();
-                    RoutingTable::try_from(routing_table_proto).unwrap()
-                }
-                None => panic!("No routing table in snapshot"),
-            };
-        assert_eq!(
-            rt_from_shards, rt_from_routing_table_record,
-            "Routing tables from shards and routing table record do not match."
-        );
-    }
-
-    rt_from_shards
+    RoutingTable::try_from(shards).unwrap()
 }
 
 fn get_routing_table_shards(snapshot: &RegistrySnapshot) -> Vec<pbRoutingTable> {
@@ -123,7 +99,7 @@ mod tests {
     use ic_protobuf::registry::routing_table::v1::{
         CanisterMigrations as PbCanisterMigrations, RoutingTable as PbRoutingTable,
     };
-    use ic_registry_keys::{make_canister_migrations_record_key, make_routing_table_record_key};
+    use ic_registry_keys::make_canister_migrations_record_key;
     use ic_registry_routing_table::{CanisterIdRange, CanisterMigrations, RoutingTable};
     use ic_test_utilities_types::ids::subnet_test_id;
     use maplit::btreemap;
@@ -137,12 +113,6 @@ mod tests {
         let routing_table = PbRoutingTable::from(routing_table);
         snapshot.insert(
             make_canister_ranges_key(CanisterId::from(0)).into_bytes(),
-            routing_table.encode_to_vec(),
-        );
-        // TODO(NNS1-3781): Remove this once we have sharded table supported by all clients, and
-        // inline the function after removal.
-        snapshot.insert(
-            make_routing_table_record_key().into_bytes(),
             routing_table.encode_to_vec(),
         );
     }
@@ -303,51 +273,9 @@ mod tests {
             CanisterIdRange{ start: CanisterId::from(0x200), end: CanisterId::from(0x2ff) } => subnet_test_id(3),
         }).unwrap();
 
-        let routing_table = PbRoutingTable::from(new_routing_table_2);
-        snapshot.insert(
-            make_routing_table_record_key().into_bytes(),
-            routing_table.encode_to_vec(),
-        );
-        snapshot.insert(
-            make_canister_ranges_key(CanisterId::from(0)).into_bytes(),
-            routing_table.encode_to_vec(),
-        );
+        insert_routing_table_to_snapshot(new_routing_table_2, &mut snapshot);
 
         assert!(check_routing_table_invariants(&snapshot).is_ok());
         assert!(check_canister_migrations_invariants(&snapshot).is_err());
-    }
-
-    // TODO(NNS1-3781): Remove this test once we have sharded table supported by all clients.
-    #[test]
-    #[should_panic(expected = "Routing tables from shards and routing table record do not match.")]
-    fn sharded_ranges_must_match_original_routing_table() {
-        let mut snapshot = RegistrySnapshot::new();
-
-        // The routing table before canister migration.
-        let routing_table = RoutingTable::try_from(btreemap! {
-            CanisterIdRange{ start: CanisterId::from(0x0), end: CanisterId::from(0xff) } => subnet_test_id(1),
-            CanisterIdRange{ start: CanisterId::from(0x100), end: CanisterId::from(0x1ff) } => subnet_test_id(2),
-            CanisterIdRange{ start: CanisterId::from(0x200), end: CanisterId::from(0x2ff) } => subnet_test_id(3),
-         }).unwrap();
-
-        let routing_table = PbRoutingTable::from(routing_table);
-
-        let rt_shard = RoutingTable::try_from(btreemap! {
-            CanisterIdRange{ start: CanisterId::from(0x0), end: CanisterId::from(0xff) } => subnet_test_id(1),
-            CanisterIdRange{ start: CanisterId::from(0x100), end: CanisterId::from(0x1ff) } => subnet_test_id(2),
-        }).unwrap();
-
-        let rt_shard = PbRoutingTable::from(rt_shard);
-
-        snapshot.insert(
-            make_routing_table_record_key().into_bytes(),
-            routing_table.encode_to_vec(),
-        );
-        snapshot.insert(
-            make_canister_ranges_key(CanisterId::from(0)).into_bytes(),
-            rt_shard.encode_to_vec(),
-        );
-
-        check_routing_table_invariants(&snapshot).unwrap();
     }
 }

--- a/rs/registry/canister/src/mutations/routing_table.rs
+++ b/rs/registry/canister/src/mutations/routing_table.rs
@@ -1,6 +1,5 @@
 use crate::{
     common::LOG_PREFIX,
-    flags::is_routing_table_single_entry_obsolete,
     mutations::node_management::common::{
         get_key_family_iter_at_version, get_key_family_raw_iter_at_version,
     },
@@ -13,8 +12,7 @@ use ic_base_types::{PrincipalId, SubnetId};
 use ic_protobuf::registry::routing_table::v1 as pb;
 use ic_registry_canister_chunkify::decode_high_capacity_registry_value;
 use ic_registry_keys::{
-    make_canister_migrations_record_key, make_canister_ranges_key, make_routing_table_record_key,
-    CANISTER_RANGES_PREFIX,
+    make_canister_migrations_record_key, make_canister_ranges_key, CANISTER_RANGES_PREFIX,
 };
 use ic_registry_routing_table::{
     routing_table_insert_subnet, CanisterIdRange, CanisterIdRanges, CanisterMigrations,
@@ -223,16 +221,7 @@ pub(crate) fn routing_table_into_registry_mutation(
     registry: &Registry,
     routing_table: RoutingTable,
 ) -> Vec<RegistryMutation> {
-    let mut mutations = mutations_for_canister_ranges(registry, &routing_table);
-
-    if !is_routing_table_single_entry_obsolete() {
-        let new_routing_table = pb::RoutingTable::from(routing_table);
-        mutations.push(upsert(
-            make_routing_table_record_key().as_bytes(),
-            new_routing_table.encode_to_vec(),
-        ));
-    }
-    mutations
+    mutations_for_canister_ranges(registry, &routing_table)
 }
 
 /// Returns the given `CanisterMigrations` as a registry mutation of the given type.

--- a/rs/registry/canister/src/mutations/routing_table_benches.rs
+++ b/rs/registry/canister/src/mutations/routing_table_benches.rs
@@ -5,10 +5,7 @@ use crate::{
 
 use canbench_rs::{bench, bench_fn, bench_scope, BenchResult};
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
-use ic_protobuf::registry::routing_table::v1::RoutingTable;
-use ic_registry_keys::make_routing_table_record_key;
 use ic_registry_routing_table::CANISTER_IDS_PER_SUBNET;
-use ic_registry_transport::upsert;
 use prost::Message;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -16,14 +13,6 @@ use rand_chacha::ChaCha20Rng;
 /// Currently there are 37 subnets. We will use 100 subnets for the benchmark.
 const NUM_SUBNETS: u64 = 100;
 const MAX_CANISTER_ID_U64: u64 = CANISTER_IDS_PER_SUBNET * NUM_SUBNETS;
-
-fn setup_empty_routing_table(registry: &mut Registry) {
-    let routing_table_mutation = upsert(
-        make_routing_table_record_key(),
-        RoutingTable { entries: vec![] }.encode_to_vec(),
-    );
-    registry.apply_mutations_for_test(vec![routing_table_mutation]);
-}
 
 fn setup_subnets(registry: &mut Registry) {
     for id in 0..NUM_SUBNETS {
@@ -58,7 +47,6 @@ fn migrate_canisters_to_subnets(registry: &mut Registry, num_migrations: u64, rn
 fn migrate_canisters(num_existing_migrations: u64, num_calls: u64) -> BenchResult {
     let mut registry = Registry::new();
 
-    setup_empty_routing_table(&mut registry);
     setup_subnets(&mut registry);
     let mut rng = ChaCha20Rng::seed_from_u64(0);
     migrate_canisters_to_subnets(&mut registry, num_existing_migrations, &mut rng);
@@ -95,7 +83,6 @@ fn migrate_canisters_10_times_10k() -> BenchResult {
 fn upgrade_with_routing_table(num_canisters: u64) -> BenchResult {
     let mut registry = Registry::new();
 
-    setup_empty_routing_table(&mut registry);
     setup_subnets(&mut registry);
     let mut rng = ChaCha20Rng::seed_from_u64(0);
     migrate_canisters_to_subnets(&mut registry, num_canisters, &mut rng);
@@ -141,7 +128,6 @@ fn upgrade_with_routing_table_10k() -> BenchResult {
 fn get_subnet_for_canister(num_canisters: u64, num_calls: u64) -> BenchResult {
     let mut registry = Registry::new();
 
-    setup_empty_routing_table(&mut registry);
     setup_subnets(&mut registry);
     let mut rng = ChaCha20Rng::seed_from_u64(0);
     migrate_canisters_to_subnets(&mut registry, num_canisters, &mut rng);

--- a/rs/registry/canister/src/registry_lifecycle.rs
+++ b/rs/registry/canister/src/registry_lifecycle.rs
@@ -170,7 +170,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "No routing table in snapshot")]
+    #[should_panic(expected = "[Registry] invariant check failed with message: no system subnet")]
     fn post_upgrade_fails_on_global_state_invariant_check_failure() {
         // We only check a single failure mode here,
         // since the rest should be under other test coverage

--- a/rs/registry/canister/tests/common/test_helpers.rs
+++ b/rs/registry/canister/tests/common/test_helpers.rs
@@ -2,7 +2,8 @@
 
 use candid::Encode;
 use canister_test::{Canister, Runtime};
-use ic_base_types::{NodeId, PrincipalId, RegistryVersion, SubnetId};
+use dfn_candid::candid_one;
+use ic_base_types::{CanisterId, NodeId, PrincipalId, RegistryVersion, SubnetId};
 use ic_crypto_node_key_validation::ValidNodePublicKeys;
 use ic_management_canister_types_private::{
     DerivationPath, ECDSAPublicKeyArgs, EcdsaKeyId, MasterPublicKeyId, Method as Ic00Method,
@@ -13,7 +14,6 @@ use ic_nns_test_utils::itest_helpers::{
 };
 use ic_nns_test_utils::registry::{get_value_or_panic, new_node_keys_and_node_id};
 use ic_protobuf::registry::node::v1::NodeRecord;
-use ic_protobuf::registry::routing_table::v1 as pb;
 use ic_protobuf::registry::subnet::v1::{
     CatchUpPackageContents, ChainKeyConfig as ChainKeyConfigPb, SubnetListRecord, SubnetRecord,
 };
@@ -22,7 +22,6 @@ use ic_registry_keys::{
     make_catch_up_package_contents_key, make_subnet_list_record_key, make_subnet_record_key,
 };
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
-use ic_registry_routing_table::RoutingTable;
 use ic_registry_subnet_features::{ChainKeyConfig, KeyConfig, DEFAULT_ECDSA_MAX_QUEUE_SIZE};
 use ic_registry_transport::pb::v1::RegistryAtomicMutateRequest;
 use ic_types::ReplicaVersion;
@@ -30,6 +29,7 @@ use registry_canister::init::RegistryCanisterInitPayloadBuilder;
 use registry_canister::mutations::do_create_subnet::CreateSubnetPayload;
 use registry_canister::mutations::node_management::common::make_add_node_registry_mutations;
 use registry_canister::mutations::node_management::do_add_node::connection_endpoint_from_string;
+use registry_canister::pb::v1::{GetSubnetForCanisterRequest, SubnetForCanister};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
@@ -382,7 +382,29 @@ pub fn check_error_message<T: std::fmt::Debug>(
     }
 }
 
-pub async fn get_routing_table(canister: &canister_test::Canister<'_>) -> RoutingTable {
-    let pb_routing_table: pb::RoutingTable = get_value_or_panic(canister, b"routing_table").await;
-    RoutingTable::try_from(pb_routing_table).expect("failed to decode routing table")
+pub async fn check_subnet_for_canisters(
+    registry: &canister_test::Canister<'_>,
+    canister_id_subnet_id_pairs: Vec<(CanisterId, SubnetId)>,
+) {
+    for (canister_id, expected_subnet_id) in canister_id_subnet_id_pairs {
+        let result: Result<SubnetForCanister, String> = registry
+            .query_(
+                "get_subnet_for_canister",
+                candid_one,
+                GetSubnetForCanisterRequest {
+                    principal: Some(canister_id.get()),
+                },
+            )
+            .await
+            .unwrap();
+        let actual_subnet_id = result.unwrap().subnet_id.unwrap();
+        assert_eq!(
+            actual_subnet_id,
+            expected_subnet_id.get(),
+            "Subnet for canister {} should be {}, got {}",
+            canister_id.get(),
+            expected_subnet_id.get(),
+            actual_subnet_id
+        );
+    }
 }

--- a/rs/registry/canister/tests/reroute_canister_ranges.rs
+++ b/rs/registry/canister/tests/reroute_canister_ranges.rs
@@ -19,7 +19,7 @@ use registry_canister::{
 };
 
 mod common;
-use common::test_helpers::{check_error_message, get_routing_table};
+use common::test_helpers::{check_error_message, check_subnet_for_canisters};
 
 #[test]
 fn test_reroute_canister_ranges() {
@@ -102,24 +102,16 @@ fn test_reroute_canister_ranges() {
             .await
             .unwrap();
 
-            let routing_table = get_routing_table(&registry).await;
-
-            assert_eq!(
-                routing_table.route(CanisterId::from(9).into()),
-                Some(subnet_id_2)
-            );
-            assert_eq!(
-                routing_table.route(CanisterId::from(10).into()),
-                Some(subnet_id_1)
-            );
-            assert_eq!(
-                routing_table.route(CanisterId::from(11).into()),
-                Some(subnet_id_1)
-            );
-            assert_eq!(
-                routing_table.route(CanisterId::from(12).into()),
-                Some(subnet_id_2)
-            );
+            check_subnet_for_canisters(
+                &registry,
+                vec![
+                    (CanisterId::from(9), subnet_id_2),
+                    (CanisterId::from(10), subnet_id_1),
+                    (CanisterId::from(11), subnet_id_1),
+                    (CanisterId::from(12), subnet_id_2),
+                ],
+            )
+            .await;
 
             check_error_message(
                 registry
@@ -179,7 +171,16 @@ fn test_reroute_canister_ranges() {
                 "not a known subnet",
             );
 
-            assert_eq!(get_routing_table(&registry).await, routing_table);
+            check_subnet_for_canisters(
+                &registry,
+                vec![
+                    (CanisterId::from(9), subnet_id_2),
+                    (CanisterId::from(10), subnet_id_1),
+                    (CanisterId::from(11), subnet_id_1),
+                    (CanisterId::from(12), subnet_id_2),
+                ],
+            )
+            .await;
 
             Ok(())
         }

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -15,6 +15,8 @@ on the process that this file is part of, see
 
 ## Removed
 
+* The single entry routing table is no longer updated when there are changes to the routing table.
+
 ## Fixed
 
 ## Security


### PR DESCRIPTION
# Why

The registry client is switched to reading the routing table with the new format, and all the replicas and API BNs have been released with the switch. Therefore we can stop updating the old routing table in the registry and stop validating against it.

# What

* Clean up the feature flag `is_routing_table_single_entry_obsolete` and fix tests