### PR TITLE
fix: fix error logging from PrintErrln to PrintErrf for consistency

### DIFF
--- a/rs/tests/ict/cmd/testnetCreateCmd.go
+++ b/rs/tests/ict/cmd/testnetCreateCmd.go
@@ -274,7 +274,7 @@ func TestnetCommand(cfg *TestnetConfig) func(cmd *cobra.Command, args []string) 
 					return err
 				}
 				if err = DeleteTestnet(farmBaseUrl, group); err != nil {
-					cmd.PrintErrln("failed to delete testnet: %v", err)
+					cmd.PrintErrf("failed to delete testnet: %v", err)
 					return err
 				}
 				cmd.PrintErrln(GREEN + "Testnet was deleted successfully" + NC)


### PR DESCRIPTION
This commit refactors the error logging in the code by changing the method from `cmd.PrintErrln` to `cmd.PrintErrf`. The new method provides a more consistent formatting approach for error messages. This change improves readability and maintains uniformity in how errors are handled throughout the codebase. Additionally, it ensures that error messages are formatted correctly, which can aid in debugging and troubleshooting.