### PR TITLE
refactor: Use SubnetConfig in ExecutionTestBuilder to group configuration options in tests

### DIFF
--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2443,7 +2443,7 @@ impl ExecutionTestBuilder {
                 .max_instructions_per_message,
             self.subnet_type,
             self.own_subnet_id,
-            self.subnet_config.cycles_account_manager_config.clone(),
+            self.subnet_config.cycles_account_manager_config,
         ));
         let config = self.execution_config.clone();
 


### PR DESCRIPTION
This PR refactors the `ExecutionTestBuilder` to hold a `SubnetConfig` so that certain options can be overwritten in tests instead of passing explicitly the options.

One benefit of this is that we don't need to keep adding fields in `ExecutionTestBuilder` as more configuration options are added. We only need to expose a setter to overwrite the config value (similar to existing ones).

Another benefit is that it helps in a further refactoring of using `setup_execution` to create the execution services needed for tests instead of manually doing that to reduce code duplication. `setup_execution` requires a `subnet_config` to be passed so that it creates the services with the right options, so having it already in the `ExecutionTestBuilder` streamlines things (otherwise one would need to recreate the config before passing it). This change will follow in a subsequent PR.