### PR TITLE
fix: deflake //rs/tests/node:ipv4_integration_test by using a longer block_for_newer_registry_version

### DIFF
--- a/rs/tests/node/ipv4_integration_test.rs
+++ b/rs/tests/node/ipv4_integration_test.rs
@@ -191,7 +191,16 @@ EOT
         }
 
         info!(log, "Waiting for the registry to update from version {:?} ...", topology.get_registry_version());
-        let topology = topology.block_for_newer_registry_version().await.unwrap();
+        // Use a longer timeout (300) since node re-registration involves
+        // generating new crypto keys and registering with the NNS, which
+        // is significantly slower than a direct registry canister call.
+        let topology = topology
+            .block_for_newer_registry_version_within_duration(
+                Duration::from_secs(300),
+                Duration::from_secs(2),
+            )
+            .await
+            .unwrap();
 
         info!(log, "Assert there is 1 unassigned node again");
         assert_eq!(topology.unassigned_nodes().count(), 1);

--- a/rs/tests/node/ipv4_integration_test.rs
+++ b/rs/tests/node/ipv4_integration_test.rs
@@ -191,7 +191,7 @@ EOT
         }
 
         info!(log, "Waiting for the registry to update from version {:?} ...", topology.get_registry_version());
-        // Use a longer timeout (300) since node re-registration involves
+        // Use a longer timeout (300s) with a 2s polling interval since node re-registration involves
         // generating new crypto keys and registering with the NNS, which
         // is significantly slower than a direct registry canister call.
         let topology = topology


### PR DESCRIPTION
## Root Cause

The test flakes at the third `block_for_newer_registry_version()` call (line 194), which waits for a removed node to re-register itself after restarting its crypto and replica services. This operation involves:

1. Stopping crypto-csp and replica services
2. Deleting crypto keys
3. Restarting services with a new node operator key
4. The node generating new crypto keys and registering with the NNS

This process is significantly slower than a direct registry canister call, but the default `block_for_newer_registry_version()` uses a hardcoded 180s timeout. When the node re-registration takes longer than 180s (which happens intermittently under load), the test fails with:

```
check if latest registry version >= 4 timed out after 181s on attempt 91.
Last error: latest_version: 3, expected minimum version: 4
```

## Fix

Replace `block_for_newer_registry_version()` with `block_for_newer_registry_version_within_duration(Duration::from_secs(300), Duration::from_secs(2))` for the specific call that waits for node re-registration. This almost doubles the timeout from 180s to 300s while keeping the same 2s polling interval.

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.