### PR TITLE
test(node): Use dev hashes in mainnet-icos-revisions.json

### DIFF
--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -54,11 +54,8 @@ def download_and_hash_image(url, logger):
         raise
 
 
-def get_image_hash_for_version(version, variant, is_dev=True, logger=None):
+def get_image_hash_for_version(version, variant, logger, is_dev=True):
     """Get the SHA256 hash of an update image for a given version and variant."""
-    if logger is None:
-        logger = logging.getLogger(__name__)
-
     base_url = base_download_url(
         git_commit_id=version,
         variant=variant,
@@ -189,7 +186,7 @@ def get_subnet_replica_version_info(subnet_id: str, logger: logging.Logger) -> (
 
         # TODO(NODE-1682): Currently only the application subnet uses dev images
         is_dev = subnet_id == app_subnet_id
-        hash = get_image_hash_for_version(version, "guest-os", is_dev, logger)
+        hash = get_image_hash_for_version(version, "guest-os", logger, is_dev)
 
         return (version, hash)
 
@@ -209,7 +206,7 @@ def get_latest_hostos_version_info(logger: logging.Logger) -> (str, str):
 
         version = latest_elect_proposal["payload"]["hostos_version_to_elect"]
 
-        hash = get_image_hash_for_version(version, "host-os", is_dev=True, logger=logger)
+        hash = get_image_hash_for_version(version, "host-os", logger, is_dev=True)
 
         return (version, hash)
 

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -29,7 +29,7 @@ def base_download_url(git_commit_id, variant, update, test, dev=True):
     test_suffix = "-test" if test else ""
     return f"https://download.dfinity.systems/ic/{git_commit_id}/{variant}/{component}{test_suffix}/"
 
-
+# NOTE: We must download and hash the update dev image ourselves because public proposals only include hashes for the production images
 def download_and_hash_image(url, logger):
     """Download an image from the given URL and return its SHA256 hash."""
     logger.info(f"Downloading image from: {url}")

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -8,8 +8,6 @@ import subprocess
 import urllib.request
 from enum import Enum
 from typing import List
-import tempfile
-import os
 
 MAINNET_ICOS_REVISIONS_FILE = "mainnet-icos-revisions.json"
 nns_subnet_id = "tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe"
@@ -28,6 +26,7 @@ def base_download_url(git_commit_id, variant, update, test, dev=True):
     component = ("update-img" if update else "disk-img") + ("-dev" if dev else "")
     test_suffix = "-test" if test else ""
     return f"https://download.dfinity.systems/ic/{git_commit_id}/{variant}/{component}{test_suffix}/"
+
 
 # NOTE: We must download and hash the update dev image ourselves because public proposals only include hashes for the production images
 def download_and_hash_image(url, logger):
@@ -56,13 +55,7 @@ def download_and_hash_image(url, logger):
 
 def get_image_hash_for_version(version, variant, logger, is_dev=True):
     """Get the SHA256 hash of an update image for a given version and variant."""
-    base_url = base_download_url(
-        git_commit_id=version,
-        variant=variant,
-        update=True,
-        test=False,
-        dev=is_dev
-    )
+    base_url = base_download_url(git_commit_id=version, variant=variant, update=True, test=False, dev=is_dev)
 
     image_url = base_url + "update-img.tar.zst"
 

--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -35,6 +35,10 @@ def download_and_hash_image(url, logger):
 
     try:
         with urllib.request.urlopen(url, timeout=300) as response:
+            status = response.status
+            if status != 200:
+                raise Exception(f"Unexpected response {status}!")
+
             sha256_hash = hashlib.sha256()
 
             chunk_size = 8192

--- a/ic-os/dev-tools/hostos-upgrade-tests.sh
+++ b/ic-os/dev-tools/hostos-upgrade-tests.sh
@@ -24,7 +24,7 @@ for version in "${VERSIONS[@]}"; do
     echo "==================================="
 
     tmpfile=$(mktemp)
-    url="https://download.dfinity.systems/ic/${version}/host-os/update-img/update-img.tar.zst"
+    url="https://download.dfinity.systems/ic/${version}/host-os/update-img-dev/update-img.tar.zst"
 
     echo "Downloading update image from $url ..."
     if ! curl -fL -o "$tmpfile" "$url"; then
@@ -35,12 +35,12 @@ for version in "${VERSIONS[@]}"; do
     fi
 
     hash=$(sha256sum "$tmpfile" | awk '{print $1}')
-    echo "Calculated update_img_hash: $hash"
+    echo "Calculated update_img_hash_dev: $hash"
     rm -f "$tmpfile"
 
     # Update the mainnet-icos-revisions.json file with the current version and computed hash.
     if ! jq --arg ver "$version" --arg hash "$hash" \
-        '.hostos.latest_release.version = $ver | .hostos.latest_release.update_img_hash = $hash' \
+        '.hostos.latest_release.version = $ver | .hostos.latest_release.update_img_hash_dev = $hash' \
         "$REVISIONS_FILE" >"${REVISIONS_FILE}.tmp"; then
         echo "Failed to update $REVISIONS_FILE for version $version."
         results["$version"]="JSON update failed"

--- a/mainnet-icos-revisions.json
+++ b/mainnet-icos-revisions.json
@@ -7,14 +7,14 @@
       },
       "io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe": {
         "version": "047925dfd8386aca91d154054149727131766084",
-        "update_img_hash": "dd22a2b107cd22d848df4c7d3037bc8637dc23cf27464e0fbb5e66ec5deeceaf"
+        "update_img_hash_dev": "dd22a2b107cd22d848df4c7d3037bc8637dc23cf27464e0fbb5e66ec5deeceaf"
       }
     }
   },
   "hostos": {
     "latest_release": {
       "version": "047925dfd8386aca91d154054149727131766084",
-      "update_img_hash": "2f70da96ff1ddb8701dd0d647c46027d7f0e9fe664be98f3ffc3830bf069dc87"
+      "update_img_hash_dev": "2f70da96ff1ddb8701dd0d647c46027d7f0e9fe664be98f3ffc3830bf069dc87"
     }
   }
 }

--- a/rs/tests/common.bzl
+++ b/rs/tests/common.bzl
@@ -8,9 +8,9 @@ load(":qualifying_nns_canisters.bzl", "QUALIFYING_NNS_CANISTERS", "QUALIFYING_SN
 MAINNET_NNS_SUBNET_REVISION = mainnet_icos_versions["guestos"]["subnets"]["tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe"]["version"]
 MAINNET_NNS_SUBNET_HASH = mainnet_icos_versions["guestos"]["subnets"]["tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe"]["update_img_hash"]
 MAINNET_APPLICATION_SUBNET_REVISION = mainnet_icos_versions["guestos"]["subnets"]["io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe"]["version"]
-MAINNET_APPLICATION_SUBNET_HASH = mainnet_icos_versions["guestos"]["subnets"]["io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe"]["update_img_hash"]
+MAINNET_APPLICATION_SUBNET_HASH = mainnet_icos_versions["guestos"]["subnets"]["io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe"]["update_img_hash_dev"]
 MAINNET_LATEST_HOSTOS_REVISION = mainnet_icos_versions["hostos"]["latest_release"]["version"]
-MAINNET_LATEST_HOSTOS_HASH = mainnet_icos_versions["hostos"]["latest_release"]["update_img_hash"]
+MAINNET_LATEST_HOSTOS_HASH = mainnet_icos_versions["hostos"]["latest_release"]["update_img_hash_dev"]
 
 MAINNET_ENV = {
     "MAINNET_NNS_SUBNET_REVISION_ENV": MAINNET_NNS_SUBNET_REVISION,

--- a/rs/tests/common.bzl
+++ b/rs/tests/common.bzl
@@ -6,6 +6,8 @@ load("@mainnet_icos_versions//:defs.bzl", "mainnet_icos_versions")
 load(":qualifying_nns_canisters.bzl", "QUALIFYING_NNS_CANISTERS", "QUALIFYING_SNS_CANISTERS")
 
 MAINNET_NNS_SUBNET_REVISION = mainnet_icos_versions["guestos"]["subnets"]["tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe"]["version"]
+
+# TODO(NODE-1682): Switch mainnet_nns_setupos_disk_image to use dev image once published release is available.
 MAINNET_NNS_SUBNET_HASH = mainnet_icos_versions["guestos"]["subnets"]["tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe"]["update_img_hash"]
 MAINNET_APPLICATION_SUBNET_REVISION = mainnet_icos_versions["guestos"]["subnets"]["io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe"]["version"]
 MAINNET_APPLICATION_SUBNET_HASH = mainnet_icos_versions["guestos"]["subnets"]["io67a-2jmkw-zup3h-snbwi-g6a5n-rm5dn-b6png-lvdpl-nqnto-yih6l-gqe"]["update_img_hash_dev"]


### PR DESCRIPTION
NODE-1684

The mainnet-icos-revisions.json hash values are all for prod images, but we now support (and use!) dev images in our tests. 

We got lucky (or unlucky) that the change to start using dev mainnet images in tests didn’t break any of our tests. This was because we don’t have any tests upgrading **_TO a mainnet version_**. Our tests only test upgrading **FROM** mainnet versions or test ICs initially deployed with mainnet versions.

If a test tried to upgrade to a mainnet version, it would fail because the node would download a _dev_ upgrade image and see it doesn’t match the expected _prod_ image hash.

I only noticed this when I was testing a node joining a testnet IC with an unassigned registry version that didn’t match the node's own. 