### PR TITLE
feat: Soft limit for merge size [MR-695]

### DIFF
--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -52,11 +52,11 @@ use std::time::Instant;
 /// shards in 4 checkpoints at most.
 const NUMBER_OF_FILES_HARD_LIMIT: usize = 20;
 
-const GIB: usize = 1024 * 1024 * 1024;
+const GIB: u64 = 1024 * 1024 * 1024;
 
 /// Maximum amount of data we can safely write during merge without expecting blocking of
 /// checkpointing.
-const MERGE_SOFT_BUDGET_BYTES: usize = 250 * GIB;
+const MERGE_SOFT_BUDGET_BYTES: u64 = 250 * GIB;
 
 #[derive(Clone, Debug, Default)]
 struct CheckpointState {

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -944,7 +944,8 @@ fn merge(
     let max_storage = storage_info.mem_size * 2 + storage_info.mem_size / 2;
 
     merge_candidates.sort_by_key(|m| -(m.num_files_before() as i64));
-    let storage_to_merge_for_filenum = std::min(MERGE_SOFT_BUDGET_BYTEs, storage_info.mem_size / 4);
+    let storage_to_merge_for_filenum =
+        std::cmp::min(MERGE_SOFT_BUDGET_BYTES, storage_info.mem_size / 4);
     let min_storage_to_merge = storage_info.mem_size / 50;
     let merges_by_filenum = merge_candidates
         .iter()


### PR DESCRIPTION
As we increase the state size, we need to adjust the LSMT merge strategy to be not too aggressive unless needed. I.e. we want to avoid blocking the checkpointing unless we have to do it in order to keep the limits on storage overhead and number of files.