### PR TITLE
feat: Update consumed cycles metrics on free cost schedule

### DIFF
--- a/rs/config/src/subnet_config.rs
+++ b/rs/config/src/subnet_config.rs
@@ -108,6 +108,9 @@ pub const MAX_MESSAGE_DURATION_BEFORE_WARN_IN_SECONDS: f64 = 5.0;
 ///
 const MAX_PAUSED_EXECUTIONS: usize = 4;
 
+/// Cost for creating a new canister.
+pub const CANISTER_CREATION_FEE: Cycles = Cycles::new(500_000_000_000);
+
 /// 10B cycles corresponds to 1 SDR cent. Assuming we can create 1 signature per
 /// second, that would come to  26k SDR per month if we spent the whole time
 /// creating signatures. At 13 nodes and 2k SDR per node per month this would
@@ -458,7 +461,7 @@ impl CyclesAccountManagerConfig {
         let ten_update_instructions_execution_fee_in_cycles = 10;
         Self {
             reference_subnet_size: DEFAULT_REFERENCE_SUBNET_SIZE,
-            canister_creation_fee: Cycles::new(500_000_000_000),
+            canister_creation_fee: CANISTER_CREATION_FEE,
             compute_percent_allocated_per_second_fee: Cycles::new(10_000_000),
 
             // The following fields are set based on a thought experiment where

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -25,7 +25,7 @@ use ic_config::{
         SUBNET_MEMORY_RESERVATION, TEST_DEFAULT_LOG_MEMORY_USAGE,
     },
     flag_status::FlagStatus,
-    subnet_config::SchedulerConfig,
+    subnet_config::{CANISTER_CREATION_FEE, SchedulerConfig},
 };
 use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
 use ic_embedders::{
@@ -7261,7 +7261,7 @@ fn create_canister_free() {
             .canister_metrics()
             .consumed_cycles()
             .get(),
-        0
+        CANISTER_CREATION_FEE.get()
     );
     assert_eq!(canister.system_state.balance(), *INITIAL_CYCLES);
 }
@@ -7294,7 +7294,7 @@ fn create_canister_as_subnet_admin_succeeds_on_free_cost_schedule() {
             .canister_metrics()
             .consumed_cycles()
             .get(),
-        0
+        CANISTER_CREATION_FEE.get()
     );
     assert_eq!(canister.system_state.balance(), Cycles::new(0));
 }

--- a/rs/execution_environment/src/execution/response/tests.rs
+++ b/rs/execution_environment/src/execution/response/tests.rs
@@ -11,6 +11,7 @@ use ic_test_utilities_execution_environment::{
 };
 use ic_test_utilities_metrics::fetch_int_counter;
 use ic_test_utilities_types::messages::ResponseBuilder;
+use ic_types::NumInstructions;
 use ic_types::messages::NO_DEADLINE;
 use ic_types::{
     CanisterId, Time,
@@ -18,8 +19,7 @@ use ic_types::{
     messages::{CallbackId, MessageId},
 };
 use ic_types::{ComputeAllocation, MemoryAllocation};
-use ic_types::{NumInstructions, messages::MAX_INTER_CANISTER_PAYLOAD_IN_BYTES};
-use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles, CyclesUseCase};
 use ic_universal_canister::{call_args, wasm};
 use more_asserts::{assert_ge, assert_gt, assert_lt};
 
@@ -79,67 +79,105 @@ fn execute_response_when_stopping_status() {
 
 #[test]
 fn execute_response_refunds_cycles() {
-    // This test uses manual execution to get finer control over the execution.
-    let instruction_limit = 1_000_000_000;
-    let mut test = ExecutionTestBuilder::new()
-        .with_instruction_limit(instruction_limit)
-        .with_manual_execution()
-        .build();
-    let initial_cycles = Cycles::new(1_000_000_000_000);
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        // This test uses manual execution to get finer control over the execution.
+        let instruction_limit = 1_000_000_000;
+        let mut test = ExecutionTestBuilder::new()
+            .with_instruction_limit(instruction_limit)
+            .with_cost_schedule(cost_schedule)
+            .with_manual_execution()
+            .build();
+        let initial_cycles = Cycles::new(1_000_000_000_000);
 
-    // Create two canisters: A and B.
-    let a_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
-    let b_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+        // Create two canisters: A and B.
+        let a_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+        let b_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
 
-    // Canister A calls canister B.
-    let cycles_sent = Cycles::new(1_000_000);
-    let wasm_payload = wasm()
-        .call_with_cycles(b_id, "update", call_args(), cycles_sent)
-        .build();
+        // Canister A calls canister B.
+        let cycles_sent = Cycles::new(1_000_000);
+        let wasm_payload = wasm()
+            .call_with_cycles(b_id, "update", call_args(), cycles_sent)
+            .build();
 
-    // Enqueue ingress message to canister A and execute it.
-    let msg_id = test.ingress_raw(a_id, "update", wasm_payload).0;
-    assert_matches!(test.ingress_state(&msg_id), IngressState::Received);
-    test.execute_message(a_id);
+        // Enqueue ingress message to canister A and execute it.
+        let msg_id = test.ingress_raw(a_id, "update", wasm_payload).0;
+        assert_matches!(test.ingress_state(&msg_id), IngressState::Received);
+        test.execute_message(a_id);
 
-    // Create response from canister B to canister A.
-    let response = ResponseBuilder::new()
-        .originator(a_id)
-        .respondent(b_id)
-        .originator_reply_callback(CallbackId::from(1))
-        .refund(cycles_sent / 2_u64)
-        .build();
-    let response_payload_size = response.payload_size_bytes();
+        // Create response from canister B to canister A.
+        let response = ResponseBuilder::new()
+            .originator(a_id)
+            .respondent(b_id)
+            .originator_reply_callback(CallbackId::from(1))
+            .refund(cycles_sent / 2_u64)
+            .build();
+        let response_payload_size = response.payload_size_bytes();
 
-    // Execute response.
-    let balance_before = test.canister_state(a_id).system_state.balance();
-    let instructions_before = test.canister_executed_instructions(a_id);
-    test.execute_response(a_id, response);
-    let instructions_after = test.canister_executed_instructions(a_id);
-    let instructions_executed = instructions_after - instructions_before;
-    let balance_after = test.canister_state(a_id).system_state.balance();
+        // Execute response.
+        let balance_before = test.canister_state(a_id).system_state.balance();
+        let consumed_cycles_before = *test
+            .canister_state(a_id)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_by_use_cases()
+            .get(&CyclesUseCase::RequestAndResponseTransmission)
+            .unwrap();
+        let instructions_before = test.canister_executed_instructions(a_id);
+        test.execute_response(a_id, response);
+        let instructions_after = test.canister_executed_instructions(a_id);
+        let instructions_executed = instructions_after - instructions_before;
+        let balance_after = test.canister_state(a_id).system_state.balance();
+        let consumed_cycles_after = *test
+            .canister_state(a_id)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_by_use_cases()
+            .get(&CyclesUseCase::RequestAndResponseTransmission)
+            .unwrap();
 
-    // The balance is equivalent to the amount of cycles before executing`execute_response`
-    // plus the unaccepted cycles (no more the cycles sent via request),
-    // the execution cost refund and the refunded transmission fee.
-    // Compute the response transmission refund.
-    let cost_schedule = CanisterCyclesCostSchedule::Normal;
-    let mgr = test.cycles_account_manager();
-    let response_transmission_refund = mgr
-        .xnet_call_bytes_transmitted_fee(
-            MAX_INTER_CANISTER_PAYLOAD_IN_BYTES,
+        // The balance is equivalent to the amount of cycles before executing`execute_response`
+        // plus the unaccepted cycles (no more the cycles sent via request),
+        // the execution cost refund and the refunded transmission fee.
+        // Compute the response transmission refund.
+        let mgr = test.cycles_account_manager();
+        let prepayment_for_response_transmission =
+            mgr.prepayment_for_response_transmission(test.subnet_size(), cost_schedule);
+        let actual_response_transmission_fee = mgr.xnet_call_bytes_transmitted_fee(
+            response_payload_size,
             test.subnet_size(),
             cost_schedule,
-        )
-        .real();
-    mgr.xnet_call_bytes_transmitted_fee(response_payload_size, test.subnet_size(), cost_schedule);
-    let instructions_left = NumInstructions::from(instruction_limit) - instructions_executed;
-    let execution_refund = mgr
-        .convert_instructions_to_cycles(instructions_left, test.canister_wasm_execution_mode(a_id));
-    assert_eq!(
-        balance_after,
-        balance_before + cycles_sent / 2_u64 + response_transmission_refund + execution_refund
-    );
+        );
+        let response_transmission_refund =
+            prepayment_for_response_transmission - actual_response_transmission_fee;
+        let instructions_left = NumInstructions::from(instruction_limit) - instructions_executed;
+        let execution_refund = mgr.convert_instructions_to_cycles(
+            instructions_left,
+            test.canister_wasm_execution_mode(a_id),
+        );
+
+        match cost_schedule {
+            // On a free schedule the balance changes only due to cycles transfers.
+            CanisterCyclesCostSchedule::Free => {
+                assert_eq!(balance_after, balance_before + cycles_sent / 2_u64);
+            }
+            CanisterCyclesCostSchedule::Normal => {
+                assert_eq!(
+                    balance_after,
+                    balance_before
+                        + cycles_sent / 2_u64
+                        + response_transmission_refund.real()
+                        + execution_refund
+                );
+            }
+        }
+        assert_eq!(
+            consumed_cycles_after,
+            consumed_cycles_before - response_transmission_refund.nominal(),
+        );
+    }
 }
 
 #[test]

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -2415,25 +2415,44 @@ fn metrics_are_observed_for_subnet_messages() {
 }
 
 #[test]
-fn ingress_deducts_execution_cost_from_canister_balance() {
-    let mut test = ExecutionTestBuilder::new().build();
-    let canister = test.universal_canister().unwrap();
-    let run = wasm().message_payload().append_and_reply().build();
-    let balance_before = test.canister_state(canister).system_state.balance();
-    let execution_cost_before = test.canister_execution_cost(canister);
-    test.ingress(canister, "update", run).unwrap();
-    let balance_after = test.canister_state(canister).system_state.balance();
-    let execution_cost_after = test.canister_execution_cost(canister);
-    assert_eq!(
-        balance_before - balance_after,
-        (execution_cost_after - execution_cost_before).real()
-    );
-    // Ensure that we charged some cycles. The actual value is unknown to us at
-    // this point but it is definitely larger that 1000.
-    assert_gt!(
-        (execution_cost_after - execution_cost_before).real(),
-        Cycles::new(1_000)
-    );
+fn ingress_deducts_execution_cost_from_canister_balance_and_updates_consumed_metrics() {
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        let mut test = ExecutionTestBuilder::new()
+            .with_cost_schedule(cost_schedule)
+            .build();
+        let canister = test.universal_canister().unwrap();
+        let run = wasm().message_payload().append_and_reply().build();
+        let balance_before = test.canister_state(canister).system_state.balance();
+        let execution_cost_before = test.canister_execution_cost(canister);
+        let consumed_cycles_before = *test
+            .canister_state(canister)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_by_use_cases()
+            .get(&CyclesUseCase::Instructions)
+            .unwrap_or(&NominalCycles::zero());
+        test.ingress(canister, "update", run).unwrap();
+        let balance_after = test.canister_state(canister).system_state.balance();
+        let execution_cost_after = test.canister_execution_cost(canister);
+        let consumed_cycles_after = *test
+            .canister_state(canister)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_by_use_cases()
+            .get(&CyclesUseCase::Instructions)
+            .unwrap_or(&NominalCycles::zero());
+
+        let execution_cost_diff = execution_cost_after - execution_cost_before;
+        assert_eq!(balance_before - balance_after, execution_cost_diff.real());
+        // Consumed cycles should be updated by the same amount as the execution cost.
+        assert_eq!(
+            consumed_cycles_after - consumed_cycles_before,
+            execution_cost_diff.nominal()
+        );
+    }
 }
 
 #[test]
@@ -3904,179 +3923,177 @@ fn replicated_query_does_not_burn_cycles_on_trap() {
 
 #[test]
 fn test_consumed_cycles_by_use_case_with_refund() {
-    let mut test = ExecutionTestBuilder::new().with_manual_execution().build();
-    let initial_cycles = Cycles::new(1_000_000_000_000);
-    let a_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
-    let b_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
-    let transferred_cycles = Cycles::new(1_000_000);
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        let mut test = ExecutionTestBuilder::new()
+            .with_cost_schedule(cost_schedule)
+            .with_manual_execution()
+            .build();
+        let initial_cycles = Cycles::new(1_000_000_000_000);
+        let a_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+        let b_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+        let transferred_cycles = Cycles::new(1_000_000);
 
-    let b_callback = wasm()
-        .accept_cycles(transferred_cycles)
-        .message_payload()
-        .append_and_reply()
-        .build();
+        let b_callback = wasm()
+            .accept_cycles(transferred_cycles)
+            .message_payload()
+            .append_and_reply()
+            .build();
 
-    let a_payload = wasm()
-        .call_with_cycles(
-            b_id,
-            "update",
-            call_args().other_side(b_callback.clone()),
-            transferred_cycles,
-        )
-        .build();
+        let a_payload = wasm()
+            .call_with_cycles(
+                b_id,
+                "update",
+                call_args().other_side(b_callback.clone()),
+                transferred_cycles,
+            )
+            .build();
 
-    let (message_id, _) = test.ingress_raw(a_id, "update", a_payload);
-    // Canister A sends the message to canister B.
-    test.execute_message(a_id);
-    test.induct_messages();
-    test.execute_message(b_id);
+        let (message_id, _) = test.ingress_raw(a_id, "update", a_payload);
+        // Canister A sends the message to canister B.
+        test.execute_message(a_id);
+        test.induct_messages();
+        test.execute_message(b_id);
 
-    let system_state = &mut test.canister_state_mut(b_id).system_state;
-    // Check that canister B has produced the response.
-    assert_eq!(1, system_state.queues().output_queues_len());
-    assert_eq!(1, system_state.queues().output_queues_message_count());
+        let system_state = &mut test.canister_state_mut(b_id).system_state;
+        // Check that canister B has produced the response.
+        assert_eq!(1, system_state.queues().output_queues_len());
+        assert_eq!(1, system_state.queues().output_queues_message_count());
 
-    let message = system_state
-        .queues_mut()
-        .clone()
-        .pop_canister_output(&a_id)
-        .unwrap();
+        let message = system_state
+            .queues_mut()
+            .clone()
+            .pop_canister_output(&a_id)
+            .unwrap();
 
-    if let RequestOrResponse::Response(msg) = message {
-        assert_eq!(msg.originator, a_id);
-        assert_eq!(msg.respondent, b_id);
-        assert!(matches!(msg.response_payload, Payload::Data(..)));
-    } else {
-        panic!("unexpected message popped: {message:?}");
-    }
-
-    // Get consumption for 'RequestAndResponseTransmission' and 'Instructions'
-    // before receiving a response on canister A.
-    let transmission_consumption_before_response = *test
-        .canister_state(a_id)
-        .system_state
-        .canister_metrics()
-        .consumed_cycles_by_use_cases()
-        .get(&CyclesUseCase::RequestAndResponseTransmission)
-        .unwrap();
-    let instruction_consumption_before_response = *test
-        .canister_state(a_id)
-        .system_state
-        .canister_metrics()
-        .consumed_cycles_by_use_cases()
-        .get(&CyclesUseCase::Instructions)
-        .unwrap();
-
-    assert_gt!(transmission_consumption_before_response.get(), 0);
-    assert_gt!(instruction_consumption_before_response.get(), 0);
-
-    // Check that canister A's balance is decremented for consumed cycles
-    // plus transferred cycles to canister B.
-    assert_eq!(
-        test.canister_state(a_id).system_state.balance(),
-        initial_cycles
-            - Cycles::from(transmission_consumption_before_response.get())
-            - Cycles::from(instruction_consumption_before_response.get())
-            - transferred_cycles
-    );
-
-    // Canister A executed the response.
-    test.induct_messages();
-    test.execute_message(a_id);
-
-    let ingress_state = test.ingress_state(&message_id);
-
-    if let IngressState::Completed(wasm_result) = ingress_state {
-        match wasm_result {
-            WasmResult::Reject(result) => panic!("unexpected result {result}"),
-            WasmResult::Reply(_) => (),
+        if let RequestOrResponse::Response(msg) = message {
+            assert_eq!(msg.originator, a_id);
+            assert_eq!(msg.respondent, b_id);
+            assert!(matches!(msg.response_payload, Payload::Data(..)));
+        } else {
+            panic!("unexpected message popped: {message:?}");
         }
-    } else {
-        panic!("unexpected ingress state {ingress_state:?}");
-    }
 
-    let transmission_cost = test.call_fee("update", &b_callback) + test.reply_fee(&b_callback);
-
-    let execution_cost = test.canister_execution_cost(a_id);
-
-    // Check that canister A's balance is updated correctly.
-    assert_eq!(
-        test.canister_state(a_id).system_state.balance(),
-        initial_cycles - execution_cost.real() - transmission_cost.real() - transferred_cycles
-    );
-
-    assert_eq!(
-        test.canister_state(a_id)
+        // Get consumption for 'RequestAndResponseTransmission' and 'Instructions'
+        // before receiving a response on canister A.
+        let transmission_consumption_before_response = *test
+            .canister_state(a_id)
             .system_state
             .canister_metrics()
             .consumed_cycles_by_use_cases()
-            .len(),
-        2
-    );
-
-    let transmission_consumption_after_response = *test
-        .canister_state(a_id)
-        .system_state
-        .canister_metrics()
-        .consumed_cycles_by_use_cases()
-        .get(&CyclesUseCase::RequestAndResponseTransmission)
-        .unwrap();
-    let instruction_consumption_after_response = *test
-        .canister_state(a_id)
-        .system_state
-        .canister_metrics()
-        .consumed_cycles_by_use_cases()
-        .get(&CyclesUseCase::Instructions)
-        .unwrap();
-
-    // Check that consumed cycles are correct for both use cases.
-    assert_eq!(
-        transmission_consumption_after_response,
-        transmission_cost.nominal(),
-    );
-
-    assert_eq!(
-        instruction_consumption_after_response,
-        execution_cost.nominal(),
-    );
-
-    // Consumed cycles after the response should be smaller than before
-    // the response because we expect a refund for prepaid cycles.
-    assert_lt!(
-        transmission_consumption_after_response,
-        transmission_consumption_before_response
-    );
-    assert_lt!(
-        instruction_consumption_after_response,
-        instruction_consumption_before_response
-    );
-
-    // Check that canister B's balance is updated correctly.
-    assert_eq!(
-        test.canister_state(b_id).system_state.balance(),
-        initial_cycles - test.canister_execution_cost(b_id).real() + transferred_cycles
-    );
-
-    // Check that consumed cycles are correct only for the `Instructions` use case.
-    assert_eq!(
-        test.canister_state(b_id)
-            .system_state
-            .canister_metrics()
-            .consumed_cycles_by_use_cases()
-            .len(),
-        1
-    );
-
-    assert_eq!(
-        *test
-            .canister_state(b_id)
+            .get(&CyclesUseCase::RequestAndResponseTransmission)
+            .unwrap();
+        let instruction_consumption_before_response = *test
+            .canister_state(a_id)
             .system_state
             .canister_metrics()
             .consumed_cycles_by_use_cases()
             .get(&CyclesUseCase::Instructions)
-            .unwrap(),
-        test.canister_execution_cost(b_id).nominal(),
-    );
+            .unwrap();
+
+        assert_gt!(transmission_consumption_before_response.get(), 0);
+        assert_gt!(instruction_consumption_before_response.get(), 0);
+
+        // Canister A executed the response.
+        test.induct_messages();
+        test.execute_message(a_id);
+
+        let ingress_state = test.ingress_state(&message_id);
+
+        if let IngressState::Completed(wasm_result) = ingress_state {
+            match wasm_result {
+                WasmResult::Reject(result) => panic!("unexpected result {result}"),
+                WasmResult::Reply(_) => (),
+            }
+        } else {
+            panic!("unexpected ingress state {ingress_state:?}");
+        }
+
+        let transmission_cost = test.call_fee("update", &b_callback) + test.reply_fee(&b_callback);
+
+        let execution_cost = test.canister_execution_cost(a_id);
+
+        // Check that canister A's balance is updated correctly.
+        assert_eq!(
+            test.canister_state(a_id).system_state.balance(),
+            initial_cycles - execution_cost.real() - transmission_cost.real() - transferred_cycles
+        );
+
+        assert_eq!(
+            test.canister_state(a_id)
+                .system_state
+                .canister_metrics()
+                .consumed_cycles_by_use_cases()
+                .len(),
+            2
+        );
+
+        let transmission_consumption_after_response = *test
+            .canister_state(a_id)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_by_use_cases()
+            .get(&CyclesUseCase::RequestAndResponseTransmission)
+            .unwrap();
+        let instruction_consumption_after_response = *test
+            .canister_state(a_id)
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_by_use_cases()
+            .get(&CyclesUseCase::Instructions)
+            .unwrap();
+
+        // Check that consumed cycles are correct for both use cases.
+        assert_eq!(
+            transmission_consumption_after_response,
+            transmission_cost.nominal(),
+        );
+
+        assert_eq!(
+            instruction_consumption_after_response,
+            execution_cost.nominal(),
+        );
+
+        // Consumed cycles after the response should be smaller than before
+        // the response because we expect a refund for prepaid cycles.
+        assert_lt!(
+            transmission_consumption_after_response,
+            transmission_consumption_before_response
+        );
+        assert_lt!(
+            instruction_consumption_after_response,
+            instruction_consumption_before_response
+        );
+
+        // Check that canister B's balance is updated correctly.
+        assert_eq!(
+            test.canister_state(b_id).system_state.balance(),
+            initial_cycles - test.canister_execution_cost(b_id).real() + transferred_cycles
+        );
+
+        // Check that consumed cycles are correct only for the `Instructions` use case.
+        assert_eq!(
+            test.canister_state(b_id)
+                .system_state
+                .canister_metrics()
+                .consumed_cycles_by_use_cases()
+                .len(),
+            1
+        );
+
+        assert_eq!(
+            *test
+                .canister_state(b_id)
+                .system_state
+                .canister_metrics()
+                .consumed_cycles_by_use_cases()
+                .get(&CyclesUseCase::Instructions)
+                .unwrap(),
+            test.canister_execution_cost(b_id).nominal(),
+        );
+    }
 }
 
 #[test]

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -65,7 +65,9 @@ use ic_types::{
     },
     methods::{Callback, FuncRef, SystemMethod, WasmClosure, WasmMethod},
 };
-use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
+use ic_types_cycles::{
+    CanisterCyclesCostSchedule, CompoundCycles, Cycles, ECDSAOutcalls, HTTPOutcalls,
+};
 use ic_wasm_types::CanisterModule;
 use maplit::btreemap;
 use std::{collections::BTreeSet, time::Duration};
@@ -681,18 +683,20 @@ impl SchedulerTest {
         self.state_mut().metadata.batch_time = time;
     }
 
+    /// Advances the time in `ReplicatedState` by the provided duration.
+    pub(crate) fn advance_time(&mut self, duration: Duration) {
+        self.state_mut().metadata.batch_time += duration;
+    }
+
     pub fn subnet_size(&self) -> usize {
         self.registry_settings.subnet_size
     }
 
-    pub fn ecdsa_signature_fee(&self) -> Cycles {
-        self.scheduler
-            .cycles_account_manager
-            .ecdsa_signature_fee(
-                self.registry_settings.subnet_size,
-                self.state().get_own_cost_schedule(),
-            )
-            .real()
+    pub fn ecdsa_signature_fee(&self) -> CompoundCycles<ECDSAOutcalls> {
+        self.scheduler.cycles_account_manager.ecdsa_signature_fee(
+            self.registry_settings.subnet_size,
+            self.state().get_own_cost_schedule(),
+        )
     }
 
     pub fn schnorr_signature_fee(&self) -> Cycles {
@@ -709,28 +713,41 @@ impl SchedulerTest {
         &self,
         request_size: NumBytes,
         response_size_limit: Option<NumBytes>,
-    ) -> Cycles {
-        self.scheduler
-            .cycles_account_manager
-            .http_request_fee(
-                request_size,
-                response_size_limit,
-                self.subnet_size(),
-                self.state.as_ref().unwrap().get_own_cost_schedule(),
-            )
-            .real()
+    ) -> CompoundCycles<HTTPOutcalls> {
+        self.scheduler.cycles_account_manager.http_request_fee(
+            request_size,
+            response_size_limit,
+            self.subnet_size(),
+            self.state.as_ref().unwrap().get_own_cost_schedule(),
+        )
     }
 
-    pub fn memory_cost(&self, bytes: NumBytes, duration: Duration) -> Cycles {
+    pub fn memory_cost(
+        &self,
+        bytes: NumBytes,
+        duration: Duration,
+    ) -> CompoundCycles<ic_types_cycles::Memory> {
+        self.scheduler.cycles_account_manager.memory_cost(
+            bytes,
+            duration,
+            self.subnet_size(),
+            self.state.as_ref().unwrap().get_own_cost_schedule(),
+        )
+    }
+
+    pub fn compute_allocation_cost(
+        &self,
+        compute_allocation: ComputeAllocation,
+        duration: Duration,
+    ) -> CompoundCycles<ic_types_cycles::ComputeAllocation> {
         self.scheduler
             .cycles_account_manager
-            .memory_cost(
-                bytes,
+            .compute_allocation_cost(
+                compute_allocation,
                 duration,
                 self.subnet_size(),
                 self.state.as_ref().unwrap().get_own_cost_schedule(),
             )
-            .real()
     }
 
     pub(crate) fn deliver_pre_signatures(

--- a/rs/execution_environment/src/scheduler/tests.rs
+++ b/rs/execution_environment/src/scheduler/tests.rs
@@ -174,7 +174,7 @@ fn consensus_queue_is_emptied() {
         test.inject_call_to_ic00(
             Method::SignWithECDSA,
             ecdsa_payload.clone(),
-            test.ecdsa_signature_fee(),
+            test.ecdsa_signature_fee().real(),
             canister_id,
             InputQueueType::RemoteSubnet,
         );

--- a/rs/execution_environment/src/scheduler/tests/charging.rs
+++ b/rs/execution_environment/src/scheduler/tests/charging.rs
@@ -129,10 +129,12 @@ fn charging_for_message_memory_works() {
     assert_eq!(
         canister_state.system_state.balance(),
         balance_before
-            - test.memory_cost(
-                canister_state.message_memory_usage().total(),
-                charge_duration,
-            ),
+            - test
+                .memory_cost(
+                    canister_state.message_memory_usage().total(),
+                    charge_duration,
+                )
+                .real(),
     );
 }
 
@@ -184,10 +186,12 @@ fn charging_for_logging_memory_works() {
     assert_eq!(
         canister_state.system_state.balance(),
         balance_before
-            - test.memory_cost(
-                canister_state.log_memory_store_memory_usage(),
-                charge_duration,
-            ),
+            - test
+                .memory_cost(
+                    canister_state.log_memory_store_memory_usage(),
+                    charge_duration,
+                )
+                .real(),
     );
 }
 
@@ -335,7 +339,7 @@ fn dont_charge_allocations_for_paused_canisters() {
     fn assert_balance_change(test: &SchedulerTest, canister: CanisterId, duration: Duration) {
         assert_eq!(
             test.canister_state(canister).system_state.balance(),
-            INITIAL_CYCLES - test.memory_cost(MEMORY_ALLOCATION, duration)
+            INITIAL_CYCLES - test.memory_cost(MEMORY_ALLOCATION, duration).real()
         );
     }
     // Balance has changed for the canister with no paused execution.

--- a/rs/execution_environment/src/scheduler/tests/ecdsa.rs
+++ b/rs/execution_environment/src/scheduler/tests/ecdsa.rs
@@ -27,7 +27,7 @@ fn inject_ecdsa_signing_request(test: &mut SchedulerTest, key_id: &EcdsaKeyId) {
     test.inject_call_to_ic00(
         Method::SignWithECDSA,
         payload.clone(),
-        test.ecdsa_signature_fee(),
+        test.ecdsa_signature_fee().real(),
         canister_id,
         InputQueueType::RemoteSubnet,
     );

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -1219,10 +1219,8 @@ fn consumed_cycles_are_updated_from_deleted_canisters() {
             Some(CanisterStatusType::Stopped),
         );
 
-        let removed_cycles = CompoundCycles::<Instructions>::new(
-            Cycles::from(1000_u128),
-            cost_schedule,
-        );
+        let removed_cycles =
+            CompoundCycles::<Instructions>::new(Cycles::from(1000_u128), cost_schedule);
         test.canister_state_mut(canister_id)
             .system_state
             .consume_cycles(removed_cycles);
@@ -1253,9 +1251,11 @@ fn consumed_cycles_are_updated_from_deleted_canisters() {
                     &[("use_case", "Instructions")],
                     removed_cycles.nominal().get() as f64
                 ),
+                // All cycles that remain in the canister's balance are lost when
+                // the canister is deleted.
                 (
                     &[("use_case", "DeletedCanisters")],
-                    (initial_balance.get() - removed_cycles.nominal().get()) as f64
+                    (initial_balance - removed_cycles.real()).get() as f64
                 )
             ]),
         );

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -662,14 +662,14 @@ fn threshold_signature_agreements_metric_is_updated() {
     test.inject_call_to_ic00(
         Method::SignWithECDSA,
         ecdsa_payload.clone(),
-        test.ecdsa_signature_fee(),
+        test.ecdsa_signature_fee().real(),
         canister_id,
         InputQueueType::RemoteSubnet,
     );
     test.inject_call_to_ic00(
         Method::SignWithECDSA,
         ecdsa_payload,
-        test.ecdsa_signature_fee(),
+        test.ecdsa_signature_fee().real(),
         canister_id,
         InputQueueType::RemoteSubnet,
     );
@@ -844,180 +844,193 @@ fn threshold_signature_agreements_metric_is_updated() {
 
 #[test]
 fn consumed_cycles_ecdsa_outcalls_are_added_to_consumed_cycles_total() {
-    let key_id = make_ecdsa_key_id(0);
-    let mut test = SchedulerTestBuilder::new()
-        .with_chain_key(MasterPublicKeyId::Ecdsa(key_id.clone()))
-        .build();
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        let key_id = make_ecdsa_key_id(0);
+        let mut test = SchedulerTestBuilder::new()
+            .with_chain_key(MasterPublicKeyId::Ecdsa(key_id.clone()))
+            .with_cost_schedule(cost_schedule)
+            .build();
 
-    let fee = test.ecdsa_signature_fee();
-    let payment = fee;
+        let fee = test.ecdsa_signature_fee();
+        let payment = fee.real();
 
-    let canister_id = test.create_canister();
+        let canister_id = test.create_canister();
 
-    test.scheduler().state_metrics.observe(
-        test.scheduler().own_subnet_id,
-        test.state(),
-        0.into(),
-        &no_op_logger(),
-    );
+        test.scheduler().state_metrics.observe(
+            test.scheduler().own_subnet_id,
+            test.state(),
+            0.into(),
+            &no_op_logger(),
+        );
 
-    let consumed_cycles_before = NominalCycles::new(
-        fetch_gauge(
-            test.metrics_registry(),
-            "replicated_state_consumed_cycles_since_replica_started",
-        )
-        .unwrap() as u128,
-    );
+        let consumed_cycles_before = NominalCycles::new(
+            fetch_gauge(
+                test.metrics_registry(),
+                "replicated_state_consumed_cycles_since_replica_started",
+            )
+            .unwrap() as u128,
+        );
 
-    test.inject_call_to_ic00(
-        Method::SignWithECDSA,
-        Encode!(&SignWithECDSAArgs {
-            message_hash: [0; 32],
-            derivation_path: DerivationPath::new(Vec::new()),
-            key_id,
-        })
-        .unwrap(),
-        payment,
-        canister_id,
-        InputQueueType::RemoteSubnet,
-    );
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
+        test.inject_call_to_ic00(
+            Method::SignWithECDSA,
+            Encode!(&SignWithECDSAArgs {
+                message_hash: [0; 32],
+                derivation_path: DerivationPath::new(Vec::new()),
+                key_id,
+            })
+            .unwrap(),
+            payment,
+            canister_id,
+            InputQueueType::RemoteSubnet,
+        );
+        test.execute_round(ExecutionRoundType::OrdinaryRound);
 
-    // Check that the SubnetCallContextManager contains the request.
-    let sign_with_ecdsa_contexts = &test
-        .state()
-        .metadata
-        .subnet_call_context_manager
-        .sign_with_ecdsa_contexts();
-    assert_eq!(sign_with_ecdsa_contexts.len(), 1);
+        // Check that the SubnetCallContextManager contains the request.
+        let sign_with_ecdsa_contexts = &test
+            .state()
+            .metadata
+            .subnet_call_context_manager
+            .sign_with_ecdsa_contexts();
+        assert_eq!(sign_with_ecdsa_contexts.len(), 1);
 
-    test.scheduler().state_metrics.observe(
-        test.scheduler().own_subnet_id,
-        test.state(),
-        0.into(),
-        &no_op_logger(),
-    );
-    let consumed_cycles_after = NominalCycles::new(
-        fetch_gauge(
-            test.metrics_registry(),
-            "replicated_state_consumed_cycles_since_replica_started",
-        )
-        .unwrap() as u128,
-    );
+        test.scheduler().state_metrics.observe(
+            test.scheduler().own_subnet_id,
+            test.state(),
+            0.into(),
+            &no_op_logger(),
+        );
+        let consumed_cycles_after = NominalCycles::new(
+            fetch_gauge(
+                test.metrics_registry(),
+                "replicated_state_consumed_cycles_since_replica_started",
+            )
+            .unwrap() as u128,
+        );
 
-    assert_eq!(
-        consumed_cycles_before + NominalCycles::new(fee.get()),
-        consumed_cycles_after
-    );
+        assert_eq!(
+            consumed_cycles_before + fee.nominal(),
+            consumed_cycles_after
+        );
 
-    assert_eq!(
-        fetch_gauge_vec(
-            test.metrics_registry(),
-            "replicated_state_consumed_cycles_from_replica_start",
-        ),
-        metric_vec(&[(&[("use_case", "ECDSAOutcalls")], fee.get() as f64),]),
-    );
+        assert_eq!(
+            fetch_gauge_vec(
+                test.metrics_registry(),
+                "replicated_state_consumed_cycles_from_replica_start",
+            ),
+            metric_vec(&[(&[("use_case", "ECDSAOutcalls")], fee.nominal().get() as f64),]),
+        );
+    }
 }
 
 #[test]
 fn consumed_cycles_http_outcalls_are_added_to_consumed_cycles_total() {
-    let mut test = SchedulerTestBuilder::new().build();
-    let caller_canister = test.create_canister();
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        let mut test = SchedulerTestBuilder::new()
+            .with_cost_schedule(cost_schedule)
+            .build();
+        let caller_canister = test.create_canister();
 
-    test.state_mut().metadata.own_subnet_features.http_requests = true;
+        test.state_mut().metadata.own_subnet_features.http_requests = true;
 
-    test.scheduler().state_metrics.observe(
-        test.scheduler().own_subnet_id,
-        test.state(),
-        0.into(),
-        &no_op_logger(),
-    );
+        test.scheduler().state_metrics.observe(
+            test.scheduler().own_subnet_id,
+            test.state(),
+            0.into(),
+            &no_op_logger(),
+        );
 
-    let consumed_cycles_before = NominalCycles::new(
-        fetch_gauge(
-            test.metrics_registry(),
-            "replicated_state_consumed_cycles_since_replica_started",
-        )
-        .unwrap() as u128,
-    );
+        let consumed_cycles_before = NominalCycles::new(
+            fetch_gauge(
+                test.metrics_registry(),
+                "replicated_state_consumed_cycles_since_replica_started",
+            )
+            .unwrap() as u128,
+        );
 
-    // Create payload of the request.
-    let url = "https://".to_string();
-    let response_size_limit = 1000_u64;
-    let transform_method_name = "transform".to_string();
-    let transform_context = vec![0, 1, 2];
-    let args = CanisterHttpRequestArgs {
-        url,
-        max_response_bytes: Some(response_size_limit),
-        headers: BoundedHttpHeaders::new(vec![]),
-        body: None,
-        method: HttpMethod::GET,
-        transform: Some(TransformContext {
-            function: TransformFunc(candid::Func {
-                principal: caller_canister.get().0,
-                method: transform_method_name,
+        // Create payload of the request.
+        let url = "https://".to_string();
+        let response_size_limit = 1000_u64;
+        let transform_method_name = "transform".to_string();
+        let transform_context = vec![0, 1, 2];
+        let args = CanisterHttpRequestArgs {
+            url,
+            max_response_bytes: Some(response_size_limit),
+            headers: BoundedHttpHeaders::new(vec![]),
+            body: None,
+            method: HttpMethod::GET,
+            transform: Some(TransformContext {
+                function: TransformFunc(candid::Func {
+                    principal: caller_canister.get().0,
+                    method: transform_method_name,
+                }),
+                context: transform_context,
             }),
-            context: transform_context,
-        }),
-        is_replicated: None,
-        pricing_version: None,
-    };
+            is_replicated: None,
+            pricing_version: None,
+        };
 
-    // Create request to `HttpRequest` method.
-    let payment = Cycles::new(1_000_000_000);
-    let payload = args.encode();
-    test.inject_call_to_ic00(
-        Method::HttpRequest,
-        payload,
-        payment,
-        caller_canister,
-        InputQueueType::RemoteSubnet,
-    );
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
+        // Create request to `HttpRequest` method.
+        let payment = Cycles::new(1_000_000_000);
+        let payload = args.encode();
+        test.inject_call_to_ic00(
+            Method::HttpRequest,
+            payload,
+            payment,
+            caller_canister,
+            InputQueueType::RemoteSubnet,
+        );
+        test.execute_round(ExecutionRoundType::OrdinaryRound);
 
-    // Check that the SubnetCallContextManager contains the request.
-    let canister_http_request_contexts = &test
-        .state()
-        .metadata
-        .subnet_call_context_manager
-        .canister_http_request_contexts;
-    assert_eq!(canister_http_request_contexts.len(), 1);
+        // Check that the SubnetCallContextManager contains the request.
+        let canister_http_request_contexts = &test
+            .state()
+            .metadata
+            .subnet_call_context_manager
+            .canister_http_request_contexts;
+        assert_eq!(canister_http_request_contexts.len(), 1);
 
-    let http_request_context = canister_http_request_contexts
-        .get(&CallbackId::from(0))
-        .unwrap();
+        let http_request_context = canister_http_request_contexts
+            .get(&CallbackId::from(0))
+            .unwrap();
 
-    let fee = test.http_request_fee(
-        http_request_context.variable_parts_size(),
-        Some(NumBytes::from(response_size_limit)),
-    );
+        let fee = test.http_request_fee(
+            http_request_context.variable_parts_size(),
+            Some(NumBytes::from(response_size_limit)),
+        );
 
-    test.scheduler().state_metrics.observe(
-        test.scheduler().own_subnet_id,
-        test.state(),
-        0.into(),
-        &no_op_logger(),
-    );
-    let consumed_cycles_after = NominalCycles::new(
-        fetch_gauge(
-            test.metrics_registry(),
-            "replicated_state_consumed_cycles_since_replica_started",
-        )
-        .unwrap() as u128,
-    );
+        test.scheduler().state_metrics.observe(
+            test.scheduler().own_subnet_id,
+            test.state(),
+            0.into(),
+            &no_op_logger(),
+        );
+        let consumed_cycles_after = NominalCycles::new(
+            fetch_gauge(
+                test.metrics_registry(),
+                "replicated_state_consumed_cycles_since_replica_started",
+            )
+            .unwrap() as u128,
+        );
 
-    assert_eq!(
-        consumed_cycles_before + NominalCycles::new(fee.get()),
-        consumed_cycles_after
-    );
+        assert_eq!(
+            consumed_cycles_before + fee.nominal(),
+            consumed_cycles_after
+        );
 
-    assert_eq!(
-        fetch_gauge_vec(
-            test.metrics_registry(),
-            "replicated_state_consumed_cycles_from_replica_start",
-        ),
-        metric_vec(&[(&[("use_case", "HTTPOutcalls")], fee.get() as f64),]),
-    );
+        assert_eq!(
+            fetch_gauge_vec(
+                test.metrics_registry(),
+                "replicated_state_consumed_cycles_from_replica_start",
+            ),
+            metric_vec(&[(&[("use_case", "HTTPOutcalls")], fee.nominal().get() as f64),]),
+        );
+    }
 }
 
 #[test]
@@ -1081,104 +1094,172 @@ fn http_outcalls_free() {
         http_request_context.variable_parts_size(),
         Some(NumBytes::from(response_size_limit)),
     );
-    assert_eq!(fee, Cycles::new(0));
+    assert_eq!(fee.real(), Cycles::new(0));
     let cycles_after = test.canister_state(caller_canister).system_state.balance();
     assert_eq!(cycles_before, cycles_after);
 }
 
 #[test]
-fn consumed_cycles_are_updated_from_valid_canisters() {
-    let mut test = SchedulerTestBuilder::new().build();
-
-    let canister_id = test.create_canister_with(
-        Cycles::from(5_000_000_000_000_u128),
-        ComputeAllocation::zero(),
-        MemoryAllocation::default(),
-        None,
-        None,
-        None,
-    );
-
-    let consumed_cycles = CompoundCycles::<Instructions>::new(
-        Cycles::from(1000_u128),
+fn consumed_cycles_for_instructions_are_updated_from_valid_canisters() {
+    for cost_schedule in [
         CanisterCyclesCostSchedule::Normal,
-    );
-    test.canister_state_mut(canister_id)
-        .system_state
-        .consume_cycles(consumed_cycles);
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        let mut test = SchedulerTestBuilder::new()
+            .with_cost_schedule(cost_schedule)
+            .build();
 
-    test.scheduler().state_metrics.observe(
-        test.scheduler().own_subnet_id,
-        test.state(),
-        0.into(),
-        &no_op_logger(),
-    );
+        let canister_id = test.create_canister_with(
+            Cycles::from(5_000_000_000_000_u128),
+            ComputeAllocation::zero(),
+            MemoryAllocation::default(),
+            None,
+            None,
+            None,
+        );
 
-    assert_eq!(
-        fetch_gauge_vec(
-            test.metrics_registry(),
-            "replicated_state_consumed_cycles_from_replica_start",
-        ),
-        metric_vec(&[(
-            &[("use_case", "Instructions")],
-            consumed_cycles.nominal().get() as f64
-        ),]),
-    );
+        let removed_cycles =
+            CompoundCycles::<Instructions>::new(Cycles::from(1000_u128), cost_schedule);
+        test.canister_state_mut(canister_id)
+            .system_state
+            .consume_cycles(removed_cycles);
+
+        test.scheduler().state_metrics.observe(
+            test.scheduler().own_subnet_id,
+            test.state(),
+            0.into(),
+            &no_op_logger(),
+        );
+
+        assert_eq!(
+            fetch_gauge_vec(
+                test.metrics_registry(),
+                "replicated_state_consumed_cycles_from_replica_start",
+            ),
+            metric_vec(&[(
+                &[("use_case", "Instructions")],
+                removed_cycles.nominal().get() as f64
+            ),]),
+        );
+    }
+}
+
+#[test]
+fn consumed_cycles_for_resource_allocations_are_updated_from_valid_canisters() {
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        let mut test = SchedulerTestBuilder::new()
+            .with_cost_schedule(cost_schedule)
+            .build();
+
+        let compute_allocation = ComputeAllocation::try_from(20).unwrap();
+        let memory_allocation = NumBytes::from(10_000_000);
+        test.create_canister_with(
+            Cycles::from(5_000_000_000_000_u128),
+            compute_allocation,
+            MemoryAllocation::from(memory_allocation),
+            None,
+            None,
+            None,
+        );
+
+        // Advance time by a few minutes and charge for resource allocations.
+        let duration = Duration::from_secs(5 * 60);
+        test.advance_time(duration);
+        test.charge_for_resource_allocations();
+
+        test.scheduler().state_metrics.observe(
+            test.scheduler().own_subnet_id,
+            test.state(),
+            0.into(),
+            &no_op_logger(),
+        );
+
+        assert_eq!(
+            fetch_gauge_vec(
+                test.metrics_registry(),
+                "replicated_state_consumed_cycles_from_replica_start",
+            ),
+            metric_vec(&[
+                (
+                    &[("use_case", "Memory")],
+                    test.memory_cost(memory_allocation, duration)
+                        .nominal()
+                        .get() as f64
+                ),
+                (
+                    &[("use_case", "ComputeAllocation")],
+                    test.compute_allocation_cost(compute_allocation, duration)
+                        .nominal()
+                        .get() as f64,
+                ),
+            ]),
+        );
+    }
 }
 
 #[test]
 fn consumed_cycles_are_updated_from_deleted_canisters() {
-    let mut test = SchedulerTestBuilder::new().build();
-    let initial_balance = Cycles::from(5_000_000_000_000_u128);
-    let canister_id = test.create_canister_with(
-        initial_balance,
-        ComputeAllocation::zero(),
-        MemoryAllocation::default(),
-        None,
-        None,
-        Some(CanisterStatusType::Stopped),
-    );
-
-    let consumed_cycles = CompoundCycles::<Instructions>::new(
-        Cycles::from(1000_u128),
+    for cost_schedule in [
         CanisterCyclesCostSchedule::Normal,
-    );
-    test.canister_state_mut(canister_id)
-        .system_state
-        .consume_cycles(consumed_cycles);
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        let mut test = SchedulerTestBuilder::new()
+            .with_cost_schedule(cost_schedule)
+            .build();
+        let initial_balance = Cycles::from(5_000_000_000_000_u128);
+        let canister_id = test.create_canister_with(
+            initial_balance,
+            ComputeAllocation::zero(),
+            MemoryAllocation::default(),
+            None,
+            None,
+            Some(CanisterStatusType::Stopped),
+        );
 
-    test.inject_call_to_ic00(
-        Method::DeleteCanister,
-        CanisterIdRecord::from(canister_id).encode(),
-        Cycles::from(1_000_000_000_000_u128),
-        CanisterId::try_from(user_test_id(1).get()).unwrap(),
-        InputQueueType::RemoteSubnet,
-    );
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
+        let removed_cycles = CompoundCycles::<Instructions>::new(
+            Cycles::from(1000_u128),
+            CanisterCyclesCostSchedule::Normal,
+        );
+        test.canister_state_mut(canister_id)
+            .system_state
+            .consume_cycles(removed_cycles);
 
-    test.scheduler().state_metrics.observe(
-        test.scheduler().own_subnet_id,
-        test.state(),
-        0.into(),
-        &no_op_logger(),
-    );
+        test.inject_call_to_ic00(
+            Method::DeleteCanister,
+            CanisterIdRecord::from(canister_id).encode(),
+            Cycles::from(1_000_000_000_000_u128),
+            CanisterId::try_from(user_test_id(1).get()).unwrap(),
+            InputQueueType::RemoteSubnet,
+        );
+        test.execute_round(ExecutionRoundType::OrdinaryRound);
 
-    assert_eq!(
-        fetch_gauge_vec(
-            test.metrics_registry(),
-            "replicated_state_consumed_cycles_from_replica_start",
-        ),
-        metric_vec(&[
-            (
-                &[("use_case", "Instructions")],
-                consumed_cycles.nominal().get() as f64
+        test.scheduler().state_metrics.observe(
+            test.scheduler().own_subnet_id,
+            test.state(),
+            0.into(),
+            &no_op_logger(),
+        );
+
+        assert_eq!(
+            fetch_gauge_vec(
+                test.metrics_registry(),
+                "replicated_state_consumed_cycles_from_replica_start",
             ),
-            (
-                &[("use_case", "DeletedCanisters")],
-                (initial_balance.get() - consumed_cycles.nominal().get()) as f64
-            )
-        ]),
-    );
+            metric_vec(&[
+                (
+                    &[("use_case", "Instructions")],
+                    removed_cycles.nominal().get() as f64
+                ),
+                (
+                    &[("use_case", "DeletedCanisters")],
+                    (initial_balance.get() - removed_cycles.nominal().get()) as f64
+                )
+            ]),
+        );
+    }
 }
 
 #[test]

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -1221,7 +1221,7 @@ fn consumed_cycles_are_updated_from_deleted_canisters() {
 
         let removed_cycles = CompoundCycles::<Instructions>::new(
             Cycles::from(1000_u128),
-            CanisterCyclesCostSchedule::Normal,
+            cost_schedule,
         );
         test.canister_state_mut(canister_id)
             .system_state

--- a/rs/messaging/src/routing/stream_handler/tests.rs
+++ b/rs/messaging/src/routing/stream_handler/tests.rs
@@ -1238,61 +1238,66 @@ fn garbage_collect_local_state_with_reject_signals_for_request_success() {
 /// due to induction failure because no such canister is installed on `LOCAL_SUBNET`.
 #[test]
 fn garbage_collect_local_state_with_reject_signals_for_request_from_absent_canister() {
-    with_test_setup(
-        // An outgoing stream with one request from an absent `OTHER_LOCAL_CANISTER` @21 in it.
-        btreemap![REMOTE_SUBNET => StreamConfig {
-            begin: 21,
-            messages: vec![Request(*OTHER_LOCAL_CANISTER, *REMOTE_CANISTER)],
-            ..StreamConfig::default()
-        }],
-        // An incoming stream slice with one reject signal for the request @21.
-        btreemap![REMOTE_SUBNET => StreamSliceConfig {
-            signals_end: 22,
-            reject_signals: vec![RejectSignal::new(RejectReason::CanisterStopped, 21.into())],
-            ..StreamSliceConfig::default()
-        }],
-        |stream_handler, state, slices, metrics| {
-            let mut expected_state = state.clone();
-            // The expected outgoing stream is empty with `begin` avanced.
-            let expected_stream = stream_from_config(StreamConfig {
-                begin: 22,
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        with_test_setup(
+            // An outgoing stream with one request from an absent `OTHER_LOCAL_CANISTER` @21 in it.
+            btreemap![REMOTE_SUBNET => StreamConfig {
+                begin: 21,
+                messages: vec![Request(*OTHER_LOCAL_CANISTER, *REMOTE_CANISTER)],
                 ..StreamConfig::default()
-            });
-            expected_state.with_streams(btreemap![REMOTE_SUBNET => expected_stream]);
-            // Cycles attached to the request / reject response are lost.
-            expected_state.observe_lost_cycles_due_to_dropped_messages(CompoundCycles::new(
-                message_in_stream(state.get_stream(&REMOTE_SUBNET), 21).cycles(),
-                CanisterCyclesCostSchedule::Normal,
-            ));
+            }],
+            // An incoming stream slice with one reject signal for the request @21.
+            btreemap![REMOTE_SUBNET => StreamSliceConfig {
+                signals_end: 22,
+                reject_signals: vec![RejectSignal::new(RejectReason::CanisterStopped, 21.into())],
+                ..StreamSliceConfig::default()
+            }],
+            |stream_handler, state, slices, metrics| {
+                let mut expected_state = state.clone();
+                // The expected outgoing stream is empty with `begin` avanced.
+                let expected_stream = stream_from_config(StreamConfig {
+                    begin: 22,
+                    ..StreamConfig::default()
+                });
+                expected_state.with_streams(btreemap![REMOTE_SUBNET => expected_stream]);
+                // Cycles attached to the request / reject response are lost.
+                expected_state.observe_lost_cycles_due_to_dropped_messages(CompoundCycles::new(
+                    message_in_stream(state.get_stream(&REMOTE_SUBNET), 21).cycles(),
+                    cost_schedule,
+                ));
 
-            // Act and compare to expected.
-            let mut available_guaranteed_response_memory =
-                stream_handler.available_guaranteed_response_memory(&state);
-            let inducted_state = stream_handler.garbage_collect_local_state(
-                state,
-                &mut available_guaranteed_response_memory,
-                &slices,
-            );
-            assert_eq!(expected_state, inducted_state);
-            assert_eq!(
-                available_guaranteed_response_memory,
-                stream_handler.available_guaranteed_response_memory(&inducted_state),
-            );
+                // Act and compare to expected.
+                let mut available_guaranteed_response_memory =
+                    stream_handler.available_guaranteed_response_memory(&state);
+                let inducted_state = stream_handler.garbage_collect_local_state(
+                    state,
+                    &mut available_guaranteed_response_memory,
+                    &slices,
+                );
+                assert_eq!(expected_state, inducted_state);
+                assert_eq!(
+                    available_guaranteed_response_memory,
+                    stream_handler.available_guaranteed_response_memory(&inducted_state),
+                );
 
-            // 1 reject response failed to induct.
-            metrics.assert_inducted_xnet_messages_eq(&[(
-                LABEL_VALUE_TYPE_RESPONSE,
-                LABEL_VALUE_CANISTER_NOT_FOUND,
-                1,
-            )]);
+                // 1 reject response failed to induct.
+                metrics.assert_inducted_xnet_messages_eq(&[(
+                    LABEL_VALUE_TYPE_RESPONSE,
+                    LABEL_VALUE_CANISTER_NOT_FOUND,
+                    1,
+                )]);
 
-            // One critical error raised.
-            metrics.assert_eq_critical_errors(CriticalErrorCounts {
-                induct_response_failed: 1,
-                ..CriticalErrorCounts::default()
-            });
-        },
-    );
+                // One critical error raised.
+                metrics.assert_eq_critical_errors(CriticalErrorCounts {
+                    induct_response_failed: 1,
+                    ..CriticalErrorCounts::default()
+                });
+            },
+        );
+    }
 }
 
 /// Tests that an incoming reject signal for a request to and from `LOCAL_CANISTER` in the stream
@@ -1517,87 +1522,97 @@ fn garbage_collect_local_state_with_reject_signals_for_misrouted_refunds() {
 /// everything else is treated as a misrouted message, i.e. accepted but dropped.
 #[test]
 fn induct_stream_slices_reject_response_from_old_host_subnet_is_accepted() {
-    with_test_setup(
-        // A stream slice with 3 messages in it...
-        btreemap![],
-        btreemap![CANISTER_MIGRATION_SUBNET => StreamSliceConfig {
-            messages_begin: 0,
-            messages: vec![
-                // ...a reject response for a request sent to `REMOTE_CANISTER` @0...
-                RejectResponse(*REMOTE_CANISTER, *LOCAL_CANISTER, RejectReason::QueueFull),
-                // ...a reply @1...
-                Response(*REMOTE_CANISTER, *LOCAL_CANISTER),
-                // ...and a request @2.
-                Request(*REMOTE_CANISTER, *LOCAL_CANISTER),
-            ],
-            ..StreamSliceConfig::default()
-        }],
-        |stream_handler, state, slices, metrics| {
-            // Mark `LOCAL_CANISTER` as having migrated from `CANISTER_MIGRATION_SUBNET` to `LOCAL_SUBNET`.
-            let state = simulate_canister_migration(
-                state,
-                *LOCAL_CANISTER,
-                CANISTER_MIGRATION_SUBNET,
-                LOCAL_SUBNET,
-            );
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        with_test_setup(
+            // A stream slice with 3 messages in it...
+            btreemap![],
+            btreemap![CANISTER_MIGRATION_SUBNET => StreamSliceConfig {
+                messages_begin: 0,
+                messages: vec![
+                    // ...a reject response for a request sent to `REMOTE_CANISTER` @0...
+                    RejectResponse(*REMOTE_CANISTER, *LOCAL_CANISTER, RejectReason::QueueFull),
+                    // ...a reply @1...
+                    Response(*REMOTE_CANISTER, *LOCAL_CANISTER),
+                    // ...and a request @2.
+                    Request(*REMOTE_CANISTER, *LOCAL_CANISTER),
+                ],
+                ..StreamSliceConfig::default()
+            }],
+            |stream_handler, state, slices, metrics| {
+                // Mark `LOCAL_CANISTER` as having migrated from `CANISTER_MIGRATION_SUBNET` to `LOCAL_SUBNET`.
+                let state = simulate_canister_migration(
+                    state,
+                    *LOCAL_CANISTER,
+                    CANISTER_MIGRATION_SUBNET,
+                    LOCAL_SUBNET,
+                );
 
-            // Expect a state, where the reject response was successfully inducted...
-            let mut expected_state = state.clone();
-            push_input(
-                &mut expected_state,
-                message_in_slice(slices.get(&CANISTER_MIGRATION_SUBNET), 0).clone(),
-            );
-            // ...and a stream to `CANISTER_MIGRATION_SUBNET` with the 2 responses accepted and the request rejected.
-            let expected_stream = stream_from_config(StreamConfig {
-                begin: 0,
-                signals_end: 3,
-                reject_signals: vec![RejectSignal::new(RejectReason::CanisterMigrating, 2.into())],
-                ..StreamConfig::default()
-            });
-            expected_state.with_streams(btreemap![CANISTER_MIGRATION_SUBNET => expected_stream]);
+                // Expect a state, where the reject response was successfully inducted...
+                let mut expected_state = state.clone();
+                push_input(
+                    &mut expected_state,
+                    message_in_slice(slices.get(&CANISTER_MIGRATION_SUBNET), 0).clone(),
+                );
+                // ...and a stream to `CANISTER_MIGRATION_SUBNET` with the 2 responses accepted and the request rejected.
+                let expected_stream = stream_from_config(StreamConfig {
+                    begin: 0,
+                    signals_end: 3,
+                    reject_signals: vec![RejectSignal::new(
+                        RejectReason::CanisterMigrating,
+                        2.into(),
+                    )],
+                    ..StreamConfig::default()
+                });
+                expected_state
+                    .with_streams(btreemap![CANISTER_MIGRATION_SUBNET => expected_stream]);
 
-            // Cycles attached to the dropped reply are lost.
-            let cycles_lost = message_in_slice(slices.get(&CANISTER_MIGRATION_SUBNET), 1).cycles();
-            expected_state.observe_lost_cycles_due_to_dropped_messages(CompoundCycles::new(
-                cycles_lost,
-                CanisterCyclesCostSchedule::Normal,
-            ));
+                // Cycles attached to the dropped reply are lost.
+                let cycles_lost =
+                    message_in_slice(slices.get(&CANISTER_MIGRATION_SUBNET), 1).cycles();
+                expected_state.observe_lost_cycles_due_to_dropped_messages(CompoundCycles::new(
+                    cycles_lost,
+                    cost_schedule,
+                ));
 
-            let mut available_guaranteed_response_memory =
-                stream_handler.available_guaranteed_response_memory(&state);
-            let inducted_state = stream_handler.induct_stream_slices(
-                state,
-                slices,
-                &mut available_guaranteed_response_memory,
-            );
+                let mut available_guaranteed_response_memory =
+                    stream_handler.available_guaranteed_response_memory(&state);
+                let inducted_state = stream_handler.induct_stream_slices(
+                    state,
+                    slices,
+                    &mut available_guaranteed_response_memory,
+                );
 
-            // Compare inducted to expected.
-            assert_eq!(expected_state, inducted_state);
-            assert_eq!(
-                stream_handler.available_guaranteed_response_memory(&inducted_state),
-                available_guaranteed_response_memory
-            );
+                // Compare inducted to expected.
+                assert_eq!(expected_state, inducted_state);
+                assert_eq!(
+                    stream_handler.available_guaranteed_response_memory(&inducted_state),
+                    available_guaranteed_response_memory
+                );
 
-            // Expect the reject response was inducted, the response and request got rejected.
-            metrics.assert_inducted_xnet_messages_eq(&[
-                (
-                    LABEL_VALUE_TYPE_RESPONSE,
-                    LABEL_VALUE_SENDER_SUBNET_MISMATCH,
-                    1,
-                ),
-                (
-                    LABEL_VALUE_TYPE_REQUEST,
-                    LABEL_VALUE_SENDER_SUBNET_MISMATCH_MIGRATING,
-                    1,
-                ),
-                (LABEL_VALUE_TYPE_RESPONSE, LABEL_VALUE_SUCCESS, 1),
-            ]);
-            metrics.assert_eq_critical_errors(CriticalErrorCounts {
-                sender_subnet_mismatch: 1,
-                ..CriticalErrorCounts::default()
-            });
-        },
-    );
+                // Expect the reject response was inducted, the response and request got rejected.
+                metrics.assert_inducted_xnet_messages_eq(&[
+                    (
+                        LABEL_VALUE_TYPE_RESPONSE,
+                        LABEL_VALUE_SENDER_SUBNET_MISMATCH,
+                        1,
+                    ),
+                    (
+                        LABEL_VALUE_TYPE_REQUEST,
+                        LABEL_VALUE_SENDER_SUBNET_MISMATCH_MIGRATING,
+                        1,
+                    ),
+                    (LABEL_VALUE_TYPE_RESPONSE, LABEL_VALUE_SUCCESS, 1),
+                ]);
+                metrics.assert_eq_critical_errors(CriticalErrorCounts {
+                    sender_subnet_mismatch: 1,
+                    ..CriticalErrorCounts::default()
+                });
+            },
+        );
+    }
 }
 
 /// During single canister migration, we enforce that the canister has no ongoing calls.
@@ -2085,143 +2100,148 @@ fn inducting_best_effort_response_addressed_to_non_existent_canister_does_not_ra
 /// as appropriate.
 #[test]
 fn induct_stream_slices_partial_success() {
-    with_test_setup(
-        // An outgoing stream with one request and one response in it.
-        btreemap![REMOTE_SUBNET => StreamConfig {
-            begin: 31,
-            messages: vec![
-                Request(*LOCAL_CANISTER, *REMOTE_CANISTER),
-                Response(*LOCAL_CANISTER, *REMOTE_CANISTER),
-            ],
-            signals_end: 43,
-            ..StreamConfig::default()
-        }],
-        // An incoming stream slice with...
-        btreemap![REMOTE_SUBNET => StreamSliceConfig {
-            messages_begin: 43,
-            messages: vec![
-                // ...two incoming requests @43 and @44...
-                Request(*REMOTE_CANISTER, *LOCAL_CANISTER),
-                Request(*REMOTE_CANISTER, *LOCAL_CANISTER),
-                // ...an incoming response @45...
-                Response(*REMOTE_CANISTER, *LOCAL_CANISTER),
-                // ...a request to a missing canister @46 (on this subnet according to the
-                // routing table); this is expected to trigger a reject signal...
-                Request(*REMOTE_CANISTER, *OTHER_LOCAL_CANISTER),
-                // ...a request not from `REMOTE_SUBNET` @47; this is also expected to trigger
-                // a reject signal...
-                Request(*LOCAL_CANISTER, *LOCAL_CANISTER),
-                // ...responses not from `REMOTE_SUBNET` @48 and @49; this is expected to be dropped...
-                Response(*LOCAL_CANISTER, *LOCAL_CANISTER),
-                Response(*UNKNOWN_CANISTER, *LOCAL_CANISTER),
-                // ...a request from a canister @50 not hosted anywhere according to the routing
-                // table; expected to produce a reject signal..
-                Request(*UNKNOWN_CANISTER, *LOCAL_CANISTER),
-                // ...and a response to a missing canister @51 (on this subnet according to the
-                // routing table); this expected to be accepted but dropped.
-                Response(*REMOTE_CANISTER, *OTHER_LOCAL_CANISTER),
-            ],
-            // ...and two accept signals.
-            signals_end: 33,
-            ..StreamSliceConfig::default()
-        }],
-        |stream_handler, state, slices, metrics| {
-            let mut expected_state = state.clone();
-            // The expected state has the first 3 messages inducted.
-            push_inputs(
-                &mut expected_state,
-                messages_in_slice(slices.get(&REMOTE_SUBNET), 43..=45),
-            );
-            let response_count_bytes =
-                response_in_slice(slices.get(&REMOTE_SUBNET), 45).count_bytes();
-
-            // The expected stream has...
-            let expected_stream = stream_from_config(StreamConfig {
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        with_test_setup(
+            // An outgoing stream with one request and one response in it.
+            btreemap![REMOTE_SUBNET => StreamConfig {
                 begin: 31,
-                // ...the two initial messages as `induct_stream_slices` does not gc,
-                // a reject signal for the request to a missing canister @46...
                 messages: vec![
-                    message_in_stream(state.get_stream(&REMOTE_SUBNET), 31).clone(),
-                    message_in_stream(state.get_stream(&REMOTE_SUBNET), 32).clone(),
+                    Request(*LOCAL_CANISTER, *REMOTE_CANISTER),
+                    Response(*LOCAL_CANISTER, *REMOTE_CANISTER),
                 ],
-                // ...6 accept signals for the messages in the stream slice...
-                signals_end: 52,
-                reject_signals: vec![
-                    // ...and three reject signal for the 3 misrouted requests.
-                    RejectSignal::new(RejectReason::CanisterNotFound, 46.into()),
-                    RejectSignal::new(RejectReason::CanisterMigrating, 47.into()),
-                    RejectSignal::new(RejectReason::CanisterMigrating, 50.into()),
-                ],
+                signals_end: 43,
                 ..StreamConfig::default()
-            });
-            expected_state.with_streams(btreemap![REMOTE_SUBNET => expected_stream]);
+            }],
+            // An incoming stream slice with...
+            btreemap![REMOTE_SUBNET => StreamSliceConfig {
+                messages_begin: 43,
+                messages: vec![
+                    // ...two incoming requests @43 and @44...
+                    Request(*REMOTE_CANISTER, *LOCAL_CANISTER),
+                    Request(*REMOTE_CANISTER, *LOCAL_CANISTER),
+                    // ...an incoming response @45...
+                    Response(*REMOTE_CANISTER, *LOCAL_CANISTER),
+                    // ...a request to a missing canister @46 (on this subnet according to the
+                    // routing table); this is expected to trigger a reject signal...
+                    Request(*REMOTE_CANISTER, *OTHER_LOCAL_CANISTER),
+                    // ...a request not from `REMOTE_SUBNET` @47; this is also expected to trigger
+                    // a reject signal...
+                    Request(*LOCAL_CANISTER, *LOCAL_CANISTER),
+                    // ...responses not from `REMOTE_SUBNET` @48 and @49; this is expected to be dropped...
+                    Response(*LOCAL_CANISTER, *LOCAL_CANISTER),
+                    Response(*UNKNOWN_CANISTER, *LOCAL_CANISTER),
+                    // ...a request from a canister @50 not hosted anywhere according to the routing
+                    // table; expected to produce a reject signal..
+                    Request(*UNKNOWN_CANISTER, *LOCAL_CANISTER),
+                    // ...and a response to a missing canister @51 (on this subnet according to the
+                    // routing table); this expected to be accepted but dropped.
+                    Response(*REMOTE_CANISTER, *OTHER_LOCAL_CANISTER),
+                ],
+                // ...and two accept signals.
+                signals_end: 33,
+                ..StreamSliceConfig::default()
+            }],
+            |stream_handler, state, slices, metrics| {
+                let mut expected_state = state.clone();
+                // The expected state has the first 3 messages inducted.
+                push_inputs(
+                    &mut expected_state,
+                    messages_in_slice(slices.get(&REMOTE_SUBNET), 43..=45),
+                );
+                let response_count_bytes =
+                    response_in_slice(slices.get(&REMOTE_SUBNET), 45).count_bytes();
 
-            // Cycles attached to the responses from a wrong subnet and to non-existent `OTHER_LOCAL_CANISTER` are lost.
-            let cycles_lost = message_in_slice(slices.get(&REMOTE_SUBNET), 48).cycles()
-                + message_in_slice(slices.get(&REMOTE_SUBNET), 49).cycles()
-                + message_in_slice(slices.get(&REMOTE_SUBNET), 51).cycles();
-            expected_state.observe_lost_cycles_due_to_dropped_messages(CompoundCycles::new(
-                cycles_lost,
-                CanisterCyclesCostSchedule::Normal,
-            ));
+                // The expected stream has...
+                let expected_stream = stream_from_config(StreamConfig {
+                    begin: 31,
+                    // ...the two initial messages as `induct_stream_slices` does not gc,
+                    // a reject signal for the request to a missing canister @46...
+                    messages: vec![
+                        message_in_stream(state.get_stream(&REMOTE_SUBNET), 31).clone(),
+                        message_in_stream(state.get_stream(&REMOTE_SUBNET), 32).clone(),
+                    ],
+                    // ...6 accept signals for the messages in the stream slice...
+                    signals_end: 52,
+                    reject_signals: vec![
+                        // ...and three reject signal for the 3 misrouted requests.
+                        RejectSignal::new(RejectReason::CanisterNotFound, 46.into()),
+                        RejectSignal::new(RejectReason::CanisterMigrating, 47.into()),
+                        RejectSignal::new(RejectReason::CanisterMigrating, 50.into()),
+                    ],
+                    ..StreamConfig::default()
+                });
+                expected_state.with_streams(btreemap![REMOTE_SUBNET => expected_stream]);
 
-            let initial_available_guaranteed_response_memory =
-                stream_handler.available_guaranteed_response_memory(&state);
-            let mut available_guaranteed_response_memory =
-                initial_available_guaranteed_response_memory;
+                // Cycles attached to the responses from a wrong subnet and to non-existent `OTHER_LOCAL_CANISTER` are lost.
+                let cycles_lost = message_in_slice(slices.get(&REMOTE_SUBNET), 48).cycles()
+                    + message_in_slice(slices.get(&REMOTE_SUBNET), 49).cycles()
+                    + message_in_slice(slices.get(&REMOTE_SUBNET), 51).cycles();
+                expected_state.observe_lost_cycles_due_to_dropped_messages(CompoundCycles::new(
+                    cycles_lost,
+                    cost_schedule,
+                ));
 
-            // Act
-            let inducted_state = stream_handler.induct_stream_slices(
-                state,
-                slices,
-                &mut available_guaranteed_response_memory,
-            );
+                let initial_available_guaranteed_response_memory =
+                    stream_handler.available_guaranteed_response_memory(&state);
+                let mut available_guaranteed_response_memory =
+                    initial_available_guaranteed_response_memory;
 
-            assert_eq!(expected_state, inducted_state);
-            // 2 requests and one response inducted (consuming 2 - 1 reservations).
-            assert_eq!(
-                initial_available_guaranteed_response_memory
-                    - MAX_RESPONSE_COUNT_BYTES as i64
-                    - response_count_bytes as i64,
-                available_guaranteed_response_memory
-            );
-            assert_eq!(
-                stream_handler.available_guaranteed_response_memory(&inducted_state),
-                available_guaranteed_response_memory
-            );
+                // Act
+                let inducted_state = stream_handler.induct_stream_slices(
+                    state,
+                    slices,
+                    &mut available_guaranteed_response_memory,
+                );
 
-            metrics.assert_inducted_xnet_messages_eq(&[
-                // Requests @43 and @44 successfully inducted.
-                (LABEL_VALUE_TYPE_REQUEST, LABEL_VALUE_SUCCESS, 2),
-                // Request @46 not inducted because of missing canister.
-                (LABEL_VALUE_TYPE_REQUEST, LABEL_VALUE_CANISTER_NOT_FOUND, 1),
-                // Request @47 not inducted because of canister not on `REMOTE_SUBNET`.
-                // Request @50 not inducted because of unknown canister sender.
-                (
-                    LABEL_VALUE_TYPE_REQUEST,
-                    LABEL_VALUE_SENDER_SUBNET_MISMATCH_MIGRATING,
-                    2,
-                ),
-                // Response @45 successfully inducted.
-                (LABEL_VALUE_TYPE_RESPONSE, LABEL_VALUE_SUCCESS, 1),
-                // Responses @48 and @49 not inducted because it's a response from a wrong subnet.
-                (
-                    LABEL_VALUE_TYPE_RESPONSE,
-                    LABEL_VALUE_SENDER_SUBNET_MISMATCH,
-                    2,
-                ),
-                // Response @51 not inducted because of missing canister.
-                (LABEL_VALUE_TYPE_RESPONSE, LABEL_VALUE_CANISTER_NOT_FOUND, 1),
-            ]);
-            assert_eq!(3, metrics.fetch_inducted_payload_sizes_stats().count);
-            // Three critical errors raised.
-            metrics.assert_eq_critical_errors(CriticalErrorCounts {
-                induct_response_failed: 1,
-                sender_subnet_mismatch: 2,
-                ..CriticalErrorCounts::default()
-            });
-        },
-    );
+                assert_eq!(expected_state, inducted_state);
+                // 2 requests and one response inducted (consuming 2 - 1 reservations).
+                assert_eq!(
+                    initial_available_guaranteed_response_memory
+                        - MAX_RESPONSE_COUNT_BYTES as i64
+                        - response_count_bytes as i64,
+                    available_guaranteed_response_memory
+                );
+                assert_eq!(
+                    stream_handler.available_guaranteed_response_memory(&inducted_state),
+                    available_guaranteed_response_memory
+                );
+
+                metrics.assert_inducted_xnet_messages_eq(&[
+                    // Requests @43 and @44 successfully inducted.
+                    (LABEL_VALUE_TYPE_REQUEST, LABEL_VALUE_SUCCESS, 2),
+                    // Request @46 not inducted because of missing canister.
+                    (LABEL_VALUE_TYPE_REQUEST, LABEL_VALUE_CANISTER_NOT_FOUND, 1),
+                    // Request @47 not inducted because of canister not on `REMOTE_SUBNET`.
+                    // Request @50 not inducted because of unknown canister sender.
+                    (
+                        LABEL_VALUE_TYPE_REQUEST,
+                        LABEL_VALUE_SENDER_SUBNET_MISMATCH_MIGRATING,
+                        2,
+                    ),
+                    // Response @45 successfully inducted.
+                    (LABEL_VALUE_TYPE_RESPONSE, LABEL_VALUE_SUCCESS, 1),
+                    // Responses @48 and @49 not inducted because it's a response from a wrong subnet.
+                    (
+                        LABEL_VALUE_TYPE_RESPONSE,
+                        LABEL_VALUE_SENDER_SUBNET_MISMATCH,
+                        2,
+                    ),
+                    // Response @51 not inducted because of missing canister.
+                    (LABEL_VALUE_TYPE_RESPONSE, LABEL_VALUE_CANISTER_NOT_FOUND, 1),
+                ]);
+                assert_eq!(3, metrics.fetch_inducted_payload_sizes_stats().count);
+                // Three critical errors raised.
+                metrics.assert_eq_critical_errors(CriticalErrorCounts {
+                    induct_response_failed: 1,
+                    sender_subnet_mismatch: 2,
+                    ..CriticalErrorCounts::default()
+                });
+            },
+        );
+    }
 }
 
 /// Tests that among messages addressed to canisters not currently hosted by
@@ -2688,102 +2708,107 @@ fn system_subnet_induct_stream_slices_with_subnet_message_memory_limit() {
 /// and refunds to explicitly and implicitly migrated canisters.
 #[test]
 fn induct_stream_slices_with_refunds() {
-    with_test_setup(
-        // An empty outgoing stream.
-        btreemap![REMOTE_SUBNET => StreamConfig {
-            begin: 21,
-            messages: vec![],
-            signals_end: 43,
-            ..StreamConfig::default()
-        }],
-        // An incoming stream slice with refunds to existent and nonexistent local
-        // canisters; and to explicitly and implicitly migrated canisters.
-        btreemap![REMOTE_SUBNET => StreamSliceConfig {
-            messages_begin: 43,
-            messages: vec![
-                // Existing local canister.
-                Refund(*LOCAL_CANISTER),
-                // Deleted local canister.
-                Refund(*OTHER_LOCAL_CANISTER),
-                // Remote canister (implicitly assumed to be migrated).
-                Refund(*REMOTE_CANISTER),
-                // Canister migrated from `LOCAL_SUBNET` to `REMOTE_SUBNET`.
-                Refund(*OTHER_REMOTE_CANISTER),
-                // Canister with unknown host subnet.
-                Refund(*UNKNOWN_CANISTER),
-            ],
-            signals_end: 21,
-            ..StreamSliceConfig::default()
-        }],
-        |stream_handler, state, slices, metrics| {
-            // Make it look like `OTHER_REMOTE_CANISTER` has migrated to `REMOTE_SUBNET`,
-            // with a `canister_migrations` entry still in place.
-            let state = prepare_canister_migration(
-                state,
-                *OTHER_REMOTE_CANISTER,
-                LOCAL_SUBNET,
-                REMOTE_SUBNET,
-            );
-
-            let mut expected_state = state.clone();
-            // Expecting a stream with...
-            let expected_stream = stream_from_config(StreamConfig {
+    for cost_schedule in [
+        CanisterCyclesCostSchedule::Normal,
+        CanisterCyclesCostSchedule::Free,
+    ] {
+        with_test_setup(
+            // An empty outgoing stream.
+            btreemap![REMOTE_SUBNET => StreamConfig {
                 begin: 21,
                 messages: vec![],
-                // ...signals for all 5 refunds...
-                signals_end: 48,
-                // ...and reject signals for refunds @45, @46, and @47.
-                reject_signals: vec![
-                    RejectSignal::new(RejectReason::CanisterMigrating, 45.into()),
-                    RejectSignal::new(RejectReason::CanisterMigrating, 46.into()),
-                    RejectSignal::new(RejectReason::CanisterMigrating, 47.into()),
-                ],
+                signals_end: 43,
                 ..StreamConfig::default()
-            });
-            expected_state.with_streams(btreemap![REMOTE_SUBNET => expected_stream]);
+            }],
+            // An incoming stream slice with refunds to existent and nonexistent local
+            // canisters; and to explicitly and implicitly migrated canisters.
+            btreemap![REMOTE_SUBNET => StreamSliceConfig {
+                messages_begin: 43,
+                messages: vec![
+                    // Existing local canister.
+                    Refund(*LOCAL_CANISTER),
+                    // Deleted local canister.
+                    Refund(*OTHER_LOCAL_CANISTER),
+                    // Remote canister (implicitly assumed to be migrated).
+                    Refund(*REMOTE_CANISTER),
+                    // Canister migrated from `LOCAL_SUBNET` to `REMOTE_SUBNET`.
+                    Refund(*OTHER_REMOTE_CANISTER),
+                    // Canister with unknown host subnet.
+                    Refund(*UNKNOWN_CANISTER),
+                ],
+                signals_end: 21,
+                ..StreamSliceConfig::default()
+            }],
+            |stream_handler, state, slices, metrics| {
+                // Make it look like `OTHER_REMOTE_CANISTER` has migrated to `REMOTE_SUBNET`,
+                // with a `canister_migrations` entry still in place.
+                let state = prepare_canister_migration(
+                    state,
+                    *OTHER_REMOTE_CANISTER,
+                    LOCAL_SUBNET,
+                    REMOTE_SUBNET,
+                );
 
-            // Refund to `LOCAL_CANISTER` (@43) was applied.
-            let refund43 = refund_in_slice(slices.get(&REMOTE_SUBNET), 43);
-            expected_state.credit_refund(refund43);
+                let mut expected_state = state.clone();
+                // Expecting a stream with...
+                let expected_stream = stream_from_config(StreamConfig {
+                    begin: 21,
+                    messages: vec![],
+                    // ...signals for all 5 refunds...
+                    signals_end: 48,
+                    // ...and reject signals for refunds @45, @46, and @47.
+                    reject_signals: vec![
+                        RejectSignal::new(RejectReason::CanisterMigrating, 45.into()),
+                        RejectSignal::new(RejectReason::CanisterMigrating, 46.into()),
+                        RejectSignal::new(RejectReason::CanisterMigrating, 47.into()),
+                    ],
+                    ..StreamConfig::default()
+                });
+                expected_state.with_streams(btreemap![REMOTE_SUBNET => expected_stream]);
 
-            // Cycles in refund @44 are lost
-            let refund44 = refund_in_slice(slices.get(&REMOTE_SUBNET), 44);
-            expected_state.observe_lost_cycles_due_to_dropped_messages(CompoundCycles::new(
-                refund44.amount(),
-                CanisterCyclesCostSchedule::Normal,
-            ));
+                // Refund to `LOCAL_CANISTER` (@43) was applied.
+                let refund43 = refund_in_slice(slices.get(&REMOTE_SUBNET), 43);
+                expected_state.credit_refund(refund43);
 
-            // Act.
-            let mut available_guaranteed_response_memory =
-                stream_handler.available_guaranteed_response_memory(&state);
-            let inducted_state = stream_handler.induct_stream_slices(
-                state,
-                slices,
-                &mut available_guaranteed_response_memory,
-            );
-            assert_eq!(
-                stream_handler.available_guaranteed_response_memory(&inducted_state),
-                available_guaranteed_response_memory
-            );
+                // Cycles in refund @44 are lost
+                let refund44 = refund_in_slice(slices.get(&REMOTE_SUBNET), 44);
+                expected_state.observe_lost_cycles_due_to_dropped_messages(CompoundCycles::new(
+                    refund44.amount(),
+                    cost_schedule,
+                ));
 
-            // Assert.
-            assert_eq!(expected_state, inducted_state);
+                // Act.
+                let mut available_guaranteed_response_memory =
+                    stream_handler.available_guaranteed_response_memory(&state);
+                let inducted_state = stream_handler.induct_stream_slices(
+                    state,
+                    slices,
+                    &mut available_guaranteed_response_memory,
+                );
+                assert_eq!(
+                    stream_handler.available_guaranteed_response_memory(&inducted_state),
+                    available_guaranteed_response_memory
+                );
 
-            metrics.assert_inducted_xnet_messages_eq(&[
-                (LABEL_VALUE_TYPE_REFUND, LABEL_VALUE_SUCCESS, 1),
-                (LABEL_VALUE_TYPE_REFUND, LABEL_VALUE_DROPPED, 1),
-                (LABEL_VALUE_TYPE_REFUND, LABEL_VALUE_RECEIVER_MIGRATED, 1),
-                (
-                    LABEL_VALUE_TYPE_REFUND,
-                    LABEL_VALUE_RECEIVER_LIKELY_MIGRATED,
-                    2,
-                ),
-            ]);
-            assert_eq!(0, metrics.fetch_inducted_payload_sizes_stats().count);
-            // No critical errors raised.
-            metrics.assert_eq_critical_errors(CriticalErrorCounts::default());
-        },
-    );
+                // Assert.
+                assert_eq!(expected_state, inducted_state);
+
+                metrics.assert_inducted_xnet_messages_eq(&[
+                    (LABEL_VALUE_TYPE_REFUND, LABEL_VALUE_SUCCESS, 1),
+                    (LABEL_VALUE_TYPE_REFUND, LABEL_VALUE_DROPPED, 1),
+                    (LABEL_VALUE_TYPE_REFUND, LABEL_VALUE_RECEIVER_MIGRATED, 1),
+                    (
+                        LABEL_VALUE_TYPE_REFUND,
+                        LABEL_VALUE_RECEIVER_LIKELY_MIGRATED,
+                        2,
+                    ),
+                ]);
+                assert_eq!(0, metrics.fetch_inducted_payload_sizes_stats().count);
+                // No critical errors raised.
+                metrics.assert_eq_critical_errors(CriticalErrorCounts::default());
+            },
+        );
+    }
 }
 
 /// Tests that messages in the loopback stream and incoming slices are inducted

--- a/rs/messaging/src/routing/stream_handler/tests.rs
+++ b/rs/messaging/src/routing/stream_handler/tests.rs
@@ -1257,7 +1257,7 @@ fn garbage_collect_local_state_with_reject_signals_for_request_from_absent_canis
             }],
             |stream_handler, state, slices, metrics| {
                 let mut expected_state = state.clone();
-                // The expected outgoing stream is empty with `begin` avanced.
+                // The expected outgoing stream is empty with `begin` advanced.
                 let expected_stream = stream_from_config(StreamConfig {
                     begin: 22,
                     ..StreamConfig::default()

--- a/rs/types/cycles/src/compound_cycles.rs
+++ b/rs/types/cycles/src/compound_cycles.rs
@@ -84,7 +84,8 @@ pub struct CompoundCycles<T: CyclesUseCaseKind> {
 impl<T: CyclesUseCaseKind> CompoundCycles<T> {
     pub fn new(amount: Cycles, cost_schedule: CanisterCyclesCostSchedule) -> Self {
         let use_case = T::cycles_use_case();
-        let amount = match (use_case, cost_schedule) {
+        let nominal = NominalCycles::new_private(amount.get());
+        let real = match (use_case, cost_schedule) {
             (_, CanisterCyclesCostSchedule::Normal)
             // NonConsumed represents the amounts attached on inter-canister
             // calls and it's removed from a canister's balance regardless of
@@ -113,8 +114,8 @@ impl<T: CyclesUseCaseKind> CompoundCycles<T> {
             | (CyclesUseCase::VetKd, CanisterCyclesCostSchedule::Free) => Cycles::zero(),
         };
         Self {
-            real: amount,
-            nominal: NominalCycles::new_private(amount.get()),
+            real,
+            nominal,
             _cycles_use_case_marker: PhantomData,
         }
     }


### PR DESCRIPTION
Separate the values of `NominalCycles` that are used to count consumed cycles from the `Cycles` amounts that are charged against the canister's balance. Specifically, `NominalCycles` are updated even on a free schedule with the amounts that correspond to the respective resource usage.

The main change in production code is in the constructor of `CompoundCycles` while the rest are updating tests as needed, including fixing expected values, testing both on normal and free schedule as well as adding some new tests for cases that were not covered. Additionally, a const is defined for the canister creation fee to be consistently used in production and test code where necessary.

This should be deployed after https://github.com/dfinity/ic/pull/9676 to ensure that no wrong values are used before this PR separates the two types of cycles.