### PR TITLE
fix: deflake `//rs/tests/networking:network_large_test` by colocating the test driver

### DIFF
--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -324,6 +324,7 @@ system_test_nns(
     name = "network_large_test",
     enable_head_nns_variant = False,  # only run this test with the mainnet NNS canisters.
     tags = [
+        "colocate",
         "system_test_large",
     ],
     test_timeout = "eternal",


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/9835 describes a test failure where a `try_store_msg` call fails with `TimeoutWaitingForResponse`. However, the system test logs suggest that the subnet was clearly making progress at the time. 

Therefore, another possible reason for this error could be that the ingress message was lost somewhere between the test driver and the subnet. This PR reduces the likelihood of this happening by colocating the test driver with the IC nodes.