### PR TITLE
fix: SyncMessageRouting::expected_batch_height

### DIFF
--- a/rs/interfaces/state_manager/mocks/src/lib.rs
+++ b/rs/interfaces/state_manager/mocks/src/lib.rs
@@ -42,6 +42,8 @@ mock! {
     }
 
     impl StateManager for StateManager {
+        fn tip_height(&self) -> Height;
+
         fn take_tip(&self) -> (Height, ReplicatedState);
 
         fn take_tip_at(&self, h: Height) -> StateManagerResult<ReplicatedState>;

--- a/rs/interfaces/state_manager/src/lib.rs
+++ b/rs/interfaces/state_manager/src/lib.rs
@@ -282,6 +282,11 @@ pub trait StateManager: StateReader {
         batch_summary: Option<BatchSummary>,
     );
 
+    /// Returns the height of the latest [`StateManager::commit_and_certify`] call,
+    /// or of the latest state sync once the subsequent [`StateManager::take_tip`]
+    /// call has advanced the tip to the synced height.
+    fn tip_height(&self) -> Height;
+
     /// Returns the version of the state that can be modified in-place and the
     /// height of that state.
     ///

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -1881,6 +1881,9 @@ impl SyncMessageRouting {
     }
 
     pub fn expected_batch_height(&self) -> Height {
-        self.state_manager.latest_state_height().increment()
+        self.state_manager
+            .latest_state_height()
+            .increment()
+            .max(self.state_manager.tip_height().increment())
     }
 }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -1034,6 +1034,10 @@ impl StateManager for StateMachineStateManager {
         self.deref().commit_and_certify(state, scope, batch_summary)
     }
 
+    fn tip_height(&self) -> Height {
+        self.deref().tip_height()
+    }
+
     fn take_tip(&self) -> (Height, ReplicatedState) {
         self.deref().take_tip()
     }

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -950,6 +950,9 @@ pub struct StateManagerImpl {
     // requested quite often and this causes high contention on the lock.
     latest_state_height: Arc<AtomicU64>,
     latest_certified_height: AtomicU64,
+    // Cached tip height. We cache it separately because it's requested quite
+    // often and this causes high contention on the lock.
+    tip_height: AtomicU64,
     fast_forward_height: AtomicU64,
     persist_metadata_guard: Arc<Mutex<()>>,
     tip_channel: Sender<TipRequest>,
@@ -1513,6 +1516,7 @@ impl StateManagerImpl {
 
         let latest_state_height = AtomicU64::new(0);
         let latest_certified_height = AtomicU64::new(0);
+        let tip_height = AtomicU64::new(0);
         let fast_forward_height = AtomicU64::new(0);
 
         let initial_snapshot = Snapshot {
@@ -1524,6 +1528,7 @@ impl StateManagerImpl {
             Some((snapshot, checkpoint_layout)) => {
                 // Set latest state height in metadata to be last checkpoint height
                 latest_state_height.store(snapshot.height.get(), Ordering::Relaxed);
+                tip_height.store(snapshot.height.get(), Ordering::Relaxed);
                 let starting_time = Instant::now();
 
                 let tip = initialize_tip(&log, &tip_channel, snapshot, checkpoint_layout.clone());
@@ -1630,6 +1635,7 @@ impl StateManagerImpl {
             deallocator_thread,
             latest_state_height: Arc::new(latest_state_height),
             latest_certified_height,
+            tip_height,
             fast_forward_height,
             persist_metadata_guard,
             tip_channel,
@@ -2729,6 +2735,10 @@ impl StateManager for StateManagerImpl {
             .unwrap_or(Err(StateHashError::Transient(HashNotComputedYet(height))))
     }
 
+    fn tip_height(&self) -> Height {
+        Height::new(self.tip_height.load(Ordering::Relaxed))
+    }
+
     fn take_tip(&self) -> (Height, ReplicatedState) {
         let _timer = self
             .metrics
@@ -2822,6 +2832,8 @@ impl StateManager for StateManagerImpl {
             .clone();
 
         states.tip_height = target_snapshot.height;
+        self.tip_height
+            .store(target_snapshot.height.get(), Ordering::Relaxed);
         std::mem::drop(states);
 
         let mut new_tip = initialize_tip(
@@ -3382,6 +3394,7 @@ impl StateManager for StateManagerImpl {
             self.metrics.no_state_clone_count.inc();
 
             states.tip_height = height;
+            self.tip_height.store(height.get(), Ordering::Relaxed);
             states.tip = Some(state);
             return;
         }
@@ -3529,6 +3542,7 @@ impl StateManager for StateManagerImpl {
         // The next call to take_tip() will take care of updating the
         // tip if needed.
         states.tip_height = next_tip.0;
+        self.tip_height.store(next_tip.0.get(), Ordering::Relaxed);
         states.tip = Some(next_tip.1);
 
         if scope == CertificationScope::Full {

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -1528,7 +1528,6 @@ impl StateManagerImpl {
             Some((snapshot, checkpoint_layout)) => {
                 // Set latest state height in metadata to be last checkpoint height
                 latest_state_height.store(snapshot.height.get(), Ordering::Relaxed);
-                tip_height.store(snapshot.height.get(), Ordering::Relaxed);
                 let starting_time = Instant::now();
 
                 let tip = initialize_tip(&log, &tip_channel, snapshot, checkpoint_layout.clone());
@@ -1583,6 +1582,7 @@ impl StateManagerImpl {
             tip_height: tip_height_and_state.0,
             tip: Some(tip_height_and_state.1),
         }));
+        tip_height.store(tip_height_and_state.0.get(), Ordering::Relaxed);
 
         let persist_metadata_guard = Arc::new(Mutex::new(()));
 
@@ -2865,11 +2865,13 @@ impl StateManager for StateManagerImpl {
 
         if height < tip_height {
             states.tip_height = tip_height;
+            self.tip_height.store(tip_height.get(), Ordering::Relaxed);
             states.tip = Some(state);
             return Err(StateManagerError::StateRemoved(height));
         }
         if tip_height < height {
             states.tip_height = tip_height;
+            self.tip_height.store(tip_height.get(), Ordering::Relaxed);
             states.tip = Some(state);
             return Err(StateManagerError::StateNotCommittedYet(height));
         }

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -950,9 +950,6 @@ pub struct StateManagerImpl {
     // requested quite often and this causes high contention on the lock.
     latest_state_height: Arc<AtomicU64>,
     latest_certified_height: AtomicU64,
-    // Cached tip height. We cache it separately because it's requested quite
-    // often and this causes high contention on the lock.
-    tip_height: AtomicU64,
     fast_forward_height: AtomicU64,
     persist_metadata_guard: Arc<Mutex<()>>,
     tip_channel: Sender<TipRequest>,
@@ -1516,7 +1513,6 @@ impl StateManagerImpl {
 
         let latest_state_height = AtomicU64::new(0);
         let latest_certified_height = AtomicU64::new(0);
-        let tip_height = AtomicU64::new(0);
         let fast_forward_height = AtomicU64::new(0);
 
         let initial_snapshot = Snapshot {
@@ -1582,7 +1578,6 @@ impl StateManagerImpl {
             tip_height: tip_height_and_state.0,
             tip: Some(tip_height_and_state.1),
         }));
-        tip_height.store(tip_height_and_state.0.get(), Ordering::Relaxed);
 
         let persist_metadata_guard = Arc::new(Mutex::new(()));
 
@@ -1635,7 +1630,6 @@ impl StateManagerImpl {
             deallocator_thread,
             latest_state_height: Arc::new(latest_state_height),
             latest_certified_height,
-            tip_height,
             fast_forward_height,
             persist_metadata_guard,
             tip_channel,
@@ -2736,7 +2730,7 @@ impl StateManager for StateManagerImpl {
     }
 
     fn tip_height(&self) -> Height {
-        Height::new(self.tip_height.load(Ordering::Relaxed))
+        self.states.read().tip_height
     }
 
     fn take_tip(&self) -> (Height, ReplicatedState) {
@@ -2832,8 +2826,6 @@ impl StateManager for StateManagerImpl {
             .clone();
 
         states.tip_height = target_snapshot.height;
-        self.tip_height
-            .store(target_snapshot.height.get(), Ordering::Relaxed);
         std::mem::drop(states);
 
         let mut new_tip = initialize_tip(
@@ -2865,13 +2857,11 @@ impl StateManager for StateManagerImpl {
 
         if height < tip_height {
             states.tip_height = tip_height;
-            self.tip_height.store(tip_height.get(), Ordering::Relaxed);
             states.tip = Some(state);
             return Err(StateManagerError::StateRemoved(height));
         }
         if tip_height < height {
             states.tip_height = tip_height;
-            self.tip_height.store(tip_height.get(), Ordering::Relaxed);
             states.tip = Some(state);
             return Err(StateManagerError::StateNotCommittedYet(height));
         }
@@ -3396,7 +3386,6 @@ impl StateManager for StateManagerImpl {
             self.metrics.no_state_clone_count.inc();
 
             states.tip_height = height;
-            self.tip_height.store(height.get(), Ordering::Relaxed);
             states.tip = Some(state);
             return;
         }
@@ -3544,7 +3533,6 @@ impl StateManager for StateManagerImpl {
         // The next call to take_tip() will take care of updating the
         // tip if needed.
         states.tip_height = next_tip.0;
-        self.tip_height.store(next_tip.0.get(), Ordering::Relaxed);
         states.tip = Some(next_tip.1);
 
         if scope == CertificationScope::Full {

--- a/rs/test_utilities/src/state_manager.rs
+++ b/rs/test_utilities/src/state_manager.rs
@@ -121,6 +121,10 @@ fn initial_state() -> Labeled<Arc<ReplicatedState>> {
 }
 
 impl StateManager for FakeStateManager {
+    fn tip_height(&self) -> Height {
+        self.tip_height()
+    }
+
     fn take_tip(&self) -> (Height, Self::State) {
         (
             self.tip_height(),
@@ -692,6 +696,10 @@ impl RefMockStateManager {
 }
 
 impl StateManager for RefMockStateManager {
+    fn tip_height(&self) -> Height {
+        self.mock.read().unwrap().tip_height()
+    }
+
     fn take_tip(&self) -> (Height, Self::State) {
         self.mock.read().unwrap().take_tip()
     }


### PR DESCRIPTION
Fix `SyncMessageRouting::expected_batch_height` by considering the `tip_height` (which is now additionally exposed via `trait StateManager`) since `tip_height` can be ahead of `latest_state_height` if the fast-forward mode in `commit_and_certify` triggers or due to async hashing in a follow-up PR.