### PR TITLE
chore: don't upload Bazel Events for locally run system-tests anymore

### DIFF
--- a/bazel/conf/.bazelrc.internal
+++ b/bazel/conf/.bazelrc.internal
@@ -23,7 +23,3 @@ build    --remote_upload_local_results=false
 
 # Run `bazel build ... --config=local` to build targets without cache
 build:local --remote_cache=
-
-# Upload bes by default when running system tests so that e.g. failures can
-# be shared easily without having to rerun a potentially very-long systest
-build:systest --config=bes


### PR DESCRIPTION
It sometimes takes a long time to upload Bazel Events files from locally run system-tests. So let's only do this on request. i.e. by manually passing `ict test my-test -- --config=bes`.