### PR TITLE
fix: deflake //rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test

### DIFF
--- a/rs/tests/consensus/upgrade/common.rs
+++ b/rs/tests/consensus/upgrade/common.rs
@@ -427,7 +427,8 @@ fn find_latest_computed_root_hashes_from_logs(
 /// grep match can be flushed back over the channel. On reboot the SSH session is simply
 /// re-established and the message is found in the previous boot's journal.
 ///
-/// This function will never return if an upgrade is not scheduled.
+/// If no upgrade is scheduled, this keeps retrying until the overall timeout elapses and then
+/// panics.
 fn assert_orchestrator_stopped_gracefully(node: &IcNodeSnapshot) {
     const GRACEFUL_SHUTDOWN_MSG: &str = "Orchestrator shut down gracefully";
     const OVERALL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
@@ -441,14 +442,17 @@ fn assert_orchestrator_stopped_gracefully(node: &IcNodeSnapshot) {
         || {
             let session = node.block_on_ssh_session()?;
             session.set_timeout(30 * 1000);
-            if JournalStreamer::new(session).contains(GRACEFUL_SHUTDOWN_MSG)? {
-                Ok(())
-            } else {
-                anyhow::bail!(
+            // `JournalStreamer::contains` pipes through `grep`, which exits with status 1 when
+            // there are no matches. `execute_bash_script_from_session` converts any non-zero exit
+            // status into an `Err`, so "no matches yet" is indistinguishable from a real
+            // transport-level failure. Treat both as "keep retrying".
+            match JournalStreamer::new(session).contains(GRACEFUL_SHUTDOWN_MSG) {
+                Ok(true) => Ok(()),
+                Ok(false) | Err(_) => anyhow::bail!(
                     "Node {} has not logged '{}' yet",
                     node.node_id,
                     GRACEFUL_SHUTDOWN_MSG
-                )
+                ),
             }
         }
     )

--- a/rs/tests/consensus/upgrade/common.rs
+++ b/rs/tests/consensus/upgrade/common.rs
@@ -26,6 +26,7 @@ use ic_consensus_threshold_sig_system_test_utils::run_chain_key_signature_test;
 use ic_management_canister_types::{CanisterId, TakeCanisterSnapshotArgs};
 use ic_management_canister_types_private::MasterPublicKeyId;
 use ic_registry_subnet_type::SubnetType;
+use ic_system_test_driver::retry_with_msg;
 use ic_system_test_driver::util::create_agent;
 use ic_system_test_driver::{
     driver::{test_env::TestEnv, test_env_api::*},
@@ -418,24 +419,43 @@ fn find_latest_computed_root_hashes_from_logs(
 }
 
 /// Asserts that the orchestrator has shut down gracefully by searching for a specific log entry.
-/// Panics if the log entry is not found but the log stream ends (which indicates the node
-/// rebooted).
+/// Panics if the log entry is not found within a timeout.
 ///
-/// We use a bash script instead of connecting to the log stream endpoint because as the
-/// orchestrator is shutting down, the endpoint might close right away without letting us the
-/// chance to read the relevant log entry. In constrast, the SSH connection remains open longer.
+/// Polls the node's persisted journal (across all boots) rather than following a live log stream.
+/// This avoids a race where the orchestrator writes the "shut down gracefully" line and the node
+/// reboots into the new version milliseconds later, tearing down the SSH transport before the
+/// grep match can be flushed back over the channel. On reboot the SSH session is simply
+/// re-established and the message is found in the previous boot's journal.
 ///
 /// This function will never return if an upgrade is not scheduled.
 fn assert_orchestrator_stopped_gracefully(node: &IcNodeSnapshot) {
-    let session = node.block_on_ssh_session().unwrap();
-    session.set_timeout(5 * 60 * 1000);
-    assert!(
-        JournalStreamer::new(session)
-            .follow()
-            .max_lines(1)
-            .contains("Orchestrator shut down gracefully")
-            .unwrap_or_default(),
-        "Orchestrator of node {} did not shut down gracefully",
-        node.node_id
-    );
+    const GRACEFUL_SHUTDOWN_MSG: &str = "Orchestrator shut down gracefully";
+    const OVERALL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+    let logger = node.test_env().logger();
+    retry_with_msg!(
+        format!("assert_orchestrator_stopped_gracefully({})", node.node_id),
+        logger,
+        OVERALL_TIMEOUT,
+        RETRY_BACKOFF,
+        || {
+            let session = node.block_on_ssh_session()?;
+            session.set_timeout(30 * 1000);
+            if JournalStreamer::new(session).contains(GRACEFUL_SHUTDOWN_MSG)? {
+                Ok(())
+            } else {
+                anyhow::bail!(
+                    "Node {} has not logged '{}' yet",
+                    node.node_id,
+                    GRACEFUL_SHUTDOWN_MSG
+                )
+            }
+        }
+    )
+    .unwrap_or_else(|e| {
+        panic!(
+            "Orchestrator of node {} did not shut down gracefully: {e:#}",
+            node.node_id
+        )
+    });
 }

--- a/rs/tests/consensus/upgrade/common.rs
+++ b/rs/tests/consensus/upgrade/common.rs
@@ -468,15 +468,21 @@ fn assert_orchestrator_stopped_gracefully(node: &IcNodeSnapshot, cursor: String)
             session.set_timeout(30 * 1000);
             // `JournalStreamer::contains` pipes through `grep`, which exits with status 1 when
             // there are no matches. `execute_bash_script_from_session` converts any non-zero exit
-            // status into an `Err`, so "no matches yet" is indistinguishable from a real
-            // transport-level failure. Treat both as "keep retrying".
+            // status into an `Err`, so "no matches yet" may be reported as an error. Keep
+            // retrying in both cases, but preserve the underlying error context so the final
+            // timeout is diagnosable when this is a real SSH/journal failure.
             match JournalStreamer::new(session)
                 .from_cursor(cursor.clone())
                 .contains(GRACEFUL_SHUTDOWN_MSG)
             {
                 Ok(true) => Ok(()),
-                Ok(false) | Err(_) => anyhow::bail!(
+                Ok(false) => anyhow::bail!(
                     "Node {} has not logged '{}' yet",
+                    node.node_id,
+                    GRACEFUL_SHUTDOWN_MSG
+                ),
+                Err(e) => anyhow::bail!(
+                    "Failed to check whether node {} logged '{}': {e:#}",
                     node.node_id,
                     GRACEFUL_SHUTDOWN_MSG
                 ),

--- a/rs/tests/consensus/upgrade/common.rs
+++ b/rs/tests/consensus/upgrade/common.rs
@@ -298,15 +298,12 @@ async fn upgrade_to(
     // triggered by this upgrade (not a pre-existing line from some earlier boot).
     let mut cursors_per_node: BTreeMap<NodeId, String> = BTreeMap::new();
     for node in &healthy_nodes {
-        let ssh_session = node
-            .block_on_ssh_session_async()
-            .await
-            .unwrap_or_else(|e| {
-                panic!(
-                    "Failed to establish SSH session for node {}: {e:#}",
-                    node.node_id
-                )
-            });
+        let ssh_session = node.block_on_ssh_session_async().await.unwrap_or_else(|e| {
+            panic!(
+                "Failed to establish SSH session for node {}: {e:#}",
+                node.node_id
+            )
+        });
         let cursor = JournalStreamer::new(ssh_session)
             .get_cursor()
             .unwrap_or_else(|e| {

--- a/rs/tests/consensus/upgrade/common.rs
+++ b/rs/tests/consensus/upgrade/common.rs
@@ -291,6 +291,26 @@ async fn upgrade_to(
         logger,
         "Upgrading subnet {} to {}", subnet_id, target_version
     );
+
+    // Snapshot the journal cursor of each healthy node *before* scheduling the upgrade. After the
+    // upgrade is deployed below, we poll each node's journal for the "shut down gracefully" line
+    // starting from this cursor, which is more efficient and guarantees we only observe the shutdown
+    // triggered by this upgrade (not a pre-existing line from some earlier boot).
+    let cursors_per_node: BTreeMap<NodeId, String> = healthy_nodes
+        .iter()
+        .map(|node| {
+            let cursor = JournalStreamer::new(node.block_on_ssh_session().unwrap())
+                .get_cursor()
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to fetch journal cursor for node {}: {e:#}",
+                        node.node_id
+                    )
+                });
+            (node.node_id, cursor)
+        })
+        .collect();
+
     deploy_guestos_to_all_subnet_nodes(nns_node, target_version, subnet_id).await;
 
     info!(
@@ -302,7 +322,11 @@ async fn upgrade_to(
     // Concurrently assert that all orchestrators shut down gracefully
     #[allow(clippy::redundant_iter_cloned)] // Need to clone to move the nodes into async tasks
     try_join_all(healthy_nodes.iter().cloned().map(|node| {
-        tokio::task::spawn_blocking(move || assert_orchestrator_stopped_gracefully(&node))
+        let cursor = cursors_per_node
+            .get(&node.node_id)
+            .expect("cursor must exist for every healthy node")
+            .clone();
+        tokio::task::spawn_blocking(move || assert_orchestrator_stopped_gracefully(&node, cursor))
     }))
     .await
     .unwrap();
@@ -429,7 +453,7 @@ fn find_latest_computed_root_hashes_from_logs(
 ///
 /// If no upgrade is scheduled, this keeps retrying until the overall timeout elapses and then
 /// panics.
-fn assert_orchestrator_stopped_gracefully(node: &IcNodeSnapshot) {
+fn assert_orchestrator_stopped_gracefully(node: &IcNodeSnapshot, cursor: String) {
     const GRACEFUL_SHUTDOWN_MSG: &str = "Orchestrator shut down gracefully";
     const OVERALL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
@@ -446,7 +470,10 @@ fn assert_orchestrator_stopped_gracefully(node: &IcNodeSnapshot) {
             // there are no matches. `execute_bash_script_from_session` converts any non-zero exit
             // status into an `Err`, so "no matches yet" is indistinguishable from a real
             // transport-level failure. Treat both as "keep retrying".
-            match JournalStreamer::new(session).contains(GRACEFUL_SHUTDOWN_MSG) {
+            match JournalStreamer::new(session)
+                .from_cursor(cursor.clone())
+                .contains(GRACEFUL_SHUTDOWN_MSG)
+            {
                 Ok(true) => Ok(()),
                 Ok(false) | Err(_) => anyhow::bail!(
                     "Node {} has not logged '{}' yet",

--- a/rs/tests/consensus/upgrade/common.rs
+++ b/rs/tests/consensus/upgrade/common.rs
@@ -296,20 +296,27 @@ async fn upgrade_to(
     // upgrade is deployed below, we poll each node's journal for the "shut down gracefully" line
     // starting from this cursor, which is more efficient and guarantees we only observe the shutdown
     // triggered by this upgrade (not a pre-existing line from some earlier boot).
-    let cursors_per_node: BTreeMap<NodeId, String> = healthy_nodes
-        .iter()
-        .map(|node| {
-            let cursor = JournalStreamer::new(node.block_on_ssh_session().unwrap())
-                .get_cursor()
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "Failed to fetch journal cursor for node {}: {e:#}",
-                        node.node_id
-                    )
-                });
-            (node.node_id, cursor)
-        })
-        .collect();
+    let mut cursors_per_node: BTreeMap<NodeId, String> = BTreeMap::new();
+    for node in &healthy_nodes {
+        let ssh_session = node
+            .block_on_ssh_session_async()
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to establish SSH session for node {}: {e:#}",
+                    node.node_id
+                )
+            });
+        let cursor = JournalStreamer::new(ssh_session)
+            .get_cursor()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to fetch journal cursor for node {}: {e:#}",
+                    node.node_id
+                )
+            });
+        cursors_per_node.insert(node.node_id, cursor);
+    }
 
     deploy_guestos_to_all_subnet_nodes(nns_node, target_version, subnet_id).await;
 

--- a/rs/tests/driver/src/util.rs
+++ b/rs/tests/driver/src/util.rs
@@ -1697,22 +1697,30 @@ impl JournalStreamer {
         self
     }
 
-    /// Anchors subsequent searches to start after the current latest journal entry. This is useful
-    /// for ignoring pre-existing log lines and only matching entries that appear after this call.
-    ///
-    /// Returns an error on transport errors or if the journal is empty and there is no cursor to
-    /// anchor to.
-    pub fn from_now(mut self) -> anyhow::Result<Self> {
-        let cursor = Self::new(self.session.clone())
+    /// Fetches the cursor of the latest journal entry. This can be used to anchor subsequent searches.
+    pub fn get_cursor(&self) -> anyhow::Result<String> {
+        Ok(Self::new(self.session.clone())
             .max_lines(1)
             .search_and_return_cursors("__CURSOR")?
             .into_iter()
             .next()
             .ok_or_else(|| anyhow::anyhow!("No journal entries found"))?
-            .cursor;
+            .cursor)
+    }
 
+    pub fn from_cursor(mut self, cursor: String) -> Self {
         self.from_cursor = Some(cursor);
-        Ok(self)
+        self
+    }
+
+    /// Anchors subsequent searches to start after the current latest journal entry. This is useful
+    /// for ignoring pre-existing log lines and only matching entries that appear after this call.
+    ///
+    /// Returns an error on transport errors or if the journal is empty and there is no cursor to
+    /// anchor to.
+    pub fn from_now(self) -> anyhow::Result<Self> {
+        let cursor = self.get_cursor()?;
+        Ok(self.from_cursor(cursor))
     }
 
     /// Executes the configured `journalctl` query and returns whether there are any entries


### PR DESCRIPTION
## Root cause

`//rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test` was flaking with:

```
Orchestrator of node <node_id> did not shut down gracefully
```

Inspection of the node journals for the 3 flaky runs in the past week
(2026-04-10, 2026-04-15, 2026-04-16) shows that every "failing" node
had actually logged `Orchestrator shut down gracefully` a few hundred
milliseconds *before* the test panicked. Example (2026-04-16 run):

```
10843:2026-04-16 14:46:23.843445 Orchestrator shut down gracefully
```
vs the test panic timestamp `14:46:24.229`.

The old `assert_orchestrator_stopped_gracefully` used a single long-lived
SSH session running `journalctl --follow --lines=1 | grep …`. As soon as
the orchestrator writes the shutdown message, the GuestOS reboots into
the new version. The SSH transport is torn down mid-pipeline before
`grep` flushes the matching line back to the driver. `execute_bash_script_from_session`
then returns `Err(...)` (non-zero exit / transport read error), and the
code used `.contains(...).unwrap_or_default()`, silently converting that
`Err` into `false`, causing a spurious assertion failure.

## Fix

Replace the fragile live-follow stream with a polling retry using
`retry_with_msg!`:

* Each attempt opens a fresh SSH session and searches the persisted
  journal (across all boots, non-follow mode) for
  `"Orchestrator shut down gracefully"`.
* On SSH/journal errors the retry loop simply tries again (bounded by a
  5 min overall timeout and `RETRY_BACKOFF`).
* Because we no longer rely on `--follow`, the search still succeeds
  after the node has rebooted into the new version (the message is
  present in a previous boot's journal).

## Verification

Ran 3 parallel executions:

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 \
  //rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test
```

Result:

```
//rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test   PASSED in 916.9s
  Stats over 3 runs: max = 916.9s, min = 780.7s, avg = 847.5s, dev = 55.6s
```

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
