### PR TITLE
chore(BOUN-1456): ic-boundary routing table improvements

### DIFF
--- a/rs/boundary_node/ic_boundary/src/bouncer/exec.rs
+++ b/rs/boundary_node/ic_boundary/src/bouncer/exec.rs
@@ -3,7 +3,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use anyhow::{anyhow, Context, Error};
+use anyhow::{bail, Context, Error};
 use nftables::schema::Nftables;
 
 const SUDO: &str = "/usr/bin/sudo";
@@ -71,10 +71,10 @@ impl Execute for Executor {
         // Wait for the process to finish
         let result = process.wait_with_output()?;
         if !result.status.success() {
-            return Err(anyhow!(
+            bail!(
                 "Command terminated with non-zero exit code: {}",
                 result.status
-            ));
+            );
         }
 
         let stdout = String::from_utf8(result.stdout)?;

--- a/rs/boundary_node/ic_boundary/src/bouncer/firewall.rs
+++ b/rs/boundary_node/ic_boundary/src/bouncer/firewall.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, net::IpAddr, str::FromStr, sync::Arc};
 
-use anyhow::{anyhow, Context, Error};
+use anyhow::{bail, Context, Error};
 use async_trait::async_trait;
 use nftables::{
     batch::Batch,
@@ -80,7 +80,7 @@ impl Set {
             .context("failed to deserialize stdout as Nftables struct")?;
 
         if nft.objects.len() != 2 {
-            return Err(anyhow!("Unexpected nft object len"));
+            bail!("Unexpected nft object len");
         }
 
         if let schema::NfObject::ListObject(NfListObject::Set(v)) = &nft.objects[1] {
@@ -97,7 +97,7 @@ impl Set {
             return Ok(set);
         }
 
-        Err(anyhow!("Unexpected output from nft"))
+        bail!("Unexpected output from nft")
     }
 
     // Converts a list of ips into an NFTables object

--- a/rs/boundary_node/ic_boundary/src/bouncer/mod.rs
+++ b/rs/boundary_node/ic_boundary/src/bouncer/mod.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{anyhow, Context, Error};
+use anyhow::{bail, Context, Error};
 use async_trait::async_trait;
 use axum::{body::Body, extract::State, middleware::Next, response::IntoResponse};
 use dashmap::DashMap;
@@ -72,11 +72,11 @@ impl Bouncer {
         registry: &Registry,
     ) -> Result<Self, Error> {
         if rate_per_second == 0 {
-            return Err(anyhow!("rate_per_second should be > 0"));
+            bail!("rate_per_second should be > 0");
         }
 
         if burst_size < rate_per_second {
-            return Err(anyhow!("burst_size should be >= rate_per_second"));
+            bail!("burst_size should be >= rate_per_second");
         }
 
         let metrics = Metrics {

--- a/rs/boundary_node/ic_boundary/src/check.rs
+++ b/rs/boundary_node/ic_boundary/src/check.rs
@@ -794,7 +794,7 @@ pub(crate) mod test {
     #[tokio::test]
     async fn test_check_some_unhealthy() -> Result<(), Error> {
         let routes = Arc::new(ArcSwapOption::empty());
-        let persister = Arc::new(Persister::new(Arc::clone(&routes)));
+        let persister = Arc::new(Persister::new(routes.clone()));
 
         let mut checker = MockCheck::new();
         checker
@@ -858,7 +858,7 @@ pub(crate) mod test {
     #[tokio::test]
     async fn test_check_nodes_gone() -> Result<(), Error> {
         let routes = Arc::new(ArcSwapOption::empty());
-        let persister = Arc::new(Persister::new(Arc::clone(&routes)));
+        let persister = Arc::new(Persister::new(routes.clone()));
 
         let mut checker = MockCheck::new();
         checker
@@ -950,7 +950,7 @@ pub(crate) mod test {
         checker.expect_check().returning(|_| Ok(check_result(1000)));
 
         let routes = Arc::new(ArcSwapOption::empty());
-        let persister = Arc::new(Persister::new(Arc::clone(&routes)));
+        let persister = Arc::new(Persister::new(routes.clone()));
 
         let (channel_send, channel_recv) = watch::channel(None);
         let runner = Runner::new(

--- a/rs/boundary_node/ic_boundary/src/check.rs
+++ b/rs/boundary_node/ic_boundary/src/check.rs
@@ -712,9 +712,8 @@ pub(crate) mod test {
 
     impl Routes {
         // Check if given node exists in the lookup table
-        // It's O(n) and used only in tests
         pub fn node_exists(&self, node_id: Principal) -> bool {
-            for s in self.subnets.iter() {
+            for s in self.subnet_map.values() {
                 for n in s.nodes.iter() {
                     if n.id == node_id {
                         return true;
@@ -841,7 +840,7 @@ pub(crate) mod test {
             if routes.load().is_some() {
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
         let rt = routes.load_full().unwrap();
@@ -978,13 +977,13 @@ pub(crate) mod test {
             if routes.load().is_some() {
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
         let rt = routes.load_full().unwrap();
         assert_eq!(rt.node_count, snapshot.nodes.len() as u32);
         for (i, j) in [(0, 1), (1, 0)].iter() {
-            let mut nodes_left = rt.subnets[*i].nodes.clone();
+            let mut nodes_left = rt.routes[*i].subnet.nodes.clone();
             let mut nodes_right = snapshot.subnets[*j].nodes.clone();
             nodes_left.sort_by_key(|n| n.id);
             nodes_right.sort_by_key(|n| n.id);

--- a/rs/boundary_node/ic_boundary/src/dns.rs
+++ b/rs/boundary_node/ic_boundary/src/dns.rs
@@ -75,11 +75,10 @@ mod test {
         let (reg, nodes, _) = create_fake_registry_client(4, 1, None);
         let reg = Arc::new(reg);
         let snapshot = Arc::new(ArcSwapOption::empty());
-        let dns_resolver = DnsResolver::new(Arc::clone(&snapshot));
+        let dns_resolver = DnsResolver::new(snapshot.clone());
 
         let (channel_send, _) = tokio::sync::watch::channel(None);
-        let snapshotter =
-            Snapshotter::new(Arc::clone(&snapshot), channel_send, reg, Duration::ZERO);
+        let snapshotter = Snapshotter::new(snapshot.clone(), channel_send, reg, Duration::ZERO);
         snapshotter.snapshot()?;
 
         // Check that resolved node's IPs match expected ones

--- a/rs/boundary_node/ic_boundary/src/http/handlers.rs
+++ b/rs/boundary_node/ic_boundary/src/http/handlers.rs
@@ -278,7 +278,8 @@ mod test {
     use tokio_tungstenite::tungstenite;
 
     use super::*;
-    use crate::{persist::RouteSubnet, routes::test::test_route_subnet};
+    use crate::persist::test::generate_test_subnets;
+    use crate::snapshot::Subnet;
     use std::future::IntoFuture;
     use std::net::{Ipv4Addr, SocketAddr};
 
@@ -288,14 +289,11 @@ mod test {
         fn lookup_subnet_by_canister_id(
             &self,
             _id: &CanisterId,
-        ) -> Result<Arc<RouteSubnet>, ErrorCause> {
-            Ok(Arc::new(test_route_subnet(1)))
+        ) -> Result<Arc<Subnet>, ErrorCause> {
+            Ok(Arc::new(generate_test_subnets(0)[0].clone()))
         }
 
-        fn lookup_subnet_by_id(
-            &self,
-            _id: &SubnetId,
-        ) -> Result<Arc<crate::persist::RouteSubnet>, ErrorCause> {
+        fn lookup_subnet_by_id(&self, _id: &SubnetId) -> Result<Arc<Subnet>, ErrorCause> {
             Err(ErrorCause::NoRoutingTable)
         }
     }

--- a/rs/boundary_node/ic_boundary/src/http/middleware/process.rs
+++ b/rs/boundary_node/ic_boundary/src/http/middleware/process.rs
@@ -13,9 +13,8 @@ use crate::{
     core::{decoder_config, MAX_REQUEST_BODY_SIZE},
     errors::{ApiError, ErrorCause},
     http::middleware::retry::RetryResult,
-    persist::RouteSubnet,
     routes::{HttpRequest, RequestContext},
-    snapshot::Node,
+    snapshot::{Node, Subnet},
 };
 
 const METHOD_HTTP: &str = "http_request";
@@ -160,7 +159,7 @@ pub async fn postprocess_response(request: Request, next: Next) -> impl IntoResp
         }
     }
 
-    if let Some(v) = response.extensions().get::<Arc<RouteSubnet>>().cloned() {
+    if let Some(v) = response.extensions().get::<Arc<Subnet>>().cloned() {
         response.headers_mut().insert(
             X_IC_SUBNET_ID,
             HeaderValue::from_maybe_shared(Bytes::from(v.id.to_string())).unwrap(),

--- a/rs/boundary_node/ic_boundary/src/http/middleware/retry.rs
+++ b/rs/boundary_node/ic_boundary/src/http/middleware/retry.rs
@@ -270,7 +270,7 @@ mod test {
 
         // Check update call retried
         let mut app = Router::new()
-            .route("/", post(handler).with_state(Arc::clone(&state)))
+            .route("/", post(handler).with_state(state.clone()))
             .layer(middleware::from_fn_with_state(
                 RetryParams {
                     retry_count: 3,

--- a/rs/boundary_node/ic_boundary/src/http/middleware/retry.rs
+++ b/rs/boundary_node/ic_boundary/src/http/middleware/retry.rs
@@ -11,9 +11,8 @@ use http::StatusCode;
 
 use crate::{
     errors::{ApiError, ErrorCause},
-    persist::RouteSubnet,
     routes::RequestContext,
-    snapshot::Node,
+    snapshot::{Node, Subnet},
 };
 
 #[derive(Clone)]
@@ -56,7 +55,7 @@ fn request_needs_retrying(response: &Response) -> bool {
 pub async fn retry_request(
     State(params): State<RetryParams>,
     Extension(ctx): Extension<Arc<RequestContext>>,
-    Extension(subnet): Extension<Arc<RouteSubnet>>,
+    Extension(subnet): Extension<Arc<Subnet>>,
     mut request: Request,
     next: Next,
 ) -> Result<impl IntoResponse, ApiError> {
@@ -139,7 +138,10 @@ mod test {
     use ic_types::CanisterId;
     use tower::Service;
 
-    use crate::routes::{test::test_route_subnet, RequestType};
+    use crate::{
+        persist::test::{generate_test_subnets, node},
+        routes::RequestType,
+    };
 
     struct TestState {
         failures: u8,
@@ -160,11 +162,17 @@ mod test {
 
         let ctx = Arc::new(ctx);
 
+        let mut subnet = generate_test_subnets(0)[0].clone();
+        subnet.nodes = vec![];
+        for i in 0..10 {
+            subnet.nodes.push(node(i, subnet.id))
+        }
+
         let mut req = Request::post("/").body(Body::from("foobar")).unwrap();
         req.extensions_mut().insert(ctx);
         req.extensions_mut()
             .insert(CanisterId::from_str("f7crg-kabae").unwrap());
-        req.extensions_mut().insert(Arc::new(test_route_subnet(10)));
+        req.extensions_mut().insert(Arc::new(subnet));
 
         req
     }
@@ -196,7 +204,7 @@ mod test {
         }));
 
         let mut app = Router::new()
-            .route("/", post(handler).with_state(Arc::clone(&state)))
+            .route("/", post(handler).with_state(state.clone()))
             .layer(middleware::from_fn_with_state(
                 RetryParams {
                     retry_count: 3,

--- a/rs/boundary_node/ic_boundary/src/http/mod.rs
+++ b/rs/boundary_node/ic_boundary/src/http/mod.rs
@@ -34,9 +34,7 @@ pub fn error_infer(e: &impl std::error::Error) -> ErrorCause {
     // Check if it's a Rustls error
     if let Some(e) = error_source::<RustlsError>(&e) {
         return match e {
-            RustlsError::InvalidCertificate(v) => {
-                ErrorCause::ReplicaTLSErrorCert(format!("{:?}", v))
-            }
+            RustlsError::InvalidCertificate(v) => ErrorCause::ReplicaTLSErrorCert(format!("{v:?}")),
             RustlsError::NoCertificatesPresented => {
                 ErrorCause::ReplicaTLSErrorCert("no certificate presented".into())
             }

--- a/rs/boundary_node/ic_boundary/src/metrics.rs
+++ b/rs/boundary_node/ic_boundary/src/metrics.rs
@@ -40,9 +40,8 @@ use tracing::info;
 use crate::{
     errors::ErrorCause,
     http::middleware::{cache::CacheState, geoip, retry::RetryResult},
-    persist::RouteSubnet,
     routes::{Health, RequestContext, RequestType},
-    snapshot::{Node, RegistrySnapshot},
+    snapshot::{Node, RegistrySnapshot, Subnet},
 };
 
 const KB: f64 = 1024.0;
@@ -496,11 +495,8 @@ pub async fn metrics_middleware(
     let response = next.run(request).await;
     let proc_duration = start_time.elapsed().as_secs_f64();
 
-    // in case subnet_id=None (i.e. for /api/v2/canister/... request), we get the target subnet_id from the RouteSubnet extension
-    let subnet_id = subnet_id.or(response
-        .extensions()
-        .get::<Arc<RouteSubnet>>()
-        .map(|x| x.id));
+    // in case subnet_id=None (i.e. for /api/v2/canister/... request), we get the target subnet_id from the Subnet extension
+    let subnet_id = subnet_id.or(response.extensions().get::<Arc<Subnet>>().map(|x| x.id));
     let subnet_id_str = subnet_id_str.or(subnet_id.map(|x| x.to_string()));
 
     // Extract extensions

--- a/rs/boundary_node/ic_boundary/src/metrics.rs
+++ b/rs/boundary_node/ic_boundary/src/metrics.rs
@@ -804,7 +804,7 @@ mod test {
         // - ftjgm-3pkam-aaaaa-aaaap-2ai
         // - fat3m-uhiam-aaaaa-aaaap-2ai
         let snapshot = Arc::new(generate_custom_registry_snapshot(1, 3, 0));
-        let mfs = remove_stale_metrics(Arc::clone(&snapshot), gen_metric_families());
+        let mfs = remove_stale_metrics(snapshot.clone(), gen_metric_families());
         assert_eq!(mfs.len(), 6);
 
         let mut only_node_id = 0;

--- a/rs/boundary_node/ic_boundary/src/persist.rs
+++ b/rs/boundary_node/ic_boundary/src/persist.rs
@@ -4,13 +4,11 @@ use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use candid::Principal;
 use ethnum::u256;
-use rand::seq::SliceRandom;
 use tracing::{debug, error};
 
 use crate::{
-    errors::ErrorCause,
     metrics::{MetricParamsPersist, WithMetricsPersist},
-    snapshot::{Node, Subnet},
+    snapshot::Subnet,
 };
 
 #[derive(Copy, Clone)]
@@ -27,16 +25,18 @@ pub enum PersistStatus {
     SkippedEmpty,
 }
 
-// Converts byte slice principal to a u256
-fn principal_bytes_to_u256(p: &[u8]) -> u256 {
-    if p.len() > 29 {
+// Converts principal to a u256
+pub fn principal_to_u256(p: &Principal) -> u256 {
+    let b = p.as_slice();
+
+    if b.len() > 29 {
         panic!("Principal length should be <30 bytes");
     }
 
     // Since Principal length can be anything in 0..29 range - prepend it with zeros to 32
-    let pad = 32 - p.len();
+    let pad = 32 - b.len();
     let mut padded: [u8; 32] = [0; 32];
-    padded[pad..32].copy_from_slice(p);
+    padded[pad..32].copy_from_slice(b);
 
     u256::from_be_bytes(padded)
 }
@@ -48,69 +48,36 @@ fn principal_bytes_to_u256(p: &[u8]) -> u256 {
 // But going u256 makes it future proof and according to spec
 #[derive(Eq, PartialEq, Debug)]
 pub struct RouteSubnet {
-    pub id: Principal,
+    pub subnet: Arc<Subnet>,
     pub range_start: u256,
     pub range_end: u256,
-    pub nodes: Vec<Arc<Node>>,
-}
-
-impl RouteSubnet {
-    pub fn pick_random_nodes(&self, n: usize) -> Result<Vec<Arc<Node>>, ErrorCause> {
-        let nodes = self
-            .nodes
-            .choose_multiple(&mut rand::thread_rng(), n)
-            .cloned()
-            .collect::<Vec<_>>();
-
-        if nodes.is_empty() {
-            return Err(ErrorCause::NoHealthyNodes);
-        }
-
-        Ok(nodes)
-    }
-
-    // max acceptable number of malicious nodes in a subnet
-    pub fn fault_tolerance_factor(&self) -> usize {
-        (self.nodes.len() - 1) / 3
-    }
-
-    pub fn pick_n_out_of_m_closest(
-        &self,
-        n: usize,
-        m: usize,
-    ) -> Result<Vec<Arc<Node>>, ErrorCause> {
-        // nodes should already be sorted by latency after persist() invocation
-        let m = std::cmp::min(m, self.nodes.len());
-        let nodes = &self.nodes[0..m];
-
-        let picked_nodes = nodes
-            .choose_multiple(&mut rand::thread_rng(), n)
-            .map(Arc::clone)
-            .collect::<Vec<_>>();
-
-        if picked_nodes.is_empty() {
-            return Err(ErrorCause::NoHealthyNodes);
-        }
-
-        Ok(picked_nodes)
-    }
 }
 
 #[derive(Eq, PartialEq, Debug)]
 pub struct Routes {
     pub node_count: u32,
-    // subnets should be sorted by `range_start` field for the binary search to work
-    pub subnets: Vec<Arc<RouteSubnet>>,
-    pub subnet_map: HashMap<Principal, Arc<RouteSubnet>>,
+    pub range_count: u32,
+
+    // This here should be sorted by `range_start` field for the binary search to work
+    pub routes: Vec<RouteSubnet>,
+    // Direct mapping from the Canister ID to the subnet for faster lookups
+    pub direct: HashMap<u256, Arc<Subnet>>,
+    // Mapping from Subnet ID to subnet
+    pub subnet_map: HashMap<Principal, Arc<Subnet>>,
 }
 
 impl Routes {
     // Look up the subnet by canister_id
-    pub fn lookup_by_canister_id(&self, canister_id: Principal) -> Option<Arc<RouteSubnet>> {
-        let canister_id_u256 = principal_bytes_to_u256(canister_id.as_slice());
+    pub fn lookup_by_canister_id(&self, canister_id: Principal) -> Option<Arc<Subnet>> {
+        let canister_id_u256 = principal_to_u256(&canister_id);
+
+        // First take a look in the direct table
+        if let Some(v) = self.direct.get(&canister_id_u256) {
+            return Some(v.clone());
+        }
 
         let idx = match self
-            .subnets
+            .routes
             .binary_search_by_key(&canister_id_u256, |x| x.range_start)
         {
             // Ok should happen rarely when canister_id equals lower bound of some subnet
@@ -131,16 +98,16 @@ impl Routes {
             }
         };
 
-        let subnet = self.subnets[idx].clone();
-        if canister_id_u256 < subnet.range_start || canister_id_u256 > subnet.range_end {
+        let route = &self.routes[idx];
+        if canister_id_u256 < route.range_start || canister_id_u256 > route.range_end {
             return None;
         }
 
-        Some(subnet)
+        Some(route.subnet.clone())
     }
 
     // Look up the subnet by subnet_id
-    pub fn lookup_by_id(&self, subnet_id: Principal) -> Option<Arc<RouteSubnet>> {
+    pub fn lookup_by_id(&self, subnet_id: Principal) -> Option<Arc<Subnet>> {
         self.subnet_map.get(&subnet_id).cloned()
     }
 }
@@ -168,49 +135,57 @@ impl Persist for Persister {
         }
 
         let node_count = subnets.iter().map(|x| x.nodes.len()).sum::<usize>() as u32;
+        let range_count = subnets.iter().map(|x| x.ranges.len()).sum::<usize>() as u32;
 
-        // Generate a list of subnets with a single canister range
-        // Can contain several entries with the same subnet ID
-        let mut rt_subnets = subnets
-            .into_iter()
-            .flat_map(|subnet| {
-                let mut nodes = subnet.nodes;
-                // Sort nodes by latency before publishing to avoid sorting on each retry_request() call.
-                nodes.sort_by(|a, b| a.avg_latency_secs.partial_cmp(&b.avg_latency_secs).unwrap());
+        let mut direct = HashMap::new();
+        let mut routes = Vec::new();
+        let mut subnet_map = HashMap::with_capacity(subnets.len());
 
-                subnet.ranges.into_iter().map(move |range| {
-                    Arc::new(RouteSubnet {
-                        id: subnet.id,
-                        range_start: principal_bytes_to_u256(range.start.as_slice()),
-                        range_end: principal_bytes_to_u256(range.end.as_slice()),
-                        nodes: nodes.clone(),
-                    })
-                })
-            })
-            .collect::<Vec<_>>();
+        for mut subnet in subnets {
+            // Sort nodes by an average latency before publishing
+            subnet
+                .nodes
+                .sort_by(|a, b| a.avg_latency_secs.partial_cmp(&b.avg_latency_secs).unwrap());
 
-        let subnet_map = rt_subnets
-            .iter()
-            .map(|subnet| (subnet.id, subnet.clone()))
-            .collect::<HashMap<_, _>>();
+            let subnet = Arc::new(subnet);
+            subnet_map.insert(subnet.id, subnet.clone());
+
+            for range in &subnet.ranges {
+                // For smaller ranges create a direct mapping from canister id to a subnet
+                if range.len() <= 5 {
+                    for canister_id in range.canisters() {
+                        direct.insert(canister_id, subnet.clone());
+                    }
+                } else {
+                    let route = RouteSubnet {
+                        subnet: subnet.clone(),
+                        range_start: principal_to_u256(&range.start),
+                        range_end: principal_to_u256(&range.end),
+                    };
+
+                    routes.push(route);
+                }
+            }
+        }
 
         // Sort subnets by range_start for the binary search to work in lookup()
-        rt_subnets.sort_by_key(|x| x.range_start);
+        routes.sort_by_key(|x| x.range_start);
 
-        let rt = Arc::new(Routes {
+        let rt: Arc<Routes> = Arc::new(Routes {
             node_count,
-            subnets: rt_subnets,
+            range_count,
+            routes,
+            direct,
             subnet_map,
         });
 
         // Load old subnet to get previous numbers
         let rt_old = self.published_routes.load_full();
-        let (ranges_old, nodes_old) =
-            rt_old.map_or((0, 0), |x| (x.subnets.len() as u32, x.node_count));
+        let (ranges_old, nodes_old) = rt_old.map_or((0, 0), |x| (x.range_count, x.node_count));
 
         let results = PersistResults {
             ranges_old,
-            ranges_new: rt.subnets.len() as u32,
+            ranges_new: rt.range_count,
             nodes_old,
             nodes_new: rt.node_count,
         };
@@ -254,7 +229,7 @@ impl<T: Persist> Persist for WithMetricsPersist<T> {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use super::{principal_bytes_to_u256, Persist, PersistStatus, Persister, RouteSubnet, Routes};
+    use super::*;
 
     use std::{
         collections::HashMap,
@@ -274,21 +249,12 @@ pub(crate) mod test {
         test_utils::valid_tls_certificate_and_validation_time,
     };
 
-    // Converts string principal to a u256
-    fn principal_to_u256(p: &str) -> Result<u256, Error> {
-        // Parse textual representation into a byte slice
-        let p = Principal::from_text(p)?;
-        let p = p.as_slice();
-
-        Ok(principal_bytes_to_u256(p))
-    }
-
     #[test]
-    fn test_principal_to_u256() -> Result<(), Error> {
-        assert!(principal_to_u256("foo-bar-baz").is_err());
-
+    fn test_principal_to_u256() {
         assert_eq!(
-            principal_to_u256("tg57h-slwo4-l4fga-d4zo2-4pc5z-lujes-uxqp3-pzchi-krm7r-sgvix-pae")?,
+            principal_to_u256(&principal!(
+                "tg57h-slwo4-l4fga-d4zo2-4pc5z-lujes-uxqp3-pzchi-krm7r-sgvix-pae"
+            )),
             u256::from_be_bytes([
                 0x00, 0x00, 0x00, 0x76, 0x77, 0x17, 0xc2, 0x98, 0x03, 0xe6, 0x5d, 0xae, 0x3c, 0x5d,
                 0xca, 0xe8, 0x92, 0x4a, 0x97, 0x83, 0xf6, 0xfc, 0x88, 0xe8, 0x54, 0x59, 0xf8, 0xc8,
@@ -297,7 +263,9 @@ pub(crate) mod test {
         );
 
         assert_eq!(
-            principal_to_u256("iineg-fibai-bqibi-ga4ea-searc-ijrif-iwc4m-bsibb-eirsi-jjge4-ucs")?,
+            principal_to_u256(&principal!(
+                "iineg-fibai-bqibi-ga4ea-searc-ijrif-iwc4m-bsibb-eirsi-jjge4-ucs"
+            )),
             u256::from_be_bytes([
                 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11,
                 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
@@ -306,15 +274,13 @@ pub(crate) mod test {
         );
 
         assert_eq!(
-            principal_to_u256("xtqug-aqaae-bagba-faydq-q")?,
+            principal_to_u256(&principal!("xtqug-aqaae-bagba-faydq-q")),
             u256::from_be_bytes([
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04,
                 0x05, 0x06, 0x07, 0x08
             ])
         );
-
-        Ok(())
     }
 
     pub fn node(i: u64, subnet_id: Principal) -> Arc<Node> {
@@ -380,10 +346,17 @@ pub(crate) mod test {
         let subnet3 = Subnet {
             id: subnet_id_3,
             subnet_type: SubnetType::Application,
-            ranges: vec![CanisterRange {
-                start: principal!("zdpgc-saqaa-aacai"),
-                end: principal!("fij4j-bi777-7qcai"),
-            }],
+            ranges: vec![
+                CanisterRange {
+                    start: principal!("zdpgc-saqaa-aacai"),
+                    end: principal!("fij4j-bi777-7qcai"),
+                },
+                // Range with 5 canisters that should go into direct table
+                CanisterRange {
+                    start: Principal::from_slice(&[0x01]),
+                    end: Principal::from_slice(&[0x05]),
+                },
+            ],
             nodes: vec![node3.clone()],
             replica_version: "7742d96ddd30aa6b607c9d2d4093a7b714f5b25b".to_string(),
         };
@@ -392,64 +365,58 @@ pub(crate) mod test {
     }
 
     pub fn generate_test_routes(offset: u64) -> Routes {
-        let subnet_id_1 =
-            principal!("tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe");
-        let subnet_id_2 =
-            principal!("uzr34-akd3s-xrdag-3ql62-ocgoh-ld2ao-tamcv-54e7j-krwgb-2gm4z-oqe");
-        let subnet_id_3 =
-            principal!("snjp4-xlbw4-mnbog-ddwy6-6ckfd-2w5a2-eipqo-7l436-pxqkh-l6fuv-vae");
-
-        let subnet1 = RouteSubnet {
-            id: subnet_id_1,
-            range_start: principal_to_u256("f7crg-kabae").unwrap(),
-            range_end: principal_to_u256("sxiki-5ygae-aq").unwrap(),
-            nodes: vec![node(1 + offset, subnet_id_1)],
-        };
-
-        let subnet2 = RouteSubnet {
-            id: subnet_id_2,
-            range_start: principal_to_u256("sqjm4-qahae-aq").unwrap(),
-            range_end: principal_to_u256("sqjm4-qahae-aq").unwrap(),
-            nodes: vec![node(2 + offset, subnet_id_2)],
-        };
-
-        let subnet3 = RouteSubnet {
-            id: subnet_id_1,
-            range_start: principal_to_u256("t5his-7iiae-aq").unwrap(),
-            range_end: principal_to_u256("jlzvg-byp77-7qcai").unwrap(),
-            nodes: vec![node(1 + offset, subnet_id_1)],
-        };
-
-        let subnet4 = RouteSubnet {
-            id: subnet_id_3,
-            range_start: principal_to_u256("zdpgc-saqaa-aacai").unwrap(),
-            range_end: principal_to_u256("fij4j-bi777-7qcai").unwrap(),
-            nodes: vec![node(3 + offset, subnet_id_3)],
-        };
-
-        let subnet5 = RouteSubnet {
-            id: subnet_id_2,
-            range_start: principal_to_u256("6l3jn-7icca-aaaai-b").unwrap(),
-            range_end: principal_to_u256("ca5tg-macd7-776ai-b").unwrap(),
-            nodes: vec![node(2 + offset, subnet_id_2)],
-        };
-
-        let subnets = vec![
-            Arc::new(subnet1),
-            Arc::new(subnet2),
-            Arc::new(subnet3),
-            Arc::new(subnet4),
-            Arc::new(subnet5),
-        ];
+        let subnets = generate_test_subnets(offset)
+            .into_iter()
+            .map(Arc::new)
+            .collect::<Vec<_>>();
 
         let subnet_map = subnets
             .iter()
-            .map(|subnet| (subnet.id, subnet.clone()))
+            .map(|x| (x.id, x.clone()))
             .collect::<HashMap<_, _>>();
+
+        let route1 = RouteSubnet {
+            subnet: subnets[0].clone(),
+            range_start: principal_to_u256(&principal!("f7crg-kabae")),
+            range_end: principal_to_u256(&principal!("sxiki-5ygae-aq")),
+        };
+
+        let route2 = RouteSubnet {
+            subnet: subnets[0].clone(),
+            range_start: principal_to_u256(&principal!("t5his-7iiae-aq")),
+            range_end: principal_to_u256(&principal!("jlzvg-byp77-7qcai")),
+        };
+
+        let route3 = RouteSubnet {
+            subnet: subnets[2].clone(),
+            range_start: principal_to_u256(&principal!("zdpgc-saqaa-aacai")),
+            range_end: principal_to_u256(&principal!("fij4j-bi777-7qcai")),
+        };
+
+        let route4 = RouteSubnet {
+            subnet: subnets[1].clone(),
+            range_start: principal_to_u256(&principal!("6l3jn-7icca-aaaai-b")),
+            range_end: principal_to_u256(&principal!("ca5tg-macd7-776ai-b")),
+        };
+
+        let routes = vec![route1, route2, route3, route4];
+        let mut direct = HashMap::new();
+        direct.insert(
+            principal_to_u256(&principal!("sqjm4-qahae-aq")),
+            subnets[1].clone(),
+        );
+        for i in 1..=5 {
+            direct.insert(
+                principal_to_u256(&Principal::from_slice(&[i])),
+                subnets[2].clone(),
+            );
+        }
 
         Routes {
             node_count: 3,
-            subnets,
+            range_count: 6,
+            routes,
+            direct,
             subnet_map,
         }
     }
@@ -546,6 +513,25 @@ pub(crate) mod test {
                 .to_string(),
             "uzr34-akd3s-xrdag-3ql62-ocgoh-ld2ao-tamcv-54e7j-krwgb-2gm4z-oqe"
         );
+
+        // Test direct lookups
+        assert_eq!(
+            r.lookup_by_canister_id(principal!("sqjm4-qahae-aq"))
+                .unwrap()
+                .id
+                .to_string(),
+            "uzr34-akd3s-xrdag-3ql62-ocgoh-ld2ao-tamcv-54e7j-krwgb-2gm4z-oqe"
+        );
+
+        for i in 1..=5 {
+            assert_eq!(
+                r.lookup_by_canister_id(Principal::from_slice(&[i]))
+                    .unwrap()
+                    .id
+                    .to_string(),
+                "snjp4-xlbw4-mnbog-ddwy6-6ckfd-2w5a2-eipqo-7l436-pxqkh-l6fuv-vae"
+            );
+        }
 
         // Test failure
         assert!(r

--- a/rs/boundary_node/ic_boundary/src/persist.rs
+++ b/rs/boundary_node/ic_boundary/src/persist.rs
@@ -41,13 +41,15 @@ pub fn principal_to_u256(p: &Principal) -> u256 {
     u256::from_be_bytes(padded)
 }
 
-// Principals are 2^232 max so we can use the u256 type to efficiently store them
-// Under the hood u256 is using two u128
-// This is more efficient than lexographically sorted hexadecimal strings as done in JS router
-// Currently the largest canister_id range is somewhere around 2^40 - so probably using one u128 would work for a long time
-// But going u256 makes it future proof and according to spec
+/// Route from a canister id range to a subnet.
+///
+/// Principals can be up to 2^232 long, so we can use the u256 type to efficiently store them.
+/// Under the hood u256 is using two u128, this is more efficient than lexographically sorted hexadecimal strings as was done in JS router.
+///
+/// Currently the largest canister id is somewhere around 2^40 - so probably using one u128 would work for a long time,
+/// but going u256 makes it future proof and according to spec.
 #[derive(Eq, PartialEq, Debug)]
-pub struct RouteSubnet {
+pub struct Route {
     pub subnet: Arc<Subnet>,
     pub range_start: u256,
     pub range_end: u256,
@@ -58,8 +60,8 @@ pub struct Routes {
     pub node_count: u32,
     pub range_count: u32,
 
-    // This here should be sorted by `range_start` field for the binary search to work
-    pub routes: Vec<RouteSubnet>,
+    // Routes should be sorted by `range_start` field for the binary search to work
+    pub routes: Vec<Route>,
     // Direct mapping from the Canister ID to the subnet for faster lookups
     pub direct: HashMap<u256, Arc<Subnet>>,
     // Mapping from Subnet ID to subnet
@@ -157,7 +159,7 @@ impl Persist for Persister {
                         direct.insert(canister_id, subnet.clone());
                     }
                 } else {
-                    let route = RouteSubnet {
+                    let route = Route {
                         subnet: subnet.clone(),
                         range_start: principal_to_u256(&range.start),
                         range_end: principal_to_u256(&range.end),
@@ -375,25 +377,25 @@ pub(crate) mod test {
             .map(|x| (x.id, x.clone()))
             .collect::<HashMap<_, _>>();
 
-        let route1 = RouteSubnet {
+        let route1 = Route {
             subnet: subnets[0].clone(),
             range_start: principal_to_u256(&principal!("f7crg-kabae")),
             range_end: principal_to_u256(&principal!("sxiki-5ygae-aq")),
         };
 
-        let route2 = RouteSubnet {
+        let route2 = Route {
             subnet: subnets[0].clone(),
             range_start: principal_to_u256(&principal!("t5his-7iiae-aq")),
             range_end: principal_to_u256(&principal!("jlzvg-byp77-7qcai")),
         };
 
-        let route3 = RouteSubnet {
+        let route3 = Route {
             subnet: subnets[2].clone(),
             range_start: principal_to_u256(&principal!("zdpgc-saqaa-aacai")),
             range_end: principal_to_u256(&principal!("fij4j-bi777-7qcai")),
         };
 
-        let route4 = RouteSubnet {
+        let route4 = Route {
             subnet: subnets[1].clone(),
             range_start: principal_to_u256(&principal!("6l3jn-7icca-aaaai-b")),
             range_end: principal_to_u256(&principal!("ca5tg-macd7-776ai-b")),

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/fetcher.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/fetcher.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
-use anyhow::{anyhow, Context as _, Error};
+use anyhow::{anyhow, bail, Context as _, Error};
 use async_trait::async_trait;
 use candid::{Decode, Encode};
 use ic_agent::{export::Principal, Agent};
@@ -55,7 +55,7 @@ impl FetchesConfig for CanisterConfigFetcherQuery {
             .map_err(|e| anyhow!("failed to fetch config from the canister: {e:#}"))?;
 
         if response.is_empty() {
-            Err(anyhow!("got empty response from the canister"))
+            bail!("got empty response from the canister")
         } else {
             Ok(response)
         }
@@ -76,7 +76,7 @@ impl FetchesConfig for CanisterConfigFetcherUpdate {
             .map_err(|e| anyhow!("failed to fetch config from the canister: {e:#}"))?;
 
         if response.is_empty() {
-            Err(anyhow!("got empty response from the canister"))
+            bail!("got empty response from the canister")
         } else {
             Ok(response)
         }
@@ -99,17 +99,15 @@ impl FetchesRules for CanisterFetcher {
             .map_err(|e| anyhow!("failed to get config: {e:?}"))?;
 
         if response.config.schema_version != SCHEMA_VERSION {
-            return Err(anyhow!(
+            bail!(
                 "incorrect schema version (got {}, expected {})",
                 response.config.schema_version,
                 SCHEMA_VERSION
-            ));
+            );
         }
 
         if response.config.is_redacted {
-            return Err(anyhow!(
-                "got a redacted response, probably authentication is incorrect"
-            ));
+            bail!("got a redacted response, probably authentication is incorrect");
         }
 
         let rules = response
@@ -118,11 +116,7 @@ impl FetchesRules for CanisterFetcher {
             .into_iter()
             .map(|x| -> Result<RateLimitRule, Error> {
                 let Some(raw) = x.rule_raw else {
-                    return Err(anyhow!(
-                        "rule with id {} ({:?}) is None",
-                        x.rule_id,
-                        x.description
-                    ));
+                    bail!("rule with id {} ({:?}) is None", x.rule_id, x.description);
                 };
 
                 let rule = RateLimitRule::from_bytes_yaml(&raw)

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
@@ -501,6 +501,7 @@ pub async fn middleware(
 #[cfg(test)]
 mod test {
     use super::*;
+    use anyhow::bail;
     use ic_bn_lib::principal;
     use indoc::indoc;
     use std::str::FromStr;
@@ -512,7 +513,7 @@ mod test {
     #[async_trait]
     impl FetchesRules for BrokenFetcher {
         async fn fetch_rules(&self) -> Result<Vec<RateLimitRule>, Error> {
-            Err(anyhow::anyhow!("boo"))
+            bail!("boo")
         }
     }
 

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/generic.rs
@@ -45,9 +45,8 @@ use super::{
 
 use crate::{
     errors::{ErrorCause, RateLimitCause},
-    persist::RouteSubnet,
     routes::{RequestContext, RequestType},
-    snapshot::RegistrySnapshot,
+    snapshot::{RegistrySnapshot, Subnet},
 };
 
 // Converts between different request types
@@ -468,7 +467,7 @@ impl Run for GenericLimiter {
 pub async fn middleware(
     State(state): State<Arc<GenericLimiter>>,
     Extension(ctx): Extension<Arc<RequestContext>>,
-    Extension(subnet): Extension<Arc<RouteSubnet>>,
+    Extension(subnet): Extension<Arc<Subnet>>,
     Extension(conn_info): Extension<Arc<ConnInfo>>,
     request: Request<Body>,
     next: Next,

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/mod.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/mod.rs
@@ -1,6 +1,6 @@
 use std::{net::IpAddr, sync::Arc};
 
-use anyhow::anyhow;
+use anyhow::bail;
 use axum::Router;
 use candid::Principal;
 use http::request::Request;
@@ -23,7 +23,7 @@ impl TryFrom<u32> for RateLimit {
     type Error = anyhow::Error;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         if value == 0 {
-            Err(anyhow!("rate limit cannot be 0"))
+            bail!("rate limit cannot be 0")
         } else {
             Ok(RateLimit {
                 requests_per_second: value,

--- a/rs/boundary_node/ic_boundary/src/rate_limiting/mod.rs
+++ b/rs/boundary_node/ic_boundary/src/rate_limiting/mod.rs
@@ -13,7 +13,7 @@ use tower_governor::{
     GovernorLayer,
 };
 
-use crate::persist::RouteSubnet;
+use crate::snapshot::Subnet;
 
 pub struct RateLimit {
     requests_per_second: u32, // requests per second allowed
@@ -42,7 +42,7 @@ impl KeyExtractor for SubnetKeyExtractor {
         // This should always work, because we extract the subnet id after preprocess_request puts it there.
         Ok(req
             .extensions()
-            .get::<Arc<RouteSubnet>>()
+            .get::<Arc<Subnet>>()
             .ok_or(GovernorError::UnableToExtractKey)?
             .id)
     }
@@ -127,7 +127,7 @@ mod test {
     use tower::Service;
 
     use crate::{
-        errors::ApiError, routes::test::test_route_subnet_with_id, test_utils::setup_test_router,
+        errors::ApiError, persist::test::generate_test_subnets, test_utils::setup_test_router,
     };
 
     async fn dummy_call(_request: Request<Body>) -> Result<impl IntoResponse, ApiError> {
@@ -144,10 +144,11 @@ mod test {
             .unwrap()
             .to_vec();
         let subnet_id = String::from_utf8(body_vec.clone()).unwrap();
+        let mut subnet = generate_test_subnets(0)[0].clone();
+        subnet.id = principal!(subnet_id);
+
         let mut request = Request::from_parts(parts, axum::body::Body::from(body_vec));
-        request
-            .extensions_mut()
-            .insert(Arc::new(test_route_subnet_with_id(subnet_id, 0)));
+        request.extensions_mut().insert(Arc::new(subnet));
         let resp = next.run(request).await;
         Ok(resp)
     }

--- a/rs/boundary_node/ic_boundary/src/routes.rs
+++ b/rs/boundary_node/ic_boundary/src/routes.rs
@@ -22,8 +22,8 @@ use crate::{
     core::ANONYMOUS_PRINCIPAL,
     errors::{ApiError, ErrorCause},
     http::error_infer,
-    persist::{RouteSubnet, Routes},
-    snapshot::RegistrySnapshot,
+    persist::Routes,
+    snapshot::{RegistrySnapshot, Subnet},
 };
 
 #[derive(Debug, Clone, PartialEq, Hash, CandidType, Deserialize)]
@@ -102,9 +102,8 @@ pub trait Proxy: Sync + Send {
 }
 
 pub trait Lookup: Sync + Send {
-    fn lookup_subnet_by_canister_id(&self, id: &CanisterId)
-        -> Result<Arc<RouteSubnet>, ErrorCause>;
-    fn lookup_subnet_by_id(&self, id: &SubnetId) -> Result<Arc<RouteSubnet>, ErrorCause>;
+    fn lookup_subnet_by_canister_id(&self, id: &CanisterId) -> Result<Arc<Subnet>, ErrorCause>;
+    fn lookup_subnet_by_id(&self, id: &SubnetId) -> Result<Arc<Subnet>, ErrorCause>;
 }
 
 pub trait Health: Sync + Send {
@@ -143,7 +142,7 @@ impl Lookup for ProxyRouter {
     fn lookup_subnet_by_canister_id(
         &self,
         canister_id: &CanisterId,
-    ) -> Result<Arc<RouteSubnet>, ErrorCause> {
+    ) -> Result<Arc<Subnet>, ErrorCause> {
         let subnet = self
             .routing_table
             .load_full()
@@ -154,7 +153,7 @@ impl Lookup for ProxyRouter {
         Ok(subnet)
     }
 
-    fn lookup_subnet_by_id(&self, subnet_id: &SubnetId) -> Result<Arc<RouteSubnet>, ErrorCause> {
+    fn lookup_subnet_by_id(&self, subnet_id: &SubnetId) -> Result<Arc<Subnet>, ErrorCause> {
         let subnet = self
             .routing_table
             .load_full()
@@ -240,7 +239,7 @@ pub async fn lookup_subnet(
     };
 
     // Inject subnet into request
-    request.extensions_mut().insert(Arc::clone(&subnet));
+    request.extensions_mut().insert(subnet.clone());
 
     // Pass request to the next processor
     let mut response = next.run(request).await;
@@ -259,7 +258,6 @@ pub(crate) mod test {
 
     use anyhow::Error;
     use axum::{body::Body, http::Request, routing::method_routing::get, Router};
-    use ethnum::u256;
     use http::{
         header::{HeaderName, HeaderValue, CONTENT_TYPE, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS},
         StatusCode,
@@ -285,46 +283,17 @@ pub(crate) mod test {
             handlers::{health, status},
             PATH_HEALTH, PATH_STATUS,
         },
-        persist::{test::node, Persist, Persister},
-        snapshot::{test::test_registry_snapshot, Node},
+        persist::{Persist, Persister},
+        snapshot::test::test_registry_snapshot,
         test_utils::{setup_test_router, TestHttpClient},
     };
 
-    pub fn test_node(id: u64) -> Arc<Node> {
-        node(id, principal!("f7crg-kabae"))
-    }
-
-    pub fn test_route_subnet_with_id(id: String, n: usize) -> RouteSubnet {
-        let mut nodes = Vec::new();
-
-        for i in 0..n {
-            nodes.push(test_node(i as u64));
-        }
-
-        // "casting integer literal to `u32` is unnecessary"
-        // fck clippy
-        let zero = 0u32;
-
-        RouteSubnet {
-            id: Principal::from_text(id).unwrap(),
-            range_start: u256::from(zero),
-            range_end: u256::from(zero),
-            nodes,
-        }
-    }
-
-    pub fn test_route_subnet(n: usize) -> RouteSubnet {
-        test_route_subnet_with_id("f7crg-kabae".into(), n)
-    }
-
     fn assert_header(headers: &http::HeaderMap, name: HeaderName, expected_value: &str) {
-        assert!(headers.contains_key(&name), "Header {} is missing", name);
+        assert!(headers.contains_key(&name), "Header {name} is missing");
         assert_eq!(
             headers.get(&name).unwrap(),
             &HeaderValue::from_str(expected_value).unwrap(),
-            "Header {} does not match expected value: {}",
-            name,
-            expected_value,
+            "Header {name} does not match expected value: {expected_value}"
         );
     }
 

--- a/rs/boundary_node/ic_boundary/src/snapshot.rs
+++ b/rs/boundary_node/ic_boundary/src/snapshot.rs
@@ -647,8 +647,7 @@ pub(crate) mod test {
         let reg = Arc::new(reg);
 
         let (channel_send, _) = watch::channel(None);
-        let snapshotter =
-            Snapshotter::new(Arc::clone(&snapshot), channel_send, reg, Duration::ZERO);
+        let snapshotter = Snapshotter::new(snapshot.clone(), channel_send, reg, Duration::ZERO);
         snapshotter.snapshot().unwrap();
 
         (

--- a/rs/boundary_node/ic_boundary/src/tls_verify.rs
+++ b/rs/boundary_node/ic_boundary/src/tls_verify.rs
@@ -242,9 +242,8 @@ mod test {
         let (reg, _, _) = create_fake_registry_client(1, 1, Some(node_id));
         let reg = Arc::new(reg);
         let (channel_send, _) = tokio::sync::watch::channel(None);
-        let snapshotter =
-            Snapshotter::new(Arc::clone(&snapshot), channel_send, reg, Duration::ZERO);
-        let verifier = TlsVerifier::new(Arc::clone(&snapshot));
+        let snapshotter = Snapshotter::new(snapshot.clone(), channel_send, reg, Duration::ZERO);
+        let verifier = TlsVerifier::new(snapshot.clone());
         snapshotter.snapshot()?;
 
         let snapshot = snapshot.load_full().unwrap();


### PR DESCRIPTION
* Split the table into two parts:
  - Canister ranges with a length of 5 and shorter (this is hardcoded for now) are expanded into a direct canister ID to subnet mapping in the hash table
  - The rest will go into a sorted array and will be looked up using a binary search as before
  - The lookups consult the hash table first and then do a binary search if not found
 * Refactor the table itself to return `Arc<Subnet>` directly instead of `RouteSubnet` that was redundant. `RouteSubnet` was simplified and renamed to `Route`.