### PR TITLE
chore: bump timeout of bazel-test-macos-intel to 3 hours

### DIFF
--- a/.github/workflows-source/ci-main.yml
+++ b/.github/workflows-source/ci-main.yml
@@ -289,7 +289,7 @@ jobs:
   bazel-test-macos-intel:
     name: Bazel Test macOS Intel
     needs: [ config ]
-    timeout-minutes: 130
+    timeout-minutes: 180
     runs-on:
       labels: macOS
     # Run on protected branches, but only on public repo

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -256,7 +256,7 @@ jobs:
   bazel-test-macos-intel:
     name: Bazel Test macOS Intel
     needs: [config]
-    timeout-minutes: 130
+    timeout-minutes: 180
     runs-on:
       labels: macOS
     # Run on protected branches, but only on public repo


### PR DESCRIPTION
The `bazel-test-macos-intel` is increasingly timing out so let's increase its timeout by 50 minutes to 3 hours.