### PR TITLE
fix: branch in slack-workflow-run.yml

### DIFF
--- a/.github/workflows/slack-workflow-run.yml
+++ b/.github/workflows/slack-workflow-run.yml
@@ -9,6 +9,7 @@ on:
       - master-private
       - rc--*
       - ic-mainnet-revisions
+      - ic-nervous-system-wasms
     tags:
       - release-*
     workflows:


### PR DESCRIPTION
This PR fixes `slack-workflow-run.yml` to be triggered on the branch `ic-nervous-system-wasms` such as this [PR](https://github.com/dfinity/ic/pull/6417).