### PR TITLE
feat(node): Unpin kernel base image

### DIFF
--- a/ic-os/guestos/context/Dockerfile.base
+++ b/ic-os/guestos/context/Dockerfile.base
@@ -62,10 +62,8 @@ COPY packages.* /tmp/
 RUN apt-get -y update && \
     apt-get -y upgrade && \
     apt-get -y --no-install-recommends install $(for P in ${PACKAGE_FILES}; do cat /tmp/$P | sed -e "s/#.*//" ; done) \
-        # TODO(NODE-1852): Temporarily pin the kernel here.
-        # ${_KERNEL_PACKAGE} \
-        # linux-modules-extra-$(apt-cache depends ${_KERNEL_PACKAGE} | sed -n -e 's/  Depends: linux-image-\(.*\)-generic/\1/p')-generic && \
-        linux-image-6.14.0-37-generic linux-modules-extra-6.14.0-37-generic && \
+        ${_KERNEL_PACKAGE} \
+        linux-modules-extra-$(apt-cache depends ${_KERNEL_PACKAGE} | sed -n -e 's/  Depends: linux-image-\(.*\)-generic/\1/p')-generic && \
     rm /tmp/packages.*
 
 # Install node_exporter


### PR DESCRIPTION
Remove the temporary kernel version pin. The pinned kernel (`6.14.0-37`) was needed to work around a `folio_split()` race condition bug that caused data corruption and xnet test failures. The fix was backported to Ubuntu's HWE kernel `6.17.0-14.14`; the current unpinned kernel (`6.17.0-20`) includes it.

Tested change on `xnet_slo_29_subnets_test`, the initial test that failed due to the bug.