### PR TITLE
chore: add batch_number into SystemMetadata

### DIFF
--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -131,6 +131,7 @@ const CRITICAL_ERROR_MISSING_OR_INVALID_API_BOUNDARY_NODES: &str =
 const CRITICAL_ERROR_NO_CANISTER_ALLOCATION_RANGE: &str = "mr_empty_canister_allocation_range";
 const CRITICAL_ERROR_FAILED_TO_READ_REGISTRY: &str = "mr_failed_to_read_registry_error";
 pub const CRITICAL_ERROR_NON_INCREASING_BATCH_TIME: &str = "mr_non_increasing_batch_time";
+pub const CRITICAL_ERROR_NON_INCREASING_BATCH_NUMBER: &str = "mr_non_increasing_batch_number";
 pub const CRITICAL_ERROR_INDUCT_RESPONSE_FAILED: &str = "mr_induct_response_failed";
 const CRITICAL_ERROR_ILLEGAL_NON_EMPTY_SUBNET_ADMINS: &str = "mr_illegal_non_empty_subnet_admins";
 
@@ -364,6 +365,9 @@ pub(crate) struct MessageRoutingMetrics {
     /// Critical error: the batch times of successive batches were not strictly
     /// monotonically increasing.
     critical_error_non_increasing_batch_time: IntCounter,
+    /// Critical error: the batch numbers of successive batches were not strictly
+    /// monotonically increasing.
+    critical_error_non_increasing_batch_number: IntCounter,
     /// Critical error counter (see [`MetricsRegistry::error_counter`]) tracking
     /// failures to induct responses.
     pub critical_error_induct_response_failed: IntCounter,
@@ -526,6 +530,8 @@ impl MessageRoutingMetrics {
                 .error_counter(CRITICAL_ERROR_FAILED_TO_READ_REGISTRY),
             critical_error_non_increasing_batch_time: metrics_registry
                 .error_counter(CRITICAL_ERROR_NON_INCREASING_BATCH_TIME),
+            critical_error_non_increasing_batch_number: metrics_registry
+                .error_counter(CRITICAL_ERROR_NON_INCREASING_BATCH_NUMBER),
             critical_error_induct_response_failed: metrics_registry
                 .error_counter(CRITICAL_ERROR_INDUCT_RESPONSE_FAILED),
             critical_error_illegal_non_empty_subnet_admins: metrics_registry
@@ -565,6 +571,22 @@ impl MessageRoutingMetrics {
             batch_height,
             state_time,
             batch_time
+        );
+    }
+
+    pub fn observe_non_increasing_batch_number(
+        &self,
+        log: &ReplicaLogger,
+        state_batch_number: Height,
+        batch_number: Height,
+    ) {
+        self.critical_error_non_increasing_batch_number.inc();
+        warn!(
+            log,
+            "{}: Non-increasing batch number: state_batch_number = {}, batch_number = {}.",
+            CRITICAL_ERROR_NON_INCREASING_BATCH_NUMBER,
+            state_batch_number,
+            batch_number
         );
     }
 }

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -1588,6 +1588,7 @@ impl BatchProcessor for FakeBatchProcessorImpl {
 
         let time = batch.time;
         state.metadata.batch_time = time;
+        state.metadata.batch_number = batch.batch_number;
 
         let certification_scope = if batch.requires_full_state_hash() {
             CertificationScope::Full

--- a/rs/messaging/src/state_machine.rs
+++ b/rs/messaging/src/state_machine.rs
@@ -135,6 +135,16 @@ impl StateMachine for StateMachineImpl {
                 batch.batch_number,
             )
         }
+        if batch.batch_number > state.metadata.batch_number {
+            state.metadata.batch_number = batch.batch_number;
+        } else {
+            // Batch number did not advance. This is a bug. (Implicitly) retain the old batch number.
+            self.metrics.observe_non_increasing_batch_number(
+                &self.log,
+                state.metadata.batch_number,
+                batch.batch_number,
+            )
+        }
 
         state.metadata.network_topology = network_topology;
         state.metadata.own_subnet_features = subnet_features;

--- a/rs/messaging/src/state_machine/tests.rs
+++ b/rs/messaging/src/state_machine/tests.rs
@@ -330,7 +330,7 @@ fn split_fixture() -> StateMachineTestFixture {
 fn test_online_split(new_subnet_id: SubnetId, other_subnet_id: SubnetId) -> ReplicatedState {
     let fixture = split_fixture();
     let split_batch = Batch {
-        batch_number: Height::from(0),
+        batch_number: Height::from(1),
         batch_summary: None,
         content: BatchContent::Splitting {
             new_subnet_id,

--- a/rs/messaging/src/state_machine/tests.rs
+++ b/rs/messaging/src/state_machine/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::message_routing::CRITICAL_ERROR_NON_INCREASING_BATCH_TIME;
+use crate::message_routing::{
+    CRITICAL_ERROR_NON_INCREASING_BATCH_NUMBER, CRITICAL_ERROR_NON_INCREASING_BATCH_TIME,
+};
 use crate::routing::demux::MockDemux;
 use crate::routing::stream_builder::MockStreamBuilder;
 use crate::state_machine::StateMachineImpl;
@@ -498,5 +500,89 @@ fn fetch_critical_error_non_increasing_batch_time_count(
 ) -> Option<u64> {
     fetch_int_counter_vec(metrics_registry, "critical_errors")
         .get(&btreemap! { "error".to_string() => CRITICAL_ERROR_NON_INCREASING_BATCH_TIME.to_string() })
+        .cloned()
+}
+
+#[test]
+fn test_batch_number_regression() {
+    test_batch_number_impl(Height::from(2), Height::new(1), Height::from(2), 1);
+}
+
+#[test]
+fn test_batch_number_same() {
+    test_batch_number_impl(Height::from(2), Height::new(2), Height::from(2), 1);
+}
+
+#[test]
+fn test_batch_number_advance() {
+    test_batch_number_impl(Height::from(2), Height::new(3), Height::from(3), 0);
+}
+
+/// Executes a batch with the given `batch_number` on a state with the given
+/// `state_batch_number`. Tests the resulting state's `batch_number` against
+/// `expected_batch_number`, as well as the `mr_non_increasing_batch_number`
+/// critical error counter.
+fn test_batch_number_impl(
+    state_batch_number: Height,
+    batch_number: Height,
+    expected_batch_number: Height,
+    expected_regression_count: u64,
+) {
+    // Batch with the provided `batch_number` and an advancing time.
+    let provided_batch = BatchBuilder::new()
+        .batch_number(batch_number)
+        .time(Time::from_nanos_since_unix_epoch(1))
+        .build();
+
+    // Fixture wrapping a state with the given `state_batch_number` as `batch_number`.
+    let mut fixture = test_fixture(&provided_batch);
+    fixture.initial_state.metadata.batch_number = state_batch_number;
+
+    with_test_replica_logger(|log| {
+        let _ = &fixture;
+        let state_machine = StateMachineImpl::new(
+            fixture.scheduler,
+            fixture.demux,
+            fixture.stream_builder,
+            Default::default(),
+            log,
+            fixture.metrics,
+        );
+
+        assert_eq!(
+            Some(0),
+            fetch_critical_error_non_increasing_batch_number_count(&fixture.metrics_registry)
+        );
+        assert_eq!(
+            state_batch_number,
+            fixture.initial_state.metadata.batch_number
+        );
+
+        let state = state_machine.execute_round(
+            fixture.initial_state,
+            fixture.network_topology.clone(),
+            provided_batch,
+            Default::default(),
+            Default::default(),
+            &test_registry_settings(),
+            Default::default(),
+            Default::default(),
+        );
+
+        assert_eq!(
+            Some(expected_regression_count),
+            fetch_critical_error_non_increasing_batch_number_count(&fixture.metrics_registry)
+        );
+        assert_eq!(expected_batch_number, state.metadata.batch_number);
+    });
+}
+
+fn fetch_critical_error_non_increasing_batch_number_count(
+    metrics_registry: &MetricsRegistry,
+) -> Option<u64> {
+    fetch_int_counter_vec(metrics_registry, "critical_errors")
+        .get(
+            &btreemap! { "error".to_string() => CRITICAL_ERROR_NON_INCREASING_BATCH_NUMBER.to_string() },
+        )
         .cloned()
 }

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -408,6 +408,8 @@ message SystemMetadata {
   repeated ApiBoundaryNodeEntry api_boundary_nodes = 21;
 
   registry.subnet.v1.ResourceLimits own_resource_limits = 24;
+
+  uint64 batch_number = 25;
 }
 
 message StableMemory {

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -589,6 +589,8 @@ pub struct SystemMetadata {
     #[prost(message, optional, tag = "24")]
     pub own_resource_limits:
         ::core::option::Option<super::super::super::registry::subnet::v1::ResourceLimits>,
+    #[prost(uint64, tag = "25")]
+    pub batch_number: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StableMemory {

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -24,7 +24,7 @@ use ic_registry_routing_table::{
 use ic_registry_subnet_features::SubnetFeatures;
 use ic_registry_subnet_type::SubnetType;
 use ic_types::{
-    CountBytes, CryptoHashOfPartialState, NodeId, NumBytes, PrincipalId, SubnetId,
+    CountBytes, CryptoHashOfPartialState, Height, NodeId, NumBytes, PrincipalId, SubnetId,
     batch::BlockmakerMetrics,
     crypto::CryptoHash,
     ingress::{IngressState, IngressStatus},
@@ -86,6 +86,11 @@ pub struct SystemMetadata {
     /// NOTE: this time is monotonically increasing (and not strictly
     /// increasing).
     pub batch_time: Time,
+
+    /// The Consensus-determined height of this batch.
+    /// NOTE: this height is monotonically increasing (and not strictly
+    /// increasing).
+    pub batch_number: Height,
 
     pub network_topology: NetworkTopology,
 
@@ -498,6 +503,7 @@ impl SystemMetadata {
             canister_allocation_ranges: Default::default(),
             last_generated_canister_id: None,
             batch_time: UNIX_EPOCH,
+            batch_number: Height::from(0),
             network_topology: Default::default(),
             subnet_call_context_manager: Default::default(),
             own_subnet_features: SubnetFeatures::default(),
@@ -740,6 +746,7 @@ impl SystemMetadata {
         } else {
             self.batch_time
         };
+        res.batch_number = self.batch_number;
 
         // All other fields have been reset to default.
         Ok(res)
@@ -797,6 +804,8 @@ impl SystemMetadata {
             prev_state_hash: _,
             // Overwritten as soon as the round begins, no explicit action needed.
             batch_time: _,
+            // Overwritten as soon as the round begins, no explicit action needed.
+            batch_number: _,
             // Overwritten as soon as the round begins, no explicit action needed.
             network_topology: _,
             ref own_subnet_id,
@@ -927,6 +936,7 @@ impl SystemMetadata {
             mut bitcoin_get_successors_follow_up_responses,
             blockmaker_metrics_time_series,
             unflushed_checkpoint_ops,
+            batch_number,
         } = self;
 
         assert_eq!(None, split_from);
@@ -1011,6 +1021,7 @@ impl SystemMetadata {
             last_generated_canister_id,
             prev_state_hash,
             batch_time,
+            batch_number,
             // Already populated from the registry.
             network_topology,
             // New subnet ID.
@@ -2118,6 +2129,7 @@ pub mod testing {
             canister_allocation_ranges: Default::default(),
             last_generated_canister_id: None,
             batch_time: UNIX_EPOCH,
+            batch_number: Height::from(0),
             // Not relevant, gets populated every round.
             network_topology: Default::default(),
             // Covered in `super::subnet_call_context_manager::testing`.

--- a/rs/replicated_state/src/metadata_state/proto.rs
+++ b/rs/replicated_state/src/metadata_state/proto.rs
@@ -319,6 +319,7 @@ impl From<&SystemMetadata> for pb_metadata::SystemMetadata {
                 .clone()
                 .map(|prev_hash| prev_hash.get().0),
             batch_time_nanos: item.batch_time.as_nanos_since_unix_epoch(),
+            batch_number: item.batch_number.get(),
             streams: item
                 .streams
                 .iter()
@@ -434,6 +435,7 @@ impl
         }
 
         let batch_time = Time::from_nanos_since_unix_epoch(item.batch_time_nanos);
+        let batch_number = Height::from(item.batch_number);
 
         let mut node_public_keys = BTreeMap::<NodeId, Vec<u8>>::new();
         for entry in item.node_public_keys {
@@ -477,6 +479,7 @@ impl
             last_generated_canister_id,
             prev_state_hash: item.prev_state_hash.map(|b| CryptoHash(b).into()),
             batch_time,
+            batch_number,
             // Ingress history is persisted separately. We rely on `load_checkpoint()` to
             // properly set this value.
             ingress_history: Default::default(),


### PR DESCRIPTION
This PR adds `batch_number` to `SystemMetadata`. The motivation for this change is to fix the execution environment (in a follow-up PR) to pass that `batch_number` instead of `state_reader.latest_state_height() + Height::from(1)` to `completed_execution_messages_tx` (channel notifying the synchronous update call HTTP handler) since using the height of the latest state stored in the state manager is imprecise (that state need not match the actual state on which the execution environment operates).

Once this PR is rolled out to all subnets, the critical error `mr_non_increasing_batch_number` could be further tightened to require that `batch_number` in `SystemMetadata` increases by exactly one (since batches must not be skipped). We cannot assert that stricter property now since `batch_number` is not recorded in existing `SystemMetadata` and thus will be implicitly initialized to `0` when deserializing the checkpoint.