### PR TITLE
chore(PocketIC): clean up server API

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - The field `node_ids` from `SubnetConfig`. Node ids can always be retrieved from the registry.
+- The deprecated function `PocketIc::make_deterministic`.
 
 
 

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -437,9 +437,9 @@ impl PocketIcBuilder {
     /// Configures the new instance to make progress automatically,
     /// i.e., periodically update the time of the IC instance
     /// to the real time and execute rounds on the subnets.
-    pub fn with_auto_progress(mut self, artificial_delay_ms: Option<u64>) -> Self {
+    pub fn with_auto_progress(mut self) -> Self {
         let config = AutoProgressConfig {
-            artificial_delay_ms,
+            artificial_delay_ms: None,
         };
         self.initial_time = Some(InitialTime::AutoProgress(config));
         self

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -789,13 +789,6 @@ impl PocketIc {
         runtime.block_on(async { self.pocket_ic.stop_live().await })
     }
 
-    #[deprecated(note = "Use `stop_live` instead.")]
-    /// Use `stop_live` instead.
-    pub fn make_deterministic(&mut self) {
-        let runtime = self.runtime.clone();
-        runtime.block_on(async { self.pocket_ic.stop_live().await })
-    }
-
     /// Get the root key of this IC instance. Returns `None` if the IC has no NNS subnet.
     #[instrument(skip(self), fields(instance_id=self.pocket_ic.instance_id))]
     pub fn root_key(&self) -> Option<Vec<u8>> {

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -557,12 +557,6 @@ impl PocketIc {
         self.stop_progress().await;
     }
 
-    #[deprecated(note = "Use `stop_live` instead.")]
-    /// Use `stop_live` instead.
-    pub async fn make_deterministic(&mut self) {
-        self.stop_live().await;
-    }
-
     /// Get the root key of this IC instance. Returns `None` if the IC has no NNS subnet.
     #[instrument(skip(self), fields(instance_id=self.instance_id))]
     pub async fn root_key(&self) -> Option<Vec<u8>> {

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -112,7 +112,7 @@ fn nns_ui_requires_other_icp_features() {
     };
     let _pic = PocketIcBuilder::new()
         .with_icp_features(icp_features)
-        .with_auto_progress(None)
+        .with_auto_progress()
         .with_http_gateway(instance_http_gateway_config)
         .build();
 }
@@ -126,7 +126,7 @@ fn frontend_smoke_test(frontend_canister_id: Principal, expected_str: &str) {
     };
     let pic = PocketIcBuilder::new()
         .with_icp_features(all_icp_features())
-        .with_auto_progress(None)
+        .with_auto_progress()
         .with_http_gateway(instance_http_gateway_config)
         .build();
 

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -458,7 +458,7 @@ fn test_invalid_initial_timestamp_with_cycles_minting() {
 fn test_auto_progress() {
     let pic = PocketIcBuilder::new()
         .with_application_subnet()
-        .with_auto_progress(None)
+        .with_auto_progress()
         .build();
 
     assert!(pic.auto_progress_enabled());
@@ -3236,7 +3236,7 @@ async fn with_http_gateway_config_and_cleanup_works() {
         .with_server_url(server_url.clone())
         .with_application_subnet()
         .with_http_gateway(http_gateway_config)
-        .with_auto_progress(None)
+        .with_auto_progress()
         .build_async()
         .await;
 
@@ -3340,7 +3340,7 @@ async fn with_http_gateway_config_invalid_gateway_port() {
         .with_server_url(server_url.clone())
         .with_application_subnet()
         .with_http_gateway(http_gateway_config.clone())
-        .with_auto_progress(None)
+        .with_auto_progress()
         .build_async()
         .await;
 
@@ -3440,7 +3440,7 @@ async fn with_http_gateway_config_invalid_gateway_https_config() {
 fn make_live_after_auto_progress() {
     let mut pic = PocketIcBuilder::new()
         .with_application_subnet()
-        .with_auto_progress(None)
+        .with_auto_progress()
         .build();
     pic.make_live(None);
 }


### PR DESCRIPTION
This PR
- makes the new function `PocketIcBuilder::with_auto_progress` consistent with the existing function `PocketIc::auto_progress` by making them both take no arguments;
- removes the deprecated function `PocketIc::make_deterministic`.