### PR TITLE
feat(githubstats): add --exclude-commit filter to query

### DIFF
--- a/ci/githubstats/last.sql
+++ b/ci/githubstats/last.sql
@@ -37,5 +37,6 @@ WHERE
    AND (NOT {only_prs} OR wr.event_type = 'pull_request')
    AND ({branch} = '' OR wr.head_branch LIKE {branch})
    AND (wr.event_type != 'pull_request' OR wr.pull_request_number != ALL({exclude_prs}))
+   AND (bi.head_sha != ALL({exclude_commits}))
 
 ORDER BY bt.first_start_time DESC

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -1149,7 +1149,7 @@ def top(args):
         branch=sql.Literal(args.branch if args.branch else ""),
         exclude_prs=sql.SQL("{}::int[]").format(sql.Literal(args.exclude_pr)),
         exclude_commits=sql.SQL("{}::text[]").format(
-            sql.Literal([resolve_full_commit_sha(c) for c in args.exclude_commit])
+            sql.Literal([resolve_full_commit_sha(c) for c in set(args.exclude_commit)])
         ),
         order_by=order_by,
         N=sql.Literal(args.N),
@@ -1252,7 +1252,7 @@ def last(args):
         branch=sql.Literal(args.branch if args.branch else ""),
         exclude_prs=sql.SQL("{}::int[]").format(sql.Literal(args.exclude_pr)),
         exclude_commits=sql.SQL("{}::text[]").format(
-            sql.Literal([resolve_full_commit_sha(c) for c in args.exclude_commit])
+            sql.Literal([resolve_full_commit_sha(c) for c in set(args.exclude_commit)])
         ),
     )
 

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -114,12 +114,10 @@ def is_git_commit_sha(s: str) -> bool:
     return bool(re.match(r"^[0-9a-fA-F]{7,40}$", s))
 
 
-def get_commit_timestamp(sha: str) -> datetime:
-    """Fetch a git commit and return its commit timestamp as a timezone-aware datetime object (UTC)."""
+def resolve_full_commit_sha(sha: str) -> str:
+    """Resolve a (possibly short) git commit SHA to its full 40-character form using `git rev-parse`."""
     repo_root = THIS_SCRIPT_DIR.parent.parent
-
     try:
-        # First, resolve the full commit SHA
         result = subprocess.run(
             ["git", "rev-parse", sha],
             cwd=repo_root,
@@ -127,8 +125,19 @@ def get_commit_timestamp(sha: str) -> datetime:
             capture_output=True,
             text=True,
         )
-        full_sha = result.stdout.strip()
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        die(f"Failed to resolve git commit '{sha}': {e.stderr.strip()}\nMake sure the commit exists in the repository.")
 
+
+def get_commit_timestamp(sha: str) -> datetime:
+    """Fetch a git commit and return its commit timestamp as a timezone-aware datetime object (UTC)."""
+    repo_root = THIS_SCRIPT_DIR.parent.parent
+
+    # First, resolve the full commit SHA
+    full_sha = resolve_full_commit_sha(sha)
+
+    try:
         # Then, fetch the commit to ensure it's available locally
         subprocess.run(
             ["git", "fetch", "origin", full_sha],
@@ -1121,6 +1130,9 @@ def top(args):
         only_prs=sql.Literal(args.prs),
         branch=sql.Literal(args.branch if args.branch else ""),
         exclude_prs=sql.SQL("{}::int[]").format(sql.Literal(args.exclude_pr)),
+        exclude_commits=sql.SQL("{}::text[]").format(
+            sql.Literal([resolve_full_commit_sha(c) for c in args.exclude_commit])
+        ),
         order_by=order_by,
         N=sql.Literal(args.N),
         condition=sql.Literal(True)
@@ -1221,6 +1233,9 @@ def last(args):
         only_prs=sql.Literal(args.prs),
         branch=sql.Literal(args.branch if args.branch else ""),
         exclude_prs=sql.SQL("{}::int[]").format(sql.Literal(args.exclude_pr)),
+        exclude_commits=sql.SQL("{}::text[]").format(
+            sql.Literal([resolve_full_commit_sha(c) for c in args.exclude_commit])
+        ),
     )
 
     log_psql_query(args.verbose, query.as_string(), args.conninfo)
@@ -1359,6 +1374,14 @@ Mutually exclusive with --day/--week/--month""",
         action="append",
         default=[],
         help="Exclude workflow runs on this PR number (can be repeated)",
+    )
+    filter_parser.add_argument(
+        "--exclude-commit",
+        metavar="COMMIT_SHA",
+        type=str,
+        action="append",
+        default=[],
+        help="Exclude test runs with this head commit SHA (can be repeated)",
     )
 
     subparsers = parser.add_subparsers(required=True)

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -1149,7 +1149,7 @@ def top(args):
         branch=sql.Literal(args.branch if args.branch else ""),
         exclude_prs=sql.SQL("{}::int[]").format(sql.Literal(args.exclude_pr)),
         exclude_commits=sql.SQL("{}::text[]").format(
-            sql.Literal([resolve_full_commit_sha(c) for c in set(args.exclude_commit)])
+            sql.Literal([resolve_full_commit_sha(c) for c in dict.fromkeys(args.exclude_commit)])
         ),
         order_by=order_by,
         N=sql.Literal(args.N),
@@ -1252,7 +1252,7 @@ def last(args):
         branch=sql.Literal(args.branch if args.branch else ""),
         exclude_prs=sql.SQL("{}::int[]").format(sql.Literal(args.exclude_pr)),
         exclude_commits=sql.SQL("{}::text[]").format(
-            sql.Literal([resolve_full_commit_sha(c) for c in set(args.exclude_commit)])
+            sql.Literal([resolve_full_commit_sha(c) for c in dict.fromkeys(args.exclude_commit)])
         ),
     )
 

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -114,12 +114,29 @@ def is_git_commit_sha(s: str) -> bool:
     return bool(re.match(r"^[0-9a-fA-F]{7,40}$", s))
 
 
+def commit_sha_arg(s: str) -> str:
+    """argparse `type` validator: accept only strings that look like a git commit SHA."""
+    if not is_git_commit_sha(s):
+        raise argparse.ArgumentTypeError(
+            f"Invalid git commit SHA '{s}': expected 7-40 hexadecimal characters."
+        )
+    return s
+
+
 def resolve_full_commit_sha(sha: str) -> str:
-    """Resolve a (possibly short) git commit SHA to its full 40-character form using `git rev-parse`."""
+    """Resolve a (possibly short) git commit SHA to its full 40-character form using `git rev-parse`.
+
+    Only accepts inputs that look like a git commit SHA (hex 7-40 chars) to avoid
+    accepting arbitrary revision expressions or option injection via `git rev-parse`.
+    The `--` separator and `^{commit}` suffix ensure git treats the input as a commit
+    object reference rather than an option or another kind of object (tag, tree, ...).
+    """
+    if not is_git_commit_sha(sha):
+        die(f"Invalid git commit SHA '{sha}': expected 7-40 hexadecimal characters.")
     repo_root = THIS_SCRIPT_DIR.parent.parent
     try:
         result = subprocess.run(
-            ["git", "rev-parse", sha],
+            ["git", "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}", "--"],
             cwd=repo_root,
             check=True,
             capture_output=True,
@@ -150,9 +167,10 @@ def get_commit_timestamp(sha: str) -> datetime:
         die(f"Failed to fetch git commit '{sha}': {e.stderr.strip()}\nMake sure the commit exists in the repository.")
 
     try:
-        # Get the commit timestamp in ISO 8601 format
+        # Get the commit timestamp in ISO 8601 format. Use the fully-resolved SHA
+        # to avoid ambiguity issues after fetching.
         result = subprocess.run(
-            ["git", "log", "-1", "--format=%cI", sha],
+            ["git", "log", "-1", "--format=%cI", full_sha],
             cwd=repo_root,
             check=True,
             capture_output=True,
@@ -1378,7 +1396,7 @@ Mutually exclusive with --day/--week/--month""",
     filter_parser.add_argument(
         "--exclude-commit",
         metavar="COMMIT_SHA",
-        type=str,
+        type=commit_sha_arg,
         action="append",
         default=[],
         help="Exclude test runs with this head commit SHA (can be repeated)",

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -125,6 +125,10 @@ def resolve_full_commit_sha(sha: str) -> str:
     """
     Resolve a (possibly short) git commit SHA to its full 40-character form using `git rev-parse`.
 
+    If the commit is not yet available locally, `git fetch origin` is run once and the
+    resolution is retried. This allows callers to pass commits that have not been fetched
+    yet (e.g. commits from recent PRs on a freshly-cloned repository).
+
     Only accepts inputs that look like a git commit SHA (hex 7-40 chars) to avoid
     accepting arbitrary revision expressions or option injection via `git rev-parse`.
     The `^{commit}` suffix ensures git treats the input as a commit object reference
@@ -133,38 +137,47 @@ def resolve_full_commit_sha(sha: str) -> str:
     if not is_git_commit_sha(sha):
         die(f"Invalid git commit SHA '{sha}': expected 7-40 hexadecimal characters.")
     repo_root = THIS_SCRIPT_DIR.parent.parent
-    try:
+
+    def rev_parse() -> Optional[str]:
         result = subprocess.run(
             ["git", "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}"],
             cwd=repo_root,
-            check=True,
             capture_output=True,
             text=True,
         )
+        if result.returncode != 0:
+            return None
         # Defensively take the first non-empty line of output.
         return result.stdout.splitlines()[0].strip()
-    except subprocess.CalledProcessError as e:
-        die(f"Failed to resolve git commit '{sha}': {e.stderr.strip()}\nMake sure the commit exists in the repository.")
 
+    full_sha = rev_parse()
+    if full_sha is not None:
+        return full_sha
 
-def get_commit_timestamp(sha: str) -> datetime:
-    """Fetch a git commit and return its commit timestamp as a timezone-aware datetime object (UTC)."""
-    repo_root = THIS_SCRIPT_DIR.parent.parent
-
-    # First, resolve the full commit SHA
-    full_sha = resolve_full_commit_sha(sha)
-
+    # Commit not found locally; fetch from origin and retry.
     try:
-        # Then, fetch the commit to ensure it's available locally
         subprocess.run(
-            ["git", "fetch", "origin", full_sha],
+            ["git", "fetch", "origin"],
             cwd=repo_root,
             check=True,
             capture_output=True,
             text=True,
         )
     except subprocess.CalledProcessError as e:
-        die(f"Failed to fetch git commit '{sha}': {e.stderr.strip()}\nMake sure the commit exists in the repository.")
+        die(f"Failed to fetch from origin while resolving git commit '{sha}': {e.stderr.strip()}")
+
+    full_sha = rev_parse()
+    if full_sha is None:
+        die(f"Failed to resolve git commit '{sha}' even after fetching from origin.\nMake sure the commit exists in the repository.")
+    return full_sha
+
+
+def get_commit_timestamp(sha: str) -> datetime:
+    """Return the commit timestamp of the given git commit as a timezone-aware datetime object (UTC)."""
+    repo_root = THIS_SCRIPT_DIR.parent.parent
+
+    # Resolve the full commit SHA, fetching from origin if necessary.
+    full_sha = resolve_full_commit_sha(sha)
 
     try:
         # Get the commit timestamp in ISO 8601 format. Use the fully-resolved SHA

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -127,21 +127,22 @@ def resolve_full_commit_sha(sha: str) -> str:
 
     Only accepts inputs that look like a git commit SHA (hex 7-40 chars) to avoid
     accepting arbitrary revision expressions or option injection via `git rev-parse`.
-    The `--` separator and `^{commit}` suffix ensure git treats the input as a commit
-    object reference rather than an option or another kind of object (tag, tree, ...).
+    The `^{commit}` suffix ensures git treats the input as a commit object reference
+    rather than another kind of object (tag, tree, ...).
     """
     if not is_git_commit_sha(sha):
         die(f"Invalid git commit SHA '{sha}': expected 7-40 hexadecimal characters.")
     repo_root = THIS_SCRIPT_DIR.parent.parent
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}", "--"],
+            ["git", "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}"],
             cwd=repo_root,
             check=True,
             capture_output=True,
             text=True,
         )
-        return result.stdout.strip()
+        # Defensively take the first non-empty line of output.
+        return result.stdout.splitlines()[0].strip()
     except subprocess.CalledProcessError as e:
         die(f"Failed to resolve git commit '{sha}': {e.stderr.strip()}\nMake sure the commit exists in the repository.")
 

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -148,7 +148,11 @@ def resolve_full_commit_sha(sha: str) -> str:
         if result.returncode != 0:
             return None
         # Defensively take the first non-empty line of output.
-        return result.stdout.splitlines()[0].strip()
+        for line in result.stdout.splitlines():
+            stripped_line = line.strip()
+            if stripped_line:
+                return stripped_line
+        return None
 
     full_sha = rev_parse()
     if full_sha is not None:

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -115,16 +115,15 @@ def is_git_commit_sha(s: str) -> bool:
 
 
 def commit_sha_arg(s: str) -> str:
-    """argparse `type` validator: accept only strings that look like a git commit SHA."""
+    """Argparse `type` validator: accept only strings that look like a git commit SHA."""
     if not is_git_commit_sha(s):
-        raise argparse.ArgumentTypeError(
-            f"Invalid git commit SHA '{s}': expected 7-40 hexadecimal characters."
-        )
+        raise argparse.ArgumentTypeError(f"Invalid git commit SHA '{s}': expected 7-40 hexadecimal characters.")
     return s
 
 
 def resolve_full_commit_sha(sha: str) -> str:
-    """Resolve a (possibly short) git commit SHA to its full 40-character form using `git rev-parse`.
+    """
+    Resolve a (possibly short) git commit SHA to its full 40-character form using `git rev-parse`.
 
     Only accepts inputs that look like a git commit SHA (hex 7-40 chars) to avoid
     accepting arbitrary revision expressions or option injection via `git rev-parse`.

--- a/ci/githubstats/query.py
+++ b/ci/githubstats/query.py
@@ -168,7 +168,9 @@ def resolve_full_commit_sha(sha: str) -> str:
 
     full_sha = rev_parse()
     if full_sha is None:
-        die(f"Failed to resolve git commit '{sha}' even after fetching from origin.\nMake sure the commit exists in the repository.")
+        die(
+            f"Failed to resolve git commit '{sha}' even after fetching from origin.\nMake sure the commit exists in the repository."
+        )
     return full_sha
 
 

--- a/ci/githubstats/top.sql
+++ b/ci/githubstats/top.sql
@@ -23,6 +23,7 @@ WITH
       AND (NOT {only_prs} OR wr.event_type = 'pull_request')
       AND ({branch} = '' OR wr.head_branch LIKE {branch})
       AND (wr.event_type != 'pull_request' OR wr.pull_request_number != ALL({exclude_prs}))
+      AND (bi.head_sha != ALL({exclude_commits}))
 
     GROUP BY label
   ),


### PR DESCRIPTION
Similar to https://github.com/dfinity/ic/pull/9570 this adds a new `--exclude-commit` option (repeatable) to the shared filter parser of `//ci/githubstats:query` that excludes test runs whose `bi.head_sha` matches any of the given commit SHAs. This is useful for filtering out commits that cause massive flakiness which would otherwise add too much noise.

Short SHAs are accepted and expanded to full SHAs via `git rev-parse` before being passed to SQL.

Both the `top` and `last` subcommands support the new flag.