### PR TITLE
test(nns): Increase the diff allowed for wasm memory decrease after upgrade

### DIFF
--- a/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
+++ b/rs/nns/integration_tests/src/upgrade_canisters_with_golden_nns_state.rs
@@ -455,7 +455,7 @@ mod sanity_check {
                 |metrics| governance_gauge_value(metrics, "governance_total_memory_size_bytes"),
                 |before, after| {
                     assert_not_increased_too_much(before, after, "wasm memory size", 0.5);
-                    assert_not_decreased_too_much(before, after, "wasm memory size", 0.5);
+                    assert_not_decreased_too_much(before, after, "wasm memory size", 0.8);
                 },
             );
 


### PR DESCRIPTION
The test is new and we are still calibrating the limit allowed. The current decrease seems OK.