### PR TITLE
chore: tag //rs/tests/nns:nns_dapp_test as long_test

### DIFF
--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -15,6 +15,9 @@ system_test_nns(
         "NNS_DAPP_WASM_PATH": "$(rootpath @nns_dapp_canister//file)",
         "SUBNET_RENTAL_WASM_PATH": "$(rootpath @subnet_rental_canister//file)",
     },
+    tags = [
+        "long_test",  # the P90 duration was over 6 minutes for the week starting on 2025-08-25.
+    ],
     runtime_deps = IC_GATEWAY_RUNTIME_DEPS + [
         "//rs/ledger_suite/icrc1/ledger:ledger_canister",
         "@ii_dev_canister//file",


### PR DESCRIPTION
The 90th percentile duration of the `//rs/tests/nns:nns_dapp_test` was 6 minutes and 22 for the week starting on 2025-08-25. This is longer than our maximum of 5 minutes so this commit tags this test as `long_test` to not run it on PRs by default.