### PR TITLE
feat(ICRC_Index): FI-1818: Handle fee in burn blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10024,6 +10024,7 @@ dependencies = [
  "ic-icrc1-test-utils",
  "ic-icrc1-tokens-u256",
  "ic-icrc1-tokens-u64",
+ "ic-icrc3-test-ledger",
  "ic-ledger-canister-core",
  "ic-ledger-core",
  "ic-ledger-suite-state-machine-tests",

--- a/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/index-ng/BUILD.bazel
@@ -102,12 +102,14 @@ rust_test(
         data = [
             conf["index_wasm"],
             conf["ledger_wasm"],
+            "//rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger:icrc3_test_ledger_canister.wasm.gz",
         ],
         env = {
             "RUST_TEST_THREADS": "4",
             "CARGO_MANIFEST_DIR": "rs/ledger_suite/icrc1/index-ng",
             "IC_ICRC1_INDEX_NG_WASM_PATH": "$(rootpath " + conf["index_wasm"] + ")",
             "IC_ICRC1_LEDGER_WASM_PATH": "$(rootpath " + conf["ledger_wasm"] + ")",
+            "IC_ICRC3_TEST_LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger:icrc3_test_ledger_canister.wasm.gz)",
         },
         extra_srcs = ["tests/common/mod.rs"],
         tags = ["cpu:4"],
@@ -121,6 +123,7 @@ rust_test(
             "//rs/ledger_suite/icrc1",
             "//rs/ledger_suite/icrc1/ledger",
             "//rs/ledger_suite/icrc1/test_utils",
+            "//rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger",
             "//rs/ledger_suite/icrc1/tokens_u64",
             "//rs/ledger_suite/tests/sm-tests:ic-ledger-suite-state-machine-tests",
             "//rs/registry/subnet_type",

--- a/rs/ledger_suite/icrc1/index-ng/Cargo.toml
+++ b/rs/ledger_suite/icrc1/index-ng/Cargo.toml
@@ -40,6 +40,7 @@ ic-base-types = { path = "../../../types/base_types" }
 ic-icrc1-ledger = { path = "../ledger" }
 ic-ledger-suite-state-machine-tests = { path = "../../tests/sm-tests" }
 ic-icrc1-test-utils = { path = "../test_utils" }
+ic-icrc3-test-ledger = { path = "../test_utils/icrc3_test_ledger" }
 ic-registry-subnet-type = { path = "../../../registry/subnet_type" }
 ic-rosetta-test-utils = { path = "../../../rosetta-api/icp/test_utils" }
 ic-state-machine-tests = { path = "../../../state_machine_tests" }

--- a/rs/ledger_suite/icrc1/index-ng/tests/common/mod.rs
+++ b/rs/ledger_suite/icrc1/index-ng/tests/common/mod.rs
@@ -121,6 +121,18 @@ pub fn ledger_wasm() -> Vec<u8> {
     })
 }
 
+pub fn test_ledger_wasm() -> Vec<u8> {
+    let ledger_wasm_path = std::env::var("IC_ICRC3_TEST_LEDGER_WASM_PATH").expect(
+        "The Ledger wasm path must be set using the env variable IC_ICRC3_TEST_LEDGER_WASM_PATH",
+    );
+    std::fs::read(&ledger_wasm_path).unwrap_or_else(|e| {
+        panic!(
+            "failed to load Wasm file from path {} (env var IC_ICRC3_TEST_LEDGER_WASM_PATH): {}",
+            ledger_wasm_path, e
+        )
+    })
+}
+
 #[cfg(feature = "icrc3_disabled")]
 pub fn ledger_get_blocks(
     env: &StateMachine,

--- a/rs/ledger_suite/icrc1/index-ng/tests/common/mod.rs
+++ b/rs/ledger_suite/icrc1/index-ng/tests/common/mod.rs
@@ -121,6 +121,7 @@ pub fn ledger_wasm() -> Vec<u8> {
     })
 }
 
+#[allow(dead_code)]
 pub fn test_ledger_wasm() -> Vec<u8> {
     let ledger_wasm_path = std::env::var("IC_ICRC3_TEST_LEDGER_WASM_PATH").expect(
         "The Ledger wasm path must be set using the env variable IC_ICRC3_TEST_LEDGER_WASM_PATH",

--- a/rs/ledger_suite/icrc1/index-ng/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/index-ng/tests/tests.rs
@@ -1268,6 +1268,7 @@ mod metrics {
     }
 }
 
+#[cfg(not(feature = "icrc3_disabled"))]
 mod burn_block_fees {
     use super::*;
     use crate::common::{test_ledger_wasm, STARTING_CYCLES_PER_CANISTER};


### PR DESCRIPTION
Handle potential `fee` in blocks with a `burn` transaction in the ICRC Index canister, by debiting the balance of the account from which the fee was burned, and crediting the fee collector account (if set).