### PR TITLE
chore: tag //rs/tests/consensus:guestos_recovery_engine_smoke_test as long_test

### DIFF
--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -253,6 +253,9 @@ system_test(
         "RECOVERY_STORE_1_B64_PATH": "$(rootpath //ic-os/guestos/envs/recovery-dev:ic_registry_local_store_1.b64)",
         "RECOVERY_STORE_2_B64_PATH": "$(rootpath //ic-os/guestos/envs/recovery-dev:ic_registry_local_store_2.b64)",
     },
+    tags = [
+        "long_test",  # the P90 duration of this test is over 6 minutes in the week starting on 2025-08-25.
+    ],
     uses_guestos_img = False,
     uses_guestos_recovery_dev_img = True,
     runtime_deps = IMPERSONATE_UPSTREAMS_RUNTIME_DEPS + [


### PR DESCRIPTION
The 90th percentile duration of the `//rs/tests/consensus:guestos_recovery_engine_smoke_test ` is 6m and 41s for the week starting on 2025-08-25. This is longer than the maximum of 5 minutes so this commit tags this test as `long_test` to not run it on PRs by default.