### PR TITLE
chore: increase timeout of //rs/rust_canisters/stable_memory_integrity:tests

### DIFF
--- a/rs/rust_canisters/stable_memory_integrity/BUILD.bazel
+++ b/rs/rust_canisters/stable_memory_integrity/BUILD.bazel
@@ -33,6 +33,7 @@ rust_canister(
 
 rust_ic_test(
     name = "tests",
+    timeout = "long",
     srcs = ["tests/stable_memory_integrity.rs"],
     aliases = {},
     crate_root = "tests/stable_memory_integrity.rs",


### PR DESCRIPTION
The `//rs/rust_canisters/stable_memory_integrity:tests` has a timeout rate of 1.49% from last week onwards. So let's bump its timeout from 5 to 15 minutes.