### PR TITLE
fix(IDX): fix cargo clippy logic

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -704,7 +704,8 @@ jobs:
         if: |
           steps.filter.outputs.cargo == 'true' ||
           env.BRANCH_NAME == 'master' ||
-          startsWith(env.BRANCH_NAME, 'rc--')
+          startsWith(env.BRANCH_NAME, 'rc--') ||
+          startsWith(env.BRANCH_NAME, 'hotfix-')
         shell: bash
         run: |
           set -eExuo pipefail


### PR DESCRIPTION
There was a small issue with this job where it was automatically getting skipped on master and rc branches. This changes to always run on master and rc brances and only run on PRs if a specific file change was made.