### PR TITLE
fix: Fix remaining race on the var crypt device

### DIFF
--- a/ic-os/components/early-boot/fstab/fstab-guestos
+++ b/ic-os/components/early-boot/fstab/fstab-guestos
@@ -3,7 +3,8 @@ tmpfs    /tmp    tmpfs   defaults 0   2
 /dev/disk/by-partuuid/b78084e2-3363-1346-8c25-d426f26b8928   /boot/efi   vfat    defaults    0   2
 /dev/disk/by-partuuid/6788e4cf-f456-104e-9a34-a2c58cfb0ee6   /boot/grub  vfat    defaults    0   2
 /dev/disk/by-partuuid/a5ba3816-beaa-d74d-993e-cfa5aa6ba1f6   /boot/config    ext4    defaults,sync    0   2
-/dev/mapper/var_crypt   /var  ext4    defaults    0   2
+# Remove the BindsTo on the underlying crypt device. We suspect the device flapping in udev can lead to the mount locking up.
+/dev/mapper/var_crypt   /var  ext4    defaults,x-systemd.device-bound=false    0   2
 # If you add a new mount that depends on /dev/mapper/store, don't forget to add it to maybe-disable-store-mounts.service
 /dev/mapper/store-shared--backup   /var/lib/ic/backup    ext4 defaults,context=system_u:object_r:ic_data_t:s0  0   2
 /dev/mapper/store-shared--crypto   /var/lib/ic/crypto    ext4 defaults   0   2

--- a/ic-os/components/guestos/init/setup-encryption/systemd-fsck@dev-mapper-var_crypt.service
+++ b/ic-os/components/guestos/init/setup-encryption/systemd-fsck@dev-mapper-var_crypt.service
@@ -1,11 +1,12 @@
-# This unit is overridden to remove the BindsTo on the underlying crypt device.
-# Otherwise, it is the same as the systemd generated default. We suspect the
-# device flapping in udev can lead to the mount locking up.
+# This unit is overridden to replace the BindsTo on the underlying crypt device
+# with Requires. Otherwise, it is the same as the systemd generated default. We
+# suspect the device flapping in udev can lead to the mount locking up.
 
 [Unit]
 Description=File System Check on /dev/mapper/var_crypt
 Documentation=man:systemd-fsck@.service(8)
 DefaultDependencies=no
+Requires=dev-mapper-var_crypt.device
 Conflicts=shutdown.target
 Wants=systemd-fsckd.socket
 After=dev-mapper-var_crypt.device systemd-fsck-root.service local-fs-pre.target systemd-fsckd.socket


### PR DESCRIPTION
This device flaps during setup, so do not bind to avoid the mount from quickly being unmounted.

This was seen in some flaky tests [here](https://github.com/dfinity/ic/pull/9972). With the fix, we do not see the issue once out of 100 runs.