### PR TITLE
chore: parallelize //rs/tests/networking:read_state_test

### DIFF
--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -66,7 +66,7 @@ use ic_system_test_driver::util::{
 };
 use ic_system_test_driver::{
     driver::{
-        group::SystemTestGroup,
+        group::{SystemTestGroup, SystemTestSubGroup},
         ic::InternetComputer,
         test_env::TestEnv,
         test_env_api::{HasPublicApiUrl, HasTopologySnapshot, IcNodeContainer, IcNodeSnapshot},
@@ -953,8 +953,7 @@ macro_rules! systest_all_variants {
 }
 
 fn main() -> Result<()> {
-    let mut group = SystemTestGroup::new()
-        .with_setup(setup)
+    let mut parallel_group = SystemTestSubGroup::new()
         .add_test(systest!(test_non_utf8_metadata))
         .add_test(systest!(test_subnet_canister_ranges_paths; read_state::subnet::Version::V2))
         .add_test(systest!(test_subnet_canister_ranges_paths; read_state::subnet::Version::V3))
@@ -981,12 +980,15 @@ fn main() -> Result<()> {
         .add_test(systest!(test_metadata_path; read_state::canister::Version::V2))
         .add_test(systest!(test_metadata_path; read_state::canister::Version::V3));
 
-    systest_all_variants!(group, test_empty_paths_return_time);
-    systest_all_variants!(group, test_time_path_returns_time);
-    systest_all_variants!(group, test_subnet_path);
-    systest_all_variants!(group, test_invalid_request_rejected);
-    systest_all_variants!(group, test_invalid_path_rejected);
+    systest_all_variants!(parallel_group, test_empty_paths_return_time);
+    systest_all_variants!(parallel_group, test_time_path_returns_time);
+    systest_all_variants!(parallel_group, test_subnet_path);
+    systest_all_variants!(parallel_group, test_invalid_request_rejected);
+    systest_all_variants!(parallel_group, test_invalid_path_rejected);
 
-    group.execute_from_args()?;
+    SystemTestGroup::new()
+        .with_setup(setup)
+        .add_parallel(parallel_group)
+        .execute_from_args()?;
     Ok(())
 }


### PR DESCRIPTION
The P90 duration of the `//rs/tests/networking:read_state_test` is 5m 35s from last week onwards which is longer than the maximum allowed of 5 minutes. Let's speed it up by running all tests in parallel.