### PR TITLE
fix(PocketIC): new endpoint to prune result of long-running computation

### DIFF
--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- New DELETE endpoint `/prune_graph/<state_label>/<op_id>` for pruning the result of a long-running operation.
+  This endpoint should be called after successfully reading the result using the GET endpoint `/read_graph/<state_label>/<op_id>`.
+  The `state_label` and `op_id` are returned by `ApiResponse::Started {state_label, op_id}`.
+
 
 
 ## 10.0.0 - 2025-09-12

--- a/rs/pocket_ic_server/src/lib.rs
+++ b/rs/pocket_ic_server/src/lib.rs
@@ -47,6 +47,7 @@ use candid::Principal;
 use ic_types::{NodeId, PrincipalId, SubnetId};
 use pocket_ic::PocketIc;
 use serde::Deserialize;
+use std::fmt::Display;
 
 /// Represents an identifiable operation on PocketIC.
 pub trait Operation {
@@ -67,6 +68,12 @@ pub trait Operation {
 /// Uniquely identifies an operation.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
 pub struct OpId(pub String);
+
+impl Display for OpId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 // Index into a vector of PocketIc instances
 pub type InstanceId = usize;

--- a/rs/pocket_ic_server/src/main.rs
+++ b/rs/pocket_ic_server/src/main.rs
@@ -2,7 +2,7 @@
 use aide::{
     axum::{
         ApiRouter, IntoApiResponse,
-        routing::{get, post},
+        routing::{delete, get, post},
     },
     openapi::{Info, OpenApi},
 };
@@ -28,7 +28,7 @@ use ic_crypto_utils_threshold_sig_der::parse_threshold_sig_key_from_der;
 use libc::{RLIMIT_NOFILE, getrlimit, rlimit, setrlimit};
 use pocket_ic::common::rest::{BinaryBlob, BlobCompression, BlobId, RawVerifyCanisterSigArg};
 use pocket_ic_server::BlobStore;
-use pocket_ic_server::state_api::routes::handler_read_graph;
+use pocket_ic_server::state_api::routes::{handler_prune_graph, handler_read_graph};
 use pocket_ic_server::state_api::{
     routes::{AppState, RouterExt, http_gateway_routes, instances_routes, status},
     state::{ApiState, PocketIcApiStateBuilder},
@@ -231,7 +231,13 @@ async fn start(runtime: Arc<Runtime>) {
         .directory_route("/verify_signature", post(verify_signature))
         //
         // Read state: Poll a result based on a received Started{} reply.
-        .directory_route("/read_graph/{state_label}/{op_id}", get(handler_read_graph))
+        .route("/read_graph/{state_label}/{op_id}", get(handler_read_graph))
+        //
+        // Prune state: Prune a result after successful polling based on a received Started{} reply.
+        .route(
+            "/prune_graph/{state_label}/{op_id}",
+            delete(handler_prune_graph),
+        )
         //
         // All instance routes.
         .nest("/instances", instances_routes::<AppState>())

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -150,11 +150,33 @@ impl Drop for HttpGateway {
     }
 }
 
+#[derive(Default)]
+struct Graph(HashMap<(StateLabel, OpId), (StateLabel, OpOut)>);
+
+impl Graph {
+    fn store_result(
+        &mut self,
+        old_state_label: StateLabel,
+        op_id: OpId,
+        result: (StateLabel, OpOut),
+    ) {
+        self.0.insert((old_state_label, op_id), result);
+    }
+
+    fn read_result(&self, old_state_label: StateLabel, op_id: OpId) -> Option<(StateLabel, OpOut)> {
+        self.0.get(&(old_state_label, op_id)).cloned()
+    }
+
+    fn prune_result(&mut self, state_label: StateLabel, op_id: OpId) -> Option<()> {
+        self.0.remove(&(state_label, op_id)).map(|_| ())
+    }
+}
+
 /// The state of the PocketIC API.
 pub struct ApiState {
     // impl note: If locks are acquired on both fields, acquire first on `instances` and then on `graph`.
     instances: Arc<RwLock<Vec<Mutex<Instance>>>>,
-    graph: Arc<RwLock<HashMap<StateLabel, Computations>>>,
+    graph: Arc<RwLock<Graph>>,
     seed: AtomicU64,
     // PocketIC server port
     port: Option<u16>,
@@ -187,13 +209,6 @@ impl PocketIcApiStateBuilder {
     }
 
     pub fn build(self) -> Arc<ApiState> {
-        let graph: HashMap<StateLabel, Computations> = self
-            .initial_instances
-            .iter()
-            .map(|i| (i.get_state_label(), Computations::default()))
-            .collect();
-        let graph = Arc::new(RwLock::new(graph));
-
         let instances: Vec<_> = self
             .initial_instances
             .into_iter()
@@ -208,7 +223,7 @@ impl PocketIcApiStateBuilder {
 
         Arc::new(ApiState {
             instances,
-            graph,
+            graph: Arc::new(RwLock::new(Graph::default())),
             seed: AtomicU64::new(0),
             port: self.port,
             http_gateways: Arc::new(RwLock::new(Vec::new())),
@@ -345,8 +360,6 @@ impl std::fmt::Debug for OpOut {
     }
 }
 
-pub type Computations = HashMap<OpId, (StateLabel, OpOut)>;
-
 /// The PocketIcApiState has a vector with elements of InstanceState.
 /// When an operation is bound to an instance, the corresponding element in the
 /// vector is replaced by a Busy variant which contains information about the
@@ -478,7 +491,7 @@ impl ApiState {
     // or `None` if the auto progress mode received a stop signal.
     async fn execute_operation(
         instances: Arc<RwLock<Vec<Mutex<Instance>>>>,
-        graph: Arc<RwLock<HashMap<StateLabel, Computations>>>,
+        graph: Arc<RwLock<Graph>>,
         instance_id: InstanceId,
         op: impl Operation + Send + Sync + 'static,
         rx: &mut Receiver<()>,
@@ -502,8 +515,11 @@ impl ApiState {
                     break loop {
                         sleep(READ_GRAPH_DELAY).await;
                         if let Some((_, op_out)) =
-                            Self::read_result(graph.clone(), &state_label, &op_id)
+                            Self::read_result(graph.clone(), state_label.clone(), op_id.clone())
+                                .await
                         {
+                            Self::prune_result(graph.clone(), state_label.clone(), op_id.clone())
+                                .await;
                             break Some(op_out);
                         }
                         if received_stop_signal(rx) {
@@ -520,28 +536,41 @@ impl ApiState {
         }
     }
 
+    async fn read_result(
+        graph: Arc<RwLock<Graph>>,
+        state_label: StateLabel,
+        op_id: OpId,
+    ) -> Option<(StateLabel, OpOut)> {
+        let graph_guard = graph.read().await;
+        graph_guard.read_result(state_label, op_id)
+    }
+
     /// For polling:
     /// The client lib dispatches a long running operation and gets a Started {state_label, op_id}.
     /// It then polls on that via this state tree api function.
-    fn read_result(
-        graph: Arc<RwLock<HashMap<StateLabel, Computations>>>,
-        state_label: &StateLabel,
-        op_id: &OpId,
+    pub async fn read_graph(
+        &self,
+        state_label: StateLabel,
+        op_id: OpId,
     ) -> Option<(StateLabel, OpOut)> {
-        if let Some((new_state_label, op_out)) = graph.try_read().ok()?.get(state_label)?.get(op_id)
-        {
-            Some((new_state_label.clone(), op_out.clone()))
-        } else {
-            None
-        }
+        Self::read_result(self.graph.clone(), state_label, op_id).await
     }
 
-    pub fn read_graph(
-        &self,
-        state_label: &StateLabel,
-        op_id: &OpId,
-    ) -> Option<(StateLabel, OpOut)> {
-        Self::read_result(self.graph.clone(), state_label, op_id)
+    async fn prune_result(
+        graph: Arc<RwLock<Graph>>,
+        state_label: StateLabel,
+        op_id: OpId,
+    ) -> Option<()> {
+        let mut graph_guard = graph.write().await;
+        graph_guard.prune_result(state_label, op_id)
+    }
+
+    /// After polling:
+    /// The client lib dispatches a long running operation and gets a Started {state_label, op_id}.
+    /// It then polls on that via this state tree api function.
+    /// Finally, it prunes the result to release memory on the server.
+    pub async fn prune_graph(&self, state_label: StateLabel, op_id: OpId) -> Option<()> {
+        Self::prune_result(self.graph.clone(), state_label, op_id).await
     }
 
     pub async fn add_instance<F>(
@@ -998,7 +1027,7 @@ impl ApiState {
     /// cases when clients want to enforce a long-running blocking call.
     async fn update_instances_with_timeout<O>(
         instances: Arc<RwLock<Vec<Mutex<Instance>>>>,
-        graph: Arc<RwLock<HashMap<StateLabel, Computations>>>,
+        graph: Arc<RwLock<Graph>>,
         op: Arc<O>,
         instance_id: InstanceId,
         sync_wait_time: Option<Duration>,
@@ -1006,15 +1035,14 @@ impl ApiState {
     where
         O: Operation + Send + Sync + 'static,
     {
-        let op_id = op.id().0;
+        let op_id = op.id();
         trace!(
             "update_with_timeout::start instance_id={} op_id={}",
             instance_id, op_id,
         );
         let instances_cloned = instances.clone();
         let instances_locked = instances_cloned.read().await;
-        let (bg_task, started_outcome) = if let Some(instance_mutex) =
-            instances_locked.get(instance_id)
+        let (bg_task, state_label) = if let Some(instance_mutex) = instances_locked.get(instance_id)
         {
             let mut instance = instance_mutex.lock().await;
             // If this instance is busy, return the running op and initial state
@@ -1035,7 +1063,6 @@ impl ApiState {
                     // move pocket_ic out
 
                     let state_label = pocket_ic.get_state_label();
-                    let op_id = op.id();
                     let busy = InstanceState::Busy {
                         state_label: state_label.clone(),
                         op_id: op_id.clone(),
@@ -1053,7 +1080,7 @@ impl ApiState {
                         move || {
                             trace!(
                                 "bg_task::start instance_id={} state_label={:?} op_id={}",
-                                instance_id, old_state_label, op_id.0,
+                                instance_id, old_state_label, op_id,
                             );
                             let result = op.compute(&mut pocket_ic);
                             pocket_ic.bump_state_label();
@@ -1061,10 +1088,11 @@ impl ApiState {
                             // add result to graph, but grab instance lock first!
                             let instances = instances.blocking_read();
                             let mut graph_guard = graph.blocking_write();
-                            let cached_computations =
-                                graph_guard.entry(old_state_label.clone()).or_default();
-                            cached_computations
-                                .insert(op_id.clone(), (new_state_label, result.clone()));
+                            graph_guard.store_result(
+                                old_state_label,
+                                op_id.clone(),
+                                (new_state_label, result.clone()),
+                            );
                             drop(graph_guard);
                             let mut instance = instances[instance_id].blocking_lock();
                             if let InstanceState::Deleted = &instance.state {
@@ -1075,12 +1103,12 @@ impl ApiState {
                             } else {
                                 instance.state = InstanceState::Available(pocket_ic);
                             }
-                            trace!("bg_task::end instance_id={} op_id={}", instance_id, op_id.0);
+                            trace!("bg_task::end instance_id={} op_id={}", instance_id, op_id);
                             result
                         }
                     };
 
-                    (bg_task, UpdateReply::Started { state_label, op_id })
+                    (bg_task, state_label)
                 }
             }
         } else {
@@ -1108,27 +1136,26 @@ impl ApiState {
         // note: this assumes that cancelling the JoinHandle does not stop the execution of the
         // background task. This only works because the background thread, in this case, is a
         // kernel thread.
-        if let Some(sync_wait_time) = sync_wait_time {
-            if let Ok(res) = time::timeout(sync_wait_time, bg_handle).await {
-                trace!(
-                    "update_with_timeout::synchronous instance_id={} op_id={}",
-                    instance_id, op_id,
-                );
-                return Ok(UpdateReply::Output(res.unwrap()));
-            }
+        let maybe_sync_result = if let Some(sync_wait_time) = sync_wait_time {
+            time::timeout(sync_wait_time, bg_handle).await.ok()
         } else {
-            let res = bg_handle.await;
+            Some(bg_handle.await)
+        };
+        if let Some(sync_result) = maybe_sync_result {
             trace!(
                 "update_with_timeout::synchronous instance_id={} op_id={}",
                 instance_id, op_id,
             );
-            return Ok(UpdateReply::Output(res.unwrap()));
+            let mut graph_guard = graph.write().await;
+            graph_guard.prune_result(state_label, op_id);
+            drop(graph_guard);
+            return Ok(UpdateReply::Output(sync_result.unwrap()));
         }
 
         trace!(
             "update_with_timeout::timeout instance_id={} op_id={}",
             instance_id, op_id,
         );
-        Ok(started_outcome)
+        Ok(UpdateReply::Started { state_label, op_id })
     }
 }


### PR DESCRIPTION
This PR adds a new DELETE endpoint `/prune_graph/<state_label>/<op_id>` to the PocketIC server for pruning the result of a long-running operation.

This endpoint should be called after successfully reading the result using the GET endpoint `/read_graph/<state_label>/<op_id>`. The `state_label` and `op_id` are returned by `ApiResponse::Started {state_label, op_id}`.

If the new endpoint is not called, then the result of a long-running computation is stored in the PocketIC server forever, resulting in a memory leak.