### PR TITLE
refactor: Use setup_execution consistently across production and test code

### DIFF
--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -6,24 +6,21 @@ use ic_config::embedders::Config as EmbeddersConfig;
 use ic_config::execution_environment::{
     CANISTER_GUARANTEED_CALLBACK_QUOTA, Config, SUBNET_CALLBACK_SOFT_LIMIT,
 };
-use ic_config::subnet_config::{SchedulerConfig, SubnetConfig};
-use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
+use ic_config::subnet_config::SubnetConfig;
+use ic_cycles_account_manager::ResourceSaturation;
 use ic_embedders::wasmtime_embedder::system_api::{ExecutionParameters, InstructionLimits};
 use ic_error_types::RejectCode;
 use ic_execution_environment::{
-    CompilationCostHandling, ExecutionEnvironment, Hypervisor, IngressHistoryWriterImpl,
-    RoundLimits, as_round_instructions,
+    CompilationCostHandling, ExecutionEnvironment, ExecutionServicesForTesting, RoundLimits,
+    as_round_instructions,
 };
-use ic_interfaces::execution_environment::{
-    ExecutionMode, IngressHistoryWriter, SubnetAvailableMemory,
-};
+use ic_interfaces::execution_environment::{ExecutionMode, SubnetAvailableMemory};
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
 use ic_logger::replica_logger::no_op_logger;
 use ic_metrics::MetricsRegistry;
 use ic_nns_constants::CYCLES_MINTING_CANISTER_INDEX_IN_NNS_SUBNET;
 use ic_registry_subnet_type::SubnetType;
-use ic_replicated_state::page_map::TestPageAllocatorFileDescriptorImpl;
-use ic_replicated_state::{CallOrigin, CanisterState, NetworkTopology, ReplicatedState};
+use ic_replicated_state::{CallOrigin, CanisterState, NetworkTopology};
 use ic_test_utilities::state_manager::FakeStateManager;
 use ic_test_utilities_execution_environment::generate_network_topology;
 use ic_test_utilities_state::canister_from_exec_state;
@@ -37,7 +34,7 @@ use ic_types::{
 };
 use ic_wasm_types::CanisterModule;
 use lazy_static::lazy_static;
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 pub const MAX_NUM_INSTRUCTIONS: NumInstructions = NumInstructions::new(500_000_000_000);
 // Note: this canister ID is required for the `ic0_mint_cycles128()`
@@ -244,12 +241,6 @@ where
     let own_subnet_id = subnet_test_id(1);
     let own_subnet_type = SubnetType::Application;
     let subnet_configs = SubnetConfig::new(own_subnet_type);
-    let cycles_account_manager = Arc::new(CyclesAccountManager::new(
-        subnet_configs.scheduler_config.max_instructions_per_message,
-        own_subnet_type,
-        own_subnet_id,
-        subnet_configs.cycles_account_manager_config,
-    ));
 
     let embedders_config = EmbeddersConfig {
         // Set up larger heap, of 8GB for the Wasm64 feature.
@@ -262,52 +253,24 @@ where
         ..Default::default()
     };
 
-    let metrics_registry = MetricsRegistry::new();
-    let hypervisor = Arc::new(Hypervisor::new(
-        config.clone(),
-        &metrics_registry,
-        own_subnet_id,
-        log.clone(),
-        Arc::clone(&cycles_account_manager),
-        SchedulerConfig::application_subnet().dirty_page_overhead,
-        Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
-        Arc::new(FakeStateManager::new()),
-        Path::new("/tmp"),
-    ));
-
     let (completed_execution_messages_tx, _) = tokio::sync::mpsc::channel(1);
-    let state_reader = Arc::new(FakeStateManager::new());
-    let ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState>> =
-        Arc::new(IngressHistoryWriterImpl::new(
-            config.clone(),
-            log.clone(),
-            &metrics_registry,
-            completed_execution_messages_tx,
-            state_reader,
-        ));
-    let exec_env = ExecutionEnvironment::new(
-        log,
-        hypervisor,
-        Arc::clone(&ingress_history_writer),
+    let metrics_registry = MetricsRegistry::new();
+    let state_manager = Arc::new(FakeStateManager::new());
+
+    let execution_services = ExecutionServicesForTesting::setup_execution(
+        log.clone(),
         &metrics_registry,
         own_subnet_id,
         own_subnet_type,
-        100,
-        config,
-        cycles_account_manager,
-        SchedulerConfig::application_subnet().scheduler_cores,
-        Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
-        subnet_configs.scheduler_config.heap_delta_rate_limit,
-        subnet_configs
-            .scheduler_config
-            .upload_wasm_chunk_instructions,
-        subnet_configs
-            .scheduler_config
-            .canister_snapshot_baseline_instructions,
-        subnet_configs
-            .scheduler_config
-            .canister_snapshot_data_baseline_instructions,
+        config.clone(),
+        subnet_configs.clone(),
+        state_manager.clone(),
+        state_manager.get_fd_factory(),
+        completed_execution_messages_tx,
+        state_manager.tmp(),
+        None,
     );
+
     for Benchmark(id, wat, expected_ops) in benchmarks {
         run_benchmark(
             c,
@@ -316,7 +279,7 @@ where
             wat,
             *expected_ops,
             routine,
-            &exec_env,
+            &execution_services.execution_environment,
         );
     }
 }

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -4234,7 +4234,9 @@ fn update_settings_checks_freezing_threshold_for_memory_allocation() {
 
 #[test]
 fn update_settings_checks_freezing_threshold_for_compute_allocation() {
-    let mut test = ExecutionTestBuilder::new().build();
+    let mut test = ExecutionTestBuilder::new()
+        .with_allocatable_compute_capacity_in_percent(51)
+        .build();
 
     let canister_id = test.create_canister(Cycles::new(1_000_000_000_000));
 
@@ -4255,6 +4257,7 @@ fn update_settings_checks_freezing_threshold_for_compute_allocation() {
 fn system_subnet_does_not_check_for_freezing_threshold_on_allocation_changes() {
     let mut test = ExecutionTestBuilder::new()
         .with_subnet_type(SubnetType::System)
+        .with_allocatable_compute_capacity_in_percent(51)
         .build();
 
     let canister_id = test
@@ -7624,7 +7627,9 @@ fn can_create_canister_with_extra_cycles() {
 
 #[test]
 fn create_canister_sets_correct_allocations() {
-    let mut test = ExecutionTestBuilder::new().build();
+    let mut test = ExecutionTestBuilder::new()
+        .with_allocatable_compute_capacity_in_percent(51)
+        .build();
 
     let compute_allocation = 50;
     let memory_allocation = 1024 * 1024 * 1024;
@@ -8099,7 +8104,9 @@ fn create_canister_checks_freezing_threshold_for_memory_allocation() {
 
 #[test]
 fn create_canister_checks_freezing_threshold_for_compute_allocation() {
-    let mut test = ExecutionTestBuilder::new().build();
+    let mut test = ExecutionTestBuilder::new()
+        .with_allocatable_compute_capacity_in_percent(51)
+        .build();
 
     let err = test
         .create_canister_with_allocation(Cycles::new(1_000_000_000_000), Some(50), None)

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -368,7 +368,7 @@ impl fmt::Display for DtsInstallCodeStatus {
 
 impl ExecutionEnvironment {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         log: ReplicaLogger,
         hypervisor: Arc<Hypervisor>,
         ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState>>,
@@ -4283,6 +4283,18 @@ impl ExecutionEnvironment {
     #[doc(hidden)]
     pub fn own_subnet_type(&self) -> SubnetType {
         self.own_subnet_type
+    }
+
+    // Insert a compiled module in the compilation cache speed up tests by
+    // skipping the Wasmtime compilation step.
+    #[doc(hidden)]
+    pub fn compilation_cache_insert_for_testing(
+        &self,
+        bytes: Vec<u8>,
+        compiled_module: ic_embedders::SerializedModule,
+    ) {
+        self.hypervisor
+            .compilation_cache_insert_for_testing(bytes, compiled_module);
     }
 }
 

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -182,7 +182,7 @@ impl Hypervisor {
         }
     }
 
-    pub fn new(
+    pub(crate) fn new(
         config: Config,
         metrics_registry: &MetricsRegistry,
         own_subnet_id: SubnetId,
@@ -239,8 +239,7 @@ impl Hypervisor {
         }
     }
 
-    #[doc(hidden)]
-    pub fn new_for_testing(
+    pub(crate) fn new_for_testing(
         metrics_registry: &MetricsRegistry,
         own_subnet_id: SubnetId,
         log: ReplicaLogger,
@@ -275,9 +274,8 @@ impl Hypervisor {
 
     /// Wrapper around the standalone `execute`.
     /// NOTE: this is public to enable integration testing.
-    #[doc(hidden)]
     #[allow(clippy::too_many_arguments)]
-    pub fn execute(
+    pub(crate) fn execute(
         &self,
         api_type: ApiType,
         time: Time,
@@ -342,7 +340,7 @@ impl Hypervisor {
 
     /// Executes the given WebAssembly function with deterministic time slicing.
     #[allow(clippy::too_many_arguments)]
-    pub fn execute_dts(
+    pub(crate) fn execute_dts(
         &self,
         api_type: ApiType,
         execution_state: &ExecutionState,
@@ -441,15 +439,13 @@ impl Hypervisor {
         execution_result
     }
 
-    #[doc(hidden)]
-    pub fn clear_compilation_cache_for_testing(&self) {
+    pub(crate) fn clear_compilation_cache_for_testing(&self) {
         self.compilation_cache.clear_for_testing()
     }
 
-    /// Insert a compiled module in the compilation cache speed up tests by
-    /// skipping the Wasmtime compilation step.
-    #[doc(hidden)]
-    pub fn compilation_cache_insert_for_testing(
+    // Insert a compiled module in the compilation cache speed up tests by
+    // skipping the Wasmtime compilation step.
+    pub(crate) fn compilation_cache_insert_for_testing(
         &self,
         bytes: Vec<u8>,
         compiled_module: ic_embedders::SerializedModule,

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -25,6 +25,7 @@ pub use hypervisor::{Hypervisor, HypervisorMetrics};
 use ic_base_types::PrincipalId;
 use ic_config::{execution_environment::Config, subnet_config::SubnetConfig};
 use ic_cycles_account_manager::CyclesAccountManager;
+use ic_embedders::wasm_executor::WasmExecutor;
 use ic_interfaces::execution_environment::{
     IngressFilterService, IngressHistoryReader, QueryExecutionService, Scheduler,
 };
@@ -106,91 +107,31 @@ impl ExecutionServices {
         completed_execution_messages_tx: Sender<(MessageId, Height)>,
         temp_dir: &Path,
     ) -> ExecutionServices {
-        let scheduler_config = subnet_config.scheduler_config;
-
-        // On a single core scheduler, DTS must be disabled.
-        if scheduler_config.scheduler_cores == 1 {
-            assert_eq!(
-                scheduler_config.max_instructions_per_message,
-                scheduler_config.max_instructions_per_slice,
-                "On a single core scheduler, DTS must be disabled by setting max_instructions_per_message == max_instructions_per_slice"
-            );
-            assert_eq!(
-                scheduler_config.max_instructions_per_install_code,
-                scheduler_config.max_instructions_per_install_code_slice,
-                "On a single core scheduler, DTS must be disabled by setting max_instructions_per_install_code == max_instructions_per_install_code_slice"
-            );
-        }
-
-        let cycles_account_manager = Arc::new(CyclesAccountManager::new(
-            scheduler_config.max_instructions_per_message,
+        let (
+            ingress_filter,
+            ingress_history_writer,
+            ingress_history_reader,
+            sync_query_handler,
+            query_scheduler,
+            query_stats_payload_builder,
+            cycles_account_manager,
+            execution_environment,
+        ) = setup_execution_helper(
+            logger.clone(),
+            metrics_registry,
+            own_subnet_id,
             own_subnet_type,
-            own_subnet_id,
-            subnet_config.cycles_account_manager_config,
-        ));
-
-        let hypervisor = Arc::new(Hypervisor::new(
             config.clone(),
-            metrics_registry,
-            own_subnet_id,
-            logger.clone(),
-            Arc::clone(&cycles_account_manager),
-            scheduler_config.dirty_page_overhead,
-            Arc::clone(&fd_factory),
+            subnet_config.clone(),
             Arc::clone(&state_reader),
-            temp_dir,
-        ));
-
-        let ingress_history_writer = Arc::new(IngressHistoryWriterImpl::new(
-            config.clone(),
-            logger.clone(),
-            metrics_registry,
+            Arc::clone(&fd_factory),
             completed_execution_messages_tx,
-            Arc::clone(&state_reader),
-        ));
-        let ingress_history_reader =
-            Box::new(IngressHistoryReaderImpl::new(Arc::clone(&state_reader)));
-
-        let (query_stats_collector, query_stats_payload_builder) =
-            ic_query_stats::init_query_stats(logger.clone(), &config, metrics_registry);
-
-        let exec_env = Arc::new(ExecutionEnvironment::new(
-            logger.clone(),
-            Arc::clone(&hypervisor),
-            Arc::clone(&ingress_history_writer) as Arc<_>,
-            metrics_registry,
-            own_subnet_id,
-            own_subnet_type,
-            RoundSchedule::compute_capacity_percent(scheduler_config.scheduler_cores),
-            config.clone(),
-            Arc::clone(&cycles_account_manager),
-            scheduler_config.scheduler_cores,
-            Arc::clone(&fd_factory),
-            scheduler_config.heap_delta_rate_limit,
-            scheduler_config.upload_wasm_chunk_instructions,
-            scheduler_config.canister_snapshot_baseline_instructions,
-            scheduler_config.canister_snapshot_data_baseline_instructions,
-        ));
-        let sync_query_handler = Arc::new(InternalHttpQueryHandler::new(
-            logger.clone(),
-            hypervisor,
-            own_subnet_type,
-            config.clone(),
-            metrics_registry,
-            scheduler_config.max_instructions_per_message_without_dts,
-            Arc::clone(&cycles_account_manager),
-            query_stats_collector,
-        ));
-
-        let query_scheduler = QueryScheduler::new(
-            config.query_execution_threads_total,
-            config.embedders_config.query_execution_threads_per_canister,
-            config.query_scheduling_time_slice_per_canister,
-            metrics_registry,
-            QuerySchedulerFlag::UseNewSchedulingAlgorithm,
+            temp_dir,
+            None,
+            RoundSchedule::compute_capacity_percent(subnet_config.scheduler_config.scheduler_cores),
         );
 
-        let ingress_filter_metrics: Arc<_> = IngressFilterMetrics::new(metrics_registry).into();
+        let sync_query_handler = Arc::new(sync_query_handler);
 
         // Creating the async services require that a tokio runtime context is available.
 
@@ -210,19 +151,13 @@ impl ExecutionServices {
             "https_outcall",
             false,
         );
-        let ingress_filter = IngressFilterServiceImpl::new_service(
-            query_scheduler.clone(),
-            Arc::clone(&state_reader),
-            Arc::clone(&exec_env),
-            ingress_filter_metrics.clone(),
-        );
 
         let scheduler = Box::new(SchedulerImpl::new(
-            scheduler_config,
+            subnet_config.scheduler_config,
             config.embedders_config,
             own_subnet_id,
             Arc::clone(&ingress_history_writer) as Arc<_>,
-            Arc::clone(&exec_env) as Arc<_>,
+            Arc::clone(&execution_environment) as Arc<_>,
             Arc::clone(&cycles_account_manager),
             metrics_registry,
             logger,
@@ -263,4 +198,199 @@ impl ExecutionServices {
             self.cycles_account_manager,
         )
     }
+}
+
+/// Wraps the execution services for testing purposes, like
+/// `ExecutionTest`, `SchedulerTest`, execution benchmarks
+/// and state machine tests.
+#[doc(hidden)]
+pub struct ExecutionServicesForTesting {
+    pub ingress_filter: IngressFilterService,
+    pub ingress_history_writer: Arc<IngressHistoryWriterImpl>,
+    pub ingress_history_reader: Box<dyn IngressHistoryReader>,
+    pub query_execution_service: InternalHttpQueryHandler,
+    pub query_stats_payload_builder: QueryStatsPayloadBuilderParams,
+    pub cycles_account_manager: Arc<CyclesAccountManager>,
+    pub execution_environment: Arc<ExecutionEnvironment>,
+}
+
+impl ExecutionServicesForTesting {
+    /// Constructs the public facing components that the
+    /// `ExecutionEnvironment` crate exports.
+    #[allow(clippy::type_complexity, clippy::too_many_arguments)]
+    pub fn setup_execution(
+        logger: ReplicaLogger,
+        metrics_registry: &MetricsRegistry,
+        own_subnet_id: SubnetId,
+        own_subnet_type: SubnetType,
+        config: Config,
+        subnet_config: SubnetConfig,
+        state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
+        fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
+        completed_execution_messages_tx: Sender<(MessageId, Height)>,
+        temp_dir: &Path,
+        wasm_executor: Option<Arc<dyn WasmExecutor>>,
+    ) -> ExecutionServicesForTesting {
+        let (
+            ingress_filter,
+            ingress_history_writer,
+            ingress_history_reader,
+            sync_query_handler,
+            _query_scheduler,
+            query_stats_payload_builder,
+            cycles_account_manager,
+            execution_environment,
+        ) = setup_execution_helper(
+            logger,
+            metrics_registry,
+            own_subnet_id,
+            own_subnet_type,
+            config,
+            subnet_config,
+            state_reader,
+            fd_factory,
+            completed_execution_messages_tx,
+            temp_dir,
+            wasm_executor,
+            // Compute capacity for 2-core scheduler is 100%
+            // TODO(RUN-319): the capacity should be defined based on actual `scheduler_cores`
+            100,
+        );
+
+        Self {
+            ingress_filter,
+            ingress_history_writer,
+            ingress_history_reader,
+            query_execution_service: sync_query_handler,
+            query_stats_payload_builder,
+            cycles_account_manager,
+            execution_environment,
+        }
+    }
+}
+
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+fn setup_execution_helper(
+    logger: ReplicaLogger,
+    metrics_registry: &MetricsRegistry,
+    own_subnet_id: SubnetId,
+    own_subnet_type: SubnetType,
+    config: Config,
+    subnet_config: SubnetConfig,
+    state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
+    fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
+    completed_execution_messages_tx: Sender<(MessageId, Height)>,
+    temp_dir: &Path,
+    wasm_executor: Option<Arc<dyn WasmExecutor>>,
+    compute_capacity: usize,
+) -> (
+    IngressFilterService,
+    Arc<IngressHistoryWriterImpl>,
+    Box<dyn IngressHistoryReader>,
+    InternalHttpQueryHandler,
+    QueryScheduler,
+    QueryStatsPayloadBuilderParams,
+    Arc<CyclesAccountManager>,
+    Arc<ExecutionEnvironment>,
+) {
+    let scheduler_config = subnet_config.scheduler_config;
+
+    let cycles_account_manager = Arc::new(CyclesAccountManager::new(
+        scheduler_config.max_instructions_per_message,
+        own_subnet_type,
+        own_subnet_id,
+        subnet_config.cycles_account_manager_config,
+    ));
+
+    let hypervisor = Arc::new(match wasm_executor {
+        None => Hypervisor::new(
+            config.clone(),
+            metrics_registry,
+            own_subnet_id,
+            logger.clone(),
+            Arc::clone(&cycles_account_manager),
+            scheduler_config.dirty_page_overhead,
+            Arc::clone(&fd_factory),
+            Arc::clone(&state_reader),
+            temp_dir,
+        ),
+        Some(wasm_executor) => Hypervisor::new_for_testing(
+            metrics_registry,
+            own_subnet_id,
+            logger.clone(),
+            Arc::clone(&cycles_account_manager),
+            wasm_executor,
+            config.embedders_config.cost_to_compile_wasm_instruction,
+            config.embedders_config.dirty_page_overhead,
+            config.canister_guaranteed_callback_quota,
+        ),
+    });
+
+    let ingress_history_writer = Arc::new(IngressHistoryWriterImpl::new(
+        config.clone(),
+        logger.clone(),
+        metrics_registry,
+        completed_execution_messages_tx,
+        Arc::clone(&state_reader),
+    ));
+    let ingress_history_reader = Box::new(IngressHistoryReaderImpl::new(Arc::clone(&state_reader)));
+
+    let (query_stats_collector, query_stats_payload_builder) =
+        ic_query_stats::init_query_stats(logger.clone(), &config, metrics_registry);
+
+    let exec_env = Arc::new(ExecutionEnvironment::new(
+        logger.clone(),
+        Arc::clone(&hypervisor),
+        Arc::clone(&ingress_history_writer) as Arc<_>,
+        metrics_registry,
+        own_subnet_id,
+        own_subnet_type,
+        compute_capacity,
+        config.clone(),
+        Arc::clone(&cycles_account_manager),
+        scheduler_config.scheduler_cores,
+        Arc::clone(&fd_factory),
+        scheduler_config.heap_delta_rate_limit,
+        scheduler_config.upload_wasm_chunk_instructions,
+        scheduler_config.canister_snapshot_baseline_instructions,
+        scheduler_config.canister_snapshot_data_baseline_instructions,
+    ));
+    let sync_query_handler = InternalHttpQueryHandler::new(
+        logger.clone(),
+        hypervisor,
+        own_subnet_type,
+        config.clone(),
+        metrics_registry,
+        scheduler_config.max_instructions_per_message_without_dts,
+        Arc::clone(&cycles_account_manager),
+        query_stats_collector,
+    );
+
+    let query_scheduler = QueryScheduler::new(
+        config.query_execution_threads_total,
+        config.embedders_config.query_execution_threads_per_canister,
+        config.query_scheduling_time_slice_per_canister,
+        metrics_registry,
+        QuerySchedulerFlag::UseNewSchedulingAlgorithm,
+    );
+
+    let ingress_filter_metrics: Arc<_> = IngressFilterMetrics::new(metrics_registry).into();
+
+    let ingress_filter = IngressFilterServiceImpl::new_service(
+        query_scheduler.clone(),
+        Arc::clone(&state_reader),
+        Arc::clone(&exec_env),
+        ingress_filter_metrics.clone(),
+    );
+
+    (
+        ingress_filter,
+        ingress_history_writer,
+        ingress_history_reader,
+        sync_query_handler,
+        query_scheduler,
+        query_stats_payload_builder,
+        cycles_account_manager,
+        exec_env,
+    )
 }

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -112,7 +112,7 @@ pub struct InternalHttpQueryHandler {
 }
 
 impl InternalHttpQueryHandler {
-    pub fn new(
+    pub(crate) fn new(
         log: ReplicaLogger,
         hypervisor: Arc<Hypervisor>,
         own_subnet_type: SubnetType,

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -26,8 +26,8 @@ use ic_embedders::{
 use ic_error_types::UserError;
 use ic_interfaces::execution_environment::{
     ChainKeySettings, ExecutionRoundSummary, ExecutionRoundType, HypervisorError, HypervisorResult,
-    IngressHistoryWriter, InstanceStats, RegistryExecutionSettings, Scheduler,
-    SystemApiCallCounters, WasmExecutionOutput,
+    InstanceStats, RegistryExecutionSettings, Scheduler, SystemApiCallCounters,
+    WasmExecutionOutput,
 };
 use ic_logger::{ReplicaLogger, replica_logger::no_op_logger};
 use ic_management_canister_types_private::{
@@ -67,11 +67,9 @@ use ic_wasm_types::CanisterModule;
 use maplit::btreemap;
 use std::time::Duration;
 
-use crate::{
-    ExecutionEnvironment, Hypervisor, IngressHistoryWriterImpl, RoundLimits, as_round_instructions,
-};
+use crate::{ExecutionServicesForTesting, RoundLimits, as_round_instructions};
 
-use super::{RoundSchedule, SchedulerImpl};
+use super::SchedulerImpl;
 use crate::metrics::MeasurementScope;
 use ic_crypto_prng::{Csprng, RandomnessPurpose::ExecutionThread};
 use ic_types::time::UNIX_EPOCH;
@@ -850,7 +848,7 @@ impl SchedulerTestBuilder {
         state.metadata.network_topology.nns_subnet_id = self.nns_subnet_id;
         state.metadata.batch_time = self.batch_time;
 
-        let config = SubnetConfig::new(self.subnet_type).cycles_account_manager_config;
+        let subnet_config = SubnetConfig::new(self.subnet_type);
         for key_id in &self.master_public_key_ids {
             state
                 .metadata
@@ -892,7 +890,7 @@ impl SchedulerTestBuilder {
             self.scheduler_config.max_instructions_per_message,
             self.subnet_type,
             self.own_subnet_id,
-            config,
+            subnet_config.cycles_account_manager_config,
         );
         let cycles_account_manager = Arc::new(cycles_account_manager);
         let rate_limiting_of_instructions = if self.rate_limiting_of_instructions {
@@ -920,61 +918,37 @@ impl SchedulerTestBuilder {
             Arc::clone(&cycles_account_manager),
             registry_settings.subnet_size,
         ));
-        let hypervisor = Hypervisor::new_for_testing(
-            &self.metrics_registry,
-            self.own_subnet_id,
-            self.log.clone(),
-            Arc::clone(&cycles_account_manager),
-            Arc::<TestWasmExecutor>::clone(&wasm_executor),
-            config.embedders_config.cost_to_compile_wasm_instruction,
-            SchedulerConfig::application_subnet().dirty_page_overhead,
-            self.canister_guaranteed_callback_quota,
-        );
-        let hypervisor = Arc::new(hypervisor);
         let (completed_execution_messages_tx, _) = tokio::sync::mpsc::channel(1);
-        let state_reader = Arc::new(FakeStateManager::new());
-        let ingress_history_writer = IngressHistoryWriterImpl::new(
-            config.clone(),
-            self.log.clone(),
-            &self.metrics_registry,
-            completed_execution_messages_tx,
-            state_reader,
-        );
-        let ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState>> =
-            Arc::new(ingress_history_writer);
+        let state_manager = Arc::new(FakeStateManager::new());
 
-        let exec_env = ExecutionEnvironment::new(
+        let execution_services = ExecutionServicesForTesting::setup_execution(
             self.log.clone(),
-            hypervisor,
-            Arc::clone(&ingress_history_writer),
             &self.metrics_registry,
             self.own_subnet_id,
             self.subnet_type,
-            RoundSchedule::compute_capacity_percent(self.scheduler_config.scheduler_cores),
-            config,
-            Arc::clone(&cycles_account_manager),
-            self.scheduler_config.scheduler_cores,
-            Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
-            self.scheduler_config.heap_delta_rate_limit,
-            self.scheduler_config.upload_wasm_chunk_instructions,
-            self.scheduler_config
-                .canister_snapshot_baseline_instructions,
-            self.scheduler_config
-                .canister_snapshot_data_baseline_instructions,
+            config.clone(),
+            subnet_config.clone(),
+            state_manager.clone(),
+            state_manager.get_fd_factory(),
+            completed_execution_messages_tx,
+            state_manager.tmp(),
+            Some(wasm_executor.clone()),
         );
+
         let scheduler = SchedulerImpl::new(
             self.scheduler_config,
             self.hypervisor_config,
             self.own_subnet_id,
-            ingress_history_writer,
-            Arc::new(exec_env),
-            Arc::clone(&cycles_account_manager),
+            execution_services.ingress_history_writer,
+            execution_services.execution_environment,
+            execution_services.cycles_account_manager,
             &self.metrics_registry,
             self.log,
             rate_limiting_of_heap_delta,
             rate_limiting_of_instructions,
             Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
         );
+
         SchedulerTest {
             state: Some(state),
             next_canister_id: 0,

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -17,9 +17,9 @@ use ic_embedders::{
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 pub use ic_execution_environment::ExecutionResponse;
 use ic_execution_environment::{
-    CompilationCostHandling, ExecuteMessageResult, ExecutionEnvironment, Hypervisor,
-    IngressFilterMetrics, IngressHistoryWriterImpl, InternalHttpQueryHandler, RoundInstructions,
-    RoundLimits, RoundSchedule, execute_canister,
+    CompilationCostHandling, ExecuteMessageResult, ExecutionEnvironment,
+    ExecutionServicesForTesting, Hypervisor, IngressFilterMetrics, InternalHttpQueryHandler,
+    RoundInstructions, RoundLimits, execute_canister,
 };
 use ic_interfaces::execution_environment::{
     ChainKeySettings, ExecutionMode, IngressHistoryWriter, RegistryExecutionSettings,
@@ -82,7 +82,6 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     convert::TryFrom,
     os::unix::prelude::FileExt,
-    path::Path,
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -266,7 +265,7 @@ pub struct ExecutionTest {
     replica_version: ReplicaVersion,
 
     // The actual implementation.
-    exec_env: ExecutionEnvironment,
+    exec_env: Arc<ExecutionEnvironment>,
     query_handler: InternalHttpQueryHandler,
     cycles_account_manager: Arc<CyclesAccountManager>,
     metrics_registry: MetricsRegistry,
@@ -283,8 +282,8 @@ impl ExecutionTest {
         self.exec_env.hypervisor_for_testing()
     }
 
-    pub fn execution_environment(&self) -> &ExecutionEnvironment {
-        &self.exec_env
+    pub fn execution_environment(&self) -> Arc<ExecutionEnvironment> {
+        Arc::clone(&self.exec_env)
     }
 
     pub fn dirty_heap_page_overhead(&self) -> u64 {
@@ -1875,7 +1874,6 @@ impl Default for ExecutionTestBuilder {
                 rate_limiting_of_instructions: FlagStatus::Disabled,
                 canister_sandboxing_flag: FlagStatus::Enabled,
                 composite_queries: FlagStatus::Enabled,
-                allocatable_compute_capacity_in_percent: 100,
                 ..Config::default()
             },
             subnet_config,
@@ -2501,16 +2499,6 @@ impl ExecutionTestBuilder {
             })
             .collect::<BTreeMap<_, _>>();
 
-        let cycles_account_manager = Arc::new(CyclesAccountManager::new(
-            self.subnet_config
-                .scheduler_config
-                .max_instructions_per_message,
-            self.subnet_type,
-            self.own_subnet_id,
-            self.subnet_config.cycles_account_manager_config,
-        ));
-        let config = self.execution_config.clone();
-
         let dirty_page_overhead = match self.subnet_type {
             SubnetType::Application => SchedulerConfig::application_subnet().dirty_page_overhead,
             SubnetType::System => SchedulerConfig::system_subnet().dirty_page_overhead,
@@ -2519,84 +2507,43 @@ impl ExecutionTestBuilder {
             }
         };
 
-        let dirty_heap_page_overhead = match config.embedders_config.metering_type {
+        let dirty_heap_page_overhead = match self.execution_config.embedders_config.metering_type {
             MeteringType::New => dirty_page_overhead.get(),
             _ => 0,
         };
 
-        let hypervisor = Hypervisor::new(
-            config.clone(),
-            &metrics_registry,
-            self.own_subnet_id,
-            self.log.clone(),
-            Arc::clone(&cycles_account_manager),
-            dirty_page_overhead,
-            Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
-            Arc::new(FakeStateManager::new()),
-            Path::new("/tmp"),
-        );
-        if self.precompiled_universal_canister {
-            hypervisor.compilation_cache_insert_for_testing(
-                UNIVERSAL_CANISTER_WASM.to_vec(),
-                bincode::deserialize(&UNIVERSAL_CANISTER_SERIALIZED_MODULE)
-                    .expect("Failed to deserialize universal canister module"),
-            )
-        }
-        let hypervisor = Arc::new(hypervisor);
         let (completed_execution_messages_tx, _) = tokio::sync::mpsc::channel(1);
-        let state_reader = Arc::new(FakeStateManager::new());
-        let ingress_history_writer = IngressHistoryWriterImpl::new(
-            config.clone(),
+        let state_manager = Arc::new(FakeStateManager::new());
+
+        let execution_services = ExecutionServicesForTesting::setup_execution(
             self.log.clone(),
-            &metrics_registry,
-            completed_execution_messages_tx,
-            state_reader,
-        );
-        let ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState>> =
-            Arc::new(ingress_history_writer);
-        let exec_env = ExecutionEnvironment::new(
-            self.log.clone(),
-            Arc::clone(&hypervisor),
-            Arc::clone(&ingress_history_writer),
             &metrics_registry,
             self.own_subnet_id,
             self.subnet_type,
-            RoundSchedule::compute_capacity_percent(
-                self.subnet_config.scheduler_config.scheduler_cores,
-            ),
-            config.clone(),
-            Arc::clone(&cycles_account_manager),
-            self.subnet_config.scheduler_config.scheduler_cores,
-            Arc::new(TestPageAllocatorFileDescriptorImpl::new()),
-            self.subnet_config.scheduler_config.heap_delta_rate_limit,
-            self.subnet_config
-                .scheduler_config
-                .upload_wasm_chunk_instructions,
-            self.subnet_config
-                .scheduler_config
-                .canister_snapshot_baseline_instructions,
-            self.subnet_config
-                .scheduler_config
-                .canister_snapshot_data_baseline_instructions,
+            self.execution_config.clone(),
+            self.subnet_config.clone(),
+            state_manager.clone(),
+            state_manager.get_fd_factory(),
+            completed_execution_messages_tx,
+            state_manager.tmp(),
+            None,
         );
-        let (query_stats_collector, _) =
-            ic_query_stats::init_query_stats(self.log.clone(), &config, &metrics_registry);
 
-        let query_handler = InternalHttpQueryHandler::new(
-            self.log.clone(),
-            hypervisor,
-            self.subnet_type,
-            config.clone(),
-            &metrics_registry,
-            self.subnet_config
-                .scheduler_config
-                .max_instructions_per_message_without_dts,
-            Arc::clone(&cycles_account_manager),
-            query_stats_collector,
-        );
+        if self.precompiled_universal_canister {
+            execution_services
+                .execution_environment
+                .compilation_cache_insert_for_testing(
+                    UNIVERSAL_CANISTER_WASM.to_vec(),
+                    bincode::deserialize(&UNIVERSAL_CANISTER_SERIALIZED_MODULE)
+                        .expect("Failed to deserialize universal canister module"),
+                )
+        }
+
         state.set_own_cost_schedule(self.cost_schedule);
         self.registry_settings.canister_cycles_cost_schedule = self.cost_schedule;
-        let subnet_available_memory = exec_env.scaled_subnet_available_memory(&state);
+        let subnet_available_memory = execution_services
+            .execution_environment
+            .scaled_subnet_available_memory(&state);
         ExecutionTest {
             state: Some(state),
             message_id: 0,
@@ -2624,7 +2571,7 @@ impl ExecutionTestBuilder {
                     .scheduler_config
                     .max_instructions_per_install_code_slice,
             ),
-            ingress_memory_capacity: config.ingress_history_memory_capacity,
+            ingress_memory_capacity: self.execution_config.ingress_history_memory_capacity,
             instruction_limit_without_dts: self
                 .subnet_config
                 .scheduler_config
@@ -2633,11 +2580,11 @@ impl ExecutionTestBuilder {
             registry_settings: self.registry_settings,
             user_id: user_test_id(1),
             caller_canister_id: self.caller_canister_id,
-            exec_env,
-            query_handler,
-            cycles_account_manager,
+            exec_env: execution_services.execution_environment,
+            query_handler: execution_services.query_execution_service,
+            cycles_account_manager: execution_services.cycles_account_manager,
             metrics_registry,
-            ingress_history_writer,
+            ingress_history_writer: execution_services.ingress_history_writer,
             manual_execution: self.manual_execution,
             chain_key_data: ChainKeyData {
                 master_public_keys: chain_key_subnet_public_keys,


### PR DESCRIPTION
This PR refactors some test code paths to re-use the `setup_execution` function to construct the various execution services needed. This ensures that we don't have code duplication (at the moment the same (roughly) code was repeated 3 times in `ExecutionTest`, `SchedulerTest` and execution benches).

This is achieved by defining an `ExecutionServicesForTesting` struct which captures what's needed for test purposes. There are some differences compared to the production version which made it easier to have a separate struct. Specifically, the query handler is preferred to be exposed as the sync internal query handler to allow the tests to remain sync as well whereas the production environment needs an async one. Another difference is that the test services skip returning the scheduler as we only need it in `SchedulerTest` and they require to have access to the (crate only visible) `SchedulerImpl` as opposed to the only public component which is the `Scheduler` trait (making `SchedulerImpl` public for this seemed unnecessary). `SchedulerTest` instead creates its own scheduler as it used to but based on the services returned by `ExecutionServicesForTesting::setup_execution`.

As a nice side-effect of this refactoring, we can also make `pub(crate)` some other parts like the Hypervisor's methods or the `InternalQueryHandler` constructor as they are now only constructed by `setup_execution` and not directly by any other test code outside the `execution_environment` crate.