### PR TITLE
feat: adding node states to the orchestrator to track state changes

### DIFF
--- a/rs/orchestrator/src/orchestrator.rs
+++ b/rs/orchestrator/src/orchestrator.rs
@@ -12,6 +12,7 @@ use crate::{
     registry_helper::RegistryHelper,
     ssh_access_manager::SshAccessManager,
     upgrade::{OrchestratorControlFlow, Upgrade},
+    utils::{maybe_notify_control_flow_change, NodeAssignationState},
 };
 use backoff::ExponentialBackoffBuilder;
 use get_if_addrs::get_if_addrs;
@@ -380,10 +381,36 @@ impl Orchestrator {
             // in case it gets stuck in an unexpected situation for longer than 15 minutes.
             const UPGRADE_TIMEOUT: Duration = Duration::from_secs(60 * 15);
 
+            // Assume an initial unassigned state. This is used for a graceful shutdown message
+            // to the host console. The message is displayed only if the change is from
+            // Assigned -> Unassigned.
+            let mut current_node_assignment_state = NodeAssignationState::Unknown;
+
             loop {
+                // Fetch the current state of the node assignment as visible to the registry
+                let current_subnet_in_registry = match upgrade.registry.get_subnet_id_from_node_id(
+                    upgrade.node_id(),
+                    upgrade.registry.get_latest_version(),
+                ) {
+                    Ok(maybe_subnet) => maybe_subnet,
+                    Err(e) => {
+                        error!(log, "Couldn't read information about subnet membership from registry due to: {e:?}");
+                        None
+                    }
+                };
                 match tokio::time::timeout(UPGRADE_TIMEOUT, upgrade.check_for_upgrade()).await {
                     Ok(Ok(control_flow)) => {
                         upgrade.metrics.failed_consecutive_upgrade_checks.reset();
+
+                        // Figure out the new state based on the information from
+                        // the registry and the cup information.
+                        current_node_assignment_state = maybe_notify_control_flow_change(
+                            current_node_assignment_state,
+                            control_flow.clone(),
+                            upgrade.node_id(),
+                            current_subnet_in_registry,
+                            &log,
+                        );
 
                         match control_flow {
                             OrchestratorControlFlow::Assigned(subnet_id) => {

--- a/rs/orchestrator/src/upgrade.rs
+++ b/rs/orchestrator/src/upgrade.rs
@@ -38,6 +38,7 @@ use std::{
 const KEY_CHANGES_FILENAME: &str = "key_changed_metric.cbor";
 
 #[must_use = "This may be a `Stop` variant, which should be handled"]
+#[derive(Clone, Debug)]
 pub(crate) enum OrchestratorControlFlow {
     /// The node is assigned to the subnet with the given subnet id.
     Assigned(SubnetId),
@@ -149,6 +150,10 @@ impl Upgrade {
             .reboot_duration
             .set(elapsed_time.as_secs() as i64);
         Ok(())
+    }
+
+    pub(crate) fn node_id(&self) -> NodeId {
+        self.node_id
     }
 
     /// Checks for a new release package, and if found, upgrades to this release

--- a/rs/orchestrator/src/utils.rs
+++ b/rs/orchestrator/src/utils.rs
@@ -1,7 +1,11 @@
-use ic_logger::{warn, ReplicaLogger};
+use ic_logger::{error, info, warn, ReplicaLogger};
 use ic_protobuf::registry::node::v1::ConnectionEndpoint;
+use ic_sys::utility_command::UtilityCommand;
+use ic_types::{NodeId, SubnetId};
 use std::{net::IpAddr, str::FromStr};
 use url::Url;
+
+use crate::upgrade::OrchestratorControlFlow;
 
 pub(crate) fn http_endpoint_to_url(http: &ConnectionEndpoint, log: &ReplicaLogger) -> Option<Url> {
     endpoint_to_url("http", http, log)
@@ -34,4 +38,141 @@ fn endpoint_to_url(protocol: &str, http: &ConnectionEndpoint, log: &ReplicaLogge
             None
         }
     }
+}
+
+/// Enum for tracking the node assignment states that can happen on the
+/// network.
+#[derive(PartialEq, Eq, Debug)]
+pub(crate) enum NodeAssignationState {
+    /// The node is unassigned in the registry and the node thinks it is unassigned.
+    Unassigned,
+    /// The node is unassigned in the registry but still participates in consensus.
+    Leaving { subnet_id: SubnetId },
+    /// The node is assigned in the registry but the node still hasn't synced the state.
+    Joining { subnet_id: SubnetId },
+    /// The node is assigned in the registry and the node is participating in conseusns.
+    Assigned { subnet_id: SubnetId },
+    /// The node is assigned to subnet A in the registry but the node is participating
+    /// in consensus of subnet B.
+    Moving { from: SubnetId, to: SubnetId },
+    /// Initial state
+    Unknown,
+}
+
+pub(crate) fn maybe_notify_control_flow_change(
+    previous_state: NodeAssignationState,
+    reported_flow: OrchestratorControlFlow,
+    node_id: NodeId,
+    maybe_subnet_from_registry: Option<SubnetId>,
+    log: &ReplicaLogger,
+) -> NodeAssignationState {
+    // Based on the registry view of the node and self view figure out the next state
+    let new_state = match (reported_flow, maybe_subnet_from_registry) {
+        (OrchestratorControlFlow::Unassigned, None) => NodeAssignationState::Unassigned,
+        (OrchestratorControlFlow::Unassigned, Some(s)) => {
+            NodeAssignationState::Joining { subnet_id: s }
+        }
+        (OrchestratorControlFlow::Assigned(s), None) => {
+            NodeAssignationState::Leaving { subnet_id: s }
+        }
+        (OrchestratorControlFlow::Assigned(s_node), Some(s_reg)) => {
+            if s_node == s_reg {
+                NodeAssignationState::Assigned { subnet_id: s_node }
+            } else {
+                NodeAssignationState::Moving {
+                    from: s_node,
+                    to: s_reg,
+                }
+            }
+        }
+        (OrchestratorControlFlow::Stop, _) => {
+            // Not important as the node is gracefully being shutdown in order to upgrade.
+            return previous_state;
+        }
+    };
+
+    // Based on the transition from previous_state -> new_state
+    // figure out what to do.
+    match (&previous_state, &new_state) {
+        (NodeAssignationState::Unknown, s) if s != &NodeAssignationState::Unknown => {
+            // Maybe log the inital thing...
+        }
+        (NodeAssignationState::Unassigned, NodeAssignationState::Joining { subnet_id }) => {
+            // Maybe log node joining subnet...
+            info!(log, "Detected node joining a subnet {subnet_id}");
+        }
+        (NodeAssignationState::Unassigned, NodeAssignationState::Assigned { subnet_id }) => {
+            // Maybe log instant transition...
+            info!(
+                log,
+                "Node instantly changed from Unassigned to Assigned to a subnet {subnet_id}"
+            );
+        }
+        (NodeAssignationState::Leaving { subnet_id }, NodeAssignationState::Unassigned) => {
+            // Maybe log node left subnet...
+            info!(log, "Node gracefully left a subnet {subnet_id}");
+            UtilityCommand::notify_host(&format!("The node {node_id} has gracefully left subnet {subnet_id}. The node can be turned off now."), 1);
+        }
+        (
+            NodeAssignationState::Joining {
+                subnet_id: joining_subnet,
+            },
+            NodeAssignationState::Assigned {
+                subnet_id: joined_subnet,
+            },
+        ) => {
+            if joining_subnet == joined_subnet {
+                // Maybe log node joined subnet...
+                info!(log, "Node joined subnet {joined_subnet}");
+            }
+        }
+        (NodeAssignationState::Assigned { subnet_id }, NodeAssignationState::Unassigned) => {
+            // Maybe log instant transition...
+            info!(
+                log,
+                "Node instantly changed from Assigned {subnet_id} to Unassigned"
+            );
+        }
+        (
+            NodeAssignationState::Assigned {
+                subnet_id: assinged_subnet,
+            },
+            NodeAssignationState::Leaving {
+                subnet_id: leaving_subnet,
+            },
+        ) if assinged_subnet == leaving_subnet => {
+            // Maybe log leaving subnet...
+            info!(log, "Node started leaving subnet {assinged_subnet}");
+            UtilityCommand::notify_host(&format!("The node {node_id} has been unassigned from the subnet {assinged_subnet} in the registry. Please do not turn off the machine while it completes its graceful removal from the subnet. This process can take up to 15 minutes. A new message will be displayed here when the node has been successfully removed."), 1);
+        }
+        // TODO: ATM this is not possible but it may be in the future
+        (
+            NodeAssignationState::Assigned {
+                subnet_id: assigned_subnet,
+            },
+            NodeAssignationState::Moving { from, to: _ },
+        ) if assigned_subnet == from => {
+            // Maybe log moving subnet started...
+        }
+        // TODO: ATM this is not possible but it may be in the future
+        (
+            NodeAssignationState::Moving { from: _, to },
+            NodeAssignationState::Assigned {
+                subnet_id: assigned_subnet,
+            },
+        ) if to == assigned_subnet => {
+            // Maybe log moving subnet completed...
+        }
+        (previous, new) if previous == new => {
+            // Same old and new state, do nothing
+        }
+        (previous, new) => {
+            error!(
+                log,
+                "Detected transition {previous:?} => {new:?} which should not be possible!"
+            );
+        }
+    }
+
+    new_state
 }


### PR DESCRIPTION
This feature adds the possibility for the orchestrator to know what state the node is in.

For now it is needed to display certain messages on the BMC console if the node is leaving the subnet and that the node shouldn't be turned off just yet. Later when the node leaves, it will display a different message that it is now safe to turn it off. 

Supporting pictures taken from kibana for graceful leaving:
<img width="1528" height="577" alt="image" src="https://github.com/user-attachments/assets/45e83949-6ca8-4eb4-a805-6359e40dd20d" />
