### PR TITLE
fix: ensure _head_nns variants of long system-tests only run once on nightly

### DIFF
--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -7,7 +7,6 @@ CERTIFICATE_ORCHESTRATOR_RUNTIME_DEPS = ["//rs/boundary_node/certificate_issuanc
 
 system_test_nns(
     name = "api_bn_integration_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
     ],
@@ -197,7 +196,6 @@ system_test(
 
 system_test_nns(
     name = "api_bn_decentralization_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/ckbtc/BUILD.bazel
+++ b/rs/tests/ckbtc/BUILD.bazel
@@ -69,7 +69,6 @@ system_test_nns(
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -125,7 +124,6 @@ system_test_nns(
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -153,7 +151,6 @@ system_test_nns(
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -181,7 +178,6 @@ system_test_nns(
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],
@@ -209,7 +205,6 @@ system_test_nns(
         "LEDGER_WASM_PATH": "$(rootpath //rs/ledger_suite/icrc1/ledger:ledger_canister)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -218,7 +218,6 @@ system_test_nns(
 system_test_nns(
     name = "subnet_splitting_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -359,7 +358,6 @@ system_test_nns(
         "//bazel:upload_perf_systest_results_enabled": ["upload_perf_systest_results"],
         "//conditions:default": [],
     }),
-    extra_head_nns_tags = [],
     tags = [
         "experimental_system_test_colocation",
         "manual",
@@ -385,7 +383,6 @@ system_test_nns(
 system_test_nns(
     name = "adding_nodes_to_subnet_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/consensus/backup/BUILD.bazel
+++ b/rs/tests/consensus/backup/BUILD.bazel
@@ -60,7 +60,6 @@ rust_binary(
 system_test_nns(
     name = "backup_manager_upgrade_test",
     env = BACKUP_ENV | MAINNET_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "experimental_system_test_colocation",
         "long_test",  # since it takes longer than 5 minutes.
@@ -78,7 +77,6 @@ system_test_nns(
 system_test_nns(
     name = "backup_manager_downgrade_test",
     env = BACKUP_ENV | MAINNET_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "experimental_system_test_colocation",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/consensus/orchestrator/BUILD.bazel
+++ b/rs/tests/consensus/orchestrator/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 system_test_nns(
     name = "node_assign_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -32,7 +31,6 @@ system_test_nns(
 system_test_nns(
     name = "node_reassignment_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -92,7 +90,6 @@ system_test(
 
 system_test_nns(
     name = "ssh_access_to_nodes_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -132,7 +129,6 @@ system_test_nns(
 system_test_nns(
     name = "rotate_ecdsa_idkg_key_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -48,7 +48,6 @@ rust_library(
 system_test_nns(
     name = "sr_app_same_nodes_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -107,7 +106,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_app_failover_nodes_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -169,7 +167,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_app_no_upgrade_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -189,7 +186,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_app_no_upgrade_local_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -271,7 +267,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_nns_same_nodes_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "experimental_system_test_colocation",
         "k8s",
@@ -296,7 +291,6 @@ system_test_nns(
 system_test_nns(
     name = "sr_nns_failover_nodes_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "experimental_system_test_colocation",
         "k8s",

--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -30,7 +30,6 @@ system_test_nns(
 system_test_nns(
     name = "tecdsa_add_nodes_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -57,7 +56,6 @@ system_test_nns(
 system_test_nns(
     name = "tschnorr_message_sizes_test",
     env = MESSAGE_CANISTER_ENV | SIGNER_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -80,7 +78,6 @@ system_test_nns(
 system_test_nns(
     name = "tecdsa_remove_nodes_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -216,7 +213,6 @@ system_test_nns(
 system_test_nns(
     name = "tecdsa_signature_life_cycle_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     # Remove when CON-937 is resolved
     flaky = True,  # flakiness rate of 1.57% over the month from 2025-02-11 till 2025-03-11
     tags = [
@@ -265,7 +261,6 @@ system_test_nns(
 system_test_nns(
     name = "tecdsa_signature_timeout_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -103,7 +103,6 @@ rust_binary(
 system_test_nns(
     name = "upgrade_app_subnet_test",
     env = MAINNET_ENV | MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,  # flakiness rate of over 2.27% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
@@ -121,7 +120,6 @@ system_test_nns(
 system_test_nns(
     name = "downgrade_app_subnet_test",
     env = MAINNET_ENV | MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,  # flakiness rate of over 2.97% over the month from 2025-02-11 till 2025-03-11.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/consensus/vetkd/BUILD.bazel
+++ b/rs/tests/consensus/vetkd/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 system_test_nns(
     name = "vetkd_key_life_cycle_test",
     env = MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/financial_integrations/rosetta/BUILD.bazel
+++ b/rs/tests/financial_integrations/rosetta/BUILD.bazel
@@ -35,7 +35,6 @@ system_test_nns(
 
 system_test_nns(
     name = "rosetta_neuron_follow_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.

--- a/rs/tests/nested/BUILD.bazel
+++ b/rs/tests/nested/BUILD.bazel
@@ -66,7 +66,6 @@ genrule(
 system_test_nns(
     name = "registration",
     env = MAINNET_ENV,
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     flaky = True,  # flakiness rate of over 2% over the month from 2025-02-11 till 2025-03-11.
     tags = ["long_test"],  # since it takes longer than 5 minutes.
     test_timeout = "eternal",
@@ -88,7 +87,6 @@ rust_binary(
 system_test_nns(
     name = "guestos_upgrade_smoke_test",
     env = MAINNET_ENV,
-    extra_head_nns_tags = [],
     flaky = True,
     tags = ["long_test"],
     test_driver_target = ":guestos_upgrade_test_bin",
@@ -105,7 +103,6 @@ system_test_nns(
     env = MAINNET_ENV | {
         "NODE_OPERATOR_PRIV_KEY_PATH": "$(rootpath //ic-os/setupos:config/node_operator_private_key.pem)",
     },
-    extra_head_nns_tags = [],
     flaky = True,
     tags = ["long_test"],
     test_driver_target = ":guestos_upgrade_test_bin",
@@ -129,7 +126,6 @@ rust_binary(
 system_test_nns(
     name = "hostos_upgrade_smoke_test",
     env = MAINNET_ENV,
-    extra_head_nns_tags = [],
     flaky = True,
     tags = ["long_test"],
     test_driver_target = ":hostos_upgrade_test_bin",
@@ -148,7 +144,6 @@ system_test_nns(
     env = MAINNET_ENV | {
         "NODE_OPERATOR_PRIV_KEY_PATH": "$(rootpath //ic-os/setupos:config/node_operator_private_key.pem)",
     },
-    extra_head_nns_tags = [],
     flaky = True,  # flakiness rate of 5% over the month from 2025-02-11 till 2025-03-11.
     tags = ["long_test"],
     test_driver_target = ":hostos_upgrade_test_bin",
@@ -169,7 +164,6 @@ system_test_nns(
     env = MAINNET_ENV | {
         "NODE_OPERATOR_PRIV_KEY_PATH": "$(rootpath //ic-os/setupos:config/node_operator_private_key.pem)",
     },
-    extra_head_nns_tags = [],
     flaky = True,
     tags = ["manual"],
     test_driver_target = ":hostos_upgrade_test_bin",
@@ -187,7 +181,6 @@ system_test_nns(
 system_test_nns(
     name = "recovery_upgrader_test",
     env = MAINNET_ENV,
-    extra_head_nns_tags = [],
     flaky = True,
     tags = ["long_test"],
     test_timeout = "eternal",
@@ -204,7 +197,6 @@ system_test_nns(
 system_test_nns(
     name = "nns_recovery_test",
     env = MAINNET_ENV | MESSAGE_CANISTER_ENV,
-    extra_head_nns_tags = [],
     flaky = True,
     tags = ["long_test"],
     test_timeout = "eternal",

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -48,7 +48,6 @@ system_test_nns(
     env = {
         "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
     },
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
@@ -86,7 +85,6 @@ system_test_nns(
     env = {
         "PROXY_WASM_PATH": "$(rootpath //rs/rust_canisters/proxy_canister:proxy_canister)",
     },
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "dynamic_testnet",
         "manual",

--- a/rs/tests/sdk/BUILD.bazel
+++ b/rs/tests/sdk/BUILD.bazel
@@ -30,7 +30,6 @@ RUNTIME_DEPS = [
 
 system_test_nns(
     name = "dfx_smoke_test",
-    extra_head_nns_tags = [],  # don't run the head_nns variant on nightly since it aleady runs on long_test.
     tags = [
         "long_test",  # since it takes longer than 5 minutes.
     ],

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -519,6 +519,13 @@ def system_test_nns(name, extra_head_nns_tags = ["system_test_large"], **kwargs)
     )
 
     original_tags = kwargs.pop("tags", [])
+
+    # Without the following, when a system_test_nns is tagged as a long_test it will run both on the nightly
+    # "Release Testing / CI Main / Bazel Test All" and "Release Testing / Release System Tests" which would be redundant.
+    # So we remove the default "system_test_large" tag from the head_nns variant such that it only runs on "Bazel Test All".
+    if "long_test" in original_tags and extra_head_nns_tags == ["system_test_large"]:
+        extra_head_nns_tags = []
+
     kwargs["test_driver_target"] = mainnet_nns_systest.test_driver_target
     system_test(
         name + "_head_nns",


### PR DESCRIPTION
Currently callers of `system_test_nns` have to manually configure the `extra_head_nns_tags` which determines the tags of the `_head_nns` variant of the system-test. This is error-prone as witnessed by the following two bugs:

1. `//rs/tests/boundary_nodes:api_bn_integration_test` would override the default  `extra_head_nns_tags` with `[]` which caused the `_head_nns` variant to run on PRs which is not what we want. This is fixed by https://github.com/dfinity/ic/pull/6318.
2. [`//rs/tests/boundary_nodes:api_bn_update_workload_test`](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/tests/boundary_nodes/BUILD.bazel?L25) which is marked as a `long_test` but `extra_head_nns_tags`  is not overridden with `[]` causing the `_head_nns` variant to run both on  "Release Testing / CI Main / Bazel Test All" and "Release Testing / Release System Tests" which is redundant and wastes CI resources.

So this commits abstracts setting `extra_head_nns_tags` for `system_test_nns` invocations for `long_tests` such that users don't have to think about it anymore and prevent the bugs above.
