### PR TITLE
chore(crypto): Update change logs and versions for ic-ed25519 and ic-secp256k1

### DIFF
--- a/packages/ic-ed25519/BUILD.bazel
+++ b/packages/ic-ed25519/BUILD.bazel
@@ -35,7 +35,7 @@ rust_library(
     crate_features = ["rand"],
     crate_name = "ic_ed25519",
     proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "0.2.0",
+    version = "0.3.0",
     deps = DEPENDENCIES,
 )
 

--- a/packages/ic-ed25519/CHANGELOG.md
+++ b/packages/ic-ed25519/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-08-14
+
+### Added
+
+- Add `PublicKey::mainnet_key` which allows convenient access to the master public
+  keys used for threshold EdDSA on the Internet Computer.
+
 ## [0.2.0] - 2025-02-14
 
 ### Added

--- a/packages/ic-ed25519/Cargo.toml
+++ b/packages/ic-ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-ed25519"
-version = "0.2.0"
+version = "0.3.0"
 description = "A package created for the Internet Computer Protocol for creating and verifying Ed25519 signatures."
 license = "Apache-2.0"
 readme = "README.md"

--- a/packages/ic-secp256k1/BUILD.bazel
+++ b/packages/ic-secp256k1/BUILD.bazel
@@ -38,7 +38,7 @@ rust_library(
     aliases = ALIASES,
     crate_name = "ic_secp256k1",
     proc_macro_deps = MACRO_DEPENDENCIES,
-    version = "0.1.0",
+    version = "0.2.0",
     deps = DEPENDENCIES,
 )
 

--- a/packages/ic-secp256k1/CHANGELOG.md
+++ b/packages/ic-secp256k1/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-08-14
+
+### Added
+
+- Add `PublicKey::mainnet_key` which allows convenient access to the master public
+  keys used for threshold ECDSA and threshold BIP341 Schnorr on the Internet Computer.
+
 ## [0.1.0] - 2025-02-08
 
 Initial release.

--- a/packages/ic-secp256k1/Cargo.toml
+++ b/packages/ic-secp256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-secp256k1"
-version = "0.1.0"
+version = "0.2.0"
 description = "A package created for the Internet Computer Protocol for the handling of ECDSA and Schnorr keys over the secp256k1 curve."
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
With the intent of releasing new versions of both crates to crates.io so that they can be used in the CDK and elsewhere.