### PR TITLE
fix: instruction limits for load_canister_snapshot

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2337,6 +2337,12 @@ impl CanisterManager {
                     round_limits,
                     compilation_cost_handling,
                 );
+            debug_assert!(
+                instructions_for_execution <= prepaid_execution_instructions,
+                "instructions_for_execution {:?} exceeds prepaid_execution_instructions {:?}",
+                instructions_for_execution,
+                prepaid_execution_instructions,
+            );
             let instructions_to_refund =
                 prepaid_execution_instructions.saturating_sub(&instructions_for_execution);
             self.cycles_account_manager.refund_unused_execution_cycles(

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1966,7 +1966,6 @@ fn get_instruction_limits_for_subnet_message(
             | StoredChunks
             | ClearChunkStore
             | TakeCanisterSnapshot
-            | LoadCanisterSnapshot
             | ListCanisterSnapshots
             | DeleteCanisterSnapshot
             | ReadCanisterSnapshotMetadata
@@ -1974,6 +1973,13 @@ fn get_instruction_limits_for_subnet_message(
             | UploadCanisterSnapshotMetadata
             | UploadCanisterSnapshotData
             | RenameCanister => default_limits,
+            // `LoadCanisterSnapshot` compiles a Wasm module and charges for it
+            // similar to `InstallCode`. It does not support DTS, so the slice
+            // limit equals the message limit.
+            LoadCanisterSnapshot => InstructionLimits::new(
+                config.max_instructions_per_install_code,
+                config.max_instructions_per_install_code,
+            ),
             InstallCode | InstallChunkedCode => InstructionLimits::new(
                 config.max_instructions_per_install_code,
                 config.max_instructions_per_install_code_slice,


### PR DESCRIPTION
This PR fixes instruction limits for loading a canister snapshot which are used to derive the prepaid cycles amount for compiling the canister WASM in the loaded snapshot.