### PR TITLE
chore(DSM): upgrade wasm tools to v245

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "500836e1bf6eb1f2ccc5efa32f5921f306b75af4ffa48278bb67a01eceaa0089",
+  "checksum": "973d5e40f08086e83617bf7cc893f4c4fbc17cd1d8798002a0f3c65eec39fe79",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -22718,19 +22718,19 @@
               "target": "wasm_bindgen"
             },
             {
-              "id": "wasm-encoder 0.244.0",
+              "id": "wasm-encoder 0.245.1",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasm-smith 0.244.0",
+              "id": "wasm-smith 0.245.1",
               "target": "wasm_smith"
             },
             {
-              "id": "wasmparser 0.244.0",
+              "id": "wasmparser 0.245.1",
               "target": "wasmparser"
             },
             {
-              "id": "wasmprinter 0.244.0",
+              "id": "wasmprinter 0.245.1",
               "target": "wasmprinter"
             },
             {
@@ -22742,7 +22742,7 @@
               "target": "wast"
             },
             {
-              "id": "wat 1.244.0",
+              "id": "wat 1.245.1",
               "target": "wat"
             },
             {
@@ -31355,7 +31355,8 @@
             "default-hasher",
             "equivalent",
             "inline-more",
-            "raw-entry"
+            "raw-entry",
+            "serde"
           ],
           "selects": {}
         },
@@ -31372,6 +31373,10 @@
             {
               "id": "foldhash 0.2.0",
               "target": "foldhash"
+            },
+            {
+              "id": "serde_core 1.0.228",
+              "target": "serde_core"
             }
           ],
           "selects": {}
@@ -89682,9 +89687,7 @@
         "crate_features": {
           "common": [
             "component-model",
-            "default",
-            "std",
-            "wasmparser"
+            "std"
           ],
           "selects": {}
         },
@@ -89693,10 +89696,6 @@
             {
               "id": "leb128fmt 0.1.0",
               "target": "leb128fmt"
-            },
-            {
-              "id": "wasmparser 0.244.0",
-              "target": "wasmparser"
             }
           ],
           "selects": {}
@@ -89744,7 +89743,8 @@
           "common": [
             "component-model",
             "default",
-            "std"
+            "std",
+            "wasmparser"
           ],
           "selects": {}
         },
@@ -89753,6 +89753,10 @@
             {
               "id": "leb128fmt 0.1.0",
               "target": "leb128fmt"
+            },
+            {
+              "id": "wasmparser 0.245.1",
+              "target": "wasmparser"
             }
           ],
           "selects": {}
@@ -89767,14 +89771,14 @@
       ],
       "license_file": null
     },
-    "wasm-smith 0.244.0": {
+    "wasm-smith 0.245.1": {
       "name": "wasm-smith",
-      "version": "0.244.0",
+      "version": "0.245.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-smith/0.244.0/download",
-          "sha256": "c8f72462e1ee97c48da6f599c7e47064dbab12bfee7b4fad278de4973ba72fd8"
+          "url": "https://static.crates.io/crates/wasm-smith/0.245.1/download",
+          "sha256": "7bbc45c58d90c7748d8a3cf095214531cf7733e6ff02aeda83471cab105da388"
         }
       },
       "targets": [
@@ -89817,18 +89821,18 @@
               "target": "flagset"
             },
             {
-              "id": "wasm-encoder 0.244.0",
+              "id": "wasm-encoder 0.245.1",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasmparser 0.244.0",
+              "id": "wasmparser 0.245.1",
               "target": "wasmparser"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.244.0"
+        "version": "0.245.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -90290,40 +90294,11 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "default",
-            "features",
-            "hash-collections",
-            "serde",
-            "simd",
-            "std",
-            "validate"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
               "id": "bitflags 2.10.0",
               "target": "bitflags"
-            },
-            {
-              "id": "hashbrown 0.15.2",
-              "target": "hashbrown"
-            },
-            {
-              "id": "indexmap 2.13.0",
-              "target": "indexmap"
-            },
-            {
-              "id": "semver 1.0.27",
-              "target": "semver"
-            },
-            {
-              "id": "serde 1.0.228",
-              "target": "serde"
             }
           ],
           "selects": {}
@@ -90370,7 +90345,9 @@
         "crate_features": {
           "common": [
             "component-model",
+            "default",
             "features",
+            "hash-collections",
             "serde",
             "simd",
             "std",
@@ -90385,6 +90362,14 @@
               "target": "bitflags"
             },
             {
+              "id": "hashbrown 0.16.1",
+              "target": "hashbrown"
+            },
+            {
+              "id": "indexmap 2.13.0",
+              "target": "indexmap"
+            },
+            {
               "id": "semver 1.0.27",
               "target": "semver"
             },
@@ -90397,70 +90382,6 @@
         },
         "edition": "2021",
         "version": "0.245.1"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasmprinter 0.244.0": {
-      "name": "wasmprinter",
-      "version": "0.244.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmprinter/0.244.0/download",
-          "sha256": "09390d7b2bd7b938e563e4bff10aa345ef2e27a3bc99135697514ef54495e68f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmprinter",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmprinter",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "default",
-            "validate"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "anyhow 1.0.100",
-              "target": "anyhow"
-            },
-            {
-              "id": "termcolor 1.4.1",
-              "target": "termcolor"
-            },
-            {
-              "id": "wasmparser 0.244.0",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.244.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -91749,14 +91670,85 @@
       ],
       "license_file": null
     },
-    "wat 1.244.0": {
+    "wast 245.0.1": {
+      "name": "wast",
+      "version": "245.0.1",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wast/245.0.1/download",
+          "sha256": "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wast",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wast",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "wasm-module"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bumpalo 3.20.2",
+              "target": "bumpalo"
+            },
+            {
+              "id": "leb128fmt 0.1.0",
+              "target": "leb128fmt"
+            },
+            {
+              "id": "memchr 2.7.4",
+              "target": "memchr"
+            },
+            {
+              "id": "unicode-width 0.2.0",
+              "target": "unicode_width"
+            },
+            {
+              "id": "wasm-encoder 0.245.1",
+              "target": "wasm_encoder"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "245.0.1"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "wat 1.245.1": {
       "name": "wat",
-      "version": "1.244.0",
+      "version": "1.245.1",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wat",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wat/1.244.0/download",
-          "sha256": "bbf35b87ed352f9ab6cd0732abde5a67dd6153dfd02c493e61459218b19456fa"
+          "url": "https://static.crates.io/crates/wat/1.245.1/download",
+          "sha256": "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
         }
       },
       "targets": [
@@ -91788,14 +91780,14 @@
         "deps": {
           "common": [
             {
-              "id": "wast 244.0.0",
+              "id": "wast 245.0.1",
               "target": "wast"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.244.0"
+        "version": "1.245.1"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -99213,13 +99205,13 @@
     "walrus 0.23.3",
     "warp 0.3.7",
     "wasm-bindgen 0.2.100",
-    "wasm-encoder 0.244.0",
-    "wasm-smith 0.244.0",
-    "wasmparser 0.244.0",
-    "wasmprinter 0.244.0",
+    "wasm-encoder 0.245.1",
+    "wasm-smith 0.245.1",
+    "wasmparser 0.245.1",
+    "wasmprinter 0.245.1",
     "wasmtime 43.0.1",
     "wast 244.0.0",
-    "wat 1.244.0",
+    "wat 1.245.1",
     "webpki-roots 1.0.6",
     "which 4.4.0",
     "wirm 2.1.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3978,12 +3978,12 @@ dependencies = [
  "walrus 0.23.3",
  "warp",
  "wasm-bindgen",
- "wasm-encoder 0.244.0",
+ "wasm-encoder 0.245.1",
  "wasm-smith",
- "wasmparser 0.244.0",
- "wasmprinter 0.244.0",
+ "wasmparser 0.245.1",
+ "wasmprinter",
  "wasmtime",
- "wast",
+ "wast 244.0.0",
  "wat",
  "webpki-roots 1.0.6",
  "which",
@@ -15100,15 +15100,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.244.0"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f72462e1ee97c48da6f599c7e47064dbab12bfee7b4fad278de4973ba72fd8"
+checksum = "7bbc45c58d90c7748d8a3cf095214531cf7733e6ff02aeda83471cab105da388"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -15185,10 +15185,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.10.0",
- "hashbrown 0.15.2",
  "indexmap 2.13.0",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -15202,17 +15200,6 @@ dependencies = [
  "indexmap 2.13.0",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09390d7b2bd7b938e563e4bff10aa345ef2e27a3bc99135697514ef54495e68f"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -15288,7 +15275,7 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.245.1",
  "wasmparser 0.245.1",
- "wasmprinter 0.245.1",
+ "wasmprinter",
  "wasmtime-internal-core",
 ]
 
@@ -15422,12 +15409,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wat"
-version = "1.244.0"
+name = "wast"
+version = "245.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf35b87ed352f9ab6cd0732abde5a67dd6153dfd02c493e61459218b19456fa"
+checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
 dependencies = [
- "wast",
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width 0.2.0",
+ "wasm-encoder 0.245.1",
+]
+
+[[package]]
+name = "wat"
+version = "1.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+dependencies = [
+ "wast 245.0.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
  "on_wire",
  "rand 0.8.5",
  "tokio",
- "wasmprinter 0.244.0",
+ "wasmprinter",
  "wat",
 ]
 
@@ -9603,9 +9603,9 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
- "wasmprinter 0.244.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
+ "wasmprinter",
  "wasmtime",
  "wast",
  "wat",
@@ -9729,7 +9729,7 @@ dependencies = [
  "tokio",
  "tower 0.5.3",
  "tracing",
- "wasmparser 0.244.0",
+ "wasmparser 0.245.1",
  "wat",
  "wirm",
 ]
@@ -14982,7 +14982,7 @@ dependencies = [
  "serde_cbor",
  "socket2 0.5.10",
  "tempfile",
- "wasmprinter 0.244.0",
+ "wasmprinter",
  "wat",
 ]
 
@@ -17507,7 +17507,7 @@ dependencies = [
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-test-utils",
- "wasmprinter 0.244.0",
+ "wasmprinter",
 ]
 
 [[package]]
@@ -25767,10 +25767,10 @@ dependencies = [
  "libfuzzer-sys",
  "num-traits",
  "tokio",
- "wasm-encoder 0.244.0",
+ "wasm-encoder 0.245.1",
  "wasm-smith",
- "wasmparser 0.244.0",
- "wasmprinter 0.244.0",
+ "wasmparser 0.245.1",
+ "wasmprinter",
  "wasmtime",
 ]
 
@@ -25835,7 +25835,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -25849,17 +25848,6 @@ dependencies = [
  "indexmap 2.13.0",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09390d7b2bd7b938e563e4bff10aa345ef2e27a3bc99135697514ef54495e68f"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -25935,7 +25923,7 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.245.1",
  "wasmparser 0.245.1",
- "wasmprinter 0.245.1",
+ "wasmprinter",
  "wasmtime-internal-core",
 ]
 
@@ -26057,22 +26045,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "244.0.0"
+version = "245.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e7b9f9e23311275920e3d6b56d64137c160cf8af4f84a7283b36cfecbf4acb"
+checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.244.0",
+ "wasm-encoder 0.245.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.244.0"
+version = "1.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf35b87ed352f9ab6cd0732abde5a67dd6153dfd02c493e61459218b19456fa"
+checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
 dependencies = [
  "wast",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -914,11 +914,11 @@ uuid = { version = "=1.12.1", features = ["v4", "serde"] }
 virt = "0.4"
 walkdir = "2.3.3"
 walrus = "0.23.3"
-wasm-encoder = { version = "0.244.0", features = ["wasmparser"] }
-wasmparser = "0.244.0"
-wasmprinter = "0.244.0"
-wast = "244.0.0"
-wat = "~1.244.0"
+wasm-encoder = { version = "0.245.0", features = ["wasmparser"] }
+wasmparser = "0.245.0"
+wasmprinter = "0.245.0"
+wast = "245.0.0"
+wat = "~1.245.0"
 webpki-roots = "1.0.6"
 which = "6.0.3"
 wirm = { version = "2.1.0", features = ["parallel"] }

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -1865,7 +1865,7 @@ crate.spec(
         "wasmparser",
     ],
     package = "wasm-encoder",
-    version = "^0.244.0",
+    version = "^0.245.0",
 )
 crate.spec(
     default_features = False,
@@ -1873,15 +1873,15 @@ crate.spec(
         "wasmparser",
     ],
     package = "wasm-smith",
-    version = "^0.244.0",
+    version = "^0.245.0",
 )
 crate.spec(
     package = "wasmparser",
-    version = "^0.244.0",
+    version = "^0.245.0",
 )
 crate.spec(
     package = "wasmprinter",
-    version = "^0.244.0",
+    version = "^0.245.0",
 )
 crate.spec(
     default_features = False,
@@ -1901,7 +1901,7 @@ crate.spec(
 )
 crate.spec(
     package = "wat",
-    version = "~1.244.0",
+    version = "~1.245.0",
 )
 crate.spec(
     package = "webpki-roots",


### PR DESCRIPTION
That is a follow-up to https://github.com/dfinity/ic/pull/9762.