### PR TITLE
test: check if targets in PULL_REQUEST_BAZEL_TARGETS are non-empty after excluding all manual targets

### DIFF
--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -201,7 +201,9 @@ def check():
                 errors.append(f"Pattern '{pattern}' has problematic target '{target}':\n{indented_error_msg}")
             else:
                 if len(result.stdout.splitlines()) == 0:
-                    errors.append(f"Pattern '{pattern}' with target '{target}' results in no targets after excluding all manual targets!")
+                    errors.append(
+                        f"Pattern '{pattern}' with target '{target}' results in no targets after excluding all manual targets!"
+                    )
 
     n = len(errors)
     if n > 0:

--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -201,16 +201,14 @@ def check():
                 errors.append(f"Pattern '{pattern}' has problematic target '{target}':\n{indented_error_msg}")
             else:
                 if len(result.stdout.splitlines()) == 0:
-                    tip = (
-                        (
+                    errors.append(
+                        f"Pattern '{pattern}' with target '{target}' results in no targets after excluding all manual targets!"
+                        + (
                             f"\n{indentation}It might be you're including the manual non-colocated variant of a system-test."
                             + f"\n{indentation}Try '{target}_colocate' instead."
                         )
                         if target.startswith("//rs/tests")
                         else ""
-                    )
-                    errors.append(
-                        f"Pattern '{pattern}' with target '{target}' results in no targets after excluding all manual targets!{tip}"
                     )
 
     n = len(errors)


### PR DESCRIPTION
Triggered by [this code review](https://github.com/dfinity/ic/pull/6329#discussion_r2284662305), it's important that targets in `PULL_REQUEST_BAZEL_TARGETS` are checked for non-emptiness after excluding all `manual` targets. That will prevent mistakes like including a non-colocated variant of a colocated test like `//rs/tests/consensus/backup:backup_manager_upgrade_test` (which is automatically tagged as `manual`) instead of it's colocated variant `//rs/tests/consensus/backup:backup_manager_upgrade_test_colocate`. 