### PR TITLE
refactor(sns): Make extension registration code more consistent w.r.t. extension operation execution (attempt 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13155,6 +13155,7 @@ dependencies = [
  "build-info-build",
  "canbench-rs",
  "candid",
+ "candid-utils",
  "candid_parser",
  "clap 4.5.27",
  "comparable",

--- a/rs/sns/governance/BUILD.bazel
+++ b/rs/sns/governance/BUILD.bazel
@@ -21,6 +21,7 @@ DEPENDENCIES = [
     "//rs/ledger_suite/common/ledger_core",
     "//rs/ledger_suite/icp:icp_ledger",
     "//rs/ledger_suite/icrc1/ledger",
+    "//rs/nervous_system/candid_utils",
     "//rs/nervous_system/canisters",
     "//rs/nervous_system/clients",
     "//rs/nervous_system/collections/union_multi_map",

--- a/rs/sns/governance/Cargo.toml
+++ b/rs/sns/governance/Cargo.toml
@@ -30,6 +30,7 @@ build-info = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 candid = { workspace = true }
+candid-utils = { path = "../../nervous_system/candid_utils" }
 clap = { workspace = true }
 comparable = { version = "0.5", features = ["derive"] }
 hex = { workspace = true }

--- a/rs/sns/governance/src/extensions.rs
+++ b/rs/sns/governance/src/extensions.rs
@@ -36,6 +36,16 @@ lazy_static! {
     static ref ALLOWED_EXTENSIONS: BTreeMap<[u8; 32], ExtensionSpec> = btreemap! {};
 }
 
+#[derive(Clone)]
+pub struct ExtensionContext {
+    pub sns_root_canister_id: CanisterId,
+    pub sns_governance_canister_id: CanisterId,
+    pub sns_ledger_canister_id: CanisterId,
+    pub sns_token_symbol: String,
+    pub sns_ledger_transaction_fee_e8s: u64,
+    pub icp_ledger_canister_id: CanisterId,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ExtensionType {
     TreasuryManager,
@@ -49,6 +59,7 @@ impl Display for ExtensionType {
     }
 }
 
+#[derive(Clone)]
 pub enum ValidatedExtensionInit {
     TreasuryManager(ValidatedDepositOperationArg),
     // Future: other extension type init arguments would go here
@@ -97,12 +108,14 @@ pub trait RenderablePayload {
 
 impl RenderablePayload for Precise {
     fn render_for_proposal(&self) -> String {
-        if let Ok(candid_str) = printing::pretty(self) {
+        let render = if let Ok(candid_str) = printing::pretty(self) {
             candid_str
         } else {
             // Fallback in case Candid serialization crashes.
             format!("{:#?}", self)
-        }
+        };
+
+        format!("#### Raw Payload\n\n{}", render)
     }
 }
 
@@ -112,7 +125,11 @@ pub struct ExtensionOperationSpec {
     pub name: String,
     pub description: String,
     pub extension_type: ExtensionType,
+<<<<<<< HEAD
     pub validate: fn(&Governance, ExtensionOperationArg) -> Result<ValidatedOperationArg, String>,
+=======
+    pub validate_arg: fn(ExtensionOperationArg) -> Result<ValidatedOperationArg, String>,
+>>>>>>> 6abfbd4698 (second)
 }
 
 impl ExtensionOperationSpec {
@@ -124,12 +141,17 @@ impl ExtensionOperationSpec {
         &self.description
     }
 
+<<<<<<< HEAD
     async fn validate_operation_arg(
         &self,
         governance: &Governance,
         arg: ExtensionOperationArg,
     ) -> Result<ValidatedOperationArg, String> {
         (self.validate)(governance, arg)
+=======
+    pub fn validate(&self, arg: ExtensionOperationArg) -> Result<ValidatedOperationArg, String> {
+        (self.validate_arg)(arg)
+>>>>>>> 6abfbd4698 (second)
     }
 }
 
@@ -137,7 +159,9 @@ impl ExtensionOperationSpec {
 fn validate_treasury_manager_init(init: ExtensionInit) -> Result<ValidatedExtensionInit, String> {
     let ExtensionInit { value } = init;
 
-    ValidatedDepositOperationArg::try_from(value).map(ValidatedExtensionInit::TreasuryManager)
+    let arg = ValidatedDepositOperationArg::try_from(value)?;
+
+    Ok(ValidatedExtensionInit::TreasuryManager(arg))
 }
 
 /// Validates treasury manager init arguments
@@ -151,7 +175,9 @@ fn validate_treasury_manager_init(init: ExtensionInit) -> Result<ValidatedExtens
 fn validate_deposit_operation(arg: ExtensionOperationArg) -> Result<ValidatedOperationArg, String> {
     let ExtensionOperationArg { value } = arg;
 
-    ValidatedDepositOperationArg::try_from(value).map(ValidatedOperationArg::TreasuryManagerDeposit)
+    let arg = ValidatedDepositOperationArg::try_from(value)?;
+
+    Ok(ValidatedOperationArg::TreasuryManagerDeposit(arg))
 }
 
 /// Validates withdraw operation arguments (currently requires empty arguments)
@@ -161,8 +187,9 @@ fn validate_withdraw_operation(
 ) -> Result<ValidatedOperationArg, String> {
     let ExtensionOperationArg { value } = arg;
 
-    ValidatedWithdrawOperationArg::try_from(value)
-        .map(ValidatedOperationArg::TreasuryManagerWithdraw)
+    let arg = ValidatedWithdrawOperationArg::try_from(value)?;
+
+    Ok(ValidatedOperationArg::TreasuryManagerWithdraw(arg))
 }
 
 impl ExtensionType {
@@ -173,13 +200,13 @@ impl ExtensionType {
                     name: "deposit".to_string(),
                     description: "Deposit funds into the treasury manager.".to_string(),
                     extension_type: ExtensionType::TreasuryManager,
-                    validate: validate_deposit_operation,
+                    validate_arg: validate_deposit_operation,
                 },
                 ExtensionOperationSpec {
                     name: "withdraw".to_string(),
                     description: "Withdraw funds from the treasury manager.".to_string(),
                     extension_type: ExtensionType::TreasuryManager,
-                    validate: validate_withdraw_operation,
+                    validate_arg: validate_withdraw_operation,
                 },
             ],
             // Future extension types would define their standard operations here
@@ -279,33 +306,23 @@ impl Display for ExtensionSpec {
 
 pub struct ValidatedRegisterExtension {
     pub wasm: Wasm,
+    pub extension_canister_id: CanisterId,
     pub spec: ExtensionSpec,
-    pub init: ExtensionInit,
+    pub init: ValidatedExtensionInit,
 }
 
 impl ValidatedRegisterExtension {
-    pub async fn execute(self, governance: &Governance) -> Result<(), GovernanceError> {
-        let ValidatedRegisterExtension { wasm, spec, init } = self;
-
-        let Wasm::Chunked {
-            store_canister_id, ..
-        } = &wasm
-        else {
-            return Err(GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                "RegisterExtension proposal must contain a chunked wasm module.",
-            ));
-        };
-
-        // Use the store canister to install the extension itself.
-        let extension_canister_id = *store_canister_id;
-
-        let init = spec.validate_init_arg(init).map_err(|err| {
-            GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                format!("Extension init argument validation failed: {}", err),
-            )
-        })?;
+    pub async fn execute(
+        self,
+        governance: &Governance,
+        context: ExtensionContext,
+    ) -> Result<(), GovernanceError> {
+        let ValidatedRegisterExtension {
+            spec: _,
+            init,
+            extension_canister_id,
+            wasm,
+        } = self;
 
         governance
             .register_extension_with_root(extension_canister_id)
@@ -313,13 +330,26 @@ impl ValidatedRegisterExtension {
 
         // This needs to happen before the canister code is installed.
         let init_blob = match init {
-            ValidatedExtensionInit::TreasuryManager(init) => {
-                let (init_blob, sns_amount_e8s, icp_amount_e8s) = governance
-                    .construct_treasury_manager_init_payload(init.original)
-                    .await?;
+            ValidatedExtensionInit::TreasuryManager(ValidatedDepositOperationArg {
+                treasury_allocation_sns_e8s,
+                treasury_allocation_icp_e8s,
+                original,
+            }) => {
+                let init_blob = construct_treasury_manager_init_payload(context.clone(), original)
+                    .map_err(|err| {
+                        GovernanceError::new_with_message(
+                            ErrorType::InvalidProposal,
+                            format!("Error constructing TreasuryManagerInit payload: {}", err),
+                        )
+                    })?;
 
                 governance
-                    .deposit_treasury_manager(extension_canister_id, sns_amount_e8s, icp_amount_e8s)
+                    .deposit_treasury_manager(
+                        context,
+                        extension_canister_id,
+                        treasury_allocation_sns_e8s,
+                        treasury_allocation_icp_e8s,
+                    )
                     .await?;
 
                 init_blob
@@ -343,33 +373,36 @@ impl ValidatedRegisterExtension {
 pub struct ValidatedExecuteExtensionOperation {
     pub extension_canister_id: CanisterId,
     pub operation_name: String,
-    pub operation_arg: ValidatedOperationArg,
+    pub arg: ValidatedOperationArg,
 }
 
 impl ValidatedExecuteExtensionOperation {
-    pub async fn execute(&self, governance: &Governance) -> Result<(), GovernanceError> {
-        match &self.operation_arg {
-            ValidatedOperationArg::TreasuryManagerDeposit(deposit_arg) => {
-                execute_treasury_manager_deposit(
-                    governance,
-                    self.extension_canister_id,
-                    deposit_arg,
-                )
-                .await
+    pub async fn execute(
+        self,
+        governance: &Governance,
+        context: ExtensionContext,
+    ) -> Result<(), GovernanceError> {
+        let Self {
+            operation_name: _,
+            extension_canister_id,
+            arg,
+        } = self;
+
+        match arg {
+            ValidatedOperationArg::TreasuryManagerDeposit(arg) => {
+                execute_treasury_manager_deposit(governance, context, extension_canister_id, arg)
+                    .await
             }
-            ValidatedOperationArg::TreasuryManagerWithdraw(withdraw_arg) => {
-                execute_treasury_manager_withdraw(
-                    governance,
-                    self.extension_canister_id,
-                    withdraw_arg,
-                )
-                .await
+            ValidatedOperationArg::TreasuryManagerWithdraw(arg) => {
+                execute_treasury_manager_withdraw(governance, context, extension_canister_id, arg)
+                    .await
             }
         }
     }
 }
 
 impl Governance {
+<<<<<<< HEAD
     /// Returns the ICRC-1 subaccount for the SNS treasury
     fn sns_treasury_subaccount(&self) -> Option<[u8; 32]> {
         // See ic_sns_init::distributions::FractionalDeveloperVotingPower.insert_treasury_accounts
@@ -393,6 +426,21 @@ impl Governance {
         ));
         let treasury_icp_subaccount = None;
         (treasury_sns_subaccount, treasury_icp_subaccount)
+=======
+    pub async fn extension_context(&self) -> Result<ExtensionContext, GovernanceError> {
+        let sns_ledger_canister_id = self.ledger.canister_id();
+
+        let sns_token_symbol = get_sns_token_symbol(&*self.env, sns_ledger_canister_id).await?;
+
+        Ok(ExtensionContext {
+            sns_token_symbol,
+            sns_ledger_canister_id,
+            sns_root_canister_id: self.proto.root_canister_id_or_panic(),
+            sns_governance_canister_id: self.env.canister_id(),
+            sns_ledger_transaction_fee_e8s: self.transaction_fee_e8s_or_panic(),
+            icp_ledger_canister_id: self.nns_ledger.canister_id(),
+        })
+>>>>>>> 6abfbd4698 (second)
     }
 
     async fn register_extension_with_root(
@@ -460,6 +508,7 @@ impl Governance {
         Ok(())
     }
 
+<<<<<<< HEAD
     async fn construct_treasury_manager_deposit_allowances(
         &self,
         value: Precise,
@@ -542,14 +591,22 @@ impl Governance {
         Ok((arg, sns_amount_e8s, icp_amount_e8s))
     }
 
+=======
+>>>>>>> 6abfbd4698 (second)
     pub async fn deposit_treasury_manager(
         &self,
+        context: ExtensionContext,
         extension_canister_id: CanisterId,
-        sns_amount_e8s: u64,
-        icp_amount_e8s: u64,
+        treasury_allocation_sns_e8s: u64,
+        treasury_allocation_icp_e8s: u64,
     ) -> Result<(), GovernanceError> {
+<<<<<<< HEAD
         let treasury_sns_subaccount = self.sns_treasury_subaccount();
         let treasury_icp_subaccount = self.icp_treasury_subaccount();
+=======
+        let (treasury_sns_subaccount, treasury_icp_subaccount) =
+            treasury_subaccounts(context.clone());
+>>>>>>> 6abfbd4698 (second)
 
         let to = Account {
             owner: extension_canister_id.get().0,
@@ -558,24 +615,24 @@ impl Governance {
 
         self.ledger
             .transfer_funds(
-                sns_amount_e8s,
-                self.transaction_fee_e8s_or_panic(),
+                treasury_allocation_sns_e8s,
+                context.sns_ledger_transaction_fee_e8s,
                 treasury_sns_subaccount,
                 to,
                 0,
             )
             .await
             .map(|_| ())
-            .map_err(|e| {
+            .map_err(|err| {
                 GovernanceError::new_with_message(
                     ErrorType::External,
-                    format!("Error making SNS Token treasury transfer: {}", e),
+                    format!("Error making SNS Token treasury transfer: {}", err),
                 )
             })?;
 
         self.nns_ledger
             .transfer_funds(
-                icp_amount_e8s,
+                treasury_allocation_icp_e8s,
                 icp_ledger::DEFAULT_TRANSFER_FEE.get_e8s(),
                 treasury_icp_subaccount,
                 to,
@@ -583,10 +640,10 @@ impl Governance {
             )
             .await
             .map(|_| ())
-            .map_err(|e| {
+            .map_err(|err| {
                 GovernanceError::new_with_message(
                     ErrorType::External,
-                    format!("Error making ICP treasury transfer: {}", e),
+                    format!("Error making ICP treasury transfer: {}", err),
                 )
             })?;
 
@@ -600,14 +657,13 @@ pub mod treasury_manager {
 
     use crate::pb::v1::{precise, Precise, PreciseMap};
 
-    /// Returns `(init, sns_token_amount_e8s, icp_token_amount_e8s)` in the Ok result.
     pub fn construct_deposit_allowances(
         arg: Precise,
         sns_token: Asset,
         icp_token: Asset,
         treasury_sns_account: Account,
         treasury_icp_account: Account,
-    ) -> Result<(Vec<Allowance>, u64, u64), String> {
+    ) -> Result<Vec<Allowance>, String> {
         const PREFIX: &str = "Cannot parse ExtensionInit as TreasuryManagerInit: ";
 
         let Precise {
@@ -651,54 +707,12 @@ pub mod treasury_manager {
                 owner_account: treasury_icp_account,
             },
         ];
-        Ok((allowances, sns_token_amount_e8s, icp_token_amount_e8s))
-    }
-}
-
-impl TryFrom<RegisterExtension> for ValidatedRegisterExtension {
-    type Error = String;
-
-    fn try_from(value: RegisterExtension) -> Result<Self, Self::Error> {
-        let RegisterExtension {
-            chunked_canister_wasm,
-            extension_init,
-        } = value;
-
-        let Some(ChunkedCanisterWasm {
-            wasm_module_hash,
-            store_canister_id,
-            chunk_hashes_list,
-        }) = chunked_canister_wasm
-        else {
-            return Err("chunked_canister_wasm is required".to_string());
-        };
-
-        let Some(store_canister_id) = store_canister_id else {
-            return Err("chunked_canister_wasm.store_canister_id".to_string());
-        };
-
-        let store_canister_id = CanisterId::try_from_principal_id(store_canister_id)
-            .map_err(|err| format!("Invalid store_canister_id: {}", err))?;
-
-        let spec = validate_extension_wasm(&wasm_module_hash)
-            .map_err(|err| format!("Invalid extension wasm: {err:?}"))?;
-
-        let wasm = Wasm::Chunked {
-            wasm_module_hash,
-            store_canister_id,
-            chunk_hashes_list,
-        };
-
-        let Some(init) = extension_init else {
-            return Err("RegisterExtension.extension_init is required".to_string());
-        };
-
-        Ok(Self { wasm, spec, init })
+        Ok(allowances)
     }
 }
 
 /// Validates an extension WASM against the global ALLOWED_EXTENSIONS.
-pub(crate) fn validate_extension_wasm(wasm_module_hash: &[u8]) -> Result<ExtensionSpec, String> {
+pub fn validate_extension_wasm(wasm_module_hash: &[u8]) -> Result<ExtensionSpec, String> {
     // Validate the hash length
     if wasm_module_hash.len() != 32 {
         return Err(format!(
@@ -817,10 +831,167 @@ async fn canister_module_hash(
     Ok(response.module_hash().unwrap_or_default())
 }
 
+/// Returns the ICRC-1 subaccounts for the SNS treasury and ICP treasury.
+fn treasury_subaccounts(context: ExtensionContext) -> (Option<[u8; 32]>, Option<[u8; 32]>) {
+    // See ic_sns_init::distributions::FractionalDeveloperVotingPower.insert_treasury_accounts
+    let sns_governance_principal_id = context.sns_governance_canister_id.get();
+    let treasury_sns_subaccount = Some(compute_distribution_subaccount_bytes(
+        sns_governance_principal_id,
+        TREASURY_SUBACCOUNT_NONCE,
+    ));
+    let treasury_icp_subaccount = None;
+    (treasury_sns_subaccount, treasury_icp_subaccount)
+}
+
+fn construct_treasury_manager_deposit_allowances(
+    context: ExtensionContext,
+    value: Precise,
+) -> Result<Vec<Allowance>, String> {
+    // See ic_sns_init::distributions::FractionalDeveloperVotingPower.insert_treasury_accounts
+    let (treasury_sns_subaccount, treasury_icp_subaccount) = treasury_subaccounts(context.clone());
+
+    let allowances = treasury_manager::construct_deposit_allowances(
+        value,
+        Asset::Token {
+            symbol: context.sns_token_symbol,
+            ledger_canister_id: context.sns_ledger_canister_id.get().0,
+            ledger_fee_decimals: Nat::from(context.sns_ledger_transaction_fee_e8s),
+        },
+        Asset::Token {
+            symbol: "ICP".to_string(),
+            ledger_canister_id: context.icp_ledger_canister_id.get().0,
+            ledger_fee_decimals: Nat::from(icp_ledger::DEFAULT_TRANSFER_FEE.get_e8s()),
+        },
+        sns_treasury_manager::Account {
+            owner: context.sns_governance_canister_id.get().0,
+            subaccount: treasury_sns_subaccount,
+        },
+        sns_treasury_manager::Account {
+            owner: context.sns_governance_canister_id.get().0,
+            subaccount: treasury_icp_subaccount,
+        },
+    )
+    .map_err(|err| format!("Error extracting initial allowances: {}", err))?;
+
+    Ok(allowances)
+}
+
+/// Returns `arg_blob` in the Ok result.
+pub fn construct_treasury_manager_init_payload(
+    context: ExtensionContext,
+    value: Precise,
+) -> Result<Vec<u8>, String> {
+    let allowances = construct_treasury_manager_deposit_allowances(context, value)?;
+
+    let arg = TreasuryManagerArg::Init(TreasuryManagerInit { allowances });
+    let arg = candid::encode_one(&arg)
+        .map_err(|err| format!("Error encoding TreasuryManagerArg: {}", err))?;
+
+    Ok(arg)
+}
+
+/// Returns `arg_blob` in the Ok result.
+fn construct_treasury_manager_deposit_payload(
+    context: ExtensionContext,
+    value: Precise,
+) -> Result<Vec<u8>, String> {
+    let allowances = construct_treasury_manager_deposit_allowances(context, value)?;
+
+    let arg = DepositRequest { allowances };
+    let arg = candid::encode_one(&arg)
+        .map_err(|err| format!("Error encoding DepositRequest: {}", err))?;
+
+    Ok(arg)
+}
+
+/// Returns `arg_blob` in the Ok result.
+fn construct_treasury_manager_withdraw_payload(
+    _context: ExtensionContext,
+    _value: Precise,
+) -> Result<Vec<u8>, String> {
+    let arg = WithdrawRequest {
+        withdraw_accounts: None,
+    };
+    let arg = candid::encode_one(&arg)
+        .map_err(|err| format!("Error encoding WithdrawRequest: {}", err))?;
+
+    Ok(arg)
+}
+
+pub fn validate_register_extension(
+    _context: ExtensionContext,
+    register_extension: RegisterExtension,
+) -> Result<ValidatedRegisterExtension, GovernanceError> {
+    let RegisterExtension {
+        chunked_canister_wasm,
+        extension_init,
+    } = register_extension;
+
+    // Phase I. Validate all local properties.
+    let (spec, wasm, extension_canister_id, init) = (|| {
+        let Some(ChunkedCanisterWasm {
+            wasm_module_hash,
+            store_canister_id,
+            chunk_hashes_list,
+        }) = chunked_canister_wasm
+        else {
+            return Err("chunked_canister_wasm is required".to_string());
+        };
+
+        let Some(store_canister_id) = store_canister_id else {
+            return Err("chunked_canister_wasm.store_canister_id is required".to_string());
+        };
+
+        let store_canister_id = CanisterId::try_from_principal_id(store_canister_id)
+            .map_err(|err| format!("Invalid store_canister_id: {}", err))?;
+
+        // Use the store canister to install the extension itself.
+        let extension_canister_id = store_canister_id;
+
+        let spec = validate_extension_wasm(&wasm_module_hash)
+            .map_err(|err| format!("Invalid extension wasm: {}", err))?;
+
+        let wasm = Wasm::Chunked {
+            wasm_module_hash,
+            store_canister_id,
+            chunk_hashes_list,
+        };
+
+        let Some(init) = extension_init else {
+            return Err("RegisterExtension.extension_init is required".to_string());
+        };
+
+        let init = spec
+            .validate_init_arg(init)
+            .map_err(|err| format!("Invalid init argument: {}", err))?;
+
+        Ok((spec, wasm, extension_canister_id, init))
+    })()
+    .map_err(|err| {
+        GovernanceError::new_with_message(
+            ErrorType::InvalidProposal,
+            format!("Invalid RegisterExtension: {:?}", err),
+        )
+    })?;
+
+    Ok(ValidatedRegisterExtension {
+        wasm,
+        extension_canister_id,
+        spec,
+        init,
+    })
+}
+
 /// Validates that this is a supported extension operation.
 // TODO: Enforce 50% treasury limits.
+<<<<<<< HEAD
 pub(crate) async fn validate_execute_extension_operation(
     governance: &crate::governance::Governance,
+=======
+pub async fn validate_execute_extension_operation(
+    env: &dyn Environment,
+    context: ExtensionContext,
+>>>>>>> 6abfbd4698 (second)
     operation: ExecuteExtensionOperation,
 ) -> Result<ValidatedExecuteExtensionOperation, GovernanceError> {
     let governance_proto = &governance.proto;
@@ -865,8 +1036,12 @@ pub(crate) async fn validate_execute_extension_operation(
         ));
     };
 
+<<<<<<< HEAD
     let root_canister_id = governance_proto.root_canister_id_or_panic();
     let registered_extensions = list_extensions(env, root_canister_id).await?;
+=======
+    let registered_extensions = list_extensions(env, context.sns_root_canister_id).await?;
+>>>>>>> 6abfbd4698 (second)
 
     if !registered_extensions.contains(&extension_canister_id.get()) {
         return Err(GovernanceError::new_with_message(
@@ -912,6 +1087,7 @@ pub(crate) async fn validate_execute_extension_operation(
         ));
     };
 
+<<<<<<< HEAD
     let validated_arg = operation_spec
         .validate_operation_arg(governance, operation_arg)
         .await
@@ -924,41 +1100,70 @@ pub(crate) async fn validate_execute_extension_operation(
                 ),
             )
         })?;
+=======
+    let arg = operation_spec.validate(operation_arg).map_err(|err| {
+        GovernanceError::new_with_message(
+            ErrorType::InvalidProposal,
+            format!(
+                "Extension canister {} operation {} validation failed: {}",
+                extension_canister_id, operation_name, err
+            ),
+        )
+    })?;
+>>>>>>> 6abfbd4698 (second)
 
     Ok(ValidatedExecuteExtensionOperation {
         extension_canister_id,
         operation_name,
-        operation_arg: validated_arg,
+        arg,
     })
 }
 
 /// Execute a treasury manager deposit operation
 async fn execute_treasury_manager_deposit(
     governance: &Governance,
-    treasury_manager_canister_id: CanisterId,
-    deposit_arg: &ValidatedDepositOperationArg,
+    context: ExtensionContext,
+    extension_canister_id: CanisterId,
+    arg: ValidatedDepositOperationArg,
 ) -> Result<(), GovernanceError> {
-    // 1. Construct deposit payload
-    let (arg, sns_amount_e8s, icp_amount_e8s) = governance
-        .construct_treasury_manager_deposit_payload(deposit_arg.original.clone())
-        .await?;
+    let ValidatedDepositOperationArg {
+        treasury_allocation_sns_e8s,
+        treasury_allocation_icp_e8s,
+        original,
+    } = arg;
 
-    // 2. Transfer funds from treasury to treasury manager
+    // 1. Transfer funds from treasury to treasury manager
     governance
-        .deposit_treasury_manager(treasury_manager_canister_id, sns_amount_e8s, icp_amount_e8s)
+        .deposit_treasury_manager(
+            context.clone(),
+            extension_canister_id,
+            treasury_allocation_sns_e8s,
+            treasury_allocation_icp_e8s,
+        )
         .await?;
 
-    // 3. Call deposit on treasury manager
+    let arg_blob =
+        construct_treasury_manager_deposit_payload(context, original).map_err(|err| {
+            GovernanceError::new_with_message(
+                ErrorType::PreconditionFailed,
+                format!(
+                    "Failed to construct treasury manager deposit payload: {}",
+                    err
+                ),
+            )
+        })?;
+
+    // 2. Call deposit on treasury manager
     let balances = governance
         .env
-        .call_canister(treasury_manager_canister_id, "deposit", arg)
+        .call_canister(extension_canister_id, "deposit", arg_blob)
         .await
         .map_err(|(code, err)| {
             GovernanceError::new_with_message(
                 ErrorType::External,
                 format!(
                     "Canister method call {}.deposit failed with code {:?}: {}",
-                    treasury_manager_canister_id, code, err
+                    extension_canister_id, code, err
                 ),
             )
         })
@@ -989,29 +1194,31 @@ async fn execute_treasury_manager_deposit(
 /// Execute a treasury manager withdraw operation
 async fn execute_treasury_manager_withdraw(
     governance: &Governance,
-    treasury_manager_canister_id: CanisterId,
-    _withdraw_arg: &ValidatedWithdrawOperationArg,
+    context: ExtensionContext,
+    extension_canister_id: CanisterId,
+    arg: ValidatedWithdrawOperationArg,
 ) -> Result<(), GovernanceError> {
-    let request = WithdrawRequest {
-        withdraw_accounts: None,
-    };
-    let payload: Vec<u8> = candid::encode_one(&request).map_err(|err| {
-        GovernanceError::new_with_message(
-            ErrorType::InvalidProposal,
-            format!("Error encoding WithdrawRequest: {}", err),
-        )
-    })?;
+    let arg_blob =
+        construct_treasury_manager_withdraw_payload(context, arg.original).map_err(|err| {
+            GovernanceError::new_with_message(
+                ErrorType::PreconditionFailed,
+                format!(
+                    "Failed to construct treasury manager withdraw payload: {}",
+                    err
+                ),
+            )
+        })?;
 
     let balances = governance
         .env
-        .call_canister(treasury_manager_canister_id, "withdraw", payload)
+        .call_canister(extension_canister_id, "withdraw", arg_blob)
         .await
         .map_err(|(code, err)| {
             GovernanceError::new_with_message(
                 ErrorType::External,
                 format!(
                     "Canister method call {}.withdraw failed with code {:?}: {}",
-                    treasury_manager_canister_id, code, err
+                    extension_canister_id, code, err
                 ),
             )
         })
@@ -1050,18 +1257,18 @@ pub struct ValidatedDepositOperationArg {
     /// Amount of ICP tokens to allocate from treasury
     pub treasury_allocation_icp_e8s: u64,
     /// Original Precise value with all fields
-    original: Precise,
+    pub original: Precise,
 }
 
 impl TryFrom<Option<Precise>> for ValidatedDepositOperationArg {
     type Error = String;
 
     fn try_from(value: Option<Precise>) -> Result<Self, Self::Error> {
-        let Some(value) = value else {
+        let Some(original) = value else {
             return Err("Deposit operation arguments must be provided".to_string());
         };
 
-        let map = match &value.value {
+        let map = match &original.value {
             Some(precise::Value::Map(PreciseMap { map })) => map,
             _ => return Err("Deposit operation arguments must be a PreciseMap".to_string()),
         };
@@ -1085,7 +1292,7 @@ impl TryFrom<Option<Precise>> for ValidatedDepositOperationArg {
         Ok(Self {
             treasury_allocation_sns_e8s,
             treasury_allocation_icp_e8s,
-            original: value,
+            original,
         })
     }
 }
@@ -1141,7 +1348,7 @@ impl RenderablePayload for ValidatedWithdrawOperationArg {
     }
 }
 
-pub(crate) async fn get_sns_token_symbol(
+pub async fn get_sns_token_symbol(
     env: &dyn Environment,
     ledger_canister_id: CanisterId,
 ) -> Result<String, GovernanceError> {
@@ -1199,13 +1406,18 @@ mod tests {
     use crate::pb::v1::{governance, governance::SnsMetadata, NervousSystemParameters};
     use crate::types::test_helpers::NativeEnvironment;
     use ic_management_canister_types_private::{CanisterInfoRequest, CanisterInfoResponse};
+<<<<<<< HEAD
     use ic_nervous_system_canisters::{cmc::MockCMC, ledger::MockICRC1Ledger};
+=======
+    use ic_nns_constants::LEDGER_CANISTER_ID;
+>>>>>>> 6abfbd4698 (second)
     use maplit::btreemap;
 
     /// Helper function to set up common environment mocking for validate_execute_extension_operation tests
     fn setup_env_for_test(
         extension_registered: bool,
         operation_name: &str,
+<<<<<<< HEAD
     ) -> (Governance, ExecuteExtensionOperation) {
         let mut env = NativeEnvironment::new(Some(CanisterId::from_u64(123)));
         let root_canister_id = CanisterId::from_u64(1000);
@@ -1223,6 +1435,14 @@ mod tests {
             mode: governance::Mode::Normal.into(),
             ..Default::default()
         };
+=======
+    ) -> (
+        NativeEnvironment,
+        ExtensionContext,
+        ExecuteExtensionOperation,
+    ) {
+        let mut env = NativeEnvironment::new(Some(CanisterId::from_u64(123)));
+>>>>>>> 6abfbd4698 (second)
         let extension_canister_id = CanisterId::from_u64(2000);
 
         // Mock list_sns_canisters call
@@ -1232,14 +1452,18 @@ mod tests {
             vec![] // Empty for unregistered extension tests
         };
 
+        let sns_root_canister_id = CanisterId::from_u64(1000);
+        let sns_governance_canister_id = CanisterId::from_u64(3000);
+        let sns_ledger_canister_id = CanisterId::from_u64(4000);
+
         env.set_call_canister_response(
-            root_canister_id,
+            sns_root_canister_id,
             "list_sns_canisters",
             Encode!(&ListSnsCanistersRequest {}).unwrap(),
             Ok(Encode!(&ListSnsCanistersResponse {
-                root: Some(root_canister_id.get()),
-                governance: Some(CanisterId::from_u64(3000).get()),
-                ledger: Some(CanisterId::from_u64(4000).get()),
+                root: Some(sns_root_canister_id.get()),
+                governance: Some(sns_governance_canister_id.get()),
+                ledger: Some(sns_ledger_canister_id.get()),
                 swap: Some(CanisterId::from_u64(5000).get()),
                 index: Some(CanisterId::from_u64(6000).get()),
                 archives: vec![],
@@ -1275,7 +1499,9 @@ mod tests {
         // Create operation arg based on operation type
         let operation_arg = if operation_name == "withdraw" {
             // Withdraw operations now require empty arguments
-            ExtensionOperationArg { value: None }
+            ExtensionOperationArg {
+                value: Some(Precise { value: None }),
+            }
         } else {
             // Deposit operations need the allocation values
             ExtensionOperationArg {
@@ -1286,16 +1512,6 @@ mod tests {
                                 value: Some(precise::Value::Nat(1000000))
                             },
                             "treasury_allocation_icp_e8s".to_string() => Precise {
-                                value: Some(precise::Value::Nat(2000000))
-                            },
-                             // For withdraw tests, these fields will be ignored by deposit validator
-                            "recipient_principal".to_string() => Precise {
-                                value: Some(precise::Value::Text("rdmx6-jaaaa-aaaaa-aaadq-cai".to_string()))
-                            },
-                            "withdrawal_amount_sns_e8s".to_string() => Precise {
-                                value: Some(precise::Value::Nat(1000000))
-                            },
-                            "withdrawal_amount_icp_e8s".to_string() => Precise {
                                 value: Some(precise::Value::Nat(2000000))
                             },
                         },
@@ -1310,6 +1526,7 @@ mod tests {
             operation_arg: Some(operation_arg),
         };
 
+<<<<<<< HEAD
         let governance = Governance::new(
             ValidGovernanceProto::try_from(governance_proto)
                 .expect("Failed validating governance proto"),
@@ -1320,35 +1537,67 @@ mod tests {
         );
 
         (governance, execute_operation)
+=======
+        let context = ExtensionContext {
+            sns_root_canister_id,
+            sns_governance_canister_id,
+            sns_ledger_canister_id,
+            sns_token_symbol: "SNS".to_string(),
+            sns_ledger_transaction_fee_e8s: 10_000,
+            icp_ledger_canister_id: LEDGER_CANISTER_ID,
+        };
+
+        (env, context, execute_operation)
+>>>>>>> 6abfbd4698 (second)
     }
 
     // Tests for validate_execute_extension_operation with proper environment mocking
 
     #[tokio::test]
     async fn test_validate_execute_extension_operation_deposit_success() {
+<<<<<<< HEAD
         let (governance, execute_operation) = setup_env_for_test(true, "deposit");
 
         // Test with valid operation name - should succeed
         let result = validate_execute_extension_operation(&governance, execute_operation).await;
+=======
+        let (env, context, execute_operation) = setup_env_for_test(true, "deposit");
+
+        // Test with valid operation name - should succeed
+        let result = validate_execute_extension_operation(&env, context, execute_operation).await;
+>>>>>>> 6abfbd4698 (second)
 
         result.unwrap();
     }
 
     #[tokio::test]
     async fn test_validate_execute_extension_operation_withdraw_success() {
+<<<<<<< HEAD
         let (governance, execute_operation) = setup_env_for_test(true, "withdraw");
 
         // Test with withdraw operation - should succeed (since test mode supports withdraw)
         let result = validate_execute_extension_operation(&governance, execute_operation).await;
+=======
+        let (env, context, execute_operation) = setup_env_for_test(true, "withdraw");
+
+        // Test with withdraw operation - should succeed (since test mode supports withdraw)
+        let result = validate_execute_extension_operation(&env, context, execute_operation).await;
+>>>>>>> 6abfbd4698 (second)
 
         result.unwrap();
     }
 
     #[tokio::test]
     async fn test_validate_execute_extension_operation_unregistered_extension() {
+<<<<<<< HEAD
         let (governance, execute_operation) = setup_env_for_test(false, "deposit"); // false = extension not registered
 
         let result = validate_execute_extension_operation(&governance, execute_operation).await;
+=======
+        let (env, context, execute_operation) = setup_env_for_test(false, "deposit"); // false = extension not registered
+
+        let result = validate_execute_extension_operation(&env, context, execute_operation).await;
+>>>>>>> 6abfbd4698 (second)
 
         let error = result.unwrap_err();
         assert_eq!(error.error_type, ErrorType::NotFound as i32);
@@ -1360,10 +1609,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_execute_extension_operation_invalid_operation_name() {
+<<<<<<< HEAD
         let (governance, execute_operation) = setup_env_for_test(true, "invalid_operation");
 
         // Test with invalid operation name - should fail
         let result = validate_execute_extension_operation(&governance, execute_operation).await;
+=======
+        let (env, context, execute_operation) = setup_env_for_test(true, "invalid_operation");
+
+        // Test with invalid operation name - should fail
+        let result = validate_execute_extension_operation(&env, context, execute_operation).await;
+>>>>>>> 6abfbd4698 (second)
 
         let error = result.unwrap_err();
         assert_eq!(error.error_type, ErrorType::InvalidProposal as i32);
@@ -1374,7 +1630,18 @@ mod tests {
 
     #[test]
     fn test_validate_deposit_operation() {
+<<<<<<< HEAD
         let (governance, _) = setup_env_for_test(true, "deposit");
+=======
+        let context = ExtensionContext {
+            sns_root_canister_id: CanisterId::from_u64(1000),
+            sns_governance_canister_id: CanisterId::from_u64(2000),
+            sns_ledger_canister_id: CanisterId::from_u64(3000),
+            sns_token_symbol: "SNS".to_string(),
+            sns_ledger_transaction_fee_e8s: 10_000,
+            icp_ledger_canister_id: LEDGER_CANISTER_ID,
+        };
+>>>>>>> 6abfbd4698 (second)
 
         // Test valid deposit operation
         let valid_arg = ExtensionOperationArg {
@@ -1392,7 +1659,11 @@ mod tests {
             }),
         };
 
+<<<<<<< HEAD
         let result = validate_deposit_operation(&governance, valid_arg.clone()).unwrap();
+=======
+        let result = validate_deposit_operation(context.clone(), valid_arg.clone()).unwrap();
+>>>>>>> 6abfbd4698 (second)
 
         match result {
             ValidatedOperationArg::TreasuryManagerDeposit(deposit) => {
@@ -1415,7 +1686,11 @@ mod tests {
             }),
         };
 
+<<<<<<< HEAD
         let result = validate_deposit_operation(&governance, missing_sns_arg).unwrap_err();
+=======
+        let result = validate_deposit_operation(context.clone(), missing_sns_arg).unwrap_err();
+>>>>>>> 6abfbd4698 (second)
         assert!(result.contains("treasury_allocation_sns_e8s must be a Nat value"));
 
         // Test missing ICP amount
@@ -1431,7 +1706,11 @@ mod tests {
             }),
         };
 
+<<<<<<< HEAD
         let result = validate_deposit_operation(&governance, missing_icp_arg).unwrap_err();
+=======
+        let result = validate_deposit_operation(context.clone(), missing_icp_arg).unwrap_err();
+>>>>>>> 6abfbd4698 (second)
         assert!(result.contains("treasury_allocation_icp_e8s must be a Nat value"));
 
         // Test wrong type for SNS amount
@@ -1450,12 +1729,20 @@ mod tests {
             }),
         };
 
+<<<<<<< HEAD
         let result = validate_deposit_operation(&governance, wrong_type_arg).unwrap_err();
+=======
+        let result = validate_deposit_operation(context.clone(), wrong_type_arg).unwrap_err();
+>>>>>>> 6abfbd4698 (second)
         assert!(result.contains("treasury_allocation_sns_e8s must be a Nat value"));
 
         // Test no arguments provided
         let no_args = ExtensionOperationArg { value: None };
+<<<<<<< HEAD
         let result = validate_deposit_operation(&governance, no_args).unwrap_err();
+=======
+        let result = validate_deposit_operation(context.clone(), no_args).unwrap_err();
+>>>>>>> 6abfbd4698 (second)
         assert!(result.contains("Deposit operation arguments must be provided"));
 
         // Test not a map
@@ -1465,17 +1752,36 @@ mod tests {
             }),
         };
 
+<<<<<<< HEAD
         let result = validate_deposit_operation(&governance, not_map_arg).unwrap_err();
+=======
+        let result = validate_deposit_operation(context, not_map_arg).unwrap_err();
+>>>>>>> 6abfbd4698 (second)
         assert!(result.contains("Deposit operation arguments must be a PreciseMap"));
     }
 
     #[test]
     fn test_validate_withdraw_operation() {
+<<<<<<< HEAD
         let (governance, _) = setup_env_for_test(true, "withdraw");
 
         // Test valid withdraw operation - must have empty arguments
         let valid_arg = ExtensionOperationArg { value: None };
         let result = validate_withdraw_operation(&governance, valid_arg.clone()).unwrap();
+=======
+        let context = ExtensionContext {
+            sns_root_canister_id: CanisterId::from_u64(1000),
+            sns_governance_canister_id: CanisterId::from_u64(2000),
+            sns_ledger_canister_id: CanisterId::from_u64(3000),
+            sns_token_symbol: "SNS".to_string(),
+            sns_ledger_transaction_fee_e8s: 10_000,
+            icp_ledger_canister_id: LEDGER_CANISTER_ID,
+        };
+
+        // Test valid withdraw operation - must have empty arguments
+        let valid_arg = ExtensionOperationArg { value: None };
+        let result = validate_withdraw_operation(context.clone(), valid_arg.clone()).unwrap();
+>>>>>>> 6abfbd4698 (second)
 
         match result {
             ValidatedOperationArg::TreasuryManagerWithdraw(withdraw) => {
@@ -1492,7 +1798,11 @@ mod tests {
             }),
         };
 
+<<<<<<< HEAD
         let result = validate_withdraw_operation(&governance, minimal_arg).unwrap_err();
+=======
+        let result = validate_withdraw_operation(context.clone(), minimal_arg).unwrap_err();
+>>>>>>> 6abfbd4698 (second)
         assert!(result.contains("Withdraw operation does not accept arguments at this time"));
     }
 
@@ -1545,7 +1855,7 @@ mod tests {
             });
 
         let rendered = withdraw_arg.render_for_proposal();
-        assert!(rendered.contains("Extension Operation"));
+        assert!(rendered.contains("Treasury Withdrawal"));
         assert!(rendered.contains("Raw Payload"));
         assert!(rendered.contains("test"));
         assert!(rendered.contains("data"));

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -1,8 +1,5 @@
-use crate::extensions::{
-    validate_execute_extension_operation, ExtensionType, ValidatedRegisterExtension,
-};
+use crate::extensions::{validate_execute_extension_operation, ValidatedRegisterExtension};
 use crate::icrc_ledger_helper::ICRCLedgerHelper;
-use crate::pb::sns_root_types::{register_extension_response, CanisterCallError};
 use crate::pb::v1::governance::GovernanceCachedMetrics;
 use crate::pb::v1::{
     valuation, ExecuteExtensionOperation, Metrics, RegisterExtension, TreasuryMetrics,
@@ -32,8 +29,8 @@ use crate::{
     pb::{
         sns_root_types::{
             ManageDappCanisterSettingsRequest, ManageDappCanisterSettingsResponse,
-            RegisterDappCanistersRequest, RegisterDappCanistersResponse, RegisterExtensionRequest,
-            RegisterExtensionResponse, SetDappControllersRequest, SetDappControllersResponse,
+            RegisterDappCanistersRequest, RegisterDappCanistersResponse, SetDappControllersRequest,
+            SetDappControllersResponse,
         },
         v1::{
             claim_swap_neurons_response::SwapNeuron,
@@ -2337,71 +2334,6 @@ impl Governance {
         }
     }
 
-    async fn register_extension_with_root(
-        &self,
-        extension_canister_id: CanisterId,
-    ) -> Result<(), GovernanceError> {
-        let payload = candid::Encode!(&RegisterExtensionRequest {
-            canister_id: Some(extension_canister_id.get()),
-        })
-        .map_err(|err| {
-            GovernanceError::new_with_message(
-                ErrorType::InvalidPrincipal,
-                format!("Could not encode RegisterExtensionRequest: {err:?}"),
-            )
-        })?;
-
-        let reply = self
-            .env
-            .call_canister(
-                self.proto.root_canister_id_or_panic(),
-                "register_extension",
-                payload,
-            )
-            .await
-            .map_err(|err| {
-                GovernanceError::new_with_message(
-                    ErrorType::External,
-                    format!("Canister method call failed: {err:?}"),
-                )
-            })?;
-
-        let RegisterExtensionResponse { result } = Decode!(&reply, RegisterExtensionResponse)
-            .map_err(|err| {
-                GovernanceError::new_with_message(
-                    ErrorType::External,
-                    format!("Could not decode RegisterExtensionResponse: {err:?}"),
-                )
-            })?;
-
-        if let Some(register_extension_response::Result::Err(CanisterCallError {
-            code,
-            description,
-        })) = result
-        {
-            let code = if let Some(code) = code {
-                code.to_string()
-            } else {
-                "<no code>".to_string()
-            };
-            return Err(GovernanceError::new_with_message(
-                ErrorType::External,
-                format!(
-                    "Root.register_extension failed with code {}: {}",
-                    code, description
-                ),
-            ));
-        }
-
-        log!(
-            INFO,
-            "Root.register_extension succeeded for canister {}",
-            extension_canister_id.get()
-        );
-
-        Ok(())
-    }
-
     async fn perform_register_extension(
         &mut self,
         register_extension: RegisterExtension,
@@ -2415,60 +2347,15 @@ impl Governance {
         }
 
         // Step 0. Validate the RegisterExtension proposal.
-        let ValidatedRegisterExtension { wasm, init, spec } =
-            register_extension.try_into().map_err(|err| {
+        let validated_register_extension = ValidatedRegisterExtension::try_from(register_extension)
+            .map_err(|err| {
                 GovernanceError::new_with_message(
                     ErrorType::InvalidProposal,
                     format!("Invalid RegisterExtension: {err:?}"),
                 )
             })?;
 
-        let Wasm::Chunked {
-            wasm_module_hash,
-            store_canister_id,
-            chunk_hashes_list,
-        } = wasm
-        else {
-            return Err(GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                "RegisterExtension proposal must contain a chunked wasm module.",
-            ));
-        };
-
-        // Use the store canister to install the extension itself.
-        let extension_canister_id = store_canister_id;
-
-        // Step 1. Register the extension with Root.
-        self.register_extension_with_root(extension_canister_id)
-            .await?;
-
-        // Step 2. Validate the init arguments.
-        if !spec.supports_extension_type(ExtensionType::TreasuryManager) {
-            return Err(GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                "Only TreasuryManager extensions are currently supported.",
-            ));
-        }
-
-        let treasury_manager_canister_id = extension_canister_id;
-
-        let (arg, sns_amount_e8s, icp_amount_e8s) =
-            self.construct_treasury_manager_init_payload(init).await?;
-
-        self.deposit_treasury_manager(treasury_manager_canister_id, sns_amount_e8s, icp_amount_e8s)
-            .await?;
-
-        self.upgrade_non_root_canister(
-            treasury_manager_canister_id,
-            Wasm::Chunked {
-                wasm_module_hash,
-                store_canister_id,
-                chunk_hashes_list,
-            },
-            arg,
-            CanisterInstallMode::Install,
-        )
-        .await?;
+        validated_register_extension.execute(self).await?;
 
         Ok(())
     }
@@ -2671,7 +2558,9 @@ impl Governance {
             validate_execute_extension_operation(self, execute_extension_operation).await?;
 
         // Execute the validated operation
-        validated_operation.execute(self).await
+        validated_operation.execute(self).await?;
+
+        Ok(())
     }
 
     /// Executes a ManageNervousSystemParameters proposal by updating Governance's
@@ -2792,8 +2681,8 @@ impl Governance {
         .await
     }
 
-    async fn upgrade_non_root_canister(
-        &mut self,
+    pub(crate) async fn upgrade_non_root_canister(
+        &self,
         canister_id: CanisterId,
         wasm: Wasm,
         arg: Vec<u8>,

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -1,4 +1,4 @@
-use crate::extensions::{validate_execute_extension_operation, ValidatedRegisterExtension};
+use crate::extensions::{validate_execute_extension_operation, validate_register_extension};
 use crate::icrc_ledger_helper::ICRCLedgerHelper;
 use crate::pb::v1::governance::GovernanceCachedMetrics;
 use crate::pb::v1::{
@@ -2346,16 +2346,12 @@ impl Governance {
             ));
         }
 
-        // Step 0. Validate the RegisterExtension proposal.
-        let validated_register_extension = ValidatedRegisterExtension::try_from(register_extension)
-            .map_err(|err| {
-                GovernanceError::new_with_message(
-                    ErrorType::InvalidProposal,
-                    format!("Invalid RegisterExtension: {err:?}"),
-                )
-            })?;
+        let context = self.extension_context().await?;
 
-        validated_register_extension.execute(self).await?;
+        let validated_register_extension =
+            validate_register_extension(context.clone(), register_extension)?;
+
+        validated_register_extension.execute(self, context).await?;
 
         Ok(())
     }
@@ -2554,11 +2550,17 @@ impl Governance {
             ));
         }
 
-        let validated_operation =
-            validate_execute_extension_operation(self, execute_extension_operation).await?;
+        let context = self.extension_context().await?;
+
+        let validated_operation = validate_execute_extension_operation(
+            &*self.env,
+            context.clone(),
+            execute_extension_operation,
+        )
+        .await?;
 
         // Execute the validated operation
-        validated_operation.execute(self).await?;
+        validated_operation.execute(self, context).await?;
 
         Ok(())
     }

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1,6 +1,5 @@
 use crate::cached_upgrade_steps::render_two_versions_as_markdown_table;
-use crate::extensions::validate_execute_extension_operation;
-use crate::extensions::{validate_extension_wasm, ValidatedExecuteExtensionOperation};
+use crate::extensions::validate_extension_wasm;
 use crate::pb::v1::{
     AdvanceSnsTargetVersion, ExecuteExtensionOperation, RegisterExtension,
     SetTopicsForCustomProposals, Topic,
@@ -1504,22 +1503,27 @@ async fn validate_and_render_execute_extension_operation(
     governance: &crate::governance::Governance,
     operation: &ExecuteExtensionOperation,
 ) -> Result<String, String> {
-    let ValidatedExecuteExtensionOperation {
-        extension_canister_id,
-        operation_name,
-        operation_arg,
-    } = validate_execute_extension_operation(env, root_canister_id, operation.clone())
-        .await
-        .map_err(|err| err.error_message)?;
+    // DO NOT MERGE
+    todo!()
 
-    Ok(format!(
-        r"# Proposal to execute extension operation:
+    // let context = ...
 
-* Extension canister ID: `{extension_canister_id}`
-* Operation name: `{operation_name}`
-* Operation argument: `{operation_arg}`
-#"
-    ))
+    //     let ValidatedExecuteExtensionOperation {
+    //         extension_canister_id,
+    //         operation_name,
+    //         arg,
+    //     } = validate_execute_extension_operation(env, context, operation.clone())
+    //         .await
+    //         .map_err(|err| err.error_message)?;
+
+    //     Ok(format!(
+    //         r"# Proposal to execute extension operation:
+
+    // * Extension canister ID: `{extension_canister_id}`
+    // * Operation name: `{operation_name}`
+    // * Operation argument: `{arg}`
+    // #"
+    //     ))
 }
 
 async fn validate_and_render_register_extension(

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1502,13 +1502,13 @@ pub async fn validate_and_render_execute_nervous_system_function(
 
 async fn validate_and_render_execute_extension_operation(
     governance: &crate::governance::Governance,
-    execute: &ExecuteExtensionOperation,
+    operation: &ExecuteExtensionOperation,
 ) -> Result<String, String> {
     let ValidatedExecuteExtensionOperation {
         extension_canister_id,
         operation_name,
         operation_arg,
-    } = validate_execute_extension_operation(governance, execute.clone())
+    } = validate_execute_extension_operation(env, root_canister_id, operation.clone())
         .await
         .map_err(|err| err.error_message)?;
 
@@ -1539,8 +1539,9 @@ async fn validate_and_render_register_extension(
             None
         }
         Some(chunked_wasm) => {
-            if let Some(canister_id) = chunked_wasm.store_canister_id {
-                match Wasm::try_from(chunked_wasm.clone()) {
+            let canister_id = chunked_wasm.store_canister_id.clone();
+            if let Some(canister_id) = canister_id {
+                match Wasm::try_from(chunked_wasm) {
                     Ok(wasm) => Some((wasm, canister_id)),
                     Err(err) => {
                         defects.push(format!("Invalid chunked_canister_wasm: {}", err));
@@ -1604,7 +1605,7 @@ async fn validate_and_render_register_extension(
 
 ## Extension Configuration
 
-The extension will be deployed and configured according to the provided parameters.",
+The extension will be deployed and configured according to the parameters provided above.",
     ))
 }
 

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1539,7 +1539,7 @@ async fn validate_and_render_register_extension(
             None
         }
         Some(chunked_wasm) => {
-            let canister_id = chunked_wasm.store_canister_id.clone();
+            let canister_id = chunked_wasm.store_canister_id;
             if let Some(canister_id) = canister_id {
                 match Wasm::try_from(chunked_wasm) {
                     Ok(wasm) => Some((wasm, canister_id)),


### PR DESCRIPTION
This PR follows the pattern established by the extension operation execution code to improve code organization for extension registration. This is in preparation for having common validation functions for proposal submission and execution.