### PR TITLE
feat: [MR-494] Use hardlink to copy files in state sync

### DIFF
--- a/rs/state_layout/src/utils.rs
+++ b/rs/state_layout/src/utils.rs
@@ -71,12 +71,3 @@ pub fn do_copy(log: &ReplicaLogger, src: &Path, dst: &Path) -> std::io::Result<(
         Ok(())
     }
 }
-
-/// Copies `src` into `dst` using do_copy semantics overwriting destination if
-/// it exists
-pub fn do_copy_overwrite(log: &ReplicaLogger, src: &Path, dst: &Path) -> std::io::Result<()> {
-    if dst.exists() {
-        std::fs::remove_file(dst)?;
-    }
-    do_copy(log, src, dst)
-}

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -122,7 +122,7 @@ const LABEL_VALUE_REUSED: &str = "reused";
 
 /// Labels for state sync metrics
 const LABEL_FETCH: &str = "fetch";
-const LABEL_COPY_FILES: &str = "copy_files";
+const LABEL_HARDLINK_FILES: &str = "hardlink_files";
 const LABEL_COPY_CHUNKS: &str = "copy_chunks";
 const LABEL_PREALLOCATE: &str = "preallocate";
 const LABEL_STATE_SYNC_MAKE_CHECKPOINT: &str = "state_sync_make_checkpoint";
@@ -551,14 +551,14 @@ impl StateSyncMetrics {
     pub fn new(metrics_registry: &MetricsRegistry) -> Self {
         let size = metrics_registry.int_counter_vec(
             "state_sync_size_bytes_total",
-            "Size of chunks synchronized by different operations ('fetch', 'copy_files', 'copy_chunks', 'preallocate') during all the state sync in bytes.",
+            "Size of chunks synchronized by different operations ('fetch', 'hardlink_files', 'copy_chunks', 'preallocate') during all the state sync in bytes.",
             &["op"],
         );
 
         // Note [Metrics preallocation]
         for op in &[
             LABEL_FETCH,
-            LABEL_COPY_FILES,
+            LABEL_HARDLINK_FILES,
             LABEL_COPY_CHUNKS,
             LABEL_PREALLOCATE,
         ] {
@@ -592,7 +592,7 @@ impl StateSyncMetrics {
 
         let step_duration = metrics_registry.histogram_vec(
             "state_sync_step_duration_seconds",
-            "Duration of state sync sub-steps in seconds indexed by step ('copy_files', 'copy_chunks', 'fetch', 'state_sync_make_checkpoint')",
+            "Duration of state sync sub-steps in seconds indexed by step ('hardlink_files', 'copy_chunks', 'fetch', 'state_sync_make_checkpoint')",
             // 0.1s, 0.2s, 0.5s, 1s, 2s, 5s, …, 1000s, 2000s, 5000s
             decimal_buckets(-1, 3),
             &["step"],
@@ -600,7 +600,7 @@ impl StateSyncMetrics {
 
         // Note [Metrics preallocation]
         for step in &[
-            LABEL_COPY_FILES,
+            LABEL_HARDLINK_FILES,
             LABEL_COPY_CHUNKS,
             LABEL_FETCH,
             LABEL_STATE_SYNC_MAKE_CHECKPOINT,
@@ -613,13 +613,13 @@ impl StateSyncMetrics {
 
         let corrupted_chunks = metrics_registry.int_counter_vec(
             "state_sync_corrupted_chunks",
-            "Number of chunks not copied/applied during state sync due to hash mismatch by source ('copy_files', 'copy_chunks', 'fetch_meta_manifest_chunk', 'fetch_manifest_chunk', 'fetch_state_chunk')",
+            "Number of chunks not copied/applied during state sync due to hash mismatch by source ('hardlink_files', 'copy_chunks', 'fetch_meta_manifest_chunk', 'fetch_manifest_chunk', 'fetch_state_chunk')",
             &["source"],
         );
 
         // Note [Metrics preallocation]
         for source in &[
-            LABEL_COPY_FILES,
+            LABEL_HARDLINK_FILES,
             LABEL_COPY_CHUNKS,
             LABEL_FETCH_META_MANIFEST_CHUNK,
             LABEL_FETCH_MANIFEST_CHUNK,

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -4117,17 +4117,14 @@ fn do_not_crash_in_loop_due_to_corrupted_state_sync() {
                 )
                 .unwrap();
 
-                // Write garbage to the canister memory file so that loading will fail.
-                let canister_layout = state_sync_scratchpad_layout
-                    .canister(&canister_test_id(90))
-                    .unwrap();
-                let canister_memory = canister_layout
-                    .vmemory_0()
-                    .existing_overlays()
-                    .unwrap()
-                    .remove(0);
-                make_mutable(&canister_memory).unwrap();
-                std::fs::write(&canister_memory, b"Garbage").unwrap();
+                // Write garbage to the system_metadata.pbuf file so that loading will fail.
+                let system_metadata = state_sync_scratchpad_layout
+                    .system_metadata()
+                    .raw_path()
+                    .to_path_buf();
+                make_mutable(&system_metadata).unwrap();
+                std::fs::write(&system_metadata, b"Garbage").unwrap();
+                make_readonly(&system_metadata).unwrap();
 
                 let result = panic::catch_unwind(AssertUnwindSafe(|| {
                     pipe_state_sync(msg, chunkable);

--- a/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
+++ b/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
@@ -21,8 +21,8 @@ pub const SUCCESSFUL_STATE_SYNC_DURATION_SECONDS_COUNT: &str =
     "state_sync_duration_seconds_count{status=\"ok\"}";
 
 pub const STATE_SYNC_SIZE_BYTES_TOTAL_FETCH: &str = "state_sync_size_bytes_total{op=\"fetch\"}";
-pub const STATE_SYNC_SIZE_BYTES_TOTAL_COPY_FILES: &str =
-    "state_sync_size_bytes_total{op=\"copy_files\"}";
+pub const STATE_SYNC_SIZE_BYTES_TOTAL_HARDLINK_FILES: &str =
+    "state_sync_size_bytes_total{op=\"hardlink_files\"}";
 pub const STATE_SYNC_SIZE_BYTES_TOTAL_COPY_CHUNKS: &str =
     "state_sync_size_bytes_total{op=\"copy_chunks\"}";
 
@@ -253,7 +253,7 @@ pub async fn assert_state_sync_has_happened(
                 rejoin_node.clone(),
                 vec![
                     STATE_SYNC_SIZE_BYTES_TOTAL_FETCH,
-                    STATE_SYNC_SIZE_BYTES_TOTAL_COPY_FILES,
+                    STATE_SYNC_SIZE_BYTES_TOTAL_HARDLINK_FILES,
                     STATE_SYNC_SIZE_BYTES_TOTAL_COPY_CHUNKS,
                 ],
             )
@@ -261,9 +261,9 @@ pub async fn assert_state_sync_has_happened(
 
             info!(
                 logger,
-                "State sync size summary, fetch: {} bytes, copy files: {} bytes, copy chunks: {} bytes",
+                "State sync size summary, fetch: {} bytes, hardlink files: {} bytes, copy chunks: {} bytes",
                 stats[STATE_SYNC_SIZE_BYTES_TOTAL_FETCH][0],
-                stats[STATE_SYNC_SIZE_BYTES_TOTAL_COPY_FILES][0],
+                stats[STATE_SYNC_SIZE_BYTES_TOTAL_HARDLINK_FILES][0],
                 stats[STATE_SYNC_SIZE_BYTES_TOTAL_COPY_CHUNKS][0],
             );
 


### PR DESCRIPTION
In state sync, unchanged files from previous checkpoints or caches should be copied into the scratchpad as efficiently as possible. Currently, this still uses reflink, while LSMT-based checkpointing already uses hardlink for read-only files. 

We should extend the same approach to state sync. Hardlinking is faster at scale (e.g., 100k canisters) and preserves OS page cache, while reflinking creates new inodes and discards OS page cache. To enable this safely, all hardlinked files must remain read-only to protect checkpoint integrity.

Experiments show that hardlink reduces duration of copying 200k files from 28s to 5s.