### PR TITLE
feat(nns): add ENABLE_NEURON_INDEXES feature flag

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -212,7 +212,7 @@ thread_local! {
     static ENABLE_DEREGISTER_KNOWN_NEURON: Cell<bool>
         = const { Cell::new(cfg!(feature = "test")) };
 
-    static ENABLE_NEURON_INDEXES: Cell<bool>
+    static ENABLE_COMPREHENSIVE_NEURON_LIST: Cell<bool>
         = const { Cell::new(cfg!(feature = "test")) };
 }
 
@@ -282,7 +282,17 @@ pub fn temporarily_disable_deregister_known_neuron() -> Temporary {
 }
 
 pub fn is_neuron_indexes_enabled() -> bool {
-    ENABLE_NEURON_INDEXES.get()
+    ENABLE_COMPREHENSIVE_NEURON_LIST.get()
+}
+
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_enable_comprehensive_neuron_list() -> Temporary {
+    Temporary::new(&ENABLE_DEREGISTER_KNOWN_NEURON, true)
+}
+
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_disable_comprehensive_neuron_list() -> Temporary {
+    Temporary::new(&ENABLE_DEREGISTER_KNOWN_NEURON, false)
 }
 
 pub fn decoder_config() -> DecoderConfig {


### PR DESCRIPTION
This PR add a feature flag `ENABLE_NEURON_INDEXES`, which is initially disabled, for the Neuron Index support. Before the final release, this should be enabled.