### PR TITLE
chore(node): convert version-hash to a full hash

### DIFF
--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
@@ -63,7 +63,7 @@ prepare_guestos_upgrade() {
 
 download_and_verify_upgrade() {
     local version="$1"
-    local short_hash="$2"
+    local expected_hash="$2"
     local tmpdir="$3"
 
     local base_urls=(
@@ -94,11 +94,10 @@ download_and_verify_upgrade() {
 
     echo "Verifying upgrade image hash..."
     local actual_hash=$(sha256sum "$tmpdir/upgrade.tar.zst" | cut -d' ' -f1)
-    local actual_short_hash=${actual_hash:0:6}
-    if [ "$actual_short_hash" != "$short_hash" ]; then
+    if [ "$actual_hash" != "$expected_hash" ]; then
         echo "ERROR: Hash verification failed"
-        echo "Expected short 6-character hash: $short_hash"
-        echo "Got short 6-character hash: $actual_short_hash"
+        echo "Expected hash: $expected_hash"
+        echo "Got hash: $actual_hash"
         echo "Full hash: $actual_hash"
         return 1
     fi
@@ -180,16 +179,16 @@ main() {
     echo "Starting GuestOS Recovery Upgrader"
 
     VERSION="$(get_cmdline_var version)"
-    SHORT_HASH="$(get_cmdline_var version-hash)"
+    VERSION_HASH="$(get_cmdline_var version-hash)"
 
-    if [ -z "$VERSION" ] || [ -z "$SHORT_HASH" ]; then
-        echo "ERROR: Both version and hash parameters are required"
-        echo "Usage: version=<commit-hash> hash=<first-6-chars-of-sha256>"
+    if [ -z "$VERSION" ] || [ -z "$VERSION_HASH" ]; then
+        echo "ERROR: Both version and version-hash parameters are required"
+        echo "Usage: version=<commit-hash> version-hash=<sha256>"
         exit 1
     fi
 
     echo "Version: $VERSION"
-    echo "Short hash: $SHORT_HASH"
+    echo "Version hash: $VERSION_HASH"
 
     TMPDIR=$(mktemp -d)
     trap 'guestos_upgrade_cleanup; rm -rf "$TMPDIR"' EXIT
@@ -202,7 +201,7 @@ main() {
     while [ $attempt -le $MAX_ATTEMPTS ]; do
         echo "=== Download attempt $attempt/$MAX_ATTEMPTS ==="
 
-        if download_and_verify_upgrade "$VERSION" "$SHORT_HASH" "$TMPDIR"; then
+        if download_and_verify_upgrade "$VERSION" "$VERSION_HASH" "$TMPDIR"; then
             echo "✓ Download and verification completed successfully on attempt $attempt"
             break
         else

--- a/rs/tests/nested/nns_recovery/common.rs
+++ b/rs/tests/nested/nns_recovery/common.rs
@@ -375,7 +375,7 @@ pub fn test(env: TestEnv, cfg: TestConfig) {
                     &env,
                     &vm,
                     RECOVERY_GUESTOS_IMG_VERSION,
-                    &recovery_img_hash[..6],
+                    &recovery_img_hash,
                     &artifacts_hash,
                 )
                 .await
@@ -445,7 +445,7 @@ async fn simulate_node_provider_action(
     env: &TestEnv,
     host: &NestedVm,
     img_version: &str,
-    img_short_hash: &str,
+    img_version_hash: &str,
     artifacts_hash: &str,
 ) {
     let host_boot_id_pre_reboot = get_host_boot_id_async(host).await;
@@ -458,7 +458,7 @@ async fn simulate_node_provider_action(
     );
     let boot_args_command = format!(
         "sudo mount -o remount,rw /boot && sudo sed -i 's/\\(BOOT_ARGS_A=\".*\\)enforcing=0\"/\\1enforcing=0 recovery=1 version={} version-hash={} recovery-hash={}\"/' /boot/boot_args && sudo mount -o remount,ro /boot && sudo reboot",
-        &img_version, &img_short_hash, &artifacts_hash
+        &img_version, &img_version_hash, &artifacts_hash
     );
     host.block_on_bash_script_async(&boot_args_command)
         .await

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -270,11 +270,11 @@ pub fn recovery_upgrader_test(env: TestEnv) {
         info!(logger, "Current boot_args content:\n{}", current_boot_args);
 
         let target_version = get_guestos_update_img_version();
-        let target_short_hash = &get_guestos_update_img_sha256()[..6]; // node providers only expected to input the first 6 characters of the hash
+        let target_version_hash = get_guestos_update_img_sha256();
 
         info!(
             logger,
-            "Using target version: {} and short hash: {}", target_version, target_short_hash
+            "Using target version: {} and version-hash: {}", target_version, target_version_hash
         );
 
         info!(
@@ -282,7 +282,7 @@ pub fn recovery_upgrader_test(env: TestEnv) {
             "Remounting /boot as read-write and updating boot_args file"
         );
         let boot_args_command = format!(
-            "sudo mount -o remount,rw /boot && sudo sed -i 's/\\(BOOT_ARGS_A=\".*\\)enforcing=0\"/\\1enforcing=0 recovery=1 version={target_version} version-hash={target_short_hash}\"/' /boot/boot_args && sudo mount -o remount,ro /boot"
+            "sudo mount -o remount,rw /boot && sudo sed -i 's/\\(BOOT_ARGS_A=\".*\\)enforcing=0\"/\\1enforcing=0 recovery=1 version={target_version} version-hash={target_version_hash}\"/' /boot/boot_args && sudo mount -o remount,ro /boot"
         );
         host.block_on_bash_script(&boot_args_command)
             .expect("Failed to update boot_args file");


### PR DESCRIPTION
NODE-1713
We agreed to use full hashes for the NNS recovery rather than the short six-character hashes