### PR TITLE
feat: Adds a simple function to generate N state machines with XNet traffic.

### DIFF
--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -4654,7 +4654,6 @@ pub fn subnets_simple<const N: usize>() -> [Arc<StateMachine>; N] {
     let subnets = Arc::new(SubnetsImpl::new());
 
     let envs = (1..=N)
-        .into_iter()
         .map(|seed| {
             multi_subnet_setup(
                 subnets.clone(),


### PR DESCRIPTION
This is a preparation step for simulating subnet splitting using state machine tests, where at least 3 subnets are required, i.e. 2 for the split subnet and a 3rd party subnet to test routing after split.