### PR TITLE
feat: new application subnet kind for test threshold keys in PocketIC

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The function `PocketIcBuilder::disable_ingress_validation` to specify that ingress validation
   should be disabled for mainnet-like endpoints `/instances/<instance_id>/api/...` of the instance.
+- The function `PocketIcBuilder::with_test_threshold_keys_subnet` to create a test threshold keys subnet.
 
 
 

--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -684,15 +684,33 @@ can be transferred to a different address.
 For an example of a test canister that can be deployed to an application subnet of the PocketIC instance,
 we refer to the basic Dogecoin [example canister](https://github.com/dfinity/dogecoin-canister/tree/master/examples/basic_dogecoin).
 
-## VetKd
+## Threshold Keys
 
-To test the VetKd feature, you need to create a PocketIC instance with II or fiduciary subnet:
+PocketIC provides three subnet kinds that hold threshold keys (tECDSA, Schnorr, and VetKd):
+
+- **II subnet** (`with_ii_subnet`): holds keys named `key_1` for all algorithms.
+- **Fiduciary subnet** (`with_fiduciary_subnet`): holds keys named `key_1` for all algorithms.
+- **Test threshold keys subnet** (`with_test_threshold_keys_subnet`): holds keys named `test_key_1` and `dfx_test_key` for all algorithms.
+  Its canister range matches the mainnet subnet `fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae`.
+
+To use `key_1`, add an II or fiduciary subnet to your PocketIC instance:
 
 ```rust
     // We create a PocketIC instance consisting of the II and one application subnet.
     let pic = PocketIcBuilder::new()
-        .with_ii_subnet()               // this subnet has threshold keys
-        .with_application_subnet()      // we deploy the dapp canister here
+        .with_ii_subnet()          // this subnet has threshold key key_1
+        .with_application_subnet() // we deploy the dapp canister here
+        .build();
+```
+
+To use a threshold key with `test_` prefix (such as `test_key_1` or `dfx_test_key`) in tests,
+add a test threshold keys subnet to your PocketIC instance:
+
+```rust
+    // We create a PocketIC instance consisting of the test threshold keys and one application subnet.
+    let pic = PocketIcBuilder::new()
+        .with_test_threshold_keys_subnet() // this subnet has threshold keys with test_ prefix
+        .with_application_subnet()         // we deploy the dapp canister here
         .build();
 ```
 

--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -546,7 +546,7 @@ Now we create a PocketIC instance:
     };
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_ii_subnet()          // to have tECDSA keys available
+        .with_test_threshold_keys_subnet() // to have tECDSA keys with test_ prefix available
         .with_bitcoin_subnet()
         .with_application_subnet() // to deploy the test dapp
         .with_bitcoind_addr(bitcoind.p2p_socket().unwrap().into())
@@ -631,7 +631,7 @@ Now we create a PocketIC instance:
     };
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_ii_subnet()          // to have tECDSA keys available
+        .with_test_threshold_keys_subnet() // to have tECDSA keys with test_ prefix available
         .with_bitcoin_subnet()
         .with_application_subnet() // to deploy the test dapp
         .with_dogecoind_addrs(vec![dogecoind.p2p_socket().unwrap().into()])

--- a/packages/pocket-ic/HOWTO.md
+++ b/packages/pocket-ic/HOWTO.md
@@ -546,7 +546,7 @@ Now we create a PocketIC instance:
     };
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_test_threshold_keys_subnet() // to have tECDSA keys with test_ prefix available
+        .with_test_threshold_keys_subnet() // to have tECDSA keys with names `test_key_1` and `dfx_test_key` available
         .with_bitcoin_subnet()
         .with_application_subnet() // to deploy the test dapp
         .with_bitcoind_addr(bitcoind.p2p_socket().unwrap().into())
@@ -631,7 +631,7 @@ Now we create a PocketIC instance:
     };
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_test_threshold_keys_subnet() // to have tECDSA keys with test_ prefix available
+        .with_test_threshold_keys_subnet() // to have tECDSA keys with names `test_key_1` and `dfx_test_key` available
         .with_bitcoin_subnet()
         .with_application_subnet() // to deploy the test dapp
         .with_dogecoind_addrs(vec![dogecoind.p2p_socket().unwrap().into()])
@@ -698,18 +698,17 @@ To use `key_1`, add an II or fiduciary subnet to your PocketIC instance:
 ```rust
     // We create a PocketIC instance consisting of the II and one application subnet.
     let pic = PocketIcBuilder::new()
-        .with_ii_subnet()          // this subnet has threshold key key_1
+        .with_ii_subnet()          // this subnet has threshold key `key_1`
         .with_application_subnet() // we deploy the dapp canister here
         .build();
 ```
 
-To use a threshold key with `test_` prefix (such as `test_key_1` or `dfx_test_key`) in tests,
-add a test threshold keys subnet to your PocketIC instance:
+To use `test_key_1` or `dfx_test_key`, add a test threshold keys subnet to your PocketIC instance:
 
 ```rust
     // We create a PocketIC instance consisting of the test threshold keys and one application subnet.
     let pic = PocketIcBuilder::new()
-        .with_test_threshold_keys_subnet() // this subnet has threshold keys with test_ prefix
+        .with_test_threshold_keys_subnet() // to have threshold keys with names `test_key_1` and `dfx_test_key` available
         .with_application_subnet()         // we deploy the dapp canister here
         .build();
 ```

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -466,6 +466,7 @@ pub enum SubnetKind {
     NNS,
     SNS,
     System,
+    TestThresholdKeys,
     VerifiedApplication,
 }
 
@@ -478,6 +479,7 @@ pub struct SubnetConfigSet {
     pub ii: bool,
     pub fiduciary: bool,
     pub bitcoin: bool,
+    pub test_threshold_keys: bool,
     pub system: usize,
     pub application: usize,
     pub cloud_engine: usize,
@@ -495,6 +497,7 @@ impl SubnetConfigSet {
             || self.ii
             || self.fiduciary
             || self.bitcoin
+            || self.test_threshold_keys
         {
             return Ok(());
         }
@@ -510,6 +513,7 @@ impl From<SubnetConfigSet> for ExtendedSubnetConfigSet {
             ii,
             fiduciary: fid,
             bitcoin,
+            test_threshold_keys,
             system,
             application,
             cloud_engine,
@@ -538,6 +542,11 @@ impl From<SubnetConfigSet> for ExtendedSubnetConfigSet {
                 None
             },
             bitcoin: if bitcoin {
+                Some(SubnetSpec::default())
+            } else {
+                None
+            },
+            test_threshold_keys: if test_threshold_keys {
                 Some(SubnetSpec::default())
             } else {
                 None
@@ -666,6 +675,7 @@ pub struct ExtendedSubnetConfigSet {
     pub ii: Option<SubnetSpec>,
     pub fiduciary: Option<SubnetSpec>,
     pub bitcoin: Option<SubnetSpec>,
+    pub test_threshold_keys: Option<SubnetSpec>,
     pub system: Vec<SubnetSpec>,
     pub application: Vec<SubnetSpec>,
     #[serde(default)]
@@ -793,6 +803,7 @@ impl ExtendedSubnetConfigSet {
             (self.ii.clone(), II),
             (self.fiduciary.clone(), Fiduciary),
             (self.bitcoin.clone(), Bitcoin),
+            (self.test_threshold_keys.clone(), TestThresholdKeys),
         ]
         .into_iter()
         .filter(|(mb, _)| mb.is_some())
@@ -811,6 +822,7 @@ impl ExtendedSubnetConfigSet {
             .chain(&self.ii)
             .chain(&self.fiduciary)
             .chain(&self.bitcoin)
+            .chain(&self.test_threshold_keys)
             .chain(&self.system)
             .chain(&self.verified_application);
 

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -364,6 +364,7 @@ impl PocketIcBuilder {
             SubnetKind::II => config.ii = Some(subnet_spec),
             SubnetKind::Fiduciary => config.fiduciary = Some(subnet_spec),
             SubnetKind::Bitcoin => config.bitcoin = Some(subnet_spec),
+            SubnetKind::TestThresholdKeys => config.test_threshold_keys = Some(subnet_spec),
             SubnetKind::Application => config.application.push(subnet_spec),
             SubnetKind::CloudEngine => config.cloud_engine.push(subnet_spec),
             SubnetKind::System => config.system.push(subnet_spec),
@@ -401,6 +402,14 @@ impl PocketIcBuilder {
     pub fn with_bitcoin_subnet(mut self) -> Self {
         let mut config = self.config.unwrap_or_default();
         config.bitcoin = Some(config.bitcoin.unwrap_or_default());
+        self.config = Some(config);
+        self
+    }
+
+    /// Add an empty test threshold keys subnet unless a test threshold keys subnet has already been added.
+    pub fn with_test_threshold_keys_subnet(mut self) -> Self {
+        let mut config = self.config.unwrap_or_default();
+        config.test_threshold_keys = Some(config.test_threshold_keys.unwrap_or_default());
         self.config = Some(config);
         self
     }

--- a/packages/pocket-ic/test_canister/src/canister.rs
+++ b/packages/pocket-ic/test_canister/src/canister.rs
@@ -4,7 +4,7 @@ use ic_cdk::api::call::{RejectionCode, accept_message, arg_data_raw, reject};
 use ic_cdk::api::instruction_counter;
 use ic_cdk::api::management_canister::ecdsa::{
     EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument, EcdsaPublicKeyResponse, SignWithEcdsaArgument,
-    ecdsa_public_key as ic_cdk_ecdsa_public_key, sign_with_ecdsa as ic_cdk_sign_with_ecdsa,
+    SignWithEcdsaResponse, ecdsa_public_key as ic_cdk_ecdsa_public_key,
 };
 use ic_cdk::api::management_canister::http_request::{
     CanisterHttpRequestArgument, HttpMethod, HttpResponse, TransformArgs, TransformContext,
@@ -162,6 +162,11 @@ async fn sign_with_schnorr(
     key_id: SchnorrKeyId,
     aux: Option<SignWithSchnorrAux>,
 ) -> Result<Vec<u8>, String> {
+    let fee = if key_id.name == "key_1" {
+        26_153_846_153
+    } else {
+        10_000_000_000
+    };
     let request = SignWithSchnorrArgument {
         message,
         derivation_path,
@@ -173,7 +178,7 @@ async fn sign_with_schnorr(
         Principal::management_canister(),
         "sign_with_schnorr",
         (request,),
-        26_153_846_153,
+        fee,
     )
     .await
     .map_err(|e| format!("sign_with_schnorr failed {e:?}"))?;
@@ -209,6 +214,11 @@ async fn sign_with_ecdsa(
     derivation_path: Vec<Vec<u8>>,
     name: String,
 ) -> Result<Vec<u8>, String> {
+    let fee: u128 = if name == "key_1" {
+        26_153_846_153
+    } else {
+        10_000_000_000
+    };
     let arg = SignWithEcdsaArgument {
         message_hash,
         derivation_path,
@@ -217,11 +227,18 @@ async fn sign_with_ecdsa(
             name,
         },
     };
-    Ok(ic_cdk_sign_with_ecdsa(arg)
+    Ok(
+        ic_cdk::api::call::call_with_payment128::<_, (SignWithEcdsaResponse,)>(
+            Principal::management_canister(),
+            "sign_with_ecdsa",
+            (arg,),
+            fee,
+        )
         .await
         .map_err(|(code, msg)| format!("Reject code: {code:?}; Reject message: {msg}"))?
         .0
-        .signature)
+        .signature,
+    )
 }
 
 // vetKd interface
@@ -297,6 +314,11 @@ async fn vetkd_derive_key(
     name: String,
     transport_public_key: Vec<u8>,
 ) -> Result<Vec<u8>, String> {
+    let fee = if name == "key_1" {
+        26_153_846_153
+    } else {
+        10_000_000_000
+    };
     let request = VetKdDeriveKeyArgument {
         context,
         input,
@@ -311,7 +333,7 @@ async fn vetkd_derive_key(
         Principal::management_canister(),
         "vetkd_derive_key",
         (request,),
-        26_153_846_153,
+        fee,
     )
     .await
     .map_err(|e| format!("vetkd_derive_key failed {e:?}"))?;

--- a/packages/pocket-ic/test_canister/src/canister.rs
+++ b/packages/pocket-ic/test_canister/src/canister.rs
@@ -227,18 +227,15 @@ async fn sign_with_ecdsa(
             name,
         },
     };
-    Ok(
-        ic_cdk::api::call::call_with_payment128::<_, (SignWithEcdsaResponse,)>(
-            Principal::management_canister(),
-            "sign_with_ecdsa",
-            (arg,),
-            fee,
-        )
-        .await
-        .map_err(|(code, msg)| format!("Reject code: {code:?}; Reject message: {msg}"))?
-        .0
-        .signature,
+    let (res,): (SignWithEcdsaResponse,) = ic_cdk::api::call::call_with_payment128(
+        Principal::management_canister(),
+        "sign_with_ecdsa",
+        (arg,),
+        fee,
     )
+    .await
+    .map_err(|(code, msg)| format!("Reject code: {code:?}; Reject message: {msg}"))?;
+    Ok(res.signature)
 }
 
 // vetKd interface

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1014,10 +1014,11 @@ fn test_canister_wasm() -> Vec<u8> {
 
 #[test]
 fn test_schnorr() {
-    // We create a PocketIC instance consisting of the NNS, II, and one application subnet.
+    // We create a PocketIC instance consisting of the NNS, II, test threshold keys, and one application subnet.
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_ii_subnet() // this subnet has threshold keys
+        .with_ii_subnet() // this subnet has key_1
+        .with_test_threshold_keys_subnet() // this subnet has test_key_1 and dfx_test_key
         .with_application_subnet()
         .build();
 
@@ -1132,10 +1133,11 @@ fn test_schnorr() {
 fn test_ecdsa() {
     use k256::ecdsa::signature::hazmat::PrehashVerifier;
 
-    // We create a PocketIC instance consisting of the NNS, II, and one application subnet.
+    // We create a PocketIC instance consisting of the NNS, II, test threshold keys, and one application subnet.
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_ii_subnet() // this subnet has threshold keys
+        .with_ii_subnet() // this subnet has key_1
+        .with_test_threshold_keys_subnet() // this subnet has test_key_1 and dfx_test_key
         .with_application_subnet()
         .build();
 
@@ -1259,9 +1261,10 @@ fn test_ecdsa_disabled() {
 fn test_vetkd() {
     use ic_vetkeys::{DerivedPublicKey, EncryptedVetKey, TransportSecretKey};
 
-    // We create a PocketIC instance consisting of the II and one application subnet.
+    // We create a PocketIC instance consisting of the II, test threshold keys, and one application subnet.
     let pic = PocketIcBuilder::new()
-        .with_ii_subnet() // this subnet has threshold keys
+        .with_ii_subnet() // this subnet has key_1
+        .with_test_threshold_keys_subnet() // this subnet has test_key_1 and dfx_test_key
         .with_application_subnet()
         .build();
 

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1017,8 +1017,8 @@ fn test_schnorr() {
     // We create a PocketIC instance consisting of the NNS, II, test threshold keys, and one application subnet.
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_ii_subnet() // this subnet has key_1
-        .with_test_threshold_keys_subnet() // this subnet has test_key_1 and dfx_test_key
+        .with_ii_subnet() // this subnet has `key_1`
+        .with_test_threshold_keys_subnet() // this subnet has `test_key_1` and `dfx_test_key`
         .with_application_subnet()
         .build();
 
@@ -1136,8 +1136,8 @@ fn test_ecdsa() {
     // We create a PocketIC instance consisting of the NNS, II, test threshold keys, and one application subnet.
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_ii_subnet() // this subnet has key_1
-        .with_test_threshold_keys_subnet() // this subnet has test_key_1 and dfx_test_key
+        .with_ii_subnet() // this subnet has `key_1`
+        .with_test_threshold_keys_subnet() // this subnet has `test_key_1` and `dfx_test_key`
         .with_application_subnet()
         .build();
 
@@ -1263,8 +1263,8 @@ fn test_vetkd() {
 
     // We create a PocketIC instance consisting of the II, test threshold keys, and one application subnet.
     let pic = PocketIcBuilder::new()
-        .with_ii_subnet() // this subnet has key_1
-        .with_test_threshold_keys_subnet() // this subnet has test_key_1 and dfx_test_key
+        .with_ii_subnet() // this subnet has `key_1`
+        .with_test_threshold_keys_subnet() // this subnet has `test_key_1` and `dfx_test_key`
         .with_application_subnet()
         .build();
 

--- a/packages/pocket-ic/tests/unix.rs
+++ b/packages/pocket-ic/tests/unix.rs
@@ -844,3 +844,85 @@ fn test_sender_info_in_query_call() {
         .expect("query call failed");
     assert_eq!(result, signer);
 }
+
+#[test]
+fn test_cost_threshold_keys() {
+    // We create a PocketIC instance with the II subnet (holding `key_1` with 34 nodes)
+    // and the test threshold keys subnet (holding `test_key_1` and `dfx_test_key` with 13 nodes).
+    let pic = PocketIcBuilder::new()
+        .with_ii_subnet() // this subnet has `key_1`
+        .with_test_threshold_keys_subnet() // this subnet has `test_key_1` and `dfx_test_key`
+        .with_application_subnet()
+        .build();
+
+    let canister = deploy_universal_canister(&pic);
+
+    // `key_1` is on the II subnet (34 nodes): base fee 10B scaled by 34/13.
+    // `test_key_1` and `dfx_test_key` are on the test threshold keys subnet (13 nodes): base fee 10B.
+    let cases = [
+        ("key_1", 26_153_846_153_u128),
+        ("test_key_1", 10_000_000_000_u128),
+        ("dfx_test_key", 10_000_000_000_u128),
+    ];
+
+    for (name, expected_cost) in cases {
+        let name_bytes = name.as_bytes();
+
+        // ic0.cost_sign_with_ecdsa (curve `Secp256k1` = 0)
+        let bytes = pic
+            .update_call(
+                canister,
+                Principal::anonymous(),
+                "update",
+                wasm()
+                    .cost_sign_with_ecdsa(name_bytes, 0)
+                    .reply_data_append()
+                    .reply()
+                    .build(),
+            )
+            .unwrap();
+        assert_eq!(
+            u128::from_le_bytes(bytes.try_into().unwrap()),
+            expected_cost,
+            "`ic0.cost_sign_with_ecdsa` mismatch for key `{name}`"
+        );
+
+        // ic0.cost_sign_with_schnorr (algorithm `Bip340Secp256k1` = 0)
+        let bytes = pic
+            .update_call(
+                canister,
+                Principal::anonymous(),
+                "update",
+                wasm()
+                    .cost_sign_with_schnorr(name_bytes, 0)
+                    .reply_data_append()
+                    .reply()
+                    .build(),
+            )
+            .unwrap();
+        assert_eq!(
+            u128::from_le_bytes(bytes.try_into().unwrap()),
+            expected_cost,
+            "`ic0.cost_sign_with_schnorr` mismatch for key `{name}`"
+        );
+
+        // ic0.cost_vetkd_derive_key (curve `Bls12_381_G2` = 0)
+        let bytes = pic
+            .update_call(
+                canister,
+                Principal::anonymous(),
+                "update",
+                wasm()
+                    .cost_vetkd_derive_key(name_bytes, 0)
+                    .reply_data_append()
+                    .reply()
+                    .build(),
+            )
+            .unwrap();
+        assert_eq!(
+            u128::from_le_bytes(bytes.try_into().unwrap()),
+            expected_cost,
+            "`ic0.cost_vetkd_derive_key` mismatch for key `{name}`"
+        );
+    }
+}

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The endpoint `/instances/` takes an additional optional field `disable_ingress_validation` specifying that
   ingress validation is disabled for mainnet-like endpoints `/instances/<instance_id>/api/...` of the instance.
 - Support for canister signatures produced by the ICP mainnet in mainnet-like endpoints `/instances/<instance_id>/api/...`.
+- A new test threshold keys subnet kind (`TestThresholdKeys`): a new variant in `SubnetKind` and new fields in `SubnetConfigSet` and `ExtendedSubnetConfigSet`.
+  It is an application subnet with 13 nodes holding threshold keys with `test_` prefix (`test_key_1` and `dfx_test_key`) for all supported algorithms (ECDSA, Schnorr, VetKd).
+  Its canister range matches the mainnet subnet `fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae` (`z474k-xiaaa-aaaao-qaaaa-cai` to `fxzgb-eaaaa-aaaao-7777q-cai`).
+
+### Changed
+- The II and fiduciary subnets no longer hold threshold keys with `test_` prefix (`test_key_1` and `dfx_test_key`); these keys are now exclusively held by the `TestThresholdKeys` subnet.
 
 
 

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -16,14 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ingress validation is disabled for mainnet-like endpoints `/instances/<instance_id>/api/...` of the instance.
 - Support for canister signatures produced by the ICP mainnet in mainnet-like endpoints `/instances/<instance_id>/api/...`.
 - A new test threshold keys subnet kind (`TestThresholdKeys`): a new variant in `SubnetKind` and new fields in `SubnetConfigSet` and `ExtendedSubnetConfigSet`.
-  It is an application subnet with 13 nodes holding threshold keys with `test_` prefix (`test_key_1` and `dfx_test_key`) for all supported algorithms (ECDSA, Schnorr, VetKd).
-  Its canister range matches the mainnet subnet `fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae` (`z474k-xiaaa-aaaao-qaaaa-cai` to `fxzgb-eaaaa-aaaao-7777q-cai`).
+  It is an application subnet with 13 nodes holding threshold keys with names `test_key_1` and `dfx_test_key` for all supported algorithms (ECDSA, Schnorr, VetKd).
+  Its canister range (`z474k-xiaaa-aaaao-qaaaa-cai` to `fxzgb-eaaaa-aaaao-7777q-cai`) matches the mainnet subnet `fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae`.
 
 ### Changed
 - The endpoints `/instances/<instance_id>/update/submit_ingress_message` and `/instances/<instance_id>/read/query`
   accept an additional optional field `sender_info` in the request body specifying additional information provided
   by the canister with which the sender principal is associated.
-- The II and fiduciary subnets no longer hold threshold keys with `test_` prefix (`test_key_1` and `dfx_test_key`); these keys are now exclusively held by the `TestThresholdKeys` subnet.
+- The II and fiduciary subnets no longer hold threshold keys with names `test_key_1` and `dfx_test_key`; these keys are now exclusively held by the `TestThresholdKeys` subnet.
 
 
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -190,6 +190,8 @@ const MAINNET_FIDUCIARY_SUBNET_ID: &str =
     "pzp6e-ekpqk-3c5x7-2h6so-njoeq-mt45d-h3h6c-q3mxf-vpeq5-fk5o7-yae";
 const MAINNET_SNS_SUBNET_ID: &str =
     "x33ed-h457x-bsgyx-oqxqf-6pzwv-wkhzr-rm2j3-npodi-purzm-n66cg-gae";
+const MAINNET_TEST_THRESHOLD_KEYS_SUBNET_ID: &str =
+    "fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae";
 
 const REGISTRY_CANISTER_WASM: &[u8] = include_bytes!(env!("REGISTRY_CANISTER_WASM_PATH"));
 const CYCLES_MINTING_CANISTER_WASM: &[u8] =
@@ -895,7 +897,28 @@ impl PocketIcSubnets {
         let mut subnet_chain_keys = vec![];
         if subnet_kind == SubnetKind::II || subnet_kind == SubnetKind::Fiduciary {
             for algorithm in [SchnorrAlgorithm::Bip340Secp256k1, SchnorrAlgorithm::Ed25519] {
-                for name in ["key_1", "test_key_1", "dfx_test_key"] {
+                let key_id = SchnorrKeyId {
+                    algorithm,
+                    name: "key_1".to_string(),
+                };
+                subnet_chain_keys.push(MasterPublicKeyId::Schnorr(key_id));
+            }
+
+            let key_id = EcdsaKeyId {
+                curve: EcdsaCurve::Secp256k1,
+                name: "key_1".to_string(),
+            };
+            subnet_chain_keys.push(MasterPublicKeyId::Ecdsa(key_id));
+
+            let key_id = VetKdKeyId {
+                curve: VetKdCurve::Bls12_381_G2,
+                name: "key_1".to_string(),
+            };
+            subnet_chain_keys.push(MasterPublicKeyId::VetKd(key_id));
+        }
+        if subnet_kind == SubnetKind::TestThresholdKeys {
+            for algorithm in [SchnorrAlgorithm::Bip340Secp256k1, SchnorrAlgorithm::Ed25519] {
+                for name in ["test_key_1", "dfx_test_key"] {
                     let key_id = SchnorrKeyId {
                         algorithm,
                         name: name.to_string(),
@@ -904,7 +927,7 @@ impl PocketIcSubnets {
                 }
             }
 
-            for name in ["key_1", "test_key_1", "dfx_test_key"] {
+            for name in ["test_key_1", "dfx_test_key"] {
                 let key_id = EcdsaKeyId {
                     curve: EcdsaCurve::Secp256k1,
                     name: name.to_string(),
@@ -912,7 +935,7 @@ impl PocketIcSubnets {
                 subnet_chain_keys.push(MasterPublicKeyId::Ecdsa(key_id));
             }
 
-            for name in ["key_1", "test_key_1", "dfx_test_key"] {
+            for name in ["test_key_1", "dfx_test_key"] {
                 let key_id = VetKdKeyId {
                     curve: VetKdCurve::Bls12_381_G2,
                     name: name.to_string(),
@@ -3218,7 +3241,7 @@ impl HasStateLabel for PocketIc {
 fn conv_type(inp: rest::SubnetKind) -> SubnetType {
     use rest::SubnetKind::*;
     match inp {
-        Application | Fiduciary | SNS => SubnetType::Application,
+        Application | Fiduciary | SNS | TestThresholdKeys => SubnetType::Application,
         CloudEngine => SubnetType::CloudEngine,
         Bitcoin | II | NNS | System => SubnetType::System,
         VerifiedApplication => SubnetType::VerifiedApplication,
@@ -3231,6 +3254,7 @@ fn subnet_size(subnet: SubnetKind) -> u64 {
         Application => 13,
         CloudEngine => 13,
         VerifiedApplication => 13,
+        TestThresholdKeys => 13,
         Fiduciary => 34,
         SNS => 34,
         Bitcoin => 13,
@@ -3264,6 +3288,11 @@ fn subnet_kind_subnet_id(subnet_kind: SubnetKind) -> Option<SubnetId> {
                 .into(),
         ),
         SNS => Some(PrincipalId::from_str(MAINNET_SNS_SUBNET_ID).unwrap().into()),
+        TestThresholdKeys => Some(
+            PrincipalId::from_str(MAINNET_TEST_THRESHOLD_KEYS_SUBNET_ID)
+                .unwrap()
+                .into(),
+        ),
     }
 }
 

--- a/rs/pocket_ic_server/tests/bitcoin_integration_tests.rs
+++ b/rs/pocket_ic_server/tests/bitcoin_integration_tests.rs
@@ -66,7 +66,7 @@ fn bitcoin_integration_test() {
     };
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_test_threshold_keys_subnet() // to have tECDSA keys with test_ prefix available
+        .with_test_threshold_keys_subnet() // to have tECDSA keys `test_key_1` and `dfx_test_key` available
         .with_bitcoin_subnet()
         .with_application_subnet() // to deploy the test dapp
         .with_bitcoind_addr(bitcoind.p2p_socket().unwrap().into())

--- a/rs/pocket_ic_server/tests/bitcoin_integration_tests.rs
+++ b/rs/pocket_ic_server/tests/bitcoin_integration_tests.rs
@@ -66,7 +66,7 @@ fn bitcoin_integration_test() {
     };
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_ii_subnet() // to have tECDSA keys available
+        .with_test_threshold_keys_subnet() // to have tECDSA keys with test_ prefix available
         .with_bitcoin_subnet()
         .with_application_subnet() // to deploy the test dapp
         .with_bitcoind_addr(bitcoind.p2p_socket().unwrap().into())

--- a/rs/pocket_ic_server/tests/dogecoin_integration_tests.rs
+++ b/rs/pocket_ic_server/tests/dogecoin_integration_tests.rs
@@ -66,7 +66,7 @@ fn dogecoin_integration_test() {
     };
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_test_threshold_keys_subnet() // to have tECDSA keys with test_ prefix available
+        .with_test_threshold_keys_subnet() // to have tECDSA keys `test_key_1` and `dfx_test_key` available
         .with_bitcoin_subnet()
         .with_application_subnet() // to deploy the test dapp
         .with_dogecoind_addrs(vec![dogecoind.p2p_socket().unwrap().into()])

--- a/rs/pocket_ic_server/tests/dogecoin_integration_tests.rs
+++ b/rs/pocket_ic_server/tests/dogecoin_integration_tests.rs
@@ -66,7 +66,7 @@ fn dogecoin_integration_test() {
     };
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()
-        .with_ii_subnet() // to have tECDSA keys available
+        .with_test_threshold_keys_subnet() // to have tECDSA keys with test_ prefix available
         .with_bitcoin_subnet()
         .with_application_subnet() // to deploy the test dapp
         .with_dogecoind_addrs(vec![dogecoind.p2p_socket().unwrap().into()])


### PR DESCRIPTION
This PR introduces a new (application) subnet kind holding test threshold keys so that their signing fees are 10B cycles just like in production.

In more detail, this PR performs the following changes:
- it introduces a `SubnetKind::TestThresholdKeys`: matching the mainnet subnet `fuqsr-in2lc-zbcjj-ydmcw-pzq7h-4xm2z-pto4i-dcyee-5z4rz-x63ji-nae`;
- the new subnet kind exclusively holds threshold keys with names `test_key_1` and `dfx_test_key` for all supported algorithms (ECDSA, Schnorr, VetKd);
- the II and fiduciary subnets now only hold threshold keys with the name `key_1` for all algorithms;
- adds `test_threshold_keys` field to `SubnetConfigSet` and `ExtendedSubnetConfigSet`;
- introduces `PocketIcBuilder::with_test_threshold_keys_subnet()`;
- updates tests to use the appropriate cycle amounts per key (`26_153_846_153` for `key_1` and `10_000_000_000` for `test_key_1`/`dfx_test_key`);
- adds a test that the system API `ic0.cost_sign_with_ecdsa`, `ic0.cost_sign_with_schnorr`, and `ic0.cost_vetkd_derive_key` return the appropriate cycle amounts per key (`26_153_846_153` for `key_1` and `10_000_000_000` for `test_key_1`/`dfx_test_key`).