### PR TITLE
doc(nns): Say that Topic.TOPIC_UNSPECIFIED is not applicable to Governance/SNS/Neuron's fund

### DIFF
--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -42,7 +42,7 @@ enum Topic {
   // The `Unspecified` topic is used as a fallback when
   // following. That is, if no followees are specified for a given
   // topic (other than the "Governance" and "SNS & Neurons' Fund" topics),
-  // the followees for this topic are used instead. 
+  // the followees for this topic are used instead.
   TOPIC_UNSPECIFIED = 0;
   // A special topic by means of which a neuron can be managed by the
   // followees for this topic (in this case, there is no fallback to

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -41,7 +41,8 @@ message UpdateNodeProvider {
 enum Topic {
   // The `Unspecified` topic is used as a fallback when
   // following. That is, if no followees are specified for a given
-  // topic, the followees for this topic are used instead.
+  // topic (other than the "Governance" and "SNS & Neurons' Fund" topics),
+  // the followees for this topic are used instead. 
   TOPIC_UNSPECIFIED = 0;
   // A special topic by means of which a neuron can be managed by the
   // followees for this topic (in this case, there is no fallback to

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -4132,7 +4132,8 @@ pub struct FinalizeDisburseMaturity {
 pub enum Topic {
     /// The `Unspecified` topic is used as a fallback when
     /// following. That is, if no followees are specified for a given
-    /// topic, the followees for this topic are used instead.
+    /// topic (other than the "Governance" and "SNS & Neurons' Fund" topics),
+    /// the followees for this topic are used instead. 
     Unspecified = 0,
     /// A special topic by means of which a neuron can be managed by the
     /// followees for this topic (in this case, there is no fallback to

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -4133,7 +4133,7 @@ pub enum Topic {
     /// The `Unspecified` topic is used as a fallback when
     /// following. That is, if no followees are specified for a given
     /// topic (other than the "Governance" and "SNS & Neurons' Fund" topics),
-    /// the followees for this topic are used instead. 
+    /// the followees for this topic are used instead.
     Unspecified = 0,
     /// A special topic by means of which a neuron can be managed by the
     /// followees for this topic (in this case, there is no fallback to


### PR DESCRIPTION
As the title suggests.