### PR TITLE
chore(PocketIC): make external types tests run on schedule

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -180,6 +180,7 @@ jobs:
                 fuzz_test
                 fi_tests_nightly
                 nns_tests_nightly
+                pocketic_tests_nightly
             )
 
             # Prepend tags with '-' and join them with commas for Bazel

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -123,6 +123,32 @@ jobs:
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
+  pocketic-tests-nightly:
+    name: Bazel Test PocketIC Nightly
+    <<: *dind-large-setup
+    timeout-minutes: 30
+    steps:
+      - <<: *checkout
+      - name: Run PocketIC Tests Nightly
+        uses: ./.github/actions/bazel
+        with:
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=pocketic_tests_nightly \
+              //rs/pocket_ic_server/... \
+              --test_env=SSH_AUTH_SOCK \
+              --keep_going
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Post Slack Notification
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        if: failure()
+        with:
+          channel-id: pocket-ic
+          slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Run#${{github.run_id}}>"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+
   system-tests-benchmarks-nightly:
     name: Bazel System Test Benchmarks
     <<: *dind-large-setup

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -151,6 +151,7 @@ jobs:
                 fuzz_test
                 fi_tests_nightly
                 nns_tests_nightly
+                pocketic_tests_nightly
             )
 
             # Prepend tags with '-' and join them with commas for Bazel

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -130,6 +130,37 @@ jobs:
               --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+  pocketic-tests-nightly:
+    name: Bazel Test PocketIC Nightly
+    runs-on:
+      labels: dind-large
+    container:
+      image: ghcr.io/dfinity/ic-build@sha256:40399f5c94cfc35201bc26e30fa7dded1b839f13773840819fd6c314ca2cf840
+      options: >-
+        -e NODE_NAME --privileged --cgroupns host
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run PocketIC Tests Nightly
+        uses: ./.github/actions/bazel
+        with:
+          run: |
+            bazel test \
+              --config=stamped \
+              --test_tag_filters=pocketic_tests_nightly \
+              //rs/pocket_ic_server/... \
+              --test_env=SSH_AUTH_SOCK \
+              --keep_going
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Post Slack Notification
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        if: failure()
+        with:
+          channel-id: pocket-ic
+          slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Run#${{github.run_id}}>"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
   system-tests-benchmarks-nightly:
     name: Bazel System Test Benchmarks
     runs-on:

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -247,7 +247,7 @@ rust_test(
     # this test is manual to not block automatic PR merge
     # bumping mainnet canister versions
     # from which the external types are derived
-    tags = ["manual"],
+    tags = ["pocketic_tests_nightly"],
     deps = [":pocket-ic-server-lib"] + TEST_DEPENDENCIES,
 )
 


### PR DESCRIPTION
This PR is a follow-up to #6443 (please see that PR description for more context). Upon failures, a slack alert to #pocket-ic is sent.