### PR TITLE
fix: increase timeout of nns_delegation_branch_nns_version_test to reduce flakiness

### DIFF
--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -282,6 +282,8 @@ system_test_nns(
         "long_test",
     ],
     test_driver_target = ":nns_delegation_test",
+    # The nns_delegation_on_app_subnet_test subtest takes ~10 minutes eating up the time budget for other tests.
+    test_timeout = "eternal",
     uses_guestos_img = True,
     uses_guestos_nns_mainnet_img = False,
     uses_guestos_update = True,


### PR DESCRIPTION
`//rs/tests/networking:nns_delegation_branch_nns_version_test` is quite flaky because it runs into timeouts due to the subtest `nns_delegation_on_app_subnet_test` which can take over 10 minutes eating up the 15 minute time budget of the whole test.