### PR TITLE
fix: deflake //rs/registry/canister:registry_canister_integration_test_tests/create_subnet

### DIFF
--- a/rs/registry/canister/BUILD.bazel
+++ b/rs/registry/canister/BUILD.bazel
@@ -241,6 +241,7 @@ rust_test(
 
 rust_ic_test_suite_with_extra_srcs(
     name = "registry_canister_integration_test",
+    timeout = "long",  # the create_subnet test can exceed 5 minutes.
     srcs = glob(
         ["tests/*.rs"],
         exclude = [


### PR DESCRIPTION
Set `timeout = "long"` on `//rs/registry/canister:registry_canister_integration_test_tests/create_subnet`.

## Root cause

The target did not specify a `timeout`, so it used Bazel's default `moderate` (300s).

The `create_subnet` test binary runs **6 integration tests**. Each spins up its own replica runtime via `state_machine_test_on_nns_subnet` / `canister_test_with_config_async`, and the three chain-key variants additionally poll for DKG completion via `wait_for_chain_key_setup`.

Across the 7 flaky runs in the last week (2026-04-16 .. 2026-04-22, all with "Test timed out"), the fingerprint was always the same:

- `running 6 tests`
- 5 tests complete
- 1 test is still executing when the 300s hard-kill hits
- The "stuck" test varies: usually `test_accepted_proposal_with_schnorr_gets_keys_from_other_subnet` (occasionally `…_ecdsa_…` / `…_vetkd_…`), and in one run even the trivial `test_the_anonymous_user_cannot_create_a_subnet` was the 6th one running at kill time.

No panics, no stack traces, no deadlock signatures. The polling helpers (`wait_for_{ecdsa,schnorr,vetkd}_setup`) are each bounded to 100 × 500ms ≈ 50s, so there is no infinite wait being hidden.

This is a classic total-wallclock overrun on loaded CI runners, not a test bug — the appropriate remedy is bumping the Bazel timeout bucket.

## Verification

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 \
  //rs/registry/canister:registry_canister_integration_test_tests/create_subnet
```

All 3 runs passed (max 32.3s, min 31.9s locally). On CI the same binary has been observed exceeding 300s, so `long` (900s) gives adequate headroom while still catching any true hang.

---

PR created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
