### PR TITLE
refactor(node): guestos-recovery-engine permission setting

### DIFF
--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
@@ -82,7 +82,7 @@ perform_recovery() {
 
     echo "Preparing recovery artifacts..."
     REGISTRY_PERMS=$(sudo stat -c '%a' /var/lib/ic/data/ic_registry_local_store)
-    CUP_PERMS=$(sudo stat -c '%a' /var/lib/ic/data/cups)
+    CUP_PERMS=$(sudo stat -c '%a' /var/lib/ic/data/cups/cup.types.v1.CatchUpPackage.pb)
 
     mkdir ic_registry_local_store
     tar -xf "ic_registry_local_store.tar.zst" -C ic_registry_local_store

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh
@@ -81,21 +81,19 @@ perform_recovery() {
     tar -xf "recovery.tar.zst"
 
     echo "Preparing recovery artifacts..."
-    TARGET_PERMS=$(sudo stat -c '%a' /var/lib/ic/data/ic_registry_local_store)
+    REGISTRY_PERMS=$(sudo stat -c '%a' /var/lib/ic/data/ic_registry_local_store)
+    CUP_PERMS=$(sudo stat -c '%a' /var/lib/ic/data/cups)
 
     mkdir ic_registry_local_store
     tar -xf "ic_registry_local_store.tar.zst" -C ic_registry_local_store
 
-    OWNER_UID=$(sudo stat -c '%u' /var/lib/ic/data/cups)
-    GROUP_UID=$(sudo stat -c '%g' /var/lib/ic/data/cups)
-    sudo chown -R "$OWNER_UID:$GROUP_UID" "cup.proto"
-
     echo "Applying recovery artifacts..."
     echo "Syncing ic_registry_local_store to target location..."
     sudo rsync -a --delete ic_registry_local_store/ /var/lib/ic/data/ic_registry_local_store/
-    sudo chmod "$TARGET_PERMS" /var/lib/ic/data/ic_registry_local_store
+    sudo chmod "$REGISTRY_PERMS" /var/lib/ic/data/ic_registry_local_store
     echo "Copying cup.proto to target location..."
     sudo cp "cup.proto" /var/lib/ic/data/cups/cup.types.v1.CatchUpPackage.pb
+    sudo chmod "$CUP_PERMS" /var/lib/ic/data/cups/cup.types.v1.CatchUpPackage.pb
 
     echo "Recovery artifacts applied successfully"
 


### PR DESCRIPTION
It's cleaner to have the same processing for the CUP and the local store, i.e. both calling `stat -c '%a' ...` and `chmod` afterwards, instead of `stat -c '%u' /stat -c '%g'` for local store and `chown` for the CUP