### PR TITLE
perf(idkg): [CON-1557] reduce the number of support share validations

### DIFF
--- a/rs/consensus/idkg/src/pre_signer.rs
+++ b/rs/consensus/idkg/src/pre_signer.rs
@@ -575,7 +575,6 @@ impl IDkgPreSignerImpl {
             .map(|transcript_params| transcript_params.transcript_id)
             .collect::<BTreeSet<_>>();
 
-        let ret = std::iter::empty();
         let current_height = block_reader.tip_height();
         let mut target_subnet_xnet_transcripts = BTreeSet::new();
         for transcript_params_ref in block_reader.target_subnet_xnet_transcripts() {
@@ -583,7 +582,7 @@ impl IDkgPreSignerImpl {
         }
 
         // Unvalidated dealings.
-        let action = idkg_pool
+        let ret = idkg_pool
             .unvalidated()
             .signed_dealings()
             .filter(|(_, signed_dealing)| {
@@ -595,7 +594,6 @@ impl IDkgPreSignerImpl {
                 )
             })
             .map(|(id, _)| IDkgChangeAction::RemoveUnvalidated(id));
-        let ret = ret.chain(action);
 
         // Validated dealings.
         let action = idkg_pool


### PR DESCRIPTION
Currently, for every IDKG dealing, we validate all `n` support shares. However, we actually only need `2f+1` support shares in order to complete the transcript. Since the validation of support shares represents the largest amount of computation required by the IDKG protocol, this PR reduces the number of support share validations and improves overall performance.

It does so by maintaining a separate in-memory map, that keeps track of how many support shares were already validated for a given dealing. If we already successfully validated at least `2f+1` support shares according to this map, any additional shares are removed from the unvalidated pool.

The difference in performance is quite significant!
Before:
<img width="1908" height="525" alt="image" src="https://github.com/user-attachments/assets/321dee59-9bda-4616-aadf-cef06975bf5e" />

After:
<img width="1896" height="530" alt="image" src="https://github.com/user-attachments/assets/343d4c30-1476-4d2e-91d3-24cb163eae16" />

P.S.: We also tried removing the [`has_node_issued_dealing_support`](https://github.com/dfinity/ic/pull/6526/files#diff-dbc1abf369d69171bc8d70760b200793813e40581ab3f54e298e87d18f12e83aL429-L435) check to see if it would improve performance, but it made no difference.

P.S. 2: A similar optimization (of validating only `2f+1` shares instead of `n`) led to a race condition two years ago because a membership change modified the verification threshold. This cannot happen here because the number of receivers (and thus also the verification threshold) is fixed throughout an execution of the IDKG protocol.