### PR TITLE
chore: Cleanup `HasIcDependencies` trait

### DIFF
--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -18,7 +18,7 @@ use crate::{
             get_guestos_initial_update_img_sha256, get_guestos_initial_update_img_url,
             get_malicious_ic_os_update_img_sha256, get_malicious_ic_os_update_img_url,
             get_setupos_img_sha256, get_setupos_img_url, HasTopologySnapshot, HasVmName,
-            IcNodeContainer, InitialReplicaVersion, NodesInfo,
+            IcNodeContainer, NodesInfo,
         },
         test_setup::InfraProvider,
     },
@@ -98,10 +98,6 @@ pub fn init_ic(
 
     let replica_version = get_guestos_img_version()?;
     let replica_version = ReplicaVersion::try_from(replica_version.clone())?;
-    let initial_replica_version = InitialReplicaVersion {
-        version: replica_version.clone(),
-    };
-    initial_replica_version.write_attribute(test_env);
     info!(
         logger,
         "Replica Version that is passed is: {:?}", &replica_version

--- a/rs/tests/driver/src/driver/farm.rs
+++ b/rs/tests/driver/src/driver/farm.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::driver::ic::{AmountOfMemoryKiB, NrOfVCPUs, VmAllocationStrategy};
 use crate::driver::log_events;
 use crate::driver::test_env::{RequiredHostFeaturesFromCmdLine, TestEnvAttribute};
-use crate::driver::test_env_api::{read_dependency_to_string, HasIcDependencies};
+use crate::driver::test_env_api::{read_dependency_to_string, HasFarmUrl};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use ic_crypto_sha2::Sha256;

--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -4,7 +4,7 @@ use crate::driver::{
     farm::{Farm, HostFeature},
     resource::AllocatedVm,
     task_scheduler::TaskScheduler,
-    test_env_api::{FarmBaseUrl, HasGroupSetup, HasIcDependencies},
+    test_env_api::{FarmBaseUrl, HasFarmUrl, HasGroupSetup},
     universal_vm::UNIVERSAL_VMS_DIR,
     {
         action_graph::ActionGraph,

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -184,7 +184,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_types::{
     malicious_behaviour::MaliciousBehaviour,
     messages::{HttpStatusResponse, ReplicaHealthStatus},
-    NodeId, RegistryVersion, ReplicaVersion, SubnetId,
+    NodeId, RegistryVersion, SubnetId,
 };
 use ic_utils::interfaces::ManagementCanister;
 use icp_ledger::{AccountIdentifier, LedgerCanisterInitPayload, Tokens};
@@ -1138,22 +1138,16 @@ impl HasRegistryLocalStore for TestEnv {
     }
 }
 
-pub trait HasIcDependencies {
+pub trait HasFarmUrl {
     fn get_farm_url(&self) -> Result<Url>;
-    fn get_initial_replica_version(&self) -> Result<ReplicaVersion>;
 }
 
-impl<T: HasTestEnv> HasIcDependencies for T {
+impl<T: HasTestEnv> HasFarmUrl for T {
     fn get_farm_url(&self) -> Result<Url> {
         let dep_rel_path = "farm_base_url";
         let url = read_dependency_to_string(dep_rel_path)
             .unwrap_or_else(|_| FarmBaseUrl::read_attribute(&self.test_env()).to_string());
         Ok(Url::parse(&url)?)
-    }
-
-    fn get_initial_replica_version(&self) -> Result<ReplicaVersion> {
-        let initial_replica_version = InitialReplicaVersion::read_attribute(&self.test_env());
-        Ok(initial_replica_version.version)
     }
 }
 
@@ -2507,17 +2501,6 @@ impl From<FarmBaseUrl> for Url {
 impl TestEnvAttribute for FarmBaseUrl {
     fn attribute_name() -> String {
         "farm_url".to_string()
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct InitialReplicaVersion {
-    pub version: ReplicaVersion,
-}
-
-impl TestEnvAttribute for InitialReplicaVersion {
-    fn attribute_name() -> String {
-        "initial_replica_version".to_string()
     }
 }
 


### PR DESCRIPTION
Replace `get_initial_replica_version` with `get_guestos_img_version` (this was the underlying impl anyway), and rename the trait now that `get_farm_url` is the only use.