### PR TITLE
test(btc-adapter): handle wallet already loading error

### DIFF
--- a/rs/bitcoin/adapter/test_utils/src/rpc_client.rs
+++ b/rs/bitcoin/adapter/test_utils/src/rpc_client.rs
@@ -275,7 +275,15 @@ impl<T: RpcClientType> RpcClient<T> {
                     .create_wallet("default", None, None, None, None)
                     .is_err()
                 {
-                    self.load_wallet("default")?;
+                    if let Err(RpcError::JsonRpc(jsonrpc::error::Error::Rpc(
+                        jsonrpc::error::RpcError { code, message, .. },
+                    ))) = self.load_wallet("default")
+                    {
+                        // Wait a second if it says "Wallet already loading."
+                        if code == -4 && message == "Wallet already loading." {
+                            std::thread::sleep(std::time::Duration::from_secs(1));
+                        }
+                    }
                 }
                 break;
             }

--- a/rs/bitcoin/adapter/test_utils/src/rpc_client.rs
+++ b/rs/bitcoin/adapter/test_utils/src/rpc_client.rs
@@ -275,14 +275,15 @@ impl<T: RpcClientType> RpcClient<T> {
                     .create_wallet("default", None, None, None, None)
                     .is_err()
                 {
-                    if let Err(RpcError::JsonRpc(jsonrpc::error::Error::Rpc(
-                        jsonrpc::error::RpcError { code, message, .. },
-                    ))) = self.load_wallet("default")
-                    {
+                    match self.load_wallet("default") {
                         // Wait a second if it says "Wallet already loading."
-                        if code == -4 && message == "Wallet already loading." {
+                        Err(RpcError::JsonRpc(jsonrpc::error::Error::Rpc(
+                            jsonrpc::error::RpcError { code, message, .. },
+                        ))) if code == -4 && message == "Wallet already loading." => {
                             std::thread::sleep(std::time::Duration::from_secs(1));
                         }
+                        Err(err) => return Err(err),
+                        Ok(_) => {}
                     }
                 }
                 break;


### PR DESCRIPTION
Occasionally bitcoind may return "Wallet already loading." for loadwallet RPC call even though all tests were run sequentially and the wallet was already unloaded in the previous test.

To avoid test failures, instead of throwing an error we wait a second for the wallet to finish loading before continue.