### PR TITLE
chore: do not label mainnet revision PRs with CI_ALL_BAZEL_TARGETS

### DIFF
--- a/ci/src/mainnet_revisions/mainnet_revisions.py
+++ b/ci/src/mainnet_revisions/mainnet_revisions.py
@@ -97,8 +97,6 @@ def commit_and_create_pr(
                     description,
                     "--title",
                     commit_message,
-                    "--label",
-                    "CI_ALL_BAZEL_TARGETS",
                 ],
                 cwd=repo_root,
             )


### PR DESCRIPTION
Labelling a PR with `CI_ALL_BAZEL_TARGETS` is expensive in terms of time and number of vCPUs used. Since we have [quite a number](https://github.com/dfinity/ic/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Fpr-creation-bot-dfinity-ic+label%3ACI_ALL_BAZEL_TARGETS) of automatic PRs changing the `mainnet-*-revisions.json` files which are automatically labelled with `CI_ALL_BAZEL_TARGETS` our CI metrics are worse than necessary (IMHO). 

Let's experiment with not labelling them with `CI_ALL_BAZEL_TARGETS` and see if that causes any issues. If so, we could consider adding certain long_tests to [`PULL_REQUEST_BAZEL_TARGETS`](https://github.com/dfinity/ic/blob/master/PULL_REQUEST_BAZEL_TARGETS) when `mainnet-*-revisions.json` files are changed.

Note that when `mainnet-*-revisions.json` files are modified we do already [automatically test all targets](https://github.com/dfinity/ic/blob/master/ci/bazel-scripts/targets.py#L55) (`//...`).
