### PR TITLE
chore: upgrade autocfg to 1.5.0 to fix reproducibility

### DIFF
--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -129,7 +129,6 @@ runs:
           ^@@crate_index__cranelift-assembler-x64 # has a non reproducible generated-files.rs in its OUT_DIR.
           ^@@crate_index__cranelift-isle          # has a non reproducible isle_tests.rs in its OUT_DIR.
           ^@@crate_index__secp256k1-sys           # has non reproducible object files, like lax_der_parsing.o, in it OUT_DIR.
-          ^@@crate_index__num-traits              # has non reproducible autcfg files in its OUT_DIR. See: https://github.com/rust-num/num-traits/pull/355.
           ^@@crate_index__sev                     # build.rs depends on the presence of /dev/sev and /dev/sev-guest. See: https://github.com/virtee/sev/issues/315
         )
         for execlog_zst in $(find '${{ steps.metrics-tmpdir.outputs.dir }}' -name 'execlog-*.zst'); do

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "6ad17a1e77e3efc185eed74c406a8de71536d1163b905f95eda3663aa7dead88",
+  "checksum": "e67ca206487862c4c11927720791fc6b40531022c0ba8dd3e25e06f54a1434e5",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -5000,7 +5000,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -5016,14 +5016,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "autocfg 1.1.0": {
+    "autocfg 1.5.0": {
       "name": "autocfg",
-      "version": "1.1.0",
+      "version": "1.5.0",
       "package_url": "https://github.com/cuviper/autocfg",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/autocfg/1.1.0/download",
-          "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+          "url": "https://static.crates.io/crates/autocfg/1.5.0/download",
+          "sha256": "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
         }
       },
       "targets": [
@@ -5046,7 +5046,7 @@
           "**"
         ],
         "edition": "2015",
-        "version": "1.1.0"
+        "version": "1.5.0"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -20982,6 +20982,10 @@
               "target": "async_stream"
             },
             {
+              "id": "autocfg 1.5.0",
+              "target": "autocfg"
+            },
+            {
               "id": "axum 0.8.4",
               "target": "axum"
             },
@@ -27802,7 +27806,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -38694,7 +38698,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -45189,7 +45193,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -46830,7 +46834,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -46915,7 +46919,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -49616,7 +49620,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -50171,7 +50175,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -50328,7 +50332,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -58078,7 +58082,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -73364,7 +73368,7 @@
         "deps": {
           "common": [
             {
-              "id": "autocfg 1.1.0",
+              "id": "autocfg 1.5.0",
               "target": "autocfg"
             }
           ],
@@ -95424,6 +95428,7 @@
     "async-recursion 1.0.5",
     "async-stream 0.3.6",
     "async-trait 0.1.83",
+    "autocfg 1.5.0",
     "axum 0.8.4",
     "axum-extra 0.10.1",
     "axum-server 0.7.2",

--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "e67ca206487862c4c11927720791fc6b40531022c0ba8dd3e25e06f54a1434e5",
+  "checksum": "e51e69dadcf120b597cbc0cfa98f584bddfe30b75946f5349404c4a114f4fd20",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -20980,10 +20980,6 @@
             {
               "id": "async-stream 0.3.6",
               "target": "async_stream"
-            },
-            {
-              "id": "autocfg 1.5.0",
-              "target": "autocfg"
             },
             {
               "id": "axum 0.8.4",
@@ -95428,7 +95424,6 @@
     "async-recursion 1.0.5",
     "async-stream 0.3.6",
     "async-trait 0.1.83",
-    "autocfg 1.5.0",
     "axum 0.8.4",
     "axum-extra 0.10.1",
     "axum-server 0.7.2",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -889,14 +889,14 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -3544,6 +3544,7 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
+ "autocfg 1.5.0",
  "axum 0.8.4",
  "axum-extra",
  "axum-server",
@@ -4772,7 +4773,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
  "tokio",
 ]
 
@@ -6742,7 +6743,7 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
  "hashbrown 0.12.3",
  "serde",
 ]
@@ -7767,7 +7768,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
  "scopeguard",
 ]
 
@@ -8027,7 +8028,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
@@ -8036,7 +8037,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
@@ -8455,7 +8456,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
  "num-integer",
  "num-traits",
 ]
@@ -8529,7 +8530,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
  "num-integer",
  "num-traits",
 ]
@@ -8540,7 +8541,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
  "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
@@ -8563,7 +8564,7 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
  "libm",
 ]
 
@@ -9854,7 +9855,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff39edfcaec0d64e8d0da38564fad195d2d51b680940295fcc307366e101e61"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
  "indexmap 1.9.3",
  "serde",
 ]
@@ -12298,7 +12299,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3544,7 +3544,6 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
- "autocfg 1.5.0",
  "axum 0.8.4",
  "axum-extra",
  "axum-server",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,14 +868,14 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -4959,7 +4959,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "tokio",
 ]
 
@@ -15703,7 +15703,7 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "hashbrown 0.12.3",
  "serde",
 ]
@@ -16841,7 +16841,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "scopeguard",
 ]
 
@@ -17105,7 +17105,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
@@ -17114,7 +17114,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
@@ -17768,7 +17768,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "num-integer",
  "num-traits",
 ]
@@ -17842,7 +17842,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "num-integer",
  "num-traits",
 ]
@@ -17853,7 +17853,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
@@ -17876,7 +17876,7 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "libm",
 ]
 
@@ -19270,7 +19270,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bda9164fe05bc9225752d54aae413343c36f684380005398a6a8fde95fe785"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "indexmap 1.9.3",
  "serde",
 ]
@@ -22157,7 +22157,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -258,9 +258,6 @@ def external_crates_repository(name, cargo_lockfile, lockfile):
             "async-trait": crate.spec(
                 version = "^0.1.83",
             ),
-            "autocfg": crate.spec(
-                version = "^1.5.0",
-            ),
             "axum": crate.spec(
                 version = "^0.8.4",
                 features = ["ws"],

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -258,6 +258,9 @@ def external_crates_repository(name, cargo_lockfile, lockfile):
             "async-trait": crate.spec(
                 version = "^0.1.83",
             ),
+            "autocfg": crate.spec(
+                version = "^1.5.0",
+            ),
             "axum": crate.spec(
                 version = "^0.8.4",
                 features = ["ws"],


### PR DESCRIPTION
This upgrades the `autocfg` crate to 1.5.0 in most places* to get a fix for a reproducibility issue in the `num-traits` crate. See: https://github.com/rust-num/num-traits/pull/355#issuecomment-2982171195.

\* There are still some dependencies left on `autocfg-0.1.8` from the `rand-0.6.5`, `rand_chacha-0.1.1` and `rand_pcg-0.1.8` crates. But importantly `num-traits` will now be using `autocfg-1.5.0`.