### PR TITLE
feat: EXC-2032: Add memory tracker Wasm page metrics

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/tests.rs
@@ -8,7 +8,13 @@ use super::{
         SystemApiImpl, sandbox_safe_system_state::SandboxSafeSystemState,
     },
 };
-use crate::{WasmtimeEmbedder, wasm_utils::validate_and_instrument_for_testing};
+use crate::{
+    WasmtimeEmbedder,
+    wasm_utils::validate_and_instrument_for_testing,
+    wasmtime_embedder::{
+        OS_PAGES_PER_WASM_PAGE, accessed_os_and_wasm_pages, dirty_os_and_wasm_pages,
+    },
+};
 use ic_base_types::NumSeconds;
 use ic_config::flag_status::FlagStatus;
 use ic_config::{
@@ -21,6 +27,7 @@ use ic_logger::replica_logger::no_op_logger;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::page_map::TestPageAllocatorFileDescriptorImpl;
 use ic_replicated_state::{Memory, MessageMemoryUsage, NetworkTopology, SystemState};
+use ic_sys::PageIndex;
 use ic_test_utilities::cycles_account_manager::CyclesAccountManagerBuilder;
 use ic_test_utilities_types::ids::canister_test_id;
 use ic_types::{
@@ -235,4 +242,57 @@ fn test_initial_wasmtime_config() {
             "Error expecting `{expected_err_msg}`, but got `{err_msg}`"
         );
     }
+}
+
+#[test]
+fn test_accessed_os_and_wasm_pages() {
+    let accessed: Vec<PageIndex> = vec![];
+    let (os_pages, wasm_pages) = accessed_os_and_wasm_pages(&accessed);
+    assert_eq!(os_pages, 0);
+    assert_eq!(wasm_pages, 0);
+
+    let accessed = vec![PageIndex::new(0)];
+    let (os_pages, wasm_pages) = accessed_os_and_wasm_pages(&accessed);
+    assert_eq!(os_pages, 1);
+    assert_eq!(wasm_pages, 1);
+
+    let accessed = vec![PageIndex::new(0), PageIndex::new(1)];
+    let (os_pages, wasm_pages) = accessed_os_and_wasm_pages(&accessed);
+    assert_eq!(os_pages, 2);
+    assert_eq!(wasm_pages, 1);
+
+    let accessed = vec![
+        PageIndex::new(OS_PAGES_PER_WASM_PAGE as u64),
+        PageIndex::new(0),
+    ];
+    let (os_pages, wasm_pages) = accessed_os_and_wasm_pages(&accessed);
+    assert_eq!(os_pages, 2);
+    assert_eq!(wasm_pages, 2);
+}
+
+#[test]
+fn test_dirty_os_and_wasm_pages() {
+    let speculatively_dirty: Vec<PageIndex> = vec![];
+    let dirty: Vec<PageIndex> = vec![];
+    let (os_pages, wasm_pages) = dirty_os_and_wasm_pages(&speculatively_dirty, &dirty);
+    assert_eq!(os_pages, 0);
+    assert_eq!(wasm_pages, 0);
+
+    let speculatively_dirty: Vec<PageIndex> = vec![];
+    let dirty: Vec<PageIndex> = vec![PageIndex::new(0)];
+    let (os_pages, wasm_pages) = dirty_os_and_wasm_pages(&speculatively_dirty, &dirty);
+    assert_eq!(os_pages, 1);
+    assert_eq!(wasm_pages, 1);
+
+    let speculatively_dirty: Vec<PageIndex> = vec![PageIndex::new(0)];
+    let dirty: Vec<PageIndex> = vec![PageIndex::new(1)];
+    let (os_pages, wasm_pages) = dirty_os_and_wasm_pages(&speculatively_dirty, &dirty);
+    assert_eq!(os_pages, 2);
+    assert_eq!(wasm_pages, 1);
+
+    let speculatively_dirty: Vec<PageIndex> = vec![PageIndex::new(OS_PAGES_PER_WASM_PAGE as u64)];
+    let dirty: Vec<PageIndex> = vec![PageIndex::new(0)];
+    let (os_pages, wasm_pages) = dirty_os_and_wasm_pages(&speculatively_dirty, &dirty);
+    assert_eq!(os_pages, 2);
+    assert_eq!(wasm_pages, 2);
 }

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -39,6 +39,8 @@ pub struct InstanceStats {
     pub wasm_accessed_pages: usize,
     /// Non-deterministic number of accessed OS (4 KiB) pages (read + write).
     pub wasm_accessed_os_pages_count: usize,
+    /// Non-deterministic number of accessed Wasm (64 KiB) pages (read + write).
+    pub wasm_accessed_wasm_pages_count: usize,
 
     /// Total number of (host) OS pages (4KiB) modified by the instance.
     /// By definition a page that has been dirtied has also been accessed,
@@ -46,6 +48,8 @@ pub struct InstanceStats {
     pub wasm_dirty_pages: usize,
     /// Non-deterministic number of dirty OS (4 KiB) pages (write).
     pub wasm_dirty_os_pages_count: usize,
+    /// Non-deterministic number of dirty Wasm (64 KiB) pages (write).
+    pub wasm_dirty_wasm_pages_count: usize,
 
     /// Number of times a write access is handled when the page has already been
     /// read.


### PR DESCRIPTION
This PR adds tracking of Wasm page metrics (dirty and accessed) in the memory tracker. This allows for better monitoring and analysis of memory usage patterns specific to Wasm pages.