### PR TITLE
chore: run build-ic on stock runner

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -498,81 +498,86 @@ jobs:
   build-ic:
     needs: [config]
     name: Build IC
-    runs-on: *dind-large-setup
-    container: *container-setup
+    runs-on: namespace-profile-ubuntu-24-04
+    container:
+      image: ubuntu:24.04
+      options: >-
+        -e NODE_NAME --privileged --cgroupns host
     timeout-minutes: 90
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - *checkout
-      - name: "Node Name"
+      - name: Setup podman
+        shell: bash
         run: |
-          echo "::notice::Node Name: ${NODE_NAME}"
+          apt-get update
+          apt-get -y upgrade
+          apt-get -y install curl sudo git podman
+
+      - *checkout
       - name: Run Build IC
-        uses: ./.github/actions/bazel
-        with:
-          execlogs-artifact-name: execlogs-build-ic
-          run: |
-            set -euo pipefail
+        shell: bash
+        run: |
+          set -euo pipefail
 
-            RELEASE_BUILD='${{ needs.config.outputs.release-build }}'
-            DIFF_ONLY='${{ needs.config.outputs.diff_only }}'
-            BASE_SHA='${{ github.event.pull_request.base.sha }}'
-            HEAD_SHA='${{ github.event.pull_request.head.sha }}'
+          RELEASE_BUILD='${{ needs.config.outputs.release-build }}'
+          DIFF_ONLY='${{ needs.config.outputs.diff_only }}'
+          BASE_SHA='${{ github.event.pull_request.base.sha }}'
+          HEAD_SHA='${{ github.event.pull_request.head.sha }}'
 
-            cd "$CI_PROJECT_DIR"
+          cd "$CI_PROJECT_DIR"
 
-            # run full release build on "protected" branches
-            if [[ "$RELEASE_BUILD" == 'true' ]]; then
-                ci/container/build-ic.sh -i -c -b
-                exit 0
-            fi
+          # run full release build on "protected" branches
+          if [[ "$RELEASE_BUILD" == 'true' ]]; then
+              ci/container/build-ic.sh -i -c -b
+              exit 0
+          fi
 
-            # run full non-release build if not asked to diff
-            if ! [ "$DIFF_ONLY" == 'true' ]; then
-                ci/container/build-ic.sh -i -c -b --no-release
-                exit 0
-            fi
+          # run full non-release build if not asked to diff
+          if ! [ "$DIFF_ONLY" == 'true' ]; then
+              ci/container/build-ic.sh -i -c -b --no-release
+              exit 0
+          fi
 
-            # otherwise, infer targets to build
-            target_pattern_file=$(mktemp)
-            trap "rm $target_pattern_file" INT TERM EXIT
-            targets_args=()
-            commit_range_arg=""
-            if [[ "$DIFF_ONLY" == 'true' ]]; then
-              targets_args+=("--base=$BASE_SHA" "--head=$HEAD_SHA")
-            fi
-            ci/scripts/targets.py build "${targets_args[@]}" >"$target_pattern_file"
-            num_targets=$(wc <"$target_pattern_file" -l)
-            echo "Considering $num_targets targets ..."
-            # the target list can get quite big, so we wrap it in details/summary
-            {
-              echo '<details><summary>Considered '"$num_targets"' targets</summary>';
-              echo
-              echo '```'
-              cat "$target_pattern_file"
-              echo '```'
-              echo
-              echo '</details>';
-            } >>"$GITHUB_STEP_SUMMARY"
+          # otherwise, infer targets to build
+          target_pattern_file=$(mktemp)
+          trap "rm $target_pattern_file" INT TERM EXIT
+          targets_args=()
+          commit_range_arg=""
+          if [[ "$DIFF_ONLY" == 'true' ]]; then
+            targets_args+=("--base=$BASE_SHA" "--head=$HEAD_SHA")
+          fi
+          ci/scripts/targets.py build "${targets_args[@]}" >"$target_pattern_file"
+          num_targets=$(wc <"$target_pattern_file" -l)
+          echo "Considering $num_targets targets ..."
+          # the target list can get quite big, so we wrap it in details/summary
+          {
+            echo '<details><summary>Considered '"$num_targets"' targets</summary>';
+            echo
+            echo '```'
+            cat "$target_pattern_file"
+            echo '```'
+            echo
+            echo '</details>';
+          } >>"$GITHUB_STEP_SUMMARY"
 
-            ARGS=()
+          ARGS=()
 
-            if grep -q '^//ic-os' <"$target_pattern_file"; then
-                ARGS+=(-i)
-            fi
-            if grep -q '^//publish/canisters' <"$target_pattern_file"; then
-                ARGS+=(-c)
-            fi
-            if grep -q '^//publish/binaries' <"$target_pattern_file"; then
-                ARGS+=(-b)
-            fi
+          if grep -q '^//ic-os' <"$target_pattern_file"; then
+              ARGS+=(-i)
+          fi
+          if grep -q '^//publish/canisters' <"$target_pattern_file"; then
+              ARGS+=(-c)
+          fi
+          if grep -q '^//publish/binaries' <"$target_pattern_file"; then
+              ARGS+=(-b)
+          fi
 
-            if [[ ${#ARGS[@]} -eq 0 ]]; then
-                echo "No changes that require building IC-OS, binaries or canisters."
-                exit 0
-            fi
+          if [[ ${#ARGS[@]} -eq 0 ]]; then
+              echo "No changes that require building IC-OS, binaries or canisters."
+              exit 0
+          fi
 
-            ci/container/build-ic.sh "${ARGS[@]}" --no-release
+          ci/container/build-ic.sh "${ARGS[@]}" --no-release
 
   build-determinism:
     name: Build Determinism

--- a/ci/container/build-ic.sh
+++ b/ci/container/build-ic.sh
@@ -109,8 +109,12 @@ export VERSION="$(git rev-parse HEAD)"
 
 BAZEL_TARGETS=()
 
+BAZEL_STARTUP_OPTS=(
+    --noworkspace_rc
+    --bazelrc=./bazel/conf/.bazelrc.build
+)
+
 BAZEL_COMMON_ARGS=(
-    --config=local
     --color=yes
 )
 
@@ -144,11 +148,11 @@ if "$BUILD_IMG"; then BAZEL_TARGETS+=(
 
 echo_blue "Bazel targets: ${BAZEL_TARGETS[*]}"
 
-bazel build "${BAZEL_COMMON_ARGS[@]}" "${BAZEL_TARGETS[@]}"
+bazel "${BAZEL_STARTUP_OPTS[@]}" build "${BAZEL_COMMON_ARGS[@]}" "${BAZEL_TARGETS[@]}"
 
 query="$(join_by "+" "${BAZEL_TARGETS[@]}")"
 
-for artifact in $(bazel cquery "${BAZEL_COMMON_ARGS[@]}" --output=files "$query"); do
+for artifact in $(bazel "${BAZEL_STARTUP_OPTS[@]}" cquery "${BAZEL_COMMON_ARGS[@]}" --output=files "$query"); do
     target_dir=
     case "$artifact" in
         *guestos*disk)


### PR DESCRIPTION
This moves the `build-ic` out of our custom (self-hosted) runners and onto namespace amd64 linux runners.

We try to make sure `build-ic.sh` is portable, and in order to surface issues early we run it on a non-custom runner, with no access to our internal infrastructure.