### PR TITLE
fix(IDX): release workflow fixes

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,10 +10,10 @@ on:
   workflow_dispatch:
     inputs:
       tag-name:
-        description: 'The name of the tag to publish'
+        description: 'Tag Name'
         required: true
       dry-run:
-        description: "If true, run the workflow in dry-run mode (don't actually publish the release)"
+        description: "Run in dry-run mode (don't actually publish the release)"
         required: true
         default: 'true'
         type: boolean

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,6 @@ on:
         type: boolean
 
 env:
-  CI_COMMIT_SHA: ${{ github.event.inputs.tag-name || github.sha }}
   RELEASE_TAG: ${{ github.event.inputs.tag-name || github.ref_name }}
 
 jobs:
@@ -30,12 +29,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ env.CI_COMMIT_SHA }}
+          ref: ${{ github.event.inputs.tag-name || github.ref }}
 
       - name: Collect Release Artifacts
         run: |
           set -euxo pipefail
 
+          CI_COMMIT_SHA=$(git rev-parse HEAD)
           DOWNLOAD_PREFIX="https://download.dfinity.systems/ic/${CI_COMMIT_SHA}"
 
           curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/setup-os/disk-img/disk-img.tar.zst" -o setup-os-img.tar.zst

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -54,7 +54,6 @@ jobs:
           echo "DOWNLOAD_PREFIX=${DOWNLOAD_PREFIX}" >> "$GITHUB_ENV"
 
       - name: Collect Canister Artifacts
-        if: ${{ github.event_name == 'push' || github.event.inputs.dry-run == 'false' }}
         run: |
           set -euxo pipefail
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -50,6 +50,7 @@ jobs:
           echo "DOWNLOAD_PREFIX=${DOWNLOAD_PREFIX}" >> "$GITHUB_ENV"
 
       - name: Collect Canister Artifacts
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry-run == 'false' }}
         run: |
           set -euxo pipefail
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,6 +18,10 @@ on:
         default: 'true'
         type: boolean
 
+env:
+  CI_COMMIT_SHA: ${{ github.event.inputs.tag-name || github.sha }}
+  RELEASE_TAG: ${{ github.event.inputs.tag-name || github.ref_name }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,13 +30,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.inputs.tag-name || github.ref }}
+          ref: ${{ env.CI_COMMIT_SHA }}
 
       - name: Collect Release Artifacts
         run: |
           set -euxo pipefail
 
-          DOWNLOAD_PREFIX="https://download.dfinity.systems/ic/$GITHUB_SHA"
+          DOWNLOAD_PREFIX="https://download.dfinity.systems/ic/${CI_COMMIT_SHA}"
 
           curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/setup-os/disk-img/disk-img.tar.zst" -o setup-os-img.tar.zst
           curl -sfSL --retry 3 "${DOWNLOAD_PREFIX}/guest-os/update-img/update-img.tar.zst" -o update-os-img.tar.zst
@@ -92,7 +96,7 @@ jobs:
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         if: ${{ github.event_name == 'push' || github.event.inputs.dry-run == 'false' }}
         with:
-          body: "IC ${{github.ref_name}}"
+          body: "IC ${{ env.RELEASE_TAG }}"
           files: |
             canisters.tar
             setup-os-img.tar.gz


### PR DESCRIPTION
After testing, this fixes some small issues with the updates I made to the release workflow.

A nice benefit of these changes is that we can now publish releases for any tags - if for instance we realize later that binaries were missing and we don't want to re-run the entire release-testing workflow.