### PR TITLE
chore: inline dependencies in pocket-ic

### DIFF
--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -2,62 +2,40 @@ load("@rules_rust//rust:defs.bzl", "rust_doc_test", "rust_library", "rust_test",
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:backoff",
-    "@crate_index//:base64",
-    "@crate_index//:candid",
-    "@crate_index//:flate2",
-    "@crate_index//:hex",
-    "@crate_index//:ic-certification",
-    "@crate_index//:ic-management-canister-types",
-    "@crate_index//:ic-transport-types",
-    "@crate_index//:reqwest",
-    "@crate_index//:schemars",
-    "@crate_index//:serde",
-    "@crate_index//:serde_bytes",
-    "@crate_index//:serde_cbor",
-    "@crate_index//:serde_json",
-    "@crate_index//:sha2",
-    "@crate_index//:slog",
-    "@crate_index//:strum",
-    "@crate_index//:tempfile",
-    "@crate_index//:thiserror",
-    "@crate_index//:tokio",
-    "@crate_index//:tracing",
-    "@crate_index//:tracing-appender",
-    "@crate_index//:tracing-subscriber",
-]
-
-MACRO_DEPENDENCIES = [
-    "@crate_index//:strum_macros",
-]
-
-TEST_DEPENDENCIES = [
-    # Keep sorted.
-    "//packages/ic-error-types",
-    "//packages/icrc-ledger-types",
-    "//rs/registry/client",
-    "//rs/registry/helpers",
-    "//rs/registry/proto_data_provider",
-    "//rs/types/base_types",
-    #TODO: try upgrading this to the latest bitcion crate
-    "@crate_index//:bitcoin_0_28",
-    "@crate_index//:candid_parser",
-    "@crate_index//:ed25519-dalek",
-    "@crate_index//:ic-cdk",
-    "@crate_index//:ic-vetkeys",
-    "@crate_index//:k256",
-    "@crate_index//:wat",
-]
-
 rust_library(
     name = "pocket-ic",
     srcs = glob(["src/**/*.rs"]),
     compile_data = ["README.md"],
-    proc_macro_deps = MACRO_DEPENDENCIES,
+    proc_macro_deps = [
+        "@crate_index//:strum_macros",
+    ],
     version = "9.0.2",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:backoff",
+        "@crate_index//:base64",
+        "@crate_index//:candid",
+        "@crate_index//:flate2",
+        "@crate_index//:hex",
+        "@crate_index//:ic-certification",
+        "@crate_index//:ic-management-canister-types",
+        "@crate_index//:ic-transport-types",
+        "@crate_index//:reqwest",
+        "@crate_index//:schemars",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:serde_json",
+        "@crate_index//:sha2",
+        "@crate_index//:slog",
+        "@crate_index//:strum",
+        "@crate_index//:tempfile",
+        "@crate_index//:thiserror",
+        "@crate_index//:tokio",
+        "@crate_index//:tracing",
+        "@crate_index//:tracing-appender",
+        "@crate_index//:tracing-subscriber",
+    ],
 )
 
 rust_doc_test(
@@ -67,10 +45,9 @@ rust_doc_test(
 
 rust_test(
     name = "pocket-ic-test",
-    srcs = glob(["src/**/*.rs"]),
     compile_data = ["README.md"],
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    deps = DEPENDENCIES + TEST_DEPENDENCIES,
+    crate = ":pocket-ic",
+    deps = ["//packages/ic-error-types"],
 )
 
 rust_test_suite(
@@ -91,7 +68,6 @@ rust_test_suite(
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
     },
     flaky = True,
-    proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -99,7 +75,31 @@ rust_test_suite(
         "requires-network",
         "test_macos",
     ],
-    deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":pocket-ic",
+        "//rs/registry/client",
+        "//rs/registry/helpers",
+        "//rs/registry/proto_data_provider",
+        "//rs/types/base_types",
+        "@crate_index//:bitcoin_0_28",
+        "@crate_index//:candid",
+        "@crate_index//:ed25519-dalek",
+        "@crate_index//:flate2",
+        "@crate_index//:hex",
+        "@crate_index//:ic-certification",
+        "@crate_index//:ic-management-canister-types",
+        "@crate_index//:ic-transport-types",
+        "@crate_index//:ic-vetkeys",
+        "@crate_index//:k256",
+        "@crate_index//:reqwest",
+        "@crate_index//:serde",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:sha2",
+        "@crate_index//:tempfile",
+        "@crate_index//:tokio",
+        "@crate_index//:wat",
+    ],
 )
 
 rust_test_suite(
@@ -117,7 +117,6 @@ rust_test_suite(
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
     },
-    proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -125,7 +124,17 @@ rust_test_suite(
         "requires-network",
         "test_macos",
     ],
-    deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":pocket-ic",
+        "//packages/icrc-ledger-types",
+        "@crate_index//:candid",
+        "@crate_index//:reqwest",
+        "@crate_index//:serde",
+        "@crate_index//:sha2",
+        "@crate_index//:tempfile",
+        "@crate_index//:tokio",
+    ],
 )
 
 rust_test_suite(
@@ -140,14 +149,16 @@ rust_test_suite(
         "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
     },
-    proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
         "requires-network",
         "test_macos",
     ],
-    deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
+    deps = [
+        ":pocket-ic",
+        "@crate_index//:reqwest",
+    ],
 )
 
 rust_test_suite(
@@ -164,7 +175,6 @@ rust_test_suite(
         "SSL_CERT_FILE": "$(rootpath @mozilla_root_ca_store//file)",
         "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
     },
-    proc_macro_deps = MACRO_DEPENDENCIES,
     tags = [
         "cpu:16",
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -172,5 +182,8 @@ rust_test_suite(
         "requires-network",
         "test_macos",
     ],
-    deps = [":pocket-ic"] + DEPENDENCIES + TEST_DEPENDENCIES,
+    deps = [
+        ":pocket-ic",
+        "@crate_index//:candid",
+    ],
 )


### PR DESCRIPTION
This inlines `DEPENDENCIES` and `TEST_DEPENDENCIES` in `packages/pocket-ic`. This makes the dependencies of each target more explicit and helps analysis tools.