### PR TITLE
chore: tag //rs/bitcoin/ckbtc/minter:ckbtc_minter_replay_events_tests as a long_test

### DIFF
--- a/rs/bitcoin/ckbtc/minter/BUILD.bazel
+++ b/rs/bitcoin/ckbtc/minter/BUILD.bazel
@@ -174,6 +174,9 @@ rust_test(
         "test_resources/testnet_events.gz",
     ],
     proc_macro_deps = LIB_PROC_MACRO_DEPS,
+    tags = [
+        "long_test",  # The P90 of this test is over 13m for the week starting on 2025-08-20
+    ],
     deps = [
         # Keep sorted.
         ":ckbtc_minter_lib",


### PR DESCRIPTION
The P90 duration of the `//rs/bitcoin/ckbtc/minter:ckbtc_minter_replay_events_tests` is over 13 minutes which is higher than our 5 minute maximum. So let's tag this as a `long_test` to not run it on PRs by default.

If desired this test can be triggered explicitly on certain file changes via [`PULL_REQUEST_BAZEL_TARGETS`](https://github.com/dfinity/ic/blob/master/PULL_REQUEST_BAZEL_TARGETS).

Note that this test does run when "direct" source dependencies of the test are modified. More precisely it runs whenever any of the files returned by the following are modified: 
```
bazel query 'filter("^//", kind("source file", deps(//rs/bitcoin/ckbtc/minter:ckbtc_minter_replay_events_tests, 2)))' 
```