### PR TITLE
fix: Fixup bootstrap permissions

### DIFF
--- a/ic-os/components/init/bootstrap-ic-node/bootstrap-ic-node.sh
+++ b/ic-os/components/init/bootstrap-ic-node/bootstrap-ic-node.sh
@@ -93,12 +93,22 @@ function process_bootstrap() {
         echo "Installing initial state"
         cp -rL -T "${TMPDIR}/ic_state" "${STATE_ROOT}/data/ic_state"
     fi
-    for ITEM in ic_registry_local_store nns_public_key.pem node_operator_private_key.pem; do
-        if [ -e "${TMPDIR}/${ITEM}" ]; then
-            echo "Setting up initial ${ITEM}"
-            cp -rL -T "${TMPDIR}/${ITEM}" "${STATE_ROOT}/data/${ITEM}"
-        fi
-    done
+    if [ -e "${TMPDIR}/ic_registry_local_store" ]; then
+        echo "Setting up initial ic_registry_local_store"
+        cp -rL -T "${TMPDIR}/ic_registry_local_store" "${STATE_ROOT}/data/ic_registry_local_store"
+    fi
+
+    if [ -e "${TMPDIR}/nns_public_key.pem" ]; then
+        echo "Setting up initial nns_public_key.pem"
+        cp -rL -T "${TMPDIR}/nns_public_key.pem" "${STATE_ROOT}/data/nns_public_key.pem"
+        chmod 444 "${STATE_ROOT}/data/nns_public_key.pem"
+    fi
+
+    if [ -e "${TMPDIR}/node_operator_private_key.pem" ]; then
+        echo "Setting up initial node_operator_private_key.pem"
+        cp -rL -T "${TMPDIR}/node_operator_private_key.pem" "${STATE_ROOT}/data/node_operator_private_key.pem"
+        chmod 400 "${STATE_ROOT}/data/node_operator_private_key.pem"
+    fi
 
     for DIR in accounts_ssh_authorized_keys; do
         if [ -e "${TMPDIR}/${DIR}" ]; then
@@ -108,6 +118,11 @@ function process_bootstrap() {
     done
 
     rm -rf "${TMPDIR}"
+
+    # Fix up permissions. Ideally this is specific to only what is copied. If
+    # we do make this change, we need to make sure `data` itself has the
+    # correct permissions.
+    chown ic-replica:nogroup -R "${STATE_ROOT}/data"
 
     # Synchronize the above cached writes to persistent storage
     # to make sure the system can boot successfully after a hard shutdown.
@@ -128,6 +143,7 @@ function process_config_json() {
     if [ -e "${TMPDIR}/config.json" ]; then
         echo "Setting up config.json"
         cp "${TMPDIR}/config.json" "${CONFIG_ROOT}/config.json"
+        chown ic-replica:nogroup "${CONFIG_ROOT}/config.json"
     fi
 
     rm -rf "${TMPDIR}"
@@ -182,27 +198,33 @@ while [ ! -f /boot/config/CONFIGURED ]; do
         fi
     fi
 
-    # Fix up permissions. This is actually the wrong place.
-    chown ic-replica:nogroup -R /var/lib/ic/data
-
     if [ "${DEV}" != "" ]; then
         umount /mnt
     fi
 done
 
 # Process config.json every boot (not just on first bootstrap)
+# Even if nothing can be mounted, just try and see if something usable
+# is there already -- this might be useful when operating this thing as a
+# docker container instead of full-blown VM.
 echo "Checking for config.json updates"
 DEV="$(find_config_devices)"
 if [ "${DEV}" != "" ]; then
     echo "Found CONFIG device at ${DEV}"
     mount -t vfat -o ro "${DEV}" /mnt
     process_config_json /mnt/ic-bootstrap.tar /boot/config
-    umount /mnt
-elif [ -e /mnt/ic-bootstrap.tar ]; then
+fi
+
+if [ -e /mnt/ic-bootstrap.tar ]; then
     echo "Processing config.json from pre-mounted bootstrap"
     process_config_json /mnt/ic-bootstrap.tar /boot/config
 fi
 
+if [ "${DEV}" != "" ]; then
+    umount /mnt
+fi
+
+# Write metric on use of node_operator_private_key
 node_operator_private_key_exists=0
 if [ -f "/var/lib/ic/data/node_operator_private_key.pem" ]; then
     node_operator_private_key_exists=1


### PR DESCRIPTION
New ✨:
```
root@guest-52220F4D8CD8:~# ls -lah /var/lib/ic/data/
total 12K
drwxr-xr-x. 9 ic-replica nogroup                  203 Jul 30 16:31 .
drwxr-xr-x. 5 root       root                    4.0K Jul 30 16:31 ..
drwxr-s---. 2 ic-replica nonconfidential            6 Jul 30 16:31 cups
drwxr-s---. 2 ic-replica ic-consensus-pool          6 Jul 30 16:31 ic_consensus_pool
drwxr-s---. 3 ic-replica ic-registry-local-store   24 Jul 30 16:31 ic_registry_local_store
drwxr-s---. 3 ic-replica nonconfidential           25 Jul 30 16:31 ic_state
drwxr-x--x. 2 ic-replica ic-replica                 6 Jul 30 16:31 images
-r--r--r--. 1 ic-replica nogroup                  240 Jul 30 16:31 nns_public_key.pem
-r--------. 1 ic-replica nogroup                  223 Jul 30 16:31 node_operator_private_key.pem
drwxr-s---. 2 ic-replica nonconfidential            6 Jul 30 16:31 orchestrator
drwxr-s---. 2 admin      nonconfidential            6 Jul 30 16:31 recovery
```