### PR TITLE
fix: set socket timeout on async ssh

### DIFF
--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -2017,7 +2017,7 @@ where
 }
 
 pub fn get_ssh_session_from_env(env: &TestEnv, ip: IpAddr) -> Result<Session> {
-    let tcp = TcpStream::connect_timeout((ip, 22), TCP_CONNECT_TIMEOUT)?;
+    let tcp = TcpStream::connect_timeout(&SocketAddr::new(ip, 22), TCP_CONNECT_TIMEOUT)?;
     let mut sess = Session::new()?;
     sess.set_tcp_stream(tcp);
     sess.handshake()?;


### PR DESCRIPTION
This PR aims to fix a flakiness source of `//rs/tests/nested/nns_recovery:nr_large`.

We are trying to SSH into a rebooting node to overwrite its DNS entry while the recovery upgrader is running to impersonate the upstreams. See [here](https://dash.dm1-idx1.dfinity.network/invocation/efb26d42-ecaf-4e4e-8621-8349c64120a0?target=%2F%2Frs%2Ftests%2Fnested%2Fnns_recovery%3Anr_large&targetStatus=6#1@4953) a first `No route to host` on IP `2602:fb2b:110:10:6800:ffff:fe0b:18a2`. See how a bit more than [two minutes later](https://dash.dm1-idx1.dfinity.network/invocation/efb26d42-ecaf-4e4e-8621-8349c64120a0?target=%2F%2Frs%2Ftests%2Fnested%2Fnns_recovery%3Anr_large&targetStatus=6#1@5470), we get a `Connection timed out` on the same IP. This suggests that the host is up but the TCP socket times out with the [default value of non-blocking sockets](https://man7.org/linux/man-pages/man7/tcp.7.html#:~:text=The%20default%20value%20is%206%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20which%20corresponds%20to%20retrying%20for%20up%20to%20approximately%20127%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20seconds.). The recovery upgrader [times out after 50 seconds](https://github.com/dfinity/ic/blob/ca94383ba3df22dacf7a005186b67303548eb144/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh#L16-L17), so the test fails.

By introducing a timeout on the socket, it will time out after just a few seconds, and the next try will succeed, fixing the flakiness as I reran the test >10 times in #6762 without ever running into the same issue.
