### PR TITLE
fix: let sync_with_vector ignore nested VMs without a network

### DIFF
--- a/rs/tests/driver/src/driver/vector_vm.rs
+++ b/rs/tests/driver/src/driver/vector_vm.rs
@@ -132,7 +132,7 @@ impl VectorVm {
         match env.safe_topology_snapshot() {
             Err(e) => warn!(
                 log,
-                "Could not fetch topology snapshot because: {e:?}. Skipping adding IC nodes as vector targets for now."
+                "Skipping adding IC nodes as vector targets for now because could not fetch topology snapshot because: {e:?}"
             ),
             Ok(snapshot) => {
                 let nodes = snapshot


### PR DESCRIPTION
In the `sync_with_vector()` function there was the following piece of code which sometimes failed on the `vm.get_nested_network()` step:
```rust
        for vm in env.get_all_nested_vms()? {
            ...
            let network = vm.get_nested_network().unwrap();
```
with:
```
thread 'main' panicked at rs/tests/driver/src/driver/vector_vm.rs:168:51:
called `Result::unwrap()` on an `Err` value: Could not open: ".../setup/nested_vms/host-3/ips.json"

Caused by:
    No such file or directory (os error 2)
```
This is because `vm.get_nested_network()` reads the `ips.json` file but that races with `nested.rs:write_nested_vm` which writes that file.

This commits fixes that by simply ignoring nested VMs that don't yet have a `ips.json` file. Since `sync_with_vector()` is called periodically an ignored nested VM will be picked up in a subsequent call.

Additionally this commit doesn't let `sync_with_vector()` fail when there's not yet a topology snapshot. 
