### PR TITLE
fix: git diff in ci/bazel-scripts/targets.py

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -207,7 +207,7 @@ jobs:
               targets_args+=("--skip_long_tests")
             fi
             if [[ "$DIFF_ONLY" == 'true' ]]; then
-              targets_args+=("--commit_range=$BASE_SHA..$HEAD_SHA")
+              targets_args+=("--base=$BASE_SHA" "--head=$HEAD_SHA")
             fi
             "${CI_PROJECT_DIR:-}"/ci/bazel-scripts/targets.py test "${targets_args[@]}" >"$target_pattern_file"
             # if bazel targets is empty we don't need to run any tests
@@ -492,7 +492,7 @@ jobs:
             targets_args=()
             commit_range_arg=""
             if [[ "$DIFF_ONLY" == 'true' ]]; then
-              targets_args+=("--commit_range=$BASE_SHA..$HEAD_SHA")
+              targets_args+=("--base=$BASE_SHA" "--head=$HEAD_SHA")
             fi
             ci/bazel-scripts/targets.py build "${targets_args[@]}" >"$targets"
 


### PR DESCRIPTION
What?
===

The `git diff` calculation in `ci/bazel-scripts/targets.py` used to return more diffs than present in the PR. This commit fixes that.

Why?
===
I was monitoring how our new `ci/bazel-scripts/targets.py` calculates targets to test and noticed something off:

PR https://github.com/dfinity/ic/pull/6301 only modified `Cargo.lock` and files under `rs/sns/governance/`. However `ci/bazel-scripts/targets.py` calculated the following query to return which targets to test:

```
bazel query --keep_going '
  (
    ((kind(".*_test", //...)) except attr(tags, long_test, //...))
    + set(
        //rs/tests/nested:guestos_upgrade_from_latest_release_to_current
        //rs/tests/nested:guestos_upgrade_smoke_test
        //rs/tests/nested:hostos_upgrade_smoke_test
        //rs/tests/nested:hostos_upgrade_from_latest_release_to_current
        //rs/tests/nested:registration
        //pre-commit:shfmt-check
      )
  ) except attr(tags, manual, //...)'
```

The surprise here is that the `//rs/tests/nested` tests are being triggered! According to `PULL_REQUEST_BAZEL_TARGETS` these should only be triggered when files matching `*ic[-_]os/*` are modified but the PR didn't touch any of these files. So let's find out what's going wrong:

Commits of PR: https://github.com/dfinity/ic/pull/6301/commits.

Bazel-Test-All run: https://github.com/dfinity/ic/actions/runs/17001500639/job/48204004538

Notable commits:
```sh
FIRST_COMMIT_OF_PR='728f8860dc7df74140ad7d101dd3e1daf77607af'
BASE_SHA='f2dbef4b7727111d124091f22da70bb47be447b8'           # i.e. ${{ github.event.pull_request.base.sha }}
HEAD_SHA='d2fa44599f28a63dc0cf34010cac899ea208a7fd'           # i.e. ${{ github.event.pull_request.head.sha }}
CI_COMMIT_SHA='d186e8736e4aea873b0893c1450b739ca8b6bf5f'      # this is the commit GitHub runs the workflow on which is the merge of the PR with its base (master).
```

Let's fetch them and add some tags so they're easier to spot:

```sh
git fetch origin $FIRST_COMMIT_OF_PR $BASE_SHA $HEAD_SHA $CI_COMMIT_SHA
git tag FIRST_COMMIT_OF_PR $FIRST_COMMIT_OF_PR
git tag BASE_SHA $BASE_SHA
git tag HEAD_SHA $HEAD_SHA
git tag CI_COMMIT_SHA $CI_COMMIT_SHA
```

Let's visualise the commit graph we're dealing with:

```
git log --oneline --graph $FIRST_COMMIT_OF_PR~2..$CI_COMMIT_SHA
*   d186e8736e (tag: CI_COMMIT_SHA) Merge d2fa44599f28a63dc0cf34010cac899ea208a7fd into 696287e95fdc8cfcb8a206d96b79211d0a16d09e
|\
| * d2fa44599f (tag: HEAD_SHA) fix unused import
| * 422908f00e Fix
| * 86bb3b458e clippy
| * f02ed1bef8 Small refactor
| * 2794b2adc4 Remove unused function and unnecessary test.
| * 6081ff09f1 Automatically updated Cargo*.lock
| * 728f8860dc (tag: FIRST_COMMIT_OF_PR) Migrate to stable structures and memory manager
* | 696287e95f feat(sns): Add custom topics for ExecuteExtensionOperation proposals based on which operation is running (#6281)
* | c496404d96 feat(ckbtc): cancel invalid stuck transactions (#6271)
* | f2dbef4b77 (tag: BASE_SHA) fix: Make dependency on /tmp explicit (#6284)
* | fe4832372d chore(node): remove grub-upgrader component (#6298)
|/
* ddc55cb687 test: Run some MR long tests sometimes (#6292)
```

The commit range we pass to `ci/bazel-scripts/targets.py` (and used to pass to the former `ci/bazel-scripts/diff.sh` as well) to calculate the list of modified files is `$BASE_SHA..$HEAD_SHA`. So let's see what modified files we get:

```sh
git diff --name-only $BASE_SHA..$HEAD_SHA
Cargo.lock
ic-os/components/hostos-scripts/grub-upgrader/grub-upgrader.service  !!!
ic-os/components/hostos-scripts/grub-upgrader/grub-upgrader.sh       !!!
ic-os/components/hostos.bzl                                          !!!
ic-os/components/init/init-config/init-config.service                !!!
rs/sns/governance/BUILD.bazel
rs/sns/governance/Cargo.toml
rs/sns/governance/canister/canister.rs
rs/sns/governance/canister/tests.rs
```

There it is! `ic-os/` files are included! So why is that?

It happens to be `$BASE_SHA` and its parent that are changing those `ic-os/` files:

```
git show --oneline --name-only $BASE_SHA $BASE_SHA~
f2dbef4b77 (tag: BASE_SHA) fix: Make dependency on /tmp explicit (#6284)
ic-os/components/init/init-config/init-config.service
fe4832372d chore(node): remove grub-upgrader component (#6298)
ic-os/components/hostos-scripts/grub-upgrader/grub-upgrader.service
ic-os/components/hostos-scripts/grub-upgrader/grub-upgrader.sh
ic-os/components/hostos.bzl
```

So what's `$BASE_SHA` anyway?!? Well it's `${{ github.event.pull_request.base.sha }}` which not really documented on github.com but GPT-5 gives the answer and also hints at our bug:

> github.event.pull_request.base.sha is the tip commit SHA of the target (base) branch (e.g. master) at the moment the workflow‑triggering pull_request event was generated. It is NOT the merge base with the PR branch.

So why does `git diff --name-only $BASE_SHA..$HEAD_SHA` include those unexpected `ic-os/` changes?

I was first expecting the `..` in `$BASE_SHA..$HEAD_SHA` to denote a revision range:

```
$ man 7 gitrevisions
...
REVISION RANGE SUMMARY
       ...
       <rev1>..<rev2>
           Include commits that are reachable from <rev2> but exclude those that are reachable from <rev1>. ...

       <rev1>...<rev2>
           Include commits that are reachable from either <rev1> or <rev2> but exclude those that are reachable from both. ...
       ...
```

According to that semantics `$BASE_SHA..$HEAD_SHA` should not include `$BASE_SHA` and its parent. However in `git diff` `..` means something else (great UI git):

```
$ git diff --help
...
       git diff [<options>] [--merge-base] <commit> <commit> [--] [<path>...]
           This is to view the changes between two arbitrary <commit>.

           If --merge-base is given, use the merge base of the two commits for the "before" side.  git diff --merge-base A B is equivalent to git diff $(git merge-base A B) B.
       ...
       git diff [<options>] <commit>..<commit> [--] [<path>...]
           This is synonymous to the earlier form (without the ..) for viewing the changes between two arbitrary <commit>. ...

       git diff [<options>] <commit>...<commit> [--] [<path>...]
           This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  git diff A...B is
           equivalent to git diff $(git merge-base A B) B. You can omit any one of <commit>, which has the same effect as using HEAD instead.
```

Now it's clear: if you checkout `$HEAD_SHA` (i.e. the PR) in one directory and checkout `$BASE_SHA` in another and diff them the `ic-os/` changes indeed would show up because they were added by `$BASE_SHA` and its parent but were not present in `$HEAD_SHA`.

The solution was already hinted at by GPT-5 and mentioned in `git diff --help`: we should use:

```sh
git diff --name-only --merge-base $BASE_SHA $HEAD_SHA
Cargo.lock
rs/sns/governance/BUILD.bazel
rs/sns/governance/Cargo.toml
rs/sns/governance/canister/canister.rs
rs/sns/governance/canister/tests.rs
```

Note:

```sh
git merge-base $BASE_SHA $HEAD_SHA
ddc55cb68722aceea6093a144357fc8f429aacd9
```