### PR TITLE
feat(ICRC_Rosetta): Add ICRC Rosetta release 1.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9825,7 +9825,7 @@ dependencies = [
 
 [[package]]
 name = "ic-icrc-rosetta"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "anyhow",
  "axum 0.8.4",

--- a/rs/rosetta-api/icrc1/BUILD.bazel
+++ b/rs/rosetta-api/icrc1/BUILD.bazel
@@ -83,7 +83,7 @@ MACRO_DEV_DEPENDENCIES = [
 ALIASES = {
 }
 
-ROSETTA_VERSION = "1.2.4"
+ROSETTA_VERSION = "1.2.5"
 
 rust_library(
     name = "ic-icrc-rosetta",

--- a/rs/rosetta-api/icrc1/CHANGELOG.md
+++ b/rs/rosetta-api/icrc1/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.2.5] - 2025-08-11
+### Fixed
+- Handle startup ledger errors gracefully ([#5884](https://github.com/dfinity/ic/pull/5884))
+
 ## [1.2.4] - 2025-07-07
 ### Added
 - Allow retrieving the aggregate balance of a ICRC1 token account ([#5773](https://github.com/dfinity/ic/pull/5773))

--- a/rs/rosetta-api/icrc1/Cargo.toml
+++ b/rs/rosetta-api/icrc1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ic-icrc-rosetta"
 description = "Build Once. Integrate Your Blockchain Everywhere. "
 default-run = "ic-icrc-rosetta"
-version = "1.2.4"
+version = "1.2.5"
 authors.workspace = true
 edition.workspace = true
 documentation.workspace = true

--- a/rs/rosetta-api/icrc1/src/common/constants.rs
+++ b/rs/rosetta-api/icrc1/src/common/constants.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 pub const DEFAULT_BLOCKCHAIN: &str = "Internet Computer";
-pub const ROSETTA_VERSION: &str = "1.2.4";
+pub const ROSETTA_VERSION: &str = "1.2.5";
 pub const NODE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const INGRESS_INTERVAL_SECS: u64 = 4 * 60;
 pub const BLOCK_SYNC_WAIT_SECS: u64 = 1;


### PR DESCRIPTION
Bump the ICRC Rosetta version to 1.2.5 with the following change:

- Gracefully handle ledger errors during Rosetta startup ([PR 5884](https://github.com/dfinity/ic/pull/5884))
