### PR TITLE
chore: clean up orphaned StopCanisterCall

### DIFF
--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -4574,7 +4574,8 @@ impl ExecutionEnvironment {
     /// Removes `StopCanisterCall`s from `SubnetCallContextManager` that have no
     /// corresponding `StopCanisterContext` in the target canister's stop contexts.
     /// These can arise from a bug fixed in commit 52e7b89 where a `StopCanisterCall`
-    /// was pushed but never removed when the target canister was already stopped.
+    /// was pushed but never removed when the `stop_canister` call failed, e.g., because
+    /// the target canister was already stopped or the sender was not a controller.
     fn cleanup_orphaned_stop_canister_calls(
         &self,
         state: &mut ReplicatedState,

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -4580,25 +4580,25 @@ impl ExecutionEnvironment {
         state: &mut ReplicatedState,
         canister_states: &BTreeMap<CanisterId, Arc<CanisterState>>,
     ) {
+        // Build a set of all call IDs that have a matching StopCanisterContext.
+        let call_ids_with_context: BTreeSet<StopCanisterCallId> = canister_states
+            .values()
+            .flat_map(|canister| match canister.system_state.get_status() {
+                CanisterStatus::Stopping { stop_contexts, .. } => stop_contexts.as_slice(),
+                _ => &[],
+            })
+            .filter_map(|ctx| *ctx.call_id())
+            .collect();
+
         let orphaned: Vec<(StopCanisterCallId, CanisterId)> = state
             .metadata
             .subnet_call_context_manager
             .iter_stop_canister_calls()
             .filter_map(|(call_id, stop_canister_call)| {
-                let canister_id = stop_canister_call.effective_canister_id;
-                let has_context = match canister_states
-                    .get(&canister_id)
-                    .map(|c| c.system_state.get_status())
-                {
-                    Some(CanisterStatus::Stopping { stop_contexts, .. }) => stop_contexts
-                        .iter()
-                        .any(|ctx| ctx.call_id() == &Some(*call_id)),
-                    _ => false,
-                };
-                if has_context {
+                if call_ids_with_context.contains(call_id) {
                     None
                 } else {
-                    Some((*call_id, canister_id))
+                    Some((*call_id, stop_canister_call.effective_canister_id))
                 }
             })
             .collect();

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -4571,50 +4571,6 @@ impl ExecutionEnvironment {
         }
     }
 
-    /// Removes `StopCanisterCall`s from `SubnetCallContextManager` that have no
-    /// corresponding `StopCanisterContext` in the target canister's stop contexts.
-    /// These can arise from a bug fixed in commit 52e7b89 where a `StopCanisterCall`
-    /// was pushed but never removed when the `stop_canister` call failed, e.g., because
-    /// the target canister was already stopped or the sender was not a controller.
-    fn cleanup_orphaned_stop_canister_calls(
-        &self,
-        state: &mut ReplicatedState,
-        canister_states: &BTreeMap<CanisterId, Arc<CanisterState>>,
-    ) {
-        // Build a set of all call IDs that have a matching StopCanisterContext.
-        let call_ids_with_context: BTreeSet<StopCanisterCallId> = canister_states
-            .values()
-            .flat_map(|canister| match canister.system_state.get_status() {
-                CanisterStatus::Stopping { stop_contexts, .. } => stop_contexts.as_slice(),
-                _ => &[],
-            })
-            .filter_map(|ctx| *ctx.call_id())
-            .collect();
-
-        let orphaned: Vec<(StopCanisterCallId, CanisterId)> = state
-            .metadata
-            .subnet_call_context_manager
-            .iter_stop_canister_calls()
-            .filter_map(|(call_id, stop_canister_call)| {
-                if call_ids_with_context.contains(call_id) {
-                    None
-                } else {
-                    Some((*call_id, stop_canister_call.effective_canister_id))
-                }
-            })
-            .collect();
-
-        for (call_id, canister_id) in orphaned {
-            warn!(
-                self.log,
-                "Removing orphaned StopCanisterCall with ID {} for canister {}",
-                call_id,
-                canister_id,
-            );
-            self.remove_stop_canister_call(state, canister_id, Some(call_id));
-        }
-    }
-
     /// Checks for stopping canisters and performs the following:
     ///   1. If there are stop contexts that have timed out, respond to them.
     ///   2. If any stopping canisters are ready to stop, transition them to
@@ -4629,8 +4585,6 @@ impl ExecutionEnvironment {
     ) -> ReplicatedState {
         let mut canister_states = state.take_canister_states();
         let time = state.time();
-
-        self.cleanup_orphaned_stop_canister_calls(&mut state, &canister_states);
 
         for canister in canister_states.values_mut() {
             match canister.system_state.get_status() {

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -4571,6 +4571,49 @@ impl ExecutionEnvironment {
         }
     }
 
+    /// Removes `StopCanisterCall`s from `SubnetCallContextManager` that have no
+    /// corresponding `StopCanisterContext` in the target canister's stop contexts.
+    /// These can arise from a bug fixed in commit 52e7b89 where a `StopCanisterCall`
+    /// was pushed but never removed when the target canister was already stopped.
+    fn cleanup_orphaned_stop_canister_calls(
+        &self,
+        state: &mut ReplicatedState,
+        canister_states: &BTreeMap<CanisterId, Arc<CanisterState>>,
+    ) {
+        let orphaned: Vec<(StopCanisterCallId, CanisterId)> = state
+            .metadata
+            .subnet_call_context_manager
+            .iter_stop_canister_calls()
+            .filter_map(|(call_id, stop_canister_call)| {
+                let canister_id = stop_canister_call.effective_canister_id;
+                let has_context = match canister_states
+                    .get(&canister_id)
+                    .map(|c| c.system_state.get_status())
+                {
+                    Some(CanisterStatus::Stopping { stop_contexts, .. }) => stop_contexts
+                        .iter()
+                        .any(|ctx| ctx.call_id() == &Some(*call_id)),
+                    _ => false,
+                };
+                if has_context {
+                    None
+                } else {
+                    Some((*call_id, canister_id))
+                }
+            })
+            .collect();
+
+        for (call_id, canister_id) in orphaned {
+            warn!(
+                self.log,
+                "Removing orphaned StopCanisterCall with ID {} for canister {}",
+                call_id,
+                canister_id,
+            );
+            self.remove_stop_canister_call(state, canister_id, Some(call_id));
+        }
+    }
+
     /// Checks for stopping canisters and performs the following:
     ///   1. If there are stop contexts that have timed out, respond to them.
     ///   2. If any stopping canisters are ready to stop, transition them to
@@ -4585,6 +4628,8 @@ impl ExecutionEnvironment {
     ) -> ReplicatedState {
         let mut canister_states = state.take_canister_states();
         let time = state.time();
+
+        self.cleanup_orphaned_stop_canister_calls(&mut state, &canister_states);
 
         for canister in canister_states.values_mut() {
             match canister.system_state.get_status() {

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -18,7 +18,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     CanisterStatus, ReplicatedState, SystemState,
     canister_state::{DEFAULT_QUEUE_CAPACITY, WASM_PAGE_SIZE_IN_BYTES},
-    metadata_state::subnet_call_context_manager::PreSignatureStash,
+    metadata_state::subnet_call_context_manager::{PreSignatureStash, StopCanisterCall},
     metadata_state::testing::NetworkTopologyTesting,
     testing::{CanisterQueuesTesting, SystemStateTesting},
 };
@@ -29,13 +29,14 @@ use ic_test_utilities_execution_environment::{
     get_reject, get_reply,
 };
 use ic_test_utilities_metrics::{fetch_histogram_vec_count, metric_vec};
+use ic_test_utilities_types::messages::IngressBuilder;
 use ic_types::{
     CanisterId, CountBytes, PrincipalId, RegistryVersion,
     canister_http::{CanisterHttpMethod, Transform},
     consensus::idkg::{IDkgMasterPublicKeyId, PreSigId},
     ingress::{IngressState, IngressStatus, WasmResult},
     messages::{
-        CallbackId, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, Payload, RejectContext,
+        CallbackId, CanisterCall, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, Payload, RejectContext,
         RequestOrResponse, Response,
     },
     time::UNIX_EPOCH,
@@ -1579,6 +1580,50 @@ fn clean_in_progress_stop_canister_calls_from_subnet_call_context_manager() {
             ErrorCode::CanisterNotFound,
             format!("Canister {canister_id_2} migrated during a subnet split"),
         ))
+    );
+}
+
+// Verifies that `process_stopping_canisters` removes `StopCanisterCall`s from
+// `SubnetCallContextManager` that have no corresponding `StopCanisterContext`
+// in the target canister, simulating the bug fixed in commit 52e7b89.
+#[test]
+fn cleanup_orphaned_stop_canister_calls() {
+    let mut test = ExecutionTestBuilder::new().with_manual_execution().build();
+
+    let canister_id = test
+        .create_canister_with_allocation(Cycles::new(1_000_000_000_000_000), None, None)
+        .unwrap();
+
+    // Simulate the pre-52e7b89 bug: push a StopCanisterCall for a Running canister
+    // without a corresponding StopCanisterContext in the target canister.
+    let time = test.time();
+    test.state_mut()
+        .metadata
+        .subnet_call_context_manager
+        .push_stop_canister_call(StopCanisterCall {
+            call: CanisterCall::Ingress(Arc::new(IngressBuilder::new().build())),
+            effective_canister_id: canister_id,
+            time,
+        });
+
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .stop_canister_calls_len(),
+        1
+    );
+
+    // process_stopping_canisters should remove the orphaned call since there
+    // is no matching StopCanisterContext in the target canister.
+    test.process_stopping_canisters();
+
+    assert_eq!(
+        test.state()
+            .metadata
+            .subnet_call_context_manager
+            .stop_canister_calls_len(),
+        0
     );
 }
 

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -1583,7 +1583,7 @@ fn clean_in_progress_stop_canister_calls_from_subnet_call_context_manager() {
     );
 }
 
-// Verifies that `process_stopping_canisters` removes `StopCanisterCall`s from
+// Verifies that `remove_orphaned_stop_canister_calls` removes `StopCanisterCall`s from
 // `SubnetCallContextManager` that have no corresponding `StopCanisterContext`
 // in the target canister, simulating the bug fixed in commit 52e7b89.
 #[test]
@@ -1614,9 +1614,9 @@ fn cleanup_orphaned_stop_canister_calls() {
         1
     );
 
-    // process_stopping_canisters should remove the orphaned call since there
+    // remove_orphaned_stop_canister_calls should remove the orphaned call since there
     // is no matching StopCanisterContext in the target canister.
-    test.process_stopping_canisters();
+    test.state_mut().remove_orphaned_stop_canister_calls();
 
     assert_eq!(
         test.state()

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1176,6 +1176,14 @@ impl Scheduler for SchedulerImpl {
             self.metrics.canister_ingress_queue_latencies.clone(),
         );
 
+        {
+            let _timer = self
+                .metrics
+                .remove_orphaned_stop_canister_calls_duration
+                .start_timer();
+            state.remove_orphaned_stop_canister_calls();
+        }
+
         // Round preparation.
         let mut scheduler_round_limits = {
             let _timer = self.metrics.round_preparation_duration.start_timer();

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -39,6 +39,7 @@ pub struct SchedulerMetrics {
     pub(super) inner_round_loop_consumed_max_instructions: IntCounter,
     pub(super) num_canisters_uninstalled_out_of_cycles: IntCounter,
     pub(super) round: ScopedMetrics,
+    pub(super) remove_orphaned_stop_canister_calls_duration: Histogram,
     pub(super) round_preparation_duration: Histogram,
     pub(super) round_preparation_ingress: Histogram,
     pub(super) round_consensus_queue: ScopedMetrics,
@@ -202,6 +203,7 @@ impl SchedulerMetrics {
                     metrics_registry,
                 ),
             },
+            remove_orphaned_stop_canister_calls_duration: round_phase_duration_histogram("remove orphaned stop canister calls", metrics_registry),
             round_preparation_duration: round_phase_duration_histogram("preparation", metrics_registry),
             // Expiration of messages in the ingress queue.
             round_preparation_ingress: round_preparation_phase_duration_histogram("expire ingress", metrics_registry),

--- a/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
@@ -404,6 +404,15 @@ impl SubnetCallContextManager {
         self.canister_management_calls.stop_canister_calls_len()
     }
 
+    pub fn iter_stop_canister_calls(
+        &self,
+    ) -> impl Iterator<Item = (&StopCanisterCallId, &StopCanisterCall)> {
+        self.canister_management_calls
+            .stop_canister_call_manager
+            .stop_canister_calls
+            .iter()
+    }
+
     pub fn push_raw_rand_request(
         &mut self,
         request: Request,

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -497,7 +497,7 @@ impl ReplicatedState {
     /// Removes `StopCanisterCall`s from `SubnetCallContextManager` that have no
     /// corresponding `StopCanisterContext` in the target canister's stop contexts.
     /// These can arise from a bug fixed in commit 52e7b89 where a `StopCanisterCall`
-    /// was pushed but never removed when the `stop_canister` call failed, e.g., because
+    /// was pushed but never removed when the `stop_canister` completed, e.g., when
     /// the target canister was already stopped or the sender was not a controller.
     pub fn remove_orphaned_stop_canister_calls(&mut self) {
         let call_ids_with_context: BTreeSet<StopCanisterCallId> = self

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -1,7 +1,9 @@
 use crate::canister_state::queues::{
     CanisterInput, CanisterQueuesLoopDetector, refunds::RefundPool,
 };
-use crate::canister_state::system_state::{CanisterOutputQueuesIterator, push_input};
+use crate::canister_state::system_state::{
+    CanisterOutputQueuesIterator, CanisterStatus, push_input,
+};
 use crate::metadata_state::subnet_call_context_manager::{
     PreSignatureStash, ReshareChainKeyContext, SignWithThresholdContext,
 };
@@ -30,7 +32,8 @@ use ic_types::{
     consensus::idkg::IDkgMasterPublicKeyId,
     ingress::IngressStatus,
     messages::{
-        CallbackId, Ingress, MessageId, Refund, RequestOrResponse, Response, SubnetMessage,
+        CallbackId, Ingress, MessageId, Refund, RequestOrResponse, Response, StopCanisterCallId,
+        SubnetMessage,
     },
     time::CoarseTime,
 };
@@ -488,6 +491,42 @@ impl ReplicatedState {
             refunds,
             consensus_queue: Vec::new(),
             epoch_query_stats,
+        }
+    }
+
+    /// Removes `StopCanisterCall`s from `SubnetCallContextManager` that have no
+    /// corresponding `StopCanisterContext` in the target canister's stop contexts.
+    /// These can arise from a bug fixed in commit 52e7b89 where a `StopCanisterCall`
+    /// was pushed but never removed when the `stop_canister` call failed, e.g., because
+    /// the target canister was already stopped or the sender was not a controller.
+    pub fn remove_orphaned_stop_canister_calls(&mut self) {
+        let call_ids_with_context: BTreeSet<StopCanisterCallId> = self
+            .canister_states
+            .values()
+            .flat_map(|canister| match canister.system_state.get_status() {
+                CanisterStatus::Stopping { stop_contexts, .. } => stop_contexts.as_slice(),
+                _ => &[],
+            })
+            .filter_map(|ctx| *ctx.call_id())
+            .collect();
+
+        let orphaned: Vec<StopCanisterCallId> = self
+            .metadata
+            .subnet_call_context_manager
+            .iter_stop_canister_calls()
+            .filter_map(|(call_id, _)| {
+                if call_ids_with_context.contains(call_id) {
+                    None
+                } else {
+                    Some(*call_id)
+                }
+            })
+            .collect();
+
+        for call_id in orphaned {
+            self.metadata
+                .subnet_call_context_manager
+                .remove_stop_canister_call(call_id);
         }
     }
 

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -617,13 +617,15 @@ pub fn load_checkpoint(
     };
     let (canister_states, subnet_schedule) =
         checkpoint_loader.load_canister_states(&mut thread_pool)?;
-    Ok(ReplicatedState::new_from_checkpoint(
+    let mut state = ReplicatedState::new_from_checkpoint(
         canister_states,
         checkpoint_loader.load_system_metadata(subnet_schedule)?,
         checkpoint_loader.load_subnet_queues()?,
         checkpoint_loader.load_refunds()?,
         checkpoint_loader.load_epoch_query_stats()?,
-    ))
+    );
+    state.remove_orphaned_stop_canister_calls();
+    Ok(state)
 }
 
 pub fn validate_eq_checkpoint(

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -617,14 +617,13 @@ pub fn load_checkpoint(
     };
     let (canister_states, subnet_schedule) =
         checkpoint_loader.load_canister_states(&mut thread_pool)?;
-    let mut state = ReplicatedState::new_from_checkpoint(
+    let state = ReplicatedState::new_from_checkpoint(
         canister_states,
         checkpoint_loader.load_system_metadata(subnet_schedule)?,
         checkpoint_loader.load_subnet_queues()?,
         checkpoint_loader.load_refunds()?,
         checkpoint_loader.load_epoch_query_stats()?,
     );
-    state.remove_orphaned_stop_canister_calls();
     Ok(state)
 }
 


### PR DESCRIPTION
This PR cleans up `StopCanisterCall`s from `SubnetCallContextManager` that have no corresponding `StopCanisterContext` in the target canister's stop contexts. These can arise from a bug fixed in commit 52e7b89 where a `StopCanisterCall` was pushed but never removed when the `stop_canister` call failed, e.g., because the target canister was already stopped or the sender was not a controller.