### PR TITLE
test(consensus): don't panic in adding nodes test if some metrics aren't available yet

### DIFF
--- a/rs/tests/consensus/utils/src/node.rs
+++ b/rs/tests/consensus/utils/src/node.rs
@@ -176,7 +176,7 @@ pub fn await_subnet_earliest_topology_version(
                 let earliest_registry_versions = &val[EARLIEST_TOPOLOGY_VERSION];
                 ensure!(
                     earliest_registry_versions.len() == subnet.nodes().count(),
-                    "Metrics not available for all nodes yet. Metrics {}, nodes {}",
+                    "Metrics not available for all nodes yet. {} metrics, {} nodes",
                     earliest_registry_versions.len(),
                     subnet.nodes().count()
                 );


### PR DESCRIPTION
The test is flaky most likely because it assumed that all nodes would return the metric. There could be short time frame where the added node is healthy (returning metrics) but hasn't yet set the relevant metric being fetched.