### PR TITLE
test: add management canister candid backward-compatibility test

### DIFF
--- a/rs/types/management_canister_types/BUILD.bazel
+++ b/rs/types/management_canister_types/BUILD.bazel
@@ -101,6 +101,7 @@ rust_test(
 did_git_test(
     name = "management_canister_did_git_test",
     did = ":tests/ic.did",
+    tags = ["didc"],  # to be able to override this test using the GitHub PR label `CI_OVERRIDE_DIDC_CHECK`
 )
 
 rust_test(

--- a/rs/types/management_canister_types/BUILD.bazel
+++ b/rs/types/management_canister_types/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//bazel:candid.bzl", "did_git_test")
 load("//bazel:fuzz_testing.bzl", "DEFAULT_RUSTC_FLAGS_FOR_FUZZING")
 
 # This library is private to the replica and other guestOS processes.
@@ -95,6 +96,11 @@ rust_library(
 rust_test(
     name = "management_canister_types_test",
     crate = ":management_canister_types",
+)
+
+did_git_test(
+    name = "management_canister_did_git_test",
+    did = ":tests/ic.did",
 )
 
 rust_test(


### PR DESCRIPTION
This PR adds a management canister candid backward-compatibility test to detect breaking changes to the public interface of the management canister on CI.