### PR TITLE
refactor(node): hostos_grub.cfg to contain only a single linux command

### DIFF
--- a/ic-os/bootloader/hostos_grub.cfg
+++ b/ic-os/bootloader/hostos_grub.cfg
@@ -84,22 +84,15 @@ menuentry "Boot System ${boot_alternative} (${BOOT_STATE})" {
     if [ -f "${boot}/boot_args" ]; then
         echo "Loading boot args ${boot}/boot_args"
         source "${boot}/boot_args"
-        # Use the appropriate boot args based on boot_alternative
         if [ "${boot_alternative}" = "A" ]; then
-            if [ -z "${BOOT_ARGS_A}" ]; then
-                echo "Error: BOOT_ARGS_A is not defined in ${boot}/boot_args"
-                exit 1
-            fi
-            echo "Boot arguments: ${BOOT_ARGS_A}"
-            linux /vmlinuz $BOOT_ARGS_A
+            BOOT_ARGS="${BOOT_ARGS_A}"
         else
-            if [ -z "${BOOT_ARGS_B}" ]; then
-                echo "Error: BOOT_ARGS_B is not defined in ${boot}/boot_args"
-                exit 1
-            fi
-            echo "Boot arguments: ${BOOT_ARGS_B}"
-            linux /vmlinuz $BOOT_ARGS_B
+            BOOT_ARGS="${BOOT_ARGS_B}"
         fi
+        echo "Boot arguments: ${BOOT_ARGS}"
+
+        # NODE PROVIDERS: In the event of a manual recovery, add the necessary recovery boot parameters here:
+        linux /vmlinuz $BOOT_ARGS
     fi
 
     if [ -f ${boot}/initrd.img ]; then


### PR DESCRIPTION
NODE-1710

`hostos_grub.cfg` will be edited by node providers in the event of a manual recovery. To make it easier for node providers, the two `linux` commands have been consolidated into a single call. This way, node providers will only have one command to update a single command with the recovery boot parameters.

Unfortunately, for this change to reach mainnet, we will have to bring back the grub-upgrader component and roll out a HostOS upgrade to update the `hostos_grub.cfg`

Updated grub:
<img width="898" height="602" alt="getparans 'Boot Systen A (stable)'" src="https://github.com/user-attachments/assets/b64eb036-fddd-4507-aaa7-dd11143eb5f7" />
<img width="885" height="621" alt="version 2 12" src="https://github.com/user-attachments/assets/d7c215cc-9749-4b52-bdd3-a71b8c0e7c90" />
