### PR TITLE
chore: Remove some directories from the whitelist in `dfn_*` packages

### DIFF
--- a/rs/rust_canisters/dfn_candid/BUILD.bazel
+++ b/rs/rust_canisters/dfn_candid/BUILD.bazel
@@ -4,7 +4,6 @@ load("//bazel:defs.bzl", "rust_ic_test")
 
 package(default_visibility = [
     # Keep sorted.
-    "//rs/ledger_suite/icp:__subpackages__",
     "//rs/nervous_system/clients:__pkg__",
     "//rs/nervous_system/common:__subpackages__",
     "//rs/nervous_system/runtime:__pkg__",

--- a/rs/rust_canisters/dfn_core/BUILD.bazel
+++ b/rs/rust_canisters/dfn_core/BUILD.bazel
@@ -4,7 +4,6 @@ load("//bazel:defs.bzl", "rust_ic_test")
 
 package(default_visibility = [
     # Keep sorted.
-    "//rs/ledger_suite/icp:__subpackages__",
     "//rs/nervous_system/canisters:__subpackages__",
     "//rs/nervous_system/clients:__pkg__",
     "//rs/nervous_system/common:__subpackages__",

--- a/rs/rust_canisters/dfn_macro/BUILD.bazel
+++ b/rs/rust_canisters/dfn_macro/BUILD.bazel
@@ -3,8 +3,6 @@ load("@rules_rust//rust:defs.bzl", "rust_doc_test", "rust_proc_macro")
 
 package(default_visibility = [
     # Keep sorted.
-    "//rs/nns/handlers/root:__subpackages__",
-    "//rs/rosetta-api/icp:__pkg__",
     "//rs/rust_canisters:__subpackages__",
 ])
 


### PR DESCRIPTION
After further refactorings some more directories can be removed from the whitelist allowed to use `dfn_candid`, `dfn_core` and `dfn_macro`.