### PR TITLE
fix: deflake //rs/tests/nested/nns_recovery:nr_broken_dfinity_node

### DIFF
--- a/rs/recovery/src/steps.rs
+++ b/rs/recovery/src/steps.rs
@@ -928,7 +928,7 @@ impl Step for UploadCUPAndTarStep {
             self.key_file.clone(),
         );
 
-        if !ssh_helper.can_connect() {
+        if ssh_helper.wait_for_access().is_err() {
             info!(
                 self.logger,
                 "No admin access to: {}, skipping upload...", self.node_ip


### PR DESCRIPTION
## Root Cause

`UploadCUPAndTarStep::exec()` in `rs/recovery/src/steps.rs` called `ssh_helper.can_connect()` — a **single** SSH connectivity check. When the node was transiently SSH-unreachable (e.g., after the preceding `UploadState` step restarts the replica), this one-shot check failed and immediately returned `"SSH access denied"`, crashing the test.

The log shows the SSH `echo 1;` probe issued at 08:02:22 hung for over 5 minutes before failing — indicating the node was partially reachable (TCP connected but SSH handshake stalled), a transient condition that would resolve on retry.

## Fix

Replaced `can_connect()` with `wait_for_access()`, which retries up to 20 times with 5-second delays between attempts. This is the established pattern already used in `get_download_data_step()` in `rs/recovery/src/lib.rs`.

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.