### PR TITLE
chore(PocketIC): use semantic version for server version check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19250,6 +19250,7 @@ dependencies = [
  "registry-canister",
  "reqwest 0.12.15",
  "schemars",
+ "semver",
  "serde",
  "serde_bytes",
  "serde_cbor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -812,6 +812,7 @@ rustls = { version = "0.23.18", default-features = false, features = [
 ] }
 schemars = { version = "0.8.21", features = ["derive"] }
 scopeguard = "1.2.0"
+semver = { version = "1.0.9", features = ["serde"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_bytes = "0.11.15"
 serde_cbor = "0.11.2"

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -22,6 +22,7 @@ rust_library(
         "@crate_index//:ic-transport-types",
         "@crate_index//:reqwest",
         "@crate_index//:schemars",
+        "@crate_index//:semver",
         "@crate_index//:serde",
         "@crate_index//:serde_bytes",
         "@crate_index//:serde_cbor",

--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Deprecated `PocketIcBuilder::with_initial_timestamp`, use `PocketIcBuilder::with_initial_time` instead.
+- The function `start_server` only downloads the PocketIC server binary
+  if no path to the PocketIC server binary is provided explicitly.
+
+### Removed
+- The constant `EXPECTED_SERVER_VERSION`: semantic version is now used instead of a fixed expected PocketIC server version.
 
 
 

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -30,6 +30,7 @@ ic-management-canister-types = { workspace = true }
 ic-transport-types = { workspace = true }
 reqwest = { workspace = true }
 schemars = "0.8.16"
+semver = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -74,6 +74,7 @@ use ic_management_canister_types::{
 use ic_transport_types::SubnetMetrics;
 use reqwest::Url;
 use schemars::JsonSchema;
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use slog::Level;
 #[cfg(unix)]
@@ -99,7 +100,11 @@ use wslpath::windows_to_wsl;
 pub mod common;
 pub mod nonblocking;
 
-pub const EXPECTED_SERVER_VERSION: &str = "10.0.0";
+const POCKET_IC_SERVER_NAME: &str = "pocket-ic-server";
+
+const MIN_SERVER_VERSION: &str = "10.0.0";
+const LATEST_SERVER_VERSION: &str = "10.0.0";
+const MAX_SERVER_VERSION: &str = "11";
 
 // the default timeout of a PocketIC operation
 const DEFAULT_MAX_REQUEST_TIME_MS: u64 = 300_000;
@@ -1859,20 +1864,36 @@ fn pocket_ic_server_cmd(bin_path: &PathBuf) -> Command {
     Command::new(bin_path)
 }
 
-fn check_pocketic_server_version(server_binary: &PathBuf) -> Result<(), String> {
+fn check_pocketic_server_version(version_line: &str) -> Result<(), String> {
+    let unexpected_version = format!(
+        "Unexpected PocketIC server version: got `{version_line}`; expected `{POCKET_IC_SERVER_NAME} x.y.z`."
+    );
+    let Some((pocket_ic_server, version)) = version_line.split_once(' ') else {
+        return Err(unexpected_version);
+    };
+    if pocket_ic_server != POCKET_IC_SERVER_NAME {
+        return Err(unexpected_version);
+    }
+    let req = VersionReq::parse(&format!(">={MIN_SERVER_VERSION},<{MAX_SERVER_VERSION}")).unwrap();
+    let version = Version::parse(version)
+        .map_err(|e| format!("Failed to parse PocketIC server version: {e}"))?;
+    if !req.matches(&version) {
+        return Err(format!(
+            "Incompatible PocketIC server version: got {version}; expected {req}."
+        ));
+    }
+
+    Ok(())
+}
+
+fn get_and_check_pocketic_server_version(server_binary: &PathBuf) -> Result<(), String> {
     let mut cmd = pocket_ic_server_cmd(server_binary);
     cmd.arg("--version");
     let version = cmd.output().map_err(|e| e.to_string())?.stdout;
     let version_str = String::from_utf8(version)
         .map_err(|e| format!("Failed to parse PocketIC server version: {e}."))?;
     let version_line = version_str.trim_end_matches('\n');
-    let expected_version_line = format!("pocket-ic-server {EXPECTED_SERVER_VERSION}");
-    if version_line != expected_version_line {
-        return Err(format!(
-            "Incompatible PocketIC server version: got {version_line}; expected {expected_version_line}."
-        ));
-    }
-    Ok(())
+    check_pocketic_server_version(version_line)
 }
 
 async fn download_pocketic_server(
@@ -1909,15 +1930,24 @@ pub struct StartServerParams {
 /// Attempt to start a new PocketIC server.
 pub async fn start_server(params: StartServerParams) -> (Child, Url) {
     let default_bin_dir =
-        std::env::temp_dir().join(format!("pocket-ic-server-{EXPECTED_SERVER_VERSION}"));
+        std::env::temp_dir().join(format!("{POCKET_IC_SERVER_NAME}-{LATEST_SERVER_VERSION}"));
     let default_bin_path = default_bin_dir.join("pocket-ic");
+    let bin_path_provided =
+        params.server_binary.is_some() || std::env::var_os("POCKET_IC_BIN").is_some();
     let mut bin_path: PathBuf = params.server_binary.unwrap_or_else(|| {
         std::env::var_os("POCKET_IC_BIN")
             .unwrap_or_else(|| default_bin_path.clone().into())
             .into()
     });
 
-    if let Err(e) = check_pocketic_server_version(&bin_path) {
+    if let Err(e) = get_and_check_pocketic_server_version(&bin_path) {
+        if bin_path_provided {
+            panic!(
+                "Failed to validate PocketIC server binary `{}`: `{}`.",
+                bin_path.display(),
+                e
+            );
+        }
         bin_path = default_bin_path.clone();
         std::fs::create_dir_all(&default_bin_dir)
             .expect("Failed to create PocketIC server directory");
@@ -1936,15 +1966,16 @@ pub async fn start_server(params: StartServerParams) -> (Child, Url) {
                 #[cfg(not(target_arch = "aarch64"))]
                 let arch = "x86_64";
                 let server_url = format!(
-                    "https://github.com/dfinity/pocketic/releases/download/{EXPECTED_SERVER_VERSION}/pocket-ic-{arch}-{os}.gz"
+                    "https://github.com/dfinity/pocketic/releases/download/{LATEST_SERVER_VERSION}/pocket-ic-{arch}-{os}.gz"
                 );
                 println!(
-                    "Failed to validate PocketIC server binary: `{}`. Going to download PocketIC server {} from {} to the local path {}. To avoid downloads during test execution, please specify the path to the (ungzipped and executable) PocketIC server {} using the function `PocketIcBuilder::with_server_binary` or using the `POCKET_IC_BIN` environment variable.",
+                    "Failed to validate PocketIC server binary `{}`: `{}`. Going to download PocketIC server {} from {} to the local path {}. To avoid downloads during test execution, please specify the path to the (ungzipped and executable) PocketIC server {} using the function `PocketIcBuilder::with_server_binary` or using the `POCKET_IC_BIN` environment variable.",
+                    bin_path.display(),
                     e,
-                    EXPECTED_SERVER_VERSION,
+                    LATEST_SERVER_VERSION,
                     server_url,
                     default_bin_path.display(),
-                    EXPECTED_SERVER_VERSION
+                    LATEST_SERVER_VERSION
                 );
                 if let Err(e) = download_pocketic_server(server_url, out).await {
                     let _ = std::fs::remove_file(default_bin_path);
@@ -1952,10 +1983,10 @@ pub async fn start_server(params: StartServerParams) -> (Child, Url) {
                 }
             }
             _ => {
-                // PocketIC server has already been created: wait until it's fully downloaded.
+                // PocketIC server has already been created by another test: wait until it's fully downloaded.
                 let start = std::time::Instant::now();
                 loop {
-                    if check_pocketic_server_version(&default_bin_path).is_ok() {
+                    if get_and_check_pocketic_server_version(&default_bin_path).is_ok() {
                         break;
                     }
                     if start.elapsed() > std::time::Duration::from_secs(60) {
@@ -2080,7 +2111,7 @@ pub fn copy_dir(
 
 #[cfg(test)]
 mod test {
-    use crate::{ErrorCode, RejectCode};
+    use crate::{ErrorCode, RejectCode, check_pocketic_server_version};
     use strum::IntoEnumIterator;
 
     #[test]
@@ -2123,5 +2154,37 @@ mod test {
             let error_code: ErrorCode = (ic_error_code as u64).try_into().unwrap();
             assert_eq!(format!("{error_code:?}"), format!("{:?}", ic_error_code));
         }
+    }
+
+    #[test]
+    fn test_check_pocketic_server_version() {
+        assert!(
+            check_pocketic_server_version("pocket-ic-server")
+                .unwrap_err()
+                .contains("Unexpected PocketIC server version")
+        );
+        assert!(
+            check_pocketic_server_version("pocket-ic 10.0.0")
+                .unwrap_err()
+                .contains("Unexpected PocketIC server version")
+        );
+        assert!(
+            check_pocketic_server_version("pocket-ic-server 10 0 0")
+                .unwrap_err()
+                .contains("Failed to parse PocketIC server version")
+        );
+        assert!(
+            check_pocketic_server_version("pocket-ic-server 9.0.0")
+                .unwrap_err()
+                .contains("Incompatible PocketIC server version")
+        );
+        check_pocketic_server_version("pocket-ic-server 10.0.0").unwrap();
+        check_pocketic_server_version("pocket-ic-server 10.0.1").unwrap();
+        check_pocketic_server_version("pocket-ic-server 10.1.0").unwrap();
+        assert!(
+            check_pocketic_server_version("pocket-ic-server 11.0.0")
+                .unwrap_err()
+                .contains("Incompatible PocketIC server version")
+        );
     }
 }


### PR DESCRIPTION
This PR performs the following changes to the PocketIC Rust library:
- Semantic versioning of the PocketIC server binary is now used instead of a fixed expected PocketIC server version.
- The function `start_server` only downloads the PocketIC server binary if no path to the PocketIC server binary is provided explicitly.
- The constant `EXPECTED_SERVER_VERSION` is removed: semantic versioning is now used instead of a fixed expected PocketIC server version.