### PR TITLE
chore: EXC-2129: Fix allocator bench

### DIFF
--- a/rs/replicated_state/BUILD.bazel
+++ b/rs/replicated_state/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test_suite")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 load("//bazel:defs.bzl", "rust_bench", "rust_test_with_binary")
 
 package(default_visibility = ["//visibility:public"])
@@ -69,8 +69,9 @@ rust_library(
     }),
 )
 
-rust_binary(
+rust_bench(
     name = "replicated_state_allocator_bench",
+    testonly = True,
     srcs = [
         "benches/bench_allocator.rs",
     ],

--- a/rs/replicated_state/benches/bench_allocator.rs
+++ b/rs/replicated_state/benches/bench_allocator.rs
@@ -1,54 +1,57 @@
 use std::cell::Cell;
 use std::sync::Arc;
-use std::time::Duration;
 
-use criterion::{BenchmarkId, Criterion, black_box};
-use criterion_time::ProcessTime;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use ic_replicated_state::PageIndex;
 use ic_replicated_state::page_map::PageAllocator;
 use ic_sys::{PAGE_SIZE, PageBytes};
 
 // The number of threads doing allocation in parallel
 // to simulate parallel execution of canisters.
-const NUM_THREADS: u32 = 4;
+const NUM_THREADS: u32 = 6;
 
 // The number of `allocate()` calls per allocator to
-// simulate the number of rounds between checkpoints.
-const NUM_ALLOCATIONS: usize = 100;
+// simulate the number of executed canisters on each thread.
+const NUM_ALLOCATIONS: usize = 1;
 
-fn bench_allocator(c: &mut Criterion<ProcessTime>) {
+fn bench_allocator(c: &mut Criterion) {
     let page = &[1u8; PAGE_SIZE];
     let mut group = c.benchmark_group("Allocate");
-    for n in [1usize, 10, 100, 1_000].iter().cloned() {
-        let pages: Vec<(PageIndex, &PageBytes)> =
-            (0..n).map(|i| (PageIndex::new(i as u64), page)).collect();
+    for page_delta_mib in [2, 8, 32, 128, 512, 2048].iter().cloned() {
+        let num_pages = page_delta_mib * 1024 * 1024 / PAGE_SIZE;
+        let pages: Vec<(PageIndex, &PageBytes)> = (0..num_pages)
+            .map(|i| (PageIndex::new(i as u64), page))
+            .collect();
         let mut thread_pool = Cell::new(scoped_threadpool::Pool::new(NUM_THREADS));
-        group.bench_function(BenchmarkId::new("MmapBasedPageAllocator", n), |b| {
-            b.iter(|| {
-                thread_pool.get_mut().scoped(|scope| {
-                    for _ in 0..NUM_THREADS {
-                        scope.execute(|| {
-                            let allocator = Arc::new(PageAllocator::new_for_testing());
-                            // Allocate multiple times to simulate multiple rounds per checkpoint.
-                            for _ in 0..NUM_ALLOCATIONS {
-                                let pages = PageAllocator::allocate(&allocator, &pages[..]);
-                                black_box(pages);
-                            }
-                        });
-                    }
-                });
-            })
-        });
+        group.bench_function(
+            format!(
+                "allocation:{NUM_ALLOCATIONS}/page_delta:{page_delta_mib}MiB/pages:{}K",
+                num_pages / 1024
+            ),
+            |b| {
+                b.iter(|| {
+                    thread_pool.get_mut().scoped(|scope| {
+                        for _ in 0..NUM_THREADS {
+                            scope.execute(|| {
+                                let allocator = Arc::new(PageAllocator::new_for_testing());
+                                // Allocate multiple times to simulate multiple executions.
+                                for _ in 0..NUM_ALLOCATIONS {
+                                    let pages = PageAllocator::allocate(&allocator, &pages[..]);
+                                    black_box(pages);
+                                }
+                            });
+                        }
+                    });
+                })
+            },
+        );
     }
     group.finish();
 }
 
-fn main() {
-    let mut c = Criterion::default()
-        .with_measurement(ProcessTime::UserTime)
-        .sample_size(10)
-        .measurement_time(Duration::from_secs(40))
-        .configure_from_args();
-    bench_allocator(&mut c);
-    c.final_summary();
+criterion_group! {
+    name = benchmarks;
+    config = Criterion::default().sample_size(10);
+    targets = bench_allocator
 }
+criterion_main!(benchmarks);


### PR DESCRIPTION
Fix the Bazel definition and the main function of the allocation benchmark. The benchmark range is now increased to 2 GiB of pages, and "rounds per checkpoint" are now "executions per round" (executing multiple canisters per round).

```
$ bazel run //rs/replicated_state:replicated_state_allocator_bench
Allocate/allocation:1/page_delta:2MiB/pages:0K
                        time:   [6.6416 ms 6.7005 ms 6.7747 ms]
Allocate/allocation:1/page_delta:8MiB/pages:2K
                        time:   [24.131 ms 24.393 ms 24.584 ms]
Allocate/allocation:1/page_delta:32MiB/pages:8K
                        time:   [111.36 ms 111.94 ms 112.65 ms]
Allocate/allocation:1/page_delta:128MiB/pages:32K
                        time:   [952.20 ms 1.0645 s 1.1891 s]
Allocate/allocation:1/page_delta:512MiB/pages:128K
                        time:   [5.0449 s 5.2784 s 5.5126 s]
Allocate/allocation:1/page_delta:2048MiB/pages:512K
                        time:   [21.698 s 22.617 s 23.539 s]
```