### PR TITLE
fix(NRC): Fix rewardable nodes computation

### DIFF
--- a/rs/node_rewards/canister/src/registry_querier.rs
+++ b/rs/node_rewards/canister/src/registry_querier.rs
@@ -193,9 +193,16 @@ impl RegistryQuerier {
                             // A deletion
                             if let Some(start_of_interval) = last_present_ts.take() {
                                 // The node was present and is now gone. Finalize the interval.
-                                let days_between =
-                                    DayUtc::from(start_of_interval).days_until(&DayUtc::from(ts));
-                                days.extend(days_between.unwrap_or_default());
+                                let mut days_between = DayUtc::from(start_of_interval)
+                                    .days_until(&DayUtc::from(ts))
+                                    .unwrap_or_default();
+
+                                // If a node is deleted it will be rewarded until the day before deletion.
+                                if !days_between.is_empty() {
+                                    days_between.truncate(days_between.len() - 1);
+                                }
+
+                                days.extend(days_between);
                             }
                         }
                     }

--- a/rs/node_rewards/canister/src/registry_querier/tests.rs
+++ b/rs/node_rewards/canister/src/registry_querier/tests.rs
@@ -253,7 +253,6 @@ fn test_nodes_in_registry_returns_expected_days() {
         ts("2025-07-05").into(),
         ts("2025-07-06").into(),
         ts("2025-07-07").into(),
-        ts("2025-07-08").into(),
     ];
     assert_eq!(node_1_days, &expected_node_1_days);
 
@@ -279,7 +278,6 @@ fn test_nodes_in_registry_returns_expected_days() {
     let expected_node_3_days: Vec<DayUtc> = vec![
         ts("2025-07-11").into(),
         ts("2025-07-12").into(),
-        ts("2025-07-13").into(),
         // node_3 was deleted on 2025-07-13, so it should not be present on 2025-07-14
         ts("2025-07-15").into(),
         ts("2025-07-16").into(),
@@ -316,7 +314,7 @@ fn test_rewardable_nodes_deleted_nodes() {
         "Node 1 should not be rewardable after it was deleted"
     );
 
-    // Node 2 and 3 should be rewardable in this period.
+    // Node 2 should be rewardable in this period.
     let node_2_rewardable_days = node_rewardable_days(&np_1_rewardables, 2);
 
     assert_eq!(node_2_rewardable_days.first(), Some(&from.into()));
@@ -324,8 +322,12 @@ fn test_rewardable_nodes_deleted_nodes() {
 
     let node_3_rewardable_days = node_rewardable_days(&np_1_rewardables, 3);
 
+    // Node 3 should be rewardable until 2025-07-12 because on 2025-07-13 got deleted.
     assert_eq!(node_3_rewardable_days.first(), Some(&from.into()));
-    assert_eq!(node_3_rewardable_days.last(), Some(&to.into()));
+    assert_eq!(
+        node_3_rewardable_days.last(),
+        Some(&ts("2025-07-12").into())
+    );
 }
 
 #[test]
@@ -358,7 +360,7 @@ fn test_rewardable_nodes_rewardables_till_deleted() {
     assert_eq!(node_1_rewardable_days.first(), Some(&from.into()));
     assert_eq!(
         node_1_rewardable_days.last(),
-        Some(&ts("2025-07-08").into())
+        Some(&ts("2025-07-07").into())
     );
 
     // Node 2 is active throughout the whole range.
@@ -419,7 +421,6 @@ fn test_node_re_registered_after_deletion() {
 
     let expected_days: Vec<DayUtc> = vec![
         ts("2025-07-07").into(),
-        ts("2025-07-08").into(),
         // On 2025-07-08, node_1 was deleted, so it should not be rewardable until the 2025-07-11.
         ts("2025-07-11").into(),
         ts("2025-07-12").into(),

--- a/rs/node_rewards/rewards_calculation/src/rewards_calculator/mod.rs
+++ b/rs/node_rewards/rewards_calculation/src/rewards_calculator/mod.rs
@@ -328,7 +328,8 @@ type RewardsCoefficientPercent = Decimal;
 
 /// From constant [NODE_PROVIDER_REWARD_PERIOD_SECONDS]
 /// const NODE_PROVIDER_REWARD_PERIOD_SECONDS: u64 = 2629800;
-/// 30.4375 = 2629800 / 86400
+/// const SECONDS_IN_DAY: u64 = 86400;
+/// 2629800 / 86400 = 30.4375 days of rewards
 const REWARDS_TABLE_DAYS: Decimal = dec!(30.4375);
 
 #[derive(Default)]
@@ -455,11 +456,15 @@ fn step_4_compute_base_rewards_type_region(
     let base_rewards_type3 = base_rewards_type3
         .into_iter()
         .map(
-            |((day, region), (daily_rewards, nodes_count))| BaseRewardsType3 {
-                day: *day,
-                region,
-                nodes_count,
-                value: daily_rewards,
+            |((day, region), (daily_rewards, nodes_count, avg_rewards, avg_coefficient))| {
+                BaseRewardsType3 {
+                    day: *day,
+                    region,
+                    nodes_count,
+                    avg_rewards,
+                    avg_coefficient,
+                    value: daily_rewards,
+                }
             },
         )
         .collect();

--- a/rs/node_rewards/rewards_calculation/src/rewards_calculator/mod.rs
+++ b/rs/node_rewards/rewards_calculation/src/rewards_calculator/mod.rs
@@ -1,7 +1,7 @@
 use crate::rewards_calculator_results::{
-    BaseRewards, BaseRewardsType3, DailyResults, DayUtc, NodeMetricsDaily, NodeProviderRewards,
-    NodeResults, NodeStatus, Percent, RewardCalculatorError, RewardsCalculatorResults,
-    XDRPermyriad,
+    BaseRewards, DailyBaseRewardsType3, DailyResults, DayUtc, NodeMetricsDaily,
+    NodeProviderRewards, NodeResults, NodeStatus, Percent, RewardCalculatorError,
+    RewardsCalculatorResults, XDRPermyriad,
 };
 use crate::types::{
     NodeMetricsDailyRaw, Region, RewardPeriod, RewardableNode, SubnetMetricsDailyKey,
@@ -335,7 +335,7 @@ const REWARDS_TABLE_DAYS: Decimal = dec!(30.4375);
 #[derive(Default)]
 struct Step4Results {
     base_rewards: Vec<BaseRewards>,
-    base_rewards_type3: Vec<BaseRewardsType3>,
+    base_rewards_type3: Vec<DailyBaseRewardsType3>,
     base_rewards_per_node: BTreeMap<(DayUtc, NodeId), XDRPermyriad>,
 }
 fn step_4_compute_base_rewards_type_region(
@@ -429,7 +429,10 @@ fn step_4_compute_base_rewards_type_region(
             }
             let region_rewards_avg = avg(&region_rewards).unwrap_or_default();
 
-            ((day, region), (region_rewards_avg, nodes_count))
+            (
+                (day, region),
+                (region_rewards_avg, nodes_count, avg_rate, avg_coeff),
+            )
         })
         .collect::<BTreeMap<_, _>>();
 
@@ -438,7 +441,7 @@ fn step_4_compute_base_rewards_type_region(
             let base_rewards_for_day = if is_type3(&node.node_reward_type) {
                 let region_key = type3_region_key(&node.region);
 
-                let (base_rewards_daily, _) = base_rewards_type3
+                let (base_rewards_daily, _, _, _) = base_rewards_type3
                     .get(&(day, region_key))
                     .expect("Type3 base rewards expected for provider");
                 base_rewards_daily
@@ -457,7 +460,7 @@ fn step_4_compute_base_rewards_type_region(
         .into_iter()
         .map(
             |((day, region), (daily_rewards, nodes_count, avg_rewards, avg_coefficient))| {
-                BaseRewardsType3 {
+                DailyBaseRewardsType3 {
                     day: *day,
                     region,
                     nodes_count,
@@ -557,7 +560,7 @@ fn step_6_construct_provider_results(
     mut base_rewards_per_node: BTreeMap<(DayUtc, NodeId), XDRPermyriad>,
     mut adjusted_rewards: BTreeMap<(DayUtc, NodeId), XDRPermyriad>,
     base_rewards: Vec<BaseRewards>,
-    base_rewards_type3: Vec<BaseRewardsType3>,
+    base_rewards_type3: Vec<DailyBaseRewardsType3>,
 ) -> NodeProviderRewards {
     let mut results_by_node = Vec::new();
     let mut rewards_total_xdr_permyriad = Decimal::ZERO;

--- a/rs/node_rewards/rewards_calculation/src/rewards_calculator_results.rs
+++ b/rs/node_rewards/rewards_calculation/src/rewards_calculator_results.rs
@@ -126,6 +126,8 @@ pub struct BaseRewardsType3 {
     pub day: DayUtc,
     pub region: Region,
     pub nodes_count: usize,
+    pub avg_rewards: XDRPermyriad,
+    pub avg_coefficient: Percent,
     pub value: XDRPermyriad,
 }
 

--- a/rs/node_rewards/rewards_calculation/src/rewards_calculator_results.rs
+++ b/rs/node_rewards/rewards_calculation/src/rewards_calculator_results.rs
@@ -122,7 +122,7 @@ pub struct BaseRewards {
     pub daily: XDRPermyriad,
 }
 
-pub struct BaseRewardsType3 {
+pub struct DailyBaseRewardsType3 {
     pub day: DayUtc,
     pub region: Region,
     pub nodes_count: usize,
@@ -134,7 +134,7 @@ pub struct BaseRewardsType3 {
 pub struct NodeProviderRewards {
     pub rewards_total_xdr_permyriad: u64,
     pub base_rewards: Vec<BaseRewards>,
-    pub base_rewards_type3: Vec<BaseRewardsType3>,
+    pub base_rewards_type3: Vec<DailyBaseRewardsType3>,
     pub nodes_results: Vec<NodeResults>,
 }
 


### PR DESCRIPTION
Changes:
- Fix rewardable nodes computation to not consider rewardable the day when node is removed from the registry
- Add `avg_rewards` and `avg_coefficient` to Type3 rewards