### PR TITLE
fix: deflake //rs/sns/integration_tests:neuron_test

### DIFF
--- a/rs/sns/test_utils/src/itest_helpers.rs
+++ b/rs/sns/test_utils/src/itest_helpers.rs
@@ -355,8 +355,11 @@ pub fn populate_canister_ids(
 
     // Index
     {
-        if let Some(IndexArg::Init(init_arg)) = sns_canister_init_payloads.index_ng.as_mut() {
-            init_arg.ledger_id = ledger_canister_id.0;
+        match sns_canister_init_payloads.index_ng.as_mut() {
+            Some(IndexArg::Init(init_arg)) => {
+                init_arg.ledger_id = ledger_canister_id.0;
+            }
+            other => panic!("bug: expected Some(IndexArg::Init(...)), got {other:?}"),
         }
     }
 }

--- a/rs/sns/test_utils/src/itest_helpers.rs
+++ b/rs/sns/test_utils/src/itest_helpers.rs
@@ -355,7 +355,7 @@ pub fn populate_canister_ids(
 
     // Index
     {
-        if let Some(IndexArg::Init(ref mut init_arg)) = sns_canister_init_payloads.index_ng {
+        if let Some(IndexArg::Init(init_arg)) = sns_canister_init_payloads.index_ng.as_mut() {
             init_arg.ledger_id = ledger_canister_id.0;
         }
     }

--- a/rs/sns/test_utils/src/itest_helpers.rs
+++ b/rs/sns/test_utils/src/itest_helpers.rs
@@ -352,6 +352,13 @@ pub fn populate_canister_ids(
         swap.nns_governance_canister_id = NNS_GOVERNANCE_CANISTER_ID.to_string();
         swap.icp_ledger_canister_id = ICP_LEDGER_CANISTER_ID.to_string();
     }
+
+    // Index
+    {
+        if let Some(IndexArg::Init(ref mut init_arg)) = sns_canister_init_payloads.index_ng {
+            init_arg.ledger_id = ledger_canister_id.0;
+        }
+    }
 }
 
 /// All the SNS canisters


### PR DESCRIPTION
## Root Cause

The SNS Index canister (`ic-icrc1-index-ng`) was initialized with the wrong `ledger_id` in the test helper `populate_canister_ids()` in `rs/sns/test_utils/src/itest_helpers.rs`.

`SnsTestsInitPayloadBuilder::new()` sets `index_ng.ledger_id` to `CanisterId::from_u64(0)` as a placeholder (which resolves to `rwlgt-iiaaa-aaaaa-aaaaa-cai`, the NNS Registry canister). The `populate_canister_ids()` function updates root, governance, ledger, and swap payloads with correct canister IDs, but **never updates `index_ng.ledger_id`**.

This caused the index canister to endlessly call `get_blocks` on the Registry canister (which does not have that method), creating a hot retry loop on every timer tick. With `--test-threads 7` running simultaneous local replicas, the resource contention caused legitimate ingress messages to exceed the 300-second timeout, producing either:
- Full test binary timeouts
- Individual test failures with "Ingress message did not finish executing in 300 seconds"

## Fix

Added an `// Index` section to `populate_canister_ids()` that sets `init_arg.ledger_id = ledger_canister_id.0`, matching the pattern used for root, governance, ledger, and swap.

## Verification

3 parallel runs all passed consistently (avg 180.8s, stddev 1.3s).

---
This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.