### PR TITLE
chore: set up slack alerts for CI failures on ic-nervous-system-wasms

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -23,7 +23,7 @@ on:
       - PocketIC Windows
       - Sync IC private from IC public
       - Update IC versions file
-      - Bazel Test All
+      - CI Main
 
 jobs:
   slack-workflow-run:
@@ -67,8 +67,10 @@ jobs:
             CHANNEL="eng-crypto-alerts"
           elif [[ "$TRIGGERING_WORKFLOW_NAME" == "Update IC versions file" ]]; then
             CHANNEL="eng-consensus-alerts"
-          elif [[ "$TRIGGERING_WORKFLOW_NAME" == "Bazel Test All" ]] && [[ "$TRIGGERING_WORKFLOW_BRANCH" == "ic-mainnet-revisions" ]]; then
+          elif [[ "$TRIGGERING_WORKFLOW_NAME" == "CI Main" ]] && [[ "$TRIGGERING_WORKFLOW_BRANCH" == "ic-mainnet-revisions" ]]; then
             CHANNEL="eng-consensus-alerts"
+          elif [[ "$TRIGGERING_WORKFLOW_NAME" == "CI Main" ]] && [[ "$TRIGGERING_WORKFLOW_BRANCH" == "ic-nervous-system-wasms" ]]; then
+            CHANNEL="eng-nns"
           fi
 
           echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR sets up alerts sent to `#eng-nns` for failed CI runs on automatically generated PRs updating mainnet canister versions such as this [one](https://github.com/dfinity/ic/pull/6365). This PR also fixes the workflow name to be "CI Main".