### PR TITLE
fix(ICP_Ledger): FI-1872: Add in_executor_context for ICP ledger notify endpoints

### DIFF
--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -772,7 +772,9 @@ async fn send_dfx(arg: SendArgs) -> BlockIndex {
 
 #[unsafe(export_name = "canister_update notify_pb")]
 fn notify_() {
-    trap_since_notify_is_no_longer_supported();
+    in_executor_context(|| {
+        trap_since_notify_is_no_longer_supported();
+    })
 }
 
 #[update]
@@ -871,7 +873,9 @@ async fn icrc2_transfer_from(arg: TransferFromArgs) -> Result<Nat, TransferFromE
 /// See caveats of use on send_dfx
 #[unsafe(export_name = "canister_update notify_dfx")]
 fn notify_dfx_() {
-    trap_since_notify_is_no_longer_supported();
+    in_executor_context(|| {
+        trap_since_notify_is_no_longer_supported();
+    })
 }
 
 #[unsafe(export_name = "canister_query block_pb")]


### PR DESCRIPTION
For canister `update` endpoints that are exported using `#[export_name]`, the entry point must encase its code in `in_executor_context` as described in [the `cdk-rs` documentation](https://github.com/dfinity/cdk-rs/blob/main/ic-cdk/V18_GUIDE.md#custom-exports-advanced).