### PR TITLE
chore(IDX): move secrets to separate environment

### DIFF
--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -19,6 +19,7 @@ jobs:
       options: >-
         -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 120
+    environment: Nightly Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,6 +64,7 @@ jobs:
       options: >-
         -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 720 # 12 hours
+    environment: Nightly Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -101,6 +103,7 @@ jobs:
       options: >-
         -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 30
+    environment: Nightly Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This moves the secrets `SSH_PRIVATE_KEY_BACKUP_POD`, `ZH2_DLL01_CSV_SECRETS` and `ZH2_FILE_SHARE_KEY` to a separate environment that can only be accessed on the master branch.