### PR TITLE
feat: adding rate limits for node swapping mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20706,6 +20706,7 @@ dependencies = [
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-common-test-keys",
  "ic-nervous-system-integration-tests",
+ "ic-nervous-system-rate-limits",
  "ic-nervous-system-string",
  "ic-nervous-system-temporary",
  "ic-nervous-system-time-helpers",

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -21,6 +21,7 @@ DEPENDENCIES = [
     "//rs/nervous_system/chunks",
     "//rs/nervous_system/clients",
     "//rs/nervous_system/common",
+    "//rs/nervous_system/rate_limits",
     "//rs/nervous_system/string",
     "//rs/nervous_system/temporary",
     "//rs/nervous_system/time_helpers",

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -62,6 +62,7 @@ url = { workspace = true }
 canbench-rs = { workspace = true, optional = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+ic-nervous-system-rate-limits = { path = "../../nervous_system/rate_limits" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["custom"] }

--- a/rs/registry/canister/src/mutations/do_swap_node_in_subnet_directly.rs
+++ b/rs/registry/canister/src/mutations/do_swap_node_in_subnet_directly.rs
@@ -6,6 +6,7 @@ use std::{
 
 use candid::CandidType;
 use ic_nervous_system_rate_limits::{InMemoryRateLimiter, RateLimiterConfig, Reservation};
+use ic_nervous_system_time_helpers::now_system_time;
 use ic_types::{NodeId, PrincipalId, SubnetId};
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -46,7 +47,7 @@ impl SwappingRateLimiter {
         &mut self,
         subnet_id: SubnetId,
     ) -> Result<Reservation<SubnetId>, SwapError> {
-        self.reserve_subnet(subnet_id, SystemTime::now())
+        self.reserve_subnet(subnet_id, now_system_time())
     }
 
     fn reserve_subnet(
@@ -65,7 +66,7 @@ impl SwappingRateLimiter {
     }
 
     fn commit_subnet_now(&mut self, reservation: Reservation<SubnetId>) {
-        self.commit_subnet(reservation, SystemTime::now())
+        self.commit_subnet(reservation, now_system_time())
     }
 
     fn commit_subnet(&mut self, reservation: Reservation<SubnetId>, now: SystemTime) {
@@ -79,7 +80,7 @@ impl SwappingRateLimiter {
         subnet_id: SubnetId,
         provider: PrincipalId,
     ) -> Result<Reservation<String>, SwapError> {
-        self.reserve_provider_on_subnet(subnet_id, provider, SystemTime::now())
+        self.reserve_provider_on_subnet(subnet_id, provider, now_system_time())
     }
 
     fn reserve_provider_on_subnet(
@@ -102,7 +103,7 @@ impl SwappingRateLimiter {
     }
 
     fn commit_provider_on_subnet_now(&mut self, reservation: Reservation<String>) {
-        self.commit_provider_on_subnet(reservation, SystemTime::now());
+        self.commit_provider_on_subnet(reservation, now_system_time());
     }
 
     fn commit_provider_on_subnet(&mut self, reservation: Reservation<String>, now: SystemTime) {

--- a/rs/registry/canister/src/mutations/do_swap_node_in_subnet_directly.rs
+++ b/rs/registry/canister/src/mutations/do_swap_node_in_subnet_directly.rs
@@ -563,8 +563,7 @@ mod tests {
                 )
                 .unwrap(),
             )
-            .err()
-            .expect("Expected reservation2 to error out");
+            .expect_err("Expected reservation2 to error out");
 
         assert_eq!(
             maybe_reservation2,
@@ -691,7 +690,7 @@ mod tests {
             maybe_reservation,
             SwapError::ProviderRateLimitedOnSubnet {
                 subnet_id: subnet_2,
-                caller: caller
+                caller
             }
         );
 

--- a/rs/registry/canister/src/mutations/do_swap_node_in_subnet_directly.rs
+++ b/rs/registry/canister/src/mutations/do_swap_node_in_subnet_directly.rs
@@ -251,7 +251,7 @@ impl Display for SwapError {
                     "Subnet {subnet_id} had a swap performed within last two hours. Try again later."
                 ),
                 SwapError::ProviderRateLimitedOnSubnet { subnet_id, caller } => format!(
-                    "Caller {caller} performed a swap on subnet {subnet_id} within last twelve hourse. Try again later."
+                    "Caller {caller} performed a swap on subnet {subnet_id} within last twelve hours. Try again later."
                 ),
             }
         )

--- a/rs/registry/canister/tests/swap_node_in_subnet_directly.rs
+++ b/rs/registry/canister/tests/swap_node_in_subnet_directly.rs
@@ -301,9 +301,7 @@ async fn subnet_rate_limited() {
     )
     .await;
 
-    let expected_err = SwapError::SubnetRateLimited {
-        subnet_id: subnet_id,
-    };
+    let expected_err = SwapError::SubnetRateLimited { subnet_id };
 
     assert!(
         response
@@ -389,9 +387,7 @@ async fn subnet_rate_limit_passed() {
     )
     .await;
 
-    let expected_err = SwapError::SubnetRateLimited {
-        subnet_id: subnet_id,
-    };
+    let expected_err = SwapError::SubnetRateLimited { subnet_id };
 
     assert!(
         response


### PR DESCRIPTION
This PR adds two in memory rate limits for the node swapping mechanism:
* _Subnet limit_: on *1* subnet, at most *1* swap can happen within *2* hours. The goal is to allow controlled number of swaps made with this functionality. 
* _Provider limit_: on *1* subnet, at most *1* swap can happen within *12* hours made by the same *provider*. The goal is to disallow a single node provider from abusing the functionality and not allowing other node providers to swap nodes in a same subnet.