### PR TITLE
test(node): fix guestos_recovery_engine_smoke_test permission checking

### DIFF
--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
@@ -78,12 +78,10 @@ echo "Extracting recovery artifact..."
 tar zxf "recovery.tar.zst"
 
 echo "Preparing recovery artifacts..."
-OWNER_UID=$(sudo stat -c '%u' /var/lib/ic/data/ic_registry_local_store)
-GROUP_UID=$(sudo stat -c '%g' /var/lib/ic/data/ic_registry_local_store)
+TARGET_PERMS=$(sudo stat -c '%a' /var/lib/ic/data/ic_registry_local_store)
 
 mkdir ic_registry_local_store
 tar zxf "ic_registry_local_store.tar.zst" -C ic_registry_local_store
-sudo chown -R "$OWNER_UID:$GROUP_UID" ic_registry_local_store
 
 OWNER_UID=$(sudo stat -c '%u' /var/lib/ic/data/cups)
 GROUP_UID=$(sudo stat -c '%g' /var/lib/ic/data/cups)
@@ -92,6 +90,7 @@ sudo chown -R "$OWNER_UID:$GROUP_UID" "cup.proto"
 echo "Applying recovery artifacts..."
 echo "Syncing ic_registry_local_store to target location..."
 sudo rsync -a --delete ic_registry_local_store/ /var/lib/ic/data/ic_registry_local_store/
+sudo chmod "$TARGET_PERMS" /var/lib/ic/data/ic_registry_local_store
 echo "Copying cup.proto to target location..."
 sudo cp "cup.proto" /var/lib/ic/data/cups/cup.types.v1.CatchUpPackage.pb
 

--- a/rs/tests/consensus/guestos_recovery_engine_smoke_test.rs
+++ b/rs/tests/consensus/guestos_recovery_engine_smoke_test.rs
@@ -315,18 +315,36 @@ pub fn test(env: TestEnv) {
     // Verify permissions
     //
 
-    verify_permissions_recursively(
-        &ssh_session,
-        "/var/lib/ic/data/cups",
-        "ic-replica",
-        "nonconfidential",
+    // We retry multiple times because setup-permissions service might still be running
+    retry_with_msg!(
+        "verify cups permissions",
+        log.clone(),
+        secs(30),
+        secs(5),
+        || {
+            verify_permissions_recursively(
+                &ssh_session,
+                "/var/lib/ic/data/cups",
+                "ic-replica",
+                "nonconfidential",
+            )
+        }
     )
     .unwrap();
-    verify_permissions_recursively(
-        &ssh_session,
-        "/var/lib/ic/data/ic_registry_local_store",
-        "ic-replica",
-        "ic-registry-local-store",
+
+    retry_with_msg!(
+        "verify ic_registry_local_store permissions",
+        log.clone(),
+        secs(30),
+        secs(5),
+        || {
+            verify_permissions_recursively(
+                &ssh_session,
+                "/var/lib/ic/data/ic_registry_local_store",
+                "ic-replica",
+                "ic-registry-local-store",
+            )
+        }
     )
     .unwrap();
 }

--- a/rs/tests/consensus/guestos_recovery_engine_smoke_test.rs
+++ b/rs/tests/consensus/guestos_recovery_engine_smoke_test.rs
@@ -315,36 +315,18 @@ pub fn test(env: TestEnv) {
     // Verify permissions
     //
 
-    // We retry multiple times because setup-permissions service might still be running
-    retry_with_msg!(
-        "verify cups permissions",
-        log.clone(),
-        secs(30),
-        secs(5),
-        || {
-            verify_permissions_recursively(
-                &ssh_session,
-                "/var/lib/ic/data/cups",
-                "ic-replica",
-                "nonconfidential",
-            )
-        }
+    verify_permissions_recursively(
+        &ssh_session,
+        "/var/lib/ic/data/cups",
+        "ic-replica",
+        "nonconfidential",
     )
     .unwrap();
-
-    retry_with_msg!(
-        "verify ic_registry_local_store permissions",
-        log.clone(),
-        secs(30),
-        secs(5),
-        || {
-            verify_permissions_recursively(
-                &ssh_session,
-                "/var/lib/ic/data/ic_registry_local_store",
-                "ic-replica",
-                "ic-registry-local-store",
-            )
-        }
+    verify_permissions_recursively(
+        &ssh_session,
+        "/var/lib/ic/data/ic_registry_local_store",
+        "ic-replica",
+        "ic-registry-local-store",
     )
     .unwrap();
 }


### PR DESCRIPTION
Fixes race condition in guestos-recovery-engine permission handling

**Problem**: The recovery engine was intermittently setting incorrect permissions 
on the `ic_registry_local_store` directory, causing the smoke test to fail with 
"Unexpected permissions: drwxr-xr-x. Expected: drwxr-s---"

**Root Cause**: The script captured only owner/group UIDs but not the full permission 
bits (including setgid). When creating the temporary directory:
1. `mkdir` created directory with default permissions (755 = drwxr-xr-x)  
2. `chown` set ownership but didn't preserve the setgid bit
3. `rsync -a` copied these incorrect permissions to the target
4. `setup-permissions` eventually fixed it, creating a timing window for test failures

**Fix**: Capture the target directory permissions before rsync, then restore them immediately after rsync to eliminate the timing window.