### PR TITLE
fix: temporarily disable downloading launch measurements in tests

### DIFF
--- a/rs/tests/dre/utils/steps/ensure_elected_version.rs
+++ b/rs/tests/dre/utils/steps/ensure_elected_version.rs
@@ -34,17 +34,18 @@ impl Step for EnsureElectedVersion {
         let upgrade_url = get_public_update_image_url(&self.version);
         info!(env.logger(), "Upgrade URL: {}", upgrade_url);
 
-        let (sha256, guest_launch_measurements) = rt.block_on(fetch_update_metadata_with_retry(
+        let sha256 = rt.block_on(fetch_update_metadata_with_retry(
             &env.logger(),
             &self.version,
         ));
+        let guest_launch_measurements = None;
 
         rt.block_on(bless_replica_version_with_urls(
             &nns_node,
             &self.version,
             vec![upgrade_url.clone()],
             sha256,
-            Some(guest_launch_measurements),
+            guest_launch_measurements,
             &env.logger(),
         ));
 


### PR DESCRIPTION
The RC [broke](https://github.com/dfinity/ic/actions/runs/16856805374) because the `//rs/tests/dre:guest_os_qualification` test tries to download 
`http://download.proxy-global.dfinity.network:8080/ic/<latest_release>/guest-os/update-img/launch-measurements.json` where `<latest_release>` is the commit of the latest release. However that `launch-measurements.json` file started to be [uploaded](https://github.com/dfinity/ic/blame/master/ic-os/guestos/envs/prod/BUILD.bazel#L44) from [8453885](https://github.com/dfinity/ic/commit/84538856c2e3fd365289aa74ca4090c18b81a3e5) which came later than the latest release [21a02f4](https://github.com/dfinity/ic/commit/21a02f483fa8028568f4c2c5920ec960c87269c0). 

So this temporarily disables downloading the `launch-measurements.json` file. This needs to be reverted once a new release has been deployed.
