### PR TITLE
chore(p2p): Add metrics for the number of concurrent incoming/outgoing QUIC streams

### DIFF
--- a/rs/p2p/quic_transport/src/lib.rs
+++ b/rs/p2p/quic_transport/src/lib.rs
@@ -49,6 +49,7 @@ use ic_interfaces_registry::RegistryClient;
 use ic_logger::{ReplicaLogger, info};
 use ic_metrics::MetricsRegistry;
 use phantom_newtype::AmountOf;
+use prometheus::IntGauge;
 use quinn::{
     AsyncUdpSocket, ClosedStream, ConnectError, ConnectionError, ReadToEndError, SendStream,
     StoppedError, VarInt, WriteError,
@@ -196,18 +197,27 @@ const QUIC_STREAM_CANCELLED: VarInt = VarInt::from_u32(0x80000006);
 /// This struct overrides that behavior by sending a reset frame instead, signaling
 /// that the message transmission was canceled. This approach helps optimize bandwidth
 /// usage in scenarios involving message cancellation.
+/// Additionally, keep track of the number of ongoing streams in the given metric.
 struct ResetStreamOnDrop {
     send_stream: SendStream,
+    ongoing_streams: IntGauge,
 }
 
 impl ResetStreamOnDrop {
-    fn new(send_stream: SendStream) -> Self {
-        Self { send_stream }
+    fn new(send_stream: SendStream, ongoing_streams: IntGauge) -> Self {
+        // Increment the metric when a new stream is created.
+        ongoing_streams.inc();
+        Self {
+            send_stream,
+            ongoing_streams,
+        }
     }
 }
 
 impl Drop for ResetStreamOnDrop {
     fn drop(&mut self) {
+        // Decrement the metric when the stream is dropped.
+        self.ongoing_streams.dec();
         // fails silently if the stream is already closed.
         let _ = self.send_stream.reset(QUIC_STREAM_CANCELLED);
     }

--- a/rs/p2p/quic_transport/src/metrics.rs
+++ b/rs/p2p/quic_transport/src/metrics.rs
@@ -52,6 +52,8 @@ pub struct QuicTransportMetrics {
     pub connection_handle_bytes_sent_total: IntCounterVec,
     pub connection_handle_duration_seconds: HistogramVec,
     pub connection_handle_errors_total: IntCounterVec,
+    pub connection_handle_outgoing_streams_total: IntGauge,
+    pub connection_handle_incoming_streams_total: IntGauge,
     // Quinn
     quinn_path_rtt_seconds: GaugeVec,
     quinn_path_congestion_window: IntGaugeVec,
@@ -155,6 +157,14 @@ impl QuicTransportMetrics {
                 "quic_transport_connection_handle_errors_total",
                 "Request handler errors by stream type and error type.",
                 &[QUINN_API_LABEL, ERROR_TYPE_LABEL],
+            ),
+            connection_handle_incoming_streams_total: metrics_registry.int_gauge(
+                "quic_transport_connection_handle_incoming_streams_total",
+                "The number of concurrent incoming streams accross all connections.",
+            ),
+            connection_handle_outgoing_streams_total: metrics_registry.int_gauge(
+                "quic_transport_connection_handle_outgoing_streams_total",
+                "The number of concurrent outgoing streams accross all connections.",
             ),
             // Quinn stats
             quinn_path_rtt_seconds: metrics_registry.gauge_vec(

--- a/rs/p2p/quic_transport/src/request_handler.rs
+++ b/rs/p2p/quic_transport/src/request_handler.rs
@@ -61,7 +61,7 @@ pub async fn start_stream_acceptor(
             bi = conn_handle.conn().accept_bi() => {
                 match bi {
                     Ok((bi_tx, bi_rx)) => {
-                        let send_stream = ResetStreamOnDrop::new(bi_tx);
+                        let send_stream = ResetStreamOnDrop::new(bi_tx, metrics.connection_handle_incoming_streams_total.clone());
                         inflight_requests.spawn(
                             metrics.request_task_monitor.instrument(
                                 handle_bi_stream(


### PR DESCRIPTION
For each artifact to be transmitted via a connection between two peers, P2P opens a new and dedicated QUIC stream. The maximum number of concurrent QUIC streams (and therefore the maximum number of artifacts to be transferred in parallel) is controlled by the constant [MAX_CONCURRENT_BIDI_STREAMS](https://sourcegraph.com/github.com/dfinity/ic@1ad8f453823f58e9fd48e251fb7fe30b88a56c89/-/blob/rs/p2p/quic_transport/src/connection_manager.rs?L74).

This PR adds metrics for the number of concurrent incoming/outgoing QUIC streams, which will help us determine how far away we are from reaching the configured maximum. This is especially relevant for IDKG, which transmits a lot of artifacts.