### PR TITLE
fix: increase timeout of the update_workload_large_payload test to reduce flakiness

### DIFF
--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -405,7 +405,7 @@ system_test_nns(
         "colocate",
         "long_test",
     ],
-    test_timeout = "long",
+    test_timeout = "eternal",
     runtime_deps = GRAFANA_RUNTIME_DEPS + COUNTER_CANISTER_RUNTIME_DEPS,
     deps = COMMON_DEPS + [
         "//rs/tests/networking/subnet_update_workload",


### PR DESCRIPTION
This test often hits the `long` 900s bazel timeout so let's increase it to `eternal` which is an hour.