### PR TITLE
chore(crypto): include underlying error in DecryptError::InvalidChunk

### DIFF
--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/api/ni_dkg_errors.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/api/ni_dkg_errors.rs
@@ -106,7 +106,7 @@ pub enum DecryptError {
         secret_key_epoch: Epoch,
     },
     /// One of the forward-secure-encryption chunks failed to decrypt.
-    InvalidChunk,
+    InvalidChunk(String),
     /// Hardware error: This machine cannot handle this request because some
     /// parameter was too large.
     SizeError(SizeError),

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/groth20_bls12_381/encryption.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/groth20_bls12_381/encryption.rs
@@ -244,7 +244,7 @@ pub fn decrypt(
     let ciphertext = crypto::FsEncryptionCiphertext::deserialize(ciphertext)
         .map_err(DecryptError::MalformedCiphertext)?;
     crypto::dec_chunks(secret_key, index, &ciphertext, epoch, associated_data)
-        .map_err(|_| DecryptError::InvalidChunk)
+        .map_err(|e| DecryptError::InvalidChunk(format!("{e:?}")))
 }
 
 /// Zero knowledge proof of correct chunking


### PR DESCRIPTION
Enhances the DecryptError::InvalidChunk to include the debug representation of the underlying error. Currently the underlying error is swallowed, but this is useful for debugging.