### PR TITLE
chore(test): bump signer canister to ic-cdk 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13152,7 +13152,6 @@ version = "0.9.0"
 dependencies = [
  "candid",
  "ic-cdk",
- "ic-management-canister-types",
  "ic_bls12_381",
  "serde",
 ]
@@ -14119,7 +14118,6 @@ dependencies = [
  "ic-interfaces-registry",
  "ic-ledger-core",
  "ic-limits",
- "ic-management-canister-types",
  "ic-management-canister-types-private",
  "ic-message",
  "ic-nervous-system-common",
@@ -15263,7 +15261,6 @@ dependencies = [
  "ic-cdk",
  "ic-config",
  "ic-limits",
- "ic-management-canister-types",
  "ic-management-canister-types-private",
  "ic-message",
  "ic-nervous-system-common-test-keys",

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -296,6 +296,7 @@ pub fn tecdsa_performance_test(
                         1,
                         0,
                         key_id,
+                        None,
                     )
                 }
                 MasterPublicKeyId::VetKd(key_id) => {

--- a/rs/tests/consensus/tecdsa/tschnorr_message_sizes_test.rs
+++ b/rs/tests/consensus/tecdsa/tschnorr_message_sizes_test.rs
@@ -16,7 +16,6 @@ Success::
 . Signature requests succeed and fail as expected
 
 end::catalog[] */
-#![allow(deprecated)]
 
 use anyhow::Result;
 

--- a/rs/tests/consensus/tecdsa/tschnorr_message_sizes_test.rs
+++ b/rs/tests/consensus/tecdsa/tschnorr_message_sizes_test.rs
@@ -134,11 +134,17 @@ async fn gen_message_and_get_signature_depending_on_limit(
     let message = dummy_message(message_size);
 
     let signature = match limit_type {
-        LimitType::Local => {
-            generate_dummy_schnorr_signature_with_logger(message.len(), 0, 0, key_id, sig_can, log)
-                .await
-                .map(|sig| sig.signature)
-        }
+        LimitType::Local => generate_dummy_schnorr_signature_with_logger(
+            message.len(),
+            0,
+            0,
+            key_id,
+            None,
+            sig_can,
+            log,
+        )
+        .await
+        .map(|sig| sig.signature),
 
         LimitType::XNet => {
             get_schnorr_signature_with_logger(message.clone(), cycles, key_id, msg_can, log).await

--- a/rs/tests/consensus/tecdsa/utils/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/utils/BUILD.bazel
@@ -35,7 +35,6 @@ rust_library(
         "@crate_index//:ed25519-dalek",
         "@crate_index//:ic-agent",
         "@crate_index//:ic-cdk",
-        "@crate_index//:ic-management-canister-types",
         "@crate_index//:ic-vetkeys",
         "@crate_index//:ic_bls12_381",
         "@crate_index//:k256",

--- a/rs/tests/consensus/tecdsa/utils/Cargo.toml
+++ b/rs/tests/consensus/tecdsa/utils/Cargo.toml
@@ -18,7 +18,6 @@ ic-canister-client = { path = "../../../../canister_client" }
 ic-cdk = { workspace = true }
 ic-config = { path = "../../../../config" }
 ic-limits = { path = "../../../../limits" }
-ic-management-canister-types = { workspace = true }
 ic-management-canister-types-private = { path = "../../../../types/management_canister_types" }
 ic-message = { path = "../../../test_canisters/message" }
 ic-nervous-system-common-test-keys = { path = "../../../../nervous_system/common/test_keys" }

--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -875,7 +875,7 @@ pub async fn generate_dummy_schnorr_signature_with_logger(
         derivation_path_length,
         derivation_path_element_size,
         key_id: cast_schnorr_key_id(key_id.clone()),
-        aux: aux.map(|a| cast_schnorr_aux(a)),
+        aux: aux.map(cast_schnorr_aux),
     };
     info!(
         logger,
@@ -1326,7 +1326,7 @@ impl ChainSignatureRequest {
             derivation_path_length,
             derivation_path_element_size,
             key_id: cast_schnorr_key_id(key_id),
-            aux: aux.map(|a| cast_schnorr_aux(a)),
+            aux: aux.map(cast_schnorr_aux),
         };
 
         (String::from("gen_schnorr_sig"), Encode!(&params).unwrap())

--- a/rs/tests/driver/BUILD.bazel
+++ b/rs/tests/driver/BUILD.bazel
@@ -110,7 +110,6 @@ rust_library(
         "@crate_index//:humantime-serde",
         "@crate_index//:ic-agent",
         "@crate_index//:ic-cdk",
-        "@crate_index//:ic-management-canister-types",
         "@crate_index//:ic-utils",
         "@crate_index//:itertools",
         "@crate_index//:json5",

--- a/rs/tests/driver/Cargo.toml
+++ b/rs/tests/driver/Cargo.toml
@@ -42,7 +42,6 @@ ic-icrc1 = { path = "../../ledger_suite/icrc1" }
 ic-interfaces = { path = "../../interfaces" }
 ic-interfaces-registry = { path = "../../interfaces/registry" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
-ic-management-canister-types = { workspace = true }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }
 ic-message = { path = "../test_canisters/message" }
 ic-nervous-system-common = { path = "../../nervous_system/common" }

--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use crate::{
     canister_agent::CanisterAgent,
     canister_api::GenericRequest,
@@ -28,12 +27,11 @@ use ic_agent::{
     Agent, AgentError, Identity, Signature,
 };
 use ic_canister_client::{Agent as DeprecatedAgent, Sender};
-use ic_cdk::api::management_canister::{
-    ecdsa::SignWithEcdsaResponse, schnorr::SignWithSchnorrResponse,
+use ic_cdk::management_canister::{
+    SignWithEcdsaResult, SignWithSchnorrResult, VetKDDeriveKeyResult,
 };
 use ic_config::ConfigOptional;
 use ic_limits::MAX_INGRESS_TTL;
-use ic_management_canister_types::VetKDDeriveKeyResult;
 use ic_management_canister_types_private::{CanisterStatusResultV2, EmptyBlob, Payload};
 use ic_message::ForwardParams;
 use ic_nervous_system_proto::pb::v1::GlobalTimeOfDay;
@@ -842,25 +840,25 @@ impl<'a> SignerCanister<'a> {
     pub async fn gen_ecdsa_sig(
         &self,
         params: GenEcdsaParams,
-    ) -> Result<SignWithEcdsaResponse, AgentError> {
+    ) -> Result<SignWithEcdsaResult, AgentError> {
         self.agent
             .update(&self.canister_id, "gen_ecdsa_sig")
             .with_arg(Encode!(&params).unwrap())
             .call_and_wait()
             .await
-            .map(|bytes| Decode!(&bytes, SignWithEcdsaResponse).unwrap())
+            .map(|bytes| Decode!(&bytes, SignWithEcdsaResult).unwrap())
     }
 
     pub async fn gen_schnorr_sig(
         &self,
         params: GenSchnorrParams,
-    ) -> Result<SignWithSchnorrResponse, AgentError> {
+    ) -> Result<SignWithSchnorrResult, AgentError> {
         self.agent
             .update(&self.canister_id, "gen_schnorr_sig")
             .with_arg(Encode!(&params).unwrap())
             .call_and_wait()
             .await
-            .map(|bytes| Decode!(&bytes, SignWithSchnorrResponse).unwrap())
+            .map(|bytes| Decode!(&bytes, SignWithSchnorrResult).unwrap())
     }
 
     pub async fn gen_vetkd_key(

--- a/rs/tests/test_canisters/signer/BUILD.bazel
+++ b/rs/tests/test_canisters/signer/BUILD.bazel
@@ -7,7 +7,6 @@ DEPENDENCIES = [
     # Keep sorted.
     "@crate_index//:candid",
     "@crate_index//:ic-cdk",
-    "@crate_index//:ic-management-canister-types",
     "@crate_index//:ic_bls12_381",
     "@crate_index//:serde",
 ]

--- a/rs/tests/test_canisters/signer/Cargo.toml
+++ b/rs/tests/test_canisters/signer/Cargo.toml
@@ -9,6 +9,5 @@ documentation.workspace = true
 [dependencies]
 candid = { workspace = true }
 ic-cdk = { workspace = true }
-ic-management-canister-types = { workspace = true }
 ic_bls12_381 = { workspace = true }
 serde = { workspace = true }

--- a/rs/tests/test_canisters/signer/src/lib.rs
+++ b/rs/tests/test_canisters/signer/src/lib.rs
@@ -1,7 +1,5 @@
-#![allow(deprecated)]
 use candid::CandidType;
-use ic_cdk::api::management_canister::{ecdsa::EcdsaKeyId, schnorr::SchnorrKeyId};
-use ic_management_canister_types::VetKDKeyId;
+use ic_cdk::management_canister::{EcdsaKeyId, SchnorrAux, SchnorrKeyId, VetKDKeyId};
 use serde::Deserialize;
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -17,6 +15,7 @@ pub struct GenSchnorrParams {
     pub derivation_path_length: usize,
     pub derivation_path_element_size: usize,
     pub key_id: SchnorrKeyId,
+    pub aux: Option<SchnorrAux>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]

--- a/rs/tests/test_canisters/signer/src/main.rs
+++ b/rs/tests/test_canisters/signer/src/main.rs
@@ -1,16 +1,15 @@
-#![allow(deprecated)]
-use candid::Principal;
+use std::marker::PhantomData;
+
+use candid::Encode;
 use ic_cdk::{
-    api::{
-        call::{call_with_payment128, CallResult, ManualReply},
-        management_canister::{
-            ecdsa::{sign_with_ecdsa, SignWithEcdsaArgument, SignWithEcdsaResponse},
-            schnorr::{sign_with_schnorr, SignWithSchnorrArgument, SignWithSchnorrResponse},
-        },
+    api::{msg_reject, msg_reply},
+    management_canister::{
+        sign_with_ecdsa, sign_with_schnorr, vetkd_derive_key, SignWithEcdsaArgs,
+        SignWithEcdsaResult, SignWithSchnorrArgs, SignWithSchnorrResult, VetKDDeriveKeyArgs,
+        VetKDDeriveKeyResult,
     },
     update,
 };
-use ic_management_canister_types::{VetKDDeriveKeyArgs, VetKDDeriveKeyResult};
 use ic_signer::{GenEcdsaParams, GenSchnorrParams, GenVetkdParams};
 
 /// Generates a dummy ECDSA signature of given size parameters.
@@ -22,17 +21,18 @@ pub async fn gen_ecdsa_sig(
         derivation_path_element_size,
         key_id,
     }: GenEcdsaParams,
-) -> ManualReply<SignWithEcdsaResponse> {
-    let signature_request = SignWithEcdsaArgument {
+) -> PhantomData<SignWithEcdsaResult> {
+    let signature_request = SignWithEcdsaArgs {
         message_hash: vec![1; 32],
         derivation_path: vec![vec![2; derivation_path_element_size]; derivation_path_length],
         key_id,
     };
 
-    match sign_with_ecdsa(signature_request).await {
-        Ok((sig,)) => ManualReply::one(sig),
-        Err((_, err)) => ManualReply::reject(err),
+    match sign_with_ecdsa(&signature_request).await {
+        Ok(sig) => msg_reply(Encode!(&sig).unwrap()),
+        Err(err) => msg_reject(err.to_string()),
     }
+    PhantomData
 }
 
 /// Generates a dummy Schnorr signature of given size parameters.
@@ -44,18 +44,21 @@ pub async fn gen_schnorr_sig(
         derivation_path_length,
         derivation_path_element_size,
         key_id,
+        aux,
     }: GenSchnorrParams,
-) -> ManualReply<SignWithSchnorrResponse> {
-    let signature_request = SignWithSchnorrArgument {
+) -> PhantomData<SignWithSchnorrResult> {
+    let signature_request = SignWithSchnorrArgs {
         message: vec![1; message_size],
         derivation_path: vec![vec![2; derivation_path_element_size]; derivation_path_length],
         key_id,
+        aux,
     };
 
-    match sign_with_schnorr(signature_request).await {
-        Ok((sig,)) => ManualReply::one(sig),
-        Err((_, err)) => ManualReply::reject(err),
+    match sign_with_schnorr(&signature_request).await {
+        Ok(sig) => msg_reply(Encode!(&sig).unwrap()),
+        Err(err) => msg_reject(err.to_string()),
     }
+    PhantomData
 }
 
 /// Generates a dummy VetKD key of given size parameters.
@@ -67,7 +70,7 @@ pub async fn gen_vetkd_key(
         input_size,
         key_id,
     }: GenVetkdParams,
-) -> ManualReply<VetKDDeriveKeyResult> {
+) -> PhantomData<VetKDDeriveKeyResult> {
     let key_request = VetKDDeriveKeyArgs {
         context: vec![1; context_size],
         input: vec![2; input_size],
@@ -75,20 +78,11 @@ pub async fn gen_vetkd_key(
         transport_public_key: ic_bls12_381::G1Affine::generator().to_compressed().to_vec(),
     };
 
-    match vetkd_derive_key(key_request).await {
-        Ok((key,)) => ManualReply::one(key),
-        Err((_, err)) => ManualReply::reject(err),
+    match vetkd_derive_key(&key_request).await {
+        Ok(sig) => msg_reply(Encode!(&sig).unwrap()),
+        Err(err) => msg_reject(err.to_string()),
     }
-}
-
-pub async fn vetkd_derive_key(arg: VetKDDeriveKeyArgs) -> CallResult<(VetKDDeriveKeyResult,)> {
-    call_with_payment128(
-        Principal::management_canister(),
-        "vetkd_derive_key",
-        (arg,),
-        26_153_846_153,
-    )
-    .await
+    PhantomData
 }
 
 fn main() {}

--- a/rs/tests/test_canisters/signer/src/signer.did
+++ b/rs/tests/test_canisters/signer/src/signer.did
@@ -1,3 +1,4 @@
+type Bip341 = record { merkle_root_hash : blob };
 type EcdsaCurve = variant { secp256k1 };
 type EcdsaKeyId = record { name : text; curve : EcdsaCurve };
 type GenEcdsaParams = record {
@@ -6,6 +7,7 @@ type GenEcdsaParams = record {
   derivation_path_element_size : nat64;
 };
 type GenSchnorrParams = record {
+  aux : opt SchnorrAux;
   key_id : SchnorrKeyId;
   derivation_path_length : nat64;
   derivation_path_element_size : nat64;
@@ -16,14 +18,21 @@ type GenVetkdParams = record {
   input_size : nat64;
   context_size : nat64;
 };
-type ManualReply = record { signature : blob };
-type ManualReply_1 = record { encrypted_key : blob };
 type SchnorrAlgorithm = variant { ed25519; bip340secp256k1 };
+type SchnorrAux = variant { bip341 : Bip341 };
 type SchnorrKeyId = record { algorithm : SchnorrAlgorithm; name : text };
+type SignWithEcdsaResult = record { signature : blob };
 type VetKDCurve = variant { bls12_381_g2 };
+type VetKDDeriveKeyResult = record { encrypted_key : blob };
 type VetKDKeyId = record { name : text; curve : VetKDCurve };
 service : {
-  gen_ecdsa_sig : (GenEcdsaParams) -> (ManualReply);
-  gen_schnorr_sig : (GenSchnorrParams) -> (ManualReply);
-  gen_vetkd_key : (GenVetkdParams) -> (ManualReply_1);
+  // Generates a dummy ECDSA signature of given size parameters.
+  // The call does not verify the signature, it only generates it.
+  gen_ecdsa_sig : (GenEcdsaParams) -> (SignWithEcdsaResult);
+  // Generates a dummy Schnorr signature of given size parameters.
+  // The call does not verify the signature, it only generates it.
+  gen_schnorr_sig : (GenSchnorrParams) -> (SignWithEcdsaResult);
+  // Generates a dummy VetKD key of given size parameters.
+  // The call does not verify the encrypted key, it only generates it.
+  gen_vetkd_key : (GenVetkdParams) -> (VetKDDeriveKeyResult);
 }


### PR DESCRIPTION
This PR uses the non-depecrated API from ic-cdk 0.18 in `ic-signer`, the signer canister. In particular, the API now supports VetKD, allowing us to remove the dependency to `ic-management-canister-types` and the manual implementation of `vetkd_derive_key`.