### PR TITLE
feat: CON-1530 Introduce a way to order pre-signature stashes by their priority (lowest fill level)

### DIFF
--- a/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
+++ b/rs/consensus/idkg/src/payload_builder/pre_signatures.rs
@@ -812,6 +812,13 @@ pub(super) mod tests {
         // Emptier stash has greater priority
         assert_eq!(emptier.cmp(&fuller), Ordering::Greater);
         assert_eq!(fuller.cmp(&emptier), Ordering::Less);
+
+        // switch the key_ids
+        let emptier = make_stash(1, 10, &id2, &transcript);
+        let fuller = make_stash(5, 10, &id1, &transcript);
+        // Emptier stash should still have greater priority
+        assert_eq!(emptier.cmp(&fuller), Ordering::Greater);
+        assert_eq!(fuller.cmp(&emptier), Ordering::Less);
     }
 
     #[test]


### PR DESCRIPTION
This PR introduces a struct that will allow us to order pre-signature stashes by their priority. Specifically, stashes with a proportionally lower fill level receive a higher priority. Ties between stashes with the same proportional fill level are broken by comparing the key IDs of the stashes instead.

This structure will allow us to determine for which stash the next pre-signature creation should be started. In the future, consensus will start the creation of new pre-signatures for the stash with the highest priority (meaning the lowest fill level) until the maximum capacity for creating more pre-signatures is reached.