### PR TITLE
fix(ic-admin): include missing SubnetRecord fields in get-subnet output

### DIFF
--- a/rs/registry/admin/bin/helpers.rs
+++ b/rs/registry/admin/bin/helpers.rs
@@ -37,7 +37,7 @@ pub(crate) async fn get_subnet_record(
     subnet_id: SubnetId,
 ) -> SubnetRecord {
     let value_pb = get_subnet_record_pb(registry_canister, subnet_id).await;
-    SubnetRecord::from(&value_pb)
+    SubnetRecord::from(value_pb)
 }
 
 pub(crate) async fn get_subnet_record_with_details(

--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -1921,7 +1921,7 @@ impl ProposeToBlessAlternativeGuestOsVersionCmd {
                 )
             });
         SubnetRecord::from(
-            &SubnetRecordProto::decode(&subnet_record_bytes[..]).unwrap_or_else(|err| {
+            SubnetRecordProto::decode(&subnet_record_bytes[..]).unwrap_or_else(|err| {
                 panic!(
                     "Failed to decode SubnetRecord for subnet {}: {}",
                     subnet_id, err
@@ -5961,7 +5961,7 @@ async fn print_and_get_last_value<T: Message + Default + serde::Serialize>(
                 // subnet records are emitted as JSON
                 let value = SubnetRecordProto::decode(&bytes[..])
                     .expect("Error decoding value from registry.");
-                let subnet_record = SubnetRecord::from(&value);
+                let subnet_record = SubnetRecord::from(value);
 
                 let mut registry = Registry {
                     version,

--- a/rs/registry/admin/bin/types.rs
+++ b/rs/registry/admin/bin/types.rs
@@ -101,58 +101,87 @@ impl SubnetRecord {
     }
 }
 
-impl From<&SubnetRecordProto> for SubnetRecord {
+impl From<SubnetRecordProto> for SubnetRecord {
     /// Convert a v1::SubnetRecord to a SubnetRecord. Most data is passed
     /// through unchanged, except the `membership` list, which is converted
     /// to a `Vec<String>` for nicer display.
-    fn from(value: &SubnetRecordProto) -> Self {
+    fn from(value: SubnetRecordProto) -> Self {
+        // Exhaustive destructuring (no `..`) so that adding a field to the
+        // proto forces the compiler to flag this conversion.
+        let SubnetRecordProto {
+            membership,
+            max_ingress_bytes_per_message,
+            unit_delay_millis,
+            initial_notary_delay_millis,
+            replica_version_id,
+            dkg_interval_length,
+            start_as_nns,
+            subnet_type,
+            dkg_dealings_per_block,
+            is_halted,
+            max_ingress_messages_per_block,
+            max_ingress_bytes_per_block,
+            max_block_payload_size,
+            features,
+            max_number_of_canisters,
+            ssh_readonly_access,
+            ssh_backup_access,
+            halt_at_cup_height,
+            chain_key_config,
+            canister_cycles_cost_schedule,
+            subnet_admins,
+            recalled_replica_version_ids,
+            resource_limits,
+        } = value;
+
+        let membership = membership
+            .into_iter()
+            .map(|n| {
+                PrincipalId::try_from(&n[..])
+                    .expect("could not create PrincipalId from membership entry")
+                    .to_string()
+            })
+            .collect();
+        let subnet_type = SubnetType::try_from(subnet_type).unwrap();
+        let features = features.unwrap_or_default().into();
+        let resource_limits = resource_limits.unwrap_or_default().into();
+        let chain_key_config = chain_key_config.map(|c| c.try_into().unwrap());
+        let canister_cycles_cost_schedule =
+            CanisterCyclesCostSchedule::try_from(canister_cycles_cost_schedule).unwrap();
+        let subnet_admins = subnet_admins
+            .into_iter()
+            .map(|p| {
+                PrincipalId::try_from(&p.raw[..])
+                    .expect("could not create PrincipalId from subnet_admins entry")
+                    .to_string()
+            })
+            .collect();
+
         Self {
-            membership: value
-                .membership
-                .iter()
-                .map(|n| {
-                    PrincipalId::try_from(&n[..])
-                        .expect("could not create PrincipalId from membership entry")
-                        .to_string()
-                })
-                .collect(),
+            membership,
             nodes: IndexMap::default(),
-            max_ingress_bytes_per_message: value.max_ingress_bytes_per_message,
-            max_ingress_messages_per_block: value.max_ingress_messages_per_block,
-            max_ingress_bytes_per_block: value.max_ingress_bytes_per_block,
-            max_block_payload_size: value.max_block_payload_size,
-            unit_delay_millis: value.unit_delay_millis,
-            initial_notary_delay_millis: value.initial_notary_delay_millis,
-            replica_version_id: value.replica_version_id.clone(),
-            dkg_interval_length: value.dkg_interval_length,
-            dkg_dealings_per_block: value.dkg_dealings_per_block,
-            start_as_nns: value.start_as_nns,
-            subnet_type: SubnetType::try_from(value.subnet_type).unwrap(),
-            is_halted: value.is_halted,
-            halt_at_cup_height: value.halt_at_cup_height,
-            features: value.features.unwrap_or_default().into(),
-            resource_limits: value.resource_limits.unwrap_or_default().into(),
-            max_number_of_canisters: value.max_number_of_canisters,
-            ssh_readonly_access: value.ssh_readonly_access.clone(),
-            ssh_backup_access: value.ssh_backup_access.clone(),
-            chain_key_config: value
-                .chain_key_config
-                .as_ref()
-                .map(|c| c.clone().try_into().unwrap()),
-            canister_cycles_cost_schedule: CanisterCyclesCostSchedule::try_from(
-                value.canister_cycles_cost_schedule,
-            )
-            .unwrap(),
-            subnet_admins: value
-                .subnet_admins
-                .iter()
-                .map(|p| {
-                    PrincipalId::try_from(&p.raw[..])
-                        .expect("could not create PrincipalId from subnet_admins entry")
-                        .to_string()
-                })
-                .collect(),
-            recalled_replica_version_ids: value.recalled_replica_version_ids.clone(),
+            max_ingress_bytes_per_message,
+            max_ingress_messages_per_block,
+            max_ingress_bytes_per_block,
+            max_block_payload_size,
+            unit_delay_millis,
+            initial_notary_delay_millis,
+            replica_version_id,
+            dkg_interval_length,
+            dkg_dealings_per_block,
+            start_as_nns,
+            subnet_type,
+            is_halted,
+            halt_at_cup_height,
+            features,
+            resource_limits,
+            max_number_of_canisters,
+            ssh_readonly_access,
+            ssh_backup_access,
+            chain_key_config,
+            canister_cycles_cost_schedule,
+            subnet_admins,
+            recalled_replica_version_ids,
         }
     }
 }

--- a/rs/registry/admin/bin/types.rs
+++ b/rs/registry/admin/bin/types.rs
@@ -9,7 +9,7 @@ use ic_nns_governance_api::ProposalActionRequest;
 use ic_protobuf::registry::{
     node::v1::{IPv4InterfaceConfig, NodeRewardType},
     provisional_whitelist::v1::ProvisionalWhitelist as ProvisionalWhitelistProto,
-    subnet::v1::SubnetRecord as SubnetRecordProto,
+    subnet::v1::{CanisterCyclesCostSchedule, SubnetRecord as SubnetRecordProto},
 };
 use ic_registry_nns_data_provider::registry::RegistryCanister;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -63,6 +63,7 @@ pub(crate) struct SubnetRecord {
     pub nodes: IndexMap<PrincipalId, NodeDetails>,
     pub max_ingress_bytes_per_message: u64,
     pub max_ingress_messages_per_block: u64,
+    pub max_ingress_bytes_per_block: u64,
     pub max_block_payload_size: u64,
     pub unit_delay_millis: u64,
     pub initial_notary_delay_millis: u64,
@@ -71,12 +72,17 @@ pub(crate) struct SubnetRecord {
     pub dkg_dealings_per_block: u64,
     pub start_as_nns: bool,
     pub subnet_type: SubnetType,
+    pub is_halted: bool,
+    pub halt_at_cup_height: bool,
     pub features: SubnetFeatures,
     pub resource_limits: ResourceLimits,
     pub max_number_of_canisters: u64,
     pub ssh_readonly_access: Vec<String>,
     pub ssh_backup_access: Vec<String>,
     pub chain_key_config: Option<ChainKeyConfig>,
+    pub canister_cycles_cost_schedule: CanisterCyclesCostSchedule,
+    pub subnet_admins: Vec<String>,
+    pub recalled_replica_version_ids: Vec<String>,
 }
 
 impl SubnetRecord {
@@ -113,6 +119,7 @@ impl From<&SubnetRecordProto> for SubnetRecord {
             nodes: IndexMap::default(),
             max_ingress_bytes_per_message: value.max_ingress_bytes_per_message,
             max_ingress_messages_per_block: value.max_ingress_messages_per_block,
+            max_ingress_bytes_per_block: value.max_ingress_bytes_per_block,
             max_block_payload_size: value.max_block_payload_size,
             unit_delay_millis: value.unit_delay_millis,
             initial_notary_delay_millis: value.initial_notary_delay_millis,
@@ -121,6 +128,8 @@ impl From<&SubnetRecordProto> for SubnetRecord {
             dkg_dealings_per_block: value.dkg_dealings_per_block,
             start_as_nns: value.start_as_nns,
             subnet_type: SubnetType::try_from(value.subnet_type).unwrap(),
+            is_halted: value.is_halted,
+            halt_at_cup_height: value.halt_at_cup_height,
             features: value.features.unwrap_or_default().into(),
             resource_limits: value.resource_limits.unwrap_or_default().into(),
             max_number_of_canisters: value.max_number_of_canisters,
@@ -130,6 +139,20 @@ impl From<&SubnetRecordProto> for SubnetRecord {
                 .chain_key_config
                 .as_ref()
                 .map(|c| c.clone().try_into().unwrap()),
+            canister_cycles_cost_schedule: CanisterCyclesCostSchedule::try_from(
+                value.canister_cycles_cost_schedule,
+            )
+            .unwrap(),
+            subnet_admins: value
+                .subnet_admins
+                .iter()
+                .map(|p| {
+                    PrincipalId::try_from(&p.raw[..])
+                        .expect("could not create PrincipalId from subnet_admins entry")
+                        .to_string()
+                })
+                .collect(),
+            recalled_replica_version_ids: value.recalled_replica_version_ids.clone(),
         }
     }
 }


### PR DESCRIPTION
- Several fields on the `SubnetRecord` proto were missing from the user-friendly struct used to render `ic-admin get-subnet`, so they were silently dropped from the JSON output.
- Adds `subnet_admins`, `is_halted`, `halt_at_cup_height`, `max_ingress_bytes_per_block`, `canister_cycles_cost_schedule`, and `recalled_replica_version_ids` to the output.

Manually running ic-admin to confirm the new fields are there:
```
$ bazel run //rs/registry/admin:ic-admin -- --nns-url https://icp-api.io get-subnet jmfme-gsaqk-ni4ha-75vqy-4c3ki-2u37y-xeemy-dcgq6-hbsci-6tqeb-wqe
...
{
  "version": 58169,
  "records": [
    {
      "key": "subnet_record_jmfme-gsaqk-ni4ha-75vqy-4c3ki-2u37y-xeemy-dcgq6-hbsci-6tqeb-wqe",
      "version": 58169,
      "value": {
        "membership": [
          "lg45v-ktek6-6bca5-cd7cf-ptrwr-dovu4-ptt3k-6vkse-6hwsh-ogzhm-oqe",
          "sgrf7-u2i64-nmybq-qmldk-cq67h-fkpcg-mv55a-zuqsf-7dmc4-b5gcf-eqe",
          "y7han-ubz4t-qfs4j-uc27t-6t5ag-3zpyb-yoagk-vn7b3-dqz2m-eo6dz-uae",
          "sunbj-pky5k-bgeaw-5egfi-ywf37-j5fjr-jstjx-utqg4-zkoec-sdn44-3qe"
        ],
        "nodes": {},
        "max_ingress_bytes_per_message": 2097152,
        "max_ingress_messages_per_block": 1000,
        "max_ingress_bytes_per_block": 0,
        "max_block_payload_size": 4194304,
        "unit_delay_millis": 1000,
        "initial_notary_delay_millis": 300,
        "replica_version_id": "719ff387aab462ce5759c4c20c30de959fe9538c",
        "dkg_interval_length": 499,
        "dkg_dealings_per_block": 1,
        "start_as_nns": false,
        "subnet_type": "cloud_engine",
        "is_halted": false,
        "halt_at_cup_height": false,
        "features": {
          "canister_sandboxing": false,
          "http_requests": true,
          "sev_enabled": false
        },
        "resource_limits": {
          "maximum_state_size": 42949672960,
          "maximum_state_delta": 10737418240
        },
        "max_number_of_canisters": 0,
        "ssh_readonly_access": [],
        "ssh_backup_access": [],
        "chain_key_config": null,
        "canister_cycles_cost_schedule": "Free",
        "subnet_admins": [
          "2igsz-4cjfz-unvfj-s4d3u-ftcdb-6ibug-em6tf-nzm2h-6igks-spdus-rqe",
          "e42vp-gc2do-oroja-usffa-7lmjr-35xuh-gyf2y-opkyv-4lpww-ov7yw-vqe",
          "5wns5-er7rf-v6t24-tlx7e-d6f57-5yfyc-usbec-btlph-mbpc6-rrfkb-tqe",
          "f6hqi-m27ha-oucb6-kgk2v-gcll4-lt7df-76giq-sh263-vxa4v-eohvg-vqe",
          "m7dyc-ahooa-oxlr2-vwj6r-4hfuv-37crn-ztx47-h4ytu-wlqz4-pk3ap-mqe"
        ],
        "recalled_replica_version_ids": []
      }
    }
  ]
}
```