### PR TITLE
fix: Log sender reply callback instead of request ID

### DIFF
--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -563,7 +563,7 @@ impl ExecutionEnvironment {
 
                             info!(
                                 self.log,
-                                "Canister Http request with payload_size {}, max_response_size {}, subnet_size {}, request_id {}, process_id {}",
+                                "Canister Http request with payload_size {}, max_response_size {}, subnet_size {}, reply_callback_id {}, process_id {}",
                                 response.payload_size_bytes().get(),
                                 max_response_size,
                                 registry_settings.subnet_size,

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -563,11 +563,12 @@ impl ExecutionEnvironment {
 
                             info!(
                                 self.log,
-                                "Canister Http request with payload_size {}, max_response_size {}, subnet_size {}, reply_callback_id {}, process_id {}",
+                                "Canister Http request with payload_size {}, max_response_size {}, subnet_size {}, reply_callback_id {}, sender {}, process_id {}",
                                 response.payload_size_bytes().get(),
                                 max_response_size,
                                 registry_settings.subnet_size,
                                 context.request.sender_reply_callback,
+                                context.request.sender,
                                 std::process::id(),
                             );
                         }

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -143,6 +143,7 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                         request:
                             Request {
                                 sender: request_sender,
+                                sender_reply_callback: reply_callback_id,
                                 ..
                             },
                         url: request_url,
@@ -201,11 +202,11 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
 
                     info!(
                         log,
-                        "Received canister http response from adapter: request_size: {}, response_time {}, downloaded_bytes {}, request_id {}, process_id: {}",
+                        "Received canister http response from adapter: request_size: {}, response_time {}, downloaded_bytes {}, reply_callback_id {}, process_id: {}",
                         request_size,
                         adapter_req_timer.elapsed().as_millis(),
                         body.len() + headers_size,
-                        request_id,
+                        reply_callback_id,
                         std::process::id(),
                     );
 

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -202,11 +202,12 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
 
                     info!(
                         log,
-                        "Received canister http response from adapter: request_size: {}, response_time {}, downloaded_bytes {}, reply_callback_id {}, process_id: {}",
+                        "Received canister http response from adapter: request_size: {}, response_time {}, downloaded_bytes {}, reply_callback_id {}, sender {}, process_id: {}",
                         request_size,
                         adapter_req_timer.elapsed().as_millis(),
                         body.len() + headers_size,
                         reply_callback_id,
+                        request_sender,
                         std::process::id(),
                     );
 


### PR DESCRIPTION
There are two log lines which need to be "linked" via an ID corresponding to the request.

However one of them logs the callback ID corresponding to the canister call, while the other logs the ID corresponding to the request from the management canister. (which is updated [here](https://github.com/dfinity/ic/blob/e9f4cf612cb649099c2b37f97e761b3362e39cbb/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs#L244)).

Those IDs are pretty much always corresponding to different requests.