### PR TITLE
feat(governance): Relax 8 year gang requirements.

### DIFF
--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2290,6 +2290,9 @@ message Governance {
   // dissolve delay. Enables restoring original dissolve states if the maximum is reversed.
   map<uint64, NeuronDissolveStateSnapshot> neuron_id_to_pre_clamp_dissolve_state = 32;
 
+  // Whether the relaxed eight year gang member induction is done.
+  bool relaxed_eight_year_gang_bonus_migration_done = 33;
+
   reserved 30;
   reserved "first_proposal_id_to_record_voting_history";
 

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3249,6 +3249,9 @@ pub struct Governance {
     #[prost(map = "uint64, message", tag = "32")]
     pub neuron_id_to_pre_clamp_dissolve_state:
         ::std::collections::HashMap<u64, NeuronDissolveStateSnapshot>,
+    /// Whether the relaxed eight year gang member induction is done.
+    #[prost(bool, tag = "33")]
+    pub relaxed_eight_year_gang_bonus_migration_done: bool,
 }
 /// Nested message and enum types in `Governance`.
 pub mod governance {

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -295,6 +295,16 @@ pub const NEURON_MINIMUM_DISSOLVE_DELAY_TO_PROPOSE_SECONDS: u64 = 6 * ONE_MONTH_
 pub const MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70: u64 = 8 * ONE_YEAR_SECONDS;
 pub const MAX_DISSOLVE_DELAY_SECONDS_POST_MISSION_70: u64 = 2 * ONE_YEAR_SECONDS;
 
+// Minimum dissolve delay that qualifies a neuron to be a member of the eight year gang
+// during a second round of induction.
+pub const RELAXED_EIGHT_YEAR_GANG_MIN_DISSOLVE_DELAY_SECONDS: u64 =
+    MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70 - 2 * ONE_DAY_SECONDS;
+
+// To avoid giving the eight year gang bonus to newly staked ICP, for a neuron
+// to qualify in the second round of induction into the eight year gang,
+// its ICP must not be newly staked. This defines "sufficiently old staked ICP".
+pub const RELAXED_EIGHT_YEAR_GANG_MAX_AGING_SINCE_TIMESTAMP_SECONDS: u64 = 1_774_828_800;
+
 /// Returns the maximum dissolve delay allowed for a neuron. After the flag is enabled, we can
 /// replace `max_dissolve_delay_seconds()` with `MAX_DISSOLVE_DELAY_SECONDS` and set
 /// `MAX_DISSOLVE_DELAY_SECONDS` to `MAX_DISSOLVE_DELAY_SECONDS_POST_MISSION_70`.
@@ -1376,14 +1386,30 @@ impl Governance {
     }
 
     fn maybe_set_eight_year_gang_bonus_base(&mut self) {
-        if self.heap_data.eight_year_gang_bonus_migration_done {
+        let strict_done = &mut self.heap_data.eight_year_gang_bonus_migration_done;
+        if *strict_done {
+            self.maybe_set_relaxed_eight_year_gang_bonus_base_e8s_or_panic();
             return;
         }
 
         self.neuron_store
             .set_eight_year_gang_bonus_base_e8s_for_all_neurons_or_panic();
 
-        self.heap_data.eight_year_gang_bonus_migration_done = true;
+        *strict_done = true;
+    }
+
+    fn maybe_set_relaxed_eight_year_gang_bonus_base_e8s_or_panic(&mut self) {
+        let relaxed_done = &mut self.heap_data.relaxed_eight_year_gang_bonus_migration_done;
+        if *relaxed_done {
+            return;
+        }
+
+        self.neuron_store
+            .set_relaxed_eight_year_gang_bonus_base_e8s_or_panic(
+                &self.heap_data.neuron_id_to_pre_clamp_dissolve_state,
+            );
+
+        *relaxed_done = true;
     }
 
     /// After calling this method, the proto and neuron_store (the heap neurons at least)

--- a/rs/nns/governance/src/governance/tests/mod.rs
+++ b/rs/nns/governance/src/governance/tests/mod.rs
@@ -3,8 +3,12 @@ use crate::pb::v1::ExecuteNnsFunction;
 use crate::storage::with_voting_history_store;
 use crate::test_utils::MockRandomness;
 use crate::{
-    governance::MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70,
+    governance::{
+        MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70,
+        RELAXED_EIGHT_YEAR_GANG_MAX_AGING_SINCE_TIMESTAMP_SECONDS,
+    },
     neuron::{DissolveStateAndAge, NeuronBuilder},
+    pb::v1::{NeuronDissolveStateSnapshot, neuron_dissolve_state_snapshot},
     test_utils::{MockEnvironment, StubCMC, StubIcpLedger},
 };
 use ic_base_types::PrincipalId;
@@ -1800,6 +1804,94 @@ fn test_maybe_set_eight_year_gang_bonus_base() {
         .with_neuron(&NeuronId { id: 1 }, |n| n.eight_year_gang_bonus_base_e8s)
         .unwrap();
     assert_eq!(bonus, 140 * E8);
+}
+
+#[test]
+fn test_maybe_set_relaxed_eight_year_gang_bonus_base() {
+    let mut governance = Governance::new(
+        Default::default(),
+        Arc::<MockEnvironment>::default(),
+        Arc::new(StubIcpLedger {}),
+        Arc::new(StubCMC {}),
+        Box::new(MockRandomness::new()),
+    );
+
+    // This is not exactly eight years per our (admittedly unintuitive) definition of "year",
+    // because we define 1 year to be = 365.25 days.
+    let nearly_eight_years_seconds = 8 * 365 * ONE_DAY_SECONDS;
+    let neuron_id_to_pre_clamp_dissolve_state = hashmap! {
+        // Neuron 1 will get inducted into the eight year gange.
+        1 => NeuronDissolveStateSnapshot {
+            dissolve_state: Some(
+                neuron_dissolve_state_snapshot::DissolveState::DissolveDelaySeconds(nearly_eight_years_seconds),
+            ),
+        },
+
+        2 => NeuronDissolveStateSnapshot {
+            dissolve_state: Some(
+                neuron_dissolve_state_snapshot::DissolveState::DissolveDelaySeconds(nearly_eight_years_seconds - 1),
+            ),
+        },
+    };
+
+    for neuron_id in [1, 2] {
+        let neuron = NeuronBuilder::new_for_test(
+            neuron_id,
+            DissolveStateAndAge::NotDissolving {
+                dissolve_delay_seconds: 2 * ONE_YEAR_SECONDS,
+                aging_since_timestamp_seconds:
+                    RELAXED_EIGHT_YEAR_GANG_MAX_AGING_SINCE_TIMESTAMP_SECONDS,
+            },
+        )
+        // "net stake" = 100 - 30 + 10 = 80
+        .with_cached_neuron_stake_e8s(100 * E8)
+        .with_neuron_fees_e8s(30 * E8)
+        .with_staked_maturity_e8s_equivalent(10 * E8)
+        .build();
+
+        governance.add_neuron(neuron_id, neuron).unwrap();
+    }
+
+    let mut proto = governance.take_heap_proto();
+
+    // Simulate having already run first round of induction into the eight year gang
+    // but not the second.
+    proto.eight_year_gang_bonus_migration_done = true;
+    proto.relaxed_eight_year_gang_bonus_migration_done = false;
+
+    proto.neuron_id_to_pre_clamp_dissolve_state = neuron_id_to_pre_clamp_dissolve_state;
+
+    // Step 2: Call code under test (indirectly).
+
+    let governance = Governance::new_restored(
+        proto,
+        Arc::<MockEnvironment>::default(),
+        Arc::new(StubIcpLedger {}),
+        Arc::new(StubCMC {}),
+        Box::new(MockRandomness::new()),
+    );
+
+    // Step 3: Verify results.
+
+    // Did the second round of induction occur?
+    assert!(
+        governance
+            .heap_data
+            .relaxed_eight_year_gang_bonus_migration_done
+    );
+
+    let assert_eight_year_gang_bonus_base_e8s = |neuron_id, expected| {
+        let bonus = governance
+            .neuron_store
+            .with_neuron(&NeuronId { id: neuron_id }, |n| {
+                n.eight_year_gang_bonus_base_e8s
+            })
+            .unwrap();
+        assert_eq!(bonus, expected);
+    };
+
+    assert_eight_year_gang_bonus_base_e8s(1, 80 * E8);
+    assert_eight_year_gang_bonus_base_e8s(2, 0);
 }
 
 #[test]

--- a/rs/nns/governance/src/heap_governance_data.rs
+++ b/rs/nns/governance/src/heap_governance_data.rs
@@ -38,6 +38,7 @@ pub struct HeapGovernanceData {
     pub topic_of_garbage_collected_proposals: HashMap<u64, Topic>,
     pub eight_year_gang_bonus_migration_done: bool,
     pub neuron_id_to_pre_clamp_dissolve_state: HashMap<u64, NeuronDissolveStateSnapshot>,
+    pub relaxed_eight_year_gang_bonus_migration_done: bool,
 }
 
 /// Internal representation for `XdrConversionRatePb`.
@@ -209,6 +210,7 @@ pub fn initialize_governance(
         topic_of_garbage_collected_proposals: HashMap::new(),
         eight_year_gang_bonus_migration_done: false,
         neuron_id_to_pre_clamp_dissolve_state: HashMap::new(),
+        relaxed_eight_year_gang_bonus_migration_done: false,
     };
 
     // Finally, return the result.
@@ -250,6 +252,7 @@ pub fn split_governance_proto(
         topic_of_garbage_collected_proposals,
         eight_year_gang_bonus_migration_done,
         neuron_id_to_pre_clamp_dissolve_state,
+        relaxed_eight_year_gang_bonus_migration_done,
         rng_seed,
     } = governance_proto;
 
@@ -295,6 +298,7 @@ pub fn split_governance_proto(
                 .collect(),
             eight_year_gang_bonus_migration_done,
             neuron_id_to_pre_clamp_dissolve_state,
+            relaxed_eight_year_gang_bonus_migration_done,
         },
         rng_seed,
     )
@@ -334,6 +338,7 @@ pub fn reassemble_governance_proto(
         topic_of_garbage_collected_proposals,
         eight_year_gang_bonus_migration_done,
         neuron_id_to_pre_clamp_dissolve_state,
+        relaxed_eight_year_gang_bonus_migration_done,
     } = heap_governance_proto;
 
     let neuron_management_voting_period_seconds = Some(neuron_management_voting_period_seconds);
@@ -366,6 +371,7 @@ pub fn reassemble_governance_proto(
             .collect(),
         eight_year_gang_bonus_migration_done,
         neuron_id_to_pre_clamp_dissolve_state,
+        relaxed_eight_year_gang_bonus_migration_done,
         rng_seed: rng_seed.map(|seed| seed.to_vec()),
     }
 }
@@ -407,6 +413,7 @@ mod tests {
             restore_aging_summary: None,
             topic_of_garbage_collected_proposals: hashmap! { 1 => Topic::Unspecified as i32 },
             eight_year_gang_bonus_migration_done: true,
+            relaxed_eight_year_gang_bonus_migration_done: true,
             neuron_id_to_pre_clamp_dissolve_state: hashmap! {
                 1 => NeuronDissolveStateSnapshot {
                     dissolve_state: Some(

--- a/rs/nns/governance/src/neuron_store.rs
+++ b/rs/nns/governance/src/neuron_store.rs
@@ -1,11 +1,14 @@
 use crate::{
     CURRENT_PRUNE_FOLLOWING_FULL_CYCLE_START_TIMESTAMP_SECONDS, Clock, IcClock,
-    governance::{LOG_PREFIX, TimeWarp},
+    governance::{
+        LOG_PREFIX, MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70,
+        RELAXED_EIGHT_YEAR_GANG_MIN_DISSOLVE_DELAY_SECONDS, TimeWarp,
+    },
     neuron::Neuron,
     neurons_fund::neurons_fund_neuron::pick_most_important_hotkeys,
     pb::v1::{
         GovernanceError, NeuronDissolveStateSnapshot, Topic, VotingPowerEconomics,
-        governance_error::ErrorType,
+        governance_error::ErrorType, neuron_dissolve_state_snapshot,
     },
     storage::{
         neuron_indexes::CorruptedNeuronIndexes, neurons::NeuronSections,
@@ -780,6 +783,44 @@ impl NeuronStore {
     pub fn set_eight_year_gang_bonus_base_e8s_for_all_neurons_or_panic(&mut self) {
         with_stable_neuron_store_mut(|stable_neuron_store| {
             stable_neuron_store.set_eight_year_gang_bonus_base_e8s_for_all_neurons_or_panic();
+        });
+    }
+
+    pub fn set_relaxed_eight_year_gang_bonus_base_e8s_or_panic(
+        &mut self,
+        pre_clamp_states: &HashMap<u64, NeuronDissolveStateSnapshot>,
+    ) {
+        let relaxed_eight_year_gang_candidates: Vec<u64> = pre_clamp_states
+            .iter()
+            .filter_map(|(neuron_id, pre_clamp_dissolve_state)| {
+                let Some(neuron_dissolve_state_snapshot::DissolveState::DissolveDelaySeconds(d)) =
+                    pre_clamp_dissolve_state.dissolve_state
+                else {
+                    // Skip neurons that were dissolving (or dissolved).
+                    return None;
+                };
+
+                // Skip neurons dissolve delay that was too small.
+                if d < RELAXED_EIGHT_YEAR_GANG_MIN_DISSOLVE_DELAY_SECONDS {
+                    return None;
+                }
+
+                // Skip neurons that are already in the eight year gang.
+                if d == MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70 {
+                    return None;
+                }
+
+                // This neuron is maybe eligible for relaxed eight year gang bonus,
+                // because it was not dissolving, and had a dissolve delay of nearly
+                // 8 * 365.25 days.
+                Some(*neuron_id)
+            })
+            .collect();
+
+        with_stable_neuron_store_mut(move |stable_neuron_store| {
+            stable_neuron_store.set_relaxed_eight_year_gang_bonus_base_e8s_or_panic(
+                relaxed_eight_year_gang_candidates,
+            );
         });
     }
 

--- a/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
+++ b/rs/nns/governance/src/neuron_store/neuron_store_tests.rs
@@ -1,14 +1,18 @@
 use super::*;
 use crate::{
-    governance::max_dissolve_delay_seconds,
+    governance::{
+        MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70,
+        RELAXED_EIGHT_YEAR_GANG_MAX_AGING_SINCE_TIMESTAMP_SECONDS, max_dissolve_delay_seconds,
+    },
     neuron::{DissolveStateAndAge, NeuronBuilder},
     pb::v1::{
         BallotInfo, Followees, KnownNeuronData, MaturityDisbursement, NeuronDissolveStateSnapshot,
+        neuron_dissolve_state_snapshot,
         neuron_dissolve_state_snapshot::DissolveState as SnapshotDissolveState,
     },
     storage::{with_stable_neuron_indexes, with_voting_history_store},
 };
-use ic_nervous_system_common::ONE_MONTH_SECONDS;
+use ic_nervous_system_common::{E8, ONE_DAY_SECONDS, ONE_MONTH_SECONDS, ONE_YEAR_SECONDS};
 use ic_nns_constants::GOVERNANCE_CANISTER_ID;
 use maplit::{btreemap, btreeset, hashmap, hashset};
 use pretty_assertions::assert_eq;
@@ -1193,4 +1197,150 @@ fn test_clamp_dissolve_delay_for_all_neurons_multiple_neurons() {
             );
         })
         .unwrap();
+}
+
+#[test]
+fn test_set_relaxed_eight_year_gang_bonus_base_e8s() {
+    // Step 1: Prepare the world.
+
+    let not_dissolving_with_dissolve_delay_of_nearly_eight_years = NeuronDissolveStateSnapshot {
+        dissolve_state: Some(
+            neuron_dissolve_state_snapshot::DissolveState::DissolveDelaySeconds(
+                MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70 - 1,
+            ),
+        ),
+    };
+
+    let neuron_id_to_pre_clamp_dissolve_state = hashmap! {
+        // Meets the main criterion: not dissolving and has its dissolve delay is
+        // nearly 8 years. Later, is will be seen that it meets the secondary criteria,
+        // and therefore, fully qualifies in the second round of induction into the
+        // eight year gang.
+        101 => not_dissolving_with_dissolve_delay_of_nearly_eight_years,
+
+        // Neurons that certainly do NOT qualify, based on their dissolve_state.
+
+        // Insufficient dissolve delay.
+        201 => NeuronDissolveStateSnapshot {
+            dissolve_state: Some(
+                neuron_dissolve_state_snapshot::DissolveState::DissolveDelaySeconds(
+                    MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70 - 14 * ONE_DAY_SECONDS - 1,
+                ),
+            ),
+        },
+
+        // Dissolving.
+        202 => NeuronDissolveStateSnapshot {
+            dissolve_state: Some(
+                neuron_dissolve_state_snapshot::DissolveState::WhenDissolvedTimestampSeconds(
+                    // A timestamp. This isn't used, but the value is realistic anyway.
+                    1_776_785_900,
+                ),
+            ),
+        },
+
+        // Already qualified during the first induction round.
+        203 => NeuronDissolveStateSnapshot {
+            dissolve_state: Some(
+                neuron_dissolve_state_snapshot::DissolveState::DissolveDelaySeconds(
+                    MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70,
+                ),
+            ),
+        },
+
+        // Neurons that SEEM to qualify, since they have the same dissolve_state as neuron 101,
+        // but because (as will be seen later), these do not meet the secondary criteria,
+        // do not make it in the relaxed second round of induction into the eight year gang.
+
+        // Stake is too young.
+        301 => not_dissolving_with_dissolve_delay_of_nearly_eight_years,
+
+        // Already a member of the eight year gang. In theory, this will not occur.
+        // Nevertheless, the implementation should handle this gracefully by
+        // not modifying the neuron.
+        302 => not_dissolving_with_dissolve_delay_of_nearly_eight_years,
+    };
+
+    fn new_neuron(id: u64, age_delta_seconds: i64) -> Neuron {
+        NeuronBuilder::new(
+            NeuronId { id },
+            Subaccount::from(&PrincipalId::new_user_test_id(id)),
+            PrincipalId::new_user_test_id(1),
+            DissolveStateAndAge::NotDissolving {
+                dissolve_delay_seconds: 2 * ONE_YEAR_SECONDS,
+                aging_since_timestamp_seconds:
+                    (RELAXED_EIGHT_YEAR_GANG_MAX_AGING_SINCE_TIMESTAMP_SECONDS as i64
+                        + age_delta_seconds) as u64,
+            },
+            1745249919, // created_at_timestamp_seconds
+        )
+        // Net stake = 100 - 50 + 10 = 60.
+        .with_cached_neuron_stake_e8s(100 * E8)
+        .with_neuron_fees_e8s(50 * E8)
+        .with_staked_maturity_e8s_equivalent(10 * E8)
+        .build()
+    }
+
+    let neuron_101 = new_neuron(101, 0);
+
+    let neuron_201 = new_neuron(201, 0);
+    let neuron_202 = new_neuron(202, 0);
+    let neuron_203 = new_neuron(203, 0);
+
+    // Stake is too young: started aging one second after the cutoff.
+    let neuron_301 = new_neuron(301, 1);
+
+    // Already a member: bonus was set by a prior migration.=
+    let neuron_302 = NeuronBuilder::new(
+        NeuronId { id: 302 },
+        Subaccount::from(&PrincipalId::new_user_test_id(302)),
+        PrincipalId::new_user_test_id(302),
+        DissolveStateAndAge::NotDissolving {
+            dissolve_delay_seconds: 2 * ONE_YEAR_SECONDS,
+            aging_since_timestamp_seconds:
+                RELAXED_EIGHT_YEAR_GANG_MAX_AGING_SINCE_TIMESTAMP_SECONDS,
+        },
+        1_776_790_431, // created at
+    )
+    .with_cached_neuron_stake_e8s(100 * E8)
+    .with_staked_maturity_e8s_equivalent(50 * E8)
+    .with_neuron_fees_e8s(10 * E8)
+    .with_eight_year_gang_bonus_base_e8s(42 * E8)
+    .build();
+
+    let mut neuron_store = NeuronStore::new(btreemap! {
+        101 => neuron_101,
+        201 => neuron_201,
+
+        202 => neuron_202,
+        203 => neuron_203,
+
+        301 => neuron_301,
+        302 => neuron_302,
+    });
+
+    // Step 2: Call the code under test.
+    neuron_store.set_relaxed_eight_year_gang_bonus_base_e8s_or_panic(
+        &neuron_id_to_pre_clamp_dissolve_state,
+    );
+
+    // Step 3: Verify results.
+
+    let assert_eight_year_gang_bonus_base_e8s = |neuron_id, expected| {
+        let observed = neuron_store
+            .with_neuron(&NeuronId { id: neuron_id }, |n| {
+                n.eight_year_gang_bonus_base_e8s
+            })
+            .unwrap();
+        assert_eq!(observed, expected);
+    };
+
+    assert_eight_year_gang_bonus_base_e8s(101, 60 * E8);
+
+    assert_eight_year_gang_bonus_base_e8s(201, 0);
+    assert_eight_year_gang_bonus_base_e8s(202, 0);
+    assert_eight_year_gang_bonus_base_e8s(203, 0);
+
+    assert_eight_year_gang_bonus_base_e8s(301, 0);
+    assert_eight_year_gang_bonus_base_e8s(302, 42 * E8);
 }

--- a/rs/nns/governance/src/storage/neurons.rs
+++ b/rs/nns/governance/src/storage/neurons.rs
@@ -1,5 +1,8 @@
 use crate::{
-    governance::MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70,
+    governance::{
+        LOG_PREFIX, MAX_DISSOLVE_DELAY_SECONDS_PRE_MISSION_70,
+        RELAXED_EIGHT_YEAR_GANG_MAX_AGING_SINCE_TIMESTAMP_SECONDS,
+    },
     neuron::{DecomposedNeuron, Neuron},
     neuron_store::NeuronStoreError,
     pb::v1::{
@@ -10,6 +13,7 @@ use crate::{
 };
 use candid::Principal;
 use ic_base_types::PrincipalId;
+use ic_cdk::println;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
 use ic_stable_structures::{StableBTreeMap, Storable, storable::Bound};
 use itertools::Itertools;
@@ -780,6 +784,42 @@ where
                 };
             })
             .expect("Failed to set eight year gang bonus base for neuron");
+        }
+    }
+
+    pub fn set_relaxed_eight_year_gang_bonus_base_e8s_or_panic(
+        &mut self,
+        neuron_ids_with_sufficiently_large_dissolve_delay: Vec<u64>,
+    ) {
+        for neuron_id in neuron_ids_with_sufficiently_large_dissolve_delay {
+            let neuron_id = NeuronId { id: neuron_id };
+            self.with_main_part_mut(neuron_id, |abridged_neuron| {
+                // Don't modify neurons that are already members of the eight year gang.
+                if abridged_neuron.eight_year_gang_bonus_base_e8s != 0 {
+                    println!(
+                        "{}WARNING: Neuron ID {} was passed as having a dissolve delay
+                        that was in the right range (< 8 * 365.25 days, but >= 8 * 365
+                        days), but it is already a member of the eight year gang??
+                        Skipping...",
+                        LOG_PREFIX, neuron_id.id,
+                    );
+                    return;
+                }
+
+                // This is to avoid newly staked ICP from receiving the eight year
+                // gang bonus.
+                if abridged_neuron.aging_since_timestamp_seconds
+                    > RELAXED_EIGHT_YEAR_GANG_MAX_AGING_SINCE_TIMESTAMP_SECONDS
+                {
+                    return;
+                }
+
+                abridged_neuron.eight_year_gang_bonus_base_e8s = abridged_neuron
+                    .cached_neuron_stake_e8s
+                    .saturating_sub(abridged_neuron.neuron_fees_e8s)
+                    .saturating_add(abridged_neuron.staked_maturity_e8s_equivalent.unwrap_or(0));
+            })
+            .expect("Failed to set relaxed eight year gang bonus base for neuron");
         }
     }
 

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -11,6 +11,14 @@ on the process that this file is part of, see
 
 ## Changed
 
+* Relax eight year gang membership requirement(s): Instead of needing to have dissolve
+  delay >= 8 * 365.25 days (8 "years"), which is exactly 252_460_800 seconds, a second
+  round of induction requires only that neurons had dissolve delay >= 8 * 365 days,
+  which is exactly 252_288_000 seconds. This is less than a 0.07% difference.
+  Additionally, to avoid bonusing newly staked ICP, the neuron must currently be aging
+  since before March 30 (midnight UTC). (Furthermore, neurons that are already members
+  will not have their eight year gang bonus base re-assessed.)
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
In particular, >= 8 * 365 days dissolve delay + aging since < March 30 (midnight UTC) (and not already a member of the eight year gang).

This is because there were neurons with very very very nearly 8 year dissolve delay.

# References

Closes [NNS1-4349].

[Discussion with Thomas, Jason, and Björn][dis].

[NNS1-4349]: https://dfinity.atlassian.net/browse/NNS1-4349
[dis]: https://dfinity.slack.com/archives/C01EWN833KN/p1776847314352599