### PR TITLE
chore(nervous-system): Update changelog for release 2025-09-09

### DIFF
--- a/rs/nns/cmc/CHANGELOG.md
+++ b/rs/nns/cmc/CHANGELOG.md
@@ -11,6 +11,17 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-09-05: Proposal 138372
+
+http://dashboard.internetcomputer.org/proposal/138372
+
+## Removed
+
+- Removed `transaction_notification` and `transaction_notification_pb` endpoints as they
+  no longer be called. The ICP ledger removed the notify flow, and these methods were not
+  callable by callers other than the ICP ledger.
+
+
 # 2025-08-15: Proposal 137918
 
 http://dashboard.internetcomputer.org/proposal/137918

--- a/rs/nns/cmc/unreleased_changelog.md
+++ b/rs/nns/cmc/unreleased_changelog.md
@@ -4,6 +4,7 @@ In general, upcoming/unreleased behavior changes are described here. For details
 on the process that this file is part of, see
 `rs/nervous_system/changelog_process.md`.
 
+
 # Next Upgrade Proposal
 
 ## Added
@@ -13,10 +14,6 @@ on the process that this file is part of, see
 ## Deprecated
 
 ## Removed
-
-- Removed `transaction_notification` and `transaction_notification_pb` endpoints as they
-  no longer be called. The ICP ledger removed the notify flow, and these methods were not
-  callable by callers other than the ICP ledger.
 
 ## Fixed
 

--- a/rs/nns/governance/CHANGELOG.md
+++ b/rs/nns/governance/CHANGELOG.md
@@ -11,6 +11,24 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-09-05: Proposal 138369
+
+http://dashboard.internetcomputer.org/proposal/138369
+
+## Added
+
+* The neuron `Split` command accepts an optional `memo` field that can be used to derive the neuron
+  subaccount, rather than generating a random one.
+
+## Changed
+
+* The protobuf-encoded `Storable` implementations are changed to `Unbounded`.
+
+## Removed
+
+* The `IcpXdrConversionRate` proposal is now obsolete and cannot be submitted.
+
+
 # 2025-07-25: Proposal 137582
 
 http://dashboard.internetcomputer.org/proposal/137582

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,18 +9,11 @@ on the process that this file is part of, see
 
 ## Added
 
-* The neuron `Split` command accepts an optional `memo` field that can be used to derive the neuron
-  subaccount, rather than generating a random one.
-
 ## Changed
-
-* The protobuf-encoded `Storable` implementations are changed to `Unbounded`.
 
 ## Deprecated
 
 ## Removed
-
-* The `IcpXdrConversionRate` proposal is now obsolete and cannot be submitted.
 
 ## Fixed
 

--- a/rs/nns/sns-wasm/CHANGELOG.md
+++ b/rs/nns/sns-wasm/CHANGELOG.md
@@ -11,6 +11,15 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-09-05: Proposal 138370
+
+http://dashboard.internetcomputer.org/proposal/138370
+
+## Added
+
+* A "/sns_canisters" HTTP endpoint for SNS canisters service discovery, used for prometheus.
+
+
 # 2025-06-06: Proposal 136892
 
 http://dashboard.internetcomputer.org/proposal/136892

--- a/rs/nns/sns-wasm/unreleased_changelog.md
+++ b/rs/nns/sns-wasm/unreleased_changelog.md
@@ -9,8 +9,6 @@ on the process that this file is part of, see
 
 ## Added
 
-* A "/sns_canisters" HTTP endpoint for SNS canisters service discovery, used for prometheus.
-
 ## Changed
 
 ## Deprecated

--- a/rs/registry/canister/CHANGELOG.md
+++ b/rs/registry/canister/CHANGELOG.md
@@ -11,6 +11,15 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-09-05: Proposal 138371
+
+http://dashboard.internetcomputer.org/proposal/138371
+
+## Added
+* New update method that will be used for node swapping feature.
+* `migrate_canisters` returns the new registry version.
+
+
 # 2025-08-22: Proposal 138164
 
 http://dashboard.internetcomputer.org/proposal/138164

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -8,8 +8,6 @@ on the process that this file is part of, see
 # Next Upgrade Proposal
 
 ## Added
-* New update method that will be used for node swapping feature.
-* `migrate_canisters` returns the new registry version. 
 
 ## Changed
 

--- a/rs/sns/governance/CHANGELOG.md
+++ b/rs/sns/governance/CHANGELOG.md
@@ -11,6 +11,17 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-09-05: Proposal 138373
+
+http://dashboard.internetcomputer.org/proposal/138373
+
+## Added
+
+* Added extension_operations to list_topics, which exposes the operations of each registered extension underneath the
+  topic which allows voters to correctly understand the impact of following on particular topics. Extensions are
+  canisters that add additional functionality to an SNS through a privileged integration.
+
+
 # 2025-08-11: Proposal 137819
 
 http://dashboard.internetcomputer.org/proposal/137819

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -4,13 +4,10 @@ In general, upcoming/unreleased behavior changes are described here. For details
 on the process that this file is part of, see
 `rs/nervous_system/changelog_process.md`.
 
+
 # Next Upgrade Proposal
 
 ## Added
-
-* Added extension_operations to list_topics, which exposes the operations of each registered extension underneath the
-  topic which allows voters to correctly understand the impact of following on particular topics. Extensions are
-  canisters that add additional functionality to an SNS through a privileged integration.
 
 ## Changed
 

--- a/rs/sns/swap/CHANGELOG.md
+++ b/rs/sns/swap/CHANGELOG.md
@@ -11,6 +11,15 @@ here were moved from the adjacent `unreleased_changelog.md` file.
 INSERT NEW RELEASES HERE
 
 
+# 2025-09-05: Proposal 138374
+
+http://dashboard.internetcomputer.org/proposal/138374
+
+## Changed
+
+* Expose a metric for whether auto finalization has failed.
+
+
 # 2025-08-01: Proposal 137686
 
 http://dashboard.internetcomputer.org/proposal/137686

--- a/rs/sns/swap/unreleased_changelog.md
+++ b/rs/sns/swap/unreleased_changelog.md
@@ -11,8 +11,6 @@ on the process that this file is part of, see
 
 ## Changed
 
-* Expose a metric for whether auto finalization has failed.
-
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
Update CHANGELOG.md for the release on Sept. 8th, 2025.

## NNS 
  - [138369](https://dashboard.internetcomputer.org/proposal/138369)
  - [138370](https://dashboard.internetcomputer.org/proposal/138370)
  - [138371](https://dashboard.internetcomputer.org/proposal/138371)
  - [138372](https://dashboard.internetcomputer.org/proposal/138372)

## SNS 
  - [138373](https://dashboard.internetcomputer.org/proposal/138373)
  - [138374](https://dashboard.internetcomputer.org/proposal/138374)