### PR TITLE
chore: only run rent_subnet_test in nns-tests-nightly

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -123,7 +123,7 @@ jobs:
             bazel test \
               --config=stamped \
               --test_tag_filters=nns_tests_nightly \
-              //rs/nns/... \
+              //... \
               --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -131,7 +131,7 @@ jobs:
             bazel test \
               --config=stamped \
               --test_tag_filters=nns_tests_nightly \
-              //rs/nns/... \
+              //... \
               --test_env=SSH_AUTH_SOCK --test_env=NNS_CANISTER_UPGRADE_SEQUENCE=all \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -251,6 +251,7 @@ system_test(
     },
     tags = [
         "k8s",
+        "nns_tests_nightly",  # let's only run this during nns-tests-nightly because it uses 212 vCPUs.
     ],
     runtime_deps = NNS_CANISTER_RUNTIME_DEPS + UNIVERSAL_CANISTER_RUNTIME_DEPS + [
         # Keep sorted.


### PR DESCRIPTION
The P90 duration of `//rs/tests/nns:rent_subnet_test` is over 12 minutes which is too long for PRs. Additionally it uses a lot of resources (212 vCPUs) which causes Farm to reach capacity more quickly. 

So this moves the test to run only in the `nns-tests-nightly` job.