### PR TITLE
fix(sns): Ensure governance cached metrics are recomputed once per hour

### DIFF
--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -5372,6 +5372,8 @@ impl Governance {
 
         let mut metrics = self.proto.metrics.clone().unwrap_or_default();
 
+        metrics.timestamp_seconds = now_seconds;
+
         let mut treasury_metrics = vec![];
 
         for TreasuryMetrics {

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -21,4 +21,7 @@ these proposals on mainnet is still disabled until further notice.
 
 ## Fixed
 
+Fixed a bug due to which governance cached metrics could be recomputed once every 10 seconds
+rather than with the intended rate of once per hour.
+
 ## Security


### PR DESCRIPTION
This PR fixes a bug due to which governance cached metrics could be recomputed once every 10 seconds rather than with the intended rate of once per hour.