### PR TITLE
fix: subnet memory taken for canisters with memory allocation

### DIFF
--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -3614,12 +3614,7 @@ fn subnet_available_memory_is_not_updated_when_allocation_reserved() {
         .unwrap();
     test.install_canister(canister_id, binary).unwrap();
     let initial_memory_used = test.state().memory_taken().execution();
-    let canister_history_memory = 2 * size_of::<CanisterChange>() + size_of::<PrincipalId>();
-    // canister history memory usage is not updated in SubnetAvailableMemory => we add it at RHS
-    assert_eq!(
-        initial_memory_used.get(),
-        memory_allocation.get() + canister_history_memory as u64
-    );
+    assert_eq!(initial_memory_used.get(), memory_allocation.get(),);
     let initial_subnet_available_memory = test.subnet_available_memory();
     let result = test.ingress(canister_id, "test", vec![]);
     expect_canister_did_not_reply(result);

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -26,7 +26,7 @@ use ic_protobuf::state::queues::v1::canister_queues::NextInputQueue;
 use ic_registry_routing_table::RoutingTable;
 use ic_registry_subnet_type::SubnetType;
 use ic_types::{
-    AccumulatedPriority, CanisterId, Cycles, MemoryAllocation, NumBytes, SubnetId, Time,
+    AccumulatedPriority, CanisterId, Cycles, NumBytes, SubnetId, Time,
     batch::{CanisterCyclesCostSchedule, ConsensusResponse, RawQueryStats},
     consensus::idkg::IDkgMasterPublicKeyId,
     ingress::IngressStatus,
@@ -817,22 +817,19 @@ impl ReplicatedState {
             mut best_effort_message_memory_taken,
             wasm_custom_sections_memory_taken,
             canister_history_memory_taken,
-            wasm_chunk_store_memory_usage,
         ) = self
             .canisters_iter()
             .map(|canister| {
                 (
-                    match canister.memory_allocation() {
-                        MemoryAllocation::Reserved(bytes) => bytes,
-                        MemoryAllocation::BestEffort => canister.execution_memory_usage(),
-                    },
+                    canister
+                        .memory_allocation()
+                        .allocated_bytes(canister.memory_usage()),
                     canister
                         .system_state
                         .guaranteed_response_message_memory_usage(),
                     canister.system_state.best_effort_message_memory_usage(),
                     canister.wasm_custom_sections_memory_usage(),
                     canister.canister_history_memory_usage(),
-                    canister.wasm_chunk_store_memory_usage(),
                 )
             })
             .reduce(|accum, val| {
@@ -842,7 +839,6 @@ impl ReplicatedState {
                     accum.2 + val.2,
                     accum.3 + val.3,
                     accum.4 + val.4,
-                    accum.5 + val.5,
                 )
             })
             .unwrap_or_default();
@@ -852,13 +848,8 @@ impl ReplicatedState {
         best_effort_message_memory_taken +=
             (self.subnet_queues.best_effort_message_memory_usage() as u64).into();
 
-        let canister_snapshots_memory_taken = self.canister_snapshots.memory_taken();
-
         MemoryTaken {
-            execution: raw_memory_taken
-                + canister_history_memory_taken
-                + wasm_chunk_store_memory_usage
-                + canister_snapshots_memory_taken,
+            execution: raw_memory_taken,
             guaranteed_response_messages: guaranteed_response_message_memory_taken,
             best_effort_messages: best_effort_message_memory_taken,
             wasm_custom_sections: wasm_custom_sections_memory_taken,

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -580,7 +580,7 @@ fn memory_taken_by_canister_history() {
 
     // Memory for two canister changes.
     let canister_history_memory: usize =
-        size_of::<CanisterChange>() + (size_of::<CanisterChange>() + 4 * size_of::<PrincipalId>());
+        2 * (size_of::<CanisterChange>() + 2 * size_of::<PrincipalId>());
 
     // Push two canister changes into canister history.
     let canister_state = fixture.state.canister_state_mut(&CANISTER_ID).unwrap();
@@ -603,10 +603,16 @@ fn memory_taken_by_canister_history() {
     assert_execution_memory_taken(canister_history_memory, &fixture);
     assert_canister_history_memory_taken(canister_history_memory, &fixture);
 
-    // Test fixed memory allocation.
+    // Test small fixed memory allocation.
+    let canister_state = fixture.state.canister_state_mut(&CANISTER_ID).unwrap();
+    canister_state.system_state.memory_allocation = MemoryAllocation::Reserved(NumBytes::from(2));
+    assert_execution_memory_taken(canister_history_memory, &fixture);
+    assert_canister_history_memory_taken(canister_history_memory, &fixture);
+
+    // Test large fixed memory allocation.
     let canister_state = fixture.state.canister_state_mut(&CANISTER_ID).unwrap();
     canister_state.system_state.memory_allocation = MemoryAllocation::Reserved(NumBytes::from(888));
-    assert_execution_memory_taken(888 + canister_history_memory, &fixture);
+    assert_execution_memory_taken(888, &fixture);
     assert_canister_history_memory_taken(canister_history_memory, &fixture);
 
     // Reset canister memory allocation.


### PR DESCRIPTION
This PR fixes subnet memory taken for canisters with memory allocation: so far their contribution to the `execution` field in `MemoryTaken` was the sum of their memory allocation, canister history, wasm chunk store, and canister snapshots memory usage. However, this leads to accounting for canister history, wasm chunk store, and canister snapshots memory usage twice - once in the memory allocation and one more time separately. This PR fixes that by taking the maximum of the canister memory usage (execution, canister history, wasm chunk store, and canister snapshots memory usage) and memory allocation.

This PR also adds a regression test:
- fill a subnet with canisters having 100 GiB of memory allocation each;
- make the memory allocation of the last canister best-effort;
- grow their stable memory to 40 GiB and take a canister snapshot (all within the memory allocation of 100 GiB);
- because of the double accounting the subnet claims to have no more available memory left for the best-effort canister although no canister with memory allocation of 100 GiB exceeds its memory allocation and thus at least 100 GiB (the original memory allocation of the best-effort canister) are definitely available.