### PR TITLE
chore(dsm): set `wasm_backtrace_max_frames` to 20

### DIFF
--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -11,7 +11,7 @@ use ic_types::{MAX_STABLE_MEMORY_IN_BYTES, NumBytes, NumInstructions};
 use ic_wasm_types::{BinaryEncodedWasm, WasmValidationError};
 use std::{
     cmp,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet}, num::NonZero,
 };
 
 use crate::wasmtime_embedder::{
@@ -1706,6 +1706,7 @@ pub fn wasmtime_validation_config(_embedders_config: &EmbeddersConfig) -> wasmti
     // The signal handler uses Posix signals, not Mach ports on MacOS.
     config.macos_use_mach_ports(false);
     config.wasm_backtrace(true);
+    config.wasm_backtrace_max_frames(NonZero::new(20_usize));
     config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Disable);
     config.wasm_bulk_memory(true);
     config.wasm_function_references(false);

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -11,7 +11,8 @@ use ic_types::{MAX_STABLE_MEMORY_IN_BYTES, NumBytes, NumInstructions};
 use ic_wasm_types::{BinaryEncodedWasm, WasmValidationError};
 use std::{
     cmp,
-    collections::{BTreeMap, HashMap, HashSet}, num::NonZero,
+    collections::{BTreeMap, HashMap, HashSet},
+    num::NonZero,
 };
 
 use crate::wasmtime_embedder::{

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -1705,6 +1705,7 @@ pub fn wasmtime_validation_config(_embedders_config: &EmbeddersConfig) -> wasmti
     config.generate_address_map(false);
     // The signal handler uses Posix signals, not Mach ports on MacOS.
     config.macos_use_mach_ports(false);
+    config.wasm_backtrace(true);
     config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Disable);
     config.wasm_bulk_memory(true);
     config.wasm_function_references(false);

--- a/rs/embedders/src/wasm_utils/validation.rs
+++ b/rs/embedders/src/wasm_utils/validation.rs
@@ -1706,7 +1706,6 @@ pub fn wasmtime_validation_config(_embedders_config: &EmbeddersConfig) -> wasmti
     config.generate_address_map(false);
     // The signal handler uses Posix signals, not Mach ports on MacOS.
     config.macos_use_mach_ports(false);
-    config.wasm_backtrace(true);
     config.wasm_backtrace_max_frames(NonZero::new(20_usize));
     config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Disable);
     config.wasm_bulk_memory(true);


### PR DESCRIPTION
This PR sets the `wasm_backtrace_max_frames` to 20 to avoid the default values changing in wasmtime (which is currently [set](https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.wasm_backtrace_max_frames) to 20)