### PR TITLE
fix(cmc): Change version to correctly reflect the State version

### DIFF
--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -374,7 +374,7 @@ pub struct StateV2 {
 
 impl StateV2 {
     fn state_version() -> StateVersion {
-        StateVersion(3)
+        StateVersion(2)
     }
 }
 


### PR DESCRIPTION
This is a minor fix that will help future upgrades to be seamless and easy to reason about.  