### PR TITLE
chore: add commands to simplify running rosetta tests locally

### DIFF
--- a/rs/rosetta-api/README.md
+++ b/rs/rosetta-api/README.md
@@ -1,0 +1,30 @@
+# Rosetta
+
+## Running Tests Locally
+
+### Prerequisites
+
+Install [Just](https://github.com/casey/just#installation):
+```bash
+# macOS
+brew install just
+
+# Linux/macOS with Cargo
+cargo install just
+
+# Ubuntu/Debian
+sudo apt install just
+```
+
+### Running Tests
+
+```bash
+# See all commands
+just
+
+# ICP tests
+just test icp
+
+# ICRC1 tests  
+just test icrc1
+```

--- a/rs/rosetta-api/justfile
+++ b/rs/rosetta-api/justfile
@@ -1,0 +1,28 @@
+# Default recipe to show available commands
+default:
+    @just --list
+
+# Test command - accepts 'icp' or 'icrc1' as argument
+test target:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    
+    if [ "{{ target }}" = "icp" ]; then
+        echo "Running ICP tests..."
+        cd icp
+        bazel test :rosetta-api_test --test_output=streamed
+        bazel test :rosetta-api-cli-tests --test_output=streamed
+        bazel test :icp_rosetta_system_tests --test_output=streamed
+    elif [ "{{ target }}" = "icrc1" ]; then
+        echo "Running ICRC1 tests..."
+        cd icrc1
+        bazel test :ic-icrc-rosetta-unit-tests --test_output=streamed
+        bazel test :storage-operations-tests --test_output=streamed
+        bazel test :icrc_rosetta_integration --test_output=streamed
+        bazel test :icrc_rosetta_system --test_output=streamed
+        bazel test :icrc_multitoken_rosetta_system --test_output=streamed
+    else
+        echo "Error: Invalid target '{{ target }}'"
+        echo "Usage: just test [icp|icrc1]"
+        exit 1
+    fi


### PR DESCRIPTION
Uses `just` to simplify running tests in one's dev environment. There are a number of test targets that are cumbersome to invoke all at once.

Now, one can run `just test icp` or `just test icrc1` to run those.