### PR TITLE
feat: Bump max image sizes for new kernel

### DIFF
--- a/ic-os/hostos/envs/prod/BUILD.bazel
+++ b/ic-os/hostos/envs/prod/BUILD.bazel
@@ -17,13 +17,13 @@ icos_images = icos_build(
 file_size_check(
     name = "update_img_size_check",
     file = icos_images.update_image,
-    max_file_size = 950 * 1000 * 1000,  # 877 MB on 2026-01-29
+    max_file_size = 1050 * 1000 * 1000,  # 1000 MB on 2026-04-16
 )
 
 file_size_check(
     name = "disk_img_size_check",
     file = icos_images.disk_image,
-    max_file_size = 950 * 1000 * 1000,  # 880 MB on 2026-01-29
+    max_file_size = 1050 * 1000 * 1000,  # 1000 MB on 2026-04-16
 )
 
 # Export checksums & build artifacts

--- a/ic-os/setupos/envs/prod/BUILD.bazel
+++ b/ic-os/setupos/envs/prod/BUILD.bazel
@@ -18,7 +18,7 @@ icos_images = icos_build(
 file_size_check(
     name = "disk_img_size_check",
     file = icos_images.disk_image,
-    max_file_size = 2300 * 1000 * 1000,  # 2.21 GB on 2026-02-09
+    max_file_size = 2400 * 1000 * 1000,  # 2.37 GB on 2026-04-16
 )
 
 launch_bare_metal(


### PR DESCRIPTION
To build new base images with the freshly unpinned kernel, we need to increase the max image sizes.