### PR TITLE
fix: deflake //rs/tests/nested/nns_recovery:nr_broken_dfinity_node

### DIFF
--- a/rs/tests/nested/nns_recovery/nr_broken_dfinity_node.rs
+++ b/rs/tests/nested/nns_recovery/nr_broken_dfinity_node.rs
@@ -51,6 +51,9 @@ fn main() -> Result<()> {
             fix_dfinity_owned_node_like_np: false,
             sequential_np_actions: false,
         }))
+        // The replica binary is "broken" and restarted by the orchestrator multiple times
+        // during subnet recovery, so don't assert on the default threshold of 1 start attempt.
+        .remove_metrics_to_check("orchestrator_replica_process_start_attempts_total")
         .with_timeout_per_test(Duration::from_secs(30 * 60))
         .execute_from_args()?;
 


### PR DESCRIPTION
## Root cause

The test `//rs/tests/nested/nns_recovery:nr_broken_dfinity_node_head_nns` flaked repeatedly over the past week with:

```
The metric `orchestrator_replica_process_start_attempts_total` on node <id> exceeded the maximum allowed value: 2 > 1
```

(observed `2 > 1`, `2 > 1`, `7 > 1` across the last three flaky runs).

This test intentionally breaks the replica binary on `F + 1` nodes to exercise subnet recovery; the orchestrator then restarts the replica multiple times, which is the whole point of the test. The default post-test assertion `orchestrator_replica_process_start_attempts_total <= 1` is therefore wrong for this test.

All sibling subnet-recovery tests under `rs/tests/consensus/subnet_recovery/` already remove this metric from the assertion set (see e.g. `sr_app_same_nodes_test.rs`). This PR applies the same pattern to `nr_broken_dfinity_node.rs`.

## Fix

Call `.remove_metrics_to_check("orchestrator_replica_process_start_attempts_total")` on the `SystemTestGroup` builder.

## Verification

Ran the test 3 times in parallel locally:

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 \
  //rs/tests/nested/nns_recovery:nr_broken_dfinity_node_head_nns
```

All 3 runs passed (max 1280s, min 1128s, avg 1189s).

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.