### PR TITLE
chore: rename main_memory to wasm_memory in snapshot data API

### DIFF
--- a/rs/execution_environment/benches/management_canister/canister_snapshots.rs
+++ b/rs/execution_environment/benches/management_canister/canister_snapshots.rs
@@ -233,7 +233,7 @@ fn read_canister_snapshot_data_bench<M: criterion::measurement::Measurement>(
                 let args = ReadCanisterSnapshotDataArgs::new(
                     canister_id,
                     snapshot_id,
-                    CanisterSnapshotDataKind::MainMemory { offset, size: 1 },
+                    CanisterSnapshotDataKind::WasmMemory { offset, size: 1 },
                 );
                 let _ = env
                     .read_canister_snapshot_data(&args)
@@ -252,7 +252,7 @@ fn read_canister_snapshot_data_bench<M: criterion::measurement::Measurement>(
                 let args = ReadCanisterSnapshotDataArgs::new(
                     canister_id,
                     snapshot_id,
-                    CanisterSnapshotDataKind::MainMemory { offset, size: 1 },
+                    CanisterSnapshotDataKind::WasmMemory { offset, size: 1 },
                 );
                 let _ = env
                     .read_canister_snapshot_data(&args)
@@ -279,7 +279,7 @@ fn write_canister_snapshot_data_bench<M: criterion::measurement::Measurement>(
                 let args = UploadCanisterSnapshotDataArgs::new(
                     canister_id,
                     snapshot_id,
-                    CanisterSnapshotDataOffset::MainMemory { offset },
+                    CanisterSnapshotDataOffset::WasmMemory { offset },
                     vec![42],
                 );
                 env.upload_canister_snapshot_data(&args)
@@ -298,7 +298,7 @@ fn write_canister_snapshot_data_bench<M: criterion::measurement::Measurement>(
                 let args = UploadCanisterSnapshotDataArgs::new(
                     canister_id,
                     snapshot_id,
-                    CanisterSnapshotDataOffset::MainMemory { offset },
+                    CanisterSnapshotDataOffset::WasmMemory { offset },
                     vec![42],
                 );
                 env.upload_canister_snapshot_data(&args)

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2419,7 +2419,7 @@ impl CanisterManager {
                     Err(e) => Err(e.into()),
                 }
             }
-            CanisterSnapshotDataKind::MainMemory { offset, size } => {
+            CanisterSnapshotDataKind::WasmMemory { offset, size } => {
                 let main_memory = snapshot.execution_snapshot().wasm_memory.clone();
                 match CanisterSnapshot::get_memory_chunk(main_memory, offset, size) {
                     Ok(chunk) => Ok(chunk),
@@ -2669,7 +2669,7 @@ impl CanisterManager {
                     });
                 }
             }
-            CanisterSnapshotDataOffset::MainMemory { offset } => {
+            CanisterSnapshotDataOffset::WasmMemory { offset } => {
                 let max_size_bytes =
                     snapshot_inner.wasm_memory().size.get() * WASM_PAGE_SIZE_IN_BYTES;
                 if max_size_bytes < args.chunk.len().saturating_add(offset as usize) {
@@ -2796,7 +2796,7 @@ impl CanisterManager {
                 args.chunk.len() as u64,
                 NumInstructions::new(args.chunk.len() as u64),
             ),
-            CanisterSnapshotDataOffset::MainMemory { .. } => (
+            CanisterSnapshotDataOffset::WasmMemory { .. } => (
                 args.chunk.len() as u64,
                 NumInstructions::new(args.chunk.len() as u64),
             ),
@@ -2883,7 +2883,7 @@ impl CanisterManager {
 fn get_response_size(kind: &CanisterSnapshotDataKind) -> Result<u64, CanisterManagerError> {
     let size = match kind {
         CanisterSnapshotDataKind::WasmModule { size, .. } => *size,
-        CanisterSnapshotDataKind::MainMemory { size, .. } => *size,
+        CanisterSnapshotDataKind::WasmMemory { size, .. } => *size,
         CanisterSnapshotDataKind::StableMemory { size, .. } => *size,
         CanisterSnapshotDataKind::WasmChunk { .. } => return Ok(CHUNK_SIZE),
     };

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -2375,7 +2375,7 @@ fn verify_data_wasm_heap(
     let args_main = ReadCanisterSnapshotDataArgs::new(
         canister_id,
         snapshot_id,
-        CanisterSnapshotDataKind::MainMemory {
+        CanisterSnapshotDataKind::WasmMemory {
             offset: 0,
             size: max_chunk_size,
         },
@@ -2386,7 +2386,7 @@ fn verify_data_wasm_heap(
     let args_main = ReadCanisterSnapshotDataArgs::new(
         canister_id,
         snapshot_id,
-        CanisterSnapshotDataKind::MainMemory {
+        CanisterSnapshotDataKind::WasmMemory {
             offset: max_chunk_size,
             size: rest,
         },
@@ -2501,7 +2501,7 @@ fn read_canister_snapshot_data_fails_bad_slice() {
     let args_module = ReadCanisterSnapshotDataArgs::new(
         canister_id,
         snapshot_id,
-        CanisterSnapshotDataKind::MainMemory {
+        CanisterSnapshotDataKind::WasmMemory {
             offset: 0,
             size: 1 + max_slice_size,
         },
@@ -2515,7 +2515,7 @@ fn read_canister_snapshot_data_fails_bad_slice() {
     let args_module = ReadCanisterSnapshotDataArgs::new(
         canister_id,
         snapshot_id,
-        CanisterSnapshotDataKind::MainMemory {
+        CanisterSnapshotDataKind::WasmMemory {
             offset: (pages - 1) * PAGE_SIZE as u64,
             size: PAGE_SIZE as u64 + 1000,
         },
@@ -2582,7 +2582,7 @@ fn read_canister_snapshot_data_fails_invalid_controller() {
     let args = ReadCanisterSnapshotDataArgs::new(
         canister_id,
         snapshot_id,
-        CanisterSnapshotDataKind::MainMemory { offset: 0, size: 0 },
+        CanisterSnapshotDataKind::WasmMemory { offset: 0, size: 0 },
     );
     let error = test
         .subnet_message("read_canister_snapshot_data", args.encode())
@@ -2628,7 +2628,7 @@ fn read_canister_snapshot_data_fails_canister_and_snapshot_must_match() {
     let args = ReadCanisterSnapshotDataArgs::new(
         other_canister_id,
         snapshot_id,
-        CanisterSnapshotDataKind::MainMemory { offset: 0, size: 0 },
+        CanisterSnapshotDataKind::WasmMemory { offset: 0, size: 0 },
     );
     let error = test
         .subnet_message("read_canister_snapshot_data", args.encode())
@@ -2639,7 +2639,7 @@ fn read_canister_snapshot_data_fails_canister_and_snapshot_must_match() {
     let args = ReadCanisterSnapshotDataArgs::new(
         canister_id,
         (canister_id, 42).into(),
-        CanisterSnapshotDataKind::MainMemory { offset: 0, size: 0 },
+        CanisterSnapshotDataKind::WasmMemory { offset: 0, size: 0 },
     );
     let error = test
         .subnet_message("read_canister_snapshot_data", args.encode())
@@ -2795,7 +2795,7 @@ fn canister_snapshot_roundtrip_succeeds() {
     let args_main = ReadCanisterSnapshotDataArgs::new(
         canister_id,
         snapshot_id,
-        CanisterSnapshotDataKind::MainMemory {
+        CanisterSnapshotDataKind::WasmMemory {
             offset: 0,
             size: wasm_memory_size,
         },
@@ -2870,7 +2870,7 @@ fn canister_snapshot_roundtrip_succeeds() {
     let args_heap = UploadCanisterSnapshotDataArgs::new(
         canister_id,
         new_snapshot_id,
-        CanisterSnapshotDataOffset::MainMemory { offset: 0 },
+        CanisterSnapshotDataOffset::WasmMemory { offset: 0 },
         snapshot_wasm_heap,
     );
     test.subnet_message(

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -3414,7 +3414,7 @@ impl StateMachine {
         self.get_snapshot_blob(
             args,
             |md: &ReadCanisterSnapshotMetadataResponse| md.wasm_memory_size,
-            |offset, size| CanisterSnapshotDataKind::MainMemory { offset, size },
+            |offset, size| CanisterSnapshotDataKind::WasmMemory { offset, size },
         )
     }
 
@@ -3540,7 +3540,7 @@ impl StateMachine {
             data,
             start_chunk,
             end_chunk,
-            |x| CanisterSnapshotDataOffset::MainMemory { offset: x },
+            |x| CanisterSnapshotDataOffset::WasmMemory { offset: x },
         )
     }
 

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -4124,7 +4124,7 @@ impl TryFrom<pb_canister_state_bits::OnLowWasmMemoryHookStatus> for OnLowWasmMem
 ///         offset : nat64;
 ///         size : nat64;
 ///     };
-///     main_memory : record {
+///     wasm_memory : record {
 ///         offset : nat64;
 ///         size : nat64;
 ///     };
@@ -4173,8 +4173,8 @@ impl ReadCanisterSnapshotDataArgs {
 pub enum CanisterSnapshotDataKind {
     #[serde(rename = "wasm_module")]
     WasmModule { offset: u64, size: u64 },
-    #[serde(rename = "main_memory")]
-    MainMemory { offset: u64, size: u64 },
+    #[serde(rename = "wasm_memory")]
+    WasmMemory { offset: u64, size: u64 },
     #[serde(rename = "stable_memory")]
     StableMemory { offset: u64, size: u64 },
     #[serde(rename = "wasm_chunk")]
@@ -4313,7 +4313,7 @@ impl UploadCanisterSnapshotMetadataResponse {
 ///         wasm_module : record {
 ///             offset : nat64;
 ///         };
-///         main_memory : record {
+///         wasm_memory : record {
 ///             offset : nat64;
 ///         };
 ///         stable_memory : record {
@@ -4363,8 +4363,8 @@ impl UploadCanisterSnapshotDataArgs {
 pub enum CanisterSnapshotDataOffset {
     #[serde(rename = "wasm_module")]
     WasmModule { offset: u64 },
-    #[serde(rename = "main_memory")]
-    MainMemory { offset: u64 },
+    #[serde(rename = "wasm_memory")]
+    WasmMemory { offset: u64 },
     #[serde(rename = "stable_memory")]
     StableMemory { offset: u64 },
     #[serde(rename = "wasm_chunk")]

--- a/rs/types/management_canister_types/tests/ic.did
+++ b/rs/types/management_canister_types/tests/ic.did
@@ -540,7 +540,7 @@ type read_canister_snapshot_data_args = record {
             offset : nat64;
             size : nat64;
         };
-        main_memory : record {
+        wasm_memory : record {
             offset : nat64;
             size : nat64;
         };
@@ -594,7 +594,7 @@ type upload_canister_snapshot_data_args = record {
         wasm_module : record {
             offset : nat64;
         };
-        main_memory : record {
+        wasm_memory : record {
             offset : nat64;
         };
         stable_memory : record {


### PR DESCRIPTION
This PR renames `main_memory` to `wasm_memory` in the snapshot data API of the management canister. Using the term `wasm_memory` to refer to the WASM (a.k.a. heap) memory is consistent with `wasm_memory_size` in the snapshot metadata API  and with `wasm_memory_limit` and `wasm_memory_threshold` in the `canister_status` endpoint of the management canister.