### PR TITLE
chore(proposal-cli): add word canister(s) to forum post title and description

### DIFF
--- a/rs/cross-chain/proposal-cli/src/forum/mod.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/mod.rs
@@ -187,11 +187,12 @@ impl ForumTopic {
                     aggregate_install_mode.to_string()
                 };
                 format!(
-                    "{} {} to {} the {}",
+                    "{} {} to {} the {} {}",
                     pluralize("Proposal", proposals.len()),
                     display_sequence(proposal_ids.as_slice()),
                     summary_install_mode,
                     display_sequence(canister_names.as_slice()),
+                    pluralize("canister", canister_names.len())
                 )
             }
         }
@@ -210,7 +211,7 @@ impl ForumTopic {
                 ));
                 for (proposal_id, summary) in proposals {
                     res.push(format!(
-                        "* Proposal [{}](https://dashboard.internetcomputer.org/proposal/{}): {} the {}",
+                        "* Proposal [{}](https://dashboard.internetcomputer.org/proposal/{}): {} the {} canister",
                         proposal_id, proposal_id, summary.install_mode, summary.canister
                     ))
                 }

--- a/rs/cross-chain/proposal-cli/src/forum/tests.rs
+++ b/rs/cross-chain/proposal-cli/src/forum/tests.rs
@@ -15,13 +15,13 @@ fn should_have_correct_content_when_creating_topic_for_multiple_proposals() {
     assert_eq!(
         request,
         CreateTopicRequest {
-            title: "Proposals (137359, 137360, 137361) to upgrade the (ckBTC index, ckBTC ledger, ckBTC archive)".to_string(),
+            title: "Proposals (137359, 137360, 137361) to upgrade the (ckBTC index, ckBTC ledger, ckBTC archive) canisters".to_string(),
             raw: "\
             Hi everyone :waving_hand:\n\n\
             Please use this forum thread to discuss the following proposals:\n\
-            * Proposal [137359](https://dashboard.internetcomputer.org/proposal/137359): upgrade the ckBTC index\n\
-            * Proposal [137360](https://dashboard.internetcomputer.org/proposal/137360): upgrade the ckBTC ledger\n\
-            * Proposal [137361](https://dashboard.internetcomputer.org/proposal/137361): upgrade the ckBTC archive\n\n\
+            * Proposal [137359](https://dashboard.internetcomputer.org/proposal/137359): upgrade the ckBTC index canister\n\
+            * Proposal [137360](https://dashboard.internetcomputer.org/proposal/137360): upgrade the ckBTC ledger canister\n\
+            * Proposal [137361](https://dashboard.internetcomputer.org/proposal/137361): upgrade the ckBTC archive canister\n\n\
             :information_source: All listed proposals should contain the necessary information to verify them.\
             ".to_string(),
             category:76,
@@ -39,11 +39,11 @@ fn should_have_correct_content_when_creating_topic_for_single_proposals() {
     assert_eq!(
         request,
         CreateTopicRequest {
-            title: "Proposal 137360 to upgrade the ckBTC ledger".to_string(),
+            title: "Proposal 137360 to upgrade the ckBTC ledger canister".to_string(),
             raw: "\
             Hi everyone :waving_hand:\n\n\
             Please use this forum thread to discuss the following proposal:\n\
-            * Proposal [137360](https://dashboard.internetcomputer.org/proposal/137360): upgrade the ckBTC ledger\n\n\
+            * Proposal [137360](https://dashboard.internetcomputer.org/proposal/137360): upgrade the ckBTC ledger canister\n\n\
             :information_source: All listed proposals should contain the necessary information to verify them.\
             ".to_string(),
             category: 76,


### PR DESCRIPTION
The word "canister(s)" is missing from the forum post title and description. See e.g. this [post](https://forum.dfinity.org/t/proposal-141435-to-upgrade-the-bitcoin/67525). This PR fixes this issue.