### PR TITLE
chore: copy the test directory of the colocated test-driver to the local test-driver

### DIFF
--- a/rs/tests/idx/colocate_test.rs
+++ b/rs/tests/idx/colocate_test.rs
@@ -21,7 +21,7 @@ use std::str;
 use std::time::Duration;
 use std::{env, fs};
 
-const UVM_NAME: &str = "test-driver";
+const UVM_NAME: &str = "colocated-test-driver";
 const COLOCATED_TEST: &str = "COLOCATED_TEST";
 const COLOCATED_TEST_BIN: &str = "COLOCATED_TEST_BIN";
 const EXTRA_TIME_LOG_COLLECTION: Duration = Duration::from_secs(10);
@@ -93,7 +93,7 @@ fn setup(env: TestEnv) {
     let output = Command::new("tar")
         .arg("--create")
         .arg("--file")
-        .arg(runfiles_tar_path.clone())
+        .arg(&runfiles_tar_path)
         .arg("--auto-compress")
         .arg("--directory")
         .arg(runfiles)
@@ -120,7 +120,7 @@ fn setup(env: TestEnv) {
     let output = Command::new("tar")
         .arg("--create")
         .arg("--file")
-        .arg(env_tar_path.clone())
+        .arg(&env_tar_path)
         .arg("--auto-compress")
         .arg("--directory")
         .arg(env.base_path())
@@ -143,17 +143,17 @@ fn setup(env: TestEnv) {
         .block_on_ssh_session()
         .unwrap_or_else(|e| panic!("Failed to setup SSH session to {UVM_NAME} because: {e}"));
 
-    scp(
+    scp_send_to(
         log.clone(),
         &session,
-        runfiles_tar_path,
-        Path::new("/home/admin").join(RUNFILES_TAR_ZST),
+        &runfiles_tar_path,
+        &Path::new("/home/admin").join(RUNFILES_TAR_ZST),
     );
-    scp(
+    scp_send_to(
         log.clone(),
         &session,
-        env_tar_path,
-        Path::new("/home/admin").join(ENV_TAR_ZST),
+        &env_tar_path,
+        &Path::new("/home/admin").join(ENV_TAR_ZST),
     );
 
     // Create a temporary environment file that we SCP into the UVM. These environment
@@ -174,11 +174,11 @@ fn setup(env: TestEnv) {
 
         file.write_all(&output.stdout).expect("Could not write env");
 
-        scp(
+        scp_send_to(
             log.clone(),
             &session,
-            filepath,
-            Path::new("/home/admin/env_vars").to_path_buf(),
+            &filepath,
+            Path::new("/home/admin/env_vars"),
         );
     };
 
@@ -218,12 +218,11 @@ fn setup(env: TestEnv) {
                 panic!("Tarring the dashboards directory failed with error: {err}");
             }
 
-            let source = Path::new(&DASHBOARDS_TAR_ZST).to_path_buf();
-            scp(
+            scp_send_to(
                 log.clone(),
                 &session,
-                source,
-                Path::new(&dashboards_uvm_host_path).to_path_buf(),
+                Path::new(&DASHBOARDS_TAR_ZST),
+                Path::new(&dashboards_uvm_host_path),
             );
             provided_path
         }
@@ -295,14 +294,17 @@ chmod +x /home/admin/run
     uvm.block_on_bash_script_from_session(&session, prepare_docker_script)
         .unwrap_or_else(|e| panic!("Failed to create final docker image on UVM because: {e}"));
     info!(log, "Starting test remotely ...");
-    start_test(env, uvm);
+    start_test(env.clone(), &uvm);
     let test_result_handle = {
         info!(log, "Waiting for test results asynchronously ...");
-        receive_test_exit_code_async(session, log.clone())
+        receive_test_exit_code_async(session.clone(), log.clone())
     };
     let test_exit_code = test_result_handle
         .join()
         .expect("test execution thread failed");
+
+    fetch_test_dir(env.clone(), &uvm, &session);
+
     info!(
         log,
         "Wait extra {} sec to collect last uvm logs",
@@ -313,7 +315,7 @@ chmod +x /home/admin/run
     info!(log, "test execution has finished successfully");
 }
 
-fn start_test(env: TestEnv, uvm: DeployedUniversalVm) {
+fn start_test(env: TestEnv, uvm: &DeployedUniversalVm) {
     let run_test_script = r#"
     set -E
     nohup sh -c '/home/admin/run > /dev/null 2>&1; echo $? > test_exit_code' &
@@ -356,25 +358,82 @@ fn start_test(env: TestEnv, uvm: DeployedUniversalVm) {
     }
 }
 
-fn scp(log: Logger, session: &Session, from: std::path::PathBuf, to: std::path::PathBuf) {
-    let size = fs::metadata(from.clone()).unwrap().len();
+fn fetch_test_dir(env: TestEnv, uvm: &DeployedUniversalVm, session: &Session) {
+    let log = env.logger();
+    let test_dir_tar = Path::new("/home/admin/test.tar");
+    info!(
+        log,
+        "Tarring the test directory on the {UVM_NAME} to {test_dir_tar:?}..."
+    );
+    uvm.block_on_bash_script_from_session(
+        session,
+        &format!("sudo tar -cf {test_dir_tar:?} -C /home/admin/test ."),
+    )
+    .unwrap_or_else(|e| panic!("Failed to tar the test directory on {UVM_NAME} because: {e}"));
+    let local_test_dir_tar = env.get_path("test.tar");
+    info!(
+        log,
+        "Copying {test_dir_tar:?} from the {UVM_NAME} to the local test-driver at {local_test_dir_tar:?}..."
+    );
+    scp_recv_from(log.clone(), session, test_dir_tar, &local_test_dir_tar);
+    let colocated_test_dir = env.get_path("colocated_test");
+    info!(
+        log,
+        "Untarring the test directory from the {UVM_NAME} to {colocated_test_dir:?} ..."
+    );
+    let colocated_test_dir_str = colocated_test_dir.display();
+    let mut cmd = Command::new("tar");
+    cmd.arg("-x")
+        .arg("-f")
+        .arg(&local_test_dir_tar)
+        .arg(format!("--one-top-level={colocated_test_dir_str}"));
+    let output = cmd.output().unwrap_or_else(|e| {
+        panic!("Failed to untar {local_test_dir_tar:?} directory because: {e}")
+    });
+    if !output.status.success() {
+        let err = str::from_utf8(&output.stderr).unwrap_or("");
+        panic!("Untarring {local_test_dir_tar:?} failed with error: {err}");
+    }
+    info!(
+        log,
+        "Untarred the test directory from the {UVM_NAME} to {colocated_test_dir:?}."
+    );
+}
+
+fn scp_send_to(log: Logger, session: &Session, from: &std::path::Path, to: &std::path::Path) {
+    let size = fs::metadata(from).unwrap().len();
     ic_system_test_driver::retry_with_msg!(
-        format!("scp-ing {:?} of {:?} B to {UVM_NAME}:{to:?}", from, size,),
+        format!("scp-ing {from:?} of {size:?} B to {UVM_NAME}:{to:?}"),
         log.clone(),
         SCP_RETRY_TIMEOUT,
         SCP_RETRY_BACKOFF,
         || {
-            let mut remote_file = session.scp_send(&to, 0o644, size, None)?;
-            let mut from_file = File::open(from.clone())?;
+            let mut remote_file = session.scp_send(to, 0o644, size, None)?;
+            let mut from_file = File::open(from)?;
             std::io::copy(&mut from_file, &mut remote_file)?;
+            info!(log, "scp-ed {from:?} of {size:?} B to {UVM_NAME}:{to:?} .");
             Ok(())
         }
     )
-    .unwrap_or_else(|e| panic!("Failed to scp {:?} to {UVM_NAME}:{to:?} because: {e}", from));
-    info!(
-        log,
-        "scp-ed {:?} of {:?} B to {UVM_NAME}:{to:?} .", from, size,
-    );
+    .unwrap_or_else(|e| panic!("Failed to scp {from:?} to {UVM_NAME}:{to:?} because: {e}"));
+}
+
+fn scp_recv_from(log: Logger, session: &Session, from: &std::path::Path, to: &std::path::Path) {
+    ic_system_test_driver::retry_with_msg!(
+        format!("scp-ing {UVM_NAME}:{from:?} to {to:?}"),
+        log.clone(),
+        SCP_RETRY_TIMEOUT,
+        SCP_RETRY_BACKOFF,
+        || {
+            let (mut remote_file, scp_file_stat) = session.scp_recv(from)?;
+            let size = scp_file_stat.size();
+            let mut to_file = File::create(to)?;
+            std::io::copy(&mut remote_file, &mut to_file)?;
+            info!(log, "scp-ed {UVM_NAME}:{from:?} of {size:?} B to {to:?}.");
+            Ok(())
+        }
+    )
+    .unwrap_or_else(|e| panic!("Failed to scp {UVM_NAME}:{from:?} to {to:?} because: {e}",));
 }
 
 fn receive_test_exit_code_async(


### PR DESCRIPTION
Copy the test directory containing all the testing artifacts from the colocated test-driver to the local test-driver such that the artifacts can be inspected. 

This is primarily useful for colocated tests that download the p8s data directory.