### PR TITLE
fix: Upgrade libcryptsetup-rs and patch segfault bug

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1d88faead9fe3d4ca18cc2287397ac1457604de13e94aded554c8104ad506e69",
+  "checksum": "d6ba737c2af952b1785742116c13e25c6f7e9f4586a4921bbe38ed42119b7c61",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -21964,7 +21964,7 @@
               "target": "libc"
             },
             {
-              "id": "libcryptsetup-rs 0.13.2",
+              "id": "libcryptsetup-rs 0.15.0",
               "target": "libcryptsetup_rs"
             },
             {
@@ -44195,14 +44195,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "libcryptsetup-rs 0.13.2": {
+    "libcryptsetup-rs 0.15.0": {
       "name": "libcryptsetup-rs",
-      "version": "0.13.2",
+      "version": "0.15.0",
       "package_url": "https://github.com/stratis-storage/libcryptsetup-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/libcryptsetup-rs/0.13.2/download",
-          "sha256": "3ffd3642e85d0a4a7852c28545764754e8f7ca00c33ea5f2035f241a1da869ed"
+          "url": "https://static.crates.io/crates/libcryptsetup-rs/0.15.0/download",
+          "sha256": "3ba8f9447e9320030e045b3c7f1b1a978355c43cd05cdaba7e618d1e080519dd",
+          "patch_args": [
+            "-p1"
+          ],
+          "patches": [
+            "@@//bazel:libcryptsetup-rs.patch"
+          ]
         }
       },
       "targets": [
@@ -44257,7 +44263,7 @@
               "target": "libc"
             },
             {
-              "id": "libcryptsetup-rs 0.13.2",
+              "id": "libcryptsetup-rs 0.15.0",
               "target": "build_script_build"
             },
             {
@@ -44267,10 +44273,6 @@
             {
               "id": "log 0.4.28",
               "target": "log"
-            },
-            {
-              "id": "once_cell 1.21.3",
-              "target": "once_cell"
             },
             {
               "id": "per-thread-mutex 0.1.4",
@@ -44288,7 +44290,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.13.2"
+        "version": "0.15.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -98720,7 +98722,7 @@
     "lazy_static 1.5.0",
     "leb128 0.2.5",
     "libc 0.2.177",
-    "libcryptsetup-rs 0.13.2",
+    "libcryptsetup-rs 0.15.0",
     "libflate 2.1.0",
     "libfuzzer-sys 0.4.7",
     "libnss 0.5.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -7734,16 +7734,15 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libcryptsetup-rs"
-version = "0.13.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffd3642e85d0a4a7852c28545764754e8f7ca00c33ea5f2035f241a1da869ed"
+checksum = "3ba8f9447e9320030e045b3c7f1b1a978355c43cd05cdaba7e618d1e080519dd"
 dependencies = [
  "bitflags 2.10.0",
  "either",
  "libc",
  "libcryptsetup-rs-sys",
  "log",
- "once_cell",
  "per-thread-mutex",
  "pkg-config",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17295,16 +17295,15 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libcryptsetup-rs"
-version = "0.13.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffd3642e85d0a4a7852c28545764754e8f7ca00c33ea5f2035f241a1da869ed"
+checksum = "3ba8f9447e9320030e045b3c7f1b1a978355c43cd05cdaba7e618d1e080519dd"
 dependencies = [
  "bitflags 2.11.0",
  "either",
  "libc",
  "libcryptsetup-rs-sys",
  "log",
- "once_cell",
  "per-thread-mutex",
  "pkg-config",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -733,7 +733,7 @@ k256 = { version = "0.13.4", default-features = false, features = [
 lazy_static = "1.4.0"
 leb128 = "0.2.5"
 libc = "0.2.158"
-libcryptsetup-rs = "0.13"
+libcryptsetup-rs = "0.15"
 libflate = "2.1.0"
 libnss = "0.5.0"
 lmdb-rkv = { git = "https://github.com/dfinity-lab/lmdb-rs", rev = "64eb770caa940f215190d86d61e4c132511be5e2" }

--- a/bazel/libcryptsetup-rs.patch
+++ b/bazel/libcryptsetup-rs.patch
@@ -1,3 +1,5 @@
+# Fixes CryptKeyslotHandle::get_pbkdf() segfault for type Argon2I/Argon2Id keyslots
+# See: https://github.com/stratis-storage/libcryptsetup-rs/issues/473
 diff --git a/src/settings.rs b/src/settings.rs
 --- a/src/settings.rs
 +++ b/src/settings.rs

--- a/bazel/libcryptsetup-rs.patch
+++ b/bazel/libcryptsetup-rs.patch
@@ -1,0 +1,28 @@
+diff --git a/src/settings.rs b/src/settings.rs
+--- a/src/settings.rs
++++ b/src/settings.rs
+@@ -37,7 +37,11 @@ impl TryFrom<libcryptsetup_rs_sys::crypt_pbkdf_type> for CryptPbkdfType {
+         Ok(CryptPbkdfType {
+             type_: CryptKdf::from_ptr(type_.type_)?,
+-            hash: String::from(from_str_ptr!(type_.hash)?),
++            hash: if type_.hash.is_null() {
++                String::new()
++            } else {
++                String::from(from_str_ptr!(type_.hash)?)
++            },
+             time_ms: type_.time_ms,
+             iterations: type_.iterations,
+             max_memory_kb: type_.max_memory_kb,
+@@ -51,7 +55,11 @@ impl<'a> TryFrom<&'a libcryptsetup_rs_sys::crypt_pbkdf_type> for CryptPbkdfType {
+     fn try_from(v: &'a libcryptsetup_rs_sys::crypt_pbkdf_type) -> Result<Self, Self::Error> {
+         Ok(CryptPbkdfType {
+             type_: CryptKdf::from_ptr(v.type_)?,
+-            hash: from_str_ptr!(v.hash)?.to_string(),
++            hash: if v.hash.is_null() {
++                String::new()
++            } else {
++                from_str_ptr!(v.hash)?.to_string()
++            },
+             time_ms: v.time_ms,
+             iterations: v.iterations,
+             max_memory_kb: v.max_memory_kb,

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -869,7 +869,7 @@ crate.spec(
         "mutex",
     ],
     package = "libcryptsetup-rs",
-    version = "^0.13.2",
+    version = "0.15",
 )
 crate.spec(
     package = "libflate",
@@ -2051,6 +2051,11 @@ crate.annotation(
     # Patch for determinism issues
     patch_args = ["-p1"],
     patches = ["@@//bazel:libssh2-sys.patch"],
+)
+crate.annotation(
+    crate = "libcryptsetup-rs",
+    patch_args = ["-p1"],
+    patches = ["@@//bazel:libcryptsetup-rs.patch"],
 )
 crate.annotation(
     crate = "libz-sys",


### PR DESCRIPTION
The crate has a bug causing segfaults which was reported here: https://github.com/stratis-storage/libcryptsetup-rs/issues/473

This PR patches it for the IC repo.