### PR TITLE
chore: remove obsolete canister_log_memory_usage v1 metric

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1570,10 +1570,6 @@ impl Scheduler for SchedulerImpl {
                             ),
                             FlagStatus::Disabled => NumInstructions::from(0),
                         };
-                    // TODO(EXC-1722): remove after migrating to v2.
-                    self.metrics
-                        .canister_log_memory_usage
-                        .observe(canister.system_state.canister_log.used_space() as f64);
                     self.metrics
                         .canister_log_memory_usage_v2
                         .observe(canister.system_state.canister_log.used_space() as f64);

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -31,7 +31,6 @@ pub(super) struct SchedulerMetrics {
     pub(super) canister_compute_allocation_violation: IntCounter,
     pub(super) canister_balance: Histogram,
     pub(super) canister_binary_size: Histogram,
-    pub(super) canister_log_memory_usage: Histogram, // TODO(EXC-1722): remove after migrating to v2.
     pub(super) canister_log_memory_usage_v2: Histogram,
     pub(super) canister_wasm_memory_usage: Histogram,
     pub(super) canister_stable_memory_usage: Histogram,
@@ -159,12 +158,6 @@ impl SchedulerMetrics {
             canister_binary_size: memory_histogram(
                 "canister_binary_size_bytes",
                 "Canisters Wasm binary size distribution in bytes.",
-                metrics_registry,
-            ),
-            // TODO(EXC-1722): remove after migrating to v2.
-            canister_log_memory_usage: memory_histogram(
-                "canister_log_memory_usage_bytes",
-                "Canisters log memory usage distribution in bytes.",
                 metrics_registry,
             ),
             canister_log_memory_usage_v2: metrics_registry.histogram(


### PR DESCRIPTION
This PR removes obsolete v1 `canister_log_memory_usage` metric.