### PR TITLE
chore: print the bazel targets to test in bazel-test-all

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -206,7 +206,7 @@ jobs:
             num_targets=$(wc <"$target_pattern_file" -l)
             # if bazel targets is empty we don't need to run any tests
             if [ "$num_targets" -eq 0 ]; then
-              echo "No bazel targets to test"
+              echo "No bazel targets"
               exit 0
             fi
             echo "Testing the following $num_targets targets:"

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -203,11 +203,14 @@ jobs:
               targets_args+=("--base=$BASE_SHA" "--head=$HEAD_SHA")
             fi
             "${CI_PROJECT_DIR:-}"/ci/bazel-scripts/targets.py test "${targets_args[@]}" >"$target_pattern_file"
+            num_targets=$(wc <"$target_pattern_file" -l)
             # if bazel targets is empty we don't need to run any tests
-            if [ $(wc <"$target_pattern_file" -l) -eq 0 ]; then
-              echo "No bazel targets to build"
+            if [ "$num_targets" -eq 0 ]; then
+              echo "No bazel targets to test"
               exit 0
             fi
+            echo "Testing the following $num_targets targets:"
+            cat "$target_pattern_file"
             bazel_args+=( --target_pattern_file="$target_pattern_file" )
 
             echo "Building as user: $(whoami)"

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -491,6 +491,9 @@ jobs:
             fi
             ci/bazel-scripts/targets.py build "${targets_args[@]}" >"$targets"
 
+            echo "Considering the following $(wc <"$targets" -l) targets:"
+            cat "$targets"
+
             ARGS=()
 
             if grep -q '^//ic-os' <"$targets"; then

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -177,7 +177,7 @@ jobs:
             num_targets=$(wc <"$target_pattern_file" -l)
             # if bazel targets is empty we don't need to run any tests
             if [ "$num_targets" -eq 0 ]; then
-              echo "No bazel targets to test"
+              echo "No bazel targets"
               exit 0
             fi
             echo "Testing the following $num_targets targets:"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -174,11 +174,14 @@ jobs:
               targets_args+=("--base=$BASE_SHA" "--head=$HEAD_SHA")
             fi
             "${CI_PROJECT_DIR:-}"/ci/bazel-scripts/targets.py test "${targets_args[@]}" >"$target_pattern_file"
+            num_targets=$(wc <"$target_pattern_file" -l)
             # if bazel targets is empty we don't need to run any tests
-            if [ $(wc <"$target_pattern_file" -l) -eq 0 ]; then
-              echo "No bazel targets to build"
+            if [ "$num_targets" -eq 0 ]; then
+              echo "No bazel targets to test"
               exit 0
             fi
+            echo "Testing the following $num_targets targets:"
+            cat "$target_pattern_file"
             bazel_args+=( --target_pattern_file="$target_pattern_file" )
 
             echo "Building as user: $(whoami)"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -479,6 +479,9 @@ jobs:
             fi
             ci/bazel-scripts/targets.py build "${targets_args[@]}" >"$targets"
 
+            echo "Considering the following $(wc <"$targets" -l) targets:"
+            cat "$targets"
+
             ARGS=()
 
             if grep -q '^//ic-os' <"$targets"; then


### PR DESCRIPTION
Print the targets to test in `Bazel Test All` which is useful for debugging. The output will look something like:
```
bazel query --keep_going '((((kind(".*_test", //...)) except attr(tags, long_test, //...)) + attr(tags, long_test, rdeps(//..., set(.github/workflows-source/ci-main.yml .github/workflows/ci-main.yml), 2))) + set()) except attr(tags, 'manual|system_test_large|system_test_benchmark|fuzz_test|fi_tests_nightly|nns_tests_nightly|pocketic_tests_nightly', //...)'
Testing the following 974 targets:
//:python-requirements_test
//bazel:buildifier_test
//bazel:gazelle_test
//bazel/candid_integration_tests:candid_integration_tests
//bazel/inject_version_into_wasm_tests:inspect_stamped_trivial_wasm
//ic-os/components:check_unused_components_test
...
```