### PR TITLE
fix: spelling error in schedule-daily

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -101,7 +101,7 @@ jobs:
           launch_bare_metal "${{ fromJSON(steps.gen-uuids.outputs.output).benchmark_id }}" --benchmark
 
           # Run bare metal node hostOS metrics check
-          launch_bare_metal "${{ fromJSON(steps.gen-uuids.output.output).hostos_metrics_id }}" --check_hostos_metrics
+          launch_bare_metal "${{ fromJSON(steps.gen-uuids.outputs.output).hostos_metrics_id }}" --check_hostos_metrics
 
           bazel clean
         env:

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -70,7 +70,7 @@ jobs:
           launch_bare_metal "${{ fromJSON(steps.gen-uuids.outputs.output).benchmark_id }}" --benchmark
 
           # Run bare metal node hostOS metrics check
-          launch_bare_metal "${{ fromJSON(steps.gen-uuids.output.output).hostos_metrics_id }}" --check_hostos_metrics
+          launch_bare_metal "${{ fromJSON(steps.gen-uuids.outputs.output).hostos_metrics_id }}" --check_hostos_metrics
 
           bazel clean
         env:


### PR DESCRIPTION
This fixes the [broken](https://github.com/dfinity/ic/actions/runs/17782650527/job/50544507906) schedule-daily workflow.