### PR TITLE
refactor(cmc/root): Fix a few places where ic_cdk_macros are not used

### DIFF
--- a/rs/nns/cmc/src/main.rs
+++ b/rs/nns/cmc/src/main.rs
@@ -1,14 +1,13 @@
 #![allow(deprecated)]
-use candid::{CandidType, Encode};
+use candid::{CandidType, Encode, Nat};
 use core::cmp::Ordering;
 use cycles_minting_canister::*;
-use dfn_protobuf::ProtoBuf;
 use environment::Environment;
 use exchange_rate_canister::{
     RealExchangeRateCanisterClient, UpdateExchangeRateError, UpdateExchangeRateState,
 };
 use ic_cdk::{
-    api::call::{CallResult, ManualReply, reply_raw},
+    api::call::{CallResult, ManualReply},
     heartbeat, init, post_upgrade, pre_upgrade, println, query, update,
 };
 use ic_crypto_tree_hash::{
@@ -42,7 +41,6 @@ use icp_ledger::{
 };
 use icrc_ledger_types::icrc1::account::Account;
 use lazy_static::lazy_static;
-use on_wire::IntoWire;
 use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -2321,11 +2319,9 @@ fn ensure_balance(
     Ok(())
 }
 
-#[unsafe(export_name = "canister_query total_cycles_minted")]
-fn total_cycles_minted() {
-    let value: u64 = with_state(|state| state.total_cycles_minted.get().try_into().unwrap());
-    let response = ProtoBuf::new(value).into_bytes().unwrap();
-    reply_raw(&response);
+#[query(hidden = true)]
+fn total_cycles_minted() -> Nat {
+    with_state(|state| state.total_cycles_minted.get().into())
 }
 
 /// Return the list of subnets in which this controller is allowed to create

--- a/rs/nns/handlers/lifeline/impl/BUILD.bazel
+++ b/rs/nns/handlers/lifeline/impl/BUILD.bazel
@@ -18,6 +18,18 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
+genrule(
+    name = "patch_root.did",
+    srcs = [
+        "//rs/nns/handlers/root/impl:canister/root.did",
+    ],
+    outs = ["patched_root.did"],
+    cmd_bash = """
+    cat $(location //rs/nns/handlers/root/impl:canister/root.did) | sed 's|service : () -> |service : |g' > $@
+""",
+    visibility = ["//visibility:private"],
+)
+
 external_actor(
     name = "governance",
     idl = ":patched_governance.did",
@@ -27,7 +39,7 @@ external_actor(
 
 external_actor(
     name = "root",
-    idl = "//rs/nns/handlers/root/impl:canister/root.did",
+    idl = ":patched_root.did",
     principal = "r7inp-6aaaa-aaaaa-aaabq-cai",
     visibility = ["//visibility:private"],
 )

--- a/rs/nns/handlers/root/impl/canister/canister.rs
+++ b/rs/nns/handlers/root/impl/canister/canister.rs
@@ -35,9 +35,8 @@ use ic_nns_handler_root_interface::{
 use std::cell::RefCell;
 
 use ic_cdk::futures::spawn_017_compat;
-#[cfg(target_arch = "wasm32")]
 use ic_cdk::println;
-use ic_cdk::{post_upgrade, query, update};
+use ic_cdk::{init, post_upgrade, query, update};
 
 fn caller() -> PrincipalId {
     PrincipalId::from(ic_cdk::api::msg_caller())
@@ -65,10 +64,7 @@ fn new_management_canister_client() -> impl ManagementCanisterClient {
     )
 }
 
-// canister_init and canister_post_upgrade are needed here
-// to ensure that printer hook is set up, otherwise error
-// messages are quite obscure.
-#[unsafe(export_name = "canister_init")]
+#[init]
 fn canister_init() {
     println!("{LOG_PREFIX}canister_init");
 }

--- a/rs/nns/handlers/root/impl/canister/root.did
+++ b/rs/nns/handlers/root/impl/canister/root.did
@@ -145,7 +145,7 @@ type UpdateCanisterSettingsResponse = variant {
   Err : UpdateCanisterSettingsError;
 };
 
-service : {
+service : () -> {
   add_nns_canister : (AddCanisterRequest) -> ();
   canister_status : (CanisterIdRecord) -> (CanisterStatusResult);
   change_canister_controllers : (ChangeCanisterControllersRequest) -> (

--- a/rs/nns/integration_tests/src/cycles_minting_canister.rs
+++ b/rs/nns/integration_tests/src/cycles_minting_canister.rs
@@ -1502,14 +1502,12 @@ fn notify_top_up(
     notify_top_up_as(state_machine, canister_id, amount, *TEST_USER1_PRINCIPAL)
 }
 
-fn total_cycles_minted(state_machine: &StateMachine) -> u64 {
-    use prost::Message;
-
+fn total_cycles_minted(state_machine: &StateMachine) -> Nat {
     if let WasmResult::Reply(res) = state_machine
         .query(CYCLES_MINTING_CANISTER_ID, "total_cycles_minted", vec![])
         .unwrap()
     {
-        u64::decode(&res[..]).unwrap()
+        Decode!(&res, Nat).unwrap()
     } else {
         panic!("total_cycles_minted rejected")
     }
@@ -1539,7 +1537,7 @@ fn cmc_notify_top_up_valid() {
     assert_eq!(cycles, Cycles::new(100_000_000_000_000u128));
     assert_eq!(
         total_minted_after - total_minted_before,
-        100_000_000_000_000
+        100_000_000_000_000u64
     );
 }
 
@@ -1567,7 +1565,7 @@ fn cmc_notify_top_up_invalid() {
     assert_matches!(error, NotifyError::Refunded { .. });
     assert_eq!(
         total_minted_after - total_minted_before,
-        100_000_000_000_000
+        100_000_000_000_000u64
     );
 
     let total_minted_before = total_cycles_minted(&state_machine);
@@ -1579,7 +1577,7 @@ fn cmc_notify_top_up_invalid() {
     .unwrap_err();
     let total_minted_after = total_cycles_minted(&state_machine);
     assert_matches!(error, NotifyError::Refunded { .. });
-    assert_eq!(total_minted_after - total_minted_before, 0);
+    assert_eq!(total_minted_after - total_minted_before, 0u64);
 }
 
 #[test]


### PR DESCRIPTION
# Why

There are a few places (root/cmc) not using the ic_cdk_macros without a good reason.

# What

* Use `ic_cdk_macros::query(hidden = true)` for `total_cycles_minted`
* Switch `total_cycles_minted` to return candid rather than protobuf. Note that the current value on the mainnet is at 70% of u64::MAX, so the u64 doesn't make sense anyway. This is a breaking change, but the method has never been exposed (not in .did)
* Use `#[init]` for root