### PR TITLE
feat(sns): Use same validation function for proposal creation as execution

### DIFF
--- a/rs/sns/governance/src/extensions.rs
+++ b/rs/sns/governance/src/extensions.rs
@@ -1792,10 +1792,7 @@ mod tests {
         let err = validate_register_extension(&governance, missing_store_id)
             .await
             .unwrap_err();
-        assert_eq!(
-            err,
-            "Invalid RegisterExtension: \"chunked_canister_wasm.store_canister_id is required\""
-        );
+        assert_eq!(err, "chunked_canister_wasm.store_canister_id is required");
 
         // Test invalid store_canister_id (not a valid principal)
         let invalid_store_id = {
@@ -1827,7 +1824,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err,
-            "Invalid RegisterExtension: \"Invalid extension wasm: Invalid wasm module hash length: expected 32 bytes, got 16\""
+            "Invalid extension wasm: Invalid wasm module hash length: expected 32 bytes, got 16"
         );
 
         // Test missing extension_init

--- a/rs/sns/governance/src/extensions.rs
+++ b/rs/sns/governance/src/extensions.rs
@@ -1777,13 +1777,7 @@ mod tests {
         let err = validate_register_extension(&governance, missing_wasm)
             .await
             .unwrap_err();
-        assert_eq!(
-            err,
-            GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                "Invalid RegisterExtension: \"chunked_canister_wasm is required\""
-            )
-        );
+        assert_eq!(err, "chunked_canister_wasm is required");
 
         // Test missing store_canister_id
         let missing_store_id = {
@@ -1800,10 +1794,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err,
-            GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                "Invalid RegisterExtension: \"chunked_canister_wasm.store_canister_id is required\""
-            )
+            "Invalid RegisterExtension: \"chunked_canister_wasm.store_canister_id is required\""
         );
 
         // Test invalid store_canister_id (not a valid principal)
@@ -1819,7 +1810,7 @@ mod tests {
         let err = validate_register_extension(&governance, invalid_store_id)
             .await
             .unwrap_err();
-        assert!(err.error_message.contains("invalid principal id"));
+        assert!(err.contains("invalid principal id"));
 
         // Test invalid wasm module hash length
         let invalid_hash_length = {
@@ -1836,10 +1827,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err,
-            GovernanceError::new_with_message(
-                ErrorType::InvalidProposal,
-                "Invalid RegisterExtension: \"Invalid extension wasm: Invalid wasm module hash length: expected 32 bytes, got 16\""
-            )
+            "Invalid RegisterExtension: \"Invalid extension wasm: Invalid wasm module hash length: expected 32 bytes, got 16\""
         );
 
         // Test missing extension_init
@@ -1851,9 +1839,7 @@ mod tests {
         let err = validate_register_extension(&governance, missing_init)
             .await
             .unwrap_err();
-        assert!(err
-            .error_message
-            .contains("RegisterExtension.extension_init is required"));
+        assert!(err.contains("RegisterExtension.extension_init is required"));
 
         // Test wasm not in whitelist (in non-test mode this would fail)
         // Since we're in test mode, this will succeed, so we can't test the whitelist rejection here
@@ -1906,9 +1892,7 @@ mod tests {
         let err = validate_register_extension(&governance, missing_sns_init)
             .await
             .unwrap_err();
-        assert!(err
-            .error_message
-            .contains("treasury_allocation_sns_e8s must be a Nat value"));
+        assert!(err.contains("treasury_allocation_sns_e8s must be a Nat value"));
 
         // Structural validation failure: missing ICP allocation
         let missing_icp_init = mk_register_extension(Some(Precise {
@@ -1921,9 +1905,7 @@ mod tests {
         let err = validate_register_extension(&governance, missing_icp_init)
             .await
             .unwrap_err();
-        assert!(err
-            .error_message
-            .contains("treasury_allocation_icp_e8s must be a Nat value"));
+        assert!(err.contains("treasury_allocation_icp_e8s must be a Nat value"));
 
         // Structural validation failure: wrong type
         let wrong_type_init = mk_register_extension(Some(Precise {
@@ -1937,18 +1919,14 @@ mod tests {
         let err = validate_register_extension(&governance, wrong_type_init)
             .await
             .unwrap_err();
-        assert!(err
-            .error_message
-            .contains("treasury_allocation_sns_e8s must be a Nat value"));
+        assert!(err.contains("treasury_allocation_sns_e8s must be a Nat value"));
 
         // Structural validation failure: no arguments
         let no_args_init = mk_register_extension(None);
         let err = validate_register_extension(&governance, no_args_init)
             .await
             .unwrap_err();
-        assert!(err
-            .error_message
-            .contains("Deposit operation arguments must be provided"));
+        assert!(err.contains("Deposit operation arguments must be provided"));
 
         // Structural validation failure: not a map
         let not_map_init = mk_register_extension(Some(Precise {
@@ -1957,9 +1935,7 @@ mod tests {
         let err = validate_register_extension(&governance, not_map_init)
             .await
             .unwrap_err();
-        assert!(err
-            .error_message
-            .contains("Deposit operation arguments must be a PreciseMap"));
+        assert!(err.contains("Deposit operation arguments must be a PreciseMap"));
     }
 
     #[tokio::test]

--- a/rs/sns/governance/src/extensions.rs
+++ b/rs/sns/governance/src/extensions.rs
@@ -909,7 +909,7 @@ fn construct_treasury_manager_withdraw_payload(_value: Precise) -> Result<Vec<u8
 pub async fn validate_register_extension(
     governance: &Governance,
     register_extension: RegisterExtension,
-) -> Result<ValidatedRegisterExtension, GovernanceError> {
+) -> Result<ValidatedRegisterExtension, String> {
     let RegisterExtension {
         chunked_canister_wasm,
         extension_init,
@@ -956,13 +956,7 @@ pub async fn validate_register_extension(
 
         Ok::<_, String>((spec, wasm, extension_canister_id, init))
     })
-    .await
-    .map_err(|err| {
-        GovernanceError::new_with_message(
-            ErrorType::InvalidProposal,
-            format!("Invalid RegisterExtension: {:?}", err),
-        )
-    })?;
+    .await?;
 
     Ok(ValidatedRegisterExtension {
         wasm,

--- a/rs/sns/governance/src/extensions.rs
+++ b/rs/sns/governance/src/extensions.rs
@@ -916,47 +916,42 @@ pub async fn validate_register_extension(
     } = register_extension;
 
     // Phase I. Validate all local properties.
-    let (spec, wasm, extension_canister_id, init) = (async {
-        let Some(ChunkedCanisterWasm {
-            wasm_module_hash,
-            store_canister_id,
-            chunk_hashes_list,
-        }) = chunked_canister_wasm
-        else {
-            return Err("chunked_canister_wasm is required".to_string());
-        };
+    let Some(ChunkedCanisterWasm {
+        wasm_module_hash,
+        store_canister_id,
+        chunk_hashes_list,
+    }) = chunked_canister_wasm
+    else {
+        return Err("chunked_canister_wasm is required".to_string());
+    };
 
-        let Some(store_canister_id) = store_canister_id else {
-            return Err("chunked_canister_wasm.store_canister_id is required".to_string());
-        };
+    let Some(store_canister_id) = store_canister_id else {
+        return Err("chunked_canister_wasm.store_canister_id is required".to_string());
+    };
 
-        let store_canister_id = CanisterId::try_from_principal_id(store_canister_id)
-            .map_err(|err| format!("Invalid store_canister_id: {}", err))?;
+    let store_canister_id = CanisterId::try_from_principal_id(store_canister_id)
+        .map_err(|err| format!("Invalid store_canister_id: {}", err))?;
 
-        // Use the store canister to install the extension itself.
-        let extension_canister_id = store_canister_id;
+    // Use the store canister to install the extension itself.
+    let extension_canister_id = store_canister_id;
 
-        let spec = validate_extension_wasm(&wasm_module_hash)
-            .map_err(|err| format!("Invalid extension wasm: {}", err))?;
+    let spec = validate_extension_wasm(&wasm_module_hash)
+        .map_err(|err| format!("Invalid extension wasm: {}", err))?;
 
-        let wasm = Wasm::Chunked {
-            wasm_module_hash,
-            store_canister_id,
-            chunk_hashes_list,
-        };
+    let wasm = Wasm::Chunked {
+        wasm_module_hash,
+        store_canister_id,
+        chunk_hashes_list,
+    };
 
-        let Some(init) = extension_init else {
-            return Err("RegisterExtension.extension_init is required".to_string());
-        };
+    let Some(init) = extension_init else {
+        return Err("RegisterExtension.extension_init is required".to_string());
+    };
 
-        let init = spec
-            .validate_init_arg(governance, init)
-            .await
-            .map_err(|err| format!("Invalid init argument: {}", err))?;
-
-        Ok::<_, String>((spec, wasm, extension_canister_id, init))
-    })
-    .await?;
+    let init = spec
+        .validate_init_arg(governance, init)
+        .await
+        .map_err(|err| format!("Invalid init argument: {}", err))?;
 
     Ok(ValidatedRegisterExtension {
         wasm,

--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -2344,8 +2344,14 @@ impl Governance {
             ));
         }
 
-        let validated_register_extension =
-            validate_register_extension(self, register_extension).await?;
+        let validated_register_extension = validate_register_extension(self, register_extension)
+            .await
+            .map_err(|err| {
+                GovernanceError::new_with_message(
+                    ErrorType::InvalidProposal,
+                    format!("Invalid RegisterExtension: {:?}", err),
+                )
+            })?;
 
         validated_register_extension.execute(self).await?;
 

--- a/rs/sns/governance/src/proposal.rs
+++ b/rs/sns/governance/src/proposal.rs
@@ -1,16 +1,10 @@
-use crate::cached_upgrade_steps::render_two_versions_as_markdown_table;
-use crate::extensions::{
-    validate_execute_extension_operation, validate_register_extension, ValidatedRegisterExtension,
-};
-use crate::extensions::{validate_extension_wasm, ValidatedExecuteExtensionOperation};
-use crate::pb::v1::{
-    AdvanceSnsTargetVersion, ExecuteExtensionOperation, RegisterExtension,
-    SetTopicsForCustomProposals, Topic,
-};
-use crate::treasury::assess_treasury_balance;
-use crate::types::Wasm;
 use crate::{
+    cached_upgrade_steps::render_two_versions_as_markdown_table,
     canister_control::perform_execute_generic_nervous_system_function_validate_and_render_call,
+    extensions::{
+        validate_execute_extension_operation, validate_register_extension,
+        ValidatedExecuteExtensionOperation, ValidatedRegisterExtension,
+    },
     governance::{
         bytes_to_subaccount, log_prefix, NERVOUS_SYSTEM_FUNCTION_DELETION_MARKER,
         TREASURY_SUBACCOUNT_NONCE,
@@ -27,15 +21,18 @@ use crate::{
             MintSnsTokensActionAuxiliary, TransferSnsTreasuryFundsActionAuxiliary,
         },
         transfer_sns_treasury_funds::TransferFrom,
-        DeregisterDappCanisters, ExecuteGenericNervousSystemFunction, Governance, GovernanceError,
-        LogVisibility, ManageDappCanisterSettings, ManageLedgerParameters, ManageSnsMetadata,
-        MintSnsTokens, Motion, NervousSystemFunction, NervousSystemParameters, Proposal,
-        ProposalData, ProposalDecisionStatus, ProposalId, ProposalRewardStatus,
-        RegisterDappCanisters, SnsVersion, Tally, Topic as TopicPb, TransferSnsTreasuryFunds,
-        UpgradeSnsControlledCanister, UpgradeSnsToNextVersion, Valuation as ValuationPb, Vote,
+        AdvanceSnsTargetVersion, DeregisterDappCanisters, ExecuteExtensionOperation,
+        ExecuteGenericNervousSystemFunction, Governance, GovernanceError, LogVisibility,
+        ManageDappCanisterSettings, ManageLedgerParameters, ManageSnsMetadata, MintSnsTokens,
+        Motion, NervousSystemFunction, NervousSystemParameters, Proposal, ProposalData,
+        ProposalDecisionStatus, ProposalId, ProposalRewardStatus, RegisterDappCanisters,
+        RegisterExtension, SetTopicsForCustomProposals, SnsVersion, Tally, Topic, Topic as TopicPb,
+        TransferSnsTreasuryFunds, UpgradeSnsControlledCanister, UpgradeSnsToNextVersion,
+        Valuation as ValuationPb, Vote,
     },
     sns_upgrade::{get_proposal_id_that_added_wasm, get_upgrade_params, UpgradeSnsParams},
-    types::Environment,
+    treasury::assess_treasury_balance,
+    types::{Environment, Wasm},
     validate_chars_count, validate_len, validate_required_field,
 };
 use candid::Principal;
@@ -49,8 +46,7 @@ use ic_nervous_system_common::{
 use ic_nervous_system_proto::pb::v1::Percentage;
 use ic_nervous_system_timestamp::format_timestamp_for_humans;
 use ic_protobuf::types::v1::CanisterInstallMode;
-use ic_sns_governance_api::format_full_hash;
-use ic_sns_governance_api::pb::v1 as pb_api;
+use ic_sns_governance_api::{format_full_hash, pb::v1 as pb_api};
 use ic_sns_governance_proposals_amount_total_limit::{
     // TODO(NNS1-2982): Uncomment. mint_sns_tokens_7_day_total_upper_bound_tokens,
     transfer_sns_treasury_funds_7_day_total_upper_bound_tokens,
@@ -2771,9 +2767,8 @@ mod set_topics_for_custom_proposals;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::governance::ValidGovernanceProto;
     use crate::{
-        governance::Governance,
+        governance::{Governance, ValidGovernanceProto},
         pb::v1::{
             governance::{self, Version},
             Ballot, ChunkedCanisterWasm, Empty, Governance as GovernanceProto, NeuronId, Proposal,


### PR DESCRIPTION
This improves the validation for the proposal submission, by using the same function that's used for validation which is more thorough and uses more context than the original validation function.