### PR TITLE
chore: warn about failed delete instance request

### DIFF
--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1666,11 +1666,9 @@ impl PocketIc {
 
     pub(crate) async fn do_drop(&mut self) {
         if self.owns_instance {
-            self.reqwest_client
-                .delete(self.instance_url())
-                .send()
-                .await
-                .expect("Failed to send delete request");
+            if let Err(err) = self.reqwest_client.delete(self.instance_url()).send().await {
+                warn!("Failed to send delete request: {err:?}");
+            }
         } else {
             self.stop_http_gateway().await;
         }

--- a/rs/pocket_ic_server/tests/common.rs
+++ b/rs/pocket_ic_server/tests/common.rs
@@ -89,11 +89,9 @@ pub fn send_signal_to_pic(pic: PocketIc, mut child: Child, shutdown_signal: Opti
         .unwrap();
         let status = child.wait().unwrap();
         assert!(status.success());
-        // the PocketIC instance can't be deleted and thus dropping the PocketIC instance panics
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            drop(pic);
-        }))
-        .unwrap_err();
+        // The PocketIC instance can't be deleted on the server,
+        // but dropping the PocketIC instance is still safe.
+        drop(pic);
     } else {
         // Delete the PocketIC instance.
         drop(pic);


### PR DESCRIPTION
This PR replaces a panic upon a failed HTTP request to delete a PocketIC instance by a warning about the error. The motivation for this change is to prevent crashes if heavy work is done after interacting with PocketIC:
```
use pocket_ic::PocketIc;
use std::thread::sleep;
use std::time::Duration;

fn main() {
    let _pic = PocketIc::new();

    sleep(Duration::from_secs(70));

    println!("Exiting!");
}
```
This change is safe since deleting an instance is only relevant for resource management and thus it is fine to not delete an instance.