### PR TITLE
perf: Replace `RoutingTable::route` by `NetworkTopology::route`

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
@@ -45,7 +45,6 @@ fn route_canister_id(
     network_topology: &NetworkTopology,
 ) -> Result<PrincipalId, ResolveDestinationError> {
     network_topology
-        .routing_table
         .route(canister_id.get())
         .map(|subnet_id| subnet_id.get())
         .ok_or(ResolveDestinationError::SubnetNotFound(canister_id, method))

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1284,12 +1284,7 @@ impl CanisterManager {
             return Err(CanisterManagerError::CanisterAlreadyExists(new_canister_id));
         }
 
-        if state
-            .metadata
-            .network_topology
-            .routing_table
-            .route(specified_id)
-            == Some(state.metadata.own_subnet_id)
+        if state.metadata.network_topology.route(specified_id) == Some(state.metadata.own_subnet_id)
         {
             Ok(new_canister_id)
         } else {

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -3290,7 +3290,7 @@ impl ExecutionEnvironment {
 
         let topology = &state.metadata.network_topology;
         // If the request isn't from the NNS, then we need to charge for it.
-        let source_subnet = topology.routing_table.route(request.sender.get());
+        let source_subnet = topology.route(request.sender.get());
         if source_subnet != Some(state.metadata.network_topology.nns_subnet_id) {
             let cost_schedule = state.get_own_cost_schedule();
             let signature_fee = self.calculate_signature_fee(&args, subnet_size, cost_schedule);

--- a/rs/messaging/src/routing/stream_builder.rs
+++ b/rs/messaging/src/routing/stream_builder.rs
@@ -305,10 +305,8 @@ impl StreamBuilderImpl {
         };
 
         let mut streams = state.take_streams();
-        let routing_table = state.routing_table();
-        let subnet_types: BTreeMap<_, _> = state
-            .metadata
-            .network_topology
+        let network_topology = state.metadata.network_topology.clone();
+        let subnet_types: BTreeMap<_, _> = network_topology
             .subnets
             .iter()
             .map(|(subnet_id, topology)| (*subnet_id, topology.subnet_type))
@@ -342,7 +340,7 @@ impl StreamBuilderImpl {
             }
             last_output_size = output_size;
 
-            match routing_table.route(msg.receiver().get()) {
+            match network_topology.route(msg.receiver().get()) {
                 // Destination subnet found.
                 Some(dst_subnet_id) => {
                     let dst_stream_entry = streams.entry(dst_subnet_id);

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -606,6 +606,11 @@ fn build_streams_with_messages_targeted_to_other_subnets() {
                 CanisterIdRange{ start: CanisterId::from(0), end: CanisterId::from(0xfff) } => REMOTE_SUBNET,
             },
         ).unwrap());
+        provided_state
+            .metadata
+            .network_topology
+            .subnets
+            .insert(REMOTE_SUBNET, Default::default());
 
         // Set up the provided_canister_states.
         let provided_canister_states = canister_states_with_outputs(msgs.clone());

--- a/rs/messaging/src/routing/stream_handler.rs
+++ b/rs/messaging/src/routing/stream_handler.rs
@@ -570,7 +570,6 @@ impl StreamHandlerImpl {
             let new_destination = state
                 .metadata
                 .network_topology
-                .routing_table
                 .route(response.receiver().get())
                 .expect("Canister disappeared from registry. Registry in an inconsistent state.");
             info!(
@@ -827,11 +826,7 @@ impl StreamHandlerImpl {
         available_guaranteed_response_memory: &mut i64,
     ) -> InductionResult {
         // Subnet that should have received the message according to the routing table.
-        let receiver_host_subnet = state
-            .metadata
-            .network_topology
-            .routing_table
-            .route(msg.receiver().get());
+        let receiver_host_subnet = state.metadata.network_topology.route(msg.receiver().get());
 
         let payload_size = msg.payload_size_bytes().get();
         let msg_cycles = msg.cycles();
@@ -966,11 +961,7 @@ impl StreamHandlerImpl {
         state: &ReplicatedState,
     ) -> bool {
         // Remote subnet that should have sent the message according to the routing table.
-        let expected_subnet_id = state
-            .metadata
-            .network_topology
-            .routing_table
-            .route(msg.sender().get());
+        let expected_subnet_id = state.metadata.network_topology.route(msg.sender().get());
 
         match expected_subnet_id {
             // The actual originating subnet and the routing table entry for the sender are in agreement.
@@ -1030,11 +1021,7 @@ impl StreamHandlerImpl {
     ) -> bool {
         debug_assert_eq!(
             Some(actual_receiver_subnet_id),
-            state
-                .metadata
-                .network_topology
-                .routing_table
-                .route(msg.receiver().get())
+            state.metadata.network_topology.route(msg.receiver().get())
         );
 
         // Reroute if `msg.receiver()` is being migrated from `self.subnet_id` to

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -661,8 +661,11 @@ impl PocketIcSubnets {
     }
 
     fn route(&self, canister_id: CanisterId) -> Option<Arc<StateMachine>> {
-        let subnet_id = self.routing_table.route(canister_id.get());
-        subnet_id.map(|subnet_id| self.get(subnet_id).unwrap())
+        self.get(SubnetId::from(canister_id.get())).or_else(|| {
+            self.routing_table
+                .lookup_entry(canister_id)
+                .and_then(|(_, subnet_id)| self.get(subnet_id))
+        })
     }
 
     fn time(&self) -> SystemTime {

--- a/rs/registry/routing_table/src/lib.rs
+++ b/rs/registry/routing_table/src/lib.rs
@@ -1,7 +1,7 @@
 mod proto;
 
 use candid::CandidType;
-use ic_base_types::{CanisterId, CanisterIdError, PrincipalId, SubnetId};
+use ic_base_types::{CanisterId, CanisterIdError, SubnetId};
 use ic_protobuf::proxy::ProxyDecodeError;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
@@ -525,30 +525,6 @@ impl RoutingTable {
         }
 
         Ok(())
-    }
-
-    /// Returns the `SubnetId` that the given `principal_id` is assigned to or
-    /// `None` if an assignment cannot be found.
-    pub fn route(&self, principal_id: PrincipalId) -> Option<SubnetId> {
-        // Check if the given `principal_id` is a subnet.
-        // Note that the following assumes that all known subnets are in the routing
-        // table, even if they're empty (i.e. no canister exists on them). In the
-        // future, if this assumption does not hold, the list of existing
-        // subnets should be taken from the rest of the registry (which should
-        // be the absolute source of truth).
-        if let Some(subnet_id) = self.0.values().find(|x| x.get() == principal_id) {
-            return Some(*subnet_id);
-        }
-
-        // If the `principal_id` was not a subnet, it must be a `CanisterId` (otherwise
-        // we can't route to it).
-        match CanisterId::try_from(principal_id) {
-            Ok(canister_id) => {
-                lookup_in_ranges(&self.0, canister_id).map(|(_range, subnet_id)| subnet_id)
-            }
-            // Cannot route to any subnet as we couldn't convert to a `CanisterId`.
-            Err(_) => None,
-        }
     }
 
     /// Returns the corresponding `CanisterIdRange` and `SubnetId` that the given `canister_id` is assigned to

--- a/rs/registry/routing_table/src/tests.rs
+++ b/rs/registry/routing_table/src/tests.rs
@@ -2,13 +2,17 @@ use super::*;
 use assert_matches::assert_matches;
 use ic_test_utilities_types::ids::subnet_test_id;
 
+fn new_canister_id_range(start: u64, end: u64) -> CanisterIdRange {
+    CanisterIdRange {
+        start: CanisterId::from(start),
+        end: CanisterId::from(end),
+    }
+}
+
 fn new_canister_id_ranges(ranges: Vec<(u64, u64)>) -> CanisterIdRanges {
     let ranges = ranges
         .into_iter()
-        .map(|(start, end)| CanisterIdRange {
-            start: CanisterId::from(start),
-            end: CanisterId::from(end),
-        })
+        .map(|(start, end)| new_canister_id_range(start, end))
         .collect();
     CanisterIdRanges(ranges)
 }
@@ -16,10 +20,7 @@ fn new_canister_id_ranges(ranges: Vec<(u64, u64)>) -> CanisterIdRanges {
 fn new_routing_table(ranges: Vec<((u64, u64), u64)>) -> RoutingTable {
     let mut map = BTreeMap::new();
     for ((start, end), subnet_id) in ranges {
-        let range = CanisterIdRange {
-            start: CanisterId::from(start),
-            end: CanisterId::from(end),
-        };
+        let range = new_canister_id_range(start, end);
         map.insert(range, subnet_test_id(subnet_id));
     }
     RoutingTable(map)
@@ -28,10 +29,7 @@ fn new_routing_table(ranges: Vec<((u64, u64), u64)>) -> RoutingTable {
 fn new_canister_migrations(migrations: Vec<((u64, u64), Vec<u64>)>) -> CanisterMigrations {
     let mut map = BTreeMap::new();
     for ((start, end), subnet_ids) in migrations {
-        let range = CanisterIdRange {
-            start: CanisterId::from(start),
-            end: CanisterId::from(end),
-        };
+        let range = new_canister_id_range(start, end);
         map.insert(range, subnet_ids.into_iter().map(subnet_test_id).collect());
     }
     CanisterMigrations(map)
@@ -303,76 +301,69 @@ fn valid_routing_table() {
 
     assert_eq!(rt.well_formed(), Ok(()));
 
-    assert!(rt.route(CanisterId::from(0).get()).is_none());
-    assert!(rt.route(CanisterId::from(0x99).get()).is_none());
-    assert!(rt.route(CanisterId::from(0x100).get()) == Some(subnet_test_id(1)));
-    assert!(rt.route(CanisterId::from(0x10000).get()) == Some(subnet_test_id(1)));
-    assert!(rt.route(CanisterId::from(0x100ff).get()) == Some(subnet_test_id(1)));
-    assert!(rt.route(CanisterId::from(0x10100).get()).is_none());
-    assert!(rt.route(CanisterId::from(0x20500).get()) == Some(subnet_test_id(2)));
-    assert!(rt.route(CanisterId::from(0x50050).get()) == Some(subnet_test_id(1)));
-    assert!(rt.route(CanisterId::from(0x100000).get()).is_none());
-    assert!(rt.route(CanisterId::from(0x80500).get()) == Some(subnet_test_id(8)));
-    assert!(rt.route(CanisterId::from(0x8ffff).get()) == Some(subnet_test_id(8)));
-    assert!(rt.route(CanisterId::from(0x90000).get()) == Some(subnet_test_id(9)));
-    assert!(rt.route(CanisterId::from(0xffffffffffffffff).get()) == Some(subnet_test_id(0xf)));
+    let range1 = new_canister_id_range(0x100, 0x100ff);
+    let range2 = new_canister_id_range(0x20000, 0x2ffff);
+    let range3 = new_canister_id_range(0x50000, 0x50fff);
+    let range4 = new_canister_id_range(0x80000, 0x8ffff);
+    let range5 = new_canister_id_range(0x90000, 0xfffff);
+    let range6 = new_canister_id_range(0x1000000000000000, 0xffffffffffffffff);
 
-    assert_eq!(rt.ranges(subnet_test_id(1)).well_formed(), Ok(()));
-    assert!(
-        rt.ranges(subnet_test_id(1)).0
-            == new_canister_id_ranges(vec![(0x100, 0x100ff), (0x50000, 0x50fff)]).0
+    assert!(rt.lookup_entry(CanisterId::from(0)).is_none());
+    assert!(rt.lookup_entry(CanisterId::from(0x99)).is_none());
+    assert_eq!(
+        rt.lookup_entry(CanisterId::from(0x100)),
+        Some((range1, subnet_test_id(1)))
     );
-}
-
-#[test]
-fn route_when_principal_corresponds_to_subnet() {
-    // Valid routing table
-    let rt = new_routing_table(
-        [
-            ((0x100, 0x100ff), 1),
-            ((0x20000, 0x2ffff), 2),
-            ((0x50000, 0x50fff), 1),
-            ((0x80000, 0x8ffff), 8),
-            ((0x90000, 0xfffff), 9),
-            ((0x1000000000000000, 0xffffffffffffffff), 0xf),
-        ]
-        .to_vec(),
+    assert_eq!(
+        rt.lookup_entry(CanisterId::from(0x10000)),
+        Some((range1, subnet_test_id(1)))
     );
-
-    assert_eq!(rt.well_formed(), Ok(()));
-
-    // Existing subnets.
-    let subnet_id1 = subnet_test_id(1);
-    let subnet_id8 = subnet_test_id(8);
-
-    // Non existing subnets
-    let subnet_id5 = subnet_test_id(5);
-    let subnet_id12 = subnet_test_id(12);
-
-    assert_eq!(rt.route(subnet_id1.get()), Some(subnet_id1));
-    assert_eq!(rt.route(subnet_id8.get()), Some(subnet_id8));
-    assert_eq!(rt.route(subnet_id5.get()), None);
-    assert_eq!(rt.route(subnet_id12.get()), None);
+    assert_eq!(
+        rt.lookup_entry(CanisterId::from(0x100ff)),
+        Some((range1, subnet_test_id(1)))
+    );
+    assert!(rt.lookup_entry(CanisterId::from(0x10100)).is_none());
+    assert_eq!(
+        rt.lookup_entry(CanisterId::from(0x20500)),
+        Some((range2, subnet_test_id(2)))
+    );
+    assert_eq!(
+        rt.lookup_entry(CanisterId::from(0x50050)),
+        Some((range3, subnet_test_id(1)))
+    );
+    assert!(rt.lookup_entry(CanisterId::from(0x100000)).is_none());
+    assert_eq!(
+        rt.lookup_entry(CanisterId::from(0x80500)),
+        Some((range4, subnet_test_id(8)))
+    );
+    assert_eq!(
+        rt.lookup_entry(CanisterId::from(0x8ffff)),
+        Some((range4, subnet_test_id(8)))
+    );
+    assert_eq!(
+        rt.lookup_entry(CanisterId::from(0x90000)),
+        Some((range5, subnet_test_id(9)))
+    );
+    assert_eq!(
+        rt.lookup_entry(CanisterId::from(0xffffffffffffffff)),
+        Some((range6, subnet_test_id(0xf)))
+    );
 }
 
 #[test]
 fn can_insert_valid_route() {
     let mut rt = new_routing_table(vec![((1, 1000), 1)]);
     assert_eq!(rt.well_formed(), Ok(()));
-    assert_eq!(
-        rt.insert(
-            CanisterIdRange {
-                start: CanisterId::from(1001u64),
-                end: CanisterId::from(2000u64)
-            },
-            subnet_test_id(2)
-        ),
-        Ok(())
-    );
+    let new_range = CanisterIdRange {
+        start: CanisterId::from(1001u64),
+        end: CanisterId::from(2000u64),
+    };
+    let new_subnet_id = subnet_test_id(2);
+    assert_eq!(rt.insert(new_range.clone(), new_subnet_id), Ok(()));
     assert_eq!(rt.well_formed(), Ok(()));
     assert_eq!(
-        rt.route(CanisterId::from(1001u64).get()),
-        Some(subnet_test_id(2))
+        rt.lookup_entry(CanisterId::from(1001u64)),
+        Some((new_range, new_subnet_id))
     );
 }
 
@@ -380,19 +371,21 @@ fn can_insert_valid_route() {
 fn cannot_insert_invalid_route() {
     let mut rt = new_routing_table(vec![((1, 1000), 1)]);
     assert_eq!(rt.well_formed(), Ok(()));
+    let invalid_range = CanisterIdRange {
+        start: CanisterId::from(100u64),
+        end: CanisterId::from(2000u64),
+    };
     assert_matches!(
-        rt.insert(
-            CanisterIdRange {
-                start: CanisterId::from(100u64),
-                end: CanisterId::from(2000u64)
-            },
-            subnet_test_id(2)
-        ),
+        rt.insert(invalid_range, subnet_test_id(2)),
         Err(WellFormedError::RoutingTableNotDisjoint(_))
     );
+    let original_range = CanisterIdRange {
+        start: CanisterId::from(1u64),
+        end: CanisterId::from(1000u64),
+    };
     assert_eq!(
-        rt.route(CanisterId::from(101u64).get()),
-        Some(subnet_test_id(1))
+        rt.lookup_entry(CanisterId::from(101u64)),
+        Some((original_range, subnet_test_id(1)))
     );
     assert_eq!(rt.well_formed(), Ok(()));
 }
@@ -402,12 +395,18 @@ fn can_remove_subnet() {
     let mut rt = new_routing_table(vec![((1, 1000), 1), ((2000, 3000), 2)]);
     assert_eq!(rt.well_formed(), Ok(()));
     assert_eq!(
-        rt.route(CanisterId::from(100u64).get()),
-        Some(subnet_test_id(1))
+        rt.lookup_entry(CanisterId::from(100u64)),
+        Some((
+            CanisterIdRange {
+                start: CanisterId::from(1u64),
+                end: CanisterId::from(1000u64),
+            },
+            subnet_test_id(1)
+        ))
     );
     rt.remove_subnet(subnet_test_id(1));
     assert_eq!(rt.well_formed(), Ok(()));
-    assert_eq!(rt.route(CanisterId::from(100u64).get()), None);
+    assert_eq!(rt.lookup_entry(CanisterId::from(100u64)), None);
 }
 
 #[test]
@@ -434,17 +433,26 @@ fn can_reassign_ranges() {
 
             for i in 0u64..start {
                 assert_eq!(
-                    rt.route(CanisterId::from(i).into()),
-                    rt_copy.route(CanisterId::from(i).into())
+                    rt.lookup_entry(CanisterId::from(i).into()).map(|(_, s)| s),
+                    rt_copy
+                        .lookup_entry(CanisterId::from(i).into())
+                        .map(|(_, s)| s)
                 );
             }
             for i in start..=end {
-                assert_eq!(rt_copy.route(CanisterId::from(i).into()), Some(dst));
+                assert_eq!(
+                    rt_copy
+                        .lookup_entry(CanisterId::from(i).into())
+                        .map(|(_, s)| s),
+                    Some(dst)
+                );
             }
             for i in (end + 1)..=30u64 {
                 assert_eq!(
-                    rt.route(CanisterId::from(i).into()),
-                    rt_copy.route(CanisterId::from(i).into())
+                    rt.lookup_entry(CanisterId::from(i).into()).map(|(_, s)| s),
+                    rt_copy
+                        .lookup_entry(CanisterId::from(i).into())
+                        .map(|(_, s)| s)
                 );
             }
         }
@@ -474,8 +482,10 @@ fn can_optimize_routing_table() {
     assert_eq!(rt_optimized.ranges(subnet_test_id(1)).0.len(), 3);
     for i in 0..=30 {
         assert_eq!(
-            rt_optimized.route(CanisterId::from(i).into()),
-            rt.route(CanisterId::from(i).into())
+            rt_optimized
+                .lookup_entry(CanisterId::from(i))
+                .map(|(_, s)| s),
+            rt.lookup_entry(CanisterId::from(i)).map(|(_, s)| s)
         );
     }
 }

--- a/rs/registry/routing_table/src/tests.rs
+++ b/rs/registry/routing_table/src/tests.rs
@@ -359,7 +359,7 @@ fn can_insert_valid_route() {
         end: CanisterId::from(2000u64),
     };
     let new_subnet_id = subnet_test_id(2);
-    assert_eq!(rt.insert(new_range.clone(), new_subnet_id), Ok(()));
+    assert_eq!(rt.insert(new_range, new_subnet_id), Ok(()));
     assert_eq!(rt.well_formed(), Ok(()));
     assert_eq!(
         rt.lookup_entry(CanisterId::from(1001u64)),
@@ -433,26 +433,20 @@ fn can_reassign_ranges() {
 
             for i in 0u64..start {
                 assert_eq!(
-                    rt.lookup_entry(CanisterId::from(i).into()).map(|(_, s)| s),
-                    rt_copy
-                        .lookup_entry(CanisterId::from(i).into())
-                        .map(|(_, s)| s)
+                    rt.lookup_entry(CanisterId::from(i)).map(|(_, s)| s),
+                    rt_copy.lookup_entry(CanisterId::from(i)).map(|(_, s)| s)
                 );
             }
             for i in start..=end {
                 assert_eq!(
-                    rt_copy
-                        .lookup_entry(CanisterId::from(i).into())
-                        .map(|(_, s)| s),
+                    rt_copy.lookup_entry(CanisterId::from(i)).map(|(_, s)| s),
                     Some(dst)
                 );
             }
             for i in (end + 1)..=30u64 {
                 assert_eq!(
-                    rt.lookup_entry(CanisterId::from(i).into()).map(|(_, s)| s),
-                    rt_copy
-                        .lookup_entry(CanisterId::from(i).into())
-                        .map(|(_, s)| s)
+                    rt.lookup_entry(CanisterId::from(i)).map(|(_, s)| s),
+                    rt_copy.lookup_entry(CanisterId::from(i)).map(|(_, s)| s)
                 );
             }
         }

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -907,11 +907,7 @@ impl ReplicatedState {
     /// Returns the `SubnetId` hosting the given `principal_id` (canister or
     /// subnet).
     pub fn find_subnet_id(&self, principal_id: PrincipalId) -> Result<SubnetId, UserError> {
-        let subnet_id = self
-            .metadata
-            .network_topology
-            .routing_table
-            .route(principal_id);
+        let subnet_id = self.metadata.network_topology.route(principal_id);
 
         match subnet_id {
             None => Err(UserError::new(
@@ -1399,8 +1395,12 @@ impl ReplicatedState {
         // Retain only canisters hosted by `own_subnet_id`.
         //
         // TODO: Validate that canisters are split across no more than 2 subnets.
-        canister_states
-            .retain(|canister_id, _| routing_table.route(canister_id.get()) == Some(subnet_id));
+        canister_states.retain(|canister_id, _| {
+            routing_table
+                .lookup_entry(*canister_id)
+                .map(|(_range, subnet_id)| subnet_id)
+                == Some(subnet_id)
+        });
 
         // All subnet messages (ingress and canister) only remain on subnet A' because:
         //

--- a/rs/state_manager/src/manifest/split.rs
+++ b/rs/state_manager/src/manifest/split.rs
@@ -80,7 +80,9 @@ pub fn split_manifest(
 
         if let Some(canister_id) = canister_id_from_path(path) {
             // Part of a canister state.
-            let subnet = routing_table.route(canister_id.get());
+            let subnet = routing_table
+                .lookup_entry(canister_id)
+                .map(|(_range, subnet_id)| subnet_id);
             if subnet == Some(subnet_a) {
                 // Retained on subnet A'.
                 manifest_a.append(file, chunks);


### PR DESCRIPTION
This commit removes `RoutingTable::route`, which was used to route messages to the correct subnet.

The difference to the still existing `RoutingTable::lookup_entry` was that `route` would additionally consider the case where the target is a subnet id instead of a canister id. However, previously this was implemented by scanning over all canister ranges and checking if the input occurs as the subnet id for any range. There are two issues with this, which this commit both solves:

1. As it's a linear scan, route was `O(n)`, where n is the number of ranges in the routing table. Currently `n` is small, but will grow with the upcoming canister migration feature.

2. There is a theoretical edge case of subnets with no ranges assigned to them. It was not possible to route to such a subnet.

This commit solves both problems by instead implementing `route` in the `NetworkTopology` struct. `NetworkTopology` contains both a `RoutingTable` and a `BTreeMap` of subnets. Instead of a linear scan, we now only need to do a quick lookup in the `BTreeMap`. Furthermore, subnets without any ranges will also be found this way.

This commit is somewhat large due to the necessary test changes. In production code, the switch is very simple.