### PR TITLE
fix: increase timeout of the api_bn_update_workload_test to reduce flakiness

### DIFF
--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -27,7 +27,7 @@ system_test_nns(
         "colocate",
         "long_test",
     ],
-    test_timeout = "long",
+    test_timeout = "eternal",
     runtime_deps = GRAFANA_RUNTIME_DEPS + COUNTER_CANISTER_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",


### PR DESCRIPTION
This test is often timing out after 900s so to reduce flakiness this increases the timeout to `eternal` which is 1 hour.