### PR TITLE
chore(PocketIC): set OS limits at very start of main

### DIFF
--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -129,7 +129,6 @@ fn main() {
 
     // Set RUST_MIN_STACK if not yet set:
     // the value of 8192000 is set according to `ic-os/components/ic/ic-replica.service`.
-    // TODO: Audit that the environment access only happens in single-threaded code.
     unsafe { std::env::set_var("RUST_MIN_STACK", "8192000") };
 
     // Set the maximum number of open files:


### PR DESCRIPTION
This PR sets OS limits (stack size, max number of open files) at the very start of PocketIC server's main function. This is because such changes should be performed before multiple threads are spawned.