### PR TITLE
Fix: approval fee added the by SNS approved value

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -596,8 +596,8 @@ http_file(
 http_file(
     name = "kongswap-adaptor-canister",
     downloaded_file_path = "kongswap-adaptor-canister.wasm.gz",
-    sha256 = "4b3445ff18b417364a25c733f377eb0eb5943dea8781de73c226023657642ad1",
-    url = "https://github.com/dfinity/sns-kongswap-adaptor/releases/download/vrc-20250821-094346-bab9aa4/kongswap-adaptor-canister.wasm.gz",
+    sha256 = "c623ef63a395254fe02fb4c3a57a5257167fb310cf2eb1663d2c95c8763c00e6",
+    url = "https://github.com/dfinity/sns-kongswap-adaptor/releases/download/vrc-20250903-100247-bb9eb6c/kongswap-adaptor-canister.wasm.gz",
 )
 
 # Cycles Ledger canister

--- a/rs/sns/governance/src/extensions.rs
+++ b/rs/sns/governance/src/extensions.rs
@@ -652,7 +652,7 @@ impl Governance {
         self.ledger
             .icrc2_approve(
                 to,
-                sns_amount_e8s.saturating_sub(self.transaction_fee_e8s_or_panic()),
+                sns_amount_e8s,
                 Some(expiry_time_nsec),
                 self.transaction_fee_e8s_or_panic(),
                 self.sns_treasury_subaccount(),
@@ -670,7 +670,7 @@ impl Governance {
         self.nns_ledger
             .icrc2_approve(
                 to,
-                icp_amount_e8s.saturating_sub(icp_ledger::DEFAULT_TRANSFER_FEE.get_e8s()),
+                icp_amount_e8s,
                 Some(expiry_time_nsec),
                 icp_ledger::DEFAULT_TRANSFER_FEE.get_e8s(),
                 self.icp_treasury_subaccount(),


### PR DESCRIPTION
When creating an initialization/deposit proposal the approval fee should also be paid by the SNS, so that the adaptor receives the exact value mentioned in the proposal. This PR solves this issue.