### PR TITLE
fix: remove obsolete `--config=lint` from Mainnet NNS Recovery

### DIFF
--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           run: |
             bazel test \
-              --config=lint \
               --config=flaky_retry \
               --config=stamped \
               //rs/tests/nested/nns_recovery:nr_large_with_mainnet_state \


### PR DESCRIPTION
Me again sorry, this night's Mainnet NNS Recovery run [failed](https://github.com/dfinity/ic/actions/runs/24920630290/job/72981289178) because of an unrecognized `--config=lint`. I had written this action before this was removed from the neighbouring ones.