### PR TITLE
chore: allow accessing the test dir of colocated system-tests

### DIFF
--- a/rs/tests/idx/colocate_test.rs
+++ b/rs/tests/idx/colocate_test.rs
@@ -275,7 +275,7 @@ docker run \
   --name {COLOCATE_CONTAINER_NAME} \
   --network host \
   -v /home/admin/test:/home/root/test \
-  -v /home/admin/runfiles:/home/root/runfiles:ro \
+  -v /home/admin/runfiles:/home/root/runfiles \
   -v /home/admin/dashboards:{dashboards_path_in_docker}:ro \
   --env-file /home/admin/env_vars \
   --env RUNFILES=/home/root/runfiles \


### PR DESCRIPTION
What?
===

Make the working directory of a colocated system-test running in a docker container accessible on the `test-driver` VM such that files written there by the test can be retrieved.

Why?
===

Some tests download the p8s datadir of the prometheus VM to their test directory such that users can run a local p8s and Grafana on it later to investigate the metrics generated during the test. However, when a test is colocated the p8s datadir is downloaded to the docker container running on the colocated `test-driver` VM. This makes it hard (impossible maybe) to retrieve those files.

So we need to make sure that the working directory of the colocated test running in the docker container is accessible from the `test-driver` VM.

How?
===

Previously a docker image was created dynamically for each colocated test that included the working directory of the test. Now we simply prepare the working directory on the `test-driver` VM under `/home/admin/test` and mount it to the container at runtime to `/home/root/test`.

This means that after the test has finished we can retrieve the files from `/home/admin/test`.