### PR TITLE
refactor(test-driver): move environment to `systest!`'s closure

### DIFF
--- a/rs/tests/driver/src/driver/dsl.rs
+++ b/rs/tests/driver/src/driver/dsl.rs
@@ -16,7 +16,7 @@ macro_rules! systest {
     ($function:path; $arg:expr_2021) => {
         ic_system_test_driver::driver::dsl::TestFunction::new(
             &format!("{}({:?})", std::stringify!($function), $arg),
-            |env| ($function(env, $arg)),
+            move |env| ($function(env, $arg)),
         )
     };
 }

--- a/rs/tests/networking/nns_delegation_test.rs
+++ b/rs/tests/networking/nns_delegation_test.rs
@@ -800,41 +800,31 @@ fn upgrade_non_nns_subnets_if_necessary(env: &TestEnv) {
     ));
 }
 
-macro_rules! systest_all_subnet_types {
-    ($group: expr, $function_name:path) => {
-        // Keep up to date with `TESTED_SUBNET_TYPES` constant
-        $group = $group.add_test(systest!($function_name; SubnetType::System));
-        $group = $group.add_test(systest!($function_name; SubnetType::Application));
-        $group = $group.add_test(systest!($function_name; SubnetType::VerifiedApplication));
-        // TODO(CON-1696): Remove this condition (and always run the test for cloud engines) when
-        // #9613 reaches mainnet NNS
-        if get_guestos_img_version() == get_guestos_update_img_version() {
-            $group = $group.add_test(systest!($function_name; SubnetType::CloudEngine));
-        }
-    };
-}
-
 fn main() -> Result<()> {
     let mut par_group = SystemTestSubGroup::new();
-    systest_all_subnet_types!(par_group, nns_delegation_updates);
-    systest_all_subnet_types!(par_group, canister_read_state_v2_returns_correct_delegation);
-    systest_all_subnet_types!(par_group, canister_read_state_v3_returns_correct_delegation);
-    systest_all_subnet_types!(
-        par_group,
-        canister_read_state_v3_management_canister_returns_correct_delegation
-    );
-    systest_all_subnet_types!(par_group, subnet_read_state_v2_returns_correct_delegation);
-    systest_all_subnet_types!(par_group, subnet_read_state_v3_returns_correct_delegation);
-    // note: the v2 call endpoint doesn't return an NNS delegation, so there is nothing to test
-    systest_all_subnet_types!(par_group, call_v3_returns_correct_delegation);
-    systest_all_subnet_types!(par_group, call_v4_returns_correct_delegation);
-    systest_all_subnet_types!(
-        par_group,
-        call_v4_management_canister_returns_correct_delegation
-    );
-    systest_all_subnet_types!(par_group, query_v2_passes_correct_delegation_to_canister);
-    systest_all_subnet_types!(par_group, query_v3_passes_correct_delegation_to_canister);
-    systest_all_subnet_types!(par_group, interlaced_v2_and_v3_query_requests);
+    for subnet_type in TESTED_SUBNET_TYPES {
+        par_group = par_group.add_test(systest!(nns_delegation_updates; subnet_type));
+        par_group = par_group
+            .add_test(systest!(canister_read_state_v2_returns_correct_delegation; subnet_type));
+        par_group = par_group
+            .add_test(systest!(canister_read_state_v3_returns_correct_delegation; subnet_type));
+        par_group = par_group.add_test(systest!(canister_read_state_v3_management_canister_returns_correct_delegation; subnet_type));
+        par_group = par_group
+            .add_test(systest!(subnet_read_state_v2_returns_correct_delegation; subnet_type));
+        par_group = par_group
+            .add_test(systest!(subnet_read_state_v3_returns_correct_delegation; subnet_type));
+        // note: the v2 call endpoint doesn't return an NNS delegation, so there is nothing to test
+        par_group = par_group.add_test(systest!(call_v3_returns_correct_delegation; subnet_type));
+        par_group = par_group.add_test(systest!(call_v4_returns_correct_delegation; subnet_type));
+        par_group = par_group.add_test(
+            systest!(call_v4_management_canister_returns_correct_delegation; subnet_type),
+        );
+        par_group = par_group
+            .add_test(systest!(query_v2_passes_correct_delegation_to_canister; subnet_type));
+        par_group = par_group
+            .add_test(systest!(query_v3_passes_correct_delegation_to_canister; subnet_type));
+        par_group = par_group.add_test(systest!(interlaced_v2_and_v3_query_requests; subnet_type));
+    }
 
     SystemTestGroup::new()
         .with_setup(setup)

--- a/rs/tests/networking/nns_delegation_test.rs
+++ b/rs/tests/networking/nns_delegation_test.rs
@@ -801,27 +801,19 @@ fn upgrade_non_nns_subnets_if_necessary(env: &TestEnv) {
 fn main() -> Result<()> {
     let mut par_group = SystemTestSubGroup::new();
     for subnet_type in TESTED_SUBNET_TYPES {
-        par_group = par_group.add_test(systest!(nns_delegation_updates; subnet_type));
-        par_group = par_group
-            .add_test(systest!(canister_read_state_v2_returns_correct_delegation; subnet_type));
-        par_group = par_group
-            .add_test(systest!(canister_read_state_v3_returns_correct_delegation; subnet_type));
-        par_group = par_group.add_test(systest!(canister_read_state_v3_management_canister_returns_correct_delegation; subnet_type));
-        par_group = par_group
-            .add_test(systest!(subnet_read_state_v2_returns_correct_delegation; subnet_type));
-        par_group = par_group
-            .add_test(systest!(subnet_read_state_v3_returns_correct_delegation; subnet_type));
-        // note: the v2 call endpoint doesn't return an NNS delegation, so there is nothing to test
-        par_group = par_group.add_test(systest!(call_v3_returns_correct_delegation; subnet_type));
-        par_group = par_group.add_test(systest!(call_v4_returns_correct_delegation; subnet_type));
-        par_group = par_group.add_test(
-            systest!(call_v4_management_canister_returns_correct_delegation; subnet_type),
-        );
-        par_group = par_group
-            .add_test(systest!(query_v2_passes_correct_delegation_to_canister; subnet_type));
-        par_group = par_group
-            .add_test(systest!(query_v3_passes_correct_delegation_to_canister; subnet_type));
-        par_group = par_group.add_test(systest!(interlaced_v2_and_v3_query_requests; subnet_type));
+        par_group = par_group.add_test(systest!(nns_delegation_updates; subnet_type))
+            .add_test(systest!(canister_read_state_v2_returns_correct_delegation; subnet_type))
+            .add_test(systest!(canister_read_state_v3_returns_correct_delegation; subnet_type))
+            .add_test(systest!(canister_read_state_v3_management_canister_returns_correct_delegation; subnet_type))
+            .add_test(systest!(subnet_read_state_v2_returns_correct_delegation; subnet_type))
+            .add_test(systest!(subnet_read_state_v3_returns_correct_delegation; subnet_type))
+            // note: the v2 call endpoint doesn't return an NNS delegation, so there is nothing to test
+            .add_test(systest!(call_v3_returns_correct_delegation; subnet_type))
+            .add_test(systest!(call_v4_returns_correct_delegation; subnet_type))
+            .add_test(systest!(call_v4_management_canister_returns_correct_delegation; subnet_type))
+            .add_test(systest!(query_v2_passes_correct_delegation_to_canister; subnet_type))
+            .add_test(systest!(query_v3_passes_correct_delegation_to_canister; subnet_type))
+            .add_test(systest!(interlaced_v2_and_v3_query_requests; subnet_type));
     }
 
     SystemTestGroup::new()

--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -1091,15 +1091,6 @@ where
         .unwrap())
 }
 
-macro_rules! systest_all_variants {
-    ($group: expr, $function_name:path) => {
-        $group = $group.add_test(systest!($function_name; Endpoint::CanisterReadState(read_state::canister::Version::V2)));
-        $group = $group.add_test(systest!($function_name; Endpoint::CanisterReadState(read_state::canister::Version::V3)));
-        $group = $group.add_test(systest!($function_name; Endpoint::SubnetReadState(read_state::subnet::Version::V2)));
-        $group = $group.add_test(systest!($function_name; Endpoint::SubnetReadState(read_state::subnet::Version::V3)));
-    };
-}
-
 fn main() -> Result<()> {
     let mut parallel_group = SystemTestSubGroup::new()
         .add_test(systest!(test_non_utf8_metadata))
@@ -1128,12 +1119,20 @@ fn main() -> Result<()> {
         .add_test(systest!(test_metadata_path; read_state::canister::Version::V2))
         .add_test(systest!(test_metadata_path; read_state::canister::Version::V3));
 
-    systest_all_variants!(parallel_group, test_empty_paths_return_time);
-    systest_all_variants!(parallel_group, test_time_path_returns_time);
-    systest_all_variants!(parallel_group, test_subnet_path);
-    systest_all_variants!(parallel_group, test_invalid_request_rejected);
-    systest_all_variants!(parallel_group, test_invalid_path_rejected);
-    systest_all_variants!(parallel_group, test_deprecated_subnet_canister_ranges_paths);
+    for endpoint in [
+        Endpoint::CanisterReadState(read_state::canister::Version::V2),
+        Endpoint::CanisterReadState(read_state::canister::Version::V3),
+        Endpoint::SubnetReadState(read_state::subnet::Version::V2),
+        Endpoint::SubnetReadState(read_state::subnet::Version::V3),
+    ] {
+        parallel_group = parallel_group.add_test(systest!(test_empty_paths_return_time; endpoint));
+        parallel_group = parallel_group.add_test(systest!(test_time_path_returns_time; endpoint));
+        parallel_group = parallel_group.add_test(systest!(test_subnet_path; endpoint));
+        parallel_group = parallel_group.add_test(systest!(test_invalid_request_rejected; endpoint));
+        parallel_group = parallel_group.add_test(systest!(test_invalid_path_rejected; endpoint));
+        parallel_group = parallel_group
+            .add_test(systest!(test_deprecated_subnet_canister_ranges_paths; endpoint));
+    }
 
     SystemTestGroup::new()
         .with_setup(setup)

--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -1125,12 +1125,12 @@ fn main() -> Result<()> {
         Endpoint::SubnetReadState(read_state::subnet::Version::V2),
         Endpoint::SubnetReadState(read_state::subnet::Version::V3),
     ] {
-        parallel_group = parallel_group.add_test(systest!(test_empty_paths_return_time; endpoint));
-        parallel_group = parallel_group.add_test(systest!(test_time_path_returns_time; endpoint));
-        parallel_group = parallel_group.add_test(systest!(test_subnet_path; endpoint));
-        parallel_group = parallel_group.add_test(systest!(test_invalid_request_rejected; endpoint));
-        parallel_group = parallel_group.add_test(systest!(test_invalid_path_rejected; endpoint));
         parallel_group = parallel_group
+            .add_test(systest!(test_empty_paths_return_time; endpoint))
+            .add_test(systest!(test_time_path_returns_time; endpoint))
+            .add_test(systest!(test_subnet_path; endpoint))
+            .add_test(systest!(test_invalid_request_rejected; endpoint))
+            .add_test(systest!(test_invalid_path_rejected; endpoint))
             .add_test(systest!(test_deprecated_subnet_canister_ranges_paths; endpoint));
     }
 


### PR DESCRIPTION
This PR moves the environment inside the closure generated by `systest!`. That way, it is possible to pass variables that would otherwise be outlived by the closure in question.
This could restrict further applications as the caller now needs to abandon the passed variable. Though in all practical scenarios, this argument is a small parameter that slightly changes the test's behavior. This is probably cheap to clone, something that the caller can do before passing it if they ever wanted to re-use it.