### PR TITLE
feat(IDX): use gh hosted runner for python tests

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -488,8 +488,7 @@ jobs:
 
   python-ci-tests:
     name: Python CI Tests
-    runs-on: &dind-small-setup
-      labels: dind-small
+    runs-on: ubuntu-latest
     container: *container-setup
     timeout-minutes: 30
     steps:
@@ -683,7 +682,8 @@ jobs:
 
   cargo-clippy-linux:
     name: Cargo Clippy Linux
-    runs-on: *dind-small-setup
+    runs-on: &dind-small-setup
+      labels: dind-small
     container: *container-setup
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -489,7 +489,6 @@ jobs:
   python-ci-tests:
     name: Python CI Tests
     runs-on: ubuntu-latest
-    container: *container-setup
     timeout-minutes: 30
     steps:
       - *checkout


### PR DESCRIPTION
This moves the `python-ci-tests` to run on `ubuntu-latest` instead of self-hosted runners. Apparently it runs without issues.