### PR TITLE
feat(XC): enable Dogecoin for canisters on Bitcoin subnet

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -139,6 +139,12 @@ pub const BITCOIN_MAINNET_CANISTER_ID: &str = "ghsi2-tqaaa-aaaan-aaaca-cai";
 // TODO(EXC-1298): Uninstall this canister once the bitcoin mainnet canister is live.
 const BITCOIN_MAINNET_SOFT_LAUNCH_CANISTER_ID: &str = "gsvzx-syaaa-aaaan-aaabq-cai";
 
+// The ID of the Dogecoin testnet canister.
+pub const DOGECOIN_TESTNET_CANISTER_ID: &str = "hd7hi-kqaaa-aaaan-aaaea-cai";
+
+// The ID of the Dogecoin mainnet canister.
+pub const DOGECOIN_MAINNET_CANISTER_ID: &str = "gordg-fyaaa-aaaan-aaadq-cai";
+
 // The ID of the staging Dogecoin mainnet and testnet canisters.
 // These canisters will be used to run the dogecoin canisters pre-launch
 // for final validation and may be used in the future to validate some canister upgrades.
@@ -349,11 +355,13 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        let [bitcoin_testnet_canister_id, bitcoin_mainnet_canister_id, bitcoin_mainnet_soft_launch_canister_id, dogecoin_testnet_staging_canister_id, dogecoin_mainnet_staging_canister_id] =
+        let [bitcoin_testnet_canister_id, bitcoin_mainnet_canister_id, bitcoin_mainnet_soft_launch_canister_id, dogegoin_testnet_canister_id, dogegoin_mainnet_canister_id, dogecoin_testnet_staging_canister_id, dogecoin_mainnet_staging_canister_id] =
             expect_canister_id([
                 BITCOIN_TESTNET_CANISTER_ID,
                 BITCOIN_MAINNET_CANISTER_ID,
                 BITCOIN_MAINNET_SOFT_LAUNCH_CANISTER_ID,
+                DOGECOIN_TESTNET_CANISTER_ID,
+                DOGECOIN_MAINNET_CANISTER_ID,
                 DOGECOIN_TESTNET_STAGING_CANISTER_ID,
                 DOGECOIN_MAINNET_STAGING_CANISTER_ID,
             ]);
@@ -400,6 +408,8 @@ impl Default for Config {
                     bitcoin_testnet_canister_id,
                     bitcoin_mainnet_canister_id,
                     bitcoin_mainnet_soft_launch_canister_id,
+                    dogegoin_testnet_canister_id,
+                    dogegoin_mainnet_canister_id,
                     dogecoin_testnet_staging_canister_id,
                     dogecoin_mainnet_staging_canister_id,
                 ],
@@ -460,7 +470,8 @@ mod tests {
     use crate::execution_environment::{
         expect_canister_id, Config, BITCOIN_MAINNET_CANISTER_ID,
         BITCOIN_MAINNET_SOFT_LAUNCH_CANISTER_ID, BITCOIN_TESTNET_CANISTER_ID,
-        DOGECOIN_MAINNET_STAGING_CANISTER_ID, DOGECOIN_TESTNET_STAGING_CANISTER_ID,
+        DOGECOIN_MAINNET_CANISTER_ID, DOGECOIN_MAINNET_STAGING_CANISTER_ID,
+        DOGECOIN_TESTNET_CANISTER_ID, DOGECOIN_TESTNET_STAGING_CANISTER_ID,
     };
     use std::collections::BTreeSet;
 
@@ -470,6 +481,8 @@ mod tests {
             BITCOIN_TESTNET_CANISTER_ID,
             BITCOIN_MAINNET_CANISTER_ID,
             BITCOIN_MAINNET_SOFT_LAUNCH_CANISTER_ID,
+            DOGECOIN_TESTNET_CANISTER_ID,
+            DOGECOIN_MAINNET_CANISTER_ID,
             DOGECOIN_TESTNET_STAGING_CANISTER_ID,
             DOGECOIN_MAINNET_STAGING_CANISTER_ID,
         ])


### PR DESCRIPTION
Follow-up on #6563 to enable two canisters on the Bitcoin subnet ([w4rem](https://dashboard.internetcomputer.org/network/subnets/w4rem-dv5e3-widiz-wbpea-kbttk-mnzfm-tzrc7-svcj3-kbxyb-zamch-hqe)) to have access to the dogecoin adapter:

1. [gordg-fyaaa-aaaan-aaadq-cai](https://dashboard.internetcomputer.org/canister/gordg-fyaaa-aaaan-aaadq-cai) for Dogecoin mainnet.
2. [hd7hi-kqaaa-aaaan-aaaea-cai](https://dashboard.internetcomputer.org/canister/hd7hi-kqaaa-aaaan-aaaea-cai) for Dogecoin testnet