### PR TITLE
fix(ic-recovery): ignore `ic_adapter` when downloading state

### DIFF
--- a/rs/recovery/src/lib.rs
+++ b/rs/recovery/src/lib.rs
@@ -76,6 +76,7 @@ pub const IC_STATE_EXCLUDES: &[&str] = &[
     // page deltas. We do not need to copy page deltas when nodes are re-assigned.
     "page_deltas",
     "node_operator_private_key.pem",
+    "ic_adapter",
     IC_REGISTRY_LOCAL_STORE,
 ];
 pub const IC_STATE: &str = "ic_state";


### PR DESCRIPTION
#6901 added a new folder to `/var/lib/ic/data` that is not necessary for recoveries. This PR makes `ic-recovery` ignore it when downloading a node's state.