### PR TITLE
chore(node): deprecate logging field

### DIFF
--- a/ic-os/components/hostos.bzl
+++ b/ic-os/components/hostos.bzl
@@ -82,7 +82,6 @@ component_files = {
     Label("networking/nftables/hostos/setup-nftables.service"): "/etc/systemd/system/setup-nftables.service",
     Label("networking/nftables/hostos/setup-nftables.sh"): "/opt/ic/bin/setup-nftables.sh",
     Label("networking/hosts"): "/etc/hosts",
-    Label("networking/dev-certs/canister_http_test_ca.cert"): "/dev-certs/canister_http_test_ca.cert",
 
     # ssh
     Label("ssh/generate-host-ssh-keys/generate-host-ssh-keys.sh"): "/opt/ic/bin/generate-host-ssh-keys.sh",

--- a/ic-os/hostos/context/Dockerfile
+++ b/ic-os/hostos/context/Dockerfile
@@ -10,11 +10,8 @@
 # argument MUST be given by the build script, otherwise build will fail.
 ARG BASE_IMAGE=
 
-# We support prod and dev images
-ARG BUILD_TYPE=
 
-
-FROM $BASE_IMAGE as output_prod
+FROM $BASE_IMAGE
 
 USER root:root
 
@@ -115,6 +112,12 @@ RUN systemctl disable \
 # ruleset.
 RUN ln -sf /run/ic-node/nftables-ruleset/nftables.conf /etc/nftables.conf
 
+ARG ROOT_PASSWORD=
+RUN \
+    if [ "${ROOT_PASSWORD}" != "" ]; then \
+        echo "root:$(openssl passwd -6 -salt jE8zzDEHeRg/DuGq ${ROOT_PASSWORD})" | chpasswd -e ; \
+    fi
+
 # Clear additional files that may lead to indeterministic build.
 RUN rm -rf \
         /usr/local/share/qemu/edk2-arm-code.fd \
@@ -195,28 +198,3 @@ RUN find /opt -type d -exec chmod 0755 {} \+ && \
     find /opt -type f -exec chmod 0644 {} \+ && \
     chmod 0755 /opt/ic/bin/* && \
     chmod 0644 /opt/ic/share/*
-
-# ------ DEV VARIANT ---------------------------------------------
-
-# The following steps apply conditionally to the dev image ONLY
-# https://www.docker.com/blog/advanced-dockerfiles-faster-builds-and-smaller-images-using-buildkit-and-multistage-builds/#4374
-FROM output_prod as output_dev
-
-USER root:root
-
-# Set a root password if specified
-ARG ROOT_PASSWORD=
-RUN \
-    if [ "${ROOT_PASSWORD}" != "" ]; then \
-        echo "root:$(openssl passwd -6 -salt jE8zzDEHeRg/DuGq ${ROOT_PASSWORD})" | chpasswd -e ; \
-    fi
-
-# Include the dev root CA cert
-COPY dev-certs/canister_http_test_ca.cert /usr/local/share/ca-certificates/dev-root-ca.crt
-RUN chmod 0644 /usr/local/share/ca-certificates/dev-root-ca.crt
-RUN update-ca-certificates
-
-
-FROM output_${BUILD_TYPE}
-
-USER root:root


### PR DESCRIPTION
Before complete removal, the now-deprecated logging field must be given a default attribute. This way, the config tool can still deserialize config.json objects that do not include a logging field.

Once this change has rolled out to all nodes, the field can be removed.

I've fixed the Configuration Update Protocol accordingly.