### PR TITLE
test(node): Upload setupOS dev images to s3 bucket

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -166,6 +166,7 @@ upload_artifacts(
             "//ic-os/guestos/envs/prod:bundle-update",
             "//ic-os/hostos/envs/prod:bundle-update",
             "//ic-os/setupos/envs/prod:bundle",
+            "//ic-os/setupos/envs/dev:bundle",  # used by {guest,host}os_upgrade_from_latest_release_to_current nested tests
         ],
     }),
     visibility = ["//visibility:public"],

--- a/ic-os/setupos/envs/dev/BUILD.bazel
+++ b/ic-os/setupos/envs/dev/BUILD.bazel
@@ -1,6 +1,7 @@
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/dev-tools/bare_metal_deployment:tools.bzl", "launch_bare_metal")
 load("//ic-os/setupos:defs.bzl", "image_deps")
+load("//publish:defs.bzl", "artifact_bundle")
 
 # The macro contains several targets.
 # Check
@@ -20,4 +21,14 @@ icos_build(
 launch_bare_metal(
     name = "launch_bare_metal",
     image_zst_file = ":disk-img.tar.zst",
+)
+
+# Export checksums & build artifacts
+# (image is used for {guest,host}os_upgrade_from_latest_release_to_current nested tests)
+artifact_bundle(
+    name = "bundle",
+    testonly = True,
+    inputs = [":dev"],
+    prefix = "setup-os/disk-img-dev",
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
[NODE-1656](https://dfinity.atlassian.net/browse/NODE-1656)

This change is driven by the desire to restrict overriding the nns_public_key.pem to dev images: [feat(node): Hard code NNS private key to guestos image, allow dev override by andrewbattat · Pull Request #6094 · dfinity/ic](https://github.com/dfinity/ic/pull/6094#discussion_r2251391602)

The above PR would break the latest_release tests ({guest,host}os_upgrade_from_latest_release_to_current) because the latest_release tests use the prod image from uses_setupos_mainnet_img and [configure it with a test NNS public key at runtime](https://github.com/dfinity/ic/blob/233b0ce1b73a0bfc9746bd655f395a2f761f9d60/rs/tests/nested/src/util.rs#L247).

To solve this, we will have to convert the latest_release tests to use dev images, and to do this, we need to start uploading dev setupOS images.

---------

But also, it would be nice to start using dev images for these tests regardless. I've had a pair of cases where I was debugging a broken latest_release test, and I couldn't access the console to see the failure, so I just had to read the code until I had a theory of what was wrong, make the change, and rerun the test.