### PR TITLE
feat: CON-1707 Limit the number of `SetupInitialDkg` contexts in flight

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -201,6 +201,9 @@ pub const MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER: usize = 10;
 /// The worst case request latency used here should be equivalent to the request timeout in the adapter.
 pub const MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT: usize = 3000;
 
+/// Maximum number of setup initial DKG requests in-flight on a subnet.
+pub const MAX_SETUP_INITIAL_DKG_REQUESTS_IN_FLIGHT: usize = 20;
+
 /// The default value of `wasm_memory_limit` in the canister settings:
 /// - this value is used directly for newly created canisters.
 /// - existing canisters will get their field initialized as follows:
@@ -353,7 +356,11 @@ pub struct Config {
     /// Indicates whether dirty page logging is enabled or not.
     pub dirty_page_logging: FlagStatus,
 
+    /// The maximum number of canister HTTP requests in flight on a subnet.
     pub max_canister_http_requests_in_flight: usize,
+
+    /// The maximum number of setup initial DKG requests in flight on a subnet.
+    pub max_setup_initial_dkg_requests_in_flight: usize,
 
     /// The default value of `wasm_memory_limit` in the canister settings:
     /// - this value is used directly for newly created canisters.
@@ -461,6 +468,7 @@ impl Default for Config {
             stop_canister_timeout_duration: STOP_CANISTER_TIMEOUT_DURATION,
             dirty_page_logging: FlagStatus::Disabled,
             max_canister_http_requests_in_flight: MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT,
+            max_setup_initial_dkg_requests_in_flight: MAX_SETUP_INITIAL_DKG_REQUESTS_IN_FLIGHT,
             default_wasm_memory_limit: DEFAULT_WASM_MEMORY_LIMIT,
             max_number_of_snapshots_per_canister: MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER,
             environment_variables: FlagStatus::Enabled,

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -3400,6 +3400,21 @@ impl ExecutionEnvironment {
         state: &mut ReplicatedState,
         rng: &mut dyn RngCore,
     ) -> Result<(), UserError> {
+        if state
+            .metadata
+            .subnet_call_context_manager
+            .setup_initial_dkg_contexts
+            .len()
+            >= self.config.max_setup_initial_dkg_requests_in_flight
+        {
+            return Err(UserError::new(
+                ErrorCode::CanisterRejectedMessage,
+                format!(
+                    "max number ({}) of setup initial DKG requests in-flight reached.",
+                    self.config.max_setup_initial_dkg_requests_in_flight
+                ),
+            ));
+        }
         match SetupInitialDKGArgs::decode(payload) {
             Err(err) => Err(err),
             Ok(settings) => match settings.get_set_of_node_ids() {

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -2333,6 +2333,55 @@ fn setup_initial_dkg_sender_not_on_nns() {
 }
 
 #[test]
+fn setup_initial_dkg_bound_holds() {
+    let own_subnet = subnet_test_id(1);
+    let nns_subnet = subnet_test_id(2);
+    let nns_canister = canister_test_id(1);
+    let mut test = ExecutionTestBuilder::new()
+        .with_subnet_type(SubnetType::System)
+        .with_own_subnet_id(own_subnet)
+        .with_nns_subnet_id(nns_subnet)
+        .with_caller(nns_subnet, nns_canister)
+        .with_max_setup_initial_dkg_requests_in_flight(2)
+        .build();
+    let nodes = vec![node_test_id(1)];
+    let args = ic00::SetupInitialDKGArgs::new(nodes, RegistryVersion::new(1));
+    test.inject_call_to_ic00(
+        Method::SetupInitialDKG,
+        args.encode(),
+        test.canister_creation_fee().real(),
+    );
+    test.execute_all();
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .setup_initial_dkg_contexts
+            .len(),
+        1
+    );
+
+    for _ in 0..10 {
+        let args = ic00::SetupInitialDKGArgs::new(vec![node_test_id(1)], RegistryVersion::new(1));
+        test.inject_call_to_ic00(
+            Method::SetupInitialDKG,
+            args.encode(),
+            test.canister_creation_fee().real(),
+        );
+    }
+    test.execute_all();
+
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .setup_initial_dkg_contexts
+            .len(),
+        2
+    );
+}
+
+#[test]
 fn metrics_are_observed_for_subnet_messages() {
     let mut test = ExecutionTestBuilder::new().build();
     let methods: [ic00::Method; 5] = [

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2734,6 +2734,15 @@ impl ExecutionTestBuilder {
         self
     }
 
+    pub fn with_max_setup_initial_dkg_requests_in_flight(
+        mut self,
+        max_setup_initial_dkg_requests_in_flight: usize,
+    ) -> Self {
+        self.execution_config
+            .max_setup_initial_dkg_requests_in_flight = max_setup_initial_dkg_requests_in_flight;
+        self
+    }
+
     pub fn with_max_wasm_memory_size(mut self, wasm_memory_size: NumBytes) -> Self {
         self.execution_config.embedders_config.max_wasm_memory_size = wasm_memory_size;
         self


### PR DESCRIPTION
`SetupInitialDkg` is a management canister call used to generate the subnet's initial key material. It is typically called during subnet creation/recovery. 

In the future it will also be used to create cloud engines, which may not necessarily be gated behind the adoption of a governance proposal. For that reason, we should limit the number of open contexts, similar to other management canister calls handled by consensus.

This PR limits the number of open `SetupInitialDkg` to 20, although the exact number may change in the future.