### PR TITLE
feat(PocketIC): enable specifying initial time during PocketIC instance creation

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The function `start_server` and its input type `StartServerParams` to manually start a PocketIC server.
 - The function `PocketIcBuilder::with_all_icp_features` to specify that all ICP features (supported by PocketIC) should be enabled.
 - The function `PocketIc::upgrade_eop_canister` to upgrade a Motoko EOP canister.
+- The function `PocketIcBuilder::with_icp_features` to specify that selected ICP features (supported by PocketIC) should be enabled.
+- The function `PocketIcBuilder::with_initial_timestamp` to specify the initial timestamp of the newly created PocketIC instance.
+- The function `PocketIcBuilder::with_auto_progress` to specify that the new instance should make progress automatically,
+  i.e., PocketIC should periodically update the time of the instance to the real time and execute rounds on the subnets.
 
 
 

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -74,7 +74,7 @@ pub enum CreateInstanceResponse {
     },
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Copy, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct RawTime {
     pub nanos_since_epoch: u64,
 }
@@ -564,6 +564,18 @@ impl IcpFeatures {
     }
 }
 
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub enum InitialTime {
+    /// Sets the initial timestamp of the new instance to the provided value which must be at least
+    /// - 10 May 2021 10:00:01 AM CEST if the `cycles_minting` feature is enabled in `icp_features`;
+    /// - 06 May 2021 21:17:10 CEST otherwise.
+    Timestamp(RawTime),
+    /// Configures the new instance to make progress automatically,
+    /// i.e., periodically update the time of the IC instance
+    /// to the real time and execute rounds on the subnets.
+    AutoProgress(AutoProgressConfig),
+}
+
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
 pub struct InstanceConfig {
     pub subnet_config_set: ExtendedSubnetConfigSet,
@@ -573,6 +585,7 @@ pub struct InstanceConfig {
     pub bitcoind_addr: Option<Vec<SocketAddr>>,
     pub icp_features: Option<IcpFeatures>,
     pub allow_incomplete_state: Option<bool>,
+    pub initial_time: Option<InitialTime>,
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -55,9 +55,9 @@
 ///
 use crate::{
     common::rest::{
-        BlobCompression, BlobId, CanisterHttpRequest, ExtendedSubnetConfigSet, HttpsConfig,
-        IcpFeatures, InstanceId, MockCanisterHttpResponse, RawEffectivePrincipal, RawMessageId,
-        SubnetId, SubnetKind, SubnetSpec, Topology,
+        AutoProgressConfig, BlobCompression, BlobId, CanisterHttpRequest, ExtendedSubnetConfigSet,
+        HttpsConfig, IcpFeatures, InitialTime, InstanceId, MockCanisterHttpResponse,
+        RawEffectivePrincipal, RawMessageId, RawTime, SubnetId, SubnetKind, SubnetSpec, Topology,
     },
     nonblocking::PocketIc as PocketIcAsync,
 };
@@ -162,6 +162,7 @@ pub struct PocketIcBuilder {
     log_level: Option<Level>,
     bitcoind_addr: Option<Vec<SocketAddr>>,
     icp_features: IcpFeatures,
+    initial_time: Option<InitialTime>,
 }
 
 #[allow(clippy::new_without_default)]
@@ -178,6 +179,7 @@ impl PocketIcBuilder {
             log_level: None,
             bitcoind_addr: None,
             icp_features: IcpFeatures::default(),
+            initial_time: None,
         }
     }
 
@@ -199,6 +201,7 @@ impl PocketIcBuilder {
             self.log_level,
             self.bitcoind_addr,
             self.icp_features,
+            self.initial_time,
         )
     }
 
@@ -214,6 +217,7 @@ impl PocketIcBuilder {
             self.log_level,
             self.bitcoind_addr,
             self.icp_features,
+            self.initial_time,
         )
         .await
     }
@@ -414,6 +418,34 @@ impl PocketIcBuilder {
         self.icp_features = IcpFeatures::all_icp_features();
         self
     }
+
+    /// Enables selected ICP features supported by PocketIC and implemented by system canisters
+    /// (deployed to the PocketIC instance automatically when creating a new PocketIC instance).
+    pub fn with_icp_features(mut self, icp_features: IcpFeatures) -> Self {
+        self.icp_features = icp_features;
+        self
+    }
+
+    /// Sets the initial timestamp of the new instance to the provided value which must be at least
+    /// - 10 May 2021 10:00:01 AM CEST if the `cycles_minting` feature is enabled in `icp_features`;
+    /// - 06 May 2021 21:17:10 CEST otherwise.
+    pub fn with_initial_timestamp(mut self, initial_timestamp_nanos: u64) -> Self {
+        self.initial_time = Some(InitialTime::Timestamp(RawTime {
+            nanos_since_epoch: initial_timestamp_nanos,
+        }));
+        self
+    }
+
+    /// Configures the new instance to make progress automatically,
+    /// i.e., periodically update the time of the IC instance
+    /// to the real time and execute rounds on the subnets.
+    pub fn with_auto_progress(mut self, artificial_delay_ms: Option<u64>) -> Self {
+        let config = AutoProgressConfig {
+            artificial_delay_ms,
+        };
+        self.initial_time = Some(InitialTime::AutoProgress(config));
+        self
+    }
 }
 
 /// Representation of system time as duration since UNIX epoch
@@ -527,6 +559,7 @@ impl PocketIc {
         log_level: Option<Level>,
         bitcoind_addr: Option<Vec<SocketAddr>>,
         icp_features: IcpFeatures,
+        initial_time: Option<InitialTime>,
     ) -> Self {
         let (tx, rx) = channel();
         let thread = thread::spawn(move || {
@@ -550,6 +583,7 @@ impl PocketIc {
                 log_level,
                 bitcoind_addr,
                 icp_features,
+                initial_time,
             )
             .await
         });

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1,11 +1,11 @@
 use crate::common::rest::{
     ApiResponse, AutoProgressConfig, BlobCompression, BlobId, CanisterHttpRequest,
     CreateHttpGatewayResponse, CreateInstanceResponse, ExtendedSubnetConfigSet, HttpGatewayBackend,
-    HttpGatewayConfig, HttpGatewayInfo, HttpsConfig, IcpFeatures, InstanceConfig, InstanceId,
-    MockCanisterHttpResponse, RawAddCycles, RawCanisterCall, RawCanisterHttpRequest, RawCanisterId,
-    RawCanisterResult, RawCycles, RawEffectivePrincipal, RawIngressStatusArgs, RawMessageId,
-    RawMockCanisterHttpResponse, RawPrincipalId, RawSetStableMemory, RawStableMemory, RawSubnetId,
-    RawTime, RawVerifyCanisterSigArg, SubnetId, TickConfigs, Topology,
+    HttpGatewayConfig, HttpGatewayInfo, HttpsConfig, IcpFeatures, InitialTime, InstanceConfig,
+    InstanceId, MockCanisterHttpResponse, RawAddCycles, RawCanisterCall, RawCanisterHttpRequest,
+    RawCanisterId, RawCanisterResult, RawCycles, RawEffectivePrincipal, RawIngressStatusArgs,
+    RawMessageId, RawMockCanisterHttpResponse, RawPrincipalId, RawSetStableMemory, RawStableMemory,
+    RawSubnetId, RawTime, RawVerifyCanisterSigArg, SubnetId, TickConfigs, Topology,
 };
 #[cfg(windows)]
 use crate::wsl_path;
@@ -139,6 +139,7 @@ impl PocketIc {
         log_level: Option<Level>,
         bitcoind_addr: Option<Vec<SocketAddr>>,
         icp_features: IcpFeatures,
+        initial_time: Option<InitialTime>,
     ) -> Self {
         let server_url = if let Some(server_url) = server_url {
             server_url
@@ -205,6 +206,7 @@ impl PocketIc {
             bitcoind_addr,
             icp_features: Some(icp_features),
             allow_incomplete_state: Some(false),
+            initial_time,
         };
 
         let test_driver_pid = std::process::id();

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -957,6 +957,7 @@ async fn with_all_icp_features_and_nns_subnet_state() {
         bitcoind_addr: None,
         icp_features: Some(IcpFeatures::all_icp_features()),
         allow_incomplete_state: None,
+        initial_time: None,
     };
     let response = client
         .post(url.join("instances").unwrap())

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -12,8 +12,8 @@ use ic_transport_types::EnvelopeContent::{Call, ReadState};
 use pocket_ic::common::rest::{BlockmakerConfigs, RawSubnetBlockmaker, TickConfigs};
 use pocket_ic::{
     common::rest::{
-        BlobCompression, CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse,
-        RawEffectivePrincipal, RawMessageId, SubnetKind,
+        BlobCompression, CanisterHttpReply, CanisterHttpResponse, IcpFeatures,
+        MockCanisterHttpResponse, RawEffectivePrincipal, RawMessageId, SubnetKind,
     },
     query_candid, update_candid, DefaultEffectiveCanisterIdError, ErrorCode, IngressStatusResult,
     PocketIc, PocketIcBuilder, PocketIcState, RejectCode, Time,
@@ -381,6 +381,81 @@ fn test_multiple_large_xnet_payloads() {
     }
 }
 
+#[test]
+fn test_initial_timestamp() {
+    let initial_timestamp = 1_620_328_630_000_000_000; // 06 May 2021 21:17:10 CEST
+    let pic = PocketIcBuilder::new()
+        .with_application_subnet()
+        .with_initial_timestamp(initial_timestamp)
+        .build();
+
+    // Initial time is bumped by 1ns during instance creation to ensure strict monotonicity.
+    assert_eq!(
+        pic.get_time().as_nanos_since_unix_epoch(),
+        initial_timestamp + 1
+    );
+}
+
+#[test]
+#[should_panic(
+    expected = "The initial timestamp (unix timestamp in nanoseconds) must be no earlier than 1620328630000000000 (provided 0)."
+)]
+fn test_invalid_initial_timestamp() {
+    let _pic = PocketIcBuilder::new()
+        .with_application_subnet()
+        .with_initial_timestamp(0)
+        .build();
+}
+
+#[test]
+fn test_initial_timestamp_with_cycles_minting() {
+    let initial_timestamp = 1_620_633_601_000_000_000; // 10 May 2021 10:00:01
+    let icp_features = IcpFeatures {
+        cycles_minting: true,
+        ..Default::default()
+    };
+    let pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_application_subnet()
+        .with_icp_features(icp_features)
+        .with_initial_timestamp(initial_timestamp)
+        .build();
+
+    // Initial time is bumped during each subnet creation and when executing rounds to deploy the CMC.
+    assert_eq!(
+        pic.get_time().as_nanos_since_unix_epoch(),
+        initial_timestamp + 7
+    );
+}
+
+#[test]
+#[should_panic(
+    expected = "The initial timestamp (unix timestamp in nanoseconds) must be no earlier than 1620633601000000000 (provided 1620328630000000000)."
+)]
+fn test_invalid_initial_timestamp_with_cycles_minting() {
+    let initial_timestamp = 1_620_328_630_000_000_000; // 06 May 2021 21:17:10 CEST
+    let icp_features = IcpFeatures {
+        cycles_minting: true,
+        ..Default::default()
+    };
+    let _pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_application_subnet()
+        .with_icp_features(icp_features)
+        .with_initial_timestamp(initial_timestamp)
+        .build();
+}
+
+#[test]
+fn test_auto_progress() {
+    let pic = PocketIcBuilder::new()
+        .with_application_subnet()
+        .with_auto_progress(None)
+        .build();
+
+    assert!(pic.auto_progress_enabled());
+}
+
 fn query_and_check_time(pic: &PocketIc, test_canister: Principal) {
     let current_time = pic.get_time().as_nanos_since_unix_epoch();
     let t: (u64,) = query_candid(pic, test_canister, "time", ((),)).unwrap();
@@ -542,6 +617,7 @@ async fn resume_killed_instance_impl(allow_incomplete_state: Option<bool>) -> Re
         bitcoind_addr: None,
         icp_features: None,
         allow_incomplete_state,
+        initial_time: None,
     };
     let response = client
         .post(server_url.join("instances").unwrap())

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to fix a performance regression when using the two endpoints `/instances/<instance_id>/update/tick` and `/instances/<instance_id>/read/ingress_status` in a loop.
 - The argument of the endpoint `/instances/` takes an additional optional field `icp_features` specifying ICP features (implemented by system canisters) to be enabled in the newly created PocketIC instance.
 - The argument of the endpoint `/instances/` takes an additional optional field `allow_incomplete_state` specifying if incomplete state (e.g., resulting from not deleting a PocketIC instance gracefully) is allowed.
+- The argument of the endpoint `/instances/` takes an additional optional field `initial_time` specifying the initial timestamp of the newly created instance or
+  if the new instance should make progress automatically, i.e., if PocketIC should periodically update the time of the instance to the real time and execute rounds on the subnets.
 
 
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -517,6 +517,7 @@ struct PocketIcSubnets {
     log_level: Option<Level>,
     bitcoind_addr: Option<Vec<SocketAddr>>,
     icp_features: Option<IcpFeatures>,
+    initial_time: SystemTime,
     synced_registry_version: RegistryVersion,
     _bitcoin_adapter_parts: Option<BitcoinAdapterParts>,
 }
@@ -595,6 +596,7 @@ impl PocketIcSubnets {
         log_level: Option<Level>,
         bitcoind_addr: Option<Vec<SocketAddr>>,
         icp_features: Option<IcpFeatures>,
+        initial_time: SystemTime,
         synced_registry_version: Option<u64>,
     ) -> Self {
         let registry_data_provider = Arc::new(ProtoRegistryDataProvider::new());
@@ -620,6 +622,7 @@ impl PocketIcSubnets {
             log_level,
             bitcoind_addr,
             icp_features,
+            initial_time,
             synced_registry_version,
             _bitcoin_adapter_parts: None,
         }
@@ -678,7 +681,7 @@ impl PocketIcSubnets {
             subnet_state_dir,
             subnet_kind,
             instruction_config,
-            time,
+            expected_state_time,
         } = subnet_config_info;
 
         let subnet_seed = compute_subnet_seed(ranges.clone(), alloc_range);
@@ -761,7 +764,7 @@ impl PocketIcSubnets {
         // if one was provided).
         let subnet_id = sm.get_subnet_id();
 
-        if let Some(expected_time) = time {
+        if let Some(expected_time) = expected_state_time {
             let actual_time: SystemTime = sm.get_state_time().into();
             if actual_time != expected_time {
                 return Err(format!(
@@ -845,7 +848,7 @@ impl PocketIcSubnets {
 
         // All subnets must have the same time and time can only advance =>
         // set the time to the maximum time in the latest state across all subnets.
-        let mut time: SystemTime = default_timestamp(&self.icp_features);
+        let mut time: SystemTime = self.initial_time;
         for subnet in self.subnets.get_all() {
             time = max(time, subnet.state_machine.get_state_time().into());
         }
@@ -1836,10 +1839,23 @@ impl PocketIc {
         bitcoind_addr: Option<Vec<SocketAddr>>,
         icp_features: Option<IcpFeatures>,
         allow_incomplete_state: Option<bool>,
+        initial_time: Option<Time>,
     ) -> Result<Self, String> {
         if let Some(ref icp_features) = icp_features {
             subnet_configs = subnet_configs.try_with_icp_features(icp_features)?;
         }
+        if let Some(time) = initial_time {
+            let systime: SystemTime = time.into();
+            let minimum_systime = default_timestamp(&icp_features);
+            if systime < minimum_systime {
+                return Err(format!("The initial timestamp (unix timestamp in nanoseconds) must be no earlier than {} (provided {}).",
+                    systemtime_to_unix_epoch_nanos(minimum_systime),
+                    systemtime_to_unix_epoch_nanos(systime)));
+            }
+        }
+        let initial_time: SystemTime = initial_time
+            .map(|time| time.into())
+            .unwrap_or_else(|| default_timestamp(&icp_features));
 
         let registry: Option<Vec<u8>> = if let Some(ref state_dir) = state_dir {
             let registry_file_path = state_dir.join("registry.proto");
@@ -1882,7 +1898,7 @@ impl PocketIc {
                     if let Some(allocation_range) = config.alloc_range {
                         range_gen.add_assigned(vec![allocation_range]).unwrap();
                     }
-                    let time = if let Some(true) = allow_incomplete_state {
+                    let expected_state_time = if let Some(true) = allow_incomplete_state {
                         None
                     } else {
                         Some(topology.time)
@@ -1894,7 +1910,7 @@ impl PocketIc {
                         subnet_state_dir: None,
                         subnet_kind: config.subnet_kind,
                         instruction_config: config.instruction_config,
-                        time,
+                        expected_state_time,
                     }
                 })
                 .collect()
@@ -2043,7 +2059,7 @@ impl PocketIc {
                     subnet_state_dir,
                     subnet_kind,
                     instruction_config,
-                    time: None,
+                    expected_state_time: None,
                 });
             }
 
@@ -2065,6 +2081,7 @@ impl PocketIc {
             log_level,
             bitcoind_addr,
             icp_features,
+            initial_time,
             synced_registry_version,
         );
         let mut subnet_configs = Vec::new();
@@ -2293,7 +2310,7 @@ struct SubnetConfigInfo {
     pub subnet_state_dir: Option<PathBuf>,
     pub subnet_kind: SubnetKind,
     pub instruction_config: SubnetInstructionConfig,
-    pub time: Option<SystemTime>,
+    pub expected_state_time: Option<SystemTime>,
 }
 
 // ---------------------------------------------------------------------------------------- //
@@ -3866,7 +3883,7 @@ fn route(
                         subnet_state_dir: None,
                         subnet_kind,
                         instruction_config,
-                        time: None,
+                        expected_state_time: None,
                     })?;
                     pic.subnets
                         .persist_topology(pic.default_effective_canister_id);
@@ -3974,6 +3991,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .unwrap();
             let mut pic1 = PocketIc::try_new(
@@ -3985,6 +4003,7 @@ mod tests {
                 },
                 None,
                 false,
+                None,
                 None,
                 None,
                 None,

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -37,8 +37,8 @@ use ic_gateway::{setup_router, Cli};
 use ic_types::{canister_http::CanisterHttpRequestId, CanisterId, NodeId, PrincipalId, SubnetId};
 use itertools::Itertools;
 use pocket_ic::common::rest::{
-    CanisterHttpRequest, HttpGatewayBackend, HttpGatewayConfig, HttpGatewayDetails,
-    HttpGatewayInfo, Topology,
+    AutoProgressConfig, CanisterHttpRequest, HttpGatewayBackend, HttpGatewayConfig,
+    HttpGatewayDetails, HttpGatewayInfo, Topology,
 };
 use pocket_ic::RejectResponse;
 use reqwest::Url;
@@ -556,13 +556,17 @@ impl ApiState {
         Self::read_result(self.graph.clone(), state_label, op_id)
     }
 
-    pub async fn add_instance<F>(&self, f: F) -> Result<(InstanceId, Topology), String>
+    pub async fn add_instance<F>(
+        &self,
+        create_instance_from_seed: F,
+        auto_progress: Option<AutoProgressConfig>,
+    ) -> Result<(InstanceId, Topology), String>
     where
         F: FnOnce(u64) -> Result<PocketIc, String> + std::marker::Send + 'static,
     {
         let seed = self.seed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         // create the instance using `spawn_blocking` before acquiring a lock
-        let instance = tokio::task::spawn_blocking(move || f(seed))
+        let instance = tokio::task::spawn_blocking(move || create_instance_from_seed(seed))
             .await
             .expect("Failed to create PocketIC instance")?;
         let topology = instance.topology();
@@ -572,6 +576,14 @@ impl ApiState {
             progress_thread: None,
             state: InstanceState::Available(instance),
         }));
+        drop(instances);
+        if let Some(config) = auto_progress {
+            // safe to unwrap here because the instance is fresh and thus auto progress
+            // cannot be enabled already
+            self.auto_progress(instance_id, config.artificial_delay_ms)
+                .await
+                .unwrap();
+        }
         Ok((instance_id, topology))
     }
 

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -131,6 +131,7 @@ fn test_creation_of_instance_extended() {
         bitcoind_addr: None,
         icp_features: None,
         allow_incomplete_state: None,
+        initial_time: None,
     };
     let response = client
         .post(url.join("instances").unwrap())


### PR DESCRIPTION
This PR enables specifying the initial timestamp of a newly created PocketIC instance or if the new instance should make progress automatically (i.e., if PocketIC should periodically update the time of the instance to the real time and execute rounds on the subnets) during PocketIC instance creation (instead of only after the instance is created using a separate PocketIC operation).

The motivation for this PR is two-fold:
- setting time only after PocketIC instance creation is longer equivalent to setting time during PocketIC instance creation if system canisters are deployed during PocketIC instance creation (using the `icp_features` option) - the system canisters could then see time that is significantly off the time set afterwards that could be unexpected for the system canisters (and they indeed produce canister logs related to that);
- enabling auto progress during PocketIC instance creation ensures that canister http outcalls are handled automatically by PocketIC and thus system canisters (e.g., II to be added in a follow-up PR) could rely on canister http outcalls.