### PR TITLE
chore: Remove UpdateImageType

### DIFF
--- a/rs/tests/consensus/backup/common.rs
+++ b/rs/tests/consensus/backup/common.rs
@@ -36,7 +36,7 @@ use ic_consensus_system_test_utils::{
     },
     upgrade::{
         assert_assigned_replica_version, deploy_guestos_to_all_subnet_nodes,
-        get_assigned_replica_version, UpdateImageType,
+        get_assigned_replica_version,
     },
 };
 use ic_consensus_threshold_sig_system_test_utils::{
@@ -112,7 +112,6 @@ pub fn test(env: TestEnv) {
     block_on(bless_replica_version(
         &nns_node,
         &target_version,
-        UpdateImageType::Image,
         &log,
         &sha256,
         vec![upgrade_url.to_string()],

--- a/rs/tests/consensus/orchestrator/unstuck_subnet_test.rs
+++ b/rs/tests/consensus/orchestrator/unstuck_subnet_test.rs
@@ -17,7 +17,6 @@ use anyhow::bail;
 use anyhow::Result;
 use ic_consensus_system_test_utils::upgrade::{
     bless_replica_version, deploy_guestos_to_all_subnet_nodes, get_assigned_replica_version,
-    UpdateImageType,
 };
 use ic_consensus_system_test_utils::{
     rw_message::{
@@ -78,7 +77,6 @@ fn test(test_env: TestEnv) {
     block_on(bless_replica_version(
         &nns_node,
         &target_version,
-        UpdateImageType::Image,
         &logger,
         &sha256,
         vec![upgrade_url.to_string()],

--- a/rs/tests/consensus/upgrade/common.rs
+++ b/rs/tests/consensus/upgrade/common.rs
@@ -20,7 +20,6 @@ use ic_consensus_system_test_utils::rw_message::{
 use ic_consensus_system_test_utils::subnet::enable_chain_key_signing_on_subnet;
 use ic_consensus_system_test_utils::upgrade::{
     assert_assigned_replica_version, bless_replica_version, deploy_guestos_to_all_subnet_nodes,
-    UpdateImageType,
 };
 use ic_consensus_threshold_sig_system_test_utils::run_chain_key_signature_test;
 use ic_management_canister_types_private::MasterPublicKeyId;
@@ -52,7 +51,6 @@ pub fn bless_target_version(env: &TestEnv, nns_node: &IcNodeSnapshot) -> String 
     block_on(bless_replica_version(
         nns_node,
         &target_version,
-        UpdateImageType::Image,
         &logger,
         &sha256,
         vec![upgrade_url.to_string()],

--- a/rs/tests/consensus/upgrade/upgrade_with_alternative_urls.rs
+++ b/rs/tests/consensus/upgrade/upgrade_with_alternative_urls.rs
@@ -26,7 +26,7 @@ use anyhow::Result;
 use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
 use ic_consensus_system_test_utils::upgrade::{
     assert_assigned_replica_version, bless_replica_version_with_urls,
-    deploy_guestos_to_all_subnet_nodes, get_assigned_replica_version, UpdateImageType,
+    deploy_guestos_to_all_subnet_nodes, get_assigned_replica_version,
 };
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
@@ -86,7 +86,6 @@ fn test(env: TestEnv) {
     block_on(bless_replica_version_with_urls(
         &nns_node,
         &target_version,
-        UpdateImageType::Image,
         release_package_urls,
         get_guestos_update_img_sha256(&env).expect("no SHA256 hash"),
         &logger,

--- a/rs/tests/consensus/utils/src/upgrade.rs
+++ b/rs/tests/consensus/utils/src/upgrade.rs
@@ -19,12 +19,6 @@ use prost::Message;
 use slog::{info, Logger};
 use std::{convert::TryFrom, fs, io::Read, path::Path};
 
-#[derive(Copy, Clone, PartialEq)]
-pub enum UpdateImageType {
-    Image,
-    ImageTest,
-}
-
 pub fn get_public_update_image_url(git_revision: &str) -> String {
     format!(
                 "http://download.proxy-global.dfinity.network:8080/ic/{}/guest-os/update-img/update-img.tar.zst",
@@ -200,7 +194,6 @@ pub fn get_assigned_replica_version(node: &IcNodeSnapshot) -> Result<String, Str
 async fn bless_replica_version_with_sha(
     nns_node: &IcNodeSnapshot,
     target_version: &str,
-    image_type: UpdateImageType,
     logger: &Logger,
     sha256: &String,
     upgrade_url: Vec<String>,
@@ -211,12 +204,7 @@ async fn bless_replica_version_with_sha(
     let proposal_sender = Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR);
     let test_neuron_id = NeuronId(TEST_NEURON_1_ID);
 
-    let replica_version = match image_type {
-        UpdateImageType::ImageTest => {
-            ReplicaVersion::try_from(format!("{}-test", target_version)).unwrap()
-        }
-        UpdateImageType::Image => ReplicaVersion::try_from(target_version).unwrap(),
-    };
+    let replica_version = ReplicaVersion::try_from(target_version).unwrap();
 
     let registry_canister = RegistryCanister::new(vec![nns_node.get_public_url()]);
     let blessed_versions = get_blessed_replica_versions(&registry_canister).await;
@@ -249,20 +237,11 @@ async fn bless_replica_version_with_sha(
 pub async fn bless_replica_version(
     nns_node: &IcNodeSnapshot,
     target_version: &str,
-    image_type: UpdateImageType,
     logger: &Logger,
     sha256: &String,
     upgrade_url: Vec<String>,
 ) {
-    bless_replica_version_with_sha(
-        nns_node,
-        target_version,
-        image_type,
-        logger,
-        sha256,
-        upgrade_url,
-    )
-    .await;
+    bless_replica_version_with_sha(nns_node, target_version, logger, sha256, upgrade_url).await;
 }
 
 pub async fn bless_public_replica_version(
@@ -278,7 +257,6 @@ pub async fn bless_public_replica_version(
     bless_replica_version_with_sha(
         nns_node,
         target_version,
-        UpdateImageType::Image,
         logger,
         &sha256,
         vec![upgrade_url.clone()],
@@ -289,7 +267,6 @@ pub async fn bless_public_replica_version(
 pub async fn bless_replica_version_with_urls(
     nns_node: &IcNodeSnapshot,
     target_version: &str,
-    image_type: UpdateImageType,
     release_package_urls: Vec<String>,
     sha256: String,
     logger: &Logger,
@@ -302,12 +279,7 @@ pub async fn bless_replica_version_with_urls(
     let blessed_versions = get_blessed_replica_versions(&registry_canister).await;
     info!(logger, "Initial: {:?}", blessed_versions);
 
-    let replica_version = match image_type {
-        UpdateImageType::ImageTest => {
-            ReplicaVersion::try_from(format!("{}-test", target_version)).unwrap()
-        }
-        UpdateImageType::Image => ReplicaVersion::try_from(target_version).unwrap(),
-    };
+    let replica_version = ReplicaVersion::try_from(target_version).unwrap();
 
     info!(
         logger,

--- a/rs/tests/message_routing/xnet/xnet_compatibility.rs
+++ b/rs/tests/message_routing/xnet/xnet_compatibility.rs
@@ -27,7 +27,6 @@ use anyhow::Result;
 use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
 use ic_consensus_system_test_utils::upgrade::{
     assert_assigned_replica_version, bless_replica_version, deploy_guestos_to_all_subnet_nodes,
-    UpdateImageType,
 };
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
@@ -183,7 +182,6 @@ pub async fn test_async(env: TestEnv) {
     bless_replica_version(
         &nns_node,
         &branch_version,
-        UpdateImageType::Image,
         &logger,
         &sha256,
         vec![upgrade_url.to_string()],


### PR DESCRIPTION
After https://github.com/dfinity/ic/pull/5912, this is now unused.