### PR TITLE
feat(nns): Implement a proposal type DeregisterKnownNeuron behind feature flag

### DIFF
--- a/rs/nns/governance/api/src/proposal_submission_helpers.rs
+++ b/rs/nns/governance/api/src/proposal_submission_helpers.rs
@@ -101,6 +101,7 @@ impl From<ProposalActionRequest> for Action {
             ProposalActionRequest::RewardNodeProvider(v) => Action::RewardNodeProvider(v),
             ProposalActionRequest::RewardNodeProviders(v) => Action::RewardNodeProviders(v),
             ProposalActionRequest::RegisterKnownNeuron(v) => Action::RegisterKnownNeuron(v),
+            ProposalActionRequest::DeregisterKnownNeuron(v) => Action::DeregisterKnownNeuron(v),
             ProposalActionRequest::CreateServiceNervousSystem(v) => {
                 Action::CreateServiceNervousSystem(v)
             }

--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -602,6 +602,8 @@ pub mod proposal {
         RewardNodeProviders(super::RewardNodeProviders),
         /// Register Known Neuron
         RegisterKnownNeuron(super::KnownNeuron),
+        /// Deregister Known Neuron
+        DeregisterKnownNeuron(super::DeregisterKnownNeuron),
         /// Obsolete. Superseded by CreateServiceNervousSystem. Kept for Candid compatibility.
         SetSnsTokenSwapOpenTimeWindow(super::SetSnsTokenSwapOpenTimeWindow),
         /// Call the open method on an SNS swap canister.
@@ -1374,6 +1376,7 @@ pub enum ProposalActionRequest {
     RewardNodeProvider(RewardNodeProvider),
     RewardNodeProviders(RewardNodeProviders),
     RegisterKnownNeuron(KnownNeuron),
+    DeregisterKnownNeuron(DeregisterKnownNeuron),
     CreateServiceNervousSystem(CreateServiceNervousSystem),
     InstallCode(InstallCodeRequest),
     StopOrStartCanister(StopOrStartCanister),
@@ -2194,6 +2197,13 @@ pub struct KnownNeuron {
 pub struct KnownNeuronData {
     pub name: String,
     pub description: Option<String>,
+}
+/// Proposal action to deregister a known neuron by removing its name and description.
+#[derive(
+    candid::CandidType, candid::Deserialize, serde::Serialize, Clone, PartialEq, Debug, Default,
+)]
+pub struct DeregisterKnownNeuron {
+    pub id: Option<NeuronId>,
 }
 /// Proposal action to call the "open" method of an SNS token swap canister.
 #[derive(

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -4,6 +4,7 @@ type AccountIdentifier = record {
 
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
+  DeregisterKnownNeuron : DeregisterKnownNeuron;
   ManageNeuron : ManageNeuron;
   UpdateCanisterSettings : UpdateCanisterSettings;
   InstallCode : InstallCode;
@@ -438,6 +439,10 @@ type InstallCodeRequest = record {
 type KnownNeuron = record {
   id : opt NeuronId;
   known_neuron_data : opt KnownNeuronData;
+};
+
+type DeregisterKnownNeuron = record {
+  id : opt NeuronId;
 };
 
 type KnownNeuronData = record {
@@ -977,6 +982,7 @@ type Proposal = record {
 
 type ProposalActionRequest = variant {
   RegisterKnownNeuron : KnownNeuron;
+  DeregisterKnownNeuron : DeregisterKnownNeuron;
   ManageNeuron : ManageNeuronRequest;
   UpdateCanisterSettings : UpdateCanisterSettings;
   InstallCode : InstallCodeRequest;

--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -4,6 +4,7 @@ type AccountIdentifier = record {
 
 type Action = variant {
   RegisterKnownNeuron : KnownNeuron;
+  DeregisterKnownNeuron : DeregisterKnownNeuron;
   ManageNeuron : ManageNeuron;
   UpdateCanisterSettings : UpdateCanisterSettings;
   InstallCode : InstallCode;
@@ -437,6 +438,10 @@ type KnownNeuron = record {
   known_neuron_data : opt KnownNeuronData;
 };
 
+type DeregisterKnownNeuron = record {
+  id : opt NeuronId;
+};
+
 type KnownNeuronData = record {
   name : text;
   description : opt text;
@@ -861,6 +866,7 @@ type Proposal = record {
 
 type ProposalActionRequest = variant {
   RegisterKnownNeuron : KnownNeuron;
+  DeregisterKnownNeuron : DeregisterKnownNeuron;
   ManageNeuron : ManageNeuronRequest;
   UpdateCanisterSettings : UpdateCanisterSettings;
   InstallCode : InstallCodeRequest;

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -677,6 +677,8 @@ message Proposal {
     RewardNodeProviders reward_node_providers = 19;
     // Register Known Neuron
     KnownNeuron register_known_neuron = 21;
+    // Deregister Known Neuron
+    DeregisterKnownNeuron deregister_known_neuron = 29;
     // Obsolete. Superseded by CreateServiceNervousSystem. Kept for Candid compatibility.
     SetSnsTokenSwapOpenTimeWindow set_sns_token_swap_open_time_window = 22 [deprecated = true];
     // Call the open method on an SNS swap canister.
@@ -1666,6 +1668,11 @@ message KnownNeuron {
 message KnownNeuronData {
   string name = 1;
   optional string description = 2;
+}
+
+// Proposal action to deregister a known neuron by removing its name and description.
+message DeregisterKnownNeuron {
+  ic_nns_common.pb.v1.NeuronId id = 1;
 }
 
 // Proposal action to call the "open" method of an SNS token swap canister.

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -427,7 +427,7 @@ pub struct Proposal {
     /// take.
     #[prost(
         oneof = "proposal::Action",
-        tags = "10, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27, 28"
+        tags = "10, 12, 13, 14, 15, 16, 17, 18, 19, 21, 29, 22, 23, 24, 25, 26, 27, 28"
     )]
     pub action: ::core::option::Option<proposal::Action>,
 }
@@ -506,6 +506,9 @@ pub mod proposal {
         /// Register Known Neuron
         #[prost(message, tag = "21")]
         RegisterKnownNeuron(super::KnownNeuron),
+        /// Deregister Known Neuron
+        #[prost(message, tag = "29")]
+        DeregisterKnownNeuron(super::DeregisterKnownNeuron),
         /// Obsolete. Superseded by CreateServiceNervousSystem. Kept for Candid compatibility.
         #[prost(message, tag = "22")]
         SetSnsTokenSwapOpenTimeWindow(super::SetSnsTokenSwapOpenTimeWindow),
@@ -2164,6 +2167,21 @@ pub struct KnownNeuronData {
     pub name: ::prost::alloc::string::String,
     #[prost(string, optional, tag = "2")]
     pub description: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Proposal action to deregister a known neuron by removing its name and description.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    Copy,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct DeregisterKnownNeuron {
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<::ic_nns_common::pb::v1::NeuronId>,
 }
 /// Proposal action to call the "open" method of an SNS token swap canister.
 #[derive(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -696,9 +696,9 @@ impl Proposal {
                 Action::RewardNodeProvider(_) | Action::RewardNodeProviders(_) => {
                     Topic::NodeProviderRewards
                 }
-                Action::SetDefaultFollowees(_) | Action::RegisterKnownNeuron(_) => {
-                    Topic::Governance
-                }
+                Action::SetDefaultFollowees(_)
+                | Action::RegisterKnownNeuron(_)
+                | Action::DeregisterKnownNeuron(_) => Topic::Governance,
                 Action::SetSnsTokenSwapOpenTimeWindow(_)
                 | Action::OpenSnsTokenSwap(_)
                 | Action::CreateServiceNervousSystem(_) => Topic::SnsAndCommunityFund,
@@ -780,6 +780,7 @@ impl Action {
             Action::RewardNodeProviders(_) => "ACTION_REWARD_NODE_PROVIDERS",
             Action::SetDefaultFollowees(_) => "ACTION_SET_DEFAULT_FOLLOWEES",
             Action::RegisterKnownNeuron(_) => "ACTION_REGISTER_KNOWN_NEURON",
+            Action::DeregisterKnownNeuron(_) => "ACTION_DEREGISTER_KNOWN_NEURON",
             Action::SetSnsTokenSwapOpenTimeWindow(_) => {
                 "ACTION_SET_SNS_TOKEN_SWAP_OPEN_TIME_WINDOW"
             }
@@ -4368,6 +4369,10 @@ impl Governance {
                 let result = self.register_known_neuron(known_neuron);
                 self.set_proposal_execution_status(pid, result);
             }
+            Action::DeregisterKnownNeuron(deregister_request) => {
+                let result = deregister_request.execute(&mut self.neuron_store);
+                self.set_proposal_execution_status(pid, result);
+            }
             Action::CreateServiceNervousSystem(ref create_service_nervous_system) => {
                 self.create_service_nervous_system(pid, create_service_nervous_system)
                     .await;
@@ -5004,6 +5009,9 @@ impl Governance {
             Action::UpdateCanisterSettings(update_settings) => update_settings.validate(),
             Action::FulfillSubnetRentalRequest(fulfill_subnet_rental_request) => {
                 fulfill_subnet_rental_request.validate()
+            }
+            Action::DeregisterKnownNeuron(deregister_known_neuron) => {
+                deregister_known_neuron.validate(&self.neuron_store)
             }
         }?;
 

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -210,6 +210,9 @@ thread_local! {
 
     static ENABLE_KNOWN_NEURON_VOTING_HISTORY: Cell<bool>
         = const { Cell::new(cfg!(feature = "test")) };
+
+    static ENABLE_DEREGISTER_KNOWN_NEURON: Cell<bool>
+        = const { Cell::new(cfg!(feature = "test")) };
 }
 
 thread_local! {
@@ -261,6 +264,20 @@ pub fn temporarily_enable_known_neuron_voting_history() -> Temporary {
 #[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_known_neuron_voting_history() -> Temporary {
     Temporary::new(&ENABLE_KNOWN_NEURON_VOTING_HISTORY, false)
+}
+
+pub fn is_deregister_known_neuron_enabled() -> bool {
+    ENABLE_DEREGISTER_KNOWN_NEURON.get()
+}
+
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_enable_deregister_known_neuron() -> Temporary {
+    Temporary::new(&ENABLE_DEREGISTER_KNOWN_NEURON, true)
+}
+
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_disable_deregister_known_neuron() -> Temporary {
+    Temporary::new(&ENABLE_DEREGISTER_KNOWN_NEURON, false)
 }
 
 pub fn decoder_config() -> DecoderConfig {

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -1089,7 +1089,6 @@ impl Neuron {
 
     /// Does NOT touch visiblity. If you want to go private, call set_visibility
     /// after calling this.
-    #[cfg(test)] // This can be used in production, but so far, it is not needed.
     pub(crate) fn clear_known_neuron_data(&mut self) {
         self.known_neuron_data = None;
     }

--- a/rs/nns/governance/src/pb/conversions/mod.rs
+++ b/rs/nns/governance/src/pb/conversions/mod.rs
@@ -50,6 +50,18 @@ impl From<pb_api::UpdateNodeProvider> for pb::UpdateNodeProvider {
     }
 }
 
+impl From<pb_api::DeregisterKnownNeuron> for pb::DeregisterKnownNeuron {
+    fn from(item: pb_api::DeregisterKnownNeuron) -> Self {
+        Self { id: item.id }
+    }
+}
+
+impl From<pb::DeregisterKnownNeuron> for pb_api::DeregisterKnownNeuron {
+    fn from(item: pb::DeregisterKnownNeuron) -> Self {
+        Self { id: item.id }
+    }
+}
+
 impl From<pb::BallotInfo> for pb_api::BallotInfo {
     fn from(item: pb::BallotInfo) -> Self {
         Self {
@@ -417,6 +429,9 @@ impl From<pb_api::proposal::Action> for pb::proposal::Action {
             pb_api::proposal::Action::RegisterKnownNeuron(v) => {
                 pb::proposal::Action::RegisterKnownNeuron(v.into())
             }
+            pb_api::proposal::Action::DeregisterKnownNeuron(v) => {
+                pb::proposal::Action::DeregisterKnownNeuron(v.into())
+            }
             pb_api::proposal::Action::SetSnsTokenSwapOpenTimeWindow(v) => {
                 pb::proposal::Action::SetSnsTokenSwapOpenTimeWindow(v.into())
             }
@@ -466,6 +481,9 @@ impl From<pb_api::ProposalActionRequest> for pb::proposal::Action {
             }
             pb_api::ProposalActionRequest::RegisterKnownNeuron(v) => {
                 pb::proposal::Action::RegisterKnownNeuron(v.into())
+            }
+            pb_api::ProposalActionRequest::DeregisterKnownNeuron(v) => {
+                pb::proposal::Action::DeregisterKnownNeuron(v.into())
             }
             pb_api::ProposalActionRequest::CreateServiceNervousSystem(v) => {
                 pb::proposal::Action::CreateServiceNervousSystem(v.into())

--- a/rs/nns/governance/src/pb/proposal_conversions.rs
+++ b/rs/nns/governance/src/pb/proposal_conversions.rs
@@ -162,6 +162,9 @@ fn convert_action(
         pb::proposal::Action::RegisterKnownNeuron(v) => {
             pb_api::proposal::Action::RegisterKnownNeuron(v.clone().into())
         }
+        pb::proposal::Action::DeregisterKnownNeuron(v) => {
+            pb_api::proposal::Action::DeregisterKnownNeuron((*v).into())
+        }
         pb::proposal::Action::SetSnsTokenSwapOpenTimeWindow(v) => {
             pb_api::proposal::Action::SetSnsTokenSwapOpenTimeWindow(v.clone().into())
         }

--- a/rs/nns/governance/src/proposals/deregister_known_neuron.rs
+++ b/rs/nns/governance/src/proposals/deregister_known_neuron.rs
@@ -1,0 +1,63 @@
+use crate::{
+    is_deregister_known_neuron_enabled,
+    neuron_store::NeuronStore,
+    pb::v1::{governance_error::ErrorType, DeregisterKnownNeuron, GovernanceError},
+};
+
+impl DeregisterKnownNeuron {
+    /// Validates the deregister known neuron request.
+    ///
+    /// Preconditions:
+    ///  - A Neuron ID is given in the request and this ID identifies an existing neuron.
+    ///  - The neuron currently has known neuron data to be removed.
+    pub fn validate(&self, neuron_store: &NeuronStore) -> Result<(), GovernanceError> {
+        if !is_deregister_known_neuron_enabled() {
+            return Err(GovernanceError::new_with_message(
+                ErrorType::InvalidProposal,
+                "DeregisterKnownNeuron proposals are not enabled yet.".to_string(),
+            ));
+        }
+
+        let neuron_id = self.id.as_ref().ok_or_else(|| {
+            GovernanceError::new_with_message(
+                ErrorType::InvalidProposal,
+                "No neuron ID specified in the request to deregister a known neuron.",
+            )
+        })?;
+
+        // Check if the neuron has known neuron data
+        let is_known_neuron =
+            neuron_store.with_neuron(neuron_id, |neuron| neuron.known_neuron_data().is_some())?;
+
+        if !is_known_neuron {
+            return Err(GovernanceError::new_with_message(
+                ErrorType::PreconditionFailed,
+                format!("Neuron {} is not a known neuron", neuron_id.id),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Executes the deregister known neuron action.
+    ///
+    /// This method removes the known neuron data (name and description) from the neuron,
+    /// making it a regular neuron again.
+    pub fn execute(&self, neuron_store: &mut NeuronStore) -> Result<(), GovernanceError> {
+        let neuron_id = self.id.as_ref().ok_or_else(|| {
+            GovernanceError::new_with_message(
+                ErrorType::InvalidProposal,
+                "No neuron ID specified in the request to deregister a known neuron.",
+            )
+        })?;
+
+        // Remove the known neuron data
+        neuron_store.with_neuron_mut(neuron_id, |neuron| neuron.clear_known_neuron_data())?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "deregister_known_neuron_tests.rs"]
+mod tests;

--- a/rs/nns/governance/src/proposals/deregister_known_neuron_tests.rs
+++ b/rs/nns/governance/src/proposals/deregister_known_neuron_tests.rs
@@ -1,0 +1,208 @@
+use crate::{
+    neuron::{DissolveStateAndAge, NeuronBuilder},
+    neuron_store::NeuronStore,
+    pb::v1::{governance_error::ErrorType, DeregisterKnownNeuron, KnownNeuronData},
+    temporarily_disable_deregister_known_neuron, temporarily_enable_deregister_known_neuron,
+};
+use assert_matches::assert_matches;
+use ic_nns_common::pb::v1::NeuronId;
+use std::collections::BTreeMap;
+
+fn create_test_neuron_store() -> NeuronStore {
+    let mut neuron_store = NeuronStore::new(BTreeMap::new());
+
+    // Create a known neuron (ID: 1)
+    let known_neuron = NeuronBuilder::new_for_test(
+        1,
+        DissolveStateAndAge::NotDissolving {
+            dissolve_delay_seconds: 86400,
+            aging_since_timestamp_seconds: 0,
+        },
+    )
+    .with_cached_neuron_stake_e8s(1_000_000_000)
+    .with_known_neuron_data(Some(KnownNeuronData {
+        name: "Test Known Neuron".to_string(),
+        description: Some("A test known neuron for deregistration".to_string()),
+    }))
+    .build();
+
+    neuron_store.add_neuron(known_neuron).unwrap();
+
+    // Create a regular neuron without known neuron data (ID: 2)
+    let regular_neuron = NeuronBuilder::new_for_test(
+        2,
+        DissolveStateAndAge::NotDissolving {
+            dissolve_delay_seconds: 86400,
+            aging_since_timestamp_seconds: 0,
+        },
+    )
+    .build();
+
+    neuron_store.add_neuron(regular_neuron).unwrap();
+
+    neuron_store
+}
+
+#[test]
+fn test_validate_feature_disabled() {
+    let _t = temporarily_disable_deregister_known_neuron();
+    let neuron_store = create_test_neuron_store();
+    let request = DeregisterKnownNeuron {
+        id: Some(NeuronId { id: 1 }),
+    };
+
+    let result = request.validate(&neuron_store);
+    assert_matches!(
+        result,
+        Err(error) if error.error_type == ErrorType::InvalidProposal as i32
+            && error.error_message.contains("DeregisterKnownNeuron proposals are not enabled yet")
+    );
+}
+
+#[test]
+fn test_validate_success_with_known_neuron() {
+    let _t = temporarily_enable_deregister_known_neuron();
+    let neuron_store = create_test_neuron_store();
+    let request = DeregisterKnownNeuron {
+        id: Some(NeuronId { id: 1 }),
+    };
+
+    let result = request.validate(&neuron_store);
+    assert!(
+        result.is_ok(),
+        "Expected validation to succeed for known neuron"
+    );
+}
+
+#[test]
+fn test_validate_missing_neuron_id() {
+    let _t = temporarily_enable_deregister_known_neuron();
+    let neuron_store = create_test_neuron_store();
+    let request = DeregisterKnownNeuron { id: None };
+
+    let result = request.validate(&neuron_store);
+    assert_matches!(
+        result,
+        Err(error) if error.error_type == ErrorType::InvalidProposal as i32
+            && error.error_message.contains("No neuron ID specified")
+    );
+}
+
+#[test]
+fn test_validate_nonexistent_neuron() {
+    let _t = temporarily_enable_deregister_known_neuron();
+    let neuron_store = create_test_neuron_store();
+    let request = DeregisterKnownNeuron {
+        id: Some(NeuronId { id: 999 }),
+    };
+
+    let result = request.validate(&neuron_store);
+    assert_matches!(
+        result,
+        Err(error) if error.error_type == ErrorType::NotFound as i32
+            && error.error_message.contains("Neuron not found")
+            && error.error_message.contains("999")
+    );
+}
+
+#[test]
+fn test_validate_regular_neuron_not_known() {
+    let _t = temporarily_enable_deregister_known_neuron();
+    let neuron_store = create_test_neuron_store();
+    let request = DeregisterKnownNeuron {
+        id: Some(NeuronId { id: 2 }), // Regular neuron without known data
+    };
+
+    let result = request.validate(&neuron_store);
+    assert_matches!(
+        result,
+        Err(error) if error.error_type == ErrorType::PreconditionFailed as i32
+            && error.error_message.contains("is not a known neuron")
+            && error.error_message.contains("2")
+    );
+}
+
+#[test]
+fn test_execute_success() {
+    let _t = temporarily_enable_deregister_known_neuron();
+    let mut neuron_store = create_test_neuron_store();
+    let neuron_id = NeuronId { id: 1 };
+    let request = DeregisterKnownNeuron {
+        id: Some(neuron_id),
+    };
+
+    // Verify the neuron has known neuron data before execution
+    let has_known_data_before = neuron_store
+        .with_neuron(&neuron_id, |neuron| neuron.known_neuron_data().is_some())
+        .expect("Neuron should exist");
+    assert!(
+        has_known_data_before,
+        "Neuron should have known data before deregistration"
+    );
+
+    // Also verify the actual data
+    let known_data_before = neuron_store
+        .with_neuron(&neuron_id, |neuron| neuron.known_neuron_data().cloned())
+        .expect("Neuron should exist");
+    assert!(
+        known_data_before.is_some(),
+        "Known data should exist before deregistration"
+    );
+    let data = known_data_before.unwrap();
+    assert_eq!(data.name, "Test Known Neuron");
+    assert_eq!(
+        data.description,
+        Some("A test known neuron for deregistration".to_string())
+    );
+
+    // Execute the deregistration
+    let result = request.execute(&mut neuron_store);
+    assert!(result.is_ok(), "Execute should succeed: {:?}", result);
+
+    // Verify the known neuron data has been removed
+    let has_known_data_after = neuron_store
+        .with_neuron(&neuron_id, |neuron| neuron.known_neuron_data().is_some())
+        .expect("Neuron should still exist after deregistration");
+    assert!(
+        !has_known_data_after,
+        "Neuron should not have known data after deregistration"
+    );
+
+    // Verify the neuron itself still exists with other data intact
+    let neuron_exists = neuron_store.contains(neuron_id);
+    assert!(
+        neuron_exists,
+        "Neuron should still exist after deregistration"
+    );
+
+    let stake = neuron_store
+        .with_neuron(&neuron_id, |neuron| neuron.cached_neuron_stake_e8s)
+        .expect("Neuron should exist");
+    assert_eq!(stake, 1_000_000_000, "Neuron stake should remain unchanged");
+}
+
+#[test]
+fn test_execute_missing_neuron_id() {
+    let _t = temporarily_enable_deregister_known_neuron();
+    let mut neuron_store = create_test_neuron_store();
+    let request = DeregisterKnownNeuron { id: None };
+
+    let result = request.execute(&mut neuron_store);
+    assert_matches!(
+        result,
+        Err(error) if error.error_type == ErrorType::InvalidProposal as i32
+            && error.error_message.contains("No neuron ID specified")
+    );
+}
+
+#[test]
+fn test_execute_nonexistent_neuron() {
+    let _t = temporarily_enable_deregister_known_neuron();
+    let mut neuron_store = create_test_neuron_store();
+    let request = DeregisterKnownNeuron {
+        id: Some(NeuronId { id: 999 }),
+    };
+
+    let result = request.execute(&mut neuron_store);
+    assert_matches!(result, Err(_), "Execute should fail for nonexistent neuron");
+}

--- a/rs/nns/governance/src/proposals/mod.rs
+++ b/rs/nns/governance/src/proposals/mod.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 
 pub mod call_canister;
 pub mod create_service_nervous_system;
+pub mod deregister_known_neuron;
 pub mod fulfill_subnet_rental_request;
 pub mod install_code;
 pub mod stop_or_start_canister;

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,6 +9,8 @@ on the process that this file is part of, see
 
 ## Added
 
+* Added a new proposal type `DeregisterKnownNeuron` without enabling it (behind feature flag).
+
 ## Changed
 
 ## Deprecated

--- a/rs/nns/integration_tests/src/known_neurons.rs
+++ b/rs/nns/integration_tests/src/known_neurons.rs
@@ -1,196 +1,225 @@
-use dfn_candid::{candid, candid_one};
-use ic_canister_client_sender::Sender;
+use ic_nervous_system_common::ONE_YEAR_SECONDS;
 use ic_nervous_system_common_test_keys::{
-    TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_KEYPAIR, TEST_NEURON_2_ID, TEST_NEURON_3_ID,
+    TEST_NEURON_1_OWNER_PRINCIPAL, TEST_NEURON_2_OWNER_PRINCIPAL,
 };
-use ic_nns_common::{pb::v1::NeuronId, types::ProposalId};
+use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance_api::{
-    manage_neuron::NeuronIdOrSubaccount, manage_neuron_response::Command as CommandResponse,
-    GovernanceError, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse, MakeProposalRequest,
-    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse, NeuronInfo,
-    ProposalActionRequest, ProposalStatus,
+    DeregisterKnownNeuron, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
-    governance::wait_for_final_state,
-    itest_helpers::{state_machine_test_on_nns_subnet, NnsCanisters},
+    state_test_helpers::{
+        list_known_neurons, nns_claim_or_refresh_neuron, nns_deregister_known_neuron,
+        nns_governance_get_neuron_info, nns_increase_dissolve_delay, nns_register_known_neuron,
+        nns_send_icp_to_claim_or_refresh_neuron, setup_nns_canisters,
+        state_machine_builder_for_nns_tests,
+    },
 };
+use icp_ledger::{AccountIdentifier, Tokens};
 
-/// Integration test for the known neuron functionality.
+/// Integration test for the known neuron functionality including deregistration.
 ///
 /// The test does the following:
 /// - Start with 3 neurons, none of them "known".
-/// - Register a name for two of them.
-/// - Assert than when querying the known neurons by id the result is the
-///   expected one.
-/// - Assert than when querying all known neurons the result is the expected
-///   one.
+/// - Assert entire list_known_neurons response equals empty list initially.
+/// - Register a name for two of them via governance proposals.
+/// - Assert entire list_known_neurons response equals expected 2-neuron list.
+/// - Deregister one of the known neurons via governance proposal.
+/// - Assert entire list_known_neurons response equals expected 1-neuron list.
+/// - Update the remaining known neuron to have a description.
+/// - Assert entire list_known_neurons response equals expected 1-neuron list with description.
 #[test]
 fn test_known_neurons() {
-    state_machine_test_on_nns_subnet(|runtime| async move {
-        let nns_init_payload = NnsInitPayloadsBuilder::new()
-            .with_initial_invariant_compliant_mutations()
-            .with_test_neurons()
-            .build();
+    // Step 1.1: Prepare the world by setting up NNS canisters with 2 principals both with 10 ICP.
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    let principal_1 = *TEST_NEURON_1_OWNER_PRINCIPAL;
+    let principal_2 = *TEST_NEURON_2_OWNER_PRINCIPAL;
+    let nns_init_payloads = NnsInitPayloadsBuilder::new()
+        .with_ledger_accounts(vec![
+            (
+                AccountIdentifier::new(principal_1, None),
+                Tokens::from_e8s(1_000_000_000),
+            ),
+            (
+                AccountIdentifier::new(principal_2, None),
+                Tokens::from_e8s(1_000_000_000),
+            ),
+        ])
+        .build();
+    setup_nns_canisters(&state_machine, nns_init_payloads);
 
-        let nns_canisters = NnsCanisters::set_up(&runtime, nns_init_payload).await;
+    // Step 1.2: Claim 3 neurons - principal 1 has 2 neurons, principal 2 has 1 neuron. All with 2 ICPs.
+    nns_send_icp_to_claim_or_refresh_neuron(
+        &state_machine,
+        principal_1,
+        Tokens::from_e8s(200_000_000),
+        1,
+    );
+    let neuron_id_1 = nns_claim_or_refresh_neuron(&state_machine, principal_1, 1);
 
-        // Submit two proposal to register a name for a neuron, and then wait until both
-        // are executed. Proposals are submitted by neuron 1, because it has
-        // enough stake to have them accepted immediately.
-        let result_1: ManageNeuronResponse = nns_canisters
-            .governance
-            .update_from_sender(
-                "manage_neuron",
-                candid_one,
-                ManageNeuronRequest {
-                    neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
-                        ic_nns_common::pb::v1::NeuronId {
-                            id: TEST_NEURON_1_ID,
-                        },
-                    )),
-                    id: None,
-                    command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
-                        MakeProposalRequest {
-                            title: Some("Naming neuron 2.".to_string()),
-                            summary: "".to_string(),
-                            url: "".to_string(),
-                            action: Some(ProposalActionRequest::RegisterKnownNeuron(KnownNeuron {
-                                id: Some(NeuronId {
-                                    id: TEST_NEURON_2_ID,
-                                }),
-                                known_neuron_data: Some(KnownNeuronData {
-                                    name: "NeuronTwo".to_string(),
-                                    description: None,
-                                }),
-                            })),
-                        },
-                    ))),
+    nns_send_icp_to_claim_or_refresh_neuron(
+        &state_machine,
+        principal_1,
+        Tokens::from_e8s(200_000_000),
+        2,
+    );
+    let neuron_id_2 = nns_claim_or_refresh_neuron(&state_machine, principal_1, 2);
+
+    nns_send_icp_to_claim_or_refresh_neuron(
+        &state_machine,
+        principal_2,
+        Tokens::from_e8s(200_000_000),
+        3,
+    );
+    let neuron_id_3 = nns_claim_or_refresh_neuron(&state_machine, principal_2, 3);
+
+    // Step 1.3: Increase dissolve delay to enable proposal making.
+    nns_increase_dissolve_delay(&state_machine, principal_1, neuron_id_1, ONE_YEAR_SECONDS)
+        .expect("Failed to increase dissolve delay for neuron 1");
+
+    // Step 1.4: Verify that initially there are no known neurons.
+    assert_eq!(
+        list_known_neurons(&state_machine),
+        ListKnownNeuronsResponse {
+            known_neurons: vec![],
+        }
+    );
+
+    // Step 2: Register two neurons as known neurons.
+    nns_register_known_neuron(
+        &state_machine,
+        principal_1,
+        neuron_id_1,
+        KnownNeuron {
+            id: Some(NeuronId { id: neuron_id_2.id }),
+            known_neuron_data: Some(KnownNeuronData {
+                name: "NeuronTwo".to_string(),
+                description: Some("Second test neuron".to_string()),
+            }),
+        },
+    );
+    nns_register_known_neuron(
+        &state_machine,
+        principal_1,
+        neuron_id_1,
+        KnownNeuron {
+            id: Some(NeuronId { id: neuron_id_3.id }),
+            known_neuron_data: Some(KnownNeuronData {
+                name: "NeuronThree".to_string(),
+                description: None,
+            }),
+        },
+    );
+
+    // Step 3: Verify that both neurons are now known neurons and get_neuron_info returns the KnownNeuronData.
+    assert_eq!(
+        list_known_neurons(&state_machine),
+        ListKnownNeuronsResponse {
+            known_neurons: vec![
+                KnownNeuron {
+                    id: Some(NeuronId { id: neuron_id_3.id }),
+                    known_neuron_data: Some(KnownNeuronData {
+                        name: "NeuronThree".to_string(),
+                        description: None,
+                    }),
                 },
-                &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
-            )
-            .await
-            .expect("Error calling the manage_neuron api.");
-        let result_2: ManageNeuronResponse = nns_canisters
-            .governance
-            .update_from_sender(
-                "manage_neuron",
-                candid_one,
-                ManageNeuronRequest {
-                    neuron_id_or_subaccount: Some(NeuronIdOrSubaccount::NeuronId(
-                        ic_nns_common::pb::v1::NeuronId {
-                            id: TEST_NEURON_1_ID,
-                        },
-                    )),
-                    id: None,
-                    command: Some(ManageNeuronCommandRequest::MakeProposal(Box::new(
-                        MakeProposalRequest {
-                            title: Some("Naming neuron 3.".to_string()),
-                            summary: "".to_string(),
-                            url: "".to_string(),
-                            action: Some(ProposalActionRequest::RegisterKnownNeuron(KnownNeuron {
-                                id: Some(NeuronId {
-                                    id: TEST_NEURON_3_ID,
-                                }),
-                                known_neuron_data: Some(KnownNeuronData {
-                                    name: "NeuronThree".to_string(),
-                                    description: None,
-                                }),
-                            })),
-                        },
-                    ))),
+                KnownNeuron {
+                    id: Some(NeuronId { id: neuron_id_2.id }),
+                    known_neuron_data: Some(KnownNeuronData {
+                        name: "NeuronTwo".to_string(),
+                        description: Some("Second test neuron".to_string()),
+                    }),
                 },
-                &Sender::from_keypair(&TEST_NEURON_1_OWNER_KEYPAIR),
-            )
-            .await
-            .expect("Error calling the manage_neuron api.");
-
-        let pid_1 = match result_1
-            .panic_if_error("Error making proposal")
-            .command
+            ],
+        }
+    );
+    assert_eq!(
+        nns_governance_get_neuron_info(&state_machine, principal_1, neuron_id_2.id)
             .unwrap()
-        {
-            CommandResponse::MakeProposal(resp) => resp.proposal_id.unwrap(),
-            some_error => {
-                panic!(
-                    "Cannot find proposal id in response. The response is: {:?}",
-                    some_error
-                )
-            }
-        };
-        let pid_2 = match result_2
-            .panic_if_error("Error making proposal")
-            .command
+            .known_neuron_data
+            .unwrap(),
+        KnownNeuronData {
+            name: "NeuronTwo".to_string(),
+            description: Some("Second test neuron".to_string()),
+        }
+    );
+    assert_eq!(
+        nns_governance_get_neuron_info(&state_machine, principal_1, neuron_id_3.id)
             .unwrap()
-        {
-            CommandResponse::MakeProposal(resp) => resp.proposal_id.unwrap(),
-            some_error => {
-                panic!(
-                    "Cannot find proposal id in response. The response is: {:?}",
-                    some_error
-                )
-            }
-        };
+            .known_neuron_data
+            .unwrap(),
+        KnownNeuronData {
+            name: "NeuronThree".to_string(),
+            description: None,
+        }
+    );
 
-        assert_eq!(
-            wait_for_final_state(&nns_canisters.governance, ProposalId::from(pid_1))
-                .await
-                .status,
-            ProposalStatus::Executed as i32
-        );
-        assert_eq!(
-            wait_for_final_state(&nns_canisters.governance, ProposalId::from(pid_2))
-                .await
-                .status,
-            ProposalStatus::Executed as i32
-        );
+    // Step 4: Deregister one of the known neurons.
+    nns_deregister_known_neuron(
+        &state_machine,
+        principal_1,
+        neuron_id_1,
+        DeregisterKnownNeuron {
+            id: Some(NeuronId { id: neuron_id_2.id }),
+        },
+    );
 
-        // Check that neuron 2 has the correct name
-        let ni: Result<NeuronInfo, GovernanceError> = nns_canisters
-            .governance
-            .query_("get_neuron_info", candid, (TEST_NEURON_2_ID,))
-            .await
-            .expect("Error calling the neuron_info api.");
-        assert_eq!(
-            "NeuronTwo",
-            ni.as_ref()
-                .unwrap()
-                .known_neuron_data
-                .as_ref()
-                .unwrap()
-                .name
-        );
-
-        let expected_known_neurons = vec![
-            KnownNeuron {
-                id: Some(NeuronId {
-                    id: TEST_NEURON_2_ID,
-                }),
-                known_neuron_data: Some(KnownNeuronData {
-                    name: "NeuronTwo".to_string(),
-                    description: None,
-                }),
-            },
-            KnownNeuron {
-                id: Some(NeuronId {
-                    id: TEST_NEURON_3_ID,
-                }),
+    // Step 5: Verify that only one known neuron remains and the get_neuron_info doesn't return the
+    // KnownNeuronData for the deregistered neuron.
+    assert_eq!(
+        list_known_neurons(&state_machine),
+        ListKnownNeuronsResponse {
+            known_neurons: vec![KnownNeuron {
+                id: Some(NeuronId { id: neuron_id_3.id }),
                 known_neuron_data: Some(KnownNeuronData {
                     name: "NeuronThree".to_string(),
                     description: None,
                 }),
-            },
-        ];
-        let list_known_neurons_response: ListKnownNeuronsResponse = nns_canisters
-            .governance
-            .query_("list_known_neurons", candid, ())
-            .await
-            .expect("Error calling list known neurons api.");
-        let mut sorted_response_known_neurons = list_known_neurons_response.known_neurons;
-        sorted_response_known_neurons
-            .sort_by(|a, b| a.id.as_ref().unwrap().id.cmp(&b.id.as_ref().unwrap().id));
-        assert_eq!(sorted_response_known_neurons, expected_known_neurons);
+            }],
+        }
+    );
+    assert_eq!(
+        nns_governance_get_neuron_info(&state_machine, principal_1, neuron_id_2.id)
+            .unwrap()
+            .known_neuron_data,
+        None,
+    );
 
-        Ok(())
-    });
+    // Step 6: Upate the remaininig known neuron to have a description.
+    nns_register_known_neuron(
+        &state_machine,
+        principal_1,
+        neuron_id_1,
+        KnownNeuron {
+            id: Some(NeuronId { id: neuron_id_3.id }),
+            known_neuron_data: Some(KnownNeuronData {
+                name: "NeuronThree (changed)".to_string(),
+                description: Some("Third test neuron".to_string()),
+            }),
+        },
+    );
+
+    // Step 7: Verify that the known neuron now has a description through list_known_neurons and get_neuron_info.
+    assert_eq!(
+        list_known_neurons(&state_machine),
+        ListKnownNeuronsResponse {
+            known_neurons: vec![KnownNeuron {
+                id: Some(NeuronId { id: neuron_id_3.id }),
+                known_neuron_data: Some(KnownNeuronData {
+                    name: "NeuronThree (changed)".to_string(),
+                    description: Some("Third test neuron".to_string()),
+                }),
+            }],
+        }
+    );
+    assert_eq!(
+        nns_governance_get_neuron_info(&state_machine, principal_1, neuron_id_3.id)
+            .unwrap()
+            .known_neuron_data
+            .unwrap(),
+        KnownNeuronData {
+            name: "NeuronThree (changed)".to_string(),
+            description: Some("Third test neuron".to_string()),
+        }
+    );
 }

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -2324,3 +2324,86 @@ pub fn setup_subnet_rental_canister_with_correct_canister_id(state_machine: &Sta
     // Subnet Rental Canister needs cycles to call XRC
     state_machine.add_cycles(canister_id, 100_000_000_000_000);
 }
+
+/// Helper function to register a known neuron via governance proposal.
+pub fn nns_register_known_neuron(
+    state_machine: &StateMachine,
+    proposer_principal: PrincipalId,
+    proposer_neuron_id: NeuronId,
+    known_neuron: ic_nns_governance_api::KnownNeuron,
+) {
+    let proposal = ic_nns_governance_api::MakeProposalRequest {
+        title: Some("Register Known Neuron".to_string()),
+        summary: "Proposal to register a neuron as a known neuron".to_string(),
+        url: "".to_string(),
+        action: Some(
+            ic_nns_governance_api::ProposalActionRequest::RegisterKnownNeuron(known_neuron),
+        ),
+    };
+
+    let manage_neuron_response = nns_governance_make_proposal(
+        state_machine,
+        proposer_principal,
+        proposer_neuron_id,
+        &proposal,
+    );
+
+    match manage_neuron_response.command.unwrap() {
+        ic_nns_governance_api::manage_neuron_response::Command::MakeProposal(response) => {
+            let proposal_id = response.proposal_id.unwrap();
+            nns_wait_for_proposal_execution(state_machine, proposal_id.id);
+        }
+        other => panic!("Expected MakeProposal response but got: {:?}", other),
+    }
+}
+
+/// Helper function to deregister a known neuron via governance proposal.
+pub fn nns_deregister_known_neuron(
+    state_machine: &StateMachine,
+    proposer_principal: PrincipalId,
+    proposer_neuron_id: NeuronId,
+    deregister_request: ic_nns_governance_api::DeregisterKnownNeuron,
+) {
+    let proposal = ic_nns_governance_api::MakeProposalRequest {
+        title: Some("Deregister Known Neuron".to_string()),
+        summary: "Proposal to deregister a known neuron".to_string(),
+        url: "".to_string(),
+        action: Some(
+            ic_nns_governance_api::ProposalActionRequest::DeregisterKnownNeuron(deregister_request),
+        ),
+    };
+
+    let manage_neuron_response = nns_governance_make_proposal(
+        state_machine,
+        proposer_principal,
+        proposer_neuron_id,
+        &proposal,
+    );
+
+    match manage_neuron_response.command.unwrap() {
+        ic_nns_governance_api::manage_neuron_response::Command::MakeProposal(response) => {
+            let proposal_id = response.proposal_id.unwrap();
+            nns_wait_for_proposal_execution(state_machine, proposal_id.id);
+        }
+        other => panic!("Expected MakeProposal response but got: {:?}", other),
+    }
+}
+
+/// Helper function to list known neurons.
+pub fn list_known_neurons(
+    state_machine: &StateMachine,
+) -> ic_nns_governance_api::ListKnownNeuronsResponse {
+    let response_bytes = query(
+        state_machine,
+        GOVERNANCE_CANISTER_ID,
+        "list_known_neurons",
+        Encode!(&()).unwrap(),
+    )
+    .expect("Error calling list_known_neurons");
+
+    Decode!(
+        &response_bytes,
+        ic_nns_governance_api::ListKnownNeuronsResponse
+    )
+    .expect("Error decoding ListKnownNeuronsResponse")
+}


### PR DESCRIPTION
# Why

There are many known neurons that are no longer active, and currently there is no way to remove them.

# What

Implement a deregister_known_neuron proposal type behind a feature flag.