### PR TITLE
feat(ic-admin): add --canister-cycles-cost-schedule option to propose-to-create-subnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21422,6 +21422,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
+ "strum_macros 0.26.4",
  "tempfile",
  "tokio",
  "url",

--- a/rs/registry/admin/bin/create_subnet.rs
+++ b/rs/registry/admin/bin/create_subnet.rs
@@ -166,6 +166,11 @@ pub(crate) struct ProposeToCreateSubnetCmd {
     #[clap(long)]
     pub max_number_of_canisters: Option<u64>,
 
+    /// The canister cycles cost schedule for this subnet.
+    /// Can be "normal" (default) or "free" (used by cloud engine subnets).
+    #[clap(long)]
+    pub canister_cycles_cost_schedule: Option<do_create_subnet::CanisterCyclesCostSchedule>,
+
     /// The features that are enabled and disabled on the subnet.
     #[clap(long)]
     pub features: Option<SubnetFeatures>,
@@ -272,6 +277,8 @@ impl ProposeToCreateSubnetCmd {
                 .get_or_insert(ReplicaVersion::default());
             self.max_number_of_canisters.get_or_insert(0);
             self.features.get_or_insert(SubnetFeatures::default());
+            self.canister_cycles_cost_schedule
+                .get_or_insert(do_create_subnet::CanisterCyclesCostSchedule::Normal);
         }
     }
 
@@ -329,7 +336,8 @@ impl ProposeToCreateSubnetCmd {
             max_number_of_canisters: self.max_number_of_canisters.unwrap_or_default(),
             chain_key_config,
             canister_cycles_cost_schedule: Some(
-                do_create_subnet::CanisterCyclesCostSchedule::Normal,
+                self.canister_cycles_cost_schedule
+                    .expect("canister_cycles_cost_schedule must be specified."),
             ),
             subnet_admins: Some(self.subnet_admins.clone()),
             resource_limits: self.resource_limits,
@@ -411,6 +419,7 @@ mod tests {
             features: None,
             subnet_admins: vec![],
             resource_limits: None,
+            canister_cycles_cost_schedule: None,
         }
     }
 
@@ -452,6 +461,9 @@ mod tests {
 
             replica_version_id: Some(replica_version_id.clone()),
             features: Some(features),
+            canister_cycles_cost_schedule: Some(
+                do_create_subnet::CanisterCyclesCostSchedule::Normal,
+            ),
             ..empty_propose_to_create_subnet_cmd()
         };
         assert_eq!(

--- a/rs/registry/admin/bin/create_subnet.rs
+++ b/rs/registry/admin/bin/create_subnet.rs
@@ -16,6 +16,7 @@ use ic_registry_subnet_features::SubnetFeatures;
 use ic_registry_subnet_type::SubnetType;
 use ic_types::{NodeId, PrincipalId, ReplicaVersion};
 use registry_canister::mutations::do_create_subnet;
+use registry_canister::mutations::do_create_subnet::CanisterCyclesCostSchedule;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use url::Url;
@@ -167,9 +168,9 @@ pub(crate) struct ProposeToCreateSubnetCmd {
     pub max_number_of_canisters: Option<u64>,
 
     /// The canister cycles cost schedule for this subnet.
-    /// Can be "normal" (default) or "free" (used by cloud engine subnets).
+    /// Can be "Normal" (default) or "Free" (used by cloud engine subnets).
     #[clap(long)]
-    pub canister_cycles_cost_schedule: Option<do_create_subnet::CanisterCyclesCostSchedule>,
+    pub canister_cycles_cost_schedule: Option<CanisterCyclesCostSchedule>,
 
     /// The features that are enabled and disabled on the subnet.
     #[clap(long)]
@@ -278,7 +279,7 @@ impl ProposeToCreateSubnetCmd {
             self.max_number_of_canisters.get_or_insert(0);
             self.features.get_or_insert(SubnetFeatures::default());
             self.canister_cycles_cost_schedule
-                .get_or_insert(do_create_subnet::CanisterCyclesCostSchedule::Normal);
+                .get_or_insert(CanisterCyclesCostSchedule::Normal);
         }
     }
 
@@ -376,9 +377,7 @@ mod tests {
 
     fn minimal_create_payload() -> do_create_subnet::CreateSubnetPayload {
         do_create_subnet::CreateSubnetPayload {
-            canister_cycles_cost_schedule: Some(
-                do_create_subnet::CanisterCyclesCostSchedule::Normal,
-            ),
+            canister_cycles_cost_schedule: Some(CanisterCyclesCostSchedule::Normal),
             subnet_admins: Some(vec![]),
             ..Default::default()
         }
@@ -461,9 +460,7 @@ mod tests {
 
             replica_version_id: Some(replica_version_id.clone()),
             features: Some(features),
-            canister_cycles_cost_schedule: Some(
-                do_create_subnet::CanisterCyclesCostSchedule::Normal,
-            ),
+            canister_cycles_cost_schedule: Some(CanisterCyclesCostSchedule::Normal),
             ..empty_propose_to_create_subnet_cmd()
         };
         assert_eq!(

--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -101,6 +101,7 @@ DEV_DEPENDENCIES = [
 MACRO_DEPENDENCIES = [
     # Keep sorted.
     "//rs/nervous_system/common/build_metadata",
+    "@crate_index//:strum_macros",
 ]
 
 DEV_MACRO_DEPENDENCIES = [
@@ -234,7 +235,7 @@ rust_ic_test(
 rust_test(
     name = "registry_canister_test",
     srcs = glob(["src/**"]),
-    proc_macro_deps = DEV_MACRO_DEPENDENCIES,
+    proc_macro_deps = MACRO_DEPENDENCIES + DEV_MACRO_DEPENDENCIES,
     deps = DEPENDENCIES + DEV_DEPENDENCIES,
 )
 

--- a/rs/registry/canister/Cargo.toml
+++ b/rs/registry/canister/Cargo.toml
@@ -60,6 +60,7 @@ on_wire = { path = "../../rust_canisters/on_wire" }
 prost = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }
+strum_macros = { workspace = true }
 url = { workspace = true }
 canbench-rs = { workspace = true, optional = true }
 rand = { workspace = true }

--- a/rs/registry/canister/src/mutations/do_create_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_create_subnet.rs
@@ -520,12 +520,10 @@ impl TryFrom<KeyConfigRequest> for KeyConfigRequestInternal {
 pub enum CanisterCyclesCostSchedule {
     /// Use the cost schedule associate with the subnet's type.
     #[default]
-    #[strum(serialize = "normal")]
     Normal,
 
     /// This is used by rented subnets. This is because rented subnets get paid
     /// for in a different way.
-    #[strum(serialize = "free")]
     Free,
 }
 

--- a/rs/registry/canister/src/mutations/do_create_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_create_subnet.rs
@@ -31,6 +31,7 @@ use on_wire::bytes;
 use prost::Message;
 use serde::Serialize;
 use std::{collections::HashSet, convert::TryFrom};
+use strum_macros::{Display, EnumString};
 
 impl Registry {
     /// Adds the new subnet to the registry.
@@ -503,14 +504,28 @@ impl TryFrom<KeyConfigRequest> for KeyConfigRequestInternal {
 ///
 ///     1. Execute instructions.
 ///     2. Store Data - In normal memory, and stable memory.
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Default, CandidType, Deserialize, Serialize)]
+#[derive(
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Debug,
+    Default,
+    CandidType,
+    Deserialize,
+    Display,
+    EnumString,
+    Serialize,
+)]
 pub enum CanisterCyclesCostSchedule {
     /// Use the cost schedule associate with the subnet's type.
     #[default]
+    #[strum(serialize = "normal")]
     Normal,
 
     /// This is used by rented subnets. This is because rented subnets get paid
     /// for in a different way.
+    #[strum(serialize = "free")]
     Free,
 }
 


### PR DESCRIPTION
## Summary
- Expose `canister_cycles_cost_schedule` as a CLI flag on `ic-admin propose-to-create-subnet` (previously hard-coded to `Normal`), so cloud engine subnets — which require `Free` — can be proposed through ic-admin.
- Defaults to `Normal` to preserve existing behavior; accepts `normal` or `free`.
- Adds `Display` / `EnumString` derives to `CanisterCyclesCostSchedule` so clap can parse the flag via `FromStr`, matching the `SubnetType` pattern.