### PR TITLE
refactor: log_memory_store cleanup

### DIFF
--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/header.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/header.rs
@@ -9,7 +9,7 @@ pub(crate) const MAGIC: &[u8; 3] = b"CLB";
 
 /// Header structure for the log memory store (version 1).
 /// This is the in-memory representation of the header.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub(super) struct Header {
     // Validation and compatibility.
     pub magic: [u8; 3],

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/header.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/header.rs
@@ -5,7 +5,7 @@ use crate::canister_state::system_state::log_memory_store::{
 use more_asserts::{debug_assert_gt, debug_assert_lt};
 
 /// Magic prefix that marks a properly initialized canister log buffer.
-pub(crate) const MAGIC: &[u8; 3] = b"CLB";
+pub(super) const MAGIC: &[u8; 3] = b"CLB";
 
 /// Header structure for the log memory store (version 1).
 /// This is the in-memory representation of the header.

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/log_record.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/log_record.rs
@@ -20,8 +20,7 @@ impl LogRecord {
         Self::estimate_bytes_len(self.len as usize)
     }
 
-    #[inline]
-    pub fn estimate_bytes_len(content_len: usize) -> usize {
+    pub const fn estimate_bytes_len(content_len: usize) -> usize {
         8 + 8 + 4 + content_len
     }
 

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/log_record.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/log_record.rs
@@ -4,7 +4,7 @@ use ic_management_canister_types_private::{CanisterLogRecord, FetchCanisterLogsF
 ///
 /// Unlike `CanisterLogRecord`, it stores the content length explicitly
 /// to enable serialization and deserialization of content.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub(super) struct LogRecord {
     pub idx: u64,
     pub timestamp: u64,

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/memory.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/memory.rs
@@ -4,7 +4,7 @@ use std::ops::{Add, Mul, Rem, Sub};
 ///
 /// It is used to read/write data from/to the memory store.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Debug)]
 pub(super) struct MemoryAddress(u64);
 const _: () = assert!(std::mem::size_of::<MemoryAddress>() == 8);
 
@@ -43,7 +43,7 @@ impl Add<MemorySize> for MemoryAddress {
 /// It is used to manage the head and tail positions of the circular buffer where log records are stored.
 /// Belongs in the range of [0, data_capacity), and wraps around when it reaches the end of the data region.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Debug)]
 pub(super) struct MemoryPosition(u64);
 const _: () = assert!(std::mem::size_of::<MemoryPosition>() == 8);
 
@@ -78,7 +78,7 @@ impl Rem<MemorySize> for MemoryPosition {
 /// It is used to manage the capacity and size of the data region in the memory store,
 /// where log records are stored in a circular buffer manner.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Debug)]
 pub(super) struct MemorySize(u64);
 const _: () = assert!(std::mem::size_of::<MemorySize>() == 8);
 

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
@@ -318,7 +318,7 @@ impl LogMemoryStore {
 
     /// Calculates the size of a single log record when encoded
     /// and stored within the `LogMemoryStore`.
-    pub fn estimate_record_size(content_size: usize) -> usize {
+    pub const fn estimate_record_size(content_size: usize) -> usize {
         LogRecord::estimate_bytes_len(content_size)
     }
 }

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
@@ -26,6 +26,26 @@ use std::sync::OnceLock;
 /// number of messages per canister (and so delta log appends).
 const DELTA_LOG_SIZES_CAP: usize = 10_000;
 
+/// Canister log storage backed by a PageMap-based ring buffer.
+///
+/// Using PageMap allows log data to be stored outside the heap and
+/// checkpointed efficiently via copy-on-write pages.
+///
+/// Stores the canister's accumulated log records. During execution,
+/// log messages are collected into delta logs in the sandbox, then
+/// appended to this store in bulk after each message completes.
+///
+/// The ring buffer has a configurable capacity. Resizing reads all
+/// existing records and rewrites them into a new ring buffer of the
+/// requested size.
+///
+/// When the ring buffer is full, oldest records at the head are
+/// evicted to make room for new ones.
+///
+/// An index table partitions the data region into segments, enabling
+/// filtered queries by record index or timestamp without scanning
+/// the entire ring buffer. Returned results are trimmed to fit within
+/// the maximum message response size.
 #[derive(Debug, ValidateEq)]
 pub struct LogMemoryStore {
     /// Feature flag for controlling LogMemoryStore enabled.
@@ -161,7 +181,7 @@ impl LogMemoryStore {
             .get_or_init(|| self.load_ring_buffer().map(|rb| rb.get_header()))
     }
 
-    /// Returns actual memory usage of the ring buffer.
+    /// Returns the total allocated memory.
     pub fn memory_usage(&self) -> usize {
         self.total_virtual_memory_usage()
     }
@@ -245,10 +265,7 @@ impl LogMemoryStore {
         self.bytes_used() == 0
     }
 
-    /// Returns the number of bytes used by the ring buffer.
-    ///
-    /// This is the actual number of bytes used by the ring buffer, not the
-    /// allocated capacity.
+    /// Returns bytes occupied by stored log records (not allocated capacity).
     pub fn bytes_used(&self) -> usize {
         self.get_header()
             .map(|h| h.data_size.get() as usize)

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/ring_buffer.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/ring_buffer.rs
@@ -9,24 +9,24 @@ use ic_management_canister_types_private::{CanisterLogRecord, DataSize, FetchCan
 use more_asserts::assert_le;
 
 // PageMap file layout.
-pub(crate) const VIRTUAL_PAGE_SIZE: usize = 4_096;
+pub(super) const VIRTUAL_PAGE_SIZE: usize = 4_096;
 // Header layout constants.
-pub(crate) const HEADER_OFFSET: MemoryAddress = MemoryAddress::new(0);
-pub(crate) const HEADER_SIZE: MemorySize = MemorySize::new(VIRTUAL_PAGE_SIZE as u64);
+pub(super) const HEADER_OFFSET: MemoryAddress = MemoryAddress::new(0);
+pub(super) const HEADER_SIZE: MemorySize = MemorySize::new(VIRTUAL_PAGE_SIZE as u64);
 // Index table layout constants.
-pub(crate) const INDEX_TABLE_OFFSET: MemoryAddress = HEADER_OFFSET.add_size(HEADER_SIZE);
-pub(crate) const INDEX_TABLE_PAGES: usize = 1;
-pub(crate) const INDEX_TABLE_SIZE: MemorySize =
+pub(super) const INDEX_TABLE_OFFSET: MemoryAddress = HEADER_OFFSET.add_size(HEADER_SIZE);
+pub(super) const INDEX_TABLE_PAGES: usize = 1;
+pub(super) const INDEX_TABLE_SIZE: MemorySize =
     MemorySize::new((INDEX_TABLE_PAGES * VIRTUAL_PAGE_SIZE) as u64);
-pub(crate) const INDEX_ENTRY_SIZE: MemorySize = MemorySize::new(28);
-pub(crate) const INDEX_ENTRY_COUNT_MAX: u64 = INDEX_TABLE_SIZE.get() / INDEX_ENTRY_SIZE.get();
+pub(super) const INDEX_ENTRY_SIZE: MemorySize = MemorySize::new(28);
+pub(super) const INDEX_ENTRY_COUNT_MAX: u64 = INDEX_TABLE_SIZE.get() / INDEX_ENTRY_SIZE.get();
 // Data region layout constants.
-pub(crate) const DATA_REGION_OFFSET: MemoryAddress = INDEX_TABLE_OFFSET.add_size(INDEX_TABLE_SIZE);
+pub(super) const DATA_REGION_OFFSET: MemoryAddress = INDEX_TABLE_OFFSET.add_size(INDEX_TABLE_SIZE);
 
 // Ring buffer constraints.
 
 /// Maximum total size of log records returned in a single message.
-pub(crate) const RESULT_MAX_SIZE: MemorySize = MemorySize::new(2_000_000);
+pub(super) const RESULT_MAX_SIZE: MemorySize = MemorySize::new(2_000_000);
 const _: () = assert!(RESULT_MAX_SIZE.get() <= 2_000_000, "Exceeds 2 MB");
 
 // With index table of 1 page (4 KiB) and 28 bytes per entry -> 146 entries max.
@@ -34,7 +34,7 @@ const _: () = assert!(RESULT_MAX_SIZE.get() <= 2_000_000, "Exceeds 2 MB");
 // say 20% of that (400 KB). So 146 segments turns into ~55 MB total data capacity.
 // Small segments help to reduce work on refining log records filtering
 // when fetching logs.
-pub(crate) const DATA_CAPACITY_MAX: MemorySize = MemorySize::new(55_000_000); // 55 MB
+pub(super) const DATA_CAPACITY_MAX: MemorySize = MemorySize::new(55_000_000); // 55 MB
 const DATA_SEGMENT_SIZE_MAX: u64 = DATA_CAPACITY_MAX.get() / INDEX_ENTRY_COUNT_MAX;
 // Ensure data segment size is significantly smaller than max result size, say 20%.
 const _: () = assert!(5 * DATA_SEGMENT_SIZE_MAX <= RESULT_MAX_SIZE.get());
@@ -44,7 +44,7 @@ const _: () = assert!(5 * DATA_SEGMENT_SIZE_MAX <= RESULT_MAX_SIZE.get());
 /// Log memory limit can be zero to disable logging,
 /// but when it is non-zero it must be at least this value
 /// to properly account for the size of at least one OS page.
-pub(crate) const DATA_CAPACITY_MIN: usize = VIRTUAL_PAGE_SIZE;
+pub(super) const DATA_CAPACITY_MIN: usize = VIRTUAL_PAGE_SIZE;
 const _: () = assert!(VIRTUAL_PAGE_SIZE <= DATA_CAPACITY_MIN); // data capacity must be at least one page.
 
 pub(super) struct RingBuffer {
@@ -303,7 +303,7 @@ impl RingBuffer {
     }
 }
 
-pub struct RingBufferIterator<'a> {
+pub(super) struct RingBufferIterator<'a> {
     io: &'a StructIO,
     header: Header,
     pos: MemoryPosition,


### PR DESCRIPTION
This PR cleans up `log_memory_store` code.

- Make `estimate_bytes_len` and `estimate_record_size` `const fn` and remove unnecessary `#[inline]`
- Narrow 12 constants and `RingBufferIterator` from `pub(crate)` to `pub(super)` — none are used outside the module
- Improve `LogMemoryStore` struct doc comment and clarify `memory_usage()` / `bytes_used()` docs