### PR TITLE
test(sns): Re-enable final balance assertion in treasury manager test

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -601,8 +601,8 @@ http_file(
 http_file(
     name = "kongswap-adaptor-canister",
     downloaded_file_path = "kongswap-adaptor-canister.wasm.gz",
-    sha256 = "edda2e8793a306074f3b6db7912a425486d5f0218926d3296d706c0c74174160",
-    url = "https://github.com/dfinity/sns-kongswap-adaptor/releases/download/vrc-20250722-135352-102b70f/kongswap-adaptor-canister.wasm.gz",
+    sha256 = "d5b1326ddc4c002a211bb3e263c0d94c20250e5683b401096c74f385c326c175",
+    url = "https://github.com/dfinity/sns-kongswap-adaptor/releases/download/vrc-20250723-193307-6c37829/kongswap-adaptor-canister.wasm.gz",
 )
 
 # Cycles Ledger canister

--- a/rs/nervous_system/integration_tests/tests/sns_extension_test.rs
+++ b/rs/nervous_system/integration_tests/tests/sns_extension_test.rs
@@ -315,7 +315,7 @@ async fn test_treasury_manager() {
             withdraw_accounts: Some(ledger_id_to_account),
         };
 
-        let _response = PocketIcAgent::new(&pocket_ic, sns.root.canister_id)
+        let response = PocketIcAgent::new(&pocket_ic, sns.root.canister_id)
             .call(adaptor_canister_id, request)
             .await
             .unwrap()
@@ -328,20 +328,19 @@ async fn test_treasury_manager() {
             println!(">>> AuditTrail: {:#?}", response);
         }
 
-        // TODO: Reenable this assertion.
-        // assert_eq!(
-        //     response.asset_to_balances,
-        //     Some(btreemap! {
-        //         sns_token => empty_sns_balance_book
-        //             .clone()
-        //             .treasury_owner(treasury_allocation_sns_e8s - 4 * SNS_FEE)
-        //             .fee_collector(4 * SNS_FEE),
-        //         icp_token => empty_icp_balance_book
-        //             .clone()
-        //             .treasury_owner(treasury_allocation_icp_e8s - 4 * ICP_FEE)
-        //             .fee_collector(4 * ICP_FEE),
-        //     }),
-        // );
+        assert_eq!(
+            response.asset_to_balances,
+            Some(btreemap! {
+                sns_token => empty_sns_balance_book
+                    .clone()
+                    .treasury_owner(treasury_allocation_sns_e8s - 4 * SNS_FEE)
+                    .fee_collector(4 * SNS_FEE),
+                icp_token => empty_icp_balance_book
+                    .clone()
+                    .treasury_owner(treasury_allocation_icp_e8s - 4 * ICP_FEE)
+                    .fee_collector(4 * ICP_FEE),
+            }),
+        );
     };
 
     validate_treasury_balances(


### PR DESCRIPTION
This PR re-enables the final balance assertion in the treasury manager integration test, which now passes due to the fix in the dependency canister being bumped.