### PR TITLE
feat(governance): switch spawning and disbursement to locally computed maturity modulation

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -78,6 +78,9 @@ use crate::{
         sum_weighted_voting_power,
     },
     storage::{VOTING_POWER_SNAPSHOTS, with_voting_history_store, with_voting_history_store_mut},
+    timer_tasks::{
+        MATURITY_MODULATION_MAX_PERMYRIAD_MISSION_70, MATURITY_MODULATION_MIN_PERMYRIAD_MISSION_70,
+    },
 };
 use async_trait::async_trait;
 use candid::{Decode, Encode};
@@ -270,7 +273,9 @@ pub(crate) const LOG_PREFIX: &str = "[Governance] ";
 /// canisters). (Such rewards come in the form of minted ICP.)
 pub const NODE_PROVIDER_REWARD_PERIOD_SECONDS: u64 = ONE_MONTH_SECONDS;
 
-const VALID_MATURITY_MODULATION_BASIS_POINTS_RANGE: RangeInclusive<i32> = -500..=500;
+const VALID_MATURITY_MODULATION_BASIS_POINTS_RANGE: RangeInclusive<i32> =
+    MATURITY_MODULATION_MIN_PERMYRIAD_MISSION_70 as i32
+        ..=MATURITY_MODULATION_MAX_PERMYRIAD_MISSION_70 as i32;
 
 /// Maximum allowed number of Neurons' Fund participants that may participate in an SNS swap. Given
 /// the maximum number of SNS neurons per swap participant (a.k.a. neuron basket count), this
@@ -6432,8 +6437,11 @@ impl Governance {
         // Sanity check that the maturity modulation returned is within bounds.
         if !VALID_MATURITY_MODULATION_BASIS_POINTS_RANGE.contains(&maturity_modulation) {
             println!(
-                "{}Maturity modulation (in basis points) out-of-bounds. Should be in range [-500, 500], actually is: {}",
-                LOG_PREFIX, maturity_modulation
+                "{}Maturity modulation (in basis points) out-of-bounds. Should be in range [{}, {}], actually is: {}",
+                LOG_PREFIX,
+                MATURITY_MODULATION_MIN_PERMYRIAD_MISSION_70,
+                MATURITY_MODULATION_MAX_PERMYRIAD_MISSION_70,
+                maturity_modulation
             );
             return;
         }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6421,9 +6421,9 @@ impl Governance {
         let now_seconds = self.env.now();
         let maturity_modulation = match self
             .heap_data
-            .icp_xdr_rate_history
+            .maturity_modulation
             .as_ref()
-            .and_then(|h| h.current_maturity_modulation_permyriad)
+            .and_then(|m| m.current_value_permyriad)
         {
             None => return,
             Some(value) => value,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6419,7 +6419,11 @@ impl Governance {
         }
 
         let now_seconds = self.env.now();
-        let maturity_modulation = match self.heap_data.cached_daily_maturity_modulation_basis_points
+        let maturity_modulation = match self
+            .heap_data
+            .icp_xdr_rate_history
+            .as_ref()
+            .and_then(|h| h.current_maturity_modulation_permyriad)
         {
             None => return,
             Some(value) => value,

--- a/rs/nns/governance/src/governance/disburse_maturity.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity.rs
@@ -560,12 +560,15 @@ async fn try_finalize_maturity_disbursement(
 ) -> Result<(), FinalizeMaturityDisbursementError> {
     let (maturity_disbursement_finalization, now_seconds) = governance.with_borrow(|governance| {
         let now_seconds = governance.env.now();
+        let maturity_modulation = governance
+            .heap_data
+            .icp_xdr_rate_history
+            .as_ref()
+            .and_then(|h| h.current_maturity_modulation_permyriad);
         let maturity_disbursement_finalization = next_maturity_disbursement_to_finalize(
             &governance.neuron_store,
             &governance.heap_data.in_flight_commands,
-            governance
-                .heap_data
-                .cached_daily_maturity_modulation_basis_points,
+            maturity_modulation,
             now_seconds,
         );
         (maturity_disbursement_finalization, now_seconds)

--- a/rs/nns/governance/src/governance/disburse_maturity.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity.rs
@@ -562,9 +562,9 @@ async fn try_finalize_maturity_disbursement(
         let now_seconds = governance.env.now();
         let maturity_modulation = governance
             .heap_data
-            .icp_xdr_rate_history
+            .maturity_modulation
             .as_ref()
-            .and_then(|h| h.current_maturity_modulation_permyriad);
+            .and_then(|m| m.current_value_permyriad);
         let maturity_disbursement_finalization = next_maturity_disbursement_to_finalize(
             &governance.neuron_store,
             &governance.heap_data.in_flight_commands,

--- a/rs/nns/governance/src/governance/disburse_maturity_tests.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::{
     governance::Environment,
     neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
-    pb::v1::{IcpXdrRateHistory, Subaccount},
+    pb::v1::{MaturityModulation, Subaccount},
     test_utils::{MockEnvironment, MockRandomness},
 };
 
@@ -543,8 +543,8 @@ fn set_governance_for_test(
         Arc::new(MockCMC::default()),
         Box::new(MockRandomness::new()),
     );
-    governance.heap_data.icp_xdr_rate_history = Some(IcpXdrRateHistory {
-        current_maturity_modulation_permyriad: Some(maturity_modulation),
+    governance.heap_data.maturity_modulation = Some(MaturityModulation {
+        current_value_permyriad: Some(maturity_modulation),
         ..Default::default()
     });
     for neuron in neurons {
@@ -618,7 +618,7 @@ async fn test_finalize_maturity_disbursement_no_maturity_modulation() {
         DEFAULT_MATURITY_MODULATION_BASIS_POINTS,
     );
     TEST_GOVERNANCE.with_borrow_mut(|governance| {
-        governance.heap_data.icp_xdr_rate_history = None;
+        governance.heap_data.maturity_modulation = None;
     });
 
     // Step 2: Initiate the maturity disbursement and advance to disbursement time.

--- a/rs/nns/governance/src/governance/disburse_maturity_tests.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::{
     governance::Environment,
     neuron::{DissolveStateAndAge, Neuron, NeuronBuilder},
-    pb::v1::Subaccount,
+    pb::v1::{IcpXdrRateHistory, Subaccount},
     test_utils::{MockEnvironment, MockRandomness},
 };
 
@@ -537,15 +537,16 @@ fn set_governance_for_test(
     maturity_modulation: i32,
 ) {
     let mut governance = Governance::new(
-        GovernanceApi {
-            cached_daily_maturity_modulation_basis_points: Some(maturity_modulation),
-            ..Default::default()
-        },
+        GovernanceApi::default(),
         MOCK_ENVIRONMENT.with(|env| env.clone()),
         Arc::new(mock_ledger),
         Arc::new(MockCMC::default()),
         Box::new(MockRandomness::new()),
     );
+    governance.heap_data.icp_xdr_rate_history = Some(IcpXdrRateHistory {
+        current_maturity_modulation_permyriad: Some(maturity_modulation),
+        ..Default::default()
+    });
     for neuron in neurons {
         governance.neuron_store.add_neuron(neuron).unwrap();
     }
@@ -617,9 +618,7 @@ async fn test_finalize_maturity_disbursement_no_maturity_modulation() {
         DEFAULT_MATURITY_MODULATION_BASIS_POINTS,
     );
     TEST_GOVERNANCE.with_borrow_mut(|governance| {
-        governance
-            .heap_data
-            .cached_daily_maturity_modulation_basis_points = None;
+        governance.heap_data.icp_xdr_rate_history = None;
     });
 
     // Step 2: Initiate the maturity disbursement and advance to disbursement time.

--- a/rs/nns/governance/src/governance/tests/get_maturity_modulation.rs
+++ b/rs/nns/governance/src/governance/tests/get_maturity_modulation.rs
@@ -21,7 +21,11 @@ fn make_governance() -> Governance {
 }
 
 #[test]
-fn returns_none_when_unset() {
+fn defaults_to_zero_at_init() {
+    // `initialize_governance` seeds `heap_data.maturity_modulation` with a neutral 0-permyriad
+    // value at init so spawning and disbursement keep working immediately rather than early-
+    // returning while the XRC-fed price history task accumulates enough data to compute a real
+    // value. `updated_at` is left absent until the task produces a real measurement.
     let governance = make_governance();
 
     let response = governance.get_maturity_modulation();
@@ -29,7 +33,10 @@ fn returns_none_when_unset() {
     assert_eq!(
         response,
         GetMaturityModulationResponse {
-            maturity_modulation: None
+            maturity_modulation: Some(ApiMaturityModulation {
+                current_value_permyriad: Some(0),
+                updated_at_timestamp_seconds: None,
+            }),
         }
     );
 }

--- a/rs/nns/governance/src/governance/tla/mod.rs
+++ b/rs/nns/governance/src/governance/tla/mod.rs
@@ -164,7 +164,9 @@ pub fn get_tla_globals(p: &UnsafeSendPtr<Governance>) -> GlobalState {
     state.add(
         "cached_maturity_basis_points",
         gov.heap_data
-            .cached_daily_maturity_modulation_basis_points
+            .icp_xdr_rate_history
+            .as_ref()
+            .and_then(|h| h.current_maturity_modulation_permyriad)
             .unwrap_or(0)
             .to_tla_value(),
     );

--- a/rs/nns/governance/src/governance/tla/mod.rs
+++ b/rs/nns/governance/src/governance/tla/mod.rs
@@ -164,9 +164,9 @@ pub fn get_tla_globals(p: &UnsafeSendPtr<Governance>) -> GlobalState {
     state.add(
         "cached_maturity_basis_points",
         gov.heap_data
-            .icp_xdr_rate_history
+            .maturity_modulation
             .as_ref()
-            .and_then(|h| h.current_maturity_modulation_permyriad)
+            .and_then(|m| m.current_value_permyriad)
             .unwrap_or(0)
             .to_tla_value(),
     );

--- a/rs/nns/governance/src/heap_governance_data.rs
+++ b/rs/nns/governance/src/heap_governance_data.rs
@@ -221,7 +221,15 @@ pub fn initialize_governance(
         neuron_id_to_pre_clamp_dissolve_state: HashMap::new(),
         relaxed_eight_year_gang_bonus_migration_done: false,
         icp_price_history: None,
-        maturity_modulation: None,
+        // Default to a neutral 0 permyriad so that spawning and maturity disbursement keep
+        // working immediately after init, before `update_icp_xdr_rate_related_data` accumulates
+        // enough price history to compute a real one. `updated_at_days_since_epoch` is left
+        // `None` so the task treats this as "no prior measurement" rather than "already updated
+        // today".
+        maturity_modulation: Some(MaturityModulation {
+            current_value_permyriad: Some(0),
+            updated_at_days_since_epoch: None,
+        }),
     };
 
     // Finally, return the result.

--- a/rs/nns/governance/src/timer_tasks/mod.rs
+++ b/rs/nns/governance/src/timer_tasks/mod.rs
@@ -14,6 +14,10 @@ use std::sync::Arc;
 use unstake_maturity_of_dissolved_neurons::UnstakeMaturityOfDissolvedNeuronsTask;
 use update_icp_xdr_rate_related_data::UpdateIcpXdrRateRelatedData;
 
+pub(crate) use update_icp_xdr_rate_related_data::{
+    MATURITY_MODULATION_MAX_PERMYRIAD_MISSION_70, MATURITY_MODULATION_MIN_PERMYRIAD_MISSION_70,
+};
+
 use crate::{canister_state::GOVERNANCE, storage::VOTING_POWER_SNAPSHOTS};
 
 mod calculate_distributable_rewards;

--- a/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data_tests.rs
+++ b/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data_tests.rs
@@ -589,8 +589,15 @@ async fn test_execute_stores_rate_and_computes_modulation() {
                 }],
             }
         );
-        // The 365-day window is not yet full, so maturity modulation is not computed.
-        assert_eq!(gov.heap_data.maturity_modulation, None);
+        // The 365-day window is not yet full, so maturity modulation has not been recomputed
+        // from price history; it's still the neutral init default.
+        assert_eq!(
+            gov.heap_data.maturity_modulation,
+            Some(MaturityModulation {
+                current_value_permyriad: Some(0),
+                updated_at_days_since_epoch: None,
+            })
+        );
     });
 
     // With almost no history, the next delay should be short (backfill interval) so that
@@ -1012,7 +1019,14 @@ async fn test_execute_repeated_calls_accumulate_rates() {
                 ],
             }
         );
-        // The 365-day window is not yet full, so maturity modulation is not computed.
-        assert_eq!(gov.heap_data.maturity_modulation, None);
+        // The 365-day window is not yet full, so maturity modulation has not been recomputed
+        // from price history; it's still the neutral init default.
+        assert_eq!(
+            gov.heap_data.maturity_modulation,
+            Some(MaturityModulation {
+                current_value_permyriad: Some(0),
+                updated_at_days_since_epoch: None,
+            })
+        );
     });
 }

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -59,10 +59,10 @@ use ic_nns_governance::{
     pb::v1::{
         AddOrRemoveNodeProvider, Ballot, BallotInfo, CreateServiceNervousSystem, Empty,
         ExecuteNnsFunction, Followees, GovernanceError, IdealMatchedParticipationFunction,
-        InstallCode, KnownNeuron, KnownNeuronData, ManageNeuron, MonthlyNodeProviderRewards,
-        Motion, NetworkEconomics, NeuronType, NeuronsFundData, NeuronsFundEconomics,
-        NeuronsFundMatchedFundingCurveCoefficients, NeuronsFundParticipation, NeuronsFundSnapshot,
-        NnsFunction, NodeProvider, Proposal, ProposalData,
+        InstallCode, KnownNeuron, KnownNeuronData, ManageNeuron, MaturityModulation,
+        MonthlyNodeProviderRewards, Motion, NetworkEconomics, NeuronType, NeuronsFundData,
+        NeuronsFundEconomics, NeuronsFundMatchedFundingCurveCoefficients, NeuronsFundParticipation,
+        NeuronsFundSnapshot, NnsFunction, NodeProvider, Proposal, ProposalData,
         ProposalRewardStatus::{self, AcceptVotes, ReadyToSettle},
         ProposalStatus::{self, Rejected},
         RewardEvent, RewardNodeProvider, RewardNodeProviders,
@@ -5723,6 +5723,14 @@ fn run_periodic_tasks_often_enough_to_update_maturity_modulation(gov: &mut Gover
     for _i in 0..5 {
         gov.run_periodic_tasks().now_or_never();
     }
+    // The CMC periodic task populates `cached_daily_maturity_modulation_basis_points`, but the
+    // XRC-fed `maturity_modulation` field that spawning and disbursement now read isn't populated
+    // in unit tests (no XRC mock). Set it directly so consumers see a value consistent with
+    // the FakeDriver's 100 bp.
+    gov.heap_data.maturity_modulation = Some(MaturityModulation {
+        current_value_permyriad: Some(100),
+        updated_at_days_since_epoch: Some(gov.env.now() / ONE_DAY_SECONDS),
+    });
 }
 
 /// Checks that:

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,6 +11,10 @@ on the process that this file is part of, see
 
 ## Changed
 
+* Neuron spawning and maturity disbursement finalization now read the locally
+  computed Mission 70 maturity modulation (derived from the XRC-backed price
+  history) instead of the CMC-polled `cached_daily_maturity_modulation_basis_points`.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
## Why

The previous PR (#9847) added local maturity modulation computation. This PR switches the actual consumers (neuron spawning and maturity disbursement finalization) to use it.

https://dfinity.atlassian.net/browse/NNS1-4319

## What

- `maybe_spawn_neurons()` reads from `heap_data.maturity_modulation.current_value_permyriad` instead of `cached_daily_maturity_modulation_basis_points`
- `try_finalize_maturity_disbursement()` reads from the same new source
- TLA state export updated accordingly
- Tests updated to set up `MaturityModulation` instead of the old field

The old CMC-polled field is not yet removed; that happens in a follow-up PR.

### PR Chain
- ⬅️ Previous: #9847 (merged)
- ➡️ Next: #9877

## Testing

Existing `disburse_maturity` and `maybe_spawn_neurons` tests updated and passing.