### PR TITLE
chore: HostOS SEV improvements

### DIFF
--- a/ic-os/components/networking/nftables/hostos/nftables.template
+++ b/ic-os/components/networking/nftables/hostos/nftables.template
@@ -210,6 +210,7 @@ table ip6 filter {
     ct state { invalid } drop
     ct state { established, related } accept
     icmpv6 type $icmp_v6_types_accept accept
+    ip6 daddr { ::/0 } ct state { new } tcp dport { 1080 } accept
     ip6 daddr { ::/0 } ct state { new } tcp dport { 53 } accept
     ip6 daddr { ::/0 } ct state { new } udp dport { 53 } accept
     ip6 daddr { ::/0 } ct state { new } udp dport { 123 } accept

--- a/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_sev.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/guestos_vm_sev.xml
@@ -23,9 +23,6 @@
     <reducedPhysBits>1</reducedPhysBits>
     <policy>30000</policy>
   </launchSecurity>
-  <memoryBacking>
-    <locked/>
-  </memoryBacking>
   <resource>
     <partition>/machine</partition>
   </resource>

--- a/rs/ic_os/os_tools/guest_vm_runner/golden/upgrade_guestos.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/golden/upgrade_guestos.xml
@@ -15,9 +15,6 @@
     <reducedPhysBits>1</reducedPhysBits>
     <policy>30000</policy>
   </launchSecurity>
-  <memoryBacking>
-    <locked/>
-  </memoryBacking>
   <resource>
     <partition>/machine</partition>
   </resource>

--- a/rs/ic_os/os_tools/guest_vm_runner/templates/guestos_vm_template.xml
+++ b/rs/ic_os/os_tools/guest_vm_runner/templates/guestos_vm_template.xml
@@ -30,9 +30,6 @@
     <reducedPhysBits>1</reducedPhysBits>
     <policy>30000</policy>
   </launchSecurity>
-  <memoryBacking>
-    <locked/>
-  </memoryBacking>
   {% endif -%}
 
   <resource>


### PR DESCRIPTION
- Open outgoing SOCKS proxy connections via TCP 1080 port
- Remove locked memory from the SEV config (this is unnecessary according to Rüdiger K and was preventing the VM from starting)