### PR TITLE
feat(sns): Ensure extension canisters do not already run any Wasm module when its being registered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11031,6 +11031,7 @@ dependencies = [
  "canister-test",
  "cycles-minting-canister",
  "futures",
+ "hex",
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-error-types 0.2.0",

--- a/rs/nervous_system/agent/src/helpers/sns.rs
+++ b/rs/nervous_system/agent/src/helpers/sns.rs
@@ -17,7 +17,7 @@ use ic_sns_swap::{
 use icp_ledger::Tokens;
 use icrc_ledger_types::icrc1::{account::Account, transfer::TransferArg};
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum SnsProposalError {
     #[error("Error submitting proposal: {0}")]
     ProposalSubmissionError(ProposalSubmissionError),

--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -26,7 +26,7 @@ pub struct SubmittedProposal {
     pub proposal_id: ProposalId,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ProposalSubmissionError {
     #[error("SNS Governance returned an error: {0:?}")]
     GovernanceError(GovernanceError),

--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -35,6 +35,7 @@ BASE_DEPENDENCIES = [
     "@crate_index//:assert_matches",
     "@crate_index//:candid",
     "@crate_index//:futures",
+    "@crate_index//:hex",
     "@crate_index//:ic-management-canister-types",
     "@crate_index//:itertools",
     "@crate_index//:lazy_static",

--- a/rs/nervous_system/integration_tests/Cargo.toml
+++ b/rs/nervous_system/integration_tests/Cargo.toml
@@ -12,6 +12,7 @@ assert_matches = { workspace = true }
 candid = { workspace = true }
 cycles-minting-canister = { path = "../../nns/cmc" }
 futures = { workspace = true }
+hex = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
 ic-interfaces-registry = { path = "../../interfaces/registry" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }


### PR DESCRIPTION
This PR ensures that extension canisters do not already run any Wasm module when its being registered. This is closing a security gap.