### PR TITLE
chore: rename test_macos to test_all_platforms and test on arm64-linux

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -302,7 +302,7 @@ jobs:
             bazel build \
               --config=stamped \
               --invocation_id="${{ fromJSON(steps.gen-uuids.outputs.output).build_id }}" \
-              --build_tag_filters=test_macos \
+              --build_tag_filters=test_all_platforms \
               //... --nobuild
 
       - name: Build & Test
@@ -313,7 +313,7 @@ jobs:
             bazel test \
               --config=stamped \
               --invocation_id="${{ fromJSON(steps.gen-uuids.outputs.output).test_id }}" \
-              --test_tag_filters=test_macos \
+              --test_tag_filters=test_all_platforms \
               //...
 
       - name: Upload artifacts
@@ -353,16 +353,24 @@ jobs:
 
       - name: Build and Test
         run: |
-          # run pocket-ic tests
+          # Setup zig-cache
+          mkdir -p /tmp/zig-cache
+
+          bazel_targets=(
+            # make sure codebase builds for local development
+            //rs/...
+            //publish/binaries:pocket-ic.gz
+
+            # necessary artifacts & tests for pocket -ic
+            //packages/pocket-ic:all
+          )
+
           bazel \
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
             test \
-              //packages/pocket-ic:all \
-              //rs/pocket_ic_server:test \
-              //rs/pocket_ic_server:gateway \
-              //rs/pocket_ic_server:pocket-ic-server \
-              //publish/binaries:pocket-ic.gz
+            --test_tag_filters="test_all_platforms,test_all_platforms_slow" \
+            "${bazel_targets[@]}"
 
           mkdir -p build
           cp \
@@ -396,22 +404,17 @@ jobs:
           bazel_targets=(
             # make sure codebase builds for local development
             //rs/...
-            //publish/binaries/...
+            //publish/binaries:pocket-ic.gz
 
             # necessary artifacts & tests for pocket -ic
-            //packages/pocket-ic:all \
-            # NOTE: technically covered by //rs/... above, but
-            # added explicitly for clarity
-            //rs/pocket_ic_server:test \
-            //rs/pocket_ic_server:gateway \
-            //rs/pocket_ic_server:pocket-ic-server
+            //packages/pocket-ic:all
           )
 
           bazel \
             --noworkspace_rc \
             --bazelrc=./bazel/conf/.bazelrc.build --bazelrc=/tmp/bazel-cache.bazelrc \
             test \
-            --test_tag_filters="test_macos,test_macos_slow" \
+            --test_tag_filters="test_all_platforms,test_all_platforms_slow" \
             "${bazel_targets[@]}"
 
           mkdir -p build

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -77,7 +77,7 @@ rust_test(
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
         "requires-network",
-        "test_macos",
+        "test_all_platforms",
     ],
     deps = [
         # Keep sorted.
@@ -132,7 +132,7 @@ rust_test(
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
         "requires-network",
-        "test_macos",
+        "test_all_platforms",
     ],
     deps = [
         # Keep sorted.
@@ -179,7 +179,7 @@ rust_test(
             # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
             # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
             "requires-network",
-            "test_macos",
+            "test_all_platforms",
             "long_test",  # The P90 of this test is over 8m for the week starting on 2025-08-20
         ],
         deps = [
@@ -222,7 +222,7 @@ rust_test(
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
         "requires-network",
-        "test_macos",
+        "test_all_platforms",
     ],
     deps = [
         ":pocket-ic",
@@ -249,7 +249,7 @@ rust_test(
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
         "requires-network",
-        "test_macos",
+        "test_all_platforms",
     ],
     deps = [
         ":pocket-ic",

--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -150,6 +150,6 @@ sh_test(
     args = ["$(rootpath " + b + ")" for b in BINS_TO_TEST],
     data = BINS_TO_TEST,
     tags = [
-        "test_macos",
+        "test_all_platforms",
     ],
 )

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -79,7 +79,7 @@ rust_ic_test(
     # TODO(IDX-3164): enable on PR when flakiness issue is resolved
     #                 or we have new darwin runners in use
     tags = [
-        "test_macos_slow",
+        "test_all_platforms_slow",
     ],
     deps = [
         # Keep sorted.
@@ -139,7 +139,7 @@ rust_ic_test_suite(
         "@crate_index//:test-strategy",
     ],
     tags = [
-        "test_macos_slow",
+        "test_all_platforms_slow",
     ],
     deps = [
         # Keep sorted.
@@ -205,7 +205,7 @@ rust_ic_test(
     },
     tags = [
         "cpu:4",
-        "test_macos_slow",
+        "test_all_platforms_slow",
     ],
     deps = [
         # Keep sorted.
@@ -231,7 +231,7 @@ rust_doc_test(
     name = "execution_environment_doc_test",
     crate = ":execution_environment",
     tags = [
-        "test_macos",
+        "test_all_platforms",
     ],
 )
 

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -349,7 +349,7 @@ rust_test(
             #    )
             #  }
             "requires-network",
-            "test_macos",
+            "test_all_platforms",
         ],
         deps = TEST_DEPENDENCIES,
     )
@@ -412,7 +412,7 @@ rust_test(
         # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
         # Failed to crate http gateway: Failed to bind to address 127.0.0.1:0: Operation not permitted (os error 1)
         "requires-network",
-        "test_macos",
+        "test_all_platforms",
     ],
     deps = TEST_DEPENDENCIES,
 )

--- a/rs/replica/BUILD.bazel
+++ b/rs/replica/BUILD.bazel
@@ -150,7 +150,7 @@ rust_test(
     crate = ":replica",
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
-        "test_macos",
+        "test_all_platforms",
     ],
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )
@@ -162,7 +162,7 @@ rust_test_suite(
     data = [":replica"],
     proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
     tags = [
-        "test_macos",
+        "test_all_platforms",
     ],
     deps = [":replica_lib"] + DEPENDENCIES + DEV_DEPENDENCIES,
 )


### PR DESCRIPTION
This PR renames the bazel tag `test_macos` to `test_all_platforms` and unifies arm64-darwin and arm64-linux jobs so that all tests tagged with `test_all_platforms` run on both arm64-darwin and arm64-linux.