### PR TITLE
feat(IDX): move weekly secrets to env

### DIFF
--- a/.github/workflows/schedule-weekly.yml
+++ b/.github/workflows/schedule-weekly.yml
@@ -14,6 +14,7 @@ jobs:
       options: >-
         -e NODE_NAME
     timeout-minutes: 60 # 1 hour
+    environment: Weekly Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This moves weekly secrets to an environment so they can only be accessed on the master branch.