### PR TITLE
fix: Some more cleanups in execution fuzzers

### DIFF
--- a/rs/embedders/fuzz/src/compile.rs
+++ b/rs/embedders/fuzz/src/compile.rs
@@ -18,7 +18,8 @@ const MAX_PARALLEL_EXECUTIONS: usize = 4;
 impl<'a> Arbitrary<'a> for MaybeInvalidModule {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let mut config = if u.ratio(1, 2)? {
-            let mut config = ic_wasm_config(EmbeddersConfig::default());
+            let is_wasm64 = u.arbitrary()?;
+            let mut config = ic_wasm_config(EmbeddersConfig::default(), is_wasm64);
             config.exports = generate_exports(EmbeddersConfig::default(), u)?;
             config.min_data_segments = 2;
             config.max_data_segments = 10;

--- a/rs/embedders/fuzz/src/compile.rs
+++ b/rs/embedders/fuzz/src/compile.rs
@@ -18,7 +18,7 @@ const MAX_PARALLEL_EXECUTIONS: usize = 4;
 impl<'a> Arbitrary<'a> for MaybeInvalidModule {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let mut config = if u.ratio(1, 2)? {
-            let is_wasm64 = u.arbitrary()?;
+            let is_wasm64 = u.ratio(2, 3)?;
             let mut config = ic_wasm_config(EmbeddersConfig::default(), is_wasm64);
             config.exports = generate_exports(EmbeddersConfig::default(), u)?;
             config.min_data_segments = 2;

--- a/rs/embedders/fuzz/src/ic_wasm.rs
+++ b/rs/embedders/fuzz/src/ic_wasm.rs
@@ -49,7 +49,7 @@ impl<'a> Arbitrary<'a> for ICWasmModule {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let embedder_config = EmbeddersConfig::default();
         let exports = generate_exports(embedder_config.clone(), u)?;
-        let is_wasm64 = u.arbitrary()?;
+        let is_wasm64 = u.ratio(2, 3)?;
         let mut config = ic_wasm_config(embedder_config, is_wasm64);
         config.exports = exports;
         Ok(ICWasmModule::new(config.clone(), Module::new(config, u)?))
@@ -71,7 +71,7 @@ impl<'a> Arbitrary<'a> for SystemApiModule {
         // memory pages are bound to 100
         let memory_minimum = u.int_in_range(0..=50)?;
         let memory_maximum = u.int_in_range(memory_minimum..=100)?;
-        let is_wasm64 = u.arbitrary()?;
+        let is_wasm64 = u.ratio(2, 3)?;
 
         let store: &'static SystemApiImportStore = if is_wasm64 {
             &SYSTEM_API_IMPORTS_WASM64
@@ -264,7 +264,7 @@ pub fn ic_wasm_config(embedder_config: EmbeddersConfig, is_wasm64: bool) -> Conf
         bulk_memory_enabled: true,
         reference_types_enabled: true,
         simd_enabled: true,
-        memory64_enabled: true,
+        memory64_enabled: is_wasm64,
 
         threads_enabled: false,
         relaxed_simd_enabled: false,

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_ic_wasm.rs
@@ -10,8 +10,7 @@ use std::cell::RefCell;
 use wasm_fuzzers::ic_wasm::ICWasmModule;
 
 thread_local! {
-    static ENV_32: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(false));
-    static ENV_64: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(true));
+    static ENV: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env());
 }
 
 // r#"
@@ -37,40 +36,23 @@ fn main() {
 }
 
 fuzz_target!(|data: ICWasmModule| {
-    with_env(data.config.memory64_enabled, |env, canister_id| {
+    ENV.with(|env| {
+        let canister_id = env.borrow().1;
+        let execution_test = &mut env.borrow_mut().0;
         let wasm = data.module.to_bytes();
-        if env.reinstall_canister(*canister_id, wasm).is_ok() {
+        if execution_test.reinstall_canister(canister_id, wasm).is_ok() {
             // For determinism, all methods are executed.
             for wasm_method in &data.exported_functions {
-                let _ = env.ingress(*canister_id, wasm_method.name(), vec![]);
+                let _ = execution_test.ingress(canister_id, wasm_method.name(), vec![]);
             }
         }
     });
 });
 
-fn with_env<F, R>(memory64_enabled: bool, f: F) -> R
-where
-    F: FnOnce(&mut ExecutionTest, &CanisterId) -> R,
-{
-    if memory64_enabled {
-        ENV_64.with(|env| {
-            let canister_id = env.borrow().1;
-            let execution_test = &mut env.borrow_mut().0;
-            f(execution_test, &canister_id)
-        })
-    } else {
-        ENV_32.with(|env| {
-            let canister_id = env.borrow().1;
-            let execution_test = &mut env.borrow_mut().0;
-            f(execution_test, &canister_id)
-        })
-    }
-}
-
 // A setup function to initialize ExecutionTest with a dummy canister and expose the canister_id.
 // The same canister_id and ExecutionTest reference is used in the fuzzing runs, where the
 // canister is reinstalled under the same canister_id.
-fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {
+fn setup_env() -> (ExecutionTest, CanisterId) {
     let exec_config = ExecutionConfig {
         embedders_config: EmbeddersConfig::default(),
         max_compilation_cache_size: NumBytes::new(10 * 1024 * 1024), // 10MiB

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
@@ -10,8 +10,7 @@ use std::cell::RefCell;
 use wasm_fuzzers::ic_wasm::SystemApiModule;
 
 thread_local! {
-    static ENV_32: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(false));
-    static ENV_64: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env(true));
+    static ENV: RefCell<(ExecutionTest, CanisterId)> = RefCell::new(setup_env());
 }
 
 // r#"
@@ -37,7 +36,9 @@ fn main() {
 }
 
 fuzz_target!(|data: SystemApiModule| {
-    with_env(data.memory64_enabled, |env, canister_id| {
+    ENV.with(|env| {
+        let canister_id = env.borrow().1;
+        let execution_test = &mut env.borrow_mut().0;
         let wasm = data.module;
         if env.reinstall_canister(*canister_id, wasm).is_ok() {
             // For determinism, all methods are executed.
@@ -45,32 +46,13 @@ fuzz_target!(|data: SystemApiModule| {
                 let _ = env.ingress(*canister_id, wasm_method.name(), vec![]);
             }
         }
-    });
+    })
 });
-
-fn with_env<F, R>(memory64_enabled: bool, f: F) -> R
-where
-    F: FnOnce(&mut ExecutionTest, &CanisterId) -> R,
-{
-    if memory64_enabled {
-        ENV_64.with(|env| {
-            let canister_id = env.borrow().1;
-            let execution_test = &mut env.borrow_mut().0;
-            f(execution_test, &canister_id)
-        })
-    } else {
-        ENV_32.with(|env| {
-            let canister_id = env.borrow().1;
-            let execution_test = &mut env.borrow_mut().0;
-            f(execution_test, &canister_id)
-        })
-    }
-}
 
 // A setup function to initialize ExecutionTest with a dummy canister and expose the canister_id.
 // The same canister_id and ExecutionTest reference is used in the fuzzing runs, where the
 // canister is reinstalled under the same canister_id.
-fn setup_env(memory64_enabled: bool) -> (ExecutionTest, CanisterId) {
+fn setup_env() -> (ExecutionTest, CanisterId) {
     let exec_config = ExecutionConfig {
         embedders_config: EmbeddersConfig::default(),
         max_compilation_cache_size: NumBytes::new(10 * 1024 * 1024), // 10MiB

--- a/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
+++ b/rs/execution_environment/fuzz/fuzz_targets/execute_system_api.rs
@@ -40,10 +40,10 @@ fuzz_target!(|data: SystemApiModule| {
         let canister_id = env.borrow().1;
         let execution_test = &mut env.borrow_mut().0;
         let wasm = data.module;
-        if env.reinstall_canister(*canister_id, wasm).is_ok() {
+        if execution_test.reinstall_canister(canister_id, wasm).is_ok() {
             // For determinism, all methods are executed.
             for wasm_method in &data.exported_functions {
-                let _ = env.ingress(*canister_id, wasm_method.name(), vec![]);
+                let _ = execution_test.ingress(canister_id, wasm_method.name(), vec![]);
             }
         }
     })


### PR DESCRIPTION
The previous [PR](https://github.com/dfinity/ic/pull/6354) that cleaned up the embedder flag for enabling memory64 missed a few things:

1. Setting up the test environment can be made easier in some execution fuzz tests as we do not need to differentiate between an embedder that allows 32-bit only or 64-bit Wasms (missed as there was no complaint about the unused bool that controlled whether the embedder enables `wasm64`).
2. While `SystemApiModule` was correctly producing both 32-bit and 64-bit Wasms with the respective imports of the system API, `ICWasmModule` and `MaybeInvalidModule` were inadvertently changed to only include the 64-bit version of the system API. Technically, this works but it's better to keep the behaviour closer to what we had before where for 32-bit Wasms we import the respective system API.

As a drive-by also renaming the boolean that used to control this from `memory64_enabled` to `is_wasm64` to better reflect that it's not related to enabling anything in the embedder but rather it controls the type of the produced module.