### PR TITLE
fix: correct place for invocation id

### DIFF
--- a/.github/workflows-source/schedule-daily.yml
+++ b/.github/workflows-source/schedule-daily.yml
@@ -83,7 +83,7 @@ jobs:
 
             # shellcheck disable=SC2046,SC2086
             bazel --output_base=/var/tmp/bazel-output run \
-                 --invocation_id="$invocation_id" \
+              --invocation_id="$invocation_id" \
               //ic-os/setupos/envs/dev:launch_bare_metal -- \
                 --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
                 --csv_filename "$(realpath file1)" \

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -52,13 +52,13 @@ jobs:
 
             # shellcheck disable=SC2046,SC2086
             bazel --output_base=/var/tmp/bazel-output run \
+              --invocation_id="$invocation_id" \
               //ic-os/setupos/envs/dev:launch_bare_metal -- \
                 --config_path "$(realpath  ./ic-os/dev-tools/bare_metal_deployment/zh2-dll01.yaml)" \
                 --csv_filename "$(realpath file1)" \
                 --file_share_ssh_key "$(realpath file2)" \
                 --inject_image_pub_key "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3gjE/2K5nxIBbk3ohgs8J5LW+XiObwA+kGtSaF5+4c" \
                 --file_share_username ci_interim \
-                --invocation_id="$invocation_id" \
                 --ci_mode \
                 $@
           }


### PR DESCRIPTION
Fixing the order of arguments as `--invocation_id` is a bazel argument instead of a target argument