### PR TITLE
fix: use correct container options for rosetta

### DIFF
--- a/.github/workflows/rosetta-release.yml
+++ b/.github/workflows/rosetta-release.yml
@@ -23,6 +23,8 @@ jobs:
       labels: dind-large
     container:
       image: ghcr.io/dfinity/ic-build@sha256:40399f5c94cfc35201bc26e30fa7dded1b839f13773840819fd6c314ca2cf840
+      options: >-
+        -e NODE_NAME --privileged --cgroupns host
     environment: DockerHub
     steps:
       - name: Checkout


### PR DESCRIPTION
This sets the container options required by podman in the `Rosetta Release` workflow. Without these options, our podman wrapper will fail to start.