### PR TITLE
chore: improved log message in targets.py

### DIFF
--- a/ci/bazel-scripts/targets.py
+++ b/ci/bazel-scripts/targets.py
@@ -120,7 +120,7 @@ def diff_only_query(command: str, base: str, head: str, skip_long_tests: bool) -
         ["git", "diff", "--name-only", "--merge-base", base, head], check=True, capture_output=True, text=True
     ).stdout.splitlines()
 
-    n=len(modified_files)
+    n = len(modified_files)
     log(f"Calculating targets to {command} for the following {n} modified files:")
     for file in modified_files:
         log(file)


### PR DESCRIPTION
This improves the message in `targets.py` to say 
`Calculating targets to build ...` instead of 
`Calculating targets to test ...` when only building targets.