### PR TITLE
fix: relax expectations in system test for nodes catching up

### DIFF
--- a/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
+++ b/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
@@ -432,7 +432,7 @@ pub fn rejoin_test_long_rounds(
     // The restarted node will be the slowest node
     // required for consensus in terms of batch processing time:
     // this way, the restarted node cannot catch up with the subnet
-    // without additional measures (to be implemented in the future).
+    // without additional measures.
     // E.g., for `n = 13`, we have `f = 4` and the nodes at indices
     // `0`, `1`, ..., `n - (f + 1)` are required for consensus,
     // i.e., we restart the node at (0-based) index
@@ -452,7 +452,7 @@ pub fn rejoin_test_long_rounds(
 
     // Wait for the subnet to produce a CUP and then restart the rejoin_node.
     // This way, the restarted node starts from that CUP
-    // and we can assert it to catch up until the next CUP.
+    // and we can assert it to catch up until the second next CUP.
     info!(logger, "Waiting for a CUP ...");
     let reference_node_status = reference_node
         .status()
@@ -470,10 +470,10 @@ pub fn rejoin_test_long_rounds(
     info!(logger, "Start the killed node again ...");
     rejoin_node.vm().start();
 
-    info!(logger, "Waiting for the next CUP ...");
+    info!(logger, "Waiting for the second next CUP ...");
     let last_cup_height = block_on(wait_for_cup(
         &logger,
-        latest_certified_height + dkg_interval + 1,
+        latest_certified_height + 2 * (dkg_interval + 1),
         reference_node.clone(),
     ));
 

--- a/rs/tests/message_routing/rejoin_test_long_rounds.rs
+++ b/rs/tests/message_routing/rejoin_test_long_rounds.rs
@@ -12,8 +12,8 @@ Runbook::
 . start the killed node
 
 Success::
-.. if the restarted node reaches the next CUP height and becomes healthy by the time the next CUP is produced
-.. if metrics confirm that the restarted node skipped cloning many states to speed up its catch-up
+.. if the restarted node reaches the second next CUP height and becomes healthy by the time the second next CUP is produced
+.. if metrics confirm that the restarted node skipped cloning and hashing many states to speed up its catch-up
 
 end::catalog[] */
 


### PR DESCRIPTION
This PR relaxes the expectation in the system test `//rs/tests/message_routing:rejoin_test_long_rounds` so that the restarted node is only expected to catch up with the remaining nodes and become healthy until the _second_ next CUP (the condition used to be until the very next CUP). The motivation for this change is increased test flakiness (nodes not catching up until the very next CUP) which makes sense given the recent optimizations of the DSM overhead which lower the "advantage" (due to skipping state cloning and hashing) of a node that is catching up. Hence, it is expected that the node takes longer to catch up with the remaining nodes of the subnet.

The system test has been executed 59 times over the weekend and only failed 2 times (~3.4% failure rate).