### PR TITLE
feat(nns): Archive topics of garbage collected proposals

### DIFF
--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2141,6 +2141,9 @@ message Governance {
   // source of randomness (from the platform)
   optional bytes rng_seed = 28;
 
+  // Map of proposal IDs to their topics for those garbage collected.
+  map<uint64, Topic> topic_of_garbage_collected_proposals = 29;
+
   reserved 6;
   reserved "authz";
 

--- a/rs/nns/governance/src/garbage_collection.rs
+++ b/rs/nns/governance/src/garbage_collection.rs
@@ -75,6 +75,9 @@ impl Governance {
                         && prop.can_be_purged(now_seconds, voting_period_seconds)
                     {
                         self.heap_data.proposals.remove(prop_id);
+                        self.heap_data
+                            .topic_of_garbage_collected_proposals
+                            .insert(*prop_id, topic);
                     }
                 }
             }

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -2892,6 +2892,9 @@ pub struct Governance {
     /// source of randomness (from the platform)
     #[prost(bytes = "vec", optional, tag = "28")]
     pub rng_seed: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    /// Map of proposal IDs to their topics for those garbage collected.
+    #[prost(map = "uint64, enumeration(Topic)", tag = "29")]
+    pub topic_of_garbage_collected_proposals: ::std::collections::HashMap<u64, i32>,
 }
 /// Nested message and enum types in `Governance`.
 pub mod governance {

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -8092,10 +8092,16 @@ fn test_proposal_gc() {
                             }))
                         } else {
                             Action::ExecuteNnsFunction(ExecuteNnsFunction {
+                                nns_function: NnsFunction::NnsCanisterInstall as i32,
                                 ..Default::default()
                             })
                         }),
                         ..Default::default()
+                    }),
+                    topic: Some(if id % 2 == 0 {
+                        Topic::NeuronManagement as i32
+                    } else {
+                        Topic::ProtocolCanisterManagement as i32
                     }),
                     ..Default::default()
                 },
@@ -8131,12 +8137,27 @@ fn test_proposal_gc() {
     assert!(gov.heap_data.proposals.len() <= 200);
     // Check that the proposals with high IDs have been kept and the
     // proposals with low IDs have been purged.
-    for i in 1..500 {
+    for i in 1..800 {
         assert!(!gov.heap_data.proposals.contains_key(&i));
     }
-    for i in 900..1000 {
+    for i in 800..1000 {
         assert!(gov.heap_data.proposals.contains_key(&i));
     }
+    // Check that garbage collected proposals are tracked with their topics
+    assert_eq!(
+        gov.heap_data.topic_of_garbage_collected_proposals,
+        (1..800)
+            .map(|i| {
+                let topic = if i % 2 == 0 {
+                    Topic::NeuronManagement
+                } else {
+                    Topic::ProtocolCanisterManagement
+                };
+                (i, topic)
+            })
+            .collect()
+    );
+
     // Running again, nothing should change...
     assert!(!gov.maybe_gc());
     // Reset all proposals.


### PR DESCRIPTION
# Why

Since the known neuron voting history involves proposal ids, and the known neurons have committed topics, the topics of the proposals need to be persisted even though we garbage collect proposals for now. Otherwise there will be no way of computing the voting statistics from the voting history, without relying on offline data.

# What

* Add a `topic_of_garbage_collected_proposals` field
* Insert `(proposal_id, topic)` into the map for a garbage collected proposal
