### PR TITLE
chore(PocketIC): top up anonymous account on cycles ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19311,6 +19311,7 @@ dependencies = [
  "ic-utils-thread",
  "ic-validator-ingress-message",
  "icp-ledger",
+ "icrc-ledger-types",
  "itertools 0.12.1",
  "libc",
  "nix 0.29.0",

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -590,7 +590,7 @@ pub struct IcpFeatures {
     pub cycles_minting: Option<IcpFeaturesConfig>,
     /// Deploys the ICP ledger and index canisters and initializes the ICP account of the anonymous principal with 1,000,000,000 ICP.
     pub icp_token: Option<IcpFeaturesConfig>,
-    /// Deploys the cycles ledger and index canisters.
+    /// Deploys the cycles ledger and index canisters and initializes the cycles account of the anonymous principal with 2^127 cycles.
     pub cycles_token: Option<IcpFeaturesConfig>,
     /// Deploys the NNS governance and root canisters and sets up an initial NNS neuron with 1 ICP stake.
     /// The initial NNS neuron is controlled by the anonymous principal.

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -8,6 +8,7 @@ LIB_DEPENDENCIES = [
     # Keep sorted.
     "//packages/ic-ed25519",
     "//packages/ic-error-types",
+    "//packages/icrc-ledger-types",
     "//packages/pocket-ic:pocket-ic",
     "//rs/bitcoin/adapter",
     "//rs/boundary_node/ic_boundary",

--- a/rs/pocket_ic_server/Cargo.toml
+++ b/rs/pocket_ic_server/Cargo.toml
@@ -77,6 +77,7 @@ ic-types = { path = "../types/types" }
 ic-utils = { workspace = true }
 ic-utils-thread = { path = "../utils/thread" }
 ic-validator-ingress-message = { path = "../validator/ingress_message" }
+icrc-ledger-types = { path = "../../packages/icrc-ledger-types" }
 itertools = { workspace = true }
 libc = { workspace = true }
 pocket-ic = { path = "../../packages/pocket-ic" }

--- a/rs/pocket_ic_server/src/external_canister_types.rs
+++ b/rs/pocket_ic_server/src/external_canister_types.rs
@@ -1,4 +1,5 @@
 use candid::{CandidType, Principal};
+use icrc_ledger_types::icrc1::account::Account;
 
 /* NNS dapp */
 
@@ -21,6 +22,7 @@ pub struct SnsAggregatorConfig {
 pub struct CyclesLedgerConfig {
     pub max_blocks_per_request: u64,
     pub index_id: Option<Principal>,
+    pub initial_balances: Option<Vec<(Account, u128)>>,
 }
 
 #[derive(CandidType)]

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -111,6 +111,7 @@ use ic_types::{
 use ic_types::{NumBytes, Time};
 use ic_validator_ingress_message::StandaloneIngressSigVerifier;
 use icp_ledger::{AccountIdentifier, LedgerCanisterInitPayloadBuilder, Subaccount, Tokens};
+use icrc_ledger_types::icrc1::account::Account;
 use itertools::Itertools;
 use pocket_ic::common::rest::{
     self, BinaryBlob, BlobCompression, CanisterHttpHeader, CanisterHttpMethod, CanisterHttpRequest,
@@ -1430,9 +1431,14 @@ impl PocketIcSubnets {
             // `dfx canister call um5iw-rqaaa-aaaaq-qaaba-cai icrc1_metadata --ic --update`:
             //   record { "dfn:max_blocks_per_request"; variant { Nat = 50 : nat } };
             //   record { "dfn:index_id"; variant { Blob = blob "\00\00\00\00\02\10\00\03\01\01" }; };
+            let anonymous_account = Account {
+                owner: Principal::anonymous(),
+                subaccount: None,
+            };
             let cycles_ledger_config = CyclesLedgerConfig {
                 max_blocks_per_request: 50,
                 index_id: Some(CYCLES_LEDGER_INDEX_CANISTER_ID.into()),
+                initial_balances: Some(vec![(anonymous_account, INITIAL_CYCLES)]),
             };
             let cycles_ledger_args = CyclesLedgerArgs::Init(cycles_ledger_config);
             ii_subnet


### PR DESCRIPTION
This PR initializes the cycles account of the anonymous principal with `2^127` cycles if the `cycles_token` feature is requested during PocketIC instance creation. This flow has only been enabled on the cycles ledger recently and thus it is added to PocketIC now.