### PR TITLE
fix(subnet-splitting): relax one of checks in the `do_split_subnet` method

### DIFF
--- a/rs/registry/canister/src/mutations/do_split_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_split_subnet.rs
@@ -388,12 +388,9 @@ impl Registry {
         &self,
         record_key: &str,
         version: Version,
-    ) -> Version {
+    ) -> Option<Version> {
         self.get(record_key.as_bytes(), version)
             .map(|record| record.version)
-            .unwrap_or_else(|| {
-                panic!("Record for {record_key} not found in registry");
-            })
     }
 }
 

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -17,4 +17,7 @@ on the process that this file is part of, see
 
 ## Fixed
 
+* `do_split_subnet` - don't assume that all the registry entries exist when checking whether the
+  entries changed across await point
+
 ## Security


### PR DESCRIPTION
When checking if some registry records changed across an await point, we were assuming that the records must exist, which is not necessarily the case. For example, the `subnet_splitting_v2_test` system test fails because `canister_migrations_record` doesn't exist in the registry when `do_split_subnet` is executed for the first time

Note: this endpoint is not yet used