### PR TITLE
fix: use docker-compatible authentication file

### DIFF
--- a/.github/workflows/rosetta-release.yml
+++ b/.github/workflows/rosetta-release.yml
@@ -32,7 +32,11 @@ jobs:
 
       - name: Login to Docker
         run: |
-          podman login -u ${{ vars.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_PASSWORD }} docker.io
+          # --compat-auth-file is required by rules_oci/crane.
+          mkdir -p "$HOME/.docker"
+          podman login \
+            --compat-auth-file="$HOME/.docker/config.json" \
+            -u ${{ vars.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_PASSWORD }} docker.io
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
The `rules_oci` use `crane` under the hood which only understand `docker`-style credentials, so we ask `podman` to use `docker`-compatible credentials when performing `login`.