### PR TITLE
test(DSM): Update tests to pass with or without tracker charging

### DIFF
--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -71,6 +71,7 @@ fn cannot_execute_wasm_without_memory() {
 fn correctly_count_instructions() {
     let data_size = 1024;
     let mut instance = WasmtimeInstanceBuilder::new()
+        .with_deterministic_memory_tracker_enabled(false)
         .with_wat(
             format!(
                 r#"
@@ -215,6 +216,7 @@ fn correctly_report_performance_counter() {
         + system_api_complexity::overhead::PERFORMANCE_COUNTER.get();
     let expected_instructions = expected_instructions_counter2;
     let mut instance = WasmtimeInstanceBuilder::new()
+        .with_deterministic_memory_tracker_enabled(false)
         .with_wat(
             format!(
                 r#"
@@ -1805,6 +1807,7 @@ fn wasm_debug_print_instructions_charging() {
     for (rate_limiting, subnet_type, expected_instructions) in test_cases.clone() {
         let mut config = Config::default();
         config.feature_flags.rate_limiting_of_debug_prints = rate_limiting;
+        config.feature_flags.deterministic_memory_tracker = FlagStatus::Disabled;
         let mut instance = WasmtimeInstanceBuilder::new()
             .with_config(config)
             .with_subnet_type(subnet_type)
@@ -1826,6 +1829,7 @@ fn wasm_debug_print_instructions_charging() {
     for (rate_limiting, subnet_type, expected_instructions) in test_cases {
         let mut config = Config::default();
         config.feature_flags.rate_limiting_of_debug_prints = rate_limiting;
+        config.feature_flags.deterministic_memory_tracker = FlagStatus::Disabled;
         let mut instance = WasmtimeInstanceBuilder::new()
             .with_config(config)
             .with_subnet_type(subnet_type)
@@ -1859,6 +1863,7 @@ fn wasm_canister_logging_instructions_charging() {
     for (message_len, expected_instructions) in test_cases.clone() {
         let mut config = Config::default();
         config.feature_flags.rate_limiting_of_debug_prints = FlagStatus::Enabled;
+        config.feature_flags.deterministic_memory_tracker = FlagStatus::Disabled;
         let mut instance = WasmtimeInstanceBuilder::new()
             .with_config(config)
             .with_subnet_type(SubnetType::Application)
@@ -1877,6 +1882,7 @@ fn wasm_canister_logging_instructions_charging() {
     for (message_len, expected_instructions) in test_cases {
         let mut config = Config::default();
         config.feature_flags.rate_limiting_of_debug_prints = FlagStatus::Enabled;
+        config.feature_flags.deterministic_memory_tracker = FlagStatus::Disabled;
         let mut instance = WasmtimeInstanceBuilder::new()
             .with_config(config)
             .with_subnet_type(SubnetType::Application)
@@ -1935,6 +1941,7 @@ fn wasm_logging_new_records_after_exceeding_log_size_limit() {
 
     let mut config = Config::default();
     config.feature_flags.rate_limiting_of_debug_prints = FlagStatus::Enabled;
+    config.feature_flags.deterministic_memory_tracker = FlagStatus::Disabled;
     let instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_subnet_type(SubnetType::Application)
@@ -1946,6 +1953,7 @@ fn wasm_logging_new_records_after_exceeding_log_size_limit() {
     // same for wasm64
     let mut config = Config::default();
     config.feature_flags.rate_limiting_of_debug_prints = FlagStatus::Enabled;
+    config.feature_flags.deterministic_memory_tracker = FlagStatus::Disabled;
     let instance = WasmtimeInstanceBuilder::new()
         .with_config(config)
         .with_subnet_type(SubnetType::Application)

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -45,6 +45,24 @@ const SUBNET_MEMORY_CAPACITY: i64 = i64::MAX / 2;
 
 const TEST_DEFAULT_LOG_MEMORY_LIMIT: usize = 4 * 1024; // 4 KiB
 
+const OS_PAGES_PER_WASM_PAGE: usize =
+    ic_replicated_state::canister_state::WASM_PAGE_SIZE_IN_BYTES / ic_sys::PAGE_SIZE;
+
+/// Returns the per-Wasm-page instruction charge applied by the deterministic
+/// memory tracker when it is enabled in the default config, or 0 otherwise.
+fn dsm_charge_per_wasm_page() -> u64 {
+    use ic_config::flag_status::FlagStatus;
+    if EmbeddersConfig::default()
+        .feature_flags
+        .deterministic_memory_tracker
+        == FlagStatus::Enabled
+    {
+        OS_PAGES_PER_WASM_PAGE as u64
+    } else {
+        0
+    }
+}
+
 lazy_static! {
     static ref MAX_SUBNET_AVAILABLE_MEMORY: SubnetAvailableMemory =
         SubnetAvailableMemory::new_for_testing(
@@ -775,9 +793,7 @@ mod tests {
         //! stable API operations.  Each function contains a single stable read
         //! or write, in addition to 7 instructions required for setup.
 
-        use super::{
-            MAX_NUM_INSTRUCTIONS, STABLE_OP_BYTES, SubnetType, get_num_instructions_consumed,
-        };
+        use super::*;
         use ic_config::subnet_config::SchedulerConfig;
         use ic_embedders::wasm_utils::instrumentation::WasmMemoryType;
         use ic_embedders::wasm_utils::instrumentation::instruction_to_cost;
@@ -825,13 +841,16 @@ mod tests {
             )
             .unwrap();
             // Read of `STABLE_OP_BYTES` should cost an additional instruction
-            // for each byte.
+            // for each byte, plus charges for accessing and dirtying the
+            // destination heap page.
             assert_eq!(
                 instructions_consumed.get(),
                 setup_instruction_overhead()
                     + ic_embedders::wasmtime_embedder::system_api_complexity::overhead::STABLE_READ
                         .get()
                     + STABLE_OP_BYTES
+                    + dsm_charge_per_wasm_page()
+                    + dsm_charge_per_wasm_page()
             );
         }
 
@@ -846,13 +865,16 @@ mod tests {
             )
             .unwrap();
             // Read of `STABLE_OP_BYTES` should cost an additional instruction
-            // for each byte.
+            // for each byte, plus charges for accessing and dirtying the
+            // destination heap page.
             assert_eq!(
                 instructions_consumed.get(),
                 setup_instruction_overhead()
                     + ic_embedders::wasmtime_embedder::system_api_complexity::overhead::STABLE64_READ
                         .get()
                     + STABLE_OP_BYTES
+                    + dsm_charge_per_wasm_page()
+                    + dsm_charge_per_wasm_page()
             );
         }
 
@@ -866,13 +888,16 @@ mod tests {
                 SubnetType::System,
             )
             .unwrap();
-            // Only the fixed cost is charged on system subnets.
+            // Fixed cost plus charges for accessing and dirtying the
+            // destination heap page.
             assert_eq!(
                 instructions_consumed.get(),
                 setup_instruction_overhead()
                     + ic_embedders::wasmtime_embedder::system_api_complexity::overhead::STABLE_READ
                         .get()
                     + STABLE_OP_BYTES
+                    + dsm_charge_per_wasm_page()
+                    + dsm_charge_per_wasm_page()
             );
         }
 
@@ -886,8 +911,9 @@ mod tests {
                 SubnetType::Application,
             )
             .unwrap();
-            // Read of `STABLE_OP_BYTES` should cost an additional instruction
-            // for each byte and an extra charge for one dirty page.
+            // Write of `STABLE_OP_BYTES` should cost an additional instruction
+            // for each byte, a dirty page overhead charge, plus charges for
+            // accessing and dirtying the source heap page.
             assert_eq!(
                 instructions_consumed.get(),
                 setup_instruction_overhead()
@@ -897,6 +923,7 @@ mod tests {
                     + SchedulerConfig::application_subnet()
                         .dirty_page_overhead
                         .get()
+                    + dsm_charge_per_wasm_page() + dsm_charge_per_wasm_page()
             );
         }
 
@@ -910,7 +937,8 @@ mod tests {
                 SubnetType::System,
             )
             .unwrap();
-            // Only the extra charge for the dirty page.
+            // Dirty page overhead plus charges for accessing and dirtying the
+            // source heap page.
             assert_eq!(
                 instructions_consumed.get(),
                 setup_instruction_overhead()
@@ -918,6 +946,7 @@ mod tests {
                         .get()
                     + STABLE_OP_BYTES
                     + SchedulerConfig::system_subnet().dirty_page_overhead.get()
+                    + dsm_charge_per_wasm_page() + dsm_charge_per_wasm_page()
             );
         }
 
@@ -931,8 +960,9 @@ mod tests {
                 SubnetType::Application,
             )
             .unwrap();
-            // Read of `STABLE_OP_BYTES` should cost an additional instruction
-            // for each byte and an extra charge for one dirty page.
+            // Write of `STABLE_OP_BYTES` should cost an additional instruction
+            // for each byte, a dirty page overhead charge, plus charges for
+            // accessing and dirtying the source heap page.
             assert_eq!(
                 instructions_consumed.get(),
                 setup_instruction_overhead()
@@ -942,6 +972,7 @@ mod tests {
                     + SchedulerConfig::application_subnet()
                         .dirty_page_overhead
                         .get()
+                    + dsm_charge_per_wasm_page() + dsm_charge_per_wasm_page()
             );
         }
 
@@ -955,7 +986,8 @@ mod tests {
                 SubnetType::System,
             )
             .unwrap();
-            // Only the extra charge for the dirty page.
+            // Dirty page overhead plus charges for accessing and dirtying the
+            // source heap page.
             assert_eq!(
                 instructions_consumed.get(),
                 setup_instruction_overhead()
@@ -963,6 +995,7 @@ mod tests {
                         .get()
                     + STABLE_OP_BYTES
                     + SchedulerConfig::system_subnet().dirty_page_overhead.get()
+                    + dsm_charge_per_wasm_page() + dsm_charge_per_wasm_page()
             );
         }
     }
@@ -1004,19 +1037,30 @@ mod tests {
                 let mut double_size_payload: Vec<u8> = payload.clone();
                 double_size_payload.extend(random_payload());
 
-                let (instructions_consumed_without_data, dry_run_stats) = run_and_get_stats(
-                    log.clone(),
-                    "write_bytes",
-                    dst.to_le_bytes().to_vec(),
-                    MAX_NUM_INSTRUCTIONS,
-                    subnet_type,
-                )
-                .unwrap();
+                // The deterministic memory tracker charges at 64 KiB Wasm page
+                // granularity. Use InstanceStats to get the actual Wasm page
+                // counts and compute the exact tracker charge.
+                let tracker_charge =
+                    |stats: &ic_interfaces::execution_environment::InstanceStats| -> u64 {
+                        stats.wasm_accessed_wasm_pages_count as u64 * dsm_charge_per_wasm_page()
+                            + stats.wasm_dirty_wasm_pages_count as u64 * dsm_charge_per_wasm_page()
+                    };
+
+                let (instructions_consumed_without_data, dry_run_stats, dry_run_instance_stats) =
+                    run_and_get_stats(
+                        log.clone(),
+                        "write_bytes",
+                        dst.to_le_bytes().to_vec(),
+                        MAX_NUM_INSTRUCTIONS,
+                        subnet_type,
+                    )
+                    .unwrap();
                 let dry_run_dirty_heap = dry_run_stats.wasm_dirty_pages.len() as u64;
+                let dry_run_tracker = tracker_charge(&dry_run_instance_stats);
 
                 {
                     // Number of instructions consumed only for copying the payload.
-                    let (consumed_instructions, run_stats) = run_and_get_stats(
+                    let (consumed_instructions, run_stats, instance_stats) = run_and_get_stats(
                         log.clone(),
                         "write_bytes",
                         payload,
@@ -1028,15 +1072,17 @@ mod tests {
                     let consumed_instructions =
                         consumed_instructions - instructions_consumed_without_data;
                     assert_eq!(
-                        (consumed_instructions.get() - dirty_heap * dirty_heap_cost) as usize,
+                        (consumed_instructions.get()
+                            - dirty_heap * dirty_heap_cost
+                            - tracker_charge(&instance_stats)) as usize,
                         (payload_size / BYTES_PER_INSTRUCTION)
-                            - (dry_run_dirty_heap * dirty_heap_cost) as usize,
+                            - (dry_run_dirty_heap * dirty_heap_cost + dry_run_tracker) as usize,
                     );
                 }
 
                 {
                     // Number of instructions consumed increased with the size of the data.
-                    let (consumed_instructions, run_stats) = run_and_get_stats(
+                    let (consumed_instructions, run_stats, instance_stats) = run_and_get_stats(
                         log,
                         "write_bytes",
                         double_size_payload,
@@ -1049,9 +1095,11 @@ mod tests {
                         consumed_instructions - instructions_consumed_without_data;
 
                     assert_eq!(
-                        (consumed_instructions.get() - dirty_heap * dirty_heap_cost) as usize,
+                        (consumed_instructions.get()
+                            - dirty_heap * dirty_heap_cost
+                            - tracker_charge(&instance_stats)) as usize,
                         (2 * payload_size / BYTES_PER_INSTRUCTION)
-                            - (dry_run_dirty_heap * dirty_heap_cost) as usize
+                            - (dry_run_dirty_heap * dirty_heap_cost + dry_run_tracker) as usize
                     );
                 }
             })
@@ -1064,7 +1112,14 @@ mod tests {
         payload: Vec<u8>,
         max_num_instructions: NumInstructions,
         subnet_type: SubnetType,
-    ) -> Result<(NumInstructions, ic_embedders::InstanceRunResult), HypervisorError> {
+    ) -> Result<
+        (
+            NumInstructions,
+            ic_embedders::InstanceRunResult,
+            ic_interfaces::execution_environment::InstanceStats,
+        ),
+        HypervisorError,
+    > {
         let wat = make_module_wat(2 * TEST_NUM_PAGES);
         let wasm = wat2wasm(&wat).unwrap();
 
@@ -1105,8 +1160,9 @@ mod tests {
             .system_api()
             .unwrap()
             .slice_instructions_executed(instruction_counter);
+        let stats = inst.get_stats();
 
-        Ok((instructions_executed, res))
+        Ok((instructions_executed, res, stats))
     }
 
     fn get_num_instructions_consumed(
@@ -1116,7 +1172,7 @@ mod tests {
         max_num_instructions: NumInstructions,
         subnet_type: SubnetType,
     ) -> Result<NumInstructions, HypervisorError> {
-        let (num_instructions, _) =
+        let (num_instructions, _, _) =
             run_and_get_stats(log, method, payload, max_num_instructions, subnet_type)?;
         Ok(num_instructions)
     }

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -4702,7 +4702,9 @@ fn upgrade_without_pre_and_post_upgrade_succeeds() {
 
 #[test]
 fn install_code_calls_canister_init_and_start() {
-    let mut test = ExecutionTestBuilder::new().build();
+    let mut test = ExecutionTestBuilder::new()
+        .with_deterministic_memory_tracker_enabled(false)
+        .build();
     let wat = r#"
         (module
             (import "ic0" "msg_reply" (func $msg_reply))
@@ -5123,7 +5125,9 @@ fn cannot_execute_query_on_stopped_canister() {
 
 #[test]
 fn ic0_trap_preserves_some_cycles() {
-    let mut test = ExecutionTestBuilder::new().build();
+    let mut test = ExecutionTestBuilder::new()
+        .with_deterministic_memory_tracker_enabled(false)
+        .build();
     let wat = r#"
         (module
             (import "ic0" "trap" (func $ic_trap (param i32) (param i32)))
@@ -8601,6 +8605,7 @@ fn yield_triggers_dts_slice_with_many_dirty_pages() {
 
     let mut test = ExecutionTestBuilder::new()
         .with_manual_execution()
+        .with_deterministic_memory_tracker_enabled(false)
         .with_max_dirty_pages_optimization_embedder_config(pages_to_touch - 1)
         .build();
 


### PR DESCRIPTION
Adjust tests so they pass whether the deterministic memory tracker is enabled or disabled:

- embedders/tests/wasmtime_embedder.rs, embedders/tests/wasmtime_random_memory_writes.rs, execution_environment/tests/hypervisor.rs: Tests that check exact instruction counts which would be thrown off by in-band page charges now explicitly disable the tracker, keeping them focused on non-tracker behaviour.

- embedders/tests/wasmtime_random_memory_writes.rs stable-API tests: Replace hardcoded CHARGE_FOR_ACCESSED/DIRTY_WASM_PAGE constants with dsm_charge_per_wasm_page(), which returns OS_PAGES_PER_WASM_PAGE when the tracker is enabled in the default config and 0 otherwise.  The tracker_charge closure used in the write_bytes property test is updated the same way.