### PR TITLE
chore: tag all //rs/tests/research:spec_compliance tests as long_test

### DIFF
--- a/rs/tests/research/BUILD.bazel
+++ b/rs/tests/research/BUILD.bazel
@@ -13,7 +13,10 @@ package(default_visibility = ["//rs:system-tests-pkg"])
         env = {
             "IC_REF_TEST_BIN": "$(rootpath //hs/spec_compliance:ic-ref-test)",
         },
-        tags = ["colocate"],
+        tags = [
+            "colocate",
+            "long_test",  # all the spec_compliance tests take ~7 minutes so let's no run them by default on PRs.
+        ],
         runtime_deps = UNIVERSAL_VM_RUNTIME_DEPS + CANISTER_HTTP_RUNTIME_DEPS + [
             ":ic-hs",
             "//hs/spec_compliance:ic-ref-test",


### PR DESCRIPTION
In the week starting on 2025-08-21 the 90th percentile duration of the `//rs/tests/research:spec_compliance...` tests was:
| test | P90 duration |
|---|---|
| `//rs/tests/research:spec_compliance_system_subnet_test_colocate` | 7m 29s |
| `//rs/tests/research:spec_compliance_group_01_application_subnet_test_colocate` | 7m 14s |
| `//rs/tests/research:spec_compliance_group_01_system_subnet_test_colocate` | 7m 5s |
| `//rs/tests/research:spec_compliance_application_subnet_test_colocate` | 6m 52s |

This is longer than our 5 minute maximum so let's move them to `long_test`.