### PR TITLE
chore: Remove wasm64 feature flag

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -124,8 +124,6 @@ pub struct FeatureFlags {
     /// If this flag is enabled, then the output of the `debug_print` system-api
     /// call will be skipped based on heuristics.
     pub rate_limiting_of_debug_prints: FlagStatus,
-    /// Indicates whether the support for 64 bit main memory is enabled
-    pub wasm64: FlagStatus,
     /// Collect a backtrace from the canister when it panics.
     pub canister_backtrace: FlagStatus,
     /// If this flag is enabled, then the environment variables are supported.
@@ -136,7 +134,6 @@ impl FeatureFlags {
     const fn const_default() -> Self {
         Self {
             rate_limiting_of_debug_prints: FlagStatus::Enabled,
-            wasm64: FlagStatus::Enabled,
             canister_backtrace: FlagStatus::Enabled,
             environment_variables: FlagStatus::Disabled,
         }

--- a/rs/drun/src/main.rs
+++ b/rs/drun/src/main.rs
@@ -61,8 +61,7 @@ async fn drun_main() -> Result<(), String> {
         hypervisor_config.rate_limiting_of_heap_delta = FlagStatus::Disabled;
         hypervisor_config.rate_limiting_of_instructions = FlagStatus::Disabled;
         // For testing enhanced orthogonal persistence in Motoko,
-        // enable Wasm Memory64 and re-configure the main memory capacity.
-        hypervisor_config.embedders_config.feature_flags.wasm64 = FlagStatus::Enabled;
+        // re-configure the main memory capacity.
         hypervisor_config.embedders_config.max_wasm64_memory_size = MAIN_MEMORY_CAPACITY;
         // Disable trap backtrace in `drun` to have less implementation-specific test outputs.
         hypervisor_config

--- a/rs/embedders/benches/embedders_bench/src/lib.rs
+++ b/rs/embedders/benches/embedders_bench/src/lib.rs
@@ -56,7 +56,6 @@ fn initialize_execution_test(
         .with_slice_instruction_limit(LARGE_INSTRUCTION_LIMIT);
 
     if is_wasm64 {
-        test = test.with_wasm64();
         // Set memory size to 8 GiB for Wasm64.
         test = test.with_max_wasm64_memory_size(NumBytes::from(8 * 1024 * 1024 * 1024));
     }

--- a/rs/embedders/fuzz/src/compile.rs
+++ b/rs/embedders/fuzz/src/compile.rs
@@ -1,5 +1,6 @@
-use crate::ic_wasm::{generate_exports, ic_embedders_config, ic_wasm_config};
+use crate::ic_wasm::{generate_exports, ic_wasm_config};
 use arbitrary::{Arbitrary, Result, Unstructured};
+use ic_config::embedders::Config as EmbeddersConfig;
 use ic_embedders::{wasm_utils::compile, WasmtimeEmbedder};
 use ic_logger::replica_logger::no_op_logger;
 use ic_wasm_types::BinaryEncodedWasm;
@@ -10,7 +11,6 @@ use wasm_smith::{Config, MemoryOffsetChoices, Module};
 #[derive(Debug)]
 pub struct MaybeInvalidModule {
     pub module: Module,
-    pub memory64_enabled: bool,
 }
 
 const MAX_PARALLEL_EXECUTIONS: usize = 4;
@@ -18,9 +18,8 @@ const MAX_PARALLEL_EXECUTIONS: usize = 4;
 impl<'a> Arbitrary<'a> for MaybeInvalidModule {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let mut config = if u.ratio(1, 2)? {
-            let memory64_enabled = u.ratio(2, 3)?;
-            let mut config = ic_wasm_config(ic_embedders_config(memory64_enabled));
-            config.exports = generate_exports(ic_embedders_config(memory64_enabled), u)?;
+            let mut config = ic_wasm_config(EmbeddersConfig::default());
+            config.exports = generate_exports(EmbeddersConfig::default(), u)?;
             config.min_data_segments = 2;
             config.max_data_segments = 10;
             config
@@ -31,7 +30,6 @@ impl<'a> Arbitrary<'a> for MaybeInvalidModule {
         config.memory_offset_choices = MemoryOffsetChoices(40, 20, 40);
         Ok(MaybeInvalidModule {
             module: Module::new(config.clone(), u)?,
-            memory64_enabled: config.memory64_enabled,
         })
     }
 }
@@ -46,24 +44,21 @@ pub fn run_fuzzer(bytes: &[u8]) {
     // 33% - Wasm with arbitrary wasm-smith config + maybe invalid functions
     // 33% - IC compliant wasm + maybe invalid functions
 
-    // Only used w/ random bytes
-    let memory64_enabled = u.ratio(1, 2).unwrap_or(false);
-
     let wasm = if u.ratio(1, 3).unwrap_or(false)
         || bytes.len() < <MaybeInvalidModule as Arbitrary>::size_hint(0).0
     {
-        config = ic_embedders_config(memory64_enabled);
+        config = EmbeddersConfig::default();
         raw_wasm_bytes(bytes)
     } else {
         let data = <MaybeInvalidModule as Arbitrary>::arbitrary_take_rest(u);
 
         match data {
             Ok(data) => {
-                config = ic_embedders_config(data.memory64_enabled);
+                config = EmbeddersConfig::default();
                 data.module.to_bytes()
             }
             Err(_) => {
-                config = ic_embedders_config(memory64_enabled);
+                config = EmbeddersConfig::default();
                 raw_wasm_bytes(bytes)
             }
         }

--- a/rs/embedders/fuzz/src/ic_wasm.rs
+++ b/rs/embedders/fuzz/src/ic_wasm.rs
@@ -2,7 +2,6 @@ use crate::imports::{system_api_imports, SystemApiImportStore};
 use crate::special_int::SpecialInt;
 use arbitrary::{Arbitrary, Result, Unstructured};
 use ic_config::embedders::Config as EmbeddersConfig;
-use ic_config::flag_status::FlagStatus;
 use ic_embedders::wasm_utils::validation::{
     RESERVED_SYMBOLS, WASM_FUNCTION_SIZE_LIMIT, WASM_VALID_SYSTEM_FUNCTIONS,
 };
@@ -22,9 +21,9 @@ use wasmparser::*;
 
 lazy_static! {
     static ref SYSTEM_API_IMPORTS_WASM32: SystemApiImportStore =
-        system_api_imports(ic_embedders_config(false));
+        system_api_imports(EmbeddersConfig::default());
     static ref SYSTEM_API_IMPORTS_WASM64: SystemApiImportStore =
-        system_api_imports(ic_embedders_config(true));
+        system_api_imports(EmbeddersConfig::default());
 }
 
 const CANISTER_EXPORT_FUNCTION_PREFIX: &[&str] = &[
@@ -48,8 +47,7 @@ pub struct ICWasmModule {
 
 impl<'a> Arbitrary<'a> for ICWasmModule {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
-        let memory64_enabled = u.ratio(2, 3)?;
-        let embedder_config = ic_embedders_config(memory64_enabled);
+        let embedder_config = EmbeddersConfig::default();
         let exports = generate_exports(embedder_config.clone(), u)?;
         let mut config = ic_wasm_config(embedder_config);
         config.exports = exports;
@@ -249,7 +247,6 @@ impl ICWasmModule {
 }
 
 pub fn ic_wasm_config(embedder_config: EmbeddersConfig) -> Config {
-    let memory64_enabled = embedder_config.feature_flags.wasm64 == FlagStatus::Enabled;
     Config {
         min_funcs: 10,
         min_exports: 10,
@@ -266,30 +263,16 @@ pub fn ic_wasm_config(embedder_config: EmbeddersConfig) -> Config {
         bulk_memory_enabled: true,
         reference_types_enabled: true,
         simd_enabled: true,
-        memory64_enabled,
+        memory64_enabled: true,
 
         threads_enabled: false,
         relaxed_simd_enabled: false,
         canonicalize_nans: false,
         exceptions_enabled: false,
 
-        available_imports: Some(if memory64_enabled {
-            SYSTEM_API_IMPORTS_WASM64.module.to_vec()
-        } else {
-            SYSTEM_API_IMPORTS_WASM32.module.to_vec()
-        }),
+        available_imports: Some(SYSTEM_API_IMPORTS_WASM64.module.to_vec()),
         ..Default::default()
     }
-}
-
-pub fn ic_embedders_config(memory64_enabled: bool) -> EmbeddersConfig {
-    let mut config = EmbeddersConfig::default();
-    if memory64_enabled {
-        config.feature_flags.wasm64 = FlagStatus::Enabled;
-    } else {
-        config.feature_flags.wasm64 = FlagStatus::Disabled;
-    }
-    config
 }
 
 fn get_persisted_global(g: wasmparser::Global) -> Option<Global> {

--- a/rs/embedders/fuzz/src/imports.rs
+++ b/rs/embedders/fuzz/src/imports.rs
@@ -4,7 +4,6 @@ use crate::wasm_executor::{
     get_execution_parameters, get_system_state, MAX_SUBNET_AVAILABLE_MEMORY,
 };
 use ic_config::embedders::Config as EmbeddersConfig;
-use ic_config::flag_status::FlagStatus;
 use ic_embedders::{
     wasm_utils::instrumentation::WasmMemoryType,
     wasmtime_embedder::{
@@ -64,26 +63,13 @@ pub(crate) fn system_api_imports(config: EmbeddersConfig) -> SystemApiImportStor
     );
     let mut linker: wasmtime::Linker<StoreData> = wasmtime::Linker::new(&engine);
 
-    match config.feature_flags.wasm64 {
-        FlagStatus::Enabled => {
-            linker::syscalls::<u64>(
-                &mut linker,
-                config.feature_flags,
-                config.stable_memory_dirty_page_limit,
-                config.stable_memory_accessed_page_limit,
-                WasmMemoryType::Wasm64,
-            );
-        }
-        FlagStatus::Disabled => {
-            linker::syscalls::<u32>(
-                &mut linker,
-                config.feature_flags,
-                config.stable_memory_dirty_page_limit,
-                config.stable_memory_accessed_page_limit,
-                WasmMemoryType::Wasm32,
-            );
-        }
-    }
+    linker::syscalls::<u64>(
+        &mut linker,
+        config.feature_flags,
+        config.stable_memory_dirty_page_limit,
+        config.stable_memory_accessed_page_limit,
+        WasmMemoryType::Wasm64,
+    );
 
     // to avoid store move
     let mut system_api_imports: Vec<(&str, &str, wasmtime::Func)> = linker

--- a/rs/embedders/fuzz/src/wasm_executor.rs
+++ b/rs/embedders/fuzz/src/wasm_executor.rs
@@ -1,7 +1,7 @@
-use crate::ic_wasm::{ic_embedders_config, ICWasmModule};
+use crate::ic_wasm::ICWasmModule;
 use ic_config::{
-    execution_environment::Config as HypervisorConfig, flag_status::FlagStatus,
-    subnet_config::SchedulerConfig,
+    embedders::Config as EmbeddersConfig, execution_environment::Config as HypervisorConfig,
+    flag_status::FlagStatus, subnet_config::SchedulerConfig,
 };
 use ic_cycles_account_manager::ResourceSaturation;
 use ic_embedders::{
@@ -59,7 +59,7 @@ pub fn run_fuzzer(module: ICWasmModule) {
     let wasm_methods: BTreeSet<WasmMethod> = module.exported_functions;
 
     let log = no_op_logger();
-    let embedder_config = ic_embedders_config(module.config.memory64_enabled);
+    let embedder_config = EmbeddersConfig::default();
     let metrics_registry = MetricsRegistry::new();
     let fd_factory = Arc::new(TestPageAllocatorFileDescriptorImpl::new());
 

--- a/rs/embedders/fuzz/src/wasmtime.rs
+++ b/rs/embedders/fuzz/src/wasmtime.rs
@@ -1,4 +1,5 @@
-use crate::ic_wasm::{ic_embedders_config, ICWasmModule};
+use crate::ic_wasm::ICWasmModule;
+use ic_config::embedders::Config as EmbeddersConfig;
 use ic_test_utilities_embedders::WasmtimeInstanceBuilder;
 use ic_types::methods::{FuncRef, WasmMethod};
 use libfuzzer_sys::Corpus;
@@ -9,7 +10,7 @@ pub fn run_fuzzer(module: ICWasmModule) -> Corpus {
     let wasm = module.module.to_bytes();
     let wasm_methods: BTreeSet<WasmMethod> = module.exported_functions;
 
-    let config = ic_embedders_config(module.config.memory64_enabled);
+    let config = EmbeddersConfig::default();
 
     let instance_result = WasmtimeInstanceBuilder::new()
         .with_wasm(wasm)

--- a/rs/embedders/fuzz/src/ws2wasm.rs
+++ b/rs/embedders/fuzz/src/ws2wasm.rs
@@ -1,5 +1,6 @@
 use arbitrary::{Arbitrary, Unstructured};
 use clap::Parser;
+use ic_config::embedders::Config as EmbeddersConfig;
 use ic_logger::replica_logger::no_op_logger;
 use std::fs::File;
 use std::io;
@@ -7,7 +8,7 @@ use std::io::prelude::*;
 use std::io::BufReader;
 use std::path::PathBuf;
 use std::sync::Arc;
-use wasm_fuzzers::ic_wasm::{ic_embedders_config, ICWasmModule};
+use wasm_fuzzers::ic_wasm::ICWasmModule;
 use wasmprinter::print_bytes;
 
 use ic_embedders::{
@@ -56,7 +57,7 @@ fn main() -> io::Result<()> {
 
     let instrumentation = CommandLineArgs::parse().inst;
     if instrumentation {
-        let config = ic_embedders_config(module.config.memory64_enabled);
+        let config = EmbeddersConfig::default();
         let decoded = decode_wasm(config.wasm_max_size, Arc::new(wasm))
             .expect("failed to decode canister module");
         let embedder = WasmtimeEmbedder::new(config, no_op_logger());

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -1616,11 +1616,7 @@ pub fn wasmtime_validation_config(embedders_config: &EmbeddersConfig) -> wasmtim
     config.wasm_bulk_memory(true);
     config.wasm_function_references(false);
     config.wasm_gc(false);
-    if embedders_config.feature_flags.wasm64 == ic_config::flag_status::FlagStatus::Enabled {
-        config.wasm_memory64(true);
-    } else {
-        config.wasm_memory64(false);
-    }
+    config.wasm_memory64(true);
     // Wasm multi-memory feature is disabled during validation,
     // but enabled during execution for the Wasm-native stable memory
     // implementation.

--- a/rs/embedders/tests/validation.rs
+++ b/rs/embedders/tests/validation.rs
@@ -1391,16 +1391,8 @@ fn wasm_with_multiple_code_sections_is_invalid() {
 #[test]
 fn test_wasm64_initial_wasm_memory_size_validation() {
     use crate::WasmValidationError::InitialWasm64MemoryTooLarge;
-    use ic_config::embedders::FeatureFlags;
-    use ic_config::flag_status::FlagStatus;
 
-    let embedders_config = EmbeddersConfig {
-        feature_flags: FeatureFlags {
-            wasm64: FlagStatus::Enabled,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
+    let embedders_config = EmbeddersConfig::default();
     let allowed_wasm_memory_size_in_pages =
         embedders_config.max_wasm64_memory_size.get() / WASM_PAGE_SIZE as u64;
     let declared_wasm_memory_size_in_pages = allowed_wasm_memory_size_in_pages + 10;
@@ -1423,16 +1415,7 @@ fn test_wasm64_initial_wasm_memory_size_validation() {
 
 #[test]
 fn test_validate_table64() {
-    use ic_config::embedders::FeatureFlags;
-    use ic_config::flag_status::FlagStatus;
-
-    let embedders_config = EmbeddersConfig {
-        feature_flags: FeatureFlags {
-            wasm64: FlagStatus::Enabled,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
+    let embedders_config = EmbeddersConfig::default();
 
     let wasm = wat2wasm(
         r#"(module

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -1822,7 +1822,6 @@ fn wasm_debug_print_instructions_charging() {
     for (rate_limiting, subnet_type, expected_instructions) in test_cases {
         let mut config = Config::default();
         config.feature_flags.rate_limiting_of_debug_prints = rate_limiting;
-        config.feature_flags.wasm64 = FlagStatus::Enabled;
         let mut instance = WasmtimeInstanceBuilder::new()
             .with_config(config)
             .with_subnet_type(subnet_type)
@@ -1877,7 +1876,6 @@ fn wasm_canister_logging_instructions_charging() {
     for (message_len, expected_instructions) in test_cases {
         let mut config = Config::default();
         config.feature_flags.rate_limiting_of_debug_prints = FlagStatus::Enabled;
-        config.feature_flags.wasm64 = FlagStatus::Enabled;
         let mut instance = WasmtimeInstanceBuilder::new()
             .with_config(config)
             .with_subnet_type(SubnetType::Application)
@@ -1947,7 +1945,6 @@ fn wasm_logging_new_records_after_exceeding_log_size_limit() {
     // same for wasm64
     let mut config = Config::default();
     config.feature_flags.rate_limiting_of_debug_prints = FlagStatus::Enabled;
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
     let instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_subnet_type(SubnetType::Application)
@@ -1972,8 +1969,7 @@ fn wasm64_basic_test() {
         (memory (export "memory") i64 10)
     )"#;
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -1999,8 +1995,7 @@ fn memory_copy_test() {
         (memory (export "memory") 10)
     )"#;
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2025,8 +2020,7 @@ fn wasm64_memory_copy_test() {
         (memory (export "memory") i64 10)
     )"#;
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2052,8 +2046,7 @@ fn wasm64_memory_init_test() {
             (data (;0;) "\01\02\03\04")
     )"#;
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2080,8 +2073,7 @@ fn wasm64_handles_memory_grow_failure_test() {
         (memory (export "memory") i64 10)
     )"#;
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2225,8 +2217,7 @@ fn wasm64_import_system_api_functions() {
         (memory (export "memory") i64 10)
     )"#;
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2266,8 +2257,7 @@ fn wasm64_msg_caller_copy() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2336,8 +2326,7 @@ fn wasm64_msg_arg_data_copy() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2397,8 +2386,7 @@ fn wasm64_msg_method_name_copy() {
     let msg_name = "test".to_string();
     let api = ApiType::inspect_message(caller, msg_name.clone(), payload, UNIX_EPOCH);
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2467,8 +2455,7 @@ fn wasm64_msg_reply_data_append() {
         caller,
         call_context_test_id(13),
     );
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2518,8 +2505,7 @@ fn wasm64_msg_reject() {
         caller,
         call_context_test_id(13),
     );
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2570,8 +2556,7 @@ fn wasm64_reject_msg_copy() {
         NumInstructions::new(700),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2637,8 +2622,7 @@ fn wasm64_root_key() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2710,8 +2694,7 @@ fn wasm64_canister_self_copy() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2781,8 +2764,7 @@ fn wasm64_subnet_self_size() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2835,8 +2817,7 @@ fn wasm64_subnet_self_copy() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2909,8 +2890,7 @@ fn wasm64_trap() {
         user_test_id(24).get(),
         call_context_test_id(13),
     );
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -2951,8 +2931,7 @@ fn wasm64_canister_cycle_balance128() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -3017,8 +2996,7 @@ fn wasm64_canister_liquid_cycle_balance128() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -3092,8 +3070,7 @@ fn wasm64_msg_cycles_refunded128() {
         NumInstructions::new(700),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -3155,8 +3132,7 @@ fn wasm64_cycles_burn128() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)
@@ -3198,8 +3174,7 @@ fn large_wasm64_memory_allocation_test() {
     // This test checks if maximum memory size
     // is capped to the maximum allowed memory size in 64 bit mode.
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let max_heap_size_in_pages = config.max_wasm64_memory_size.get() / WASM_PAGE_SIZE as u64;
     let wat = format!(
         r#"
@@ -3280,10 +3255,11 @@ fn large_wasm64_stable_read_write_test() {
 
     let gb = 1024 * 1024 * 1024;
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
-    // Declare a large heap.
-    config.max_wasm64_memory_size = NumBytes::from(10 * gb);
+    let config = ic_config::embedders::Config {
+        // Declare a large heap.
+        max_wasm64_memory_size: NumBytes::from(10 * gb),
+        ..Default::default()
+    };
 
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
@@ -3359,8 +3335,7 @@ fn wasm64_saturate_fun_index() {
         call_context_test_id(13),
     );
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.wasm64 = FlagStatus::Enabled;
+    let config = ic_config::embedders::Config::default();
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_wat(wat)

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -1404,8 +1404,7 @@ mod tests {
         with_test_replica_logger(|log| {
             let wat = make_module64_wat_for_api_calls(TEST_NUM_PAGES);
             let wasm = wat2wasm(&wat).unwrap();
-            let mut config = EmbeddersConfig::default();
-            config.feature_flags.wasm64 = FlagStatus::Enabled;
+            let config = EmbeddersConfig::default();
             let embedder = WasmtimeEmbedder::new(config, log);
             let (embedder_cache, result) = compile(&embedder, &wasm);
             result.unwrap();

--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -2,7 +2,7 @@
 /// Common System API benchmark functions, types, constants.
 ///
 use criterion::{BatchSize, Criterion};
-use ic_config::embedders::{Config as EmbeddersConfig, FeatureFlags};
+use ic_config::embedders::Config as EmbeddersConfig;
 use ic_config::execution_environment::{
     Config, CANISTER_GUARANTEED_CALLBACK_QUOTA, SUBNET_CALLBACK_SOFT_LIMIT,
 };
@@ -254,16 +254,12 @@ where
         own_subnet_id,
         subnet_configs.cycles_account_manager_config,
     ));
-    let mut embedders_config = EmbeddersConfig {
-        feature_flags: FeatureFlags {
-            wasm64: FlagStatus::Enabled,
-            ..FeatureFlags::default()
-        },
+
+    let embedders_config = EmbeddersConfig {
+        // Set up larger heap, of 8GB for the Wasm64 feature.
+        max_wasm64_memory_size: NumBytes::from(8 * 1024 * 1024 * 1024),
         ..EmbeddersConfig::default()
     };
-
-    // Set up larger heap, of 8GB for the Wasm64 feature.
-    embedders_config.max_wasm64_memory_size = NumBytes::from(8 * 1024 * 1024 * 1024);
 
     let config = Config {
         embedders_config,

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
@@ -1,11 +1,13 @@
-use ic_config::execution_environment::Config as ExecutionConfig;
+use ic_config::{
+    embedders::Config as EmbeddersConfig, execution_environment::Config as ExecutionConfig,
+};
 use ic_management_canister_types_private::CanisterSettingsArgsBuilder;
 use ic_test_utilities_execution_environment::{ExecutionTest, ExecutionTestBuilder};
 use ic_types::{CanisterId, Cycles, NumBytes};
 
 use libfuzzer_sys::fuzz_target;
 use std::cell::RefCell;
-use wasm_fuzzers::ic_wasm::{ic_embedders_config, ICWasmModule};
+use wasm_fuzzers::ic_wasm::ICWasmModule;
 
 thread_local! {
     static ENV_32: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(false));
@@ -70,7 +72,7 @@ where
 // canister is reinstalled under the same canister_id.
 fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {
     let exec_config = ExecutionConfig {
-        embedders_config: ic_embedders_config(memory64_enabled),
+        embedders_config: EmbeddersConfig::default(),
         max_compilation_cache_size: NumBytes::new(10 * 1024 * 1024), // 10MiB
         ..Default::default()
     };

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
@@ -1,11 +1,13 @@
-use ic_config::execution_environment::Config as ExecutionConfig;
+use ic_config::{
+    embedders::Config as EmbeddersConfig, execution_environment::Config as ExecutionConfig,
+};
 use ic_management_canister_types_private::CanisterSettingsArgsBuilder;
 use ic_test_utilities_execution_environment::{ExecutionTest, ExecutionTestBuilder};
 use ic_types::{CanisterId, Cycles, NumBytes};
 
 use libfuzzer_sys::fuzz_target;
 use std::cell::RefCell;
-use wasm_fuzzers::ic_wasm::{ic_embedders_config, SystemApiModule};
+use wasm_fuzzers::ic_wasm::SystemApiModule;
 
 thread_local! {
     static ENV_32: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(false));
@@ -70,7 +72,7 @@ where
 // canister is reinstalled under the same canister_id.
 fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {
     let exec_config = ExecutionConfig {
-        embedders_config: ic_embedders_config(memory64_enabled),
+        embedders_config: EmbeddersConfig::default(),
         max_compilation_cache_size: NumBytes::new(10 * 1024 * 1024), // 10MiB
         ..Default::default()
     };

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -6181,7 +6181,7 @@ fn run_canister_in_wasm_mode(is_wasm64_mode: bool, execute_ingress: bool) -> (Cy
     "#
     );
 
-    let mut test = ExecutionTestBuilder::new().with_wasm64().build();
+    let mut test = ExecutionTestBuilder::new().build();
     let canister_id = test
         .canister_from_cycles_and_wat(DEFAULT_PROVISIONAL_BALANCE, canister_wat)
         .unwrap();

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -1339,8 +1339,7 @@ fn canister_with_memory_allocation_cannot_grow_wasm_memory_above_allocation() {
 #[test]
 fn canister_with_memory_allocation_cannot_grow_wasm_memory_above_allocation_wasm64() {
     let subnet_config = SubnetConfig::new(SubnetType::Application);
-    let mut embedders_config = ic_config::embedders::Config::default();
-    embedders_config.feature_flags.wasm64 = ic_config::flag_status::FlagStatus::Enabled;
+    let embedders_config = ic_config::embedders::Config::default();
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
         HypervisorConfig {

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -1825,7 +1825,7 @@ fn ic0_msg_reject_works() {
 
 #[test]
 fn wasm64_active_data_segments() {
-    let mut test = ExecutionTestBuilder::new().with_wasm64().build();
+    let mut test = ExecutionTestBuilder::new().build();
     let wat = r#"
         (module
             (import "ic0" "msg_reply" (func $msg_reply))
@@ -2944,7 +2944,7 @@ fn ic0_call_perform_enqueues_request() {
 
 #[test]
 fn wasm64_ic0_call_perform_enqueues_request() {
-    let mut test = ExecutionTestBuilder::new().with_wasm64().build();
+    let mut test = ExecutionTestBuilder::new().build();
     let wat = r#"
         (module
             (import "ic0" "call_new"
@@ -3463,7 +3463,7 @@ fn ic0_msg_cycles_available_works_for_calls() {
 
 #[test]
 fn wasm64_ic0_msg_cycles_available128_works_for_calls() {
-    let mut test = ExecutionTestBuilder::new().with_wasm64().build();
+    let mut test = ExecutionTestBuilder::new().build();
     let wat = r#"
         (module
             (import "ic0" "msg_cycles_available128" (func $msg_cycles_available128 (param i64)))
@@ -3491,7 +3491,7 @@ fn wasm64_ic0_msg_cycles_available128_works_for_calls() {
 
 #[test]
 fn wasm64_ic0_msg_cycles_accept128_works_for_calls() {
-    let mut test = ExecutionTestBuilder::new().with_wasm64().build();
+    let mut test = ExecutionTestBuilder::new().build();
     let wat = r#"
         (module
             (import "ic0" "msg_cycles_accept128"
@@ -8643,7 +8643,7 @@ fn ic0_mint_cycles_u64() {
 }
 
 fn check_correct_execution_state(is_wasm64: bool) {
-    let mut test = ExecutionTestBuilder::new().with_wasm64().build();
+    let mut test = ExecutionTestBuilder::new().build();
     let memory_size = if is_wasm64 { "i64" } else { "" };
     let wat = format!(
         r#"

--- a/rs/pocket_ic_server/src/nonmainnet_features.rs
+++ b/rs/pocket_ic_server/src/nonmainnet_features.rs
@@ -14,7 +14,6 @@ pub fn hypervisor_config(canister_sandboxing: bool) -> HypervisorConfig {
         embedders_config: EmbeddersConfig {
             feature_flags: FeatureFlags {
                 rate_limiting_of_debug_prints: FlagStatus::Disabled,
-                wasm64: FlagStatus::Enabled,
                 canister_backtrace: FlagStatus::Enabled,
                 environment_variables: FlagStatus::Enabled,
             },

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2200,11 +2200,6 @@ impl ExecutionTestBuilder {
         self
     }
 
-    pub fn with_wasm64(mut self) -> Self {
-        self.execution_config.embedders_config.feature_flags.wasm64 = FlagStatus::Enabled;
-        self
-    }
-
     pub fn with_max_wasm_memory_size(mut self, wasm_memory_size: NumBytes) -> Self {
         self.execution_config.embedders_config.max_wasm_memory_size = wasm_memory_size;
         self


### PR DESCRIPTION
The wasm64 feature has been enabled for a long time and all tests etc already expect it to be enabled. Removing the flag as it's not needed anymore.

The bulk of changes are in tests/fuzzers to remove enabling the flag in the config.