### PR TITLE
fix(PocketIC): stop HTTP gateways before deleting PocketIC instance

### DIFF
--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1504,6 +1504,8 @@ impl PocketIc {
                 .send()
                 .await
                 .expect("Failed to send delete request");
+        } else {
+            self.stop_http_gateway().await;
         }
     }
 

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1498,7 +1498,6 @@ impl PocketIc {
     }
 
     pub(crate) async fn do_drop(&mut self) {
-        self.stop_http_gateway().await;
         if self.owns_instance {
             self.reqwest_client
                 .delete(self.instance_url())

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -17,6 +17,7 @@ use pocket_ic::{
         InitialTime, InstanceConfig, InstanceHttpGatewayConfig, MockCanisterHttpResponse,
         RawEffectivePrincipal, RawMessageId, SubnetConfigSet, SubnetKind,
     },
+    nonblocking::PocketIc as PocketIcAsync,
     query_candid, start_server, update_candid,
 };
 use reqwest::header::CONTENT_LENGTH;
@@ -2813,6 +2814,8 @@ async fn list_http_gateways(server_url: &Url) -> Vec<HttpGatewayDetails> {
 
 #[tokio::test]
 async fn with_http_gateway_config_and_cleanup_works() {
+    // We start a fresh server so that we can easily list instances and HTTP gateways
+    // created by this test (without filtering those created by other tests).
     let server_params = StartServerParams {
         server_binary: None,
         reuse: false,
@@ -2820,6 +2823,17 @@ async fn with_http_gateway_config_and_cleanup_works() {
     };
     let (_child, server_url) = start_server(server_params).await;
 
+    // Assert that
+    // - an instance exists on the server iff `instance_exists` is set to `true`;
+    // - the number of HTTP gateways on the server matches `gateway_count`.
+    let assert_server_state = |server_url: Url, instance_exists: bool, gateway_count: usize| async move {
+        let instances = list_instances(&server_url).await;
+        assert_eq!(instances.len(), 1);
+        assert!(instances[0].contains("Deleted") != instance_exists);
+        assert_eq!(list_http_gateways(&server_url).await.len(), gateway_count);
+    };
+
+    // We create a PocketIC instance and its HTTP gateway.
     let http_gateway_config = InstanceHttpGatewayConfig {
         ip_addr: None,
         port: None,
@@ -2833,18 +2847,34 @@ async fn with_http_gateway_config_and_cleanup_works() {
         .with_auto_progress()
         .build_async()
         .await;
+    assert_server_state(server_url.clone(), true, 1).await;
 
-    let instances = list_instances(&server_url).await;
-    assert_eq!(instances.len(), 1);
-    assert!(!instances[0].contains("Deleted"));
-    assert_eq!(list_http_gateways(&server_url).await.len(), 1);
+    // We create an additional handle for the existing PocketIC instance and start an additional HTTP gateway.
+    let mut pic_handle =
+        PocketIcAsync::new_from_existing_instance(server_url.clone(), pic.instance_id, None);
+    pic_handle.make_live(None).await;
+    assert_server_state(server_url.clone(), true, 2).await;
 
+    // We create yet another handle for the existing PocketIC instance and start an additional HTTP gateway.
+    let mut yet_another_pic_handle =
+        PocketIcAsync::new_from_existing_instance(server_url.clone(), pic.instance_id, None);
+    yet_another_pic_handle.make_live(None).await;
+    assert_server_state(server_url.clone(), true, 3).await;
+
+    // Dropping one of the extra handles for the existing PocketIC instance only stops its new HTTP gateway.
+    pic_handle.drop().await;
+    assert_server_state(server_url.clone(), true, 2).await;
+
+    // The instance is still in auto progress mode.
+    assert!(pic.auto_progress_enabled().await);
+
+    // Dropping the original handle deletes the PocketIC instance and stops all its HTTP gateways.
     pic.drop().await;
+    assert_server_state(server_url.clone(), false, 0).await;
 
-    let instances = list_instances(&server_url).await;
-    assert_eq!(instances.len(), 1);
-    assert_eq!(instances[0], "Deleted");
-    assert!(list_http_gateways(&server_url).await.is_empty());
+    // Dropping the other extra handle for the existing PocketIC instance succeeds, but is a no-op.
+    yet_another_pic_handle.drop().await;
+    assert_server_state(server_url.clone(), false, 0).await;
 }
 
 async fn assert_create_instance_failure(

--- a/rs/pocket_ic_server/src/state_api/state.rs
+++ b/rs/pocket_ic_server/src/state_api/state.rs
@@ -640,7 +640,28 @@ impl ApiState {
     }
 
     pub async fn delete_instance(&self, instance_id: InstanceId) {
+        // stop all HTTP gateways for the instance
+        // to release their resources
+        // (since such HTTP gateways won't work once the instance is deleted)
+        let mut http_gateways = self.http_gateways.write().await;
+        for maybe_http_gateway in http_gateways.iter_mut() {
+            if let Some(http_gateway) = maybe_http_gateway
+                && http_gateway.details.forward_to
+                    == HttpGatewayBackend::PocketIcInstance(instance_id)
+            {
+                *maybe_http_gateway = None;
+            }
+        }
+        // release the lock on HTTP gateways before acquiring a lock on instances
+        // to prevent deadlocks
+        drop(http_gateways);
+
+        // stop progress on the instance
+        // so that the instance is not permanently busy
+        // and can be actually deleted
         self.stop_progress(instance_id).await;
+
+        // finally, delete the instance
         loop {
             let instances = self.instances.read().await;
             let mut instance = instances[instance_id].lock().await;
@@ -654,6 +675,8 @@ impl ApiState {
                 }
                 InstanceState::Busy { .. } => {}
             }
+            // release locks before sleeping so that the instance can actually finish
+            // its computation while we're sleeping
             drop(instance);
             drop(instances);
             tokio::time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
This PR stops all HTTP gateways for a PocketIC instance before deleting that PocketIC instance.

The motivation for this fix is that such HTTP gateways won't work anyway once the PocketIC instance is deleted and thus we could release their resources (e.g., ports).

This PR has been tested by the existing (hardened) test `with_http_gateway_config_and_cleanup_works` since the Rust library is also updated to not explicitly stop an HTTP gateway for a PocketIC instance before deleting the instance (and thus the test ensures that the HTTP gateway is stopped as part of PocketIC instance deletion implemented by this PR).