### PR TITLE
chore: increase timeout of the //rs/pocket_ic_server:bitcoin_integration_tests

### DIFF
--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -387,7 +387,6 @@ rust_test(
 
 rust_test(
     name = "bitcoin_integration_tests",
-    size = "small",
     srcs = [
         "tests/bitcoin_integration_tests.rs",
     ],


### PR DESCRIPTION
The `//rs/pocket_ic_server:bitcoin_integration_tests` has a timeout rate of 1.89% from last week onwards. So let's bump its timeout from 1 minute to 5 minutes by removing the `size = "small"` setting.