### PR TITLE
fix(guestos-recovery-upgrader): curl fails on server errors

### DIFF
--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
@@ -76,7 +76,7 @@ download_and_verify_upgrade() {
         local url="${base_url}/ic/${version}/guest-os/update-img/update-img.tar.zst"
         echo "Attempting to download upgrade from $url..."
 
-        if curl -L -o "$tmpdir/upgrade.tar.zst" "$url"; then
+        if curl -L --fail -o "$tmpdir/upgrade.tar.zst" "$url"; then
             echo "Download from $base_url completed successfully"
             download_successful=true
             break


### PR DESCRIPTION
This PR adds the `--fail` flag to `curl`, similar to the [guestos-recovery-engine](https://github.com/dfinity/ic/blob/d0996890b8edd4af8923deb6607b55f80f587950/ic-os/components/misc/guestos-recovery/guestos-recovery-engine/guestos-recovery-engine.sh#L43), to make curl fail on server errors, like a 404 if the recovery image is not present. This correctly attempts the download on the other upstream, and does not try to compare the hash of the 404 XML/HTML page returned by S3/R2, that yields confusing logs otherwise.

Please let me know if this was actually intended.