### PR TITLE
chore: add a metric for the number of expired ingress messages in the artifact pool

### DIFF
--- a/rs/artifact_pool/src/ingress_pool.rs
+++ b/rs/artifact_pool/src/ingress_pool.rs
@@ -320,22 +320,23 @@ impl MutablePool<SignedIngress> for IngressPoolImpl {
                             .map(ArtifactTransmit::Abort),
                     );
 
-                    let expired_messages_count =
-                        expired_validated.len() + expired_unvalidated.len();
-                    if expired_messages_count > 0 {
-                        warn!(
-                            every_n_seconds => 30,
-                            self.log,
-                            "Purging {} expired ingress messages \
-                            from the validated ingress pool and {} \
-                            from the unvalidated ingress pool",
-                            expired_validated.len(),
-                            expired_unvalidated.len()
-                        );
-                        self.metrics
-                            .ingress_messages_expired
-                            .inc_by(expired_messages_count as u64)
-                    }
+                    let log_if_non_zero = |count, pool_type| {
+                        if count > 0 {
+                            warn!(
+                                every_n_seconds => 30,
+                                self.log,
+                                "Purging {count} expired ingress messages from \
+                                the {pool_type} ingress pool"
+                            );
+                            self.metrics
+                                .ingress_messages_expired
+                                .with_label_values(&[pool_type])
+                                .inc_by(count as u64);
+                        }
+                    };
+
+                    log_if_non_zero(expired_validated.len(), "validated");
+                    log_if_non_zero(expired_unvalidated.len(), "unvalidated");
                 }
             }
         }
@@ -670,7 +671,11 @@ mod tests {
                 assert!(!result.poll_immediately);
                 assert_eq!(ingress_pool.validated().size(), non_expired_count);
                 assert_eq!(
-                    ingress_pool.metrics.ingress_messages_expired.get(),
+                    ingress_pool
+                        .metrics
+                        .ingress_messages_expired
+                        .with_label_values(&["validated"])
+                        .get(),
                     expired_count as u64
                 );
             })

--- a/rs/artifact_pool/src/ingress_pool.rs
+++ b/rs/artifact_pool/src/ingress_pool.rs
@@ -103,7 +103,7 @@ impl<T: AsRef<IngressPoolObject>> IngressPoolSection<T> {
 
     // Purge below an expiry prefix (non-inclusive), and return the purged artifacts
     // as an iterator.
-    fn purge_below(&mut self, expiry: Time) -> Box<dyn Iterator<Item = T> + '_> {
+    fn purge_below(&mut self, expiry: Time) -> BTreeMap<IngressMessageId, T> {
         let _timer = self
             .metrics
             .op_duration
@@ -121,7 +121,7 @@ impl<T: AsRef<IngressPoolObject>> IngressPoolSection<T> {
         }
         // SAFETY: Checking byte size invariant
         self.assert_section_ok();
-        Box::new(to_remove.into_values())
+        to_remove
     }
 
     /// Counts the exact bytes by iterating over the artifact btreemap, instead
@@ -312,15 +312,18 @@ impl MutablePool<SignedIngress> for IngressPoolImpl {
                     }
                 }
                 ChangeAction::PurgeBelowExpiry(expiry) => {
-                    let mut expired_messages_count = 0;
+                    let expired_validated = self.validated.purge_below(expiry);
+                    let expired_unvalidated = self.unvalidated.purge_below(expiry);
+
                     transmits.extend(
-                        self.validated
-                            .purge_below(expiry)
-                            .inspect(|_| expired_messages_count += 1)
+                        expired_validated
+                            .values()
                             .map(|i| (&i.msg.signed_ingress).into())
                             .map(ArtifactTransmit::Abort),
                     );
 
+                    let expired_messages_count =
+                        expired_validated.len() + expired_unvalidated.len();
                     if expired_messages_count > 0 {
                         warn!(
                             every_n_seconds => 30,
@@ -330,10 +333,8 @@ impl MutablePool<SignedIngress> for IngressPoolImpl {
                         );
                         self.metrics
                             .ingress_messages_expired
-                            .inc_by(expired_messages_count)
+                            .inc_by(expired_messages_count as u64)
                     }
-
-                    let _unused = self.unvalidated.purge_below(expiry);
                 }
             }
         }

--- a/rs/artifact_pool/src/ingress_pool.rs
+++ b/rs/artifact_pool/src/ingress_pool.rs
@@ -101,8 +101,7 @@ impl<T: AsRef<IngressPoolObject>> IngressPoolSection<T> {
         removed
     }
 
-    // Purge below an expiry prefix (non-inclusive), and return the purged artifacts
-    // as an iterator.
+    // Purge below an expiry prefix (non-inclusive), and return the purged artifacts.
     fn purge_below(&mut self, expiry: Time) -> BTreeMap<IngressMessageId, T> {
         let _timer = self
             .metrics
@@ -665,7 +664,6 @@ mod tests {
                         .any(|x| matches!(x, ArtifactTransmit::Deliver(_)))
                 );
                 let expired_count = initial_count - non_expired_count;
-                assert!(expired_count > 0);
                 assert_eq!(result.transmits.len(), expired_count);
                 assert!(!result.poll_immediately);
                 assert_eq!(ingress_pool.validated().size(), non_expired_count);

--- a/rs/artifact_pool/src/ingress_pool.rs
+++ b/rs/artifact_pool/src/ingress_pool.rs
@@ -325,7 +325,7 @@ impl MutablePool<SignedIngress> for IngressPoolImpl {
                         warn!(
                             every_n_seconds => 30,
                             self.log,
-                            "Purging {expired_messages_count} expired ingress message \
+                            "Purging {expired_messages_count} expired ingress messages \
                             from the ingress pool"
                         );
                         self.metrics

--- a/rs/artifact_pool/src/ingress_pool.rs
+++ b/rs/artifact_pool/src/ingress_pool.rs
@@ -326,8 +326,11 @@ impl MutablePool<SignedIngress> for IngressPoolImpl {
                         warn!(
                             every_n_seconds => 30,
                             self.log,
-                            "Purging {expired_messages_count} expired ingress messages \
-                            from the ingress pool"
+                            "Purging {} expired ingress messages \
+                            from the validated ingress pool and {} \
+                            from the unvalidated ingress pool",
+                            expired_validated.len(),
+                            expired_unvalidated.len()
                         );
                         self.metrics
                             .ingress_messages_expired

--- a/rs/artifact_pool/src/ingress_pool.rs
+++ b/rs/artifact_pool/src/ingress_pool.rs
@@ -3,6 +3,7 @@
 /// But we keep it separated for code readability
 use crate::{
     HasTimestamp,
+    ingress_pool::metrics::IngressPoolMetrics,
     metrics::{POOL_TYPE_UNVALIDATED, POOL_TYPE_VALIDATED, PoolMetrics},
 };
 use ic_config::artifact_pool::ArtifactPoolConfig;
@@ -16,16 +17,16 @@ use ic_interfaces::{
         ValidatedPoolReader,
     },
 };
-use ic_logger::{ReplicaLogger, debug};
+use ic_logger::{ReplicaLogger, debug, warn};
 use ic_metrics::MetricsRegistry;
 use ic_types::{
     CountBytes, NodeId, Time,
     artifact::IngressMessageId,
     messages::{EXPECTED_MESSAGE_ID_LENGTH, MessageId, SignedIngress},
 };
-use prometheus::IntCounter;
 use std::collections::BTreeMap;
 
+mod metrics;
 mod peer_counter;
 
 use peer_counter::PeerCounters;
@@ -179,9 +180,9 @@ impl<T: AsRef<IngressPoolObject> + HasTimestamp> PoolSection<T> for IngressPoolS
 pub struct IngressPoolImpl {
     validated: IngressPoolSection<ValidatedIngressArtifact>,
     unvalidated: IngressPoolSection<UnvalidatedIngressArtifact>,
+    metrics: IngressPoolMetrics,
     ingress_pool_max_count: usize,
     ingress_pool_max_bytes: usize,
-    ingress_messages_throttled: IntCounter,
     node_id: NodeId,
     log: ReplicaLogger,
 }
@@ -198,10 +199,7 @@ impl IngressPoolImpl {
         IngressPoolImpl {
             ingress_pool_max_count: config.ingress_pool_max_count,
             ingress_pool_max_bytes: config.ingress_pool_max_bytes,
-            ingress_messages_throttled: metrics_registry.int_counter(
-                "ingress_messages_throttled",
-                "Number of throttled ingress messages",
-            ),
+            metrics: IngressPoolMetrics::new(&metrics_registry),
             validated: IngressPoolSection::new(
                 log.clone(),
                 PoolMetrics::new(metrics_registry.clone(), POOL_INGRESS, POOL_TYPE_VALIDATED),
@@ -314,12 +312,27 @@ impl MutablePool<SignedIngress> for IngressPoolImpl {
                     }
                 }
                 ChangeAction::PurgeBelowExpiry(expiry) => {
+                    let mut expired_messages_count = 0;
                     transmits.extend(
                         self.validated
                             .purge_below(expiry)
+                            .inspect(|_| expired_messages_count += 1)
                             .map(|i| (&i.msg.signed_ingress).into())
                             .map(ArtifactTransmit::Abort),
                     );
+
+                    if expired_messages_count > 0 {
+                        warn!(
+                            every_n_seconds => 30,
+                            self.log,
+                            "Purging {expired_messages_count} expired ingress message \
+                            from the ingress pool"
+                        );
+                        self.metrics
+                            .ingress_messages_expired
+                            .inc_by(expired_messages_count)
+                    }
+
                     let _unused = self.unvalidated.purge_below(expiry);
                 }
             }
@@ -346,7 +359,7 @@ impl ValidatedPoolReader<SignedIngress> for IngressPoolImpl {
 impl IngressPoolThrottler for IngressPoolImpl {
     fn exceeds_threshold(&self) -> bool {
         if self.exceeds_limit(&self.node_id) {
-            self.ingress_messages_throttled.inc();
+            self.metrics.ingress_messages_throttled.inc();
 
             true
         } else {
@@ -650,9 +663,15 @@ mod tests {
                         .iter()
                         .any(|x| matches!(x, ArtifactTransmit::Deliver(_)))
                 );
-                assert_eq!(result.transmits.len(), initial_count - non_expired_count);
+                let expired_count = initial_count - non_expired_count;
+                assert!(expired_count > 0);
+                assert_eq!(result.transmits.len(), expired_count);
                 assert!(!result.poll_immediately);
                 assert_eq!(ingress_pool.validated().size(), non_expired_count);
+                assert_eq!(
+                    ingress_pool.metrics.ingress_messages_expired.get(),
+                    expired_count as u64
+                );
             })
         })
     }

--- a/rs/artifact_pool/src/ingress_pool.rs
+++ b/rs/artifact_pool/src/ingress_pool.rs
@@ -175,7 +175,6 @@ impl<T: AsRef<IngressPoolObject> + HasTimestamp> PoolSection<T> for IngressPoolS
     }
 }
 
-#[derive(Clone)]
 pub struct IngressPoolImpl {
     validated: IngressPoolSection<ValidatedIngressArtifact>,
     unvalidated: IngressPoolSection<UnvalidatedIngressArtifact>,

--- a/rs/artifact_pool/src/ingress_pool/metrics.rs
+++ b/rs/artifact_pool/src/ingress_pool/metrics.rs
@@ -17,7 +17,7 @@ impl IngressPoolMetrics {
             ),
             ingress_messages_expired: metrics_registry.int_counter(
                 "ingress_messages_expired",
-                "Number of throttled ingress messages",
+                "Number of expired ingress messages",
             ),
         }
     }

--- a/rs/artifact_pool/src/ingress_pool/metrics.rs
+++ b/rs/artifact_pool/src/ingress_pool/metrics.rs
@@ -1,0 +1,24 @@
+use ic_metrics::MetricsRegistry;
+use prometheus::IntCounter;
+
+#[derive(Clone)]
+/// Some ingress pool specific metrics.
+pub(super) struct IngressPoolMetrics {
+    pub ingress_messages_throttled: IntCounter,
+    pub ingress_messages_expired: IntCounter,
+}
+
+impl IngressPoolMetrics {
+    pub fn new(metrics_registry: &MetricsRegistry) -> Self {
+        Self {
+            ingress_messages_throttled: metrics_registry.int_counter(
+                "ingress_messages_throttled",
+                "Number of throttled ingress messages",
+            ),
+            ingress_messages_expired: metrics_registry.int_counter(
+                "ingress_messages_expired",
+                "Number of throttled ingress messages",
+            ),
+        }
+    }
+}

--- a/rs/artifact_pool/src/ingress_pool/metrics.rs
+++ b/rs/artifact_pool/src/ingress_pool/metrics.rs
@@ -15,8 +15,9 @@ impl IngressPoolMetrics {
                 "Number of throttled ingress messages",
             ),
             ingress_messages_expired: metrics_registry.int_counter(
-                "ingress_messages_expired",
-                "Number of expired ingress messages",
+                "ingress_pool_messages_expired_total",
+                "Total number of ingress messages in either section of the ingress pool \
+                which expired",
             ),
         }
     }

--- a/rs/artifact_pool/src/ingress_pool/metrics.rs
+++ b/rs/artifact_pool/src/ingress_pool/metrics.rs
@@ -1,10 +1,10 @@
 use ic_metrics::MetricsRegistry;
-use prometheus::IntCounter;
+use prometheus::{IntCounter, IntCounterVec};
 
 /// Some ingress pool specific metrics.
 pub(super) struct IngressPoolMetrics {
     pub ingress_messages_throttled: IntCounter,
-    pub ingress_messages_expired: IntCounter,
+    pub ingress_messages_expired: IntCounterVec,
 }
 
 impl IngressPoolMetrics {
@@ -14,10 +14,10 @@ impl IngressPoolMetrics {
                 "ingress_messages_throttled",
                 "Number of throttled ingress messages",
             ),
-            ingress_messages_expired: metrics_registry.int_counter(
+            ingress_messages_expired: metrics_registry.int_counter_vec(
                 "ingress_pool_messages_expired_total",
-                "Total number of ingress messages which expired in either section of \
-                the ingress pool",
+                "Total number of ingress messages which expired in the ingress pool",
+                &["pool_type"],
             ),
         }
     }

--- a/rs/artifact_pool/src/ingress_pool/metrics.rs
+++ b/rs/artifact_pool/src/ingress_pool/metrics.rs
@@ -16,8 +16,8 @@ impl IngressPoolMetrics {
             ),
             ingress_messages_expired: metrics_registry.int_counter(
                 "ingress_pool_messages_expired_total",
-                "Total number of ingress messages in either section of the ingress pool \
-                which expired",
+                "Total number of ingress messages which expired in either section of \
+                the ingress pool",
             ),
         }
     }

--- a/rs/artifact_pool/src/ingress_pool/metrics.rs
+++ b/rs/artifact_pool/src/ingress_pool/metrics.rs
@@ -1,7 +1,6 @@
 use ic_metrics::MetricsRegistry;
 use prometheus::IntCounter;
 
-#[derive(Clone)]
 /// Some ingress pool specific metrics.
 pub(super) struct IngressPoolMetrics {
     pub ingress_messages_throttled: IntCounter,

--- a/rs/ingress_manager/benches/handle_ingress.rs
+++ b/rs/ingress_manager/benches/handle_ingress.rs
@@ -322,21 +322,29 @@ fn handle_ingress(criterion: &mut Criterion) {
              log: ReplicaLogger,
              history: &SimulatedIngressHistory,
              manager: &mut IngressManager| {
-                let messages = prepare(time_source.as_ref(), expiry_range, total_messages as usize);
-                let (pool, message_ids) = setup(time_source.as_ref(), pool_config, log, messages);
                 group.bench_function(format!("handle_ingress({ingress_rate})"), |bench| {
                     bench.iter_custom(|iters| {
                         let mut elapsed = Duration::from_secs(0);
                         for _ in 0..iters {
-                            let bench_start = Instant::now();
-                            let mut ingress_pool = pool.clone();
+                            let messages = prepare(
+                                time_source.as_ref(),
+                                expiry_range,
+                                total_messages as usize,
+                            );
+                            let (mut ingress_pool, message_ids) = setup(
+                                time_source.as_ref(),
+                                pool_config.clone(),
+                                log.clone(),
+                                messages,
+                            );
                             time_source.reset();
                             // We skip the first MAX_INGRESS_TTL duration in order to save
                             // overall benchmark time. Also by this time, the ingress
                             // history has become fully populated.
                             let start = time_source.get_relative_time() + MAX_INGRESS_TTL;
                             time_source.set_time(start).unwrap();
-                            history.set_history(message_ids.clone());
+                            history.set_history(message_ids);
+                            let bench_start = Instant::now();
                             // Increment time every 200ms until it is over.
                             loop {
                                 on_state_change(&mut ingress_pool, manager);


### PR DESCRIPTION
It could be useful for detecting overloaded subnets and for debugging system tests (such as the system test which is being deflaked in https://github.com/dfinity/ic/pull/9835 and https://github.com/dfinity/ic/pull/9856).

Note that we already have a similar metric in [the execution environment](https://github.com/dfinity/ic/blob/f644cd861299fc2aa9829e9c0ecd7863c9d549fc/rs/execution_environment/src/scheduler.rs#L778-L780) and a similar log in the [http handler](https://github.com/dfinity/ic/blob/master/rs/http_endpoints/public/src/common.rs#L254-L260); meaning that currently, as far as I know, the ingress pool is the only place in the replica code where we don't log expired ingress messages in some way before/after purging them.