### PR TITLE
fix: add empty governance_test.did files to make cargo clippy succeed

### DIFF
--- a/rs/nns/governance/canister/governance_test.did
+++ b/rs/nns/governance/canister/governance_test.did
@@ -1,0 +1,2 @@
+// This empty Candid file is to make `cargo clippy` happy since it will be include at build time into Rust files.
+// Bazel will actually generate a real governance_test.did based on governance.did and governance_test.did.patch.

--- a/rs/sns/governance/canister/governance_test.did
+++ b/rs/sns/governance/canister/governance_test.did
@@ -1,0 +1,2 @@
+// This empty Candid file is to make `cargo clippy` happy since it will be include at build time into Rust files.
+// Bazel will actually generate a real governance_test.did based on governance.did and governance_test.did.patch.


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/6947 removed `governance_test.did` files and generated them with bazel instead. However these files are included in rust code (`include_str!("governance_test.did")`) which means that `cargo clippy` will [fail](https://github.com/dfinity/ic/actions/runs/18238768918/job/51941823743#step:5:2903) on it.

The reason the `cargo clippy` job [succeeded](https://github.com/dfinity/ic/actions/runs/18230285300/job/51912091777) on the PR was that the `cargo clippy` step only runs if `.rs` files have been modified which the PR didn't touch.

To fix the `cargo clippy` job we commit empty `governance_test.did` files.