### PR TITLE
feat: Whitelist migration canister to call registry endpoint

### DIFF
--- a/rs/nns/canister_ids.json
+++ b/rs/nns/canister_ids.json
@@ -58,5 +58,9 @@
   "node-rewards": {
     "local": "sgymv-uiaaa-aaaaa-aaaia-cai",
     "mainnet": "sgymv-uiaaa-aaaaa-aaaia-cai"
+  },
+  "migration": {
+    "local": "sbzkb-zqaaa-aaaaa-aaaiq-cai",
+    "mainnet": "sbzkb-zqaaa-aaaaa-aaaiq-cai"
   }
 }

--- a/rs/nns/canister_ids.json
+++ b/rs/nns/canister_ids.json
@@ -58,9 +58,5 @@
   "node-rewards": {
     "local": "sgymv-uiaaa-aaaaa-aaaia-cai",
     "mainnet": "sgymv-uiaaa-aaaaa-aaaia-cai"
-  },
-  "migration": {
-    "local": "sbzkb-zqaaa-aaaaa-aaaiq-cai",
-    "mainnet": "sbzkb-zqaaa-aaaaa-aaaiq-cai"
   }
 }

--- a/rs/nns/constants/src/lib.rs
+++ b/rs/nns/constants/src/lib.rs
@@ -32,6 +32,7 @@ pub const SUBNET_RENTAL_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 13;
 pub const ICP_LEDGER_ARCHIVE_2_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 14;
 pub const ICP_LEDGER_ARCHIVE_3_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 15;
 pub const NODE_REWARDS_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 16;
+pub const MIGRATION_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 17;
 // Exchange Rate, Cycles Ledger (Index) Canisters are deployed to the II subnet.
 pub const EXCHANGE_RATE_CANISTER_INDEX: u64 = 0x2100001;
 pub const CYCLES_LEDGER_CANISTER_INDEX: u64 = 0x2100002;
@@ -51,7 +52,7 @@ pub const SNS_AGGREGATOR_CANISTER_INDEX: u64 = 0x2000010;
 /// run when creating a new net (e.g. mainnet, or testnet). For whatever reason,
 /// that doesn't need ledger archive, nor ledger index. (I guess because those
 /// are spawned by ledger.) Thus, they are not included.
-pub const NNS_CANISTER_WASMS: [&str; 13] = [
+pub const NNS_CANISTER_WASMS: [&str; 14] = [
     "registry-canister",
     "governance-canister",
     "governance-canister_test",
@@ -66,6 +67,7 @@ pub const NNS_CANISTER_WASMS: [&str; 13] = [
     "sns-wasm-canister",
     "ic-icrc1-ledger",
     "ic-ckbtc-minter",
+    "migration-canister",
 ];
 
 /// WARNING: This count is incomplete. See comments on NNS_CANISTER_WASMS.
@@ -123,6 +125,9 @@ pub const ICP_LEDGER_ARCHIVE_3_CANISTER_ID: CanisterId =
 // 16: sgymv-uiaaa-aaaaa-aaaia-cai
 pub const NODE_REWARDS_CANISTER_ID: CanisterId =
     CanisterId::from_u64(NODE_REWARDS_CANISTER_INDEX_IN_NNS_SUBNET);
+// 17: sbzkb-zqaaa-aaaaa-aaaiq-cai
+pub const MIGRATION_CANISTER_ID: CanisterId =
+    CanisterId::from_u64(MIGRATION_CANISTER_INDEX_IN_NNS_SUBNET);
 /// 0x2_100_001 (34_603_009): uf6dk-hyaaa-aaaaq-qaaaq-cai
 pub const EXCHANGE_RATE_CANISTER_ID: CanisterId =
     CanisterId::from_u64(EXCHANGE_RATE_CANISTER_INDEX);
@@ -147,7 +152,7 @@ pub const SNS_AGGREGATOR_CANISTER_ID: CanisterId =
 ///
 /// As of May 2024, it looks like this is only used by (a whole bunch of) tests, mostly as the
 /// argument to send_whitelist.
-pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 17] = [
+pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 18] = [
     &REGISTRY_CANISTER_ID,
     &GOVERNANCE_CANISTER_ID,
     &LEDGER_CANISTER_ID,
@@ -165,9 +170,10 @@ pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 17] = [
     &ICP_LEDGER_ARCHIVE_2_CANISTER_ID,
     &ICP_LEDGER_ARCHIVE_3_CANISTER_ID,
     &NODE_REWARDS_CANISTER_ID,
+    &MIGRATION_CANISTER_ID,
 ];
 
-pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 19] = [
+pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 20] = [
     &REGISTRY_CANISTER_ID,
     &GOVERNANCE_CANISTER_ID,
     &LEDGER_CANISTER_ID,
@@ -182,6 +188,7 @@ pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 19] = [
     &ICP_LEDGER_ARCHIVE_2_CANISTER_ID,
     &ICP_LEDGER_ARCHIVE_3_CANISTER_ID,
     &NODE_REWARDS_CANISTER_ID,
+    &MIGRATION_CANISTER_ID,
     &EXCHANGE_RATE_CANISTER_ID,
     &BITCOIN_MAINNET_CANISTER_ID,
     &BITCOIN_TESTNET_CANISTER_ID,
@@ -239,12 +246,13 @@ pub fn canister_id_to_nns_canister_name(canister_id: CanisterId) -> String {
         ROOT_CANISTER_ID                 => "root",
         SNS_WASM_CANISTER_ID             => "sns-wasm",
         SUBNET_RENTAL_CANISTER_ID        => "subnet-rental",
+        MIGRATION_CANISTER_ID            => "migration"
     };
     debug_assert_eq!(
         id_to_name.len(),
         // Because 0 through 14 accounts for the first 15 canister +
         // 1 for exchange rate canister.
-        18,
+        19,
         "{id_to_name:#?}"
     );
 

--- a/rs/nns/constants/src/lib.rs
+++ b/rs/nns/constants/src/lib.rs
@@ -52,7 +52,7 @@ pub const SNS_AGGREGATOR_CANISTER_INDEX: u64 = 0x2000010;
 /// run when creating a new net (e.g. mainnet, or testnet). For whatever reason,
 /// that doesn't need ledger archive, nor ledger index. (I guess because those
 /// are spawned by ledger.) Thus, they are not included.
-pub const NNS_CANISTER_WASMS: [&str; 14] = [
+pub const NNS_CANISTER_WASMS: [&str; 13] = [
     "registry-canister",
     "governance-canister",
     "governance-canister_test",
@@ -67,7 +67,6 @@ pub const NNS_CANISTER_WASMS: [&str; 14] = [
     "sns-wasm-canister",
     "ic-icrc1-ledger",
     "ic-ckbtc-minter",
-    "migration-canister",
 ];
 
 /// WARNING: This count is incomplete. See comments on NNS_CANISTER_WASMS.
@@ -152,7 +151,7 @@ pub const SNS_AGGREGATOR_CANISTER_ID: CanisterId =
 ///
 /// As of May 2024, it looks like this is only used by (a whole bunch of) tests, mostly as the
 /// argument to send_whitelist.
-pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 18] = [
+pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 17] = [
     &REGISTRY_CANISTER_ID,
     &GOVERNANCE_CANISTER_ID,
     &LEDGER_CANISTER_ID,
@@ -170,10 +169,9 @@ pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 18] = [
     &ICP_LEDGER_ARCHIVE_2_CANISTER_ID,
     &ICP_LEDGER_ARCHIVE_3_CANISTER_ID,
     &NODE_REWARDS_CANISTER_ID,
-    &MIGRATION_CANISTER_ID,
 ];
 
-pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 20] = [
+pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 19] = [
     &REGISTRY_CANISTER_ID,
     &GOVERNANCE_CANISTER_ID,
     &LEDGER_CANISTER_ID,
@@ -188,7 +186,6 @@ pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 20] = [
     &ICP_LEDGER_ARCHIVE_2_CANISTER_ID,
     &ICP_LEDGER_ARCHIVE_3_CANISTER_ID,
     &NODE_REWARDS_CANISTER_ID,
-    &MIGRATION_CANISTER_ID,
     &EXCHANGE_RATE_CANISTER_ID,
     &BITCOIN_MAINNET_CANISTER_ID,
     &BITCOIN_TESTNET_CANISTER_ID,
@@ -246,13 +243,12 @@ pub fn canister_id_to_nns_canister_name(canister_id: CanisterId) -> String {
         ROOT_CANISTER_ID                 => "root",
         SNS_WASM_CANISTER_ID             => "sns-wasm",
         SUBNET_RENTAL_CANISTER_ID        => "subnet-rental",
-        MIGRATION_CANISTER_ID            => "migration"
     };
     debug_assert_eq!(
         id_to_name.len(),
         // Because 0 through 14 accounts for the first 15 canister +
         // 1 for exchange rate canister.
-        19,
+        18,
         "{id_to_name:#?}"
     );
 

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -7,7 +7,7 @@ use dfn_core::{
 use ic_base_types::{NodeId, PrincipalId};
 use ic_certified_map::{AsHashTree, HashTree};
 use ic_nervous_system_string::clamp_debug_len;
-use ic_nns_constants::{GOVERNANCE_CANISTER_ID, ROOT_CANISTER_ID};
+use ic_nns_constants::{GOVERNANCE_CANISTER_ID, MIGRATION_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_protobuf::registry::{
     dc::v1::{AddOrRemoveDataCentersProposalPayload, DataCenterRecord},
     node_operator::v1::NodeOperatorRecord,
@@ -127,10 +127,9 @@ fn check_caller_is_governance_and_log(method_name: &str) {
 fn check_caller_is_canister_migration_orchestrator_and_log(method_name: &str) {
     let caller = dfn_core::api::caller();
     println!("{LOG_PREFIX}call: {method_name} from: {caller}");
-    // TODO - change GOVERNANCE_CANISTER to the new canister when the constant is available.
     assert_eq!(
         caller,
-        GOVERNANCE_CANISTER_ID.into(),
+        MIGRATION_CANISTER_ID.into(),
         "{LOG_PREFIX}Principal: {caller} is not authorized to call this method: {method_name}"
     );
 }

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -9,6 +9,8 @@ on the process that this file is part of, see
 
 ## Added
 
+- Whitelisted the migration canister to call `migrate_canisters`
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
The migration canister [was added to the NNS](https://dashboard.internetcomputer.org/proposal/138487), resulting in a [definitive canister ID](http://[2001:1ab9:f002:5:6801:63ff:feb7:7ad7]:8080/_/dashboard). This PR whitelists that new canister ID to call the registry canister endpoint for canister migration. 