### PR TITLE
chore: drop environment variables feature flag

### DIFF
--- a/rs/config/src/embedders.rs
+++ b/rs/config/src/embedders.rs
@@ -120,8 +120,6 @@ pub struct FeatureFlags {
     /// If this flag is enabled, then the output of the `debug_print` system-api
     /// call will be skipped based on heuristics.
     pub rate_limiting_of_debug_prints: FlagStatus,
-    /// If this flag is enabled, then the environment variables are supported.
-    pub environment_variables: FlagStatus,
     /// Use deterministic memory tracker.
     pub deterministic_memory_tracker: FlagStatus,
 }
@@ -130,7 +128,6 @@ impl FeatureFlags {
     const fn const_default() -> Self {
         Self {
             rate_limiting_of_debug_prints: FlagStatus::Enabled,
-            environment_variables: FlagStatus::Enabled,
             deterministic_memory_tracker: FlagStatus::Disabled,
         }
     }

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -365,9 +365,6 @@ pub struct Config {
     /// The maximum number of snapshots allowed per canister.
     pub max_number_of_snapshots_per_canister: usize,
 
-    /// Whether environment variables are supported.
-    pub environment_variables: FlagStatus,
-
     /// The maximum number of environment variables allowed per canister.
     pub max_environment_variables: usize,
 
@@ -463,7 +460,6 @@ impl Default for Config {
             max_canister_http_requests_in_flight: MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT,
             default_wasm_memory_limit: DEFAULT_WASM_MEMORY_LIMIT,
             max_number_of_snapshots_per_canister: MAX_NUMBER_OF_SNAPSHOTS_PER_CANISTER,
-            environment_variables: FlagStatus::Enabled,
             max_environment_variables: MAX_ENVIRONMENT_VARIABLES,
             max_environment_variable_name_length: MAX_ENVIRONMENT_VARIABLE_NAME_LENGTH,
             max_environment_variable_value_length: MAX_ENVIRONMENT_VARIABLE_VALUE_LENGTH,

--- a/rs/embedders/src/wasmtime_embedder/linker.rs
+++ b/rs/embedders/src/wasmtime_embedder/linker.rs
@@ -582,121 +582,99 @@ pub fn syscalls<
         })
         .unwrap();
 
-    if feature_flags.environment_variables == FlagStatus::Enabled {
-        linker
-            .func_wrap("ic0", "env_var_count", {
-                move |mut caller: Caller<'_, StoreData>| {
-                    charge_for_cpu(&mut caller, overhead::ENV_VAR_COUNT)?;
+    linker
+        .func_wrap("ic0", "env_var_count", {
+            move |mut caller: Caller<'_, StoreData>| {
+                charge_for_cpu(&mut caller, overhead::ENV_VAR_COUNT)?;
 
-                    with_system_api(&mut caller, |s| s.ic0_env_var_count()).and_then(|s| {
-                        I::try_from(s).map_err(|e| {
-                            wasmtime::Error::msg(format!("ic0::env_var_count failed: {e}"))
-                        })
+                with_system_api(&mut caller, |s| s.ic0_env_var_count()).and_then(|s| {
+                    I::try_from(s).map_err(|e| {
+                        wasmtime::Error::msg(format!("ic0::env_var_count failed: {e}"))
                     })
-                }
-            })
-            .unwrap();
-    }
-    if feature_flags.environment_variables == FlagStatus::Enabled {
-        linker
-            .func_wrap("ic0", "env_var_name_size", {
-                move |mut caller: Caller<'_, StoreData>, index: I| {
-                    let index: usize = index.try_into().expect("Failed to convert I to usize");
-                    charge_for_cpu(&mut caller, overhead::ENV_VAR_NAME_SIZE)?;
-                    with_system_api(&mut caller, |s| s.ic0_env_var_name_size(index)).and_then(|s| {
-                        I::try_from(s).map_err(|e| {
-                            wasmtime::Error::msg(format!("ic0::env_var_name_size failed: {e}"))
-                        })
+                })
+            }
+        })
+        .unwrap();
+    linker
+        .func_wrap("ic0", "env_var_name_size", {
+            move |mut caller: Caller<'_, StoreData>, index: I| {
+                let index: usize = index.try_into().expect("Failed to convert I to usize");
+                charge_for_cpu(&mut caller, overhead::ENV_VAR_NAME_SIZE)?;
+                with_system_api(&mut caller, |s| s.ic0_env_var_name_size(index)).and_then(|s| {
+                    I::try_from(s).map_err(|e| {
+                        wasmtime::Error::msg(format!("ic0::env_var_name_size failed: {e}"))
                     })
-                }
-            })
-            .unwrap();
-    }
-
-    if feature_flags.environment_variables == FlagStatus::Enabled {
-        linker
-            .func_wrap("ic0", "env_var_name_copy", {
-                move |mut caller: Caller<'_, StoreData>, index: I, dst: I, offset: I, size: I| {
-                    let index: usize = index.try_into().expect("Failed to convert I to usize");
-                    let dst: usize = dst.try_into().expect("Failed to convert I to usize");
-                    let offset: usize = offset.try_into().expect("Failed to convert I to usize");
-                    let size: usize = size.try_into().expect("Failed to convert I to usize");
-                    charge_for_cpu_and_mem(&mut caller, overhead::ENV_VAR_NAME_COPY, size)?;
-                    with_memory_and_system_api(&mut caller, |system_api, memory| {
-                        system_api.ic0_env_var_name_copy(index, dst, offset, size, memory)
-                    })?;
-                    Ok(())
-                }
-            })
-            .unwrap();
-    }
-
-    if feature_flags.environment_variables == FlagStatus::Enabled {
-        linker
-            .func_wrap("ic0", "env_var_name_exists", {
-                move |mut caller: Caller<'_, StoreData>, name_src: I, name_size: I| {
-                    let name_src: usize =
-                        name_src.try_into().expect("Failed to convert I to usize");
-                    let name_size: usize =
-                        name_size.try_into().expect("Failed to convert I to usize");
-                    charge_for_cpu(&mut caller, overhead::ENV_VAR_NAME_EXISTS)?;
-                    with_memory_and_system_api(&mut caller, |system_api, memory| {
-                        system_api.ic0_env_var_name_exists(name_src, name_size, memory)
+                })
+            }
+        })
+        .unwrap();
+    linker
+        .func_wrap("ic0", "env_var_name_copy", {
+            move |mut caller: Caller<'_, StoreData>, index: I, dst: I, offset: I, size: I| {
+                let index: usize = index.try_into().expect("Failed to convert I to usize");
+                let dst: usize = dst.try_into().expect("Failed to convert I to usize");
+                let offset: usize = offset.try_into().expect("Failed to convert I to usize");
+                let size: usize = size.try_into().expect("Failed to convert I to usize");
+                charge_for_cpu_and_mem(&mut caller, overhead::ENV_VAR_NAME_COPY, size)?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_env_var_name_copy(index, dst, offset, size, memory)
+                })?;
+                Ok(())
+            }
+        })
+        .unwrap();
+    linker
+        .func_wrap("ic0", "env_var_name_exists", {
+            move |mut caller: Caller<'_, StoreData>, name_src: I, name_size: I| {
+                let name_src: usize = name_src.try_into().expect("Failed to convert I to usize");
+                let name_size: usize = name_size.try_into().expect("Failed to convert I to usize");
+                charge_for_cpu(&mut caller, overhead::ENV_VAR_NAME_EXISTS)?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_env_var_name_exists(name_src, name_size, memory)
+                })
+            }
+        })
+        .unwrap();
+    linker
+        .func_wrap("ic0", "env_var_value_size", {
+            move |mut caller: Caller<'_, StoreData>, name_src: I, name_size: I| {
+                let name_src: usize = name_src.try_into().expect("Failed to convert I to usize");
+                let name_size: usize = name_size.try_into().expect("Failed to convert I to usize");
+                charge_for_cpu(&mut caller, overhead::ENV_VAR_VALUE_SIZE)?;
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api.ic0_env_var_value_size(name_src, name_size, memory)
+                })
+                .and_then(|s| {
+                    I::try_from(s).map_err(|e| {
+                        wasmtime::Error::msg(format!("ic0::env_var_value_size failed: {e}"))
                     })
-                }
-            })
-            .unwrap();
-    }
+                })
+            }
+        })
+        .unwrap();
+    linker
+        .func_wrap("ic0", "env_var_value_copy", {
+            move |mut caller: Caller<'_, StoreData>,
+                  name_src: I,
+                  name_size: I,
+                  dst: I,
+                  offset: I,
+                  size: I| {
+                let name_src: usize = name_src.try_into().expect("Failed to convert I to usize");
+                let name_size: usize = name_size.try_into().expect("Failed to convert I to usize");
+                let dst: usize = dst.try_into().expect("Failed to convert I to usize");
+                let offset: usize = offset.try_into().expect("Failed to convert I to usize");
+                let size: usize = size.try_into().expect("Failed to convert I to usize");
+                charge_for_cpu_and_mem(&mut caller, overhead::ENV_VAR_VALUE_COPY, size)?;
 
-    if feature_flags.environment_variables == FlagStatus::Enabled {
-        linker
-            .func_wrap("ic0", "env_var_value_size", {
-                move |mut caller: Caller<'_, StoreData>, name_src: I, name_size: I| {
-                    let name_src: usize =
-                        name_src.try_into().expect("Failed to convert I to usize");
-                    let name_size: usize =
-                        name_size.try_into().expect("Failed to convert I to usize");
-                    charge_for_cpu(&mut caller, overhead::ENV_VAR_VALUE_SIZE)?;
-                    with_memory_and_system_api(&mut caller, |system_api, memory| {
-                        system_api.ic0_env_var_value_size(name_src, name_size, memory)
-                    })
-                    .and_then(|s| {
-                        I::try_from(s).map_err(|e| {
-                            wasmtime::Error::msg(format!("ic0::env_var_value_size failed: {e}"))
-                        })
-                    })
-                }
-            })
-            .unwrap();
-    }
-
-    if feature_flags.environment_variables == FlagStatus::Enabled {
-        linker
-            .func_wrap("ic0", "env_var_value_copy", {
-                move |mut caller: Caller<'_, StoreData>,
-                      name_src: I,
-                      name_size: I,
-                      dst: I,
-                      offset: I,
-                      size: I| {
-                    let name_src: usize =
-                        name_src.try_into().expect("Failed to convert I to usize");
-                    let name_size: usize =
-                        name_size.try_into().expect("Failed to convert I to usize");
-                    let dst: usize = dst.try_into().expect("Failed to convert I to usize");
-                    let offset: usize = offset.try_into().expect("Failed to convert I to usize");
-                    let size: usize = size.try_into().expect("Failed to convert I to usize");
-                    charge_for_cpu_and_mem(&mut caller, overhead::ENV_VAR_VALUE_COPY, size)?;
-
-                    with_memory_and_system_api(&mut caller, |system_api, memory| {
-                        system_api
-                            .ic0_env_var_value_copy(name_src, name_size, dst, offset, size, memory)
-                    })?;
-                    Ok(())
-                }
-            })
-            .unwrap();
-    }
+                with_memory_and_system_api(&mut caller, |system_api, memory| {
+                    system_api
+                        .ic0_env_var_value_copy(name_src, name_size, dst, offset, size, memory)
+                })?;
+                Ok(())
+            }
+        })
+        .unwrap();
 
     linker
         .func_wrap("ic0", "debug_print", {

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -3510,9 +3510,6 @@ fn test_environment_variable_system_api() {
     env_vars.insert("TEST_VAR_1".to_string(), "Hello World".to_string());
     env_vars.insert("TEST_VAR_2".to_string(), "Test Value".to_string());
 
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.environment_variables = FlagStatus::Enabled;
-
     let mut instance = WasmtimeInstanceBuilder::new()
         .with_api_type(ApiType::update(
             UNIX_EPOCH,
@@ -3522,7 +3519,6 @@ fn test_environment_variable_system_api() {
             0.into(),
             None,
         ))
-        .with_config(config)
         .with_environment_variables(env_vars)
         .with_wat(wat)
         .build();
@@ -3536,42 +3532,6 @@ fn test_environment_variable_system_api() {
     assert_eq!(
         result,
         Ok(Some(WasmResult::Reply(b"Hello WorldTest Value".to_vec())))
-    );
-}
-
-// TODO(EXC-2071): Delete test when feature flag is removed.
-#[test]
-fn test_environment_variable_system_api_not_enabled() {
-    let wat = r#"
-    (module
-        (import "ic0" "env_var_count" (func $ic0_env_var_count (result i32)))
-
-        (func (export "canister_update go")
-            (call $ic0_env_var_count)
-            drop
-        )
-    )"#;
-
-    let mut config = ic_config::embedders::Config::default();
-    config.feature_flags.environment_variables = FlagStatus::Disabled;
-
-    let builder = WasmtimeInstanceBuilder::new()
-        .with_wat(wat)
-        .with_config(config)
-        .with_api_type(ApiType::update(
-            UNIX_EPOCH,
-            vec![],
-            Cycles::zero(),
-            PrincipalId::new_user_test_id(0),
-            0.into(),
-            None,
-        ));
-
-    let instance = builder.try_build();
-    assert!(instance.is_err());
-    assert_matches!(
-        instance.err().unwrap().0,
-        HypervisorError::WasmEngineError { .. }
     );
 }
 

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -101,7 +101,6 @@ pub(crate) struct CanisterManager {
     config: CanisterMgrConfig,
     cycles_account_manager: Arc<CyclesAccountManager>,
     fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
-    environment_variables_flag: FlagStatus,
 }
 
 impl CanisterManager {
@@ -111,7 +110,6 @@ impl CanisterManager {
         config: CanisterMgrConfig,
         cycles_account_manager: Arc<CyclesAccountManager>,
         fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
-        environment_variables_flag: FlagStatus,
     ) -> Self {
         CanisterManager {
             hypervisor,
@@ -119,7 +117,6 @@ impl CanisterManager {
             config,
             cycles_account_manager,
             fd_factory,
-            environment_variables_flag,
         }
     }
 
@@ -615,9 +612,7 @@ impl CanisterManager {
         if let Some(wasm_memory_limit) = settings.wasm_memory_limit() {
             canister.system_state.wasm_memory_limit = Some(wasm_memory_limit);
         }
-        if let Some(environment_variables) = settings.environment_variables()
-            && self.environment_variables_flag == FlagStatus::Enabled
-        {
+        if let Some(environment_variables) = settings.environment_variables() {
             canister.system_state.environment_variables = environment_variables.clone();
         }
     }
@@ -1516,26 +1511,14 @@ impl CanisterManager {
             .copied()
             .collect();
 
-        let available_execution_memory_change = match self.environment_variables_flag {
-            FlagStatus::Enabled => {
-                let environment_variables_hash = settings
-                    .environment_variables()
-                    .map(|env_vars| env_vars.hash());
-                new_canister.add_canister_change(
-                    state.time(),
-                    origin,
-                    CanisterChangeDetails::canister_creation(
-                        controllers,
-                        environment_variables_hash,
-                    ),
-                )
-            }
-            FlagStatus::Disabled => new_canister.add_canister_change(
-                state.time(),
-                origin,
-                CanisterChangeDetails::canister_creation(controllers, None),
-            ),
-        };
+        let environment_variables_hash = settings
+            .environment_variables()
+            .map(|env_vars| env_vars.hash());
+        let available_execution_memory_change = new_canister.add_canister_change(
+            state.time(),
+            origin,
+            CanisterChangeDetails::canister_creation(controllers, environment_variables_hash),
+        );
         round_limits
             .subnet_available_memory
             .update_execution_memory_unchecked(available_execution_memory_change);

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -280,7 +280,6 @@ impl CanisterManagerBuilder {
             ),
             cycles_account_manager,
             Arc::new(TestPageAllocatorFileDescriptorImpl),
-            FlagStatus::Disabled,
         )
     }
 }

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -1632,9 +1632,7 @@ fn get_canister_status_of_stopping_canister() {
 
 #[test]
 fn canister_status_with_environment_variables() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_environment_variables_flag(FlagStatus::Enabled)
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
     let environment_variables = btreemap![
         "TEST_VAR".to_string() => "test_value".to_string(),
         "TEST_VAR2".to_string() => "test_value2".to_string(),
@@ -6141,12 +6139,7 @@ fn update_wasm_memory_limit_updates_hook_status_ready_to_not_satisfied() {
 
 #[test]
 fn test_environment_variables_are_changed_via_create_canister() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_execution_config(Config {
-            environment_variables: FlagStatus::Enabled,
-            ..Default::default()
-        })
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
 
     let env_vars = BTreeMap::from([
         ("KEY1".to_string(), "VALUE1".to_string()),
@@ -6179,12 +6172,7 @@ fn test_environment_variables_are_changed_via_create_canister() {
 
 #[test]
 fn test_environment_variables_are_updated_on_update_settings() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_execution_config(Config {
-            environment_variables: FlagStatus::Enabled,
-            ..Default::default()
-        })
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
     let canister_id = test.create_canister(Cycles::new(1_000_000_000_000_000));
 
     let env_vars = EnvironmentVariables::new(BTreeMap::from([
@@ -6230,70 +6218,8 @@ fn test_environment_variables_are_updated_on_update_settings() {
 }
 
 #[test]
-fn test_environment_variables_are_not_set_when_disabled() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_execution_config(Config {
-            environment_variables: FlagStatus::Disabled,
-            ..Default::default()
-        })
-        .build();
-
-    // Create environment variables.
-    let env_vars = BTreeMap::from([
-        ("KEY1".to_string(), "VALUE1".to_string()),
-        ("KEY2".to_string(), "VALUE2".to_string()),
-    ]);
-    let env_vars_args = env_vars
-        .iter()
-        .map(|(name, value)| EnvironmentVariable {
-            name: name.clone(),
-            value: value.clone(),
-        })
-        .collect::<Vec<_>>();
-    // Create canister with environment variables.
-    let canister_id = test
-        .create_canister_with_settings(
-            Cycles::new(1_000_000_000_000_000),
-            CanisterSettingsArgsBuilder::new()
-                .with_environment_variables(env_vars_args.clone())
-                .build(),
-        )
-        .unwrap();
-
-    // Verify environment variables are not set.
-    let canister = test.canister_state(canister_id);
-    assert_eq!(
-        canister.system_state.environment_variables,
-        EnvironmentVariables::new(BTreeMap::new())
-    );
-
-    // Set environment variables via `update_settings`.
-    let args = UpdateSettingsArgs {
-        canister_id: canister_id.get(),
-        settings: CanisterSettingsArgsBuilder::new()
-            .with_environment_variables(env_vars_args)
-            .build(),
-        sender_canister_version: None,
-    };
-    test.subnet_message(Method::UpdateSettings, args.encode())
-        .unwrap();
-
-    // Verify environment variables are not set.
-    let canister = test.canister_state(canister_id);
-    assert_eq!(
-        canister.system_state.environment_variables,
-        EnvironmentVariables::new(BTreeMap::new())
-    );
-}
-
-#[test]
 fn test_environment_variables_are_not_set_when_too_many_keys() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_execution_config(Config {
-            environment_variables: FlagStatus::Enabled,
-            ..Default::default()
-        })
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
 
     let env_vars = (0..MAX_ENVIRONMENT_VARIABLES + 1)
         .map(|i| (format!("KEY{i}"), "VAL".to_string()))
@@ -6325,12 +6251,7 @@ fn test_environment_variables_are_not_set_when_too_many_keys() {
 
 #[test]
 fn test_environment_variables_are_not_set_when_key_is_too_long() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_execution_config(Config {
-            environment_variables: FlagStatus::Enabled,
-            ..Default::default()
-        })
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
 
     let long_key = "K".repeat(MAX_ENVIRONMENT_VARIABLE_NAME_LENGTH + 1);
     let env_vars = [
@@ -6366,12 +6287,7 @@ fn test_environment_variables_are_not_set_when_key_is_too_long() {
 
 #[test]
 fn test_environment_variables_are_not_set_when_value_is_too_long() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_execution_config(Config {
-            environment_variables: FlagStatus::Enabled,
-            ..Default::default()
-        })
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
 
     let long_value = "V".repeat(MAX_ENVIRONMENT_VARIABLE_VALUE_LENGTH + 1);
     let env_vars = [
@@ -6407,12 +6323,7 @@ fn test_environment_variables_are_not_set_when_value_is_too_long() {
 
 #[test]
 fn test_environment_variables_are_not_set_duplicate_keys() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_execution_config(Config {
-            environment_variables: FlagStatus::Enabled,
-            ..Default::default()
-        })
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
 
     let env_vars = [
         ("KEY1".to_string(), "VALUE1".to_string()),
@@ -6489,12 +6400,7 @@ fn check_environment_variables_via_canister_status(
 
 #[test]
 fn test_environment_variables() {
-    let mut test = ExecutionTestBuilder::new()
-        .with_execution_config(Config {
-            environment_variables: FlagStatus::Enabled,
-            ..Default::default()
-        })
-        .build();
+    let mut test = ExecutionTestBuilder::new().build();
 
     let env_vars = [
         ("KEY1".to_string(), "VALUE1".to_string()),

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -379,7 +379,6 @@ fn setup_execution_helper(
         canister_manager_config,
         Arc::clone(&cycles_account_manager),
         Arc::clone(&fd_factory),
-        config.environment_variables,
     ));
 
     let exec_env = Arc::new(ExecutionEnvironment::new(

--- a/rs/execution_environment/tests/canister_history.rs
+++ b/rs/execution_environment/tests/canister_history.rs
@@ -440,7 +440,8 @@ where
     );
 }
 
-fn canister_history_tracks_controllers_change() {
+#[test]
+fn canister_history_tracks_controllers_change_as_controllers_change() {
     let mut now = std::time::SystemTime::now();
     let env = setup_with_application_subnet();
     env.set_time(now);
@@ -547,11 +548,6 @@ fn canister_history_tracks_controllers_change() {
             reference_change_entries
         );
     }
-}
-
-#[test]
-fn canister_history_tracks_controllers_change_as_controllers_change() {
-    canister_history_tracks_controllers_change();
 }
 
 #[test]

--- a/rs/execution_environment/tests/canister_history.rs
+++ b/rs/execution_environment/tests/canister_history.rs
@@ -1,5 +1,4 @@
 use ic_base_types::{EnvironmentVariables, PrincipalId};
-use ic_config::flag_status::FlagStatus;
 use ic_config::{execution_environment::Config as HypervisorConfig, subnet_config::SubnetConfig};
 use ic_crypto_sha2::Sha256;
 use ic_error_types::{ErrorCode, UserError};
@@ -441,9 +440,9 @@ where
     );
 }
 
-fn canister_history_tracks_controllers_change(environment_variables_flag: FlagStatus) {
+fn canister_history_tracks_controllers_change() {
     let mut now = std::time::SystemTime::now();
-    let env = setup_with_environment_variables_flag(environment_variables_flag);
+    let env = setup_with_application_subnet();
     env.set_time(now);
 
     // declare user IDs
@@ -552,8 +551,7 @@ fn canister_history_tracks_controllers_change(environment_variables_flag: FlagSt
 
 #[test]
 fn canister_history_tracks_controllers_change_as_controllers_change() {
-    canister_history_tracks_controllers_change(FlagStatus::Disabled);
-    canister_history_tracks_controllers_change(FlagStatus::Enabled);
+    canister_history_tracks_controllers_change();
 }
 
 #[test]
@@ -1203,27 +1201,23 @@ fn canister_history_load_snapshot_fails_incorrect_sender_version() {
     );
 }
 
-fn setup_with_environment_variables_flag(environment_variables_flag: FlagStatus) -> StateMachine {
+fn setup_with_application_subnet() -> StateMachine {
     StateMachine::new_with_config(StateMachineConfig::new(
         SubnetConfig::new(SubnetType::Application),
-        HypervisorConfig {
-            environment_variables: environment_variables_flag,
-            ..Default::default()
-        },
+        HypervisorConfig::default(),
     ))
 }
 
 fn check_environment_variables_for_create_canister_history(
     method: Method,
     payload: Vec<u8>,
-    environment_variables_flag: FlagStatus,
     env_vars: &BTreeMap<String, String>,
     user_id1: PrincipalId,
     user_id2: PrincipalId,
 ) {
     // Set up StateMachine.
     let anonymous_user = PrincipalId::new_anonymous();
-    let env = setup_with_environment_variables_flag(environment_variables_flag);
+    let env = setup_with_application_subnet();
 
     // Set time of StateMachine to current system time.
     let mut now = std::time::SystemTime::now();
@@ -1256,28 +1250,13 @@ fn check_environment_variables_for_create_canister_history(
     let canister_id = canister_id_from_wasm_result(wasm_result);
 
     // Expected canister history.
-    let reference_change_entries = match environment_variables_flag {
-        FlagStatus::Enabled => {
-            let env_vars_hash = EnvironmentVariables::new(env_vars.clone()).hash();
-            vec![CanisterChange::new(
-                now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 1, // the canister is created in the next round after the ingress message is received
-                0,
-                CanisterChangeOrigin::from_canister(ucan.into(), Some(2)),
-                CanisterChangeDetails::canister_creation(
-                    vec![user_id1, user_id2],
-                    Some(env_vars_hash),
-                ),
-            )]
-        }
-        FlagStatus::Disabled => {
-            vec![CanisterChange::new(
-                now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 1, // the canister is created in the next round after the ingress message is received
-                0,
-                CanisterChangeOrigin::from_canister(ucan.into(), Some(2)),
-                CanisterChangeDetails::canister_creation(vec![user_id1, user_id2], None),
-            )]
-        }
-    };
+    let env_vars_hash = EnvironmentVariables::new(env_vars.clone()).hash();
+    let reference_change_entries = vec![CanisterChange::new(
+        now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64 + 1, // the canister is created in the next round after the ingress message is received
+        0,
+        CanisterChangeOrigin::from_canister(ucan.into(), Some(2)),
+        CanisterChangeDetails::canister_creation(vec![user_id1, user_id2], Some(env_vars_hash)),
+    )];
 
     // Verify canister history is updated.
     let history = env.get_canister_history(canister_id);
@@ -1291,20 +1270,10 @@ fn check_environment_variables_for_create_canister_history(
     // Verify the environment variables of the canister state.
     let state = env.get_latest_state();
     let canister_state = state.canister_state(&canister_id).unwrap();
-    match environment_variables_flag {
-        FlagStatus::Enabled => {
-            assert_eq!(
-                canister_state.system_state.environment_variables,
-                EnvironmentVariables::new(env_vars.clone())
-            );
-        }
-        FlagStatus::Disabled => {
-            assert_eq!(
-                canister_state.system_state.environment_variables,
-                EnvironmentVariables::new(BTreeMap::new())
-            );
-        }
-    }
+    assert_eq!(
+        canister_state.system_state.environment_variables,
+        EnvironmentVariables::new(env_vars.clone())
+    );
 }
 
 #[test]
@@ -1317,7 +1286,7 @@ fn canister_history_tracking_env_vars_update_settings() {
     let initial_env_vars_hash = intial_env_vars.hash();
 
     // Set up StateMachine.
-    let env = setup_with_environment_variables_flag(FlagStatus::Enabled);
+    let env = setup_with_application_subnet();
     // Set time of StateMachine to current system time.
     let mut now = std::time::SystemTime::now();
     env.set_time(now);
@@ -1405,7 +1374,7 @@ fn canister_history_tracking_env_vars_update_settings() {
 #[test]
 fn canister_history_no_change_during_update_settings() {
     let user_id = user_test_id(7).get();
-    let env = setup_with_environment_variables_flag(FlagStatus::Enabled);
+    let env = setup_with_application_subnet();
     let canister_id = env.create_canister_with_cycles(
         None,
         INITIAL_CYCLES_BALANCE,
@@ -1485,18 +1454,7 @@ fn canister_history_tracking_env_vars_create_canister() {
 
     check_environment_variables_for_create_canister_history(
         Method::CreateCanister,
-        payload.clone(),
-        FlagStatus::Enabled,
-        &env_vars,
-        user_id1,
-        user_id2,
-    );
-
-    // TODO(EXC-2071): Delete test when feature flag is removed.
-    check_environment_variables_for_create_canister_history(
-        Method::CreateCanister,
         payload,
-        FlagStatus::Disabled,
         &env_vars,
         user_id1,
         user_id2,
@@ -1533,18 +1491,7 @@ fn canister_history_tracking_env_vars_provisional_create_canister() {
     .encode();
     check_environment_variables_for_create_canister_history(
         Method::ProvisionalCreateCanisterWithCycles,
-        payload.clone(),
-        FlagStatus::Enabled,
-        &env_vars,
-        user_id1,
-        user_id2,
-    );
-
-    // TODO(EXC-2071): Delete test when feature flag is removed.
-    check_environment_variables_for_create_canister_history(
-        Method::ProvisionalCreateCanisterWithCycles,
         payload,
-        FlagStatus::Disabled,
         &env_vars,
         user_id1,
         user_id2,
@@ -1568,7 +1515,7 @@ fn canister_history_tracking_env_vars_update_with_identical_values() {
         .collect::<Vec<_>>();
 
     // Set up StateMachine with environment variables tracking enabled.
-    let env = setup_with_environment_variables_flag(FlagStatus::Enabled);
+    let env = setup_with_application_subnet();
     let mut now = std::time::SystemTime::now();
     env.set_time(now);
 

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -2807,14 +2807,6 @@ impl ExecutionTestBuilder {
         self
     }
 
-    pub fn with_environment_variables_flag(
-        mut self,
-        environment_variables_flag: FlagStatus,
-    ) -> Self {
-        self.execution_config.environment_variables = environment_variables_flag;
-        self
-    }
-
     pub fn with_deterministic_memory_tracker_enabled(mut self, enabled: bool) -> Self {
         self.execution_config
             .embedders_config


### PR DESCRIPTION
The environment variables feature has been rolled out since a long time so this PR cleans up its feature flag.