### PR TITLE
refactor(ICP_Rosetta): FI-1814: Clean up ICP Rosetta system test dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12981,7 +12981,6 @@ dependencies = [
  "ic-nns-governance-api",
  "ic-nns-governance-init",
  "ic-nns-handler-root",
- "ic-nns-test-utils",
  "ic-rosetta-test-utils",
  "ic-sys",
  "ic-types",

--- a/rs/rosetta-api/icp/BUILD.bazel
+++ b/rs/rosetta-api/icp/BUILD.bazel
@@ -75,7 +75,6 @@ DEV_DEPENDENCIES = [
     "//rs/ledger_suite/icrc1/tokens_u256",
     "//rs/nns/governance/init",
     "//rs/nns/handlers/root/impl:root",
-    "//rs/nns/test_utils",
     "//rs/registry/canister",
     "//rs/rosetta-api/icp:rosetta-api",
     "//rs/rosetta-api/icp/client:ic-icp-rosetta-client",

--- a/rs/rosetta-api/icp/Cargo.toml
+++ b/rs/rosetta-api/icp/Cargo.toml
@@ -74,7 +74,6 @@ icrc-ledger-agent = { path = "../../../packages/icrc-ledger-agent" }
 num-traits = { workspace = true }
 ic-icrc1 = { path = "../../ledger_suite/icrc1" }
 ic-icrc1-tokens-u256 = { path = "../../ledger_suite/icrc1/tokens_u256" }
-ic-nns-test-utils = { path = "../../nns/test_utils" }
 ic-nns-governance-init = { path = "../../nns/governance/init" }
 ic-nns-handler-root = { path = "../../nns/handlers/root/impl" }
 prost = { workspace = true }

--- a/rs/rosetta-api/icp/tests/system_tests/common/system_test_environment.rs
+++ b/rs/rosetta-api/icp/tests/system_tests/common/system_test_environment.rs
@@ -25,10 +25,6 @@ use ic_nns_constants::REGISTRY_CANISTER_ID;
 use ic_nns_constants::ROOT_CANISTER_ID;
 use ic_nns_governance_init::GovernanceCanisterInitPayloadBuilder;
 use ic_nns_handler_root::init::RootCanisterInitPayloadBuilder;
-use ic_nns_test_utils::common::build_governance_wasm;
-use ic_nns_test_utils::common::build_lifeline_wasm;
-use ic_nns_test_utils::common::build_registry_wasm;
-use ic_nns_test_utils::common::build_root_wasm;
 use ic_rosetta_test_utils::path_from_env;
 use ic_types::PrincipalId;
 use icp_ledger::{AccountIdentifier, LedgerCanisterInitPayload};
@@ -289,7 +285,9 @@ impl RosettaTestingEnvironmentBuilder {
             );
         }
         if self.governance_canister {
-            let nns_root_canister_wasm = build_root_wasm();
+            let nns_root_canister_wasm_bytes =
+                std::fs::read(std::env::var("ROOT_CANISTER_WASM_PATH").unwrap())
+                    .expect("Could not read root canister wasm");
             let nns_root_canister_id = Principal::from(ROOT_CANISTER_ID);
             let nns_root_canister_controller = LIFELINE_CANISTER_ID.get().0;
             let nns_root_canister = pocket_ic
@@ -307,7 +305,7 @@ impl RosettaTestingEnvironmentBuilder {
             pocket_ic
                 .install_canister(
                     nns_root_canister,
-                    nns_root_canister_wasm.bytes().to_vec(),
+                    nns_root_canister_wasm_bytes,
                     Encode!(&RootCanisterInitPayloadBuilder::new().build()).unwrap(),
                     Some(nns_root_canister_controller),
                 )
@@ -315,7 +313,9 @@ impl RosettaTestingEnvironmentBuilder {
             pocket_ic
                 .add_cycles(nns_root_canister_id, STARTING_CYCLES_PER_CANISTER)
                 .await;
-            let governance_canister_wasm = build_governance_wasm();
+            let governance_canister_wasm_bytes =
+                std::fs::read(std::env::var("GOVERNANCE_CANISTER_WASM_PATH").unwrap())
+                    .expect("Could not read governance canister wasm");
             let governance_canister_id = Principal::from(GOVERNANCE_CANISTER_ID);
             let governance_canister_controller = ROOT_CANISTER_ID.get().0;
             let governance_canister = pocket_ic
@@ -346,7 +346,7 @@ impl RosettaTestingEnvironmentBuilder {
             pocket_ic
                 .install_canister(
                     governance_canister,
-                    governance_canister_wasm.bytes().to_vec(),
+                    governance_canister_wasm_bytes,
                     Encode!(&install_arg).unwrap(),
                     Some(governance_canister_controller),
                 )
@@ -363,7 +363,9 @@ impl RosettaTestingEnvironmentBuilder {
                 .await;
             pocket_ic.tick().await;
 
-            let nns_lifeline_canister_wasm = build_lifeline_wasm();
+            let nns_lifeline_canister_wasm_bytes =
+                std::fs::read(std::env::var("LIFELINE_CANISTER_WASM_PATH").unwrap())
+                    .expect("Could not read lifeline canister wasm");
             let nns_lifeline_canister_id = Principal::from(LIFELINE_CANISTER_ID);
             let nns_lifeline_canister_controller = ROOT_CANISTER_ID.get().0;
             let nns_lifeline_canister = pocket_ic
@@ -381,7 +383,7 @@ impl RosettaTestingEnvironmentBuilder {
             pocket_ic
                 .install_canister(
                     nns_lifeline_canister,
-                    nns_lifeline_canister_wasm.bytes().to_vec(),
+                    nns_lifeline_canister_wasm_bytes,
                     Encode!(&LifelineCanisterInitPayloadBuilder::new().build()).unwrap(),
                     Some(nns_lifeline_canister_controller),
                 )
@@ -390,7 +392,9 @@ impl RosettaTestingEnvironmentBuilder {
                 .add_cycles(nns_lifeline_canister_id, STARTING_CYCLES_PER_CANISTER)
                 .await;
 
-            let nns_registry_canister_wasm = build_registry_wasm();
+            let nns_registry_canister_wasm_bytes =
+                std::fs::read(std::env::var("REGISTRY_CANISTER_WASM_PATH").unwrap())
+                    .expect("Could not read registry canister wasm");
             let nns_registry_canister_id = Principal::from(REGISTRY_CANISTER_ID);
             let nns_registry_canister_controller = ROOT_CANISTER_ID.get().0;
             let nns_registry_canister = pocket_ic
@@ -408,7 +412,7 @@ impl RosettaTestingEnvironmentBuilder {
             pocket_ic
                 .install_canister(
                     nns_registry_canister,
-                    nns_registry_canister_wasm.bytes().to_vec(),
+                    nns_registry_canister_wasm_bytes,
                     Encode!(&RegistryCanisterInitPayloadBuilder::new().build()).unwrap(),
                     Some(nns_registry_canister_controller),
                 )


### PR DESCRIPTION
Remove the ICP Rosetta system test dependency on `ic-nns-test-utils`, which in turn removes the transitive dependency on `ic-state-machine-tests`.