### PR TITLE
fix(node): nested test affected targets

### DIFF
--- a/ic-os/components/setupos-scripts/setupos.sh
+++ b/ic-os/components/setupos-scripts/setupos.sh
@@ -42,7 +42,7 @@ main() {
 
     echo "TEST FAILURE"
     exit 1
-    
+
     /opt/ic/bin/check-setupos-age.sh
     /opt/ic/bin/check-config.sh
     /opt/ic/bin/check-hardware.sh

--- a/ic-os/components/setupos-scripts/setupos.sh
+++ b/ic-os/components/setupos-scripts/setupos.sh
@@ -39,6 +39,10 @@ function reboot_setupos() {
 main() {
     log_start "$(basename $0)"
     start_setupos
+
+    echo "TEST FAILURE"
+    exit 1
+    
     /opt/ic/bin/check-setupos-age.sh
     /opt/ic/bin/check-config.sh
     /opt/ic/bin/check-hardware.sh

--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -64,7 +64,9 @@ system_test_nns(
     uses_guestos_img = False,
     uses_guestos_mainnet_img = True,
     uses_setupos_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
+        "//ic-os/setupos:test-img.tar.zst",
+    ],
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -86,7 +88,10 @@ system_test_nns(
     test_timeout = "eternal",
     uses_guestos_test_update = True,
     uses_setupos_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
+        "//ic-os/guestos/envs/dev:update-img-test.tar.zst",
+        "//ic-os/setupos:test-img.tar.zst",
+    ],
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -110,7 +115,10 @@ system_test_nns(
     uses_guestos_mainnet_img = True,
     uses_hostos_test_update = True,
     uses_setupos_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS,
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
+        "//ic-os/hostos/envs/dev:update-img-test.tar.zst",
+        "//ic-os/setupos:test-img.tar.zst",
+    ],
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -129,7 +137,11 @@ system_test_nns(
     uses_guestos_mainnet_img = True,
     uses_hostos_update = True,
     uses_setupos_mainnet_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
+        "//ic-os/hostos/envs/dev:update-img.tar.zst",
+        "//ic-os/setupos:config/node_operator_private_key.pem",
+        "//ic-os/setupos:mainnet-test-img.tar.zst",
+    ],
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -150,6 +162,9 @@ system_test_nns(
     uses_guestos_mainnet_img = True,
     uses_hostos_mainnet_update = True,
     uses_setupos_mainnet_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
+        "//ic-os/setupos:config/node_operator_private_key.pem",
+        "//ic-os/setupos:mainnet-test-img.tar.zst",
+    ],
     deps = RUNNER_DEPENDENCIES,
 )

--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -64,9 +64,7 @@ system_test_nns(
     uses_guestos_img = False,
     uses_guestos_mainnet_img = True,
     uses_setupos_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
-        "//ic-os/setupos:test-img.tar.zst",
-    ],
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS,
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -88,10 +86,7 @@ system_test_nns(
     test_timeout = "eternal",
     uses_guestos_test_update = True,
     uses_setupos_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
-        "//ic-os/guestos/envs/dev:update-img-test.tar.zst",
-        "//ic-os/setupos:test-img.tar.zst",
-    ],
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS,
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -115,10 +110,7 @@ system_test_nns(
     uses_guestos_mainnet_img = True,
     uses_hostos_test_update = True,
     uses_setupos_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
-        "//ic-os/hostos/envs/dev:update-img-test.tar.zst",
-        "//ic-os/setupos:test-img.tar.zst",
-    ],
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS,
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -137,11 +129,7 @@ system_test_nns(
     uses_guestos_mainnet_img = True,
     uses_hostos_update = True,
     uses_setupos_mainnet_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
-        "//ic-os/hostos/envs/dev:update-img.tar.zst",
-        "//ic-os/setupos:config/node_operator_private_key.pem",
-        "//ic-os/setupos:mainnet-test-img.tar.zst",
-    ],
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
     deps = RUNNER_DEPENDENCIES,
 )
 
@@ -162,9 +150,6 @@ system_test_nns(
     uses_guestos_mainnet_img = True,
     uses_hostos_mainnet_update = True,
     uses_setupos_mainnet_img = True,
-    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + [
-        "//ic-os/setupos:config/node_operator_private_key.pem",
-        "//ic-os/setupos:mainnet-test-img.tar.zst",
-    ],
+    runtime_deps = GUESTOS_RUNTIME_DEPS + IC_GATEWAY_RUNTIME_DEPS + VECTOR_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
     deps = RUNNER_DEPENDENCIES,
 )

--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -59,7 +59,6 @@ system_test_nns(
     env = MAINNET_ENV | VECTOR_ENV,
     extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,  # flakiness rate of over 2% over the month from 2025-02-11 till 2025-03-11.
-    tags = ["long_test"],  # since it takes longer than 5 minutes.
     test_timeout = "eternal",
     uses_guestos_img = False,
     uses_guestos_mainnet_img = True,
@@ -81,7 +80,6 @@ system_test_nns(
     env = MAINNET_ENV | VECTOR_ENV,
     extra_head_nns_tags = [],
     flaky = True,
-    tags = ["long_test"],
     test_driver_target = ":guestos_upgrade_test_bin",
     test_timeout = "eternal",
     uses_guestos_test_update = True,
@@ -103,7 +101,6 @@ system_test_nns(
     env = MAINNET_ENV | VECTOR_ENV,
     extra_head_nns_tags = [],
     flaky = True,
-    tags = ["long_test"],
     test_driver_target = ":hostos_upgrade_test_bin",
     test_timeout = "eternal",
     uses_guestos_img = False,
@@ -122,7 +119,6 @@ system_test_nns(
     },
     extra_head_nns_tags = [],
     flaky = True,  # flakiness rate of 5% over the month from 2025-02-11 till 2025-03-11.
-    tags = ["long_test"],
     test_driver_target = ":hostos_upgrade_test_bin",
     test_timeout = "eternal",
     uses_guestos_img = False,


### PR DESCRIPTION
NODE-1643
Fix nested test affected targets so that they run when runtime dependencies change.