### PR TITLE
chore(DSM): add flag const and tune buckets for canister log metrics

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -11,6 +11,8 @@ const MIB: u64 = 1024 * KIB;
 const GIB: u64 = 1024 * MIB;
 const TIB: u64 = 1024 * GIB;
 
+const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Enabled;
+
 // TODO(DSM-105): remove after the feature is enabled by default.
 pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = false;
 pub const LOG_MEMORY_STORE_FEATURE: FlagStatus = if LOG_MEMORY_STORE_FEATURE_ENABLED {
@@ -463,7 +465,7 @@ impl Default for Config {
             max_environment_variables: MAX_ENVIRONMENT_VARIABLES,
             max_environment_variable_name_length: MAX_ENVIRONMENT_VARIABLE_NAME_LENGTH,
             max_environment_variable_value_length: MAX_ENVIRONMENT_VARIABLE_VALUE_LENGTH,
-            replicated_inter_canister_log_fetch: FlagStatus::Disabled,
+            replicated_inter_canister_log_fetch: REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE,
             log_memory_store_feature: LOG_MEMORY_STORE_FEATURE,
         }
     }

--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -11,7 +11,7 @@ const MIB: u64 = 1024 * KIB;
 const GIB: u64 = 1024 * MIB;
 const TIB: u64 = 1024 * GIB;
 
-const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Enabled;
+const REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE: FlagStatus = FlagStatus::Disabled;
 
 // TODO(DSM-105): remove after the feature is enabled by default.
 pub const LOG_MEMORY_STORE_FEATURE_ENABLED: bool = false;

--- a/rs/execution_environment/src/execution_environment_metrics.rs
+++ b/rs/execution_environment/src/execution_environment_metrics.rs
@@ -7,7 +7,6 @@ use ic_management_canister_types_private as ic00;
 use ic_metrics::MetricsRegistry;
 use ic_metrics::buckets::{decimal_buckets, decimal_buckets_with_zero};
 use ic_replicated_state::metadata_state::subnet_call_context_manager::InstallCodeCallId;
-use ic_replicated_state::metrics::duration_histogram;
 use ic_types::CanisterId;
 use ic_types::canister_http::{CanisterHttpRequestContext, MAX_CANISTER_HTTP_RESPONSE_BYTES};
 use ic_types::messages::Response;
@@ -95,10 +94,11 @@ impl ExecutionEnvironmentMetrics {
                 // The `outcome` label is deprecated and should be replaced by `status` eventually.
                 &["method_name", "outcome", "status", "speed"],
             ),
-            canister_log_resize_duration: duration_histogram(
+            canister_log_resize_duration: metrics_registry.histogram(
                 "canister_log_resize_duration_seconds",
                 "Duration of `log_memory_limit` resize operations on the canister log memory store, in seconds.",
-                metrics_registry,
+                // Buckets: 1ms, 2ms, 5ms, ..., 10s, 20s, 50s.
+                decimal_buckets(-3, 1),
             ),
             executions_aborted: metrics_registry
                 .int_counter("executions_aborted", "Total number of aborted executions"),


### PR DESCRIPTION
Two small, related tweaks to canister log plumbing:

- **Feature-flag const.** Introduce `REPLICATED_INTER_CANISTER_LOG_FETCH_FEATURE` in `rs/config/src/execution_environment.rs` as a sibling to `LOG_MEMORY_STORE_FEATURE`, so both canister-log feature defaults can be toggled from one place in `rs/config`.
- **Custom buckets for `canister_log_resize_duration_seconds`.** Replace the generic `duration_histogram` with `decimal_buckets(-3, 1)` (1ms, 2ms, 5ms, …, 10s, 20s, 50s). Sub-ms granularity is not useful for `log_memory_limit` resize operations, and the tail buckets above 5s keep overflow visibility as a guardrail.
