### PR TITLE
chore: add tip how to find matching files to PULL_REQUEST_BAZEL_TARGETS

### DIFF
--- a/PULL_REQUEST_BAZEL_TARGETS
+++ b/PULL_REQUEST_BAZEL_TARGETS
@@ -36,7 +36,7 @@
 #   like gitignore wildmatch patterns.
 #
 # Tip: to test which files matches <PATTERN> you can use the following:
-# find . | python -c 'import sys, fnmatch; print("\n".join(fnmatch.filter(sys.stdin.read().splitlines(),"<PATTERN>")))'
+# git ls-files | python -c 'import sys, fnmatch; print("\n".join(fnmatch.filter(sys.stdin.read().splitlines(),"<PATTERN>")))'
 
 
 *.sh        //pre-commit:shfmt-check

--- a/PULL_REQUEST_BAZEL_TARGETS
+++ b/PULL_REQUEST_BAZEL_TARGETS
@@ -35,7 +35,7 @@
 #   So there's no negation of patterns or special directory handling
 #   like gitignore wildmatch patterns.
 #
-# Tip: to test which files <PATTERN> matches you can use the following:
+# Tip: to test which files matches <PATTERN> you can use the following:
 # find . | python -c 'import sys, fnmatch; print("\n".join(fnmatch.filter(sys.stdin.read().splitlines(),"<PATTERN>")))'
 
 

--- a/PULL_REQUEST_BAZEL_TARGETS
+++ b/PULL_REQUEST_BAZEL_TARGETS
@@ -34,6 +34,10 @@
 #   https://docs.python.org/3/library/fnmatch.html
 #   So there's no negation of patterns or special directory handling
 #   like gitignore wildmatch patterns.
+#
+# Tip: to test which files <PATTERN> matches you can use the following:
+# find . | python -c 'import sys, fnmatch; print("\n".join(fnmatch.filter(sys.stdin.read().splitlines(),"<PATTERN>")))'
+
 
 *.sh        //pre-commit:shfmt-check
 *.py        //pre-commit:ruff-lint


### PR DESCRIPTION
This adds a tip on how to get a list of files matching `<PATTERN>` to the `PULL_REQUEST_BAZEL_TARGETS` file. 
It uses the same logic as the `ci/bazel-scripts/targets.py` script.