### PR TITLE
fix(ckbtc): fix a bug in replace transaction

### DIFF
--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -744,9 +744,9 @@ async fn finalize_requests<R: CanisterRuntime>(runtime: &R, force_resubmit: bool
         state::read_state(|s| s.retrieve_btc_min_amount),
         maybe_finalized_transactions,
         |outpoint| state::read_state(|s| s.outpoint_account.get(outpoint).cloned()),
-        |old_txid, new_tx| {
+        |old_txid, new_tx, reason| {
             state::mutate_state(|s| {
-                state::audit::replace_transaction(s, old_txid, new_tx, runtime);
+                state::audit::replace_transaction(s, old_txid, new_tx, Some(reason), runtime);
             })
         },
         &IC_CANISTER_RUNTIME,
@@ -757,7 +757,7 @@ async fn finalize_requests<R: CanisterRuntime>(runtime: &R, force_resubmit: bool
 pub async fn resubmit_transactions<
     R: CanisterRuntime,
     F: Fn(&OutPoint) -> Option<Account>,
-    G: Fn(Txid, state::SubmittedBtcTransaction),
+    G: Fn(Txid, state::SubmittedBtcTransaction, state::eventlog::ReplacedReason),
 >(
     key_name: &str,
     fee_per_vbyte: u64,
@@ -791,6 +791,7 @@ pub async fn resubmit_transactions<
         };
 
         let mut input_utxos = submitted_tx.used_utxos;
+        let mut replaced_reason = state::eventlog::ReplacedReason::ToRetry;
         let mut new_tx_requests = submitted_tx.requests;
         let build_result = match build_unsigned_transaction_from_inputs(
             &input_utxos,
@@ -819,6 +820,10 @@ pub async fn resubmit_transactions<
                     }
                 };
                 let reason = reimbursement::WithdrawalReimbursementReason::InvalidTransaction(err);
+                replaced_reason = state::eventlog::ReplacedReason::ToCancel {
+                    reason: reason.clone(),
+                    used_utxos: None,
+                };
                 new_tx_requests = state::SubmittedWithdrawalRequests::ToCancel { requests, reason };
                 let outputs = vec![(main_address.clone(), retrieve_btc_min_amount)];
                 build_unsigned_transaction_from_inputs(
@@ -887,6 +892,12 @@ pub async fn resubmit_transactions<
                     &old_txid,
                     hex::encode(tx::encode_into(&signed_tx, Vec::new()))
                 );
+                match &mut replaced_reason {
+                    state::eventlog::ReplacedReason::ToCancel { used_utxos, .. } => {
+                        *used_utxos = Some(input_utxos.clone())
+                    }
+                    state::eventlog::ReplacedReason::ToRetry => {}
+                }
                 let new_tx = state::SubmittedBtcTransaction {
                     requests: new_tx_requests,
                     used_utxos: input_utxos,
@@ -896,8 +907,7 @@ pub async fn resubmit_transactions<
                     fee_per_vbyte: Some(tx_fee_per_vbyte),
                     withdrawal_fee: Some(total_fee),
                 };
-
-                replace_transaction(old_txid, new_tx);
+                replace_transaction(old_txid, new_tx, replaced_reason);
             }
             Err(err) => {
                 log!(P0, "[finalize_requests]: failed to send transaction bytes {} to replace stuck transaction {}: {}",

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -2,7 +2,7 @@ use crate::address::BitcoinAddress;
 use crate::logs::{P0, P1};
 use crate::management::CallError;
 use crate::queries::WithdrawalFee;
-use crate::reimbursement::InvalidTransactionError;
+use crate::reimbursement::{InvalidTransactionError, WithdrawalReimbursementReason};
 use crate::updates::update_balance::UpdateBalanceError;
 use async_trait::async_trait;
 use candid::{CandidType, Deserialize, Principal};
@@ -293,7 +293,7 @@ pub async fn estimate_fee_per_vbyte() -> Option<MillisatoshiPerByte> {
 fn reimburse_canceled_requests<R: CanisterRuntime>(
     state: &mut state::CkBtcMinterState,
     requests: BTreeSet<state::RetrieveBtcRequest>,
-    err: InvalidTransactionError,
+    reason: WithdrawalReimbursementReason,
     total_fee: u64,
     runtime: &R,
 ) {
@@ -305,8 +305,6 @@ fn reimburse_canceled_requests<R: CanisterRuntime>(
         if let Some(account) = request.reimbursement_account {
             let amount = request.amount.saturating_sub(fee);
             if amount > 0 {
-                let reason =
-                    reimbursement::WithdrawalReimbursementReason::InvalidTransaction(err.clone());
                 state::audit::reimburse_withdrawal(
                     state,
                     request.block_index,
@@ -408,7 +406,8 @@ async fn submit_pending_requests<R: CanisterRuntime>(runtime: &R) {
                 // Since the transaction otherwise would have more than MAX_NUM_INPUTS, it
                 // is reasonable to charge a fee based on it.
                 let fee = MINTER_FEE_PER_INPUT * MAX_NUM_INPUTS_IN_TRANSACTION as u64;
-                reimburse_canceled_requests(s, batch, err, fee, runtime);
+                let reason = reimbursement::WithdrawalReimbursementReason::InvalidTransaction(err);
+                reimburse_canceled_requests(s, batch, reason, fee, runtime);
                 None
             }
             Err(BuildTxError::AmountTooLow) => {
@@ -819,10 +818,8 @@ pub async fn resubmit_transactions<
                         unreachable!("cancellation tx never has too many inputs!")
                     }
                 };
-                new_tx_requests = state::SubmittedWithdrawalRequests::ToCancel {
-                    requests,
-                    reason: err,
-                };
+                let reason = reimbursement::WithdrawalReimbursementReason::InvalidTransaction(err);
+                new_tx_requests = state::SubmittedWithdrawalRequests::ToCancel { requests, reason };
                 let outputs = vec![(main_address.clone(), retrieve_btc_min_amount)];
                 build_unsigned_transaction_from_inputs(
                     &input_utxos,

--- a/rs/bitcoin/ckbtc/minter/src/state.rs
+++ b/rs/bitcoin/ckbtc/minter/src/state.rs
@@ -91,7 +91,7 @@ pub enum SubmittedWithdrawalRequests {
     },
     ToCancel {
         requests: BTreeSet<RetrieveBtcRequest>,
-        reason: InvalidTransactionError,
+        reason: WithdrawalReimbursementReason,
     },
 }
 
@@ -493,7 +493,7 @@ pub enum ReimbursementReason {
 
 pub struct WithdrawalCancellation {
     pub fee: u64,
-    pub reason: InvalidTransactionError,
+    pub reason: WithdrawalReimbursementReason,
     pub requests: BTreeSet<RetrieveBtcRequest>,
 }
 

--- a/rs/bitcoin/ckbtc/minter/src/state/audit.rs
+++ b/rs/bitcoin/ckbtc/minter/src/state/audit.rs
@@ -1,8 +1,9 @@
 //! State modifications that should end up in the event log.
 
 use super::{
-    eventlog::EventType, CkBtcMinterState, FinalizedBtcRetrieval, FinalizedStatus, LedgerBurnIndex,
-    RetrieveBtcRequest, SubmittedBtcTransaction, SuspendedReason, WithdrawalCancellation,
+    eventlog::{EventType, ReplacedReason},
+    CkBtcMinterState, FinalizedBtcRetrieval, FinalizedStatus, LedgerBurnIndex, RetrieveBtcRequest,
+    SubmittedBtcTransaction, SuspendedReason, WithdrawalCancellation,
 };
 use crate::reimbursement::{ReimburseWithdrawalTask, WithdrawalReimbursementReason};
 use crate::state::invariants::CheckInvariantsImpl;
@@ -194,6 +195,7 @@ pub fn replace_transaction<R: CanisterRuntime>(
     state: &mut CkBtcMinterState,
     old_txid: Txid,
     new_tx: SubmittedBtcTransaction,
+    reason: Option<ReplacedReason>,
     runtime: &R,
 ) {
     record_event(
@@ -209,6 +211,7 @@ pub fn replace_transaction<R: CanisterRuntime>(
                 .fee_per_vbyte
                 .expect("bug: all replacement transactions must have the fee"),
             withdrawal_fee: new_tx.withdrawal_fee,
+            reason,
         },
         runtime,
     );

--- a/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
@@ -253,7 +253,7 @@ async fn should_not_resubmit_tx_87ebf46e400a39e5ec22b28515056a3ce55187dba9669de8
                 subaccount: None,
             })
         },
-        |old_txid, new_tx| replaced.borrow_mut().push((old_txid, new_tx)),
+        |old_txid, new_tx, reason| replaced.borrow_mut().push((old_txid, new_tx, reason)),
         &runtime,
     )
     .await;
@@ -261,6 +261,7 @@ async fn should_not_resubmit_tx_87ebf46e400a39e5ec22b28515056a3ce55187dba9669de8
     assert_eq!(replaced.len(), 1);
     assert_eq!(replaced[0].0, resubmitted_txid);
     let cancellation_tx = replaced[0].1.clone();
+    let replaced_reason = replaced[0].2.clone();
     let cancellation_txid = cancellation_tx.txid;
     assert_eq!(cancellation_tx.used_utxos.len(), 1);
     let used_utxo = cancellation_tx.used_utxos[0].clone();
@@ -275,6 +276,7 @@ async fn should_not_resubmit_tx_87ebf46e400a39e5ec22b28515056a3ce55187dba9669de8
         &mut state,
         resubmitted_txid,
         cancellation_tx.clone(),
+        Some(replaced_reason),
         &runtime,
     );
     assert!(!state


### PR DESCRIPTION
When replaying events, the handling of `ReplacedBtcTransaction` didn't produce cancellation transaction correctly.
This PR fixes the problem.