### PR TITLE
fix: increase timeout of the query_workload_long_test to reduce flakiness

### DIFF
--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -391,7 +391,7 @@ system_test_nns(
         "k8s",
         "long_test",
     ],
-    test_timeout = "long",
+    test_timeout = "eternal",
     runtime_deps = GRAFANA_RUNTIME_DEPS + COUNTER_CANISTER_RUNTIME_DEPS,
     deps = COMMON_DEPS + [
         "//rs/tests/networking/subnet_update_workload",


### PR DESCRIPTION
This test is often timing out after 900s so let's increase its timeout to `eternal` (1 hour).