### PR TITLE
chore(cmc): Remove unreachable functions (ledger removed notify flow)

### DIFF
--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -38,7 +38,7 @@ use ic_nns_constants::{
 use ic_types::{CanisterId, Cycles, PrincipalId, SubnetId};
 use icp_ledger::{
     AccountIdentifier, Block, BlockIndex, BlockRes, Memo, Operation, SendArgs, Subaccount, Tokens,
-    Transaction, TransactionNotification, DEFAULT_TRANSFER_FEE,
+    Transaction, DEFAULT_TRANSFER_FEE,
 };
 use icrc_ledger_types::icrc1::account::Account;
 use lazy_static::lazy_static;

--- a/rs/nns/cmc/unreleased_changelog.md
+++ b/rs/nns/cmc/unreleased_changelog.md
@@ -4,7 +4,6 @@ In general, upcoming/unreleased behavior changes are described here. For details
 on the process that this file is part of, see
 `rs/nervous_system/changelog_process.md`.
 
-
 # Next Upgrade Proposal
 
 ## Added
@@ -14,6 +13,10 @@ on the process that this file is part of, see
 ## Deprecated
 
 ## Removed
+
+- Removed `transaction_notification` and `transaction_notification_pb` endpoints as they
+  no longer be called. The ICP ledger removed the notify flow, and these methods were not
+  callable by callers other than the ICP ledger.
 
 ## Fixed
 


### PR DESCRIPTION
This removes transaction_notification and transaction_notification_pb endpoints which are no longer usable, as the corresponding functionality in the ledger has been removed in https://dashboard.internetcomputer.org/proposal/138271.