### PR TITLE
test: add canister logging resize benchmarks

### DIFF
--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -469,8 +469,10 @@ rust_ic_bench(
         # Keep sorted.
         "//rs/config",
         "//rs/registry/subnet_type",
+        "//rs/replicated_state",
         "//rs/rust_canisters/canister_test",
         "//rs/state_machine_tests",
+        "//rs/test_utilities/execution_environment",
         "//rs/types/base_types",
         "//rs/types/cycles",
         "//rs/types/management_canister_types",

--- a/rs/execution_environment/benches/management_canister/canister_logging.rs
+++ b/rs/execution_environment/benches/management_canister/canister_logging.rs
@@ -14,18 +14,17 @@ use ic_types_cycles::Cycles;
 const KIB: u64 = 1024;
 const MIB: u64 = 1024 * KIB;
 
-/// Zero-byte messages create the maximum number of records per buffer,
-/// which is the worst case for resize (most deserialization/re-encoding work).
-const LOG_MESSAGE_SIZE: usize = 0;
-
 fn run_bench_resize_canister_log<M: criterion::measurement::Measurement>(
     group: &mut BenchmarkGroup<M>,
     bench_name: &str,
     initial_log_memory_limit: u64,
     new_log_memory_limit: u64,
 ) {
-    let log_message = vec![b'a'; LOG_MESSAGE_SIZE];
-    let record_size = LogMemoryStore::estimate_record_size(LOG_MESSAGE_SIZE) as u64;
+    // Empty messages maximize records per buffer — worst case for resize
+    // since each record is deserialized and re-encoded individually.
+    let log_message_size = 0;
+    let log_message = vec![b'a'; log_message_size];
+    let record_size = LogMemoryStore::estimate_record_size(log_message_size) as u64;
     let records_to_fill = (initial_log_memory_limit / record_size + 1) as u32;
 
     group.bench_function(bench_name, |b| {

--- a/rs/execution_environment/benches/management_canister/canister_logging.rs
+++ b/rs/execution_environment/benches/management_canister/canister_logging.rs
@@ -1,0 +1,109 @@
+use std::time::Duration;
+
+use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main};
+use ic_base_types::PrincipalId;
+use ic_management_canister_types_private::{
+    CanisterInstallMode, CanisterSettingsArgsBuilder, LogVisibilityV2,
+};
+use ic_registry_subnet_type::SubnetType;
+use ic_replicated_state::canister_state::system_state::log_memory_store::LogMemoryStore;
+use ic_state_machine_tests::StateMachineBuilder;
+use ic_test_utilities_execution_environment::{wat_canister, wat_fn};
+use ic_types_cycles::Cycles;
+
+const KIB: u64 = 1024;
+const MIB: u64 = 1024 * KIB;
+
+/// Message size used for log records in benchmarks.
+const LOG_MESSAGE_SIZE: usize = 100;
+
+/// How many records to write per ingress call.
+/// Chosen so that 2 MiB of logs can be filled in 1-2 calls.
+const RECORDS_PER_CALL: u32 = 20_000;
+
+fn run_bench_resize_canister_log<M: criterion::measurement::Measurement>(
+    group: &mut BenchmarkGroup<M>,
+    bench_name: &str,
+    initial_log_memory_limit: u64,
+    new_log_memory_limit: u64,
+) {
+    let log_message = vec![b'a'; LOG_MESSAGE_SIZE];
+    let record_size = LogMemoryStore::estimate_record_size(LOG_MESSAGE_SIZE) as u64;
+    let records_to_fill = initial_log_memory_limit / record_size + 1;
+    let calls_to_fill = records_to_fill.div_ceil(RECORDS_PER_CALL as u64);
+
+    group.bench_function(bench_name, |b| {
+        b.iter_batched(
+            // Setup: create canister and fill its log store.
+            || {
+                let env = StateMachineBuilder::new()
+                    .with_subnet_type(SubnetType::Application)
+                    .with_checkpoints_enabled(false)
+                    .build();
+                let settings = CanisterSettingsArgsBuilder::new()
+                    .with_controllers(vec![PrincipalId::new_anonymous()])
+                    .with_log_memory_limit(initial_log_memory_limit)
+                    .with_log_visibility(LogVisibilityV2::Public)
+                    .build();
+                let canister_id = env.create_canister_with_cycles(
+                    None,
+                    Cycles::new(u128::MAX / 2),
+                    Some(settings),
+                );
+                env.install_wasm_in_mode(
+                    canister_id,
+                    CanisterInstallMode::Install,
+                    wat_canister()
+                        .update(
+                            "fill_logs",
+                            wat_fn().repeat(RECORDS_PER_CALL, wat_fn().debug_print(&log_message)),
+                        )
+                        .build_wasm(),
+                    vec![],
+                )
+                .unwrap();
+                for _ in 0..calls_to_fill {
+                    let _ = env.execute_ingress(canister_id, "fill_logs", vec![]);
+                }
+                (env, canister_id)
+            },
+            // Measurement: resize the log memory store.
+            |(env, canister_id)| {
+                let result = env.update_settings(
+                    &canister_id,
+                    CanisterSettingsArgsBuilder::new()
+                        .with_log_memory_limit(new_log_memory_limit)
+                        .build(),
+                );
+                assert!(result.is_ok());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
+
+pub fn canister_logging_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resize_canister_log");
+    group.sample_size(60);
+    group.warm_up_time(Duration::from_secs(1));
+
+    // Varying sizes to verify linear scaling of resize cost.
+    run_bench_resize_canister_log(
+        &mut group,
+        "from:256KiB/to:-1/msg:100B",
+        256 * KIB,
+        256 * KIB - 1,
+    );
+    run_bench_resize_canister_log(&mut group, "from:1MiB/to:-1/msg:100B", MIB, MIB - 1);
+    run_bench_resize_canister_log(&mut group, "from:2MiB/to:-1/msg:100B", 2 * MIB, 2 * MIB - 1);
+    // Resize up to confirm symmetric cost.
+    run_bench_resize_canister_log(
+        &mut group,
+        "from:2MiB-1/to:2MiB/msg:100B",
+        2 * MIB - 1,
+        2 * MIB,
+    );
+}
+
+criterion_group!(benchmarks, canister_logging_benchmark);
+criterion_main!(benchmarks);

--- a/rs/execution_environment/benches/management_canister/canister_logging.rs
+++ b/rs/execution_environment/benches/management_canister/canister_logging.rs
@@ -14,12 +14,9 @@ use ic_types_cycles::Cycles;
 const KIB: u64 = 1024;
 const MIB: u64 = 1024 * KIB;
 
-/// Message size used for log records in benchmarks.
-const LOG_MESSAGE_SIZE: usize = 100;
-
-/// How many records to write per ingress call.
-/// Chosen so that 2 MiB of logs can be filled in 1-2 calls.
-const RECORDS_PER_CALL: u32 = 20_000;
+/// Zero-byte messages create the maximum number of records per buffer,
+/// which is the worst case for resize (most deserialization/re-encoding work).
+const LOG_MESSAGE_SIZE: usize = 0;
 
 fn run_bench_resize_canister_log<M: criterion::measurement::Measurement>(
     group: &mut BenchmarkGroup<M>,
@@ -29,8 +26,7 @@ fn run_bench_resize_canister_log<M: criterion::measurement::Measurement>(
 ) {
     let log_message = vec![b'a'; LOG_MESSAGE_SIZE];
     let record_size = LogMemoryStore::estimate_record_size(LOG_MESSAGE_SIZE) as u64;
-    let records_to_fill = initial_log_memory_limit / record_size + 1;
-    let calls_to_fill = records_to_fill.div_ceil(RECORDS_PER_CALL as u64);
+    let records_to_fill = (initial_log_memory_limit / record_size + 1) as u32;
 
     group.bench_function(bench_name, |b| {
         b.iter_batched(
@@ -56,15 +52,13 @@ fn run_bench_resize_canister_log<M: criterion::measurement::Measurement>(
                     wat_canister()
                         .update(
                             "fill_logs",
-                            wat_fn().repeat(RECORDS_PER_CALL, wat_fn().debug_print(&log_message)),
+                            wat_fn().repeat(records_to_fill, wat_fn().debug_print(&log_message)),
                         )
                         .build_wasm(),
                     vec![],
                 )
                 .unwrap();
-                for _ in 0..calls_to_fill {
-                    let _ = env.execute_ingress(canister_id, "fill_logs", vec![]);
-                }
+                let _ = env.execute_ingress(canister_id, "fill_logs", vec![]);
                 (env, canister_id)
             },
             // Measurement: resize the log memory store.
@@ -90,16 +84,16 @@ pub fn canister_logging_benchmark(c: &mut Criterion) {
     // Varying sizes to verify linear scaling of resize cost.
     run_bench_resize_canister_log(
         &mut group,
-        "from:256KiB/to:-1/msg:100B",
+        "from:256KiB/to:-1/msg:0B",
         256 * KIB,
         256 * KIB - 1,
     );
-    run_bench_resize_canister_log(&mut group, "from:1MiB/to:-1/msg:100B", MIB, MIB - 1);
-    run_bench_resize_canister_log(&mut group, "from:2MiB/to:-1/msg:100B", 2 * MIB, 2 * MIB - 1);
+    run_bench_resize_canister_log(&mut group, "from:1MiB/to:-1/msg:0B", MIB, MIB - 1);
+    run_bench_resize_canister_log(&mut group, "from:2MiB/to:-1/msg:0B", 2 * MIB, 2 * MIB - 1);
     // Resize up to confirm symmetric cost.
     run_bench_resize_canister_log(
         &mut group,
-        "from:2MiB-1/to:2MiB/msg:100B",
+        "from:2MiB-1/to:2MiB/msg:0B",
         2 * MIB - 1,
         2 * MIB,
     );

--- a/rs/execution_environment/benches/management_canister/main.rs
+++ b/rs/execution_environment/benches/management_canister/main.rs
@@ -1,3 +1,4 @@
+mod canister_logging;
 mod canister_snapshots;
 mod create_canisters;
 mod ecdsa;
@@ -9,12 +10,13 @@ mod utils;
 use criterion::{Criterion, criterion_group, criterion_main};
 
 fn all_benchmarks(c: &mut Criterion) {
+    canister_logging::canister_logging_benchmark(c);
     canister_snapshots::benchmark(c);
     create_canisters::create_canisters_benchmark(c);
-    install_code::install_code_benchmark(c);
-    update_settings::update_settings_benchmark(c);
     ecdsa::ecdsa_benchmark(c);
     http_request::http_request_benchmark(c);
+    install_code::install_code_benchmark(c);
+    update_settings::update_settings_benchmark(c);
 }
 
 criterion_group!(benchmarks, all_benchmarks);


### PR DESCRIPTION
This PR adds criterion benchmarks for log memory store resize operations in `update_settings`. 

Covers resize down at 256 KiB, 1 MiB, 2 MiB buffer sizes and resize up at 2 MiB to verify linear scaling and symmetric cost.