### PR TITLE
fix: prepend `--test_arg` in Mainnet NNS Recovery Bazel's command

### DIFF
--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -71,7 +71,7 @@ jobs:
               --config=flaky_retry \
               --config=stamped \
               //rs/tests/nested/nns_recovery:nr_large_with_mainnet_state \
-              --set-required-host-features=dc=zh1 \
+              --test_arg=--set-required-host-features=dc=zh1 \
               --keep_going --test_timeout=7200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/rs/tests/nested/nns_recovery/BUILD.bazel
+++ b/rs/tests/nested/nns_recovery/BUILD.bazel
@@ -64,11 +64,13 @@ system_test_nns(
 #
 #     bazel \
 #         test \
-#         --set-required-host-features=dc=zh1 \
 #         --test_timeout=7200 \  # 2 hours
+#         --test_arg=--set-required-host-features=dc=zh1 \
 #         //rs/tests/nested/nns_recovery:nr_large_with_mainnet_state
 #
 # You should use `--test_timeout=7200` because the test is expected to take a very long time.
+# You should use `--test_arg=--set-required-host-features=dc=zh1` because the test fetches mainnet test
+# data from a location close to the `zh1` data center.
 # You should also have your `SSH_AUTH_SOCK` environment variable set, and the corresponding SSH agent
 # should be running and have permission to fetch mainnet test data.
 system_test_nns(


### PR DESCRIPTION
Yesterday's Mainnet NNS Recovery system test [failed](https://github.com/dfinity/ic/actions/runs/24869410105/job/72812461065) because I had passed `--set-required-host-features=dc=zh1` without prepending `--test_arg=`, which is [normally done](https://github.com/dfinity/ic/blob/920df8055260f443ac3335cc0f2b06e285a688b4/rs/tests/ict/cmd/testCmd.go#L65) by `ict test` when translating to the underlying `bazel test` command. This PR fixes that.