### PR TITLE
fix: notify sync update call HTTP handler with correct state height

### DIFF
--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -602,6 +602,7 @@ impl ExecutionEnvironment {
         msg: &mut CanisterCall,
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult
     where
         F: for<'a, 'b> FnOnce(
@@ -621,7 +622,12 @@ impl ExecutionEnvironment {
                 let saved_canister = canister.clone();
                 let saved_round_limits = round_limits.clone();
                 match op(canister, round_limits, &mut consumed_cycles) {
-                    Ok(response) => self.process_canister_manager_result(Ok(response), state, msg),
+                    Ok(response) => self.process_canister_manager_result(
+                        Ok(response),
+                        state,
+                        msg,
+                        current_round,
+                    ),
                     Err(err) => {
                         *canister = saved_canister;
                         *round_limits = saved_round_limits;
@@ -632,7 +638,7 @@ impl ExecutionEnvironment {
                             cost_schedule,
                             &self.metrics.failed_subnet_message_charge,
                         );
-                        self.process_canister_manager_result(Err(err), state, msg)
+                        self.process_canister_manager_result(Err(err), state, msg, current_round)
                     }
                 }
             }
@@ -783,6 +789,7 @@ impl ExecutionEnvironment {
                     refund,
                 },
                 since,
+                current_round,
             );
         }
 
@@ -799,6 +806,7 @@ impl ExecutionEnvironment {
                     instruction_limits,
                     round_limits,
                     registry_settings.subnet_size,
+                    current_round,
                 );
             }
 
@@ -814,6 +822,7 @@ impl ExecutionEnvironment {
                     instruction_limits,
                     round_limits,
                     registry_settings.subnet_size,
+                    current_round,
                 );
             }
 
@@ -965,6 +974,7 @@ impl ExecutionEnvironment {
                         subnet_admins,
                         time,
                         registry_settings,
+                        current_round,
                     )
                 }
             },
@@ -996,6 +1006,7 @@ impl ExecutionEnvironment {
                                 &mut msg,
                                 round_limits,
                                 registry_settings,
+                                current_round,
                             ),
                         };
                         // The induction cost of `UpdateSettings` is charged
@@ -1121,6 +1132,7 @@ impl ExecutionEnvironment {
                         subnet_admins,
                         round_limits,
                         registry_settings,
+                        current_round,
                     )
                 }
             },
@@ -1132,7 +1144,13 @@ impl ExecutionEnvironment {
                 },
                 Ok(args) => {
                     let subnet_admins = state.get_own_subnet_admins();
-                    self.stop_canister(args.get_canister_id(), &mut msg, &mut state, subnet_admins)
+                    self.stop_canister(
+                        args.get_canister_id(),
+                        &mut msg,
+                        &mut state,
+                        subnet_admins,
+                        current_round,
+                    )
                 }
             },
 
@@ -1188,7 +1206,7 @@ impl ExecutionEnvironment {
                 },
                 Ok(args) => {
                     let canister_id = args.get_canister_id();
-                    self.deposit_cycles(canister_id, &mut msg, &mut state)
+                    self.deposit_cycles(canister_id, &mut msg, &mut state, current_round)
                 }
             },
 
@@ -1619,6 +1637,7 @@ impl ExecutionEnvironment {
                         &registry_settings.provisional_whitelist,
                         round_limits,
                         registry_settings,
+                        current_round,
                     ),
                 }
             }
@@ -1699,6 +1718,7 @@ impl ExecutionEnvironment {
                         round_limits,
                         registry_settings,
                         &resource_saturation,
+                        current_round,
                     ),
                 }
             }
@@ -1721,6 +1741,7 @@ impl ExecutionEnvironment {
                         round_limits,
                         registry_settings,
                         &resource_saturation,
+                        current_round,
                     )
                 }
             },
@@ -1849,6 +1870,7 @@ impl ExecutionEnvironment {
                     args,
                     round_limits,
                     registry_settings,
+                    current_round,
                 ),
             },
 
@@ -1869,6 +1891,7 @@ impl ExecutionEnvironment {
                         instruction_limits,
                         origin,
                         registry_settings,
+                        current_round,
                     )
                 }
             },
@@ -1904,6 +1927,7 @@ impl ExecutionEnvironment {
                             round_limits,
                             registry_settings,
                             &resource_saturation,
+                            current_round,
                         )
                     }
                 }
@@ -1940,6 +1964,7 @@ impl ExecutionEnvironment {
                         args,
                         round_limits,
                         registry_settings,
+                        current_round,
                     ),
                 }
             }
@@ -1957,6 +1982,7 @@ impl ExecutionEnvironment {
                         args,
                         round_limits,
                         registry_settings,
+                        current_round,
                     ),
                 }
             }
@@ -1974,6 +2000,7 @@ impl ExecutionEnvironment {
                         args,
                         round_limits,
                         registry_settings,
+                        current_round,
                     ),
                 }
             }
@@ -2011,7 +2038,7 @@ impl ExecutionEnvironment {
         //   - `VetKdDeriveKey`
         // If you modify code below, please also update
         // these cases.
-        self.finish_subnet_message_execution(state, msg, result, since)
+        self.finish_subnet_message_execution(state, msg, result, since, current_round)
     }
 
     /// Applies changes to `ReplicatedState` and constructs `ExecuteSubnetMessageResult`
@@ -2021,6 +2048,7 @@ impl ExecutionEnvironment {
         result: Result<CanisterManagerResponse, CanisterManagerError>,
         state: &mut ReplicatedState,
         msg: &mut CanisterCall,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         match result {
             Ok(response) => {
@@ -2045,11 +2073,13 @@ impl ExecutionEnvironment {
                     Arc::clone(&self.ingress_history_writer),
                     self.log.clone(),
                     &self.metrics.canister_not_found_error,
+                    current_round,
                 );
                 self.reject_stop_requests(
                     response.canister_id,
                     response.stop_contexts_to_reject,
                     state,
+                    current_round,
                 );
                 if let Some(call_id) = response.stop_call_id_to_remove {
                     self.remove_stop_canister_call(state, response.canister_id, Some(call_id));
@@ -2157,6 +2187,7 @@ impl ExecutionEnvironment {
         message: CanisterCall,
         result: ExecuteSubnetMessageResult,
         since: Instant,
+        current_round: ExecutionRound,
     ) -> (ReplicatedState, ExecuteSubnetMessageResultType) {
         match &result {
             ExecuteSubnetMessageResult::Processing => {}
@@ -2183,7 +2214,7 @@ impl ExecutionEnvironment {
                 );
             }
         }
-        self.output_subnet_response(message, state, result)
+        self.output_subnet_response(message, state, result, current_round)
     }
 
     /// Executes a replicated message sent to a canister or a canister task.
@@ -2455,6 +2486,7 @@ impl ExecutionEnvironment {
         msg: &mut CanisterCall,
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         let cost_schedule = state.get_own_cost_schedule();
         let saturation = self.subnet_memory_saturation(
@@ -2480,6 +2512,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -2493,6 +2526,7 @@ impl ExecutionEnvironment {
         subnet_admins: Option<BTreeSet<PrincipalId>>,
         time: Time,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         self.execute_mgmt_operation_on_canister(
             canister_id,
@@ -2509,6 +2543,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -2521,6 +2556,7 @@ impl ExecutionEnvironment {
         subnet_admins: Option<BTreeSet<PrincipalId>>,
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         self.execute_mgmt_operation_on_canister(
             canister_id,
@@ -2532,6 +2568,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -2540,6 +2577,7 @@ impl ExecutionEnvironment {
         canister_id: CanisterId,
         msg: &mut CanisterCall,
         state: &mut ReplicatedState,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         match state.canister_state_make_mut(&canister_id) {
             None => {
@@ -2559,7 +2597,7 @@ impl ExecutionEnvironment {
                 let response = self
                     .canister_manager
                     .deposit_cycles(canister_state, cycles, sender);
-                self.process_canister_manager_result(Ok(response), state, msg)
+                self.process_canister_manager_result(Ok(response), state, msg, current_round)
             }
         }
     }
@@ -2634,6 +2672,7 @@ impl ExecutionEnvironment {
         msg: &mut CanisterCall,
         state: &mut ReplicatedState,
         subnet_admins: Option<BTreeSet<PrincipalId>>,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         let call_id = state
             .metadata
@@ -2659,7 +2698,7 @@ impl ExecutionEnvironment {
         if result.is_err() {
             self.remove_stop_canister_call(state, canister_id, Some(call_id));
         }
-        self.process_canister_manager_result(result, state, msg)
+        self.process_canister_manager_result(result, state, msg, current_round)
     }
 
     fn add_cycles(
@@ -2672,6 +2711,7 @@ impl ExecutionEnvironment {
         provisional_whitelist: &ProvisionalWhitelist,
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         self.execute_mgmt_operation_on_canister(
             canister_id,
@@ -2683,6 +2723,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -2695,6 +2736,7 @@ impl ExecutionEnvironment {
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
         resource_saturation: &ResourceSaturation,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         let cost_schedule = state.get_own_cost_schedule();
         let canister_id = args.get_canister_id();
@@ -2717,6 +2759,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -2729,6 +2772,7 @@ impl ExecutionEnvironment {
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
         resource_saturation: &ResourceSaturation,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         let cost_schedule = state.get_own_cost_schedule();
         let canister_id = args.get_canister_id();
@@ -2748,6 +2792,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -2773,6 +2818,7 @@ impl ExecutionEnvironment {
         args: TakeCanisterSnapshotArgs,
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         let canister_id = args.get_canister_id();
         let cost_schedule = state.get_own_cost_schedule();
@@ -2802,6 +2848,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -2816,6 +2863,7 @@ impl ExecutionEnvironment {
         instruction_limits: InstructionLimits,
         origin: CanisterChangeOrigin,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         // Check if the canister on which the snapshot is loaded exists.
         // We do this check at the very beginning for the sake of consistency
@@ -2884,6 +2932,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -2911,6 +2960,7 @@ impl ExecutionEnvironment {
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
         resource_saturation: &ResourceSaturation,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         let canister_id = args.get_canister_id();
         let cost_schedule = state.get_own_cost_schedule();
@@ -2931,6 +2981,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -2942,6 +2993,7 @@ impl ExecutionEnvironment {
         args: ReadCanisterSnapshotDataArgs,
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         let canister_id = args.get_canister_id();
         let cost_schedule = state.get_own_cost_schedule();
@@ -2963,6 +3015,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -3034,6 +3087,7 @@ impl ExecutionEnvironment {
         args: UploadCanisterSnapshotMetadataArgs,
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         let canister_id = args.get_canister_id();
         let cost_schedule = state.get_own_cost_schedule();
@@ -3060,6 +3114,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -3071,6 +3126,7 @@ impl ExecutionEnvironment {
         args: UploadCanisterSnapshotDataArgs,
         round_limits: &mut RoundLimits,
         registry_settings: &RegistryExecutionSettings,
+        current_round: ExecutionRound,
     ) -> ExecuteSubnetMessageResult {
         let canister_id = args.get_canister_id();
         let cost_schedule = state.get_own_cost_schedule();
@@ -3096,6 +3152,7 @@ impl ExecutionEnvironment {
             msg,
             round_limits,
             registry_settings,
+            current_round,
         )
     }
 
@@ -3346,6 +3403,7 @@ impl ExecutionEnvironment {
         msg: CanisterCall,
         mut state: ReplicatedState,
         result: ExecuteSubnetMessageResult,
+        current_round: ExecutionRound,
     ) -> (ReplicatedState, ExecuteSubnetMessageResultType) {
         match msg {
             CanisterCall::Request(req) => match result {
@@ -3384,6 +3442,7 @@ impl ExecutionEnvironment {
                         &mut state,
                         ingress.message_id.clone(),
                         status,
+                        current_round,
                     );
                     (state, ExecuteSubnetMessageResultType::Processing)
                 }
@@ -3418,6 +3477,7 @@ impl ExecutionEnvironment {
                         &mut state,
                         ingress.message_id.clone(),
                         status,
+                        current_round,
                     );
                     (state, ExecuteSubnetMessageResultType::Finished)
                 }
@@ -3432,6 +3492,7 @@ impl ExecutionEnvironment {
         canister_id: CanisterId,
         stop_contexts: Vec<StopCanisterContext>,
         state: &mut ReplicatedState,
+        current_round: ExecutionRound,
     ) {
         for stop_context in stop_contexts {
             match stop_context {
@@ -3455,6 +3516,7 @@ impl ExecutionEnvironment {
                                 format!("Canister {canister_id}'s stop request was cancelled."),
                             )),
                         },
+                        current_round,
                     );
                 }
                 StopCanisterContext::Canister {
@@ -3890,6 +3952,7 @@ impl ExecutionEnvironment {
         instruction_limits: InstructionLimits,
         round_limits: &mut RoundLimits,
         subnet_size: usize,
+        current_round: ExecutionRound,
     ) -> (ReplicatedState, ExecuteSubnetMessageResultType) {
         // Start logging execution time for `install_code`.
         let since = Instant::now();
@@ -3907,6 +3970,7 @@ impl ExecutionEnvironment {
                             refund,
                         },
                         since,
+                        current_round,
                     );
                 }
             };
@@ -3995,7 +4059,7 @@ impl ExecutionEnvironment {
             state.get_own_cost_schedule(),
             self.config.dirty_page_logging,
         );
-        self.process_install_code_result(state, dts_result, dts_status, since)
+        self.process_install_code_result(state, dts_result, dts_status, since, current_round)
     }
 
     /// Processes the result of install code message that was executed using
@@ -4012,6 +4076,7 @@ impl ExecutionEnvironment {
         dts_result: DtsInstallCodeResult,
         dts_status: DtsInstallCodeStatus,
         since: Instant,
+        current_round: ExecutionRound,
     ) -> (ReplicatedState, ExecuteSubnetMessageResultType) {
         let execution_duration = since.elapsed().as_secs_f64();
         match dts_result {
@@ -4078,6 +4143,7 @@ impl ExecutionEnvironment {
                         refund,
                     },
                     since,
+                    current_round,
                 )
             }
             DtsInstallCodeResult::Paused {
@@ -4093,8 +4159,12 @@ impl ExecutionEnvironment {
 
                 match (dts_status, ingress_status) {
                     (DtsInstallCodeStatus::StartingFirstExecution, Some((message_id, status))) => {
-                        self.ingress_history_writer
-                            .set_status(&mut state, message_id, status);
+                        self.ingress_history_writer.set_status(
+                            &mut state,
+                            message_id,
+                            status,
+                            current_round,
+                        );
                     }
                     (DtsInstallCodeStatus::StartingFirstExecution, None) => {
                         // The original message is not an ingress message.
@@ -4127,6 +4197,7 @@ impl ExecutionEnvironment {
         instruction_limits: InstructionLimits,
         round_limits: &mut RoundLimits,
         subnet_size: usize,
+        current_round: ExecutionRound,
     ) -> (ReplicatedState, ExecuteSubnetMessageResultType) {
         let task = state
             .canister_state_make_mut(canister_id)
@@ -4169,7 +4240,13 @@ impl ExecutionEnvironment {
                 };
                 let dts_result = paused.resume(canister, round, round_limits);
                 let dts_status = DtsInstallCodeStatus::ResumingPausedOrAbortedExecution;
-                self.process_install_code_result(state, dts_result, dts_status, since)
+                self.process_install_code_result(
+                    state,
+                    dts_result,
+                    dts_status,
+                    since,
+                    current_round,
+                )
             }
             ExecutionTask::AbortedInstallCode {
                 message,
@@ -4184,6 +4261,7 @@ impl ExecutionEnvironment {
                 instruction_limits,
                 round_limits,
                 subnet_size,
+                current_round,
             ),
         }
     }
@@ -4394,6 +4472,7 @@ impl ExecutionEnvironment {
         canister_id: CanisterId,
         time: Time,
         reply: StopCanisterReply,
+        current_round: ExecutionRound,
     ) {
         let call_id = stop_context.call_id();
         self.remove_stop_canister_call(state, canister_id, *call_id);
@@ -4421,6 +4500,7 @@ impl ExecutionEnvironment {
                         time,
                         state: ingress_state,
                     },
+                    current_round,
                 );
             }
             StopCanisterContext::Canister {
@@ -4497,7 +4577,11 @@ impl ExecutionEnvironment {
     ///
     /// Responses to the pending stop messages are written to ingress history
     /// or returned to the calling canisters respectively.
-    pub fn process_stopping_canisters(&self, mut state: ReplicatedState) -> ReplicatedState {
+    pub fn process_stopping_canisters(
+        &self,
+        mut state: ReplicatedState,
+        current_round: ExecutionRound,
+    ) -> ReplicatedState {
         let mut canister_states = state.take_canister_states();
         let time = state.time();
 
@@ -4542,6 +4626,7 @@ impl ExecutionEnvironment {
                     } else {
                         StopCanisterReply::Timeout
                     },
+                    current_round,
                 );
             }
         }

--- a/rs/execution_environment/src/history.rs
+++ b/rs/execution_environment/src/history.rs
@@ -11,11 +11,11 @@ use ic_metrics::{
     buckets::{decimal_buckets, linear_buckets},
 };
 use ic_replicated_state::ReplicatedState;
+use ic_types::state_manager::StateManagerError;
 use ic_types::{
-    Height, Time,
+    ExecutionRound, Height, Time,
     ingress::{IngressState, IngressStatus},
     messages::MessageId,
-    state_manager::StateManagerError,
 };
 use prometheus::{Histogram, HistogramVec};
 use std::{
@@ -92,7 +92,6 @@ pub struct IngressHistoryWriterImpl {
     log: ReplicaLogger,
     metrics: IngressHistoryMetrics,
     completed_execution_messages_tx: Sender<(MessageId, Height)>,
-    state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
 }
 
 struct IngressHistoryMetrics {
@@ -115,7 +114,6 @@ impl IngressHistoryWriterImpl {
         log: ReplicaLogger,
         metrics_registry: &MetricsRegistry,
         completed_execution_messages_tx: Sender<(MessageId, Height)>,
-        state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
     ) -> Self {
         Self {
             config,
@@ -181,7 +179,6 @@ impl IngressHistoryWriterImpl {
                 )
             },
             completed_execution_messages_tx,
-            state_reader
         }
     }
 }
@@ -194,6 +191,7 @@ impl IngressHistoryWriter for IngressHistoryWriterImpl {
         state: &mut Self::State,
         message_id: MessageId,
         status: IngressStatus,
+        current_round: ExecutionRound,
     ) -> Arc<IngressStatus> {
         let time = state.time();
         let current_status = state.get_ingress_status(&message_id);
@@ -312,11 +310,10 @@ impl IngressHistoryWriter for IngressHistoryWriterImpl {
             // We want to send the height of the replicated state where
             // ingress message went into a terminal state.
             //
-            // latest_state_height() will return the height of the last committed state, `H`.
-            // The ingress message will have completed execution AND be updated to a terminal state from the next state, `H+1`.
-            let last_committed_height = self.state_reader.latest_state_height();
+            // After `ExecutionRound h` completes, the resulting state is marked
+            // with `Height h`, so `current_round` directly gives the height.
             let completed_execution_and_updated_to_terminal_state: Height =
-                last_committed_height + Height::from(1);
+                Height::from(current_round.get());
 
             let _ = self.completed_execution_messages_tx.try_send((
                 message_id.clone(),

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -345,7 +345,6 @@ fn setup_execution_helper(
         logger.clone(),
         metrics_registry,
         completed_execution_messages_tx,
-        Arc::clone(&state_reader),
     ));
     let ingress_history_reader = Box::new(IngressHistoryReaderImpl::new(Arc::clone(&state_reader)));
 

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -196,6 +196,7 @@ impl SchedulerImpl {
         long_running_canisters: &[CanisterId],
         measurement_scope: &MeasurementScope,
         subnet_size: usize,
+        current_round: ExecutionRound,
     ) -> ReplicatedState {
         let mut ongoing_long_install_code = false;
         for canister_id in long_running_canisters.iter() {
@@ -217,6 +218,7 @@ impl SchedulerImpl {
                     instruction_limits,
                     round_limits,
                     subnet_size,
+                    current_round,
                 );
             state = new_state;
             ongoing_long_install_code |= state
@@ -606,9 +608,12 @@ impl SchedulerImpl {
         }
 
         for (message_id, status) in ingress_execution_results {
-            let old_status = self
-                .ingress_history_writer
-                .set_status(&mut state, message_id, status);
+            let old_status = self.ingress_history_writer.set_status(
+                &mut state,
+                message_id,
+                status,
+                current_round,
+            );
             canister_ingress_latencies.on_ingress_status_changed(&old_status);
         }
 
@@ -764,6 +769,7 @@ impl SchedulerImpl {
         &self,
         state: &mut ReplicatedState,
         canister_ingress_latencies: &mut CanisterIngressQueueLatencies,
+        current_round: ExecutionRound,
     ) {
         let current_time = state.time();
         let not_expired = |ingress: &Ingress| ingress.expiry_time >= current_time;
@@ -795,6 +801,7 @@ impl SchedulerImpl {
                     time: current_time,
                     state: IngressState::Failed(error),
                 },
+                current_round,
             );
             canister_ingress_latencies.on_ingress_status_changed(&old_status);
         }
@@ -807,6 +814,7 @@ impl SchedulerImpl {
         &self,
         state: &mut ReplicatedState,
         subnet_size: usize,
+        current_round: ExecutionRound,
     ) {
         let cost_schedule = state.get_own_cost_schedule();
         let state_time = state.time();
@@ -878,6 +886,7 @@ impl SchedulerImpl {
                 Arc::clone(&self.ingress_history_writer),
                 self.log.clone(),
                 self.exec_env.canister_not_found_error(),
+                current_round,
             );
         }
     }
@@ -1213,7 +1222,11 @@ impl Scheduler for SchedulerImpl {
 
             {
                 let _timer = self.metrics.round_preparation_ingress.start_timer();
-                self.purge_expired_ingress_messages(&mut state, &mut canister_ingress_latencies);
+                self.purge_expired_ingress_messages(
+                    &mut state,
+                    &mut canister_ingress_latencies,
+                    current_round,
+                );
             }
 
             // In the future, subnet messages might be executed in threads. In
@@ -1404,6 +1417,7 @@ impl Scheduler for SchedulerImpl {
                 &long_running_canisters,
                 &measurement_scope,
                 registry_settings.subnet_size,
+                current_round,
             );
 
             scheduler_round_limits.update_subnet_round_limits(&subnet_round_limits);
@@ -1533,7 +1547,9 @@ impl Scheduler for SchedulerImpl {
             // beginning of the round), then canister deletion logic should be revised.
             {
                 let _timer = self.metrics.round_finalization_stop_canisters.start_timer();
-                final_state = self.exec_env.process_stopping_canisters(state);
+                final_state = self
+                    .exec_env
+                    .process_stopping_canisters(state, current_round);
             }
             {
                 let _timer = self.metrics.round_finalization_ingress.start_timer();
@@ -1544,6 +1560,7 @@ impl Scheduler for SchedulerImpl {
                 self.charge_canisters_for_resource_allocation_and_usage(
                     &mut final_state,
                     registry_settings.subnet_size,
+                    current_round,
                 );
             }
 

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -654,6 +654,7 @@ impl SchedulerTest {
             .charge_canisters_for_resource_allocation_and_usage(
                 self.state.as_mut().unwrap(),
                 subnet_size,
+                ExecutionRound::from(0),
             )
     }
 

--- a/rs/execution_environment/src/util.rs
+++ b/rs/execution_environment/src/util.rs
@@ -2,7 +2,7 @@ use crate::types::Response;
 use ic_interfaces::execution_environment::IngressHistoryWriter;
 use ic_logger::{ReplicaLogger, error};
 use ic_replicated_state::ReplicatedState;
-use ic_types::CanisterId;
+use ic_types::{CanisterId, ExecutionRound};
 use prometheus::IntCounter;
 use std::sync::Arc;
 
@@ -48,6 +48,7 @@ pub fn process_responses(
     ingress_history_writer: Arc<dyn IngressHistoryWriter<State = ReplicatedState>>,
     log: ReplicaLogger,
     canister_not_found_error: &IntCounter,
+    current_round: ExecutionRound,
 ) {
     responses.into_iter().for_each(|response| match response {
         Response::Ingress(ingress_response) => {
@@ -55,6 +56,7 @@ pub fn process_responses(
                 state,
                 ingress_response.message_id,
                 ingress_response.status,
+                current_round,
             );
         }
         Response::Canister(canister_response) => {

--- a/rs/execution_environment/tests/history.rs
+++ b/rs/execution_environment/tests/history.rs
@@ -7,17 +7,15 @@ use ic_interfaces_state_manager_mocks::MockStateManager;
 use ic_metrics::MetricsRegistry;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::ReplicatedState;
-use ic_test_utilities::state_manager::FakeStateManager;
 use ic_test_utilities_logger::with_test_replica_logger;
 use ic_test_utilities_types::ids::{
     canister_test_id, message_test_id, subnet_test_id, user_test_id,
 };
 use ic_types::{
-    Height,
+    ExecutionRound, Height,
     ingress::{IngressState, IngressStatus, WasmResult},
     time::UNIX_EPOCH,
 };
-use std::sync::Arc;
 use tokio::sync::mpsc::{channel, error::TryRecvError};
 
 use IngressStatus::*;
@@ -98,12 +96,8 @@ fn valid_transitions() -> Vec<(IngressStatus, Vec<IngressStatus>)> {
 #[test]
 fn test_terminal_states_are_transmitted() {
     with_test_replica_logger(|log| {
-        let mut state_manager = MockStateManager::new();
-
-        let last_committed_state_height = Height::new(10);
-        state_manager
-            .expect_latest_state_height()
-            .return_const(last_committed_state_height);
+        let current_round = ExecutionRound::from(11);
+        let expected_height = Height::from(current_round.get());
 
         let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
         let (completed_execution_messages_tx, mut completed_execution_messages_rx) = channel(100);
@@ -112,18 +106,27 @@ fn test_terminal_states_are_transmitted() {
             log,
             &MetricsRegistry::new(),
             completed_execution_messages_tx,
-            Arc::new(state_manager),
         );
         let message_id = message_test_id(1);
 
-        ingress_history_writer.set_status(&mut state, message_id.clone(), received());
+        ingress_history_writer.set_status(
+            &mut state,
+            message_id.clone(),
+            received(),
+            ExecutionRound::from(0),
+        );
         assert_eq!(
             completed_execution_messages_rx.try_recv(),
             Err(TryRecvError::Empty),
             "Non terminal state should not trigger a transmission."
         );
 
-        ingress_history_writer.set_status(&mut state, message_id.clone(), processing());
+        ingress_history_writer.set_status(
+            &mut state,
+            message_id.clone(),
+            processing(),
+            ExecutionRound::from(0),
+        );
         assert_eq!(
             completed_execution_messages_rx.try_recv(),
             Err(TryRecvError::Empty),
@@ -132,26 +135,30 @@ fn test_terminal_states_are_transmitted() {
 
         {
             let mut state = state.clone();
-            ingress_history_writer.set_status(&mut state, message_id.clone(), completed());
+            ingress_history_writer.set_status(
+                &mut state,
+                message_id.clone(),
+                completed(),
+                current_round,
+            );
             assert_eq!(
                 completed_execution_messages_rx.try_recv(),
-                Ok((
-                    message_id.clone(),
-                    last_committed_state_height + Height::from(1)
-                )),
+                Ok((message_id.clone(), expected_height)),
                 "Terminal state, `Completed`, should trigger the height of state to be sent"
             );
         }
 
         {
             let mut state = state.clone();
-            ingress_history_writer.set_status(&mut state, message_id.clone(), failed());
+            ingress_history_writer.set_status(
+                &mut state,
+                message_id.clone(),
+                failed(),
+                current_round,
+            );
             assert_eq!(
                 completed_execution_messages_rx.try_recv(),
-                Ok((
-                    message_id.clone(),
-                    last_committed_state_height + Height::from(1)
-                )),
+                Ok((message_id.clone(), expected_height)),
                 "Terminal state, `Failed`, should trigger the height of state to be sent"
             );
         }
@@ -163,20 +170,23 @@ fn test_valid_transitions() {
     with_test_replica_logger(|log| {
         let state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
 
-        let state_reader = Arc::new(FakeStateManager::new());
         let (completed_execution_messages_tx, _) = channel(1);
         let ingress_history_writer = IngressHistoryWriterImpl::new(
             Config::default(),
             log,
             &MetricsRegistry::new(),
             completed_execution_messages_tx,
-            state_reader,
         );
         let message_id = message_test_id(1);
 
         for (origin_state, next_states) in valid_transitions().into_iter() {
             let mut state = state.clone();
-            ingress_history_writer.set_status(&mut state, message_id.clone(), origin_state);
+            ingress_history_writer.set_status(
+                &mut state,
+                message_id.clone(),
+                origin_state,
+                ExecutionRound::from(0),
+            );
 
             for next_state in next_states {
                 let mut state = state.clone();
@@ -184,6 +194,7 @@ fn test_valid_transitions() {
                     &mut state,
                     message_id.clone(),
                     next_state.clone(),
+                    ExecutionRound::from(0),
                 );
                 assert_eq!(state.get_ingress_status(&message_id), &next_state);
             }
@@ -194,14 +205,12 @@ fn test_valid_transitions() {
 #[test]
 fn test_invalid_transitions() {
     with_test_replica_logger(|log| {
-        let state_reader = Arc::new(FakeStateManager::new());
         let (completed_execution_messages_tx, _) = channel(1);
         let ingress_history_writer = IngressHistoryWriterImpl::new(
             Config::default(),
             log,
             &MetricsRegistry::new(),
             completed_execution_messages_tx,
-            state_reader,
         );
         let message_id = message_test_id(1);
 
@@ -238,11 +247,13 @@ fn test_invalid_transitions() {
                     &mut state,
                     message_id.clone(),
                     origin_state.clone(),
+                    ExecutionRound::from(0),
                 );
                 ingress_history_writer.set_status(
                     &mut state,
                     message_id.clone(),
                     next_state.clone(),
+                    ExecutionRound::from(0),
                 )
             });
             assert!(

--- a/rs/interfaces/src/execution_environment.rs
+++ b/rs/interfaces/src/execution_environment.rs
@@ -656,6 +656,7 @@ pub trait IngressHistoryWriter: Send + Sync {
         state: &mut Self::State,
         message_id: MessageId,
         status: IngressStatus,
+        current_round: ExecutionRound,
     ) -> Arc<IngressStatus>;
 }
 

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -44,8 +44,8 @@ use ic_types::registry::RegistryClientError;
 use ic_types::state_manager::StateManagerError;
 use ic_types::xnet::{StreamHeader, StreamIndex};
 use ic_types::{
-    Height, NodeId, NumBytes, PrincipalId, PrincipalIdBlobParseError, RegistryVersion, SubnetId,
-    Time,
+    ExecutionRound, Height, NodeId, NumBytes, PrincipalId, PrincipalIdBlobParseError,
+    RegistryVersion, SubnetId, Time,
 };
 use ic_types_cycles::CanisterCyclesCostSchedule;
 use ic_utils_thread::JoinOnDrop;
@@ -1618,9 +1618,10 @@ impl BatchProcessor for FakeBatchProcessorImpl {
             )
         });
 
+        let current_round = ExecutionRound::from(batch.batch_number.get());
         for (msg_id, status) in all_ingress_execution_results {
             self.ingress_history_writer
-                .set_status(&mut state, msg_id, status);
+                .set_status(&mut state, msg_id, status, current_round);
         }
 
         state.prune_ingress_history();

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -38,7 +38,7 @@ use ic_test_utilities_types::{
 };
 use ic_types::batch::BlockmakerMetrics;
 use ic_types::xnet::{StreamIndexedQueue, StreamSlice};
-use ic_types::{CanisterId, ReplicaVersion};
+use ic_types::{CanisterId, ExecutionRound, ReplicaVersion};
 use ic_types::{
     NodeId, PrincipalId, Randomness,
     batch::{Batch, BatchMessages},
@@ -2289,6 +2289,7 @@ fn test_demux_delivers_certified_stream_slices() {
             &self,
             _: &mut ReplicatedState,
             _: Vec<ic_types::messages::SignedIngress>,
+            _: ic_types::ExecutionRound,
         ) {
             // do nothing
         }
@@ -2386,6 +2387,7 @@ fn test_demux_delivers_certified_stream_slices() {
 
         demux.process_payload(
             dst_state,
+            ExecutionRound::from(0),
             BatchMessages {
                 certified_stream_slices,
                 ..Default::default()

--- a/rs/messaging/src/routing/demux.rs
+++ b/rs/messaging/src/routing/demux.rs
@@ -5,7 +5,7 @@ use crate::{
 use ic_interfaces_certified_stream_store::CertifiedStreamStore;
 use ic_logger::{ReplicaLogger, debug, trace};
 use ic_replicated_state::ReplicatedState;
-use ic_types::batch::BatchMessages;
+use ic_types::{ExecutionRound, batch::BatchMessages};
 use std::sync::Arc;
 
 #[cfg(test)]
@@ -17,7 +17,12 @@ pub(crate) trait Demux: Send {
     /// Process the provided payload. Splices off XNetMessages as appropriate
     /// and (attempts) to induct the messages contained in the payload as
     /// appropriate.
-    fn process_payload(&self, state: ReplicatedState, messages: BatchMessages) -> ReplicatedState;
+    fn process_payload(
+        &self,
+        state: ReplicatedState,
+        current_round: ExecutionRound,
+        messages: BatchMessages,
+    ) -> ReplicatedState;
 }
 
 pub(crate) struct DemuxImpl<'a> {
@@ -50,6 +55,7 @@ impl Demux for DemuxImpl<'_> {
     fn process_payload(
         &self,
         state: ReplicatedState,
+        current_round: ExecutionRound,
         batch_messages: BatchMessages,
     ) -> ReplicatedState {
         trace!(self.log, "Processing Payload");
@@ -71,8 +77,11 @@ impl Demux for DemuxImpl<'_> {
             .stream_handler
             .process_stream_slices(state, decoded_slices);
 
-        self.valid_set_rule
-            .induct_messages(&mut state, batch_messages.signed_ingress_msgs);
+        self.valid_set_rule.induct_messages(
+            &mut state,
+            batch_messages.signed_ingress_msgs,
+            current_round,
+        );
 
         for response in batch_messages.bitcoin_adapter_responses.into_iter() {
             state.push_response_bitcoin(response).unwrap_or_else(|err| {

--- a/rs/messaging/src/scheduling/valid_set_rule.rs
+++ b/rs/messaging/src/scheduling/valid_set_rule.rs
@@ -17,7 +17,7 @@ use ic_metrics::{MetricsRegistry, buckets::decimal_buckets, buckets::linear_buck
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
-    Time,
+    ExecutionRound, Time,
     ingress::{IngressState, IngressStatus},
     messages::{
         HttpRequestContent, Ingress, ParseIngressError, SignedIngress,
@@ -104,7 +104,12 @@ impl VsrMetrics {
 
 pub(crate) trait ValidSetRule: Send {
     /// Inducts the provided messages into the ReplicatedState.
-    fn induct_messages(&self, state: &mut ReplicatedState, msgs: Vec<SignedIngress>);
+    fn induct_messages(
+        &self,
+        state: &mut ReplicatedState,
+        msgs: Vec<SignedIngress>,
+        current_round: ExecutionRound,
+    );
 }
 
 pub(crate) struct ValidSetRuleImpl<
@@ -138,7 +143,13 @@ impl<IngressHistoryWriter_: IngressHistoryWriter<State = ReplicatedState>>
     /// Tries to induct a single ingress message and sets the message status in
     /// `state` accordingly (to `Received` if successful; or to `Failed` with
     /// the relevant error code on failure).
-    fn induct_message(&self, state: &mut ReplicatedState, msg: SignedIngress, subnet_size: usize) {
+    fn induct_message(
+        &self,
+        state: &mut ReplicatedState,
+        msg: SignedIngress,
+        subnet_size: usize,
+        current_round: ExecutionRound,
+    ) {
         trace!(self.log, "induct_message");
         let ingress_content = msg.content();
         let message_id = ingress_content.id();
@@ -160,6 +171,7 @@ impl<IngressHistoryWriter_: IngressHistoryWriter<State = ReplicatedState>>
                         time,
                         state: IngressState::Received,
                     },
+                    current_round,
                 );
                 LABEL_VALUE_SUCCESS
             }
@@ -182,6 +194,7 @@ impl<IngressHistoryWriter_: IngressHistoryWriter<State = ReplicatedState>>
                         time,
                         state: IngressState::Failed(UserError::new(error_code, err.to_string())),
                     },
+                    current_round,
                 );
                 err.to_label_value()
             }
@@ -331,12 +344,17 @@ impl<IngressHistoryWriter_: IngressHistoryWriter<State = ReplicatedState>>
 impl<IngressHistoryWriter_: IngressHistoryWriter<State = ReplicatedState>> ValidSetRule
     for ValidSetRuleImpl<IngressHistoryWriter_>
 {
-    fn induct_messages(&self, state: &mut ReplicatedState, msgs: Vec<SignedIngress>) {
+    fn induct_messages(
+        &self,
+        state: &mut ReplicatedState,
+        msgs: Vec<SignedIngress>,
+        current_round: ExecutionRound,
+    ) {
         let subnet_size = state.get_own_subnet_size();
         for msg in msgs {
             let message_id = msg.content().id();
             if !self.is_duplicate(state, &msg) {
-                self.induct_message(state, msg, subnet_size);
+                self.induct_message(state, msg, subnet_size, current_round);
             } else {
                 self.observe_inducted_ingress_status(LABEL_VALUE_DUPLICATE);
                 debug!(self.log, "Didn't induct duplicate message {}", message_id);

--- a/rs/messaging/src/scheduling/valid_set_rule/test.rs
+++ b/rs/messaging/src/scheduling/valid_set_rule/test.rs
@@ -23,7 +23,7 @@ use ic_test_utilities_types::{
     messages::SignedIngressBuilder,
 };
 use ic_types::{
-    CanisterId,
+    CanisterId, ExecutionRound,
     ingress::{IngressState, IngressStatus},
     messages::{MessageId, SignedIngress},
     time::UNIX_EPOCH,
@@ -41,6 +41,7 @@ impl IngressHistoryWriter for NoopIngressHistoryWriter {
         _state: &mut ReplicatedState,
         _message_id: MessageId,
         _status: IngressStatus,
+        _current_round: ExecutionRound,
     ) -> Arc<IngressStatus> {
         IngressStatus::Unknown.into()
     }
@@ -100,9 +101,9 @@ fn induct_message_with_successful_history_update() {
         let mut ingress_history_writer = MockIngressHistory::new();
         ingress_history_writer
             .expect_set_status()
-            .with(always(), eq(msg.id()), always())
+            .with(always(), eq(msg.id()), always(), always())
             .times(1)
-            .returning(move |state, _, _| {
+            .returning(move |state, _, _, _| {
                 state.set_ingress_status(
                     msg_id.clone(),
                     IngressStatus::Known {
@@ -135,7 +136,12 @@ fn induct_message_with_successful_history_update() {
         let mut state = ReplicatedState::new(subnet_test_id(1), subnet_type);
         insert_canister(&mut state, canister_id);
 
-        valid_set_rule.induct_message(&mut state, signed_ingress, SMALL_APP_SUBNET_MAX_SIZE);
+        valid_set_rule.induct_message(
+            &mut state,
+            signed_ingress,
+            SMALL_APP_SUBNET_MAX_SIZE,
+            ExecutionRound::from(0),
+        );
         assert_eq!(ingress_queue_size(&state, canister_id), 1);
         assert_inducted_ingress_messages_eq(
             metric_vec(&[(&[(LABEL_STATUS, LABEL_VALUE_SUCCESS)], 1)]),
@@ -176,9 +182,10 @@ fn induct_message_fails_for_stopping_canister() {
                         format!("Canister {canister_id} is stopping"),
                     )),
                 }),
+                always(),
             )
             .times(1)
-            .returning(move |state, _, status| {
+            .returning(move |state, _, status, _| {
                 state.set_ingress_status(msg_id.clone(), status, NumBytes::from(u64::MAX), |_| {});
                 IngressStatus::Unknown.into()
             });
@@ -194,7 +201,12 @@ fn induct_message_fails_for_stopping_canister() {
         let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
         state.put_canister_state(get_stopping_canister(canister_id));
 
-        valid_set_rule.induct_message(&mut state, signed_ingress, SMALL_APP_SUBNET_MAX_SIZE);
+        valid_set_rule.induct_message(
+            &mut state,
+            signed_ingress,
+            SMALL_APP_SUBNET_MAX_SIZE,
+            ExecutionRound::from(0),
+        );
         assert_eq!(ingress_queue_size(&state, canister_id), 0);
         assert_inducted_ingress_messages_eq(
             metric_vec(&[(&[(LABEL_STATUS, LABEL_VALUE_CANISTER_STOPPING)], 1)]),
@@ -232,9 +244,10 @@ fn induct_message_fails_for_stopped_canister() {
                         format!("Canister {canister_id} is stopped"),
                     )),
                 }),
+                always(),
             )
             .times(1)
-            .returning(move |state, _, status| {
+            .returning(move |state, _, status, _| {
                 state.set_ingress_status(msg_id.clone(), status, NumBytes::from(u64::MAX), |_| {});
                 IngressStatus::Unknown.into()
             });
@@ -251,7 +264,12 @@ fn induct_message_fails_for_stopped_canister() {
         let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
         state.put_canister_state(get_stopped_canister(canister_id));
 
-        valid_set_rule.induct_message(&mut state, signed_ingress, SMALL_APP_SUBNET_MAX_SIZE);
+        valid_set_rule.induct_message(
+            &mut state,
+            signed_ingress,
+            SMALL_APP_SUBNET_MAX_SIZE,
+            ExecutionRound::from(0),
+        );
         assert_eq!(ingress_queue_size(&state, canister_id), 0);
         assert_inducted_ingress_messages_eq(
             metric_vec(&[(&[(LABEL_STATUS, LABEL_VALUE_CANISTER_STOPPED)], 1)]),
@@ -275,9 +293,9 @@ fn try_to_induct_a_message_marked_as_already_inducted() {
         let mut ingress_history_writer = MockIngressHistory::new();
         ingress_history_writer
             .expect_set_status()
-            .with(always(), eq(msg.id()), always())
+            .with(always(), eq(msg.id()), always(), always())
             .times(1)
-            .returning(|_, _, _| panic!("duplicate message induction"));
+            .returning(|_, _, _, _| panic!("duplicate message induction"));
         let ingress_history_writer = Arc::new(ingress_history_writer);
         let metrics_registry = MetricsRegistry::new();
         let valid_set_rule = ValidSetRuleImpl::new(
@@ -297,7 +315,12 @@ fn try_to_induct_a_message_marked_as_already_inducted() {
             state: IngressState::Received,
         };
         state.set_ingress_status(msg.id(), status, NumBytes::from(u64::MAX), |_| {});
-        valid_set_rule.induct_message(&mut state, signed_ingress, SMALL_APP_SUBNET_MAX_SIZE);
+        valid_set_rule.induct_message(
+            &mut state,
+            signed_ingress,
+            SMALL_APP_SUBNET_MAX_SIZE,
+            ExecutionRound::from(0),
+        );
     });
 }
 
@@ -323,9 +346,9 @@ fn update_history_if_induction_failed() {
         let status_clone = status.clone();
         ingress_history_writer
             .expect_set_status()
-            .with(always(), eq(msg.id()), always())
+            .with(always(), eq(msg.id()), always(), always())
             .times(1)
-            .returning(move |state, _, _| {
+            .returning(move |state, _, _, _| {
                 state.set_ingress_status(
                     msg_id.clone(),
                     status.clone(),
@@ -351,6 +374,7 @@ fn update_history_if_induction_failed() {
             &mut state,
             signed_ingress.clone(),
             SMALL_APP_SUBNET_MAX_SIZE,
+            ExecutionRound::from(0),
         );
         assert!(state.canister_state(&canister_id).is_none());
         assert_eq!(state.get_ingress_status(&msg.id()), &status_clone);
@@ -392,9 +416,9 @@ fn dont_induct_duplicate_messages() {
 
         ingress_history_writer
             .expect_set_status()
-            .with(always(), eq(msg3.id()), always())
+            .with(always(), eq(msg3.id()), always(), always())
             .times(1)
-            .returning(|state, message_id3, _| {
+            .returning(|state, message_id3, _, _| {
                 state.set_ingress_status(
                     message_id3,
                     IngressStatus::Known {
@@ -444,7 +468,7 @@ fn dont_induct_duplicate_messages() {
         insert_canister(&mut state, canister_id1);
         insert_canister(&mut state, canister_id2);
 
-        valid_set_rule.induct_messages(&mut state, vec![msg1, msg2, msg3]);
+        valid_set_rule.induct_messages(&mut state, vec![msg1, msg2, msg3], ExecutionRound::from(0));
         assert_eq!(ingress_queue_size(&state, canister_id1), 0);
         assert_eq!(ingress_queue_size(&state, canister_id2), 1);
         assert_inducted_ingress_messages_eq(
@@ -513,7 +537,7 @@ fn canister_on_application_subnet_charges_for_ingress() {
         .system_state
         .balance();
 
-    valid_set_rule.induct_messages(&mut state, vec![signed_ingress]);
+    valid_set_rule.induct_messages(&mut state, vec![signed_ingress], ExecutionRound::from(0));
 
     let balance_after = state
         .canister_state(&canister_test_id(0))
@@ -560,7 +584,7 @@ fn canister_on_system_subnet_does_not_charge_for_ingress() {
     let msg = SignedIngressBuilder::new()
         .canister_id(canister_test_id(0))
         .build();
-    valid_set_rule.induct_messages(&mut state, vec![msg]);
+    valid_set_rule.induct_messages(&mut state, vec![msg], ExecutionRound::from(0));
 
     let balance_after = state
         .canister_state(&canister_test_id(0))
@@ -665,7 +689,12 @@ fn running_canister_on_application_subnet_accepts_and_charges_for_ingress() {
             )
             .cost();
 
-        valid_set_rule.induct_message(&mut state, ingress, SMALL_APP_SUBNET_MAX_SIZE);
+        valid_set_rule.induct_message(
+            &mut state,
+            ingress,
+            SMALL_APP_SUBNET_MAX_SIZE,
+            ExecutionRound::from(0),
+        );
 
         let balance_after = state
             .canister_state(&canister_id)
@@ -704,7 +733,12 @@ fn running_canister_on_system_subnet_accepts_and_does_not_charge_for_ingress() {
         state.put_canister_state(canister);
 
         let ingress = SignedIngressBuilder::new().build();
-        valid_set_rule.induct_message(&mut state, ingress, SMALL_APP_SUBNET_MAX_SIZE);
+        valid_set_rule.induct_message(
+            &mut state,
+            ingress,
+            SMALL_APP_SUBNET_MAX_SIZE,
+            ExecutionRound::from(0),
+        );
 
         let balance_after = state
             .canister_state(&canister_id)
@@ -857,9 +891,9 @@ fn ingress_history_max_messages_impl(subnet_type: SubnetType) {
         let mut ingress_history_writer = MockIngressHistory::new();
         ingress_history_writer
             .expect_set_status()
-            .with(always(), always(), always())
+            .with(always(), always(), always(), always())
             .times(4)
-            .returning(move |state, msg_id, status| {
+            .returning(move |state, msg_id, status, _| {
                 state.set_ingress_status(msg_id, status, NumBytes::from(u64::MAX), |_| {});
                 IngressStatus::Unknown.into()
             });
@@ -885,7 +919,7 @@ fn ingress_history_max_messages_impl(subnet_type: SubnetType) {
         valid_set_rule.ingress_history_max_messages = 3;
 
         // Attempt inducting all 4 messages.
-        valid_set_rule.induct_messages(&mut state, msgs);
+        valid_set_rule.induct_messages(&mut state, msgs, ExecutionRound::from(0));
 
         match subnet_type {
             // System subnets ignore the `ingress_history_max_messages` limit.

--- a/rs/messaging/src/state_machine.rs
+++ b/rs/messaging/src/state_machine.rs
@@ -215,7 +215,10 @@ impl StateMachine for StateMachineImpl {
 
         // Preprocess messages and add messages to the induction pool through the Demux.
         let since = Instant::now();
-        let mut state_with_messages = self.demux.process_payload(state, batch_messages);
+        let current_round = ExecutionRound::from(batch.batch_number.get());
+        let mut state_with_messages =
+            self.demux
+                .process_payload(state, current_round, batch_messages);
         // Batch creation time is essentially wall time (on some replica), so the median
         // duration should be meaningful.
         self.metrics.induct_batch_latency.observe(
@@ -248,7 +251,7 @@ impl StateMachine for StateMachineImpl {
             batch.randomness,
             chain_key_data,
             &batch.replica_version,
-            ExecutionRound::from(batch.batch_number.get()),
+            current_round,
             round_summary,
             execution_round_type,
             registry_settings,

--- a/rs/messaging/src/state_machine/tests.rs
+++ b/rs/messaging/src/state_machine/tests.rs
@@ -92,8 +92,8 @@ fn test_fixture(provided_batch: &Batch) -> StateMachineTestFixture {
         .expect_process_payload()
         .times(1)
         .in_sequence(&mut seq)
-        .with(always(), eq(messages))
-        .returning(|state, _| state);
+        .with(always(), eq(round), eq(messages))
+        .returning(|state, _, _| state);
 
     let mut scheduler = Box::new(MockScheduler::new());
     scheduler

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -878,7 +878,7 @@ impl ExecutionTest {
     pub fn process_stopping_canisters(&mut self) {
         let state = self
             .exec_env
-            .process_stopping_canisters(self.state.take().unwrap());
+            .process_stopping_canisters(self.state.take().unwrap(), ExecutionRound::from(0));
         self.state = Some(state);
     }
 
@@ -1227,6 +1227,7 @@ impl ExecutionTest {
                 time: self.time,
                 state: IngressState::Received,
             },
+            ExecutionRound::from(0),
         );
         self.state = Some(state);
         if !self.manual_execution {
@@ -1512,6 +1513,7 @@ impl ExecutionTest {
                 time: self.time,
                 state: IngressState::Received,
             },
+            ExecutionRound::from(0),
         );
 
         self.state = Some(state);
@@ -1835,8 +1837,12 @@ impl ExecutionTest {
                 }
                 canister = result.canister;
                 if let Some(ir) = result.ingress_status {
-                    self.ingress_history_writer
-                        .set_status(&mut state, ir.0, ir.1);
+                    self.ingress_history_writer.set_status(
+                        &mut state,
+                        ir.0,
+                        ir.1,
+                        ExecutionRound::from(0),
+                    );
                 };
                 executed_any = true;
             }
@@ -1895,6 +1901,7 @@ impl ExecutionTest {
                         self.install_code_instruction_limits.clone(),
                         &mut round_limits,
                         self.subnet_size(),
+                        ExecutionRound::from(0),
                     );
                 let slice_instructions_used =
                     remaining_round_instructions_before - round_limits.instructions;
@@ -1977,8 +1984,12 @@ impl ExecutionTest {
                 }
                 canister = result.canister;
                 if let Some(ir) = result.ingress_status {
-                    self.ingress_history_writer
-                        .set_status(&mut state, ir.0, ir.1);
+                    self.ingress_history_writer.set_status(
+                        &mut state,
+                        ir.0,
+                        ir.1,
+                        ExecutionRound::from(0),
+                    );
                 };
                 canisters.insert(canister_id, canister);
                 state.put_canister_states(canisters);

--- a/rs/test_utilities/state/src/history.rs
+++ b/rs/test_utilities/state/src/history.rs
@@ -2,7 +2,7 @@ use ic_interfaces::execution_environment::{
     IngressHistoryError, IngressHistoryReader, IngressHistoryWriter,
 };
 use ic_replicated_state::ReplicatedState;
-use ic_types::{Height, ingress::IngressStatus, messages::MessageId};
+use ic_types::{ExecutionRound, Height, ingress::IngressStatus, messages::MessageId};
 use mockall::*;
 use std::sync::Arc;
 
@@ -17,6 +17,7 @@ mock! {
             state: &mut ReplicatedState,
             message_id: MessageId,
             status: IngressStatus,
+            current_round: ExecutionRound,
         ) -> Arc<IngressStatus>;
     }
 


### PR DESCRIPTION
This PR sends `current_round` instead of `state_reader.latest_state_height() + Height::from(1)` to `completed_execution_messages_tx` (channel notifying the synchronous update call HTTP handler) since using the height of the latest state stored in the state manager is imprecise (that state need not match the actual state on which the execution environment operates).