### PR TITLE
feat(sns): Add extension_operations to list_topics

### DIFF
--- a/rs/sns/governance/api/src/topics.rs
+++ b/rs/sns/governance/api/src/topics.rs
@@ -28,6 +28,30 @@ pub enum Topic {
     TreasuryAssetManagement,
     CriticalDappOperations,
 }
+
+/// Types of extension operations
+#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq, Serialize)]
+pub enum ExtensionOperationType {
+    TreasuryManagerDeposit,
+    TreasuryManagerWithdraw,
+    Custom(String),
+}
+
+/// Specification for an extension operation
+#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq, Serialize)]
+pub struct ExtensionOperationSpec {
+    pub operation_type: Option<ExtensionOperationType>,
+    pub description: Option<String>,
+    pub extension_type: Option<ExtensionType>,
+    pub topic: Option<Topic>,
+}
+
+/// Types of extensions that can be registered
+#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq, Serialize)]
+pub enum ExtensionType {
+    TreasuryManager,
+}
+
 /// Each topic has some information associated with it. This information is for the benefit of the user but has
 /// no effect on the behavior of the SNS.
 #[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq, Serialize)]
@@ -37,6 +61,7 @@ pub struct TopicInfo {
     pub description: Option<String>,
     pub native_functions: Option<Vec<NervousSystemFunction>>,
     pub custom_functions: Option<Vec<NervousSystemFunction>>,
+    pub extension_operations: Option<Vec<ExtensionOperationSpec>>,
     pub is_critical: Option<bool>,
 }
 

--- a/rs/sns/governance/api/src/topics.rs
+++ b/rs/sns/governance/api/src/topics.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::pb::v1::NervousSystemFunction;
+use crate::pb::v1::{ExtensionOperationSpec, NervousSystemFunction};
 
 /// Functions are categorized into topics.
 /// (As a reminder, a function is either a built-in proposal type, or a generic function that has been added via an
@@ -27,29 +27,6 @@ pub enum Topic {
     Governance,
     TreasuryAssetManagement,
     CriticalDappOperations,
-}
-
-/// Types of extension operations
-#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq, Serialize)]
-pub enum ExtensionOperationType {
-    TreasuryManagerDeposit,
-    TreasuryManagerWithdraw,
-    Custom(String),
-}
-
-/// Specification for an extension operation
-#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq, Serialize)]
-pub struct ExtensionOperationSpec {
-    pub operation_type: Option<ExtensionOperationType>,
-    pub description: Option<String>,
-    pub extension_type: Option<ExtensionType>,
-    pub topic: Option<Topic>,
-}
-
-/// Types of extensions that can be registered
-#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq, Serialize)]
-pub enum ExtensionType {
-    TreasuryManager,
 }
 
 /// Each topic has some information associated with it. This information is for the benefit of the user but has

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -776,6 +776,11 @@ type ExtensionType = variant {
   TreasuryManager;
 };
 
+type RegisteredExtensionOperationSpec = record {
+  canister_id : opt principal;
+  spec : opt ExtensionOperationSpec;
+};
+
 type RegisterVote = record {
   vote : int32;
   proposal : opt ProposalId;
@@ -1009,7 +1014,7 @@ type TopicInfo = record {
   description : opt text;
   native_functions : opt vec NervousSystemFunction;
   custom_functions : opt vec NervousSystemFunction;
-  extension_operations : opt vec ExtensionOperationSpec;
+  extension_operations : opt vec RegisteredExtensionOperationSpec;
   is_critical : opt bool;
 };
 

--- a/rs/sns/governance/canister/governance.did
+++ b/rs/sns/governance/canister/governance.did
@@ -759,6 +759,23 @@ type ExecuteExtensionOperation = record {
   operation_arg : opt ExtensionOperationArg;
 };
 
+type ExtensionOperationSpec = record {
+  operation_type : opt ExtensionOperationType;
+  description : opt text;
+  extension_type : opt ExtensionType;
+  topic : opt Topic;
+};
+
+type ExtensionOperationType = variant {
+  TreasuryManagerDeposit;
+  TreasuryManagerWithdraw;
+  Custom : text;
+};
+
+type ExtensionType = variant {
+  TreasuryManager;
+};
+
 type RegisterVote = record {
   vote : int32;
   proposal : opt ProposalId;
@@ -992,6 +1009,7 @@ type TopicInfo = record {
   description : opt text;
   native_functions : opt vec NervousSystemFunction;
   custom_functions : opt vec NervousSystemFunction;
+  extension_operations : opt vec ExtensionOperationSpec;
   is_critical : opt bool;
 };
 

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -773,6 +773,23 @@ type ExecuteExtensionOperation = record {
   operation_arg : opt ExtensionOperationArg;
 };
 
+type ExtensionOperationSpec = record {
+  operation_type : opt ExtensionOperationType;
+  description : opt text;
+  extension_type : opt ExtensionType;
+  topic : opt Topic;
+};
+
+type ExtensionOperationType = variant {
+  TreasuryManagerDeposit;
+  TreasuryManagerWithdraw;
+  Custom : text;
+};
+
+type ExtensionType = variant {
+  TreasuryManager;
+};
+
 type RegisterVote = record {
   vote : int32;
   proposal : opt ProposalId;
@@ -1010,6 +1027,7 @@ type TopicInfo = record {
   description : opt text;
   native_functions : opt vec NervousSystemFunction;
   custom_functions : opt vec NervousSystemFunction;
+  extension_operations : opt vec ExtensionOperationSpec;
   is_critical : opt bool;
 };
 

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -790,6 +790,11 @@ type ExtensionType = variant {
   TreasuryManager;
 };
 
+type RegisteredExtensionOperationSpec = record {
+  canister_id : opt principal;
+  spec : opt ExtensionOperationSpec;
+};
+
 type RegisterVote = record {
   vote : int32;
   proposal : opt ProposalId;
@@ -1027,7 +1032,7 @@ type TopicInfo = record {
   description : opt text;
   native_functions : opt vec NervousSystemFunction;
   custom_functions : opt vec NervousSystemFunction;
-  extension_operations : opt vec ExtensionOperationSpec;
+  extension_operations : opt vec RegisteredExtensionOperationSpec;
   is_critical : opt bool;
 };
 

--- a/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
+++ b/rs/sns/governance/proto/ic_sns_governance/pb/v1/governance.proto
@@ -485,6 +485,24 @@ message ExecuteExtensionOperation {
   optional ExtensionOperationArg operation_arg = 3;
 }
 
+// Specification for an SNS extension
+message ExtensionSpec {
+  // The name of the extension
+  optional string name = 1;
+  // The version of the extension.
+  optional uint64 version = 2;
+  // The topic that the extension's registration proposal will be under
+  optional Topic topic = 3;
+  // The type of the extension, which determines its standard operations.
+  optional ExtensionType extension_type = 4;
+}
+
+// Types of extensions that can be registered
+enum ExtensionType {
+  EXTENSION_TYPE_UNSPECIFIED = 0;
+  EXTENSION_TYPE_TREASURY_MANAGER = 1;
+}
+
 // A proposal to remove a list of dapps from the SNS and assign them to new controllers
 message DeregisterDappCanisters {
   // The canister IDs to be deregistered (i.e. removed from the management of the SNS).

--- a/rs/sns/governance/protobuf_generator/src/lib.rs
+++ b/rs/sns/governance/protobuf_generator/src/lib.rs
@@ -61,6 +61,8 @@ pub fn generate_prost_files(proto: ProtoPaths<'_>, out: &Path) {
             "NeuronPermissionType",
             "Proposal.action",
             "Topic",
+            "ExtensionType",
+            "OperationType",
         ],
     );
     apply_attribute(

--- a/rs/sns/governance/src/extensions.rs
+++ b/rs/sns/governance/src/extensions.rs
@@ -9,7 +9,7 @@ use crate::{
         v1::{
             governance_error::ErrorType, precise, ChunkedCanisterWasm, ExecuteExtensionOperation,
             ExtensionInit, ExtensionOperationArg, GovernanceError, Precise, PreciseMap,
-            RegisterExtension, Topic,
+            RegisterExtension,
         },
     },
     types::{Environment, Wasm},
@@ -34,6 +34,7 @@ use crate::storage::{cache_registered_extension, get_registered_extension_from_c
 use futures::future::BoxFuture;
 use ic_ledger_core::Tokens;
 
+use crate::pb::v1::Topic;
 use std::fmt::Formatter;
 use std::{collections::BTreeMap, fmt::Display};
 

--- a/rs/sns/governance/src/extensions.rs
+++ b/rs/sns/governance/src/extensions.rs
@@ -427,7 +427,7 @@ impl ValidatedRegisterExtension {
         let context = governance.treasury_manager_deposit_context().await?;
 
         let ValidatedRegisterExtension {
-            spec: _,
+            spec,
             init,
             extension_canister_id,
             wasm,
@@ -472,6 +472,8 @@ impl ValidatedRegisterExtension {
                 CanisterInstallMode::Install,
             )
             .await?;
+
+        cache_registered_extension(extension_canister_id, spec);
 
         Ok(())
     }

--- a/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
+++ b/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
@@ -761,6 +761,29 @@ pub struct ExecuteExtensionOperation {
     #[prost(message, optional, tag = "3")]
     pub operation_arg: ::core::option::Option<ExtensionOperationArg>,
 }
+/// Specification for an SNS extension
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct ExtensionSpec {
+    /// The name of the extension
+    #[prost(string, optional, tag = "1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    /// The version of the extension.
+    #[prost(uint64, optional, tag = "2")]
+    pub version: ::core::option::Option<u64>,
+    /// The topic that the extension's registration proposal will be under
+    #[prost(enumeration = "Topic", optional, tag = "3")]
+    pub topic: ::core::option::Option<i32>,
+    /// The type of the extension, which determines its standard operations.
+    #[prost(enumeration = "ExtensionType", optional, tag = "4")]
+    pub extension_type: ::core::option::Option<i32>,
+}
 /// A proposal to remove a list of dapps from the SNS and assign them to new controllers
 #[derive(
     candid::CandidType,
@@ -4272,6 +4295,47 @@ impl Vote {
             "VOTE_UNSPECIFIED" => Some(Self::Unspecified),
             "VOTE_YES" => Some(Self::Yes),
             "VOTE_NO" => Some(Self::No),
+            _ => None,
+        }
+    }
+}
+/// Types of extensions that can be registered
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    comparable::Comparable,
+    strum_macros::EnumIter,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+)]
+#[repr(i32)]
+pub enum ExtensionType {
+    Unspecified = 0,
+    TreasuryManager = 1,
+}
+impl ExtensionType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "EXTENSION_TYPE_UNSPECIFIED",
+            Self::TreasuryManager => "EXTENSION_TYPE_TREASURY_MANAGER",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "EXTENSION_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "EXTENSION_TYPE_TREASURY_MANAGER" => Some(Self::TreasuryManager),
             _ => None,
         }
     }

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -4768,6 +4768,7 @@ fn test_list_topics() {
                     function_1,
                 ],
             },
+            extension_operations: vec![],
             is_critical: true,
         },
         TopicInfo {
@@ -4805,6 +4806,7 @@ fn test_list_topics() {
                     function_2
                 ],
             },
+            extension_operations: vec![],
             is_critical: false,
         },
         TopicInfo {
@@ -4852,6 +4854,7 @@ fn test_list_topics() {
                 ],
                 custom_functions: vec![],
             },
+            extension_operations: vec![],
             is_critical: false,
         },
         TopicInfo {
@@ -4862,6 +4865,7 @@ fn test_list_topics() {
                 native_functions: vec![],
                 custom_functions: vec![],
             },
+            extension_operations: vec![],
             is_critical: false,
         },
         TopicInfo {
@@ -4885,6 +4889,7 @@ fn test_list_topics() {
                 ],
                 custom_functions: vec![],
             },
+            extension_operations: vec![],
             is_critical: false,
         },
         TopicInfo {
@@ -4920,6 +4925,7 @@ fn test_list_topics() {
                 ],
                 custom_functions: vec![],
             },
+            extension_operations: vec![],
             is_critical: true,
         },
         TopicInfo {
@@ -4991,6 +4997,7 @@ fn test_list_topics() {
                 ],
                 custom_functions: vec![],
             },
+            extension_operations: vec![],
             is_critical: true,
         },
     ];

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -11,6 +11,8 @@ use super::test_helpers::{
 };
 use super::*;
 use crate::extensions::ExtensionSpec;
+use crate::extensions::ExtensionType;
+use crate::extensions::ExtensionVersion;
 use crate::storage::cache_registered_extension;
 use crate::{
     pb::v1::{

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -10,6 +10,8 @@ use super::test_helpers::{
     TEST_LEDGER_CANISTER_ID, TEST_ROOT_CANISTER_ID, TEST_SWAP_CANISTER_ID,
 };
 use super::*;
+use crate::extensions::ExtensionSpec;
+use crate::storage::cache_registered_extension;
 use crate::{
     pb::v1::{
         governance::{CachedUpgradeSteps as CachedUpgradeStepsPb, Versions},
@@ -4717,6 +4719,14 @@ fn test_list_topics() {
         topics: topic_infos,
         uncategorized_functions,
     } = governance.list_topics();
+
+    let registered_spec = ExtensionSpec {
+        name: "KongSwap".to_string(),
+        version: ExtensionVersion(1),
+        topic: Topic::TreasuryAssetManagement.into(),
+        extension_type: ExtensionType::TreasuryManager,
+    };
+    cache_registered_extension(CanisterId::from_u64(100_001), registered_spec);
 
     // Assert the results are as expected
     assert_eq!(uncategorized_functions, vec![function_3]);

--- a/rs/sns/governance/src/governance/assorted_governance_tests.rs
+++ b/rs/sns/governance/src/governance/assorted_governance_tests.rs
@@ -4871,7 +4871,7 @@ fn test_list_topics() {
         TopicInfo {
             topic: Topic::Governance,
             name: "Governance".to_string(),
-            description: "Proposals that represent community polls or other forms of community opinion but don’t have any immediate effect in terms of code changes.".to_string(),
+            description: "Proposals that represent community polls or other forms of community opinion but don't have any immediate effect in terms of code changes.".to_string(),
             functions: NervousSystemFunctions {
                 native_functions: vec![
                     NervousSystemFunction {

--- a/rs/sns/governance/src/governance/proposal_topics_tests.rs
+++ b/rs/sns/governance/src/governance/proposal_topics_tests.rs
@@ -1,4 +1,3 @@
-use crate::extensions::with_extension_spec_cache_mut;
 use crate::extensions::ExtensionType::TreasuryManager;
 use crate::extensions::{ExtensionSpec, ExtensionVersion, ValidatedExtensionInit};
 use crate::governance::test_helpers::basic_governance_proto;
@@ -8,6 +7,7 @@ use crate::pb::v1::Topic::TreasuryAssetManagement;
 use crate::pb::v1::{
     self as pb, nervous_system_function, ExecuteExtensionOperation, ExtensionInit,
 };
+use crate::storage::with_registered_extensions_map_mut;
 use crate::types::{native_action_ids::nervous_system_functions, test_helpers::NativeEnvironment};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_nervous_system_canisters::cmc::FakeCmc;
@@ -215,8 +215,8 @@ fn test_all_topics() {
         extension_types: vec![TreasuryManager],
         validate_init_arg: unimplemented_validator,
     };
-    with_extension_spec_cache_mut(|spec_cache| {
-        spec_cache.insert(extension_canister_id, extension_spec);
+    with_registered_extensions_map_mut(|registered_extensions| {
+        registered_extensions.insert(extension_canister_id, extension_spec);
     });
     test_cases.push((
         pb::proposal::Action::ExecuteExtensionOperation(ExecuteExtensionOperation {

--- a/rs/sns/governance/src/governance/proposal_topics_tests.rs
+++ b/rs/sns/governance/src/governance/proposal_topics_tests.rs
@@ -7,7 +7,7 @@ use crate::pb::v1::Topic::TreasuryAssetManagement;
 use crate::pb::v1::{
     self as pb, nervous_system_function, ExecuteExtensionOperation, ExtensionInit,
 };
-use crate::storage::with_registered_extensions_map_mut;
+use crate::storage::cache_registered_extension;
 use crate::types::{native_action_ids::nervous_system_functions, test_helpers::NativeEnvironment};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_nervous_system_canisters::cmc::FakeCmc;
@@ -212,12 +212,9 @@ fn test_all_topics() {
         name: "foo".to_string(),
         version: ExtensionVersion(1),
         topic: TreasuryAssetManagement,
-        extension_types: vec![TreasuryManager],
-        validate_init_arg: unimplemented_validator,
+        extension_type: TreasuryManager,
     };
-    with_registered_extensions_map_mut(|registered_extensions| {
-        registered_extensions.insert(extension_canister_id, extension_spec);
-    });
+    cache_registered_extension(extension_canister_id, extension_spec);
     test_cases.push((
         pb::proposal::Action::ExecuteExtensionOperation(ExecuteExtensionOperation {
             extension_canister_id: Some(extension_canister_id.get()),

--- a/rs/sns/governance/src/lib.rs
+++ b/rs/sns/governance/src/lib.rs
@@ -22,6 +22,7 @@ pub mod types;
 pub mod upgrade_journal;
 
 pub mod icrc_ledger_helper;
+pub mod storage;
 
 // Feature flag for SNS Extensions
 thread_local! {

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -4412,16 +4412,13 @@ impl From<topics::TopicInfo<topics::NervousSystemFunctions>> for pb_api::topics:
                     native_functions,
                     custom_functions,
                 },
+            extension_operations,
             is_critical,
         } = value;
 
-        // Collect extension operations for this topic from the global specs
-        let extension_operations: Vec<pb_api::topics::ExtensionOperationSpec> = 
-            crate::extensions::EXTENSION_OPERATION_SPECS
-                .values()
-                .filter(|spec| pb_api::topics::Topic::try_from(spec.topic).unwrap() == topic)
-                .map(|spec| pb_api::topics::ExtensionOperationSpec::from(spec.clone()))
-                .collect();
+        let extension_operations = extension_operations
+            .map(|op| pb_api::topics::ExtensionOperationSpec::from(op))
+            .collect();
 
         pb_api::topics::TopicInfo {
             topic: Some(topic),
@@ -4503,7 +4500,9 @@ impl From<pb_api::topics::ExtensionType> for crate::extensions::ExtensionType {
 impl From<crate::extensions::ExtensionOperationSpec> for pb_api::topics::ExtensionOperationSpec {
     fn from(value: crate::extensions::ExtensionOperationSpec) -> Self {
         pb_api::topics::ExtensionOperationSpec {
-            operation_type: Some(pb_api::topics::ExtensionOperationType::from(value.operation_type)),
+            operation_type: Some(pb_api::topics::ExtensionOperationType::from(
+                value.operation_type,
+            )),
             description: Some(value.description),
             extension_type: Some(pb_api::topics::ExtensionType::from(value.extension_type)),
             topic: Some(pb_api::topics::Topic::try_from(value.topic).unwrap()),
@@ -4515,15 +4514,13 @@ impl From<pb_api::topics::ExtensionOperationSpec> for crate::extensions::Extensi
     fn from(value: pb_api::topics::ExtensionOperationSpec) -> Self {
         crate::extensions::ExtensionOperationSpec {
             operation_type: crate::extensions::OperationType::from(
-                value.operation_type.expect("operation_type is required")
+                value.operation_type.expect("operation_type is required"),
             ),
             description: value.description.expect("description is required"),
             extension_type: crate::extensions::ExtensionType::from(
-                value.extension_type.expect("extension_type is required")
+                value.extension_type.expect("extension_type is required"),
             ),
-            topic: pb::Topic::from(
-                value.topic.expect("topic is required")
-            ),
+            topic: pb::Topic::from(value.topic.expect("topic is required")),
         }
     }
 }

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -4414,6 +4414,15 @@ impl From<topics::TopicInfo<topics::NervousSystemFunctions>> for pb_api::topics:
                 },
             is_critical,
         } = value;
+
+        // Collect extension operations for this topic from the global specs
+        let extension_operations: Vec<pb_api::topics::ExtensionOperationSpec> = 
+            crate::extensions::EXTENSION_OPERATION_SPECS
+                .values()
+                .filter(|spec| pb_api::topics::Topic::try_from(spec.topic).unwrap() == topic)
+                .map(|spec| pb_api::topics::ExtensionOperationSpec::from(spec.clone()))
+                .collect();
+
         pb_api::topics::TopicInfo {
             topic: Some(topic),
             name: Some(name),
@@ -4430,7 +4439,91 @@ impl From<topics::TopicInfo<topics::NervousSystemFunctions>> for pb_api::topics:
                     .map(pb_api::NervousSystemFunction::from)
                     .collect(),
             ),
+            extension_operations: Some(extension_operations),
             is_critical: Some(is_critical),
+        }
+    }
+}
+
+// Conversions for ExtensionOperationType
+impl From<crate::extensions::OperationType> for pb_api::topics::ExtensionOperationType {
+    fn from(value: crate::extensions::OperationType) -> Self {
+        match value {
+            crate::extensions::OperationType::TreasuryManagerDeposit => {
+                pb_api::topics::ExtensionOperationType::TreasuryManagerDeposit
+            }
+            crate::extensions::OperationType::TreasuryManagerWithdraw => {
+                pb_api::topics::ExtensionOperationType::TreasuryManagerWithdraw
+            }
+            crate::extensions::OperationType::Custom(name) => {
+                pb_api::topics::ExtensionOperationType::Custom(name)
+            }
+        }
+    }
+}
+
+impl From<pb_api::topics::ExtensionOperationType> for crate::extensions::OperationType {
+    fn from(value: pb_api::topics::ExtensionOperationType) -> Self {
+        match value {
+            pb_api::topics::ExtensionOperationType::TreasuryManagerDeposit => {
+                crate::extensions::OperationType::TreasuryManagerDeposit
+            }
+            pb_api::topics::ExtensionOperationType::TreasuryManagerWithdraw => {
+                crate::extensions::OperationType::TreasuryManagerWithdraw
+            }
+            pb_api::topics::ExtensionOperationType::Custom(name) => {
+                crate::extensions::OperationType::Custom(name)
+            }
+        }
+    }
+}
+
+// Conversions for ExtensionType
+impl From<crate::extensions::ExtensionType> for pb_api::topics::ExtensionType {
+    fn from(value: crate::extensions::ExtensionType) -> Self {
+        match value {
+            crate::extensions::ExtensionType::TreasuryManager => {
+                pb_api::topics::ExtensionType::TreasuryManager
+            }
+        }
+    }
+}
+
+impl From<pb_api::topics::ExtensionType> for crate::extensions::ExtensionType {
+    fn from(value: pb_api::topics::ExtensionType) -> Self {
+        match value {
+            pb_api::topics::ExtensionType::TreasuryManager => {
+                crate::extensions::ExtensionType::TreasuryManager
+            }
+        }
+    }
+}
+
+// Conversions for ExtensionOperationSpec
+impl From<crate::extensions::ExtensionOperationSpec> for pb_api::topics::ExtensionOperationSpec {
+    fn from(value: crate::extensions::ExtensionOperationSpec) -> Self {
+        pb_api::topics::ExtensionOperationSpec {
+            operation_type: Some(pb_api::topics::ExtensionOperationType::from(value.operation_type)),
+            description: Some(value.description),
+            extension_type: Some(pb_api::topics::ExtensionType::from(value.extension_type)),
+            topic: Some(pb_api::topics::Topic::try_from(value.topic).unwrap()),
+        }
+    }
+}
+
+impl From<pb_api::topics::ExtensionOperationSpec> for crate::extensions::ExtensionOperationSpec {
+    fn from(value: pb_api::topics::ExtensionOperationSpec) -> Self {
+        crate::extensions::ExtensionOperationSpec {
+            operation_type: crate::extensions::OperationType::from(
+                value.operation_type.expect("operation_type is required")
+            ),
+            description: value.description.expect("description is required"),
+            extension_type: crate::extensions::ExtensionType::from(
+                value.extension_type.expect("extension_type is required")
+            ),
+            topic: pb::Topic::from(
+                value.topic.expect("topic is required")
+            ),
         }
     }
 }

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -1,8 +1,7 @@
-use core::convert::Into;
-use core::option::Option::Some;
-
 use crate::pb::v1::{self as pb};
 use crate::topics;
+use core::convert::Into;
+use core::option::Option::Some;
 use ic_sns_governance_api::pb::v1 as pb_api;
 
 impl From<pb::NeuronPermission> for pb_api::NeuronPermission {
@@ -4418,7 +4417,7 @@ impl From<topics::TopicInfo<topics::NervousSystemFunctions>> for pb_api::topics:
 
         let extension_operations = extension_operations
             .into_iter()
-            .map(pb_api::ExtensionOperationSpec::from)
+            .map(pb_api::RegisteredExtensionOperationSpec::from)
             .collect();
 
         pb_api::topics::TopicInfo {
@@ -4460,38 +4459,12 @@ impl From<crate::extensions::OperationType> for pb_api::ExtensionOperationType {
     }
 }
 
-impl From<pb_api::ExtensionOperationType> for crate::extensions::OperationType {
-    fn from(value: pb_api::ExtensionOperationType) -> Self {
-        match value {
-            pb_api::ExtensionOperationType::TreasuryManagerDeposit => {
-                crate::extensions::OperationType::TreasuryManagerDeposit
-            }
-            pb_api::ExtensionOperationType::TreasuryManagerWithdraw => {
-                crate::extensions::OperationType::TreasuryManagerWithdraw
-            }
-            pb_api::ExtensionOperationType::Custom(name) => {
-                crate::extensions::OperationType::Custom(name)
-            }
-        }
-    }
-}
-
 // Conversions for ExtensionType
 impl From<crate::extensions::ExtensionType> for pb_api::ExtensionType {
     fn from(value: crate::extensions::ExtensionType) -> Self {
         match value {
             crate::extensions::ExtensionType::TreasuryManager => {
                 pb_api::ExtensionType::TreasuryManager
-            }
-        }
-    }
-}
-
-impl From<pb_api::ExtensionType> for crate::extensions::ExtensionType {
-    fn from(value: pb_api::ExtensionType) -> Self {
-        match value {
-            pb_api::ExtensionType::TreasuryManager => {
-                crate::extensions::ExtensionType::TreasuryManager
             }
         }
     }
@@ -4509,17 +4482,14 @@ impl From<crate::extensions::ExtensionOperationSpec> for pb_api::ExtensionOperat
     }
 }
 
-impl From<pb_api::ExtensionOperationSpec> for crate::extensions::ExtensionOperationSpec {
-    fn from(value: pb_api::ExtensionOperationSpec) -> Self {
-        crate::extensions::ExtensionOperationSpec {
-            operation_type: crate::extensions::OperationType::from(
-                value.operation_type.expect("operation_type is required"),
-            ),
-            description: value.description.expect("description is required"),
-            extension_type: crate::extensions::ExtensionType::from(
-                value.extension_type.expect("extension_type is required"),
-            ),
-            topic: pb::Topic::from(value.topic.expect("topic is required")),
+// Conversions for RegisteredExtensionOperationSpec
+impl From<crate::topics::RegisteredExtensionOperationSpec>
+    for pb_api::RegisteredExtensionOperationSpec
+{
+    fn from(value: crate::topics::RegisteredExtensionOperationSpec) -> Self {
+        pb_api::RegisteredExtensionOperationSpec {
+            canister_id: Some(value.canister_id.get()),
+            spec: Some(pb_api::ExtensionOperationSpec::from(value.spec)),
         }
     }
 }

--- a/rs/sns/governance/src/pb/conversions.rs
+++ b/rs/sns/governance/src/pb/conversions.rs
@@ -4417,7 +4417,8 @@ impl From<topics::TopicInfo<topics::NervousSystemFunctions>> for pb_api::topics:
         } = value;
 
         let extension_operations = extension_operations
-            .map(|op| pb_api::topics::ExtensionOperationSpec::from(op))
+            .into_iter()
+            .map(pb_api::ExtensionOperationSpec::from)
             .collect();
 
         pb_api::topics::TopicInfo {
@@ -4443,32 +4444,32 @@ impl From<topics::TopicInfo<topics::NervousSystemFunctions>> for pb_api::topics:
 }
 
 // Conversions for ExtensionOperationType
-impl From<crate::extensions::OperationType> for pb_api::topics::ExtensionOperationType {
+impl From<crate::extensions::OperationType> for pb_api::ExtensionOperationType {
     fn from(value: crate::extensions::OperationType) -> Self {
         match value {
             crate::extensions::OperationType::TreasuryManagerDeposit => {
-                pb_api::topics::ExtensionOperationType::TreasuryManagerDeposit
+                pb_api::ExtensionOperationType::TreasuryManagerDeposit
             }
             crate::extensions::OperationType::TreasuryManagerWithdraw => {
-                pb_api::topics::ExtensionOperationType::TreasuryManagerWithdraw
+                pb_api::ExtensionOperationType::TreasuryManagerWithdraw
             }
             crate::extensions::OperationType::Custom(name) => {
-                pb_api::topics::ExtensionOperationType::Custom(name)
+                pb_api::ExtensionOperationType::Custom(name)
             }
         }
     }
 }
 
-impl From<pb_api::topics::ExtensionOperationType> for crate::extensions::OperationType {
-    fn from(value: pb_api::topics::ExtensionOperationType) -> Self {
+impl From<pb_api::ExtensionOperationType> for crate::extensions::OperationType {
+    fn from(value: pb_api::ExtensionOperationType) -> Self {
         match value {
-            pb_api::topics::ExtensionOperationType::TreasuryManagerDeposit => {
+            pb_api::ExtensionOperationType::TreasuryManagerDeposit => {
                 crate::extensions::OperationType::TreasuryManagerDeposit
             }
-            pb_api::topics::ExtensionOperationType::TreasuryManagerWithdraw => {
+            pb_api::ExtensionOperationType::TreasuryManagerWithdraw => {
                 crate::extensions::OperationType::TreasuryManagerWithdraw
             }
-            pb_api::topics::ExtensionOperationType::Custom(name) => {
+            pb_api::ExtensionOperationType::Custom(name) => {
                 crate::extensions::OperationType::Custom(name)
             }
         }
@@ -4476,20 +4477,20 @@ impl From<pb_api::topics::ExtensionOperationType> for crate::extensions::Operati
 }
 
 // Conversions for ExtensionType
-impl From<crate::extensions::ExtensionType> for pb_api::topics::ExtensionType {
+impl From<crate::extensions::ExtensionType> for pb_api::ExtensionType {
     fn from(value: crate::extensions::ExtensionType) -> Self {
         match value {
             crate::extensions::ExtensionType::TreasuryManager => {
-                pb_api::topics::ExtensionType::TreasuryManager
+                pb_api::ExtensionType::TreasuryManager
             }
         }
     }
 }
 
-impl From<pb_api::topics::ExtensionType> for crate::extensions::ExtensionType {
-    fn from(value: pb_api::topics::ExtensionType) -> Self {
+impl From<pb_api::ExtensionType> for crate::extensions::ExtensionType {
+    fn from(value: pb_api::ExtensionType) -> Self {
         match value {
-            pb_api::topics::ExtensionType::TreasuryManager => {
+            pb_api::ExtensionType::TreasuryManager => {
                 crate::extensions::ExtensionType::TreasuryManager
             }
         }
@@ -4497,21 +4498,19 @@ impl From<pb_api::topics::ExtensionType> for crate::extensions::ExtensionType {
 }
 
 // Conversions for ExtensionOperationSpec
-impl From<crate::extensions::ExtensionOperationSpec> for pb_api::topics::ExtensionOperationSpec {
+impl From<crate::extensions::ExtensionOperationSpec> for pb_api::ExtensionOperationSpec {
     fn from(value: crate::extensions::ExtensionOperationSpec) -> Self {
-        pb_api::topics::ExtensionOperationSpec {
-            operation_type: Some(pb_api::topics::ExtensionOperationType::from(
-                value.operation_type,
-            )),
+        pb_api::ExtensionOperationSpec {
+            operation_type: Some(pb_api::ExtensionOperationType::from(value.operation_type)),
             description: Some(value.description),
-            extension_type: Some(pb_api::topics::ExtensionType::from(value.extension_type)),
+            extension_type: Some(pb_api::ExtensionType::from(value.extension_type)),
             topic: Some(pb_api::topics::Topic::try_from(value.topic).unwrap()),
         }
     }
 }
 
-impl From<pb_api::topics::ExtensionOperationSpec> for crate::extensions::ExtensionOperationSpec {
-    fn from(value: pb_api::topics::ExtensionOperationSpec) -> Self {
+impl From<pb_api::ExtensionOperationSpec> for crate::extensions::ExtensionOperationSpec {
+    fn from(value: pb_api::ExtensionOperationSpec) -> Self {
         crate::extensions::ExtensionOperationSpec {
             operation_type: crate::extensions::OperationType::from(
                 value.operation_type.expect("operation_type is required"),

--- a/rs/sns/governance/src/storage.rs
+++ b/rs/sns/governance/src/storage.rs
@@ -1,6 +1,6 @@
 use crate::extensions::ExtensionSpec;
 use candid::Principal;
-use ic_base_types::CanisterId;
+use ic_base_types::{CanisterId, PrincipalId};
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::{BTreeMap, DefaultMemoryImpl, Storable};
@@ -42,6 +42,19 @@ pub fn clear_registered_extension_cache(canister_id: CanisterId) {
 
 pub fn get_registered_extension_from_cache(canister_id: CanisterId) -> Option<ExtensionSpec> {
     REGISTERED_EXTENSIONS.with_borrow(|map| map.get(&canister_id.get().0))
+}
+
+pub fn list_registered_extensions_from_cache() -> Vec<(CanisterId, ExtensionSpec)> {
+    REGISTERED_EXTENSIONS.with_borrow(|map| {
+        map.iter()
+            .map(|(principal, spec)| {
+                (
+                    CanisterId::unchecked_from_principal(PrincipalId::from(principal)),
+                    spec,
+                )
+            })
+            .collect()
+    })
 }
 
 // TODO - how should we handle this?  The extension spec has to come from somewhere.

--- a/rs/sns/governance/src/storage.rs
+++ b/rs/sns/governance/src/storage.rs
@@ -1,8 +1,10 @@
 use crate::extensions::ExtensionSpec;
+use candid::Principal;
 use ic_base_types::CanisterId;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::{BTreeMap, DefaultMemoryImpl, Storable};
+use prost::Message;
 use std::borrow::Cow;
 use std::cell::RefCell;
 
@@ -21,7 +23,7 @@ thread_local! {
     pub static UPGRADES_MEMORY: RefCell<VirtualMemory<DefaultMemoryImpl>> = MEMORY_MANAGER.with(|memory_manager|
         RefCell::new(memory_manager.borrow().get(UPGRADES_MEMORY_ID)));
 
-    pub static REGISTERED_EXTENSIONS: RefCell<BTreeMap<CanisterId, ExtensionSpec, VM>> = MEMORY_MANAGER.with_borrow(|memory_manager| {
+    pub static REGISTERED_EXTENSIONS: RefCell<BTreeMap<Principal, ExtensionSpec, VM>> = MEMORY_MANAGER.with_borrow(|memory_manager| {
         RefCell::new(BTreeMap::init(memory_manager.get(REGISTERED_EXTENSIONS_MEMORY_ID)))
     });
 }
@@ -30,16 +32,16 @@ pub fn with_upgrades_memory<R>(f: impl FnOnce(&VM) -> R) -> R {
     UPGRADES_MEMORY.with_borrow(f)
 }
 
-pub fn with_registered_extensions_map<R>(
-    f: impl FnOnce(&BTreeMap<CanisterId, ExtensionSpec, VM>) -> R,
-) -> R {
-    REGISTERED_EXTENSIONS.with_borrow(f)
+pub fn cache_registered_extension(canister_id: CanisterId, spec: ExtensionSpec) {
+    REGISTERED_EXTENSIONS.with_borrow_mut(|map| map.insert(canister_id.get().0, spec));
 }
 
-pub fn with_registered_extensions_map_mut<R>(
-    f: impl FnOnce(&mut BTreeMap<CanisterId, ExtensionSpec, VM>) -> R,
-) -> R {
-    REGISTERED_EXTENSIONS.with_borrow_mut(f)
+pub fn clear_registered_extension_cache(canister_id: CanisterId) {
+    REGISTERED_EXTENSIONS.with_borrow_mut(|map| map.remove(&canister_id.get().0));
+}
+
+pub fn get_registered_extension_from_cache(canister_id: CanisterId) -> Option<ExtensionSpec> {
+    REGISTERED_EXTENSIONS.with_borrow(|map| map.get(&canister_id.get().0))
 }
 
 // TODO - how should we handle this?  The extension spec has to come from somewhere.
@@ -51,11 +53,12 @@ pub fn with_registered_extensions_map_mut<R>(
 // goes away.  Using the data tree of references seems like a less than ideal solution.
 impl Storable for ExtensionSpec {
     fn to_bytes(&self) -> Cow<[u8]> {
-        todo!()
+        Cow::Owned(crate::pb::v1::ExtensionSpec::from(self.clone()).encode_to_vec())
     }
 
     fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        todo!()
+        let proto = crate::pb::v1::ExtensionSpec::decode(bytes.as_ref()).unwrap();
+        Self::try_from(proto).unwrap()
     }
 
     const BOUND: Bound = Bound::Unbounded;

--- a/rs/sns/governance/src/storage.rs
+++ b/rs/sns/governance/src/storage.rs
@@ -1,9 +1,12 @@
+use crate::extensions::ExtensionSpec;
+use ic_base_types::CanisterId;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
-use ic_stable_structures::DefaultMemoryImpl;
+use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
 use std::cell::RefCell;
 
 /// Constants to define memory segments.  Must not change.
 const UPGRADES_MEMORY_ID: MemoryId = MemoryId::new(0);
+const REGISTERED_EXTENSIONS_MEMORY_ID: MemoryId = MemoryId::new(1);
 
 type VM = VirtualMemory<DefaultMemoryImpl>;
 
@@ -15,8 +18,24 @@ thread_local! {
     // The memory where the governance reads and writes its state during an upgrade.
     pub static UPGRADES_MEMORY: RefCell<VirtualMemory<DefaultMemoryImpl>> = MEMORY_MANAGER.with(|memory_manager|
         RefCell::new(memory_manager.borrow().get(UPGRADES_MEMORY_ID)));
+
+    pub static REGISTERED_EXTENSIONS: RefCell<BTreeMap<CanisterId, ExtensionSpec, VM>> = MEMORY_MANAGER.with_borrow(|memory_manager| {
+        RefCell::new(BTreeMap::init(memory_manager.get(REGISTERED_EXTENSIONS_MEMORY_ID)))
+    });
 }
 
 pub fn with_upgrades_memory<R>(f: impl FnOnce(&VM) -> R) -> R {
     UPGRADES_MEMORY.with_borrow(f)
+}
+
+pub fn with_registered_extensions_map<R>(
+    f: impl FnOnce(&BTreeMap<CanisterId, ExtensionSpec, VM>) -> R,
+) -> R {
+    REGISTERED_EXTENSIONS.with_borrow(f)
+}
+
+pub fn with_registered_extensions_map_mut<R>(
+    f: impl FnOnce(&mut BTreeMap<CanisterId, ExtensionSpec, VM>) -> R,
+) -> R {
+    REGISTERED_EXTENSIONS.with_borrow_mut(f)
 }

--- a/rs/sns/governance/src/storage.rs
+++ b/rs/sns/governance/src/storage.rs
@@ -1,7 +1,9 @@
 use crate::extensions::ExtensionSpec;
 use ic_base_types::CanisterId;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
-use ic_stable_structures::{BTreeMap, DefaultMemoryImpl};
+use ic_stable_structures::storable::Bound;
+use ic_stable_structures::{BTreeMap, DefaultMemoryImpl, Storable};
+use std::borrow::Cow;
 use std::cell::RefCell;
 
 /// Constants to define memory segments.  Must not change.
@@ -38,4 +40,23 @@ pub fn with_registered_extensions_map_mut<R>(
     f: impl FnOnce(&mut BTreeMap<CanisterId, ExtensionSpec, VM>) -> R,
 ) -> R {
     REGISTERED_EXTENSIONS.with_borrow_mut(f)
+}
+
+// TODO - how should we handle this?  The extension spec has to come from somewhere.
+// Eventually it will not come from our local machine.  It needs to be serializable.  And so do
+// the validation functions.
+// But currently, we are creating specs for operations and extensions that use types and
+// function pointers.  How is that going to be something that we can transfer into SNS Governance?
+// If we cache them with a reference to a hash, we can work well until such time as that hash
+// goes away.  Using the data tree of references seems like a less than ideal solution.
+impl Storable for ExtensionSpec {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        todo!()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        todo!()
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
 }

--- a/rs/sns/governance/src/storage.rs
+++ b/rs/sns/governance/src/storage.rs
@@ -1,0 +1,22 @@
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::DefaultMemoryImpl;
+use std::cell::RefCell;
+
+/// Constants to define memory segments.  Must not change.
+const UPGRADES_MEMORY_ID: MemoryId = MemoryId::new(0);
+
+type VM = VirtualMemory<DefaultMemoryImpl>;
+
+thread_local! {
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(
+        MemoryManager::init(DefaultMemoryImpl::default())
+    );
+
+    // The memory where the governance reads and writes its state during an upgrade.
+    pub static UPGRADES_MEMORY: RefCell<VirtualMemory<DefaultMemoryImpl>> = MEMORY_MANAGER.with(|memory_manager|
+        RefCell::new(memory_manager.borrow().get(UPGRADES_MEMORY_ID)));
+}
+
+pub fn with_upgrades_memory<R>(f: impl FnOnce(&VM) -> R) -> R {
+    UPGRADES_MEMORY.with_borrow(f)
+}

--- a/rs/sns/governance/src/topics.rs
+++ b/rs/sns/governance/src/topics.rs
@@ -1,5 +1,5 @@
 use crate::extensions;
-use crate::extensions::get_extension_operation_spec_from_cache;
+use crate::extensions::{get_extension_operation_spec_from_cache, ExtensionOperationSpec};
 use crate::logs::ERROR;
 use crate::pb::v1::{self as pb, NervousSystemFunction};
 use crate::types::native_action_ids::{self, SET_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION};
@@ -19,6 +19,7 @@ pub struct TopicInfo<C> {
     pub name: String,
     pub description: String,
     pub functions: C,
+    pub extension_operations: Vec<ExtensionOperationSpec>,
     pub is_critical: bool,
 }
 
@@ -67,6 +68,7 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
                     MANAGE_SNS_METADATA,
                 ],
             },
+            extension_operations: vec![],
             is_critical: true,
         },
         TopicInfo::<NativeFunctions> {
@@ -79,6 +81,7 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
                     ADVANCE_SNS_TARGET_VERSION,
                 ],
             },
+            extension_operations: vec![],
             is_critical: false,
         },
         TopicInfo::<NativeFunctions> {
@@ -92,6 +95,7 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
                     MANAGE_DAPP_CANISTER_SETTINGS,
                 ],
             },
+            extension_operations: vec![],
             is_critical: false,
         },
         TopicInfo::<NativeFunctions> {
@@ -101,6 +105,7 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
             functions: NativeFunctions {
                 native_functions: vec![],
             },
+            extension_operations: vec![],
             is_critical: false,
         },
         TopicInfo::<NativeFunctions> {
@@ -110,6 +115,7 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
             functions: NativeFunctions {
                 native_functions: vec![MOTION],
             },
+            extension_operations: vec![],
             is_critical: false,
         },
         TopicInfo::<NativeFunctions> {
@@ -122,6 +128,7 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
                     MINT_SNS_TOKENS,
                 ],
             },
+            extension_operations: vec![],
             is_critical: true,
         },
         TopicInfo::<NativeFunctions> {
@@ -137,6 +144,7 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
                     REGISTER_EXTENSION,
                 ],
             },
+            extension_operations: vec![],
             is_critical: true,
         },
     ]
@@ -199,6 +207,7 @@ impl Governance {
                         .unwrap_or_default()
                         .clone(),
                 },
+                extension_operations: vec![],
                 is_critical: topic.is_critical,
             })
             .to_vec();

--- a/rs/sns/governance/src/topics.rs
+++ b/rs/sns/governance/src/topics.rs
@@ -4,12 +4,19 @@ use crate::logs::ERROR;
 use crate::pb::v1::{self as pb, NervousSystemFunction};
 use crate::types::native_action_ids::{self, SET_TOPICS_FOR_CUSTOM_PROPOSALS_ACTION};
 use crate::{governance::Governance, pb::v1::nervous_system_function::FunctionType};
+use ic_base_types::CanisterId;
 use ic_canister_log::log;
 use ic_sns_governance_api::pb::v1::topics::Topic;
 use ic_sns_governance_proposal_criticality::ProposalCriticality;
 use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
+
+#[derive(Debug, candid::CandidType, candid::Deserialize, Clone, PartialEq)]
+pub struct RegisteredExtensionOperationSpec {
+    pub canister_id: CanisterId,
+    pub spec: ExtensionOperationSpec,
+}
 
 /// Each topic has some information associated with it. This information is for the benefit of the user but has
 /// no effect on the behavior of the SNS.
@@ -19,7 +26,7 @@ pub struct TopicInfo<C> {
     pub name: String,
     pub description: String,
     pub functions: C,
-    pub extension_operations: Vec<ExtensionOperationSpec>,
+    pub extension_operations: Vec<RegisteredExtensionOperationSpec>,
     pub is_critical: bool,
 }
 

--- a/rs/sns/governance/src/topics.rs
+++ b/rs/sns/governance/src/topics.rs
@@ -106,7 +106,7 @@ pub fn topic_descriptions() -> [TopicInfo<NativeFunctions>; 7] {
         TopicInfo::<NativeFunctions> {
             topic: Topic::Governance,
             name: "Governance".to_string(),
-            description: "Proposals that represent community polls or other forms of community opinion but don’t have any immediate effect in terms of code changes.".to_string(),
+            description: "Proposals that represent community polls or other forms of community opinion but don't have any immediate effect in terms of code changes.".to_string(),
             functions: NativeFunctions {
                 native_functions: vec![MOTION],
             },


### PR DESCRIPTION
This adds extension operations under listed topics, so that it's possible to see specific SNS extension canisters installed and the operations available for each one.

This will help voters configure their following correctly, as they will know which topics they want to vote on manually.