### PR TITLE
chore: print bazel query in targets.py with proper quotes

### DIFF
--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -234,17 +234,16 @@ def check():
             if result.returncode != 0:
                 indented_error_msg = f"{indentation}" + f"\n{indentation}".join(result.stderr.strip().splitlines())
                 errors.append(f"Pattern '{pattern}' has problematic target '{target}':\n{indented_error_msg}")
-            else:
-                if len(result.stdout.splitlines()) == 0:
-                    errors.append(
-                        f"Pattern '{pattern}' with target '{target}' results in no targets after excluding all manual targets!"
-                        + (
-                            f"\n{indentation}It might be you're including the manual non-colocated variant of a system-test."
-                            + f"\n{indentation}Try '{target}_colocate' instead."
-                        )
-                        if target.startswith("//rs/tests")
-                        else ""
+            elif len(result.stdout.splitlines()) == 0:
+                errors.append(
+                    f"Pattern '{pattern}' with target '{target}' results in no targets after excluding all manual targets!"
+                    + (
+                        f"\n{indentation}It might be you're including the manual non-colocated variant of a system-test."
+                        + f"\n{indentation}Try '{target}_colocate' instead."
                     )
+                    if target.startswith("//rs/tests")
+                    else ""
+                )
 
     n = len(errors)
     if n > 0:

--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -179,7 +179,7 @@ def targets(command: str, skip_long_tests: bool, base: str | None, head: str | N
 
     # Finally, exclude targets that have any of the excluded tags:
     excluded_tags_regex = "|".join(EXCLUDED_TAGS)
-    query = f"({query}) except attr(tags, '{excluded_tags_regex}', //...)"
+    query = f'({query}) except attr(tags, "{excluded_tags_regex}", //...)'
 
     log(f"bazel query --keep_going '{query}'")
     result = subprocess.run(["bazel", "query", "--keep_going", query], stderr=subprocess.PIPE, text=True)
@@ -227,7 +227,7 @@ def check():
 
         for target in explicit_targets_for_pattern:
             excluded_tags_regex = "|".join(EXCLUDED_TAGS)
-            query = f"({target}) except attr(tags, '{excluded_tags_regex}', //...)"
+            query = f'({target}) except attr(tags, "{excluded_tags_regex}", //...)'
             result = subprocess.run(["bazel", "query", query], capture_output=True, text=True)
             if result.returncode != 0:
                 indented_error_msg = f"{indentation}" + f"\n{indentation}".join(result.stderr.strip().splitlines())

--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -126,7 +126,7 @@ def diff_only_query(command: str, base: str, head: str, skip_long_tests: bool) -
     # The files matching the all_targets_globs are typically not depended upon by any bazel target
     # but will determine which bazel targets there are in the first place so in case they're modified
     # simply return all bazel targets. Otherwise return all targets that depend on the modified files.
-    mfiles = " ".join(modified_files)
+    mfiles = " ".join(f'"{f}"' for f in modified_files)
     query = (
         "//..."
         if any(len(fnmatch.filter(modified_files, glob)) > 0 for glob in all_targets_globs)

--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -22,6 +22,7 @@
 
 import argparse
 import fnmatch
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -181,8 +182,9 @@ def targets(command: str, skip_long_tests: bool, base: str | None, head: str | N
     excluded_tags_regex = "|".join(EXCLUDED_TAGS)
     query = f'({query}) except attr(tags, "{excluded_tags_regex}", //...)'
 
-    log(f"bazel query --keep_going '{query}'")
-    result = subprocess.run(["bazel", "query", "--keep_going", query], stderr=subprocess.PIPE, text=True)
+    args = ["bazel", "query", "--keep_going", query]
+    log(shlex.join(args))
+    result = subprocess.run(args, stderr=subprocess.PIPE, text=True)
 
     # As described above, when the query contains files not tracked by bazel,
     # --keep_going will ignore them but will return the special exit code 3 which we ignore:

--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -18,7 +18,7 @@
 #
 # The script will print the bazel query to stderr which is useful for debugging:
 #   ci/bazel-scripts/targets.py --skip_long_tests --base=master test
-#   bazel query --keep_going '(((kind(".*_test", //...)) except attr(tags, long_test, //...)) + set(//pre-commit:shfmt-check //pre-commit:ruff-lint)) except attr(tags, manual, //...)'
+#   bazel query --keep_going '((((kind(".*_test", rdeps(//..., set("ci/bazel-scripts/targets.py")))) except attr(tags, long_test, //...)) + attr(tags, long_test, rdeps(//..., set("ci/bazel-scripts/targets.py"), 2))) + set(//pre-commit:ruff-lint)) except attr(tags, "manual|system_test_large|system_test_benchmark|fuzz_test|fi_tests_nightly|nns_tests_nightly|pocketic_tests_nightly", //...)'
 
 import argparse
 import fnmatch

--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -45,7 +45,7 @@ EXCLUDED_TAGS = [
 
 # Return all bazel targets (//...) sans the long_tests (if --skip_long_tests is specified)
 # in case any file is modified matching any of the following globs:
-all_targets_globs = [
+ALL_TARGETS_BLOBS = [
     ".bazelrc",
     ".bazelversion",
     ".github/*",
@@ -112,7 +112,7 @@ def load_explicit_targets() -> dict[str, Set[str]]:
 def diff_only_query(command: str, base: str, head: str, skip_long_tests: bool) -> str:
     """
     Return a bazel query for all targets that have modified inputs in the specified git commit range. Taking into account:
-    * To return all targets in case files matching all_targets_globs are modified.
+    * To return all targets in case files matching ALL_TARGETS_BLOBS are modified.
     * To only include test targets in case the bazel command was 'test'.
     * To exclude long_tests if requested.
     """
@@ -124,13 +124,13 @@ def diff_only_query(command: str, base: str, head: str, skip_long_tests: bool) -
     for file in modified_files:
         log(file)
 
-    # The files matching the all_targets_globs are typically not depended upon by any bazel target
+    # The files matching the ALL_TARGETS_BLOBS are typically not depended upon by any bazel target
     # but will determine which bazel targets there are in the first place so in case they're modified
     # simply return all bazel targets. Otherwise return all targets that depend on the modified files.
     mfiles = " ".join(f'"{f}"' for f in modified_files)
     query = (
         "//..."
-        if any(len(fnmatch.filter(modified_files, glob)) > 0 for glob in all_targets_globs)
+        if any(len(fnmatch.filter(modified_files, glob)) > 0 for glob in ALL_TARGETS_BLOBS)
         # Note that modified_files may contain files not depended upon by any bazel target.
         # `bazel query --keep_going` will ignore those but will return the special exit code 3
         # in case this happens which we check for below.


### PR DESCRIPTION
Previously the bazel query printed by `targets.py` would wrap the `excluded_tags_regex` in single quotes which would conflict with the single quotes around the whole query preventing easy copy/paste/run in your terminal. So this fixes that by wrapping the  `excluded_tags_regex` in double quotes instead.

Additionally this wraps the modified files (`mfiles`) appearing in the query in double quotes as well to allow files with spaces. We could do even better by doing various kinds of escaping but this is good enough for now. 

Now the printed query looks like:
```
bazel query --keep_going '((((kind(".*_test", rdeps(//..., set("ci/bazel-scripts/targets.py")))) except attr(tags, long_test, //...)) + attr(tags, long_test, rdeps(//..., set("ci/bazel-scripts/targets.py"), 2))) + set(//pre-commit:ruff-lint)) except attr(tags, "manual|system_test_large|system_test_benchmark|fuzz_test|fi_tests_nightly|nns_tests_nightly|pocketic_tests_nightly", //...)'
```