### PR TITLE
test(idkg): Increase tECDSA performance test `rps`

### DIFF
--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -109,7 +109,7 @@ const NETWORK_SIMULATION: FixedNetworkSimulation = FixedNetworkSimulation::new()
 
 // Signature parameters
 const PRE_SIGNATURES_TO_CREATE: u32 = 30;
-const MAX_QUEUE_SIZE: u32 = 20;
+const MAX_QUEUE_SIZE: u32 = 10;
 const CANISTER_COUNT: usize = 4;
 const SIGNATURE_REQUESTS_PER_SECOND: f64 = 3.5;
 


### PR DESCRIPTION
Increase the number of signature requests per second from 2.5 to 3.5. This seems to be necessary after merging https://github.com/dfinity/ic/pull/6842