### PR TITLE
test(pocket-ic): test index and ledger with the same balance

### DIFF
--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -529,7 +529,9 @@ fn test_cycles_ledger() {
     pic.add_cycles(canister_id, init_cycles);
     pic.install_canister(canister_id, test_canister_wasm(), vec![], None);
 
-    let check_balance = |owner: Principal, expected_balance: u128| {
+    let check_balance = |owner: Principal,
+                         expected_ledger_balance: u128,
+                         expected_index_balance: u128| {
         // Check balance via cycles ledger.
         let account = Account {
             owner,
@@ -539,7 +541,7 @@ fn test_cycles_ledger() {
             update_candid::<_, (Nat,)>(&pic, cycles_ledger_id, "icrc1_balance_of", (account,))
                 .unwrap()
                 .0;
-        assert_eq!(balance, expected_balance);
+        assert_eq!(balance, expected_ledger_balance);
 
         // The cycles ledger index only syncs with the cycles ledger once per second.
         pic.advance_time(Duration::from_secs(1));
@@ -555,7 +557,7 @@ fn test_cycles_ledger() {
         )
         .unwrap()
         .0;
-        assert_eq!(balance, expected_balance);
+        assert_eq!(balance, expected_index_balance);
     };
     let check_cycles = |expected: u128| {
         let actual = pic.cycle_balance(canister_id);
@@ -567,7 +569,7 @@ fn test_cycles_ledger() {
         );
     };
 
-    check_balance(test_identity, 0);
+    check_balance(test_identity, 0, 0);
     check_cycles(init_cycles);
 
     // Deposit cycles to the cycles ledger.
@@ -582,7 +584,11 @@ fn test_cycles_ledger() {
     .unwrap();
 
     // The fee has been deducted from the deposit.
-    check_balance(test_identity, cycles - CYCLES_LEDGER_FEE);
+    check_balance(
+        test_identity,
+        cycles - CYCLES_LEDGER_FEE,
+        cycles - CYCLES_LEDGER_FEE,
+    );
     check_cycles(init_cycles - cycles);
 
     // Withdraw cycles from the cycles ledger.
@@ -605,12 +611,14 @@ fn test_cycles_ledger() {
     .0
     .unwrap();
 
-    check_balance(test_identity, 0);
+    // The cycles ledger index reports a wrong balance due to a bug in the interaction between the cycles ledger and its index
+    // (this bug is independent of PocketIC and to be fixed separately).
+    check_balance(test_identity, 0, CYCLES_LEDGER_FEE);
     check_cycles(init_cycles);
 
     // Withdraw cycles from the anonymous account on the cycles ledger.
     let anonymous_balance = u128::MAX / 2; // hard-coded in PocketIC server
-    check_balance(Principal::anonymous(), anonymous_balance);
+    check_balance(Principal::anonymous(), anonymous_balance, anonymous_balance);
     let amount = anonymous_balance - CYCLES_LEDGER_FEE;
     let withdraw_args = WithdrawArgs {
         from_subaccount: None,
@@ -629,7 +637,9 @@ fn test_cycles_ledger() {
     .0
     .unwrap();
 
-    check_balance(Principal::anonymous(), 0);
+    // The cycles ledger index reports a wrong balance due to a bug in the interaction between the cycles ledger and its index
+    // (this bug is independent of PocketIC and to be fixed separately).
+    check_balance(Principal::anonymous(), 0, CYCLES_LEDGER_FEE);
     check_cycles(init_cycles + anonymous_balance);
 }
 

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -529,9 +529,7 @@ fn test_cycles_ledger() {
     pic.add_cycles(canister_id, init_cycles);
     pic.install_canister(canister_id, test_canister_wasm(), vec![], None);
 
-    let check_balance = |owner: Principal,
-                         expected_ledger_balance: u128,
-                         expected_index_balance: u128| {
+    let check_balance = |owner: Principal, expected_balance: u128| {
         // Check balance via cycles ledger.
         let account = Account {
             owner,
@@ -541,7 +539,7 @@ fn test_cycles_ledger() {
             update_candid::<_, (Nat,)>(&pic, cycles_ledger_id, "icrc1_balance_of", (account,))
                 .unwrap()
                 .0;
-        assert_eq!(balance, expected_ledger_balance);
+        assert_eq!(balance, expected_balance);
 
         // The cycles ledger index only syncs with the cycles ledger once per second.
         pic.advance_time(Duration::from_secs(1));
@@ -557,7 +555,7 @@ fn test_cycles_ledger() {
         )
         .unwrap()
         .0;
-        assert_eq!(balance, expected_index_balance);
+        assert_eq!(balance, expected_balance);
     };
     let check_cycles = |expected: u128| {
         let actual = pic.cycle_balance(canister_id);
@@ -569,7 +567,7 @@ fn test_cycles_ledger() {
         );
     };
 
-    check_balance(test_identity, 0, 0);
+    check_balance(test_identity, 0);
     check_cycles(init_cycles);
 
     // Deposit cycles to the cycles ledger.
@@ -584,11 +582,7 @@ fn test_cycles_ledger() {
     .unwrap();
 
     // The fee has been deducted from the deposit.
-    check_balance(
-        test_identity,
-        cycles - CYCLES_LEDGER_FEE,
-        cycles - CYCLES_LEDGER_FEE,
-    );
+    check_balance(test_identity, cycles - CYCLES_LEDGER_FEE);
     check_cycles(init_cycles - cycles);
 
     // Withdraw cycles from the cycles ledger.
@@ -611,14 +605,12 @@ fn test_cycles_ledger() {
     .0
     .unwrap();
 
-    // The cycles ledger index reports a wrong balance due to a bug in the interaction between the cycles ledger and its index
-    // (this bug is independent of PocketIC and to be fixed separately).
-    check_balance(test_identity, 0, CYCLES_LEDGER_FEE);
+    check_balance(test_identity, 0);
     check_cycles(init_cycles);
 
     // Withdraw cycles from the anonymous account on the cycles ledger.
     let anonymous_balance = u128::MAX / 2; // hard-coded in PocketIC server
-    check_balance(Principal::anonymous(), anonymous_balance, anonymous_balance);
+    check_balance(Principal::anonymous(), anonymous_balance);
     let amount = anonymous_balance - CYCLES_LEDGER_FEE;
     let withdraw_args = WithdrawArgs {
         from_subaccount: None,
@@ -637,9 +629,7 @@ fn test_cycles_ledger() {
     .0
     .unwrap();
 
-    // The cycles ledger index reports a wrong balance due to a bug in the interaction between the cycles ledger and its index
-    // (this bug is independent of PocketIC and to be fixed separately).
-    check_balance(Principal::anonymous(), 0, CYCLES_LEDGER_FEE);
+    check_balance(Principal::anonymous(), 0);
     check_cycles(init_cycles + anonymous_balance);
 }
 

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -557,7 +557,9 @@ fn test_cycles_ledger() {
         )
         .unwrap()
         .0;
-        assert_eq!(balance, expected_index_balance);
+        // TODO: Once https://github.com/dfinity/ic/pull/6508 is on mainnet we can remove
+        // `expected_index_balance` param and only compare against `expected_ledger_balance`.
+        assert!(balance == expected_index_balance || balance == expected_ledger_balance);
     };
     let check_cycles = |expected: u128| {
         let actual = pic.cycle_balance(canister_id);


### PR DESCRIPTION
The broken test was compensating for the discrepancy in balance calculation between the ledger and index.
https://github.com/dfinity/ic/pull/6508 fixed this discrepancy so both index and ledger have the same balances. Since this PR is not on mainnet yet, we temporarily have to compare against both correct balance (for testing with master) and incorrect (for testing with mainnet).