### PR TITLE
chore(XC): remove deprecation from `ic-cdk` in `ic-ckbtc-minter`

### DIFF
--- a/rs/bitcoin/ckbtc/minter/ckbtc_minter.did
+++ b/rs/bitcoin/ckbtc/minter/ckbtc_minter.did
@@ -10,6 +10,7 @@ type CanisterStatusResponse = record {
   module_hash : opt vec nat8;
   query_stats : QueryStats;
   reserved_cycles : nat;
+  memory_metrics : MemoryMetrics;
 };
 
 type QueryStats = record {
@@ -17,6 +18,17 @@ type QueryStats = record {
   num_instructions_total : nat;
   num_calls_total : nat;
   request_payload_bytes_total : nat;
+};
+
+type MemoryMetrics = record {
+    wasm_memory_size : nat;
+    stable_memory_size : nat;
+    global_memory_size : nat;
+    wasm_binary_size : nat;
+    custom_sections_size : nat;
+    canister_history_size : nat;
+    wasm_chunk_store_size : nat;
+    snapshots_size : nat;
 };
 
 type CanisterStatusType = variant { stopped; stopping; running };
@@ -29,6 +41,7 @@ type DefiniteCanisterSettings = record {
   reserved_cycles_limit : nat;
   log_visibility: LogVisibility;
   wasm_memory_limit : nat;
+  wasm_memory_threshold : nat;
 };
 
 type LogVisibility = variant {

--- a/rs/bitcoin/ckbtc/minter/src/dashboard.rs
+++ b/rs/bitcoin/ckbtc/minter/src/dashboard.rs
@@ -276,7 +276,7 @@ pub fn build_account_to_utxos_table(s: &CkBtcMinterState, start: u64, page_size:
 
 pub fn build_metadata(s: &CkBtcMinterState) -> String {
     let main_account = Account {
-        owner: ic_cdk::id(),
+        owner: ic_cdk::api::canister_self(),
         subaccount: None,
     };
     format!(

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -1460,7 +1460,7 @@ pub struct IcCanisterRuntime {}
 #[async_trait]
 impl CanisterRuntime for IcCanisterRuntime {
     fn caller(&self) -> Principal {
-        ic_cdk::caller()
+        ic_cdk::api::msg_caller()
     }
 
     fn id(&self) -> Principal {

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -1427,7 +1427,7 @@ pub trait CanisterRuntime {
     /// Fetches all unspent transaction outputs (UTXOs) associated with the provided address in the specified Bitcoin network.
     async fn bitcoin_get_utxos(
         &self,
-        request: GetUtxosRequest,
+        request: &GetUtxosRequest,
     ) -> Result<GetUtxosResponse, CallError>;
 
     async fn check_transaction(
@@ -1481,7 +1481,7 @@ impl CanisterRuntime for IcCanisterRuntime {
 
     async fn bitcoin_get_utxos(
         &self,
-        request: GetUtxosRequest,
+        request: &GetUtxosRequest,
     ) -> Result<GetUtxosResponse, CallError> {
         management::bitcoin_get_utxos(request).await
     }

--- a/rs/bitcoin/ckbtc/minter/src/lib.rs
+++ b/rs/bitcoin/ckbtc/minter/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use crate::address::BitcoinAddress;
 use crate::logs::{P0, P1};
 use crate::management::CallError;
@@ -367,7 +366,7 @@ async fn submit_pending_requests<R: CanisterRuntime>(runtime: &R) {
     }
 
     let main_account = Account {
-        owner: ic_cdk::id(),
+        owner: ic_cdk::api::canister_self(),
         subaccount: None,
     };
 
@@ -681,7 +680,7 @@ async fn finalize_requests<R: CanisterRuntime>(runtime: &R, force_resubmit: bool
     }
 
     let main_account = Account {
-        owner: ic_cdk::id(),
+        owner: ic_cdk::api::canister_self(),
         subaccount: None,
     };
 
@@ -1465,7 +1464,7 @@ impl CanisterRuntime for IcCanisterRuntime {
     }
 
     fn id(&self) -> Principal {
-        ic_cdk::id()
+        ic_cdk::api::canister_self()
     }
 
     fn time(&self) -> u64 {

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use candid::Principal;
 use ic_btc_interface::Utxo;
 use ic_canister_log::export as export_logs;
@@ -193,15 +192,12 @@ async fn update_balance(args: UpdateBalanceArgs) -> Result<Vec<UtxoStatus>, Upda
 }
 
 #[update]
-async fn get_canister_status() -> ic_cdk::api::management_canister::main::CanisterStatusResponse {
-    ic_cdk::api::management_canister::main::canister_status(
-        ic_cdk::api::management_canister::main::CanisterIdRecord {
-            canister_id: ic_cdk::api::canister_self(),
-        },
-    )
+async fn get_canister_status() -> ic_cdk::management_canister::CanisterStatusResult {
+    ic_cdk::management_canister::canister_status(&ic_cdk::management_canister::CanisterStatusArgs {
+        canister_id: ic_cdk::api::canister_self(),
+    })
     .await
     .expect("failed to fetch canister status")
-    .0
 }
 
 #[cfg(feature = "self_check")]

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -196,7 +196,7 @@ async fn update_balance(args: UpdateBalanceArgs) -> Result<Vec<UtxoStatus>, Upda
 async fn get_canister_status() -> ic_cdk::api::management_canister::main::CanisterStatusResponse {
     ic_cdk::api::management_canister::main::canister_status(
         ic_cdk::api::management_canister::main::CanisterIdRecord {
-            canister_id: ic_cdk::id(),
+            canister_id: ic_cdk::api::canister_self(),
         },
     )
     .await

--- a/rs/bitcoin/ckbtc/minter/src/main.rs
+++ b/rs/bitcoin/ckbtc/minter/src/main.rs
@@ -105,7 +105,7 @@ fn check_postcondition<T>(t: T) -> T {
 }
 
 fn check_anonymous_caller() {
-    if ic_cdk::caller() == Principal::anonymous() {
+    if ic_cdk::api::msg_caller() == Principal::anonymous() {
         panic!("anonymous caller not allowed")
     }
 }
@@ -180,7 +180,7 @@ fn retrieve_btc_status_v2_by_account(target: Option<Account>) -> Vec<BtcRetrieva
 fn get_known_utxos(args: UpdateBalanceArgs) -> Vec<Utxo> {
     read_state(|s| {
         s.known_utxos_for_account(&Account {
-            owner: args.owner.unwrap_or(ic_cdk::caller()),
+            owner: args.owner.unwrap_or(ic_cdk::api::msg_caller()),
             subaccount: args.subaccount,
         })
     })

--- a/rs/bitcoin/ckbtc/minter/src/management.rs
+++ b/rs/bitcoin/ckbtc/minter/src/management.rs
@@ -10,6 +10,7 @@ use ic_btc_interface::{Address, MillisatoshiPerByte, Utxo};
 use ic_canister_log::log;
 use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::management_canister::bitcoin::UtxoFilter;
+use ic_cdk::management_canister::SignCallError;
 use ic_management_canister_types::{
     EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, EcdsaPublicKeyResult,
 };
@@ -40,6 +41,24 @@ impl CallError {
         CallError {
             method: String::from(method),
             reason: Reason::from_reject(code, msg),
+        }
+    }
+
+    pub fn from_sign_error(error: SignCallError) -> Self {
+        let reason = match error {
+            SignCallError::SignCostError(e) => {
+                //no signatures were made
+                Reason::Rejected(e.to_string())
+            }
+            SignCallError::CallFailed(e) => {
+                //no signatures were made
+                Reason::Rejected(e.to_string())
+            }
+            SignCallError::CandidDecodeFailed(e) => Reason::CanisterError(e.to_string()),
+        };
+        Self {
+            method: "sign_with_ecdsa".to_string(),
+            reason,
         }
     }
 }

--- a/rs/bitcoin/ckbtc/minter/src/management.rs
+++ b/rs/bitcoin/ckbtc/minter/src/management.rs
@@ -143,7 +143,7 @@ pub async fn get_utxos<R: CanisterRuntime>(
             Ok(res)
         } else {
             crate::metrics::GET_UTXOS_CACHE_MISSES.with(|cell| cell.set(cell.get() + 1));
-            runtime.bitcoin_get_utxos(req.clone()).await.inspect(|res| {
+            runtime.bitcoin_get_utxos(&req).await.inspect(|res| {
                 *now = runtime.time();
                 crate::state::mutate_state(|s| s.get_utxos_cache.insert(req, res.clone(), *now))
             })
@@ -184,9 +184,8 @@ pub async fn get_utxos<R: CanisterRuntime>(
 }
 
 /// Fetches a subset of UTXOs for the specified address.
-pub async fn bitcoin_get_utxos(request: GetUtxosRequest) -> Result<GetUtxosResponse, CallError> {
-    // TODO XC-455: take only reference instead of ownership of GetUtxosRequest
-    bitcoin_canister::bitcoin_get_utxos(&request)
+pub async fn bitcoin_get_utxos(request: &GetUtxosRequest) -> Result<GetUtxosResponse, CallError> {
+    bitcoin_canister::bitcoin_get_utxos(request)
         .await
         .map(GetUtxosResponse::from)
         .map_err(|err| CallError::from_cdk_call_error("bitcoin_get_utxos", err))

--- a/rs/bitcoin/ckbtc/minter/src/management.rs
+++ b/rs/bitcoin/ckbtc/minter/src/management.rs
@@ -1,21 +1,15 @@
 //! This module contains async functions for interacting with the management canister.
-use crate::logs::P0;
 use crate::metrics::{observe_get_utxos_latency, observe_sign_with_ecdsa_latency};
 use crate::{CanisterRuntime, ECDSAPublicKey, GetUtxosRequest, GetUtxosResponse, Network, tx};
-use candid::{CandidType, Principal};
+use candid::Principal;
 use ic_btc_checker::{
     CheckAddressArgs, CheckAddressResponse, CheckTransactionArgs, CheckTransactionResponse,
 };
 use ic_btc_interface::{Address, MillisatoshiPerByte, Utxo};
-use ic_canister_log::log;
-use ic_cdk::api::call::RejectionCode;
-use ic_cdk::api::management_canister::bitcoin::UtxoFilter;
+use ic_cdk::bitcoin_canister;
 use ic_cdk::management_canister::SignCallError;
-use ic_management_canister_types::{
-    EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, EcdsaPublicKeyResult,
-};
+use ic_management_canister_types::{EcdsaCurve, EcdsaKeyId};
 use ic_management_canister_types_private::DerivationPath;
-use serde::de::DeserializeOwned;
 use std::fmt;
 
 /// Represents an error from a management canister call, such as
@@ -37,10 +31,16 @@ impl CallError {
         &self.reason
     }
 
-    pub fn from_cdk_error(method: &str, (code, msg): (RejectionCode, String)) -> CallError {
+    pub fn from_cdk_call_error<T: Into<ic_cdk::call::Error>>(method: &str, error: T) -> CallError {
+        use ic_cdk::call::Error as CdkError;
         CallError {
             method: String::from(method),
-            reason: Reason::from_reject(code, msg),
+            reason: match error.into() {
+                CdkError::InsufficientLiquidCycleBalance(_e) => Reason::OutOfCycles,
+                CdkError::CallPerformFailed(e) => Reason::Rejected(e.to_string()),
+                CdkError::CallRejected(e) => Reason::Rejected(e.to_string()),
+                CdkError::CandidDecodeFailed(e) => Reason::CanisterError(e.to_string()),
+            },
         }
     }
 
@@ -101,55 +101,6 @@ impl fmt::Display for Reason {
     }
 }
 
-impl Reason {
-    fn from_reject(reject_code: RejectionCode, reject_message: String) -> Self {
-        match reject_code {
-            RejectionCode::SysTransient => Self::QueueIsFull,
-            RejectionCode::CanisterError => Self::CanisterError(reject_message),
-            RejectionCode::CanisterReject => Self::Rejected(reject_message),
-            _ => Self::QueueIsFull,
-        }
-    }
-}
-
-pub(crate) async fn call<I, O>(method: &str, payment: u64, input: &I) -> Result<O, CallError>
-where
-    I: CandidType,
-    O: CandidType + DeserializeOwned,
-{
-    let balance = ic_cdk::api::canister_balance128();
-    if balance < payment as u128 {
-        log!(
-            P0,
-            "Failed to call {}: need {} cycles, the balance is only {}",
-            method,
-            payment,
-            balance
-        );
-
-        return Err(CallError {
-            method: method.to_string(),
-            reason: Reason::OutOfCycles,
-        });
-    }
-
-    let res: Result<(O,), _> = ic_cdk::api::call::call_with_payment(
-        Principal::management_canister(),
-        method,
-        (input,),
-        payment,
-    )
-    .await;
-
-    match res {
-        Ok((output,)) => Ok(output),
-        Err((code, msg)) => Err(CallError {
-            method: method.to_string(),
-            reason: Reason::from_reject(code, msg),
-        }),
-    }
-}
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CallSource {
     /// The client initiated the call.
@@ -204,7 +155,9 @@ pub async fn get_utxos<R: CanisterRuntime>(
     let request = GetUtxosRequest {
         address: address.clone(),
         network: network.into(),
-        filter: Some(UtxoFilter::MinConfirmations(min_confirmations)),
+        filter: Some(bitcoin_canister::UtxosFilter::MinConfirmations(
+            min_confirmations,
+        )),
     };
 
     let mut response = bitcoin_get_utxos(&mut now, request.clone(), source, runtime).await?;
@@ -215,7 +168,7 @@ pub async fn get_utxos<R: CanisterRuntime>(
     // Continue fetching until there are no more pages.
     while let Some(page) = response.next_page {
         let paged_request = GetUtxosRequest {
-            filter: Some(UtxoFilter::Page(page.to_vec())),
+            filter: Some(bitcoin_canister::UtxosFilter::Page(page.to_vec())),
             ..request.clone()
         };
         response = bitcoin_get_utxos(&mut now, paged_request, source, runtime).await?;
@@ -232,22 +185,22 @@ pub async fn get_utxos<R: CanisterRuntime>(
 
 /// Fetches a subset of UTXOs for the specified address.
 pub async fn bitcoin_get_utxos(request: GetUtxosRequest) -> Result<GetUtxosResponse, CallError> {
-    ic_cdk::api::management_canister::bitcoin::bitcoin_get_utxos(request)
+    // TODO XC-455: take only reference instead of ownership of GetUtxosRequest
+    bitcoin_canister::bitcoin_get_utxos(&request)
         .await
-        .map(|(response,)| response.into())
-        .map_err(|err| CallError::from_cdk_error("bitcoin_get_utxos", err))
+        .map(GetUtxosResponse::from)
+        .map_err(|err| CallError::from_cdk_call_error("bitcoin_get_utxos", err))
 }
 
 /// Returns the current fee percentiles on the Bitcoin network.
 pub async fn get_current_fees(network: Network) -> Result<Vec<MillisatoshiPerByte>, CallError> {
-    ic_cdk::api::management_canister::bitcoin::bitcoin_get_current_fee_percentiles(
-        ic_cdk::api::management_canister::bitcoin::GetCurrentFeePercentilesRequest {
+    bitcoin_canister::bitcoin_get_current_fee_percentiles(
+        &bitcoin_canister::GetCurrentFeePercentilesRequest {
             network: network.into(),
         },
     )
     .await
-    .map(|(result,)| result)
-    .map_err(|err| CallError::from_cdk_error("bitcoin_get_current_fee_percentiles", err))
+    .map_err(|err| CallError::from_cdk_call_error("bitcoin_get_current_fee_percentiles", err))
 }
 
 /// Sends the transaction to the network the management canister interacts with.
@@ -255,14 +208,12 @@ pub async fn send_transaction(
     transaction: &tx::SignedTransaction,
     network: Network,
 ) -> Result<(), CallError> {
-    ic_cdk::api::management_canister::bitcoin::bitcoin_send_transaction(
-        ic_cdk::api::management_canister::bitcoin::SendTransactionRequest {
-            transaction: transaction.serialize(),
-            network: network.into(),
-        },
-    )
+    bitcoin_canister::bitcoin_send_transaction(&bitcoin_canister::SendTransactionRequest {
+        transaction: transaction.serialize(),
+        network: network.into(),
+    })
     .await
-    .map_err(|err| CallError::from_cdk_error("bitcoin_send_transaction", err))
+    .map_err(|err| CallError::from_cdk_call_error("bitcoin_send_transaction", err))
 }
 
 /// Fetches the ECDSA public key of the canister.
@@ -270,12 +221,8 @@ pub async fn ecdsa_public_key(
     key_name: String,
     derivation_path: DerivationPath,
 ) -> Result<ECDSAPublicKey, CallError> {
-    // Retrieve the public key of this canister at the given derivation path
-    // from the ECDSA API.
-    call(
-        "ecdsa_public_key",
-        /*payment=*/ 0,
-        &EcdsaPublicKeyArgs {
+    ic_cdk::management_canister::ecdsa_public_key(
+        &ic_cdk::management_canister::EcdsaPublicKeyArgs {
             canister_id: None,
             derivation_path: derivation_path.into_inner(),
             key_id: EcdsaKeyId {
@@ -285,10 +232,11 @@ pub async fn ecdsa_public_key(
         },
     )
     .await
-    .map(|response: EcdsaPublicKeyResult| ECDSAPublicKey {
+    .map(|response| ECDSAPublicKey {
         public_key: response.public_key,
         chain_code: response.chain_code,
     })
+    .map_err(|err| CallError::from_cdk_call_error("ecdsa_public_key", err))
 }
 
 /// Signs a message hash using the tECDSA API.
@@ -314,17 +262,12 @@ pub async fn check_withdrawal_destination_address(
     btc_checker_principal: Principal,
     address: String,
 ) -> Result<CheckAddressResponse, CallError> {
-    let (res,): (CheckAddressResponse,) = ic_cdk::api::call::call(
-        btc_checker_principal,
-        "check_address",
-        (CheckAddressArgs { address },),
-    )
-    .await
-    .map_err(|(code, message)| CallError {
-        method: "check_address".to_string(),
-        reason: Reason::from_reject(code, message),
-    })?;
-    Ok(res)
+    ic_cdk::call::Call::bounded_wait(btc_checker_principal, "check_address")
+        .with_arg(CheckAddressArgs { address })
+        .await
+        .map_err(|e| CallError::from_cdk_call_error("check_address", e))?
+        .candid()
+        .map_err(|e| CallError::from_cdk_call_error("check_address", e))
 }
 
 /// Check if the given UTXO passes Bitcoin check.
@@ -333,18 +276,15 @@ pub async fn check_transaction(
     utxo: &Utxo,
     cycle_payment: u128,
 ) -> Result<CheckTransactionResponse, CallError> {
-    let (res,): (CheckTransactionResponse,) = ic_cdk::api::call::call_with_payment128(
-        btc_checker_principal,
-        "check_transaction",
-        (CheckTransactionArgs {
+    // use unbounded wait because calls require cycles
+    // and currently cycles are not reimbursed with bounded-wait calls in case of a timeout.
+    ic_cdk::call::Call::unbounded_wait(btc_checker_principal, "check_transaction")
+        .with_arg(CheckTransactionArgs {
             txid: utxo.outpoint.txid.as_ref().to_vec(),
-        },),
-        cycle_payment,
-    )
-    .await
-    .map_err(|(code, message)| CallError {
-        method: "check_transaction".to_string(),
-        reason: Reason::from_reject(code, message),
-    })?;
-    Ok(res)
+        })
+        .with_cycles(cycle_payment)
+        .await
+        .map_err(|e| CallError::from_cdk_call_error("check_transaction", e))?
+        .candid()
+        .map_err(|e| CallError::from_cdk_call_error("check_transaction", e))
 }

--- a/rs/bitcoin/ckbtc/minter/src/metrics.rs
+++ b/rs/bitcoin/ckbtc/minter/src/metrics.rs
@@ -171,7 +171,7 @@ pub fn encode_metrics(
 
     metrics.encode_gauge(
         "stable_memory_bytes",
-        ic_cdk::api::stable::stable_size() as f64 * WASM_PAGE_SIZE_IN_BYTES,
+        ic_cdk::stable::stable_size() as f64 * WASM_PAGE_SIZE_IN_BYTES,
         "Size of the stable memory allocated by this canister.",
     )?;
     metrics.encode_gauge(
@@ -180,7 +180,7 @@ pub fn encode_metrics(
         "Size of the heap memory allocated by this canister.",
     )?;
 
-    let cycle_balance = ic_cdk::api::canister_balance128() as f64;
+    let cycle_balance = ic_cdk::api::canister_cycle_balance() as f64;
 
     metrics.encode_gauge(
         "ckbtc_minter_cycle_balance",

--- a/rs/bitcoin/ckbtc/minter/src/state.rs
+++ b/rs/bitcoin/ckbtc/minter/src/state.rs
@@ -632,7 +632,7 @@ impl CkBtcMinterState {
         target: Option<Account>,
     ) -> Vec<BtcRetrievalStatusV2> {
         let target_account = target.unwrap_or(Account {
-            owner: ic_cdk::caller(),
+            owner: ic_cdk::api::msg_caller(),
             subaccount: None,
         });
 

--- a/rs/bitcoin/ckbtc/minter/src/test_fixtures.rs
+++ b/rs/bitcoin/ckbtc/minter/src/test_fixtures.rs
@@ -156,7 +156,7 @@ pub mod mock {
             fn id(&self) -> Principal;
             fn time(&self) -> u64;
             fn global_timer_set(&self, timestamp: u64);
-            async fn bitcoin_get_utxos(&self, request: GetUtxosRequest) -> Result<GetUtxosResponse, CallError>;
+            async fn bitcoin_get_utxos(&self, request: &GetUtxosRequest) -> Result<GetUtxosResponse, CallError>;
             async fn check_transaction(&self, btc_checker_principal: Principal, utxo: &Utxo, cycle_payment: u128, ) -> Result<CheckTransactionResponse, CallError>;
             async fn mint_ckbtc(&self, amount: u64, to: Account, memo: Memo) -> Result<u64, UpdateBalanceError>;
             async fn sign_with_ecdsa(&self, key_name: String, derivation_path: DerivationPath, message_hash: [u8; 32]) -> Result<Vec<u8>, CallError>;

--- a/rs/bitcoin/ckbtc/minter/src/updates/get_btc_address.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/get_btc_address.rs
@@ -27,7 +27,7 @@ pub fn account_to_p2wpkh_address_from_state(s: &CkBtcMinterState, account: &Acco
 }
 
 pub async fn get_btc_address(args: GetBtcAddressArgs) -> String {
-    let owner = args.owner.unwrap_or_else(ic_cdk::caller);
+    let owner = args.owner.unwrap_or_else(ic_cdk::api::msg_caller);
     assert_ne!(
         owner,
         Principal::anonymous(),

--- a/rs/bitcoin/ckbtc/minter/src/updates/get_withdrawal_account.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/get_withdrawal_account.rs
@@ -8,7 +8,7 @@ use super::get_btc_address::init_ecdsa_public_key;
 pub async fn get_withdrawal_account() -> Account {
     let caller = PrincipalId(ic_cdk::caller());
     init_ecdsa_public_key().await;
-    let ck_btc_principal = ic_cdk::id();
+    let ck_btc_principal = ic_cdk::api::canister_self();
     let caller_subaccount: Subaccount = compute_subaccount(caller, 0);
     // Check that the computed subaccount doesn't collide with minting account.
     if &caller_subaccount == DEFAULT_SUBACCOUNT {

--- a/rs/bitcoin/ckbtc/minter/src/updates/get_withdrawal_account.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/get_withdrawal_account.rs
@@ -6,7 +6,7 @@ use super::get_btc_address::init_ecdsa_public_key;
 
 /// Deterministically computes a ckBTC Ledger account ID based on the ckBTC Minter’s principal ID and the caller’s principal ID.
 pub async fn get_withdrawal_account() -> Account {
-    let caller = PrincipalId(ic_cdk::caller());
+    let caller = PrincipalId(ic_cdk::api::msg_caller());
     init_ecdsa_public_key().await;
     let ck_btc_principal = ic_cdk::api::canister_self();
     let caller_subaccount: Subaccount = compute_subaccount(caller, 0);

--- a/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
@@ -147,7 +147,7 @@ impl From<ParseAddressError> for RetrieveBtcWithApprovalError {
 }
 
 pub async fn retrieve_btc(args: RetrieveBtcArgs) -> Result<RetrieveBtcOk, RetrieveBtcError> {
-    let caller = ic_cdk::caller();
+    let caller = ic_cdk::api::msg_caller();
 
     state::read_state(|s| s.mode.is_withdrawal_available_for(&caller))
         .map_err(RetrieveBtcError::TemporarilyUnavailable)?;
@@ -255,7 +255,7 @@ pub async fn retrieve_btc(args: RetrieveBtcArgs) -> Result<RetrieveBtcOk, Retrie
 pub async fn retrieve_btc_with_approval(
     args: RetrieveBtcWithApprovalArgs,
 ) -> Result<RetrieveBtcOk, RetrieveBtcWithApprovalError> {
-    let caller = ic_cdk::caller();
+    let caller = ic_cdk::api::msg_caller();
 
     state::read_state(|s| s.mode.is_withdrawal_available_for(&caller))
         .map_err(RetrieveBtcWithApprovalError::TemporarilyUnavailable)?;

--- a/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/retrieve_btc.rs
@@ -156,7 +156,7 @@ pub async fn retrieve_btc(args: RetrieveBtcArgs) -> Result<RetrieveBtcOk, Retrie
     let main_address = account_to_bitcoin_address(
         &ecdsa_public_key,
         &Account {
-            owner: ic_cdk::id(),
+            owner: ic_cdk::api::canister_self(),
             subaccount: None,
         },
     );
@@ -264,7 +264,7 @@ pub async fn retrieve_btc_with_approval(
     let main_address = account_to_bitcoin_address(
         &ecdsa_public_key,
         &Account {
-            owner: ic_cdk::id(),
+            owner: ic_cdk::api::canister_self(),
             subaccount: None,
         },
     );
@@ -360,7 +360,7 @@ async fn balance_of(user: Principal) -> Result<u64, RetrieveBtcError> {
         runtime: CdkRuntime,
         ledger_canister_id: read_state(|s| s.ledger_id.get().into()),
     };
-    let minter = ic_cdk::id();
+    let minter = ic_cdk::api::canister_self();
     let subaccount = compute_subaccount(PrincipalId(user), 0);
     let result = client
         .balance_of(Account {
@@ -383,7 +383,7 @@ async fn burn_ckbtcs(user: Principal, amount: u64, memo: Memo) -> Result<u64, Re
         runtime: CdkRuntime,
         ledger_canister_id: read_state(|s| s.ledger_id.get().into()),
     };
-    let minter = ic_cdk::id();
+    let minter = ic_cdk::api::canister_self();
     let from_subaccount = compute_subaccount(PrincipalId(user), 0);
     let result = client
         .transfer(TransferArg {
@@ -456,7 +456,7 @@ async fn burn_ckbtcs_icrc2(
         runtime: CdkRuntime,
         ledger_canister_id: read_state(|s| s.ledger_id.get().into()),
     };
-    let minter = ic_cdk::id();
+    let minter = ic_cdk::api::canister_self();
     let result = client
         .transfer_from(TransferFromArgs {
             spender_subaccount: None,

--- a/rs/bitcoin/ckbtc/minter/src/updates/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/tests.rs
@@ -636,9 +636,12 @@ mod update_balance {
 
             let mock_result = match result {
                 MetricsResult::Ok => Ok(vec![]),
-                MetricsResult::Err => Err(CallError::from_cdk_error(
-                    "sign_with_ecdsa",
-                    (RejectionCode::Unknown, "mock error".to_string()),
+                MetricsResult::Err => Err(CallError::from_sign_error(
+                    ic_cdk::management_canister::SignCallError::CallFailed(
+                        ic_cdk::call::CallFailed::CallPerformFailed(
+                            ic_cdk::call::CallPerformFailed {},
+                        ),
+                    ),
                 )),
             };
             runtime.expect_sign_with_ecdsa().return_const(mock_result);

--- a/rs/bitcoin/ckbtc/minter/src/updates/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/src/updates/tests.rs
@@ -16,7 +16,6 @@ mod update_balance {
     use crate::{CanisterRuntime, GetUtxosResponse, Timestamp, storage};
     use ic_btc_checker::{CheckTransactionResponse, CheckTransactionStatus};
     use ic_btc_interface::Utxo;
-    use ic_cdk::api::call::RejectionCode;
     use ic_management_canister_types_private::BoundedVec;
     use icrc_ledger_types::icrc1::account::Account;
     use std::iter;

--- a/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/replay_events.rs
@@ -49,7 +49,7 @@ pub mod mock {
             fn id(&self) -> Principal;
             fn time(&self) -> u64;
             fn global_timer_set(&self, timestamp: u64);
-            async fn bitcoin_get_utxos(&self, request: GetUtxosRequest) -> Result<GetUtxosResponse, CallError>;
+            async fn bitcoin_get_utxos(&self, request: &GetUtxosRequest) -> Result<GetUtxosResponse, CallError>;
             async fn check_transaction(&self, btc_checker_principal: Principal, utxo: &Utxo, cycle_payment: u128, ) -> Result<CheckTransactionResponse, CallError>;
             async fn mint_ckbtc(&self, amount: u64, to: Account, memo: Memo) -> Result<u64, UpdateBalanceError>;
             async fn sign_with_ecdsa(&self, key_name: String, derivation_path: DerivationPath, message_hash: [u8; 32]) -> Result<Vec<u8>, CallError>;

--- a/rs/bitcoin/ckbtc/minter/tests/tests.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/tests.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use assert_matches::assert_matches;
 use bitcoin::util::psbt::serialize::Deserialize;
 use bitcoin::{Address as BtcAddress, Network as BtcNetwork};
@@ -659,13 +658,12 @@ fn bitcoin_canister_id(btc_network: Network) -> CanisterId {
 }
 
 fn install_bitcoin_mock_canister(env: &StateMachine, btc_network: Network) {
-    use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
     let cid = bitcoin_canister_id(btc_network);
     env.create_canister_with_cycles(Some(cid.into()), Cycles::new(0), None);
     env.install_existing_canister(
         cid,
         bitcoin_mock_wasm(),
-        Encode!(&BitcoinNetwork::from(btc_network)).unwrap(),
+        Encode!(&ic_cdk::bitcoin_canister::Network::from(btc_network)).unwrap(),
     )
     .unwrap();
 }


### PR DESCRIPTION
Follow-up to #6264 to remove the introduced `#![allow(deprecated)]` in the code of the `ic-ckbtc-minter` canister:

1. in [`rs/bitcoin/ckbtc/minter/src/main.rs`](https://github.com/dfinity/ic/blob/3794e29f4a7b0174dd40539262a22ef48bd7d6de/rs/bitcoin/ckbtc/minter/src/main.rs#L1)
2. in [`rs/bitcoin/ckbtc/minter/src/lib.rs`](https://github.com/dfinity/ic/blob/3794e29f4a7b0174dd40539262a22ef48bd7d6de/rs/bitcoin/ckbtc/minter/src/lib.rs#L1)
3. in [`rs/bitcoin/ckbtc/minter/tests/tests.rs`](https://github.com/dfinity/ic/blob/3794e29f4a7b0174dd40539262a22ef48bd7d6de/rs/bitcoin/ckbtc/minter/tests/tests.rs#L1)

The changes in the ckBTC minter API are due to changes in the return type of `get_canister_status`, which is a debug endpoint where backwards-compatibility is not guaranteed.