### PR TITLE
refactor(governance): Use slightly more authoritative source of Subnet Rental canister API types.

### DIFF
--- a/rs/nns/governance/src/proposals/fulfill_subnet_rental_request.rs
+++ b/rs/nns/governance/src/proposals/fulfill_subnet_rental_request.rs
@@ -149,8 +149,12 @@ impl FulfillSubnetRentalRequest {
                 )
             })?;
 
-        // TODO(NNS1-3965): Source definition from an official Subnet Rental
-        // canister library.
+        // This is a partial copy n' paste from the subnet-rental-canister repo.
+        // Trying to depend on that creates a bunch of headaches, and maybe
+        // requires a different set of hack(s). In particular, it slightly grows
+        // the sizes of a couple of wasms. Therefore, leaving this piece of
+        // "code schrapnel in the body" seems like the least harmful thing, but
+        // if you find a way to do it, more power to you.
         #[derive(CandidType, Deserialize, Serialize)]
         struct RentalRequest {
             user: Principal,
@@ -328,8 +332,12 @@ impl FulfillSubnetRentalRequest {
         let proposal_id = proposal_id.id;
 
         // Assemble the request.
-        // TODO(NNS1-3965): Source definition from an official Subnet Rental
-        // canister library.
+        // This is a partial copy n' paste from the subnet-rental-canister repo.
+        // Trying to depend on that creates a bunch of headaches, and maybe
+        // requires a different set of hack(s). In particular, it slightly grows
+        // the sizes of a couple of wasms. Therefore, leaving this piece of
+        // "code schrapnel in the body" seems like the least harmful thing, but
+        // if you find a way to do it, more power to you.
         #[derive(CandidType, Deserialize, Serialize)]
         struct CreateRentalAgreementPayload {
             user: Principal,

--- a/rs/tests/driver/src/nns.rs
+++ b/rs/tests/driver/src/nns.rs
@@ -11,7 +11,7 @@ use crate::{
     driver::test_env_api::{HasPublicApiUrl, IcNodeContainer, IcNodeSnapshot, TopologySnapshot},
     util::{create_agent, runtime_from_url},
 };
-use candid::{CandidType, Deserialize, Principal};
+use candid::CandidType;
 use canister_test::{Canister, Runtime};
 use cycles_minting_canister::{
     ChangeSubnetTypeAssignmentArgs, SetAuthorizedSubnetworkListArgs, SubnetListWithType,
@@ -29,6 +29,7 @@ use ic_nns_governance_api::{
     ProposalStatus, Vote,
     manage_neuron::{Command, NeuronIdOrSubaccount, RegisterVote},
     manage_neuron_response,
+    subnet_rental::{RentalConditionId, SubnetRentalRequest},
 };
 use ic_nns_test_utils::governance::{
     get_proposal_info, submit_external_update_proposal,
@@ -482,24 +483,10 @@ pub async fn execute_subnet_rental_request(
     topology_snapshot: &TopologySnapshot,
     user: PrincipalId,
 ) {
-    // TODO(NNS1-3965): Replace.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, CandidType, Deserialize, Hash)]
-    pub enum RentalConditionId {
-        App13CH,
-    }
-
-    #[derive(Clone, CandidType, Deserialize)]
-    pub struct SubnetRentalProposalPayload {
-        pub user: Principal,
-        pub rental_condition_id: RentalConditionId,
-    }
-
-    let user = Principal::from(user);
-
     execute_nns_function(
         topology_snapshot,
         NnsFunction::SubnetRentalRequest,
-        SubnetRentalProposalPayload {
+        SubnetRentalRequest {
             user,
             rental_condition_id: RentalConditionId::App13CH,
         },


### PR DESCRIPTION
I tried (in [PR 6722]) sourcing the definition of these types from the [subnet-rental-canister repo][src] (the true authoritative source), but that created various headaches. The headache that convinced me to abandon the aforementioned PR was how it increased the size of the NNS Governance WASM. The increase was not massive, but since that PR doesn't even add any new features, I doesn't seem worthwhile to further eat into our head room.

[PR 6722]: https://github.com/dfinity/ic/pull/6722

[src]: https://github.com/dfinity/subnet-rental-canister