### PR TITLE
revert: "fix: move bazel-build-all-no-cache to schedule-daily"

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -614,6 +614,22 @@ jobs:
             | awk -F, 'BEGIN { N_BAD=0; } $3 != $4 { print $1 " " $2 ": " $3 " != " $4; N_BAD++; } END { if (N_BAD) { print N_BAD " mismatches found"; exit 1; } else { print "No mismatches"; }; }' \
             | column -t | sort
 
+  bazel-build-all-no-cache:
+    name: Bazel Build All No Cache
+    needs: [config]
+    if: ${{ needs.config.outputs.skip_long_tests != 'true' }} # GHA output quirk, 'true' is a string
+    runs-on: *dind-large-setup
+    container: *container-setup
+    timeout-minutes: 90
+    steps:
+      - *checkout
+      - uses: ./.github/actions/netrc
+      - name: Run Bazel Build All No Cache
+        uses: ./.github/actions/bazel
+        with:
+          run: bazel build --config=stamped --config=local //...
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
   cargo-linux:
     strategy:
       matrix:

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -52,21 +52,6 @@ jobs:
               --keep_going --test_timeout=43200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-  bazel-build-all-no-cache:
-    name: Bazel Build All No Cache
-    needs: [config]
-    runs-on: *dind-large-setup
-    container: *container-setup
-    timeout-minutes: 90
-    steps:
-      - *checkout
-      - uses: ./.github/actions/netrc
-      - name: Run Bazel Build All No Cache
-        uses: ./.github/actions/bazel
-        with:
-          run: bazel build --config=stamped --config=local //...
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
   bazel-test-bare-metal:
     name: Bazel Test Bare Metal
     runs-on: *dind-large-setup


### PR DESCRIPTION
Reverts dfinity/ic#9788

I didn't catch this earlier, but the workflow is invalid with the error `(Line: 57, Col: 13): Job 'bazel-build-all-no-cache' depends on unknown job 'config'.` - let's revert this first and see if the rate limit is still an issue.