### PR TITLE
fix: deflake //rs/tests/networking:canister_http_flexible_test

### DIFF
--- a/ic-os/components/networking/nftables/reload_nftables.service
+++ b/ic-os/components/networking/nftables/reload_nftables.service
@@ -1,5 +1,11 @@
 [Unit]
 Description=Reload nftables when the configuration changes
+# The orchestrator-generated nftables config uses the hostname "hostos" which
+# is resolved via the nss_icos NSS plugin. We must wait for name resolution to
+# be available, otherwise the nft reload fails with "Could not resolve hostname"
+# and the entire ruleset is discarded (nft is transactional).
+After=nss-lookup.target systemd-resolved.service
+Wants=nss-lookup.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Root Cause

During GuestOS boot, the orchestrator writes the nftables configuration file to `/run/ic-node/nftables-ruleset/nftables.conf`. The systemd path unit `reload_nftables.path` detects the file change and triggers `reload_nftables.service`, which flushes the ruleset and reloads nftables.

The orchestrator-generated nftables config contains the hostname `hostos` in rules like:
```
ip6 saddr { hostos } ct state { new } tcp dport { 42372 } accept
```

This hostname is resolved at `nft` load time via the `nss_icos` NSS plugin. However, early at boot, `systemd-resolved` may not yet be fully operational when `reload_nftables.service` runs. This causes `nft` to fail with:
```
/etc/nftables.conf:95:17-22: Error: Could not resolve hostname: Temporary failure in name resolution
```

Since `nft` is transactional, the entire ruleset is discarded. The orchestrator only re-writes the config file when its content changes (not on every 10s check cycle), so the reload is never retried. This leaves the `ip6 filter OUTPUT` chain missing entirely, causing `wait_for_orchestrator_fw_rule` in the test driver to time out after 60 seconds and the test setup to fail.

This was observed consistently in all 3 flaky runs from the past week — all nodes had the same DNS resolution failure at boot.

## Fix

Added `After=nss-lookup.target systemd-resolved.service` and `Wants=nss-lookup.target` to `reload_nftables.service`. This ensures that when the path unit triggers a reload, systemd delays starting the service until name resolution is available, so the `hostos` hostname can be resolved by the `nss_icos` plugin.

## Verification

`bazel test --test_output=errors //rs/tests/networking:canister_http_flexible_test` passes. All affected unit tests also pass.

---
This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.