### PR TITLE
fix(node): Depend ic-replica on guestos-recovery-engine

### DIFF
--- a/ic-os/components/BUILD.bazel
+++ b/ic-os/components/BUILD.bazel
@@ -49,6 +49,7 @@ ignored_repo_components = [
     "networking/dev-certs/root_cert_gen.sh",
     "misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh",
     "misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.service",
+    "misc/guestos-recovery/guestos-recovery-engine/ic-replica-recovery.conf",
     "selinux/guestos-recovery-engine/guestos-recovery-engine.fc",
     "selinux/guestos-recovery-engine/guestos-recovery-engine.te",
 ]

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.service
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.service
@@ -3,7 +3,6 @@ Description=Recovery Engine
 After=upgrade-shared-data-store.service
 Wants=network-online.target
 After=network-online.target
-Before=ic-replica.service
 
 [Install]
 WantedBy=multi-user.target

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.service
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.service
@@ -3,6 +3,7 @@ Description=Recovery Engine
 After=upgrade-shared-data-store.service
 Wants=network-online.target
 After=network-online.target
+Before=ic-replica.service
 
 [Install]
 WantedBy=multi-user.target

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/ic-replica-recovery.conf
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/ic-replica-recovery.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=guestos-recovery-engine.service
+After=guestos-recovery-engine.service 

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/ic-replica-recovery.conf
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/ic-replica-recovery.conf
@@ -1,3 +1,4 @@
-[Unit]
-Requires=guestos-recovery-engine.service
-After=guestos-recovery-engine.service 
+# This systemd drop-in ensures ic-replica.service waits for guestos-recovery-engine.service
+# to succeed, even if guestos-recovery-engine.service fails initially and restarts.
+[Service]
+ExecStartPre=/bin/sh -c 'while ! systemctl is-active --quiet guestos-recovery-engine.service; do sleep 5; done'

--- a/ic-os/guestos/defs.bzl
+++ b/ic-os/guestos/defs.bzl
@@ -110,6 +110,7 @@ def image_deps(mode, malicious = False):
         deps["component_files"].update({
             recovery_engine_path: "/opt/ic/bin/guestos-recovery-engine.sh",
             Label("//ic-os/components:misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.service"): "/etc/systemd/system/guestos-recovery-engine.service",
+            Label("//ic-os/components:misc/guestos-recovery/guestos-recovery-engine/ic-replica-recovery.conf"): "/etc/systemd/system/ic-replica.service.d/ic-replica-recovery.conf",
             Label("//ic-os/components:selinux/guestos-recovery-engine/guestos-recovery-engine.fc"): "/prep/guestos-recovery-engine/guestos-recovery-engine.fc",
             Label("//ic-os/components:selinux/guestos-recovery-engine/guestos-recovery-engine.te"): "/prep/guestos-recovery-engine/guestos-recovery-engine.te",
         })


### PR DESCRIPTION
[NODE-1649](https://dfinity.atlassian.net/browse/NODE-1649)

Only run ic-replica after guestos-recovery-engine completes on recovery variants

[NODE-1649]: https://dfinity.atlassian.net/browse/NODE-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ