### PR TITLE
test(node): Scaffold initial structure for E2E NNS recovery test 

### DIFF
--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -90,6 +90,25 @@ system_test_nns(
     deps = RUNNER_DEPENDENCIES,
 )
 
+# Tests if "latest_release" in mainnet-icos-revisions.json can successfully guestos upgrade to current commit
+system_test_nns(
+    name = "guestos_upgrade_from_latest_release_to_current",
+    env = MAINNET_ENV | {
+        "NODE_OPERATOR_PRIV_KEY_PATH": "$(rootpath //ic-os/setupos:config/node_operator_private_key.pem)",
+    },
+    extra_head_nns_tags = [],
+    flaky = True,
+    tags = ["long_test"],
+    test_driver_target = ":guestos_upgrade_test_bin",
+    test_timeout = "eternal",
+    uses_guestos_img = False,
+    uses_guestos_mainnet_img = True,
+    uses_guestos_update = True,
+    uses_setupos_mainnet_img = True,
+    runtime_deps = IC_GATEWAY_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
+    deps = RUNNER_DEPENDENCIES,
+)
+
 rust_binary(
     name = "hostos_upgrade_test_bin",
     testonly = True,
@@ -128,25 +147,6 @@ system_test_nns(
     uses_guestos_img = False,
     uses_guestos_mainnet_img = True,
     uses_hostos_update = True,
-    uses_setupos_mainnet_img = True,
-    runtime_deps = IC_GATEWAY_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
-    deps = RUNNER_DEPENDENCIES,
-)
-
-# Tests if "latest_release" in mainnet-icos-revisions.json can successfully guestos upgrade to current commit
-system_test_nns(
-    name = "guestos_upgrade_from_latest_release_to_current",
-    env = MAINNET_ENV | {
-        "NODE_OPERATOR_PRIV_KEY_PATH": "$(rootpath //ic-os/setupos:config/node_operator_private_key.pem)",
-    },
-    extra_head_nns_tags = [],
-    flaky = True,
-    tags = ["long_test"],
-    test_driver_target = ":guestos_upgrade_test_bin",
-    test_timeout = "eternal",
-    uses_guestos_img = False,
-    uses_guestos_mainnet_img = True,
-    uses_guestos_update = True,
     uses_setupos_mainnet_img = True,
     runtime_deps = IC_GATEWAY_RUNTIME_DEPS + ["//ic-os/setupos:config/node_operator_private_key.pem"],
     deps = RUNNER_DEPENDENCIES,

--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -196,3 +196,28 @@ system_test_nns(
     runtime_deps = IC_GATEWAY_RUNTIME_DEPS,
     deps = RUNNER_DEPENDENCIES,
 )
+
+rust_binary(
+    name = "nns_recovery_test_bin",
+    testonly = True,
+    srcs = ["nns_recovery_test.rs"],
+    deps = DEPENDENCIES + [":nested"],
+)
+
+# Tests the manual NNS recovery process:
+# - NNS subnet is broken
+# - guestos-recovery-upgrader is used to upgrade the GuestOS to the recovery image
+# - guestos-recovery-engine is used to recover the NNS subnet
+system_test_nns(
+    name = "nns_recovery_test",
+    env = MAINNET_ENV,
+    extra_head_nns_tags = [],
+    flaky = True,
+    tags = ["long_test"],
+    target_compatible_with = ["@platforms//os:linux"],  # requires libssh that does not build on Mac OS
+    test_driver_target = ":nns_recovery_test_bin",
+    test_timeout = "eternal",
+    uses_setupos_img = True,
+    runtime_deps = IC_GATEWAY_RUNTIME_DEPS,
+    deps = RUNNER_DEPENDENCIES,
+)

--- a/rs/tests/nested/nns_recovery_test.rs
+++ b/rs/tests/nested/nns_recovery_test.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+use ic_system_test_driver::{driver::group::SystemTestGroup, systest};
+use std::time::Duration;
+
+fn main() -> Result<()> {
+    SystemTestGroup::new()
+        .with_setup(nested::config)
+        .add_test(systest!(nested::nns_recovery_test))
+        .with_timeout_per_test(Duration::from_secs(20 * 60))
+        .with_overall_timeout(Duration::from_secs(25 * 60))
+        .execute_from_args()?;
+
+    Ok(())
+}

--- a/rs/tests/nested/nns_recovery_test.rs
+++ b/rs/tests/nested/nns_recovery_test.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_setup(nested::config)
+        .with_setup(nested::config_four_vms)
         .add_test(systest!(nested::nns_recovery_test))
         .with_timeout_per_test(Duration::from_secs(20 * 60))
         .with_overall_timeout(Duration::from_secs(25 * 60))

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -177,7 +177,7 @@ pub fn nns_recovery_test(env: TestEnv) {
 
     info!(logger, "Waiting for all four nodes to join ...");
 
-    let final_topology = retry_with_msg!(
+    retry_with_msg!(
         "Waiting for all four nodes to register and appear as unassigned nodes",
         logger.clone(),
         NODE_REGISTRATION_TIMEOUT,
@@ -186,7 +186,8 @@ pub fn nns_recovery_test(env: TestEnv) {
             let topology = env.topology_snapshot();
             let num_unassigned_nodes = topology.unassigned_nodes().count();
             if num_unassigned_nodes == 4 {
-                Ok(topology)
+                info!(logger, "SUCCESS: All four nodes have registered");
+                Ok(())
             } else {
                 bail!(
                     "Expected 4 unassigned nodes, but found {}",
@@ -196,17 +197,6 @@ pub fn nns_recovery_test(env: TestEnv) {
         }
     )
     .unwrap();
-
-    let num_unassigned_nodes = final_topology.unassigned_nodes().count();
-    assert_eq!(
-        num_unassigned_nodes, 4,
-        "Expected 4 unassigned nodes, but found {}",
-        num_unassigned_nodes
-    );
-    info!(
-        logger,
-        "SUCCESS: All four nodes have registered and are unassigned as expected."
-    );
 }
 
 /// Upgrade each HostOS VM to the target version, and verify that each is

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -59,7 +59,7 @@ pub fn config(env: TestEnv) {
         .start(&env)
         .expect("failed to setup ic-gateway");
 
-    setup_nested_vm(env.clone(), HOST_VM_NAME);
+    setup_nested_vm(env.clone(), &[HOST_VM_NAME]);
 
     let vm = env.get_nested_vm(HOST_VM_NAME).unwrap_or_else(|e| {
         panic!(
@@ -90,7 +90,7 @@ pub fn config(env: TestEnv) {
 /// Minimal setup that only creates a nested VM without any IC infrastructure.
 /// This is much faster than the full config() setup.
 pub fn simple_config(env: TestEnv) {
-    simple_setup_nested_vm(env.clone(), HOST_VM_NAME);
+    simple_setup_nested_vm(env.clone(), &[HOST_VM_NAME]);
 }
 
 /// Allow the nested GuestOS to install and launch, and check that it can

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -26,8 +26,8 @@ mod util;
 use util::{
     check_hostos_version, elect_guestos_version, elect_hostos_version,
     get_blessed_guestos_versions, get_host_boot_id, get_unassigned_nodes_config, setup_nested_vm,
-    simple_setup_nested_vm, start_nested_vm, update_nodes_hostos_version, update_unassigned_nodes,
-    wait_for_expected_guest_version, wait_for_guest_version,
+    simple_setup_nested_vm, start_nested_vm_group, update_nodes_hostos_version,
+    update_unassigned_nodes, wait_for_expected_guest_version, wait_for_guest_version,
 };
 
 use anyhow::bail;
@@ -128,7 +128,7 @@ pub fn registration(env: TestEnv) {
     let num_unassigned_nodes = initial_topology.unassigned_nodes().count();
     assert_eq!(num_unassigned_nodes, 0);
 
-    start_nested_vm(env.clone());
+    start_nested_vm_group(env.clone());
 
     // Assert that the GuestOS was started with direct kernel boot.
     let guest_kernel_cmdline = env
@@ -173,7 +173,7 @@ pub fn nns_recovery_test(env: TestEnv) {
     let num_unassigned_nodes = initial_topology.unassigned_nodes().count();
     assert_eq!(num_unassigned_nodes, 0);
 
-    start_nested_vm(env.clone());
+    start_nested_vm_group(env.clone());
 
     info!(logger, "Waiting for all four nodes to join ...");
 
@@ -224,7 +224,7 @@ pub fn upgrade_hostos(env: TestEnv) {
     let update_image_sha256 = get_hostos_update_img_sha256().unwrap();
 
     let initial_topology = env.topology_snapshot();
-    start_nested_vm(env.clone());
+    start_nested_vm_group(env.clone());
     info!(logger, "Waiting for node to join ...");
     let new_topology = block_on(
         initial_topology.block_for_newer_registry_version_within_duration(
@@ -330,7 +330,7 @@ pub fn upgrade_hostos(env: TestEnv) {
 pub fn recovery_upgrader_test(env: TestEnv) {
     let logger = env.logger();
 
-    start_nested_vm(env.clone());
+    start_nested_vm_group(env.clone());
 
     let host = env
         .get_nested_vm(HOST_VM_NAME)
@@ -449,7 +449,7 @@ pub fn upgrade_guestos(env: TestEnv) {
 
     // start the nested VM and wait for it to join the network
     let initial_topology = env.topology_snapshot();
-    start_nested_vm(env.clone());
+    start_nested_vm_group(env.clone());
     info!(logger, "Waiting for node to join ...");
     block_on(
         initial_topology.block_for_newer_registry_version_within_duration(

--- a/rs/tests/nested/src/util.rs
+++ b/rs/tests/nested/src/util.rs
@@ -300,7 +300,7 @@ pub(crate) fn simple_setup_nested_vm(env: TestEnv, names: &[&str]) {
     info!(logger, "Minimal nested VM(s) setup complete!");
 }
 
-pub(crate) fn start_nested_vm(env: TestEnv) {
+pub(crate) fn start_nested_vm_group(env: TestEnv) {
     let logger = env.logger();
     info!(logger, "Setup nested VMs ...");
 

--- a/rs/tests/nested/src/util.rs
+++ b/rs/tests/nested/src/util.rs
@@ -209,16 +209,19 @@ pub(crate) async fn update_nodes_hostos_version(
     vote_execute_proposal_assert_executed(&governance_canister, proposal_id).await;
 }
 
-pub(crate) fn setup_nested_vm(env: TestEnv, name: &str) {
+pub(crate) fn setup_nested_vm(env: TestEnv, names: &[&str]) {
     let logger = env.logger();
-    info!(logger, "Setup nested VMs ...");
+    info!(logger, "Setting up nested VM(s) ...");
 
     let farm_url = env.get_farm_url().expect("Unable to get Farm url.");
     let farm = Farm::new(farm_url, logger.clone());
     let group_setup = GroupSetup::read_attribute(&env);
     let group_name: String = group_setup.infra_group_name;
 
-    let nodes = vec![NestedNode::new(name.to_owned())];
+    let nodes: Vec<NestedNode> = names
+        .iter()
+        .map(|name| NestedNode::new(name.to_string()))
+        .collect();
 
     let res_request = get_resource_request_for_nested_nodes(&nodes, &env, &group_name)
         .expect("Failed to build resource request for nested test.");
@@ -247,14 +250,16 @@ pub(crate) fn setup_nested_vm(env: TestEnv, name: &str) {
         &nns_public_key,
     )
     .expect("Unable to setup nested VMs.");
+
+    info!(logger, "Nested VM(s) setup complete!");
 }
 
 /// Simplified nested VM setup that bypasses IC Gateway and NNS requirements.
-pub(crate) fn simple_setup_nested_vm(env: TestEnv, name: &str) {
+pub(crate) fn simple_setup_nested_vm(env: TestEnv, names: &[&str]) {
     let logger = env.logger();
     info!(
         logger,
-        "Setup minimal nested VM without IC infrastructure..."
+        "Setting up minimal nested VM(s) without IC infrastructure..."
     );
 
     let farm_url = env.get_farm_url().expect("Unable to get Farm url.");
@@ -262,7 +267,10 @@ pub(crate) fn simple_setup_nested_vm(env: TestEnv, name: &str) {
     let group_setup = GroupSetup::read_attribute(&env);
     let group_name: String = group_setup.infra_group_name;
 
-    let nodes = vec![NestedNode::new(name.to_owned())];
+    let nodes: Vec<NestedNode> = names
+        .iter()
+        .map(|name| NestedNode::new(name.to_string()))
+        .collect();
 
     // Allocate VM resources
     let res_request = get_resource_request_for_nested_nodes(&nodes, &env, &group_name)
@@ -289,7 +297,7 @@ pub(crate) fn simple_setup_nested_vm(env: TestEnv, name: &str) {
     )
     .expect("Unable to setup nested VMs with minimal config.");
 
-    info!(logger, "Minimal nested VM setup complete!");
+    info!(logger, "Minimal nested VM(s) setup complete!");
 }
 
 pub(crate) fn start_nested_vm(env: TestEnv) {


### PR DESCRIPTION
Creates a basic NNS recovery test that creates four nested VMs and registers them to the testnet.