### PR TITLE
test(ICRC-Ledger): FI-1874: endpoint that disables icrc3 in the test ledger

### DIFF
--- a/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/BUILD.bazel
+++ b/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/BUILD.bazel
@@ -70,6 +70,7 @@ rust_ic_test_suite(
         # Keep sorted.
         ":icrc3_test_ledger",
         "//packages/icrc-ledger-types:icrc_ledger_types",
+        "//rs/ledger_suite/icrc1",
         "//rs/ledger_suite/icrc1/ledger",
         "//rs/ledger_suite/icrc1/test_utils",
         "//rs/ledger_suite/tests/sm-tests:ic-ledger-suite-state-machine-tests",

--- a/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/icrc3_test_ledger.did
+++ b/rs/ledger_suite/icrc1/test_utils/icrc3_test_ledger/icrc3_test_ledger.did
@@ -141,4 +141,6 @@ service : () -> {
     get_blocks : (GetBlocksArgs) -> (GetBlocksResponse) query;
 
     icrc1_metadata : () -> (vec record { text; MetadataValue }) query;    
+
+    set_icrc3_enabled : (bool) -> ();
 }


### PR DESCRIPTION
When disabled, icrc3 is not listed as part of the supported standards when calling `icrc1_supported_standards`.