### PR TITLE
chore(icrc-ledger-client-cdk): Bump icrc-ledger-client-cdk to include ic-cdk v0.18.6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,7 @@ go_deps.bzl               @dfinity/idx
 /packages/icrc-cbor/                            @dfinity/finint @dfinity/cross-chain-team
 /packages/icrc-ledger-agent/                    @dfinity/finint
 /packages/icrc-ledger-client/                   @dfinity/finint
+/packages/icrc-ledger-client-cdk/               @dfinity/finint
 /packages/icrc-ledger-types/                    @dfinity/finint
 /packages/ic-ledger-hash-of/                    @dfinity/finint
 /packages/pocket-ic/                            @dfinity/pocket-ic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15537,7 +15537,7 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-client-cdk"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "candid",

--- a/packages/icrc-ledger-client-cdk/CHANGELOG.md
+++ b/packages/icrc-ledger-client-cdk/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3
+
+- Bump ic-cdk version to v0.18.6.
+
 ## 0.1.2
 
 - Initial version of the ICRC Client Cdk library.

--- a/packages/icrc-ledger-client-cdk/Cargo.toml
+++ b/packages/icrc-ledger-client-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc-ledger-client-cdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "ICRC-1 compliant client library."
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Bump the version of `icrc-ledger-client-cdk` to include `ic-cdk` `v0.18.6`. Also set the FI team as the code owners of the `icrc-ledger-client-cdk` package.