### PR TITLE
chore: Shorten NNS delegation refresh interval

### DIFF
--- a/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
+++ b/rs/http_endpoints/nns_delegation_manager/src/nns_delegation_manager.rs
@@ -47,7 +47,7 @@ const CONTENT_TYPE_CBOR: &str = "application/cbor";
 // In order to properly test the time outs we set much lower values for them when we are
 // in the test mode.
 #[cfg(not(test))]
-const DELEGATION_UPDATE_INTERVAL: Duration = Duration::from_secs(10 * 60);
+const DELEGATION_UPDATE_INTERVAL: Duration = Duration::from_secs(5 * 60);
 #[cfg(test)]
 const DELEGATION_UPDATE_INTERVAL: Duration = Duration::from_secs(5);
 


### PR DESCRIPTION
This commit shortens the interval for subnets to refresh their delegation from the NNS from 10 minutes to 5 minutes.

The upcoming canister migration feature is quite sensitive to outdated NNS delegations, as responses to ingress calls to a recently migrated canister are only valid if the delegation reflects the updated routing table.

Canister migrations take at least 5 minutes anyway to protect from replay attacks. It therefore makes sense to also set the delegation update interval to 5 minutes. At the same time, updating delegations is not so costly that we cannot do it every 5 minutes.