### PR TITLE
chore: increase timeout of //rs/ledger_suite/icp/ledger:ledger_canister_test

### DIFF
--- a/rs/ledger_suite/icp/ledger/BUILD.bazel
+++ b/rs/ledger_suite/icp/ledger/BUILD.bazel
@@ -112,7 +112,7 @@ rust_test(
 
 rust_ic_test(
     name = "ledger_canister_test",
-    timeout = "long",
+    timeout = "eternal",
     srcs = ["tests/tests.rs"],
     data = [
         ":ledger-canister-wasm",


### PR DESCRIPTION
The `//rs/ledger_suite/icp/ledger:ledger_canister_test` has a timeout rate of 2.01% from last week onwards. So let's increase its timeout from 15 minutes to 1 hour to run into timeouts less (hopefully never).

It's P90 duration from last week onwards is 3m 7s so the expectation is that we don't often have to wait a full hour.