### PR TITLE
fix: colocate api_bn_update_workload_test to reduce flakiness

### DIFF
--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -25,6 +25,7 @@ system_test_nns(
 system_test_nns(
     name = "api_bn_update_workload_test",
     tags = [
+        "experimental_system_test_colocation",
         "long_test",
     ],
     test_timeout = "long",


### PR DESCRIPTION
The `//rs/tests/boundary_nodes:api_bn_update_workload_test` has a high flakiness rate of almost 5%. This test is the only test that uses the [`ic_networking_subnet_update_workload`](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/tests/networking/subnet_update_workload/src/lib.rs?L121) framework which is not colocated. For any test generating load from the test-driver to the testnet it's important the test-driver is colocated with the testnet to reduce the chance of cross DC traffic.