### PR TITLE
fix(PocketIC): use Vampire/setup-wsl

### DIFF
--- a/.github/workflows/pocket-ic-tests-windows.yml
+++ b/.github/workflows/pocket-ic-tests-windows.yml
@@ -2,6 +2,7 @@ name: PocketIC Windows
 on:
   pull_request:
     paths:
+      - .github/workflows/pocket-ic-tests-windows.yml
       - packages/pocket-ic/**
       - rs/pocket_ic_server/**
   schedule:

--- a/.github/workflows/pocket-ic-tests-windows.yml
+++ b/.github/workflows/pocket-ic-tests-windows.yml
@@ -81,9 +81,10 @@ jobs:
         with:
           name: pocket-ic-test-canister
       - name: Setup WSLv2
-        uses: vedantmgoyal9/setup-wsl2@bf0f19100f71267dd1345180b8a678864793e53f
+        uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278
         with:
-          distro: Ubuntu-24.04
+          distribution: Ubuntu-24.04
+          wsl-version: 2
       - name: Tests
         run: |
           $env:WORKDIR=(Get-Location).Path


### PR DESCRIPTION
The GitHub action `vedantmgoyal9/setup-wsl2` has been dropped and thus this PR switches to `Vampire/setup-wsl`.