### PR TITLE
feat(ICP_Rosetta): FI-1877: Add ic-agent timeout for initial sync

### DIFF
--- a/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/canister_access.rs
+++ b/rs/rosetta-api/icp/ledger_canister_blocks_synchronizer/src/canister_access.rs
@@ -88,7 +88,7 @@ impl CanisterAccess {
         canister_id: CanisterId,
         root_key: Option<Vec<u8>>,
     ) -> Result<Self, AgentError> {
-        let agent = make_agent(url, None, root_key).await?;
+        let agent = make_agent(url, Some(Duration::from_secs(1u64)), root_key).await?;
 
         Ok(Self {
             agent,


### PR DESCRIPTION
Add a 1 second timeout to ic-agent to improve the performance of ICP Rosetta's initial sync.