### PR TITLE
test(MR): Speed up rejoin_large_test

### DIFF
--- a/rs/tests/message_routing/rejoin_test_large_state.rs
+++ b/rs/tests/message_routing/rejoin_test_large_state.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-const DKG_INTERVAL: u64 = 50;
+const DKG_INTERVAL: u64 = 99;
 
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/rs/tests/message_routing/rejoin_test_large_state.rs
+++ b/rs/tests/message_routing/rejoin_test_large_state.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-const DKG_INTERVAL: u64 = 24;
+const DKG_INTERVAL: u64 = 50;
 
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/rs/tests/message_routing/rejoin_test_large_state.rs
+++ b/rs/tests/message_routing/rejoin_test_large_state.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-const DKG_INTERVAL: u64 = 499;
+const DKG_INTERVAL: u64 = 24;
 
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/rs/tests/message_routing/rejoin_test_large_state.rs
+++ b/rs/tests/message_routing/rejoin_test_large_state.rs
@@ -112,6 +112,8 @@ fn setup(env: TestEnv, config: Config) {
                     )),
                 })
                 .with_dkg_interval_length(Height::from(DKG_INTERVAL))
+                .with_unit_delay(Duration::from_millis(200))
+                .with_initial_notary_delay(Duration::from_millis(200))
                 .add_nodes(config.nodes_count),
         )
         .setup_and_start(&env)

--- a/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
+++ b/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
@@ -379,40 +379,6 @@ async fn modify_canister_heap(
     skip_odd_indexed_canister: bool,
     seed: usize,
 ) {
-    // for x in 1..=size_level {
-    //     info!(
-    //         logger,
-    //         "Start modifying canisters {} times, it is now {}",
-    //         x,
-    //         Utc::now()
-    //     );
-    //     for (i, canister) in canisters.iter().enumerate() {
-    //         if skip_odd_indexed_canister && i % 2 == 1 {
-    //             continue;
-    //         }
-    //         let seed_for_canister = i + (x - 1) * num_canisters + seed;
-    //         let payload = (x as u32, seed_for_canister as u32);
-    //         // Each call will expand the memory by writing a chunk of 128 MiB.
-    //         // There are 8 chunks in the canister, so the memory will grow by 1 GiB after 8 calls.
-    //         let _res: Result<u64, String> = canister
-    //             .update_("expand_state", dfn_candid::candid, payload)
-    //             .await
-    //             .unwrap_or_else(|e| {
-    //                 panic!(
-    //                     "Calling expand_state() on canister {} failed: {}",
-    //                     canister.canister_id_vec8()[0],
-    //                     e
-    //                 )
-    //             });
-    //     }
-    //     info!(
-    //         logger,
-    //         "Expanded canisters {} times, it is now {}",
-    //         x,
-    //         Utc::now()
-    //     );
-    // }
-
     let expansions = canisters
         .iter()
         .enumerate()

--- a/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
+++ b/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
@@ -413,10 +413,10 @@ async fn modify_canister_heap(
     //     );
     // }
 
-    // TODO: Implement skip odd canisters
     let expansions = canisters
         .iter()
         .enumerate()
+        .filter(|(idx, _)| !(skip_odd_indexed_canister && idx % 2 == 1))
         .map(|(idx, canister)| {
             let logger_clone = logger.clone();
             async move {

--- a/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
+++ b/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
@@ -379,39 +379,72 @@ async fn modify_canister_heap(
     skip_odd_indexed_canister: bool,
     seed: usize,
 ) {
-    for x in 1..=size_level {
-        info!(
-            logger,
-            "Start modifying canisters {} times, it is now {}",
-            x,
-            Utc::now()
-        );
-        for (i, canister) in canisters.iter().enumerate() {
-            if skip_odd_indexed_canister && i % 2 == 1 {
-                continue;
+    // for x in 1..=size_level {
+    //     info!(
+    //         logger,
+    //         "Start modifying canisters {} times, it is now {}",
+    //         x,
+    //         Utc::now()
+    //     );
+    //     for (i, canister) in canisters.iter().enumerate() {
+    //         if skip_odd_indexed_canister && i % 2 == 1 {
+    //             continue;
+    //         }
+    //         let seed_for_canister = i + (x - 1) * num_canisters + seed;
+    //         let payload = (x as u32, seed_for_canister as u32);
+    //         // Each call will expand the memory by writing a chunk of 128 MiB.
+    //         // There are 8 chunks in the canister, so the memory will grow by 1 GiB after 8 calls.
+    //         let _res: Result<u64, String> = canister
+    //             .update_("expand_state", dfn_candid::candid, payload)
+    //             .await
+    //             .unwrap_or_else(|e| {
+    //                 panic!(
+    //                     "Calling expand_state() on canister {} failed: {}",
+    //                     canister.canister_id_vec8()[0],
+    //                     e
+    //                 )
+    //             });
+    //     }
+    //     info!(
+    //         logger,
+    //         "Expanded canisters {} times, it is now {}",
+    //         x,
+    //         Utc::now()
+    //     );
+    // }
+
+    // TODO: Implement skip odd canisters
+    let expansions = canisters
+        .iter()
+        .enumerate()
+        .map(|(idx, canister)| {
+            let logger_clone = logger.clone();
+            async move {
+                for x in 1..=size_level {
+                    let seed_for_canister = idx + (x - 1) * num_canisters + seed;
+                    let payload = (x as u32, seed_for_canister as u32);
+                    let _res: Result<u64, String> = canister
+                        .update_("expand_state", dfn_candid::candid, payload)
+                        .await
+                        .unwrap_or_else(|err| {
+                            panic!(
+                                "Calling expand_state() on canister {:?} failed: {}",
+                                canister, err
+                            )
+                        });
+                    info!(
+                        logger_clone,
+                        "Expanded canister {:?} {} times, it is now {}",
+                        canister,
+                        x,
+                        Utc::now()
+                    );
+                }
             }
-            let seed_for_canister = i + (x - 1) * num_canisters + seed;
-            let payload = (x as u32, seed_for_canister as u32);
-            // Each call will expand the memory by writing a chunk of 128 MiB.
-            // There are 8 chunks in the canister, so the memory will grow by 1 GiB after 8 calls.
-            let _res: Result<u64, String> = canister
-                .update_("expand_state", dfn_candid::candid, payload)
-                .await
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "Calling expand_state() on canister {} failed: {}",
-                        canister.canister_id_vec8()[0],
-                        e
-                    )
-                });
-        }
-        info!(
-            logger,
-            "Expanded canisters {} times, it is now {}",
-            x,
-            Utc::now()
-        );
-    }
+        })
+        .collect::<Vec<_>>();
+
+    join_all(expansions).await;
 }
 
 // The function waits for the manifest reaching or surpassing the given height and returns the manifest height.


### PR DESCRIPTION
While taking a look at the state sync system tests, I came along this test, which seems to be similar to what I want to use for the fast state sync benchmark.

However, it seems the test was running much slower than needed.
This PR:

- Parallelizes the calls inside the `modify_canister_heap`, such that the different canisters run in parallel. This speeds up the time to fill them up from 150s to around 40s.
- Sets a shorter DKG interval, from 500 to 25. A large amount of time is spend waiting for cups
- The unit and initial notary delays are set to 200ms