### PR TITLE
test(ICRC_Ledger): FI-1821: Handle SNS ledgers without ICRC-106 support in golden state test

### DIFF
--- a/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
+++ b/rs/ledger_suite/icrc1/tests/golden_state_upgrade_downgrade.rs
@@ -3,6 +3,7 @@ use crate::index::verify_ledger_archive_and_index_block_parity;
 use candid::{Decode, Encode, Nat, Principal};
 use canister_test::Wasm;
 use ic_base_types::{CanisterId, PrincipalId};
+use ic_icrc1::endpoints::StandardRecord;
 use ic_icrc1::Block;
 use ic_icrc1_index_ng::{IndexArg, UpgradeArg as IndexUpgradeArg};
 use ic_ledger_suite_state_machine_tests::in_memory_ledger::{
@@ -138,6 +139,12 @@ impl Wasms {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Icrc106CheckError {
+    IndexPrincipalNotSet,
+    NotSupported,
+}
+
 struct LedgerSuiteConfig {
     ledger_id: &'static str,
     index_id: &'static str,
@@ -206,6 +213,10 @@ impl LedgerSuiteConfig {
                 AllowancesRecentlyPurged::No,
             ));
         }
+        // Check if the ledger supports ICRC-106, and if so, if the index principal is set.
+        let index_principal_set = self
+            .check_index_principal(state_machine, ledger_canister_id, index_canister_id)
+            .is_ok();
         // Upgrade to the new canister versions
         self.upgrade_to_master(state_machine);
         if self.extended_testing {
@@ -219,7 +230,15 @@ impl LedgerSuiteConfig {
             ));
         }
         // Verify that the index principal was set in the ledger
-        self.check_index_principal(state_machine, ledger_canister_id, index_canister_id);
+        if index_principal_set {
+            let index_principal_check =
+                self.check_index_principal(state_machine, ledger_canister_id, index_canister_id);
+            assert!(
+                index_principal_check.is_ok(),
+                "ICRC-106 index principal was set before upgrading the ledger to master, but now it is no longer set: {:?}",
+                index_principal_check
+            );
+        }
         // Downgrade back to the mainnet canister versions
         self.downgrade_to_mainnet(state_machine);
         if self.extended_testing {
@@ -239,7 +258,30 @@ impl LedgerSuiteConfig {
         env: &StateMachine,
         ledger_canister_id: CanisterId,
         index_canister_id: CanisterId,
-    ) {
+    ) -> Result<(), Icrc106CheckError> {
+        // Check if the ledger supports ICRC-106
+        let supported_standards = Decode!(
+            &env.query(
+                ledger_canister_id,
+                "icrc1_supported_standards",
+                Encode!().unwrap()
+            )
+            .expect("failed to query supported standards")
+            .bytes(),
+            Vec<StandardRecord>
+        )
+        .expect("failed to decode icrc1_supported_standards response");
+        let mut found = false;
+        for standard in supported_standards {
+            if standard.name == "ICRC-106" {
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return Err(Icrc106CheckError::NotSupported);
+        }
+        // If the ledger supports ICRC-106, check if the index principal is set
         match Decode!(
             &env.query(ledger_canister_id, "icrc106_get_index_principal", Encode!().unwrap())
                 .expect("failed to query icrc106_get_index_principal")
@@ -253,13 +295,15 @@ impl LedgerSuiteConfig {
                     index_principal,
                     index_canister_id.get().0,
                     "Index principal does not match index canister id"
-                )
+                );
+                Ok(())
             }
             Err(err) => {
-                panic!(
+                println!(
                     "Failed to get index principal for ledger {}: {:?}",
                     ledger_canister_id, err
                 );
+                Err(Icrc106CheckError::IndexPrincipalNotSet)
             }
         }
     }


### PR DESCRIPTION
Handle SNS ledgers without ICRC-106 support in the golden state test. After upgrading the ledger to the master version, only expect the index principal to be set if it was already set before the upgrade.