### PR TITLE
feat(governance): Batch proposal

### DIFF
--- a/rs/nervous_system/integration_tests/tests/batch_proposal.rs
+++ b/rs/nervous_system/integration_tests/tests/batch_proposal.rs
@@ -1,0 +1,149 @@
+use candid::Principal;
+use ic_base_types::PrincipalId;
+use ic_crypto_sha2::Sha256;
+use ic_nervous_system_common_test_utils::wasm_helpers::SMALLEST_VALID_WASM_BYTES;
+use ic_nervous_system_integration_tests::pocket_ic_helpers::{NnsInstaller, nns};
+use ic_nns_constants::ROOT_CANISTER_ID;
+use ic_nns_governance_api::{
+    BatchRequest, CreateCanisterAndInstallCodeRequest, MakeProposalRequest, ProposalActionRequest,
+    SuccessfulProposalExecutionValue, WasmModule,
+};
+use pocket_ic::PocketIcBuilder;
+
+/// Verifies that a Batch proposal containing two CreateCanisterAndInstallCode
+/// sub-actions is executed successfully and that each sub-action produces a
+/// distinct canister ID with the expected WASM installed.
+#[tokio::test]
+async fn test_batch_of_two_create_canister_and_install_code_proposals() {
+    // Step 1: Prepare the world.
+
+    // Step 1.1: Boot up an IC.
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        // Required by NnsInstaller, but otherwise, not actually used.
+        .with_sns_subnet()
+        .build_async()
+        .await;
+
+    // Step 1.2: Install NNS.
+    let mut nns_installer = NnsInstaller::default();
+    nns_installer.with_current_nns_canister_versions();
+    nns_installer.install(&pocket_ic).await;
+
+    // Step 2: Call the code under test.
+
+    // Step 2.1: Gather ingredients for proposal.
+
+    // The subnet where the canisters will be created.
+    let topology = pocket_ic.topology().await;
+    let host_subnet_id = PrincipalId::from(topology.get_nns().unwrap());
+
+    // Code that will be installed into the new canisters.
+    let wasm_a: Vec<u8> = SMALLEST_VALID_WASM_BYTES.to_vec();
+    let wasm_b: Vec<u8> = {
+        let mut w = wasm_a.clone();
+        // Append a valid custom section (id=0, size=2, name_len=0, data=[0x42]).
+        w.extend_from_slice(&[0x00, 0x02, 0x00, 0x42]);
+        w
+    };
+    // Used later for verification.
+    let hashes = [
+        Sha256::hash(&wasm_a).to_vec(),
+        Sha256::hash(&wasm_b).to_vec(),
+    ];
+
+    // Step 2.2: Assemble the kernel of the proposal, the Batch itself.
+    let actions = [wasm_a, wasm_b]
+        .into_iter()
+        .map(|wasm: Vec<u8>| -> ProposalActionRequest {
+            let result = CreateCanisterAndInstallCodeRequest {
+                host_subnet_id: Some(host_subnet_id),
+                wasm_module: Some(WasmModule::Inlined(wasm)),
+                canister_settings: None,
+                install_arg: None,
+            };
+
+            ProposalActionRequest::CreateCanisterAndInstallCode(result)
+        })
+        .collect();
+    let batch = BatchRequest {
+        actions: Some(actions),
+    };
+
+    // Step 2.3: Execute the proposal.
+    let proposal_info = nns::governance::propose_and_wait(
+        &pocket_ic,
+        MakeProposalRequest {
+            title: Some("Create two canisters (using Batch)".to_string()),
+            summary: "".to_string(),
+            url: "".to_string(),
+            action: Some(ProposalActionRequest::Batch(batch)),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Step 3: Verify results.
+
+    // Step 3.1: Proposal executed successfully.
+    assert!(
+        proposal_info.executed_timestamp_seconds > 0,
+        "{:#?}",
+        proposal_info,
+    );
+    assert_eq!(proposal_info.failure_reason, None, "{:#?}", proposal_info,);
+
+    // Step 3.2: New canister IDs (in success_value).
+    let batch_ok = match proposal_info.success_value {
+        Some(SuccessfulProposalExecutionValue::Batch(ok)) => ok,
+        wrong => panic!("Expected Batch success_value, got: {wrong:#?}"),
+    };
+    assert_eq!(batch_ok.sub_results.len(), 2, "{batch_ok:#?}");
+    let new_canister_ids = batch_ok
+        .sub_results
+        .into_iter()
+        .map(|sub_result| {
+            // Unwrap sub_result.
+            let sub_result = match sub_result.unwrap() {
+                SuccessfulProposalExecutionValue::CreateCanisterAndInstallCode(ok) => ok,
+                wrong => {
+                    panic!("Sub-result 0: expected CreateCanisterAndInstallCode, got {wrong:#?}")
+                }
+            };
+
+            sub_result.canister_id.unwrap()
+        })
+        .collect::<Vec<_>>();
+    let canister_id_a = new_canister_ids[0];
+    let canister_id_b = new_canister_ids[1];
+    assert_ne!(
+        canister_id_a, canister_id_b,
+        "Both sub-actions must produce distinct canister IDs"
+    );
+
+    // Step 3.3: Canisters created in specified subnet.
+    for (i, canister_id) in new_canister_ids.iter().enumerate() {
+        let canister_subnet = pocket_ic
+            .get_subnet(Principal::from(*canister_id))
+            .await
+            .unwrap();
+
+        assert_eq!(PrincipalId::from(canister_subnet), host_subnet_id, "{i}");
+    }
+
+    // Step 3.4: Each canister has the expected WASM installed.
+    for (i, (canister_id, expected_module_hash)) in
+        new_canister_ids.iter().zip(hashes.iter()).enumerate()
+    {
+        // Observe module hash.
+        let controller = Principal::from(PrincipalId::from(ROOT_CANISTER_ID));
+        let observed_module_hash = pocket_ic
+            .canister_status(Principal::from(*canister_id), Some(controller))
+            .await
+            .unwrap()
+            .module_hash
+            .unwrap();
+
+        assert_eq!(observed_module_hash, *expected_module_hash, "{i}");
+    }
+}

--- a/rs/nervous_system/integration_tests/tests/batch_proposal.rs
+++ b/rs/nervous_system/integration_tests/tests/batch_proposal.rs
@@ -28,6 +28,8 @@ async fn test_batch_of_two_create_canister_and_install_code_proposals() {
     // Step 1.2: Install NNS.
     let mut nns_installer = NnsInstaller::default();
     nns_installer.with_current_nns_canister_versions();
+    // Required to enable the Batch proposal feature flag.
+    nns_installer.with_test_governance_canister();
     nns_installer.install(&pocket_ic).await;
 
     // Step 2: Call the code under test.

--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -2069,6 +2069,7 @@ pub struct ProposalInfo {
 pub enum SuccessfulProposalExecutionValue {
     CreateCanisterAndInstallCode(CreateCanisterAndInstallCodeOk),
     TakeCanisterSnapshot(TakeCanisterSnapshotOk),
+    Batch(BatchOk),
 }
 
 /// The result of a successful CreateCanisterAndInstallCode proposal execution.
@@ -2083,6 +2084,14 @@ pub struct TakeCanisterSnapshotOk {
     pub snapshot_id: Vec<u8>,
 }
 
+/// The result of successfully executing a Batch proposal.
+/// Each element corresponds to the same-indexed sub-action in the batch.
+/// Sub-actions that produce no value have `None`.
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Clone, PartialEq, Debug)]
+pub struct BatchOk {
+    pub sub_results: Vec<Option<SuccessfulProposalExecutionValue>>,
+}
+
 impl From<CreateCanisterAndInstallCodeOk> for SuccessfulProposalExecutionValue {
     fn from(ok: CreateCanisterAndInstallCodeOk) -> Self {
         Self::CreateCanisterAndInstallCode(ok)
@@ -2092,6 +2101,12 @@ impl From<CreateCanisterAndInstallCodeOk> for SuccessfulProposalExecutionValue {
 impl From<TakeCanisterSnapshotOk> for SuccessfulProposalExecutionValue {
     fn from(ok: TakeCanisterSnapshotOk) -> Self {
         Self::TakeCanisterSnapshot(ok)
+    }
+}
+
+impl From<BatchOk> for SuccessfulProposalExecutionValue {
+    fn from(ok: BatchOk) -> Self {
+        Self::Batch(ok)
     }
 }
 

--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -2931,13 +2931,12 @@ pub struct Batch {
 }
 
 /// Take multiple actions, sequentially, and stop if any step fails.
-/// 
+///
 /// Topic: All actions must have the same topic. This has the same topic
 /// as the constituents.
 #[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Clone, PartialEq, Debug)]
 pub struct BatchRequest {
     pub actions: Option<Vec<ProposalActionRequest>>,
-
     // A couple of ideas for possible future enhancements (no promises though):
     //
     //   1. Let user choose a different behavior on error. Currently,

--- a/rs/nns/governance/api/src/types.rs
+++ b/rs/nns/governance/api/src/types.rs
@@ -690,6 +690,8 @@ pub mod proposal {
         LoadCanisterSnapshot(super::LoadCanisterSnapshot),
         /// Create a canister in a (possibly non-NNS) subnet and install code into it.
         CreateCanisterAndInstallCode(super::CreateCanisterAndInstallCode),
+        /// Multiple actions. Executed sequentially. Stops on first failure.
+        Batch(super::Batch),
     }
 }
 /// Empty message to use in oneof fields that represent empty
@@ -1451,6 +1453,7 @@ pub enum ProposalActionRequest {
     TakeCanisterSnapshot(TakeCanisterSnapshot),
     LoadCanisterSnapshot(LoadCanisterSnapshot),
     CreateCanisterAndInstallCode(CreateCanisterAndInstallCodeRequest),
+    Batch(BatchRequest),
 }
 
 #[derive(
@@ -2917,6 +2920,34 @@ pub struct CreateCanisterAndInstallCodeRequest {
     /// The argument to pass to the canister's install handler.
     #[serde(deserialize_with = "ic_utils::deserialize::deserialize_option_blob")]
     pub install_arg: Option<Vec<u8>>,
+}
+
+/// Analogous to BatchRequest, but used in responses.
+#[derive(
+    candid::CandidType, candid::Deserialize, serde::Serialize, Clone, PartialEq, Debug, Default,
+)]
+pub struct Batch {
+    pub actions: Option<Vec<proposal::Action>>,
+}
+
+/// Take multiple actions, sequentially, and stop if any step fails.
+/// 
+/// Topic: All actions must have the same topic. This has the same topic
+/// as the constituents.
+#[derive(candid::CandidType, candid::Deserialize, serde::Serialize, Clone, PartialEq, Debug)]
+pub struct BatchRequest {
+    pub actions: Option<Vec<ProposalActionRequest>>,
+
+    // A couple of ideas for possible future enhancements (no promises though):
+    //
+    //   1. Let user choose a different behavior on error. Currently,
+    //      we support "just stop", but you can imagine people might
+    //      want "keep going".
+    //
+    //   2. Let user choose parallel execution. Currently, we only
+    //      support sequential.
+    //
+    // Each of these would probably be involve adding an variant/enum field.
 }
 
 /// This represents the whole NNS governance system. It contains all

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -25,6 +25,7 @@ type Action = variant {
   TakeCanisterSnapshot : TakeCanisterSnapshot;
   LoadCanisterSnapshot : LoadCanisterSnapshot;
   CreateCanisterAndInstallCode : CreateCanisterAndInstallCode;
+  Batch : Batch;
 };
 
 type AddHotKey = record {
@@ -1083,6 +1084,15 @@ type ProposalActionRequest = variant {
   TakeCanisterSnapshot : TakeCanisterSnapshot;
   LoadCanisterSnapshot : LoadCanisterSnapshot;
   CreateCanisterAndInstallCode : CreateCanisterAndInstallCodeRequest;
+  Batch : BatchRequest;
+};
+
+type Batch = record {
+  actions : opt vec Action;
+};
+
+type BatchRequest = record {
+  actions : opt vec ProposalActionRequest;
 };
 
 // Creates a rented subnet from a rental request (in the Subnet Rental

--- a/rs/nns/governance/canister/governance.did
+++ b/rs/nns/governance/canister/governance.did
@@ -256,9 +256,14 @@ type TakeCanisterSnapshotOk = record {
   snapshot_id : blob;
 };
 
+type BatchOk = record {
+  sub_results : vec opt SuccessfulProposalExecutionValue;
+};
+
 type SuccessfulProposalExecutionValue = variant {
   CreateCanisterAndInstallCode : CreateCanisterAndInstallCodeOk;
   TakeCanisterSnapshot : TakeCanisterSnapshotOk;
+  Batch : BatchOk;
 };
 
 type CreateServiceNervousSystem = record {

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -1281,6 +1281,7 @@ message SuccessfulProposalExecutionValue {
   oneof proposal_type {
     CreateCanisterAndInstallCodeOk create_canister_and_install_code = 1;
     TakeCanisterSnapshotOk take_canister_snapshot = 2;
+    BatchOk batch = 3;
   }
 }
 
@@ -1290,6 +1291,14 @@ message CreateCanisterAndInstallCodeOk {
 
 message TakeCanisterSnapshotOk {
   bytes snapshot_id = 1;
+}
+
+// The result of successfully executing a Batch proposal.
+// Each element corresponds to the same-indexed sub-action in the batch.
+// Sub-actions that produce no value have an empty SuccessfulProposalExecutionValue
+// (i.e. proposal_type is not set).
+message BatchOk {
+  repeated SuccessfulProposalExecutionValue sub_results = 1;
 }
 
 // This structure contains data for settling the Neurons' Fund participation in an SNS token swap.

--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -723,7 +723,26 @@ message Proposal {
     LoadCanisterSnapshot load_canister_snapshot = 33;
     // Create a canister in a (possibly non-NNS) subnet and install code into it.
     CreateCanisterAndInstallCode create_canister_and_install_code = 34;
+    // Execute multiple proposal actions sequentially. Stops at first failure.
+    Batch batch = 35;
   }
+}
+
+// Multiple actions to execute sequentially. Stop on first failure.
+//
+// No recursion, i.e. Batch cannot contain batch.
+//
+// # Topic
+//
+// All constituent actions must have the same topic.
+//
+// This has the topic of its constituents.
+message Batch {
+  // The steps to take.
+  // Proposal includes some fields that are superfluous in this context
+  // (title, summary, etc). The only part we use here is the `action` oneof.
+  // The others will be left blank.
+  repeated Proposal actions = 1;
 }
 
 // Take a canister snapshot.

--- a/rs/nns/governance/src/canister_state.rs
+++ b/rs/nns/governance/src/canister_state.rs
@@ -1,7 +1,5 @@
-use crate::{
-    governance::{Environment, Governance, HeapGrowthPotential, RandomnessGenerator, RngError},
-    pb::v1::{GovernanceError, governance_error::ErrorType},
-    proposals::execute_nns_function::ValidExecuteNnsFunction,
+use crate::governance::{
+    Environment, Governance, HeapGrowthPotential, RandomnessGenerator, RngError,
 };
 
 use async_trait::async_trait;
@@ -11,7 +9,6 @@ use ic_nervous_system_canisters::ledger::IcpLedgerCanister;
 use ic_nervous_system_runtime::CdkRuntime;
 use ic_nervous_system_runtime::Runtime;
 use ic_nervous_system_time_helpers::now_seconds;
-use ic_nns_common::types::ProposalId;
 use ic_nns_constants::LEDGER_CANISTER_ID;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -181,60 +178,6 @@ impl Environment for CanisterEnv {
     #[cfg(any(test, feature = "test"))]
     fn set_time_warp(&self, new_time_warp: crate::governance::TimeWarp) {
         *self.time_warp.write().unwrap() = new_time_warp;
-    }
-
-    fn execute_nns_function(
-        &self,
-        proposal_id: u64,
-        execute_nns_function: &ValidExecuteNnsFunction,
-    ) -> Result<(), crate::pb::v1::GovernanceError> {
-        let reply = move || {
-            governance_mut().set_proposal_execution_status::<()>(proposal_id, Ok(vec![]));
-        };
-        let reject = move |(code, msg): (i32, String)| {
-            let mut msg = msg;
-            // There's no guarantee that the reject response is a string of character, and
-            // it can also be potential large. Propagating error information
-            // here is on a best-effort basis.
-            const MAX_REJECT_MSG_SIZE: usize = 10000;
-            if msg.len() > MAX_REJECT_MSG_SIZE {
-                msg = "(truncated error message) "
-                    .to_string()
-                    .chars()
-                    .chain(
-                        msg.char_indices()
-                            .take_while(|(pos, _)| *pos < MAX_REJECT_MSG_SIZE)
-                            .map(|(_, char)| char),
-                    )
-                    .collect();
-            }
-
-            governance_mut().set_proposal_execution_status::<()>(
-                proposal_id,
-                Err(GovernanceError::new_with_message(
-                    ErrorType::External,
-                    format!(
-                        "Error executing ExecuteNnsFunction proposal. Error Code: {code}. Rejection message: {msg}"
-                    ),
-                )),
-            );
-        };
-        let (canister_id, method) = execute_nns_function.nns_function.canister_and_function();
-        let proposal_timestamp_seconds = governance()
-            .get_proposal_data(ProposalId(proposal_id))
-            .map(|data| data.proposal_timestamp_seconds)
-            .ok_or(GovernanceError::new(ErrorType::PreconditionFailed))?;
-        let encoded_request = execute_nns_function
-            .re_encode_payload_to_target_canister(proposal_id, proposal_timestamp_seconds)?;
-
-        ic_cdk::futures::spawn_017_compat(async move {
-            match CdkRuntime::call_bytes_with_cleanup(canister_id, method, &encoded_request).await {
-                Ok(_) => reply(),
-                Err(e) => reject(e),
-            }
-        });
-
-        Ok(())
     }
 
     async fn call_canister_method(

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -440,7 +440,7 @@ pub struct Proposal {
     /// take.
     #[prost(
         oneof = "proposal::Action",
-        tags = "10, 12, 13, 14, 15, 16, 17, 18, 19, 21, 29, 22, 23, 24, 25, 26, 27, 28, 31, 32, 33, 34"
+        tags = "10, 12, 13, 14, 15, 16, 17, 18, 19, 21, 29, 22, 23, 24, 25, 26, 27, 28, 31, 32, 33, 34, 35"
     )]
     pub action: ::core::option::Option<proposal::Action>,
 }
@@ -559,7 +559,36 @@ pub mod proposal {
         /// Create a canister in a (possibly non-NNS) subnet and install code into it.
         #[prost(message, tag = "34")]
         CreateCanisterAndInstallCode(super::CreateCanisterAndInstallCode),
+        /// Execute multiple proposal actions sequentially. Stops at first failure.
+        #[prost(message, tag = "35")]
+        Batch(super::Batch),
     }
+}
+/// Multiple actions to execute sequentially. Stop on first failure.
+///
+/// No recursion, i.e. Batch cannot contain batch.
+///
+/// # Topic
+///
+/// All constituent actions must have the same topic.
+///
+/// This has the topic of its constituents.
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct Batch {
+    /// The steps to take.
+    /// Proposal includes some fields that are superfluous in this context
+    /// (title, summary, etc). The only part we use here is the `action` oneof.
+    /// The others will be left blank.
+    #[prost(message, repeated, tag = "1")]
+    pub actions: ::prost::alloc::vec::Vec<Proposal>,
 }
 /// Take a canister snapshot.
 #[derive(

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -1571,7 +1571,7 @@ pub struct ProposalData {
 pub struct SuccessfulProposalExecutionValue {
     #[prost(
         oneof = "successful_proposal_execution_value::ProposalType",
-        tags = "1, 2"
+        tags = "1, 2, 3"
     )]
     pub proposal_type: ::core::option::Option<successful_proposal_execution_value::ProposalType>,
 }
@@ -1591,6 +1591,8 @@ pub mod successful_proposal_execution_value {
         CreateCanisterAndInstallCode(super::CreateCanisterAndInstallCodeOk),
         #[prost(message, tag = "2")]
         TakeCanisterSnapshot(super::TakeCanisterSnapshotOk),
+        #[prost(message, tag = "3")]
+        Batch(super::BatchOk),
     }
 }
 #[derive(
@@ -1618,6 +1620,23 @@ pub struct CreateCanisterAndInstallCodeOk {
 pub struct TakeCanisterSnapshotOk {
     #[prost(bytes = "vec", tag = "1")]
     pub snapshot_id: ::prost::alloc::vec::Vec<u8>,
+}
+/// The result of successfully executing a Batch proposal.
+/// Each element corresponds to the same-indexed sub-action in the batch.
+/// Sub-actions that produce no value have an empty SuccessfulProposalExecutionValue
+/// (i.e. proposal_type is not set).
+#[derive(
+    candid::CandidType,
+    candid::Deserialize,
+    serde::Serialize,
+    comparable::Comparable,
+    Clone,
+    PartialEq,
+    ::prost::Message,
+)]
+pub struct BatchOk {
+    #[prost(message, repeated, tag = "1")]
+    pub sub_results: ::prost::alloc::vec::Vec<SuccessfulProposalExecutionValue>,
 }
 /// This structure contains data for settling the Neurons' Fund participation in an SNS token swap.
 #[derive(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -33,11 +33,11 @@ use crate::{
     pb::{
         proposal_conversions::{ProposalDisplayOptions, proposal_data_to_info},
         v1::{
-            self as pb, ArchivedMonthlyNodeProviderRewards, Ballot, CreateServiceNervousSystem,
-            Followees, GetNeuronsFundAuditInfoRequest, GetNeuronsFundAuditInfoResponse,
-            Governance as GovernanceProto, GovernanceError, KnownNeuron, ListKnownNeuronsResponse,
-            ManageNeuron, MonthlyNodeProviderRewards, Motion, NetworkEconomics, NeuronState,
-            NeuronsFundAuditInfo, NeuronsFundData,
+            self as pb, ArchivedMonthlyNodeProviderRewards, Ballot, BatchOk,
+            CreateServiceNervousSystem, Followees, GetNeuronsFundAuditInfoRequest,
+            GetNeuronsFundAuditInfoResponse, Governance as GovernanceProto, GovernanceError,
+            KnownNeuron, ListKnownNeuronsResponse, ManageNeuron, MonthlyNodeProviderRewards,
+            Motion, NetworkEconomics, NeuronState, NeuronsFundAuditInfo, NeuronsFundData,
             NeuronsFundParticipation as NeuronsFundParticipationPb,
             NeuronsFundSnapshot as NeuronsFundSnapshotPb, NnsFunction, NodeProvider, Proposal,
             ProposalData, ProposalRewardStatus, ProposalStatus, RestoreAgingSummary, RewardEvent,
@@ -66,6 +66,7 @@ use crate::{
             settle_neurons_fund_participation_response::{
                 self, NeuronsFundNeuron as NeuronsFundNeuronPb,
             },
+            successful_proposal_execution_value::ProposalType as SuccessfulProposalExecutionProposalType,
             swap_background_information,
         },
     },
@@ -4278,21 +4279,27 @@ impl Governance {
         proposal_id: u64,
         subactions: Vec<ValidProposalAction>,
     ) -> Result<Option<SuccessfulProposalExecutionValue>, GovernanceError> {
+        let mut sub_results = Vec::with_capacity(subactions.len());
         for (i, sub_action) in subactions.into_iter().enumerate() {
-            let sub_result = Box::pin(self.try_perform_action(proposal_id, sub_action)).await;
-
-            // DO NOT MERGE - Do NOT throw away Ok! Data is GOLD!!!
-            if let Err(e) = sub_result {
-                return Err(GovernanceError {
-                    error_message: format!(
-                        "Step {i} in batch proposal {proposal_id} failed: {}",
-                        e.error_message
-                    ),
-                    ..e
-                });
+            match Box::pin(self.try_perform_action(proposal_id, sub_action)).await {
+                Ok(value) => sub_results.push(value.unwrap_or_default()),
+                Err(e) => {
+                    return Err(GovernanceError {
+                        error_message: format!(
+                            "Step {i} in batch proposal {proposal_id} failed: {}",
+                            e.error_message
+                        ),
+                        ..e
+                    });
+                }
             }
         }
-        Ok(None)
+
+        Ok(Some(SuccessfulProposalExecutionValue {
+            proposal_type: Some(SuccessfulProposalExecutionProposalType::Batch(BatchOk {
+                sub_results,
+            })),
+        }))
     }
 
     fn try_perform_manage_network_economics(

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -31,18 +31,17 @@ use crate::{
         record_node_provider_rewards,
     },
     pb::{
-        self,
         proposal_conversions::{ProposalDisplayOptions, proposal_data_to_info},
         v1::{
-            ArchivedMonthlyNodeProviderRewards, Ballot, BlessAlternativeGuestOsVersion,
-            CreateServiceNervousSystem, Followees, GetNeuronsFundAuditInfoRequest,
-            GetNeuronsFundAuditInfoResponse, Governance as GovernanceProto, GovernanceError,
-            KnownNeuron, ListKnownNeuronsResponse, ManageNeuron, MonthlyNodeProviderRewards,
-            Motion, NetworkEconomics, NeuronState, NeuronsFundAuditInfo, NeuronsFundData,
+            self as pb, ArchivedMonthlyNodeProviderRewards, Ballot, CreateServiceNervousSystem,
+            Followees, GetNeuronsFundAuditInfoRequest, GetNeuronsFundAuditInfoResponse,
+            Governance as GovernanceProto, GovernanceError, KnownNeuron, ListKnownNeuronsResponse,
+            ManageNeuron, MonthlyNodeProviderRewards, Motion, NetworkEconomics, NeuronState,
+            NeuronsFundAuditInfo, NeuronsFundData,
             NeuronsFundParticipation as NeuronsFundParticipationPb,
             NeuronsFundSnapshot as NeuronsFundSnapshotPb, NnsFunction, NodeProvider, Proposal,
             ProposalData, ProposalRewardStatus, ProposalStatus, RestoreAgingSummary, RewardEvent,
-            RewardNodeProvider, RewardNodeProviders, SettleNeuronsFundParticipationRequest,
+            RewardNodeProvider, SettleNeuronsFundParticipationRequest,
             SettleNeuronsFundParticipationResponse, SuccessfulProposalExecutionValue, Tally, Topic,
             UpdateNodeProvider, Vote, VotingPowerEconomics, WaitForQuietState,
             archived_monthly_node_provider_rewards,
@@ -74,7 +73,6 @@ use crate::{
         ValidProposalAction,
         call_canister::{CallCanister, CallCanisterReply},
         execute_nns_function::{ValidExecuteNnsFunction, ValidNnsFunction},
-        fulfill_subnet_rental_request::ValidFulfillSubnetRentalRequest,
         sum_weighted_voting_power,
     },
     storage::{VOTING_POWER_SNAPSHOTS, with_voting_history_store, with_voting_history_store_mut},
@@ -545,6 +543,7 @@ impl Action {
             Action::TakeCanisterSnapshot(_) => "ACTION_TAKE_CANISTER_SNAPSHOT",
             Action::LoadCanisterSnapshot(_) => "ACTION_LOAD_CANISTER_SNAPSHOT",
             Action::CreateCanisterAndInstallCode(_) => "ACTION_CREATE_CANISTER_AND_INSTALL_CODE",
+            Action::Batch(_) => "ACTION_BATCH",
         }
     }
 }
@@ -1053,17 +1052,6 @@ pub trait Environment: Send + Sync {
     fn set_time_warp(&self, _new_time_warp: TimeWarp) {
         panic!("Not implemented.");
     }
-
-    /// Executes a `ValidExecuteNnsFunction`. The standard implementation is
-    /// expected to call out to another canister and eventually report the
-    /// result back
-    ///
-    /// See also call_candid_method.
-    fn execute_nns_function(
-        &self,
-        proposal_id: u64,
-        update: &ValidExecuteNnsFunction,
-    ) -> Result<(), GovernanceError>;
 
     /// Returns rough information as to how much the heap can grow.
     ///
@@ -3216,14 +3204,11 @@ impl Governance {
     /// On failure:
     ///   - `failure_reason`: set to the error (unless already executed).
     ///   - `failed_timestamp_seconds`: set to now (unless already executed).
-    pub(crate) fn set_proposal_execution_status<Reply>(
+    fn set_proposal_execution_status(
         &mut self,
         proposal_id: u64,
-        result: Result</* reply: */ Vec<u8>, GovernanceError>,
-    ) where
-        Reply: CallCanisterReply,
-        SuccessfulProposalExecutionValue: From<Reply>,
-    {
+        result: Result<Option<SuccessfulProposalExecutionValue>, GovernanceError>,
+    ) {
         let now_timestamp_seconds = self.env.now();
 
         // Fetch the ProposalData.
@@ -3256,8 +3241,7 @@ impl Governance {
             return;
         }
 
-        // Handle fail.
-        let encoded_reply: Vec<u8> = match result {
+        let success_value = match result {
             Ok(ok) => ok,
             Err(error) => {
                 println!(
@@ -3278,24 +3262,7 @@ impl Governance {
             LOG_PREFIX, proposal_id, title,
         );
         proposal_data.executed_timestamp_seconds = now_timestamp_seconds;
-
-        // Set success_value.
-        let reply = match Reply::try_decode(&encoded_reply) {
-            Ok(ok) => ok,
-            Err(err) => {
-                println!(
-                    "{}Failed to decode reply of successfully executed proposal: {} (title: {}). Error: {:?} reply: {}",
-                    LOG_PREFIX,
-                    proposal_id,
-                    title,
-                    err,
-                    humanize_blob(&encoded_reply, 200),
-                );
-
-                return;
-            }
-        };
-        proposal_data.success_value = reply.map(SuccessfulProposalExecutionValue::from);
+        proposal_data.success_value = success_value;
         if proposal_data.success_value.is_some() {
             println!(
                 "{}Proposal {} (title: {}): success_value set to {:?}.",
@@ -3815,7 +3782,7 @@ impl Governance {
                 // This should not happen as the proposal was validated when it was created. The
                 // only way it can happen is that some validation is added after the proposal was
                 // created.
-                self.set_proposal_execution_status::<()>(
+                self.set_proposal_execution_status(
                     proposal_id,
                     Err(GovernanceError::new_with_message(
                         ErrorType::PreconditionFailed,
@@ -3975,7 +3942,7 @@ impl Governance {
         }
     }
 
-    async fn reward_node_provider_helper(
+    async fn try_perform_reward_node_provider(
         &mut self,
         reward: &RewardNodeProvider,
     ) -> Result<(), GovernanceError> {
@@ -4024,11 +3991,6 @@ impl Governance {
     }
 
     /// Rewards a node provider.
-    async fn reward_node_provider(&mut self, pid: u64, reward: &RewardNodeProvider) {
-        let result = self.reward_node_provider_helper(reward).await;
-        self.set_proposal_execution_status::<()>(pid, result.map(|()| vec![]));
-    }
-
     /// Mint and transfer the specified Node Provider rewards
     async fn reward_node_providers(
         &mut self,
@@ -4037,7 +3999,7 @@ impl Governance {
         let mut result = Ok(());
 
         for reward in rewards {
-            let reward_result = self.reward_node_provider_helper(reward).await;
+            let reward_result = self.try_perform_reward_node_provider(reward).await;
             if reward_result.is_err() {
                 println!(
                     "Rewarding {:?} failed. Reason: {:}",
@@ -4049,21 +4011,6 @@ impl Governance {
         }
 
         result
-    }
-
-    /// Execute a RewardNodeProviders proposal
-    async fn reward_node_providers_from_proposal(
-        &mut self,
-        pid: u64,
-        reward_nps: RewardNodeProviders,
-    ) {
-        let result = if reward_nps.use_registry_derived_rewards == Some(true) {
-            self.mint_monthly_node_provider_rewards().await
-        } else {
-            self.reward_node_providers(&reward_nps.rewards).await
-        };
-
-        self.set_proposal_execution_status::<()>(pid, result.map(|()| vec![]));
     }
 
     /// Return `true` if `NODE_PROVIDER_REWARD_PERIOD_SECONDS` has passed since the last monthly
@@ -4200,148 +4147,155 @@ impl Governance {
     }
 
     async fn perform_action(&mut self, pid: u64, action: ValidProposalAction) {
+        let result = self.try_perform_action(pid, action).await;
+        self.set_proposal_execution_status(pid, result);
+    }
+
+    #[rustfmt::skip]
+    async fn try_perform_action(
+        &mut self,
+        proposal_id: u64,
+        action: ValidProposalAction,
+    ) -> Result<Option<SuccessfulProposalExecutionValue>, GovernanceError> {
         match action {
-            ValidProposalAction::ManageNeuron(mgmt) => {
-                // An adopted neuron management command is executed
-                // with the privileges of the controller of the
-                // neuron.
-                match mgmt.get_neuron_id_or_subaccount() {
-                    Ok(Some(ref managed_neuron_id)) => {
-                        if let Ok(controller) = self.with_neuron_by_neuron_id_or_subaccount(
-                            managed_neuron_id,
-                            |managed_neuron| managed_neuron.controller(),
-                        ) {
-                            let result = self.manage_neuron(&controller, &mgmt).await;
-                            match result.command {
-                                Some(manage_neuron_response::Command::Error(err)) => {
-                                    let err = GovernanceError::from(err);
-                                    self.set_proposal_execution_status::<()>(pid, Err(err))
-                                }
-                                _ => self.set_proposal_execution_status::<()>(pid, Ok(vec![])),
-                            };
-                        } else {
-                            self.set_proposal_execution_status::<()>(
-                                pid,
-                                Err(GovernanceError::new_with_message(
-                                    ErrorType::NotAuthorized,
-                                    "Couldn't execute manage neuron proposal.\
-                                        The neuron was not found.",
-                                )),
-                            );
-                        }
-                    }
-                    Ok(None) => {
-                        self.set_proposal_execution_status::<()>(
-                            pid,
-                            Err(GovernanceError::new_with_message(
-                                ErrorType::NotFound,
-                                "Couldn't execute manage neuron proposal.\
-                                          The neuron was not found.",
-                            )),
-                        );
-                    }
-                    Err(e) => self.set_proposal_execution_status::<()>(pid, Err(e)),
-                }
-            }
-            ValidProposalAction::ManageNetworkEconomics(network_economics) => {
-                self.perform_manage_network_economics(pid, network_economics);
-            }
-            // A motion is not executed, just recorded for posterity.
-            ValidProposalAction::Motion(_) => {
-                self.set_proposal_execution_status::<()>(pid, Ok(vec![]));
-            }
-            ValidProposalAction::ExecuteNnsFunction(m) => {
-                // This will eventually set the proposal execution
-                // status.
-                match self.env.execute_nns_function(pid, &m) {
-                    Ok(()) => {
-                        // The status will be set as a result of this
-                        // call. We don't set it now.
-                    }
-                    Err(_) => {
-                        self.set_proposal_execution_status::<()>(
-                            pid,
-                            Err(GovernanceError::new_with_message(
-                                ErrorType::External,
-                                "Couldn't execute NNS function through proposal",
-                            )),
-                        );
-                    }
-                }
-            }
-            ValidProposalAction::ApproveGenesisKyc(proposal) => {
-                let result = self.approve_genesis_kyc(&proposal.principals);
-                self.set_proposal_execution_status::<()>(pid, result.map(|()| vec![]));
-            }
-            ValidProposalAction::AddOrRemoveNodeProvider(add_or_remove_node_provider) => {
-                let result =
-                    add_or_remove_node_provider.execute(&mut self.heap_data.node_providers);
-                self.set_proposal_execution_status::<()>(pid, result.map(|()| vec![]));
-            }
-            ValidProposalAction::RewardNodeProvider(ref reward) => {
-                self.reward_node_provider(pid, reward).await;
-            }
-            ValidProposalAction::RewardNodeProviders(proposal) => {
-                self.reward_node_providers_from_proposal(pid, proposal)
-                    .await;
-            }
-            ValidProposalAction::RegisterKnownNeuron(register_request) => {
-                let result = register_request.execute(&mut self.neuron_store);
-                self.set_proposal_execution_status::<()>(pid, result.map(|()| vec![]));
-            }
-            ValidProposalAction::DeregisterKnownNeuron(deregister_request) => {
-                let result = deregister_request.execute(&mut self.neuron_store);
-                self.set_proposal_execution_status::<()>(pid, result.map(|()| vec![]));
-            }
-            ValidProposalAction::CreateServiceNervousSystem(ref create_service_nervous_system) => {
-                self.create_service_nervous_system(pid, create_service_nervous_system)
-                    .await;
-            }
-            ValidProposalAction::InstallCode(install_code) => {
-                self.perform_call_canister(pid, install_code).await;
-            }
-            ValidProposalAction::StopOrStartCanister(stop_or_start) => {
-                self.perform_call_canister(pid, stop_or_start).await;
-            }
-            ValidProposalAction::UpdateCanisterSettings(update_settings) => {
-                self.perform_call_canister(pid, update_settings).await;
-            }
-            ValidProposalAction::FulfillSubnetRentalRequest(fulfill_subnet_rental_request) => {
-                self.perform_fulfill_subnet_rental_request(pid, fulfill_subnet_rental_request)
-                    .await
-            }
-            ValidProposalAction::BlessAlternativeGuestOsVersion(
-                bless_alternative_guest_os_version,
-            ) => self.perform_bless_alternative_guest_os_version(
-                pid,
-                bless_alternative_guest_os_version,
-            ),
-            ValidProposalAction::TakeCanisterSnapshot(take_canister_snapshot) => {
-                self.perform_call_canister(pid, take_canister_snapshot)
-                    .await;
-            }
-            ValidProposalAction::LoadCanisterSnapshot(load_canister_snapshot) => {
-                self.perform_call_canister(pid, load_canister_snapshot)
-                    .await;
-            }
-            ValidProposalAction::CreateCanisterAndInstallCode(create_canister_and_install_code) => {
-                self.perform_call_canister(pid, create_canister_and_install_code)
-                    .await;
-            }
+            ValidProposalAction::Motion(_) => Ok(None),
+
+            // Execution consists of calling self.try_perform_${specific_action} (and maybe some result re-shaping).
+
+            // Sync.
+            ValidProposalAction::ApproveGenesisKyc(a)                => self.try_perform_approve_genesis_kyc(&a.principals).map(|()| None),
+            ValidProposalAction::ManageNetworkEconomics(a)           => self.try_perform_manage_network_economics(a).map(|()| None),
+            // Async.
+            ValidProposalAction::Batch(a)                            => self.try_perform_batch(proposal_id, a).await,
+            ValidProposalAction::CreateServiceNervousSystem(a)       => self.try_perform_create_service_nervous_system(proposal_id, a).await.map(|()| None),
+            ValidProposalAction::ExecuteNnsFunction(a)               => self.try_perform_execute_nns_function(proposal_id, a).await,
+            ValidProposalAction::ManageNeuron(a)                     => self.try_perform_manage_neuron(a).await,
+            ValidProposalAction::RewardNodeProvider(a)               => self.try_perform_reward_node_provider(&a).await.map(|()| None),
+            ValidProposalAction::RewardNodeProviders(a)              => self.try_perform_reward_node_providers(a).await,
+
+            // These do not require (all of) Governance, but maybe just one (sub)field in Governance.
+            ValidProposalAction::AddOrRemoveNodeProvider(a)          => a.execute(&mut self.heap_data.node_providers).map(|()| None),
+            ValidProposalAction::BlessAlternativeGuestOsVersion(a)   => a.execute().map(|()| None),
+            ValidProposalAction::DeregisterKnownNeuron(a)            => a.execute(&mut self.neuron_store).map(|()| None),
+            ValidProposalAction::FulfillSubnetRentalRequest(a)       => a.execute(ProposalId { id: proposal_id }, &self.env).await.map(|()| None),
+            ValidProposalAction::RegisterKnownNeuron(a)              => a.execute(&mut self.neuron_store).map(|()| None),
+
+            ValidProposalAction::CreateCanisterAndInstallCode(a)     => self.try_call_canister(proposal_id, a).await,
+            ValidProposalAction::InstallCode(a)                      => self.try_call_canister(proposal_id, a).await,
+            ValidProposalAction::LoadCanisterSnapshot(a)             => self.try_call_canister(proposal_id, a).await,
+            ValidProposalAction::StopOrStartCanister(a)              => self.try_call_canister(proposal_id, a).await,
+            ValidProposalAction::TakeCanisterSnapshot(a)             => self.try_call_canister(proposal_id, a).await,
+            ValidProposalAction::UpdateCanisterSettings(a)           => self.try_call_canister(proposal_id, a).await,
         }
     }
 
-    fn perform_manage_network_economics(
+    async fn try_perform_manage_neuron(
         &mut self,
-        proposal_id: u64,
-        proposed_network_economics: NetworkEconomics,
-    ) {
-        let result = self.perform_manage_network_economics_impl(proposed_network_economics);
-        self.set_proposal_execution_status::<()>(proposal_id, result.map(|()| vec![]));
+        manage_neuron: Box<ManageNeuron>,
+    ) -> Result<Option<SuccessfulProposalExecutionValue>, GovernanceError> {
+        // Get the target neuron's controller. This will be passed to manage_neuron
+        // (where the main implementation of the canister's method of the same name
+        // lives). This way, a ManageNeuron proposal has all the same powers over
+        // the neuron as its controller.
+        let Some(target_neuron_id) = manage_neuron.get_neuron_id_or_subaccount()? else {
+            return Err(GovernanceError::new_with_message(
+                ErrorType::NotFound,
+                "Couldn't execute manage neuron proposal. The neuron was not found.",
+            ));
+        };
+        let controller = self
+            .with_neuron_by_neuron_id_or_subaccount(&target_neuron_id, |n| n.controller())
+            .map_err(|_| {
+                GovernanceError::new_with_message(
+                    ErrorType::NotFound,
+                    "Couldn't execute manage neuron proposal. \
+                    The neuron was not found.",
+                )
+            })?;
+
+        // Apply mutation(s) to the target neuron.
+        let result = self.manage_neuron(&controller, &manage_neuron).await;
+
+        // Reshape result so that it has the same type as try_perform_action.
+        match result.command {
+            Some(manage_neuron_response::Command::Error(err)) => Err(GovernanceError::from(err)),
+            _ => Ok(None),
+        }
     }
 
-    /// Only call this from perform_manage_network_economics.
-    fn perform_manage_network_economics_impl(
+    async fn try_perform_execute_nns_function(
+        &mut self,
+        proposal_id: u64,
+        execute_nns_function: ValidExecuteNnsFunction,
+    ) -> Result<Option<SuccessfulProposalExecutionValue>, GovernanceError> {
+        // Enrich the request with additional information.
+        let proposal_timestamp_seconds = self
+            .get_proposal_data(ProposalId { id: proposal_id })
+            .map(|d| d.proposal_timestamp_seconds)
+            .ok_or_else(|| GovernanceError::new(ErrorType::PreconditionFailed))?;
+        let encoded_request = execute_nns_function
+            .re_encode_payload_to_target_canister(proposal_id, proposal_timestamp_seconds)?;
+
+        // Call the canister.
+        let (canister_id, method) = execute_nns_function.nns_function.canister_and_function();
+        let result = self
+            .env
+            .call_canister_method(canister_id, method, encoded_request)
+            .await;
+
+        // Reshape the result so that it is of the same type as the return value
+        // of try_perform_action.
+        result
+            .map(|_throw_away_reply| None)
+            .map_err(|(code, message)| {
+                GovernanceError::new_with_message(
+                    ErrorType::External,
+                    format!(
+                        "Error executing ExecuteNnsFunction proposal {proposal_id}. \
+                         Rejection code: {code:?}. Message: {message}"
+                    ),
+                )
+            })
+    }
+
+    async fn try_perform_reward_node_providers(
+        &mut self,
+        reward_node_providers: pb::RewardNodeProviders,
+    ) -> Result<Option<SuccessfulProposalExecutionValue>, GovernanceError> {
+        if reward_node_providers.use_registry_derived_rewards == Some(true) {
+            self.mint_monthly_node_provider_rewards()
+                .await
+                .map(|()| None)
+        } else {
+            self.reward_node_providers(&reward_node_providers.rewards)
+                .await
+                .map(|()| None)
+        }
+    }
+
+    async fn try_perform_batch(
+        &mut self,
+        proposal_id: u64,
+        subactions: Vec<ValidProposalAction>,
+    ) -> Result<Option<SuccessfulProposalExecutionValue>, GovernanceError> {
+        for (i, sub_action) in subactions.into_iter().enumerate() {
+            let sub_result = Box::pin(self.try_perform_action(proposal_id, sub_action)).await;
+
+            // DO NOT MERGE - Do NOT throw away Ok! Data is GOLD!!!
+            if let Err(e) = sub_result {
+                return Err(GovernanceError {
+                    error_message: format!(
+                        "Step {i} in batch proposal {proposal_id} failed: {}",
+                        e.error_message
+                    ),
+                    ..e
+                });
+            }
+        }
+        Ok(None)
+    }
+
+    fn try_perform_manage_network_economics(
         &mut self,
         proposed_network_economics: NetworkEconomics,
     ) -> Result<(), GovernanceError> {
@@ -4363,53 +4317,53 @@ impl Governance {
         Ok(())
     }
 
-    async fn perform_fulfill_subnet_rental_request(
+    /// Sends request, and decodes reply.
+    async fn try_call_canister<Request>(
         &mut self,
         proposal_id: u64,
-        fulfill_subnet_rental_request: ValidFulfillSubnetRentalRequest,
-    ) {
-        let result = fulfill_subnet_rental_request
-            .execute(ProposalId { id: proposal_id }, &self.env)
-            .await;
-        self.set_proposal_execution_status::<()>(proposal_id, result.map(|()| vec![]));
-    }
-
-    fn perform_bless_alternative_guest_os_version(
-        &mut self,
-        proposal_id: u64,
-        bless_alternative_guest_os_version: BlessAlternativeGuestOsVersion,
-    ) {
-        let result = bless_alternative_guest_os_version.execute();
-        self.set_proposal_execution_status::<()>(proposal_id, result.map(|()| vec![]));
-    }
-
-    /// Sends request, decodes reply, and sets proposal execution status (this last part was
-    /// added later in Mar, 2026).
-    async fn perform_call_canister<Request>(&mut self, proposal_id: u64, request: Request)
+        request: Request,
+    ) -> Result<Option<SuccessfulProposalExecutionValue>, GovernanceError>
     where
         Request: CallCanister,
         SuccessfulProposalExecutionValue: From<Request::Reply>,
     {
-        let result: Result<Vec<u8>, GovernanceError> = async {
-            let (canister_id, function) = request.canister_and_function()?;
-            let payload = request.payload()?;
+        let (canister_id, function) = request.canister_and_function()?;
+        let payload = request.payload()?;
+        let encoded_reply = self
+            .env
+            .call_canister_method(canister_id, function, payload)
+            .await
+            .map_err(|(code, message)| {
+                GovernanceError::new_with_message(
+                    ErrorType::External,
+                    format!(
+                        "Error calling external canister for proposal {proposal_id}. \
+                        Rejection code: {code:?} message: {message}"
+                    ),
+                )
+            })?;
 
-            self.env
-                .call_canister_method(canister_id, function, payload)
-                .await
-                .map_err(|(code, message)| {
-                    GovernanceError::new_with_message(
-                        ErrorType::External,
-                        format!(
-                            "Error calling external canister for proposal {proposal_id}. \
-                            Rejection code: {code:?} message: {message}"
-                        ),
-                    )
-                })
-        }
-        .await;
+        // Decode reply.
+        let reply: Option<_ /* Reply */> = match Request::Reply::try_decode(&encoded_reply) {
+            Ok(ok) => ok,
+            Err(err) => {
+                println!(
+                    "{}ERROR: Failed to decode reply of successfully executed proposal {}. \
+                    Error: {:?} reply: {}",
+                    LOG_PREFIX,
+                    proposal_id,
+                    err,
+                    humanize_blob(&encoded_reply, 200),
+                );
 
-        self.set_proposal_execution_status::<Request::Reply>(proposal_id, result);
+                // It might seem surprising that we return Ok in this case, but the
+                // reason for this is that the primary desired effect of the proposal
+                // has most likely taken place, because the canister did not reject.
+                return Ok(None);
+            }
+        };
+
+        Ok(reply.map(SuccessfulProposalExecutionValue::from))
     }
 
     fn set_sns_token_swap_lifecycle_to_open(proposal_data: &mut ProposalData) {
@@ -4433,21 +4387,10 @@ impl Governance {
         }
     }
 
-    async fn create_service_nervous_system(
+    async fn try_perform_create_service_nervous_system(
         &mut self,
         proposal_id: u64,
-        create_service_nervous_system: &CreateServiceNervousSystem,
-    ) {
-        let result = self
-            .do_create_service_nervous_system(proposal_id, create_service_nervous_system)
-            .await;
-        self.set_proposal_execution_status::<()>(proposal_id, result.map(|()| vec![]));
-    }
-
-    async fn do_create_service_nervous_system(
-        &mut self,
-        proposal_id: u64,
-        create_service_nervous_system: &CreateServiceNervousSystem,
+        create_service_nervous_system: CreateServiceNervousSystem,
     ) -> Result<(), GovernanceError> {
         // Get the current time of proposal execution.
         let current_timestamp_seconds = self.env.now();
@@ -4466,8 +4409,10 @@ impl Governance {
                 let (
                     initial_neurons_fund_participation_snapshot,
                     neurons_fund_participation_constraints,
-                ) = self
-                    .draw_maturity_from_neurons_fund(&proposal_id, create_service_nervous_system)?;
+                ) = self.draw_maturity_from_neurons_fund(
+                    &proposal_id,
+                    &create_service_nervous_system,
+                )?;
                 (
                     initial_neurons_fund_participation_snapshot,
                     Some(neurons_fund_participation_constraints),
@@ -4627,7 +4572,7 @@ impl Governance {
 
     /// Mark all Neurons controlled by the given principals as having passed
     /// KYC verification
-    pub fn approve_genesis_kyc(
+    pub fn try_perform_approve_genesis_kyc(
         &mut self,
         principals: &[PrincipalId],
     ) -> Result<(), GovernanceError> {
@@ -7745,8 +7690,8 @@ impl Governance {
 
         Ok(MonthlyNodeProviderRewards {
             timestamp: now,
-            start_date: Some(pb::v1::DateUtc::try_from(start_date).expect("from date exists")),
-            end_date: Some(pb::v1::DateUtc::try_from(end_date).expect("to date exists")),
+            start_date: Some(pb::DateUtc::try_from(start_date).expect("from date exists")),
+            end_date: Some(pb::DateUtc::try_from(end_date).expect("to date exists")),
             rewards,
             xdr_conversion_rate: Some(xdr_conversion_rate.into()),
             minimum_xdr_permyriad_per_icp: Some(minimum_xdr_permyriad_per_icp),

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -4965,6 +4965,12 @@ impl Governance {
             ValidProposalAction::CreateCanisterAndInstallCode(create_canister_and_install_code) => {
                 create_canister_and_install_code.validate()
             }
+            ValidProposalAction::Batch(actions) => {
+                for action in actions {
+                    self.validate_proposal_action(action)?;
+                }
+                Ok(())
+            }
         }
     }
 

--- a/rs/nns/governance/src/lib.rs
+++ b/rs/nns/governance/src/lib.rs
@@ -213,6 +213,9 @@ thread_local! {
     static ENABLE_CREATE_CANISTER_AND_INSTALL_CODE_PROPOSALS: Cell<bool>
         = const { Cell::new(true) };
 
+    static ENABLE_BATCH_PROPOSALS: Cell<bool>
+        = const { Cell::new(cfg!(feature = "test")) };
+
     static ENABLE_SUBNET_SPLITTING_PROPOSALS: Cell<bool>
         = const { Cell::new(false) };
 
@@ -283,6 +286,20 @@ pub fn temporarily_enable_neuron_follow_restrictions() -> Temporary {
 #[cfg(any(test, feature = "canbench-rs", feature = "test"))]
 pub fn temporarily_disable_neuron_follow_restrictions() -> Temporary {
     Temporary::new(&ENABLE_NEURON_FOLLOW_RESTRICTIONS, false)
+}
+
+pub fn are_batch_proposals_enabled() -> bool {
+    ENABLE_BATCH_PROPOSALS.get()
+}
+
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_enable_batch_proposals() -> Temporary {
+    Temporary::new(&ENABLE_BATCH_PROPOSALS, true)
+}
+
+#[cfg(any(test, feature = "canbench-rs", feature = "test"))]
+pub fn temporarily_disable_batch_proposals() -> Temporary {
+    Temporary::new(&ENABLE_BATCH_PROPOSALS, false)
 }
 
 pub fn are_create_canister_and_install_code_proposals_enabled() -> bool {

--- a/rs/nns/governance/src/pb/conversions/mod.rs
+++ b/rs/nns/governance/src/pb/conversions/mod.rs
@@ -468,6 +468,7 @@ impl From<api::proposal::Action> for pb::proposal::Action {
             api::proposal::Action::CreateCanisterAndInstallCode(v) => {
                 pb::proposal::Action::CreateCanisterAndInstallCode(v.into())
             }
+            api::proposal::Action::Batch(v) => pb::proposal::Action::Batch(v.into()),
         }
     }
 }
@@ -529,6 +530,39 @@ impl From<api::ProposalActionRequest> for pb::proposal::Action {
             api::ProposalActionRequest::CreateCanisterAndInstallCode(v) => {
                 pb::proposal::Action::CreateCanisterAndInstallCode(v.into())
             }
+            api::ProposalActionRequest::Batch(v) => pb::proposal::Action::Batch(v.into()),
+        }
+    }
+}
+
+impl From<api::Batch> for pb::Batch {
+    fn from(item: api::Batch) -> Self {
+        Self {
+            actions: item
+                .actions
+                .unwrap_or_default()
+                .into_iter()
+                .map(|action| pb::Proposal {
+                    action: Some(action.into()),
+                    ..Default::default()
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<api::BatchRequest> for pb::Batch {
+    fn from(item: api::BatchRequest) -> Self {
+        Self {
+            actions: item
+                .actions
+                .unwrap_or_default()
+                .into_iter()
+                .map(|action| pb::Proposal {
+                    action: Some(action.into()),
+                    ..Default::default()
+                })
+                .collect(),
         }
     }
 }

--- a/rs/nns/governance/src/pb/conversions/mod.rs
+++ b/rs/nns/governance/src/pb/conversions/mod.rs
@@ -1814,9 +1814,7 @@ impl From<pb::SuccessfulProposalExecutionValue> for Option<api::SuccessfulPropos
             ProposalType::TakeCanisterSnapshot(ok) => {
                 api::SuccessfulProposalExecutionValue::TakeCanisterSnapshot(ok.into())
             }
-            ProposalType::Batch(ok) => {
-                api::SuccessfulProposalExecutionValue::Batch(ok.into())
-            }
+            ProposalType::Batch(ok) => api::SuccessfulProposalExecutionValue::Batch(ok.into()),
         };
 
         Some(result)

--- a/rs/nns/governance/src/pb/conversions/mod.rs
+++ b/rs/nns/governance/src/pb/conversions/mod.rs
@@ -1814,6 +1814,9 @@ impl From<pb::SuccessfulProposalExecutionValue> for Option<api::SuccessfulPropos
             ProposalType::TakeCanisterSnapshot(ok) => {
                 api::SuccessfulProposalExecutionValue::TakeCanisterSnapshot(ok.into())
             }
+            ProposalType::Batch(ok) => {
+                api::SuccessfulProposalExecutionValue::Batch(ok.into())
+            }
         };
 
         Some(result)
@@ -1824,6 +1827,18 @@ impl From<pb::CreateCanisterAndInstallCodeOk> for api::CreateCanisterAndInstallC
     fn from(item: pb::CreateCanisterAndInstallCodeOk) -> Self {
         Self {
             canister_id: item.canister_id,
+        }
+    }
+}
+
+impl From<pb::BatchOk> for api::BatchOk {
+    fn from(item: pb::BatchOk) -> Self {
+        Self {
+            sub_results: item
+                .sub_results
+                .into_iter()
+                .map(Option::<api::SuccessfulProposalExecutionValue>::from)
+                .collect(),
         }
     }
 }

--- a/rs/nns/governance/src/pb/proposal_conversions.rs
+++ b/rs/nns/governance/src/pb/proposal_conversions.rs
@@ -281,6 +281,15 @@ fn convert_action(
                 convert_create_canister_and_install_code(v),
             )
         }
+        pb::proposal::Action::Batch(v) => api::proposal::Action::Batch(api::Batch {
+            actions: Some(
+                v.actions
+                    .iter()
+                    .filter_map(|p| p.action.as_ref())
+                    .map(|a| convert_action(a, display_options))
+                    .collect(),
+            ),
+        }),
         pb::proposal::Action::InstallCode(v) => {
             api::proposal::Action::InstallCode(convert_install_code(v))
         }

--- a/rs/nns/governance/src/proposals/mod.rs
+++ b/rs/nns/governance/src/proposals/mod.rs
@@ -1,12 +1,13 @@
 use crate::{
     governance::{Environment, LOG_PREFIX},
     pb::v1::{
-        ApproveGenesisKyc, BlessAlternativeGuestOsVersion, CreateCanisterAndInstallCode,
+        ApproveGenesisKyc, Batch, BlessAlternativeGuestOsVersion, CreateCanisterAndInstallCode,
         CreateServiceNervousSystem, DeregisterKnownNeuron, GovernanceError, InstallCode,
         KnownNeuron, LoadCanisterSnapshot, ManageNeuron, Motion, NetworkEconomics, ProposalData,
-        RewardNodeProvider, RewardNodeProviders, SelfDescribingProposalAction, StopOrStartCanister,
-        TakeCanisterSnapshot, Topic, UpdateCanisterSettings, Vote, governance_error::ErrorType,
-        proposal::Action,
+        RewardNodeProvider, RewardNodeProviders, SelfDescribingProposalAction, SelfDescribingValue,
+        SelfDescribingValueArray, StopOrStartCanister, TakeCanisterSnapshot, Topic,
+        UpdateCanisterSettings, Vote, governance_error::ErrorType, proposal::Action,
+        self_describing_value,
     },
     proposals::{
         add_or_remove_node_provider::ValidAddOrRemoveNodeProvider,
@@ -64,6 +65,7 @@ pub(crate) enum ValidProposalAction {
     TakeCanisterSnapshot(TakeCanisterSnapshot),
     LoadCanisterSnapshot(LoadCanisterSnapshot),
     CreateCanisterAndInstallCode(CreateCanisterAndInstallCode),
+    Batch(Vec<ValidProposalAction>),
 }
 
 impl TryFrom<Option<Action>> for ValidProposalAction {
@@ -133,6 +135,7 @@ impl TryFrom<Option<Action>> for ValidProposalAction {
             Action::CreateCanisterAndInstallCode(create_canister_and_install_code) => Ok(
                 ValidProposalAction::CreateCanisterAndInstallCode(create_canister_and_install_code),
             ),
+            Action::Batch(batch) => try_into_valid_batch(batch).map(ValidProposalAction::Batch),
 
             // Obsolete actions
             Action::SetDefaultFollowees(_) => Err(GovernanceError::new_with_message(
@@ -149,6 +152,61 @@ impl TryFrom<Option<Action>> for ValidProposalAction {
             )),
         }
     }
+}
+
+fn try_into_valid_batch(batch: Batch) -> Result<Vec<ValidProposalAction>, GovernanceError> {
+    // Validate length.
+    if batch.actions.is_empty() {
+        return Err(GovernanceError::new_with_message(
+            ErrorType::InvalidProposal,
+            "Batch proposal must have at least one action",
+        ));
+    }
+    if batch.actions.len() > 100 {
+        return Err(GovernanceError::new_with_message(
+            ErrorType::InvalidProposal,
+            format!(
+                "Batch proposal may have at most 100 actions, but has {}",
+                batch.actions.len()
+            ),
+        ));
+    }
+
+    // Inspect that each element is compliant: nonempty, and not batch
+    // (no recursion). If so, convert it.
+    let mut result = Vec::with_capacity(batch.actions.len());
+    for (i, sub_proposal) in batch.actions.into_iter().enumerate() {
+        let sub_action = sub_proposal.action.ok_or_else(|| {
+            GovernanceError::new_with_message(
+                ErrorType::InvalidProposal,
+                format!("Action at index {i} in batch proposal is missing"),
+            )
+        })?;
+
+        // Disallow recursion. I.e. batch is not allowed to contain batch.
+        if matches!(sub_action, Action::Batch(_)) {
+            return Err(GovernanceError::new_with_message(
+                ErrorType::InvalidProposal,
+                "Nesting batch proposals is not allowed.",
+            ));
+        }
+
+        // (Try to) convert the current sub-action.
+        let valid = ValidProposalAction::try_from(Some(sub_action)).map_err(|e| {
+            GovernanceError::new_with_message(
+                ErrorType::InvalidProposal,
+                format!(
+                    "Action at index {i} in batch proposal is invalid: {}",
+                    e.error_message
+                ),
+            )
+        })?;
+
+        // Looks good; add the sub-action to the final result.
+        result.push(valid);
+    }
+
+    Ok(result)
 }
 
 impl ValidProposalAction {
@@ -186,6 +244,15 @@ impl ValidProposalAction {
             ValidProposalAction::CreateCanisterAndInstallCode(create_canister_and_install_code) => {
                 create_canister_and_install_code.valid_topic()?
             }
+            ValidProposalAction::Batch(actions) => actions
+                .first()
+                .ok_or_else(|| {
+                    GovernanceError::new_with_message(
+                        ErrorType::InvalidProposal,
+                        "Batch proposal must have at least one action",
+                    )
+                })?
+                .topic()?,
         };
         Ok(topic)
     }
@@ -288,8 +355,41 @@ impl ValidProposalAction {
             ValidProposalAction::RewardNodeProviders(reward_node_providers) => Ok(
                 SelfDescribingProposalAction::from(reward_node_providers.clone()),
             ),
+            ValidProposalAction::Batch(actions) => batch_to_self_describing(actions, env).await,
         }
     }
+}
+
+async fn batch_to_self_describing(
+    actions: &[ValidProposalAction],
+    env: Arc<dyn Environment>,
+) -> Result<SelfDescribingProposalAction, GovernanceError> {
+    let mut converted_actions = vec![];
+    for action in actions {
+        let action = Box::pin(action.to_self_describing(env.clone())).await?;
+        converted_actions.push(action.value.ok_or_else(|| {
+            // This wouldn't happen, because to_self_describing would never set it to
+            // None, but this is handled anyway.
+            GovernanceError::new_with_message(
+                ErrorType::External,
+                "Batch sub-action produced no self-describing value",
+            )
+        })?);
+    }
+
+    Ok(SelfDescribingProposalAction {
+        type_name: "Batch".to_string(),
+        type_description: "Multiple proposal actions. Executed sequentially. \
+            Stops at the first failure."
+            .to_string(),
+        value: Some(SelfDescribingValue {
+            value: Some(self_describing_value::Value::Array(
+                SelfDescribingValueArray {
+                    values: converted_actions,
+                },
+            )),
+        }),
+    })
 }
 
 const SNS_RELATED_CANISTER_IDS: [&CanisterId; 2] =

--- a/rs/nns/governance/src/proposals/mod.rs
+++ b/rs/nns/governance/src/proposals/mod.rs
@@ -1,4 +1,5 @@
 use crate::{
+    are_batch_proposals_enabled,
     governance::{Environment, LOG_PREFIX},
     pb::v1::{
         ApproveGenesisKyc, Batch, BlessAlternativeGuestOsVersion, CreateCanisterAndInstallCode,
@@ -155,6 +156,13 @@ impl TryFrom<Option<Action>> for ValidProposalAction {
 }
 
 fn try_into_valid_batch(batch: Batch) -> Result<Vec<ValidProposalAction>, GovernanceError> {
+    if !are_batch_proposals_enabled() {
+        return Err(GovernanceError::new_with_message(
+            ErrorType::InvalidProposal,
+            "Batch proposals are not enabled yet.",
+        ));
+    }
+
     // Validate length.
     if batch.actions.is_empty() {
         return Err(GovernanceError::new_with_message(

--- a/rs/nns/governance/src/test_utils.rs
+++ b/rs/nns/governance/src/test_utils.rs
@@ -4,7 +4,7 @@
 use crate::governance::RandomnessGenerator;
 use crate::{
     governance::{Environment, HeapGrowthPotential, RngError},
-    pb::v1::{GovernanceError, OpenSnsTokenSwap},
+    pb::v1::OpenSnsTokenSwap,
 };
 use async_trait::async_trait;
 use candid::{Decode, Encode};
@@ -272,14 +272,6 @@ impl Default for MockEnvironment {
 impl Environment for MockEnvironment {
     fn now(&self) -> u64 {
         *self.now.lock().unwrap()
-    }
-
-    fn execute_nns_function(
-        &self,
-        _proposal_id: u64,
-        _update: &crate::proposals::execute_nns_function::ValidExecuteNnsFunction,
-    ) -> Result<(), GovernanceError> {
-        Ok(())
     }
 
     fn heap_growth_potential(&self) -> HeapGrowthPotential {

--- a/rs/nns/governance/tests/degraded_mode.rs
+++ b/rs/nns/governance/tests/degraded_mode.rs
@@ -16,7 +16,7 @@ use ic_nns_governance::{
         Environment, Governance, HEAP_SIZE_SOFT_LIMIT_IN_WASM32_PAGES, HeapGrowthPotential,
     },
     pb::v1::{
-        GovernanceError, InstallCode, ManageNeuron, Motion, Proposal,
+        InstallCode, ManageNeuron, Motion, Proposal,
         governance_error::ErrorType,
         install_code::CanisterInstallMode,
         manage_neuron::{
@@ -25,7 +25,6 @@ use ic_nns_governance::{
         },
         proposal,
     },
-    proposals::execute_nns_function::ValidExecuteNnsFunction,
 };
 use ic_nns_governance_api::{
     self as api, ManageNeuronResponse, manage_neuron_response::Command as CommandResponse,
@@ -42,14 +41,6 @@ struct DegradedEnv {}
 impl Environment for DegradedEnv {
     fn now(&self) -> u64 {
         111000222
-    }
-
-    fn execute_nns_function(
-        &self,
-        _: u64,
-        _: &ValidExecuteNnsFunction,
-    ) -> Result<(), GovernanceError> {
-        unimplemented!()
     }
 
     fn heap_growth_potential(&self) -> HeapGrowthPotential {

--- a/rs/nns/governance/tests/fake.rs
+++ b/rs/nns/governance/tests/fake.rs
@@ -16,10 +16,9 @@ use ic_nns_constants::{
 use ic_nns_governance::{
     governance::{Environment, Governance, HeapGrowthPotential, RngError},
     pb::v1::{
-        GovernanceError, ManageNeuron, Motion, NetworkEconomics, Proposal, Vote, manage_neuron,
+        ManageNeuron, Motion, NetworkEconomics, Proposal, Vote, manage_neuron,
         manage_neuron::NeuronIdOrSubaccount, proposal,
     },
-    proposals::execute_nns_function::ValidExecuteNnsFunction,
 };
 use ic_nns_governance_api::Neuron;
 use ic_nns_governance_api::{ManageNeuronResponse, manage_neuron_response};
@@ -486,15 +485,6 @@ impl RandomnessGenerator for FakeDriver {
 impl Environment for FakeDriver {
     fn now(&self) -> u64 {
         self.state.try_lock().unwrap().now
-    }
-
-    fn execute_nns_function(
-        &self,
-        _proposal_id: u64,
-        _update: &ValidExecuteNnsFunction,
-    ) -> Result<(), GovernanceError> {
-        Ok(())
-        //panic!("unexpected call")
     }
 
     fn heap_growth_potential(&self) -> HeapGrowthPotential {

--- a/rs/nns/governance/tests/fixtures/environment_fixture.rs
+++ b/rs/nns/governance/tests/fixtures/environment_fixture.rs
@@ -3,11 +3,7 @@ use candid::{CandidType, Decode, Encode, Error};
 use ic_base_types::CanisterId;
 use ic_nervous_system_timers::test::{advance_time_for_timers, set_time_for_timers};
 use ic_nns_governance::governance::RandomnessGenerator;
-use ic_nns_governance::{
-    governance::{Environment, HeapGrowthPotential, RngError},
-    pb::v1::GovernanceError,
-    proposals::execute_nns_function::ValidExecuteNnsFunction,
-};
+use ic_nns_governance::governance::{Environment, HeapGrowthPotential, RngError};
 use ic_sns_root::GetSnsCanistersSummaryRequest;
 use ic_sns_swap::pb::v1::GetStateRequest;
 use ic_sns_wasm::pb::v1::{DeployNewSnsRequest, ListDeployedSnsesRequest};
@@ -154,14 +150,6 @@ impl EnvironmentFixture {
 impl Environment for EnvironmentFixture {
     fn now(&self) -> u64 {
         self.environment_fixture_state.try_lock().unwrap().now
-    }
-
-    fn execute_nns_function(
-        &self,
-        _proposal_id: u64,
-        _update: &ValidExecuteNnsFunction,
-    ) -> Result<(), GovernanceError> {
-        unimplemented!()
     }
 
     fn heap_growth_potential(&self) -> HeapGrowthPotential {

--- a/rs/nns/governance/tests/fixtures/mod.rs
+++ b/rs/nns/governance/tests/fixtures/mod.rs
@@ -33,7 +33,6 @@ use ic_nns_governance::{
         manage_neuron::{Command, Merge, MergeMaturity, NeuronIdOrSubaccount},
         proposal,
     },
-    proposals::execute_nns_function::ValidExecuteNnsFunction,
     storage::reset_stable_memory,
 };
 use ic_nns_governance_api::{
@@ -594,18 +593,6 @@ impl Environment for NNSFixture {
         self.nns_state.try_lock().unwrap().environment.now()
     }
 
-    fn execute_nns_function(
-        &self,
-        proposal_id: u64,
-        update: &ValidExecuteNnsFunction,
-    ) -> Result<(), GovernanceError> {
-        self.nns_state
-            .try_lock()
-            .unwrap()
-            .environment
-            .execute_nns_function(proposal_id, update)
-    }
-
     fn heap_growth_potential(&self) -> HeapGrowthPotential {
         self.nns_state
             .try_lock()
@@ -1017,14 +1004,6 @@ impl RandomnessGenerator for NNS {
 impl Environment for NNS {
     fn now(&self) -> u64 {
         self.fixture.now()
-    }
-
-    fn execute_nns_function(
-        &self,
-        proposal_id: u64,
-        update: &ValidExecuteNnsFunction,
-    ) -> Result<(), GovernanceError> {
-        self.fixture.execute_nns_function(proposal_id, update)
     }
 
     fn heap_growth_potential(&self) -> HeapGrowthPotential {

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -57,7 +57,7 @@ use ic_nns_governance::{
     governance_proto_builder::GovernanceProtoBuilder,
     is_mission_70_voting_rewards_enabled,
     pb::v1::{
-        AddOrRemoveNodeProvider, Ballot, BallotInfo, CreateServiceNervousSystem, Empty,
+        AddOrRemoveNodeProvider, Ballot, BallotInfo, Batch, CreateServiceNervousSystem, Empty,
         ExecuteNnsFunction, Followees, GovernanceError, IdealMatchedParticipationFunction,
         InstallCode, KnownNeuron, KnownNeuronData, ManageNeuron, MonthlyNodeProviderRewards,
         Motion, NetworkEconomics, NeuronType, NeuronsFundData, NeuronsFundEconomics,
@@ -14376,6 +14376,66 @@ async fn test_grandfathering() {
             .unwrap()
             .followees
             .contains(&NeuronId { id: 1 })
+    );
+}
+
+#[tokio::test]
+async fn test_batch_proposal_with_two_motions() {
+    let driver = fake::FakeDriver::default();
+    let mut gov = Governance::new(
+        fixture_for_following(),
+        driver.get_fake_env(),
+        driver.get_fake_ledger(),
+        driver.get_fake_cmc(),
+        driver.get_fake_randomness_generator(),
+    );
+
+    gov.make_proposal(
+        &NeuronId { id: 1 },
+        &principal(1),
+        &Proposal {
+            title: Some("Batch of two motions".to_string()),
+            summary: "test".to_string(),
+            action: Some(proposal::Action::Batch(Batch {
+                actions: vec![
+                    Proposal {
+                        action: Some(proposal::Action::Motion(Motion {
+                            motion_text: "First motion".to_string(),
+                        })),
+                        ..Default::default()
+                    },
+                    Proposal {
+                        action: Some(proposal::Action::Motion(Motion {
+                            motion_text: "Second motion".to_string(),
+                        })),
+                        ..Default::default()
+                    },
+                ],
+            })),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // Vote in the proposal.
+    for neuron_id in 5_u64..=8 {
+        fake::register_vote_assert_success(
+            &mut gov,
+            principal(neuron_id),
+            NeuronId { id: neuron_id },
+            ProposalId { id: 1 },
+            Vote::Yes,
+        );
+    }
+
+    gov.process_voting_state_machines().await;
+
+    assert_eq!(
+        ProposalStatus::Executed,
+        gov.get_proposal_data(ProposalId { id: 1 })
+            .unwrap()
+            .status()
     );
 }
 

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -89,7 +89,6 @@ use ic_nns_governance::{
         reward_node_provider::{RewardMode, RewardToAccount, RewardToNeuron},
         settle_neurons_fund_participation_request, swap_background_information,
     },
-    proposals::execute_nns_function::ValidExecuteNnsFunction,
 };
 use ic_nns_governance::{
     canister_state::{governance_mut, set_governance_for_tests},
@@ -4133,7 +4132,8 @@ fn test_approve_kyc() {
             .expect("Neuron not found")
     );
 
-    gov.approve_genesis_kyc(&[principal1, principal2]).unwrap();
+    gov.try_perform_approve_genesis_kyc(&[principal1, principal2])
+        .unwrap();
 
     assert!(
         gov.neuron_store
@@ -11116,14 +11116,6 @@ impl Environment for MockEnvironment<'_> {
 
     fn now(&self) -> u64 {
         DEFAULT_TEST_START_TIMESTAMP_SECONDS
-    }
-
-    fn execute_nns_function(
-        &self,
-        _proposal_id: u64,
-        _update: &ValidExecuteNnsFunction,
-    ) -> Result<(), GovernanceError> {
-        panic!("Unexpected call to Environment::execute_nns_function");
     }
 
     fn heap_growth_potential(&self) -> HeapGrowthPotential {


### PR DESCRIPTION
All sub-actions must have same topic.

Topic is inherited from sub-action(s).

# Implementation

To make this work, I (well, Claude, really) had to split `perform_action` into two separate steps:

1. `try_perform_action` (new), followed by
2. `set_proposal_execution_status` (existing)

This way, `perform_batch` can call `try_perform_action` for each sub-action, and NOT set the proposal's final execution status.

Furthermore, we also had to make sure that the implementation of every action (called by `try_perform_action`) did not try to set the proposal's execution status.

In particular, significant rework was needed for `ExecuteNnsFunction`. Such rework includes getting rid of `execute_nns_function` in the `Environment` trait. It was just a shitty version of `call_canister_method` anyway; therefore, deleting `execute_nns_function` is really not as bad as it sounds.

# References

Closes [NNS1-4296].

[NNS1-4296]: https://dfinity.atlassian.net/browse/NNS1-4296