### PR TITLE
chore: trigger upgrade tests on mainnet-icos-revisions.json changes

### DIFF
--- a/PULL_REQUEST_BAZEL_TARGETS
+++ b/PULL_REQUEST_BAZEL_TARGETS
@@ -48,6 +48,11 @@
 *.proto     //pre-commit:protobuf-format-check
             //pre-commit:buf-breaking
 
+mainnet-icos-revisions.json
+  //rs/tests/consensus/backup:backup_manager_downgrade_test_colocate
+  //rs/tests/consensus/backup:backup_manager_upgrade_test_colocate
+  //rs/tests/consensus/upgrade:upgrade_downgrade_app_subnet_test_colocate
+
 # Run most nested tests for any ic-os/ or rs/ic_os/ changes:
 *ic[-_]os/* //rs/tests/nested:guestos_upgrade_smoke_test
             //rs/tests/nested:guestos_upgrade_from_latest_release_to_current


### PR DESCRIPTION
Since https://github.com/dfinity/ic/pull/6900 changed the `mainnet-icos-revisions.json` file and broke the following upgrade tests:
* `//rs/tests/consensus/backup:backup_manager_downgrade_test_colocate`
* `//rs/tests/consensus/backup:backup_manager_upgrade_test_colocate`
* `//rs/tests/consensus/upgrade:upgrade_downgrade_app_subnet_test_colocate`

It makes sense to run these tests whenever `mainnet-icos-revisions.json` changes to prevent future failures like this.