### PR TITLE
fix(nervous_system): Release Runscript should use correct commit to generate proposals

### DIFF
--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -308,6 +308,8 @@ fn run_create_proposal_texts(cmd: CreateProposalTexts) -> Result<()> {
             commit
         );
 
+        let _switcher = CommitSwitcher::switch(commit.clone());
+
         // For each NNS canister, run the prepare-nns-upgrade-proposal-text.sh script and write its output to a file.
         for canister in &nns_canisters {
             println!("Creating proposal text for NNS canister: {canister}");


### PR DESCRIPTION
This fixes an issue where release runscript uses the currently checked out version of the repository to generate proposal text, which can result in a difference between what is released and the release notes that are included in the generated propsoal.