### PR TITLE
fix: deflake //rs/tests/ckbtc:ckdoge_minter_basics_test

### DIFF
--- a/rs/tests/ckbtc/ckdoge_minter_basics_test.rs
+++ b/rs/tests/ckbtc/ckdoge_minter_basics_test.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use bitcoin::{Amount, Txid, dogecoin, dogecoin::Address};
 use candid::Nat;
 use candid::{Decode, Encode, Principal};
-use ic_ckdoge_agent::CkDogeMinterAgent;
+use ic_ckdoge_agent::{CkDogeMinterAgent, CkDogeMinterAgentError};
 use ic_ckdoge_minter::{
     UpdateBalanceArgs, UtxoStatus,
     candid_api::{RetrieveDogeStatus, RetrieveDogeWithApprovalArgs, WithdrawalFee},
@@ -280,10 +280,19 @@ async fn test_retrieve_doge_status<F: Fn(Txid) -> bool>(
     let retries = 30;
     let mut i = 1;
     while i < retries {
-        let status = minter_agent
-            .retrieve_doge_status(block_index)
-            .await
-            .expect("failed to call retrieve_doge_status");
+        let status = match minter_agent.retrieve_doge_status(block_index).await {
+            Ok(status) => status,
+            Err(CkDogeMinterAgentError::AgentError(ic_agent::AgentError::TransportError(err))) => {
+                info!(
+                    &logger,
+                    "[{i}/{retries}] retrieve_doge_status transport error: {err}, retrying..."
+                );
+                i += 1;
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue;
+            }
+            Err(err) => panic!("failed to call retrieve_doge_status: {err:?}"),
+        };
         // Whenever status changes, reset the retry count
         i = if Some(&status) != last_status.as_ref() {
             0


### PR DESCRIPTION
## Root cause

Two recent flaky runs of `//rs/tests/ckbtc:ckdoge_minter_basics_test` failed inside `test_retrieve_doge_status` with:

```
failed to call retrieve_doge_status: AgentError(TransportError(Reqwest(reqwest::Error { kind: Request, url: \"http://[...]:8080/api/v3/canister/.../query\", source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(Io, Kind(TimedOut))) })))
```

In both cases the test had already been polling the minter every 5 s and received `Submitted { .. }` several times successfully. Then a single `ic-agent` query over IPv6 hit a TCP-level timeout (`hyper::Error(Io, Kind(TimedOut))`) — a transient connectivity/replica slowness blip, not a logic bug. The second attempt of the same bazel invocation passed, confirming the underlying infrastructure was fine.

The retry loop in `test_retrieve_doge_status` already tolerates non-terminal statuses (`Pending`, `Signing`, `Submitted`) but called `.expect(...)` on the agent result, so any transport error panicked immediately and failed the whole attempt.

## Fix

On `ic_agent::AgentError::TransportError`, log and retry (still counting the attempt against the existing 30-retry budget / 5 s sleep) instead of panicking. All other errors still panic.

## Verification

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 //rs/tests/ckbtc:ckdoge_minter_basics_test
```
3/3 runs passed.

Created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.