### PR TITLE
feat: calibrate fetch_canister_logs fee and add benchmarks

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -12,7 +12,7 @@ const GIB: u64 = 1024 * MIB;
 const TIB: u64 = 1024 * GIB;
 
 // TODO(DSM-105): remove after the feature is enabled by default.
-pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = true; // TODO: revert to false before merging
+pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = false;
 pub const LOG_MEMORY_STORE_FEATURE: FlagStatus = if LOG_MEMORY_STORE_FEATURE_ENABLED {
     FlagStatus::Enabled
 } else {

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -12,7 +12,7 @@ const GIB: u64 = 1024 * MIB;
 const TIB: u64 = 1024 * GIB;
 
 // TODO(DSM-105): remove after the feature is enabled by default.
-pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = false;
+pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = true; // TODO: revert to false before merging
 pub const LOG_MEMORY_STORE_FEATURE: FlagStatus = if LOG_MEMORY_STORE_FEATURE_ENABLED {
     FlagStatus::Enabled
 } else {

--- a/rs/config/src/subnet_config.rs
+++ b/rs/config/src/subnet_config.rs
@@ -490,8 +490,8 @@ impl CyclesAccountManagerConfig {
             http_response_per_byte_fee: Cycles::new(800),
             max_storage_reservation_period: Duration::from_secs(300_000_000),
             default_reserved_balance_limit: DEFAULT_RESERVED_BALANCE_LIMIT,
-            fetch_canister_logs_base_fee: Cycles::new(1_000_000),
-            fetch_canister_logs_per_byte_fee: Cycles::new(800),
+            fetch_canister_logs_base_fee: Cycles::new(5_000_000),
+            fetch_canister_logs_per_byte_fee: Cycles::new(80),
         }
     }
 

--- a/rs/execution_environment/benches/management_canister/canister_logging.rs
+++ b/rs/execution_environment/benches/management_canister/canister_logging.rs
@@ -1,18 +1,121 @@
 use std::time::Duration;
 
 use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main};
-use ic_base_types::PrincipalId;
+use ic_base_types::{CanisterId, PrincipalId};
+use ic_config::execution_environment::{Config as ExecutionConfig, LOG_MEMORY_STORE_FEATURE};
+use ic_config::flag_status::FlagStatus;
+use ic_config::subnet_config::SubnetConfig;
 use ic_management_canister_types_private::{
-    CanisterInstallMode, CanisterSettingsArgsBuilder, LogVisibilityV2,
+    CanisterIdRecord, CanisterInstallMode, CanisterSettingsArgsBuilder, FetchCanisterLogsRequest,
+    LogVisibilityV2, Payload,
 };
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::system_state::log_memory_store::LogMemoryStore;
-use ic_state_machine_tests::StateMachineBuilder;
+use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
 use ic_test_utilities_execution_environment::{wat_canister, wat_fn};
 use ic_types_cycles::Cycles;
+use ic_universal_canister::{UNIVERSAL_CANISTER_WASM, call_args, wasm};
 
 const KIB: u64 = 1024;
 const MIB: u64 = 1024 * KIB;
+
+/// Creates a StateMachine with a canister whose log buffer is filled to capacity.
+fn setup_canister_with_full_log(
+    log_memory_limit: u64,
+    log_message_size: usize,
+) -> (StateMachine, CanisterId) {
+    let log_message = vec![b'a'; log_message_size];
+    let record_size = LogMemoryStore::estimate_record_size(log_message_size) as u64;
+    let records_to_fill = (log_memory_limit / record_size + 1) as u32;
+
+    let env = StateMachineBuilder::new()
+        .with_subnet_type(SubnetType::Application)
+        .with_checkpoints_enabled(false)
+        .build();
+    let settings = CanisterSettingsArgsBuilder::new()
+        .with_controllers(vec![PrincipalId::new_anonymous()])
+        .with_log_memory_limit(log_memory_limit)
+        .with_log_visibility(LogVisibilityV2::Public)
+        .build();
+    let canister_id =
+        env.create_canister_with_cycles(None, Cycles::new(u128::MAX / 2), Some(settings));
+    env.install_wasm_in_mode(
+        canister_id,
+        CanisterInstallMode::Install,
+        wat_canister()
+            .update(
+                "fill_logs",
+                wat_fn().repeat(records_to_fill, wat_fn().debug_print(&log_message)),
+            )
+            .build_wasm(),
+        vec![],
+    )
+    .unwrap();
+    let _ = env.execute_ingress(canister_id, "fill_logs", vec![]);
+    (env, canister_id)
+}
+
+/// Creates a StateMachine with two canisters:
+/// - `caller`: universal canister that will call fetch_canister_logs
+/// - `target`: canister with log buffer filled to capacity
+///
+/// Returns (env, caller, target).
+fn setup_fetch_bench(
+    log_memory_limit: u64,
+    log_message_size: usize,
+) -> (StateMachine, CanisterId, CanisterId) {
+    let log_message = vec![b'a'; log_message_size];
+    let record_size = LogMemoryStore::estimate_record_size(log_message_size) as u64;
+    let records_to_fill = (log_memory_limit / record_size + 1) as u32;
+
+    let subnet_type = SubnetType::Application;
+    let config = StateMachineConfig::new(
+        SubnetConfig::new(subnet_type),
+        ExecutionConfig {
+            replicated_inter_canister_log_fetch: FlagStatus::Enabled,
+            log_memory_store_feature: LOG_MEMORY_STORE_FEATURE,
+            ..Default::default()
+        },
+    );
+    let env = StateMachineBuilder::new()
+        .with_config(Some(config))
+        .with_subnet_type(subnet_type)
+        .with_checkpoints_enabled(false)
+        .build();
+
+    // Create the caller (universal canister).
+    let caller = env
+        .install_canister_with_cycles(
+            UNIVERSAL_CANISTER_WASM.to_vec(),
+            vec![],
+            None,
+            Cycles::new(u128::MAX / 2),
+        )
+        .unwrap();
+
+    // Create the target canister controlled by the caller.
+    let settings = CanisterSettingsArgsBuilder::new()
+        .with_controllers(vec![caller.get()])
+        .with_log_memory_limit(log_memory_limit)
+        .with_log_visibility(LogVisibilityV2::Controllers)
+        .build();
+    let target = env.create_canister_with_cycles(None, Cycles::new(u128::MAX / 2), Some(settings));
+    env.install_wasm_in_mode(
+        target,
+        CanisterInstallMode::Install,
+        wat_canister()
+            .update(
+                "fill_logs",
+                wat_fn().repeat(records_to_fill, wat_fn().debug_print(&log_message)),
+            )
+            .build_wasm(),
+        vec![],
+    )
+    .unwrap();
+    let _ = env.execute_ingress(target, "fill_logs", vec![]);
+
+    (env, caller, target)
+}
 
 fn run_bench_resize_canister_log<M: criterion::measurement::Measurement>(
     group: &mut BenchmarkGroup<M>,
@@ -20,47 +123,9 @@ fn run_bench_resize_canister_log<M: criterion::measurement::Measurement>(
     initial_log_memory_limit: u64,
     new_log_memory_limit: u64,
 ) {
-    // Empty messages maximize records per buffer — worst case for resize
-    // since each record is deserialized and re-encoded individually.
-    let log_message_size = 0;
-    let log_message = vec![b'a'; log_message_size];
-    let record_size = LogMemoryStore::estimate_record_size(log_message_size) as u64;
-    let records_to_fill = (initial_log_memory_limit / record_size + 1) as u32;
-
     group.bench_function(bench_name, |b| {
         b.iter_batched(
-            // Setup: create canister and fill its log store.
-            || {
-                let env = StateMachineBuilder::new()
-                    .with_subnet_type(SubnetType::Application)
-                    .with_checkpoints_enabled(false)
-                    .build();
-                let settings = CanisterSettingsArgsBuilder::new()
-                    .with_controllers(vec![PrincipalId::new_anonymous()])
-                    .with_log_memory_limit(initial_log_memory_limit)
-                    .with_log_visibility(LogVisibilityV2::Public)
-                    .build();
-                let canister_id = env.create_canister_with_cycles(
-                    None,
-                    Cycles::new(u128::MAX / 2),
-                    Some(settings),
-                );
-                env.install_wasm_in_mode(
-                    canister_id,
-                    CanisterInstallMode::Install,
-                    wat_canister()
-                        .update(
-                            "fill_logs",
-                            wat_fn().repeat(records_to_fill, wat_fn().debug_print(&log_message)),
-                        )
-                        .build_wasm(),
-                    vec![],
-                )
-                .unwrap();
-                let _ = env.execute_ingress(canister_id, "fill_logs", vec![]);
-                (env, canister_id)
-            },
-            // Measurement: resize the log memory store.
+            || setup_canister_with_full_log(initial_log_memory_limit, 0),
             |(env, canister_id)| {
                 let result = env.update_settings(
                     &canister_id,
@@ -75,27 +140,97 @@ fn run_bench_resize_canister_log<M: criterion::measurement::Measurement>(
     });
 }
 
-pub fn canister_logging_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("resize_canister_log");
-    group.sample_size(60);
-    group.warm_up_time(Duration::from_secs(1));
+fn run_bench_fetch_canister_log<M: criterion::measurement::Measurement>(
+    group: &mut BenchmarkGroup<M>,
+    bench_name: &str,
+    log_memory_limit: u64,
+    log_message_size: usize,
+) {
+    group.bench_function(bench_name, |b| {
+        b.iter_batched(
+            || setup_fetch_bench(log_memory_limit, log_message_size),
+            |(env, caller, target)| {
+                let result = env.execute_ingress(
+                    caller,
+                    "update",
+                    wasm()
+                        .call_with_cycles(
+                            CanisterId::ic_00(),
+                            "fetch_canister_logs",
+                            call_args().other_side(FetchCanisterLogsRequest::new(target).encode()),
+                            Cycles::new(5_000_000_000),
+                        )
+                        .build(),
+                );
+                assert!(result.is_ok());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+}
 
-    // Varying sizes to verify linear scaling of resize cost.
-    run_bench_resize_canister_log(
-        &mut group,
-        "from:256KiB/to:-1/msg:0B",
-        256 * KIB,
-        256 * KIB - 1,
-    );
-    run_bench_resize_canister_log(&mut group, "from:1MiB/to:-1/msg:0B", MIB, MIB - 1);
-    run_bench_resize_canister_log(&mut group, "from:2MiB/to:-1/msg:0B", 2 * MIB, 2 * MIB - 1);
-    // Resize up to confirm symmetric cost.
-    run_bench_resize_canister_log(
-        &mut group,
-        "from:2MiB-1/to:2MiB/msg:0B",
-        2 * MIB - 1,
-        2 * MIB,
-    );
+pub fn canister_logging_benchmark(c: &mut Criterion) {
+    {
+        let mut group = c.benchmark_group("resize_canister_log");
+        group.sample_size(60);
+        group.warm_up_time(Duration::from_secs(1));
+
+        // Varying sizes to verify linear scaling of resize cost.
+        run_bench_resize_canister_log(
+            &mut group,
+            "from:256KiB/to:-1/msg:0B",
+            256 * KIB,
+            256 * KIB - 1,
+        );
+        run_bench_resize_canister_log(&mut group, "from:1MiB/to:-1/msg:0B", MIB, MIB - 1);
+        run_bench_resize_canister_log(&mut group, "from:2MiB/to:-1/msg:0B", 2 * MIB, 2 * MIB - 1);
+        // Resize up to confirm symmetric cost.
+        run_bench_resize_canister_log(
+            &mut group,
+            "from:2MiB-1/to:2MiB/msg:0B",
+            2 * MIB - 1,
+            2 * MIB,
+        );
+    }
+
+    {
+        let mut group = c.benchmark_group("fetch_canister_log");
+        group.sample_size(60);
+        group.warm_up_time(Duration::from_secs(1));
+
+        // Baseline: inter-canister call to canister_status (same call overhead,
+        // no log reading). Subtract this from fetch results to isolate fetch cost.
+        group.bench_function("baseline", |b| {
+            b.iter_batched(
+                || setup_fetch_bench(128 * KIB, 0),
+                |(env, caller, target)| {
+                    let result = env.execute_ingress(
+                        caller,
+                        "update",
+                        wasm()
+                            .call_with_cycles(
+                                CanisterId::ic_00(),
+                                "canister_status",
+                                call_args().other_side(CanisterIdRecord::from(target).encode()),
+                                Cycles::new(0),
+                            )
+                            .build(),
+                    );
+                    assert!(result.is_ok());
+                },
+                BatchSize::LargeInput,
+            );
+        });
+
+        // Worst case: 0-byte messages maximize records per buffer.
+        run_bench_fetch_canister_log(&mut group, "fetch:128KiB/msg:0B", 128 * KIB, 0);
+        run_bench_fetch_canister_log(&mut group, "fetch:1MiB/msg:0B", MIB, 0);
+        run_bench_fetch_canister_log(&mut group, "fetch:2MiB/msg:0B", 2 * MIB, 0);
+        // Realistic: 100-byte messages.
+        run_bench_fetch_canister_log(&mut group, "fetch:128KiB/msg:100B", 128 * KIB, 100);
+        run_bench_fetch_canister_log(&mut group, "fetch:1MiB/msg:100B", MIB, 100);
+        run_bench_fetch_canister_log(&mut group, "fetch:2MiB/msg:100B", 2 * MIB, 100);
+    }
 }
 
 criterion_group!(benchmarks, canister_logging_benchmark);

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -2385,3 +2385,84 @@ fn test_canister_log_resize_no_extra_charge_feature_disabled() {
         baseline_cost
     );
 }
+
+#[test]
+fn test_fetch_canister_logs_update_call_rejected_insufficient_cycles() {
+    let user_controller = PrincipalId::new_user_test_id(42);
+    let env = setup_env();
+    let canister_a = create_and_install_canister(
+        &env,
+        CanisterSettingsArgsBuilder::new()
+            .with_controllers(vec![user_controller])
+            .build(),
+        UNIVERSAL_CANISTER_WASM.to_vec(),
+    );
+    let canister_b = create_and_install_canister(
+        &env,
+        CanisterSettingsArgsBuilder::new()
+            .with_log_visibility(LogVisibilityV2::Controllers)
+            .with_controllers(vec![canister_a.get()])
+            .build(),
+        wat_canister()
+            .update("test", wat_fn().debug_print(b"message"))
+            .build_wasm(),
+    );
+    let _ = env.execute_ingress(canister_b, "test", vec![]);
+
+    // Send with 1 cycle — far below the required max fee.
+    let result = fetch_canister_logs_intercanister(&env, canister_a, canister_b, Cycles::new(1));
+    let reject_message = get_reject(result);
+    assert!(
+        reject_message.contains("cycles are required"),
+        "Expected insufficient cycles error, got: {reject_message}"
+    );
+}
+
+#[test]
+fn test_fetch_canister_logs_update_call_deducts_cycles() {
+    let user_controller = PrincipalId::new_user_test_id(42);
+    let env = setup_env();
+    let canister_a = create_and_install_canister(
+        &env,
+        CanisterSettingsArgsBuilder::new()
+            .with_controllers(vec![user_controller])
+            .build(),
+        UNIVERSAL_CANISTER_WASM.to_vec(),
+    );
+    let canister_b = create_and_install_canister(
+        &env,
+        CanisterSettingsArgsBuilder::new()
+            .with_log_visibility(LogVisibilityV2::Controllers)
+            .with_controllers(vec![canister_a.get()])
+            .build(),
+        wat_canister()
+            .update("test", wat_fn().debug_print(b"message"))
+            .build_wasm(),
+    );
+    let _ = env.execute_ingress(canister_b, "test", vec![]);
+
+    let balance_before = env.cycle_balance(canister_a);
+
+    // Provide more than enough cycles for the fetch.
+    let cycles_sent = Cycles::new(5_000_000_000);
+    let records = fetch_log_records_intercanister(&env, canister_a, canister_b, cycles_sent);
+    assert_eq!(records.len(), 1);
+
+    let balance_after = env.cycle_balance(canister_a);
+    let cycles_spent = balance_before - balance_after;
+
+    // Some cycles must have been deducted (fetch fee + execution overhead).
+    assert!(
+        cycles_spent > 0,
+        "Expected some cycles to be spent, but balance is unchanged"
+    );
+    // The refund should have returned most of the overpayment.
+    // cycles_sent was 5B, and the actual fetch fee for a small response
+    // plus execution overhead should be well under 2B.
+    assert_lt!(
+        cycles_spent,
+        2_000_000_000,
+        "Expected most cycles to be refunded, but {} were spent",
+        cycles_spent
+    );
+}

--- a/rs/execution_environment/tests/subnet_size_test.rs
+++ b/rs/execution_environment/tests/subnet_size_test.rs
@@ -807,8 +807,8 @@ fn get_cycles_account_manager_config(subnet_type: SubnetType) -> CyclesAccountMa
                 max_storage_reservation_period: Duration::from_secs(0),
                 default_reserved_balance_limit: CyclesAccountManagerConfig::application_subnet()
                     .default_reserved_balance_limit,
-                fetch_canister_logs_base_fee: Cycles::new(1_000_000),
-                fetch_canister_logs_per_byte_fee: Cycles::new(800),
+                fetch_canister_logs_base_fee: Cycles::new(5_000_000),
+                fetch_canister_logs_per_byte_fee: Cycles::new(80),
             }
         }
     }

--- a/rs/execution_environment/tests/subnet_size_test.rs
+++ b/rs/execution_environment/tests/subnet_size_test.rs
@@ -738,6 +738,19 @@ fn trillion_cycles(value: f64) -> Cycles {
     Cycles::new((value * 1e12) as u128)
 }
 
+/// Returns a hand-copy of the fees defined in
+/// `CyclesAccountManagerConfig::{application,system}_subnet()` in
+/// `rs/config/src/subnet_config.rs`.
+///
+/// The duplication is intentional. These tests compute expected costs from the
+/// fee values returned here and compare them against the actual charges made by
+/// the replica. If someone changes a fee in `subnet_config.rs` without updating
+/// this mirror, the tests fail — which forces a conscious update of the copy
+/// and a review of the cycle-economics impact, since fee changes affect every
+/// canister on the IC.
+///
+/// Do not replace this with a direct call to `CyclesAccountManagerConfig::…`
+/// from `subnet_config.rs` — doing so would silently bless any fee change.
 fn get_cycles_account_manager_config(subnet_type: SubnetType) -> CyclesAccountManagerConfig {
     let ten_update_instructions_execution_fee_in_cycles = 10;
     const WASM64_INSTRUCTION_COST_MULTIPLIER: u128 = 2;


### PR DESCRIPTION
- Update `fetch_canister_logs` fee from placeholder values to calibrated.
- Add `fetch_canister_logs` benchmarks using inter-canister update calls with a baseline (`canister_status`) for isolating fetch cost.
- Add tests verifying fee rejection and cycle deduction.