### PR TITLE
chore(PocketIC): use Option<EmptyConfig> instead of bool and Option<bool>

### DIFF
--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -570,26 +570,26 @@ pub struct NonmainnetFeatures {
 /// during the PocketIC instance lifetime.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
 pub struct IcpFeatures {
-    pub registry: bool,
+    pub registry: Option<EmptyConfig>,
     /// If the `cycles_minting` feature is enabled, then the default timestamp of a PocketIC instance is set to 10 May 2021 10:00:01 AM CEST (the smallest value that is strictly larger than the default timestamp hard-coded in the CMC state).
-    pub cycles_minting: bool,
-    pub icp_token: bool,
-    pub cycles_token: bool,
-    pub nns_governance: bool,
-    pub sns: bool,
-    pub ii: bool,
+    pub cycles_minting: Option<EmptyConfig>,
+    pub icp_token: Option<EmptyConfig>,
+    pub cycles_token: Option<EmptyConfig>,
+    pub nns_governance: Option<EmptyConfig>,
+    pub sns: Option<EmptyConfig>,
+    pub ii: Option<EmptyConfig>,
 }
 
 impl IcpFeatures {
     pub fn all_icp_features() -> Self {
         Self {
-            registry: true,
-            cycles_minting: true,
-            icp_token: true,
-            cycles_token: true,
-            nns_governance: true,
-            sns: true,
-            ii: true,
+            registry: Some(EmptyConfig {}),
+            cycles_minting: Some(EmptyConfig {}),
+            icp_token: Some(EmptyConfig {}),
+            cycles_token: Some(EmptyConfig {}),
+            nns_governance: Some(EmptyConfig {}),
+            sns: Some(EmptyConfig {}),
+            ii: Some(EmptyConfig {}),
         }
     }
 }
@@ -615,7 +615,7 @@ pub struct InstanceConfig {
     pub log_level: Option<String>,
     pub bitcoind_addr: Option<Vec<SocketAddr>>,
     pub icp_features: Option<IcpFeatures>,
-    pub allow_incomplete_state: Option<bool>,
+    pub allow_incomplete_state: Option<EmptyConfig>,
     pub initial_time: Option<InitialTime>,
 }
 
@@ -771,27 +771,33 @@ impl ExtendedSubnetConfigSet {
         } = icp_features;
         // NNS canisters
         for (flag, icp_feature_str) in [
-            (*registry, "registry"),
-            (*cycles_minting, "cycles_minting"),
-            (*icp_token, "icp_token"),
-            (*nns_governance, "nns_governance"),
-            (*sns, "sns"),
+            (registry, "registry"),
+            (cycles_minting, "cycles_minting"),
+            (icp_token, "icp_token"),
+            (nns_governance, "nns_governance"),
+            (sns, "sns"),
         ] {
-            if flag {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = flag {
                 check_empty_subnet(&self.nns, "NNS", icp_feature_str)?;
                 self.nns = Some(self.nns.unwrap_or_default());
             }
         }
         // canisters on the II subnet
-        for (flag, icp_feature_str) in [(*cycles_token, "cycles_token"), (*ii, "ii")] {
-            if flag {
+        for (flag, icp_feature_str) in [(cycles_token, "cycles_token"), (ii, "ii")] {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = flag {
                 check_empty_subnet(&self.ii, "II", icp_feature_str)?;
                 self.ii = Some(self.ii.unwrap_or_default());
             }
         }
         // canisters on the SNS subnet
-        for (flag, icp_feature_str) in [(*sns, "sns")] {
-            if flag {
+        for (flag, icp_feature_str) in [(sns, "sns")] {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = flag {
                 check_empty_subnet(&self.sns, "SNS", icp_feature_str)?;
                 self.sns = Some(self.sns.unwrap_or_default());
             }

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -208,7 +208,7 @@ impl PocketIc {
             log_level: log_level.map(|l| l.to_string()),
             bitcoind_addr,
             icp_features: Some(icp_features),
-            allow_incomplete_state: Some(false),
+            allow_incomplete_state: None,
             initial_time,
         };
 

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -24,9 +24,9 @@ use pocket_ic::{common::rest::ExtendedSubnetConfigSet, nonblocking::PocketIc as 
 use pocket_ic::{
     common::rest::{
         AutoProgressConfig, BlobCompression, CanisterHttpReply, CanisterHttpResponse,
-        CreateInstanceResponse, HttpGatewayDetails, IcpFeatures, InitialTime, InstanceConfig,
-        InstanceHttpGatewayConfig, MockCanisterHttpResponse, RawEffectivePrincipal, RawMessageId,
-        SubnetConfigSet, SubnetKind,
+        CreateInstanceResponse, EmptyConfig, HttpGatewayDetails, IcpFeatures, InitialTime,
+        InstanceConfig, InstanceHttpGatewayConfig, MockCanisterHttpResponse, RawEffectivePrincipal,
+        RawMessageId, SubnetConfigSet, SubnetKind,
     },
     query_candid, start_server, update_candid, DefaultEffectiveCanisterIdError, ErrorCode,
     IngressStatusResult, PocketIc, PocketIcBuilder, PocketIcState, RejectCode, StartServerParams,
@@ -419,7 +419,7 @@ fn test_invalid_initial_timestamp() {
 fn test_initial_timestamp_with_cycles_minting() {
     let initial_timestamp = 1_620_633_601_000_000_000; // 10 May 2021 10:00:01
     let icp_features = IcpFeatures {
-        cycles_minting: true,
+        cycles_minting: Some(EmptyConfig {}),
         ..Default::default()
     };
     let pic = PocketIcBuilder::new()
@@ -443,7 +443,7 @@ fn test_initial_timestamp_with_cycles_minting() {
 fn test_invalid_initial_timestamp_with_cycles_minting() {
     let initial_timestamp = 1_620_328_630_000_000_000; // 06 May 2021 21:17:10 CEST
     let icp_features = IcpFeatures {
-        cycles_minting: true,
+        cycles_minting: Some(EmptyConfig {}),
         ..Default::default()
     };
     let _pic = PocketIcBuilder::new()
@@ -558,7 +558,9 @@ fn time_on_resumed_instance() {
 
 // Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
 #[cfg(not(windows))]
-async fn resume_killed_instance_impl(allow_incomplete_state: Option<bool>) -> Result<(), String> {
+async fn resume_killed_instance_impl(
+    allow_incomplete_state: Option<EmptyConfig>,
+) -> Result<(), String> {
     let (mut server, server_url) = start_server(StartServerParams::default()).await;
     let temp_dir = TempDir::new().unwrap();
 
@@ -659,7 +661,7 @@ async fn resume_killed_instance_impl(allow_incomplete_state: Option<bool>) -> Re
 // Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
 #[cfg(not(windows))]
 #[tokio::test]
-async fn resume_killed_instance_default() {
+async fn resume_killed_instance_strict() {
     let err = resume_killed_instance_impl(None).await.unwrap_err();
     assert!(err.contains("The state of subnet with seed 7712b2c09cb96b3aa3fbffd4034a21a39d5d13f80e043161d1d71f4c593434af is incomplete."));
 }
@@ -667,16 +669,10 @@ async fn resume_killed_instance_default() {
 // Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
 #[cfg(not(windows))]
 #[tokio::test]
-async fn resume_killed_instance_strict() {
-    let err = resume_killed_instance_impl(Some(false)).await.unwrap_err();
-    assert!(err.contains("The state of subnet with seed 7712b2c09cb96b3aa3fbffd4034a21a39d5d13f80e043161d1d71f4c593434af is incomplete."));
-}
-
-// Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
-#[cfg(not(windows))]
-#[tokio::test]
 async fn resume_killed_instance() {
-    resume_killed_instance_impl(Some(true)).await.unwrap();
+    resume_killed_instance_impl(Some(EmptyConfig {}))
+        .await
+        .unwrap();
 }
 
 #[test]

--- a/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
+++ b/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
@@ -9,14 +9,14 @@ use ic_node_rewards_canister_api::provider_rewards_calculation::{
     GetNodeProviderRewardsCalculationResponse,
 };
 use ic_types::PrincipalId;
-use pocket_ic::common::rest::IcpFeatures;
+use pocket_ic::common::rest::{EmptyConfig, IcpFeatures};
 use pocket_ic::nonblocking::{query_candid, update_candid, PocketIc};
 use pocket_ic::PocketIcBuilder;
 use std::time::Duration;
 
 async fn setup_env() -> PocketIc {
     let icp_features = IcpFeatures {
-        registry: true,
+        registry: Some(EmptyConfig {}),
         ..Default::default()
     };
     let pocket_ic = PocketIcBuilder::new()

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -181,11 +181,14 @@ const CONTENT_TYPE_CBOR: HeaderValue = HeaderValue::from_static("application/cbo
 
 fn default_timestamp(icp_features: &Option<IcpFeatures>) -> SystemTime {
     // To set the ICP/XDR conversion rate, the PocketIC time (in seconds) must be strictly larger than the default timestamp in CMC state.
-    if icp_features
+    let cycles_minting_feature = icp_features
         .as_ref()
-        .map(|icp_features| icp_features.cycles_minting)
-        .unwrap_or_default()
-    {
+        .map(|icp_features|
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            matches!(icp_features.cycles_minting, Some(EmptyConfig {})))
+        .unwrap_or_default();
+    if cycles_minting_feature {
         UNIX_EPOCH + Duration::from_secs(DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS + 1)
     } else {
         GENESIS.into()
@@ -942,25 +945,39 @@ impl PocketIcSubnets {
                 sns,
                 ii,
             } = icp_features;
-            if registry {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = registry {
                 self.update_registry();
             }
-            if cycles_minting {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = cycles_minting {
                 self.update_cmc();
             }
-            if icp_token {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = icp_token {
                 self.deploy_icp_token();
             }
-            if cycles_token {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = cycles_token {
                 self.deploy_cycles_token();
             }
-            if nns_governance {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = nns_governance {
                 self.deploy_nns_governance();
             }
-            if sns {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = sns {
                 self.deploy_sns();
             }
-            if ii {
+            // using `EmptyConfig { }` explicitly
+            // to force an update after adding a new field to `EmptyConfig`
+            if let Some(EmptyConfig {}) = ii {
                 self.deploy_ii();
             }
         }
@@ -1092,7 +1109,10 @@ impl PocketIcSubnets {
             let cycles_ledger_canister_id = if self
                 .icp_features
                 .as_ref()
-                .map(|icp_features| icp_features.cycles_token)
+                .map(|icp_features|
+                  // using `EmptyConfig { }` explicitly
+                  // to force an update after adding a new field to `EmptyConfig`
+                  matches!(icp_features.cycles_minting, Some(EmptyConfig {})))
                 .unwrap_or_default()
             {
                 Some(CYCLES_LEDGER_CANISTER_ID)
@@ -2038,7 +2058,7 @@ impl PocketIc {
         log_level: Option<Level>,
         bitcoind_addr: Option<Vec<SocketAddr>>,
         icp_features: Option<IcpFeatures>,
-        allow_incomplete_state: Option<bool>,
+        allow_incomplete_state: Option<EmptyConfig>,
         initial_time: Option<Time>,
         auto_progress_enabled: bool,
     ) -> Result<Self, String> {
@@ -2099,7 +2119,9 @@ impl PocketIc {
                     if let Some(allocation_range) = config.alloc_range {
                         range_gen.add_assigned(vec![allocation_range]).unwrap();
                     }
-                    let expected_state_time = if let Some(true) = allow_incomplete_state {
+                    // using `EmptyConfig { }` explicitly
+                    // to force an update after adding a new field to `EmptyConfig`
+                    let expected_state_time = if let Some(EmptyConfig {}) = allow_incomplete_state {
                         None
                     } else {
                         Some(topology.time)


### PR DESCRIPTION
This PR replaces `bool` and `Option<bool>` by `Option<EmptyConfig>` in public PocketIC types for the sake of backward-compatibility if we need to add further parameters in the future.