### PR TITLE
chore(node): Remove recovery-engine restart logic

### DIFF
--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.service
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.service
@@ -12,8 +12,6 @@ WantedBy=multi-user.target
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/opt/ic/bin/guestos-recovery-engine.sh
-Restart=on-failure
-RestartSec=10
 
 # All guestos services that networking depends on log their outputs to the 
 # console to be piped to the host terminal if the verbose flag is enabled.


### PR DESCRIPTION
guestos-recovery-engine already has retry logic in the script itself. If guestos-recovery-engine fails, ic-replica will then run. If guestos-recovery-engine then restarts, we have a potential race condition overwriting the CUP/local registry store while the orchestrator is active.