### PR TITLE
fix: deploy.py wait_func path and guestos_ipv6_address optionality

### DIFF
--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -149,7 +149,7 @@ class Args:
         self.csv_filename = self.csv_filename or csv_filename_env_var
 
         assert (self.inject_image_ipv6_prefix and self.inject_image_ipv6_gateway) or not (
-            self.inject_image_ipv6_prefix and self.inject_image_ipv6_gateway
+            self.inject_image_ipv6_prefix or self.inject_image_ipv6_gateway
         ), "Both ipv6_prefix and ipv6_gateway flags must be present or none"
         if self.inject_image_ipv6_prefix:
             assert self.inject_configuration_tool, "setupos_inject_config tool required to modify image"
@@ -222,7 +222,7 @@ def parse_from_row(row: List[str], network_image_url: str) -> BMCInfo:
             IPv6Address(hostos_ipv6_address),
         )
 
-    assert False, f"Invalid csv row found. Must be 3 or 4 items: {row}"
+    assert False, f"Invalid csv row found. Must be 4 items: {row}"
 
 
 def parse_from_csv_file(csv_filename: str, network_image_url: str) -> List["BMCInfo"]:

--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -472,7 +472,6 @@ def deploy_server(
 
         def check_connectivity_func() -> bool:
             log.info(f"Checking guestos ({bmc_info.guestos_ipv6_address}) connectivity...")
-            assert bmc_info.guestos_ipv6_address is not None, "Logic error"
 
             result = check_guestos_ping_connectivity(bmc_info.guestos_ipv6_address, timeout_secs)
             result = result and check_guestos_metrics_version(bmc_info.guestos_ipv6_address, timeout_secs)

--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -184,7 +184,7 @@ class BMCInfo:
 
     # Don't print secrets
     def __str__(self):
-        return f"BMCInfo(ip_address={self.ip_address}, username={self.username}, password=<redacted>, network_image_url={self.network_image_url}, hostos_ipv6_address={self.hostos_ipv6_address}), guestos_ipv6_address={self.guestos_ipv6_address})"
+        return f"BMCInfo(ip_address={self.ip_address}, username={self.username}, password=<redacted>, network_image_url={self.network_image_url}, hostos_ipv6_address={self.hostos_ipv6_address}, guestos_ipv6_address={self.guestos_ipv6_address})"
 
     def __repr__(self):
         return self.__str__()

--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -171,8 +171,8 @@ class BMCInfo:
     username: str
     password: str
     network_image_url: str
-    guestos_ipv6_address: Optional[IPv6Address] = None
-    hostos_ipv6_address: Optional[IPv6Address] = None
+    guestos_ipv6_address: IPv6Address
+    hostos_ipv6_address: IPv6Address
 
     def __post_init__(self):
         def assert_not_empty(name: str, x: Any) -> None:
@@ -209,10 +209,6 @@ class Ipv4Args:
 
 
 def parse_from_row(row: List[str], network_image_url: str) -> BMCInfo:
-    if len(row) == 3:
-        ip_address, username, password = row
-        return BMCInfo(ip_address, username, password, network_image_url)
-
     if len(row) == 4:
         ip_address, username, password, guestos_ipv6_address = row
         hostos_ipv6_address = guestos_ipv6_address.replace("6801", "6800", 1)

--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -473,6 +473,7 @@ def deploy_server(
         )
 
         timeout_secs = 5
+
         def check_connectivity_func() -> bool:
             log.info(f"Checking guestos ({bmc_info.guestos_ipv6_address}) connectivity...")
             assert bmc_info.guestos_ipv6_address is not None, "Logic error"


### PR DESCRIPTION
If wait_func is triggered (when there's no IP address in the BMC info), the test fails. Remove this code path.