### PR TITLE
chore: in the kill_start_test run the kill-start iteration 5 times

### DIFF
--- a/PULL_REQUEST_BAZEL_TARGETS
+++ b/PULL_REQUEST_BAZEL_TARGETS
@@ -53,6 +53,8 @@ mainnet-icos-revisions.json
   //rs/tests/consensus/backup:backup_manager_upgrade_test_colocate
   //rs/tests/consensus/upgrade:upgrade_downgrade_app_subnet_test_colocate
 
+ic-os/guestos/context/docker-base.* //rs/tests/node:kill_start_test
+
 # Run most nested tests for any ic-os/ or rs/ic_os/ changes:
 *ic[-_]os/* //rs/tests/nested:guestos_upgrade_smoke_test
             //rs/tests/nested:guestos_upgrade_from_latest_release_to_current

--- a/rs/tests/node/BUILD.bazel
+++ b/rs/tests/node/BUILD.bazel
@@ -104,11 +104,11 @@ system_test(
 
 system_test(
     name = "kill_start_test",
+    tags = ["long_test"],
     uses_guestos_img = True,
     deps = [
         # Keep sorted.
         "//rs/registry/subnet_type",
-        "//rs/tests/consensus/upgrade:common",
         "//rs/tests/driver:ic-system-test-driver",
         "@crate_index//:anyhow",
         "@crate_index//:slog",

--- a/rs/tests/node/kill_start_test.rs
+++ b/rs/tests/node/kill_start_test.rs
@@ -1,15 +1,25 @@
-// This is a regression test that checks if killing an IC node does not corrupt the filesystems of its data partitions.
-// The test deploys a single node IC, kills the node, waits a bit, and then starts the node again and checks if it comes back up healthy.
+// This is a regression test introduced in https://github.com/dfinity/ic/pull/7025.
+// It checks if killing an IC node does not corrupt the filesystems of its data partitions.
+// The test deploys a single node IC and then in a loop (to increase the probability of corruption):
+// * kills the node,
+// * waits a bit,
+// * starts it back up again,
+// * checks if it comes back up healthy
+//   and if the data partitions are mounted correctly.
+
 use anyhow::Result;
-use ic_consensus_system_test_upgrade_common::{start_node, stop_node};
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::ic::InternetComputer;
 use ic_system_test_driver::driver::test_env::TestEnv;
-use ic_system_test_driver::driver::test_env_api::GetFirstHealthyNodeSnapshot;
+use ic_system_test_driver::driver::test_env_api::*;
 use ic_system_test_driver::systest;
 use slog::info;
 use std::time::Duration;
+
+const NUM_KILL_START_ITERATIONS: usize = 5;
+
+const POST_KILL_SLEEP_DURATION: Duration = Duration::from_secs(5);
 
 fn setup(env: TestEnv) {
     InternetComputer::new()
@@ -21,10 +31,32 @@ fn setup(env: TestEnv) {
 fn test(env: TestEnv) {
     let log = env.logger();
     let node = env.get_first_healthy_system_node_snapshot();
-    stop_node(&log, &node);
-    info!(log, "Sleeping for 10 seconds...");
-    std::thread::sleep(Duration::from_secs(10));
-    start_node(&log, &node);
+    let node_id = node.node_id;
+    let vm = node.vm();
+    for i in 1..NUM_KILL_START_ITERATIONS + 1 {
+        info!(
+            log,
+            "Kill start iteration: {i}/{NUM_KILL_START_ITERATIONS} ..."
+        );
+
+        node.await_status_is_healthy().expect("Node not healthy");
+        info!(log, "Killing node: {node_id} ...");
+        vm.kill();
+        node.await_status_is_unavailable()
+            .expect("Node still healthy");
+
+        info!(log, "Sleeping for {POST_KILL_SLEEP_DURATION:?}...");
+        std::thread::sleep(POST_KILL_SLEEP_DURATION);
+
+        info!(log, "Starting node: {node_id} ...");
+        vm.start();
+        node.await_status_is_healthy().expect("Node not healthy");
+
+        let cmd =
+            "findmnt /var/lib/ic/backup && findmnt /var/lib/ic/crypto && findmnt /var/lib/ic/data";
+        let out = node.block_on_bash_script(cmd).unwrap();
+        info!(log, "{cmd}:\n{out}");
+    }
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
The `//rs/tests/node:kill_start_test` succeeded in the Update Base Image PR https://github.com/dfinity/ic/pull/7039. However when I ran it manually multiple times it eventually failed. So we need to make this test more reliable in catching IC node filesystem corruption.

This PR does this by simply running the VM kill-start-check iteration multiple times (5 atm).

Since the test now runs for longer we turn it into a `long_test` but trigger it whenever the GuestOS base image is updated.

Future Work
===

Generating some I/O load on the IC node such that it writes to its data partitions more which would hopefully trigger the corruption more reliably.