### PR TITLE
chore: Update Mainnet IC revisions canisters file and fix II in PocketIC

### DIFF
--- a/mainnet-canister-revisions.json
+++ b/mainnet-canister-revisions.json
@@ -88,8 +88,8 @@
     "sha256": "b443df3315902404b142d60f3cfd2f580181683310f6e6321b52de297deffcda"
   },
   "internet_identity_test": {
-    "sha256": "8f04c2f99d9d1bf2e17dbceb01a2b1922e0e9adb4f5182cbf622ecf08979e2e3",
-    "tag": "release-2025-08-19"
+    "sha256": "e43612c989c35899308361d366d933c3b3af9669c9145ce6020d37fa36cc404f",
+    "tag": "release-2025-08-22"
   },
   "ledger": {
     "rev": "fed75e2a5d21eae03b0ac017582640bc4264bae3",

--- a/rs/pocket_ic_server/src/external_canister_types.rs
+++ b/rs/pocket_ic_server/src/external_canister_types.rs
@@ -43,8 +43,20 @@ pub struct CaptchaConfig {
 }
 
 #[derive(CandidType)]
-pub struct OpenIdConfig {
+pub struct GoogleOpenIdConfig {
     pub client_id: String,
+}
+
+#[derive(CandidType)]
+pub struct OpenIdConfig {
+    pub name: String,
+    pub logo: String,
+    pub issuer: String,
+    pub client_id: String,
+    pub jwks_uri: String,
+    pub auth_uri: String,
+    pub auth_scope: Vec<String>,
+    pub fedcm_uri: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -72,13 +84,15 @@ pub struct InternetIdentityInit {
     pub captcha_config: Option<CaptchaConfig>,
     pub related_origins: Option<Vec<String>>,
     pub new_flow_origins: Option<Vec<String>>,
-    pub openid_google: Option<Option<OpenIdConfig>>,
+    pub openid_google: Option<Option<GoogleOpenIdConfig>>,
+    pub openid_configs: Option<Vec<OpenIdConfig>>,
     pub analytics_config: Option<Option<AnalyticsConfig>>,
     pub fetch_root_key: Option<bool>,
     pub enable_dapps_explorer: Option<bool>,
     pub is_production: Option<bool>,
     pub dummy_auth: Option<Option<DummyAuthConfig>>,
     pub feature_flag_continue_from_another_device: Option<bool>,
+    pub feature_flag_enable_generic_open_id_fe: Option<bool>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR bumps II in `mainnet-canister-revisions.json` and fixes its types used in PocketIC.