### PR TITLE
chore: tag //rs/tests/node/... as long_test

### DIFF
--- a/rs/tests/node/BUILD.bazel
+++ b/rs/tests/node/BUILD.bazel
@@ -8,6 +8,9 @@ system_test_nns(
     proc_macro_deps = [
         "@crate_index//:indoc",
     ],
+    tags = [
+        "long_test",  # The P90 duration of this test was over 5 minutes for the week starting on 2025-08-21.
+    ],
     deps = [
         "//rs/nns/constants",
         "//rs/registry/canister",
@@ -30,6 +33,9 @@ system_test(
     env = {
         "NODE_ROOT_TESTS_UVM_CONFIG_PATH": "$(rootpath :root_tests_config_image)",
     },
+    tags = [
+        "long_test",  # The P90 duration of this test was over 6 minutes for the week starting on 2025-08-21.
+    ],
     runtime_deps = UNIVERSAL_VM_RUNTIME_DEPS + [":root_tests_config_image"],
     deps = [
         "//rs/tests/driver:ic-system-test-driver",


### PR DESCRIPTION
In the week starting on 2025-08-21 the 90th percentile duration of the `//rs/tests/node:...` tests was:
| test | P90 duration |
|---|---|
| //rs/tests/node:root_tests | 6m 41s |
| //rs/tests/node:ipv4_integration_test | 5m 16s |

These are all longer than our 5 minute maximum so let's move them to `long_test`.

If desired this test can be triggered explicitly on certain file changes via [`PULL_REQUEST_BAZEL_TARGETS`](https://github.com/dfinity/ic/blob/master/PULL_REQUEST_BAZEL_TARGETS).

Note that this test does run when "direct" source dependencies of the tests are modified. More precisely it runs whenever any of the files returned by the following are modified: 
```
bazel query 'filter("^//", kind("source file", deps(//rs/tests/node:root_tests, 2)))' 
```