### PR TITLE
feat(sns_treasury_manager): API to record pending transactions

### DIFF
--- a/rs/sns/treasury_manager/src/lib.rs
+++ b/rs/sns/treasury_manager/src/lib.rs
@@ -476,11 +476,13 @@ pub struct Transfer {
     pub receiver: Option<Account>,
 }
 
-/// Most of the time, this just points to the Ledger block index. But for generality, once can
+/// Most of the time, this just points to the Ledger block index. But for generality, one can
 /// also use this structure for representing witnesses of non-ledger transactions, e.g., from adding
 /// a token to a DEX for the first time.
 #[derive(CandidType, Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum TransactionWitness {
+    Pending,
+
     Ledger(Vec<Transfer>),
 
     /// Represents a transaction that is not related to the ledger, e.g., DEX operations.

--- a/rs/sns/treasury_manager/treasury_manager.did
+++ b/rs/sns/treasury_manager/treasury_manager.did
@@ -200,6 +200,10 @@ type TransactionResult = variant {
 // also use this structure for representing witnesses of non-ledger transactions, e.g., from adding
 // a token to a DEX for the first time.
 type TransactionWitness = variant {
+  // A placeholder for a transaction witness used to record a transaction attempt before
+  // it is completed.
+  Pending;
+
   // For financial audits.
   Ledger : vec Transfer;
 


### PR DESCRIPTION
This PR extends the `TransactionWitness` API with a new case `Pending`, a placeholder for a transaction witness used to record a transaction attempt before it is completed. This is to implement security recommendations on how to best record transactions in treasury manager implementations.