### PR TITLE
chore: fix-flaky-tests: add instruction to just document root causes without fixing them

### DIFF
--- a/.claude/skills/fix-flaky-tests/SKILL.md
+++ b/.claude/skills/fix-flaky-tests/SKILL.md
@@ -66,6 +66,9 @@ This guide explains how to find flaky tests to fix and how to debug them. Flaky 
    ```
    as those are due to infrastructure issues unrelated to the test code.
 
+4. When asked to just figure out the root causes without fixing them,
+   document the root causes in a markdown file and finish without running the following steps.
+
 4. Once the root causes have been determined, pick the most common or recent one
    and fix the test by addressing that root cause taking `.claude/CLAUDE.md` into account.
 

--- a/.claude/skills/fix-flaky-tests/SKILL.md
+++ b/.claude/skills/fix-flaky-tests/SKILL.md
@@ -69,19 +69,19 @@ This guide explains how to find flaky tests to fix and how to debug them. Flaky 
 4. When asked to just figure out the root causes without fixing them,
    document the root causes in a markdown file and finish without running the following steps.
 
-4. Once the root causes have been determined, pick the most common or recent one
+5. Once the root causes have been determined, pick the most common or recent one
    and fix the test by addressing that root cause taking `.claude/CLAUDE.md` into account.
 
    Don't address multiple root causes in the same fix.
    Prefer making separate PRs for each root cause to make it easier to review and revert if needed.
 
-5. Verify the test still passes by running:
+6. Verify the test still passes by running:
    ```
    bazel test --test_output=errors --runs_per_test=3 --jobs=3 <label>
    ```
    This executes 3 runs of the test in parallel to increase the chances of reproducing the flakiness. If it fails, analyze the failure and fix it until it passes reliably.
 
-6. Make a draft Pull Request with the fix, following these steps:
+7. Make a draft Pull Request with the fix, following these steps:
 
    1. From the root of the repository, create a new git branch named `ai/deflake-<test_name>-<date>`,
       replacing `<test_name>` with the name of the test


### PR DESCRIPTION
Sometimes I first want to know the root-cause of a flaky test without AI going ahead and attempting to fix it. So add an instruction what to do if prompted to only figure out the root cause.