### PR TITLE
feat(proposal-cli): create forum topic for canister upgrade proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10538,6 +10538,7 @@ dependencies = [
  "strum_macros 0.26.4",
  "tempfile",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/rs/cross-chain/proposal-cli/BUILD.bazel
+++ b/rs/cross-chain/proposal-cli/BUILD.bazel
@@ -16,6 +16,7 @@ DEPENDENCIES = [
     "@crate_index//:strum",
     "@crate_index//:tempfile",
     "@crate_index//:tokio",
+    "@crate_index//:url",
 ]
 
 MACRO_DEPENDENCIES = [

--- a/rs/cross-chain/proposal-cli/BUILD.bazel
+++ b/rs/cross-chain/proposal-cli/BUILD.bazel
@@ -8,6 +8,7 @@ DEPENDENCIES = [
     "@crate_index//:clap",
     "@crate_index//:futures",
     "@crate_index//:hex",
+    "@crate_index//:maplit",
     "@crate_index//:reqwest",
     "@crate_index//:serde",
     "@crate_index//:serde_json",

--- a/rs/cross-chain/proposal-cli/Cargo.toml
+++ b/rs/cross-chain/proposal-cli/Cargo.toml
@@ -22,6 +22,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/rs/cross-chain/proposal-cli/Cargo.toml
+++ b/rs/cross-chain/proposal-cli/Cargo.toml
@@ -13,6 +13,7 @@ candid_parser = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+maplit = "1.0.2"
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rs/cross-chain/proposal-cli/README.adoc
+++ b/rs/cross-chain/proposal-cli/README.adoc
@@ -47,7 +47,7 @@ As part of the Voting Neuron Grants season 2, teams submitting canister upgrade 
 
 Once the proposal is published, the corresponding proposal ID can be used to create an appropriate forum topic.
 
-NOTE: Using this functionality requires having an API key and username for the https://forum.dfinity.org/[DFINITY developer forum].
+NOTE: Using this functionality requires having an API key and username for the https://forum.dfinity.org/[DFINITY developer forum]. See the https://docs.discourse.org/[Discourse API] for more information.
 
 .Create a new forum topic for a single canister upgrade proposal (ckETH minter)
 ====

--- a/rs/cross-chain/proposal-cli/README.adoc
+++ b/rs/cross-chain/proposal-cli/README.adoc
@@ -40,3 +40,27 @@ bazel run //rs/cross-chain/proposal-cli:make_proposal -- upgrade cketh-ledger --
 . Candid encoding of the given uprade arguments or use default empty ones.
 . Generates a proposal summary based on the previous information, where only the Motivation section remains to be (manually) filled out.
 . Generates a shell script to submit the proposal using the `ic-admin` command-line tool.
+
+== Create a Forum Topic
+
+As part of the Voting Neuron Grants season 2, teams submitting canister upgrade proposals are required to https://forum.dfinity.org/t/nns-proposal-discussions/34492[create a forum topic] for every proposal or group of proposals in the https://forum.dfinity.org/c/governance/nns-proposal-discussions/76[NNS proposal discussions] category with the tag https://forum.dfinity.org/tags/c/governance/nns-proposal-discussions/76/application-canister-mgmt[Application-canister-mgmt].
+
+Once the proposal is published, the corresponding proposal ID can be used to create an appropriate forum topic.
+
+NOTE: Using this functionality requires having an API key and username for the https://forum.dfinity.org/[DFINITY developer forum].
+
+.Create a new forum topic for a single canister upgrade proposal (ckETH minter)
+====
+[source,shell]
+----
+bazel run //rs/cross-chain/proposal-cli:make_proposal -- create-forum-post --api-key "1234" --api-user "team" 136787
+----
+====
+
+.Create a new forum topic for multiple canister upgrade proposals (ckBTC ledger suite)
+====
+[source,shell]
+----
+bazel run //rs/cross-chain/proposal-cli:make_proposal -- create-forum-post --api-key "1234" --api-user "team" 137359 137360 137361
+----
+====

--- a/rs/cross-chain/proposal-cli/src/canister/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/mod.rs
@@ -1,11 +1,12 @@
 #[cfg(test)]
 mod tests;
 
+use candid::Principal;
 use std::fmt::Display;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
-use strum_macros::EnumIter;
+use strum_macros::{EnumCount, EnumIter};
 
 pub enum DownloadableFile {
     /// For cases where the file is stored locally.
@@ -14,7 +15,7 @@ pub enum DownloadableFile {
     Remote { url: String },
 }
 
-#[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd, EnumIter)]
+#[derive(Clone, Eq, PartialEq, Debug, Ord, PartialOrd, EnumIter, EnumCount)]
 #[allow(clippy::enum_variant_names)]
 pub enum TargetCanister {
     BtcChecker,
@@ -351,6 +352,38 @@ impl TargetCanister {
                 url: "https://raw.githubusercontent.com/dfinity/cycles-ledger/6aaf0cb2bf96fe6a9b117cc9c7aa832574c6427a/canister_ids.json".to_string()
             },
         }
+    }
+
+    pub fn canister_id(&self) -> Principal {
+        let principal = match self {
+            TargetCanister::BtcChecker => "oltsj-fqaaa-aaaar-qal5q-cai",
+            TargetCanister::CkBtcArchive => "nbsys-saaaa-aaaar-qaaga-cai",
+            TargetCanister::CkBtcIndex => "n5wcd-faaaa-aaaar-qaaea-cai",
+            TargetCanister::CkBtcLedger => "mxzaz-hqaaa-aaaar-qaada-cai",
+            TargetCanister::CkBtcMinter => "mqygn-kiaaa-aaaar-qaadq-cai",
+            TargetCanister::CkEthArchive => "xob7s-iqaaa-aaaar-qacra-cai",
+            TargetCanister::CkEthIndex => "s3zol-vqaaa-aaaar-qacpa-cai",
+            TargetCanister::CkEthLedger => "ss2fx-dyaaa-aaaar-qacoq-cai",
+            TargetCanister::CkEthMinter => "sv3dd-oaaaa-aaaar-qacoa-cai",
+            TargetCanister::IcpArchive1 => "qjdve-lqaaa-aaaaa-aaaeq-cai",
+            TargetCanister::IcpArchive2 => "qsgjb-riaaa-aaaaa-aaaga-cai",
+            TargetCanister::IcpArchive3 => "q4eej-kyaaa-aaaaa-aaaha-cai",
+            TargetCanister::IcpArchive4 => "q3fc5-haaaa-aaaaa-aaahq-cai",
+            TargetCanister::IcpIndex => "qhbym-qaaaa-aaaaa-aaafq-cai",
+            TargetCanister::IcpLedger => "ryjl3-tyaaa-aaaaa-aaaba-cai",
+            TargetCanister::LedgerSuiteOrchestrator => "vxkom-oyaaa-aaaar-qafda-cai",
+            TargetCanister::EvmRpc => "7hfb6-caaaa-aaaar-qadga-cai",
+            TargetCanister::CyclesLedger => "um5iw-rqaaa-aaaaq-qaaba-cai",
+            TargetCanister::CyclesIndex => "ul4oc-4iaaa-aaaaq-qaabq-cai",
+            TargetCanister::ExchangeRateCanister => "uf6dk-hyaaa-aaaaq-qaaaq-cai",
+            TargetCanister::SolRpc => "tghme-zyaaa-aaaar-qarca-cai",
+        };
+        Principal::from_text(principal).unwrap()
+    }
+
+    pub fn find_by_id(canister_id: &Principal) -> Option<Self> {
+        use strum::IntoEnumIterator;
+        TargetCanister::iter().find(|c| &c.canister_id() == canister_id)
     }
 
     pub fn default_upgrade_args(&self) -> String {

--- a/rs/cross-chain/proposal-cli/src/canister/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/canister/tests.rs
@@ -1,1 +1,10 @@
-//TODO
+use crate::canister::TargetCanister;
+use std::collections::BTreeSet;
+use strum::{EnumCount, IntoEnumIterator};
+
+#[test]
+fn should_have_unique_canister_ids() {
+    let all_canister_ids: BTreeSet<_> = TargetCanister::iter().map(|c| c.canister_id()).collect();
+
+    assert_eq!(all_canister_ids.len(), TargetCanister::COUNT)
+}

--- a/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
@@ -4,9 +4,11 @@ mod responses;
 #[cfg(test)]
 mod tests;
 
-use crate::dashboard::responses::CanisterInfo;
+use crate::dashboard::responses::{CanisterInfo, ProposalInfo};
 use candid::Principal;
+use reqwest::StatusCode;
 use std::collections::BTreeSet;
+use std::time::Duration;
 
 pub struct DashboardClient {
     client: reqwest::Client,
@@ -42,5 +44,39 @@ impl DashboardClient {
             fut.push(self.list_canister_upgrade_proposals(canister_id));
         }
         futures::future::join_all(fut).await
+    }
+
+    /// Retrieve a given proposal by ID.
+    ///
+    /// When the proposal was recently submitted, the dashboard API may need some time
+    /// to catch up, so that retries are maybe necessary.
+    pub async fn retrieve_proposal(&self, proposal_id: u64) -> ProposalInfo {
+        let url = format!("{}/proposals/{}", self.base_url, proposal_id);
+        let num_retries = 5;
+        let sleep_duration = Duration::from_secs(5);
+        for i in 1..=num_retries {
+            let response = self.client.get(&url).send().await.unwrap();
+            match response.status() {
+                StatusCode::OK => {
+                    let proposal: ProposalInfo = response.json().await.unwrap();
+                    assert_eq!(proposal.proposal_id, proposal_id);
+                    println!("Found proposal {proposal_id}");
+                    return proposal;
+                }
+                StatusCode::NOT_FOUND => {
+                    let delay = sleep_duration * i;
+                    println!(
+                        "Proposal {proposal_id} not found, retrying in {}s",
+                        delay.as_secs()
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                error_status => {
+                    panic!("Error when retrieving proposal {proposal_id}. Received response {response:?} with status code {error_status}")
+                }
+            }
+        }
+        panic!("Unable to retrieve proposal {proposal_id} after {num_retries} attempts.");
     }
 }

--- a/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
@@ -48,10 +48,7 @@ impl DashboardClient {
     }
 
     pub async fn retrieve_proposal_batch(&self, proposal_ids: &[u64]) -> Vec<ProposalInfo> {
-        let mut fut = Vec::with_capacity(proposal_ids.len());
-        for proposal_id in proposal_ids {
-            fut.push(self.retrieve_proposal(proposal_id));
-        }
+        let fut = proposal_ids.iter().map(|id| self.retrieve_proposal(id));
         futures::future::join_all(fut).await
     }
 

--- a/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 use crate::dashboard::responses::CanisterInfo;
 use candid::Principal;
 use reqwest::StatusCode;
-pub(crate) use responses::ProposalInfo;
+pub(crate) use responses::{ProposalInfo, ProposalPayloadInfo};
 use std::collections::BTreeSet;
 use std::time::Duration;
 

--- a/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/dashboard/mod.rs
@@ -4,9 +4,10 @@ mod responses;
 #[cfg(test)]
 mod tests;
 
-use crate::dashboard::responses::{CanisterInfo, ProposalInfo};
+use crate::dashboard::responses::CanisterInfo;
 use candid::Principal;
 use reqwest::StatusCode;
+pub(crate) use responses::ProposalInfo;
 use std::collections::BTreeSet;
 use std::time::Duration;
 

--- a/rs/cross-chain/proposal-cli/src/dashboard/responses.rs
+++ b/rs/cross-chain/proposal-cli/src/dashboard/responses.rs
@@ -42,3 +42,15 @@ impl CanisterUpgradeInfo {
             .expect("Failed to parse proposal id into a u64")
     }
 }
+
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
+pub struct ProposalInfo {
+    pub proposal_id: u64,
+    pub payload: ProposalPayloadInfo,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
+pub struct ProposalPayloadInfo {
+    pub canister_id: String,
+    pub install_mode_name: String,
+}

--- a/rs/cross-chain/proposal-cli/src/dashboard/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/dashboard/tests.rs
@@ -1,5 +1,5 @@
 mod deser {
-    use crate::dashboard::responses::CanisterInfo;
+    use crate::dashboard::responses::{CanisterInfo, ProposalInfo, ProposalPayloadInfo};
     use maplit::btreeset;
 
     #[test]
@@ -129,5 +129,309 @@ mod deser {
         let canister_info: CanisterInfo =
             serde_json::from_str(json_info_with_integer_proposal_id).unwrap();
         assert_eq!(canister_info.list_upgrade_proposals(), btreeset! {131388});
+    }
+
+    #[test]
+    fn should_deserialize_proposal_info() {
+        //raw output of curl https://ic-api.internetcomputer.org/api/v3/proposals/137875
+        let json_info = r##"
+        {
+            "action": "InstallCode",
+            "action_nns_function": null,
+            "deadline_timestamp_seconds": 1755462381,
+            "decided_timestamp_seconds": 1755180499,
+            "executed_timestamp_seconds": 1755180499,
+            "failed_timestamp_seconds": 0,
+            "failure_reason": null,
+            "id": 118001,
+            "known_neurons_ballots": [
+              {
+                "id": "27",
+                "name": "DFINITY Foundation",
+                "vote": 1
+              },
+              {
+                "id": "4966884161088437903",
+                "name": "Synapse.vote (original)",
+                "vote": 1
+              },
+              {
+                "id": "5967494994762486275",
+                "name": "Arthur’s Neuron (used to be cycle_dao)",
+                "vote": 1
+              },
+              {
+                "id": "14231996777861930328",
+                "name": "ICDevs.org",
+                "vote": 1
+              },
+              {
+                "id": "428687636340283207",
+                "name": "CryptoIsGood",
+                "vote": 1
+              },
+              {
+                "id": "10843833286193887500",
+                "name": "Anvil",
+                "vote": 1
+              },
+              {
+                "id": "55674167450360693",
+                "name": "ICPL.app",
+                "vote": 1
+              },
+              {
+                "id": "7766735497505253681",
+                "name": "Inactive (Request Removal) - The Fools' Court",
+                "vote": 0
+              },
+              {
+                "id": "12860062727199510685",
+                "name": "ysyms",
+                "vote": 1
+              },
+              {
+                "id": "8959053254051540391",
+                "name": "The Accumulators’ Neuron",
+                "vote": 1
+              },
+              {
+                "id": "6362091663310642824",
+                "name": "RawTech Venture",
+                "vote": 1
+              },
+              {
+                "id": "8777656085298269769",
+                "name": "Paul Young",
+                "vote": 0
+              },
+              {
+                "id": "5728549712200490799",
+                "name": "ICPMANUAL",
+                "vote": 0
+              },
+              {
+                "id": "13538714184009896865",
+                "name": "8yeargangDAO",
+                "vote": 1
+              },
+              {
+                "id": "12911334408382674412",
+                "name": "John Wiegley",
+                "vote": 0
+              },
+              {
+                "id": "13765488517578645474",
+                "name": "Isaac Valadez",
+                "vote": 1
+              },
+              {
+                "id": "5944070935127277981",
+                "name": "Krzysztof Żelazko",
+                "vote": 1
+              },
+              {
+                "id": "12890113924500239096",
+                "name": "Always Rejects",
+                "vote": 0
+              },
+              {
+                "id": "11053086394920719168",
+                "name": "Nicolas.ic",
+                "vote": 2
+              },
+              {
+                "id": "16335946240875077438",
+                "name": "Smaug’s Neuron for Retail Investors",
+                "vote": 1
+              },
+              {
+                "id": "11595773061053702367",
+                "name": "ICLight.io",
+                "vote": 0
+              },
+              {
+                "id": "5553849921138062661",
+                "name": "Synapse.vote (NEW)",
+                "vote": 1
+              },
+              {
+                "id": "16737374299031693047",
+                "name": "Taggr Network",
+                "vote": 2
+              },
+              {
+                "id": "2649066124191664356",
+                "name": "CodeGov",
+                "vote": 1
+              },
+              {
+                "id": "10323780370508631162",
+                "name": "Sonic AMM",
+                "vote": 0
+              },
+              {
+                "id": "6914974521667616512",
+                "name": "Rakeoff.io",
+                "vote": 1
+              },
+              {
+                "id": "11974742799838195634",
+                "name": "$STACK",
+                "vote": 0
+              },
+              {
+                "id": "17682165960669268263",
+                "name": "OpenChat",
+                "vote": 1
+              },
+              {
+                "id": "4714336137769716208",
+                "name": "ELNA AI",
+                "vote": 0
+              },
+              {
+                "id": "1767081890685465163",
+                "name": "GEEKFACTORY",
+                "vote": 1
+              },
+              {
+                "id": "2776371642396604393",
+                "name": "ICP Hub México",
+                "vote": 0
+              },
+              {
+                "id": "5132308922522452058",
+                "name": "ICP Hub Poland",
+                "vote": 1
+              },
+              {
+                "id": "7902983898778678943",
+                "name": "Jerry Banfield",
+                "vote": 1
+              },
+              {
+                "id": "433047053926084807",
+                "name": "WaterNeuron",
+                "vote": 1
+              },
+              {
+                "id": "1100477100620240869",
+                "name": "ICP Hub Bulgaria",
+                "vote": 0
+              },
+              {
+                "id": "7446549063176501841",
+                "name": "Gold DAO",
+                "vote": 1
+              },
+              {
+                "id": "8571487073262291504",
+                "name": "NeuronPool",
+                "vote": 1
+              },
+              {
+                "id": "16459595263909468577",
+                "name": "LORIMER ♾️ 🐶",
+                "vote": 1
+              },
+              {
+                "id": "16122208542864232355",
+                "name": "B3Pay",
+                "vote": 1
+              },
+              {
+                "id": "3172308420039087400",
+                "name": "ZenithCode",
+                "vote": 0
+              },
+              {
+                "id": "12093733865587997066",
+                "name": "Aviate Labs",
+                "vote": 0
+              },
+              {
+                "id": "4713806069430754115",
+                "name": "D-QUORUM",
+                "vote": 1
+              },
+              {
+                "id": "16673157401414569992",
+                "name": "Yuku AI",
+                "vote": 0
+              },
+              {
+                "id": "3099449518038519101",
+                "name": "Cosmicrafts",
+                "vote": 1
+              },
+              {
+                "id": "5371276303191057244",
+                "name": "1e0",
+                "vote": 1
+              },
+              {
+                "id": "33138099823745946",
+                "name": "CO.DELTA △",
+                "vote": 1
+              },
+              {
+                "id": "12977943926061800402",
+                "name": "DragginCorp",
+                "vote": 1
+              },
+              {
+                "id": "1637856224910350276",
+                "name": "Gwojda",
+                "vote": 1
+              },
+              {
+                "id": "2334327054503903846",
+                "name": "Thyassa",
+                "vote": 1
+              }
+            ],
+            "latest_tally": {
+              "no": 63497607294091,
+              "timestamp_seconds": 1755460866,
+              "total": 46334384189105008,
+              "yes": 42674270141132169
+            },
+            "payload": {
+              "arg_hash": "0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e",
+              "canister_id": "mqygn-kiaaa-aaaar-qaadq-cai",
+              "install_mode": 3,
+              "install_mode_name": "CANISTER_INSTALL_MODE_UPGRADE",
+              "skip_stopping_before_installing": false,
+              "wasm_module_hash": "b9688aed7377dc6ec4ec33cb303d73355ee47f2a1faea2bfc111abe2c7fa3186"
+            },
+            "proposal_id": 137875,
+            "proposal_timestamp_seconds": 1755116781,
+            "proposer": "17212304975669116357",
+            "reject_cost_e8s": 2500000000,
+            "reward_status": "SETTLED",
+            "settled_at": 1755532800,
+            "status": "EXECUTED",
+            "summary": "# Proposal to upgrade the ckBTC minter canister\n\nRepository: `https://github.com/dfinity/ic.git`\n\nGit hash: `1db8f933fdadc81a90e7db2389b081e21263a9b6`\n\nNew compressed Wasm hash: `b9688aed7377dc6ec4ec33cb303d73355ee47f2a1faea2bfc111abe2c7fa3186`\n\nUpgrade args hash: `0fee102bd16b053022b69f2c65fd5e2f41d150ce9c214ac8731cfaf496ebda4e`\n\nTarget canister: `mqygn-kiaaa-aaaar-qaadq-cai`\n\nPrevious ckBTC minter proposal: https://dashboard.internetcomputer.org/proposal/137163\n\n---\n\n## Motivation\n\nUpgrade the ckBTC minter to ensure that a transaction signed by the minter does not use too many inputs.\nOtherwise, the resulting transaction may be *non-standard* as the resulting transaction size may be above 100k vbytes,\nwhich implies that the transaction will not be relayed by Bitcoin nodes and this transaction will be effectively stuck.\nThis is currently the case for transaction `87ebf46e400a39e5ec22b28515056a3ce55187dba9669de8300160ac08f64c30`.\n\nThis is a stop-gap solution until a proper solution is implemented.\n\n## Release Notes\n\n```\ngit log --format='%C(auto) %h %s' 47c5931cdafd82167feee85faf1e1dffa30fc3d8..1db8f933fdadc81a90e7db2389b081e21263a9b6 -- rs/bitcoin/ckbtc/minter\n1db8f933fd fix(ckbtc): prevent signing transaction with too many inputs (#6260)\n55ec0283bb build: update ic0 to v1.0.0. (#6216)\n ```\n\n## Upgrade args\n\n```\ngit fetch\ngit checkout 1db8f933fdadc81a90e7db2389b081e21263a9b6\ndidc encode '()' | xxd -r -p | sha256sum\n```\n\n## Wasm Verification\n\nVerify that the hash of the gzipped WASM matches the proposed hash.\n\n```\ngit fetch\ngit checkout 1db8f933fdadc81a90e7db2389b081e21263a9b6\n\"./ci/container/build-ic.sh\" \"--canisters\"\nsha256sum ./artifacts/canisters/ic-ckbtc-minter.wasm.gz\n```\n",
+            "title": "Upgrade NNS Canister: mqygn-kiaaa-aaaar-qaadq-cai to wasm with hash: b9688aed7377dc6ec4ec33cb303d73355ee47f2a1faea2bfc111abe2c7fa3186",
+            "topic": "TOPIC_NETWORK_CANISTER_MANAGEMENT",
+            "total_potential_voting_power": 50559286701411626,
+            "updated_at": "2025-08-18T16:01:25.884819",
+            "url": ""
+        }
+        "##;
+
+        let proposal_info: ProposalInfo = serde_json::from_str(json_info).unwrap();
+
+        assert_eq!(
+            proposal_info,
+            ProposalInfo {
+                proposal_id: 137875,
+                payload: ProposalPayloadInfo {
+                    canister_id: "mqygn-kiaaa-aaaar-qaadq-cai".to_string(),
+                    install_mode_name: "CANISTER_INSTALL_MODE_UPGRADE".to_string(),
+                },
+            }
+        );
     }
 }

--- a/rs/cross-chain/proposal-cli/src/forum/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/mod.rs
@@ -130,7 +130,24 @@ impl ForumTopic {
 
     fn body(&self) -> String {
         match self {
-            ForumTopic::ApplicationCanisterManagement { proposals } => "".to_string(),
+            ForumTopic::ApplicationCanisterManagement { proposals } => {
+                let mut res = Vec::new();
+                res.push("Hi everyone :waving_hand:".to_string());
+                res.push(String::new());
+                res.push(format!(
+                    "Please use this forum thread to discuss the following {}:",
+                    pluralize("proposal", proposals.len())
+                ));
+                for (proposal_id, summary) in proposals {
+                    res.push(format!(
+                        "* Proposal [{}](https://dashboard.internetcomputer.org/proposal/{}): {} the {}",
+                        proposal_id, proposal_id, summary.install_mode, summary.canister
+                    ))
+                }
+                res.push(String::new());
+                res.push(":information_source: All listed proposals should contain the necessary information to verify them.".to_string());
+                res.join("\n")
+            }
         }
     }
 

--- a/rs/cross-chain/proposal-cli/src/forum/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/mod.rs
@@ -1,0 +1,47 @@
+use maplit::btreeset;
+use std::collections::BTreeSet;
+
+#[derive(Clone, PartialEq, Eq)]
+enum ForumPost {
+    ApplicationCanisterManagement { title: String, body: String },
+}
+
+impl ForumPost {
+    fn title(&self) -> &String {
+        match self {
+            ForumPost::ApplicationCanisterManagement { title, .. } => title,
+        }
+    }
+
+    fn body(&self) -> &String {
+        match self {
+            ForumPost::ApplicationCanisterManagement { body, .. } => body,
+        }
+    }
+
+    fn category(&self) -> u64 {
+        match &self {
+            ForumPost::ApplicationCanisterManagement { .. } => {
+                // Category "NNS proposal discussions"
+                // https://forum.dfinity.org/c/governance/nns-proposal-discussions/76
+                76
+            }
+        }
+    }
+
+    fn tags(&self) -> BTreeSet<Tag> {
+        btreeset! {Tag::ApplicationCanisterMgmt}
+    }
+}
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Tag {
+    ApplicationCanisterMgmt,
+}
+
+impl Tag {
+    fn id(&self) -> &'static str {
+        match self {
+            Tag::ApplicationCanisterMgmt => "Application-canister-mgmt",
+        }
+    }
+}

--- a/rs/cross-chain/proposal-cli/src/forum/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/mod.rs
@@ -12,6 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Formatter;
 use std::str::FromStr;
 use std::time::Duration;
+use url::Url;
 
 type ProposalId = u64;
 
@@ -234,13 +235,13 @@ pub struct CreateTopicResponse {
 
 pub struct DiscourseClient {
     client: reqwest::Client,
-    forum_url: String,
+    forum_url: Url,
     api_user: String,
     api_key: String,
 }
 
 impl DiscourseClient {
-    pub fn new(url: String, api_user: String, api_key: String) -> Self {
+    pub fn new(url: Url, api_user: String, api_key: String) -> Self {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
@@ -268,9 +269,10 @@ impl DiscourseClient {
         path: &str,
         request: Request,
     ) -> Result<Response, String> {
+        let url = self.forum_url.join(path).map_err(|e| e.to_string())?;
         let response = self
             .client
-            .post(format!("{}/{}", self.forum_url, path))
+            .post(url)
             .json(&request)
             .header("Api-Key", &self.api_key)
             .header("Api-Username", &self.api_user)

--- a/rs/cross-chain/proposal-cli/src/forum/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/mod.rs
@@ -33,6 +33,7 @@ impl ForumPost {
         btreeset! {Tag::ApplicationCanisterMgmt}
     }
 }
+
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum Tag {
     ApplicationCanisterMgmt,

--- a/rs/cross-chain/proposal-cli/src/forum/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/mod.rs
@@ -1,5 +1,8 @@
 use maplit::btreeset;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+use std::time::Duration;
 
 #[derive(Clone, PartialEq, Eq)]
 enum ForumPost {
@@ -44,5 +47,73 @@ impl Tag {
         match self {
             Tag::ApplicationCanisterMgmt => "Application-canister-mgmt",
         }
+    }
+}
+
+/// Create a new topic (first forum post in a thread)
+#[derive(Clone, PartialEq, Eq, Serialize)]
+pub struct CreateTopicRequest {
+    title: String,
+    raw: String,
+    category: u64,
+    tags: Vec<String>,
+}
+
+/// Response returned upon successful creation of a new topic.
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+pub struct CreateTopicResponse {
+    pub id: u64,
+    pub topic_id: u64,
+    pub topic_slug: String,
+    pub post_url: String,
+}
+
+pub struct DiscourseClient {
+    client: reqwest::Client,
+    forum_url: String,
+    api_user: String,
+    api_key: String,
+}
+
+impl DiscourseClient {
+    pub fn new(url: String, api_user: String, api_key: String) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("ERROR: Failed to create client");
+
+        Self {
+            client,
+            forum_url: url,
+            api_key,
+            api_user,
+        }
+    }
+
+    pub async fn create_topic<T: Into<CreateTopicRequest>>(
+        &self,
+        request: T,
+    ) -> Result<CreateTopicResponse, String> {
+        let request = request.into();
+        self.post_request("posts.json?skip_validations=true", request)
+            .await
+    }
+
+    async fn post_request<Request: Serialize, Response: DeserializeOwned>(
+        &self,
+        path: &str,
+        request: Request,
+    ) -> Result<Response, String> {
+        self.client
+            .post(format!("{}/{}", self.forum_url, path))
+            .json(&request)
+            .header("Api-Key", &self.api_key)
+            .header("Api-Username", &self.api_user)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?
+            .json()
+            .await
+            .map_err(|e| e.to_string())
     }
 }

--- a/rs/cross-chain/proposal-cli/src/forum/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/mod.rs
@@ -2,7 +2,7 @@
 mod tests;
 
 use crate::canister::TargetCanister;
-use crate::dashboard::ProposalInfo;
+use crate::dashboard::responses::ProposalInfo;
 use candid::Principal;
 use core::fmt;
 use maplit::btreeset;
@@ -16,7 +16,7 @@ use std::time::Duration;
 type ProposalId = u64;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum ForumTopic {
+pub enum ForumTopic {
     /// A new topic in the application canister management category for the given proposals.
     /// A single post may cover multiple proposals (e.g. a topic to cover a new ckBTC ledger suite,
     /// which involves 3 proposals: for the ledger, index and archive canisters).
@@ -26,7 +26,7 @@ enum ForumTopic {
 }
 
 impl ForumTopic {
-    fn for_upgrade_proposals<I: IntoIterator<Item = ProposalInfo>>(
+    pub fn for_upgrade_proposals<I: IntoIterator<Item = ProposalInfo>>(
         proposals: I,
     ) -> Result<ForumTopic, String> {
         let mut summaries = BTreeMap::new();
@@ -62,7 +62,7 @@ impl TryFrom<ProposalInfo> for UpgradeProposalSummary {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct UpgradeProposalSummary {
+pub struct UpgradeProposalSummary {
     canister: TargetCanister,
     install_mode: CanisterInstallMode,
 }

--- a/rs/cross-chain/proposal-cli/src/forum/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/mod.rs
@@ -268,16 +268,18 @@ impl DiscourseClient {
         path: &str,
         request: Request,
     ) -> Result<Response, String> {
-        self.client
+        let response = self
+            .client
             .post(format!("{}/{}", self.forum_url, path))
             .json(&request)
             .header("Api-Key", &self.api_key)
             .header("Api-Username", &self.api_user)
             .send()
             .await
-            .map_err(|e| e.to_string())?
-            .json()
-            .await
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        if !response.status().is_success() {
+            return Err(format!("HTTP error: {:?}", response));
+        }
+        response.json().await.map_err(|e| e.to_string())
     }
 }

--- a/rs/cross-chain/proposal-cli/src/forum/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/tests.rs
@@ -1,4 +1,4 @@
-use crate::dashboard::{ProposalInfo, ProposalPayloadInfo};
+use crate::dashboard::responses::{ProposalInfo, ProposalPayloadInfo};
 use crate::forum::{CreateTopicRequest, ForumTopic};
 
 #[test]
@@ -18,12 +18,10 @@ fn should_have_correct_content_when_creating_topic_for_multiple_proposals() {
             title: "Proposals (137359, 137360, 137361) to upgrade the (ckBTC index, ckBTC ledger, ckBTC archive)".to_string(),
             raw: "\
             Hi everyone :waving_hand:\n\n\
-
             Please use this forum thread to discuss the following proposals:\n\
             * Proposal [137359](https://dashboard.internetcomputer.org/proposal/137359): upgrade the ckBTC index\n\
             * Proposal [137360](https://dashboard.internetcomputer.org/proposal/137360): upgrade the ckBTC ledger\n\
             * Proposal [137361](https://dashboard.internetcomputer.org/proposal/137361): upgrade the ckBTC archive\n\n\
-
             :information_source: All listed proposals should contain the necessary information to verify them.\
             ".to_string(),
             category:76,
@@ -44,10 +42,8 @@ fn should_have_correct_content_when_creating_topic_for_single_proposals() {
             title: "Proposal 137360 to upgrade the ckBTC ledger".to_string(),
             raw: "\
             Hi everyone :waving_hand:\n\n\
-
             Please use this forum thread to discuss the following proposal:\n\
             * Proposal [137360](https://dashboard.internetcomputer.org/proposal/137360): upgrade the ckBTC ledger\n\n\
-
             :information_source: All listed proposals should contain the necessary information to verify them.\
             ".to_string(),
             category: 76,

--- a/rs/cross-chain/proposal-cli/src/forum/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/tests.rs
@@ -2,7 +2,7 @@ use crate::dashboard::{ProposalInfo, ProposalPayloadInfo};
 use crate::forum::{CreateTopicRequest, ForumTopic};
 
 #[test]
-fn should_have_correct_title_when_creating_topic_for_multiple_proposals() {
+fn should_have_correct_content_when_creating_topic_for_multiple_proposals() {
     let topic = ForumTopic::for_upgrade_proposals(vec![
         ckbtc_ledger_proposal(),
         ckbtc_index_proposal(),
@@ -16,7 +16,16 @@ fn should_have_correct_title_when_creating_topic_for_multiple_proposals() {
         request,
         CreateTopicRequest {
             title: "Proposals (137359, 137360, 137361) to upgrade the (ckBTC index, ckBTC ledger, ckBTC archive)".to_string(),
-            raw: "".to_string(),
+            raw: "\
+            Hi everyone :waving_hand:\n\n\
+
+            Please use this forum thread to discuss the following proposals:\n\
+            * Proposal [137359](https://dashboard.internetcomputer.org/proposal/137359): upgrade the ckBTC index\n\
+            * Proposal [137360](https://dashboard.internetcomputer.org/proposal/137360): upgrade the ckBTC ledger\n\
+            * Proposal [137361](https://dashboard.internetcomputer.org/proposal/137361): upgrade the ckBTC archive\n\n\
+
+            :information_source: All listed proposals should contain the necessary information to verify them.\
+            ".to_string(),
             category:76,
             tags: vec!["Application-canister-mgmt".to_string()],
         }
@@ -24,7 +33,7 @@ fn should_have_correct_title_when_creating_topic_for_multiple_proposals() {
 }
 
 #[test]
-fn should_have_correct_title_when_creating_topic_for_single_proposals() {
+fn should_have_correct_content_when_creating_topic_for_single_proposals() {
     let topic = ForumTopic::for_upgrade_proposals(vec![ckbtc_ledger_proposal()]).unwrap();
 
     let request = CreateTopicRequest::from(topic);
@@ -33,8 +42,15 @@ fn should_have_correct_title_when_creating_topic_for_single_proposals() {
         request,
         CreateTopicRequest {
             title: "Proposal 137360 to upgrade the ckBTC ledger".to_string(),
-            raw: "".to_string(),
-            category:76,
+            raw: "\
+            Hi everyone :waving_hand:\n\n\
+
+            Please use this forum thread to discuss the following proposal:\n\
+            * Proposal [137360](https://dashboard.internetcomputer.org/proposal/137360): upgrade the ckBTC ledger\n\n\
+
+            :information_source: All listed proposals should contain the necessary information to verify them.\
+            ".to_string(),
+            category: 76,
             tags: vec!["Application-canister-mgmt".to_string()],
         }
     );

--- a/rs/cross-chain/proposal-cli/src/forum/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/tests.rs
@@ -1,0 +1,71 @@
+use crate::dashboard::{ProposalInfo, ProposalPayloadInfo};
+use crate::forum::{CreateTopicRequest, ForumTopic};
+
+#[test]
+fn should_have_correct_title_when_creating_topic_for_multiple_proposals() {
+    let topic = ForumTopic::for_upgrade_proposals(vec![
+        ckbtc_ledger_proposal(),
+        ckbtc_index_proposal(),
+        ckbtc_archive_proposal(),
+    ])
+    .unwrap();
+
+    let request = CreateTopicRequest::from(topic);
+
+    assert_eq!(
+        request,
+        CreateTopicRequest {
+            title: "Proposals (137359, 137360, 137361) to upgrade the (ckBTC index, ckBTC ledger, ckBTC archive)".to_string(),
+            raw: "".to_string(),
+            category:76,
+            tags: vec!["Application-canister-mgmt".to_string()],
+        }
+    );
+}
+
+#[test]
+fn should_have_correct_title_when_creating_topic_for_single_proposals() {
+    let topic = ForumTopic::for_upgrade_proposals(vec![ckbtc_ledger_proposal()]).unwrap();
+
+    let request = CreateTopicRequest::from(topic);
+
+    assert_eq!(
+        request,
+        CreateTopicRequest {
+            title: "Proposal 137360 to upgrade the ckBTC ledger".to_string(),
+            raw: "".to_string(),
+            category:76,
+            tags: vec!["Application-canister-mgmt".to_string()],
+        }
+    );
+}
+
+fn ckbtc_ledger_proposal() -> ProposalInfo {
+    ProposalInfo {
+        proposal_id: 137360,
+        payload: ProposalPayloadInfo {
+            canister_id: "mxzaz-hqaaa-aaaar-qaada-cai".to_string(),
+            install_mode_name: "CANISTER_INSTALL_MODE_UPGRADE".to_string(),
+        },
+    }
+}
+
+fn ckbtc_index_proposal() -> ProposalInfo {
+    ProposalInfo {
+        proposal_id: 137359,
+        payload: ProposalPayloadInfo {
+            canister_id: "n5wcd-faaaa-aaaar-qaaea-cai".to_string(),
+            install_mode_name: "CANISTER_INSTALL_MODE_UPGRADE".to_string(),
+        },
+    }
+}
+
+fn ckbtc_archive_proposal() -> ProposalInfo {
+    ProposalInfo {
+        proposal_id: 137361,
+        payload: ProposalPayloadInfo {
+            canister_id: "nbsys-saaaa-aaaar-qaaga-cai".to_string(),
+            install_mode_name: "CANISTER_INSTALL_MODE_UPGRADE".to_string(),
+        },
+    }
+}

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -12,6 +12,7 @@ use crate::forum::DiscourseClient;
 use crate::git::{GitCommitHash, GitRepository};
 use crate::ic_admin::ProposalFiles;
 use crate::proposal::{InstallProposalTemplate, ProposalTemplate, UpgradeProposalTemplate};
+use ::candid::Principal;
 use clap::{Parser, Subcommand};
 use ic_admin::IcAdminArgs;
 use std::collections::{BTreeMap, BTreeSet};
@@ -206,6 +207,10 @@ async fn main() {
         } => {
             let dashboard = DashboardClient::new();
             let proposal = dashboard.retrieve_proposal(proposal_id).await;
+            let canister_id = Principal::from_text(proposal.payload.canister_id)
+                .expect("ERROR: invalid canister ID");
+            let target_canister = TargetCanister::find_by_id(&canister_id)
+                .unwrap_or_else(|| panic!("ERROR: no known target canister for {canister_id}"));
             let forum_client =
                 DiscourseClient::new("https://forum.dfinity.org".to_string(), api_user, api_key);
             panic!("BOOM!: {proposal:?}")

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -213,7 +213,6 @@ async fn main() {
                 .unwrap_or_else(|| panic!("ERROR: no known target canister for {canister_id}"));
             let forum_client =
                 DiscourseClient::new("https://forum.dfinity.org".to_string(), api_user, api_key);
-            panic!("BOOM!: {proposal:?}")
         }
     }
 }

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -226,7 +226,7 @@ async fn main() {
                 "y" => {
                     const DFINITY_FORUM_URL: &str = "https://forum.dfinity.org";
                     let forum_client =
-                        DiscourseClient::new(DFINITY_FORUM_URL.to_string(), api_user, api_key);
+                        DiscourseClient::new(DFINITY_FORUM_URL.parse().unwrap(), api_user, api_key);
                     let response = forum_client
                         .create_topic(request)
                         .await

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -8,6 +8,7 @@ mod proposal;
 
 use crate::canister::TargetCanister;
 use crate::dashboard::DashboardClient;
+use crate::forum::DiscourseClient;
 use crate::git::{GitCommitHash, GitRepository};
 use crate::ic_admin::ProposalFiles;
 use crate::proposal::{InstallProposalTemplate, ProposalTemplate, UpgradeProposalTemplate};
@@ -82,6 +83,10 @@ enum Commands {
         /// ID of the proposal.
         #[arg(long)]
         proposal_id: u64,
+        /// API key to submit the post
+        api_key: String,
+        /// Username associated with the API key
+        api_user: String,
     },
 }
 
@@ -194,9 +199,15 @@ async fn main() {
                 }
             }
         }
-        Commands::CreateForumPost { proposal_id } => {
+        Commands::CreateForumPost {
+            proposal_id,
+            api_key,
+            api_user,
+        } => {
             let dashboard = DashboardClient::new();
             let proposal = dashboard.retrieve_proposal(proposal_id).await;
+            let forum_client =
+                DiscourseClient::new("https://forum.dfinity.org".to_string(), api_user, api_key);
             panic!("BOOM!: {proposal:?}")
         }
     }

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod candid;
 mod canister;
 mod dashboard;
+mod forum;
 mod git;
 mod ic_admin;
 mod proposal;

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -195,7 +195,9 @@ async fn main() {
             }
         }
         Commands::CreateForumPost { proposal_id } => {
-            panic!("BOOM!: {proposal_id}")
+            let dashboard = DashboardClient::new();
+            let proposal = dashboard.retrieve_proposal(proposal_id).await;
+            panic!("BOOM!: {proposal:?}")
         }
     }
 }

--- a/rs/cross-chain/proposal-cli/src/main.rs
+++ b/rs/cross-chain/proposal-cli/src/main.rs
@@ -76,6 +76,13 @@ enum Commands {
         #[command(subcommand)]
         submit: Option<SubmitProposal>,
     },
+    /// Create a forum post for a new proposal
+    #[command(arg_required_else_help = true)]
+    CreateForumPost {
+        /// ID of the proposal.
+        #[arg(long)]
+        proposal_id: u64,
+    },
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -186,6 +193,9 @@ async fn main() {
                     write_to_disk(output_dir, proposal, submit.clone(), &git_repo);
                 }
             }
+        }
+        Commands::CreateForumPost { proposal_id } => {
+            panic!("BOOM!: {proposal_id}")
         }
     }
 }


### PR DESCRIPTION
As part of the Voting Neuron Grants season 2 teams submitting canister upgrade proposals are required to [create a forum topic](https://forum.dfinity.org/t/nns-proposal-discussions/34492) for every proposal or group of proposals. This PR adds a new functionality to `proposal-cli` to be able to create a new forum topic given one or several proposal IDs.