### PR TITLE
fix(state-machine-tests): DEFI-2779: Register non-local subnets from routing table in registry

### DIFF
--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -499,7 +499,29 @@ fn add_subnet_local_registry_records(
         .with_resource_limits(resource_limits)
         .build();
 
-    // Insert initial DKG transcripts
+    add_cup_contents_and_key_record(
+        subnet_id,
+        ni_dkg_transcript,
+        public_key,
+        &registry_data_provider,
+        registry_version,
+    );
+
+    add_single_subnet_record(
+        &registry_data_provider,
+        registry_version.get(),
+        subnet_id,
+        record,
+    );
+}
+
+fn add_cup_contents_and_key_record(
+    subnet_id: SubnetId,
+    ni_dkg_transcript: NiDkgTranscript,
+    public_key: ThresholdSigPublicKey,
+    registry_data_provider: &Arc<ProtoRegistryDataProvider>,
+    registry_version: RegistryVersion,
+) {
     let mut high_threshold_transcript = ni_dkg_transcript.clone();
     high_threshold_transcript.dkg_id.dkg_tag = NiDkgTag::HighThreshold;
     let mut low_threshold_transcript = ni_dkg_transcript;
@@ -515,16 +537,9 @@ fn add_subnet_local_registry_records(
             registry_version,
             Some(cup_contents),
         )
-        .expect("Failed to add subnet record.");
-
-    add_single_subnet_record(
-        &registry_data_provider,
-        registry_version.get(),
-        subnet_id,
-        record,
-    );
+        .expect("Failed to add CUP contents record.");
     add_subnet_key_record(
-        &registry_data_provider,
+        registry_data_provider,
         registry_version.get(),
         subnet_id,
         public_key,
@@ -533,36 +548,28 @@ fn add_subnet_local_registry_records(
 
 /// Register minimal registry records for a non-local subnet so that it
 /// appears in the `NetworkTopology` and its routing table entries are not
-/// filtered out.
+/// filtered out. This is needed because `try_to_populate_network_topology`
+/// filters the routing table to only include entries for subnets with
+/// registry records.
 fn register_non_local_subnet(
-    extra_subnet_id: SubnetId,
+    subnet_id: SubnetId,
     registry_data_provider: &Arc<ProtoRegistryDataProvider>,
 ) {
+    let principal_id = subnet_id.get();
+    let principal_bytes = principal_id.as_slice();
     let mut seed = [0u8; 32];
-    let subnet_bytes = extra_subnet_id.get().to_vec();
-    for (i, b) in subnet_bytes.iter().enumerate() {
-        seed[i % 32] ^= b;
-    }
+    seed[..principal_bytes.len()].copy_from_slice(principal_bytes);
     let (ni_dkg_transcript, _) =
         dummy_initial_dkg_transcript_with_master_key(&mut StdRng::from_seed(seed));
     let public_key: ThresholdSigPublicKey = (&ni_dkg_transcript).try_into().unwrap();
 
-    let mut high_threshold_transcript = ni_dkg_transcript.clone();
-    high_threshold_transcript.dkg_id.dkg_tag = NiDkgTag::HighThreshold;
-    let mut low_threshold_transcript = ni_dkg_transcript;
-    low_threshold_transcript.dkg_id.dkg_tag = NiDkgTag::LowThreshold;
-    let cup_contents = CatchUpPackageContents {
-        initial_ni_dkg_transcript_high_threshold: Some(high_threshold_transcript.into()),
-        initial_ni_dkg_transcript_low_threshold: Some(low_threshold_transcript.into()),
-        ..Default::default()
-    };
-    registry_data_provider
-        .add(
-            &make_catch_up_package_contents_key(extra_subnet_id),
-            INITIAL_REGISTRY_VERSION,
-            Some(cup_contents),
-        )
-        .unwrap();
+    add_cup_contents_and_key_record(
+        subnet_id,
+        ni_dkg_transcript,
+        public_key,
+        registry_data_provider,
+        INITIAL_REGISTRY_VERSION,
+    );
 
     let record = SubnetRecordBuilder::from(&[])
         .with_subnet_type(SubnetType::Application)
@@ -570,14 +577,8 @@ fn register_non_local_subnet(
     add_single_subnet_record(
         registry_data_provider,
         INITIAL_REGISTRY_VERSION.get(),
-        extra_subnet_id,
+        subnet_id,
         record,
-    );
-    add_subnet_key_record(
-        registry_data_provider,
-        INITIAL_REGISTRY_VERSION.get(),
-        extra_subnet_id,
-        public_key,
     );
 }
 

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -571,6 +571,12 @@ fn register_non_local_subnet(
         INITIAL_REGISTRY_VERSION,
     );
 
+    // Assume Application as the type for this synthetic catch-all subnet:
+    // the only subnet type that gets filtered out is CloudEngine, and the
+    // real subnets whose canisters end up here should mainly be application
+    // subnets. Even if there are requests from canisters on System subnets,
+    // it shouldn't make a difference (at least, for the current callers of
+    // this function).
     let record = SubnetRecordBuilder::from(&[])
         .with_subnet_type(SubnetType::Application)
         .build();

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -531,6 +531,56 @@ fn add_subnet_local_registry_records(
     );
 }
 
+/// Register minimal registry records for a non-local subnet so that it
+/// appears in the `NetworkTopology` and its routing table entries are not
+/// filtered out.
+fn register_non_local_subnet(
+    extra_subnet_id: SubnetId,
+    registry_data_provider: &Arc<ProtoRegistryDataProvider>,
+) {
+    let mut seed = [0u8; 32];
+    let subnet_bytes = extra_subnet_id.get().to_vec();
+    for (i, b) in subnet_bytes.iter().enumerate() {
+        seed[i % 32] ^= b;
+    }
+    let (ni_dkg_transcript, _) =
+        dummy_initial_dkg_transcript_with_master_key(&mut StdRng::from_seed(seed));
+    let public_key: ThresholdSigPublicKey = (&ni_dkg_transcript).try_into().unwrap();
+
+    let mut high_threshold_transcript = ni_dkg_transcript.clone();
+    high_threshold_transcript.dkg_id.dkg_tag = NiDkgTag::HighThreshold;
+    let mut low_threshold_transcript = ni_dkg_transcript;
+    low_threshold_transcript.dkg_id.dkg_tag = NiDkgTag::LowThreshold;
+    let cup_contents = CatchUpPackageContents {
+        initial_ni_dkg_transcript_high_threshold: Some(high_threshold_transcript.into()),
+        initial_ni_dkg_transcript_low_threshold: Some(low_threshold_transcript.into()),
+        ..Default::default()
+    };
+    registry_data_provider
+        .add(
+            &make_catch_up_package_contents_key(extra_subnet_id),
+            INITIAL_REGISTRY_VERSION,
+            Some(cup_contents),
+        )
+        .unwrap();
+
+    let record = SubnetRecordBuilder::from(&[])
+        .with_subnet_type(SubnetType::Application)
+        .build();
+    add_single_subnet_record(
+        registry_data_provider,
+        INITIAL_REGISTRY_VERSION.get(),
+        extra_subnet_id,
+        record,
+    );
+    add_subnet_key_record(
+        registry_data_provider,
+        INITIAL_REGISTRY_VERSION.get(),
+        extra_subnet_id,
+        public_key,
+    );
+}
+
 fn make_fresh_registry_cup(
     registry_client: Arc<FakeRegistryClient>,
     subnet_id: SubnetId,
@@ -1574,7 +1624,23 @@ impl StateMachineBuilder {
                 )
                 .expect("failed to assign a canister range");
         }
-        let subnet_list = vec![sm.get_subnet_id()];
+        // Register all subnet IDs referenced in the routing table (not just
+        // the local one) so that the routing table entries survive the
+        // filtering in `try_to_populate_network_topology`. Without this,
+        // entries for non-local subnets are silently dropped and any
+        // response destined for those subnets triggers a critical error
+        // in the stream builder.
+        let subnet_list: Vec<SubnetId> = routing_table
+            .iter()
+            .map(|(_, sid)| *sid)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        for &extra_subnet_id in &subnet_list {
+            if extra_subnet_id != subnet_id {
+                register_non_local_subnet(extra_subnet_id, &registry_data_provider);
+            }
+        }
         let chain_keys = chain_keys_enabled_status
             .into_iter()
             .filter_map(|(key_id, is_enabled)| {

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -557,7 +557,7 @@ fn register_non_local_subnet(
 ) {
     let principal_id = subnet_id.get();
     let principal_bytes = principal_id.as_slice();
-    let mut seed = [0u8; 32];
+    let mut seed = [0_u8; 32];
     seed[..principal_bytes.len()].copy_from_slice(principal_bytes);
     let (ni_dkg_transcript, _) =
         dummy_initial_dkg_transcript_with_master_key(&mut StdRng::from_seed(seed));


### PR DESCRIPTION
Fix flaky `icrc_ledger_suite_integration_golden_state_upgrade_downgrade_test` by registering all subnets referenced in the routing table in the registry. Extract `add_cup_contents_and_key_record` helper to eliminate code duplication.

The golden state tests use `create_routing_table` (introduced in [PR #1530](https://github.com/dfinity/ic/pull/1530)) to route canister IDs outside the local subnet to a non-existent subnet. This ensures that leftover cross-subnet responses in the golden state backup are routed into a remote stream (where they sit harmlessly) rather than triggering a critical error in the stream builder.

This worked until [PR #9449](https://github.com/dfinity/ic/pull/9449) introduced routing table filtering in `try_to_populate_network_topology`: non-CloudEngine subnets now filter the routing table to only include entries for subnets that have registry records. Since `StateMachineBuilder::build()` only registered the local subnet, the non-existent subnet's routing entries were silently dropped, leaving cross-subnet responses unroutable and causing `mr_stream_builder_response_destination_not_found` critical errors in the golden state test.

The test is flaky (rather than always failing) because, depending on the timing of the snapshot, it may or may not contain messages destined for other subnets.

`StateMachineBuilder::build()` now derives the subnet list from the routing table and registers minimal registry records (DKG transcript, subnet record, key record) for each non-local subnet via `register_non_local_subnet`. This ensures their routing table entries survive the filtering.