### PR TITLE
Create retry_with_msg_async_quiet

### DIFF
--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -148,7 +148,7 @@ use crate::{
         tnet::TNet,
         virtualmachine::{destroy_vm, restart_vm, start_vm},
     },
-    retry_with_msg, retry_with_msg_async,
+    retry_with_msg, retry_with_msg_async, retry_with_msg_async_quiet,
     util::{block_on, create_agent},
 };
 use anyhow::{anyhow, bail, Context, Result};
@@ -647,7 +647,7 @@ impl TopologySnapshot {
     ) -> Result<TopologySnapshot> {
         let mut latest_version = self.local_registry.get_latest_version();
         if min_version > latest_version {
-            latest_version = retry_with_msg_async!(
+            latest_version = retry_with_msg_async_quiet!(
                 format!(
                     "check if latest registry version >= {}",
                     min_version.to_string()
@@ -695,7 +695,7 @@ impl TopologySnapshot {
         let backoff = Duration::from_secs(2);
         let prev_version: Arc<TokioMutex<RegistryVersion>> =
             Arc::new(TokioMutex::new(self.local_registry.get_latest_version()));
-        let version = retry_with_msg_async!(
+        let version = retry_with_msg_async_quiet!(
             "block_for_newest_mainnet_registry_version",
             &self.env.logger(),
             duration,
@@ -2140,6 +2140,20 @@ macro_rules! retry_with_msg_async {
     };
 }
 
+/// This is a quieter version of retry_with_msg_async that only logs the initial attempt and final result, not every intermediate failure.
+#[macro_export]
+macro_rules! retry_with_msg_async_quiet {
+    ($msg:expr, $log:expr, $timeout:expr, $backoff:expr, $f:expr) => {
+        $crate::driver::test_env_api::retry_async_quiet(
+            format!("{} [{}:{}]", $msg, file!(), line!()),
+            $log,
+            $timeout,
+            $backoff,
+            $f,
+        )
+    };
+}
+
 pub async fn retry_async<S: AsRef<str>, F, Fut, R>(
     msg: S,
     log: &slog::Logger,
@@ -2180,6 +2194,55 @@ where
                     log,
                     "Func=\"{msg}\" failed on attempt {attempt}. Error: {}",
                     trunc_error(err_msg)
+                );
+                tokio::time::sleep(backoff).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+/// A quieter version of `retry_async` that only logs the initial attempt and final result.
+/// This reduces log noise when there are many retry attempts.
+pub async fn retry_async_quiet<S: AsRef<str>, F, Fut, R>(
+    msg: S,
+    log: &slog::Logger,
+    timeout: Duration,
+    backoff: Duration,
+    f: F,
+) -> Result<R>
+where
+    Fut: Future<Output = Result<R>>,
+    F: Fn() -> Fut,
+{
+    let msg = msg.as_ref();
+    let mut attempt = 1;
+    let start = Instant::now();
+    debug!(
+        log,
+        "Func=\"{msg}\" is being retried for the maximum of {timeout:?} with a constant backoff of {backoff:?}"
+    );
+    loop {
+        match f().await {
+            Ok(v) => {
+                debug!(
+                    log,
+                    "Func=\"{msg}\" succeeded after {:?} on attempt {attempt}",
+                    start.elapsed()
+                );
+                break Ok(v);
+            }
+            Err(err) => {
+                let err_msg = format!("{:?}", err);
+                if start.elapsed() > timeout {
+                    break Err(err.context(format!(
+                        "Func=\"{msg}\" timed out after {:?} on attempt {attempt}. \n Last error: {err_msg}",
+                        start.elapsed(),
+                    )));
+                }
+                debug!(
+                    log,
+                    "Func=\"{msg}\" failed on attempt {attempt}",
                 );
                 tokio::time::sleep(backoff).await;
                 attempt += 1;

--- a/rs/tests/nested/src/util.rs
+++ b/rs/tests/nested/src/util.rs
@@ -29,7 +29,7 @@ use ic_system_test_driver::{
         submit_update_nodes_hostos_version_proposal,
         submit_update_unassigned_node_version_proposal, vote_execute_proposal_assert_executed,
     },
-    retry_with_msg_async,
+    retry_with_msg_async_quiet,
     util::runtime_from_url,
 };
 use ic_types::{hostos_version::HostosVersion, NodeId, ReplicaVersion};
@@ -313,7 +313,7 @@ pub async fn wait_for_guest_version(
     timeout: Duration,
     backoff: Duration,
 ) -> Result<String> {
-    retry_with_msg_async!(
+    retry_with_msg_async_quiet!(
         "Waiting until the guest returns a version",
         logger,
         timeout,
@@ -323,10 +323,10 @@ pub async fn wait_for_guest_version(
                 .await
                 .unwrap_or("unavailable".to_string());
             if current_version != "unavailable" {
-                info!(logger, "Guest reported version '{}'", current_version);
+                info!(logger, "SUCCESS: Guest reported version '{}'", current_version);
                 Ok(current_version)
             } else {
-                bail!("Guest version is still unavailable")
+                bail!("FAIL: Guest version is still unavailable")
             }
         }
     )
@@ -342,7 +342,7 @@ pub async fn wait_for_expected_guest_version(
     timeout: Duration,
     backoff: Duration,
 ) -> Result<()> {
-    retry_with_msg_async!(
+    retry_with_msg_async_quiet!(
         format!(
             "Waiting until the guest is on the expected version '{}'",
             expected_version
@@ -357,11 +357,11 @@ pub async fn wait_for_expected_guest_version(
             if current_version == expected_version {
                 info!(
                     logger,
-                    "Guest is now on expected version '{}'", current_version
+                    "SUCCESS: Guest is now on expected version '{}'", current_version
                 );
                 Ok(())
             } else {
-                bail!("Guest is still on version '{}'", current_version)
+                bail!("FAIL: Guest is still on version '{}'", current_version)
             }
         }
     )


### PR DESCRIPTION
retry_with_msg_async_quiet greatly reduces logging noise for retries that are expected to fail a lot


Example: 
`2025-07-31 08:39:04.454 DEBG[nested::upgrade_guestos:rs/tests/driver/src/driver/test_env_api.rs:2179:0] Func="Waiting until the guest is on the expected version '0000000000000000000000000000000000000000' [rs/tests/nested/src/util.rs:345]" failed on attempt 20. Error: Guest is still on version '143a635e2af0f574e1ea0f795f8754dfbd86c0c0'\n \n Stack backtrace:\n    0: anyhow::error::<impl anyhow::Error>::msg\n    1: nested::util::wait_for_expected_guest_version::{{clo...`
—>
`2025-07-31 08:39:04.454 DEBG[nested::upgrade_guestos:rs/tests/driver/src/driver/test_env_api.rs:2179:0] Func="Waiting until the guest is on the expected version '0000000000000000000000000000000000000000' [rs/tests/nested/src/util.rs:345]" failed on attempt 20`


`2025-07-31 09:52:59.890 DEBG[nested::upgrade_guestos:rs/tests/driver/src/driver/test_env_api.rs:2195:0] Func="check if latest registry version >= 2 [rs/tests/driver/src/driver/test_env_api.rs:650]" failed on attempt 70. Error: latest_version: 1, expected minimum version: 2\n \n Stack backtrace:\n    0: anyhow::error::<impl anyhow::Error>::msg\n    1: ic_system_test_driver::driver::test_env_api::retry_async::{{closure}}\n   ...
`—>
`2025-07-31 09:52:59.890 DEBG[nested::upgrade_guestos:rs/tests/driver/src/driver/test_env_api.rs:2195:0] Func="check if latest registry version >= 2 [rs/tests/driver/src/driver/test_env_api.rs:650]" failed on attempt 70
`