### PR TITLE
test: add //rs/tests/node:xfs_corruption_repair_test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18498,6 +18498,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "candid",
+ "chrono",
  "ic-agent",
  "ic-base-types",
  "ic-nns-constants",

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -7,28 +7,24 @@ DEVICE=/dev/mapper/store-shared--data
 echo "Checking if ${DEVICE} has a valid filesystem..."
 if ! blkid "${DEVICE}" >/dev/null 2>&1; then
     echo "No filesystem exists on ${DEVICE}, creating one..."
-    mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
+    mkfs.xfs -m crc=1,reflink=1 "${DEVICE}"
     exit 0
 fi
 
-echo "Filesystem exists on ${DEVICE}, running xfs_repair to check and repair if necessary..."
-# xfs_repair (without -L) is safe: it exits non-zero without modifying
-# anything when the journal is dirty but valid (normal after a crash),
-# telling us to mount the filesystem to replay the log. In that case
-# the real mount (via fstab) will replay the journal automatically.
-if REPAIR_OUTPUT=$(xfs_repair "${DEVICE}" 2>&1); then
-    echo "xfs_repair succeeded on ${DEVICE}."
+DATA_MOUNT="/mnt/data"
+cleanup() {
+    mountpoint -q "${DATA_MOUNT}" && umount "${DATA_MOUNT}" || true
+    rm -rf "${DATA_MOUNT}" || true
+}
+trap cleanup EXIT
+mkdir -p "${DATA_MOUNT}"
+
+echo "Performing a test mount of ${DEVICE} to ${DATA_MOUNT} to check filesystem health..."
+if MOUNT_OUTPUT=$(mount -t xfs "${DEVICE}" "${DATA_MOUNT}" 2>&1); then
+    echo "Mount succeeded, filesystem is healthy. Unmounting ${DATA_MOUNT}..."
+    umount "${DATA_MOUNT}" || echo "Warning: umount ${DATA_MOUNT} failed, EXIT trap will retry." >&2
     exit 0
 fi
 
-if echo "${REPAIR_OUTPUT}" | grep -qi "replay the log"; then
-    # Dirty but valid journal. The real mount will replay it.
-    echo "XFS journal on ${DEVICE} is dirty but valid; the mount will replay it."
-    exit 0
-fi
-
-# Actual corruption. Log the output and try xfs_repair -L to zero the log and repair.
-echo "xfs_repair failed on ${DEVICE}:"
-echo "${REPAIR_OUTPUT}"
-echo "Calling 'xfs_repair -L' on ${DEVICE}..."
+echo "Mounting ${DEVICE} failed with error: '${MOUNT_OUTPUT}'. Calling xfs_repair -L ..."
 xfs_repair -L "${DEVICE}"

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -36,5 +36,4 @@ else
             fi
         fi
     fi
-    rmdir "${TESTMOUNT}" 2>/dev/null || true
 fi

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -2,6 +2,27 @@
 
 set -e
 
-blkid /dev/mapper/store-shared--data >/dev/null || (
-    mkfs.xfs -m crc=1,reflink=1 /dev/mapper/store-shared--data
-)
+DEVICE=/dev/mapper/store-shared--data
+
+if ! blkid "${DEVICE}" >/dev/null 2>&1; then
+    # No filesystem exists, create one.
+    mkfs.xfs -m crc=1,reflink=1 "${DEVICE}"
+else
+    # Filesystem exists. Try a test mount to verify it is healthy.
+    # This also replays the XFS journal if it is dirty (normal after a crash).
+    TESTMOUNT=$(mktemp -d)
+    if mount -t xfs "${DEVICE}" "${TESTMOUNT}" 2>/dev/null; then
+        # Mount succeeded, filesystem is healthy.
+        umount "${TESTMOUNT}"
+    else
+        # Mount failed, filesystem is corrupted.
+        # Attempt xfs_repair first; if that also fails, reformat.
+        # The IC node will recover its state via state sync so no data
+        # is permanently lost.
+        if ! xfs_repair "${DEVICE}" 2>&1; then
+            echo "xfs_repair failed on ${DEVICE}, reformatting."
+            mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
+        fi
+    fi
+    rmdir "${TESTMOUNT}" 2>/dev/null || true
+fi

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -4,10 +4,14 @@ set -e
 
 DEVICE=/dev/mapper/store-shared--data
 
+format_device() {
+    mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
+}
+
 echo "Checking if ${DEVICE} has a valid filesystem..."
 if ! blkid "${DEVICE}" >/dev/null 2>&1; then
     echo "No filesystem exists on ${DEVICE}, creating one..."
-    mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
+    format_device
     exit 0
 fi
 
@@ -36,5 +40,5 @@ echo "${REPAIR_OUTPUT}"
 echo "Calling 'xfs_repair -L' on ${DEVICE}..."
 if ! xfs_repair -L "${DEVICE}"; then
     echo "'xfs_repair -L' failed on ${DEVICE}, reformatting..."
-    mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
+    format_device
 fi

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -11,17 +11,29 @@ else
     # Filesystem exists. Try a test mount to verify it is healthy.
     # This also replays the XFS journal if it is dirty (normal after a crash).
     TESTMOUNT=$(mktemp -d)
-    if mount -t xfs "${DEVICE}" "${TESTMOUNT}" 2>/dev/null; then
+    # Ensure cleanup on exit: unmount if still mounted and remove temp dir.
+    cleanup() {
+        mountpoint -q "${TESTMOUNT}" && umount "${TESTMOUNT}" || true
+        rmdir "${TESTMOUNT}" 2>/dev/null || true
+    }
+    trap cleanup EXIT
+    if MOUNT_OUTPUT=$(mount -t xfs "${DEVICE}" "${TESTMOUNT}" 2>&1); then
         # Mount succeeded, filesystem is healthy.
         umount "${TESTMOUNT}"
     else
         # Mount failed, filesystem is corrupted.
-        # Attempt xfs_repair first; if that also fails, reformat.
-        # The IC node will recover its state via state sync so no data
-        # is permanently lost.
-        if ! xfs_repair "${DEVICE}" 2>&1; then
-            echo "xfs_repair failed on ${DEVICE}, reformatting."
-            mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
+        # Log the mount failure output to aid diagnostics.
+        echo "Mount of ${DEVICE} on ${TESTMOUNT} failed:" >&2
+        echo "${MOUNT_OUTPUT}" >&2
+        # Attempt xfs_repair first; if that also fails, try xfs_repair -L,
+        # and only then fall back to reformat. The IC node will recover its
+        # state via state sync so no data is permanently lost.
+        if ! xfs_repair "${DEVICE}"; then
+            echo "xfs_repair without log zeroing failed on ${DEVICE}, trying xfs_repair -L." >&2
+            if ! xfs_repair -L "${DEVICE}"; then
+                echo "xfs_repair -L failed on ${DEVICE}, reformatting." >&2
+                mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
+            fi
         fi
     fi
     rmdir "${TESTMOUNT}" 2>/dev/null || true

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 DEVICE=/dev/mapper/store-shared--data
 

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -12,7 +12,6 @@ if ! blkid "${DEVICE}" >/dev/null 2>&1; then
 fi
 
 echo "Filesystem exists on ${DEVICE}, running xfs_repair to check and repair if necessary..."
-# Filesystem exists. Run xfs_repair to check and fix it.
 # xfs_repair (without -L) is safe: it exits non-zero without modifying
 # anything when the journal is dirty but valid (normal after a crash),
 # telling us to mount the filesystem to replay the log. In that case

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -11,17 +11,16 @@ if ! blkid "${DEVICE}" >/dev/null 2>&1; then
     exit 0
 fi
 
-DATA_MOUNT="/mnt"
+DATA_TEST_MOUNTPOINT="/mnt/data_test"
 cleanup() {
-    mountpoint -q "${DATA_MOUNT}" && umount "${DATA_MOUNT}" || true
-    rm -rf "${DATA_MOUNT}" || true
+    umount --quiet "${DATA_TEST_MOUNTPOINT}" || true
 }
 trap cleanup EXIT
 
-echo "Performing a test mount of ${DEVICE} to ${DATA_MOUNT} to check filesystem health..."
-if MOUNT_OUTPUT=$(mount -t xfs "${DEVICE}" "${DATA_MOUNT}" 2>&1); then
-    echo "Mount succeeded, filesystem is healthy. Unmounting ${DATA_MOUNT}..."
-    umount "${DATA_MOUNT}" || echo "Warning: umount ${DATA_MOUNT} failed, EXIT trap will retry." >&2
+echo "Performing a test mount of ${DEVICE} to ${DATA_TEST_MOUNTPOINT} to check filesystem health..."
+if MOUNT_OUTPUT=$(mount -t xfs "${DEVICE}" "${DATA_TEST_MOUNTPOINT}" 2>&1); then
+    echo "Mount succeeded, filesystem is healthy. Unmounting ${DATA_TEST_MOUNTPOINT}..."
+    umount "${DATA_TEST_MOUNTPOINT}" || echo "Warning: umount ${DATA_TEST_MOUNTPOINT} failed, EXIT trap will retry." >&2
     exit 0
 fi
 

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -11,13 +11,12 @@ if ! blkid "${DEVICE}" >/dev/null 2>&1; then
     exit 0
 fi
 
-DATA_MOUNT="/mnt/data"
+DATA_MOUNT="/mnt"
 cleanup() {
     mountpoint -q "${DATA_MOUNT}" && umount "${DATA_MOUNT}" || true
     rm -rf "${DATA_MOUNT}" || true
 }
 trap cleanup EXIT
-mkdir -p "${DATA_MOUNT}"
 
 echo "Performing a test mount of ${DEVICE} to ${DATA_MOUNT} to check filesystem health..."
 if MOUNT_OUTPUT=$(mount -t xfs "${DEVICE}" "${DATA_MOUNT}" 2>&1); then

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -19,7 +19,7 @@ else
     trap cleanup EXIT
     if MOUNT_OUTPUT=$(mount -t xfs "${DEVICE}" "${TESTMOUNT}" 2>&1); then
         # Mount succeeded, filesystem is healthy.
-        umount "${TESTMOUNT}"
+        umount "${TESTMOUNT}" || echo "Warning: umount ${TESTMOUNT} failed, EXIT trap will retry." >&2
     else
         # Mount failed, filesystem is corrupted.
         # Log the mount failure output to aid diagnostics.

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -16,7 +16,7 @@ else
     # the real mount (via fstab) will replay the journal automatically.
     if REPAIR_OUTPUT=$(xfs_repair "${DEVICE}" 2>&1); then
         echo "xfs_repair succeeded on ${DEVICE}."
-    elif echo "${REPAIR_OUTPUT}" | grep -q "Mount the filesystem to replay the log"; then
+    elif echo "${REPAIR_OUTPUT}" | grep -qi "replay the log"; then
         # Dirty but valid journal. The real mount will replay it.
         echo "XFS journal on ${DEVICE} is dirty but valid; the mount will replay it."
     else

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -1,39 +1,34 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 DEVICE=/dev/mapper/store-shared--data
 
+echo "Checking if ${DEVICE} has a valid filesystem..."
 if ! blkid "${DEVICE}" >/dev/null 2>&1; then
     # No filesystem exists, create one.
-    mkfs.xfs -m crc=1,reflink=1 "${DEVICE}"
+    mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
 else
-    # Filesystem exists. Try a test mount to verify it is healthy.
-    # This also replays the XFS journal if it is dirty (normal after a crash).
-    TESTMOUNT=$(mktemp -d)
-    # Ensure cleanup on exit: unmount if still mounted and remove temp dir.
-    cleanup() {
-        mountpoint -q "${TESTMOUNT}" && umount "${TESTMOUNT}" || true
-        rmdir "${TESTMOUNT}" 2>/dev/null || true
-    }
-    trap cleanup EXIT
-    if MOUNT_OUTPUT=$(mount -t xfs "${DEVICE}" "${TESTMOUNT}" 2>&1); then
-        # Mount succeeded, filesystem is healthy.
-        umount "${TESTMOUNT}" || echo "Warning: umount ${TESTMOUNT} failed, EXIT trap will retry." >&2
+    # Filesystem exists. Run xfs_repair to check and fix it.
+    # xfs_repair (without -L) is safe: it exits non-zero without modifying
+    # anything when the journal is dirty but valid (normal after a crash),
+    # telling us to mount the filesystem to replay the log. In that case
+    # the real mount (via fstab) will replay the journal automatically.
+    if REPAIR_OUTPUT=$(xfs_repair "${DEVICE}" 2>&1); then
+        echo "xfs_repair succeeded on ${DEVICE}."
+    elif echo "${REPAIR_OUTPUT}" | grep -q "Mount the filesystem to replay the log"; then
+        # Dirty but valid journal. The real mount will replay it.
+        echo "XFS journal on ${DEVICE} is dirty but valid; the mount will replay it."
     else
-        # Mount failed, filesystem is corrupted.
-        # Log the mount failure output to aid diagnostics.
-        echo "Mount of ${DEVICE} on ${TESTMOUNT} failed:" >&2
-        echo "${MOUNT_OUTPUT}" >&2
-        # Attempt xfs_repair first; if that also fails, try xfs_repair -L,
-        # and only then fall back to reformat. The IC node will recover its
-        # state via state sync so no data is permanently lost.
-        if ! xfs_repair "${DEVICE}"; then
-            echo "xfs_repair without log zeroing failed on ${DEVICE}, trying xfs_repair -L." >&2
-            if ! xfs_repair -L "${DEVICE}"; then
-                echo "xfs_repair -L failed on ${DEVICE}, reformatting." >&2
-                mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
-            fi
+        # Actual corruption. Log the output and try xfs_repair -L to zero
+        # the log and repair. If that also fails, reformat as last resort.
+        # The IC node will recover its state via state sync so no data is
+        # permanently lost.
+        echo "xfs_repair failed on ${DEVICE}:" >&2
+        echo "${REPAIR_OUTPUT}" >&2
+        if ! xfs_repair -L "${DEVICE}"; then
+            echo "xfs_repair -L failed on ${DEVICE}, reformatting." >&2
+            mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
         fi
     fi
 fi

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -8,29 +8,34 @@ echo "Checking if ${DEVICE} has a valid filesystem..."
 if ! blkid "${DEVICE}" >/dev/null 2>&1; then
     echo "No filesystem exists on ${DEVICE}, creating one..."
     mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
-else
-    echo "Filesystem exists on ${DEVICE}, running xfs_repair to check and repair if necessary..."
-    # Filesystem exists. Run xfs_repair to check and fix it.
-    # xfs_repair (without -L) is safe: it exits non-zero without modifying
-    # anything when the journal is dirty but valid (normal after a crash),
-    # telling us to mount the filesystem to replay the log. In that case
-    # the real mount (via fstab) will replay the journal automatically.
-    if REPAIR_OUTPUT=$(xfs_repair "${DEVICE}" 2>&1); then
-        echo "xfs_repair succeeded on ${DEVICE}."
-    elif echo "${REPAIR_OUTPUT}" | grep -qi "replay the log"; then
-        # Dirty but valid journal. The real mount will replay it.
-        echo "XFS journal on ${DEVICE} is dirty but valid; the mount will replay it."
-    else
-        # Actual corruption. Log the output and try xfs_repair -L to zero
-        # the log and repair. If that also fails, reformat as last resort.
-        # The IC node will recover its state via state sync so no data is
-        # permanently lost.
-        echo "xfs_repair failed on ${DEVICE}:"
-        echo "${REPAIR_OUTPUT}"
-        echo "Calling 'xfs_repair -L' on ${DEVICE}..."
-        if ! xfs_repair -L "${DEVICE}"; then
-            echo "'xfs_repair -L' failed on ${DEVICE}, reformatting..."
-            mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
-        fi
-    fi
+    exit 0
+fi
+
+echo "Filesystem exists on ${DEVICE}, running xfs_repair to check and repair if necessary..."
+# Filesystem exists. Run xfs_repair to check and fix it.
+# xfs_repair (without -L) is safe: it exits non-zero without modifying
+# anything when the journal is dirty but valid (normal after a crash),
+# telling us to mount the filesystem to replay the log. In that case
+# the real mount (via fstab) will replay the journal automatically.
+if REPAIR_OUTPUT=$(xfs_repair "${DEVICE}" 2>&1); then
+    echo "xfs_repair succeeded on ${DEVICE}."
+    exit 0
+fi
+
+if echo "${REPAIR_OUTPUT}" | grep -qi "replay the log"; then
+    # Dirty but valid journal. The real mount will replay it.
+    echo "XFS journal on ${DEVICE} is dirty but valid; the mount will replay it."
+    exit 0
+fi
+
+# Actual corruption. Log the output and try xfs_repair -L to zero
+# the log and repair. If that also fails, reformat as last resort.
+# The IC node will recover its state via state sync so no data is
+# permanently lost.
+echo "xfs_repair failed on ${DEVICE}:"
+echo "${REPAIR_OUTPUT}"
+echo "Calling 'xfs_repair -L' on ${DEVICE}..."
+if ! xfs_repair -L "${DEVICE}"; then
+    echo "'xfs_repair -L' failed on ${DEVICE}, reformatting..."
+    mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
 fi

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -6,9 +6,10 @@ DEVICE=/dev/mapper/store-shared--data
 
 echo "Checking if ${DEVICE} has a valid filesystem..."
 if ! blkid "${DEVICE}" >/dev/null 2>&1; then
-    # No filesystem exists, create one.
+    echo "No filesystem exists on ${DEVICE}, creating one..."
     mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
 else
+    echo "Filesystem exists on ${DEVICE}, running xfs_repair to check and repair if necessary..."
     # Filesystem exists. Run xfs_repair to check and fix it.
     # xfs_repair (without -L) is safe: it exits non-zero without modifying
     # anything when the journal is dirty but valid (normal after a crash),
@@ -24,10 +25,11 @@ else
         # the log and repair. If that also fails, reformat as last resort.
         # The IC node will recover its state via state sync so no data is
         # permanently lost.
-        echo "xfs_repair failed on ${DEVICE}:" >&2
-        echo "${REPAIR_OUTPUT}" >&2
+        echo "xfs_repair failed on ${DEVICE}:"
+        echo "${REPAIR_OUTPUT}"
+        echo "Calling 'xfs_repair -L' on ${DEVICE}..."
         if ! xfs_repair -L "${DEVICE}"; then
-            echo "xfs_repair -L failed on ${DEVICE}, reformatting." >&2
+            echo "'xfs_repair -L' failed on ${DEVICE}, reformatting..."
             mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
         fi
     fi

--- a/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
+++ b/ic-os/components/upgrade/shared-resources/setup-shared-resources/setup-shared-data.sh
@@ -4,14 +4,10 @@ set -e
 
 DEVICE=/dev/mapper/store-shared--data
 
-format_device() {
-    mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
-}
-
 echo "Checking if ${DEVICE} has a valid filesystem..."
 if ! blkid "${DEVICE}" >/dev/null 2>&1; then
     echo "No filesystem exists on ${DEVICE}, creating one..."
-    format_device
+    mkfs.xfs -f -m crc=1,reflink=1 "${DEVICE}"
     exit 0
 fi
 
@@ -31,14 +27,8 @@ if echo "${REPAIR_OUTPUT}" | grep -qi "replay the log"; then
     exit 0
 fi
 
-# Actual corruption. Log the output and try xfs_repair -L to zero
-# the log and repair. If that also fails, reformat as last resort.
-# The IC node will recover its state via state sync so no data is
-# permanently lost.
+# Actual corruption. Log the output and try xfs_repair -L to zero the log and repair.
 echo "xfs_repair failed on ${DEVICE}:"
 echo "${REPAIR_OUTPUT}"
 echo "Calling 'xfs_repair -L' on ${DEVICE}..."
-if ! xfs_repair -L "${DEVICE}"; then
-    echo "'xfs_repair -L' failed on ${DEVICE}, reformatting..."
-    format_device
-fi
+xfs_repair -L "${DEVICE}"

--- a/ic-os/guestos/context/Dockerfile
+++ b/ic-os/guestos/context/Dockerfile
@@ -127,7 +127,8 @@ RUN mkdir -p /var/lib/ic/backup \
              /var/lib/ic/data
 
 # Create two mount points for temporary use during setup of "var" partition
-RUN mkdir -p /mnt/var_old /mnt/var_new
+# and a mount point for testing the mount of the data partition.
+RUN mkdir -p /mnt/var_old /mnt/var_new /mnt/data_test
 
 # Set /bin/sh to point to /bin/bash instead of the default /bin/dash
 RUN ln -sf /bin/bash /usr/bin/sh

--- a/rs/tests/node/BUILD.bazel
+++ b/rs/tests/node/BUILD.bazel
@@ -145,6 +145,19 @@ system_test(
     test_driver_target = ":kill_start_test_bin",
 )
 
+system_test(
+    name = "xfs_corruption_repair_test",
+    deps = [
+        # Keep sorted.
+        "//rs/registry/subnet_type",
+        "//rs/tests/driver:ic-system-test-driver",
+        "//rs/tests/nested",
+        "@crate_index//:anyhow",
+        "@crate_index//:slog",
+        "@crate_index//:chrono",
+    ],
+)
+
 # Tests that no systemd units have failed on GuestOS nodes after they boot.
 system_test(
     name = "guestos_no_failed_systemd_units",

--- a/rs/tests/node/Cargo.toml
+++ b/rs/tests/node/Cargo.toml
@@ -9,6 +9,7 @@ documentation.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 candid = { workspace = true }
+chrono = { workspace = true }
 ic-agent = { workspace = true }
 ic-base-types = { path = "../../types/base_types" }
 ic-nns-constants = { path = "../../nns/constants" }
@@ -50,3 +51,7 @@ path = "kill_start_test.rs"
 [[bin]]
 name = "guestos-no-failed-systemd-units"
 path = "guestos_no_failed_systemd_units.rs"
+
+[[bin]]
+name = "rs/tests/node/xfs_corruption_repair_test"
+path = "xfs_corruption_repair_test.rs"

--- a/rs/tests/node/xfs_corruption_repair_test.rs
+++ b/rs/tests/node/xfs_corruption_repair_test.rs
@@ -1,0 +1,160 @@
+// Tests that setup-shared-data.sh correctly repairs a corrupted XFS shared-data
+// partition on reboot.  The test deploys a single-node IC, then:
+//
+// Corrupts the XFS internal journal while the filesystem is still mounted
+// (reads the log start and size from the superblock, then overwrites the
+// entire log region via oflag=direct), then hard-kills the VM.  The dirty +
+// corrupted log makes the test mount in setup-shared-data.sh fail.
+// → setup-shared-data.sh must invoke `xfs_repair -L` to recover.
+
+use anyhow::Result;
+use chrono::Utc;
+use ic_registry_subnet_type::SubnetType;
+use ic_system_test_driver::driver::group::SystemTestGroup;
+use ic_system_test_driver::driver::ic::InternetComputer;
+use ic_system_test_driver::driver::test_env::TestEnv;
+use ic_system_test_driver::driver::test_env_api::*;
+use ic_system_test_driver::systest;
+use nested::util::block_on_bash_script_and_log;
+use slog::{error, info};
+use std::time::Duration;
+
+const POST_KILL_SLEEP_DURATION: Duration = Duration::from_secs(5);
+
+fn setup(env: TestEnv) {
+    InternetComputer::new()
+        .add_fast_single_node_subnet(SubnetType::System)
+        .setup_and_start(&env)
+        .expect("failed to setup IC under test");
+}
+
+fn test(env: TestEnv) {
+    let log = &env.logger();
+    let node = &env.get_first_healthy_system_node_snapshot();
+    let node_id = node.node_id;
+    let vm = node.vm();
+
+    info!(log, "Writing /var/lib/ic/data/proof-I-was-here.txt ...");
+
+    let now = Utc::now().to_rfc3339();
+    block_on_bash_script_and_log(
+        log,
+        node,
+        &format!(
+            "echo '{now}' | sudo tee /var/lib/ic/data/proof-I-was-here.txt && sync && ls -la /var/lib/ic/data",
+        ),
+    );
+
+    // Corrupt the XFS journal by
+    // reading the log start offset (sb_logstart at byte offset 48, 8 bytes
+    // big-endian) and log size (sb_logblocks at byte offset 96, 4 bytes
+    // big-endian) from the superblock, then overwriting the entire log
+    // region via oflag=direct (bypasses the page cache).
+    // After a hard vm.kill() the log corrupted, so the kernel refuses to mount it
+    // ("Structure needs cleaning") — triggering the `xfs_repair -L`
+    // recovery path in setup-shared-data.sh.
+    info!(
+        log,
+        "Corrupting XFS journal on /dev/mapper/store-shared--data ..."
+    );
+    node.await_status_is_healthy().expect("Node not healthy");
+    // Stop services so they don't race with our dd, then read the log
+    // start block and size from the superblock and corrupt the entire log.
+    let out = node
+        .block_on_bash_script(
+            "sudo systemctl stop \
+               ic-replica.service \
+               ic-btc-mainnet-adapter.service \
+               ic-btc-mainnet-adapter.socket \
+               ic-btc-testnet-adapter.service \
+               ic-btc-testnet-adapter.socket \
+               ic-doge-mainnet-adapter.service \
+               ic-doge-mainnet-adapter.socket \
+               ic-doge-testnet-adapter.service \
+               ic-doge-testnet-adapter.socket \
+               ic-https-outcalls-adapter.service; \
+         sudo umount /var/lib/ic/data; \
+         DEV=/dev/mapper/store-shared--data; \
+         LOG_START_HEX=$(sudo od -A n -j 48 -N 8 -t x1 $DEV | tr -d ' \\n'); \
+         LOG_START=$(printf '%d' 0x$LOG_START_HEX); \
+         LOG_BLOCKS_HEX=$(sudo od -A n -j 96 -N 4 -t x1 $DEV | tr -d ' \\n'); \
+         LOG_BLOCKS=$(printf '%d' 0x$LOG_BLOCKS_HEX); \
+         echo \"XFS log: start=$LOG_START blocks=$LOG_BLOCKS\"; \
+         sudo dd if=/dev/urandom of=$DEV bs=4096 count=$LOG_BLOCKS seek=$LOG_START oflag=direct conv=notrunc",
+        )
+        .expect("Failed to corrupt XFS journal");
+    info!(log, "Corruption command output:\n{out}");
+
+    info!(log, "Killing node after XFS journal corruption ...");
+    vm.kill();
+    node.await_status_is_unavailable()
+        .expect("Node still healthy");
+    std::thread::sleep(POST_KILL_SLEEP_DURATION);
+
+    info!(log, "Starting node after XFS journal corruption ...");
+    vm.start();
+
+    node.await_can_login_as_admin_via_ssh()
+        .expect("Failed to login as admin via SSH");
+
+    let journal = node
+        .block_on_bash_script("sudo journalctl -u setup-shared-data.service -b --no-pager")
+        .expect("Failed to read setup-shared-data.service journal");
+    info!(log, "setup-shared-data.service journal:\n{journal}");
+    assert!(
+        journal.contains("xfs_repair -L"),
+        "Expected 'xfs_repair -L' in setup-shared-data.service journal after journal corruption, \
+         but got:\n{journal}"
+    );
+
+    info!(log, "ls -la /var/lib/ic/data ...");
+    block_on_bash_script_and_log(log, node, "ls -la /var/lib/ic/data");
+    let proof = node
+        .block_on_bash_script("cat /var/lib/ic/data/proof-I-was-here.txt")
+        .expect("Failed to read proof-I-was-here.txt");
+    assert_eq!(
+        proof.trim(),
+        now,
+        "Content of proof file does not match expected timestamp. \
+         Expected: {now}, Actual: {proof}"
+    );
+
+    info!(log, "systemctl --failed:");
+    block_on_bash_script_and_log(log, node, "systemctl --failed");
+    info!(
+        log,
+        "sudo journalctl -u ic-replica.service -b --no-pager | tail -50:"
+    );
+    block_on_bash_script_and_log(
+        log,
+        node,
+        "sudo journalctl -u ic-replica.service -b --no-pager | tail -50",
+    );
+    info!(log, "sudo journalctl -u 'systemd-fsck@*' -b --no-pager:");
+    block_on_bash_script_and_log(
+        log,
+        node,
+        "sudo journalctl -u 'systemd-fsck@*' -b --no-pager",
+    );
+    info!(log, "systemctl status var-lib-ic-data.mount:");
+    block_on_bash_script_and_log(log, node, "systemctl status var-lib-ic-data.mount");
+
+    if let Err(err) = node.await_status_is_healthy() {
+        error!(
+            log,
+            "Node {node_id} not healthy after XFS journal corruption: {err:?}. Dumping journal ..."
+        );
+        block_on_bash_script_and_log(log, node, "journalctl -b");
+        panic!("Node was not healthy after XFS journal corruption!")
+    }
+    block_on_bash_script_and_log(log, node, "findmnt /var/lib/ic/data");
+}
+
+fn main() -> Result<()> {
+    SystemTestGroup::new()
+        .with_setup(setup)
+        .add_test(systest!(test))
+        .without_assert_no_replica_restarts()
+        .execute_from_args()?;
+    Ok(())
+}


### PR DESCRIPTION
Based on: https://github.com/dfinity/ic/pull/9536.

Adds the `//rs/tests/node:xfs_corruption_repair_test` which:
* Boots an IC node.
* Waits for it to become healthy.
* Then stops all services that write to `/var/lib/ic/data`.
* Unmounts `/var/lib/ic/data`.
* Corrupts the XFS log of `/dev/mapper/store-shared--data`.
* Kills the node.
* Starts it up again.
* Asserts that `xfs_repair -L` has ran and that the files in `/var/lib/ic/data` are still there.
* Waits for the node to become healthy.

That last step fails for some reason I haven't figured out yet.