### PR TITLE
chore: error log if the status of call is unknown in sync call handler certificate

### DIFF
--- a/rs/http_endpoints/public/src/call/call_sync.rs
+++ b/rs/http_endpoints/public/src/call/call_sync.rs
@@ -348,6 +348,11 @@ async fn call_sync(
     // TODO(DSM-121): ensure that `ParsedMessageStatus::Unknown` never occurs
     // and trigger a critical error here if it does.
     if let ParsedMessageStatus::Unknown = message_status {
+        error!(
+            every_n_seconds => LOG_EVERY_N_SECONDS,
+            log,
+            "Unknown status of call {} in the certificate at height {}.", message_id, certification.height
+        );
         return SyncCallResponse::Accepted(
             "Certified state does not contain request status. Please try /read_state.",
         );


### PR DESCRIPTION
This PR introduces an error log if the synchronous update call HTTP handler was about to return a certificate that does not contain the update call response (in which case the HTTP handler returns `SyncCallResponse::Accepted` so that the caller falls back onto querying the read state HTTP endpoint). This scenario is no longer expected to happen, but we want to start with an error log before introducing a critical error (that would page FIT etc.).