### PR TITLE
chore(nns): Clean up StopOrStartCanister as an NNS Function

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -447,6 +447,9 @@ impl NnsFunction {
             NnsFunction::NnsCanisterUpgrade | NnsFunction::NnsRootUpgrade => {
                 Err(format_obsolete_message("InstallCode"))
             }
+            NnsFunction::StopOrStartNnsCanister => {
+                Err(format_obsolete_message("Action::StopOrStartCanister"))
+            }
             NnsFunction::UpdateAllowedPrincipals => Err(
                 "NNS_FUNCTION_UPDATE_ALLOWED_PRINCIPALS is only used for the old SNS \
                 initialization mechanism, which is now obsolete. Use \
@@ -511,7 +514,6 @@ impl NnsFunction {
             NnsFunction::AddFirewallRules => (REGISTRY_CANISTER_ID, "add_firewall_rules"),
             NnsFunction::RemoveFirewallRules => (REGISTRY_CANISTER_ID, "remove_firewall_rules"),
             NnsFunction::UpdateFirewallRules => (REGISTRY_CANISTER_ID, "update_firewall_rules"),
-            NnsFunction::StopOrStartNnsCanister => (ROOT_CANISTER_ID, "stop_or_start_nns_canister"),
             NnsFunction::RemoveNodes => (REGISTRY_CANISTER_ID, "remove_nodes"),
             NnsFunction::UninstallCode => (CanisterId::ic_00(), "uninstall_code"),
             NnsFunction::UpdateNodeRewardsTable => {
@@ -567,7 +569,8 @@ impl NnsFunction {
             | NnsFunction::UpdateUnassignedNodesConfig
             | NnsFunction::UpdateNodesHostosVersion
             | NnsFunction::NnsCanisterUpgrade
-            | NnsFunction::NnsRootUpgrade => {
+            | NnsFunction::NnsRootUpgrade
+            | NnsFunction::StopOrStartNnsCanister => {
                 let error_message = match self.check_obsolete() {
                     Err(error_message) => error_message,
                     Ok(_) => unreachable!("Obsolete NnsFunction not handled"),
@@ -599,7 +602,8 @@ impl NnsFunction {
             | NnsFunction::NnsCanisterUpgrade
             | NnsFunction::NnsRootUpgrade
             | NnsFunction::UpdateAllowedPrincipals
-            | NnsFunction::IcpXdrConversionRate => match self.check_obsolete() {
+            | NnsFunction::IcpXdrConversionRate
+            | NnsFunction::StopOrStartNnsCanister => match self.check_obsolete() {
                 Ok(_) => unreachable!("Obsolete NnsFunction not handled"),
                 Err(error_message) => {
                     return Err(GovernanceError::new_with_message(
@@ -625,7 +629,6 @@ impl NnsFunction {
             | NnsFunction::DeployGuestosToAllSubnetNodes
             | NnsFunction::DeployGuestosToSomeApiBoundaryNodes
             | NnsFunction::DeployGuestosToAllUnassignedNodes => Topic::IcOsVersionDeployment,
-            NnsFunction::StopOrStartNnsCanister => Topic::ApplicationCanisterManagement,
             NnsFunction::ClearProvisionalWhitelist => Topic::NetworkEconomics,
             NnsFunction::SetAuthorizedSubnetworks => Topic::SubnetManagement,
             NnsFunction::SetFirewallConfig => Topic::SubnetManagement,

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -24,6 +24,9 @@ on the process that this file is part of, see
 
 ## Deprecated
 
+* The `StopOrStartCanister` NNS Function is now obsolete (Use `Action::StopOrStartCanister`
+  instead).
+
 ## Removed
 
 ## Fixed

--- a/rs/nns/integration_tests/src/stop_or_start_canister.rs
+++ b/rs/nns/integration_tests/src/stop_or_start_canister.rs
@@ -1,13 +1,9 @@
-use candid::Encode;
 use ic_base_types::CanisterId;
 use ic_nervous_system_clients::canister_status::CanisterStatusType;
-use ic_nervous_system_root::change_canister::{
-    CanisterAction as RootCanisterAction, StopOrStartCanisterRequest,
-};
 use ic_nns_constants::{REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::{
-    ExecuteNnsFunction, MakeProposalRequest, NnsFunction, ProposalActionRequest,
-    StopOrStartCanister, manage_neuron_response::Command, stop_or_start_canister::CanisterAction,
+    MakeProposalRequest, ProposalActionRequest, StopOrStartCanister,
+    manage_neuron_response::Command, stop_or_start_canister::CanisterAction,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
@@ -18,7 +14,8 @@ use ic_nns_test_utils::{
     },
 };
 
-fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
+#[test]
+fn test_stop_and_start_registry_canister() {
     // Step 1: Set up the NNS canisters and get the neuron.
     let state_machine = state_machine_builder_for_nns_tests().build();
     let nns_init_payloads = NnsInitPayloadsBuilder::new().with_test_neurons().build();
@@ -38,21 +35,11 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
     assert_eq!(canister_status_type(), CanisterStatusType::Running);
 
     // Step 3: Make a proposal to stop the canister and wait for it to be executed.
-    let action = if use_proposal_action {
-        ProposalActionRequest::StopOrStartCanister(StopOrStartCanister {
-            canister_id: Some(REGISTRY_CANISTER_ID.get()),
-            action: Some(CanisterAction::Stop as i32),
-        })
-    } else {
-        let stop_or_start_request = StopOrStartCanisterRequest {
-            canister_id: REGISTRY_CANISTER_ID,
-            action: RootCanisterAction::Stop,
-        };
-        ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::StopOrStartNnsCanister as i32,
-            payload: Encode!(&stop_or_start_request).unwrap(),
-        })
-    };
+    let action = ProposalActionRequest::StopOrStartCanister(StopOrStartCanister {
+        canister_id: Some(REGISTRY_CANISTER_ID.get()),
+        action: Some(CanisterAction::Stop as i32),
+    });
+
     let propose_response = nns_governance_make_proposal(
         &state_machine,
         n1.principal_id,
@@ -73,21 +60,11 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
     assert_eq!(canister_status_type(), CanisterStatusType::Stopped);
 
     // Step 5: Make a proposal to start the canister and wait for it to be executed.
-    let action = if use_proposal_action {
-        ProposalActionRequest::StopOrStartCanister(StopOrStartCanister {
-            canister_id: Some(REGISTRY_CANISTER_ID.get()),
-            action: Some(CanisterAction::Start as i32),
-        })
-    } else {
-        let stop_or_start_request = StopOrStartCanisterRequest {
-            canister_id: REGISTRY_CANISTER_ID,
-            action: RootCanisterAction::Start,
-        };
-        ProposalActionRequest::ExecuteNnsFunction(ExecuteNnsFunction {
-            nns_function: NnsFunction::StopOrStartNnsCanister as i32,
-            payload: Encode!(&stop_or_start_request).unwrap(),
-        })
-    };
+    let action = ProposalActionRequest::StopOrStartCanister(StopOrStartCanister {
+        canister_id: Some(REGISTRY_CANISTER_ID.get()),
+        action: Some(CanisterAction::Start as i32),
+    });
+
     let propose_response = nns_governance_make_proposal(
         &state_machine,
         n1.principal_id,
@@ -106,14 +83,4 @@ fn test_stop_and_start_registry_canister(use_proposal_action: bool) {
 
     // Step 6: Make sure the canister is running.
     assert_eq!(canister_status_type(), CanisterStatusType::Running);
-}
-
-#[test]
-fn stop_and_start_registry_by_action() {
-    test_stop_and_start_registry_canister(true);
-}
-
-#[test]
-fn stop_and_start_registry_by_nns_function() {
-    test_stop_and_start_registry_canister(false);
 }


### PR DESCRIPTION
# Why

The StopOrStartCanister NNS Function is replaced by Action::StopOrStartCanister which uses different topics for different canisters. The ic-admin also always use the latter. This PR makes the NNS Function obsolete.

# What

- Add `NnsFunction::StopOrStartNnsCanister` to `check_obsolete`, suggesting `Action::StopOrStartNnsCanister`
- Update integration tests