### PR TITLE
fix(governance): Do not let snapshot proposal execution deadlock when the target is Governance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11787,6 +11787,7 @@ dependencies = [
  "ic-nervous-system-clients",
  "ic-nervous-system-lock",
  "ic-nervous-system-runtime",
+ "ic-nns-constants",
  "serde",
  "serde_bytes",
  "tokio",

--- a/rs/nervous_system/root/BUILD.bazel
+++ b/rs/nervous_system/root/BUILD.bazel
@@ -6,9 +6,9 @@ DEPENDENCIES = [
     # Keep sorted.
     "//rs/crypto/sha2",
     "//rs/nervous_system/clients",
-    "//rs/nns/constants",
     "//rs/nervous_system/lock",
     "//rs/nervous_system/runtime",
+    "//rs/nns/constants",
     "//rs/rust_canisters/dfn_core",
     "//rs/types/base_types",
     "//rs/types/management_canister_types",

--- a/rs/nervous_system/root/BUILD.bazel
+++ b/rs/nervous_system/root/BUILD.bazel
@@ -6,6 +6,7 @@ DEPENDENCIES = [
     # Keep sorted.
     "//rs/crypto/sha2",
     "//rs/nervous_system/clients",
+    "//rs/nns/constants",
     "//rs/nervous_system/lock",
     "//rs/nervous_system/runtime",
     "//rs/rust_canisters/dfn_core",

--- a/rs/nervous_system/root/Cargo.toml
+++ b/rs/nervous_system/root/Cargo.toml
@@ -12,6 +12,7 @@ documentation.workspace = true
 candid = { workspace = true }
 dfn_core = { path = "../../rust_canisters/dfn_core" }
 ic-base-types = { path = "../../types/base_types" }
+ic-nns-constants = { path = "../../nns/constants" }
 ic-cdk = { workspace = true }
 ic-crypto-sha2 = { path = "../../crypto/sha2" }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }

--- a/rs/nervous_system/root/src/change_canister.rs
+++ b/rs/nervous_system/root/src/change_canister.rs
@@ -11,7 +11,7 @@
 //! this start the canister back up again, and unlocks it.
 
 #![allow(deprecated)]
-use crate::{LOG_PREFIX, private::exclusively_stop_and_start_canister};
+use crate::{LOG_PREFIX, private::perform_offline_canister_maintenance};
 use candid::{CandidType, Deserialize, Encode, Principal};
 use dfn_core::api::CanisterId;
 #[cfg(target_arch = "wasm32")]
@@ -234,11 +234,11 @@ pub async fn change_canister(request: ChangeCanisterRequest) -> Result<(), Strin
 
     // Ship code to the canister.
     //
-    let result = exclusively_stop_and_start_canister::<_, _, _>(
+    let result = perform_offline_canister_maintenance::<_, _, _>(
         canister_id,
         &request_str,
         stop_before_installing,
-        || async {
+        || async move {
             // Note that there's no guarantee that the canister to install/reinstall/upgrade
             // is actually stopped here, even if stop_before_installing is true. This is
             // because there could be a concurrent request to restart it. This could be
@@ -254,7 +254,7 @@ pub async fn change_canister(request: ChangeCanisterRequest) -> Result<(), Strin
     .await;
 
     // This handles errors such as not being able to acquire canister lock,
-    // which gets emited directly by exclusively_stop_and_start_canister
+    // which gets emited directly by perform_offline_canister_maintenance
     // itself.
     let result = match result {
         Ok(ok) => ok,

--- a/rs/nervous_system/root/src/load_canister_snapshot.rs
+++ b/rs/nervous_system/root/src/load_canister_snapshot.rs
@@ -1,8 +1,10 @@
-use crate::private::exclusively_stop_and_start_canister;
+use crate::{LOG_PREFIX, private::exclusively_stop_and_start_canister};
 use candid::CandidType;
 use ic_base_types::{CanisterId, PrincipalId, SnapshotId};
+use ic_cdk::{futures::spawn_017_compat, println};
 use ic_management_canister_types_private::LoadCanisterSnapshotArgs;
 use ic_nervous_system_clients::management_canister_client::ManagementCanisterClient;
+use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use serde::Deserialize;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize)]
@@ -26,71 +28,145 @@ pub struct LoadCanisterSnapshotError {
     pub description: String,
 }
 
+/// Restores a canister to a previously taken snapshot, an earlier state,
+/// which includes its memory (normal and stable) and code.
+///
+/// When the target canister is Governance, the operation is performed in the
+/// background and this function returns immediately with a placeholder `Ok`
+/// response. This avoids a deadlock: Root would need to stop Governance, but
+/// Governance cannot stop while it is waiting for Root to reply.
 pub async fn load_canister_snapshot(
     load_canister_snapshot_request: LoadCanisterSnapshotRequest,
-    management_canister_client: &mut impl ManagementCanisterClient,
+    management_canister_client: impl ManagementCanisterClient + 'static,
 ) -> LoadCanisterSnapshotResponse {
     let operation_description = format!("{:?}", load_canister_snapshot_request);
+    // Retain our own copy, because the async block will take the original.
+    let operation_description_for_log = operation_description.clone();
 
-    let LoadCanisterSnapshotRequest {
-        canister_id,
-        snapshot_id,
-    } = load_canister_snapshot_request;
+    // Used later, but calculated now, because the main async block is going
+    // to take load_canister_snapshot_request.
+    let targets_governance =
+        load_canister_snapshot_request.canister_id == PrincipalId::from(GOVERNANCE_CANISTER_ID);
 
-    let snapshot_id = match SnapshotId::try_from(snapshot_id) {
-        Ok(ok) => ok,
-        Err(err) => {
-            return LoadCanisterSnapshotResponse::Err(LoadCanisterSnapshotError {
+    let operation = async move {
+        // Construct the request that we will be sending to the Management canister
+        // in the next (large) statement.
+        let load_canister_snapshot_args =
+            LoadCanisterSnapshotArgs::try_from(load_canister_snapshot_request)?;
+
+        // Call the Management canister (but make sure we are not already
+        // operating on the canister, and also, stop before and start
+        // again after).
+        let result = exclusively_stop_and_start_canister::<_, _, _>(
+            load_canister_snapshot_args.get_canister_id(),
+            &operation_description,
+            true, // stop_before
+            || async {
+                management_canister_client
+                    .load_canister_snapshot(load_canister_snapshot_args)
+                    .await
+            },
+        )
+        .await;
+
+        // Handle errors.
+        // This line explicitly shows that no data is thrown away.
+        let _: () = result
+            // Handle errors from exclusively_stop_and_start_canister.
+            .map_err(|err| LoadCanisterSnapshotError {
                 code: None,
-                description: format!("Invalid snapshot ID: {err}"),
-            });
-        }
+                description: format!("{err}"),
+            })?
+            // Handle errors from calling management_canister_client.
+            .map_err(|(code, description)| LoadCanisterSnapshotError {
+                code: Some(code),
+                description,
+            })?;
+
+        Ok(LoadCanisterSnapshotOk {})
     };
 
-    let canister_id = match CanisterId::try_from(canister_id) {
-        Ok(ok) => ok,
-        Err(err) => {
-            return LoadCanisterSnapshotResponse::Err(LoadCanisterSnapshotError {
+    // Log result.
+    let operation = async move {
+        let result = LoadCanisterSnapshotResponse::from(operation.await);
+        println!("{LOG_PREFIX}{operation_description_for_log}: {result:?}");
+        result
+    };
+
+    // In the case of Governance, do the operation in the background.
+    // This is necessary to avoid deadlock:
+    //
+    // 1. the Governance canister calls the Root canister's load_canister_snapshot
+    //    method, but
+    // 2. the first thing load_canister_snapshot does (via
+    //    exclusively_stop_and_start_canister) is to stop the target canister,
+    //    which in this case, is Governance, but
+    // 3. Governance is waiting for the call in step 1 to return.
+    //
+    // So, what we have is Governance waiting for Root to reply in order to stop, but Root
+    // is waiting for Governance to stop before it can reply. Circular waiting, i.e. deadlock.
+    if targets_governance {
+        spawn_017_compat(async move {
+            // It is ok to throw this away, because it is already logged above.
+            let _: LoadCanisterSnapshotResponse = operation.await;
+
+            // Because spawn_017_compat does not know what to do with
+            // a LoadCanisterSnapshotResponse.
+            ()
+        });
+
+        // Even though we do not yet know that the operation will succeed,
+        // we return Ok here, because we also do not know that it will fail.
+        // The important thing is that we launched the operation. That's
+        // the definition of success in the special case of Governance.
+        return LoadCanisterSnapshotResponse::Ok(LoadCanisterSnapshotOk {});
+    }
+
+    operation.await
+}
+
+impl TryFrom<LoadCanisterSnapshotRequest> for LoadCanisterSnapshotArgs {
+    type Error = LoadCanisterSnapshotError;
+
+    fn try_from(request: LoadCanisterSnapshotRequest) -> Result<Self, LoadCanisterSnapshotError> {
+        let LoadCanisterSnapshotRequest {
+            canister_id,
+            snapshot_id,
+        } = request;
+
+        let canister_id =
+            CanisterId::try_from(canister_id).map_err(|err| LoadCanisterSnapshotError {
                 code: None,
                 description: format!("Invalid canister ID: {err}"),
-            });
-        }
-    };
+            })?;
 
-    let result = exclusively_stop_and_start_canister::<_, _, _>(
-        canister_id,
-        &operation_description,
-        true, // stop_before
-        || async {
-            let load_canister_snapshot_args = LoadCanisterSnapshotArgs::new(
-                canister_id,
-                snapshot_id,
-                management_canister_client.canister_version(),
-            );
-
-            management_canister_client
-                .load_canister_snapshot(load_canister_snapshot_args)
-                .await
-        },
-    )
-    .await;
-
-    let result = match result {
-        Ok(ok) => ok,
-        Err(err) => {
-            let description = format!("{err}");
-            return LoadCanisterSnapshotResponse::Err(LoadCanisterSnapshotError {
+        let snapshot_id =
+            SnapshotId::try_from(snapshot_id).map_err(|err| LoadCanisterSnapshotError {
                 code: None,
-                description,
-            });
-        }
-    };
+                description: format!("Invalid snapshot ID: {err}"),
+            })?;
 
-    match result {
-        Ok(()) => LoadCanisterSnapshotResponse::Ok(LoadCanisterSnapshotOk {}),
-        Err((code, description)) => LoadCanisterSnapshotResponse::Err(LoadCanisterSnapshotError {
-            code: Some(code),
-            description,
-        }),
+        Ok(LoadCanisterSnapshotArgs::new(
+            canister_id,
+            snapshot_id,
+            None,
+        ))
+    }
+}
+
+impl From<LoadCanisterSnapshotError> for LoadCanisterSnapshotResponse {
+    fn from(err: LoadCanisterSnapshotError) -> Self {
+        LoadCanisterSnapshotResponse::Err(err)
+    }
+}
+
+impl From<Result<LoadCanisterSnapshotOk, LoadCanisterSnapshotError>>
+    for LoadCanisterSnapshotResponse
+{
+    fn from(result: Result<LoadCanisterSnapshotOk, LoadCanisterSnapshotError>) -> Self {
+        match result {
+            Ok(ok) => LoadCanisterSnapshotResponse::Ok(ok),
+            Err(err) => LoadCanisterSnapshotResponse::Err(err),
+        }
     }
 }

--- a/rs/nervous_system/root/src/load_canister_snapshot.rs
+++ b/rs/nervous_system/root/src/load_canister_snapshot.rs
@@ -1,10 +1,8 @@
-use crate::{LOG_PREFIX, private::exclusively_stop_and_start_canister};
+use crate::private::{OfflineMaintenanceError, perform_offline_canister_maintenance};
 use candid::CandidType;
 use ic_base_types::{CanisterId, PrincipalId, SnapshotId};
-use ic_cdk::{futures::spawn_017_compat, println};
 use ic_management_canister_types_private::LoadCanisterSnapshotArgs;
 use ic_nervous_system_clients::management_canister_client::ManagementCanisterClient;
-use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use serde::Deserialize;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize)]
@@ -39,90 +37,29 @@ pub async fn load_canister_snapshot(
     load_canister_snapshot_request: LoadCanisterSnapshotRequest,
     management_canister_client: impl ManagementCanisterClient + 'static,
 ) -> LoadCanisterSnapshotResponse {
+    // Convert input.
     let operation_description = format!("{:?}", load_canister_snapshot_request);
-    // Retain our own copy, because the async block will take the original.
-    let operation_description_for_log = operation_description.clone();
+    let args = match LoadCanisterSnapshotArgs::try_from(load_canister_snapshot_request) {
+        Ok(args) => args,
+        Err(err) => return LoadCanisterSnapshotResponse::Err(err),
+    };
+    let canister_id = args.get_canister_id();
 
-    // Used later, but calculated now, because the main async block is going
-    // to take load_canister_snapshot_request.
-    let targets_governance =
-        load_canister_snapshot_request.canister_id == PrincipalId::from(GOVERNANCE_CANISTER_ID);
-
-    let operation = async move {
-        // Construct the request that we will be sending to the Management canister
-        // in the next (large) statement.
-        let load_canister_snapshot_args =
-            LoadCanisterSnapshotArgs::try_from(load_canister_snapshot_request)?;
-
-        // Call the Management canister (but make sure we are not already
-        // operating on the canister, and also, stop before and start
-        // again after).
-        let result = exclusively_stop_and_start_canister::<_, _, _>(
-            load_canister_snapshot_args.get_canister_id(),
+    let do_the_real_work = move || async move {
+        management_canister_client
+            .load_canister_snapshot(args)
+            .await
+    };
+    let result: Result<Result<(), (i32, String)>, OfflineMaintenanceError> =
+        perform_offline_canister_maintenance(
+            canister_id,
             &operation_description,
             true, // stop_before
-            || async {
-                management_canister_client
-                    .load_canister_snapshot(load_canister_snapshot_args)
-                    .await
-            },
+            do_the_real_work,
         )
         .await;
 
-        // Handle errors.
-        // This line explicitly shows that no data is thrown away.
-        let _: () = result
-            // Handle errors from exclusively_stop_and_start_canister.
-            .map_err(|err| LoadCanisterSnapshotError {
-                code: None,
-                description: format!("{err}"),
-            })?
-            // Handle errors from calling management_canister_client.
-            .map_err(|(code, description)| LoadCanisterSnapshotError {
-                code: Some(code),
-                description,
-            })?;
-
-        Ok(LoadCanisterSnapshotOk {})
-    };
-
-    // Log result.
-    let operation = async move {
-        let result = LoadCanisterSnapshotResponse::from(operation.await);
-        println!("{LOG_PREFIX}{operation_description_for_log}: {result:?}");
-        result
-    };
-
-    // In the case of Governance, do the operation in the background.
-    // This is necessary to avoid deadlock:
-    //
-    // 1. the Governance canister calls the Root canister's load_canister_snapshot
-    //    method, but
-    // 2. the first thing load_canister_snapshot does (via
-    //    exclusively_stop_and_start_canister) is to stop the target canister,
-    //    which in this case, is Governance, but
-    // 3. Governance is waiting for the call in step 1 to return.
-    //
-    // So, what we have is Governance waiting for Root to reply in order to stop, but Root
-    // is waiting for Governance to stop before it can reply. Circular waiting, i.e. deadlock.
-    if targets_governance {
-        spawn_017_compat(async move {
-            // It is ok to throw this away, because it is already logged above.
-            let _: LoadCanisterSnapshotResponse = operation.await;
-
-            // Because spawn_017_compat does not know what to do with
-            // a LoadCanisterSnapshotResponse.
-            ()
-        });
-
-        // Even though we do not yet know that the operation will succeed,
-        // we return Ok here, because we also do not know that it will fail.
-        // The important thing is that we launched the operation. That's
-        // the definition of success in the special case of Governance.
-        return LoadCanisterSnapshotResponse::Ok(LoadCanisterSnapshotOk {});
-    }
-
-    operation.await
+    LoadCanisterSnapshotResponse::from(result)
 }
 
 impl TryFrom<LoadCanisterSnapshotRequest> for LoadCanisterSnapshotArgs {
@@ -154,19 +91,24 @@ impl TryFrom<LoadCanisterSnapshotRequest> for LoadCanisterSnapshotArgs {
     }
 }
 
-impl From<LoadCanisterSnapshotError> for LoadCanisterSnapshotResponse {
-    fn from(err: LoadCanisterSnapshotError) -> Self {
-        LoadCanisterSnapshotResponse::Err(err)
-    }
-}
+// Convert output from Management canister to ours.
 
-impl From<Result<LoadCanisterSnapshotOk, LoadCanisterSnapshotError>>
+impl From<Result<Result<(), (i32, String)>, OfflineMaintenanceError>>
     for LoadCanisterSnapshotResponse
 {
-    fn from(result: Result<LoadCanisterSnapshotOk, LoadCanisterSnapshotError>) -> Self {
+    fn from(result: Result<Result<(), (i32, String)>, OfflineMaintenanceError>) -> Self {
         match result {
-            Ok(ok) => LoadCanisterSnapshotResponse::Ok(ok),
-            Err(err) => LoadCanisterSnapshotResponse::Err(err),
+            Ok(Ok(())) => LoadCanisterSnapshotResponse::Ok(LoadCanisterSnapshotOk {}),
+            Ok(Err((code, description))) => {
+                LoadCanisterSnapshotResponse::Err(LoadCanisterSnapshotError {
+                    code: Some(code),
+                    description,
+                })
+            }
+            Err(err) => LoadCanisterSnapshotResponse::Err(LoadCanisterSnapshotError {
+                code: None,
+                description: format!("{err}"),
+            }),
         }
     }
 }

--- a/rs/nervous_system/root/src/private.rs
+++ b/rs/nervous_system/root/src/private.rs
@@ -3,8 +3,10 @@ use crate::{
     change_canister::{start_canister, stop_canister},
 };
 use dfn_core::api::CanisterId;
+use ic_cdk::futures::spawn_migratory;
 use ic_nervous_system_lock::acquire_for;
 use ic_nervous_system_runtime::CdkRuntime;
+use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use std::{
     cell::RefCell,
     collections::BTreeMap,
@@ -20,6 +22,19 @@ thread_local! {
         // (A description of) what operation is being performed on it.
         String,
     >> = const { RefCell::new(BTreeMap::new()) };
+}
+
+/// Provides a placeholder "looks ok" value for use when the operation
+/// runs in the background and the actual outcome is known before returning
+/// the reply from the canister method.
+pub(crate) trait Optimistic {
+    fn new_optimistic() -> Self;
+}
+
+impl<E> Optimistic for Result<(), E> {
+    fn new_optimistic() -> Self {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,7 +53,7 @@ impl From<(i32, String)> for Reject {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(clippy::enum_variant_names)] // Because all names end with "Failed".
-pub(crate) enum ExclusivelyStopAndStartCanisterError {
+pub(crate) enum OfflineMaintenanceError {
     LockAcquisitionFailed {
         ongoing_operation_description: String,
     },
@@ -54,11 +69,11 @@ pub(crate) enum ExclusivelyStopAndStartCanisterError {
     },
 }
 
-pub(crate) use ExclusivelyStopAndStartCanisterError::{
+pub(crate) use OfflineMaintenanceError::{
     LockAcquisitionFailed, StartAfterMainOperationFailed, StopBeforeMainOperationFailed,
 };
 
-impl Display for ExclusivelyStopAndStartCanisterError {
+impl Display for OfflineMaintenanceError {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         let result = match self {
             LockAcquisitionFailed {
@@ -117,51 +132,98 @@ impl Display for ExclusivelyStopAndStartCanisterError {
 /// The "after" operations are performed regardless of the outcome of the main
 /// operation. Releasing the lock is performed regardless of whether re-starting
 /// succeeds.
-pub(crate) async fn exclusively_stop_and_start_canister<MainOperation, Fut, R>(
+///
+/// # Special Governance Behavior
+///
+/// To avoid deadlock, when `canister_id` is Governance, everything is done
+/// in the background (via spawn_migratory). Furthermore,
+/// `Ok(R::new_optimistic())` is returned immediately, i.e. with no .await.
+///
+/// Without this, deadlock would occur:
+///
+/// 1. Governance calls some root method, and the implementation of that method
+///    uses this function.
+/// 2. The first thing this does is stop canister_id, which in this special case,
+///    is Governance itself.
+///
+/// At this point, Governance and Root are waiting for each other before they
+/// can proceeed.
+pub(crate) async fn perform_offline_canister_maintenance<MainOperation, Fut, R>(
     canister_id: CanisterId,
     operation_description: &str,
     stop_before: bool,
     main_operation: MainOperation,
-) -> Result<R, ExclusivelyStopAndStartCanisterError>
+) -> Result<R, OfflineMaintenanceError>
 where
-    MainOperation: FnOnce() -> Fut,
-    Fut: Future<Output = R>,
-    R: Debug,
+    MainOperation: FnOnce() -> Fut + 'static,
+    Fut: Future<Output = R> + 'static,
+    R: Debug + Optimistic + 'static,
 {
-    // Try to acquire lock for this canister; fail immediately if the canister
-    // is already locked (indicating that some other operation is currently in
-    // progress).
-    let _release_on_drop = acquire_for(
-        &CANISTER_LOCK_ACQUISITIONS,
-        canister_id,
-        operation_description.to_string(),
-    )
-    .map_err(|ongoing_operation_description| LockAcquisitionFailed {
-        ongoing_operation_description,
-    })?;
+    // These will be moved into the following async blocks.
+    let operation_description = operation_description.to_string();
+    let operation_description_for_log = operation_description.clone();
 
-    if stop_before {
-        stop_before_main_operation(canister_id, operation_description).await?;
-    }
-
-    let main_operation_result = main_operation().await;
-
-    if stop_before {
-        return restart_after_main_operation(
+    // Compose all work into a single future so it can be either awaited
+    // directly or spawned in the background.
+    let operation = async move {
+        // Try to acquire lock for this canister; fail immediately if the canister
+        // is already locked (indicating that some other operation is currently in
+        // progress).
+        let _release_on_drop = acquire_for(
+            &CANISTER_LOCK_ACQUISITIONS,
             canister_id,
-            operation_description,
-            main_operation_result,
+            operation_description.clone(),
         )
-        .await;
+        .map_err(|ongoing_operation_description| LockAcquisitionFailed {
+            ongoing_operation_description,
+        })?;
+
+        if stop_before {
+            stop_before_main_operation(canister_id, &operation_description).await?;
+        }
+
+        let main_operation_result = main_operation().await;
+
+        if stop_before {
+            return restart_after_main_operation(
+                canister_id,
+                &operation_description,
+                main_operation_result,
+            )
+            .await;
+        }
+
+        Ok(main_operation_result)
+    };
+
+    // Log result.
+    let operation = async move {
+        let result = operation.await;
+        println!(
+            "{LOG_PREFIX}Result of {operation_description_for_log} on {canister_id}: {result:?}."
+        );
+        result
+    };
+
+    if canister_id == GOVERNANCE_CANISTER_ID {
+        spawn_migratory(async move {
+            // Result is discarded here; it is above.
+            let _: Result<R, OfflineMaintenanceError> = operation.await;
+        });
+
+        // Even though we do not yet know that the operation will succeed, we
+        // return the optimistic value here, because we also do not know that it
+        // will fail. The important thing is that we launched the operation.
+        return Ok(R::new_optimistic());
     }
 
-    Ok(main_operation_result)
+    operation.await
 }
 
 async fn stop_before_main_operation(
     canister_id: CanisterId,
     operation_description: &str,
-) -> Result<(), ExclusivelyStopAndStartCanisterError> {
+) -> Result<(), OfflineMaintenanceError> {
     let stop_reject = match stop_canister::<CdkRuntime>(canister_id).await {
         Ok(()) => {
             return Ok(());
@@ -211,7 +273,7 @@ async fn restart_after_main_operation<R>(
     canister_id: CanisterId,
     operation_description: &str,
     main_operation_result: R,
-) -> Result<R, ExclusivelyStopAndStartCanisterError>
+) -> Result<R, OfflineMaintenanceError>
 where
     R: Debug,
 {

--- a/rs/nervous_system/root/src/take_canister_snapshot.rs
+++ b/rs/nervous_system/root/src/take_canister_snapshot.rs
@@ -1,8 +1,10 @@
-use crate::private::exclusively_stop_and_start_canister;
+use crate::{LOG_PREFIX, private::exclusively_stop_and_start_canister};
 use candid::CandidType;
 use ic_base_types::{CanisterId, PrincipalId, SnapshotId};
+use ic_cdk::{futures::spawn_017_compat, println};
 use ic_management_canister_types_private::{CanisterSnapshotResponse, TakeCanisterSnapshotArgs};
 use ic_nervous_system_clients::management_canister_client::ManagementCanisterClient;
+use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use serde::Deserialize;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize)]
@@ -30,103 +32,170 @@ pub struct TakeCanisterSnapshotError {
     pub description: String,
 }
 
+/// A snapshot consists of a canister's memory (normal and stable) and code.
+/// Taking a snapshot simply means that we capture that data atomically.
+/// A snapshot can then later be used (usually for disaster recovery)
+/// to restore the canister to the state it was in when the snapshot was taken.
+///
+/// When the target canister is Governance, the operation is performed in the
+/// background and this function returns immediately with a placeholder `Ok`
+/// response (fields zeroed). This avoids a deadlock: Root would need to stop
+/// Governance, but Governance cannot stop while it is waiting for Root to reply.
 pub async fn take_canister_snapshot(
     take_canister_snapshot_request: TakeCanisterSnapshotRequest,
-    management_canister_client: &mut impl ManagementCanisterClient,
+    management_canister_client: impl ManagementCanisterClient + 'static,
 ) -> TakeCanisterSnapshotResponse {
     let operation_description = format!("{:?}", take_canister_snapshot_request);
+    // Retain our own copy, because the async block will take the original.
+    let operation_description_for_log = operation_description.clone();
 
-    let TakeCanisterSnapshotRequest {
-        canister_id,
-        replace_snapshot,
-    } = take_canister_snapshot_request;
+    // Used later, but calculated now, because the main async block is going
+    // to take take_canister_snapshot_request.
+    let targets_governance =
+        take_canister_snapshot_request.canister_id == PrincipalId::from(GOVERNANCE_CANISTER_ID);
 
-    let replace_snapshot = match replace_snapshot {
-        None => None,
-        Some(snapshot_id) => {
-            let snapshot_id = match SnapshotId::try_from(&snapshot_id) {
-                Ok(ok) => ok,
-                Err(err) => {
-                    return TakeCanisterSnapshotResponse::Err(TakeCanisterSnapshotError {
-                        code: None,
-                        description: format!("Invalid snapshot ID ({snapshot_id:02X?}): {err}"),
-                    });
-                }
-            };
+    let operation = async move {
+        // Construct the request that we will be sending to the Management canister
+        // in the next (large) statement.
+        let take_canister_snapshot_args =
+            TakeCanisterSnapshotArgs::try_from(take_canister_snapshot_request)?;
 
-            Some(snapshot_id)
-        }
-    };
+        // Call the Management canister (but make sure we are not already
+        // operating on the canister, and also, stop before and start
+        // again after).
+        let result = exclusively_stop_and_start_canister(
+            take_canister_snapshot_args.get_canister_id(),
+            &operation_description,
+            true, // stop_before
+            || async {
+                management_canister_client
+                    .take_canister_snapshot(take_canister_snapshot_args)
+                    .await
+            },
+        )
+        .await;
 
-    let canister_id = match CanisterId::try_from(canister_id) {
-        Ok(id) => id,
-        Err(e) => {
-            return TakeCanisterSnapshotResponse::Err(TakeCanisterSnapshotError {
-                code: None,
-                description: format!("Invalid canister ID: {:?}", e),
-            });
-        }
-    };
-
-    let result = exclusively_stop_and_start_canister(
-        canister_id,
-        &operation_description,
-        true, // stop_before
-        || async {
-            let canister_id = PrincipalId::from(canister_id);
-
-            let take_canister_snapshot_args = TakeCanisterSnapshotArgs {
-                canister_id,
-                replace_snapshot,
-                uninstall_code: None,
-                sender_canister_version: management_canister_client.canister_version(),
-            };
-
-            management_canister_client
-                .take_canister_snapshot(take_canister_snapshot_args)
-                .await
-        },
-    )
-    .await;
-
-    let result = match result {
-        Ok(ok) => ok,
-        Err(err) => {
-            return TakeCanisterSnapshotResponse::Err(TakeCanisterSnapshotError {
+        // Handle errors.
+        let snapshot: CanisterSnapshotResponse = result
+            // Handle errors from exclusively_stop_and_start_canister.
+            .map_err(|err| TakeCanisterSnapshotError {
                 code: None,
                 description: format!("{err}"),
-            });
-        }
+            })?
+            // Handle errors from calling management_canister_client.
+            .map_err(|(code, description)| TakeCanisterSnapshotError {
+                code: Some(code),
+                description,
+            })?;
+
+        Ok(TakeCanisterSnapshotOk::from(snapshot))
     };
 
-    match result {
-        Ok(result) => {
-            let result =
-                convert_from_canister_snapshot_response_to_take_canister_snapshot_ok(result);
-            TakeCanisterSnapshotResponse::Ok(result)
-        }
+    // Log result.
+    let operation = async move {
+        let result = TakeCanisterSnapshotResponse::from(operation.await);
+        println!("{LOG_PREFIX}{operation_description_for_log}: {result:?}");
+        result
+    };
 
-        Err((code, description)) => TakeCanisterSnapshotResponse::Err(TakeCanisterSnapshotError {
-            code: Some(code),
-            description,
-        }),
+    // In the case of Governance, do the operation in the background.
+    // This is necessary to avoid deadlock:
+    //
+    // 1. the Governance canister calls the Root canister's take_canister_snapshot
+    //    method, but
+    // 2. the first thing take_canister_snapshot does (via
+    //    exclusively_stop_and_start_canister) is to stop the target canister,
+    //    which in this case, is Governance, but
+    // 3. Governance is waiting for the call in step 1 to return.
+    //
+    // So, what we have is Governance waiting for Root to reply in order to stop, but Root
+    // is waiting for Governance to stop before it can reply. Circular waiting, i.e. deadlock.
+    if targets_governance {
+        spawn_017_compat(async move {
+            // It is ok to throw this away, because it is already logged above.
+            let _: TakeCanisterSnapshotResponse = operation.await;
+
+            // Because spawn_017_compat does not know what to do with
+            // a TakeCanisterSnapshotResponse.
+            ()
+        });
+
+        // Even though we do not yet know that the operation will succeed,
+        // we return Ok here, because we also do not know that it will fail.
+        // The important thing is that we launched the operation. That's
+        // the definition of success in the special case of Governance.
+        return TakeCanisterSnapshotResponse::Ok(TakeCanisterSnapshotOk {
+            id: vec![],
+            taken_at_timestamp: 0,
+            total_size: 0,
+        });
+    }
+
+    operation.await
+}
+
+impl TryFrom<TakeCanisterSnapshotRequest> for TakeCanisterSnapshotArgs {
+    type Error = TakeCanisterSnapshotError;
+
+    fn try_from(request: TakeCanisterSnapshotRequest) -> Result<Self, TakeCanisterSnapshotError> {
+        let TakeCanisterSnapshotRequest {
+            canister_id,
+            replace_snapshot,
+        } = request;
+
+        let canister_id =
+            CanisterId::try_from(canister_id).map_err(|err| TakeCanisterSnapshotError {
+                code: None,
+                description: format!("Invalid canister ID: {err}"),
+            })?;
+
+        let replace_snapshot = replace_snapshot
+            .map(|snapshot_id| {
+                SnapshotId::try_from(&snapshot_id).map_err(|err| TakeCanisterSnapshotError {
+                    code: None,
+                    description: format!("Invalid snapshot ID: {err}"),
+                })
+            })
+            .transpose()?;
+
+        Ok(TakeCanisterSnapshotArgs::new(
+            canister_id,
+            replace_snapshot,
+            None, // uninstall_code
+            None, // sender_canister_version
+        ))
     }
 }
 
-fn convert_from_canister_snapshot_response_to_take_canister_snapshot_ok(
-    response: CanisterSnapshotResponse,
-) -> TakeCanisterSnapshotOk {
-    let CanisterSnapshotResponse {
-        id,
-        taken_at_timestamp,
-        total_size,
-    } = response;
+impl From<TakeCanisterSnapshotError> for TakeCanisterSnapshotResponse {
+    fn from(err: TakeCanisterSnapshotError) -> Self {
+        TakeCanisterSnapshotResponse::Err(err)
+    }
+}
 
-    let id = id.to_vec();
+impl From<Result<TakeCanisterSnapshotOk, TakeCanisterSnapshotError>>
+    for TakeCanisterSnapshotResponse
+{
+    fn from(result: Result<TakeCanisterSnapshotOk, TakeCanisterSnapshotError>) -> Self {
+        match result {
+            Ok(ok) => TakeCanisterSnapshotResponse::Ok(ok),
+            Err(err) => TakeCanisterSnapshotResponse::Err(err),
+        }
+    }
+}
 
-    TakeCanisterSnapshotOk {
-        id,
-        taken_at_timestamp,
-        total_size,
+impl From<CanisterSnapshotResponse> for TakeCanisterSnapshotOk {
+    fn from(response: CanisterSnapshotResponse) -> Self {
+        let CanisterSnapshotResponse {
+            id,
+            taken_at_timestamp,
+            total_size,
+        } = response;
+
+        TakeCanisterSnapshotOk {
+            id: id.to_vec(),
+            taken_at_timestamp,
+            total_size,
+        }
     }
 }

--- a/rs/nervous_system/root/src/take_canister_snapshot.rs
+++ b/rs/nervous_system/root/src/take_canister_snapshot.rs
@@ -1,10 +1,8 @@
-use crate::{LOG_PREFIX, private::exclusively_stop_and_start_canister};
+use crate::private::{OfflineMaintenanceError, Optimistic, perform_offline_canister_maintenance};
 use candid::CandidType;
 use ic_base_types::{CanisterId, PrincipalId, SnapshotId};
-use ic_cdk::{futures::spawn_017_compat, println};
 use ic_management_canister_types_private::{CanisterSnapshotResponse, TakeCanisterSnapshotArgs};
 use ic_nervous_system_clients::management_canister_client::ManagementCanisterClient;
-use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use serde::Deserialize;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize)]
@@ -45,95 +43,43 @@ pub async fn take_canister_snapshot(
     take_canister_snapshot_request: TakeCanisterSnapshotRequest,
     management_canister_client: impl ManagementCanisterClient + 'static,
 ) -> TakeCanisterSnapshotResponse {
+    // Convert input.
     let operation_description = format!("{:?}", take_canister_snapshot_request);
-    // Retain our own copy, because the async block will take the original.
-    let operation_description_for_log = operation_description.clone();
+    let args = match TakeCanisterSnapshotArgs::try_from(take_canister_snapshot_request) {
+        Ok(args) => args,
+        Err(err) => return TakeCanisterSnapshotResponse::Err(err),
+    };
+    let canister_id = args.get_canister_id();
 
-    // Used later, but calculated now, because the main async block is going
-    // to take take_canister_snapshot_request.
-    let targets_governance =
-        take_canister_snapshot_request.canister_id == PrincipalId::from(GOVERNANCE_CANISTER_ID);
-
-    let operation = async move {
-        // Construct the request that we will be sending to the Management canister
-        // in the next (large) statement.
-        let take_canister_snapshot_args =
-            TakeCanisterSnapshotArgs::try_from(take_canister_snapshot_request)?;
-
-        // Call the Management canister (but make sure we are not already
-        // operating on the canister, and also, stop before and start
-        // again after).
-        let result = exclusively_stop_and_start_canister(
-            take_canister_snapshot_args.get_canister_id(),
+    let do_the_real_work = move || async move {
+        management_canister_client
+            .take_canister_snapshot(args)
+            .await
+    };
+    let result: Result<Result<CanisterSnapshotResponse, (i32, String)>, OfflineMaintenanceError> =
+        perform_offline_canister_maintenance(
+            canister_id,
             &operation_description,
             true, // stop_before
-            || async {
-                management_canister_client
-                    .take_canister_snapshot(take_canister_snapshot_args)
-                    .await
-            },
+            do_the_real_work,
         )
         .await;
 
-        // Handle errors.
-        let snapshot: CanisterSnapshotResponse = result
-            // Handle errors from exclusively_stop_and_start_canister.
-            .map_err(|err| TakeCanisterSnapshotError {
-                code: None,
-                description: format!("{err}"),
-            })?
-            // Handle errors from calling management_canister_client.
-            .map_err(|(code, description)| TakeCanisterSnapshotError {
-                code: Some(code),
-                description,
-            })?;
-
-        Ok(TakeCanisterSnapshotOk::from(snapshot))
-    };
-
-    // Log result.
-    let operation = async move {
-        let result = TakeCanisterSnapshotResponse::from(operation.await);
-        println!("{LOG_PREFIX}{operation_description_for_log}: {result:?}");
-        result
-    };
-
-    // In the case of Governance, do the operation in the background.
-    // This is necessary to avoid deadlock:
-    //
-    // 1. the Governance canister calls the Root canister's take_canister_snapshot
-    //    method, but
-    // 2. the first thing take_canister_snapshot does (via
-    //    exclusively_stop_and_start_canister) is to stop the target canister,
-    //    which in this case, is Governance, but
-    // 3. Governance is waiting for the call in step 1 to return.
-    //
-    // So, what we have is Governance waiting for Root to reply in order to stop, but Root
-    // is waiting for Governance to stop before it can reply. Circular waiting, i.e. deadlock.
-    if targets_governance {
-        spawn_017_compat(async move {
-            // It is ok to throw this away, because it is already logged above.
-            let _: TakeCanisterSnapshotResponse = operation.await;
-
-            // Because spawn_017_compat does not know what to do with
-            // a TakeCanisterSnapshotResponse.
-            ()
-        });
-
-        // Even though we do not yet know that the operation will succeed,
-        // we return Ok here, because we also do not know that it will fail.
-        // The important thing is that we launched the operation. That's
-        // the definition of success in the special case of Governance.
-        return TakeCanisterSnapshotResponse::Ok(TakeCanisterSnapshotOk {
-            id: vec![],
-            taken_at_timestamp: 0,
-            total_size: 0,
-        });
-    }
-
-    operation.await
+    // Convert output.
+    TakeCanisterSnapshotResponse::from(result)
 }
 
+impl Optimistic for Result<CanisterSnapshotResponse, (i32, String)> {
+    fn new_optimistic() -> Self {
+        Ok(CanisterSnapshotResponse {
+            id: SnapshotId::from((CanisterId::from_u64(0), 0_u64)),
+            taken_at_timestamp: 0,
+            total_size: 0,
+        })
+    }
+}
+
+// Convert input from ours to what Management canister wants.
 impl TryFrom<TakeCanisterSnapshotRequest> for TakeCanisterSnapshotArgs {
     type Error = TakeCanisterSnapshotError;
 
@@ -167,19 +113,28 @@ impl TryFrom<TakeCanisterSnapshotRequest> for TakeCanisterSnapshotArgs {
     }
 }
 
-impl From<TakeCanisterSnapshotError> for TakeCanisterSnapshotResponse {
-    fn from(err: TakeCanisterSnapshotError) -> Self {
-        TakeCanisterSnapshotResponse::Err(err)
-    }
-}
+// Convert output from Management canister to ours.
 
-impl From<Result<TakeCanisterSnapshotOk, TakeCanisterSnapshotError>>
+impl From<Result<Result<CanisterSnapshotResponse, (i32, String)>, OfflineMaintenanceError>>
     for TakeCanisterSnapshotResponse
 {
-    fn from(result: Result<TakeCanisterSnapshotOk, TakeCanisterSnapshotError>) -> Self {
+    fn from(
+        result: Result<Result<CanisterSnapshotResponse, (i32, String)>, OfflineMaintenanceError>,
+    ) -> Self {
         match result {
-            Ok(ok) => TakeCanisterSnapshotResponse::Ok(ok),
-            Err(err) => TakeCanisterSnapshotResponse::Err(err),
+            Ok(Ok(snapshot)) => {
+                TakeCanisterSnapshotResponse::Ok(TakeCanisterSnapshotOk::from(snapshot))
+            }
+            Ok(Err((code, description))) => {
+                TakeCanisterSnapshotResponse::Err(TakeCanisterSnapshotError {
+                    code: Some(code),
+                    description,
+                })
+            }
+            Err(err) => TakeCanisterSnapshotResponse::Err(TakeCanisterSnapshotError {
+                code: None,
+                description: format!("{err}"),
+            }),
         }
     }
 }

--- a/rs/nns/handlers/root/impl/canister/canister.rs
+++ b/rs/nns/handlers/root/impl/canister/canister.rs
@@ -248,7 +248,7 @@ async fn take_canister_snapshot(
     check_caller_is_governance();
     ic_nervous_system_root::take_canister_snapshot::take_canister_snapshot(
         take_canister_snapshot_request,
-        &mut new_management_canister_client(),
+        new_management_canister_client(),
     )
     .await
 }
@@ -262,7 +262,7 @@ async fn load_canister_snapshot(
     check_caller_is_governance();
     ic_nervous_system_root::load_canister_snapshot::load_canister_snapshot(
         load_canister_snapshot_request,
-        &mut new_management_canister_client(),
+        new_management_canister_client(),
     )
     .await
 }

--- a/rs/nns/handlers/root/unreleased_changelog.md
+++ b/rs/nns/handlers/root/unreleased_changelog.md
@@ -17,4 +17,6 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* Do not deadlock when doing snapshot operations that target the Governance canister.
+
 ## Security

--- a/rs/nns/integration_tests/src/canister_snapshot.rs
+++ b/rs/nns/integration_tests/src/canister_snapshot.rs
@@ -3,19 +3,18 @@ use ic_base_types::{CanisterId, PrincipalId};
 use ic_ledger_core::tokens::{CheckedAdd, CheckedSub};
 use ic_management_canister_types_private::{CanisterSnapshotResponse, ListCanisterSnapshotArgs};
 use ic_nervous_system_common::E8;
-use ic_nns_constants::{LEDGER_CANISTER_ID, ROOT_CANISTER_ID};
-use ic_nns_governance::pb::v1::ProposalStatus;
+use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL};
+use ic_nns_common::pb::v1::NeuronId;
+use ic_nns_constants::{GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_governance_api::{
-    LoadCanisterSnapshot, MakeProposalRequest, ProposalActionRequest, TakeCanisterSnapshot,
-    manage_neuron_response::Command,
+    LoadCanisterSnapshot, MakeProposalRequest, Motion, ProposalActionRequest, TakeCanisterSnapshot,
 };
 use ic_nns_test_utils::{
     common::NnsInitPayloadsBuilder,
-    neuron_helpers::get_neuron_1,
     state_test_helpers::{
-        icrc1_balance, icrc1_transfer, nns_governance_get_proposal_info_as_anonymous,
-        nns_governance_make_proposal, nns_wait_for_proposal_execution, setup_nns_canisters,
-        state_machine_builder_for_nns_tests, update_with_sender,
+        icrc1_balance, icrc1_transfer, nns_execute_proposal, nns_get_proposal_info,
+        nns_governance_make_proposal, setup_nns_canisters, state_machine_builder_for_nns_tests,
+        update_with_sender,
     },
 };
 use ic_state_machine_tests::StateMachine;
@@ -56,54 +55,20 @@ fn test_canister_snapshot() {
 
     setup_nns_canisters(&state_machine, nns_init_payloads);
 
-    // Basic facts.
-    let neuron = get_neuron_1();
     let target_canister_id = LEDGER_CANISTER_ID;
 
     // Scenario A: The most basic thing: take a snapshot.
 
     // Step 2(A): Run the code under test: Take a snapshot via proposal.
-
-    // Step 2(A).1: Assemble MakeProposalRequest.
-    let take_snapshot = TakeCanisterSnapshot {
-        canister_id: Some(target_canister_id.get()),
-        replace_snapshot: None,
-    };
-    let action = ProposalActionRequest::TakeCanisterSnapshot(take_snapshot);
-    let make_proposal_request = MakeProposalRequest {
-        title: Some("Take a Snapshot of the Ledger Canister".to_string()),
-        summary: "Do what the title says.".to_string(),
-        url: "https://forum.dfinity.org/discuss-take-canister-snapshot".to_string(),
-        action: Some(action),
-    };
-
-    // Step 2A.2: Submit the proposal.
-    let make_proposal_response = nns_governance_make_proposal(
+    let first_proposal_id = nns_execute_proposal(
         &state_machine,
-        neuron.principal_id,
-        neuron.neuron_id,
-        &make_proposal_request,
-    );
-    let first_proposal_id = match make_proposal_response.command.as_ref().unwrap() {
-        Command::MakeProposal(response) => response.proposal_id.unwrap(),
-        _ => panic!("{make_proposal_response:#?}"),
-    };
-
-    // Step 2A.3: Wait for execution.
-    nns_wait_for_proposal_execution(&state_machine, first_proposal_id.id);
-
-    // Step 3A. Verify results.
-
-    // Step 3A.1: Proposal marked success.
-    let first_proposal_info =
-        nns_governance_get_proposal_info_as_anonymous(&state_machine, first_proposal_id.id);
-    assert_eq!(
-        ProposalStatus::try_from(first_proposal_info.status),
-        Ok(ProposalStatus::Executed),
-        "{first_proposal_info:#?}",
+        ProposalActionRequest::TakeCanisterSnapshot(TakeCanisterSnapshot {
+            canister_id: Some(target_canister_id.get()),
+            replace_snapshot: None,
+        }),
     );
 
-    // Step 3A.2: Verify that a snapshot was created, by calling
+    // Step 3A: Verify that a snapshot was created, by calling
     // list_canister_snapshots.
     let list_canister_snapshots_response: Vec<CanisterSnapshotResponse> = update_with_sender(
         &state_machine,
@@ -167,38 +132,15 @@ fn test_canister_snapshot() {
 
     // Make a proposal, like in scenario A, but this time, set the
     // replace_snapshot field to the ID of the first snapshot (from scenario A).
-    let take_snapshot_replace = TakeCanisterSnapshot {
-        canister_id: Some(target_canister_id.get()),
-        replace_snapshot: Some(first_snapshot.snapshot_id().to_vec()),
-    };
-    let action = ProposalActionRequest::TakeCanisterSnapshot(take_snapshot_replace);
-    let make_proposal_request = MakeProposalRequest {
-        title: Some("Take ANOTHER Snapshot and clobber the first".to_string()),
-        summary: "Delete old, make new.".to_string(),
-        url: "https://forum.dfinity.org/clobber-snapshot".to_string(),
-        action: Some(action),
-    };
-    let propose_replace_response = nns_governance_make_proposal(
+    let replace_proposal_id = nns_execute_proposal(
         &state_machine,
-        neuron.principal_id,
-        neuron.neuron_id,
-        &make_proposal_request,
+        ProposalActionRequest::TakeCanisterSnapshot(TakeCanisterSnapshot {
+            canister_id: Some(target_canister_id.get()),
+            replace_snapshot: Some(first_snapshot.snapshot_id().to_vec()),
+        }),
     );
-    let replace_proposal_id = match propose_replace_response.command.unwrap() {
-        Command::MakeProposal(response) => response.proposal_id.unwrap(),
-        _ => panic!("Propose replace didn't return MakeProposal"),
-    };
 
     assert_ne!(replace_proposal_id, first_proposal_id);
-    nns_wait_for_proposal_execution(&state_machine, replace_proposal_id.id);
-
-    let replace_proposal_info =
-        nns_governance_get_proposal_info_as_anonymous(&state_machine, replace_proposal_id.id);
-    assert_eq!(
-        ProposalStatus::try_from(replace_proposal_info.status),
-        Ok(ProposalStatus::Executed),
-        "{replace_proposal_info:#?}",
-    );
 
     // Step 3(B): Verify results.
 
@@ -304,35 +246,156 @@ fn test_canister_snapshot() {
     // `second_snapshot`, which was taken BEFORE the transfer (which took place
     // in Step 1(C)).
 
-    let load_snapshot = LoadCanisterSnapshot {
-        canister_id: Some(target_canister_id.get()),
-        snapshot_id: Some(second_snapshot.snapshot_id().to_vec()),
-    };
-    let action = ProposalActionRequest::LoadCanisterSnapshot(load_snapshot);
-    let make_proposal_request = MakeProposalRequest {
-        title: Some("Restore Ledger Canister to Snapshot 2".to_string()),
-        summary: r#"This will revert the ICP transfer."#.to_string(),
-        url: "https://forum.dfinity.org/restore-ledger-canister-to-snapshot-2".to_string(),
-        action: Some(action),
-    };
-    let make_proposal_response = nns_governance_make_proposal(
+    nns_execute_proposal(
         &state_machine,
-        neuron.principal_id,
-        neuron.neuron_id,
-        &make_proposal_request,
+        ProposalActionRequest::LoadCanisterSnapshot(LoadCanisterSnapshot {
+            canister_id: Some(target_canister_id.get()),
+            snapshot_id: Some(second_snapshot.snapshot_id().to_vec()),
+        }),
     );
-    let load_canister_snapshot_proposal_id = match make_proposal_response.command.as_ref().unwrap()
-    {
-        Command::MakeProposal(response) => response.proposal_id.unwrap(),
-        _ => panic!("{make_proposal_response:#?}"),
-    };
 
-    // Step 3C: Verify LoadCanisterSnapshot execution.
-
-    nns_wait_for_proposal_execution(&state_machine, load_canister_snapshot_proposal_id.id);
+    // Step 3(C): Verify results.
 
     // Balanaces are back to what they were.
     assert_balance(&state_machine, icp_token_sender, initial_balance);
     assert_balance(&state_machine, icp_token_receiver, initial_balance);
     assert_balance(&state_machine, stable_balance_principal, initial_balance);
+}
+
+/// Similar to previous test with the main difference being that Governance
+/// is the guinea pig.
+///
+/// The reason for this additional test is that when the target canister is
+/// Governance, there is special behavior: Root is supposed to do the operation
+/// in the background. Without this, proposal execution would deadlock.
+///
+/// Minor difference: To verify that LoadCanisterSnapshot actually rolled
+/// back Governance's state, we create a Motion proposal after the snapshot
+/// and confirm it disappears after loading the snapshot.
+#[test]
+fn test_governance_canister_snapshot() {
+    // Step 1: Prepare the world.
+
+    let state_machine = state_machine_builder_for_nns_tests().build();
+    let nns_init_payloads = NnsInitPayloadsBuilder::new().with_test_neurons().build();
+    setup_nns_canisters(&state_machine, nns_init_payloads);
+
+    let target_canister_id = GOVERNANCE_CANISTER_ID;
+
+    // Create a Motion proposal BEFORE taking a snapshot. This one should survive
+    // loading the snapshot near the end.
+    let pre_snapshot_motion_proposal_id = nns_execute_proposal(
+        &state_machine,
+        ProposalActionRequest::Motion(Motion {
+            motion_text: "This one survives.".to_string(),
+        }),
+    );
+
+    // Take a snapshot of Governance (via proposal).
+    //
+    // Cannot use nns_execute_proposal for the same reason as LoadCanisterSnapshot
+    // below: Root stops/restarts Governance in the background, racing with the poll.
+    nns_governance_make_proposal(
+        &state_machine,
+        *TEST_NEURON_1_OWNER_PRINCIPAL,
+        NeuronId {
+            id: TEST_NEURON_1_ID,
+        },
+        &MakeProposalRequest {
+            title: Some("TakeCanisterSnapshot".to_string()),
+            summary: String::new(),
+            url: String::new(),
+            action: Some(ProposalActionRequest::TakeCanisterSnapshot(
+                TakeCanisterSnapshot {
+                    canister_id: Some(target_canister_id.get()),
+                    replace_snapshot: None,
+                },
+            )),
+        },
+    );
+    // Let the background work (stop → take snapshot → start Governance) complete.
+    for _ in 0..50 {
+        state_machine.tick();
+    }
+
+    // Verify that the proposal had the desired effect: a new snapshot of
+    // the Governance canister.
+    let snapshots: Vec<CanisterSnapshotResponse> = update_with_sender(
+        &state_machine,
+        CanisterId::ic_00(),
+        "list_canister_snapshots",
+        ListCanisterSnapshotArgs::new(target_canister_id),
+        ROOT_CANISTER_ID.get(),
+    )
+    .unwrap();
+    assert_eq!(snapshots.len(), 1, "{snapshots:#?}");
+    let snapshot = &snapshots[0];
+    assert_eq!(snapshot.id.get_canister_id(), GOVERNANCE_CANISTER_ID,);
+
+    // Change Governance's state by creating ANOTHER (Motion) proposal.
+    // This will get blown away at the end when we load the snapshot,
+    // because the snapshot was taken before this proposal.
+    let doomed_motion_proposal_id = nns_execute_proposal(
+        &state_machine,
+        ProposalActionRequest::Motion(Motion {
+            motion_text: "This one gets rolled back.".to_string(),
+        }),
+    );
+    // Verify the second/doommed Motion proposal exists. This is so that
+    // when we find it absent after loading the canister snapshot, we are
+    // seeing a CHANGE, not just the final state.
+    let doomed_motion_proposal_info_before_load =
+        nns_get_proposal_info(&state_machine, doomed_motion_proposal_id.id);
+    assert_ne!(doomed_motion_proposal_info_before_load, None,);
+
+    // Step 2: Execute the code under test: Load the snapshot (via proposal).
+    //
+    // We cannot use nns_execute_proposal here: when targeting Governance,
+    // the proposal is marked Executed immediately (to avoid deadlock), then
+    // Root stops/restores/starts Governance in the background, at which point
+    // the proposal itself is gone (rolled back with the snapshot). Polling for
+    // Executed status would race with the stop or never find the proposal.
+    nns_governance_make_proposal(
+        &state_machine,
+        *TEST_NEURON_1_OWNER_PRINCIPAL,
+        NeuronId {
+            id: TEST_NEURON_1_ID,
+        },
+        &MakeProposalRequest {
+            title: Some("LoadCanisterSnapshot".to_string()),
+            summary: String::new(),
+            url: String::new(),
+            action: Some(ProposalActionRequest::LoadCanisterSnapshot(
+                LoadCanisterSnapshot {
+                    canister_id: Some(target_canister_id.get()),
+                    snapshot_id: Some(snapshot.snapshot_id().to_vec()),
+                },
+            )),
+        },
+    );
+
+    // Let the background work (stop → load snapshot → start Governance) complete.
+    for _ in 0..50 {
+        state_machine.tick();
+    }
+
+    // Step 3: Verify results.
+
+    // The pre-snapshot Motion proposal should still exist (it was part of the
+    // snapshot).
+    let pre_snapshot_motion_info_after =
+        nns_get_proposal_info(&state_machine, pre_snapshot_motion_proposal_id.id);
+    assert_ne!(
+        pre_snapshot_motion_info_after, None,
+        "Pre-snapshot Motion proposal should still exist: {pre_snapshot_motion_info_after:#?}",
+    );
+
+    // The post-snapshot Motion proposal should be gone, because it was not in
+    // the snapshot.
+    //
+    // (As a side effect, the load proposal itself also disappears, but we use
+    // this Motion proposal as the primary indicator since it is less confusing.)
+    let doomed_motion_info_after_load =
+        nns_get_proposal_info(&state_machine, doomed_motion_proposal_id.id);
+    assert_eq!(doomed_motion_info_after_load, None,);
 }

--- a/rs/nns/test_utils/src/state_test_helpers.rs
+++ b/rs/nns/test_utils/src/state_test_helpers.rs
@@ -25,6 +25,7 @@ use ic_nervous_system_common::{
     DEFAULT_TRANSFER_FEE, ONE_DAY_SECONDS,
     ledger::{compute_neuron_staking_subaccount, compute_neuron_staking_subaccount_bytes},
 };
+use ic_nervous_system_common_test_keys::{TEST_NEURON_1_ID, TEST_NEURON_1_OWNER_PRINCIPAL};
 use ic_nns_common::init::LifelineCanisterInitPayload;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_nns_constants::{
@@ -909,6 +910,31 @@ pub fn nns_governance_get_proposal_info(
     Decode!(&result, Option<ProposalInfo>).unwrap().unwrap()
 }
 
+/// Like `nns_governance_get_proposal_info_as_anonymous`, but returns `None`
+/// when the proposal does not exist, rather than panicking.
+pub fn nns_get_proposal_info(
+    state_machine: &StateMachine,
+    proposal_id: u64,
+) -> Option<ProposalInfo> {
+    let result = state_machine
+        .execute_ingress_as(
+            PrincipalId::new_anonymous(),
+            GOVERNANCE_CANISTER_ID,
+            "get_proposal_info",
+            Encode!(&proposal_id).unwrap(),
+        )
+        .unwrap();
+
+    let result = match result {
+        WasmResult::Reply(reply) => reply,
+        WasmResult::Reject(reject) => {
+            panic!("get_proposal_info was rejected by the NNS governance canister: {reject:#?}")
+        }
+    };
+
+    Decode!(&result, Option<ProposalInfo>).unwrap()
+}
+
 pub fn nns_send_icp_to_claim_or_refresh_neuron(
     state_machine: &StateMachine,
     sender: PrincipalId,
@@ -1466,6 +1492,12 @@ pub fn nns_leave_community_fund(
     manage_neuron_or_panic(state_machine, sender, neuron_id, command)
 }
 
+/// If you are in the common case where
+///
+/// 1. TEST_NEURON_1 has a majority of the voting power, and
+/// 2. You expect the proposal to pass right away and execute successfully
+///
+/// Then, use nns_execute_proposal instead.
 pub fn nns_governance_make_proposal(
     state_machine: &StateMachine,
     sender: PrincipalId,
@@ -1475,6 +1507,38 @@ pub fn nns_governance_make_proposal(
     let command = ManageNeuronCommandRequest::MakeProposal(Box::new(proposal.clone()));
 
     manage_neuron_or_panic(state_machine, sender, neuron_id, command)
+}
+
+/// Returns proposal ID.
+///
+/// TEST_NEURON_1 submits the proposal. Then, waits for it to execute
+/// successfully (see `nns_wait_for_proposal_execution`).
+///
+/// Panics if the proposal is Rejected, fails during execution (i.e. reaches
+/// Failed status), times out, etc.
+pub fn nns_execute_proposal(
+    state_machine: &StateMachine,
+    action: ProposalActionRequest,
+) -> ProposalId {
+    let response = nns_governance_make_proposal(
+        state_machine,
+        *TEST_NEURON_1_OWNER_PRINCIPAL,
+        NeuronId {
+            id: TEST_NEURON_1_ID,
+        },
+        &MakeProposalRequest {
+            title: Some(format!("{action:?}")),
+            summary: String::new(),
+            url: String::new(),
+            action: Some(action),
+        },
+    );
+    let proposal_id = match response.command.unwrap() {
+        manage_neuron_response::Command::MakeProposal(r) => r.proposal_id.unwrap(),
+        other => panic!("{other:#?}"),
+    };
+    nns_wait_for_proposal_execution(state_machine, proposal_id.id);
+    proposal_id
 }
 
 pub fn nns_add_hot_key(


### PR DESCRIPTION
Deadlock is avoided by performing the operation IN THE BACKGROUND when Governance is the target. For other targets, the Root behaves as before: synchronously.

# How Deadlock Would Occur Otherwise

1. Governance calls Root, and waits for Root to reply.
2. Root orders Governance to stop. Stop does not complete while the canister (in this case, Governance) is waiting for calls to complete.

This is circular waiting, deadlock.

# How Background Avoids Deadlock

By doing the operation in spawn_migratory, the second wait (where Root is waiting for Governance to stop) does not happen. Thus, the first wait (where Governance waits for Root to reply) is able to terminate.

# Changes in Greater Detail

Renamed `exclusively_stop_and_start_canister` to `perform_offline_canister_maintenance`. This is not strictly necessary; the old name is not wrong now, but the new name seems better, because it shifts emphasis away from secondary operations (stop, lock, start, etc.) to the main thing, i.e. maintenance of some kind, such as upgrade, taking snapshot, loading snapshot, etc.

The main enhancement to this function is that it now behaves a little bit differently in the special case where the target canister is Governance. In this special case, the operation is performed in the background (via spawn_migratory).

Also, in this case, "success" is defined as "we were able to launch this operation in the background", not "the operation itself went well".

This is why we need the new `Optimistic` trait: it is used when we need to report success in this much weaker definition of success.

Added some helpers to `ic_nns_test_utils`, very similar to existing ones:

* `nns_get_proposal_info` - Unlike other similar helpers, this returns `Option<ProposalInfo>` instead of `ProposalInfo`, because we (for the first time?) needed a way to query a proposal that does NOT exist.

* `nns_execute_proposal` - This probably should have existed before. It optimizes a very common case: TEST_NEURON_1 has majority voting power, and can therefore be used to make a proposal that passes right away + the test expects the proposal to be executed successfully + the test does not care about the title, summary, url.

# Testing

Made a copy of an existing test for snapshots (via proposal). In the new test, the target canister is Governance (instead of Ledger). The code under test is verified by verifying that after loading a snapshot (via proposal) old proposals are still there, but new ones are not.

# References

Closes [NNS1-4321].

[NNS1-4321]: https://dfinity.atlassian.net/browse/NNS1-4321