### PR TITLE
chore: Extract reusable device-related code and add small improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5333,7 +5333,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "askama",
- "async-trait",
  "clap 4.5.27",
  "config",
  "config_types",
@@ -5343,13 +5342,12 @@ dependencies = [
  "gpt",
  "grub",
  "ic-metrics-tool",
+    "ic_device",
  "ic_sev",
- "loopdev-3",
  "macaddr",
  "nix 0.24.3",
  "partition_tools",
  "regex",
- "sys-mount",
  "systemd",
  "tempfile",
  "thiserror 2.0.12",
@@ -15193,6 +15191,23 @@ dependencies = [
  "serde_cbor",
  "slog",
  "tokio",
+]
+
+[[package]]
+name = "ic_device"
+version = "0.1.0"
+dependencies = [
+    "anyhow",
+    "async-trait",
+    "devicemapper",
+    "gpt",
+    "loopdev-3",
+    "nix 0.24.3",
+    "partition_tools",
+    "sys-mount",
+    "tempfile",
+    "tokio",
+    "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ members = [
     "rs/ic_os/config_types",
     "rs/ic_os/config_types/compatibility_tests",
     "rs/ic_os/deterministic_ips",
+    "rs/ic_os/device",
     "rs/ic_os/dev_test_tools/launch-single-vm",
     "rs/ic_os/dev_test_tools/setupos-disable-checks",
     "rs/ic_os/dev_test_tools/setupos-image-config",
@@ -551,6 +552,7 @@ curve25519-dalek = { version = "4.1.3", features = [
 ] }
 der = { version = "0.7", default-features = false }
 derive-new = "0.7.0"
+devicemapper = "0.34"
 dfx-core = { version = "0.1.4" }
 ed25519-dalek = { version = "2.1.1", features = [
     "std",
@@ -636,6 +638,7 @@ libc = "0.2.158"
 libflate = "2.1.0"
 libnss = "0.5.0"
 local-ip-address = "0.5.6"
+loopdev-3 = "0.5"
 macaddr = "1.0"
 memmap2 = "0.9.5"
 minicbor = { version = "0.19.1", features = ["alloc", "derive"] }

--- a/rs/ic_os/device/BUILD.bazel
+++ b/rs/ic_os/device/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//rs/ic_os:__subpackages__"])
+
+DEPENDENCIES = [
+    # Keep sorted.
+    "//rs/ic_os/build_tools/partition_tools",
+    "@crate_index//:anyhow",
+    "@crate_index//:devicemapper",
+    "@crate_index//:gpt",
+    "@crate_index//:loopdev-3",
+    "@crate_index//:nix",
+    "@crate_index//:sys-mount",
+    "@crate_index//:tempfile",
+    "@crate_index//:tokio",
+    "@crate_index//:uuid",
+]
+
+MACRO_DEPENDENCIES = [
+    # Keep sorted.
+    "@crate_index//:async-trait",
+]
+
+DEV_DEPENDENCIES = [
+    # Keep sorted.
+]
+
+rust_library(
+    name = "device",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "ic_device",
+    proc_macro_deps = MACRO_DEPENDENCIES,
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    deps = DEPENDENCIES,
+)
+
+rust_test(
+    name = "device_test",
+    crate = ":device",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    deps = DEV_DEPENDENCIES,
+)

--- a/rs/ic_os/device/Cargo.toml
+++ b/rs/ic_os/device/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ic_device"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+devicemapper = { workspace = true }
+gpt = { workspace = true }
+loopdev-3 = { workspace = true }
+nix = { workspace = true }
+partition_tools = { path = "../build_tools/partition_tools" }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+sys-mount = { workspace = true }

--- a/rs/ic_os/device/src/io.rs
+++ b/rs/ic_os/device/src/io.rs
@@ -1,0 +1,47 @@
+use std::io;
+
+/// Retries a function, returning its result if it succeeds, or retrying if it fails with
+/// ResourceBusy.
+pub fn retry_if_busy<T>(mut f: impl FnMut() -> io::Result<T>) -> io::Result<T> {
+    const MAX_ATTEMPTS: i32 = 10;
+    let mut attempts = MAX_ATTEMPTS;
+    loop {
+        match f() {
+            Ok(res) => return Ok(res),
+            Err(e) => {
+                if e.kind() == io::ErrorKind::ResourceBusy && attempts > 0 {
+                    attempts -= 1;
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_retry_if_busy() {
+        let mut attempts = 0;
+        let result = retry_if_busy(|| {
+            attempts += 1;
+            if attempts < 3 {
+                Err(io::Error::new(io::ErrorKind::ResourceBusy, "busy"))
+            } else {
+                Ok("success")
+            }
+        });
+
+        assert_eq!(result, Ok("success"));
+        assert_eq!(attempts, 3);
+    }
+
+    #[test]
+    fn test_retry_if_busy_failure() {
+        let result = retry_if_busy(|| Err(io::Error::new(io::ErrorKind::Other, "fail")));
+        assert!(result.is_err());
+    }
+}

--- a/rs/ic_os/device/src/lib.rs
+++ b/rs/ic_os/device/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod device_mapping;
+mod io;
+pub mod mount;

--- a/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
+++ b/rs/ic_os/os_tools/guest_vm_runner/BUILD.bazel
@@ -8,6 +8,7 @@ DEPENDENCIES = [
     ":build_script",
     "//rs/ic_os/config_types",
     "//rs/ic_os/deterministic_ips",
+    "//rs/ic_os/device",
     "//rs/ic_os/grub",
     "//rs/ic_os/metrics_tool",
     "//rs/ic_os/sev",
@@ -16,11 +17,9 @@ DEPENDENCIES = [
     "@crate_index//:clap",
     "@crate_index//:devicemapper",
     "@crate_index//:gpt",
-    "@crate_index//:loopdev-3",
     "@crate_index//:macaddr",
     "@crate_index//:nix",
     "@crate_index//:regex",
-    "@crate_index//:sys-mount",
     "@crate_index//:systemd",
     "@crate_index//:tempfile",
     "@crate_index//:thiserror",
@@ -38,9 +37,7 @@ DEV_DEPENDENCIES = [
     "@crate_index//:url",
 ]
 
-MACRO_DEPENDENCIES = [
-    "@crate_index//:async-trait",
-]
+MACRO_DEPENDENCIES = []
 
 cargo_build_script(
     name = "build_script",

--- a/rs/ic_os/os_tools/guest_vm_runner/Cargo.toml
+++ b/rs/ic_os/os_tools/guest_vm_runner/Cargo.toml
@@ -10,17 +10,16 @@ path = "src/main.rs"
 config = { path = "../../config" }
 config_types = { path = "../../config_types" }
 deterministic_ips = { path = "../../deterministic_ips" }
+ic_device = { path = "../../device" }
 grub = { path = "../../grub" }
 ic-metrics-tool = { path = "../../metrics_tool" }
 ic_sev = { path = "../../sev" }
 
 anyhow = { workspace = true }
 askama = { workspace = true }
-async-trait = { workspace = true }
 clap = { workspace = true }
 devicemapper = "0.34"
 gpt = { workspace = true }
-loopdev-3 = "0.5"
 macaddr = { workspace = true }
 nix = { workspace = true }
 regex = { workspace = true }
@@ -32,7 +31,6 @@ uuid = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 systemd = { workspace = true }
-sys-mount = { workspace = true }
 virt = { workspace = true }
 
 [features]

--- a/rs/ic_os/os_tools/guest_vm_runner/src/guest_direct_boot.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/guest_direct_boot.rs
@@ -1,10 +1,10 @@
 use crate::boot_args::read_boot_args;
 use crate::guest_vm_config::DirectBootConfig;
-use crate::mount::{FileSystem, MountOptions, PartitionProvider};
 use crate::GuestVMType;
 use anyhow::Context;
 use anyhow::Result;
 use grub::{BootAlternative, BootCycle, GrubEnv, WithDefault};
+use ic_device::mount::{FileSystem, MountOptions, PartitionProvider};
 use std::fs::File;
 use tempfile::NamedTempFile;
 use uuid::Uuid;
@@ -206,8 +206,8 @@ fn refresh_grubenv(grub_env: &mut GrubEnv) -> Result<bool> {
 #[cfg(all(test, not(feature = "skip_default_tests")))]
 mod tests {
     use super::*;
-    use crate::mount::testing::MockPartitionProvider;
     use grub::GrubEnvVariableError;
+    use ic_device::mount::testing::MockPartitionProvider;
     use std::collections::HashMap;
     use std::fs;
     use std::io::Write;

--- a/rs/ic_os/os_tools/guest_vm_runner/src/upgrade_device_mapper.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/upgrade_device_mapper.rs
@@ -1,6 +1,6 @@
-use crate::device_mapping::{BaseDevice, LinearSegment, MappedDevice, TempDevice};
 use anyhow::{bail, ensure, Context, Result};
 use devicemapper::{Bytes, DevId, DmName, DmOptions, Sectors, DM};
+use ic_device::device_mapping::{BaseDevice, LinearSegment, MappedDevice, TempDevice};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -153,9 +153,8 @@ fn try_remove_device(dev_mapper: &DM, name: &DmName) {
 #[cfg(all(test, feature = "upgrade_device_mapper_test"))]
 mod tests {
     use super::*;
-    use crate::device_mapping::LoopDeviceWrapper;
     use gpt::{GptConfig, GptDisk};
-    use loopdev::LoopControl;
+    use ic_device::device_mapping::LoopDeviceWrapper;
     use std::fs::File;
     use std::os::unix::fs::FileExt;
     use std::path::PathBuf;
@@ -183,15 +182,7 @@ mod tests {
 
         let backing_file = backing_file.into_temp_path();
 
-        let loop_device = LoopDeviceWrapper(
-            LoopControl::open()
-                .expect("Failed to open loop control")
-                .next_free()
-                .expect("Failed to find free loop device"),
-        );
-        loop_device
-            .attach_file(&backing_file)
-            .expect("Failed to attach file to loop device");
+        let loop_device = LoopDeviceWrapper::attach_to_next_free(&backing_file).unwrap();
         let loop_device_path = loop_device.path().expect("Failed to get loop device path");
 
         let mut gpt = GptConfig::new()
@@ -225,6 +216,19 @@ mod tests {
             .expect("Failed to read /dev/mapper")
             .map(|entry| entry.unwrap().path())
             .collect()
+    }
+
+    fn assert_mapped_devices_are_cleaned_up() {
+        let mapped_devices = get_mapped_devices();
+        for device in ALL_DM_NAMES_IN_CLEANUP_ORDER {
+            assert!(
+                !mapped_devices
+                    .iter()
+                    .any(|p| p.file_name() == Some(device.as_ref())),
+                "Device {} should be cleaned up",
+                device
+            );
+        }
     }
 
     /// Tests the creation of a mapped device for the upgrade VM.
@@ -293,8 +297,7 @@ mod tests {
             "Device file should be removed after drop"
         );
 
-        // Verify that the device mapper entries are cleaned up
-        assert_eq!(mapped_devices_before, get_mapped_devices());
+        assert_mapped_devices_are_cleaned_up();
     }
 
     #[test]
@@ -326,10 +329,7 @@ mod tests {
             !device_path.exists(),
             "Previous device should be cleaned up"
         );
-        assert_eq!(
-            mapped_devices_before,
-            get_mapped_devices(),
-            "Device mapper entries should be cleaned up"
-        );
+
+        assert_mapped_devices_are_cleaned_up();
     }
 }


### PR DESCRIPTION
There was quite a bit of code related to devices in guest_vm_runner that would be useful in other codepaths so this PR extracts the code out to a separate crate.

I've also found that when we attach a disk image to a loop device, there is a race condition since finding a free loop device and attaching the image is not atomic. This PR adds a fix.