### PR TITLE
chore: increase timeout of catch_up_possible_test

### DIFF
--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -48,6 +48,7 @@ system_test(
         "k8s",
         "long_test",
     ],
+    test_timeout = "eternal",
     uses_guestos_img = False,
     uses_guestos_malicious_img = True,
     runtime_deps = GRAFANA_RUNTIME_DEPS,


### PR DESCRIPTION
The `//rs/tests/consensus:catch_up_possible_test` is often flaking due to the test timing out after the bazel timeout of 15 minutes. Note that the test sets a per-task timeout of 30 minutes so we just increase the bazel timeout to "eternal" (1 hour).