### PR TITLE
chore: using absolute time to determine kibana links

### DIFF
--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -27,6 +27,7 @@ use crate::driver::{
 };
 use crate::k8s::tnet::TNet;
 use crate::util::block_on;
+use chrono::Utc;
 use walkdir::WalkDir;
 
 use serde::{Deserialize, Serialize};
@@ -545,6 +546,7 @@ impl SystemTestGroup {
 
     fn make_plan(self, rh: &Handle, group_ctx: GroupContext) -> Result<Plan<Box<dyn Task>>> {
         debug!(group_ctx.log(), "SystemTestGroup.make_plan");
+        let start_time = Utc::now();
 
         let mut compose_ctx = ComposeContext {
             rh,
@@ -689,7 +691,7 @@ impl SystemTestGroup {
                         std::thread::sleep(KEEPALIVE_INTERVAL);
                     }
 
-                    let mut vector_vm = VectorVm::new();
+                    let mut vector_vm = VectorVm::new().with_start_time(start_time);
                     vector_vm.start(&env).expect("Failed to start Vector VM");
 
                     loop {

--- a/rs/tests/driver/src/driver/vector_vm.rs
+++ b/rs/tests/driver/src/driver/vector_vm.rs
@@ -280,11 +280,18 @@ fn emit_kibana_url_event(log: &slog::Logger, network_name: &str) {
         url: String,
     }
 
+    let now = chrono::Utc::now();
+
+    let before = now - chrono::Duration::hours(1);
+    let after = now + chrono::Duration::hours(4);
+
+    let fmt = |dt: chrono::DateTime<chrono::Utc>| dt.format("'%Y-%m-%dT%H:%M:%S%.3fZ'").to_string();
+
     let event = LogEvent::new(
         "kibana_url_created_new_event".to_string(),
         KibanaUrl {
             message: "Pulled replica logs will appear in Kibana".to_string(),
-            url: format!("https://kibana.testnet.dfinity.network/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-5h,to:now%2B5h))&_a=(columns:!(MESSAGE,ic_subnet,ic_node),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:ic,index:testnet-vector-push,key:ic,negate:!f,params:(query:{network_name}),type:phrase),query:(match_phrase:(ic:{network_name})))),hideChart:!f,index:testnet-vector-push,interval:auto,query:(language:kuery,query:''),sort:!(!(timestamp,desc)))")
+            url: format!("https://kibana.testnet.dfinity.network/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:{},to:{}))&_a=(columns:!(MESSAGE,ic_subnet,ic_node),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:ic,index:testnet-vector-push,key:ic,negate:!f,params:(query:{network_name}),type:phrase),query:(match_phrase:(ic:{network_name})))),hideChart:!f,index:testnet-vector-push,interval:auto,query:(language:kuery,query:''),sort:!(!(timestamp,desc)))", fmt(before), fmt(after))
         }
     );
 


### PR DESCRIPTION
We used to create relative links, which if shared and viewed at a later time, may not show the logs at all. This change uses absolute times and produces links like the following:
```bash
https://kibana.testnet.dfinity.network/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:'2025-07-30T22:53:05.332Z',to:now))&_a=(columns:!(MESSAGE,ic_subnet,ic_node),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,field:ic,index:testnet-vector-push,key:ic,negate:!f,params:(query:small--1753915985067),type:phrase),query:(match_phrase:(ic:small--1753915985067)))),hideChart:!f,index:testnet-vector-push,interval:auto,query:(language:kuery,query:''),sort:!(!(timestamp,desc)))
```