### PR TITLE
fix: //rs/tests/consensus/subnet_recovery:sr_app_no_upgrade_local_test_colocate

### DIFF
--- a/rs/tests/consensus/subnet_recovery/common.rs
+++ b/rs/tests/consensus/subnet_recovery/common.rs
@@ -304,6 +304,13 @@ pub fn test_no_upgrade_without_chain_keys_local(env: TestEnv) {
 fn app_subnet_recovery_test(env: TestEnv, cfg: TestConfig) {
     let logger = env.logger();
 
+    if cfg.local_recovery {
+        std::env::set_var(
+            "IC_ADMIN_BIN",
+            get_dependency_path_from_env("IC_ADMIN_PATH"),
+        );
+    }
+
     let initial_version = get_guestos_img_version();
     info!(logger, "IC_VERSION_ID: {initial_version:?}");
     let topology_snapshot = env.topology_snapshot();
@@ -425,7 +432,7 @@ fn app_subnet_recovery_test(env: TestEnv, cfg: TestConfig) {
         key_file: Some(ssh_authorized_priv_keys_dir.join(SSH_USERNAME)),
         test_mode: true,
         skip_prompts: true,
-        use_local_binaries: false,
+        use_local_binaries: cfg.local_recovery,
     };
 
     let mut unassigned_nodes = env.topology_snapshot().unassigned_nodes();


### PR DESCRIPTION
`//rs/tests/consensus/subnet_recovery:sr_app_no_upgrade_local_test_colocate` is [failing](https://dash.zh1-idx1.dfinity.network/invocation/b80da4ed-4d5b-46ff-9f20-9f2d64e68838?target=%2F%2Frs%2Ftests%2Fconsensus%2Fsubnet_recovery%3Asr_app_no_upgrade_local_test_colocate&targetStatus=6#@981) on master after https://github.com/dfinity/ic/commit/35c2c471826be310d2e5d6549a7ebef038f780ea because it tries to wrongly download `ic-admin` from the CDN and getting a 404.

The fix is the use the local `ic-admin` by setting the `IC_ADMIN_BIN` environment variable in the test.