### PR TITLE
fix(recovery): escape ic-recovery filepaths

### DIFF
--- a/rs/recovery/src/file_sync_helper.rs
+++ b/rs/recovery/src/file_sync_helper.rs
@@ -255,6 +255,6 @@ mod tests {
                 "/tmp/src",
                 "/tmp/target",
                 "-e",
-                "ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=0 -o ConnectionAttempts=4 -o ConnectTimeout=15 -A -i /tmp/key_file"]);
+                "ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=0 -o ConnectionAttempts=4 -o ConnectTimeout=15 -A -i \"/tmp/key_file\""]);
     }
 }

--- a/rs/recovery/src/ssh_helper.rs
+++ b/rs/recovery/src/ssh_helper.rs
@@ -93,9 +93,10 @@ impl SshHelper {
 
 /// Return the configured SSH command options as an environment argument usable by `rsync`.
 pub fn get_rsync_ssh_arg(key_file: Option<&PathBuf>) -> String {
-    let mut arg = format!("ssh {}", SSH_ARGS.join(" "));
+    let mut arg = Command::new("ssh");
+    arg.args(SSH_ARGS);
     if let Some(file) = key_file {
-        arg.push_str(&format!(" -i {}", file.display()));
+        arg.arg("-i").arg(file);
     }
-    arg
+    format!("{:?}", arg)
 }

--- a/rs/recovery/src/ssh_helper.rs
+++ b/rs/recovery/src/ssh_helper.rs
@@ -93,10 +93,10 @@ impl SshHelper {
 
 /// Return the configured SSH command options as an environment argument usable by `rsync`.
 pub fn get_rsync_ssh_arg(key_file: Option<&PathBuf>) -> String {
-    let mut arg = Command::new("ssh");
-    arg.args(SSH_ARGS);
+    let mut arg = format!("ssh {}", SSH_ARGS.join(" "));
     if let Some(file) = key_file {
-        arg.arg("-i").arg(file);
+        // We use debug formatting because it escapes the path in case it contains spaces.
+        arg.push_str(&format!(" -i {file:?}"));
     }
-    format!("{:?}", arg)
+    arg
 }

--- a/rs/recovery/src/steps.rs
+++ b/rs/recovery/src/steps.rs
@@ -1064,27 +1064,29 @@ impl CreateNNSRecoveryTarStep {
     }
 
     fn get_create_commands(&self) -> String {
+        // We use debug formatting because it escapes the paths in case they contain spaces.
         format!(
             r#"
-mkdir -p {output_dir}
-tar --zstd -cvf {output_dir}/{tar_name} -C {work_dir} cup.proto {IC_REGISTRY_LOCAL_STORE}.tar.zst
+mkdir -p {output_dir:?}
+tar --zstd -cvf {tar_file:?} -C {work_dir:?} cup.proto {IC_REGISTRY_LOCAL_STORE}.tar.zst
 
-artifacts_hash="$(sha256sum {output_dir}/{tar_name} | cut -d ' ' -f1)"
-echo "$artifacts_hash" > {output_dir}/{sha_name}
+artifacts_hash="$(sha256sum {tar_file:?} | cut -d ' ' -f1)"
+echo "$artifacts_hash" > {sha_file:?}
             "#,
-            output_dir = self.output_dir.display(),
-            tar_name = self.get_tar_name(),
-            sha_name = self.get_sha_name(),
-            work_dir = self.work_dir.display(),
+            output_dir = self.output_dir,
+            tar_file = self.output_dir.join(self.get_tar_name()),
+            sha_file = self.output_dir.join(self.get_sha_name()),
+            work_dir = self.work_dir,
         )
     }
 
     fn get_next_steps(&self, artifacts_hash: &str) -> String {
+        // We use debug formatting because it escapes the paths in case they contain spaces.
         format!(
             r#"
-Recovery artifacts with checksum {artifacts_hash} were successfully created in {output_dir}.
+Recovery artifacts with checksum {artifacts_hash} were successfully created in {output_dir:?}.
 Now please:
-  - Upload {output_dir}/{tar_name} to:
+  - Upload {tar_file:?} to:
     - https://download.dfinity.systems/recovery/{artifacts_hash}/{tar_name}
     - https://download.dfinity.network/recovery/{artifacts_hash}/{tar_name}
   - Run the following command and commit + push to a branch of dfinity/ic:
@@ -1092,7 +1094,8 @@ Now please:
   - Build a recovery image from that branch.
   - Provide other Node Providers with the commit hash as version and the image hash. Ask them to reboot and follow the recovery instructions.
             "#,
-            output_dir = self.output_dir.display(),
+            output_dir = self.output_dir,
+            tar_file = self.output_dir.join(self.get_tar_name()),
             tar_name = self.get_tar_name(),
         )
     }


### PR DESCRIPTION
The code breaks if the path to the key file or output directory have a space in them.

A concrete example is by running a system test with a space inside its name. For example, launching a system test with `.add_test(systest!(nns_recovery_test; TestConfig {}))` (which will be the format for NNS recovery tests) gives the path `…/tests/nns_recovery_test (TestConfig {})/ssh/authorized_priv_keys/admin`.

This PR properly escapes the paths (I tested using the path above, and it now works).