### PR TITLE
chore(rejoin_test_lib): improved logging for creating many canisters

### DIFF
--- a/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
+++ b/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
@@ -349,7 +349,7 @@ async fn deploy_canisters_for_long_rounds(
                         );
                     }
                 }
-                tokio::time::sleep(Duration::from_millis(BACKOFF_TIME_MILLIS)).await;
+                tokio::time::sleep(Duration::from_secs(5)).await;
             }
             info!(
                 logger,
@@ -391,7 +391,7 @@ async fn deploy_canisters_for_long_rounds(
                         );
                     }
                 }
-                tokio::time::sleep(Duration::from_millis(BACKOFF_TIME_MILLIS)).await;
+                tokio::time::sleep(Duration::from_secs(5)).await;
             }
         };
         create_many_canisters_futs.push(fut);

--- a/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
+++ b/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
@@ -325,9 +325,10 @@ async fn deploy_canisters_for_long_rounds(
     );
     let mut create_many_canisters_futs = vec![];
     for seed_canister_id in seed_canisters {
+        let seed_canister_id_str = seed_canister_id.to_string();
         info!(
             logger,
-            "Creating {num_canisters_per_seed_canister:?} canisters via seed canister {seed_canister_id:?} by calling create_many_canisters ...",
+            "Creating {num_canisters_per_seed_canister:?} canisters via seed canister {seed_canister_id_str:?} by calling create_many_canisters ...",
         );
         let agent = agent.clone();
         let fut = async move {
@@ -344,7 +345,7 @@ async fn deploy_canisters_for_long_rounds(
                     Err(err) => {
                         info!(
                             logger,
-                            "Creating {num_canisters_per_seed_canister:?} canisters via seed canister {seed_canister_id:?} failed because {err:?}. Retrying ...",
+                            "Creating {num_canisters_per_seed_canister:?} canisters via seed canister {seed_canister_id_str:?} failed because {err:?}. Retrying ...",
                         );
                     }
                 }
@@ -352,7 +353,7 @@ async fn deploy_canisters_for_long_rounds(
             }
             info!(
                 logger,
-                "Successfully called create_many_canisters on seed canister {seed_canister_id:?}. Now querying canister_creation_status ...",
+                "Successfully called create_many_canisters on seed canister {seed_canister_id_str:?}. Now querying canister_creation_status ...",
             );
             loop {
                 let bytes = Encode!(&()).expect("Failed to candid encode unit type");
@@ -369,13 +370,13 @@ async fn deploy_canisters_for_long_rounds(
                             CanisterCreationStatus::Idle => {
                                 info!(
                                     logger,
-                                    "Canister creation on seed canister {seed_canister_id:?} is idle. Retrying canister_creation_status query ...",
+                                    "Canister creation on seed canister {seed_canister_id_str:?} is idle. Retrying canister_creation_status query ...",
                                 );
                             }
                             CanisterCreationStatus::InProgress(n) => {
                                 info!(
                                     logger,
-                                    "Canister creation on seed canister {seed_canister_id:?} is in progress ({n}). Retrying canister_creation_status query ...",
+                                    "Canister creation on seed canister {seed_canister_id_str:?} is in progress ({n}). Retrying canister_creation_status query ...",
                                 );
                             }
                             CanisterCreationStatus::Done(_) => {

--- a/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
+++ b/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
@@ -387,7 +387,7 @@ async fn deploy_canisters_for_long_rounds(
                     Err(err) => {
                         info!(
                             logger,
-                            "Querying canister_creation_status on seed canister {seed_canister_id:?} failed because {err:?}. Retrying canister_creation_status query...",
+                            "Querying canister_creation_status on seed canister {seed_canister_id_str:?} failed because {err:?}. Retrying canister_creation_status query...",
                         );
                     }
                 }

--- a/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
+++ b/rs/tests/message_routing/rejoin_test_lib/rejoin_test_lib.rs
@@ -325,6 +325,10 @@ async fn deploy_canisters_for_long_rounds(
     );
     let mut create_many_canisters_futs = vec![];
     for seed_canister_id in seed_canisters {
+        info!(
+            logger,
+            "Creating {num_canisters_per_seed_canister:?} canisters via seed canister {seed_canister_id:?} by calling create_many_canisters ...",
+        );
         let agent = agent.clone();
         let fut = async move {
             loop {
@@ -335,11 +339,21 @@ async fn deploy_canisters_for_long_rounds(
                     .with_arg(bytes)
                     .call_and_wait()
                     .await;
-                if res.is_ok() {
-                    break;
+                match res {
+                    Ok(_) => break,
+                    Err(err) => {
+                        info!(
+                            logger,
+                            "Creating {num_canisters_per_seed_canister:?} canisters via seed canister {seed_canister_id:?} failed because {err:?}. Retrying ...",
+                        );
+                    }
                 }
                 tokio::time::sleep(Duration::from_millis(BACKOFF_TIME_MILLIS)).await;
             }
+            info!(
+                logger,
+                "Successfully called create_many_canisters on seed canister {seed_canister_id:?}. Now querying canister_creation_status ...",
+            );
             loop {
                 let bytes = Encode!(&()).expect("Failed to candid encode unit type");
                 let res = agent
@@ -347,14 +361,33 @@ async fn deploy_canisters_for_long_rounds(
                     .with_arg(bytes)
                     .call()
                     .await;
-                if let Ok(bytes) = res {
-                    let status = Decode!(&bytes, CanisterCreationStatus)
-                        .expect("Failed to candid decode canister creation status");
-                    match status {
-                        CanisterCreationStatus::Idle | CanisterCreationStatus::InProgress(_) => (),
-                        CanisterCreationStatus::Done(_) => {
-                            break;
+                match res {
+                    Ok(bytes) => {
+                        let status = Decode!(&bytes, CanisterCreationStatus)
+                            .expect("Failed to candid decode canister creation status");
+                        match status {
+                            CanisterCreationStatus::Idle => {
+                                info!(
+                                    logger,
+                                    "Canister creation on seed canister {seed_canister_id:?} is idle. Retrying canister_creation_status query ...",
+                                );
+                            }
+                            CanisterCreationStatus::InProgress(n) => {
+                                info!(
+                                    logger,
+                                    "Canister creation on seed canister {seed_canister_id:?} is in progress ({n}). Retrying canister_creation_status query ...",
+                                );
+                            }
+                            CanisterCreationStatus::Done(_) => {
+                                break;
+                            }
                         }
+                    }
+                    Err(err) => {
+                        info!(
+                            logger,
+                            "Querying canister_creation_status on seed canister {seed_canister_id:?} failed because {err:?}. Retrying canister_creation_status query...",
+                        );
                     }
                 }
                 tokio::time::sleep(Duration::from_millis(BACKOFF_TIME_MILLIS)).await;


### PR DESCRIPTION
The `//rs/tests/message_routing:rejoin_test_long_rounds` is frequently getting stuck while creating 100000 canisters via the seed canisters. To get more insight into why and where it gets stuck we add more logs.