### PR TITLE
feat: enable listing canisters via query call with subnet ID in the URL

### DIFF
--- a/rs/http_endpoints/public/src/call.rs
+++ b/rs/http_endpoints/public/src/call.rs
@@ -261,7 +261,7 @@ impl IngressValidator {
                     Err(HttpError {
                         status: StatusCode::BAD_REQUEST,
                         message: format!(
-                            "Specified CanisterId {} does not match effective canister id in URL {}",
+                            "Specified canister ID {} does not match effective canister ID in URL {}",
                             msg.canister_id(),
                             effective_canister_id
                         ),
@@ -273,7 +273,7 @@ impl IngressValidator {
                     Err(HttpError {
                         status: StatusCode::BAD_REQUEST,
                         message: format!(
-                            "Specified SubnetId {} does not match the subnet id of this node {}",
+                            "Specified subnet ID {} does not match the subnet ID of this node {}",
                             effective_subnet_id, subnet_id
                         ),
                     })?;

--- a/rs/http_endpoints/public/src/lib.rs
+++ b/rs/http_endpoints/public/src/lib.rs
@@ -133,7 +133,7 @@ struct HttpHandler {
     subnet_call_v4_router: Router,
     query_v2_router: Router,
     query_v3_router: Router,
-    subnet_query_v4_router: Router,
+    subnet_query_v3_router: Router,
     catchup_router: Router,
     dashboard_router: Router,
     status_router: Router,
@@ -350,7 +350,7 @@ pub fn start_server(
 
     let query_v2_router = query_router(query::Version::V2);
     let query_v3_router = query_router(query::Version::V3);
-    let subnet_query_v4_router = query_router(query::Version::SubnetV4);
+    let subnet_query_v3_router = query_router(query::Version::SubnetV3);
 
     let read_state_router = |version, target| {
         ReadStateServiceBuilder::builder(
@@ -420,7 +420,7 @@ pub fn start_server(
         subnet_call_v4_router,
         query_v2_router,
         query_v3_router,
-        subnet_query_v4_router,
+        subnet_query_v3_router,
         status_router,
         catchup_router,
         dashboard_router,
@@ -613,7 +613,7 @@ fn make_router(
             .merge(http_handler.query_v3_router.layer(service_builder(
                 GlobalConcurrencyLimitLayer::new(config.max_query_concurrent_requests),
             )))
-            .merge(http_handler.subnet_query_v4_router.layer(service_builder(
+            .merge(http_handler.subnet_query_v3_router.layer(service_builder(
                 GlobalConcurrencyLimitLayer::new(config.max_query_concurrent_requests),
             )))
             .merge(
@@ -823,8 +823,8 @@ pub(crate) mod tests {
                 QueryService::route(query::Version::V3),
                 axum::routing::post(dummy_cbor),
             ),
-            subnet_query_v4_router: Router::new().route(
-                QueryService::route(query::Version::SubnetV4),
+            subnet_query_v3_router: Router::new().route(
+                QueryService::route(query::Version::SubnetV3),
                 axum::routing::post(dummy_cbor),
             ),
             catchup_router: Router::new().route(

--- a/rs/http_endpoints/public/src/lib.rs
+++ b/rs/http_endpoints/public/src/lib.rs
@@ -133,6 +133,7 @@ struct HttpHandler {
     subnet_call_v4_router: Router,
     query_v2_router: Router,
     query_v3_router: Router,
+    subnet_query_v4_router: Router,
     catchup_router: Router,
     dashboard_router: Router,
     status_router: Router,
@@ -339,6 +340,7 @@ pub fn start_server(
             ingress_verifier.clone(),
             nns_delegation_reader.clone(),
             query_execution_service.clone(),
+            subnet_id,
             version,
         )
         .with_health_status(health_status.clone())
@@ -348,6 +350,7 @@ pub fn start_server(
 
     let query_v2_router = query_router(query::Version::V2);
     let query_v3_router = query_router(query::Version::V3);
+    let subnet_query_v4_router = query_router(query::Version::SubnetV4);
 
     let read_state_router = |version, target| {
         ReadStateServiceBuilder::builder(
@@ -417,6 +420,7 @@ pub fn start_server(
         subnet_call_v4_router,
         query_v2_router,
         query_v3_router,
+        subnet_query_v4_router,
         status_router,
         catchup_router,
         dashboard_router,
@@ -607,6 +611,9 @@ fn make_router(
                 GlobalConcurrencyLimitLayer::new(config.max_query_concurrent_requests),
             )))
             .merge(http_handler.query_v3_router.layer(service_builder(
+                GlobalConcurrencyLimitLayer::new(config.max_query_concurrent_requests),
+            )))
+            .merge(http_handler.subnet_query_v4_router.layer(service_builder(
                 GlobalConcurrencyLimitLayer::new(config.max_query_concurrent_requests),
             )))
             .merge(
@@ -814,6 +821,10 @@ pub(crate) mod tests {
             ),
             query_v3_router: Router::new().route(
                 QueryService::route(query::Version::V3),
+                axum::routing::post(dummy_cbor),
+            ),
+            subnet_query_v4_router: Router::new().route(
+                QueryService::route(query::Version::SubnetV4),
                 axum::routing::post(dummy_cbor),
             ),
             catchup_router: Router::new().route(

--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -234,7 +234,7 @@ pub(crate) async fn query(
             if canister_id != CanisterId::ic_00() && canister_id != effective_canister_id {
                 let status = StatusCode::BAD_REQUEST;
                 let text = format!(
-                    "Specified CanisterId {canister_id} does not match effective canister id in URL {effective_canister_id}"
+                    "Specified canister ID {canister_id} does not match effective canister ID in URL {effective_canister_id}"
                 );
                 return (status, text).into_response();
             }
@@ -244,7 +244,7 @@ pub(crate) async fn query(
             if effective_subnet_id != subnet_id {
                 let status = StatusCode::BAD_REQUEST;
                 let text = format!(
-                    "Specified SubnetId {effective_subnet_id} does not match the subnet id of this node {subnet_id}"
+                    "Specified subnet ID {effective_subnet_id} does not match the subnet ID of this node {subnet_id}"
                 );
                 return (status, text).into_response();
             }

--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -1,4 +1,4 @@
-//! Module that deals with requests to /api/v2/canister/.../query and /api/v3/subnet/.../query
+//! Module that deals with requests to /api/v{2,3}/canister/.../query and /api/v3/subnet/.../query
 
 use crate::{
     ReplicaHealthStatus,

--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -1,4 +1,4 @@
-//! Module that deals with requests to /api/v2/canister/.../query
+//! Module that deals with requests to /api/v2/canister/.../query and /api/v4/subnet/.../query
 
 use crate::{
     ReplicaHealthStatus,
@@ -29,7 +29,7 @@ use ic_logger::{ReplicaLogger, error};
 use ic_nns_delegation_manager::{CanisterRangesFilter, NNSDelegationReader};
 use ic_registry_client_helpers::crypto::root_of_trust::RegistryRootOfTrustProvider;
 use ic_types::{
-    CanisterId, NodeId,
+    CanisterId, NodeId, PrincipalId, SubnetId,
     crypto::threshold_sig::IcRootOfTrust,
     ingress::WasmResult,
     malicious_flags::MaliciousFlags,
@@ -53,6 +53,8 @@ pub enum Version {
     V2,
     // Endpoint with the NNS delegation using the tree format of the canister ranges.
     V3,
+    // Subnet endpoint with no canister ranges in the NNS delegation.
+    SubnetV4,
 }
 
 #[derive(Clone)]
@@ -68,6 +70,7 @@ pub struct QueryService {
     additional_root_of_trust: Option<IcRootOfTrust>,
     query_execution_service: Arc<Mutex<QueryExecutionService>>,
     version: Version,
+    subnet_id: SubnetId,
 }
 
 pub struct QueryServiceBuilder {
@@ -82,6 +85,7 @@ pub struct QueryServiceBuilder {
     registry_client: Arc<dyn RegistryClient>,
     additional_root_of_trust: Option<IcRootOfTrust>,
     query_execution_service: QueryExecutionService,
+    subnet_id: SubnetId,
     version: Version,
 }
 
@@ -90,6 +94,7 @@ impl QueryService {
         match version {
             Version::V2 => "/api/v2/canister/{effective_canister_id}/query",
             Version::V3 => "/api/v3/canister/{effective_canister_id}/query",
+            Version::SubnetV4 => "/api/v4/subnet/{effective_subnet_id}/query",
         }
     }
 }
@@ -103,6 +108,7 @@ impl QueryServiceBuilder {
         ingress_verifier: Arc<dyn IngressSigVerifier>,
         nns_delegation_reader: NNSDelegationReader,
         query_execution_service: QueryExecutionService,
+        subnet_id: SubnetId,
         version: Version,
     ) -> Self {
         Self {
@@ -117,6 +123,7 @@ impl QueryServiceBuilder {
             registry_client,
             additional_root_of_trust: None,
             query_execution_service,
+            subnet_id,
             version,
         }
     }
@@ -163,6 +170,7 @@ impl QueryServiceBuilder {
             additional_root_of_trust: self.additional_root_of_trust,
             query_execution_service: Arc::new(Mutex::new(self.query_execution_service)),
             version: self.version,
+            subnet_id: self.subnet_id,
         };
         Router::new().route_service(
             QueryService::route(self.version),
@@ -179,7 +187,7 @@ impl QueryServiceBuilder {
 }
 
 pub(crate) async fn query(
-    axum::extract::Path(effective_canister_id): axum::extract::Path<CanisterId>,
+    axum::extract::Path(id): axum::extract::Path<PrincipalId>,
     State(QueryService {
         log,
         node_id,
@@ -192,6 +200,7 @@ pub(crate) async fn query(
         additional_root_of_trust,
         query_execution_service,
         version,
+        subnet_id,
     }): State<QueryService>,
     WithTimeout(Cbor(request)): WithTimeout<Cbor<HttpRequestEnvelope<HttpQueryContent>>>,
 ) -> impl IntoResponse {
@@ -217,12 +226,41 @@ pub(crate) async fn query(
         }
     };
     let canister_id = request.content().canister_id();
-    if canister_id != CanisterId::ic_00() && canister_id != effective_canister_id {
-        let status = StatusCode::BAD_REQUEST;
-        let text = format!(
-            "Specified CanisterId {canister_id} does not match effective canister id in URL {effective_canister_id}"
-        );
-        return (status, text).into_response();
+
+    // Validate effective destination.
+    match version {
+        Version::V2 | Version::V3 => {
+            let effective_canister_id = CanisterId::unchecked_from_principal(id);
+            if canister_id != CanisterId::ic_00() && canister_id != effective_canister_id {
+                let status = StatusCode::BAD_REQUEST;
+                let text = format!(
+                    "Specified CanisterId {canister_id} does not match effective canister id in URL {effective_canister_id}"
+                );
+                return (status, text).into_response();
+            }
+        }
+        Version::SubnetV4 => {
+            let effective_subnet_id = SubnetId::from(id);
+            if effective_subnet_id != subnet_id {
+                let status = StatusCode::BAD_REQUEST;
+                let text = format!(
+                    "Specified SubnetId {effective_subnet_id} does not match the subnet id of this node {subnet_id}"
+                );
+                return (status, text).into_response();
+            }
+            if canister_id != CanisterId::ic_00()
+                || request.content().method_name != "list_canisters"
+            {
+                let status = StatusCode::BAD_REQUEST;
+                let text = format!(
+                    "Subnet query endpoint only accepts queries to the management canister ({}) 'list_canisters' method, got canister_id={} method_name='{}'",
+                    CanisterId::ic_00(),
+                    canister_id,
+                    request.content().method_name
+                );
+                return (status, text).into_response();
+            }
+        }
     }
 
     let root_of_trust_provider = if let Some(additional_root_of_trust) = additional_root_of_trust {
@@ -263,8 +301,12 @@ pub(crate) async fn query(
         Version::V2 => {
             nns_delegation_reader.get_delegation_with_metadata(CanisterRangesFilter::Flat)
         }
-        Version::V3 => nns_delegation_reader
-            .get_delegation_with_metadata(CanisterRangesFilter::Tree(effective_canister_id)),
+        Version::V3 => nns_delegation_reader.get_delegation_with_metadata(
+            CanisterRangesFilter::Tree(CanisterId::unchecked_from_principal(id)),
+        ),
+        Version::SubnetV4 => {
+            nns_delegation_reader.get_delegation_with_metadata(CanisterRangesFilter::None)
+        }
     };
     let query_execution_input = QueryExecutionInput {
         query: user_query.clone(),

--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -1,4 +1,4 @@
-//! Module that deals with requests to /api/v2/canister/.../query and /api/v4/subnet/.../query
+//! Module that deals with requests to /api/v2/canister/.../query and /api/v3/subnet/.../query
 
 use crate::{
     ReplicaHealthStatus,
@@ -54,7 +54,7 @@ pub enum Version {
     // Endpoint with the NNS delegation using the tree format of the canister ranges.
     V3,
     // Subnet endpoint with no canister ranges in the NNS delegation.
-    SubnetV4,
+    SubnetV3,
 }
 
 #[derive(Clone)]
@@ -94,7 +94,7 @@ impl QueryService {
         match version {
             Version::V2 => "/api/v2/canister/{effective_canister_id}/query",
             Version::V3 => "/api/v3/canister/{effective_canister_id}/query",
-            Version::SubnetV4 => "/api/v4/subnet/{effective_subnet_id}/query",
+            Version::SubnetV3 => "/api/v3/subnet/{effective_subnet_id}/query",
         }
     }
 }
@@ -239,7 +239,7 @@ pub(crate) async fn query(
                 return (status, text).into_response();
             }
         }
-        Version::SubnetV4 => {
+        Version::SubnetV3 => {
             let effective_subnet_id = SubnetId::from(id);
             if effective_subnet_id != subnet_id {
                 let status = StatusCode::BAD_REQUEST;
@@ -304,7 +304,7 @@ pub(crate) async fn query(
         Version::V3 => nns_delegation_reader.get_delegation_with_metadata(
             CanisterRangesFilter::Tree(CanisterId::unchecked_from_principal(id)),
         ),
-        Version::SubnetV4 => {
+        Version::SubnetV3 => {
             nns_delegation_reader.get_delegation_with_metadata(CanisterRangesFilter::None)
         }
     };

--- a/rs/http_endpoints/public/src/query.rs
+++ b/rs/http_endpoints/public/src/query.rs
@@ -69,8 +69,8 @@ pub struct QueryService {
     registry_client: Arc<dyn RegistryClient>,
     additional_root_of_trust: Option<IcRootOfTrust>,
     query_execution_service: Arc<Mutex<QueryExecutionService>>,
-    version: Version,
     subnet_id: SubnetId,
+    version: Version,
 }
 
 pub struct QueryServiceBuilder {
@@ -169,8 +169,8 @@ impl QueryServiceBuilder {
             registry_client: self.registry_client,
             additional_root_of_trust: self.additional_root_of_trust,
             query_execution_service: Arc::new(Mutex::new(self.query_execution_service)),
-            version: self.version,
             subnet_id: self.subnet_id,
+            version: self.version,
         };
         Router::new().route_service(
             QueryService::route(self.version),
@@ -199,8 +199,8 @@ pub(crate) async fn query(
         nns_delegation_reader,
         additional_root_of_trust,
         query_execution_service,
-        version,
         subnet_id,
+        version,
     }): State<QueryService>,
     WithTimeout(Cbor(request)): WithTimeout<Cbor<HttpRequestEnvelope<HttpQueryContent>>>,
 ) -> impl IntoResponse {

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -117,31 +117,21 @@ impl UpdateEndpoint {
     }
 }
 
-/// Unified endpoint type used to parameterise tests that cover both the canister and subnet
-/// query paths.
-#[derive(Copy, Clone, Debug)]
-pub enum QueryEndpoint {
-    Canister(query::Version),
-    Subnet,
-}
-
-impl QueryEndpoint {
-    pub async fn query(self, addr: SocketAddr) -> reqwest::Response {
-        match self {
-            QueryEndpoint::Canister(version) => {
-                ic_http_endpoints_test_agent::Query::new(
-                    PrincipalId::default(),
-                    PrincipalId::default(),
-                    version,
-                )
+pub async fn query_endpoint(version: query::Version, addr: SocketAddr) -> reqwest::Response {
+    match version {
+        query::Version::V2 | query::Version::V3 => {
+            ic_http_endpoints_test_agent::Query::new(
+                PrincipalId::default(),
+                PrincipalId::default(),
+                version,
+            )
+            .query(addr)
+            .await
+        }
+        query::Version::SubnetV3 => {
+            ic_http_endpoints_test_agent::Query::new_subnet(subnet_test_id(1).get())
                 .query(addr)
                 .await
-            }
-            QueryEndpoint::Subnet => {
-                ic_http_endpoints_test_agent::Query::new_subnet(subnet_test_id(1).get())
-                    .query(addr)
-                    .await
-            }
         }
     }
 }

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -13,7 +13,7 @@ use ic_crypto_test_utils_crypto_returning_ok::CryptoReturningOk;
 use ic_crypto_tls_interfaces::TlsConfig;
 use ic_crypto_tls_interfaces_mocks::MockTlsConfig;
 use ic_crypto_tree_hash::{Digest, LabeledTree, MatchPatternPath, MixedHashTree, Witness};
-use ic_http_endpoints_public::start_server;
+use ic_http_endpoints_public::{query, start_server};
 use ic_interfaces::{
     consensus_pool::ConsensusPoolCache,
     execution_environment::{
@@ -48,7 +48,7 @@ use ic_replicated_state::{
 };
 use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
 use ic_types::{
-    CanisterId, CryptoHashOfPartialState, Height, RegistryVersion,
+    CanisterId, CryptoHashOfPartialState, Height, PrincipalId, RegistryVersion,
     artifact::UnvalidatedArtifactMutation,
     batch::RawQueryStats,
     consensus::certification::{Certification, CertificationContent},
@@ -113,6 +113,35 @@ impl UpdateEndpoint {
             UpdateEndpoint::Subnet(_) => ic_http_endpoints_test_agent::IngressMessage::default()
                 .with_canister_id(CanisterId::ic_00().get(), CanisterId::ic_00().get())
                 .with_method_name("create_canister".to_string()),
+        }
+    }
+}
+
+/// Unified endpoint type used to parameterise tests that cover both the canister and subnet
+/// query paths.
+#[derive(Copy, Clone, Debug)]
+pub enum QueryEndpoint {
+    Canister(query::Version),
+    Subnet,
+}
+
+impl QueryEndpoint {
+    pub async fn query(self, addr: SocketAddr) -> reqwest::Response {
+        match self {
+            QueryEndpoint::Canister(version) => {
+                ic_http_endpoints_test_agent::Query::new(
+                    PrincipalId::default(),
+                    PrincipalId::default(),
+                    version,
+                )
+                .query(addr)
+                .await
+            }
+            QueryEndpoint::Subnet => {
+                ic_http_endpoints_test_agent::QuerySubnet::new(subnet_test_id(1).get())
+                    .query(addr)
+                    .await
+            }
         }
     }
 }

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -138,7 +138,7 @@ impl QueryEndpoint {
                 .await
             }
             QueryEndpoint::Subnet => {
-                ic_http_endpoints_test_agent::QuerySubnet::new(subnet_test_id(1).get())
+                ic_http_endpoints_test_agent::Query::new_subnet(subnet_test_id(1).get())
                     .query(addr)
                     .await
             }

--- a/rs/http_endpoints/public/tests/load_shed_test.rs
+++ b/rs/http_endpoints/public/tests/load_shed_test.rs
@@ -1,9 +1,9 @@
 pub mod common;
 
 use crate::common::{
-    HttpEndpointBuilder, MockIngressPoolThrottler, QueryEndpoint, UpdateEndpoint,
-    default_certified_state_reader, default_get_latest_state, default_read_certified_state,
-    get_free_localhost_socket_addr,
+    HttpEndpointBuilder, MockIngressPoolThrottler, UpdateEndpoint, default_certified_state_reader,
+    default_get_latest_state, default_read_certified_state, get_free_localhost_socket_addr,
+    query_endpoint,
 };
 use async_trait::async_trait;
 use axum::body::Body;
@@ -11,7 +11,7 @@ use hyper::{Method, Request, StatusCode};
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use ic_config::http_handler::Config;
 use ic_crypto_tree_hash::{Label, Path};
-use ic_http_endpoints_public::read_state;
+use ic_http_endpoints_public::{query, read_state};
 use ic_http_endpoints_test_agent::{
     self, Call, CallSubnet, CanisterReadState, IngressMessage, wait_for_status_healthy,
 };
@@ -35,12 +35,8 @@ use tokio::{runtime::Runtime, sync::Notify};
 /// we return 429.
 #[rstest]
 fn test_load_shedding_query(
-    #[values(
-        QueryEndpoint::Canister(ic_http_endpoints_public::query::Version::V2),
-        QueryEndpoint::Canister(ic_http_endpoints_public::query::Version::V3),
-        QueryEndpoint::Subnet
-    )]
-    endpoint: QueryEndpoint,
+    #[values(query::Version::V2, query::Version::V3, query::Version::SubnetV3)]
+    version: query::Version,
 ) {
     let rt = Runtime::new().unwrap();
     let addr = get_free_localhost_socket_addr();
@@ -63,7 +59,7 @@ fn test_load_shedding_query(
     let load_shedded_request = rt.spawn(async move {
         query_exec_running_clone.notified().await;
 
-        let response = endpoint.query(addr).await;
+        let response = query_endpoint(version, addr).await;
 
         load_shedder_returned_clone.notify_one();
 
@@ -85,7 +81,7 @@ fn test_load_shedding_query(
     rt.block_on(async {
         wait_for_status_healthy(&addr).await.unwrap();
 
-        let response = endpoint.query(addr).await;
+        let response = query_endpoint(version, addr).await;
 
         assert_eq!(
             StatusCode::OK,

--- a/rs/http_endpoints/public/tests/load_shed_test.rs
+++ b/rs/http_endpoints/public/tests/load_shed_test.rs
@@ -1,8 +1,9 @@
 pub mod common;
 
 use crate::common::{
-    HttpEndpointBuilder, MockIngressPoolThrottler, UpdateEndpoint, default_certified_state_reader,
-    default_get_latest_state, default_read_certified_state, get_free_localhost_socket_addr,
+    HttpEndpointBuilder, MockIngressPoolThrottler, QueryEndpoint, UpdateEndpoint,
+    default_certified_state_reader, default_get_latest_state, default_read_certified_state,
+    get_free_localhost_socket_addr,
 };
 use async_trait::async_trait;
 use axum::body::Body;
@@ -10,10 +11,9 @@ use hyper::{Method, Request, StatusCode};
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use ic_config::http_handler::Config;
 use ic_crypto_tree_hash::{Label, Path};
-use ic_http_endpoints_public::query;
 use ic_http_endpoints_public::read_state;
 use ic_http_endpoints_test_agent::{
-    self, Call, CallSubnet, CanisterReadState, IngressMessage, Query, wait_for_status_healthy,
+    self, Call, CallSubnet, CanisterReadState, IngressMessage, wait_for_status_healthy,
 };
 use ic_test_utilities_types::ids::subnet_test_id;
 
@@ -35,7 +35,12 @@ use tokio::{runtime::Runtime, sync::Notify};
 /// we return 429.
 #[rstest]
 fn test_load_shedding_query(
-    #[values(query::Version::V2, query::Version::V3)] version: query::Version,
+    #[values(
+        QueryEndpoint::Canister(ic_http_endpoints_public::query::Version::V2),
+        QueryEndpoint::Canister(ic_http_endpoints_public::query::Version::V3),
+        QueryEndpoint::Subnet
+    )]
+    endpoint: QueryEndpoint,
 ) {
     let rt = Runtime::new().unwrap();
     let addr = get_free_localhost_socket_addr();
@@ -58,9 +63,7 @@ fn test_load_shedding_query(
     let load_shedded_request = rt.spawn(async move {
         query_exec_running_clone.notified().await;
 
-        let response = Query::new(PrincipalId::default(), PrincipalId::default(), version)
-            .query(addr)
-            .await;
+        let response = endpoint.query(addr).await;
 
         load_shedder_returned_clone.notify_one();
 
@@ -82,9 +85,7 @@ fn test_load_shedding_query(
     rt.block_on(async {
         wait_for_status_healthy(&addr).await.unwrap();
 
-        let response = Query::new(PrincipalId::default(), PrincipalId::default(), version)
-            .query(addr)
-            .await;
+        let response = endpoint.query(addr).await;
 
         assert_eq!(
             StatusCode::OK,

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -1944,11 +1944,10 @@ fn test_call_v4_subnet_correct_subnet_id() {
     });
 }
 
-/// Tests that /api/v4/subnet/../call rejects calls to non-management canisters (even with
-/// Tests that /api/v4/subnet/../query rejects a request whose URL subnet ID does not match
+/// Tests that /api/v3/subnet/../query rejects a request whose URL subnet ID does not match
 /// the node's own subnet ID.
 #[test]
-fn test_query_v4_subnet_wrong_subnet_id() {
+fn test_query_v3_subnet_wrong_subnet_id() {
     let rt = Runtime::new().unwrap();
     let addr = get_free_localhost_socket_addr();
     let config = Config {
@@ -1976,10 +1975,10 @@ fn test_query_v4_subnet_wrong_subnet_id() {
     });
 }
 
-/// Tests that /api/v4/subnet/../query accepts a valid list_canisters query to the management
+/// Tests that /api/v3/subnet/../query accepts a valid list_canisters query to the management
 /// canister when the URL subnet ID matches the node's own subnet ID.
 #[test]
-fn test_query_v4_subnet_correct_subnet_id() {
+fn test_query_v3_subnet_correct_subnet_id() {
     let rt = Runtime::new().unwrap();
     let addr = get_free_localhost_socket_addr();
     let config = Config {
@@ -2010,12 +2009,12 @@ fn test_query_v4_subnet_correct_subnet_id() {
     });
 }
 
-/// Tests that /api/v4/subnet/../query rejects calls to non-management canisters (even with
+/// Tests that /api/v3/subnet/../query rejects calls to non-management canisters (even with
 /// method "list_canisters") and calls to IC_00 methods other than "list_canisters".
 #[rstest]
 #[case::wrong_canister_id(canister_test_id(1).get(), "list_canisters")]
 #[case::wrong_method_name(CanisterId::ic_00().get(), "install_code")]
-fn test_query_v4_subnet_wrong_canister_or_method(
+fn test_query_v3_subnet_wrong_canister_or_method(
     #[case] canister_id: PrincipalId,
     #[case] method_name: &str,
 ) {

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -30,7 +30,7 @@ use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_http_endpoints_public::{query, read_state};
 use ic_http_endpoints_test_agent::{
     self, APPLICATION_CBOR, Call, CallSubnet, CanisterReadState, IngressMessage, Query,
-    QuerySubnet, wait_for_status_healthy,
+    wait_for_status_healthy,
 };
 use ic_interfaces::execution_environment::QueryExecutionError;
 use ic_interfaces_mocks::consensus_pool::MockConsensusPoolCache;
@@ -1963,7 +1963,7 @@ fn test_query_v3_subnet_wrong_subnet_id() {
 
     rt.block_on(async {
         wait_for_status_healthy(&addr).await.unwrap();
-        let response = QuerySubnet::new(wrong_subnet_id).query(addr).await;
+        let response = Query::new_subnet(wrong_subnet_id).query(addr).await;
 
         assert_eq!(StatusCode::BAD_REQUEST, response.status());
         assert_eq!(
@@ -1998,7 +1998,7 @@ fn test_query_v3_subnet_correct_subnet_id() {
 
     rt.block_on(async {
         wait_for_status_healthy(&addr).await.unwrap();
-        let response = QuerySubnet::new(subnet_id).query(addr).await;
+        let response = Query::new_subnet(subnet_id).query(addr).await;
 
         assert_eq!(
             StatusCode::OK,
@@ -2031,7 +2031,7 @@ fn test_query_v3_subnet_wrong_canister_or_method(
 
     rt.block_on(async {
         wait_for_status_healthy(&addr).await.unwrap();
-        let response = QuerySubnet::new(subnet_id)
+        let response = Query::new_subnet(subnet_id)
             .with_canister_id(canister_id)
             .with_method_name(method_name.to_string())
             .query(addr)

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -4,9 +4,9 @@
 pub mod common;
 
 use crate::common::{
-    HttpEndpointBuilder, QueryEndpoint, UpdateEndpoint, basic_state_manager_mock,
-    create_conn_and_send_request, default_get_latest_state, default_read_certified_state,
-    get_free_localhost_socket_addr,
+    HttpEndpointBuilder, UpdateEndpoint, basic_state_manager_mock, create_conn_and_send_request,
+    default_get_latest_state, default_read_certified_state, get_free_localhost_socket_addr,
+    query_endpoint,
 };
 use axum::body::{Body, to_bytes};
 use bytes::Bytes;
@@ -417,12 +417,8 @@ async fn test_connection_read_timeout() {
 /// If the downstream service is stuck return 504.
 #[rstest]
 fn test_request_timeout(
-    #[values(
-        QueryEndpoint::Canister(query::Version::V2),
-        QueryEndpoint::Canister(query::Version::V3),
-        QueryEndpoint::Subnet
-    )]
-    endpoint: QueryEndpoint,
+    #[values(query::Version::V2, query::Version::V3, query::Version::SubnetV3)]
+    version: query::Version,
 ) {
     let rt = Runtime::new().unwrap();
     let addr = get_free_localhost_socket_addr();
@@ -448,7 +444,7 @@ fn test_request_timeout(
 
     rt.block_on(async {
         wait_for_status_healthy(&addr).await.unwrap();
-        let response = endpoint.query(addr).await;
+        let response = query_endpoint(version, addr).await;
         assert_eq!(StatusCode::GATEWAY_TIMEOUT, response.status());
     });
 }
@@ -714,12 +710,8 @@ fn test_too_long_paths_are_rejected(
 /// returns [QueryExecutionError::CertifiedStateUnavailable`].
 #[rstest]
 fn test_query_endpoint_returns_service_unavailable_on_missing_state(
-    #[values(
-        QueryEndpoint::Canister(query::Version::V2),
-        QueryEndpoint::Canister(query::Version::V3),
-        QueryEndpoint::Subnet
-    )]
-    endpoint: QueryEndpoint,
+    #[values(query::Version::V2, query::Version::V3, query::Version::SubnetV3)]
+    version: query::Version,
 ) {
     let rt = Runtime::new().unwrap();
     let addr = get_free_localhost_socket_addr();
@@ -741,7 +733,7 @@ fn test_query_endpoint_returns_service_unavailable_on_missing_state(
     rt.block_on(async {
         wait_for_status_healthy(&addr).await.unwrap();
 
-        let response = endpoint.query(addr).await;
+        let response = query_endpoint(version, addr).await;
         let expected_status_code = StatusCode::SERVICE_UNAVAILABLE;
 
         assert_eq!(expected_status_code, response.status());

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -4,8 +4,9 @@
 pub mod common;
 
 use crate::common::{
-    HttpEndpointBuilder, UpdateEndpoint, basic_state_manager_mock, create_conn_and_send_request,
-    default_get_latest_state, default_read_certified_state, get_free_localhost_socket_addr,
+    HttpEndpointBuilder, QueryEndpoint, UpdateEndpoint, basic_state_manager_mock,
+    create_conn_and_send_request, default_get_latest_state, default_read_certified_state,
+    get_free_localhost_socket_addr,
 };
 use axum::body::{Body, to_bytes};
 use bytes::Bytes;
@@ -29,7 +30,7 @@ use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_http_endpoints_public::{query, read_state};
 use ic_http_endpoints_test_agent::{
     self, APPLICATION_CBOR, Call, CallSubnet, CanisterReadState, IngressMessage, Query,
-    wait_for_status_healthy,
+    QuerySubnet, wait_for_status_healthy,
 };
 use ic_interfaces::execution_environment::QueryExecutionError;
 use ic_interfaces_mocks::consensus_pool::MockConsensusPoolCache;
@@ -415,7 +416,14 @@ async fn test_connection_read_timeout() {
 
 /// If the downstream service is stuck return 504.
 #[rstest]
-fn test_request_timeout(#[values(query::Version::V2, query::Version::V3)] version: query::Version) {
+fn test_request_timeout(
+    #[values(
+        QueryEndpoint::Canister(query::Version::V2),
+        QueryEndpoint::Canister(query::Version::V3),
+        QueryEndpoint::Subnet
+    )]
+    endpoint: QueryEndpoint,
+) {
     let rt = Runtime::new().unwrap();
     let addr = get_free_localhost_socket_addr();
     let request_timeout_seconds = 2;
@@ -440,9 +448,7 @@ fn test_request_timeout(#[values(query::Version::V2, query::Version::V3)] versio
 
     rt.block_on(async {
         wait_for_status_healthy(&addr).await.unwrap();
-        let response = Query::new(PrincipalId::default(), PrincipalId::default(), version)
-            .query(addr)
-            .await;
+        let response = endpoint.query(addr).await;
         assert_eq!(StatusCode::GATEWAY_TIMEOUT, response.status());
     });
 }
@@ -708,7 +714,12 @@ fn test_too_long_paths_are_rejected(
 /// returns [QueryExecutionError::CertifiedStateUnavailable`].
 #[rstest]
 fn test_query_endpoint_returns_service_unavailable_on_missing_state(
-    #[values(query::Version::V2, query::Version::V3)] version: query::Version,
+    #[values(
+        QueryEndpoint::Canister(query::Version::V2),
+        QueryEndpoint::Canister(query::Version::V3),
+        QueryEndpoint::Subnet
+    )]
+    endpoint: QueryEndpoint,
 ) {
     let rt = Runtime::new().unwrap();
     let addr = get_free_localhost_socket_addr();
@@ -730,9 +741,7 @@ fn test_query_endpoint_returns_service_unavailable_on_missing_state(
     rt.block_on(async {
         wait_for_status_healthy(&addr).await.unwrap();
 
-        let response = Query::new(PrincipalId::default(), PrincipalId::default(), version)
-            .query(addr)
-            .await;
+        let response = endpoint.query(addr).await;
         let expected_status_code = StatusCode::SERVICE_UNAVAILABLE;
 
         assert_eq!(expected_status_code, response.status());
@@ -1936,6 +1945,113 @@ fn test_call_v4_subnet_correct_subnet_id() {
 }
 
 /// Tests that /api/v4/subnet/../call rejects calls to non-management canisters (even with
+/// Tests that /api/v4/subnet/../query rejects a request whose URL subnet ID does not match
+/// the node's own subnet ID.
+#[test]
+fn test_query_v4_subnet_wrong_subnet_id() {
+    let rt = Runtime::new().unwrap();
+    let addr = get_free_localhost_socket_addr();
+    let config = Config {
+        listen_addr: addr,
+        ..Default::default()
+    };
+
+    // HttpEndpointBuilder configures the node with subnet_test_id(1).
+    let node_subnet_id = subnet_test_id(1).get();
+    let wrong_subnet_id = subnet_test_id(2).get();
+
+    let _handlers = HttpEndpointBuilder::new(rt.handle().clone(), config).run();
+
+    rt.block_on(async {
+        wait_for_status_healthy(&addr).await.unwrap();
+        let response = QuerySubnet::new(wrong_subnet_id).query(addr).await;
+
+        assert_eq!(StatusCode::BAD_REQUEST, response.status());
+        assert_eq!(
+            format!(
+                "Specified SubnetId {wrong_subnet_id} does not match the subnet id of this node {node_subnet_id}"
+            ),
+            response.text().await.unwrap()
+        );
+    });
+}
+
+/// Tests that /api/v4/subnet/../query accepts a valid list_canisters query to the management
+/// canister when the URL subnet ID matches the node's own subnet ID.
+#[test]
+fn test_query_v4_subnet_correct_subnet_id() {
+    let rt = Runtime::new().unwrap();
+    let addr = get_free_localhost_socket_addr();
+    let config = Config {
+        listen_addr: addr,
+        ..Default::default()
+    };
+
+    let subnet_id = subnet_test_id(1).get();
+
+    let mut handlers = HttpEndpointBuilder::new(rt.handle().clone(), config).run();
+    rt.spawn(async move {
+        loop {
+            let (_, resp) = handlers.query_execution.next_request().await.unwrap();
+            resp.send_response(Ok((Ok(WasmResult::Reply(vec![])), current_time())))
+        }
+    });
+
+    rt.block_on(async {
+        wait_for_status_healthy(&addr).await.unwrap();
+        let response = QuerySubnet::new(subnet_id).query(addr).await;
+
+        assert_eq!(
+            StatusCode::OK,
+            response.status(),
+            "{:?}",
+            response.text().await
+        );
+    });
+}
+
+/// Tests that /api/v4/subnet/../query rejects calls to non-management canisters (even with
+/// method "list_canisters") and calls to IC_00 methods other than "list_canisters".
+#[rstest]
+#[case::wrong_canister_id(canister_test_id(1).get(), "list_canisters")]
+#[case::wrong_method_name(CanisterId::ic_00().get(), "install_code")]
+fn test_query_v4_subnet_wrong_canister_or_method(
+    #[case] canister_id: PrincipalId,
+    #[case] method_name: &str,
+) {
+    let rt = Runtime::new().unwrap();
+    let addr = get_free_localhost_socket_addr();
+    let config = Config {
+        listen_addr: addr,
+        ..Default::default()
+    };
+
+    let subnet_id = subnet_test_id(1).get();
+
+    let _handlers = HttpEndpointBuilder::new(rt.handle().clone(), config).run();
+
+    rt.block_on(async {
+        wait_for_status_healthy(&addr).await.unwrap();
+        let response = QuerySubnet::new(subnet_id)
+            .with_canister_id(canister_id)
+            .with_method_name(method_name.to_string())
+            .query(addr)
+            .await;
+
+        assert_eq!(StatusCode::BAD_REQUEST, response.status());
+        let body = response.text().await.unwrap();
+        assert_eq!(
+            body,
+            format!(
+                "Subnet query endpoint only accepts queries to the management canister ({}) 'list_canisters' method, got canister_id={} method_name='{}'",
+                CanisterId::ic_00(),
+                CanisterId::unchecked_from_principal(canister_id),
+                method_name,
+            )
+        );
+    });
+}
+
 /// method "create_canister") and calls to IC_00 methods other than "create_canister".
 #[rstest]
 #[case::wrong_canister_id(canister_test_id(1).get(), "create_canister")]

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -2051,6 +2051,7 @@ fn test_query_v3_subnet_wrong_canister_or_method(
     });
 }
 
+/// Tests that /api/v4/subnet/../call rejects calls to non-management canisters (even with
 /// method "create_canister") and calls to IC_00 methods other than "create_canister".
 #[rstest]
 #[case::wrong_canister_id(canister_test_id(1).get(), "create_canister")]

--- a/rs/http_endpoints/public/tests/test.rs
+++ b/rs/http_endpoints/public/tests/test.rs
@@ -275,7 +275,7 @@ fn test_unauthorized_query(
 
         assert_eq!(
             format!(
-                "Specified CanisterId {canister1} does not match effective canister id in URL {canister2}"
+                "Specified canister ID {canister1} does not match effective canister ID in URL {canister2}"
             ),
             response.text().await.unwrap()
         )
@@ -383,7 +383,7 @@ fn test_unauthorized_call(#[values(Call::V2, Call::V3, Call::V4)] endpoint: Call
 
         assert_eq!(
             format!(
-                "Specified CanisterId {canister1} does not match effective canister id in URL {canister2}"
+                "Specified canister ID {canister1} does not match effective canister ID in URL {canister2}"
             ),
             invalid_update_call.text().await.unwrap()
         );
@@ -1884,7 +1884,7 @@ fn test_call_v4_subnet_wrong_subnet_id() {
         assert_eq!(StatusCode::BAD_REQUEST, response.status());
         assert_eq!(
             format!(
-                "Specified SubnetId {wrong_subnet_id} does not match the subnet id of this node {node_subnet_id}"
+                "Specified subnet ID {wrong_subnet_id} does not match the subnet ID of this node {node_subnet_id}"
             ),
             response.text().await.unwrap()
         );
@@ -1960,7 +1960,7 @@ fn test_query_v3_subnet_wrong_subnet_id() {
         assert_eq!(StatusCode::BAD_REQUEST, response.status());
         assert_eq!(
             format!(
-                "Specified SubnetId {wrong_subnet_id} does not match the subnet id of this node {node_subnet_id}"
+                "Specified subnet ID {wrong_subnet_id} does not match the subnet ID of this node {node_subnet_id}"
             ),
             response.text().await.unwrap()
         );

--- a/rs/http_endpoints/test_agent/src/lib.rs
+++ b/rs/http_endpoints/test_agent/src/lib.rs
@@ -200,18 +200,36 @@ impl CallSubnet {
     }
 }
 
-pub struct QuerySubnet {
-    subnet_id: PrincipalId,
+pub struct Query {
     canister_id: PrincipalId,
+    effective_canister_id: PrincipalId,
     method_name: String,
+    version: query::Version,
+    subnet_id: Option<PrincipalId>,
 }
 
-impl QuerySubnet {
-    pub fn new(subnet_id: PrincipalId) -> Self {
+impl Query {
+    pub fn new(
+        canister_id: PrincipalId,
+        effective_canister_id: PrincipalId,
+        version: query::Version,
+    ) -> Self {
         Self {
-            subnet_id,
+            canister_id,
+            effective_canister_id,
+            method_name: METHOD_NAME.to_string(),
+            version,
+            subnet_id: None,
+        }
+    }
+
+    pub fn new_subnet(subnet_id: PrincipalId) -> Self {
+        Self {
             canister_id: CanisterId::ic_00().get(),
+            effective_canister_id: PrincipalId::default(),
             method_name: "list_canisters".to_string(),
+            version: query::Version::SubnetV3,
+            subnet_id: Some(subnet_id),
         }
     }
 
@@ -248,71 +266,20 @@ impl QuerySubnet {
         };
 
         let body = serde_cbor::to_vec(&envelope).unwrap();
-        let url = format!("http://{}/api/v3/subnet/{}/query", addr, self.subnet_id);
-
-        reqwest::Client::new()
-            .post(url)
-            .body(body)
-            .header(CONTENT_TYPE, APPLICATION_CBOR)
-            .send()
-            .await
-            .unwrap()
-    }
-}
-
-pub struct Query {
-    canister_id: PrincipalId,
-    effective_canister_id: PrincipalId,
-    version: query::Version,
-}
-
-impl Query {
-    pub fn new(
-        canister_id: PrincipalId,
-        effective_canister_id: PrincipalId,
-        version: query::Version,
-    ) -> Self {
-        Self {
-            canister_id,
-            effective_canister_id,
-            version,
-        }
-    }
-
-    pub async fn query(self, addr: SocketAddr) -> reqwest::Response {
-        let ingress_expiry = (current_time() + INGRESS_EXPIRY_DURATION).as_nanos_since_unix_epoch();
-
-        let call_content = HttpQueryContent::Query {
-            query: HttpUserQuery {
-                canister_id: Blob(self.canister_id.into_vec()),
-                method_name: METHOD_NAME.to_string(),
-                arg: Blob(ARG),
-                sender: Blob(SENDER.into_vec()),
-                ingress_expiry,
-                nonce: None,
-                sender_info: None,
-            },
+        let url = match self.version {
+            query::Version::V2 => format!(
+                "http://{addr}/api/v2/canister/{}/query",
+                self.effective_canister_id
+            ),
+            query::Version::V3 => format!(
+                "http://{addr}/api/v3/canister/{}/query",
+                self.effective_canister_id
+            ),
+            query::Version::SubnetV3 => format!(
+                "http://{addr}/api/v3/subnet/{}/query",
+                self.subnet_id.expect("subnet_id required for SubnetV3")
+            ),
         };
-
-        let envelope = HttpRequestEnvelope {
-            content: call_content,
-            sender_pubkey: None,
-            sender_sig: None,
-            sender_delegation: None,
-        };
-
-        let body = serde_cbor::to_vec(&envelope).unwrap();
-        let version_str = match self.version {
-            query::Version::V2 => "v2",
-            query::Version::V3 => "v3",
-            query::Version::SubnetV3 => {
-                unreachable!("Use QuerySubnet for the subnet query endpoint")
-            }
-        };
-        let url = format!(
-            "http://{addr}/api/{version_str}/canister/{}/query",
-            self.effective_canister_id
-        );
 
         reqwest::Client::new()
             .post(url)

--- a/rs/http_endpoints/test_agent/src/lib.rs
+++ b/rs/http_endpoints/test_agent/src/lib.rs
@@ -1,7 +1,7 @@
 use ic_crypto_tree_hash::Path;
 use ic_http_endpoints_public::{query, read_state};
 use ic_types::{
-    PrincipalId, UserId,
+    CanisterId, PrincipalId, UserId,
     ingress::{IngressState, IngressStatus, WasmResult},
     messages::{
         Blob, HttpCallContent, HttpCanisterUpdate, HttpQueryContent, HttpReadState,
@@ -200,6 +200,66 @@ impl CallSubnet {
     }
 }
 
+pub struct QuerySubnet {
+    subnet_id: PrincipalId,
+    canister_id: PrincipalId,
+    method_name: String,
+}
+
+impl QuerySubnet {
+    pub fn new(subnet_id: PrincipalId) -> Self {
+        Self {
+            subnet_id,
+            canister_id: CanisterId::ic_00().get(),
+            method_name: "list_canisters".to_string(),
+        }
+    }
+
+    pub fn with_canister_id(mut self, canister_id: PrincipalId) -> Self {
+        self.canister_id = canister_id;
+        self
+    }
+
+    pub fn with_method_name(mut self, method_name: String) -> Self {
+        self.method_name = method_name;
+        self
+    }
+
+    pub async fn query(self, addr: SocketAddr) -> reqwest::Response {
+        let ingress_expiry = (current_time() + INGRESS_EXPIRY_DURATION).as_nanos_since_unix_epoch();
+
+        let call_content = HttpQueryContent::Query {
+            query: HttpUserQuery {
+                canister_id: Blob(self.canister_id.into_vec()),
+                method_name: self.method_name,
+                arg: Blob(ARG),
+                sender: Blob(SENDER.into_vec()),
+                ingress_expiry,
+                nonce: None,
+                sender_info: None,
+            },
+        };
+
+        let envelope = HttpRequestEnvelope {
+            content: call_content,
+            sender_pubkey: None,
+            sender_sig: None,
+            sender_delegation: None,
+        };
+
+        let body = serde_cbor::to_vec(&envelope).unwrap();
+        let url = format!("http://{}/api/v4/subnet/{}/query", addr, self.subnet_id);
+
+        reqwest::Client::new()
+            .post(url)
+            .body(body)
+            .header(CONTENT_TYPE, APPLICATION_CBOR)
+            .send()
+            .await
+            .unwrap()
+    }
+}
+
 pub struct Query {
     canister_id: PrincipalId,
     effective_canister_id: PrincipalId,
@@ -245,6 +305,9 @@ impl Query {
         let version_str = match self.version {
             query::Version::V2 => "v2",
             query::Version::V3 => "v3",
+            query::Version::SubnetV4 => {
+                unreachable!("Use QuerySubnet for the subnet query endpoint")
+            }
         };
         let url = format!(
             "http://{addr}/api/{version_str}/canister/{}/query",

--- a/rs/http_endpoints/test_agent/src/lib.rs
+++ b/rs/http_endpoints/test_agent/src/lib.rs
@@ -248,7 +248,7 @@ impl QuerySubnet {
         };
 
         let body = serde_cbor::to_vec(&envelope).unwrap();
-        let url = format!("http://{}/api/v4/subnet/{}/query", addr, self.subnet_id);
+        let url = format!("http://{}/api/v3/subnet/{}/query", addr, self.subnet_id);
 
         reqwest::Client::new()
             .post(url)
@@ -305,7 +305,7 @@ impl Query {
         let version_str = match self.version {
             query::Version::V2 => "v2",
             query::Version::V3 => "v3",
-            query::Version::SubnetV4 => {
+            query::Version::SubnetV3 => {
                 unreachable!("Use QuerySubnet for the subnet query endpoint")
             }
         };

--- a/rs/http_endpoints/test_agent/src/lib.rs
+++ b/rs/http_endpoints/test_agent/src/lib.rs
@@ -204,8 +204,8 @@ pub struct Query {
     canister_id: PrincipalId,
     effective_canister_id: PrincipalId,
     method_name: String,
-    version: query::Version,
     subnet_id: Option<PrincipalId>,
+    version: query::Version,
 }
 
 impl Query {
@@ -218,8 +218,8 @@ impl Query {
             canister_id,
             effective_canister_id,
             method_name: METHOD_NAME.to_string(),
-            version,
             subnet_id: None,
+            version,
         }
     }
 
@@ -228,8 +228,8 @@ impl Query {
             canister_id: CanisterId::ic_00().get(),
             effective_canister_id: PrincipalId::default(),
             method_name: "list_canisters".to_string(),
-            version: query::Version::SubnetV3,
             subnet_id: Some(subnet_id),
+            version: query::Version::SubnetV3,
         }
     }
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -4842,6 +4842,7 @@ impl Operation for QueryRequest {
                     Arc::new(StandaloneIngressSigVerifier),
                     NNSDelegationReader::new(delegation_rx, subnet.replica_logger.clone()),
                     query_handler,
+                    subnet_id,
                     self.version,
                 )
                 .with_malicious_flags(pic.malicious_flags.clone())
@@ -4852,6 +4853,9 @@ impl Operation for QueryRequest {
                 let version_str = match self.version {
                     query::Version::V2 => "v2",
                     query::Version::V3 => "v3",
+                    query::Version::SubnetV4 => {
+                        unreachable!("SubnetV4 query not supported in PocketIC")
+                    }
                 };
 
                 let request = axum::http::Request::builder()

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -4853,8 +4853,8 @@ impl Operation for QueryRequest {
                 let version_str = match self.version {
                     query::Version::V2 => "v2",
                     query::Version::V3 => "v3",
-                    query::Version::SubnetV4 => {
-                        unreachable!("SubnetV4 query not supported in PocketIC")
+                    query::Version::SubnetV3 => {
+                        unreachable!("SubnetV3 query not supported in PocketIC")
                     }
                 };
 

--- a/rs/tests/execution/system_subnets_test.rs
+++ b/rs/tests/execution/system_subnets_test.rs
@@ -106,7 +106,7 @@ pub fn ingress_message_to_subnet_id_fails(env: TestEnv) {
                 AgentError::HttpError(payload) => {
                     let error_message = String::from_utf8(payload.content).unwrap();
                     assert!(error_message.contains(&format!(
-                        "Specified CanisterId {subnet_id} does not match effective canister id in URL {canister_id}"
+                        "Specified canister ID {subnet_id} does not match effective canister ID in URL {canister_id}"
                     )));
                 }
                 _ => panic!("Unexpected error: {err:?}"),

--- a/rs/tests/networking/http_endpoints_public_spec_test.rs
+++ b/rs/tests/networking/http_endpoints_public_spec_test.rs
@@ -784,6 +784,42 @@ fn get_canister_test_ids(snapshot: &TopologySnapshot) -> (CanisterId, [CanisterI
     )
 }
 
+fn query_calls_subnet_v4(env: TestEnv) {
+    let logger = env.logger();
+    let snapshot = env.topology_snapshot();
+    let socket = get_socket_addr(&snapshot);
+    let (sys_subnet_id, app_subnet_id) = get_subnet_ids(&snapshot);
+
+    block_on(async {
+        // Correct subnet ID with ic_00 and list_canisters → accepted
+        let response = QuerySubnet::new(sys_subnet_id.get()).query(socket).await;
+        let status = inspect_response(response, "QuerySubnet", &logger).await;
+        assert_2xx(&status);
+
+        // Wrong subnet ID → rejected
+        let response = QuerySubnet::new(app_subnet_id.get()).query(socket).await;
+        let status = inspect_response(response, "QuerySubnet", &logger).await;
+        assert_4xx(&status);
+
+        // Non-management canister with "list_canisters" → rejected
+        let (non_mgmt_canister, _) = get_canister_test_ids(&snapshot);
+        let response = QuerySubnet::new(sys_subnet_id.get())
+            .with_canister_id(non_mgmt_canister.get())
+            .query(socket)
+            .await;
+        let status = inspect_response(response, "QuerySubnet", &logger).await;
+        assert_4xx(&status);
+
+        // IC_00 with wrong method → rejected
+        let response = QuerySubnet::new(sys_subnet_id.get())
+            .with_method_name("install_code".to_string())
+            .query(socket)
+            .await;
+        let status = inspect_response(response, "QuerySubnet", &logger).await;
+        assert_4xx(&status);
+    });
+}
+
 fn update_calls_subnet_v4(env: TestEnv) {
     let logger = env.logger();
     let snapshot = env.topology_snapshot();
@@ -859,6 +895,7 @@ fn main() -> Result<()> {
             SystemTestSubGroup::new()
                 .add_test(systest!(query_calls; query::Version::V2))
                 .add_test(systest!(query_calls; query::Version::V3))
+                .add_test(systest!(query_calls_subnet_v4))
                 .add_test(systest!(update_calls; Call::V2))
                 .add_test(systest!(update_calls; Call::V3))
                 .add_test(systest!(update_calls; Call::V4))

--- a/rs/tests/networking/http_endpoints_public_spec_test.rs
+++ b/rs/tests/networking/http_endpoints_public_spec_test.rs
@@ -792,18 +792,18 @@ fn query_calls_subnet_v4(env: TestEnv) {
 
     block_on(async {
         // Correct subnet ID with ic_00 and list_canisters → accepted
-        let response = QuerySubnet::new(sys_subnet_id.get()).query(socket).await;
+        let response = Query::new_subnet(sys_subnet_id.get()).query(socket).await;
         let status = inspect_response(response, "QuerySubnet", &logger).await;
         assert_2xx(&status);
 
         // Wrong subnet ID → rejected
-        let response = QuerySubnet::new(app_subnet_id.get()).query(socket).await;
+        let response = Query::new_subnet(app_subnet_id.get()).query(socket).await;
         let status = inspect_response(response, "QuerySubnet", &logger).await;
         assert_4xx(&status);
 
         // Non-management canister with "list_canisters" → rejected
         let (non_mgmt_canister, _) = get_canister_test_ids(&snapshot);
-        let response = QuerySubnet::new(sys_subnet_id.get())
+        let response = Query::new_subnet(sys_subnet_id.get())
             .with_canister_id(non_mgmt_canister.get())
             .query(socket)
             .await;
@@ -811,7 +811,7 @@ fn query_calls_subnet_v4(env: TestEnv) {
         assert_4xx(&status);
 
         // IC_00 with wrong method → rejected
-        let response = QuerySubnet::new(sys_subnet_id.get())
+        let response = Query::new_subnet(sys_subnet_id.get())
             .with_method_name("install_code".to_string())
             .query(socket)
             .await;

--- a/rs/tests/networking/http_endpoints_public_spec_test.rs
+++ b/rs/tests/networking/http_endpoints_public_spec_test.rs
@@ -895,7 +895,7 @@ fn main() -> Result<()> {
             SystemTestSubGroup::new()
                 .add_test(systest!(query_calls; query::Version::V2))
                 .add_test(systest!(query_calls; query::Version::V3))
-                .add_test(systest!(query_calls_subnet_v4))
+                .add_test(systest!(query_calls_subnet_v3))
                 .add_test(systest!(update_calls; Call::V2))
                 .add_test(systest!(update_calls; Call::V3))
                 .add_test(systest!(update_calls; Call::V4))

--- a/rs/tests/networking/http_endpoints_public_spec_test.rs
+++ b/rs/tests/networking/http_endpoints_public_spec_test.rs
@@ -784,7 +784,7 @@ fn get_canister_test_ids(snapshot: &TopologySnapshot) -> (CanisterId, [CanisterI
     )
 }
 
-fn query_calls_subnet_v4(env: TestEnv) {
+fn query_calls_subnet_v3(env: TestEnv) {
     let logger = env.logger();
     let snapshot = env.topology_snapshot();
     let socket = get_socket_addr(&snapshot);


### PR DESCRIPTION
This PR adds a new public HTTP endpoint `/api/v3/subnet/<effective_subnet_id>/query` on the replica that supports call to the `list_canisters` endpoint of the management canister (`aaaaa-aa`). It is specified in this [PR](https://github.com/dfinity/portal/pull/6224).

Note. PocketIC support will be added in a separate PR.