### PR TITLE
fix(ckbtc): prevent signing transaction with too many inputs

### DIFF
--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -1049,7 +1049,7 @@ pub fn build_unsigned_transaction(
     }
 }
 
-fn build_unsigned_transaction_from_inputs(
+pub fn build_unsigned_transaction_from_inputs(
     input_utxos: &[Utxo],
     outputs: Vec<(BitcoinAddress, Satoshi)>,
     main_address: BitcoinAddress,

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 use serde_bytes::ByteBuf;
 use std::cmp::max;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::time::Duration;
 
 pub mod address;
@@ -848,6 +849,44 @@ fn greedy(target: u64, available_utxos: &mut BTreeSet<Utxo>) -> Vec<Utxo> {
     solution
 }
 
+/// Error returned when signing a transaction.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum SignTransactionError {
+    /// Error from the management canister
+    ManagementCanisterError(CallError),
+    /// The transaction contains too many inputs.
+    /// If such a transaction where signed, there is a risk that the resulting transaction will be *non-standard*
+    /// since it will have a size over 100kB.
+    TooManyInputs {
+        num_inputs: usize,
+        max_num_inputs: usize,
+    },
+}
+
+impl From<CallError> for SignTransactionError {
+    fn from(e: CallError) -> Self {
+        SignTransactionError::ManagementCanisterError(e)
+    }
+}
+
+impl fmt::Display for SignTransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SignTransactionError::ManagementCanisterError(e) => {
+                write!(f, "Management canister error: {}", e)
+            }
+            SignTransactionError::TooManyInputs {
+                num_inputs,
+                max_num_inputs,
+            } => write!(
+                f,
+                "Transaction has too many inputs: {} (maximum: {})",
+                num_inputs, max_num_inputs
+            ),
+        }
+    }
+}
+
 /// Gathers ECDSA signatures for all the inputs in the specified unsigned
 /// transaction.
 ///
@@ -860,10 +899,20 @@ pub async fn sign_transaction(
     ecdsa_public_key: &ECDSAPublicKey,
     output_account: &BTreeMap<tx::OutPoint, Account>,
     unsigned_tx: tx::UnsignedTransaction,
-) -> Result<tx::SignedTransaction, CallError> {
+) -> Result<tx::SignedTransaction, SignTransactionError> {
     use crate::address::{derivation_path, derive_public_key};
 
-    let mut signed_inputs = Vec::with_capacity(unsigned_tx.inputs.len());
+    const MAX_NUM_INPUTS: usize = 1_000;
+
+    let num_inputs = unsigned_tx.inputs.len();
+    if num_inputs > MAX_NUM_INPUTS {
+        return Err(SignTransactionError::TooManyInputs {
+            max_num_inputs: MAX_NUM_INPUTS,
+            num_inputs: num_inputs,
+        });
+    }
+
+    let mut signed_inputs = Vec::with_capacity(num_inputs);
     let sighasher = tx::TxSigHasher::new(&unsigned_tx);
     for input in &unsigned_tx.inputs {
         let outpoint = &input.previous_output;

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -908,7 +908,7 @@ pub async fn sign_transaction(
     if num_inputs > MAX_NUM_INPUTS {
         return Err(SignTransactionError::TooManyInputs {
             max_num_inputs: MAX_NUM_INPUTS,
-            num_inputs: num_inputs,
+            num_inputs,
         });
     }
 

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -855,8 +855,8 @@ pub enum SignTransactionError {
     /// Error from the management canister
     ManagementCanisterError(CallError),
     /// The transaction contains too many inputs.
-    /// If such a transaction where signed, there is a risk that the resulting transaction will be *non-standard*
-    /// since it will have a size over 100kB.
+    /// If such a transaction where signed, there is a risk that the resulting transaction will have a size
+    /// over 100k vbytes and therefore be *non-standard*.
     TooManyInputs {
         num_inputs: usize,
         max_num_inputs: usize,

--- a/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
@@ -65,13 +65,6 @@ async fn should_migrate_events_for(file: impl GetEventsFile) -> CkBtcMinterState
 }
 
 #[tokio::test]
-async fn should_migrate_events_for_mainnet() {
-    let state = should_migrate_events_for(Mainnet).await;
-    assert_eq!(state.btc_network, Network::Mainnet);
-    assert_eq!(state.get_total_btc_managed(), 20_209_150_152);
-}
-
-#[tokio::test]
 async fn should_migrate_events_for_testnet() {
     let state = should_migrate_events_for(Testnet).await;
     assert_eq!(state.btc_network, Network::Testnet);
@@ -215,9 +208,8 @@ async fn should_not_grow_number_of_useless_events() {
     }
 
     let (total_event_count, useless_events_indexes) = test(Mainnet);
-    assert_eq!(total_event_count, 443_137);
-    assert_eq!(useless_events_indexes.len(), 409_141);
-    assert_eq!(useless_events_indexes.last(), Some(&411_301_usize));
+    assert_eq!(total_event_count, 551_739);
+    assert_eq!(useless_events_indexes.len(), 0);
 
     let (total_event_count, useless_events_indexes) = test(Testnet);
     assert_eq!(total_event_count, 46_815);

--- a/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
@@ -132,7 +132,7 @@ async fn should_not_resubmit_tx_87ebf46e400a39e5ec22b28515056a3ce55187dba9669de8
     .unwrap();
     let tx_fee_per_vbyte = submitted_tx.fee_per_vbyte.unwrap();
     let (unsigned_tx, _change_output) = build_unsigned_transaction_from_inputs(
-        &input_utxos,
+        input_utxos,
         outputs,
         main_address.clone(),
         tx_fee_per_vbyte,

--- a/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
@@ -116,7 +116,7 @@ async fn analyze_tx_87ebf46e400a39e5ec22b28515056a3ce55187dba9669de8300160ac08f6
             .iter()
             .map(|req| req.amount)
             .sum::<u64>(),
-        33_16_317_017_u64 //33 BTC!
+        3_316_317_017_u64 //33 BTC!
     );
     assert_eq!(submitted_transaction.used_utxos.len(), 1_799);
     assert_eq!(submitted_transaction.fee_per_vbyte, Some(7_486));

--- a/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
@@ -84,7 +84,7 @@ async fn should_replay_events_for_mainnet() {
         .expect("Failed to check invariants");
 
     assert_eq!(state.btc_network, Network::Mainnet);
-    assert_eq!(state.get_total_btc_managed(), 20_209_150_152);
+    assert_eq!(state.get_total_btc_managed(), 43_332_249_778);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Prevent the ckBTC minter from signing a transaction that uses too many inputs to ensure that the transaction remains standard and has a size below the limit of 100kB. This is a stop-gap solution to prevent sending and resubmitting non-standard transactions. 