### PR TITLE
perf(crypto): Generate unmasked key transcript directly in test utils and benchmarks

### DIFF
--- a/rs/crypto/benches/idkg.rs
+++ b/rs/crypto/benches/idkg.rs
@@ -4,10 +4,10 @@ use criterion::{BenchmarkGroup, Criterion, SamplingMode, criterion_group, criter
 use ic_crypto_test_utils_canister_threshold_sigs::node::{Node, Nodes};
 use ic_crypto_test_utils_canister_threshold_sigs::{
     CanisterThresholdSigTestEnvironment, IDkgMode, IDkgModeTestContext, IDkgParticipants,
-    IDkgTestContextForComplaint, build_params_from_previous, create_transcript_or_panic,
+    IDkgTestContextForComplaint, create_transcript_or_panic,
     generate_and_verify_openings_for_complaint, generate_ecdsa_presig_quadruple,
     load_previous_transcripts_for_all_dealers, load_transcript_or_panic, random_transcript_id,
-    run_idkg_without_complaint, setup_masked_random_params, setup_unmasked_random_params,
+    run_idkg_without_complaint, setup_unmasked_random_params,
 };
 use ic_crypto_test_utils_reproducible_rng::ReproducibleRng;
 use ic_interfaces::crypto::IDkgProtocol;
@@ -228,23 +228,15 @@ fn bench_verify_initial_dealings<M: Measurement, R: RngCore + CryptoRng>(
                         )
                     });
 
-                let initial_params = setup_masked_random_params(
+                let initial_params = setup_unmasked_random_params(
                     dealers_env,
                     test_case.alg(),
                     src_dealers,
                     src_receivers,
                     rng,
                 );
-                let initial_transcript =
-                    run_idkg_without_complaint(&initial_params, &dealers_env.nodes, rng);
-
-                let unmasked_params = build_params_from_previous(
-                    initial_params,
-                    IDkgTranscriptOperation::ReshareOfMasked(initial_transcript),
-                    rng,
-                );
                 let unmasked_transcript =
-                    run_idkg_without_complaint(&unmasked_params, &dealers_env.nodes, rng);
+                    run_idkg_without_complaint(&initial_params, &dealers_env.nodes, rng);
 
                 let reshare_of_unmasked_params = IDkgTranscriptParams::new(
                     random_transcript_id(rng),

--- a/rs/crypto/benches/idkg.rs
+++ b/rs/crypto/benches/idkg.rs
@@ -7,7 +7,7 @@ use ic_crypto_test_utils_canister_threshold_sigs::{
     IDkgTestContextForComplaint, build_params_from_previous, create_transcript_or_panic,
     generate_and_verify_openings_for_complaint, generate_ecdsa_presig_quadruple,
     load_previous_transcripts_for_all_dealers, load_transcript_or_panic, random_transcript_id,
-    run_idkg_without_complaint, setup_masked_random_params,
+    run_idkg_without_complaint, setup_masked_random_params, setup_unmasked_random_params,
 };
 use ic_crypto_test_utils_reproducible_rng::ReproducibleRng;
 use ic_interfaces::crypto::IDkgProtocol;
@@ -757,15 +757,7 @@ fn generate_key_transcript<R: RngCore + CryptoRng>(
     receivers: &IDkgReceivers,
     rng: &mut R,
 ) -> IDkgTranscript {
-    let masked_key_params = setup_masked_random_params(env, alg, dealers, receivers, rng);
-    let masked_key_transcript = run_idkg_without_complaint(&masked_key_params, &env.nodes, rng);
-
-    let unmasked_key_params = build_params_from_previous(
-        masked_key_params,
-        IDkgTranscriptOperation::ReshareOfMasked(masked_key_transcript),
-        rng,
-    );
-
+    let unmasked_key_params = setup_unmasked_random_params(env, alg, dealers, receivers, rng);
     run_idkg_without_complaint(&unmasked_key_params, &env.nodes, rng)
 }
 

--- a/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
+++ b/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
@@ -207,18 +207,7 @@ pub fn generate_key_transcript<R: RngCore + CryptoRng>(
     alg: AlgorithmId,
     rng: &mut R,
 ) -> IDkgTranscript {
-    let masked_key_params = setup_masked_random_params(env, alg, dealers, receivers, rng);
-
-    let masked_key_transcript = env
-        .nodes
-        .run_idkg_and_create_and_verify_transcript(&masked_key_params, rng);
-
-    let unmasked_key_params = build_params_from_previous(
-        masked_key_params,
-        IDkgTranscriptOperation::ReshareOfMasked(masked_key_transcript),
-        rng,
-    );
-
+    let unmasked_key_params = setup_unmasked_random_params(env, alg, dealers, receivers, rng);
     env.nodes
         .run_idkg_and_create_and_verify_transcript(&unmasked_key_params, rng)
 }

--- a/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
+++ b/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
@@ -1752,7 +1752,7 @@ pub fn setup_reshare_of_unmasked_params<R: Rng + CryptoRng>(
     receivers: &IDkgReceivers,
     rng: &mut R,
 ) -> IDkgTranscriptParams {
-    let unmasked_params = setup_reshare_of_masked_params(env, alg, dealers, receivers, rng);
+    let unmasked_params = setup_unmasked_random_params(env, alg, dealers, receivers, rng);
     let unmasked_transcript = run_idkg_without_complaint(&unmasked_params, &env.nodes, rng);
     let reshare_params = build_params_from_previous(
         unmasked_params,

--- a/rs/crypto/tests/canister_threshold_idkg.rs
+++ b/rs/crypto/tests/canister_threshold_idkg.rs
@@ -3542,23 +3542,17 @@ mod reshare_key_transcript {
             let (source_dealers, source_receivers) = source_subnet_nodes
                 .choose_dealers_and_receivers(&IDkgParticipants::RandomForThresholdSignature, rng);
             let source_key_transcript = {
-                let masked_key_params = IDkgTranscriptParams::new(
+                let unmasked_key_params = IDkgTranscriptParams::new(
                     random_transcript_id(rng),
                     source_dealers.get().clone(),
                     source_receivers.get().clone(),
                     env.newest_registry_version,
                     alg,
-                    IDkgTranscriptOperation::Random,
+                    IDkgTranscriptOperation::RandomUnmasked,
                 )
                 .expect("failed to create random IDkgTranscriptParams");
-                let masked_key_transcript = source_subnet_nodes
-                    .run_idkg_and_create_and_verify_transcript(&masked_key_params, rng);
-                let unmasked_params = build_params_from_previous(
-                    masked_key_params,
-                    IDkgTranscriptOperation::ReshareOfMasked(masked_key_transcript),
-                    rng,
-                );
-                source_subnet_nodes.run_idkg_and_create_and_verify_transcript(&unmasked_params, rng)
+                source_subnet_nodes
+                    .run_idkg_and_create_and_verify_transcript(&unmasked_key_params, rng)
             };
             let source_tecdsa_master_public_key =
                 get_master_public_key_from_transcript(&source_key_transcript)
@@ -3634,23 +3628,17 @@ mod reshare_key_transcript {
             let (source_dealers, source_receivers) = source_subnet_nodes
                 .choose_dealers_and_receivers(&IDkgParticipants::RandomForThresholdSignature, rng);
             let source_key_transcript = {
-                let masked_key_params = IDkgTranscriptParams::new(
+                let unmasked_key_params = IDkgTranscriptParams::new(
                     random_transcript_id(rng),
                     source_dealers.get().clone(),
                     source_receivers.get().clone(),
                     env.newest_registry_version,
                     alg,
-                    IDkgTranscriptOperation::Random,
+                    IDkgTranscriptOperation::RandomUnmasked,
                 )
                 .expect("failed to create random IDkgTranscriptParams");
-                let masked_key_transcript = source_subnet_nodes
-                    .run_idkg_and_create_and_verify_transcript(&masked_key_params, rng);
-                let unmasked_params = build_params_from_previous(
-                    masked_key_params,
-                    IDkgTranscriptOperation::ReshareOfMasked(masked_key_transcript),
-                    rng,
-                );
-                source_subnet_nodes.run_idkg_and_create_and_verify_transcript(&unmasked_params, rng)
+                source_subnet_nodes
+                    .run_idkg_and_create_and_verify_transcript(&unmasked_key_params, rng)
             };
             let source_tecdsa_master_public_key =
                 get_master_public_key_from_transcript(&source_key_transcript)


### PR DESCRIPTION
Updates the canister threshold sig utils so that `generate_key_transcript` directly creates an unmasked key transcript rather than first creating a masked one and then resharing it to unmask it.

This is possible because we now have an IDKG mode to direclty create random unmasked transcripts, but the new approach isn't used everywhere yet. There are likely a few more places where we still do the indirection via the masked random transcript.

The change will (slightly) improve the runtimes of the crypto benchmarks, as this utility is used at a few places in the benchmarks (for both tECDSA and tSchnorr: `bench_sign_share`, `bench_verify_sig_share`, `bench_combine_sig_shares`, `bench_verify_combined_sig`).

Also adjusts some integration tests and benchmarks accordingly.