### PR TITLE
test(btc-adapter): fix flaky test in generate_to_address call

### DIFF
--- a/rs/bitcoin/adapter/test_utils/src/rpc_client.rs
+++ b/rs/bitcoin/adapter/test_utils/src/rpc_client.rs
@@ -87,6 +87,16 @@ pub enum RpcError {
     AddressNotAvailable,
 }
 
+impl RpcError {
+    pub fn is_resource_temporarily_unavailable(&self) -> bool {
+        if let RpcError::JsonRpc(jsonrpc::error::Error::Transport(err)) = self {
+            err.to_string().contains("Resource temporarily unavailable")
+        } else {
+            false
+        }
+    }
+}
+
 impl From<BtcAddressParseError> for RpcError {
     fn from(e: BtcAddressParseError) -> Self {
         Self::InvalidBtcAddress(e)


### PR DESCRIPTION
In btc adapter's integration test, occasionally the call to `generate_to_address` would return the following error:
```
JsonRpc(Transport(SocketError(Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" })))
```
In this case we can retry a couple times to improve the success rate.