### PR TITLE
chore: tag //rs/sns/integration_tests:upgrade_canister_test as a long_test

### DIFF
--- a/rs/sns/integration_tests/BUILD.bazel
+++ b/rs/sns/integration_tests/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_rust//rust:defs.bzl", "rust_library")
 load("//bazel:canisters.bzl", "rust_canister")
-load("//bazel:defs.bzl", "rust_ic_test_suite_with_extra_srcs")
+load("//bazel:defs.bzl", "rust_ic_test", "rust_ic_test_suite_with_extra_srcs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -197,7 +197,8 @@ rust_ic_test_suite_with_extra_srcs(
         ["src/*.rs"],
         exclude = [
             "src/lib.rs",
-            "src/golden_state_swap_upgrade_twice.rs",
+            "src/golden_state_swap_upgrade_twice.rs",  # there's a dedicated :golden_state_swap_upgrade_twice target for this test below.
+            "src/upgrade_canister.rs",  # there's a dedicated :upgrade_canister_test target for this test below.
         ],
     ),
     aliases = ALIASES,
@@ -212,6 +213,26 @@ rust_ic_test_suite_with_extra_srcs(
     flaky = True,  # flakiness rate of over 1% for the "proposals" and "upgrade_canister" tests over the month from 2025-02-11 till 2025-03-11.
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = ["cpu:8"],
+    deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,
+)
+
+rust_ic_test(
+    name = "upgrade_canister_test",
+    size = "large",
+    srcs = ["src/upgrade_canister.rs"],
+    args = [
+        "--test-threads",
+        "7",
+    ],
+    crate_features = ["test"],
+    data = DATA_DEPS,
+    env = ENV,
+    flaky = True,  # flakiness rate of over 1% over the month from 2025-02-11 till 2025-03-11.
+    #proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
+    tags = [
+        "cpu:8",
+        "long_test",  # The P90 duration of this test is over 6 minutes for the week starting on 2025-08-21.
+    ],
     deps = DEPENDENCIES_WITH_TEST_FEATURES + TEST_DEV_DEPENDENCIES,
 )
 


### PR DESCRIPTION
The 90th percentile duration of the `//rs/sns/integration_tests:integration_test_src/upgrade_canister` test was 
6m 48s for the week starting on 2025-08-21. This is higher than our maximum of 5 minutes. 

So this moves this tests from `//rs/sns/integration_tests:integration_test_src` to the dedicated target `//rs/sns/integration_tests:upgrade_canister_test` tagged as a `long_test` such that it doesn't run on PRs by default anymore.

If desired this test can be triggered explictly on certain file changes via [`PULL_REQUEST_BAZEL_TARGETS`](https://github.com/dfinity/ic/blob/master/PULL_REQUEST_BAZEL_TARGETS).

Note that this test does run when "direct" source dependencies of the test are modified. More precisely it runs whenever any of the files returned by the following are modified: 
```
bazel query 'filter("^//", kind("source file", deps(//rs/sns/integration_tests:upgrade_canister_test , 2)))' 
```