### PR TITLE
chore: unify management canister doc comments for Rust types

### DIFF
--- a/rs/types/management_canister_types/src/http.rs
+++ b/rs/types/management_canister_types/src/http.rs
@@ -3,11 +3,13 @@ use candid::{CandidType, Deserialize};
 use ic_base_types::PrincipalId;
 use serde::Serialize;
 
-/// Enum used for encoding/decoding:
-/// `record {
-///     response : http_response;
-///     context : blob;
-/// }`
+/// Struct used for encoding/decoding
+/// ```text
+/// record {
+///   response : http_response;
+///   context : blob;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize, Serialize)]
 pub struct TransformArgs {
     pub response: CanisterHttpResponsePayload,
@@ -20,11 +22,13 @@ impl Payload<'_> for TransformArgs {}
 // Encapsulating the corresponding candid `func` type.
 candid::define_function!(pub TransformFunc : (TransformArgs) -> (CanisterHttpResponsePayload) query);
 
-/// Enum used for encoding/decoding:
-/// `record {
-//       function : func (record {response : http_response; context : blob}) -> (http_response) query;
-//       context : blob;
-//   }`
+/// Struct used for encoding/decoding
+/// ```text
+/// record {
+///   function : func (record {response : http_response; context : blob}) -> (http_response) query;
+///   context : blob;
+/// }
+/// ```
 #[derive(Clone, PartialEq, Debug, CandidType, Deserialize)]
 pub struct TransformContext {
     /// Reference function with signature: `func (record {response : http_response; context : blob}) -> (http_response) query;`.
@@ -60,18 +64,20 @@ pub type BoundedHttpHeaders = BoundedVec<
 >;
 
 /// Struct used for encoding/decoding
-/// `(http_request : (record {
-//     url : text;
-//     max_response_bytes: opt nat64;
-//     headers : vec http_header;
-//     method : variant { get; head; post };
-//     body : opt blob;
-//     transform : opt record {
-//       function : func (record {response : http_response; context : blob}) -> (http_response) query;
-//       context : blob;
-//     };
-//     is_replicated: opt bool;
-//   })`
+/// ```text
+/// record {
+///   url : text;
+///   max_response_bytes : opt nat64;
+///   headers : vec http_header;
+///   method : variant { get; head; post };
+///   body : opt blob;
+///   transform : opt record {
+///     function : func (record {response : http_response; context : blob}) -> (http_response) query;
+///     context : blob;
+///   };
+///   is_replicated : opt bool;
+/// }
+/// ```
 #[derive(Clone, PartialEq, Debug, CandidType, Deserialize)]
 pub struct CanisterHttpRequestArgs {
     pub url: String,
@@ -244,10 +250,12 @@ fn test_http_headers_max_element_size() {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-/// name: text;
-/// value: text;
-/// })`;
+/// ```text
+/// record {
+///   name : text;
+///   value : text;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize, Serialize)]
 pub struct HttpHeader {
     pub name: String,
@@ -296,11 +304,13 @@ pub enum HttpMethod {
 
 /// Represents the response for a canister http request.
 /// Struct used for encoding/decoding
-/// `(record {
-///     status: nat;
-///     headers: vec http_header;
-///     body: blob;
-/// })`;
+/// ```text
+/// record {
+///   status : nat;
+///   headers : vec http_header;
+///   body : blob;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize, Serialize)]
 pub struct CanisterHttpResponsePayload {
     pub status: u128,

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -160,7 +160,12 @@ pub trait Payload<'a>: Sized + CandidType + Deserialize<'a> {
     }
 }
 
-/// Struct used for encoding/decoding `(record {canister_id})`.
+/// Struct used for encoding/decoding
+/// ```text
+/// record {
+///   canister_id : principal;
+/// }
+/// ```
 #[derive(Debug, CandidType, Deserialize, Serialize)]
 pub struct CanisterIdRecord {
     canister_id: PrincipalId,
@@ -324,7 +329,7 @@ impl CanisterControllersChangeRecord {
 ///    canister_version : nat64;
 ///    snapshot_id : blob;
 ///    taken_at_timestamp : nat64;
-///    source: variant {
+///    source : variant {
 ///         taken_from_canister : reserved;
 ///         metadata_upload : reserved;
 ///    };
@@ -443,7 +448,7 @@ pub struct RenameToRecord {
 ///     controllers : vec principal;
 ///   };
 ///   load_snapshot : record {
-///     canister_version: nat64;
+///     canister_version : nat64;
 ///     snapshot_id : blob;
 ///     taken_at_timestamp : nat64;
 ///     source : variant {
@@ -1122,7 +1127,7 @@ pub type BoundedAllowedViewers =
 /// variant {
 ///    controllers;
 ///    public;
-///    allowed_viewers: vec principal;
+///    allowed_viewers : vec principal;
 /// }
 /// ```
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize, EnumIter)]
@@ -1649,14 +1654,16 @@ impl WasmMemoryPersistence {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default, CandidType, Deserialize, Serialize)]
-/// Struct used for encoding/decoding:
-/// `record {
-///    skip_pre_upgrade : opt bool;
-///    wasm_memory_persistence : opt variant {
-///      keep;
-///      replace;
-///    };
-/// }`
+/// Struct used for encoding/decoding
+/// ```text
+/// record {
+///   skip_pre_upgrade : opt bool;
+///   wasm_memory_persistence : opt variant {
+///     keep;
+///     replace;
+///   };
+/// }
+/// ```
 /// Extendibility for the future: Adding new optional fields ensures both backwards- and
 /// forwards-compatibility in Candid.
 pub struct CanisterUpgradeOptions {
@@ -2114,10 +2121,12 @@ impl DataSize for PrincipalId {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     name: text;
-///     value: text;
-/// })`
+/// ```text
+/// record {
+///   name : text;
+///   value : text;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize)]
 pub struct EnvironmentVariable {
     pub name: String,
@@ -2352,10 +2361,12 @@ impl<'a> Payload<'a> for CreateCanisterArgs {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     node_ids : vec principal;
-///     registry_version: nat64;
-/// })`
+/// ```text
+/// record {
+///   node_ids : vec principal;
+///   registry_version : nat64;
+/// }
+/// ```
 #[derive(Debug, CandidType, Deserialize)]
 pub struct SetupInitialDKGArgs {
     node_ids: Vec<PrincipalId>,
@@ -2524,7 +2535,7 @@ impl FromStr for EcdsaCurve {
 /// is just a identifier, but it may be used to convey some information about
 /// the key (e.g. that the key is meant to be used for testing purposes).
 /// ```text
-/// (record { curve: ecdsa_curve; name: text})
+/// (record { curve : ecdsa_curve; name : text})
 /// ```
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CandidType, Deserialize, Serialize,
@@ -2662,7 +2673,7 @@ impl FromStr for SchnorrAlgorithm {
 /// is just a identifier, but it may be used to convey some information about
 /// the key (e.g. that the key is meant to be used for testing purposes).
 /// ```text
-/// (record { algorithm: schnorr_algorithm; name: text})
+/// (record { algorithm : schnorr_algorithm; name : text})
 /// ```
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CandidType, Deserialize, Serialize,
@@ -2796,7 +2807,7 @@ impl FromStr for VetKdCurve {
 /// some information about the key (e.g. that the key is meant to be used for
 /// testing purposes).
 /// ```text
-/// (record { curve: vetkd_curve; name: text})
+/// (record { curve : vetkd_curve; name : text})
 /// ```
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CandidType, Deserialize, Serialize,
@@ -3048,10 +3059,10 @@ pub type BoundedNodes = BoundedVec<MAX_ALLOWED_NODES_COUNT, UNBOUNDED, UNBOUNDED
 
 /// Argument of the reshare_chain_key API.
 /// `(record {
-///     key_id: master_public_key_id;
-///     subnet_id: principal;
-///     nodes: vec principal;
-///     registry_version: nat64;
+///     key_id : master_public_key_id;
+///     subnet_id : principal;
+///     nodes : vec principal;
+///     registry_version : nat64;
 /// })`
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct ReshareChainKeyArgs {
@@ -3128,7 +3139,7 @@ impl ReshareChainKeyResponse {
 /// Represents the BIP341 aux argument of the sign_with_schnorr API.
 /// ```text
 /// (record {
-///   merkle_root_hash: blob;
+///   merkle_root_hash : blob;
 /// })
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
@@ -3139,8 +3150,8 @@ pub struct SignWithBip341Aux {
 /// Represents the aux argument of the sign_with_schnorr API.
 /// ```text
 /// (variant {
-///    bip341: record {
-///      merkle_root_hash: blob;
+///    bip341 : record {
+///      merkle_root_hash : blob;
 ///   }
 /// })
 /// ```
@@ -3216,9 +3227,9 @@ impl Payload<'_> for SchnorrPublicKeyResponse {}
 /// Represents the argument of the vetkd_derive_key API.
 /// ```text
 /// (record {
-///   input: blob;
+///   input : blob;
 ///   context : blob;
-///   transport_public_key: blob;
+///   transport_public_key : blob;
 ///   key_id : record { curve : vetkd_curve; name : text };
 /// })
 /// ```
@@ -3316,7 +3327,7 @@ pub enum QueryMethod {
 /// `CandidType` for `SubnetInfoArgs`
 /// ```text
 /// record {
-///     subnet_id: principal;
+///   subnet_id : principal;
 /// }
 /// ```
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
@@ -3329,8 +3340,8 @@ impl Payload<'_> for SubnetInfoArgs {}
 /// `CandidType` for `SubnetInfoResponse`
 /// ```text
 /// record {
-///     replica_version: text;
-///     registry_version: nat64;
+///     replica_version : text;
+///     registry_version : nat64;
 /// }
 /// ```
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
@@ -3344,8 +3355,8 @@ impl Payload<'_> for SubnetInfoResponse {}
 /// `CandidType` for `NodeMetricsHistoryArgs`
 /// ```text
 /// record {
-///     subnet_id: principal;
-///     start_at_timestamp_nanos: nat64;
+///     subnet_id : principal;
+///     start_at_timestamp_nanos : nat64;
 /// }
 /// ```
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
@@ -3479,9 +3490,9 @@ impl FetchCanisterLogsRequest {
 /// `CandidType` for `CanisterLogRecord`
 /// ```text
 /// record {
-///     idx: nat64;
-///     timestamp_nanos: nat64;
-///     content: blob;
+///     idx : nat64;
+///     timestamp_nanos : nat64;
+///     content : blob;
 /// }
 /// ```
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize, Serialize)]
@@ -3533,7 +3544,7 @@ impl From<pb_canister_state_bits::CanisterLogRecord> for CanisterLogRecord {
 /// `CandidType` for `FetchCanisterLogsResponse`
 /// ```text
 /// record {
-///     canister_log_records: vec canister_log_record;
+///     canister_log_records : vec canister_log_record;
 /// }
 /// ```
 #[derive(Clone, PartialEq, Debug, Default, CandidType, Deserialize)]
@@ -3545,8 +3556,8 @@ impl Payload<'_> for FetchCanisterLogsResponse {}
 
 /// Struct used for encoding/decoding
 /// `(record {
-///     canister_id: principal;
-///     chunk: blob;
+///     canister_id : principal;
+///     chunk : blob;
 /// })`
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
 pub struct UploadChunkArgs {
@@ -3564,9 +3575,11 @@ impl UploadChunkArgs {
 }
 
 /// Candid type representing the hash of a wasm chunk.
-/// `(record {
-///      hash: blob;
-/// })`
+/// ```text
+/// record {
+///   hash : blob;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, CandidType, Deserialize)]
 pub struct ChunkHash {
     #[serde(with = "serde_bytes")]
@@ -3576,9 +3589,11 @@ pub struct ChunkHash {
 impl Payload<'_> for ChunkHash {}
 
 /// Struct to be returned when uploading a Wasm chunk.
-/// `(record {
-///      hash: blob;
-/// })`
+/// ```text
+/// record {
+///   hash : blob;
+/// }
+/// ```
 pub type UploadChunkReply = ChunkHash;
 
 /// Struct used for encoding/decoding
@@ -3676,7 +3691,7 @@ impl InstallChunkedCodeArgs {
 ///         install;
 ///         reinstall;
 ///         upgrade : opt record {
-///             skip_pre_upgrade: opt bool
+///             skip_pre_upgrade : opt bool
 ///         }
 ///     };
 ///     target_canister_id : principal;
@@ -3741,9 +3756,11 @@ impl InstallChunkedCodeArgsLegacy {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id: principal;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+/// }
+/// ```
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
 pub struct ClearChunkStoreArgs {
     pub canister_id: PrincipalId,
@@ -3758,9 +3775,11 @@ impl ClearChunkStoreArgs {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id: principal;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+/// }
+/// ```
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
 pub struct StoredChunksArgs {
     pub canister_id: PrincipalId,
@@ -3775,7 +3794,9 @@ impl StoredChunksArgs {
 }
 
 /// Struct to be returned when listing chunks in the Wasm store
-/// `(vec record { hash: blob })`
+/// ```text
+/// vec record { hash : blob }
+/// ```
 #[derive(PartialEq, Debug, CandidType, Deserialize)]
 pub struct StoredChunksReply(pub Vec<ChunkHash>);
 
@@ -3853,9 +3874,9 @@ impl Payload<'_> for LoadCanisterSnapshotArgs {}
 
 /// Struct to be returned when taking a canister snapshot.
 /// `(record {
-///      id: blob;
-///      taken_at_timestamp: nat64;
-///      total_size: nat64;
+///      id : blob;
+///      taken_at_timestamp : nat64;
+///      total_size : nat64;
 /// })`
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct CanisterSnapshotResponse {
@@ -3890,8 +3911,8 @@ impl CanisterSnapshotResponse {
 
 /// Struct used for encoding/decoding
 /// `(record {
-///     canister_id: principal;
-///     snapshot_id: blob;
+///     canister_id : principal;
+///     snapshot_id : blob;
 /// })`
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct DeleteCanisterSnapshotArgs {
@@ -3919,9 +3940,11 @@ impl DeleteCanisterSnapshotArgs {
 impl Payload<'_> for DeleteCanisterSnapshotArgs {}
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id: principal;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize)]
 pub struct ListCanisterSnapshotArgs {
     canister_id: PrincipalId,
@@ -4344,7 +4367,9 @@ pub enum CanisterSnapshotDataKind {
 #[derive(Clone, Debug, Deserialize, CandidType, Serialize)]
 
 /// Struct to encode/decode
-/// (record { chunk: blob }; )
+/// ```text
+/// record { chunk : blob }
+/// ```
 pub struct ReadCanisterSnapshotDataResponse {
     #[serde(with = "serde_bytes")]
     pub chunk: Vec<u8>,
@@ -4359,6 +4384,7 @@ impl ReadCanisterSnapshotDataResponse {
 }
 
 /// Struct to encode/decode
+/// ```text
 /// (record {
 ///     canister_id : principal;
 ///     replace_snapshot : opt blob;
@@ -4383,6 +4409,7 @@ impl ReadCanisterSnapshotDataResponse {
 ///         executed;
 ///     };
 /// };)
+/// ```
 
 #[derive(Clone, Debug, Deserialize, CandidType, Serialize)]
 pub struct UploadCanisterSnapshotMetadataArgs {
@@ -4446,9 +4473,11 @@ impl UploadCanisterSnapshotMetadataArgs {
 }
 
 /// Struct to encode/decode
+/// ```text
 /// (record {
-///     snapshot_id: blob;
+///   snapshot_id : blob;
 /// };)
+/// ```
 #[derive(Clone, Debug, Deserialize, CandidType, Serialize)]
 pub struct UploadCanisterSnapshotMetadataResponse {
     pub snapshot_id: SnapshotId,

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -461,6 +461,15 @@ pub struct RenameToRecord {
 ///     controllers : opt vec principal;
 ///     environment_variables_hash : opt blob;
 ///   };
+///   rename_canister : record {
+///     canister_id : principal;
+///     total_num_changes : nat64;
+///     rename_to : record {
+///       canister_id : principal;
+///       version : nat64;
+///       total_num_changes : nat64;
+///     };
+///   };
 /// }
 /// ```
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
@@ -2878,7 +2887,7 @@ impl FromStr for VetKdKeyId {
 /// Unique identifier for a key that can be used for one of the signature schemes
 /// supported on the IC.
 /// ```text
-/// variant { EcdsaKeyId; SchnorrKeyId; VetKdKeyId }
+/// variant { Ecdsa : ecdsa_key_id; Schnorr : schnorr_key_id; VetKd : vetkd_key_id }
 /// ```
 #[derive(
     Clone,

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -1996,6 +1996,26 @@ impl InstallCodeArgs {
     }
 }
 
+/// Struct used for encoding/decoding
+/// ```text
+/// record {
+///   mode : variant {
+///     install;
+///     reinstall;
+///     upgrade : opt record {
+///       skip_pre_upgrade : opt bool;
+///       wasm_memory_persistence : opt variant {
+///         keep;
+///         replace;
+///       };
+///     };
+///   };
+///   canister_id : principal;
+///   wasm_module : blob;
+///   arg : blob;
+///   sender_canister_version : opt nat64;
+/// }
+/// ```
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct InstallCodeArgsV2 {
     pub mode: CanisterInstallModeV2,
@@ -3451,7 +3471,7 @@ impl Payload<'_> for FetchCanisterLogsFilter {}
 /// ```text
 /// record {
 ///     canister_id : principal;
-///     filter : variant {
+///     filter : opt variant {
 ///       by_idx : record { start : nat64; end : nat64 };
 ///       by_timestamp_nanos : record { start : nat64; end : nat64 };
 ///     }

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -1087,10 +1087,12 @@ impl TryFrom<pb_canister_state_bits::CanisterChange> for CanisterChange {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id : principal;
-///     sender_canister_version : opt nat64;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+///   sender_canister_version : opt nat64;
+/// }
+/// ```
 #[derive(Debug, CandidType, Deserialize, Serialize)]
 pub struct UninstallCodeArgs {
     canister_id: PrincipalId,
@@ -1212,18 +1214,20 @@ impl TryFrom<pb_canister_state_bits::LogVisibilityV2> for LogVisibilityV2 {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     controller : principal;
-///     compute_allocation : nat;
-///     memory_allocation : nat;
-///     freezing_threshold : nat;
-///     reserved_cycles_limit : nat;
-///     log_visibility : log_visibility;
-///     log_size : nat;
-///     wasm_memory_limit : nat;
-///     wasm_memory_threshold : nat;
-///     environment_variables : vec environment_variable;
-/// })`
+/// ```text
+/// record {
+///   controller : principal;
+///   compute_allocation : nat;
+///   memory_allocation : nat;
+///   freezing_threshold : nat;
+///   reserved_cycles_limit : nat;
+///   log_visibility : log_visibility;
+///   log_size : nat;
+///   wasm_memory_limit : nat;
+///   wasm_memory_threshold : nat;
+///   environment_variables : vec environment_variable;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettingsArgs {
     controller: PrincipalId,
@@ -1330,35 +1334,37 @@ pub struct QueryStats {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     status : variant { running; stopping; stopped };
-///     ready_for_migration : bool,
-///     version : nat64,
-///     settings : definite_canister_settings;
-///     module_hash : opt blob;
-///     controller : principal;
-///     memory_size : nat;
-///     memory_metrics : record {
-///         wasm_memory_size : nat;
-///         stable_memory_size : nat;
-///         global_memory_size : nat;
-///         wasm_binary_size : nat;
-///         custom_sections_size : nat;
-///         canister_history_size : nat;
-///         wasm_chunk_store_size : nat;
-///         snapshots_size : nat;
-///     };
-///     cycles : nat;
-///     freezing_threshold : nat,
-///     idle_cycles_burned_per_day : nat;
-///     reserved_cycles : nat;
-///     query_stats : record {
-///         num_calls : nat;
-///         num_instructions : nat;
-///         ingress_payload_size : nat;
-///         egress_payload_size : nat;
-///     }
-/// })`
+/// ```text
+/// record {
+///   status : variant { running; stopping; stopped };
+///   ready_for_migration : bool;
+///   version : nat64;
+///   settings : definite_canister_settings;
+///   module_hash : opt blob;
+///   controller : principal;
+///   memory_size : nat;
+///   memory_metrics : record {
+///     wasm_memory_size : nat;
+///     stable_memory_size : nat;
+///     global_memory_size : nat;
+///     wasm_binary_size : nat;
+///     custom_sections_size : nat;
+///     canister_history_size : nat;
+///     wasm_chunk_store_size : nat;
+///     snapshots_size : nat;
+///   };
+///   cycles : nat;
+///   freezing_threshold : nat;
+///   idle_cycles_burned_per_day : nat;
+///   reserved_cycles : nat;
+///   query_stats : record {
+///     num_calls : nat;
+///     num_instructions : nat;
+///     ingress_payload_size : nat;
+///     egress_payload_size : nat;
+///   };
+/// }
+/// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct CanisterStatusResultV2 {
     status: CanisterStatusType,
@@ -1937,13 +1943,15 @@ impl TryFrom<WasmMemoryPersistenceProto> for WasmMemoryPersistence {
 impl Payload<'_> for CanisterStatusResultV2 {}
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     mode : variant { install; reinstall; upgrade };
-///     canister_id : principal;
-///     wasm_module : blob;
-///     arg : blob;
-///     sender_canister_version : opt nat64;
-/// })`
+/// ```text
+/// record {
+///   mode : variant { install; reinstall; upgrade };
+///   canister_id : principal;
+///   wasm_module : blob;
+///   arg : blob;
+///   sender_canister_version : opt nat64;
+/// }
+/// ```
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct InstallCodeArgs {
     pub mode: CanisterInstallMode,
@@ -2059,11 +2067,13 @@ impl<'a> Payload<'a> for EmptyBlob {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id : principal;
-///     settings : canister_settings;
-///     sender_canister_version : opt nat64;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+///   settings : canister_settings;
+///   sender_canister_version : opt nat64;
+/// }
+/// ```
 #[derive(Debug, CandidType, Deserialize)]
 pub struct UpdateSettingsArgs {
     pub canister_id: PrincipalId,
@@ -2134,18 +2144,20 @@ pub struct EnvironmentVariable {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     controllers : opt vec principal;
-///     compute_allocation : opt nat;
-///     memory_allocation : opt nat;
-///     freezing_threshold : opt nat;
-///     reserved_cycles_limit : opt nat;
-///     log_visibility : opt log_visibility;
-///     log_size : opt nat;
-///     wasm_memory_limit : opt nat;
-///     wasm_memory_threshold : opt nat;
-///     environment_variables : opt vec environment_variable;
-/// })`
+/// ```text
+/// record {
+///   controllers : opt vec principal;
+///   compute_allocation : opt nat;
+///   memory_allocation : opt nat;
+///   freezing_threshold : opt nat;
+///   reserved_cycles_limit : opt nat;
+///   log_visibility : opt log_visibility;
+///   log_size : opt nat;
+///   wasm_memory_limit : opt nat;
+///   wasm_memory_threshold : opt nat;
+///   environment_variables : opt vec environment_variable;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize)]
 pub struct CanisterSettingsArgs {
     pub controllers: Option<BoundedControllers>,
@@ -2318,10 +2330,12 @@ impl CanisterSettingsArgsBuilder {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     settings : opt canister_settings;
-///     sender_canister_version : opt nat64;
-/// })`
+/// ```text
+/// record {
+///   settings : opt canister_settings;
+///   sender_canister_version : opt nat64;
+/// }
+/// ```
 #[derive(Clone, PartialEq, Debug, Default, CandidType, Deserialize)]
 pub struct CreateCanisterArgs {
     pub settings: Option<CanisterSettingsArgs>,
@@ -3555,10 +3569,12 @@ pub struct FetchCanisterLogsResponse {
 impl Payload<'_> for FetchCanisterLogsResponse {}
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id : principal;
-///     chunk : blob;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+///   chunk : blob;
+/// }
+/// ```
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
 pub struct UploadChunkArgs {
     pub canister_id: PrincipalId,
@@ -3597,21 +3613,23 @@ impl Payload<'_> for ChunkHash {}
 pub type UploadChunkReply = ChunkHash;
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     mode : variant {
-///         install;
-///         reinstall;
-///         upgrade : opt record {
-///             skip_pre_upgrade : opt bool
-///         }
+/// ```text
+/// record {
+///   mode : variant {
+///     install;
+///     reinstall;
+///     upgrade : opt record {
+///       skip_pre_upgrade : opt bool;
 ///     };
-///     target_canister_id : principal;
-///     store_canister_id : opt principal;
-///     chunk_hashes_list : vec chunk_hash;
-///     wasm_module_hash : blob;
-///     arg : blob;
-///     sender_canister_version : opt nat64;
-/// })`
+///   };
+///   target_canister_id : principal;
+///   store_canister_id : opt principal;
+///   chunk_hashes_list : vec chunk_hash;
+///   wasm_module_hash : blob;
+///   arg : blob;
+///   sender_canister_version : opt nat64;
+/// }
+/// ```
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct InstallChunkedCodeArgs {
     pub mode: CanisterInstallModeV2,
@@ -3803,10 +3821,12 @@ pub struct StoredChunksReply(pub Vec<ChunkHash>);
 impl Payload<'_> for StoredChunksReply {}
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id : principal;
-///     replace_snapshot : opt blob;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+///   replace_snapshot : opt blob;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize)]
 pub struct TakeCanisterSnapshotArgs {
     pub canister_id: PrincipalId,
@@ -3832,11 +3852,13 @@ impl TakeCanisterSnapshotArgs {
 impl Payload<'_> for TakeCanisterSnapshotArgs {}
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id : principal;
-///     snapshot_id : blob;
-///     sender_canister_version : opt nat64;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+///   snapshot_id : blob;
+///   sender_canister_version : opt nat64;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct LoadCanisterSnapshotArgs {
     canister_id: PrincipalId,
@@ -3910,10 +3932,12 @@ impl CanisterSnapshotResponse {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id : principal;
-///     snapshot_id : blob;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+///   snapshot_id : blob;
+/// }
+/// ```
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct DeleteCanisterSnapshotArgs {
     pub canister_id: PrincipalId,
@@ -4059,10 +4083,12 @@ impl TryFrom<pb_canister_state_bits::Global> for Global {
 }
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id : principal;
-///     snapshot_id : blob;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+///   snapshot_id : blob;
+/// }
+/// ```
 
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct ReadCanisterSnapshotMetadataArgs {

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -18,7 +18,6 @@ use ic_base_types::{
     SubnetId,
 };
 use ic_error_types::{ErrorCode, UserError};
-use ic_protobuf::log::{self, log_entry};
 use ic_protobuf::proxy::ProxyDecodeError;
 use ic_protobuf::proxy::{try_decode_hash, try_from_option_field};
 use ic_protobuf::registry::crypto::v1::PublicKey;

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -260,7 +260,7 @@ impl CanisterChangeOrigin {
 /// ```text
 /// record {
 ///   controllers : vec principal;
-///   environment_variables_hash: opt blob;
+///   environment_variables_hash : opt blob;
 /// }
 /// ```
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
@@ -382,7 +382,7 @@ impl CanisterLoadSnapshotRecord {
 /// ``` text
 /// record {
 ///   controllers : opt vec principal;
-///   environment_variables_hash: opt blob;
+///   environment_variables_hash : opt blob;
 /// }
 /// ```
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
@@ -432,7 +432,7 @@ pub struct RenameToRecord {
 /// variant {
 ///   creation : record {
 ///     controllers : vec principal;
-///     environment_variables_hash: opt blob;
+///     environment_variables_hash : opt blob;
 ///   };
 ///   code_uninstall;
 ///   code_deployment : record {
@@ -444,17 +444,17 @@ pub struct RenameToRecord {
 ///   };
 ///   load_snapshot : record {
 ///     canister_version: nat64;
-///     snapshot_id: blob;
-///     taken_at_timestamp: nat64;
+///     snapshot_id : blob;
+///     taken_at_timestamp : nat64;
 ///     source : variant {
 ///       taken_from_canister : reserved;
 ///       metadata_upload : reserved;
 ///     };
-///     from_canister_id: opt principal;
+///     from_canister_id : opt principal;
 ///   };
 ///   settings_change : record {
 ///     controllers : opt vec principal;
-///     environment_variables_hash: opt blob;
+///     environment_variables_hash : opt blob;
 ///   };
 /// }
 /// ```
@@ -1209,14 +1209,15 @@ impl TryFrom<pb_canister_state_bits::LogVisibilityV2> for LogVisibilityV2 {
 /// Struct used for encoding/decoding
 /// `(record {
 ///     controller : principal;
-///     compute_allocation: nat;
-///     memory_allocation: nat;
-///     freezing_threshold: nat;
-///     reserved_cycles_limit: nat;
-///     log_visibility: log_visibility;
-///     wasm_memory_limit: nat;
-///     wasm_memory_threshold: nat;
-///     environment_variables: vec environment_variable;
+///     compute_allocation : nat;
+///     memory_allocation : nat;
+///     freezing_threshold : nat;
+///     reserved_cycles_limit : nat;
+///     log_visibility : log_visibility;
+///     log_size : nat;
+///     wasm_memory_limit : nat;
+///     wasm_memory_threshold : nat;
+///     environment_variables : vec environment_variable;
 /// })`
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct DefiniteCanisterSettingsArgs {
@@ -1227,6 +1228,7 @@ pub struct DefiniteCanisterSettingsArgs {
     freezing_threshold: candid::Nat,
     reserved_cycles_limit: candid::Nat,
     log_visibility: LogVisibilityV2,
+    log_size: candid::Nat,
     wasm_memory_limit: candid::Nat,
     wasm_memory_threshold: candid::Nat,
     environment_variables: Vec<EnvironmentVariable>,
@@ -1241,6 +1243,7 @@ impl DefiniteCanisterSettingsArgs {
         freezing_threshold: u64,
         reserved_cycles_limit: Option<u128>,
         log_visibility: LogVisibilityV2,
+        log_size: u64,
         wasm_memory_limit: Option<u64>,
         wasm_memory_threshold: u64,
         environment_variables: EnvironmentVariables,
@@ -1263,6 +1266,7 @@ impl DefiniteCanisterSettingsArgs {
             freezing_threshold: candid::Nat::from(freezing_threshold),
             reserved_cycles_limit,
             log_visibility,
+            log_size,
             wasm_memory_limit,
             wasm_memory_threshold: candid::Nat::from(wasm_memory_threshold),
             environment_variables,
@@ -1279,6 +1283,10 @@ impl DefiniteCanisterSettingsArgs {
 
     pub fn log_visibility(&self) -> &LogVisibilityV2 {
         &self.log_visibility
+    }
+
+    pub fn log_size(&self) -> candid::Nat {
+        self.log_size.clone()
     }
 
     pub fn wasm_memory_limit(&self) -> candid::Nat {
@@ -1319,13 +1327,13 @@ pub struct QueryStats {
 /// Struct used for encoding/decoding
 /// `(record {
 ///     status : variant { running; stopping; stopped };
-///     ready_for_migration: bool,
-///     version: nat64,
-///     settings: definite_canister_settings;
-///     module_hash: opt blob;
-///     controller: principal;
-///     memory_size: nat;
-///     memory_metrics: record {
+///     ready_for_migration : bool,
+///     version : nat64,
+///     settings : definite_canister_settings;
+///     module_hash : opt blob;
+///     controller : principal;
+///     memory_size : nat;
+///     memory_metrics : record {
 ///         wasm_memory_size : nat;
 ///         stable_memory_size : nat;
 ///         global_memory_size : nat;
@@ -1335,15 +1343,15 @@ pub struct QueryStats {
 ///         wasm_chunk_store_size : nat;
 ///         snapshots_size : nat;
 ///     };
-///     cycles: nat;
-///     freezing_threshold: nat,
-///     idle_cycles_burned_per_day: nat;
-///     reserved_cycles: nat;
-///     query_stats: record {
-///         num_calls: nat;
-///         num_instructions: nat;
-///         ingress_payload_size: nat;
-///         egress_payload_size: nat;
+///     cycles : nat;
+///     freezing_threshold : nat,
+///     idle_cycles_burned_per_day : nat;
+///     reserved_cycles : nat;
+///     query_stats : record {
+///         num_calls : nat;
+///         num_instructions : nat;
+///         ingress_payload_size : nat;
+///         egress_payload_size : nat;
 ///     }
 /// })`
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
@@ -1643,7 +1651,7 @@ impl WasmMemoryPersistence {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default, CandidType, Deserialize, Serialize)]
 /// Struct used for encoding/decoding:
 /// `record {
-///    skip_pre_upgrade: opt bool;
+///    skip_pre_upgrade : opt bool;
 ///    wasm_memory_persistence : opt variant {
 ///      keep;
 ///      replace;
@@ -1924,9 +1932,9 @@ impl Payload<'_> for CanisterStatusResultV2 {}
 /// Struct used for encoding/decoding
 /// `(record {
 ///     mode : variant { install; reinstall; upgrade };
-///     canister_id: principal;
-///     wasm_module: blob;
-///     arg: blob;
+///     canister_id : principal;
+///     wasm_module : blob;
+///     arg : blob;
 ///     sender_canister_version : opt nat64;
 /// })`
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -2046,7 +2054,7 @@ impl<'a> Payload<'a> for EmptyBlob {
 /// Struct used for encoding/decoding
 /// `(record {
 ///     canister_id : principal;
-///     settings: canister_settings;
+///     settings : canister_settings;
 ///     sender_canister_version : opt nat64;
 /// })`
 #[derive(Debug, CandidType, Deserialize)]
@@ -2118,15 +2126,16 @@ pub struct EnvironmentVariable {
 
 /// Struct used for encoding/decoding
 /// `(record {
-///     controllers: opt vec principal;
-///     compute_allocation: opt nat;
-///     memory_allocation: opt nat;
-///     freezing_threshold: opt nat;
-///     reserved_cycles_limit: opt nat;
+///     controllers : opt vec principal;
+///     compute_allocation : opt nat;
+///     memory_allocation : opt nat;
+///     freezing_threshold : opt nat;
+///     reserved_cycles_limit : opt nat;
 ///     log_visibility : opt log_visibility;
-///     wasm_memory_limit: opt nat;
-///     wasm_memory_threshold: opt nat;
-///     environment_variables: opt vec environment_variable;
+///     log_size : opt nat;
+///     wasm_memory_limit : opt nat;
+///     wasm_memory_threshold : opt nat;
+///     environment_variables : opt vec environment_variable;
 /// })`
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize)]
 pub struct CanisterSettingsArgs {
@@ -2136,6 +2145,7 @@ pub struct CanisterSettingsArgs {
     pub freezing_threshold: Option<candid::Nat>,
     pub reserved_cycles_limit: Option<candid::Nat>,
     pub log_visibility: Option<LogVisibilityV2>,
+    pub log_size: Option<candid::Nat>,
     pub wasm_memory_limit: Option<candid::Nat>,
     pub wasm_memory_threshold: Option<candid::Nat>,
     pub environment_variables: Option<Vec<EnvironmentVariable>>,
@@ -2154,6 +2164,7 @@ impl CanisterSettingsArgs {
             freezing_threshold: None,
             reserved_cycles_limit: None,
             log_visibility: None,
+            log_size: None,
             wasm_memory_limit: None,
             wasm_memory_threshold: None,
             environment_variables: None,
@@ -2169,6 +2180,7 @@ pub struct CanisterSettingsArgsBuilder {
     freezing_threshold: Option<candid::Nat>,
     reserved_cycles_limit: Option<candid::Nat>,
     log_visibility: Option<LogVisibilityV2>,
+    log_size: Option<candid::Nat>,
     wasm_memory_limit: Option<candid::Nat>,
     wasm_memory_threshold: Option<candid::Nat>,
     environment_variables: Option<Vec<EnvironmentVariable>>,
@@ -2188,6 +2200,7 @@ impl CanisterSettingsArgsBuilder {
             freezing_threshold: self.freezing_threshold,
             reserved_cycles_limit: self.reserved_cycles_limit,
             log_visibility: self.log_visibility,
+            log_size: self.log_size,
             wasm_memory_limit: self.wasm_memory_limit,
             wasm_memory_threshold: self.wasm_memory_threshold,
             environment_variables: self.environment_variables,
@@ -2256,6 +2269,14 @@ impl CanisterSettingsArgsBuilder {
     pub fn with_log_visibility(self, log_visibility: LogVisibilityV2) -> Self {
         Self {
             log_visibility: Some(log_visibility),
+            ..self
+        }
+    }
+
+    /// Sets the log size in bytes.
+    pub fn with_log_size(self, log_size: u64) -> Self {
+        Self {
+            log_size: Some(candid::Nat::from(log_size)),
             ..self
         }
     }
@@ -3135,7 +3156,7 @@ pub enum SignWithSchnorrAux {
 ///   message : blob;
 ///   derivation_path : vec blob;
 ///   key_id : schnorr_key_id;
-///   aux: opt schnorr_aux;
+///   aux : opt schnorr_aux;
 /// })
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
@@ -3420,10 +3441,10 @@ impl Payload<'_> for FetchCanisterLogsFilter {}
 /// `CandidType` for `FetchCanisterLogsRequest`
 /// ```text
 /// record {
-///     canister_id: principal;
-///     filter: opt variant {
-///       by_idx: record { start: nat64; end: nat64 };
-///       by_timestamp_nanos: record { start: nat64; end: nat64 };
+///     canister_id : principal;
+///     filter : variant {
+///       by_idx : record { start : nat64; end : nat64 };
+///       by_timestamp_nanos : record { start : nat64; end : nat64 };
 ///     }
 /// }
 /// ```
@@ -3565,15 +3586,15 @@ pub type UploadChunkReply = ChunkHash;
 ///     mode : variant {
 ///         install;
 ///         reinstall;
-///         upgrade: opt record {
-///             skip_pre_upgrade: opt bool
+///         upgrade : opt record {
+///             skip_pre_upgrade : opt bool
 ///         }
 ///     };
-///     target_canister_id: principal;
-///     store_canister_id: opt principal;
-///     chunk_hashes_list: vec chunk_hash;
-///     wasm_module_hash: blob;
-///     arg: blob;
+///     target_canister_id : principal;
+///     store_canister_id : opt principal;
+///     chunk_hashes_list : vec chunk_hash;
+///     wasm_module_hash : blob;
+///     arg : blob;
 ///     sender_canister_version : opt nat64;
 /// })`
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -3654,15 +3675,15 @@ impl InstallChunkedCodeArgs {
 ///     mode : variant {
 ///         install;
 ///         reinstall;
-///         upgrade: opt record {
+///         upgrade : opt record {
 ///             skip_pre_upgrade: opt bool
 ///         }
 ///     };
-///     target_canister_id: principal;
-///     store_canister_id: opt principal;
-///     chunk_hashes_list: vec blob;
-///     wasm_module_hash: blob;
-///     arg: blob;
+///     target_canister_id : principal;
+///     store_canister_id : opt principal;
+///     chunk_hashes_list : vec blob;
+///     wasm_module_hash : blob;
+///     arg : blob;
 ///     sender_canister_version : opt nat64;
 /// })`
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -3762,8 +3783,8 @@ impl Payload<'_> for StoredChunksReply {}
 
 /// Struct used for encoding/decoding
 /// `(record {
-///     canister_id: principal;
-///     replace_snapshot: opt blob;
+///     canister_id : principal;
+///     replace_snapshot : opt blob;
 /// })`
 #[derive(Clone, Eq, PartialEq, Debug, Default, CandidType, Deserialize)]
 pub struct TakeCanisterSnapshotArgs {
@@ -3791,9 +3812,9 @@ impl Payload<'_> for TakeCanisterSnapshotArgs {}
 
 /// Struct used for encoding/decoding
 /// `(record {
-///     canister_id: principal;
-///     snapshot_id: blob;
-///     sender_canister_version: opt nat64;
+///     canister_id : principal;
+///     snapshot_id : blob;
+///     sender_canister_version : opt nat64;
 /// })`
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct LoadCanisterSnapshotArgs {

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2473,7 +2473,7 @@ impl SetupInitialDKGResponse {
 
 /// Types of curves that can be used for ECDSA signing.
 /// ```text
-/// (variant { secp256k1; })
+/// variant { secp256k1; }
 /// ```
 #[derive(
     Copy,
@@ -2605,7 +2605,7 @@ impl FromStr for EcdsaKeyId {
 
 /// Types of algorithms that can be used for Schnorr signing.
 /// ```text
-/// (variant { bip340secp256k1; ed25519 })
+/// variant { bip340secp256k1; ed25519 }
 /// ```
 #[derive(
     Copy,
@@ -2743,7 +2743,7 @@ impl FromStr for SchnorrKeyId {
 
 /// Types of curves that can be used for threshold key derivation (vetKD).
 /// ```text
-/// (variant { bls12_381_g2; })
+/// variant { bls12_381_g2; }
 /// ```
 #[derive(
     Copy,
@@ -2878,7 +2878,7 @@ impl FromStr for VetKdKeyId {
 /// Unique identifier for a key that can be used for one of the signature schemes
 /// supported on the IC.
 /// ```text
-/// (variant { EcdsaKeyId; SchnorrKeyId })
+/// variant { EcdsaKeyId; SchnorrKeyId; VetKdKeyId }
 /// ```
 #[derive(
     Clone,
@@ -3166,11 +3166,11 @@ pub struct SignWithBip341Aux {
 
 /// Represents the aux argument of the sign_with_schnorr API.
 /// ```text
-/// (variant {
+/// variant {
 ///    bip341 : record {
 ///      merkle_root_hash : blob;
 ///   }
-/// })
+/// }
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub enum SignWithSchnorrAux {

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -2550,7 +2550,7 @@ impl FromStr for EcdsaCurve {
 /// is just a identifier, but it may be used to convey some information about
 /// the key (e.g. that the key is meant to be used for testing purposes).
 /// ```text
-/// (record { curve : ecdsa_curve; name : text})
+/// record { curve : ecdsa_curve; name : text}
 /// ```
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CandidType, Deserialize, Serialize,
@@ -2688,7 +2688,7 @@ impl FromStr for SchnorrAlgorithm {
 /// is just a identifier, but it may be used to convey some information about
 /// the key (e.g. that the key is meant to be used for testing purposes).
 /// ```text
-/// (record { algorithm : schnorr_algorithm; name : text})
+/// record { algorithm : schnorr_algorithm; name : text}
 /// ```
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CandidType, Deserialize, Serialize,
@@ -2822,7 +2822,7 @@ impl FromStr for VetKdCurve {
 /// some information about the key (e.g. that the key is meant to be used for
 /// testing purposes).
 /// ```text
-/// (record { curve : vetkd_curve; name : text})
+/// record { curve : vetkd_curve; name : text}
 /// ```
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CandidType, Deserialize, Serialize,
@@ -3009,11 +3009,11 @@ impl DataSize for ByteBuf {
 
 /// Represents the argument of the sign_with_ecdsa API.
 /// ```text
-/// (record {
+/// record {
 ///   message_hash : blob;
 ///   derivation_path : vec blob;
 ///   key_id : ecdsa_key_id;
-/// })
+/// }
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct SignWithECDSAArgs {
@@ -3035,11 +3035,11 @@ impl Payload<'_> for SignWithECDSAReply {}
 
 /// Represents the argument of the ecdsa_public_key API.
 /// ```text
-/// (record {
+/// record {
 ///   canister_id : opt canister_id;
 ///   derivation_path : vec blob;
 ///   key_id : ecdsa_key_id;
-/// })
+/// }
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct ECDSAPublicKeyArgs {
@@ -3052,10 +3052,10 @@ impl Payload<'_> for ECDSAPublicKeyArgs {}
 
 /// Represents the response of the ecdsa_public_key API.
 /// ```text
-/// (record {
+/// record {
 ///   public_key : blob;
 ///   chain_code : blob;
-/// })
+/// }
 /// ```
 #[derive(Debug, CandidType, Deserialize)]
 pub struct ECDSAPublicKeyResponse {
@@ -3074,12 +3074,12 @@ pub type BoundedNodes = BoundedVec<MAX_ALLOWED_NODES_COUNT, UNBOUNDED, UNBOUNDED
 
 /// Argument of the reshare_chain_key API.
 /// ```text
-/// (record {
+/// record {
 ///     key_id : master_public_key_id;
 ///     subnet_id : principal;
 ///     nodes : vec principal;
 ///     registry_version : nat64;
-/// })
+/// }
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct ReshareChainKeyArgs {
@@ -3155,9 +3155,9 @@ impl ReshareChainKeyResponse {
 
 /// Represents the BIP341 aux argument of the sign_with_schnorr API.
 /// ```text
-/// (record {
+/// record {
 ///   merkle_root_hash : blob;
-/// })
+/// }
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct SignWithBip341Aux {
@@ -3180,12 +3180,12 @@ pub enum SignWithSchnorrAux {
 
 /// Represents the argument of the sign_with_schnorr API.
 /// ```text
-/// (record {
+/// record {
 ///   message : blob;
 ///   derivation_path : vec blob;
 ///   key_id : schnorr_key_id;
 ///   aux : opt schnorr_aux;
-/// })
+/// }
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct SignWithSchnorrArgs {
@@ -3209,11 +3209,11 @@ impl Payload<'_> for SignWithSchnorrReply {}
 
 /// Represents the argument of the schnorr_public_key API.
 /// ```text
-/// (record {
+/// record {
 ///   canister_id : opt canister_id;
 ///   derivation_path : vec blob;
 ///   key_id : schnorr_key_id;
-/// })
+/// }
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct SchnorrPublicKeyArgs {
@@ -3226,10 +3226,10 @@ impl Payload<'_> for SchnorrPublicKeyArgs {}
 
 /// Represents the response of the schnorr_public_key API.
 /// ```text
-/// (record {
+/// record {
 ///   public_key : blob;
 ///   chain_code : blob;
-/// })
+/// }
 /// ```
 #[derive(Debug, CandidType, Deserialize)]
 pub struct SchnorrPublicKeyResponse {
@@ -3243,12 +3243,12 @@ impl Payload<'_> for SchnorrPublicKeyResponse {}
 
 /// Represents the argument of the vetkd_derive_key API.
 /// ```text
-/// (record {
+/// record {
 ///   input : blob;
 ///   context : blob;
 ///   transport_public_key : blob;
 ///   key_id : record { curve : vetkd_curve; name : text };
-/// })
+/// }
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct VetKdDeriveKeyArgs {
@@ -3265,9 +3265,9 @@ impl Payload<'_> for VetKdDeriveKeyArgs {}
 
 /// Struct used to return vet KD result.
 /// ```text
-/// (record {
+/// record {
 ///   encrypted_key : blob;
-/// })
+/// }
 /// ```
 #[derive(Debug, CandidType, Deserialize)]
 pub struct VetKdDeriveKeyResult {
@@ -3279,11 +3279,11 @@ impl Payload<'_> for VetKdDeriveKeyResult {}
 
 /// Represents the argument of the vetkd_public_key API.
 /// ```text
-/// (record {
+/// record {
 ///   canister_id : opt canister_id;
 ///   context : blob;
 ///   key_id : record { curve : vetkd_curve; name : text };
-/// })
+/// }
 /// ```
 #[derive(Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct VetKdPublicKeyArgs {
@@ -3297,9 +3297,9 @@ impl Payload<'_> for VetKdPublicKeyArgs {}
 
 /// Represents the response of the vetkd_public_key API.
 /// ```text
-/// (record {
+/// record {
 ///   public_key : blob;
-/// })
+/// }
 /// ```
 #[derive(Debug, CandidType, Deserialize)]
 pub struct VetKdPublicKeyResult {
@@ -3708,7 +3708,7 @@ impl InstallChunkedCodeArgs {
 /// Struct used for encoding/decoding of legacy version of `InstallChunkedCodeArgs`,
 /// it is used to preserve backward compatibility.
 /// ```text
-/// (record {
+/// record {
 ///     mode : variant {
 ///         install;
 ///         reinstall;
@@ -3722,7 +3722,7 @@ impl InstallChunkedCodeArgs {
 ///     wasm_module_hash : blob;
 ///     arg : blob;
 ///     sender_canister_version : opt nat64;
-/// })
+/// }
 /// ```
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct InstallChunkedCodeArgsLegacy {
@@ -3901,11 +3901,11 @@ impl Payload<'_> for LoadCanisterSnapshotArgs {}
 
 /// Struct to be returned when taking a canister snapshot.
 /// ```text
-/// (record {
+/// record {
 ///      id : blob;
 ///      taken_at_timestamp : nat64;
 ///      total_size : nat64;
-/// })
+/// }
 /// ```
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
 pub struct CanisterSnapshotResponse {
@@ -4184,7 +4184,8 @@ impl TryFrom<pb_canister_state_bits::SnapshotSource> for SnapshotSource {
 }
 
 /// Struct used for encoding/decoding
-/// (record {
+/// ```text
+/// record {
 ///     source : variant {
 ///         taken_from_canister : reserved;
 ///         metadata_upload : reserved;
@@ -4214,7 +4215,8 @@ impl TryFrom<pb_canister_state_bits::SnapshotSource> for SnapshotSource {
 ///         ready;
 ///         executed;
 ///     };
-/// })
+/// }
+/// ```
 
 #[derive(Clone, PartialEq, Debug, CandidType, Deserialize)]
 pub struct ReadCanisterSnapshotMetadataResponse {
@@ -4329,7 +4331,8 @@ impl TryFrom<pb_canister_state_bits::OnLowWasmMemoryHookStatus> for OnLowWasmMem
 }
 
 /// Struct for encoding/decoding
-/// (record {
+/// ```text
+/// record {
 ///  canister_id : principal;
 ///  snapshot_id : blob;
 ///  kind : variant {
@@ -4349,7 +4352,8 @@ impl TryFrom<pb_canister_state_bits::OnLowWasmMemoryHookStatus> for OnLowWasmMem
 ///         hash : blob;
 ///     };
 ///  };
-/// })
+/// }
+/// ```
 
 #[derive(Clone, Debug, Deserialize, CandidType, Serialize)]
 pub struct ReadCanisterSnapshotDataArgs {
@@ -4418,7 +4422,7 @@ impl ReadCanisterSnapshotDataResponse {
 
 /// Struct to encode/decode
 /// ```text
-/// (record {
+/// record {
 ///     canister_id : principal;
 ///     replace_snapshot : opt blob;
 ///     wasm_module_size : nat64;
@@ -4441,7 +4445,7 @@ impl ReadCanisterSnapshotDataResponse {
 ///         ready;
 ///         executed;
 ///     };
-/// };)
+/// }
 /// ```
 
 #[derive(Clone, Debug, Deserialize, CandidType, Serialize)]
@@ -4507,9 +4511,9 @@ impl UploadCanisterSnapshotMetadataArgs {
 
 /// Struct to encode/decode
 /// ```text
-/// (record {
+/// record {
 ///   snapshot_id : blob;
-/// };)
+/// }
 /// ```
 #[derive(Clone, Debug, Deserialize, CandidType, Serialize)]
 pub struct UploadCanisterSnapshotMetadataResponse {
@@ -4525,7 +4529,8 @@ impl UploadCanisterSnapshotMetadataResponse {
 }
 
 /// Struct to encode/decode
-/// (record {
+/// ```text
+/// record {
 ///     canister_id : principal;
 ///     snapshot_id : blob;
 ///     kind : variant {
@@ -4541,7 +4546,8 @@ impl UploadCanisterSnapshotMetadataResponse {
 ///         wasm_chunk;
 ///     };
 ///     chunk : blob;
-/// };)
+/// }
+/// ```
 
 #[derive(Clone, Debug, Deserialize, CandidType, Serialize)]
 pub struct UploadCanisterSnapshotDataArgs {
@@ -4591,7 +4597,8 @@ pub enum CanisterSnapshotDataOffset {
 }
 
 /// Struct to encode/decode
-/// (record {
+/// ```text
+/// record {
 ///   canister_id : principal;
 ///   rename_to : record {
 ///     canister_id : principal;
@@ -4599,7 +4606,8 @@ pub enum CanisterSnapshotDataOffset {
 ///     total_num_changes : nat64;
 ///   };
 ///   sender_canister_version : nat64;
-/// };)
+/// }
+/// ```
 
 #[derive(Clone, Debug, Deserialize, CandidType, Serialize, PartialEq)]
 pub struct RenameCanisterArgs {

--- a/rs/types/management_canister_types/src/provisional.rs
+++ b/rs/types/management_canister_types/src/provisional.rs
@@ -7,6 +7,9 @@ use num_traits::ToPrimitive;
 /// ```text
 /// record {
 ///   amount : opt nat;
+///   settings : opt canister_settings;
+///   specified_id : opt principal;
+///   sender_canister_version : opt nat64;
 /// }
 /// ```
 #[derive(Debug, CandidType, Deserialize)]

--- a/rs/types/management_canister_types/src/provisional.rs
+++ b/rs/types/management_canister_types/src/provisional.rs
@@ -3,7 +3,12 @@ use candid::{CandidType, Deserialize};
 use ic_base_types::{CanisterId, PrincipalId};
 use num_traits::ToPrimitive;
 
-/// Struct used for encoding/decoding `(record { amount : opt nat; })`
+/// Struct used for encoding/decoding
+/// ```text
+/// record {
+///   amount : opt nat;
+/// }
+/// ```
 #[derive(Debug, CandidType, Deserialize)]
 pub struct ProvisionalCreateCanisterWithCyclesArgs {
     pub amount: Option<candid::Nat>,
@@ -37,10 +42,12 @@ impl ProvisionalCreateCanisterWithCyclesArgs {
 impl Payload<'_> for ProvisionalCreateCanisterWithCyclesArgs {}
 
 /// Struct used for encoding/decoding
-/// `(record {
-///     canister_id : principal;
-///     amount: nat;
-/// })`
+/// ```text
+/// record {
+///   canister_id : principal;
+///   amount : nat;
+/// }
+/// ```
 #[derive(Debug, CandidType, Deserialize)]
 pub struct ProvisionalTopUpCanisterArgs {
     canister_id: PrincipalId,

--- a/rs/types/management_canister_types/tests/ic.did
+++ b/rs/types/management_canister_types/tests/ic.did
@@ -20,6 +20,7 @@ type canister_settings = record {
     freezing_threshold : opt nat;
     reserved_cycles_limit : opt nat;
     log_visibility : opt log_visibility;
+    log_size: opt nat;
     wasm_memory_limit : opt nat;
     wasm_memory_threshold : opt nat;
     environment_variables : opt vec environment_variable;
@@ -33,6 +34,7 @@ type definite_canister_settings = record {
     freezing_threshold : nat;
     reserved_cycles_limit : nat;
     log_visibility : log_visibility;
+    log_size : nat;
     wasm_memory_limit : nat;
     wasm_memory_threshold: nat;
     environment_variables : vec environment_variable;

--- a/rs/types/management_canister_types/tests/ic.did
+++ b/rs/types/management_canister_types/tests/ic.did
@@ -20,7 +20,6 @@ type canister_settings = record {
     freezing_threshold : opt nat;
     reserved_cycles_limit : opt nat;
     log_visibility : opt log_visibility;
-    log_size: opt nat;
     wasm_memory_limit : opt nat;
     wasm_memory_threshold : opt nat;
     environment_variables : opt vec environment_variable;
@@ -34,7 +33,6 @@ type definite_canister_settings = record {
     freezing_threshold : nat;
     reserved_cycles_limit : nat;
     log_visibility : log_visibility;
-    log_size : nat;
     wasm_memory_limit : nat;
     wasm_memory_threshold: nat;
     environment_variables : vec environment_variable;


### PR DESCRIPTION
This PR unifies Candid declarations in doc comments for management canister Rust types.

No functional changes, only doc comments.

Changes:
- removes extra parenthesis `(record {...})` with `record {...}`
- consistently uses ` ```text ` in blocks