### PR TITLE
fix: let //pre-commit:buf-breaking use the default medium size

### DIFF
--- a/pre-commit/BUILD.bazel
+++ b/pre-commit/BUILD.bazel
@@ -219,7 +219,6 @@ sh_binary(
 
 sh_test(
     name = "buf-breaking",
-    size = "small",
     srcs = ["check-incompatibilities.sh"],
     data = [
         "//:WORKSPACE.bazel",


### PR DESCRIPTION
`//pre-commit:buf-breaking` is occasionally flaking or failing due to the 1 minute timeout. So let's remove `size = "small"` to use the default `medium` size which sets a 5 minute timeout.