### PR TITLE
refactor: Restrict which CompoundCycles specializations can be refundable

### DIFF
--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -46,7 +46,7 @@ use ic_types::{
 };
 use ic_types_cycles::{
     CanisterCyclesCostSchedule, CompoundCycles, Cycles, CyclesUseCase, CyclesUseCaseKind,
-    IngressInduction, Instructions, NominalCycles, Uninstall,
+    CyclesUseCaseRefundableKind, IngressInduction, Instructions, NominalCycles, Uninstall,
 };
 use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;
@@ -1823,7 +1823,7 @@ impl SystemState {
     /// Similar to `add_cycles` but additionally updates the metrics to match
     /// the refund that was provided. Should be used after a prepayment has been
     /// made.
-    pub fn refund_cycles<T: CyclesUseCaseKind>(
+    pub fn refund_cycles<T: CyclesUseCaseRefundableKind>(
         &mut self,
         prepayment: CompoundCycles<T>,
         refund: CompoundCycles<T>,

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -896,7 +896,7 @@ fn update_balance_and_consumed_cycles_correctly() {
     );
     assert_eq!(
         system_state.canister_metrics().consumed_cycles(),
-        NominalCycles::new(initial_consumed_cycles.get())
+        prepaid_cycles.nominal()
     );
 
     let refund = CompoundCycles::<Instructions>::new(Cycles::new(100), cost_schedule);
@@ -907,7 +907,7 @@ fn update_balance_and_consumed_cycles_correctly() {
     );
     assert_eq!(
         system_state.canister_metrics().consumed_cycles(),
-        NominalCycles::new((initial_consumed_cycles - refund.real()).get())
+        (prepaid_cycles - refund).nominal()
     );
 }
 
@@ -929,9 +929,9 @@ fn update_balance_and_consumed_cycles_by_use_case_correctly() {
         *system_state
             .canister_metrics()
             .consumed_cycles_by_use_cases()
-            .get(&CyclesUseCase::Memory)
+            .get(&CyclesUseCase::Instructions)
             .unwrap(),
-        NominalCycles::new((cycles_to_consume - refund.real()).get())
+        (prepaid_cycles - refund).nominal()
     );
 }
 

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -33,7 +33,7 @@ use ic_types::methods::{Callback, WasmClosure};
 use ic_types::time::{CoarseTime, UNIX_EPOCH};
 use ic_types::{CountBytes, Time};
 use ic_types_cycles::{
-    CanisterCyclesCostSchedule, CompoundCycles, Cycles, CyclesUseCase, NominalCycles,
+    CanisterCyclesCostSchedule, CompoundCycles, Cycles, CyclesUseCase, Instructions, NominalCycles,
     NominalCyclesTesting,
 };
 use ic_wasm_types::CanisterModule;
@@ -888,7 +888,7 @@ fn update_balance_and_consumed_cycles_correctly() {
     let initial_consumed_cycles = Cycles::new(1000);
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
     let prepaid_cycles =
-        CompoundCycles::<ic_types_cycles::Memory>::new(initial_consumed_cycles, cost_schedule);
+        CompoundCycles::<Instructions>::new(initial_consumed_cycles, cost_schedule);
     system_state.consume_cycles(prepaid_cycles);
     assert_eq!(
         system_state.balance(),
@@ -899,7 +899,7 @@ fn update_balance_and_consumed_cycles_correctly() {
         NominalCycles::new(initial_consumed_cycles.get())
     );
 
-    let refund = CompoundCycles::<ic_types_cycles::Memory>::new(Cycles::new(100), cost_schedule);
+    let refund = CompoundCycles::<Instructions>::new(Cycles::new(100), cost_schedule);
     system_state.refund_cycles(prepaid_cycles, refund);
     assert_eq!(
         system_state.balance(),
@@ -916,12 +916,10 @@ fn update_balance_and_consumed_cycles_by_use_case_correctly() {
     let mut system_state = CanisterStateFixture::new().canister_state.system_state;
     let cycles_to_consume = Cycles::from(1000_u128);
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
-    let prepaid_cycles =
-        CompoundCycles::<ic_types_cycles::Memory>::new(cycles_to_consume, cost_schedule);
+    let prepaid_cycles = CompoundCycles::<Instructions>::new(cycles_to_consume, cost_schedule);
     system_state.consume_cycles(prepaid_cycles);
 
-    let refund =
-        CompoundCycles::<ic_types_cycles::Memory>::new(Cycles::from(100_u128), cost_schedule);
+    let refund = CompoundCycles::<Instructions>::new(Cycles::from(100_u128), cost_schedule);
     system_state.refund_cycles(prepaid_cycles, refund);
     assert_eq!(
         system_state.balance(),

--- a/rs/types/cycles/src/cycles_use_case.rs
+++ b/rs/types/cycles/src/cycles_use_case.rs
@@ -109,6 +109,10 @@ pub trait CyclesUseCaseKind: Copy + Clone + Debug {
     fn cycles_use_case() -> CyclesUseCase;
 }
 
+/// Marker trait to identify which use cases of `CyclesUseCase` are refundable,
+/// i.e. the ones that are prepaid and expected to be refunded if not fully consumed.
+pub trait CyclesUseCaseRefundableKind: CyclesUseCaseKind {}
+
 /*
  * Empty structs are added for each use case to act like tags that can be used
  * to allow the compiler to enforce type-safe operations on `CompoundCycles`
@@ -143,7 +147,7 @@ impl CyclesUseCaseKind for IngressInduction {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct Instructions;
 
 impl CyclesUseCaseKind for Instructions {
@@ -152,7 +156,9 @@ impl CyclesUseCaseKind for Instructions {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+impl CyclesUseCaseRefundableKind for Instructions {}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct RequestAndResponseTransmission;
 
 impl CyclesUseCaseKind for RequestAndResponseTransmission {
@@ -160,6 +166,8 @@ impl CyclesUseCaseKind for RequestAndResponseTransmission {
         CyclesUseCase::RequestAndResponseTransmission
     }
 }
+
+impl CyclesUseCaseRefundableKind for RequestAndResponseTransmission {}
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct Uninstall;

--- a/rs/types/cycles/src/lib.rs
+++ b/rs/types/cycles/src/lib.rs
@@ -9,7 +9,8 @@ pub use cycles::Cycles;
 pub use cycles_cost_schedule::CanisterCyclesCostSchedule;
 pub use cycles_use_case::{
     BurnedCycles, CanisterCreation, ComputeAllocation, CyclesUseCase, CyclesUseCaseKind,
-    DeletedCanisters, DroppedMessages, ECDSAOutcalls, HTTPOutcalls, IngressInduction, Instructions,
-    Memory, NonConsumed, RequestAndResponseTransmission, SchnorrOutcalls, Uninstall, VetKd,
+    CyclesUseCaseRefundableKind, DeletedCanisters, DroppedMessages, ECDSAOutcalls, HTTPOutcalls,
+    IngressInduction, Instructions, Memory, NonConsumed, RequestAndResponseTransmission,
+    SchnorrOutcalls, Uninstall, VetKd,
 };
 pub use nominal_cycles::{NominalCycles, testing::NominalCyclesTesting};


### PR DESCRIPTION
Restrict which type specializations of `CompoundCycles` can be refundable, i.e. they are prepaid for and then they would need to be refunded via a call to `SystemState::refund_cycles`. This hardens the code and ensures that the decision of which ones are refundable and thus can be provided to `SystemState::refund_cycles` is an explicit choice of the code author.