### PR TITLE
chore(crypto): CRP-2928 Fix some formatting errors introduced in Rust 2024 Edition conversion

### DIFF
--- a/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_server.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/remote_csp_vault/tarpc_csp_vault_server.rs
@@ -98,9 +98,10 @@ where
             return;
         }
         let result = job();
-        let _ = tx.send(result); // Errors occur if the associated receiver
-        // handle was dropped and are considered
+
+        // Errors occur if the associated receiver handle was dropped and are considered
         // legitimate and are thus ignored.
+        let _ = tx.send(result);
     });
     rx.await.expect("the sender was dropped")
 }

--- a/rs/crypto/internal/crypto_service_provider/src/vault/test_utils/ni_dkg/fixtures.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/vault/test_utils/ni_dkg/fixtures.rs
@@ -245,9 +245,13 @@ impl MockDkgConfig {
         let dkg_id = random_ni_dkg_id(rng);
         let max_corrupt_dealers = rng.gen_range(0..num_dealers); // Need at least one honest dealer.
         let threshold = rng.gen_range(min_threshold..=num_receivers); // threshold <= num_receivers
+
         let max_corrupt_receivers =
-            rng.gen_range(0..std::cmp::min(num_receivers + 1 - threshold, threshold)); // (max_corrupt_receivers <= num_receivers - threshold) &&
-        // (max_corrupt_receivers < threshold)
+            rng.gen_range(0..std::cmp::min(num_receivers + 1 - threshold, threshold));
+
+        assert!(max_corrupt_receivers <= num_receivers - threshold);
+        assert!(max_corrupt_receivers < threshold);
+
         let epoch = Epoch::from(rng.r#gen::<u32>());
 
         let receiver_keys: BTreeMap<NodeIndex, CspFsEncryptionPublicKey> = receivers

--- a/rs/crypto/node_key_validation/src/tests.rs
+++ b/rs/crypto/node_key_validation/src/tests.rs
@@ -275,8 +275,8 @@ mod committee_signing_public_key_validation {
     fn should_fail_if_committee_signing_key_pubkey_is_corrupted() {
         let corrupted_committee_signing_key = {
             let mut public_key = valid_committee_signing_public_key();
-            public_key.key_value[0] ^= 0xff; // this flips the compression flag and thus
-            // makes the encoding of the point invalid
+            // this flips the compression flag and thus makes the encoding of the point invalid
+            public_key.key_value[0] ^= 0xff;
             public_key
         };
 

--- a/rs/crypto/src/sign/threshold_sig/ni_dkg/transcript/tests.rs
+++ b/rs/crypto/src/sign/threshold_sig/ni_dkg/transcript/tests.rs
@@ -572,8 +572,7 @@ mod load_transcript {
                 *algorithm_id == AlgorithmId::NiDkg_Groth20_Bls12_381
                     && *epoch_ == epoch(REG_V1)
                     && *transcript == csp_transcript
-                    && *receiver_index == 2 // index of NODE_3 in (sorted)
-                // resharing committee
+                    && *receiver_index == 2 // index of NODE_3 in (sorted) resharing committee
             })
             .times(1)
             .return_const(Ok(()));

--- a/rs/types/types/src/crypto/threshold_sig/ni_dkg/transcripts_to_retain.rs
+++ b/rs/types/types/src/crypto/threshold_sig/ni_dkg/transcripts_to_retain.rs
@@ -41,12 +41,13 @@ impl TranscriptsToRetain {
 
     /// Returns the minimum registry version of all transcripts
     pub fn min_registry_version(&self) -> RegistryVersion {
+        // This unwrap never panics because the invariants ensure that
+        // there are at least two elements in `transcripts`.
         self.transcripts
             .iter()
             .map(|t| t.registry_version)
             .min()
-            .unwrap() // This never panics because the invariants ensure that
-        // there are at least two elements in `transcripts`.
+            .unwrap()
     }
 
     /// Returns a string representation of `TranscriptsToRetain`. Can be used


### PR DESCRIPTION
Previously the Rust formatting rules incorrectly assumed that any comments on a line following an item with a trailing comment should always be indented to match the trailing comment.

This is fixed in the Rust 2024 edition; now the formatter incorrectly assumes that any comments on a line following an item with a trailing comment should never be indented to match the trailing comment.

Progress.