### PR TITLE
fix(icrc-ledger-types): FI-1866: Add try_from_subaccount_to_principal

### DIFF
--- a/packages/icrc-ledger-types/CHANGELOG.md
+++ b/packages/icrc-ledger-types/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `try_from_subaccount_to_principal` that returns an error rather than panicking if the subaccount is not a valid Principal.
+
 ## 0.1.11
 
 ### Changed

--- a/packages/icrc-ledger-types/src/icrc1/account.rs
+++ b/packages/icrc-ledger-types/src/icrc1/account.rs
@@ -193,6 +193,8 @@ impl Storable for Account {
 
 /// Maps a `Principal` to a `Subaccount`.
 /// Can be used to create a separate `Subaccount` for each `Principal`.
+/// Note that no canonical mapping exists from `Principal` to `Subaccount` - this is just one
+/// possible mapping.
 pub fn principal_to_subaccount(principal: Principal) -> Subaccount {
     let mut subaccount = [0; 32];
     let principal = principal.as_slice();
@@ -202,7 +204,8 @@ pub fn principal_to_subaccount(principal: Principal) -> Subaccount {
 }
 
 /// Maps a `Subaccount` to a `Principal`.
-/// Reverse of `principal_to_subaccount` above.
+/// Reverse of `principal_to_subaccount` above - if the `Subaccount` contains a `Principal` that
+/// was converted using another mechanism than `principal_to_subaccount`, the result may be invalid.
 ///
 /// # Panics
 /// Panics if the `Subaccount` does not contain a valid `Principal`.
@@ -213,6 +216,8 @@ pub fn subaccount_to_principal(subaccount: Subaccount) -> Principal {
 }
 
 /// Tries to map a `Subaccount` to a `Principal`.
+/// Reverse of `principal_to_subaccount` above - if the `Subaccount` contains a `Principal` that
+/// was converted using another mechanism than `principal_to_subaccount`, the result may be invalid.
 ///
 /// # Errors
 /// * `PrincipalError::BytesTooLong()` if the length of the principal (`subaccount[0]`) is larger

--- a/packages/icrc-ledger-types/src/icrc1/account.rs
+++ b/packages/icrc-ledger-types/src/icrc1/account.rs
@@ -224,7 +224,7 @@ pub fn try_from_subaccount_to_principal(
     subaccount: Subaccount,
 ) -> Result<Principal, PrincipalError> {
     let len = subaccount[0] as usize;
-    if len > subaccount.len() - 2 {
+    if len > Principal::MAX_LENGTH_IN_BYTES {
         return Err(PrincipalError::BytesTooLong());
     }
     Principal::try_from_slice(&subaccount[1..len + 1])
@@ -415,12 +415,14 @@ mod tests {
 
     #[test]
     fn test_try_from_principal_to_subaccount() {
+        // Should be caught by `Principal::try_from_slice`.
         assert_matches!(
-            try_from_subaccount_to_principal([31u8; 32]),
+            try_from_subaccount_to_principal([(Principal::MAX_LENGTH_IN_BYTES + 1) as u8; 32]),
             Err(PrincipalError::BytesTooLong())
         );
+        // Should be caught by the additional check in `try_from_subaccount_to_principal`.
         assert_matches!(
-            try_from_subaccount_to_principal([255u8; 32]),
+            try_from_subaccount_to_principal([32u8; 32]),
             Err(PrincipalError::BytesTooLong())
         );
         use proptest::{prop_assert_eq, proptest};
@@ -436,7 +438,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "slice length exceeds capacity")]
     fn test_principal_error_subaccount_to_principal() {
-        let principal_slice_too_large = [31u8; 32];
+        let principal_slice_too_large = [(Principal::MAX_LENGTH_IN_BYTES + 1) as u8; 32];
         subaccount_to_principal(principal_slice_too_large);
     }
 

--- a/packages/icrc-ledger-types/src/icrc1/account.rs
+++ b/packages/icrc-ledger-types/src/icrc1/account.rs
@@ -215,7 +215,7 @@ pub fn subaccount_to_principal(subaccount: Subaccount) -> Principal {
 /// Tries to map a `Subaccount` to a `Principal`.
 ///
 /// # Errors
-/// * `PrincipalError::BytesTooLong()` if the length of the principal (`subaccount[0]`) if larger
+/// * `PrincipalError::BytesTooLong()` if the length of the principal (`subaccount[0]`) is larger
 ///   than 29.
 ///
 /// # Returns


### PR DESCRIPTION
Add a `try_from_subaccount_to_principal` function that returns an error rather than panicking if the `Subaccount` cannot be converted to a `Principal`.