### PR TITLE
chore: Bump glibc version to 2.31

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -881,7 +881,7 @@ use_repo(toolchains, "zig_sdk")
 
 register_toolchains(
     # Linux toolchains
-    "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
+    "@zig_sdk//toolchain:linux_amd64_gnu.2.31",
 
     # macOS toolchains
     # Do not use hermetic toolchains for macOS until we have had a chance to


### PR DESCRIPTION
This version was shipped with Ubuntu 20.04.