### PR TITLE
chore: tag //rs/tests/consensus:cup_explorer_test as long_test

### DIFF
--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -192,6 +192,7 @@ system_test_nns(
     name = "cup_explorer_test",
     tags = [
         "k8s",
+        "long_test",  # The P90 duration was over 6 minutes for the week starting on 2025-08-25.
     ],
     deps = [
         # Keep sorted.


### PR DESCRIPTION
The 90th percentile duration of the `//rs/tests/consensus:cup_explorer_test` was 6 minutes and 34s for the week starting on 2025-08-25. This is longer than our maximum of 5 minutes so this commit tags this test as `long_test` to not run it on PRs by default.