### PR TITLE
chore: support dynamically downloading the p8s data and document how to use Grafana dashboards locally

### DIFF
--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -11,7 +11,7 @@
 // You can setup this test by executing the following commands:
 //
 //   $ ci/container/container-run.sh
-//   $ ict test consensus_performance_test_colocate --keepalive -- --test_tmpdir=./performance --test_env DOWNLOAD_P8S_DATA=1
+//   $ ict test tecdsa_performance_test_colocate --keepalive -- --test_tmpdir=./performance --test_env DOWNLOAD_P8S_DATA=1
 //
 // The --test_tmpdir=./performance will store the test output in the specified directory.
 // This is useful to have access to in case you need to SSH into an IC node for example like:

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -11,7 +11,7 @@
 // You can setup this test by executing the following commands:
 //
 //   $ ci/container/container-run.sh
-//   $ ict test consensus_performance_test_colocate --keepalive -- --test_tmpdir=./performance
+//   $ ict test consensus_performance_test_colocate --keepalive -- --test_tmpdir=./performance --test_env DOWNLOAD_P8S_DATA=1
 //
 // The --test_tmpdir=./performance will store the test output in the specified directory.
 // This is useful to have access to in case you need to SSH into an IC node for example like:
@@ -218,7 +218,9 @@ pub fn setup(env: TestEnv) {
 }
 
 pub fn test(env: TestEnv) {
-    tecdsa_performance_test(env, false, false);
+    let download_p8s_data =
+        std::env::var("DOWNLOAD_P8S_DATA").is_ok_and(|v| v == "true" || v == "1");
+    tecdsa_performance_test(env, false, download_p8s_data);
 }
 
 pub fn tecdsa_performance_test(

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -27,7 +27,7 @@
 //     vCPUs: 64
 //     Memory: 512142680 KiB
 //
-// To get access to P8s and Grafana look for the following log lines:
+// To get live access to P8s and Grafana while the test is running look for the following log lines:
 //
 //   Apr 11 15:33:58.903 INFO[rs/tests/src/driver/prometheus_vm.rs:168:0]
 //     Prometheus Web UI at http://prometheus.performance--1681227226065.testnet.farm.dfinity.systems
@@ -35,6 +35,20 @@
 //     IC Progress Clock at http://grafana.performance--1681227226065.testnet.farm.dfinity.systems/d/ic-progress-clock/ic-progress-clock?refresh=10s&from=now-5m&to=now
 //   Apr 11 15:33:58.903 INFO[rs/tests/src/driver/prometheus_vm.rs:169:0]
 //     Grafana at http://grafana.performance--1681227226065.testnet.farm.dfinity.systems
+//
+// To inspect the metrics after the test has finished, exit the dev container
+// and run a local p8s and Grafana on the downloaded p8s data directory using:
+//
+// $ rs/tests/run-p8s.sh --grafana-dashboards-dir ~/k8s/bases/apps/ic-dashboards performance/_tmp/*/setup/colocated_test/tests/test/universal_vms/prometheus/prometheus-data-dir.tar.zst
+//
+// Note this this script requires Nix so make sure it's installed (https://nixos.org/download/).
+// The script also requires a local clone of https://github.com/dfinity-ops/k8s containing the Grafana dashboards.
+//
+// Then, on your laptop, forward the Grafana port 3000 to your devenv:
+//
+// $ ssh devenv -L 3000:localhost:3000 -N
+//
+// and load http://localhost:3000/ in your browser to inspect the dashboards.
 //
 // Happy testing!
 

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -39,14 +39,14 @@
 // To inspect the metrics after the test has finished, exit the dev container
 // and run a local p8s and Grafana on the downloaded p8s data directory using:
 //
-// $ rs/tests/run-p8s.sh --grafana-dashboards-dir ~/k8s/bases/apps/ic-dashboards performance/_tmp/*/setup/colocated_test/tests/test/universal_vms/prometheus/prometheus-data-dir.tar.zst
+//   $ rs/tests/run-p8s.sh --grafana-dashboards-dir ~/k8s/bases/apps/ic-dashboards performance/_tmp/*/setup/colocated_test/tests/test/universal_vms/prometheus/prometheus-data-dir.tar.zst
 //
 // Note this this script requires Nix so make sure it's installed (https://nixos.org/download/).
 // The script also requires a local clone of https://github.com/dfinity-ops/k8s containing the Grafana dashboards.
 //
 // Then, on your laptop, forward the Grafana port 3000 to your devenv:
 //
-// $ ssh devenv -L 3000:localhost:3000 -N
+//   $ ssh devenv -L 3000:localhost:3000 -N
 //
 // and load http://localhost:3000/ in your browser to inspect the dashboards.
 //


### PR DESCRIPTION
This supports dynamically enabling the download of p8s data in the `tecdsa_performance_test` by setting the `DOWNLOAD_P8S_DATA` environment variable and documents how to inspect metrics of system-tests after the test has finished.