### PR TITLE
feat: [MR-719] Introduce `Refund` and `StreamMessage`

### DIFF
--- a/rs/protobuf/def/state/queues/v1/queues.proto
+++ b/rs/protobuf/def/state/queues/v1/queues.proto
@@ -107,6 +107,19 @@ message RequestOrResponse {
   }
 }
 
+message Refund {
+  types.v1.CanisterId recipient = 1;
+  Cycles amount = 2;
+}
+
+message StreamMessage {
+  oneof message {
+    Request request = 1;
+    Response response = 2;
+    Refund refund = 3;
+  }
+}
+
 message MessageDeadline {
   uint64 deadline = 1;
   uint64 index = 2;

--- a/rs/protobuf/src/gen/state/state.queues.v1.rs
+++ b/rs/protobuf/src/gen/state/state.queues.v1.rs
@@ -131,6 +131,30 @@ pub mod request_or_response {
         Response(super::Response),
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Refund {
+    #[prost(message, optional, tag = "1")]
+    pub recipient: ::core::option::Option<super::super::super::types::v1::CanisterId>,
+    #[prost(message, optional, tag = "2")]
+    pub amount: ::core::option::Option<Cycles>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamMessage {
+    #[prost(oneof = "stream_message::Message", tags = "1, 2, 3")]
+    pub message: ::core::option::Option<stream_message::Message>,
+}
+/// Nested message and enum types in `StreamMessage`.
+pub mod stream_message {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Message {
+        #[prost(message, tag = "1")]
+        Request(super::Request),
+        #[prost(message, tag = "2")]
+        Response(super::Response),
+        #[prost(message, tag = "3")]
+        Refund(super::Refund),
+    }
+}
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct MessageDeadline {
     #[prost(uint64, tag = "1")]

--- a/rs/protobuf/src/gen/types/state.queues.v1.rs
+++ b/rs/protobuf/src/gen/types/state.queues.v1.rs
@@ -131,6 +131,30 @@ pub mod request_or_response {
         Response(super::Response),
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Refund {
+    #[prost(message, optional, tag = "1")]
+    pub recipient: ::core::option::Option<super::super::super::types::v1::CanisterId>,
+    #[prost(message, optional, tag = "2")]
+    pub amount: ::core::option::Option<Cycles>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamMessage {
+    #[prost(oneof = "stream_message::Message", tags = "1, 2, 3")]
+    pub message: ::core::option::Option<stream_message::Message>,
+}
+/// Nested message and enum types in `StreamMessage`.
+pub mod stream_message {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Message {
+        #[prost(message, tag = "1")]
+        Request(super::Request),
+        #[prost(message, tag = "2")]
+        Response(super::Response),
+        #[prost(message, tag = "3")]
+        Refund(super::Refund),
+    }
+}
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct MessageDeadline {
     #[prost(uint64, tag = "1")]

--- a/rs/types/types/src/messages.rs
+++ b/rs/types/types/src/messages.rs
@@ -32,8 +32,8 @@ pub use ingress_messages::{
     Ingress, ParseIngressError, SignedIngress, SignedIngressContent, extract_effective_canister_id,
 };
 pub use inter_canister::{
-    CallContextId, CallbackId, MAX_REJECT_MESSAGE_LEN_BYTES, NO_DEADLINE, Payload, RejectContext,
-    Request, RequestMetadata, RequestOrResponse, Response,
+    CallContextId, CallbackId, MAX_REJECT_MESSAGE_LEN_BYTES, NO_DEADLINE, Payload, Refund,
+    RejectContext, Request, RequestMetadata, RequestOrResponse, Response, StreamMessage,
 };
 pub use message_id::{EXPECTED_MESSAGE_ID_LENGTH, MessageId, MessageIdError};
 use phantom_newtype::Id;

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -722,6 +722,12 @@ impl CountBytes for Refund {
     }
 }
 
+/// Ensure that `RequestOrResponse` and `StreamMessage` have the same size, so that
+/// their respective `CountBytes` implementations are consistent.
+const _: () = {
+    assert!(size_of::<RequestOrResponse>() == size_of::<StreamMessage>());
+};
+
 impl CountBytes for RequestOrResponse {
     fn count_bytes(&self) -> usize {
         match self {
@@ -740,12 +746,6 @@ impl CountBytes for StreamMessage {
         }
     }
 }
-
-/// Ensure that `RequestOrResponse` and `StreamMessage` have the same size, so that
-/// their respective `CountBytes` implementations are consistent.
-const _: () = {
-    assert!(size_of::<RequestOrResponse>() == size_of::<StreamMessage>());
-};
 
 impl From<Request> for RequestOrResponse {
     fn from(req: Request) -> Self {

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -544,7 +544,7 @@ impl Hash for Response {
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize, ValidateEq)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct Refund {
-    /// Who this refund is to be delivered to.
+    /// Whom this refund is to be delivered to.
     recipient: CanisterId,
 
     /// The amount of cycles being refunded. Non-zero for anonymous refunds.


### PR DESCRIPTION
Introduce the new `Refund` message type; and the `StreamMessage` enum, which will replace `RequestOrResponse` in streams.