### PR TITLE
feat: [CON-1578] don't allow requesting `/canister_ranges` paths in `/api/{v2,v3}/canister/<canister_id>/read_state`

### DIFF
--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -764,6 +764,7 @@ fn validate_canister_ranges(
 }
 
 fn main() -> Result<()> {
+    // TODO(CON-1487): test the `/api/v3` endpoints as well
     SystemTestGroup::new()
         .with_setup(setup)
         .add_test(systest!(test_empty_paths_return_time))

--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -681,8 +681,8 @@ fn test_request_path_access(env: TestEnv) {
     assert_matches!(result, Err(AgentError::HttpError(payload)) if payload.status == 400);
 }
 
-// Queries the `api/v2/canister/{canister_id}/read_state` endpoint for the canister ranges,
-// and compares the result with the canister ranges obtained from the registry.
+/// Queries the `api/v2/canister/{canister_id}/read_state` endpoint for the canister ranges,
+/// and compares the result with the canister ranges obtained from the registry.
 fn test_canister_canister_ranges_paths(env: TestEnv) {
     let subnet = get_first_app_subnet(&env);
     let node = subnet.nodes().next().unwrap();
@@ -693,19 +693,22 @@ fn test_canister_canister_ranges_paths(env: TestEnv) {
         subnet.subnet_id.get_ref().as_slice().into(),
     ];
 
-    let cert = read_state_with_identity_and_canister_id(
+    let err = read_state_with_identity_and_canister_id(
         &env,
         vec![path.clone()],
         get_identity(),
         effective_canister_id,
     )
-    .expect("Failed to read state");
+    .expect_err(
+        "/canister_ranges path should not be fetchable from \
+        the /api/v2/canister/<canister_id>/read_state endpoint",
+    );
 
-    validate_canister_ranges(&subnet, &path, &cert);
+    assert_matches!(err, AgentError::HttpError(payload) if payload.status == 404);
 }
 
-// Queries the `api/v2/subnet/{subnet_id}/read_state` endpoint for the canister ranges.
-// and compares the result with the canister ranges obtained from the registry.
+/// Queries the `api/v2/subnet/{subnet_id}/read_state` endpoint for the canister ranges.
+/// and compares the result with the canister ranges obtained from the registry.
 fn test_subnet_canister_ranges_paths(env: TestEnv) {
     let subnet = get_first_app_subnet(&env);
 

--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -31,10 +31,10 @@ Success::
   principal than who made the original request with request ID R;
 . Read state requests for two paths /request_status/R and /request_status/S with two different request
   IDs R and S are rejected with 400 (while requesting each of the two paths in isolation would succeed);
-. Read state requests for the path /canister_ranges/{subnet_id} succeed and return a correct list of canister
-  ranges assigned to the subnet. Both /api/v2/subnet/{subnet_id}/read_state and
-  /api/v2/canister/{canister_id}/read_state endpoints are tested.
-
+. Read state requests at `/api/v2/subnet/{subnet_id}/read_state` for the path `/canister_ranges/{subnet_id}`
+  succeed and return a correct list of canister ranges assigned to the subnet.
+. Read state requests at `/api/v2/canister/{canister_id}/read_state` for the path `/canister_ranges/{subnet_id}`
+  should fail because the path is disallowed.
 end::catalog[] */
 
 use std::collections::BTreeSet;
@@ -682,7 +682,7 @@ fn test_request_path_access(env: TestEnv) {
 }
 
 /// Queries the `api/v2/canister/{canister_id}/read_state` endpoint for the canister ranges,
-/// and compares the result with the canister ranges obtained from the registry.
+/// and makes sure the requests fails.
 fn test_canister_canister_ranges_paths(env: TestEnv) {
     let subnet = get_first_app_subnet(&env);
     let node = subnet.nodes().next().unwrap();


### PR DESCRIPTION
See the deprecation note in https://internetcomputer.org/docs/references/ic-interface-spec#http-read-state

Note: the paths were allowlisted in https://github.com/dfinity/ic/pull/6152 which has been deployed on mainnet for less than a month, so there shouldn't be many users of it