### PR TITLE
feat(nns): Expose known neuron voting history

### DIFF
--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -4390,3 +4390,24 @@ pub struct MaturityDisbursement {
     /// The account identifier to disburse the maturity to.
     pub account_identifier_to_disburse_to: Option<AccountIdentifier>,
 }
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Debug, Clone, PartialEq)]
+pub struct ListNeuronVotesRequest {
+    pub neuron_id: Option<NeuronId>,
+    pub before_proposal: Option<ProposalId>,
+    pub limit: Option<u64>,
+}
+
+pub type ListNeuronVotesResponse = Result<NeuronVotes, GovernanceError>;
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Debug, Clone, PartialEq)]
+pub struct NeuronVotes {
+    pub votes: Option<Vec<NeuronVote>>,
+    pub all_finalized_before_proposal: Option<ProposalId>,
+}
+
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Debug, Clone, PartialEq)]
+pub struct NeuronVote {
+    pub proposal_id: Option<ProposalId>,
+    pub vote: Option<Vote>,
+}

--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -27,14 +27,14 @@ use ic_nns_governance_api::test_api::TimeWarp;
 use ic_nns_governance_api::{
     ClaimOrRefreshNeuronFromAccount, ClaimOrRefreshNeuronFromAccountResponse,
     GetNeuronsFundAuditInfoRequest, GetNeuronsFundAuditInfoResponse,
-    Governance as ApiGovernanceProto, GovernanceError, ListKnownNeuronsResponse, ListNeurons,
-    ListNeuronsResponse, ListNodeProviderRewardsRequest, ListNodeProviderRewardsResponse,
-    ListNodeProvidersResponse, ListProposalInfo, ListProposalInfoResponse,
-    ManageNeuronCommandRequest, ManageNeuronRequest, ManageNeuronResponse,
-    MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo, NodeProvider, Proposal,
-    ProposalInfo, RestoreAgingSummary, RewardEvent, SettleCommunityFundParticipation,
-    SettleNeuronsFundParticipationRequest, SettleNeuronsFundParticipationResponse,
-    UpdateNodeProvider, Vote,
+    Governance as ApiGovernanceProto, GovernanceError, ListKnownNeuronsResponse,
+    ListNeuronVotesRequest, ListNeuronVotesResponse, ListNeurons, ListNeuronsResponse,
+    ListNodeProviderRewardsRequest, ListNodeProviderRewardsResponse, ListNodeProvidersResponse,
+    ListProposalInfo, ListProposalInfoResponse, ManageNeuronCommandRequest, ManageNeuronRequest,
+    ManageNeuronResponse, MonthlyNodeProviderRewards, NetworkEconomics, Neuron, NeuronInfo,
+    NodeProvider, Proposal, ProposalInfo, RestoreAgingSummary, RewardEvent,
+    SettleCommunityFundParticipation, SettleNeuronsFundParticipationRequest,
+    SettleNeuronsFundParticipationResponse, UpdateNodeProvider, Vote,
     claim_or_refresh_neuron_from_account_response::Result as ClaimOrRefreshNeuronFromAccountResponseResult,
     governance::GovernanceCachedMetrics,
     governance_error::ErrorType,
@@ -550,6 +550,11 @@ fn get_neuron_data_validation_summary() -> NeuronDataValidationSummary {
 fn get_restore_aging_summary() -> RestoreAgingSummary {
     let response = governance().get_restore_aging_summary().unwrap_or_default();
     RestoreAgingSummary::from(response)
+}
+
+#[query]
+fn list_neuron_votes(request: ListNeuronVotesRequest) -> ListNeuronVotesResponse {
+    with_governance(|governance| governance.list_neuron_votes(request))
 }
 
 #[query(

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -1333,6 +1333,46 @@ type MaturityDisbursement = record {
   account_identifier_to_disburse_to : opt AccountIdentifier;
 };
 
+type ListNeuronVotesRequest = record {
+  // The neuron id for which the voting history will be returned. Currently, the voting history is
+  // only recorded for known neurons.
+  neuron_id : opt NeuronId;
+  // Only fetch the voting history for proposal whose id `< before_proposal`. This can be used as a
+  // pagination token - pass the minimum proposal id as `before_proposal` for the next page.
+  before_proposal : opt ProposalId;
+  // The maximum number of votes to fetch. The maximum number allowed is 500, and 500 will be used
+  // if is set as either null or > 500.
+  limit : opt nat64;
+};
+
+type ListNeuronVotesResponse = variant {
+  Ok : record {
+    votes : opt vec NeuronVote;
+    // All the proposals before this id is "finalized", which means if a proposal before this id
+    // does not exist in the votes, it will never appear in the voting history, either because the
+    // neuron is not eligible to vote on the proposal, or the neuron is not a known neuron at the
+    // time of the proposal creation. Therefore, if a client syncs the entire voting history of a
+    // certain neuron and store `all_finalized_before_proposal`, it doesn't need to start from
+    // scratch the next time - it can stop as soon as they have seen any votes 
+    // `< all_finalized_before_proposal`.
+    all_finalized_before_proposal : opt ProposalId;
+  };
+  Err : GovernanceError;
+};
+
+type NeuronVote = record {
+  proposal_id : opt ProposalId;
+  // The vote of the neuron on the specific proposal id.
+  vote : opt Vote;
+};
+
+type Vote = variant {
+  // Abstentions are recorded as Unspecified.
+  Unspecified;
+  Yes;
+  No;
+};
+
 service : (Governance) -> {
   claim_gtc_neurons : (principal, vec NeuronId) -> (Result);
   claim_or_refresh_neuron_from_account : (ClaimOrRefreshNeuronFromAccount) -> (
@@ -1369,6 +1409,7 @@ service : (Governance) -> {
     ) query;
   list_node_providers : () -> (ListNodeProvidersResponse) query;
   list_proposals : (ListProposalInfo) -> (ListProposalInfoResponse) query;
+  list_neuron_votes : (ListNeuronVotesRequest) -> (ListNeuronVotesResponse) query;
   manage_neuron : (ManageNeuronRequest) -> (ManageNeuronResponse);
   settle_community_fund_participation : (SettleCommunityFundParticipation) -> (
       Result,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -70,7 +70,7 @@ use crate::{
         },
     },
     proposals::{call_canister::CallCanister, sum_weighted_voting_power},
-    storage::{VOTING_POWER_SNAPSHOTS, with_voting_history_store_mut},
+    storage::{VOTING_POWER_SNAPSHOTS, with_voting_history_store, with_voting_history_store_mut},
 };
 use async_trait::async_trait;
 use candid::{Decode, Encode};
@@ -96,8 +96,9 @@ use ic_nns_constants::{
     SNS_WASM_CANISTER_ID, SUBNET_RENTAL_CANISTER_ID,
 };
 use ic_nns_governance_api::{
-    self as api, CreateServiceNervousSystem as ApiCreateServiceNervousSystem, ListNeurons,
-    ListNeuronsResponse, ListProposalInfoResponse, ManageNeuronResponse, NeuronInfo, ProposalInfo,
+    self as api, CreateServiceNervousSystem as ApiCreateServiceNervousSystem,
+    ListNeuronVotesRequest, ListNeurons, ListNeuronsResponse, ListProposalInfoResponse,
+    ManageNeuronResponse, NeuronInfo, NeuronVote, NeuronVotes, ProposalInfo,
     manage_neuron_response::{self, StakeMaturityResponse},
     proposal_validation,
     subnet_rental::SubnetRentalRequest,
@@ -2024,6 +2025,46 @@ impl Governance {
             .collect();
 
         ListKnownNeuronsResponse { known_neurons }
+    }
+
+    pub fn list_neuron_votes(
+        &self,
+        request: ListNeuronVotesRequest,
+    ) -> Result<NeuronVotes, api::GovernanceError> {
+        let ListNeuronVotesRequest {
+            neuron_id,
+            before_proposal,
+            limit,
+        } = request;
+        let neuron_id = neuron_id.ok_or(GovernanceError::new_with_message(
+            ErrorType::PreconditionFailed,
+            "Neuron ID is required",
+        ))?;
+
+        let votes = with_voting_history_store(|voting_history| {
+            voting_history.list_neuron_votes(neuron_id, before_proposal, limit)
+        });
+        let votes = votes
+            .into_iter()
+            .map(|(proposal_id, vote)| NeuronVote {
+                proposal_id: Some(proposal_id),
+                vote: Some(vote.into()),
+            })
+            .collect();
+
+        let all_finalized_before_proposal =
+            self.heap_data.proposals.iter().find_map(|(id, proposal)| {
+                if proposal.ballots.is_empty() {
+                    None
+                } else {
+                    Some(ProposalId { id: *id })
+                }
+            });
+
+        Ok(NeuronVotes {
+            votes: Some(votes),
+            all_finalized_before_proposal,
+        })
     }
 
     /// Claim the neurons supplied by the GTC on behalf of `new_controller`

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -1840,13 +1840,25 @@ fn test_record_known_neuron_abstentions() {
 
     with_voting_history_store(|voting_history| {
         assert_eq!(
-            voting_history.list_neuron_votes(NeuronId { id: 1 }),
+            voting_history.list_neuron_votes(NeuronId { id: 1 }, None, Some(100)),
             vec![(ProposalId { id: 1 }, Vote::Unspecified)]
         );
-        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 2 }), vec![]);
-        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 3 }), vec![]);
-        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 4 }), vec![]);
-        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 5 }), vec![]);
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 2 }, None, Some(100)),
+            vec![]
+        );
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 3 }, None, Some(100)),
+            vec![]
+        );
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 4 }, None, Some(100)),
+            vec![]
+        );
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 5 }, None, Some(100)),
+            vec![]
+        );
     });
 
     record_known_neuron_abstentions(
@@ -1861,15 +1873,24 @@ fn test_record_known_neuron_abstentions() {
 
     with_voting_history_store(|voting_history| {
         assert_eq!(
-            voting_history.list_neuron_votes(NeuronId { id: 1 }),
+            voting_history.list_neuron_votes(NeuronId { id: 1 }, None, Some(100)),
             vec![(ProposalId { id: 1 }, Vote::Unspecified),]
         );
-        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 2 }), vec![]);
         assert_eq!(
-            voting_history.list_neuron_votes(NeuronId { id: 3 }),
+            voting_history.list_neuron_votes(NeuronId { id: 2 }, None, Some(100)),
+            vec![]
+        );
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 3 }, None, Some(100)),
             vec![(ProposalId { id: 2 }, Vote::Unspecified)]
         );
-        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 4 }), vec![]);
-        assert_eq!(voting_history.list_neuron_votes(NeuronId { id: 5 }), vec![]);
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 4 }, None, Some(100)),
+            vec![]
+        );
+        assert_eq!(
+            voting_history.list_neuron_votes(NeuronId { id: 5 }, None, Some(100)),
+            vec![]
+        );
     });
 }

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -1047,8 +1047,9 @@ fn test_record_neuron_vote() {
         }]
     );
 
-    let voting_history =
-        with_voting_history_store(|voting_history| voting_history.list_neuron_votes(neuron_id));
+    let voting_history = with_voting_history_store(|voting_history| {
+        voting_history.list_neuron_votes(neuron_id, None, Some(10))
+    });
     if cfg!(feature = "test") {
         assert_eq!(voting_history, vec![(ProposalId { id: 1 }, Vote::Yes)]);
     } else {

--- a/rs/nns/governance/src/voting_history_store_tests.rs
+++ b/rs/nns/governance/src/voting_history_store_tests.rs
@@ -21,12 +21,12 @@ fn proposal_id(id: u64) -> ProposalId {
 fn test_record_and_retrieve_single_vote() {
     let mut store = create_test_store();
 
-    let empty_votes = store.list_neuron_votes(neuron_id(1));
+    let empty_votes = store.list_neuron_votes(neuron_id(1), None, Some(100));
     assert_eq!(empty_votes, vec![]);
 
     store.record_vote(neuron_id(123), proposal_id(456), Vote::Yes);
 
-    let votes = store.list_neuron_votes(neuron_id(123));
+    let votes = store.list_neuron_votes(neuron_id(123), None, Some(100));
     assert_eq!(votes, vec![(proposal_id(456), Vote::Yes)]);
 }
 
@@ -40,13 +40,14 @@ fn test_record_multiple_votes_same_neuron() {
     store.record_vote(test_neuron_id, proposal_id(4), Vote::Unspecified);
     store.record_vote(test_neuron_id, proposal_id(3), Vote::Yes);
 
+    // Votes should be returned in descending order by proposal ID
     assert_eq!(
-        store.list_neuron_votes(test_neuron_id),
+        store.list_neuron_votes(test_neuron_id, None, Some(100)),
         vec![
-            (proposal_id(1), Vote::No),
-            (proposal_id(2), Vote::Yes),
-            (proposal_id(3), Vote::Yes),
             (proposal_id(4), Vote::Unspecified),
+            (proposal_id(3), Vote::Yes),
+            (proposal_id(2), Vote::Yes),
+            (proposal_id(1), Vote::No),
         ]
     );
 }
@@ -65,15 +66,16 @@ fn test_record_votes_different_neurons() {
     store.record_vote(neuron_id_1, proposal_id_2, Vote::No);
     store.record_vote(neuron_id_2, proposal_id_2, Vote::Yes);
 
+    // Votes should be returned in descending order by proposal ID
     assert_eq!(
-        store.list_neuron_votes(neuron_id_1),
-        vec![(proposal_id_1, Vote::Yes), (proposal_id_2, Vote::No)]
+        store.list_neuron_votes(neuron_id_1, None, Some(100)),
+        vec![(proposal_id_2, Vote::No), (proposal_id_1, Vote::Yes)]
     );
     assert_eq!(
-        store.list_neuron_votes(neuron_id_2),
+        store.list_neuron_votes(neuron_id_2, None, Some(100)),
         vec![
+            (proposal_id_2, Vote::Yes),
             (proposal_id_1, Vote::Unspecified),
-            (proposal_id_2, Vote::Yes)
         ]
     );
 }
@@ -87,11 +89,97 @@ fn test_overwrite_existing_vote() {
 
     store.record_vote(test_neuron_id, test_proposal_id, Vote::Unspecified);
 
-    let votes = store.list_neuron_votes(test_neuron_id);
+    let votes = store.list_neuron_votes(test_neuron_id, None, Some(100));
     assert_eq!(votes, vec![(test_proposal_id, Vote::Unspecified)]);
 
     store.record_vote(test_neuron_id, test_proposal_id, Vote::No);
 
-    let votes = store.list_neuron_votes(test_neuron_id);
+    let votes = store.list_neuron_votes(test_neuron_id, None, Some(100));
     assert_eq!(votes, vec![(test_proposal_id, Vote::No)]);
+}
+
+#[test]
+fn test_list_neuron_votes_with_limit() {
+    let mut store = create_test_store();
+    let test_neuron_id = neuron_id(123);
+
+    for i in 1..=5 {
+        store.record_vote(test_neuron_id, proposal_id(i), Vote::Yes);
+    }
+
+    let votes = store.list_neuron_votes(test_neuron_id, None, Some(3));
+    assert_eq!(
+        votes,
+        vec![
+            (proposal_id(5), Vote::Yes),
+            (proposal_id(4), Vote::Yes),
+            (proposal_id(3), Vote::Yes),
+        ]
+    );
+}
+
+#[test]
+fn test_list_neuron_votes_with_before_proposal() {
+    let mut store = create_test_store();
+    let test_neuron_id = neuron_id(123);
+
+    for i in 1..=10 {
+        store.record_vote(test_neuron_id, proposal_id(i), Vote::Yes);
+    }
+
+    let votes = store.list_neuron_votes(test_neuron_id, Some(proposal_id(8)), Some(3));
+    assert_eq!(
+        votes,
+        vec![
+            (proposal_id(7), Vote::Yes),
+            (proposal_id(6), Vote::Yes),
+            (proposal_id(5), Vote::Yes),
+        ]
+    );
+
+    let votes = store.list_neuron_votes(test_neuron_id, Some(proposal_id(1)), Some(10));
+    assert_eq!(votes, vec![]);
+}
+
+#[test]
+fn test_pagination_sync_entire_voting_history() {
+    let mut store = create_test_store();
+    let test_neuron_id = neuron_id(42);
+
+    let proposal_ids = vec![1, 3, 5, 7, 9, 12, 15, 18, 20, 25];
+    for &id in &proposal_ids {
+        store.record_vote(test_neuron_id, proposal_id(id), Vote::Yes);
+    }
+
+    let mut all_votes = Vec::new();
+    let mut before_proposal = None;
+    let limit = 3;
+
+    loop {
+        let batch = store.list_neuron_votes(test_neuron_id, before_proposal, Some(limit));
+
+        if batch.is_empty() {
+            break;
+        }
+
+        all_votes.extend(batch.clone());
+
+        before_proposal = Some(batch.last().unwrap().0);
+    }
+
+    assert_eq!(
+        all_votes,
+        vec![
+            (proposal_id(25), Vote::Yes),
+            (proposal_id(20), Vote::Yes),
+            (proposal_id(18), Vote::Yes),
+            (proposal_id(15), Vote::Yes),
+            (proposal_id(12), Vote::Yes),
+            (proposal_id(9), Vote::Yes),
+            (proposal_id(7), Vote::Yes),
+            (proposal_id(5), Vote::Yes),
+            (proposal_id(3), Vote::Yes),
+            (proposal_id(1), Vote::Yes),
+        ]
+    );
 }

--- a/rs/nns/integration_tests/src/known_neurons.rs
+++ b/rs/nns/integration_tests/src/known_neurons.rs
@@ -1,21 +1,25 @@
-use ic_nervous_system_common::ONE_YEAR_SECONDS;
+use ic_base_types::PrincipalId;
+use ic_nervous_system_common::{ONE_DAY_SECONDS, ONE_YEAR_SECONDS};
 use ic_nervous_system_common_test_keys::{
     TEST_NEURON_1_OWNER_PRINCIPAL, TEST_NEURON_2_OWNER_PRINCIPAL,
 };
-use ic_nns_common::pb::v1::NeuronId;
+use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_governance_api::{
     DeregisterKnownNeuron, KnownNeuron, KnownNeuronData, ListKnownNeuronsResponse,
+    MakeProposalRequest, Motion, ProposalActionRequest, Vote, manage_neuron_response::Command,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
     state_test_helpers::{
         list_known_neurons, nns_claim_or_refresh_neuron, nns_deregister_known_neuron,
-        nns_governance_get_neuron_info, nns_increase_dissolve_delay, nns_register_known_neuron,
-        nns_send_icp_to_claim_or_refresh_neuron, setup_nns_canisters,
-        state_machine_builder_for_nns_tests,
+        nns_governance_get_neuron_info, nns_governance_make_proposal, nns_increase_dissolve_delay,
+        nns_list_neuron_votes, nns_register_known_neuron, nns_send_icp_to_claim_or_refresh_neuron,
+        setup_nns_canisters, state_machine_builder_for_nns_tests,
     },
 };
+use ic_state_machine_tests::StateMachine;
 use icp_ledger::{AccountIdentifier, Tokens};
+use std::time::Duration;
 
 /// Integration test for the known neuron functionality including deregistration.
 ///
@@ -29,7 +33,7 @@ use icp_ledger::{AccountIdentifier, Tokens};
 /// - Update the remaining known neuron to have a description.
 /// - Assert entire list_known_neurons response equals expected 1-neuron list with description.
 #[test]
-fn test_known_neurons() {
+fn test_known_neurons_lifecycle() {
     // Step 1.1: Prepare the world by setting up NNS canisters with 2 principals both with 10 ICP.
     let state_machine = state_machine_builder_for_nns_tests().build();
     let principal_1 = *TEST_NEURON_1_OWNER_PRINCIPAL;
@@ -232,4 +236,106 @@ fn test_known_neurons() {
             links: Some(vec!["https://example.com".to_string()]),
         }
     );
+}
+
+fn make_motion_proposal(
+    state_machine: &StateMachine,
+    sender: PrincipalId,
+    neuron_id: NeuronId,
+) -> ProposalId {
+    let response = nns_governance_make_proposal(
+        state_machine,
+        sender,
+        neuron_id,
+        &MakeProposalRequest {
+            title: Some("Some title".to_string()),
+            summary: "Some summary".to_string(),
+            url: "".to_string(),
+            action: Some(ProposalActionRequest::Motion(Motion {
+                motion_text: "Motion text".to_string(),
+            })),
+        },
+    );
+    match response.command {
+        Some(Command::MakeProposal(make_proposal_response)) => {
+            make_proposal_response.proposal_id.unwrap()
+        }
+        _ => panic!("Failed to make motion proposal: {response:?}"),
+    }
+}
+
+#[test]
+fn test_known_neurons_voting_history() {
+    // Step 1: Prepare the world by setting up NNS canisters with a principal with 10 ICP.
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    let principal = *TEST_NEURON_1_OWNER_PRINCIPAL;
+    let nns_init_payloads = NnsInitPayloadsBuilder::new()
+        .with_ledger_account(
+            AccountIdentifier::new(principal, None),
+            Tokens::from_e8s(1_000_000_000),
+        )
+        .build();
+    setup_nns_canisters(&state_machine, nns_init_payloads);
+
+    // Step 2: Claim 2 neurons, while the first neuron has majority of voting power.
+    nns_send_icp_to_claim_or_refresh_neuron(
+        &state_machine,
+        principal,
+        Tokens::from_e8s(700_000_000),
+        1,
+    );
+    nns_send_icp_to_claim_or_refresh_neuron(
+        &state_machine,
+        principal,
+        Tokens::from_e8s(200_000_000),
+        2,
+    );
+    let neuron_id_1 = nns_claim_or_refresh_neuron(&state_machine, principal, 1);
+    let neuron_id_2 = nns_claim_or_refresh_neuron(&state_machine, principal, 2);
+
+    // Step 3: Increase dissolve delay so both neurons are voting eligible.
+    nns_increase_dissolve_delay(&state_machine, principal, neuron_id_1, ONE_YEAR_SECONDS)
+        .expect("Failed to increase dissolve delay for neuron 1");
+    nns_increase_dissolve_delay(&state_machine, principal, neuron_id_2, ONE_YEAR_SECONDS)
+        .expect("Failed to increase dissolve delay for neuron 2");
+
+    // Step 3: Register neuron 1 as a known neuron.
+    let proposal_id_register_known_neuron = nns_register_known_neuron(
+        &state_machine,
+        principal,
+        neuron_id_1,
+        KnownNeuron {
+            id: Some(NeuronId { id: neuron_id_1.id }),
+            known_neuron_data: Some(KnownNeuronData {
+                name: "NeuronOne".to_string(),
+                description: Some("First test neuron".to_string()),
+                links: Some(vec![]),
+            }),
+        },
+    );
+
+    // Step 4: Make 2 proposals, one voted by neuron 1 and one not voted by neuron 1.
+    let proposal_id_voted_by_neuron_1 =
+        make_motion_proposal(&state_machine, principal, neuron_id_1);
+    let proposal_id_not_voted_by_neuron_1 =
+        make_motion_proposal(&state_machine, principal, neuron_id_2);
+
+    // Step 5: Advance time and tick so that the proposals reach their deadline.
+    state_machine.advance_time(Duration::from_secs(ONE_DAY_SECONDS * 10));
+    for _ in 0..10 {
+        state_machine.tick();
+    }
+
+    // Step 6: Verify the votes of neuron 1 (including abstentions).
+    assert_eq!(
+        nns_list_neuron_votes(&state_machine, neuron_id_1),
+        vec![
+            (proposal_id_not_voted_by_neuron_1, Vote::Unspecified),
+            (proposal_id_voted_by_neuron_1, Vote::Yes),
+            (proposal_id_register_known_neuron, Vote::Yes),
+        ]
+    );
+
+    // Step 7: Verify that there are no votes for neuron 2 as it's not a known neuron.
+    assert_eq!(nns_list_neuron_votes(&state_machine, neuron_id_2), vec![]);
 }


### PR DESCRIPTION
# Why

As the voting history will be persisted for all known neurons (more details [here](https://forum.dfinity.org/t/better-known-neurons/55747)), we need a way to fetch the voting history.

# What

Implement a list_neuron_votes method for fetching the voting history of a given neuron.