### PR TITLE
refactor(consensus): move `cup_utils` to its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7660,6 +7660,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-consensus-cup-utils"
+version = "0.9.0"
+dependencies = [
+ "ic-consensus-dkg",
+ "ic-consensus-idkg",
+ "ic-crypto-test-utils-ni-dkg",
+ "ic-interfaces-registry",
+ "ic-logger",
+ "ic-protobuf",
+ "ic-registry-client-helpers",
+ "ic-types",
+ "ic-types-test-utils",
+ "phantom_newtype",
+ "prost 0.13.4",
+ "slog",
+]
+
+[[package]]
 name = "ic-consensus-dkg"
 version = "0.9.0"
 dependencies = [
@@ -12797,6 +12815,7 @@ dependencies = [
  "ic-config",
  "ic-consensus",
  "ic-consensus-certification",
+ "ic-consensus-cup-utils",
  "ic-consensus-dkg",
  "ic-consensus-utils",
  "ic-crypto-for-verification-only",
@@ -14009,6 +14028,7 @@ dependencies = [
  "ic-btc-consensus",
  "ic-config",
  "ic-consensus",
+ "ic-consensus-cup-utils",
  "ic-consensus-utils",
  "ic-crypto-iccsa",
  "ic-crypto-interfaces-sig-verification",
@@ -18517,7 +18537,7 @@ dependencies = [
  "hyper-util",
  "ic-agent",
  "ic-config",
- "ic-consensus",
+ "ic-consensus-cup-utils",
  "ic-consensus-dkg",
  "ic-crypto",
  "ic-crypto-node-key-generation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
     "rs/config",
     "rs/consensus",
     "rs/consensus/certification",
+    "rs/consensus/cup_utils",
     "rs/consensus/dkg",
     "rs/consensus/idkg",
     "rs/consensus/mocks",
@@ -901,4 +902,3 @@ zstd = "0.13.2"
 default-features = false
 features = ["exe"]
 version = "^0.8.1"
-

--- a/rs/consensus/cup_utils/BUILD.bazel
+++ b/rs/consensus/cup_utils/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "cup_utils",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "ic_consensus_cup_utils",
+    version = "0.9.0",
+    deps = [
+        "//rs/consensus/dkg",
+        "//rs/consensus/idkg",
+        "//rs/interfaces/registry",
+        "//rs/monitoring/logger",
+        "//rs/phantom_newtype",
+        "//rs/protobuf",
+        "//rs/registry/helpers",
+        "//rs/types/types",
+        "@crate_index//:slog",
+    ]
+)
+
+rust_test(
+    name = "cup_utils_test",
+    crate = ":cup_utils",
+    deps = [
+        "//rs/crypto/test_utils/ni-dkg",
+        "//rs/types/types_test_utils",
+        "@crate_index//:prost",
+    ]
+)

--- a/rs/consensus/cup_utils/Cargo.toml
+++ b/rs/consensus/cup_utils/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ic-consensus-cup-utils"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description.workspace = true
+documentation.workspace = true
+
+[dependencies]
+ic-consensus-idkg = { path = "../idkg" }
+ic-consensus-dkg = { path = "../dkg" }
+ic-interfaces-registry = { path = "../../interfaces/registry" }
+ic-logger = { path = "../../monitoring/logger" }
+ic-protobuf = { path = "../../protobuf" }
+ic-registry-client-helpers = { path = "../../registry/helpers" }
+ic-types = { path = "../../types/types" }
+phantom_newtype = { path = "../../phantom_newtype" }
+slog = { workspace = true }
+
+[dev-dependencies]
+ic-crypto-test-utils-ni-dkg = { path = "../../crypto/test_utils/ni-dkg" }
+ic-types-test-utils = { path = "../../types/types_test_utils" }
+prost = { workspace = true }

--- a/rs/consensus/cup_utils/src/lib.rs
+++ b/rs/consensus/cup_utils/src/lib.rs
@@ -243,7 +243,8 @@ fn bootstrap_idkg_summary(
 
 #[cfg(test)]
 mod tests {
-    use crate::cup_utils::make_registry_cup;
+    use super::*;
+
     use ic_crypto_test_utils_ni_dkg::dummy_initial_dkg_transcript;
     use ic_interfaces_registry::{RegistryClient, RegistryVersionedRecord};
     use ic_logger::no_op_logger;

--- a/rs/consensus/src/lib.rs
+++ b/rs/consensus/src/lib.rs
@@ -6,5 +6,3 @@
 //! by the upper layers of the internet computer.
 
 pub mod consensus;
-pub mod cup_utils;
-pub use cup_utils::{make_registry_cup, make_registry_cup_from_cup_contents};

--- a/rs/orchestrator/BUILD.bazel
+++ b/rs/orchestrator/BUILD.bazel
@@ -20,7 +20,7 @@ rust_library(
         # Keep sorted.
         "//packages/ic-ed25519",
         "//rs/config",
-        "//rs/consensus",
+        "//rs/consensus/cup_utils",
         "//rs/consensus/dkg",
         "//rs/crypto",
         "//rs/crypto/node_key_generation",

--- a/rs/orchestrator/Cargo.toml
+++ b/rs/orchestrator/Cargo.toml
@@ -22,7 +22,7 @@ hyper-util = { workspace = true }
 hyper-rustls = { workspace = true }
 ic-agent = { workspace = true }
 ic-config = { path = "../config" }
-ic-consensus = { path = "../consensus" }
+ic-consensus-cup-utils = { path = "../consensus/cup_utils" }
 ic-consensus-dkg = { path = "../consensus/dkg" }
 ic-crypto = { path = "../crypto" }
 ic-crypto-node-key-generation = { path = "../crypto/node_key_generation" }

--- a/rs/orchestrator/src/registry_helper.rs
+++ b/rs/orchestrator/src/registry_helper.rs
@@ -1,5 +1,5 @@
 use crate::error::{OrchestratorError, OrchestratorResult};
-use ic_consensus::make_registry_cup;
+use ic_consensus_cup_utils::make_registry_cup;
 use ic_interfaces_registry::RegistryClient;
 use ic_logger::ReplicaLogger;
 use ic_protobuf::registry::{

--- a/rs/replay/BUILD.bazel
+++ b/rs/replay/BUILD.bazel
@@ -8,6 +8,7 @@ DEPENDENCIES = [
     "//rs/config",
     "//rs/consensus",
     "//rs/consensus/certification",
+    "//rs/consensus/cup_utils",
     "//rs/consensus/dkg",
     "//rs/consensus/utils",
     "//rs/crypto",

--- a/rs/replay/Cargo.toml
+++ b/rs/replay/Cargo.toml
@@ -17,6 +17,7 @@ ic-canister-sandbox-backend-lib = { path = "../canister_sandbox" }
 ic-config = { path = "../config" }
 ic-consensus = { path = "../consensus" }
 ic-consensus-certification = { path = "../consensus/certification" }
+ic-consensus-cup-utils = { path = "../consensus/cup_utils" }
 ic-consensus-dkg = { path = "../consensus/dkg" }
 ic-consensus-utils = { path = "../consensus/utils" }
 ic-crypto-for-verification-only = { path = "../crypto/for_verification_only" }

--- a/rs/replay/src/lib.rs
+++ b/rs/replay/src/lib.rs
@@ -254,7 +254,7 @@ fn cmd_get_recovery_cup(
         chain_key_initializations: vec![],
     };
 
-    let cup = ic_consensus::make_registry_cup_from_cup_contents(
+    let cup = ic_consensus_cup_utils::make_registry_cup_from_cup_contents(
         &*player.registry,
         player.subnet_id,
         cup_contents,

--- a/rs/replica/BUILD.bazel
+++ b/rs/replica/BUILD.bazel
@@ -10,6 +10,7 @@ DEPENDENCIES = [
     "//rs/bitcoin/consensus",
     "//rs/config",
     "//rs/consensus/certification",
+    "//rs/consensus/cup_utils",
     "//rs/crypto",
     "//rs/crypto/sha2",
     "//rs/cycles_account_manager",

--- a/rs/replica/Cargo.toml
+++ b/rs/replica/Cargo.toml
@@ -17,6 +17,7 @@ ic-btc-consensus = { path = "../bitcoin/consensus" }
 ic-config = { path = "../config" }
 ic-consensus = { path = "../consensus" }
 ic-consensus-certification = { path = "../consensus/certification" }
+ic-consensus-cup_utils = { path = "../consensus/cup_utils" }
 ic-consensus-dkg = { path = "../consensus/dkg" }
 ic-crypto = { path = "../crypto" }
 ic-crypto-sha2 = { path = "../crypto/sha2" }

--- a/rs/replica/src/setup_ic_stack.rs
+++ b/rs/replica/src/setup_ic_stack.rs
@@ -107,8 +107,9 @@ pub fn construct_ic_stack(
             // This case is only possible if the replica is started without an orchestrator which
             // is currently only possible in the local development mode with `dfx`.
             None => {
-                let registry_cup = ic_consensus::make_registry_cup(&*registry, subnet_id, log)
-                    .expect("Couldn't create a registry CUP");
+                let registry_cup =
+                    ic_consensus_cup_utils::make_registry_cup(&*registry, subnet_id, log)
+                        .expect("Couldn't create a registry CUP");
 
                 info!(
                     log,

--- a/rs/state_machine_tests/BUILD.bazel
+++ b/rs/state_machine_tests/BUILD.bazel
@@ -13,6 +13,7 @@ DEPENDENCIES = [
     "//rs/bitcoin/consensus",
     "//rs/config",
     "//rs/consensus",
+    "//rs/consensus/cup_utils",
     "//rs/consensus/utils",
     "//rs/crypto/interfaces/sig_verification",
     "//rs/crypto/test_utils/ni-dkg",

--- a/rs/state_machine_tests/Cargo.toml
+++ b/rs/state_machine_tests/Cargo.toml
@@ -19,6 +19,7 @@ ic-btc-adapter-client = { path = "../bitcoin/client" }
 ic-btc-consensus = { path = "../bitcoin/consensus" }
 ic-config = { path = "../config" }
 ic-consensus = { path = "../consensus" }
+ic-consensus-cup-utils = { path = "../consensus/cup_utils" }
 ic-consensus-utils = { path = "../consensus/utils" }
 ic-limits = { path = "../limits" }
 ic-crypto-iccsa = { path = "../crypto/iccsa" }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -13,10 +13,8 @@ use ic_config::{
     state_manager::LsmtConfig,
     subnet_config::SubnetConfig,
 };
-use ic_consensus::{
-    consensus::payload_builder::PayloadBuilderImpl, make_registry_cup,
-    make_registry_cup_from_cup_contents,
-};
+use ic_consensus::consensus::payload_builder::PayloadBuilderImpl;
+use ic_consensus_cup_utils::{make_registry_cup, make_registry_cup_from_cup_contents};
 use ic_consensus_utils::crypto::SignVerify;
 use ic_crypto_test_utils_ni_dkg::{
     SecretKeyBytes, dummy_initial_dkg_transcript_with_master_key, sign_message,


### PR DESCRIPTION
This removes the dependency of the `orchestrator` crate on the `consensus` crate and improves compilation time