### PR TITLE
fix: colocate //rs/tests/execution:btc_get_balance_test

### DIFF
--- a/rs/tests/execution/BUILD.bazel
+++ b/rs/tests/execution/BUILD.bazel
@@ -238,6 +238,7 @@ system_test_nns(
     },
     flaky = True,  # flakiness rate of over 3% over the month from 2025-02-11 till 2025-03-11 only for the //rs/tests/execution:btc_get_balance_test_head_nns variant.
     tags = [
+        "colocate",
         "k8s",
     ],
     runtime_deps =


### PR DESCRIPTION
As discussed in [this thread](https://dfinity.slack.com/archives/CGZJ7G1J6/p1756295814014999) the `//rs/tests/execution:btc_get_balance_test` sometimes sends two `generatetoaddress` requests to the btc-node while in the code we only sent one. This is likely caused by [retry logic in the jsonrpc crate](https://github.com/apoelstra/rust-jsonrpc/blob/master/src/http/simple_http.rs#L168). 

To make it less likely there are networking issues between the test-driver and btc-node we colocate them together.