### PR TITLE
chore(nns): Add the migration canister as a protocol canister

### DIFF
--- a/rs/nns/constants/src/lib.rs
+++ b/rs/nns/constants/src/lib.rs
@@ -171,7 +171,7 @@ pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 17] = [
     &NODE_REWARDS_CANISTER_ID,
 ];
 
-pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 19] = [
+pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 20] = [
     &REGISTRY_CANISTER_ID,
     &GOVERNANCE_CANISTER_ID,
     &LEDGER_CANISTER_ID,
@@ -191,6 +191,7 @@ pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 19] = [
     &BITCOIN_TESTNET_CANISTER_ID,
     &CYCLES_LEDGER_CANISTER_ID,
     &CYCLES_LEDGER_INDEX_CANISTER_ID,
+    &MIGRATION_CANISTER_ID,
 ];
 
 /// The current value is 4 GiB, s.t. the SNS governance canister never hits the soft memory limit.

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -20,6 +20,9 @@ on the process that this file is part of, see
 * Added links to the `KnownNeuronData` that can be submitted as part of the `RegisterKnownNeuron`
   proposal.
 
+* Add the migration canister (sbzkb-zqaaa-aaaaa-aaaiq-cai) into `PROTOCOL_CANISTER_IDS` so that its
+  upgrade proposals will be considered "Protocol Canister Management".
+
 ## Changed
 
 ## Deprecated


### PR DESCRIPTION
Add the migration canister as a protocol canister (proposal to install the canister: [138487](https://dashboard.internetcomputer.org/proposal/138487)), so that the topic of the upgrade proposals for this canister will fall into "Protocol Canister Management"