### PR TITLE
chore: CON-1547 Use the full pre-signature to determine "oldest registry version in use"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7742,6 +7742,7 @@ dependencies = [
  "ic-registry-client-helpers",
  "ic-replicated-state",
  "ic-test-utilities",
+ "ic-test-utilities-consensus",
  "ic-test-utilities-registry",
  "ic-test-utilities-state",
  "ic-test-utilities-time",

--- a/rs/consensus/src/consensus/catchup_package_maker.rs
+++ b/rs/consensus/src/consensus/catchup_package_maker.rs
@@ -209,7 +209,7 @@ impl CatchUpPackageMaker {
             }
             Ok(state_hash) => {
                 let summary = start_block.payload.as_ref().as_summary();
-                let registry_version = if let Some(idkg) = summary.idkg.as_ref() {
+                let registry_version = if summary.idkg.is_some() {
                     // Should succeed as we already got the hash above
                     let state = self
                         .state_manager
@@ -224,7 +224,7 @@ impl CatchUpPackageMaker {
                             )
                         })
                         .ok()?;
-                    get_oldest_idkg_state_registry_version(idkg, state.get_ref())
+                    get_oldest_idkg_state_registry_version(state.get_ref())
                 } else {
                     None
                 };
@@ -274,15 +274,15 @@ mod tests {
     use ic_logger::replica_logger::no_op_logger;
     use ic_test_utilities::message_routing::FakeMessageRouting;
     use ic_test_utilities_consensus::idkg::{
-        add_available_quadruple_to_payload, empty_idkg_payload,
-        fake_ecdsa_idkg_master_public_key_id, fake_signature_request_context_with_pre_sig,
-        fake_state_with_signature_requests, request_id,
+        empty_idkg_payload, fake_ecdsa_idkg_master_public_key_id,
+        fake_signature_request_context_with_registry_version, fake_state_with_signature_requests,
     };
     use ic_test_utilities_registry::SubnetRecordBuilder;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
     use ic_types::{
         consensus::{idkg::PreSigId, BlockPayload, Payload, SummaryPayload},
         crypto::CryptoHash,
+        messages::CallbackId,
         CryptoHashOfState, Height, RegistryVersion,
     };
     use std::sync::{Arc, RwLock};
@@ -396,26 +396,34 @@ mod tests {
 
             let key_id = fake_ecdsa_idkg_master_public_key_id();
 
-            // Create three quadruple Ids and contexts, quadruple "2" will remain unmatched.
+            // Create three quadruple Ids and contexts, context "2" will remain unmatched.
             let pre_sig_id1 = PreSigId(1);
-            let pre_sig_id2 = PreSigId(2);
             let pre_sig_id3 = PreSigId(3);
 
             let contexts = vec![
-                fake_signature_request_context_with_pre_sig(
-                    request_id(1, height),
-                    key_id.clone(),
-                    Some(pre_sig_id1),
+                (
+                    CallbackId::new(1),
+                    fake_signature_request_context_with_registry_version(
+                        Some(pre_sig_id1),
+                        key_id.inner(),
+                        RegistryVersion::from(3),
+                    ),
                 ),
-                fake_signature_request_context_with_pre_sig(
-                    request_id(2, height),
-                    key_id.clone(),
-                    None,
+                (
+                    CallbackId::new(2),
+                    fake_signature_request_context_with_registry_version(
+                        None,
+                        key_id.inner(),
+                        RegistryVersion::from(1),
+                    ),
                 ),
-                fake_signature_request_context_with_pre_sig(
-                    request_id(3, height),
-                    key_id.clone(),
-                    Some(pre_sig_id3),
+                (
+                    CallbackId::new(3),
+                    fake_signature_request_context_with_registry_version(
+                        Some(pre_sig_id3),
+                        key_id.inner(),
+                        RegistryVersion::from(2),
+                    ),
                 ),
             ];
 
@@ -451,12 +459,7 @@ mod tests {
             let block = proposal.content.as_mut();
             block.context.certified_height = block.height();
 
-            let mut idkg = empty_idkg_payload(subnet_test_id(0));
-            // Add the three quadruples using registry version 3, 1 and 2 in order
-            add_available_quadruple_to_payload(&mut idkg, pre_sig_id1, RegistryVersion::from(3));
-            add_available_quadruple_to_payload(&mut idkg, pre_sig_id2, RegistryVersion::from(1));
-            add_available_quadruple_to_payload(&mut idkg, pre_sig_id3, RegistryVersion::from(2));
-
+            let idkg = empty_idkg_payload(subnet_test_id(0));
             let dkg = block.payload.as_ref().as_summary().dkg.clone();
             block.payload = Payload::new(
                 ic_types::crypto::crypto_hash,

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -1,6 +1,6 @@
 //! This module encapsulates functions required for validating consensus
 //! artifacts.
-
+#![allow(clippy::result_large_err)]
 use crate::consensus::{
     check_protocol_version,
     metrics::ValidatorMetrics,

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -1,6 +1,6 @@
 //! This module encapsulates functions required for validating consensus
 //! artifacts.
-#![allow(clippy::result_large_err)]
+
 use crate::consensus::{
     check_protocol_version,
     metrics::ValidatorMetrics,
@@ -1672,13 +1672,13 @@ impl Validator {
         }
 
         let summary = block.payload.as_ref().as_summary();
-        let registry_version = if let Some(idkg) = summary.idkg.as_ref() {
+        let registry_version = if summary.idkg.is_some() {
             // Should succeed as we already got the hash above
             let state = self
                 .state_manager
                 .get_state_at(height)
                 .map_err(ValidationFailure::StateManagerError)?;
-            get_oldest_idkg_state_registry_version(idkg, state.get_ref())
+            get_oldest_idkg_state_registry_version(state.get_ref())
         } else {
             None
         };
@@ -1921,9 +1921,9 @@ pub mod test {
         assert_changeset_matches_pattern,
         fake::*,
         idkg::{
-            add_available_quadruple_to_payload, empty_idkg_payload,
-            fake_ecdsa_idkg_master_public_key_id, fake_signature_request_context_with_pre_sig,
-            fake_state_with_signature_requests, request_id,
+            empty_idkg_payload, fake_ecdsa_idkg_master_public_key_id,
+            fake_signature_request_context_with_registry_version,
+            fake_state_with_signature_requests,
         },
         matches_pattern,
     };
@@ -1941,6 +1941,7 @@ pub mod test {
             NotarizationShare, Payload, RandomBeaconContent, RandomTapeContent, SummaryPayload,
         },
         crypto::{BasicSig, BasicSigOf, CombinedMultiSig, CombinedMultiSigOf, CryptoHash},
+        messages::CallbackId,
         replica_config::ReplicaConfig,
         signature::ThresholdSignature,
         CryptoHashOfState, ReplicaVersion, Time,
@@ -2150,26 +2151,34 @@ pub mod test {
 
             let height = Height::from(0);
             let key_id = fake_ecdsa_idkg_master_public_key_id();
-            // Create three quadruple Ids and contexts, quadruple "2" will remain unmatched.
+            // Create three quadruple Ids and contexts, context "2" will remain unmatched.
             let pre_sig_id1 = PreSigId(1);
-            let pre_sig_id2 = PreSigId(2);
             let pre_sig_id3 = PreSigId(3);
 
             let contexts = vec![
-                fake_signature_request_context_with_pre_sig(
-                    request_id(1, height),
-                    key_id.clone(),
-                    Some(pre_sig_id1),
+                (
+                    CallbackId::new(1),
+                    fake_signature_request_context_with_registry_version(
+                        Some(pre_sig_id1),
+                        key_id.inner(),
+                        RegistryVersion::from(3),
+                    ),
                 ),
-                fake_signature_request_context_with_pre_sig(
-                    request_id(2, height),
-                    key_id.clone(),
-                    None,
+                (
+                    CallbackId::new(2),
+                    fake_signature_request_context_with_registry_version(
+                        None,
+                        key_id.inner(),
+                        RegistryVersion::from(1),
+                    ),
                 ),
-                fake_signature_request_context_with_pre_sig(
-                    request_id(3, height),
-                    key_id.clone(),
-                    Some(pre_sig_id3),
+                (
+                    CallbackId::new(3),
+                    fake_signature_request_context_with_registry_version(
+                        Some(pre_sig_id3),
+                        key_id.inner(),
+                        RegistryVersion::from(2),
+                    ),
                 ),
             ];
 
@@ -2210,12 +2219,7 @@ pub mod test {
             let block = proposal.content.as_mut();
             block.context.certified_height = block.height();
 
-            let mut idkg = empty_idkg_payload(subnet_test_id(0));
-            // Add the three quadruples using registry version 3, 1 and 2 in order
-            add_available_quadruple_to_payload(&mut idkg, pre_sig_id1, RegistryVersion::from(3));
-            add_available_quadruple_to_payload(&mut idkg, pre_sig_id2, RegistryVersion::from(1));
-            add_available_quadruple_to_payload(&mut idkg, pre_sig_id3, RegistryVersion::from(2));
-
+            let idkg = empty_idkg_payload(subnet_test_id(0));
             let dkg = block.payload.as_ref().as_summary().dkg.clone();
             block.payload = Payload::new(
                 ic_types::crypto::crypto_hash,

--- a/rs/consensus/utils/BUILD.bazel
+++ b/rs/consensus/utils/BUILD.bazel
@@ -22,6 +22,7 @@ DEV_DEPENDENCIES = [
     # Keep sorted.
     "//rs/consensus/mocks",
     "//rs/test_utilities",
+    "//rs/test_utilities/consensus",
     "//rs/test_utilities/registry",
     "//rs/test_utilities/state",
     "//rs/test_utilities/time",

--- a/rs/consensus/utils/Cargo.toml
+++ b/rs/consensus/utils/Cargo.toml
@@ -25,6 +25,7 @@ assert_matches = { workspace = true }
 ic-consensus-mocks = { path = "../mocks" }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }
 ic-test-utilities = { path = "../../test_utilities" }
+ic-test-utilities-consensus = { path = "../../test_utilities/consensus" }
 ic-test-utilities-registry = { path = "../../test_utilities/registry" }
 ic-test-utilities-state = { path = "../../test_utilities/state" }
 ic-test-utilities-time = { path = "../../test_utilities/time" }

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -448,8 +448,8 @@ pub fn get_subnet_record(
     }
 }
 
-/// Return the oldest registry version of transcripts in the given IDKG summary payload that are
-/// referenced by the given replicated state.
+/// Return the oldest registry version of transcripts that were matched to signature
+/// request contexts in the given replicated state.
 pub fn get_oldest_idkg_state_registry_version(state: &ReplicatedState) -> Option<RegistryVersion> {
     state
         .signature_request_contexts()

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -11,9 +11,7 @@ use ic_protobuf::registry::subnet::v1::SubnetRecord;
 use ic_registry_client_helpers::subnet::{NotarizationDelaySettings, SubnetRegistry};
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
-    consensus::{
-        idkg::IDkgPayload, Block, BlockProposal, HasCommittee, HasHeight, HasRank, Threshold,
-    },
+    consensus::{Block, BlockProposal, HasCommittee, HasHeight, HasRank, Threshold},
     crypto::{
         threshold_sig::ni_dkg::{NiDkgId, NiDkgReceivers, NiDkgTag, NiDkgTranscript},
         CryptoHash, CryptoHashable, Signed,
@@ -452,17 +450,11 @@ pub fn get_subnet_record(
 
 /// Return the oldest registry version of transcripts in the given IDKG summary payload that are
 /// referenced by the given replicated state.
-pub fn get_oldest_idkg_state_registry_version(
-    idkg: &IDkgPayload,
-    state: &ReplicatedState,
-) -> Option<RegistryVersion> {
+pub fn get_oldest_idkg_state_registry_version(state: &ReplicatedState) -> Option<RegistryVersion> {
     state
         .signature_request_contexts()
         .values()
-        .flat_map(|context| context.matched_pre_signature.as_ref())
-        .flat_map(|(pre_sig_id, _)| idkg.available_pre_signatures.get(pre_sig_id))
-        .flat_map(|pre_signature| pre_signature.get_refs())
-        .flat_map(|transcript_ref| idkg.idkg_transcripts.get(&transcript_ref.transcript_id))
+        .flat_map(|context| context.iter_idkg_transcripts())
         .map(|transcript| transcript.registry_version)
         .min()
 }
@@ -470,39 +462,22 @@ pub fn get_oldest_idkg_state_registry_version(
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use std::{str::FromStr, sync::Arc};
+    use ic_test_utilities_consensus::idkg::{
+        fake_master_public_key_ids_for_all_idkg_algorithms,
+        fake_signature_request_context_with_registry_version,
+    };
 
     use super::*;
     use ic_consensus_mocks::{dependencies, Dependencies};
-    use ic_management_canister_types_private::{EcdsaKeyId, MasterPublicKeyId, SchnorrKeyId};
-    use ic_replicated_state::metadata_state::subnet_call_context_manager::{
-        EcdsaArguments, SchnorrArguments, SignWithThresholdContext, ThresholdArguments,
-    };
+    use ic_management_canister_types_private::MasterPublicKeyId;
+    use ic_replicated_state::metadata_state::subnet_call_context_manager::SignWithThresholdContext;
     use ic_test_utilities_state::ReplicatedStateBuilder;
-    use ic_test_utilities_types::{
-        ids::{node_test_id, subnet_test_id},
-        messages::RequestBuilder,
-    };
+    use ic_test_utilities_types::ids::node_test_id;
     use ic_types::{
-        consensus::{
-            get_faults_tolerated,
-            idkg::{
-                common::PreSignatureRef, ecdsa::PreSignatureQuadrupleRef,
-                schnorr::PreSignatureTranscriptRef, KeyTranscriptCreation, MaskedTranscript,
-                MasterKeyTranscript, PreSigId, UnmaskedTranscript,
-            },
-            Rank,
-        },
-        crypto::{
-            canister_threshold_sig::idkg::{
-                IDkgMaskedTranscriptOrigin, IDkgReceivers, IDkgTranscript, IDkgTranscriptId,
-                IDkgTranscriptType, IDkgUnmaskedTranscriptOrigin,
-            },
-            ThresholdSigShare, ThresholdSigShareOf,
-        },
+        consensus::{get_faults_tolerated, idkg::PreSigId, Rank},
+        crypto::{ThresholdSigShare, ThresholdSigShareOf},
         messages::CallbackId,
         signature::ThresholdSignatureShare,
-        time::UNIX_EPOCH,
     };
 
     /// Test that two shares with the same content are grouped together, and
@@ -574,118 +549,6 @@ mod tests {
         assert_eq!(round_robin.call_next(&calls), vec![1]);
     }
 
-    fn empty_idkg_payload(key_id: MasterPublicKeyId) -> IDkgPayload {
-        IDkgPayload::empty(
-            Height::new(0),
-            subnet_test_id(0),
-            vec![MasterKeyTranscript::new(
-                key_id.try_into().unwrap(),
-                KeyTranscriptCreation::Begin,
-            )],
-        )
-    }
-
-    fn fake_transcript(id: IDkgTranscriptId, registry_version: RegistryVersion) -> IDkgTranscript {
-        IDkgTranscript {
-            transcript_id: id,
-            receivers: IDkgReceivers::new(BTreeSet::from_iter([node_test_id(0)])).unwrap(),
-            registry_version,
-            verified_dealings: Default::default(),
-            transcript_type: IDkgTranscriptType::Unmasked(
-                IDkgUnmaskedTranscriptOrigin::ReshareMasked(fake_transcript_id(0)),
-            ),
-            algorithm_id: ic_types::crypto::AlgorithmId::EcdsaSecp256k1,
-            internal_transcript_raw: vec![],
-        }
-    }
-
-    fn fake_transcript_id(id: u64) -> IDkgTranscriptId {
-        IDkgTranscriptId::new(subnet_test_id(0), id, Height::from(0))
-    }
-
-    // Create a fake ecdsa pre-signature, it will use transcripts with ids
-    // id, id+1, id+2, and id+3.
-    fn fake_ecdsa_quadruple(id: u64, key_id: EcdsaKeyId) -> PreSignatureQuadrupleRef {
-        let temp_rv = RegistryVersion::from(0);
-        let kappa_unmasked = fake_transcript(fake_transcript_id(id), temp_rv);
-        let mut lambda_masked = kappa_unmasked.clone();
-        lambda_masked.transcript_id = fake_transcript_id(id + 1);
-        lambda_masked.transcript_type =
-            IDkgTranscriptType::Masked(IDkgMaskedTranscriptOrigin::Random);
-        let mut kappa_times_lambda = lambda_masked.clone();
-        kappa_times_lambda.transcript_id = fake_transcript_id(id + 2);
-        let mut key_times_lambda = lambda_masked.clone();
-        key_times_lambda.transcript_id = fake_transcript_id(id + 3);
-        let mut key_unmasked = kappa_unmasked.clone();
-        key_unmasked.transcript_id = fake_transcript_id(id + 4);
-        let h = Height::from(0);
-        PreSignatureQuadrupleRef {
-            key_id,
-            kappa_unmasked_ref: UnmaskedTranscript::try_from((h, &kappa_unmasked)).unwrap(),
-            lambda_masked_ref: MaskedTranscript::try_from((h, &lambda_masked)).unwrap(),
-            kappa_times_lambda_ref: MaskedTranscript::try_from((h, &kappa_times_lambda)).unwrap(),
-            key_times_lambda_ref: MaskedTranscript::try_from((h, &key_times_lambda)).unwrap(),
-            key_unmasked_ref: UnmaskedTranscript::try_from((h, &key_unmasked)).unwrap(),
-        }
-    }
-
-    // Create a fake schnorr pre-signature, it will use transcripts with ids
-    // id and id+1.
-    fn fake_schnorr_transcript(id: u64, key_id: SchnorrKeyId) -> PreSignatureTranscriptRef {
-        let temp_rv = RegistryVersion::from(0);
-        let blinder_unmasked = fake_transcript(fake_transcript_id(id), temp_rv);
-        let mut key_unmasked = blinder_unmasked.clone();
-        key_unmasked.transcript_id = fake_transcript_id(id + 1);
-        let h = Height::from(0);
-        PreSignatureTranscriptRef {
-            key_id,
-            blinder_unmasked_ref: UnmaskedTranscript::try_from((h, &blinder_unmasked)).unwrap(),
-            key_unmasked_ref: UnmaskedTranscript::try_from((h, &key_unmasked)).unwrap(),
-        }
-    }
-
-    fn fake_pre_signature(id: u64, key_id: &MasterPublicKeyId) -> PreSignatureRef {
-        match key_id {
-            MasterPublicKeyId::Ecdsa(key_id) => {
-                PreSignatureRef::Ecdsa(fake_ecdsa_quadruple(id, key_id.clone()))
-            }
-            MasterPublicKeyId::Schnorr(key_id) => {
-                PreSignatureRef::Schnorr(fake_schnorr_transcript(id, key_id.clone()))
-            }
-            MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
-        }
-    }
-
-    fn fake_context(
-        pre_signature_id: Option<PreSigId>,
-        key_id: &MasterPublicKeyId,
-    ) -> SignWithThresholdContext {
-        SignWithThresholdContext {
-            request: RequestBuilder::new().build(),
-            args: match key_id {
-                MasterPublicKeyId::Ecdsa(key_id) => ThresholdArguments::Ecdsa(EcdsaArguments {
-                    message_hash: [0; 32],
-                    key_id: key_id.clone(),
-                    pre_signature: None,
-                }),
-                MasterPublicKeyId::Schnorr(key_id) => {
-                    ThresholdArguments::Schnorr(SchnorrArguments {
-                        message: Arc::new(vec![1; 64]),
-                        key_id: key_id.clone(),
-                        taproot_tree_root: None,
-                        pre_signature: None,
-                    })
-                }
-                MasterPublicKeyId::VetKd(_) => panic!("not applicable to vetKD"),
-            },
-            derivation_path: Arc::new(vec![]),
-            pseudo_random_id: [0; 32],
-            matched_pre_signature: pre_signature_id.map(|qid| (qid, Height::from(0))),
-            nonce: None,
-            batch_time: UNIX_EPOCH,
-        }
-    }
-
     fn fake_state_with_contexts(contexts: Vec<SignWithThresholdContext>) -> ReplicatedState {
         let mut state = ReplicatedStateBuilder::default().build();
         let iter = contexts
@@ -700,52 +563,30 @@ mod tests {
     }
 
     fn fake_key_ids() -> Vec<MasterPublicKeyId> {
-        vec![
-            MasterPublicKeyId::Ecdsa(EcdsaKeyId::from_str("Secp256k1:some_key").unwrap()),
-            MasterPublicKeyId::Schnorr(SchnorrKeyId::from_str("Ed25519:some_key").unwrap()),
-        ]
-    }
-
-    // Create an IDKG payload with 10 pre-signatures, each using registry version 2, 3 or 4.
-    fn idkg_payload_with_pre_sigs(key_id: &MasterPublicKeyId) -> IDkgPayload {
-        let mut idkg = empty_idkg_payload(key_id.clone());
-        let mut rvs = [
-            RegistryVersion::from(2),
-            RegistryVersion::from(3),
-            RegistryVersion::from(4),
-        ]
-        .into_iter()
-        .cycle();
-        for i in (0..50).step_by(5) {
-            let pre_sig = fake_pre_signature(i as u64, key_id);
-            let rv = rvs.next().unwrap();
-            for r in pre_sig.get_refs() {
-                idkg.idkg_transcripts
-                    .insert(r.transcript_id, fake_transcript(r.transcript_id, rv));
-            }
-            idkg.available_pre_signatures
-                .insert(PreSigId(i as u64), pre_sig);
-        }
-        idkg
+        fake_master_public_key_ids_for_all_idkg_algorithms()
+            .into_iter()
+            .map(|id| id.inner().clone())
+            .collect()
     }
 
     #[test]
     fn test_empty_state_should_return_no_registry_version() {
-        for key_id in fake_key_ids() {
-            println!("Running test for key ID {key_id}");
-            let idkg = idkg_payload_with_pre_sigs(&key_id);
-            let state = fake_state_with_contexts(vec![]);
-            assert_eq!(None, get_oldest_idkg_state_registry_version(&idkg, &state));
-        }
+        let state = fake_state_with_contexts(vec![]);
+        assert_eq!(None, get_oldest_idkg_state_registry_version(&state));
     }
 
     #[test]
     fn test_state_without_matches_should_return_no_registry_version() {
         for key_id in fake_key_ids() {
             println!("Running test for key ID {key_id}");
-            let idkg = idkg_payload_with_pre_sigs(&key_id);
-            let state = fake_state_with_contexts(vec![fake_context(None, &key_id)]);
-            assert_eq!(None, get_oldest_idkg_state_registry_version(&idkg, &state));
+            let state = fake_state_with_contexts(vec![
+                fake_signature_request_context_with_registry_version(
+                    None,
+                    &key_id,
+                    RegistryVersion::from(4),
+                ),
+            ]);
+            assert_eq!(None, get_oldest_idkg_state_registry_version(&state));
         }
     }
 
@@ -758,38 +599,38 @@ mod tests {
     }
 
     fn test_should_return_oldest_registry_version(key_id: MasterPublicKeyId) {
-        let idkg = idkg_payload_with_pre_sigs(&key_id);
-        // create contexts for all pre-signatures, but only create a match for
-        // pre-signatures with registry version >= 3 (not 2!). Thus the oldest
-        // registry version referenced by the state should be 3.
-        let contexts = idkg
-            .available_pre_signatures
-            .iter()
-            .map(|(id, pre_sig)| {
-                let t_id = pre_sig.key_unmasked().as_ref().transcript_id;
-                let transcript = idkg.idkg_transcripts.get(&t_id).unwrap();
-                (transcript.registry_version.get() >= 3).then_some(*id)
-            })
-            .map(|id| fake_context(id, &key_id))
-            .collect();
+        let mut contexts = vec![];
+        // Create some contexts with registry version 4 and some unmatched ones
+        for i in 0..3 {
+            contexts.push(fake_signature_request_context_with_registry_version(
+                Some(PreSigId(i)),
+                &key_id,
+                RegistryVersion::from(4),
+            ));
+            contexts.push(fake_signature_request_context_with_registry_version(
+                None,
+                &key_id,
+                RegistryVersion::from(4),
+            ));
+        }
+        // Create one context with registry version 2
+        contexts.push(fake_signature_request_context_with_registry_version(
+            Some(PreSigId(3)),
+            &key_id,
+            RegistryVersion::from(2),
+        ));
+        // Create some contexts with registry version 3
+        for i in 4..7 {
+            contexts.push(fake_signature_request_context_with_registry_version(
+                Some(PreSigId(i)),
+                &key_id,
+                RegistryVersion::from(3),
+            ));
+        }
         let state = fake_state_with_contexts(contexts);
         assert_eq!(
-            Some(RegistryVersion::from(3)),
-            get_oldest_idkg_state_registry_version(&idkg, &state)
-        );
-
-        let mut idkg_without_transcripts = idkg.clone();
-        idkg_without_transcripts.idkg_transcripts = BTreeMap::new();
-        assert_eq!(
-            None,
-            get_oldest_idkg_state_registry_version(&idkg_without_transcripts, &state)
-        );
-
-        let mut idkg_without_pre_sigs = idkg.clone();
-        idkg_without_pre_sigs.available_pre_signatures = BTreeMap::new();
-        assert_eq!(
-            None,
-            get_oldest_idkg_state_registry_version(&idkg_without_pre_sigs, &state)
+            Some(RegistryVersion::from(2)),
+            get_oldest_idkg_state_registry_version(&state)
         );
     }
 


### PR DESCRIPTION
Request contexts are now paired with the full pre-signature (instead of only the pre-signature ID). Therefore, we can now determine the registry versions referenced by ongoing signature requests via the transcripts of the paired pre-signature directly, instead of having to look up the corresponding full pre-signature in the payload.

The "oldest" such registry version continues to be included in the CUP, and affects when a node is allowed to leave the subnet. A node may only leave the subnet if it is no longer part of it according to this "oldest" registry version. This ensures that all ongoing signature requests that require the node's contribution may be finished.