### PR TITLE
feat(NRC): Add endpoint to fetch historical rewards

### DIFF
--- a/rs/node_rewards/canister/api/src/provider_rewards_calculation.rs
+++ b/rs/node_rewards/canister/api/src/provider_rewards_calculation.rs
@@ -6,6 +6,15 @@ pub struct GetNodeProviderRewardsCalculationRequest {
     pub from_nanos: u64,
     pub to_nanos: u64,
     pub provider_id: Principal,
+    pub historical: bool,
 }
 
 pub type GetNodeProviderRewardsCalculationResponse = Result<NodeProviderRewards, String>;
+
+#[derive(CandidType, Clone, Deserialize, Debug, PartialEq, Eq)]
+pub struct HistoricalRewardPeriod {
+    pub from_nanos: u64,
+    pub to_nanos: u64,
+    pub providers_rewarded: Vec<Principal>,
+}
+pub type GetHistoricalRewardPeriods = Vec<HistoricalRewardPeriod>;

--- a/rs/node_rewards/canister/node-rewards-canister.did
+++ b/rs/node_rewards/canister/node-rewards-canister.did
@@ -102,11 +102,20 @@ type GetNodeProviderRewardsCalculationRequest = record {
   from_nanos: nat64;
   to_nanos: nat64;
   provider_id: principal;
+  historical: bool;
+};
+
+type HistoricalRewardPeriod = record {
+  from_nanos: nat64;
+  to_nanos: nat64;
+  providers_rewarded: vec principal;
 };
 
 type GetNodeProvidersRewardsResponse = variant { Ok : NodeProvidersRewards; Err : text };
 
 type GetNodeProviderRewardsCalculationResponse = variant { Ok : NodeProviderRewards; Err : text };
+
+type GetHistoricalRewardPeriods = vec HistoricalRewardPeriod;
 
 service : () -> {
     get_node_providers_monthly_xdr_rewards: (GetNodeProvidersMonthlyXdrRewardsRequest) -> (
@@ -114,4 +123,5 @@ service : () -> {
     );
     get_node_providers_rewards: (GetNodeProvidersRewardsRequest) -> (GetNodeProvidersRewardsResponse);
     get_node_provider_rewards_calculation : (GetNodeProviderRewardsCalculationRequest) -> (GetNodeProviderRewardsCalculationResponse) query;
+    get_historical_reward_periods: () -> (GetHistoricalRewardPeriods) query;
 }

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -8,13 +8,14 @@ use ic_node_rewards_canister_api::monthly_rewards::{
     NodeProvidersMonthlyXdrRewards,
 };
 use ic_node_rewards_canister_api::provider_rewards_calculation::{
-    GetNodeProviderRewardsCalculationRequest, GetNodeProviderRewardsCalculationResponse,
+    GetHistoricalRewardPeriods, GetNodeProviderRewardsCalculationRequest,
+    GetNodeProviderRewardsCalculationResponse, HistoricalRewardPeriod,
 };
 use ic_node_rewards_canister_api::providers_rewards::{
     GetNodeProvidersRewardsRequest, GetNodeProvidersRewardsResponse, NodeProvidersRewards,
 };
 use ic_node_rewards_canister_protobuf::pb::rewards_calculator::v1::{
-    NodeProviderRewardsKey, SubnetsFailureRateKey, SubnetsFailureRateValue,
+    DayUtc, NodeProviderRewardsKey, SubnetsFailureRateKey, SubnetsFailureRateValue,
 };
 use ic_protobuf::registry::dc::v1::DataCenterRecord;
 use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
@@ -27,6 +28,7 @@ use ic_registry_keys::{
 };
 use ic_registry_node_provider_rewards::{calculate_rewards_v0, RewardsPerNodeProvider};
 use ic_types::RegistryVersion;
+use itertools::Itertools;
 use rewards_calculation::rewards_calculator::RewardsCalculatorInput;
 use rewards_calculation::rewards_calculator_results::RewardsCalculatorResults;
 use rewards_calculation::types::RewardPeriod;
@@ -279,23 +281,73 @@ impl NodeRewardsCanister {
     }
 
     pub fn get_node_provider_rewards_calculation<S: RegistryDataStableMemory>(
-        canister: &'static LocalKey<RefCell<NodeRewardsCanister>>,
+        _canister: &'static LocalKey<RefCell<NodeRewardsCanister>>,
         request: GetNodeProviderRewardsCalculationRequest,
     ) -> GetNodeProviderRewardsCalculationResponse {
         let provider_id = ic_base_types::PrincipalId::from(request.provider_id);
-        let request_inner = GetNodeProvidersRewardsRequest {
-            from_nanos: request.from_nanos,
-            to_nanos: request.to_nanos,
-        };
-        let result =
-            canister.with_borrow(|canister| canister.calculate_rewards::<S>(request_inner))?;
-        let node_provider_rewards = result
-            .provider_results
-            .get(&provider_id)
-            .cloned()
-            .ok_or_else(|| format!("No rewards found for node provider {}", provider_id))?;
+        if request.historical {
+            let reward_key = NodeProviderRewardsKey {
+                principal_id: Some(provider_id),
+                end_day: Some(DayUtc {
+                    value: Some(request.to_nanos),
+                }),
+                start_day: Some(DayUtc {
+                    value: Some(request.from_nanos),
+                }),
+            };
+            HISTORICAL_REWARDS
+                .with_borrow(|historical_rewards| historical_rewards.get(&reward_key))
+                .ok_or("No historical rewards found for node provider".to_string())
+        } else {
+            Err("Not yet active.".to_string())
+            // TODO: Add rate limiting and restrictions on reward period before enabling it.
+            //
+            // let request_inner = GetNodeProvidersRewardsRequest {
+            //     from_nanos: request.from_nanos,
+            //     to_nanos: request.to_nanos,
+            // };
+            // let mut result =
+            //     canister.with_borrow(|canister| canister.calculate_rewards::<S>(request_inner))?;
+            // let node_provider_rewards = result.provider_results.remove(&provider_id).ok_or(
+            //     format!("No rewards found for node provider {}", provider_id),
+            // )?;
+            //
+            // node_provider_rewards.into()
+        }
+    }
 
-        Ok(node_provider_rewards.into())
+    pub fn get_historical_reward_periods() -> GetHistoricalRewardPeriods {
+        HISTORICAL_REWARDS.with_borrow(|historical_rewards| {
+            historical_rewards
+                .keys()
+                .filter_map(|reward_key| {
+                    match (
+                        reward_key.principal_id,
+                        reward_key.start_day,
+                        reward_key.end_day,
+                    ) {
+                        (
+                            Some(principal_id),
+                            Some(DayUtc {
+                                value: Some(ts_start),
+                            }),
+                            Some(DayUtc {
+                                value: Some(ts_end),
+                            }),
+                        ) => Some((principal_id, ts_start, ts_end)),
+                        _ => None,
+                    }
+                })
+                .sorted_by_key(|(_, ts_start, ts_end)| (*ts_start, *ts_end))
+                .group_by(|(_, ts_start, ts_end)| (*ts_start, *ts_end))
+                .into_iter()
+                .map(|((ts_start, ts_end), group)| HistoricalRewardPeriod {
+                    from_nanos: ts_start,
+                    to_nanos: ts_end,
+                    providers_rewarded: group.map(|(principal_id, _, _)| principal_id.0).collect(),
+                })
+                .collect()
+        })
     }
 }
 

--- a/rs/node_rewards/canister/src/canister/test/get_node_providers_rewards.rs
+++ b/rs/node_rewards/canister/src/canister/test/get_node_providers_rewards.rs
@@ -4,15 +4,21 @@ use crate::canister::test::test_utils::{
 use crate::canister::NodeRewardsCanister;
 use crate::metrics::MetricsManager;
 use crate::storage::HISTORICAL_REWARDS;
+use candid::Principal;
 use futures_util::FutureExt;
 use ic_nervous_system_canisters::registry::fake::FakeRegistry;
+use ic_node_rewards_canister_api::provider_rewards_calculation::{
+    GetNodeProviderRewardsCalculationRequest, HistoricalRewardPeriod,
+};
 use ic_node_rewards_canister_api::providers_rewards::{
     GetNodeProvidersRewardsRequest, NodeProvidersRewards,
 };
 use ic_node_rewards_canister_protobuf::pb::ic_node_rewards::v1::{
     NodeMetrics, SubnetMetricsKey, SubnetMetricsValue,
 };
-use ic_node_rewards_canister_protobuf::pb::rewards_calculator::v1::NodeProviderRewardsKey;
+use ic_node_rewards_canister_protobuf::pb::rewards_calculator::v1::{
+    NodeProviderRewards as NodeProviderRewardsProto, NodeProviderRewardsKey,
+};
 use ic_protobuf::registry::dc::v1::DataCenterRecord;
 use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
 use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
@@ -653,4 +659,96 @@ fn test_get_node_providers_rewards() {
             Some(p2_rewards)
         );
     })
+}
+
+#[test]
+fn test_get_historical_reward_periods() {
+    let reward_periods = btreemap! {
+        "2024-01-01" => "2024-01-31",
+        "2024-02-01" => "2024-02-28",
+    }
+    .into_iter()
+    .map(|(from, to)| {
+        (
+            DayUtc::try_from(from).unwrap(),
+            DayUtc::try_from(to).unwrap(),
+        )
+    })
+    .collect::<BTreeMap<DayUtc, DayUtc>>();
+
+    let providers: Vec<PrincipalId> = (0..10).map(|idx| test_provider_id(idx as u64)).collect();
+
+    HISTORICAL_REWARDS.with_borrow_mut(|historical_rewards| {
+        for (from, to) in reward_periods.clone() {
+            for provider in providers.clone() {
+                let key = NodeProviderRewardsKey {
+                    principal_id: Some(provider),
+                    start_day: Some(from.into()),
+                    end_day: Some(to.into()),
+                };
+                let rewards = NodeProviderRewardsProto::default();
+                historical_rewards.insert(key, rewards);
+            }
+        }
+    });
+
+    let providers: Vec<Principal> = providers.into_iter().map(|p| p.0).collect();
+
+    let got = NodeRewardsCanister::get_historical_reward_periods();
+    for (from, to) in reward_periods {
+        let expected = HistoricalRewardPeriod {
+            from_nanos: from.get(),
+            to_nanos: to.get(),
+            providers_rewarded: providers.clone(),
+        };
+        assert!(got.contains(&expected));
+    }
+}
+
+#[test]
+fn test_get_node_provider_rewards_calculation_historical() {
+    use pretty_assertions::assert_eq;
+
+    let (fake_registry, metrics_manager) = setup_thread_local_canister_for_test();
+    setup_data_for_test_rewards_calculation(fake_registry, metrics_manager);
+    let from = DayUtc::try_from("2024-01-01").unwrap();
+    let to = DayUtc::try_from("2024-01-02").unwrap();
+
+    let request = GetNodeProvidersRewardsRequest {
+        from_nanos: from.unix_ts_at_day_end(),
+        to_nanos: to.unix_ts_at_day_end(),
+    };
+
+    // Invoke to populate historical rewards
+    let _ = NodeRewardsCanister::get_node_providers_rewards::<TestState>(
+        &CANISTER_TEST,
+        request.clone(),
+    )
+    .now_or_never()
+    .unwrap();
+
+    let expected: BTreeMap<PrincipalId, NodeProviderRewards> =
+        serde_json::from_str(EXPECTED_TEST_1).unwrap();
+
+    for (provider_id, expected_rewards) in expected {
+        let request = GetNodeProviderRewardsCalculationRequest {
+            from_nanos: from.unix_ts_at_day_end(),
+            to_nanos: to.unix_ts_at_day_end(),
+            provider_id: provider_id.0,
+            historical: true,
+        };
+
+        let got = NodeRewardsCanister::get_node_provider_rewards_calculation::<TestState>(
+            &CANISTER_TEST,
+            request,
+        )
+        .unwrap();
+
+        assert_eq!(
+            got,
+            expected_rewards.into(),
+            "Mismatch for provider {:?}",
+            provider_id
+        );
+    }
 }

--- a/rs/node_rewards/canister/src/main.rs
+++ b/rs/node_rewards/canister/src/main.rs
@@ -7,7 +7,13 @@ use ic_node_rewards_canister::telemetry;
 use ic_node_rewards_canister_api::monthly_rewards::{
     GetNodeProvidersMonthlyXdrRewardsRequest, GetNodeProvidersMonthlyXdrRewardsResponse,
 };
+use ic_node_rewards_canister_api::provider_historical_rewards::{
+    GetNodeProviderHistoricalRewardsCalculationRequest,
+    GetNodeProviderHistoricalRewardsCalculationResponse,
+    GetNodeProvidersHistoricalRewardsTsResponse,
+};
 use ic_node_rewards_canister_api::provider_rewards_calculation::{
+    GetHistoricalRewardPeriods, GetNodeProviderLatestRewardsCalculationRequest,
     GetNodeProviderRewardsCalculationRequest, GetNodeProviderRewardsCalculationResponse,
 };
 use ic_node_rewards_canister_api::providers_rewards::{
@@ -120,14 +126,16 @@ async fn get_node_providers_rewards(
 
 #[query]
 fn get_node_provider_rewards_calculation(
-    _request: GetNodeProviderRewardsCalculationRequest,
+    request: GetNodeProviderRewardsCalculationRequest,
 ) -> GetNodeProviderRewardsCalculationResponse {
-    // TODO: Add rate limiting and restrictions on reward period before enabling it.
-    // NodeRewardsCanister::get_node_provider_rewards_calculation::<RegistryStoreStableMemoryBorrower>(
-    //     &CANISTER, request,
-    // );
+    NodeRewardsCanister::get_node_provider_rewards_calculation::<RegistryStoreStableMemoryBorrower>(
+        &CANISTER, request,
+    )
+}
 
-    Err("Not yet active.".to_string())
+#[query]
+fn get_historical_reward_periods() -> GetHistoricalRewardPeriods {
+    NodeRewardsCanister::get_historical_reward_periods()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Changes:

- Modify `get_node_provider_rewards_calculation` endpoint to retrieve historical rewards
- Add endpoint `get_historical_reward_periods` to fetch historical reward periods and the providers rewarded
- Testing