### PR TITLE
chore(PocketIC): replace EmptyConfig by better readable enumerations

### DIFF
--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -746,7 +746,7 @@ use `PocketIcBuilder::with_nonmainnet_features` when creating a new PocketIC ins
 ```rust
     // We create a PocketIC instance with beta features enabled that are not yet available on the ICP mainnet.
     let nonmainnet_features = NonmainnetFeatures {
-        enable_beta_features: Some(EmptyConfig {}),
+        enable_beta_features: Some(NonmainnetFeaturesConfig::Enabled),
         ..Default::default()
     };
     let pic = PocketIcBuilder::new()

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -568,25 +568,26 @@ pub struct NonmainnetFeatures {
     pub canister_execution_rate_limiting: Option<NonmainnetFeaturesConfig>,
 }
 
-/// Forward-compatible configuration type used instead of `bool` and `Option<bool>`:
-/// if provided, the corresponding feature is enabled.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
-pub struct EmptyConfig {}
+pub enum IcpFeaturesConfig {
+    #[default]
+    DefaultConfig,
+}
 
 /// Specifies ICP features enabled by deploying their corresponding system canisters
 /// when creating a PocketIC instance and keeping them up to date
 /// during the PocketIC instance lifetime.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
 pub struct IcpFeatures {
-    pub registry: Option<EmptyConfig>,
+    pub registry: Option<IcpFeaturesConfig>,
     /// If the `cycles_minting` feature is enabled, then the default timestamp of a PocketIC instance is set to 10 May 2021 10:00:01 AM CEST (the smallest value that is strictly larger than the default timestamp hard-coded in the CMC state).
-    pub cycles_minting: Option<EmptyConfig>,
-    pub icp_token: Option<EmptyConfig>,
-    pub cycles_token: Option<EmptyConfig>,
-    pub nns_governance: Option<EmptyConfig>,
-    pub sns: Option<EmptyConfig>,
-    pub ii: Option<EmptyConfig>,
-    pub nns_ui: Option<EmptyConfig>,
+    pub cycles_minting: Option<IcpFeaturesConfig>,
+    pub icp_token: Option<IcpFeaturesConfig>,
+    pub cycles_token: Option<IcpFeaturesConfig>,
+    pub nns_governance: Option<IcpFeaturesConfig>,
+    pub sns: Option<IcpFeaturesConfig>,
+    pub ii: Option<IcpFeaturesConfig>,
+    pub nns_ui: Option<IcpFeaturesConfig>,
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -781,27 +782,21 @@ impl ExtendedSubnetConfigSet {
             (sns, "sns"),
             (nns_ui, "nns_ui"),
         ] {
-            // using `EmptyConfig { }` explicitly
-            // to force an update after adding a new field to `EmptyConfig`
-            if let Some(EmptyConfig {}) = flag {
+            if let Some(IcpFeaturesConfig::DefaultConfig) = flag {
                 check_empty_subnet(&self.nns, "NNS", icp_feature_str)?;
                 self.nns = Some(self.nns.unwrap_or_default());
             }
         }
         // canisters on the II subnet
         for (flag, icp_feature_str) in [(cycles_token, "cycles_token"), (ii, "ii")] {
-            // using `EmptyConfig { }` explicitly
-            // to force an update after adding a new field to `EmptyConfig`
-            if let Some(EmptyConfig {}) = flag {
+            if let Some(IcpFeaturesConfig::DefaultConfig) = flag {
                 check_empty_subnet(&self.ii, "II", icp_feature_str)?;
                 self.ii = Some(self.ii.unwrap_or_default());
             }
         }
         // canisters on the SNS subnet
         for (flag, icp_feature_str) in [(sns, "sns")] {
-            // using `EmptyConfig { }` explicitly
-            // to force an update after adding a new field to `EmptyConfig`
-            if let Some(EmptyConfig {}) = flag {
+            if let Some(IcpFeaturesConfig::DefaultConfig) = flag {
                 check_empty_subnet(&self.sns, "SNS", icp_feature_str)?;
                 self.sns = Some(self.sns.unwrap_or_default());
             }

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -546,24 +546,32 @@ impl From<SubnetConfigSet> for ExtendedSubnetConfigSet {
     }
 }
 
-/// Forward-compatible configuration type used instead of `bool` and `Option<bool>`:
-/// if provided, the corresponding feature is enabled.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
-pub struct EmptyConfig {}
+pub enum NonmainnetFeaturesConfig {
+    #[default]
+    Mainnet,
+    Enabled,
+    Disabled,
+}
 
 /// Specifies nonmainnet features enabled in this instance.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
 pub struct NonmainnetFeatures {
-    /// Enables (beta) features (disabled on the ICP mainnet).
-    pub enable_beta_features: Option<EmptyConfig>,
-    /// Disables canister backtraces (enabled on the ICP mainnet).
-    pub disable_canister_backtrace: Option<EmptyConfig>,
-    /// Disables limits on function name length in canister WASM (enabled on the ICP mainnet).
-    pub disable_function_name_length_limits: Option<EmptyConfig>,
-    /// Disables rate-limiting of canister execution (enabled on the ICP mainnet).
+    /// Beta features (disabled on the ICP mainnet).
+    pub beta_features: Option<NonmainnetFeaturesConfig>,
+    /// Canister backtraces (enabled on the ICP mainnet).
+    pub canister_backtrace: Option<NonmainnetFeaturesConfig>,
+    /// Limits on function name length in canister WASM (enabled on the ICP mainnet).
+    pub function_name_length_limits: Option<NonmainnetFeaturesConfig>,
+    /// Rate-limiting of canister execution (enabled on the ICP mainnet).
     /// Canister execution refers to instructions and memory writes here.
-    pub disable_canister_execution_rate_limiting: Option<EmptyConfig>,
+    pub canister_execution_rate_limiting: Option<NonmainnetFeaturesConfig>,
 }
+
+/// Forward-compatible configuration type used instead of `bool` and `Option<bool>`:
+/// if provided, the corresponding feature is enabled.
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
+pub struct EmptyConfig {}
 
 /// Specifies ICP features enabled by deploying their corresponding system canisters
 /// when creating a PocketIC instance and keeping them up to date

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -550,8 +550,8 @@ impl From<SubnetConfigSet> for ExtendedSubnetConfigSet {
 pub enum NonmainnetFeaturesConfig {
     #[default]
     Mainnet,
-    Enabled,
     Disabled,
+    Enabled,
 }
 
 /// Specifies nonmainnet features enabled in this instance.
@@ -602,6 +602,13 @@ pub enum InitialTime {
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
+pub enum IncompleteStateConfig {
+    #[default]
+    Disabled,
+    Enabled,
+}
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
 pub struct InstanceConfig {
     pub subnet_config_set: ExtendedSubnetConfigSet,
     pub http_gateway_config: Option<InstanceHttpGatewayConfig>,
@@ -610,7 +617,7 @@ pub struct InstanceConfig {
     pub log_level: Option<String>,
     pub bitcoind_addr: Option<Vec<SocketAddr>>,
     pub icp_features: Option<IcpFeatures>,
-    pub allow_incomplete_state: Option<EmptyConfig>,
+    pub allow_incomplete_state: Option<IncompleteStateConfig>,
     pub initial_time: Option<InitialTime>,
 }
 

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -3,8 +3,8 @@ use flate2::read::GzDecoder;
 use icrc_ledger_types::icrc1::account::{Account, Subaccount};
 use icrc_ledger_types::icrc1::transfer::{Memo, TransferArg, TransferError};
 use pocket_ic::common::rest::{
-    EmptyConfig, ExtendedSubnetConfigSet, IcpFeatures, InstanceConfig, InstanceHttpGatewayConfig,
-    SubnetSpec,
+    ExtendedSubnetConfigSet, IcpFeatures, IcpFeaturesConfig, InstanceConfig,
+    InstanceHttpGatewayConfig, SubnetSpec,
 };
 use pocket_ic::{
     start_server, update_candid, update_candid_as, PocketIc, PocketIcBuilder, PocketIcState,
@@ -41,14 +41,14 @@ fn decode_gzipped_bytes(data: Vec<u8>) -> Vec<u8> {
 
 fn all_icp_features() -> IcpFeatures {
     IcpFeatures {
-        registry: Some(EmptyConfig {}),
-        cycles_minting: Some(EmptyConfig {}),
-        icp_token: Some(EmptyConfig {}),
-        cycles_token: Some(EmptyConfig {}),
-        nns_governance: Some(EmptyConfig {}),
-        sns: Some(EmptyConfig {}),
-        ii: Some(EmptyConfig {}),
-        nns_ui: Some(EmptyConfig {}),
+        registry: Some(IcpFeaturesConfig::DefaultConfig),
+        cycles_minting: Some(IcpFeaturesConfig::DefaultConfig),
+        icp_token: Some(IcpFeaturesConfig::DefaultConfig),
+        cycles_token: Some(IcpFeaturesConfig::DefaultConfig),
+        nns_governance: Some(IcpFeaturesConfig::DefaultConfig),
+        sns: Some(IcpFeaturesConfig::DefaultConfig),
+        ii: Some(IcpFeaturesConfig::DefaultConfig),
+        nns_ui: Some(IcpFeaturesConfig::DefaultConfig),
     }
 }
 
@@ -56,13 +56,13 @@ fn all_icp_features() -> IcpFeatures {
 // so we only enable this feature for frontend canister tests.
 fn all_icp_features_but_nns_ui() -> IcpFeatures {
     IcpFeatures {
-        registry: Some(EmptyConfig {}),
-        cycles_minting: Some(EmptyConfig {}),
-        icp_token: Some(EmptyConfig {}),
-        cycles_token: Some(EmptyConfig {}),
-        nns_governance: Some(EmptyConfig {}),
-        sns: Some(EmptyConfig {}),
-        ii: Some(EmptyConfig {}),
+        registry: Some(IcpFeaturesConfig::DefaultConfig),
+        cycles_minting: Some(IcpFeaturesConfig::DefaultConfig),
+        icp_token: Some(IcpFeaturesConfig::DefaultConfig),
+        cycles_token: Some(IcpFeaturesConfig::DefaultConfig),
+        nns_governance: Some(IcpFeaturesConfig::DefaultConfig),
+        sns: Some(IcpFeaturesConfig::DefaultConfig),
+        ii: Some(IcpFeaturesConfig::DefaultConfig),
         nns_ui: None,
     }
 }
@@ -107,7 +107,7 @@ fn nns_ui_requires_other_icp_features() {
         https_config: None,
     };
     let icp_features = IcpFeatures {
-        nns_ui: Some(EmptyConfig {}),
+        nns_ui: Some(IcpFeaturesConfig::DefaultConfig),
         ..Default::default()
     };
     let _pic = PocketIcBuilder::new()

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -25,8 +25,8 @@ use pocket_ic::{
     common::rest::{
         AutoProgressConfig, BlobCompression, CanisterHttpReply, CanisterHttpResponse,
         CreateInstanceResponse, EmptyConfig, HttpGatewayDetails, HttpsConfig, IcpFeatures,
-        InitialTime, InstanceConfig, InstanceHttpGatewayConfig, MockCanisterHttpResponse,
-        RawEffectivePrincipal, RawMessageId, SubnetConfigSet, SubnetKind,
+        IncompleteStateConfig, InitialTime, InstanceConfig, InstanceHttpGatewayConfig,
+        MockCanisterHttpResponse, RawEffectivePrincipal, RawMessageId, SubnetConfigSet, SubnetKind,
     },
     query_candid, start_server, update_candid, DefaultEffectiveCanisterIdError, ErrorCode,
     IngressStatusResult, PocketIc, PocketIcBuilder, PocketIcState, RejectCode, StartServerParams,
@@ -559,7 +559,7 @@ fn time_on_resumed_instance() {
 // Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
 #[cfg(not(windows))]
 async fn resume_killed_instance_impl(
-    allow_incomplete_state: Option<EmptyConfig>,
+    allow_incomplete_state: Option<IncompleteStateConfig>,
 ) -> Result<(), String> {
     let (mut server, server_url) = start_server(StartServerParams::default()).await;
     let temp_dir = TempDir::new().unwrap();
@@ -661,7 +661,7 @@ async fn resume_killed_instance_impl(
 // Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
 #[cfg(not(windows))]
 #[tokio::test]
-async fn resume_killed_instance_strict() {
+async fn resume_killed_instance_default() {
     let err = resume_killed_instance_impl(None).await.unwrap_err();
     assert!(err.contains("The state of subnet with seed 7712b2c09cb96b3aa3fbffd4034a21a39d5d13f80e043161d1d71f4c593434af is incomplete."));
 }
@@ -669,8 +669,18 @@ async fn resume_killed_instance_strict() {
 // Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
 #[cfg(not(windows))]
 #[tokio::test]
+async fn resume_killed_instance_strict() {
+    let err = resume_killed_instance_impl(Some(IncompleteStateConfig::Disabled))
+        .await
+        .unwrap_err();
+    assert!(err.contains("The state of subnet with seed 7712b2c09cb96b3aa3fbffd4034a21a39d5d13f80e043161d1d71f4c593434af is incomplete."));
+}
+
+// Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
+#[cfg(not(windows))]
+#[tokio::test]
 async fn resume_killed_instance() {
-    resume_killed_instance_impl(Some(EmptyConfig {}))
+    resume_killed_instance_impl(Some(IncompleteStateConfig::Enabled))
         .await
         .unwrap();
 }

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -24,7 +24,7 @@ use pocket_ic::{common::rest::ExtendedSubnetConfigSet, nonblocking::PocketIc as 
 use pocket_ic::{
     common::rest::{
         AutoProgressConfig, BlobCompression, CanisterHttpReply, CanisterHttpResponse,
-        CreateInstanceResponse, EmptyConfig, HttpGatewayDetails, HttpsConfig, IcpFeatures,
+        CreateInstanceResponse, HttpGatewayDetails, HttpsConfig, IcpFeatures, IcpFeaturesConfig,
         IncompleteStateConfig, InitialTime, InstanceConfig, InstanceHttpGatewayConfig,
         MockCanisterHttpResponse, RawEffectivePrincipal, RawMessageId, SubnetConfigSet, SubnetKind,
     },
@@ -419,7 +419,7 @@ fn test_invalid_initial_timestamp() {
 fn test_initial_timestamp_with_cycles_minting() {
     let initial_timestamp = 1_620_633_601_000_000_000; // 10 May 2021 10:00:01
     let icp_features = IcpFeatures {
-        cycles_minting: Some(EmptyConfig {}),
+        cycles_minting: Some(IcpFeaturesConfig::DefaultConfig),
         ..Default::default()
     };
     let pic = PocketIcBuilder::new()
@@ -443,7 +443,7 @@ fn test_initial_timestamp_with_cycles_minting() {
 fn test_invalid_initial_timestamp_with_cycles_minting() {
     let initial_timestamp = 1_620_328_630_000_000_000; // 06 May 2021 21:17:10 CEST
     let icp_features = IcpFeatures {
-        cycles_minting: Some(EmptyConfig {}),
+        cycles_minting: Some(IcpFeaturesConfig::DefaultConfig),
         ..Default::default()
     };
     let _pic = PocketIcBuilder::new()

--- a/rs/bitcoin/checker/tests/tests.rs
+++ b/rs/bitcoin/checker/tests/tests.rs
@@ -20,8 +20,8 @@ use ic_universal_canister::{call_args, wasm, UNIVERSAL_CANISTER_WASM};
 use pocket_ic::{
     common::rest::{
         CanisterHttpHeader, CanisterHttpReject, CanisterHttpReply, CanisterHttpRequest,
-        CanisterHttpResponse, EmptyConfig, MockCanisterHttpResponse, NonmainnetFeatures,
-        RawMessageId,
+        CanisterHttpResponse, MockCanisterHttpResponse, NonmainnetFeatures,
+        NonmainnetFeaturesConfig, RawMessageId,
     },
     query_candid, PocketIc, PocketIcBuilder, RejectCode, RejectResponse,
 };
@@ -65,7 +65,7 @@ impl Setup {
         // Enable nonmainnet_features to avoid CanisterInstallCodeRateLimited error
         // for canister upgrades
         let nonmainnet_features = NonmainnetFeatures {
-            disable_canister_execution_rate_limiting: Some(EmptyConfig::default()),
+            canister_execution_rate_limiting: Some(NonmainnetFeaturesConfig::Disabled),
             ..Default::default()
         };
         let env = PocketIcBuilder::new()

--- a/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
+++ b/rs/node_rewards/canister/tests/get_node_providers_monthly_xdr_rewards.rs
@@ -8,14 +8,14 @@ use ic_node_rewards_canister_api::provider_rewards_calculation::{
     GetNodeProviderRewardsCalculationRequest, GetNodeProviderRewardsCalculationResponse,
 };
 use ic_types::PrincipalId;
-use pocket_ic::common::rest::{EmptyConfig, IcpFeatures};
+use pocket_ic::common::rest::{IcpFeatures, IcpFeaturesConfig};
 use pocket_ic::nonblocking::{query_candid, update_candid, PocketIc};
 use pocket_ic::PocketIcBuilder;
 use std::time::Duration;
 
 async fn setup_env() -> PocketIc {
     let icp_features = IcpFeatures {
-        registry: Some(EmptyConfig {}),
+        registry: Some(IcpFeaturesConfig::DefaultConfig),
         ..Default::default()
     };
     let pocket_ic = PocketIcBuilder::new()

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -111,10 +111,10 @@ use icp_ledger::{AccountIdentifier, LedgerCanisterInitPayloadBuilder, Subaccount
 use itertools::Itertools;
 use pocket_ic::common::rest::{
     self, BinaryBlob, BlobCompression, CanisterHttpHeader, CanisterHttpMethod, CanisterHttpRequest,
-    CanisterHttpResponse, EmptyConfig, ExtendedSubnetConfigSet, IcpFeatures, IncompleteStateConfig,
-    MockCanisterHttpResponse, NonmainnetFeatures, NonmainnetFeaturesConfig, RawAddCycles,
-    RawCanisterCall, RawCanisterId, RawEffectivePrincipal, RawMessageId, RawSetStableMemory,
-    SubnetInstructionConfig, SubnetKind, TickConfigs, Topology,
+    CanisterHttpResponse, ExtendedSubnetConfigSet, IcpFeatures, IcpFeaturesConfig,
+    IncompleteStateConfig, MockCanisterHttpResponse, NonmainnetFeatures, NonmainnetFeaturesConfig,
+    RawAddCycles, RawCanisterCall, RawCanisterId, RawEffectivePrincipal, RawMessageId,
+    RawSetStableMemory, SubnetInstructionConfig, SubnetKind, TickConfigs, Topology,
 };
 use pocket_ic::{copy_dir, ErrorCode, RejectCode, RejectResponse};
 use registry_canister::init::RegistryCanisterInitPayload;
@@ -197,10 +197,12 @@ fn default_timestamp(icp_features: &Option<IcpFeatures>) -> SystemTime {
     // To set the ICP/XDR conversion rate, the PocketIC time (in seconds) must be strictly larger than the default timestamp in CMC state.
     let cycles_minting_feature = icp_features
         .as_ref()
-        .map(|icp_features|
-            // using `EmptyConfig { }` explicitly
-            // to force an update after adding a new field to `EmptyConfig`
-            matches!(icp_features.cycles_minting, Some(EmptyConfig {})))
+        .map(|icp_features| {
+            matches!(
+                icp_features.cycles_minting,
+                Some(IcpFeaturesConfig::DefaultConfig)
+            )
+        })
         .unwrap_or_default();
     if cycles_minting_feature {
         UNIX_EPOCH + Duration::from_secs(DEFAULT_ICP_XDR_CONVERSION_RATE_TIMESTAMP_SECONDS + 1)
@@ -977,44 +979,28 @@ impl PocketIcSubnets {
                     ii,
                     nns_ui,
                 } = icp_features;
-                // using `EmptyConfig { }` explicitly
-                // to force an update after adding a new field to `EmptyConfig`
-                if let Some(EmptyConfig {}) = registry {
+                if let Some(IcpFeaturesConfig::DefaultConfig) = registry {
                     self.update_registry();
                 }
-                // using `EmptyConfig { }` explicitly
-                // to force an update after adding a new field to `EmptyConfig`
-                if let Some(EmptyConfig {}) = cycles_minting {
+                if let Some(IcpFeaturesConfig::DefaultConfig) = cycles_minting {
                     self.update_cmc(&subnet_kind);
                 }
-                // using `EmptyConfig { }` explicitly
-                // to force an update after adding a new field to `EmptyConfig`
-                if let Some(EmptyConfig {}) = icp_token {
+                if let Some(IcpFeaturesConfig::DefaultConfig) = icp_token {
                     self.deploy_icp_token();
                 }
-                // using `EmptyConfig { }` explicitly
-                // to force an update after adding a new field to `EmptyConfig`
-                if let Some(EmptyConfig {}) = cycles_token {
+                if let Some(IcpFeaturesConfig::DefaultConfig) = cycles_token {
                     self.deploy_cycles_token();
                 }
-                // using `EmptyConfig { }` explicitly
-                // to force an update after adding a new field to `EmptyConfig`
-                if let Some(EmptyConfig {}) = nns_governance {
+                if let Some(IcpFeaturesConfig::DefaultConfig) = nns_governance {
                     self.deploy_nns_governance();
                 }
-                // using `EmptyConfig { }` explicitly
-                // to force an update after adding a new field to `EmptyConfig`
-                if let Some(EmptyConfig {}) = sns {
+                if let Some(IcpFeaturesConfig::DefaultConfig) = sns {
                     self.deploy_sns();
                 }
-                // using `EmptyConfig { }` explicitly
-                // to force an update after adding a new field to `EmptyConfig`
-                if let Some(EmptyConfig {}) = ii {
+                if let Some(IcpFeaturesConfig::DefaultConfig) = ii {
                     self.deploy_ii();
                 }
-                // using `EmptyConfig { }` explicitly
-                // to force an update after adding a new field to `EmptyConfig`
-                if let Some(EmptyConfig {}) = nns_ui {
+                if let Some(IcpFeaturesConfig::DefaultConfig) = nns_ui {
                     self.deploy_nns_ui();
                 }
             }
@@ -1148,10 +1134,12 @@ impl PocketIcSubnets {
             let cycles_ledger_canister_id = if self
                 .icp_features
                 .as_ref()
-                .map(|icp_features|
-                  // using `EmptyConfig { }` explicitly
-                  // to force an update after adding a new field to `EmptyConfig`
-                  matches!(icp_features.cycles_token, Some(EmptyConfig {})))
+                .map(|icp_features| {
+                    matches!(
+                        icp_features.cycles_token,
+                        Some(IcpFeaturesConfig::DefaultConfig)
+                    )
+                })
                 .unwrap_or_default()
             {
                 Some(CYCLES_LEDGER_CANISTER_ID)

--- a/rs/sns/testing/src/bin/init.rs
+++ b/rs/sns/testing/src/bin/init.rs
@@ -3,7 +3,7 @@ use ic_sns_testing::nns_dapp::bootstrap_nns;
 use ic_sns_testing::utils::{get_identity_principal, TREASURY_PRINCIPAL_ID};
 use ic_sns_testing::NnsInitArgs;
 use icp_ledger::Tokens;
-use pocket_ic::common::rest::{EmptyConfig, IcpFeatures};
+use pocket_ic::common::rest::{IcpFeatures, IcpFeaturesConfig};
 use pocket_ic::PocketIcBuilder;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::tempdir;
@@ -23,13 +23,13 @@ async fn nns_init(args: NnsInitArgs) {
     // which would make `deciding_nns_neuron_id` non-deterministic.
     // Hence, we deploy the NNS dapp separately for now.
     let all_icp_features_but_nns_ui = IcpFeatures {
-        registry: Some(EmptyConfig {}),
-        cycles_minting: Some(EmptyConfig {}),
-        icp_token: Some(EmptyConfig {}),
-        cycles_token: Some(EmptyConfig {}),
-        nns_governance: Some(EmptyConfig {}),
-        sns: Some(EmptyConfig {}),
-        ii: Some(EmptyConfig {}),
+        registry: Some(IcpFeaturesConfig::DefaultConfig),
+        cycles_minting: Some(IcpFeaturesConfig::DefaultConfig),
+        icp_token: Some(IcpFeaturesConfig::DefaultConfig),
+        cycles_token: Some(IcpFeaturesConfig::DefaultConfig),
+        nns_governance: Some(IcpFeaturesConfig::DefaultConfig),
+        sns: Some(IcpFeaturesConfig::DefaultConfig),
+        ii: Some(IcpFeaturesConfig::DefaultConfig),
         nns_ui: None,
     };
     // We set the time of the PocketIC instance to the current time so that

--- a/rs/sns/testing/tests/sns_testing_ci.rs
+++ b/rs/sns/testing/tests/sns_testing_ci.rs
@@ -18,7 +18,7 @@ use ic_sns_testing::utils::{
     SnsTestingNetworkValidationError, TREASURY_PRINCIPAL_ID,
 };
 use icp_ledger::Tokens;
-use pocket_ic::common::rest::{EmptyConfig, IcpFeatures};
+use pocket_ic::common::rest::{IcpFeatures, IcpFeaturesConfig};
 use pocket_ic::nonblocking::PocketIc;
 use pocket_ic::PocketIcBuilder;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -38,13 +38,13 @@ pub struct TestCanisterInitArgs {
 // Hence, we deploy the NNS dapp separately for now.
 fn all_icp_features_but_nns_ui() -> IcpFeatures {
     IcpFeatures {
-        registry: Some(EmptyConfig {}),
-        cycles_minting: Some(EmptyConfig {}),
-        icp_token: Some(EmptyConfig {}),
-        cycles_token: Some(EmptyConfig {}),
-        nns_governance: Some(EmptyConfig {}),
-        sns: Some(EmptyConfig {}),
-        ii: Some(EmptyConfig {}),
+        registry: Some(IcpFeaturesConfig::DefaultConfig),
+        cycles_minting: Some(IcpFeaturesConfig::DefaultConfig),
+        icp_token: Some(IcpFeaturesConfig::DefaultConfig),
+        cycles_token: Some(IcpFeaturesConfig::DefaultConfig),
+        nns_governance: Some(IcpFeaturesConfig::DefaultConfig),
+        sns: Some(IcpFeaturesConfig::DefaultConfig),
+        ii: Some(IcpFeaturesConfig::DefaultConfig),
         nns_ui: None,
     }
 }


### PR DESCRIPTION
This PR replaces `EmptyConfig` in PocketIC public types with better readable enumerations that are less confusing to developers.

There's no changelog update since we'll delay the public release of PocketIC v10.0.0 until after this PR is merged.