### PR TITLE
chore(crypto): CRP-1799 Don't panic on invalid ZK proof instances in NIDKG

### DIFF
--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/benches/zk.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/benches/zk.rs
@@ -46,7 +46,7 @@ fn setup_sharing_instance_and_witness() -> (SharingInstance, SharingWitness) {
         .map(|(yi, si)| G1Projective::mul2(&yi.into(), &r, &g1.into(), si).to_affine())
         .collect();
 
-    let instance = SharingInstance::new(pk, aa, rr, cc);
+    let instance = SharingInstance::new(pk, aa, rr, cc).expect("Valid sharing instance");
 
     let witness = SharingWitness::new(r, s);
 
@@ -101,7 +101,8 @@ fn setup_chunking_instance_and_witness<R: Rng + CryptoRng>(
         chunk.push(chunk_i.try_into().expect("Unexpected size"));
     }
 
-    let instance = ChunkingInstance::new(y, chunk, rr.try_into().expect("Unexpected size"));
+    let instance = ChunkingInstance::new(y, chunk, rr.try_into().expect("Unexpected size"))
+        .expect("Valid chunking instance");
     let witness = ChunkingWitness::new(r.try_into().expect("Unexpected size"), s);
     (instance, witness)
 }

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_chunking.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_chunking.rs
@@ -62,17 +62,29 @@ impl ChunkingInstance {
         &self.randomizers_r
     }
 
+    /// Creates a new `ChunkingInstance`, validating the inputs.
+    ///
+    /// Returns `Err(ZkProofChunkingError::InvalidInstance)` if
+    ///   * `public_keys` is empty,
+    ///   * `ciphertext_chunks` is empty, or
+    ///   * `public_keys` and `ciphertext_chunks` have different lengths.
     pub fn new(
         public_keys: Vec<G1Affine>,
         ciphertext_chunks: Vec<[G1Affine; NUM_CHUNKS]>,
         randomizers_r: [G1Affine; NUM_CHUNKS],
-    ) -> Self {
-        Self {
+    ) -> Result<Self, ZkProofChunkingError> {
+        if public_keys.is_empty() || ciphertext_chunks.is_empty() {
+            return Err(ZkProofChunkingError::InvalidInstance);
+        }
+        if public_keys.len() != ciphertext_chunks.len() {
+            return Err(ZkProofChunkingError::InvalidInstance);
+        }
+        Ok(Self {
             g1_gen: G1Affine::generator().clone(),
             public_keys,
             ciphertext_chunks,
             randomizers_r,
-        }
+        })
     }
 }
 
@@ -126,21 +138,6 @@ struct SecondMoveChunking {
     z_s: Vec<Scalar>,
     dd: Vec<G1Affine>,
     yy: G1Affine,
-}
-
-impl ChunkingInstance {
-    pub fn check_instance(&self) -> Result<(), ZkProofChunkingError> {
-        if self.public_keys.is_empty()
-            || self.ciphertext_chunks.is_empty()
-            || self.randomizers_r.is_empty()
-        {
-            return Err(ZkProofChunkingError::InvalidInstance);
-        };
-        if self.public_keys.len() != self.ciphertext_chunks.len() {
-            return Err(ZkProofChunkingError::InvalidInstance);
-        };
-        Ok(())
-    }
 }
 
 impl FirstMoveChunking {
@@ -200,10 +197,6 @@ pub fn prove_chunking<R: RngCore + CryptoRng>(
     witness: &ChunkingWitness,
     rng: &mut R,
 ) -> ProofChunking {
-    instance
-        .check_instance()
-        .expect("The chunking proof instance is invalid");
-
     let m = instance.randomizers_r.len();
     let n = instance.public_keys.len();
 
@@ -329,8 +322,6 @@ pub fn verify_chunking(
     instance: &ChunkingInstance,
     nizk: &ProofChunking,
 ) -> Result<(), ZkProofChunkingError> {
-    instance.check_instance()?;
-
     let num_receivers = instance.public_keys.len();
     require_eq("bb", nizk.bb.len(), NUM_ZK_REPETITIONS)?;
     require_eq("cc", nizk.cc.len(), NUM_ZK_REPETITIONS)?;

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_sharing.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/fs_ni_dkg/nizk_sharing.rs
@@ -28,20 +28,32 @@ pub struct SharingInstance {
 }
 
 impl SharingInstance {
+    /// Creates a new `SharingInstance`, validating the inputs.
+    ///
+    /// Returns `Err(ZkProofSharingError::InvalidInstance)` if
+    ///   * `public_keys` is empty,
+    ///   * `public_coefficients` is empty, or
+    ///   * `public_keys` and `combined_ciphertexts` have different lengths.
     pub fn new(
         public_keys: Vec<G1Affine>,
         public_coefficients: Vec<G2Affine>,
         combined_randomizer: G1Affine,
         combined_ciphertexts: Vec<G1Affine>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, ZkProofSharingError> {
+        if public_keys.is_empty() || public_coefficients.is_empty() {
+            return Err(ZkProofSharingError::InvalidInstance);
+        }
+        if public_keys.len() != combined_ciphertexts.len() {
+            return Err(ZkProofSharingError::InvalidInstance);
+        }
+        Ok(Self {
             g1_gen: G1Affine::generator().clone(),
             g2_gen: G2Affine::generator().clone(),
             public_keys,
             public_coefficients,
             combined_randomizer,
             combined_ciphertexts,
-        }
+        })
     }
 }
 
@@ -145,15 +157,6 @@ impl SharingInstance {
     pub fn hash_to_scalar(&self) -> Scalar {
         random_oracle_to_scalar(DOMAIN_PROOF_OF_SHARING_INSTANCE, self)
     }
-    pub fn check_instance(&self) -> Result<(), ZkProofSharingError> {
-        if self.public_keys.is_empty() || self.public_coefficients.is_empty() {
-            return Err(ZkProofSharingError::InvalidInstance);
-        };
-        if self.public_keys.len() != self.combined_ciphertexts.len() {
-            return Err(ZkProofSharingError::InvalidInstance);
-        };
-        Ok(())
-    }
 }
 impl From<&ProofSharing> for FirstMoveSharing {
     fn from(proof: &ProofSharing) -> Self {
@@ -192,9 +195,6 @@ pub fn prove_sharing<R: RngCore + CryptoRng>(
 ) -> ProofSharing {
     //   instance = ([y_1..y_n], [A_0..A_{t-1}], R, [C_1..C_n])
     //   witness = (r, [s_1..s_n])
-    instance
-        .check_instance()
-        .expect("The sharing proof instance is invalid");
     assert_eq!(instance.public_keys.len(), witness.scalars_s.len());
 
     // Hash of instance: x = oracle(instance)
@@ -254,7 +254,6 @@ pub fn verify_sharing(
     instance: &SharingInstance,
     nizk: &ProofSharing,
 ) -> Result<(), ZkProofSharingError> {
-    instance.check_instance()?;
     // Hash of Instance
     // x = oracle(instance)
     let x = instance.hash_to_scalar();

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/groth20_bls12_381/encryption.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/ni_dkg/groth20_bls12_381/encryption.rs
@@ -171,15 +171,14 @@ pub fn encrypt_and_prove(
 
     #[cfg(test)]
     {
+        let chunking_instance = crypto::ChunkingInstance::new(
+            public_keys.clone(),
+            ciphertext.ciphertext_chunks().to_vec(),
+            ciphertext.randomizers_r().clone(),
+        )
+        .expect("We just created an invalid chunking instance");
         assert_eq!(
-            crypto::verify_chunking(
-                &crypto::ChunkingInstance::new(
-                    public_keys.clone(),
-                    ciphertext.ciphertext_chunks().to_vec(),
-                    ciphertext.randomizers_r().clone(),
-                ),
-                &chunking_proof,
-            ),
+            crypto::verify_chunking(&chunking_instance, &chunking_proof,),
             Ok(()),
             "We just created an invalid chunking proof"
         );
@@ -189,16 +188,15 @@ pub fn encrypt_and_prove(
             .map(|s| util::g1_from_big_endian_chunks(s))
             .collect();
 
+        let sharing_instance = crypto::SharingInstance::new(
+            public_keys,
+            public_coefficients,
+            util::g1_from_big_endian_chunks(ciphertext.randomizers_r()),
+            combined_ciphertexts,
+        )
+        .expect("We just created an invalid sharing instance");
         assert_eq!(
-            crypto::verify_sharing(
-                &crypto::SharingInstance::new(
-                    public_keys,
-                    public_coefficients,
-                    util::g1_from_big_endian_chunks(ciphertext.randomizers_r()),
-                    combined_ciphertexts,
-                ),
-                &sharing_proof,
-            ),
+            crypto::verify_sharing(&sharing_instance, &sharing_proof,),
             Ok(()),
             "We just created an invalid sharing proof"
         );
@@ -270,7 +268,8 @@ fn prove_chunking<R: RngCore + CryptoRng>(
         public_keys.to_vec(),
         ciphertext.ciphertext_chunks().to_vec(),
         ciphertext.randomizers_r().clone(),
-    );
+    )
+    .expect("Chunking instance constructed from valid encryption output");
 
     let chunking_witness =
         crypto::ChunkingWitness::new(encryption_witness.witness().clone(), big_plaintext_chunks);
@@ -303,13 +302,16 @@ fn prove_sharing<R: RngCore + CryptoRng>(
         .map(|chunks| chunks.recombine_to_scalar())
         .collect::<Vec<_>>();
 
+    let sharing_instance = crypto::SharingInstance::new(
+        receiver_fs_public_keys.to_vec(),
+        public_coefficients.to_vec(),
+        combined_r,
+        combined_ciphertexts,
+    )
+    .expect("Sharing instance constructed from valid encryption output");
+
     crypto::prove_sharing(
-        &crypto::SharingInstance::new(
-            receiver_fs_public_keys.to_vec(),
-            public_coefficients.to_vec(),
-            combined_r,
-            combined_ciphertexts,
-        ),
+        &sharing_instance,
         &crypto::SharingWitness::new(combined_r_scalar, combined_plaintexts),
         rng,
     )
@@ -387,16 +389,19 @@ pub fn verify_zk_proofs(
         })
     })?;
 
-    // Verify proof
-    crypto::verify_chunking(
-        &crypto::ChunkingInstance::new(
-            public_keys.clone(),
-            ciphertext.ciphertext_chunks().to_vec(),
-            ciphertext.randomizers_r().clone(),
-        ),
-        &chunking_proof,
+    let chunking_instance = crypto::ChunkingInstance::new(
+        public_keys.clone(),
+        ciphertext.ciphertext_chunks().to_vec(),
+        ciphertext.randomizers_r().clone(),
     )
     .map_err(|_| {
+        CspDkgVerifyDealingError::InvalidDealingError(InvalidArgumentError {
+            message: "Invalid chunking instance".to_string(),
+        })
+    })?;
+
+    // Verify proof
+    crypto::verify_chunking(&chunking_instance, &chunking_proof).map_err(|_| {
         let error = InvalidArgumentError {
             message: "Invalid chunking proof".to_string(),
         };
@@ -429,16 +434,19 @@ pub fn verify_zk_proofs(
         })
     })?;
 
-    crypto::verify_sharing(
-        &crypto::SharingInstance::new(
-            public_keys,
-            public_coefficients,
-            combined_r,
-            combined_ciphertexts,
-        ),
-        &sharing_proof,
+    let sharing_instance = crypto::SharingInstance::new(
+        public_keys,
+        public_coefficients,
+        combined_r,
+        combined_ciphertexts,
     )
     .map_err(|_| {
+        CspDkgVerifyDealingError::InvalidDealingError(InvalidArgumentError {
+            message: "Invalid sharing instance".to_string(),
+        })
+    })?;
+
+    crypto::verify_sharing(&sharing_instance, &sharing_proof).map_err(|_| {
         let error = InvalidArgumentError {
             message: "Invalid sharing proof".to_string(),
         };

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/tests/integration_tests.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/tests/integration_tests.rs
@@ -170,7 +170,8 @@ fn encrypted_chunks_should_validate(epoch: Epoch) {
             receiver_fs_public_keys.clone(),
             crsz.ciphertext_chunks().to_vec(),
             crsz.randomizers_r().clone(),
-        );
+        )
+        .expect("Valid chunking instance");
 
         let chunking_witness =
             ChunkingWitness::new(encryption_witness.witness().clone(), big_plaintext_chunks);
@@ -263,7 +264,8 @@ fn encrypted_chunks_should_validate(epoch: Epoch) {
             polynomial_exp,
             combined_r_exp,
             combined_ciphertexts,
-        );
+        )
+        .expect("Valid sharing instance");
         let sharing_witness = SharingWitness::new(combined_r, combined_plaintexts);
 
         let sharing_proof = prove_sharing(&sharing_instance, &sharing_witness, rng);

--- a/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/tests/nizk.rs
+++ b/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/tests/nizk.rs
@@ -79,7 +79,7 @@ fn sharing_nizk_should_verify() {
     let rng = &mut reproducible_rng();
     let (pk, aa, rr, cc, r, s) = setup_sharing_instance_and_witness(rng);
 
-    let instance = SharingInstance::new(pk, aa, rr, cc);
+    let instance = SharingInstance::new(pk, aa, rr, cc).expect("Valid sharing instance");
 
     let witness = SharingWitness::new(r, s);
     let sharing_proof = prove_sharing(&instance, &witness, rng);
@@ -100,7 +100,7 @@ fn sharing_nizk_is_stable() {
         "04c66ff4854bff12d8ce0c2a6aa69791812b5dc2e029040fd3f806936516ece3",
     );
 
-    let instance = SharingInstance::new(pk, aa, rr, cc);
+    let instance = SharingInstance::new(pk, aa, rr, cc).expect("Valid sharing instance");
 
     assert_expected_scalar(
         &instance.hash_to_scalar(),
@@ -144,48 +144,45 @@ fn sharing_nizk_is_stable() {
 }
 
 #[test]
-#[should_panic(expected = "The sharing proof instance is invalid: InvalidInstance")]
-fn sharing_prover_should_panic_on_empty_coefficients() {
+fn sharing_instance_new_should_fail_on_empty_coefficients() {
     let rng = &mut reproducible_rng();
-    let (pk, _aa, rr, cc, r, s) = setup_sharing_instance_and_witness(rng);
+    let (pk, _aa, rr, cc, _r, _s) = setup_sharing_instance_and_witness(rng);
 
-    let instance = SharingInstance::new(pk, vec![], rr, cc);
-    let witness = SharingWitness::new(r, s);
-    let _panic_one = prove_sharing(&instance, &witness, rng);
+    assert!(
+        matches!(
+            SharingInstance::new(pk, vec![], rr, cc),
+            Err(ZkProofSharingError::InvalidInstance)
+        ),
+        "SharingInstance::new rejects empty public coefficients"
+    );
 }
 
 #[test]
-#[should_panic(expected = "The sharing proof instance is invalid: InvalidInstance")]
-fn sharing_prover_should_panic_on_invalid_instance() {
+fn sharing_instance_new_should_fail_on_mismatched_lengths() {
     let rng = &mut reproducible_rng();
-    let (mut pk, aa, rr, cc, r, s) = setup_sharing_instance_and_witness(rng);
+    let (mut pk, aa, rr, cc, _r, _s) = setup_sharing_instance_and_witness(rng);
     pk.push(G1Affine::generator().clone());
 
-    let instance = SharingInstance::new(pk, aa, rr, cc);
-
-    let witness = SharingWitness::new(r, s);
-    let _panic_one = prove_sharing(&instance, &witness, rng);
+    assert!(
+        matches!(
+            SharingInstance::new(pk, aa, rr, cc),
+            Err(ZkProofSharingError::InvalidInstance)
+        ),
+        "SharingInstance::new rejects mismatched public_keys / combined_ciphertexts lengths"
+    );
 }
 
 #[test]
-fn sharing_nizk_should_fail_on_invalid_instance() {
+fn sharing_instance_new_should_fail_on_empty_public_keys() {
     let rng = &mut reproducible_rng();
-    let (mut pk, aa, rr, cc, r, s) = setup_sharing_instance_and_witness(rng);
+    let (_pk, aa, rr, _cc, _r, _s) = setup_sharing_instance_and_witness(rng);
 
-    let instance = SharingInstance::new(pk.clone(), aa.clone(), rr.clone(), cc.clone());
-
-    pk.push(G1Affine::generator().clone());
-
-    let invalid_instance = SharingInstance::new(pk, aa, rr, cc);
-
-    let witness = SharingWitness::new(r, s);
-    let _panic_one = prove_sharing(&instance, &witness, rng);
-
-    let sharing_proof = prove_sharing(&instance, &witness, rng);
-    assert_eq!(
-        Err(ZkProofSharingError::InvalidInstance),
-        verify_sharing(&invalid_instance, &sharing_proof),
-        "verify_sharing fails on invalid instance"
+    assert!(
+        matches!(
+            SharingInstance::new(vec![], aa, rr, vec![]),
+            Err(ZkProofSharingError::InvalidInstance)
+        ),
+        "SharingInstance::new rejects empty public keys"
     );
 }
 
@@ -194,10 +191,9 @@ fn sharing_nizk_should_fail_on_invalid_proof() {
     let rng = &mut reproducible_rng();
     let (pk, aa, rr, cc, r, s) = setup_sharing_instance_and_witness(rng);
 
-    let instance = SharingInstance::new(pk, aa, rr, cc);
+    let instance = SharingInstance::new(pk, aa, rr, cc).expect("Valid sharing instance");
 
     let witness = SharingWitness::new(r, s);
-    let _panic_one = prove_sharing(&instance, &witness, rng);
 
     let sharing_proof = prove_sharing(&instance, &witness, rng).serialize();
 
@@ -242,7 +238,7 @@ fn setup_chunking_instance_and_witness<R: RngCore + CryptoRng>(
         chunk.push(chunk_i.try_into().expect("Expected size"));
     }
 
-    let instance = ChunkingInstance::new(y, chunk, rr);
+    let instance = ChunkingInstance::new(y, chunk, rr).expect("Valid chunking instance");
     let witness = ChunkingWitness::new(r, s);
     (instance, witness)
 }
@@ -261,19 +257,36 @@ fn chunking_nizk_should_verify() {
 }
 
 #[test]
-#[should_panic(expected = "The chunking proof instance is invalid: InvalidInstance")]
-fn chunking_prover_should_panic_on_empty_chunks() {
+fn chunking_instance_new_should_fail_on_empty_chunks() {
     let rng = &mut reproducible_rng();
-    let (instance, witness) = setup_chunking_instance_and_witness(rng);
+    let (instance, _witness) = setup_chunking_instance_and_witness(rng);
 
     let empty_chunks = vec![];
-    let invalid_instance = ChunkingInstance::new(
-        instance.public_keys().to_vec(),
-        empty_chunks,
-        instance.randomizers_r().clone(),
+    assert!(
+        matches!(
+            ChunkingInstance::new(
+                instance.public_keys().to_vec(),
+                empty_chunks,
+                instance.randomizers_r().clone(),
+            ),
+            Err(ZkProofChunkingError::InvalidInstance)
+        ),
+        "ChunkingInstance::new rejects empty ciphertext chunks"
     );
+}
 
-    let _panic = prove_chunking(&invalid_instance, &witness, rng);
+#[test]
+fn chunking_instance_new_should_fail_on_empty_public_keys() {
+    let rng = &mut reproducible_rng();
+    let (instance, _witness) = setup_chunking_instance_and_witness(rng);
+
+    assert!(
+        matches!(
+            ChunkingInstance::new(vec![], vec![], instance.randomizers_r().clone(),),
+            Err(ZkProofChunkingError::InvalidInstance)
+        ),
+        "ChunkingInstance::new rejects empty public keys"
+    );
 }
 
 #[test]
@@ -298,43 +311,23 @@ fn chunking_nizk_is_stable() {
 }
 
 #[test]
-#[should_panic(expected = "The chunking proof instance is invalid: InvalidInstance")]
-fn chunking_prover_should_panic_on_invalid_instance() {
+fn chunking_instance_new_should_fail_on_mismatched_lengths() {
     let rng = &mut reproducible_rng();
-    let (instance, witness) = setup_chunking_instance_and_witness(rng);
+    let (instance, _witness) = setup_chunking_instance_and_witness(rng);
 
     let mut with_extra_key = instance.public_keys().to_vec();
     with_extra_key.push(G1Affine::generator().clone());
 
-    let invalid_instance = ChunkingInstance::new(
-        with_extra_key,
-        instance.ciphertext_chunks().to_vec(),
-        instance.randomizers_r().clone(),
-    );
-
-    let _panic = prove_chunking(&invalid_instance, &witness, rng);
-}
-
-#[test]
-fn chunking_nizk_should_fail_on_invalid_instance() {
-    let rng = &mut reproducible_rng();
-    let (instance, witness) = setup_chunking_instance_and_witness(rng);
-
-    let chunking_proof = prove_chunking(&instance, &witness, rng);
-
-    let mut with_extra_key = instance.public_keys().to_vec();
-    with_extra_key.push(G1Affine::generator().clone());
-
-    let invalid_instance = ChunkingInstance::new(
-        with_extra_key,
-        instance.ciphertext_chunks().to_vec(),
-        instance.randomizers_r().clone(),
-    );
-
-    assert_eq!(
-        Err(ZkProofChunkingError::InvalidInstance),
-        verify_chunking(&invalid_instance, &chunking_proof),
-        "verify_chunking fails on invalid instance"
+    assert!(
+        matches!(
+            ChunkingInstance::new(
+                with_extra_key,
+                instance.ciphertext_chunks().to_vec(),
+                instance.randomizers_r().clone(),
+            ),
+            Err(ZkProofChunkingError::InvalidInstance)
+        ),
+        "ChunkingInstance::new rejects mismatched public_keys / ciphertext_chunks lengths"
     );
 }
 


### PR DESCRIPTION
Previously in NIDKG a proof instance type could be instantiated even if manifestly invalid; then check_instance would return an error. In some cases this error would propagate to the caller, but in others it would simply panic.

Change this so that creating a ZK proof instance is falliable, and handle the error directly. This also eliminates any possibility of forgetting to call check_instance in the right spot.