### PR TITLE
feat(nns-recovery): [CON-1588] force `--use-local-binaries` to avoid unnecessary download

### DIFF
--- a/rs/recovery/src/nns_recovery_same_nodes.rs
+++ b/rs/recovery/src/nns_recovery_same_nodes.rs
@@ -108,7 +108,12 @@ impl NNSRecoverySameNodes {
     ) -> Self {
         let recovery = Recovery::new(
             logger.clone(),
-            recovery_args.clone(),
+            RecoveryArgs {
+                // ic-admin is not needed for NNS recovery on same nodes so we force this argument
+                // to true to avoid downloading it.
+                use_local_binaries: true,
+                ..recovery_args.clone()
+            },
             /*neuron_args=*/ None,
             recovery_args.nns_url.clone(),
             RegistryPollingStrategy::OnlyOnInit,


### PR DESCRIPTION
In recoveries, setting `--use-local-binaries` makes `ic-recovery` assume we already have `ic-admin` and avoids downloading it. As `ic-admin` is not used in NNS recoveries, this PR always sets this argument to `true` to never have to download it.