### PR TITLE
chore: reduce resources of rent_subnet_test

### DIFF
--- a/rs/tests/nns/BUILD.bazel
+++ b/rs/tests/nns/BUILD.bazel
@@ -251,7 +251,7 @@ system_test(
     },
     tags = [
         "k8s",
-        "nns_tests_nightly",  # let's only run this during nns-tests-nightly because it uses 212 vCPUs.
+        "long_test",  # The test takes over 10 minutes so let's not run it on PRs by default.
     ],
     runtime_deps = NNS_CANISTER_RUNTIME_DEPS + UNIVERSAL_CANISTER_RUNTIME_DEPS + [
         # Keep sorted.


### PR DESCRIPTION
Reduce the resources of the `//rs/tests/nns:rent_subnet_test` such that it uses a total of 52 instead of 212 vCPUs which means we can run it on pushes to master again (`long_test`) instead of only daily (`nns_tests_nightly`).