### PR TITLE
feat(flexible-outcalls): CON-1708 add is_reject to CanisterHttpResponseMetadata

### DIFF
--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -263,6 +263,7 @@ mod tests {
                 id: CallbackId::from(id),
                 content_hash: CryptoHashOf::from(CryptoHash(vec![1, 2, 3])),
                 content_size: 42,
+                is_reject: false,
                 registry_version: RegistryVersion::from(id),
                 replica_version: ReplicaVersion::default(),
             },

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -679,10 +679,7 @@ impl CanisterHttpPayloadBuilderImpl {
                 )
                 .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
 
-                if matches!(
-                    response_with_proof.response.content,
-                    CanisterHttpResponseContent::Reject(_)
-                ) {
+                if response_with_proof.response.content.is_reject() {
                     return invalid_artifact(
                         InvalidCanisterHttpPayloadReason::FlexibleRejectNotAllowedInOkResponses {
                             callback_id,
@@ -743,10 +740,7 @@ impl CanisterHttpPayloadBuilderImpl {
                         )
                         .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
 
-                        if !matches!(
-                            response_with_proof.response.content,
-                            CanisterHttpResponseContent::Reject(_)
-                        ) {
+                        if !response_with_proof.response.content.is_reject() {
                             return invalid_artifact(
                                 InvalidCanisterHttpPayloadReason::FlexibleRejectExpectedInErrorResponse(
                                     callback_id,

--- a/rs/https_outcalls/consensus/src/payload_builder/proptests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/proptests.rs
@@ -172,6 +172,7 @@ fn prop_response_with_shares(
             id: response.id,
             content_hash: crypto_hash(&response),
             content_size: response.content.count_bytes() as u32,
+            is_reject: matches!(response.content, CanisterHttpResponseContent::Reject(_)),
             registry_version: RegistryVersion::new(1),
             replica_version: ReplicaVersion::default(),
         };
@@ -203,11 +204,12 @@ fn prop_response(max_size: usize) -> impl Strategy<Value = CanisterHttpResponse>
 
 /// Generate a random metadata with a random registry version value
 fn prop_random_metadata() -> impl Strategy<Value = CanisterHttpResponseMetadata> {
-    any::<(u64, [u8; 32], u32)>().prop_map(|(id, hash, content_size)| {
+    any::<(u64, [u8; 32], u32, bool)>().prop_map(|(id, hash, content_size, is_reject)| {
         CanisterHttpResponseMetadata {
             id: CallbackId::new(id),
             content_hash: CryptoHashOf::new(CryptoHash(hash.to_vec())),
             content_size,
+            is_reject,
             registry_version: RegistryVersion::new(1),
             replica_version: ReplicaVersion::default(),
         }

--- a/rs/https_outcalls/consensus/src/payload_builder/proptests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/proptests.rs
@@ -172,7 +172,7 @@ fn prop_response_with_shares(
             id: response.id,
             content_hash: crypto_hash(&response),
             content_size: response.content.count_bytes() as u32,
-            is_reject: matches!(response.content, CanisterHttpResponseContent::Reject(_)),
+            is_reject: response.content.is_reject(),
             registry_version: RegistryVersion::new(1),
             replica_version: ReplicaVersion::default(),
         };

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -600,7 +600,8 @@ fn registry_unavailable_validation() {
 /// the existing helper functions
 #[test]
 fn feature_disabled_validation() {
-    let validation_result = run_non_flexible_validation_test(false, |_, _| {}, &default_validation_context());
+    let validation_result =
+        run_non_flexible_validation_test(false, |_, _| {}, &default_validation_context());
     match validation_result {
         Err(ValidationError::ValidationFailed(
             PayloadValidationFailure::CanisterHttpPayloadValidationFailed(

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -472,7 +472,7 @@ fn divergence_responses_count_toward_max_responses() {
 /// Test that oversized payloads don't validate
 #[test]
 fn oversized_validation() {
-    let validation_result = run_validatation_test(
+    let validation_result = run_non_flexible_validation_test(
         true,
         |response, _| {
             // Give response oversized content
@@ -493,7 +493,7 @@ fn oversized_validation() {
 /// Test that payloads with wrong registry version don't validate
 #[test]
 fn registry_version_validation() {
-    let validation_result = run_validatation_test(
+    let validation_result = run_non_flexible_validation_test(
         true,
         |_, metadata| {
             // Set metadata to a newer registry version
@@ -516,7 +516,7 @@ fn registry_version_validation() {
 /// Test that payloads with wrong hash don't validate
 #[test]
 fn hash_validation() {
-    let validation_result = run_validatation_test(
+    let validation_result = run_non_flexible_validation_test(
         true,
         |response, _| {
             // Change response content to have a different hash
@@ -537,7 +537,7 @@ fn hash_validation() {
 /// Test that payloads with wrong content size don't validate
 #[test]
 fn content_size_validation() {
-    let validation_result = run_validatation_test(
+    let validation_result = run_non_flexible_validation_test(
         true,
         |_response, metadata| {
             metadata.content_size = metadata.content_size.wrapping_add(1);
@@ -557,7 +557,7 @@ fn content_size_validation() {
 /// Test that payloads with wrong is_reject flag don't validate
 #[test]
 fn is_reject_validation() {
-    let validation_result = run_validatation_test(
+    let validation_result = run_non_flexible_validation_test(
         true,
         |_response, metadata| {
             metadata.is_reject = !metadata.is_reject;
@@ -577,7 +577,7 @@ fn is_reject_validation() {
 /// Test that payloads don't validate, if registry for height does not exist
 #[test]
 fn registry_unavailable_validation() {
-    let validation_result = run_validatation_test(
+    let validation_result = run_non_flexible_validation_test(
         true,
         |_, _| { /* Nothing to modify */ },
         &ValidationContext {
@@ -600,7 +600,7 @@ fn registry_unavailable_validation() {
 /// the existing helper functions
 #[test]
 fn feature_disabled_validation() {
-    let validation_result = run_validatation_test(false, |_, _| {}, &default_validation_context());
+    let validation_result = run_non_flexible_validation_test(false, |_, _| {}, &default_validation_context());
     match validation_result {
         Err(ValidationError::ValidationFailed(
             PayloadValidationFailure::CanisterHttpPayloadValidationFailed(
@@ -1577,7 +1577,7 @@ pub(crate) fn default_validation_context() -> ValidationContext {
 ///
 /// This is useful to run a number of tests against the payload validator, without the need
 /// to mock up all needed structures again and again.
-fn run_validatation_test<F>(
+fn run_non_flexible_validation_test<F>(
     https_feature_flag: bool,
     mut modify: F,
     validation_context: &ValidationContext,

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -1393,7 +1393,7 @@ fn test_response_and_metadata_with_content(
         id: response.id,
         content_hash: crypto_hash(&response),
         content_size: response.content.count_bytes() as u32,
-        is_reject: matches!(response.content, CanisterHttpResponseContent::Reject(_)),
+        is_reject: response.content.is_reject(),
         registry_version: RegistryVersion::new(1),
         replica_version: ReplicaVersion::default(),
     };

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -554,6 +554,26 @@ fn content_size_validation() {
     );
 }
 
+/// Test that payloads with wrong is_reject flag don't validate
+#[test]
+fn is_reject_validation() {
+    let validation_result = run_validatation_test(
+        true,
+        |_response, metadata| {
+            metadata.is_reject = !metadata.is_reject;
+        },
+        &default_validation_context(),
+    );
+    assert_matches!(
+        validation_result,
+        Err(ValidationError::InvalidArtifact(
+            InvalidPayloadReason::InvalidCanisterHttpPayload(
+                InvalidCanisterHttpPayloadReason::IsRejectMismatch { .. },
+            ),
+        ))
+    );
+}
+
 /// Test that payloads don't validate, if registry for height does not exist
 #[test]
 fn registry_unavailable_validation() {
@@ -1373,6 +1393,7 @@ fn test_response_and_metadata_with_content(
         id: response.id,
         content_hash: crypto_hash(&response),
         content_size: response.content.count_bytes() as u32,
+        is_reject: matches!(response.content, CanisterHttpResponseContent::Reject(_)),
         registry_version: RegistryVersion::new(1),
         replica_version: ReplicaVersion::default(),
     };
@@ -2344,6 +2365,37 @@ fn flexible_invalid_content_size_mismatch() {
                     }
                 )
             )) if metadata_size == wrong_size && calculated_size == expected_size
+        );
+    });
+}
+
+#[test]
+fn flexible_invalid_is_reject_mismatch() {
+    let committee: BTreeSet<_> = (0..4).map(node_test_id).collect();
+    let callback_id = CallbackId::from(42);
+
+    setup_test_with_flexible_context(4, callback_id, committee, 1, 4, |payload_builder, _pool| {
+        let mut entry = flexible_response(42, 0, b"data");
+        entry.proof.content.is_reject = !entry.proof.content.is_reject;
+
+        let payload = flexible_payload(vec![FlexibleCanisterHttpResponses {
+            callback_id,
+            responses: vec![entry],
+        }]);
+
+        let result = payload_builder.validate_payload(
+            Height::from(1),
+            &test_proposal_context(&default_validation_context()),
+            &payload_to_bytes_max_4mb(payload),
+            &[],
+        );
+        assert_matches!(
+            result,
+            Err(ValidationError::InvalidArtifact(
+                InvalidPayloadReason::InvalidCanisterHttpPayload(
+                    InvalidCanisterHttpPayloadReason::IsRejectMismatch { .. }
+                )
+            ))
         );
     });
 }
@@ -3850,6 +3902,41 @@ fn flexible_error_too_many_request_errors_content_size_mismatch() {
 }
 
 #[test]
+fn flexible_error_too_many_request_errors_is_reject_mismatch() {
+    let num_nodes = 4;
+    let committee: BTreeSet<_> = (0..num_nodes as u64).map(node_test_id).collect();
+    let callback_id = CallbackId::from(42);
+
+    setup_test_with_flexible_context(num_nodes, callback_id, committee, 3, 4, |pb, _pool| {
+        let entry_ok = flexible_reject_response(callback_id.get(), 0);
+        let mut entry_bad = flexible_reject_response(callback_id.get(), 1);
+        entry_bad.proof.content.is_reject = !entry_bad.proof.content.is_reject;
+
+        let payload = CanisterHttpPayload {
+            flexible_errors: vec![FlexibleCanisterHttpError::TooManyRequestErrors {
+                callback_id,
+                reject_responses: vec![entry_ok, entry_bad],
+            }],
+            ..Default::default()
+        };
+        let result = pb.validate_payload(
+            Height::new(1),
+            &test_proposal_context(&default_validation_context()),
+            &payload_to_bytes_max_4mb(payload),
+            &[],
+        );
+        assert_matches!(
+            result,
+            Err(ValidationError::InvalidArtifact(
+                InvalidPayloadReason::InvalidCanisterHttpPayload(
+                    InvalidCanisterHttpPayloadReason::IsRejectMismatch { .. }
+                )
+            ))
+        );
+    });
+}
+
+#[test]
 fn flexible_error_too_many_request_errors_proof_id_mismatch() {
     let num_nodes = 4;
     let committee: BTreeSet<_> = (0..num_nodes as u64).map(node_test_id).collect();
@@ -4084,6 +4171,7 @@ fn metadata_share_with_content_size(
         id: CallbackId::new(callback_id),
         content_hash: CryptoHashOf::new(CryptoHash(vec![0xAB; 32])),
         content_size,
+        is_reject: false,
         registry_version: RegistryVersion::new(1),
         replica_version: ReplicaVersion::default(),
     };

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -62,7 +62,7 @@ pub(crate) fn check_response_consistency(
     }
 
     // Check the is_reject flag matches the response content type
-    let calculated_is_reject = matches!(content.content, CanisterHttpResponseContent::Reject(_));
+    let calculated_is_reject = content.content.is_reject();
     if calculated_is_reject != metadata.is_reject {
         return Err(InvalidCanisterHttpPayloadReason::IsRejectMismatch {
             metadata_is_reject: metadata.is_reject,
@@ -119,10 +119,7 @@ pub(crate) fn validate_flexible_response_with_proof(
         });
     }
 
-    let calculated_is_reject = matches!(
-        response_with_proof.response.content,
-        CanisterHttpResponseContent::Reject(_)
-    );
+    let calculated_is_reject = response_with_proof.response.content.is_reject();
     if calculated_is_reject != response_with_proof.proof.content.is_reject {
         return Err(InvalidCanisterHttpPayloadReason::IsRejectMismatch {
             metadata_is_reject: response_with_proof.proof.content.is_reject,

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -26,6 +26,7 @@ use std::{
 /// - The signed metadata is the same as the metadata of the response
 /// - The content_hash is the same as the hash of the content
 /// - The content_size is the same as the size of the content
+/// - The is_reject flag matches whether the content is a Reject
 ///
 /// **NOTE**: The signature is not checked
 pub(crate) fn check_response_consistency(
@@ -57,6 +58,15 @@ pub(crate) fn check_response_consistency(
         return Err(InvalidCanisterHttpPayloadReason::ContentSizeMismatch {
             metadata_size: metadata.content_size,
             calculated_size,
+        });
+    }
+
+    // Check the is_reject flag matches the response content type
+    let calculated_is_reject = matches!(content.content, CanisterHttpResponseContent::Reject(_));
+    if calculated_is_reject != metadata.is_reject {
+        return Err(InvalidCanisterHttpPayloadReason::IsRejectMismatch {
+            metadata_is_reject: metadata.is_reject,
+            calculated_is_reject,
         });
     }
 
@@ -106,6 +116,17 @@ pub(crate) fn validate_flexible_response_with_proof(
         return Err(InvalidCanisterHttpPayloadReason::ContentSizeMismatch {
             metadata_size: response_with_proof.proof.content.content_size,
             calculated_size,
+        });
+    }
+
+    let calculated_is_reject = matches!(
+        response_with_proof.response.content,
+        CanisterHttpResponseContent::Reject(_)
+    );
+    if calculated_is_reject != response_with_proof.proof.content.is_reject {
+        return Err(InvalidCanisterHttpPayloadReason::IsRejectMismatch {
+            metadata_is_reject: response_with_proof.proof.content.is_reject,
+            calculated_is_reject,
         });
     }
 

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -368,7 +368,10 @@ impl CanisterHttpPoolManagerImpl {
                         registry_version,
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
-                        is_reject: matches!(response.content, CanisterHttpResponseContent::Reject(_)),
+                        is_reject: matches!(
+                            response.content,
+                            CanisterHttpResponseContent::Reject(_)
+                        ),
                         replica_version: ReplicaVersion::default(),
                     };
                     let signature = if let Ok(signature) = self
@@ -521,8 +524,9 @@ impl CanisterHttpPoolManagerImpl {
                             ));
                         }
 
-                        let expected_is_reject = matches!(response.content, CanisterHttpResponseContent::Reject(_));
-                        if share.content.is_reject != expected_is_reject {
+                        if share.content.is_reject
+                            != matches!(response.content, CanisterHttpResponseContent::Reject(_))
+                        {
                             return Some(CanisterHttpChangeAction::HandleInvalid(
                                 share.clone(),
                                 "is_reject does not match the response content".to_string(),

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -368,6 +368,7 @@ impl CanisterHttpPoolManagerImpl {
                         registry_version,
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
+                        is_reject: matches!(response.content, CanisterHttpResponseContent::Reject(_)),
                         replica_version: ReplicaVersion::default(),
                     };
                     let signature = if let Ok(signature) = self
@@ -517,6 +518,14 @@ impl CanisterHttpPoolManagerImpl {
                             return Some(CanisterHttpChangeAction::HandleInvalid(
                                 share.clone(),
                                 "Content size does not match the response".to_string(),
+                            ));
+                        }
+
+                        let expected_is_reject = matches!(response.content, CanisterHttpResponseContent::Reject(_));
+                        if share.content.is_reject != expected_is_reject {
+                            return Some(CanisterHttpChangeAction::HandleInvalid(
+                                share.clone(),
+                                "is_reject does not match the response content".to_string(),
                             ));
                         }
 
@@ -797,6 +806,7 @@ pub mod test {
                         registry_version: RegistryVersion::from(1),
                         content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                         content_size: 0,
+                        is_reject: false,
                         replica_version: ReplicaVersion::default(),
                     };
 
@@ -893,6 +903,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                     content_size: 0,
+                    is_reject: false,
                     replica_version: ReplicaVersion::default(),
                 };
 
@@ -998,6 +1009,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                     content_size: 0,
+                    is_reject: false,
                     replica_version: ReplicaVersion::default(),
                 };
 
@@ -1125,6 +1137,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: ic_types::crypto::crypto_hash(&response),
                     content_size: response.content.count_bytes() as u32,
+                    is_reject: false,
                     replica_version: ReplicaVersion::default(),
                 };
 
@@ -1242,6 +1255,38 @@ pub mod test {
                         CanisterHttpChangeAction::HandleInvalid(_, reason) if reason == "Content size does not match the response"
                     );
                 }
+
+                // TEST 4: Non-replicated request artifact has a mismatched is_reject flag.
+                // It should be marked as invalid.
+                {
+                    let response = empty_canister_http_response(0);
+                    let mut canister_http_pool =
+                        CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
+
+                    let mut bad_share = share.clone();
+                    bad_share.content.is_reject = !bad_share.content.is_reject;
+
+                    let artifact_with_mismatched_is_reject = CanisterHttpResponseArtifact {
+                        share: bad_share,
+                        response: Some(response),
+                    };
+                    canister_http_pool.insert(UnvalidatedArtifact {
+                        message: artifact_with_mismatched_is_reject,
+                        peer_id: delegated_node_id,
+                        timestamp: UNIX_EPOCH,
+                    });
+
+                    let changes = pool_manager.validate_shares(
+                        pool.get_cache().as_ref(),
+                        &canister_http_pool,
+                        Height::from(0),
+                    );
+
+                    assert_matches!(
+                        &changes[0],
+                        CanisterHttpChangeAction::HandleInvalid(_, reason) if reason == "is_reject does not match the response content"
+                    );
+                }
             })
         });
     }
@@ -1289,6 +1334,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: ic_types::crypto::crypto_hash(&response),
                     content_size: response.content.count_bytes() as u32,
+                    is_reject: false,
                     replica_version: ReplicaVersion::default(),
                 };
                 let share = Signed {
@@ -1386,6 +1432,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: ic_types::crypto::crypto_hash(&response),
                     content_size: response.content.count_bytes() as u32,
+                    is_reject: false,
                     replica_version: ReplicaVersion::default(),
                 };
 
@@ -1523,6 +1570,7 @@ pub mod test {
                         registry_version: RegistryVersion::from(1),
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
+                        is_reject: false,
                         replica_version: ReplicaVersion::default(),
                     };
                     let share = Signed {
@@ -1588,6 +1636,7 @@ pub mod test {
                         registry_version: RegistryVersion::from(1),
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
+                        is_reject: false,
                         replica_version: ReplicaVersion::default(),
                     };
                     let share = Signed {
@@ -1691,6 +1740,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: ic_types::crypto::crypto_hash(&response),
                     content_size: response.content.count_bytes() as u32,
+                    is_reject: true,
                     replica_version: ReplicaVersion::default(),
                 };
 
@@ -2022,6 +2072,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: dishonest_hash,
                     content_size: dishonest_response.content.count_bytes() as u32,
+                    is_reject: true,
                     replica_version: ReplicaVersion::default(),
                 };
                 let share = Signed {
@@ -2160,6 +2211,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: ic_types::crypto::crypto_hash(&response),
                     content_size: response.content.count_bytes() as u32,
+                    is_reject: true,
                     replica_version: ReplicaVersion::default(),
                 };
 
@@ -2237,6 +2289,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                     content_size: 0,
+                    is_reject: false,
                     replica_version: ReplicaVersion::default(),
                 };
 
@@ -2501,6 +2554,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                     content_size: 0,
+                    is_reject: false,
                     replica_version: ReplicaVersion::default(),
                 };
 
@@ -2664,6 +2718,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: crypto_hash(&response),
                     content_size: response.content.count_bytes() as u32,
+                    is_reject: false,
                     replica_version: ReplicaVersion::default(),
                 };
                 let share = Signed {
@@ -2762,6 +2817,7 @@ pub mod test {
                     registry_version: RegistryVersion::from(1),
                     content_hash: crypto_hash(&response),
                     content_size: response.content.count_bytes() as u32,
+                    is_reject: false,
                     replica_version: ReplicaVersion::default(),
                 };
 
@@ -2883,6 +2939,37 @@ pub mod test {
                         if reason == "Content size does not match the response"
                     );
                 }
+
+                // TEST 4: Flexible artifact has a mismatched is_reject flag -- should be invalid.
+                {
+                    let response = empty_canister_http_response(callback_id.get());
+                    let mut canister_http_pool =
+                        CanisterHttpPoolImpl::new(MetricsRegistry::new(), no_op_logger());
+
+                    let mut bad_share = share.clone();
+                    bad_share.content.is_reject = !bad_share.content.is_reject;
+
+                    canister_http_pool.insert(UnvalidatedArtifact {
+                        message: CanisterHttpResponseArtifact {
+                            share: bad_share,
+                            response: Some(response),
+                        },
+                        peer_id: committee_member,
+                        timestamp: UNIX_EPOCH,
+                    });
+
+                    let changes = pool_manager.validate_shares(
+                        pool.get_cache().as_ref(),
+                        &canister_http_pool,
+                        Height::from(0),
+                    );
+
+                    assert_matches!(
+                        &changes[0],
+                        CanisterHttpChangeAction::HandleInvalid(_, reason)
+                        if reason == "is_reject does not match the response content"
+                    );
+                }
             })
         });
     }
@@ -2963,6 +3050,7 @@ pub mod test {
                         registry_version: RegistryVersion::from(1),
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
+                        is_reject: false,
                         replica_version: ReplicaVersion::default(),
                     };
                     let share = Signed {
@@ -3026,6 +3114,7 @@ pub mod test {
                         registry_version: RegistryVersion::from(1),
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
+                        is_reject: false,
                         replica_version: ReplicaVersion::default(),
                     };
                     let share = Signed {

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -368,10 +368,7 @@ impl CanisterHttpPoolManagerImpl {
                         registry_version,
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
-                        is_reject: matches!(
-                            response.content,
-                            CanisterHttpResponseContent::Reject(_)
-                        ),
+                        is_reject: response.content.is_reject(),
                         replica_version: ReplicaVersion::default(),
                     };
                     let signature = if let Ok(signature) = self
@@ -524,9 +521,7 @@ impl CanisterHttpPoolManagerImpl {
                             ));
                         }
 
-                        if share.content.is_reject
-                            != matches!(response.content, CanisterHttpResponseContent::Reject(_))
-                        {
+                        if share.content.is_reject != response.content.is_reject() {
                             return Some(CanisterHttpChangeAction::HandleInvalid(
                                 share.clone(),
                                 "is_reject does not match the response content".to_string(),

--- a/rs/interfaces/src/canister_http.rs
+++ b/rs/interfaces/src/canister_http.rs
@@ -40,6 +40,11 @@ pub enum InvalidCanisterHttpPayloadReason {
         metadata_size: u32,
         calculated_size: u32,
     },
+    /// The is_reject flag of the signed metadata does not match the actual response content type
+    IsRejectMismatch {
+        metadata_is_reject: bool,
+        calculated_is_reject: bool,
+    },
     /// A timeout refers to a CallbackId that is unknown by the StateManager
     UnknownCallbackId(CallbackId),
     /// A CallbackId was included as a timeout, however the Request has not timed out at all

--- a/rs/protobuf/def/types/v1/canister_http.proto
+++ b/rs/protobuf/def/types/v1/canister_http.proto
@@ -30,6 +30,7 @@ message CanisterHttpResponseMetadata {
   uint64 registry_version = 4;
   string replica_version = 5;
   uint32 content_size = 6;
+  bool is_reject = 7;
 }
 
 message CanisterHttpResponseContent {
@@ -62,6 +63,7 @@ message CanisterHttpResponseWithConsensus {
   reserved 6;
   repeated CanisterHttpResponseSignature signatures = 7;
   uint32 content_size = 9;
+  bool is_reject = 10;
 }
 
 message CanisterHttpShare {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -554,6 +554,8 @@ pub struct CanisterHttpResponseMetadata {
     pub replica_version: ::prost::alloc::string::String,
     #[prost(uint32, tag = "6")]
     pub content_size: u32,
+    #[prost(bool, tag = "7")]
+    pub is_reject: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CanisterHttpResponseContent {
@@ -598,6 +600,8 @@ pub struct CanisterHttpResponseWithConsensus {
     pub signatures: ::prost::alloc::vec::Vec<CanisterHttpResponseSignature>,
     #[prost(uint32, tag = "9")]
     pub content_size: u32,
+    #[prost(bool, tag = "10")]
+    pub is_reject: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CanisterHttpShare {

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2613,6 +2613,7 @@ impl StateMachine {
                 registry_version,
                 content_hash: ic_types::crypto::crypto_hash(&response),
                 content_size: content.count_bytes() as u32,
+                is_reject: matches!(content, CanisterHttpResponseContent::Reject(_)),
                 replica_version: ReplicaVersion::default(),
             };
             let signature = CryptoReturningOk::default()

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2613,7 +2613,7 @@ impl StateMachine {
                 registry_version,
                 content_hash: ic_types::crypto::crypto_hash(&response),
                 content_size: content.count_bytes() as u32,
-                is_reject: matches!(content, CanisterHttpResponseContent::Reject(_)),
+                is_reject: content.is_reject(),
                 replica_version: ReplicaVersion::default(),
             };
             let signature = CryptoReturningOk::default()

--- a/rs/types/types/src/batch/canister_http.rs
+++ b/rs/types/types/src/batch/canister_http.rs
@@ -199,6 +199,7 @@ impl From<CanisterHttpResponseWithConsensus> for pb::CanisterHttpResponseWithCon
                 })
                 .collect(),
             content_size: payload.proof.content.content_size,
+            is_reject: payload.proof.content.is_reject,
         }
     }
 }
@@ -240,6 +241,7 @@ impl TryFrom<pb::CanisterHttpResponseWithConsensus> for CanisterHttpResponseWith
                         payload.hash,
                     )),
                     content_size: payload.content_size,
+                    is_reject: payload.is_reject,
                     registry_version: RegistryVersion::new(payload.registry_version),
                     replica_version: ReplicaVersion::try_from(payload.replica_version)
                         .map_err(|err| ProxyDecodeError::ReplicaVersionParseError(Box::new(err)))?,
@@ -335,6 +337,7 @@ impl From<CanisterHttpResponseShare> for pb::CanisterHttpShare {
                 registry_version: share.content.registry_version.get(),
                 replica_version: share.content.replica_version.into(),
                 content_size: share.content.content_size,
+                is_reject: share.content.is_reject,
             }),
             signature: Some(pb::CanisterHttpResponseSignature {
                 signer: share.signature.signer.get().into_vec(),
@@ -363,6 +366,7 @@ impl TryFrom<pb::CanisterHttpShare> for CanisterHttpResponseShare {
                 id,
                 content_hash,
                 content_size: metadata.content_size,
+                is_reject: metadata.is_reject,
                 registry_version,
                 replica_version,
             },
@@ -583,6 +587,7 @@ mod tests {
                     4, 5, 6, 7,
                 ])),
                 content_size: 42,
+                is_reject: false,
                 registry_version: RegistryVersion::new(2),
                 replica_version: ReplicaVersion::default(),
             },

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -834,7 +834,10 @@ pub enum CanisterHttpResponseContent {
 
 impl CanisterHttpResponseContent {
     pub fn is_reject(&self) -> bool {
-        matches!(self, CanisterHttpResponseContent::Reject(_))
+        match self {
+            CanisterHttpResponseContent::Success(_) => false,
+            CanisterHttpResponseContent::Reject(_) => true,
+        }
     }
 }
 

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -832,6 +832,12 @@ pub enum CanisterHttpResponseContent {
     Reject(CanisterHttpReject),
 }
 
+impl CanisterHttpResponseContent {
+    pub fn is_reject(&self) -> bool {
+        matches!(self, CanisterHttpResponseContent::Reject(_))
+    }
+}
+
 impl CountBytes for CanisterHttpResponseContent {
     fn count_bytes(&self) -> usize {
         match self {

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -987,6 +987,7 @@ pub struct CanisterHttpResponseMetadata {
     pub id: CallbackId,
     pub content_hash: CryptoHashOf<CanisterHttpResponse>,
     pub content_size: u32,
+    pub is_reject: bool,
     pub registry_version: RegistryVersion,
     pub replica_version: ReplicaVersion,
 }
@@ -997,12 +998,14 @@ impl CountBytes for CanisterHttpResponseMetadata {
             id,
             content_hash,
             content_size,
+            is_reject,
             registry_version,
             replica_version,
         } = self;
         size_of_val(id)
             + content_hash.get_ref().0.len()
             + size_of_val(content_size)
+            + size_of_val(is_reject)
             + size_of_val(registry_version)
             + replica_version.as_ref().len()
     }

--- a/rs/types/types/src/crypto/hash/tests.rs
+++ b/rs/types/types/src/crypto/hash/tests.rs
@@ -1071,13 +1071,14 @@ mod crypto_hash_stability {
             id: CallbackId::from(42),
             content_hash: test_crypto_hash_of(0x42),
             content_size: 0,
+            is_reject: false,
             registry_version: RegistryVersion::from(1),
             replica_version: ReplicaVersion::default(),
         };
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "7c32c9aca0291c4440de5a0c7b370c6b977fdc9efff58847f8c8db6bb83f1f17",
+            "ebf5373f06dadd9a3d7d3b59ce457533428ff27d4d588b8434f786d1d8c1a9db",
             "Hash of CanisterHttpResponseMetadata changed"
         );
     }
@@ -1089,6 +1090,7 @@ mod crypto_hash_stability {
             id: CallbackId::from(42),
             content_hash: test_crypto_hash_of(0x42),
             content_size: 0,
+            is_reject: false,
             registry_version: RegistryVersion::from(1),
             replica_version: ReplicaVersion::default(),
         };
@@ -1102,7 +1104,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "9adaec0a8b383039b5723e2dd4c5b27c545bcc43c9492f1037633ef725aafc73",
+            "7bff0af6053ad0f648acffecf0434e299e9ce1d04b6752934935a13e390de986",
             "Hash of CanisterHttpResponseShare changed"
         );
     }


### PR DESCRIPTION
## Summary

Adds an `is_reject: bool` field to `CanisterHttpResponseMetadata` so that signed metadata alone can distinguish success from reject responses. This is a prerequisite for fixing the `ResponsesTooLarge` validation logic (CON-1709), where the validator needs to partition shares into OK vs reject sets using only signed metadata — without requiring the full response body.

Follows the same pattern established by PR #9673, which added `content_size` to the metadata.

## Key changes

- **Protobuf**: `bool is_reject = 7` on `CanisterHttpResponseMetadata`, `bool is_reject = 10` on `CanisterHttpResponseWithConsensus`.
- **Rust struct**: New `is_reject: bool` field on `CanisterHttpResponseMetadata`, included in `count_bytes()` and CBOR signing.
- **Pool manager**: Sets `is_reject` from the response content when constructing metadata; validates consistency when receiving shares from peers.
- **Payload validation**: `check_response_consistency` (fully-replicated / non-replicated) and `validate_flexible_response_with_proof` (flexible) both verify `is_reject` matches the response body, returning a new `IsRejectMismatch` error on mismatch.
- **Tests**: Dedicated `is_reject` mismatch tests for `payload.responses`, `payload.flexible_responses`, `payload.flexible_errors` (TooManyRequestErrors), and pool manager share validation (non-replicated + flexible). Updated hash stability golden values. Updated all metadata construction sites including proptests.

## Backward compatibility

No concerns — the canister HTTP pool is purely in-memory (backed by `BTreeMap`, not LMDB) and is emptied on every replica restart. On subnet upgrades all nodes restart simultaneously, so there is no mixed-version period where old shares (missing `is_reject`) coexist with new ones.

The hash stability test golden values changed because the CBOR-serialized (and signed) metadata now includes the new field. This is safe because `CanisterHttpResponseMetadata` is never persisted to disk — it only lives in the in-memory pool and in block payloads, both of which are rebuilt fresh after an upgrade.