### PR TITLE
chore(nns): Clean up making_sns_proposal

### DIFF
--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -2708,7 +2708,6 @@ pub struct Governance {
     /// Whether the heartbeat function is currently spawning neurons, meaning
     /// that it should finish before being called again.
     pub spawning_neurons: Option<bool>,
-    pub making_sns_proposal: Option<governance::MakingSnsProposal>,
     /// Local cache for XDR-related conversion rates (the source of truth is in the CMC canister).
     pub xdr_conversion_rate: Option<XdrConversionRate>,
     /// The summary of restore aging event.
@@ -2866,22 +2865,6 @@ pub mod governance {
             pub deciding_voting_power_buckets: ::std::collections::HashMap<u64, u64>,
             pub potential_voting_power_buckets: ::std::collections::HashMap<u64, u64>,
         }
-    }
-    /// Records that making an OpenSnsTokenSwap (OSTS) or CreateServiceNervousSystem (CSNS)
-    /// proposal is in progress. We only want one of these to be happening at the same time,
-    /// because otherwise, it is error prone to enforce that open OSTS or CSNS proposals are
-    /// unique. In particular, the result of checking that the proposal currently being made
-    /// would be unique is liable to becoming invalid during an .await.
-    ///
-    /// This is a temporary measure, because OSTS is part of the SNS flow that will
-    /// be replaced by 1-proposal very soon.
-    #[derive(
-        candid::CandidType, candid::Deserialize, serde::Serialize, Clone, PartialEq, Debug, Default,
-    )]
-    pub struct MakingSnsProposal {
-        pub proposer_id: Option<NeuronId>,
-        pub caller: Option<PrincipalId>,
-        pub proposal: Option<super::Proposal>,
     }
 }
 #[derive(

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -311,7 +311,6 @@ type GlobalTimeOfDay = record {
 
 type Governance = record {
   default_followees : vec record { int32; Followees };
-  making_sns_proposal : opt MakingSnsProposal;
   most_recent_monthly_node_provider_rewards : opt MonthlyNodeProviderRewards;
   maturity_modulation_last_updated_at_timestamp_seconds : opt nat64;
   wait_for_quiet_threshold_seconds : nat64;
@@ -532,12 +531,6 @@ type MakeProposalRequest = record {
 type MakeProposalResponse = record {
   message : opt text;
   proposal_id : opt ProposalId;
-};
-
-type MakingSnsProposal = record {
-  proposal : opt Proposal;
-  caller : opt principal;
-  proposer_id : opt NeuronId;
 };
 
 // Not to be confused with ManageNeuronRequest. (Yes, this is very structurally

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -308,7 +308,6 @@ type GlobalTimeOfDay = record {
 
 type Governance = record {
   default_followees : vec record { int32; Followees };
-  making_sns_proposal : opt MakingSnsProposal;
   most_recent_monthly_node_provider_rewards : opt MonthlyNodeProviderRewards;
   maturity_modulation_last_updated_at_timestamp_seconds : opt nat64;
   wait_for_quiet_threshold_seconds : nat64;
@@ -510,12 +509,6 @@ type MakeProposalRequest = record {
 type MakeProposalResponse = record {
   message : opt text;
   proposal_id : opt ProposalId;
-};
-
-type MakingSnsProposal = record {
-  proposal : opt Proposal;
-  caller : opt principal;
-  proposer_id : opt NeuronId;
 };
 
 type ManageNeuron = record {

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2123,22 +2123,6 @@ message Governance {
   // that it should finish before being called again.
   optional bool spawning_neurons = 19;
 
-  // Records that making an OpenSnsTokenSwap (OSTS) or CreateServiceNervousSystem (CSNS)
-  // proposal is in progress. We only want one of these to be happening at the same time,
-  // because otherwise, it is error prone to enforce that open OSTS or CSNS proposals are
-  // unique. In particular, the result of checking that the proposal currently being made
-  // would be unique is liable to becoming invalid during an .await.
-  //
-  // This is a temporary measure, because OSTS is part of the SNS flow that will
-  // be replaced by 1-proposal very soon.
-  message MakingSnsProposal {
-    ic_nns_common.pb.v1.NeuronId proposer_id = 1;
-    ic_base_types.pb.v1.PrincipalId caller = 2;
-    Proposal proposal = 3;
-  }
-
-  MakingSnsProposal making_sns_proposal = 20;
-
   // Local cache for XDR-related conversion rates (the source of truth is in the CMC canister).
   optional XdrConversionRate xdr_conversion_rate = 26;
 
@@ -2171,6 +2155,10 @@ message Governance {
   // Reserved id for deprecated `neurons`
   reserved 1;
   reserved "neurons";
+
+  // Reserved id for deprecated `making_sns_proposal`
+  reserved 20;
+  reserved "making_sns_proposal";
 }
 
 message XdrConversionRate {

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -2862,8 +2862,6 @@ pub struct Governance {
     /// that it should finish before being called again.
     #[prost(bool, optional, tag = "19")]
     pub spawning_neurons: ::core::option::Option<bool>,
-    #[prost(message, optional, tag = "20")]
-    pub making_sns_proposal: ::core::option::Option<governance::MakingSnsProposal>,
     /// Local cache for XDR-related conversion rates (the source of truth is in the CMC canister).
     #[prost(message, optional, tag = "26")]
     pub xdr_conversion_rate: ::core::option::Option<XdrConversionRate>,
@@ -3106,31 +3104,6 @@ pub mod governance {
             #[prost(map = "uint64, uint64", tag = "14")]
             pub potential_voting_power_buckets: ::std::collections::HashMap<u64, u64>,
         }
-    }
-    /// Records that making an OpenSnsTokenSwap (OSTS) or CreateServiceNervousSystem (CSNS)
-    /// proposal is in progress. We only want one of these to be happening at the same time,
-    /// because otherwise, it is error prone to enforce that open OSTS or CSNS proposals are
-    /// unique. In particular, the result of checking that the proposal currently being made
-    /// would be unique is liable to becoming invalid during an .await.
-    ///
-    /// This is a temporary measure, because OSTS is part of the SNS flow that will
-    /// be replaced by 1-proposal very soon.
-    #[derive(
-        candid::CandidType,
-        candid::Deserialize,
-        serde::Serialize,
-        comparable::Comparable,
-        Clone,
-        PartialEq,
-        ::prost::Message,
-    )]
-    pub struct MakingSnsProposal {
-        #[prost(message, optional, tag = "1")]
-        pub proposer_id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
-        #[prost(message, optional, tag = "2")]
-        pub caller: ::core::option::Option<::ic_base_types::PrincipalId>,
-        #[prost(message, optional, tag = "3")]
-        pub proposal: ::core::option::Option<super::Proposal>,
     }
 }
 #[derive(

--- a/rs/nns/governance/src/heap_governance_data.rs
+++ b/rs/nns/governance/src/heap_governance_data.rs
@@ -1,7 +1,7 @@
 use crate::{
     neuron::Neuron,
     pb::v1::{
-        governance::{GovernanceCachedMetrics, MakingSnsProposal, NeuronInFlightCommand},
+        governance::{GovernanceCachedMetrics, NeuronInFlightCommand},
         Followees, Governance as GovernanceProto, MonthlyNodeProviderRewards, NetworkEconomics,
         NeuronStakeTransfer, NodeProvider, ProposalData, RestoreAgingSummary, RewardEvent,
         XdrConversionRate as XdrConversionRatePb,
@@ -33,7 +33,6 @@ pub struct HeapGovernanceData {
     pub cached_daily_maturity_modulation_basis_points: Option<i32>,
     pub maturity_modulation_last_updated_at_timestamp_seconds: Option<u64>,
     pub spawning_neurons: Option<bool>,
-    pub making_sns_proposal: Option<MakingSnsProposal>,
     pub xdr_conversion_rate: XdrConversionRate,
     pub restore_aging_summary: Option<RestoreAgingSummary>,
 }
@@ -135,7 +134,6 @@ pub fn initialize_governance(
         cached_daily_maturity_modulation_basis_points,
         maturity_modulation_last_updated_at_timestamp_seconds,
         spawning_neurons,
-        making_sns_proposal,
         xdr_conversion_rate,
         restore_aging_summary,
     } = initial_governance;
@@ -156,7 +154,6 @@ pub fn initialize_governance(
     let metrics = metrics.map(|x| x.into());
     let most_recent_monthly_node_provider_rewards =
         most_recent_monthly_node_provider_rewards.map(|x| x.into());
-    let making_sns_proposal = making_sns_proposal.map(|x| x.into());
     let restore_aging_summary = restore_aging_summary.map(|x| x.into());
 
     // Third, fill in the missing fields.
@@ -204,7 +201,6 @@ pub fn initialize_governance(
         cached_daily_maturity_modulation_basis_points,
         maturity_modulation_last_updated_at_timestamp_seconds,
         spawning_neurons,
-        making_sns_proposal,
         xdr_conversion_rate,
         restore_aging_summary,
     };
@@ -243,7 +239,6 @@ pub fn split_governance_proto(
         cached_daily_maturity_modulation_basis_points,
         maturity_modulation_last_updated_at_timestamp_seconds,
         spawning_neurons,
-        making_sns_proposal,
         xdr_conversion_rate,
         restore_aging_summary,
         rng_seed,
@@ -282,7 +277,7 @@ pub fn split_governance_proto(
             cached_daily_maturity_modulation_basis_points,
             maturity_modulation_last_updated_at_timestamp_seconds,
             spawning_neurons,
-            making_sns_proposal,
+
             xdr_conversion_rate,
             restore_aging_summary,
         },
@@ -318,7 +313,7 @@ pub fn reassemble_governance_proto(
         cached_daily_maturity_modulation_basis_points,
         maturity_modulation_last_updated_at_timestamp_seconds,
         spawning_neurons,
-        making_sns_proposal,
+
         xdr_conversion_rate,
         restore_aging_summary,
     } = heap_governance_proto;
@@ -344,7 +339,7 @@ pub fn reassemble_governance_proto(
         cached_daily_maturity_modulation_basis_points,
         maturity_modulation_last_updated_at_timestamp_seconds,
         spawning_neurons,
-        making_sns_proposal,
+
         xdr_conversion_rate: Some(xdr_conversion_rate),
         restore_aging_summary,
         rng_seed: rng_seed.map(|seed| seed.to_vec()),
@@ -380,7 +375,6 @@ mod tests {
             cached_daily_maturity_modulation_basis_points: Some(6),
             maturity_modulation_last_updated_at_timestamp_seconds: Some(7),
             spawning_neurons: Some(true),
-            making_sns_proposal: Some(MakingSnsProposal::default()),
             xdr_conversion_rate: Some(XdrConversionRatePb {
                 timestamp_seconds: Some(1),
                 xdr_permyriad_per_icp: Some(50_000),

--- a/rs/nns/governance/src/pb/conversions/mod.rs
+++ b/rs/nns/governance/src/pb/conversions/mod.rs
@@ -2919,16 +2919,6 @@ impl From<pb_api::governance::governance_cached_metrics::NeuronSubsetMetrics>
     }
 }
 
-impl From<pb_api::governance::MakingSnsProposal> for pb::governance::MakingSnsProposal {
-    fn from(item: pb_api::governance::MakingSnsProposal) -> Self {
-        Self {
-            proposer_id: item.proposer_id,
-            caller: item.caller,
-            proposal: item.proposal.map(|x| x.into()),
-        }
-    }
-}
-
 impl From<pb::XdrConversionRate> for pb_api::XdrConversionRate {
     fn from(item: pb::XdrConversionRate) -> Self {
         Self {


### PR DESCRIPTION
# Why

The `making_sns_proposal` was used as a lock to prevent making a OpenSnsTokenSwap proposal and a CreateServiceNervousSystem proposal at the same time. Now that the former cannot be made, this lock is useless.

# What

Clean up all definitions and usage of `making_sns_proposal`