### PR TITLE
chore: Increase total test timeout for `xnet_compatibility` test

### DIFF
--- a/rs/tests/message_routing/xnet/xnet_compatibility.rs
+++ b/rs/tests/message_routing/xnet/xnet_compatibility.rs
@@ -45,7 +45,7 @@ use slog::{info, Logger};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-const PER_TASK_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const PER_TASK_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const OVERALL_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 
 const DKG_INTERVAL: u64 = 9;


### PR DESCRIPTION
Currently, this test tends to be rather flaky. A major contributing factor is the need to perform both an upgrade and a downgrade of the guestOS version, requiring potentially long downloads of the respective images. Depending on which servers the file downloads resolve to, this can result in long transatlantic transfers - this is the case for the recent peak shown in the plot below, which displays download times from recent test runs. Similar peaks have been observed in the past, and in general there is a high discrepancy between the median and worst-case download times, as can also be noted from the same plot.

Internally, individual downloads are already limited to 600 seconds, but the test requires more than that to complete both downloads, perform the upgrade and downgrade, and run the remaining test logic.

As a first step toward getting a better signal from this test, this change bumps the total test timeout from 600 to 900 seconds.

<img width="3128" height="900" alt="image" src="https://github.com/user-attachments/assets/5a9e050d-e318-4c77-88dd-49fa02d51da3" />