### PR TITLE
chore: refactor SubnetAvailableMemory

### DIFF
--- a/rs/canister_sandbox/src/protocol/sbxsvc.rs
+++ b/rs/canister_sandbox/src/protocol/sbxsvc.rs
@@ -476,7 +476,7 @@ mod tests {
                     execution_mode: ExecutionMode::Replicated,
                     subnet_memory_saturation: ResourceSaturation::new(8, 5, 10),
                 },
-                subnet_available_memory: SubnetAvailableMemory::new(123, 12, 1),
+                subnet_available_memory: SubnetAvailableMemory::new_for_testing(123, 12, 1),
                 next_wasm_memory_id: MemoryId::new(),
                 next_stable_memory_id: MemoryId::new(),
                 sandbox_safe_system_state: SandboxSafeSystemState::new(

--- a/rs/canister_sandbox/src/sandbox_server.rs
+++ b/rs/canister_sandbox/src/sandbox_server.rs
@@ -266,7 +266,7 @@ mod tests {
             canister_current_memory_usage: NumBytes::new(0),
             canister_current_message_memory_usage: MessageMemoryUsage::ZERO,
             execution_parameters: execution_parameters(),
-            subnet_available_memory: SubnetAvailableMemory::new(
+            subnet_available_memory: SubnetAvailableMemory::new_for_testing(
                 i64::MAX / 2,
                 i64::MAX / 2,
                 i64::MAX / 2,
@@ -298,7 +298,7 @@ mod tests {
             canister_current_memory_usage: NumBytes::new(0),
             canister_current_message_memory_usage: MessageMemoryUsage::ZERO,
             execution_parameters: execution_parameters(),
-            subnet_available_memory: SubnetAvailableMemory::new(
+            subnet_available_memory: SubnetAvailableMemory::new_for_testing(
                 i64::MAX / 2,
                 i64::MAX / 2,
                 i64::MAX / 2,

--- a/rs/cycles_account_manager/src/lib.rs
+++ b/rs/cycles_account_manager/src/lib.rs
@@ -104,12 +104,6 @@ impl ResourceSaturation {
         }
     }
 
-    /// Creates a new `ResourceSaturation` like the `new()` constructor, but also
-    /// divides `usage`, `threshold`, and `capacity` by the given `scaling` factor.
-    pub fn new_scaled(usage: u64, threshold: u64, capacity: u64, scaling: u64) -> Self {
-        Self::new(usage / scaling, threshold / scaling, capacity / scaling)
-    }
-
     /// Returns the part of the usage that is above the threshold.
     pub fn usage_above_threshold(&self) -> u64 {
         self.usage.saturating_sub(self.threshold)

--- a/rs/embedders/fuzz/src/wasm_executor.rs
+++ b/rs/embedders/fuzz/src/wasm_executor.rs
@@ -40,7 +40,7 @@ const SUBNET_MEMORY_CAPACITY: i64 = i64::MAX / 2;
 
 lazy_static! {
     pub(crate) static ref MAX_SUBNET_AVAILABLE_MEMORY: SubnetAvailableMemory =
-        SubnetAvailableMemory::new(
+        SubnetAvailableMemory::new_for_testing(
             SUBNET_MEMORY_CAPACITY,
             SUBNET_MEMORY_CAPACITY,
             SUBNET_MEMORY_CAPACITY

--- a/rs/embedders/src/wasmtime_embedder/tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/tests.rs
@@ -37,11 +37,12 @@ use wasmtime::{Engine, Module, Store, StoreLimits, Val};
 const SUBNET_MEMORY_CAPACITY: i64 = i64::MAX / 2;
 
 lazy_static! {
-    static ref MAX_SUBNET_AVAILABLE_MEMORY: SubnetAvailableMemory = SubnetAvailableMemory::new(
-        SUBNET_MEMORY_CAPACITY,
-        SUBNET_MEMORY_CAPACITY,
-        SUBNET_MEMORY_CAPACITY
-    );
+    static ref MAX_SUBNET_AVAILABLE_MEMORY: SubnetAvailableMemory =
+        SubnetAvailableMemory::new_for_testing(
+            SUBNET_MEMORY_CAPACITY,
+            SUBNET_MEMORY_CAPACITY,
+            SUBNET_MEMORY_CAPACITY
+        );
 }
 const MAX_NUM_INSTRUCTIONS: NumInstructions = NumInstructions::new(1_000_000_000);
 

--- a/rs/embedders/tests/common/mod.rs
+++ b/rs/embedders/tests/common/mod.rs
@@ -225,7 +225,7 @@ pub fn get_system_api(
         CANISTER_CURRENT_MEMORY_USAGE,
         CANISTER_CURRENT_MESSAGE_MEMORY_USAGE,
         execution_parameters,
-        SubnetAvailableMemory::new(
+        SubnetAvailableMemory::new_for_testing(
             SUBNET_MEMORY_CAPACITY,
             SUBNET_MEMORY_CAPACITY,
             SUBNET_MEMORY_CAPACITY,

--- a/rs/embedders/tests/system_api.rs
+++ b/rs/embedders/tests/system_api.rs
@@ -1396,7 +1396,8 @@ fn call_perform_not_enough_cycles_does_not_trap() {
 fn growing_wasm_memory_updates_subnet_available_memory() {
     let wasm_page_size = 64 << 10;
     let subnet_available_memory_bytes = 2 * wasm_page_size;
-    let subnet_available_memory = SubnetAvailableMemory::new(subnet_available_memory_bytes, 0, 0);
+    let subnet_available_memory =
+        SubnetAvailableMemory::new_for_testing(subnet_available_memory_bytes, 0, 0);
     let wasm_custom_sections_available_memory_before =
         subnet_available_memory.get_wasm_custom_sections_memory();
     let system_state = SystemStateBuilder::default().build();
@@ -1465,7 +1466,8 @@ fn helper_test_on_low_wasm_memory(
 ) {
     let wasm_page_size = 64 << 10;
     let subnet_available_memory_bytes = 20 * GIB;
-    let subnet_available_memory = SubnetAvailableMemory::new(subnet_available_memory_bytes, 0, 0);
+    let subnet_available_memory =
+        SubnetAvailableMemory::new_for_testing(subnet_available_memory_bytes, 0, 0);
 
     let mut state_builder = SystemStateBuilder::default()
         .wasm_memory_threshold(wasm_memory_threshold)
@@ -1698,7 +1700,7 @@ fn push_output_request_respects_memory_limits() {
     let subnet_available_memory_bytes = 1 << 30;
     let subnet_available_message_memory_bytes = MAX_RESPONSE_COUNT_BYTES as i64 + 13;
 
-    let subnet_available_memory = SubnetAvailableMemory::new(
+    let subnet_available_memory = SubnetAvailableMemory::new_for_testing(
         subnet_available_memory_bytes,
         subnet_available_message_memory_bytes,
         0,
@@ -1809,7 +1811,7 @@ fn push_output_request_oversized_request_memory_limits() {
     let subnet_available_memory_bytes = 1 << 30;
     let subnet_available_message_memory_bytes = 3 * MAX_RESPONSE_COUNT_BYTES as i64;
 
-    let subnet_available_memory = SubnetAvailableMemory::new(
+    let subnet_available_memory = SubnetAvailableMemory::new_for_testing(
         subnet_available_memory_bytes,
         subnet_available_message_memory_bytes,
         0,
@@ -2253,7 +2255,7 @@ fn get_system_api_for_best_effort_response(
         CANISTER_CURRENT_MEMORY_USAGE,
         CANISTER_CURRENT_MESSAGE_MEMORY_USAGE,
         execution_parameters,
-        SubnetAvailableMemory::new(
+        SubnetAvailableMemory::new_for_testing(
             SUBNET_MEMORY_CAPACITY,
             SUBNET_MEMORY_CAPACITY,
             SUBNET_MEMORY_CAPACITY,

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -40,11 +40,12 @@ const STABLE_OP_BYTES: u64 = 37;
 const SUBNET_MEMORY_CAPACITY: i64 = i64::MAX / 2;
 
 lazy_static! {
-    static ref MAX_SUBNET_AVAILABLE_MEMORY: SubnetAvailableMemory = SubnetAvailableMemory::new(
-        SUBNET_MEMORY_CAPACITY,
-        SUBNET_MEMORY_CAPACITY,
-        SUBNET_MEMORY_CAPACITY
-    );
+    static ref MAX_SUBNET_AVAILABLE_MEMORY: SubnetAvailableMemory =
+        SubnetAvailableMemory::new_for_testing(
+            SUBNET_MEMORY_CAPACITY,
+            SUBNET_MEMORY_CAPACITY,
+            SUBNET_MEMORY_CAPACITY
+        );
 }
 
 fn test_api_for_update(

--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -56,11 +56,12 @@ pub enum Wasm64 {
 }
 
 lazy_static! {
-    static ref MAX_SUBNET_AVAILABLE_MEMORY: SubnetAvailableMemory = SubnetAvailableMemory::new(
-        SUBNET_MEMORY_CAPACITY,
-        SUBNET_MEMORY_CAPACITY,
-        SUBNET_MEMORY_CAPACITY
-    );
+    static ref MAX_SUBNET_AVAILABLE_MEMORY: SubnetAvailableMemory =
+        SubnetAvailableMemory::new_for_testing(
+            SUBNET_MEMORY_CAPACITY,
+            SUBNET_MEMORY_CAPACITY,
+            SUBNET_MEMORY_CAPACITY
+        );
 }
 
 /// Pieces needed to execute a benchmark.

--- a/rs/execution_environment/src/execution/call_or_task/tests.rs
+++ b/rs/execution_environment/src/execution/call_or_task/tests.rs
@@ -4,7 +4,6 @@ use assert_matches::assert_matches;
 
 use ic_base_types::NumSeconds;
 use ic_error_types::ErrorCode;
-use ic_interfaces::execution_environment::SubnetAvailableMemory;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::system_state::CyclesUseCase;
 use ic_replicated_state::testing::SystemStateTesting;
@@ -1120,11 +1119,7 @@ fn stable_grow_updates_subnet_available_memory() {
 
     let mut test = ExecutionTestBuilder::new().build();
     let canister_id = test.universal_canister().unwrap();
-    test.set_subnet_available_memory(SubnetAvailableMemory::new(
-        initial_subnet_memory,
-        initial_subnet_memory,
-        initial_subnet_memory,
-    ));
+    test.set_available_execution_memory(initial_subnet_memory);
 
     // Growing stable memory should reduce the subnet total memory.
     let payload = wasm()

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -254,6 +254,7 @@ pub struct RoundLimits {
 
     /// The number of outgoing calls that can still be made across the subnet before
     /// canisters are limited to their own callback quota.
+    /// This is a soft cap which can be exceeded when executing canisters on threads.
     pub subnet_available_callbacks: i64,
 
     // TODO would be nice to change that to available, but this requires
@@ -340,7 +341,7 @@ pub struct ExecutionEnvironment {
     // This scaling factor accounts for the execution threads running in
     // parallel and potentially reserving resources. It should be initialized to
     // the number of scheduler cores.
-    resource_saturation_scaling: usize,
+    scheduler_cores: usize,
     deallocator_thread: DeallocatorThread,
 }
 
@@ -376,7 +377,7 @@ impl ExecutionEnvironment {
         compute_capacity: usize,
         config: ExecutionConfig,
         cycles_account_manager: Arc<CyclesAccountManager>,
-        resource_saturation_scaling: usize,
+        scheduler_cores: usize,
         fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
         heap_delta_rate_limit: NumBytes,
         upload_wasm_chunk_instructions: NumInstructions,
@@ -440,7 +441,7 @@ impl ExecutionEnvironment {
             own_subnet_id,
             own_subnet_type,
             paused_execution_registry: Default::default(),
-            resource_saturation_scaling,
+            scheduler_cores,
             deallocator_thread,
         }
     }
@@ -453,12 +454,16 @@ impl ExecutionEnvironment {
         &self.metrics.canister_not_found_error
     }
 
-    /// Computes the current amount of memory available on the subnet.
+    /// Computes the current amount of memory available for execution.
     ///
     /// Time complexity: `O(|canisters|)`.
-    pub fn subnet_available_memory(&self, state: &ReplicatedState) -> SubnetAvailableMemory {
+    pub fn scaled_subnet_available_memory(&self, state: &ReplicatedState) -> SubnetAvailableMemory {
         let memory_taken = state.memory_taken();
-        SubnetAvailableMemory::new(
+        // We apply the scaling factor `self.scheduler_cores`
+        // consistently with the scaling factor of `ResourceSaturation`
+        // in the function `self.subnet_memory_saturation`.
+        let scaling_factor = self.scheduler_cores as i64;
+        SubnetAvailableMemory::new_scaled(
             self.config.subnet_memory_capacity.get() as i64
                 - self.config.subnet_memory_reservation.get() as i64
                 - memory_taken.execution().get() as i64,
@@ -470,6 +475,7 @@ impl ExecutionEnvironment {
                 .subnet_wasm_custom_sections_memory_capacity
                 .get() as i64
                 - memory_taken.wasm_custom_sections().get() as i64,
+            scaling_factor,
         )
     }
 
@@ -2809,10 +2815,14 @@ impl ExecutionEnvironment {
         // This function is called on an execution thread with a scaled
         // available memory. We also need to scale the subnet reservation in
         // order to be consistent with the scaling of the available memory.
-        let scaled_subnet_memory_reservation = NumBytes::new(
-            self.config.subnet_memory_reservation.get()
-                / round_limits.subnet_available_memory.get_scaling_factor() as u64,
-        );
+        // We apply the scaling factor `self.scheduler_cores`
+        // consistently with the scaling factor of `SubnetAvailableMemory`
+        // in the function `self.scaled_subnet_available_memory`.
+        // and the scaling factor of `ResourceSaturation`
+        // in the function `self.subnet_memory_saturation`.
+        let scaling_factor = self.scheduler_cores as u64;
+        let scaled_subnet_memory_reservation =
+            NumBytes::new(self.config.subnet_memory_reservation.get() / scaling_factor);
         execute_response(
             canister,
             response,
@@ -2935,7 +2945,7 @@ impl ExecutionEnvironment {
 
         // Letting the canister grow arbitrarily when executing the
         // query is fine as we do not persist state modifications.
-        let subnet_available_memory = subnet_memory_capacity(&self.config);
+        let subnet_available_memory = full_subnet_memory_capacity(&self.config);
         let execution_parameters = self.execution_parameters(
             canister_state,
             instruction_limits,
@@ -4145,31 +4155,29 @@ impl ExecutionEnvironment {
         }
     }
 
-    // Returns the subnet memory saturation based on the given subnet available
-    // memory, which may have been scaled for the current thread.
+    // Returns the subnet memory saturation based on the given subnet available memory
+    // which is assumed to be scaled with the scaling factor `self.scheduler_cores`.
     fn subnet_memory_saturation(
         &self,
         subnet_available_memory: &SubnetAvailableMemory,
     ) -> ResourceSaturation {
-        // Compute the total subnet available memory based on the scaled subnet
-        // available memory. In other words, un-scale the scaled value.
-        let subnet_available_memory = subnet_available_memory
-            .get_execution_memory()
-            .saturating_mul(subnet_available_memory.get_scaling_factor())
-            .max(0) as u64;
+        // We apply the scaling factor `self.scheduler_cores`
+        // consistently with the scaling factor of `SubnetAvailableMemory`
+        // in the function `self.scaled_subnet_available_memory`.
+        let scaling_factor = self.scheduler_cores as u64;
 
-        // Compute the memory usage as the capacity minus the available memory.
-        let subnet_memory_usage = self
-            .config
-            .subnet_memory_capacity
-            .get()
-            .saturating_sub(subnet_available_memory);
+        // Compute the scaled memory usage as the scaled capacity minus the scaled available memory.
+        let scaled_subnet_memory_capacity: u64 =
+            self.config.subnet_memory_capacity.get() / scaling_factor;
+        let scaled_subnet_available_memory =
+            subnet_available_memory.get_execution_memory().max(0) as u64;
+        let scaled_subnet_memory_usage: u64 =
+            scaled_subnet_memory_capacity.saturating_sub(scaled_subnet_available_memory);
 
-        ResourceSaturation::new_scaled(
-            subnet_memory_usage,
-            self.config.subnet_memory_threshold.get(),
-            self.config.subnet_memory_capacity.get(),
-            self.resource_saturation_scaling as u64,
+        ResourceSaturation::new(
+            scaled_subnet_memory_usage,
+            self.config.subnet_memory_threshold.get() / scaling_factor,
+            scaled_subnet_memory_capacity,
         )
     }
 
@@ -4237,11 +4245,12 @@ impl CompilationCostHandling {
 }
 
 /// Returns the subnet's configured memory capacity (ignoring current usage).
-pub(crate) fn subnet_memory_capacity(config: &ExecutionConfig) -> SubnetAvailableMemory {
-    SubnetAvailableMemory::new(
+pub(crate) fn full_subnet_memory_capacity(config: &ExecutionConfig) -> SubnetAvailableMemory {
+    SubnetAvailableMemory::new_scaled(
         config.subnet_memory_capacity.get() as i64,
         config.guaranteed_response_message_memory_capacity.get() as i64,
         config.subnet_wasm_custom_sections_memory_capacity.get() as i64,
+        1,
     )
 }
 

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -8,7 +8,7 @@ mod query_scheduler;
 #[cfg(test)]
 mod tests;
 
-use crate::execution_environment::subnet_memory_capacity;
+use crate::execution_environment::full_subnet_memory_capacity;
 use crate::{
     hypervisor::Hypervisor,
     metrics::{MeasurementScope, QueryHandlerMetrics},
@@ -249,7 +249,7 @@ impl InternalHttpQueryHandler {
 
         // Letting the canister grow arbitrarily when executing the
         // query is fine as we do not persist state modifications.
-        let subnet_available_memory = subnet_memory_capacity(&self.config);
+        let subnet_available_memory = full_subnet_memory_capacity(&self.config);
         // We apply the (rather high) subnet soft limit for callbacks because the
         // instruction limit for the whole composite query tree imposes a much lower
         // implicit bound anyway.

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -570,7 +570,10 @@ impl SchedulerTest {
             instructions: as_round_instructions(
                 self.scheduler.config.max_instructions_per_round / 16,
             ),
-            subnet_available_memory: self.scheduler.exec_env.subnet_available_memory(&state),
+            subnet_available_memory: self
+                .scheduler
+                .exec_env
+                .scaled_subnet_available_memory(&state),
             subnet_available_callbacks: self.scheduler.exec_env.subnet_available_callbacks(&state),
             compute_allocation_used,
         };

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -8,7 +8,7 @@ use ic_embedders::{
     wasmtime_embedder::system_api::MAX_CALL_TIMEOUT_SECONDS,
 };
 use ic_error_types::{ErrorCode, RejectCode};
-use ic_interfaces::execution_environment::{HypervisorError, SubnetAvailableMemory};
+use ic_interfaces::execution_environment::HypervisorError;
 use ic_management_canister_types_private::Global;
 use ic_management_canister_types_private::{
     CanisterChange, CanisterHttpResponsePayload, CanisterStatusType, CanisterUpgradeOptions,
@@ -5884,7 +5884,7 @@ fn dts_concurrent_subnet_available_change() {
         test.canister_state(canister_id).next_execution(),
         NextExecution::ContinueLong
     );
-    test.set_subnet_available_memory(SubnetAvailableMemory::new(0, 0, 0));
+    test.set_available_execution_memory(0);
     while test.canister_state(canister_id).next_execution() == NextExecution::ContinueLong {
         test.execute_slice(canister_id);
     }
@@ -5933,7 +5933,7 @@ fn system_state_apply_change_fails() {
     test.induct_messages();
     test.execute_slice(b_id);
     // No memory available after the first slice.
-    test.set_subnet_available_memory(SubnetAvailableMemory::new(0, 0, 0));
+    test.set_available_execution_memory(0);
     while test.canister_state(b_id).next_execution() == NextExecution::ContinueLong {
         test.execute_slice(b_id);
     }

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
     convert::{Infallible, TryFrom},
-    fmt, ops,
+    fmt,
     sync::Arc,
     time::Duration,
 };
@@ -336,25 +336,36 @@ pub struct SubnetAvailableMemory {
     guaranteed_response_message_memory: i64,
     /// The memory available for Wasm custom sections.
     wasm_custom_sections_memory: i64,
-    /// Specifies the factor by which the subnet available memory was scaled
-    /// using the division operator. It is useful for approximating the global
-    /// available memory from the per-thread available memory.
-    scaling_factor: i64,
 }
 
 impl SubnetAvailableMemory {
-    pub fn new(
+    /// This function should only be used in tests.
+    #[doc(hidden)]
+    pub fn new_for_testing(
         execution_memory: i64,
         guaranteed_response_message_memory: i64,
         wasm_custom_sections_memory: i64,
     ) -> Self {
-        SubnetAvailableMemory {
+        // We do not apply scaling in tests that create `SubnetAvailableMemory` manually.
+        let scaling_factor = 1;
+        SubnetAvailableMemory::new_scaled(
             execution_memory,
             guaranteed_response_message_memory,
             wasm_custom_sections_memory,
-            // The newly created value is not scaled (divided), which
-            // corresponds to the scaling factor of 1.
-            scaling_factor: 1,
+            scaling_factor,
+        )
+    }
+
+    pub fn new_scaled(
+        execution_memory: i64,
+        guaranteed_response_message_memory: i64,
+        wasm_custom_sections_memory: i64,
+        scaling_factor: i64,
+    ) -> Self {
+        SubnetAvailableMemory {
+            execution_memory: execution_memory / scaling_factor,
+            guaranteed_response_message_memory: guaranteed_response_message_memory / scaling_factor,
+            wasm_custom_sections_memory: wasm_custom_sections_memory / scaling_factor,
         }
     }
 
@@ -372,17 +383,6 @@ impl SubnetAvailableMemory {
     /// execution available memory.
     pub fn get_wasm_custom_sections_memory(&self) -> i64 {
         self.wasm_custom_sections_memory
-    }
-
-    /// Returns the scaling factor that specifies by how much the initial
-    /// available memory was scaled using the division operator.
-    ///
-    /// It is useful for approximating the global available memory from the
-    /// per-thread available memory. Note that the approximation may be off in
-    /// both directions because there is no way to deterministically know how
-    /// much other threads have allocated.
-    pub fn get_scaling_factor(&self) -> i64 {
-        self.scaling_factor
     }
 
     /// Returns `Ok(())` if the subnet has enough available room for allocating
@@ -484,19 +484,6 @@ impl SubnetAvailableMemory {
         self.execution_memory -= execution_amount.get() as i64;
         self.guaranteed_response_message_memory -= guaranteed_response_message_amount.get() as i64;
         self.wasm_custom_sections_memory -= wasm_custom_sections_amount.get() as i64;
-    }
-}
-
-impl ops::Div<i64> for SubnetAvailableMemory {
-    type Output = Self;
-
-    fn div(self, rhs: i64) -> Self::Output {
-        Self {
-            execution_memory: self.execution_memory / rhs,
-            guaranteed_response_message_memory: self.guaranteed_response_message_memory / rhs,
-            wasm_custom_sections_memory: self.wasm_custom_sections_memory / rhs,
-            scaling_factor: self.scaling_factor * rhs,
-        }
     }
 }
 
@@ -1491,12 +1478,12 @@ mod tests {
 
     #[test]
     fn test_available_memory() {
-        let available = SubnetAvailableMemory::new(20, 10, 4);
+        let available = SubnetAvailableMemory::new_for_testing(20, 10, 4);
         assert_eq!(available.get_execution_memory(), 20);
         assert_eq!(available.get_guaranteed_response_message_memory(), 10);
         assert_eq!(available.get_wasm_custom_sections_memory(), 4);
 
-        let available = available / 2;
+        let available = SubnetAvailableMemory::new_scaled(20, 10, 4, 2);
         assert_eq!(available.get_execution_memory(), 10);
         assert_eq!(available.get_guaranteed_response_message_memory(), 5);
         assert_eq!(available.get_wasm_custom_sections_memory(), 2);
@@ -1505,7 +1492,7 @@ mod tests {
     #[test]
     fn test_subnet_available_memory() {
         let mut available: SubnetAvailableMemory =
-            SubnetAvailableMemory::new(1 << 30, (1 << 30) - 5, 1 << 20);
+            SubnetAvailableMemory::new_for_testing(1 << 30, (1 << 30) - 5, 1 << 20);
         assert!(available
             .try_decrement(NumBytes::from(10), NumBytes::from(5), NumBytes::from(5))
             .is_ok());
@@ -1524,7 +1511,7 @@ mod tests {
             .is_err());
 
         let mut available: SubnetAvailableMemory =
-            SubnetAvailableMemory::new(1 << 30, (1 << 30) - 5, 1 << 20);
+            SubnetAvailableMemory::new_for_testing(1 << 30, (1 << 30) - 5, 1 << 20);
         assert!(available
             .try_decrement(NumBytes::from(10), NumBytes::from(5), NumBytes::from(5))
             .is_ok());
@@ -1542,7 +1529,8 @@ mod tests {
             .try_decrement(NumBytes::from(1), NumBytes::from(0), NumBytes::from(0))
             .is_ok());
 
-        let mut available: SubnetAvailableMemory = SubnetAvailableMemory::new(1 << 30, -1, -1);
+        let mut available: SubnetAvailableMemory =
+            SubnetAvailableMemory::new_for_testing(1 << 30, -1, -1);
         assert!(available
             .try_decrement(NumBytes::from(1), NumBytes::from(1), NumBytes::from(1))
             .is_err());
@@ -1589,7 +1577,7 @@ mod tests {
             )
             .is_err());
 
-        let mut available = SubnetAvailableMemory::new(44, 45, 30);
+        let mut available = SubnetAvailableMemory::new_for_testing(44, 45, 30);
         assert_eq!(available.get_execution_memory(), 44);
         assert_eq!(available.get_guaranteed_response_message_memory(), 45);
         assert_eq!(available.get_wasm_custom_sections_memory(), 30);

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -3133,7 +3133,7 @@ impl StateMachine {
         self.create_canister_with_cycles(None, Cycles::new(0), settings)
     }
 
-    /// Creates a new canister with a cycles balance and returns the canister principal.
+    /// Creates a new canister and returns the canister principal.
     pub fn create_canister_with_cycles(
         &self,
         specified_id: Option<PrincipalId>,
@@ -3141,17 +3141,7 @@ impl StateMachine {
         settings: Option<CanisterSettingsArgs>,
     ) -> CanisterId {
         let wasm_result = self
-            .execute_ingress(
-                ic00::IC_00,
-                ic00::Method::ProvisionalCreateCanisterWithCycles,
-                ic00::ProvisionalCreateCanisterWithCyclesArgs {
-                    amount: Some(candid::Nat::from(cycles.get())),
-                    settings,
-                    specified_id,
-                    sender_canister_version: None,
-                }
-                .encode(),
-            )
+            .create_canister_with_cycles_impl(specified_id, cycles, settings)
             .expect("failed to create canister");
         match wasm_result {
             WasmResult::Reply(bytes) => CanisterIdRecord::decode(&bytes[..])
@@ -3159,6 +3149,26 @@ impl StateMachine {
                 .get_canister_id(),
             WasmResult::Reject(reason) => panic!("create_canister call rejected: {}", reason),
         }
+    }
+
+    /// Creates a new canister.
+    pub fn create_canister_with_cycles_impl(
+        &self,
+        specified_id: Option<PrincipalId>,
+        cycles: Cycles,
+        settings: Option<CanisterSettingsArgs>,
+    ) -> Result<WasmResult, UserError> {
+        self.execute_ingress(
+            ic00::IC_00,
+            ic00::Method::ProvisionalCreateCanisterWithCycles,
+            ic00::ProvisionalCreateCanisterWithCyclesArgs {
+                amount: Some(candid::Nat::from(cycles.get())),
+                settings,
+                specified_id,
+                sender_canister_version: None,
+            }
+            .encode(),
+        )
     }
 
     /// Creates a new canister and installs its code.

--- a/rs/test_utilities/embedders/src/lib.rs
+++ b/rs/test_utilities/embedders/src/lib.rs
@@ -187,7 +187,7 @@ impl WasmtimeInstanceBuilder {
                 execution_mode: ExecutionMode::Replicated,
                 subnet_memory_saturation: ResourceSaturation::default(),
             },
-            SubnetAvailableMemory::new(
+            SubnetAvailableMemory::new_for_testing(
                 subnet_memory_capacity,
                 subnet_memory_capacity,
                 subnet_memory_capacity,

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -508,8 +508,14 @@ impl ExecutionTest {
         self.subnet_available_memory
     }
 
-    pub fn set_subnet_available_memory(&mut self, memory: SubnetAvailableMemory) {
-        self.subnet_available_memory = memory
+    pub fn set_available_execution_memory(&mut self, execution_memory: i64) {
+        self.subnet_available_memory = SubnetAvailableMemory::new_for_testing(
+            execution_memory,
+            self.subnet_available_memory
+                .get_guaranteed_response_message_memory(),
+            self.subnet_available_memory
+                .get_wasm_custom_sections_memory(),
+        );
     }
 
     pub fn subnet_available_callbacks(&self) -> i64 {
@@ -2515,7 +2521,7 @@ impl ExecutionTestBuilder {
             execution_cost: HashMap::new(),
             xnet_messages: vec![],
             lost_messages: vec![],
-            subnet_available_memory: SubnetAvailableMemory::new(
+            subnet_available_memory: SubnetAvailableMemory::new_for_testing(
                 self.execution_config.subnet_memory_capacity.get() as i64
                     - self.execution_config.subnet_memory_reservation.get() as i64,
                 self.execution_config


### PR DESCRIPTION
This PR refactors `SubnetAvailableMemory` by splitting its constructor `new` into a pair of constructors:
- `new_for_testing`: no scaling factor applied in tests that create `SubnetAvailableMemory` manually (only to be used in tests);
- `new_scaled`: used internally in the execution environment to apply the scaling factor `self.scheduler_cores` (renamed from `self.resource_saturation_scaling` to make the semantics of the value clearer);

removing the division operator on `SubnetAvailableMemory` (an instance of `SubnetAvailableMemory` should be created with an appropriate scaling factor and not rescaled later) and the scaling factor as an explicit field of `SubnetAvailableMemory` (since `SubnetAvailableMemory` is always scaled with the same scaling factor).

This way, we scale `SubnetAvailableMemory` with the same scaling factor as `ResourceSaturation` by design (instead of relying on the fact that the same value of the scaling factor is used at the moment when computing `ResourceSaturation` and when manually scaling `SubnetAvailableMemory`).

This PR also renames `subnet_memory_capacity` to `full_subnet_memory_capacity` to make it explicit that no scaling is applied.

Finally, existing tests are updated.