### PR TITLE
fix: deflake //rs/tests/idx:test_e2e_scenarios

### DIFF
--- a/rs/tests/driver/src/driver/process.rs
+++ b/rs/tests/driver/src/driver/process.rs
@@ -95,14 +95,14 @@ impl Process {
     {
         let buffered_reader = BufReader::new(src);
         let mut lines = buffered_reader.lines();
+        let task_id_str = format!("{task_id}");
+        let output_channel_str = format!("{channel_tag:?}");
         loop {
             select! {
                 line_res = lines.next_line() => {
                     match line_res {
                         Ok(Some(line)) => {
-                            let task_id: String = format!("{task_id}");
-                            let output_channel: String = format!("{channel_tag:?}");
-                            info!(log, "{}", line; "task_id" => task_id, "output_channel" => output_channel)
+                            info!(log, "{}", line; "task_id" => &task_id_str, "output_channel" => &output_channel_str)
                         }
                         Ok(None) => break,
                         Err(e) => eprintln!("listen_on_channel(): {e:?}"),
@@ -114,13 +114,23 @@ impl Process {
                     // Use a short timeout to avoid blocking on grandchild
                     // processes that keep the pipe open after the child is killed.
                     let drain_timeout = Duration::from_secs(1);
-                    let _ = timeout(drain_timeout, async {
-                        while let Ok(Some(line)) = lines.next_line().await {
-                            let task_id: String = format!("{task_id}");
-                            let output_channel: String = format!("{channel_tag:?}");
-                            info!(log, "{}", line; "task_id" => task_id, "output_channel" => output_channel);
+                    match timeout(drain_timeout, async {
+                        loop {
+                            match lines.next_line().await {
+                                Ok(Some(line)) => {
+                                    info!(log, "{}", line; "task_id" => &task_id_str, "output_channel" => &output_channel_str);
+                                }
+                                Ok(None) => break,
+                                Err(e) => {
+                                    info!(log, "({}|{:?}): Error during drain: {e:?}", task_id, channel_tag);
+                                    break;
+                                }
+                            }
                         }
-                    }).await;
+                    }).await {
+                        Ok(()) => info!(log, "({}|{:?}): Drain complete.", task_id, channel_tag),
+                        Err(_) => info!(log, "({}|{:?}): Drain timed out.", task_id, channel_tag),
+                    }
                     return;
                 }
             }

--- a/rs/tests/driver/src/driver/process.rs
+++ b/rs/tests/driver/src/driver/process.rs
@@ -4,12 +4,14 @@ use nix::{
 };
 use slog::{Logger, info};
 use std::process::{Command, ExitStatus, Stdio};
+use std::time::Duration;
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, BufReader},
     process::{Child, Command as AsyncCommand},
     select,
     sync::watch::{Receiver, channel},
     task::{self, JoinHandle},
+    time::timeout,
 };
 
 pub trait KillFn: FnOnce() + Send + Sync {}
@@ -107,7 +109,18 @@ impl Process {
                     }
                 }
                 _ = kill_watch.changed() => {
-                    info!(log, "({}|{:?}): Kill received.", task_id, channel_tag);
+                    info!(log, "({}|{:?}): Kill received. Draining remaining output ...", task_id, channel_tag);
+                    // Drain any remaining buffered lines before returning.
+                    // Use a short timeout to avoid blocking on grandchild
+                    // processes that keep the pipe open after the child is killed.
+                    let drain_timeout = Duration::from_secs(1);
+                    let _ = timeout(drain_timeout, async {
+                        while let Ok(Some(line)) = lines.next_line().await {
+                            let task_id: String = format!("{task_id}");
+                            let output_channel: String = format!("{channel_tag:?}");
+                            info!(log, "{}", line; "task_id" => task_id, "output_channel" => output_channel);
+                        }
+                    }).await;
                     return;
                 }
             }


### PR DESCRIPTION
## Root Cause Analysis

4 flaky runs observed in the past week (Apr 8–14, 2026), all failing on attempt 1 and passing on attempt 2. The **most common root cause** (3 out of 4 failures) is `test_test_spawning_proc_gets_stopped`:

### Race condition in output capture on kill

`listen_on_channel()` in `rs/tests/driver/src/driver/process.rs` uses `tokio::select!` to read subprocess output lines vs. a kill signal. When the kill signal fires (on test timeout), the `kill_watch.changed()` branch can win the `select!` race against a pending `next_line()` read, causing **already-buffered output to be discarded**.

The `test_child_process` scenario spawns a grandchild `sh` process printing `magicchild1`, `magicchild2`, etc. (one per second) with a 5-second per-test timeout. The test asserts `magicchild1` appears in captured output. Under load (21 test cases running in parallel, each spawning subprocesses), the kill signal races against the line read, and the output is lost.

**Failure evidence:**
- 2 failures: `assertion failed: err_str.contains("magicchild1")` — output lost
- 1 failure: `left: 1, right: 2` success count mismatch — incomplete report from same race

A 4th failure (`test_overall_group_timeout_in_test`, tight 5s overall timeout) is a separate load-dependent issue not addressed here.

## Fix

After receiving the kill signal in `listen_on_channel`, drain remaining buffered lines with a 1-second timeout before returning. This ensures output already in the pipe buffer gets captured, while still not blocking indefinitely on grandchild processes that keep the pipe open after the child is killed.

Also precomputes `task_id`/`output_channel` format strings once before the loop to avoid per-line allocations.

## Verification

Ran `bazel test --test_output=errors --runs_per_test=3 --jobs=3 //rs/tests/idx:test_e2e_scenarios` — all 3 runs passed (twice, before and after addressing review comments).

---
*This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.*