### PR TITLE
feat: [MR-670] Bump certification version

### DIFF
--- a/rs/canonical_state/certification_version/src/lib.rs
+++ b/rs/canonical_state/certification_version/src/lib.rs
@@ -44,7 +44,7 @@ impl std::convert::TryFrom<u32> for CertificationVersion {
 
 /// The Canonical State certification version that should be used for newly
 /// computed states.
-pub const CURRENT_CERTIFICATION_VERSION: CertificationVersion = CertificationVersion::V20;
+pub const CURRENT_CERTIFICATION_VERSION: CertificationVersion = CertificationVersion::V21;
 
 /// Minimum supported certification version.
 ///

--- a/rs/http_endpoints/public/src/read_state/canister.rs
+++ b/rs/http_endpoints/public/src/read_state/canister.rs
@@ -289,6 +289,7 @@ fn verify_paths(
             | [b"subnet", _subnet_id, b"public_key" | b"canister_ranges" | b"node"] => {}
             [b"subnet", _subnet_id, b"node", _node_id]
             | [b"subnet", _subnet_id, b"node", _node_id, b"public_key"] => {}
+            [b"canister_ranges", _subnet_id] => {}
             [b"request_status", request_id]
             | [b"request_status", request_id, b"status" | b"reply" | b"reject_code" | b"reject_message" | b"error_code"] =>
             {
@@ -548,7 +549,8 @@ mod test {
                         Label::from("request_status"),
                         [0; 32].into(),
                         Label::from("reply")
-                    ])
+                    ]),
+                    Path::new(vec![Label::from("canister_ranges"), [0; 32].into(),])
                 ],
                 &CanisterIdSet::all(),
                 canister_test_id(1).get(),

--- a/rs/http_endpoints/public/src/read_state/subnet.rs
+++ b/rs/http_endpoints/public/src/read_state/subnet.rs
@@ -193,6 +193,7 @@ fn verify_paths(paths: &[Path], effective_principal_id: PrincipalId) -> Result<(
             | [b"subnet", _subnet_id, b"public_key" | b"canister_ranges" | b"node"] => {}
             [b"subnet", _subnet_id, b"node", _node_id]
             | [b"subnet", _subnet_id, b"node", _node_id, b"public_key"] => {}
+            [b"canister_ranges", _subnet_id] => {}
             [b"subnet", subnet_id, b"metrics"] => {
                 let principal_id = parse_principal_id(subnet_id)?;
                 verify_principal_ids(&principal_id, &effective_principal_id)?;
@@ -249,6 +250,10 @@ mod test {
                         ByteBuf::from(subnet_test_id(1).get().to_vec()).into(),
                         Label::from("metrics")
                     ]),
+                    Path::new(vec![
+                        Label::from("canister_ranges"),
+                        ByteBuf::from(subnet_test_id(1).get().to_vec()).into(),
+                    ]),
                 ],
                 subnet_test_id(1).get(),
             ),
@@ -284,6 +289,16 @@ mod test {
                     ByteBuf::from(canister_test_id(1).get().to_vec()).into(),
                     Label::from("module_hash")
                 ])
+            ],
+            subnet_test_id(1).get(),
+        )
+        .is_err());
+
+        assert!(verify_paths(
+            &[
+                Path::new(vec![
+                    Label::from("canister_ranges"),
+                ]),
             ],
             subnet_test_id(1).get(),
         )


### PR DESCRIPTION
This commit bumps the current certification version to V21. V21 introduces a new format to represent the routing table in the state tree and was previously implemented in commit 7a809c0.

In addition, this PR also whitelists the new paths for calls to `api/v2/canister/*/read_state` and `api/v2/subnet/*/read_state`.

This commit is part of the larger canister migration feature and particularly the effort to expose the routing table in delegations in a more scalable way.