### PR TITLE
chore: schedule daily workflow an hour earlier so it doesn't overlap with Release Testing

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -2,7 +2,7 @@ name: Schedule Daily
 
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:

--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -2,6 +2,8 @@ name: Schedule Daily
 
 on:
   schedule:
+    # Note that we would like there to be no overlap between the system-tests-benchmarks-nightly job below
+    # and the Release Testing workflow triggered by the Schedule RC workflow.
     - cron: "0 0 * * *"
   workflow_dispatch:
 

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -1,6 +1,8 @@
 name: Schedule Daily
 on:
   schedule:
+    # Note that we would like there to be no overlap between the system-tests-benchmarks-nightly job below
+    # and the Release Testing workflow triggered by the Schedule RC workflow.
     - cron: "0 0 * * *"
   workflow_dispatch:
 env:

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -1,7 +1,7 @@
 name: Schedule Daily
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
The `Bazel System Test Benchmarks` job of the `Schedule Daily` workflow overlaps with the `Release Testing` workflow causing some load from `Release Testing` to spill over to the `dm1` Performance DC. To prevent this we move `Schedule Daily` an hour earlier to midnight.

<img width="4412" height="607" alt="jobs" src="https://github.com/user-attachments/assets/e96ccbf0-dc4a-4fd1-89d0-5808fcf9abb2" />

