### PR TITLE
fix: use `/api/v2/subnet/<subnet_id>/read_state` instead of `/api/v2/canister/<effective_canister_id>/read_state` when fetching nns delegation

### DIFF
--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -300,8 +300,7 @@ async fn try_fetch_delegation_from_nns(
         format!("Timed out while connecting to the nns node after {CONNECTION_TIMEOUT:?}")
     })??;
 
-    // any effective canister id can be used when invoking read_state here
-    let uri = "/api/v2/canister/aaaaa-aa/read_state";
+    let uri = format!("/api/v2/subnet/{nns_subnet_id}/read_state");
 
     info!(
         log,


### PR DESCRIPTION
As @schneiderstefan pointed out, requesting paths with prefix `/subnet` (which we are) via `/api/v2/canister` url might be deprecated in the future and it's recommended to use `/api/v2/subnet` instead. See https://internetcomputer.org/docs/references/ic-interface-spec#http-read-state