### PR TITLE
chore: Remove `generate_responses_to_signature_request_contexts`

### DIFF
--- a/rs/consensus/idkg/src/utils.rs
+++ b/rs/consensus/idkg/src/utils.rs
@@ -18,13 +18,12 @@ use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_features::ChainKeyConfig;
 use ic_types::{
     Height, RegistryVersion, SubnetId,
-    batch::{AvailablePreSignatures, ConsensusResponse},
+    batch::AvailablePreSignatures,
     consensus::{
         Block, HasHeight,
         idkg::{
-            CompletedSignature, HasIDkgMasterPublicKeyId, IDkgBlockReader, IDkgMasterPublicKeyId,
-            IDkgMessage, IDkgPayload, IDkgTranscriptParamsRef, PreSigId, TranscriptLookupError,
-            TranscriptRef,
+            HasIDkgMasterPublicKeyId, IDkgBlockReader, IDkgMasterPublicKeyId, IDkgMessage,
+            IDkgPayload, IDkgTranscriptParamsRef, PreSigId, TranscriptLookupError, TranscriptRef,
         },
     },
     crypto::canister_threshold_sig::{
@@ -361,20 +360,6 @@ pub fn get_idkg_chain_key_config_if_enabled(
     } else {
         Ok(None)
     }
-}
-
-/// Creates responses to `SignWithECDSA` and `SignWithSchnorr` system calls with the computed
-/// signature.
-pub fn generate_responses_to_signature_request_contexts(
-    idkg_payload: &IDkgPayload,
-) -> Vec<ConsensusResponse> {
-    let mut consensus_responses = Vec::new();
-    for completed in idkg_payload.signature_agreements.values() {
-        if let CompletedSignature::Unreported(response) = completed {
-            consensus_responses.push(response.clone());
-        }
-    }
-    consensus_responses
 }
 
 /// This function returns the subnet master public keys to be added to the batch, if required.

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -8,10 +8,7 @@ use crate::consensus::{
 };
 use ic_consensus_chain_key::ChainKeyPayloadBuilderImpl;
 use ic_consensus_dkg::get_vetkey_public_keys;
-use ic_consensus_idkg::utils::{
-    generate_responses_to_signature_request_contexts,
-    get_idkg_subnet_public_keys_and_pre_signatures,
-};
+use ic_consensus_idkg::utils::get_idkg_subnet_public_keys_and_pre_signatures;
 use ic_consensus_utils::{membership::Membership, pool_reader::PoolReader};
 use ic_error_types::RejectCode;
 use ic_https_outcalls_consensus::payload_builder::CanisterHttpPayloadBuilderImpl;
@@ -337,9 +334,6 @@ fn generate_responses_to_subnet_calls(
         ));
 
         if let Some(payload) = &block_payload.idkg {
-            consensus_responses.append(&mut generate_responses_to_signature_request_contexts(
-                payload,
-            ));
             consensus_responses.append(&mut generate_responses_to_initial_dealings_calls(payload));
         }
 


### PR DESCRIPTION
tECDSA and tSchnorr signatures are now part of the `ChainKeyPayload`. This means their delivery to execution is handled by `ChainKeyPayloadBuilderImpl::into_messages`, and the original function no longer used.