### PR TITLE
test: always test long system-tests on PRs of which direct source files have been modified

### DIFF
--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -126,8 +126,11 @@ def diff_only_query(command: str, base: str, head: str, skip_long_tests: bool) -
     # Exclude the long_tests if requested:
     query = f"({query})" + (" except attr(tags, long_test, //...)" if skip_long_tests else "")
 
-    # Include all long system-tests (under //rs/tests) of which a direct source file has been modified.
-    # We specify a depth of 2 since a system-test depends on the test binary which depends on the source file.
+    # Include all long system-tests (under //rs/tests) of which a "direct" source file has been modified.
+    # We specify a depth of 2 since a system-test depends on the test binary (1st degree) which depends
+    # on the source file (2nd degree).
+    # This will trigger long system-tests if some files other than its .rs file are modified but we think
+    # this is acceptable since it would be good to run the tests if those direct files are modified anyways.
     query = f"({query}) + attr(tags, long_test, rdeps(//rs/tests/..., set({mfiles}), 2))"
 
     # Next, add the explicit targets from the PULL_REQUEST_BAZEL_TARGETS file that match the modified files:


### PR DESCRIPTION
What?
===

Trigger long system-test if their direct source files are modified.

Why?
===
Without this the risk is high that a direct change of a long system-test will break it since it won't be tested on the PR.

This is exactly what happened with https://github.com/dfinity/ic/pull/5011 which changed `rs/tests/nns/nns_cycles_minting_test.rs` [breaking](https://github.com/dfinity/ic/actions/runs/15052377429/job/42310102295) the long `//rs/tests/nns:nns_cycles_minting_test` on `master` and causing a long thread on slack.

How?
===
There are two ways of implementing this:

1. Add patterns for each source file of each long test to [`PULL_REQUEST_BAZEL_TARGETS`](https://github.com/dfinity/ic/blob/master/PULL_REQUEST_BAZEL_TARGETS) to trigger the respected long test. This is the most precise and will cover 100% of cases but is error-prone because it's easy to miss a long test or go out of sync in other ways.
2. Add a single rule to `ci/bazel-scripts/targets.py` which includes long tests of which a "direct" dependency has changed.

This commit implements the 2nd way. It extends the `{query}` formed in `ci/bazel-scripts/targets.py` by including all long tests from the set of system-tests of which a dependency in the 2nd degree has been modified (`{mfiles}`):

```
({query}) + attr(tags, long_test, rdeps(//rs/tests/..., set({mfiles}), 2))"
```

Why 2nd degree? Well a system-test depends on its test binary (1st degree) which depends on its source file (2nd degree).

This does mean other source dependencies of a system-test could trigger it. For example the long `//rs/tests/nns:nns_cycles_minting_test` not only depends on its source file in the 2nd degree but also on some other source files:

```
bazel query 'filter("^//", kind("source file", deps(//rs/tests/nns:nns_cycles_minting_test, 2)))' 
//bazel:upload_systest_dep.sh
//rs/tests:create-universal-vm-config-image.sh
//rs/tests/nns:nns_cycles_minting_test.rs
```

We think this is acceptable. It would anyway be good to trigger the long test if those other files are modified.

Test
===
Bogus [change of `rs/tests/nns/nns_cycles_minting_test.rs`](https://github.com/dfinity/ic/pull/6350/commits/ee5059b5ba9508de459784918c3bfba4c5e34906) resulting in run of [Bazel Test All](https://github.com/dfinity/ic/actions/runs/17078523167/job/48426140302?pr=6350#step:5:184) which indeed [shows](https://dash.zh1-idx1.dfinity.network/invocation/b32d890a-67f8-45ec-842f-4a129f9b7c6b#details) that the long `//rs/tests/nns:nns_cycles_minting_test` is ran.
