### PR TITLE
fix: filter for excluded tags in targets.py

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -173,21 +173,8 @@ jobs:
             BASE_SHA='${{ github.event.pull_request.base.sha }}'
             HEAD_SHA='${{ github.event.pull_request.head.sha }}'
 
-            # Determine which tests to skip
-            EXCLUDED_TEST_TAGS=(
-                system_test_large
-                system_test_benchmark
-                fuzz_test
-                fi_tests_nightly
-                nns_tests_nightly
-                pocketic_tests_nightly
-            )
-
-            # Prepend tags with '-' and join them with commas for Bazel
-            TEST_TAG_FILTERS=$(IFS=,; echo "${EXCLUDED_TEST_TAGS[*]/#/-}")
             # Determine bazel_args based on event type or branch name
             bazel_args=(
-              "--test_tag_filters=$TEST_TAG_FILTERS"
               --config=lint # enable lint checks
               --config=flaky_retry # auto retry eg systests
               )

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -144,21 +144,8 @@ jobs:
             BASE_SHA='${{ github.event.pull_request.base.sha }}'
             HEAD_SHA='${{ github.event.pull_request.head.sha }}'
 
-            # Determine which tests to skip
-            EXCLUDED_TEST_TAGS=(
-                system_test_large
-                system_test_benchmark
-                fuzz_test
-                fi_tests_nightly
-                nns_tests_nightly
-                pocketic_tests_nightly
-            )
-
-            # Prepend tags with '-' and join them with commas for Bazel
-            TEST_TAG_FILTERS=$(IFS=,; echo "${EXCLUDED_TEST_TAGS[*]/#/-}")
             # Determine bazel_args based on event type or branch name
             bazel_args=(
-              "--test_tag_filters=$TEST_TAG_FILTERS"
               --config=lint # enable lint checks
               --config=flaky_retry # auto retry eg systests
               )

--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -17,7 +17,7 @@
 # When the command is `check` the PULL_REQUEST_BAZEL_TARGETS file is checked for correctness.
 #
 # The script will print the bazel query to stderr which is useful for debugging:
-#   ci/bazel-scripts/targets.py --skip_long_tests --base=master.. test
+#   ci/bazel-scripts/targets.py --skip_long_tests --base=master test
 #   bazel query --keep_going '(((kind(".*_test", //...)) except attr(tags, long_test, //...)) + set(//pre-commit:shfmt-check //pre-commit:ruff-lint)) except attr(tags, manual, //...)'
 
 import argparse
@@ -30,6 +30,17 @@ from typing import Set
 # The file specifying which bazel targets to test explicitly on PRs based on which file modifications
 # regardless of whether those targets explicitly depend on those files or whether they're tagged as `long_test`.
 PULL_REQUEST_BAZEL_TARGETS = "PULL_REQUEST_BAZEL_TARGETS"
+
+# Targets will always be excluded if they have any of the following tags:
+EXCLUDED_TAGS = [
+    "manual",
+    "system_test_large",
+    "system_test_benchmark",
+    "fuzz_test",
+    "fi_tests_nightly",
+    "nns_tests_nightly",
+    "pocketic_tests_nightly",
+]
 
 # Return all bazel targets (//...) sans the long_tests (if --skip_long_tests is specified)
 # in case any file is modified matching any of the following globs:
@@ -158,8 +169,9 @@ def targets(command: str, skip_long_tests: bool, base: str | None, head: str | N
         else diff_only_query(command, base, "HEAD" if head is None else head, skip_long_tests)
     )
 
-    # Finally, exclude targets tagged with 'manual' to avoid running manual tests:
-    query = f"({query}) except attr(tags, manual, //...)"
+    # Finally, exclude targets that have any of the excluded tags:
+    excluded_tags_regex = "|".join(EXCLUDED_TAGS)
+    query = f"({query}) except attr(tags, '{excluded_tags_regex}', //...)"
 
     log(f"bazel query --keep_going '{query}'")
     result = subprocess.run(["bazel", "query", "--keep_going", query], stderr=subprocess.PIPE, text=True)

--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -189,7 +189,7 @@ def check():
     * can be read and parsed.
     * each pattern matches at least one file tracked by git.
     * each pattern has at least one explicit target.
-    * each target is valid and when queried results in at least one target after excluding all manual targets.
+    * each target is valid and when queried results in at least one target after excluding all excluded targets.
     Otherwise print all errors to stderr and exit erroneously with 1.
     """
     try:
@@ -218,7 +218,8 @@ def check():
             errors.append(f"Pattern '{pattern}' has no explicit targets!")
 
         for target in explicit_targets_for_pattern:
-            query = f"({target}) except attr(tags, manual, //...)"
+            excluded_tags_regex = "|".join(EXCLUDED_TAGS)
+            query = f"({target}) except attr(tags, '{excluded_tags_regex}', //...)"
             result = subprocess.run(["bazel", "query", query], capture_output=True, text=True)
             if result.returncode != 0:
                 indented_error_msg = f"{indentation}" + f"\n{indentation}".join(result.stderr.strip().splitlines())


### PR DESCRIPTION
Previously when a PR only modified dependencies of targets that matched the `EXCLUDED_TEST_TAGS` the `targets.py` script would return these targets but they would then subsequently be filtered out by `--test_tag_filters` which would cause bazel to error with:

```
ERROR: No test targets were found, yet testing was requested
```

This commit fixes that by excluding the targets matching  `EXCLUDED_TEST_TAGS`  inside the `targets.py` script. If a PR only modifies dependencies of targets matching `EXCLUDED_TEST_TAGS` `targets.py` will return no targets causing the bazel action to exit early and thus not invoke bazel preventing the error.