### PR TITLE
test: restructure canister logging metrics tests

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -12,7 +12,7 @@ const GIB: u64 = 1024 * MIB;
 const TIB: u64 = 1024 * GIB;
 
 // TODO(DSM-105): remove after the feature is enabled by default.
-pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = true; // TODO: do not submit!
+pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = false;
 pub const LOG_MEMORY_STORE_FEATURE: FlagStatus = if LOG_MEMORY_STORE_FEATURE_ENABLED {
     FlagStatus::Enabled
 } else {

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -12,7 +12,7 @@ const GIB: u64 = 1024 * MIB;
 const TIB: u64 = 1024 * GIB;
 
 // TODO(DSM-105): remove after the feature is enabled by default.
-pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = false;
+pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = true; // TODO: do not submit!
 pub const LOG_MEMORY_STORE_FEATURE: FlagStatus = if LOG_MEMORY_STORE_FEATURE_ENABLED {
     FlagStatus::Enabled
 } else {

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -279,24 +279,24 @@ fn test_fetch_canister_logs_via_query_call() {
 }
 
 #[test]
-fn test_metrics_for_fetch_canister_logs_via_query_call() {
-    fn fetch_canister_logs_count(env: &StateMachine) -> u64 {
-        fetch_histogram_vec_stats(
-            env.metrics_registry(),
-            "execution_subnet_query_message_duration_seconds",
-        )
-        .get(&labels(&[
-            ("method_name", "query_ic00_fetch_canister_logs"),
-            ("status", "success"),
-        ]))
-        .map_or(0, |stats| stats.count)
+fn test_metric_fetch_canister_logs_via_query_call() {
+    // Query calls to `fetch_canister_logs` are captured by the subnet query
+    // message duration histogram with `method_name="query_ic00_fetch_canister_logs"`.
+    const METRIC: &str = "execution_subnet_query_message_duration_seconds";
+    fn count(env: &StateMachine) -> u64 {
+        fetch_histogram_vec_stats(env.metrics_registry(), METRIC)
+            .get(&labels(&[
+                ("method_name", "query_ic00_fetch_canister_logs"),
+                ("status", "success"),
+            ]))
+            .map_or(0, |s| s.count)
     }
     let user_controller = PrincipalId::new_user_test_id(42);
     let (env, canister_id) = setup_with_controller(user_controller, wat_canister().build_wasm());
 
-    assert_eq!(fetch_canister_logs_count(&env), 0);
+    assert_eq!(count(&env), 0);
     let _ = fetch_canister_logs_query(&env, user_controller, canister_id);
-    assert_eq!(fetch_canister_logs_count(&env), 1);
+    assert_eq!(count(&env), 1);
 }
 
 #[test]
@@ -1695,52 +1695,144 @@ fn test_logging_of_long_running_dts_over_checkpoint() {
     );
 }
 
+const METRIC_BYTES_OVERHEAD_FACTOR: f64 = 1.05;
+const METRIC_PAYLOAD_SIZE: usize = 1_000;
+
 #[test]
-fn test_canister_log_memory_usage_bytes_old() {
+fn test_metric_canister_log_memory_usage_bytes_from_canister_log() {
+    // When the log memory store feature is disabled, the metric tracks
+    // `CanisterLog.bytes_used()`, which grows with each debug_print.
     if LOG_MEMORY_STORE_FEATURE_ENABLED {
         return;
     }
-    let metric = "canister_log_memory_usage_bytes_v3";
-    const PAYLOAD_SIZE: usize = 1_000;
+    const METRIC: &str = "canister_log_memory_usage_bytes_v3";
     let env = setup_env();
     let canister_id = create_and_install_canister(
         &env,
         CanisterSettingsArgsBuilder::new().build(),
         wat_canister()
-            .update("test", wat_fn().debug_print(&[37; PAYLOAD_SIZE]))
+            .update("test", wat_fn().debug_print(&[37; METRIC_PAYLOAD_SIZE]))
             .build_wasm(),
     );
-    // Assert canister log size metric is zero initially.
-    let stats = fetch_histogram_stats(env.metrics_registry(), metric).unwrap();
+
+    // Nothing logged yet — sum is zero.
+    let stats = fetch_histogram_stats(env.metrics_registry(), METRIC).unwrap();
     assert_eq!(stats.sum, 0.0);
 
-    // Add log message.
+    // One debug_print — sum reflects the payload plus small record metadata.
     let _ = env.execute_ingress(canister_id, "test", vec![]);
-
-    // Assert canister log size metric is within the expected range.
-    let stats = fetch_histogram_stats(env.metrics_registry(), metric).unwrap();
-    assert_le!(PAYLOAD_SIZE as f64, stats.sum);
-    assert_le!(stats.sum, 1.05 * (PAYLOAD_SIZE as f64));
+    let stats = fetch_histogram_stats(env.metrics_registry(), METRIC).unwrap();
+    assert_le!(METRIC_PAYLOAD_SIZE as f64, stats.sum);
+    assert_le!(
+        stats.sum,
+        METRIC_BYTES_OVERHEAD_FACTOR * METRIC_PAYLOAD_SIZE as f64
+    );
 }
 
 #[test]
-fn test_canister_log_memory_usage_bytes_new() {
+fn test_metric_canister_log_memory_usage_bytes_from_log_memory_store() {
+    // When the log memory store feature is enabled, the metric tracks
+    // `LogMemoryStore.memory_usage()` — the allocated capacity of the store.
+    // It is set at canister creation from the default limit and stays stable
+    // under debug_print; only a `log_memory_limit` resize changes it.
     if !LOG_MEMORY_STORE_FEATURE_ENABLED {
         return;
     }
-    // Test canister logging metrics record the size of the log.
-    let metric = "canister_log_memory_usage_bytes_v3";
+    const METRIC: &str = "canister_log_memory_usage_bytes_v3";
     let env = setup_env();
-    let _canister_id = create_and_install_canister(
+    let canister_id = create_and_install_canister(
         &env,
         CanisterSettingsArgsBuilder::new().build(),
+        wat_canister()
+            .update("test", wat_fn().debug_print(&[37; METRIC_PAYLOAD_SIZE]))
+            .build_wasm(),
+    );
+
+    // Every per-round observation equals the default allocated store size.
+    let before = fetch_histogram_stats(env.metrics_registry(), METRIC).unwrap();
+    assert_eq!(
+        before.sum as u64 / before.count,
+        TEST_DEFAULT_LOG_MEMORY_USAGE
+    );
+
+    // After a debug_print: allocation unchanged; new observations carry the
+    // same value, so the per-observation average remains the default.
+    let _ = env.execute_ingress(canister_id, "test", vec![]);
+    let after = fetch_histogram_stats(env.metrics_registry(), METRIC).unwrap();
+    assert_gt!(after.count, before.count);
+    assert_eq!(
+        after.sum as u64 / after.count,
+        TEST_DEFAULT_LOG_MEMORY_USAGE
+    );
+}
+
+#[test]
+fn test_metric_canister_log_delta_memory_usage_bytes() {
+    // Recorded by the scheduler at round finalization for every canister that
+    // produced delta log records that round. One debug_print in one round
+    // yields exactly one additional sample.
+    const METRIC: &str = "canister_log_delta_memory_usage_bytes";
+    let env = setup_env();
+    let canister_id = create_and_install_canister(
+        &env,
+        CanisterSettingsArgsBuilder::new().build(),
+        wat_canister()
+            .update("test", wat_fn().debug_print(&[37; METRIC_PAYLOAD_SIZE]))
+            .build_wasm(),
+    );
+    let before = fetch_histogram_stats(env.metrics_registry(), METRIC).unwrap();
+
+    let _ = env.execute_ingress(canister_id, "test", vec![]);
+
+    let after = fetch_histogram_stats(env.metrics_registry(), METRIC).unwrap();
+    assert_eq!(after.count, before.count + 1);
+    let delta_sum = after.sum - before.sum;
+    assert_le!(METRIC_PAYLOAD_SIZE as f64, delta_sum);
+    assert_le!(
+        delta_sum,
+        METRIC_BYTES_OVERHEAD_FACTOR * METRIC_PAYLOAD_SIZE as f64
+    );
+}
+
+#[test]
+fn test_metric_fetch_canister_logs_via_update_call() {
+    // Inter-canister update calls to `fetch_canister_logs` are captured by the
+    // general subnet-message duration histogram with
+    // `method_name="ic00_fetch_canister_logs"`.
+    const METRIC: &str = "execution_subnet_message_duration_seconds";
+    fn count(env: &StateMachine) -> u64 {
+        fetch_histogram_vec_stats(env.metrics_registry(), METRIC)
+            .get(&labels(&[
+                ("method_name", "ic00_fetch_canister_logs"),
+                ("outcome", "finished"),
+                ("status", "success"),
+                ("speed", "fast"),
+            ]))
+            .map_or(0, |s| s.count)
+    }
+    // canister_a is a universal canister controlled by the user; it makes the
+    // inter-canister call. canister_b is controlled by canister_a and its
+    // logs are fetched.
+    let user_controller = PrincipalId::new_user_test_id(42);
+    let (env, canister_a) =
+        setup_with_controller(user_controller, UNIVERSAL_CANISTER_WASM.to_vec());
+    let canister_b = create_and_install_canister(
+        &env,
+        CanisterSettingsArgsBuilder::new()
+            .with_log_visibility(LogVisibilityV2::Controllers)
+            .with_controllers(vec![canister_a.get()])
+            .build(),
         wat_canister().build_wasm(),
     );
 
-    // Assert canister log size metric is equal to the default log memory usage.
-    let stats = fetch_histogram_stats(env.metrics_registry(), metric).unwrap();
-    let average_memory_usage = stats.sum as u64 / stats.count;
-    assert_eq!(average_memory_usage, TEST_DEFAULT_LOG_MEMORY_USAGE);
+    assert_eq!(count(&env), 0);
+    let _ = fetch_canister_logs_intercanister(
+        &env,
+        canister_a,
+        canister_b,
+        Cycles::new(50_000_000_000),
+    );
+    assert_eq!(count(&env), 1);
 }
 
 #[test]


### PR DESCRIPTION
- Rename the two memory-usage tests after which backing store they exercise (`CanisterLog` vs `LogMemoryStore`) and give them symmetric before/after coverage around a single `debug_print`. 
- Rename the query-path fetch test to match. 
- Add regression tests for two metrics that had no coverage: 
  - `canister_log_delta_memory_usage_bytes` (observed at round finalization)
  - `execution_subnet_message_duration_seconds` (update-path fetch)

