### PR TITLE
fix(node-rewards): exclude cloud engine subnets from metrics collection

### DIFF
--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -124,7 +124,7 @@ impl NodeRewardsCanister {
         });
         let registry_querier = RegistryQuerier::new(registry_client.clone());
         let version = registry_client.get_latest_version();
-        let subnets_list = registry_querier.subnets_list(version)?;
+        let subnets_list = registry_querier.subnets_for_metrics(version)?;
         let last_day_synced: NaiveDate =
             metrics_manager.update_subnets_metrics(subnets_list).await?;
         canister.with_borrow(|canister| {

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -20,6 +20,7 @@ use ic_node_rewards_canister_api::providers_rewards::{
 use ic_protobuf::registry::dc::v1::DataCenterRecord;
 use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
 use ic_protobuf::registry::node_rewards::v2::NodeRewardsTable;
+use ic_protobuf::registry::subnet::v1::SubnetType;
 use ic_registry_canister_client::{CanisterRegistryClient, get_decoded_value};
 use ic_registry_keys::{
     DATA_CENTER_KEY_PREFIX, NODE_OPERATOR_RECORD_KEY_PREFIX, NODE_REWARDS_TABLE_KEY,
@@ -124,7 +125,22 @@ impl NodeRewardsCanister {
         });
         let registry_querier = RegistryQuerier::new(registry_client.clone());
         let version = registry_client.get_latest_version();
-        let subnets_list = registry_querier.subnets_for_metrics(version)?;
+        let subnets_list: Vec<SubnetId> = registry_querier
+            .subnets_list(version)?
+            .into_iter()
+            .filter(|subnet_id| {
+                match registry_querier.get_subnet_record(*subnet_id, version) {
+                    Ok(Some(record)) if record.subnet_type() == SubnetType::CloudEngine => {
+                        ic_cdk::println!(
+                            "Excluding cloud engine subnet {} from metrics collection",
+                            subnet_id,
+                        );
+                        false
+                    }
+                    _ => true,
+                }
+            })
+            .collect();
         let last_day_synced: NaiveDate =
             metrics_manager.update_subnets_metrics(subnets_list).await?;
         canister.with_borrow(|canister| {

--- a/rs/node_rewards/canister/src/canister/mod.rs
+++ b/rs/node_rewards/canister/src/canister/mod.rs
@@ -128,8 +128,8 @@ impl NodeRewardsCanister {
         let subnets_list: Vec<SubnetId> = registry_querier
             .subnets_list(version)?
             .into_iter()
-            .filter(|subnet_id| {
-                match registry_querier.get_subnet_record(*subnet_id, version) {
+            .filter(
+                |subnet_id| match registry_querier.get_subnet_record(*subnet_id, version) {
                     Ok(Some(record)) if record.subnet_type() == SubnetType::CloudEngine => {
                         ic_cdk::println!(
                             "Excluding cloud engine subnet {} from metrics collection",
@@ -138,8 +138,8 @@ impl NodeRewardsCanister {
                         false
                     }
                     _ => true,
-                }
-            })
+                },
+            )
             .collect();
         let last_day_synced: NaiveDate =
             metrics_manager.update_subnets_metrics(subnets_list).await?;

--- a/rs/node_rewards/canister/src/registry_querier.rs
+++ b/rs/node_rewards/canister/src/registry_querier.rs
@@ -6,7 +6,7 @@ use ic_protobuf::registry::dc::v1::DataCenterRecord;
 use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
 use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
 use ic_protobuf::registry::node_rewards::v2::NodeRewardsTable;
-use ic_protobuf::registry::subnet::v1::{SubnetListRecord, SubnetRecord, SubnetType};
+use ic_protobuf::registry::subnet::v1::{SubnetListRecord, SubnetRecord};
 use ic_registry_canister_client::CanisterRegistryClient;
 use ic_registry_keys::{
     DATA_CENTER_KEY_PREFIX, NODE_OPERATOR_RECORD_KEY_PREFIX, NODE_RECORD_KEY_PREFIX,
@@ -63,13 +63,13 @@ impl RegistryQuerier {
             .collect()
     }
 
-    /// Returns the [`SubnetType`] for the given subnet at the specified registry version,
-    /// or `None` if the subnet record does not exist.
-    fn subnet_type(
+    /// Returns the [`SubnetRecord`] for the given subnet at the specified registry version,
+    /// or `None` if the record does not exist.
+    pub fn get_subnet_record(
         &self,
         subnet_id: SubnetId,
         version: RegistryVersion,
-    ) -> Result<Option<SubnetType>, String> {
+    ) -> Result<Option<SubnetRecord>, String> {
         let key = make_subnet_record_key(subnet_id);
         let record_bytes = self
             .registry_client
@@ -80,37 +80,10 @@ impl RegistryQuerier {
             Some(bytes) => {
                 let record = SubnetRecord::decode(bytes.as_slice())
                     .map_err(|e| format!("Failed to decode SubnetRecord for {subnet_id}: {e:?}"))?;
-                Ok(Some(record.subnet_type()))
+                Ok(Some(record))
             }
             None => Ok(None),
         }
-    }
-
-    /// Returns the list of subnets eligible for metrics collection.
-    ///
-    /// Cloud engine subnets are excluded because their management canister
-    /// does not expose `node_metrics_history`, which causes the entire
-    /// metrics sync to fail.
-    pub fn subnets_for_metrics(
-        &self,
-        version: RegistryVersion,
-    ) -> Result<Vec<SubnetId>, String> {
-        let all_subnets = self.subnets_list(version)?;
-        let mut result = Vec::with_capacity(all_subnets.len());
-
-        for subnet_id in all_subnets {
-            match self.subnet_type(subnet_id, version)? {
-                Some(SubnetType::CloudEngine) => {
-                    ic_cdk::println!(
-                        "Excluding cloud engine subnet {} from metrics collection",
-                        subnet_id,
-                    );
-                }
-                _ => result.push(subnet_id),
-            }
-        }
-
-        Ok(result)
     }
 
     /// Returns the NodeRewardsTable at the specified version.

--- a/rs/node_rewards/canister/src/registry_querier.rs
+++ b/rs/node_rewards/canister/src/registry_querier.rs
@@ -6,11 +6,11 @@ use ic_protobuf::registry::dc::v1::DataCenterRecord;
 use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
 use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
 use ic_protobuf::registry::node_rewards::v2::NodeRewardsTable;
-use ic_protobuf::registry::subnet::v1::SubnetListRecord;
+use ic_protobuf::registry::subnet::v1::{SubnetListRecord, SubnetRecord, SubnetType};
 use ic_registry_canister_client::CanisterRegistryClient;
 use ic_registry_keys::{
     DATA_CENTER_KEY_PREFIX, NODE_OPERATOR_RECORD_KEY_PREFIX, NODE_RECORD_KEY_PREFIX,
-    NODE_REWARDS_TABLE_KEY, make_subnet_list_record_key,
+    NODE_REWARDS_TABLE_KEY, make_subnet_list_record_key, make_subnet_record_key,
 };
 use ic_types::registry::RegistryClientError;
 use rewards_calculation::types::{RewardableNode, UnixTsNanos};
@@ -61,6 +61,56 @@ impl RegistryQuerier {
                 Ok(SubnetId::from(principal))
             })
             .collect()
+    }
+
+    /// Returns the [`SubnetType`] for the given subnet at the specified registry version,
+    /// or `None` if the subnet record does not exist.
+    fn subnet_type(
+        &self,
+        subnet_id: SubnetId,
+        version: RegistryVersion,
+    ) -> Result<Option<SubnetType>, String> {
+        let key = make_subnet_record_key(subnet_id);
+        let record_bytes = self
+            .registry_client
+            .get_value(key.as_str(), version)
+            .map_err(|e| format!("Failed to get SubnetRecord for {subnet_id}: {e:?}"))?;
+
+        match record_bytes {
+            Some(bytes) => {
+                let record = SubnetRecord::decode(bytes.as_slice())
+                    .map_err(|e| format!("Failed to decode SubnetRecord for {subnet_id}: {e:?}"))?;
+                Ok(Some(record.subnet_type()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the list of subnets eligible for metrics collection.
+    ///
+    /// Cloud engine subnets are excluded because their management canister
+    /// does not expose `node_metrics_history`, which causes the entire
+    /// metrics sync to fail.
+    pub fn subnets_for_metrics(
+        &self,
+        version: RegistryVersion,
+    ) -> Result<Vec<SubnetId>, String> {
+        let all_subnets = self.subnets_list(version)?;
+        let mut result = Vec::with_capacity(all_subnets.len());
+
+        for subnet_id in all_subnets {
+            match self.subnet_type(subnet_id, version)? {
+                Some(SubnetType::CloudEngine) => {
+                    ic_cdk::println!(
+                        "Excluding cloud engine subnet {} from metrics collection",
+                        subnet_id,
+                    );
+                }
+                _ => result.push(subnet_id),
+            }
+        }
+
+        Ok(result)
     }
 
     /// Returns the NodeRewardsTable at the specified version.

--- a/rs/node_rewards/canister/src/registry_querier/tests.rs
+++ b/rs/node_rewards/canister/src/registry_querier/tests.rs
@@ -309,43 +309,20 @@ fn test_node_re_registered_after_deletion() {
 }
 
 #[test]
-fn test_subnets_for_metrics_excludes_cloud_engine() {
+fn test_get_subnet_record_returns_correct_type() {
     let client = client_for_tests();
     let app_subnet: SubnetId = PrincipalId::new_subnet_test_id(10).into();
-    let system_subnet: SubnetId = PrincipalId::new_subnet_test_id(11).into();
     let cloud_engine_subnet: SubnetId = PrincipalId::new_subnet_test_id(12).into();
+    let missing_subnet: SubnetId = PrincipalId::new_subnet_test_id(99).into();
 
     let version = 39680u64;
     let date = "2025-07-17";
-
-    let subnets_record = SubnetListRecord {
-        subnets: vec![
-            app_subnet.get().to_vec(),
-            system_subnet.get().to_vec(),
-            cloud_engine_subnet.get().to_vec(),
-        ],
-    };
-    add_record_helper(
-        &make_subnet_list_record_key(),
-        version,
-        Some(subnets_record),
-        date,
-    );
 
     add_record_helper(
         &make_subnet_record_key(app_subnet),
         version,
         Some(SubnetRecord {
             subnet_type: SubnetType::Application as i32,
-            ..SubnetRecord::default()
-        }),
-        date,
-    );
-    add_record_helper(
-        &make_subnet_record_key(system_subnet),
-        version,
-        Some(SubnetRecord {
-            subnet_type: SubnetType::System as i32,
             ..SubnetRecord::default()
         }),
         date,
@@ -360,11 +337,20 @@ fn test_subnets_for_metrics_excludes_cloud_engine() {
         date,
     );
 
-    let metrics_subnets = client.subnets_for_metrics(version.into()).unwrap();
+    let app_record = client
+        .get_subnet_record(app_subnet, version.into())
+        .unwrap()
+        .unwrap();
+    assert_eq!(app_record.subnet_type(), SubnetType::Application);
 
-    assert_eq!(metrics_subnets, vec![app_subnet, system_subnet]);
-    assert!(
-        !metrics_subnets.contains(&cloud_engine_subnet),
-        "Cloud engine subnet should be excluded from metrics collection"
-    );
+    let cloud_record = client
+        .get_subnet_record(cloud_engine_subnet, version.into())
+        .unwrap()
+        .unwrap();
+    assert_eq!(cloud_record.subnet_type(), SubnetType::CloudEngine);
+
+    let missing = client
+        .get_subnet_record(missing_subnet, version.into())
+        .unwrap();
+    assert!(missing.is_none());
 }

--- a/rs/node_rewards/canister/src/registry_querier/tests.rs
+++ b/rs/node_rewards/canister/src/registry_querier/tests.rs
@@ -6,14 +6,14 @@ use ic_protobuf::registry::dc::v1::DataCenterRecord;
 use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
 use ic_protobuf::registry::node_operator::v1::NodeOperatorRecord;
 use ic_protobuf::registry::node_rewards::v2::{NodeRewardRate, NodeRewardRates, NodeRewardsTable};
-use ic_protobuf::registry::subnet::v1::SubnetListRecord;
+use ic_protobuf::registry::subnet::v1::{SubnetListRecord, SubnetRecord, SubnetType};
 use ic_registry_canister_client::{
     RegistryDataStableMemory, StableCanisterRegistryClient, StorableRegistryKey,
     StorableRegistryValue, test_registry_data_stable_memory_impl,
 };
 use ic_registry_keys::{
     DATA_CENTER_KEY_PREFIX, NODE_OPERATOR_RECORD_KEY_PREFIX, NODE_RECORD_KEY_PREFIX,
-    NODE_REWARDS_TABLE_KEY, make_subnet_list_record_key,
+    NODE_REWARDS_TABLE_KEY, make_subnet_list_record_key, make_subnet_record_key,
 };
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
@@ -306,4 +306,65 @@ fn test_node_re_registered_after_deletion() {
             );
         }
     }
+}
+
+#[test]
+fn test_subnets_for_metrics_excludes_cloud_engine() {
+    let client = client_for_tests();
+    let app_subnet: SubnetId = PrincipalId::new_subnet_test_id(10).into();
+    let system_subnet: SubnetId = PrincipalId::new_subnet_test_id(11).into();
+    let cloud_engine_subnet: SubnetId = PrincipalId::new_subnet_test_id(12).into();
+
+    let version = 39680u64;
+    let date = "2025-07-17";
+
+    let subnets_record = SubnetListRecord {
+        subnets: vec![
+            app_subnet.get().to_vec(),
+            system_subnet.get().to_vec(),
+            cloud_engine_subnet.get().to_vec(),
+        ],
+    };
+    add_record_helper(
+        &make_subnet_list_record_key(),
+        version,
+        Some(subnets_record),
+        date,
+    );
+
+    add_record_helper(
+        &make_subnet_record_key(app_subnet),
+        version,
+        Some(SubnetRecord {
+            subnet_type: SubnetType::Application as i32,
+            ..SubnetRecord::default()
+        }),
+        date,
+    );
+    add_record_helper(
+        &make_subnet_record_key(system_subnet),
+        version,
+        Some(SubnetRecord {
+            subnet_type: SubnetType::System as i32,
+            ..SubnetRecord::default()
+        }),
+        date,
+    );
+    add_record_helper(
+        &make_subnet_record_key(cloud_engine_subnet),
+        version,
+        Some(SubnetRecord {
+            subnet_type: SubnetType::CloudEngine as i32,
+            ..SubnetRecord::default()
+        }),
+        date,
+    );
+
+    let metrics_subnets = client.subnets_for_metrics(version.into()).unwrap();
+
+    assert_eq!(metrics_subnets, vec![app_subnet, system_subnet]);
+    assert!(
+        !metrics_subnets.contains(&cloud_engine_subnet),
+        "Cloud engine subnet should be excluded from metrics collection"
+    );
 }

--- a/rs/node_rewards/canister/src/registry_querier/tests.rs
+++ b/rs/node_rewards/canister/src/registry_querier/tests.rs
@@ -315,7 +315,7 @@ fn test_get_subnet_record_returns_correct_type() {
     let cloud_engine_subnet: SubnetId = PrincipalId::new_subnet_test_id(12).into();
     let missing_subnet: SubnetId = PrincipalId::new_subnet_test_id(99).into();
 
-    let version = 39680u64;
+    let version = 39680_u64;
     let date = "2025-07-17";
 
     add_record_helper(


### PR DESCRIPTION
# Motivation

The NodeRewardsCanister is failing to compute rewards because it cannot retrieve metrics from subnet `jimdo-4evsc-75zsl-p6kw6-2flps-77ium-oorct-qzf7m-aa5z4-4ewoh-kae`, which is a newly created subnet of type `cloud_engine`.

Cloud engine subnets mgm canister cannot be reached due to xnet shielding. When `schedule_metrics_sync` tries to fetch metrics for **all** subnets (including cloud engines), the call fails, which causes the entire metrics sync to return an error and prevents reward computation for all providers.

# Fix
Exclude cloud engine subnets from metrics collection