### PR TITLE
chore: replace CanisterSnapshotNotEnoughCycles by NotEnoughCycles

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2005,7 +2005,7 @@ impl CanisterManager {
                 cost_schedule,
                 reveal_top_up,
             )
-            .map_err(CanisterManagerError::CanisterSnapshotNotEnoughCycles)?;
+            .map_err(CanisterManagerError::NotEnoughCycles)?;
 
         // Check that storage reservation cycles can be reserved.
         let new_storage_reservation_cycles =
@@ -2394,7 +2394,7 @@ impl CanisterManager {
         ) {
             Ok(cycles) => cycles,
             Err(err) => {
-                return Err(CanisterManagerError::CanisterSnapshotNotEnoughCycles(err));
+                return Err(CanisterManagerError::NotEnoughCycles(err));
             }
         };
 
@@ -2787,7 +2787,7 @@ impl CanisterManager {
                 subnet_size,
                 cost_schedule,
             )
-            .map_err(CanisterManagerError::CanisterSnapshotNotEnoughCycles)?;
+            .map_err(CanisterManagerError::NotEnoughCycles)?;
         let cost = self.cycles_account_manager.management_canister_cost(
             num_instructions,
             subnet_size,
@@ -3024,7 +3024,7 @@ impl CanisterManager {
                 subnet_size,
                 cost_schedule,
             )
-            .map_err(CanisterManagerError::CanisterSnapshotNotEnoughCycles)?;
+            .map_err(CanisterManagerError::NotEnoughCycles)?;
         let cost = self.cycles_account_manager.management_canister_cost(
             instructions,
             subnet_size,

--- a/rs/execution_environment/src/canister_manager/types.rs
+++ b/rs/execution_environment/src/canister_manager/types.rs
@@ -449,7 +449,7 @@ pub(crate) enum CanisterManagerError {
         canister_id: CanisterId,
         limit: usize,
     },
-    CanisterSnapshotNotEnoughCycles(CanisterOutOfCyclesError),
+    NotEnoughCycles(CanisterOutOfCyclesError),
     CanisterSnapshotImmutable,
     CanisterSnapshotInconsistent {
         message: String,
@@ -678,9 +678,9 @@ impl AsErrorHelp for CanisterManagerError {
                 suggestion: "Consider deleting an unnecessary snapshot of the specified canister before creating a new one.".to_string(),
                 doc_link: "canister-snapshot-limit-exceeded".to_string(),
             },
-            CanisterManagerError::CanisterSnapshotNotEnoughCycles { .. } => ErrorHelp::UserError {
+            CanisterManagerError::NotEnoughCycles { .. } => ErrorHelp::UserError {
                 suggestion: "Try sending more cycles with the request.".to_string(),
-                doc_link: "canister-snapshot-not-enough-cycles".to_string(),
+                doc_link: "not-enough-cycles".to_string(),
             },
             CanisterManagerError::CanisterSnapshotImmutable => ErrorHelp::UserError {
                 suggestion: "Only canister snapshots created by metadata upload can be mutated.".to_string(),
@@ -1080,9 +1080,9 @@ impl From<CanisterManagerError> for UserError {
                     "Canister {canister_id} has reached the maximum number of snapshots allowed: {limit}.{additional_help}",
                 ),
             ),
-            CanisterSnapshotNotEnoughCycles(err) => Self::new(
+            NotEnoughCycles(err) => Self::new(
                 ErrorCode::CanisterOutOfCycles,
-                format!("Canister snapshotting failed with: `{err}`{additional_help}"),
+                format!("Canister management operation failed with: `{err}`{additional_help}"),
             ),
             CanisterSnapshotImmutable => Self::new(
                 ErrorCode::CanisterSnapshotImmutable,


### PR DESCRIPTION
This PR replaces the `CanisterSnapshotNotEnoughCycles` variant of `CanisterManagerError` by `NotEnoughCycles` since that variant is used in the generic `cycles_and_memory_usage_checks_and_updates` and thus it should not be specific to canister snapshots.