### PR TITLE
chore(http-outcalls): Improve soak test's throughput estimate

### DIFF
--- a/rs/rust_canisters/proxy_canister/src/main.rs
+++ b/rs/rust_canisters/proxy_canister/src/main.rs
@@ -8,6 +8,7 @@
 #![allow(deprecated)]
 use candid::Principal;
 use futures::future::join_all;
+use futures::stream::{FuturesUnordered, StreamExt};
 use ic_cdk::api::call::RejectionCode;
 use ic_cdk::api::time;
 use ic_cdk::{caller, spawn};
@@ -89,31 +90,23 @@ pub async fn start_continuous_requests(
     ))
 }
 
-// TODO: instead of sequentially awaiting on each batch, try to send the next requests anyway, with backoff.
-// This should improve the overall qps, as the canister message queue is the bottleneck, and it's not being saturated.
 async fn run_continuous_request_loop(request: RemoteHttpRequest) {
-    const BATCH_SIZE: usize = 500;
-    let futures_iter = (0..BATCH_SIZE).map(|_| send_request(request.clone()));
-    let results = join_all(futures_iter).await;
+    const PARALLEL_REQUESTS: usize = 500;
 
-    let mut successes = 0;
-    let mut errors = 0;
-    for result in results {
-        match result {
-            Ok(_resp) => {
-                successes += 1;
-            }
-            Err((rejection_code, msg)) => {
-                errors += 1;
-                println!("Request failed: {rejection_code:?} - {msg}");
-            }
-        }
+    let mut futures = FuturesUnordered::new();
+
+    for _ in 0..PARALLEL_REQUESTS {
+        futures.push(send_request(request.clone()));
     }
-    println!("Finished batch of {BATCH_SIZE} requests => successes: {successes}, errors: {errors}");
 
-    spawn(async move {
-        run_continuous_request_loop(request).await;
-    });
+    while let Some(result) = futures.next().await {
+        match result {
+            Ok(_resp) => {}
+            Err((_rejection_code, _msg)) => {}
+        }
+
+        futures.push(send_request(request.clone()));
+    }
 }
 
 #[update]


### PR DESCRIPTION
Two main changes:
1. Instead of installing 1 proxy canisters, we install 6. Each canister makes 500 concurrent requests => 3000 total concurrent request, which is exactly the limit of the http outcalls adapter. 
2. The proxy canister, instead of sending 500 concurrent requests, then waiting for all of them to finish in order to send the next 500 batch, it now awaits for each request independently, and whenever one finishes, it spawns another.

This improved throughput benchmarks by 50-100%.

Current benchmarks, 13 node subnet:
- fully replicated: 190 qps
- non replicated: 260 qps
  - 400 qps with improvements brought by https://github.com/dfinity/ic/pull/7092
