### PR TITLE
fix(governance): reset INFLIGHT flag on get_node_providers_rewards failure

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -7606,9 +7606,10 @@ impl Governance {
         }
 
         INFLIGHT.set(true);
-        let rewards = self.get_node_providers_rewards().await?;
+        let rewards = self.get_node_providers_rewards().await;
         INFLIGHT.set(false);
 
+        let rewards = rewards?;
         CACHE.set(Some((now, rewards.clone())));
 
         Ok(rewards)

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -17,4 +17,7 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* When result in `get_node_providers_rewards_cached` is `Err`,
+  release INFLIGHT (i.e. set it to `false`).
+
 ## Security


### PR DESCRIPTION
# Motivation

The `INFLIGHT` guard in `get_node_providers_rewards_cached` is never reset when the inter-canister call to the Node Rewards Canister fails. The `?` operator on the `await` line returns early, skipping `INFLIGHT.set(false)`. This permanently blocks all subsequent calls to the cached endpoint with:

```
GovernanceError { error_type: External, error_message: "get_node_provider_rewards called while there is an inflight call to NRC. Please try again in 10 seconds." }
```

This is currently happening on mainnet because the NRC is failing due to a newly created cloud engine subnet (tracked in #9852).

# Changes

- Split the `await?` into separate `await` + `?` steps so that `INFLIGHT.set(false)` always executes regardless of call success or failure.
