### PR TITLE
feat: [EXC-1848] Enrich `CallOrigin` with method name 1/2

### DIFF
--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -18,6 +18,10 @@ message CallContext {
     types.v1.UserId user_id = 1;
     bytes message_id = 2;
   }
+  message Query {
+    types.v1.UserId user_id = 1;
+    string method_name = 2;
+  }
   message CanisterUpdateOrQuery {
     types.v1.CanisterId canister_id = 1;
     uint64 callback_id = 2;
@@ -33,6 +37,7 @@ message CallContext {
     types.v1.UserId query = 3;
     CanisterUpdateOrQuery canister_query = 4;
     SystemTask system_task = 7;
+    Query user_query = 12;
   }
   bool responded = 5;
   state.queues.v1.Funds available_funds = 6;

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -13,7 +13,7 @@ pub struct CallContext {
     pub instructions_executed: u64,
     #[prost(message, optional, tag = "11")]
     pub metadata: ::core::option::Option<super::super::queues::v1::RequestMetadata>,
-    #[prost(oneof = "call_context::CallOrigin", tags = "1, 2, 3, 4, 7")]
+    #[prost(oneof = "call_context::CallOrigin", tags = "1, 2, 3, 4, 7, 12")]
     pub call_origin: ::core::option::Option<call_context::CallOrigin>,
 }
 /// Nested message and enum types in `CallContext`.
@@ -24,6 +24,13 @@ pub mod call_context {
         pub user_id: ::core::option::Option<super::super::super::super::types::v1::UserId>,
         #[prost(bytes = "vec", tag = "2")]
         pub message_id: ::prost::alloc::vec::Vec<u8>,
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Query {
+        #[prost(message, optional, tag = "1")]
+        pub user_id: ::core::option::Option<super::super::super::super::types::v1::UserId>,
+        #[prost(string, tag = "2")]
+        pub method_name: ::prost::alloc::string::String,
     }
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct CanisterUpdateOrQuery {
@@ -50,6 +57,8 @@ pub mod call_context {
         CanisterQuery(CanisterUpdateOrQuery),
         #[prost(message, tag = "7")]
         SystemTask(SystemTask),
+        #[prost(message, tag = "12")]
+        UserQuery(Query),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/replicated_state/src/canister_state/system_state/call_context_manager/proto.rs
+++ b/rs/replicated_state/src/canister_state/system_state/call_context_manager/proto.rs
@@ -107,6 +107,13 @@ impl TryFrom<pb::call_context::CallOrigin> for CallOrigin {
                 callback_id.into(),
             ),
             pb::call_context::CallOrigin::SystemTask { .. } => Self::SystemTask,
+            pb::call_context::CallOrigin::UserQuery(pb::call_context::Query {
+                user_id,
+                method_name: _,
+            }) => Self::Query(user_id_try_from_protobuf(try_from_option_field(
+                user_id,
+                "CallOrigin::UserQuery::user_id",
+            )?)?),
         };
         Ok(call_origin)
     }


### PR DESCRIPTION
This PR makes sure that replicas can [deal with the future](https://github.com/dfinity/ic/pull/7072). 

That is, decode an enum variant from a protobuf file with a future version. See above link for details. 

**Reviewers**: Please review the above PR before approving this one, in case it needs some changes that feed back into this one. 