### PR TITLE
fix: prevent //rs/tests/boundary_nodes:api_bn_integration_test_head_nns from running on PRs

### DIFF
--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -7,7 +7,6 @@ CERTIFICATE_ORCHESTRATOR_RUNTIME_DEPS = ["//rs/boundary_node/certificate_issuanc
 
 system_test_nns(
     name = "api_bn_integration_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
     ],


### PR DESCRIPTION
https://github.com/dfinity/ic/commit/fd5c4949944cde2a7301449b84df2acb4211e618 removed the `long_test` tag from `//rs/tests/boundary_nodes:api_bn_integration_test`. However this test overwrote the default[`extra_head_nns_tags = ["system_test_large"]`](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/tests/system_tests.bzl?L484) with `extra_head_nns_tags = []` causing the `_head_nns` variant to run on PRs which is not necessary. So this commit removes the overwrite. 