### PR TITLE
fix: deflake //rs/state_manager:state_manager_integration

### DIFF
--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -3720,9 +3720,13 @@ impl StateManagerImpl {
     /// Note: Do not call this function while the calling scope holds a write lock to `SharedState`.
     pub fn flush_hash_channel(&self) {
         let (sender, recv) = bounded(1);
+        // Both sending the `Wait` request and receiving the response can fail if the
+        // hashing thread has already panicked (e.g. due to a hash mismatch). In either
+        // case the caller cannot wait for the hashing thread, so use a single panic
+        // message to avoid racy panic messages (see `commit_and_certify_panic_on_delivered_fake_certification`).
         self.hash_channel
             .send(HashRequest::Wait { sender })
-            .expect("failed to send Wait message to hashing thread");
+            .expect("failed to wait for hashing thread");
         recv.recv().expect("failed to wait for hashing thread");
     }
 }


### PR DESCRIPTION
## Root cause

Since https://github.com/dfinity/ic/pull/8464 `//rs/state_manager:state_manager_integration` has been flaking on the test
`commit_and_certify_panic_on_delivered_fake_certification`, which is marked:

```rust
#[should_panic(expected = "failed to wait for hashing thread")]
```

The test deliberately delivers a fake certification so that the background
`HashThread` panics with a hash-mismatch error once the real state is
committed. The main test thread then only panics later, when the
`StateManagerImpl` is dropped and `flush_hash_channel` is called.

`flush_hash_channel` used to have two distinct panic sites:

```rust
self.hash_channel
    .send(HashRequest::Wait { sender })
    .expect("failed to send Wait message to hashing thread");
recv.recv().expect("failed to wait for hashing thread");
```

Whether the first or second `expect` fires depends on a race between the
`HashThread` panicking (and thereby closing the channel) and the main
thread reaching the `send` call:

- If the `HashThread` closes the channel **before** `send`, the panic
  message is `"failed to send Wait message to hashing thread"`, which
  does **not** match the `expected` substring, and the test fails.
- If `send` succeeds but the `HashThread` has panicked before responding,
  the panic message is `"failed to wait for hashing thread"`, matching
  the expected substring, and the test passes.

Observed in multiple flaky runs over the past week, e.g.:

```
thread 'HashThread' panicked at rs/state_manager/src/lib.rs:3600:37:
Committed state @1 with hash ... which is different from delivered hash ...
thread 'commit_and_certify_panic_on_delivered_fake_certification' panicked at rs/state_manager/src/lib.rs:3681:14:
failed to send Wait message to hashing thread: "SendError(..)"
```

## Fix

Use the same panic message (`"failed to wait for hashing thread"`) for
both the `send` and `recv` failures in `flush_hash_channel`. From the
caller's point of view both failures mean the same thing: we could not
wait for the hashing thread to finish. This removes the race in the
panic message without changing any behavior.

Verified with:

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 \
    //rs/state_manager:state_manager_integration
```

All 3 runs pass.

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
