### PR TITLE
chore(Ledger_archives): No special COMPRESSED_CANISTERS treatment for ledger archives

### DIFF
--- a/publish/canisters/BUILD.bazel
+++ b/publish/canisters/BUILD.bazel
@@ -20,6 +20,8 @@ CANISTERS = {
     "ic-ckbtc-minter.wasm.gz": "//rs/bitcoin/ckbtc/minter:ckbtc_minter",
     "ic-ckbtc-minter_debug.wasm.gz": "//rs/bitcoin/ckbtc/minter:ckbtc_minter_debug",
     "ic-cketh-minter.wasm.gz": "//rs/ethereum/cketh/minter:cketh_minter",
+    "ic-icrc1-archive.wasm.gz": "//rs/ledger_suite/icrc1/archive:archive_canister",
+    "ic-icrc1-archive-u256.wasm.gz": "//rs/ledger_suite/icrc1/archive:archive_canister_u256",
     "ic-icrc1-index-ng.wasm.gz": "//rs/ledger_suite/icrc1/index-ng:index_ng_canister",
     "ic-icrc1-index-ng-u256.wasm.gz": "//rs/ledger_suite/icrc1/index-ng:index_ng_canister_u256",
     "ic-icrc1-ledger.wasm.gz": "//rs/ledger_suite/icrc1/ledger:ledger_canister",
@@ -27,6 +29,7 @@ CANISTERS = {
     "ic-icp-index-canister.wasm.gz": "//rs/ledger_suite/icp/index:ic-icp-index-canister",
     "ic-ledger-suite-orchestrator-canister.wasm.gz": "//rs/ethereum/ledger-suite-orchestrator:ledger_suite_orchestrator_canister",
     "identity-canister.wasm.gz": "//rs/nns/identity:identity-canister",
+    "ledger-archive-node-canister.wasm.gz": "//rs/ledger_suite/icp/archive:ledger-archive-node-canister-wasm",
     "ledger-canister.wasm.gz": "//rs/ledger_suite/icp/ledger:ledger-canister-wasm",
     "ledger-canister_notify-method.wasm.gz": "//rs/ledger_suite/icp/ledger:ledger-canister-wasm-notify-method",
     "lifeline_canister.wasm.gz": "//rs/nns/handlers/lifeline/impl:lifeline_canister",
@@ -58,9 +61,6 @@ CANISTERS = {
 
 COMPRESSED_CANISTERS = {
     "ic-btc-canister.wasm.gz": "@btc_canister//file",
-    "ic-icrc1-archive.wasm.gz": "//rs/ledger_suite/icrc1/archive:archive_canister.wasm.gz",
-    "ic-icrc1-archive-u256.wasm.gz": "//rs/ledger_suite/icrc1/archive:archive_canister_u256.wasm.gz",
-    "ledger-archive-node-canister.wasm.gz": "//rs/ledger_suite/icp/archive:ledger-archive-node-canister-wasm.wasm.gz",
 }
 
 DEFAULT_CANISTERS_MAX_SIZE_E5_BYTES = 21


### PR DESCRIPTION
Move the ICP and ICRC ledger archive canisters from the `COMPRESSED_CANISTERS` list into the regular `CANISTERS` for building and publishing canisters. Since all canisters are compressed these days, it doesn't seem necessary to have the ledger archives in the separate list, and having them in the `CANISTERS` list also means that their `.did` files are also bundled and published.