### PR TITLE
feat: CON-1445 Helper functions to create `NiDkgConfig`s from request contexts

### DIFF
--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -32,6 +32,8 @@ use std::{
 pub mod dkg_key_manager;
 pub mod payload_builder;
 pub mod payload_validator;
+#[allow(dead_code)]
+pub(crate) mod remote;
 
 pub use crate::utils::get_vetkey_public_keys;
 

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -798,7 +798,6 @@ fn process_reshare_chain_key_contexts(
         .metadata
         .subnet_call_context_manager
         .reshare_chain_key_contexts;
-    let get_reshare_transcript = |tag: &NiDkgTag| reshared_transcripts.get(tag).cloned();
 
     for (_callback_id, context) in contexts.iter() {
         // if we haven't reached the required registry version yet, skip this context
@@ -811,20 +810,33 @@ fn process_reshare_chain_key_contexts(
             continue;
         };
 
-        match create_remote_dkg_config_for_key_id(
-            key_id,
+        let dkg_id = NiDkgId {
             start_block_height,
-            this_subnet_id,
-            context.target_id,
+            dealer_subnet: this_subnet_id,
+            dkg_tag: NiDkgTag::HighThresholdForKey(key_id),
+            target_subnet: NiDkgTargetSubnet::Remote(context.target_id),
+        };
+        let Some(resharing_transcript) = reshared_transcripts.get(&dkg_id.dkg_tag).cloned() else {
+            let err = format!(
+                "Failed to find resharing transcript for a remote dkg for tag {:?}",
+                &dkg_id.dkg_tag
+            );
+            errors.push((dkg_id, err));
+            continue;
+        };
+
+        match create_remote_dkg_config(
+            dkg_id.clone(),
+            resharing_transcript.committee.get().clone(),
             context.nodes.clone(),
-            get_reshare_transcript,
             &context.registry_version,
+            Some(resharing_transcript),
         ) {
             Ok(config) => {
                 new_configs.push(vec![config]);
                 valid_target_ids.push(context.target_id);
             }
-            Err(err) => errors.push(*err),
+            Err(err) => errors.push((dkg_id, format!("{err:?}"))),
         }
     }
     (new_configs, errors, valid_target_ids)
@@ -1015,42 +1027,7 @@ pub(crate) fn create_low_high_remote_dkg_configs(
     }
 }
 
-pub(crate) fn create_remote_dkg_config_for_key_id(
-    key_id: NiDkgMasterPublicKeyId,
-    start_block_height: Height,
-    dealer_subnet: SubnetId,
-    target_id: NiDkgTargetId,
-    receivers: BTreeSet<NodeId>,
-    get_reshare_transcript: impl Fn(&NiDkgTag) -> Option<NiDkgTranscript>,
-    registry_version: &RegistryVersion,
-) -> Result<NiDkgConfig, Box<(NiDkgId, String)>> {
-    let dkg_id = NiDkgId {
-        start_block_height,
-        dealer_subnet,
-        dkg_tag: NiDkgTag::HighThresholdForKey(key_id),
-        target_subnet: NiDkgTargetSubnet::Remote(target_id),
-    };
-
-    // Find the resharing transcript corresponding to the remote dkg id
-    let Some(resharing_transcript) = get_reshare_transcript(&dkg_id.dkg_tag) else {
-        let err = format!(
-            "Failed to find resharing transcript for a remote dkg for tag {:?}",
-            &dkg_id.dkg_tag
-        );
-        return Err(Box::new((dkg_id, err)));
-    };
-
-    create_remote_dkg_config(
-        dkg_id.clone(),
-        resharing_transcript.committee.get().clone(),
-        receivers,
-        registry_version,
-        Some(resharing_transcript),
-    )
-    .map_err(|err| Box::new((dkg_id, format!("{err:?}"))))
-}
-
-fn create_remote_dkg_config(
+pub(crate) fn create_remote_dkg_config(
     dkg_id: NiDkgId,
     dealers: BTreeSet<NodeId>,
     receivers: BTreeSet<NodeId>,
@@ -1221,7 +1198,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_remote_dkg_config_for_key_id_dealers_match_reshared_transcript_committee() {
+    fn test_remote_dkg_config_dealers_match_reshared_transcript_committee() {
         let transcript_committee: Vec<_> = (0..4).map(node_test_id).collect();
         let receivers: BTreeSet<_> = (4..8).map(node_test_id).collect();
         let start_block_height = Height::from(500);
@@ -1242,18 +1219,18 @@ mod tests {
             777,
         );
 
-        let mut reshared_transcripts = BTreeMap::new();
-        reshared_transcripts.insert(tag, resharing_transcript.clone());
-
-        let get_reshare_transcript = |tag: &NiDkgTag| reshared_transcripts.get(tag).cloned();
-        let config = super::create_remote_dkg_config_for_key_id(
-            key_id,
+        let dkg_id = NiDkgId {
             start_block_height,
             dealer_subnet,
-            target_id,
+            dkg_tag: tag,
+            target_subnet: NiDkgTargetSubnet::Remote(target_id),
+        };
+        let config = super::create_remote_dkg_config(
+            dkg_id,
+            resharing_transcript.committee.get().clone(),
             receivers,
-            get_reshare_transcript,
             &registry_version,
+            Some(resharing_transcript.clone()),
         )
         .expect("expected remote DKG config for resharing");
 

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -1008,7 +1008,7 @@ impl<'a> RemoteDkgContext<'a> {
                         start_block_height,
                         dealer_subnet,
                         dkg_tag,
-                        target_subnet: NiDkgTargetSubnet::Remote(self.target_id().clone()),
+                        target_subnet: NiDkgTargetSubnet::Remote(*self.target_id()),
                     },
                     REMOTE_DKG_REPEATED_FAILURE_ERROR.to_string(),
                 )

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -1073,7 +1073,13 @@ fn create_remote_dkg_config(
 
 #[cfg(test)]
 mod tests {
-    use crate::{test_utils::create_dealing, tests::test_vet_key_config};
+    use crate::{
+        test_utils::{
+            create_dealing, local_dkg_id, make_test_config, remote_dkg_id,
+            remote_dkg_id_with_target,
+        },
+        tests::test_vet_key_config,
+    };
 
     use super::{super::test_utils::complement_state_manager_with_setup_initial_dkg_request, *};
     use ic_consensus_mocks::{
@@ -1998,43 +2004,6 @@ mod tests {
         }
         fn validated_contains(&self, _msg: &Message) -> bool {
             unimplemented!()
-        }
-    }
-
-    fn make_test_config(dkg_id: NiDkgId, max_corrupt_dealers: u32) -> NiDkgConfig {
-        let nodes: BTreeSet<_> = (0..10).map(node_test_id).collect();
-        NiDkgConfig::new(NiDkgConfigData {
-            dkg_id,
-            max_corrupt_dealers: NumberOfNodes::from(max_corrupt_dealers),
-            dealers: nodes.clone(),
-            max_corrupt_receivers: NumberOfNodes::from(1),
-            receivers: nodes,
-            threshold: NumberOfNodes::from(2),
-            registry_version: RegistryVersion::from(1),
-            resharing_transcript: None,
-        })
-        .unwrap()
-    }
-
-    fn local_dkg_id(tag: NiDkgTag) -> NiDkgId {
-        NiDkgId {
-            start_block_height: Height::from(0),
-            dealer_subnet: subnet_test_id(0),
-            dkg_tag: tag,
-            target_subnet: NiDkgTargetSubnet::Local,
-        }
-    }
-
-    fn remote_dkg_id(tag: NiDkgTag) -> NiDkgId {
-        remote_dkg_id_with_target(tag, [0_u8; 32])
-    }
-
-    fn remote_dkg_id_with_target(tag: NiDkgTag, target_id: [u8; 32]) -> NiDkgId {
-        NiDkgId {
-            start_block_height: Height::from(0),
-            dealer_subnet: subnet_test_id(0),
-            dkg_tag: tag,
-            target_subnet: NiDkgTargetSubnet::Remote(NiDkgTargetId::new(target_id)),
         }
     }
 

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -1039,11 +1039,10 @@ pub(crate) fn create_remote_dkg_config_for_key_id(
         );
         return Err(Box::new((dkg_id, err)));
     };
-    let dealers = resharing_transcript.committee.clone();
 
     create_remote_dkg_config(
         dkg_id.clone(),
-        dealers.into(),
+        resharing_transcript.committee.get().clone(),
         receivers,
         registry_version,
         Some(resharing_transcript),

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use crate::{
     MAX_REMOTE_DKG_ATTEMPTS, MAX_REMOTE_DKGS_PER_INTERVAL, REMOTE_DKG_REPEATED_FAILURE_ERROR,
     utils::{self, tags_iter, vetkd_key_ids_for_subnet},
@@ -14,10 +13,7 @@ use ic_protobuf::registry::subnet::v1::{
 use ic_registry_client_helpers::{
     crypto::initial_ni_dkg_transcript_from_registry_record, subnet::SubnetRegistry,
 };
-use ic_replicated_state::{
-    ReplicatedState,
-    metadata_state::subnet_call_context_manager::{ReshareChainKeyContext, SetupInitialDkgContext},
-};
+use ic_replicated_state::ReplicatedState;
 use ic_types::{
     Height, NodeId, NumberOfNodes, RegistryVersion, SubnetId,
     batch::ValidationContext,
@@ -885,7 +881,7 @@ fn process_setup_initial_dkg_contexts(
     Ok((new_configs, errors, valid_target_ids))
 }
 
-fn get_node_list(
+pub(crate) fn get_node_list(
     subnet_id: SubnetId,
     registry_client: &dyn RegistryClient,
     registry_version: RegistryVersion,
@@ -950,206 +946,10 @@ fn add_callback_ids_to_transcript_results(
         .collect()
 }
 
-/// The result of creating DKG configs for a given request context.
-pub(crate) type ConfigResult = Result<Vec<NiDkgConfig>, Vec<(NiDkgId, String)>>;
-
-/// A wrapper around the ReshareChainKeyContexts to be handled by the NiDKG module.
-struct NiDkgReshareChainKeyContext<'a> {
-    context: &'a ReshareChainKeyContext,
-    key_id: NiDkgMasterPublicKeyId,
-}
-
-impl<'a> TryFrom<&'a ReshareChainKeyContext> for NiDkgReshareChainKeyContext<'a> {
-    type Error = &'static str;
-
-    fn try_from(context: &'a ReshareChainKeyContext) -> Result<Self, Self::Error> {
-        let key_id = NiDkgMasterPublicKeyId::try_from(context.key_id.clone())?;
-        Ok(NiDkgReshareChainKeyContext { context, key_id })
-    }
-}
-
-enum RemoteDkgContext<'a> {
-    SetupInitialDKG(&'a SetupInitialDkgContext),
-    ReshareChainKey(NiDkgReshareChainKeyContext<'a>),
-}
-
-impl<'a> RemoteDkgContext<'a> {
-    fn target_id(&self) -> &'a NiDkgTargetId {
-        match self {
-            RemoteDkgContext::SetupInitialDKG(context) => &context.target_id,
-            RemoteDkgContext::ReshareChainKey(context) => &context.context.target_id,
-        }
-    }
-
-    fn registry_version(&self) -> RegistryVersion {
-        match self {
-            RemoteDkgContext::SetupInitialDKG(context) => context.registry_version,
-            RemoteDkgContext::ReshareChainKey(context) => context.context.registry_version,
-        }
-    }
-
-    fn generate_timeout_errors(
-        &self,
-        start_block_height: Height,
-        dealer_subnet: SubnetId,
-    ) -> Vec<(NiDkgId, String)> {
-        let tags = match self {
-            RemoteDkgContext::SetupInitialDKG(_) => {
-                vec![NiDkgTag::LowThreshold, NiDkgTag::HighThreshold]
-            }
-            RemoteDkgContext::ReshareChainKey(context) => {
-                vec![NiDkgTag::HighThresholdForKey(context.key_id.clone())]
-            }
-        };
-        tags.into_iter()
-            .map(|dkg_tag| {
-                (
-                    NiDkgId {
-                        start_block_height,
-                        dealer_subnet,
-                        dkg_tag,
-                        target_subnet: NiDkgTargetSubnet::Remote(*self.target_id()),
-                    },
-                    REMOTE_DKG_REPEATED_FAILURE_ERROR.to_string(),
-                )
-            })
-            .collect()
-    }
-
-    fn create_configs(
-        &self,
-        start_block_height: Height,
-        dealer_subnet: SubnetId,
-        registry_client: &dyn RegistryClient,
-        get_reshare_transcript: impl Fn(&NiDkgTag) -> Option<NiDkgTranscript>,
-        logger: &ReplicaLogger,
-    ) -> Result<ConfigResult, DkgPayloadCreationError> {
-        let config_result = match self {
-            RemoteDkgContext::SetupInitialDKG(context) => {
-                let dealers =
-                    get_node_list(dealer_subnet, registry_client, context.registry_version)?;
-                create_low_high_remote_dkg_configs(
-                    start_block_height,
-                    dealer_subnet,
-                    context.target_id,
-                    &dealers,
-                    &context.nodes_in_target_subnet,
-                    &context.registry_version,
-                    logger,
-                )
-                .map(|(config0, config1)| vec![config0, config1])
-            }
-            RemoteDkgContext::ReshareChainKey(context) => create_remote_dkg_config_for_key_id(
-                context.key_id.clone(),
-                start_block_height,
-                dealer_subnet,
-                context.context.target_id,
-                &context.context.nodes,
-                get_reshare_transcript,
-                &context.context.registry_version,
-            )
-            .map(|config| vec![config])
-            .map_err(|err_box| vec![*err_box]),
-        };
-        Ok(config_result)
-    }
-}
-
-/// Builds a map from callback ids to config results for all remote DKG contexts
-/// found in the given replicated state.
-pub(crate) fn build_callback_id_config_map(
-    this_subnet_id: SubnetId,
-    registry_client: &dyn RegistryClient,
-    state: &ReplicatedState,
-    registry_version: RegistryVersion,
-    dkg_summary: &DkgSummary,
-    logger: &ReplicaLogger,
-) -> Result<BTreeMap<CallbackId, ConfigResult>, DkgPayloadCreationError> {
-    let mut callback_id_config_map = BTreeMap::new();
-    let call_contexts = &state.metadata.subnet_call_context_manager;
-    let remote_dkg_attempts = &dkg_summary.initial_dkg_attempts;
-
-    // Iterate over all context types
-    let setup_contexts = call_contexts
-        .setup_initial_dkg_contexts
-        .iter()
-        .map(|(&callback_id, context)| (callback_id, RemoteDkgContext::SetupInitialDKG(context)));
-    let reshare_contexts =
-        call_contexts
-            .reshare_chain_key_contexts
-            .iter()
-            .filter_map(|(&callback_id, context)| {
-                // Filter out IDKG contexts.
-                NiDkgReshareChainKeyContext::try_from(context)
-                    .ok()
-                    .map(|context| (callback_id, RemoteDkgContext::ReshareChainKey(context)))
-            });
-
-    let get_reshare_transcript = |tag: &NiDkgTag| {
-        dkg_summary
-            .next_transcripts()
-            .get(tag)
-            .cloned()
-            .or_else(|| dkg_summary.current_transcripts().get(tag).cloned())
-    };
-
-    for (callback_id, context) in setup_contexts.chain(reshare_contexts) {
-        if context.registry_version() > registry_version {
-            // Skip contexts with a registry version that hasn't been reached yet
-            continue;
-        }
-
-        if let Some(&attempts) = remote_dkg_attempts.get(context.target_id()) {
-            if attempts == 0 {
-                // An attempt count of 0 means that the context has already been completed
-                // in the last interval. We skip the context to avoid handling it again in
-                // the current interval.
-                continue;
-            }
-            if attempts > MAX_REMOTE_DKG_ATTEMPTS {
-                // Add timeout errors for contexts that have been attempted too many times
-                callback_id_config_map.insert(
-                    callback_id,
-                    Err(context.generate_timeout_errors(dkg_summary.height, this_subnet_id)),
-                );
-                continue;
-            }
-        }
-
-        // Create configs for the context and insert them into the map
-        callback_id_config_map.insert(
-            callback_id,
-            context.create_configs(
-                dkg_summary.height,
-                this_subnet_id,
-                registry_client,
-                get_reshare_transcript,
-                logger,
-            )?,
-        );
-    }
-
-    Ok(callback_id_config_map)
-}
-
-/// Merges the configs from the summary and the configs from the request contexts.
-pub(crate) fn merge_configs<'a>(
-    summary_configs: &'a BTreeMap<NiDkgId, NiDkgConfig>,
-    config_results: &'a BTreeMap<CallbackId, ConfigResult>,
-) -> BTreeMap<&'a NiDkgId, &'a NiDkgConfig> {
-    let mut merged_configs: BTreeMap<&NiDkgId, &NiDkgConfig> = summary_configs.iter().collect();
-    for configs in config_results.values().flatten() {
-        for config in configs {
-            merged_configs.insert(config.dkg_id(), config);
-        }
-    }
-    merged_configs
-}
-
 /// This function is called on each entry on the SetupInitialDkgContext. It returns
 /// either the created high and low configs for the entry or returns two errors
 /// identified by the NiDkgId.
-fn create_low_high_remote_dkg_configs(
+pub(crate) fn create_low_high_remote_dkg_configs(
     start_block_height: Height,
     dealer_subnet: SubnetId,
     target_subnet: NiDkgTargetId,
@@ -1215,7 +1015,7 @@ fn create_low_high_remote_dkg_configs(
     }
 }
 
-fn create_remote_dkg_config_for_key_id(
+pub(crate) fn create_remote_dkg_config_for_key_id(
     key_id: NiDkgMasterPublicKeyId,
     start_block_height: Height,
     dealer_subnet: SubnetId,
@@ -1283,19 +1083,14 @@ mod tests {
     };
     use ic_crypto_test_utils_ni_dkg::dummy_transcript_for_tests_with_params;
     use ic_logger::replica_logger::no_op_logger;
-    use ic_management_canister_types_private::{
-        EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, VetKdCurve, VetKdKeyId,
-    };
+    use ic_management_canister_types_private::{VetKdCurve, VetKdKeyId};
     use ic_registry_client_helpers::subnet::SubnetRegistry;
     use ic_test_utilities_logger::with_test_replica_logger;
-    use ic_test_utilities_registry::{SubnetRecordBuilder, add_subnet_record, setup_registry};
-    use ic_test_utilities_state::ReplicatedStateBuilder;
+    use ic_test_utilities_registry::{SubnetRecordBuilder, add_subnet_record};
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
-    use ic_test_utilities_types::messages::RequestBuilder;
     use ic_types::{
         RegistryVersion,
         crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet},
-        messages::CallbackId,
         time::UNIX_EPOCH,
     };
     use std::collections::BTreeSet;
@@ -1461,353 +1256,6 @@ mod tests {
             config.dealers().get(),
             resharing_transcript.committee.get(),
             "dealers must be the committee of the transcript being reshared"
-        );
-    }
-
-    fn test_dkg_summary(
-        height: Height,
-        current_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
-        next_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
-        initial_dkg_attempts: BTreeMap<NiDkgTargetId, u32>,
-    ) -> DkgSummary {
-        DkgSummary::new(
-            vec![],
-            current_transcripts,
-            next_transcripts,
-            vec![],
-            RegistryVersion::from(1),
-            Height::from(10),
-            Height::from(10),
-            height,
-            initial_dkg_attempts,
-        )
-    }
-
-    fn test_setup_initial_dkg_context(
-        target_id: NiDkgTargetId,
-        registry_version: RegistryVersion,
-        nodes_in_target_subnet: BTreeSet<NodeId>,
-    ) -> SetupInitialDkgContext {
-        SetupInitialDkgContext {
-            request: RequestBuilder::default().build(),
-            nodes_in_target_subnet,
-            target_id,
-            registry_version,
-            time: UNIX_EPOCH,
-        }
-    }
-
-    fn test_reshare_chain_key_context(
-        key_id: MasterPublicKeyId,
-        target_id: NiDkgTargetId,
-        registry_version: RegistryVersion,
-        nodes: BTreeSet<NodeId>,
-    ) -> ReshareChainKeyContext {
-        ReshareChainKeyContext {
-            request: RequestBuilder::default().build(),
-            key_id,
-            nodes,
-            registry_version,
-            time: UNIX_EPOCH,
-            target_id,
-        }
-    }
-
-    #[test]
-    fn test_build_callback_id_config_map_setup_initial_dkg() {
-        let this_subnet_id = subnet_test_id(10);
-        let dealers: Vec<_> = (0..4).map(node_test_id).collect();
-        let registry = setup_registry(
-            this_subnet_id,
-            vec![(1, SubnetRecordBuilder::from(&dealers).build())],
-        );
-
-        let target_id = NiDkgTargetId::new([1_u8; 32]);
-        let target_id2 = NiDkgTargetId::new([2_u8; 32]);
-        let target_id3 = NiDkgTargetId::new([3_u8; 32]);
-        let callback_id = CallbackId::from(1);
-        let mut state = ReplicatedStateBuilder::new()
-            .with_subnet_id(this_subnet_id)
-            .build();
-        state
-            .metadata
-            .subnet_call_context_manager
-            .setup_initial_dkg_contexts
-            .insert(
-                callback_id,
-                test_setup_initial_dkg_context(
-                    target_id,
-                    RegistryVersion::from(1),
-                    (10..14).map(node_test_id).collect(),
-                ),
-            );
-        // Second setup initial DKG context with a registry version that hasn't been reached yet.
-        state
-            .metadata
-            .subnet_call_context_manager
-            .setup_initial_dkg_contexts
-            .insert(
-                CallbackId::from(2),
-                test_setup_initial_dkg_context(
-                    target_id2,
-                    RegistryVersion::from(10),
-                    (10..14).map(node_test_id).collect(),
-                ),
-            );
-        state
-            .metadata
-            .subnet_call_context_manager
-            .reshare_chain_key_contexts
-            .insert(
-                CallbackId::from(3),
-                test_reshare_chain_key_context(
-                    MasterPublicKeyId::Ecdsa(EcdsaKeyId {
-                        curve: EcdsaCurve::Secp256k1,
-                        name: "idkg_key".to_string(),
-                    }),
-                    target_id3,
-                    RegistryVersion::from(1),
-                    (10..14).map(node_test_id).collect(),
-                ),
-            );
-
-        let dkg_summary = test_dkg_summary(
-            Height::from(100),
-            BTreeMap::new(),
-            BTreeMap::new(),
-            BTreeMap::new(),
-        );
-        let map = build_callback_id_config_map(
-            this_subnet_id,
-            registry.as_ref(),
-            &state,
-            RegistryVersion::from(1),
-            &dkg_summary,
-            &no_op_logger(),
-        )
-        .expect("expected callback-id config map");
-        assert_eq!(map.len(), 1);
-        let configs = map
-            .get(&callback_id)
-            .expect("missing callback entry")
-            .as_ref()
-            .expect("expected successful configs");
-        assert_eq!(configs.len(), 2);
-
-        let tags = configs
-            .iter()
-            .map(|config| config.dkg_id().dkg_tag.clone())
-            .collect::<BTreeSet<_>>();
-        assert_eq!(
-            tags,
-            BTreeSet::from([NiDkgTag::LowThreshold, NiDkgTag::HighThreshold])
-        );
-        assert!(configs.iter().all(|config| {
-            config.dkg_id().dealer_subnet == this_subnet_id
-                && config.dkg_id().target_subnet == NiDkgTargetSubnet::Remote(target_id)
-        }));
-
-        // Zero attempts => context must be skipped.
-        let zero_attempts_summary = test_dkg_summary(
-            Height::from(101),
-            BTreeMap::new(),
-            BTreeMap::new(),
-            BTreeMap::from([(target_id, 0), (target_id2, 0), (target_id3, 0)]),
-        );
-        let zero_attempts_map = build_callback_id_config_map(
-            this_subnet_id,
-            registry.as_ref(),
-            &state,
-            RegistryVersion::from(1),
-            &zero_attempts_summary,
-            &no_op_logger(),
-        )
-        .expect("expected callback-id config map");
-        assert!(zero_attempts_map.is_empty());
-
-        // Attempts above the max => timeout errors must be returned.
-        let max_attempts_summary = test_dkg_summary(
-            Height::from(102),
-            BTreeMap::new(),
-            BTreeMap::new(),
-            BTreeMap::from([
-                (target_id, MAX_REMOTE_DKG_ATTEMPTS + 1),
-                (target_id2, MAX_REMOTE_DKG_ATTEMPTS + 1),
-                (target_id3, MAX_REMOTE_DKG_ATTEMPTS + 1),
-            ]),
-        );
-        let max_attempts_map = build_callback_id_config_map(
-            this_subnet_id,
-            registry.as_ref(),
-            &state,
-            RegistryVersion::from(1),
-            &max_attempts_summary,
-            &no_op_logger(),
-        )
-        .expect("expected callback-id config map");
-        assert_eq!(max_attempts_map.len(), 1);
-        let timeout_errors = max_attempts_map
-            .get(&callback_id)
-            .expect("missing callback entry for timeout path")
-            .as_ref()
-            .expect_err("expected timeout errors");
-        assert_eq!(timeout_errors.len(), 2);
-        assert!(
-            timeout_errors
-                .iter()
-                .all(|(_, err)| err == REMOTE_DKG_REPEATED_FAILURE_ERROR)
-        );
-        assert_eq!(
-            timeout_errors
-                .iter()
-                .map(|(id, _)| id.dkg_tag.clone())
-                .collect::<BTreeSet<_>>(),
-            BTreeSet::from([NiDkgTag::LowThreshold, NiDkgTag::HighThreshold])
-        );
-
-        // Setup context creation error should be propagated.
-        state
-            .metadata
-            .subnet_call_context_manager
-            .setup_initial_dkg_contexts
-            .insert(
-                CallbackId::from(2),
-                test_setup_initial_dkg_context(
-                    target_id2,
-                    RegistryVersion::from(2),
-                    (10..14).map(node_test_id).collect(),
-                ),
-            );
-        let setup_error_summary = test_dkg_summary(
-            Height::from(103),
-            BTreeMap::new(),
-            BTreeMap::new(),
-            BTreeMap::new(),
-        );
-        let result = build_callback_id_config_map(
-            this_subnet_id,
-            registry.as_ref(),
-            &state,
-            RegistryVersion::from(2),
-            &setup_error_summary,
-            &no_op_logger(),
-        );
-        assert!(matches!(
-            result,
-            Err(DkgPayloadCreationError::FailedToGetSubnetMemberListFromRegistry(_))
-        ));
-    }
-
-    #[test]
-    fn test_build_callback_id_config_map_reshare_chain_key() {
-        let this_subnet_id = subnet_test_id(20);
-        let dealers: Vec<_> = (0..4).map(node_test_id).collect();
-        let registry = setup_registry(
-            this_subnet_id,
-            vec![(1, SubnetRecordBuilder::from(&dealers).build())],
-        );
-
-        let vet_key_id = VetKdKeyId {
-            curve: VetKdCurve::Bls12_381_G2,
-            name: "key_a".to_string(),
-        };
-        let ni_dkg_key_id = NiDkgMasterPublicKeyId::VetKd(vet_key_id.clone());
-        let tag = NiDkgTag::HighThresholdForKey(ni_dkg_key_id.clone());
-        let transcript_committee: Vec<_> = (50..54).map(node_test_id).collect();
-        let transcript = dummy_transcript_for_tests_with_params(
-            transcript_committee.clone(),
-            tag.clone(),
-            tag.threshold_for_subnet_of_size(transcript_committee.len()) as u32,
-            1,
-        );
-        let current_transcript_committee: Vec<_> = (90..94).map(node_test_id).collect();
-        let current_transcript = dummy_transcript_for_tests_with_params(
-            current_transcript_committee.clone(),
-            tag.clone(),
-            tag.threshold_for_subnet_of_size(current_transcript_committee.len()) as u32,
-            1,
-        );
-
-        let target_id = NiDkgTargetId::new([2_u8; 32]);
-        let callback_id = CallbackId::from(2);
-        let mut state = ReplicatedStateBuilder::new()
-            .with_subnet_id(this_subnet_id)
-            .build();
-        state
-            .metadata
-            .subnet_call_context_manager
-            .reshare_chain_key_contexts
-            .insert(
-                callback_id,
-                test_reshare_chain_key_context(
-                    MasterPublicKeyId::VetKd(vet_key_id),
-                    target_id,
-                    RegistryVersion::from(1),
-                    (60..64).map(node_test_id).collect(),
-                ),
-            );
-
-        let dkg_summary = test_dkg_summary(
-            Height::from(101),
-            BTreeMap::from([(tag.clone(), current_transcript.clone())]),
-            BTreeMap::from([(tag, transcript.clone())]),
-            BTreeMap::new(),
-        );
-        let map = build_callback_id_config_map(
-            this_subnet_id,
-            registry.as_ref(),
-            &state,
-            RegistryVersion::from(1),
-            &dkg_summary,
-            &no_op_logger(),
-        )
-        .expect("expected callback-id config map");
-
-        let configs = map
-            .get(&callback_id)
-            .expect("missing callback entry")
-            .as_ref()
-            .expect("expected successful configs");
-        assert_eq!(configs.len(), 1);
-        let config = &configs[0];
-        assert_eq!(config.resharing_transcript().as_ref(), Some(&transcript));
-        assert_ne!(
-            config.resharing_transcript().as_ref(),
-            Some(&current_transcript)
-        );
-        assert_eq!(config.dealers().get(), transcript.committee.get());
-        assert_ne!(config.dealers().get(), current_transcript.committee.get());
-
-        // Re-run with no available transcripts and assert per-context error.
-        let missing_transcript_summary = test_dkg_summary(
-            Height::from(102),
-            BTreeMap::new(),
-            BTreeMap::new(),
-            BTreeMap::new(),
-        );
-        let missing_transcript_map = build_callback_id_config_map(
-            this_subnet_id,
-            registry.as_ref(),
-            &state,
-            RegistryVersion::from(1),
-            &missing_transcript_summary,
-            &no_op_logger(),
-        )
-        .expect("expected callback-id config map");
-        let errors = missing_transcript_map
-            .get(&callback_id)
-            .expect("missing callback entry")
-            .as_ref()
-            .expect_err("expected per-context reshare error");
-        assert_eq!(errors.len(), 1);
-        assert_eq!(
-            errors[0].0.dkg_tag,
-            NiDkgTag::HighThresholdForKey(ni_dkg_key_id)
-        );
-        assert!(
-            errors[0]
-                .1
-                .contains("Failed to find resharing transcript for a remote dkg")
         );
     }
 
@@ -2589,43 +2037,6 @@ mod tests {
             dkg_tag: tag,
             target_subnet: NiDkgTargetSubnet::Remote(NiDkgTargetId::new(target_id)),
         }
-    }
-
-    #[test]
-    fn test_merge_configs_merges_successes_and_ignores_errors() {
-        let summary_only_id = local_dkg_id(NiDkgTag::LowThreshold);
-        let overlap_id = remote_dkg_id_with_target(NiDkgTag::HighThreshold, [11_u8; 32]);
-        let context_only_id = remote_dkg_id_with_target(NiDkgTag::LowThreshold, [11_u8; 32]);
-        let error_only_id = remote_dkg_id_with_target(NiDkgTag::LowThreshold, [12_u8; 32]);
-
-        let summary_only_config = make_test_config(summary_only_id.clone(), 1);
-        let overlap_config = make_test_config(overlap_id.clone(), 1);
-        let context_only_config = make_test_config(context_only_id.clone(), 1);
-
-        let summary_configs: BTreeMap<_, _> = [
-            (summary_only_id.clone(), summary_only_config),
-            (overlap_id.clone(), overlap_config.clone()),
-        ]
-        .into();
-        let config_results: BTreeMap<_, _> = [
-            (
-                CallbackId::from(1),
-                Ok(vec![overlap_config.clone(), context_only_config.clone()]),
-            ),
-            (
-                CallbackId::from(2),
-                Err(vec![(error_only_id.clone(), "test error".to_string())]),
-            ),
-        ]
-        .into();
-
-        let merged = merge_configs(&summary_configs, &config_results);
-
-        assert_eq!(merged.len(), 3);
-        assert!(merged.contains_key(&summary_only_id));
-        assert!(merged.contains_key(&overlap_id));
-        assert!(merged.contains_key(&context_only_id));
-        assert!(!merged.contains_key(&error_only_id));
     }
 
     #[test]

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -798,6 +798,7 @@ fn process_reshare_chain_key_contexts(
         .metadata
         .subnet_call_context_manager
         .reshare_chain_key_contexts;
+    let get_reshare_transcript = |tag: &NiDkgTag| reshared_transcripts.get(tag).cloned();
 
     for (_callback_id, context) in contexts.iter() {
         // if we haven't reached the required registry version yet, skip this context
@@ -810,13 +811,12 @@ fn process_reshare_chain_key_contexts(
             continue;
         };
 
-        let get_reshare_transcript = |tag: &NiDkgTag| reshared_transcripts.get(tag).cloned();
         match create_remote_dkg_config_for_key_id(
             key_id,
             start_block_height,
             this_subnet_id,
             context.target_id,
-            &context.nodes,
+            context.nodes.clone(),
             get_reshare_transcript,
             &context.registry_version,
         ) {
@@ -866,8 +866,8 @@ fn process_setup_initial_dkg_contexts(
             start_block_height,
             this_subnet_id,
             context.target_id,
-            &dealers,
-            &context.nodes_in_target_subnet,
+            dealers,
+            context.nodes_in_target_subnet.clone(),
             &context.registry_version,
             logger,
         ) {
@@ -953,8 +953,8 @@ pub(crate) fn create_low_high_remote_dkg_configs(
     start_block_height: Height,
     dealer_subnet: SubnetId,
     target_subnet: NiDkgTargetId,
-    dealers: &BTreeSet<NodeId>,
-    receivers: &BTreeSet<NodeId>,
+    dealers: BTreeSet<NodeId>,
+    receivers: BTreeSet<NodeId>,
     registry_version: &RegistryVersion,
     logger: &ReplicaLogger,
 ) -> Result<(NiDkgConfig, NiDkgConfig), Vec<(NiDkgId, String)>> {
@@ -974,8 +974,8 @@ pub(crate) fn create_low_high_remote_dkg_configs(
 
     let low_thr_config = create_remote_dkg_config(
         low_thr_dkg_id.clone(),
-        dealers,
-        receivers,
+        dealers.clone(),
+        receivers.clone(),
         registry_version,
         None,
     );
@@ -1020,7 +1020,7 @@ pub(crate) fn create_remote_dkg_config_for_key_id(
     start_block_height: Height,
     dealer_subnet: SubnetId,
     target_id: NiDkgTargetId,
-    receivers: &BTreeSet<NodeId>,
+    receivers: BTreeSet<NodeId>,
     get_reshare_transcript: impl Fn(&NiDkgTag) -> Option<NiDkgTranscript>,
     registry_version: &RegistryVersion,
 ) -> Result<NiDkgConfig, Box<(NiDkgId, String)>> {
@@ -1043,7 +1043,7 @@ pub(crate) fn create_remote_dkg_config_for_key_id(
 
     create_remote_dkg_config(
         dkg_id.clone(),
-        dealers.get(),
+        dealers.into(),
         receivers,
         registry_version,
         Some(resharing_transcript),
@@ -1053,8 +1053,8 @@ pub(crate) fn create_remote_dkg_config_for_key_id(
 
 fn create_remote_dkg_config(
     dkg_id: NiDkgId,
-    dealers: &BTreeSet<NodeId>,
-    receivers: &BTreeSet<NodeId>,
+    dealers: BTreeSet<NodeId>,
+    receivers: BTreeSet<NodeId>,
     registry_version: &RegistryVersion,
     resharing_transcript: Option<NiDkgTranscript>,
 ) -> Result<NiDkgConfig, NiDkgConfigValidationError> {
@@ -1065,8 +1065,8 @@ fn create_remote_dkg_config(
         dkg_id,
         max_corrupt_dealers: NumberOfNodes::from(get_faults_tolerated(dealers.len()) as u32),
         max_corrupt_receivers: NumberOfNodes::from(get_faults_tolerated(receivers.len()) as u32),
-        dealers: dealers.clone(),
-        receivers: receivers.clone(),
+        dealers,
+        receivers,
         registry_version: *registry_version,
         resharing_transcript,
     })
@@ -1246,7 +1246,7 @@ mod tests {
             start_block_height,
             dealer_subnet,
             target_id,
-            &receivers,
+            receivers,
             get_reshare_transcript,
             &registry_version,
         )

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -1246,7 +1246,7 @@ fn create_remote_dkg_config_for_key_id(
         dealers.get(),
         receivers,
         registry_version,
-        Some(resharing_transcript.clone()),
+        Some(resharing_transcript),
     )
     .map_err(|err| Box::new((dkg_id, format!("{err:?}"))))
 }

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use crate::{
     MAX_REMOTE_DKG_ATTEMPTS, MAX_REMOTE_DKGS_PER_INTERVAL, REMOTE_DKG_REPEATED_FAILURE_ERROR,
     utils::{self, tags_iter, vetkd_key_ids_for_subnet},
@@ -13,7 +14,10 @@ use ic_protobuf::registry::subnet::v1::{
 use ic_registry_client_helpers::{
     crypto::initial_ni_dkg_transcript_from_registry_record, subnet::SubnetRegistry,
 };
-use ic_replicated_state::ReplicatedState;
+use ic_replicated_state::{
+    ReplicatedState,
+    metadata_state::subnet_call_context_manager::{ReshareChainKeyContext, SetupInitialDkgContext},
+};
 use ic_types::{
     Height, NodeId, NumberOfNodes, RegistryVersion, SubnetId,
     batch::ValidationContext,
@@ -810,13 +814,14 @@ fn process_reshare_chain_key_contexts(
             continue;
         };
 
+        let get_reshare_transcript = |tag: &NiDkgTag| reshared_transcripts.get(tag).cloned();
         match create_remote_dkg_config_for_key_id(
             key_id,
             start_block_height,
             this_subnet_id,
             context.target_id,
             &context.nodes,
-            reshared_transcripts,
+            get_reshare_transcript,
             &context.registry_version,
         ) {
             Ok(config) => {
@@ -945,6 +950,202 @@ fn add_callback_ids_to_transcript_results(
         .collect()
 }
 
+/// The result of creating DKG configs for a given request context.
+pub(crate) type ConfigResult = Result<Vec<NiDkgConfig>, Vec<(NiDkgId, String)>>;
+
+/// A wrapper around the ReshareChainKeyContexts to be handled by the NiDKG module.
+struct NiDkgReshareChainKeyContext<'a> {
+    context: &'a ReshareChainKeyContext,
+    key_id: NiDkgMasterPublicKeyId,
+}
+
+impl<'a> TryFrom<&'a ReshareChainKeyContext> for NiDkgReshareChainKeyContext<'a> {
+    type Error = &'static str;
+
+    fn try_from(context: &'a ReshareChainKeyContext) -> Result<Self, Self::Error> {
+        let key_id = NiDkgMasterPublicKeyId::try_from(context.key_id.clone())?;
+        Ok(NiDkgReshareChainKeyContext { context, key_id })
+    }
+}
+
+enum RemoteDkgContext<'a> {
+    SetupInitialDKG(&'a SetupInitialDkgContext),
+    ReshareChainKey(NiDkgReshareChainKeyContext<'a>),
+}
+
+impl<'a> RemoteDkgContext<'a> {
+    fn target_id(&self) -> &'a NiDkgTargetId {
+        match self {
+            RemoteDkgContext::SetupInitialDKG(context) => &context.target_id,
+            RemoteDkgContext::ReshareChainKey(context) => &context.context.target_id,
+        }
+    }
+
+    fn registry_version(&self) -> RegistryVersion {
+        match self {
+            RemoteDkgContext::SetupInitialDKG(context) => context.registry_version,
+            RemoteDkgContext::ReshareChainKey(context) => context.context.registry_version,
+        }
+    }
+
+    fn generate_timeout_errors(
+        &self,
+        start_block_height: Height,
+        dealer_subnet: SubnetId,
+    ) -> Vec<(NiDkgId, String)> {
+        let tags = match self {
+            RemoteDkgContext::SetupInitialDKG(_) => {
+                vec![NiDkgTag::LowThreshold, NiDkgTag::HighThreshold]
+            }
+            RemoteDkgContext::ReshareChainKey(context) => {
+                vec![NiDkgTag::HighThresholdForKey(context.key_id.clone())]
+            }
+        };
+        tags.into_iter()
+            .map(|dkg_tag| {
+                (
+                    NiDkgId {
+                        start_block_height,
+                        dealer_subnet,
+                        dkg_tag,
+                        target_subnet: NiDkgTargetSubnet::Remote(self.target_id().clone()),
+                    },
+                    REMOTE_DKG_REPEATED_FAILURE_ERROR.to_string(),
+                )
+            })
+            .collect()
+    }
+
+    fn create_configs(
+        &self,
+        start_block_height: Height,
+        dealer_subnet: SubnetId,
+        registry_client: &dyn RegistryClient,
+        get_reshare_transcript: impl Fn(&NiDkgTag) -> Option<NiDkgTranscript>,
+        logger: &ReplicaLogger,
+    ) -> Result<ConfigResult, DkgPayloadCreationError> {
+        let config_result = match self {
+            RemoteDkgContext::SetupInitialDKG(context) => {
+                let dealers =
+                    get_node_list(dealer_subnet, registry_client, context.registry_version)?;
+                create_low_high_remote_dkg_configs(
+                    start_block_height,
+                    dealer_subnet,
+                    context.target_id,
+                    &dealers,
+                    &context.nodes_in_target_subnet,
+                    &context.registry_version,
+                    logger,
+                )
+                .map(|(config0, config1)| vec![config0, config1])
+            }
+            RemoteDkgContext::ReshareChainKey(context) => create_remote_dkg_config_for_key_id(
+                context.key_id.clone(),
+                start_block_height,
+                dealer_subnet,
+                context.context.target_id,
+                &context.context.nodes,
+                get_reshare_transcript,
+                &context.context.registry_version,
+            )
+            .map(|config| vec![config])
+            .map_err(|err_box| vec![*err_box]),
+        };
+        Ok(config_result)
+    }
+}
+
+/// Builds a map from callback ids to config results for all remote DKG contexts
+/// found in the given replicated state.
+pub(crate) fn build_callback_id_config_map(
+    this_subnet_id: SubnetId,
+    registry_client: &dyn RegistryClient,
+    state: &ReplicatedState,
+    registry_version: RegistryVersion,
+    dkg_summary: &DkgSummary,
+    logger: &ReplicaLogger,
+) -> Result<BTreeMap<CallbackId, ConfigResult>, DkgPayloadCreationError> {
+    let mut callback_id_config_map = BTreeMap::new();
+    let call_contexts = &state.metadata.subnet_call_context_manager;
+    let remote_dkg_attempts = &dkg_summary.initial_dkg_attempts;
+
+    // Iterate over all context types
+    let setup_contexts = call_contexts
+        .setup_initial_dkg_contexts
+        .iter()
+        .map(|(&callback_id, context)| (callback_id, RemoteDkgContext::SetupInitialDKG(context)));
+    let reshare_contexts =
+        call_contexts
+            .reshare_chain_key_contexts
+            .iter()
+            .filter_map(|(&callback_id, context)| {
+                // Filter out IDKG contexts.
+                NiDkgReshareChainKeyContext::try_from(context)
+                    .ok()
+                    .map(|context| (callback_id, RemoteDkgContext::ReshareChainKey(context)))
+            });
+
+    let get_reshare_transcript = |tag: &NiDkgTag| {
+        dkg_summary
+            .next_transcripts()
+            .get(tag)
+            .cloned()
+            .or_else(|| dkg_summary.current_transcripts().get(tag).cloned())
+    };
+
+    for (callback_id, context) in setup_contexts.chain(reshare_contexts) {
+        if context.registry_version() > registry_version {
+            // Skip contexts with a registry version that hasn't been reached yet
+            continue;
+        }
+
+        if let Some(&attempts) = remote_dkg_attempts.get(context.target_id()) {
+            if attempts == 0 {
+                // An attempt count of 0 means that the context has already been completed
+                // in the last interval. We skip the context to avoid handling it again in
+                // the current interval.
+                continue;
+            }
+            if attempts > MAX_REMOTE_DKG_ATTEMPTS {
+                // Add timeout errors for contexts that have been attempted too many times
+                callback_id_config_map.insert(
+                    callback_id,
+                    Err(context.generate_timeout_errors(dkg_summary.height, this_subnet_id)),
+                );
+                continue;
+            }
+        }
+
+        // Create configs for the context and insert them into the map
+        callback_id_config_map.insert(
+            callback_id,
+            context.create_configs(
+                dkg_summary.height,
+                this_subnet_id,
+                registry_client,
+                get_reshare_transcript,
+                logger,
+            )?,
+        );
+    }
+
+    Ok(callback_id_config_map)
+}
+
+/// Merges the configs from the summary and the configs from the request contexts.
+pub(crate) fn merge_configs<'a>(
+    summary_configs: &'a BTreeMap<NiDkgId, NiDkgConfig>,
+    config_results: &'a BTreeMap<CallbackId, ConfigResult>,
+) -> BTreeMap<&'a NiDkgId, &'a NiDkgConfig> {
+    let mut merged_configs: BTreeMap<&NiDkgId, &NiDkgConfig> = summary_configs.iter().collect();
+    for configs in config_results.values().flatten() {
+        for config in configs {
+            merged_configs.insert(config.dkg_id(), config);
+        }
+    }
+    merged_configs
+}
+
 /// This function is called on each entry on the SetupInitialDkgContext. It returns
 /// either the created high and low configs for the entry or returns two errors
 /// identified by the NiDkgId.
@@ -1020,7 +1221,7 @@ fn create_remote_dkg_config_for_key_id(
     dealer_subnet: SubnetId,
     target_id: NiDkgTargetId,
     receivers: &BTreeSet<NodeId>,
-    reshared_transcripts: &BTreeMap<NiDkgTag, NiDkgTranscript>,
+    get_reshare_transcript: impl Fn(&NiDkgTag) -> Option<NiDkgTranscript>,
     registry_version: &RegistryVersion,
 ) -> Result<NiDkgConfig, Box<(NiDkgId, String)>> {
     let dkg_id = NiDkgId {
@@ -1031,17 +1232,18 @@ fn create_remote_dkg_config_for_key_id(
     };
 
     // Find the resharing transcript corresponding to the remote dkg id
-    let Some(resharing_transcript) = reshared_transcripts.get(&dkg_id.dkg_tag) else {
+    let Some(resharing_transcript) = get_reshare_transcript(&dkg_id.dkg_tag) else {
         let err = format!(
             "Failed to find resharing transcript for a remote dkg for tag {:?}",
             &dkg_id.dkg_tag
         );
         return Err(Box::new((dkg_id, err)));
     };
+    let dealers = resharing_transcript.committee.clone();
 
     create_remote_dkg_config(
         dkg_id.clone(),
-        resharing_transcript.committee.get(),
+        dealers.get(),
         receivers,
         registry_version,
         Some(resharing_transcript.clone()),
@@ -1081,14 +1283,19 @@ mod tests {
     };
     use ic_crypto_test_utils_ni_dkg::dummy_transcript_for_tests_with_params;
     use ic_logger::replica_logger::no_op_logger;
-    use ic_management_canister_types_private::{VetKdCurve, VetKdKeyId};
+    use ic_management_canister_types_private::{
+        EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, VetKdCurve, VetKdKeyId,
+    };
     use ic_registry_client_helpers::subnet::SubnetRegistry;
     use ic_test_utilities_logger::with_test_replica_logger;
-    use ic_test_utilities_registry::{SubnetRecordBuilder, add_subnet_record};
+    use ic_test_utilities_registry::{SubnetRecordBuilder, add_subnet_record, setup_registry};
+    use ic_test_utilities_state::ReplicatedStateBuilder;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
+    use ic_test_utilities_types::messages::RequestBuilder;
     use ic_types::{
         RegistryVersion,
         crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet},
+        messages::CallbackId,
         time::UNIX_EPOCH,
     };
     use std::collections::BTreeSet;
@@ -1238,13 +1445,14 @@ mod tests {
         let mut reshared_transcripts = BTreeMap::new();
         reshared_transcripts.insert(tag, resharing_transcript.clone());
 
+        let get_reshare_transcript = |tag: &NiDkgTag| reshared_transcripts.get(tag).cloned();
         let config = super::create_remote_dkg_config_for_key_id(
             key_id,
             start_block_height,
             dealer_subnet,
             target_id,
             &receivers,
-            &reshared_transcripts,
+            get_reshare_transcript,
             &registry_version,
         )
         .expect("expected remote DKG config for resharing");
@@ -1253,6 +1461,353 @@ mod tests {
             config.dealers().get(),
             resharing_transcript.committee.get(),
             "dealers must be the committee of the transcript being reshared"
+        );
+    }
+
+    fn test_dkg_summary(
+        height: Height,
+        current_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
+        next_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
+        initial_dkg_attempts: BTreeMap<NiDkgTargetId, u32>,
+    ) -> DkgSummary {
+        DkgSummary::new(
+            vec![],
+            current_transcripts,
+            next_transcripts,
+            vec![],
+            RegistryVersion::from(1),
+            Height::from(10),
+            Height::from(10),
+            height,
+            initial_dkg_attempts,
+        )
+    }
+
+    fn test_setup_initial_dkg_context(
+        target_id: NiDkgTargetId,
+        registry_version: RegistryVersion,
+        nodes_in_target_subnet: BTreeSet<NodeId>,
+    ) -> SetupInitialDkgContext {
+        SetupInitialDkgContext {
+            request: RequestBuilder::default().build(),
+            nodes_in_target_subnet,
+            target_id,
+            registry_version,
+            time: UNIX_EPOCH,
+        }
+    }
+
+    fn test_reshare_chain_key_context(
+        key_id: MasterPublicKeyId,
+        target_id: NiDkgTargetId,
+        registry_version: RegistryVersion,
+        nodes: BTreeSet<NodeId>,
+    ) -> ReshareChainKeyContext {
+        ReshareChainKeyContext {
+            request: RequestBuilder::default().build(),
+            key_id,
+            nodes,
+            registry_version,
+            time: UNIX_EPOCH,
+            target_id,
+        }
+    }
+
+    #[test]
+    fn test_build_callback_id_config_map_setup_initial_dkg() {
+        let this_subnet_id = subnet_test_id(10);
+        let dealers: Vec<_> = (0..4).map(node_test_id).collect();
+        let registry = setup_registry(
+            this_subnet_id,
+            vec![(1, SubnetRecordBuilder::from(&dealers).build())],
+        );
+
+        let target_id = NiDkgTargetId::new([1_u8; 32]);
+        let target_id2 = NiDkgTargetId::new([2_u8; 32]);
+        let target_id3 = NiDkgTargetId::new([3_u8; 32]);
+        let callback_id = CallbackId::from(1);
+        let mut state = ReplicatedStateBuilder::new()
+            .with_subnet_id(this_subnet_id)
+            .build();
+        state
+            .metadata
+            .subnet_call_context_manager
+            .setup_initial_dkg_contexts
+            .insert(
+                callback_id,
+                test_setup_initial_dkg_context(
+                    target_id,
+                    RegistryVersion::from(1),
+                    (10..14).map(node_test_id).collect(),
+                ),
+            );
+        // Second setup initial DKG context with a registry version that hasn't been reached yet.
+        state
+            .metadata
+            .subnet_call_context_manager
+            .setup_initial_dkg_contexts
+            .insert(
+                CallbackId::from(2),
+                test_setup_initial_dkg_context(
+                    target_id2,
+                    RegistryVersion::from(10),
+                    (10..14).map(node_test_id).collect(),
+                ),
+            );
+        state
+            .metadata
+            .subnet_call_context_manager
+            .reshare_chain_key_contexts
+            .insert(
+                CallbackId::from(3),
+                test_reshare_chain_key_context(
+                    MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+                        curve: EcdsaCurve::Secp256k1,
+                        name: "idkg_key".to_string(),
+                    }),
+                    target_id3,
+                    RegistryVersion::from(1),
+                    (10..14).map(node_test_id).collect(),
+                ),
+            );
+
+        let dkg_summary = test_dkg_summary(
+            Height::from(100),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        let map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &dkg_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+        assert_eq!(map.len(), 1);
+        let configs = map
+            .get(&callback_id)
+            .expect("missing callback entry")
+            .as_ref()
+            .expect("expected successful configs");
+        assert_eq!(configs.len(), 2);
+
+        let tags = configs
+            .iter()
+            .map(|config| config.dkg_id().dkg_tag.clone())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            tags,
+            BTreeSet::from([NiDkgTag::LowThreshold, NiDkgTag::HighThreshold])
+        );
+        assert!(configs.iter().all(|config| {
+            config.dkg_id().dealer_subnet == this_subnet_id
+                && config.dkg_id().target_subnet == NiDkgTargetSubnet::Remote(target_id)
+        }));
+
+        // Zero attempts => context must be skipped.
+        let zero_attempts_summary = test_dkg_summary(
+            Height::from(101),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::from([(target_id, 0), (target_id2, 0), (target_id3, 0)]),
+        );
+        let zero_attempts_map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &zero_attempts_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+        assert!(zero_attempts_map.is_empty());
+
+        // Attempts above the max => timeout errors must be returned.
+        let max_attempts_summary = test_dkg_summary(
+            Height::from(102),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::from([
+                (target_id, MAX_REMOTE_DKG_ATTEMPTS + 1),
+                (target_id2, MAX_REMOTE_DKG_ATTEMPTS + 1),
+                (target_id3, MAX_REMOTE_DKG_ATTEMPTS + 1),
+            ]),
+        );
+        let max_attempts_map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &max_attempts_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+        assert_eq!(max_attempts_map.len(), 1);
+        let timeout_errors = max_attempts_map
+            .get(&callback_id)
+            .expect("missing callback entry for timeout path")
+            .as_ref()
+            .expect_err("expected timeout errors");
+        assert_eq!(timeout_errors.len(), 2);
+        assert!(
+            timeout_errors
+                .iter()
+                .all(|(_, err)| err == REMOTE_DKG_REPEATED_FAILURE_ERROR)
+        );
+        assert_eq!(
+            timeout_errors
+                .iter()
+                .map(|(id, _)| id.dkg_tag.clone())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([NiDkgTag::LowThreshold, NiDkgTag::HighThreshold])
+        );
+
+        // Setup context creation error should be propagated.
+        state
+            .metadata
+            .subnet_call_context_manager
+            .setup_initial_dkg_contexts
+            .insert(
+                CallbackId::from(2),
+                test_setup_initial_dkg_context(
+                    target_id2,
+                    RegistryVersion::from(2),
+                    (10..14).map(node_test_id).collect(),
+                ),
+            );
+        let setup_error_summary = test_dkg_summary(
+            Height::from(103),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        let result = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(2),
+            &setup_error_summary,
+            &no_op_logger(),
+        );
+        assert!(matches!(
+            result,
+            Err(DkgPayloadCreationError::FailedToGetSubnetMemberListFromRegistry(_))
+        ));
+    }
+
+    #[test]
+    fn test_build_callback_id_config_map_reshare_chain_key() {
+        let this_subnet_id = subnet_test_id(20);
+        let dealers: Vec<_> = (0..4).map(node_test_id).collect();
+        let registry = setup_registry(
+            this_subnet_id,
+            vec![(1, SubnetRecordBuilder::from(&dealers).build())],
+        );
+
+        let vet_key_id = VetKdKeyId {
+            curve: VetKdCurve::Bls12_381_G2,
+            name: "key_a".to_string(),
+        };
+        let ni_dkg_key_id = NiDkgMasterPublicKeyId::VetKd(vet_key_id.clone());
+        let tag = NiDkgTag::HighThresholdForKey(ni_dkg_key_id.clone());
+        let transcript_committee: Vec<_> = (50..54).map(node_test_id).collect();
+        let transcript = dummy_transcript_for_tests_with_params(
+            transcript_committee.clone(),
+            tag.clone(),
+            tag.threshold_for_subnet_of_size(transcript_committee.len()) as u32,
+            1,
+        );
+        let current_transcript_committee: Vec<_> = (90..94).map(node_test_id).collect();
+        let current_transcript = dummy_transcript_for_tests_with_params(
+            current_transcript_committee.clone(),
+            tag.clone(),
+            tag.threshold_for_subnet_of_size(current_transcript_committee.len()) as u32,
+            1,
+        );
+
+        let target_id = NiDkgTargetId::new([2_u8; 32]);
+        let callback_id = CallbackId::from(2);
+        let mut state = ReplicatedStateBuilder::new()
+            .with_subnet_id(this_subnet_id)
+            .build();
+        state
+            .metadata
+            .subnet_call_context_manager
+            .reshare_chain_key_contexts
+            .insert(
+                callback_id,
+                test_reshare_chain_key_context(
+                    MasterPublicKeyId::VetKd(vet_key_id),
+                    target_id,
+                    RegistryVersion::from(1),
+                    (60..64).map(node_test_id).collect(),
+                ),
+            );
+
+        let dkg_summary = test_dkg_summary(
+            Height::from(101),
+            BTreeMap::from([(tag.clone(), current_transcript.clone())]),
+            BTreeMap::from([(tag, transcript.clone())]),
+            BTreeMap::new(),
+        );
+        let map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &dkg_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+
+        let configs = map
+            .get(&callback_id)
+            .expect("missing callback entry")
+            .as_ref()
+            .expect("expected successful configs");
+        assert_eq!(configs.len(), 1);
+        let config = &configs[0];
+        assert_eq!(config.resharing_transcript().as_ref(), Some(&transcript));
+        assert_ne!(
+            config.resharing_transcript().as_ref(),
+            Some(&current_transcript)
+        );
+        assert_eq!(config.dealers().get(), transcript.committee.get());
+        assert_ne!(config.dealers().get(), current_transcript.committee.get());
+
+        // Re-run with no available transcripts and assert per-context error.
+        let missing_transcript_summary = test_dkg_summary(
+            Height::from(102),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        let missing_transcript_map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &missing_transcript_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+        let errors = missing_transcript_map
+            .get(&callback_id)
+            .expect("missing callback entry")
+            .as_ref()
+            .expect_err("expected per-context reshare error");
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].0.dkg_tag,
+            NiDkgTag::HighThresholdForKey(ni_dkg_key_id)
+        );
+        assert!(
+            errors[0]
+                .1
+                .contains("Failed to find resharing transcript for a remote dkg")
         );
     }
 
@@ -2034,6 +2589,43 @@ mod tests {
             dkg_tag: tag,
             target_subnet: NiDkgTargetSubnet::Remote(NiDkgTargetId::new(target_id)),
         }
+    }
+
+    #[test]
+    fn test_merge_configs_merges_successes_and_ignores_errors() {
+        let summary_only_id = local_dkg_id(NiDkgTag::LowThreshold);
+        let overlap_id = remote_dkg_id_with_target(NiDkgTag::HighThreshold, [11_u8; 32]);
+        let context_only_id = remote_dkg_id_with_target(NiDkgTag::LowThreshold, [11_u8; 32]);
+        let error_only_id = remote_dkg_id_with_target(NiDkgTag::LowThreshold, [12_u8; 32]);
+
+        let summary_only_config = make_test_config(summary_only_id.clone(), 1);
+        let overlap_config = make_test_config(overlap_id.clone(), 1);
+        let context_only_config = make_test_config(context_only_id.clone(), 1);
+
+        let summary_configs: BTreeMap<_, _> = [
+            (summary_only_id.clone(), summary_only_config),
+            (overlap_id.clone(), overlap_config.clone()),
+        ]
+        .into();
+        let config_results: BTreeMap<_, _> = [
+            (
+                CallbackId::from(1),
+                Ok(vec![overlap_config.clone(), context_only_config.clone()]),
+            ),
+            (
+                CallbackId::from(2),
+                Err(vec![(error_only_id.clone(), "test error".to_string())]),
+            ),
+        ]
+        .into();
+
+        let merged = merge_configs(&summary_configs, &config_results);
+
+        assert_eq!(merged.len(), 3);
+        assert!(merged.contains_key(&summary_only_id));
+        assert!(merged.contains_key(&overlap_id));
+        assert!(merged.contains_key(&context_only_id));
+        assert!(!merged.contains_key(&error_only_id));
     }
 
     #[test]

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -146,7 +146,7 @@ impl<'a> RemoteDkgContext<'a> {
 /// Builds a map from callback ids to config results for all remote DKG contexts
 /// found in the given replicated state.
 pub(crate) fn build_callback_id_config_map(
-    this_subnet_id: SubnetId,
+    dealer_subnet: SubnetId,
     registry_client: &dyn RegistryClient,
     state: &ReplicatedState,
     registry_version: RegistryVersion,
@@ -190,7 +190,7 @@ pub(crate) fn build_callback_id_config_map(
                 // Add timeout errors for contexts that have been attempted too many times
                 callback_id_config_map.insert(
                     callback_id,
-                    Err(context.generate_timeout_errors(dkg_summary.height, this_subnet_id)),
+                    Err(context.generate_timeout_errors(dkg_summary.height, dealer_subnet)),
                 );
                 continue;
             }
@@ -199,7 +199,7 @@ pub(crate) fn build_callback_id_config_map(
         // Create configs for the context and insert them into the map
         callback_id_config_map.insert(
             callback_id,
-            context.create_configs(dkg_summary, this_subnet_id, registry_client, logger)?,
+            context.create_configs(dkg_summary, dealer_subnet, registry_client, logger)?,
         );
     }
 
@@ -294,10 +294,10 @@ mod tests {
 
     #[test]
     fn test_build_callback_id_config_map_setup_initial_dkg() {
-        let this_subnet_id = subnet_test_id(10);
+        let dealer_subnet = subnet_test_id(10);
         let dealers: Vec<_> = (0..4).map(node_test_id).collect();
         let registry = setup_registry(
-            this_subnet_id,
+            dealer_subnet,
             vec![(1, SubnetRecordBuilder::from(&dealers).build())],
         );
 
@@ -306,7 +306,7 @@ mod tests {
         let target_id3 = NiDkgTargetId::new([3_u8; 32]);
         let callback_id = CallbackId::from(1);
         let mut state = ReplicatedStateBuilder::new()
-            .with_subnet_id(this_subnet_id)
+            .with_subnet_id(dealer_subnet)
             .build();
         state
             .metadata
@@ -356,7 +356,7 @@ mod tests {
             BTreeMap::new(),
         );
         let map = build_callback_id_config_map(
-            this_subnet_id,
+            dealer_subnet,
             registry.as_ref(),
             &state,
             RegistryVersion::from(1),
@@ -381,7 +381,7 @@ mod tests {
             BTreeSet::from([NiDkgTag::LowThreshold, NiDkgTag::HighThreshold])
         );
         assert!(configs.iter().all(|config| {
-            config.dkg_id().dealer_subnet == this_subnet_id
+            config.dkg_id().dealer_subnet == dealer_subnet
                 && config.dkg_id().target_subnet == NiDkgTargetSubnet::Remote(target_id)
         }));
 
@@ -393,7 +393,7 @@ mod tests {
             BTreeMap::from([(target_id, 0), (target_id2, 0), (target_id3, 0)]),
         );
         let zero_attempts_map = build_callback_id_config_map(
-            this_subnet_id,
+            dealer_subnet,
             registry.as_ref(),
             &state,
             RegistryVersion::from(1),
@@ -415,7 +415,7 @@ mod tests {
             ]),
         );
         let max_attempts_map = build_callback_id_config_map(
-            this_subnet_id,
+            dealer_subnet,
             registry.as_ref(),
             &state,
             RegistryVersion::from(1),
@@ -463,7 +463,7 @@ mod tests {
             BTreeMap::new(),
         );
         let result = build_callback_id_config_map(
-            this_subnet_id,
+            dealer_subnet,
             registry.as_ref(),
             &state,
             RegistryVersion::from(2),
@@ -478,10 +478,10 @@ mod tests {
 
     #[test]
     fn test_build_callback_id_config_map_reshare_chain_key() {
-        let this_subnet_id = subnet_test_id(20);
+        let dealer_subnet = subnet_test_id(20);
         let dealers: Vec<_> = (0..4).map(node_test_id).collect();
         let registry = setup_registry(
-            this_subnet_id,
+            dealer_subnet,
             vec![(1, SubnetRecordBuilder::from(&dealers).build())],
         );
 
@@ -509,7 +509,7 @@ mod tests {
         let target_id = NiDkgTargetId::new([2_u8; 32]);
         let callback_id = CallbackId::from(2);
         let mut state = ReplicatedStateBuilder::new()
-            .with_subnet_id(this_subnet_id)
+            .with_subnet_id(dealer_subnet)
             .build();
         state
             .metadata
@@ -532,7 +532,7 @@ mod tests {
             BTreeMap::new(),
         );
         let map = build_callback_id_config_map(
-            this_subnet_id,
+            dealer_subnet,
             registry.as_ref(),
             &state,
             RegistryVersion::from(1),
@@ -563,7 +563,7 @@ mod tests {
             BTreeMap::new(),
         );
         let missing_transcript_map = build_callback_id_config_map(
-            this_subnet_id,
+            dealer_subnet,
             registry.as_ref(),
             &state,
             RegistryVersion::from(1),

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -1,0 +1,648 @@
+#![allow(dead_code)]
+
+use crate::{
+    MAX_REMOTE_DKG_ATTEMPTS, REMOTE_DKG_REPEATED_FAILURE_ERROR,
+    payload_builder::{
+        create_low_high_remote_dkg_configs, create_remote_dkg_config_for_key_id, get_node_list,
+    },
+};
+use ic_interfaces_registry::RegistryClient;
+use ic_logger::ReplicaLogger;
+use ic_replicated_state::{
+    ReplicatedState,
+    metadata_state::subnet_call_context_manager::{ReshareChainKeyContext, SetupInitialDkgContext},
+};
+use ic_types::{
+    Height, RegistryVersion, SubnetId,
+    consensus::dkg::{DkgPayloadCreationError, DkgSummary},
+    crypto::threshold_sig::ni_dkg::{
+        NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
+        NiDkgTranscript, config::NiDkgConfig,
+    },
+    messages::CallbackId,
+};
+use std::collections::BTreeMap;
+
+/// The result of creating DKG configs for a given request context.
+pub(crate) type ConfigResult = Result<Vec<NiDkgConfig>, Vec<(NiDkgId, String)>>;
+
+/// A wrapper around the ReshareChainKeyContexts to be handled by the NiDKG module.
+struct NiDkgReshareChainKeyContext<'a> {
+    context: &'a ReshareChainKeyContext,
+    key_id: NiDkgMasterPublicKeyId,
+}
+
+impl<'a> TryFrom<&'a ReshareChainKeyContext> for NiDkgReshareChainKeyContext<'a> {
+    type Error = &'static str;
+
+    fn try_from(context: &'a ReshareChainKeyContext) -> Result<Self, Self::Error> {
+        let key_id = NiDkgMasterPublicKeyId::try_from(context.key_id.clone())?;
+        Ok(NiDkgReshareChainKeyContext { context, key_id })
+    }
+}
+
+enum RemoteDkgContext<'a> {
+    SetupInitialDKG(&'a SetupInitialDkgContext),
+    ReshareChainKey(NiDkgReshareChainKeyContext<'a>),
+}
+
+impl<'a> RemoteDkgContext<'a> {
+    fn target_id(&self) -> &'a NiDkgTargetId {
+        match self {
+            RemoteDkgContext::SetupInitialDKG(context) => &context.target_id,
+            RemoteDkgContext::ReshareChainKey(context) => &context.context.target_id,
+        }
+    }
+
+    fn registry_version(&self) -> RegistryVersion {
+        match self {
+            RemoteDkgContext::SetupInitialDKG(context) => context.registry_version,
+            RemoteDkgContext::ReshareChainKey(context) => context.context.registry_version,
+        }
+    }
+
+    fn generate_timeout_errors(
+        &self,
+        start_block_height: Height,
+        dealer_subnet: SubnetId,
+    ) -> Vec<(NiDkgId, String)> {
+        let tags = match self {
+            RemoteDkgContext::SetupInitialDKG(_) => {
+                vec![NiDkgTag::LowThreshold, NiDkgTag::HighThreshold]
+            }
+            RemoteDkgContext::ReshareChainKey(context) => {
+                vec![NiDkgTag::HighThresholdForKey(context.key_id.clone())]
+            }
+        };
+        tags.into_iter()
+            .map(|dkg_tag| {
+                (
+                    NiDkgId {
+                        start_block_height,
+                        dealer_subnet,
+                        dkg_tag,
+                        target_subnet: NiDkgTargetSubnet::Remote(*self.target_id()),
+                    },
+                    REMOTE_DKG_REPEATED_FAILURE_ERROR.to_string(),
+                )
+            })
+            .collect()
+    }
+
+    fn create_configs(
+        &self,
+        start_block_height: Height,
+        dealer_subnet: SubnetId,
+        registry_client: &dyn RegistryClient,
+        get_reshare_transcript: impl Fn(&NiDkgTag) -> Option<NiDkgTranscript>,
+        logger: &ReplicaLogger,
+    ) -> Result<ConfigResult, DkgPayloadCreationError> {
+        let config_result = match self {
+            RemoteDkgContext::SetupInitialDKG(context) => {
+                let dealers =
+                    get_node_list(dealer_subnet, registry_client, context.registry_version)?;
+                create_low_high_remote_dkg_configs(
+                    start_block_height,
+                    dealer_subnet,
+                    context.target_id,
+                    &dealers,
+                    &context.nodes_in_target_subnet,
+                    &context.registry_version,
+                    logger,
+                )
+                .map(|(config0, config1)| vec![config0, config1])
+            }
+            RemoteDkgContext::ReshareChainKey(context) => create_remote_dkg_config_for_key_id(
+                context.key_id.clone(),
+                start_block_height,
+                dealer_subnet,
+                context.context.target_id,
+                &context.context.nodes,
+                get_reshare_transcript,
+                &context.context.registry_version,
+            )
+            .map(|config| vec![config])
+            .map_err(|err_box| vec![*err_box]),
+        };
+        Ok(config_result)
+    }
+}
+
+/// Builds a map from callback ids to config results for all remote DKG contexts
+/// found in the given replicated state.
+pub(crate) fn build_callback_id_config_map(
+    this_subnet_id: SubnetId,
+    registry_client: &dyn RegistryClient,
+    state: &ReplicatedState,
+    registry_version: RegistryVersion,
+    dkg_summary: &DkgSummary,
+    logger: &ReplicaLogger,
+) -> Result<BTreeMap<CallbackId, ConfigResult>, DkgPayloadCreationError> {
+    let mut callback_id_config_map = BTreeMap::new();
+    let call_contexts = &state.metadata.subnet_call_context_manager;
+    let remote_dkg_attempts = &dkg_summary.initial_dkg_attempts;
+
+    let setup_contexts = call_contexts
+        .setup_initial_dkg_contexts
+        .iter()
+        .map(|(&callback_id, context)| (callback_id, RemoteDkgContext::SetupInitialDKG(context)));
+    let reshare_contexts =
+        call_contexts
+            .reshare_chain_key_contexts
+            .iter()
+            .filter_map(|(&callback_id, context)| {
+                NiDkgReshareChainKeyContext::try_from(context)
+                    .ok()
+                    .map(|context| (callback_id, RemoteDkgContext::ReshareChainKey(context)))
+            });
+
+    let get_reshare_transcript = |tag: &NiDkgTag| {
+        dkg_summary
+            .next_transcripts()
+            .get(tag)
+            .cloned()
+            .or_else(|| dkg_summary.current_transcripts().get(tag).cloned())
+    };
+
+    for (callback_id, context) in setup_contexts.chain(reshare_contexts) {
+        if context.registry_version() > registry_version {
+            continue;
+        }
+
+        if let Some(&attempts) = remote_dkg_attempts.get(context.target_id()) {
+            if attempts == 0 {
+                continue;
+            }
+            if attempts > MAX_REMOTE_DKG_ATTEMPTS {
+                callback_id_config_map.insert(
+                    callback_id,
+                    Err(context.generate_timeout_errors(dkg_summary.height, this_subnet_id)),
+                );
+                continue;
+            }
+        }
+
+        callback_id_config_map.insert(
+            callback_id,
+            context.create_configs(
+                dkg_summary.height,
+                this_subnet_id,
+                registry_client,
+                get_reshare_transcript,
+                logger,
+            )?,
+        );
+    }
+
+    Ok(callback_id_config_map)
+}
+
+/// Merges the configs from the summary and the configs from the request contexts.
+pub(crate) fn merge_configs<'a>(
+    summary_configs: &'a BTreeMap<NiDkgId, NiDkgConfig>,
+    config_results: &'a BTreeMap<CallbackId, ConfigResult>,
+) -> BTreeMap<&'a NiDkgId, &'a NiDkgConfig> {
+    let mut merged_configs: BTreeMap<&NiDkgId, &NiDkgConfig> = summary_configs.iter().collect();
+    for configs in config_results.values().flatten() {
+        for config in configs {
+            merged_configs.insert(config.dkg_id(), config);
+        }
+    }
+    merged_configs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ic_crypto_test_utils_ni_dkg::dummy_transcript_for_tests_with_params;
+    use ic_logger::replica_logger::no_op_logger;
+    use ic_management_canister_types_private::{
+        EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, VetKdCurve, VetKdKeyId,
+    };
+    use ic_replicated_state::metadata_state::subnet_call_context_manager::{
+        ReshareChainKeyContext, SetupInitialDkgContext,
+    };
+    use ic_test_utilities_registry::{SubnetRecordBuilder, setup_registry};
+    use ic_test_utilities_state::ReplicatedStateBuilder;
+    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
+    use ic_test_utilities_types::messages::RequestBuilder;
+    use ic_types::{
+        NodeId, NumberOfNodes, RegistryVersion,
+        crypto::threshold_sig::ni_dkg::{NiDkgTag, NiDkgTargetSubnet, config::NiDkgConfigData},
+        messages::CallbackId,
+        time::UNIX_EPOCH,
+    };
+    use std::collections::BTreeSet;
+
+    fn test_dkg_summary(
+        height: Height,
+        current_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
+        next_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
+        initial_dkg_attempts: BTreeMap<NiDkgTargetId, u32>,
+    ) -> DkgSummary {
+        DkgSummary::new(
+            vec![],
+            current_transcripts,
+            next_transcripts,
+            vec![],
+            RegistryVersion::from(1),
+            Height::from(10),
+            Height::from(10),
+            height,
+            initial_dkg_attempts,
+        )
+    }
+
+    fn test_setup_initial_dkg_context(
+        target_id: NiDkgTargetId,
+        registry_version: RegistryVersion,
+        nodes_in_target_subnet: BTreeSet<NodeId>,
+    ) -> SetupInitialDkgContext {
+        SetupInitialDkgContext {
+            request: RequestBuilder::default().build(),
+            nodes_in_target_subnet,
+            target_id,
+            registry_version,
+            time: UNIX_EPOCH,
+        }
+    }
+
+    fn test_reshare_chain_key_context(
+        key_id: MasterPublicKeyId,
+        target_id: NiDkgTargetId,
+        registry_version: RegistryVersion,
+        nodes: BTreeSet<NodeId>,
+    ) -> ReshareChainKeyContext {
+        ReshareChainKeyContext {
+            request: RequestBuilder::default().build(),
+            key_id,
+            nodes,
+            registry_version,
+            time: UNIX_EPOCH,
+            target_id,
+        }
+    }
+
+    fn make_test_config(dkg_id: NiDkgId, max_corrupt_dealers: u32) -> NiDkgConfig {
+        let nodes: BTreeSet<_> = (0..10).map(node_test_id).collect();
+        NiDkgConfig::new(NiDkgConfigData {
+            dkg_id,
+            max_corrupt_dealers: NumberOfNodes::from(max_corrupt_dealers),
+            dealers: nodes.clone(),
+            max_corrupt_receivers: NumberOfNodes::from(1),
+            receivers: nodes,
+            threshold: NumberOfNodes::from(2),
+            registry_version: RegistryVersion::from(1),
+            resharing_transcript: None,
+        })
+        .unwrap()
+    }
+
+    fn local_dkg_id(tag: NiDkgTag) -> NiDkgId {
+        NiDkgId {
+            start_block_height: Height::from(0),
+            dealer_subnet: subnet_test_id(0),
+            dkg_tag: tag,
+            target_subnet: NiDkgTargetSubnet::Local,
+        }
+    }
+
+    fn remote_dkg_id_with_target(tag: NiDkgTag, target_id: [u8; 32]) -> NiDkgId {
+        NiDkgId {
+            start_block_height: Height::from(0),
+            dealer_subnet: subnet_test_id(0),
+            dkg_tag: tag,
+            target_subnet: NiDkgTargetSubnet::Remote(NiDkgTargetId::new(target_id)),
+        }
+    }
+
+    #[test]
+    fn test_build_callback_id_config_map_setup_initial_dkg() {
+        let this_subnet_id = subnet_test_id(10);
+        let dealers: Vec<_> = (0..4).map(node_test_id).collect();
+        let registry = setup_registry(
+            this_subnet_id,
+            vec![(1, SubnetRecordBuilder::from(&dealers).build())],
+        );
+
+        let target_id = NiDkgTargetId::new([1_u8; 32]);
+        let target_id2 = NiDkgTargetId::new([2_u8; 32]);
+        let target_id3 = NiDkgTargetId::new([3_u8; 32]);
+        let callback_id = CallbackId::from(1);
+        let mut state = ReplicatedStateBuilder::new()
+            .with_subnet_id(this_subnet_id)
+            .build();
+        state
+            .metadata
+            .subnet_call_context_manager
+            .setup_initial_dkg_contexts
+            .insert(
+                callback_id,
+                test_setup_initial_dkg_context(
+                    target_id,
+                    RegistryVersion::from(1),
+                    (10..14).map(node_test_id).collect(),
+                ),
+            );
+        state
+            .metadata
+            .subnet_call_context_manager
+            .setup_initial_dkg_contexts
+            .insert(
+                CallbackId::from(2),
+                test_setup_initial_dkg_context(
+                    target_id2,
+                    RegistryVersion::from(10),
+                    (10..14).map(node_test_id).collect(),
+                ),
+            );
+        state
+            .metadata
+            .subnet_call_context_manager
+            .reshare_chain_key_contexts
+            .insert(
+                CallbackId::from(3),
+                test_reshare_chain_key_context(
+                    MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+                        curve: EcdsaCurve::Secp256k1,
+                        name: "idkg_key".to_string(),
+                    }),
+                    target_id3,
+                    RegistryVersion::from(1),
+                    (10..14).map(node_test_id).collect(),
+                ),
+            );
+
+        let dkg_summary = test_dkg_summary(
+            Height::from(100),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        let map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &dkg_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+        assert_eq!(map.len(), 1);
+        let configs = map
+            .get(&callback_id)
+            .expect("missing callback entry")
+            .as_ref()
+            .expect("expected successful configs");
+        assert_eq!(configs.len(), 2);
+
+        let tags = configs
+            .iter()
+            .map(|config| config.dkg_id().dkg_tag.clone())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            tags,
+            BTreeSet::from([NiDkgTag::LowThreshold, NiDkgTag::HighThreshold])
+        );
+        assert!(configs.iter().all(|config| {
+            config.dkg_id().dealer_subnet == this_subnet_id
+                && config.dkg_id().target_subnet == NiDkgTargetSubnet::Remote(target_id)
+        }));
+
+        let zero_attempts_summary = test_dkg_summary(
+            Height::from(101),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::from([(target_id, 0), (target_id2, 0), (target_id3, 0)]),
+        );
+        let zero_attempts_map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &zero_attempts_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+        assert!(zero_attempts_map.is_empty());
+
+        let max_attempts_summary = test_dkg_summary(
+            Height::from(102),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::from([
+                (target_id, MAX_REMOTE_DKG_ATTEMPTS + 1),
+                (target_id2, MAX_REMOTE_DKG_ATTEMPTS + 1),
+                (target_id3, MAX_REMOTE_DKG_ATTEMPTS + 1),
+            ]),
+        );
+        let max_attempts_map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &max_attempts_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+        assert_eq!(max_attempts_map.len(), 1);
+        let timeout_errors = max_attempts_map
+            .get(&callback_id)
+            .expect("missing callback entry for timeout path")
+            .as_ref()
+            .expect_err("expected timeout errors");
+        assert_eq!(timeout_errors.len(), 2);
+        assert!(
+            timeout_errors
+                .iter()
+                .all(|(_, err)| err == REMOTE_DKG_REPEATED_FAILURE_ERROR)
+        );
+        assert_eq!(
+            timeout_errors
+                .iter()
+                .map(|(id, _)| id.dkg_tag.clone())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([NiDkgTag::LowThreshold, NiDkgTag::HighThreshold])
+        );
+
+        state
+            .metadata
+            .subnet_call_context_manager
+            .setup_initial_dkg_contexts
+            .insert(
+                CallbackId::from(2),
+                test_setup_initial_dkg_context(
+                    target_id2,
+                    RegistryVersion::from(2),
+                    (10..14).map(node_test_id).collect(),
+                ),
+            );
+        let setup_error_summary = test_dkg_summary(
+            Height::from(103),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        let result = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(2),
+            &setup_error_summary,
+            &no_op_logger(),
+        );
+        assert!(matches!(
+            result,
+            Err(DkgPayloadCreationError::FailedToGetSubnetMemberListFromRegistry(_))
+        ));
+    }
+
+    #[test]
+    fn test_build_callback_id_config_map_reshare_chain_key() {
+        let this_subnet_id = subnet_test_id(20);
+        let dealers: Vec<_> = (0..4).map(node_test_id).collect();
+        let registry = setup_registry(
+            this_subnet_id,
+            vec![(1, SubnetRecordBuilder::from(&dealers).build())],
+        );
+
+        let vet_key_id = VetKdKeyId {
+            curve: VetKdCurve::Bls12_381_G2,
+            name: "key_a".to_string(),
+        };
+        let ni_dkg_key_id = NiDkgMasterPublicKeyId::VetKd(vet_key_id.clone());
+        let tag = NiDkgTag::HighThresholdForKey(ni_dkg_key_id.clone());
+        let transcript_committee: Vec<_> = (50..54).map(node_test_id).collect();
+        let transcript = dummy_transcript_for_tests_with_params(
+            transcript_committee.clone(),
+            tag.clone(),
+            tag.threshold_for_subnet_of_size(transcript_committee.len()) as u32,
+            1,
+        );
+        let current_transcript_committee: Vec<_> = (90..94).map(node_test_id).collect();
+        let current_transcript = dummy_transcript_for_tests_with_params(
+            current_transcript_committee.clone(),
+            tag.clone(),
+            tag.threshold_for_subnet_of_size(current_transcript_committee.len()) as u32,
+            1,
+        );
+
+        let target_id = NiDkgTargetId::new([2_u8; 32]);
+        let callback_id = CallbackId::from(2);
+        let mut state = ReplicatedStateBuilder::new()
+            .with_subnet_id(this_subnet_id)
+            .build();
+        state
+            .metadata
+            .subnet_call_context_manager
+            .reshare_chain_key_contexts
+            .insert(
+                callback_id,
+                test_reshare_chain_key_context(
+                    MasterPublicKeyId::VetKd(vet_key_id),
+                    target_id,
+                    RegistryVersion::from(1),
+                    (60..64).map(node_test_id).collect(),
+                ),
+            );
+
+        let dkg_summary = test_dkg_summary(
+            Height::from(101),
+            BTreeMap::from([(tag.clone(), current_transcript.clone())]),
+            BTreeMap::from([(tag, transcript.clone())]),
+            BTreeMap::new(),
+        );
+        let map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &dkg_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+
+        let configs = map
+            .get(&callback_id)
+            .expect("missing callback entry")
+            .as_ref()
+            .expect("expected successful configs");
+        assert_eq!(configs.len(), 1);
+        let config = &configs[0];
+        assert_eq!(config.resharing_transcript().as_ref(), Some(&transcript));
+        assert_ne!(
+            config.resharing_transcript().as_ref(),
+            Some(&current_transcript)
+        );
+        assert_eq!(config.dealers().get(), transcript.committee.get());
+        assert_ne!(config.dealers().get(), current_transcript.committee.get());
+
+        let missing_transcript_summary = test_dkg_summary(
+            Height::from(102),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        let missing_transcript_map = build_callback_id_config_map(
+            this_subnet_id,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &missing_transcript_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+        let errors = missing_transcript_map
+            .get(&callback_id)
+            .expect("missing callback entry")
+            .as_ref()
+            .expect_err("expected per-context reshare error");
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].0.dkg_tag,
+            NiDkgTag::HighThresholdForKey(ni_dkg_key_id)
+        );
+        assert!(
+            errors[0]
+                .1
+                .contains("Failed to find resharing transcript for a remote dkg")
+        );
+    }
+
+    #[test]
+    fn test_merge_configs_merges_successes_and_ignores_errors() {
+        let summary_only_id = local_dkg_id(NiDkgTag::LowThreshold);
+        let overlap_id = remote_dkg_id_with_target(NiDkgTag::HighThreshold, [11_u8; 32]);
+        let context_only_id = remote_dkg_id_with_target(NiDkgTag::LowThreshold, [11_u8; 32]);
+        let error_only_id = remote_dkg_id_with_target(NiDkgTag::LowThreshold, [12_u8; 32]);
+
+        let summary_only_config = make_test_config(summary_only_id.clone(), 1);
+        let overlap_config = make_test_config(overlap_id.clone(), 1);
+        let context_only_config = make_test_config(context_only_id.clone(), 1);
+
+        let summary_configs: BTreeMap<_, _> = [
+            (summary_only_id.clone(), summary_only_config),
+            (overlap_id.clone(), overlap_config.clone()),
+        ]
+        .into();
+        let config_results: BTreeMap<_, _> = [
+            (
+                CallbackId::from(1),
+                Ok(vec![overlap_config.clone(), context_only_config.clone()]),
+            ),
+            (
+                CallbackId::from(2),
+                Err(vec![(error_only_id.clone(), "test error".to_string())]),
+            ),
+        ]
+        .into();
+
+        let merged = merge_configs(&summary_configs, &config_results);
+
+        assert_eq!(merged.len(), 3);
+        assert!(merged.contains_key(&summary_only_id));
+        assert!(merged.contains_key(&overlap_id));
+        assert!(merged.contains_key(&context_only_id));
+        assert!(!merged.contains_key(&error_only_id));
+    }
+}

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -45,7 +45,7 @@ enum RemoteDkgContext<'a> {
 }
 
 impl<'a> RemoteDkgContext<'a> {
-    fn target_id(&self) -> &'a NiDkgTargetId {
+    fn target_id(&self) -> &NiDkgTargetId {
         match self {
             RemoteDkgContext::SetupInitialDKG(context) => &context.target_id,
             RemoteDkgContext::ReshareChainKey(context) => &context.context.target_id,

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -1,7 +1,7 @@
 use crate::{
     MAX_REMOTE_DKG_ATTEMPTS, REMOTE_DKG_REPEATED_FAILURE_ERROR,
     payload_builder::{
-        create_low_high_remote_dkg_configs, create_remote_dkg_config_for_key_id, get_node_list,
+        create_low_high_remote_dkg_configs, create_remote_dkg_config, get_node_list,
     },
 };
 use ic_interfaces_registry::RegistryClient;
@@ -15,7 +15,7 @@ use ic_types::{
     consensus::dkg::{DkgPayloadCreationError, DkgSummary},
     crypto::threshold_sig::ni_dkg::{
         NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
-        NiDkgTranscript, config::NiDkgConfig,
+        config::NiDkgConfig,
     },
     messages::CallbackId,
 };
@@ -89,10 +89,9 @@ impl<'a> RemoteDkgContext<'a> {
 
     fn create_configs(
         &self,
-        start_block_height: Height,
+        dkg_summary: &DkgSummary,
         dealer_subnet: SubnetId,
         registry_client: &dyn RegistryClient,
-        get_reshare_transcript: impl Fn(&NiDkgTag) -> Option<NiDkgTranscript>,
         logger: &ReplicaLogger,
     ) -> Result<ConfigResult, DkgPayloadCreationError> {
         let config_result = match self {
@@ -100,7 +99,7 @@ impl<'a> RemoteDkgContext<'a> {
                 let dealers =
                     get_node_list(dealer_subnet, registry_client, context.registry_version)?;
                 create_low_high_remote_dkg_configs(
-                    start_block_height,
+                    dkg_summary.height,
                     dealer_subnet,
                     context.target_id,
                     dealers,
@@ -110,17 +109,35 @@ impl<'a> RemoteDkgContext<'a> {
                 )
                 .map(|(config0, config1)| vec![config0, config1])
             }
-            RemoteDkgContext::ReshareChainKey(context) => create_remote_dkg_config_for_key_id(
-                context.key_id.clone(),
-                start_block_height,
-                dealer_subnet,
-                context.context.target_id,
-                context.context.nodes.clone(),
-                get_reshare_transcript,
-                &context.context.registry_version,
-            )
-            .map(|config| vec![config])
-            .map_err(|err_box| vec![*err_box]),
+            RemoteDkgContext::ReshareChainKey(context) => {
+                let dkg_id = NiDkgId {
+                    start_block_height: dkg_summary.height,
+                    dealer_subnet,
+                    dkg_tag: NiDkgTag::HighThresholdForKey(context.key_id.clone()),
+                    target_subnet: NiDkgTargetSubnet::Remote(context.context.target_id),
+                };
+                let Some(resharing_transcript) = dkg_summary
+                    .next_transcripts()
+                    .get(&dkg_id.dkg_tag)
+                    .or_else(|| dkg_summary.current_transcripts().get(&dkg_id.dkg_tag))
+                    .cloned()
+                else {
+                    let err = format!(
+                        "Failed to find resharing transcript for a remote dkg for tag {:?}",
+                        &dkg_id.dkg_tag
+                    );
+                    return Ok(Err(vec![(dkg_id, err)]));
+                };
+                create_remote_dkg_config(
+                    dkg_id.clone(),
+                    resharing_transcript.committee.get().clone(),
+                    context.context.nodes.clone(),
+                    &context.context.registry_version,
+                    Some(resharing_transcript),
+                )
+                .map(|config| vec![config])
+                .map_err(|err| vec![(dkg_id, format!("{err:?}"))])
+            }
         };
         Ok(config_result)
     }
@@ -156,14 +173,6 @@ pub(crate) fn build_callback_id_config_map(
                     .map(|context| (callback_id, RemoteDkgContext::ReshareChainKey(context)))
             });
 
-    let get_reshare_transcript = |tag: &NiDkgTag| {
-        dkg_summary
-            .next_transcripts()
-            .get(tag)
-            .or_else(|| dkg_summary.current_transcripts().get(tag))
-            .cloned()
-    };
-
     for (callback_id, context) in setup_contexts.chain(reshare_contexts) {
         if context.registry_version() > registry_version {
             // Skip contexts with a registry version that hasn't been reached yet
@@ -190,13 +199,7 @@ pub(crate) fn build_callback_id_config_map(
         // Create configs for the context and insert them into the map
         callback_id_config_map.insert(
             callback_id,
-            context.create_configs(
-                dkg_summary.height,
-                this_subnet_id,
-                registry_client,
-                get_reshare_transcript,
-                logger,
-            )?,
+            context.create_configs(dkg_summary, this_subnet_id, registry_client, logger)?,
         );
     }
 
@@ -233,6 +236,7 @@ mod tests {
     use ic_test_utilities_state::ReplicatedStateBuilder;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
     use ic_test_utilities_types::messages::RequestBuilder;
+    use ic_types::crypto::threshold_sig::ni_dkg::NiDkgTranscript;
     use ic_types::{
         NodeId, RegistryVersion, crypto::threshold_sig::ni_dkg::NiDkgTag, messages::CallbackId,
         time::UNIX_EPOCH,

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -582,13 +582,40 @@ mod tests {
         assert_eq!(errors.len(), 1);
         assert_eq!(
             errors[0].0.dkg_tag,
-            NiDkgTag::HighThresholdForKey(ni_dkg_key_id)
+            NiDkgTag::HighThresholdForKey(ni_dkg_key_id.clone())
         );
         assert!(
             errors[0]
                 .1
                 .contains("Failed to find resharing transcript for a remote dkg")
         );
+
+        let max_attempts_summary = test_dkg_summary(
+            Height::from(103),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::from([(target_id, MAX_REMOTE_DKG_ATTEMPTS)]),
+        );
+        let max_attempts_map = build_callback_id_config_map(
+            dealer_subnet,
+            registry.as_ref(),
+            &state,
+            RegistryVersion::from(1),
+            &max_attempts_summary,
+            &no_op_logger(),
+        )
+        .expect("expected callback-id config map");
+        let timeout_errors = max_attempts_map
+            .get(&callback_id)
+            .expect("missing callback entry")
+            .as_ref()
+            .expect_err("expected timeout errors");
+        assert_eq!(timeout_errors.len(), 1);
+        assert_eq!(
+            timeout_errors[0].0.dkg_tag,
+            NiDkgTag::HighThresholdForKey(ni_dkg_key_id)
+        );
+        assert_eq!(timeout_errors[0].1, REMOTE_DKG_REPEATED_FAILURE_ERROR);
     }
 
     #[test]

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -140,6 +140,7 @@ pub(crate) fn build_callback_id_config_map(
     let call_contexts = &state.metadata.subnet_call_context_manager;
     let remote_dkg_attempts = &dkg_summary.initial_dkg_attempts;
 
+    // Iterate over all context types
     let setup_contexts = call_contexts
         .setup_initial_dkg_contexts
         .iter()
@@ -149,6 +150,7 @@ pub(crate) fn build_callback_id_config_map(
             .reshare_chain_key_contexts
             .iter()
             .filter_map(|(&callback_id, context)| {
+                // Filter out IDKG contexts.
                 NiDkgReshareChainKeyContext::try_from(context)
                     .ok()
                     .map(|context| (callback_id, RemoteDkgContext::ReshareChainKey(context)))
@@ -158,20 +160,25 @@ pub(crate) fn build_callback_id_config_map(
         dkg_summary
             .next_transcripts()
             .get(tag)
+            .or_else(|| dkg_summary.current_transcripts().get(tag))
             .cloned()
-            .or_else(|| dkg_summary.current_transcripts().get(tag).cloned())
     };
 
     for (callback_id, context) in setup_contexts.chain(reshare_contexts) {
         if context.registry_version() > registry_version {
+            // Skip contexts with a registry version that hasn't been reached yet
             continue;
         }
 
         if let Some(&attempts) = remote_dkg_attempts.get(context.target_id()) {
             if attempts == 0 {
+                // An attempt count of 0 means that the context has already been completed
+                // in the last interval. We skip the context to avoid handling it again in
+                // the current interval.
                 continue;
             }
             if attempts >= MAX_REMOTE_DKG_ATTEMPTS {
+                // Add timeout errors for contexts that have been attempted too many times
                 callback_id_config_map.insert(
                     callback_id,
                     Err(context.generate_timeout_errors(dkg_summary.height, this_subnet_id)),
@@ -180,6 +187,7 @@ pub(crate) fn build_callback_id_config_map(
             }
         }
 
+        // Create configs for the context and insert them into the map
         callback_id_config_map.insert(
             callback_id,
             context.create_configs(
@@ -212,6 +220,7 @@ pub(crate) fn merge_configs<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::{local_dkg_id, make_test_config, remote_dkg_id_with_target};
     use ic_crypto_test_utils_ni_dkg::dummy_transcript_for_tests_with_params;
     use ic_logger::replica_logger::no_op_logger;
     use ic_management_canister_types_private::{
@@ -225,9 +234,7 @@ mod tests {
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
     use ic_test_utilities_types::messages::RequestBuilder;
     use ic_types::{
-        NodeId, NumberOfNodes, RegistryVersion,
-        crypto::threshold_sig::ni_dkg::{NiDkgTag, NiDkgTargetSubnet, config::NiDkgConfigData},
-        messages::CallbackId,
+        NodeId, RegistryVersion, crypto::threshold_sig::ni_dkg::NiDkgTag, messages::CallbackId,
         time::UNIX_EPOCH,
     };
     use std::collections::BTreeSet;
@@ -278,39 +285,6 @@ mod tests {
             registry_version,
             time: UNIX_EPOCH,
             target_id,
-        }
-    }
-
-    fn make_test_config(dkg_id: NiDkgId, max_corrupt_dealers: u32) -> NiDkgConfig {
-        let nodes: BTreeSet<_> = (0..10).map(node_test_id).collect();
-        NiDkgConfig::new(NiDkgConfigData {
-            dkg_id,
-            max_corrupt_dealers: NumberOfNodes::from(max_corrupt_dealers),
-            dealers: nodes.clone(),
-            max_corrupt_receivers: NumberOfNodes::from(1),
-            receivers: nodes,
-            threshold: NumberOfNodes::from(2),
-            registry_version: RegistryVersion::from(1),
-            resharing_transcript: None,
-        })
-        .unwrap()
-    }
-
-    fn local_dkg_id(tag: NiDkgTag) -> NiDkgId {
-        NiDkgId {
-            start_block_height: Height::from(0),
-            dealer_subnet: subnet_test_id(0),
-            dkg_tag: tag,
-            target_subnet: NiDkgTargetSubnet::Local,
-        }
-    }
-
-    fn remote_dkg_id_with_target(tag: NiDkgTag, target_id: [u8; 32]) -> NiDkgId {
-        NiDkgId {
-            start_block_height: Height::from(0),
-            dealer_subnet: subnet_test_id(0),
-            dkg_tag: tag,
-            target_subnet: NiDkgTargetSubnet::Remote(NiDkgTargetId::new(target_id)),
         }
     }
 
@@ -407,6 +381,7 @@ mod tests {
                 && config.dkg_id().target_subnet == NiDkgTargetSubnet::Remote(target_id)
         }));
 
+        // Zero attempts => context must be skipped.
         let zero_attempts_summary = test_dkg_summary(
             Height::from(101),
             BTreeMap::new(),
@@ -424,6 +399,7 @@ mod tests {
         .expect("expected callback-id config map");
         assert!(zero_attempts_map.is_empty());
 
+        // Attempts above the max => timeout errors must be returned.
         let max_attempts_summary = test_dkg_summary(
             Height::from(102),
             BTreeMap::new(),
@@ -463,6 +439,7 @@ mod tests {
             BTreeSet::from([NiDkgTag::LowThreshold, NiDkgTag::HighThreshold])
         );
 
+        // Setup context creation error should be propagated.
         state
             .metadata
             .subnet_call_context_manager

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::{
     MAX_REMOTE_DKG_ATTEMPTS, REMOTE_DKG_REPEATED_FAILURE_ERROR,
     payload_builder::{

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -173,7 +173,7 @@ pub(crate) fn build_callback_id_config_map(
             if attempts == 0 {
                 continue;
             }
-            if attempts > MAX_REMOTE_DKG_ATTEMPTS {
+            if attempts >= MAX_REMOTE_DKG_ATTEMPTS {
                 callback_id_config_map.insert(
                     callback_id,
                     Err(context.generate_timeout_errors(dkg_summary.height, this_subnet_id)),
@@ -431,9 +431,9 @@ mod tests {
             BTreeMap::new(),
             BTreeMap::new(),
             BTreeMap::from([
-                (target_id, MAX_REMOTE_DKG_ATTEMPTS + 1),
-                (target_id2, MAX_REMOTE_DKG_ATTEMPTS + 1),
-                (target_id3, MAX_REMOTE_DKG_ATTEMPTS + 1),
+                (target_id, MAX_REMOTE_DKG_ATTEMPTS),
+                (target_id2, MAX_REMOTE_DKG_ATTEMPTS),
+                (target_id3, MAX_REMOTE_DKG_ATTEMPTS),
             ]),
         );
         let max_attempts_map = build_callback_id_config_map(

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -103,8 +103,8 @@ impl<'a> RemoteDkgContext<'a> {
                     start_block_height,
                     dealer_subnet,
                     context.target_id,
-                    &dealers,
-                    &context.nodes_in_target_subnet,
+                    dealers,
+                    context.nodes_in_target_subnet.clone(),
                     &context.registry_version,
                     logger,
                 )
@@ -115,7 +115,7 @@ impl<'a> RemoteDkgContext<'a> {
                 start_block_height,
                 dealer_subnet,
                 context.context.target_id,
-                &context.context.nodes,
+                context.context.nodes.clone(),
                 get_reshare_transcript,
                 &context.context.registry_version,
             )

--- a/rs/consensus/dkg/src/remote.rs
+++ b/rs/consensus/dkg/src/remote.rs
@@ -491,11 +491,11 @@ mod tests {
         };
         let ni_dkg_key_id = NiDkgMasterPublicKeyId::VetKd(vet_key_id.clone());
         let tag = NiDkgTag::HighThresholdForKey(ni_dkg_key_id.clone());
-        let transcript_committee: Vec<_> = (50..54).map(node_test_id).collect();
-        let transcript = dummy_transcript_for_tests_with_params(
-            transcript_committee.clone(),
+        let next_transcript_committee: Vec<_> = (50..54).map(node_test_id).collect();
+        let next_transcript = dummy_transcript_for_tests_with_params(
+            next_transcript_committee.clone(),
             tag.clone(),
-            tag.threshold_for_subnet_of_size(transcript_committee.len()) as u32,
+            tag.threshold_for_subnet_of_size(next_transcript_committee.len()) as u32,
             1,
         );
         let current_transcript_committee: Vec<_> = (90..94).map(node_test_id).collect();
@@ -528,7 +528,7 @@ mod tests {
         let dkg_summary = test_dkg_summary(
             Height::from(101),
             BTreeMap::from([(tag.clone(), current_transcript.clone())]),
-            BTreeMap::from([(tag, transcript.clone())]),
+            BTreeMap::from([(tag, next_transcript.clone())]),
             BTreeMap::new(),
         );
         let map = build_callback_id_config_map(
@@ -548,12 +548,15 @@ mod tests {
             .expect("expected successful configs");
         assert_eq!(configs.len(), 1);
         let config = &configs[0];
-        assert_eq!(config.resharing_transcript().as_ref(), Some(&transcript));
+        assert_eq!(
+            config.resharing_transcript().as_ref(),
+            Some(&next_transcript)
+        );
         assert_ne!(
             config.resharing_transcript().as_ref(),
             Some(&current_transcript)
         );
-        assert_eq!(config.dealers().get(), transcript.committee.get());
+        assert_eq!(config.dealers().get(), next_transcript.committee.get());
         assert_ne!(config.dealers().get(), current_transcript.committee.get());
 
         let missing_transcript_summary = test_dkg_summary(

--- a/rs/consensus/dkg/src/test_utils.rs
+++ b/rs/consensus/dkg/src/test_utils.rs
@@ -6,13 +6,19 @@ use ic_replicated_state::metadata_state::subnet_call_context_manager::{
 };
 use ic_test_utilities::state_manager::RefMockStateManager;
 use ic_test_utilities_consensus::fake::FakeContentSigner;
-use ic_test_utilities_types::{ids::node_test_id, messages::RequestBuilder};
-use ic_types::{
-    Height, RegistryVersion,
-    consensus::dkg::{DealingContent, Message},
-    crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTargetId},
+use ic_test_utilities_types::{
+    ids::{node_test_id, subnet_test_id},
+    messages::RequestBuilder,
 };
-use std::sync::Arc;
+use ic_types::{
+    Height, NumberOfNodes, RegistryVersion,
+    consensus::dkg::{DealingContent, Message},
+    crypto::threshold_sig::ni_dkg::{
+        NiDkgId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
+        config::{NiDkgConfig, NiDkgConfigData},
+    },
+};
+use std::{collections::BTreeSet, sync::Arc};
 
 pub(super) fn complement_state_manager_with_setup_initial_dkg_request(
     state_manager: Arc<RefMockStateManager>,
@@ -85,4 +91,41 @@ pub(super) fn complement_state_manager_with_reshare_chain_key_request(
 pub(super) fn create_dealing(node_idx: u64, dkg_id: NiDkgId) -> Message {
     let content = DealingContent::new(dummy_dealing(node_idx as u8), dkg_id);
     Message::fake(content, node_test_id(node_idx))
+}
+
+pub(super) fn make_test_config(dkg_id: NiDkgId, max_corrupt_dealers: u32) -> NiDkgConfig {
+    let nodes: BTreeSet<_> = (0..10).map(node_test_id).collect();
+    NiDkgConfig::new(NiDkgConfigData {
+        dkg_id,
+        max_corrupt_dealers: NumberOfNodes::from(max_corrupt_dealers),
+        dealers: nodes.clone(),
+        max_corrupt_receivers: NumberOfNodes::from(1),
+        receivers: nodes,
+        threshold: NumberOfNodes::from(2),
+        registry_version: RegistryVersion::from(1),
+        resharing_transcript: None,
+    })
+    .unwrap()
+}
+
+pub(super) fn local_dkg_id(tag: NiDkgTag) -> NiDkgId {
+    NiDkgId {
+        start_block_height: Height::from(0),
+        dealer_subnet: subnet_test_id(0),
+        dkg_tag: tag,
+        target_subnet: NiDkgTargetSubnet::Local,
+    }
+}
+
+pub(super) fn remote_dkg_id(tag: NiDkgTag) -> NiDkgId {
+    remote_dkg_id_with_target(tag, [0_u8; 32])
+}
+
+pub(super) fn remote_dkg_id_with_target(tag: NiDkgTag, target_id: [u8; 32]) -> NiDkgId {
+    NiDkgId {
+        start_block_height: Height::from(0),
+        dealer_subnet: subnet_test_id(0),
+        dkg_tag: tag,
+        target_subnet: NiDkgTargetSubnet::Remote(NiDkgTargetId::new(target_id)),
+    }
 }

--- a/rs/types/types/src/crypto/threshold_sig/ni_dkg/config/receivers.rs
+++ b/rs/types/types/src/crypto/threshold_sig/ni_dkg/config/receivers.rs
@@ -75,9 +75,3 @@ impl NiDkgReceivers {
         self.count
     }
 }
-
-impl From<NiDkgReceivers> for BTreeSet<NodeId> {
-    fn from(receivers: NiDkgReceivers) -> Self {
-        receivers.receivers
-    }
-}

--- a/rs/types/types/src/crypto/threshold_sig/ni_dkg/config/receivers.rs
+++ b/rs/types/types/src/crypto/threshold_sig/ni_dkg/config/receivers.rs
@@ -75,3 +75,9 @@ impl NiDkgReceivers {
         self.count
     }
 }
+
+impl From<NiDkgReceivers> for BTreeSet<NodeId> {
+    fn from(receivers: NiDkgReceivers) -> Self {
+        receivers.receivers
+    }
+}


### PR DESCRIPTION
Previously, configs for Remote DKG requests were only created and included as part of summary blocks. This implies that a request has to wait until the end of the current interval to even be started.

This PR introduces two new functions that will be used to start working on remote DKG requests as soon as they appear in the replicated state.

### `build_callback_id_config_map`
This function iterates over all remote DKG request contexts and attempts to derive the corresponding DKG configs. This is done by using the start height of the most recent summary block. In case of malformed inputs, errors are returned instead.

One special aspect is the use of the `initial_dkg_attempts` map, which is maintained by the summary payload. Entries of this map are incremented whenever there is still an outstanding request context in the replicated state, when the summary block is created. If the number of attempts exceeds the maximum, the new function will generate a timeout error instead. Furthermore, we will use this map to track remote DKG requests that have been completed as part of the previous interval. Target IDs for such requests will be inserted into this map with a count of 0. This ensures that they will not be attempted again in the subsequent interval.

### `merge_configs`
This function takes configs from the recent summary, and merges them with configs derived from the latest state using `build_callback_id_config_map`. The output represents the combined set of configs for currently ongoing DKGs.


Note that the new functions are still unused.