### PR TITLE
fix: ensure the cargo jobs run on Release Testing

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -605,7 +605,8 @@ jobs:
         if: |
           steps.filter.outputs.cargo == 'true' ||
           github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch'
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'workflow_call'
         shell: bash
         run: |
           set -eExuo pipefail
@@ -634,7 +635,8 @@ jobs:
         if: |
           steps.filter.outputs.cargo == 'true' ||
           github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch'
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'workflow_call'
         shell: bash
         run: |
           set -eExuo pipefail

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -605,7 +605,8 @@ jobs:
         if: |
           steps.filter.outputs.cargo == 'true' ||
           github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch'
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'workflow_call'
         shell: bash
         run: |
           set -eExuo pipefail
@@ -642,7 +643,8 @@ jobs:
         if: |
           steps.filter.outputs.cargo == 'true' ||
           github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch'
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'workflow_call'
         shell: bash
         run: |
           set -eExuo pipefail


### PR DESCRIPTION
The cargo jobs in CI Main do not trigger on `workflow_call` which means that they won't run as part of Release Testing:

* `cargo-clippy-linux`: [example non run](https://github.com/dfinity/ic/actions/runs/17034304497/job/48283183248)
* `cargo-build-release-linux`: [example non run](https://github.com/dfinity/ic/actions/runs/17034304497/job/48283183285)

It's important they do run as part of release testing since we want our release to be buildable by cargo. So this adds the `||  github.event_name == 'workflow_call'` condition to both steps.