### PR TITLE
feat(nns): Stop exposing KnownNeuronData in list_neurons

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -1985,7 +1985,7 @@ impl Governance {
             // requested_neuron_ids are supplied by the caller.
             let _ignore_when_neuron_not_found = self.with_neuron(neuron_id, |neuron| {
                 // Populate neuron_infos.
-                let neuron_info = neuron.get_neuron_info(self.voting_power_economics(), now, caller);
+                let neuron_info = neuron.get_neuron_info(self.voting_power_economics(), now, caller, true);
                 neuron_infos.insert(neuron_id.id, neuron_info);
 
                 // Populate full_neurons.
@@ -1999,7 +1999,7 @@ impl Governance {
                             && neuron.visibility() == Visibility::Public
                         );
                 if let_caller_read_full_neuron {
-                    full_neurons.push(neuron.clone().into_api(now, self.voting_power_economics()));
+                    full_neurons.push(neuron.clone().into_api(now, self.voting_power_economics(), true));
                 }
             });
         }
@@ -3450,7 +3450,7 @@ impl Governance {
     ) -> Result<NeuronInfo, GovernanceError> {
         let now = self.env.now();
         self.with_neuron(id, |neuron| {
-            neuron.get_neuron_info(self.voting_power_economics(), now, requester)
+            neuron.get_neuron_info(self.voting_power_economics(), now, requester, false)
         })
     }
 
@@ -3463,7 +3463,12 @@ impl Governance {
         requester: PrincipalId,
     ) -> Result<NeuronInfo, GovernanceError> {
         self.with_neuron_by_neuron_id_or_subaccount(find_by, |neuron| {
-            neuron.get_neuron_info(self.voting_power_economics(), self.env.now(), requester)
+            neuron.get_neuron_info(
+                self.voting_power_economics(),
+                self.env.now(),
+                requester,
+                false,
+            )
         })
     }
 
@@ -3498,7 +3503,7 @@ impl Governance {
 
         let now_seconds = self.env.now();
         let voting_power_economics = self.voting_power_economics();
-        Ok(native_neuron.into_api(now_seconds, voting_power_economics))
+        Ok(native_neuron.into_api(now_seconds, voting_power_economics, false))
     }
 
     // Returns the set of currently registered node providers.

--- a/rs/nns/governance/src/governance/merge_neurons.rs
+++ b/rs/nns/governance/src/governance/merge_neurons.rs
@@ -349,13 +349,21 @@ pub fn build_merge_neurons_response(
     now_seconds: u64,
     requester: PrincipalId,
 ) -> MergeResponse {
-    let source_neuron = Some(source.clone().into_api(now_seconds, voting_power_economics));
-    let target_neuron = Some(target.clone().into_api(now_seconds, voting_power_economics));
+    let source_neuron = Some(
+        source
+            .clone()
+            .into_api(now_seconds, voting_power_economics, false),
+    );
+    let target_neuron = Some(
+        target
+            .clone()
+            .into_api(now_seconds, voting_power_economics, false),
+    );
 
     let source_neuron_info =
-        Some(source.get_neuron_info(voting_power_economics, now_seconds, requester));
+        Some(source.get_neuron_info(voting_power_economics, now_seconds, requester, false));
     let target_neuron_info =
-        Some(target.get_neuron_info(voting_power_economics, now_seconds, requester));
+        Some(target.get_neuron_info(voting_power_economics, now_seconds, requester, false));
 
     MergeResponse {
         source_neuron,

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1568,7 +1568,7 @@ fn test_update_neuron_errors_out_expectedly() {
     governance.add_neuron(1, neuron).unwrap();
 
     assert_eq!(
-        governance.update_neuron(new_neuron(vec![0; 32]).into_api(0, &Default::default())),
+        governance.update_neuron(new_neuron(vec![0; 32]).into_api(0, &Default::default(), false)),
         Err(GovernanceError::new_with_message(
             ErrorType::PreconditionFailed,
             format!("Cannot change the subaccount {neuron_subaccount} of a neuron."),

--- a/rs/nns/governance/src/neuron/types.rs
+++ b/rs/nns/governance/src/neuron/types.rs
@@ -833,6 +833,7 @@ impl Neuron {
         voting_power_economics: &VotingPowerEconomics,
         now_seconds: u64,
         requester: PrincipalId,
+        multi_query: bool,
     ) -> NeuronInfo {
         let mut recent_ballots = vec![];
         let mut joined_community_fund_timestamp_seconds = None;
@@ -853,6 +854,13 @@ impl Neuron {
         let visibility = Some(self.visibility() as i32);
         let deciding_voting_power = self.deciding_voting_power(voting_power_economics, now_seconds);
         let potential_voting_power = self.potential_voting_power(now_seconds);
+        let known_neuron_data = if multi_query {
+            None
+        } else {
+            self.known_neuron_data
+                .clone()
+                .map(api::KnownNeuronData::from)
+        };
 
         NeuronInfo {
             retrieved_at_timestamp_seconds: now_seconds,
@@ -863,10 +871,7 @@ impl Neuron {
             created_timestamp_seconds: self.created_timestamp_seconds,
             stake_e8s: self.minted_stake_e8s(),
             joined_community_fund_timestamp_seconds,
-            known_neuron_data: self
-                .known_neuron_data
-                .clone()
-                .map(api::KnownNeuronData::from),
+            known_neuron_data,
             neuron_type: self.neuron_type,
             visibility,
             voting_power_refreshed_timestamp_seconds: Some(
@@ -1260,6 +1265,7 @@ impl Neuron {
         self,
         now_seconds: u64,
         voting_power_economics: &VotingPowerEconomics,
+        multi_query: bool,
     ) -> api::Neuron {
         let visibility = Some(self.visibility() as i32);
         let deciding_voting_power =
@@ -1309,7 +1315,11 @@ impl Neuron {
             .map(api::BallotInfo::from)
             .collect();
         let transfer = transfer.map(api::NeuronStakeTransfer::from);
-        let known_neuron_data = known_neuron_data.map(api::KnownNeuronData::from);
+        let known_neuron_data = if multi_query {
+            None
+        } else {
+            known_neuron_data.map(api::KnownNeuronData::from)
+        };
 
         let followees = followees
             .into_iter()

--- a/rs/nns/governance/src/neuron/types/tests.rs
+++ b/rs/nns/governance/src/neuron/types/tests.rs
@@ -52,9 +52,11 @@ fn test_neuron_into_api() {
     original_neuron.recent_ballots_next_entry_index = Some(3);
 
     // Step 2: run code under test.
-    let api_neuron = original_neuron
-        .clone()
-        .into_api(some_timestamp_seconds + 99, &VotingPowerEconomics::DEFAULT);
+    let api_neuron = original_neuron.clone().into_api(
+        some_timestamp_seconds + 99,
+        &VotingPowerEconomics::DEFAULT,
+        false,
+    );
 
     // Step 3: Inspect result(s).
 
@@ -570,6 +572,7 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
             &VotingPowerEconomics::DEFAULT,
             timestamp_seconds,
             principal_id,
+            false,
         );
         assert_eq!(neuron_info.visibility, Some(visibility as i32),);
     }
@@ -584,6 +587,7 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
         &VotingPowerEconomics::DEFAULT,
         timestamp_seconds,
         principal_id,
+        false,
     );
     assert_eq!(neuron_info.visibility, Some(Visibility::Private as i32),);
 
@@ -602,6 +606,7 @@ fn test_visibility_when_converting_neuron_to_neuron_info_and_neuron_proto() {
         &VotingPowerEconomics::DEFAULT,
         timestamp_seconds,
         principal_id,
+        false,
     );
     assert_eq!(neuron_info.visibility, Some(Visibility::Public as i32),);
 }

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -13,6 +13,9 @@ on the process that this file is part of, see
 
 ## Changed
 
+* Stop exposing known neuron data in list_neurons so that it's less likely to exceed message size
+  limit.
+
 ## Deprecated
 
 * The `StopOrStartCanister` NNS Function is now obsolete (Use `Action::StopOrStartCanister`


### PR DESCRIPTION
# Why

As we add more and more data into KnownNeuronData (especially links), it becomes more likely that they will make list_neurons exceeds the message size limit (arguable, it was already the case before recent changes).

# What

For list_neurons, not include known_neuron_data in "neuron info" or "full neuron"