### PR TITLE
chore(nns): Remove `_stable` suffix in benchmarks as there is no `_heap` counterparts anymore

### DIFF
--- a/rs/nns/governance/canbench/canbench_results.yml
+++ b/rs/nns/governance/canbench/canbench_results.yml
@@ -1,12 +1,12 @@
 benches:
-  add_neuron_active_maximum_stable:
+  add_neuron_active_maximum:
     total:
       calls: 1
       instructions: 64864804
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  add_neuron_active_typical_stable:
+  add_neuron_active_typical:
     total:
       calls: 1
       instructions: 4558061
@@ -34,7 +34,7 @@ benches:
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
-  centralized_following_all_stable:
+  centralized_following_all:
     total:
       calls: 1
       instructions: 41716567
@@ -55,28 +55,28 @@ benches:
       heap_increase: 0
       stable_memory_increase: 256
     scopes: {}
-  draw_maturity_from_neurons_fund_stable:
+  draw_maturity_from_neurons_fund:
     total:
       calls: 1
       instructions: 7476971
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  list_active_neurons_fund_neurons_stable:
+  list_active_neurons_fund_neurons:
     total:
       calls: 1
       instructions: 2173617
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  list_neurons_by_subaccount_stable:
+  list_neurons_by_subaccount:
     total:
       calls: 1
       instructions: 62121572
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
-  list_neurons_stable:
+  list_neurons:
     total:
       calls: 1
       instructions: 63040420
@@ -90,21 +90,21 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  list_ready_to_spawn_neuron_ids_stable:
+  list_ready_to_spawn_neuron_ids:
     total:
       calls: 1
       instructions: 35915801
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  neuron_data_validation_stable:
+  neuron_data_validation:
     total:
       calls: 1
       instructions: 205505866
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  neuron_metrics_calculation_stable:
+  neuron_metrics_calculation:
     total:
       calls: 1
       instructions: 2640309
@@ -139,14 +139,14 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  single_vote_all_stable:
+  single_vote_all:
     total:
       calls: 1
       instructions: 277193
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
-  unstake_maturity_of_dissolved_neurons_stable:
+  unstake_maturity_of_dissolved_neurons:
     total:
       calls: 1
       instructions: 62896555
@@ -184,28 +184,28 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  with_neuron_mut_all_sections_maximum_stable:
+  with_neuron_mut_all_sections_maximum:
     total:
       calls: 1
       instructions: 4247543
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  with_neuron_mut_all_sections_typical_stable:
+  with_neuron_mut_all_sections_typical:
     total:
       calls: 1
       instructions: 847980
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  with_neuron_mut_main_section_maximum_stable:
+  with_neuron_mut_main_section_maximum:
     total:
       calls: 1
       instructions: 2344650
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-  with_neuron_mut_main_section_typical_stable:
+  with_neuron_mut_main_section_typical:
     total:
       calls: 1
       instructions: 395381

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -421,7 +421,7 @@ fn cascading_vote_stable_everything() -> BenchResult {
 }
 
 #[bench(raw)]
-fn single_vote_all_stable() -> BenchResult {
+fn single_vote_all() -> BenchResult {
     cast_vote_cascade_helper(
         SetUpStrategy::SingleVote { num_neurons: 151 },
         Topic::NetworkEconomics,
@@ -429,7 +429,7 @@ fn single_vote_all_stable() -> BenchResult {
 }
 
 #[bench(raw)]
-fn centralized_following_all_stable() -> BenchResult {
+fn centralized_following_all() -> BenchResult {
     cast_vote_cascade_helper(
         SetUpStrategy::Centralized { num_neurons: 151 },
         Topic::NetworkEconomics,
@@ -563,7 +563,7 @@ fn distribute_rewards_with_stable_neurons() -> BenchResult {
 }
 
 #[bench(raw)]
-fn list_neurons_stable() -> BenchResult {
+fn list_neurons() -> BenchResult {
     let mut governance = Governance::new(
         Default::default(),
         Arc::new(MockEnvironment::new(Default::default(), 0)),
@@ -599,7 +599,7 @@ fn list_neurons_stable() -> BenchResult {
 }
 
 #[bench(raw)]
-fn list_neurons_by_subaccount_stable() -> BenchResult {
+fn list_neurons_by_subaccount() -> BenchResult {
     let num_neurons = 100;
     let neurons = (1..=num_neurons)
         .map(|id| {
@@ -753,6 +753,6 @@ fn update_empty() {
 /// embedders crate.
 #[export_name = "canister_query go"]
 fn go() {
-    let _ = list_neurons_stable();
+    let _ = list_neurons();
     ic_cdk::api::msg_reply([]);
 }

--- a/rs/nns/governance/src/neuron_store/benches.rs
+++ b/rs/nns/governance/src/neuron_store/benches.rs
@@ -157,7 +157,7 @@ fn set_up_neuron_store(
 }
 
 #[bench(raw)]
-fn add_neuron_active_typical_stable() -> BenchResult {
+fn add_neuron_active_typical() -> BenchResult {
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron =
@@ -169,7 +169,7 @@ fn add_neuron_active_typical_stable() -> BenchResult {
 }
 
 #[bench(raw)]
-fn add_neuron_active_maximum_stable() -> BenchResult {
+fn add_neuron_active_maximum() -> BenchResult {
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let neuron =
@@ -236,22 +236,22 @@ fn modify_neuron_main_section(neuron: &mut Neuron) {
 }
 
 #[bench(raw)]
-fn with_neuron_mut_all_sections_typical_stable() -> BenchResult {
+fn with_neuron_mut_all_sections_typical() -> BenchResult {
     with_neuron_mut_benchmark(NeuronSize::Typical, modify_neuron_all_sections)
 }
 
 #[bench(raw)]
-fn with_neuron_mut_all_sections_maximum_stable() -> BenchResult {
+fn with_neuron_mut_all_sections_maximum() -> BenchResult {
     with_neuron_mut_benchmark(NeuronSize::Maximum, modify_neuron_all_sections)
 }
 
 #[bench(raw)]
-fn with_neuron_mut_main_section_typical_stable() -> BenchResult {
+fn with_neuron_mut_main_section_typical() -> BenchResult {
     with_neuron_mut_benchmark(NeuronSize::Typical, modify_neuron_main_section)
 }
 
 #[bench(raw)]
-fn with_neuron_mut_main_section_maximum_stable() -> BenchResult {
+fn with_neuron_mut_main_section_maximum() -> BenchResult {
     with_neuron_mut_benchmark(NeuronSize::Maximum, modify_neuron_main_section)
 }
 
@@ -352,7 +352,7 @@ fn neuron_metrics_benchmark() -> BenchResult {
 }
 
 #[bench(raw)]
-fn neuron_metrics_calculation_stable() -> BenchResult {
+fn neuron_metrics_calculation() -> BenchResult {
     neuron_metrics_benchmark()
 }
 
@@ -397,7 +397,7 @@ fn list_ready_to_spawn_neuron_ids_benchmark() -> BenchResult {
 }
 
 #[bench(raw)]
-fn list_ready_to_spawn_neuron_ids_stable() -> BenchResult {
+fn list_ready_to_spawn_neuron_ids() -> BenchResult {
     list_ready_to_spawn_neuron_ids_benchmark()
 }
 
@@ -423,7 +423,7 @@ fn add_neuron_ready_to_unstake_maturity(
 }
 
 #[bench(raw)]
-fn unstake_maturity_of_dissolved_neurons_stable() -> BenchResult {
+fn unstake_maturity_of_dissolved_neurons() -> BenchResult {
     let mut rng = new_rng();
     let mut neuron_store = set_up_neuron_store(&mut rng, 1_000, 2_000);
     for _ in 0..100 {
@@ -482,7 +482,7 @@ fn draw_maturity_from_neurons_fund_benchmark() -> BenchResult {
 }
 
 #[bench(raw)]
-fn draw_maturity_from_neurons_fund_stable() -> BenchResult {
+fn draw_maturity_from_neurons_fund() -> BenchResult {
     draw_maturity_from_neurons_fund_benchmark()
 }
 
@@ -508,7 +508,7 @@ fn list_active_neurons_fund_neurons_benchmark() -> BenchResult {
 }
 
 #[bench(raw)]
-fn list_active_neurons_fund_neurons_stable() -> BenchResult {
+fn list_active_neurons_fund_neurons() -> BenchResult {
     list_active_neurons_fund_neurons_benchmark()
 }
 
@@ -529,7 +529,7 @@ fn validate_all_neurons(neuron_store: &NeuronStore, validator: &mut NeuronDataVa
 }
 
 #[bench(raw)]
-fn neuron_data_validation_stable() -> BenchResult {
+fn neuron_data_validation() -> BenchResult {
     let mut rng = new_rng();
     let neuron_store = set_up_neuron_store(&mut rng, 100, 200);
     let mut validator = NeuronDataValidator::new();


### PR DESCRIPTION
The `_stable` suffix is redundant. It was for differentiating between `_stable` and `_heap`, but it's no longer necessary as `_heap` ones were deleted after the neuron migration finished.
