### PR TITLE
chore: include all modified long_tests

### DIFF
--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -9,7 +9,7 @@
 #
 # If --skip_long_tests is passed, tests tagged with 'long_test' will be excluded.
 #
-# However, long system-tests of which a direct source file has been modified will be included.
+# However, long_tests of which a direct source file has been modified will be included.
 #
 # Finally ./PULL_REQUEST_BAZEL_TARGETS is taken into account to explicitly return targets based on modified files
 # even though they're not an explicit dependency of a bazel target or are tagged as `long_test`.
@@ -126,12 +126,14 @@ def diff_only_query(command: str, base: str, head: str, skip_long_tests: bool) -
     # Exclude the long_tests if requested:
     query = f"({query})" + (" except attr(tags, long_test, //...)" if skip_long_tests else "")
 
-    # Include all long system-tests (under //rs/tests) of which a "direct" source file has been modified.
+    # Include all long_tests of which a "direct" source file has been modified.
     # We specify a depth of 2 since a system-test depends on the test binary (1st degree) which depends
     # on the source file (2nd degree).
-    # This will trigger long system-tests if some files other than its .rs file are modified but we think
-    # this is acceptable since it would be good to run the tests if those direct files are modified anyways.
-    query = f"({query}) + attr(tags, long_test, rdeps(//rs/tests/..., set({mfiles}), 2))"
+    # This will trigger long_tests if some files other than its .rs file are modified but we think
+    # this is acceptable since it would be good to run the tests if those files close to the test are modified anyways.
+    # To see which source files are within a depth of 2 away from <TEST> use:
+    # bazel query 'filter("^//", kind("source file", deps(<TEST>, 2)))'
+    query = f"({query}) + attr(tags, long_test, rdeps(//..., set({mfiles}), 2))"
 
     # Next, add the explicit targets from the PULL_REQUEST_BAZEL_TARGETS file that match the modified files:
     explicit_targets: Set[str] = set()


### PR DESCRIPTION
We previously only included long_tests under `rs/tests` which were directly modified. However we have a few tests tagged as `long_test` outside of `rs/tests` which should receive the same treatment. So this replaces:
```diff
-rdeps(//rs/tests/..., set({mfiles}), 2)
+rdeps(//..., set({mfiles}), 2)
```