### PR TITLE
chore: Stop preparing routing table in the old format outside of production

### DIFF
--- a/rs/boundary_node/ic_boundary/src/test_utils.rs
+++ b/rs/boundary_node/ic_boundary/src/test_utils.rs
@@ -24,8 +24,7 @@ use ic_protobuf::registry::{
 use ic_registry_client_fake::FakeRegistryClient;
 use ic_registry_keys::{
     make_canister_ranges_key, make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key,
-    make_node_record_key, make_routing_table_record_key, make_subnet_list_record_key,
-    make_subnet_record_key, ROOT_SUBNET_ID_KEY,
+    make_node_record_key, make_subnet_list_record_key, make_subnet_record_key, ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_registry_routing_table::{CanisterIdRange, RoutingTable as RoutingTableIC};
@@ -241,14 +240,6 @@ pub fn create_fake_registry_client(
             &make_canister_ranges_key(CanisterId::from_u64(0)),
             reg_ver,
             Some(PbRoutingTable::from(routing_table.clone())),
-        )
-        .expect("could not add routing table");
-    // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
-    data_provider
-        .add(
-            &make_routing_table_record_key(),
-            reg_ver,
-            Some(PbRoutingTable::from(routing_table)),
         )
         .expect("could not add routing table");
 

--- a/rs/determinism_test/src/setup.rs
+++ b/rs/determinism_test/src/setup.rs
@@ -12,8 +12,7 @@ use ic_protobuf::types::v1::PrincipalId as PrincipalIdIdProto;
 use ic_protobuf::types::v1::SubnetId as SubnetIdProto;
 use ic_registry_client::client::RegistryClientImpl;
 use ic_registry_keys::{
-    make_canister_ranges_key, make_provisional_whitelist_record_key, make_routing_table_record_key,
-    ROOT_SUBNET_ID_KEY,
+    make_canister_ranges_key, make_provisional_whitelist_record_key, ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -61,14 +60,6 @@ fn get_registry(
             &make_canister_ranges_key(CanisterId::from_u64(0)),
             registry_version,
             Some(pb_routing_table.clone()),
-        )
-        .unwrap();
-    // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
-    data_provider
-        .add(
-            &make_routing_table_record_key(),
-            registry_version,
-            Some(pb_routing_table),
         )
         .unwrap();
     let pb_whitelist = PbProvisionalWhitelist::from(ProvisionalWhitelist::All);

--- a/rs/drun/src/lib.rs
+++ b/rs/drun/src/lib.rs
@@ -22,8 +22,7 @@ use ic_protobuf::types::v1::PrincipalId as PrincipalIdIdProto;
 use ic_protobuf::types::v1::SubnetId as SubnetIdProto;
 use ic_registry_client::client::RegistryClientImpl;
 use ic_registry_keys::{
-    make_canister_ranges_key, make_provisional_whitelist_record_key, make_routing_table_record_key,
-    ROOT_SUBNET_ID_KEY,
+    make_canister_ranges_key, make_provisional_whitelist_record_key, ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -137,14 +136,6 @@ fn get_registry(
             &make_canister_ranges_key(CanisterId::from_u64(0)),
             registry_version,
             Some(pb_routing_table.clone()),
-        )
-        .unwrap();
-    // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
-    data_provider
-        .add(
-            &make_routing_table_record_key(),
-            registry_version,
-            Some(pb_routing_table),
         )
         .unwrap();
     let pb_whitelist = PbProvisionalWhitelist::from(ProvisionalWhitelist::All);

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -19,9 +19,7 @@ use ic_protobuf::registry::{
     node::v1::NodeRecord,
 };
 use ic_registry_client_fake::FakeRegistryClient;
-use ic_registry_keys::{
-    make_canister_ranges_key, make_chain_key_enabled_subnet_list_key, make_routing_table_record_key,
-};
+use ic_registry_keys::{make_canister_ranges_key, make_chain_key_enabled_subnet_list_key};
 use ic_registry_local_registry::LocalRegistry;
 use ic_registry_proto_data_provider::{ProtoRegistryDataProvider, ProtoRegistryDataProviderError};
 use ic_registry_routing_table::{routing_table_insert_subnet, CanisterMigrations, RoutingTable};
@@ -435,11 +433,6 @@ impl RegistryFixture {
 
         self.write_record(
             &make_canister_ranges_key(CanisterId::from_u64(0)),
-            routing_table.map(RoutingTableProto::from),
-        )?;
-        // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
-        self.write_record(
-            &make_routing_table_record_key(),
             routing_table.map(RoutingTableProto::from),
         )
     }

--- a/rs/nns/integration_tests/src/registry_get_changes_since.rs
+++ b/rs/nns/integration_tests/src/registry_get_changes_since.rs
@@ -38,7 +38,7 @@ fn test_allow_opaque_caller() {
     assert_eq!(error, None);
     // The important thing is that deltas is not empty. The exact number of
     // elements is not so important.
-    assert_eq!(deltas.len(), 14);
+    assert_eq!(deltas.len(), 13);
     assert_eq!(version, 1);
 }
 
@@ -70,6 +70,6 @@ fn test_allow_self_authenticating_caller() {
     assert_eq!(error, None);
     // The important thing is that deltas is not empty. The exact number of
     // elements is not so important.
-    assert_eq!(deltas.len(), 14);
+    assert_eq!(deltas.len(), 13);
     assert_eq!(version, 1);
 }

--- a/rs/nns/test_utils/src/registry.rs
+++ b/rs/nns/test_utils/src/registry.rs
@@ -38,8 +38,7 @@ use ic_registry_keys::{
     make_catch_up_package_contents_key, make_crypto_node_key,
     make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key,
     make_data_center_record_key, make_node_operator_record_key, make_node_record_key,
-    make_replica_version_key, make_routing_table_record_key, make_subnet_list_record_key,
-    make_subnet_record_key,
+    make_replica_version_key, make_subnet_list_record_key, make_subnet_record_key,
 };
 use ic_registry_routing_table::{CanisterIdRange, RoutingTable};
 use ic_registry_subnet_type::SubnetType;
@@ -299,19 +298,11 @@ pub fn initial_routing_table_mutations(rt: &RoutingTable) -> Vec<RegistryMutatio
     let rt_pb = pb::RoutingTable::from(rt);
     let mut buf = vec![];
     rt_pb.encode(&mut buf).unwrap();
-    vec![
-        // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
-        RegistryMutation {
-            mutation_type: Type::Upsert as i32,
-            key: make_routing_table_record_key().into_bytes(),
-            value: buf.clone(),
-        },
-        RegistryMutation {
-            mutation_type: Type::Upsert as i32,
-            key: make_canister_ranges_key(CanisterId::from(0)).into_bytes(),
-            value: buf,
-        },
-    ]
+    vec![RegistryMutation {
+        mutation_type: Type::Upsert as i32,
+        key: make_canister_ranges_key(CanisterId::from(0)).into_bytes(),
+        value: buf,
+    }]
 }
 
 /// Returns a mutation that sets the initial state of the registry to be
@@ -665,11 +656,6 @@ pub fn initial_mutations_for_a_multinode_nns_subnet() -> Vec<RegistryMutation> {
         insert(
             make_subnet_record_key(nns_subnet_id).as_bytes(),
             system_subnet.encode_to_vec(),
-        ),
-        // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
-        insert(
-            make_routing_table_record_key().as_bytes(),
-            RoutingTablePB::from(routing_table.clone()).encode_to_vec(),
         ),
         insert(
             make_canister_ranges_key(CanisterId::from_u64(0)).as_bytes(),

--- a/rs/orchestrator/registry_replicator/src/internal_state.rs
+++ b/rs/orchestrator/registry_replicator/src/internal_state.rs
@@ -14,8 +14,8 @@ use ic_registry_client_helpers::{
     subnet::{SubnetRegistry, SubnetTransportRegistry},
 };
 use ic_registry_keys::{
-    make_canister_ranges_key, make_routing_table_record_key, make_subnet_list_record_key,
-    make_subnet_record_key, CANISTER_RANGES_PREFIX, ROOT_SUBNET_ID_KEY,
+    make_canister_ranges_key, make_subnet_list_record_key, make_subnet_record_key,
+    CANISTER_RANGES_PREFIX, ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_local_store::{Changelog, ChangelogEntry, KeyMutation, LocalStore};
 use ic_registry_nns_data_provider::registry::RegistryCanister;
@@ -427,7 +427,6 @@ pub fn apply_switch_over_to_last_changelog_entry_impl(
     last.retain(|k| {
         k.key != ROOT_SUBNET_ID_KEY
             && k.key != make_subnet_list_record_key()
-            && k.key != make_routing_table_record_key()
             && k.key != subnet_record_key
             // Remove all canister_ranges_* records that are not deletion records, since those
             // won't come up in the canister_range_keys due to being deleted.
@@ -498,23 +497,16 @@ pub fn apply_switch_over_to_last_changelog_entry_impl(
         })
         .collect();
 
-    last.push(KeyMutation {
-        key: make_routing_table_record_key(),
-        value: Some(new_routing_table.encode_to_vec()),
-    });
-
     last.append(&mut routing_table_updates);
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use ic_protobuf::registry::routing_table;
-    use ic_protobuf::registry::routing_table::v1::routing_table::Entry;
     use ic_registry_client_fake::FakeRegistryClient;
     use ic_registry_keys::{
-        make_canister_ranges_key, make_routing_table_record_key, make_subnet_list_record_key,
-        make_subnet_record_key, ROOT_SUBNET_ID_KEY,
+        make_canister_ranges_key, make_subnet_list_record_key, make_subnet_record_key,
+        ROOT_SUBNET_ID_KEY,
     };
     use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
     use ic_registry_routing_table::{CanisterIdRange, RoutingTable};
@@ -567,29 +559,6 @@ mod test {
                 Some(old_nns_subnet_id_proto),
             )
             .expect("Failed to set root subnet ID");
-
-        // Set routing table
-        let pb_routing_table = PbRoutingTable::from(
-            RoutingTable::try_from(
-                shards
-                    .values()
-                    .map(|map| {
-                        PbRoutingTable::from(
-                            RoutingTable::try_from(map.clone())
-                                .expect("Invalid routing table shard"),
-                        )
-                    })
-                    .collect::<Vec<_>>(),
-            )
-            .expect("Invalid routing table"),
-        );
-        data_provider
-            .add(
-                &make_routing_table_record_key(),
-                RegistryVersion::from(2),
-                Some(pb_routing_table.clone()),
-            )
-            .expect("Failed to set routing table");
 
         // Add canister range keys
         for (key, shard) in shards {
@@ -677,10 +646,6 @@ mod test {
                     value: Some(vec![2]),
                 },
                 KeyMutation {
-                    key: make_routing_table_record_key(),
-                    value: Some(vec![3]),
-                },
-                KeyMutation {
                     key: make_subnet_record_key(new_nns_subnet_id),
                     value: Some(vec![4]),
                 },
@@ -723,7 +688,6 @@ mod test {
         // Verify all required keys are present
         assert!(keys.contains(&&ROOT_SUBNET_ID_KEY.to_string()));
         assert!(keys.contains(&&make_subnet_list_record_key()));
-        assert!(keys.contains(&&make_routing_table_record_key()));
         assert!(keys.contains(&&make_subnet_record_key(new_nns_subnet_id)));
         assert!(keys.contains(&&make_canister_ranges_key(CanisterId::from_u64(0))));
 
@@ -758,31 +722,6 @@ mod test {
         assert!(!decoded_record.start_as_nns);
         assert_eq!(decoded_record.subnet_type, SubnetType::System as i32);
 
-        // Verify routing table was updated correctly
-        let routing_table_mutation = last_entry
-            .iter()
-            .find(|km| km.key == make_routing_table_record_key())
-            .expect("Routing table mutation should exist");
-
-        assert!(routing_table_mutation.value.is_some());
-
-        let decoded_routing_table =
-            PbRoutingTable::decode(routing_table_mutation.value.as_ref().unwrap().as_slice())
-                .expect("Should decode successfully");
-
-        // The routing table should only contain ranges that were previously assigned to old NNS
-        assert!(!decoded_routing_table.entries.is_empty());
-        let expected_routing_table = PbRoutingTable {
-            entries: vec![Entry {
-                range: Some(routing_table::v1::CanisterIdRange {
-                    start_canister_id: Some(CanisterId::from_u64(0).into()),
-                    end_canister_id: Some(CanisterId::from_u64(50).into()),
-                }),
-                subnet_id: Some(ic_types::subnet_id_into_protobuf(new_nns_subnet_id)),
-            }],
-        };
-        assert_eq!(decoded_routing_table, expected_routing_table);
-
         // Verify canister range key handling
         let canister_0_key = make_canister_ranges_key(CanisterId::from_u64(0));
         let canister_0_mutation = last_entry
@@ -790,7 +729,6 @@ mod test {
             .find(|km| km.key == canister_0_key)
             .expect("Expected mutation for CanisterId = 0");
         assert!(canister_0_mutation.value.is_some());
-        assert_eq!(canister_0_mutation.value, routing_table_mutation.value);
 
         let canister_51_key = make_canister_ranges_key(CanisterId::from_u64(51));
         let canister_51_mutation = last_entry

--- a/rs/prep/src/internet_computer.rs
+++ b/rs/prep/src/internet_computer.rs
@@ -45,9 +45,8 @@ use ic_registry_client::client::RegistryDataProviderError;
 use ic_registry_keys::{
     make_api_boundary_node_record_key, make_blessed_replica_versions_key, make_canister_ranges_key,
     make_data_center_record_key, make_firewall_rules_record_key, make_node_operator_record_key,
-    make_provisional_whitelist_record_key, make_replica_version_key, make_routing_table_record_key,
-    make_subnet_list_record_key, make_unassigned_nodes_config_record_key, FirewallRulesScope,
-    ROOT_SUBNET_ID_KEY,
+    make_provisional_whitelist_record_key, make_replica_version_key, make_subnet_list_record_key,
+    make_unassigned_nodes_config_record_key, FirewallRulesScope, ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_local_store::{Changelog, KeyMutation, LocalStoreImpl, LocalStoreWriter};
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
@@ -600,15 +599,6 @@ impl IcConfig {
             &make_canister_ranges_key(CanisterId::from_u64(0)),
             version,
             routing_table_record.clone(),
-        );
-
-        // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
-        write_registry_entry(
-            &data_provider,
-            self.target_dir.as_path(),
-            &make_routing_table_record_key(),
-            version,
-            routing_table_record,
         );
 
         fn opturl_to_string_vec(opt_url: Option<Url>) -> Vec<String> {

--- a/rs/registry/regedit/src/protobuf.rs
+++ b/rs/registry/regedit/src/protobuf.rs
@@ -19,9 +19,8 @@ use ic_registry_client_helpers::node::NodeRecord;
 use ic_registry_keys::{
     make_blessed_replica_versions_key, make_canister_migrations_record_key,
     make_firewall_config_record_key, make_nns_canister_records_key,
-    make_provisional_whitelist_record_key, make_routing_table_record_key,
-    make_subnet_list_record_key, CANISTER_RANGES_PREFIX, CRYPTO_RECORD_KEY_PREFIX,
-    CRYPTO_THRESHOLD_SIGNING_KEY_PREFIX, CRYPTO_TLS_CERT_KEY_PREFIX,
+    make_provisional_whitelist_record_key, make_subnet_list_record_key, CANISTER_RANGES_PREFIX,
+    CRYPTO_RECORD_KEY_PREFIX, CRYPTO_THRESHOLD_SIGNING_KEY_PREFIX, CRYPTO_TLS_CERT_KEY_PREFIX,
     NODE_OPERATOR_RECORD_KEY_PREFIX, NODE_RECORD_KEY_PREFIX, REPLICA_VERSION_KEY_PREFIX,
     ROOT_SUBNET_ID_KEY, SUBNET_RECORD_KEY_PREFIX,
 };
@@ -91,11 +90,7 @@ fn get_transformer(key: &str) -> Transformers {
         FirewallConfig::transformers()
     } else if key.starts_with(&make_blessed_replica_versions_key()) {
         BlessedReplicaVersions::transformers()
-    } else if key.starts_with(&make_routing_table_record_key()) {
-        // TODO(NNS1-3781): Remove this once the routing table is fully migrated to the new format and
-        // there is no real reason to need to modify routing_table record.
-        RoutingTable::transformers()
-    } else if key.starts_with(CANISTER_RANGES_PREFIX) {
+    } else if key.starts_with(CANISTER_RANGES_PREFIX) || key == "routing_table" {
         RoutingTable::transformers()
     } else if key.starts_with(&make_canister_migrations_record_key()) {
         CanisterMigrations::transformers()

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -91,7 +91,7 @@ use ic_registry_keys::{
     make_canister_ranges_key, make_catch_up_package_contents_key,
     make_chain_key_enabled_subnet_list_key, make_crypto_node_key, make_crypto_tls_cert_key,
     make_node_record_key, make_provisional_whitelist_record_key, make_replica_version_key,
-    make_routing_table_record_key, ROOT_SUBNET_ID_KEY,
+    ROOT_SUBNET_ID_KEY,
 };
 use ic_registry_proto_data_provider::{ProtoRegistryDataProvider, INITIAL_REGISTRY_VERSION};
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -262,14 +262,6 @@ pub fn add_global_registry_records(
             &make_canister_ranges_key(CanisterId::from_u64(0)),
             registry_version,
             Some(pb_routing_table.clone()),
-        )
-        .unwrap();
-    // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
-    registry_data_provider
-        .add(
-            &make_routing_table_record_key(),
-            registry_version,
-            Some(pb_routing_table),
         )
         .unwrap();
 
@@ -4047,14 +4039,6 @@ impl StateMachine {
                 &make_canister_ranges_key(CanisterId::from_u64(0)),
                 next_version,
                 Some(pb_routing_table.clone()),
-            )
-            .unwrap();
-        // TODO(NNS1-3781): Remove this once routing_table is no longer used by clients.
-        self.registry_data_provider
-            .add(
-                &make_routing_table_record_key(),
-                next_version,
-                Some(pb_routing_table),
             )
             .unwrap();
         self.registry_client.update_to_latest_version();


### PR DESCRIPTION
The old routing table format is no longer read by the clients, and it's no longer validated by the registry client in the previous PR (#6034). This PR stops preparing the routing table with the "routing_table" key. This cannot be done at the same time as the previous PR because some tests run by CI uses the mainnet registry canister, so they won't pass until the previous PR gets into the mainnet.

