### PR TITLE
feat(sns-wasm): Service discovery for SNS canisters

### DIFF
--- a/rs/nns/sns-wasm/canister/canister.rs
+++ b/rs/nns/sns-wasm/canister/canister.rs
@@ -493,7 +493,7 @@ fn serve_metrics_service_discovery() -> HttpResponse {
 fn http_request(request: HttpRequest) -> HttpResponse {
     match request.path() {
         "/metrics" => serve_metrics(encode_metrics),
-        "/metrics/sd" => serve_metrics_service_discovery(),
+        "/sns_canisters" => serve_metrics_service_discovery(),
         _ => HttpResponseBuilder::not_found().build(),
     }
 }

--- a/rs/nns/sns-wasm/canister/canister.rs
+++ b/rs/nns/sns-wasm/canister/canister.rs
@@ -477,6 +477,15 @@ fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::i
     Ok(())
 }
 
+fn serve_metrics_service_discovery() -> HttpResponse {
+    let service_discovery = SNS_WASM.with_borrow(SnsWasmCanister::get_metrics_service_discovery);
+    HttpResponseBuilder::ok()
+        .header("Content-Type", "application/json")
+        .header("Cache-Control", "no-store")
+        .with_body_and_content_length(service_discovery.as_bytes())
+        .build()
+}
+
 #[query(
     hidden = true,
     decode_with = "candid::decode_one_with_decoding_quota::<100000,_>"
@@ -484,6 +493,7 @@ fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::i
 fn http_request(request: HttpRequest) -> HttpResponse {
     match request.path() {
         "/metrics" => serve_metrics(encode_metrics),
+        "/metrics/sd" => serve_metrics_service_discovery(),
         _ => HttpResponseBuilder::not_found().build(),
     }
 }

--- a/rs/nns/sns-wasm/unreleased_changelog.md
+++ b/rs/nns/sns-wasm/unreleased_changelog.md
@@ -9,6 +9,8 @@ on the process that this file is part of, see
 
 ## Added
 
+* A "/sns_canisters" HTTP endpoint for SNS canisters service discovery, used for prometheus.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
# Why

The original motivation is to detect when swap finalization fails - since such event starts at the beginning of the SNS lifecycle, we cannot reasonably rely on manually updated list of SNSes. Therefore, we need a way to automatically detect new SNSes, and allow prometheus to scrape metrics from new SNS canisters.

# What

Expose a "/sns_canisters" endpoint similar to [orbit](https://5mxvd-qaaaa-aaaal-ajbkq-cai.raw.icp0.io/metrics/sd) based on `deployed_sns_list`.