### PR TITLE
test(ICRC_Ledgers): Add ICRC-3 test ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9934,6 +9934,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-icrc3-test-ledger"
+version = "0.9.0"
+dependencies = [
+ "candid",
+ "candid_parser",
+ "ic-base-types",
+ "ic-cdk 0.17.2",
+ "ic-state-machine-tests",
+ "ic-test-utilities-load-wasm",
+ "icrc-ledger-types",
+ "num-traits",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-identity-hsm"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ members = [
     "rs/ledger_suite/icrc1/index-ng",
     "rs/ledger_suite/icrc1/ledger",
     "rs/ledger_suite/icrc1/test_utils",
+    "rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger",
     "rs/ledger_suite/icrc1/tokens_u256",
     "rs/ledger_suite/icrc1/tokens_u64",
     "rs/ledger_suite/tests/sm-tests",

--- a/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/BUILD.bazel
@@ -1,0 +1,72 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//bazel:canisters.bzl", "rust_canister")
+load("//bazel:defs.bzl", "rust_ic_test_suite")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "icrc3_test_ledger",
+    srcs = glob(["src/**/lib.rs"]),
+    crate_name = "ic_icrc3_test_ledger",
+    version = "0.1.0",
+    deps = [
+        # Keep sorted.
+        "//packages/icrc-ledger-types:icrc_ledger_types",
+        "@crate_index//:candid",
+        "@crate_index//:ic-cdk",
+    ],
+)
+
+rust_canister(
+    name = "icrc3_test_ledger_canister",
+    srcs = ["src/main.rs"],
+    crate_name = "ic_icrc3_test_ledger_canister",
+    opt = "z",
+    service_file = ":icrc3_test_ledger.did",
+    version = "0.9.0",
+    deps = [
+        # Keep sorted.
+        ":icrc3_test_ledger",
+        "//packages/icrc-ledger-types:icrc_ledger_types",
+        "@crate_index//:candid",
+        "@crate_index//:ic-cdk",
+        "@crate_index//:num-traits",
+        "@crate_index//:serde",
+    ],
+)
+
+rust_test(
+    name = "icrc3_test_ledger_canister_test",
+    crate = ":_wasm_icrc3_test_ledger_canister",
+    data = [
+        ":icrc3_test_ledger.did",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": "rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger",
+    },
+    deps = [
+        "@crate_index//:candid_parser",
+    ],
+)
+
+rust_ic_test_suite(
+    name = "icrc3_test_ledger_integration_test",
+    srcs = ["tests/tests.rs"],
+    data = [
+        ":icrc3_test_ledger_canister.wasm.gz",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": "rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger",
+        "ICRC3_TEST_LEDGER_CANISTER_WASM_PATH": "$(rootpath :icrc3_test_ledger_canister.wasm.gz)",
+    },
+    deps = [
+        # Keep sorted.
+        ":icrc3_test_ledger",
+        "//packages/icrc-ledger-types:icrc_ledger_types",
+        "//rs/state_machine_tests",
+        "//rs/test_utilities/load_wasm",
+        "//rs/types/base_types",
+        "@crate_index//:candid",
+        "@crate_index//:serde_bytes",
+    ],
+)

--- a/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/Cargo.toml
+++ b/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ic-icrc3-test-ledger"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[lib]
+name = "ic_icrc3_test_ledger"
+path = "src/lib.rs"
+
+[[bin]]
+name = "ic-icrc3-test-ledger"
+path = "src/main.rs"
+
+[dependencies]
+candid = { workspace = true }
+ic-cdk = { workspace = true }
+icrc-ledger-types = { path = "../../../../../packages/icrc-ledger-types" }
+num-traits = { workspace = true }
+
+[dev-dependencies]
+candid_parser = { workspace = true }
+ic-base-types = { path = "../../../../types/base_types" }
+ic-state-machine-tests = { path = "../../../../state_machine_tests" }
+ic-test-utilities-load-wasm = { path = "../../../../test_utilities/load_wasm" }
+serde_bytes = { workspace = true }

--- a/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/README.md
+++ b/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/README.md
@@ -1,0 +1,57 @@
+# ICRC-3 Test Ledger
+
+This is a simplified ICRC-3 ledger canister for testing purposes. It allows users to store and retrieve ICRC-3
+compatible blocks.
+
+## Features
+
+- **add_block**: An update endpoint that accepts an `ICRC3Value` (representing an ICRC-3 block) and stores it with an
+  auto-incrementing block ID
+- **icrc3_get_blocks**: A query endpoint compatible with the ICRC-3 standard that returns stored blocks
+
+## Interface
+
+The canister exposes the following endpoints:
+
+### Update Methods
+
+- `add_block(block: ICRC3Value) -> AddBlockResult`
+    - Stores a new block and returns its assigned ID
+    - Returns `Ok(block_id)` on success or `Err(message)` on failure
+    - Does not perform any validation on the block content, e.g., it does not check if the block is a valid ICRC-3
+      block, if it contains valid transactions, or a valid parent block hash.
+
+### Query Methods
+
+- `icrc3_get_blocks(requests: Vec<GetBlocksArgs>) -> GetBlocksResult`
+    - Retrieves blocks according to ICRC-3 standard
+    - Supports querying multiple ranges of blocks in a single call
+    - Compatible with existing ICRC-3 tooling
+
+## Building
+
+Build the canister using Bazel:
+
+```bash
+bazel build //rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger:icrc3_test_ledger_canister.wasm.gz
+```
+
+## Testing
+
+Run the tests:
+
+```bash
+bazel test //rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger:icrc3_test_ledger_canister_test
+```
+
+## Storage
+
+q
+The canister uses in-memory storage (heap) for simplicity. Data will not persist across canister upgrades. For a
+production use case, you would want to implement stable storage.
+
+## Type Definitions
+
+- `ICRC3Value`: The ICRC-3 value type from `icrc_ledger_types::icrc::generic_value::ICRC3Value`
+- `AddBlockResult`: `Result<Nat, String>` where `Nat` is the block ID
+- `GetBlocksArgs` and `GetBlocksResult`: Standard ICRC-3 types for block retrieval

--- a/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/icrc3_test_ledger.did
+++ b/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/icrc3_test_ledger.did
@@ -1,0 +1,43 @@
+type BlockIndex = nat;
+
+type ICRC3Value = variant {
+    Blob : blob;
+    Text : text;
+    Nat : nat;
+    Int : int;
+    Array : vec ICRC3Value;
+    Map : vec record { text; ICRC3Value };
+};
+
+type GetBlocksArgs = record {
+    // The index of the first block to fetch.
+    start : BlockIndex;
+    // Max number of blocks to fetch.
+    length : nat;
+};
+
+type GetBlocksResult = record {
+    // Total number of blocks in the
+    // block log
+    log_length : nat;
+
+    blocks : vec record { id : nat; block: ICRC3Value };
+
+    archived_blocks : vec record {
+        args : vec GetBlocksArgs;
+        callback : func (vec GetBlocksArgs) -> (GetBlocksResult) query;
+    };
+};
+
+type AddBlockResult = variant {
+    Ok : nat;
+    Err : text;
+};
+
+service : {
+    // Update endpoint to add a block to the ledger
+    add_block : (ICRC3Value) -> (AddBlockResult);
+
+    // Query endpoint to retrieve blocks (ICRC-3 compatible)
+    icrc3_get_blocks : (vec GetBlocksArgs) -> (GetBlocksResult) query;
+}

--- a/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/src/lib.rs
+++ b/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/src/lib.rs
@@ -1,0 +1,3 @@
+use candid::Nat;
+
+pub type AddBlockResult = Result<Nat, String>;

--- a/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/src/main.rs
@@ -1,0 +1,104 @@
+use candid::{candid_method, Nat};
+use ic_cdk::{query, update};
+use ic_icrc3_test_ledger::AddBlockResult;
+use icrc_ledger_types::icrc::generic_value::ICRC3Value;
+use icrc_ledger_types::icrc3::blocks::{BlockWithId, GetBlocksRequest, GetBlocksResult};
+use num_traits::ToPrimitive;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+type BlockStorage = BTreeMap<u64, ICRC3Value>;
+
+thread_local! {
+    static BLOCKS: RefCell<BlockStorage> = RefCell::new(BTreeMap::new());
+    static NEXT_BLOCK_ID: RefCell<u64> = RefCell::new(0);
+}
+
+/// Add a block to the ledger storage
+#[candid_method(update)]
+#[update]
+pub fn add_block(block: ICRC3Value) -> AddBlockResult {
+    BLOCKS.with(|blocks| {
+        NEXT_BLOCK_ID.with(|next_id| {
+            let mut blocks = blocks.borrow_mut();
+            let mut next_id = next_id.borrow_mut();
+
+            let block_id = *next_id;
+            blocks.insert(block_id, block);
+            *next_id += 1;
+
+            Ok(Nat::from(block_id))
+        })
+    })
+}
+
+/// Get blocks from the ledger (ICRC-3 compatible)
+#[candid_method(query)]
+#[query]
+pub fn icrc3_get_blocks(requests: Vec<GetBlocksRequest>) -> GetBlocksResult {
+    BLOCKS.with(|blocks| {
+        NEXT_BLOCK_ID.with(|next_id| {
+            let blocks = blocks.borrow();
+            let total_blocks = *next_id.borrow();
+
+            let mut result_blocks = Vec::new();
+
+            // Process all requests
+            for request in requests {
+                let start = request.start.0.to_u64().unwrap_or(0);
+                let length = request.length.0.to_u64().unwrap_or(0) as usize;
+
+                // Get blocks in the requested range
+                for block_id in start..std::cmp::min(start + length as u64, total_blocks) {
+                    if let Some(block) = blocks.get(&block_id) {
+                        result_blocks.push(BlockWithId {
+                            id: Nat::from(block_id),
+                            block: block.clone(),
+                        });
+                    }
+                }
+            }
+
+            GetBlocksResult {
+                log_length: Nat::from(total_blocks),
+                blocks: result_blocks,
+                archived_blocks: vec![], // No archiving in this simple implementation
+            }
+        })
+    })
+}
+
+pub fn get_block_count() -> u64 {
+    NEXT_BLOCK_ID.with(|next_id| *next_id.borrow())
+}
+
+fn main() {}
+
+#[cfg(test)]
+candid::export_service!();
+
+#[cfg(test)]
+mod tests {
+    use crate::__export_service;
+
+    #[test]
+    fn check_candid_interface() {
+        use candid_parser::utils::{service_equal, CandidSource};
+
+        let new_interface = __export_service();
+
+        let manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+        let old_interface = manifest_dir.join("icrc3_test_ledger.did");
+        service_equal(
+            CandidSource::Text(&new_interface),
+            CandidSource::File(old_interface.as_path()),
+        )
+        .unwrap_or_else(|e| {
+            panic!(
+                "the icrc3_test_ledger interface is not compatible with {}: {:?}",
+                old_interface.display(),
+                e
+            )
+        });
+    }
+}

--- a/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/tests/tests.rs
@@ -1,0 +1,346 @@
+use candid::{Decode, Encode, Nat};
+use ic_base_types::{CanisterId, PrincipalId};
+use ic_icrc3_test_ledger::AddBlockResult;
+use ic_state_machine_tests::StateMachine;
+use ic_test_utilities_load_wasm::load_wasm;
+use icrc_ledger_types::icrc::generic_value::ICRC3Value;
+use icrc_ledger_types::icrc3::blocks::{GetBlocksRequest, GetBlocksResult};
+use serde_bytes::ByteBuf;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+const TEST_USER_1: PrincipalId = PrincipalId::new_user_test_id(1);
+const TEST_USER_2: PrincipalId = PrincipalId::new_user_test_id(2);
+
+fn icrc3_test_ledger_wasm() -> Vec<u8> {
+    load_wasm(
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .parent()
+            .unwrap()
+            .join("icrc3_test_ledger"),
+        "icrc3_test_ledger_canister",
+        &[],
+    )
+}
+
+fn setup_icrc3_test_ledger() -> (StateMachine, CanisterId) {
+    let env = StateMachine::new();
+    let canister_id = env
+        .install_canister(icrc3_test_ledger_wasm(), vec![], None)
+        .unwrap();
+    (env, canister_id)
+}
+
+fn add_block(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    block: ICRC3Value,
+) -> Result<Nat, String> {
+    let result = Decode!(
+        &env.execute_ingress(canister_id, "add_block", Encode!(&block).unwrap())
+            .expect("failed to add block")
+            .bytes(),
+        AddBlockResult
+    )
+    .expect("failed to decode add_block response");
+
+    result
+}
+
+fn icrc3_get_blocks(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    requests: Vec<GetBlocksRequest>,
+) -> GetBlocksResult {
+    Decode!(
+        &env.query(canister_id, "icrc3_get_blocks", Encode!(&requests).unwrap())
+            .expect("failed to get blocks")
+            .bytes(),
+        GetBlocksResult
+    )
+    .expect("failed to decode icrc3_get_blocks response")
+}
+
+fn create_test_transfer_block(block_id: u64, amount: u64, timestamp: u64) -> ICRC3Value {
+    let mut block_map = BTreeMap::new();
+
+    // Add timestamp
+    block_map.insert("ts".to_string(), ICRC3Value::Nat(Nat::from(timestamp)));
+
+    // Create transaction
+    let mut tx_map = BTreeMap::new();
+    tx_map.insert("op".to_string(), ICRC3Value::Text("xfer".to_string()));
+
+    tx_map.insert(
+        "from".to_string(),
+        ICRC3Value::Array(vec![ICRC3Value::Blob(ByteBuf::from(TEST_USER_1))]),
+    );
+    tx_map.insert(
+        "to".to_string(),
+        ICRC3Value::Array(vec![ICRC3Value::Blob(ByteBuf::from(TEST_USER_2))]),
+    );
+    tx_map.insert("amt".to_string(), ICRC3Value::Nat(Nat::from(amount)));
+
+    block_map.insert("tx".to_string(), ICRC3Value::Map(tx_map));
+
+    // Add parent hash for blocks after the first
+    if block_id > 0 {
+        let parent_hash = vec![0u8; 32]; // Simplified parent hash for testing
+        block_map.insert(
+            "phash".to_string(),
+            ICRC3Value::Blob(ByteBuf::from(parent_hash)),
+        );
+    }
+
+    ICRC3Value::Map(block_map)
+}
+
+fn create_test_mint_block(block_id: u64, amount: u64, timestamp: u64) -> ICRC3Value {
+    let mut block_map = BTreeMap::new();
+
+    // Add timestamp
+    block_map.insert("ts".to_string(), ICRC3Value::Nat(Nat::from(timestamp)));
+
+    // Create transaction
+    let mut tx_map = BTreeMap::new();
+    tx_map.insert("op".to_string(), ICRC3Value::Text("mint".to_string()));
+
+    tx_map.insert(
+        "to".to_string(),
+        ICRC3Value::Array(vec![ICRC3Value::Blob(ByteBuf::from(TEST_USER_1))]),
+    );
+    tx_map.insert("amt".to_string(), ICRC3Value::Nat(Nat::from(amount)));
+
+    block_map.insert("tx".to_string(), ICRC3Value::Map(tx_map));
+
+    // Add parent hash for blocks after the first
+    if block_id > 0 {
+        let parent_hash = vec![0u8; 32]; // Simplified parent hash for testing
+        block_map.insert(
+            "phash".to_string(),
+            ICRC3Value::Blob(ByteBuf::from(parent_hash)),
+        );
+    }
+
+    ICRC3Value::Map(block_map)
+}
+
+#[test]
+fn test_basic_add_and_get_blocks() {
+    let (env, canister_id) = setup_icrc3_test_ledger();
+
+    // Create some test blocks
+    let block0 = create_test_mint_block(0, 1_000_000, 1000);
+    let block1 = create_test_transfer_block(1, 100_000, 2000);
+    let block2 = create_test_mint_block(2, 500_000, 3000);
+
+    // Add blocks to the ledger
+    let result0 = add_block(&env, canister_id, block0.clone()).expect("Failed to add block 0");
+    assert_eq!(result0, Nat::from(0u64));
+
+    let result1 = add_block(&env, canister_id, block1.clone()).expect("Failed to add block 1");
+    assert_eq!(result1, Nat::from(1u64));
+
+    let result2 = add_block(&env, canister_id, block2.clone()).expect("Failed to add block 2");
+    assert_eq!(result2, Nat::from(2u64));
+
+    // Test retrieving blocks
+    let get_blocks_result = icrc3_get_blocks(
+        &env,
+        canister_id,
+        vec![GetBlocksRequest {
+            start: Nat::from(0u64),
+            length: Nat::from(3u64),
+        }],
+    );
+
+    assert_eq!(get_blocks_result.log_length, Nat::from(3u64));
+    assert_eq!(get_blocks_result.blocks.len(), 3);
+    assert!(get_blocks_result.archived_blocks.is_empty());
+
+    // Verify the blocks are returned in the correct order
+    assert_eq!(get_blocks_result.blocks[0].id, Nat::from(0u64));
+    assert_eq!(get_blocks_result.blocks[0].block, block0);
+
+    assert_eq!(get_blocks_result.blocks[1].id, Nat::from(1u64));
+    assert_eq!(get_blocks_result.blocks[1].block, block1);
+
+    assert_eq!(get_blocks_result.blocks[2].id, Nat::from(2u64));
+    assert_eq!(get_blocks_result.blocks[2].block, block2);
+}
+
+#[test]
+fn test_get_blocks_with_different_ranges() {
+    let (env, canister_id) = setup_icrc3_test_ledger();
+
+    // Add 5 blocks
+    let mut added_blocks = Vec::new();
+    for i in 0..5 {
+        let block = create_test_transfer_block(i, 1000 + i * 100, 1000 + i * 1000);
+        add_block(&env, canister_id, block.clone()).expect("Failed to add block");
+        added_blocks.push(block);
+    }
+
+    // Test getting first 2 blocks
+    let result = icrc3_get_blocks(
+        &env,
+        canister_id,
+        vec![GetBlocksRequest {
+            start: Nat::from(0u64),
+            length: Nat::from(2u64),
+        }],
+    );
+    assert_eq!(result.blocks.len(), 2);
+    assert_eq!(result.blocks[0].id, Nat::from(0u64));
+    assert_eq!(result.blocks[1].id, Nat::from(1u64));
+
+    // Test getting blocks 2-4
+    let result = icrc3_get_blocks(
+        &env,
+        canister_id,
+        vec![GetBlocksRequest {
+            start: Nat::from(2u64),
+            length: Nat::from(3u64),
+        }],
+    );
+    assert_eq!(result.blocks.len(), 3);
+    assert_eq!(result.blocks[0].id, Nat::from(2u64));
+    assert_eq!(result.blocks[1].id, Nat::from(3u64));
+    assert_eq!(result.blocks[2].id, Nat::from(4u64));
+
+    // Test getting non-existent blocks
+    let result = icrc3_get_blocks(
+        &env,
+        canister_id,
+        vec![GetBlocksRequest {
+            start: Nat::from(10u64),
+            length: Nat::from(2u64),
+        }],
+    );
+    assert_eq!(result.blocks.len(), 0);
+    assert_eq!(result.log_length, Nat::from(5u64));
+}
+
+#[test]
+fn test_get_blocks_with_multiple_requests() {
+    let (env, canister_id) = setup_icrc3_test_ledger();
+
+    // Add 5 blocks
+    for i in 0..5 {
+        let block = create_test_transfer_block(i, 1000 + i * 100, 1000 + i * 1000);
+        add_block(&env, canister_id, block).expect("Failed to add block");
+    }
+
+    // Test multiple requests in a single call
+    let result = icrc3_get_blocks(
+        &env,
+        canister_id,
+        vec![
+            GetBlocksRequest {
+                start: Nat::from(0u64),
+                length: Nat::from(2u64),
+            },
+            GetBlocksRequest {
+                start: Nat::from(3u64),
+                length: Nat::from(2u64),
+            },
+        ],
+    );
+
+    // Should return 4 blocks total (blocks 0, 1, 3, 4)
+    assert_eq!(result.blocks.len(), 4);
+    assert_eq!(result.blocks[0].id, Nat::from(0u64));
+    assert_eq!(result.blocks[1].id, Nat::from(1u64));
+    assert_eq!(result.blocks[2].id, Nat::from(3u64));
+    assert_eq!(result.blocks[3].id, Nat::from(4u64));
+}
+
+#[test]
+fn test_get_blocks_empty_request() {
+    let (env, canister_id) = setup_icrc3_test_ledger();
+
+    // Test getting blocks when no blocks exist
+    let result = icrc3_get_blocks(&env, canister_id, vec![]);
+    assert_eq!(result.blocks.len(), 0);
+    assert_eq!(result.log_length, Nat::from(0u64));
+
+    // Add a block
+    let block = create_test_mint_block(0, 1_000_000, 1000);
+    add_block(&env, canister_id, block).expect("Failed to add block");
+
+    // Test empty request with blocks present
+    let result = icrc3_get_blocks(&env, canister_id, vec![]);
+    assert_eq!(result.blocks.len(), 0);
+    assert_eq!(result.log_length, Nat::from(1u64));
+}
+
+#[test]
+fn test_get_blocks_zero_length() {
+    let (env, canister_id) = setup_icrc3_test_ledger();
+
+    // Add a block
+    let block = create_test_mint_block(0, 1_000_000, 1000);
+    add_block(&env, canister_id, block).expect("Failed to add block");
+
+    // Test zero-length request
+    let result = icrc3_get_blocks(
+        &env,
+        canister_id,
+        vec![GetBlocksRequest {
+            start: Nat::from(0u64),
+            length: Nat::from(0u64),
+        }],
+    );
+    assert_eq!(result.blocks.len(), 0);
+    assert_eq!(result.log_length, Nat::from(1u64));
+}
+
+#[test]
+fn test_add_complex_block() {
+    let (env, canister_id) = setup_icrc3_test_ledger();
+
+    // Create a complex block with multiple fields
+    let mut block_map = BTreeMap::new();
+    block_map.insert("ts".to_string(), ICRC3Value::Nat(Nat::from(1000u64)));
+    block_map.insert("fee".to_string(), ICRC3Value::Nat(Nat::from(10000u64)));
+
+    // Add a complex transaction with memo
+    let mut tx_map = BTreeMap::new();
+    tx_map.insert("op".to_string(), ICRC3Value::Text("xfer".to_string()));
+    tx_map.insert(
+        "memo".to_string(),
+        ICRC3Value::Blob(ByteBuf::from(b"test memo".to_vec())),
+    );
+
+    tx_map.insert(
+        "from".to_string(),
+        ICRC3Value::Array(vec![ICRC3Value::Blob(ByteBuf::from(TEST_USER_1))]),
+    );
+    tx_map.insert(
+        "to".to_string(),
+        ICRC3Value::Array(vec![ICRC3Value::Blob(ByteBuf::from(TEST_USER_2))]),
+    );
+    tx_map.insert("amt".to_string(), ICRC3Value::Nat(Nat::from(500000u64)));
+
+    block_map.insert("tx".to_string(), ICRC3Value::Map(tx_map));
+
+    let complex_block = ICRC3Value::Map(block_map);
+
+    // Add the complex block
+    let result =
+        add_block(&env, canister_id, complex_block.clone()).expect("Failed to add complex block");
+    assert_eq!(result, Nat::from(0u64));
+
+    // Retrieve and verify the complex block
+    let get_result = icrc3_get_blocks(
+        &env,
+        canister_id,
+        vec![GetBlocksRequest {
+            start: Nat::from(0u64),
+            length: Nat::from(1u64),
+        }],
+    );
+
+    assert_eq!(get_result.blocks.len(), 1);
+    assert_eq!(get_result.blocks[0].block, complex_block);
+}


### PR DESCRIPTION
Add an ICRC-3 test ledger that can be used for storing and retrieving arbitrary ICRC-3 blocks. The test ledger can be useful for e.g., testing new block types with ICRC ledger clients such as the index canister or ICRC Rosetta.