### PR TITLE
feat(NPR): Add scheduled metrics synchronization for subnets

### DIFF
--- a/rs/node_rewards/canister/src/main.rs
+++ b/rs/node_rewards/canister/src/main.rs
@@ -4,7 +4,8 @@ use ic_cdk::{init, post_upgrade, pre_upgrade, spawn, update};
 use ic_nervous_system_canisters::registry::RegistryCanister;
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use ic_node_rewards_canister::canister::NodeRewardsCanister;
-use ic_node_rewards_canister::storage::RegistryStoreStableMemoryBorrower;
+use ic_node_rewards_canister::registry_querier::RegistryQuerier;
+use ic_node_rewards_canister::storage::{RegistryStoreStableMemoryBorrower, METRICS_MANAGER};
 use ic_node_rewards_canister_api::monthly_rewards::{
     GetNodeProvidersMonthlyXdrRewardsRequest, GetNodeProvidersMonthlyXdrRewardsResponse,
 };
@@ -44,15 +45,16 @@ fn post_upgrade() {
 
 fn schedule_timers() {
     schedule_registry_sync();
+    schedule_metrics_sync();
 }
 
 // The frequency of regular registry syncs.  This is set to 1 hour to avoid
 // making too many requests.  Before meaningful calculations are made, however, the
-// registry data should be updated.
-const REGISTRY_SYNC_INTERVAL_SECONDS: Duration = Duration::from_secs(60 * 60); // 1 hour
+// registry data and metrics should be updated.
+const SYNC_INTERVAL_SECONDS: Duration = Duration::from_secs(60 * 60); // 1 hour
 
 fn schedule_registry_sync() {
-    ic_cdk_timers::set_timer_interval(REGISTRY_SYNC_INTERVAL_SECONDS, move || {
+    ic_cdk_timers::set_timer_interval(SYNC_INTERVAL_SECONDS, move || {
         spawn(async move {
             let store = REGISTRY_STORE.with(|s| s.clone());
             // panicking here is okay because we are using an interval instead of a timer that
@@ -61,6 +63,22 @@ fn schedule_registry_sync() {
                 .sync_registry_stored()
                 .await
                 .expect("Could not sync registry store!");
+        });
+    });
+}
+
+fn schedule_metrics_sync() {
+    ic_cdk_timers::set_timer_interval(SYNC_INTERVAL_SECONDS, move || {
+        spawn(async move {
+            let registry_store = REGISTRY_STORE.with(|m| m.clone());
+            let latest_version = registry_store.get_latest_version().await;
+            let registry_querier = RegistryQuerier::new(registry_store.clone());
+            let latest_subnets_list = registry_querier.subnets_list(latest_version);
+
+            let metrics_manager = METRICS_MANAGER.with(|m| m.clone());
+            metrics_manager
+                .update_subnets_metrics(latest_subnets_list)
+                .await;
         });
     });
 }
@@ -87,7 +105,6 @@ async fn get_node_providers_monthly_xdr_rewards(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use candid_parser::utils::{service_equal, CandidSource};
     #[test]
     fn test_implemented_interface_matches_declared_interface_exactly() {

--- a/rs/node_rewards/canister/src/metrics.rs
+++ b/rs/node_rewards/canister/src/metrics.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use rewards_calculation::rewards_calculator_results::DayUTC;
 use rewards_calculation::types::{NodeMetricsDailyRaw, SubnetMetricsDailyKey, UnixTsNanos};
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 pub type RetryCount = u64;
 
@@ -108,7 +108,7 @@ where
     /// This function fetches the nodes metrics for the given subnets from the management canisters
     /// updating the local metrics with the fetched metrics.
     pub async fn update_subnets_metrics(&self, subnets: Vec<SubnetId>) {
-        let mut subnets_to_update = subnets.clone();
+        let mut subnets_to_update: HashSet<SubnetId> = subnets.clone().into_iter().collect();
         let subnets_to_retry: Vec<SubnetId> = self
             .subnets_to_retry
             .borrow()

--- a/rs/node_rewards/canister/src/metrics.rs
+++ b/rs/node_rewards/canister/src/metrics.rs
@@ -108,7 +108,16 @@ where
     /// This function fetches the nodes metrics for the given subnets from the management canisters
     /// updating the local metrics with the fetched metrics.
     pub async fn update_subnets_metrics(&self, subnets: Vec<SubnetId>) {
-        let last_timestamp_per_subnet: BTreeMap<SubnetId, _> = subnets
+        let mut subnets_to_update = subnets.clone();
+        let subnets_to_retry: Vec<SubnetId> = self
+            .subnets_to_retry
+            .borrow()
+            .keys()
+            .map(|key| key.into())
+            .collect();
+        subnets_to_update.extend(subnets_to_retry);
+
+        let last_timestamp_per_subnet: BTreeMap<SubnetId, _> = subnets_to_update
             .into_iter()
             .map(|subnet| {
                 let last_timestamp = self.last_timestamp_per_subnet.borrow().get(&subnet.into());


### PR DESCRIPTION
Changes:
- Add metrics synchronization for subnets
- Modified update_subnets_metrics to also retry failed subnets when invoked