### PR TITLE
fix: deflake //rs/execution_environment:dts_test

### DIFF
--- a/rs/canister_sandbox/src/transport.rs
+++ b/rs/canister_sandbox/src/transport.rs
@@ -180,7 +180,14 @@ impl<Message: 'static + Serialize + Send + EnumerateInnerFileDescriptors>
                 (guard.buf.split(), std::mem::take(&mut guard.fds))
             };
             while !buf.is_empty() {
-                send_message(&self.socket, &mut buf, &mut fds, 0);
+                if send_message(&self.socket, &mut buf, &mut fds, 0) < 0 {
+                    // The socket is broken (e.g., EPIPE or EBADF because the
+                    // other end closed the connection). There is no point in
+                    // retrying because all subsequent sends will also fail.
+                    // Without this check the loop would spin forever since
+                    // `send_message` does not drain the buffer on error.
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
## Root Cause

The `background_sending_thread` in `UnixStreamMessageWriter` ([rs/canister_sandbox/src/transport.rs](https://github.com/dfinity/ic/blob/master/rs/canister_sandbox/src/transport.rs#L186)) has a sending loop:

```rust
while !buf.is_empty() {
    send_message(&self.socket, &mut buf, &mut fds, 0);
}
```

When the remote end closes the socket (e.g., sandbox process exits after receiving a `TerminateRequest`), `sendmsg()` fails with `EPIPE` or `EBADF` and returns `-1`. However, `send_message()` only drains the buffer when `num_bytes_sent > 0`, so on error the buffer is never drained and `buf.is_empty()` stays `false` — causing the loop to **spin forever**.

This stuck background thread prevents the test process from exiting, leading to the 60-second timeout. The `"Failed to update sandbox IPC socket timeout: Bad file descriptor (os error 9)"` message in the logs is a symptom of the same underlying race — the socket fd becoming invalid when the sandbox process terminates while the controller still holds a reference.

## Fix

Check the return value of `send_message()` in the background sending loop. If it returns a negative value (error), exit the thread immediately since the socket is broken and all subsequent sends would also fail.

## Verification

- All unit tests in `//rs/canister_sandbox:backend_lib_test` pass
- `//rs/execution_environment:dts_test` passes with `--runs_per_test=3 --jobs=3` (3 parallel runs)
- All other affected tests (`//rs/replay:player_integration_tests`, `//rs/replay:replay_test`) pass

---
*This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.*