### PR TITLE
chore(IDX): replace dependencies-check runner

### DIFF
--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -160,8 +160,7 @@ jobs:
 
   dependencies-check:
     name: Dependency Scan for PR
-    runs-on: *dind-small-setup
-    container: *container-setup
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     if: ${{ github.event_name != 'merge_group' }}
     permissions:


### PR DESCRIPTION
In preparation for open-sourcing the IC we are replacing self-hosted runners with gh hosted runners.