### PR TITLE
fix(sns): Fix an issue where neuron topic follower index is updated incorrectly

### DIFF
--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -17,4 +17,6 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* Fixed a bug with the topic follower index.
+
 ## Security


### PR DESCRIPTION
The topic follower index was updated incorrectly as the update was based on the new followees rather than the old one. This PR fixes the ordering of the operations so that the index can be updated correctly.