### PR TITLE
fix: disable the //rs/tests/message_routing:rejoin_test_long_rounds

### DIFF
--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -94,7 +94,7 @@ system_test_nns(
     enable_head_nns_variant = False,  # only run this test with the mainnet NNS canisters.
     enable_metrics = True,
     tags = [
-        "system_test_large",
+        "manual",  # TODO: replace with "system_test_large" when the test has been made to work with d28780e
     ],
     test_timeout = "eternal",
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS | {


### PR DESCRIPTION
[d28780e](https://github.com/dfinity/ic/commit/d28780e61310fb889c16dc49f40b08cefd5a05a6) breaks the `//rs/tests/message_routing:rejoin_test_long_rounds`. Instead of reverting it was decided to temporarily disable the test.