### PR TITLE
feat(icrc1): add ICRC-153 freeze/unfreeze ledger endpoints and freeze guard

### DIFF
--- a/packages/icrc-ledger-types/src/icrc153/mod.rs
+++ b/packages/icrc-ledger-types/src/icrc153/mod.rs
@@ -45,7 +45,6 @@ pub enum FreezeAccountError {
 pub enum UnfreezeAccountError {
     Unauthorized { message: String },
     InvalidAccount { message: String },
-    NotFrozen { message: String },
     Duplicate { duplicate_of: Nat },
     GenericError { error_code: Nat, message: String },
 }
@@ -63,7 +62,6 @@ pub enum FreezePrincipalError {
 pub enum UnfreezePrincipalError {
     Unauthorized { message: String },
     InvalidPrincipal { message: String },
-    NotFrozen { message: String },
     Duplicate { duplicate_of: Nat },
     GenericError { error_code: Nat, message: String },
 }

--- a/rs/ledger_suite/icrc1/archive/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/archive/tests/tests.rs
@@ -359,5 +359,11 @@ fn test_archive_http_request_decoding_quota() {
 fn test_icrc3_supported_block_types() {
     let setup = Setup::default();
 
-    check_icrc3_supported_block_types_ext(&setup.state_machine, setup.archive_id, true, false);
+    check_icrc3_supported_block_types_ext(
+        &setup.state_machine,
+        setup.archive_id,
+        true,
+        false,
+        false,
+    );
 }

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
@@ -2,70 +2,70 @@ benches:
   bench_icrc1_transfers:
     total:
       calls: 1
-      instructions: 54491238395
-      heap_increase: 264
+      instructions: 53797152107
+      heap_increase: 262
       stable_memory_increase: 256
     scopes:
       icrc103_get_allowances:
         calls: 1
-        instructions: 6379538
+        instructions: 6489820
         heap_increase: 0
         stable_memory_increase: 0
       icrc1_transfer:
         calls: 1
-        instructions: 12927451546
-        heap_increase: 32
+        instructions: 12779932859
+        heap_increase: 31
         stable_memory_increase: 0
       icrc2_approve:
         calls: 1
-        instructions: 19382509154
-        heap_increase: 29
+        instructions: 19166091269
+        heap_increase: 28
         stable_memory_increase: 128
       icrc2_transfer_from:
         calls: 1
-        instructions: 21477262663
+        instructions: 21147218689
         heap_increase: 3
         stable_memory_increase: 0
       icrc3_get_blocks:
         calls: 1
-        instructions: 8714812
+        instructions: 8889807
         heap_increase: 0
         stable_memory_increase: 0
       post_upgrade:
         calls: 1
-        instructions: 345728772
+        instructions: 345637310
         heap_increase: 71
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 148895740
+        instructions: 149859904
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
         calls: 1
-        instructions: 494627254
+        instructions: 495499883
         heap_increase: 200
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
       calls: 1
-      instructions: 8695301
+      instructions: 8701405
       heap_increase: 258
       stable_memory_increase: 128
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 8613042
+        instructions: 8617093
         heap_increase: 129
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 79335
+        instructions: 81388
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
         calls: 1
-        instructions: 8694393
+        instructions: 8700497
         heap_increase: 258
         stable_memory_increase: 128
 version: 0.4.1

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
@@ -2,70 +2,70 @@ benches:
   bench_icrc1_transfers:
     total:
       calls: 1
-      instructions: 52110539550
-      heap_increase: 263
+      instructions: 52233883164
+      heap_increase: 264
       stable_memory_increase: 256
     scopes:
       icrc103_get_allowances:
         calls: 1
-        instructions: 5652590
+        instructions: 5652189
         heap_increase: 0
         stable_memory_increase: 0
       icrc1_transfer:
         calls: 1
-        instructions: 12272395213
-        heap_increase: 34
+        instructions: 12229113523
+        heap_increase: 31
         stable_memory_increase: 0
       icrc2_approve:
         calls: 1
-        instructions: 18492811180
-        heap_increase: 25
+        instructions: 18608328972
+        heap_increase: 28
         stable_memory_increase: 128
       icrc2_transfer_from:
         calls: 1
-        instructions: 20643585966
+        instructions: 20694359995
         heap_increase: 3
         stable_memory_increase: 0
       icrc3_get_blocks:
         calls: 1
-        instructions: 8197351
+        instructions: 8282666
         heap_increase: 0
         stable_memory_increase: 0
       post_upgrade:
         calls: 1
-        instructions: 351454807
-        heap_increase: 72
+        instructions: 351197002
+        heap_increase: 73
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 148926118
+        instructions: 149741137
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
         calls: 1
-        instructions: 500383666
-        heap_increase: 201
+        instructions: 500940880
+        heap_increase: 202
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
       calls: 1
-      instructions: 8699772
+      instructions: 8705768
       heap_increase: 258
       stable_memory_increase: 128
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 8616474
+        instructions: 8620513
         heap_increase: 129
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 80374
+        instructions: 82331
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
         calls: 1
-        instructions: 8698864
+        instructions: 8704860
         heap_increase: 258
         stable_memory_increase: 128
 version: 0.4.1

--- a/rs/ledger_suite/icrc1/ledger/ledger.did
+++ b/rs/ledger_suite/icrc1/ledger/ledger.did
@@ -655,7 +655,6 @@ type FreezeAccountError = variant {
 type UnfreezeAccountError = variant {
   Unauthorized : record { message : text };
   InvalidAccount : record { message : text };
-  NotFrozen : record { message : text };
   Duplicate : record { duplicate_of : nat };
   GenericError : record { error_code : nat; message : text }
 };
@@ -671,7 +670,6 @@ type FreezePrincipalError = variant {
 type UnfreezePrincipalError = variant {
   Unauthorized : record { message : text };
   InvalidPrincipal : record { message : text };
-  NotFrozen : record { message : text };
   Duplicate : record { duplicate_of : nat };
   GenericError : record { error_code : nat; message : text }
 };

--- a/rs/ledger_suite/icrc1/ledger/ledger.did
+++ b/rs/ledger_suite/icrc1/ledger/ledger.did
@@ -620,6 +620,85 @@ type PauseResult = variant { Ok : nat; Err : PauseError };
 type UnpauseResult = variant { Ok : nat; Err : UnpauseError };
 type DeactivateResult = variant { Ok : nat; Err : DeactivateError };
 
+type FreezeAccountArgs = record {
+  account : Account;
+  reason : opt text;
+  created_at_time : nat64
+};
+
+type UnfreezeAccountArgs = record {
+  account : Account;
+  reason : opt text;
+  created_at_time : nat64
+};
+
+type FreezePrincipalArgs = record {
+  "principal" : principal;
+  reason : opt text;
+  created_at_time : nat64
+};
+
+type UnfreezePrincipalArgs = record {
+  "principal" : principal;
+  reason : opt text;
+  created_at_time : nat64
+};
+
+type FreezeAccountError = variant {
+  Unauthorized : record { message : text };
+  InvalidAccount : record { message : text };
+  AlreadyFrozen : record { message : text };
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text }
+};
+
+type UnfreezeAccountError = variant {
+  Unauthorized : record { message : text };
+  InvalidAccount : record { message : text };
+  NotFrozen : record { message : text };
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text }
+};
+
+type FreezePrincipalError = variant {
+  Unauthorized : record { message : text };
+  InvalidPrincipal : record { message : text };
+  AlreadyFrozen : record { message : text };
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text }
+};
+
+type UnfreezePrincipalError = variant {
+  Unauthorized : record { message : text };
+  InvalidPrincipal : record { message : text };
+  NotFrozen : record { message : text };
+  Duplicate : record { duplicate_of : nat };
+  GenericError : record { error_code : nat; message : text }
+};
+
+type FreezeAccountResult = variant { Ok : nat; Err : FreezeAccountError };
+type UnfreezeAccountResult = variant { Ok : nat; Err : UnfreezeAccountError };
+type FreezePrincipalResult = variant { Ok : nat; Err : FreezePrincipalError };
+type UnfreezePrincipalResult = variant { Ok : nat; Err : UnfreezePrincipalError };
+
+type FrozenAccountsRequest = record {
+  start : opt Account;
+  limit : opt nat
+};
+
+type FrozenAccountsResponse = record {
+  frozen_accounts : vec Account
+};
+
+type FrozenPrincipalsRequest = record {
+  start : opt principal;
+  limit : opt nat
+};
+
+type FrozenPrincipalsResponse = record {
+  frozen_principals : vec principal
+};
+
 service : (ledger_arg : LedgerArg) -> {
   archives : () -> (vec ArchiveInfo) query;
   get_transactions : (GetTransactionsRequest) -> (GetTransactionsResponse) query;
@@ -658,6 +737,15 @@ service : (ledger_arg : LedgerArg) -> {
   icrc154_deactivate : (DeactivateArgs) -> (DeactivateResult);
   icrc154_is_paused : () -> (bool) query;
   icrc154_is_deactivated : () -> (bool) query;
+
+  icrc153_freeze_account : (FreezeAccountArgs) -> (FreezeAccountResult);
+  icrc153_unfreeze_account : (UnfreezeAccountArgs) -> (UnfreezeAccountResult);
+  icrc153_freeze_principal : (FreezePrincipalArgs) -> (FreezePrincipalResult);
+  icrc153_unfreeze_principal : (UnfreezePrincipalArgs) -> (UnfreezePrincipalResult);
+  icrc153_is_frozen_account : (Account) -> (bool) query;
+  icrc153_is_frozen_principal : (principal) -> (bool) query;
+  icrc153_list_frozen_accounts : (FrozenAccountsRequest) -> (FrozenAccountsResponse) query;
+  icrc153_list_frozen_principals : (FrozenPrincipalsRequest) -> (FrozenPrincipalsResponse) query;
 
   is_ledger_ready : () -> (bool) query
 }

--- a/rs/ledger_suite/icrc1/ledger/src/lib.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/lib.rs
@@ -595,6 +595,11 @@ pub struct Ledger {
     paused: bool,
     #[serde(default)]
     deactivated: bool,
+
+    #[serde(default)]
+    frozen_accounts: std::collections::BTreeSet<Account>,
+    #[serde(default)]
+    frozen_principals: std::collections::BTreeSet<Principal>,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize, Serialize)]
@@ -723,6 +728,8 @@ impl Ledger {
             token_type: wasm_token_type(),
             paused: false,
             deactivated: false,
+            frozen_accounts: std::collections::BTreeSet::new(),
+            frozen_principals: std::collections::BTreeSet::new(),
         };
 
         if ledger.fee_collector.as_ref().map(|fc| fc.fee_collector) == Some(ledger.minting_account)
@@ -880,6 +887,61 @@ impl Ledger {
 
     pub fn set_deactivated(&mut self, deactivated: bool) {
         self.deactivated = deactivated;
+    }
+
+    pub fn is_account_frozen(&self, account: &Account) -> bool {
+        self.frozen_accounts.contains(account)
+    }
+
+    pub fn is_principal_frozen(&self, principal: &Principal) -> bool {
+        self.frozen_principals.contains(principal)
+    }
+
+    /// Returns true if the account is directly frozen or its owner principal is frozen.
+    pub fn is_effectively_frozen(&self, account: &Account) -> bool {
+        self.frozen_accounts.contains(account) || self.frozen_principals.contains(&account.owner)
+    }
+
+    pub fn freeze_account(&mut self, account: Account) {
+        self.frozen_accounts.insert(account);
+    }
+
+    pub fn unfreeze_account(&mut self, account: &Account) {
+        self.frozen_accounts.remove(account);
+    }
+
+    pub fn freeze_principal(&mut self, principal: Principal) {
+        self.frozen_principals.insert(principal);
+    }
+
+    pub fn unfreeze_principal(&mut self, principal: &Principal) {
+        self.frozen_principals.remove(principal);
+    }
+
+    pub fn list_frozen_accounts(&self, start_after: Option<&Account>, max: usize) -> Vec<Account> {
+        use std::ops::Bound;
+        let iter = match start_after {
+            Some(start) => self
+                .frozen_accounts
+                .range((Bound::Excluded(*start), Bound::Unbounded)),
+            None => self.frozen_accounts.range(..),
+        };
+        iter.take(max).copied().collect()
+    }
+
+    pub fn list_frozen_principals(
+        &self,
+        start_after: Option<&Principal>,
+        max: usize,
+    ) -> Vec<Principal> {
+        use std::ops::Bound;
+        let iter = match start_after {
+            Some(start) => self
+                .frozen_principals
+                .range((Bound::Excluded(*start), Bound::Unbounded)),
+            None => self.frozen_principals.range(..),
+        };
+        iter.take(max).copied().collect()
     }
 
     pub fn metadata(&self) -> Vec<(MetadataKey, Value)> {

--- a/rs/ledger_suite/icrc1/ledger/src/lib.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/lib.rs
@@ -597,11 +597,12 @@ pub struct Ledger {
     deactivated: bool,
 
     #[serde(default)]
-    /// Maps accounts to (block_index, is_frozen) of the latest account-level action.
-    account_freeze_status: std::collections::BTreeMap<Account, (u64, bool)>,
+    /// Set of principals that are frozen at the principal level.
+    frozen_principals: std::collections::BTreeSet<Principal>,
     #[serde(default)]
-    /// Maps principals to (block_index, is_frozen) of the latest principal-level action.
-    principal_freeze_status: std::collections::BTreeMap<Principal, (u64, bool)>,
+    /// Account-level freeze overrides. An entry exists only when it differs
+    /// from or postdates the principal-level state for that account's owner.
+    account_freeze_overrides: std::collections::BTreeMap<Account, bool>,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize, Serialize)]
@@ -730,8 +731,8 @@ impl Ledger {
             token_type: wasm_token_type(),
             paused: false,
             deactivated: false,
-            account_freeze_status: std::collections::BTreeMap::new(),
-            principal_freeze_status: std::collections::BTreeMap::new(),
+            frozen_principals: std::collections::BTreeSet::new(),
+            account_freeze_overrides: std::collections::BTreeMap::new(),
         };
 
         if ledger.fee_collector.as_ref().map(|fc| fc.fee_collector) == Some(ledger.minting_account)
@@ -891,77 +892,72 @@ impl Ledger {
         self.deactivated = deactivated;
     }
 
-    /// Returns true if the latest account-level action was a freeze.
+    /// Returns true if the account has an explicit account-level freeze override set to true.
     pub fn is_account_frozen(&self, account: &Account) -> bool {
-        self.account_freeze_status
-            .get(account)
-            .is_some_and(|(_, frozen)| *frozen)
+        self.account_freeze_overrides.get(account) == Some(&true)
     }
 
-    /// Returns true if the latest principal-level action was a freeze.
+    /// Returns true if the principal is frozen at the principal level.
     pub fn is_principal_frozen(&self, principal: &Principal) -> bool {
-        self.principal_freeze_status
-            .get(principal)
-            .is_some_and(|(_, frozen)| *frozen)
+        self.frozen_principals.contains(principal)
     }
 
-    /// Returns true if the account is effectively frozen under ICRC-123
-    /// latest-action-wins semantics: the most recent freeze/unfreeze block
-    /// affecting this account (at either account or principal level) determines
-    /// the effective status.
+    /// Returns true if the account is effectively frozen: an account-level
+    /// override takes precedence if present, otherwise the principal-level
+    /// state applies.
     pub fn is_effectively_frozen(&self, account: &Account) -> bool {
-        let acct = self.account_freeze_status.get(account).copied();
-        let princ = self.principal_freeze_status.get(&account.owner).copied();
-        match (acct, princ) {
-            (Some((a_idx, a_frozen)), Some((p_idx, p_frozen))) => {
-                if a_idx > p_idx {
-                    a_frozen
-                } else {
-                    p_frozen
-                }
-            }
-            (Some((_, frozen)), None) => frozen,
-            (None, Some((_, frozen))) => frozen,
-            (None, None) => false,
+        match self.account_freeze_overrides.get(account) {
+            Some(&frozen) => frozen,
+            None => self.frozen_principals.contains(&account.owner),
         }
     }
 
-    pub fn freeze_account(&mut self, account: Account, block_idx: u64) {
-        self.account_freeze_status
-            .insert(account, (block_idx, true));
+    pub fn freeze_account(&mut self, account: Account) {
+        self.account_freeze_overrides.insert(account, true);
     }
 
-    pub fn unfreeze_account(&mut self, account: &Account, block_idx: u64) {
-        self.account_freeze_status
-            .insert(*account, (block_idx, false));
+    pub fn unfreeze_account(&mut self, account: &Account) {
+        if self.frozen_principals.contains(&account.owner) {
+            // Principal is frozen — insert an exception override.
+            self.account_freeze_overrides.insert(*account, false);
+        } else {
+            // Principal is not frozen — remove override (if any).
+            self.account_freeze_overrides.remove(account);
+        }
     }
 
-    pub fn freeze_principal(&mut self, principal: Principal, block_idx: u64) {
-        self.principal_freeze_status
-            .insert(principal, (block_idx, true));
+    pub fn freeze_principal(&mut self, principal: Principal) {
+        self.frozen_principals.insert(principal);
+        self.remove_account_overrides_for_principal(&principal);
     }
 
-    pub fn unfreeze_principal(&mut self, principal: &Principal, block_idx: u64) {
-        self.principal_freeze_status
-            .insert(*principal, (block_idx, false));
+    pub fn unfreeze_principal(&mut self, principal: &Principal) {
+        self.frozen_principals.remove(principal);
+        self.remove_account_overrides_for_principal(principal);
     }
 
-    /// Lists accounts whose latest account-level action was a freeze.
+    /// Removes all account-level freeze overrides for the given principal.
+    fn remove_account_overrides_for_principal(&mut self, principal: &Principal) {
+        self.account_freeze_overrides
+            .retain(|account, _| account.owner != *principal);
+    }
+
+    /// Lists accounts that have an explicit account-level freeze override set to true.
     pub fn list_frozen_accounts(&self, start_after: Option<&Account>, max: usize) -> Vec<Account> {
         use std::ops::Bound;
         let iter = match start_after {
             Some(start) => self
-                .account_freeze_status
+                .account_freeze_overrides
                 .range((Bound::Excluded(*start), Bound::Unbounded)),
-            None => self.account_freeze_status.range(..),
+            None => self.account_freeze_overrides.range(..),
         };
-        iter.filter(|(_, (_, frozen))| *frozen)
+        iter.filter(|(_, frozen)| **frozen)
             .take(max)
             .map(|(k, _)| *k)
             .collect()
     }
 
-    /// Lists principals whose latest principal-level action was a freeze.
+    /// Lists principals that are frozen at the principal level.
     pub fn list_frozen_principals(
         &self,
         start_after: Option<&Principal>,
@@ -970,14 +966,11 @@ impl Ledger {
         use std::ops::Bound;
         let iter = match start_after {
             Some(start) => self
-                .principal_freeze_status
+                .frozen_principals
                 .range((Bound::Excluded(*start), Bound::Unbounded)),
-            None => self.principal_freeze_status.range(..),
+            None => self.frozen_principals.range(..),
         };
-        iter.filter(|(_, (_, frozen))| *frozen)
-            .take(max)
-            .map(|(k, _)| *k)
-            .collect()
+        iter.take(max).copied().collect()
     }
 
     pub fn metadata(&self) -> Vec<(MetadataKey, Value)> {

--- a/rs/ledger_suite/icrc1/ledger/src/lib.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/lib.rs
@@ -597,9 +597,11 @@ pub struct Ledger {
     deactivated: bool,
 
     #[serde(default)]
-    frozen_accounts: std::collections::BTreeSet<Account>,
+    /// Maps accounts to (block_index, is_frozen) of the latest account-level action.
+    account_freeze_status: std::collections::BTreeMap<Account, (u64, bool)>,
     #[serde(default)]
-    frozen_principals: std::collections::BTreeSet<Principal>,
+    /// Maps principals to (block_index, is_frozen) of the latest principal-level action.
+    principal_freeze_status: std::collections::BTreeMap<Principal, (u64, bool)>,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize, Serialize)]
@@ -728,8 +730,8 @@ impl Ledger {
             token_type: wasm_token_type(),
             paused: false,
             deactivated: false,
-            frozen_accounts: std::collections::BTreeSet::new(),
-            frozen_principals: std::collections::BTreeSet::new(),
+            account_freeze_status: std::collections::BTreeMap::new(),
+            principal_freeze_status: std::collections::BTreeMap::new(),
         };
 
         if ledger.fee_collector.as_ref().map(|fc| fc.fee_collector) == Some(ledger.minting_account)
@@ -889,46 +891,77 @@ impl Ledger {
         self.deactivated = deactivated;
     }
 
+    /// Returns true if the latest account-level action was a freeze.
     pub fn is_account_frozen(&self, account: &Account) -> bool {
-        self.frozen_accounts.contains(account)
+        self.account_freeze_status
+            .get(account)
+            .is_some_and(|(_, frozen)| *frozen)
     }
 
+    /// Returns true if the latest principal-level action was a freeze.
     pub fn is_principal_frozen(&self, principal: &Principal) -> bool {
-        self.frozen_principals.contains(principal)
+        self.principal_freeze_status
+            .get(principal)
+            .is_some_and(|(_, frozen)| *frozen)
     }
 
-    /// Returns true if the account is directly frozen or its owner principal is frozen.
+    /// Returns true if the account is effectively frozen under ICRC-123
+    /// latest-action-wins semantics: the most recent freeze/unfreeze block
+    /// affecting this account (at either account or principal level) determines
+    /// the effective status.
     pub fn is_effectively_frozen(&self, account: &Account) -> bool {
-        self.frozen_accounts.contains(account) || self.frozen_principals.contains(&account.owner)
+        let acct = self.account_freeze_status.get(account).copied();
+        let princ = self.principal_freeze_status.get(&account.owner).copied();
+        match (acct, princ) {
+            (Some((a_idx, a_frozen)), Some((p_idx, p_frozen))) => {
+                if a_idx > p_idx {
+                    a_frozen
+                } else {
+                    p_frozen
+                }
+            }
+            (Some((_, frozen)), None) => frozen,
+            (None, Some((_, frozen))) => frozen,
+            (None, None) => false,
+        }
     }
 
-    pub fn freeze_account(&mut self, account: Account) {
-        self.frozen_accounts.insert(account);
+    pub fn freeze_account(&mut self, account: Account, block_idx: u64) {
+        self.account_freeze_status
+            .insert(account, (block_idx, true));
     }
 
-    pub fn unfreeze_account(&mut self, account: &Account) {
-        self.frozen_accounts.remove(account);
+    pub fn unfreeze_account(&mut self, account: &Account, block_idx: u64) {
+        self.account_freeze_status
+            .insert(*account, (block_idx, false));
     }
 
-    pub fn freeze_principal(&mut self, principal: Principal) {
-        self.frozen_principals.insert(principal);
+    pub fn freeze_principal(&mut self, principal: Principal, block_idx: u64) {
+        self.principal_freeze_status
+            .insert(principal, (block_idx, true));
     }
 
-    pub fn unfreeze_principal(&mut self, principal: &Principal) {
-        self.frozen_principals.remove(principal);
+    pub fn unfreeze_principal(&mut self, principal: &Principal, block_idx: u64) {
+        self.principal_freeze_status
+            .insert(*principal, (block_idx, false));
     }
 
+    /// Lists accounts whose latest account-level action was a freeze.
     pub fn list_frozen_accounts(&self, start_after: Option<&Account>, max: usize) -> Vec<Account> {
         use std::ops::Bound;
         let iter = match start_after {
             Some(start) => self
-                .frozen_accounts
+                .account_freeze_status
                 .range((Bound::Excluded(*start), Bound::Unbounded)),
-            None => self.frozen_accounts.range(..),
+            None => self.account_freeze_status.range(..),
         };
-        iter.take(max).copied().collect()
+        iter.filter(|(_, (_, frozen))| *frozen)
+            .take(max)
+            .map(|(k, _)| *k)
+            .collect()
     }
 
+    /// Lists principals whose latest principal-level action was a freeze.
     pub fn list_frozen_principals(
         &self,
         start_after: Option<&Principal>,
@@ -937,11 +970,14 @@ impl Ledger {
         use std::ops::Bound;
         let iter = match start_after {
             Some(start) => self
-                .frozen_principals
+                .principal_freeze_status
                 .range((Bound::Excluded(*start), Bound::Unbounded)),
-            None => self.frozen_principals.range(..),
+            None => self.principal_freeze_status.range(..),
         };
-        iter.take(max).copied().collect()
+        iter.filter(|(_, (_, frozen))| *frozen)
+            .take(max)
+            .map(|(k, _)| *k)
+            .collect()
     }
 
     pub fn metadata(&self) -> Vec<(MetadataKey, Value)> {

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -1295,7 +1295,7 @@ fn icrc153_freeze_account_not_async(
                     message: format!("{other:?}"),
                 },
             })?;
-        ledger.freeze_account(arg.account, block_idx);
+        ledger.freeze_account(arg.account);
         Ok(block_idx)
     })?;
     Ok(block_idx)
@@ -1353,7 +1353,7 @@ fn icrc153_unfreeze_account_not_async(
                     message: format!("{other:?}"),
                 },
             })?;
-        ledger.unfreeze_account(&arg.account, block_idx);
+        ledger.unfreeze_account(&arg.account);
         Ok(block_idx)
     })?;
     Ok(block_idx)
@@ -1416,7 +1416,7 @@ fn icrc153_freeze_principal_not_async(
                     message: format!("{other:?}"),
                 },
             })?;
-        ledger.freeze_principal(arg.principal, block_idx);
+        ledger.freeze_principal(arg.principal);
         Ok(block_idx)
     })?;
     Ok(block_idx)
@@ -1474,7 +1474,7 @@ fn icrc153_unfreeze_principal_not_async(
                     message: format!("{other:?}"),
                 },
             })?;
-        ledger.unfreeze_principal(&arg.principal, block_idx);
+        ledger.unfreeze_principal(&arg.principal);
         Ok(block_idx)
     })?;
     Ok(block_idx)

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -1295,7 +1295,7 @@ fn icrc153_freeze_account_not_async(
                     message: format!("{other:?}"),
                 },
             })?;
-        ledger.freeze_account(arg.account);
+        ledger.freeze_account(arg.account, block_idx);
         Ok(block_idx)
     })?;
     Ok(block_idx)
@@ -1358,7 +1358,7 @@ fn icrc153_unfreeze_account_not_async(
                     message: format!("{other:?}"),
                 },
             })?;
-        ledger.unfreeze_account(&arg.account);
+        ledger.unfreeze_account(&arg.account, block_idx);
         Ok(block_idx)
     })?;
     Ok(block_idx)
@@ -1421,7 +1421,7 @@ fn icrc153_freeze_principal_not_async(
                     message: format!("{other:?}"),
                 },
             })?;
-        ledger.freeze_principal(arg.principal);
+        ledger.freeze_principal(arg.principal, block_idx);
         Ok(block_idx)
     })?;
     Ok(block_idx)
@@ -1484,7 +1484,7 @@ fn icrc153_unfreeze_principal_not_async(
                     message: format!("{other:?}"),
                 },
             })?;
-        ledger.unfreeze_principal(&arg.principal);
+        ledger.unfreeze_principal(&arg.principal, block_idx);
         Ok(block_idx)
     })?;
     Ok(block_idx)

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -1257,6 +1257,11 @@ fn icrc153_freeze_account_not_async(
             message: "caller is not a controller".to_string(),
         });
     }
+    if arg.account.owner == Principal::anonymous() {
+        return Err(FreezeAccountError::InvalidAccount {
+            message: "cannot freeze the anonymous principal's account".to_string(),
+        });
+    }
     let block_idx = Access::with_ledger_mut(|ledger| {
         if ledger.is_deactivated() {
             return Err(FreezeAccountError::GenericError {
@@ -1311,6 +1316,11 @@ fn icrc153_unfreeze_account_not_async(
     if !ic_cdk::api::is_controller(&caller) {
         return Err(UnfreezeAccountError::Unauthorized {
             message: "caller is not a controller".to_string(),
+        });
+    }
+    if arg.account.owner == Principal::anonymous() {
+        return Err(UnfreezeAccountError::InvalidAccount {
+            message: "cannot unfreeze the anonymous principal's account".to_string(),
         });
     }
     let block_idx = Access::with_ledger_mut(|ledger| {
@@ -1371,6 +1381,11 @@ fn icrc153_freeze_principal_not_async(
             message: "caller is not a controller".to_string(),
         });
     }
+    if arg.principal == Principal::anonymous() {
+        return Err(FreezePrincipalError::InvalidPrincipal {
+            message: "cannot freeze the anonymous principal".to_string(),
+        });
+    }
     let block_idx = Access::with_ledger_mut(|ledger| {
         if ledger.is_deactivated() {
             return Err(FreezePrincipalError::GenericError {
@@ -1427,6 +1442,11 @@ fn icrc153_unfreeze_principal_not_async(
     if !ic_cdk::api::is_controller(&caller) {
         return Err(UnfreezePrincipalError::Unauthorized {
             message: "caller is not a controller".to_string(),
+        });
+    }
+    if arg.principal == Principal::anonymous() {
+        return Err(UnfreezePrincipalError::InvalidPrincipal {
+            message: "cannot unfreeze the anonymous principal".to_string(),
         });
     }
     let block_idx = Access::with_ledger_mut(|ledger| {

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -1330,11 +1330,6 @@ fn icrc153_unfreeze_account_not_async(
                 message: "ledger is deactivated".to_string(),
             });
         }
-        if !ledger.is_account_frozen(&arg.account) {
-            return Err(UnfreezeAccountError::NotFrozen {
-                message: format!("account {} is not frozen", arg.account),
-            });
-        }
         let now = TimeStamp::from_nanos_since_unix_epoch(ic_cdk::api::time());
         let tx = Transaction {
             operation: Operation::UnfreezeAccount {
@@ -1454,11 +1449,6 @@ fn icrc153_unfreeze_principal_not_async(
             return Err(UnfreezePrincipalError::GenericError {
                 error_code: Nat::from(0u64),
                 message: "ledger is deactivated".to_string(),
-            });
-        }
-        if !ledger.is_principal_frozen(&arg.principal) {
-            return Err(UnfreezePrincipalError::NotFrozen {
-                message: format!("principal {} is not frozen", arg.principal),
             });
         }
         let now = TimeStamp::from_nanos_since_unix_epoch(ic_cdk::api::time());

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -42,7 +42,17 @@ use icrc_ledger_types::icrc103::get_allowances::{
     Allowances, GetAllowancesArgs, GetAllowancesError,
 };
 use icrc_ledger_types::icrc106::errors::Icrc106Error;
+use icrc_ledger_types::icrc123::schema::{
+    MTHD_153_FREEZE_ACCOUNT, MTHD_153_FREEZE_PRINCIPAL, MTHD_153_UNFREEZE_ACCOUNT,
+    MTHD_153_UNFREEZE_PRINCIPAL,
+};
 use icrc_ledger_types::icrc124::schema::{MTHD_154_DEACTIVATE, MTHD_154_PAUSE, MTHD_154_UNPAUSE};
+use icrc_ledger_types::icrc153::{
+    FreezeAccountArgs, FreezeAccountError, FreezePrincipalArgs, FreezePrincipalError,
+    FrozenAccountsRequest, FrozenAccountsResponse, FrozenPrincipalsRequest,
+    FrozenPrincipalsResponse, UnfreezeAccountArgs, UnfreezeAccountError, UnfreezePrincipalArgs,
+    UnfreezePrincipalError,
+};
 use icrc_ledger_types::icrc154::{
     DeactivateArgs, DeactivateError, PauseArgs, PauseError, UnpauseArgs, UnpauseError,
 };
@@ -685,6 +695,18 @@ fn check_not_paused_or_deactivated() -> Result<(), String> {
     })
 }
 
+fn check_not_frozen(sender: &Account, recipient: &Account) -> Result<(), String> {
+    Access::with_ledger(|ledger| {
+        if ledger.is_effectively_frozen(sender) {
+            return Err(format!("sender account {} is frozen", sender));
+        }
+        if ledger.is_effectively_frozen(recipient) {
+            return Err(format!("recipient account {} is frozen", recipient));
+        }
+        Ok(())
+    })
+}
+
 #[update]
 async fn icrc1_transfer(arg: TransferArg) -> Result<Nat, TransferError> {
     check_not_paused_or_deactivated().map_err(|msg| TransferError::GenericError {
@@ -695,6 +717,10 @@ async fn icrc1_transfer(arg: TransferArg) -> Result<Nat, TransferError> {
         owner: ic_cdk::api::caller(),
         subaccount: arg.from_subaccount,
     };
+    check_not_frozen(&from_account, &arg.to).map_err(|msg| TransferError::GenericError {
+        error_code: Nat::from(0u64),
+        message: msg,
+    })?;
     execute_transfer(
         from_account,
         arg.to,
@@ -718,6 +744,10 @@ async fn icrc1_transfer(arg: TransferArg) -> Result<Nat, TransferError> {
 #[update]
 async fn icrc2_transfer_from(arg: TransferFromArgs) -> Result<Nat, TransferFromError> {
     check_not_paused_or_deactivated().map_err(|msg| TransferFromError::GenericError {
+        error_code: Nat::from(0u64),
+        message: msg,
+    })?;
+    check_not_frozen(&arg.from, &arg.to).map_err(|msg| TransferFromError::GenericError {
         error_code: Nat::from(0u64),
         message: msg,
     })?;
@@ -803,6 +833,10 @@ fn supported_standards() -> Vec<StandardRecord> {
         StandardRecord {
             name: "ICRC-154".to_string(),
             url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-154.md".to_string(),
+        },
+        StandardRecord {
+            name: "ICRC-153".to_string(),
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-153.md".to_string(),
         },
     ];
     standards
@@ -915,6 +949,22 @@ async fn icrc2_approve(arg: ApproveArgs) -> Result<Nat, ApproveError> {
         error_code: Nat::from(0u64),
         message: msg,
     })?;
+    {
+        let from = Account {
+            owner: ic_cdk::api::caller(),
+            subaccount: arg.from_subaccount,
+        };
+        // For approve, check the account granting the approval is not frozen.
+        Access::with_ledger(|ledger| {
+            if ledger.is_effectively_frozen(&from) {
+                return Err(ApproveError::GenericError {
+                    error_code: Nat::from(0u64),
+                    message: format!("account {} is frozen", from),
+                });
+            }
+            Ok(())
+        })?;
+    }
     let block_idx = icrc2_approve_not_async(ic_cdk::api::caller(), arg)?;
 
     // NB. we need to set the certified data before the first async call to make sure that the
@@ -997,6 +1047,22 @@ fn icrc3_supported_block_types() -> Vec<icrc_ledger_types::icrc3::blocks::Suppor
         SupportedBlockType {
             block_type: "124deactivate".to_string(),
             url: "https://github.com/dfinity/ICRC/pull/135".to_string(),
+        },
+        SupportedBlockType {
+            block_type: "123freezeaccount".to_string(),
+            url: "https://github.com/dfinity/ICRC/pull/123".to_string(),
+        },
+        SupportedBlockType {
+            block_type: "123unfreezeaccount".to_string(),
+            url: "https://github.com/dfinity/ICRC/pull/123".to_string(),
+        },
+        SupportedBlockType {
+            block_type: "123freezeprincipal".to_string(),
+            url: "https://github.com/dfinity/ICRC/pull/123".to_string(),
+        },
+        SupportedBlockType {
+            block_type: "123unfreezeprincipal".to_string(),
+            url: "https://github.com/dfinity/ICRC/pull/123".to_string(),
         },
     ]
 }
@@ -1178,6 +1244,276 @@ fn icrc154_is_paused() -> bool {
 #[query]
 fn icrc154_is_deactivated() -> bool {
     Access::with_ledger(|ledger| ledger.is_deactivated())
+}
+
+// ---- ICRC-153 Freeze/Unfreeze endpoints ----
+
+fn icrc153_freeze_account_not_async(
+    caller: Principal,
+    arg: FreezeAccountArgs,
+) -> Result<u64, FreezeAccountError> {
+    if !ic_cdk::api::is_controller(&caller) {
+        return Err(FreezeAccountError::Unauthorized {
+            message: "caller is not a controller".to_string(),
+        });
+    }
+    let block_idx = Access::with_ledger_mut(|ledger| {
+        if ledger.is_deactivated() {
+            return Err(FreezeAccountError::GenericError {
+                error_code: Nat::from(0u64),
+                message: "ledger is deactivated".to_string(),
+            });
+        }
+        if ledger.is_account_frozen(&arg.account) {
+            return Err(FreezeAccountError::AlreadyFrozen {
+                message: format!("account {} is already frozen", arg.account),
+            });
+        }
+        let now = TimeStamp::from_nanos_since_unix_epoch(ic_cdk::api::time());
+        let tx = Transaction {
+            operation: Operation::FreezeAccount {
+                account: arg.account,
+                caller: Some(caller),
+                mthd: Some(MTHD_153_FREEZE_ACCOUNT.to_string()),
+                reason: arg.reason,
+            },
+            created_at_time: Some(arg.created_at_time),
+            memo: None,
+        };
+        let (block_idx, _) =
+            apply_transaction(ledger, tx, now, Tokens::zero()).map_err(|err| match err {
+                CoreTransferError::TxDuplicate { duplicate_of } => FreezeAccountError::Duplicate {
+                    duplicate_of: Nat::from(duplicate_of),
+                },
+                other => FreezeAccountError::GenericError {
+                    error_code: Nat::from(0u64),
+                    message: format!("{other:?}"),
+                },
+            })?;
+        ledger.freeze_account(arg.account);
+        Ok(block_idx)
+    })?;
+    Ok(block_idx)
+}
+
+#[update]
+async fn icrc153_freeze_account(arg: FreezeAccountArgs) -> Result<Nat, FreezeAccountError> {
+    let block_idx = icrc153_freeze_account_not_async(ic_cdk::api::caller(), arg)?;
+    ic_cdk::api::set_certified_data(&Access::with_ledger(Ledger::root_hash));
+    archive_blocks::<Access>(&LOG, MAX_MESSAGE_SIZE).await;
+    Ok(Nat::from(block_idx))
+}
+
+fn icrc153_unfreeze_account_not_async(
+    caller: Principal,
+    arg: UnfreezeAccountArgs,
+) -> Result<u64, UnfreezeAccountError> {
+    if !ic_cdk::api::is_controller(&caller) {
+        return Err(UnfreezeAccountError::Unauthorized {
+            message: "caller is not a controller".to_string(),
+        });
+    }
+    let block_idx = Access::with_ledger_mut(|ledger| {
+        if ledger.is_deactivated() {
+            return Err(UnfreezeAccountError::GenericError {
+                error_code: Nat::from(0u64),
+                message: "ledger is deactivated".to_string(),
+            });
+        }
+        if !ledger.is_account_frozen(&arg.account) {
+            return Err(UnfreezeAccountError::NotFrozen {
+                message: format!("account {} is not frozen", arg.account),
+            });
+        }
+        let now = TimeStamp::from_nanos_since_unix_epoch(ic_cdk::api::time());
+        let tx = Transaction {
+            operation: Operation::UnfreezeAccount {
+                account: arg.account,
+                caller: Some(caller),
+                mthd: Some(MTHD_153_UNFREEZE_ACCOUNT.to_string()),
+                reason: arg.reason,
+            },
+            created_at_time: Some(arg.created_at_time),
+            memo: None,
+        };
+        let (block_idx, _) =
+            apply_transaction(ledger, tx, now, Tokens::zero()).map_err(|err| match err {
+                CoreTransferError::TxDuplicate { duplicate_of } => {
+                    UnfreezeAccountError::Duplicate {
+                        duplicate_of: Nat::from(duplicate_of),
+                    }
+                }
+                other => UnfreezeAccountError::GenericError {
+                    error_code: Nat::from(0u64),
+                    message: format!("{other:?}"),
+                },
+            })?;
+        ledger.unfreeze_account(&arg.account);
+        Ok(block_idx)
+    })?;
+    Ok(block_idx)
+}
+
+#[update]
+async fn icrc153_unfreeze_account(arg: UnfreezeAccountArgs) -> Result<Nat, UnfreezeAccountError> {
+    let block_idx = icrc153_unfreeze_account_not_async(ic_cdk::api::caller(), arg)?;
+    ic_cdk::api::set_certified_data(&Access::with_ledger(Ledger::root_hash));
+    archive_blocks::<Access>(&LOG, MAX_MESSAGE_SIZE).await;
+    Ok(Nat::from(block_idx))
+}
+
+fn icrc153_freeze_principal_not_async(
+    caller: Principal,
+    arg: FreezePrincipalArgs,
+) -> Result<u64, FreezePrincipalError> {
+    if !ic_cdk::api::is_controller(&caller) {
+        return Err(FreezePrincipalError::Unauthorized {
+            message: "caller is not a controller".to_string(),
+        });
+    }
+    let block_idx = Access::with_ledger_mut(|ledger| {
+        if ledger.is_deactivated() {
+            return Err(FreezePrincipalError::GenericError {
+                error_code: Nat::from(0u64),
+                message: "ledger is deactivated".to_string(),
+            });
+        }
+        if ledger.is_principal_frozen(&arg.principal) {
+            return Err(FreezePrincipalError::AlreadyFrozen {
+                message: format!("principal {} is already frozen", arg.principal),
+            });
+        }
+        let now = TimeStamp::from_nanos_since_unix_epoch(ic_cdk::api::time());
+        let tx = Transaction {
+            operation: Operation::FreezePrincipal {
+                principal: arg.principal,
+                caller: Some(caller),
+                mthd: Some(MTHD_153_FREEZE_PRINCIPAL.to_string()),
+                reason: arg.reason,
+            },
+            created_at_time: Some(arg.created_at_time),
+            memo: None,
+        };
+        let (block_idx, _) =
+            apply_transaction(ledger, tx, now, Tokens::zero()).map_err(|err| match err {
+                CoreTransferError::TxDuplicate { duplicate_of } => {
+                    FreezePrincipalError::Duplicate {
+                        duplicate_of: Nat::from(duplicate_of),
+                    }
+                }
+                other => FreezePrincipalError::GenericError {
+                    error_code: Nat::from(0u64),
+                    message: format!("{other:?}"),
+                },
+            })?;
+        ledger.freeze_principal(arg.principal);
+        Ok(block_idx)
+    })?;
+    Ok(block_idx)
+}
+
+#[update]
+async fn icrc153_freeze_principal(arg: FreezePrincipalArgs) -> Result<Nat, FreezePrincipalError> {
+    let block_idx = icrc153_freeze_principal_not_async(ic_cdk::api::caller(), arg)?;
+    ic_cdk::api::set_certified_data(&Access::with_ledger(Ledger::root_hash));
+    archive_blocks::<Access>(&LOG, MAX_MESSAGE_SIZE).await;
+    Ok(Nat::from(block_idx))
+}
+
+fn icrc153_unfreeze_principal_not_async(
+    caller: Principal,
+    arg: UnfreezePrincipalArgs,
+) -> Result<u64, UnfreezePrincipalError> {
+    if !ic_cdk::api::is_controller(&caller) {
+        return Err(UnfreezePrincipalError::Unauthorized {
+            message: "caller is not a controller".to_string(),
+        });
+    }
+    let block_idx = Access::with_ledger_mut(|ledger| {
+        if ledger.is_deactivated() {
+            return Err(UnfreezePrincipalError::GenericError {
+                error_code: Nat::from(0u64),
+                message: "ledger is deactivated".to_string(),
+            });
+        }
+        if !ledger.is_principal_frozen(&arg.principal) {
+            return Err(UnfreezePrincipalError::NotFrozen {
+                message: format!("principal {} is not frozen", arg.principal),
+            });
+        }
+        let now = TimeStamp::from_nanos_since_unix_epoch(ic_cdk::api::time());
+        let tx = Transaction {
+            operation: Operation::UnfreezePrincipal {
+                principal: arg.principal,
+                caller: Some(caller),
+                mthd: Some(MTHD_153_UNFREEZE_PRINCIPAL.to_string()),
+                reason: arg.reason,
+            },
+            created_at_time: Some(arg.created_at_time),
+            memo: None,
+        };
+        let (block_idx, _) =
+            apply_transaction(ledger, tx, now, Tokens::zero()).map_err(|err| match err {
+                CoreTransferError::TxDuplicate { duplicate_of } => {
+                    UnfreezePrincipalError::Duplicate {
+                        duplicate_of: Nat::from(duplicate_of),
+                    }
+                }
+                other => UnfreezePrincipalError::GenericError {
+                    error_code: Nat::from(0u64),
+                    message: format!("{other:?}"),
+                },
+            })?;
+        ledger.unfreeze_principal(&arg.principal);
+        Ok(block_idx)
+    })?;
+    Ok(block_idx)
+}
+
+#[update]
+async fn icrc153_unfreeze_principal(
+    arg: UnfreezePrincipalArgs,
+) -> Result<Nat, UnfreezePrincipalError> {
+    let block_idx = icrc153_unfreeze_principal_not_async(ic_cdk::api::caller(), arg)?;
+    ic_cdk::api::set_certified_data(&Access::with_ledger(Ledger::root_hash));
+    archive_blocks::<Access>(&LOG, MAX_MESSAGE_SIZE).await;
+    Ok(Nat::from(block_idx))
+}
+
+#[query]
+fn icrc153_is_frozen_account(account: Account) -> bool {
+    Access::with_ledger(|ledger| ledger.is_effectively_frozen(&account))
+}
+
+#[query]
+fn icrc153_is_frozen_principal(principal: Principal) -> bool {
+    Access::with_ledger(|ledger| ledger.is_principal_frozen(&principal))
+}
+
+#[query]
+fn icrc153_list_frozen_accounts(req: FrozenAccountsRequest) -> FrozenAccountsResponse {
+    let max = req
+        .limit
+        .map(|n| n.0.try_into().unwrap_or(usize::MAX))
+        .unwrap_or(100usize);
+    let accounts =
+        Access::with_ledger(|ledger| ledger.list_frozen_accounts(req.start.as_ref(), max));
+    FrozenAccountsResponse {
+        frozen_accounts: accounts,
+    }
+}
+
+#[query]
+fn icrc153_list_frozen_principals(req: FrozenPrincipalsRequest) -> FrozenPrincipalsResponse {
+    let max = req
+        .limit
+        .map(|n| n.0.try_into().unwrap_or(usize::MAX))
+        .unwrap_or(100usize);
+    let principals =
+        Access::with_ledger(|ledger| ledger.list_frozen_principals(req.start.as_ref(), max));
+    FrozenPrincipalsResponse {
+        frozen_principals: principals,
+    }
 }
 
 #[update]

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -813,6 +813,14 @@ fn test_freeze_principal_compositional() {
 }
 
 #[test]
+fn test_freeze_latest_action_wins() {
+    ic_ledger_suite_state_machine_tests::test_freeze_latest_action_wins(
+        ledger_wasm(),
+        encode_init_args,
+    );
+}
+
+#[test]
 fn test_freeze_deactivated_rejects() {
     ic_ledger_suite_state_machine_tests::test_freeze_deactivated_rejects(
         ledger_wasm(),

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -760,6 +760,74 @@ fn test_cycles_for_archive_creation_default_spawns_archive() {
     );
 }
 
+// ---- ICRC-153 Freeze/Unfreeze tests ----
+
+#[test]
+fn test_freeze_account_happy_path() {
+    ic_ledger_suite_state_machine_tests::test_freeze_account_happy_path(
+        ledger_wasm(),
+        encode_init_args,
+    );
+}
+
+#[test]
+fn test_freeze_principal_happy_path() {
+    ic_ledger_suite_state_machine_tests::test_freeze_principal_happy_path(
+        ledger_wasm(),
+        encode_init_args,
+    );
+}
+
+#[test]
+fn test_freeze_unauthorized() {
+    ic_ledger_suite_state_machine_tests::test_freeze_unauthorized(ledger_wasm(), encode_init_args);
+}
+
+#[test]
+fn test_freeze_already_frozen() {
+    ic_ledger_suite_state_machine_tests::test_freeze_already_frozen(
+        ledger_wasm(),
+        encode_init_args,
+    );
+}
+
+#[test]
+fn test_unfreeze_not_frozen() {
+    ic_ledger_suite_state_machine_tests::test_unfreeze_not_frozen(ledger_wasm(), encode_init_args);
+}
+
+#[test]
+fn test_freeze_guard_transfer() {
+    ic_ledger_suite_state_machine_tests::test_freeze_guard_transfer(
+        ledger_wasm(),
+        encode_init_args,
+    );
+}
+
+#[test]
+fn test_freeze_principal_compositional() {
+    ic_ledger_suite_state_machine_tests::test_freeze_principal_compositional(
+        ledger_wasm(),
+        encode_init_args,
+    );
+}
+
+#[test]
+fn test_freeze_deactivated_rejects() {
+    ic_ledger_suite_state_machine_tests::test_freeze_deactivated_rejects(
+        ledger_wasm(),
+        encode_init_args,
+    );
+}
+
+#[test]
+fn test_list_frozen_accounts_pagination() {
+    ic_ledger_suite_state_machine_tests::test_list_frozen_accounts_pagination(
+        ledger_wasm(),
+        encode_init_args,
+    );
+}
+
 mod metrics {
     use crate::{encode_init_args, encode_upgrade_args, ledger_wasm};
     use ic_ledger_suite_state_machine_tests::metrics::LedgerSuiteType;

--- a/rs/ledger_suite/icrc1/ledger/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/ledger/tests/tests.rs
@@ -792,8 +792,11 @@ fn test_freeze_already_frozen() {
 }
 
 #[test]
-fn test_unfreeze_not_frozen() {
-    ic_ledger_suite_state_machine_tests::test_unfreeze_not_frozen(ledger_wasm(), encode_init_args);
+fn test_unfreeze_not_frozen_succeeds() {
+    ic_ledger_suite_state_machine_tests::test_unfreeze_not_frozen_succeeds(
+        ledger_wasm(),
+        encode_init_args,
+    );
 }
 
 #[test]

--- a/rs/ledger_suite/icrc1/src/lib.rs
+++ b/rs/ledger_suite/icrc1/src/lib.rs
@@ -863,6 +863,18 @@ impl<Tokens: TokensType> BlockType for Block<Tokens> {
             Some(FeeCollector { block_index, .. }) => (None, block_index),
             None => (None, None),
         };
+        let btype = match &transaction.operation {
+            Operation::Pause { .. } => Some(TRANSACTION_124_PAUSE.to_string()),
+            Operation::Unpause { .. } => Some(TRANSACTION_124_UNPAUSE.to_string()),
+            Operation::Deactivate { .. } => Some(TRANSACTION_124_DEACTIVATE.to_string()),
+            Operation::FreezeAccount { .. } => Some(TRANSACTION_123_FREEZE_ACCOUNT.to_string()),
+            Operation::UnfreezeAccount { .. } => Some(TRANSACTION_123_UNFREEZE_ACCOUNT.to_string()),
+            Operation::FreezePrincipal { .. } => Some(TRANSACTION_123_FREEZE_PRINCIPAL.to_string()),
+            Operation::UnfreezePrincipal { .. } => {
+                Some(TRANSACTION_123_UNFREEZE_PRINCIPAL.to_string())
+            }
+            _ => None,
+        };
         Self {
             parent_hash,
             transaction,
@@ -870,7 +882,7 @@ impl<Tokens: TokensType> BlockType for Block<Tokens> {
             timestamp: timestamp.as_nanos_since_unix_epoch(),
             fee_collector,
             fee_collector_block_index,
-            btype: None,
+            btype,
         }
     }
 }

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -61,6 +61,12 @@ use icrc_ledger_types::icrc103::get_allowances::{Allowances, GetAllowancesArgs};
 use icrc_ledger_types::icrc106::errors::Icrc106Error;
 use icrc_ledger_types::icrc107;
 use icrc_ledger_types::icrc107::schema::{BTYPE_107, SET_FEE_COL_107};
+use icrc_ledger_types::icrc153::{
+    FreezeAccountArgs, FreezeAccountError, FreezePrincipalArgs, FreezePrincipalError,
+    FrozenAccountsRequest, FrozenAccountsResponse, FrozenPrincipalsRequest,
+    FrozenPrincipalsResponse, UnfreezeAccountArgs, UnfreezeAccountError, UnfreezePrincipalArgs,
+    UnfreezePrincipalError,
+};
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use proptest::prelude::*;
@@ -585,7 +591,8 @@ where
     assert_eq!(
         standards,
         vec![
-            "ICRC-1", "ICRC-10", "ICRC-103", "ICRC-106", "ICRC-154", "ICRC-2", "ICRC-21", "ICRC-3"
+            "ICRC-1", "ICRC-10", "ICRC-103", "ICRC-106", "ICRC-153", "ICRC-154", "ICRC-2",
+            "ICRC-21", "ICRC-3"
         ]
     );
 }
@@ -614,6 +621,22 @@ pub fn check_icrc3_supported_block_types_ext(
     supports_107: bool,
     supports_124: bool,
 ) {
+    check_icrc3_supported_block_types_ext2(
+        env,
+        canister_id,
+        supports_107,
+        supports_124,
+        supports_124,
+    )
+}
+
+pub fn check_icrc3_supported_block_types_ext2(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    supports_107: bool,
+    supports_124: bool,
+    supports_123: bool,
+) {
     let mut block_types = vec![];
     for supported_block_type in supported_block_types(env, canister_id) {
         block_types.push(supported_block_type.block_type);
@@ -624,6 +647,12 @@ pub fn check_icrc3_supported_block_types_ext(
         expected_block_types.push("124deactivate");
         expected_block_types.push("124pause");
         expected_block_types.push("124unpause");
+    }
+    if supports_123 {
+        expected_block_types.push("123freezeaccount");
+        expected_block_types.push("123freezeprincipal");
+        expected_block_types.push("123unfreezeaccount");
+        expected_block_types.push("123unfreezeprincipal");
     }
     if supports_107 {
         expected_block_types.push(BTYPE_107);
@@ -6107,4 +6136,642 @@ pub fn test_http_request_decoding_quota(env: &StateMachine, canister_id: Caniste
                 .description()
                 .contains("Decoding cost exceeds the limit")
     );
+}
+
+// ---- ICRC-153 Freeze/Unfreeze helpers ----
+
+fn freeze_account(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    caller: Principal,
+    account: Account,
+    created_at_time: u64,
+    reason: Option<String>,
+) -> Result<Nat, FreezeAccountError> {
+    Decode!(
+        &env.execute_ingress_as(
+            PrincipalId::from(caller),
+            canister_id,
+            "icrc153_freeze_account",
+            Encode!(&FreezeAccountArgs {
+                account,
+                reason,
+                created_at_time,
+            })
+            .unwrap(),
+        )
+        .expect("Failed to call icrc153_freeze_account")
+        .bytes(),
+        Result<Nat, FreezeAccountError>
+    )
+    .unwrap()
+}
+
+fn unfreeze_account(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    caller: Principal,
+    account: Account,
+    created_at_time: u64,
+    reason: Option<String>,
+) -> Result<Nat, UnfreezeAccountError> {
+    Decode!(
+        &env.execute_ingress_as(
+            PrincipalId::from(caller),
+            canister_id,
+            "icrc153_unfreeze_account",
+            Encode!(&UnfreezeAccountArgs {
+                account,
+                reason,
+                created_at_time,
+            })
+            .unwrap(),
+        )
+        .expect("Failed to call icrc153_unfreeze_account")
+        .bytes(),
+        Result<Nat, UnfreezeAccountError>
+    )
+    .unwrap()
+}
+
+fn freeze_principal_call(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    caller: Principal,
+    target: Principal,
+    created_at_time: u64,
+    reason: Option<String>,
+) -> Result<Nat, FreezePrincipalError> {
+    Decode!(
+        &env.execute_ingress_as(
+            PrincipalId::from(caller),
+            canister_id,
+            "icrc153_freeze_principal",
+            Encode!(&FreezePrincipalArgs {
+                principal: target,
+                reason,
+                created_at_time,
+            })
+            .unwrap(),
+        )
+        .expect("Failed to call icrc153_freeze_principal")
+        .bytes(),
+        Result<Nat, FreezePrincipalError>
+    )
+    .unwrap()
+}
+
+fn unfreeze_principal_call(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    caller: Principal,
+    target: Principal,
+    created_at_time: u64,
+    reason: Option<String>,
+) -> Result<Nat, UnfreezePrincipalError> {
+    Decode!(
+        &env.execute_ingress_as(
+            PrincipalId::from(caller),
+            canister_id,
+            "icrc153_unfreeze_principal",
+            Encode!(&UnfreezePrincipalArgs {
+                principal: target,
+                reason,
+                created_at_time,
+            })
+            .unwrap(),
+        )
+        .expect("Failed to call icrc153_unfreeze_principal")
+        .bytes(),
+        Result<Nat, UnfreezePrincipalError>
+    )
+    .unwrap()
+}
+
+fn is_frozen_account(env: &StateMachine, canister_id: CanisterId, account: Account) -> bool {
+    Decode!(
+        &env.query(
+            canister_id,
+            "icrc153_is_frozen_account",
+            Encode!(&account).unwrap(),
+        )
+        .expect("Failed to query icrc153_is_frozen_account")
+        .bytes(),
+        bool
+    )
+    .unwrap()
+}
+
+fn is_frozen_principal(env: &StateMachine, canister_id: CanisterId, principal: Principal) -> bool {
+    Decode!(
+        &env.query(
+            canister_id,
+            "icrc153_is_frozen_principal",
+            Encode!(&principal).unwrap(),
+        )
+        .expect("Failed to query icrc153_is_frozen_principal")
+        .bytes(),
+        bool
+    )
+    .unwrap()
+}
+
+fn list_frozen_accounts(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    start: Option<Account>,
+    limit: Option<u64>,
+) -> FrozenAccountsResponse {
+    Decode!(
+        &env.query(
+            canister_id,
+            "icrc153_list_frozen_accounts",
+            Encode!(&FrozenAccountsRequest {
+                start,
+                limit: limit.map(Nat::from),
+            })
+            .unwrap(),
+        )
+        .expect("Failed to query icrc153_list_frozen_accounts")
+        .bytes(),
+        FrozenAccountsResponse
+    )
+    .unwrap()
+}
+
+#[allow(dead_code)]
+fn list_frozen_principals(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    start: Option<Principal>,
+    limit: Option<u64>,
+) -> FrozenPrincipalsResponse {
+    Decode!(
+        &env.query(
+            canister_id,
+            "icrc153_list_frozen_principals",
+            Encode!(&FrozenPrincipalsRequest {
+                start,
+                limit: limit.map(Nat::from),
+            })
+            .unwrap(),
+        )
+        .expect("Failed to query icrc153_list_frozen_principals")
+        .bytes(),
+        FrozenPrincipalsResponse
+    )
+    .unwrap()
+}
+
+pub fn test_freeze_account_happy_path<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
+where
+    T: CandidType,
+{
+    let p1 = PrincipalId::new_user_test_id(1);
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![(Account::from(p1.0), 10_000_000)],
+    );
+    let controller = env
+        .canister_status(canister_id)
+        .unwrap()
+        .unwrap()
+        .controllers()[0];
+    let now = system_time_to_nanos(env.time());
+    let target_account = Account::from(p1.0);
+
+    // Freeze account
+    let result = freeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        target_account,
+        now,
+        Some("compliance".to_string()),
+    );
+    assert!(result.is_ok(), "freeze_account should succeed: {result:?}");
+
+    // Check it's frozen
+    assert!(is_frozen_account(&env, canister_id, target_account));
+    assert!(!is_frozen_principal(&env, canister_id, p1.0));
+
+    // Unfreeze account
+    let result = unfreeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        target_account,
+        now + 1,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "unfreeze_account should succeed: {result:?}"
+    );
+
+    // Check it's no longer frozen
+    assert!(!is_frozen_account(&env, canister_id, target_account));
+}
+
+pub fn test_freeze_principal_happy_path<T>(
+    ledger_wasm: Vec<u8>,
+    encode_init_args: fn(InitArgs) -> T,
+) where
+    T: CandidType,
+{
+    let p1 = PrincipalId::new_user_test_id(1);
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![(Account::from(p1.0), 10_000_000)],
+    );
+    let controller = env
+        .canister_status(canister_id)
+        .unwrap()
+        .unwrap()
+        .controllers()[0];
+    let now = system_time_to_nanos(env.time());
+
+    // Freeze principal
+    let result = freeze_principal_call(&env, canister_id, controller.0, p1.0, now, None);
+    assert!(
+        result.is_ok(),
+        "freeze_principal should succeed: {result:?}"
+    );
+
+    // Check principal is frozen
+    assert!(is_frozen_principal(&env, canister_id, p1.0));
+    // Account is effectively frozen (owner principal frozen)
+    assert!(is_frozen_account(&env, canister_id, Account::from(p1.0)));
+
+    // Unfreeze principal
+    let result = unfreeze_principal_call(&env, canister_id, controller.0, p1.0, now + 1, None);
+    assert!(
+        result.is_ok(),
+        "unfreeze_principal should succeed: {result:?}"
+    );
+
+    // Both should be unfrozen
+    assert!(!is_frozen_principal(&env, canister_id, p1.0));
+    assert!(!is_frozen_account(&env, canister_id, Account::from(p1.0)));
+}
+
+pub fn test_freeze_unauthorized<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
+where
+    T: CandidType,
+{
+    let p1 = PrincipalId::new_user_test_id(1);
+    let p2 = PrincipalId::new_user_test_id(2);
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![(Account::from(p1.0), 10_000_000)],
+    );
+
+    let now = system_time_to_nanos(env.time());
+
+    // Non-controller tries to freeze
+    let result = freeze_account(&env, canister_id, p2.0, Account::from(p1.0), now, None);
+    assert!(matches!(
+        result,
+        Err(FreezeAccountError::Unauthorized { .. })
+    ));
+
+    let result = freeze_principal_call(&env, canister_id, p2.0, p1.0, now + 1, None);
+    assert!(matches!(
+        result,
+        Err(FreezePrincipalError::Unauthorized { .. })
+    ));
+}
+
+pub fn test_freeze_already_frozen<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
+where
+    T: CandidType,
+{
+    let p1 = PrincipalId::new_user_test_id(1);
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![(Account::from(p1.0), 10_000_000)],
+    );
+    let controller = env
+        .canister_status(canister_id)
+        .unwrap()
+        .unwrap()
+        .controllers()[0];
+    let now = system_time_to_nanos(env.time());
+    let target = Account::from(p1.0);
+
+    // Freeze once
+    freeze_account(&env, canister_id, controller.0, target, now, None).unwrap();
+    // Freeze again -> AlreadyFrozen
+    let result = freeze_account(&env, canister_id, controller.0, target, now + 1, None);
+    assert!(matches!(
+        result,
+        Err(FreezeAccountError::AlreadyFrozen { .. })
+    ));
+
+    // Same for principal
+    freeze_principal_call(&env, canister_id, controller.0, p1.0, now + 2, None).unwrap();
+    let result = freeze_principal_call(&env, canister_id, controller.0, p1.0, now + 3, None);
+    assert!(matches!(
+        result,
+        Err(FreezePrincipalError::AlreadyFrozen { .. })
+    ));
+}
+
+pub fn test_unfreeze_not_frozen<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
+where
+    T: CandidType,
+{
+    let p1 = PrincipalId::new_user_test_id(1);
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![(Account::from(p1.0), 10_000_000)],
+    );
+    let controller = env
+        .canister_status(canister_id)
+        .unwrap()
+        .unwrap()
+        .controllers()[0];
+    let now = system_time_to_nanos(env.time());
+
+    let result = unfreeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        Account::from(p1.0),
+        now,
+        None,
+    );
+    assert!(matches!(
+        result,
+        Err(UnfreezeAccountError::NotFrozen { .. })
+    ));
+
+    let result = unfreeze_principal_call(&env, canister_id, controller.0, p1.0, now + 1, None);
+    assert!(matches!(
+        result,
+        Err(UnfreezePrincipalError::NotFrozen { .. })
+    ));
+}
+
+pub fn test_freeze_guard_transfer<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
+where
+    T: CandidType,
+{
+    let p1 = PrincipalId::new_user_test_id(1);
+    let p2 = PrincipalId::new_user_test_id(2);
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![
+            (Account::from(p1.0), 10_000_000),
+            (Account::from(p2.0), 10_000_000),
+        ],
+    );
+    let controller = env
+        .canister_status(canister_id)
+        .unwrap()
+        .unwrap()
+        .controllers()[0];
+    let now = system_time_to_nanos(env.time());
+
+    // Freeze p1's account
+    freeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        Account::from(p1.0),
+        now,
+        None,
+    )
+    .unwrap();
+
+    // p1 cannot send
+    let result = transfer(
+        &env,
+        canister_id,
+        Account::from(p1.0),
+        Account::from(p2.0),
+        1000,
+    );
+    assert!(
+        result.is_err(),
+        "frozen sender should not be able to transfer"
+    );
+
+    // p2 cannot send to frozen p1
+    let result = transfer(
+        &env,
+        canister_id,
+        Account::from(p2.0),
+        Account::from(p1.0),
+        1000,
+    );
+    assert!(result.is_err(), "transfer to frozen recipient should fail");
+
+    // Unfreeze p1
+    unfreeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        Account::from(p1.0),
+        now + 1,
+        None,
+    )
+    .unwrap();
+
+    // Now both can transfer
+    let result = transfer(
+        &env,
+        canister_id,
+        Account::from(p1.0),
+        Account::from(p2.0),
+        1000,
+    );
+    assert!(result.is_ok(), "unfrozen sender should be able to transfer");
+}
+
+pub fn test_freeze_principal_compositional<T>(
+    ledger_wasm: Vec<u8>,
+    encode_init_args: fn(InitArgs) -> T,
+) where
+    T: CandidType,
+{
+    let p1 = PrincipalId::new_user_test_id(1);
+    let p2 = PrincipalId::new_user_test_id(2);
+    let subaccount = [1u8; 32];
+    let p1_sub = Account {
+        owner: p1.0,
+        subaccount: Some(subaccount),
+    };
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![
+            (Account::from(p1.0), 10_000_000),
+            (p1_sub, 5_000_000),
+            (Account::from(p2.0), 10_000_000),
+        ],
+    );
+    let controller = env
+        .canister_status(canister_id)
+        .unwrap()
+        .unwrap()
+        .controllers()[0];
+    let now = system_time_to_nanos(env.time());
+
+    // Freeze principal p1
+    freeze_principal_call(&env, canister_id, controller.0, p1.0, now, None).unwrap();
+
+    // All of p1's accounts are effectively frozen
+    assert!(is_frozen_account(&env, canister_id, Account::from(p1.0)));
+    assert!(is_frozen_account(&env, canister_id, p1_sub));
+    // But not p2
+    assert!(!is_frozen_account(&env, canister_id, Account::from(p2.0)));
+
+    // p1 cannot transfer from any subaccount
+    let result = transfer(
+        &env,
+        canister_id,
+        Account::from(p1.0),
+        Account::from(p2.0),
+        1000,
+    );
+    assert!(result.is_err());
+
+    // Unfreeze principal -> all accounts unfrozen
+    unfreeze_principal_call(&env, canister_id, controller.0, p1.0, now + 1, None).unwrap();
+    assert!(!is_frozen_account(&env, canister_id, Account::from(p1.0)));
+    assert!(!is_frozen_account(&env, canister_id, p1_sub));
+
+    let result = transfer(
+        &env,
+        canister_id,
+        Account::from(p1.0),
+        Account::from(p2.0),
+        1000,
+    );
+    assert!(result.is_ok());
+}
+
+pub fn test_freeze_deactivated_rejects<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
+where
+    T: CandidType,
+{
+    use icrc_ledger_types::icrc154::DeactivateArgs;
+
+    let p1 = PrincipalId::new_user_test_id(1);
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![(Account::from(p1.0), 10_000_000)],
+    );
+    let controller = env
+        .canister_status(canister_id)
+        .unwrap()
+        .unwrap()
+        .controllers()[0];
+    let now = system_time_to_nanos(env.time());
+
+    // Deactivate ledger
+    let _: Result<Nat, icrc_ledger_types::icrc154::DeactivateError> = Decode!(
+        &env.execute_ingress_as(
+            PrincipalId::from(controller.0),
+            canister_id,
+            "icrc154_deactivate",
+            Encode!(&DeactivateArgs {
+                reason: None,
+                created_at_time: now,
+            })
+            .unwrap(),
+        )
+        .expect("Failed to call icrc154_deactivate")
+        .bytes(),
+        Result<Nat, icrc_ledger_types::icrc154::DeactivateError>
+    )
+    .unwrap();
+
+    // Freeze should fail with GenericError
+    let result = freeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        Account::from(p1.0),
+        now + 1,
+        None,
+    );
+    assert!(matches!(
+        result,
+        Err(FreezeAccountError::GenericError { .. })
+    ));
+}
+
+pub fn test_list_frozen_accounts_pagination<T>(
+    ledger_wasm: Vec<u8>,
+    encode_init_args: fn(InitArgs) -> T,
+) where
+    T: CandidType,
+{
+    let p1 = PrincipalId::new_user_test_id(1);
+    let p2 = PrincipalId::new_user_test_id(2);
+    let p3 = PrincipalId::new_user_test_id(3);
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![
+            (Account::from(p1.0), 10_000_000),
+            (Account::from(p2.0), 10_000_000),
+            (Account::from(p3.0), 10_000_000),
+        ],
+    );
+    let controller = env
+        .canister_status(canister_id)
+        .unwrap()
+        .unwrap()
+        .controllers()[0];
+    let now = system_time_to_nanos(env.time());
+
+    // Freeze all three
+    freeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        Account::from(p1.0),
+        now,
+        None,
+    )
+    .unwrap();
+    freeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        Account::from(p2.0),
+        now + 1,
+        None,
+    )
+    .unwrap();
+    freeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        Account::from(p3.0),
+        now + 2,
+        None,
+    )
+    .unwrap();
+
+    // List all
+    let resp = list_frozen_accounts(&env, canister_id, None, None);
+    assert_eq!(resp.frozen_accounts.len(), 3);
+
+    // Paginate with limit 1
+    let page1 = list_frozen_accounts(&env, canister_id, None, Some(1));
+    assert_eq!(page1.frozen_accounts.len(), 1);
+    let page2 = list_frozen_accounts(&env, canister_id, Some(page1.frozen_accounts[0]), Some(1));
+    assert_eq!(page2.frozen_accounts.len(), 1);
+    assert_ne!(page1.frozen_accounts[0], page2.frozen_accounts[0]);
 }

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -6466,8 +6466,12 @@ where
     ));
 }
 
-pub fn test_unfreeze_not_frozen<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
-where
+/// Unfreezing a non-frozen target must succeed (ICRC-123 latest-action-wins:
+/// the unfreeze block can lift account-level freezes at another level).
+pub fn test_unfreeze_not_frozen_succeeds<T>(
+    ledger_wasm: Vec<u8>,
+    encode_init_args: fn(InitArgs) -> T,
+) where
     T: CandidType,
 {
     let p1 = PrincipalId::new_user_test_id(1);
@@ -6491,16 +6495,16 @@ where
         now,
         None,
     );
-    assert!(matches!(
-        result,
-        Err(UnfreezeAccountError::NotFrozen { .. })
-    ));
+    assert!(
+        result.is_ok(),
+        "unfreeze_account on non-frozen account should succeed"
+    );
 
     let result = unfreeze_principal_call(&env, canister_id, controller.0, p1.0, now + 1, None);
-    assert!(matches!(
-        result,
-        Err(UnfreezePrincipalError::NotFrozen { .. })
-    ));
+    assert!(
+        result.is_ok(),
+        "unfreeze_principal on non-frozen principal should succeed"
+    );
 }
 
 pub fn test_freeze_guard_transfer<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -612,25 +612,10 @@ pub fn check_icrc3_supported_block_types(
     canister_id: CanisterId,
     supports_107: bool,
 ) {
-    check_icrc3_supported_block_types_ext(env, canister_id, supports_107, true)
+    check_icrc3_supported_block_types_ext(env, canister_id, supports_107, true, true)
 }
 
 pub fn check_icrc3_supported_block_types_ext(
-    env: &StateMachine,
-    canister_id: CanisterId,
-    supports_107: bool,
-    supports_124: bool,
-) {
-    check_icrc3_supported_block_types_ext2(
-        env,
-        canister_id,
-        supports_107,
-        supports_124,
-        supports_124,
-    )
-}
-
-pub fn check_icrc3_supported_block_types_ext2(
     env: &StateMachine,
     canister_id: CanisterId,
     supports_107: bool,

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -6643,6 +6643,109 @@ pub fn test_freeze_principal_compositional<T>(
     assert!(result.is_ok());
 }
 
+/// Tests ICRC-123 latest-action-wins semantics: a principal unfreeze lifts
+/// an earlier account-level freeze, and a subsequent account freeze re-freezes
+/// only that specific account.
+pub fn test_freeze_latest_action_wins<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
+where
+    T: CandidType,
+{
+    let p1 = PrincipalId::new_user_test_id(1);
+    let p2 = PrincipalId::new_user_test_id(2);
+    let p1_sub = Account {
+        owner: p1.0,
+        subaccount: Some([1u8; 32]),
+    };
+    let (env, canister_id) = setup(
+        ledger_wasm,
+        encode_init_args,
+        vec![
+            (Account::from(p1.0), 10_000_000),
+            (p1_sub, 5_000_000),
+            (Account::from(p2.0), 10_000_000),
+        ],
+    );
+    let controller = env
+        .canister_status(canister_id)
+        .unwrap()
+        .unwrap()
+        .controllers()[0];
+    let now = system_time_to_nanos(env.time());
+
+    // 1. Freeze account p1 (account-level, block N)
+    freeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        Account::from(p1.0),
+        now,
+        None,
+    )
+    .unwrap();
+    assert!(is_frozen_account(&env, canister_id, Account::from(p1.0)));
+
+    // 2. Freeze principal p1 (block N+1), then unfreeze principal (block N+2).
+    //    The principal unfreeze is the latest action affecting p1's accounts,
+    //    so it overrides the earlier account-level freeze.
+    freeze_principal_call(&env, canister_id, controller.0, p1.0, now + 1, None).unwrap();
+    unfreeze_principal_call(&env, canister_id, controller.0, p1.0, now + 2, None).unwrap();
+    assert!(
+        !is_frozen_account(&env, canister_id, Account::from(p1.0)),
+        "principal unfreeze should lift earlier account freeze (latest-action-wins)"
+    );
+
+    // p1 can transfer again
+    let result = transfer(
+        &env,
+        canister_id,
+        Account::from(p1.0),
+        Account::from(p2.0),
+        1000,
+    );
+    assert!(
+        result.is_ok(),
+        "account should be able to transfer after principal unfreeze lifts account freeze"
+    );
+
+    // 3. Freeze principal p1 (block N+3)
+    freeze_principal_call(&env, canister_id, controller.0, p1.0, now + 3, None).unwrap();
+    assert!(is_frozen_account(&env, canister_id, Account::from(p1.0)));
+    assert!(is_frozen_account(&env, canister_id, p1_sub));
+
+    // 4. Unfreeze specific account p1 (block N+4) — only the default account is unfrozen,
+    //    the subaccount is still frozen via the principal freeze at block N+3
+    unfreeze_account(
+        &env,
+        canister_id,
+        controller.0,
+        Account::from(p1.0),
+        now + 4,
+        None,
+    )
+    .unwrap();
+    assert!(
+        !is_frozen_account(&env, canister_id, Account::from(p1.0)),
+        "account unfreeze should lift principal freeze for that specific account"
+    );
+    assert!(
+        is_frozen_account(&env, canister_id, p1_sub),
+        "subaccount should still be frozen via principal freeze"
+    );
+
+    // Default account can transfer, subaccount cannot
+    let result = transfer(
+        &env,
+        canister_id,
+        Account::from(p1.0),
+        Account::from(p2.0),
+        1000,
+    );
+    assert!(result.is_ok());
+
+    let result = transfer(&env, canister_id, p1_sub, Account::from(p2.0), 1000);
+    assert!(result.is_err(), "subaccount should still be frozen");
+}
+
 pub fn test_freeze_deactivated_rejects<T>(ledger_wasm: Vec<u8>, encode_init_args: fn(InitArgs) -> T)
 where
     T: CandidType,


### PR DESCRIPTION
## Summary

- Add 8 endpoints: `icrc153_freeze_account`, `icrc153_unfreeze_account`, `icrc153_freeze_principal`, `icrc153_unfreeze_principal` and their query counterparts (`icrc153_frozen_accounts`, `icrc153_frozen_principals`, `icrc153_is_frozen_account`, `icrc153_is_frozen_principal`)
- Implement freeze guard that blocks transfers from/to frozen accounts/principals
- Add persistent `BTreeSet` storage for frozen accounts and principals
- Add comprehensive state machine tests for freeze/unfreeze flows

Stacked on #9556.

## Test plan

- [x] Ledger unit tests pass (`ledger_unit_test`, `ledger_unit_test_u256`)
- [x] Ledger canister tests pass (`ledger_canister_test`, `ledger_canister_test_u256`)
- [x] Ledger integration tests pass (`ledger_test`, `ledger_test_u256`)
- [x] Canbench tests pass (`canbench_u64_test`, `canbench_u256_test`)
- [x] All .did git tests pass (6 variants)
- [x] Upgrade/downgrade tests pass
- [x] Archive, index-ng, icrc1 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)