### PR TITLE
chore: rm systest bazel config

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -70,8 +70,6 @@ test --test_output=errors
 
 test:precommit --build_tests_only --test_tag_filters="smoke"
 
-test:systest --test_output=streamed
-
 build:testnet --build_tag_filters=
 test:testnet --test_output=streamed --test_tag_filters=
 

--- a/ic-os/dev-tools/hostos-upgrade-tests.sh
+++ b/ic-os/dev-tools/hostos-upgrade-tests.sh
@@ -50,7 +50,7 @@ for version in "${VERSIONS[@]}"; do
     echo "Updated $REVISIONS_FILE for version $version."
 
     echo "Running hostos_upgrade_from_latest_release_to_current test for version $version ..."
-    if bazel test --config=systest //rs/tests/nested:hostos_upgrade_from_latest_release_to_current; then
+    if bazel test //rs/tests/nested:hostos_upgrade_from_latest_release_to_current; then
         echo "Test for version $version PASSED."
         results["$version"]="Passed"
     else

--- a/ic-os/guestos/README.adoc
+++ b/ic-os/guestos/README.adoc
@@ -34,7 +34,7 @@ Alternatively, Bazel can be used to perform a testnet deployment. For documentat
 
 Instead of running GuestOS locally in qemu, you can launch a GuestOS virtual machine on Farm:
 
-    bazel run --config=systest //ic-os/guestos/envs/dev:launch-remote-vm
+    bazel run --test_output=streamed //ic-os/guestos/envs/dev:launch-remote-vm
 
 The program will spin up a new GuestOS VM on Farm, and the machine can then be accessed via SSH.
 

--- a/rs/tests/README.md
+++ b/rs/tests/README.md
@@ -35,7 +35,7 @@ In order to run system tests, enter the build docker container:
 ```
 To launch a test target (`my_test_target` in this case) within the docker run:
 ```
-devenv-container$ bazel test --config=systest //rs/tests:my_test_target
+devenv-container$ bazel test --test_output=streamed //rs/tests:my_test_target
 ```
 
 In the docker container, you can also use `ict` to start tests.

--- a/rs/tests/README_NEW.md
+++ b/rs/tests/README_NEW.md
@@ -28,7 +28,7 @@ this container provides all the necessary environment setup for building and run
 ### Via native Bazel commands
 Within the docker execute:
 ```
-devenv-container$ bazel test --config=systest //rs/tests/idx:basic_health_test
+devenv-container$ bazel test --test_output=streamed //rs/tests/idx:basic_health_test
 ```
 You can provide additional [flags](https://bazel.build/reference/command-line-reference#test) to the Bazel [test](https://bazel.build/reference/command-line-reference#test) command. For example, *--test_tmpdir* would be useful, if you want to keep test artifacts (logs, ssh keys, etc.) after the test execution has finished.
 ### Via `ict` command line tool
@@ -39,7 +39,7 @@ devenv-container$ ict test //rs/tests/idx:basic_health_test
 Upon this invocation `ict` launches the test and also displays the raw Bazel command, which is called under the hood:
 ```
 Raw Bazel command to be invoked:
-$ bazel test //rs/tests/idx:basic_health_test --config=systest --cache_test_results=no
+$ bazel test //rs/tests/idx:basic_health_test --test_output=streamed --cache_test_results=no
 ```
 You can explore the functionality of the continuously developed `ict` tool by:
 ```

--- a/rs/tests/ict/cmd/testCmd.go
+++ b/rs/tests/ict/cmd/testCmd.go
@@ -41,7 +41,7 @@ func TestCommandWithConfig(cfg *Config) func(cmd *cobra.Command, args []string) 
 				return err
 			}
 		}
-		command := []string{"bazel", "test", target, "--config=systest"}
+		command := []string{"bazel", "test", target, "--test_output=streamed"}
 		command = append(command, "--cache_test_results=no")
 		// Try and sync k8s dashboards
 		cmd.Println(GREEN + "Will try to sync dashboards from k8s branch: " + cfg.k8sBranch)

--- a/rs/tests/ict/cmd/testnetCreateCmd.go
+++ b/rs/tests/ict/cmd/testnetCreateCmd.go
@@ -186,7 +186,7 @@ func TestnetCommand(cfg *TestnetConfig) func(cmd *cobra.Command, args []string) 
 				return err
 			}
 		}
-		command := []string{"bazel", "test", target, "--config=systest"}
+		command := []string{"bazel", "test", target, "--test_output=streamed"}
 		command = append(command, "--cache_test_results=no")
 		cmd.Println(GREEN + "Will try to sync dashboards from k8s branch: " + cfg.k8sBranch)
 		icDashboardsDir, err := sparse_checkout("git@github.com:dfinity-ops/k8s.git", "", []string{"bases/apps/ic-dashboards"}, cfg.k8sBranch)


### PR DESCRIPTION
The bazel `systest` config now only enables `--test_output=streamed` which is not enough to warrant a dedicated bazel config. So this commit removes the `systest` config and just sets `--test_output=streamed` where necessary.