### PR TITLE
test(delegations): [CON-1696] re-enable mainnet variant delegation system test for cloud engines

### DIFF
--- a/rs/tests/networking/nns_delegation_test.rs
+++ b/rs/tests/networking/nns_delegation_test.rs
@@ -778,8 +778,6 @@ fn upgrade_non_nns_subnets_if_necessary(env: &TestEnv) {
             .iter()
             .copied()
             .filter(|t| *t != SubnetType::System)
-            // TODO(CON-1696): Remove next line when #9613 reaches mainnet NNS
-            .filter(|t| *t != SubnetType::CloudEngine)
             .map(|subnet_type| {
                 let env = env.clone();
                 let nns_node = nns_node.clone();
@@ -806,11 +804,7 @@ macro_rules! systest_all_subnet_types {
         $group = $group.add_test(systest!($function_name; SubnetType::System));
         $group = $group.add_test(systest!($function_name; SubnetType::Application));
         $group = $group.add_test(systest!($function_name; SubnetType::VerifiedApplication));
-        // TODO(CON-1696): Remove this condition (and always run the test for cloud engines) when
-        // #9613 reaches mainnet NNS
-        if get_guestos_img_version() == get_guestos_update_img_version() {
-            $group = $group.add_test(systest!($function_name; SubnetType::CloudEngine));
-        }
+        $group = $group.add_test(systest!($function_name; SubnetType::CloudEngine));
     };
 }
 

--- a/rs/tests/networking/nns_delegation_test.rs
+++ b/rs/tests/networking/nns_delegation_test.rs
@@ -801,7 +801,6 @@ fn upgrade_non_nns_subnets_if_necessary(env: &TestEnv) {
 macro_rules! systest_all_subnet_types {
     ($group: expr, $function_name:path) => {
         // Keep up to date with `TESTED_SUBNET_TYPES` constant
-        $group = $group.add_test(systest!($function_name; SubnetType::System));
         $group = $group.add_test(systest!($function_name; SubnetType::Application));
         $group = $group.add_test(systest!($function_name; SubnetType::VerifiedApplication));
         $group = $group.add_test(systest!($function_name; SubnetType::CloudEngine));

--- a/rs/tests/networking/nns_delegation_test.rs
+++ b/rs/tests/networking/nns_delegation_test.rs
@@ -1,3 +1,4 @@
+/* tag::catalog[]
 Title:: NNS Delegation Tests
 
 Goal:: Test the behavior NNS Delegations.

--- a/rs/tests/networking/nns_delegation_test.rs
+++ b/rs/tests/networking/nns_delegation_test.rs
@@ -801,6 +801,7 @@ fn upgrade_non_nns_subnets_if_necessary(env: &TestEnv) {
 macro_rules! systest_all_subnet_types {
     ($group: expr, $function_name:path) => {
         // Keep up to date with `TESTED_SUBNET_TYPES` constant
+        $group = $group.add_test(systest!($function_name; SubnetType::System));
         $group = $group.add_test(systest!($function_name; SubnetType::Application));
         $group = $group.add_test(systest!($function_name; SubnetType::VerifiedApplication));
         $group = $group.add_test(systest!($function_name; SubnetType::CloudEngine));

--- a/rs/tests/networking/nns_delegation_test.rs
+++ b/rs/tests/networking/nns_delegation_test.rs
@@ -1,4 +1,3 @@
-/* tag::catalog[]
 Title:: NNS Delegation Tests
 
 Goal:: Test the behavior NNS Delegations.


### PR DESCRIPTION
#9613 has reached mainnet NNS and unblocks the mainnet variant of the delegation system tests for cloud engines.