### PR TITLE
feat(crypto): CRP-2810 Add support for subkey derivation to ic-ed25519 and ic-secp256k1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9077,6 +9077,7 @@ dependencies = [
 name = "ic-ed25519"
 version = "0.2.0"
 dependencies = [
+ "candid",
  "curve25519-dalek",
  "ed25519-dalek",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12951,6 +12951,7 @@ version = "0.1.0"
 dependencies = [
  "bip32 0.5.3",
  "bitcoin 0.28.2",
+ "candid",
  "hex",
  "hex-literal",
  "hmac",

--- a/packages/ic-ed25519/BUILD.bazel
+++ b/packages/ic-ed25519/BUILD.bazel
@@ -4,8 +4,10 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
+    "@crate_index//:candid",
     "@crate_index//:curve25519-dalek",
     "@crate_index//:ed25519-dalek",
+    "@crate_index//:hex-literal",
     "@crate_index//:hkdf",
     "@crate_index//:pem",
     "@crate_index//:rand",
@@ -18,7 +20,6 @@ MACRO_DEPENDENCIES = []
 DEV_DEPENDENCIES = [
     # Keep sorted.
     "@crate_index//:hex",
-    "@crate_index//:hex-literal",
     "@crate_index//:rand_chacha",
     "@crate_index//:wycheproof",
 ]

--- a/packages/ic-ed25519/Cargo.toml
+++ b/packages/ic-ed25519/Cargo.toml
@@ -13,11 +13,13 @@ documentation.workspace = true
 [dependencies]
 curve25519-dalek = { workspace = true }
 ed25519-dalek = { workspace = true }
+hex-literal = "0.4"
 hkdf = "0.12"
 pem = "1"
-rand = { workspace = true, optional = true, no-default-features = true }
+rand = { workspace = true, optional = true }
 thiserror = { workspace = true }
 zeroize = { workspace = true }
+candid = { workspace = true }
 
 [features]
 default = ["rand"]
@@ -25,7 +27,6 @@ rand = ["dep:rand"]
 
 [dev-dependencies]
 hex = { workspace = true }
-hex-literal = "0.4"
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 wycheproof = { version = "0.6", default-features = false, features = ["eddsa"] }

--- a/packages/ic-ed25519/tests/tests.rs
+++ b/packages/ic-ed25519/tests/tests.rs
@@ -592,3 +592,44 @@ fn verification_follows_zip215() {
         );
     }
 }
+
+#[test]
+fn offline_key_derivation_matches_mainnet_for_key_1() {
+    use std::str::FromStr;
+
+    let canister_id = ic_ed25519::CanisterId::from_str("h5jwf-5iaaa-aaaan-qmvoa-cai").unwrap();
+    let derivation_path = [hex!("ABCDEF").to_vec(), hex!("012345").to_vec()];
+
+    let dpk = PublicKey::derive_mainnet_key(
+        ic_ed25519::MasterPublicKeyId::Key1,
+        &canister_id,
+        &derivation_path,
+    );
+
+    assert_eq!(
+        hex::encode(dpk.0.serialize_raw()),
+        "43f0008b26564b6da51f585ad47669dfeb1db6d94d7dd216bd304fc1f5f5e997"
+    );
+}
+
+#[test]
+fn offline_key_derivation_matches_mainnet_for_test_key_1() {
+    use std::str::FromStr;
+
+    let canister_id = ic_ed25519::CanisterId::from_str("h5jwf-5iaaa-aaaan-qmvoa-cai").unwrap();
+    let derivation_path = [
+        "Hello".as_bytes().to_vec(),
+        "Threshold".as_bytes().to_vec(),
+        "Signatures".as_bytes().to_vec(),
+    ];
+    let dpk = PublicKey::derive_mainnet_key(
+        ic_ed25519::MasterPublicKeyId::TestKey1,
+        &canister_id,
+        &derivation_path,
+    );
+
+    assert_eq!(
+        hex::encode(dpk.0.serialize_raw()),
+        "d9a2ce6a3cd33fe16dce37e045609e51ff516e93bb51013823d6d7a915e3cfb9"
+    );
+}

--- a/packages/ic-secp256k1/BUILD.bazel
+++ b/packages/ic-secp256k1/BUILD.bazel
@@ -4,6 +4,8 @@ package(default_visibility = ["//visibility:public"])
 
 DEPENDENCIES = [
     # Keep sorted.
+    "@crate_index//:candid",
+    "@crate_index//:hex-literal",
     "@crate_index//:hmac",
     "@crate_index//:k256",
     "@crate_index//:lazy_static",
@@ -23,7 +25,6 @@ DEV_DEPENDENCIES = [
     "@crate_index//:bip32",
     "@crate_index//:bitcoin_0_28",
     "@crate_index//:hex",
-    "@crate_index//:hex-literal",
     "@crate_index//:wycheproof",
 ]
 

--- a/packages/ic-secp256k1/Cargo.toml
+++ b/packages/ic-secp256k1/Cargo.toml
@@ -13,6 +13,8 @@ documentation.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+candid = { workspace = true }
+hex-literal = "0.4"
 hmac = "0.12"
 k256 = { workspace = true }
 lazy_static = { workspace = true }
@@ -28,6 +30,5 @@ zeroize = { workspace = true }
 bip32 = "0.5"
 bitcoin = { version = "0.28.2" }
 hex = { workspace = true }
-hex-literal = "0.4"
 secp256k1 = { version = "0.22", features = ["global-context", "rand-std"] }
 wycheproof = { version = "0.6", default-features = false, features = ["ecdsa"] }

--- a/packages/ic-secp256k1/tests/tests.rs
+++ b/packages/ic-secp256k1/tests/tests.rs
@@ -674,3 +674,85 @@ Fuih1ILwOK+Hmr2Q5yPe4k0Kz2se3NM1eQeVaTl5BtwlTTc9IOcky4I7oQ==
         Err(e) => panic!("Unexpected error {:?}", e),
     }
 }
+
+#[test]
+fn offline_ecdsa_key_derivation_matches_mainnet_for_key_1() {
+    use std::str::FromStr;
+
+    let canister_id = ic_secp256k1::CanisterId::from_str("h5jwf-5iaaa-aaaan-qmvoa-cai").unwrap();
+    let derivation_path = [hex!("ABCDEF").to_vec(), hex!("012345").to_vec()];
+
+    let dpk = PublicKey::derive_mainnet_key(
+        ic_secp256k1::MasterPublicKeyId::EcdsaKey1,
+        &canister_id,
+        &derivation_path,
+    );
+
+    assert_eq!(
+        hex::encode(dpk.0.serialize_sec1(true)),
+        "02735ca28b5c3e380016d7f28bf4703b540a8bbe8e24beffdc021455ca2ab93fe3",
+    );
+}
+
+#[test]
+fn offline_ecdsa_key_derivation_matches_mainnet_for_test_key_1() {
+    use std::str::FromStr;
+
+    let canister_id = ic_secp256k1::CanisterId::from_str("h5jwf-5iaaa-aaaan-qmvoa-cai").unwrap();
+    let derivation_path = [
+        "Hello".as_bytes().to_vec(),
+        "Threshold".as_bytes().to_vec(),
+        "Signatures".as_bytes().to_vec(),
+    ];
+    let dpk = PublicKey::derive_mainnet_key(
+        ic_secp256k1::MasterPublicKeyId::EcdsaTestKey1,
+        &canister_id,
+        &derivation_path,
+    );
+
+    assert_eq!(
+        hex::encode(dpk.0.serialize_sec1(true)),
+        "0315ae8bb8c6e9f78eec2167f5ac773067f37a39da1a1efbc585f9e90658d1c620"
+    );
+}
+
+#[test]
+fn offline_schnorr_key_derivation_matches_mainnet_for_key_1() {
+    use std::str::FromStr;
+
+    let canister_id = ic_secp256k1::CanisterId::from_str("h5jwf-5iaaa-aaaan-qmvoa-cai").unwrap();
+    let derivation_path = [hex!("ABCDEF").to_vec(), hex!("012345").to_vec()];
+
+    let dpk = PublicKey::derive_mainnet_key(
+        ic_secp256k1::MasterPublicKeyId::SchnorrKey1,
+        &canister_id,
+        &derivation_path,
+    );
+
+    assert_eq!(
+        hex::encode(dpk.0.serialize_sec1(true)),
+        "03e5e92c2399985f82521b110ac3dbf697a6b9522002c0d31d0b7cd5352c343457",
+    );
+}
+
+#[test]
+fn offline_schnorr_key_derivation_matches_mainnet_for_test_key_1() {
+    use std::str::FromStr;
+
+    let canister_id = ic_secp256k1::CanisterId::from_str("h5jwf-5iaaa-aaaan-qmvoa-cai").unwrap();
+    let derivation_path = [
+        "Hello".as_bytes().to_vec(),
+        "Threshold".as_bytes().to_vec(),
+        "Signatures".as_bytes().to_vec(),
+    ];
+    let dpk = PublicKey::derive_mainnet_key(
+        ic_secp256k1::MasterPublicKeyId::SchnorrTestKey1,
+        &canister_id,
+        &derivation_path,
+    );
+
+    assert_eq!(
+        hex::encode(dpk.0.serialize_sec1(true)),
+        "0237ca6a41c1db8ab40410445250a5d46fbec7f3e449c8f40f86d8622a4106cebd",
+    );
+}


### PR DESCRIPTION
This embeds the production public master keys for Ed25519 and adds a convenience function for performing fully offline key derivation.