### PR TITLE
chore: Add dogecoind to mirrored docker images

### DIFF
--- a/.github/workflows/container-mirror-images.json
+++ b/.github/workflows/container-mirror-images.json
@@ -50,6 +50,11 @@
       "image": "nginxproxy/nginx-proxy",
       "repo": "docker.io",
       "sha256": "c9ba1ba8a93223305a8bce2ae09024060797698121cd01a48e5cd7462b22faa1"
+    },
+    {
+      "image": "cmajewski/shkeeper-dogecoind",
+      "repo": "docker.io",
+      "sha256": "b2fcdeece97660f9d80871395ef13703e480efa0d387ea4702433045e083d563"
     }
   ]
 }


### PR DESCRIPTION
This will be used for dogecoin related system tests.