### PR TITLE
fix: deflake //rs/tests/execution:canister_migration_test_head_nns

### DIFF
--- a/rs/tests/execution/canister_migration_test.rs
+++ b/rs/tests/execution/canister_migration_test.rs
@@ -6,7 +6,7 @@ use anyhow::{Result, bail};
 use candid::{CandidType, Decode, Deserialize, Encode, Principal, Reserved};
 use canister_test::Canister;
 use futures::future::join_all;
-use ic_agent::Agent;
+use ic_agent::{Agent, AgentError};
 use ic_consensus_system_test_utils::rw_message::install_nns_and_check_progress;
 use ic_nns_constants::{GOVERNANCE_CANISTER_ID, MIGRATION_CANISTER_ID, REGISTRY_CANISTER_ID};
 use ic_nns_test_utils::governance::{pause_canister_migrations, unpause_canister_migrations};
@@ -21,7 +21,7 @@ use ic_system_test_driver::driver::{
     test_env::TestEnv,
 };
 use ic_system_test_driver::util::*;
-use ic_system_test_driver::{retry_with_msg_async, systest};
+use ic_system_test_driver::{retry_agent_on_transport_errors, retry_with_msg_async, systest};
 use ic_universal_canister::{call_args, wasm};
 use ic_utils::call::AsyncCall;
 use ic_utils::interfaces::ManagementCanister;
@@ -391,12 +391,17 @@ async fn test_async(env: TestEnv) {
 
     info!(logger, "Calling migrate_canister on paused canister");
 
-    let result = nns_agent
-        .update(&migration_canister_id, "migrate_canister")
-        .with_arg(args.clone())
-        .call_and_wait()
-        .await
-        .expect("Failed to call migrate_canister.");
+    let result = retry_agent_on_transport_errors!(
+        "migrate_canister (paused)",
+        &logger,
+        nns_agent
+            .update(&migration_canister_id, "migrate_canister")
+            .with_arg(args.clone())
+            .call_and_wait()
+    )
+    .await
+    .expect("Failed to call migrate_canister after retries.")
+    .expect("Failed to call migrate_canister.");
 
     let decoded_result = Decode!(&result, Result<(), Option<ValidationError>>)
         .expect("Failed to decode reponse from migrate_canister.");
@@ -412,19 +417,29 @@ async fn test_async(env: TestEnv) {
 
     info!(logger, "Calling migrate_canister on unpaused canister");
 
-    let result = nns_agent
-        .update(&migration_canister_id, "migrate_canister")
-        .with_arg(args.clone())
-        .call_and_wait()
-        .await
-        .expect("Failed to call migrate_canister.");
+    let result = retry_agent_on_transport_errors!(
+        "migrate_canister (unpaused, args)",
+        &logger,
+        nns_agent
+            .update(&migration_canister_id, "migrate_canister")
+            .with_arg(args.clone())
+            .call_and_wait()
+    )
+    .await
+    .expect("Failed to call migrate_canister after retries.")
+    .expect("Failed to call migrate_canister.");
 
-    let _result = nns_agent
-        .update(&migration_canister_id, "migrate_canister")
-        .with_arg(args2.clone())
-        .call_and_wait()
-        .await
-        .expect("Failed to call migrate_canister.");
+    let _result = retry_agent_on_transport_errors!(
+        "migrate_canister (unpaused, args2)",
+        &logger,
+        nns_agent
+            .update(&migration_canister_id, "migrate_canister")
+            .with_arg(args2.clone())
+            .call_and_wait()
+    )
+    .await
+    .expect("Failed to call migrate_canister after retries.")
+    .expect("Failed to call migrate_canister.");
 
     let decoded_result = Decode!(&result, Result<(), Option<ValidationError>>)
         .expect("Failed to decode reponse from migrate_canister.");
@@ -440,12 +455,19 @@ async fn test_async(env: TestEnv) {
         Duration::from_secs(420),
         Duration::from_secs(10),
         || async {
-            let status = nns_agent
+            let status = match nns_agent
                 .update(&migration_canister_id, "migration_status")
                 .with_arg(args.clone())
                 .call_and_wait()
                 .await
-                .expect("Failed to call migration_status.");
+            {
+                Ok(s) => s,
+                // Retry only on transport errors.
+                Err(AgentError::TransportError(e)) => {
+                    bail!("transport error calling migration_status: {e}")
+                }
+                Err(e) => panic!("Failed to call migration_status: {e}"),
+            };
             let decoded_status = Decode!(&status, Option<MigrationStatus>)
                 .expect("Failed to decode response from migration_status.")
                 .expect("There should be a migration status available.");


### PR DESCRIPTION
## Root cause

The test `//rs/tests/execution:canister_migration_test_head_nns` flaked 3 times in the last week for the same underlying reason: `ic-agent` calls to the replica's public API (`:8080`) intermittently failed with transient `AgentError::TransportError` variants (`ConnectionRefused`, `BrokenPipe`, `TimedOut`) during brief replica restart windows, and the test treated every such transient error as fatal via `.expect(...)`.

Representative failure messages from the logs:

- `Failed to call migration_status.: TransportError(Reqwest(... ConnectError("tcp connect error", ... ConnectionRefused ...)))`
- `Failed to call migration_status.: TransportError(Reqwest(... hyper::Error(Io, Custom { kind: BrokenPipe ... })))`
- `Failed to call migrate_canister.: TransportError(Reqwest(... hyper::Error(Io, Kind(TimedOut)) on /api/v3/.../read_state))`

In the 2026-04-17 run the replica was restarted by the orchestrator (`orchestrator_replica_process_start_attempts_total = 2 > 1`), explaining the `ConnectionRefused`/`BrokenPipe` during the restart window.

## Fix

- Wrap the three `migrate_canister` update calls with `retry_agent_on_transport_errors!` (120 s / 5 s defaults), which only retries on `AgentError::TransportError` and surfaces all other agent errors immediately, preserving the existing `Result<(), Option<ValidationError>>` semantics via the macro's `other => Ok(other)` arm.
- Inside the existing `retry_with_msg_async!` polling loop for `migration_status`, match on the agent result: on `TransportError`, `bail!` to trigger a retry; on any other agent error, `panic!` so that real protocol/logic bugs still fail loudly instead of being silently retried away.

This keeps the test's diagnostic value for real regressions while absorbing the short-lived transport blips the replica exhibits during restarts.

## Verification

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 //rs/tests/execution:canister_migration_test_head_nns
```

passed all 3 runs (max 564 s, min 550 s).

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
