### PR TITLE
chore(crypto): CRP-2810 add missing PublicKey::derive_mainnet_key to changelogs

### DIFF
--- a/packages/ic-ed25519/CHANGELOG.md
+++ b/packages/ic-ed25519/CHANGELOG.md
@@ -13,9 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keys used for threshold EdDSA on the Internet Computer.
 - Add `PublicKey::derive_mainnet_key` to derive public key offline, in the same way it is done by the respective management canister call (`schnorr_public_key`).
 
-convenient access to the master public
-  keys used for threshold EdDSA on the Internet Computer.
-
 ## [0.2.0] - 2025-02-14
 
 ### Added

--- a/packages/ic-ed25519/CHANGELOG.md
+++ b/packages/ic-ed25519/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `PublicKey::mainnet_key` which allows convenient access to the master public
   keys used for threshold EdDSA on the Internet Computer.
+- Add `PublicKey::derive_mainnet_key` to derive public key offline, in the same way it is done by the respective management canister call (`schnorr_public_key`).
+
+convenient access to the master public
+  keys used for threshold EdDSA on the Internet Computer.
 
 ## [0.2.0] - 2025-02-14
 

--- a/packages/ic-secp256k1/CHANGELOG.md
+++ b/packages/ic-secp256k1/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `PublicKey::mainnet_key` which allows convenient access to the master public
   keys used for threshold ECDSA and threshold BIP341 Schnorr on the Internet Computer.
+- Add `PublicKey::derive_mainnet_key` to derive public key offline, in the same way it is done by the respective management canister call (`ecdsa_public_key`, `schnorr_public_key`).
 
 ## [0.1.0] - 2025-02-08
 


### PR DESCRIPTION
Add missing entries for `PublicKey::derive_mainnet_key` to the changelogs of ic-ed25519 and ic-secp256k1. It seems this was forgotten in https://github.com/dfinity/ic/pull/6173 and https://github.com/dfinity/ic/pull/6262.