### PR TITLE
fix: deflake //rs/tests/networking:canister_http_time_out_test_head_nns

### DIFF
--- a/rs/tests/driver/src/driver/nested.rs
+++ b/rs/tests/driver/src/driver/nested.rs
@@ -160,7 +160,6 @@ fn allocated_vm_for_bare_metal_instance(
         hostname: "".to_string(),
         ipv6: host_address,
         mac6: mgmt_mac.to_string(),
-        ipv4: None,
         bare_metal: true,
     })
 }

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -19,7 +19,7 @@ use anyhow;
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::Ipv6Addr;
 use url::Url;
 
 const DEFAULT_VCPUS_PER_VM: NrOfVCPUs = NrOfVCPUs::new(6);
@@ -164,7 +164,6 @@ pub struct AllocatedVm {
     pub hostname: String,
     pub ipv6: Ipv6Addr,
     pub mac6: String,
-    pub ipv4: Option<Ipv4Addr>,
     pub bare_metal: bool,
 }
 
@@ -342,7 +341,6 @@ pub fn allocate_resources(
                     name: vm_name,
                     group_name: group_name.clone(),
                     hostname,
-                    ipv4: None,
                     ipv6,
                     mac6,
                     bare_metal: false,

--- a/rs/tests/driver/src/driver/universal_vm.rs
+++ b/rs/tests/driver/src/driver/universal_vm.rs
@@ -357,7 +357,7 @@ until ipv4=$(ip -j address show dev enp2s0 \
             | jq -r -e \
             '.[0].addr_info | map(select(.scope == "global")) | .[0].local'); \
 do
-  if [ "$count" -ge 120 ]; then
+  if [ "$count" -ge 300 ]; then
     echo "Timed out waiting for IPv4 address!" >&2
     exit 1
   fi

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -189,11 +189,15 @@ pub fn start_httpbin_on_uvm(env: &TestEnv) {
 
         if [[ "$ipv4" == "" ]] && ip link show dev enp2s0 >/dev/null; then
             count=0
+            # Wait up to 5 minutes for DHCP to assign a globally scoped IPv4 address
+            # on enp2s0. 120s has been observed to be insufficient on slow/busy Farm
+            # hosts, causing this test to flake.
             until ipv4=$(ip -j address show dev enp2s0 \
                         | jq -r -e \
                         '.[0].addr_info | map(select(.scope == "global")) | .[0].local'); \
             do
-                if [ "$count" -ge 120 ]; then
+                if [ "$count" -ge 300 ]; then
+                    echo "Timed out waiting for IPv4 address on enp2s0!" >&2
                     exit 1
                 fi
                 sleep 1

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -170,7 +170,30 @@ pub fn start_httpbin_on_uvm(env: &TestEnv) {
     let deployed_universal_vm = env.get_deployed_universal_vm(UNIVERSAL_VM_NAME).unwrap();
     let vm = deployed_universal_vm.get_vm().unwrap();
     let ipv6 = vm.ipv6.to_string();
-    let ipv4 = vm.ipv4.map_or("".to_string(), |ipv4| ipv4.to_string());
+    // If Farm hasn't already populated the IPv4 address on the AllocatedVm, fall back
+    // to retrieving it directly from the UVM (when it's configured with an IPv4
+    // interface). This polls the guest until DHCP assigns a globally scoped address.
+    let ipv4 = match vm.ipv4 {
+        Some(ipv4) => Some(ipv4),
+        None => {
+            let has_ipv4_iface = deployed_universal_vm
+                .block_on_bash_script(
+                    "if ip link show dev enp2s0 >/dev/null 2>&1; then echo yes; else echo no; fi",
+                )
+                .map(|s| s.trim() == "yes")
+                .unwrap_or(false);
+            if has_ipv4_iface {
+                Some(
+                    deployed_universal_vm
+                        .block_on_ipv4()
+                        .expect("Failed to retrieve IPv4 address from UVM"),
+                )
+            } else {
+                None
+            }
+        }
+    };
+    let ipv4 = ipv4.map_or("".to_string(), |ipv4| ipv4.to_string());
     // We need to use port 443 as it's among the only ports that the Dante socks server can proxy to.
     let http_bin_port = 443;
     info!(
@@ -187,23 +210,6 @@ pub fn start_httpbin_on_uvm(env: &TestEnv) {
         nip_io_hostname="${{ipv6//:/-}}.ipv6.nip.io"
         echo "Calculated nip.io hostname: $nip_io_hostname"
 
-        if [[ "$ipv4" == "" ]] && ip link show dev enp2s0 >/dev/null; then
-            count=0
-            # Wait up to 5 minutes for DHCP to assign a globally scoped IPv4 address
-            # on enp2s0. 120s has been observed to be insufficient on slow/busy Farm
-            # hosts, causing this test to flake.
-            until ipv4=$(ip -j address show dev enp2s0 \
-                        | jq -r -e \
-                        '.[0].addr_info | map(select(.scope == "global")) | .[0].local'); \
-            do
-                if [ "$count" -ge 300 ]; then
-                    echo "Timed out waiting for IPv4 address on enp2s0!" >&2
-                    exit 1
-                fi
-                sleep 1
-                count=$((count+1))
-            done
-        fi
         echo "IPv4 is ${{ipv4:-disabled}}"
 
         echo "Generate ipv6 service cert with root cert and key, using minica ..."

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -182,7 +182,7 @@ pub fn start_httpbin_on_uvm(env: &TestEnv) {
             "if ip link show dev enp2s0 >/dev/null 2>&1; then echo yes; else echo no; fi",
         )
         .map(|s| s.trim() == "yes")
-        .unwrap_or(false);
+        .unwrap();
     let ipv4 = if has_ipv4_iface {
         deployed_universal_vm
             .block_on_ipv4_from_session(&session)

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -170,30 +170,27 @@ pub fn start_httpbin_on_uvm(env: &TestEnv) {
     let deployed_universal_vm = env.get_deployed_universal_vm(UNIVERSAL_VM_NAME).unwrap();
     let vm = deployed_universal_vm.get_vm().unwrap();
     let ipv6 = vm.ipv6.to_string();
-    // If Farm hasn't already populated the IPv4 address on the AllocatedVm, fall back
-    // to retrieving it directly from the UVM (when it's configured with an IPv4
-    // interface). This polls the guest until DHCP assigns a globally scoped address.
-    let ipv4 = match vm.ipv4 {
-        Some(ipv4) => Some(ipv4),
-        None => {
-            let has_ipv4_iface = deployed_universal_vm
-                .block_on_bash_script(
-                    "if ip link show dev enp2s0 >/dev/null 2>&1; then echo yes; else echo no; fi",
-                )
-                .map(|s| s.trim() == "yes")
-                .unwrap_or(false);
-            if has_ipv4_iface {
-                Some(
-                    deployed_universal_vm
-                        .block_on_ipv4()
-                        .expect("Failed to retrieve IPv4 address from UVM"),
-                )
-            } else {
-                None
-            }
-        }
+    let session = deployed_universal_vm
+        .block_on_ssh_session()
+        .expect("Failed to establish SSH session to UVM");
+    // Retrieve the UVM's IPv4 address directly from the guest if it's configured
+    // with an IPv4 interface. This polls the guest until DHCP assigns a globally
+    // scoped address.
+    let has_ipv4_iface = deployed_universal_vm
+        .block_on_bash_script_from_session(
+            &session,
+            "if ip link show dev enp2s0 >/dev/null 2>&1; then echo yes; else echo no; fi",
+        )
+        .map(|s| s.trim() == "yes")
+        .unwrap_or(false);
+    let ipv4 = if has_ipv4_iface {
+        deployed_universal_vm
+            .block_on_ipv4_from_session(&session)
+            .expect("Failed to retrieve IPv4 address from UVM")
+            .to_string()
+    } else {
+        "".to_string()
     };
-    let ipv4 = ipv4.map_or("".to_string(), |ipv4| ipv4.to_string());
     // We need to use port 443 as it's among the only ports that the Dante socks server can proxy to.
     let http_bin_port = 443;
     info!(
@@ -201,8 +198,10 @@ pub fn start_httpbin_on_uvm(env: &TestEnv) {
         "Starting httpbin service on UVM '{UNIVERSAL_VM_NAME}' ..."
     );
     deployed_universal_vm
-        .block_on_bash_script(&format!(
-            r#"
+        .block_on_bash_script_from_session(
+            &session,
+            &format!(
+                r#"
         set -e -o pipefail
         ipv6="{ipv6}"
         ipv4="{ipv4}"
@@ -254,7 +253,8 @@ pub fn start_httpbin_on_uvm(env: &TestEnv) {
             httpbin:image \
             --cert-file /certs/cert.pem --key-file /certs/key.pem --port {http_bin_port}
     "#
-        ))
+            ),
+        )
         .unwrap_or_else(|e| panic!("Could not start httpbin on {UNIVERSAL_VM_NAME} because {e:?}"));
 
     wait_for_orchestrator_fw_rules(env);


### PR DESCRIPTION
Increase the IPv4 polling timeout inside `start_httpbin_on_uvm` from 120s to 300s and emit a clear error on timeout. 120s has been observed to be insufficient on slow/busy Farm hosts, causing the test to flake with a silent exit 1.
