### PR TITLE
fix: Revert async hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7926,6 +7926,7 @@ dependencies = [
  "mockall",
  "prometheus",
  "slog",
+ "tokio",
 ]
 
 [[package]]
@@ -12771,7 +12772,6 @@ dependencies = [
  "slog",
  "tempfile",
  "thiserror 2.0.18",
- "tokio",
  "url",
  "x509-cert",
 ]
@@ -14688,7 +14688,6 @@ dependencies = [
  "strum 0.26.3",
  "tempfile",
  "test-strategy 0.4.5",
- "tokio",
  "tree-deserializer",
  "uuid",
 ]

--- a/rs/consensus/BUILD.bazel
+++ b/rs/consensus/BUILD.bazel
@@ -77,6 +77,7 @@ DEV_DEPENDENCIES = [
     "@crate_index//:slog-term",
     "@crate_index//:strum",
     "@crate_index//:tempfile",
+    "@crate_index//:tokio",
 ]
 
 NONMALICIOUS_DEPENDENCIES = [
@@ -197,6 +198,5 @@ rust_ic_bench(
         "//rs/types/types",
         "@crate_index//:criterion",
         "@crate_index//:tempfile",
-        "@crate_index//:tokio",
     ],
 )

--- a/rs/consensus/benches/validate_payload.rs
+++ b/rs/consensus/benches/validate_payload.rs
@@ -104,7 +104,6 @@ where
             &StateManagerConfig::new(tmpdir.path().to_path_buf()),
             None,
             ic_types::malicious_flags::MaliciousFlags::default(),
-            tokio::sync::watch::channel(ic_types::Height::from(0)).0,
         );
         setup_ingress_state(now, &mut state_manager);
         let state_manager = Arc::new(state_manager);

--- a/rs/consensus/certification/BUILD.bazel
+++ b/rs/consensus/certification/BUILD.bazel
@@ -17,6 +17,7 @@ DEPENDENCIES = [
     "//rs/types/types",
     "@crate_index//:prometheus",
     "@crate_index//:slog",
+    "@crate_index//:tokio",
 ]
 
 DEV_DEPENDENCIES = [

--- a/rs/consensus/certification/Cargo.toml
+++ b/rs/consensus/certification/Cargo.toml
@@ -20,6 +20,7 @@ ic-replicated-state = { path = "../../replicated_state" }
 ic-types = { path = "../../types/types" }
 prometheus = { workspace = true }
 slog = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/rs/consensus/certification/src/certifier.rs
+++ b/rs/consensus/certification/src/certifier.rs
@@ -31,6 +31,7 @@ use ic_types::{
 };
 use prometheus::{Histogram, IntCounter, IntGauge};
 use std::{cell::RefCell, collections::BTreeSet, sync::Arc, time::Instant};
+use tokio::sync::watch;
 
 struct CertifierMetrics {
     shares_created: IntCounter,
@@ -49,6 +50,7 @@ pub struct CertifierImpl {
     metrics: CertifierMetrics,
     /// The highest height that has been purged. Used to avoid redundant purging.
     highest_purged_height: RefCell<Height>,
+    max_certified_height_tx: watch::Sender<Height>,
     log: ReplicaLogger,
 }
 
@@ -149,6 +151,16 @@ impl<T: CertificationPool> PoolMutationsProducer<T> for CertifierImpl {
                         .deliver_state_certification(certification);
                     self.metrics.last_certified_height.set(height.get() as i64);
                     debug!(&self.log, "Delivered certification for height {}", height);
+
+                    self.max_certified_height_tx.send_if_modified(|h| {
+                        if height > *h {
+                            *h = height;
+                            true
+                        } else {
+                            false
+                        }
+                    });
+
                     true
                 }
                 None => false,
@@ -271,6 +283,7 @@ impl CertifierImpl {
         consensus_pool_cache: Arc<dyn ConsensusPoolCache>,
         metrics_registry: MetricsRegistry,
         log: ReplicaLogger,
+        max_certified_height_tx: watch::Sender<Height>,
     ) -> Self {
         let membership = Arc::new(Membership::new(
             consensus_pool_cache.clone(),
@@ -305,6 +318,7 @@ impl CertifierImpl {
             },
             log,
             highest_purged_height: RefCell::new(Height::from(1)),
+            max_certified_height_tx,
         }
     }
 
@@ -749,6 +763,8 @@ mod tests {
                     ..
                 } = dependencies(pool_config.clone(), 1);
 
+                let (max_certified_height_tx, _) = watch::channel(Height::from(0));
+
                 let certifier = CertifierImpl::new(
                     replica_config,
                     registry,
@@ -757,6 +773,7 @@ mod tests {
                     pool.get_cache(),
                     MetricsRegistry::new(),
                     log,
+                    max_certified_height_tx,
                 );
 
                 let mut cert = if let CertificationMessage::Certification(cert) =
@@ -793,6 +810,8 @@ mod tests {
                     ic_logger::replica_logger::no_op_logger(),
                     metrics_registry.clone(),
                 );
+                let (max_certified_height_tx, _) = watch::channel(Height::from(0));
+
                 let certifier = CertifierImpl::new(
                     replica_config,
                     registry,
@@ -801,6 +820,7 @@ mod tests {
                     pool.get_cache(),
                     metrics_registry.clone(),
                     log,
+                    max_certified_height_tx,
                 );
                 let bouncer_factory = CertifierBouncer::new(&metrics_registry, pool.get_cache());
 
@@ -854,6 +874,7 @@ mod tests {
                 pool.advance_round_normal_operation_n(6);
                 add_expectations(state_manager.clone(), 1, 4);
                 let metrics_registry = MetricsRegistry::new();
+                let (max_certified_height_tx, _) = watch::channel(Height::from(0));
                 let mut cert_pool = CertificationPoolImpl::new(
                     replica_config.node_id,
                     pool_config,
@@ -868,6 +889,7 @@ mod tests {
                     pool.get_cache(),
                     metrics_registry,
                     log,
+                    max_certified_height_tx,
                 );
 
                 // generate a certifications for heights 1, 2 and 4
@@ -996,6 +1018,8 @@ mod tests {
                 ic_logger::replica_logger::no_op_logger(),
                 metrics_registry.clone(),
             );
+            let (max_certified_height_tx, _) = watch::channel(Height::from(0));
+
             with_test_replica_logger(|log| {
                 let certifier = CertifierImpl::new(
                     replica_config,
@@ -1005,6 +1029,7 @@ mod tests {
                     pool.get_cache(),
                     metrics_registry,
                     log,
+                    max_certified_height_tx,
                 );
 
                 std::iter::empty()
@@ -1077,6 +1102,8 @@ mod tests {
                 ic_logger::replica_logger::no_op_logger(),
                 metrics_registry.clone(),
             );
+            let (max_certified_height_tx, _) = watch::channel(Height::from(0));
+
             with_test_replica_logger(|log| {
                 let certifier = CertifierImpl::new(
                     replica_config,
@@ -1086,6 +1113,7 @@ mod tests {
                     pool.get_cache(),
                     metrics_registry,
                     log,
+                    max_certified_height_tx,
                 );
 
                 std::iter::empty()
@@ -1150,6 +1178,8 @@ mod tests {
                 ic_logger::replica_logger::no_op_logger(),
                 metrics_registry.clone(),
             );
+            let (max_certified_height_tx, _) = watch::channel(Height::from(0));
+
             with_test_replica_logger(|log| {
                 let certifier = CertifierImpl::new(
                     replica_config,
@@ -1159,6 +1189,7 @@ mod tests {
                     pool.get_cache(),
                     metrics_registry,
                     log,
+                    max_certified_height_tx,
                 );
 
                 let shares = certifier.sign(
@@ -1216,6 +1247,8 @@ mod tests {
                 // make the mock state manager return empty hashes for heights 3, 4 and 5
                 add_expectations(state_manager.clone(), 3, 5);
                 let metrics_registry = MetricsRegistry::new();
+                let (max_certified_height_tx, _) = watch::channel(Height::from(0));
+
                 let certifier = CertifierImpl::new(
                     replica_config.clone(),
                     registry,
@@ -1224,6 +1257,7 @@ mod tests {
                     pool.get_cache(),
                     metrics_registry.clone(),
                     log,
+                    max_certified_height_tx,
                 );
                 let mut cert_pool = CertificationPoolImpl::new(
                     replica_config.node_id,
@@ -1394,6 +1428,8 @@ mod tests {
                 ic_logger::replica_logger::no_op_logger(),
                 metrics_registry.clone(),
             );
+            let (max_certified_height_tx, _) = watch::channel(Height::from(0));
+
             with_test_replica_logger(|log| {
                 let certifier = CertifierImpl::new(
                     replica_config,
@@ -1403,6 +1439,7 @@ mod tests {
                     pool.get_cache(),
                     metrics_registry,
                     log,
+                    max_certified_height_tx,
                 );
 
                 std::iter::empty()
@@ -1464,6 +1501,144 @@ mod tests {
         })
     }
 
+    /// Test that the certifier always transmits the highest certified height that
+    /// has been seen so far. I.e. always transmit the global maximum height.
+    /// Test scenario:
+    /// 1. Certifier receives certifications for heights 1, 2, 3.
+    ///     - Certifier should transmit height 3.
+    /// 2. Certifier receives certification for height 4.
+    ///    - Certifier should transmit height 4.
+    /// 3. Certifier receives certifications for heights 4, 3, 2, 1.
+    ///   - Certifier should not transmit any height, as none of the heights are higher
+    ///     than the last transmitted height.
+    #[test]
+    fn test_certified_heights_are_transmitted() {
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            with_test_replica_logger(|log| {
+                let Dependencies {
+                    pool,
+                    replica_config,
+                    registry,
+                    crypto,
+                    state_manager,
+                    ..
+                } = dependencies(pool_config.clone(), 4);
+
+                let metrics_registry = MetricsRegistry::new();
+                let (max_certified_height_tx, mut max_certified_height_rx) =
+                    watch::channel(Height::from(0));
+                let cert_pool = CertificationPoolImpl::new(
+                    replica_config.node_id,
+                    pool_config,
+                    ic_logger::replica_logger::no_op_logger(),
+                    metrics_registry.clone(),
+                );
+
+                for height in 1..=4 {
+                    cert_pool
+                        .validated
+                        .insert(CertificationMessage::Certification(Certification {
+                            height: Height::from(height),
+                            height_witness: Some(Witness::new_for_testing_with_height()),
+                            signed: Signed {
+                                content: gen_content(Height::from(height)),
+                                signature: ThresholdSignature::fake(),
+                            },
+                        }));
+                }
+
+                let certifier = CertifierImpl::new(
+                    replica_config,
+                    registry,
+                    crypto,
+                    state_manager.clone(),
+                    pool.get_cache(),
+                    metrics_registry,
+                    log,
+                    max_certified_height_tx,
+                );
+
+                // We expect deliver_state_certification() to be called 8 times since we call
+                // CertifierImpl::on_state_change 3 times with 8 heights in total:
+                // We mock the certified heights [1, 2, 3], [4], [4, 3, 2, 1] which are in total 8 heights.
+                // I.e. the certifier should deliver the state certification 8 times.
+                state_manager
+                    .get_mut()
+                    .expect_deliver_state_certification()
+                    .times(8)
+                    .return_const(());
+
+                let state_hashes = |heights: Vec<u64>| {
+                    heights
+                        .into_iter()
+                        .map(|h| StateHashMetadata {
+                            height: Height::from(h),
+                            hash: CryptoHashOfPartialState::from(CryptoHash(Vec::new())),
+                            height_witness: Witness::new_for_testing_with_height(),
+                        })
+                        .collect::<Vec<_>>()
+                };
+
+                // We mock the state manager to return the heights
+                // of the states that are certified. The CertifierImpl
+                // should transmit the highest height that it has seen
+                // each time it sees a new height it certifies by delivering it
+                // to the state manager.
+                state_manager
+                    .get_mut()
+                    .expect_list_state_hashes_to_certify()
+                    .times(1)
+                    .return_const(state_hashes(vec![1, 2, 3]));
+                state_manager
+                    .get_mut()
+                    .expect_list_state_heights_to_certify()
+                    .times(1)
+                    .return_const(vec![]);
+
+                certifier.on_state_change(&cert_pool);
+                assert_eq!(
+                    *max_certified_height_rx.borrow_and_update(),
+                    Height::from(3)
+                );
+
+                // New max height is 4, so it should be transmitted
+                state_manager
+                    .get_mut()
+                    .expect_list_state_hashes_to_certify()
+                    .times(1)
+                    .return_const(state_hashes(vec![4]));
+                state_manager
+                    .get_mut()
+                    .expect_list_state_heights_to_certify()
+                    .times(1)
+                    .return_const(vec![]);
+                certifier.on_state_change(&cert_pool);
+                assert_eq!(
+                    *max_certified_height_rx.borrow_and_update(),
+                    Height::from(4),
+                    "Expected height 4 to be transmitted as it is higher than previous transmitted heights"
+                );
+
+                // None of these heights are higher than the last transmitted height
+                state_manager
+                    .get_mut()
+                    .expect_list_state_hashes_to_certify()
+                    .times(1)
+                    .return_const(state_hashes(vec![4, 3, 2, 1]));
+                state_manager
+                    .get_mut()
+                    .expect_list_state_heights_to_certify()
+                    .times(1)
+                    .return_const(vec![]);
+                certifier.on_state_change(&cert_pool);
+                assert!(
+                    !max_certified_height_rx.has_changed().unwrap(),
+                    "No new height should be sent if they are lower than a previously sent height."
+                );
+            })
+        })
+    }
+
     /// Test that the certifier delivers certification requested by the state manager
     /// via the function `StateManager::list_state_heights_to_certify`.
     /// Test scenario:
@@ -1485,6 +1660,8 @@ mod tests {
                 } = dependencies(pool_config.clone(), 4);
 
                 let metrics_registry = MetricsRegistry::new();
+                let (max_certified_height_tx, _max_certified_height_rx) =
+                    watch::channel(Height::from(0));
                 let cert_pool = CertificationPoolImpl::new(
                     replica_config.node_id,
                     pool_config,
@@ -1513,6 +1690,7 @@ mod tests {
                     pool.get_cache(),
                     metrics_registry,
                     log,
+                    max_certified_height_tx,
                 );
 
                 // We expect deliver_state_certification() to be called 2 times for heights 3 and 4.

--- a/rs/consensus/tests/framework/runner.rs
+++ b/rs/consensus/tests/framework/runner.rs
@@ -17,6 +17,7 @@ use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
+use tokio::sync::watch;
 
 fn stop_immediately(_: &ConsensusInstance<'_>) -> bool {
     true
@@ -194,6 +195,7 @@ impl<'a> ConsensusRunner<'a> {
             deps.consensus_pool.read().unwrap().get_cache(),
             deps.metrics_registry.clone(),
             replica_logger.clone(),
+            watch::channel(Height::from(0)).0,
         );
         let now = self.time.get_relative_time();
         let in_queue: Queue<Input> = Default::default();

--- a/rs/consensus/tests/payload.rs
+++ b/rs/consensus/tests/payload.rs
@@ -38,6 +38,7 @@ use std::{
     sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
+use tokio::sync::watch;
 
 /// Test that the batches that Consensus produces contain expected batch
 /// numbers and payloads
@@ -155,6 +156,8 @@ fn consensus_produces_expected_batches() {
             &PoolReader::new(&*consensus_pool.read().unwrap()),
         )));
 
+        let (dummy_watcher, _) = watch::channel(Height::from(0));
+
         let consensus = ic_consensus::consensus::ConsensusImpl::new(
             replica_config.clone(),
             Arc::clone(&registry_client) as Arc<_>,
@@ -205,6 +208,7 @@ fn consensus_produces_expected_batches() {
             Arc::clone(&consensus_cache),
             metrics_registry.clone(),
             no_op_logger(),
+            dummy_watcher,
         );
 
         let driver = ConsensusDriver::new(

--- a/rs/determinism_test/src/setup.rs
+++ b/rs/determinism_test/src/setup.rs
@@ -121,7 +121,6 @@ pub(crate) fn setup() -> (
         &config.state_manager,
         None,
         ic_types::malicious_flags::MaliciousFlags::default(),
-        tokio::sync::watch::channel(ic_types::Height::from(0)).0,
     ));
 
     let (completed_execution_messages_tx, _) = tokio::sync::mpsc::channel(1);

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -3042,7 +3042,6 @@ impl PocketIc {
                             ),
                             None,
                             MaliciousFlags::default(),
-                            tokio::sync::watch::channel(ic_types::Height::from(0)).0,
                         );
                         let metadata = state_manager.get_latest_state().take().metadata.clone();
                         // Shut down the temporary state manager to avoid race conditions.

--- a/rs/prep/BUILD.bazel
+++ b/rs/prep/BUILD.bazel
@@ -42,7 +42,6 @@ DEPENDENCIES = [
     "@crate_index//:slog",
     "@crate_index//:tempfile",
     "@crate_index//:thiserror",
-    "@crate_index//:tokio",
     "@crate_index//:url",
     "@crate_index//:x509-cert",
 ]

--- a/rs/prep/Cargo.toml
+++ b/rs/prep/Cargo.toml
@@ -45,7 +45,6 @@ serde_json = { workspace = true }
 slog = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
 url = { workspace = true }
 x509-cert = { workspace = true }
 

--- a/rs/prep/src/node.rs
+++ b/rs/prep/src/node.rs
@@ -227,7 +227,6 @@ impl InitializedNode {
             &config,
             None,
             ic_types::malicious_flags::MaliciousFlags::default(),
-            tokio::sync::watch::channel(ic_types::Height::from(0)).0,
         );
 
         let (_height, state) = state_manager.take_tip();

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -300,7 +300,6 @@ impl Player {
             &cfg.state_manager,
             None,
             MaliciousFlags::default(),
-            tokio::sync::watch::channel(ic_types::Height::from(0)).0,
         ));
         let (completed_execution_messages_tx, _) = tokio::sync::mpsc::channel(1);
         let execution_service = ExecutionServices::setup_execution(

--- a/rs/replica/setup_ic_network/src/lib.rs
+++ b/rs/replica/setup_ic_network/src/lib.rs
@@ -47,7 +47,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::ReplicatedState;
 use ic_state_manager::state_sync::types::StateSyncMessage;
 use ic_types::{
-    NodeId, SubnetId,
+    Height, NodeId, SubnetId,
     artifact::UnvalidatedArtifactMutation,
     canister_http::{CanisterHttpRequest, CanisterHttpResponse, CanisterHttpResponseArtifact},
     consensus::{
@@ -63,7 +63,7 @@ use std::{
     str::FromStr,
     sync::{Arc, Mutex, RwLock},
 };
-use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc::Sender, watch};
 use tower_http::trace::TraceLayer;
 
 /// This limit is used to protect against a malicious peer advertising many ingress messages.
@@ -353,6 +353,7 @@ pub fn setup_consensus_and_p2p(
     cycles_account_manager: Arc<CyclesAccountManager>,
     canister_http_adapter_client: CanisterHttpAdapterClient,
     registry_poll_delay_duration_ms: u64,
+    max_certified_height_tx: watch::Sender<Height>,
 ) -> (
     Arc<RwLock<IngressPoolImpl>>,
     Sender<UnvalidatedArtifactMutation<SignedIngress>>,
@@ -456,6 +457,7 @@ pub fn setup_consensus_and_p2p(
         cycles_account_manager,
         registry_poll_delay_duration_ms,
         canister_http_adapter_client,
+        max_certified_height_tx,
         time_source,
     )
 }
@@ -489,6 +491,7 @@ fn start_consensus(
     cycles_account_manager: Arc<CyclesAccountManager>,
     registry_poll_delay_duration_ms: u64,
     canister_http_adapter_client: CanisterHttpAdapterClient,
+    max_certified_height_tx: watch::Sender<Height>,
     time_source: Arc<dyn TimeSource>,
 ) -> (
     Arc<RwLock<IngressPoolImpl>>,
@@ -599,6 +602,7 @@ fn start_consensus(
         Arc::clone(&consensus_pool_cache) as Arc<_>,
         metrics_registry.clone(),
         log.clone(),
+        max_certified_height_tx,
     );
     join_handles.push(create_artifact_handler(
         abortable_broadcast_channels.certifier,

--- a/rs/replica/src/setup_ic_stack.rs
+++ b/rs/replica/src/setup_ic_stack.rs
@@ -165,7 +165,6 @@ pub fn construct_ic_stack(
     // ---------- REPLICATED STATE DEPS FOLLOW ----------
     let consensus_pool_cache = consensus_pool.read().unwrap().get_cache();
     let verifier = Arc::new(VerifierImpl::new(crypto.clone()));
-    let (max_certified_height_tx, max_certified_height_rx) = watch::channel(Height::from(0));
     let state_manager = Arc::new(StateManagerImpl::new(
         verifier,
         subnet_id,
@@ -178,7 +177,6 @@ pub fn construct_ic_stack(
         // Hence the need of the dependency on consensus here.
         Some(consensus_pool_cache.starting_height()),
         config.malicious_behavior.malicious_flags.clone(),
-        max_certified_height_tx,
     ));
     // ---------- EXECUTION DEPS FOLLOW ----------
 
@@ -306,6 +304,7 @@ pub fn construct_ic_stack(
     );
     // ---------- CONSENSUS AND P2P DEPS FOLLOW ----------
     let state_sync = StateSync::new(state_manager.clone(), log.clone());
+    let (max_certified_height_tx, max_certified_height_rx) = watch::channel(Height::from(0));
 
     let (ingress_throttler, ingress_tx, p2p_runner) = setup_consensus_and_p2p(
         log,
@@ -336,6 +335,7 @@ pub fn construct_ic_stack(
         execution_services.cycles_account_manager,
         canister_http_adapter_client,
         config.nns_registry_replicator.poll_delay_duration_ms,
+        max_certified_height_tx,
     );
 
     // ---------- PUBLIC ENDPOINT DEPS FOLLOW ----------

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -767,6 +767,8 @@ impl SystemMetadata {
     /// roll back `Stopping` states on all subnet B canisters.
     ///
     /// Notes:
+    ///  * `prev_state_hash` has just been set by `take_tip()` to the checkpoint
+    ///    hash (checked against the hash in the CUP). It must be preserved.
     ///  * `own_subnet_type` has just been set during `load_checkpoint()`, based on
     ///    the registry subnet record of the subnet that this node is part of.
     ///  * `batch_time`, `network_topology` and `own_subnet_features` will be set

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -3073,7 +3073,6 @@ impl StateMachine {
             .process_batch(batch)
             .expect("Could not process batch");
 
-        self.state_manager.flush_hash_channel();
         if self.remove_old_states {
             self.state_manager.remove_states_below(batch_number);
         }
@@ -3178,7 +3177,6 @@ impl StateMachine {
         replicated_state.metadata.batch_time = time;
         self.state_manager
             .commit_and_certify(replicated_state, CertificationScope::Metadata, None);
-        self.state_manager.flush_hash_channel();
         self.set_time(time.into());
         *self.time_of_last_round.write().unwrap() = time;
     }
@@ -3379,7 +3377,6 @@ impl StateMachine {
 
         self.state_manager
             .commit_and_certify(state, CertificationScope::Metadata, None);
-        self.state_manager.flush_hash_channel();
     }
 
     /// Enables checkpoints and makes a tick to write a checkpoint.
@@ -3419,7 +3416,6 @@ impl StateMachine {
         state.put_canister_state(source_state.canister_state(&canister_id).unwrap().clone());
         self.state_manager
             .commit_and_certify(state, CertificationScope::Full, None);
-        self.state_manager.flush_hash_channel();
         self.state_manager.remove_states_below(h.increment());
     }
 
@@ -3445,8 +3441,6 @@ impl StateMachine {
         if state.take_canister_state(&canister_id).is_some() {
             self.state_manager
                 .commit_and_certify(state, CertificationScope::Full, None);
-            self.state_manager.flush_hash_channel();
-
             self.state_manager.flush_tip_channel();
 
             other_env.import_canister_state(
@@ -3659,7 +3653,6 @@ impl StateMachine {
 
         self.state_manager
             .commit_and_certify(state, CertificationScope::Full, None);
-        self.state_manager.flush_hash_channel();
 
         // Perform the split on `env`, which requires preserving the `prev_state_hash`
         // (as opposed to MVP subnet splitting where it is adjusted manually).
@@ -3671,7 +3664,6 @@ impl StateMachine {
 
         env.state_manager
             .commit_and_certify(state, CertificationScope::Full, None);
-        self.state_manager.flush_hash_channel();
 
         Ok(env)
     }
@@ -4963,7 +4955,6 @@ impl StateMachine {
             .stable_memory = memory;
         self.state_manager
             .commit_and_certify(replicated_state, CertificationScope::Metadata, None);
-        self.state_manager.flush_hash_channel();
     }
 
     /// Returns the query stats of the specified canister.
@@ -4996,7 +4987,6 @@ impl StateMachine {
 
         self.state_manager
             .commit_and_certify(state, CertificationScope::Metadata, None);
-        self.state_manager.flush_hash_channel();
     }
 
     /// Returns the cycle balance of the specified canister.
@@ -5028,7 +5018,6 @@ impl StateMachine {
         let balance = canister_state.system_state.balance().get();
         self.state_manager
             .commit_and_certify(state, CertificationScope::Metadata, None);
-        self.state_manager.flush_hash_channel();
         balance
     }
 
@@ -5112,7 +5101,6 @@ impl StateMachine {
 
     /// Make sure the latest state is certified.
     pub fn certify_latest_state(&self) {
-        self.state_manager.flush_hash_channel();
         certify_latest_state_helper(self.state_manager.clone(), &self.secret_key, self.subnet_id)
     }
 
@@ -5249,7 +5237,6 @@ impl StateMachine {
         }
         self.state_manager
             .commit_and_certify(replicated_state, CertificationScope::Metadata, None);
-        self.state_manager.flush_hash_channel();
     }
 }
 
@@ -5262,7 +5249,6 @@ pub fn certify_latest_state_helper(
     if state_manager.latest_state_height() == Height::from(0) {
         let (_height, replicated_state) = state_manager.take_tip();
         state_manager.commit_and_certify(replicated_state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
     }
     assert_ne!(state_manager.latest_state_height(), Height::from(0));
     if state_manager.latest_state_height() > state_manager.latest_certified_height() {

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -1183,6 +1183,7 @@ pub struct StateMachine {
     consensus_pool_cache: Arc<FakeConsensusPoolCache>,
     canister_http_pool: Arc<RwLock<CanisterHttpPoolImpl>>,
     canister_http_payload_builder: Arc<CanisterHttpPayloadBuilderImpl>,
+    certified_height_tx: watch::Sender<Height>,
     pub ingress_watcher_handle: IngressWatcherHandle,
     /// A drop guard to gracefully cancel the ingress watcher task.
     _ingress_watcher_drop_guard: tokio_util::sync::DropGuard,
@@ -1820,6 +1821,10 @@ impl StateMachine {
         self.certify_latest_state();
         let certified_height = self.state_manager.latest_certified_height();
 
+        self.certified_height_tx
+            .send(certified_height)
+            .expect("Ingress watcher is running");
+
         let state = self
             .state_manager
             .get_state_at(certified_height)
@@ -2040,11 +2045,6 @@ impl StateMachine {
             ..Default::default()
         };
 
-        // Setup ingress watcher for synchronous call endpoint.
-        let (completed_execution_messages_tx, completed_execution_messages_rx) =
-            mpsc::channel(COMPLETED_EXECUTION_MESSAGES_BUFFER_SIZE);
-        let (certified_height_tx, certified_height_rx) = watch::channel(Height::from(0));
-
         let state_manager_impl = StateManagerImpl::new(
             Arc::new(FakeVerifier),
             subnet_id,
@@ -2054,7 +2054,6 @@ impl StateMachine {
             &sm_config,
             None,
             malicious_flags.clone(),
-            certified_height_tx,
         );
         let state_manager = Arc::new(StateMachineStateManager {
             inner: state_manager_impl,
@@ -2102,6 +2101,11 @@ impl StateMachine {
         ));
 
         let chain_key_payload_builder = Arc::new(MockBatchPayloadBuilder::new().expect_noop());
+
+        // Setup ingress watcher for synchronous call endpoint.
+        let (completed_execution_messages_tx, completed_execution_messages_rx) =
+            mpsc::channel(COMPLETED_EXECUTION_MESSAGES_BUFFER_SIZE);
+        let (certified_height_tx, certified_height_rx) = watch::channel(Height::from(0));
 
         let cancellation_token = tokio_util::sync::CancellationToken::new();
         let cancellation_token_clone = cancellation_token.clone();
@@ -2345,6 +2349,7 @@ impl StateMachine {
             transform_handler: Arc::new(Mutex::new(execution_services.transform_execution_service)),
             ingress_watcher_handle,
             _ingress_watcher_drop_guard: ingress_watcher_drop_guard,
+            certified_height_tx,
             runtime,
             // Note: state machine tests are commonly used for testing
             // canisters, such tests usually don't rely on any persistence.

--- a/rs/state_manager/BUILD.bazel
+++ b/rs/state_manager/BUILD.bazel
@@ -42,7 +42,6 @@ DEPENDENCIES = [
     "@crate_index//:serde_bytes",
     "@crate_index//:slog",
     "@crate_index//:tempfile",
-    "@crate_index//:tokio",
     "@crate_index//:uuid",
 ]
 

--- a/rs/state_manager/Cargo.toml
+++ b/rs/state_manager/Cargo.toml
@@ -44,7 +44,6 @@ serde_bytes = { workspace = true }
 slog = { workspace = true }
 strum = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true }
 tree-deserializer = { path = "../tree_deserializer" }
 uuid = { workspace = true }
 

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -89,7 +89,6 @@ use std::{
     sync::Mutex,
 };
 use tempfile::tempfile;
-use tokio::sync::watch;
 use uuid::Uuid;
 
 /// The number of threads that state manager starts to construct checkpoints.
@@ -943,7 +942,7 @@ pub struct StateManagerImpl {
     // Cached latest state height.  We cache it separately because it's
     // requested quite often and this causes high contention on the lock.
     latest_state_height: Arc<AtomicU64>,
-    latest_certified_height: Arc<AtomicU64>,
+    latest_certified_height: AtomicU64,
     fast_forward_height: AtomicU64,
     persist_metadata_guard: Arc<Mutex<()>>,
     tip_channel: Sender<TipRequest>,
@@ -955,7 +954,6 @@ pub struct StateManagerImpl {
     latest_height_update_time: Arc<Mutex<Instant>>,
     /// The height at which this StateManager was started. Set once during initialization and never modified.
     started_height: Height,
-    max_certified_height_tx: Arc<watch::Sender<Height>>,
 }
 
 #[cfg(debug_assertions)]
@@ -1322,7 +1320,6 @@ impl StateManagerImpl {
         config: &Config,
         starting_height: Option<Height>,
         malicious_flags: MaliciousFlags,
-        max_certified_height_tx: watch::Sender<Height>,
     ) -> Self {
         let metrics = StateManagerMetrics::new(metrics_registry, log.clone());
 
@@ -1512,7 +1509,7 @@ impl StateManagerImpl {
         );
 
         let latest_state_height = Arc::new(AtomicU64::new(0));
-        let latest_certified_height = Arc::new(AtomicU64::new(0));
+        let latest_certified_height = AtomicU64::new(0);
         let fast_forward_height = AtomicU64::new(0);
 
         let initial_snapshot = Snapshot {
@@ -1640,7 +1637,6 @@ impl StateManagerImpl {
             malicious_flags,
             latest_height_update_time,
             started_height,
-            max_certified_height_tx: Arc::new(max_certified_height_tx),
         }
     }
 
@@ -2620,24 +2616,6 @@ impl StateManagerImpl {
     }
 }
 
-fn update_latest_certified_height(
-    latest_certified_height: &AtomicU64,
-    metrics: &StateManagerMetrics,
-    max_certified_height_tx: &watch::Sender<Height>,
-    height: Height,
-) {
-    let latest_certified = update_latest_height(latest_certified_height, height);
-    metrics.latest_certified_height.set(latest_certified as i64);
-    max_certified_height_tx.send_if_modified(|h| {
-        if height > *h {
-            *h = height;
-            true
-        } else {
-            false
-        }
-    });
-}
-
 fn initial_state(own_subnet_id: SubnetId, own_subnet_type: SubnetType) -> Labeled<ReplicatedState> {
     Labeled::new(
         StateManagerImpl::INITIAL_STATE_HEIGHT,
@@ -3073,12 +3051,11 @@ impl StateManager for StateManagerImpl {
                 );
             }
 
-            update_latest_certified_height(
-                &self.latest_certified_height,
-                &self.metrics,
-                &self.max_certified_height_tx,
-                certification_height,
-            );
+            let latest_certified =
+                update_latest_height(&self.latest_certified_height, certification.height);
+            self.metrics
+                .latest_certified_height
+                .set(latest_certified as i64);
 
             if let Some((_, certification_requested_at)) = metadata.hash_tree {
                 self.metrics
@@ -3438,13 +3415,11 @@ impl StateManager for StateManagerImpl {
             state: Arc::clone(&state),
             states: Arc::clone(&self.states),
             latest_state_height: Arc::clone(&self.latest_state_height),
-            latest_certified_height: Arc::clone(&self.latest_certified_height),
             height,
             latest_height_update_time: Arc::clone(&self.latest_height_update_time),
             reference_certification: Box::new(maybe_delivered_certification),
             scope: scope.clone(),
             state_layout: Box::new(self.state_layout.clone()),
-            max_certified_height_tx: Arc::clone(&self.max_certified_height_tx),
         };
         self.hash_channel.send(hash_req).unwrap();
 
@@ -3559,7 +3534,6 @@ enum HashRequest {
         state: Arc<ReplicatedState>,
         states: Arc<parking_lot::RwLock<SharedState>>,
         latest_state_height: Arc<AtomicU64>,
-        latest_certified_height: Arc<AtomicU64>,
         height: Height,
         latest_height_update_time: Arc<Mutex<Instant>>,
         /// A certification from consensus. If `Some`, we compare it with the state hash
@@ -3570,7 +3544,6 @@ enum HashRequest {
         scope: CertificationScope,
         /// Boxed so that variants have similar size and we don't waste space when sending `HashRequest::Wait`.
         state_layout: Box<StateLayout>,
-        max_certified_height_tx: Arc<watch::Sender<Height>>,
     },
     /// Wait for the message to be executed and notify back via `sender`.
     Wait { sender: Sender<()> },
@@ -3592,13 +3565,11 @@ fn spawn_hash_thread(
                             state,
                             states,
                             latest_state_height,
-                            latest_certified_height,
                             height,
                             latest_height_update_time,
                             reference_certification,
                             scope,
                             state_layout,
-                            max_certified_height_tx,
                         } => {
                             let mut certification_metadata =
                                 StateManagerImpl::compute_certification_metadata(
@@ -3664,8 +3635,6 @@ fn spawn_hash_thread(
                                     .make_contiguous()
                                     .sort_by_key(|snapshot| snapshot.height);
 
-                                let has_certification =
-                                    certification_metadata.certification.is_some();
                                 states
                                     .certifications_metadata
                                     .insert(height, certification_metadata);
@@ -3682,19 +3651,6 @@ fn spawn_hash_thread(
                                         .height_update_time_seconds
                                         .observe((now - *last_height_update_time).as_secs_f64());
                                     *last_height_update_time = now;
-                                }
-                                // Only update the certified height and notify the channel if the
-                                // certification is actually being stored. We must not fire the channel
-                                // when the snapshot already existed (e.g., due to state sync), because
-                                // in that case `certification_metadata` is never inserted and the
-                                // certified state at this height would not be available.
-                                if has_certification {
-                                    update_latest_certified_height(
-                                        &latest_certified_height,
-                                        &metrics,
-                                        &max_certified_height_tx,
-                                        height,
-                                    );
                                 }
                             }
                         }

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     tip::{PageMapToFlush, TipRequest, flush_tip_channel, spawn_tip_thread},
 };
-use crossbeam_channel::{Sender, bounded, unbounded};
+use crossbeam_channel::Sender;
 use ic_canonical_state::lazy_tree_conversion::replicated_state_as_lazy_tree;
 use ic_canonical_state_tree_hash::{
     hash_tree::{HashTree, HashTreeError, hash_lazy_tree},
@@ -122,7 +122,7 @@ const ARCHIVED_DIVERGED_CHECKPOINT_MAX_AGE: Duration = Duration::from_secs(30 * 
 /// The maximum number of consecutive rounds for which the optimization of
 /// skipping state cloning and computing certification metadata triggers
 /// while catching up.
-const MAX_CONSECUTIVE_ROUNDS_WITHOUT_STATE_CLONING_AND_HASHING: u64 = 10;
+const MAX_CONSECUTIVE_ROUNDS_WITHOUT_STATE_CLONING: u64 = 10;
 
 /// The maximum number of future heights starting at tip height
 /// that the state manager optimistically asks consensus to certify
@@ -188,6 +188,7 @@ pub struct StateManagerMetrics {
     latest_hash_tree_max_index: IntGauge,
     fast_forward_height: IntGauge,
     no_state_clone_count: IntCounter,
+    tip_hash_count: IntCounter,
 }
 
 #[derive(Clone)]
@@ -483,6 +484,11 @@ impl StateManagerMetrics {
             "Number of heights whose states were not cloned and not stored by this node.",
         );
 
+        let tip_hash_count = metrics_registry.int_counter(
+            "state_manager_tip_hash_count",
+            "Number of tip heights whose state snapshot was not stored by this node and whose state hash was computed by this node.",
+        );
+
         Self {
             state_manager_error_count,
             checkpoint_op_duration,
@@ -510,6 +516,7 @@ impl StateManagerMetrics {
             latest_hash_tree_max_index,
             fast_forward_height,
             no_state_clone_count,
+            tip_hash_count,
         }
     }
 
@@ -947,8 +954,6 @@ pub struct StateManagerImpl {
     persist_metadata_guard: Arc<Mutex<()>>,
     tip_channel: Sender<TipRequest>,
     _tip_thread_handle: JoinOnDrop<()>,
-    hash_channel: Sender<HashRequest>,
-    _hash_thread_handle: JoinOnDrop<()>,
     fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
     malicious_flags: MaliciousFlags,
     latest_height_update_time: Arc<Mutex<Instant>>,
@@ -1303,7 +1308,6 @@ impl StateManagerImpl {
 
     /// Finish all asynchronous operations.
     pub fn flush_all(&self) {
-        self.flush_hash_channel();
         self.flush_tip_channel();
         self.state_layout().flush_checkpoint_removal_channel();
     }
@@ -1362,7 +1366,6 @@ impl StateManagerImpl {
             metrics.clone(),
             malicious_flags.clone(),
         );
-        let (_hash_thread_handle, hash_channel) = spawn_hash_thread(metrics.clone(), log.clone());
 
         let starting_time = Instant::now();
         let loaded_states_metadata =
@@ -1508,7 +1511,7 @@ impl StateManagerImpl {
             starting_time.elapsed()
         );
 
-        let latest_state_height = Arc::new(AtomicU64::new(0));
+        let latest_state_height = AtomicU64::new(0);
         let latest_certified_height = AtomicU64::new(0);
         let fast_forward_height = AtomicU64::new(0);
 
@@ -1615,7 +1618,7 @@ impl StateManagerImpl {
         }
 
         report_last_diverged_state(&log, &metrics, &state_layout);
-        let latest_height_update_time = Arc::new(Mutex::new(Instant::now()));
+
         Self {
             log,
             metrics,
@@ -1625,17 +1628,15 @@ impl StateManagerImpl {
             own_subnet_id,
             own_subnet_type,
             deallocator_thread,
-            latest_state_height,
+            latest_state_height: Arc::new(latest_state_height),
             latest_certified_height,
             fast_forward_height,
             persist_metadata_guard,
             tip_channel,
             _tip_thread_handle,
-            hash_channel,
-            _hash_thread_handle,
             fd_factory,
             malicious_flags,
-            latest_height_update_time,
+            latest_height_update_time: Arc::new(Mutex::new(Instant::now())),
             started_height,
         }
     }
@@ -1964,9 +1965,35 @@ impl StateManagerImpl {
         }
     }
 
-    fn populate_extra_metadata(&self, state: &mut ReplicatedState) {
+    fn populate_extra_metadata(&self, state: &mut ReplicatedState, height: Height) {
         state.metadata.state_sync_version = CURRENT_STATE_SYNC_VERSION;
         state.metadata.certification_version = ic_canonical_state::CURRENT_CERTIFICATION_VERSION;
+
+        if height == Self::INITIAL_STATE_HEIGHT {
+            return;
+        }
+        let prev_height = height - Height::from(1);
+
+        if prev_height == Self::INITIAL_STATE_HEIGHT {
+            return;
+        }
+
+        let states = self.states.read();
+        if let Some(metadata) = states.certifications_metadata.get(&prev_height) {
+            assert_eq!(
+                state.metadata.prev_state_hash,
+                Some(CryptoHashOfPartialState::from(
+                    metadata.certified_state_hash.clone(),
+                ))
+            );
+        } else {
+            info!(
+                self.log,
+                "The previous certification metadata at height {} are not available. This can happen when the replica \
+                (i) catches up or (ii) syncs a newer state concurrently and removes the states below.",
+                prev_height,
+            );
+        }
     }
 
     fn find_checkpoint_by_root_hash(
@@ -2138,11 +2165,6 @@ impl StateManagerImpl {
             last_checkpoint_to_keep
         );
 
-        let tip_height = {
-            let states = self.states.read();
-            states.tip_height
-        };
-
         // In debug builds we store the latest_state_height here so
         // that we can verify later that this height is retained.
         #[cfg(debug_assertions)]
@@ -2241,7 +2263,6 @@ impl StateManagerImpl {
         // as decisions to retain a checkpoint or an in-memory state are made independently.
         let inmemory_heights_to_keep = std::iter::once(latest_certified_height)
             .chain(extra_inmemory_heights_to_keep.iter().copied())
-            .chain(std::iter::once(tip_height))
             .collect::<BTreeSet<_>>();
 
         let (removed, retained) = states.snapshots.drain(0..).partition(|snapshot| {
@@ -2721,14 +2742,56 @@ impl StateManager for StateManagerImpl {
 
         let mut states = self.states.write();
         let tip_height = states.tip_height;
-        let tip = states.tip.take().expect("failed to get TIP");
+        let mut tip = states.tip.take().expect("failed to get TIP");
 
-        let target_snapshot = match states.snapshots.back() {
-            // The most recent available state is more recent than what we have in the tip,
-            // because we are catching up.
-            Some(snapshot) if snapshot.height > tip_height => snapshot.clone(),
-            // The tip is the most recent state we know of, proceed with that.
+        let (target_snapshot, target_hash) = match states.snapshots.back() {
+            Some(snapshot) if snapshot.height > tip_height => {
+                let tip_height = snapshot.height;
+
+                let tip_metadata = states
+                    .certifications_metadata
+                    .get(&tip_height)
+                    .unwrap_or_else(|| {
+                        fatal!(self.log, "Bug: missing tip metadata @{}", tip_height)
+                    });
+
+                // Since the state machine will use this tip to compute the *next* state,
+                // we populate the prev_state_hash with the hash of the current tip.
+                let tip_hash =
+                    CryptoHashOfPartialState::from(tip_metadata.certified_state_hash.clone());
+
+                (snapshot.clone(), tip_hash)
+            }
             _ => {
+                let tip_hash = if let Some(tip_metadata) =
+                    states.certifications_metadata.get(&tip_height)
+                {
+                    CryptoHashOfPartialState::from(tip_metadata.certified_state_hash.clone())
+                } else if let Some(tip_certification) = states.certifications.get(&tip_height) {
+                    tip_certification.signed.content.hash.clone()
+                } else {
+                    std::mem::drop(states);
+
+                    let mut tip_certification_metadata = Self::compute_certification_metadata(
+                        &tip,
+                        tip_height,
+                        &self.metrics,
+                        &self.log,
+                    )
+                    .unwrap_or_else(|err| {
+                        fatal!(self.log, "Failed to compute hash tree: {:?}", err)
+                    });
+                    let tip_certified_state_hash = tip_certification_metadata.certified_state_hash;
+                    if let Some((hash_tree, _)) = tip_certification_metadata.hash_tree.take() {
+                        self.deallocator_thread.send(Box::new(hash_tree));
+                    }
+
+                    self.metrics.tip_hash_count.inc();
+
+                    CryptoHashOfPartialState::from(tip_certified_state_hash)
+                };
+
+                tip.metadata.prev_state_hash = Some(tip_hash);
                 return (tip_height, tip);
             }
         };
@@ -2765,12 +2828,14 @@ impl StateManager for StateManagerImpl {
         states.tip_height = target_snapshot.height;
         std::mem::drop(states);
 
-        let new_tip = initialize_tip(
+        let mut new_tip = initialize_tip(
             &self.log,
             &self.tip_channel,
             &target_snapshot,
             checkpoint_layout,
         );
+
+        new_tip.metadata.prev_state_hash = Some(target_hash);
 
         // This might still not be the latest version: there might have been
         // another successful state sync while we were updating the tip.
@@ -3262,64 +3327,12 @@ impl StateManager for StateManagerImpl {
             .with_label_values(&["commit_and_certify"])
             .start_timer();
 
-        let states = self.states.read();
-        let (prev_height, height) = {
-            let prev_height = states.tip_height;
-            let height = prev_height.increment();
-            (prev_height, height)
+        let height = {
+            let states = self.states.read();
+            states.tip_height.increment()
         };
 
-        self.populate_extra_metadata(&mut state);
-
-        // Get the previous state hash either from consensus via certifications (if we are catching up)
-        // or wait for the hashing thread to finish computing it.
-        let maybe_hash = states
-            .certifications
-            .get(&prev_height)
-            .map(|x| x.signed.content.hash.clone().get());
-        drop(states);
-        let prev_state_hash = if let Some(hash) = maybe_hash {
-            hash
-        } else {
-            // At prev_height 0, we don't have a hash yet, so we have to compute it.
-            if prev_height.get() == 0 {
-                let states = self.states.read();
-                let initial_snapshot = &states
-                    .snapshots
-                    .front()
-                    .expect("Initial state should always be present in states.snapshots.");
-                debug_assert_eq!(initial_snapshot.height.get(), 0);
-                let initial_state = &initial_snapshot.state;
-                let certification = StateManagerImpl::compute_certification_metadata(
-                    initial_state,
-                    prev_height,
-                    &self.metrics,
-                    &self.log,
-                )
-                .unwrap_or_else(|err| fatal!(self.log, "Failed to compute hash tree: {:?}", err));
-                certification.certified_state_hash.clone()
-            } else {
-                // Wait for the hashing thread.
-                let (sender, recv) = bounded(1);
-                self.hash_channel
-                    .send(HashRequest::Wait { sender })
-                    .expect("Failed to send `Wait` to hash channel");
-                recv.recv().expect("Failed to wait for hash channel");
-                // After awaiting the hashing thread, snapshot and certification_metadata
-                // must have an entry at height-1, so we can unwrap.
-                let states = self.states.read();
-                if let Some(cert_md) = states.certifications_metadata.get(&prev_height) {
-                    cert_md.certified_state_hash.clone()
-                } else {
-                    fatal!(
-                        self.log,
-                        "Previous state hash was not available after awaiting the hash thread. This is a bug."
-                    );
-                }
-            }
-        };
-        // Write the previous state hash to the state.
-        state.metadata.prev_state_hash = Some(CryptoHashOfPartialState::from(prev_state_hash));
+        self.populate_extra_metadata(&mut state, height);
 
         if let CertificationScope::Metadata = scope {
             // We want to balance writing too many overlay files with having too many unflushed pages at
@@ -3353,36 +3366,29 @@ impl StateManager for StateManagerImpl {
 
         // If the node is catching up (`height.get() < fast_forward_height`)
         // and this is not a checkpoint height (`matches!(scope, CertificationScope::Metadata)`),
-        // and the state hash @ height is present in states.certifications (via consensus),
         // then we do not clone, do not hash, and do not store the state and certification metadata.
-        // This optimization is skipped every `MAX_CONSECUTIVE_ROUNDS_WITHOUT_STATE_CLONING_AND_HASHING` heights
+        // This optimization is skipped every `MAX_CONSECUTIVE_ROUNDS_WITHOUT_STATE_CLONING` heights
         // so that we always have a reasonably "recent" state snapshot and
         // its certification metadata available.
-        let maybe_delivered_certification = {
-            // Scope to drop this lock.
+        let fast_forward_height = self.fast_forward_height.load(Ordering::Relaxed);
+        if matches!(scope, CertificationScope::Metadata)
+            && height.get() < fast_forward_height
+            && !height
+                .get()
+                .is_multiple_of(MAX_CONSECUTIVE_ROUNDS_WITHOUT_STATE_CLONING)
+        {
             let mut states = self.states.write();
-            let maybe_delivered_certification = states.certifications.get(&height).cloned();
-            let fast_forward_height = self.fast_forward_height.load(Ordering::Relaxed);
-            if matches!(scope, CertificationScope::Metadata)
-                && height.get() < fast_forward_height
-                && !height
-                    .get()
-                    .is_multiple_of(MAX_CONSECUTIVE_ROUNDS_WITHOUT_STATE_CLONING_AND_HASHING)
-                && maybe_delivered_certification.is_some()
-            {
-                #[cfg(debug_assertions)]
-                check_certifications_metadata_snapshots_and_states_metadata_are_consistent(&states);
+            #[cfg(debug_assertions)]
+            check_certifications_metadata_snapshots_and_states_metadata_are_consistent(&states);
 
-                assert_tip_is_none(&states);
+            assert_tip_is_none(&states);
 
-                self.metrics.no_state_clone_count.inc();
+            self.metrics.no_state_clone_count.inc();
 
-                states.tip_height = height;
-                states.tip = Some(state);
-                return;
-            }
-            maybe_delivered_certification
-        };
+            states.tip_height = height;
+            states.tip = Some(state);
+            return;
+        }
 
         self.metrics
             .tip_handler_queue_length
@@ -3409,19 +3415,18 @@ impl StateManager for StateManagerImpl {
             CertificationScope::Metadata => Arc::new(state),
         };
 
-        // Kick off hashing of the new state. This will also compare the result with the
-        // delivered hash, if present, in order to detect divergence.
-        let hash_req = HashRequest::HashState {
-            state: Arc::clone(&state),
-            states: Arc::clone(&self.states),
-            latest_state_height: Arc::clone(&self.latest_state_height),
-            height,
-            latest_height_update_time: Arc::clone(&self.latest_height_update_time),
-            reference_certification: Box::new(maybe_delivered_certification),
-            scope: scope.clone(),
-            state_layout: Box::new(self.state_layout.clone()),
-        };
-        self.hash_channel.send(hash_req).unwrap();
+        let mut certification_metadata =
+            Self::compute_certification_metadata(&state, height, &self.metrics, &self.log)
+                .unwrap_or_else(|err| fatal!(self.log, "Failed to compute hash tree: {:?}", err));
+
+        if scope == CertificationScope::Full {
+            info!(
+                self.log,
+                "Certification hash for height {}: {:?}",
+                height,
+                certification_metadata.certified_state_hash
+            );
+        }
 
         // This step is expensive, so we do it before the write lock for `states`.
         let next_tip = {
@@ -3433,18 +3438,76 @@ impl StateManager for StateManagerImpl {
             (height, state.deref().clone())
         };
 
-        // For checkpoint heights, we await the state hash immediately. This may not be necessary,
-        // but it keeps the existing checkpointing behaviour as is.
-        // Note: This must not be called while a write lock to `states` is being held.
-        if scope == CertificationScope::Full {
-            self.flush_hash_channel();
-        }
-
         let mut states = self.states.write();
         #[cfg(debug_assertions)]
         check_certifications_metadata_snapshots_and_states_metadata_are_consistent(&states);
 
         assert_tip_is_none(&states);
+
+        let assert_prev_hash_matches = |prev_hash| {
+            let hash = &certification_metadata.certified_state_hash;
+            if prev_hash != hash {
+                if let Err(err) = self.state_layout.create_diverged_state_marker(height) {
+                    error!(
+                        self.log,
+                        "Failed to mark state @{} diverged: {}", height, err
+                    );
+                }
+                panic!(
+                    "Committed state @{height} with hash {hash:?} which is different from previously computed or delivered hash {prev_hash:?}"
+                );
+            }
+        };
+
+        // It's possible that we already computed this state before.  We
+        // validate that hashes agree to spot bugs causing non-determinism as
+        // early as possible.
+        if let Some(prev_metadata) = states.certifications_metadata.get(&height) {
+            let prev_hash = &prev_metadata.certified_state_hash;
+            assert_prev_hash_matches(prev_hash);
+        }
+
+        // We reuse certification delivered by consensus if possible.
+        // We also validate that hashes agree to spot bugs causing non-determinism as
+        // early as possible.
+        if let Some(certification) = states.certifications.get(&height) {
+            let prev_hash = &certification.signed.content.hash.clone().get();
+            assert_prev_hash_matches(prev_hash);
+            certification_metadata.certification = Some(certification.clone());
+        }
+
+        if !states
+            .snapshots
+            .iter()
+            .any(|snapshot| snapshot.height == height)
+        {
+            states.snapshots.push_back(Snapshot {
+                height,
+                state: Arc::clone(&state),
+            });
+            states
+                .snapshots
+                .make_contiguous()
+                .sort_by_key(|snapshot| snapshot.height);
+
+            states
+                .certifications_metadata
+                .insert(height, certification_metadata);
+
+            let latest_height = update_latest_height(&self.latest_state_height, height);
+            self.metrics.max_resident_height.set(latest_height as i64);
+            {
+                let mut last_height_update_time = self
+                    .latest_height_update_time
+                    .lock()
+                    .expect("Failed to lock last height update time.");
+                let now = Instant::now();
+                self.metrics
+                    .height_update_time_seconds
+                    .observe((now - *last_height_update_time).as_secs_f64());
+                *last_height_update_time = now;
+            }
+        }
 
         if let Some((state_metadata, compute_manifest_request)) =
             state_metadata_and_compute_manifest_request
@@ -3471,6 +3534,7 @@ impl StateManager for StateManagerImpl {
         // tip if needed.
         states.tip_height = next_tip.0;
         states.tip = Some(next_tip.1);
+
         if scope == CertificationScope::Full {
             self.release_lock_and_persist_metadata(states);
         }
@@ -3526,160 +3590,6 @@ impl StateManager for StateManagerImpl {
         self.release_lock_and_persist_metadata(states);
 
         fatal!(self.log, "Replica diverged at height {}", height)
-    }
-}
-
-enum HashRequest {
-    HashState {
-        state: Arc<ReplicatedState>,
-        states: Arc<parking_lot::RwLock<SharedState>>,
-        latest_state_height: Arc<AtomicU64>,
-        height: Height,
-        latest_height_update_time: Arc<Mutex<Instant>>,
-        /// A certification from consensus. If `Some`, we compare it with the state hash
-        /// we calculate and panic on divergence. It should be `Some` whenever we are catching up and could
-        /// skip hashing, but we do hash anyway because we are at a height which is a multiple of
-        /// `MAX_CONSECUTIVE_ROUNDS_WITHOUT_STATE_CLONING`.
-        reference_certification: Box<Option<Certification>>,
-        scope: CertificationScope,
-        /// Boxed so that variants have similar size and we don't waste space when sending `HashRequest::Wait`.
-        state_layout: Box<StateLayout>,
-    },
-    /// Wait for the message to be executed and notify back via `sender`.
-    Wait { sender: Sender<()> },
-}
-
-fn spawn_hash_thread(
-    metrics: StateManagerMetrics,
-    log: ReplicaLogger,
-) -> (JoinOnDrop<()>, Sender<HashRequest>) {
-    #[allow(clippy::disallowed_methods)]
-    let (hash_req_sender, receiver) = unbounded();
-    let handle = JoinOnDrop::new(
-        std::thread::Builder::new()
-            .name("HashThread".to_string())
-            .spawn(move || {
-                while let Ok(req) = receiver.recv() {
-                    match req {
-                        HashRequest::HashState {
-                            state,
-                            states,
-                            latest_state_height,
-                            height,
-                            latest_height_update_time,
-                            reference_certification,
-                            scope,
-                            state_layout,
-                        } => {
-                            let mut certification_metadata =
-                                StateManagerImpl::compute_certification_metadata(
-                                    &state, height, &metrics, &log,
-                                )
-                                .unwrap_or_else(|err| {
-                                    fatal!(log, "Failed to compute hash tree: {:?}", err)
-                                });
-                            if scope == CertificationScope::Full {
-                                info!(
-                                    log,
-                                    "Certification hash for height {}: {:?}",
-                                    height,
-                                    certification_metadata.certified_state_hash
-                                );
-                            }
-                            let hash = &certification_metadata.certified_state_hash;
-
-                            // Closure to compare computed hash with potential hashes from other sources.
-                            let assert_prev_hash_matches = |prev_hash: &CryptoHash, msg: &str| {
-                                if prev_hash != hash {
-                                    if let Err(err) = state_layout.create_diverged_state_marker(height) {
-                                        error!(
-                                            log,
-                                            "Failed to mark state @{} diverged: {}", height, err
-                                        );
-                                    }
-                                    panic!(
-                                        "Committed state @{height} with hash {hash:?} which is different from {msg} hash {prev_hash:?}"
-                                    );
-                                }
-                            };
-                            // If a reference hash from consensus is available, check if we agree.
-                            if let Some(ref cert) = *reference_certification {
-                                let delivered_hash = cert.signed.content.hash.as_ref();
-                                assert_prev_hash_matches(delivered_hash, "delivered");
-                                // If we do agree, write the certification to the metadata, so that consensus does
-                                // not have to deliver it again. 
-                                certification_metadata.certification = *reference_certification;
-                            }
-
-                            // It's possible that we already computed this state before. We
-                            // validate that hashes agree to spot bugs causing non-determinism as
-                            // early as possible. 
-                            let mut states = states.write();
-                            if let Some(prev_metadata) = states.certifications_metadata.get(&height) {
-                                let prev_hash = &prev_metadata.certified_state_hash;
-                                assert_prev_hash_matches(prev_hash, "previously computed");
-                            }
-
-                            // Add state and hash to snapshots and certification_metadata
-                            if !states
-                                .snapshots
-                                .iter()
-                                .any(|snapshot| snapshot.height == height)
-                            {
-                                states.snapshots.push_back(Snapshot {
-                                    height,
-                                    state: Arc::clone(&state),
-                                });
-                                states
-                                    .snapshots
-                                    .make_contiguous()
-                                    .sort_by_key(|snapshot| snapshot.height);
-
-                                states
-                                    .certifications_metadata
-                                    .insert(height, certification_metadata);
-                                let latest_height =
-                                    update_latest_height(&latest_state_height, height);
-
-                                metrics.max_resident_height.set(latest_height as i64);
-                                {
-                                    let mut last_height_update_time = latest_height_update_time
-                                        .lock()
-                                        .expect("Failed to lock last height update time.");
-                                    let now = Instant::now();
-                                    metrics
-                                        .height_update_time_seconds
-                                        .observe((now - *last_height_update_time).as_secs_f64());
-                                    *last_height_update_time = now;
-                                }
-                            }
-                        }
-                        HashRequest::Wait { sender } => {
-                            sender.send(()).unwrap();
-                        }
-                    }
-                }
-            })
-            .unwrap(),
-    );
-    (handle, hash_req_sender)
-}
-
-impl StateManagerImpl {
-    /// After this method terminates, both `SharedState.snapshots` and `SharedState.certification_metadata`
-    /// at the height from the previous `commit_and_certify` are populated. It also updates `latest_state_height`
-    /// to the maximum of the value before and the committed height.
-    ///
-    /// This used to happen synchronously inside `commit_and_certify`, but now happens in the hash thread
-    /// at an unpredictable time.
-    ///
-    /// Note: Do not call this function while the calling scope holds a write lock to `SharedState`.
-    pub fn flush_hash_channel(&self) {
-        let (sender, recv) = bounded(1);
-        self.hash_channel
-            .send(HashRequest::Wait { sender })
-            .expect("failed to send Wait message to hashing thread");
-        recv.recv().expect("failed to wait for hashing thread");
     }
 }
 

--- a/rs/state_manager/src/state_sync/chunkable/cache/tests.rs
+++ b/rs/state_manager/src/state_sync/chunkable/cache/tests.rs
@@ -43,7 +43,6 @@ impl TestEnvironment {
             &config,
             None,
             ic_types::malicious_flags::MaliciousFlags::default(),
-            tokio::sync::watch::channel(ic_types::Height::from(0)).0,
         ));
 
         let state_layout = state_manager.state_layout.clone();

--- a/rs/state_manager/tests/common/mod.rs
+++ b/rs/state_manager/tests/common/mod.rs
@@ -574,7 +574,6 @@ fn state_manager_with_verifier_result(
         &config,
         None,
         ic_types::malicious_flags::MaliciousFlags::default(),
-        tokio::sync::watch::channel(Height::from(0)).0,
     );
     (state_manager, tmp)
 }
@@ -629,7 +628,6 @@ fn state_manager_test_with_state_sync_and_verifier_result<
             &config,
             None,
             ic_types::malicious_flags::MaliciousFlags::default(),
-            tokio::sync::watch::channel(Height::from(0)).0,
         ));
         f(&metrics_registry, sm.clone(), StateSync::new(sm, log));
     })
@@ -668,7 +666,6 @@ where
                 &config,
                 starting_height,
                 ic_types::malicious_flags::MaliciousFlags::default(),
-                tokio::sync::watch::channel(Height::from(0)).0,
             ));
             let state_sync = StateSync::new(state_manager.clone(), log.clone());
 
@@ -727,7 +724,6 @@ where
                 &config,
                 starting_height,
                 ic_types::malicious_flags::MaliciousFlags::default(),
-                tokio::sync::watch::channel(Height::from(0)).0,
             );
 
             (metrics_registry, state_manager)
@@ -790,7 +786,6 @@ where
                 &config,
                 starting_height,
                 ic_types::malicious_flags::MaliciousFlags::default(),
-                tokio::sync::watch::channel(Height::from(0)).0,
             );
 
             (metrics_registry, state_manager)

--- a/rs/state_manager/tests/common/mod.rs
+++ b/rs/state_manager/tests/common/mod.rs
@@ -157,7 +157,7 @@ pub fn encode_decode_stream_test<
         });
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
+
         certify_height(&state_manager, Height::new(1));
 
         let slice = state_manager
@@ -219,7 +219,7 @@ pub fn encode_partial_slice_test(
         });
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
+
         certify_height(&state_manager, Height::new(1));
 
         let slice = state_manager
@@ -313,7 +313,6 @@ pub fn modify_encoded_stream_helper<F: FnOnce(StreamSlice) -> Stream>(
     });
 
     state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-    state_manager.flush_hash_channel();
 
     certify_height(state_manager, Height::new(2));
 

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -992,7 +992,6 @@ fn state_manager_crash_test<Test>(
                     &config,
                     None,
                     ic_types::malicious_flags::MaliciousFlags::default(),
-                    tokio::sync::watch::channel(Height::from(0)).0,
                 ));
             })
             .expect_err(&format!("Crash test fixture {i} did not crash"));
@@ -1011,7 +1010,6 @@ fn state_manager_crash_test<Test>(
                 &config,
                 None,
                 ic_types::malicious_flags::MaliciousFlags::default(),
-                tokio::sync::watch::channel(Height::from(0)).0,
             ),
         );
     });
@@ -1147,7 +1145,6 @@ fn checkpoints_outlive_state_manager() {
                 &config,
                 None,
                 ic_types::malicious_flags::MaliciousFlags::default(),
-                tokio::sync::watch::channel(Height::from(0)).0,
             );
             let (_height, mut state) = state_manager.take_tip();
             insert_dummy_canister(&mut state, canister_id);
@@ -1182,7 +1179,6 @@ fn checkpoints_outlive_state_manager() {
             &config,
             None,
             ic_types::malicious_flags::MaliciousFlags::default(),
-            tokio::sync::watch::channel(Height::from(0)).0,
         );
 
         assert_eq!(
@@ -1216,7 +1212,6 @@ fn certifications_are_not_persisted() {
                 &config,
                 None,
                 ic_types::malicious_flags::MaliciousFlags::default(),
-                tokio::sync::watch::channel(Height::from(0)).0,
             );
             let (_height, state) = state_manager.take_tip();
             state_manager.commit_and_certify(state, CertificationScope::Full, None);
@@ -1235,7 +1230,6 @@ fn certifications_are_not_persisted() {
                 &config,
                 None,
                 ic_types::malicious_flags::MaliciousFlags::default(),
-                tokio::sync::watch::channel(Height::from(0)).0,
             );
             assert_eq!(vec![Height(1)], heights_to_certify(&state_manager));
         }
@@ -6108,7 +6102,6 @@ fn diverged_checkpoint_is_complete() {
             &config,
             None,
             ic_types::malicious_flags::MaliciousFlags::default(),
-            tokio::sync::watch::channel(Height::from(0)).0,
         );
 
         let (_, state) = state_manager.take_tip();
@@ -6131,7 +6124,6 @@ fn diverged_checkpoint_is_complete() {
                 &config,
                 None,
                 ic_types::malicious_flags::MaliciousFlags::default(),
-                tokio::sync::watch::channel(Height::from(0)).0,
             );
             // If the Tip thread is active while we report diverged checkpoint, it may crash
             // which is OK in production but confuses debug assertions.
@@ -6150,7 +6142,6 @@ fn diverged_checkpoint_is_complete() {
             &config,
             None,
             ic_types::malicious_flags::MaliciousFlags::default(),
-            tokio::sync::watch::channel(Height::from(0)).0,
         );
 
         // check that the diverged checkpoint has the same manifest as before
@@ -9212,116 +9203,6 @@ fn deliver_state_certification_for_future_heights() {
             vec![opt_height]
         );
         assert_eq!(sm.certifications().get(&opt_height), Some(&certification));
-    });
-}
-
-/// Test that `max_certified_height_tx` is updated when `deliver_state_certification`
-/// certifies a height whose state is already committed (the common case), and that
-/// it is NOT updated again for the same or a lower height.
-#[test]
-fn max_certified_height_fires_when_state_already_committed() {
-    with_test_replica_logger(|log| {
-        let tmp = ic_test_utilities_tmpdir::tmpdir("sm");
-        let config = Config::new(tmp.path().into());
-        let metrics = MetricsRegistry::new();
-        let (max_certified_height_tx, mut max_certified_height_rx) =
-            tokio::sync::watch::channel(Height::from(0));
-        let sm = StateManagerImpl::new(
-            std::sync::Arc::new(FakeVerifier::new()),
-            subnet_test_id(42),
-            SubnetType::Application,
-            log,
-            &metrics,
-            &config,
-            None,
-            ic_types::malicious_flags::MaliciousFlags::default(),
-            max_certified_height_tx,
-        );
-
-        // Commit heights 1 and 2 so they are in certifications_metadata.
-        let (_, state) = sm.take_tip();
-        sm.commit_and_certify(state, CertificationScope::Full, None);
-        let (_, state) = sm.take_tip();
-        sm.commit_and_certify(state, CertificationScope::Full, None);
-
-        // No certification delivered yet — receiver should not have changed.
-        assert!(!max_certified_height_rx.has_changed().unwrap());
-
-        // Deliver certification for height 1: state is in certifications_metadata,
-        // so the height is certified immediately.
-        let cert1 = certify_height(&sm, Height(1));
-        assert!(
-            max_certified_height_rx.has_changed().unwrap(),
-            "receiver should fire when a committed state is certified"
-        );
-        assert_eq!(*max_certified_height_rx.borrow_and_update(), Height(1));
-
-        // Deliver certification for height 2: new higher height — receiver fires again.
-        certify_height(&sm, Height(2));
-        assert!(max_certified_height_rx.has_changed().unwrap());
-        assert_eq!(*max_certified_height_rx.borrow_and_update(), Height(2));
-
-        // Re-deliver certification for height 1 (lower than current max of 2): receiver must NOT fire.
-        // We call deliver_state_certification directly because list_state_hashes_to_certify()
-        // no longer returns already-certified heights.
-        sm.deliver_state_certification(cert1);
-        assert!(
-            !max_certified_height_rx.has_changed().unwrap(),
-            "receiver must not fire for a height lower than the already-transmitted maximum"
-        );
-    });
-}
-
-/// Test that `max_certified_height_tx` is NOT updated when `deliver_state_certification`
-/// receives a certification for a height whose state has not been committed yet
-/// (the certification is deferred into `states.certifications`).
-#[test]
-fn max_certified_height_deferred_when_cert_arrives_before_state() {
-    with_test_replica_logger(|log| {
-        let tmp = ic_test_utilities_tmpdir::tmpdir("sm");
-        let config = Config::new(tmp.path().into());
-        let metrics = MetricsRegistry::new();
-        let (max_certified_height_tx, max_certified_height_rx) =
-            tokio::sync::watch::channel(Height::from(0));
-        let sm = StateManagerImpl::new(
-            std::sync::Arc::new(FakeVerifier::new()),
-            subnet_test_id(42),
-            SubnetType::Application,
-            log,
-            &metrics,
-            &config,
-            None,
-            ic_types::malicious_flags::MaliciousFlags::default(),
-            max_certified_height_tx,
-        );
-
-        // Set fast_forward_height so that height 1 is in the range of heights to certify.
-        sm.update_fast_forward_height(Height::new(2));
-
-        // Deliver a certification for height 1 before the state at height 1 is committed.
-        // This stores the certification in `states.certifications` (deferred path).
-        // The hash is fake so this cert will never match a real committed state,
-        // but it is sufficient to verify that the receiver does not fire prematurely.
-        let fake_cert = fake_certification_for_height(Height::new(1));
-        sm.deliver_state_certification(fake_cert.clone());
-
-        // The certification is stored in `states.certifications` but the height is not yet
-        // certified — the receiver must not fire.
-        assert_eq!(sm.certifications_metadata_heights(), vec![]);
-        assert_eq!(
-            sm.certifications().keys().cloned().collect::<Vec<_>>(),
-            vec![Height::new(1)]
-        );
-        assert_eq!(sm.certifications().get(&Height::new(1)), Some(&fake_cert));
-        assert!(
-            !max_certified_height_rx.has_changed().unwrap(),
-            "receiver must not fire when the state has not been committed yet"
-        );
-        assert_eq!(
-            *max_certified_height_rx.borrow(),
-            Height::from(0),
-            "max certified height must remain 0 until a state is truly certified"
-        );
     });
 }
 

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -1051,12 +1051,10 @@ fn latest_state_height_updated_on_commit() {
         assert_eq!(Height(0), state_manager.latest_state_height());
 
         state_manager.commit_and_certify(tip, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         assert_eq!(Height(1), state_manager.latest_state_height());
 
         let (_, tip) = state_manager.take_tip();
         state_manager.commit_and_certify(tip, CertificationScope::Full, None);
-        state_manager.flush_hash_channel();
         assert_eq!(Height(2), state_manager.latest_state_height());
     })
 }
@@ -1069,7 +1067,6 @@ fn populates_prev_state_hash() {
 
         let (_height, state_1) = state_manager.take_tip();
         state_manager.commit_and_certify(state_1, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         let state_2 = state_manager.get_latest_state().take();
 
         let hashes = state_manager.list_state_hashes_to_certify();
@@ -1100,8 +1097,7 @@ fn returns_state_no_committed_for_future_states() {
 }
 
 #[test]
-#[should_panic(expected = "failed to wait for hashing thread: RecvError")]
-// The hash thread panics with "which is different from previously computed or delivered hash", but we can't relay this.
+#[should_panic(expected = "which is different from previously computed or delivered hash")]
 fn panics_on_forked_history() {
     state_manager_test(|_metrics, state_manager| {
         // Create a checkpoint at h which we can fetch later.
@@ -1503,7 +1499,6 @@ fn should_archive_checkpoints_correctly() {
 
             state_manager.commit_and_certify(state, scope.clone(), None);
         }
-        state_manager.flush_hash_channel();
 
         assert_eq!(Height(13), state_manager.latest_state_height());
         let latest_state = state_manager.get_latest_state();
@@ -1567,7 +1562,6 @@ fn can_remove_checkpoints() {
 
             state_manager.commit_and_certify(state, scope.clone(), None);
         }
-        state_manager.flush_hash_channel();
         assert_eq!(state_manager.list_state_heights(CERT_ANY), heights);
         state_manager.flush_tip_channel();
         state_manager.remove_states_below(Height(4));
@@ -1615,7 +1609,6 @@ fn cannot_remove_height_zero() {
 
         let (_height, state) = state_manager.take_tip();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         assert_eq!(
             state_manager.list_state_heights(CERT_ANY),
@@ -1647,7 +1640,6 @@ fn cannot_remove_latest_height_or_checkpoint() {
 
             state_manager.commit_and_certify(state, scope.clone(), None);
         }
-        state_manager.flush_hash_channel();
 
         assert_eq!(
             state_manager.list_state_heights(CERT_ANY).last(),
@@ -1668,7 +1660,6 @@ fn cannot_remove_latest_height_or_checkpoint() {
 
         let (_height, state) = state_manager.take_tip();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         assert_eq!(
             state_manager.list_state_heights(CERT_ANY).last(),
@@ -1869,7 +1860,6 @@ fn can_keep_last_checkpoint_and_higher_states_after_removal() {
 
             state_manager.commit_and_certify(state, scope.clone(), None);
         }
-        state_manager.flush_hash_channel();
         assert_eq!(state_manager.list_state_heights(CERT_ANY), heights);
         state_manager.flush_tip_channel();
         state_manager.remove_states_below(Height(10));
@@ -1923,7 +1913,6 @@ fn can_keep_latest_verified_checkpoint_after_removal_with_unverified_checkpoints
 
             state_manager.commit_and_certify(state, scope.clone(), None);
         }
-        state_manager.flush_hash_channel();
         assert_eq!(state_manager.list_state_heights(CERT_ANY), heights);
         state_manager.flush_tip_channel();
 
@@ -1998,7 +1987,6 @@ fn should_restart_from_the_latest_checkpoint_requested_to_remove() {
 
             state_manager.commit_and_certify(state, scope.clone(), None);
         }
-        state_manager.flush_hash_channel();
         assert_eq!(state_manager.list_state_heights(CERT_ANY), heights);
         state_manager.flush_tip_channel();
         state_manager.remove_states_below(Height(7));
@@ -2158,7 +2146,6 @@ fn should_not_remove_latest_state_after_restarting_without_checkpoints() {
             let (_, state) = state_manager.take_tip();
             state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
             state_manager.remove_states_below(Height(i));
-            state_manager.flush_hash_channel();
             state_manager.flush_deallocation_channel();
         }
 
@@ -2167,7 +2154,6 @@ fn should_not_remove_latest_state_after_restarting_without_checkpoints() {
             let (_, state) = state_manager.take_tip();
             state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
             state_manager.remove_states_below(Height(10));
-            state_manager.flush_hash_channel();
             state_manager.flush_deallocation_channel();
             assert_eq!(Height(i), state_manager.latest_state_height());
         }
@@ -2293,7 +2279,6 @@ fn latest_certified_state_is_not_removed() {
     state_manager_test(|_metrics, state_manager| {
         let (_height, state) = state_manager.take_tip();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         certify_height(&state_manager, Height(1));
 
         let (_height, state) = state_manager.take_tip();
@@ -2304,7 +2289,6 @@ fn latest_certified_state_is_not_removed() {
 
         let (_height, state) = state_manager.take_tip();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         state_manager.flush_tip_channel();
         state_manager.remove_states_below(Height(4));
@@ -2328,7 +2312,7 @@ fn can_return_and_remember_certifications() {
 
         let (_height, state) = state_manager.take_tip();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
+
         assert_eq!(
             vec![Height(1), Height(2)],
             heights_to_certify(&state_manager)
@@ -2344,12 +2328,10 @@ fn certifications_of_transient_states_are_not_cached() {
     state_manager_restart_test(|state_manager, restart_fn| {
         let (_height, state) = state_manager.take_tip();
         state_manager.commit_and_certify(state, CertificationScope::Full, None);
-        state_manager.flush_hash_channel();
         certify_height(&state_manager, Height(1));
 
         let (_height, state) = state_manager.take_tip();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         certify_height(&state_manager, Height(2));
 
         assert_eq!(Vec::<Height>::new(), heights_to_certify(&state_manager));
@@ -2360,7 +2342,6 @@ fn certifications_of_transient_states_are_not_cached() {
         let (_height, state) = state_manager.take_tip();
         // Commit the same state again. The certification should be re-used.
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         assert_eq!(
             vec![Height(1), Height(2)],
             heights_to_certify(&state_manager)
@@ -2373,7 +2354,7 @@ fn uses_latest_certified_state_to_decode_certified_streams() {
     state_manager_test(|_metrics, state_manager| {
         let (_height, state) = state_manager.take_tip();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
+
         let subnet = subnet_test_id(42);
 
         // no streams yet
@@ -2390,7 +2371,6 @@ fn uses_latest_certified_state_to_decode_certified_streams() {
         });
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         // Have a stream, but this state is not certified yet.
         assert_eq!(
             state_manager.encode_certified_stream_slice(subnet, None, None, None, None),
@@ -2418,7 +2398,6 @@ fn encode_stream_index_is_checked() {
         });
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         certify_height(&state_manager, Height(1));
 
         let zero_idx = StreamIndex::from(0);
@@ -4172,7 +4151,6 @@ fn can_commit_after_prev_state_is_gone() {
             let (_height, mut tip) = dst_state_manager.take_tip();
             insert_dummy_canister(&mut tip, canister_test_id(100));
             dst_state_manager.commit_and_certify(tip, CertificationScope::Metadata, None);
-            dst_state_manager.flush_hash_channel();
 
             let (_height, tip) = dst_state_manager.take_tip();
 
@@ -4184,11 +4162,9 @@ fn can_commit_after_prev_state_is_gone() {
             dst_state_manager.flush_deallocation_channel();
 
             assert_eq!(Height(3), dst_state_manager.latest_state_height());
-            // tip_height should be present
-            assert!(dst_state_manager.get_state_at(Height(1)).is_ok());
             assert_eq!(
-                dst_state_manager.get_state_at(Height(2)),
-                Err(StateManagerError::StateRemoved(Height(2)))
+                dst_state_manager.get_state_at(Height(1)),
+                Err(StateManagerError::StateRemoved(Height(1)))
             );
 
             // Check that we can still commit the old tip.
@@ -5055,7 +5031,7 @@ fn should_not_leak_checkpoint_when_state_sync_into_existing_snapshot_height() {
 
         let (_height, state) = src_state_manager.take_tip();
         src_state_manager.commit_and_certify(state, CertificationScope::Full, None);
-        src_state_manager.flush_hash_channel();
+
         wait_for_checkpoint(&*src_state_manager, Height(3));
 
         certify_height(&*src_state_manager, Height(1));
@@ -5076,7 +5052,6 @@ fn should_not_leak_checkpoint_when_state_sync_into_existing_snapshot_height() {
             let (tip_height, state) = dst_state_manager.take_tip();
             assert_eq!(tip_height, Height(0));
             dst_state_manager.commit_and_certify(state, CertificationScope::Full, None);
-            dst_state_manager.flush_hash_channel();
             dst_state_manager.flush_tip_channel();
             certify_height(&*dst_state_manager, Height(1));
 
@@ -5093,12 +5068,10 @@ fn should_not_leak_checkpoint_when_state_sync_into_existing_snapshot_height() {
 
             let (_height, state) = dst_state_manager.take_tip();
             dst_state_manager.commit_and_certify(state, CertificationScope::Full, None);
-            dst_state_manager.flush_hash_channel();
             certify_height(&*dst_state_manager, Height(2));
 
             let (_height, state) = dst_state_manager.take_tip();
             dst_state_manager.commit_and_certify(state, CertificationScope::Full, None);
-            dst_state_manager.flush_hash_channel();
             dst_state_manager.flush_tip_channel();
 
             dst_state_manager.remove_states_below(Height(3));
@@ -5138,7 +5111,6 @@ fn should_not_leak_checkpoint_when_state_sync_into_existing_snapshot_height() {
 
             let (_height, state) = dst_state_manager.take_tip();
             dst_state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-            dst_state_manager.flush_hash_channel();
             certify_height(&*dst_state_manager, Height(3));
             certify_height(&*dst_state_manager, Height(4));
             assert_eq!(dst_state_manager.latest_certified_height(), Height(4));
@@ -5410,7 +5382,6 @@ fn certified_read_can_certify_ingress_history_entry() {
             |_| {},
         );
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         let path: LabeledTree<()> = LabeledTree::SubTree(flatmap! {
             label("request_status") => LabeledTree::SubTree(
                 flatmap! {
@@ -5452,7 +5423,6 @@ fn certified_read_can_certify_time() {
 
         state.metadata.batch_time += Duration::new(0, 100);
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         let path: LabeledTree<()> = LabeledTree::SubTree(flatmap! {
             label("time") => Leaf(())
         });
@@ -5483,7 +5453,6 @@ fn certified_read_can_certify_canister_data() {
         insert_dummy_canister(&mut state, canister_id);
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let path = SubTree(flatmap! {
             label("canister") => SubTree(
@@ -5554,7 +5523,6 @@ fn certified_read_can_certify_node_public_keys_since_v12() {
         state.metadata.node_public_keys = node_public_keys;
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let subnet_id = subnet_test_id(42).get();
         let node_id = node_test_id(39).get();
@@ -5620,7 +5588,6 @@ fn certified_read_can_certify_api_boundary_nodes_since_v16() {
         };
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let api_bn_id = node_test_id(11).get();
         let path: Vec<&[u8]> = vec![b"api_boundary_nodes", api_bn_id.as_ref()];
@@ -5659,7 +5626,6 @@ fn certified_read_succeeds_for_empty_forks() {
         let (_, state) = state_manager.take_tip();
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let path: LabeledTree<()> = LabeledTree::SubTree(flatmap! {
             label("api_boundary_nodes") => LabeledTree::Leaf(()),
@@ -5700,7 +5666,6 @@ fn certified_read_succeeds_for_empty_tree() {
         let (_, state) = state_manager.take_tip();
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let path: LabeledTree<()> = LabeledTree::SubTree(flatmap! {});
 
@@ -5731,7 +5696,6 @@ fn certified_read_returns_absence_proof_for_non_existing_entries() {
             |_| {},
         );
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let path: LabeledTree<()> = LabeledTree::SubTree(flatmap! {
             label("request_status") => LabeledTree::SubTree(
@@ -5772,7 +5736,6 @@ fn certified_read_returns_absence_proof_for_non_existing_entries_in_empty_state(
         let (_, state) = state_manager.take_tip();
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let path: LabeledTree<()> = LabeledTree::SubTree(flatmap! {
             label("request_status") => LabeledTree::SubTree(
@@ -5821,7 +5784,6 @@ fn certified_read_can_fetch_multiple_entries_in_one_go() {
             |_| {},
         );
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let path: LabeledTree<()> = LabeledTree::SubTree(flatmap! {
             label("request_status") => LabeledTree::SubTree(
@@ -5889,7 +5851,6 @@ fn certified_read_can_produce_proof_of_absence() {
             |_| {},
         );
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let path: LabeledTree<()> = LabeledTree::SubTree(flatmap! {
             label("request_status") => LabeledTree::SubTree(
@@ -5970,7 +5931,6 @@ fn certified_read_can_exclude_canister_ranges() {
         state.metadata.network_topology = network_topology;
 
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
 
         let path = SubTree(flatmap! {
             label("subnet") => Leaf(())
@@ -6165,12 +6125,10 @@ fn report_diverged_state() {
         vec![Box::new(|state_manager: StateManagerImpl| {
             let (_height, state) = state_manager.take_tip();
             state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-            state_manager.flush_hash_channel();
             std::thread::sleep(std::time::Duration::from_secs(2));
             let mut certification = certify_height(&state_manager, Height(1));
             let (_height, state) = state_manager.take_tip();
             state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-            state_manager.flush_hash_channel();
             // Hack the certification so it is a divergence
             certification.height = Height(2);
 
@@ -6384,13 +6342,11 @@ fn remove_too_many_diverged_state_markers() {
     fn diverge_state_at(state_manager: StateManagerImpl, divergence: u64) {
         let (_height, state) = state_manager.take_tip();
         state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
-        state_manager.flush_hash_channel();
         let mut certification = certify_height(&state_manager, Height(1));
         for _i in 2..(divergence + 1) {
             let (_height, state) = state_manager.take_tip();
             state_manager.commit_and_certify(state, CertificationScope::Metadata, None);
         }
-        state_manager.flush_hash_channel();
         // Hack the certification so it is a divergence
         certification.height = Height(divergence);
 
@@ -6882,6 +6838,7 @@ fn can_delete_canister() {
 
         state_manager.commit_and_certify(state, CertificationScope::Full, None);
         state_manager.flush_tip_channel();
+
         // Check the checkpoint has the canister.
         let canister_path = state_manager
             .state_layout()
@@ -8975,6 +8932,12 @@ fn no_state_clone_count(metrics: &MetricsRegistry) -> u64 {
         .sum::<u64>()
 }
 
+fn tip_hash_count(metrics: &MetricsRegistry) -> u64 {
+    fetch_int_counter_vec(metrics, "state_manager_tip_hash_count")
+        .values()
+        .sum::<u64>()
+}
+
 fn flush_unflushed_delta_count(metrics: &MetricsRegistry) -> u64 {
     let mut labels = BTreeMap::new();
     labels.insert("request".to_string(), "flush_unflushed_delta".to_string());
@@ -9006,15 +8969,11 @@ fn fake_certification_for_height_with_hash(height: Height, hash: CryptoHash) -> 
 fn commit_and_certify_optimization_conditions() {
     state_manager_test(|metrics, sm| {
         // update `fast_forward_height` to enable optimization
-        sm.update_fast_forward_height(Height::new(11));
-        assert_eq!(sm.fast_forward_height(), 11);
+        sm.update_fast_forward_height(Height::new(21));
+        assert_eq!(sm.fast_forward_height(), 21);
 
         // optimization has not triggered yet
         assert_eq!(no_state_clone_count(metrics), 0);
-
-        // consensus delivers a certification so the optimization triggers
-        let certification = fake_certification_for_height(Height::new(1));
-        sm.deliver_state_certification(certification.clone());
 
         // all conditions are satisfied => optimization triggers
         let state = sm.take_tip().1;
@@ -9026,11 +8985,9 @@ fn commit_and_certify_optimization_conditions() {
         sm.commit_and_certify_at_height(state, Height::new(2), CertificationScope::Full, None);
         assert_eq!(no_state_clone_count(metrics), 1);
 
-        // deliver cert -> optimization triggers
+        // heights of 10 and 20 are divisible by 10 => optimization does not trigger at those heights
         let mut expected_no_state_clone_count = 1;
-        for height in 3_u64..10_u64 {
-            expected_no_state_clone_count += 1;
-            sm.deliver_state_certification(fake_certification_for_height(Height::new(height)));
+        for height in 3..21 {
             let state = sm.take_tip().1;
             sm.commit_and_certify_at_height(
                 state,
@@ -9038,36 +8995,16 @@ fn commit_and_certify_optimization_conditions() {
                 CertificationScope::Metadata,
                 None,
             );
+            if !height.is_multiple_of(10) {
+                expected_no_state_clone_count += 1;
+            }
             assert_eq!(no_state_clone_count(metrics), expected_no_state_clone_count);
         }
-        // at height 10, do deliver cert, but it should skip optimization anyway
-        let height = 10;
-        sm.deliver_state_certification(fake_certification_for_height_with_hash(
-            Height::new(height),
-            CryptoHash(
-                hex::decode("d90d05f3d971482d2ccdc594de723d786afaed32737b19e42f85a1ebe8e21a21")
-                    .unwrap(),
-            ),
-        ));
-        let state = sm.take_tip().1;
-        sm.commit_and_certify_at_height(
-            state,
-            Height::new(height),
-            CertificationScope::Metadata,
-            None,
-        );
-        assert_eq!(no_state_clone_count(metrics), expected_no_state_clone_count);
 
-        // height of 11 is not less than `fast_forward_height` => optimization does not trigger
-        let height = 11;
-        assert_eq!(sm.fast_forward_height(), height);
+        // height of 21 is not less than `fast_forward_height` => optimization does not trigger
+        assert_eq!(sm.fast_forward_height(), 21);
         let state = sm.take_tip().1;
-        sm.commit_and_certify_at_height(
-            state,
-            Height::new(height),
-            CertificationScope::Metadata,
-            None,
-        );
+        sm.commit_and_certify_at_height(state, Height::new(21), CertificationScope::Metadata, None);
         assert_eq!(no_state_clone_count(metrics), expected_no_state_clone_count);
     });
 }
@@ -9086,15 +9023,14 @@ fn commit_and_certify_optimization_semantics() {
         let only_initial_state = || {
             assert_eq!(sm.state_snapshot_heights(), vec![INITIAL_STATE_HEIGHT]);
             assert!(sm.certifications_metadata_heights().is_empty());
+            assert!(sm.certifications().is_empty());
         };
         only_initial_state();
-        assert!(sm.certifications().is_empty());
 
         // optimization triggers => no state snapshot and certifications metadata are stored => still just the initial state in `states`
         let mut batch_time_opt = None;
         let mut expected_no_state_clone_count = 0;
         for opt_height in 1..10 {
-            sm.deliver_state_certification(fake_certification_for_height(Height::new(opt_height)));
             let (height, mut state) = sm.take_tip();
             assert_eq!(height, Height::new(opt_height - 1)); // tip height is set correctly if optimization triggers
             if let Some(batch_time) = batch_time_opt {
@@ -9119,7 +9055,6 @@ fn commit_and_certify_optimization_semantics() {
         let batch_time_no_opt = state.metadata.batch_time;
         let no_opt_height = Height::new(10);
         sm.commit_and_certify_at_height(state, no_opt_height, CertificationScope::Metadata, None);
-        sm.flush_hash_channel();
         assert_eq!(no_state_clone_count(metrics), expected_no_state_clone_count);
 
         assert_eq!(
@@ -9138,6 +9073,7 @@ fn commit_and_certify_optimization_semantics() {
             sm.certifications_metadata_certification(no_opt_height)
                 .is_none()
         );
+        assert!(sm.certifications().is_empty());
     });
 }
 
@@ -9207,6 +9143,112 @@ fn deliver_state_certification_for_future_heights() {
 }
 
 #[test]
+fn take_tip_does_not_hash_without_optimization() {
+    state_manager_test(|metrics, sm| {
+        // optimization has not triggered yet
+        assert_eq!(no_state_clone_count(metrics), 0);
+
+        // the initial state is always hashed in `take_tip`
+        assert_eq!(tip_hash_count(metrics), 0);
+        let (initial_height, initial_state) = sm.take_tip();
+        assert_eq!(initial_height, INITIAL_STATE_HEIGHT);
+        assert_eq!(tip_hash_count(metrics), 1);
+
+        // optimization does not trigger
+        let no_opt_height = Height::new(1);
+        sm.commit_and_certify_at_height(
+            initial_state,
+            no_opt_height,
+            CertificationScope::Metadata,
+            None,
+        );
+        assert_eq!(no_state_clone_count(metrics), 0);
+
+        // the state at height 1 is not hashed in `take_tip` since certification metadata are computed
+        assert_eq!(tip_hash_count(metrics), 1);
+        let (height, _state) = sm.take_tip();
+        assert_eq!(tip_hash_count(metrics), 1);
+        assert_eq!(height, no_opt_height);
+    });
+}
+
+#[test]
+fn take_tip_does_not_hash_with_optimization() {
+    state_manager_test(|metrics, sm| {
+        // consensus delivers certification for the next height
+        let opt_height = Height::new(1);
+        let certification = fake_certification_for_height(opt_height);
+        sm.deliver_state_certification(certification);
+        assert_eq!(
+            sm.certifications().keys().cloned().collect::<Vec<_>>(),
+            vec![opt_height]
+        );
+
+        // update `fast_forward_height` to enable optimization
+        sm.update_fast_forward_height(Height::new(42));
+        assert_eq!(sm.fast_forward_height(), 42);
+
+        // optimization has not triggered yet
+        assert_eq!(no_state_clone_count(metrics), 0);
+
+        // the initial state is always hashed in `take_tip`
+        assert_eq!(tip_hash_count(metrics), 0);
+        let (initial_height, initial_state) = sm.take_tip();
+        assert_eq!(initial_height, INITIAL_STATE_HEIGHT);
+        assert_eq!(tip_hash_count(metrics), 1);
+
+        // optimization triggers
+        sm.commit_and_certify_at_height(
+            initial_state,
+            opt_height,
+            CertificationScope::Metadata,
+            None,
+        );
+        assert_eq!(no_state_clone_count(metrics), 1);
+
+        // the state at height 1 is not hashed in `take_tip` since certification was delivered
+        assert_eq!(tip_hash_count(metrics), 1);
+        let (height, _state) = sm.take_tip();
+        assert_eq!(tip_hash_count(metrics), 1);
+        assert_eq!(height, opt_height);
+    });
+}
+
+#[test]
+fn take_tip_hashes_with_optimization() {
+    state_manager_test(|metrics, sm| {
+        // update `fast_forward_height` to enable optimization
+        sm.update_fast_forward_height(Height::new(42));
+        assert_eq!(sm.fast_forward_height(), 42);
+
+        // optimization has not triggered yet
+        assert_eq!(no_state_clone_count(metrics), 0);
+
+        // the initial state is always hashed in `take_tip`
+        assert_eq!(tip_hash_count(metrics), 0);
+        let (initial_height, initial_state) = sm.take_tip();
+        assert_eq!(initial_height, INITIAL_STATE_HEIGHT);
+        assert_eq!(tip_hash_count(metrics), 1);
+
+        // optimization triggers
+        let opt_height = Height::new(1);
+        sm.commit_and_certify_at_height(
+            initial_state,
+            opt_height,
+            CertificationScope::Metadata,
+            None,
+        );
+        assert_eq!(no_state_clone_count(metrics), 1);
+
+        // the state at height 1 is hashed in `take_tip` since certification metadata are not computed
+        assert_eq!(tip_hash_count(metrics), 1);
+        let (height, _state) = sm.take_tip();
+        assert_eq!(tip_hash_count(metrics), 2);
+        assert_eq!(height, opt_height);
+    });
+}
+
+#[test]
 fn remove_inmemory_states_below_prunes_certification() {
     state_manager_test(|metrics, sm| {
         // consensus delivers certification for the next height
@@ -9239,8 +9281,6 @@ fn remove_inmemory_states_below_prunes_certification() {
         // we commit a strictly larger height 2 without optimization
         let state = sm.take_tip().1;
         sm.commit_and_certify_at_height(state, Height::new(2), CertificationScope::Metadata, None);
-        // flusing the hash channel guarantees that the `latest_state_height` is incremented, which we rely on below.
-        sm.flush_hash_channel();
         assert_eq!(no_state_clone_count(metrics), 0);
 
         // certification at height 1 is pruned now that `latest_state_height` advanced to 2
@@ -9298,10 +9338,6 @@ fn get_state_hash_at() {
         // optimization triggers every multiple of 10
         let mut expected_no_state_clone_count = 0;
         for height in 1..checkpoint_height.get() {
-            if !height.is_multiple_of(10) {
-                sm.deliver_state_certification(fake_certification_for_height(Height::new(height)));
-                expected_no_state_clone_count += 1;
-            }
             let state = sm.take_tip().1;
             sm.commit_and_certify_at_height(
                 state,
@@ -9309,6 +9345,9 @@ fn get_state_hash_at() {
                 CertificationScope::Metadata,
                 None,
             );
+            if !height.is_multiple_of(10) {
+                expected_no_state_clone_count += 1;
+            }
             assert_eq!(no_state_clone_count(metrics), expected_no_state_clone_count);
             assert_eq!(
                 sm.get_state_hash_at(checkpoint_height),
@@ -9343,7 +9382,6 @@ fn flush_with_optimization() {
         assert_eq!(flush_unflushed_delta_count(metrics), 0);
 
         // optimization triggers
-        sm.deliver_state_certification(fake_certification_for_height(Height::new(1)));
         let state = sm.take_tip().1;
         let opt_height = Height::new(1);
         let batch_summary = BatchSummary {
@@ -9357,7 +9395,6 @@ fn flush_with_optimization() {
             CertificationScope::Metadata,
             Some(batch_summary),
         );
-        sm.flush_hash_channel();
         assert_eq!(no_state_clone_count(metrics), 1);
 
         // delta has been flushed
@@ -9372,7 +9409,6 @@ fn valid_witness_in_list_state_hashes_to_certify() {
         let state = sm.take_tip().1;
         let height = Height::new(1);
         sm.commit_and_certify_at_height(state, height, CertificationScope::Metadata, None);
-        sm.flush_hash_channel();
 
         let state_hashes = sm.list_state_hashes_to_certify();
         assert_eq!(state_hashes.len(), 1);
@@ -9457,8 +9493,8 @@ fn commit_and_certify_reuses_certification() {
         // optimization does not trigger
         let state = sm.take_tip().1;
         sm.commit_and_certify_at_height(state, no_opt_height, CertificationScope::Metadata, None);
-        sm.flush_hash_channel();
         assert_eq!(no_state_clone_count(metrics), 0);
+
         // `commit_and_certify` reused certification from `states.certifications`
         assert!(
             sm.certifications_metadata_certification(no_opt_height)
@@ -9475,10 +9511,9 @@ fn commit_and_certify_reuses_certification() {
 }
 
 #[test]
-#[should_panic]
-// This test fails with the following panic message, but we can't inspect it because is happens in another thread:
-// Committed state @1 with hash CryptoHash(0x4e2d174de5daaeb4622d8f5e426ee09274f7ec4fb01d62fb9a3d36ae50961353) which is different from previously computed or delivered hash CryptoHash(0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a)
-// We don't expect a specific panic message because it is not deterministic (could happen when sending `Wait` or when awaiting it).
+#[should_panic(
+    expected = "Committed state @1 with hash CryptoHash(0x4e2d174de5daaeb4622d8f5e426ee09274f7ec4fb01d62fb9a3d36ae50961353) which is different from previously computed or delivered hash CryptoHash(0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a)"
+)]
 fn commit_and_certify_panic_on_delivered_fake_certification() {
     state_manager_test(|metrics, sm| {
         // consensus delivers certification for a future height

--- a/rs/xnet/payload_builder/tests/common/mod.rs
+++ b/rs/xnet/payload_builder/tests/common/mod.rs
@@ -95,7 +95,6 @@ impl StateManagerFixture {
         height.inc_assign();
         self.state_manager
             .commit_and_certify(state, CertificationScope::Metadata, None);
-        self.state_manager.flush_hash_channel();
         certify_height(&self.state_manager, height);
         self.certified_height = height;
 

--- a/rs/xnet/payload_builder/tests/common/mod.rs
+++ b/rs/xnet/payload_builder/tests/common/mod.rs
@@ -71,7 +71,6 @@ impl StateManagerFixture {
             &config,
             None,
             ic_types::malicious_flags::MaliciousFlags::default(),
-            tokio::sync::watch::channel(ic_types::Height::from(0)).0,
         );
 
         Self {


### PR DESCRIPTION
This PR reverts https://github.com/dfinity/ic/pull/9850 and https://github.com/dfinity/ic/pull/8464 because the latter may have introduced a bug. The former depends on the latter, so reverting them together leads to the smallest conflict. 