### PR TITLE
fix: deflake //rs/tests/crypto:canister_sig_verification_cache_test

### DIFF
--- a/rs/tests/crypto/canister_sig_verification_cache_test.rs
+++ b/rs/tests/crypto/canister_sig_verification_cache_test.rs
@@ -365,7 +365,7 @@ async fn scrape_metrics_and_check_cache_stats(env: &TestEnv, user_i: usize, call
                         "For user={user_i} after call={call_j}, \
                         observed (num_cache_hits={num_cache_hits}, num_cache_misses={num_cache_misses}, cache_size={cache_size}) = \
                         with num_cache_hits + num_cache_misses = {} \
-                        while expecting (MIN_NUM_BLS_SIG_VERS_PER_CALL * (user + 1) * (call + 1)) = {} -> Retrying \
+                        while expecting at least (MIN_NUM_BLS_SIG_VERS_PER_CALL * (user + 1) * (call + 1)) = {} -> Retrying \
                         {count_waiting_for_expected_values}/{NUM_RETRIES}",
                         num_cache_hits + num_cache_misses,
                         (MIN_NUM_BLS_SIG_VERS_PER_CALL * (user_i + 1) * (call_j + 1))

--- a/rs/tests/crypto/canister_sig_verification_cache_test.rs
+++ b/rs/tests/crypto/canister_sig_verification_cache_test.rs
@@ -13,10 +13,11 @@ query (checking the count) calls for each user to the counter canister. Then, sc
 from the node directly, fetching the cache statistics. Finally, check that the cache statistics are sound:
 - cache size == number of cache misses
 - number of cache misses is between 2 and number of users + 1
-- number of cache hits + number of cache misses equals number of BLS sig verification per
-  request * user_id * number of calls per user, for each user
+- number of cache hits + number of cache misses is at least number of BLS sig verification per
+  request * user_id * number of calls per user, for each user (the actual number may be higher
+  due to additional BLS sig verifications triggered by, e.g., `read_state` polls during
+  `call_and_wait`)
 - for the 1st user, number of cache misses is exactly 2
-- for the 1st user, implicitly ensures the correct number of cache hits after *each* counter canister call
 - for the 2nd user, number of cache misses is exactly 3
 end::catalog[] */
 
@@ -48,9 +49,13 @@ use std::time::Duration;
 const HITS_STR: &str = "crypto_bls12_381_sig_cache_hits";
 const MISSES_STR: &str = "crypto_bls12_381_sig_cache_misses";
 const SIZE_STR: &str = "crypto_bls12_381_sig_cache_size";
-/// in the current implementation, for a single-replica subnet, a user call requires
-/// 8 BLS signature verifications for updating the counter of the counter canister
-const NUM_BLS_SIG_VERS_PER_CALL: usize = 8;
+/// In the current implementation, for a single-replica subnet, a user call requires
+/// at least 8 BLS signature verifications for updating the counter of the counter
+/// canister. The actual number may be higher, e.g., because `ic-agent`'s
+/// `call_and_wait` issues additional `read_state` polls while waiting for the
+/// response, each of which triggers additional BLS signature verifications on the
+/// replica during ingress message validation.
+const MIN_NUM_BLS_SIG_VERS_PER_CALL: usize = 8;
 
 /// delay for retrying a failed action in this test
 const RETRY_DELAY: Duration = Duration::from_secs(1);
@@ -314,7 +319,7 @@ async fn scrape_metrics_and_check_cache_stats(env: &TestEnv, user_i: usize, call
                 let num_cache_misses = val[MISSES_STR][0];
                 let cache_size = val[SIZE_STR][0];
                 if (num_cache_hits + num_cache_misses) as usize
-                    == (NUM_BLS_SIG_VERS_PER_CALL * (user_i + 1) * (call_j + 1))
+                    >= (MIN_NUM_BLS_SIG_VERS_PER_CALL * (user_i + 1) * (call_j + 1))
                 {
                     assert_eq!(
                         cache_size, num_cache_misses,
@@ -360,10 +365,10 @@ async fn scrape_metrics_and_check_cache_stats(env: &TestEnv, user_i: usize, call
                         "For user={user_i} after call={call_j}, \
                         observed (num_cache_hits={num_cache_hits}, num_cache_misses={num_cache_misses}, cache_size={cache_size}) = \
                         with num_cache_hits + num_cache_misses = {} \
-                        while expecting (NUM_BLS_SIG_VERS_PER_CALL * (user + 1) * (call + 1)) = {} -> Retrying \
+                        while expecting (MIN_NUM_BLS_SIG_VERS_PER_CALL * (user + 1) * (call + 1)) = {} -> Retrying \
                         {count_waiting_for_expected_values}/{NUM_RETRIES}",
                         num_cache_hits + num_cache_misses,
-                        (NUM_BLS_SIG_VERS_PER_CALL * (user_i + 1) * (call_j + 1))
+                        (MIN_NUM_BLS_SIG_VERS_PER_CALL * (user_i + 1) * (call_j + 1))
                     );
                     tokio::time::sleep(RETRY_DELAY).await;
                 }


### PR DESCRIPTION
# Root cause

The test in `rs/tests/crypto/canister_sig_verification_cache_test.rs` waits for the app subnet's BLS signature cache metrics (`crypto_bls12_381_sig_cache_hits`, `crypto_bls12_381_sig_cache_misses`) to reach a specific expected count after each counter canister call, and hard-checks equality:

```rust
if (num_cache_hits + num_cache_misses) as usize
    == (NUM_BLS_SIG_VERS_PER_CALL * (user_i + 1) * (call_j + 1))
```

with `NUM_BLS_SIG_VERS_PER_CALL = 8`.

However, the actual number of BLS signature verifications performed on the app subnet for a single counter call is **at least** 8 but can be higher. Extra verifications can happen, for example, because `ic-agent`'s `call_and_wait` issues additional `read_state` polls while waiting for the call response, and each poll triggers ingress validation that verifies the II subnet delegation (BLS) and the canister signature (BLS).

Since the cache counters are monotonically increasing, once they pass the expected value they can never match it again, so the loop exhausts its 100 retries and the test fails with:

```
Expected cache state was not observed after 100 retries each with the timeout of 1 secs
```

All 5 recent flaky runs (last week) showed the same symptom: observed count strictly greater than expected. Examples:

| user | call | observed hits+misses | expected |
|------|------|----------------------|----------|
| 0    | 0    | 14                   | 8        |
| 0    | 4    | 44                   | 40       |
| 1    | 7    | 220                  | 128      |
| 2    | 7    | 200                  | 192      |
| 2    | 7    | 224                  | 192      |

# Fix

Relax the wait condition from `==` to `>=` and rename the constant to `MIN_NUM_BLS_SIG_VERS_PER_CALL` to reflect that it is a lower bound. The other invariants remain unchanged and continue to verify correctness:

- `cache_size == num_cache_misses`
- `2 <= num_cache_misses <= user_i + 2`
- For user 0: `num_cache_misses == 2`
- For user 1: `num_cache_misses == 3`

# Verification

Ran the test 3 times in parallel, all passed:

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 \
    //rs/tests/crypto:canister_sig_verification_cache_test
//rs/tests/crypto:canister_sig_verification_cache_test        PASSED in 127.0s
  Stats over 3 runs: max = 127.0s, min = 110.0s, avg = 117.9s, dev = 7.0s
```

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
