### PR TITLE
fix: deflake //rs/tests/networking:network_large_test

### DIFF
--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -18,7 +18,7 @@ use futures::{
 use ic_agent::{
     Agent, AgentError, Identity, Signature,
     agent::{
-        CallResponse, EnvelopeContent, RejectCode, RejectResponse,
+        AgentBuilder, CallResponse, EnvelopeContent, RejectCode, RejectResponse,
         http_transport::reqwest_transport::reqwest,
     },
     agent_error::TransportError,
@@ -968,13 +968,27 @@ pub async fn agent_with_client_identity(
     client: reqwest::Client,
     identity: impl Identity + 'static,
 ) -> Result<Agent, AgentError> {
-    let a = Agent::builder()
+    let a = agent_builder(url, client, identity).build().unwrap();
+    a.fetch_root_key().await?;
+    Ok(a)
+}
+
+/// Returns an [`AgentBuilder`] pre-configured with the standard IC system test
+/// settings (HTTP client, identity, max concurrent requests, polling time, and
+/// ingress expiry). Callers can override any setting by chaining additional
+/// builder methods before `.build()`.
+pub fn agent_builder(
+    url: &str,
+    client: reqwest::Client,
+    identity: impl Identity + 'static,
+) -> AgentBuilder {
+    Agent::builder()
         .with_url(url)
         .with_http_client(client)
         .with_identity(identity)
+        .with_max_concurrent_requests(MAX_CONCURRENT_REQUESTS)
         // Setting a large polling time for the sake of long-running update calls.
         .with_max_polling_time(Duration::from_secs(600))
-        .with_max_concurrent_requests(MAX_CONCURRENT_REQUESTS)
         // Ingresses are created with the system time but are checked against the consensus time.
         // Consensus time is the time that is in the last finalized block. Consensus time might lag
         // behind, for example when the subnet has many modes and the progress of consensus is
@@ -988,10 +1002,6 @@ pub async fn agent_with_client_identity(
         // the delays in the progress of consensus, we reduce 30sn from MAX_INGRESS_TTL and set the
         // expiry_time of ingresses accordingly.
         .with_ingress_expiry(MAX_INGRESS_TTL - std::time::Duration::from_secs(30))
-        .build()
-        .unwrap();
-    a.fetch_root_key().await?;
-    Ok(a)
 }
 
 // Creates an identity to be used with `Agent`.

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -331,6 +331,7 @@ system_test_nns(
     deps = COMMON_DEPS + [
         "//rs/tests/consensus/utils",
         "//rs/types/types",
+        "@crate_index//:ic-agent",
         "@crate_index//:tokio",
         "@crate_index//:tokio-util",
     ],

--- a/rs/tests/networking/network_large_test.rs
+++ b/rs/tests/networking/network_large_test.rs
@@ -14,6 +14,8 @@ Runbook::
 end::catalog[] */
 
 use anyhow::Result;
+use ic_agent::Agent;
+use ic_limits::MAX_INGRESS_TTL;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
@@ -24,11 +26,14 @@ use ic_system_test_driver::{
             HasPublicApiUrl, HasTopologySnapshot, HasVm, IcNodeContainer, NnsInstallationBuilder,
         },
     },
-    systest,
-    util::{MessageCanister, assert_create_agent, block_on},
+    retry_with_msg_async, systest,
+    util::{
+        AGENT_REQUEST_TIMEOUT, MAX_CONCURRENT_REQUESTS, MessageCanister, assert_create_agent,
+        block_on, get_identity,
+    },
 };
 use ic_types::Height;
-use slog::info;
+use slog::{Logger, info};
 use std::time::Duration;
 
 // Timeout parameters
@@ -45,6 +50,53 @@ const FAULTY: usize = 16;
 const NODES: usize = 3 * FAULTY + 1; // 49
 
 const IDLE_DURATION: Duration = Duration::from_secs(10 * 60);
+
+// Under degraded conditions (f faulty nodes), consensus is slow and ingress messages
+// may expire before execution. Use a shorter polling time so each attempt fails fast,
+// then retry with a fresh ingress message.
+const DEGRADED_MAX_POLLING_TIME: Duration = Duration::from_secs(60);
+const DEGRADED_RETRY_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const DEGRADED_RETRY_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Creates an agent with a shorter `max_polling_time`, suitable for making
+/// update calls when the subnet is running at the minimum consensus threshold.
+async fn create_agent_with_short_polling_time(url: &str) -> Agent {
+    let client = reqwest::Client::builder()
+        .timeout(AGENT_REQUEST_TIMEOUT)
+        .http2_prior_knowledge()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .expect("Failed to build HTTP client");
+    let agent = Agent::builder()
+        .with_url(url)
+        .with_http_client(client)
+        .with_identity(get_identity())
+        .with_max_polling_time(DEGRADED_MAX_POLLING_TIME)
+        .with_max_concurrent_requests(MAX_CONCURRENT_REQUESTS)
+        .with_ingress_expiry(MAX_INGRESS_TTL - Duration::from_secs(30))
+        .build()
+        .unwrap();
+    agent.fetch_root_key().await.unwrap();
+    agent
+}
+
+/// Retries `try_store_msg` with backoff, creating a fresh ingress message each attempt.
+fn store_msg_with_retries(log: &Logger, canister: &MessageCanister<'_>, msg: &str) {
+    let msg = msg.to_string();
+    block_on(retry_with_msg_async!(
+        format!("store_msg('{msg}')"),
+        log,
+        DEGRADED_RETRY_TIMEOUT,
+        DEGRADED_RETRY_BACKOFF,
+        || async {
+            canister
+                .try_store_msg(msg.clone())
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        }
+    ))
+    .expect("Update canister call failed after retries");
+}
 
 pub fn setup(env: TestEnv) {
     InternetComputer::new()
@@ -133,11 +185,20 @@ pub fn test(env: TestEnv) {
             .expect("Node still healthy");
     }
 
+    // Create an agent with a shorter polling time for degraded-subnet operations.
+    // With f faulty nodes, consensus is slow and ingress messages may expire before
+    // execution. A short polling time + retry gives each attempt a fresh ingress message.
+    let degraded_agent = block_on(create_agent_with_short_polling_time(
+        node.get_public_url().as_str(),
+    ));
+    let degraded_canister =
+        MessageCanister::from_canister_id(&degraded_agent, message_canister.canister_id());
+
     info!(
         log,
         "Step 6: Assert that update call succeeds in presence of {} faulty nodes", FAULTY
     );
-    block_on(message_canister.try_store_msg(UPDATE_MSG_3)).expect("Update canister call failed.");
+    store_msg_with_retries(&log, &degraded_canister, UPDATE_MSG_3);
     assert_eq!(
         block_on(message_canister.try_read_msg()),
         Ok(Some(UPDATE_MSG_3.to_string()))
@@ -176,7 +237,7 @@ pub fn test(env: TestEnv) {
     );
 
     info!(log, "Storing message '{}' ...", UPDATE_MSG_5);
-    block_on(message_canister.try_store_msg(UPDATE_MSG_5)).expect("Update canister call failed.");
+    store_msg_with_retries(&log, &degraded_canister, UPDATE_MSG_5);
     info!(log, "Reading message '{}' ...", UPDATE_MSG_5);
     assert_eq!(
         block_on(message_canister.try_read_msg()),
@@ -188,7 +249,7 @@ pub fn test(env: TestEnv) {
         "Step 9: Run idle for a few min on faulty node boundary"
     );
     block_on(async { tokio::time::sleep(IDLE_DURATION).await });
-    block_on(message_canister.try_store_msg(UPDATE_MSG_6)).expect("Update canister call failed.");
+    store_msg_with_retries(&log, &degraded_canister, UPDATE_MSG_6);
     assert_eq!(
         block_on(message_canister.try_read_msg()),
         Ok(Some(UPDATE_MSG_6.to_string()))

--- a/rs/tests/networking/network_large_test.rs
+++ b/rs/tests/networking/network_large_test.rs
@@ -15,7 +15,6 @@ end::catalog[] */
 
 use anyhow::Result;
 use ic_agent::Agent;
-use ic_limits::MAX_INGRESS_TTL;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
@@ -28,8 +27,8 @@ use ic_system_test_driver::{
     },
     retry_with_msg_async, systest,
     util::{
-        AGENT_REQUEST_TIMEOUT, MAX_CONCURRENT_REQUESTS, MessageCanister, assert_create_agent,
-        block_on, get_identity,
+        AGENT_REQUEST_TIMEOUT, MessageCanister, agent_builder, assert_create_agent, block_on,
+        get_identity,
     },
 };
 use ic_types::Height;
@@ -67,15 +66,10 @@ async fn create_agent_with_short_polling_time(url: &str) -> Agent {
         .danger_accept_invalid_certs(true)
         .build()
         .expect("Failed to build HTTP client");
-    let agent = Agent::builder()
-        .with_url(url)
-        .with_http_client(client)
-        .with_identity(get_identity())
+    let agent = agent_builder(url, client, get_identity())
         .with_max_polling_time(DEGRADED_MAX_POLLING_TIME)
-        .with_max_concurrent_requests(MAX_CONCURRENT_REQUESTS)
-        .with_ingress_expiry(MAX_INGRESS_TTL - Duration::from_secs(30))
         .build()
-        .unwrap();
+        .expect("Failed to build agent with short polling time");
     agent.fetch_root_key().await.unwrap();
     agent
 }


### PR DESCRIPTION
The `//rs/tests/networking:network_large_test` [ran]( https://dash.zh1-idx1.dfinity.network/invocation/3b17bb9e-acf3-4e24-95ab-96117657fc9b?target=//rs/tests/networking:network_large_test#@1242
) into a `TimeoutWaitingForResponse` error when calling `try_store_msg(UPDATE_MSG_5)`  after restarting one node to restore the subnet to exactly the minimum consensus threshold.

## Root Cause

With f=16 faulty nodes (out of 49), the subnet runs at the minimum consensus threshold (2f+1=33 nodes). Block production drops to ~0.3-0.4 blocks/s, and DKG transcript loading at interval boundaries (every 100 heights) causes 12-17 second stalls.

The `try_store_msg` call uses `call_and_wait()` with the default 600s `max_polling_time`. The ingress message has a ~4.5 minute expiry (`MAX_INGRESS_TTL - 30s`). When the call coincides with DKG boundary stalls, the ingress message expires before the slow subnet can include and execute it. The agent then polls fruitlessly for the remaining ~5.5 minutes until the 600s timeout, returning `TimeoutWaitingForResponse`.

The flakiness depends on timing: Step 6 (same f=16) usually succeeds because the subnet is running steadily, while Step 8 (after restarting a node at a DKG boundary) fails when transcript loading stalls consensus right when the message is submitted.

## Fix

- Create a dedicated agent with `max_polling_time` of 60s (instead of 600s) for update calls made under degraded conditions (Steps 6, 8, 9).
- Use `retry_with_msg_async!` with a 15-minute timeout and 5s backoff so each retry submits a fresh ingress message with a new expiry.
- This ensures the message eventually lands within its expiry window, even with slow consensus.

## Verification

Ran `bazel test --runs_per_test=3 --jobs=3` — all 3 runs passed (1 run hit an unrelated Farm infrastructure error, which is expected and excluded per the flaky test skill).

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.