### PR TITLE
refactor(governance): Reference ic-limits for subnet creation parameters.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11409,6 +11409,7 @@ dependencies = [
  "ic-dummy-getrandom-for-wasm",
  "ic-http-types",
  "ic-ledger-core",
+ "ic-limits",
  "ic-management-canister-types-private",
  "ic-metrics-encoder",
  "ic-nervous-system-canisters",

--- a/rs/nns/governance/BUILD.bazel
+++ b/rs/nns/governance/BUILD.bazel
@@ -45,6 +45,7 @@ DEPENDENCIES = [
     "//packages/ic-http-types",
     "//packages/icrc-ledger-types:icrc_ledger_types",
     "//rs/crypto/sha2",
+    "//rs/limits",
     "//rs/ledger_suite/common/ledger_core",
     "//rs/ledger_suite/icp:icp_ledger",
     "//rs/nervous_system/canisters",

--- a/rs/nns/governance/Cargo.toml
+++ b/rs/nns/governance/Cargo.toml
@@ -37,6 +37,7 @@ ic-crypto-sha2 = { path = "../../crypto/sha2/" }
 ic-dummy-getrandom-for-wasm = { path = "../../../packages/ic-dummy-getrandom-for-wasm" }
 ic-http-types = { path = "../../../packages/ic-http-types" }
 ic-ledger-core = { path = "../../ledger_suite/common/ledger_core" }
+ic-limits = { path = "../../limits" }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }
 ic-metrics-encoder = "1"
 ic-nervous-system-canisters = { path = "../../nervous_system/canisters" }


### PR DESCRIPTION
Because ic-limits is the source of truth for the standard parameter values. The comments in ic-limits are pretty informative; it's good that we are now linking back to those instead of using magic copy n' pasted numbers.

# Reference(s)

Closes [NNS1-4116].

[NNS1-4116]: https://dfinity.atlassian.net/browse/NNS1-4116