### PR TITLE
chore: Add clobber argument to write_atomically and use it in ic_os code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5318,6 +5318,7 @@ dependencies = [
 name = "grub"
 version = "1.0.0"
 dependencies = [
+ "ic-sys",
  "regex",
  "strum 0.26.3",
  "tempfile",
@@ -5332,12 +5333,11 @@ dependencies = [
  "clap 4.5.27",
  "config",
  "config_types",
- "grub",
+ "ic-sys",
  "ic_device",
  "ic_sev",
  "itertools 0.12.1",
  "libcryptsetup-rs",
- "linux_kernel_command_line",
  "nix 0.24.3",
  "parking_lot",
  "rand 0.8.5",

--- a/rs/ic_os/grub/BUILD.bazel
+++ b/rs/ic_os/grub/BUILD.bazel
@@ -4,6 +4,7 @@ package(default_visibility = ["//rs:ic-os-pkg"])
 
 DEPENDENCIES = [
     # Keep sorted.
+    "//rs/sys",
     "@crate_index//:regex",
     "@crate_index//:strum",
     "@crate_index//:thiserror",

--- a/rs/ic_os/grub/Cargo.toml
+++ b/rs/ic_os/grub/Cargo.toml
@@ -4,9 +4,10 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
+ic-sys = { path = "../../sys" }
+regex = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
-regex = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/rs/ic_os/grub/src/lib.rs
+++ b/rs/ic_os/grub/src/lib.rs
@@ -1,4 +1,4 @@
-use ic_sys::fs::write_atomically;
+use ic_sys::fs::{write_atomically, Clobber};
 use regex::Regex;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
@@ -131,7 +131,9 @@ impl GrubEnv {
     /// Writes the GRUB environment to a file atomically.
     /// If the function fails, the file will not be modified.
     pub fn write_to_file(&self, path: &Path) -> Result<(), std::io::Error> {
-        write_atomically(path, |file| file.write_all(&self.write_to_vec()?))
+        write_atomically(path, Clobber::Yes, |file| {
+            file.write_all(&self.write_to_vec()?)
+        })
     }
 }
 

--- a/rs/ic_os/grub/src/lib.rs
+++ b/rs/ic_os/grub/src/lib.rs
@@ -1,3 +1,4 @@
+use ic_sys::fs::write_atomically;
 use regex::Regex;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
@@ -127,9 +128,10 @@ impl GrubEnv {
         }
     }
 
+    /// Writes the GRUB environment to a file atomically.
+    /// If the function fails, the file will not be modified.
     pub fn write_to_file(&self, path: &Path) -> Result<(), std::io::Error> {
-        // We write to a buffer first so that the file is not changed if there is a problem.
-        std::fs::write(path, self.write_to_vec()?)
+        write_atomically(path, |file| file.write_all(&self.write_to_vec()?))
     }
 }
 

--- a/rs/ic_os/os_tools/guest_disk/BUILD.bazel
+++ b/rs/ic_os/os_tools/guest_disk/BUILD.bazel
@@ -4,11 +4,10 @@ package(default_visibility = ["//rs:ic-os-pkg"])
 
 DEPENDENCIES = [
     # Keep sorted.
+    "//rs/sys",
     "//rs/ic_os/config:config_lib",
     "//rs/ic_os/config_types",
     "//rs/ic_os/device",
-    "//rs/ic_os/grub",
-    "//rs/ic_os/linux_kernel_command_line",
     "//rs/ic_os/sev",
     "@crate_index//:anyhow",
     "@crate_index//:clap",

--- a/rs/ic_os/os_tools/guest_disk/BUILD.bazel
+++ b/rs/ic_os/os_tools/guest_disk/BUILD.bazel
@@ -4,11 +4,11 @@ package(default_visibility = ["//rs:ic-os-pkg"])
 
 DEPENDENCIES = [
     # Keep sorted.
-    "//rs/sys",
     "//rs/ic_os/config:config_lib",
     "//rs/ic_os/config_types",
     "//rs/ic_os/device",
     "//rs/ic_os/sev",
+    "//rs/sys",
     "@crate_index//:anyhow",
     "@crate_index//:clap",
     "@crate_index//:itertools",

--- a/rs/ic_os/os_tools/guest_disk/Cargo.toml
+++ b/rs/ic_os/os_tools/guest_disk/Cargo.toml
@@ -7,11 +7,10 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 config = { path = "../../config" }
 config_types = { path = "../../config_types" }
-grub = { path = "../../grub" }
 libcryptsetup-rs = { workspace = true }
-linux_kernel_command_line = { path = "../../linux_kernel_command_line" }
 ic_device = { path = "../../device" }
 ic_sev = { path = "../../sev" }
+ic-sys = { path = "../../../sys" }
 itertools = { workspace = true }
 nix = { workspace = true }
 rand = { workspace = true }

--- a/rs/ic_os/os_tools/guest_disk/src/generated_key.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/generated_key.rs
@@ -45,7 +45,7 @@ impl GeneratedKeyDiskEncryption<'_> {
                 .key_path
                 .parent()
                 .context("Could not find parent directory for key file")?;
-            let mut temp = tempfile::Builder::new()
+            let temp = tempfile::Builder::new()
                 .permissions(Permissions::from_mode(0o600))
                 .tempfile_in(parent_dir)
                 .context("Could not create temporary file for boot partition key")?;

--- a/rs/ic_os/os_tools/guest_disk/src/generated_key.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/generated_key.rs
@@ -1,7 +1,7 @@
 use crate::crypt::{activate_crypt_device, format_crypt_device};
 use crate::{activate_flags, DiskEncryption, Partition};
 use anyhow::{Context, Result};
-use ic_sys::fs::write_atomically_using_tmp_file_noclobber;
+use ic_sys::fs::{write_atomically_using_tmp_file, Clobber};
 use std::fs::Permissions;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
@@ -50,7 +50,7 @@ impl GeneratedKeyDiskEncryption<'_> {
                 .tempfile_in(parent_dir)
                 .context("Could not create temporary file for boot partition key")?;
             let rand_key = rand::random::<[u8; GENERATED_KEY_SIZE_BYTES]>();
-            match write_atomically_using_tmp_file_noclobber(self.key_path, temp.path(), |buf| {
+            match write_atomically_using_tmp_file(self.key_path, temp.path(), Clobber::No, |buf| {
                 buf.write_all(&rand_key)
             }) {
                 Ok(_) => {

--- a/rs/ic_os/os_tools/guest_disk/src/generated_key.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/generated_key.rs
@@ -1,6 +1,7 @@
 use crate::crypt::{activate_crypt_device, format_crypt_device};
 use crate::{activate_flags, DiskEncryption, Partition};
 use anyhow::{Context, Result};
+use ic_sys::fs::write_atomically_using_tmp_file_noclobber;
 use std::fs::Permissions;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
@@ -49,13 +50,9 @@ impl GeneratedKeyDiskEncryption<'_> {
                 .tempfile_in(parent_dir)
                 .context("Could not create temporary file for boot partition key")?;
             let rand_key = rand::random::<[u8; GENERATED_KEY_SIZE_BYTES]>();
-            temp.write_all(&rand_key)
-                .context("Could not write generated key")?;
-
-            match temp
-                .persist_noclobber(self.key_path)
-                .context("Could not persist boot partition key")
-            {
+            match write_atomically_using_tmp_file_noclobber(self.key_path, temp.path(), |buf| {
+                buf.write_all(&rand_key)
+            }) {
                 Ok(_) => {
                     println!(
                         "Generated disk encryption key and saved it to {}",
@@ -65,7 +62,7 @@ impl GeneratedKeyDiskEncryption<'_> {
                 }
                 Err(err) => {
                     if !self.key_path.exists() {
-                        return Err(err);
+                        return Err(err.into());
                     }
                     // If the file was created in the meantime by a concurrent process, fall through
                     // to reading it.

--- a/rs/registry/proto_data_provider/src/lib.rs
+++ b/rs/registry/proto_data_provider/src/lib.rs
@@ -4,7 +4,7 @@ use ic_registry_common_proto::pb::proto_registry::v1::{ProtoRegistry, ProtoRegis
 use ic_registry_transport::pb::v1::registry_mutation::Type;
 use ic_registry_transport::pb::v1::{RegistryAtomicMutateRequest, RegistryMutation};
 use ic_registry_transport::upsert;
-use ic_sys::fs::write_atomically;
+use ic_sys::fs::{write_atomically, Clobber};
 use ic_types::{registry::RegistryDataProviderError, RegistryVersion};
 use std::collections::HashMap;
 use std::{
@@ -147,7 +147,7 @@ impl ProtoRegistryDataProvider {
     where
         P: AsRef<Path>,
     {
-        write_atomically(path, |f| {
+        write_atomically(path, Clobber::Yes, |f| {
             let mut buf: Vec<u8> = vec![];
             self.encode(&mut buf);
             f.write_all(buf.as_slice())

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -387,7 +387,9 @@ pub fn tecdsa_performance_test(
         };
 
         let open_and_write_to_file_result =
-            ic_sys::fs::write_atomically(&report_path, |f| f.write_all(json_report_str.as_bytes()));
+            ic_sys::fs::write_atomically(&report_path, ic_sys::fs::Clobber::Yes, |f| {
+                f.write_all(json_report_str.as_bytes())
+            });
 
         match create_dir_result.and(open_and_write_to_file_result) {
             Ok(()) => info!(log, "Benchmark report written to {}", report_path.display()),

--- a/rs/tests/driver/src/driver/test_env.rs
+++ b/rs/tests/driver/src/driver/test_env.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use ic_prep_lib::prep_state_directory::IcPrepStateDir;
 use ic_registry_local_registry::LocalRegistry;
-use ic_sys::fs::{sync_path, write_atomically};
+use ic_sys::fs::{sync_path, write_atomically, Clobber};
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use serde::de::DeserializeOwned;
@@ -82,7 +82,7 @@ impl TestEnv {
         if let Some(parent_dir) = path.parent() {
             fs::create_dir_all(parent_dir)?;
         }
-        write_atomically(&path, |buf| {
+        write_atomically(&path, Clobber::Yes, |buf| {
             serde_json::to_writer(buf, t).map_err(|e| std::io::Error::other(e.to_string()))
         })
         .with_context(|| format!("{:?}: Could not write json object.", path))


### PR DESCRIPTION
The new noclobber variant only writes the file if it doesn't exist already. The implementation guarantees that the existence check and the write are done atomically.