### PR TITLE
fix(adapter): benchmark hanging due to server blocking thread

### DIFF
--- a/rs/bitcoin/adapter/benches/e2e.rs
+++ b/rs/bitcoin/adapter/benches/e2e.rs
@@ -78,9 +78,11 @@ fn e2e(criterion: &mut Criterion) {
         .make(|uds_path| {
             let mut config = Config::default_with(network.into());
             config.incoming_source = IncomingSource::Path(uds_path.to_path_buf());
-            rt.spawn(async {
-                start_server(no_op_logger(), MetricsRegistry::default(), config).await;
-            });
+            rt.spawn(start_server(
+                no_op_logger(),
+                MetricsRegistry::default(),
+                config,
+            ));
             Ok(rt.block_on(async { start_client(uds_path).await }))
         })
         .unwrap()

--- a/rs/bitcoin/adapter/benches/e2e.rs
+++ b/rs/bitcoin/adapter/benches/e2e.rs
@@ -67,8 +67,6 @@ fn prepare(
 
 fn e2e(criterion: &mut Criterion) {
     let network = Network::Regtest;
-    let mut config = Config::default_with(network.into());
-
     let mut processed_block_hashes = vec![];
     let genesis = network.genesis_block_header();
 
@@ -78,11 +76,12 @@ fn e2e(criterion: &mut Criterion) {
 
     let (client, _temp) = Builder::new()
         .make(|uds_path| {
-            Ok(rt.block_on(async {
-                config.incoming_source = IncomingSource::Path(uds_path.to_path_buf());
-                start_server(no_op_logger(), MetricsRegistry::default(), config.clone()).await;
-                start_client(uds_path).await
-            }))
+            let mut config = Config::default_with(network.into());
+            config.incoming_source = IncomingSource::Path(uds_path.to_path_buf());
+            rt.spawn(async {
+                start_server(no_op_logger(), MetricsRegistry::default(), config).await;
+            });
+            Ok(rt.block_on(async { start_client(uds_path).await }))
         })
         .unwrap()
         .into_parts();


### PR DESCRIPTION
Fix bug introduced in #6760 where the benchmark `e2e` for the Bitcoin/Dogecoin adapter was left hanging due to running the gRPC server as a blocking task, although that task never finishes (on purpose).