### PR TITLE
feat(IDX): add binaries to release

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -7,6 +7,16 @@ on:
   push:
     tags:
       - 'release-*'
+  workflow_dispatch:
+    inputs:
+      tag-name:
+        description: 'The name of the tag to publish'
+        required: true
+      dry-run:
+        description: "If true, run the workflow in dry-run mode (don't actually publish the release)"
+        required: true
+        default: 'true'
+        type: boolean
 
 jobs:
   build:
@@ -15,6 +25,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.tag-name || github.ref }}
 
       - name: Collect Release Artifacts
         run: |
@@ -28,7 +40,11 @@ jobs:
           curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/binaries/x86_64-linux/pocket-ic.gz" -o pocket-ic-x86_64-linux.gz
           curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/binaries/x86_64-darwin/pocket-ic.gz" -o pocket-ic-x86_64-darwin.gz
           curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/binaries/arm64-linux/pocket-ic.gz" -o pocket-ic-arm64-linux.gz
+          curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/binaries/arm64-linux/ic-admin.gz" -o ic-admin-arm64-linux.gz
+          curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/binaries/arm64-linux/sns.gz" -o sns-arm64-linux.gz
           curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/binaries/arm64-darwin/pocket-ic.gz" -o pocket-ic-arm64-darwin.gz
+          curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/binaries/arm64-darwin/ic-admin.gz" -o ic-admin-arm64-darwin.gz
+          curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/binaries/arm64-darwin/sns.gz" -o sns-arm64-darwin.gz
           sha256sum *.gz > sha256sums.txt
 
           echo "DOWNLOAD_PREFIX=${DOWNLOAD_PREFIX}" >> "$GITHUB_ENV"
@@ -73,6 +89,7 @@ jobs:
       - name: Publish Release
         # v0.1.15
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry-run == 'false' }}
         with:
           body: "IC ${{github.ref_name}}"
           files: |
@@ -80,8 +97,12 @@ jobs:
             setup-os-img.tar.gz
             update-os-img.tar.gz
             ic-admin-x86_64-linux.gz
+            ic-admin-arm64-linux.gz
+            ic-admin-arm64-darwin.gz
             pocket-ic-x86_64-linux.gz
             pocket-ic-x86_64-darwin.gz
             pocket-ic-arm64-linux.gz
             pocket-ic-arm64-darwin.gz
+            sns-arm64-linux.gz
+            sns-arm64-darwin.gz
             sha256sums.txt


### PR DESCRIPTION
This PR adds the binaries to the release that we introduced in https://github.com/dfinity/ic/pull/9703.

It also introduces a manual dispatch trigger with a dry-run mode, so we can test that this works before the actual release. Unfortunately I need to merge to master before I can test the manual kickoff.