### PR TITLE
chore(ICP-Ledger): update ledger version comment

### DIFF
--- a/rs/ledger_suite/icp/ledger/src/lib.rs
+++ b/rs/ledger_suite/icp/ledger/src/lib.rs
@@ -159,7 +159,6 @@ pub enum LedgerField {
 
 /// The ledger versions represent backwards incompatible versions of the ledger.
 /// Downgrading to a lower ledger version is never suppported.
-/// Upgrading from version N to version N+1 should always be possible.
 /// We have the following ledger versions:
 ///   * 0 - the whole ledger state is stored on the heap.
 ///   * 1 - the allowances are stored in stable structures.


### PR DESCRIPTION
Remove the part of the comment that says it should be possible to upgrade from the previous version, as it is currently not possible.