### PR TITLE
feat(ic-icrc1): add freeze/unfreeze Operation variants

### DIFF
--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -1119,6 +1119,12 @@ fn process_balance_changes(block_index: BlockIndex64, block: &Block<Tokens>) {
             Operation::AuthorizedBurn { from, amount, .. } => {
                 debit(block_index, from, amount);
             }
+            Operation::FreezeAccount { .. }
+            | Operation::UnfreezeAccount { .. }
+            | Operation::FreezePrincipal { .. }
+            | Operation::UnfreezePrincipal { .. } => {
+                // Freeze/unfreeze operations do not affect balances
+            }
         },
     );
 }
@@ -1164,6 +1170,10 @@ fn get_accounts(block: &Block<Tokens>) -> Vec<Account> {
         Operation::FeeCollector { .. } => vec![],
         Operation::AuthorizedMint { to, .. } => vec![to],
         Operation::AuthorizedBurn { from, .. } => vec![from],
+        Operation::FreezeAccount { account, .. } | Operation::UnfreezeAccount { account, .. } => {
+            vec![account]
+        }
+        Operation::FreezePrincipal { .. } | Operation::UnfreezePrincipal { .. } => vec![],
     }
 }
 

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u256.yml
@@ -2,7 +2,7 @@ benches:
   bench_icrc1_transfers:
     total:
       calls: 1
-      instructions: 54503709185
+      instructions: 54516392211
       heap_increase: 264
       stable_memory_increase: 256
     scopes:
@@ -13,17 +13,17 @@ benches:
         stable_memory_increase: 0
       icrc1_transfer:
         calls: 1
-        instructions: 12932131566
+        instructions: 12936411636
         heap_increase: 32
         stable_memory_increase: 0
       icrc2_approve:
         calls: 1
-        instructions: 19387929174
+        instructions: 19392009244
         heap_increase: 29
         stable_memory_increase: 128
       icrc2_transfer_from:
         calls: 1
-        instructions: 21482922683
+        instructions: 21487202753
         heap_increase: 3
         stable_memory_increase: 0
       icrc3_get_blocks:
@@ -38,18 +38,18 @@ benches:
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 148924963
+        instructions: 148924979
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
         calls: 1
-        instructions: 491281484
+        instructions: 491281500
         heap_increase: 200
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
       calls: 1
-      instructions: 8690537
+      instructions: 8690553
       heap_increase: 258
       stable_memory_increase: 128
     scopes:
@@ -60,12 +60,12 @@ benches:
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 78458
+        instructions: 78474
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
         calls: 1
-        instructions: 8689629
+        instructions: 8689645
         heap_increase: 258
         stable_memory_increase: 128
 version: 0.4.1

--- a/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
+++ b/rs/ledger_suite/icrc1/ledger/canbench_results/canbench_u64.yml
@@ -2,7 +2,7 @@ benches:
   bench_icrc1_transfers:
     total:
       calls: 1
-      instructions: 52125398932
+      instructions: 52134023453
       heap_increase: 263
       stable_memory_increase: 256
     scopes:
@@ -13,17 +13,17 @@ benches:
         stable_memory_increase: 0
       icrc1_transfer:
         calls: 1
-        instructions: 12277234966
+        instructions: 12283171030
         heap_increase: 34
         stable_memory_increase: 0
       icrc2_approve:
         calls: 1
-        instructions: 18497580928
+        instructions: 18503661238
         heap_increase: 25
         stable_memory_increase: 128
       icrc2_transfer_from:
         calls: 1
-        instructions: 20649025716
+        instructions: 20654602846
         heap_increase: 3
         stable_memory_increase: 0
       icrc3_get_blocks:
@@ -33,39 +33,39 @@ benches:
         stable_memory_increase: 0
       post_upgrade:
         calls: 1
-        instructions: 351211421
+        instructions: 342206914
         heap_increase: 72
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 148925235
+        instructions: 148925244
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
         calls: 1
-        instructions: 500139397
+        instructions: 491134899
         heap_increase: 201
         stable_memory_increase: 128
   bench_upgrade_baseline:
     total:
       calls: 1
-      instructions: 8696311
+      instructions: 8691726
       heap_increase: 258
       stable_memory_increase: 128
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 8613896
+        instructions: 8609302
         heap_increase: 129
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 79491
+        instructions: 79500
         heap_increase: 129
         stable_memory_increase: 128
       upgrade:
         calls: 1
-        instructions: 8695403
+        instructions: 8690818
         heap_increase: 258
         stable_memory_increase: 128
 version: 0.4.1

--- a/rs/ledger_suite/icrc1/src/endpoints.rs
+++ b/rs/ledger_suite/icrc1/src/endpoints.rs
@@ -285,6 +285,12 @@ impl<Tokens: TokensType> From<Block<Tokens>> for Transaction {
                     reason,
                 });
             }
+            Operation::FreezeAccount { .. }
+            | Operation::UnfreezeAccount { .. }
+            | Operation::FreezePrincipal { .. }
+            | Operation::UnfreezePrincipal { .. } => {
+                panic!("freeze/unfreeze not yet supported in candid conversion")
+            }
         }
 
         tx

--- a/rs/ledger_suite/icrc1/src/lib.rs
+++ b/rs/ledger_suite/icrc1/src/lib.rs
@@ -17,6 +17,10 @@ use ic_ledger_core::{
 use ic_ledger_hash_of::HashOf;
 use icrc_ledger_types::icrc1::account::Account;
 use icrc_ledger_types::icrc122::schema::{BTYPE_122_BURN, BTYPE_122_MINT};
+use icrc_ledger_types::icrc123::schema::{
+    BTYPE_123_FREEZE_ACCOUNT, BTYPE_123_FREEZE_PRINCIPAL, BTYPE_123_UNFREEZE_ACCOUNT,
+    BTYPE_123_UNFREEZE_PRINCIPAL,
+};
 use icrc_ledger_types::{icrc1::transfer::Memo, icrc3::transactions::TRANSACTION_FEE_COLLECTOR};
 use serde::{Deserialize, Serialize};
 
@@ -65,6 +69,30 @@ pub enum Operation<Tokens: TokensType> {
     AuthorizedBurn {
         from: Account,
         amount: Tokens,
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+    },
+    FreezeAccount {
+        account: Account,
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+    },
+    UnfreezeAccount {
+        account: Account,
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+    },
+    FreezePrincipal {
+        principal: Principal,
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+    },
+    UnfreezePrincipal {
+        principal: Principal,
         caller: Option<Principal>,
         mthd: Option<String>,
         reason: Option<String>,
@@ -141,6 +169,15 @@ struct FlattenedTransaction<Tokens: TokensType> {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(with = "compact_account::opt")]
+    account: Option<Account>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    principal: Option<Principal>,
 }
 
 impl<Tokens: TokensType> TryFrom<FlattenedTransaction<Tokens>> for Transaction<Tokens> {
@@ -197,6 +234,38 @@ impl<Tokens: TokensType> TryFrom<(Option<String>, FlattenedTransaction<Tokens>)>
                 amount: value
                     .amount
                     .ok_or("`amount` required for `122burn` block")?,
+                caller: value.caller,
+                mthd: value.mthd,
+                reason: value.reason,
+            },
+            Some(BTYPE_123_FREEZE_ACCOUNT) => Operation::FreezeAccount {
+                account: value
+                    .account
+                    .ok_or("`account` field required for `123freezeaccount` block")?,
+                caller: value.caller,
+                mthd: value.mthd,
+                reason: value.reason,
+            },
+            Some(BTYPE_123_UNFREEZE_ACCOUNT) => Operation::UnfreezeAccount {
+                account: value
+                    .account
+                    .ok_or("`account` field required for `123unfreezeaccount` block")?,
+                caller: value.caller,
+                mthd: value.mthd,
+                reason: value.reason,
+            },
+            Some(BTYPE_123_FREEZE_PRINCIPAL) => Operation::FreezePrincipal {
+                principal: value
+                    .principal
+                    .ok_or("`principal` field required for `123freezeprincipal` block")?,
+                caller: value.caller,
+                mthd: value.mthd,
+                reason: value.reason,
+            },
+            Some(BTYPE_123_UNFREEZE_PRINCIPAL) => Operation::UnfreezePrincipal {
+                principal: value
+                    .principal
+                    .ok_or("`principal` field required for `123unfreezeprincipal` block")?,
                 caller: value.caller,
                 mthd: value.mthd,
                 reason: value.reason,
@@ -280,18 +349,37 @@ impl<Tokens: TokensType> From<Transaction<Tokens>> for FlattenedTransaction<Toke
                 Mint { .. } => Some("mint".to_string()),
                 Transfer { .. } => Some("xfer".to_string()),
                 Approve { .. } => Some("approve".to_string()),
-                FeeCollector { .. } | AuthorizedMint { .. } | AuthorizedBurn { .. } => None,
+                FeeCollector { .. }
+                | AuthorizedMint { .. }
+                | AuthorizedBurn { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
             },
             from: match &t.operation {
                 Transfer { from, .. }
                 | Burn { from, .. }
                 | Approve { from, .. }
                 | AuthorizedBurn { from, .. } => Some(*from),
-                Mint { .. } | FeeCollector { .. } | AuthorizedMint { .. } => None,
+                Mint { .. }
+                | FeeCollector { .. }
+                | AuthorizedMint { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
             },
             to: match &t.operation {
                 Mint { to, .. } | Transfer { to, .. } | AuthorizedMint { to, .. } => Some(*to),
-                Burn { .. } | Approve { .. } | FeeCollector { .. } | AuthorizedBurn { .. } => None,
+                Burn { .. }
+                | Approve { .. }
+                | FeeCollector { .. }
+                | AuthorizedBurn { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
             },
             spender: match &t.operation {
                 Transfer { spender, .. } | Burn { spender, .. } => spender.to_owned(),
@@ -299,7 +387,11 @@ impl<Tokens: TokensType> From<Transaction<Tokens>> for FlattenedTransaction<Toke
                 Mint { .. }
                 | FeeCollector { .. }
                 | AuthorizedMint { .. }
-                | AuthorizedBurn { .. } => None,
+                | AuthorizedBurn { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
             },
             amount: match &t.operation {
                 Burn { amount, .. }
@@ -308,14 +400,24 @@ impl<Tokens: TokensType> From<Transaction<Tokens>> for FlattenedTransaction<Toke
                 | Approve { amount, .. }
                 | AuthorizedMint { amount, .. }
                 | AuthorizedBurn { amount, .. } => Some(amount.clone()),
-                FeeCollector { .. } => None,
+                FeeCollector { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
             },
             fee: match &t.operation {
                 Transfer { fee, .. }
                 | Approve { fee, .. }
                 | Mint { fee, .. }
                 | Burn { fee, .. } => fee.to_owned(),
-                FeeCollector { .. } | AuthorizedMint { .. } | AuthorizedBurn { .. } => None,
+                FeeCollector { .. }
+                | AuthorizedMint { .. }
+                | AuthorizedBurn { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
             },
             expected_allowance: match &t.operation {
                 Approve {
@@ -326,7 +428,11 @@ impl<Tokens: TokensType> From<Transaction<Tokens>> for FlattenedTransaction<Toke
                 | Burn { .. }
                 | FeeCollector { .. }
                 | AuthorizedMint { .. }
-                | AuthorizedBurn { .. } => None,
+                | AuthorizedBurn { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
             },
             expires_at: match &t.operation {
                 Approve { expires_at, .. } => expires_at.to_owned(),
@@ -335,7 +441,11 @@ impl<Tokens: TokensType> From<Transaction<Tokens>> for FlattenedTransaction<Toke
                 | Burn { .. }
                 | FeeCollector { .. }
                 | AuthorizedMint { .. }
-                | AuthorizedBurn { .. } => None,
+                | AuthorizedBurn { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
             },
             fee_collector: match &t.operation {
                 FeeCollector { fee_collector, .. } => fee_collector.to_owned(),
@@ -344,27 +454,70 @@ impl<Tokens: TokensType> From<Transaction<Tokens>> for FlattenedTransaction<Toke
                 | Burn { .. }
                 | Approve { .. }
                 | AuthorizedMint { .. }
-                | AuthorizedBurn { .. } => None,
+                | AuthorizedBurn { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
             },
             caller: match &t.operation {
                 FeeCollector { caller, .. }
                 | AuthorizedMint { caller, .. }
-                | AuthorizedBurn { caller, .. } => caller.to_owned(),
+                | AuthorizedBurn { caller, .. }
+                | FreezeAccount { caller, .. }
+                | UnfreezeAccount { caller, .. }
+                | FreezePrincipal { caller, .. }
+                | UnfreezePrincipal { caller, .. } => caller.to_owned(),
                 Mint { .. } | Transfer { .. } | Burn { .. } | Approve { .. } => None,
             },
             mthd: match &t.operation {
                 FeeCollector { mthd, .. }
                 | AuthorizedMint { mthd, .. }
-                | AuthorizedBurn { mthd, .. } => mthd.to_owned(),
+                | AuthorizedBurn { mthd, .. }
+                | FreezeAccount { mthd, .. }
+                | UnfreezeAccount { mthd, .. }
+                | FreezePrincipal { mthd, .. }
+                | UnfreezePrincipal { mthd, .. } => mthd.to_owned(),
                 Mint { .. } | Transfer { .. } | Burn { .. } | Approve { .. } => None,
             },
             reason: match &t.operation {
-                AuthorizedMint { reason, .. } | AuthorizedBurn { reason, .. } => reason.to_owned(),
+                AuthorizedMint { reason, .. }
+                | AuthorizedBurn { reason, .. }
+                | FreezeAccount { reason, .. }
+                | UnfreezeAccount { reason, .. }
+                | FreezePrincipal { reason, .. }
+                | UnfreezePrincipal { reason, .. } => reason.to_owned(),
                 Mint { .. }
                 | Transfer { .. }
                 | Burn { .. }
                 | Approve { .. }
                 | FeeCollector { .. } => None,
+            },
+            account: match &t.operation {
+                FreezeAccount { account, .. } | UnfreezeAccount { account, .. } => Some(*account),
+                Mint { .. }
+                | Transfer { .. }
+                | Burn { .. }
+                | Approve { .. }
+                | FeeCollector { .. }
+                | AuthorizedMint { .. }
+                | AuthorizedBurn { .. }
+                | FreezePrincipal { .. }
+                | UnfreezePrincipal { .. } => None,
+            },
+            principal: match &t.operation {
+                FreezePrincipal { principal, .. } | UnfreezePrincipal { principal, .. } => {
+                    Some(*principal)
+                }
+                Mint { .. }
+                | Transfer { .. }
+                | Burn { .. }
+                | Approve { .. }
+                | FeeCollector { .. }
+                | AuthorizedMint { .. }
+                | AuthorizedBurn { .. }
+                | FreezeAccount { .. }
+                | UnfreezeAccount { .. } => None,
             },
         }
     }
@@ -565,6 +718,10 @@ impl<Tokens: TokensType> LedgerTransaction for Transaction<Tokens> {
             Operation::FeeCollector { .. } => {
                 panic!("FeeCollector107 not implemented")
             }
+            Operation::FreezeAccount { .. }
+            | Operation::UnfreezeAccount { .. }
+            | Operation::FreezePrincipal { .. }
+            | Operation::UnfreezePrincipal { .. } => {}
         }
         Ok(())
     }
@@ -752,6 +909,10 @@ impl<Tokens: TokensType> BlockType for Block<Tokens> {
         let btype = match &transaction.operation {
             Operation::AuthorizedMint { .. } => Some(BTYPE_122_MINT.to_string()),
             Operation::AuthorizedBurn { .. } => Some(BTYPE_122_BURN.to_string()),
+            Operation::FreezeAccount { .. } => Some(BTYPE_123_FREEZE_ACCOUNT.to_string()),
+            Operation::UnfreezeAccount { .. } => Some(BTYPE_123_UNFREEZE_ACCOUNT.to_string()),
+            Operation::FreezePrincipal { .. } => Some(BTYPE_123_FREEZE_PRINCIPAL.to_string()),
+            Operation::UnfreezePrincipal { .. } => Some(BTYPE_123_UNFREEZE_PRINCIPAL.to_string()),
             _ => None,
         };
         let effective_fee = match &transaction.operation {
@@ -763,7 +924,11 @@ impl<Tokens: TokensType> BlockType for Block<Tokens> {
             Operation::Mint { .. }
             | Operation::Burn { .. }
             | Operation::AuthorizedMint { .. }
-            | Operation::AuthorizedBurn { .. } => None,
+            | Operation::AuthorizedBurn { .. }
+            | Operation::FreezeAccount { .. }
+            | Operation::UnfreezeAccount { .. }
+            | Operation::FreezePrincipal { .. }
+            | Operation::UnfreezePrincipal { .. } => None,
         };
         let (fee_collector, fee_collector_block_index) = match fee_collector {
             Some(FeeCollector {

--- a/rs/ledger_suite/icrc1/test_utils/src/lib.rs
+++ b/rs/ledger_suite/icrc1/test_utils/src/lib.rs
@@ -17,6 +17,10 @@ use icrc_ledger_types::icrc2::approve::ApproveArgs;
 use icrc_ledger_types::icrc2::transfer_from::TransferFromArgs;
 use icrc_ledger_types::icrc107::schema::BTYPE_107;
 use icrc_ledger_types::icrc122::schema::{BTYPE_122_BURN, BTYPE_122_MINT};
+use icrc_ledger_types::icrc123::schema::{
+    BTYPE_123_FREEZE_ACCOUNT, BTYPE_123_FREEZE_PRINCIPAL, BTYPE_123_UNFREEZE_ACCOUNT,
+    BTYPE_123_UNFREEZE_PRINCIPAL,
+};
 use num_traits::cast::ToPrimitive;
 use proptest::prelude::*;
 use proptest::sample::select;
@@ -298,12 +302,22 @@ pub fn blocks_strategy<Tokens: TokensType>(
                 Operation::Mint { ref fee, .. } => fee.clone().is_none().then_some(arb_fee),
                 Operation::FeeCollector { .. }
                 | Operation::AuthorizedMint { .. }
-                | Operation::AuthorizedBurn { .. } => None,
+                | Operation::AuthorizedBurn { .. }
+                | Operation::FreezeAccount { .. }
+                | Operation::UnfreezeAccount { .. }
+                | Operation::FreezePrincipal { .. }
+                | Operation::UnfreezePrincipal { .. } => None,
             };
             let btype = match transaction.operation {
                 Operation::FeeCollector { .. } => Some(BTYPE_107.to_string()),
                 Operation::AuthorizedMint { .. } => Some(BTYPE_122_MINT.to_string()),
                 Operation::AuthorizedBurn { .. } => Some(BTYPE_122_BURN.to_string()),
+                Operation::FreezeAccount { .. } => Some(BTYPE_123_FREEZE_ACCOUNT.to_string()),
+                Operation::UnfreezeAccount { .. } => Some(BTYPE_123_UNFREEZE_ACCOUNT.to_string()),
+                Operation::FreezePrincipal { .. } => Some(BTYPE_123_FREEZE_PRINCIPAL.to_string()),
+                Operation::UnfreezePrincipal { .. } => {
+                    Some(BTYPE_123_UNFREEZE_PRINCIPAL.to_string())
+                }
                 _ => None,
             };
 
@@ -672,6 +686,12 @@ impl TransactionsAndBalances {
             Operation::AuthorizedBurn { from, amount, .. } => {
                 self.debit(from, amount.get_e8s());
             }
+            Operation::FreezeAccount { .. }
+            | Operation::UnfreezeAccount { .. }
+            | Operation::FreezePrincipal { .. }
+            | Operation::UnfreezePrincipal { .. } => {
+                // Freeze/unfreeze operations do not affect balances
+            }
         };
         self.transactions.push(tx);
 
@@ -707,6 +727,12 @@ impl TransactionsAndBalances {
             }
             Operation::AuthorizedBurn { from, .. } => {
                 self.check_and_update_account_validity(*from, default_fee);
+            }
+            Operation::FreezeAccount { .. }
+            | Operation::UnfreezeAccount { .. }
+            | Operation::FreezePrincipal { .. }
+            | Operation::UnfreezePrincipal { .. } => {
+                // Freeze/unfreeze operations do not affect balances or allowances
             }
         }
     }

--- a/rs/ledger_suite/icrc1/tests/tests.rs
+++ b/rs/ledger_suite/icrc1/tests/tests.rs
@@ -571,3 +571,253 @@ mod authorized_mint_burn_tests {
         assert!(validate_152_burn(&generic_block).is_err());
     }
 }
+
+mod freeze_operation_tests {
+    use super::*;
+    use candid::Principal;
+    use ic_icrc1::Operation;
+    use ic_ledger_core::block::BlockType;
+    use icrc_ledger_types::icrc1::account::Account;
+    use icrc_ledger_types::icrc123::schema::{
+        BTYPE_123_FREEZE_ACCOUNT, BTYPE_123_FREEZE_PRINCIPAL, BTYPE_123_UNFREEZE_ACCOUNT,
+        BTYPE_123_UNFREEZE_PRINCIPAL,
+    };
+
+    fn test_account(n: u64) -> Account {
+        Account {
+            owner: Principal::from_slice(&n.to_be_bytes()),
+            subaccount: None,
+        }
+    }
+
+    fn test_principal(n: u64) -> Principal {
+        Principal::from_slice(&n.to_be_bytes())
+    }
+
+    fn make_freeze_account_block(
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+        created_at_time: Option<u64>,
+    ) -> Block<U64> {
+        let transaction = Transaction {
+            operation: Operation::FreezeAccount {
+                account: test_account(1),
+                caller,
+                mthd,
+                reason,
+            },
+            created_at_time,
+            memo: None,
+        };
+        Block::from_transaction(
+            None,
+            transaction,
+            ic_ledger_core::timestamp::TimeStamp::from_nanos_since_unix_epoch(1_000_000_000),
+            U64::from(0_u64),
+            None,
+        )
+    }
+
+    fn make_unfreeze_account_block(
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+        created_at_time: Option<u64>,
+    ) -> Block<U64> {
+        let transaction = Transaction {
+            operation: Operation::UnfreezeAccount {
+                account: test_account(1),
+                caller,
+                mthd,
+                reason,
+            },
+            created_at_time,
+            memo: None,
+        };
+        Block::from_transaction(
+            None,
+            transaction,
+            ic_ledger_core::timestamp::TimeStamp::from_nanos_since_unix_epoch(1_000_000_000),
+            U64::from(0_u64),
+            None,
+        )
+    }
+
+    fn make_freeze_principal_block(
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+        created_at_time: Option<u64>,
+    ) -> Block<U64> {
+        let transaction = Transaction {
+            operation: Operation::FreezePrincipal {
+                principal: test_principal(2),
+                caller,
+                mthd,
+                reason,
+            },
+            created_at_time,
+            memo: None,
+        };
+        Block::from_transaction(
+            None,
+            transaction,
+            ic_ledger_core::timestamp::TimeStamp::from_nanos_since_unix_epoch(1_000_000_000),
+            U64::from(0_u64),
+            None,
+        )
+    }
+
+    fn make_unfreeze_principal_block(
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+        created_at_time: Option<u64>,
+    ) -> Block<U64> {
+        let transaction = Transaction {
+            operation: Operation::UnfreezePrincipal {
+                principal: test_principal(2),
+                caller,
+                mthd,
+                reason,
+            },
+            created_at_time,
+            memo: None,
+        };
+        Block::from_transaction(
+            None,
+            transaction,
+            ic_ledger_core::timestamp::TimeStamp::from_nanos_since_unix_epoch(1_000_000_000),
+            U64::from(0_u64),
+            None,
+        )
+    }
+
+    // --- CBOR round-trip tests ---
+
+    #[test]
+    fn test_freeze_account_cbor_round_trip() {
+        let block = make_freeze_account_block(
+            Some(Principal::anonymous()),
+            Some("153freeze_account".to_string()),
+            Some("test reason".to_string()),
+            Some(1_000_000_000),
+        );
+        let encoded = block.clone().encode();
+        let decoded = Block::<U64>::decode(encoded).unwrap();
+        assert_eq!(block, decoded);
+    }
+
+    #[test]
+    fn test_unfreeze_account_cbor_round_trip() {
+        let block = make_unfreeze_account_block(
+            Some(Principal::anonymous()),
+            Some("153unfreeze_account".to_string()),
+            None,
+            Some(1_000_000_000),
+        );
+        let encoded = block.clone().encode();
+        let decoded = Block::<U64>::decode(encoded).unwrap();
+        assert_eq!(block, decoded);
+    }
+
+    #[test]
+    fn test_freeze_principal_cbor_round_trip() {
+        let block = make_freeze_principal_block(
+            Some(Principal::anonymous()),
+            Some("153freeze_principal".to_string()),
+            Some("suspicious activity".to_string()),
+            Some(1_000_000_000),
+        );
+        let encoded = block.clone().encode();
+        let decoded = Block::<U64>::decode(encoded).unwrap();
+        assert_eq!(block, decoded);
+    }
+
+    #[test]
+    fn test_unfreeze_principal_cbor_round_trip() {
+        let block = make_unfreeze_principal_block(
+            Some(Principal::anonymous()),
+            Some("153unfreeze_principal".to_string()),
+            None,
+            Some(1_000_000_000),
+        );
+        let encoded = block.clone().encode();
+        let decoded = Block::<U64>::decode(encoded).unwrap();
+        assert_eq!(block, decoded);
+    }
+
+    // --- btype tests ---
+
+    #[test]
+    fn test_freeze_account_btype_set_correctly() {
+        let block = make_freeze_account_block(None, None, None, None);
+        assert_eq!(block.btype.as_deref(), Some(BTYPE_123_FREEZE_ACCOUNT));
+    }
+
+    #[test]
+    fn test_unfreeze_account_btype_set_correctly() {
+        let block = make_unfreeze_account_block(None, None, None, None);
+        assert_eq!(block.btype.as_deref(), Some(BTYPE_123_UNFREEZE_ACCOUNT));
+    }
+
+    #[test]
+    fn test_freeze_principal_btype_set_correctly() {
+        let block = make_freeze_principal_block(None, None, None, None);
+        assert_eq!(block.btype.as_deref(), Some(BTYPE_123_FREEZE_PRINCIPAL));
+    }
+
+    #[test]
+    fn test_unfreeze_principal_btype_set_correctly() {
+        let block = make_unfreeze_principal_block(None, None, None, None);
+        assert_eq!(block.btype.as_deref(), Some(BTYPE_123_UNFREEZE_PRINCIPAL));
+    }
+
+    // --- FlattenedTransaction / generic block round-trip tests ---
+
+    #[test]
+    fn test_freeze_account_generic_block_round_trip() {
+        let block = make_freeze_account_block(
+            Some(Principal::anonymous()),
+            Some("153freeze_account".to_string()),
+            None,
+            Some(1_000_000_000),
+        );
+        let generic_block = encoded_block_to_generic_block(&block.clone().encode());
+        let encoded_block = generic_block_to_encoded_block(generic_block.clone()).unwrap();
+        let round_tripped = Block::<U64>::decode(encoded_block).unwrap();
+        assert_eq!(block, round_tripped);
+    }
+
+    #[test]
+    fn test_freeze_principal_generic_block_round_trip() {
+        let block = make_freeze_principal_block(
+            Some(Principal::anonymous()),
+            Some("153freeze_principal".to_string()),
+            Some("reason".to_string()),
+            Some(1_000_000_000),
+        );
+        let generic_block = encoded_block_to_generic_block(&block.clone().encode());
+        let encoded_block = generic_block_to_encoded_block(generic_block.clone()).unwrap();
+        let round_tripped = Block::<U64>::decode(encoded_block).unwrap();
+        assert_eq!(block, round_tripped);
+    }
+
+    #[test]
+    fn test_freeze_account_hash_stability() {
+        let block = make_freeze_account_block(
+            Some(Principal::anonymous()),
+            Some("153freeze_account".to_string()),
+            None,
+            Some(1_000_000_000),
+        );
+        let generic_block = encoded_block_to_generic_block(&block.clone().encode());
+        assert_eq!(
+            generic_block.hash().to_vec(),
+            Block::<U64>::block_hash(&block.encode())
+                .as_slice()
+                .to_vec()
+        );
+    }
+}

--- a/rs/ledger_suite/test_utils/in_memory_ledger/src/lib.rs
+++ b/rs/ledger_suite/test_utils/in_memory_ledger/src/lib.rs
@@ -547,6 +547,12 @@ where
                 Operation::AuthorizedBurn { from, amount, .. } => {
                     self.process_burn(from, &None, amount, index);
                 }
+                Operation::FreezeAccount { .. }
+                | Operation::UnfreezeAccount { .. }
+                | Operation::FreezePrincipal { .. }
+                | Operation::UnfreezePrincipal { .. } => {
+                    // Freeze/unfreeze operations do not affect balances
+                }
             }
         }
         self.post_process_ledger_blocks(blocks);

--- a/rs/rosetta-api/icrc1/src/common/storage/storage_operations/mod.rs
+++ b/rs/rosetta-api/icrc1/src/common/storage/storage_operations/mod.rs
@@ -495,6 +495,12 @@ pub fn update_account_balances(
                 } => {
                     current_fee_collector_107 = Some(fee_collector);
                 }
+                crate::common::storage::types::IcrcOperation::FreezeAccount { .. }
+                | crate::common::storage::types::IcrcOperation::UnfreezeAccount { .. }
+                | crate::common::storage::types::IcrcOperation::FreezePrincipal { .. }
+                | crate::common::storage::types::IcrcOperation::UnfreezePrincipal { .. } => {
+                    panic!("freeze/unfreeze not yet supported in Rosetta")
+                }
             }
         }
 
@@ -671,6 +677,12 @@ pub fn store_blocks(
                 None,
                 None,
             ),
+            crate::common::storage::types::IcrcOperation::FreezeAccount { .. }
+            | crate::common::storage::types::IcrcOperation::UnfreezeAccount { .. }
+            | crate::common::storage::types::IcrcOperation::FreezePrincipal { .. }
+            | crate::common::storage::types::IcrcOperation::UnfreezePrincipal { .. } => {
+                panic!("freeze/unfreeze not yet supported in Rosetta")
+            }
         };
 
         // SQLite doesn't support unsigned 64-bit integers. We need to convert the timestamps to signed

--- a/rs/rosetta-api/icrc1/src/common/storage/types.rs
+++ b/rs/rosetta-api/icrc1/src/common/storage/types.rs
@@ -9,6 +9,10 @@ use icrc_ledger_types::icrc::metadata_key::MetadataKey;
 use icrc_ledger_types::icrc3::blocks::GenericBlock;
 use icrc_ledger_types::icrc107::schema::BTYPE_107;
 use icrc_ledger_types::icrc122::schema::{BTYPE_122_BURN, BTYPE_122_MINT};
+use icrc_ledger_types::icrc123::schema::{
+    BTYPE_123_FREEZE_ACCOUNT, BTYPE_123_FREEZE_PRINCIPAL, BTYPE_123_UNFREEZE_ACCOUNT,
+    BTYPE_123_UNFREEZE_PRINCIPAL,
+};
 use icrc_ledger_types::{
     icrc::generic_value::Value,
     icrc1::{account::Account, transfer::Memo},
@@ -141,7 +145,11 @@ impl RosettaBlock {
                 IcrcOperation::Burn { fee, .. } => fee,
                 IcrcOperation::FeeCollector { .. }
                 | IcrcOperation::AuthorizedMint { .. }
-                | IcrcOperation::AuthorizedBurn { .. } => None,
+                | IcrcOperation::AuthorizedBurn { .. }
+                | IcrcOperation::FreezeAccount { .. }
+                | IcrcOperation::UnfreezeAccount { .. }
+                | IcrcOperation::FreezePrincipal { .. }
+                | IcrcOperation::UnfreezePrincipal { .. } => None,
             }))
     }
 
@@ -395,6 +403,30 @@ pub enum IcrcOperation {
         mthd: Option<String>,
         reason: Option<String>,
     },
+    FreezeAccount {
+        account: Account,
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+    },
+    UnfreezeAccount {
+        account: Account,
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+    },
+    FreezePrincipal {
+        principal: Principal,
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+    },
+    UnfreezePrincipal {
+        principal: Principal,
+        caller: Option<Principal>,
+        mthd: Option<String>,
+        reason: Option<String>,
+    },
 }
 
 impl TryFrom<(Option<String>, BTreeMap<String, Value>)> for IcrcOperation {
@@ -501,6 +533,14 @@ impl TryFrom<(Option<String>, BTreeMap<String, Value>)> for IcrcOperation {
                         mthd,
                         reason,
                     })
+                }
+                found
+                    if found == BTYPE_123_FREEZE_ACCOUNT
+                        || found == BTYPE_123_UNFREEZE_ACCOUNT
+                        || found == BTYPE_123_FREEZE_PRINCIPAL
+                        || found == BTYPE_123_UNFREEZE_PRINCIPAL =>
+                {
+                    panic!("freeze/unfreeze not yet supported in Rosetta")
                 }
                 found => {
                     bail!(
@@ -638,6 +678,12 @@ impl From<IcrcOperation> for BTreeMap<String, Value> {
                 if let Some(reason) = reason {
                     map.insert("reason".to_string(), Value::text(reason));
                 }
+            }
+            Op::FreezeAccount { .. }
+            | Op::UnfreezeAccount { .. }
+            | Op::FreezePrincipal { .. }
+            | Op::UnfreezePrincipal { .. } => {
+                panic!("freeze/unfreeze not yet supported in Rosetta")
             }
         }
         map
@@ -787,6 +833,12 @@ where
                 mthd,
                 reason,
             },
+            Op::FreezeAccount { .. }
+            | Op::UnfreezeAccount { .. }
+            | Op::FreezePrincipal { .. }
+            | Op::UnfreezePrincipal { .. } => {
+                panic!("freeze/unfreeze not yet supported in Rosetta")
+            }
         }
     }
 }

--- a/rs/rosetta-api/icrc1/src/common/utils/utils.rs
+++ b/rs/rosetta-api/icrc1/src/common/utils/utils.rs
@@ -813,6 +813,12 @@ pub fn icrc1_operation_to_rosetta_core_operations(
                 ),
             ));
         }
+        crate::common::storage::types::IcrcOperation::FreezeAccount { .. }
+        | crate::common::storage::types::IcrcOperation::UnfreezeAccount { .. }
+        | crate::common::storage::types::IcrcOperation::FreezePrincipal { .. }
+        | crate::common::storage::types::IcrcOperation::UnfreezePrincipal { .. } => {
+            panic!("freeze/unfreeze not yet supported in Rosetta")
+        }
     };
 
     Ok(operations)

--- a/rs/rosetta-api/icrc1/src/construction_api/services.rs
+++ b/rs/rosetta-api/icrc1/src/construction_api/services.rs
@@ -548,7 +548,11 @@ mod tests {
                                 panic!("FeeCollector107 not implemented")
                             }
                             ic_icrc1::Operation::AuthorizedMint { .. }
-                            | ic_icrc1::Operation::AuthorizedBurn { .. } => continue,
+                            | ic_icrc1::Operation::AuthorizedBurn { .. }
+                            | ic_icrc1::Operation::FreezeAccount { .. }
+                            | ic_icrc1::Operation::UnfreezeAccount { .. }
+                            | ic_icrc1::Operation::FreezePrincipal { .. }
+                            | ic_icrc1::Operation::UnfreezePrincipal { .. } => continue,
                         };
                         let args = match arg_with_caller.arg {
                             LedgerEndpointArg::TransferArg(arg) => Encode!(&arg),

--- a/rs/rosetta-api/icrc1/src/construction_api/utils.rs
+++ b/rs/rosetta-api/icrc1/src/construction_api/utils.rs
@@ -281,6 +281,12 @@ pub fn build_icrc1_ledger_canister_method_args(
         crate::common::storage::types::IcrcOperation::AuthorizedBurn { .. } => {
             bail!("AuthorizedBurn operation not supported")
         }
+        crate::common::storage::types::IcrcOperation::FreezeAccount { .. }
+        | crate::common::storage::types::IcrcOperation::UnfreezeAccount { .. }
+        | crate::common::storage::types::IcrcOperation::FreezePrincipal { .. }
+        | crate::common::storage::types::IcrcOperation::UnfreezePrincipal { .. } => {
+            bail!("freeze/unfreeze operations not yet supported")
+        }
     }
     .context("Unable to encode canister method args")
 }
@@ -315,6 +321,12 @@ fn extract_caller_principal_from_icrc1_ledger_operation(
         }
         crate::common::storage::types::IcrcOperation::AuthorizedBurn { .. } => {
             bail!("AuthorizedBurn operation not supported")
+        }
+        crate::common::storage::types::IcrcOperation::FreezeAccount { .. }
+        | crate::common::storage::types::IcrcOperation::UnfreezeAccount { .. }
+        | crate::common::storage::types::IcrcOperation::FreezePrincipal { .. }
+        | crate::common::storage::types::IcrcOperation::UnfreezePrincipal { .. } => {
+            bail!("freeze/unfreeze operations not yet supported")
         }
     })
 }

--- a/rs/rosetta-api/icrc1/src/data_api/services.rs
+++ b/rs/rosetta-api/icrc1/src/data_api/services.rs
@@ -1238,6 +1238,12 @@ mod test {
                                         IcrcOperation::AuthorizedBurn { from, .. } => {
                                             Some(from.into())
                                         }
+                                        IcrcOperation::FreezeAccount { account, .. }
+                                        | IcrcOperation::UnfreezeAccount { account, .. } => {
+                                            Some(account.into())
+                                        }
+                                        IcrcOperation::FreezePrincipal { .. }
+                                        | IcrcOperation::UnfreezePrincipal { .. } => None,
                                     };
                                 if search_transactions_request.account_identifier.is_some() {
                                     break;
@@ -1312,6 +1318,10 @@ mod test {
                                             .try_into()
                                             .unwrap()
                                     }
+                                    IcrcOperation::FreezeAccount { .. }
+                                    | IcrcOperation::UnfreezeAccount { .. }
+                                    | IcrcOperation::FreezePrincipal { .. }
+                                    | IcrcOperation::UnfreezePrincipal { .. } => false,
                                 })
                                 .count();
 

--- a/rs/rosetta-api/icrc1/tests/multitoken_system_tests.rs
+++ b/rs/rosetta-api/icrc1/tests/multitoken_system_tests.rs
@@ -1843,7 +1843,11 @@ fn test_construction_submit() {
                             ic_icrc1::Operation::Burn { .. } => None,
                             ic_icrc1::Operation::FeeCollector { .. } => None,
                             ic_icrc1::Operation::AuthorizedMint { .. }
-                            | ic_icrc1::Operation::AuthorizedBurn { .. } => None,
+                            | ic_icrc1::Operation::AuthorizedBurn { .. }
+                            | ic_icrc1::Operation::FreezeAccount { .. }
+                            | ic_icrc1::Operation::UnfreezeAccount { .. }
+                            | ic_icrc1::Operation::FreezePrincipal { .. }
+                            | ic_icrc1::Operation::UnfreezePrincipal { .. } => None,
                         };
 
                         if matches!(

--- a/rs/rosetta-api/icrc1/tests/system_tests.rs
+++ b/rs/rosetta-api/icrc1/tests/system_tests.rs
@@ -1539,7 +1539,11 @@ fn test_construction_submit() {
                             ic_icrc1::Operation::Burn { .. } => None,
                             ic_icrc1::Operation::FeeCollector { .. } => None,
                             ic_icrc1::Operation::AuthorizedMint { .. }
-                            | ic_icrc1::Operation::AuthorizedBurn { .. } => None,
+                            | ic_icrc1::Operation::AuthorizedBurn { .. }
+                            | ic_icrc1::Operation::FreezeAccount { .. }
+                            | ic_icrc1::Operation::UnfreezeAccount { .. }
+                            | ic_icrc1::Operation::FreezePrincipal { .. }
+                            | ic_icrc1::Operation::UnfreezePrincipal { .. } => None,
                         };
 
                         // Rosetta does not support mint and burn operations


### PR DESCRIPTION
## Context

This is **Phase 2 of 5** in the ICRC-123/153 implementation (freeze/unfreeze for regulated asset management). The full stack:

| PR | Phase | What it does |
|---|---|---|
| #9981 | 1. Schema validators | Block format definitions — what a valid freeze/unfreeze block looks like |
| **#9980** | **2. Operation variants** | **This PR — adds the internal representation of freeze/unfreeze to the core ledger types** |
| #9979 | 3. Candid + index-ng + .did | Makes freeze/unfreeze visible through query APIs and the index canister |
| #9978 | 4. Rosetta | Rosetta data API can read and serve freeze/unfreeze blocks |
| #9976 | 5. Ledger endpoints | The actual `icrc153_freeze_account` etc. endpoints + freeze guard |

## What this PR does

The ICRC ledger represents every on-chain action (transfer, mint, burn, approve, etc.) as a variant of the `Operation` enum in `rs/ledger_suite/icrc1/src/lib.rs`. This PR adds 4 new variants for freeze/unfreeze:

- `FreezeAccount { account, caller, mthd, reason }`
- `UnfreezeAccount { account, caller, mthd, reason }`
- `FreezePrincipal { principal, caller, mthd, reason }`
- `UnfreezePrincipal { principal, caller, mthd, reason }`

These operations **don't change balances** — they record that an account or principal was frozen/unfrozen. The `apply()` method is a no-op.

Since `Operation` is used across the entire ledger suite (index-ng, Rosetta, test utils, in-memory ledger), every exhaustive match on `Operation` needs new arms. This PR adds **stub arms** (`panic!("not yet supported")` or no-ops) in all affected crates. The real implementations come in subsequent PRs in the stack:
- `endpoints.rs` panic → replaced in PR #9979
- Rosetta panics → replaced in PR #9978
- Index-ng no-ops → already correct (no balance changes for freeze ops)

## Changes

- `rs/ledger_suite/icrc1/src/lib.rs` — 4 new Operation variants, FlattenedTransaction support (new `account` and `principal` fields for CBOR encoding), btype assignment in `Block::from_transaction`, no-op `apply()`
- 13 other files with exhaustive match fixups (stubs)
- `rs/ledger_suite/icrc1/tests/tests.rs` — CBOR round-trip and btype tests for all 4 variants
- Canbench baselines updated (WASM changed due to new match arms)

## Test plan

- CBOR round-trip for all 4 freeze/unfreeze Operation variants
- btype set correctly (`123freezeaccount`, `123unfreezeaccount`, `123freezeprincipal`, `123unfreezeprincipal`)
- Generic block round-trip (encode → decode → compare)
- Hash stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)