### PR TITLE
feat(XC): enable adapter on-disk cache for dogecoin in guest OS

### DIFF
--- a/ic-os/components/guestos/ic-btc-adapter/generate-doge-adapter-config.sh
+++ b/ic-os/components/guestos/ic-btc-adapter/generate-doge-adapter-config.sh
@@ -50,12 +50,12 @@ if [ "${config_socks_proxy}" != "" ] && [ "${config_socks_proxy}" != "null" ]; t
     SOCKS_PROXY="${config_socks_proxy}"
 fi
 
-DOGECOIN_NETWORK='"dogecoin:testnet"'
+DOGECOIN_NETWORK='dogecoin:testnet'
 DNS_SEEDS='"jrn.me.uk",
             "testseed.jrn.me.uk"'
 
 if [ "$MAINNET" = true ]; then
-    DOGECOIN_NETWORK='"dogecoin"'
+    DOGECOIN_NETWORK='dogecoin'
     DNS_SEEDS='"seed.multidoge.org",
             "seed2.multidoge.org"'
 fi
@@ -77,9 +77,11 @@ if [ "${config_dogecoind_addr}" != "" ] && [ "${config_dogecoind_addr}" != "null
         }
     }' >$OUT_FILE
 else
+    CACHE_DIR="/var/lib/ic/data/ic_adapter/${DOGECOIN_NETWORK}_cache"
     echo '{
-        "network": '"${DOGECOIN_NETWORK}"',
+        "network": '"\"${DOGECOIN_NETWORK}\""',
         "dns_seeds": ['"${DNS_SEEDS}"'],
+        "cache_dir": '"\"${CACHE_DIR}\""',
         "logger": {
             "format": "json",
             "level": "info"

--- a/ic-os/components/guestos/setup-permissions/setup-permissions.sh
+++ b/ic-os/components/guestos/setup-permissions/setup-permissions.sh
@@ -38,6 +38,8 @@ make_group_owned_and_sticky /var/lib/ic/data/orchestrator ic-replica nonconfiden
 make_group_owned_and_sticky /var/lib/ic/data/ic_registry_local_store ic-replica ic-registry-local-store
 make_group_owned_and_sticky /var/lib/ic/data/ic_state/page_deltas ic-replica nonconfidential
 make_group_owned_and_sticky /var/lib/ic/data/recovery admin nonconfidential
+make_group_owned_and_sticky /var/lib/ic/data/ic_adapter/dogecoin_cache ic-replica nonconfidential
+make_group_owned_and_sticky /var/lib/ic/data/ic_adapter/dogecoin:testnet_cache ic-replica nonconfidential
 
 # Fix up security labels for everything.
 echo "Restoring SELinux security contexts in /var/lib/ic"


### PR DESCRIPTION
On-disk cache can shorten adapter sync time when the adapter is restarted.
It is important we turn this on for dogecoin adapters because they take much longer to sync.