### PR TITLE
chore: Tidy up icos defs

### DIFF
--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -409,7 +409,8 @@ write_info_file_var = rule(
 def file_size_check(
         name,
         file,
-        max_file_size):
+        max_file_size,
+        tags = []):
     """
     A check to make sure the given file is below the specified size.
 
@@ -417,6 +418,7 @@ def file_size_check(
       name: Name of the test.
       file: File to check (label).
       max_file_size: Max accepted size in bytes.
+      tags: See Bazel documentation
     """
 
     native.sh_test(
@@ -427,4 +429,5 @@ def file_size_check(
             "FILE": "$(rootpath %s)" % file,
             "MAX_SIZE": str(max_file_size),
         },
+        tags = tags,
     )

--- a/ic-os/BUILD.bazel
+++ b/ic-os/BUILD.bazel
@@ -10,5 +10,6 @@ exports_files([
 py_console_script_binary(
     name = "sev-snp-measure",
     pkg = "@python_deps//sev_snp_measure",
+    tags = ["manual"],
     visibility = ["//ic-os:__subpackages__"],
 )

--- a/ic-os/components/BUILD.bazel
+++ b/ic-os/components/BUILD.bazel
@@ -28,6 +28,7 @@ exports_files(
 
 write_info_file_var(
     name = "commit_timestamp_txt",
+    tags = ["manual"],
     varname = "STABLE_COMMIT_TIMESTAMP",
 )
 

--- a/ic-os/components/ovmf/BUILD.bazel
+++ b/ic-os/components/ovmf/BUILD.bazel
@@ -34,5 +34,6 @@ genrule(
 
         mv Build/AmdSev/RELEASE_CLANGDWARF/FV/OVMF.fd "$$out"
     """,
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
 )

--- a/ic-os/defs.bzl
+++ b/ic-os/defs.bzl
@@ -285,6 +285,7 @@ def icos_build(
                 srcs = ["//ic-os/components/ovmf:ovmf_sev", boot_args, ":extracted_initrd.img", ":extracted_vmlinuz"],
                 visibility = visibility,
                 tools = ["//ic-os:sev-snp-measure"],
+                tags = ["manual"],
                 cmd = r"""
                     source $(execpath """ + boot_args + """)
                     # Create GuestLaunchMeasurements JSON
@@ -311,11 +312,13 @@ def icos_build(
     native.alias(
         name = "boot_args_template",
         actual = image_deps["boot_args_template"],
+        tags = ["manual"],
     )
 
     native.alias(
         name = "extra_boot_args_template",
         actual = image_deps["extra_boot_args_template"],
+        tags = ["manual"],
     )
 
     # -------------------- Assemble disk partitions ---------------

--- a/ic-os/dev-tools/bare_metal_deployment/BUILD.bazel
+++ b/ic-os/dev-tools/bare_metal_deployment/BUILD.bazel
@@ -11,5 +11,6 @@ exports_files([
 whl_filegroup(
     name = "redfish_scripts",
     pattern = ".*/scripts/.*",
+    tags = ["manual"],
     whl = "@python_deps//idracredfishsupport:whl",
 )

--- a/ic-os/guestos/envs/dev-malicious/BUILD.bazel
+++ b/ic-os/guestos/envs/dev-malicious/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//bazel:defs.bzl", "file_size_check")
 load("//ic-os:defs.bzl", "icos_build")
 load("//ic-os/guestos:defs.bzl", "image_deps")
 
@@ -15,22 +14,4 @@ icos_images = icos_build(
         "//rs:ic-os-pkg",
         "//rs:system-tests-pkg",
     ],
-)
-
-file_size_check(
-    name = "disk_img_size_check",
-    file = icos_images.disk_image,
-    max_file_size = 600 * 1000 * 1000,  # 584 MB on 2025-06-26
-)
-
-file_size_check(
-    name = "update_img_size_check",
-    file = icos_images.update_image,
-    max_file_size = 600 * 1000 * 1000,  # 583 MB on 2025-06-26
-)
-
-file_size_check(
-    name = "update_img_test_size_check",
-    file = icos_images.update_image_test,
-    max_file_size = 600 * 1000 * 1000,  # 583 MB on 2025-06-26
 )

--- a/ic-os/guestos/envs/recovery-dev/BUILD.bazel
+++ b/ic-os/guestos/envs/recovery-dev/BUILD.bazel
@@ -24,18 +24,30 @@ file_size_check(
     name = "disk_img_size_check",
     file = icos_images.disk_image,
     max_file_size = 600 * 1000 * 1000,  # 580 MB on 2025-06-26
+    tags = [
+        "manual",
+        "no-cache",
+    ],
 )
 
 file_size_check(
     name = "update_img_size_check",
     file = icos_images.update_image,
     max_file_size = 600 * 1000 * 1000,  # 578 MB on 2025-06-26
+    tags = [
+        "manual",
+        "no-cache",
+    ],
 )
 
 file_size_check(
     name = "update_img_test_size_check",
     file = icos_images.update_image_test,
     max_file_size = 600 * 1000 * 1000,  # 578 MB on 2025-06-26
+    tags = [
+        "manual",
+        "no-cache",
+    ],
 )
 
 generate_dummy_recovery_archive(

--- a/ic-os/guestos/envs/recovery-dev/defs.bzl
+++ b/ic-os/guestos/envs/recovery-dev/defs.bzl
@@ -67,4 +67,5 @@ def generate_dummy_recovery_archive(name):
         visibility = [
             "//rs:system-tests-pkg",
         ],
+        tags = ["manual"],
     )

--- a/ic-os/guestos/envs/recovery/BUILD.bazel
+++ b/ic-os/guestos/envs/recovery/BUILD.bazel
@@ -23,18 +23,30 @@ file_size_check(
     name = "disk_img_size_check",
     file = icos_images.disk_image,
     max_file_size = 450 * 1000 * 1000,  # 419 MB on 2025-06-26
+    tags = [
+        "manual",
+        "no-cache",
+    ],
 )
 
 file_size_check(
     name = "update_img_size_check",
     file = icos_images.update_image,
     max_file_size = 450 * 1000 * 1000,  # 417 MB on 2025-06-26
+    tags = [
+        "manual",
+        "no-cache",
+    ],
 )
 
 file_size_check(
     name = "update_img_test_size_check",
     file = icos_images.update_image_test,
     max_file_size = 450 * 1000 * 1000,  # 417 MB on 2025-06-26
+    tags = [
+        "manual",
+        "no-cache",
+    ],
 )
 
 artifact_bundle(


### PR DESCRIPTION
This reduces the targets when building `//ic-os/...` to:
```
//ic-os:_sev-snp-measure_gen # Can't seem to get rid of this one
//ic-os/components:check_unused_components_test
//ic-os/components:validate-ic-json5
//ic-os/components/setupos-scripts:test-kernel-cmdline-function
//ic-os/components/setupos-scripts:test_setupos
//ic-os/guestos/envs/dev:bundle-disk
//ic-os/guestos/envs/dev:bundle-update
//ic-os/guestos/envs/dev:disk_img_size_check
//ic-os/guestos/envs/dev:update_img_size_check
//ic-os/guestos/envs/dev:update_img_test_size_check
//ic-os/guestos/envs/prod:bundle-update
//ic-os/guestos/envs/prod:disk_img_size_check
//ic-os/guestos/envs/prod:update_img_size_check
//ic-os/guestos/envs/prod:update_img_test_size_check
//ic-os/hostos/envs/dev:bundle-update
//ic-os/hostos/envs/prod:bundle-update
//ic-os/hostos/envs/prod:disk_img_size_check
//ic-os/hostos/envs/prod:update_img_size_check
//ic-os/setupos/envs/dev:bundle
//ic-os/setupos/envs/prod:bundle
//ic-os/setupos/envs/prod:disk_img_size_check
//ic-os/tests:integration_tests
```