### PR TITLE
feat: //ci/githubstats:query: add --exclude-fixed flag to top subcommand

### DIFF
--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -1017,7 +1017,7 @@ def extract_test_name(label: str) -> str:
     return parts[1] if len(parts) == 2 else label
 
 
-def get_recent_commits(git_since: str) -> list:
+def get_recent_commits(git_since: str) -> list[str]:
     """Run git log --oneline --since once and return the list of commit lines."""
     repo_root = THIS_SCRIPT_DIR.parent.parent
     try:

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -1029,8 +1029,8 @@ def get_recent_commits(git_since: str) -> list[str]:
             check=True,
         )
         return result.stdout.strip().splitlines()
-    except subprocess.CalledProcessError as e:
-        print(f"Warning: git log failed: {e.stderr.strip()}", file=sys.stderr)
+    except (subprocess.CalledProcessError, OSError) as e:
+        print(f"Warning: git log failed: {e}", file=sys.stderr)
         return []
 
 
@@ -1045,8 +1045,8 @@ def has_open_pr(test_name: str) -> bool:
             check=True,
         )
         return bool(result.stdout.strip())
-    except subprocess.CalledProcessError as e:
-        print(f"Warning: gh pr list failed: {e.stderr.strip()}", file=sys.stderr)
+    except (subprocess.CalledProcessError, OSError) as e:
+        print(f"Warning: gh pr list failed: {e}", file=sys.stderr)
         return False
 
 

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -997,6 +997,55 @@ def fmt_time(t):
     return t.strftime("%a %Y-%m-%d %X") if pd.notna(t) else ""
 
 
+def get_git_since_arg(args) -> str:
+    """Convert the time filter args into a --since argument for git log."""
+    if args.since:
+        if is_git_commit_sha(args.since):
+            dt = get_commit_timestamp(args.since)
+            return dt.strftime("%Y-%m-%d %H:%M:%S")
+        return args.since
+    return f"last {period(args)}"
+
+
+def extract_test_name(label: str) -> str:
+    """Extract the test target name from a Bazel label (part after ':')."""
+    parts = label.rsplit(":", 1)
+    return parts[1] if len(parts) == 2 else label
+
+
+def get_recent_commits(git_since: str) -> list:
+    """Run git log --oneline --since once and return the list of commit lines."""
+    repo_root = THIS_SCRIPT_DIR.parent.parent
+    try:
+        result = subprocess.run(
+            ["git", "log", "--oneline", "--since", git_since],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip().splitlines()
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: git log failed: {e.stderr.strip()}", file=sys.stderr)
+        return []
+
+
+def has_open_pr(test_name: str) -> bool:
+    """Check if there is an open PR that mentions the test name."""
+    search_term = test_name.replace("_", " ")
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--search", search_term, "--state", "open", "--repo", f"{ORG}/{REPO}", "--limit", "1"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return bool(result.stdout.strip())
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: gh pr list failed: {e.stderr.strip()}", file=sys.stderr)
+        return False
+
+
 def top(args):
     """
     Get the top N non-successful / flaky / failed / timed-out tests
@@ -1065,6 +1114,27 @@ def top(args):
     df["impact"] = df["impact"].apply(normalize_duration)
     df["total_duration"] = df["total_duration"].apply(normalize_duration)
     df["duration_p90"] = df["duration_p90"].apply(normalize_duration)
+
+    # Optionally exclude tests that appear to already be fixed:
+    if args.exclude_fixed:
+        git_since = get_git_since_arg(args)
+        commit_lines = get_recent_commits(git_since)
+        test_names = df["label"].apply(extract_test_name)
+        # Check commits in-memory first, then only call gh for the rest:
+        fixed_by_commit = test_names.apply(
+            lambda name: any(re.search(name.replace("_", "."), line, re.IGNORECASE) for line in commit_lines)
+        )
+        remaining = test_names[~fixed_by_commit]
+        with ThreadPoolExecutor() as executor:
+            pr_results = dict(zip(remaining.index, executor.map(has_open_pr, remaining)))
+        fixed = fixed_by_commit | pd.Series({i: pr_results.get(i, False) for i in df.index})
+        excluded_count = fixed.sum()
+        if excluded_count > 0:
+            excluded_labels = df.loc[fixed, "label"].tolist()
+            print(f"Excluded {excluded_count} test(s) that appear already fixed:", file=sys.stderr)
+            for lbl in excluded_labels:
+                print(f"  {lbl}", file=sys.stderr)
+        df = df[~fixed]
 
     # Find the CODEOWNERS for each test target:
     owners = codeowners.CodeOwners(Path(os.environ["CODEOWNERS_PATH"]).read_text())
@@ -1332,7 +1402,11 @@ duration_p90:\t\t90th percentile duration of all runs in the specified period"""
         "--include", metavar="TEST", type=str, help="Include only tests matching this SQL LIKE pattern"
     )
 
-    top_parser.set_defaults(func=top)
+    top_parser.add_argument(
+        "--exclude-fixed",
+        action="store_true",
+        help="Exclude tests that appear already fixed (mentioned in a recent git commit or an open PR)",
+    )
 
     top_parser.add_argument(
         "--tablefmt",
@@ -1343,6 +1417,8 @@ duration_p90:\t\t90th percentile duration of all runs in the specified period"""
     )
 
     add_columns_argument(top_parser, TOP_COLUMNS)
+
+    top_parser.set_defaults(func=top)
 
     ## last ###################################################################
 
@@ -1430,7 +1506,6 @@ logs
         help="""Return runs of bazel targets matching the given SQL LIKE pattern.
 If omitted retuns all bazel test runs in the specified period.""",
     )
-    last_runs_parser.set_defaults(func=last)
 
     last_runs_parser.add_argument(
         "--tablefmt",
@@ -1441,6 +1516,8 @@ If omitted retuns all bazel test runs in the specified period.""",
     )
 
     add_columns_argument(last_runs_parser, LAST_COLUMNS)
+
+    last_runs_parser.set_defaults(func=last)
 
     ###########################################################################
 

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -1128,7 +1128,8 @@ def top(args):
             )
         )
         remaining = test_names[~fixed_by_commit]
-        with ThreadPoolExecutor() as executor:
+        max_pr_check_workers = max(1, min(4, len(remaining)))
+        with ThreadPoolExecutor(max_workers=max_pr_check_workers) as executor:
             pr_results = dict(zip(remaining.index, executor.map(has_open_pr, remaining)))
         fixed = fixed_by_commit | pd.Series({i: pr_results.get(i, False) for i in df.index})
         excluded_count = fixed.sum()

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -998,12 +998,15 @@ def fmt_time(t):
 
 
 def get_git_since_arg(args) -> str:
-    """Convert the time filter args into a --since argument for git log."""
+    """Convert the time filter args into a --since argument for git log.
+
+    When --since is specified, parses it via parse_datetime (which returns a
+    UTC-aware datetime) and formats it as ISO-8601 with a Z suffix so that
+    git log --since uses the same UTC time window as the SQL query.
+    """
     if args.since:
-        if is_git_commit_sha(args.since):
-            dt = get_commit_timestamp(args.since)
-            return dt.strftime("%Y-%m-%d %H:%M:%S")
-        return args.since
+        dt = parse_datetime(args.since)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
     return f"last {period(args)}"
 
 

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -998,7 +998,8 @@ def fmt_time(t):
 
 
 def get_git_since_arg(args) -> str:
-    """Convert the time filter args into a --since argument for git log.
+    """
+    Convert the time filter args into a --since argument for git log.
 
     When --since is specified, parses it via parse_datetime (which returns a
     UTC-aware datetime) and formats it as ISO-8601 with a Z suffix so that
@@ -1126,8 +1127,7 @@ def top(args):
         # Check commits in-memory first, then only call gh for the rest:
         fixed_by_commit = test_names.apply(
             lambda name: any(
-                re.search(re.escape(name).replace("_", "[_. ]"), line, re.IGNORECASE)
-                for line in commit_lines
+                re.search(re.escape(name).replace("_", "[_. ]"), line, re.IGNORECASE) for line in commit_lines
             )
         )
         remaining = test_names[~fixed_by_commit]

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -1122,7 +1122,10 @@ def top(args):
         test_names = df["label"].apply(extract_test_name)
         # Check commits in-memory first, then only call gh for the rest:
         fixed_by_commit = test_names.apply(
-            lambda name: any(re.search(name.replace("_", "."), line, re.IGNORECASE) for line in commit_lines)
+            lambda name: any(
+                re.search(re.escape(name).replace("_", "[_. ]"), line, re.IGNORECASE)
+                for line in commit_lines
+            )
         )
         remaining = test_names[~fixed_by_commit]
         with ThreadPoolExecutor() as executor:


### PR DESCRIPTION
When `--exclude-fixed` is specified on the `top` subcommand, tests that appear already fixed are filtered out. A test is considered fixed if:

- A recent git commit (in the same time period as the DB query) mentions the test name
- An open PR mentions the test name

### Implementation details

- `git log --oneline --since` is fetched **once** and searched in-memory per test (cheap)
- Open PR checks via `gh pr list` are only run for tests **not** already matched by a commit
- PR checks are parallelized via `ThreadPoolExecutor`
- Excluded tests are reported to stderr with their labels

### New helper functions

- `get_git_since_arg(args)` — mirrors the DB time filter for `git log --since`
- `extract_test_name(label)` — extracts target name after `:` from Bazel labels
- `get_recent_commits(git_since)` — fetches commit lines once
- `has_open_pr(test_name)` — checks for open PRs via `gh` CLI

### Usage

```bash
bazel run //ci/githubstats:query -- top 10 flaky% --week --exclude-fixed
```