### PR TITLE
fix: Removes the bad subnet ID from the State Machine Tests split function.

### DIFF
--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -3132,7 +3132,6 @@ impl StateMachine {
             )
             .with_subnet_size(self.nodes.len())
             .with_subnet_seed(seed)
-            .with_subnet_id(ic_test_utilities_types::ids::subnet_test_id(1221))
             .with_registry_data_provider(self.registry_data_provider.clone())
             .build_with_subnets(
                 (*self.pocket_xnet.read().unwrap())


### PR DESCRIPTION
This line accidentally made it in. It was used during debugging to trigger an error. Since there is no test using the `split` function yet, this went in unnoticed.