### PR TITLE
chore(sns): Cleanup SNS migration code

### DIFF
--- a/rs/sns/governance/canister/canister.rs
+++ b/rs/sns/governance/canister/canister.rs
@@ -5,10 +5,7 @@ use async_trait::async_trait;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_canister_log::log;
 use ic_canister_profiler::{measure_span, measure_span_async};
-use ic_cdk::{
-    api::stable::stable_read, caller as cdk_caller, init, post_upgrade, pre_upgrade, println,
-    query, update,
-};
+use ic_cdk::{caller as cdk_caller, init, post_upgrade, pre_upgrade, println, query, update};
 use ic_cdk_timers::TimerId;
 use ic_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 use ic_nervous_system_canisters::{cmc::CMCCanister, ledger::IcpLedgerCanister};
@@ -59,7 +56,6 @@ use ic_sns_governance_api::pb::v1::{
     AdvanceTargetVersionResponse, MintTokensRequest, MintTokensResponse,
     RefreshCachedUpgradeStepsRequest, RefreshCachedUpgradeStepsResponse,
 };
-use prost::Message;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use std::{
@@ -68,14 +64,6 @@ use std::{
     convert::TryFrom,
     time::{Duration, SystemTime},
 };
-
-/// Size of the buffer for stable memory reads and writes.
-///
-/// Smaller buffer size means more stable_write and stable_read calls. With
-/// 100MiB buffer size, when the heap is near full, we need ~40 system calls.
-/// Larger buffer size means we may not be able to serialize the heap fully in
-/// some cases.
-const STABLE_MEM_BUFFER_SIZE: u32 = 100 * 1024 * 1024; // 100MiB
 
 static mut GOVERNANCE: Option<Governance> = None;
 


### PR DESCRIPTION
This removes the migration code, since the last SNS Governance canister has been published with the migration.

See https://dashboard.internetcomputer.org/proposal/138281 where the previous change went out.