### PR TITLE
chore: CON-1583 Add a topology version metric and use it in some tests adding nodes

### DIFF
--- a/rs/p2p/peer_manager/src/lib.rs
+++ b/rs/p2p/peer_manager/src/lib.rs
@@ -85,10 +85,10 @@ impl PeerManager {
             let _timer = self.metrics.topology_watcher_update_duration.start_timer();
             self.metrics
                 .earliest_registry_version
-                .set(topology.earliest_registry_version().get());
+                .set(topology.earliest_registry_version().get() as i64);
             self.metrics
                 .latest_registry_version
-                .set(topology.latest_registry_version().get());
+                .set(topology.latest_registry_version().get() as i64);
             // Notify watchers of latest shared state iff the latest topology is different to the old one.
             self.topology_sender
                 .send_if_modified(move |old_topology: &mut SubnetTopology| {

--- a/rs/p2p/peer_manager/src/lib.rs
+++ b/rs/p2p/peer_manager/src/lib.rs
@@ -83,6 +83,12 @@ impl PeerManager {
 
             let mut topology = self.get_latest_subnet_topology();
             let _timer = self.metrics.topology_watcher_update_duration.start_timer();
+            self.metrics
+                .earliest_registry_version
+                .set(topology.earliest_registry_version().get());
+            self.metrics
+                .latest_registry_version
+                .set(topology.latest_registry_version().get());
             // Notify watchers of latest shared state iff the latest topology is different to the old one.
             self.topology_sender
                 .send_if_modified(move |old_topology: &mut SubnetTopology| {

--- a/rs/p2p/peer_manager/src/metrics.rs
+++ b/rs/p2p/peer_manager/src/metrics.rs
@@ -11,18 +11,18 @@ pub struct PeerManagerMetrics {
 }
 
 impl PeerManagerMetrics {
-    /// The constructor returns a `GossipMetrics` instance.
+    /// The constructor returns a `PeerManagerMetrics` instance.
     pub fn new(metrics_registry: &MetricsRegistry) -> Self {
         Self {
             topology_updates: metrics_registry.int_counter(
                 "peer_manager_topology_updates_total",
                 "Number of times registry is checked for topology updates.",
             ),
-            earliest_registry_version: metrics_registry.int_counter(
+            earliest_registry_version: metrics_registry.int_gauge(
                 "peer_manager_topology_earliest_registry_version",
                 "Registry version of the earliest relevant subnet topology.",
             ),
-            latest_registry_version: metrics_registry.int_counter(
+            latest_registry_version: metrics_registry.int_gauge(
                 "peer_manager_topology_latest_registry_version",
                 "Registry version of the latest relevant subnet topology.",
             ),

--- a/rs/p2p/peer_manager/src/metrics.rs
+++ b/rs/p2p/peer_manager/src/metrics.rs
@@ -1,9 +1,11 @@
 use ic_metrics::{buckets::exponential_buckets, MetricsRegistry};
-use prometheus::{Histogram, IntCounter};
+use prometheus::{Histogram, IntCounter, IntGauge};
 
 #[derive(Clone, Debug)]
 pub struct PeerManagerMetrics {
     pub topology_updates: IntCounter,
+    pub earliest_registry_version: IntGauge,
+    pub latest_registry_version: IntGauge,
     pub topology_watcher_update_duration: Histogram,
     pub topology_update_duration: Histogram,
 }
@@ -15,6 +17,14 @@ impl PeerManagerMetrics {
             topology_updates: metrics_registry.int_counter(
                 "peer_manager_topology_updates_total",
                 "Number of times registry is checked for topology updates.",
+            ),
+            earliest_registry_version: metrics_registry.int_counter(
+                "peer_manager_topology_earliest_registry_version",
+                "Registry version of the earliest relevant subnet topology.",
+            ),
+            latest_registry_version: metrics_registry.int_counter(
+                "peer_manager_topology_latest_registry_version",
+                "Registry version of the latest relevant subnet topology.",
             ),
             topology_watcher_update_duration: metrics_registry.histogram(
                 "peer_manager_topology_watcher_update_duration_seconds",

--- a/rs/tests/consensus/tecdsa/tecdsa_add_nodes_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_add_nodes_test.rs
@@ -24,7 +24,10 @@ end::catalog[] */
 use anyhow::Result;
 
 use canister_test::Canister;
-use ic_consensus_system_test_utils::rw_message::cert_state_makes_progress_with_retries;
+use ic_consensus_system_test_utils::{
+    node::await_subnet_earliest_topology_version,
+    rw_message::cert_state_makes_progress_with_retries,
+};
 use ic_consensus_threshold_sig_system_test_utils::{
     enable_chain_key_signing, get_public_key_and_test_signature, get_public_key_with_logger,
     make_key_ids_for_all_schemes, DKG_INTERVAL,
@@ -39,8 +42,8 @@ use ic_system_test_driver::{
         ic::{InternetComputer, Subnet},
         test_env::TestEnv,
         test_env_api::{
-            secs, HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, NnsInstallationBuilder,
-            SubnetSnapshot,
+            secs, HasPublicApiUrl, HasRegistryVersion, HasTopologySnapshot, IcNodeContainer,
+            NnsInstallationBuilder, SubnetSnapshot,
         },
     },
     nns::{submit_external_proposal_with_test_id, vote_execute_proposal_assert_executed},
@@ -147,48 +150,52 @@ fn test(env: TestEnv) {
         &governance,
         proposal_id,
     ));
+
     info!(log, "Waiting for registry update.");
-    block_on(async {
-        topology_snapshot
-            .block_for_newer_registry_version()
-            .await
-            .expect("Could not block for newer registry version");
-        info!(log, "Asserting nodes membership has changed.");
-        // Get a new snapshot.
-        let topology_snapshot = env.topology_snapshot();
-        assert!(topology_snapshot.unassigned_nodes().next().is_none());
-        let nns = topology_snapshot.root_subnet();
-        assert_eq!(nns.nodes().count(), UNASSIGNED_NODES_COUNT + NODES_COUNT);
+    let topology_snapshot = block_on(topology_snapshot.block_for_newer_registry_version())
+        .expect("Should get newer registry version");
+    info!(log, "Asserting nodes membership has changed.");
+    assert!(topology_snapshot.unassigned_nodes().next().is_none());
+    let nns = topology_snapshot.root_subnet();
+    assert_eq!(nns.nodes().count(), UNASSIGNED_NODES_COUNT + NODES_COUNT);
 
-        for key_id in &key_ids {
-            if !key_id.is_idkg_key() {
-                continue;
-            }
-            info!(log, "Make sure key {} was rotated.", key_id);
-            // All nodes (old and new) should have increased their metric by one.
-            assert_metric_sum(&nns, key_id, 2 * NODES_COUNT + UNASSIGNED_NODES_COUNT, &log).await;
-        }
+    info!(log, "Ensure active subnet membership has progressed.");
+    await_subnet_earliest_topology_version(&nns, topology_snapshot.get_registry_version(), &log);
 
-        info!(log, "Assert all nodes are making progress.");
-        for node in nns.nodes() {
-            cert_state_makes_progress_with_retries(
-                &node.get_public_url(),
-                node.effective_canister_id(),
-                &log,
-                /*timeout=*/ secs(100),
-                /*backoff=*/ secs(3),
-            );
+    for key_id in &key_ids {
+        if !key_id.is_idkg_key() {
+            continue;
         }
+        info!(log, "Make sure key {} was rotated.", key_id);
+        // All nodes (old and new) should have increased their key rotation metric by one.
+        block_on(assert_metric_sum(
+            &nns,
+            key_id,
+            2 * NODES_COUNT + UNASSIGNED_NODES_COUNT,
+            &log,
+        ));
+    }
 
-        info!(log, "Run through signature test.");
-        let msg_can = MessageCanister::from_canister_id(&agent, msg_can.canister_id());
-        for (key_id, public_key) in public_keys {
-            let public_key_ = get_public_key_and_test_signature(&key_id, &msg_can, true, &log)
-                .await
-                .unwrap();
-            assert_eq!(public_key, public_key_);
-        }
-    });
+    info!(log, "Assert all nodes are making progress.");
+    for node in nns.nodes() {
+        cert_state_makes_progress_with_retries(
+            &node.get_public_url(),
+            node.effective_canister_id(),
+            &log,
+            /*timeout=*/ secs(100),
+            /*backoff=*/ secs(3),
+        );
+    }
+
+    info!(log, "Run through signature test.");
+    let msg_can = MessageCanister::from_canister_id(&agent, msg_can.canister_id());
+    for (key_id, public_key) in public_keys {
+        let public_key_ = block_on(get_public_key_and_test_signature(
+            &key_id, &msg_can, true, &log,
+        ))
+        .unwrap();
+        assert_eq!(public_key, public_key_);
+    }
 }
 
 async fn assert_metric_sum(


### PR DESCRIPTION
This PR adds two metrics:
- the registry version of the latest subnet topology relevant to P2P
- the registry version of the earliest subnet topology relevant to P2P (this is equivalent to the "oldest registry version in use" by consensus).

Additionally, we use the latter metric to improve the robustness of two system tests (`adding_nodes_to_subnet` and `tecdsa_add_nodes`): 

These tests execute proposals to add nodes to a subnet, and then assert that the added nodes make progress as part of the new subnet. Technically, this isn't enough to ensure that the new nodes indeed joined the _active_ subnet membership, and participate in consensus after a successful resharing of the old membership. The reason is that such an assertion will always pass as long as the new nodes manage to sync blocks, even if consensus is still driven by the old membership.

Therefore, this PR adds a check making sure that the "earliest subnet topology" used by P2P progresses as expected with each membership change. This indicates a successful resharing of (N)IDkg transcripts to the new membership, and therefore the release of the old membership.

An alternative approach would have been the following: After adding all nodes to the subnet, kill f+1 nodes of the new membership. If the subnet stalls, then these nodes did indeed join the active subnet membership. This is done by some other tests around membership changes such as `network_large_test` and `node_assign_test`.