### PR TITLE
docs(node): improve the rs/ic_os doc comments 

### DIFF
--- a/rs/ic_os/boot/grub/src/lib.rs
+++ b/rs/ic_os/boot/grub/src/lib.rs
@@ -1,3 +1,9 @@
+//! Read, modify, and write GRUB environment blocks. Used by HostOS tools
+//! to manage GuestOS A/B boot partition selection and boot cycle state
+//! (stable, first_boot, failsafe_check, install). HostOS manages this because
+//! it launches the GuestOS VM and must read grubenv to determine which
+//! partition and kernel to boot (`guest_vm_runner`, `hostos_tool`).
+
 use ic_sys::fs::{Clobber, write_atomically};
 use regex::Regex;
 use std::io::{BufRead, BufReader, Read, Write};

--- a/rs/ic_os/build_tools/partition_tools/src/lib.rs
+++ b/rs/ic_os/build_tools/partition_tools/src/lib.rs
@@ -1,3 +1,6 @@
+//! Tools for creating and manipulating disk partitions (ext4, FAT, GPT) used
+//! during IC-OS image construction.
+
 pub mod ext;
 pub mod fat;
 mod gpt;

--- a/rs/ic_os/dev_test_tools/bare_metal_deployment/src/lib.rs
+++ b/rs/ic_os/dev_test_tools/bare_metal_deployment/src/lib.rs
@@ -1,3 +1,8 @@
+//! Fast HostOS/GuestOS deployment to bare metal nodes, bypassing full SetupOS
+//! redeployment. SSHes into the target, copies images, and triggers an
+//! upgrade via the `reload_icos` script. Falls back to IPMI Serial-over-LAN
+//! for SSH key injection when SSH authentication fails.
+
 pub mod deploy;
 
 pub use deploy::SshAuthMethod;

--- a/rs/ic_os/dev_test_tools/setupos-image-config/src/lib.rs
+++ b/rs/ic_os/dev_test_tools/setupos-image-config/src/lib.rs
@@ -1,3 +1,8 @@
+//! Injects configuration into SetupOS disk images. The `setupos-inject-config`
+//! binary modifies the config and data partitions of an existing SetupOS image
+//! in-place, updating `config.ini`, `deployment.json`, SSH keys, and NNS
+//! public key without rebuilding the image.
+
 use std::{
     assert,
     fs::{self, File},

--- a/rs/ic_os/device/src/lib.rs
+++ b/rs/ic_os/device/src/lib.rs
@@ -1,3 +1,7 @@
+//! Linux device-mapper and partition mounting abstractions for IC-OS. Provides
+//! RAII-managed loop devices, linear mappings, and snapshots (`device_mapping`),
+//! plus GPT-aware partition access by UUID or label (`mount`).
+
 #[cfg(target_os = "linux")]
 pub mod device_mapping;
 mod io;

--- a/rs/ic_os/linux_kernel_command_line/src/lib.rs
+++ b/rs/ic_os/linux_kernel_command_line/src/lib.rs
@@ -1,5 +1,6 @@
+//! Parse, modify, and serialize Linux kernel command line strings.
+
 use regex::Regex;
-/// Utilities to manipulate a kernel command line reliably.
 use std::error::Error as StdError;
 use std::fmt;
 use std::fmt::{Display, Write};

--- a/rs/ic_os/networking/network/src/lib.rs
+++ b/rs/ic_os/networking/network/src/lib.rs
@@ -1,3 +1,7 @@
+//! Generates systemd-networkd configuration files for SetupOS and HostOS from
+//! the IC-OS network settings. Resolves the management MAC address from IPMI
+//! or config overrides.
+
 use std::path::Path;
 use std::process::Command;
 

--- a/rs/ic_os/os_tools/fstrim_tool/src/lib.rs
+++ b/rs/ic_os/os_tools/fstrim_tool/src/lib.rs
@@ -1,3 +1,7 @@
+//! Runs `fstrim` on GuestOS filesystems and reports Prometheus metrics on
+//! trim duration and success/failure. Skips the data directory if the node
+//! is assigned to a subnet (has a CatchUpPackage).
+
 use anyhow::{Context, Result, format_err};
 use ic_sys::fs::write_string_using_tmp_file;
 use std::fs::File;

--- a/rs/ic_os/os_tools/guest_vm_runner/src/guest_direct_boot.rs
+++ b/rs/ic_os/os_tools/guest_vm_runner/src/guest_direct_boot.rs
@@ -1,3 +1,8 @@
+//! Direct boot bypasses the GuestOS VM's internal GRUB bootloader. Instead,
+//! HostOS extracts the kernel, initrd, and boot args from the GuestOS partition
+//! and passes them to QEMU directly. Required for SEV-SNP so that the kernel
+//! and root hash are included in the VM's launch measurement.
+
 use crate::GuestVMType;
 use crate::boot_args::read_boot_args;
 use crate::guest_vm_config::DirectBootConfig;

--- a/rs/ic_os/os_tools/manual_guestos_recovery/src/lib.rs
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/src/lib.rs
@@ -1,3 +1,7 @@
+//! Interactive TUI application for manual GuestOS recovery. Prompts the operator
+//! for a recovery version and hash prefix, downloads and verifies recovery
+//! artifacts, and installs the recovery GuestOS image.
+
 pub mod recovery_utils;
 mod ui;
 

--- a/rs/ic_os/sev/attestation/README.md
+++ b/rs/ic_os/sev/attestation/README.md
@@ -1,7 +1,7 @@
 SEV Attestation
 ===============
 
-This crate provides types and utilities for SEV-SNP attestation.
+SEV-SNP attestation verification library. Parses and validates attestation packages (report + certificate chain), verifying measurements, signatures, custom data, and chip identity. Used by both the canister and OS-level attestation flows.
 
 Folder structure:
 

--- a/rs/ic_os/sev/guest/firmware/src/lib.rs
+++ b/rs/ic_os/sev/guest/firmware/src/lib.rs
@@ -1,5 +1,5 @@
 //! Trait abstraction over the AMD SEV guest firmware interface (`/dev/sev-guest`).
- 
+
 use sev::error::UserApiError;
 use sev::firmware::guest::DerivedKey;
 #[cfg(target_os = "linux")]

--- a/rs/ic_os/sev/guest/firmware/src/lib.rs
+++ b/rs/ic_os/sev/guest/firmware/src/lib.rs
@@ -1,3 +1,5 @@
+//! Trait abstraction over the AMD SEV guest firmware interface (`/dev/sev-guest`).
+ 
 use sev::error::UserApiError;
 use sev::firmware::guest::DerivedKey;
 #[cfg(target_os = "linux")]

--- a/rs/ic_os/sev/host/src/lib.rs
+++ b/rs/ic_os/sev/host/src/lib.rs
@@ -1,3 +1,8 @@
+//! SEV-SNP host-side certificate management for IC-OS. Fetches the VCEK
+//! (Versioned Chip Endorsement Key) from AMD's key distribution service,
+//! caches it locally, and assembles the full certificate chain (VCEK + ASK + ARK)
+//! needed for guest attestation verification.
+
 use anyhow::{Context, Result, anyhow};
 use der::pem::LineEnding;
 use der::{Decode, Document};

--- a/rs/ic_os/vsock/README.md
+++ b/rs/ic_os/vsock/README.md
@@ -1,10 +1,10 @@
 # Vsock
 
-The vsock is the GuestOS’s only means of communicating with the HostOS. The vsock exists to perform certain functions unavailable to the GuestOS.
+The vsock is the GuestOS’s primary command channel for communicating with the HostOS. The vsock exists to perform certain functions unavailable to the GuestOS.
 
 The `vsock_guest` binary runs in the GuestOS and sends messages over the vsock channel to the `vsock_host` binary running in the HostOS.
 
-`vsock_guest` is used solely by the orchestator.
+`vsock_guest` is used solely by the orchestrator.
 
 The `protocol` module defines the communication protocol and offers utility functions for communication.
 


### PR DESCRIPTION
NODE-1938

This is part of a larger effort to make the ic codebase more LLM-friendly. Adding more doc comments helps LLMs quickly understand each crate's purpose.