### PR TITLE
perf(crypto): CRP-2929 In tECDSA using variable time inversions where possible

### DIFF
--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/signing/ecdsa.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/signing/ecdsa.rs
@@ -333,7 +333,7 @@ impl ThresholdEcdsaCombinedSigInternal {
         let numerator = coefficients.interpolate_scalar(&numerator_samples)?;
         let denominator = coefficients.interpolate_scalar(&denominator_samples)?;
 
-        let denominator_inv = match denominator.invert() {
+        let denominator_inv = match denominator.invert_vartime() {
             Some(s) => s,
             None => return Err(CanisterThresholdError::InterpolationError),
         };
@@ -404,7 +404,7 @@ impl ThresholdEcdsaCombinedSigInternal {
         let public_key = tweak_g.add_points(&master_public_key)?;
 
         // This return shouldn't happen because we already checked that s != 0 above
-        let s_inv = match self.s.invert() {
+        let s_inv = match self.s.invert_vartime() {
             Some(si) => si,
             None => return Err(CanisterThresholdError::InvalidSignature),
         };

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/utils/group.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/utils/group.rs
@@ -199,6 +199,20 @@ impl EccScalar {
         }
     }
 
+    /// Compute the modular inverse of Self
+    ///
+    /// This function may leak the value of self to side channels, and should only
+    /// be used for public inputs
+    ///
+    /// Returns None if self is equal to zero
+    pub fn invert_vartime(&self) -> Option<Self> {
+        match self {
+            Self::K256(s) => s.invert_vartime().map(Self::K256),
+            Self::P256(s) => s.invert_vartime().map(Self::P256),
+            Self::Ed25519(s) => s.invert_vartime().map(Self::Ed25519),
+        }
+    }
+
     /// Serialize the scalar
     ///
     /// For P-256 and secp256k1 this uses a big-endian encoding.

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/utils/group/ed25519.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/utils/group/ed25519.rs
@@ -250,6 +250,15 @@ impl Scalar {
         Some(Self::new(self.s.invert()))
     }
 
+    /// Perform modular inversion
+    ///
+    /// Returns None if no modular inverse exists (ie because the
+    /// scalar is zero)
+    pub fn invert_vartime(&self) -> Option<Self> {
+        // Currently, Dalek doesn't support a variable time inversion
+        self.invert()
+    }
+
     /// Check if the scalar is zero
     pub fn is_zero(&self) -> bool {
         bool::from(self.s.is_zero())

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/utils/group/secp256k1.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/utils/group/secp256k1.rs
@@ -2,7 +2,7 @@ use hex_literal::hex;
 use k256::elliptic_curve::{
     Field, Group,
     group::{GroupEncoding, ff::PrimeField},
-    ops::{LinearCombination, MulByGenerator, Reduce},
+    ops::{Invert, LinearCombination, MulByGenerator, Reduce},
     scalar::IsHigh,
     sec1::FromEncodedPoint,
 };
@@ -244,6 +244,19 @@ impl Scalar {
     /// scalar is zero)
     pub fn invert(&self) -> Option<Self> {
         let inv = self.s.invert();
+        if bool::from(inv.is_some()) {
+            Some(Self::new(inv.unwrap()))
+        } else {
+            None
+        }
+    }
+
+    /// Perform modular inversion
+    ///
+    /// Returns None if no modular inverse exists (ie because the
+    /// scalar is zero)
+    pub fn invert_vartime(&self) -> Option<Self> {
+        let inv = self.s.invert_vartime();
         if bool::from(inv.is_some()) {
             Some(Self::new(inv.unwrap()))
         } else {

--- a/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/utils/group/secp256r1.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/canister_threshold_sig/src/utils/group/secp256r1.rs
@@ -2,7 +2,7 @@ use hex_literal::hex;
 use p256::elliptic_curve::{
     Field, Group,
     group::{GroupEncoding, ff::PrimeField},
-    ops::{LinearCombination, Reduce},
+    ops::{Invert, LinearCombination, Reduce},
     scalar::IsHigh,
     sec1::FromEncodedPoint,
 };
@@ -146,6 +146,19 @@ impl Scalar {
     /// scalar is zero)
     pub fn invert(&self) -> Option<Self> {
         let inv = self.s.invert();
+        if bool::from(inv.is_some()) {
+            Some(Self::new(inv.unwrap()))
+        } else {
+            None
+        }
+    }
+
+    /// Perform modular inversion
+    ///
+    /// Returns None if no modular inverse exists (ie because the
+    /// scalar is zero)
+    pub fn invert_vartime(&self) -> Option<Self> {
+        let inv = self.s.invert_vartime();
         if bool::from(inv.is_some()) {
             Some(Self::new(inv.unwrap()))
         } else {


### PR DESCRIPTION
In some cases a modular inversion is required on an input which is anyway public; namely during signature verification and also share recombination. In this case it is not necessary for the inversion to be constant time, since there is no concern of side channels.