### PR TITLE
test(consensus): Make query_stats_basic test more stable

### DIFF
--- a/rs/tests/query_stats/lib/src/aggregation.rs
+++ b/rs/tests/query_stats/lib/src/aggregation.rs
@@ -66,7 +66,7 @@ fn query_stats_fault_tolerance(env: TestEnv, query_range: Range<usize>, expect_s
         // NOTE: The `round_robin_query_call` below sometimes fails, if we
         // execute it immidiately and one of the nodes is slightly behind,
         // such that the Universal canister does not exist on that node yet
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(Duration::from_secs(5)).await;
 
         // Do a query call against all nodes
         round_robin_query_call(&uc_id, &agents[query_range.clone()]).await;


### PR DESCRIPTION
In the test, we update a universal canister to contain some data. Then we query each node individually to return the data.

Occasionally, this fails, since a single node might be behind, and therefore might serve outdated data.

This PR sets the waiting time from 2 secs to 5 secs, which hopefully makes the test more robust.