### PR TITLE
fix: Use a more reliable way to check if SEV is active in the Guest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15372,6 +15372,7 @@ dependencies = [
  "hkdf",
  "mockall",
  "pem 1.1.1",
+    "raw-cpuid",
  "rcgen",
  "reqwest 0.12.15",
  "sev",
@@ -20274,9 +20275,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.3.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6928fa44c097620b706542d428957635951bade7143269085389d42c8a4927e"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags 2.9.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -755,6 +755,7 @@ quinn-udp = "0.5.5"
 quote = "1.0.37"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_chacha = "0.3.1"
+raw-cpuid = "11.5"
 rayon = "1.10.0"
 rcgen = { version = "0.13.1", features = ["zeroize"] }
 regex = "1.11.0"

--- a/bazel/external_crates.bzl
+++ b/bazel/external_crates.bzl
@@ -449,6 +449,9 @@ def external_crates_repository(name, cargo_lockfile, lockfile):
             "convert_case": crate.spec(
                 version = "^0.6.0",
             ),
+            "raw-cpuid": crate.spec(
+                version = "11.5",
+            ),
             "crc32fast": crate.spec(
                 version = "^1.2.0",
             ),

--- a/ic-os/components/ssh/setup-ssh-user-keys/setup-ssh-user-keys-guestos.sh
+++ b/ic-os/components/ssh/setup-ssh-user-keys/setup-ssh-user-keys-guestos.sh
@@ -13,7 +13,13 @@ copy_ssh_keys() {
     fi
 }
 
-ENABLE_TEE=$(get_config_value '.icos_settings.enable_trusted_execution_environment')
+if /opt/ic/bin/sev_active; then
+  ENABLE_TEE="true"
+elif [ $? -eq 1 ]; then
+  ENABLE_TEE="false"
+else
+  exit 1
+fi
 
 for ACCOUNT in backup readonly admin; do
     HOMEDIR=$(getent passwd "${ACCOUNT}" | cut -d: -f6)

--- a/ic-os/guestos/defs.bzl
+++ b/ic-os/guestos/defs.bzl
@@ -54,6 +54,7 @@ def image_deps(mode, malicious = False):
             "//cpp:infogetty": "/opt/ic/bin/infogetty:0755",  # Terminal manager that replaces the login shell.
             "//rs/ic_os/release:metrics-proxy": "/opt/ic/bin/metrics-proxy:0755",  # Proxies, filters, and serves public node metrics.
             "//rs/ic_os/release:metrics_tool": "/opt/ic/bin/metrics_tool:0755",  # Collects and reports custom metrics.
+            "//rs/ic_os/sev:sev_active": "/opt/ic/bin/sev_active:0755",  # Tool for querying the SEV activation status
 
             # additional libraries to install
             "//rs/ic_os/release:nss_icos": "/usr/lib/x86_64-linux-gnu/libnss_icos.so.2:0644",  # Allows referring to the guest IPv6 by name guestos from host, and host as hostos from guest.

--- a/rs/ic_os/config_types/src/lib.rs
+++ b/rs/ic_os/config_types/src/lib.rs
@@ -122,6 +122,9 @@ pub struct ICOSSettings {
     /// If the value is enabled, we check during deployment that SEV-SNP is supported
     /// by the hardware. Once deployment is successful, we rely on the hardware supporting
     /// SEV-SNP.
+    ///
+    /// IMPORTANT: In GuestOS code, it's recommended to use `is_sev_active()` from the ic_sev crate
+    /// instead, which queries the CPU and cannot be faked by a malicious HostOS.
     #[serde(default)]
     pub enable_trusted_execution_environment: bool,
     /// This ssh keys directory contains individual files named `admin`, `backup`, `readonly`.

--- a/rs/ic_os/os_tools/guest_disk/src/tests.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/tests.rs
@@ -93,6 +93,9 @@ impl<'a> TestFixture<'a> {
         run(
             args,
             &self.guestos_config,
+            self.guestos_config
+                .icos_settings
+                .enable_trusted_execution_environment,
             || Ok(self.get_mock_sev_key_deriver()),
             &self.previous_key_path,
             &self.generated_key_path,

--- a/rs/ic_os/sev/BUILD.bazel
+++ b/rs/ic_os/sev/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 
 package(default_visibility = ["//rs:ic-os-pkg"])
 
@@ -9,6 +9,7 @@ DEPENDENCIES = [
     "@crate_index//:der",
     "@crate_index//:hkdf",
     "@crate_index//:mockall",
+    "@crate_index//:raw-cpuid",
     "@crate_index//:reqwest",
     "@crate_index//:sev",
     "@crate_index//:sha2",
@@ -20,8 +21,6 @@ DEV_DEPENDENCIES = [
     "@crate_index//:pem",
     "@crate_index//:rcgen",
 ]
-
-MACRO_DEPENDENCIES = []
 
 ALIASES = {}
 
@@ -36,11 +35,19 @@ rust_library(
         "fixtures/mock_amd_key_server_response.crt",
     ],
     crate_name = "ic_sev",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     target_compatible_with = [
         "@platforms//os:linux",
     ],
     deps = DEPENDENCIES,
+)
+
+rust_binary(
+    name = "sev_active",
+    srcs = ["src/bin/sev_active.rs"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    deps = DEPENDENCIES + [":sev"],
 )
 
 rust_test(

--- a/rs/ic_os/sev/Cargo.toml
+++ b/rs/ic_os/sev/Cargo.toml
@@ -2,12 +2,17 @@
 name = "ic_sev"
 edition = "2021"
 
+[[bin]]
+name = "sev_active"
+path = "src/bin/sev_active.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
 der = { workspace = true }
 hkdf = { workspace = true }
 mockall = { workspace = true }
+raw-cpuid = { workspace = true }
 reqwest = { workspace = true }
 sev = { workspace = true }
 sha2 = { workspace = true }

--- a/rs/ic_os/sev/src/bin/sev_active.rs
+++ b/rs/ic_os/sev/src/bin/sev_active.rs
@@ -1,0 +1,13 @@
+use ic_sev::guest::is_sev_active;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match is_sev_active() {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::from(1),
+        Err(err) => {
+            eprintln!("Error checking SEV status: {err:?}");
+            ExitCode::from(2)
+        }
+    }
+}

--- a/rs/ic_os/sev/src/guest/mod.rs
+++ b/rs/ic_os/sev/src/guest/mod.rs
@@ -1,2 +1,34 @@
+use anyhow::{Context, Result};
+use raw_cpuid::CpuId;
+use std::fs::File;
+use std::os::unix::fs::FileExt;
+use std::path::Path;
+
 pub mod firmware;
 pub mod key_deriver;
+
+/// Checks if SEV is active in the Guest Virtual Machine
+pub fn is_sev_active() -> Result<bool> {
+    // See https://docs.kernel.org/6.2/x86/amd-memory-encryption.html
+    const MSR_AMD64_SEV: u64 = 0xc0010131;
+
+    if Path::new("/dev/sev-guest").exists() {
+        return Ok(true);
+    }
+
+    let Some(memory_encryption_info) = CpuId::new().get_memory_encryption_info() else {
+        // If the CPU does not report memory encryption info, SEV cannot be active.
+        return Ok(false);
+    };
+    if !memory_encryption_info.has_sev() {
+        // If the CPU does not support SEV, it cannot be active.
+        return Ok(false);
+    }
+
+    let msr = File::open("/dev/cpu/0/msr").context("Failed to open /dev/cpu/0/msr")?;
+    // MSR reads must be multiplies of 8 bytes, see msr_read in the kernel
+    let mut bytes = [0u8; 8];
+    msr.read_at(&mut bytes, MSR_AMD64_SEV)
+        .context("Failed to read from /dev/cpu/0/msr")?;
+    Ok((bytes[0] & 1) != 0)
+}


### PR DESCRIPTION
This new method queries the CPU for the SEV status which cannot be faked by a malicious host.