### PR TITLE
refactor(governance): remove old CMC-based maturity modulation polling

### DIFF
--- a/rs/nns/governance/canister/canister.rs
+++ b/rs/nns/governance/canister/canister.rs
@@ -1,7 +1,6 @@
 use ic_base_types::PrincipalId;
 use ic_cdk::{heartbeat, init, post_upgrade, pre_upgrade, println, update};
 use ic_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
-use ic_nervous_system_canisters::cmc::CMCCanister;
 use ic_nervous_system_clients::exchange_rate_canister_client::RealExchangeRateCanisterClient;
 use ic_nervous_system_common::{
     memory_manager_upgrade_storage::{load_protobuf, store_protobuf},
@@ -128,7 +127,6 @@ fn canister_init_(init_payload: ApiGovernanceProto) {
         init_payload,
         Arc::new(CanisterEnv::new()),
         Arc::new(IcpLedgerCanister::<CdkRuntime>::new(LEDGER_CANISTER_ID)),
-        Arc::new(CMCCanister::<CdkRuntime>::new()),
         Box::new(CanisterRandomnessGenerator::new()),
     ));
 
@@ -175,7 +173,6 @@ fn canister_post_upgrade() {
         restored_state,
         Arc::new(CanisterEnv::new()),
         Arc::new(IcpLedgerCanister::<CdkRuntime>::new(LEDGER_CANISTER_ID)),
-        Arc::new(CMCCanister::<CdkRuntime>::new()),
         Box::new(CanisterRandomnessGenerator::new()),
     ));
 

--- a/rs/nns/governance/src/canister_state.rs
+++ b/rs/nns/governance/src/canister_state.rs
@@ -6,7 +6,6 @@ use crate::{
 
 use async_trait::async_trait;
 use ic_base_types::CanisterId;
-use ic_nervous_system_canisters::cmc::CMCCanister;
 use ic_nervous_system_canisters::ledger::IcpLedgerCanister;
 use ic_nervous_system_runtime::CdkRuntime;
 use ic_nervous_system_runtime::Runtime;
@@ -25,7 +24,6 @@ thread_local! {
     pub(crate) static GOVERNANCE: RefCell<Governance> = RefCell::new(Governance::new_uninitialized(
         Arc::new(CanisterEnv::new()),
         Arc::new(IcpLedgerCanister::<CdkRuntime>::new(LEDGER_CANISTER_ID)),
-        Arc::new(CMCCanister::<CdkRuntime>::new()),
         Box::new(CanisterRandomnessGenerator::new()),
     ));
 }

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -93,7 +93,6 @@ use ic_base_types::{CanisterId, PrincipalId};
 use ic_cdk::println;
 #[cfg(target_arch = "wasm32")]
 use ic_cdk::spawn;
-use ic_nervous_system_canisters::cmc::CMC;
 use ic_nervous_system_canisters::ledger::IcpLedger;
 use ic_nervous_system_common::{
     NervousSystemError, ONE_DAY_SECONDS, ONE_MONTH_SECONDS, ONE_YEAR_SECONDS, ledger,
@@ -1103,9 +1102,6 @@ pub struct Governance {
     /// Implementation of the interface with the Ledger canister.
     ledger: Arc<dyn IcpLedger>,
 
-    /// Implementation of the interface with the CMC canister.
-    cmc: Arc<dyn CMC>,
-
     /// Implementation of a randomness generator
     randomness: Box<dyn RandomnessGenerator>,
 
@@ -1278,7 +1274,6 @@ impl Governance {
     pub fn new_uninitialized(
         env: Arc<dyn Environment>,
         ledger: Arc<dyn IcpLedger>,
-        cmc: Arc<dyn CMC>,
         randomness: Box<dyn RandomnessGenerator>,
     ) -> Self {
         Self {
@@ -1286,7 +1281,6 @@ impl Governance {
             neuron_store: NeuronStore::new(BTreeMap::new()),
             env,
             ledger,
-            cmc,
             randomness,
             closest_proposal_deadline_timestamp_seconds: 0,
             latest_gc_timestamp_seconds: 0,
@@ -1302,7 +1296,6 @@ impl Governance {
         initial_governance: api::Governance,
         env: Arc<dyn Environment>,
         ledger: Arc<dyn IcpLedger>,
-        cmc: Arc<dyn CMC>,
         randomness: Box<dyn RandomnessGenerator>,
     ) -> Self {
         let (neurons, heap_governance_proto) = initialize_governance(initial_governance, env.now());
@@ -1312,7 +1305,6 @@ impl Governance {
             neuron_store: NeuronStore::new(neurons),
             env,
             ledger,
-            cmc,
             randomness,
             closest_proposal_deadline_timestamp_seconds: 0,
             latest_gc_timestamp_seconds: 0,
@@ -1327,7 +1319,6 @@ impl Governance {
         governance_proto: GovernanceProto,
         env: Arc<dyn Environment>,
         ledger: Arc<dyn IcpLedger>,
-        cmc: Arc<dyn CMC>,
         mut randomness: Box<dyn RandomnessGenerator>,
     ) -> Self {
         let (mut heap_governance_proto, maybe_rng_seed) = split_governance_proto(governance_proto);
@@ -1349,7 +1340,6 @@ impl Governance {
             neuron_store: NeuronStore::new_restored(),
             env,
             ledger,
-            cmc,
             randomness,
             closest_proposal_deadline_timestamp_seconds: 0,
             latest_gc_timestamp_seconds: 0,

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6273,9 +6273,6 @@ impl Governance {
                     GovernanceError::from(e),
                 ),
             }
-        // Try to update maturity modulation (once per day).
-        } else if self.should_update_maturity_modulation() {
-            self.update_maturity_modulation().await;
         } else {
             // This is the lowest-priority async task. All other tasks should have their own
             // `else if`, like the ones above.
@@ -6289,48 +6286,6 @@ impl Governance {
         }
 
         self.maybe_gc();
-    }
-
-    fn should_update_maturity_modulation(&self) -> bool {
-        // Check if we're already updating the neuron maturity modulation.
-        let now_seconds = self.env.now();
-        let last_updated = self
-            .heap_data
-            .maturity_modulation_last_updated_at_timestamp_seconds;
-        last_updated.is_none() || last_updated.unwrap() + ONE_DAY_SECONDS <= now_seconds
-    }
-
-    async fn update_maturity_modulation(&mut self) {
-        if !self.should_update_maturity_modulation() {
-            return;
-        };
-
-        let now_seconds = self.env.now();
-        let maturity_modulation = match self.cmc.neuron_maturity_modulation().await {
-            Ok(maturity_modulation) => maturity_modulation,
-            Err(err) => {
-                let silence_message =
-                    err.contains("Canister rkp4c-7iaaa-aaaaa-aaaca-cai not found");
-                if !silence_message {
-                    println!(
-                        "{}Couldn't update maturity modulation. Error: {}",
-                        LOG_PREFIX, err
-                    );
-                }
-                return;
-            }
-        };
-        println!(
-            "{}Updated daily maturity modulation rate to (in basis points): {}, at: {}. Last updated: {:?}",
-            LOG_PREFIX,
-            maturity_modulation,
-            now_seconds,
-            self.heap_data
-                .maturity_modulation_last_updated_at_timestamp_seconds,
-        );
-        self.heap_data.cached_daily_maturity_modulation_basis_points = Some(maturity_modulation);
-        self.heap_data
-            .maturity_modulation_last_updated_at_timestamp_seconds = Some(now_seconds);
     }
 
     fn should_refresh_xdr_rate(&self) -> bool {

--- a/rs/nns/governance/src/governance/benches.rs
+++ b/rs/nns/governance/src/governance/benches.rs
@@ -14,7 +14,7 @@ use crate::{
         NnsFunction, Proposal, ProposalData, Topic, Vote, install_code::CanisterInstallMode,
         proposal::Action,
     },
-    test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
+    test_utils::{MockEnvironment, StubIcpLedger},
 };
 use canbench_rs::{BenchResult, bench, bench_fn};
 use futures::FutureExt;
@@ -335,7 +335,6 @@ fn cast_vote_cascade_helper(strategy: SetUpStrategy, topic: Topic) -> BenchResul
         Default::default(),
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -446,7 +445,6 @@ fn compute_ballots_for_new_proposal_with_stable_neurons() -> BenchResult {
         Default::default(),
         Arc::new(MockEnvironment::new(vec![], now_seconds)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -541,7 +539,6 @@ fn distribute_rewards_with_stable_neurons() -> BenchResult {
         governance_api,
         Arc::new(MockEnvironment::new(vec![], now_seconds)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -560,7 +557,6 @@ fn list_neurons() -> BenchResult {
         Default::default(),
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -617,7 +613,6 @@ fn list_neurons_by_subaccount() -> BenchResult {
         Default::default(),
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -661,7 +656,6 @@ fn list_proposals_benchmark() -> BenchResult {
         },
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 

--- a/rs/nns/governance/src/governance/create_neuron_tests.rs
+++ b/rs/nns/governance/src/governance/create_neuron_tests.rs
@@ -5,7 +5,7 @@ use crate::{
     test_utils::{MockEnvironment, MockRandomness},
 };
 
-use ic_nervous_system_canisters::{cmc::MockCMC, ledger::MockIcpLedger};
+use ic_nervous_system_canisters::ledger::MockIcpLedger;
 use ic_nervous_system_common::{E8, ONE_YEAR_SECONDS};
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance_api::{
@@ -24,7 +24,6 @@ thread_local! {
     static TEST_GOVERNANCE: RefCell<Governance> = RefCell::new(Governance::new_uninitialized(
         MOCK_ENVIRONMENT.with(|env| env.clone()),
         Arc::new(MockIcpLedger::default()),
-        Arc::new(MockCMC::default()),
         Box::new(MockRandomness::new()),
     ));
 }
@@ -61,7 +60,6 @@ fn set_governance_for_test(mock_ledger: MockIcpLedger) {
         },
         MOCK_ENVIRONMENT.with(|env| env.clone()),
         Arc::new(mock_ledger),
-        Arc::new(MockCMC::default()),
         Box::new(MockRandomness::new()),
     );
 

--- a/rs/nns/governance/src/governance/disburse_maturity_tests.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity_tests.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 use futures::FutureExt;
-use ic_nervous_system_canisters::{cmc::MockCMC, ledger::MockIcpLedger};
+use ic_nervous_system_canisters::ledger::MockIcpLedger;
 use ic_nervous_system_common::NervousSystemError;
 use ic_nns_governance_api::Governance as GovernanceApi;
 use icp_ledger::AccountIdentifier;
@@ -471,7 +471,6 @@ thread_local! {
     static TEST_GOVERNANCE: RefCell<Governance> = RefCell::new(Governance::new_uninitialized(
         MOCK_ENVIRONMENT.with(|env| env.clone()),
         Arc::new(MockIcpLedger::default()),
-        Arc::new(MockCMC::default()),
         Box::new(MockRandomness::new()),
     ));
 }
@@ -540,7 +539,6 @@ fn set_governance_for_test(
         GovernanceApi::default(),
         MOCK_ENVIRONMENT.with(|env| env.clone()),
         Arc::new(mock_ledger),
-        Arc::new(MockCMC::default()),
         Box::new(MockRandomness::new()),
     );
     governance.heap_data.maturity_modulation = Some(MaturityModulation {

--- a/rs/nns/governance/src/governance/tests/get_maturity_modulation.rs
+++ b/rs/nns/governance/src/governance/tests/get_maturity_modulation.rs
@@ -1,6 +1,6 @@
 use crate::governance::{
     Governance,
-    tests::{MockEnvironment, StubCMC, StubIcpLedger},
+    tests::{MockEnvironment, StubIcpLedger},
 };
 use crate::pb::v1::MaturityModulation;
 use crate::test_utils::MockRandomness;
@@ -15,7 +15,6 @@ fn make_governance() -> Governance {
         Default::default(),
         Arc::new(MockEnvironment::new(vec![], 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     )
 }

--- a/rs/nns/governance/src/governance/tests/get_neuron_index.rs
+++ b/rs/nns/governance/src/governance/tests/get_neuron_index.rs
@@ -5,7 +5,7 @@ use crate::neuron_store::MAX_NEURON_PAGE_SIZE;
 use crate::test_utils::MockRandomness;
 use crate::{
     governance::Governance,
-    test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
+    test_utils::{MockEnvironment, StubIcpLedger},
 };
 use crate::{
     temporarily_disable_comprehensive_neuron_list, temporarily_enable_comprehensive_neuron_list,
@@ -26,7 +26,6 @@ fn make_governance_for_neuron_index() -> Governance {
         },
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 

--- a/rs/nns/governance/src/governance/tests/list_neurons.rs
+++ b/rs/nns/governance/src/governance/tests/list_neurons.rs
@@ -2,7 +2,7 @@ use crate::neuron::{DissolveStateAndAge, NeuronBuilder};
 use crate::test_utils::MockRandomness;
 use crate::{
     governance::Governance,
-    test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
+    test_utils::{MockEnvironment, StubIcpLedger},
 };
 use ic_base_types::PrincipalId;
 use ic_nns_governance_api::{
@@ -39,7 +39,6 @@ fn test_list_neurons_with_paging() {
         },
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -136,7 +135,6 @@ fn test_list_neurons_by_subaccounts_and_ids() {
         },
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 

--- a/rs/nns/governance/src/governance/tests/list_proposals.rs
+++ b/rs/nns/governance/src/governance/tests/list_proposals.rs
@@ -10,7 +10,7 @@ use crate::{
         manage_neuron::{Command, NeuronIdOrSubaccount, RegisterVote},
         proposal::Action,
     },
-    test_utils::{MockEnvironment, MockRandomness, StubCMC, StubIcpLedger},
+    test_utils::{MockEnvironment, MockRandomness, StubIcpLedger},
 };
 
 use assert_matches::assert_matches;
@@ -43,7 +43,6 @@ fn new_governance() -> Governance {
         },
         Arc::new(MockEnvironment::new(Default::default(), *NOW)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     )
 }

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -4,7 +4,7 @@ use crate::storage::with_voting_history_store;
 use crate::test_utils::MockRandomness;
 use crate::{
     neuron::{DissolveStateAndAge, NeuronBuilder},
-    test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
+    test_utils::{MockEnvironment, StubIcpLedger},
 };
 use ic_base_types::PrincipalId;
 use ic_nervous_system_common::{
@@ -866,7 +866,7 @@ mod metrics_tests {
         encode_metrics,
         governance::Governance,
         pb::v1::{Motion, Proposal, ProposalData, Tally, Topic, proposal},
-        test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
+        test_utils::{MockEnvironment, StubIcpLedger},
     };
 
     #[test]
@@ -875,7 +875,6 @@ mod metrics_tests {
             Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 0)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 
@@ -937,7 +936,6 @@ mod metrics_tests {
             Default::default(),
             Arc::<MockEnvironment>::default(),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 
@@ -1167,7 +1165,6 @@ fn test_pre_and_post_upgrade_first_time() {
         Default::default(),
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -1193,7 +1190,6 @@ fn test_pre_and_post_upgrade_first_time() {
         extracted_proto,
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -1211,7 +1207,6 @@ fn can_spawn_neurons_only_true_when_not_spawning_and_neurons_ready_to_spawn() {
         Default::default(),
         Arc::new(mock_env),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
     // No neurons to spawn...
@@ -1259,7 +1254,6 @@ fn test_validate_execute_nns_function() {
         },
         Arc::new(MockEnvironment::new(vec![], 100)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -1488,7 +1482,6 @@ fn test_update_neuron_errors_out_expectedly() {
         Default::default(),
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
     let neuron = new_neuron(vec![1; 32]);
@@ -1539,7 +1532,6 @@ fn test_compute_ballots_for_manage_neuron_proposal() {
         Default::default(),
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -1584,7 +1576,6 @@ fn test_compute_ballots_for_standard_proposal() {
         Default::default(),
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 

--- a/rs/nns/governance/src/governance/tests/neurons_fund.rs
+++ b/rs/nns/governance/src/governance/tests/neurons_fund.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     pb::v1::create_service_nervous_system::SwapParameters,
-    test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
+    test_utils::{MockEnvironment, StubIcpLedger},
 };
 use assert_matches::assert_matches;
 use ic_nervous_system_common::E8;
@@ -21,7 +21,6 @@ fn proposal_passes_if_not_too_many_nf_neurons_can_occur() {
         governance_init,
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -90,7 +89,6 @@ fn proposal_fails_if_too_many_nf_neurons_can_occur() {
         governance_init,
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
     governance.heap_data.proposals.insert(
@@ -130,7 +128,6 @@ fn proposal_fails_if_no_nf_neurons_exist() {
         governance_init,
         Arc::<MockEnvironment>::default(),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
     governance.heap_data.proposals.insert(

--- a/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
+++ b/rs/nns/governance/src/governance/tests/node_provider_rewards.rs
@@ -3,7 +3,7 @@ use crate::{
     governance::Governance,
     node_provider_rewards::DateRangeFilter,
     pb::v1::MonthlyNodeProviderRewards,
-    test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
+    test_utils::{MockEnvironment, StubIcpLedger},
 };
 use std::sync::Arc;
 
@@ -38,7 +38,6 @@ fn test_node_provider_rewards_read_from_correct_sources() {
         Default::default(),
         Arc::new(MockEnvironment::new(vec![], 100)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -95,7 +94,6 @@ fn test_list_node_provider_rewards_api() {
         Default::default(),
         Arc::new(MockEnvironment::new(vec![], 100)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -114,7 +112,6 @@ fn test_list_node_provider_rewards_api_with_paging_and_filters() {
         Default::default(),
         Arc::new(MockEnvironment::new(vec![], 100)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 

--- a/rs/nns/governance/src/governance/tests/stake_maturity.rs
+++ b/rs/nns/governance/src/governance/tests/stake_maturity.rs
@@ -3,7 +3,7 @@ use crate::test_utils::MockRandomness;
 use crate::{
     governance::{
         Governance,
-        tests::{MockEnvironment, StubCMC, StubIcpLedger},
+        tests::{MockEnvironment, StubIcpLedger},
     },
     pb::v1::manage_neuron::StakeMaturity,
 };
@@ -18,7 +18,6 @@ fn test_stake_maturity() {
         Default::default(),
         Arc::new(MockEnvironment::new(vec![], 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 
@@ -60,7 +59,6 @@ fn test_stake_maturity_of_dissolved_neuron_fails() {
         Default::default(),
         Arc::new(MockEnvironment::new(vec![], 100)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     );
 

--- a/rs/nns/governance/src/governance/tests/update_node_provider.rs
+++ b/rs/nns/governance/src/governance/tests/update_node_provider.rs
@@ -1,4 +1,4 @@
-use crate::governance::tests::{MockEnvironment, StubCMC, StubIcpLedger};
+use crate::governance::tests::{MockEnvironment, StubIcpLedger};
 use crate::test_utils::MockRandomness;
 use crate::{
     governance::Governance,
@@ -146,7 +146,6 @@ fn create_governance_with_node_provider(node_provider_id: PrincipalId) -> Govern
         initial_governance,
         Arc::new(MockEnvironment::new(vec![], 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     )
 }

--- a/rs/nns/governance/src/neuron_lock_tests.rs
+++ b/rs/nns/governance/src/neuron_lock_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use crate::{
     pb::v1::{governance::neuron_in_flight_command::SyncCommand, manage_neuron::Split},
-    test_utils::{MockEnvironment, MockRandomness, StubCMC, StubIcpLedger},
+    test_utils::{MockEnvironment, MockRandomness, StubIcpLedger},
 };
 
 use std::sync::Arc;
@@ -16,7 +16,6 @@ fn new_governance_for_test() -> Governance {
         Default::default(),
         Arc::new(MockEnvironment::new(Default::default(), 0)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     )
 }

--- a/rs/nns/governance/src/reward/distribution.rs
+++ b/rs/nns/governance/src/reward/distribution.rs
@@ -234,7 +234,7 @@ mod test {
     use crate::neuron::{DissolveStateAndAge, Neuron, NeuronBuilder};
     use crate::pb::v1::VotingPowerEconomics;
     use crate::test_utils::{
-        MockEnvironment, MockRandomness, StubCMC, StubIcpLedger, test_subaccount_for_neuron_id,
+        MockEnvironment, MockRandomness, StubIcpLedger, test_subaccount_for_neuron_id,
     };
     use ic_base_types::PrincipalId;
     use ic_nervous_system_timers::test::run_pending_timers_every_interval_for_count;
@@ -400,7 +400,6 @@ mod test {
             Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 0)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 

--- a/rs/nns/governance/src/seed_accounts/seed_accounts_tests.rs
+++ b/rs/nns/governance/src/seed_accounts/seed_accounts_tests.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use candid::Encode;
 use ic_base_types::PrincipalId;
-use ic_nervous_system_common::{E8, cmc::MockCMC, ledger::MockIcpLedger};
+use ic_nervous_system_common::{E8, ledger::MockIcpLedger};
 use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_governance_api as api;
 use icp_ledger::Subaccount;
@@ -49,7 +49,6 @@ fn test_can_tag_seed_neurons_handles_corrupted_state() {
         Default::default(),
         Arc::new(create_mock_environment(None)),
         Arc::<MockIcpLedger>::default(),
-        Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
 
@@ -112,7 +111,6 @@ fn test_can_tag_seed_neurons_transitions() {
         Default::default(),
         Arc::new(create_mock_environment(None)),
         Arc::<MockIcpLedger>::default(),
-        Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
 
@@ -143,7 +141,6 @@ fn test_can_tag_seed_neurons_exits_early_if_data_is_processed() {
         Default::default(),
         Arc::new(create_mock_environment(None)),
         Arc::<MockIcpLedger>::default(),
-        Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
 
@@ -197,7 +194,6 @@ async fn test_tag_seed_neurons_happy() {
         },
         Arc::new(environment),
         Arc::<MockIcpLedger>::default(),
-        Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
 
@@ -289,7 +285,6 @@ async fn test_tag_neuron_sad() {
         },
         Arc::new(environment),
         Arc::<MockIcpLedger>::default(),
-        Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
 
@@ -389,7 +384,6 @@ async fn test_tag_seed_neurons_handles_neuron_splits() {
         },
         Arc::new(environment),
         Arc::<MockIcpLedger>::default(),
-        Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
 
@@ -458,7 +452,6 @@ async fn test_tag_seed_neurons_doesnt_over_tag_seed_neurons() {
         },
         Arc::new(environment),
         Arc::<MockIcpLedger>::default(),
-        Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
     governance
@@ -510,7 +503,6 @@ fn test_calculate_genesis_account_expected_stake_e8s() {
         },
         Arc::new(create_mock_environment(None)),
         Arc::<MockIcpLedger>::default(),
-        Arc::<MockCMC>::default(),
         Box::new(MockRandomness::new()),
     );
 

--- a/rs/nns/governance/src/test_utils.rs
+++ b/rs/nns/governance/src/test_utils.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 use candid::{Decode, Encode};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_ledger_core::Tokens;
-use ic_nervous_system_canisters::cmc::CMC;
 use ic_nervous_system_canisters::ledger::IcpLedger;
 use ic_nervous_system_common::{E8, NervousSystemError};
 use ic_nns_constants::SNS_WASM_CANISTER_ID;
@@ -136,14 +135,6 @@ impl IcpLedger for StubIcpLedger {
         &self,
         _args: Vec<GetBlocksRequest>,
     ) -> Result<GetBlocksResult, NervousSystemError> {
-        unimplemented!()
-    }
-}
-
-pub(crate) struct StubCMC {}
-#[async_trait]
-impl CMC for StubCMC {
-    async fn neuron_maturity_modulation(&self) -> Result<i32, String> {
         unimplemented!()
     }
 }

--- a/rs/nns/governance/src/timer_tasks/calculate_distributable_rewards.rs
+++ b/rs/nns/governance/src/timer_tasks/calculate_distributable_rewards.rs
@@ -86,7 +86,7 @@ mod tests {
     use super::*;
     use crate::canister_state::{CanisterRandomnessGenerator, set_governance_for_tests};
     use crate::governance::Governance;
-    use crate::test_utils::{MockEnvironment, StubCMC, StubIcpLedger};
+    use crate::test_utils::{MockEnvironment, StubIcpLedger};
     use ic_nns_governance_api as api;
     use std::sync::Arc;
 
@@ -177,7 +177,6 @@ mod tests {
             },
             Arc::new(MockEnvironment::new(vec![], now)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(CanisterRandomnessGenerator::new()),
         );
         set_governance_for_tests(gov);

--- a/rs/nns/governance/src/timer_tasks/distribute_rewards.rs
+++ b/rs/nns/governance/src/timer_tasks/distribute_rewards.rs
@@ -60,7 +60,7 @@ mod tests {
     use crate::canister_state::{GOVERNANCE, governance_mut, set_governance_for_tests};
     use crate::governance::Governance;
     use crate::reward::distribution::RewardsDistribution;
-    use crate::test_utils::{MockEnvironment, MockRandomness, StubCMC, StubIcpLedger};
+    use crate::test_utils::{MockEnvironment, MockRandomness, StubIcpLedger};
     use crate::timer_tasks::distribute_rewards::REWARDS_TIMER_ID;
     use ic_nervous_system_timers::test::{
         existing_timer_ids, has_timer_task, run_pending_timers_every_interval_for_count,
@@ -78,7 +78,6 @@ mod tests {
             Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 0)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 

--- a/rs/nns/governance/src/timer_tasks/snapshot_voting_power.rs
+++ b/rs/nns/governance/src/timer_tasks/snapshot_voting_power.rs
@@ -96,7 +96,7 @@ mod tests {
 
     use crate::{
         neuron::{DissolveStateAndAge, NeuronBuilder},
-        test_utils::{MockEnvironment, MockRandomness, StubCMC, StubIcpLedger},
+        test_utils::{MockEnvironment, MockRandomness, StubIcpLedger},
     };
 
     thread_local! {
@@ -127,7 +127,6 @@ mod tests {
             },
             MOCK_ENVIRONMENT.with(|env| env.clone()),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
         let dissolve_delay_seconds =

--- a/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data_tests.rs
+++ b/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::test_utils::{MockEnvironment, MockRandomness, StubCMC, StubIcpLedger};
+use crate::test_utils::{MockEnvironment, MockRandomness, StubIcpLedger};
 use ic_nervous_system_clients::exchange_rate_canister_client::{
     GetExchangeRateError, ICP_SYMBOL, MINIMUM_CXDR_SOURCES, MINIMUM_ICP_SOURCES,
 };
@@ -63,7 +63,6 @@ fn new_governance(now_seconds: u64) -> Governance {
         api::Governance::default(),
         Arc::new(MockEnvironment::new(vec![], now_seconds)),
         Arc::new(StubIcpLedger {}),
-        Arc::new(StubCMC {}),
         Box::new(MockRandomness::new()),
     )
 }

--- a/rs/nns/governance/src/voting.rs
+++ b/rs/nns/governance/src/voting.rs
@@ -604,9 +604,7 @@ mod test {
         storage::with_voting_state_machines_mut,
         temporarily_disable_mission_70_voting_rewards,
         temporarily_enable_mission_70_voting_rewards,
-        test_utils::{
-            ExpectedCallCanisterMethodCallArguments, MockEnvironment, StubCMC, StubIcpLedger,
-        },
+        test_utils::{ExpectedCallCanisterMethodCallArguments, MockEnvironment, StubIcpLedger},
         voting::{
             ProposalVotingStateMachine, VotingStateMachines,
             temporarily_set_over_soft_message_limit,
@@ -675,7 +673,6 @@ mod test {
             Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 0)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 
@@ -834,7 +831,6 @@ mod test {
             Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 234)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 
@@ -1158,7 +1154,6 @@ mod test {
             Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 0)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 
@@ -1229,7 +1224,6 @@ mod test {
             Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 0)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 
@@ -1284,7 +1278,6 @@ mod test {
             Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 0)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 
@@ -1376,7 +1369,6 @@ mod test {
             Default::default(),
             Arc::new(MockEnvironment::new(Default::default(), 1234)),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 
@@ -1493,7 +1485,6 @@ mod test {
             },
             Arc::new(environment),
             Arc::new(StubIcpLedger {}),
-            Arc::new(StubCMC {}),
             Box::new(MockRandomness::new()),
         );
 

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use futures::future::FutureExt;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_crypto_sha2::Sha256;
-use ic_nervous_system_canisters::cmc::CMC;
 use ic_nervous_system_canisters::ledger::IcpLedger;
 use ic_nervous_system_common::NervousSystemError;
 use ic_nns_common::pb::v1::NeuronId;
@@ -122,13 +121,6 @@ impl IcpLedger for DegradedEnv {
     }
 }
 
-#[async_trait]
-impl CMC for DegradedEnv {
-    async fn neuron_maturity_modulation(&self) -> Result<i32, String> {
-        unimplemented!()
-    }
-}
-
 /// Constructs a test principal id from an integer.
 /// Convenience functions to make creating neurons more concise.
 fn principal(i: u64) -> PrincipalId {
@@ -167,7 +159,6 @@ fn fixture_two_neurons_second_is_bigger() -> api::Governance {
 fn degraded_governance() -> Governance {
     Governance::new(
         fixture_two_neurons_second_is_bigger(),
-        Arc::new(DegradedEnv {}),
         Arc::new(DegradedEnv {}),
         Arc::new(DegradedEnv {}),
         Box::new(CanisterRandomnessGenerator::new()),

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -4,7 +4,6 @@ use cycles_minting_canister::{IcpXdrConversionRate, IcpXdrConversionRateCertifie
 use futures::future::FutureExt;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_ledger_core::tokens::CheckedSub;
-use ic_nervous_system_canisters::cmc::CMC;
 use ic_nervous_system_canisters::ledger::IcpLedger;
 use ic_nervous_system_common::NervousSystemError;
 use ic_nervous_system_timers::test::{advance_time_for_timers, set_time_for_timers};
@@ -206,13 +205,6 @@ impl FakeDriver {
 
     /// Constructs a `Ledger` that interacts with this driver.
     pub fn get_fake_ledger(&self) -> Arc<dyn IcpLedger> {
-        Arc::new(FakeDriver {
-            state: Arc::clone(&self.state),
-            error_on_next_ledger_call: Arc::clone(&self.error_on_next_ledger_call),
-        })
-    }
-
-    pub fn get_fake_cmc(&self) -> Arc<dyn CMC> {
         Arc::new(FakeDriver {
             state: Arc::clone(&self.state),
             error_on_next_ledger_call: Arc::clone(&self.error_on_next_ledger_call),
@@ -452,13 +444,6 @@ impl IcpLedger for FakeDriver {
         Err(NervousSystemError {
             error_message: "Not Implemented".to_string(),
         })
-    }
-}
-
-#[async_trait]
-impl CMC for FakeDriver {
-    async fn neuron_maturity_modulation(&self) -> Result<i32, String> {
-        Ok(100)
     }
 }
 

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -12,7 +12,6 @@ use comparable::Comparable;
 use futures::future::FutureExt;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_crypto_sha2::Sha256;
-use ic_nervous_system_canisters::cmc::CMC;
 use ic_nervous_system_canisters::ledger::IcpLedger;
 use ic_nervous_system_common::NervousSystemError;
 use ic_nns_common::{
@@ -630,13 +629,6 @@ impl Environment for NNSFixture {
     }
 }
 
-#[async_trait]
-impl CMC for NNSFixture {
-    async fn neuron_maturity_modulation(&self) -> Result<i32, String> {
-        Ok(100)
-    }
-}
-
 /// The NNSState is used to capture all of the salient details of the NNS
 /// environment, so that we can compute the "delta", or what changed between
 /// actions.
@@ -1083,7 +1075,6 @@ impl NNSBuilder {
             ledger: self.ledger_builder.create(),
             environment: self.environment_builder.create(),
         });
-        let cmc: Arc<dyn CMC> = Arc::new(fixture.clone());
         let mut ledger: Arc<dyn IcpLedger> = Arc::new(fixture.clone());
         for t in self.ledger_transforms {
             ledger = t(ledger);
@@ -1095,7 +1086,7 @@ impl NNSBuilder {
         let randomness = Box::new(fixture.clone());
         NNS {
             fixture: fixture.clone(),
-            governance: Governance::new(self.governance, environment, ledger, cmc, randomness),
+            governance: Governance::new(self.governance, environment, ledger, randomness),
         }
     }
 

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -240,7 +240,6 @@ fn check_proposal_status_after_voting_and_after_expiration(
         governance_proto,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -636,7 +635,6 @@ async fn test_cascade_following() {
         fixture_for_following(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     gov.make_proposal(
@@ -750,7 +748,6 @@ async fn test_minimum_icp_xdr_conversion_rate_limits_monthly_node_provider_rewar
         fixture_for_following(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     // Set minimum conversion rate.
@@ -810,7 +807,6 @@ async fn test_manage_network_economics_change_one_deep_subfield() {
         },
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -925,7 +921,6 @@ async fn test_manage_network_economics_reject_invalid() {
         },
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -1161,7 +1156,6 @@ async fn test_manage_network_economics_revalidate_at_execution_time(
         },
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -1332,7 +1326,6 @@ async fn test_mint_monthly_node_provider_rewards() {
         },
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     gov.heap_data.economics = Some(default_economics.clone());
@@ -1382,7 +1375,6 @@ async fn test_node_provider_must_be_registered() {
         fixture_for_following(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     let node_provider = NodeProvider {
@@ -1447,7 +1439,6 @@ async fn test_sufficient_stake() {
         fixture_for_following(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     // Set stake to 0.5 ICP.
@@ -1510,7 +1501,6 @@ async fn test_all_follow_proposer() {
         fixture_for_following(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -1613,7 +1603,6 @@ async fn test_follow_negative() {
         fixture_for_following(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     gov.make_proposal(
@@ -1702,7 +1691,6 @@ async fn test_no_default_follow_for_governance() {
         fixture_for_following(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     gov.make_proposal(
@@ -1772,7 +1760,6 @@ async fn test_no_voting_after_deadline() {
         fixture_for_following(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     let proposal_id = gov
@@ -1892,7 +1879,6 @@ fn test_enforce_public_neuron() {
         fixture_for_manage_neuron(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -1948,7 +1934,6 @@ fn test_query_for_manage_neuron() {
         fixture_for_manage_neuron(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     // Test that anybody can call `get_neuron_info` as long as the
@@ -2088,7 +2073,6 @@ async fn test_manage_neuron() {
         fixture_for_manage_neuron(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     // Make a proposal to replace the list of followees (2-4) with just 2.
@@ -2272,7 +2256,6 @@ async fn test_sufficient_stake_for_manage_neuron() {
         fixture_for_manage_neuron(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     // Set stake to less than 0.01 ICP (same as
@@ -2394,7 +2377,6 @@ async fn test_invalid_proposals_fail() {
         governance_proto,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -2437,7 +2419,6 @@ async fn test_compute_tally_while_open() {
         },
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -2482,7 +2463,6 @@ async fn test_compute_tally_after_decided() {
         },
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -2548,7 +2528,6 @@ async fn test_no_compute_tally_after_deadline() {
         },
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -2622,7 +2601,6 @@ async fn test_reward_event_proposals_last_longer_than_reward_period() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     set_governance_for_tests(gov);
@@ -2845,7 +2823,6 @@ async fn test_restricted_proposals_are_not_eligible_for_voting_rewards() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     set_governance_for_tests(gov);
@@ -2937,7 +2914,6 @@ async fn test_disallow_large_manage_neuron_proposals() {
         fixture_for_manage_neuron(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -3200,7 +3176,6 @@ async fn test_reward_distribution_skips_deleted_neurons() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -3281,7 +3256,6 @@ async fn test_genesis_in_the_future_is_supported() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     set_governance_for_tests(gov);
@@ -3516,7 +3490,6 @@ fn compute_maturities(
         governance_proto,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     set_governance_for_tests(gov);
@@ -4060,7 +4033,6 @@ fn test_approve_kyc() {
         governance_proto,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     let neuron_a = gov
@@ -4258,7 +4230,6 @@ fn test_get_neuron_ids_by_principal() {
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -4352,7 +4323,6 @@ fn governance_with_staked_neuron(
         empty_fixture(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -4695,7 +4665,6 @@ fn governance_with_staked_unclaimed_neuron(
         empty_fixture(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -6192,13 +6161,13 @@ fn test_maturity_correctly_reset_if_spawn_fails() {
     );
     assert_eq!(child_neuron.kyc_verified, true);
     assert_eq!(child_neuron.cached_neuron_stake_e8s, 0);
-    // We expect maturity modulation of 100 basis points, which is 1%, because of the
-    // result returned from FakeDriver when pretending to be CMC.
+    // The helper sets maturity_modulation to 100 permyriad (1%); confirm that's still in place.
     assert_eq!(
         gov.heap_data
-            .cached_daily_maturity_modulation_basis_points
-            .unwrap(),
-        100
+            .maturity_modulation
+            .as_ref()
+            .and_then(|m| m.current_value_permyriad),
+        Some(100)
     );
     // The value here should be reset to the original value, without being modulated.
     assert_eq!(child_neuron.maturity_e8s_equivalent, 123_456_789);
@@ -6534,7 +6503,6 @@ async fn test_neuron_with_non_self_authenticating_controller_is_now_allowed() {
         empty_fixture(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -6751,7 +6719,6 @@ fn governance_with_neurons(neurons: &[api::Neuron]) -> (fake::FakeDriver, Govern
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     assert_eq!(gov.neuron_store.len(), neurons.len());
@@ -7923,7 +7890,6 @@ fn test_get_proposal_info() {
         fixture_for_proposals(proposal_id, vec![1, 2, 3]),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     let caller = &principal(1);
@@ -7976,7 +7942,6 @@ async fn test_make_proposal_message() {
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -8015,7 +7980,6 @@ async fn test_max_number_of_proposals_with_ballots() {
         proto,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     set_governance_for_tests(gov);
@@ -8183,7 +8147,6 @@ fn test_proposal_gc() {
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     gov.heap_data.proposals = proposals.clone();
@@ -8277,7 +8240,6 @@ fn test_gc_ignores_exempt_proposals() {
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     gov.heap_data.proposals = props;
@@ -8296,7 +8258,6 @@ async fn test_id_v1_works() {
         fixture_for_manage_neuron(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     // Make a proposal to replace the list of followees (2-4) with just 2.
@@ -8336,7 +8297,6 @@ fn test_can_follow_by_subaccount_and_neuron_id() {
             fixture_for_manage_neuron(),
             driver.get_fake_env(),
             driver.get_fake_ledger(),
-            driver.get_fake_cmc(),
             driver.get_fake_randomness_generator(),
         );
 
@@ -8448,7 +8408,6 @@ fn test_manage_neuron_merge_maturity_returns_expected_error() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -8521,7 +8480,6 @@ fn test_start_dissolving() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -8581,7 +8539,6 @@ fn test_start_dissolving_panics() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -8628,7 +8585,6 @@ fn test_stop_dissolving() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -8691,7 +8647,6 @@ fn test_stop_dissolving_panics() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -8866,7 +8821,6 @@ fn test_increase_dissolve_delay() {
         fixture,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     // Tests for neuron 1. Non-dissolving.
@@ -9015,7 +8969,6 @@ fn test_join_neurons_fund() {
         fixture,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
     {
@@ -9368,7 +9321,6 @@ fn test_neuron_set_visibility() {
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -9481,7 +9433,6 @@ fn test_deciding_and_potential_voting_power() {
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -9705,7 +9656,6 @@ fn test_include_public_neurons_in_full_neurons() {
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -9800,7 +9750,6 @@ async fn test_refresh_voting_power() {
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -9944,7 +9893,6 @@ fn wait_for_quiet_test_helper(
         governance_proto,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     let pid = gov
@@ -10857,7 +10805,6 @@ async fn test_known_neurons() {
         governance_proto,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -11879,7 +11826,6 @@ async fn test_settle_neurons_fund_participation_restores_lifecycle_on_sns_w_fail
             call_canister_method_min_duration: None,
         }),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -12011,7 +11957,6 @@ async fn test_settle_neurons_fund_participation_restores_lifecycle_on_ledger_fai
             call_canister_method_min_duration: None,
         }),
         Arc::new(icp_ledger),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -12147,7 +12092,6 @@ async fn test_create_service_nervous_system_failure_due_to_swap_deployment_error
             call_canister_method_min_duration: None,
         }),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -12248,7 +12192,6 @@ async fn test_create_service_nervous_system_settles_neurons_fund_commit() {
             call_canister_method_min_duration: None,
         }),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -12393,7 +12336,6 @@ async fn test_create_service_nervous_system_settles_neurons_fund_abort() {
             call_canister_method_min_duration: None,
         }),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -12549,7 +12491,6 @@ async fn test_create_service_nervous_system_proposal_execution_fails() {
             call_canister_method_min_duration: None,
         }),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -12648,7 +12589,6 @@ async fn test_settle_neurons_fund_is_idempotent_for_create_service_nervous_syste
             call_canister_method_min_duration: None,
         }),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -12888,7 +12828,6 @@ async fn distribute_rewards_test() {
         governance_init,
         helper.get_fake_env(),
         helper.get_fake_ledger(),
-        helper.get_fake_cmc(),
         helper.get_fake_randomness_generator(),
     );
     governance.heap_data.proposals = proposal_data_list
@@ -12980,7 +12919,6 @@ async fn test_proposal_url_not_on_list_fails() {
         governance_proto,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -13057,7 +12995,6 @@ fn test_ready_to_be_settled_proposals_ids() {
         governance_proto,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     let rewardable_proposal_ids = |now_timestamp_seconds| -> Vec<u64> {
@@ -13235,7 +13172,6 @@ async fn test_metrics() {
         governance_init,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -13452,7 +13388,6 @@ fn randomly_pick_swap_start() {
         Default::default(),
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
 
@@ -13511,7 +13446,6 @@ fn compute_closest_proposal_deadline_timestamp_seconds_no_wfq_fallback() {
         },
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     gov.heap_data.proposals.insert(1, proposal_1);
@@ -13562,7 +13496,6 @@ fn compute_closest_proposal_deadline_timestamp_seconds_incorporates_wfq() {
         },
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     gov.heap_data.proposals.insert(1, proposal_1);
@@ -13593,7 +13526,6 @@ fn voting_period_seconds_topic_dependency() {
         governance_proto,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -13721,7 +13653,6 @@ fn test_neuron_info_private_enforcement() {
         governance_proto,
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -13932,7 +13863,6 @@ async fn test_follow_private_neuron_same_controller() {
         fixture_for_follow_private_neuron_restrictions(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -13984,7 +13914,6 @@ async fn test_follow_private_neuron_fails() {
         fixture_for_follow_private_neuron_restrictions(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -14034,7 +13963,6 @@ async fn test_follow_private_neuron_hotkeys() {
         fixture_for_follow_private_neuron_restrictions(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -14106,7 +14034,6 @@ async fn test_follow_public_neuron_succeeds() {
         fixture_for_follow_private_neuron_restrictions(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -14180,7 +14107,6 @@ async fn test_follow_private_neuron_neuron_management() {
         fixture_for_follow_private_neuron_restrictions(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 
@@ -14303,7 +14229,6 @@ async fn test_grandfathering() {
         fixture_for_grandfathering(),
         driver.get_fake_env(),
         driver.get_fake_ledger(),
-        driver.get_fake_cmc(),
         driver.get_fake_randomness_generator(),
     );
 

--- a/rs/nns/governance/tests/monitoring.rs
+++ b/rs/nns/governance/tests/monitoring.rs
@@ -27,7 +27,6 @@ fn test_reward_event_amounts_metrics() {
         governance_api,
         helpers.get_fake_env(),
         helpers.get_fake_ledger(),
-        helpers.get_fake_cmc(),
         helpers.get_fake_randomness_generator(),
     );
 

--- a/rs/nns/governance/tests/proposals.rs
+++ b/rs/nns/governance/tests/proposals.rs
@@ -221,7 +221,6 @@ async fn test_distribute_rewards_with_total_potential_voting_power() {
         governance_init,
         fake_driver.get_fake_env(),
         fake_driver.get_fake_ledger(),
-        fake_driver.get_fake_cmc(),
         fake_driver.get_fake_randomness_generator(),
     );
     governance.heap_data.proposals = PROPOSALS.clone();


### PR DESCRIPTION
## Why

Previous PRs added local computation and switched consumers off the daily CMC
`neuron_maturity_modulation()` poll. This PR removes the now-dead polling code.

https://dfinity.atlassian.net/browse/NNS1-4319

## What

Removed from Governance:
- `should_update_maturity_modulation()`, `update_maturity_modulation()`
- Their call site in `run_periodic_tasks`

The `xdr_conversion_rate` heartbeat refresh (`should_refresh_xdr_rate` /
`maybe_refresh_xdr_rate`) is **kept**. It will be retired in two follow-up PRs:
1. Switch `icp_xdr_rate()` to derive from `icp_price_history`.
2. Remove `should_refresh_xdr_rate` / `maybe_refresh_xdr_rate` and the
   `heap_data.xdr_conversion_rate` field.

### PR Chain
- ⬅️ Previous: #9848
- ➡️ Next: #9878

## Testing

All existing tests pass. Clippy clean.
