### PR TITLE
feat: Add a canister_metadata management canister method

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
@@ -8,14 +8,15 @@ use ic_logger::{ReplicaLogger, info};
 use ic_management_canister_types_private::{
     BitcoinGetBalanceArgs, BitcoinGetBlockHeadersArgs, BitcoinGetCurrentFeePercentilesArgs,
     BitcoinGetUtxosArgs, BitcoinSendTransactionArgs, CanisterIdRecord, CanisterInfoRequest,
-    ClearChunkStoreArgs, DeleteCanisterSnapshotArgs, ECDSAPublicKeyArgs, FetchCanisterLogsRequest,
-    InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs,
-    MasterPublicKeyId, Method as Ic00Method, NodeMetricsHistoryArgs, Payload,
-    ProvisionalTopUpCanisterArgs, ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs,
-    RenameCanisterArgs, ReshareChainKeyArgs, SchnorrPublicKeyArgs, SignWithECDSAArgs,
-    SignWithSchnorrArgs, StoredChunksArgs, SubnetInfoArgs, TakeCanisterSnapshotArgs,
-    UninstallCodeArgs, UpdateSettingsArgs, UploadCanisterSnapshotDataArgs,
-    UploadCanisterSnapshotMetadataArgs, UploadChunkArgs, VetKdDeriveKeyArgs, VetKdPublicKeyArgs,
+    CanisterMetadataRequest, ClearChunkStoreArgs, DeleteCanisterSnapshotArgs, ECDSAPublicKeyArgs,
+    FetchCanisterLogsRequest, InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs,
+    LoadCanisterSnapshotArgs, MasterPublicKeyId, Method as Ic00Method, NodeMetricsHistoryArgs,
+    Payload, ProvisionalTopUpCanisterArgs, ReadCanisterSnapshotDataArgs,
+    ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs, ReshareChainKeyArgs,
+    SchnorrPublicKeyArgs, SignWithECDSAArgs, SignWithSchnorrArgs, StoredChunksArgs, SubnetInfoArgs,
+    TakeCanisterSnapshotArgs, UninstallCodeArgs, UpdateSettingsArgs,
+    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
+    VetKdDeriveKeyArgs, VetKdPublicKeyArgs,
 };
 use ic_replicated_state::NetworkTopology;
 use itertools::Itertools;
@@ -113,6 +114,11 @@ pub(super) fn resolve_destination(
             let args = CanisterInfoRequest::decode(payload)?;
             let canister_id = args.canister_id();
             route_canister_id(canister_id, Ic00Method::CanisterInfo, network_topology)
+        }
+        Ok(Ic00Method::CanisterMetadata) => {
+            let args = CanisterMetadataRequest::decode(payload)?;
+            let canister_id = args.canister_id();
+            route_canister_id(canister_id, Ic00Method::CanisterMetadata, network_topology)
         }
         Ok(Ic00Method::UninstallCode) => {
             let args = UninstallCodeArgs::decode(payload)?;

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -254,6 +254,7 @@ impl SystemStateModifications {
             Ok(Ic00Method::SignWithECDSA)
             | Ok(Ic00Method::CanisterStatus)
             | Ok(Ic00Method::CanisterInfo)
+            | Ok(Ic00Method::CanisterMetadata)
             | Ok(Ic00Method::StartCanister)
             | Ok(Ic00Method::StopCanister)
             | Ok(Ic00Method::DeleteCanister)

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -143,6 +143,7 @@ impl CanisterManager {
             Err(_)
             | Ok(Ic00Method::CreateCanister)
             | Ok(Ic00Method::CanisterInfo)
+            | Ok(Ic00Method::CanisterMetadata)
             | Ok(Ic00Method::ECDSAPublicKey)
             | Ok(Ic00Method::SetupInitialDKG)
             | Ok(Ic00Method::SignWithECDSA)

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -21,17 +21,17 @@ use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_interfaces::execution_environment::{IngressHistoryWriter, SubnetAvailableMemory};
 use ic_logger::{ReplicaLogger, error, fatal, info};
 use ic_management_canister_types_private::{
-    CanisterChangeDetails, CanisterChangeOrigin, CanisterInstallModeV2, CanisterSnapshotDataKind,
-    CanisterSnapshotDataOffset, CanisterSnapshotResponse, CanisterStatusResultV2,
-    CanisterStatusType, ChunkHash, Global, GlobalTimer, Method as Ic00Method,
-    ReadCanisterSnapshotDataResponse, ReadCanisterSnapshotMetadataResponse, SnapshotSource,
-    StoredChunksReply, UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs,
-    UploadChunkReply,
+    CanisterChangeDetails, CanisterChangeOrigin, CanisterInstallModeV2, CanisterMetadataResponse,
+    CanisterSnapshotDataKind, CanisterSnapshotDataOffset, CanisterSnapshotResponse,
+    CanisterStatusResultV2, CanisterStatusType, ChunkHash, Global, GlobalTimer,
+    Method as Ic00Method, ReadCanisterSnapshotDataResponse, ReadCanisterSnapshotMetadataResponse,
+    SnapshotSource, StoredChunksReply, UploadCanisterSnapshotDataArgs,
+    UploadCanisterSnapshotMetadataArgs, UploadChunkReply,
 };
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
 use ic_replicated_state::canister_snapshots::ValidatedSnapshotMetadata;
 use ic_replicated_state::canister_state::WASM_PAGE_SIZE_IN_BYTES;
-use ic_replicated_state::canister_state::execution_state::SandboxMemory;
+use ic_replicated_state::canister_state::execution_state::{CustomSectionType, SandboxMemory};
 use ic_replicated_state::canister_state::system_state::wasm_chunk_store::{
     CHUNK_SIZE, ChunkValidationResult, WasmChunkHash,
 };
@@ -1121,6 +1121,42 @@ impl CanisterManager {
             wasm_memory_threshold.get(),
             canister.system_state.environment_variables.clone(),
         ))
+    }
+
+    /// Gets the metadata of the canister.
+    pub(crate) fn get_canister_metadata(
+        &self,
+        sender: PrincipalId,
+        canister: &CanisterState,
+        section_name: &str,
+    ) -> Result<CanisterMetadataResponse, CanisterManagerError> {
+        let Some(execution_state) = &canister.execution_state else {
+            return Err(CanisterManagerError::CanisterMetadataNoWasmModule {
+                canister_id: canister.canister_id(),
+            });
+        };
+        let Some(custom_section) = execution_state.metadata.get_custom_section(section_name) else {
+            return Err(CanisterManagerError::CanisterMetadataSectionNotFound {
+                canister_id: canister.canister_id(),
+                section_name: section_name.to_string(),
+            });
+        };
+
+        let is_sender_controller = canister.controllers().contains(&sender);
+        let can_non_controller_read_section = match custom_section.visibility() {
+            CustomSectionType::Public => true,
+            CustomSectionType::Private => false,
+        };
+        if is_sender_controller || can_non_controller_read_section {
+            Ok(CanisterMetadataResponse::new(
+                custom_section.content().to_vec(),
+            ))
+        } else {
+            Err(CanisterManagerError::CanisterMetadataSectionNotFound {
+                canister_id: canister.canister_id(),
+                section_name: section_name.to_string(),
+            })
+        }
     }
 
     /// Permanently deletes a canister from `ReplicatedState`.

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -1130,17 +1130,18 @@ impl CanisterManager {
         canister: &CanisterState,
         section_name: &str,
     ) -> Result<CanisterMetadataResponse, CanisterManagerError> {
-        let Some(execution_state) = &canister.execution_state else {
-            return Err(CanisterManagerError::CanisterMetadataNoWasmModule {
+        let execution_state = canister.execution_state.as_ref().ok_or(
+            CanisterManagerError::CanisterMetadataNoWasmModule {
                 canister_id: canister.canister_id(),
-            });
-        };
-        let Some(custom_section) = execution_state.metadata.get_custom_section(section_name) else {
-            return Err(CanisterManagerError::CanisterMetadataSectionNotFound {
+            },
+        )?;
+        let custom_section = execution_state
+            .metadata
+            .get_custom_section(section_name)
+            .ok_or(CanisterManagerError::CanisterMetadataSectionNotFound {
                 canister_id: canister.canister_id(),
                 section_name: section_name.to_string(),
-            });
-        };
+            })?;
 
         let is_sender_controller = canister.controllers().contains(&sender);
         let can_non_controller_read_section = match custom_section.visibility() {

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -752,12 +752,12 @@ impl AsErrorHelp for CanisterManagerError {
                 doc_link: "".to_string(),
             },
             CanisterManagerError::CanisterMetadataNoWasmModule { .. } => ErrorHelp::UserError {
-                suggestion: "The canister has no Wasm module.".to_string(),
-                doc_link: "".to_string(),
+                suggestion: "If you are a controller of the canister, install a Wasm module containing a metadata section with the given name.".to_string(),
+                doc_link: "canister-metadata-no-wasm-module".to_string(),
             },
             CanisterManagerError::CanisterMetadataSectionNotFound { .. } => ErrorHelp::UserError {
                 suggestion: "The canister has no metadata section with the given name.".to_string(),
-                doc_link: "".to_string(),
+                doc_link: "canister-metadata-section-not-found".to_string(),
             },
         }
     }
@@ -1133,13 +1133,13 @@ impl From<CanisterManagerError> for UserError {
                     "Environment variable value \"{value}\" exceeds the maximum allowed length of {max_value_length}."
                 ),
             ),
-            CanisterManagerError::CanisterMetadataNoWasmModule { canister_id } => Self::new(
+            CanisterMetadataNoWasmModule { canister_id } => Self::new(
                 ErrorCode::CanisterRejectedMessage,
                 format!(
                     "The canister {canister_id} has no Wasm module and hence no metadata is available."
                 ),
             ),
-            CanisterManagerError::CanisterMetadataSectionNotFound {
+            CanisterMetadataSectionNotFound {
                 canister_id,
                 section_name,
             } => Self::new(

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -508,6 +508,13 @@ pub(crate) enum CanisterManagerError {
         value: String,
         max_value_length: usize,
     },
+    CanisterMetadataNoWasmModule {
+        canister_id: CanisterId,
+    },
+    CanisterMetadataSectionNotFound {
+        canister_id: CanisterId,
+        section_name: String,
+    },
 }
 
 impl AsErrorHelp for CanisterManagerError {
@@ -742,6 +749,14 @@ impl AsErrorHelp for CanisterManagerError {
             },
             CanisterManagerError::EnvironmentVariablesValueTooLong { .. } => ErrorHelp::UserError {
                 suggestion: "Shorten the environment variable value to fit within the allowed limit.".to_string(),
+                doc_link: "".to_string(),
+            },
+            CanisterManagerError::CanisterMetadataNoWasmModule { .. } => ErrorHelp::UserError {
+                suggestion: "The canister has no Wasm module.".to_string(),
+                doc_link: "".to_string(),
+            },
+            CanisterManagerError::CanisterMetadataSectionNotFound { .. } => ErrorHelp::UserError {
+                suggestion: "The canister has no metadata section with the given name.".to_string(),
                 doc_link: "".to_string(),
             },
         }
@@ -1116,6 +1131,21 @@ impl From<CanisterManagerError> for UserError {
                 ErrorCode::InvalidManagementPayload,
                 format!(
                     "Environment variable value \"{value}\" exceeds the maximum allowed length of {max_value_length}."
+                ),
+            ),
+            CanisterManagerError::CanisterMetadataNoWasmModule { canister_id } => Self::new(
+                ErrorCode::CanisterRejectedMessage,
+                format!(
+                    "The canister {canister_id} has no Wasm module and hence no metadata is available."
+                ),
+            ),
+            CanisterManagerError::CanisterMetadataSectionNotFound {
+                canister_id,
+                section_name,
+            } => Self::new(
+                ErrorCode::CanisterRejectedMessage,
+                format!(
+                    "The canister {canister_id} has no metadata section with the name {section_name}."
                 ),
             ),
         }

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -37,19 +37,19 @@ use ic_limits::{LOG_CANISTER_OPERATION_CYCLES_THRESHOLD, SMALL_APP_SUBNET_MAX_SI
 use ic_logger::{ReplicaLogger, error, info, warn};
 use ic_management_canister_types_private::{
     CanisterChangeOrigin, CanisterHttpRequestArgs, CanisterIdRecord, CanisterInfoRequest,
-    CanisterInfoResponse, CanisterMetadataRequest, CanisterMetadataResponse, CanisterStatusType,
-    ClearChunkStoreArgs, CreateCanisterArgs, DeleteCanisterSnapshotArgs, ECDSAPublicKeyArgs,
-    ECDSAPublicKeyResponse, EmptyBlob, FetchCanisterLogsRequest, IC_00, InstallChunkedCodeArgs,
-    InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs, MasterPublicKeyId,
-    Method as Ic00Method, NodeMetricsHistoryArgs, Payload as Ic00Payload,
-    ProvisionalCreateCanisterWithCyclesArgs, ProvisionalTopUpCanisterArgs,
-    ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs,
-    ReshareChainKeyArgs, SchnorrAlgorithm, SchnorrPublicKeyArgs, SchnorrPublicKeyResponse,
-    SetupInitialDKGArgs, SignWithECDSAArgs, SignWithSchnorrArgs, SignWithSchnorrAux,
-    StoredChunksArgs, SubnetInfoArgs, SubnetInfoResponse, TakeCanisterSnapshotArgs,
-    UninstallCodeArgs, UpdateSettingsArgs, UploadCanisterSnapshotDataArgs,
-    UploadCanisterSnapshotMetadataArgs, UploadCanisterSnapshotMetadataResponse, UploadChunkArgs,
-    VetKdDeriveKeyArgs, VetKdPublicKeyArgs, VetKdPublicKeyResult,
+    CanisterInfoResponse, CanisterMetadataRequest, CanisterStatusType, ClearChunkStoreArgs,
+    CreateCanisterArgs, DeleteCanisterSnapshotArgs, ECDSAPublicKeyArgs, ECDSAPublicKeyResponse,
+    EmptyBlob, FetchCanisterLogsRequest, IC_00, InstallChunkedCodeArgs, InstallCodeArgsV2,
+    ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs, MasterPublicKeyId, Method as Ic00Method,
+    NodeMetricsHistoryArgs, Payload as Ic00Payload, ProvisionalCreateCanisterWithCyclesArgs,
+    ProvisionalTopUpCanisterArgs, ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs,
+    RenameCanisterArgs, ReshareChainKeyArgs, SchnorrAlgorithm, SchnorrPublicKeyArgs,
+    SchnorrPublicKeyResponse, SetupInitialDKGArgs, SignWithECDSAArgs, SignWithSchnorrArgs,
+    SignWithSchnorrAux, StoredChunksArgs, SubnetInfoArgs, SubnetInfoResponse,
+    TakeCanisterSnapshotArgs, UninstallCodeArgs, UpdateSettingsArgs,
+    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs,
+    UploadCanisterSnapshotMetadataResponse, UploadChunkArgs, VetKdDeriveKeyArgs,
+    VetKdPublicKeyArgs, VetKdPublicKeyResult,
 };
 use ic_metrics::MetricsRegistry;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -58,7 +58,6 @@ use ic_replicated_state::{
     CanisterState, ExecutionTask, NetworkTopology, ReplicatedState,
     canister_state::{
         NextExecution,
-        execution_state::CustomSectionType,
         system_state::{CyclesUseCase, PausedExecutionId},
     },
     metadata_state::subnet_call_context_manager::{
@@ -934,8 +933,13 @@ impl ExecutionEnvironment {
             Ok(Ic00Method::CanisterMetadata) => match &msg {
                 CanisterCall::Request(_) => {
                     let res = CanisterMetadataRequest::decode(payload).and_then(|record| {
-                        self.get_canister_metadata(record.canister_id(), record.name(), &state)
-                            .map(|res| (res, Some(record.canister_id())))
+                        self.get_canister_metadata(
+                            *msg.sender(),
+                            record.canister_id(),
+                            &state,
+                            record.name(),
+                        )
+                        .map(|res| (res, Some(record.canister_id())))
                     });
                     ExecuteSubnetMessageResult::Finished {
                         response: res,
@@ -2334,35 +2338,16 @@ impl ExecutionEnvironment {
 
     fn get_canister_metadata(
         &self,
+        sender: PrincipalId,
         canister_id: CanisterId,
-        name: &str,
         state: &ReplicatedState,
+        name: &str,
     ) -> Result<Vec<u8>, UserError> {
         let canister = get_canister(canister_id, state)?;
-        let Some(execution_state) = &canister.execution_state else {
-            return Err(UserError::new(
-                ErrorCode::CanisterRejectedMessage,
-                "Canister has no execution state",
-            ));
-        };
-        let Some(custom_section) = execution_state.metadata.get_custom_section(name) else {
-            return Err(UserError::new(
-                ErrorCode::CanisterRejectedMessage,
-                format!("Metadata section '{}' not found", name),
-            ));
-        };
-        match custom_section.visibility() {
-            // Only allow public metadata sections to be read.
-            CustomSectionType::Public => {}
-            CustomSectionType::Private => {
-                return Err(UserError::new(
-                    ErrorCode::CanisterRejectedMessage,
-                    format!("Metadata section '{}' is private", name),
-                ));
-            }
-        };
-        let res = CanisterMetadataResponse::new(custom_section.content().to_vec());
-        Ok(res.encode())
+        self.canister_manager
+            .get_canister_metadata(sender, canister, name)
+            .map(|res| res.encode())
+            .map_err(|err| err.into())
     }
 
     fn stop_canister(

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -1109,7 +1109,7 @@ fn get_canister_metadata_no_execution_state_fails() {
     let caller = test.universal_canister().unwrap();
 
     let canister_metadata_args =
-        CanisterMetadataRequest::new(canister, "my_private_section".to_string()).encode();
+        CanisterMetadataRequest::new(canister, "my_public_section".to_string()).encode();
     let get_canister_metadata = wasm()
         .call_simple(
             ic00::IC_00,

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -1086,11 +1086,8 @@ fn get_canister_metadata_success() {
     let canister = test.canister_from_wat(CUSTOM_SECTIONS_WAT).unwrap();
     let caller = test.universal_canister().unwrap();
 
-    let canister_metadata_args = Encode!(&CanisterMetadataRequest::new(
-        canister,
-        "my_public_section".to_string()
-    ))
-    .unwrap();
+    let canister_metadata_args =
+        CanisterMetadataRequest::new(canister, "my_public_section".to_string()).encode();
     let get_canister_metadata = wasm()
         .call_simple(
             ic00::IC_00,
@@ -1106,37 +1103,13 @@ fn get_canister_metadata_success() {
 }
 
 #[test]
-fn get_canister_metadata_ingress_fails() {
-    let mut test = ExecutionTestBuilder::new().build();
-    let canister = test.canister_from_wat(CUSTOM_SECTIONS_WAT).unwrap();
-
-    let canister_metadata_args = Encode!(&CanisterMetadataRequest::new(
-        canister,
-        "my_public_section".to_string()
-    ))
-    .unwrap();
-    let result = test.subnet_message(Method::CanisterMetadata, canister_metadata_args);
-
-    assert_eq!(
-        result,
-        Err(UserError::new(
-            ErrorCode::CanisterContractViolation,
-            "canister_metadata cannot be called by a user."
-        ))
-    );
-}
-
-#[test]
 fn get_canister_metadata_no_execution_state_fails() {
     let mut test = ExecutionTestBuilder::new().build();
     let canister = test.empty_canister();
     let caller = test.universal_canister().unwrap();
 
-    let canister_metadata_args = Encode!(&CanisterMetadataRequest::new(
-        canister,
-        "my_private_section".to_string()
-    ))
-    .unwrap();
+    let canister_metadata_args =
+        CanisterMetadataRequest::new(canister, "my_private_section".to_string()).encode();
     let get_canister_metadata = wasm()
         .call_simple(
             ic00::IC_00,
@@ -1158,11 +1131,8 @@ fn get_canister_metadata_not_found_fails() {
     let canister = test.canister_from_wat(CUSTOM_SECTIONS_WAT).unwrap();
     let caller = test.universal_canister().unwrap();
 
-    let canister_metadata_args = Encode!(&CanisterMetadataRequest::new(
-        canister,
-        "my_not_found_section".to_string()
-    ))
-    .unwrap();
+    let canister_metadata_args =
+        CanisterMetadataRequest::new(canister, "my_not_found_section".to_string()).encode();
     let get_canister_metadata = wasm()
         .call_simple(
             ic00::IC_00,
@@ -1184,11 +1154,8 @@ fn get_canister_metadata_private_section_fails() {
     let canister = test.canister_from_wat(CUSTOM_SECTIONS_WAT).unwrap();
     let caller = test.universal_canister().unwrap();
 
-    let canister_metadata_args = Encode!(&CanisterMetadataRequest::new(
-        canister,
-        "my_private_section".to_string()
-    ))
-    .unwrap();
+    let canister_metadata_args =
+        CanisterMetadataRequest::new(canister, "my_private_section".to_string()).encode();
     let get_canister_metadata = wasm()
         .call_simple(
             ic00::IC_00,

--- a/rs/execution_environment/src/execution_environment_metrics.rs
+++ b/rs/execution_environment/src/execution_environment_metrics.rs
@@ -283,6 +283,7 @@ impl ExecutionEnvironmentMetrics {
                 let speed_label = match method_name {
                     ic00::Method::CanisterStatus
                     | ic00::Method::CanisterInfo
+                    | ic00::Method::CanisterMetadata
                     | ic00::Method::CreateCanister
                     | ic00::Method::DeleteCanister
                     | ic00::Method::DepositCycles

--- a/rs/execution_environment/src/ic00_permissions.rs
+++ b/rs/execution_environment/src/ic00_permissions.rs
@@ -26,6 +26,7 @@ impl Ic00MethodPermissions {
         match method {
             Ic00Method::CanisterStatus
             | Ic00Method::CanisterInfo
+            | Ic00Method::CanisterMetadata
             | Ic00Method::DepositCycles
             | Ic00Method::ECDSAPublicKey
             | Ic00Method::SignWithECDSA

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -2265,6 +2265,7 @@ fn get_instructions_limits_for_subnet_message(
         Ok(method) => match method {
             CanisterStatus
             | CanisterInfo
+            | CanisterMetadata
             | CreateCanister
             | DeleteCanister
             | DepositCycles

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -1128,7 +1128,8 @@ fn dts_aborted_execution_does_not_block_subnet_messages() {
             }),
             Method::CanisterMetadata => test_supported(|aborted_canister_id| {
                 let args =
-                    CanisterMetadataRequest::new(aborted_canister_id, "test".to_string()).encode();
+                    CanisterMetadataRequest::new(aborted_canister_id, "git_commit_id".to_string())
+                        .encode();
                 (method, call_args().other_side(args))
             }),
             // No effective canister id.

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -1128,6 +1128,8 @@ fn dts_aborted_execution_does_not_block_subnet_messages() {
             }),
             Method::CanisterMetadata => test_supported(|aborted_canister_id| {
                 let args =
+                    // The "git_commit_id" is one of the metadata sections in the universal canister
+                    // wasm (for any canister wasm built in the monorepo).
                     CanisterMetadataRequest::new(aborted_canister_id, "git_commit_id".to_string())
                         .encode();
                 (method, call_args().other_side(args))

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -13,13 +13,13 @@ use ic_cycles_account_manager::IngressInductionCost;
 use ic_error_types::UserError;
 use ic_management_canister_types_private::{
     CanisterIdRecord, CanisterInfoRequest, CanisterInstallMode, CanisterInstallModeV2,
-    CanisterSettingsArgsBuilder, CanisterSnapshotDataKind, CanisterSnapshotDataOffset,
-    ClearChunkStoreArgs, DeleteCanisterSnapshotArgs, EmptyBlob, GlobalTimer, IC_00,
-    InstallChunkedCodeArgs, InstallCodeArgs, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs,
-    Method, OnLowWasmMemoryHookStatus, Payload, ReadCanisterSnapshotDataArgs,
-    ReadCanisterSnapshotMetadataArgs, StoredChunksArgs, TakeCanisterSnapshotArgs,
-    UninstallCodeArgs, UpdateSettingsArgs, UploadCanisterSnapshotDataArgs,
-    UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
+    CanisterMetadataRequest, CanisterSettingsArgsBuilder, CanisterSnapshotDataKind,
+    CanisterSnapshotDataOffset, ClearChunkStoreArgs, DeleteCanisterSnapshotArgs, EmptyBlob,
+    GlobalTimer, IC_00, InstallChunkedCodeArgs, InstallCodeArgs, ListCanisterSnapshotArgs,
+    LoadCanisterSnapshotArgs, Method, OnLowWasmMemoryHookStatus, Payload,
+    ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs, StoredChunksArgs,
+    TakeCanisterSnapshotArgs, UninstallCodeArgs, UpdateSettingsArgs,
+    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
 };
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::{NextExecution, execution_state::NextScheduledMethod};
@@ -1124,6 +1124,11 @@ fn dts_aborted_execution_does_not_block_subnet_messages() {
             }
             Method::CanisterInfo => test_supported(|aborted_canister_id| {
                 let args = CanisterInfoRequest::new(aborted_canister_id, None).encode();
+                (method, call_args().other_side(args))
+            }),
+            Method::CanisterMetadata => test_supported(|aborted_canister_id| {
+                let args =
+                    CanisterMetadataRequest::new(aborted_canister_id, "test".to_string()).encode();
                 (method, call_args().other_side(args))
             }),
             // No effective canister id.

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -8,10 +8,10 @@ use ic_config::{
 };
 use ic_embedders::wasmtime_embedder::system_api::MAX_CALL_TIMEOUT_SECONDS;
 use ic_management_canister_types_private::{
-    CanisterIdRecord, CanisterSettingsArgs, CanisterSettingsArgsBuilder, CanisterStatusResultV2,
-    CreateCanisterArgs, DerivationPath, EcdsaKeyId, EmptyBlob, IC_00, LoadCanisterSnapshotArgs,
-    MasterPublicKeyId, Method, Payload, SignWithECDSAArgs, TakeCanisterSnapshotArgs,
-    UpdateSettingsArgs,
+    CanisterIdRecord, CanisterMetadataRequest, CanisterMetadataResponse, CanisterSettingsArgs,
+    CanisterSettingsArgsBuilder, CanisterStatusResultV2, CreateCanisterArgs, DerivationPath,
+    EcdsaKeyId, EmptyBlob, IC_00, LoadCanisterSnapshotArgs, MasterPublicKeyId, Method, Payload,
+    SignWithECDSAArgs, TakeCanisterSnapshotArgs, UpdateSettingsArgs,
 };
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::NumWasmPages;
@@ -3019,4 +3019,50 @@ fn large_ipc_call_fails() {
         for single message execution."
     );
     err.assert_contains(ErrorCode::CanisterInstructionLimitExceeded, &expected_error);
+}
+
+#[test]
+fn get_canister_metadata() {
+    let env = StateMachine::new();
+    let canister_with_metadata = env.install_canister_wat(
+        r#"(module
+(memory $memory 1)
+(export "memory" (memory $memory))
+(@custom "icp:public my_public_section" "my_public_section_value")
+)"#,
+        vec![],
+        None,
+    );
+    let universal_canister =
+        create_universal_canister_with_cycles(&env, None, INITIAL_CYCLES_BALANCE);
+    let canister_metadata_args =
+        CanisterMetadataRequest::new(canister_with_metadata, "my_public_section".to_string())
+            .encode();
+
+    // Call the canister metadata method through an inter-canister call should succeed.
+    let get_canister_metadata = wasm()
+        .call_simple(
+            IC_00,
+            Method::CanisterMetadata,
+            call_args().other_side(canister_metadata_args.clone()),
+        )
+        .build();
+    let res = env
+        .execute_ingress(universal_canister, "update", get_canister_metadata)
+        .unwrap();
+    let reply = match res {
+        WasmResult::Reply(blob) => blob,
+        WasmResult::Reject(msg) => panic!("Unexpected reject: {msg}"),
+    };
+    let response = CanisterMetadataResponse::decode(&reply).unwrap();
+    assert_eq!(response.value(), b"my_public_section_value");
+
+    // Call the canister metadata method through an ingress message should fail.
+    let err = env
+        .execute_ingress(IC_00, Method::CanisterMetadata, canister_metadata_args)
+        .unwrap_err();
+    err.assert_contains(
+        ErrorCode::CanisterRejectedMessage,
+        "Only canisters can call ic00 method canister_metadata",
+    );
 }

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1031,7 +1031,7 @@ impl ExecutionTest {
         self.canister_from_cycles_and_wat(self.initial_canister_cycles, wat)
     }
 
-    pub fn empty_canister(&mut self) -> CanisterId {
+    pub fn create_canister_with_default_cycles(&mut self) -> CanisterId {
         self.create_canister(self.initial_canister_cycles)
     }
 

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1031,6 +1031,10 @@ impl ExecutionTest {
         self.canister_from_cycles_and_wat(self.initial_canister_cycles, wat)
     }
 
+    pub fn empty_canister(&mut self) -> CanisterId {
+        self.create_canister(self.initial_canister_cycles)
+    }
+
     /// Creates and installs a universal canister.
     pub fn universal_canister(&mut self) -> Result<CanisterId, UserError> {
         self.canister_from_binary(UNIVERSAL_CANISTER_WASM.to_vec())

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -759,6 +759,7 @@ impl Payload<'_> for CanisterMetadataRequest {}
 /// ```
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct CanisterMetadataResponse {
+    #[serde(with = "serde_bytes")]
     value: Vec<u8>,
 }
 

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -71,6 +71,7 @@ fn decoder_config() -> DecoderConfig {
 pub enum Method {
     CanisterStatus,
     CanisterInfo,
+    CanisterMetadata,
     CreateCanister,
     DeleteCanister,
     DepositCycles,
@@ -717,6 +718,61 @@ impl CanisterInfoResponse {
 }
 
 impl Payload<'_> for CanisterInfoResponse {}
+
+/// `CandidType` for `CanisterMetadataRequest`
+/// ```text
+/// record {
+///   canister_id : principal;
+///   name : text;
+/// }
+/// ```
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub struct CanisterMetadataRequest {
+    canister_id: PrincipalId,
+    name: String,
+}
+
+impl CanisterMetadataRequest {
+    pub fn new(canister_id: CanisterId, name: String) -> CanisterMetadataRequest {
+        CanisterMetadataRequest {
+            canister_id: canister_id.into(),
+            name,
+        }
+    }
+
+    pub fn canister_id(&self) -> CanisterId {
+        CanisterId::unchecked_from_principal(self.canister_id)
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Payload<'_> for CanisterMetadataRequest {}
+
+/// `CandidType` for `CanisterMetadataResponse`
+/// ```text
+/// record {
+///   value : blob;
+/// }
+/// ```
+#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
+pub struct CanisterMetadataResponse {
+    value: Vec<u8>,
+}
+
+impl CanisterMetadataResponse {
+    pub fn new(value: Vec<u8>) -> Self {
+        Self { value }
+    }
+
+    pub fn value(&self) -> &[u8] {
+        &self.value
+    }
+}
+
+impl Payload<'_> for CanisterMetadataResponse {}
 
 impl From<&CanisterChangeOrigin> for pb_canister_state_bits::canister_change::ChangeOrigin {
     fn from(item: &CanisterChangeOrigin) -> Self {

--- a/rs/types/management_canister_types/tests/candid_equality.rs
+++ b/rs/types/management_canister_types/tests/candid_equality.rs
@@ -13,6 +13,8 @@ type CanisterStatusArgs = CanisterIdRecord;
 type CanisterStatusResult = CanisterStatusResultV2;
 type CanisterInfoArgs = CanisterInfoRequest;
 type CanisterInfoResult = CanisterInfoResponse;
+type CanisterMetadataArgs = CanisterMetadataRequest;
+type CanisterMetadataResult = CanisterMetadataResponse;
 type SubnetInfoResult = SubnetInfoResponse;
 type DeleteCanisterArgs = CanisterIdRecord;
 type DepositCyclesArgs = CanisterIdRecord;
@@ -90,6 +92,11 @@ fn canister_status(_: CanisterStatusArgs) -> CanisterStatusResult {
 
 #[candid_method(update)]
 fn canister_info(_: CanisterInfoArgs) -> CanisterInfoResult {
+    unreachable!()
+}
+
+#[candid_method(update)]
+fn canister_metadata(_: CanisterMetadataArgs) -> CanisterMetadataResult {
     unreachable!()
 }
 

--- a/rs/types/management_canister_types/tests/ic.did
+++ b/rs/types/management_canister_types/tests/ic.did
@@ -320,6 +320,15 @@ type canister_info_result = record {
     controllers : vec principal;
 };
 
+type canister_metadata_args = record {
+    canister_id : canister_id;
+    name : text;
+};
+
+type canister_metadata_result = record {
+    value : blob;
+};
+
 type delete_canister_args = record {
     canister_id : canister_id;
 };
@@ -630,6 +639,7 @@ service ic : {
     stop_canister : (stop_canister_args) -> ();
     canister_status : (canister_status_args) -> (canister_status_result);
     canister_info : (canister_info_args) -> (canister_info_result);
+    canister_metadata : (canister_metadata_args) -> (canister_metadata_result);
     delete_canister : (delete_canister_args) -> ();
     deposit_cycles : (deposit_cycles_args) -> ();
     raw_rand : () -> (raw_rand_result);

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -12,11 +12,12 @@ use crate::{
 };
 use ic_error_types::{ErrorCode, UserError};
 use ic_management_canister_types_private::{
-    CanisterIdRecord, CanisterInfoRequest, ClearChunkStoreArgs, DeleteCanisterSnapshotArgs, IC_00,
-    InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs,
-    Method, Payload, ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs,
-    RenameCanisterArgs, StoredChunksArgs, TakeCanisterSnapshotArgs, UpdateSettingsArgs,
-    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
+    CanisterIdRecord, CanisterInfoRequest, CanisterMetadataRequest, ClearChunkStoreArgs,
+    DeleteCanisterSnapshotArgs, IC_00, InstallChunkedCodeArgs, InstallCodeArgsV2,
+    ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs, Method, Payload,
+    ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs,
+    StoredChunksArgs, TakeCanisterSnapshotArgs, UpdateSettingsArgs, UploadCanisterSnapshotDataArgs,
+    UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
 };
 use ic_protobuf::{
     log::ingress_message_log_entry::v1::IngressMessageLogEntry,
@@ -498,6 +499,10 @@ pub fn extract_effective_canister_id(
             Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
         },
         Ok(Method::CanisterInfo) => match CanisterInfoRequest::decode(ingress.arg()) {
+            Ok(record) => Ok(Some(record.canister_id())),
+            Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
+        },
+        Ok(Method::CanisterMetadata) => match CanisterMetadataRequest::decode(ingress.arg()) {
             Ok(record) => Ok(Some(record.canister_id())),
             Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
         },

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -7,12 +7,12 @@ use ic_error_types::{RejectCode, UserError};
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;
 use ic_management_canister_types_private::{
-    CanisterIdRecord, CanisterInfoRequest, ClearChunkStoreArgs, DeleteCanisterSnapshotArgs,
-    FetchCanisterLogsRequest, InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs,
-    LoadCanisterSnapshotArgs, Method, Payload as _, ProvisionalTopUpCanisterArgs,
-    ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs,
-    StoredChunksArgs, TakeCanisterSnapshotArgs, UpdateSettingsArgs, UploadCanisterSnapshotDataArgs,
-    UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
+    CanisterIdRecord, CanisterInfoRequest, CanisterMetadataRequest, ClearChunkStoreArgs,
+    DeleteCanisterSnapshotArgs, FetchCanisterLogsRequest, InstallChunkedCodeArgs,
+    InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs, Method, Payload as _,
+    ProvisionalTopUpCanisterArgs, ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs,
+    RenameCanisterArgs, StoredChunksArgs, TakeCanisterSnapshotArgs, UpdateSettingsArgs,
+    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
 };
 use ic_protobuf::{
     proxy::{ProxyDecodeError, try_from_option_field},
@@ -162,6 +162,12 @@ impl Request {
                 Ok(record) => Some(record.canister_id()),
                 Err(_) => None,
             },
+            Ok(Method::CanisterMetadata) => {
+                match CanisterMetadataRequest::decode(&self.method_payload) {
+                    Ok(record) => Some(record.canister_id()),
+                    Err(_) => None,
+                }
+            }
             Ok(Method::UpdateSettings) => match UpdateSettingsArgs::decode(&self.method_payload) {
                 Ok(record) => Some(record.get_canister_id()),
                 Err(_) => None,


### PR DESCRIPTION
Add a management canister endpoint `canister_metadata` ([spec](https://github.com/dfinity/portal/pull/6069))