### PR TITLE
chore: tag //rs/tests/boundary_nodes:rate_limit_canister_test as long_test

### DIFF
--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -110,6 +110,7 @@ system_test_nns(
     proc_macro_deps = ["@crate_index//:async-trait"],
     tags = [
         "k8s",
+        "long_test",  # the P90 duration was over 5 minutes for the week starting on 2025-08-25.
     ],
     runtime_deps = [
         "//rs/boundary_node/rate_limits:rate_limit_canister",


### PR DESCRIPTION
The 90th percentile duration of the `//rs/tests/boundary_nodes:rate_limit_canister_test` was 5 minutes and 41 seconds for the week starting on 2025-08-25. This is longer than our maximum of 5 minutes so this commit tags this test as `long_test` to not run it on PRs by default.

Note if desired this test can be triggered automatically on PRs for certain file changes (like for `rs/boundary_node/rate_limits/*`) by adding the necessary pattern to [`PULL_REQUEST_BAZEL_TARGETS`](https://github.com/dfinity/ic/blob/master/PULL_REQUEST_BAZEL_TARGETS). I'm happy to do that in this PR if desired.