### PR TITLE
chore(canister_migration): [CON-1487] Rename some structs/constants from *CALL_V3* to *SYNC_CALL*

### DIFF
--- a/rs/http_endpoints/public/src/call/call_async.rs
+++ b/rs/http_endpoints/public/src/call/call_async.rs
@@ -97,10 +97,10 @@ pub fn new_service(
     BoxCloneService::new(router.into_service())
 }
 
-pub(super) type CallV2Response = Result<Accepted, IngressError>;
+type AsyncResponse = Result<Accepted, IngressError>;
 
 /// Handles a call to /api/v2/canister/../call
-pub(super) async fn handler(
+async fn handler(
     Path(effective_canister_id): Path<CanisterId>,
     State(AsynchronousCallHandlerState {
         ingress_tracking_semaphore,
@@ -108,7 +108,7 @@ pub(super) async fn handler(
         ingress_watcher_handle,
     }): State<AsynchronousCallHandlerState>,
     WithTimeout(Cbor(request)): WithTimeout<Cbor<HttpRequestEnvelope<HttpCallContent>>>,
-) -> CallV2Response {
+) -> AsyncResponse {
     let logger = ingress_validator.log.clone();
 
     let ingress_submitter = ingress_validator

--- a/rs/http_endpoints/public/src/call/call_sync.rs
+++ b/rs/http_endpoints/public/src/call/call_sync.rs
@@ -7,12 +7,12 @@ use super::{
 use crate::{
     common::{into_cbor, Cbor, WithTimeout},
     metrics::{
-        HttpHandlerMetrics, CALL_V3_EARLY_RESPONSE_CERTIFICATION_TIMEOUT,
-        CALL_V3_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION,
-        CALL_V3_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING,
-        CALL_V3_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE,
-        CALL_V3_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT, CALL_V3_STATUS_IS_INVALID_UTF8,
-        CALL_V3_STATUS_IS_NOT_LEAF,
+        HttpHandlerMetrics, CALL_SYNC_EARLY_RESPONSE_CERTIFICATION_TIMEOUT,
+        CALL_SYNC_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION,
+        CALL_SYNC_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING,
+        CALL_SYNC_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE,
+        CALL_SYNC_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT, CALL_SYNC_STATUS_IS_INVALID_UTF8,
+        CALL_SYNC_STATUS_IS_NOT_LEAF,
     },
     HttpError,
 };
@@ -56,7 +56,7 @@ pub enum Version {
     V4,
 }
 
-pub(crate) enum CallV3Response {
+enum SyncCallResponse {
     Certificate(Certificate),
     Accepted(&'static str),
     UserError(UserError),
@@ -74,10 +74,10 @@ struct SynchronousCallHandlerState {
     version: Version,
 }
 
-impl IntoResponse for CallV3Response {
+impl IntoResponse for SyncCallResponse {
     fn into_response(self) -> Response {
         match self {
-            CallV3Response::Certificate(cert) => Cbor(CBOR::Map(BTreeMap::from([
+            SyncCallResponse::Certificate(cert) => Cbor(CBOR::Map(BTreeMap::from([
                 (
                     CBOR::Text("status".to_string()),
                     CBOR::Text("replied".to_string()),
@@ -89,7 +89,7 @@ impl IntoResponse for CallV3Response {
             ])))
             .into_response(),
 
-            CallV3Response::UserError(user_err) => Cbor(CBOR::Map(BTreeMap::from([
+            SyncCallResponse::UserError(user_err) => Cbor(CBOR::Map(BTreeMap::from([
                 (
                     CBOR::Text("status".to_string()),
                     CBOR::Text("non_replicated_rejection".to_string()),
@@ -109,22 +109,22 @@ impl IntoResponse for CallV3Response {
             ])))
             .into_response(),
 
-            CallV3Response::Accepted(reason) => {
+            SyncCallResponse::Accepted(reason) => {
                 (StatusCode::ACCEPTED, reason.to_string()).into_response()
             }
 
-            CallV3Response::HttpError(HttpError { status, message }) => {
+            SyncCallResponse::HttpError(HttpError { status, message }) => {
                 (status, message).into_response()
             }
         }
     }
 }
 
-impl From<IngressError> for CallV3Response {
+impl From<IngressError> for SyncCallResponse {
     fn from(err: IngressError) -> Self {
         match err {
-            IngressError::UserError(user_err) => CallV3Response::UserError(user_err),
-            IngressError::HttpError(http_err) => CallV3Response::HttpError(http_err),
+            IngressError::UserError(user_err) => SyncCallResponse::UserError(user_err),
+            IngressError::HttpError(http_err) => SyncCallResponse::HttpError(http_err),
         }
     }
 }
@@ -197,7 +197,7 @@ async fn call_sync(
         version,
     }): State<SynchronousCallHandlerState>,
     WithTimeout(Cbor(request)): WithTimeout<Cbor<HttpRequestEnvelope<HttpCallContent>>>,
-) -> CallV3Response {
+) -> SyncCallResponse {
     let log = call_handler.log.clone();
 
     let ingress_submitter = match call_handler
@@ -205,7 +205,7 @@ async fn call_sync(
         .await
     {
         Ok(ingress_submitter) => ingress_submitter,
-        Err(ingress_error) => return CallV3Response::from(ingress_error),
+        Err(ingress_error) => return SyncCallResponse::from(ingress_error),
     };
 
     let message_id = ingress_submitter.message_id();
@@ -225,11 +225,11 @@ async fn call_sync(
             let signature = certification.signed.signature.signature.get().0;
 
             metrics
-                .call_v3_early_response_trigger_total
-                .with_label_values(&[CALL_V3_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE])
+                .call_sync_early_response_trigger_total
+                .with_label_values(&[CALL_SYNC_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE])
                 .inc();
 
-            return CallV3Response::Certificate(Certificate {
+            return SyncCallResponse::Certificate(Certificate {
                 tree,
                 signature: Blob(signature),
                 delegation: delegation_from_nns,
@@ -245,7 +245,7 @@ async fn call_sync(
         Ok(Ok(message_subscriber)) => Ok(message_subscriber),
         Ok(Err(SubscriptionError::DuplicateSubscriptionError)) => Err((
             "Duplicate request. Message is already being tracked and executed.",
-            CALL_V3_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION,
+            CALL_SYNC_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION,
         )),
         Ok(Err(SubscriptionError::IngressWatcherNotRunning { error_message })) => {
             error!(
@@ -255,7 +255,7 @@ async fn call_sync(
             );
             Err((
                 "Could not track the ingress message. Please try /read_state for the status.",
-                CALL_V3_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING,
+                CALL_SYNC_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING,
             ))
         }
         Err(_) => {
@@ -266,7 +266,7 @@ async fn call_sync(
             );
             Err((
                 "Could not track the ingress message. Please try /read_state for the status.",
-                CALL_V3_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT,
+                CALL_SYNC_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT,
             ))
         }
     };
@@ -274,7 +274,7 @@ async fn call_sync(
     let ingres_submission = ingress_submitter.try_submit();
 
     if let Err(ingress_submission) = ingres_submission {
-        return CallV3Response::HttpError(ingress_submission);
+        return SyncCallResponse::HttpError(ingress_submission);
     }
     // The ingress message was submitted successfully.
     // From this point on we only return a certificate or `Accepted 202``.
@@ -282,10 +282,10 @@ async fn call_sync(
         Ok(certification_subscriber) => certification_subscriber,
         Err((reason, metric_label)) => {
             metrics
-                .call_v3_early_response_trigger_total
+                .call_sync_early_response_trigger_total
                 .with_label_values(&[metric_label])
                 .inc();
-            return CallV3Response::Accepted(reason);
+            return SyncCallResponse::Accepted(reason);
         }
     };
 
@@ -299,10 +299,10 @@ async fn call_sync(
         Ok(()) => (),
         Err(_) => {
             metrics
-                .call_v3_early_response_trigger_total
-                .with_label_values(&[CALL_V3_EARLY_RESPONSE_CERTIFICATION_TIMEOUT])
+                .call_sync_early_response_trigger_total
+                .with_label_values(&[CALL_SYNC_EARLY_RESPONSE_CERTIFICATION_TIMEOUT])
                 .inc();
-            return CallV3Response::Accepted(
+            return SyncCallResponse::Accepted(
                 "Message did not complete execution and certification within the replica defined timeout.",
             );
         }
@@ -311,7 +311,7 @@ async fn call_sync(
     let Some((tree, certification)) =
         tree_and_certificate_for_message(state_reader, message_id.clone()).await
     else {
-        return CallV3Response::Accepted(
+        return SyncCallResponse::Accepted(
             "Certified state is not available. Please try /read_state.",
         );
     };
@@ -322,7 +322,7 @@ async fn call_sync(
     };
 
     metrics
-        .call_v3_certificate_status_total
+        .call_sync_certificate_status_total
         .with_label_values(&[&status_label])
         .inc();
 
@@ -334,7 +334,7 @@ async fn call_sync(
     };
     let signature = certification.signed.signature.signature.get().0;
 
-    CallV3Response::Certificate(Certificate {
+    SyncCallResponse::Certificate(Certificate {
         tree,
         signature: Blob(signature),
         delegation: delegation_from_nns,
@@ -352,10 +352,10 @@ fn parsed_message_status(tree: &MixedHashTree, message_id: &MessageId) -> Parsed
     match tree.lookup(&status_path) {
         LookupStatus::Found(MixedHashTree::Leaf(status)) => ParsedMessageStatus::Known(
             String::from_utf8(status.clone())
-                .unwrap_or_else(|_| CALL_V3_STATUS_IS_INVALID_UTF8.to_string()),
+                .unwrap_or_else(|_| CALL_SYNC_STATUS_IS_INVALID_UTF8.to_string()),
         ),
         LookupStatus::Found(_) => {
-            ParsedMessageStatus::Known(CALL_V3_STATUS_IS_NOT_LEAF.to_string())
+            ParsedMessageStatus::Known(CALL_SYNC_STATUS_IS_NOT_LEAF.to_string())
         }
         LookupStatus::Absent | LookupStatus::Unknown => ParsedMessageStatus::Unknown,
     }

--- a/rs/http_endpoints/public/src/metrics.rs
+++ b/rs/http_endpoints/public/src/metrics.rs
@@ -14,19 +14,19 @@ pub const LABEL_HTTP_VERSION: &str = "http_version";
 pub const LABEL_HEALTH_STATUS_BEFORE: &str = "before";
 pub const LABEL_HEALTH_STATUS_AFTER: &str = "after";
 
-pub const LABEL_CALL_V3_CERTIFICATE_STATUS: &str = "status";
-
-// Call v3 labels
+// Sync Call labels
 // !!! Be careful to update alert queries in k8s repo if changing these constants.!!!
-pub const LABEL_CALL_V3_EARLY_RESPONSE_TRIGGER: &str = "trigger";
-pub const CALL_V3_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING: &str = "ingress_watcher_not_running";
-pub const CALL_V3_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION: &str = "duplicate_subscription";
-pub const CALL_V3_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT: &str = "subscription_timeout";
-pub const CALL_V3_EARLY_RESPONSE_CERTIFICATION_TIMEOUT: &str = "certification_timeout";
-pub const CALL_V3_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE: &str =
+pub const LABEL_CALL_SYNC_CERTIFICATE_STATUS: &str = "status";
+pub const LABEL_CALL_SYNC_EARLY_RESPONSE_TRIGGER: &str = "trigger";
+pub const CALL_SYNC_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING: &str =
+    "ingress_watcher_not_running";
+pub const CALL_SYNC_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION: &str = "duplicate_subscription";
+pub const CALL_SYNC_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT: &str = "subscription_timeout";
+pub const CALL_SYNC_EARLY_RESPONSE_CERTIFICATION_TIMEOUT: &str = "certification_timeout";
+pub const CALL_SYNC_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE: &str =
     "message_already_in_certified_state";
-pub const CALL_V3_STATUS_IS_NOT_LEAF: &str = "not_leaf";
-pub const CALL_V3_STATUS_IS_INVALID_UTF8: &str = "is_invalid_utf8";
+pub const CALL_SYNC_STATUS_IS_NOT_LEAF: &str = "not_leaf";
+pub const CALL_SYNC_STATUS_IS_INVALID_UTF8: &str = "is_invalid_utf8";
 
 /// Placeholder used when we can't determine the appropriate prometheus label.
 pub const LABEL_UNKNOWN: &str = "unknown";
@@ -68,9 +68,9 @@ pub struct HttpHandlerMetrics {
     pub ingress_watcher_wait_for_certification_duration_seconds: Histogram,
     pub ingress_watcher_messages_completed_execution_channel_capacity: IntGauge,
 
-    // Call v3 handler metrics
-    pub call_v3_early_response_trigger_total: IntCounterVec,
-    pub call_v3_certificate_status_total: IntCounterVec,
+    // sync call handler metrics
+    pub call_sync_early_response_trigger_total: IntCounterVec,
+    pub call_sync_certificate_status_total: IntCounterVec,
 }
 
 // There is a mismatch between the labels and the public spec.
@@ -157,15 +157,18 @@ impl HttpHandlerMetrics {
             ),
             ingress_watcher_tracked_messages: metrics_registry.int_gauge(
                 "replica_http_ingress_watcher_tracked_messages",
-            "The current number of messages being tracked in the ingress watcher waiting for certification"
+                "The current number of messages being tracked in the ingress watcher \
+                waiting for certification"
             ),
             ingress_watcher_heights_waiting_for_certification: metrics_registry.int_gauge(
                 "replica_http_ingress_watcher_heights_waiting_for_certification",
-                "The current number of unique heights that the ingress watcher is waiting for certification on."
+                "The current number of unique heights that the ingress watcher \
+                is waiting for certification on."
             ),
             ingress_watcher_subscription_latency_duration_seconds: metrics_registry.histogram(
                 "replica_http_ingress_watcher_subscription_latency_duration_seconds",
-                "The duration the call v3 handler waits for subscribing to a message. I.e. `IngressWatcherHandle::subscribe_for_certification()`.",
+                "The duration the sync call handler waits for subscribing to a message. \
+                I.e. `IngressWatcherHandle::subscribe_for_certification()`.",
                 // 0.1ms - 500ms
                 decimal_buckets(-4, -1),
             ),
@@ -175,7 +178,8 @@ impl HttpHandlerMetrics {
             ),
             ingress_watcher_wait_for_certification_duration_seconds: metrics_registry.histogram(
                 "replica_http_ingress_watcher_wait_for_certification_duration_seconds",
-                "The duration the call v3 handler waits for a message to complete execution at some height, h, and for h to become certified.",
+                "The duration the sync call handler waits for a message to complete execution \
+                at some height, h, and for h to become certified.",
                 // 52 buckets
                 // 0.50s - 0.60s - ... - 4.5s - 5.0s - 5.5s - ... - 12s - 14s - 16s
                 {
@@ -192,15 +196,16 @@ impl HttpHandlerMetrics {
                 },
 
             ),
-            call_v3_certificate_status_total: metrics_registry.int_counter_vec(
+            // TODO: rename the metric names
+            call_sync_certificate_status_total: metrics_registry.int_counter_vec(
                 "replica_http_call_v3_certificate_status_total",
-                "The count of certificate states returned by the /v3/.../call endpoint. I.e. replied, rejected, unknown, etc.",
-                &[LABEL_CALL_V3_CERTIFICATE_STATUS],
+                "The count of certificate states returned by the /{v3,v4}/.../call endpoint. I.e. replied, rejected, unknown, etc.",
+                &[LABEL_CALL_SYNC_CERTIFICATE_STATUS],
             ),
-            call_v3_early_response_trigger_total: metrics_registry.int_counter_vec(
+            call_sync_early_response_trigger_total: metrics_registry.int_counter_vec(
                 "replica_http_call_v3_early_response_trigger_total",
-                "The count of early response triggers for the /v3/.../call endpoint.",
-                &[LABEL_CALL_V3_EARLY_RESPONSE_TRIGGER],
+                "The count of early response triggers for the /{v3,v4}/.../call endpoint.",
+                &[LABEL_CALL_SYNC_EARLY_RESPONSE_TRIGGER],
             ),
         }
     }

--- a/rs/http_endpoints/public/src/metrics.rs
+++ b/rs/http_endpoints/public/src/metrics.rs
@@ -16,17 +16,17 @@ pub const LABEL_HEALTH_STATUS_AFTER: &str = "after";
 
 // Sync Call labels
 // !!! Be careful to update alert queries in k8s repo if changing these constants.!!!
-pub const LABEL_CALL_SYNC_CERTIFICATE_STATUS: &str = "status";
-pub const LABEL_CALL_SYNC_EARLY_RESPONSE_TRIGGER: &str = "trigger";
-pub const CALL_SYNC_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING: &str =
+const LABEL_SYNC_CALL_CERTIFICATE_STATUS: &str = "status";
+const LABEL_SYNC_CALL_EARLY_RESPONSE_TRIGGER: &str = "trigger";
+pub const SYNC_CALL_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING: &str =
     "ingress_watcher_not_running";
-pub const CALL_SYNC_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION: &str = "duplicate_subscription";
-pub const CALL_SYNC_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT: &str = "subscription_timeout";
-pub const CALL_SYNC_EARLY_RESPONSE_CERTIFICATION_TIMEOUT: &str = "certification_timeout";
-pub const CALL_SYNC_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE: &str =
+pub const SYNC_CALL_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION: &str = "duplicate_subscription";
+pub const SYNC_CALL_EARLY_RESPONSE_SUBSCRIPTION_TIMEOUT: &str = "subscription_timeout";
+pub const SYNC_CALL_EARLY_RESPONSE_CERTIFICATION_TIMEOUT: &str = "certification_timeout";
+pub const SYNC_CALL_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE: &str =
     "message_already_in_certified_state";
-pub const CALL_SYNC_STATUS_IS_NOT_LEAF: &str = "not_leaf";
-pub const CALL_SYNC_STATUS_IS_INVALID_UTF8: &str = "is_invalid_utf8";
+pub const SYNC_CALL_STATUS_IS_NOT_LEAF: &str = "not_leaf";
+pub const SYNC_CALL_STATUS_IS_INVALID_UTF8: &str = "is_invalid_utf8";
 
 /// Placeholder used when we can't determine the appropriate prometheus label.
 pub const LABEL_UNKNOWN: &str = "unknown";
@@ -69,8 +69,8 @@ pub struct HttpHandlerMetrics {
     pub ingress_watcher_messages_completed_execution_channel_capacity: IntGauge,
 
     // sync call handler metrics
-    pub call_sync_early_response_trigger_total: IntCounterVec,
-    pub call_sync_certificate_status_total: IntCounterVec,
+    pub sync_call_early_response_trigger_total: IntCounterVec,
+    pub sync_call_certificate_status_total: IntCounterVec,
 }
 
 // There is a mismatch between the labels and the public spec.
@@ -197,15 +197,15 @@ impl HttpHandlerMetrics {
 
             ),
             // TODO: rename the metric names
-            call_sync_certificate_status_total: metrics_registry.int_counter_vec(
+            sync_call_certificate_status_total: metrics_registry.int_counter_vec(
                 "replica_http_call_v3_certificate_status_total",
                 "The count of certificate states returned by the /{v3,v4}/.../call endpoint. I.e. replied, rejected, unknown, etc.",
-                &[LABEL_CALL_SYNC_CERTIFICATE_STATUS],
+                &[LABEL_SYNC_CALL_CERTIFICATE_STATUS],
             ),
-            call_sync_early_response_trigger_total: metrics_registry.int_counter_vec(
+            sync_call_early_response_trigger_total: metrics_registry.int_counter_vec(
                 "replica_http_call_v3_early_response_trigger_total",
                 "The count of early response triggers for the /{v3,v4}/.../call endpoint.",
-                &[LABEL_CALL_SYNC_EARLY_RESPONSE_TRIGGER],
+                &[LABEL_SYNC_CALL_EARLY_RESPONSE_TRIGGER],
             ),
         }
     }

--- a/rs/http_endpoints/public/src/metrics.rs
+++ b/rs/http_endpoints/public/src/metrics.rs
@@ -196,7 +196,7 @@ impl HttpHandlerMetrics {
                 },
 
             ),
-            // TODO: rename the metric names
+            // TODO(CON-1576): rename the metric names and add `api_version` label to them
             sync_call_certificate_status_total: metrics_registry.int_counter_vec(
                 "replica_http_call_v3_certificate_status_total",
                 "The count of certificate states returned by the /{v3,v4}/.../call endpoint. I.e. replied, rejected, unknown, etc.",

--- a/rs/http_endpoints/public/tests/load_shed_test.rs
+++ b/rs/http_endpoints/public/tests/load_shed_test.rs
@@ -405,6 +405,7 @@ fn test_load_shedding_update_call() {
 #[rstest]
 #[case::v2_endpoint(Call::V2)]
 #[case::v3_endpoint(Call::V3)]
+#[case::v4_endpoint(Call::V4)]
 fn test_load_shedding_update_call_when_ingress_pool_is_full(#[case] endpoint: Call) {
     use std::sync::RwLock;
 
@@ -442,6 +443,7 @@ fn test_load_shedding_update_call_when_ingress_pool_is_full(#[case] endpoint: Ca
 #[rstest]
 #[case::v2_endpoint(Call::V2)]
 #[case::v3_endpoint(Call::V3)]
+#[case::v4_endpoint(Call::V4)]
 fn test_load_shedding_update_call_when_ingress_channel_is_full(#[case] endpoint: Call) {
     let rt = Runtime::new().unwrap();
 


### PR DESCRIPTION
Didn't want to do it in https://github.com/dfinity/ic/pull/6378 because the PR was quite big already