### PR TITLE
feat(nns): Record known neuron votes before clearing ballots

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -12,6 +12,7 @@ use crate::{
         HeapGovernanceData, XdrConversionRate, initialize_governance, reassemble_governance_proto,
         split_governance_proto,
     },
+    is_known_neuron_voting_history_enabled,
     neuron::{DissolveStateAndAge, Neuron, NeuronBuilder, Visibility},
     neuron_data_validation::{NeuronDataValidationSummary, NeuronDataValidator},
     neuron_store::{
@@ -69,7 +70,7 @@ use crate::{
         },
     },
     proposals::{call_canister::CallCanister, sum_weighted_voting_power},
-    storage::VOTING_POWER_SNAPSHOTS,
+    storage::{VOTING_POWER_SNAPSHOTS, with_voting_history_store_mut},
 };
 use async_trait::async_trait;
 use candid::{Decode, Encode};
@@ -6918,6 +6919,8 @@ impl Governance {
             );
         }
 
+        let known_neuron_ids = self.neuron_store.list_known_neuron_ids();
+
         // Mark the proposals that we just considered as "rewarded". More
         // formally, causes their reward_status to be Settled; whereas, before,
         // they were in the ReadyToSettle state.
@@ -6950,7 +6953,8 @@ impl Governance {
                         })
                     };
                     p.reward_event_round = new_reward_event.day_after_genesis;
-                    p.ballots.clear();
+                    let ballots = std::mem::take(&mut p.ballots);
+                    record_known_neuron_abstentions(&known_neuron_ids, *pid, ballots);
                 }
             };
         }
@@ -8252,6 +8256,27 @@ impl From<ic_nervous_system_clients::canister_status::CanisterStatusType>
     }
 }
 
+fn record_known_neuron_abstentions(
+    known_neuron_ids: &[NeuronId],
+    proposal_id: ProposalId,
+    ballots: HashMap<u64, Ballot>,
+) {
+    if is_known_neuron_voting_history_enabled() {
+        for known_neuron_id in known_neuron_ids {
+            if let Some(ballot) = ballots.get(&known_neuron_id.id)
+                && ballot.vote() == Vote::Unspecified
+            {
+                with_voting_history_store_mut(|voting_history_store| {
+                    voting_history_store.record_vote(
+                        *known_neuron_id,
+                        proposal_id,
+                        Vote::Unspecified,
+                    );
+                });
+            }
+        }
+    }
+}
 /// Affects the perception of time by users of CanisterEnv (i.e. Governance).
 ///
 /// Specifically, the time that Governance sees is the real time + delta.

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::storage::with_voting_history_store;
+use crate::temporarily_enable_known_neuron_voting_history;
 use crate::test_utils::MockRandomness;
 use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
@@ -1819,4 +1821,55 @@ fn test_validate_add_or_remove_node_provider() {
         result.is_err(),
         "Expected to fail, but got success: {result:?}"
     );
+}
+
+#[test]
+fn test_record_known_neuron_abstentions() {
+    let _t = temporarily_enable_known_neuron_voting_history();
+
+    record_known_neuron_abstentions(
+        &[NeuronId { id: 1 }, NeuronId { id: 2 }],
+        ProposalId { id: 1 },
+        hashmap! {
+            1 => Ballot { voting_power: 1, vote: Vote::Unspecified as i32 },
+            2 => Ballot { voting_power: 1, vote: Vote::Yes as i32 },
+            3 => Ballot { voting_power: 1, vote: Vote::Unspecified as i32 },
+            4 => Ballot { voting_power: 1, vote: Vote::Unspecified as i32 },
+        },
+    );
+
+    with_voting_history_store(|voting_history| {
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 1 }),
+            vec![(ProposalId { id: 1 }, Vote::Unspecified)]
+        );
+        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 2 }), vec![]);
+        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 3 }), vec![]);
+        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 4 }), vec![]);
+        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 5 }), vec![]);
+    });
+
+    record_known_neuron_abstentions(
+        &[NeuronId { id: 1 }, NeuronId { id: 2 }, NeuronId { id: 3 }],
+        ProposalId { id: 2 },
+        hashmap! {
+            1 => Ballot { voting_power: 1, vote: Vote::Yes as i32 },
+            3 => Ballot { voting_power: 1, vote: Vote::Unspecified as i32 },
+            4 => Ballot { voting_power: 1, vote: Vote::No as i32 },
+        },
+    );
+
+    with_voting_history_store(|voting_history| {
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 1 }),
+            vec![(ProposalId { id: 1 }, Vote::Unspecified),]
+        );
+        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 2 }), vec![]);
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 3 }),
+            vec![(ProposalId { id: 2 }, Vote::Unspecified)]
+        );
+        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 4 }), vec![]);
+        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 5 }), vec![]);
+    });
 }

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -9,6 +9,8 @@ on the process that this file is part of, see
 
 ## Added
 
+* Record votes by known neurons before clearing ballots.
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
# Why

If a known neuron does not vote on a proposal, this fact should be recorded (`vote = Vote::Unspecified`), and the only way to know that they did not vote is to check the ballots after the voting window. One way is to check the ballots right before they are cleared.

# What

- Record the votes by known neurons right before the ballots are cleared.