### PR TITLE
fix: replace outdated hard-coded constant by size_of::<Global>()

### DIFF
--- a/rs/execution_environment/src/execution/install_code/tests.rs
+++ b/rs/execution_environment/src/execution/install_code/tests.rs
@@ -336,7 +336,7 @@ fn install_code_respects_wasm_custom_sections_available_memory() {
 
     // This value might need adjustment if something changes in the canister's
     // wasm that gets installed in the test.
-    let total_memory_taken_per_canister_in_bytes = 364249;
+    let total_memory_taken_per_canister_in_bytes = 364441;
 
     let mut test = ExecutionTestBuilder::new()
         .with_install_code_instruction_limit(1_000_000_000)

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -984,7 +984,7 @@ fn get_canister_status_memory_metrics_global_memory_size() {
     let exported_globals = test.execution_state(canister_id).exported_globals.clone();
     assert_eq!(
         csr.global_memory_size(),
-        NumBytes::new(8 * exported_globals.len() as u64)
+        NumBytes::new(32 * exported_globals.len() as u64)
     );
 }
 

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -446,8 +446,7 @@ impl ExecutionState {
 
     // Returns the global memory currently used by the `ExecutionState`.
     pub fn global_memory_usage(&self) -> NumBytes {
-        // We use 8 bytes per global.
-        let globals_size_bytes = 8 * self.exported_globals.len() as u64;
+        let globals_size_bytes = size_of::<Global>() as u64 * self.exported_globals.len() as u64;
         NumBytes::from(globals_size_bytes)
     }
 


### PR DESCRIPTION
This PR replaces an outdated hard-coded constant 8 by `size_of::<Global>()` in the computation of execution state size. This change is consistent with the [value](https://github.com/dfinity/ic/blob/abbed6b27a69f85f3ff539ed9a214faa666e1299/rs/replicated_state/src/canister_snapshots.rs#L656) in the computation of snapshot size.