### PR TITLE
feat: print node name in Build IC

### DIFF
--- a/.github/actions/bazel-test-all/action.yaml
+++ b/.github/actions/bazel-test-all/action.yaml
@@ -35,7 +35,6 @@ runs:
           execlogs-artifact-name: ${{ inputs.execlogs-artifact-name }}
           run: |
             set -euo pipefail
-            echo "::notice::Node Name: ${NODE_NAME}"
 
             diff_only='${{ inputs.diff-only }}'
             stamp_build='${{ inputs.stamp-build }}'

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -150,6 +150,9 @@ jobs:
       CI_OVERRIDE_BUF_BREAKING: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_BUF_BREAKING') }}
     steps:
       - <<: *checkout
+      - name: "Node Name"
+        run: |
+          echo "::notice::Node Name: ${NODE_NAME}"
       - name: Set BAZEL_EXTRA_ARGS
         shell: bash
         id: bazel-extra-args
@@ -419,6 +422,9 @@ jobs:
     if: ${{ github.event_name != 'merge_group' }}
     steps:
       - <<: *checkout
+      - name: "Node Name"
+        run: |
+          echo "::notice::Node Name: ${NODE_NAME}"
       - name: Run Build IC
         uses: ./.github/actions/bazel
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -122,6 +122,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
+      - name: "Node Name"
+        run: |
+          echo "::notice::Node Name: ${NODE_NAME}"
       - name: Set BAZEL_EXTRA_ARGS
         shell: bash
         id: bazel-extra-args
@@ -409,6 +412,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
+      - name: "Node Name"
+        run: |
+          echo "::notice::Node Name: ${NODE_NAME}"
       - name: Run Build IC
         uses: ./.github/actions/bazel
         with:


### PR DESCRIPTION
This moves the node name notice out of bazel-test-all and into the main CI workflow. This also adds a node name notice to Build IC to help us track down build reproducibility issues that may be linked to specific nodes.