### PR TITLE
feat(flexible-outcalls): CON-1714 deliver flexible errors to execution

### DIFF
--- a/rs/consensus/src/consensus/metrics.rs
+++ b/rs/consensus/src/consensus/metrics.rs
@@ -181,6 +181,7 @@ pub(crate) struct FinalizerMetrics {
     pub canister_http_timeouts_delivered: IntCounter,
     pub canister_http_divergences_delivered: IntCounter,
     pub canister_http_flexible_candid_failures: IntCounter,
+    pub canister_http_flexible_errors_delivered: IntCounter,
     pub canister_http_payload_bytes_delivered: Histogram,
 }
 
@@ -281,6 +282,10 @@ impl FinalizerMetrics {
                 "canister_http_flexible_candid_failures",
                 "Total number of flexible canister http responses skipped due to candid encoding/decoding failures",
             ),
+            canister_http_flexible_errors_delivered: metrics_registry.int_counter(
+                "canister_http_flexible_errors_delivered",
+                "Total number of flexible canister http errors delivered",
+            ),
             canister_http_payload_bytes_delivered: metrics_registry.histogram(
                 "canister_http_payload_bytes_delivered",
                 "Total number of bytes in the canister http payload",
@@ -316,11 +321,17 @@ impl FinalizerMetrics {
             .inc_by(batch_stats.canister_http.timeouts as u64);
         self.canister_http_divergences_delivered
             .inc_by(batch_stats.canister_http.divergence_responses as u64);
-        self.canister_http_flexible_candid_failures.inc_by(
-            batch_stats
-                .canister_http
-                .flexible_ok_responses_candid_failures as u64,
-        );
+
+        let flexible_ok_candid_failures = batch_stats
+            .canister_http
+            .flexible_ok_responses_candid_failures as u64;
+        let flexible_error_candid_failures =
+            batch_stats.canister_http.flexible_errors_candid_failures as u64;
+        self.canister_http_flexible_candid_failures
+            .inc_by(flexible_ok_candid_failures + flexible_error_candid_failures);
+
+        self.canister_http_flexible_errors_delivered
+            .inc_by(batch_stats.canister_http.flexible_errors as u64);
         self.canister_http_payload_bytes_delivered
             .observe(batch_stats.canister_http.payload_bytes as f64);
 

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -1120,12 +1120,19 @@ fn flexible_error_into_consensus_response(
                 })
                 .collect();
 
-            let relevant_ok_sizes: Vec<_> = all_seen_shares
+            let mut ok_sizes: Vec<_> = all_seen_shares
                 .iter()
                 .filter(|s| !s.content.is_reject)
-                .take(min_known_ok_needed as usize)
-                .map(|share| share.content.content_size.to_string())
+                .map(|share| share.content.content_size)
                 .collect();
+            // Sort defensively, as validator doesn't enforce ordering on `all_seen_shares`
+            ok_sizes.sort_unstable();
+            let relevant_ok_sizes: Vec<_> = ok_sizes
+                .iter()
+                .take(min_known_ok_needed as usize)
+                .map(|size| size.to_string())
+                .collect();
+
             let message = format!(
                 "Responses too large: need at least {min_known_ok_needed} \
                  (= {min_responses} min_responses - {num_unseen} unseen) \

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -1134,10 +1134,10 @@ fn flexible_error_into_consensus_response(
                 .collect();
 
             let message = format!(
-                "Responses too large: need at least {min_known_ok_needed} \
-                 (= {min_responses} min_responses - {num_unseen} unseen) \
+                "Responses too large: need at least {min_responses} \
                  OK responses to fit within {MAX_CANISTER_HTTP_PAYLOAD_SIZE} bytes, \
-                 but even the smallest {min_known_ok_needed} of {num_ok} \
+                 but even the smallest {min_known_ok_needed} \
+                 (= {min_responses} min_responses - {num_unseen} unseen) of {num_ok} \
                  OK responses have sizes [{}] bytes \
                  ({num_ok} ok + {num_reject} reject + {num_unseen} unseen = {total_requests} total_requests)",
                 relevant_ok_sizes.join(", "),

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -31,7 +31,9 @@ use ic_interfaces_registry::RegistryClient;
 use ic_interfaces_state_manager::StateReader;
 use ic_logger::{ReplicaLogger, warn};
 use ic_management_canister_types_private::{
-    CanisterHttpResponsePayload, FlexibleHttpRequestResult,
+    CanisterHttpResponsePayload, FlexibleHttpGlobalError, FlexibleHttpNodeDetail,
+    FlexibleHttpNodeError, FlexibleHttpRequestErr, FlexibleHttpRequestResult,
+    HttpRequestResourceReport,
 };
 use ic_metrics::MetricsRegistry;
 use ic_registry_client_helpers::subnet::SubnetRegistry;
@@ -77,6 +79,8 @@ pub struct CanisterHttpBatchStats {
     pub single_signature_responses: usize,
     pub flexible_ok_responses: usize,
     pub flexible_ok_responses_candid_failures: usize,
+    pub flexible_errors: usize,
+    pub flexible_errors_candid_failures: usize,
     pub payload_bytes: usize,
 }
 
@@ -976,10 +980,21 @@ impl IntoMessages<(Vec<ConsensusResponse>, CanisterHttpBatchStats)>
             })
             .flatten();
 
+        let flexible_errors = messages
+            .flexible_errors
+            .into_iter()
+            .map(flexible_error_into_consensus_response)
+            .inspect(|result| match result {
+                Some(_) => stats.flexible_errors += 1,
+                None => stats.flexible_errors_candid_failures += 1,
+            })
+            .flatten();
+
         let responses = responses
             .chain(timeouts)
             .chain(divergence_responses)
             .chain(flexible_ok_responses)
+            .chain(flexible_errors)
             .collect();
 
         (responses, stats)
@@ -1016,6 +1031,124 @@ fn flexible_ok_responses_into_consensus_response(
         response_group.callback_id,
         Payload::Data(bytes),
     ))
+}
+
+/// Converts a [`FlexibleCanisterHttpError`] into a [`ConsensusResponse`]
+/// carrying a Candid-encoded [`FlexibleHttpRequestResult::Err`].
+///
+/// Returns `None` if Candid encoding fails (should never happen).
+fn flexible_error_into_consensus_response(
+    error: FlexibleCanisterHttpError,
+) -> Option<ConsensusResponse> {
+    let callback_id = error.callback_id();
+
+    let (global_error, node_details, message) = match error {
+        FlexibleCanisterHttpError::Timeout { .. } => (
+            FlexibleHttpGlobalError::Timeout(candid::Reserved),
+            vec![],
+            "Flexible HTTP request timed out".to_string(),
+        ),
+        FlexibleCanisterHttpError::TooManyRequestErrors {
+            reject_responses, ..
+        } => {
+            let message = format!(
+                "Too many request errors: {} responses are rejects",
+                reject_responses.len(),
+            );
+            let node_details: Vec<_> = reject_responses
+                .into_iter()
+                .filter_map(|reject_response| {
+                    match reject_response.response.content {
+                        CanisterHttpResponseContent::Reject(reject) => {
+                            Some(FlexibleHttpNodeDetail {
+                                node_id: candid::Principal::from(
+                                    reject_response.proof.signature.signer.get(),
+                                ),
+                                report: HttpRequestResourceReport::default(),
+                                error: Some(FlexibleHttpNodeError {
+                                    code: format!("{:?}", reject.reject_code),
+                                    message: reject.message,
+                                }),
+                            })
+                        }
+                        CanisterHttpResponseContent::Success(_) => {
+                            // Unreachable: payload building/validation ensure
+                            // that there are no oks in the reject-responses.
+                            None
+                        }
+                    }
+                })
+                .collect();
+            (
+                FlexibleHttpGlobalError::TooManyRequestErrors(candid::Reserved),
+                node_details,
+                message,
+            )
+        }
+        FlexibleCanisterHttpError::ResponsesTooLarge {
+            all_seen_shares,
+            total_requests,
+            min_responses,
+            ..
+        } => {
+            let num_ok = all_seen_shares
+                .iter()
+                .filter(|s| !s.content.is_reject)
+                .count() as u32;
+            let num_reject = all_seen_shares.len() as u32 - num_ok;
+            let num_unseen = total_requests.saturating_sub(all_seen_shares.len() as u32);
+            let min_known_ok_needed = min_responses.saturating_sub(num_unseen);
+
+            let node_details: Vec<_> = all_seen_shares
+                .iter()
+                .map(|share| {
+                    let code = if share.content.is_reject {
+                        "reject"
+                    } else {
+                        "ok"
+                    };
+                    FlexibleHttpNodeDetail {
+                        node_id: candid::Principal::from(share.signature.signer.get()),
+                        report: HttpRequestResourceReport::default(),
+                        error: Some(FlexibleHttpNodeError {
+                            code: code.to_string(),
+                            message: format!("{} bytes", share.content.content_size),
+                        }),
+                    }
+                })
+                .collect();
+
+            let relevant_ok_sizes: Vec<_> = all_seen_shares
+                .iter()
+                .filter(|s| !s.content.is_reject)
+                .take(min_known_ok_needed as usize)
+                .map(|share| share.content.content_size.to_string())
+                .collect();
+            let message = format!(
+                "Responses too large: need at least {min_known_ok_needed} \
+                 (= {min_responses} min_responses - {num_unseen} unseen) \
+                 OK responses to fit within {MAX_CANISTER_HTTP_PAYLOAD_SIZE} bytes, \
+                 but even the smallest {min_known_ok_needed} of {num_ok} \
+                 OK responses have sizes [{}] bytes \
+                 ({num_ok} ok + {num_reject} reject + {num_unseen} unseen = {total_requests} total_requests)",
+                relevant_ok_sizes.join(", "),
+            );
+            (
+                FlexibleHttpGlobalError::ResponsesTooLarge(candid::Reserved),
+                node_details,
+                message,
+            )
+        }
+    };
+
+    let err = FlexibleHttpRequestErr {
+        global_error: Some(global_error),
+        node_details,
+        message,
+    };
+    let bytes = Encode!(&FlexibleHttpRequestResult::Err(err)).ok()?;
+
+    Some(ConsensusResponse::new(callback_id, Payload::Data(bytes)))
 }
 
 /// Turns a [`CanisterHttpResponseDivergence`] into a [`ConsensusResponse`] containing a rejection.

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -1042,12 +1042,12 @@ fn flexible_error_into_consensus_response(
 ) -> Option<ConsensusResponse> {
     let callback_id = error.callback_id();
 
-    let (global_error, node_details, message) = match error {
-        FlexibleCanisterHttpError::Timeout { .. } => (
-            FlexibleHttpGlobalError::Timeout(candid::Reserved),
-            vec![],
-            "Flexible HTTP request timed out".to_string(),
-        ),
+    let err = match error {
+        FlexibleCanisterHttpError::Timeout { .. } => FlexibleHttpRequestErr {
+            global_error: Some(FlexibleHttpGlobalError::Timeout(candid::Reserved)),
+            node_details: vec![],
+            message: "Flexible HTTP request timed out".to_string(),
+        },
         FlexibleCanisterHttpError::TooManyRequestErrors {
             reject_responses, ..
         } => {
@@ -1079,11 +1079,13 @@ fn flexible_error_into_consensus_response(
                     }
                 })
                 .collect();
-            (
-                FlexibleHttpGlobalError::TooManyRequestErrors(candid::Reserved),
+            FlexibleHttpRequestErr {
+                global_error: Some(FlexibleHttpGlobalError::TooManyRequestErrors(
+                    candid::Reserved,
+                )),
                 node_details,
                 message,
-            )
+            }
         }
         FlexibleCanisterHttpError::ResponsesTooLarge {
             all_seen_shares,
@@ -1133,19 +1135,14 @@ fn flexible_error_into_consensus_response(
                  ({num_ok} ok + {num_reject} reject + {num_unseen} unseen = {total_requests} total_requests)",
                 relevant_ok_sizes.join(", "),
             );
-            (
-                FlexibleHttpGlobalError::ResponsesTooLarge(candid::Reserved),
+            FlexibleHttpRequestErr {
+                global_error: Some(FlexibleHttpGlobalError::ResponsesTooLarge(candid::Reserved)),
                 node_details,
                 message,
-            )
+            }
         }
     };
 
-    let err = FlexibleHttpRequestErr {
-        global_error: Some(global_error),
-        node_details,
-        message,
-    };
     let bytes = Encode!(&FlexibleHttpRequestResult::Err(err)).ok()?;
 
     Some(ConsensusResponse::new(callback_id, Payload::Data(bytes)))

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -26,7 +26,8 @@ use ic_interfaces::{
 use ic_interfaces_mocks::crypto::MockCrypto;
 use ic_logger::replica_logger::no_op_logger;
 use ic_management_canister_types_private::{
-    CanisterHttpResponsePayload, FlexibleHttpRequestResult, HttpHeader,
+    CanisterHttpResponsePayload, FlexibleHttpGlobalError, FlexibleHttpRequestResult, HttpHeader,
+    HttpRequestResourceReport,
 };
 use ic_metrics::MetricsRegistry;
 use ic_registry_subnet_features::SubnetFeatures;
@@ -2794,6 +2795,185 @@ fn flexible_ok_responses_into_messages_decode_failure_is_skipped() {
     assert_eq!(responses.len(), 0);
     assert_eq!(stats.flexible_ok_responses, 0);
     assert_eq!(stats.flexible_ok_responses_candid_failures, 1);
+}
+
+#[test]
+fn flexible_error_into_messages_timeout() {
+    let callback_id = CallbackId::from(42);
+
+    let payload = CanisterHttpPayload {
+        flexible_errors: vec![FlexibleCanisterHttpError::Timeout { callback_id }],
+        ..Default::default()
+    };
+    let bytes = payload_to_bytes_max_4mb(payload);
+
+    let (responses, stats) = CanisterHttpPayloadBuilderImpl::into_messages(&bytes);
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].callback, callback_id);
+    assert_eq!(stats.flexible_errors, 1);
+    assert_eq!(stats.flexible_errors_candid_failures, 0);
+
+    let Payload::Data(ref data) = responses[0].payload else {
+        panic!("Expected Payload::Data, got {:?}", responses[0].payload);
+    };
+    let result = Decode!(data, FlexibleHttpRequestResult).unwrap();
+    let FlexibleHttpRequestResult::Err(err) = result else {
+        panic!("Expected Err variant, got {result:?}");
+    };
+    assert_eq!(
+        err.global_error,
+        Some(FlexibleHttpGlobalError::Timeout(candid::Reserved))
+    );
+    assert!(err.node_details.is_empty());
+    assert!(err.message.contains("timed out"));
+}
+
+#[test]
+fn flexible_error_into_messages_too_many_request_errors() {
+    let callback_id = CallbackId::from(42);
+
+    let reject_entries: Vec<_> = (0..2_u64)
+        .map(|node_idx| flexible_reject_response(callback_id.get(), node_idx))
+        .collect();
+
+    let payload = CanisterHttpPayload {
+        flexible_errors: vec![FlexibleCanisterHttpError::TooManyRequestErrors {
+            callback_id,
+            reject_responses: reject_entries,
+        }],
+        ..Default::default()
+    };
+    let bytes = payload_to_bytes_max_4mb(payload);
+
+    let (responses, stats) = CanisterHttpPayloadBuilderImpl::into_messages(&bytes);
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].callback, callback_id);
+    assert_eq!(stats.flexible_errors, 1);
+    assert_eq!(stats.flexible_errors_candid_failures, 0);
+
+    let Payload::Data(ref data) = responses[0].payload else {
+        panic!("Expected Payload::Data, got {:?}", responses[0].payload);
+    };
+    let result = Decode!(data, FlexibleHttpRequestResult).unwrap();
+    let FlexibleHttpRequestResult::Err(err) = result else {
+        panic!("Expected Err variant, got {result:?}");
+    };
+    assert_eq!(
+        err.global_error,
+        Some(FlexibleHttpGlobalError::TooManyRequestErrors(
+            candid::Reserved
+        ))
+    );
+    assert_eq!(err.node_details.len(), 2);
+    for (i, detail) in err.node_details.iter().enumerate() {
+        assert_eq!(
+            detail.node_id,
+            candid::Principal::from(node_test_id(i as u64).get())
+        );
+        assert_eq!(detail.report, HttpRequestResourceReport::default());
+        let error = detail.error.as_ref().unwrap();
+        assert_eq!(error.code, format!("{:?}", RejectCode::SysTransient));
+        assert_eq!(error.message, "could not connect");
+    }
+    assert!(err.message.contains("Too many request errors"));
+    assert!(err.message.contains("2 responses are rejects"));
+}
+
+#[test]
+fn flexible_error_into_messages_responses_too_large() {
+    let callback_id = CallbackId::from(42);
+
+    let share_a = metadata_share_with_content_size(callback_id.get(), 0, 1_200_000);
+    let share_b = metadata_share_with_content_size(callback_id.get(), 1, 1_300_000);
+
+    let share_c = metadata_share_with_content_size(callback_id.get(), 2, 1_400_000);
+    let share_reject = reject_metadata_share(callback_id.get(), 3);
+
+    let payload = CanisterHttpPayload {
+        flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
+            callback_id,
+            all_seen_shares: vec![share_a, share_b, share_c, share_reject],
+            total_requests: 5,
+            min_responses: 3,
+        }],
+        ..Default::default()
+    };
+    let bytes = payload_to_bytes_max_4mb(payload);
+
+    let (responses, stats) = CanisterHttpPayloadBuilderImpl::into_messages(&bytes);
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].callback, callback_id);
+    assert_eq!(stats.flexible_errors, 1);
+    assert_eq!(stats.flexible_errors_candid_failures, 0);
+
+    let Payload::Data(ref data) = responses[0].payload else {
+        panic!("Expected Payload::Data, got {:?}", responses[0].payload);
+    };
+    let result = Decode!(data, FlexibleHttpRequestResult).unwrap();
+    let FlexibleHttpRequestResult::Err(err) = result else {
+        panic!("Expected Err variant, got {result:?}");
+    };
+    assert_eq!(
+        err.global_error,
+        Some(FlexibleHttpGlobalError::ResponsesTooLarge(candid::Reserved))
+    );
+    // All 4 shares (3 ok + 1 reject) are in node_details
+    assert_eq!(err.node_details.len(), 4);
+    for detail in &err.node_details {
+        assert_eq!(detail.report, HttpRequestResourceReport::default());
+    }
+
+    assert_eq!(
+        err.node_details[0].node_id,
+        candid::Principal::from(node_test_id(0).get())
+    );
+    assert_eq!(err.node_details[0].error.as_ref().unwrap().code, "ok");
+    assert_eq!(
+        err.node_details[0].error.as_ref().unwrap().message,
+        "1200000 bytes"
+    );
+
+    assert_eq!(
+        err.node_details[1].node_id,
+        candid::Principal::from(node_test_id(1).get())
+    );
+    assert_eq!(err.node_details[1].error.as_ref().unwrap().code, "ok");
+    assert_eq!(
+        err.node_details[1].error.as_ref().unwrap().message,
+        "1300000 bytes"
+    );
+
+    assert_eq!(
+        err.node_details[2].node_id,
+        candid::Principal::from(node_test_id(2).get())
+    );
+    assert_eq!(err.node_details[2].error.as_ref().unwrap().code, "ok");
+    assert_eq!(
+        err.node_details[2].error.as_ref().unwrap().message,
+        "1400000 bytes"
+    );
+
+    assert_eq!(
+        err.node_details[3].node_id,
+        candid::Principal::from(node_test_id(3).get())
+    );
+    assert_eq!(err.node_details[3].error.as_ref().unwrap().code, "reject");
+    assert_eq!(
+        err.node_details[3].error.as_ref().unwrap().message,
+        "50 bytes"
+    );
+    // min_known_ok_needed = 3 - 1 unseen = 2, so message lists only the 2 smallest OK sizes
+    assert!(err.message.contains("3 min_responses"));
+    assert!(err.message.contains("5 total_requests"));
+    assert!(err.message.contains("3 ok"));
+    assert!(err.message.contains("1 reject"));
+    assert!(err.message.contains("1 unseen"));
+    assert!(err.message.contains("1200000"));
+    assert!(err.message.contains("1300000"));
+    assert!(!err.message.contains("1400000"));
 }
 
 #[test]

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -2885,10 +2885,11 @@ fn flexible_error_into_messages_too_many_request_errors() {
 fn flexible_error_into_messages_responses_too_large() {
     let callback_id = CallbackId::from(42);
 
-    let share_a = metadata_share_with_content_size(callback_id.get(), 0, 1_200_000);
-    let share_b = metadata_share_with_content_size(callback_id.get(), 1, 1_300_000);
-
-    let share_c = metadata_share_with_content_size(callback_id.get(), 2, 1_400_000);
+    // Deliberately construct OK shares in non-ascending size order so that
+    // `into_messages` must sort them to report the correct "smallest" sizes.
+    let share_a = metadata_share_with_content_size(callback_id.get(), 0, 1_400_000);
+    let share_b = metadata_share_with_content_size(callback_id.get(), 1, 1_200_000);
+    let share_c = metadata_share_with_content_size(callback_id.get(), 2, 1_300_000);
     let share_reject = reject_metadata_share(callback_id.get(), 3);
 
     let payload = CanisterHttpPayload {
@@ -2933,7 +2934,7 @@ fn flexible_error_into_messages_responses_too_large() {
     assert_eq!(err.node_details[0].error.as_ref().unwrap().code, "ok");
     assert_eq!(
         err.node_details[0].error.as_ref().unwrap().message,
-        "1200000 bytes"
+        "1400000 bytes"
     );
 
     assert_eq!(
@@ -2943,7 +2944,7 @@ fn flexible_error_into_messages_responses_too_large() {
     assert_eq!(err.node_details[1].error.as_ref().unwrap().code, "ok");
     assert_eq!(
         err.node_details[1].error.as_ref().unwrap().message,
-        "1300000 bytes"
+        "1200000 bytes"
     );
 
     assert_eq!(
@@ -2953,7 +2954,7 @@ fn flexible_error_into_messages_responses_too_large() {
     assert_eq!(err.node_details[2].error.as_ref().unwrap().code, "ok");
     assert_eq!(
         err.node_details[2].error.as_ref().unwrap().message,
-        "1400000 bytes"
+        "1300000 bytes"
     );
 
     assert_eq!(
@@ -2971,9 +2972,7 @@ fn flexible_error_into_messages_responses_too_large() {
     assert!(err.message.contains("3 ok"));
     assert!(err.message.contains("1 reject"));
     assert!(err.message.contains("1 unseen"));
-    assert!(err.message.contains("1200000"));
-    assert!(err.message.contains("1300000"));
-    assert!(!err.message.contains("1400000"));
+    assert!(err.message.contains("[1200000, 1300000"));
 }
 
 #[test]

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -2972,7 +2972,8 @@ fn flexible_error_into_messages_responses_too_large() {
     assert!(err.message.contains("3 ok"));
     assert!(err.message.contains("1 reject"));
     assert!(err.message.contains("1 unseen"));
-    assert!(err.message.contains("[1200000, 1300000"));
+    assert!(err.message.contains("[1200000, 1300000]"));
+    assert!(!err.message.contains("1400000"));
 }
 
 #[test]

--- a/rs/types/management_canister_types/src/http.rs
+++ b/rs/types/management_canister_types/src/http.rs
@@ -435,6 +435,8 @@ pub enum FlexibleHttpGlobalError {
     OutOfCycles(candid::Reserved),
     #[serde(rename = "responses_too_large")]
     ResponsesTooLarge(candid::Reserved),
+    #[serde(rename = "too_many_request_errors")]
+    TooManyRequestErrors(candid::Reserved),
 }
 
 /// Per-node detail in a flexible HTTP outcall error.
@@ -464,7 +466,7 @@ pub struct FlexibleHttpNodeDetail {
 ///   cycles: opt variant { used: nat; exceeded: reserved };
 /// };
 /// ```
-#[derive(Clone, Eq, PartialEq, Hash, Debug, CandidType, Deserialize, Serialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default, CandidType, Deserialize, Serialize)]
 pub struct HttpRequestResourceReport {
     pub raw_response_bytes: Option<ResourceUsage<u64>>,
     pub http_roundtrip_time_ms: Option<ResourceUsage<u64>>,


### PR DESCRIPTION
Implements the `IntoMessages` path for flexible HTTP outcall errors, converting each `FlexibleCanisterHttpError` from the consensus payload into a single Candid-encoded `ConsensusResponse` carrying a `FlexibleHttpRequestResult::Err` for delivery to the execution environment.

For each flexible error, a `FlexibleHttpRequestErr` is constructed with:
- `global_error`: `Timeout`, `TooManyRequestErrors`, or `ResponsesTooLarge` (matching the error variant).
- `node_details`: per-node entries with `code` and `message`.
  - `Timeout`: empty (no per-node info is carried in the payload today).
  - `TooManyRequestErrors`: one entry per reject with the adapter's reject code and message.
  - `ResponsesTooLarge`: one entry per seen share with `code` being `"ok"` or `"reject"` and `message` being the content size in bytes.
- `message`: a diagnostic summary. For `ResponsesTooLarge`, this includes the explicit calculation of why the limit could not be met, e.g. `"Responses too large: need at least 5 (= 8 min_responses - 3 unseen) OK responses to fit within 2097152 bytes, but even the smallest 5 of 7 OK responses have sizes [...] bytes (7 ok + 3 reject + 3 unseen = 13 total_requests)"`.

`Success` entries inside a `TooManyRequestErrors` batch are filtered out as this path is unreachable due to payload building/validation ensuring that no ok responses are included in the error-payload.

If Candid encoding fails, the delivery of the response is skipped and a timeout will eventually gracefully end the outstanding callback.

A new `TooManyRequestErrors(candid::Reserved)` variant is added to `FlexibleHttpGlobalError`, mirroring the existing `Timeout` and `ResponsesTooLarge` variants. Note that https://github.com/dfinity/ic/pull/9927 will rename `TooManyRequestErrors` to `TooManyRejects`.

Consensus metrics are extended to track `canister_http_flexible_errors_delivered` and to include flexible-error Candid failures in the existing `canister_http_flexible_candid_failures` counter.

### Known limitation

The `ResponsesTooLarge` mapping to `node_details` is a pragmatic fit but not ideal: the `FlexibleHttpNodeDetail.error` field is shaped for error information, yet we use it to convey both OK and reject shares (with `code` set to `"ok"` or `"reject"`). This overloads the field's intent. We can improve this in a future PR, e.g. by extending `FlexibleHttpNodeDetail` with a variant that cleanly distinguishes OK vs reject shares for the `ResponsesTooLarge` case.
