### PR TITLE
feat(nns-tools): Add a warning when the release candates contain a mix of icrc ledger suite and other canisters

### DIFF
--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -7,7 +7,7 @@ use clap::{Parser, Subcommand};
 use colored::*;
 use commands::{run_script, run_script_in_current_process};
 use commit_switcher::CommitSwitcher;
-use std::path::PathBuf;
+use std::{collections::BTreeSet, path::PathBuf};
 use url::Url;
 use utils::*;
 
@@ -207,13 +207,29 @@ fn run_determine_targets(cmd: DetermineTargets) -> Result<()> {
         }
     }
 
+    let icrc_ledger_suite: BTreeSet<String> = ["index", "ledger", "archive"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let sns_canisters_set: BTreeSet<String> = sns_canisters.iter().map(String::from).collect();
+    let has_icrc_ledger_suite = sns_canisters_set.intersection(&icrc_ledger_suite).count() > 0;
+    let not_exactly_icrc_ledger_suite =
+        !nns_canisters.is_empty() || sns_canisters_set != icrc_ledger_suite;
+    let maybe_warning = if has_icrc_ledger_suite && not_exactly_icrc_ledger_suite {
+        "\nWARNING: You are releasing some of the ICRC ledger suite but also some other canisters at the same commit. \
+        ICRC ledger suite usually requires a specific commit, so you might want to consider releasing them separately."
+    } else {
+        ""
+    };
+
     print_step(
         2,
         "Determine Upgrade Targets",
         &format!(
-            "NNS canisters selected for release: {}\nSNS canisters selected for release: {}",
+            "NNS canisters selected for release: {}\nSNS canisters selected for release: {}{}",
             nns_canisters.join(", "),
-            sns_canisters.join(", ")
+            sns_canisters.join(", "),
+            maybe_warning
         ),
     )?;
 


### PR DESCRIPTION
Since the icrc ledger suite has its own release process and they should be published to the SNS-WASM at a specific commit, most likely they shouldn't be released along with other NNS/SNS canisters. Print a warning when the candidates have a mix of the icrc ledger suite and other canisters.