### PR TITLE
chore(node): fix nested test flakiness

### DIFF
--- a/ic-os/setupos/BUILD.bazel
+++ b/ic-os/setupos/BUILD.bazel
@@ -42,9 +42,9 @@ genrule(
 
 # Postprocess SetupOS mainnet into a "test" image for use in nested tests
 genrule(
-    name = "mainnet-test-img",
+    name = "latest-release-mainnet-test-img",
     srcs = ["@mainnet_latest_setupos_disk_image//file"],
-    outs = ["mainnet-test-img.tar.zst"],
+    outs = ["latest-release-mainnet-test-img.tar.zst"],
     cmd = """
         tar -xf $<
         $(location //rs/ic_os/dev_test_tools/setupos-disable-checks) --image-path disk.img
@@ -59,11 +59,28 @@ genrule(
     ],
 )
 
-# Extract the GuestOS image from SetupOS
+# Extract the GuestOS NNS image from SetupOS
 genrule(
-    name = "mainnet-guest-img",
+    name = "nns-mainnet-guest-img",
     srcs = ["@mainnet_nns_setupos_disk_image//file"],
-    outs = ["mainnet-guest-img.tar.zst"],
+    outs = ["nns-mainnet-guest-img.tar.zst"],
+    cmd = """
+        $(location //rs/ic_os/build_tools/partition_tools:extract-guestos) --image $< $@
+    """,
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tools = ["//rs/ic_os/build_tools/partition_tools:extract-guestos"],
+    visibility = [
+        "//rs:ic-os-pkg",
+        "//rs:system-tests-pkg",
+    ],
+)
+
+# Extract the GuestOS latest release image from SetupOS
+genrule(
+    name = "latest-release-mainnet-guest-img",
+    srcs = ["@mainnet_latest_setupos_disk_image//file"],
+    outs = ["latest-release-mainnet-guest-img.tar.zst"],
     cmd = """
         $(location //rs/ic_os/build_tools/partition_tools:extract-guestos) --image $< $@
     """,

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -329,7 +329,7 @@ def system_test(
 
     if uses_guestos_nns_mainnet_img:
         env["ENV_DEPS__GUESTOS_DISK_IMG_VERSION"] = MAINNET_NNS_SUBNET_REVISION
-        icos_images["ENV_DEPS__GUESTOS_DISK_IMG"] = "//ic-os/setupos:mainnet-guest-img.tar.zst"
+        icos_images["ENV_DEPS__GUESTOS_DISK_IMG"] = "//ic-os/setupos:nns-mainnet-guest-img.tar.zst"
         env["ENV_DEPS__GUESTOS_INITIAL_UPDATE_IMG_URL"] = base_download_url(
             git_commit_id = MAINNET_NNS_SUBNET_REVISION,
             variant = "guest-os",
@@ -342,7 +342,7 @@ def system_test(
 
     if uses_guestos_latest_release_mainnet_img:
         env["ENV_DEPS__GUESTOS_DISK_IMG_VERSION"] = MAINNET_APPLICATION_SUBNET_REVISION
-        icos_images["ENV_DEPS__GUESTOS_DISK_IMG"] = "//ic-os/setupos:mainnet-guest-img.tar.zst"
+        icos_images["ENV_DEPS__GUESTOS_DISK_IMG"] = "//ic-os/setupos:latest-release-mainnet-guest-img.tar.zst"
         env["ENV_DEPS__GUESTOS_INITIAL_UPDATE_IMG_URL"] = base_download_url(
             git_commit_id = MAINNET_APPLICATION_SUBNET_REVISION,
             variant = "guest-os",
@@ -403,7 +403,7 @@ def system_test(
     if uses_setupos_latest_release_mainnet_img:
         icos_images["ENV_DEPS__EMPTY_DISK_IMG"] = "//rs/tests/nested:empty-disk-img.tar.zst"
         env["ENV_DEPS__SETUPOS_DISK_IMG_VERSION"] = MAINNET_LATEST_HOSTOS_REVISION
-        icos_images["ENV_DEPS__SETUPOS_DISK_IMG"] = "//ic-os/setupos:mainnet-test-img.tar.zst"
+        icos_images["ENV_DEPS__SETUPOS_DISK_IMG"] = "//ic-os/setupos:latest-release-mainnet-test-img.tar.zst"
 
         _env_deps["ENV_DEPS__SETUPOS_BUILD_CONFIG"] = "//ic-os:dev-tools/build-setupos-config-image.sh"
         _env_deps["ENV_DEPS__SETUPOS_CREATE_CONFIG"] = "//rs/ic_os/dev_test_tools/setupos-image-config:setupos-create-config"


### PR DESCRIPTION
NODE-1651

Fix nested test flakiness by adding a `latest-release-mainnet-guest-img` target. This way, when `uses_guestos_latest_release_mainnet_img` is true, the NNS deployed will have the same `latest_release` version. 

