### PR TITLE
fix(nns-recovery): fix `registry_store_uri` parameter in NNS recovery on same nodes

### DIFF
--- a/rs/recovery/src/steps.rs
+++ b/rs/recovery/src/steps.rs
@@ -911,8 +911,6 @@ impl Step for GetRecoveryCUPStep {
             Some(SubCommand::GetRecoveryCup(GetRecoveryCupCmd {
                 state_hash: self.state_hash.clone(),
                 height: self.recovery_height.get(),
-                registry_store_uri: None,
-                registry_store_sha256: None,
                 output_file: self.work_dir.join("cup.proto"),
             })),
             None,

--- a/rs/replay/src/cmd.rs
+++ b/rs/replay/src/cmd.rs
@@ -91,10 +91,6 @@ pub struct GetRecoveryCupCmd {
     pub height: u64,
     /// Output file
     pub output_file: PathBuf,
-    /// Registry store URI
-    pub registry_store_uri: Option<String>,
-    /// Registry store SHA256 hash
-    pub registry_store_sha256: Option<String>,
 }
 
 #[derive(Clone, Parser)]

--- a/rs/replay/src/lib.rs
+++ b/rs/replay/src/lib.rs
@@ -209,12 +209,12 @@ pub fn consent_given(question: &str) -> bool {
 }
 
 // Creates a recovery CUP by using the latest CUP and overriding the height and
-// the state hash.
+// the state hash, intended to be used in NNS recovery on same nodes.
 fn cmd_get_recovery_cup(
     player: &crate::player::Player,
     cmd: &crate::cmd::GetRecoveryCupCmd,
 ) -> Result<(), String> {
-    use ic_protobuf::registry::subnet::v1::{CatchUpPackageContents, RegistryStoreUri};
+    use ic_protobuf::registry::subnet::v1::CatchUpPackageContents;
     use ic_types::{consensus::HasHeight, crypto::threshold_sig::ni_dkg::NiDkgTag};
 
     let context_time = ic_types::time::current_time();
@@ -245,11 +245,7 @@ fn cmd_get_recovery_cup(
         height: cmd.height,
         time: time.as_nanos_since_unix_epoch(),
         state_hash,
-        registry_store_uri: Some(RegistryStoreUri {
-            uri: cmd.registry_store_uri.clone().unwrap_or_default(),
-            hash: cmd.registry_store_sha256.clone().unwrap_or_default(),
-            registry_version: registry_version.get(),
-        }),
+        registry_store_uri: None,
         ecdsa_initializations: vec![],
         chain_key_initializations: vec![],
     };


### PR DESCRIPTION
The NNS recovery system tests sometimes failed because nodes would take forever to load the NiDKG transcripts from the recovery CUP. The problem was that the latter set the `registry_store_uri` field, which [means](https://github.com/dfinity/ic/blob/a44bcc6d2867d6cbb9e035353d9a0cf5a171c52c/rs/consensus/dkg/src/payload_builder.rs#L516-L520) we were overwriting the registry version of these transcripts with a newer one, effectively corrupting them. As the comment in the link above suggests, this field is used in NNS recovery on *failover* nodes, but the `cmd_get_recovery_cup` function is called only in NNS recovery on *same* nodes. This PR thus unsets this field there.

The bug did not happen very often because [this check](https://github.com/dfinity/ic/blob/fa37988f9a26f6dfa05b1953362c7b0719214ef5/rs/crypto/internal/crypto_service_provider/src/vault/local_csp_vault/ni_dkg/mod.rs#L405-L415) made the nodes that had already loaded these transcripts not decrypt them, which leaves a very small window where a node would have to be broken and the rest of the subnet load new transcripts before the next node gets broken and stalls the subnet. If this check is removed, then the tests indeed deterministically always [fail](https://dash.dm1-idx1.dfinity.network/invocation/36215613-7b65-4a32-8ca3-ed2440e6051d).