### PR TITLE
test: bump timeout of the //rs/tests/consensus/upgrade:upgrade_downgrade_app_subnet_test

### DIFF
--- a/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
+++ b/rs/tests/consensus/upgrade/upgrade_downgrade_app_subnet_test.rs
@@ -38,8 +38,8 @@ const SCHNORR_MSG_SIZE_BYTES: usize = 32;
 const DKG_INTERVAL: u64 = 9;
 const ALLOWED_FAILURES: usize = 1;
 const SUBNET_SIZE: usize = 3 * ALLOWED_FAILURES + 1; // 4 nodes
-const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(25 * 60);
-const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const UP_DOWNGRADE_OVERALL_TIMEOUT: Duration = Duration::from_secs(35 * 60);
+const UP_DOWNGRADE_PER_TEST_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 const REQUESTS_DISPATCH_EXTRA_TIMEOUT: Duration = Duration::from_secs(1);
 
 fn setup(env: TestEnv) {
@@ -132,7 +132,10 @@ fn upgrade_downgrade_app_subnet(env: TestEnv) {
         None,
         /*assert_graceful_orchestrator_tasks_exits=*/ true,
     );
-    // Make sure we can still read the message stored before the first upgrade
+    info!(
+        logger,
+        "Make sure we can still read the message stored before the first upgrade ..."
+    );
     assert!(can_read_msg_with_retries(
         &env.logger(),
         &faulty_node.get_public_url(),


### PR DESCRIPTION
Similar to https://github.com/dfinity/ic/pull/6356, which bumped the timeout of the `//rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test`, this bumps the timeout of the `//rs/tests/consensus/upgrade:upgrade_downgrade_app_subnet_test` since it frequently runs into a timeout as well.