### PR TITLE
chore(EXC-2099): Remove memory barrier flag

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -124,8 +124,6 @@ pub struct FeatureFlags {
     /// If this flag is enabled, then the output of the `debug_print` system-api
     /// call will be skipped based on heuristics.
     pub rate_limiting_of_debug_prints: FlagStatus,
-    /// Track dirty pages with a write barrier instead of the signal handler.
-    pub write_barrier: FlagStatus,
     /// Indicates whether the support for 64 bit main memory is enabled
     pub wasm64: FlagStatus,
     /// Collect a backtrace from the canister when it panics.
@@ -138,7 +136,6 @@ impl FeatureFlags {
     const fn const_default() -> Self {
         Self {
             rate_limiting_of_debug_prints: FlagStatus::Enabled,
-            write_barrier: FlagStatus::Disabled,
             wasm64: FlagStatus::Enabled,
             canister_backtrace: FlagStatus::Enabled,
             environment_variables: FlagStatus::Disabled,

--- a/rs/embedders/fuzz/src/ic_wasm.rs
+++ b/rs/embedders/fuzz/src/ic_wasm.rs
@@ -284,7 +284,6 @@ pub fn ic_wasm_config(embedder_config: EmbeddersConfig) -> Config {
 
 pub fn ic_embedders_config(memory64_enabled: bool) -> EmbeddersConfig {
     let mut config = EmbeddersConfig::default();
-    config.feature_flags.write_barrier = FlagStatus::Enabled;
     if memory64_enabled {
         config.feature_flags.wasm64 = FlagStatus::Enabled;
     } else {

--- a/rs/embedders/src/wasm_utils.rs
+++ b/rs/embedders/src/wasm_utils.rs
@@ -217,7 +217,6 @@ fn validate_and_instrument(
     let instrumentation_output = instrument(
         module,
         config.cost_to_compile_wasm_instruction,
-        config.feature_flags.write_barrier,
         config.metering_type,
         config.dirty_page_overhead,
         max_wasm_memory_size,

--- a/rs/embedders/src/wasmtime_embedder.rs
+++ b/rs/embedders/src/wasmtime_embedder.rs
@@ -61,7 +61,6 @@ mod tests;
 
 const BAD_SIGNATURE_MESSAGE: &str = "function invocation does not match its signature";
 pub(crate) const WASM_HEAP_MEMORY_NAME: &str = "memory";
-pub(crate) const WASM_HEAP_BYTEMAP_MEMORY_NAME: &str = "bytemap_memory";
 pub(crate) const STABLE_MEMORY_NAME: &str = "stable_memory";
 pub(crate) const STABLE_BYTEMAP_MEMORY_NAME: &str = "stable_bytemap_memory";
 
@@ -358,23 +357,14 @@ impl WasmtimeEmbedder {
         heap_memory: &execution_state::Memory,
         stable_memory: &execution_state::Memory,
     ) -> Vec<WasmMemoryInfo> {
-        let dirty_page_tracking = match (
-            modification_tracking,
-            self.config.feature_flags.write_barrier,
-        ) {
-            (ModificationTracking::Ignore, _) | (_, FlagStatus::Enabled) => {
-                DirtyPageTracking::Ignore
-            }
-            (ModificationTracking::Track, FlagStatus::Disabled) => DirtyPageTracking::Track,
+        let dirty_page_tracking = match modification_tracking {
+            ModificationTracking::Ignore => DirtyPageTracking::Ignore,
+            ModificationTracking::Track => DirtyPageTracking::Track,
         };
 
         let mut result = vec![WasmMemoryInfo {
             name: WASM_HEAP_MEMORY_NAME,
-            bytemap_name: if self.config.feature_flags.write_barrier == FlagStatus::Enabled {
-                Some(WASM_HEAP_BYTEMAP_MEMORY_NAME)
-            } else {
-                None
-            },
+            bytemap_name: None,
             memory: heap_memory.clone(),
             memory_type: CanisterMemoryType::Heap,
             dirty_page_tracking,
@@ -570,7 +560,6 @@ impl WasmtimeEmbedder {
             log: self.log.clone(),
             instance_stats: InstanceStats::default(),
             store,
-            write_barrier: self.config.feature_flags.write_barrier,
             canister_backtrace: self.config.feature_flags.canister_backtrace,
             modification_tracking,
             dirty_page_overhead,
@@ -826,7 +815,6 @@ pub struct WasmtimeInstance {
     log: ReplicaLogger,
     instance_stats: InstanceStats,
     store: wasmtime::Store<StoreData>,
-    write_barrier: FlagStatus,
     #[allow(unused)]
     canister_backtrace: FlagStatus,
     modification_tracking: ModificationTracking,
@@ -866,7 +854,7 @@ impl WasmtimeInstance {
     }
 
     fn page_accesses(&mut self) -> HypervisorResult<PageAccessResults> {
-        let stable_dirty_pages = self.dirty_pages_from_bytemap(CanisterMemoryType::Stable)?;
+        let stable_dirty_pages = self.stable_dirty_pages_from_bytemap()?;
 
         // Get stable accessed pages from the global counter.
         let stable_accessed_pages = (self.stable_memory_page_access_limit.get() as i64
@@ -890,26 +878,21 @@ impl WasmtimeInstance {
             })
         } else {
             let wasm_dirty_pages = match self.modification_tracking {
-                ModificationTracking::Track => match self.write_barrier {
-                    FlagStatus::Enabled => {
-                        self.dirty_pages_from_bytemap(CanisterMemoryType::Heap)?
-                    }
-                    FlagStatus::Disabled => {
-                        let tracker = self
-                            .memory_trackers
-                            .get(&CanisterMemoryType::Heap)
-                            .unwrap()
-                            .lock()
-                            .unwrap();
-                        let speculatively_dirty_pages = tracker.take_speculatively_dirty_pages();
-                        let dirty_pages = tracker.take_dirty_pages();
-                        dirty_pages
-                            .into_iter()
-                            .chain(speculatively_dirty_pages)
-                            .filter_map(|p| tracker.validate_speculatively_dirty_page(p))
-                            .collect::<Vec<PageIndex>>()
-                    }
-                },
+                ModificationTracking::Track => {
+                    let tracker = self
+                        .memory_trackers
+                        .get(&CanisterMemoryType::Heap)
+                        .unwrap()
+                        .lock()
+                        .unwrap();
+                    let speculatively_dirty_pages = tracker.take_speculatively_dirty_pages();
+                    let dirty_pages = tracker.take_dirty_pages();
+                    dirty_pages
+                        .into_iter()
+                        .chain(speculatively_dirty_pages)
+                        .filter_map(|p| tracker.validate_speculatively_dirty_page(p))
+                        .collect::<Vec<PageIndex>>()
+                }
                 ModificationTracking::Ignore => {
                     vec![]
                 }
@@ -1122,22 +1105,18 @@ impl WasmtimeInstance {
         }
     }
 
-    fn dirty_pages_from_bytemap(
-        &mut self,
-        memory_type: CanisterMemoryType,
-    ) -> HypervisorResult<Vec<PageIndex>> {
-        let (memory_name, bytemap_name) = match memory_type {
-            CanisterMemoryType::Heap => (WASM_HEAP_MEMORY_NAME, WASM_HEAP_BYTEMAP_MEMORY_NAME),
-            CanisterMemoryType::Stable => (STABLE_MEMORY_NAME, STABLE_BYTEMAP_MEMORY_NAME),
-        };
+    fn stable_dirty_pages_from_bytemap(&mut self) -> HypervisorResult<Vec<PageIndex>> {
         let mut result = vec![];
-        if let Ok(heap_memory) = self.get_memory(memory_name) {
-            let bytemap = self.get_memory(bytemap_name)?.data(&self.store);
-            let tracker = self.memory_trackers.get(&memory_type).ok_or_else(|| {
-                HypervisorError::ToolchainContractViolation {
-                    error: format!("No {} memory tracker", memory_type),
-                }
-            })?;
+        if let Ok(heap_memory) = self.get_memory(STABLE_MEMORY_NAME) {
+            let bytemap = self
+                .get_memory(STABLE_BYTEMAP_MEMORY_NAME)?
+                .data(&self.store);
+            let tracker = self
+                .memory_trackers
+                .get(&CanisterMemoryType::Stable)
+                .ok_or_else(|| HypervisorError::ToolchainContractViolation {
+                    error: "No memory tracker for stable memory".to_string(),
+                })?;
             let tracker = tracker.lock().unwrap();
             let page_map = tracker.page_map();
             let accessed_pages = tracker.accessed_pages().borrow();

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -613,29 +613,18 @@ mod tests {
                     // Add the target pages.
                     for Write { dst, bytes } in writes {
                         if !bytes.is_empty() {
-                            if embedder.config().feature_flags.write_barrier == FlagStatus::Disabled
-                            {
-                                // A page will not actually be considered dirty
-                                // unless the contents has changed. Memory is
-                                // initially all 0, so this means we should ignore
-                                // all zero bytes.
-                                result.extend(
-                                    bytes
-                                        .iter()
-                                        .enumerate()
-                                        .filter(|(_, b)| **b != 0)
-                                        .map(|(addr, _)| {
-                                            (*dst as u64 + addr as u64) / PAGE_SIZE as u64
-                                        })
-                                        .collect::<BTreeSet<_>>(),
-                                );
-                            } else {
-                                result.extend(
-                                    *dst as u64 / PAGE_SIZE as u64
-                                        ..=(*dst as u64 + bytes.len() as u64 - 1)
-                                            / PAGE_SIZE as u64,
-                                );
-                            }
+                            // A page will not actually be considered dirty
+                            // unless the contents has changed. Memory is
+                            // initially all 0, so this means we should ignore
+                            // all zero bytes.
+                            result.extend(
+                                bytes
+                                    .iter()
+                                    .enumerate()
+                                    .filter(|(_, b)| **b != 0)
+                                    .map(|(addr, _)| (*dst as u64 + addr as u64) / PAGE_SIZE as u64)
+                                    .collect::<BTreeSet<_>>(),
+                            );
                         }
                     }
                     result.iter().cloned().collect()

--- a/rs/pocket_ic_server/src/nonmainnet_features.rs
+++ b/rs/pocket_ic_server/src/nonmainnet_features.rs
@@ -17,7 +17,6 @@ pub fn hypervisor_config(canister_sandboxing: bool) -> HypervisorConfig {
                 wasm64: FlagStatus::Enabled,
                 canister_backtrace: FlagStatus::Enabled,
                 environment_variables: FlagStatus::Enabled,
-                ..FeatureFlags::default()
             },
             ..EmbeddersConfig::default()
         },


### PR DESCRIPTION
EXC-2099

We're not using this flag and if we want to try enabling it later, it's probably better to go with at new implementation based off of https://github.com/dfinity/ic/pull/5811.