### PR TITLE
chore: increase timeouts of subnet_recovery tests to reduce flakiness

### DIFF
--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -55,6 +55,7 @@ system_test_nns(
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
     deps = [
@@ -74,6 +75,7 @@ system_test_nns(
         "long_test",
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
     deps = [
@@ -92,6 +94,7 @@ system_test_nns(
         "long_test",
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
     deps = [
@@ -111,6 +114,7 @@ system_test_nns(
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
     deps = [
@@ -130,6 +134,7 @@ system_test_nns(
         "long_test",
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_img = True,
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
@@ -150,6 +155,7 @@ system_test_nns(
         "long_test",
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_img = True,
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
@@ -170,6 +176,7 @@ system_test_nns(
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
     deps = [
@@ -189,6 +196,7 @@ system_test_nns(
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
     deps = [
@@ -207,6 +215,7 @@ system_test_nns(
         "long_test",
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_img = True,
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
@@ -227,6 +236,7 @@ system_test_nns(
         "long_test",
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_img = True,
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
@@ -268,6 +278,7 @@ system_test_nns(
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     uses_guestos_test_update = True,
     runtime_deps = GUESTOS_RUNTIME_DEPS + MESSAGE_CANISTER_RUNTIME_DEPS + SUBNET_RECOVERY_RUNTIME_DEPS,
     deps = [
@@ -292,6 +303,7 @@ system_test_nns(
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
     ],
+    test_timeout = "eternal",
     runtime_deps =
         GUESTOS_RUNTIME_DEPS +
         MESSAGE_CANISTER_RUNTIME_DEPS +

--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -86,7 +86,7 @@ const APP_NODES_LARGE: usize = 37;
 /// plus 4 to make checkpoint heights more predictable
 const DKG_INTERVAL_LARGE: u64 = 124;
 
-pub const CHAIN_KEY_SUBNET_RECOVERY_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+pub const CHAIN_KEY_SUBNET_RECOVERY_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 /// Setup an IC with the given number of unassigned nodes and
 /// an app subnet with the given number of nodes


### PR DESCRIPTION
A lot of the `//rs/tests/consensus/subnet_recovery:...` tests timeout after 15 minutes causing them to have high flakiness rates (some as high as 25%). So this increases the bazel timeout from `long` (900s) to `eternal` (3600s) and the timeout in the test from 15 to 30 minutes.