### PR TITLE
fix: Split mainnet SetupOS vars

### DIFF
--- a/bazel/mainnet-icos-images.bzl
+++ b/bazel/mainnet-icos-images.bzl
@@ -3,9 +3,7 @@ This module defines Bazel targets for the mainnet versions of ICOS images
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-load("@mainnet_icos_versions//:defs.bzl", "mainnet_icos_versions")
-
-MAINNET_REVISION = mainnet_icos_versions["hostos"]["latest_release"]["version"]
+load("//rs/tests:common.bzl", "MAINNET_LATEST_HOSTOS_REVISION", "MAINNET_NNS_SUBNET_REVISION")
 
 def base_download_url(git_commit_id, variant, update, test):
     return "https://download.dfinity.systems/ic/{git_commit_id}/{variant}/{component}{test}/".format(
@@ -17,7 +15,13 @@ def base_download_url(git_commit_id, variant, update, test):
 
 def mainnet_icos_images():
     http_file(
-        name = "mainnet_setupos_disk_image",
+        name = "mainnet_latest_setupos_disk_image",
         downloaded_file_path = "disk-img.tar.zst",
-        url = base_download_url(MAINNET_REVISION, "setup-os", False, False) + "disk-img.tar.zst",
+        url = base_download_url(MAINNET_LATEST_HOSTOS_REVISION, "setup-os", False, False) + "disk-img.tar.zst",
+    )
+
+    http_file(
+        name = "mainnet_nns_setupos_disk_image",
+        downloaded_file_path = "disk-img.tar.zst",
+        url = base_download_url(MAINNET_NNS_SUBNET_REVISION, "setup-os", False, False) + "disk-img.tar.zst",
     )

--- a/ic-os/setupos/BUILD.bazel
+++ b/ic-os/setupos/BUILD.bazel
@@ -43,7 +43,7 @@ genrule(
 # Postprocess SetupOS mainnet into a "test" image for use in nested tests
 genrule(
     name = "mainnet-test-img",
-    srcs = ["@mainnet_setupos_disk_image//file"],
+    srcs = ["@mainnet_latest_setupos_disk_image//file"],
     outs = ["mainnet-test-img.tar.zst"],
     cmd = """
         tar -xf $<
@@ -62,7 +62,7 @@ genrule(
 # Extract the GuestOS image from SetupOS
 genrule(
     name = "mainnet-guest-img",
-    srcs = ["@mainnet_setupos_disk_image//file"],
+    srcs = ["@mainnet_nns_setupos_disk_image//file"],
     outs = ["mainnet-guest-img.tar.zst"],
     cmd = """
         $(location //rs/ic_os/build_tools/partition_tools:extract-guestos) --image $< $@

--- a/rs/tests/common.bzl
+++ b/rs/tests/common.bzl
@@ -13,6 +13,8 @@ MAINNET_NNS_SUBNET_REVISION = mainnet_icos_versions["guestos"]["subnets"]["tdb26
 MAINNET_NNS_SUBNET_HASH = mainnet_icos_versions["guestos"]["subnets"]["tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe"]["update_img_hash"]
 MAINNET_APPLICATION_SUBNET_REVISION = mainnet_icos_versions["guestos"]["subnets"]["io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe"]["version"]
 MAINNET_APPLICATION_SUBNET_HASH = mainnet_icos_versions["guestos"]["subnets"]["io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe"]["update_img_hash"]
+MAINNET_LATEST_HOSTOS_REVISION = mainnet_icos_versions["hostos"]["latest_release"]["version"]
+MAINNET_LATEST_HOSTOS_HASH = mainnet_icos_versions["hostos"]["latest_release"]["update_img_hash"]
 
 MAINNET_ENV = {
     "MAINNET_NNS_SUBNET_REVISION_ENV": MAINNET_NNS_SUBNET_REVISION,

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -4,12 +4,11 @@ Rules for system-tests.
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@mainnet_icos_versions//:defs.bzl", "mainnet_icos_versions")
 load("@rules_oci//oci:defs.bzl", "oci_load")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//bazel:defs.bzl", "mcopy", "zstd_compress")
 load("//bazel:mainnet-icos-images.bzl", "base_download_url")
-load("//rs/tests:common.bzl", "MAINNET_NNS_CANISTER_ENV", "MAINNET_NNS_CANISTER_RUNTIME_DEPS", "MAINNET_NNS_SUBNET_HASH", "MAINNET_NNS_SUBNET_REVISION", "NNS_CANISTER_ENV", "NNS_CANISTER_RUNTIME_DEPS", "UNIVERSAL_VM_RUNTIME_DEPS")
+load("//rs/tests:common.bzl", "MAINNET_LATEST_HOSTOS_HASH", "MAINNET_LATEST_HOSTOS_REVISION", "MAINNET_NNS_CANISTER_ENV", "MAINNET_NNS_CANISTER_RUNTIME_DEPS", "MAINNET_NNS_SUBNET_HASH", "MAINNET_NNS_SUBNET_REVISION", "NNS_CANISTER_ENV", "NNS_CANISTER_RUNTIME_DEPS", "UNIVERSAL_VM_RUNTIME_DEPS")
 
 def _run_system_test(ctx):
     run_test_script_file = ctx.actions.declare_file(ctx.label.name + "/run-test.sh")
@@ -356,7 +355,7 @@ def system_test(
 
     if uses_setupos_mainnet_img:
         icos_images["ENV_DEPS__EMPTY_DISK_IMG"] = "//rs/tests/nested:empty-disk-img.tar.zst"
-        env["ENV_DEPS__SETUPOS_DISK_IMG_VERSION"] = mainnet_icos_versions["hostos"]["latest_release"]["version"]
+        env["ENV_DEPS__SETUPOS_DISK_IMG_VERSION"] = MAINNET_LATEST_HOSTOS_REVISION
         icos_images["ENV_DEPS__SETUPOS_DISK_IMG"] = "//ic-os/setupos:mainnet-test-img.tar.zst"
 
         _env_deps["ENV_DEPS__SETUPOS_BUILD_CONFIG"] = "//ic-os:dev-tools/build-setupos-config-image.sh"
@@ -371,10 +370,9 @@ def system_test(
         icos_images["ENV_DEPS__HOSTOS_UPDATE_IMG"] = "//ic-os/hostos/envs/dev:update-img-test.tar.zst"
 
     if uses_hostos_mainnet_update:
-        mainnet_hostos_version = mainnet_icos_versions["hostos"]["latest_release"]["version"]
-        env["ENV_DEPS__HOSTOS_UPDATE_IMG_VERSION"] = mainnet_hostos_version
-        env["ENV_DEPS__HOSTOS_UPDATE_IMG_URL"] = base_download_url(mainnet_hostos_version, "host-os", True, False) + "update-img.tar.zst"
-        env["ENV_DEPS__HOSTOS_UPDATE_IMG_HASH"] = mainnet_icos_versions["hostos"]["latest_release"]["update_img_hash"]
+        env["ENV_DEPS__HOSTOS_UPDATE_IMG_VERSION"] = MAINNET_LATEST_HOSTOS_REVISION
+        env["ENV_DEPS__HOSTOS_UPDATE_IMG_URL"] = base_download_url(MAINNET_LATEST_HOSTOS_REVISION, "host-os", True, False) + "update-img.tar.zst"
+        env["ENV_DEPS__HOSTOS_UPDATE_IMG_HASH"] = MAINNET_LATEST_HOSTOS_HASH
 
     if malicious:
         _guestos_malicous = "//ic-os/guestos/envs/dev-malicious:"


### PR DESCRIPTION
In a followup I realized [this note](https://github.com/dfinity/ic/blob/ada7e8fe4311b0aab4f21c502737bb1990dda9bb/rs/tests/system_tests.bzl#L324) was out of date. The GuestOS update images were based in the NNS version, and the disks in the "latest", so the two could be out of sync.

This syncs the two back up, and consolidates some variables.