### PR TITLE
chore: Update exhaustive test to generate empty `signature_agreements`

### DIFF
--- a/rs/types/types/src/exhaustive.rs
+++ b/rs/types/types/src/exhaustive.rs
@@ -903,7 +903,6 @@ impl ExhaustiveSet for QuadrupleInCreation {
 #[derive(Clone)]
 #[cfg_attr(test, derive(ExhaustiveSet))]
 pub struct DerivedIDkgPayload {
-    pub signature_agreements: BTreeMap<PseudoRandomId, CompletedSignature>,
     pub available_pre_signatures: BTreeMap<PreSigId, PreSignatureRef>,
     pub pre_signatures_in_creation: BTreeMap<PreSigId, PreSignatureInCreation>,
     pub uid_generator: IDkgUIDGenerator,
@@ -918,7 +917,7 @@ impl ExhaustiveSet for IDkgPayload {
         DerivedIDkgPayload::exhaustive_set(rng)
             .into_iter()
             .map(|payload| IDkgPayload {
-                signature_agreements: payload.signature_agreements,
+                signature_agreements: BTreeMap::new(),
                 available_pre_signatures: payload.available_pre_signatures,
                 pre_signatures_in_creation: payload.pre_signatures_in_creation,
                 uid_generator: payload.uid_generator,


### PR DESCRIPTION
After https://github.com/dfinity/ic/pull/9481, the `signature_agreements` field no longer holds any data (signatures are included in the `ChainKeyPayload` instead). Also see the following metrics: [1](https://victoria.ch1-obs1.dfinity.network/select/0/vmui/#/?g0.range_input=7d&g0.end_input=2026-04-13T12%3A02%3A50&g0.relative_time=last_7_days&g0.tab=0&g0.tenantID=0&g0.expr=idkg_payload_metrics%7Btype%3D%22signature_agreements%22%7D+%3E+0), [2](https://victoria.ch1-obs1.dfinity.network/select/0/vmui/#/?g0.range_input=7d&g0.end_input=2026-04-13T12%3A04%3A45&g0.relative_time=last_7_days&g0.tab=0&g0.tenantID=0&g0.expr=consensus_threshold_signature_agreements+%3E+0).

This PR updates the exhaustive test suite to stop generating payloads with non-empty `signature_agreements` (therefore correctly describing the production behavior). This is required in order to remove the field in the future.