### PR TITLE
feat: enable asynchronous canister creation with subnet ID in the URL

### DIFF
--- a/rs/http_endpoints/public/src/read_state.rs
+++ b/rs/http_endpoints/public/src/read_state.rs
@@ -1334,6 +1334,10 @@ mod test {
         )
         .expect_err("Should fail");
         assert_eq!(err.status, StatusCode::FORBIDDEN);
+        assert_eq!(
+            err.message,
+            "The user tries to access Request ID not signed by the caller."
+        );
     }
 
     #[rstest]
@@ -1367,5 +1371,10 @@ mod test {
         )
         .expect_err("Should fail");
         assert_eq!(err.status, StatusCode::FORBIDDEN);
+        assert_eq!(
+            err.message,
+            "The user tries to access request IDs for canisters \
+                not belonging to sender delegation targets."
+        );
     }
 }

--- a/rs/http_endpoints/public/src/read_state.rs
+++ b/rs/http_endpoints/public/src/read_state.rs
@@ -633,7 +633,11 @@ mod test {
         SUBNET_0, SUBNET_1, canister_test_id, subnet_test_id, user_test_id,
     };
     use ic_types::{
-        SubnetId, batch::RawQueryStats, consensus::certification::Certification, time::UNIX_EPOCH,
+        NumBytes, SubnetId,
+        batch::RawQueryStats,
+        consensus::certification::Certification,
+        ingress::{IngressState, IngressStatus},
+        time::UNIX_EPOCH,
     };
     use ic_validator::CanisterIdSet;
     use rstest::rstest;
@@ -1278,5 +1282,90 @@ mod test {
                 .get(),
             1
         );
+    }
+
+    fn state_with_ingress_status(
+        message_id: MessageId,
+        user_id: UserId,
+        receiver: CanisterId,
+    ) -> ReplicatedState {
+        let mut state = fake_replicated_state();
+        state.set_ingress_status(
+            message_id,
+            IngressStatus::Known {
+                receiver: receiver.get(),
+                user_id,
+                time: UNIX_EPOCH,
+                state: IngressState::Processing,
+            },
+            NumBytes::from(u64::MAX),
+            |_| {},
+        );
+        state
+    }
+
+    #[rstest]
+    #[case(Target::Canister, Version::V2, canister_test_id(1).get())]
+    #[case(Target::Canister, Version::V3, canister_test_id(1).get())]
+    #[case(Target::Subnet, Version::V3, APP_SUBNET_ID.get())]
+    fn test_request_status_wrong_user_is_rejected(
+        #[case] target: Target,
+        #[case] version: Version,
+        #[case] effective_principal_id: PrincipalId,
+    ) {
+        let metrics = test_metrics();
+        let message_id = MessageId::from([0u8; 32]);
+        let state =
+            state_with_ingress_status(message_id.clone(), user_test_id(1), canister_test_id(1));
+
+        let err = verify_paths(
+            &metrics,
+            target,
+            version,
+            &state,
+            &user_test_id(2),
+            &[Path::new(vec![
+                Label::from("request_status"),
+                message_id.as_bytes().to_vec().into(),
+            ])],
+            &CanisterIdSet::all(),
+            effective_principal_id,
+            NNS_SUBNET_ID,
+        )
+        .expect_err("Should fail");
+        assert_eq!(err.status, StatusCode::FORBIDDEN);
+    }
+
+    #[rstest]
+    #[case(Target::Canister, Version::V2, canister_test_id(1).get())]
+    #[case(Target::Canister, Version::V3, canister_test_id(1).get())]
+    #[case(Target::Subnet, Version::V3, APP_SUBNET_ID.get())]
+    fn test_request_status_receiver_not_in_targets_is_rejected(
+        #[case] target: Target,
+        #[case] version: Version,
+        #[case] effective_principal_id: PrincipalId,
+    ) {
+        let metrics = test_metrics();
+        let message_id = MessageId::from([0u8; 32]);
+        let receiver = canister_test_id(1);
+        let state = state_with_ingress_status(message_id.clone(), user_test_id(1), receiver);
+        let other_canister = canister_test_id(2);
+
+        let err = verify_paths(
+            &metrics,
+            target,
+            version,
+            &state,
+            &user_test_id(1),
+            &[Path::new(vec![
+                Label::from("request_status"),
+                message_id.as_bytes().to_vec().into(),
+            ])],
+            &CanisterIdSet::try_from_iter(vec![other_canister]).unwrap(),
+            effective_principal_id,
+            NNS_SUBNET_ID,
+        )
+        .expect_err("Should fail");
+        assert_eq!(err.status, StatusCode::FORBIDDEN);
     }
 }

--- a/rs/http_endpoints/public/src/read_state.rs
+++ b/rs/http_endpoints/public/src/read_state.rs
@@ -1314,7 +1314,7 @@ mod test {
         #[case] effective_principal_id: PrincipalId,
     ) {
         let metrics = test_metrics();
-        let message_id = MessageId::from([0u8; 32]);
+        let message_id = MessageId::from([0_u8; 32]);
         let state =
             state_with_ingress_status(message_id.clone(), user_test_id(1), canister_test_id(1));
 
@@ -1346,7 +1346,7 @@ mod test {
         #[case] effective_principal_id: PrincipalId,
     ) {
         let metrics = test_metrics();
-        let message_id = MessageId::from([0u8; 32]);
+        let message_id = MessageId::from([0_u8; 32]);
         let receiver = canister_test_id(1);
         let state = state_with_ingress_status(message_id.clone(), user_test_id(1), receiver);
         let other_canister = canister_test_id(2);

--- a/rs/http_endpoints/public/src/read_state.rs
+++ b/rs/http_endpoints/public/src/read_state.rs
@@ -514,7 +514,9 @@ fn verify_paths(
                 b"request_status",
                 request_id,
                 b"status" | b"reply" | b"reject_code" | b"reject_message" | b"error_code",
-            ] if target == Target::Canister => {
+            ] if target == Target::Canister
+                || (target == Target::Subnet && version == Version::V3) =>
+            {
                 let message_id = MessageId::try_from(*request_id).map_err(|_| HttpError {
                     status: StatusCode::BAD_REQUEST,
                     message: format!(
@@ -1002,8 +1004,8 @@ mod test {
             Ok(())
         );
 
-        // request_status not allowed on subnet endpoint
-        let err = verify_paths(
+        // request_status not allowed on subnet V2 endpoint, allowed on V3
+        let result = verify_paths(
             &metrics,
             Target::Subnet,
             version,
@@ -1017,9 +1019,16 @@ mod test {
             &CanisterIdSet::all(),
             APP_SUBNET_ID.get(),
             NNS_SUBNET_ID,
-        )
-        .expect_err("Should fail");
-        assert_eq!(err.status, StatusCode::NOT_FOUND);
+        );
+        match version {
+            Version::V2 => {
+                assert_eq!(
+                    result.expect_err("Should fail").status,
+                    StatusCode::NOT_FOUND
+                )
+            }
+            Version::V3 => assert_eq!(result, Ok(())),
+        }
 
         // canister/* not allowed on subnet endpoint
         let err = verify_paths(

--- a/rs/tests/execution/system_subnets_test.rs
+++ b/rs/tests/execution/system_subnets_test.rs
@@ -106,7 +106,7 @@ pub fn ingress_message_to_subnet_id_fails(env: TestEnv) {
                 AgentError::HttpError(payload) => {
                     let error_message = String::from_utf8(payload.content).unwrap();
                     assert!(error_message.contains(&format!(
-                        "Specified CanisterId {subnet_id} does not match effective canister id in URL {canister_id}"
+                        "Specified canister ID {subnet_id} does not match effective canister ID in URL {canister_id}"
                     )));
                 }
                 _ => panic!("Unexpected error: {err:?}"),

--- a/rs/tests/execution/system_subnets_test.rs
+++ b/rs/tests/execution/system_subnets_test.rs
@@ -106,7 +106,7 @@ pub fn ingress_message_to_subnet_id_fails(env: TestEnv) {
                 AgentError::HttpError(payload) => {
                     let error_message = String::from_utf8(payload.content).unwrap();
                     assert!(error_message.contains(&format!(
-                        "Specified canister ID {subnet_id} does not match effective canister ID in URL {canister_id}"
+                        "Specified CanisterId {subnet_id} does not match effective canister id in URL {canister_id}"
                     )));
                 }
                 _ => panic!("Unexpected error: {err:?}"),

--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -348,8 +348,7 @@ fn test_invalid_request_rejected(env: TestEnv, endpoint: Endpoint) {
         let path = vec!["request_status".into(), invalid_request_id.into()];
         let error = read_state(&env, vec![path], endpoint).expect_err("Invalid request");
         match endpoint {
-            Endpoint::CanisterReadState(_)
-            | Endpoint::SubnetReadState(read_state::Version::V3) => {
+            Endpoint::CanisterReadState(_) | Endpoint::SubnetReadState(read_state::Version::V3) => {
                 assert_matches!(
                     error,
                     AgentError::HttpError(error) if error.status == StatusCode::BAD_REQUEST.as_u16(),

--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -1096,6 +1096,7 @@ fn main() -> Result<()> {
         .add_test(systest!(test_subnet_canister_ranges_paths; read_state::Version::V3))
         .add_test(systest!(test_canister_canister_ranges_paths; read_state::Version::V2))
         .add_test(systest!(test_canister_canister_ranges_paths; read_state::Version::V3))
+        // paths with /request_status prefix are not supported by /api/v2/subnet/read_state
         .add_test(systest!(test_request_path; Endpoint::CanisterReadState(read_state::Version::V2)))
         .add_test(systest!(test_request_path; Endpoint::CanisterReadState(read_state::Version::V3)))
         .add_test(systest!(test_request_path; Endpoint::SubnetReadState(read_state::Version::V3)))

--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -366,8 +366,7 @@ fn test_invalid_request_rejected(env: TestEnv, endpoint: Endpoint) {
     }
 }
 
-fn test_absent_request(env: TestEnv, version: read_state::Version) {
-    let endpoint = Endpoint::CanisterReadState(version);
+fn test_absent_request(env: TestEnv, endpoint: Endpoint) {
     for absent_request_id in [&[0; 32], &[8; 32], &[255; 32]] {
         let path = vec!["request_status".into(), absent_request_id.into()];
         let cert = read_state(&env, vec![path], endpoint).expect("Valid request");
@@ -722,8 +721,7 @@ fn make_update_call(agent: &Agent, canister_id: &Principal) -> (RequestId, Vec<u
     (request_id, result)
 }
 
-fn test_request_path(env: TestEnv, version: read_state::Version) {
-    let endpoint = Endpoint::CanisterReadState(version);
+fn test_request_path(env: TestEnv, endpoint: Endpoint) {
     let node = get_first_app_node(&env);
     let effective_canister_id = node.effective_canister_id();
     let agent = node.build_default_agent();
@@ -760,8 +758,7 @@ fn test_request_path(env: TestEnv, version: read_state::Version) {
     assert_eq!(value.to_vec(), result);
 }
 
-fn test_request_path_access(env: TestEnv, version: read_state::Version) {
-    let endpoint = Endpoint::CanisterReadState(version);
+fn test_request_path_access(env: TestEnv, endpoint: Endpoint) {
     let node = get_first_app_node(&env);
     let effective_canister_id = node.effective_canister_id();
     let agent = node.build_default_agent();
@@ -1096,18 +1093,15 @@ fn main() -> Result<()> {
         .add_test(systest!(test_subnet_canister_ranges_paths; read_state::Version::V3))
         .add_test(systest!(test_canister_canister_ranges_paths; read_state::Version::V2))
         .add_test(systest!(test_canister_canister_ranges_paths; read_state::Version::V3))
-        // Only /api/{v2,v3}/canister/read_state endpoints are tested because paths with
-        // /request_status prefix are not supported by /api/{v2,v3}/subnet/read_state
-        .add_test(systest!(test_request_path; read_state::Version::V2))
-        .add_test(systest!(test_request_path; read_state::Version::V3))
-        // Only /api/{v2,v3}/canister/read_state endpoints are tested because paths with
-        // /request_status prefix are not supported by /api/{v2,v3}/subnet/read_state
-        .add_test(systest!(test_request_path_access; read_state::Version::V2))
-        .add_test(systest!(test_request_path_access; read_state::Version::V3))
-        // Only /api/{v2,v3}/canister/read_state endpoints are tested because paths with
-        // /request_status prefix are not supported by /api/{v2,v3}/subnet/read_state
-        .add_test(systest!(test_absent_request; read_state::Version::V2))
-        .add_test(systest!(test_absent_request; read_state::Version::V3))
+        .add_test(systest!(test_request_path; Endpoint::CanisterReadState(read_state::Version::V2)))
+        .add_test(systest!(test_request_path; Endpoint::CanisterReadState(read_state::Version::V3)))
+        .add_test(systest!(test_request_path; Endpoint::SubnetReadState(read_state::Version::V3)))
+        .add_test(systest!(test_request_path_access; Endpoint::CanisterReadState(read_state::Version::V2)))
+        .add_test(systest!(test_request_path_access; Endpoint::CanisterReadState(read_state::Version::V3)))
+        .add_test(systest!(test_request_path_access; Endpoint::SubnetReadState(read_state::Version::V3)))
+        .add_test(systest!(test_absent_request; Endpoint::CanisterReadState(read_state::Version::V2)))
+        .add_test(systest!(test_absent_request; Endpoint::CanisterReadState(read_state::Version::V3)))
+        .add_test(systest!(test_absent_request; Endpoint::SubnetReadState(read_state::Version::V3)))
         // Only /api/{v2,v3}/canister/read_state endpoints are tested because paths with
         // /canister prefix are not supported by /api/{v2,v3}/subnet/read_state
         .add_test(systest!(test_canister_path; read_state::Version::V2))

--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -13,7 +13,7 @@ Success::
     . public key and canister ranges for all subnets
     . public keys of nodes on the subnet
     . no public keys of nodes on other subnets
-. Malformed status requests are rejected by /api/{v2,v3}/canister/.../read_state
+. Malformed status requests are rejected by /api/{v2,v3}/canister/.../read_state and /api/v3/subnet/.../read_state
 . Status requests for non-existent requests contain an absence proof by /api/{v2,v3}/canister/.../read_state
 . /api/{v2,v3}/canister/.../read_state requests of invalid paths are rejected
 . A canister's public metadata sections can be read by
@@ -348,18 +348,19 @@ fn test_invalid_request_rejected(env: TestEnv, endpoint: Endpoint) {
         let path = vec!["request_status".into(), invalid_request_id.into()];
         let error = read_state(&env, vec![path], endpoint).expect_err("Invalid request");
         match endpoint {
-            Endpoint::CanisterReadState(_version) => {
+            Endpoint::CanisterReadState(_)
+            | Endpoint::SubnetReadState(read_state::Version::V3) => {
                 assert_matches!(
                     error,
                     AgentError::HttpError(error) if error.status == StatusCode::BAD_REQUEST.as_u16(),
                     "Invalid request id"
                 )
             }
-            Endpoint::SubnetReadState(_version) => {
+            Endpoint::SubnetReadState(read_state::Version::V2) => {
                 assert_matches!(
                     error,
                     AgentError::HttpError(error) if error.status == StatusCode::NOT_FOUND.as_u16(),
-                    "request_status is not allowed on subnet read_state endpoint"
+                    "request_status is not allowed on subnet read_state V2 endpoint"
                 )
             }
         }

--- a/rs/tests/networking/read_state_test.rs
+++ b/rs/tests/networking/read_state_test.rs
@@ -13,9 +13,10 @@ Success::
     . public key and canister ranges for all subnets
     . public keys of nodes on the subnet
     . no public keys of nodes on other subnets
-. Malformed status requests are rejected by /api/{v2,v3}/canister/.../read_state and /api/v3/subnet/.../read_state
+. Malformed status requests are rejected by /api/{v2,v3}/canister/.../read_state and /api/{v2,v3}/subnet/.../read_state
 . Status requests for non-existent requests contain an absence proof by /api/{v2,v3}/canister/.../read_state
-. /api/{v2,v3}/canister/.../read_state requests of invalid paths are rejected
+  and /api/v3/subnet/.../read_state
+. /api/{v2,v3}/canister/.../read_state and /api/{v2,v3}/subnet/.../read_state requests of invalid paths are rejected
 . A canister's public metadata sections can be read by
     . The canister controller
     . The anonymous identity
@@ -27,11 +28,13 @@ Success::
     . module_hash is absent for empty canisters;
     . module_hash is a blob for non-empty canisters;
     . controllers are always present for existing canisters and consist of a list of principals
-. /api/{v2,v3}/canister/.../read_state requests for the full paths /request_status/R/status and /request_status/R/reply succeed
-. /api/{v2,v3}/canister/.../read_state requests for the path /request_status/R are rejected with 403 if signed by a different
-  principal than who made the original request with request ID R;
-. /api/{v2,v3}/canister/.../read_state requests for two paths /request_status/R and /request_status/S with two different request
-  IDs R and S are rejected with 400 (while requesting each of the two paths in isolation would succeed);
+. /api/{v2,v3}/canister/.../read_state and /api/v3/subnet/.../read_state requests for the full paths
+  /request_status/R/status and /request_status/R/reply succeed
+. /api/{v2,v3}/canister/.../read_state and /api/v3/subnet/.../read_state requests for the path /request_status/R
+  are rejected with 403 if signed by a different principal than who made the original request with request ID R;
+. /api/{v2,v3}/canister/.../read_state and /api/v3/subnet/.../read_state requests for two paths /request_status/R
+  and /request_status/S with two different request IDs R and S are rejected with 400
+  (while requesting each of the two paths in isolation would succeed);
 . Read state requests at `/api/{v2,v3}/subnet/{subnet_id}/read_state` for the path `/canister_ranges/{subnet_id}`
   succeed and return a correct list of canister ranges assigned to the subnet.
 . Read state requests at `/api/{v2,v3}/canister/{canister_id}/read_state` for the path `/canister_ranges/{subnet_id}`
@@ -271,7 +274,7 @@ fn test_subnet_path(env: TestEnv, endpoint: Endpoint) {
     let (app_subnet, other_app_subnet) = get_both_app_subnets(&env);
     let app_subnet_id = app_subnet.subnet_id;
 
-    // Query the `/subnet` enpoint of the app subnet
+    // Query the `/subnet` endpoint of the app subnet
     let path = vec!["subnet".into()];
     let cert = read_state(&env, vec![path], endpoint).expect("Valid request");
 
@@ -806,7 +809,7 @@ fn test_request_path_access(env: TestEnv, endpoint: Endpoint) {
 }
 
 /// Queries the `api/{v2,v3}/canister/{canister_id}/read_state` endpoint for the canister ranges,
-/// and makes sure the requests fails.
+/// and makes sure the request fails.
 fn test_canister_canister_ranges_paths(env: TestEnv, version: read_state::Version) {
     let endpoint = Endpoint::CanisterReadState(version);
     let subnet = get_first_app_subnet(&env);
@@ -824,7 +827,7 @@ fn test_canister_canister_ranges_paths(env: TestEnv, version: read_state::Versio
     assert_matches!(err, AgentError::HttpError(payload) if payload.status == 404);
 }
 
-/// Queries the `api/{v2,v3}/subnet/{subnet_id}/read_state` endpoint for the canister ranges.
+/// Queries the `api/{v2,v3}/subnet/{subnet_id}/read_state` endpoint for the canister ranges
 /// and compares the result with the canister ranges obtained from the registry.
 fn test_subnet_canister_ranges_paths(env: TestEnv, version: read_state::Version) {
     let endpoint = Endpoint::SubnetReadState(version);


### PR DESCRIPTION
This PR enables to retrieve the status of an (asynchronous) update call via the (existing) public HTTP endpoint `/api/v3/subnet/<effective_subnet_id>/read_state` on the replica. It is specified in this [PR](https://github.com/dfinity/portal/pull/6224).

In more detail, this PR is needed if the synchronous update call endpoint `/api/v4/subnet/.../call` returns 202 and thus the user needs to process the update call (to create canister as nothing else is allowed on `/api/v4/subnet/.../call`) asynchronously (by polling `/api/v3/subnet/.../read_state` for the `/request_status/...`).