### PR TITLE
fix: publish pocket-ic-server arm64 gzipped binaries to the correct path

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -451,14 +451,14 @@ jobs:
         with:
           name: pocket-ic-server-arm64-linux.gz
           # avoid downloading to workspace to avoid version being marked as dirty
-          path: ~/.cache/pocket-ic-server-arm64-linux.gz
+          path: ~/.cache/pocket-ic-server-arm64-linux
 
       - name: Download pocket-ic-server (arm64-darwin)
         uses: actions/download-artifact@v4
         with:
           name: pocket-ic-server-arm64-darwin.gz
           # avoid downloading to workspace to avoid version being marked as dirty
-          path: ~/.cache/pocket-ic-server-arm64-darwin.gz
+          path: ~/.cache/pocket-ic-server-arm64-darwin
 
       - name: Prepare bundle
         id: prepare-bundle
@@ -467,10 +467,10 @@ jobs:
 
             # Create a "bundle" that the uploader can digest
             mkdir -p "$bundledir/binaries/arm64-linux/"
-            cp ~/.cache/pocket-ic-server-arm64-linux.gz "$bundledir/binaries/arm64-linux/pocket-ic.gz"
+            cp ~/.cache/pocket-ic-server-arm64-linux/pocket-ic-server-arm64-linux.gz "$bundledir/binaries/arm64-linux/pocket-ic.gz"
 
             mkdir -p "$bundledir/binaries/arm64-darwin/"
-            cp ~/.cache/pocket-ic-server-arm64-darwin.gz "$bundledir/binaries/arm64-darwin/pocket-ic.gz"
+            cp ~/.cache/pocket-ic-server-arm64-darwin/pocket-ic-server-arm64-darwin.gz "$bundledir/binaries/arm64-darwin/pocket-ic.gz"
 
             echo bundledir="$bundledir" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -418,13 +418,13 @@ jobs:
         with:
           name: pocket-ic-server-arm64-linux.gz
           # avoid downloading to workspace to avoid version being marked as dirty
-          path: ~/.cache/pocket-ic-server-arm64-linux.gz
+          path: ~/.cache/pocket-ic-server-arm64-linux
       - name: Download pocket-ic-server (arm64-darwin)
         uses: actions/download-artifact@v4
         with:
           name: pocket-ic-server-arm64-darwin.gz
           # avoid downloading to workspace to avoid version being marked as dirty
-          path: ~/.cache/pocket-ic-server-arm64-darwin.gz
+          path: ~/.cache/pocket-ic-server-arm64-darwin
       - name: Prepare bundle
         id: prepare-bundle
         run: |
@@ -432,10 +432,10 @@ jobs:
 
           # Create a "bundle" that the uploader can digest
           mkdir -p "$bundledir/binaries/arm64-linux/"
-          cp ~/.cache/pocket-ic-server-arm64-linux.gz "$bundledir/binaries/arm64-linux/pocket-ic.gz"
+          cp ~/.cache/pocket-ic-server-arm64-linux/pocket-ic-server-arm64-linux.gz "$bundledir/binaries/arm64-linux/pocket-ic.gz"
 
           mkdir -p "$bundledir/binaries/arm64-darwin/"
-          cp ~/.cache/pocket-ic-server-arm64-darwin.gz "$bundledir/binaries/arm64-darwin/pocket-ic.gz"
+          cp ~/.cache/pocket-ic-server-arm64-darwin/pocket-ic-server-arm64-darwin.gz "$bundledir/binaries/arm64-darwin/pocket-ic.gz"
 
           echo bundledir="$bundledir" >> "$GITHUB_OUTPUT"
       - name: Upload


### PR DESCRIPTION
arm64 pocket-ics were [uploaded](https://github.com/dfinity/ic/actions/runs/17647086960/job/50165812494#step:7:182) to:

* `ic/$rev/binaries/arm64-linux/pocket-ic-server-arm64-linux`
* `ic/$rev/binaries/arm64-darwin/pocket-ic-server-arm64-darwin`

However `Publish Release` [expects](https://github.com/dfinity/ic/actions/runs/17678023313/job/50244961227#step:3:26) them at: `ic/$rev/binaries/arm64-linux/pocket-ic.gz`.

This is fixed by letting `upload-external-artifacts` upload the gzipped pocket-ic-server binaries to the path expected by `Publish Release`.
