### PR TITLE
chore: Factor out VSockClient trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24543,6 +24543,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "ic-http-utils",
+ "mockall",
  "reqwest 0.12.15",
  "rusb",
  "serde",

--- a/rs/ic_os/vsock/guest/src/main.rs
+++ b/rs/ic_os/vsock/guest/src/main.rs
@@ -2,13 +2,13 @@
 
 use clap::{Args, Parser};
 use vsock_lib::protocol::{Command, NotifyData, Payload, UpgradeData};
-use vsock_lib::send_command;
+use vsock_lib::{LinuxVSockClient, VSockClient};
 fn main() -> Result<(), String> {
     let cli = Cli::parse();
 
     let port = cli.port;
     let command = get_command(cli)?;
-    let payload = send_command(command, port)?;
+    let payload = LinuxVSockClient::with_port(port).send_command(command)?;
 
     // Output the values directly
     match payload {

--- a/rs/ic_os/vsock/vsock_lib/BUILD.bazel
+++ b/rs/ic_os/vsock/vsock_lib/BUILD.bazel
@@ -6,6 +6,7 @@ DEPENDENCIES = [
     # Keep sorted.
     "//rs/http_utils",
     "@crate_index//:anyhow",
+    "@crate_index//:mockall",
     "@crate_index//:rusb",
     "@crate_index//:serde",
     "@crate_index//:serde_json",

--- a/rs/ic_os/vsock/vsock_lib/Cargo.toml
+++ b/rs/ic_os/vsock/vsock_lib/Cargo.toml
@@ -5,12 +5,15 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[dependencies]
 anyhow = { workspace = true }
-reqwest = { workspace = true }
-rusb = "0.9"
+mockall = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+reqwest = { workspace = true }
+rusb = "0.9"
 sha2 = { workspace = true }
 tempfile = { workspace = true }
 vsock = "0.4"

--- a/rs/ic_os/vsock/vsock_lib/src/guest/mod.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/guest/mod.rs
@@ -1,11 +1,51 @@
+#[cfg(target_os = "linux")]
 mod client;
+
 use crate::protocol::{Command, Request, Response};
+use mockall::automock;
 
-/// Send a command to the host vsock server
-pub fn send_command(command: Command, port: u32) -> Response {
-    let guest_cid = vsock::get_local_cid().map_err(|e| e.to_string())?;
+#[cfg(target_os = "linux")]
+pub use linux::*;
 
-    let request = Request { guest_cid, command };
+#[automock]
+pub trait VSockClient {
+    fn send_command(&self, command: Command) -> Response;
+}
 
-    client::send_request_to_host_and_parse_response(&request, &port)
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::*;
+
+    /// Send a command to the host vsock server
+    pub fn send_command(command: Command, port: u32) -> Response {
+        let guest_cid = vsock::get_local_cid().map_err(|e| e.to_string())?;
+
+        let request = Request { guest_cid, command };
+
+        client::send_request_to_host_and_parse_response(&request, &port)
+    }
+
+    pub struct LinuxVSockClient {
+        port: u32,
+    }
+
+    impl LinuxVSockClient {
+        pub const DEFAULT_PORT: u32 = 19090;
+
+        pub fn with_port(port: u32) -> Self {
+            Self { port }
+        }
+    }
+
+    impl Default for LinuxVSockClient {
+        fn default() -> Self {
+            Self::with_port(Self::DEFAULT_PORT)
+        }
+    }
+
+    impl VSockClient for LinuxVSockClient {
+        fn send_command(&self, command: Command) -> Response {
+            send_command(command, self.port)
+        }
+    }
 }

--- a/rs/ic_os/vsock/vsock_lib/src/guest/mod.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/guest/mod.rs
@@ -16,15 +16,6 @@ pub trait VSockClient {
 mod linux {
     use super::*;
 
-    /// Send a command to the host vsock server
-    pub fn send_command(command: Command, port: u32) -> Response {
-        let guest_cid = vsock::get_local_cid().map_err(|e| e.to_string())?;
-
-        let request = Request { guest_cid, command };
-
-        client::send_request_to_host_and_parse_response(&request, &port)
-    }
-
     pub struct LinuxVSockClient {
         port: u32,
     }
@@ -45,7 +36,12 @@ mod linux {
 
     impl VSockClient for LinuxVSockClient {
         fn send_command(&self, command: Command) -> Response {
-            send_command(command, self.port)
+            let port = self.port;
+            let guest_cid = vsock::get_local_cid().map_err(|e| e.to_string())?;
+
+            let request = Request { guest_cid, command };
+
+            client::send_request_to_host_and_parse_response(&request, &port)
         }
     }
 }

--- a/rs/ic_os/vsock/vsock_lib/src/lib.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/lib.rs
@@ -1,9 +1,11 @@
-#![cfg(target_os = "linux")]
-
 mod guest;
-pub use guest::send_command;
+#[cfg(target_os = "linux")]
+pub use guest::{send_command, LinuxVSockClient};
+pub use guest::{MockVSockClient, VSockClient};
 
+#[cfg(target_os = "linux")]
 mod host;
+#[cfg(target_os = "linux")]
 pub use host::server::run_server;
 
 pub mod protocol;

--- a/rs/ic_os/vsock/vsock_lib/src/lib.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/lib.rs
@@ -1,6 +1,6 @@
 mod guest;
 #[cfg(target_os = "linux")]
-pub use guest::{send_command, LinuxVSockClient};
+pub use guest::LinuxVSockClient;
 pub use guest::{MockVSockClient, VSockClient};
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
It allows for mocking vsock command invocations in tests.