### PR TITLE
fix: repro-check due to unset BAZEL_BUILD_INVOCATION_ID

### DIFF
--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -144,7 +144,7 @@ if "$BUILD_IMG"; then BAZEL_TARGETS+=(
 echo_blue "Bazel targets: ${BAZEL_TARGETS[*]}"
 
 # Only add invocation if specified by the environment variable
-if [ -z "$BAZEL_BUILD_INVOCATION_ID" ]; then
+if [ -n "${BAZEL_BUILD_INVOCATION_ID:-}" ]; then
     BAZEL_COMMON_ARGS+=(--invocation_id="$BAZEL_BUILD_INVOCATION_ID")
 fi
 


### PR DESCRIPTION
This will fix the [broken](https://github.com/dfinity/ic/actions/runs/17785505383/job/50554438749#step:5:79) `repro-check` job of the `Release Testing` workflow.

