### PR TITLE
feat: support non-SEV bare metal in baremetal_app_subnet testnet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -246,7 +246,7 @@ go.sum                    @dfinity/idx
 /rs/tests/testnets/mainnet_nns/                         @dfinity/consensus
 /rs/tests/testnets/mainnet_nns.rs                       @dfinity/consensus
 /rs/tests/testnets/nns_recovery.rs                      @dfinity/consensus
-/rs/tests/testnets/baremetal_app_subnet.rs          @dfinity/idx @dfinity/node
+/rs/tests/testnets/baremetal_app_subnet.rs              @dfinity/idx @dfinity/node
 /rs/tests/driver/src/driver/simulate_network.rs         @dfinity/consensus @dfinity/idx
 /rs/tests/boundary_nodes/                               @dfinity/node
 /rs/tests/ckbtc/                                        @dfinity/defi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -246,7 +246,7 @@ go.sum                    @dfinity/idx
 /rs/tests/testnets/mainnet_nns/                         @dfinity/consensus
 /rs/tests/testnets/mainnet_nns.rs                       @dfinity/consensus
 /rs/tests/testnets/nns_recovery.rs                      @dfinity/consensus
-/rs/tests/testnets/sev_baremetal_app_subnet.rs          @dfinity/idx @dfinity/node
+/rs/tests/testnets/baremetal_app_subnet.rs          @dfinity/idx @dfinity/node
 /rs/tests/driver/src/driver/simulate_network.rs         @dfinity/consensus @dfinity/idx
 /rs/tests/boundary_nodes/                               @dfinity/node
 /rs/tests/ckbtc/                                        @dfinity/defi

--- a/rs/tests/nested/src/lib.rs
+++ b/rs/tests/nested/src/lib.rs
@@ -57,14 +57,23 @@ pub fn create_bare_metal_session(env: &TestEnv) -> BareMetalIpmiSession {
     bare_metal
 }
 
-/// Creates a `NestedNodes` with a single bare metal TEE node.
-pub fn create_bare_metal_tee_node(bare_metal: &BareMetalIpmiSession) -> NestedNode {
+/// Creates a bare-metal nested node. Set `enable_trusted_execution_environment` when the host
+/// runs AMD SEV-SNP (same meaning as the `TRUSTED_EXECUTION_ENVIRONMENT` env var in `setup()`).
+pub fn create_bare_metal_node(
+    bare_metal: &BareMetalIpmiSession,
+    enable_trusted_execution_environment: bool,
+) -> NestedNode {
     NestedNode::new_bare_metal(
         HOST_VM_NAME.to_string(),
         bare_metal.hostos_address(),
         bare_metal.mgmt_mac(),
-        /*enable_trusted_execution_environment=*/ true,
+        enable_trusted_execution_environment,
     )
+}
+
+/// Creates a `NestedNodes` with a single bare metal TEE (SEV-SNP) node.
+pub fn create_bare_metal_tee_node(bare_metal: &BareMetalIpmiSession) -> NestedNode {
+    create_bare_metal_node(bare_metal, true)
 }
 
 pub fn get_bare_metal_login_info() -> LoginInfo {

--- a/rs/tests/testnets/BUILD.bazel
+++ b/rs/tests/testnets/BUILD.bazel
@@ -298,10 +298,13 @@ system_test_nns(
 )
 
 system_test_nns(
-    name = "sev_baremetal_app_subnet",
+    name = "baremetal_app_subnet",
     enable_metrics = True,
-    env = MAINNET_ENV | {"TRUSTED_EXECUTION_ENVIRONMENT": "true"},
-    env_inherit = ["BARE_METAL_HOST_SECRETS"],
+    env = MAINNET_ENV,
+    env_inherit = [
+        "BARE_METAL_HOST_SECRETS",
+        "TRUSTED_EXECUTION_ENVIRONMENT",
+    ],
     guestos = True,
     hostos = True,
     tags = [

--- a/rs/tests/testnets/Cargo.toml
+++ b/rs/tests/testnets/Cargo.toml
@@ -93,8 +93,8 @@ name = "small_with_query_stats"
 path = "small_with_query_stats.rs"
 
 [[bin]]
-name = "sev_baremetal_app_subnet"
-path = "sev_baremetal_app_subnet.rs"
+name = "baremetal_app_subnet"
+path = "baremetal_app_subnet.rs"
 
 [[bin]]
 name = "nns_recovery"

--- a/rs/tests/testnets/baremetal_app_subnet.rs
+++ b/rs/tests/testnets/baremetal_app_subnet.rs
@@ -10,20 +10,13 @@
 //   - `BARE_METAL_HOST_SECRETS` must name an INI file with bare-metal login info
 //     (same as `//rs/tests/nested:sev_recovery`). Without it, setup fails.
 //
-// Setup example (either export in your shell or pass `--test_env` so the driver sees it):
-//
-//   SEV-SNP host:
-//   $ export BARE_METAL_HOST_SECRETS="$(realpath /path/to/host.ini)"
-//   $ export TRUSTED_EXECUTION_ENVIRONMENT=true
-//
-//   Non-SEV bare metal:
-//   $ export BARE_METAL_HOST_SECRETS="$(realpath /path/to/host.ini)"
+// Setup example (pass `--test_env` so the driver sees it):
 //
 //   $ ./ci/container/container-run.sh
 //   $ ict testnet create baremetal_app_subnet --verbose --output-dir=./test_tmpdir -- \
 //       --test_tmpdir=./test_tmpdir \
 //       --test_env BARE_METAL_HOST_SECRETS="$(realpath /path/to/host.ini)" \
-//       --test_env TRUSTED_EXECUTION_ENVIRONMENT=true   # omit for non-SEV
+//       --test_env TRUSTED_EXECUTION_ENVIRONMENT=true   # false for non-SEV
 //
 // The bare-metal guest IPv6 appears in the driver log after registration; SSH uses the
 // same admin key layout as other testnets under `test_tmpdir`.

--- a/rs/tests/testnets/baremetal_app_subnet.rs
+++ b/rs/tests/testnets/baremetal_app_subnet.rs
@@ -22,8 +22,8 @@
 //   $ ./ci/container/container-run.sh
 //   $ ict testnet create baremetal_app_subnet --verbose --output-dir=./test_tmpdir -- \
 //       --test_tmpdir=./test_tmpdir \
-//       --test_env=BARE_METAL_HOST_SECRETS="$(realpath /path/to/host.ini)" \
-//       --test_env=TRUSTED_EXECUTION_ENVIRONMENT=true   # omit for non-SEV
+//       --test_env BARE_METAL_HOST_SECRETS="$(realpath /path/to/host.ini)" \
+//       --test_env TRUSTED_EXECUTION_ENVIRONMENT=true   # omit for non-SEV
 //
 // The bare-metal guest IPv6 appears in the driver log after registration; SSH uses the
 // same admin key layout as other testnets under `test_tmpdir`.

--- a/rs/tests/testnets/baremetal_app_subnet.rs
+++ b/rs/tests/testnets/baremetal_app_subnet.rs
@@ -43,8 +43,7 @@ use ic_system_test_driver::nns::{
 };
 use ic_system_test_driver::util::{block_on, runtime_from_url};
 use nested::{
-    create_bare_metal_node, create_bare_metal_session, registration,
-    util::setup_ic_infrastructure,
+    create_bare_metal_node, create_bare_metal_session, registration, util::setup_ic_infrastructure,
 };
 use nns_dapp::set_authorized_subnets;
 use slog::info;
@@ -73,8 +72,7 @@ fn setup(env: TestEnv) {
     let enable_tee = std::env::var_os("TRUSTED_EXECUTION_ENVIRONMENT").is_some();
     info!(
         logger,
-        "Bare-metal nested node: trusted_execution_environment (SEV-SNP path) = {}",
-        enable_tee
+        "Bare-metal nested node: trusted_execution_environment (SEV-SNP path) = {}", enable_tee
     );
 
     let bare_metal = create_bare_metal_session(&env);

--- a/rs/tests/testnets/baremetal_app_subnet.rs
+++ b/rs/tests/testnets/baremetal_app_subnet.rs
@@ -1,6 +1,10 @@
-// Interactive testnet: NNS on Farm, one AMD SEV-SNP bare-metal machine (via IPMI like
-// `sev_recovery.rs`) that joins the registry, then a CreateSubnet proposal places that
-// node alone on a new Application subnet.
+// Interactive testnet: NNS on Farm, one bare-metal machine (via IPMI like `sev_recovery.rs`)
+// that joins the registry, then a CreateSubnet proposal places that node alone on a new
+// Application subnet.
+//
+// The host may be AMD SEV-SNP-capable or not. When `TRUSTED_EXECUTION_ENVIRONMENT` is set in the
+// environment (any value), SetupOS is built with the trusted execution path enabled, as in
+// `nested::setup`. Omit it for bare metal without SEV-SNP.
 //
 // Prerequisites:
 //   - `BARE_METAL_HOST_SECRETS` must name an INI file with bare-metal login info
@@ -8,11 +12,18 @@
 //
 // Setup example (either export in your shell or pass `--test_env` so the driver sees it):
 //
+//   SEV-SNP host:
 //   $ export BARE_METAL_HOST_SECRETS="$(realpath /path/to/host.ini)"
+//   $ export TRUSTED_EXECUTION_ENVIRONMENT=true
+//
+//   Non-SEV bare metal:
+//   $ export BARE_METAL_HOST_SECRETS="$(realpath /path/to/host.ini)"
+//
 //   $ ./ci/container/container-run.sh
-//   $ ict testnet create sev_baremetal_app_subnet --verbose --output-dir=./test_tmpdir -- \
+//   $ ict testnet create baremetal_app_subnet --verbose --output-dir=./test_tmpdir -- \
 //       --test_tmpdir=./test_tmpdir \
-//       --test_env=BARE_METAL_HOST_SECRETS="$(realpath /path/to/host.ini)"
+//       --test_env=BARE_METAL_HOST_SECRETS="$(realpath /path/to/host.ini)" \
+//       --test_env=TRUSTED_EXECUTION_ENVIRONMENT=true   # omit for non-SEV
 //
 // The bare-metal guest IPv6 appears in the driver log after registration; SSH uses the
 // same admin key layout as other testnets under `test_tmpdir`.
@@ -32,7 +43,7 @@ use ic_system_test_driver::nns::{
 };
 use ic_system_test_driver::util::{block_on, runtime_from_url};
 use nested::{
-    create_bare_metal_session, create_bare_metal_tee_node, registration,
+    create_bare_metal_node, create_bare_metal_session, registration,
     util::setup_ic_infrastructure,
 };
 use nns_dapp::set_authorized_subnets;
@@ -59,9 +70,16 @@ fn setup(env: TestEnv) {
 
     setup_ic_infrastructure(&env, /* dkg_interval */ None, /* is_fast */ true);
 
+    let enable_tee = std::env::var_os("TRUSTED_EXECUTION_ENVIRONMENT").is_some();
+    info!(
+        logger,
+        "Bare-metal nested node: trusted_execution_environment (SEV-SNP path) = {}",
+        enable_tee
+    );
+
     let bare_metal = create_bare_metal_session(&env);
     let mut nodes = NestedNodes {
-        nodes: vec![create_bare_metal_tee_node(&bare_metal)],
+        nodes: vec![create_bare_metal_node(&bare_metal, enable_tee)],
     };
     nodes
         .setup_and_start(&env)
@@ -135,8 +153,9 @@ fn setup(env: TestEnv) {
 
     info!(
         logger,
-        "SEV bare-metal application subnet is ready (subnet_id = {}, node_id = {})",
+        "Bare-metal application subnet is ready (subnet_id = {}, node_id = {}, tee = {})",
         app_subnets[0].subnet_id,
-        bare_metal_node_id
+        bare_metal_node_id,
+        enable_tee
     );
 }


### PR DESCRIPTION
### Summary
The interactive bare-metal application-subnet testnet is renamed to `baremetal_app_subnet` and no longer assumes AMD SEV-SNP. SetupOS / nested config uses the trusted-execution (TEE) path only when `TRUSTED_EXECUTION_ENVIRONMENT` is present in the environment, consistent with `nested::setup`.

### Changes
Testnet driver (`baremetal_app_subnet.rs`): Chooses create_bare_metal_node(..., enable_tee) from `TRUSTED_EXECUTION_ENVIRONMENT`; documents SEV vs non-SEV setup and ict examples.
Bazel (`BUILD.bazel`): Target renamed to baremetal_app_subnet; drops hard-coded TRUSTED_EXECUTION_ENVIRONMENT=true; inherits `BARE_METAL_HOST_SECRETS` and TRUSTED_EXECUTION_ENVIRONMENT from the caller environment when using `bazel test / --test_env`.
Nested helpers (`nested/src/lib.rs`): Adds create_bare_metal_node with an explicit enable_trusted_execution_environment flag; create_bare_metal_tee_node remains as a thin wrapper for existing callers (e.g. sev_recovery).
Cargo (`testnets/Cargo.toml`): Binary name aligned with the new testnet.
### How to run
SEV-SNP host: set `TRUSTED_EXECUTION_ENVIRONMENT` (e.g. true) in addition to `BARE_METAL_HOST_SECRETS`.
Non-SEV bare metal: set only `BARE_METAL_HOST_SECRETS`; ensure `TRUSTED_EXECUTION_ENVIRONMENT` is not inherited if your shell usually exports it.
### Breaking change
ict testnet create / Bazel target name changes from `sev_baremetal_app_subnet` to `baremetal_app_subnet`.
SEV runs no longer get TEE enabled by default from the BUILD file; you must pass or export TRUSTED_EXECUTION_ENVIRONMENT when you want the SEV-SNP path.