### PR TITLE
chore: use a function instead of a for-loop in bazel-test-all

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -275,8 +275,6 @@ jobs:
             bazel_do build "${{ fromJSON(steps.gen-uuids.outputs.output).build_id }}"
             bazel_do test "${{ fromJSON(steps.gen-uuids.outputs.output).test_id }}"
 
-            done
-
       - name: Upload to S3
         uses: ./.github/actions/upload-artifacts
         if: needs.config.outputs.release-build == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -243,8 +243,6 @@ jobs:
 
             bazel_do build "${{ fromJSON(steps.gen-uuids.outputs.output).build_id }}"
             bazel_do test "${{ fromJSON(steps.gen-uuids.outputs.output).test_id }}"
-
-            done
       - name: Upload to S3
         uses: ./.github/actions/upload-artifacts
         if: needs.config.outputs.release-build == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
We would like to start doing stuff between the `bazel build` and `bazel test` like uploading images to our bazel cache and uploading artifacts to S3 (in parallel with `bazel test`). To make this easier to implement we replace the for loop over `build` and `test` with a `bazel_do` function which is applied to `build` and then to `test`.