### PR TITLE
feat(governance): Enable Mission 70 voting rewards changes.

### DIFF
--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -223,7 +223,7 @@ thread_local! {
     //   4. Reduce the minimum dissolve delay needed to vote.
     //   5. 8 year gang 10% bonus.
     static ENABLE_MISSION_70_VOTING_REWARDS: Cell<bool>
-        = const { Cell::new(cfg!(feature = "test")) };
+        = const { Cell::new(true) };
 }
 
 thread_local! {

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -218,9 +218,9 @@ thread_local! {
 
     // The planned effects of enabling this flag include
     //   1. Reduce max dissolve delay from 8 years to 2 years. This includes capping existing neurons via data migration.
-    //   2. Reduce voting rewards pool by approximately 36.5% (equivalently, scale by 0.635 times).
-    //   3. Quadratic dissolve delay bonus (instead of linear).
-    //   4. Reduce the minimum dissolve delay needed to vote.
+    //   2. Reduce voting rewards pool by approximately 36.71% (equivalently, scale by 0.6329 times).
+    //   3. Dissolve delay bonus: quadratic instead of linear, with a maximum of 3x instead of 2x.
+    //   4. Reduce the minimum dissolve delay needed to vote to 2 weeks instead of 6 months.
     //   5. 8 year gang 10% bonus.
     static ENABLE_MISSION_70_VOTING_REWARDS: Cell<bool>
         = const { Cell::new(true) };

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -15,7 +15,13 @@ on the process that this file is part of, see
 
 * The minimum dissolve delay required to submit non-manage-neuron proposals is now
   a fixed 6 months, decoupled from the voting eligibility threshold which can be lower.
-* Mission 70 voting rewards adjustment has been re-calculated. Now: 63.29%. Before: 65.5%.
+
+* Enable Mission 70 voting rewards changes. This includes the following:
+  1. Reduce max dissolve delay from 8 years to 2 years. This includes capping existing neurons via data migration.
+  2. Reduce voting rewards pool by approximately 36.71% (equivalently, scale by 0.6329 times).
+  3. Dissolve delay bonus: quadratic instead of linear, with a maximum of 3x instead of 2x.
+  4. Reduce the minimum dissolve delay needed to vote to 2 weeks instead of 6 months.
+  5. 8 year gang 10% bonus.
 
 ## Deprecated
 


### PR DESCRIPTION
1. Reduce max dissolve delay from 8 years to 2 years. This includes capping existing neurons via data migration.
2. Reduce voting rewards pool by approximately 36.71% (equivalently, scale by 0.6329 times).
3. Dissolve delay bonus: quadratic instead of linear, with a maximum of 3x instead of 2x.
4. Reduce the minimum dissolve delay needed to vote to 2 weeks instead of 6 months.
5. 8 year gang 10% bonus.