### PR TITLE
fix: use lld linker on aarch64-linux to work around linker bug

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -327,6 +327,8 @@ jobs:
           nsc bazel cache setup --bazelrc=/tmp/bazel-cache.bazelrc
       - uses: actions/checkout@v4
 
+      # We need to use lld on aarch64-linux because the default gold linker runs into the following linker bug:
+      # /usr/bin/ld.gold: internal error in update_erratum_insn, at ../../gold/aarch64.cc:1003
       - name: Install lld
         run: |
           sudo apt install lld

--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -327,6 +327,10 @@ jobs:
           nsc bazel cache setup --bazelrc=/tmp/bazel-cache.bazelrc
       - uses: actions/checkout@v4
 
+      - name: Install lld
+        run: |
+          sudo apt install lld
+
       - name: Build and Test
         run: |
           # run pocket-ic tests

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -292,6 +292,8 @@ jobs:
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
           nsc bazel cache setup --bazelrc=/tmp/bazel-cache.bazelrc
       - uses: actions/checkout@v4
+      # We need to use lld on aarch64-linux because the default gold linker runs into the following linker bug:
+      # /usr/bin/ld.gold: internal error in update_erratum_insn, at ../../gold/aarch64.cc:1003
       - name: Install lld
         run: |
           sudo apt install lld

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -292,6 +292,9 @@ jobs:
           # Creates a bazelrc configuration fragment which tells bazel where the cache lives.
           nsc bazel cache setup --bazelrc=/tmp/bazel-cache.bazelrc
       - uses: actions/checkout@v4
+      - name: Install lld
+        run: |
+          sudo apt install lld
       - name: Build and Test
         run: |
           # run pocket-ic tests

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -144,6 +144,8 @@ crate_universe_dependencies()
 rust_register_toolchains(
     edition = "2024",
     extra_rustc_flags = {
+        # We need to use lld on aarch64-linux because the default gold linker runs into the following bug when linking pocket-ic-server:
+        # /usr/bin/ld.gold: internal error in update_erratum_insn, at ../../gold/aarch64.cc:1003
         "aarch64-unknown-linux-gnu": [
             "-C",
             "link-arg=-fuse-ld=lld",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -143,6 +143,12 @@ crate_universe_dependencies()
 
 rust_register_toolchains(
     edition = "2024",
+    extra_rustc_flags = {
+        "aarch64-unknown-linux-gnu": [
+            "-C",
+            "link-arg=-fuse-ld=lld",
+        ],
+    },
     strip_level = {"x86_64-unknown-linux-gnu": {
         "dbg": "none",
         "fastbuild": "none",


### PR DESCRIPTION
Fix to work around [the gold linker bug on aarch64-linux](https://github.com/dfinity/ic/actions/runs/17692688125/job/50290153280?pr=6705) which was introduced when https://github.com/dfinity/ic/pull/6705 merged https://github.com/dfinity/ic/commit/b9221277cd5e0dc9a2cd5af5ed7ddc9aff10e7a3 (chore: bumping edition to 2024):
```
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: /usr/bin/ld.gold: internal error in update_erratum_insn, at ../../gold/aarch64.cc:1003
          collect2: error: ld returned 1 exit status
```