### PR TITLE
feat(nns): Add memo for the split neuron command

### DIFF
--- a/rs/nervous_system/common/src/ledger.rs
+++ b/rs/nervous_system/common/src/ledger.rs
@@ -26,6 +26,12 @@ pub fn compute_neuron_disburse_subaccount_bytes(controller: PrincipalId, nonce: 
     compute_neuron_domain_subaccount_bytes(controller, b"neuron-split", nonce)
 }
 
+// Computes the subaccount to which neuron split transfers are made.
+pub fn compute_neuron_split_subaccount_bytes(controller: PrincipalId, nonce: u64) -> [u8; 32] {
+    // Unfortunately "neuron-split" is used for disburse, so we need to use a different domain.
+    compute_neuron_domain_subaccount_bytes(controller, b"split-neuron", nonce)
+}
+
 fn compute_neuron_domain_subaccount_bytes(
     controller: PrincipalId,
     domain: &[u8],

--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -785,6 +785,8 @@ pub mod manage_neuron {
     pub struct Split {
         /// The amount to split to the child neuron.
         pub amount_e8s: u64,
+        /// The memo to use for the child neuron.
+        pub memo: Option<u64>,
     }
     /// Merge another neuron into this neuron.
     #[derive(

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -1218,6 +1218,7 @@ type SpawnResponse = record {
 
 type Split = record {
   amount_e8s : nat64;
+  memo : opt nat64;
 };
 
 type StakeMaturity = record {

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -1102,6 +1102,7 @@ type SpawnResponse = record {
 
 type Split = record {
   amount_e8s : nat64;
+  memo : opt nat64;
 };
 
 type StakeMaturity = record {

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -801,6 +801,8 @@ message ManageNeuron {
   message Split {
     // The amount to split to the child neuron.
     uint64 amount_e8s = 1;
+    // The memo to use for the child neuron.
+    optional uint64 memo = 2;
   }
 
   // Merge another neuron into this neuron.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -823,6 +823,9 @@ pub mod manage_neuron {
         /// The amount to split to the child neuron.
         #[prost(uint64, tag = "1")]
         pub amount_e8s: u64,
+        /// The memo to use for the child neuron.
+        #[prost(uint64, optional, tag = "2")]
+        pub memo: ::core::option::Option<u64>,
     }
     /// Merge another neuron into this neuron.
     #[derive(

--- a/rs/nns/governance/src/neuron_lock_tests.rs
+++ b/rs/nns/governance/src/neuron_lock_tests.rs
@@ -28,7 +28,10 @@ pub fn test_governance_mut() -> &'static mut Governance {
 
 #[test]
 fn test_neuron_async_lock_different_neurons_both_locked() {
-    let command = Command::Split(Split { amount_e8s: 1 });
+    let command = Command::Split(Split {
+        amount_e8s: 1,
+        memo: None,
+    });
     let _neuron_lock_1 = Governance::acquire_neuron_async_lock(
         &TEST_GOVERNANCE,
         NeuronId { id: 1 },
@@ -44,7 +47,10 @@ fn test_neuron_async_lock_different_neurons_both_locked() {
 #[test]
 fn test_neuron_async_lock_same_neuron_cannot_lock_twice() {
     let neuron_id = NeuronId { id: 1 };
-    let command = Command::Split(Split { amount_e8s: 1 });
+    let command = Command::Split(Split {
+        amount_e8s: 1,
+        memo: None,
+    });
 
     let _neuron_lock =
         Governance::acquire_neuron_async_lock(&TEST_GOVERNANCE, neuron_id, 1, command.clone())
@@ -58,7 +64,10 @@ fn test_neuron_async_lock_same_neuron_cannot_lock_twice() {
 #[test]
 fn test_neuron_async_lock_same_neuron_can_lock_after_unlock() {
     let neuron_id = NeuronId { id: 1 };
-    let command = Command::Split(Split { amount_e8s: 1 });
+    let command = Command::Split(Split {
+        amount_e8s: 1,
+        memo: None,
+    });
 
     {
         let _neuron_lock_1 =
@@ -72,7 +81,10 @@ fn test_neuron_async_lock_same_neuron_can_lock_after_unlock() {
 #[test]
 fn test_neuron_async_lock_same_neuron_cannot_lock_after_retained() {
     let neuron_id = NeuronId { id: 1 };
-    let command = Command::Split(Split { amount_e8s: 1 });
+    let command = Command::Split(Split {
+        amount_e8s: 1,
+        memo: None,
+    });
 
     {
         let mut neuron_lock =
@@ -101,7 +113,10 @@ fn test_neuron_async_lock_does_not_work_with_sync_command() {
 #[test]
 fn test_ledger_update_lock_different_neurons_both_locked() {
     let inflight_command = NeuronInFlightCommand {
-        command: Some(Command::Split(Split { amount_e8s: 1 })),
+        command: Some(Command::Split(Split {
+            amount_e8s: 1,
+            memo: None,
+        })),
         timestamp: 1,
     };
     let _neuron_lock = test_governance_mut()
@@ -116,7 +131,10 @@ fn test_ledger_update_lock_different_neurons_both_locked() {
 fn test_ledger_update_lock_same_neuron_cannot_lock_twice() {
     let neuron_id = NeuronId { id: 1 };
     let inflight_command = NeuronInFlightCommand {
-        command: Some(Command::Split(Split { amount_e8s: 1 })),
+        command: Some(Command::Split(Split {
+            amount_e8s: 1,
+            memo: None,
+        })),
         timestamp: 1,
     };
 
@@ -133,7 +151,10 @@ fn test_ledger_update_lock_same_neuron_cannot_lock_twice() {
 fn test_ledger_update_lock_same_neuron_can_lock_after_unlock() {
     let neuron_id = NeuronId { id: 1 };
     let inflight_command = NeuronInFlightCommand {
-        command: Some(Command::Split(Split { amount_e8s: 1 })),
+        command: Some(Command::Split(Split {
+            amount_e8s: 1,
+            memo: None,
+        })),
         timestamp: 1,
     };
 
@@ -152,7 +173,10 @@ fn test_ledger_update_lock_same_neuron_can_lock_after_unlock() {
 fn test_ledger_update_lock_same_neuron_cannot_lock_after_retained() {
     let neuron_id = NeuronId { id: 1 };
     let inflight_command = NeuronInFlightCommand {
-        command: Some(Command::Split(Split { amount_e8s: 1 })),
+        command: Some(Command::Split(Split {
+            amount_e8s: 1,
+            memo: None,
+        })),
         timestamp: 1,
     };
 
@@ -173,7 +197,10 @@ fn test_ledger_update_lock_compatible_with_neuron_async_lock() {
     // In this test we make sure that a neuron locked with `lock_neuron_for_command` cannot
     // `acquire_neuron_async_lock`, and vice versa.
     let neuron_id = NeuronId { id: 1 };
-    let command = Command::Split(Split { amount_e8s: 1 });
+    let command = Command::Split(Split {
+        amount_e8s: 1,
+        memo: None,
+    });
     let inflight_command = NeuronInFlightCommand {
         command: Some(command.clone()),
         timestamp: 1,

--- a/rs/nns/governance/src/pb/conversions/mod.rs
+++ b/rs/nns/governance/src/pb/conversions/mod.rs
@@ -789,6 +789,7 @@ impl From<pb::manage_neuron::Split> for pb_api::manage_neuron::Split {
     fn from(item: pb::manage_neuron::Split) -> Self {
         Self {
             amount_e8s: item.amount_e8s,
+            memo: item.memo,
         }
     }
 }
@@ -796,6 +797,7 @@ impl From<pb_api::manage_neuron::Split> for pb::manage_neuron::Split {
     fn from(item: pb_api::manage_neuron::Split) -> Self {
         Self {
             amount_e8s: item.amount_e8s,
+            memo: item.memo,
         }
     }
 }

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,6 +9,9 @@ on the process that this file is part of, see
 
 ## Added
 
+* The neuron `Split` command accepts an optional `memo` field that can be used to derive the neuron
+  subaccount, rather than generating a random one.
+
 ## Changed
 
 ## Deprecated

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -1345,7 +1345,10 @@ pub fn nns_split_neuron(
     neuron_id: NeuronId,
     amount: u64,
 ) -> ManageNeuronResponse {
-    let command = ManageNeuronCommandRequest::Split(Split { amount_e8s: amount });
+    let command = ManageNeuronCommandRequest::Split(Split {
+        amount_e8s: amount,
+        memo: None,
+    });
 
     manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }


### PR DESCRIPTION
Similar to SNS, add a `memo: opt nat64` field so that clients can specify a memo when splitting neurons and hence make the subaccount of the child neuron predictable.