### PR TITLE
chore: replace const RESERVED_BY_SNAPSHOT by recomputing the value dynamically

### DIFF
--- a/rs/execution_environment/tests/storage_reservation.rs
+++ b/rs/execution_environment/tests/storage_reservation.rs
@@ -15,6 +15,7 @@ use ic_test_utilities::universal_canister::{call_args, wasm, UNIVERSAL_CANISTER_
 use ic_types::{CanisterId, Cycles, NumBytes};
 use more_asserts::{assert_gt, assert_lt};
 
+const B: u128 = 1_000_000_000;
 const T: u128 = 1_000_000_000_000;
 
 const KIB: u64 = 1024;
@@ -475,9 +476,11 @@ fn reserved_cycles_for_snapshot() -> u128 {
     })
     .unwrap();
     let after = reserved_balance(&env, canister_id);
-
     let reserved_by_snapshot = after - before;
-    assert!(reserved_by_snapshot >= 40_000_000_000);
+
+    let margin = 10;
+    assert!(reserved_by_snapshot > 40 * B * margin);
+
     reserved_by_snapshot
 }
 


### PR DESCRIPTION
This PR replaces a hard-coded `const RESERVED_BY_SNAPSHOT` in the storage reservation cycles tests by a function `reserved_cycles_for_snapshot()` computing the value of this constant dynamically at runtime.

The motivation for this change is that the universal canister WASM has a different size when `--config=stamped` is passed to its build by bazel and this has an influence on the number of reserved cycles. With `--config=stamped`, there's a custom section
```
git_commit_id544fa2c3189aa7dff50330bf189aa19a08018d30-dirty
```
and otherwise
```
git_commit_id0000000000000000000000000000000000000000
```
Even if we appended, e.g., `-clean` to the all zero `git_commit_id`, the gzipped size would likely still be different.