### PR TITLE
chore: log when expand_lv finished

### DIFF
--- a/ic-os/components/upgrade/shared-resources/monitor-expand-shared-data/monitor-expand-shared-data.py
+++ b/ic-os/components/upgrade/shared-resources/monitor-expand-shared-data/monitor-expand-shared-data.py
@@ -115,6 +115,9 @@ def expand_lv(device_name, lv_name, mount_point, fs_free, required_avail, expand
     # leave the XFS filesystem larger than the underlying logical volume.
     subprocess.run(["sync"], check=True)
 
+    sys.stderr.write("Expanded %s by %d MiB\n" % (device_name, expand_size))
+    sys.stderr.flush()
+
 
 def main():
     # Total VG and LV sizes change only if we call lvextend below.


### PR DESCRIPTION
There's the hypothesis that the test `//rs/tests/message_routing:rejoin_test_large_state` is flaky because when the node is killed while it's executing `xfs_growfs` it leads to XFS corruption. 

On the last [flaky run](https://dash.zh1-idx1.dfinity.network/invocation/7784dc1d-467d-4315-9419-615de07663df?target=//rs/tests/message_routing:rejoin_test_large_state#@608) we indeed saw `expand_lv` starting before the node was killed at 04:31:09:
```
2026-04-13 04:29:34.505098 Free space on /dev/store/shared-data is 5009 MiB -- below 9184 MiB, expanding by 4592 MiB
```

However, we can't say for sure that `expand_lv` finished before the kill. So this PR adds a log message such that we know if it finishes.

Note that due to https://github.com/dfinity/ic/pull/9823 the node will probably not run `expand_lv` anymore in the test. But it would be good to have this log message in any case.