### PR TITLE
chore: Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23258,11 +23258,8 @@ dependencies = [
  "nested",
  "nns_dapp",
  "os_qualification_utils",
- "reqwest 0.12.15",
- "serde",
  "serde_json",
  "slog",
- "url",
  "xrc-mock",
 ]
 

--- a/rs/tests/testnets/Cargo.toml
+++ b/rs/tests/testnets/Cargo.toml
@@ -19,11 +19,8 @@ ic_nested_nns_recovery_common = { path = "../nested/nns_recovery" }
 nested = { path = "../nested" }
 nns_dapp = { path = "../nns/nns_dapp" }
 os_qualification_utils = { path = "../dre/utils" }
-reqwest = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true }
-url = { workspace = true }
 xrc-mock = { path = "../../rosetta-api/tvl/xrc_mock" }
 
 [[bin]]


### PR DESCRIPTION
Remove some unused dependencies from `rs/tests/testnets/Cargo.toml`. The corresponding `BUILD.bazel` file does not have the dependencies (`reqwest`, `url`, `serde`), so it's not necessary to update it.