### PR TITLE
perf: CON-1712 Avoid cloning sender info when verifying signature

### DIFF
--- a/rs/crypto/interfaces/sig_verification/src/lib.rs
+++ b/rs/crypto/interfaces/sig_verification/src/lib.rs
@@ -62,7 +62,7 @@ pub trait IngressSigVerifier:
     + BasicSigVerifierByPublicKey<Delegation>
     + CanisterSigVerifier<Delegation>
     + CanisterSigVerifier<MessageId>
-    + CanisterSigVerifier<SenderInfoContent>
+    + for<'a> CanisterSigVerifier<SenderInfoContent<'a>>
 {
 }
 
@@ -74,6 +74,6 @@ impl<T> IngressSigVerifier for T where
         + BasicSigVerifierByPublicKey<Delegation>
         + CanisterSigVerifier<Delegation>
         + CanisterSigVerifier<MessageId>
-        + CanisterSigVerifier<SenderInfoContent>
+        + for<'a> CanisterSigVerifier<SenderInfoContent<'a>>
 {
 }

--- a/rs/tests/crypto/ingress_verification_test.rs
+++ b/rs/tests/crypto/ingress_verification_test.rs
@@ -1179,7 +1179,7 @@ pub fn requests_with_valid_sender_info(env: TestEnv) {
 
             // The info blob that the signing canister attests to.
             let info_bytes = b"some user attributes".to_vec();
-            let sender_info_content = SenderInfoContent(info_bytes.clone());
+            let sender_info_content = SenderInfoContent(&info_bytes);
             let sender_info_signed_bytes = sender_info_content.as_signed_bytes();
             let sender_info_sig = signer.sign(&sender_info_signed_bytes).await;
 

--- a/rs/types/types/src/crypto/sign.rs
+++ b/rs/types/types/src/crypto/sign.rs
@@ -72,7 +72,7 @@ mod private {
     impl SignatureDomainSeal for Delegation {}
     impl SignatureDomainSeal for CanisterHttpResponseMetadata {}
     impl SignatureDomainSeal for MessageId {}
-    impl SignatureDomainSeal for SenderInfoContent {}
+    impl<'a> SignatureDomainSeal for SenderInfoContent<'a> {}
     impl SignatureDomainSeal for CertificationContent {}
     impl SignatureDomainSeal for CatchUpContent {}
     impl SignatureDomainSeal for CatchUpContentProtobufBytes {}
@@ -158,7 +158,7 @@ impl SignatureDomain for MessageId {
     }
 }
 
-impl SignatureDomain for SenderInfoContent {
+impl<'a> SignatureDomain for SenderInfoContent<'a> {
     fn domain(&self) -> Vec<u8> {
         domain_with_prepended_length("ic-sender-info")
     }

--- a/rs/types/types/src/messages/http.rs
+++ b/rs/types/types/src/messages/http.rs
@@ -339,11 +339,11 @@ pub struct SignedSenderInfo {
 /// The signing canister (e.g. Internet Identity) signs the `info` blob
 /// using a canister signature with the domain separator `"ic-sender-info"`.
 #[derive(Clone, Debug)]
-pub struct SenderInfoContent(pub Vec<u8>);
+pub struct SenderInfoContent<'a>(pub &'a [u8]);
 
-impl crate::crypto::SignedBytesWithoutDomainSeparator for SenderInfoContent {
+impl crate::crypto::SignedBytesWithoutDomainSeparator for SenderInfoContent<'_> {
     fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        self.0.clone()
+        self.0.to_vec()
     }
 }
 

--- a/rs/validator/ingress_message/tests/validate_request.rs
+++ b/rs/validator/ingress_message/tests/validate_request.rs
@@ -2015,7 +2015,7 @@ mod sender_info {
             root_public_key: root_of_trust.public_key,
             root_secret_key: root_of_trust.secret_key,
         };
-        let sig = signer.sign(&SenderInfoContent(info_bytes.clone()));
+        let sig = signer.sign(&SenderInfoContent(&info_bytes));
         let raw = RawSignedSenderInfo {
             info: Blob(info_bytes),
             signer: Blob(CANISTER_ID_SIGNER.get().into_vec()),

--- a/rs/validator/src/ingress_validation.rs
+++ b/rs/validator/src/ingress_validation.rs
@@ -527,7 +527,7 @@ where
     };
 
     // Construct the signable content (domain = "ic-sender-info")
-    let sender_info_content = SenderInfoContent(sender_info.info.clone());
+    let sender_info_content = SenderInfoContent(&sender_info.info);
     let canister_sig = CanisterSigOf::from(CanisterSig(sender_info.sig.clone()));
 
     verify_canister_sig_with_fallback!(


### PR DESCRIPTION
`SignedSenderInfo::info` is currently cloned twice during validation: Once to construct `SenderInfoContent` (which exists for the purpose of implementing `SignedBytesWithoutDomainSeparator`), and once in the `SignedBytesWithoutDomainSeparator` implementation itself.

The size of this field may be comparatively large, as it is only bounded by the ingress limit. We can easily avoid the first clone by making `SenderInfoContent` take a slice instead.