### PR TITLE
fix: ensure /boot/grub/grubenv is always synced after writing

### DIFF
--- a/ic-os/components/upgrade/grub.sh
+++ b/ic-os/components/upgrade/grub.sh
@@ -48,5 +48,6 @@ write_grubenv() {
     # Truncate to arrive at precisely 1024 bytes
     truncate --size=1024 "${TMP_FILE}"
     cat "${TMP_FILE}" >"${GRUBENV_FILE}"
+    sync "${GRUBENV_FILE}"
     rm "${TMP_FILE}"
 }

--- a/ic-os/components/upgrade/manageboot/manageboot.sh
+++ b/ic-os/components/upgrade/manageboot/manageboot.sh
@@ -279,7 +279,6 @@ case "${ACTION}" in
             "gauge"
 
         write_log "${SYSTEM_TYPE} upgrade rebooting now, next slot ${TARGET_ALTERNATIVE}"
-        sync
         # Ignore termination signals from the following reboot, so that
         # the script exits without error.
         trap -- '' SIGTERM


### PR DESCRIPTION
`manageboot.sh confirm` does not synchronise the updated `/boot/grub/grubenv` to disk in all cases. This means that if a node is killed after `manageboot.sh confirm` it will boot to the previous version. This is causing massive flakiness in all system-tests that perform upgrades (like the `//rs/tests/consensus/upgrade:...` tests).

This is fixed by calling `sync` in `write_grubenv` right after writing `/boot/grub/grubenv`.
Since we now sync there we can remove the sync in `manageboot.sh upgrade-commit`.