### PR TITLE
chore: send a slack notification on nns-tests-nightly failures

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -130,7 +130,7 @@ jobs:
         if: failure()
         with:
           channel-id: eng-nns
-          slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{github.job}}|Job#${{github.job}}>"
+          slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Run#${{github.run_id}}>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
 

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -125,6 +125,14 @@ jobs:
               --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Post Slack Notification
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        if: failure()
+        with:
+          channel-id: eng-nns
+          slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{github.job}}|Job#${{github.job}}>"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
 
   pocketic-tests-nightly:
     name: Bazel Test PocketIC Nightly

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -133,6 +133,14 @@ jobs:
               --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Post Slack Notification
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        if: failure()
+        with:
+          channel-id: eng-nns
+          slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{github.job}}|Job#${{github.job}}>"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
   pocketic-tests-nightly:
     name: Bazel Test PocketIC Nightly
     runs-on:

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -138,7 +138,7 @@ jobs:
         if: failure()
         with:
           channel-id: eng-nns
-          slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{github.job}}|Job#${{github.job}}>"
+          slack-message: "${{ github.job }} failed :disappointed: - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Run#${{github.run_id}}>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
   pocketic-tests-nightly:


### PR DESCRIPTION
Send a slack notification to #eng-nns whenever the nightly `nns-tests-nightly` job fails.