### PR TITLE
fix(NPR): Discard historical rewards storage and APIs

### DIFF
--- a/rs/node_rewards/canister/api/src/provider_rewards_calculation.rs
+++ b/rs/node_rewards/canister/api/src/provider_rewards_calculation.rs
@@ -6,15 +6,6 @@ pub struct GetNodeProviderRewardsCalculationRequest {
     pub from_nanos: u64,
     pub to_nanos: u64,
     pub provider_id: Principal,
-    pub historical: bool,
 }
 
 pub type GetNodeProviderRewardsCalculationResponse = Result<NodeProviderRewards, String>;
-
-#[derive(CandidType, Clone, Deserialize, Debug, PartialEq, Eq)]
-pub struct HistoricalRewardPeriod {
-    pub from_nanos: u64,
-    pub to_nanos: u64,
-    pub providers_rewarded: Vec<Principal>,
-}
-pub type GetHistoricalRewardPeriodsResponse = Result<Vec<HistoricalRewardPeriod>, String>;

--- a/rs/node_rewards/canister/node-rewards-canister.did
+++ b/rs/node_rewards/canister/node-rewards-canister.did
@@ -102,20 +102,11 @@ type GetNodeProviderRewardsCalculationRequest = record {
   from_nanos: nat64;
   to_nanos: nat64;
   provider_id: principal;
-  historical: bool;
-};
-
-type HistoricalRewardPeriod = record {
-  from_nanos: nat64;
-  to_nanos: nat64;
-  providers_rewarded: vec principal;
 };
 
 type GetNodeProvidersRewardsResponse = variant { Ok : NodeProvidersRewards; Err : text };
 
 type GetNodeProviderRewardsCalculationResponse = variant { Ok : NodeProviderRewards; Err : text };
-
-type GetHistoricalRewardPeriodsResponse = variant { Ok : vec HistoricalRewardPeriod; Err : text };
 
 service : () -> {
     get_node_providers_monthly_xdr_rewards: (GetNodeProvidersMonthlyXdrRewardsRequest) -> (
@@ -123,5 +114,4 @@ service : () -> {
     );
     get_node_providers_rewards: (GetNodeProvidersRewardsRequest) -> (GetNodeProvidersRewardsResponse);
     get_node_provider_rewards_calculation : (GetNodeProviderRewardsCalculationRequest) -> (GetNodeProviderRewardsCalculationResponse) query;
-    get_historical_reward_periods: () -> (GetHistoricalRewardPeriodsResponse) query;
 }

--- a/rs/node_rewards/canister/proto/rewards_calculator/pb/v1/types.proto
+++ b/rs/node_rewards/canister/proto/rewards_calculator/pb/v1/types.proto
@@ -72,18 +72,3 @@ message NodeProviderRewards {
   repeated DailyBaseRewardsType3 base_rewards_type3 = 3;
   repeated NodeResults nodes_results = 4;
 }
-
-message NodeProviderRewardsKey {
-  ic_base_types.pb.v1.PrincipalId principal_id = 1;
-  DayUtc end_day = 2;
-  DayUtc start_day = 3;
-}
-
-message SubnetsFailureRateValue {
-  ic_nervous_system.pb.v1.Decimal subnet_fr_percent = 1;
-}
-
-message SubnetsFailureRateKey {
-  DayUtc day = 1;
-  ic_base_types.pb.v1.PrincipalId subnet_id = 2;
-}

--- a/rs/node_rewards/canister/protobuf/src/gen/rewards_calculator.pb.v1.rs
+++ b/rs/node_rewards/canister/protobuf/src/gen/rewards_calculator.pb.v1.rs
@@ -125,24 +125,3 @@ pub struct NodeProviderRewards {
     #[prost(message, repeated, tag = "4")]
     pub nodes_results: ::prost::alloc::vec::Vec<NodeResults>,
 }
-#[derive(PartialOrd, Ord, Eq, Clone, PartialEq, ::prost::Message)]
-pub struct NodeProviderRewardsKey {
-    #[prost(message, optional, tag = "1")]
-    pub principal_id: ::core::option::Option<::ic_base_types::PrincipalId>,
-    #[prost(message, optional, tag = "2")]
-    pub end_day: ::core::option::Option<DayUtc>,
-    #[prost(message, optional, tag = "3")]
-    pub start_day: ::core::option::Option<DayUtc>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SubnetsFailureRateValue {
-    #[prost(message, optional, tag = "1")]
-    pub subnet_fr_percent: ::core::option::Option<::ic_nervous_system_proto::pb::v1::Decimal>,
-}
-#[derive(PartialOrd, Ord, Eq, Clone, PartialEq, ::prost::Message)]
-pub struct SubnetsFailureRateKey {
-    #[prost(message, optional, tag = "1")]
-    pub day: ::core::option::Option<DayUtc>,
-    #[prost(message, optional, tag = "2")]
-    pub subnet_id: ::core::option::Option<::ic_base_types::PrincipalId>,
-}

--- a/rs/node_rewards/canister/protobuf/src/lib.rs
+++ b/rs/node_rewards/canister/protobuf/src/lib.rs
@@ -105,36 +105,6 @@ impl Storable for pb::rewards_calculator::v1::NodeProviderRewards {
     const BOUND: Bound = Bound::Unbounded;
 }
 
-impl Storable for pb::rewards_calculator::v1::NodeProviderRewardsKey {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        Cow::Owned(self.encode_to_vec())
-    }
-    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
-        Self::decode(bytes.as_ref()).unwrap()
-    }
-    const BOUND: Bound = Bound::Unbounded;
-}
-
-impl Storable for pb::rewards_calculator::v1::SubnetsFailureRateKey {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        Cow::Owned(self.encode_to_vec())
-    }
-    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
-        Self::decode(bytes.as_ref()).unwrap()
-    }
-    const BOUND: Bound = Bound::Unbounded;
-}
-
-impl Storable for pb::rewards_calculator::v1::SubnetsFailureRateValue {
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        Cow::Owned(self.encode_to_vec())
-    }
-    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
-        Self::decode(bytes.as_ref()).unwrap()
-    }
-    const BOUND: Bound = Bound::Unbounded;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -24,7 +24,6 @@ use ic_registry_keys::{
 };
 use ic_registry_node_provider_rewards::{calculate_rewards_v0, RewardsPerNodeProvider};
 use ic_types::RegistryVersion;
-use itertools::Itertools;
 use rewards_calculation::rewards_calculator::RewardsCalculatorInput;
 use rewards_calculation::rewards_calculator_results::RewardsCalculatorResults;
 use rewards_calculation::types::RewardPeriod;

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -121,7 +121,6 @@ impl NodeRewardsCanister {
     fn calculate_rewards<S: RegistryDataStableMemory>(
         &self,
         request: GetNodeProvidersRewardsRequest,
-        provider_filter: Option<PrincipalId>,
     ) -> Result<RewardsCalculatorResults, String> {
         let reward_period = RewardPeriod::new(request.from_nanos.into(), request.to_nanos.into())
             .map_err(|e| e.to_string())?;
@@ -134,16 +133,12 @@ impl NodeRewardsCanister {
         let daily_metrics_by_subnet = self
             .metrics_manager
             .daily_metrics_by_subnet(reward_period.from, reward_period.to);
-        let mut provider_rewardable_nodes =
-            RegistryQuerier::get_rewardable_nodes_per_provider::<S>(
-                &*self.registry_client,
-                reward_period.from,
-                reward_period.to,
-            )
-            .map_err(|e| format!("Could not get rewardable nodes: {e:?}"))?;
-        if let Some(provider_id) = provider_filter {
-            provider_rewardable_nodes.retain(|p, _| p == &provider_id);
-        }
+        let provider_rewardable_nodes = RegistryQuerier::get_rewardable_nodes_per_provider::<S>(
+            &*self.registry_client,
+            reward_period.from,
+            reward_period.to,
+        )
+        .map_err(|e| format!("Could not get rewardable nodes: {e:?}"))?;
 
         let input = RewardsCalculatorInput {
             reward_period,
@@ -243,8 +238,7 @@ impl NodeRewardsCanister {
                 )
             })?;
         NodeRewardsCanister::schedule_metrics_sync(canister).await;
-        let result =
-            canister.with_borrow(|canister| canister.calculate_rewards::<S>(request, None))?;
+        let result = canister.with_borrow(|canister| canister.calculate_rewards::<S>(request))?;
         let rewards_xdr_permyriad = result
             .provider_results
             .iter()
@@ -267,9 +261,8 @@ impl NodeRewardsCanister {
             from_nanos: request.from_nanos,
             to_nanos: request.to_nanos,
         };
-        let mut result = canister.with_borrow(|canister| {
-            canister.calculate_rewards::<S>(request_inner, Some(provider_id))
-        })?;
+        let mut result =
+            canister.with_borrow(|canister| canister.calculate_rewards::<S>(request_inner))?;
         let node_provider_rewards = result.provider_results.remove(&provider_id).ok_or(format!(
             "No rewards found for node provider {}",
             provider_id

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -1,21 +1,17 @@
 use crate::metrics::MetricsManager;
 use crate::registry_querier::RegistryQuerier;
-use crate::storage::{HISTORICAL_REWARDS, HISTORICAL_SUBNETS_FR, VM};
-use ic_base_types::SubnetId;
+use crate::storage::VM;
+use ic_base_types::{PrincipalId, SubnetId};
 use ic_interfaces_registry::ZERO_REGISTRY_VERSION;
 use ic_node_rewards_canister_api::monthly_rewards::{
     GetNodeProvidersMonthlyXdrRewardsRequest, GetNodeProvidersMonthlyXdrRewardsResponse,
     NodeProvidersMonthlyXdrRewards,
 };
 use ic_node_rewards_canister_api::provider_rewards_calculation::{
-    GetHistoricalRewardPeriodsResponse, GetNodeProviderRewardsCalculationRequest,
-    GetNodeProviderRewardsCalculationResponse, HistoricalRewardPeriod,
+    GetNodeProviderRewardsCalculationRequest, GetNodeProviderRewardsCalculationResponse,
 };
 use ic_node_rewards_canister_api::providers_rewards::{
     GetNodeProvidersRewardsRequest, GetNodeProvidersRewardsResponse, NodeProvidersRewards,
-};
-use ic_node_rewards_canister_protobuf::pb::rewards_calculator::v1::{
-    DayUtc, NodeProviderRewardsKey, SubnetsFailureRateKey, SubnetsFailureRateValue,
 };
 use ic_protobuf::registry::dc::v1::DataCenterRecord;
 use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
@@ -125,6 +121,7 @@ impl NodeRewardsCanister {
     fn calculate_rewards<S: RegistryDataStableMemory>(
         &self,
         request: GetNodeProvidersRewardsRequest,
+        provider_filter: Option<PrincipalId>,
     ) -> Result<RewardsCalculatorResults, String> {
         let reward_period = RewardPeriod::new(request.from_nanos.into(), request.to_nanos.into())
             .map_err(|e| e.to_string())?;
@@ -137,12 +134,16 @@ impl NodeRewardsCanister {
         let daily_metrics_by_subnet = self
             .metrics_manager
             .daily_metrics_by_subnet(reward_period.from, reward_period.to);
-        let provider_rewardable_nodes = RegistryQuerier::get_rewardable_nodes_per_provider::<S>(
-            &*self.registry_client,
-            reward_period.from,
-            reward_period.to,
-        )
-        .map_err(|e| format!("Could not get rewardable nodes: {e:?}"))?;
+        let mut provider_rewardable_nodes =
+            RegistryQuerier::get_rewardable_nodes_per_provider::<S>(
+                &*self.registry_client,
+                reward_period.from,
+                reward_period.to,
+            )
+            .map_err(|e| format!("Could not get rewardable nodes: {e:?}"))?;
+        if let Some(provider_id) = provider_filter {
+            provider_rewardable_nodes.retain(|p, _| p == &provider_id);
+        }
 
         let input = RewardsCalculatorInput {
             reward_period,
@@ -242,7 +243,8 @@ impl NodeRewardsCanister {
                 )
             })?;
         NodeRewardsCanister::schedule_metrics_sync(canister).await;
-        let result = canister.with_borrow(|canister| canister.calculate_rewards::<S>(request))?;
+        let result =
+            canister.with_borrow(|canister| canister.calculate_rewards::<S>(request, None))?;
         let rewards_xdr_permyriad = result
             .provider_results
             .iter()
@@ -250,30 +252,6 @@ impl NodeRewardsCanister {
                 (provider_id.0, provider_rewards.rewards_total_xdr_permyriad)
             })
             .collect();
-
-        HISTORICAL_SUBNETS_FR.with_borrow_mut(|historical_subnets_fr| {
-            for ((day, subnet_id), subnet_fr_percent) in result.subnets_fr {
-                let key = SubnetsFailureRateKey {
-                    day: Some(day.into()),
-                    subnet_id: Some(subnet_id.get()),
-                };
-                let value = SubnetsFailureRateValue {
-                    subnet_fr_percent: Some(subnet_fr_percent.into()),
-                };
-                historical_subnets_fr.insert(key, value);
-            }
-        });
-
-        HISTORICAL_REWARDS.with_borrow_mut(|historical_rewards| {
-            for (provider_id, provider_rewards) in result.provider_results {
-                let key = NodeProviderRewardsKey {
-                    principal_id: Some(provider_id),
-                    end_day: Some(result.end_day.into()),
-                    start_day: Some(result.start_day.into()),
-                };
-                historical_rewards.insert(key, provider_rewards.into());
-            }
-        });
 
         Ok(NodeProvidersRewards {
             rewards_xdr_permyriad,
@@ -284,70 +262,20 @@ impl NodeRewardsCanister {
         canister: &'static LocalKey<RefCell<NodeRewardsCanister>>,
         request: GetNodeProviderRewardsCalculationRequest,
     ) -> GetNodeProviderRewardsCalculationResponse {
-        let provider_id = ic_base_types::PrincipalId::from(request.provider_id);
-        if request.historical {
-            let reward_key = NodeProviderRewardsKey {
-                principal_id: Some(provider_id),
-                end_day: Some(DayUtc {
-                    value: Some(request.to_nanos),
-                }),
-                start_day: Some(DayUtc {
-                    value: Some(request.from_nanos),
-                }),
-            };
-            HISTORICAL_REWARDS
-                .with_borrow(|historical_rewards| historical_rewards.get(&reward_key))
-                .ok_or(format!(
-                    "No historical rewards found for node provider {}",
-                    provider_id
-                ))
-        } else {
-            let request_inner = GetNodeProvidersRewardsRequest {
-                from_nanos: request.from_nanos,
-                to_nanos: request.to_nanos,
-            };
-            let mut result =
-                canister.with_borrow(|canister| canister.calculate_rewards::<S>(request_inner))?;
-            let node_provider_rewards = result.provider_results.remove(&provider_id).ok_or(
-                format!("No rewards found for node provider {}", provider_id),
-            )?;
+        let provider_id = PrincipalId::from(request.provider_id);
+        let request_inner = GetNodeProvidersRewardsRequest {
+            from_nanos: request.from_nanos,
+            to_nanos: request.to_nanos,
+        };
+        let mut result = canister.with_borrow(|canister| {
+            canister.calculate_rewards::<S>(request_inner, Some(provider_id))
+        })?;
+        let node_provider_rewards = result.provider_results.remove(&provider_id).ok_or(format!(
+            "No rewards found for node provider {}",
+            provider_id
+        ))?;
 
-            Ok(node_provider_rewards.into())
-        }
-    }
-
-    pub fn get_historical_reward_periods() -> GetHistoricalRewardPeriodsResponse {
-        Ok(HISTORICAL_REWARDS.with_borrow(|historical_rewards| {
-            historical_rewards
-                .keys()
-                .filter_map(|reward_key| {
-                    match (
-                        reward_key.principal_id,
-                        reward_key.start_day,
-                        reward_key.end_day,
-                    ) {
-                        (
-                            Some(principal_id),
-                            Some(DayUtc {
-                                value: Some(ts_start),
-                            }),
-                            Some(DayUtc {
-                                value: Some(ts_end),
-                            }),
-                        ) => Some((principal_id, ts_start, ts_end)),
-                        _ => None,
-                    }
-                })
-                .sorted_by_key(|(_, ts_start, ts_end)| (*ts_start, *ts_end))
-                .group_by(|(_, ts_start, ts_end)| (*ts_start, *ts_end))
-                .into_iter()
-                .map(|((ts_start, ts_end), group)| HistoricalRewardPeriod {
-                    from_nanos: ts_start,
-                    to_nanos: ts_end,
-                    providers_rewarded: group.map(|(principal_id, _, _)| principal_id.0).collect(),
-                })
-                .collect()
-        }))
+        Ok(node_provider_rewards.into())
     }
 }
 

--- a/rs/node_rewards/canister/src/canister/test/get_node_providers_rewards.rs
+++ b/rs/node_rewards/canister/src/canister/test/get_node_providers_rewards.rs
@@ -608,7 +608,7 @@ fn test_get_node_providers_rewards() {
     .unwrap();
 
     let inner_results = CANISTER_TEST
-        .with_borrow(|canister| canister.calculate_rewards::<TestState>(request, None))
+        .with_borrow(|canister| canister.calculate_rewards::<TestState>(request))
         .unwrap();
     let expected: BTreeMap<PrincipalId, NodeProviderRewards> =
         serde_json::from_str(EXPECTED_TEST_1).unwrap();

--- a/rs/node_rewards/canister/src/canister/test/get_node_providers_rewards.rs
+++ b/rs/node_rewards/canister/src/canister/test/get_node_providers_rewards.rs
@@ -3,21 +3,14 @@ use crate::canister::test::test_utils::{
 };
 use crate::canister::NodeRewardsCanister;
 use crate::metrics::MetricsManager;
-use crate::storage::HISTORICAL_REWARDS;
-use candid::Principal;
 use futures_util::FutureExt;
 use ic_nervous_system_canisters::registry::fake::FakeRegistry;
-use ic_node_rewards_canister_api::provider_rewards_calculation::{
-    GetNodeProviderRewardsCalculationRequest, HistoricalRewardPeriod,
-};
+use ic_node_rewards_canister_api::provider_rewards_calculation::GetNodeProviderRewardsCalculationRequest;
 use ic_node_rewards_canister_api::providers_rewards::{
     GetNodeProvidersRewardsRequest, NodeProvidersRewards,
 };
 use ic_node_rewards_canister_protobuf::pb::ic_node_rewards::v1::{
     NodeMetrics, SubnetMetricsKey, SubnetMetricsValue,
-};
-use ic_node_rewards_canister_protobuf::pb::rewards_calculator::v1::{
-    NodeProviderRewards as NodeProviderRewardsProto, NodeProviderRewardsKey,
 };
 use ic_protobuf::registry::dc::v1::DataCenterRecord;
 use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
@@ -615,7 +608,7 @@ fn test_get_node_providers_rewards() {
     .unwrap();
 
     let inner_results = CANISTER_TEST
-        .with_borrow(|canister| canister.calculate_rewards::<TestState>(request))
+        .with_borrow(|canister| canister.calculate_rewards::<TestState>(request, None))
         .unwrap();
     let expected: BTreeMap<PrincipalId, NodeProviderRewards> =
         serde_json::from_str(EXPECTED_TEST_1).unwrap();
@@ -628,81 +621,6 @@ fn test_get_node_providers_rewards() {
         },
     };
     assert_eq!(result_endpoint, Ok(expected));
-
-    HISTORICAL_REWARDS.with_borrow(|historical_rewards| {
-        let p1 = test_provider_id(1);
-        let p2 = test_provider_id(2);
-        let mut key = NodeProviderRewardsKey {
-            principal_id: Some(p1),
-            start_day: Some(from.into()),
-            end_day: Some(to.into()),
-        };
-
-        let p1_rewards = historical_rewards.get(&key).unwrap();
-        key.principal_id = Some(p2);
-        let p2_rewards = historical_rewards.get(&key).unwrap();
-
-        assert_eq!(
-            inner_results
-                .provider_results
-                .get(&p1)
-                .cloned()
-                .map(|r| r.into()),
-            Some(p1_rewards)
-        );
-        assert_eq!(
-            inner_results
-                .provider_results
-                .get(&p2)
-                .cloned()
-                .map(|r| r.into()),
-            Some(p2_rewards)
-        );
-    })
-}
-
-#[test]
-fn test_get_historical_reward_periods() {
-    let reward_periods = btreemap! {
-        "2024-01-01" => "2024-01-31",
-        "2024-02-01" => "2024-02-28",
-    }
-    .into_iter()
-    .map(|(from, to)| {
-        (
-            DayUtc::try_from(from).unwrap(),
-            DayUtc::try_from(to).unwrap(),
-        )
-    })
-    .collect::<BTreeMap<DayUtc, DayUtc>>();
-
-    let providers: Vec<PrincipalId> = (0..10).map(|idx| test_provider_id(idx as u64)).collect();
-
-    HISTORICAL_REWARDS.with_borrow_mut(|historical_rewards| {
-        for (from, to) in reward_periods.clone() {
-            for provider in providers.clone() {
-                let key = NodeProviderRewardsKey {
-                    principal_id: Some(provider),
-                    start_day: Some(from.into()),
-                    end_day: Some(to.into()),
-                };
-                let rewards = NodeProviderRewardsProto::default();
-                historical_rewards.insert(key, rewards);
-            }
-        }
-    });
-
-    let providers: Vec<Principal> = providers.into_iter().map(|p| p.0).collect();
-
-    let got = NodeRewardsCanister::get_historical_reward_periods().unwrap();
-    for (from, to) in reward_periods {
-        let expected = HistoricalRewardPeriod {
-            from_nanos: from.get(),
-            to_nanos: to.get(),
-            providers_rewarded: providers.clone(),
-        };
-        assert!(got.contains(&expected));
-    }
 }
 
 #[test]
@@ -735,7 +653,6 @@ fn test_get_node_provider_rewards_calculation_historical() {
             from_nanos: from.unix_ts_at_day_end(),
             to_nanos: to.unix_ts_at_day_end(),
             provider_id: provider_id.0,
-            historical: true,
         };
 
         let got = NodeRewardsCanister::get_node_provider_rewards_calculation::<TestState>(

--- a/rs/node_rewards/canister/src/main.rs
+++ b/rs/node_rewards/canister/src/main.rs
@@ -9,8 +9,7 @@ use ic_node_rewards_canister_api::monthly_rewards::{
     GetNodeProvidersMonthlyXdrRewardsRequest, GetNodeProvidersMonthlyXdrRewardsResponse,
 };
 use ic_node_rewards_canister_api::provider_rewards_calculation::{
-    GetHistoricalRewardPeriodsResponse, GetNodeProviderRewardsCalculationRequest,
-    GetNodeProviderRewardsCalculationResponse,
+    GetNodeProviderRewardsCalculationRequest, GetNodeProviderRewardsCalculationResponse,
 };
 use ic_node_rewards_canister_api::providers_rewards::{
     GetNodeProvidersRewardsRequest, GetNodeProvidersRewardsResponse,
@@ -134,18 +133,6 @@ fn get_node_provider_rewards_calculation(
     NodeRewardsCanister::get_node_provider_rewards_calculation::<RegistryStoreStableMemoryBorrower>(
         &CANISTER, request,
     )
-}
-
-#[query]
-fn get_historical_reward_periods() -> GetHistoricalRewardPeriodsResponse {
-    if in_replicated_execution() {
-        return Err(
-            "Replicated execution of this method is not allowed. Use a non-replicated query call."
-                .to_string(),
-        );
-    }
-
-    NodeRewardsCanister::get_historical_reward_periods()
 }
 
 #[cfg(test)]

--- a/rs/node_rewards/canister/src/storage.rs
+++ b/rs/node_rewards/canister/src/storage.rs
@@ -1,7 +1,4 @@
 use crate::metrics::{ICCanisterClient, MetricsManager};
-use ic_node_rewards_canister_protobuf::pb::rewards_calculator::v1::{
-    NodeProviderRewards, NodeProviderRewardsKey, SubnetsFailureRateKey, SubnetsFailureRateValue,
-};
 use ic_registry_canister_client::{
     RegistryDataStableMemory, StorableRegistryKey, StorableRegistryValue,
 };
@@ -14,8 +11,6 @@ const REGISTRY_STORE_MEMORY_ID: MemoryId = MemoryId::new(0);
 const SUBNETS_METRICS_MEMORY_ID: MemoryId = MemoryId::new(1);
 const LAST_TIMESTAMP_PER_SUBNET_MEMORY_ID: MemoryId = MemoryId::new(2);
 const SUBNETS_TO_RETRY_MEMORY_ID: MemoryId = MemoryId::new(3);
-const HISTORICAL_REWARDS_MEMORY_ID: MemoryId = MemoryId::new(4);
-const HISTORICAL_SUBNETS_FR_MEMORY_ID: MemoryId = MemoryId::new(5);
 
 pub type VM = VirtualMemory<DefaultMemoryImpl>;
 
@@ -42,16 +37,6 @@ thread_local! {
 
         Rc::new(metrics_manager)
     };
-
-    pub static HISTORICAL_REWARDS: RefCell<StableBTreeMap<NodeProviderRewardsKey, NodeProviderRewards, VM>>
-        = RefCell::new(MEMORY_MANAGER.with_borrow(|mm|
-            StableBTreeMap::init(mm.get(HISTORICAL_REWARDS_MEMORY_ID))
-        ));
-
-    pub static HISTORICAL_SUBNETS_FR: RefCell<StableBTreeMap<SubnetsFailureRateKey, SubnetsFailureRateValue, VM>>
-        = RefCell::new(MEMORY_MANAGER.with_borrow(|mm|
-            StableBTreeMap::init(mm.get(HISTORICAL_SUBNETS_FR_MEMORY_ID))
-        ));
 
     static REGISTRY_DATA_STORE_BTREE_MAP: RefCell<StableBTreeMap<StorableRegistryKey, StorableRegistryValue, VM>>
         = RefCell::new(MEMORY_MANAGER.with_borrow(|mm|

--- a/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
+++ b/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
@@ -76,47 +76,38 @@ async fn get_node_provider_rewards_calculation_is_only_callable_in_nonreplicated
     pocket_ic.advance_time(Duration::from_secs(86_400)).await;
     pocket_ic.tick().await;
 
-    for historical in [false, true] {
-        let request = GetNodeProviderRewardsCalculationRequest {
-            from_nanos: past_time_nanos,
-            to_nanos: past_time_nanos,
-            provider_id: Principal::anonymous(),
-        };
+    let request = GetNodeProviderRewardsCalculationRequest {
+        from_nanos: past_time_nanos,
+        to_nanos: past_time_nanos,
+        provider_id: Principal::anonymous(),
+    };
 
-        // Non-replicated query call is allowed.
-        let err = query_candid::<_, (GetNodeProviderRewardsCalculationResponse,)>(
-            &pocket_ic,
-            node_rewards_id,
-            "get_node_provider_rewards_calculation",
-            (request.clone(),),
-        )
-        .await
-        .unwrap()
-        .0
-        .unwrap_err();
-        let maybe_historical = if historical { "historical " } else { "" };
-        assert_eq!(
-            err,
-            format!(
-                "No {}rewards found for node provider 2vxsx-fae",
-                maybe_historical
-            )
-        );
+    // Non-replicated query call is allowed.
+    let err = query_candid::<_, (GetNodeProviderRewardsCalculationResponse,)>(
+        &pocket_ic,
+        node_rewards_id,
+        "get_node_provider_rewards_calculation",
+        (request.clone(),),
+    )
+    .await
+    .unwrap()
+    .0
+    .unwrap_err();
+    assert_eq!(err, "No rewards found for node provider 2vxsx-fae");
 
-        // Replicated update call is not allowed.
-        let err = update_candid::<_, (GetNodeProviderRewardsCalculationResponse,)>(
-            &pocket_ic,
-            node_rewards_id,
-            "get_node_provider_rewards_calculation",
-            (request,),
-        )
-        .await
-        .unwrap()
-        .0
-        .unwrap_err();
-        assert_eq!(
-            err,
-            "Replicated execution of this method is not allowed. Use a non-replicated query call."
-        );
-    }
+    // Replicated update call is not allowed.
+    let err = update_candid::<_, (GetNodeProviderRewardsCalculationResponse,)>(
+        &pocket_ic,
+        node_rewards_id,
+        "get_node_provider_rewards_calculation",
+        (request,),
+    )
+    .await
+    .unwrap()
+    .0
+    .unwrap_err();
+    assert_eq!(
+        err,
+        "Replicated execution of this method is not allowed. Use a non-replicated query call."
+    );
 }

--- a/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
+++ b/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
@@ -5,8 +5,7 @@ use ic_nns_constants::NODE_REWARDS_CANISTER_ID;
 use ic_nns_test_utils::common::build_node_rewards_test_wasm;
 use ic_node_rewards_canister_api::monthly_rewards::GetNodeProvidersMonthlyXdrRewardsRequest;
 use ic_node_rewards_canister_api::provider_rewards_calculation::{
-    GetHistoricalRewardPeriodsResponse, GetNodeProviderRewardsCalculationRequest,
-    GetNodeProviderRewardsCalculationResponse,
+    GetNodeProviderRewardsCalculationRequest, GetNodeProviderRewardsCalculationResponse,
 };
 use ic_types::PrincipalId;
 use pocket_ic::common::rest::{EmptyConfig, IcpFeatures};
@@ -82,7 +81,6 @@ async fn get_node_provider_rewards_calculation_is_only_callable_in_nonreplicated
             from_nanos: past_time_nanos,
             to_nanos: past_time_nanos,
             provider_id: Principal::anonymous(),
-            historical,
         };
 
         // Non-replicated query call is allowed.
@@ -121,39 +119,4 @@ async fn get_node_provider_rewards_calculation_is_only_callable_in_nonreplicated
             "Replicated execution of this method is not allowed. Use a non-replicated query call."
         );
     }
-}
-
-#[tokio::test]
-async fn get_historical_reward_periods_is_only_callable_in_nonreplicated_mode() {
-    let pocket_ic = setup_env().await;
-    let node_rewards_id = NODE_REWARDS_CANISTER_ID.get().0;
-
-    // Non-replicated query call is allowed.
-    let res = query_candid::<_, (GetHistoricalRewardPeriodsResponse,)>(
-        &pocket_ic,
-        node_rewards_id,
-        "get_historical_reward_periods",
-        (),
-    )
-    .await
-    .unwrap()
-    .0
-    .unwrap();
-    assert!(res.is_empty());
-
-    // Replicated update call is not allowed.
-    let err = update_candid::<_, (GetHistoricalRewardPeriodsResponse,)>(
-        &pocket_ic,
-        node_rewards_id,
-        "get_historical_reward_periods",
-        (),
-    )
-    .await
-    .unwrap()
-    .0
-    .unwrap_err();
-    assert_eq!(
-        err,
-        "Replicated execution of this method is not allowed. Use a non-replicated query call."
-    );
 }


### PR DESCRIPTION
Changes:

- Remove historical rewards storage
- Remove APIs for retrieving historical rewards as they will be recomputed whenever is needed. Gov. canister will store breadcrumbs to recompute rewards