### PR TITLE
fix(governance): reset INFLIGHT flag on get_node_providers_rewards failure

### DIFF
--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -7606,9 +7606,10 @@ impl Governance {
         }
 
         INFLIGHT.set(true);
-        let rewards = self.get_node_providers_rewards().await?;
+        let rewards = self.get_node_providers_rewards().await;
         INFLIGHT.set(false);
 
+        let rewards = rewards?;
         CACHE.set(Some((now, rewards.clone())));
 
         Ok(rewards)


### PR DESCRIPTION
The INFLIGHT guard in get_node_providers_rewards_cached was never reset when the inter-canister call to the Node Rewards Canister failed, because the `?` operator returned early before reaching `INFLIGHT.set(false)`. This permanently blocked all subsequent calls to the cached endpoint.

Split the await and error propagation so INFLIGHT is always reset regardless of the call outcome.