### PR TITLE
fix: deflake //rs/tests/consensus:subnet_splitting_v2_test_colocate

### DIFF
--- a/rs/tests/consensus/subnet_splitting_v2_test.rs
+++ b/rs/tests/consensus/subnet_splitting_v2_test.rs
@@ -76,6 +76,11 @@ fn main() -> Result<()> {
         .with_timeout_per_test(Duration::from_secs(30 * 60))
         .with_overall_timeout(Duration::from_secs(35 * 60))
         .add_test(systest!(subnet_splitting_test))
+        // The replica is restarted when the orchestrator observes the recovery CUP in the registry
+        .update_orchestrator_metrics_to_check(
+            "orchestrator_replica_process_start_attempts_total",
+            2,
+        )
         .execute_from_args()
 }
 


### PR DESCRIPTION
## Root Cause

The test `//rs/tests/consensus:subnet_splitting_v2_test_colocate` is flaky because the metric `orchestrator_replica_process_start_attempts_total` reaches 2, exceeding the default maximum of 1.

During a subnet split, the orchestrator detects a new unsigned recovery CUP in the registry via `stop_replica_if_new_recovery_cup()`, stops the replica, and restarts it on the next loop iteration. This is expected behavior that results in the metric incrementing to 2 (one for initial start, one for restart after CUP-triggered stop).

## Fix

Raise the allowed threshold from 1 to 2 using `update_orchestrator_metrics_to_check()`, matching what the older `subnet_splitting_test.rs` already does.

---

*This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.*