### PR TITLE
chore(Ledgers): FI-1865: Simplify canister ID conversion

### DIFF
--- a/rs/ledger_suite/common/ledger_canister_core/src/runtime.rs
+++ b/rs/ledger_suite/common/ledger_canister_core/src/runtime.rs
@@ -41,7 +41,7 @@ pub struct CdkRuntime;
 #[async_trait]
 impl Runtime for CdkRuntime {
     fn id() -> CanisterId {
-        CanisterId::try_from(PrincipalId::from(ic_cdk::api::id())).unwrap()
+        CanisterId::unchecked_from_principal(PrincipalId::from(ic_cdk::api::id()))
     }
 
     fn print(msg: impl AsRef<str>) {


### PR DESCRIPTION
The conversion of the principal returned from `ic_cdk::api::id()` to a `ic_base_types::canister_id::CanisterId` can be simplified by calling `CanisterId::unchecked_from_principal()` instead of `CanisterId::try_from`.