### PR TITLE
feat: add Xen modules to GuestOS initramfs

### DIFF
--- a/ic-os/components/early-boot/initramfs-tools/guestos/modules
+++ b/ic-os/components/early-boot/initramfs-tools/guestos/modules
@@ -21,3 +21,6 @@ vmw_pvscsi
 mptsas
 mptspi
 sd_mod
+xen_blkfront
+xen_netfront
+xen_platform_pci


### PR DESCRIPTION
Add xen_blkfront, xen_netfront, and xen_platform_pci modules to the GuestOS initramfs so the GuestOS can boot under a Xen hypervisor.