### PR TITLE
feat: EXC-2087: Implement `ByteCount` trait and derive

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -287,9 +287,11 @@ go_deps.bzl               @dfinity/idx
 /rs/types/wasm_types/                                   @dfinity/execution
 /rs/universal_canister/                                 @dfinity/execution
 /rs/utils/                                              @dfinity/ic-interface-owners
+/rs/utils/byte_count/                                   @dfinity/execution
+/rs/utils/byte_count_derive/                            @dfinity/execution
+/rs/utils/ensure/                                       @dfinity/finint
 /rs/utils/lru_cache/                                    @dfinity/execution
 /rs/utils/thread/                                       @dfinity/ic-message-routing-owners
-/rs/utils/ensure/                                       @dfinity/finint
 /rs/validator/                                          @dfinity/crypto-team
 /rs/wasm_transform/                                     @dfinity/execution
 /rs/xnet/                                               @dfinity/ic-message-routing-owners

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6787,6 +6787,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-byte-count"
+version = "0.9.0"
+dependencies = [
+ "ic-byte-count-derive",
+ "paste",
+]
+
+[[package]]
+name = "ic-byte-count-derive"
+version = "0.9.0"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "ic-canister-client"
 version = "0.9.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -442,6 +442,8 @@ members = [
     "rs/types/wasm_types",
     "rs/universal_canister/lib",
     "rs/utils",
+    "rs/utils/byte_count",
+    "rs/utils/byte_count_derive",
     "rs/utils/ensure",
     "rs/utils/lru_cache",
     "rs/utils/rustfmt",

--- a/rs/utils/byte_count/BUILD.bazel
+++ b/rs/utils/byte_count/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "byte_count",
+    srcs = glob(["src/**"]),
+    crate_name = "ic_byte_count",
+    version = "0.1.0",
+    deps = [
+    ],
+)
+
+rust_test(
+    name = "byte_count_test",
+    crate = ":byte_count",
+    proc_macro_deps = [
+        # Keep sorted.
+        "//rs/utils/byte_count_derive",
+        "@crate_index//:paste",
+    ],
+)

--- a/rs/utils/byte_count/Cargo.toml
+++ b/rs/utils/byte_count/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ic-byte-count"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[lib]
+name = "ic_byte_count"
+path = "src/lib.rs"
+
+[dependencies]
+ic-byte-count-derive = { path = "../byte_count_derive" }
+paste = { workspace = true }

--- a/rs/utils/byte_count/src/lib.rs
+++ b/rs/utils/byte_count/src/lib.rs
@@ -1,0 +1,173 @@
+use paste::paste;
+use std::collections::BTreeMap;
+
+/// A trait for types that can report their total memory usage,
+/// including heap allocations.
+///
+/// This trait provides a `byte_count` method and allows for both
+/// precise (`heap_bytes`) and fast, approximate (`approx_heap_bytes`)
+/// calculations of heap-allocated memory.
+///
+/// It can be derived for structs and enums. The `#[byte_count(approx)]`
+/// attribute can be used on fields to specify that the `approx_heap_bytes`
+/// method should be used instead of the slower `heap_bytes`.
+pub trait ByteCount {
+    /// Returns the total size of the object in bytes.
+    fn byte_count(&self) -> usize {
+        size_of_val(self) + self.heap_bytes()
+    }
+
+    /// Returns the total size of heap-allocated data.
+    ///
+    /// This method performs a precise, recursive heap memory calculation.
+    /// For large collections, this can be slow. In such cases, consider
+    /// using the `#[byte_count(approx)]` attribute in derive macros.
+    ///
+    /// The default implementation returns 0, which is correct for
+    /// types that do not have any heap allocations.
+    fn heap_bytes(&self) -> usize {
+        0
+    }
+
+    /// Returns a fast, constant-time approximation of heap-allocated data.
+    ///
+    /// By default, this method calls `heap_bytes` for a precise count.
+    /// Types can override it to provide a faster, less precise estimate,
+    /// which is useful for large data collections.
+    fn approx_heap_bytes(&self) -> usize {
+        self.heap_bytes()
+    }
+}
+
+// Basic types.
+impl ByteCount for u8 {}
+impl ByteCount for u16 {}
+impl ByteCount for u32 {}
+impl ByteCount for u64 {}
+impl ByteCount for u128 {}
+impl ByteCount for usize {}
+impl ByteCount for i8 {}
+impl ByteCount for i16 {}
+impl ByteCount for i32 {}
+impl ByteCount for i64 {}
+impl ByteCount for i128 {}
+impl ByteCount for isize {}
+impl ByteCount for f32 {}
+impl ByteCount for f64 {}
+impl ByteCount for bool {}
+impl ByteCount for char {}
+
+impl ByteCount for String {
+    fn heap_bytes(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: ByteCount, const N: usize> ByteCount for [T; N] {
+    /// Calculates the precise heap size by summing the heap usage of all elements.
+    fn heap_bytes(&self) -> usize {
+        self.iter().map(ByteCount::heap_bytes).sum()
+    }
+
+    /// Provides a fast approximation based only on the number of elements.
+    /// Since an array itself has no heap allocation, this is 0.
+    fn approx_heap_bytes(&self) -> usize {
+        0
+    }
+}
+
+impl<T: ByteCount> ByteCount for Vec<T> {
+    /// Calculates the precise heap size by summing the heap usage of all elements.
+    fn heap_bytes(&self) -> usize {
+        let self_heap_bytes = self.len() * size_of::<T>();
+        let elements_heap_bytes: usize = self.iter().map(ByteCount::heap_bytes).sum();
+        self_heap_bytes + elements_heap_bytes
+    }
+
+    /// Provides a fast approximation based only on the number of elements.
+    fn approx_heap_bytes(&self) -> usize {
+        self.len() * size_of::<T>()
+    }
+}
+
+impl<K: ByteCount, V: ByteCount> ByteCount for BTreeMap<K, V> {
+    /// Calculates the precise heap size by summing the heap usage of all elements.
+    ///
+    /// WARNING: This performs a full scan of the map and is `O(N)`.
+    /// It is implemented for completeness but should be avoided on large maps.
+    /// The `#[byte_count(approx)]` attribute uses `approx_heap_bytes` instead.
+    fn heap_bytes(&self) -> usize {
+        let self_heap_bytes = self.len() * (size_of::<K>() + size_of::<V>());
+        let elements_heap_bytes: usize = self
+            .iter()
+            .map(|(k, v)| k.heap_bytes() + v.heap_bytes())
+            .sum();
+        self_heap_bytes + elements_heap_bytes
+    }
+
+    /// Provides a fast approximation based only on the number of elements.
+    fn approx_heap_bytes(&self) -> usize {
+        self.len() * (size_of::<K>() + size_of::<V>())
+    }
+}
+
+macro_rules! impl_byte_count_for_tuple {
+    ( $( $idx:tt ),* ) => {
+        paste! {
+            impl< $([<T $idx>]: ByteCount),* > ByteCount for ( $([<T $idx>],)* ) {
+                fn heap_bytes(&self) -> usize {
+                    0 $(+ self.$idx.heap_bytes())*
+                }
+
+                fn approx_heap_bytes(&self) -> usize {
+                    0 $(+ self.$idx.approx_heap_bytes())*
+                }
+            }
+        }
+    };
+}
+
+impl ByteCount for () {}
+impl_byte_count_for_tuple!(0);
+impl_byte_count_for_tuple!(0, 1);
+impl_byte_count_for_tuple!(0, 1, 2);
+impl_byte_count_for_tuple!(0, 1, 2, 3);
+impl_byte_count_for_tuple!(0, 1, 2, 3, 4);
+impl_byte_count_for_tuple!(0, 1, 2, 3, 4, 5);
+impl_byte_count_for_tuple!(0, 1, 2, 3, 4, 5, 6);
+impl_byte_count_for_tuple!(0, 1, 2, 3, 4, 5, 6, 7);
+
+impl<T: ByteCount> ByteCount for Option<T> {
+    fn heap_bytes(&self) -> usize {
+        match self {
+            Some(s) => s.heap_bytes(),
+            None => 0,
+        }
+    }
+
+    fn approx_heap_bytes(&self) -> usize {
+        match self {
+            Some(s) => s.approx_heap_bytes(),
+            None => 0,
+        }
+    }
+}
+
+impl<T: ByteCount, E: ByteCount> ByteCount for Result<T, E> {
+    fn heap_bytes(&self) -> usize {
+        match self {
+            Ok(ok) => ok.heap_bytes(),
+            Err(err) => err.heap_bytes(),
+        }
+    }
+
+    fn approx_heap_bytes(&self) -> usize {
+        match self {
+            Ok(ok) => ok.approx_heap_bytes(),
+            Err(err) => err.approx_heap_bytes(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/rs/utils/byte_count/src/tests.rs
+++ b/rs/utils/byte_count/src/tests.rs
@@ -1,0 +1,538 @@
+use std::collections::BTreeMap;
+
+use super::ByteCount;
+use ic_byte_count_derive::ByteCount;
+
+#[test]
+fn empty_byte_count() {
+    #[derive(ByteCount, Default)]
+    struct S {}
+    assert_eq!(S::default().byte_count(), 0);
+    #[derive(ByteCount, Default)]
+    enum E {
+        #[default]
+        One,
+    }
+    assert_eq!(E::default().byte_count(), 0);
+    assert_eq!(String::new().byte_count(), size_of::<String>());
+    assert_eq!([()].byte_count(), 0);
+    assert_eq!(vec![()].byte_count(), size_of::<Vec<()>>());
+    assert_eq!(
+        BTreeMap::<(), ()>::new().byte_count(),
+        size_of::<BTreeMap<(), ()>>()
+    );
+    assert_eq!(().byte_count(), 0);
+    assert_eq!(None::<()>.byte_count(), 1);
+    assert_eq!(Ok::<(), ()>(()).byte_count(), 1);
+    assert_eq!(Err::<(), ()>(()).byte_count(), 1);
+}
+
+macro_rules! assert_struct_basic_field_byte_count_eq {
+    ($field_type:ty, $expected_size:expr) => {{
+        #[derive(ByteCount, Default)]
+        struct S {
+            v: $field_type,
+        }
+        assert_eq!(S::default().byte_count(), $expected_size);
+    }};
+}
+
+#[test]
+fn struct_basic_field_byte_count() {
+    assert_struct_basic_field_byte_count_eq!(u8, size_of::<u8>());
+    assert_struct_basic_field_byte_count_eq!(u16, size_of::<u16>());
+    assert_struct_basic_field_byte_count_eq!(u32, size_of::<u32>());
+    assert_struct_basic_field_byte_count_eq!(u64, size_of::<u64>());
+    assert_struct_basic_field_byte_count_eq!(u128, size_of::<u128>());
+    assert_struct_basic_field_byte_count_eq!(usize, size_of::<usize>());
+    assert_struct_basic_field_byte_count_eq!(i8, size_of::<i8>());
+    assert_struct_basic_field_byte_count_eq!(i16, size_of::<i16>());
+    assert_struct_basic_field_byte_count_eq!(i32, size_of::<i32>());
+    assert_struct_basic_field_byte_count_eq!(i64, size_of::<i64>());
+    assert_struct_basic_field_byte_count_eq!(i128, size_of::<i128>());
+    assert_struct_basic_field_byte_count_eq!(isize, size_of::<isize>());
+    assert_struct_basic_field_byte_count_eq!(f32, size_of::<f32>());
+    assert_struct_basic_field_byte_count_eq!(f64, size_of::<f64>());
+    assert_struct_basic_field_byte_count_eq!(bool, size_of::<bool>());
+    assert_struct_basic_field_byte_count_eq!(char, size_of::<char>());
+}
+
+#[test]
+fn struct_basic_fields_byte_count() {
+    #[derive(ByteCount, Default)]
+    struct S {
+        v1: u8,
+        v2: u128,
+    }
+    assert_eq!(S::default().byte_count(), size_of::<S>());
+}
+
+macro_rules! assert_enum_basic_field_byte_count_eq {
+    ($field_type:ty, $expected_size:expr) => {{
+        #[derive(ByteCount)]
+        enum E {
+            One($field_type),
+        }
+        assert_eq!(
+            E::One(<$field_type>::default()).byte_count(),
+            $expected_size
+        );
+    }};
+}
+
+#[test]
+fn enum_basic_field_byte_count() {
+    assert_enum_basic_field_byte_count_eq!(u8, size_of::<u8>());
+    assert_enum_basic_field_byte_count_eq!(u16, size_of::<u16>());
+    assert_enum_basic_field_byte_count_eq!(u32, size_of::<u32>());
+    assert_enum_basic_field_byte_count_eq!(u64, size_of::<u64>());
+    assert_enum_basic_field_byte_count_eq!(u128, size_of::<u128>());
+    assert_enum_basic_field_byte_count_eq!(usize, size_of::<usize>());
+    assert_enum_basic_field_byte_count_eq!(i8, size_of::<i8>());
+    assert_enum_basic_field_byte_count_eq!(i16, size_of::<i16>());
+    assert_enum_basic_field_byte_count_eq!(i32, size_of::<i32>());
+    assert_enum_basic_field_byte_count_eq!(i64, size_of::<i64>());
+    assert_enum_basic_field_byte_count_eq!(i128, size_of::<i128>());
+    assert_enum_basic_field_byte_count_eq!(isize, size_of::<isize>());
+    assert_enum_basic_field_byte_count_eq!(f32, size_of::<f32>());
+    assert_enum_basic_field_byte_count_eq!(f64, size_of::<f64>());
+    assert_enum_basic_field_byte_count_eq!(bool, size_of::<bool>());
+    assert_enum_basic_field_byte_count_eq!(char, size_of::<char>());
+}
+
+#[test]
+fn enum_basic_fields_byte_count() {
+    #[derive(ByteCount)]
+    enum E {
+        One(u8, u128),
+    }
+    assert_eq!(
+        E::One(<u8>::default(), <u128>::default()).byte_count(),
+        size_of::<E>()
+    );
+}
+
+#[test]
+fn enum_repr_byte_count() {
+    #[derive(ByteCount, Default)]
+    #[repr(u8)]
+    enum U8 {
+        #[default]
+        One,
+    }
+    assert_eq!(U8::default().byte_count(), size_of::<u8>());
+
+    #[derive(ByteCount, Default)]
+    #[repr(u64)]
+    enum U64 {
+        #[default]
+        One,
+    }
+    assert_eq!(U64::default().byte_count(), size_of::<u64>());
+}
+
+#[test]
+fn string_byte_count() {
+    let b = size_of::<String>();
+    assert_eq!("".to_string().byte_count(), b);
+    assert_eq!("123".to_string().byte_count(), b + 3);
+}
+
+#[test]
+fn array_basic_byte_count() {
+    assert_eq!([42_u8; 42].byte_count(), size_of::<u8>() * 42);
+    assert_eq!([42_u16; 42].byte_count(), size_of::<u16>() * 42);
+    assert_eq!([42_u32; 42].byte_count(), size_of::<u32>() * 42);
+    assert_eq!([42_u64; 42].byte_count(), size_of::<u64>() * 42);
+    assert_eq!([42_u128; 42].byte_count(), size_of::<u128>() * 42);
+    assert_eq!([42_usize; 42].byte_count(), size_of::<usize>() * 42);
+    assert_eq!([42_i8; 42].byte_count(), size_of::<i8>() * 42);
+    assert_eq!([42_i16; 42].byte_count(), size_of::<i16>() * 42);
+    assert_eq!([42_i32; 42].byte_count(), size_of::<i32>() * 42);
+    assert_eq!([42_i64; 42].byte_count(), size_of::<i64>() * 42);
+    assert_eq!([42_i128; 42].byte_count(), size_of::<i128>() * 42);
+    assert_eq!([42_isize; 42].byte_count(), size_of::<isize>() * 42);
+    assert_eq!([42_f32; 42].byte_count(), size_of::<f32>() * 42);
+    assert_eq!([42_f64; 42].byte_count(), size_of::<f64>() * 42);
+    assert_eq!([true; 42].byte_count(), size_of::<bool>() * 42);
+    assert_eq!(['c'; 42].byte_count(), size_of::<char>() * 42);
+}
+
+#[test]
+fn vec_basic_byte_count() {
+    let b = size_of::<Vec<()>>();
+    assert_eq!(vec![42_u8; 42].byte_count(), b + size_of::<u8>() * 42);
+    assert_eq!(vec![42_u16; 42].byte_count(), b + size_of::<u16>() * 42);
+    assert_eq!(vec![42_u32; 42].byte_count(), b + size_of::<u32>() * 42);
+    assert_eq!(vec![42_u64; 42].byte_count(), b + size_of::<u64>() * 42);
+    assert_eq!(vec![42_u128; 42].byte_count(), b + size_of::<u128>() * 42);
+    assert_eq!(vec![42_usize; 42].byte_count(), b + size_of::<usize>() * 42);
+    assert_eq!(vec![42_i8; 42].byte_count(), b + size_of::<i8>() * 42);
+    assert_eq!(vec![42_i16; 42].byte_count(), b + size_of::<i16>() * 42);
+    assert_eq!(vec![42_i32; 42].byte_count(), b + size_of::<i32>() * 42);
+    assert_eq!(vec![42_i64; 42].byte_count(), b + size_of::<i64>() * 42);
+    assert_eq!(vec![42_i128; 42].byte_count(), b + size_of::<i128>() * 42);
+    assert_eq!(vec![42_isize; 42].byte_count(), b + size_of::<isize>() * 42);
+    assert_eq!(vec![42_f32; 42].byte_count(), b + size_of::<f32>() * 42);
+    assert_eq!(vec![42_f64; 42].byte_count(), b + size_of::<f64>() * 42);
+    assert_eq!(vec![true; 42].byte_count(), b + size_of::<bool>() * 42);
+    assert_eq!(vec!['c'; 42].byte_count(), b + size_of::<char>() * 42);
+}
+
+macro_rules! assert_btree_map_basic_byte_count_eq {
+    ($field_type:ty, $expected_size:expr) => {{
+        let t = <$field_type>::default();
+        assert_eq!(BTreeMap::from([(t, t)]).byte_count(), $expected_size);
+    }};
+}
+
+#[test]
+fn btree_map_basic_byte_count() {
+    let b = size_of::<BTreeMap<(), ()>>();
+    assert_btree_map_basic_byte_count_eq!(u8, b + size_of::<u8>() * 2);
+    assert_btree_map_basic_byte_count_eq!(u16, b + size_of::<u16>() * 2);
+    assert_btree_map_basic_byte_count_eq!(u32, b + size_of::<u32>() * 2);
+    assert_btree_map_basic_byte_count_eq!(u64, b + size_of::<u64>() * 2);
+    assert_btree_map_basic_byte_count_eq!(u128, b + size_of::<u128>() * 2);
+    assert_btree_map_basic_byte_count_eq!(usize, b + size_of::<usize>() * 2);
+    assert_btree_map_basic_byte_count_eq!(i8, b + size_of::<i8>() * 2);
+    assert_btree_map_basic_byte_count_eq!(i16, b + size_of::<i16>() * 2);
+    assert_btree_map_basic_byte_count_eq!(i32, b + size_of::<i32>() * 2);
+    assert_btree_map_basic_byte_count_eq!(i64, b + size_of::<i64>() * 2);
+    assert_btree_map_basic_byte_count_eq!(i128, b + size_of::<i128>() * 2);
+    assert_btree_map_basic_byte_count_eq!(isize, b + size_of::<isize>() * 2);
+    assert_btree_map_basic_byte_count_eq!(bool, b + size_of::<bool>() * 2);
+    assert_btree_map_basic_byte_count_eq!(char, b + size_of::<char>() * 2);
+}
+
+#[test]
+fn tuple_basic_byte_count() {
+    assert_eq!((42_u8,).byte_count(), size_of::<u8>());
+    assert_eq!((42_u8, 42_u8,).byte_count(), size_of::<u8>() * 2);
+    assert_eq!((42_u8, 42_u8, 42_u8,).byte_count(), size_of::<u8>() * 3);
+    assert_eq!(
+        (42_u8, 42_u8, 42_u8, 42_u8,).byte_count(),
+        size_of::<u8>() * 4
+    );
+    assert_eq!(
+        (42_u8, 42_u8, 42_u8, 42_u8, 42_u8,).byte_count(),
+        size_of::<u8>() * 5
+    );
+    assert_eq!(
+        (42_u8, 42_u8, 42_u8, 42_u8, 42_u8, 42_u8,).byte_count(),
+        size_of::<u8>() * 6
+    );
+    assert_eq!(
+        (42_u8, 42_u8, 42_u8, 42_u8, 42_u8, 42_u8, 42_u8,).byte_count(),
+        size_of::<u8>() * 7
+    );
+    assert_eq!(
+        (42_u8, 42_u8, 42_u8, 42_u8, 42_u8, 42_u8, 42_u8, 42_u8,).byte_count(),
+        size_of::<(u8, u8, u8, u8, u8, u8, u8, u8,)>()
+    );
+}
+
+#[test]
+fn option_basic_byte_count() {
+    assert_eq!(Some(42_u8).byte_count(), size_of::<u8>() * 2);
+    assert_eq!(None::<u8>.byte_count(), size_of::<u8>() * 2);
+    assert_eq!(Some(42_u16).byte_count(), size_of::<u16>() * 2);
+    assert_eq!(None::<u16>.byte_count(), size_of::<u16>() * 2);
+    assert_eq!(Some(42_u32).byte_count(), size_of::<u32>() * 2);
+    assert_eq!(None::<u32>.byte_count(), size_of::<u32>() * 2);
+    assert_eq!(Some(42_u64).byte_count(), size_of::<u64>() * 2);
+    assert_eq!(None::<u64>.byte_count(), size_of::<u64>() * 2);
+    assert_eq!(Some(42_u128).byte_count(), size_of::<u128>() * 2);
+    assert_eq!(None::<u128>.byte_count(), size_of::<u128>() * 2);
+    assert_eq!(Some(42_usize).byte_count(), size_of::<usize>() * 2);
+    assert_eq!(None::<usize>.byte_count(), size_of::<usize>() * 2);
+    assert_eq!(Some(true).byte_count(), size_of::<bool>());
+    assert_eq!(None::<bool>.byte_count(), size_of::<bool>());
+    assert_eq!(Some('c').byte_count(), size_of::<char>());
+    assert_eq!(None::<char>.byte_count(), size_of::<char>());
+}
+
+#[test]
+fn result_basic_byte_count() {
+    assert_eq!(Ok::<u8, u8>(42).byte_count(), size_of::<u8>() * 2);
+    assert_eq!(Err::<u8, u8>(42).byte_count(), size_of::<u8>() * 2);
+    assert_eq!(Ok::<u16, u16>(42).byte_count(), size_of::<u16>() * 2);
+    assert_eq!(Err::<u16, u16>(42).byte_count(), size_of::<u16>() * 2);
+    assert_eq!(Ok::<u32, u32>(42).byte_count(), size_of::<u32>() * 2);
+    assert_eq!(Err::<u32, u32>(42).byte_count(), size_of::<u32>() * 2);
+    assert_eq!(Ok::<u64, u64>(42).byte_count(), size_of::<u64>() * 2);
+    assert_eq!(Err::<u64, u64>(42).byte_count(), size_of::<u64>() * 2);
+    assert_eq!(Ok::<u128, u128>(42).byte_count(), size_of::<u128>() * 2);
+    assert_eq!(Err::<u128, u128>(42).byte_count(), size_of::<u128>() * 2);
+    assert_eq!(Ok::<usize, usize>(42).byte_count(), size_of::<usize>() * 2);
+    assert_eq!(Err::<usize, usize>(42).byte_count(), size_of::<usize>() * 2);
+    assert_eq!(Ok::<bool, bool>(true).byte_count(), size_of::<bool>() * 2);
+    assert_eq!(Err::<bool, bool>(true).byte_count(), size_of::<bool>() * 2);
+    assert_eq!(Ok::<char, char>('c').byte_count(), size_of::<char>() * 2);
+    assert_eq!(Err::<char, char>('c').byte_count(), size_of::<char>() * 2);
+}
+
+#[test]
+fn mixed_struct() {
+    #[derive(ByteCount, Default)]
+    struct S {
+        b: usize,
+        s: String,
+        o: Option<String>,
+        t: (String, String),
+        a: [String; 3],
+        v: Vec<String>,
+        m: BTreeMap<String, String>,
+    }
+    assert_eq!(
+        S::default().byte_count(),
+        size_of::<usize>()
+            + size_of::<String>()
+            + size_of::<Option<String>>()
+            + size_of::<(String, String)>()
+            + size_of::<[String; 3]>()
+            + size_of::<Vec<String>>()
+            + size_of::<BTreeMap<String, String>>()
+    );
+}
+
+#[test]
+fn mixed_enum() {
+    #[allow(dead_code)]
+    #[derive(ByteCount, Default)]
+    #[repr(usize)]
+    enum E {
+        #[default]
+        Empty,
+        Basic(usize),
+        String(String),
+        Option(Option<usize>),
+        Tuple((usize, usize)),
+        Array([usize; 3]),
+        Vec(Vec<usize>),
+        BTreeMap(BTreeMap<usize, usize>),
+    }
+    assert_eq!(
+        E::default().byte_count(),
+        size_of::<usize>()
+            + size_of::<String>()
+                .max(size_of::<Option<usize>>())
+                .max(size_of::<(usize, usize)>())
+                .max(size_of::<[usize; 3]>())
+                .max(size_of::<Vec<usize>>())
+                .max(size_of::<BTreeMap<usize, usize>>())
+    );
+}
+
+#[test]
+fn mixed_tuple() {
+    let tuple = (
+        42_usize,
+        String::new(),
+        Some(String::new()),
+        Ok::<String, String>(String::new()),
+        (String::new(), String::new()),
+        [42_usize; 3],
+        vec![String::new(); 3],
+        BTreeMap::from([(String::new(), String::new())]),
+    );
+    assert_eq!(
+        tuple.byte_count(),
+        size_of::<usize>()
+            + size_of::<String>()
+            + size_of::<Option<String>>()
+            + size_of::<Result::<String, String>>()
+            + size_of::<(String, String)>()
+            + size_of::<[usize; 3]>()
+            + size_of::<Vec<String>>()
+            + size_of::<String>() * 3
+            + size_of::<BTreeMap<String, String>>()
+            + size_of::<String>() * 2
+    );
+
+    let tuple = ("1".to_string(), "123".to_string(), "12345".to_string());
+    assert_eq!(tuple.byte_count(), size_of::<String>() * 3 + 1 + 3 + 5);
+}
+
+#[test]
+fn mixed_array() {
+    let arr = [
+        ("1".to_string(), "123".to_string()),
+        ("12345".to_string(), "1234567".to_string()),
+    ];
+    assert_eq!(
+        arr.byte_count(),
+        size_of::<[(String, String); 2]>() + 1 + 3 + 5 + 7
+    );
+}
+
+#[test]
+fn mixed_vec() {
+    let vec = vec![
+        ("1".to_string(), "123".to_string()),
+        ("12345".to_string(), "1234567".to_string()),
+    ];
+    assert_eq!(
+        vec.byte_count(),
+        size_of::<Vec<(String, String)>>() + size_of::<String>() * 4 + 1 + 3 + 5 + 7
+    );
+}
+
+#[test]
+fn mixed_btree_map() {
+    let btree_map = BTreeMap::from([
+        ("1".to_string(), "123".to_string()),
+        ("12345".to_string(), "1234567".to_string()),
+    ]);
+    assert_eq!(
+        btree_map.byte_count(),
+        size_of::<BTreeMap<String, String>>() + size_of::<String>() * 4 + 1 + 3 + 5 + 7
+    );
+}
+
+#[test]
+fn nested_vec_enum_struct_string() {
+    #[derive(ByteCount)]
+    struct S {
+        v: Vec<String>,
+        m: BTreeMap<String, String>,
+    }
+    #[derive(ByteCount)]
+    enum E {
+        One,
+        Two(Option<(S, S)>),
+        Three(Vec<Result<S, S>>),
+    }
+    let v = vec![
+        E::One,
+        E::Two(Some((
+            S {
+                v: vec!["!".to_string(), "!".repeat(3).to_string()],
+                m: BTreeMap::from([("!".repeat(5).to_string(), "!".repeat(7).to_string())]),
+            },
+            S {
+                v: vec!["!".repeat(11).to_string(), "!".repeat(13).to_string()],
+                m: BTreeMap::from([("!".repeat(17).to_string(), "!".repeat(19).to_string())]),
+            },
+        ))),
+        E::Three(vec![
+            Ok(S {
+                v: vec!["!".repeat(23).to_string(), "!".repeat(29).to_string()],
+                m: BTreeMap::from([("!".repeat(31).to_string(), "!".repeat(37).to_string())]),
+            }),
+            Err(S {
+                v: vec!["!".repeat(41).to_string(), "!".repeat(43).to_string()],
+                m: BTreeMap::from([("!".repeat(47).to_string(), "!".repeat(53).to_string())]),
+            }),
+        ]),
+    ];
+    assert_eq!(
+        v.byte_count(),
+        size_of::<Vec<E>>()
+            + size_of::<E>() * 3
+            + size_of::<Result<S, S>>() * 2
+            + size_of::<String>() * 16
+            + 1
+            + 3
+            + 5
+            + 7
+            + 11
+            + 13
+            + 17
+            + 19
+            + 23
+            + 29
+            + 31
+            + 37
+            + 41
+            + 43
+            + 47
+            + 53
+    );
+}
+
+#[test]
+fn approx_vec_enum_struct_string() {
+    #[derive(ByteCount)]
+    struct S {
+        v: Vec<String>,
+        #[byte_count(approx)]
+        m: BTreeMap<String, String>,
+    }
+    #[derive(ByteCount)]
+    enum E {
+        One,
+        Two(Option<(S, S)>),
+        #[byte_count(approx)]
+        Three(Vec<Result<S, S>>),
+    }
+    let v = vec![
+        E::One,
+        E::Two(Some((
+            S {
+                v: vec!["!".to_string(), "!".repeat(3).to_string()],
+                m: BTreeMap::from([("!".repeat(5).to_string(), "!".repeat(7).to_string())]),
+            },
+            S {
+                v: vec!["!".repeat(11).to_string(), "!".repeat(13).to_string()],
+                m: BTreeMap::from([("!".repeat(17).to_string(), "!".repeat(19).to_string())]),
+            },
+        ))),
+        E::Three(vec![
+            Ok(S {
+                v: vec!["!".repeat(23).to_string(), "!".repeat(29).to_string()],
+                m: BTreeMap::from([("!".repeat(31).to_string(), "!".repeat(37).to_string())]),
+            }),
+            Err(S {
+                v: vec!["!".repeat(41).to_string(), "!".repeat(43).to_string()],
+                m: BTreeMap::from([("!".repeat(47).to_string(), "!".repeat(53).to_string())]),
+            }),
+        ]),
+    ];
+    // All BTreeMap strings and vector of results (third enum variant) are approximated.
+    assert_eq!(
+        v.byte_count(),
+        size_of::<Vec<E>>()
+            + size_of::<E>() * 3
+            + size_of::<Result<S, S>>() * 2
+            + size_of::<String>() * 8
+            + 1
+            + 3
+            + 11
+            + 13
+    );
+}
+
+#[test]
+fn example_struct() {
+    #[derive(ByteCount)]
+    struct PreciseCount {
+        s: String,
+        v: Vec<String>,
+    }
+
+    assert_eq!(
+        PreciseCount {
+            s: "1".to_string(),
+            v: vec!["123".to_string(), "12345".to_string()]
+        }
+        .byte_count(),
+        size_of::<PreciseCount>() + size_of::<String>() * 2 + 1 + 3 + 5
+    );
+
+    #[derive(ByteCount)]
+    struct ApproxCount {
+        s: String,
+        #[byte_count(approx)]
+        v: Vec<String>,
+    }
+
+    assert_eq!(
+        ApproxCount {
+            s: "1".to_string(),
+            v: vec!["123".to_string(), "12345".to_string()]
+        }
+        .byte_count(),
+        size_of::<ApproxCount>() + size_of::<String>() * 2 + 1
+    );
+}

--- a/rs/utils/byte_count_derive/BUILD.bazel
+++ b/rs/utils/byte_count_derive/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_proc_macro(
+    name = "byte_count_derive",
+    srcs = glob(["src/**"]),
+    crate_name = "ic_byte_count_derive",
+    version = "0.1.0",
+    deps = [
+        # Keep sorted.
+        "@crate_index//:darling",
+        "@crate_index//:proc-macro2",
+        "@crate_index//:quote",
+        "@crate_index//:syn2",
+    ],
+)

--- a/rs/utils/byte_count_derive/Cargo.toml
+++ b/rs/utils/byte_count_derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+name = "ic-byte-count-derive"
+version.workspace = true
+
+[lib]
+name = "ic_byte_count_derive"
+path = "src/lib.rs"
+proc-macro = true
+
+[dependencies]
+darling = "0.20.11"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { version = "2.0.100", features = ["derive"] }

--- a/rs/utils/byte_count_derive/src/lib.rs
+++ b/rs/utils/byte_count_derive/src/lib.rs
@@ -1,0 +1,132 @@
+use darling::{ast::Data, FromDeriveInput, FromField, FromVariant};
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Ident, Index};
+
+#[derive(FromDeriveInput)]
+struct ByteCountReceiver {
+    ident: Ident,
+    data: Data<VariantReceiver, FieldReceiver>,
+}
+
+#[derive(Debug, FromVariant)]
+#[darling(attributes(byte_count))]
+struct VariantReceiver {
+    ident: Ident,
+    fields: darling::ast::Fields<FieldReceiver>,
+    #[darling(default)]
+    approx: bool,
+}
+
+#[derive(Debug, FromField)]
+#[darling(attributes(byte_count))]
+struct FieldReceiver {
+    ident: Option<Ident>,
+    #[darling(default)]
+    approx: bool,
+}
+
+#[proc_macro_derive(ByteCount, attributes(byte_count))]
+pub fn derive_byte_count(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let receiver = match ByteCountReceiver::from_derive_input(&input) {
+        Ok(r) => r,
+        Err(e) => return e.write_errors().into(),
+    };
+
+    let heap_bytes_body = match receiver.data {
+        Data::Enum(variants) => enum_heap_bytes_body(&variants),
+        Data::Struct(fields) => struct_heap_bytes_body(&fields),
+    };
+
+    let struct_name = &receiver.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics ByteCount for #struct_name #ty_generics #where_clause {
+            fn heap_bytes(&self) -> usize {
+                #heap_bytes_body
+            }
+        }
+    }
+    .into()
+}
+
+fn struct_heap_bytes_body(
+    fields: &darling::ast::Fields<FieldReceiver>,
+) -> proc_macro2::TokenStream {
+    let field_sum_exprs = fields.fields.iter().enumerate().map(|(i, field)| {
+        let field_accessor = if let Some(ident) = &field.ident {
+            // Named field: `self.my_field`
+            quote! { self.#ident }
+        } else {
+            // Tuple field: `self.0`
+            let index = Index::from(i);
+            quote! { self.#index }
+        };
+
+        if field.approx {
+            quote! { #field_accessor.approx_heap_bytes() }
+        } else {
+            quote! { #field_accessor.heap_bytes() }
+        }
+    });
+
+    // Sum the heap bytes of all fields. The initial `0` handles unit structs correctly.
+    quote! {
+        0 #(+ #field_sum_exprs)*
+    }
+}
+
+fn enum_heap_bytes_body(variants: &[VariantReceiver]) -> proc_macro2::TokenStream {
+    let match_arms = variants.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+
+        // Generate bindings for fields in the match pattern (e.g., `v0, v1` or `field1, field2`).
+        let (field_pats, sum_exprs): (Vec<_>, Vec<_>) = variant
+            .fields
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| {
+                let (field_pat, field_accessor) = if let Some(ident) = &field.ident {
+                    (quote! { #ident }, quote! { #ident })
+                } else {
+                    let var_name = format!("v{}", i);
+                    let ident = Ident::new(&var_name, proc_macro2::Span::call_site());
+                    (quote! { #ident }, quote! { #ident })
+                };
+
+                let expr = if variant.approx || field.approx {
+                    quote! { #field_accessor.approx_heap_bytes() }
+                } else {
+                    quote! { #field_accessor.heap_bytes() }
+                };
+
+                (field_pat, expr)
+            })
+            .unzip();
+
+        // Generate the expression to sum the heap bytes of all fields in the variant.
+        let sum_expr = quote! { 0 #(+ #sum_exprs)* };
+
+        // Create the full match arm for this variant.
+        match variant.fields.style {
+            darling::ast::Style::Struct => {
+                quote! { Self::#variant_ident { #(#field_pats),* } => #sum_expr }
+            }
+            darling::ast::Style::Tuple => {
+                quote! { Self::#variant_ident(#(#field_pats),*) => #sum_expr }
+            }
+            darling::ast::Style::Unit => {
+                quote! { Self::#variant_ident => 0 }
+            }
+        }
+    });
+
+    // The final implementation is a `match` statement over `self`.
+    quote! {
+        match self {
+            #(#match_arms),*
+        }
+    }
+}


### PR DESCRIPTION
This commit adds the `ByteCount` trait and its derive macro. The trait could be easily derived for structs and enums:

```rust
    #[derive(ByteCount)]
    struct PreciseCount {
        s: String,
        v: Vec<String>,
    }

    assert_eq!(
        PreciseCount {
            s: "1".to_string(),
            v: vec!["123".to_string(), "12345".to_string()]
        }
        .byte_count(),
        size_of::<PreciseCount>() + size_of::<String>() * 2 + 1 + 3 + 5
    );
```

To avoid performance issues, the `#[byte_count(approx)]` attribute can be used on fields to specify that the `approx_heap_bytes` method should be used instead of the slower `heap_bytes`.

```rust
    #[derive(ByteCount)]
    struct ApproxCount {
        s: String,
        #[byte_count(approx)]
        v: Vec<String>,
    }

    assert_eq!(
        ApproxCount {
            s: "1".to_string(),
            v: vec!["123".to_string(), "12345".to_string()]
        }
        .byte_count(),
        size_of::<ApproxCount>() + size_of::<String>() * 2 + 1
    );
```