### PR TITLE
feat: CON-1571 Count the total number of available pre-signatures in the state and blockchain

### DIFF
--- a/rs/artifact_pool/src/consensus_pool_cache.rs
+++ b/rs/artifact_pool/src/consensus_pool_cache.rs
@@ -493,6 +493,14 @@ impl ConsensusBlockChain for ConsensusBlockChainImpl {
     fn len(&self) -> usize {
         self.blocks.len()
     }
+
+    fn iter_above(&self, height: Height) -> Box<dyn Iterator<Item = &Block> + '_> {
+        Box::new(
+            self.blocks
+                .range(height.increment()..)
+                .map(|(_, block)| block),
+        )
+    }
 }
 
 #[cfg(test)]

--- a/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
+++ b/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
@@ -698,11 +698,23 @@ pub(super) mod tests {
             let certified_state =
                 ic_interfaces_state_manager::Labeled::new(Height::new(6), Arc::new(state));
 
-            // Count the total pre-signatures in and above the state
+            // The entire blockchain should now contain pre-signatures for different keys as follows:
+            // [ C ]--[ B1 ]--[ B2 ]--[ B3 ]--[ B4 ]--[   B5   ]---[   B6   ]---[   B7   ]---[   B8   ]
+            //                                        [key0 x 3]   [key0 x 3]   [key0 x 3]   [key0 x 3]
+            //                                        [key1 x 1]   [key1 x 1]   [key1 x 1]   [key1 x 1]
+            //                                                         ||
+            //                                            {State; key0 x 2; key3 x 1}
+
+            // Count the total pre-signatures in and above the state for each key
             let count = count_pre_signatures_total(&certified_state, &block_reader);
             assert_eq!(count.len(), 3);
+            // key0: 2 in the stash + 3 at height seven + 3 at height eight = 8
             assert_eq!(count[&key_ids[0]], 8);
+            // key1: 0 in the stash + 1 at height seven + 1 at height eight = 2
             assert_eq!(count[&key_ids[1]], 2);
+            // key2: No pre-signatures in the stash or the blockchain
+            assert!(!count.contains_key(&key_ids[2]));
+            // key3: 1 in the stash + 0 at height seven + 0 at height eight = 1
             assert_eq!(count[&new_key_id], 1);
         });
     }

--- a/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
+++ b/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
@@ -694,7 +694,7 @@ pub(super) mod tests {
                 .subnet_call_context_manager
                 .pre_signature_stashes = stashes;
 
-            // create the certified state at height 6 (there are two more IDkgPayloads above)
+            // Create the certified state at height 6 (there are two more IDkgPayloads above)
             let certified_state =
                 ic_interfaces_state_manager::Labeled::new(Height::new(6), Arc::new(state));
 

--- a/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
+++ b/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
@@ -678,12 +678,14 @@ pub(super) mod tests {
 
             // Create two pre-signature stashes, one for the first key, one for a new key
             let mut stashes = BTreeMap::new();
+            // The first stash has 2 pre-signatures
             stashes.insert(key_ids[0].clone(), fake_pre_signature_stash(&key_ids[0], 2));
             let new_key_id = IDkgMasterPublicKeyId::try_from(key_id_with_name(
                 key_ids[0].inner(),
                 "some_new_key",
             ))
             .unwrap();
+            // The second stash has 1 pre-signature
             stashes.insert(new_key_id.clone(), fake_pre_signature_stash(&new_key_id, 1));
 
             let mut state = ic_test_utilities_state::get_initial_state(0, 0);

--- a/rs/consensus/idkg/src/test_utils.rs
+++ b/rs/consensus/idkg/src/test_utils.rs
@@ -246,6 +246,10 @@ impl IDkgBlockReader for TestIDkgBlockReader {
     fn active_transcripts(&self) -> BTreeSet<TranscriptRef> {
         self.idkg_transcripts.keys().cloned().collect()
     }
+
+    fn iter_above(&self, _height: Height) -> Box<dyn Iterator<Item = &IDkgPayload> + '_> {
+        Box::new(std::iter::empty())
+    }
 }
 
 pub(crate) enum TestTranscriptLoadStatus {

--- a/rs/consensus/idkg/src/utils.rs
+++ b/rs/consensus/idkg/src/utils.rs
@@ -171,6 +171,14 @@ impl IDkgBlockReader for IDkgBlockReaderImpl {
             ))
             .cloned()
     }
+
+    fn iter_above(&self, height: Height) -> Box<dyn Iterator<Item = &IDkgPayload> + '_> {
+        Box::new(
+            self.chain
+                .iter_above(height)
+                .flat_map(|block| block.payload.as_ref().as_idkg()),
+        )
+    }
 }
 
 pub(super) fn block_chain_reader(

--- a/rs/interfaces/src/consensus_pool.rs
+++ b/rs/interfaces/src/consensus_pool.rs
@@ -423,6 +423,9 @@ pub trait ConsensusBlockChain: Send + Sync {
 
     /// Returns the length of the chain.
     fn len(&self) -> usize;
+
+    /// Iterate over all Blocks above the given height.
+    fn iter_above(&self, height: Height) -> Box<dyn Iterator<Item = &Block> + '_>;
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/rs/types/types/src/consensus/idkg/common.rs
+++ b/rs/types/types/src/consensus/idkg/common.rs
@@ -1,6 +1,8 @@
 //! Canister threshold transcripts and references related defininitions.
 use crate::{
-    consensus::idkg::{ecdsa::PreSignatureQuadrupleError, schnorr::PreSignatureTranscriptError},
+    consensus::idkg::{
+        ecdsa::PreSignatureQuadrupleError, schnorr::PreSignatureTranscriptError, IDkgPayload,
+    },
     crypto::{
         canister_threshold_sig::{
             error::{
@@ -670,6 +672,9 @@ pub trait IDkgBlockReader: Send + Sync {
         &self,
         transcript_ref: &TranscriptRef,
     ) -> Result<IDkgTranscript, TranscriptLookupError>;
+
+    /// Iterate over all Blocks above the given height.
+    fn iter_above(&self, height: Height) -> Box<dyn Iterator<Item = &IDkgPayload> + '_>;
 }
 
 /// Counterpart of IDkgTranscriptParams that holds transcript references,

--- a/rs/types/types/src/consensus/idkg/common.rs
+++ b/rs/types/types/src/consensus/idkg/common.rs
@@ -673,7 +673,7 @@ pub trait IDkgBlockReader: Send + Sync {
         transcript_ref: &TranscriptRef,
     ) -> Result<IDkgTranscript, TranscriptLookupError>;
 
-    /// Iterate over all Blocks above the given height.
+    /// Iterate over all IDkgPayloads above the given height.
     fn iter_above(&self, height: Height) -> Box<dyn Iterator<Item = &IDkgPayload> + '_>;
 }
 


### PR DESCRIPTION
This PR adds a function to count the total number of available pre-signatures that are stored in the state at a given height, and all payloads above the state height.

The function is currently unused. In the future it will be needed to determine the number of additional pre-signature creations that we should start for each stash.

Counting the number of pre-signatures correctly additionally relies on https://github.com/dfinity/ic/pull/6308, which ensures that all blocks above the certified height are part of the `IDkgBlockReader`.