### PR TITLE
chore: rename the experimental_system_test_colocation to colocate

### DIFF
--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -24,7 +24,7 @@ system_test_nns(
 system_test_nns(
     name = "api_bn_update_workload_test",
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "long_test",
     ],
     test_timeout = "long",

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -65,7 +65,7 @@ system_test(
     name = "dual_workload_test",
     env = UNIVERSAL_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
     ],
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS,
@@ -219,7 +219,7 @@ system_test_nns(
     name = "subnet_splitting_test",
     env = MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_splitting",
@@ -359,7 +359,7 @@ system_test_nns(
         "//conditions:default": [],
     }),
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "manual",
     ],
     test_timeout = "eternal",

--- a/rs/tests/consensus/backup/BUILD.bazel
+++ b/rs/tests/consensus/backup/BUILD.bazel
@@ -61,7 +61,7 @@ system_test_nns(
     name = "backup_manager_upgrade_test",
     env = BACKUP_ENV | MAINNET_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "long_test",  # since it takes longer than 5 minutes.
     ],
     test_driver_target = ":backup_manager_test_bin",
@@ -78,7 +78,7 @@ system_test_nns(
     name = "backup_manager_downgrade_test",
     env = BACKUP_ENV | MAINNET_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "long_test",  # since it takes longer than 5 minutes.
     ],
     test_driver_target = ":backup_manager_test_bin",

--- a/rs/tests/consensus/subnet_recovery/BUILD.bazel
+++ b/rs/tests/consensus/subnet_recovery/BUILD.bazel
@@ -49,7 +49,7 @@ system_test_nns(
     name = "sr_app_same_nodes_test",
     env = MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
@@ -69,7 +69,7 @@ system_test_nns(
     env = MESSAGE_CANISTER_ENV,
     flaky = True,  # flakiness rate of over 3.33% over the month from 2025-02-11 till 2025-03-11.
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",
         "subnet_recovery",
@@ -88,7 +88,7 @@ system_test_nns(
     name = "sr_app_same_nodes_with_chain_keys_test",
     env = MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",
         "subnet_recovery",
@@ -107,7 +107,7 @@ system_test_nns(
     name = "sr_app_failover_nodes_test",
     env = MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
@@ -127,7 +127,7 @@ system_test_nns(
     env = MESSAGE_CANISTER_ENV,
     flaky = True,  # flakiness rate of over 1.67% over the month from 2025-02-11 till 2025-03-11.
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",
         "subnet_recovery",
@@ -148,7 +148,7 @@ system_test_nns(
     env = MESSAGE_CANISTER_ENV,
     flaky = True,  # flakiness rate of 3.33% over the month from 2025-02-11 till 2025-03-11.
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",
         "subnet_recovery",
@@ -168,7 +168,7 @@ system_test_nns(
     name = "sr_app_no_upgrade_test",
     env = MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
@@ -187,7 +187,7 @@ system_test_nns(
     name = "sr_app_no_upgrade_local_test",
     env = MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
@@ -206,7 +206,7 @@ system_test_nns(
     name = "sr_app_no_upgrade_enable_chain_keys_test",
     env = MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",
         "subnet_recovery",
@@ -227,7 +227,7 @@ system_test_nns(
     env = MESSAGE_CANISTER_ENV,
     flaky = True,  # flakiness rate of over 6% over the month from 2025-02-11 till 2025-03-11 (only for //rs/tests/consensus/subnet_recovery:sr_app_no_upgrade_with_chain_keys_test_head_nns_colocate).
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",
         "subnet_recovery",
@@ -249,7 +249,7 @@ system_test_nns(
     env = MESSAGE_CANISTER_ENV,
     flaky = True,  # flakiness rate of over 2.21% over the month from 2025-02-11 till 2025-03-11.
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "subnet_recovery",
         "system_test_large",  # only run as part of release-testing since this test requires many resources.
     ],
@@ -268,7 +268,7 @@ system_test_nns(
     name = "sr_nns_same_nodes_test",
     env = MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",
@@ -292,7 +292,7 @@ system_test_nns(
     name = "sr_nns_failover_nodes_test",
     env = MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",  # since it takes longer than 5 minutes.
         "subnet_recovery",

--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -292,7 +292,7 @@ tecdsa_performance_test_template = system_test_nns(
         "//conditions:default": [],
     }),
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "manual",
     ],
     test_timeout = "eternal",
@@ -336,7 +336,7 @@ system_test_nns(
         "BENCHMARK_NAME": "tecdsa_performance_test",
     },
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "manual",
     ],
@@ -364,7 +364,7 @@ system_test_nns(
         "BENCHMARK_NAME": "tschnorr_ed25519_performance_test",
     },
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "manual",
     ],
@@ -392,7 +392,7 @@ system_test_nns(
         "BENCHMARK_NAME": "tschnorr_bip340_performance_test",
     },
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "manual",
     ],
@@ -420,7 +420,7 @@ system_test_nns(
         "BENCHMARK_NAME": "vetkd_performance_test",
     },
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "manual",
     ],

--- a/rs/tests/consensus/upgrade/BUILD.bazel
+++ b/rs/tests/consensus/upgrade/BUILD.bazel
@@ -32,7 +32,7 @@ system_test_nns(
     },
     env = MAINNET_ENV | MESSAGE_CANISTER_ENV,
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "long_test",
     ],
     test_timeout = "eternal",

--- a/rs/tests/financial_integrations/rosetta/BUILD.bazel
+++ b/rs/tests/financial_integrations/rosetta/BUILD.bazel
@@ -5,7 +5,7 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 
 system_test_nns(
     name = "rosetta_test",
-    tags = ["experimental_system_test_colocation"],
+    tags = ["colocate"],
     test_timeout = "long",
     runtime_deps = [
         "//rs/rosetta-api/icp:ic-rosetta-api",

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -320,7 +320,7 @@ system_test_nns(
     enable_head_nns_variant = False,  # only run this test with the mainnet NNS canisters.
     flaky = True,  # flakiness rate of 3.45% over the month from 2025-02-11 till 2025-03-11.
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "system_test_large",
     ],
@@ -351,7 +351,7 @@ system_test_nns(
     name = "query_workload_long_test",
     flaky = True,  # flakiness rate of over 1.1% over the month from 2025-02-11 till 2025-03-11.
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "k8s",
         "long_test",
     ],
@@ -366,7 +366,7 @@ system_test_nns(
     name = "update_workload_large_payload",
     flaky = True,  # flakiness rate of 1.83% over the month from 2025-02-11 till 2025-03-11.
     tags = [
-        "experimental_system_test_colocation",
+        "colocate",
         "long_test",
     ],
     test_timeout = "long",

--- a/rs/tests/research/BUILD.bazel
+++ b/rs/tests/research/BUILD.bazel
@@ -13,7 +13,7 @@ package(default_visibility = ["//rs:system-tests-pkg"])
         env = {
             "IC_REF_TEST_BIN": "$(rootpath //hs/spec_compliance:ic-ref-test)",
         },
-        tags = ["experimental_system_test_colocation"],
+        tags = ["colocate"],
         runtime_deps = UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
             ":ic-hs",
             "//hs/spec_compliance:ic-ref-test",

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -433,7 +433,7 @@ def system_test(
         info_file_vars = info_file_vars,
         env_inherit = env_inherit,
         tags = tags + ["requires-network", "system_test"] +
-               (["manual"] if "experimental_system_test_colocation" in tags else []),
+               (["manual"] if "colocate" in tags else []),
         target_compatible_with = ["@platforms//os:linux"],
         timeout = test_timeout,
         flaky = flaky,
@@ -472,7 +472,7 @@ def system_test(
         icos_images = icos_images,
         info_file_vars = info_file_vars,
         tags = tags + ["requires-network", "system_test"] +
-               (["colocated"] if "experimental_system_test_colocation" in tags else ["manual"]) +
+               (["colocated"] if "colocate" in tags else ["manual"]) +
                additional_colocate_tags,
         target_compatible_with = ["@platforms//os:linux"],
         timeout = test_timeout,


### PR DESCRIPTION
System-test colocation has been very stable for a long time and many system-tests and performance tests rely on it so I declare it no longer experimental by renaming the `experimental_system_test_colocation` tag to `colocate`.