### PR TITLE
refactor: replace AgentWithDelegation with ic-agent's DelegatedIdentity

### DIFF
--- a/rs/tests/crypto/canister_sig_verification_cache_test.rs
+++ b/rs/tests/crypto/canister_sig_verification_cache_test.rs
@@ -39,7 +39,6 @@ use ic_system_test_driver::util::delegations::*;
 use ic_system_test_driver::util::{
     MetricsFetcher, agent_with_identity, block_on, random_ed25519_identity,
 };
-use ic_types::messages::Blob;
 use rand::Rng;
 use serde_bytes::ByteBuf;
 use slog::info;
@@ -104,19 +103,15 @@ pub fn test(env: TestEnv) {
         "Randomly generated num_users={num_users} and num_calls_per_user={num_calls_per_user}"
     );
     block_on(async move {
-        let (delegation_identities, users) =
-            new_random_users(&env, num_users, &ii_node, ii_canister_id, ctr_canister_id).await;
-        let app_agents_with_delegation: Vec<_> = delegation_identities
-            .iter()
-            .zip(users.iter())
-            .map(|(delegation_identity, user)| AgentWithDelegation {
-                node_url: app_node.get_public_url(),
-                pubkey: user.ii_derived_public_key.clone(),
-                signed_delegation: user.signed_delegation.clone(),
-                delegation_identity,
-                polling_timeout: UPDATE_POLLING_TIMEOUT,
-            })
-            .collect();
+        let app_agents_with_delegation = new_random_user_agents(
+            &env,
+            num_users,
+            &ii_node,
+            &app_node,
+            ii_canister_id,
+            ctr_canister_id,
+        )
+        .await;
 
         for user_i in 0..num_users {
             for call_j in 0..num_calls_per_user {
@@ -167,18 +162,14 @@ fn install_counter_canister(env: &TestEnv, app_node: &IcNodeSnapshot) -> Princip
     canister_id
 }
 
-struct UserData {
-    pub signed_delegation: SignedDelegation,
-    pub ii_derived_public_key: ByteBuf,
-}
-
-async fn new_random_users(
+async fn new_random_user_agents(
     env: &TestEnv,
     num_users: usize,
     ii_node: &IcNodeSnapshot,
+    app_node: &IcNodeSnapshot,
     ii_canister_id: Principal,
     ctr_canister_id: Principal,
-) -> (Vec<BasicIdentity>, Vec<UserData>) {
+) -> Vec<Agent> {
     let user_ii_agents = ii_agents_for_new_random_users(num_users, ii_node, ii_canister_id).await;
     info!(env.logger(), "{num_users} users registered successfully");
 
@@ -193,17 +184,22 @@ async fn new_random_users(
         .await;
     info!(env.logger(), "Delegations received");
 
-    (
-        delegation_identities,
-        signed_delegations
-            .into_iter()
-            .zip(ii_derived_public_keys)
-            .map(|(signed_delegation, ii_derived_public_key)| UserData {
-                signed_delegation,
-                ii_derived_public_key,
-            })
-            .collect(),
-    )
+    let mut agents = Vec::with_capacity(num_users);
+    for ((delegation_identity, signed_delegation), ii_derived_pk) in delegation_identities
+        .into_iter()
+        .zip(signed_delegations)
+        .zip(ii_derived_public_keys)
+    {
+        let agent = agent_with_delegation(
+            app_node.get_public_url().as_str(),
+            ii_derived_pk.into_vec(),
+            signed_delegation,
+            delegation_identity,
+        )
+        .await;
+        agents.push(agent);
+    }
+    agents
 }
 
 async fn ii_agents_for_new_random_users(
@@ -230,7 +226,11 @@ async fn new_random_delegations(
     ctr_canister_id: Principal,
     ii_canister_id: Principal,
     ii_node: &IcNodeSnapshot,
-) -> (Vec<BasicIdentity>, Vec<SignedDelegation>, Vec<ByteBuf>) {
+) -> (
+    Vec<BasicIdentity>,
+    Vec<ic_agent::identity::SignedDelegation>,
+    Vec<ByteBuf>,
+) {
     let mut delegation_identities = Vec::with_capacity(user_ii_agents.len());
     let mut signed_delegations = Vec::with_capacity(user_ii_agents.len());
     let mut ii_derived_pks = Vec::with_capacity(user_ii_agents.len());
@@ -274,7 +274,7 @@ fn copy_pk(identity: &BasicIdentity) -> Vec<u8> {
 
 async fn increment_counter_canister(
     env: &TestEnv,
-    app_agents_with_delegation: &[AgentWithDelegation<'_>],
+    app_agents_with_delegation: &[Agent],
     ctr_canister_id: Principal,
     user_i: usize,
     call_j: usize,
@@ -283,9 +283,12 @@ async fn increment_counter_canister(
         env.logger(),
         "Making an update call #{call_j} for user #{user_i} on counter canister with delegation (increment counter)"
     );
-    let _ = app_agents_with_delegation[user_i]
-        .update(&ctr_canister_id, "write", Blob(vec![]))
-        .await;
+    app_agents_with_delegation[user_i]
+        .update(&ctr_canister_id, "write")
+        .with_arg(vec![])
+        .call_and_wait()
+        .await
+        .unwrap();
 }
 
 async fn scrape_metrics_and_check_cache_stats(env: &TestEnv, user_i: usize, call_j: usize) {

--- a/rs/tests/crypto/cloud_engine_canister_sig_test.rs
+++ b/rs/tests/crypto/cloud_engine_canister_sig_test.rs
@@ -155,10 +155,10 @@ fn test(env: TestEnv) {
             content: content.clone(),
             sender_delegation: Some(vec![ic_types::messages::SignedDelegation::new(
                 ic_types::messages::Delegation::new(
-                    signed_delegation.delegation.pubkey.clone().into_vec(),
+                    signed_delegation.delegation.pubkey.clone(),
                     Time::from_nanos_since_unix_epoch(signed_delegation.delegation.expiration),
                 ),
-                signed_delegation.signature.clone().into_vec(),
+                signed_delegation.signature.clone(),
             )]),
             sender_pubkey: Some(Blob(ii_derived_public_key.clone().into_vec())),
             sender_sig: Some(Blob(signature.signature.unwrap())),

--- a/rs/tests/driver/src/util/delegations.rs
+++ b/rs/tests/driver/src/util/delegations.rs
@@ -15,8 +15,8 @@ pub const USER_NUMBER_OFFSET: u64 = 10_000;
 
 pub type AnchorNumber = u64;
 
-type CredentialId = ByteBuf;
-type PublicKey = ByteBuf;
+pub type CredentialId = ByteBuf;
+pub type PublicKey = ByteBuf;
 pub type UserKey = PublicKey;
 // in nanos since epoch
 type Timestamp = u64;

--- a/rs/tests/driver/src/util/delegations.rs
+++ b/rs/tests/driver/src/util/delegations.rs
@@ -60,12 +60,11 @@ pub async fn agent_with_delegation(
     signed_delegation: ic_agent::identity::SignedDelegation,
     delegation_identity: BasicIdentity,
 ) -> Agent {
-    let delegated_identity = DelegatedIdentity::new(
+    let delegated_identity = DelegatedIdentity::new_unchecked(
         ii_derived_public_key,
         Box::new(delegation_identity),
         vec![signed_delegation],
-    )
-    .expect("invalid delegation chain: signed_delegation does not delegate to delegation_identity");
+    );
     agent_with_identity(url, delegated_identity).await.unwrap()
 }
 

--- a/rs/tests/driver/src/util/delegations.rs
+++ b/rs/tests/driver/src/util/delegations.rs
@@ -60,11 +60,12 @@ pub async fn agent_with_delegation(
     signed_delegation: ic_agent::identity::SignedDelegation,
     delegation_identity: BasicIdentity,
 ) -> Agent {
-    let delegated_identity = DelegatedIdentity::new_unchecked(
+    let delegated_identity = DelegatedIdentity::new(
         ii_derived_public_key,
         Box::new(delegation_identity),
         vec![signed_delegation],
-    );
+    )
+    .expect("invalid delegation chain: signed_delegation does not delegate to delegation_identity");
     agent_with_identity(url, delegated_identity).await.unwrap()
 }
 

--- a/rs/tests/driver/src/util/delegations.rs
+++ b/rs/tests/driver/src/util/delegations.rs
@@ -1,252 +1,71 @@
-use crate::util::{expiry_time, sign_query, sign_update};
+use crate::util::agent_with_identity;
 
-use super::sign_read_state;
 use candid::{CandidType, Deserialize, Principal};
 use canister_test::PrincipalId;
 use ic_agent::Agent;
-use ic_agent::identity::BasicIdentity;
-use ic_crypto_tree_hash::Path;
-use ic_types::Time;
-use ic_types::messages::{
-    Blob, Certificate, HttpCallContent, HttpCanisterUpdate, HttpQueryContent, HttpQueryResponse,
-    HttpReadState, HttpReadStateContent, HttpReadStateResponse, HttpRequestEnvelope, HttpUserQuery,
-    MessageId,
-};
+use ic_agent::identity::{BasicIdentity, DelegatedIdentity};
 use ic_universal_canister::{UNIVERSAL_CANISTER_WASM, wasm};
 use ic_utils::interfaces::ManagementCanister;
-use reqwest::{Client, Response};
 use serde::Serialize;
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
 
-pub const UPDATE_POLLING_TIMEOUT: Duration = Duration::from_secs(10);
 /// user ids start with 10000 and increase by 1 for each new user
 pub const USER_NUMBER_OFFSET: u64 = 10_000;
 
 pub type AnchorNumber = u64;
 
-pub type CredentialId = ByteBuf;
-pub type PublicKey = ByteBuf;
-pub type DeviceKey = PublicKey;
+type CredentialId = ByteBuf;
+type PublicKey = ByteBuf;
 pub type UserKey = PublicKey;
 // in nanos since epoch
-pub type Timestamp = u64;
+type Timestamp = u64;
 type Signature = ByteBuf;
 
-#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
-pub enum Purpose {
-    #[serde(rename = "recovery")]
-    Recovery,
-    #[serde(rename = "authentication")]
-    Authentication,
-}
-
-#[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize)]
-pub enum DeviceProtection {
-    #[serde(rename = "protected")]
-    Protected,
-    #[serde(rename = "unprotected")]
-    Unprotected,
+#[derive(Clone, Debug, CandidType, Deserialize)]
+struct CandidDelegation {
+    pubkey: PublicKey,
+    expiration: Timestamp,
+    targets: Option<Vec<Principal>>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct Delegation {
-    pub pubkey: PublicKey,
-    pub expiration: Timestamp,
-    pub targets: Option<Vec<Principal>>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct SignedDelegation {
-    pub delegation: Delegation,
-    pub signature: Signature,
+struct CandidSignedDelegation {
+    delegation: CandidDelegation,
+    signature: Signature,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 enum GetDelegationResponse {
     #[serde(rename = "signed_delegation")]
-    SignedDelegation(SignedDelegation),
+    SignedDelegation(CandidSignedDelegation),
     #[serde(rename = "no_such_delegation")]
     NoSuchDelegation,
 }
 
-pub struct AgentWithDelegation<'a> {
-    pub node_url: url::Url,
-    pub pubkey: UserKey,
-    pub signed_delegation: SignedDelegation,
-    pub delegation_identity: &'a BasicIdentity,
-    pub polling_timeout: Duration,
+fn to_agent_signed_delegation(d: CandidSignedDelegation) -> ic_agent::identity::SignedDelegation {
+    ic_agent::identity::SignedDelegation {
+        delegation: ic_agent::identity::Delegation {
+            pubkey: d.delegation.pubkey.into_vec(),
+            expiration: d.delegation.expiration,
+            targets: d.delegation.targets,
+        },
+        signature: d.signature.into_vec(),
+    }
 }
 
-impl AgentWithDelegation<'_> {
-    async fn send_http_request(
-        &self,
-        method: &str,
-        canister_id: &Principal,
-        body: Vec<u8>,
-    ) -> Response {
-        let client = Client::new();
-        client
-            .post(format!(
-                "{}api/v2/canister/{}/{}",
-                self.node_url.as_str(),
-                canister_id,
-                method
-            ))
-            .header("Content-Type", "application/cbor")
-            .body(body)
-            .send()
-            .await
-            .unwrap()
-    }
-
-    fn sender(&self) -> Blob {
-        Blob(
-            Principal::self_authenticating(self.pubkey.clone().into_vec())
-                .as_slice()
-                .to_vec(),
-        )
-    }
-
-    pub async fn update(&self, canister_id: &Principal, method_name: &str, arg: Blob) -> MessageId {
-        let update = HttpCanisterUpdate {
-            canister_id: Blob(canister_id.as_slice().to_vec()),
-            method_name: method_name.to_string(),
-            arg,
-            sender: self.sender(),
-            ingress_expiry: expiry_time().as_nanos() as u64,
-            nonce: None,
-            sender_info: None,
-        };
-        let request_id = update.id();
-        let content = HttpCallContent::Call { update };
-        let signature = sign_update(&content, self.delegation_identity);
-        let envelope = HttpRequestEnvelope {
-            content: content.clone(),
-            sender_delegation: Some(vec![ic_types::messages::SignedDelegation::new(
-                ic_types::messages::Delegation::new(
-                    self.signed_delegation.delegation.pubkey.clone().into_vec(),
-                    Time::from_nanos_since_unix_epoch(self.signed_delegation.delegation.expiration),
-                ),
-                self.signed_delegation.signature.clone().into_vec(),
-            )]),
-            sender_pubkey: Some(Blob(self.pubkey.clone().into_vec())),
-            sender_sig: Some(Blob(signature.signature.unwrap())),
-        };
-        let body = serde_cbor::ser::to_vec(&envelope).unwrap();
-        let _ = self.send_http_request("call", canister_id, body).await;
-        request_id
-    }
-
-    pub async fn query(
-        &self,
-        canister_id: &Principal,
-        method_name: &str,
-        arg: Blob,
-    ) -> HttpQueryResponse {
-        let content = HttpQueryContent::Query {
-            query: HttpUserQuery {
-                canister_id: Blob(canister_id.as_slice().to_vec()),
-                method_name: method_name.to_string(),
-                arg,
-                sender: self.sender(),
-                ingress_expiry: expiry_time().as_nanos() as u64,
-                nonce: None,
-                sender_info: None,
-            },
-        };
-        let signature = sign_query(&content, self.delegation_identity);
-        let envelope = HttpRequestEnvelope {
-            content: content.clone(),
-            sender_delegation: Some(vec![ic_types::messages::SignedDelegation::new(
-                ic_types::messages::Delegation::new(
-                    self.signed_delegation.delegation.pubkey.clone().into_vec(),
-                    Time::from_nanos_since_unix_epoch(self.signed_delegation.delegation.expiration),
-                ),
-                self.signed_delegation.signature.clone().into_vec(),
-            )]),
-            sender_pubkey: Some(Blob(self.pubkey.clone().into_vec())),
-            sender_sig: Some(Blob(signature.signature.unwrap())),
-        };
-        let body = serde_cbor::ser::to_vec(&envelope).unwrap();
-        let response = self.send_http_request("query", canister_id, body).await;
-        let response_bytes = response.bytes().await.unwrap();
-        serde_cbor::from_slice(&response_bytes).unwrap()
-    }
-
-    pub async fn update_and_wait(
-        &self,
-        canister_id: &Principal,
-        method_name: &str,
-        arg: Blob,
-    ) -> Result<Vec<u8>, String> {
-        let request_id = self.update(canister_id, method_name, arg.clone()).await;
-        let content = HttpReadStateContent::ReadState {
-            read_state: HttpReadState {
-                sender: self.sender(),
-                paths: vec![Path::new(vec![
-                    b"request_status".into(),
-                    request_id.as_bytes().into(),
-                ])],
-                nonce: None,
-                ingress_expiry: expiry_time().as_nanos() as u64,
-            },
-        };
-        let sig = sign_read_state(&content, self.delegation_identity);
-        let read_state_envelope: HttpRequestEnvelope<HttpReadStateContent> = HttpRequestEnvelope {
-            content,
-            sender_pubkey: Some(Blob(self.pubkey.clone().into_vec())),
-            sender_sig: Some(Blob(sig.signature.unwrap())),
-            sender_delegation: Some(vec![ic_types::messages::SignedDelegation::new(
-                ic_types::messages::Delegation::new(
-                    self.signed_delegation.delegation.pubkey.clone().into_vec(),
-                    Time::from_nanos_since_unix_epoch(self.signed_delegation.delegation.expiration),
-                ),
-                self.signed_delegation.signature.clone().into_vec(),
-            )]),
-        };
-        let body = serde_cbor::ser::to_vec(&read_state_envelope).unwrap();
-        let path = {
-            let p1: &[u8] = b"request_status";
-            let p2: &[u8] = request_id.as_bytes();
-            let p3: &[u8] = b"reply";
-            vec![p1, p2, p3]
-        };
-        let start = Instant::now();
-        let read_state: Vec<u8> = loop {
-            if start.elapsed() > self.polling_timeout {
-                return Err(format!(
-                    "Polling timeout of {} ms was reached",
-                    self.polling_timeout.as_millis()
-                ));
-            }
-            let response = self
-                .send_http_request("read_state", canister_id, body.clone())
-                .await;
-            let read_state_body = response.bytes().await.unwrap();
-            let response_bytes: HttpReadStateResponse =
-                serde_cbor::from_slice(&read_state_body).unwrap();
-            let certificate: Certificate =
-                serde_cbor::from_slice(&response_bytes.certificate).unwrap();
-            let lookup_status = certificate.tree.lookup(&path);
-            match lookup_status {
-                ic_crypto_tree_hash::LookupStatus::Found(x) => match x {
-                    ic_crypto_tree_hash::MixedHashTree::Leaf(y) => break y.clone(),
-                    _ => panic!("Unexpected result from the read_state tree hash structure"),
-                },
-                ic_crypto_tree_hash::LookupStatus::Absent => {
-                    // If request is absent, keep polling
-                    continue;
-                }
-                ic_crypto_tree_hash::LookupStatus::Unknown => {
-                    // If request is unknown, keep polling
-                    continue;
-                }
-            };
-        };
-        Ok(read_state)
-    }
+pub async fn agent_with_delegation(
+    url: &str,
+    ii_derived_public_key: Vec<u8>,
+    signed_delegation: ic_agent::identity::SignedDelegation,
+    delegation_identity: BasicIdentity,
+) -> Agent {
+    let delegated_identity = DelegatedIdentity::new_unchecked(
+        ii_derived_public_key,
+        Box::new(delegation_identity),
+        vec![signed_delegation],
+    );
+    agent_with_identity(url, delegated_identity).await.unwrap()
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -446,7 +265,7 @@ pub async fn create_delegation(
     ii_canister_id: Principal,
     canister_url: String,
     user_id: u64,
-) -> (SignedDelegation, UserKey) {
+) -> (ic_agent::identity::SignedDelegation, UserKey) {
     let data: Vec<u8> = agent
         .update(&ii_canister_id, "prepare_delegation")
         .with_arg(
@@ -478,13 +297,16 @@ pub async fn create_delegation(
         .await
         .unwrap();
     let delegation_response: GetDelegationResponse = candid::decode_one(&data).unwrap();
-    let signed_delegation = match delegation_response {
+    let candid_signed_delegation = match delegation_response {
         GetDelegationResponse::SignedDelegation(delegation) => delegation,
         GetDelegationResponse::NoSuchDelegation => {
             panic!("unexpected get_delegation result: NoSuchDelegation")
         }
     };
-    (signed_delegation, ii_derived_public_key)
+    (
+        to_agent_signed_delegation(candid_signed_delegation),
+        ii_derived_public_key,
+    )
 }
 
 pub async fn install_universal_canister(

--- a/rs/tests/idx/ii_delegation_test.rs
+++ b/rs/tests/idx/ii_delegation_test.rs
@@ -13,7 +13,6 @@ use ic_system_test_driver::util::delegations::*;
 use ic_system_test_driver::util::{
     agent_with_identity, assert_canister_counter_with_retries, block_on, random_ed25519_identity,
 };
-use ic_types::messages::{Blob, HttpQueryResponse};
 use ic_universal_canister::wasm;
 use slog::info;
 use std::env;
@@ -100,32 +99,34 @@ pub fn test(env: TestEnv) {
         USER_NUMBER_OFFSET,
     ));
     info!(log, "Delegation received");
-    let app_agent_with_delegation = AgentWithDelegation {
-        node_url: app_node.get_public_url(),
-        pubkey: ii_derived_public_key.clone(),
+    let app_agent_with_delegation = block_on(agent_with_delegation(
+        app_node.get_public_url().as_str(),
+        ii_derived_public_key.clone().into_vec(),
         signed_delegation,
-        delegation_identity: &delegation_identity,
-        polling_timeout: UPDATE_POLLING_TIMEOUT,
-    };
+        delegation_identity,
+    ));
     info!(
         log,
         "Making an update call on counter canister with delegation (increment counter)"
     );
-    let _ = block_on(app_agent_with_delegation.update(&counter_canister_id, "write", Blob(vec![])));
+    block_on(
+        app_agent_with_delegation
+            .update(&counter_canister_id, "write")
+            .with_arg(vec![])
+            .call_and_wait(),
+    )
+    .unwrap();
     info!(
         log,
         "Making a query call on counter canister with delegation (read counter)"
     );
-    let query_response =
-        block_on(app_agent_with_delegation.query(&counter_canister_id, "read", Blob(vec![])));
-    match query_response {
-        HttpQueryResponse::Replied { .. } => (),
-        HttpQueryResponse::Rejected {
-            error_code,
-            reject_message,
-            ..
-        } => panic!("Query call was rejected: code={error_code}, message={reject_message}"),
-    }
+    block_on(
+        app_agent_with_delegation
+            .query(&counter_canister_id, "read")
+            .with_arg(vec![])
+            .call(),
+    )
+    .unwrap();
     info!(log, "Asserting canister counter has value=1");
     let app_agent = app_node.build_default_agent();
     block_on(assert_canister_counter_with_retries(
@@ -144,28 +145,26 @@ pub fn test(env: TestEnv) {
     );
     info!(log, "Asserting caller identity of the query call");
     let observed_principal = {
-        let response: HttpQueryResponse = block_on(app_agent_with_delegation.query(
-            &ucan_id,
-            "query",
-            Blob(wasm().caller().append_and_reply().build()),
-        ));
-        match response {
-            HttpQueryResponse::Replied { reply } => Principal::from_slice(reply.arg.as_ref()),
-            HttpQueryResponse::Rejected { reject_message, .. } => {
-                panic!("Query call was rejected: {reject_message}")
-            }
-        }
+        let response = block_on(
+            app_agent_with_delegation
+                .query(&ucan_id, "query")
+                .with_arg(wasm().caller().append_and_reply().build())
+                .call(),
+        )
+        .unwrap();
+        Principal::from_slice(&response)
     };
     assert_eq!(expected_principal, observed_principal);
     info!(log, "Asserting caller identity of the update call");
     let observed_principal = {
-        let response = block_on(app_agent_with_delegation.update_and_wait(
-            &ucan_id,
-            "update",
-            Blob(wasm().caller().append_and_reply().build()),
-        ))
+        let response = block_on(
+            app_agent_with_delegation
+                .update(&ucan_id, "update")
+                .with_arg(wasm().caller().append_and_reply().build())
+                .call_and_wait(),
+        )
         .unwrap();
-        Principal::from_slice(response.as_ref())
+        Principal::from_slice(&response)
     };
     assert_eq!(expected_principal, observed_principal);
 }


### PR DESCRIPTION
## Summary

Triggered by the flaky `//rs/tests/idx:ii_delegation_test`, which often failed because it called `AgentWithDelegation.update(...)` without waiting for it to finish, we realised we should replace the custom `AgentWithDelegation` struct with ic-agent's built-in `DelegatedIdentity`, which implements the `Identity` trait and handles delegation chains automatically.

`AgentWithDelegation` manually constructed HTTP envelopes with delegation fields for update, query, and read_state calls. The `DelegatedIdentity` type in ic-agent 0.45.0 does all of this internally when used as the identity for a standard `Agent`.

## Changes

**`rs/tests/driver/src/util/delegations.rs`**
- Removed `AgentWithDelegation` struct and its ~120-line `impl` block
- Added `agent_with_delegation()` helper that creates a standard `Agent` using `DelegatedIdentity::new()`
- Updated `create_delegation()` to return `ic_agent::identity::SignedDelegation` (converted from Candid-decoded types at the boundary)
- Removed unused imports (`reqwest`, `ic_types::messages::*`, `ic_crypto_tree_hash`, etc.) and the `UPDATE_POLLING_TIMEOUT` constant
- Removed unused `Purpose` and `DeviceProtection` enums

**`rs/tests/idx/ii_delegation_test.rs`**
- Replaced `AgentWithDelegation` with a standard `Agent` built via `agent_with_delegation()`
- Uses `agent.update(...).call_and_wait()` and `agent.query(...).call()` instead of manual HTTP methods
- Removed `Blob` and `HttpQueryResponse` imports

**`rs/tests/crypto/canister_sig_verification_cache_test.rs`**
- Replaced `Vec<AgentWithDelegation>` with `Vec<Agent>`
- Merged `new_random_users()` into `new_random_user_agents()` that returns agents directly
- Removed `Blob` import and unused `UserData` struct

**`rs/tests/crypto/cloud_engine_canister_sig_test.rs`**
- Updated to work with the new `ic_agent::identity::SignedDelegation` return type from `create_delegation()`
- Removed `.into_vec()` calls on delegation fields that are now `Vec<u8>` instead of `ByteBuf`
- This test intentionally constructs raw HTTP envelopes to verify CloudEngine delegations are rejected, so it does not use the `DelegatedIdentity` path

## Testing

- `cargo clippy` passes on all affected crates
- All affected bazel tests pass:
  - `//rs/tests/crypto:canister_sig_verification_cache_test`
  - `//rs/tests/crypto:cloud_engine_canister_sig_test`
  - `//rs/tests/driver:generic_workload_engine`
  - `//rs/tests/idx:ii_delegation_test`
  - `//rs/tests/idx:test_e2e_scenarios`