### PR TITLE
feat: query method to list all canisters on a subnet

### DIFF
--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -29,6 +29,7 @@ rust_library(
         "//rs/query_stats",
         "//rs/registry/provisional_whitelist",
         "//rs/registry/resource_limits",
+        "//rs/registry/routing_table",
         "//rs/registry/subnet_type",
         "//rs/replicated_state",
         "//rs/state_layout",

--- a/rs/execution_environment/Cargo.toml
+++ b/rs/execution_environment/Cargo.toml
@@ -27,6 +27,7 @@ ic-metrics = { path = "../monitoring/metrics" }
 ic-query-stats = { path = "../query_stats" }
 ic-registry-provisional-whitelist = { path = "../registry/provisional_whitelist" }
 ic-registry-resource-limits = { path = "../registry/resource_limits" }
+ic-registry-routing-table = { path = "../registry/routing_table" }
 ic-registry-subnet-type = { path = "../registry/subnet_type" }
 ic-replicated-state = { path = "../replicated_state" }
 ic-state-layout = { path = "../state_layout" }
@@ -67,7 +68,6 @@ ic-crypto-sha2 = { path = "../crypto/sha2" }
 ic-crypto-test-utils-vetkd = { path = "../crypto/test_utils/vetkd" }
 ic-interfaces-state-manager-mocks = { path = "../interfaces/state_manager/mocks" }
 ic-nns-constants = { path = "../nns/constants" }
-ic-registry-routing-table = { path = "../registry/routing_table" }
 ic-registry-subnet-features = { path = "../registry/subnet_features" }
 ic-state-machine-tests = { path = "../state_machine_tests" }
 ic-test-utilities = { path = "../test_utilities" }

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -57,8 +57,8 @@ use tower::{Service, util::BoxCloneService};
 pub(crate) use self::query_scheduler::QueryScheduler;
 use crate::execution::common::validate_subnet_admin;
 use ic_management_canister_types_private::{
-    CanisterIdRange, CanisterIdRecord, FetchCanisterLogsRequest, ListCanistersResponse, Payload,
-    QueryMethod,
+    CanisterIdRange, CanisterIdRecord, EmptyBlob, FetchCanisterLogsRequest, ListCanistersResponse,
+    Payload, QueryMethod,
 };
 use ic_registry_routing_table::canister_id_into_u64;
 
@@ -180,31 +180,41 @@ impl InternalHttpQueryHandler {
         &self,
         state: &ReplicatedState,
         caller: &ic_types::PrincipalId,
+        payload: &[u8],
     ) -> Result<WasmResult, UserError> {
-        match state.get_own_subnet_admins() {
-            Some(ref admins) => validate_subnet_admin(admins, caller).map_err(UserError::from)?,
-            None => {
-                return Err(UserError::new(
-                    ErrorCode::CanisterRejectedMessage,
-                    "list_canisters is only available on subnets with subnet admins",
-                ));
-            }
-        }
-        let mut canisters: Vec<CanisterIdRange> = Vec::new();
-        for id in state.canister_states().keys() {
-            let id_u64 = canister_id_into_u64(*id);
-            match canisters.last_mut() {
-                Some(last) if canister_id_into_u64(last.end).checked_add(1) == Some(id_u64) => {
-                    last.end = *id;
+        match EmptyBlob::decode(payload) {
+            Err(err) => Err(err),
+            Ok(EmptyBlob) => {
+                match state.get_own_subnet_admins() {
+                    Some(ref admins) => {
+                        validate_subnet_admin(admins, caller).map_err(UserError::from)?
+                    }
+                    None => {
+                        return Err(UserError::new(
+                            ErrorCode::CanisterRejectedMessage,
+                            "list_canisters is only available on subnets with subnet admins",
+                        ));
+                    }
                 }
-                _ => canisters.push(CanisterIdRange {
-                    start: *id,
-                    end: *id,
-                }),
+                let mut canisters: Vec<CanisterIdRange> = Vec::new();
+                for id in state.canister_states().keys() {
+                    let id_u64 = canister_id_into_u64(*id);
+                    match canisters.last_mut() {
+                        Some(last)
+                            if canister_id_into_u64(last.end).checked_add(1) == Some(id_u64) =>
+                        {
+                            last.end = *id;
+                        }
+                        _ => canisters.push(CanisterIdRange {
+                            start: *id,
+                            end: *id,
+                        }),
+                    }
+                }
+                let response = ListCanistersResponse { canisters };
+                Ok(WasmResult::Reply(Encode!(&response).unwrap()))
             }
         }
-        let response = ListCanistersResponse { canisters };
-        Ok(WasmResult::Reply(Encode!(&response).unwrap()))
     }
 
     /// Handle a query of type `Query`.
@@ -272,7 +282,8 @@ impl InternalHttpQueryHandler {
                 Ok(QueryMethod::ListCanisters) => {
                     let since = Instant::now();
                     let caller = query.source();
-                    let result = self.list_canisters(state.get_ref(), &caller);
+                    let result =
+                        self.list_canisters(state.get_ref(), &caller, &query.method_payload);
                     self.metrics.observe_subnet_query_message(
                         QueryMethod::ListCanisters,
                         since.elapsed().as_secs_f64(),

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -176,6 +176,37 @@ impl InternalHttpQueryHandler {
         self.local_query_execution_stats.set_epoch(epoch);
     }
 
+    fn list_canisters(
+        &self,
+        state: &ReplicatedState,
+        caller: &ic_types::PrincipalId,
+    ) -> Result<WasmResult, UserError> {
+        match state.get_own_subnet_admins() {
+            Some(ref admins) => validate_subnet_admin(admins, caller).map_err(UserError::from)?,
+            None => {
+                return Err(UserError::new(
+                    ErrorCode::CanisterRejectedMessage,
+                    "list_canisters is only available on subnets with subnet admins",
+                ));
+            }
+        }
+        let mut canisters: Vec<CanisterIdRange> = Vec::new();
+        for id in state.canister_states().keys() {
+            let id_u64 = canister_id_into_u64(*id);
+            match canisters.last_mut() {
+                Some(last) if canister_id_into_u64(last.end).checked_add(1) == Some(id_u64) => {
+                    last.end = *id;
+                }
+                _ => canisters.push(CanisterIdRange {
+                    start: *id,
+                    end: *id,
+                }),
+            }
+        }
+        let response = ListCanistersResponse { canisters };
+        Ok(WasmResult::Reply(Encode!(&response).unwrap()))
+    }
+
     /// Handle a query of type `Query`.
     pub fn query(
         &self,
@@ -241,35 +272,7 @@ impl InternalHttpQueryHandler {
                 Ok(QueryMethod::ListCanisters) => {
                     let since = Instant::now();
                     let caller = query.source();
-                    match state.get_ref().get_own_subnet_admins() {
-                        Some(ref admins) => {
-                            validate_subnet_admin(admins, &caller).map_err(UserError::from)?
-                        }
-                        None => {
-                            return Err(UserError::new(
-                                ErrorCode::CanisterRejectedMessage,
-                                "list_canisters is only available on subnets with subnet admins",
-                            ));
-                        }
-                    }
-                    let mut canisters: Vec<CanisterIdRange> = Vec::new();
-                    for id in state.get_ref().canister_states().keys() {
-                        let id_u64 = canister_id_into_u64(*id);
-                        match canisters.last_mut() {
-                            Some(last)
-                                if canister_id_into_u64(last.end).checked_add(1)
-                                    == Some(id_u64) =>
-                            {
-                                last.end = *id;
-                            }
-                            _ => canisters.push(CanisterIdRange {
-                                start: *id,
-                                end: *id,
-                            }),
-                        }
-                    }
-                    let response = ListCanistersResponse { canisters };
-                    let result = Ok(WasmResult::Reply(Encode!(&response).unwrap()));
+                    let result = self.list_canisters(state.get_ref(), &caller);
                     self.metrics.observe_subnet_query_message(
                         QueryMethod::ListCanisters,
                         since.elapsed().as_secs_f64(),

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -55,9 +55,12 @@ use tokio::sync::oneshot;
 use tower::{Service, util::BoxCloneService};
 
 pub(crate) use self::query_scheduler::QueryScheduler;
+use crate::execution::common::validate_subnet_admin;
 use ic_management_canister_types_private::{
-    CanisterIdRecord, FetchCanisterLogsRequest, Payload, QueryMethod,
+    CanisterIdRange, CanisterIdRecord, FetchCanisterLogsRequest, ListCanistersResponse, Payload,
+    QueryMethod,
 };
+use ic_registry_routing_table::canister_id_into_u64;
 
 pub struct DataCertificateWithDelegationMetadata {
     pub data_certificate: Vec<u8>,
@@ -230,6 +233,45 @@ impl InternalHttpQueryHandler {
                     let result = Ok(WasmResult::Reply(Encode!(&response).unwrap()));
                     self.metrics.observe_subnet_query_message(
                         QueryMethod::CanisterStatus,
+                        since.elapsed().as_secs_f64(),
+                        &result,
+                    );
+                    return result;
+                }
+                Ok(QueryMethod::ListCanisters) => {
+                    let since = Instant::now();
+                    let caller = query.source();
+                    match state.get_ref().get_own_subnet_admins() {
+                        Some(ref admins) => {
+                            validate_subnet_admin(admins, &caller).map_err(UserError::from)?
+                        }
+                        None => {
+                            return Err(UserError::new(
+                                ErrorCode::CanisterRejectedMessage,
+                                "list_canisters is only available on subnets with subnet admins",
+                            ));
+                        }
+                    }
+                    let mut canisters: Vec<CanisterIdRange> = Vec::new();
+                    for id in state.get_ref().canister_states().keys() {
+                        let id_u64 = canister_id_into_u64(*id);
+                        match canisters.last_mut() {
+                            Some(last)
+                                if canister_id_into_u64(last.end).checked_add(1)
+                                    == Some(id_u64) =>
+                            {
+                                last.end = *id;
+                            }
+                            _ => canisters.push(CanisterIdRange {
+                                start: *id,
+                                end: *id,
+                            }),
+                        }
+                    }
+                    let response = ListCanistersResponse { canisters };
+                    let result = Ok(WasmResult::Reply(Encode!(&response).unwrap()));
+                    self.metrics.observe_subnet_query_message(
+                        QueryMethod::ListCanisters,
                         since.elapsed().as_secs_f64(),
                         &result,
                     );

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -1,16 +1,19 @@
 use crate::InternalHttpQueryHandler;
-use ic_base_types::{CanisterId, NumSeconds};
+use candid::Decode;
+use ic_base_types::{CanisterId, NumSeconds, PrincipalId};
 use ic_config::execution_environment::INSTRUCTION_OVERHEAD_PER_QUERY_CALL;
 use ic_error_types::{ErrorCode, UserError};
+use ic_management_canister_types_private::{CanisterIdRange, ListCanistersResponse};
 use ic_test_utilities::universal_canister::{call_args, wasm};
 use ic_test_utilities_execution_environment::{ExecutionTest, ExecutionTestBuilder};
+use ic_test_utilities_state::CanisterStateBuilder;
 use ic_test_utilities_types::ids::user_test_id;
 use ic_types::{
     NumInstructions,
     ingress::WasmResult,
     messages::{Query, QuerySource},
 };
-use ic_types_cycles::Cycles;
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use more_asserts::{assert_gt, assert_lt};
 use std::sync::Arc;
 
@@ -1282,5 +1285,73 @@ fn query_call_exceeds_instructions_limit() {
             &format!(
                 "Error from Canister {canister}: Canister exceeded the limit of {instructions_limit} instructions for single message execution."
             )
+    );
+}
+
+// Subnet with a Normal cost schedule has no subnet admins concept; any caller
+// must be rejected with CanisterRejectedMessage.
+#[test]
+fn test_list_canisters_no_subnet_admins() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let err = test
+        .non_replicated_query(CanisterId::ic_00(), "list_canisters", vec![])
+        .unwrap_err();
+    assert_eq!(err.code(), ErrorCode::CanisterRejectedMessage);
+}
+
+// Subnet has admins configured, but the caller is not one of them.
+#[test]
+fn test_list_canisters_non_admin_rejected() {
+    let admin: PrincipalId = user_test_id(1).get();
+    let non_admin = user_test_id(2);
+    let mut test = ExecutionTestBuilder::new()
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![admin])
+        .build();
+    test.set_user_id(non_admin);
+    let err = test
+        .non_replicated_query(CanisterId::ic_00(), "list_canisters", vec![])
+        .unwrap_err();
+    assert_eq!(err.code(), ErrorCode::InvalidSubnetAdmin);
+}
+
+// Admin caller receives correct ranges: two consecutive IDs coalesced into one
+// range, a gap, then a third canister as its own range.
+#[test]
+fn test_list_canisters_success() {
+    let admin: PrincipalId = user_test_id(1).get();
+    let mut test = ExecutionTestBuilder::new()
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![admin])
+        .build();
+    test.set_user_id(user_test_id(1));
+
+    // Insert three canisters: IDs 5 and 6 are consecutive (should coalesce),
+    // then ID 10 after a gap (its own range).
+    for raw_id in [5u64, 6, 10] {
+        test.state_mut().put_canister_state(
+            CanisterStateBuilder::new()
+                .with_canister_id(CanisterId::from(raw_id))
+                .build(),
+        );
+    }
+
+    let reply = test
+        .non_replicated_query(CanisterId::ic_00(), "list_canisters", vec![])
+        .unwrap();
+    let response = Decode!(&reply.bytes(), ListCanistersResponse).unwrap();
+
+    assert_eq!(
+        response.canisters,
+        vec![
+            CanisterIdRange {
+                start: CanisterId::from(5u64),
+                end: CanisterId::from(6u64),
+            },
+            CanisterIdRange {
+                start: CanisterId::from(10u64),
+                end: CanisterId::from(10u64),
+            },
+        ]
     );
 }

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -1315,8 +1315,8 @@ fn test_list_canisters_non_admin_rejected() {
     assert_eq!(err.code(), ErrorCode::InvalidSubnetAdmin);
 }
 
-// Admin caller receives correct ranges: two consecutive IDs coalesced into one
-// range, a gap, then a third canister as its own range.
+// Admin caller receives correct ranges: 5-7 coalesced, gap, 10 alone, gap,
+// 12-15 coalesced.
 #[test]
 fn test_list_canisters_success() {
     let admin: PrincipalId = user_test_id(1).get();
@@ -1326,9 +1326,9 @@ fn test_list_canisters_success() {
         .build();
     test.set_user_id(user_test_id(1));
 
-    // Insert three canisters: IDs 5 and 6 are consecutive (should coalesce),
-    // then ID 10 after a gap (its own range).
-    for raw_id in [5_u64, 6, 10] {
+    // IDs 5, 6, 7 are consecutive (coalesce into [5,7]), ID 10 is isolated
+    // ([10,10]), and IDs 12, 13, 14, 15 are consecutive (coalesce into [12,15]).
+    for raw_id in [5_u64, 6, 7, 10, 12, 13, 14, 15] {
         test.state_mut().put_canister_state(
             CanisterStateBuilder::new()
                 .with_canister_id(CanisterId::from(raw_id))
@@ -1346,11 +1346,15 @@ fn test_list_canisters_success() {
         vec![
             CanisterIdRange {
                 start: CanisterId::from(5_u64),
-                end: CanisterId::from(6_u64),
+                end: CanisterId::from(7_u64),
             },
             CanisterIdRange {
                 start: CanisterId::from(10_u64),
                 end: CanisterId::from(10_u64),
+            },
+            CanisterIdRange {
+                start: CanisterId::from(12_u64),
+                end: CanisterId::from(15_u64),
             },
         ]
     );

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -1,5 +1,5 @@
 use crate::InternalHttpQueryHandler;
-use candid::Decode;
+use candid::{Decode, Encode};
 use ic_base_types::{CanisterId, NumSeconds, PrincipalId};
 use ic_config::execution_environment::INSTRUCTION_OVERHEAD_PER_QUERY_CALL;
 use ic_error_types::{ErrorCode, UserError};
@@ -1294,7 +1294,7 @@ fn query_call_exceeds_instructions_limit() {
 fn test_list_canisters_no_subnet_admins() {
     let mut test = ExecutionTestBuilder::new().build();
     let err = test
-        .non_replicated_query(CanisterId::ic_00(), "list_canisters", vec![])
+        .non_replicated_query(CanisterId::ic_00(), "list_canisters", Encode!().unwrap())
         .unwrap_err();
     assert_eq!(err.code(), ErrorCode::CanisterRejectedMessage);
 }
@@ -1310,7 +1310,7 @@ fn test_list_canisters_non_admin_rejected() {
         .build();
     test.set_user_id(non_admin);
     let err = test
-        .non_replicated_query(CanisterId::ic_00(), "list_canisters", vec![])
+        .non_replicated_query(CanisterId::ic_00(), "list_canisters", Encode!().unwrap())
         .unwrap_err();
     assert_eq!(err.code(), ErrorCode::InvalidSubnetAdmin);
 }
@@ -1337,7 +1337,7 @@ fn test_list_canisters_success() {
     }
 
     let reply = test
-        .non_replicated_query(CanisterId::ic_00(), "list_canisters", vec![])
+        .non_replicated_query(CanisterId::ic_00(), "list_canisters", Encode!().unwrap())
         .unwrap();
     let response = Decode!(&reply.bytes(), ListCanistersResponse).unwrap();
 

--- a/rs/execution_environment/src/query_handler/tests.rs
+++ b/rs/execution_environment/src/query_handler/tests.rs
@@ -1328,7 +1328,7 @@ fn test_list_canisters_success() {
 
     // Insert three canisters: IDs 5 and 6 are consecutive (should coalesce),
     // then ID 10 after a gap (its own range).
-    for raw_id in [5u64, 6, 10] {
+    for raw_id in [5_u64, 6, 10] {
         test.state_mut().put_canister_state(
             CanisterStateBuilder::new()
                 .with_canister_id(CanisterId::from(raw_id))
@@ -1345,12 +1345,12 @@ fn test_list_canisters_success() {
         response.canisters,
         vec![
             CanisterIdRange {
-                start: CanisterId::from(5u64),
-                end: CanisterId::from(6u64),
+                start: CanisterId::from(5_u64),
+                end: CanisterId::from(6_u64),
             },
             CanisterIdRange {
-                start: CanisterId::from(10u64),
-                end: CanisterId::from(10u64),
+                start: CanisterId::from(10_u64),
+                end: CanisterId::from(10_u64),
             },
         ]
     );

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -3562,12 +3562,37 @@ impl Payload<'_> for BitcoinGetSuccessorsArgs {}
 impl Payload<'_> for BitcoinGetSuccessorsResponse {}
 impl Payload<'_> for BitcoinSendTransactionInternalArgs {}
 
+/// A closed range of canister IDs, both endpoints inclusive.
+/// ```text
+/// record {
+///   start : principal;
+///   end   : principal;
+/// }
+/// ```
+#[derive(Clone, Debug, PartialEq, CandidType, Deserialize)]
+pub struct CanisterIdRange {
+    pub start: CanisterId,
+    pub end: CanisterId,
+}
+
+/// Response type for the `list_canisters` query method.
+/// ```text
+/// record {
+///   canisters : vec record { start : principal; end : principal };
+/// }
+/// ```
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct ListCanistersResponse {
+    pub canisters: Vec<CanisterIdRange>,
+}
+
 /// Query methods exported by the management canister.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Display, EnumIter, EnumString)]
 #[strum(serialize_all = "snake_case")]
 pub enum QueryMethod {
     FetchCanisterLogs,
     CanisterStatus,
+    ListCanisters,
 }
 
 /// `CandidType` for `SubnetInfoArgs`

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -3586,6 +3586,7 @@ pub struct ListCanistersResponse {
     pub canisters: Vec<CanisterIdRange>,
 }
 
+impl Payload<'_> for ListCanistersResponse {}
 /// Query methods exported by the management canister.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Display, EnumIter, EnumString)]
 #[strum(serialize_all = "snake_case")]

--- a/rs/types/management_canister_types/tests/candid_equality.rs
+++ b/rs/types/management_canister_types/tests/candid_equality.rs
@@ -34,6 +34,7 @@ type ListCanisterSnapshotsArgs = CanisterIdRecord;
 type ListCanisterSnapshotsResult = Vec<CanisterSnapshotResponse>;
 type FetchCanisterLogsArgs = FetchCanisterLogsRequest;
 type FetchCanisterLogsResult = FetchCanisterLogsResponse;
+type ListCanistersResult = ListCanistersResponse;
 
 #[candid_method(update)]
 fn create_canister(_: CreateCanisterArgs) -> CreateCanisterResult {
@@ -184,6 +185,11 @@ fn delete_canister_snapshot(_: DeleteCanisterSnapshotArgs) {
 
 #[candid_method(query)]
 fn fetch_canister_logs(_: FetchCanisterLogsArgs) -> FetchCanisterLogsResult {
+    unreachable!()
+}
+
+#[candid_method(query)]
+fn list_canisters() -> ListCanistersResult {
     unreachable!()
 }
 

--- a/rs/types/management_canister_types/tests/ic.did
+++ b/rs/types/management_canister_types/tests/ic.did
@@ -506,6 +506,15 @@ type delete_canister_snapshot_args = record {
   snapshot_id : snapshot_id;
 };
 
+type canister_id_range = record {
+    start : principal;
+    end : principal;
+};
+
+type list_canisters_result = record {
+    canisters : vec canister_id_range;
+};
+
 type fetch_canister_logs_args = record {
     canister_id : canister_id;
     filter: opt variant {
@@ -698,4 +707,7 @@ service ic : {
 
     // canister logging
     fetch_canister_logs : (fetch_canister_logs_args) -> (fetch_canister_logs_result) query;
+
+    // list canisters
+    list_canisters : () -> (list_canisters_result) query;
 };


### PR DESCRIPTION
This PR implements a query method that subnets admins can use to list all canisters on their subnet. The method returns the canister IDs of existing canisters (omitting deleted canisters) encoded as a list of canister IDs pairs with all canister IDs inside those pairs existing on the subnet. In the future, pagination could be added in a backward-compatible way by extending the input and output types in Candid.