### PR TITLE
chore: in system-tests start p8s again after tarring its datadir

### DIFF
--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -483,11 +483,13 @@ impl HasPrometheus for TestEnv {
         let create_tarball_script = &format!(
             r#"
 set -e
+# Stop p8s so we can create a clean tarball of its data directory without concurrent writes going on:
 sudo systemctl stop prometheus.service
 sudo tar -cf "{tarball_full_path:?}" \
     --sparse \
     --use-compress-program="zstd --threads=0 -10" \
     -C /var/lib/prometheus .
+# Start p8s again because users might still want to use it if they started their test with --keepalive:
 sudo systemctl start prometheus.service
     "#,
         );

--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -488,6 +488,7 @@ sudo tar -cf "{tarball_full_path:?}" \
     --sparse \
     --use-compress-program="zstd --threads=0 -10" \
     -C /var/lib/prometheus .
+sudo systemctl start prometheus.service
     "#,
         );
         let session = deployed_prometheus_vm


### PR DESCRIPTION
When system-tests request to `download_prometheus_data_dir_if_exists()` at the end of their tests the p8s service is stopped after which its data directory is tarred. However users expect that p8s will keep running when they use `--keepalive` so this commit restart p8s right after tarring its datadir.