### PR TITLE
fix(networking): Fix state sync performance test

### DIFF
--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -427,8 +427,6 @@ system_test_nns(
     },
     tags = [
         "colocate",
-        # TODO: Investigate test failures
-        #"system_test_large",
         "manual",
     ],
     test_timeout = "eternal",

--- a/rs/tests/networking/state_sync_performance.rs
+++ b/rs/tests/networking/state_sync_performance.rs
@@ -171,16 +171,19 @@ fn test(env: TestEnv) {
         )
         .await;
 
-        let _topology = topology
+        let topology = topology
             .block_for_newer_registry_version()
             .await
             .expect("Failed to wait for new topology version");
         env.sync_with_prometheus();
 
         // Wait for the new nodes to report healthy
-        for node in new_nodes.clone() {
-            node.await_status_is_healthy()
-                .expect("Nodes failed to come up healthy")
+        for subnet in topology.subnets() {
+            for node in subnet.nodes() {
+                node.await_status_is_healthy_async()
+                    .await
+                    .expect("Nodes failed to come up healthy")
+            }
         }
         info!(logger, "All newly joined nodes report healthy");
 


### PR DESCRIPTION
The state sync performance test has been problems getting stuck on `await_status_is_healthy`.

It seemed to work occasionally, but often, it would get stuck, doing the actual request to the `status` endpoint.
Looking at the logs, sometimes the request was actually made, while other times it was not being made, and the request was not timing out after 6 seconds.

I replaced the call with it's async version and now it seems to work. I do not fully understand the previous behaviour, as I thought, calling `block_on` while already being in an async block should be handled gracefully.

This PR does not reactivate the test yet, as I would like to get a better understanding first.