### PR TITLE
chore: send slack notifications about system-tests-benchmarks-nightly failures to #eng-ic-benchmark-alerts

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -187,7 +187,7 @@ jobs:
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         if: failure()
         with:
-          channel-id: eng-crypto-alerts
+          channel-id: eng-ic-benchmark-alerts
           slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Run#${{github.run_id}}>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -205,7 +205,7 @@ jobs:
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         if: failure()
         with:
-          channel-id: eng-crypto-alerts
+          channel-id: eng-ic-benchmark-alerts
           slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Run#${{github.run_id}}>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}


### PR DESCRIPTION
The `system-tests-benchmarks-nightly` job is running and going to run benchmarks owned not only by @dfinity/crypto-team so this commit sends slack notifications about failures of this job to, the more general, #eng-ic-benchmark-alerts instead of #eng-crypto-alerts.