### PR TITLE
chore: Use `StateReader` instead of `StateManager` where possible

### DIFF
--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -5,7 +5,7 @@ use crate::{
 use ic_consensus_utils::{crypto::ConsensusCrypto, pool_reader::PoolReader};
 use ic_interfaces::{crypto::ErrorReproducibility, dkg::DkgPool};
 use ic_interfaces_registry::RegistryClient;
-use ic_interfaces_state_manager::StateManager;
+use ic_interfaces_state_manager::StateReader;
 use ic_logger::{ReplicaLogger, error, warn};
 use ic_protobuf::registry::subnet::v1::{
     CatchUpPackageContents, chain_key_initialization::Initialization,
@@ -47,7 +47,7 @@ pub fn create_payload(
     pool_reader: &PoolReader<'_>,
     dkg_pool: Arc<RwLock<dyn DkgPool>>,
     parent: &Block,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     validation_context: &ValidationContext,
     logger: ReplicaLogger,
     max_dealings_per_block: usize,
@@ -70,7 +70,7 @@ pub fn create_payload(
             last_dkg_summary,
             parent,
             last_summary_block.context.registry_version,
-            state_manager,
+            state_reader,
             validation_context,
             logger,
         )
@@ -249,7 +249,7 @@ pub(super) fn create_summary_payload(
     last_summary: &DkgSummary,
     parent: &Block,
     registry_version: RegistryVersion,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     validation_context: &ValidationContext,
     logger: ReplicaLogger,
 ) -> Result<DkgSummary, DkgPayloadCreationError> {
@@ -334,7 +334,7 @@ pub(super) fn create_summary_payload(
             subnet_id,
             height,
             registry_client,
-            state_manager,
+            state_reader,
             validation_context,
             transcripts_for_remote_subnets,
             &previous_transcripts,
@@ -414,7 +414,7 @@ fn compute_remote_dkg_data(
     subnet_id: SubnetId,
     height: Height,
     registry_client: &dyn RegistryClient,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     validation_context: &ValidationContext,
     mut new_transcripts: BTreeMap<NiDkgId, Result<NiDkgTranscript, String>>,
     previous_transcripts: &BTreeMap<NiDkgId, Result<NiDkgTranscript, String>>,
@@ -429,7 +429,7 @@ fn compute_remote_dkg_data(
     ),
     DkgPayloadCreationError,
 > {
-    let state = state_manager
+    let state = state_reader
         .get_state_at(validation_context.certified_height)
         .map_err(DkgPayloadCreationError::StateManagerError)?;
     let (context_configs, errors, valid_target_ids) = process_subnet_call_context(

--- a/rs/consensus/dkg/src/payload_validator.rs
+++ b/rs/consensus/dkg/src/payload_validator.rs
@@ -5,7 +5,7 @@ use ic_interfaces::{
     validation::ValidationResult,
 };
 use ic_interfaces_registry::RegistryClient;
-use ic_interfaces_state_manager::StateManager;
+use ic_interfaces_state_manager::StateReader;
 use ic_logger::{ReplicaLogger, warn};
 use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_replicated_state::ReplicatedState;
@@ -31,7 +31,7 @@ pub fn validate_payload(
     dkg_pool: &dyn DkgPool,
     parent: Block,
     payload: &BlockPayload,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     validation_context: &ValidationContext,
     metrics: &IntCounterVec,
     log: &ReplicaLogger,
@@ -65,7 +65,7 @@ pub fn validate_payload(
                 last_dkg_summary,
                 &parent,
                 registry_version,
-                state_manager,
+                state_reader,
                 validation_context,
                 ic_logger::replica_logger::no_op_logger(),
             )?;

--- a/rs/consensus/idkg/src/payload_builder.rs
+++ b/rs/consensus/idkg/src/payload_builder.rs
@@ -10,7 +10,7 @@ use ic_consensus_utils::pool_reader::PoolReader;
 use ic_crypto::retrieve_mega_public_key_from_registry;
 use ic_interfaces::idkg::IDkgPool;
 use ic_interfaces_registry::RegistryClient;
-use ic_interfaces_state_manager::StateManager;
+use ic_interfaces_state_manager::StateReader;
 use ic_logger::{ReplicaLogger, error, info, warn};
 use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_features::ChainKeyConfig;
@@ -483,7 +483,7 @@ pub fn create_data_payload(
     registry_client: &dyn RegistryClient,
     pool_reader: &PoolReader<'_>,
     idkg_pool: Arc<RwLock<dyn IDkgPool>>,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     context: &ValidationContext,
     parent_block: &Block,
     idkg_payload_metrics: &IDkgPayloadMetrics,
@@ -535,7 +535,7 @@ pub fn create_data_payload(
         &summary_block,
         &block_reader,
         &transcript_builder,
-        state_manager,
+        state_reader,
         registry_client,
         Some(idkg_payload_metrics),
         log,
@@ -575,7 +575,7 @@ pub(crate) fn create_data_payload_helper(
     summary_block: &Block,
     block_reader: &dyn IDkgBlockReader,
     transcript_builder: &dyn IDkgTranscriptBuilder,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     registry_client: &dyn RegistryClient,
     idkg_payload_metrics: Option<&IDkgPayloadMetrics>,
     log: &ReplicaLogger,
@@ -601,7 +601,7 @@ pub(crate) fn create_data_payload_helper(
     };
 
     let receivers = get_subnet_nodes(registry_client, next_interval_registry_version, subnet_id)?;
-    let state = state_manager.get_state_at(context.certified_height)?;
+    let state = state_reader.get_state_at(context.certified_height)?;
 
     let reshare_contexts = state.get_ref().reshare_chain_key_contexts();
     let idkg_dealings_contexts = filter_idkg_reshare_chain_key_contexts(reshare_contexts);

--- a/rs/consensus/idkg/src/payload_verifier.rs
+++ b/rs/consensus/idkg/src/payload_verifier.rs
@@ -35,7 +35,7 @@ use crate::{
 use ic_consensus_utils::{crypto::ConsensusCrypto, pool_reader::PoolReader};
 use ic_interfaces::validation::{ValidationError, ValidationResult};
 use ic_interfaces_registry::RegistryClient;
-use ic_interfaces_state_manager::StateManager;
+use ic_interfaces_state_manager::StateReader;
 use ic_management_canister_types_private::ReshareChainKeyResponse;
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
@@ -227,7 +227,7 @@ pub fn validate_payload(
     crypto: &dyn ConsensusCrypto,
     thread_pool: &ThreadPool,
     pool_reader: &PoolReader<'_>,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     context: &ValidationContext,
     parent_block: &Block,
     payload: &BlockPayload,
@@ -258,7 +258,7 @@ pub fn validate_payload(
                     crypto,
                     thread_pool,
                     pool_reader,
-                    state_manager,
+                    state_reader,
                     context,
                     parent_block,
                     payload.as_data().idkg.as_ref(),
@@ -329,7 +329,7 @@ fn validate_data_payload(
     crypto: &dyn ConsensusCrypto,
     thread_pool: &ThreadPool,
     pool_reader: &PoolReader<'_>,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     context: &ValidationContext,
     parent_block: &Block,
     data_payload: Option<&idkg::IDkgPayload>,
@@ -435,7 +435,7 @@ fn validate_data_payload(
         &summary_block,
         &block_reader,
         &builder,
-        state_manager,
+        state_reader,
         registry_client,
         None,
         &ic_logger::replica_logger::no_op_logger(),

--- a/rs/consensus/src/consensus.rs
+++ b/rs/consensus/src/consensus.rs
@@ -48,7 +48,7 @@ use ic_interfaces::{
     time_source::TimeSource,
 };
 use ic_interfaces_registry::{POLLING_PERIOD, RegistryClient};
-use ic_interfaces_state_manager::StateManager;
+use ic_interfaces_state_manager::{StateManager, StateReader};
 use ic_logger::{ReplicaLogger, debug, error, info, trace, warn};
 use ic_metrics::MetricsRegistry;
 use ic_registry_client_helpers::subnet::SubnetRegistry;
@@ -140,7 +140,7 @@ pub struct ConsensusImpl {
     metrics: ConsensusMetrics,
     time_source: Arc<dyn TimeSource>,
     registry_client: Arc<dyn RegistryClient>,
-    state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
+    state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
     dkg_key_manager: Arc<Mutex<DkgKeyManager>>,
     last_invoked: RefCell<BTreeMap<ConsensusSubcomponent, Time>>,
     schedule: RoundRobin,
@@ -299,7 +299,7 @@ impl ConsensusImpl {
             log: logger,
             time_source,
             registry_client,
-            state_manager,
+            state_reader: state_manager,
             malicious_flags,
             replica_config,
             last_invoked: RefCell::new(last_invoked),
@@ -449,7 +449,7 @@ impl<T: ConsensusPool> PoolMutationsProducer<T> for ConsensusImpl {
             "Consensus finalized height: {}, state available: {}, DKG key material available: {}",
             pool_reader.get_finalized_height(),
             pool_reader.get_finalized_tip().context.certified_height
-                <= self.state_manager.latest_certified_height(),
+                <= self.state_reader.latest_certified_height(),
             self.dkgs_available(&pool_reader)
         );
 

--- a/rs/consensus/src/consensus/block_maker.rs
+++ b/rs/consensus/src/consensus/block_maker.rs
@@ -16,7 +16,7 @@ use ic_interfaces::{
     consensus::PayloadBuilder, dkg::DkgPool, idkg::IDkgPool, time_source::TimeSource,
 };
 use ic_interfaces_registry::RegistryClient;
-use ic_interfaces_state_manager::StateManager;
+use ic_interfaces_state_manager::StateReader;
 use ic_logger::{ReplicaLogger, debug, error, trace, warn};
 use ic_metrics::MetricsRegistry;
 use ic_replicated_state::ReplicatedState;
@@ -72,7 +72,7 @@ pub(crate) struct BlockMaker {
     payload_builder: Arc<dyn PayloadBuilder>,
     dkg_pool: Arc<RwLock<dyn DkgPool>>,
     idkg_pool: Arc<RwLock<dyn IDkgPool>>,
-    state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
+    state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
     metrics: BlockMakerMetrics,
     idkg_payload_metrics: IDkgPayloadMetrics,
     log: ReplicaLogger,
@@ -94,7 +94,7 @@ impl BlockMaker {
         payload_builder: Arc<dyn PayloadBuilder>,
         dkg_pool: Arc<RwLock<dyn DkgPool>>,
         idkg_pool: Arc<RwLock<dyn IDkgPool>>,
-        state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
+        state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
         stable_registry_version_age: Duration,
         metrics_registry: MetricsRegistry,
         log: ReplicaLogger,
@@ -108,7 +108,7 @@ impl BlockMaker {
             payload_builder,
             dkg_pool,
             idkg_pool,
-            state_manager,
+            state_reader,
             log,
             metrics: BlockMakerMetrics::new(metrics_registry.clone()),
             idkg_payload_metrics: IDkgPayloadMetrics::new(metrics_registry),
@@ -184,7 +184,7 @@ impl BlockMaker {
         parent: HashedBlock,
     ) -> Option<BlockProposal> {
         let height = parent.height().increment();
-        let certified_height = self.state_manager.latest_certified_height();
+        let certified_height = self.state_reader.latest_certified_height();
 
         // Note that we will skip blockmaking if registry versions or replica_versions
         // are missing or temporarily not retrievable.
@@ -302,7 +302,7 @@ impl BlockMaker {
             pool,
             Arc::clone(&self.dkg_pool),
             parent.as_ref(),
-            &*self.state_manager,
+            &*self.state_reader,
             &context,
             self.log.clone(),
             max_dealings_per_block,
@@ -366,7 +366,7 @@ impl BlockMaker {
                                 &*self.registry_client,
                                 pool,
                                 self.idkg_pool.clone(),
-                                &*self.state_manager,
+                                &*self.state_reader,
                                 &context,
                                 parent.as_ref(),
                                 &self.idkg_payload_metrics,

--- a/rs/consensus/src/consensus/malicious_consensus.rs
+++ b/rs/consensus/src/consensus/malicious_consensus.rs
@@ -138,7 +138,7 @@ impl ConsensusImpl {
     ) -> Option<BlockProposal> {
         let height = parent.height().increment();
         let mut context = parent.as_ref().context.clone();
-        context.certified_height = self.state_manager.latest_certified_height();
+        context.certified_height = self.state_reader.latest_certified_height();
 
         // Note that we will skip blockmaking if registry versions or replica_versions
         // are missing or temporarily not retrievable.

--- a/rs/consensus/src/consensus/notary.rs
+++ b/rs/consensus/src/consensus/notary.rs
@@ -34,7 +34,7 @@ use ic_consensus_utils::{
     pool_reader::PoolReader,
 };
 use ic_interfaces::time_source::TimeSource;
-use ic_interfaces_state_manager::StateManager;
+use ic_interfaces_state_manager::StateReader;
 use ic_logger::{ReplicaLogger, error, trace, warn};
 use ic_metrics::MetricsRegistry;
 use ic_registry_client_helpers::subnet::NotarizationDelaySettings;
@@ -66,7 +66,7 @@ pub(crate) struct Notary {
     replica_config: ReplicaConfig,
     membership: Arc<Membership>,
     pub(crate) crypto: Arc<dyn ConsensusCrypto>,
-    state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
+    state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
     log: ReplicaLogger,
     metrics: NotaryMetrics,
 }
@@ -77,7 +77,7 @@ impl Notary {
         replica_config: ReplicaConfig,
         membership: Arc<Membership>,
         crypto: Arc<dyn ConsensusCrypto>,
-        state_manager: Arc<dyn StateManager<State = ReplicatedState>>,
+        state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
         metrics_registry: MetricsRegistry,
         log: ReplicaLogger,
     ) -> Notary {
@@ -86,7 +86,7 @@ impl Notary {
             replica_config,
             membership,
             crypto,
-            state_manager,
+            state_reader,
             log,
             metrics: NotaryMetrics::new(metrics_registry),
         }
@@ -129,7 +129,7 @@ impl Notary {
         let adjusted_notary_delay = get_adjusted_notary_delay(
             self.membership.as_ref(),
             pool,
-            self.state_manager.as_ref(),
+            self.state_reader.as_ref(),
             &self.log,
             height,
             rank,
@@ -240,7 +240,7 @@ enum NotaryDelay {
 fn get_adjusted_notary_delay(
     membership: &Membership,
     pool: &PoolReader<'_>,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     log: &ReplicaLogger,
     height: Height,
     rank: Rank,
@@ -253,7 +253,7 @@ fn get_adjusted_notary_delay(
             pool.registry_version(height)?,
         ),
         pool,
-        state_manager,
+        state_reader,
         membership,
         rank,
         log,
@@ -295,7 +295,7 @@ fn get_adjusted_notary_delay(
 fn get_adjusted_notary_delay_from_settings(
     settings: NotarizationDelaySettings,
     pool: &PoolReader<'_>,
-    state_manager: &dyn StateManager<State = ReplicatedState>,
+    state_reader: &dyn StateReader<State = ReplicatedState>,
     membership: &Membership,
     rank: Rank,
     logger: &ReplicaLogger,
@@ -308,7 +308,7 @@ fn get_adjusted_notary_delay_from_settings(
 
     // We impose a hard limit on the gap between notarization and certification.
     let notarized_height = pool.get_notarized_height();
-    let certified_height = state_manager.latest_certified_height();
+    let certified_height = state_reader.latest_certified_height();
     if notarized_height
         .get()
         .saturating_sub(certified_height.get())
@@ -338,7 +338,7 @@ fn get_adjusted_notary_delay_from_settings(
     // finalized height, we increase the delay. More precisely, for every
     // round that certified height is behind finalized height, we add `unit_delay`.
     let certified_gap =
-        finalized_height.saturating_sub(state_manager.latest_certified_height().get());
+        finalized_height.saturating_sub(state_reader.latest_certified_height().get());
 
     // Determine if we are currently in the process of halting at the next CUP height, i.e.
     // due to a pending upgrade or registry flag. In this case, we should not adjust the


### PR DESCRIPTION
This PR changes some consensus crates to use the more restrictive `StateReader` interface where possible. Doing so helps in clarifying the interaction between consensus and DSM.