### PR TITLE
chore: changes to support external prs

### DIFF
--- a/.github/CI_README.md
+++ b/.github/CI_README.md
@@ -4,6 +4,7 @@ GitHub CI for the IC Repo
 
 ### CI Main
 
+Workflow *'CI Main'* is the core of CI and is also the only workflow relevant for external PRs.
 
 | Job Name                  | Runner / Image                   | Secrets Required                      | When Invoked                                                                                               | Purpose                                                                                      | External PR |
 |---------------------------|----------------------------------|---------------------------------------|------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|-------------|
@@ -21,14 +22,7 @@ GitHub CI for the IC Repo
 | bazel-test-macos-apple-silicon| namespace-profile-darwin, dfinity/ic-build | None                                                           | PR, merge_group, push (master, dev-gh-*)                   | Test targets with tag test_macos,test_macos_slow                        | Yes         |
 | dependencies-check          | dind-small, dfinity/ic-build | GITHUB_TOKEN, JIRA_API_TOKEN, SLACK_PSEC_BOT_OAUTH_TOKEN       | On internal pull_request (not merge_group) and repository_dispatch              | Dependency scanning (Rust, Bazel, lock/toml changes)          | Yes / `/run-ci-main`       |
 
-### CI PR Only
-
-| Job Name                    | Runner / Image        | Secrets Required                                               | When Invoked                                                          | Purpose                                                      | External PR |
-|-----------------------------|----------------------|----------------------------------------------------------------|-----------------------------------------------------------------------|--------------------------------------------------------------|-------------|
-| bazel-build-fuzzers-archives| dind-large, dfinity/ic-build | None                                                           | PR (opened, synchronize, reopened); not merge_group                   | Build and archive all fuzzers for PRs                        | Yes         |
-| lock-generate               | dind-small, dfinity/ic-build | PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY (for GitHub App Token)    | PR (opened, synchronize, reopened); not merge_group                   | Generate lock files and related dependencies for PRs          | No, needs to be run manually.         |
-| generate-config-fixtures    | dind-small, dfinity/ic-build | PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY (for GitHub App Token)    | PR (opened, synchronize, reopened); not merge_group                   | Generate config fixture files for config_types changes        | No, needs to be run manually.         |
-| bazel-test-coverage         | dind-large, dfinity/ic-build | None                                                           | PR with label `CI_COVERAGE`                                           | Run Bazel test coverage and upload HTML report                | Yes         |
+TODO: document other workflows.
 
 ## Using custom CI labels
 Note that setting custom CI logic via the pull request title has been deprecated and we now use labels instead. See labels below for custom logic that can be enabled:

--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -35,7 +35,7 @@ runs:
           execlogs-artifact-name: ${{ inputs.execlogs-artifact-name }}
           run: |
             set -euo pipefail
-            echo "::notice::Node Name: ${NODE_NAME}"
+            [ -n "${NODE_NAME:-}" ] && echo "::notice::Node Name: ${NODE_NAME:-}"
 
             diff_only='${{ inputs.diff-only }}'
             stamp_build='${{ inputs.stamp-build }}'

--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -31,6 +31,7 @@ runs:
       env:
         # Used by the bazel wrapper
         BUILDBUDDY_LINKS: '[CI Job](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+        FORK_PR: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
       run: |
         set -euo pipefail
 

--- a/.github/actions/bazel/bin/bazel
+++ b/.github/actions/bazel/bin/bazel
@@ -12,6 +12,7 @@ log() {
 }
 
 BUILDBUDDY_LINKS="${BUILDBUDDY_LINKS:-}"
+FORK_PR="${FORK_PR:-false}"
 
 # Remove ourselves from the PATH, in case the bazel command tries to call bazel as well
 PATH="$BAZEL_ACTION_OLDPATH"
@@ -68,14 +69,6 @@ if [[ $bazel_command == "build" ]] || [[ $bazel_command == "test" ]]; then
         --remote_upload_local_results=true
 
         --color=yes # Nice CI output
-
-        # Write build events to the dedicated tempdir
-        --build_event_binary_file="$BAZEL_ACTION_METRICS_OUT/bazel-bep-$command_timestamp.pb"
-        --profile="$BAZEL_ACTION_METRICS_OUT/profile-$command_timestamp.json"
-        # Associate each action in the profile with a target label.
-        # This helps analysis tools like https://github.com/EngFlow/bazel_invocation_analyzer
-        # break down bottlenecks.
-        --experimental_profile_include_target_label
     )
 
     if [ -n "${BUILDBUDDY_LINKS:-}" ]; then
@@ -83,6 +76,24 @@ if [[ $bazel_command == "build" ]] || [[ $bazel_command == "test" ]]; then
             --build_metadata=BUILDBUDDY_LINKS="$BUILDBUDDY_LINKS"
         )
     fi
+
+     # Build without remote cache if this is a pull request run from a forked repo
+    if [ "$FORK_PR" = true ]; then
+        if [[ ! " ${bazel_args[*]} " =~ " --config=local " ]]; then
+            bazel_args+=("--config=local")
+        fi
+    else
+        bazel_args+=(
+            # Write build events to the dedicated tempdir
+            --build_event_binary_file="$BAZEL_ACTION_METRICS_OUT/bazel-bep-$command_timestamp.pb"
+            --profile="$BAZEL_ACTION_METRICS_OUT/profile-$command_timestamp.json"
+            # Associate each action in the profile with a target label.
+            # This helps analysis tools like https://github.com/EngFlow/bazel_invocation_analyzer
+            # break down bottlenecks.
+            --experimental_profile_include_target_label
+        )
+    fi
+
 fi
 
 # Wrapper repeating the build metadata URL, useful for long builds with a lot of

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -1,23 +1,25 @@
 name: CI Main
 
 on:
+  pull_request:
+    branches-ignore:
+      - hotfix-* # This is to ensure that this workflow is not triggered twice on ic-private, as it's already triggered from release-testing
   merge_group:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
   push:
     branches:
       - master
       - 'dev-gh-*'
-  pull_request:
-    branches-ignore:
-      - hotfix-* # This is to ensure that this workflow is not triggered twice on ic-private, as it's already triggered from release-testing
-  # Used as reusable workflow within release-testing workflow
-  workflow_call:
+  workflow_call: # Used as reusable workflow within release-testing workflow
+  workflow_dispatch: # Trigger via UI or gh CLI
+  repository_dispatch: # Trigger via API / ChatOps
+    types: [run-ci-main]
 
-# runs for the same workflow are cancelled on PRs but not on master
-# explanation: on push to master head_ref is not set, so we want it to fall back to run_id so it is not cancelled
+# Runs for the same workflow are cancelled on PRs but not on master (on push to master head_ref is not set - fall back to run_id so it is not cancelled)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: >
+    ${{ github.event_name == 'repository_dispatch'
+        && format('{0}-dispatch-{1}', github.workflow, github.event.client_payload.pr_number || github.run_id)
+        || format('{0}-ci-{1}', github.workflow, github.head_ref || github.ref_name || github.run_id) }}
   cancel-in-progress: true
 
 permissions:
@@ -36,16 +38,14 @@ anchors:
   image: &image
     image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
   dind-large-setup: &dind-large-setup
-    runs-on:
-      labels: dind-large
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
     container:
       <<: *image
       options: >-
         -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 90
   dind-small-setup: &dind-small-setup
-    runs-on:
-      labels: dind-small
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
     container:
       <<: *image
       options: >-
@@ -144,12 +144,11 @@ jobs:
     needs: [ config ]
     <<: *dind-large-setup
     timeout-minutes: 120
-    runs-on:
-      labels: dind-large
     env:
       # Only run ci/bazel-scripts/diff.sh on PRs that are not labeled with "CI_ALL_BAZEL_TARGETS".
       OVERRIDE_DIDC_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_DIDC_CHECK') }}
       CI_OVERRIDE_BUF_BREAKING: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_BUF_BREAKING') }}
+      FORK_PR: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
     steps:
       - <<: *checkout
       - name: Set BAZEL_EXTRA_ARGS
@@ -168,6 +167,11 @@ jobs:
 
           if [[ '${{ needs.config.outputs.skip_long_tests }}' == 'true' ]]; then
             EXCLUDED_TEST_TAGS+=(long_test)
+          fi
+
+          # No system tests on forked PR runs
+          if [[ "$FORK_PR" == "true" ]]; then
+            EXCLUDED_TEST_TAGS+=(system_test)
           fi
 
           # Export excluded tags as environment variable for ci/bazel-scripts/diff.sh
@@ -253,6 +257,7 @@ jobs:
     runs-on: namespace-profile-arm64-linux # profile created in namespace console
     if: github.repository == 'dfinity/ic' # only run on public repo, not private since Namespace runners are not configured there, so these CI jobs get stuck otherwise.
     steps:
+      # TODO: Set up separate Bazel cache for external PRs
       - name: Set up Bazel cache
         run: |
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
@@ -288,6 +293,7 @@ jobs:
     runs-on: namespace-profile-darwin # profile created in namespace console
     if: github.repository == 'dfinity/ic' # only run on public repo, not private since Namespace runners are not configured there, so these CI jobs get stuck otherwise.
     steps:
+      # TODO: Set up separate Bazel cache for external PRs
       - name: Set up Bazel cache
         run: |
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
@@ -391,7 +397,7 @@ jobs:
 
   python-ci-tests:
     name: Python CI Tests
-    <<: *dind-small-setup
+    runs-on: ubuntu-latest
     steps:
       - <<: *checkout
       - <<: *python-setup
@@ -399,10 +405,18 @@ jobs:
         shell: bash
         run: |
           set -xeuo pipefail
+
+          # Set up virtualenv and activate it
+          python3 -m venv venv
+          source venv/bin/activate
+
+          # Upgrade pip and install requirements
+          pip install --upgrade pip
+          pip install -r requirements.txt
+
           export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
-          # Ignore externally-managed-environment pip error, install packages system-wide.
-          PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --ignore-installed -r requirements.txt
           cd ci/src
+
           pytest -m "not fails_on_merge_train" -v -o junit_family=xunit1 \
             --junitxml=../../test_report.xml --cov=. --cov-report=term \
             --cov-report=term-missing --cov-report=html --cov-branch
@@ -415,9 +429,6 @@ jobs:
     needs: [ config ]
     name: Build IC
     <<: *dind-large-setup
-    # keep options from dind-large-setup but run on dind-small-setup
-    runs-on:
-      labels: dind-small
     if: ${{ github.event_name != 'merge_group' }}
     steps:
       - <<: *checkout
@@ -557,3 +568,59 @@ jobs:
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors
           cargo build --release --locked
+
+  dependencies-check:
+    name: Dependency Scan for PR
+    <<: *dind-small-setup
+    if: >
+      ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      || github.event_name == 'repository_dispatch' }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      SHELL_WRAPPER: "/usr/bin/time"
+      CI_MERGE_REQUEST_IID: ${{ github.event.pull_request.number }}
+      CI_PROJECT_PATH: ${{ github.repository }}
+      CI_PIPELINE_ID: ${{ github.run_id }}
+      CI_COMMIT_SHA: ${{ github.sha }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
+      REPO_NAME: ${{ github.repository }}
+    steps:
+      - <<: *checkout
+        with:
+          fetch-depth: 256
+      - name: Filter Relevant Files
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: filter
+        with:
+          filters: |
+            depcheck:
+              - '.github/workflows/ci-pr-only.yml'
+              - 'bazel/external_crates.bzl'
+              - '**/*.lock'
+              - '**/*.toml'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        if: steps.filter.outputs.depcheck == 'true'
+        with:
+          python-version: "3.12"
+      - name: Setup python deps
+        id: setup-python-deps
+        if: steps.filter.outputs.depcheck == 'true'
+        shell: bash
+        run: |
+          # Ignore externally-managed-environment pip error, install packages system-wide.
+          PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --ignore-installed -r requirements.txt
+      - name: Dependency Scan for Pull Request
+        id: dependencies-check
+        if: steps.filter.outputs.depcheck == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
+          cd ci/src/dependencies/
+          $SHELL_WRAPPER python3 job/bazel_rust_ic_scanner_merge_job.py

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -624,3 +624,39 @@ jobs:
           export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
           cd ci/src/dependencies/
           $SHELL_WRAPPER python3 job/bazel_rust_ic_scanner_merge_job.py
+
+  update-pr-comment:
+    name: Slash Comment Update
+    if: github.event_name == 'repository_dispatch' && always()
+    runs-on: ubuntu-latest
+    needs:
+      - config
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+      - name: Update Comment / Success
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: success()
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ github.event.client_payload.slash_command.args.named.pr_number }}
+          comment-id: ${{ github.event.client_payload.slash_command.args.named.comment_id }}
+          body: |
+            ✅ [Run#${{ github.run_id }}/${{ github.run_attempt }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?attempt=${{ github.run_attempt }})
+
+      - name: Update Comment / Failure
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: failure()
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ github.event.client_payload.slash_command.args.named.pr_number }}
+          comment-id: ${{ github.event.client_payload.slash_command.args.named.comment_id }}
+          body: |
+            ❌ [Run#${{ github.run_id }}/${{ github.run_attempt }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?attempt=${{ github.run_attempt }})

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -117,8 +117,8 @@ jobs:
   generate-config-fixtures:
     name: Generate Config Fixtures
     <<: *dind-small-setup
+    <<: *skip-merge-group
     timeout-minutes: 5
-    if: ${{ github.event_name != 'merge_group' }}
     env:
       CI_EVENT_NAME: ${{ github.event_name }}
     steps:

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -37,7 +37,7 @@ anchors:
     name: Checkout
     uses: actions/checkout@v4
   skip-merge-group: &skip-merge-group
-    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository }}
+    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
 
 jobs:
   insta-tests:

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -37,7 +37,7 @@ anchors:
     name: Checkout
     uses: actions/checkout@v4
   skip-merge-group: &skip-merge-group
-    if: ${{ github.event_name != 'merge_group' }}
+    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository }}
 
 jobs:
   insta-tests:
@@ -145,60 +145,6 @@ jobs:
         id: generate-config-fixtures
         if: steps.filter.outputs.generate-config-fixtures == 'true'
         run: ./ci/scripts/generate-config-fixtures.sh
-
-  dependencies-check:
-    name: Dependency Scan for PR
-    <<: *dind-small-setup
-    <<: *skip-merge-group
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      SHELL_WRAPPER: "/usr/bin/time"
-      CI_MERGE_REQUEST_IID: ${{ github.event.pull_request.number }}
-      CI_PROJECT_PATH: ${{ github.repository }}
-      CI_PIPELINE_ID: ${{ github.run_id }}
-      CI_COMMIT_SHA: ${{ github.sha }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-      SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
-      REPO_NAME: ${{ github.repository }}
-    steps:
-      - <<: *checkout
-        with:
-          fetch-depth: 256
-      - name: Filter Relevant Files
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: filter
-        with:
-          filters: |
-            depcheck:
-              - '.github/workflows/ci-pr-only.yml'
-              - 'bazel/external_crates.bzl'
-              - '**/*.lock'
-              - '**/*.toml'
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        if: steps.filter.outputs.depcheck == 'true'
-        with:
-          python-version: "3.12"
-      - name: Setup python deps
-        id: setup-python-deps
-        if: steps.filter.outputs.depcheck == 'true'
-        shell: bash
-        run: |
-          # Ignore externally-managed-environment pip error, install packages system-wide.
-          PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --ignore-installed -r requirements.txt
-      - name: Dependency Scan for Pull Request
-        id: dependencies-check
-        if: steps.filter.outputs.depcheck == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
-          cd ci/src/dependencies/
-          $SHELL_WRAPPER python3 job/bazel_rust_ic_scanner_merge_job.py
 
   # CI job is also executed in Schedule Hourly
   bazel-test-coverage:

--- a/.github/workflows-source/ci-pr-only.yml
+++ b/.github/workflows-source/ci-pr-only.yml
@@ -37,7 +37,7 @@ anchors:
     name: Checkout
     uses: actions/checkout@v4
   skip-merge-group: &skip-merge-group
-    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository }}
 
 jobs:
   insta-tests:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -632,3 +632,36 @@ jobs:
           export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
           cd ci/src/dependencies/
           $SHELL_WRAPPER python3 job/bazel_rust_ic_scanner_merge_job.py
+  update-pr-comment:
+    name: Slash Comment Update
+    if: github.event_name == 'repository_dispatch' && always()
+    runs-on: ubuntu-latest
+    needs:
+      - config
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+      - name: Update Comment / Success
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: success()
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ github.event.client_payload.slash_command.args.named.pr_number }}
+          comment-id: ${{ github.event.client_payload.slash_command.args.named.comment_id }}
+          body: |
+            ✅ [Run#${{ github.run_id }}/${{ github.run_attempt }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?attempt=${{ github.run_attempt }})
+      - name: Update Comment / Failure
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: failure()
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ github.event.client_payload.slash_command.args.named.pr_number }}
+          comment-id: ${{ github.event.client_payload.slash_command.args.named.comment_id }}
+          body: |
+            ❌ [Run#${{ github.run_id }}/${{ github.run_attempt }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?attempt=${{ github.run_attempt }})

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -228,6 +228,7 @@ jobs:
     runs-on: namespace-profile-arm64-linux # profile created in namespace console
     if: github.repository == 'dfinity/ic' # only run on public repo, not private since Namespace runners are not configured there, so these CI jobs get stuck otherwise.
     steps:
+      # TODO: Set up separate Bazel cache for external PRs
       - name: Set up Bazel cache
         run: |
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
@@ -260,6 +261,7 @@ jobs:
     runs-on: namespace-profile-darwin # profile created in namespace console
     if: github.repository == 'dfinity/ic' # only run on public repo, not private since Namespace runners are not configured there, so these CI jobs get stuck otherwise.
     steps:
+      # TODO: Set up separate Bazel cache for external PRs
       - name: Set up Bazel cache
         run: |
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
@@ -570,3 +572,63 @@ jobs:
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors
           cargo build --release --locked
+  dependencies-check:
+    name: Dependency Scan for PR
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
+    container:
+      image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
+      options: >-
+        -e NODE_NAME
+    if: >
+      ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'repository_dispatch' }}
+
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      SHELL_WRAPPER: "/usr/bin/time"
+      CI_MERGE_REQUEST_IID: ${{ github.event.pull_request.number }}
+      CI_PROJECT_PATH: ${{ github.repository }}
+      CI_PIPELINE_ID: ${{ github.run_id }}
+      CI_COMMIT_SHA: ${{ github.sha }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
+      REPO_NAME: ${{ github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 256
+      - name: Filter Relevant Files
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: filter
+        with:
+          filters: |
+            depcheck:
+              - '.github/workflows/ci-pr-only.yml'
+              - 'bazel/external_crates.bzl'
+              - '**/*.lock'
+              - '**/*.toml'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        if: steps.filter.outputs.depcheck == 'true'
+        with:
+          python-version: "3.12"
+      - name: Setup python deps
+        id: setup-python-deps
+        if: steps.filter.outputs.depcheck == 'true'
+        shell: bash
+        run: |
+          # Ignore externally-managed-environment pip error, install packages system-wide.
+          PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --ignore-installed -r requirements.txt
+      - name: Dependency Scan for Pull Request
+        id: dependencies-check
+        if: steps.filter.outputs.depcheck == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
+          cd ci/src/dependencies/
+          $SHELL_WRAPPER python3 job/bazel_rust_ic_scanner_merge_job.py

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,21 +1,25 @@
 name: CI Main
 on:
+  pull_request:
+    branches-ignore:
+      - hotfix-* # This is to ensure that this workflow is not triggered twice on ic-private, as it's already triggered from release-testing
   merge_group:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
   push:
     branches:
       - master
       - 'dev-gh-*'
-  pull_request:
-    branches-ignore:
-      - hotfix-* # This is to ensure that this workflow is not triggered twice on ic-private, as it's already triggered from release-testing
-  # Used as reusable workflow within release-testing workflow
-  workflow_call:
-# runs for the same workflow are cancelled on PRs but not on master
-# explanation: on push to master head_ref is not set, so we want it to fall back to run_id so it is not cancelled
+  workflow_call: # Used as reusable workflow within release-testing workflow
+  workflow_dispatch: # Trigger via UI or gh CLI
+  repository_dispatch: # Trigger via API / ChatOps
+    types: [run-ci-main]
+# Runs for the same workflow are cancelled on PRs but not on master (on push to master head_ref is not set - fall back to run_id so it is not cancelled)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: >
+    ${{ github.event_name == 'repository_dispatch'
+
+
+        && format('{0}-dispatch-{1}', github.workflow, github.event.client_payload.pr_number || github.run_id)
+        || format('{0}-ci-{1}', github.workflow, github.head_ref || github.ref_name || github.run_id) }}
   cancel-in-progress: true
 permissions:
   contents: read
@@ -106,17 +110,17 @@ jobs:
   bazel-test-all:
     name: Bazel Test All
     needs: [config]
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
     container:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 120
-    runs-on:
-      labels: dind-large
     env:
       # Only run ci/bazel-scripts/diff.sh on PRs that are not labeled with "CI_ALL_BAZEL_TARGETS".
       OVERRIDE_DIDC_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_DIDC_CHECK') }}
       CI_OVERRIDE_BUF_BREAKING: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_BUF_BREAKING') }}
+      FORK_PR: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -138,6 +142,11 @@ jobs:
 
           if [[ '${{ needs.config.outputs.skip_long_tests }}' == 'true' ]]; then
             EXCLUDED_TEST_TAGS+=(long_test)
+          fi
+
+          # No system tests on forked PR runs
+          if [[ "$FORK_PR" == "true" ]]; then
+            EXCLUDED_TEST_TAGS+=(system_test)
           fi
 
           # Export excluded tags as environment variable for ci/bazel-scripts/diff.sh
@@ -295,8 +304,7 @@ jobs:
   # Upload external artifacts, retrieved from non-DFINITY runner builds.
   upload-external-artifacts:
     name: Upload external artifacts
-    runs-on:
-      labels: dind-large
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
     container:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
@@ -339,8 +347,7 @@ jobs:
           credentials-content: ${{ secrets.CLOUD_CREDENTIALS_CONTENT }}
   bazel-run-fuzzers:
     name: Bazel Run Fuzzers
-    runs-on:
-      labels: dind-large
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
     container:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
@@ -361,13 +368,7 @@ jobs:
           run: ./bin/fuzzing/run-all-fuzzers.sh --afl 100
   python-ci-tests:
     name: Python CI Tests
-    runs-on:
-      labels: dind-small
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
-      options: >-
-        -e NODE_NAME
-    timeout-minutes: 30
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -381,10 +382,18 @@ jobs:
         shell: bash
         run: |
           set -xeuo pipefail
+
+          # Set up virtualenv and activate it
+          python3 -m venv venv
+          source venv/bin/activate
+
+          # Upgrade pip and install requirements
+          pip install --upgrade pip
+          pip install -r requirements.txt
+
           export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
-          # Ignore externally-managed-environment pip error, install packages system-wide.
-          PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --ignore-installed -r requirements.txt
           cd ci/src
+
           pytest -m "not fails_on_merge_train" -v -o junit_family=xunit1 \
             --junitxml=../../test_report.xml --cov=. --cov-report=term \
             --cov-report=term-missing --cov-report=html --cov-branch
@@ -395,14 +404,12 @@ jobs:
   build-ic:
     needs: [config]
     name: Build IC
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
     container:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 90
-    # keep options from dind-large-setup but run on dind-small-setup
-    runs-on:
-      labels: dind-small
     if: ${{ github.event_name != 'merge_group' }}
     steps:
       - name: Checkout
@@ -475,8 +482,7 @@ jobs:
     name: Bazel Build All No Cache
     needs: [config]
     if: ${{ needs.config.outputs.skip_long_tests != 'true' }} # GHA output quirk, 'true' is a string
-    runs-on:
-      labels: dind-large
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
     container:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
@@ -494,8 +500,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
   cargo-clippy-linux:
     name: Cargo Clippy Linux
-    runs-on:
-      labels: dind-small
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
     container:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
@@ -531,8 +536,7 @@ jobs:
           "$CI_PROJECT_DIR"/ci/scripts/rust-lint.sh
   cargo-build-release-linux:
     name: Cargo Build Release Linux
-    runs-on:
-      labels: dind-small
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24-large') || 'dind-large' }}
     container:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -23,7 +23,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' }}
+    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' }}
+    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' }}
+    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository }}
     env:
       CI_EVENT_NAME: ${{ github.event_name }}
     steps:
@@ -141,65 +141,6 @@ jobs:
         id: generate-config-fixtures
         if: steps.filter.outputs.generate-config-fixtures == 'true'
         run: ./ci/scripts/generate-config-fixtures.sh
-  dependencies-check:
-    name: Dependency Scan for PR
-    runs-on:
-      labels: dind-small
-    container:
-      image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
-      options: >-
-        -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' }}
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      SHELL_WRAPPER: "/usr/bin/time"
-      CI_MERGE_REQUEST_IID: ${{ github.event.pull_request.number }}
-      CI_PROJECT_PATH: ${{ github.repository }}
-      CI_PIPELINE_ID: ${{ github.run_id }}
-      CI_COMMIT_SHA: ${{ github.sha }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-      SLACK_PSEC_BOT_OAUTH_TOKEN: ${{ secrets.SLACK_PSEC_BOT_OAUTH_TOKEN }}
-      REPO_NAME: ${{ github.repository }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 256
-      - name: Filter Relevant Files
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: filter
-        with:
-          filters: |
-            depcheck:
-              - '.github/workflows/ci-pr-only.yml'
-              - 'bazel/external_crates.bzl'
-              - '**/*.lock'
-              - '**/*.toml'
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        if: steps.filter.outputs.depcheck == 'true'
-        with:
-          python-version: "3.12"
-      - name: Setup python deps
-        id: setup-python-deps
-        if: steps.filter.outputs.depcheck == 'true'
-        shell: bash
-        run: |
-          # Ignore externally-managed-environment pip error, install packages system-wide.
-          PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --ignore-installed -r requirements.txt
-      - name: Dependency Scan for Pull Request
-        id: dependencies-check
-        if: steps.filter.outputs.depcheck == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          export PYTHONPATH=$PWD/ci/src:$PWD/ci/src/dependencies
-          cd ci/src/dependencies/
-          $SHELL_WRAPPER python3 job/bazel_rust_ic_scanner_merge_job.py
   # CI job is also executed in Schedule Hourly
   bazel-test-coverage:
     name: Bazel Test Coverage

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -23,7 +23,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository }}
     env:
       CI_EVENT_NAME: ${{ github.event_name }}
     steps:

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -113,8 +113,8 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
+    if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository }}
     timeout-minutes: 5
-    if: ${{ github.event_name != 'merge_group' }}
     env:
       CI_EVENT_NAME: ${{ github.event_name }}
     steps:

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -23,7 +23,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository }}
+    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository }}
+    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:d8f7308e97e095a9c9b0cdb1b6f260f459424e3792ebd49bb7c6ff6098941a34
       options: >-
         -e NODE_NAME
-    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository }}
+    if: ${{ github.event_name != 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
     env:
       CI_EVENT_NAME: ${{ github.event_name }}
     steps:

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -1,0 +1,32 @@
+name: Slash Command Listener
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  slash-command-dispatch:
+    name: Slash Command Dispatch
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+        # users with 'admin' role can invoke `/run-ci-main` command
+      - name: Command Dispatch Admin
+        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          permission: admin
+          issue-type: pull-request
+          commands: |
+            run-ci-main
+          static-args: |
+            pr_number=${{ github.event.issue.number }}
+            comment_id=${{ github.event.comment.id }}
+            actor=${{ github.actor }}

--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -153,3 +153,6 @@ build --repo_env=HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX=/tmp/zig-cache
 build --sandbox_add_mount_pair=/tmp/zig-cache
 # Allow writes to the shared cache
 build --sandbox_writable_path=/tmp/zig-cache
+# Run `bazel build ... --config=local` to build targets without cache
+build:local --remote_cache=
+build:local --experimental_remote_downloader=

--- a/bazel/conf/.bazelrc.internal
+++ b/bazel/conf/.bazelrc.internal
@@ -17,12 +17,8 @@ build --experimental_remote_cache_compression # If enabled, compress/decompress 
 #build --remote_download_outputs=toplevel # Still download outputs from top level targets.
 
 build --experimental_remote_downloader=bazel-remote.idx.dfinity.network --experimental_remote_downloader_local_fallback
-build:local --experimental_remote_downloader=
 build --remote_local_fallback
-build    --remote_upload_local_results=false
-
-# Run `bazel build ... --config=local` to build targets without cache
-build:local --remote_cache=
+build --remote_upload_local_results=false
 
 # Upload bes by default when running system tests so that e.g. failures can
 # be shared easily without having to rerun a potentially very-long systest

--- a/ci/scripts/run-build-ic.sh
+++ b/ci/scripts/run-build-ic.sh
@@ -38,4 +38,8 @@ if [[ ${#ARGS[@]} -eq 0 ]]; then
     exit 0
 fi
 
+if [ ! -e /cache ]; then
+    sudo mkdir -p /cache/bazel/content_addressable && sudo chown -R 1001:1001 /cache
+fi
+
 ci/container/build-ic.sh "${ARGS[@]}" --no-release


### PR DESCRIPTION
- [x] Introduce `/run-ci-main` slash command (can be only triggered by someone who has *admin* role)
- [x] Run internal PR on on-prem runners and external PR on public / hosted runner (NO system tests for external PR run)
- [x] Consolidate jobs so that only *CI Main* is required for external contributors (jobs in *CI PR Only* must be done manually)
- [ ] Revoke approvals on new commit for external PR
- [ ] Update *CI_REAMDE.md*
- [ ] Separate bazel cache for ext PR? GitHub runners or Namespace runners?