### PR TITLE
fix: registry setup for cloud engines in PocketIC

### DIFF
--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -3498,6 +3498,26 @@ fn default_cost_schedule_on_cloud_engine() {
 }
 
 #[test]
+fn cloud_engine_with_registry() {
+    // Regression test: creating a cloud engine subnet with the registry ICP feature enabled
+    // must not trigger the registry invariant check failure
+    // "is a cloud engine subnet but some nodes do not have reward type 4".
+    let icp_features = IcpFeatures {
+        registry: Some(IcpFeaturesConfig::DefaultConfig),
+        ..Default::default()
+    };
+    let subnet_spec = SubnetSpec::default().with_cost_schedule(CanisterCyclesCostSchedule::Free);
+    let config = ExtendedSubnetConfigSet {
+        nns: Some(SubnetSpec::default()),
+        cloud_engine: vec![subnet_spec],
+        ..Default::default()
+    };
+    let _pic = PocketIcBuilder::new_with_config(config)
+        .with_icp_features(icp_features)
+        .build();
+}
+
+#[test]
 fn cloud_engine_default_effective_canister_id() {
     // Create a PocketIC instance with a single (cloud) engine and NNS subnet.
     let admin = Principal::anonymous();

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -78,7 +78,7 @@ use ic_metrics::MetricsRegistry;
 use ic_protobuf::{
     registry::{
         crypto::v1::{ChainKeyEnabledSubnetList, PublicKey as PublicKeyProto, X509PublicKeyCert},
-        node::v1::{ConnectionEndpoint, NodeRecord},
+        node::v1::{ConnectionEndpoint, NodeRecord, NodeRewardType},
         node_rewards::v2::NodeRewardsTable,
         provisional_whitelist::v1::ProvisionalWhitelist as PbProvisionalWhitelist,
         replica_version::v1::{BlessedReplicaVersions, ReplicaVersionRecord},
@@ -398,7 +398,8 @@ fn add_subnet_local_registry_records(
             chip_id: None,
             public_ipv4_config: None,
             domain: None,
-            node_reward_type: None,
+            node_reward_type: (subnet_type == SubnetType::CloudEngine)
+                .then_some(NodeRewardType::Type4 as i32),
             ssh_node_state_write_access: vec![],
         };
         registry_data_provider


### PR DESCRIPTION
This PR fixes the registry setup for cloud engines in PocketIC so that the registry canister can be deployed and initialized with PocketIC registry without violating registry invariants.