### PR TITLE
feat(PocketIC): support update/query calls with subnet ID in the URL

### DIFF
--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -4637,7 +4637,7 @@ pub enum CallRequestVersion {
 }
 
 pub struct CallRequest {
-    pub effective_principal_id: CanisterId,
+    pub effective_principal_id: PrincipalId,
     pub bytes: Bytes,
     pub version: CallRequestVersion,
 }
@@ -4666,13 +4666,15 @@ impl Operation for CallRequest {
         let subnet = match self.version {
             CallRequestVersion::SubnetV4 => route(
                 pic,
-                EffectivePrincipal::SubnetId(SubnetId::from(self.effective_principal_id.get())),
+                EffectivePrincipal::SubnetId(SubnetId::from(self.effective_principal_id)),
                 false,
             )
             .map_err(PocketIcError::SubnetRequestRoutingError),
             _ => route(
                 pic,
-                EffectivePrincipal::CanisterId(self.effective_principal_id),
+                EffectivePrincipal::CanisterId(CanisterId::unchecked_from_principal(
+                    self.effective_principal_id,
+                )),
                 is_provisional_create_canister,
             )
             .map_err(PocketIcError::CanisterRequestRoutingError),
@@ -4754,10 +4756,9 @@ impl Operation for CallRequest {
                 };
 
                 let uri = match self.version {
-                    CallRequestVersion::SubnetV4 => format!(
-                        "/api/v4/subnet/{}/call",
-                        PrincipalId(self.effective_principal_id.get().into())
-                    ),
+                    CallRequestVersion::SubnetV4 => {
+                        format!("/api/v4/subnet/{}/call", self.effective_principal_id)
+                    }
                     _ => format!(
                         "/api/{}/canister/{}/call",
                         match self.version {
@@ -4766,7 +4767,7 @@ impl Operation for CallRequest {
                             CallRequestVersion::V4 => "v4",
                             CallRequestVersion::SubnetV4 => unreachable!(),
                         },
-                        PrincipalId(self.effective_principal_id.get().into())
+                        self.effective_principal_id
                     ),
                 };
 
@@ -4808,7 +4809,7 @@ impl Operation for CallRequest {
 }
 
 pub struct QueryRequest {
-    pub effective_principal_id: CanisterId,
+    pub effective_principal_id: PrincipalId,
     pub bytes: Bytes,
     pub version: query::Version,
 }
@@ -4832,13 +4833,15 @@ impl Operation for QueryRequest {
         let subnet = match self.version {
             query::Version::SubnetV3 => route(
                 pic,
-                EffectivePrincipal::SubnetId(SubnetId::from(self.effective_principal_id.get())),
+                EffectivePrincipal::SubnetId(SubnetId::from(self.effective_principal_id)),
                 false,
             )
             .map_err(PocketIcError::SubnetRequestRoutingError),
             _ => route(
                 pic,
-                EffectivePrincipal::CanisterId(self.effective_principal_id),
+                EffectivePrincipal::CanisterId(CanisterId::unchecked_from_principal(
+                    self.effective_principal_id,
+                )),
                 false,
             )
             .map_err(PocketIcError::CanisterRequestRoutingError),
@@ -4879,10 +4882,9 @@ impl Operation for QueryRequest {
                 .build_service();
 
                 let uri = match self.version {
-                    query::Version::SubnetV3 => format!(
-                        "/api/v3/subnet/{}/query",
-                        PrincipalId(self.effective_principal_id.get().into())
-                    ),
+                    query::Version::SubnetV3 => {
+                        format!("/api/v3/subnet/{}/query", self.effective_principal_id)
+                    }
                     _ => format!(
                         "/api/{}/canister/{}/query",
                         match self.version {
@@ -4890,7 +4892,7 @@ impl Operation for QueryRequest {
                             query::Version::V3 => "v3",
                             query::Version::SubnetV3 => unreachable!(),
                         },
-                        PrincipalId(self.effective_principal_id.get().into())
+                        self.effective_principal_id
                     ),
                 };
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -4633,10 +4633,11 @@ pub enum CallRequestVersion {
     V2,
     V3,
     V4,
+    SubnetV4,
 }
 
 pub struct CallRequest {
-    pub effective_canister_id: CanisterId,
+    pub effective_principal_id: CanisterId,
     pub bytes: Bytes,
     pub version: CallRequestVersion,
 }
@@ -4662,13 +4663,22 @@ impl Operation for CallRequest {
                 }
                 Err(_) => false,
             };
-        let subnet = route(
-            pic,
-            EffectivePrincipal::CanisterId(self.effective_canister_id),
-            is_provisional_create_canister,
-        );
+        let subnet = match self.version {
+            CallRequestVersion::SubnetV4 => route(
+                pic,
+                EffectivePrincipal::SubnetId(SubnetId::from(self.effective_principal_id.get())),
+                false,
+            )
+            .map_err(PocketIcError::SubnetRequestRoutingError),
+            _ => route(
+                pic,
+                EffectivePrincipal::CanisterId(self.effective_principal_id),
+                is_provisional_create_canister,
+            )
+            .map_err(PocketIcError::CanisterRequestRoutingError),
+        };
         match subnet {
-            Err(e) => OpOut::Error(PocketIcError::CanisterRequestRoutingError(e)),
+            Err(e) => OpOut::Error(e),
             Ok(subnet) => {
                 // Make sure the latest state is certified for the ingress filter to work.
                 subnet.certify_latest_state();
@@ -4708,7 +4718,9 @@ impl Operation for CallRequest {
 
                 let svc = match self.version {
                     CallRequestVersion::V2 => call_async::new_service(ingress_validator),
-                    CallRequestVersion::V3 | CallRequestVersion::V4 => {
+                    CallRequestVersion::V3
+                    | CallRequestVersion::V4
+                    | CallRequestVersion::SubnetV4 => {
                         let subnet_id = subnet.get_subnet_id();
                         let delegation = pic.get_nns_delegation_for_subnet(subnet_id);
                         let builder = delegation.map(|delegation| {
@@ -4735,25 +4747,33 @@ impl Operation for CallRequest {
                                 CallRequestVersion::V2 => unreachable!(),
                                 CallRequestVersion::V3 => call_sync::Version::V3,
                                 CallRequestVersion::V4 => call_sync::Version::V4,
+                                CallRequestVersion::SubnetV4 => call_sync::Version::SubnetV4,
                             },
                         )
                     }
                 };
 
-                let api_version = match self.version {
-                    CallRequestVersion::V2 => "v2",
-                    CallRequestVersion::V3 => "v3",
-                    CallRequestVersion::V4 => "v4",
+                let uri = match self.version {
+                    CallRequestVersion::SubnetV4 => format!(
+                        "/api/v4/subnet/{}/call",
+                        PrincipalId(self.effective_principal_id.get().into())
+                    ),
+                    _ => format!(
+                        "/api/{}/canister/{}/call",
+                        match self.version {
+                            CallRequestVersion::V2 => "v2",
+                            CallRequestVersion::V3 => "v3",
+                            CallRequestVersion::V4 => "v4",
+                            CallRequestVersion::SubnetV4 => unreachable!(),
+                        },
+                        PrincipalId(self.effective_principal_id.get().into())
+                    ),
                 };
 
                 let request = axum::http::Request::builder()
                     .method(Method::POST)
                     .header(CONTENT_TYPE, CONTENT_TYPE_CBOR)
-                    .uri(format!(
-                        "/api/{}/canister/{}/call",
-                        api_version,
-                        PrincipalId(self.effective_canister_id.get().into())
-                    ))
+                    .uri(uri)
                     .body(self.bytes.clone().into())
                     .unwrap();
 
@@ -4783,12 +4803,12 @@ impl Operation for CallRequest {
         let mut hasher = Sha256::new();
         self.bytes.hash(&mut hasher);
         let hash = Digest(hasher.finish());
-        OpId(format!("call({},{})", self.effective_canister_id, hash,))
+        OpId(format!("call({},{})", self.effective_principal_id, hash,))
     }
 }
 
 pub struct QueryRequest {
-    pub effective_canister_id: CanisterId,
+    pub effective_principal_id: CanisterId,
     pub bytes: Bytes,
     pub version: query::Version,
 }
@@ -4809,13 +4829,22 @@ impl BasicSigner<QueryResponseHash> for PocketNodeSigner {
 
 impl Operation for QueryRequest {
     fn compute(&self, pic: &mut PocketIc) -> OpOut {
-        let subnet = route(
-            pic,
-            EffectivePrincipal::CanisterId(self.effective_canister_id),
-            false,
-        );
+        let subnet = match self.version {
+            query::Version::SubnetV3 => route(
+                pic,
+                EffectivePrincipal::SubnetId(SubnetId::from(self.effective_principal_id.get())),
+                false,
+            )
+            .map_err(PocketIcError::SubnetRequestRoutingError),
+            _ => route(
+                pic,
+                EffectivePrincipal::CanisterId(self.effective_principal_id),
+                false,
+            )
+            .map_err(PocketIcError::CanisterRequestRoutingError),
+        };
         match subnet {
-            Err(e) => OpOut::Error(PocketIcError::CanisterRequestRoutingError(e)),
+            Err(e) => OpOut::Error(e),
             Ok(subnet) => {
                 let subnet_id = subnet.get_subnet_id();
                 let delegation = pic.get_nns_delegation_for_subnet(subnet_id);
@@ -4849,21 +4878,26 @@ impl Operation for QueryRequest {
                 .with_additional_root_of_trust(mainnet_root_of_trust)
                 .build_service();
 
-                let version_str = match self.version {
-                    query::Version::V2 => "v2",
-                    query::Version::V3 => "v3",
-                    query::Version::SubnetV3 => {
-                        unreachable!("SubnetV3 query not supported in PocketIC")
-                    }
+                let uri = match self.version {
+                    query::Version::SubnetV3 => format!(
+                        "/api/v3/subnet/{}/query",
+                        PrincipalId(self.effective_principal_id.get().into())
+                    ),
+                    _ => format!(
+                        "/api/{}/canister/{}/query",
+                        match self.version {
+                            query::Version::V2 => "v2",
+                            query::Version::V3 => "v3",
+                            query::Version::SubnetV3 => unreachable!(),
+                        },
+                        PrincipalId(self.effective_principal_id.get().into())
+                    ),
                 };
 
                 let request = axum::http::Request::builder()
                     .method(Method::POST)
                     .header(CONTENT_TYPE, CONTENT_TYPE_CBOR)
-                    .uri(format!(
-                        "/api/{version_str}/canister/{}/query",
-                        PrincipalId(self.effective_canister_id.get().into())
-                    ))
+                    .uri(uri)
                     .body(self.bytes.clone().into())
                     .unwrap();
                 let resp = pic.runtime.block_on(svc.oneshot(request)).unwrap();
@@ -4882,7 +4916,7 @@ impl Operation for QueryRequest {
         let mut hasher = Sha256::new();
         self.bytes.hash(&mut hasher);
         let hash = Digest(hasher.finish());
-        OpId(format!("query({},{})", self.effective_canister_id, hash,))
+        OpId(format!("query({},{})", self.effective_principal_id, hash,))
     }
 }
 

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -208,6 +208,12 @@ where
                 .layer(axum::middleware::from_fn(handle_limit_error)),
         )
         .directory_route(
+            "/subnet/{sid}/query",
+            post(handler_query_subnet_v3)
+                .layer(RequestBodyLimitLayer::new(MAX_REQUEST_BODY_SIZE))
+                .layer(axum::middleware::from_fn(handle_limit_error)),
+        )
+        .directory_route(
             "/canister/{ecid}/read_state",
             post(handler_canister_read_state_v3)
                 .layer(RequestBodyLimitLayer::new(MAX_REQUEST_BODY_SIZE))
@@ -226,12 +232,19 @@ where
     S: Clone + Send + Sync + 'static,
     AppState: extract::FromRef<S>,
 {
-    ApiRouter::new().directory_route(
-        "/canister/{ecid}/call",
-        post(handler_call_v4)
-            .layer(RequestBodyLimitLayer::new(MAX_REQUEST_BODY_SIZE))
-            .layer(axum::middleware::from_fn(handle_limit_error)),
-    )
+    ApiRouter::new()
+        .directory_route(
+            "/canister/{ecid}/call",
+            post(handler_call_v4)
+                .layer(RequestBodyLimitLayer::new(MAX_REQUEST_BODY_SIZE))
+                .layer(axum::middleware::from_fn(handle_limit_error)),
+        )
+        .directory_route(
+            "/subnet/{sid}/call",
+            post(handler_call_subnet_v4)
+                .layer(RequestBodyLimitLayer::new(MAX_REQUEST_BODY_SIZE))
+                .layer(axum::middleware::from_fn(handle_limit_error)),
+        )
 }
 
 pub fn instances_routes<S>() -> ApiRouter<S>
@@ -908,12 +921,12 @@ pub async fn handler_status(
 
 async fn handler_call(
     State(AppState { api_state, .. }): State<AppState>,
-    NoApi(Path((instance_id, effective_canister_id))): NoApi<Path<(InstanceId, CanisterId)>>,
+    NoApi(Path((instance_id, effective_principal_id))): NoApi<Path<(InstanceId, CanisterId)>>,
     bytes: Bytes,
     version: CallRequestVersion,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     let op = CallRequest {
-        effective_canister_id,
+        effective_principal_id,
         bytes,
         version,
     };
@@ -944,14 +957,40 @@ pub async fn handler_call_v4(
     handler_call(state, path, bytes, CallRequestVersion::V4).await
 }
 
+pub async fn handler_query_subnet_v3(
+    State(AppState { api_state, .. }): State<AppState>,
+    NoApi(Path((instance_id, subnet_id))): NoApi<Path<(InstanceId, SubnetId)>>,
+    bytes: Bytes,
+) -> (StatusCode, NoApi<Response<Body>>) {
+    let op = QueryRequest {
+        effective_principal_id: CanisterId::unchecked_from_principal(subnet_id.get()),
+        bytes,
+        version: query::Version::SubnetV3,
+    };
+    handle_raw(api_state, instance_id, op).await
+}
+
+pub async fn handler_call_subnet_v4(
+    State(AppState { api_state, .. }): State<AppState>,
+    NoApi(Path((instance_id, subnet_id))): NoApi<Path<(InstanceId, SubnetId)>>,
+    bytes: Bytes,
+) -> (StatusCode, NoApi<Response<Body>>) {
+    let op = CallRequest {
+        effective_principal_id: CanisterId::unchecked_from_principal(subnet_id.get()),
+        bytes,
+        version: CallRequestVersion::SubnetV4,
+    };
+    handle_raw(api_state, instance_id, op).await
+}
+
 async fn handler_query(
     State(AppState { api_state, .. }): State<AppState>,
-    NoApi(Path((instance_id, effective_canister_id))): NoApi<Path<(InstanceId, CanisterId)>>,
+    NoApi(Path((instance_id, effective_principal_id))): NoApi<Path<(InstanceId, CanisterId)>>,
     bytes: Bytes,
     version: query::Version,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     let op = QueryRequest {
-        effective_canister_id,
+        effective_principal_id,
         bytes,
         version,
     };

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -40,7 +40,7 @@ use ic_boundary::{ErrorClientFacing, MAX_REQUEST_BODY_SIZE};
 use ic_http_endpoints_public::{cors_layer, make_plaintext_response, query, read_state};
 use ic_registry_routing_table::RoutingTable;
 use ic_types::malicious_flags::MaliciousFlags;
-use ic_types::{CanisterId, SnapshotId, SubnetId};
+use ic_types::{CanisterId, PrincipalId, SnapshotId, SubnetId};
 use pocket_ic::RejectResponse;
 use pocket_ic::common::rest::{
     self, ApiResponse, AutoProgressConfig, ExtendedSubnetConfigSet, HttpGatewayConfig,
@@ -921,7 +921,7 @@ pub async fn handler_status(
 
 async fn handler_call(
     State(AppState { api_state, .. }): State<AppState>,
-    NoApi(Path((instance_id, effective_principal_id))): NoApi<Path<(InstanceId, CanisterId)>>,
+    NoApi(Path((instance_id, effective_principal_id))): NoApi<Path<(InstanceId, PrincipalId)>>,
     bytes: Bytes,
     version: CallRequestVersion,
 ) -> (StatusCode, NoApi<Response<Body>>) {
@@ -935,7 +935,7 @@ async fn handler_call(
 
 pub async fn handler_call_v2(
     state: State<AppState>,
-    path: NoApi<Path<(InstanceId, CanisterId)>>,
+    path: NoApi<Path<(InstanceId, PrincipalId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     handler_call(state, path, bytes, CallRequestVersion::V2).await
@@ -943,7 +943,7 @@ pub async fn handler_call_v2(
 
 pub async fn handler_call_v3(
     state: State<AppState>,
-    path: NoApi<Path<(InstanceId, CanisterId)>>,
+    path: NoApi<Path<(InstanceId, PrincipalId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     handler_call(state, path, bytes, CallRequestVersion::V3).await
@@ -951,7 +951,7 @@ pub async fn handler_call_v3(
 
 pub async fn handler_call_v4(
     state: State<AppState>,
-    path: NoApi<Path<(InstanceId, CanisterId)>>,
+    path: NoApi<Path<(InstanceId, PrincipalId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     handler_call(state, path, bytes, CallRequestVersion::V4).await
@@ -959,11 +959,11 @@ pub async fn handler_call_v4(
 
 pub async fn handler_query_subnet_v3(
     State(AppState { api_state, .. }): State<AppState>,
-    NoApi(Path((instance_id, subnet_id))): NoApi<Path<(InstanceId, SubnetId)>>,
+    NoApi(Path((instance_id, subnet_id))): NoApi<Path<(InstanceId, PrincipalId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     let op = QueryRequest {
-        effective_principal_id: CanisterId::unchecked_from_principal(subnet_id.get()),
+        effective_principal_id: subnet_id,
         bytes,
         version: query::Version::SubnetV3,
     };
@@ -972,11 +972,11 @@ pub async fn handler_query_subnet_v3(
 
 pub async fn handler_call_subnet_v4(
     State(AppState { api_state, .. }): State<AppState>,
-    NoApi(Path((instance_id, subnet_id))): NoApi<Path<(InstanceId, SubnetId)>>,
+    NoApi(Path((instance_id, subnet_id))): NoApi<Path<(InstanceId, PrincipalId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     let op = CallRequest {
-        effective_principal_id: CanisterId::unchecked_from_principal(subnet_id.get()),
+        effective_principal_id: subnet_id,
         bytes,
         version: CallRequestVersion::SubnetV4,
     };
@@ -985,7 +985,7 @@ pub async fn handler_call_subnet_v4(
 
 async fn handler_query(
     State(AppState { api_state, .. }): State<AppState>,
-    NoApi(Path((instance_id, effective_principal_id))): NoApi<Path<(InstanceId, CanisterId)>>,
+    NoApi(Path((instance_id, effective_principal_id))): NoApi<Path<(InstanceId, PrincipalId)>>,
     bytes: Bytes,
     version: query::Version,
 ) -> (StatusCode, NoApi<Response<Body>>) {
@@ -999,7 +999,7 @@ async fn handler_query(
 
 pub async fn handler_query_v2(
     state: State<AppState>,
-    path: NoApi<Path<(InstanceId, CanisterId)>>,
+    path: NoApi<Path<(InstanceId, PrincipalId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     handler_query(state, path, bytes, query::Version::V2).await
@@ -1007,7 +1007,7 @@ pub async fn handler_query_v2(
 
 pub async fn handler_query_v3(
     state: State<AppState>,
-    path: NoApi<Path<(InstanceId, CanisterId)>>,
+    path: NoApi<Path<(InstanceId, PrincipalId)>>,
     bytes: Bytes,
 ) -> (StatusCode, NoApi<Response<Body>>) {
     handler_query(state, path, bytes, query::Version::V3).await


### PR DESCRIPTION
This PR adds PocketIC support for the new HTTP endpoints
- `/api/v4/subnet/<effective_subnet_id>/call`;
- `/api/v3/subnet/<effective_subnet_id>/query`;

specified in this [PR](https://github.com/dfinity/portal/pull/6224).

Tests will be added once the new endpoints are supported in `ic-agent`.