### PR TITLE
chore: Publish Universal Canister

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -53,7 +53,7 @@ CANISTERS = {
     "node-rewards-canister-test.wasm.gz": "//rs/node_rewards/canister:node-rewards-canister-test",
 
     # Helpful in advanced testing scenarios, e.g., to emulate a broken 3rd party canister.
-    "universal_canister": "//rs/universal_canister/impl:universal_canister.wasm.gz",
+    "universal_canister.wasm.gz": "//rs/universal_canister/impl:universal_canister.wasm.gz",
 }
 
 COMPRESSED_CANISTERS = {

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -51,6 +51,9 @@ CANISTERS = {
     # Node Rewards
     "node-rewards-canister.wasm.gz": "//rs/node_rewards/canister:node-rewards-canister",
     "node-rewards-canister-test.wasm.gz": "//rs/node_rewards/canister:node-rewards-canister-test",
+
+    # Helpful in advanced testing scenarios, e.g., to emulate a broken 3rd party canister.
+    "universal_canister": "//rs/universal_canister/impl:universal_canister.wasm.gz",
 }
 
 COMPRESSED_CANISTERS = {

--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -53,7 +53,7 @@ CANISTERS = {
     "node-rewards-canister-test.wasm.gz": "//rs/node_rewards/canister:node-rewards-canister-test",
 
     # Helpful in advanced testing scenarios, e.g., to emulate a broken 3rd party canister.
-    "universal_canister.wasm.gz": "//rs/universal_canister/impl:universal_canister.wasm.gz",
+    "universal_canister.wasm.gz": "//rs/universal_canister/impl:universal_canister",
 }
 
 COMPRESSED_CANISTERS = {


### PR DESCRIPTION
This PR enables publishing the Universal Canister Wasm to DFINITY's CDN, enabling projects outside this repo to depend on and use it in advanced testing scenarios, e.g., the emulate a broken 3rd party canister.