### PR TITLE
feat(governance): enable Mission 70 voting rewards

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -223,7 +223,7 @@ thread_local! {
     //   4. Reduce the minimum dissolve delay needed to vote.
     //   5. 8 year gang 10% bonus.
     static ENABLE_MISSION_70_VOTING_REWARDS: Cell<bool>
-        = const { Cell::new(cfg!(feature = "test")) };
+        = const { Cell::new(true) };
 }
 
 thread_local! {

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -16,6 +16,9 @@ on the process that this file is part of, see
 * The minimum dissolve delay required to submit non-manage-neuron proposals is now
   a fixed 6 months, decoupled from the voting eligibility threshold which can be lower.
 * Mission 70 voting rewards adjustment has been re-calculated. Now: 63.29%. Before: 65.5%.
+* Enabled Mission 70 voting rewards. This activates: max dissolve delay capped at
+  2 years, voting rewards pool scaled by 0.6329, quadratic dissolve delay bonus,
+  reduced minimum dissolve delay to vote, and the 8 year gang 10% voting power bonus.
 
 ## Deprecated
 


### PR DESCRIPTION
`rs/nns/governance/src/lib.rs`: replace `Cell::new(cfg!(feature = "test"))` with `Cell::new(true)`.

Effects that turn on:
- Max neuron dissolve delay capped at 2 years, with existing neurons clamped (#9688)
- Voting rewards pool scaled by 0.6329 (#9698, later re-calculated)
- Quadratic dissolve delay bonus, replacing linear (#9719)
- Reduced minimum dissolve delay required to vote; vote/propose thresholds decoupled (#9689, #9880)
- 8 year gang 10% voting power bonus (#9687, #9896)
- Voting power snapshots cleared on activation (#9731)
