### PR TITLE
refactor(IDX): combine CI cargo jobs

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -672,7 +672,7 @@ jobs:
         include:
           - name: Lint
           - name: Build
-    name: Cargo Clippy Linux ${{ matrix.name }}
+    name: Cargo  ${{ matrix.name }} Linux
     runs-on:
       labels: dind-small
     container: *container-setup

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -670,8 +670,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: lint
-          - name: build
+          - name: Lint
+          - name: Build
     name: Cargo Clippy Linux ${{ matrix.name }}
     runs-on:
       labels: dind-small
@@ -689,7 +689,7 @@ jobs:
               - "**/*.toml"
               - "**/*.lock"
       - name: Run Cargo Clippy Linux ${{ matrix.name }}
-        id: cargo-clippy-linux-${{ matrix.name }}
+        id: cargo-clippy-linux-run
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         if: |
@@ -702,7 +702,7 @@ jobs:
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors
 
-          if [[ "${{ matrix.name }}" == "lint" ]]; then
+          if [[ "${{ matrix.name }}" == "Lint" ]]; then
             "$CI_PROJECT_DIR"/ci/scripts/rust-lint.sh
           else
             cargo build --release --locked

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -667,8 +667,13 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   cargo-clippy-linux:
-    name: Cargo Clippy Linux
-    runs-on: &dind-small-setup
+    strategy:
+      matrix:
+        include:
+          - name: lint
+          - name: build
+    name: Cargo Clippy Linux ${{ matrix.name }}
+    runs-on:
       labels: dind-small
     container: *container-setup
     timeout-minutes: 30
@@ -683,8 +688,8 @@ jobs:
               - "**/*.rs"
               - "**/*.toml"
               - "**/*.lock"
-      - name: Run Cargo Clippy Linux
-        id: cargo-clippy-linux
+      - name: Run Cargo Clippy Linux ${{ matrix.name }}
+        id: cargo-clippy-linux-${{ matrix.name }}
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         if: |
@@ -696,38 +701,12 @@ jobs:
         run: |
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors
-          "$CI_PROJECT_DIR"/ci/scripts/rust-lint.sh
 
-  cargo-build-release-linux:
-    name: Cargo Build Release Linux
-    runs-on: *dind-small-setup
-    container: *container-setup
-    timeout-minutes: 30
-    steps:
-      - *checkout
-      - name: Filter Rust Files [*.{rs,toml,lock}]
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: filter
-        with:
-          filters: |
-            cargo:
-              - "**/*.rs"
-              - "**/*.toml"
-              - "**/*.lock"
-      - name: Run Cargo Build Release Linux
-        id: cargo-build-release-linux
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        if: |
-          steps.filter.outputs.cargo == 'true' ||
-          env.BRANCH_NAME == 'master' ||
-          startsWith(env.BRANCH_NAME, 'rc--') ||
-          startsWith(env.BRANCH_NAME, 'hotfix-')
-        shell: bash
-        run: |
-          set -eExuo pipefail
-          export CARGO_TERM_COLOR=always # ensure output has colors
-          cargo build --release --locked
+          if [[ "${{ matrix.name }}" == "lint" ]]; then
+            "$CI_PROJECT_DIR"/ci/scripts/rust-lint.sh
+          else
+            cargo build --release --locked
+          fi
 
   check-pull-request-bazel-targets:
     name: Check PULL_REQUEST_BAZEL_TARGETS

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -688,7 +688,7 @@ jobs:
               - "**/*.rs"
               - "**/*.toml"
               - "**/*.lock"
-      - name: Run Cargo Clippy Linux ${{ matrix.name }}
+      - name: Run Cargo ${{ matrix.name }} Linux 
         id: cargo-clippy-linux-run
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -694,6 +694,7 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         if: |
           steps.filter.outputs.cargo == 'true' ||
+          contains(github.event.pull_request.labels.*.name, 'CI_RUN_CARGO_JOBS') ||
           env.BRANCH_NAME == 'master' ||
           startsWith(env.BRANCH_NAME, 'rc--') ||
           startsWith(env.BRANCH_NAME, 'hotfix-')

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -666,7 +666,7 @@ jobs:
           run: bazel build --config=stamped --config=local --invocation_id="${{ fromJSON(steps.gen-uuids.outputs.output).build_id }}" //...
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-  cargo-clippy-linux:
+  cargo-linux:
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -689,7 +689,6 @@ jobs:
               - "**/*.toml"
               - "**/*.lock"
       - name: Run Cargo ${{ matrix.name }} Linux 
-        id: cargo-clippy-linux-run
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         if: |


### PR DESCRIPTION
These two CI jobs are basically identical, just executing different commands, so we combine them into one, so that we can make updates to them more easily.

It also introduces the label `CI_RUN_CARGO_JOBS` in case we want to run the job without making any cargo file changes on our PR.

In the next PR I will move these jobs to gh-hosted runners.