### PR TITLE
test: bump timeout of the //rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test

### DIFF
--- a/rs/tests/consensus/upgrade/upgrade_downgrade_nns_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_nns_subnet_test.rs
@@ -20,8 +20,8 @@ use ic_types::Height;
 const DKG_INTERVAL: u64 = 9;
 const ALLOWED_FAILURES: usize = 1;
 const SUBNET_SIZE: usize = 3 * ALLOWED_FAILURES + 1; // 4 nodes
-const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(25 * 60);
-const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(35 * 60);
+const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 fn setup(env: TestEnv) {
     let subnet_under_test = Subnet::new(SubnetType::System)


### PR DESCRIPTION
The `//rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test` frequently runs into the 20min timeout of the test task. It seems it's not stuck at the point of timeout but just taking a long time so before investigating further let's bump the timeout with an extra 10 minutes to see if that fixes the flakiness.