### PR TITLE
chore: Add prefix to named temp files in production

### DIFF
--- a/rs/ic_os/dev_test_tools/setupos-image-config/src/bin/inject.rs
+++ b/rs/ic_os/dev_test_tools/setupos-image-config/src/bin/inject.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Error> {
     println!("{previous_config}");
 
     // Update config.ini
-    let config_ini = NamedTempFile::new()?;
+    let config_ini = NamedTempFile::with_prefix("config.ini")?;
     write_config(config_ini.path(), &cli.config_ini).context("failed to write config file")?;
     config
         .write_file(config_ini.path(), Path::new("/config.ini"))
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Error> {
 
     // Update SSH keys
     if let Some(ks) = cli.public_keys {
-        let public_keys = NamedTempFile::new()?;
+        let public_keys = NamedTempFile::with_prefix("public_keys")?;
         write_public_keys(public_keys.path(), ks)
             .await
             .context("failed to write public keys")?;
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Error> {
     println!("{previous_deployment}");
 
     // Update deployment.json
-    let mut deployment_json = NamedTempFile::new()?;
+    let mut deployment_json = NamedTempFile::with_prefix("deployment.json")?;
     deployment_json.write_all(previous_deployment.as_bytes())?;
     fs::set_permissions(deployment_json.path(), Permissions::from_mode(0o644))?;
     update_deployment(deployment_json.path(), &cli.deployment)
@@ -156,7 +156,7 @@ async fn main() -> Result<(), Error> {
 
     // Update NNS key
     if let Some(public_key) = cli.deployment.nns_public_key_override {
-        let mut nns_key = NamedTempFile::new()?;
+        let mut nns_key = NamedTempFile::with_prefix("nns_key")?;
         write!(&mut nns_key, "{public_key}")?;
         fs::set_permissions(nns_key.path(), Permissions::from_mode(0o644))?;
 

--- a/rs/ic_os/device/src/device_mapping.rs
+++ b/rs/ic_os/device/src/device_mapping.rs
@@ -149,7 +149,7 @@ pub struct TempDevice {
 impl TempDevice {
     pub fn new(len: Sectors) -> Result<Self> {
         let temp_file =
-            NamedTempFile::new().context("Could not create temporary file for COW device")?;
+            NamedTempFile::with_prefix("temp_device").context("Could not create temporary file for COW device")?;
 
         temp_file
             .as_file()

--- a/rs/ic_os/device/src/device_mapping.rs
+++ b/rs/ic_os/device/src/device_mapping.rs
@@ -148,8 +148,8 @@ pub struct TempDevice {
 
 impl TempDevice {
     pub fn new(len: Sectors) -> Result<Self> {
-        let temp_file =
-            NamedTempFile::with_prefix("temp_device").context("Could not create temporary file for COW device")?;
+        let temp_file = NamedTempFile::with_prefix("temp_device")
+            .context("Could not create temporary file for COW device")?;
 
         temp_file
             .as_file()

--- a/rs/ic_os/os_tools/guest_vm_runner/src/guest_direct_boot.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/guest_direct_boot.rs
@@ -142,9 +142,9 @@ pub async fn prepare_direct_boot(
     let boot_args =
         read_boot_args(&boot_args_path, boot_args_var_name).context("Failed to read boot args")?;
 
-    let kernel = NamedTempFile::new()?;
-    let initrd = NamedTempFile::new()?;
-    let ovmf_sev = NamedTempFile::new()?;
+    let kernel = NamedTempFile::with_prefix("kernel")?;
+    let initrd = NamedTempFile::with_prefix("initrd")?;
+    let ovmf_sev = NamedTempFile::with_prefix("ovmf_sev")?;
 
     tokio::fs::copy(boot_partition.mount_point().join("vmlinuz"), &kernel)
         .await

--- a/rs/ic_os/os_tools/guest_vm_runner/src/main.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/main.rs
@@ -366,7 +366,8 @@ impl GuestVmService {
     }
 
     async fn start_virtual_machine(&mut self) -> Result<VirtualMachine> {
-        let config_media = NamedTempFile::new().context("Failed to create config media file")?;
+        let config_media = NamedTempFile::with_prefix("config_media")
+            .context("Failed to create config media file")?;
 
         println!("Extracting direct boot dependencies");
         let direct_boot = prepare_direct_boot(self.guest_vm_type, self.partition_provider.as_ref())
@@ -648,7 +649,7 @@ mod tests {
             "Tar returned error"
         );
 
-        let guestos_device = NamedTempFile::new().unwrap();
+        let guestos_device = NamedTempFile::with_prefix("guestos_device").unwrap();
         std::fs::rename(tempdir.path().join("disk.img"), guestos_device.path()).unwrap();
 
         guestos_device

--- a/rs/ic_os/sev/src/host/mod.rs
+++ b/rs/ic_os/sev/src/host/mod.rs
@@ -148,7 +148,7 @@ impl HostSevCertificateProviderImpl {
             .context("Failed to create certificate cache directory")?;
 
         // Save to temp file and rename to prevent race conditions
-        let temp_file = NamedTempFile::new_in(&self.certificate_cache_dir)
+        let temp_file = NamedTempFile::with_prefix_in("vcek", &self.certificate_cache_dir)
             .context("Failed to create temporary file")?;
         fs::write(&temp_file, vcek_der).context("Failed to write VCEK")?;
         temp_file

--- a/rs/ic_os/vsock/vsock_lib/src/host/hsm.rs
+++ b/rs/ic_os/vsock/vsock_lib/src/host/hsm.rs
@@ -114,7 +114,7 @@ fn get_hsm_xml_string(hsm_info: &HSMInfo) -> String {
 }
 
 fn write_to_temp_file(content: &str) -> Result<NamedTempFile, Error> {
-    let mut file: NamedTempFile = NamedTempFile::new()?;
+    let mut file: NamedTempFile = NamedTempFile::with_prefix("hsm")?;
     file.write_all(content.as_bytes())?;
     Ok(file)
 }


### PR DESCRIPTION
When there is a problem with one of these files, we get better logs if the name contains some information.