### PR TITLE
chore: drop unused logs

### DIFF
--- a/rs/execution_environment/src/query_handler/query_context.rs
+++ b/rs/execution_environment/src/query_handler/query_context.rs
@@ -217,10 +217,6 @@ impl<'a> QueryContext<'a> {
         match query.source {
             QuerySource::System => {
                 if let WasmMethod::CompositeQuery(_) = &method {
-                    info!(
-                        self.log,
-                        "Running composite canister http transform on canister {}.", query.receiver
-                    );
                     return Err(UserError::new(
                         ErrorCode::CompositeQueryCalledInReplicatedMode,
                         "Composite query cannot be used as transform in canister http outcalls.",

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -256,14 +256,6 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                             };
 
                             if transform_result_size as u64 > max_response_size_bytes {
-                                info!(
-                                    log,
-                                    "Canister http transform result size {} on canister {} \
-                                    exceeds the `max_response_size` of {}.",
-                                    transform_result_size,
-                                    request_sender,
-                                    max_response_size_bytes
-                                );
                                 let err_msg = format!(
                                     "Transformed http response exceeds limit: {}",
                                     max_response_size_bytes


### PR DESCRIPTION
This PR removes logs collecting information about canister behavior (that should not be collected unless really necessary) that did not have any hits on the ICP mainnet in the last month (and thus they do not seem relevant anymore).