### PR TITLE
refactor(consensus): make some structs in the consensus crate private

### DIFF
--- a/rs/consensus/src/consensus/finalizer.rs
+++ b/rs/consensus/src/consensus/finalizer.rs
@@ -38,22 +38,21 @@ use ic_types::{
 };
 use std::{cell::RefCell, sync::Arc, time::Instant};
 
-pub struct Finalizer {
-    pub(crate) replica_config: ReplicaConfig,
+pub(crate) struct Finalizer {
+    replica_config: ReplicaConfig,
     registry_client: Arc<dyn RegistryClient>,
     membership: Arc<Membership>,
     pub(crate) crypto: Arc<dyn ConsensusCrypto>,
     message_routing: Arc<dyn MessageRouting>,
     ingress_selector: Arc<dyn IngressSelector>,
-    pub(crate) log: ReplicaLogger,
+    log: ReplicaLogger,
     metrics: FinalizerMetrics,
     prev_finalized_height: RefCell<Height>,
     last_batch_delivered_at: RefCell<Option<Instant>>,
 }
 
 impl Finalizer {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         replica_config: ReplicaConfig,
         registry_client: Arc<dyn RegistryClient>,
         membership: Arc<Membership>,
@@ -80,7 +79,7 @@ impl Finalizer {
     /// Attempt to:
     /// * deliver finalized blocks (as `Batch`s) via `Messaging`
     /// * publish finalization shares for relevant rounds
-    pub fn on_state_change(&self, pool: &PoolReader<'_>) -> Vec<FinalizationShare> {
+    pub(crate) fn on_state_change(&self, pool: &PoolReader<'_>) -> Vec<FinalizationShare> {
         trace!(self.log, "on_state_change");
         let notarized_height = pool.get_notarized_height();
         let finalized_height = pool.get_finalized_height();

--- a/rs/consensus/src/consensus/malicious_consensus.rs
+++ b/rs/consensus/src/consensus/malicious_consensus.rs
@@ -1,13 +1,10 @@
 //! This module defines malicious behavior regarding the consensus crate,
 //! enabling testing consensus algorithm and implementation in the presence
 //! of malicious nodes.
-use crate::consensus::{
-    add_all_to_validated, block_maker, block_maker::BlockMaker, finalizer::Finalizer,
-    notary::Notary,
-};
+use crate::consensus::{add_all_to_validated, block_maker};
 use ic_consensus_utils::pool_reader::PoolReader;
 use ic_interfaces::consensus_pool::{ChangeAction, HeightRange, Mutations};
-use ic_logger::{ReplicaLogger, info, trace};
+use ic_logger::{info, trace};
 use ic_types::{
     Time,
     consensus::{
@@ -19,95 +16,97 @@ use ic_types::{
 };
 use std::time::Duration;
 
+use super::ConsensusImpl;
+
 /// Return a `Mutations` that moves all block proposals in the range to the
 /// validated pool.
-fn maliciously_validate_all_blocks(pool_reader: &PoolReader, logger: &ReplicaLogger) -> Mutations {
-    trace!(logger, "maliciously_validate_all_blocks");
-    let mut change_set = Vec::new();
+impl ConsensusImpl {
+    fn maliciously_validate_all_blocks(&self, pool_reader: &PoolReader) -> Mutations {
+        trace!(self.log, "maliciously_validate_all_blocks");
+        let mut change_set = Vec::new();
 
-    let finalized_height = pool_reader.get_finalized_height();
-    let beacon_height = pool_reader.get_random_beacon_height();
-    let max_height = beacon_height.increment();
-    let range = HeightRange::new(finalized_height.increment(), max_height);
+        let finalized_height = pool_reader.get_finalized_height();
+        let beacon_height = pool_reader.get_random_beacon_height();
+        let max_height = beacon_height.increment();
+        let range = HeightRange::new(finalized_height.increment(), max_height);
 
-    for proposal in pool_reader
-        .pool()
-        .unvalidated()
-        .block_proposal()
-        .get_by_height_range(range)
-    {
-        change_set.push(ChangeAction::MoveToValidated(proposal.into_message()))
+        for proposal in pool_reader
+            .pool()
+            .unvalidated()
+            .block_proposal()
+            .get_by_height_range(range)
+        {
+            change_set.push(ChangeAction::MoveToValidated(proposal.into_message()))
+        }
+
+        if !change_set.is_empty() {
+            ic_logger::debug!(
+                self.log,
+                "[MALICIOUS] maliciously validating all {} proposals",
+                change_set.len()
+            );
+        }
+
+        change_set
     }
 
-    if !change_set.is_empty() {
-        ic_logger::debug!(
-            logger,
-            "[MALICIOUS] maliciously validating all {} proposals",
-            change_set.len()
-        );
-    }
+    /// Maliciously propose blocks irrespective of the rank, based on the flags
+    /// received. If maliciously_propose_empty_blocks is set, propose only empty
+    /// blocks. If maliciously_equivocation_blockmaker is set, propose
+    /// multiple blocks at once.
+    fn maliciously_propose_blocks(
+        &self,
+        pool: &PoolReader<'_>,
+        maliciously_propose_empty_blocks: bool,
+        maliciously_equivocation_blockmaker: bool,
+    ) -> Vec<BlockProposal> {
+        use ic_protobuf::log::malicious_behavior_log_entry::v1::{
+            MaliciousBehavior, MaliciousBehaviorLogEntry,
+        };
+        trace!(self.log, "maliciously_propose_blocks");
+        let number_of_proposals = 5;
 
-    change_set
-}
+        let my_node_id = self.replica_config.node_id;
+        let (beacon, parent) = match block_maker::get_dependencies(pool) {
+            Some((b, p)) => (b, p),
+            None => {
+                return Vec::new();
+            }
+        };
+        let height = beacon.content.height.increment();
+        let registry_version = match pool.registry_version(height) {
+            Some(v) => v,
+            None => {
+                return Vec::new();
+            }
+        };
 
-/// Maliciously propose blocks irrespective of the rank, based on the flags
-/// received. If maliciously_propose_empty_blocks is set, propose only empty
-/// blocks. If maliciously_equivocation_blockmaker is set, propose
-/// multiple blocks at once.
-fn maliciously_propose_blocks(
-    block_maker: &BlockMaker,
-    pool: &PoolReader<'_>,
-    maliciously_propose_empty_blocks: bool,
-    maliciously_equivocation_blockmaker: bool,
-) -> Vec<BlockProposal> {
-    use ic_protobuf::log::malicious_behavior_log_entry::v1::{
-        MaliciousBehavior, MaliciousBehaviorLogEntry,
-    };
-    trace!(block_maker.log, "maliciously_propose_blocks");
-    let number_of_proposals = 5;
+        // If this node is a blockmaker, use its rank. If not, use rank 0.
+        // If the rank is not yet available, wait further.
+        let maybe_rank = match self
+            .block_maker
+            .membership
+            .get_block_maker_rank(height, &beacon, my_node_id)
+        {
+            Ok(Some(rank)) => Some(rank),
+            // TODO: introduce a malicious flag which will instruct a malicious node to propose a block
+            // when it's not elected a block maker; implement a system test which uses the flag.
+            Ok(None) => None,
+            Err(_) => None,
+        };
 
-    let my_node_id = block_maker.replica_config.node_id;
-    let (beacon, parent) = match block_maker::get_dependencies(pool) {
-        Some((b, p)) => (b, p),
-        None => {
-            return Vec::new();
-        }
-    };
-    let height = beacon.content.height.increment();
-    let registry_version = match pool.registry_version(height) {
-        Some(v) => v,
-        None => {
-            return Vec::new();
-        }
-    };
+        if let Some(rank) = maybe_rank {
+            if !block_maker::already_proposed(pool, height, my_node_id) {
+                // If maliciously_propose_empty_blocks is set, propose only empty blocks.
+                let maybe_proposal = match maliciously_propose_empty_blocks {
+                    true => self.maliciously_propose_empty_block(pool, rank, parent),
+                    false => self.block_maker.propose_block(pool, rank, parent),
+                };
 
-    // If this node is a blockmaker, use its rank. If not, use rank 0.
-    // If the rank is not yet available, wait further.
-    let maybe_rank = match block_maker
-        .membership
-        .get_block_maker_rank(height, &beacon, my_node_id)
-    {
-        Ok(Some(rank)) => Some(rank),
-        // TODO: introduce a malicious flag which will instruct a malicious node to propose a block
-        // when it's not elected a block maker; implement a system test which uses the flag.
-        Ok(None) => None,
-        Err(_) => None,
-    };
+                if let Some(proposal) = maybe_proposal {
+                    let mut proposals = vec![];
 
-    if let Some(rank) = maybe_rank {
-        if !block_maker::already_proposed(pool, height, my_node_id) {
-            // If maliciously_propose_empty_blocks is set, propose only empty blocks.
-            let maybe_proposal = match maliciously_propose_empty_blocks {
-                true => maliciously_propose_empty_block(block_maker, pool, rank, parent),
-                false => block_maker.propose_block(pool, rank, parent),
-            };
-
-            if let Some(proposal) = maybe_proposal {
-                let mut proposals = vec![];
-
-                match maliciously_equivocation_blockmaker {
-                    false => {}
-                    true => {
+                    if maliciously_equivocation_blockmaker {
                         let original_block = Block::from(proposal.clone());
                         // Generate more valid proposals based on this proposal, by slightly
                         // increasing the time in the context of
@@ -119,11 +118,11 @@ fn maliciously_propose_blocks(
                                 hashed::Hashed::new(ic_types::crypto::crypto_hash, new_block);
                             let metadata = BlockMetadata::from_block(
                                 &hashed_block,
-                                block_maker.replica_config.subnet_id,
+                                self.replica_config.subnet_id,
                             );
-                            if let Ok(signature) = block_maker.crypto.sign(
+                            if let Ok(signature) = self.block_maker.crypto.sign(
                                 &metadata,
-                                block_maker.replica_config.node_id,
+                                self.replica_config.node_id,
                                 registry_version,
                             ) {
                                 proposals.push(BlockProposal {
@@ -133,256 +132,252 @@ fn maliciously_propose_blocks(
                             }
                         }
                     }
-                };
-                proposals.push(proposal);
+                    proposals.push(proposal);
 
-                if maliciously_propose_empty_blocks {
-                    ic_logger::info!(
-                        block_maker.log,
-                        "[MALICIOUS] proposing empty blocks";
-                        malicious_behavior => MaliciousBehaviorLogEntry { malicious_behavior: MaliciousBehavior::ProposeEmptyBlocks as i32}
-                    );
-                }
-                if maliciously_equivocation_blockmaker {
-                    ic_logger::info!(
-                        block_maker.log,
-                        "[MALICIOUS] proposing {} equivocation blocks",
-                        proposals.len();
-                        malicious_behavior => MaliciousBehaviorLogEntry { malicious_behavior: MaliciousBehavior::ProposeEquivocatingBlocks as i32}
-                    );
-                }
+                    if maliciously_propose_empty_blocks {
+                        ic_logger::info!(
+                            self.log,
+                            "[MALICIOUS] proposing empty blocks";
+                            malicious_behavior => MaliciousBehaviorLogEntry { malicious_behavior: MaliciousBehavior::ProposeEmptyBlocks as i32}
+                        );
+                    }
+                    if maliciously_equivocation_blockmaker {
+                        ic_logger::info!(
+                            self.log,
+                            "[MALICIOUS] proposing {} equivocation blocks",
+                            proposals.len();
+                            malicious_behavior => MaliciousBehaviorLogEntry { malicious_behavior: MaliciousBehavior::ProposeEquivocatingBlocks as i32}
+                        );
+                    }
 
-                return proposals;
+                    return proposals;
+                }
             }
         }
-    }
-    Vec::new()
-}
-
-/// Maliciously construct a block proposal with valid DKG, but with empty
-/// batch payload.
-fn maliciously_propose_empty_block(
-    block_maker: &BlockMaker,
-    pool: &PoolReader<'_>,
-    rank: Rank,
-    parent: HashedBlock,
-) -> Option<BlockProposal> {
-    let height = parent.height().increment();
-    let mut context = parent.as_ref().context.clone();
-    context.certified_height = block_maker.state_manager.latest_certified_height();
-
-    // Note that we will skip blockmaking if registry versions or replica_versions
-    // are missing or temporarily not retrievable.
-    let registry_version = pool.registry_version(height)?;
-
-    // Get the subnet records that are relevant to making a block
-    let stable_registry_version = block_maker.get_stable_registry_version(parent.as_ref())?;
-    let subnet_records = block_maker::subnet_records_for_registry_version(
-        block_maker,
-        registry_version,
-        stable_registry_version,
-    )?;
-
-    block_maker.construct_block_proposal(
-        pool,
-        context,
-        parent,
-        height,
-        rank,
-        registry_version,
-        &subnet_records,
-    )
-}
-
-/// Maliciously notarize all unnotarized proposals for the current height.
-fn maliciously_notarize_all(notary: &Notary, pool: &PoolReader<'_>) -> Vec<NotarizationShare> {
-    use ic_protobuf::log::malicious_behavior_log_entry::v1::{
-        MaliciousBehavior, MaliciousBehaviorLogEntry,
-    };
-    trace!(notary.log, "maliciously_notarize");
-    let mut notarization_shares = Vec::<NotarizationShare>::new();
-
-    let range = HeightRange::new(
-        pool.get_notarized_height().increment(),
-        pool.get_random_beacon_height().increment(),
-    );
-
-    let proposals = pool
-        .pool()
-        .validated()
-        .block_proposal()
-        .get_by_height_range(range);
-    for proposal in proposals {
-        if !notary.is_proposal_already_notarized_by_me(pool, &proposal) {
-            if let Some(share) = notary.notarize_block(pool, &proposal.content) {
-                notarization_shares.push(share);
-            }
-        }
+        Vec::new()
     }
 
-    if !notarization_shares.is_empty() {
-        ic_logger::info!(
-            notary.log,
-            "[MALICIOUS] maliciously notarizing all {} proposals",
-            notarization_shares.len();
-            malicious_behavior => MaliciousBehaviorLogEntry { malicious_behavior: MaliciousBehavior::NotarizeAll as i32}
+    /// Maliciously construct a block proposal with valid DKG, but with empty
+    /// batch payload.
+    fn maliciously_propose_empty_block(
+        &self,
+        pool: &PoolReader<'_>,
+        rank: Rank,
+        parent: HashedBlock,
+    ) -> Option<BlockProposal> {
+        let height = parent.height().increment();
+        let mut context = parent.as_ref().context.clone();
+        context.certified_height = self.state_manager.latest_certified_height();
+
+        // Note that we will skip blockmaking if registry versions or replica_versions
+        // are missing or temporarily not retrievable.
+        let registry_version = pool.registry_version(height)?;
+
+        // Get the subnet records that are relevant to making a block
+        let stable_registry_version = self
+            .block_maker
+            .get_stable_registry_version(parent.as_ref())?;
+        let subnet_records = self
+            .block_maker
+            .subnet_records_for_registry_version(registry_version, stable_registry_version)?;
+
+        self.block_maker.construct_block_proposal(
+            pool,
+            context,
+            parent,
+            height,
+            rank,
+            registry_version,
+            &subnet_records,
+        )
+    }
+
+    /// Maliciously notarize all unnotarized proposals for the current height.
+    fn maliciously_notarize_all(&self, pool: &PoolReader<'_>) -> Vec<NotarizationShare> {
+        use ic_protobuf::log::malicious_behavior_log_entry::v1::{
+            MaliciousBehavior, MaliciousBehaviorLogEntry,
+        };
+        trace!(self.log, "maliciously_notarize");
+        let mut notarization_shares = Vec::<NotarizationShare>::new();
+
+        let range = HeightRange::new(
+            pool.get_notarized_height().increment(),
+            pool.get_random_beacon_height().increment(),
         );
-    }
 
-    notarization_shares
-}
-
-/// Generate finalization shares for each notarized block in the validated
-/// pool.
-fn maliciously_finalize_all(
-    finalizer: &Finalizer,
-    pool: &PoolReader<'_>,
-) -> Vec<FinalizationShare> {
-    use ic_protobuf::log::malicious_behavior_log_entry::v1::{
-        MaliciousBehavior, MaliciousBehaviorLogEntry,
-    };
-    trace!(finalizer.log, "maliciously_finalize");
-    let mut finalization_shares = Vec::new();
-
-    let min_height = pool.get_finalized_height().increment();
-    let max_height = pool.get_notarized_height();
-
-    let proposals = pool
-        .pool()
-        .validated()
-        .block_proposal()
-        .get_by_height_range(HeightRange::new(min_height, max_height));
-
-    for proposal in proposals {
-        let block = proposal.as_ref();
-
-        // if this replica already created a finalization share for this block, we do
-        // not finality sign this block anymore. The point is not to spam.
-        let signed_this_block_before = pool
+        let proposals = pool
             .pool()
             .validated()
-            .finalization_share()
-            .get_by_height(block.height)
-            .any(|share| {
-                share.signature.signer == finalizer.replica_config.node_id
-                    && share.content.block == *proposal.content.get_hash()
-            });
-
-        if !signed_this_block_before {
-            if let Some(finalization_share) = maliciously_finalize_block(finalizer, pool, block) {
-                finalization_shares.push(finalization_share);
+            .block_proposal()
+            .get_by_height_range(range);
+        for proposal in proposals {
+            if !self
+                .notary
+                .is_proposal_already_notarized_by_me(pool, &proposal)
+            {
+                if let Some(share) = self.notary.notarize_block(pool, &proposal.content) {
+                    notarization_shares.push(share);
+                }
             }
         }
+
+        if !notarization_shares.is_empty() {
+            ic_logger::info!(
+                self.log,
+                "[MALICIOUS] maliciously notarizing all {} proposals",
+                notarization_shares.len();
+                malicious_behavior => MaliciousBehaviorLogEntry { malicious_behavior: MaliciousBehavior::NotarizeAll as i32}
+            );
+        }
+
+        notarization_shares
     }
 
-    if !finalization_shares.is_empty() {
-        info!(
-            finalizer.log,
-            "[MALICIOUS] maliciously finalizing {} proposals",
-            finalization_shares.len();
-            malicious_behavior => MaliciousBehaviorLogEntry { malicious_behavior: MaliciousBehavior::FinalizeAll as i32}
-        );
+    /// Generate finalization shares for each notarized block in the validated
+    /// pool.
+    fn maliciously_finalize_all(&self, pool: &PoolReader<'_>) -> Vec<FinalizationShare> {
+        use ic_protobuf::log::malicious_behavior_log_entry::v1::{
+            MaliciousBehavior, MaliciousBehaviorLogEntry,
+        };
+        trace!(self.log, "maliciously_finalize");
+        let mut finalization_shares = Vec::new();
+
+        let min_height = pool.get_finalized_height().increment();
+        let max_height = pool.get_notarized_height();
+
+        let proposals = pool
+            .pool()
+            .validated()
+            .block_proposal()
+            .get_by_height_range(HeightRange::new(min_height, max_height));
+
+        for proposal in proposals {
+            let block = proposal.as_ref();
+
+            // if this replica already created a finalization share for this block, we do
+            // not finality sign this block anymore. The point is not to spam.
+            let signed_this_block_before = pool
+                .pool()
+                .validated()
+                .finalization_share()
+                .get_by_height(block.height)
+                .any(|share| {
+                    share.signature.signer == self.replica_config.node_id
+                        && share.content.block == *proposal.content.get_hash()
+                });
+
+            if !signed_this_block_before {
+                if let Some(finalization_share) = self.maliciously_finalize_block(pool, block) {
+                    finalization_shares.push(finalization_share);
+                }
+            }
+        }
+
+        if !finalization_shares.is_empty() {
+            info!(
+                self.log,
+                "[MALICIOUS] maliciously finalizing {} proposals",
+                finalization_shares.len();
+                malicious_behavior => MaliciousBehaviorLogEntry { malicious_behavior: MaliciousBehavior::FinalizeAll as i32}
+            );
+        }
+
+        finalization_shares
     }
 
-    finalization_shares
-}
+    /// Try to create a finalization share for a given block.
+    fn maliciously_finalize_block(
+        &self,
+        pool: &PoolReader<'_>,
+        block: &Block,
+    ) -> Option<FinalizationShare> {
+        let content = FinalizationContent::new(block.height, ic_types::crypto::crypto_hash(block));
+        let signature = self
+            .finalizer
+            .crypto
+            .sign(
+                &content,
+                self.replica_config.node_id,
+                pool.registry_version(block.height)?,
+            )
+            .ok()?;
+        Some(FinalizationShare { content, signature })
+    }
 
-/// Try to create a finalization share for a given block.
-fn maliciously_finalize_block(
-    finalizer: &Finalizer,
-    pool: &PoolReader<'_>,
-    block: &Block,
-) -> Option<FinalizationShare> {
-    let content = FinalizationContent::new(block.height, ic_types::crypto::crypto_hash(block));
-    let signature = finalizer
-        .crypto
-        .sign(
-            &content,
-            finalizer.replica_config.node_id,
-            pool.registry_version(block.height)?,
-        )
-        .ok()?;
-    Some(FinalizationShare { content, signature })
-}
+    /// Simulate malicious consensus behavior by modifying changeset.
+    pub fn maliciously_alter_changeset(
+        &self,
+        pool: &PoolReader,
+        honest_changeset: Mutations,
+        malicious_flags: &MaliciousFlags,
+        timestamp: Time,
+    ) -> Mutations {
+        let mut changeset = honest_changeset;
 
-/// Simulate malicious consensus behavior by modifying changeset.
-#[allow(unused, clippy::too_many_arguments)]
-pub fn maliciously_alter_changeset(
-    pool: &PoolReader,
-    honest_changeset: Mutations,
-    malicious_flags: &MaliciousFlags,
-    block_maker: &BlockMaker,
-    finalizer: &Finalizer,
-    notary: &Notary,
-    logger: &ReplicaLogger,
-    timestamp: Time,
-) -> Mutations {
-    let mut changeset = honest_changeset;
-
-    if malicious_flags.maliciously_propose_equivocating_blocks
-        || malicious_flags.maliciously_propose_empty_blocks
-    {
-        // If maliciously_propose_empty_blocks is enabled, we should remove non-empty
-        // block proposals by the honest code from the changeset.
-        if malicious_flags.maliciously_propose_empty_blocks {
-            changeset.retain(|change_action| {
+        if malicious_flags.maliciously_propose_equivocating_blocks
+            || malicious_flags.maliciously_propose_empty_blocks
+        {
+            // If maliciously_propose_empty_blocks is enabled, we should remove non-empty
+            // block proposals by the honest code from the changeset.
+            if malicious_flags.maliciously_propose_empty_blocks {
+                changeset.retain(|change_action| {
                 !matches!(
                     change_action,
                     ChangeAction::AddToValidated(x) if matches!(x.msg ,ConsensusMessage::BlockProposal(_))
                 )
             });
+            }
+
+            changeset.append(&mut add_all_to_validated(
+                timestamp,
+                self.maliciously_propose_blocks(
+                    pool,
+                    malicious_flags.maliciously_propose_empty_blocks,
+                    malicious_flags.maliciously_propose_equivocating_blocks,
+                ),
+            ));
         }
 
-        changeset.append(&mut add_all_to_validated(
-            timestamp,
-            maliciously_propose_blocks(
-                block_maker,
-                pool,
-                malicious_flags.maliciously_propose_empty_blocks,
-                malicious_flags.maliciously_propose_equivocating_blocks,
-            ),
-        ));
-    }
+        if malicious_flags.maliciously_notarize_all {
+            // First undo validations and invalidations of block proposals by the honest
+            // code. We would not want the new ChangeActions to contradict or repeat
+            // an existing ChangeAction.
+            changeset.retain(|change_action| {
+                !matches!(
+                    change_action,
+                    ChangeAction::RemoveFromUnvalidated(ConsensusMessage::BlockProposal(_))
+                        | ChangeAction::MoveToValidated(ConsensusMessage::BlockProposal(_))
+                        | ChangeAction::HandleInvalid(ConsensusMessage::BlockProposal(_), _)
+                )
+            });
 
-    if malicious_flags.maliciously_notarize_all {
-        // First undo validations and invalidations of block proposals by the honest
-        // code. We would not want the new ChangeActions to contradict or repeat
-        // an existing ChangeAction.
-        changeset.retain(|change_action| {
-            !matches!(
-                change_action,
-                ChangeAction::RemoveFromUnvalidated(ConsensusMessage::BlockProposal(_))
-                    | ChangeAction::MoveToValidated(ConsensusMessage::BlockProposal(_))
-                    | ChangeAction::HandleInvalid(ConsensusMessage::BlockProposal(_), _)
-            )
-        });
+            // Validate all block proposals in a range
+            changeset.append(&mut self.maliciously_validate_all_blocks(pool));
 
-        // Validate all block proposals in a range
-        changeset.append(&mut maliciously_validate_all_blocks(pool, logger));
+            // Notarize all valid block proposals
+            changeset.append(&mut add_all_to_validated(
+                timestamp,
+                self.maliciously_notarize_all(pool),
+            ));
+        }
 
-        // Notarize all valid block proposals
-        changeset.append(&mut add_all_to_validated(
-            timestamp,
-            maliciously_notarize_all(notary, pool),
-        ));
-    }
-
-    if malicious_flags.maliciously_finalize_all {
-        // Remove any finalization shares that might have been output by the honest
-        // code, to avoid deduplication.
-        changeset.retain(|change_action| {
+        if malicious_flags.maliciously_finalize_all {
+            // Remove any finalization shares that might have been output by the honest
+            // code, to avoid deduplication.
+            changeset.retain(|change_action| {
             !matches!(
                 change_action,
                 ChangeAction::AddToValidated(x) if matches!(x.msg, ConsensusMessage::FinalizationShare(_))
             )
         });
 
-        // Finalize all block proposals
-        changeset.append(&mut add_all_to_validated(
-            timestamp,
-            maliciously_finalize_all(finalizer, pool),
-        ));
-    }
+            // Finalize all block proposals
+            changeset.append(&mut add_all_to_validated(
+                timestamp,
+                self.maliciously_finalize_all(pool),
+            ));
+        }
 
-    changeset
+        changeset
+    }
 }

--- a/rs/consensus/src/consensus/notary.rs
+++ b/rs/consensus/src/consensus/notary.rs
@@ -60,18 +60,18 @@ const ACCEPTABLE_FINALIZATION_CERTIFICATION_GAP: u64 = 1;
 /// for each height that the latest finalized block is ahead of the latest certified state.
 /// The value was chosen empirically.
 const BACKLOG_DELAY_MILLIS: u64 = 2_000;
-pub struct Notary {
+pub(crate) struct Notary {
     time_source: Arc<dyn TimeSource>,
     replica_config: ReplicaConfig,
     membership: Arc<Membership>,
     crypto: Arc<dyn ConsensusCrypto>,
     state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
-    pub(crate) log: ReplicaLogger,
+    log: ReplicaLogger,
     metrics: NotaryMetrics,
 }
 
 impl Notary {
-    pub fn new(
+    pub(crate) fn new(
         time_source: Arc<dyn TimeSource>,
         replica_config: ReplicaConfig,
         membership: Arc<Membership>,
@@ -94,7 +94,7 @@ impl Notary {
     /// If this node is a member of the notary group for the current round,
     /// attempt to find the best blocks that we can notarize, and notarize them.
     /// Else, do nothing.
-    pub fn on_state_change(&self, pool: &PoolReader<'_>) -> Vec<NotarizationShare> {
+    pub(crate) fn on_state_change(&self, pool: &PoolReader<'_>) -> Vec<NotarizationShare> {
         trace!(self.log, "on_state_change");
         let notarized_height = pool.get_notarized_height();
         let mut notarization_shares = Vec::new();

--- a/rs/consensus/tests/framework/malicious.rs
+++ b/rs/consensus/tests/framework/malicious.rs
@@ -100,14 +100,10 @@ impl<T: ConsensusPool> PoolMutationsProducer<T> for ConsensusWithMaliciousFlags 
         let changeset = self.consensus.on_state_change(pool);
         let pool_reader = PoolReader::new(pool);
         if self.malicious_flags.is_consensus_malicious() {
-            ic_consensus::consensus::malicious_consensus::maliciously_alter_changeset(
+            self.consensus.maliciously_alter_changeset(
                 &pool_reader,
                 changeset,
                 &self.malicious_flags,
-                &self.consensus.block_maker,
-                &self.consensus.finalizer,
-                &self.consensus.notary,
-                &self.consensus.log,
                 current_time(),
             )
         } else {


### PR DESCRIPTION
The structs were public only for the integration tests which use malicious behavior.

This should help with dead code analysis.