### PR TITLE
feat(PocketIC): enable HTTP gateway creation together with instance creation

### DIFF
--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -34,6 +34,14 @@ pub struct HttpsConfig {
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct InstanceHttpGatewayConfig {
+    pub ip_addr: Option<String>,
+    pub port: Option<u16>,
+    pub domains: Option<Vec<String>>,
+    pub https_config: Option<HttpsConfig>,
+}
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct HttpGatewayConfig {
     pub ip_addr: Option<String>,
     pub port: Option<u16>,
@@ -68,6 +76,7 @@ pub enum CreateInstanceResponse {
     Created {
         instance_id: InstanceId,
         topology: Topology,
+        http_gateway_info: Option<HttpGatewayInfo>,
     },
     Error {
         message: String,
@@ -581,6 +590,7 @@ pub enum InitialTime {
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
 pub struct InstanceConfig {
     pub subnet_config_set: ExtendedSubnetConfigSet,
+    pub http_gateway_config: Option<InstanceHttpGatewayConfig>,
     pub state_dir: Option<PathBuf>,
     pub nonmainnet_features: bool,
     pub log_level: Option<String>,

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -195,6 +195,7 @@ impl PocketIc {
 
         let instance_config = InstanceConfig {
             subnet_config_set,
+            http_gateway_config: None,
             #[cfg(not(windows))]
             state_dir: state_dir.as_ref().map(|state_dir| state_dir.state_dir()),
             #[cfg(windows)]

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -1038,6 +1038,7 @@ async fn with_all_icp_features_and_nns_subnet_state() {
             nns: Some(SubnetSpec::default().with_state_dir(state_dir_path_buf)),
             ..Default::default()
         },
+        http_gateway_config: None,
         state_dir: None,
         nonmainnet_features: false,
         log_level: None,

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -611,6 +611,7 @@ async fn resume_killed_instance_impl(allow_incomplete_state: Option<bool>) -> Re
     let client = reqwest::Client::new();
     let instance_config = InstanceConfig {
         subnet_config_set: ExtendedSubnetConfigSet::default(),
+        http_gateway_config: None,
         state_dir: Some(temp_dir.path().to_path_buf()),
         nonmainnet_features: false,
         log_level: None,

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The argument of the endpoint `/instances/` takes an additional optional field `allow_incomplete_state` specifying if incomplete state (e.g., resulting from not deleting a PocketIC instance gracefully) is allowed.
 - The argument of the endpoint `/instances/` takes an additional optional field `initial_time` specifying the initial timestamp of the newly created instance or
   if the new instance should make progress automatically, i.e., if PocketIC should periodically update the time of the instance to the real time and execute rounds on the subnets.
+- The argument of the endpoint `/instances/` takes an additional optional field `http_gateway_config` specifying that an HTTP gateway with the given configuration
+  should be created for the newly created instance.
 
 
 

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -126,6 +126,7 @@ fn test_creation_of_instance_extended() {
             ..Default::default()
         }
         .into(),
+        http_gateway_config: None,
         state_dir: None,
         nonmainnet_features: false,
         log_level: None,


### PR DESCRIPTION
This PR extends the argument of the endpoint `/instances/` with an additional optional field `http_gateway_config` specifying that an HTTP gateway with the given configuration should be created for the newly created instance.