### PR TITLE
chore: Deprecate `pseudo_random_id` in signature request context

### DIFF
--- a/rs/consensus/chain_key/src/test_utils.rs
+++ b/rs/consensus/chain_key/src/test_utils.rs
@@ -139,7 +139,7 @@ pub(super) fn fake_signature_request_context(
         ),
         derivation_path: Arc::new(vec![vec![]]),
         batch_time: UNIX_EPOCH,
-        pseudo_random_id: [0; 32],
+        deprecated_pseudo_random_id: Some([0; 32]),
         nonce,
     }
 }

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -3659,15 +3659,15 @@ impl ExecutionEnvironment {
             ));
         }
 
-        let mut pseudo_random_id = [0_u8; 32];
-        rng.fill_bytes(&mut pseudo_random_id);
+        let mut deprecated_pseudo_random_id = [0_u8; 32];
+        rng.fill_bytes(&mut deprecated_pseudo_random_id);
 
         state.metadata.subnet_call_context_manager.push_context(
             SubnetCallContext::SignWithThreshold(SignWithThresholdContext {
                 request,
                 args,
                 derivation_path: Arc::new(derivation_path),
-                pseudo_random_id,
+                deprecated_pseudo_random_id: Some(deprecated_pseudo_random_id),
                 batch_time: state.metadata.batch_time,
                 nonce: None,
             }),

--- a/rs/execution_environment/src/scheduler/threshold_signatures.rs
+++ b/rs/execution_environment/src/scheduler/threshold_signatures.rs
@@ -268,7 +268,7 @@ mod tests {
         let context = SignWithThresholdContext {
             request: RequestBuilder::new().build(),
             args,
-            pseudo_random_id: [id as u8; 32],
+            deprecated_pseudo_random_id: Some([id as u8; 32]),
             derivation_path: Arc::new(vec![]),
             batch_time: UNIX_EPOCH,
             nonce: None,

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -112,7 +112,7 @@ message SignWithThresholdContext {
   state.queues.v1.Request request = 1;
   ThresholdArguments args = 2;
   repeated bytes derivation_path_vec = 3;
-  bytes pseudo_random_id = 4;
+  bytes deprecated_pseudo_random_id = 4;
   uint64 batch_time = 5;
   optional bytes nonce = 8;
 }

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -163,7 +163,7 @@ pub struct SignWithThresholdContext {
     #[prost(bytes = "vec", repeated, tag = "3")]
     pub derivation_path_vec: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
     #[prost(bytes = "vec", tag = "4")]
-    pub pseudo_random_id: ::prost::alloc::vec::Vec<u8>,
+    pub deprecated_pseudo_random_id: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag = "5")]
     pub batch_time: u64,
     #[prost(bytes = "vec", optional, tag = "8")]

--- a/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
@@ -288,7 +288,7 @@ impl SubnetCallContextManager {
                         info!(
                             logger,
                             "Received the response for SignWithThreshold request with id {:?} from {:?}",
-                            context.pseudo_random_id,
+                            callback_id,
                             context.request.sender
                         );
                         SubnetCallContext::SignWithThreshold(context)
@@ -549,7 +549,7 @@ pub struct SignWithThresholdContext {
     pub request: Request,
     pub args: ThresholdArguments,
     pub derivation_path: Arc<Vec<Vec<u8>>>,
-    pub pseudo_random_id: [u8; PSEUDO_RANDOM_ID_SIZE],
+    pub deprecated_pseudo_random_id: Option<[u8; PSEUDO_RANDOM_ID_SIZE]>,
     pub batch_time: Time,
     pub nonce: Option<[u8; NONCE_SIZE]>,
 }

--- a/rs/replicated_state/src/metadata_state/subnet_call_context_manager/proto.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_call_context_manager/proto.rs
@@ -535,7 +535,10 @@ impl From<&SignWithThresholdContext> for pb_metadata::SignWithThresholdContext {
             request: Some((&context.request).into()),
             args: Some((&context.args).into()),
             derivation_path_vec: context.derivation_path.to_vec(),
-            pseudo_random_id: context.pseudo_random_id.to_vec(),
+            deprecated_pseudo_random_id: context
+                .deprecated_pseudo_random_id
+                .map(|id| id.to_vec())
+                .unwrap_or_default(),
             batch_time: context.batch_time.as_nanos_since_unix_epoch(),
             nonce: context.nonce.map(|n| n.to_vec()),
         }
@@ -553,7 +556,10 @@ impl TryFrom<pb_metadata::SignWithThresholdContext> for SignWithThresholdContext
             request,
             args,
             derivation_path: Arc::new(context.derivation_path_vec),
-            pseudo_random_id: try_into_array_pseudo_random_id(context.pseudo_random_id)?,
+            deprecated_pseudo_random_id: try_into_array_pseudo_random_id(
+                context.deprecated_pseudo_random_id,
+            )
+            .ok(),
             batch_time: Time::from_nanos_since_unix_epoch(context.batch_time),
             nonce: context.nonce.map(try_into_array_nonce).transpose()?,
         })

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -1141,7 +1141,7 @@ fn sign_with_threshold_context_roundtrip() {
                     request: RequestBuilder::new().build(),
                     args,
                     derivation_path: Arc::new(vec![]),
-                    pseudo_random_id: [1; 32],
+                    deprecated_pseudo_random_id: Some([1; 32]),
                     batch_time: UNIX_EPOCH,
                     nonce: Some([3; 32]),
                 },

--- a/rs/test_utilities/consensus/src/idkg.rs
+++ b/rs/test_utilities/consensus/src/idkg.rs
@@ -234,7 +234,7 @@ pub fn fake_signature_request_args(
 
 pub fn fake_signature_request_context(
     key_id: MasterPublicKeyId,
-    pseudo_random_id: [u8; 32],
+    deprecated_pseudo_random_id: [u8; 32],
 ) -> SignWithThresholdContext {
     let rv = RegistryVersion::from(10);
     SignWithThresholdContext {
@@ -242,7 +242,7 @@ pub fn fake_signature_request_context(
         args: fake_signature_request_args(key_id, Height::from(0), None, rv),
         derivation_path: Arc::new(vec![]),
         batch_time: UNIX_EPOCH,
-        pseudo_random_id,
+        deprecated_pseudo_random_id: Some(deprecated_pseudo_random_id),
         nonce: None,
     }
 }
@@ -259,7 +259,7 @@ pub fn fake_signature_request_context_with_pre_sig(
         args: fake_signature_request_args(key_id.into(), height, pre_signature, rv),
         derivation_path: Arc::new(vec![]),
         batch_time: UNIX_EPOCH,
-        pseudo_random_id: [request_id.callback_id.get() as u8; 32],
+        deprecated_pseudo_random_id: Some([request_id.callback_id.get() as u8; 32]),
         nonce: None,
     };
     (request_id.callback_id, context)
@@ -277,7 +277,7 @@ pub fn fake_signature_request_context_from_id(
         args: fake_signature_request_args(key_id, height, Some(pre_sig_id), rv),
         derivation_path: Arc::new(vec![vec![]]),
         batch_time: UNIX_EPOCH,
-        pseudo_random_id: [request_id.callback_id.get() as u8; 32],
+        deprecated_pseudo_random_id: Some([request_id.callback_id.get() as u8; 32]),
         nonce: Some([0; 32]),
     };
     (request_id.callback_id, context)
@@ -333,7 +333,7 @@ pub fn fake_signature_request_context_with_registry_version(
         args: fake_signature_request_args(key_id.clone(), height, pre_sig_id, rv),
         derivation_path: Arc::new(vec![]),
         batch_time: UNIX_EPOCH,
-        pseudo_random_id: [1; 32],
+        deprecated_pseudo_random_id: Some([1; 32]),
         nonce: Some([0; 32]),
     }
 }


### PR DESCRIPTION
The `pseudo_random_id` field is no longer in use. This PR begins the process of removing it from the context struct which is stored in the replicated state.

In particular, this PR renames the field to `deprecated_pseudo_random_id` and changes its type to be `Option<_>`.  The deserialization function is adapted to accept contexts with empty `deprecated_pseudo_random_id`. 

For now the field is still set to `Some(_)` value everywhere. Once the change of this PR is rolled out to all subnets, we can then set `deprecated_pseudo_random_id` to `None` instead.

The field may then be removed entirely in the third step.