### PR TITLE
perf(idkg): [CON-1575] reduce the number of signature share validations

### DIFF
--- a/rs/consensus/idkg/Cargo.toml
+++ b/rs/consensus/idkg/Cargo.toml
@@ -35,6 +35,7 @@ ic-consensus-mocks = { path = "../mocks" }
 ic-interfaces-mocks = { path = "../../interfaces/mocks" }
 ic-crypto-interfaces-sig-verification = { path = "../../crypto/interfaces/sig_verification" }
 ic-crypto-temp-crypto = { path = "../../crypto/temp_crypto" }
+ic-crypto-test-utils-canister-threshold-sigs = { path = "../../crypto/test_utils/canister_threshold_sigs" }
 ic-crypto-test-utils-crypto-returning-ok = { path = "../../crypto/test_utils/crypto_returning_ok" }
 ic-crypto-test-utils-reproducible-rng = { path = "../../crypto/test_utils/reproducible_rng" }
 ic-crypto-tree-hash = { path = "../../crypto/tree_hash" }

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -1433,7 +1433,7 @@ mod tests {
             });
         }
 
-        // In the single threaded case only 2f + 1 shares should be accepted, the rest dropped
+        // In the single threaded case only f + 1 shares should be accepted, the rest dropped
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let (mut idkg_pool, signer) =
@@ -1467,7 +1467,7 @@ mod tests {
             })
         });
 
-        // In the multi threaded case at least 2f + 1 shares should be accepted, the rest dropped
+        // In the multi threaded case at least f + 1 shares should be accepted, the rest dropped
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             with_test_replica_logger(|logger| {
                 let (mut idkg_pool, signer) = create_signer_dependencies(pool_config, logger);

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -41,7 +41,7 @@ use rayon::{
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::{self, Debug, Formatter},
-    sync::Arc,
+    sync::{Arc, RwLock},
 };
 
 #[derive(Clone, Debug)]
@@ -115,6 +115,7 @@ pub(crate) struct ThresholdSignerImpl {
     crypto: Arc<dyn ConsensusCrypto>,
     thread_pool: Arc<ThreadPool>,
     state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
+    validated_sig_share_signers: RwLock<BTreeMap<RequestId, BTreeSet<NodeId>>>,
     metrics: ThresholdSignerMetrics,
     log: ReplicaLogger,
 }
@@ -133,6 +134,7 @@ impl ThresholdSignerImpl {
             crypto,
             thread_pool,
             state_reader,
+            validated_sig_share_signers: RwLock::new(BTreeMap::new()),
             metrics: ThresholdSignerMetrics::new(metrics_registry),
             log,
         }
@@ -146,7 +148,7 @@ impl ThresholdSignerImpl {
         transcript_loader: &dyn IDkgTranscriptLoader,
         state_snapshot: &dyn CertifiedStateSnapshot<State = ReplicatedState>,
     ) -> IDkgChangeSet {
-        self.thread_pool.install(|| {
+        let ret = self.thread_pool.install(|| {
             state_snapshot
                 .get_state()
                 .signature_request_contexts()
@@ -180,7 +182,22 @@ impl ThresholdSignerImpl {
                     )
                 })
                 .collect()
-        })
+        });
+
+        let mut valid_sig_share_signers = self.validated_sig_share_signers.write().unwrap();
+        for action in &ret {
+            if let &IDkgChangeAction::AddToValidated(ref action) = action
+                && let Some((request_id, signer)) = action.sig_share_request_id_and_signer()
+            {
+                // Record our share in the map of validated signature share signers
+                valid_sig_share_signers
+                    .entry(request_id)
+                    .or_default()
+                    .insert(signer);
+            }
+        }
+
+        ret
     }
 
     /// Processes the received signature shares
@@ -207,7 +224,7 @@ impl ThresholdSignerImpl {
 
         let shares: Vec<_> = idkg_pool.unvalidated().signature_shares().collect();
 
-        let results: Vec<_> = self.thread_pool.install(|| {
+        self.thread_pool.install(|| {
             // Iterate over all signature shares of all schemes
             shares
                 .into_par_iter()
@@ -225,25 +242,7 @@ impl ThresholdSignerImpl {
                     }
                 })
                 .collect()
-        });
-
-        let mut ret = Vec::new();
-        // Collection of validated shares
-        let mut validated_sig_shares = BTreeSet::new();
-        for action in results {
-            if let IDkgChangeAction::MoveToValidated(msg) = &action
-                && let Some(key) = msg.sig_share_dedup_key()
-                && !validated_sig_shares.insert(key)
-            {
-                self.metrics
-                    .sign_errors_inc("duplicate_sig_shares_in_batch");
-                ret.push(IDkgChangeAction::RemoveUnvalidated(msg.message_id()));
-                continue;
-            }
-            ret.push(action);
-        }
-
-        ret
+        })
     }
 
     fn validate_signature_share(
@@ -253,27 +252,40 @@ impl ThresholdSignerImpl {
         share: SigShare,
         inputs: &ThresholdSigInputs,
     ) -> Option<IDkgChangeAction> {
-        if self.signer_has_issued_share(
-            idkg_pool,
-            &share.signer(),
-            &share.request_id(),
-            share.scheme(),
-        ) {
+        {
+            let valid_sig_share_signers = self.validated_sig_share_signers.read().unwrap();
+            let maybe_signers = valid_sig_share_signers.get(&share.request_id());
+            if maybe_signers.is_some_and(|signers| signers.contains(&share.signer())) {
+                self.metrics
+                    .sign_errors_inc("duplicate_sig_share_cache_hit");
+                return Some(IDkgChangeAction::RemoveUnvalidated(id));
+            }
+
+            if self.inputs_already_have_enough_shares(inputs, maybe_signers) {
+                // We already have enough valid shares for this request
+                return Some(IDkgChangeAction::RemoveUnvalidated(id));
+            }
+        }
+
+        let request_id = share.request_id();
+        let signer = share.signer();
+        let scheme = share.scheme();
+        if self.signer_has_issued_share(idkg_pool, &signer, &request_id, scheme) {
             // The node already sent a valid share for this request
             self.metrics.sign_errors_inc("duplicate_sig_share");
             return Some(IDkgChangeAction::RemoveUnvalidated(id));
         }
 
         let share_string = share.to_string();
-        match self.crypto_verify_sig_share(inputs, share, idkg_pool.stats()) {
+        let ret = match self.crypto_verify_sig_share(inputs, share, idkg_pool.stats()) {
             Err(error) if error.is_reproducible() => {
                 self.metrics.sign_errors_inc("verify_sig_share_permanent");
-                Some(IDkgChangeAction::HandleInvalid(
+                return Some(IDkgChangeAction::HandleInvalid(
                     id,
                     format!(
                         "Signature share validation(permanent error): {share_string}, error = {error:?}"
                     ),
-                ))
+                ));
             }
             Err(error) => {
                 // Defer in case of transient errors
@@ -290,13 +302,27 @@ impl ThresholdSignerImpl {
                     "verify_sig_share_transient"
                 };
                 self.metrics.sign_errors_inc(label);
-                None
+                return None;
             }
             Ok(share) => {
                 self.metrics.sign_metrics_inc("sig_shares_received");
                 Some(IDkgChangeAction::MoveToValidated(share))
             }
+        };
+
+        // Although we already checked the cache for duplicate shares above, it could happen that a
+        // different thread validated a share for the same request_id  in the meantime, after we
+        // released the read lock. Therefore, we acquire the write lock here to check again with
+        // exclusive access.
+        let mut valid_sig_share_signers = self.validated_sig_share_signers.write().unwrap();
+        let signers = valid_sig_share_signers.entry(request_id).or_default();
+        if !signers.insert(signer) {
+            self.metrics
+                .sign_errors_inc("duplicate_sig_share_cache_miss");
+            return Some(IDkgChangeAction::RemoveUnvalidated(id));
         }
+
+        ret
     }
 
     /// Purges the entries no longer needed from the artifact pool
@@ -312,28 +338,33 @@ impl ThresholdSignerImpl {
             .cloned()
             .collect::<BTreeSet<_>>();
 
-        let mut ret = Vec::new();
         let current_height = state_snapshot.get_height();
 
         // Unvalidated signature shares.
-        let mut action = idkg_pool
+        let ret = idkg_pool
             .unvalidated()
             .signature_shares()
-            .filter(|(_, share)| self.should_purge(share, current_height, &in_progress))
-            .map(|(id, _)| IDkgChangeAction::RemoveUnvalidated(id))
-            .collect();
-        ret.append(&mut action);
+            .filter(|(_, share)| {
+                self.should_purge(share.request_id(), current_height, &in_progress)
+            })
+            .map(|(id, _)| IDkgChangeAction::RemoveUnvalidated(id));
 
         // Validated signature shares.
-        let mut action = idkg_pool
+        let mut valid_sig_share_signers = self.validated_sig_share_signers.write().unwrap();
+        let action = idkg_pool
             .validated()
             .signature_shares()
-            .filter(|(_, share)| self.should_purge(share, current_height, &in_progress))
-            .map(|(id, _)| IDkgChangeAction::RemoveValidated(id))
-            .collect();
-        ret.append(&mut action);
+            .filter(|(_, share)| {
+                self.should_purge(share.request_id(), current_height, &in_progress)
+            })
+            // Side-effect: remove from the validated_sig_share_signers map
+            .map(|(id, share)| {
+                valid_sig_share_signers.remove(&share.request_id());
+                IDkgChangeAction::RemoveValidated(id)
+            });
+        let ret = ret.chain(action);
 
-        ret
+        ret.collect()
     }
 
     /// Load necessary transcripts for the signature inputs
@@ -536,14 +567,31 @@ impl ThresholdSignerImpl {
         }
     }
 
+    fn inputs_already_have_enough_shares(
+        &self,
+        inputs: &ThresholdSigInputs,
+        maybe_signers: Option<&BTreeSet<NodeId>>,
+    ) -> bool {
+        let reconstruction_threshold = match inputs {
+            ThresholdSigInputs::Ecdsa(inputs) => inputs.reconstruction_threshold().get() as usize,
+            ThresholdSigInputs::Schnorr(inputs) => inputs.reconstruction_threshold().get() as usize,
+            // VetKd's API does not expose the number of shares needed for reconstruction directly.
+            // As this code path is an optimization, we conservatively assume that we do not have
+            // enough shares if the inputs are for VetKd.
+            // The worst thing that can happen is to validate a few extra shares.
+            ThresholdSigInputs::VetKd(_inputs) => return false,
+        };
+
+        maybe_signers.as_ref().map_or(0, |signers| signers.len()) >= reconstruction_threshold
+    }
+
     /// Checks if the signature share should be purged
     fn should_purge(
         &self,
-        share: &SigShare,
+        request_id: RequestId,
         current_height: Height,
         in_progress: &BTreeSet<CallbackId>,
     ) -> bool {
-        let request_id = share.request_id();
         request_id.height <= current_height && !in_progress.contains(&request_id.callback_id)
     }
 }

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -738,12 +738,13 @@ mod tests {
     use ic_test_utilities_types::ids::{NODE_1, NODE_2, NODE_3, subnet_test_id, user_test_id};
     use ic_types::{
         Height, Randomness,
-        consensus::idkg::*,
+        consensus::{get_faults_tolerated, idkg::*},
         crypto::{
             AlgorithmId, ExtendedDerivationPath, canister_threshold_sig::idkg::IDkgReceivers,
         },
         time::UNIX_EPOCH,
     };
+    use ic_types_test_utils::ids::node_test_id;
     use std::sync::RwLock;
 
     impl ThresholdSignerImpl {
@@ -1387,6 +1388,122 @@ mod tests {
                         (id_2, BTreeSet::from([NODE_2])),
                         (id_3, BTreeSet::from([NODE_2])),
                     ])
+                );
+            })
+        });
+    }
+
+    // Tests that signature shares are validated only until the reconstruction threshold is
+    // reached, and shares received after that are not validated.
+    #[test]
+    fn test_validate_signature_shares_validates_only_necessary_all_algorithms() {
+        for key_id in fake_master_public_key_ids_for_all_algorithms() {
+            println!("Running test for key ID {key_id}");
+            test_validate_signature_shares_until_reconstruction_threshold(key_id);
+        }
+    }
+
+    fn test_validate_signature_shares_until_reconstruction_threshold(key_id: MasterPublicKeyId) {
+        let height = Height::from(100);
+        let mut generator = IDkgUIDGenerator::new(subnet_test_id(1), Height::new(0));
+        let id = request_id(1, height);
+        let pid = generator.next_pre_signature_id();
+
+        let state = fake_state_with_signature_requests(
+            height,
+            [fake_signature_request_context_from_id(
+                key_id.clone(),
+                pid,
+                id,
+            )],
+        );
+
+        let n = 4;
+        let node_ids = (0..n)
+            .map(|i| node_test_id(i.try_into().unwrap()))
+            .collect::<Vec<_>>();
+        let expected_nb_sig_shares = match key_id {
+            MasterPublicKeyId::Ecdsa(_) => get_faults_tolerated(n) + 1,
+            MasterPublicKeyId::Schnorr(_) => get_faults_tolerated(n) + 1,
+            MasterPublicKeyId::VetKd(_) => n, // The optimization is disabled for VetKD for now
+        };
+
+        // Add unvalidated shares for all nodes
+        let mut msg_ids = vec![];
+        let mut artifacts = vec![];
+        for node_id in &node_ids {
+            let message = create_signature_share(&key_id, *node_id, id);
+            msg_ids.push(message.message_id());
+            artifacts.push(UnvalidatedArtifact {
+                message,
+                peer_id: *node_id,
+                timestamp: UNIX_EPOCH,
+            });
+        }
+
+        // In the single threaded case only 2f + 1 shares should be accepted, the rest dropped
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            with_test_replica_logger(|logger| {
+                let (mut idkg_pool, signer) =
+                    create_signer_dependencies_with_threads(pool_config, logger, 1);
+                artifacts.iter().for_each(|a| idkg_pool.insert(a.clone()));
+
+                let change_set = signer.validate_signature_shares(&idkg_pool, &state);
+                assert_eq!(change_set.len(), n);
+                let (accepted, dropped): (Vec<_>, Vec<_>) = msg_ids
+                    .clone()
+                    .into_iter()
+                    .partition(|msg_id| is_moved_to_validated(&change_set, msg_id));
+                assert!(
+                    dropped
+                        .iter()
+                        .all(|msg_id| is_removed_from_unvalidated(&change_set, msg_id))
+                );
+                assert_eq!(accepted.len(), expected_nb_sig_shares);
+                assert_eq!(dropped.len(), n - expected_nb_sig_shares);
+
+                assert_eq!(signer.validated_sig_share_signers().len(), 1);
+                assert!(
+                    signer
+                        .validated_sig_share_signers()
+                        .get(&id)
+                        .is_some_and(|signers| {
+                            signers.len() == expected_nb_sig_shares
+                                && signers.is_subset(&node_ids.iter().cloned().collect())
+                        })
+                );
+            })
+        });
+
+        // In the multi threaded case at least 2f + 1 shares should be accepted, the rest dropped
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            with_test_replica_logger(|logger| {
+                let (mut idkg_pool, signer) = create_signer_dependencies(pool_config, logger);
+                artifacts.iter().for_each(|a| idkg_pool.insert(a.clone()));
+
+                let change_set = signer.validate_signature_shares(&idkg_pool, &state);
+                assert_eq!(change_set.len(), n);
+                let (accepted, dropped): (Vec<_>, Vec<_>) = msg_ids
+                    .clone()
+                    .into_iter()
+                    .partition(|msg_id| is_moved_to_validated(&change_set, msg_id));
+                assert!(
+                    dropped
+                        .iter()
+                        .all(|msg_id| is_removed_from_unvalidated(&change_set, msg_id))
+                );
+                assert!(accepted.len() >= expected_nb_sig_shares);
+                assert_eq!(dropped.len(), n - accepted.len());
+
+                assert_eq!(signer.validated_sig_share_signers().len(), 1);
+                assert!(
+                    signer
+                        .validated_sig_share_signers()
+                        .get(&id)
+                        .is_some_and(|signers| {
+                            signers.len() == accepted.len()
+                                && signers.is_subset(&node_ids.iter().cloned().collect())
+                        })
                 );
             })
         });

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -746,6 +746,15 @@ mod tests {
     };
     use std::sync::RwLock;
 
+    impl ThresholdSignerImpl {
+        fn validated_sig_share_signers(&self) -> BTreeMap<RequestId, BTreeSet<NodeId>> {
+            self.validated_sig_share_signers
+                .read()
+                .expect("ThresholdSignerImpl::validated_sig_share_signers(): RwLock poisoned")
+                .clone()
+        }
+    }
+
     #[test]
     fn test_ecdsa_signer_action() {
         let key_id = fake_ecdsa_idkg_master_public_key_id();
@@ -846,6 +855,12 @@ mod tests {
                     IDkgChangeAction::AddToValidated(share2),
                 ];
                 idkg_pool.apply(change_set);
+                {
+                    let mut valid_sig_share_signers =
+                        signer.validated_sig_share_signers.write().unwrap();
+                    valid_sig_share_signers.insert(id_1, BTreeSet::from([NODE_1]));
+                    valid_sig_share_signers.insert(id_2, BTreeSet::from([NODE_2]));
+                }
 
                 let schedule = IDkgSchedule::new(Height::from(0));
                 // Certified height doesn't increase, so share1 shouldn't be purged
@@ -859,6 +874,10 @@ mod tests {
                 assert_eq!(*schedule.last_purge.borrow(), new_height);
                 assert_eq!(change_set.len(), 1);
                 assert!(is_removed_from_validated(&change_set, &msg_id1));
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([(id_2, BTreeSet::from([NODE_2]))])
+                );
                 idkg_pool.apply(change_set);
 
                 // Certified height increases above share2, so it is purged
@@ -868,6 +887,7 @@ mod tests {
                 assert_eq!(height_30, new_height);
                 assert_eq!(change_set.len(), 1);
                 assert!(is_removed_from_validated(&change_set, &msg_id2));
+                assert_eq!(signer.validated_sig_share_signers(), BTreeMap::new());
             })
         })
     }
@@ -937,6 +957,13 @@ mod tests {
                     &ids[4],
                     height,
                 ));
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([
+                        (ids[3], BTreeSet::from([NODE_1])),
+                        (ids[4], BTreeSet::from([NODE_1])),
+                    ])
+                );
             })
         });
 
@@ -960,6 +987,7 @@ mod tests {
                 let change_set =
                     signer.send_signature_shares(&idkg_pool, &transcript_loader, &state);
                 assert!(change_set.is_empty());
+                assert_eq!(signer.validated_sig_share_signers(), BTreeMap::new());
             })
         });
     }
@@ -1017,6 +1045,10 @@ mod tests {
                     &ids[2],
                     height,
                 ));
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([(ids[2], BTreeSet::from([NODE_1]))])
+                );
             })
         });
     }
@@ -1055,10 +1087,19 @@ mod tests {
                 if key_id.is_idkg_key() {
                     // No shares should be created for IDKG keys when transcripts fail to load
                     assert!(change_set.is_empty());
+                    assert_eq!(signer.validated_sig_share_signers(), BTreeMap::new());
                 } else {
                     // NiDKG transcripts are loaded ahead of time, so creation should succeed, even if
                     // IDKG transcripts fail to load.
                     assert_eq!(change_set.len(), 3);
+                    assert_eq!(
+                        signer.validated_sig_share_signers(),
+                        BTreeMap::from([
+                            (ids[0], BTreeSet::from([NODE_1])),
+                            (ids[1], BTreeSet::from([NODE_1])),
+                            (ids[2], BTreeSet::from([NODE_1])),
+                        ])
+                    );
                 }
                 idkg_pool.apply(change_set);
 
@@ -1070,9 +1111,25 @@ mod tests {
                 if key_id.is_idkg_key() {
                     // IDKG key siganture shares should be created when transcripts succeed to load
                     assert_eq!(change_set.len(), 3);
+                    assert_eq!(
+                        signer.validated_sig_share_signers(),
+                        BTreeMap::from([
+                            (ids[0], BTreeSet::from([NODE_1])),
+                            (ids[1], BTreeSet::from([NODE_1])),
+                            (ids[2], BTreeSet::from([NODE_1])),
+                        ])
+                    );
                 } else {
                     // No new shares should be created with NiDKG, as they were already created above
                     assert!(change_set.is_empty());
+                    assert_eq!(
+                        signer.validated_sig_share_signers(),
+                        BTreeMap::from([
+                            (ids[0], BTreeSet::from([NODE_1])),
+                            (ids[1], BTreeSet::from([NODE_1])),
+                            (ids[2], BTreeSet::from([NODE_1])),
+                        ])
+                    );
                 }
             })
         })
@@ -1133,6 +1190,7 @@ mod tests {
                         &NODE_1,
                     ));
                 }
+                assert_eq!(signer.validated_sig_share_signers(), BTreeMap::new());
             })
         })
     }
@@ -1323,6 +1381,13 @@ mod tests {
                 assert!(is_moved_to_validated(&change_set, &msg_id_2));
                 assert!(is_moved_to_validated(&change_set, &msg_id_3));
                 assert!(is_removed_from_unvalidated(&change_set, &msg_id_4));
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([
+                        (id_2, BTreeSet::from([NODE_2])),
+                        (id_3, BTreeSet::from([NODE_2])),
+                    ])
+                );
             })
         });
     }
@@ -1394,6 +1459,10 @@ mod tests {
                     &msg_id_2,
                     "Signature share validation(permanent error)"
                 ));
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([(id_1, BTreeSet::from([NODE_2]))])
+                );
             })
         });
     }
@@ -1489,6 +1558,10 @@ mod tests {
                 assert_eq!(change_set.len(), 2);
                 assert!(is_moved_to_validated(&change_set, &msg_id_3));
                 assert!(is_removed_from_unvalidated(&change_set, &msg_id_4));
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([(ids[2], BTreeSet::from([NODE_2]))])
+                );
             })
         });
     }
@@ -1527,6 +1600,11 @@ mod tests {
                 let share = create_signature_share(&key_id, NODE_2, id_2);
                 let change_set = vec![IDkgChangeAction::AddToValidated(share)];
                 idkg_pool.apply(change_set);
+                {
+                    let mut valid_sig_share_signers =
+                        signer.validated_sig_share_signers.write().unwrap();
+                    valid_sig_share_signers.insert(id_2, BTreeSet::from([NODE_2]));
+                }
 
                 // Unvalidated pool has: {signature share 2, signer = NODE_2, height = 100}
                 let message = create_signature_share(&key_id, NODE_2, id_2);
@@ -1540,6 +1618,10 @@ mod tests {
                 let change_set = signer.validate_signature_shares(&idkg_pool, &state);
                 assert_eq!(change_set.len(), 1);
                 assert!(is_removed_from_unvalidated(&change_set, &msg_id_2));
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([(id_2, BTreeSet::from([NODE_2]))])
+                );
             })
         })
     }
@@ -1610,6 +1692,11 @@ mod tests {
                 // One is considered duplicate
                 assert!(msg_1_valid || msg_2_valid);
                 assert!(is_moved_to_validated(&change_set, &msg_id_3));
+
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([(id_1, BTreeSet::from([NODE_2, NODE_3]))])
+                );
             })
         })
     }
@@ -1732,9 +1819,24 @@ mod tests {
                 let change_set = vec![IDkgChangeAction::AddToValidated(share)];
                 idkg_pool.apply(change_set);
 
+                {
+                    let mut valid_sig_share_signers =
+                        signer.validated_sig_share_signers.write().unwrap();
+                    valid_sig_share_signers.insert(id_1, BTreeSet::from([NODE_2]));
+                    valid_sig_share_signers.insert(id_2, BTreeSet::from([NODE_2]));
+                    valid_sig_share_signers.insert(id_3, BTreeSet::from([NODE_2]));
+                }
+
                 let change_set = signer.purge_artifacts(&idkg_pool, &state);
                 assert_eq!(change_set.len(), 1);
                 assert!(is_removed_from_validated(&change_set, &msg_id_2));
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([
+                        (id_1, BTreeSet::from([NODE_2])),
+                        (id_3, BTreeSet::from([NODE_2])),
+                    ])
+                );
             })
         })
     }

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -278,15 +278,15 @@ impl ThresholdSignerImpl {
         }
 
         let share_string = share.to_string();
-        let ret = match self.crypto_verify_sig_share(inputs, share, idkg_pool.stats()) {
+        match self.crypto_verify_sig_share(inputs, share, idkg_pool.stats()) {
             Err(error) if error.is_reproducible() => {
                 self.metrics.sign_errors_inc("verify_sig_share_permanent");
-                return Some(IDkgChangeAction::HandleInvalid(
+                Some(IDkgChangeAction::HandleInvalid(
                     id,
                     format!(
                         "Signature share validation(permanent error): {share_string}, error = {error:?}"
                     ),
-                ));
+                ))
             }
             Err(error) => {
                 // Defer in case of transient errors
@@ -303,27 +303,26 @@ impl ThresholdSignerImpl {
                     "verify_sig_share_transient"
                 };
                 self.metrics.sign_errors_inc(label);
-                return None;
+                None
             }
             Ok(share) => {
                 self.metrics.sign_metrics_inc("sig_shares_received");
-                Some(IDkgChangeAction::MoveToValidated(share))
+
+                // Although we already checked the cache for duplicate shares above, it could happen that a
+                // different thread validated a share for the same request_id in the meantime, after we
+                // released the read lock. Therefore, we acquire the write lock here to check again with
+                // exclusive access.
+                let mut valid_sig_share_signers = self.validated_sig_share_signers.write().unwrap();
+                let signers = valid_sig_share_signers.entry(request_id).or_default();
+                if !signers.insert(signer) {
+                    self.metrics
+                        .sign_errors_inc("duplicate_sig_share_cache_miss");
+                    Some(IDkgChangeAction::RemoveUnvalidated(id))
+                } else {
+                    Some(IDkgChangeAction::MoveToValidated(share))
+                }
             }
-        };
-
-        // Although we already checked the cache for duplicate shares above, it could happen that a
-        // different thread validated a share for the same request_id in the meantime, after we
-        // released the read lock. Therefore, we acquire the write lock here to check again with
-        // exclusive access.
-        let mut valid_sig_share_signers = self.validated_sig_share_signers.write().unwrap();
-        let signers = valid_sig_share_signers.entry(request_id).or_default();
-        if !signers.insert(signer) {
-            self.metrics
-                .sign_errors_inc("duplicate_sig_share_cache_miss");
-            return Some(IDkgChangeAction::RemoveUnvalidated(id));
         }
-
-        ret
     }
 
     /// Purges the entries no longer needed from the artifact pool

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -1112,26 +1112,18 @@ mod tests {
                 if key_id.is_idkg_key() {
                     // IDKG key signature shares should be created when transcripts succeed to load
                     assert_eq!(change_set.len(), 3);
-                    assert_eq!(
-                        signer.validated_sig_share_signers(),
-                        BTreeMap::from([
-                            (ids[0], BTreeSet::from([NODE_1])),
-                            (ids[1], BTreeSet::from([NODE_1])),
-                            (ids[2], BTreeSet::from([NODE_1])),
-                        ])
-                    );
                 } else {
                     // No new shares should be created with NiDKG, as they were already created above
                     assert!(change_set.is_empty());
-                    assert_eq!(
-                        signer.validated_sig_share_signers(),
-                        BTreeMap::from([
-                            (ids[0], BTreeSet::from([NODE_1])),
-                            (ids[1], BTreeSet::from([NODE_1])),
-                            (ids[2], BTreeSet::from([NODE_1])),
-                        ])
-                    );
                 }
+                assert_eq!(
+                    signer.validated_sig_share_signers(),
+                    BTreeMap::from([
+                        (ids[0], BTreeSet::from([NODE_1])),
+                        (ids[1], BTreeSet::from([NODE_1])),
+                        (ids[2], BTreeSet::from([NODE_1])),
+                    ])
+                );
             })
         })
     }

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -312,7 +312,7 @@ impl ThresholdSignerImpl {
         };
 
         // Although we already checked the cache for duplicate shares above, it could happen that a
-        // different thread validated a share for the same request_id  in the meantime, after we
+        // different thread validated a share for the same request_id in the meantime, after we
         // released the read lock. Therefore, we acquire the write lock here to check again with
         // exclusive access.
         let mut valid_sig_share_signers = self.validated_sig_share_signers.write().unwrap();
@@ -1111,7 +1111,7 @@ mod tests {
                     signer.send_signature_shares(&idkg_pool, &transcript_loader, &state);
 
                 if key_id.is_idkg_key() {
-                    // IDKG key siganture shares should be created when transcripts succeed to load
+                    // IDKG key signature shares should be created when transcripts succeed to load
                     assert_eq!(change_set.len(), 3);
                     assert_eq!(
                         signer.validated_sig_share_signers(),

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -166,7 +166,7 @@ impl ThresholdSignerImpl {
                     .ok()
                 })
                 .filter(|(request_id, inputs)| {
-                    !self.signer_has_issued_share(
+                    !Self::signer_has_issued_share(
                         idkg_pool,
                         &self.node_id,
                         request_id,
@@ -262,7 +262,7 @@ impl ThresholdSignerImpl {
                 return Some(IDkgChangeAction::RemoveUnvalidated(id));
             }
 
-            if self.inputs_already_have_enough_shares(inputs, maybe_signers) {
+            if Self::inputs_already_have_enough_shares(inputs, maybe_signers) {
                 // We already have enough valid shares for this request
                 return Some(IDkgChangeAction::RemoveUnvalidated(id));
             }
@@ -271,7 +271,7 @@ impl ThresholdSignerImpl {
         let signer = share.signer();
         let request_id = share.request_id();
         let scheme = share.scheme();
-        if self.signer_has_issued_share(idkg_pool, &signer, &request_id, scheme) {
+        if Self::signer_has_issued_share(idkg_pool, &signer, &request_id, scheme) {
             // The node already sent a valid share for this request
             self.metrics.sign_errors_inc("duplicate_sig_share");
             return Some(IDkgChangeAction::RemoveUnvalidated(id));
@@ -345,7 +345,7 @@ impl ThresholdSignerImpl {
             .unvalidated()
             .signature_shares()
             .filter(|(_, share)| {
-                self.should_purge(share.request_id(), current_height, &in_progress)
+                Self::should_purge(share.request_id(), current_height, &in_progress)
             })
             .map(|(id, _)| IDkgChangeAction::RemoveUnvalidated(id));
 
@@ -355,7 +355,7 @@ impl ThresholdSignerImpl {
             .validated()
             .signature_shares()
             .filter(|(_, share)| {
-                self.should_purge(share.request_id(), current_height, &in_progress)
+                Self::should_purge(share.request_id(), current_height, &in_progress)
             })
             // Side-effect: remove from the validated_sig_share_signers map
             .map(|(id, share)| {
@@ -532,7 +532,6 @@ impl ThresholdSignerImpl {
     /// Checks if the signer node has already issued a signature share for the
     /// request
     fn signer_has_issued_share(
-        &self,
         idkg_pool: &dyn IDkgPool,
         signer_id: &NodeId,
         request_id: &RequestId,
@@ -568,7 +567,6 @@ impl ThresholdSignerImpl {
     }
 
     fn inputs_already_have_enough_shares(
-        &self,
         inputs: &ThresholdSigInputs,
         maybe_signers: Option<&BTreeSet<NodeId>>,
     ) -> bool {
@@ -587,7 +585,6 @@ impl ThresholdSignerImpl {
 
     /// Checks if the signature share should be purged
     fn should_purge(
-        &self,
         request_id: RequestId,
         current_height: Height,
         in_progress: &BTreeSet<CallbackId>,

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -268,8 +268,8 @@ impl ThresholdSignerImpl {
             }
         }
 
-        let request_id = share.request_id();
         let signer = share.signer();
+        let request_id = share.request_id();
         let scheme = share.scheme();
         if self.signer_has_issued_share(idkg_pool, &signer, &request_id, scheme) {
             // The node already sent a valid share for this request
@@ -1810,7 +1810,6 @@ mod tests {
                 // One is considered duplicate
                 assert!(msg_1_valid || msg_2_valid);
                 assert!(is_moved_to_validated(&change_set, &msg_id_3));
-
                 assert_eq!(
                     signer.validated_sig_share_signers(),
                     BTreeMap::from([(id_1, BTreeSet::from([NODE_2, NODE_3]))])

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -186,8 +186,9 @@ impl ThresholdSignerImpl {
 
         let mut valid_sig_share_signers = self.validated_sig_share_signers.write().unwrap();
         for action in &ret {
-            if let &IDkgChangeAction::AddToValidated(ref action) = action
-                && let Some((request_id, signer)) = action.sig_share_request_id_and_signer()
+            #[allow(clippy::needless_borrowed_reference)] // This borrowed reference *is* needed
+            if let &IDkgChangeAction::AddToValidated(ref share) = action
+                && let Some((request_id, signer)) = share.sig_share_request_id_and_signer()
             {
                 // Record our share in the map of validated signature share signers
                 valid_sig_share_signers

--- a/rs/consensus/idkg/src/test_utils.rs
+++ b/rs/consensus/idkg/src/test_utils.rs
@@ -453,10 +453,11 @@ pub(crate) fn create_pre_signer_dependencies_with_threads(
 }
 
 // Sets up the dependencies and creates the signer
-pub(crate) fn create_signer_dependencies_with_crypto(
+pub(crate) fn create_signer_dependencies_with_crypto_and_threads(
     pool_config: ArtifactPoolConfig,
     logger: ReplicaLogger,
     consensus_crypto: Option<Arc<dyn ConsensusCrypto>>,
+    threads: usize,
 ) -> (IDkgPoolImpl, ThresholdSignerImpl) {
     let metrics_registry = MetricsRegistry::new();
     let Dependencies {
@@ -468,7 +469,7 @@ pub(crate) fn create_signer_dependencies_with_crypto(
     let signer = ThresholdSignerImpl::new(
         NODE_1,
         consensus_crypto.unwrap_or(crypto),
-        build_thread_pool(MAX_IDKG_THREADS),
+        build_thread_pool(threads),
         state_manager as Arc<_>,
         metrics_registry.clone(),
         logger.clone(),
@@ -478,12 +479,33 @@ pub(crate) fn create_signer_dependencies_with_crypto(
     (idkg_pool, signer)
 }
 
+pub(crate) fn create_signer_dependencies_with_crypto(
+    pool_config: ArtifactPoolConfig,
+    logger: ReplicaLogger,
+    consensus_crypto: Option<Arc<dyn ConsensusCrypto>>,
+) -> (IDkgPoolImpl, ThresholdSignerImpl) {
+    create_signer_dependencies_with_crypto_and_threads(
+        pool_config,
+        logger,
+        consensus_crypto,
+        MAX_IDKG_THREADS,
+    )
+}
+
 // Sets up the dependencies and creates the signer
 pub(crate) fn create_signer_dependencies(
     pool_config: ArtifactPoolConfig,
     logger: ReplicaLogger,
 ) -> (IDkgPoolImpl, ThresholdSignerImpl) {
     create_signer_dependencies_with_crypto(pool_config, logger, None)
+}
+
+pub(crate) fn create_signer_dependencies_with_threads(
+    pool_config: ArtifactPoolConfig,
+    logger: ReplicaLogger,
+    threads: usize,
+) -> (IDkgPoolImpl, ThresholdSignerImpl) {
+    create_signer_dependencies_with_crypto_and_threads(pool_config, logger, None, threads)
 }
 
 pub(crate) fn create_signer_dependencies_and_state_manager(

--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -889,7 +889,7 @@ impl IDkgMessage {
         }
     }
 
-    pub fn sig_share_dedup_key(&self) -> Option<(RequestId, NodeId)> {
+    pub fn sig_share_request_id_and_signer(&self) -> Option<(RequestId, NodeId)> {
         match self {
             IDkgMessage::EcdsaSigShare(x) => Some((x.request_id, x.signer_id)),
             IDkgMessage::SchnorrSigShare(x) => Some((x.request_id, x.signer_id)),


### PR DESCRIPTION
This PR reduces the number of signature share validations from `N` to `f+1`, which are enough to aggregate the full signature. The strategy is very similar to the one done in #6526 to reduce the number of dealing supports: we introduce an in-memory map that keeps track for each `RequestId`, the set of share signers already validated. Once that set reaches a cardinality of `f+1`, we stop validating more signature shares for that `RequestId`. We follow the same approach as in #7069 to do all that in parallel: check with shared access to the lock, then perform the cryptographic validation and if valid, check again with exclusive access to the lock.