### PR TITLE
chore: Add exclusive filtering to MixedHashTree

### DIFF
--- a/rs/crypto/tree_hash/src/lib.rs
+++ b/rs/crypto/tree_hash/src/lib.rs
@@ -669,6 +669,14 @@ pub enum FilterBuilder {
     Pruned(Digest),
 }
 
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+enum FilterMode {
+    /// The paths in the filter are kept, everything else is pruned.
+    Keep,
+    /// The paths in the filter are pruned, everything else is kept.
+    Prune,
+}
+
 impl FilterBuilder {
     pub fn digest(&self) -> &Digest {
         match self {
@@ -698,14 +706,16 @@ impl FilterBuilder {
         }
     }
 
-    /// Returns a [`MixedHashTree`] with everything pruned except the paths in `filter`.
-    pub fn filtered(
+    /// Common code of [`filtered`] and [`pruned`], as they both have the same recursion with the decisions to prune or keep a subtree flipped.
+    fn filtered_impl(
         &self,
         filter: &LabeledTree<()>,
+        filter_mode: FilterMode,
     ) -> Result<MixedHashTree, MixedHashTreeFilterError> {
         fn filtered_inner(
             tree: &FilterBuilder,
             filter: &LabeledTree<()>,
+            filter_mode: FilterMode,
             depth: u8,
         ) -> Result<MixedHashTree, MixedHashTreeFilterError> {
             if depth > MAX_HASH_TREE_DEPTH {
@@ -713,15 +723,18 @@ impl FilterBuilder {
             }
 
             match (tree, filter) {
+                // If the path in `filter` ends, we keep the entire subtree if `FilterMode::Keep` and prune it otherwise.
+                (_, LabeledTree::Leaf(_)) => match filter_mode {
+                    FilterMode::Keep => Ok(tree.mixed_hash_tree()),
+                    FilterMode::Prune => Ok(MixedHashTree::Pruned(tree.digest().clone())),
+                },
                 // Pruned and empty subtrees are always kept.
                 (FilterBuilder::Empty(_), _) => Ok(tree.mixed_hash_tree()),
                 (FilterBuilder::Pruned(_), _) => Ok(tree.mixed_hash_tree()),
-                // Path ends in an inner node so we simply keep the entire subtree.
-                (_, LabeledTree::Leaf(_)) => Ok(tree.mixed_hash_tree()),
                 // On a fork, filter both sides.
                 (FilterBuilder::Fork(digest, b), filter) => {
-                    let l = filtered_inner(&b.0, filter, depth + 1)?;
-                    let r = filtered_inner(&b.1, filter, depth + 1)?;
+                    let l = filtered_inner(&b.0, filter, filter_mode, depth + 1)?;
+                    let r = filtered_inner(&b.1, filter, filter_mode, depth + 1)?;
 
                     // If both branches are pruned, prune the node instead.
                     match (&l, &r) {
@@ -735,13 +748,26 @@ impl FilterBuilder {
                 (FilterBuilder::Labeled(digest, label, inner), LabeledTree::SubTree(flat_map)) => {
                     match flat_map.get(label) {
                         Some(subfilter) => {
-                            let mixed_hash_tree = filtered_inner(inner, subfilter, depth + 1)?;
-                            Ok(MixedHashTree::Labeled(
-                                label.clone(),
-                                Box::new(mixed_hash_tree),
-                            ))
+                            if filter_mode == FilterMode::Prune
+                                && matches!(subfilter, LabeledTree::Leaf(_))
+                            {
+                                // A path in `filter` ends here, so we prune this subtree including the label.
+                                Ok(MixedHashTree::Pruned(digest.clone()))
+                            } else {
+                                // Otherwise it's simply recursive.
+                                let mixed_hash_tree =
+                                    filtered_inner(inner, subfilter, filter_mode, depth + 1)?;
+                                Ok(MixedHashTree::Labeled(
+                                    label.clone(),
+                                    Box::new(mixed_hash_tree),
+                                ))
+                            }
                         }
-                        None => Ok(MixedHashTree::Pruned(digest.clone())),
+                        // The path is not in `filter`.
+                        None => match filter_mode {
+                            FilterMode::Keep => Ok(MixedHashTree::Pruned(digest.clone())),
+                            FilterMode::Prune => Ok(tree.mixed_hash_tree()),
+                        },
                     }
                 }
                 // The tree ends in a leaf, but the path still continues. Invalid input.
@@ -751,7 +777,25 @@ impl FilterBuilder {
             }
         }
 
-        filtered_inner(self, filter, 0)
+        filtered_inner(self, filter, filter_mode, 0)
+    }
+
+    /// Returns a [`MixedHashTree`] with everything pruned except the paths in `filter`.
+    /// See also [`pruned`].
+    pub fn filtered(
+        &self,
+        filter: &LabeledTree<()>,
+    ) -> Result<MixedHashTree, MixedHashTreeFilterError> {
+        self.filtered_impl(filter, FilterMode::Keep)
+    }
+
+    /// Returns a [`MixedHashTree`] with everything in `paths` pruned.
+    /// See also [`filtered`].
+    pub fn pruned(
+        &self,
+        paths: &LabeledTree<()>,
+    ) -> Result<MixedHashTree, MixedHashTreeFilterError> {
+        self.filtered_impl(paths, FilterMode::Prune)
     }
 }
 

--- a/rs/crypto/tree_hash/tests/tree_hash.rs
+++ b/rs/crypto/tree_hash/tests/tree_hash.rs
@@ -3425,3 +3425,88 @@ fn filtered_mixed_hash_tree() {
         Err(MixedHashTreeFilterError::PathTooLong)
     );
 }
+
+#[test]
+fn pruned_mixed_hash_tree() {
+    let label_a = Label::from("label_a");
+    let label_a_3 = Label::from("label_a_3");
+    let label_a_3_2 = Label::from("label_a_3_2");
+    let label_b = Label::from("label_b");
+    let label_b_2 = Label::from("label_b_2");
+    let label_b_4 = Label::from("label_b_4");
+    let label_b_4_3 = Label::from("label_b_4_3");
+    let label_c = Label::from("label_c");
+
+    let subtree_a_3_map = flatmap!(
+        label_a_3_2 => LabeledTree::Leaf(Vec::from("contents_a_3_2")));
+    let subtree_a_map = flatmap!(
+        label_a_3.clone() => LabeledTree::SubTree(subtree_a_3_map),
+    );
+    let subtree_b_4_map = flatmap!(
+        label_b_4_3 => LabeledTree::Leaf(Vec::from("contents_b_4_3")));
+    let subtree_b_map = flatmap!(
+        label_b_2.clone() => LabeledTree::SubTree(FlatMap::new()),
+        label_b_4 => LabeledTree::SubTree(subtree_b_4_map.clone()),
+    );
+    let root_map = flatmap!(
+        label_a.clone() => LabeledTree::SubTree(subtree_a_map.clone()),
+        label_b.clone() => LabeledTree::SubTree(subtree_b_map),
+        label_c => LabeledTree::Leaf(Vec::from("contents_c")),
+    );
+    let partial_tree = LabeledTree::SubTree(root_map);
+
+    let builder = tree_with_three_levels();
+    let witness_generator = builder.witness_generator().unwrap();
+    let mixed_hash_tree = witness_generator.mixed_hash_tree(&partial_tree).unwrap();
+    let digest = mixed_hash_tree.digest();
+    assert_eq!(*witness_generator.hash_tree().digest(), digest);
+
+    let filter_builder = mixed_hash_tree.filter_builder();
+    assert_eq!(filter_builder.digest(), &digest);
+
+    let dropped_paths = sparse_labeled_tree_from_paths(&[
+        Path::from(vec![
+            "label_a".into(),
+            "label_a_3".into(),
+            "label_a_3_2".into(),
+        ]),
+        Path::from(vec!["label_b".into(), "label_b_4".into()]),
+        Path::from(vec!["label_c".into()]),
+    ])
+    .unwrap();
+
+    let filtered_hash_tree = filter_builder.pruned(&dropped_paths).unwrap();
+
+    assert_eq!(digest, filtered_hash_tree.digest());
+
+    let subtree_a_map_filtered = flatmap!(
+        label_a_3 => LabeledTree::SubTree(FlatMap::new()),
+    );
+
+    let subtree_b_map_filtered = flatmap!(
+        label_b_2 => LabeledTree::SubTree(FlatMap::new()),
+    );
+    let smaller_root_map = flatmap!(
+        label_a => LabeledTree::SubTree(subtree_a_map_filtered),
+        label_b => LabeledTree::SubTree(subtree_b_map_filtered),
+    );
+    let smaller_partial_tree = LabeledTree::SubTree(smaller_root_map);
+
+    let expected_hash_tree = witness_generator
+        .mixed_hash_tree(&smaller_partial_tree)
+        .unwrap();
+    assert_eq!(expected_hash_tree, filtered_hash_tree);
+
+    let too_long_partial_tree = sparse_labeled_tree_from_paths(&[Path::from(vec![
+        "label_a".into(),
+        "label_a_3".into(),
+        "label_a_3_2".into(),
+        "too_long".into(),
+    ])])
+    .unwrap();
+
+    assert_eq!(
+        filter_builder.pruned(&too_long_partial_tree),
+        Err(MixedHashTreeFilterError::PathTooLong)
+    );
+}


### PR DESCRIPTION
Previously, commit 09a91114ebaf633d7a8dd9785838ba673533eae4 introduced a way to prune a `MixedHashTree` further by providing an inclusive list of paths to keep, and anything not in the filter would be pruned. This functionality was then used to implement new HTTP endpoints in commit cb4878c4688c1e2d669f6245ff0e33c78660c57e.

This commit now provides a variant API `pruned`, where the input is instead an exclusive list of paths to prune, and any path not mentioned in the input is kept instead. It is intended as a more ergonomic helper function in some use cases and will be used for upcoming changes to the new HTTP endpoints.