### PR TITLE
feat(flexible-outcalls): CON-1714 extend ResponsesTooLarge error for good error message

### DIFF
--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -762,8 +762,32 @@ impl CanisterHttpPayloadBuilderImpl {
                     }
                 }
                 FlexibleCanisterHttpError::ResponsesTooLarge {
-                    all_seen_shares, ..
+                    all_seen_shares,
+                    total_requests,
+                    min_responses: claimed_min_responses,
+                    ..
                 } => {
+                    if *total_requests != flex_committee.len() as u32 {
+                        return invalid_artifact(
+                            InvalidCanisterHttpPayloadReason::FlexibleResponsesTooLargeParamMismatch {
+                                callback_id,
+                                field: "total_requests",
+                                expected: flex_committee.len() as u32,
+                                actual: *total_requests,
+                            },
+                        );
+                    }
+                    if *claimed_min_responses != min_responses as u32 {
+                        return invalid_artifact(
+                            InvalidCanisterHttpPayloadReason::FlexibleResponsesTooLargeParamMismatch {
+                                callback_id,
+                                field: "min_responses",
+                                expected: min_responses as u32,
+                                actual: *claimed_min_responses,
+                            },
+                        );
+                    }
+
                     let mut seen_signers = HashSet::new();
 
                     for share in all_seen_shares {

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -2857,10 +2857,14 @@ fn flexible_build_responses_too_large() {
             FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id: cb,
                 all_seen_shares,
+                total_requests,
+                min_responses,
             } => {
                 assert_eq!(*cb, callback_id);
                 assert_eq!(all_seen_shares.len(), 4);
                 assert!(all_seen_shares.iter().all(|s| !s.content.is_reject));
+                assert_eq!(*total_requests, 4);
+                assert_eq!(*min_responses, 2);
             }
         );
     });
@@ -2946,6 +2950,8 @@ fn flexible_build_responses_too_large_with_rejects_reducing_unseen() {
             FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id: cb,
                 all_seen_shares,
+                total_requests,
+                min_responses,
             } => {
                 assert_eq!(*cb, callback_id);
                 assert_eq!(all_seen_shares.len(), 5);
@@ -2953,6 +2959,8 @@ fn flexible_build_responses_too_large_with_rejects_reducing_unseen() {
                 let reject_count = all_seen_shares.iter().filter(|s| s.content.is_reject).count();
                 assert_eq!(ok_count, 3);
                 assert_eq!(reject_count, 2);
+                assert_eq!(*total_requests, 6);
+                assert_eq!(*min_responses, 3);
             }
         );
     });
@@ -3004,6 +3012,8 @@ fn flexible_build_responses_too_large_fewer_ok_than_min_responses() {
             FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id: cb,
                 all_seen_shares,
+                total_requests,
+                min_responses,
             } => {
                 assert_eq!(*cb, callback_id);
                 assert_eq!(all_seen_shares.len(), 5);
@@ -3011,6 +3021,8 @@ fn flexible_build_responses_too_large_fewer_ok_than_min_responses() {
                 let reject_count = all_seen_shares.iter().filter(|s| s.content.is_reject).count();
                 assert_eq!(ok_count, 3);
                 assert_eq!(reject_count, 2);
+                assert_eq!(*total_requests, 6);
+                assert_eq!(*min_responses, 4);
             }
         );
     });
@@ -3375,6 +3387,8 @@ fn flexible_error_responses_too_large_valid() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares,
+                total_requests: 4,
+                min_responses: 2,
             }],
             ..Default::default()
         };
@@ -3410,6 +3424,8 @@ fn flexible_error_responses_too_large_valid_with_unseen_members() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares,
+                total_requests: 6,
+                min_responses: 4,
             }],
             ..Default::default()
         };
@@ -3442,6 +3458,8 @@ fn flexible_error_responses_too_large_valid_with_mixed_ok_and_reject() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares: vec![ok_a, ok_b, reject_c, reject_d],
+                total_requests: 4,
+                min_responses: 2,
             }],
             ..Default::default()
         };
@@ -3452,6 +3470,92 @@ fn flexible_error_responses_too_large_valid_with_mixed_ok_and_reject() {
             &[],
         );
         assert_matches!(result, Ok(()));
+    });
+}
+
+#[test]
+fn flexible_error_responses_too_large_wrong_total_requests() {
+    let num_nodes = 4;
+    let committee: BTreeSet<_> = (0..num_nodes as u64).map(node_test_id).collect();
+    let callback_id = CallbackId::from(42);
+
+    let huge = (MAX_CANISTER_HTTP_PAYLOAD_SIZE as u32 / 2) + 100_000;
+    setup_test_with_flexible_context(num_nodes, callback_id, committee, 2, 4, |pb, _pool| {
+        let all_seen_shares: Vec<_> = (0..4)
+            .map(|i| metadata_share_with_content_size(callback_id.get(), i, huge))
+            .collect();
+
+        let payload = CanisterHttpPayload {
+            flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
+                callback_id,
+                all_seen_shares,
+                total_requests: 99,
+                min_responses: 2,
+            }],
+            ..Default::default()
+        };
+        let result = pb.validate_payload(
+            Height::new(1),
+            &test_proposal_context(&default_validation_context()),
+            &payload_to_bytes_max_4mb(payload),
+            &[],
+        );
+        assert_matches!(
+            result,
+            Err(ValidationError::InvalidArtifact(
+                InvalidPayloadReason::InvalidCanisterHttpPayload(
+                    InvalidCanisterHttpPayloadReason::FlexibleResponsesTooLargeParamMismatch {
+                        field: "total_requests",
+                        expected: 4,
+                        actual: 99,
+                        ..
+                    }
+                )
+            ))
+        );
+    });
+}
+
+#[test]
+fn flexible_error_responses_too_large_wrong_min_responses() {
+    let num_nodes = 4;
+    let committee: BTreeSet<_> = (0..num_nodes as u64).map(node_test_id).collect();
+    let callback_id = CallbackId::from(42);
+
+    let huge = (MAX_CANISTER_HTTP_PAYLOAD_SIZE as u32 / 2) + 100_000;
+    setup_test_with_flexible_context(num_nodes, callback_id, committee, 2, 4, |pb, _pool| {
+        let all_seen_shares: Vec<_> = (0..4)
+            .map(|i| metadata_share_with_content_size(callback_id.get(), i, huge))
+            .collect();
+
+        let payload = CanisterHttpPayload {
+            flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
+                callback_id,
+                all_seen_shares,
+                total_requests: 4,
+                min_responses: 99,
+            }],
+            ..Default::default()
+        };
+        let result = pb.validate_payload(
+            Height::new(1),
+            &test_proposal_context(&default_validation_context()),
+            &payload_to_bytes_max_4mb(payload),
+            &[],
+        );
+        assert_matches!(
+            result,
+            Err(ValidationError::InvalidArtifact(
+                InvalidPayloadReason::InvalidCanisterHttpPayload(
+                    InvalidCanisterHttpPayloadReason::FlexibleResponsesTooLargeParamMismatch {
+                        field: "min_responses",
+                        expected: 2,
+                        actual: 99,
+                        ..
+                    }
+                )
+            ))
+        );
     });
 }
 
@@ -3471,6 +3575,8 @@ fn flexible_error_responses_too_large_invalid_when_small() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares: vec![entry_a.proof.clone(), entry_b.proof.clone()],
+                total_requests: 4,
+                min_responses: 2,
             }],
             ..Default::default()
         };
@@ -3508,6 +3614,8 @@ fn flexible_error_responses_too_large_invalid_when_committee_members_omitted() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares: vec![share_a, share_b],
+                total_requests: 4,
+                min_responses: 2,
             }],
             ..Default::default()
         };
@@ -3547,6 +3655,8 @@ fn flexible_error_responses_too_large_too_few_ok_shares() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares: vec![ok_a, ok_b, reject_c, reject_d],
+                total_requests: 4,
+                min_responses: 3,
             }],
             ..Default::default()
         };
@@ -3588,6 +3698,8 @@ fn flexible_error_responses_too_large_callback_id_mismatch() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares: vec![share_ok, share_wrong],
+                total_requests: 4,
+                min_responses: 2,
             }],
             ..Default::default()
         };
@@ -3624,6 +3736,8 @@ fn flexible_error_responses_too_large_duplicate_signer() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares: vec![share_a, share_b],
+                total_requests: 4,
+                min_responses: 2,
             }],
             ..Default::default()
         };
@@ -3659,6 +3773,8 @@ fn flexible_error_responses_too_large_signer_not_in_committee() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares: vec![share_ok, share_bad],
+                total_requests: 4,
+                min_responses: 2,
             }],
             ..Default::default()
         };
@@ -3696,6 +3812,8 @@ fn flexible_error_responses_too_large_registry_version_mismatch() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares: vec![share_ok, share_bad],
+                total_requests: 4,
+                min_responses: 2,
             }],
             ..Default::default()
         };
@@ -3732,6 +3850,8 @@ fn flexible_error_responses_too_large_invalid_signature() {
             flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares: vec![share_a, share_b],
+                total_requests: 4,
+                min_responses: 2,
             }],
             ..Default::default()
         };

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -458,6 +458,8 @@ pub(crate) fn find_flexible_result(
             let error = FlexibleCanisterHttpError::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares,
+                total_requests: committee.len() as u32,
+                min_responses: min_responses as u32,
             };
             let error_size = error.count_bytes();
             return FlexibleFindResult::Error(error, error_size);

--- a/rs/interfaces/src/canister_http.rs
+++ b/rs/interfaces/src/canister_http.rs
@@ -111,6 +111,13 @@ pub enum InvalidCanisterHttpPayloadReason {
     },
     /// A TooManyRequestErrors entry contains a non-Reject response.
     FlexibleRejectExpectedInErrorResponse(CallbackId),
+    /// A ResponsesTooLarge error has incorrect total_requests or min_responses.
+    FlexibleResponsesTooLargeParamMismatch {
+        callback_id: CallbackId,
+        field: &'static str,
+        expected: u32,
+        actual: u32,
+    },
     /// A ResponsesTooLarge error does not include enough OK shares to prove impossibility.
     FlexibleResponsesTooLargeInsufficientEvidence {
         callback_id: CallbackId,

--- a/rs/protobuf/def/types/v1/canister_http.proto
+++ b/rs/protobuf/def/types/v1/canister_http.proto
@@ -89,6 +89,8 @@ message FlexibleCanisterHttpTimeout {}
 
 message FlexibleCanisterHttpResponsesTooLarge {
   repeated CanisterHttpShare all_seen_shares = 1;
+  uint32 total_requests = 2;
+  uint32 min_responses = 3;
 }
 
 message FlexibleCanisterHttpTooManyRequestErrors {

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -635,6 +635,10 @@ pub struct FlexibleCanisterHttpTimeout {}
 pub struct FlexibleCanisterHttpResponsesTooLarge {
     #[prost(message, repeated, tag = "1")]
     pub all_seen_shares: ::prost::alloc::vec::Vec<CanisterHttpShare>,
+    #[prost(uint32, tag = "2")]
+    pub total_requests: u32,
+    #[prost(uint32, tag = "3")]
+    pub min_responses: u32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FlexibleCanisterHttpTooManyRequestErrors {

--- a/rs/types/types/src/batch/canister_http.rs
+++ b/rs/types/types/src/batch/canister_http.rs
@@ -46,6 +46,8 @@ pub enum FlexibleCanisterHttpError {
     ResponsesTooLarge {
         callback_id: CallbackId,
         all_seen_shares: Vec<CanisterHttpResponseShare>,
+        total_requests: u32,
+        min_responses: u32,
     },
     TooManyRequestErrors {
         callback_id: CallbackId,
@@ -116,12 +118,16 @@ impl CountBytes for FlexibleCanisterHttpError {
             Self::ResponsesTooLarge {
                 callback_id,
                 all_seen_shares,
+                total_requests,
+                min_responses,
             } => {
                 callback_id.count_bytes()
                     + all_seen_shares
                         .iter()
                         .map(|s| s.count_bytes())
                         .sum::<usize>()
+                    + std::mem::size_of_val(total_requests)
+                    + std::mem::size_of_val(min_responses)
             }
             Self::TooManyRequestErrors {
                 callback_id,
@@ -437,12 +443,17 @@ impl From<FlexibleCanisterHttpError> for pb::FlexibleCanisterHttpError {
                 ErrorDetails::Timeout(pb::FlexibleCanisterHttpTimeout {})
             }
             FlexibleCanisterHttpError::ResponsesTooLarge {
-                all_seen_shares, ..
+                all_seen_shares,
+                total_requests,
+                min_responses,
+                ..
             } => ErrorDetails::ResponsesTooLarge(pb::FlexibleCanisterHttpResponsesTooLarge {
                 all_seen_shares: all_seen_shares
                     .into_iter()
                     .map(pb::CanisterHttpShare::from)
                     .collect(),
+                total_requests,
+                min_responses,
             }),
             FlexibleCanisterHttpError::TooManyRequestErrors {
                 reject_responses, ..
@@ -479,6 +490,8 @@ impl TryFrom<pb::FlexibleCanisterHttpError> for FlexibleCanisterHttpError {
                 Ok(FlexibleCanisterHttpError::ResponsesTooLarge {
                     callback_id,
                     all_seen_shares,
+                    total_requests: details.total_requests,
+                    min_responses: details.min_responses,
                 })
             }
             Some(ErrorDetails::TooManyRequestErrors(details)) => {


### PR DESCRIPTION
### Summary

- Adds `total_requests` and `min_responses` fields to the `FlexibleCanisterHttpResponsesTooLarge` proto message and the corresponding `FlexibleCanisterHttpError::ResponsesTooLarge` Rust enum variant.
- Validates these fields in the payload validator, rejecting payloads where a block maker claims incorrect values.
- Extends the existing tests accordingly and adds two new ones for testing the validation logic

### Motivation
A follow-up change will deliver `ResponsesTooLarge` errors to execution as Candid-encoded `FlexibleHttpRequestResult::Err` values. The error message needs `total_requests` and `min_responses` to properly explain *why* the responses don't fit. Here is an example of the envisioned error message:
```
Responses too large: need at least 2 (= 3 min_responses - 1 unseen) OK responses to fit within 2097152 bytes, but even the smallest 2 of 3 OK responses have sizes [1200000, 1300000] bytes (3 ok + 1 reject + 1 unseen = 5 total_requests)
```
Without the new fields in the error, the delivery code would have to re-derive them from the HTTP request context at `into_messages` time, which it doesn't have access to.