### PR TITLE
fix: [NODE-1680] Fix broken nested tests

### DIFF
--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -210,9 +210,9 @@ pub fn nns_recovery_test(env: TestEnv) {
 pub fn upgrade_hostos(env: TestEnv) {
     let logger = env.logger();
 
-    let target_version_str = get_hostos_update_img_version().unwrap();
-    let target_version = HostosVersion::try_from(target_version_str.to_string())
-        .expect("Invalid target hostos version");
+    let target_version = get_hostos_update_img_version().unwrap();
+    let target_version =
+        HostosVersion::try_from(target_version.to_string()).expect("Invalid target hostos version");
 
     let update_image_url =
         get_hostos_update_img_url().expect("Invalid target hostos update image URL");

--- a/rs/tests/nested/src/util.rs
+++ b/rs/tests/nested/src/util.rs
@@ -338,7 +338,7 @@ pub async fn wait_for_guest_version(
         || async {
             let current_version = check_guestos_version(client, guest_ipv6)
                 .await
-                .expect("Unable to check GuestOS version");
+                .context("Unable to check GuestOS version")?;
             info!(
                 logger,
                 "SUCCESS: Guest reported version '{}'", current_version
@@ -370,7 +370,7 @@ pub async fn wait_for_expected_guest_version(
         || async {
             let current_version = check_guestos_version(client, guest_ipv6)
                 .await
-                .expect("Unable to check GuestOS version");
+                .context("Unable to check GuestOS version")?;
             if &current_version != expected_version {
                 bail!("FAIL: Guest is still on version '{}'", current_version)
             }


### PR DESCRIPTION
Return a `Result` instead of panicking, when the version is not yet found.