### PR TITLE
chore: Release icrc-ledger-types 0.2.0 and dependents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16286,7 +16286,7 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-agent"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "candid",
  "ciborium",
@@ -16300,7 +16300,7 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-client"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -16309,7 +16309,7 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-client-cdk"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -16319,7 +16319,7 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-types"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "base32",

--- a/packages/icrc-ledger-agent/CHANGELOG.md
+++ b/packages/icrc-ledger-agent/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.2.0
+
+### Changed
+- Bump icrc-ledger-types dependency to v0.2.0.
+
 ## 0.1.1
 
 ### Changed

--- a/packages/icrc-ledger-agent/Cargo.toml
+++ b/packages/icrc-ledger-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc-ledger-agent"
-version = "0.1.1"
+version = "0.2.0"
 description = "Functions for interacting with DFINITY's implementation of the ICRC-1 fungible token standard."
 license = "Apache-2.0"
 readme = "README.md"
@@ -19,5 +19,5 @@ hex = { workspace = true }
 ic-agent = { workspace = true }
 ic-cbor = { workspace = true }
 ic-certification = { workspace = true }
-icrc-ledger-types = { path = "../icrc-ledger-types", version = "0.1.10" }
+icrc-ledger-types = { path = "../icrc-ledger-types", version = "0.2.0" }
 leb128 = { workspace = true }

--- a/packages/icrc-ledger-client-cdk/CHANGELOG.md
+++ b/packages/icrc-ledger-client-cdk/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0
+
+### Changed
+- Bump icrc-ledger-client dependency to v0.2.0.
+
 ## 0.1.4
 
 - Bump ic-cdk version to v0.19.0.

--- a/packages/icrc-ledger-client-cdk/Cargo.toml
+++ b/packages/icrc-ledger-client-cdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc-ledger-client-cdk"
-version = "0.1.4"
+version = "0.2.0"
 description = "ICRC-1 compliant client library."
 license = "Apache-2.0"
 readme = "README.md"
@@ -16,4 +16,4 @@ documentation.workspace = true
 async-trait = { workspace = true }
 candid = { workspace = true }
 ic-cdk = { workspace = true }
-icrc-ledger-client = { path = "../icrc-ledger-client", version = "0.1.4" }
+icrc-ledger-client = { path = "../icrc-ledger-client", version = "0.2.0" }

--- a/packages/icrc-ledger-client/CHANGELOG.md
+++ b/packages/icrc-ledger-client/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0
+
+### Changed
+- Bump icrc-ledger-types dependency to v0.2.0.
+
 ## 0.1.4
 
 - Bump icrc-ledger-types dependency to v0.1.10.

--- a/packages/icrc-ledger-client/Cargo.toml
+++ b/packages/icrc-ledger-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc-ledger-client"
-version = "0.1.4"
+version = "0.2.0"
 description = "ICRC-1 compliant client library."
 license = "Apache-2.0"
 readme = "README.md"
@@ -15,4 +15,4 @@ documentation.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 candid = { workspace = true }
-icrc-ledger-types = { path = "../icrc-ledger-types", version = "0.1.10" }
+icrc-ledger-types = { path = "../icrc-ledger-types", version = "0.2.0" }

--- a/packages/icrc-ledger-types/CHANGELOG.md
+++ b/packages/icrc-ledger-types/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.2.0
+
 ### Changed
 - The implementation of the `Storable` trait for `Account` and the dependency on the `ic-stable-structures` crate are now disabled by default. Enable the `storable` feature flag to opt in.
 

--- a/packages/icrc-ledger-types/Cargo.toml
+++ b/packages/icrc-ledger-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icrc-ledger-types"
-version = "0.1.13"
+version = "0.2.0"
 description = "Types for interacting with DFINITY's implementation of the ICRC-1 fungible token standard."
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Release `0.2.0` of `icrc-ledger-types. Since this is a breaking change with a minor version bump, the dependencies of some other crates in the repository need to be updated. For the following crates, update the `icrc-ledger-types` dependency and bump the minor version:

- `icrc-ledger-agent`
- `icrc-ledger-client`
- `icrc-ledger-client-cdk`