### PR TITLE
feat(sns): Add API for executing extension operations

### DIFF
--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -13,6 +13,7 @@ type Action = variant {
   AdvanceSnsTargetVersion : AdvanceSnsTargetVersion;
   RegisterDappCanisters : RegisterDappCanisters;
   RegisterExtension : RegisterExtension;
+  ExecuteExtensionOperation : ExecuteExtensionOperation;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
   DeregisterDappCanisters : DeregisterDappCanisters;
@@ -744,6 +745,18 @@ type RegisterExtension = record {
   chunked_canister_wasm : opt ChunkedCanisterWasm;
 
   extension_init : opt ExtensionInit;
+};
+
+type ExtensionOperationArg = record {
+  value : opt PreciseValue;
+};
+
+type ExecuteExtensionOperation = record {
+  extension_canister_id : opt principal;
+
+  operation_name : opt text;
+
+  operation_arg : opt ExtensionOperationArg;
 };
 
 type RegisterVote = record {

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -13,6 +13,7 @@ type Action = variant {
   AdvanceSnsTargetVersion : AdvanceSnsTargetVersion;
   RegisterDappCanisters : RegisterDappCanisters;
   RegisterExtension : RegisterExtension;
+  ExecuteExtensionOperation : ExecuteExtensionOperation;
   TransferSnsTreasuryFunds : TransferSnsTreasuryFunds;
   UpgradeSnsControlledCanister : UpgradeSnsControlledCanister;
   DeregisterDappCanisters : DeregisterDappCanisters;
@@ -758,6 +759,18 @@ type RegisterExtension = record {
   chunked_canister_wasm : opt ChunkedCanisterWasm;
 
   extension_init : opt ExtensionInit;
+};
+
+type ExtensionOperationArg = record {
+  value : opt PreciseValue;
+};
+
+type ExecuteExtensionOperation = record {
+  extension_canister_id : opt principal;
+
+  operation_name : opt text;
+
+  operation_arg : opt ExtensionOperationArg;
 };
 
 type RegisterVote = record {

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -473,6 +473,18 @@ message RegisterExtension {
   optional ExtensionInit extension_init = 2;
 }
 
+message ExtensionOperationArg {
+  optional Precise value = 1;
+}
+
+message ExecuteExtensionOperation {
+  optional ic_base_types.pb.v1.PrincipalId extension_canister_id = 1;
+
+  optional string operation_name = 2;
+
+  optional ExtensionOperationArg operation_arg = 3;
+}
+
 // A proposal to remove a list of dapps from the SNS and assign them to new controllers
 message DeregisterDappCanisters {
   // The canister IDs to be deregistered (i.e. removed from the management of the SNS).
@@ -664,6 +676,11 @@ message Proposal {
     //
     // Id = 17.
     RegisterExtension register_extension = 21;
+
+    // Execute an SNS extension's operation.
+    //
+    // Id = 18.
+    ExecuteExtensionOperation execute_extension_operation = 22;
   }
 }
 
@@ -863,6 +880,8 @@ message ProposalData {
   // Id 14 - ManageDappCanisterSettings proposals.
   // Id 15 - AdvanceSnsTargetVersion proposals.
   // Id 16 - SetTopicsForCustomProposals proposals.
+  // Id 17 - RegisterExtension.
+  // Id 18 - ExecuteExtensionOperation.
   uint64 action = 1;
 
   // This is stored here temporarily. It is also stored on the map

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -733,6 +733,34 @@ pub struct RegisterExtension {
     #[prost(message, optional, tag = "2")]
     pub extension_init: ::core::option::Option<ExtensionInit>,
 }
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ExtensionOperationArg {
+    #[prost(message, optional, tag = "1")]
+    pub value: ::core::option::Option<Precise>,
+}
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ExecuteExtensionOperation {
+    #[prost(message, optional, tag = "1")]
+    pub extension_canister_id: ::core::option::Option<::ic_base_types::PrincipalId>,
+    #[prost(string, optional, tag = "2")]
+    pub operation_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "3")]
+    pub operation_arg: ::core::option::Option<ExtensionOperationArg>,
+}
 /// A proposal to remove a list of dapps from the SNS and assign them to new controllers
 #[derive(
     candid::CandidType,
@@ -865,7 +893,7 @@ pub struct Proposal {
     /// of this mapping.
     #[prost(
         oneof = "proposal::Action",
-        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21"
+        tags = "4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22"
     )]
     pub action: ::core::option::Option<proposal::Action>,
 }
@@ -985,6 +1013,11 @@ pub mod proposal {
         /// Id = 17.
         #[prost(message, tag = "21")]
         RegisterExtension(super::RegisterExtension),
+        /// Execute an SNS extension's operation.
+        ///
+        /// Id = 18.
+        #[prost(message, tag = "22")]
+        ExecuteExtensionOperation(super::ExecuteExtensionOperation),
     }
 }
 #[derive(candid::CandidType, candid::Deserialize, comparable::Comparable)]
@@ -1232,6 +1265,8 @@ pub struct ProposalData {
     /// Id 14 - ManageDappCanisterSettings proposals.
     /// Id 15 - AdvanceSnsTargetVersion proposals.
     /// Id 16 - SetTopicsForCustomProposals proposals.
+    /// Id 17 - RegisterExtension.
+    /// Id 18 - ExecuteExtensionOperation.
     #[prost(uint64, tag = "1")]
     pub action: u64,
     /// This is stored here temporarily. It is also stored on the map

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -3515,6 +3515,7 @@ impl Governance {
         let now_seconds = self.env.now();
 
         // Validate proposal
+        // TODO: return the optional extension spec
         let (rendering, action_auxiliary) = self.validate_and_render_proposal(proposal).await?;
 
         let nervous_system_parameters = self.nervous_system_parameters_or_panic();

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -2,7 +2,10 @@ use crate::extensions::{ExtensionKind, ValidatedRegisterExtension};
 use crate::icrc_ledger_helper::ICRCLedgerHelper;
 use crate::pb::sns_root_types::{register_extension_response, CanisterCallError};
 use crate::pb::v1::governance::GovernanceCachedMetrics;
-use crate::pb::v1::{valuation, Metrics, RegisterExtension, TreasuryMetrics, VotingPowerMetrics};
+use crate::pb::v1::{
+    valuation, ExecuteExtensionOperation, Metrics, RegisterExtension, TreasuryMetrics,
+    VotingPowerMetrics,
+};
 use crate::proposal::TreasuryAccount;
 use crate::treasury::{assess_treasury_balance, interpret_token_code, tokens_to_e8s};
 use crate::{
@@ -2146,6 +2149,10 @@ impl Governance {
                 self.perform_execute_generic_nervous_system_function(call)
                     .await
             }
+            Action::ExecuteExtensionOperation(execute_extension_operation) => {
+                self.perform_execute_extension_operation(execute_extension_operation)
+                    .await
+            }
             Action::AddGenericNervousSystemFunction(nervous_system_function) => {
                 self.perform_add_generic_nervous_system_function(nervous_system_function)
             }
@@ -2592,6 +2599,16 @@ impl Governance {
                 .await
             }
         }
+    }
+
+    async fn perform_execute_extension_operation(
+        &self,
+        _execute_extension_operation: ExecuteExtensionOperation,
+    ) -> Result<(), GovernanceError> {
+        Err(GovernanceError::new_with_message(
+            ErrorType::InvalidCommand,
+            "ExecuteExtensionOperation is not supported yet.",
+        ))
     }
 
     /// Executes a ManageNervousSystemParameters proposal by updating Governance's

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -4917,6 +4917,19 @@ fn test_list_topics() {
                             ),
                         ),
                     },
+                    NervousSystemFunction {
+                        id: 18,
+                        name: "Execute SNS extension operation".to_string(),
+                        description: Some(
+                            "Proposal to execute an operation on a registered SNS extension."
+                                .to_string(),
+                        ),
+                        function_type: Some(
+                            FunctionType::NativeNervousSystemFunction(
+                                Empty {},
+                            ),
+                        ),
+                    },
                 ],
                 custom_functions: vec![],
             },

--- a/rs/sns/governance/src/governance/proposal_topics_tests.rs
+++ b/rs/sns/governance/src/governance/proposal_topics_tests.rs
@@ -185,6 +185,14 @@ fn test_all_topics() {
                 ProposalCriticality::Critical,
             )),
         ),
+        // TODO[NNS1-4002]. Criticality should depends on the topic of the extension.
+        (
+            pb::proposal::Action::ExecuteExtensionOperation(Default::default()),
+            Ok((
+                Some(pb::Topic::TreasuryAssetManagement),
+                ProposalCriticality::Critical,
+            )),
+        ),
     ];
 
     // Smoke test

--- a/rs/sns/governance/src/governance/proposal_topics_tests.rs
+++ b/rs/sns/governance/src/governance/proposal_topics_tests.rs
@@ -185,7 +185,7 @@ fn test_all_topics() {
                 ProposalCriticality::Critical,
             )),
         ),
-        // TODO[NNS1-4002]. Criticality should depends on the topic of the extension.
+        // TODO[NNS1-4002]. Criticality should depend on the topic of the extension.
         (
             pb::proposal::Action::ExecuteExtensionOperation(Default::default()),
             Ok((

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -702,6 +702,62 @@ impl From<pb_api::RegisterExtension> for pb::RegisterExtension {
     }
 }
 
+impl From<pb::ExtensionOperationArg> for pb_api::ExtensionOperationArg {
+    fn from(item: pb::ExtensionOperationArg) -> Self {
+        let pb::ExtensionOperationArg { value } = item;
+
+        let value = value.and_then(|pb::Precise { value }| value.map(pb_api::PreciseValue::from));
+
+        Self { value }
+    }
+}
+
+impl From<pb_api::ExtensionOperationArg> for pb::ExtensionOperationArg {
+    fn from(item: pb_api::ExtensionOperationArg) -> Self {
+        let pb_api::ExtensionOperationArg { value } = item;
+
+        let value = value.map(pb::Precise::from);
+
+        Self { value }
+    }
+}
+
+impl From<pb::ExecuteExtensionOperation> for pb_api::ExecuteExtensionOperation {
+    fn from(item: pb::ExecuteExtensionOperation) -> Self {
+        let pb::ExecuteExtensionOperation {
+            extension_canister_id,
+            operation_name,
+            operation_arg,
+        } = item;
+
+        let operation_arg = operation_arg.map(pb_api::ExtensionOperationArg::from);
+
+        Self {
+            extension_canister_id,
+            operation_name,
+            operation_arg,
+        }
+    }
+}
+
+impl From<pb_api::ExecuteExtensionOperation> for pb::ExecuteExtensionOperation {
+    fn from(item: pb_api::ExecuteExtensionOperation) -> Self {
+        let pb_api::ExecuteExtensionOperation {
+            extension_canister_id,
+            operation_name,
+            operation_arg,
+        } = item;
+
+        let operation_arg = operation_arg.map(pb::ExtensionOperationArg::from);
+
+        Self {
+            extension_canister_id,
+            operation_name,
+            operation_arg,
+        }
+    }
+}
+
 impl From<pb::DeregisterDappCanisters> for pb_api::DeregisterDappCanisters {
     fn from(item: pb::DeregisterDappCanisters) -> Self {
         Self {
@@ -859,6 +915,9 @@ impl From<pb::proposal::Action> for pb_api::proposal::Action {
             pb::proposal::Action::ExecuteGenericNervousSystemFunction(v) => {
                 pb_api::proposal::Action::ExecuteGenericNervousSystemFunction(v.into())
             }
+            pb::proposal::Action::ExecuteExtensionOperation(v) => {
+                pb_api::proposal::Action::ExecuteExtensionOperation(v.into())
+            }
             pb::proposal::Action::UpgradeSnsToNextVersion(v) => {
                 pb_api::proposal::Action::UpgradeSnsToNextVersion(v.into())
             }
@@ -914,6 +973,9 @@ impl From<pb_api::proposal::Action> for pb::proposal::Action {
             }
             pb_api::proposal::Action::ExecuteGenericNervousSystemFunction(v) => {
                 pb::proposal::Action::ExecuteGenericNervousSystemFunction(v.into())
+            }
+            pb_api::proposal::Action::ExecuteExtensionOperation(v) => {
+                pb::proposal::Action::ExecuteExtensionOperation(v.into())
             }
             pb_api::proposal::Action::UpgradeSnsToNextVersion(v) => {
                 pb::proposal::Action::UpgradeSnsToNextVersion(v.into())

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1,7 +1,8 @@
 use crate::cached_upgrade_steps::render_two_versions_as_markdown_table;
 use crate::extensions::validate_extension_wasm;
 use crate::pb::v1::{
-    AdvanceSnsTargetVersion, RegisterExtension, SetTopicsForCustomProposals, Topic,
+    AdvanceSnsTargetVersion, ExecuteExtensionOperation, RegisterExtension,
+    SetTopicsForCustomProposals, Topic,
 };
 use crate::treasury::assess_treasury_balance;
 use crate::types::Wasm;
@@ -445,6 +446,9 @@ pub(crate) async fn validate_and_render_action(
         proposal::Action::ExecuteGenericNervousSystemFunction(execute) => {
             validate_and_render_execute_nervous_system_function(env, execute, existing_functions)
                 .await
+        }
+        proposal::Action::ExecuteExtensionOperation(execute_extension_operation) => {
+            validate_and_render_execute_extension_operation(env, execute_extension_operation).await
         }
         proposal::Action::RegisterDappCanisters(register_dapp_canisters) => {
             validate_and_render_register_dapp_canisters(
@@ -1499,6 +1503,13 @@ pub async fn validate_and_render_execute_nervous_system_function(
             }
         }
     }
+}
+
+async fn validate_and_render_execute_extension_operation(
+    _env: &dyn Environment,
+    _execute_extension_operation: &ExecuteExtensionOperation,
+) -> Result<String, String> {
+    Err("ExecuteExtensionOperation is not supported yet.".to_string())
 }
 
 async fn validate_and_render_register_extension(

--- a/rs/sns/governance/src/topics.rs
+++ b/rs/sns/governance/src/topics.rs
@@ -48,10 +48,10 @@ pub struct ListTopicsResponse {
 pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
     use crate::types::native_action_ids::{
         ADD_GENERIC_NERVOUS_SYSTEM_FUNCTION, ADVANCE_SNS_TARGET_VERSION, DEREGISTER_DAPP_CANISTERS,
-        MANAGE_DAPP_CANISTER_SETTINGS, MANAGE_LEDGER_PARAMETERS, MANAGE_NERVOUS_SYSTEM_PARAMETERS,
-        MANAGE_SNS_METADATA, MINT_SNS_TOKENS, MOTION, REGISTER_DAPP_CANISTERS, REGISTER_EXTENSION,
-        REMOVE_GENERIC_NERVOUS_SYSTEM_FUNCTION, TRANSFER_SNS_TREASURY_FUNDS,
-        UPGRADE_SNS_CONTROLLED_CANISTER, UPGRADE_SNS_TO_NEXT_VERSION,
+        EXECUTE_EXTENSION_OPERATION, MANAGE_DAPP_CANISTER_SETTINGS, MANAGE_LEDGER_PARAMETERS,
+        MANAGE_NERVOUS_SYSTEM_PARAMETERS, MANAGE_SNS_METADATA, MINT_SNS_TOKENS, MOTION,
+        REGISTER_DAPP_CANISTERS, REGISTER_EXTENSION, REMOVE_GENERIC_NERVOUS_SYSTEM_FUNCTION,
+        TRANSFER_SNS_TREASURY_FUNDS, UPGRADE_SNS_CONTROLLED_CANISTER, UPGRADE_SNS_TO_NEXT_VERSION,
     };
 
     [
@@ -119,6 +119,8 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
                 native_functions: vec![
                     TRANSFER_SNS_TREASURY_FUNDS,
                     MINT_SNS_TOKENS,
+                    // TODO[NNS1-4002]. Support extensions in different topics.
+                    EXECUTE_EXTENSION_OPERATION,
                 ],
             },
             is_critical: true,
@@ -371,6 +373,12 @@ impl pb::Topic {
     }
 
     pub fn get_topic_for_native_action(action: &pb::proposal::Action) -> Option<Self> {
+        // Check if the action is to execute an extension operation.
+        // TODO[NNS1-4002]. Topic should depend on the topic of the extension that is being called.
+        if let pb::proposal::Action::ExecuteExtensionOperation(_) = action {
+            return Some(pb::Topic::TreasuryAssetManagement);
+        }
+
         // Check if the topic comes from the extension spec.
         if let pb::proposal::Action::RegisterExtension(pb::RegisterExtension {
             chunked_canister_wasm:

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -140,6 +140,9 @@ pub mod native_action_ids {
     /// RegisterExtension Action.
     pub const REGISTER_EXTENSION: u64 = 17;
 
+    /// ExecuteExtensionOperation Action.
+    pub const EXECUTE_EXTENSION_OPERATION: u64 = 18;
+
     // When adding something to this list, make sure to update the below function.
     pub fn nervous_system_functions() -> Vec<NervousSystemFunction> {
         vec![
@@ -160,6 +163,7 @@ pub mod native_action_ids {
             NervousSystemFunction::advance_sns_target_version(),
             NervousSystemFunction::set_topics_for_custom_proposals(),
             NervousSystemFunction::register_extension(),
+            NervousSystemFunction::execute_extension_operation(),
         ]
     }
 }
@@ -1155,6 +1159,17 @@ impl NervousSystemFunction {
         }
     }
 
+    fn execute_extension_operation() -> NervousSystemFunction {
+        NervousSystemFunction {
+            id: native_action_ids::EXECUTE_EXTENSION_OPERATION,
+            name: "Execute SNS extension operation".to_string(),
+            description: Some(
+                "Proposal to execute an operation on a registered SNS extension.".to_string(),
+            ),
+            function_type: Some(FunctionType::NativeNervousSystemFunction(Empty {})),
+        }
+    }
+
     fn upgrade_sns_to_next_version() -> NervousSystemFunction {
         NervousSystemFunction {
             id: native_action_ids::UPGRADE_SNS_TO_NEXT_VERSION,
@@ -1287,6 +1302,10 @@ impl From<Action> for NervousSystemFunction {
 
             Action::ExecuteGenericNervousSystemFunction(_) => {
                 NervousSystemFunction::execute_generic_nervous_system_function()
+            }
+
+            Action::ExecuteExtensionOperation(_) => {
+                NervousSystemFunction::execute_extension_operation()
             }
 
             Action::UpgradeSnsToNextVersion(_) => {
@@ -1882,6 +1901,7 @@ impl From<&Action> for u64 {
                 native_action_ids::REMOVE_GENERIC_NERVOUS_SYSTEM_FUNCTION
             }
             Action::ExecuteGenericNervousSystemFunction(proposal) => proposal.function_id,
+            Action::ExecuteExtensionOperation(_) => native_action_ids::EXECUTE_EXTENSION_OPERATION,
             Action::RegisterDappCanisters(_) => native_action_ids::REGISTER_DAPP_CANISTERS,
             Action::RegisterExtension(_) => native_action_ids::REGISTER_EXTENSION,
             Action::DeregisterDappCanisters(_) => native_action_ids::DEREGISTER_DAPP_CANISTERS,


### PR DESCRIPTION
This PR adds the API for executing SNS extension operations, as discussed [here](https://github.com/dfinity/ic/pull/5359).