### PR TITLE
chore: also echo init-console logs to console

### DIFF
--- a/ic-os/components/guestos/init/init-config/init-config.sh
+++ b/ic-os/components/guestos/init/init-config/init-config.sh
@@ -13,7 +13,7 @@ source /opt/ic/bin/metrics.sh
 # not yet been set up on the VM.
 function info() {
     echo "$@"
-    echo "$@" >/dev/ttyS0 || true
+    echo "init-config: $@" >/dev/ttyS0 || true
 }
 
 function mount_config_device() {

--- a/ic-os/components/guestos/init/init-config/init-config.sh
+++ b/ic-os/components/guestos/init/init-config/init-config.sh
@@ -7,42 +7,51 @@ set -eo pipefail
 source /opt/ic/bin/logging.sh
 source /opt/ic/bin/metrics.sh
 
+# Log an informational message to both stdout (captured by the journal) and
+# /dev/ttyS0 (captured by the host's serial console) so that early-boot
+# progress of this service can be observed even when journald forwarding has
+# not yet been set up on the VM.
+function info() {
+    echo "$@"
+    echo "$@" >/dev/ttyS0 || true
+}
+
 function mount_config_device() {
     CONFIG_DEVICE="/dev/disk/by-label/CONFIG"
     TIMEOUT="10"
-    echo "Trigger udev and wait up to ${TIMEOUT} seconds for all events to be handled and exit early if ${CONFIG_DEVICE} appears ..."
+    info "Trigger udev and wait up to ${TIMEOUT} seconds for all events to be handled and exit early if ${CONFIG_DEVICE} appears ..."
     udevadm trigger --subsystem-match=block --action=add
     udevadm settle --timeout="${TIMEOUT}" --exit-if-exists="${CONFIG_DEVICE}"
 
-    echo "Checking for ${CONFIG_DEVICE} device"
+    info "Checking for ${CONFIG_DEVICE} device"
 
     # Check if device exists & is a symlink to the real one
     if [ -L "${CONFIG_DEVICE}" ]; then
-        echo "Found ${CONFIG_DEVICE} device, mounting at /mnt/config"
+        info "Found ${CONFIG_DEVICE} device, mounting at /mnt/config"
 
         # Ensure that the config device is vfat. If we ever change to another filesystem type, we should ensure
         # that it only contains regular files and directories (not symlinks, devices, etc.).
         if mount -t vfat -o ro ${CONFIG_DEVICE} /mnt/config; then
-            echo "Successfully mounted ${CONFIG_DEVICE} device at /mnt/config"
+            info "Successfully mounted ${CONFIG_DEVICE} device at /mnt/config"
             return 0
         else
-            echo "Failed to mount ${CONFIG_DEVICE} device at /mnt/config"
+            info "Failed to mount ${CONFIG_DEVICE} device at /mnt/config"
         fi
     fi
 
-    echo "No ${CONFIG_DEVICE} device found for mounting"
+    info "No ${CONFIG_DEVICE} device found for mounting"
     return 1
 }
 
 # Try config disk first, then run Cloud provisioning if that fails
 if ! mount_config_device; then
-    echo "Config disk not found, trying cloud provisioning"
+    info "Config disk not found, trying cloud provisioning"
 
     # Since root is read-only - mount a tmpfs at /mnt/config to be able to write a config.json there
     mount -t tmpfs config /mnt/config
 
     if ! /opt/ic/bin/guestos_tool cloud-provision; then
-        echo "Cloud provisioning failed"
+        info "Cloud provisioning failed"
         exit 1
     fi
 fi
@@ -57,7 +66,7 @@ if [ -f /run/config/bootstrap/config.json ]; then
     cp /run/config/bootstrap/config.json /run/config/config.json
     chown ic-replica:nogroup /run/config/config.json
 else
-    echo "config.json not found in config partition"
+    info "config.json not found in config partition"
     exit 1
 fi
 


### PR DESCRIPTION
Emit logs of the `init-console` service not only to stdout (journal) but also to `/dev/ttyS0` such that they're visible in the console output of the VM.

We need this to debug why the test `//rs/tests/consensus/subnet_recovery:sr_app_large_no_upgrade_with_chain_keys_test_colocate` [flaked](https://dash.dm1-idx1.dfinity.network/invocation/a397dc69-4d1f-4dac-aaa6-814a08f5dc51?target=//rs/tests/consensus/subnet_recovery:sr_app_large_no_upgrade_with_chain_keys_test_colocate). The reason the test failed was that the driver could not authenticate the `admin` user via SSH with one of the unassigned nodes:

```
2026-04-23 04:38:44.554 INFO[uvms_logs_stream:StdOut] [uvm=colocated-test-driver] TEST_LOG: 2026-04-23 04:38:44.085 INFO[setup:StdErr] thread 'main' (17) panicked at rs/tests/consensus/utils/src/rw_message.rs:300:14:
2026-04-23 04:38:44.554 INFO[uvms_logs_stream:StdOut] [uvm=colocated-test-driver] TEST_LOG: 2026-04-23 04:38:44.085 INFO[setup:StdErr] Timeout while waiting for all unassigned nodes to be healthy: Func="get_ssh_session to 2602:fb2b:110:10:5075:16ff:fe38:eb0 [rs/tests/driver/src/driver/test_env_api.rs:1697]" timed out after 502.202196983s on attempt 98. Last error: Failed to get SSH session
2026-04-23 04:38:44.554 INFO[uvms_logs_stream:StdOut] [uvm=colocated-test-driver] TEST_LOG: 2026-04-23 04:38:44.085 INFO[setup:StdErr] 
2026-04-23 04:38:44.554 INFO[uvms_logs_stream:StdOut] [uvm=colocated-test-driver] TEST_LOG: 2026-04-23 04:38:44.085 INFO[setup:StdErr] Caused by:
2026-04-23 04:38:44.554 INFO[uvms_logs_stream:StdOut] [uvm=colocated-test-driver] TEST_LOG: 2026-04-23 04:38:44.085 INFO[setup:StdErr]     0: Failed to get SSH session
2026-04-23 04:38:44.554 INFO[uvms_logs_stream:StdOut] [uvm=colocated-test-driver] TEST_LOG: 2026-04-23 04:38:44.085 INFO[setup:StdErr]     1: [Session(-18)] Username/PublicKey combination invalid
```

Note the driver could successfully establish and authenticate SSH sessions to all other nodes. What's notable about the failing node is that it didn't log `GUESTOS BOOT SUCCESS` to its console and that it didn't forward its journal logs to ElasticSearch. This leads to the hypothesis that it might have failed to mount its CONFIG drive. To determine if this is the case we extend the `init-config` service to log its message additionally to the console.