### PR TITLE
test: improve testing of ICRC1 Rosetta CLI args [FI-1784]

### DIFF
--- a/rs/rosetta-api/icrc1/src/config.rs
+++ b/rs/rosetta-api/icrc1/src/config.rs
@@ -1,0 +1,570 @@
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+use ic_base_types::{CanisterId, PrincipalId};
+use std::path::PathBuf;
+use std::str::FromStr;
+use tracing::Level;
+use url::Url;
+
+const MAINNET_DEFAULT_URL: &str = "https://ic0.app";
+const TESTNET_DEFAULT_URL: &str = "https://exchanges.testnet.dfinity.network";
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum StoreType {
+    InMemory,
+    File,
+}
+
+#[derive(Clone, Debug)]
+pub enum Store {
+    Memory,
+    File { dir_path: PathBuf },
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum NetworkType {
+    Mainnet,
+    Testnet,
+}
+
+// This struct is used to parse the token definitions from the command line arguments.
+// The token definitions are in the format: canister_id[:s=symbol][:d=decimals]
+// The symbol and decimals are optional.
+#[derive(Clone, Debug)]
+pub struct TokenDef {
+    pub ledger_id: CanisterId,
+    // Below are optional, checked against online values if set.
+    pub icrc1_symbol: Option<String>,
+    pub icrc1_decimals: Option<u8>,
+}
+
+impl TokenDef {
+    pub fn from_string(token_description: &str) -> Result<Self> {
+        let parts: Vec<&str> = token_description.split(':').collect();
+        if parts.is_empty() || parts.len() > 3 {
+            return Err(anyhow::Error::msg(format!("Invalid token description: {}", token_description)));
+        }
+
+        let principal_id = PrincipalId::from_str(parts[0])
+            .context(format!("Failed to parse PrincipalId from {}", parts[0]))?;
+        let ledger_id = CanisterId::try_from_principal_id(principal_id)?;
+
+        let mut icrc1_symbol: Option<String> = None;
+        let mut icrc1_decimals: Option<u8> = None;
+
+        for part in parts.iter().skip(1) {
+            if let Some(symbol) = part.strip_prefix("s=") {
+                icrc1_symbol = Some(symbol.to_string());
+            } else if let Some(decimals) = part.strip_prefix("d=") {
+                icrc1_decimals = Some(
+                    decimals
+                        .parse()
+                        .context(format!("Failed to parse u8 from {}", part))?,
+                );
+            } else {
+                return Err(anyhow::Error::msg(format!(
+                    "Invalid token description: {}. It must be canister_id[:s=symbol][:d=decimals]",
+                    token_description
+                )));
+            }
+        }
+
+        Ok(Self {
+            ledger_id,
+            icrc1_symbol,
+            icrc1_decimals,
+        })
+    }
+
+    pub fn are_metadata_args_set(&self) -> bool {
+        self.icrc1_symbol.is_some() && self.icrc1_decimals.is_some()
+    }
+}
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    #[arg(short, long)]
+    pub ledger_id: Option<CanisterId>,
+
+    /// The token definitions in the format: canister_id[:s=symbol][:d=decimals]
+    /// The symbol and decimals are optional.
+    /// Can't be used with ledger_id.
+    #[arg(long, value_delimiter = ',', num_args = 0..)]
+    pub multi_tokens: Vec<String>,
+
+    /// The directory where the databases for the multi-tokens will be stored.
+    #[arg(long, default_value = "/data")]
+    pub multi_tokens_store_dir: PathBuf,
+
+    /// The symbol of the ICRC-1 token.
+    /// If set Rosetta will check the symbol against the ledger it connects to. If the symbol does not match, it will exit.
+    #[arg(long)]
+    pub icrc1_symbol: Option<String>,
+
+    #[arg(long)]
+    pub icrc1_decimals: Option<u8>,
+
+    /// The port to which Rosetta will bind.
+    /// If not set then it will be 0.
+    #[arg(short, long)]
+    pub port: Option<u16>,
+
+    /// The file where the port to which Rosetta will bind
+    /// will be written.
+    #[arg(short = 'P', long)]
+    pub port_file: Option<PathBuf>,
+
+    /// The type of the store to use.
+    #[arg(short, long, value_enum, default_value_t = StoreType::File)]
+    pub store_type: StoreType,
+
+    /// The file to use for the store if [store_type] is file.
+    #[arg(short = 'f', long, default_value = "/data/db.sqlite")]
+    pub store_file: PathBuf,
+
+    /// The network type that rosetta connects to.
+    #[arg(short = 'n', long, value_enum)]
+    pub network_type: NetworkType,
+
+    /// URL of the IC to connect to.
+    /// Default Mainnet URL is: https://ic0.app,
+    /// Default Testnet URL is: https://exchanges.testnet.dfinity.network
+    #[arg(long, short = 'u')]
+    pub network_url: Option<String>,
+
+    #[arg(short = 'L', long, default_value_t = Level::INFO)]
+    pub log_level: Level,
+
+    /// Set this option to only do one full sync of the ledger and then exit rosetta
+    #[arg(long = "exit-on-sync")]
+    pub exit_on_sync: bool,
+
+    /// Set this option to only run the rosetta server, no block synchronization will be performed and no transactions can be submitted in this mode.
+    #[arg(long)]
+    pub offline: bool,
+
+    /// The file to use for storing logs.
+    #[arg(long = "log-file", default_value = "log/rosetta-api.log")]
+    pub log_file: PathBuf,
+
+    /// Timeout in seconds for sync watchdog. If no synchronization is attempted within this time, the sync thread will be restarted.
+    #[arg(long = "watchdog-timeout-seconds", default_value = "60")]
+    pub watchdog_timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedConfig {
+    pub tokens: Vec<TokenDef>,
+    pub store: Store,
+    pub port: Option<u16>,
+    pub port_file: Option<PathBuf>,
+    pub network_url: Url,
+    pub log_level: Level,
+    pub exit_on_sync: bool,
+    pub offline: bool,
+    pub log_file: PathBuf,
+    pub watchdog_timeout_seconds: u64,
+}
+
+impl ParsedConfig {
+    pub fn from_args(args: Args) -> Result<Self> {
+        let tokens = Self::extract_token_defs_from_args(&args)?;
+        
+        // Compute the effective network URL based on network_type and provided URL
+        let network_url_str = args.network_url.unwrap_or_else(|| {
+            match args.network_type {
+                NetworkType::Mainnet => MAINNET_DEFAULT_URL.to_string(),
+                NetworkType::Testnet => TESTNET_DEFAULT_URL.to_string(),
+            }
+        });
+        
+        let network_url = Url::parse(&network_url_str)
+            .context(format!("Failed to parse network URL: {}", network_url_str))?;
+        
+        // Construct the appropriate store type
+        let store = match args.store_type {
+            StoreType::InMemory => Store::Memory,
+            StoreType::File => Store::File {
+                dir_path: args.multi_tokens_store_dir,
+            },
+        };
+        
+        Ok(Self {
+            tokens,
+            store,
+            port: args.port,
+            port_file: args.port_file,
+            network_url,
+            log_level: args.log_level,
+            exit_on_sync: args.exit_on_sync,
+            offline: args.offline,
+            log_file: args.log_file,
+            watchdog_timeout_seconds: args.watchdog_timeout_seconds,
+        })
+    }
+
+    /// Return the port to which Rosetta should bind to.
+    pub fn get_port(&self) -> u16 {
+        match (&self.port, &self.port_file) {
+            (None, None) => 8080,
+            (None, Some(_)) => 0,
+            (Some(port), _) => *port,
+        }
+    }
+
+    pub fn is_mainnet(&self) -> bool {
+        // Handle both with and without trailing slash since URL parsing normalizes
+        self.network_url.as_str() == MAINNET_DEFAULT_URL 
+            || self.network_url.as_str() == "https://ic0.app/"
+    }
+
+    /// Parses TokenDefs from the command line arguments.
+    fn extract_token_defs_from_args(args: &Args) -> Result<Vec<TokenDef>> {
+        let mut input_tokens = args.multi_tokens.clone();
+
+        // If no tokens are provided, use the legacy arguments
+        if input_tokens.is_empty() {
+            if args.ledger_id.is_none() {
+                return Err(anyhow::Error::msg("No token definitions provided"));
+            }
+
+            let mut token_dec = format!("{}", args.ledger_id.unwrap(),);
+
+            if args.icrc1_symbol.is_some() {
+                token_dec.push_str(&format!(":s={}", args.icrc1_symbol.clone().unwrap()));
+            }
+
+            if args.icrc1_decimals.is_some() {
+                token_dec.push_str(&format!(":d={}", args.icrc1_decimals.unwrap()));
+            }
+
+            input_tokens.push(token_dec);
+        } else {
+            if args.ledger_id.is_some() {
+                return Err(anyhow::Error::msg("Cannot provide both multi-tokens and ledger-id"));
+            }
+            if args.icrc1_symbol.is_some() {
+                return Err(anyhow::Error::msg("Cannot provide both multi-tokens and icrc1-symbol"));
+            }
+            if args.icrc1_decimals.is_some() {
+                return Err(anyhow::Error::msg("Cannot provide both multi-tokens and icrc1-decimals"));
+            }
+        }
+
+        let token_defs: Vec<TokenDef> = input_tokens
+            .iter()
+            .map(|token_description| TokenDef::from_string(token_description))
+            .collect::<Result<Vec<TokenDef>>>()?;
+
+        Ok(token_defs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::str::FromStr;
+    use tracing::Level;
+
+    fn create_test_args() -> Args {
+        Args {
+            ledger_id: None,
+            multi_tokens: vec![],
+            multi_tokens_store_dir: PathBuf::from("/test"),
+            icrc1_symbol: None,
+            icrc1_decimals: None,
+            port: None,
+            port_file: None,
+            store_type: StoreType::InMemory,
+            store_file: PathBuf::from("/test/db.sqlite"),
+            network_type: NetworkType::Testnet,
+            network_url: None,
+            log_level: Level::INFO,
+            exit_on_sync: false,
+            offline: false,
+            log_file: PathBuf::from("/test/log"),
+            watchdog_timeout_seconds: 60,
+        }
+    }
+
+    #[test]
+    fn test_token_def_from_string_valid_canister_only() {
+        let canister_id = "rdmx6-jaaaa-aaaaa-aaadq-cai";
+        let token_def = TokenDef::from_string(canister_id).unwrap();
+        
+        assert_eq!(token_def.ledger_id.to_string(), canister_id);
+        assert_eq!(token_def.icrc1_symbol, None);
+        assert_eq!(token_def.icrc1_decimals, None);
+    }
+
+    #[test]
+    fn test_token_def_from_string_with_symbol() {
+        let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:s=ICP";
+        let token_def = TokenDef::from_string(token_desc).unwrap();
+        
+        assert_eq!(token_def.ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+        assert_eq!(token_def.icrc1_symbol, Some("ICP".to_string()));
+        assert_eq!(token_def.icrc1_decimals, None);
+    }
+
+    #[test]
+    fn test_token_def_from_string_with_decimals() {
+        let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:d=8";
+        let token_def = TokenDef::from_string(token_desc).unwrap();
+        
+        assert_eq!(token_def.ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+        assert_eq!(token_def.icrc1_symbol, None);
+        assert_eq!(token_def.icrc1_decimals, Some(8));
+    }
+
+    #[test]
+    fn test_token_def_from_string_with_symbol_and_decimals() {
+        let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:s=ICP:d=8";
+        let token_def = TokenDef::from_string(token_desc).unwrap();
+        
+        assert_eq!(token_def.ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+        assert_eq!(token_def.icrc1_symbol, Some("ICP".to_string()));
+        assert_eq!(token_def.icrc1_decimals, Some(8));
+    }
+
+    #[test]
+    fn test_token_def_from_string_invalid_empty() {
+        let result = TokenDef::from_string("");
+        assert!(result.is_err());
+        // Empty string gets split into one empty part, so it fails on principal parsing
+        assert!(result.unwrap_err().to_string().contains("Failed to parse PrincipalId"));
+    }
+
+    #[test]
+    fn test_token_def_from_string_invalid_too_many_parts() {
+        let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:s=ICP:d=8:extra";
+        let result = TokenDef::from_string(token_desc);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid token description"));
+    }
+
+    #[test]
+    fn test_token_def_from_string_invalid_principal() {
+        let result = TokenDef::from_string("invalid-principal");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Failed to parse PrincipalId"));
+    }
+
+    #[test]
+    fn test_token_def_from_string_invalid_format() {
+        let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:invalid=value";
+        let result = TokenDef::from_string(token_desc);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("It must be canister_id[:s=symbol][:d=decimals]"));
+    }
+
+    #[test]
+    fn test_token_def_from_string_invalid_decimals() {
+        let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:d=invalid";
+        let result = TokenDef::from_string(token_desc);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Failed to parse u8"));
+    }
+
+    #[test]
+    fn test_token_def_are_metadata_args_set() {
+        let mut token_def = TokenDef {
+            ledger_id: CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap(),
+            icrc1_symbol: None,
+            icrc1_decimals: None,
+        };
+        
+        assert!(!token_def.are_metadata_args_set());
+        
+        token_def.icrc1_symbol = Some("ICP".to_string());
+        assert!(!token_def.are_metadata_args_set());
+        
+        token_def.icrc1_decimals = Some(8);
+        assert!(token_def.are_metadata_args_set());
+    }
+
+    #[test]
+    fn test_parsed_config_from_args_legacy_single_token() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.icrc1_symbol = Some("ICP".to_string());
+        args.icrc1_decimals = Some(8);
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        assert_eq!(config.tokens.len(), 1);
+        assert_eq!(config.tokens[0].ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+        assert_eq!(config.tokens[0].icrc1_symbol, Some("ICP".to_string()));
+        assert_eq!(config.tokens[0].icrc1_decimals, Some(8));
+    }
+
+    #[test]
+    fn test_parsed_config_from_args_multi_tokens() {
+        let mut args = create_test_args();
+        args.multi_tokens = vec![
+            "rdmx6-jaaaa-aaaaa-aaadq-cai:s=ICP:d=8".to_string(),
+            "rrkah-fqaaa-aaaaa-aaaaq-cai".to_string(),
+        ];
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        assert_eq!(config.tokens.len(), 2);
+        assert_eq!(config.tokens[0].ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+        assert_eq!(config.tokens[0].icrc1_symbol, Some("ICP".to_string()));
+        assert_eq!(config.tokens[1].ledger_id.to_string(), "rrkah-fqaaa-aaaaa-aaaaq-cai");
+        assert_eq!(config.tokens[1].icrc1_symbol, None);
+    }
+
+    #[test]
+    fn test_parsed_config_from_args_no_tokens_error() {
+        let args = create_test_args();
+        let result = ParsedConfig::from_args(args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No token definitions provided"));
+    }
+
+    #[test]
+    fn test_parsed_config_from_args_conflicting_args_ledger_id() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.multi_tokens = vec!["rrkah-fqaaa-aaaaa-aaaaq-cai".to_string()];
+        
+        let result = ParsedConfig::from_args(args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Cannot provide both multi-tokens and ledger-id"));
+    }
+
+    #[test]
+    fn test_parsed_config_from_args_conflicting_args_symbol() {
+        let mut args = create_test_args();
+        args.icrc1_symbol = Some("ICP".to_string());
+        args.multi_tokens = vec!["rrkah-fqaaa-aaaaa-aaaaq-cai".to_string()];
+        
+        let result = ParsedConfig::from_args(args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Cannot provide both multi-tokens and icrc1-symbol"));
+    }
+
+    #[test]
+    fn test_parsed_config_from_args_conflicting_args_decimals() {
+        let mut args = create_test_args();
+        args.icrc1_decimals = Some(8);
+        args.multi_tokens = vec!["rrkah-fqaaa-aaaaa-aaaaq-cai".to_string()];
+        
+        let result = ParsedConfig::from_args(args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Cannot provide both multi-tokens and icrc1-decimals"));
+    }
+
+    #[test]
+    fn test_parsed_config_network_url_mainnet_default() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.network_type = NetworkType::Mainnet;
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        assert_eq!(config.network_url.as_str(), "https://ic0.app/"); // URL parsing adds trailing slash
+        assert!(config.is_mainnet());
+    }
+
+    #[test]
+    fn test_parsed_config_network_url_testnet_default() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.network_type = NetworkType::Testnet;
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        assert_eq!(config.network_url.as_str(), "https://exchanges.testnet.dfinity.network/"); // URL parsing adds trailing slash
+        assert!(!config.is_mainnet());
+    }
+
+    #[test]
+    fn test_parsed_config_network_url_custom() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.network_url = Some("https://custom.network.com".to_string());
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        assert_eq!(config.network_url.as_str(), "https://custom.network.com/"); // URL parsing adds trailing slash
+        assert!(!config.is_mainnet()); // Custom URL is not considered mainnet
+    }
+
+    #[test]
+    fn test_parsed_config_network_url_invalid() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.network_url = Some("invalid-url".to_string());
+        
+        let result = ParsedConfig::from_args(args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Failed to parse network URL"));
+    }
+
+    #[test]
+    fn test_parsed_config_store_memory() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.store_type = StoreType::InMemory;
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        match config.store {
+            Store::Memory => {},
+            Store::File { .. } => panic!("Expected Memory store type"),
+        }
+    }
+
+    #[test]
+    fn test_parsed_config_store_file() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.store_type = StoreType::File;
+        args.multi_tokens_store_dir = PathBuf::from("/custom/path");
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        match config.store {
+            Store::File { dir_path } => {
+                assert_eq!(dir_path, PathBuf::from("/custom/path"));
+            },
+            Store::Memory => panic!("Expected File store type"),
+        }
+    }
+
+    #[test]
+    fn test_parsed_config_get_port_default() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        assert_eq!(config.get_port(), 8080);
+    }
+
+    #[test]
+    fn test_parsed_config_get_port_explicit() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.port = Some(9090);
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        assert_eq!(config.get_port(), 9090);
+    }
+
+    #[test]
+    fn test_parsed_config_get_port_with_port_file() {
+        let mut args = create_test_args();
+        args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
+        args.port_file = Some(PathBuf::from("/tmp/port"));
+        
+        let config = ParsedConfig::from_args(args).unwrap();
+        
+        assert_eq!(config.get_port(), 0);
+    }
+}

--- a/rs/rosetta-api/icrc1/src/config.rs
+++ b/rs/rosetta-api/icrc1/src/config.rs
@@ -42,7 +42,10 @@ impl TokenDef {
     pub fn from_string(token_description: &str) -> Result<Self> {
         let parts: Vec<&str> = token_description.split(':').collect();
         if parts.is_empty() || parts.len() > 3 {
-            return Err(anyhow::Error::msg(format!("Invalid token description: {}", token_description)));
+            return Err(anyhow::Error::msg(format!(
+                "Invalid token description: {}",
+                token_description
+            )));
         }
 
         let principal_id = PrincipalId::from_str(parts[0])
@@ -170,18 +173,16 @@ pub struct ParsedConfig {
 impl ParsedConfig {
     pub fn from_args(args: Args) -> Result<Self> {
         let tokens = Self::extract_token_defs_from_args(&args)?;
-        
+
         // Compute the effective network URL based on network_type and provided URL
-        let network_url_str = args.network_url.unwrap_or_else(|| {
-            match args.network_type {
-                NetworkType::Mainnet => MAINNET_DEFAULT_URL.to_string(),
-                NetworkType::Testnet => TESTNET_DEFAULT_URL.to_string(),
-            }
+        let network_url_str = args.network_url.unwrap_or_else(|| match args.network_type {
+            NetworkType::Mainnet => MAINNET_DEFAULT_URL.to_string(),
+            NetworkType::Testnet => TESTNET_DEFAULT_URL.to_string(),
         });
-        
+
         let network_url = Url::parse(&network_url_str)
             .context(format!("Failed to parse network URL: {}", network_url_str))?;
-        
+
         // Construct the appropriate store type
         let store = match args.store_type {
             StoreType::InMemory => Store::Memory,
@@ -189,7 +190,7 @@ impl ParsedConfig {
                 dir_path: args.multi_tokens_store_dir,
             },
         };
-        
+
         Ok(Self {
             tokens,
             store,
@@ -215,7 +216,7 @@ impl ParsedConfig {
 
     pub fn is_mainnet(&self) -> bool {
         // Handle both with and without trailing slash since URL parsing normalizes
-        self.network_url.as_str() == MAINNET_DEFAULT_URL 
+        self.network_url.as_str() == MAINNET_DEFAULT_URL
             || self.network_url.as_str() == "https://ic0.app/"
     }
 
@@ -242,13 +243,19 @@ impl ParsedConfig {
             input_tokens.push(token_dec);
         } else {
             if args.ledger_id.is_some() {
-                return Err(anyhow::Error::msg("Cannot provide both multi-tokens and ledger-id"));
+                return Err(anyhow::Error::msg(
+                    "Cannot provide both multi-tokens and ledger-id",
+                ));
             }
             if args.icrc1_symbol.is_some() {
-                return Err(anyhow::Error::msg("Cannot provide both multi-tokens and icrc1-symbol"));
+                return Err(anyhow::Error::msg(
+                    "Cannot provide both multi-tokens and icrc1-symbol",
+                ));
             }
             if args.icrc1_decimals.is_some() {
-                return Err(anyhow::Error::msg("Cannot provide both multi-tokens and icrc1-decimals"));
+                return Err(anyhow::Error::msg(
+                    "Cannot provide both multi-tokens and icrc1-decimals",
+                ));
             }
         }
 
@@ -293,7 +300,7 @@ mod tests {
     fn test_token_def_from_string_valid_canister_only() {
         let canister_id = "rdmx6-jaaaa-aaaaa-aaadq-cai";
         let token_def = TokenDef::from_string(canister_id).unwrap();
-        
+
         assert_eq!(token_def.ledger_id.to_string(), canister_id);
         assert_eq!(token_def.icrc1_symbol, None);
         assert_eq!(token_def.icrc1_decimals, None);
@@ -303,8 +310,11 @@ mod tests {
     fn test_token_def_from_string_with_symbol() {
         let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:s=ICP";
         let token_def = TokenDef::from_string(token_desc).unwrap();
-        
-        assert_eq!(token_def.ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+
+        assert_eq!(
+            token_def.ledger_id.to_string(),
+            "rdmx6-jaaaa-aaaaa-aaadq-cai"
+        );
         assert_eq!(token_def.icrc1_symbol, Some("ICP".to_string()));
         assert_eq!(token_def.icrc1_decimals, None);
     }
@@ -313,8 +323,11 @@ mod tests {
     fn test_token_def_from_string_with_decimals() {
         let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:d=8";
         let token_def = TokenDef::from_string(token_desc).unwrap();
-        
-        assert_eq!(token_def.ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+
+        assert_eq!(
+            token_def.ledger_id.to_string(),
+            "rdmx6-jaaaa-aaaaa-aaadq-cai"
+        );
         assert_eq!(token_def.icrc1_symbol, None);
         assert_eq!(token_def.icrc1_decimals, Some(8));
     }
@@ -323,8 +336,11 @@ mod tests {
     fn test_token_def_from_string_with_symbol_and_decimals() {
         let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:s=ICP:d=8";
         let token_def = TokenDef::from_string(token_desc).unwrap();
-        
-        assert_eq!(token_def.ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+
+        assert_eq!(
+            token_def.ledger_id.to_string(),
+            "rdmx6-jaaaa-aaaaa-aaadq-cai"
+        );
         assert_eq!(token_def.icrc1_symbol, Some("ICP".to_string()));
         assert_eq!(token_def.icrc1_decimals, Some(8));
     }
@@ -334,7 +350,10 @@ mod tests {
         let result = TokenDef::from_string("");
         assert!(result.is_err());
         // Empty string gets split into one empty part, so it fails on principal parsing
-        assert!(result.unwrap_err().to_string().contains("Failed to parse PrincipalId"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to parse PrincipalId"));
     }
 
     #[test]
@@ -342,14 +361,20 @@ mod tests {
         let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:s=ICP:d=8:extra";
         let result = TokenDef::from_string(token_desc);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Invalid token description"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid token description"));
     }
 
     #[test]
     fn test_token_def_from_string_invalid_principal() {
         let result = TokenDef::from_string("invalid-principal");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Failed to parse PrincipalId"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to parse PrincipalId"));
     }
 
     #[test]
@@ -357,7 +382,10 @@ mod tests {
         let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:invalid=value";
         let result = TokenDef::from_string(token_desc);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("It must be canister_id[:s=symbol][:d=decimals]"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("It must be canister_id[:s=symbol][:d=decimals]"));
     }
 
     #[test]
@@ -365,7 +393,10 @@ mod tests {
         let token_desc = "rdmx6-jaaaa-aaaaa-aaadq-cai:d=invalid";
         let result = TokenDef::from_string(token_desc);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Failed to parse u8"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to parse u8"));
     }
 
     #[test]
@@ -375,12 +406,12 @@ mod tests {
             icrc1_symbol: None,
             icrc1_decimals: None,
         };
-        
+
         assert!(!token_def.are_metadata_args_set());
-        
+
         token_def.icrc1_symbol = Some("ICP".to_string());
         assert!(!token_def.are_metadata_args_set());
-        
+
         token_def.icrc1_decimals = Some(8);
         assert!(token_def.are_metadata_args_set());
     }
@@ -391,11 +422,14 @@ mod tests {
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.icrc1_symbol = Some("ICP".to_string());
         args.icrc1_decimals = Some(8);
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
+
         assert_eq!(config.tokens.len(), 1);
-        assert_eq!(config.tokens[0].ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+        assert_eq!(
+            config.tokens[0].ledger_id.to_string(),
+            "rdmx6-jaaaa-aaaaa-aaadq-cai"
+        );
         assert_eq!(config.tokens[0].icrc1_symbol, Some("ICP".to_string()));
         assert_eq!(config.tokens[0].icrc1_decimals, Some(8));
     }
@@ -407,13 +441,19 @@ mod tests {
             "rdmx6-jaaaa-aaaaa-aaadq-cai:s=ICP:d=8".to_string(),
             "rrkah-fqaaa-aaaaa-aaaaq-cai".to_string(),
         ];
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
+
         assert_eq!(config.tokens.len(), 2);
-        assert_eq!(config.tokens[0].ledger_id.to_string(), "rdmx6-jaaaa-aaaaa-aaadq-cai");
+        assert_eq!(
+            config.tokens[0].ledger_id.to_string(),
+            "rdmx6-jaaaa-aaaaa-aaadq-cai"
+        );
         assert_eq!(config.tokens[0].icrc1_symbol, Some("ICP".to_string()));
-        assert_eq!(config.tokens[1].ledger_id.to_string(), "rrkah-fqaaa-aaaaa-aaaaq-cai");
+        assert_eq!(
+            config.tokens[1].ledger_id.to_string(),
+            "rrkah-fqaaa-aaaaa-aaaaq-cai"
+        );
         assert_eq!(config.tokens[1].icrc1_symbol, None);
     }
 
@@ -422,7 +462,10 @@ mod tests {
         let args = create_test_args();
         let result = ParsedConfig::from_args(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No token definitions provided"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No token definitions provided"));
     }
 
     #[test]
@@ -430,10 +473,13 @@ mod tests {
         let mut args = create_test_args();
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.multi_tokens = vec!["rrkah-fqaaa-aaaaa-aaaaq-cai".to_string()];
-        
+
         let result = ParsedConfig::from_args(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Cannot provide both multi-tokens and ledger-id"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot provide both multi-tokens and ledger-id"));
     }
 
     #[test]
@@ -441,10 +487,13 @@ mod tests {
         let mut args = create_test_args();
         args.icrc1_symbol = Some("ICP".to_string());
         args.multi_tokens = vec!["rrkah-fqaaa-aaaaa-aaaaq-cai".to_string()];
-        
+
         let result = ParsedConfig::from_args(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Cannot provide both multi-tokens and icrc1-symbol"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot provide both multi-tokens and icrc1-symbol"));
     }
 
     #[test]
@@ -452,10 +501,13 @@ mod tests {
         let mut args = create_test_args();
         args.icrc1_decimals = Some(8);
         args.multi_tokens = vec!["rrkah-fqaaa-aaaaa-aaaaq-cai".to_string()];
-        
+
         let result = ParsedConfig::from_args(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Cannot provide both multi-tokens and icrc1-decimals"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot provide both multi-tokens and icrc1-decimals"));
     }
 
     #[test]
@@ -463,9 +515,9 @@ mod tests {
         let mut args = create_test_args();
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.network_type = NetworkType::Mainnet;
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
+
         assert_eq!(config.network_url.as_str(), "https://ic0.app/"); // URL parsing adds trailing slash
         assert!(config.is_mainnet());
     }
@@ -475,10 +527,13 @@ mod tests {
         let mut args = create_test_args();
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.network_type = NetworkType::Testnet;
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
-        assert_eq!(config.network_url.as_str(), "https://exchanges.testnet.dfinity.network/"); // URL parsing adds trailing slash
+
+        assert_eq!(
+            config.network_url.as_str(),
+            "https://exchanges.testnet.dfinity.network/"
+        ); // URL parsing adds trailing slash
         assert!(!config.is_mainnet());
     }
 
@@ -487,9 +542,9 @@ mod tests {
         let mut args = create_test_args();
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.network_url = Some("https://custom.network.com".to_string());
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
+
         assert_eq!(config.network_url.as_str(), "https://custom.network.com/"); // URL parsing adds trailing slash
         assert!(!config.is_mainnet()); // Custom URL is not considered mainnet
     }
@@ -499,10 +554,13 @@ mod tests {
         let mut args = create_test_args();
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.network_url = Some("invalid-url".to_string());
-        
+
         let result = ParsedConfig::from_args(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Failed to parse network URL"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to parse network URL"));
     }
 
     #[test]
@@ -510,11 +568,11 @@ mod tests {
         let mut args = create_test_args();
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.store_type = StoreType::InMemory;
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
+
         match config.store {
-            Store::Memory => {},
+            Store::Memory => {}
             Store::File { .. } => panic!("Expected Memory store type"),
         }
     }
@@ -525,13 +583,13 @@ mod tests {
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.store_type = StoreType::File;
         args.multi_tokens_store_dir = PathBuf::from("/custom/path");
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
+
         match config.store {
             Store::File { dir_path } => {
                 assert_eq!(dir_path, PathBuf::from("/custom/path"));
-            },
+            }
             Store::Memory => panic!("Expected File store type"),
         }
     }
@@ -540,9 +598,9 @@ mod tests {
     fn test_parsed_config_get_port_default() {
         let mut args = create_test_args();
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
+
         assert_eq!(config.get_port(), 8080);
     }
 
@@ -551,9 +609,9 @@ mod tests {
         let mut args = create_test_args();
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.port = Some(9090);
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
+
         assert_eq!(config.get_port(), 9090);
     }
 
@@ -562,9 +620,9 @@ mod tests {
         let mut args = create_test_args();
         args.ledger_id = Some(CanisterId::from_str("rdmx6-jaaaa-aaaaa-aaadq-cai").unwrap());
         args.port_file = Some(PathBuf::from("/tmp/port"));
-        
+
         let config = ParsedConfig::from_args(args).unwrap();
-        
+
         assert_eq!(config.get_port(), 0);
     }
 }

--- a/rs/rosetta-api/icrc1/src/lib.rs
+++ b/rs/rosetta-api/icrc1/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 };
 use tokio::sync::Mutex as AsyncMutex;
 pub mod common;
+pub mod config;
 pub mod construction_api;
 pub mod data_api;
 pub mod ledger_blocks_synchronization;

--- a/rs/rosetta-api/icrc1/src/main.rs
+++ b/rs/rosetta-api/icrc1/src/main.rs
@@ -24,6 +24,7 @@ use ic_icrc_rosetta::{
 use ic_sys::fs::write_string_using_tmp_file;
 use icrc_ledger_agent::{CallMode, Icrc1Agent};
 
+use config::{Args, ParsedConfig, Store, TokenDef};
 use rosetta_core::metrics::RosettaMetrics;
 use rosetta_core::watchdog::WatchdogThread;
 use std::collections::HashMap;
@@ -40,11 +41,8 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{Layer, Registry};
 use url::Url;
-use config::{Args, ParsedConfig, Store, TokenDef};
 
 const MAXIMUM_BLOCKS_PER_REQUEST: u64 = 2000;
-
-
 
 fn init_logs(log_level: Level, log_file_path: &PathBuf) -> anyhow::Result<WorkerGuard> {
     let stdout_layer = tracing_subscriber::fmt::Layer::default()
@@ -184,8 +182,6 @@ async fn load_metadata(
     Metadata::from_metadata_entries(&ic_metadata_entries)
 }
 
-
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
@@ -241,7 +237,8 @@ async fn main() -> Result<()> {
             }
         };
 
-        let metadata = match load_metadata(token_def, &icrc1_agent, &storage, config.offline).await {
+        let metadata = match load_metadata(token_def, &icrc1_agent, &storage, config.offline).await
+        {
             Ok(metadata) => metadata,
             Err(err) => {
                 warn!(

--- a/rs/rosetta-api/icrc1/src/main.rs
+++ b/rs/rosetta-api/icrc1/src/main.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::disallowed_types)]
+mod config;
 use anyhow::{bail, Context, Result};
 use axum::{
     body::Body,
@@ -6,7 +7,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use ic_agent::{identity::AnonymousIdentity, Agent};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_icrc_rosetta::common::storage::storage_client::TokenInfo;
@@ -22,11 +23,10 @@ use ic_icrc_rosetta::{
 };
 use ic_sys::fs::write_string_using_tmp_file;
 use icrc_ledger_agent::{CallMode, Icrc1Agent};
-use lazy_static::lazy_static;
+
 use rosetta_core::metrics::RosettaMetrics;
 use rosetta_core::watchdog::WatchdogThread;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::{path::PathBuf, process, time::Duration};
 use tokio::{net::TcpListener, sync::Mutex as AsyncMutex};
@@ -40,177 +40,11 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{Layer, Registry};
 use url::Url;
+use config::{Args, ParsedConfig, Store, TokenDef};
 
-lazy_static! {
-    static ref MAINNET_DEFAULT_URL: &'static str = "https://ic0.app";
-    static ref TESTNET_DEFAULT_URL: &'static str = "https://exchanges.testnet.dfinity.network";
-    static ref MAXIMUM_BLOCKS_PER_REQUEST: u64 = 2000;
-}
+const MAXIMUM_BLOCKS_PER_REQUEST: u64 = 2000;
 
-#[derive(Clone, Debug, ValueEnum)]
-enum StoreType {
-    InMemory,
-    File,
-}
 
-#[derive(Clone, Debug, ValueEnum)]
-enum NetworkType {
-    Mainnet,
-    Testnet,
-}
-
-// This struct is used to parse the token definitions from the command line arguments.
-// The token definitions are in the format: canister_id[:s=symbol][:d=decimals]
-// The symbol and decimals are optional.
-#[derive(Clone, Debug)]
-struct TokenDef {
-    ledger_id: CanisterId,
-    // Below are optional, checked against online values if set.
-    icrc1_symbol: Option<String>,
-    icrc1_decimals: Option<u8>,
-}
-
-impl TokenDef {
-    fn from_string(token_description: &str) -> Result<Self> {
-        let parts: Vec<&str> = token_description.split(':').collect();
-        if parts.is_empty() || parts.len() > 3 {
-            bail!("Invalid token description: {}", token_description);
-        }
-
-        let principal_id = PrincipalId::from_str(parts[0])
-            .context(format!("Failed to parse PrincipalId from {}", parts[0]))?;
-        let ledger_id = CanisterId::try_from_principal_id(principal_id)?;
-
-        let mut icrc1_symbol: Option<String> = None;
-        let mut icrc1_decimals: Option<u8> = None;
-
-        for part in parts.iter().skip(1) {
-            if let Some(symbol) = part.strip_prefix("s=") {
-                icrc1_symbol = Some(symbol.to_string());
-            } else if let Some(decimals) = part.strip_prefix("d=") {
-                icrc1_decimals = Some(
-                    decimals
-                        .parse()
-                        .context(format!("Failed to parse u8 from {}", part))?,
-                );
-            } else {
-                bail!(
-                    "Invalid token description: {}. It must be canister_id[:s=symbol][:d=decimals]",
-                    token_description
-                );
-            }
-        }
-
-        Ok(Self {
-            ledger_id,
-            icrc1_symbol,
-            icrc1_decimals,
-        })
-    }
-
-    fn are_metadata_args_set(&self) -> bool {
-        self.icrc1_symbol.is_some() && self.icrc1_decimals.is_some()
-    }
-}
-
-#[derive(Debug, Parser)]
-#[command(author, version, about, long_about = None)]
-struct Args {
-    #[arg(short, long)]
-    ledger_id: Option<CanisterId>,
-
-    /// The token definitions in the format: canister_id[:s=symbol][:d=decimals]
-    /// The symbol and decimals are optional.
-    /// Can't be used with ledger_id.
-    #[arg(long, value_delimiter = ',', num_args = 0..)]
-    multi_tokens: Vec<String>,
-
-    /// The directory where the databases for the multi-tokens will be stored.
-    #[arg(long, default_value = "/data")]
-    multi_tokens_store_dir: PathBuf,
-
-    /// The symbol of the ICRC-1 token.
-    /// If set Rosetta will check the symbol against the ledger it connects to. If the symbol does not match, it will exit.
-    #[arg(long)]
-    icrc1_symbol: Option<String>,
-
-    #[arg(long)]
-    icrc1_decimals: Option<u8>,
-
-    /// The port to which Rosetta will bind.
-    /// If not set then it will be 0.
-    #[arg(short, long)]
-    port: Option<u16>,
-
-    /// The file where the port to which Rosetta will bind
-    /// will be written.
-    #[arg(short = 'P', long)]
-    port_file: Option<PathBuf>,
-
-    /// The type of the store to use.
-    #[arg(short, long, value_enum, default_value_t = StoreType::File)]
-    store_type: StoreType,
-
-    /// The file to use for the store if [store_type] is file.
-    #[arg(short = 'f', long, default_value = "/data/db.sqlite")]
-    store_file: PathBuf,
-
-    /// The network type that rosetta connects to.
-    #[arg(short = 'n', long, value_enum)]
-    network_type: NetworkType,
-
-    /// URL of the IC to connect to.
-    /// Default Mainnet URL is: https://ic0.app,
-    /// Default Testnet URL is: https://exchanges.testnet.dfinity.network
-    #[arg(long, short = 'u')]
-    network_url: Option<String>,
-
-    #[arg(short = 'L', long, default_value_t = Level::INFO)]
-    log_level: Level,
-
-    /// Set this option to only do one full sync of the ledger and then exit rosetta
-    #[arg(long = "exit-on-sync")]
-    exit_on_sync: bool,
-
-    /// Set this option to only run the rosetta server, no block synchronization will be performed and no transactions can be submitted in this mode.
-    #[arg(long)]
-    offline: bool,
-
-    /// The file to use for storing logs.
-    #[arg(long = "log-file", default_value = "log/rosetta-api.log")]
-    log_file: PathBuf,
-
-    /// Timeout in seconds for sync watchdog. If no synchronization is attempted within this time, the sync thread will be restarted.
-    #[arg(long = "watchdog-timeout-seconds", default_value = "60")]
-    watchdog_timeout_seconds: u64,
-}
-
-impl Args {
-    /// Return the port to which Rosetta should bind to.
-    fn get_port(&self) -> u16 {
-        match (&self.port, &self.port_file) {
-            (None, None) => 8080,
-            (None, Some(_)) => 0,
-            (Some(port), _) => *port,
-        }
-    }
-    fn is_mainnet(&self) -> bool {
-        match self.network_type {
-            NetworkType::Mainnet => true,
-            NetworkType::Testnet => false,
-        }
-    }
-
-    fn effective_network_url(&self) -> String {
-        self.network_url.clone().unwrap_or_else(|| {
-            if self.is_mainnet() {
-                (*MAINNET_DEFAULT_URL).to_string()
-            } else {
-                (*TESTNET_DEFAULT_URL).to_string()
-            }
-        })
-    }
-}
 
 fn init_logs(log_level: Level, log_file_path: &PathBuf) -> anyhow::Result<WorkerGuard> {
     let stdout_layer = tracing_subscriber::fmt::Layer::default()
@@ -350,77 +184,36 @@ async fn load_metadata(
     Metadata::from_metadata_entries(&ic_metadata_entries)
 }
 
-// Parses TokenDefs from the command line arguments.
-fn extract_token_defs(args: &Args) -> Result<Vec<TokenDef>> {
-    let mut input_tokens = args.multi_tokens.clone();
 
-    // If no tokens are provided, use the legacy arguments
-    if input_tokens.is_empty() {
-        if args.ledger_id.is_none() {
-            bail!("No token definitions provided");
-        }
-
-        let mut token_dec = format!("{}", args.ledger_id.unwrap(),);
-
-        if args.icrc1_symbol.is_some() {
-            token_dec.push_str(&format!(":s={}", args.icrc1_symbol.clone().unwrap()));
-        }
-
-        if args.icrc1_decimals.is_some() {
-            token_dec.push_str(&format!(":d={}", args.icrc1_decimals.unwrap()));
-        }
-
-        input_tokens.push(token_dec);
-    } else {
-        if args.ledger_id.is_some() {
-            bail!("Cannot provide both multi-tokens and ledger-id");
-        }
-        if args.icrc1_symbol.is_some() {
-            bail!("Cannot provide both multi-tokens and icrc1-symbol");
-        }
-        if args.icrc1_decimals.is_some() {
-            bail!("Cannot provide both multi-tokens and icrc1-decimals");
-        }
-    }
-
-    let token_defs: Vec<TokenDef> = input_tokens
-        .iter()
-        .map(|token_description| TokenDef::from_string(token_description))
-        .collect::<Result<Vec<TokenDef>>>()?;
-
-    Ok(token_defs)
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
+    let config = ParsedConfig::from_args(args)?;
 
-    let _guard = init_logs(args.log_level, &args.log_file)?;
+    let _guard = init_logs(config.log_level, &config.log_file)?;
 
     // Initialize rosetta metrics with a default canister ID
     // This will be updated for specific token operations but is required for middleware setup
     let rosetta_metrics = RosettaMetrics::new("icrc1".to_string(), "icrc1_default".to_string());
 
-    let token_defs = extract_token_defs(&args)?;
+    let token_defs = &config.tokens;
     let mut token_states = HashMap::new();
 
     let num_tokens = token_defs.len();
     let mut num_failed_tokens = 0;
 
     for token_def in token_defs.iter() {
-        let network_url = args.effective_network_url();
+        let network_url = &config.network_url;
 
         let ic_agent = Agent::builder()
             .with_identity(AnonymousIdentity)
-            .with_url(
-                Url::parse(&network_url)
-                    .context(format!("Failed to parse URL {}", network_url.clone()))?,
-            )
+            .with_url(network_url.clone())
             .with_http_client(reqwest::Client::new())
             .build()?;
 
         // Only fetch root key if the network is not the mainnet
-        if !args.is_mainnet() {
+        if !config.is_mainnet() {
             debug!("Network type is not mainnet --> Trying to fetch root key");
             ic_agent.fetch_root_key().await?;
         }
@@ -437,10 +230,10 @@ async fn main() -> Result<()> {
             ledger_canister_id: token_def.ledger_id.into(),
         });
 
-        let mut storage = match args.store_type {
-            StoreType::InMemory => StorageClient::new_in_memory()?,
-            StoreType::File => {
-                let mut path = args.multi_tokens_store_dir.clone();
+        let mut storage = match &config.store {
+            Store::Memory => StorageClient::new_in_memory()?,
+            Store::File { dir_path } => {
+                let mut path = dir_path.clone();
                 path.push(format!("{}.db", PrincipalId::from(token_def.ledger_id)));
                 StorageClient::new_persistent(&path).unwrap_or_else(|err| {
                     panic!("error creating persistent storage '{:?}': {}", path, err)
@@ -448,7 +241,7 @@ async fn main() -> Result<()> {
             }
         };
 
-        let metadata = match load_metadata(token_def, &icrc1_agent, &storage, args.offline).await {
+        let metadata = match load_metadata(token_def, &icrc1_agent, &storage, config.offline).await {
             Ok(metadata) => metadata,
             Err(err) => {
                 warn!(
@@ -502,8 +295,8 @@ async fn main() -> Result<()> {
         token_states: token_states.clone(),
     });
 
-    if args.exit_on_sync {
-        if args.offline {
+    if config.exit_on_sync {
+        if config.offline {
             bail!("'exit-on-sync' and 'offline' parameters cannot be specified at the same time.");
         }
 
@@ -515,7 +308,7 @@ async fn main() -> Result<()> {
                 start_synching_blocks(
                     shared_state.icrc1_agent.clone(),
                     shared_state.storage.clone(),
-                    *MAXIMUM_BLOCKS_PER_REQUEST,
+                    MAXIMUM_BLOCKS_PER_REQUEST,
                     shared_state.archive_canister_ids.clone(),
                     RecurrencyMode::OneShot,
                     Box::new(|| {}), // <-- no-op heartbeat
@@ -582,17 +375,17 @@ async fn main() -> Result<()> {
         .layer(RequestIdLayer)
         .with_state(token_app_states.clone());
 
-    let rosetta_url = format!("0.0.0.0:{}", args.get_port());
+    let rosetta_url = format!("0.0.0.0:{}", config.get_port());
     let tcp_listener = TcpListener::bind(rosetta_url.clone()).await?;
 
-    if let Some(port_file) = args.port_file {
+    if let Some(port_file) = config.port_file {
         write_string_using_tmp_file(
             port_file,
             tcp_listener.local_addr()?.port().to_string().as_str(),
         )?;
     }
 
-    if !args.offline {
+    if !config.offline {
         // For each token state, spawn a watchdog thread that repeatedly syncs blocks.
         for shared_state in token_app_states.token_states.values() {
             let token_name = shared_state.ledger_display_name();
@@ -602,7 +395,7 @@ async fn main() -> Result<()> {
 
             info!(
                 "Configuring watchdog for {} with timeout of {} seconds",
-                token_name, args.watchdog_timeout_seconds
+                token_name, config.watchdog_timeout_seconds
             );
 
             tokio::spawn(
@@ -613,7 +406,7 @@ async fn main() -> Result<()> {
                     let skip_first_hearbeat = true;
                     let local_state = Arc::clone(&shared_state);
                     let mut watchdog = WatchdogThread::new(
-                        Duration::from_secs(args.watchdog_timeout_seconds),
+                        Duration::from_secs(config.watchdog_timeout_seconds),
                         Some(Arc::new(move || {
                             local_state.storage.get_metrics().inc_sync_thread_restarts();
                             info!("Watchdog triggered restart for a sync thread");
@@ -630,7 +423,7 @@ async fn main() -> Result<()> {
                                 if let Err(e) = start_synching_blocks(
                                     shared_state.icrc1_agent.clone(),
                                     shared_state.storage.clone(),
-                                    *MAXIMUM_BLOCKS_PER_REQUEST,
+                                    MAXIMUM_BLOCKS_PER_REQUEST,
                                     shared_state.archive_canister_ids.clone(),
                                     RecurrencyMode::Recurrent(RecurrencyConfig {
                                         min_recurrency_wait: Duration::from_secs(


### PR DESCRIPTION
Makes the CLI arguments of ICRC1 Rosetta more testable and adds unit tests.

It introduces a `Config` struct, which represents the values of the CLI arguments after being parsed.

This is a prelude to adding the `--environment` preset to the CLI as we had done with ICP Rosetta.