### PR TITLE
fix: update subnet available memory after unstalling code and updating canister history

### DIFF
--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -35,13 +35,12 @@ use ic_logger::replica_logger::no_op_logger;
 use ic_management_canister_types_private::{
     CanisterChange, CanisterChangeDetails, CanisterChangeOrigin, CanisterIdRecord,
     CanisterInstallMode, CanisterInstallModeV2, CanisterSettingsArgsBuilder,
-    CanisterSnapshotResponse, CanisterStatusResultV2, CanisterStatusType, CanisterUpgradeOptions,
-    ChunkHash, ClearChunkStoreArgs, CreateCanisterArgs, EmptyBlob, EnvironmentVariable, IC_00,
-    InstallCodeArgsV2, LoadCanisterSnapshotArgs, Method, NodeMetricsHistoryArgs,
-    NodeMetricsHistoryResponse, OnLowWasmMemoryHookStatus, Payload, RenameCanisterArgs,
-    RenameToArgs, StoredChunksArgs, StoredChunksReply, SubnetInfoArgs, SubnetInfoResponse,
-    TakeCanisterSnapshotArgs, UpdateSettingsArgs, UploadChunkArgs, UploadChunkReply,
-    WasmMemoryPersistence,
+    CanisterStatusResultV2, CanisterStatusType, CanisterUpgradeOptions, ChunkHash,
+    ClearChunkStoreArgs, CreateCanisterArgs, EmptyBlob, EnvironmentVariable, IC_00,
+    InstallCodeArgsV2, Method, NodeMetricsHistoryArgs, NodeMetricsHistoryResponse,
+    OnLowWasmMemoryHookStatus, Payload, RenameCanisterArgs, RenameToArgs, StoredChunksArgs,
+    StoredChunksReply, SubnetInfoArgs, SubnetInfoResponse, TakeCanisterSnapshotArgs,
+    UpdateSettingsArgs, UploadChunkArgs, UploadChunkReply, WasmMemoryPersistence,
 };
 use ic_metrics::MetricsRegistry;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -6237,62 +6236,6 @@ fn update_memory_allocation_updates_hook_status_ready_to_not_satisfied() {
         initial_memory_state,
         updated_memory_state,
         false,
-    );
-}
-
-#[test]
-fn memory_usage_updates_increment_subnet_available_memory() {
-    let mut test = ExecutionTestBuilder::new().build();
-
-    // create a universal canister
-    let canister_id = test.create_canister(*INITIAL_CYCLES);
-    test.install_code_v2(InstallCodeArgsV2::new(
-        CanisterInstallModeV2::Install,
-        canister_id,
-        UNIVERSAL_CANISTER_WASM.to_vec(),
-        vec![],
-    ))
-    .unwrap();
-
-    // take a canister snapshot
-    let take_snapshot_args = TakeCanisterSnapshotArgs {
-        canister_id: canister_id.get(),
-        replace_snapshot: None,
-    };
-    let res = test
-        .subnet_message("take_canister_snapshot", take_snapshot_args.encode())
-        .unwrap();
-    let snapshot_id = match res {
-        WasmResult::Reply(data) => Decode!(&data, CanisterSnapshotResponse).unwrap().id,
-        WasmResult::Reject(msg) => panic!("Unexpected reject: {msg}"),
-    };
-
-    // capture current subnet available memory
-    let initial_subnet_available_memory = test.subnet_available_memory();
-
-    // grow stable memory
-    let payload = wasm().stable_grow(100).reply().build();
-    test.ingress(canister_id, "update", payload).unwrap();
-
-    // execution memory should *increase* after growing stable memory => available memory should *decrease*
-    let subnet_available_memory = test.subnet_available_memory();
-    assert_lt!(
-        subnet_available_memory.get_execution_memory(),
-        initial_subnet_available_memory.get_execution_memory()
-    );
-
-    // load canister snapshot
-    let load_snapshot_args = LoadCanisterSnapshotArgs::new(canister_id, snapshot_id, None);
-    test.subnet_message("load_canister_snapshot", load_snapshot_args.encode())
-        .unwrap();
-
-    // execution memory should get back to its initial value before growing stable memory
-    // except for the extra canister history memory
-    let subnet_available_memory = test.subnet_available_memory();
-    let extra_canister_history_memory = size_of::<CanisterChange>() as i64;
-    assert_eq!(
-        subnet_available_memory.get_execution_memory() + extra_canister_history_memory,
-        initial_subnet_available_memory.get_execution_memory()
     );
 }
 

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -1648,6 +1648,7 @@ fn uninstall_canister_doesnt_respond_to_responded_call_contexts() {
             &mut CanisterStateBuilder::new()
                 .with_call_context(CallContextBuilder::new().with_responded(true).build())
                 .build(),
+            None,
             UNIX_EPOCH,
             AddCanisterChangeToHistory::No,
             Arc::new(TestPageAllocatorFileDescriptorImpl),
@@ -1673,6 +1674,7 @@ fn uninstall_canister_responds_to_unresponded_call_contexts() {
                         .build()
                 )
                 .build(),
+            None,
             UNIX_EPOCH,
             AddCanisterChangeToHistory::No,
             Arc::new(TestPageAllocatorFileDescriptorImpl),

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -348,8 +348,8 @@ impl TryFrom<(CanisterChangeOrigin, InstallCodeArgsV2)> for InstallCodeContext {
 }
 
 /// Indicates whether `uninstall_canister` should push a canister change (with a given change origin) to canister history.
-pub enum AddCanisterChangeToHistory {
-    Yes(CanisterChangeOrigin),
+pub enum AddCanisterChangeToHistory<'a> {
+    Yes(CanisterChangeOrigin, &'a mut RoundLimits),
     No,
 }
 

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -348,8 +348,8 @@ impl TryFrom<(CanisterChangeOrigin, InstallCodeArgsV2)> for InstallCodeContext {
 }
 
 /// Indicates whether `uninstall_canister` should push a canister change (with a given change origin) to canister history.
-pub enum AddCanisterChangeToHistory<'a> {
-    Yes(CanisterChangeOrigin, &'a mut RoundLimits),
+pub enum AddCanisterChangeToHistory {
+    Yes(CanisterChangeOrigin),
     No,
 }
 

--- a/rs/execution_environment/src/execution/install_code/tests.rs
+++ b/rs/execution_environment/src/execution/install_code/tests.rs
@@ -334,13 +334,13 @@ fn install_code_respects_wasm_custom_sections_available_memory() {
     // only a few canisters.
     let available_wasm_custom_sections_memory = 1024; // 1 KiB
 
-    // This value might need adjustment if something changes in the canister's
-    // wasm that gets installed in the test.
     let canister_history_memory_for_creation =
         size_of::<CanisterChange>() + size_of::<PrincipalId>();
     let canister_history_memory_for_install = size_of::<CanisterChange>();
     let canister_history_memory_per_canister =
         canister_history_memory_for_creation + canister_history_memory_for_install;
+    // This value might need adjustment if something changes in the canister's
+    // wasm that gets installed in the test.
     let total_memory_taken_per_canister_in_bytes =
         364441 + canister_history_memory_per_canister as i64;
 

--- a/rs/execution_environment/src/execution/install_code/tests.rs
+++ b/rs/execution_environment/src/execution/install_code/tests.rs
@@ -336,7 +336,13 @@ fn install_code_respects_wasm_custom_sections_available_memory() {
 
     // This value might need adjustment if something changes in the canister's
     // wasm that gets installed in the test.
-    let total_memory_taken_per_canister_in_bytes = 364441;
+    let canister_history_memory_for_creation =
+        size_of::<CanisterChange>() + size_of::<PrincipalId>();
+    let canister_history_memory_for_install = size_of::<CanisterChange>();
+    let canister_history_memory_per_canister =
+        canister_history_memory_for_creation + canister_history_memory_for_install;
+    let total_memory_taken_per_canister_in_bytes =
+        364441 + canister_history_memory_per_canister as i64;
 
     let mut test = ExecutionTestBuilder::new()
         .with_install_code_instruction_limit(1_000_000_000)
@@ -372,24 +378,11 @@ fn install_code_respects_wasm_custom_sections_available_memory() {
         iterations += 1;
     }
 
-    // One more request to install a canister with wasm custom sections should fail.
-    let canister_id = test
-        .create_canister_with_allocation(Cycles::new(1_000_000_000_000_000), None, None)
-        .unwrap();
-
-    let payload = InstallCodeArgs {
-        mode: CanisterInstallMode::Install,
-        canister_id: canister_id.get(),
-        wasm_module: include_bytes!("../../../tests/test-data/custom_sections.wasm").to_vec(),
-        arg: vec![],
-        sender_canister_version: None,
-    };
-    let result = test.subnet_message(Method::InstallCode, payload.encode());
-
-    assert!(result.is_err());
     assert_eq!(
-        test.subnet_available_memory().get_execution_memory(),
-        subnet_available_memory_before - iterations * total_memory_taken_per_canister_in_bytes
+        test.subnet_available_memory().get_execution_memory()
+            + iterations * total_memory_taken_per_canister_in_bytes
+            + canister_history_memory_for_creation as i64,
+        subnet_available_memory_before
     );
 }
 

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -806,6 +806,7 @@ impl ExecutionEnvironment {
                             msg.canister_change_origin(args.get_sender_canister_version()),
                             args.get_canister_id(),
                             &mut state,
+                            round_limits,
                             &self.metrics.canister_not_found_error,
                         )
                         .map(|()| (EmptyBlob.encode(), Some(args.get_canister_id())))
@@ -1805,7 +1806,7 @@ impl ExecutionEnvironment {
                 let res = RenameCanisterArgs::decode(payload).and_then(|args| {
                     let canister_id = args.get_canister_id();
                     let origin = msg.canister_change_origin(args.get_sender_canister_version());
-                    self.rename_canister(*msg.sender(), &mut state, args, origin)
+                    self.rename_canister(*msg.sender(), &mut state, round_limits, args, origin)
                         .map(|res| (res, Some(canister_id)))
                 });
                 ExecuteSubnetMessageResult::Finished {
@@ -2661,6 +2662,7 @@ impl ExecutionEnvironment {
         &self,
         sender: PrincipalId,
         state: &mut ReplicatedState,
+        round_limits: &mut RoundLimits,
         args: RenameCanisterArgs,
         origin: CanisterChangeOrigin,
     ) -> Result<Vec<u8>, UserError> {
@@ -2691,6 +2693,7 @@ impl ExecutionEnvironment {
                 to_version,
                 to_total_num_changes,
                 state,
+                round_limits,
             )
             .map(|()| EmptyBlob.encode())
             .map_err(|err| err.into());

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -892,6 +892,7 @@ impl SchedulerImpl {
 
     /// Charge canisters for their resource allocation and usage. Canisters
     /// that did not manage to pay are uninstalled.
+    /// This function is expected to be called at the end of a round.
     fn charge_canisters_for_resource_allocation_and_usage(
         &self,
         state: &mut ReplicatedState,
@@ -937,7 +938,7 @@ impl SchedulerImpl {
                     all_rejects.push(uninstall_canister(
                         &self.log,
                         canister,
-                        None,
+                        None, /* we're at the end of a round so no need to update round limits */
                         state_time,
                         AddCanisterChangeToHistory::No,
                         Arc::clone(&self.fd_factory),

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -937,6 +937,7 @@ impl SchedulerImpl {
                     all_rejects.push(uninstall_canister(
                         &self.log,
                         canister,
+                        None,
                         state_time,
                         AddCanisterChangeToHistory::No,
                         Arc::clone(&self.fd_factory),

--- a/rs/execution_environment/tests/canister_history.rs
+++ b/rs/execution_environment/tests/canister_history.rs
@@ -1659,7 +1659,7 @@ fn canister_history_memory_usage_ignored_in_invariant_checks() {
 /// - loading canister snapshot;
 /// - changing canister settings (controllers).
 ///
-/// The tests also exercises the case of decreasing canister history memory usage
+/// The test also exercises the case of decreasing canister history memory usage
 /// after filling canister history with entries of the maximum possible size.
 #[test]
 fn subnet_available_memory() {
@@ -1733,7 +1733,9 @@ fn subnet_available_memory() {
     .unwrap();
     check_subnet_available_memory(&test, true);
 
-    // memory usage decreases after loading snapshot since the snapshot was taken with empty stable memory
+    // memory usage decreases after loading snapshot since the snapshot was taken with empty stable memory;
+    // this way, we also test that `CanisterManager::cycles_and_memory_usage_updates` can handle the case
+    // of decreasing memory usage
     let load_canister_snapshot_args = LoadCanisterSnapshotArgs::new(canister_id, snapshot_id, None);
     test.subnet_message(
         Method::LoadCanisterSnapshot,

--- a/rs/execution_environment/tests/canister_history.rs
+++ b/rs/execution_environment/tests/canister_history.rs
@@ -1671,13 +1671,13 @@ fn subnet_available_memory() {
 
     let canister_id = test.create_canister_with_default_cycles();
 
-    let mut check_subnet_available_memory = |test: &ExecutionTest, memory_usage_grow: bool| {
+    let mut check_subnet_available_memory = |test: &ExecutionTest, memory_usage_increase: bool| {
         assert_eq!(
             test.subnet_available_memory().get_execution_memory()
                 + test.canister_state(canister_id).memory_usage().get() as i64,
             initial_subnet_available_memory.get_execution_memory()
         );
-        if memory_usage_grow {
+        if memory_usage_increase {
             assert!(
                 test.subnet_available_memory().get_execution_memory()
                     < current_subnet_available_memory.get_execution_memory()
@@ -1691,15 +1691,15 @@ fn subnet_available_memory() {
         current_subnet_available_memory = test.subnet_available_memory();
     };
 
-    // memory usage grows after canister creation
+    // memory usage increases after canister creation
     check_subnet_available_memory(&test, true);
 
-    // memory usage grows after installing the universal canister WASM
+    // memory usage increases after installing the universal canister WASM
     test.install_canister(canister_id, UNIVERSAL_CANISTER_WASM.to_vec())
         .unwrap();
     check_subnet_available_memory(&test, true);
 
-    // memory usage grows after taking a snapshot
+    // memory usage increases after taking a snapshot
     let take_canister_snapshot_args = TakeCanisterSnapshotArgs::new(canister_id, None);
     let res = test.subnet_message(
         Method::TakeCanisterSnapshot,
@@ -1710,7 +1710,7 @@ fn subnet_available_memory() {
         .id;
     check_subnet_available_memory(&test, true);
 
-    // memory usage grows after upgrading and growing stable memory in post-upgrade
+    // memory usage increases after upgrading and growing stable memory in post-upgrade
     let grow_payload = wasm().stable_grow(100).build();
     test.upgrade_canister_with_args(
         canister_id,

--- a/rs/execution_environment/tests/canister_history.rs
+++ b/rs/execution_environment/tests/canister_history.rs
@@ -1724,7 +1724,7 @@ fn subnet_available_memory() {
     test.uninstall_code(canister_id).unwrap();
     check_subnet_available_memory(&test, false);
 
-    // memory usage increases after reinstalling code
+    // memory usage increases after reinstalling code and growing stable memory in init
     test.reinstall_canister_with_args(
         canister_id,
         UNIVERSAL_CANISTER_WASM.to_vec(),

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use candid::{Decode, Encode};
-use ic_base_types::{NumSeconds, PrincipalId};
+use ic_base_types::NumSeconds;
 use ic_config::subnet_config::SchedulerConfig;
 use ic_cycles_account_manager::ResourceSaturation;
 use ic_embedders::{
@@ -3436,12 +3436,9 @@ fn subnet_available_memory_is_updated_by_canister_init() {
             .get_guaranteed_response_message_memory()
     );
     let memory_used = test.state().memory_taken().execution().get() as i64;
-    let canister_history_memory = 2 * size_of::<CanisterChange>() + size_of::<PrincipalId>();
-    // canister history memory usage is not updated in SubnetAvailableMemory => we add it at RHS
     assert_eq!(
         test.subnet_available_memory().get_execution_memory(),
         initial_subnet_available_memory.get_execution_memory() - memory_used
-            + canister_history_memory as i64
     );
 }
 
@@ -3470,17 +3467,15 @@ fn subnet_available_memory_is_updated_by_canister_start() {
     let mem_before_upgrade = test.subnet_available_memory().get_execution_memory();
     let result = test.upgrade_canister(canister_id, wat::parse_str(wat).unwrap());
     assert_eq!(Ok(()), result);
+    let extra_canister_history_memory = size_of::<CanisterChange>() as i64;
     assert_eq!(
-        mem_before_upgrade,
+        mem_before_upgrade - extra_canister_history_memory,
         test.subnet_available_memory().get_execution_memory()
     );
     let memory_used = test.state().memory_taken().execution().get() as i64;
-    let canister_history_memory = 3 * size_of::<CanisterChange>() + size_of::<PrincipalId>();
-    // canister history memory usage is not updated in SubnetAvailableMemory => we add it at RHS
     assert_eq!(
         test.subnet_available_memory().get_execution_memory(),
         initial_subnet_available_memory.get_execution_memory() - memory_used
-            + canister_history_memory as i64
     );
     assert_eq!(
         initial_subnet_available_memory.get_guaranteed_response_message_memory(),
@@ -3506,8 +3501,11 @@ fn subnet_available_memory_is_updated_by_canister_pre_upgrade() {
     let initial_subnet_available_memory = test.subnet_available_memory();
     let result = test.upgrade_canister(canister_id, wat::parse_str(wat).unwrap());
     assert_eq!(Ok(()), result);
+    let extra_canister_history_memory = size_of::<CanisterChange>() as i64;
     assert_eq!(
-        initial_subnet_available_memory.get_execution_memory() - 10 * WASM_PAGE_SIZE as i64,
+        initial_subnet_available_memory.get_execution_memory()
+            - 10 * WASM_PAGE_SIZE as i64
+            - extra_canister_history_memory,
         test.subnet_available_memory().get_execution_memory()
     );
     assert_eq!(
@@ -3531,8 +3529,9 @@ fn subnet_available_memory_is_not_updated_by_canister_pre_upgrade_wasm_memory() 
     let initial_subnet_available_memory = test.subnet_available_memory();
     let result = test.upgrade_canister(canister_id, wat::parse_str(wat).unwrap());
     assert_eq!(Ok(()), result);
+    let extra_canister_history_memory = size_of::<CanisterChange>() as i64;
     assert_eq!(
-        initial_subnet_available_memory.get_execution_memory(),
+        initial_subnet_available_memory.get_execution_memory() - extra_canister_history_memory,
         test.subnet_available_memory().get_execution_memory()
     );
     assert_eq!(
@@ -3556,8 +3555,11 @@ fn subnet_available_memory_is_updated_by_canister_post_upgrade() {
     let initial_subnet_available_memory = test.subnet_available_memory();
     let result = test.upgrade_canister(canister_id, wat::parse_str(wat).unwrap());
     assert_eq!(Ok(()), result);
+    let extra_canister_history_memory = size_of::<CanisterChange>() as i64;
     assert_eq!(
-        initial_subnet_available_memory.get_execution_memory() - 10 * WASM_PAGE_SIZE as i64,
+        initial_subnet_available_memory.get_execution_memory()
+            - 10 * WASM_PAGE_SIZE as i64
+            - extra_canister_history_memory,
         test.subnet_available_memory().get_execution_memory()
     );
     assert_eq!(
@@ -7325,9 +7327,13 @@ fn stable_grow_checks_freezing_threshold_in_pre_upgrade() {
     test.update_freezing_threshold(canister_id, NumSeconds::new(1_000_000_000))
         .unwrap();
     let err = test.upgrade_canister(canister_id, wasm).unwrap_err();
+    let extra_canister_history_memory = size_of::<CanisterChange>() as i64;
+    let expected_err = format!(
+        "Canister cannot grow memory by {} bytes due to insufficient cycles",
+        655360000 + extra_canister_history_memory
+    );
     assert!(
-        err.description()
-            .contains("Canister cannot grow memory by 655360000 bytes due to insufficient cycles"),
+        err.description().contains(&expected_err),
         "Unexpected error: {}",
         err.description()
     );
@@ -7354,9 +7360,13 @@ fn stable_grow_checks_freezing_threshold_in_post_upgrade() {
     test.update_freezing_threshold(canister_id, NumSeconds::new(1_000_000_000))
         .unwrap();
     let err = test.upgrade_canister(canister_id, wasm).unwrap_err();
+    let extra_canister_history_memory = size_of::<CanisterChange>() as i64;
+    let expected_err = format!(
+        "Canister cannot grow memory by {} bytes due to insufficient cycles",
+        655360000 + extra_canister_history_memory
+    );
     assert!(
-        err.description()
-            .contains("Canister cannot grow memory by 655360000 bytes due to insufficient cycles"),
+        err.description().contains(&expected_err),
         "Unexpected error: {}",
         err.description()
     );
@@ -7461,9 +7471,13 @@ fn memory_grow_checks_freezing_threshold_in_post_upgrade() {
     test.update_freezing_threshold(canister_id, NumSeconds::new(1_000_000_000))
         .unwrap();
     let err = test.upgrade_canister(canister_id, wasm).unwrap_err();
+    let extra_canister_history_memory = size_of::<CanisterChange>();
+    let expected_err = format!(
+        "Canister cannot grow memory by {} bytes due to insufficient cycles",
+        655360000 + extra_canister_history_memory
+    );
     assert!(
-        err.description()
-            .contains("Canister cannot grow memory by 655360000 bytes due to insufficient cycles"),
+        err.description().contains(&expected_err),
         "Unexpected error: {}",
         err.description()
     );

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -641,6 +641,8 @@ impl CanisterState {
             )
     }
 
+    /// Adds a canister change to canister history and returns the change
+    /// of subnet available execution memory due to updating canister history.
     #[must_use]
     pub fn add_canister_change(
         &mut self,

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -655,13 +655,11 @@ impl CanisterState {
             .add_canister_change(timestamp_nanos, change_origin, change_details);
         let new_allocated_bytes = self.memory_allocated_bytes();
         if new_allocated_bytes >= old_allocated_bytes {
-            SubnetAvailableExecutionMemoryChange::Allocated(
-                new_allocated_bytes - old_allocated_bytes,
-            )
+            let allocated_bytes = new_allocated_bytes - old_allocated_bytes;
+            SubnetAvailableExecutionMemoryChange::Allocated(allocated_bytes)
         } else {
-            SubnetAvailableExecutionMemoryChange::Deallocated(
-                old_allocated_bytes - new_allocated_bytes,
-            )
+            let deallocated_bytes = old_allocated_bytes - new_allocated_bytes;
+            SubnetAvailableExecutionMemoryChange::Deallocated(deallocated_bytes)
         }
     }
 }

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -10,7 +10,10 @@ use crate::canister_state::system_state::{ExecutionTask, SystemState};
 use crate::{InputQueueType, MessageMemoryUsage, StateError};
 pub use execution_state::{EmbedderCache, ExecutionState, ExportedFunctions};
 use ic_config::embedders::Config as HypervisorConfig;
-use ic_management_canister_types_private::{CanisterStatusType, LogVisibilityV2};
+use ic_interfaces::execution_environment::SubnetAvailableExecutionMemoryChange;
+use ic_management_canister_types_private::{
+    CanisterChangeDetails, CanisterChangeOrigin, CanisterStatusType, LogVisibilityV2,
+};
 use ic_registry_subnet_type::SubnetType;
 use ic_types::batch::TotalQueryStats;
 use ic_types::methods::SystemMethod;
@@ -503,6 +506,13 @@ impl CanisterState {
         self.system_state.memory_allocation
     }
 
+    /// Returns the actual number of allocated bytes for the canister:
+    /// the maximum of its memory allocation and memory usage.
+    fn memory_allocated_bytes(&self) -> NumBytes {
+        self.memory_allocation()
+            .allocated_bytes(self.memory_usage())
+    }
+
     /// Returns the current Wasm memory threshold of the canister.
     pub fn wasm_memory_threshold(&self) -> NumBytes {
         self.system_state.wasm_memory_threshold
@@ -629,6 +639,28 @@ impl CanisterState {
                 self.memory_usage(),
                 self.wasm_memory_usage(),
             )
+    }
+
+    #[must_use]
+    pub fn add_canister_change(
+        &mut self,
+        timestamp_nanos: Time,
+        change_origin: CanisterChangeOrigin,
+        change_details: CanisterChangeDetails,
+    ) -> SubnetAvailableExecutionMemoryChange {
+        let old_allocated_bytes = self.memory_allocated_bytes();
+        self.system_state
+            .add_canister_change(timestamp_nanos, change_origin, change_details);
+        let new_allocated_bytes = self.memory_allocated_bytes();
+        if new_allocated_bytes >= old_allocated_bytes {
+            SubnetAvailableExecutionMemoryChange::Allocated(
+                new_allocated_bytes - old_allocated_bytes,
+            )
+        } else {
+            SubnetAvailableExecutionMemoryChange::Deallocated(
+                old_allocated_bytes - new_allocated_bytes,
+            )
+        }
     }
 }
 

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -508,7 +508,7 @@ impl CanisterState {
 
     /// Returns the actual number of allocated bytes for the canister:
     /// the maximum of its memory allocation and memory usage.
-    fn memory_allocated_bytes(&self) -> NumBytes {
+    pub fn memory_allocated_bytes(&self) -> NumBytes {
         self.memory_allocation()
             .allocated_bytes(self.memory_usage())
     }

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -186,9 +186,9 @@ impl CanisterHistory {
     }
 
     /// Adds a canister change to the history, updating the memory usage
-    /// and total number of changes. It also makes sure that the number
-    /// of canister changes does not exceed `MAX_CANISTER_HISTORY_CHANGES`
-    /// by dropping the oldest entry if necessary.
+    /// of canister history tracked internally and the total number of changes.
+    /// It also makes sure that the number of canister changes does not exceed
+    /// `MAX_CANISTER_HISTORY_CHANGES` by dropping the oldest entry if necessary.
     pub fn add_canister_change(&mut self, canister_change: CanisterChange) {
         let changes = Arc::make_mut(&mut self.changes);
         if changes.len() >= MAX_CANISTER_HISTORY_CHANGES as usize {


### PR DESCRIPTION
This PR performs the following changes:
- updates subnet available memory after uninstalling code;
- updates subnet available memory after updating canister history;
- adds a new test checking that subnet available memory matches canister memory usage.