### PR TITLE
fix(slack): Expression injection in Actions

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           TRIGGERING_WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
-          TRIGGERING_WORKFLOW_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          TRIGGERING_WORKFLOW_BRANCH="$HEAD_BRANCH"
           CHANNEL="eng-idx-alerts"
           FULL_MESSAGE="nothing"
 
@@ -75,7 +75,8 @@ jobs:
           echo "message=${FULL_MESSAGE}" >> $GITHUB_OUTPUT
           echo "post_to_slack=${POST_TO_SLACK}" >> $GITHUB_OUTPUT
         env:
-          MESSAGE: "*${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}} - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|Run#${{github.event.workflow_run.id}}>"
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          MESSAGE: "*${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} on $HEAD_BRANCH - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|Run#${{github.event.workflow_run.id}}>"
 
       - name: Post Slack Notification
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0


### PR DESCRIPTION
https://github.com/dfinity/ic/blob/71fc77e075b3b220235a26925fe035d6aba85a3d/.github/workflows/slack-workflow-run.yml#L36-L76


Using user-controlled input in GitHub Actions may lead to code injection in contexts like run: or script:. code injection in GitHub Actions may allow an attacker to exfiltrate any secrets used in the workflow and the temporary GitHub repository authorization token. The token might have write access to the repository, allowing an attacker to use the token to make changes to the repository.


fix the issue, we will:
- Assign the value of `${{ github.event.workflow_run.head_branch }}` to an environment variable.
- Use the environment variable in the shell script with shell-native syntax (`$VAR`) instead of `${{ ... }}`.

This approach ensures that the input is handled safely and prevents potential injection vulnerabilities.


#### References
[Keeping your GitHub Actions and workflows secure: Untrusted input](https://securitylab.github.com/research/github-actions-untrusted-input)
[Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
[Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)