### PR TITLE
chore(IDX): split out config and bazel targets

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -199,7 +199,6 @@ jobs:
             ${{ runner.temp }}/build-targets
             ${{ runner.temp }}/test-targets
 
-
   bazel-test-all:
     name: Bazel Test All
     needs: [config, infer-bazel-targets]

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -165,6 +165,7 @@ jobs:
     name: Infer Bazel Targets
     runs-on: ubuntu-latest
     needs: [config]
+    steps:
       # calculate which bazel targets may need to be rebuilt
       - *checkout
       - name: Infer Targets

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -161,6 +161,10 @@ jobs:
           echo "skip_buf_checks=$skip_buf_checks" >> "$GITHUB_OUTPUT"
           echo "| \`skip_buf_checks\` | \`$skip_buf_checks\` |" >> "$GITHUB_STEP_SUMMARY"
 
+  infer-bazel-targets:
+    name: Infer Bazel Targets
+    runs-on: ubuntu-latest
+    needs: [config]
       # calculate which bazel targets may need to be rebuilt
       - *checkout
       - name: Infer Targets
@@ -168,13 +172,13 @@ jobs:
         with:
           run: |
             targets_args=()
-            if [[ '${{ steps.config.outputs.skip_long_tests }}' == 'true' ]]; then
+            if [[ '${{ needs.config.outputs.skip_long_tests }}' == 'true' ]]; then
               targets_args+=("--skip_long_tests")
             fi
-            if [[ '${{ steps.config.outputs.skip_buf_checks }}' == 'true' ]]; then
+            if [[ '${{ needs.config.outputs.skip_buf_checks }}' == 'true' ]]; then
               targets_args+=("--exclude_tags=buf")
             fi
-            if [[ '${{ steps.config.outputs.diff-only }}' == 'true' ]]; then
+            if [[ '${{ needs.config.outputs.diff-only }}' == 'true' ]]; then
               targets_args+=(
                 '--base=${{ github.event.pull_request.base.sha }}'
                 '--head=${{ github.event.pull_request.head.sha }}'
@@ -194,9 +198,10 @@ jobs:
             ${{ runner.temp }}/build-targets
             ${{ runner.temp }}/test-targets
 
+
   bazel-test-all:
     name: Bazel Test All
-    needs: [config]
+    needs: [config, infer-bazel-targets]
     environment:
       # The `Upload artifacts` step below only executes if `release-build == 'true'` which is the case on protected branches.
       # It also requires the AWS and CF secrets which are only available in the `upload-artifacts` environment.
@@ -306,7 +311,7 @@ jobs:
     name: Bazel Test arm64-${{ matrix.os }}
     runs-on: ${{ matrix.profile }}
     timeout-minutes: 120
-    needs: config
+    needs: [config]
     if: github.repository == 'dfinity/ic' # only run on public repo, not private since Namespace runners are not configured there, so these CI jobs get stuck otherwise.
     steps:
       - name: Set up Bazel cache
@@ -500,7 +505,7 @@ jobs:
           REPO_NAME: ${{ github.repository }}
 
   build-ic:
-    needs: [config]
+    needs: [config, infer-bazel-targets]
     name: Build IC
     runs-on: *dind-large-setup
     container: *container-setup


### PR DESCRIPTION
This splits out the `config` job from `infer bazel targets`. The motivation is that `infer bazel targets` takes 2-3 minutes to run and the `Bazel Test arm64-` jobs only need the config job, so they can start 2 minutes earlier without waiting.

If this seems like too much added complexity for a minor gain I can close this PR again, but thought it was worth the suggestion.