### PR TITLE
chore: deflake //rs/tests/message_routing/xnet:xnet_malicious_slices

### DIFF
--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -87,9 +87,6 @@ system_test(
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
     malicious = True,
-    tags = [
-        "system_test_large",
-    ],
     test_timeout = "long",
     runtime_deps = GRAFANA_RUNTIME_DEPS + XNET_TEST_CANISTER_RUNTIME_DEPS,
     deps = [


### PR DESCRIPTION
The 7.6% flaky `//rs/tests/message_routing/xnet:xnet_malicious_slices` was timing out frequently in its `setup` task since it lowered the default 10 minute task timeout to 5 minutes.

So this commit:

* Removes the explicit task timeout settings and relies on the 10 minute defaults.
* Starts the PrometheusVM and IC concurrently to save time.
* Runs this tests pre-master since there's no reason to only run this nightly (it's short and doesn't consume much resources).