### PR TITLE
chore: download directly from CDN in resuming_download_test

### DIFF
--- a/rs/http_utils/tests/large_file_download_from.rs
+++ b/rs/http_utils/tests/large_file_download_from.rs
@@ -32,7 +32,7 @@ async fn test_large_file_download() {
     let hash = get_hash(downloader, version.as_ref()).await;
 
     let url = format!(
-        "http://download.proxy-global.dfinity.network:8080/ic/{version}/guest-os/update-img/update-img.tar.zst"
+        "https://download.dfinity.systems/ic/{version}/guest-os/update-img/update-img.tar.zst"
     );
     let downloader = FileDownloader::new_with_timeout(None, std::time::Duration::from_secs(2));
 


### PR DESCRIPTION
This changes the `//rs/http_utils:resuming_download_test` to download the update image directly from the CDN instead of from the dc_http_proxy. That way this test can be run outside our infrastructure like on Namespace which we're experimenting with in https://github.com/dfinity/ic/pull/7121.

Since this test is a `long_test` it mostly runs only on master so it doesn't generate too much traffic.