### PR TITLE
feat: Improvements to the linux_kernel_command_line lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16676,7 +16676,7 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 name = "linux_kernel_command_line"
 version = "0.9.0"
 dependencies = [
-    "regex",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16675,6 +16675,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 [[package]]
 name = "linux_kernel_command_line"
 version = "0.9.0"
+dependencies = [
+    "regex",
+]
 
 [[package]]
 name = "litemap"

--- a/rs/ic_os/dev_test_tools/setupos-disable-checks/src/main.rs
+++ b/rs/ic_os/dev_test_tools/setupos-disable-checks/src/main.rs
@@ -1,11 +1,11 @@
-use std::fs::Permissions;
-use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
-
 use anyhow::{Context, Error};
 use clap::Parser;
 use linux_kernel_command_line::{ImproperlyQuotedValue, KernelCommandLine};
 use regex::Regex;
+use std::fs::Permissions;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use tempfile::NamedTempFile;
 use tokio::fs;
 
@@ -48,7 +48,7 @@ fn munge(
             (
                 wholematch.start(),
                 prevmatch.as_str().to_string(),
-                KernelCommandLine::try_from(thematch.as_str().trim().trim_matches('"'))?,
+                KernelCommandLine::from_str(thematch.as_str().trim().trim_matches('"'))?,
                 postmatch.as_str().to_string(),
                 wholematch.end(),
             )

--- a/rs/ic_os/linux_kernel_command_line/BUILD.bazel
+++ b/rs/ic_os/linux_kernel_command_line/BUILD.bazel
@@ -4,6 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
+    "@crate_index//:regex",
 ]
 
 MACRO_DEPENDENCIES = [

--- a/rs/ic_os/linux_kernel_command_line/Cargo.toml
+++ b/rs/ic_os/linux_kernel_command_line/Cargo.toml
@@ -8,4 +8,4 @@ edition.workspace = true
 documentation.workspace = true
 
 [dependencies]
-regex = "1.11.1"
+regex = { workspace = true }

--- a/rs/ic_os/linux_kernel_command_line/Cargo.toml
+++ b/rs/ic_os/linux_kernel_command_line/Cargo.toml
@@ -8,3 +8,4 @@ edition.workspace = true
 documentation.workspace = true
 
 [dependencies]
+regex = "1.11.1"

--- a/rs/ic_os/linux_kernel_command_line/src/lib.rs
+++ b/rs/ic_os/linux_kernel_command_line/src/lib.rs
@@ -118,7 +118,8 @@ impl KernelCommandLine {
         Ok(())
     }
 
-    /// Returns the value of an argument if present in the command line.
+    /// Returns the value of an argument (without leading/trailing quotes) if present in the
+    /// command line.
     /// If the argument exists without a value, returns Some("").
     /// If the argument doesn't exist, returns None.
     pub fn get_argument(&self, argument_name: &str) -> Option<&str> {

--- a/rs/ic_os/linux_kernel_command_line/src/lib.rs
+++ b/rs/ic_os/linux_kernel_command_line/src/lib.rs
@@ -1,6 +1,9 @@
+use regex::Regex;
 /// Utilities to manipulate a kernel command line reliably.
 use std::error::Error as StdError;
 use std::fmt;
+use std::str::FromStr;
+use std::sync::LazyLock;
 
 #[derive(Debug)]
 /// A kernel command line with improperly-quoted argument values.
@@ -114,6 +117,31 @@ impl KernelCommandLine {
         self.tokenized_arguments.push(to_add);
         Ok(())
     }
+
+    /// Returns the value of an argument if present in the command line.
+    /// If the argument exists without a value, returns Some("").
+    /// If the argument doesn't exist, returns None.
+    pub fn get_argument(&self, argument_name: &str) -> Option<&str> {
+        static REGEX: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r#"^(?<key>.+)=('(?<value1>.+)'|"(?<value2>.+)"|(?<value3>.+))$"#).unwrap()
+        });
+
+        self.tokenized_arguments.iter().find_map(|arg| {
+            if *arg == argument_name {
+                Some("")
+            } else {
+                REGEX.captures(arg).and_then(|caps| {
+                    (caps.name("key").unwrap().as_str() == argument_name).then_some(
+                        caps.name("value1")
+                            .or(caps.name("value2"))
+                            .or(caps.name("value3"))
+                            .unwrap()
+                            .as_str(),
+                    )
+                })
+            }
+        })
+    }
 }
 
 impl From<KernelCommandLine> for String {
@@ -122,10 +150,10 @@ impl From<KernelCommandLine> for String {
     }
 }
 
-impl TryFrom<&str> for KernelCommandLine {
-    type Error = ImproperlyQuotedValue;
+impl FromStr for KernelCommandLine {
+    type Err = ImproperlyQuotedValue;
 
-    fn try_from(cmdline: &str) -> Result<Self, ImproperlyQuotedValue> {
+    fn from_str(cmdline: &str) -> Result<Self, ImproperlyQuotedValue> {
         let mut res: Vec<String> = vec![];
         let mut curr: String = "".into();
         let mut is_quoted = false;
@@ -170,6 +198,7 @@ impl TryFrom<&str> for KernelCommandLine {
 #[cfg(test)]
 mod tests {
     use crate::KernelCommandLine;
+    use std::str::FromStr;
 
     #[test]
     fn test_remove_argument() {
@@ -248,7 +277,7 @@ mod tests {
             ),
         ];
         for (name, input, argument_to_remove, expected) in table.iter() {
-            let mut cmdline = KernelCommandLine::try_from(*input).unwrap();
+            let mut cmdline = KernelCommandLine::from_str(*input).unwrap();
             cmdline.remove_argument(argument_to_remove);
             let result: String = cmdline.into();
             if result != *expected {
@@ -280,7 +309,7 @@ actual:   {result:?}",
             ),
         ];
         for (name, input) in table.iter() {
-            if KernelCommandLine::try_from(*input).is_ok() {
+            if KernelCommandLine::from_str(*input).is_ok() {
                 panic!(
                     "During test {name}: input {input:?} intentionally misquoted argument did not trigger error",
                 )
@@ -335,7 +364,7 @@ actual:   {result:?}",
             ),
         ];
         for (test_name, input, argument, value, expected) in table.into_iter() {
-            let mut cmdline = KernelCommandLine::try_from(input).unwrap();
+            let mut cmdline = KernelCommandLine::from_str(input).unwrap();
             cmdline.ensure_single_argument(argument, value).unwrap();
             let result: String = cmdline.into();
             if result != *expected {
@@ -352,6 +381,64 @@ Actual:
 "
                 );
             }
+        }
+    }
+
+    #[test]
+    fn test_get_argument() {
+        let table = [
+            (
+                "get existing argument without value",
+                "rd.debug rd.initrd=/bin/bash",
+                "rd.debug",
+                Some(""),
+            ),
+            (
+                "get existing argument with value",
+                "rd.debug rd.initrd=/bin/bash",
+                "rd.initrd",
+                Some("/bin/bash"),
+            ),
+            (
+                "get existing argument with value",
+                "repeating=ab repeating=cd repeating=ef",
+                "repeating",
+                Some("ab"),
+            ),
+            (
+                "get existing argument with quoted value",
+                "rd.debug rd.initrd=\"/bin/bash with spaces\"",
+                "rd.initrd",
+                Some("/bin/bash with spaces"),
+            ),
+            (
+                "get non-existent argument",
+                "rd.debug rd.initrd=/bin/bash",
+                "nonexistent",
+                None,
+            ),
+            (
+                "get argument that is substring of another",
+                "rd.debug rd.debuglevel=1",
+                "rd.debug",
+                Some(""),
+            ),
+            (
+                "get argument including ' character",
+                "rd.debug rd.debuglevel=\"'quoted'\"",
+                "rd.debuglevel",
+                Some("'quoted'"),
+            ),
+        ];
+
+        for (test_name, input, argument, expected) in table.iter() {
+            let cmdline = KernelCommandLine::from_str(input).unwrap();
+            let result = cmdline.get_argument(argument);
+            assert_eq!(
+                result, *expected,
+                "Test '{test_name}' failed:\nInput: {input}\nArgument: {argument}\n\
+                Expected: {expected:?}\nGot: {result:?}",
+            );
         }
     }
 }

--- a/rs/ic_os/linux_kernel_command_line/src/lib.rs
+++ b/rs/ic_os/linux_kernel_command_line/src/lib.rs
@@ -277,7 +277,7 @@ mod tests {
             ),
         ];
         for (name, input, argument_to_remove, expected) in table.iter() {
-            let mut cmdline = KernelCommandLine::from_str(*input).unwrap();
+            let mut cmdline = KernelCommandLine::from_str(input).unwrap();
             cmdline.remove_argument(argument_to_remove);
             let result: String = cmdline.into();
             if result != *expected {
@@ -309,7 +309,7 @@ actual:   {result:?}",
             ),
         ];
         for (name, input) in table.iter() {
-            if KernelCommandLine::from_str(*input).is_ok() {
+            if KernelCommandLine::from_str(input).is_ok() {
                 panic!(
                     "During test {name}: input {input:?} intentionally misquoted argument did not trigger error",
                 )


### PR DESCRIPTION
- Add new `get_argument` method
- Replace `TryFrom` with `FromStr` which is a more idiomatic choice for parsing