### PR TITLE
fix: Fix cargo build of replicated_state

### DIFF
--- a/rs/replicated_state/Cargo.toml
+++ b/rs/replicated_state/Cargo.toml
@@ -57,6 +57,7 @@ ic-test-utilities-metrics = { path = "../test_utilities/metrics", optional = tru
 proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 criterion = { workspace = true }
 criterion-time = { path = "../criterion_time" }
 ic-crypto-test-utils-canister-threshold-sigs = { path = "../crypto/test_utils/canister_threshold_sigs" }
@@ -64,6 +65,7 @@ ic-crypto-test-utils-keys = { path = "../crypto/test_utils/keys" }
 ic-crypto-test-utils-reproducible-rng = { path = "../crypto/test_utils/reproducible_rng" }
 ic-ed25519 = { path = "../../packages/ic-ed25519" }
 ic-test-utilities-io = { path = "../test_utilities/io" }
+ic-test-utilities-metrics = { path = "../test_utilities/metrics" }
 ic-test-utilities-state = { path = "../test_utilities/state" }
 ic-test-utilities-types = { path = "../test_utilities/types" }
 proptest = { workspace = true }


### PR DESCRIPTION
Some of the optional dependencies gated by the fuzzing_code feature are also used by tests. Add them back as dev dependencies.