### PR TITLE
chore: tag //packages/pocket-ic:icp_features_tests/icp_features_test as a long_test

### DIFF
--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -124,6 +124,7 @@ rust_test_suite(
         # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
         "requires-network",
         "test_macos",
+        "long_test",  # The P90 of this test is over 8m for the week starting on 2025-08-20
     ],
     deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
 )


### PR DESCRIPTION
The P90 duration of the `//packages/pocket-ic:icp_features_tests/icp_features_test` is over 8 minutes which is higher than our 5 minute maximum. So let's tag this as a `long_test` to not run it on PRs by default.

If desired this test can be triggered explictly on certain file changes via [`PULL_REQUEST_BAZEL_TARGETS`](https://github.com/dfinity/ic/blob/master/PULL_REQUEST_BAZEL_TARGETS).

Note that this test does run when "direct" source dependencies of the test are modified. More precisely it runs whenever any of the files returned by the following are modified (this requires https://github.com/dfinity/ic/pull/6493): 
```
bazel query 'filter("^//", kind("source file", deps(//packages/pocket-ic:icp_features_tests/icp_features_test, 2)))' 
//packages/pocket-ic:README.md
//packages/pocket-ic:src/common/mod.rs
//packages/pocket-ic:src/common/rest.rs
//packages/pocket-ic:src/lib.rs
//packages/pocket-ic:src/nonblocking.rs
//packages/pocket-ic:tests/icp_features.rs
//rs/pocket_ic_server:src/main.rs
```