### PR TITLE
test: improve tECDSA performance test documentation

### DIFF
--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -18,23 +18,22 @@
 //
 //   $ ssh -i performance/_tmp/*/setup/ssh/authorized_priv_keys/admin admin@$ipv6
 //
-// Note that you can get the $ipv6 address of the IC node by looking for a log line like:
+// Note that you can get the $ipv6 address of IC nodes by looking for the "IC TopologySnapshot" in the logs:
 //
-//   Apr 11 15:34:10.175 INFO[rs/tests/src/driver/farm.rs:94:0]
-//     VM(h2tf2-odxlp-fx5uw-kvn43-bam4h-i4xmw-th7l2-xxwvv-dxxpz-bs3so-iqe)
-//     Host: ln1-dll10.ln1.dfinity.network
-//     IPv6: 2a0b:21c0:4003:2:5051:85ff:feec:6864
-//     vCPUs: 64
-//     Memory: 512142680 KiB
+// [...] TEST_LOG: ============================================== IC TopologySnapshot, registry version 1 ==============================================
+// [...] TEST_LOG: Subnet id=s7nx3-ohrn3-yr3me-2u2uz-ggc3p-sxctl-6gi4m-24zkp-xbkv6-7awbl-eqe, index=0, type=System
+// [...] TEST_LOG:    Node id=gi22p-z65m6-2je6o-ofjrq-dgbhz-oovnh-qt5r4-ipuzz-zgr6s-zadz5-5ae, ipv6=2602:fb2b:100:10:50c0:4aff:fe48:621c, index=0
+// [...] TEST_LOG: Subnet id=skbnp-ytnyv-g45vf-lxmc7-uo4d4-uul7e-uqlmt-obllg-ayzue-vqlbb-bae, index=1, type=Application
+// [...] TEST_LOG:    Node id=hubhq-5a45w-jikdq-mmt2k-dtfou-w5kkl-hhqap-akg77-ucuti-iy7ea-sae, ipv6=2602:fb2b:100:10:5060:c4ff:feb4:7698, index=0
+// [...] TEST_LOG:    Node id=ahm26-luzd4-ip3xt-oma5e-f7mzd-xkmne-52tun-jtf2n-qhoe6-gpmyt-dae, ipv6=2602:fb2b:100:10:50fb:c3ff:fe3d:e3d1, index=1
+// [...] TEST_LOG:    Node id=ellje-2rvws-jx6v5-acjhp-uogh2-3gm2z-utyc3-avgre-56u3f-ybbk3-fae, ipv6=2602:fb2b:100:10:5033:d9ff:fea5:1c7b, index=2
+// =====================================================================================================================================
 //
 // To get live access to P8s and Grafana while the test is running look for the following log lines:
 //
-//   Apr 11 15:33:58.903 INFO[rs/tests/src/driver/prometheus_vm.rs:168:0]
-//     Prometheus Web UI at http://prometheus.performance--1681227226065.testnet.farm.dfinity.systems
-//   Apr 11 15:33:58.903 INFO[rs/tests/src/driver/prometheus_vm.rs:170:0]
-//     IC Progress Clock at http://grafana.performance--1681227226065.testnet.farm.dfinity.systems/d/ic-progress-clock/ic-progress-clock?refresh=10s&from=now-5m&to=now
-//   Apr 11 15:33:58.903 INFO[rs/tests/src/driver/prometheus_vm.rs:169:0]
-//     Grafana at http://grafana.performance--1681227226065.testnet.farm.dfinity.systems
+// [...] TEST_LOG: [...] {"event_name":"prometheus_vm_created_event","body":"Prometheus Web UI at http://prometheus.tecdsa-performance-test-colocate--1758706685338.testnet.farm.dfinity.systems"}
+// [...] TEST_LOG: [...] {"event_name":"grafana_instance_created_event","body":"Grafana at http://grafana.tecdsa-performance-test-colocate--1758706685338.testnet.farm.dfinity.systems"}
+// [...] TEST_LOG: [...] {"event_name":"ic_progress_clock_created_event","body":"IC Progress Clock at http://grafana.tecdsa-performance-test-colocate--1758706685338.testnet.farm.dfinity.systems/d/ic-progress-clock/ic-progress-clock?refresh=10s&from=now-5m&to=now"}
 //
 // To inspect the metrics after the test has finished, exit the dev container
 // and run a local p8s and Grafana on the downloaded p8s data directory using:


### PR DESCRIPTION
Improves the tECDSA performance test documentation in that it updates the example logs uses to find hosts' IPv6 addresses and the links to Grafana, Prometheus, etc.