### PR TITLE
chore: remove explicit settings of test_timeout = "long" since it's the default

### DIFF
--- a/rs/tests/financial_integrations/rosetta/BUILD.bazel
+++ b/rs/tests/financial_integrations/rosetta/BUILD.bazel
@@ -6,7 +6,6 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 system_test_nns(
     name = "rosetta_test",
     tags = ["colocate"],
-    test_timeout = "long",
     runtime_deps = [
         "//rs/rosetta-api/icp:ic-rosetta-api",
         "//rs/tests:rosetta_workspace",

--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -33,7 +33,6 @@ system_test_nns(
         "k8s",
         "system_test_large",
     ],
-    test_timeout = "long",
     runtime_deps = XNET_TEST_CANISTER_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",
@@ -52,7 +51,6 @@ system_test_nns(
         "k8s",
         "system_test_large",
     ],
-    test_timeout = "long",
     runtime_deps = XNET_TEST_CANISTER_RUNTIME_DEPS + GRAFANA_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",
@@ -86,7 +84,6 @@ system_test(
     env = {
         "XNET_TEST_CANISTER_WASM_PATH": "$(rootpath //rs/rust_canisters/xnet_test:xnet-test-canister)",
     },
-    test_timeout = "long",
     uses_guestos_img = False,
     uses_guestos_malicious_img = True,
     runtime_deps = GRAFANA_RUNTIME_DEPS + XNET_TEST_CANISTER_RUNTIME_DEPS,
@@ -111,7 +108,6 @@ system_test_nns(
     tags = [
         "long_test",
     ],
-    test_timeout = "long",
     uses_guestos_img = False,
     uses_guestos_nns_mainnet_img = True,
     uses_guestos_update = True,


### PR DESCRIPTION
`test_timeout = "long"` is the [default](https://sourcegraph.com/github.com/dfinity/ic/-/blob/rs/tests/system_tests.bzl?L210) for system-tests so let's not set it explicitly.