### PR TITLE
chore: update rs/tests/run-p8s.sh and support --grafana-dashboards-dir

### DIFF
--- a/rs/tests/run-p8s.nix
+++ b/rs/tests/run-p8s.nix
@@ -2,9 +2,9 @@
 # See: https://dfinity.atlassian.net/browse/VER-1941
 let
   nixpkgs = builtins.fetchTarball {
-    name = "nixpkgs-release-24.05";
-    url = "https://github.com/nixos/nixpkgs/archive/9db4f92627fe77165cf6dbb1fbad1c869db93023.tar.gz";
-    sha256 = "sha256:17pc791yicjg56dw3yzqbmjq28k15kvw11lcpy632l09r1v5h30w";
+    name = "nixpkgs-release-25.05";
+    url = "https://github.com/nixos/nixpkgs/archive/a84e756ad67fa42311e2d22cbc8f566ee46a04fd.tar.gz";
+    sha256 = "sha256:0q04kkss7ayn9yng6qfg7pgdjc3vzl837s7xqiwypjr3f6x23s9q";
   };
   pkgs = import nixpkgs { };
 in

--- a/rs/tests/run-p8s.sh
+++ b/rs/tests/run-p8s.sh
@@ -9,9 +9,14 @@ set -euo pipefail
 function usage() {
     cat <<EOF
 Usage:
-  run-p8s.sh OPTIONS prometheus-data-dir.tar.zst
+  run-p8s.sh [--prometheus-port PROMETHEUS_PORT] [--grafana-port GRAFANA_PORT] [--grafana-dashboards-dir GRAFANA_DASHBOARDS_DIR] prometheus-data-dir.tar.zst
 
   Run a local prometheus and grafana on the data directory packaged in the specified tarball.
+
+  Tip: you're most likely running this script on your devenv. So to make the Grafana Web UI accessible on your laptop
+  use the following to forward its port to your devenv:
+
+      ssh devenv -L 3000:localhost:3000 -N
 
   OPTIONS:
 
@@ -28,6 +33,10 @@ Usage:
   --grafana-dashboards-dir GRAFANA_DASHBOARDS_DIR
 
     Provision Grafana dashboards from the specified GRAFANA_DASHBOARDS_DIR directory.
+
+    Tip: point it to your local clone of the k8s repo. I.e.:
+
+        --grafana-dashboards-dir ~/k8s/bases/apps/ic-dashboards/
 
   --help
 

--- a/rs/tests/run-p8s.sh
+++ b/rs/tests/run-p8s.sh
@@ -6,11 +6,6 @@
 
 set -euo pipefail
 
-grafana_dashboards_path=$(
-    cd "$(dirname ${BASH_SOURCE[0]})"
-    pwd -P
-)/dashboards
-
 function usage() {
     cat <<EOF
 Usage:
@@ -30,15 +25,9 @@ Usage:
     Let grafana listen on port GRAFANA_PORT.
     Defaults to 3000.
 
-  --dont-provision-grafana-dashboards
+  --grafana-dashboards-dir
 
-    By default the mainnet grafana dashboards from:
-
-      $grafana_dashboards_path
-
-    are automatically provisioned in the local grafana server.
-
-    This option disables that default behaviour.
+    Provision Grafana dashboards from the specified directory.
 
   --help
 
@@ -67,8 +56,8 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
-        --dont-provision-grafana-dashboards)
-            DONT_PROVISION_GRAFANA_DASHBOARDS="1"
+        --grafana-dashboards-dir)
+            GRAFANA_DASHBOARDS_DIR="$2"
             shift
             ;;
         *)
@@ -150,9 +139,9 @@ cat <<EOF >"$grafana_data_dir/datasources/datasource.yaml"
 }
 EOF
 
-if [ -z "${DONT_PROVISION_GRAFANA_DASHBOARDS:-}" ]; then
+if [ -n "${GRAFANA_DASHBOARDS_DIR:-}" ]; then
     provisioned_grafana_dashboards="$grafana_data_dir/dashboards/provisioned"
-    cp -r "$grafana_dashboards_path" "$provisioned_grafana_dashboards"
+    cp -r "$GRAFANA_DASHBOARDS_DIR" "$provisioned_grafana_dashboards"
     cat <<EOF >"$grafana_data_dir/dashboards/dashboard.yaml"
 {
     "apiVersion": 1,

--- a/rs/tests/run-p8s.sh
+++ b/rs/tests/run-p8s.sh
@@ -25,9 +25,9 @@ Usage:
     Let grafana listen on port GRAFANA_PORT.
     Defaults to 3000.
 
-  --grafana-dashboards-dir
+  --grafana-dashboards-dir GRAFANA_DASHBOARDS_DIR
 
-    Provision Grafana dashboards from the specified directory.
+    Provision Grafana dashboards from the specified GRAFANA_DASHBOARDS_DIR directory.
 
   --help
 

--- a/rs/tests/run-p8s.sh
+++ b/rs/tests/run-p8s.sh
@@ -124,7 +124,7 @@ cat <<EOF >"$grafana_data_dir/datasources/datasource.yaml"
     "apiVersion": 1,
     "datasources": [
         {
-            "name": "prometheus",
+            "name": "IC Metrics (cluster local)",
             "type": "prometheus",
             "uid": "000000001",
             "url": "http://127.0.0.1:$PROMETHEUS_PORT",


### PR DESCRIPTION
This commit makes sure the `rs/tests/run-p8s.sh` script works again.