### PR TITLE
fix: bump timeout of bazel-test-all from 120 to 150 minutes

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -148,7 +148,7 @@ jobs:
     name: Bazel Test All
     needs: [ config ]
     <<: *dind-large-setup
-    timeout-minutes: 120
+    timeout-minutes: 150
     env:
       # Only run ci/bazel-scripts/diff.sh on PRs that are not labeled with "CI_ALL_BAZEL_TARGETS".
       OVERRIDE_DIDC_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_DIDC_CHECK') }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -117,7 +117,7 @@ jobs:
       image: ghcr.io/dfinity/ic-build@sha256:9b554adf2402a705f962ad65cc9ec37596d2bd8a7ff5d3ee97b5a933c6dbef11
       options: >-
         -e NODE_NAME --privileged --cgroupns host
-    timeout-minutes: 120
+    timeout-minutes: 150
     env:
       # Only run ci/bazel-scripts/diff.sh on PRs that are not labeled with "CI_ALL_BAZEL_TARGETS".
       OVERRIDE_DIDC_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'CI_OVERRIDE_DIDC_CHECK') }}


### PR DESCRIPTION
The "Bazel Test All" job is regularly timing out on master after 2 hours. In most of these cases the "Run Bazel Commands" and "Upload to S3" steps just took too long resulting in the job to be cancelled while running the "Upload to S3" step.

Let's bump the timeout by 30 minutes.