### PR TITLE
chore: tag //rs/tests/financial_integrations/rosetta:rosetta_test_colocate as long_test

### DIFF
--- a/rs/tests/financial_integrations/rosetta/BUILD.bazel
+++ b/rs/tests/financial_integrations/rosetta/BUILD.bazel
@@ -5,7 +5,10 @@ package(default_visibility = ["//rs:system-tests-pkg"])
 
 system_test_nns(
     name = "rosetta_test",
-    tags = ["colocate"],
+    tags = [
+        "colocate",
+        "long_test",  # the P90 duration was over 7 minutes in the week starting on 2025-08-21
+    ],
     runtime_deps = [
         "//rs/rosetta-api/icp:ic-rosetta-api",
         "//rs/tests:rosetta_workspace",


### PR DESCRIPTION
The 90th percentile duration of the `//rs/tests/financial_integrations/rosetta:rosetta_test_colocate` was over 7 minutes in the week starting on 2025-08-21. This is higher than our maximum of 5 minutes so let's not run this test by default on PRs.