### PR TITLE
chore: tag //rs/tests/consensus:dual_workload_test_colocate as long_test

### DIFF
--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -67,6 +67,7 @@ system_test(
     tags = [
         "colocate",
         "k8s",
+        "long_test",
     ],
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS,
     deps = [


### PR DESCRIPTION
The `//rs/tests/consensus:dual_workload_test_colocate` has a P90 duration of 6m 46s for the week starting on 2025-08-20. This is longer than our maximum of 5 minutes so let's tag it as a `long_test`.