### PR TITLE
fix: deflake //rs/rosetta-api/icp:icp_rosetta_system_tests

### DIFF
--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1547,7 +1547,25 @@ impl PocketIc {
                 HttpMethod::Get => reqwest_client.get(url),
                 HttpMethod::Post => reqwest_client.post(url).json(&body),
             };
-            let result = builder.send().await.expect("HTTP failure");
+            let result = match builder.send().await {
+                Ok(result) => result,
+                Err(e) => {
+                    warn!(
+                        "instance_id={} transient HTTP failure, retrying: {e}",
+                        self.instance_id,
+                    );
+                    if let Some(max_request_time_ms) = self.max_request_time_ms
+                        && start.elapsed().unwrap_or_default()
+                            > Duration::from_millis(max_request_time_ms)
+                    {
+                        panic!(
+                            "request to PocketIC server timed out after transient HTTP failure: {e}"
+                        );
+                    }
+                    std::thread::sleep(Duration::from_millis(POLLING_PERIOD_MS));
+                    continue;
+                }
+            };
             let status = result.status();
             match ApiResponse::<_>::from_response(result).await {
                 ApiResponse::Success(t) => break Ok(t),
@@ -1577,7 +1595,7 @@ impl PocketIc {
                     };
                     loop {
                         std::thread::sleep(Duration::from_millis(POLLING_PERIOD_MS));
-                        let result = reqwest_client
+                        let result = match reqwest_client
                             .get(
                                 self.server_url
                                     .join(&format!("/read_graph/{state_label}/{op_id}"))
@@ -1585,7 +1603,16 @@ impl PocketIc {
                             )
                             .send()
                             .await
-                            .expect("HTTP failure");
+                        {
+                            Ok(result) => result,
+                            Err(e) => {
+                                warn!(
+                                    "instance_id={} transient HTTP failure while polling, retrying: {e}",
+                                    self.instance_id,
+                                );
+                                continue;
+                            }
+                        };
                         if result.status() == reqwest::StatusCode::NOT_FOUND {
                             let message =
                                 String::from_utf8(result.bytes().await.unwrap().to_vec()).unwrap();


### PR DESCRIPTION
## Root Cause

The `//rs/rosetta-api/icp:icp_rosetta_system_tests` test has been flaking because the PocketIC client's `try_request` method panics on transient HTTP transport errors (e.g. `hyper::Error(IncompleteMessage)`). This happens when 34 tests run in parallel, each creating their own PocketIC instance, and the PocketIC HTTP server occasionally drops connections under load.

In the last week, this caused:
- **2026-04-09**: 13 out of 34 tests failed during `install_canister` in environment setup
- **2026-04-09**: 17 out of 34 tests failed during `install_canister` in environment setup  
- **2026-04-09**: 1 test failed (`test_load_from_storage`) with a Rosetta client error

## Fix

The `try_request` method in `packages/pocket-ic/src/nonblocking.rs` already has a retry loop for handling `Busy` responses from the PocketIC server. This change extends it to also retry on transient HTTP transport errors (like `IncompleteMessage`, `ConnectionReset`, etc.) instead of panicking via `.expect("HTTP failure")`.

Both the initial request path and the polling loop (`read_graph`) are updated.

## Verification

Ran `bazel test --test_output=errors --runs_per_test=3 --jobs=3 //rs/rosetta-api/icp:icp_rosetta_system_tests` — all 3 runs passed (100s avg).

---
*This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.*