### PR TITLE
test: Increase disk size of rejoin_test_large

### DIFF
--- a/rs/tests/message_routing/rejoin_test_large_state.rs
+++ b/rs/tests/message_routing/rejoin_test_large_state.rs
@@ -98,7 +98,7 @@ fn setup(env: TestEnv, config: Config) {
                 (24 + config.canister_size_gib * config.num_canisters as u64) * 1024 * 1024,
             )),
             boot_image_minimal_size_gibibytes: Some(ImageSizeGiB::new(
-                100 + 2 * config.canister_size_gib * config.num_canisters as u64,
+                300 + 6 * config.canister_size_gib * config.num_canisters as u64,
             )),
             ..VmResourceOverrides::default()
         })


### PR DESCRIPTION
This test is quite flaky. Since this might be related to the logic of growing the XFS partition if it is getting full, this PR attempts to solve the flakiness by growing the tests disk, and therefore also the file system's starting size.