### PR TITLE
fix: Correctly handle missing CPU in SetupOS

### DIFF
--- a/ic-os/components/setupos/check-hardware.sh
+++ b/ic-os/components/setupos/check-hardware.sh
@@ -77,7 +77,7 @@ function check_num_cpus() {
     local cpu_json="$1"
     local required_sockets="$2"
 
-    local num_cpu_sockets=$(echo "${cpu_json}" | jq -r '.[].id' | wc -l)
+    local num_cpu_sockets=$(echo "${cpu_json}" | jq -r '.[] | select(has("disabled") | not) | .id' | wc -l)
     log_and_halt_installation_on_error "$?" "Unable to extract CPU sockets from CPU JSON."
 
     if [ "${num_cpu_sockets}" -lt "${required_sockets}" ]; then
@@ -89,7 +89,7 @@ function verify_capability_for_all_sockets() {
     local cpu_json="$1"
     local capability_name="$2"
 
-    for socket_id in $(echo "${cpu_json}" | jq -r '.[].id'); do
+    for socket_id in $(echo "${cpu_json}" | jq -r '.[] | select(has("disabled") | not) | .id'); do
         local capability=$(echo "${cpu_json}" | jq -r \
             --arg socket "${socket_id}" \
             --arg capability "${capability_name}" \
@@ -112,7 +112,7 @@ function verify_model_for_all_sockets() {
     local cpu_json="$1"
     local required_model="$2"
 
-    for socket_id in $(echo "${cpu_json}" | jq -r '.[].id'); do
+    for socket_id in $(echo "${cpu_json}" | jq -r '.[] | select(has("disabled") | not) | .id'); do
         local model=$(echo "${cpu_json}" | jq -r --arg socket "${socket_id}" '.[] | select(.id==$socket) | .product')
 
         echo -n "* CPU model '${model}' "

--- a/ic-os/components/setupos/test-setupos.sh
+++ b/ic-os/components/setupos/test-setupos.sh
@@ -130,16 +130,26 @@ function test_verify_cpu() {
     ]' 64 1
 
     # Gen3 Success
-    test_verify_cpu_helper "verify_cpu Gen3 success" "3" '[
+
+    ## AMD SVM 2 sockets
+    test_verify_cpu_helper "verify_cpu Gen3 success AMD" "3" '[
       {"id": "cpu:0", "product": "Foobar CPU", "capabilities": {"svm": "true"}},
       {"id": "cpu:1", "product": "Foobaz CPU", "capabilities": {"svm": "true"}}
     ]' 1 0
 
-    test_verify_cpu_helper "verify_cpu Gen3 success" "3" '[
+    ## Intel VMX 1 socket
+    test_verify_cpu_helper "verify_cpu Gen3 success Intel" "3" '[
       {"id": "cpu:0", "product": "Foobar CPU", "capabilities": {"vmx": "true"}},
     ]' 1 0
 
+    ## One unpopulated socket ignored
+    test_verify_cpu_helper "verify_cpu Gen3 success AMD 1 socket unpopulated" "3" '[
+      {"id": "cpu:0", "product": "Foobar CPU", "capabilities": {"svm": "true"}},
+      {"id": "cpu:1", "product": "Foobaz CPU", "disabled": true}
+    ]' 1 0
+
     # Gen3 Failure
+    ## Missing caps
     test_verify_cpu_helper "verify_cpu Gen3 failure" "3" '[
       {"id": "cpu:0", "product": "Foobar CPU", "capabilities": {}},
       {"id": "cpu:1", "product": "Foobaz CPU", "capabilities": {}}

--- a/ic-os/components/setupos/test-setupos.sh
+++ b/ic-os/components/setupos/test-setupos.sh
@@ -139,7 +139,7 @@ function test_verify_cpu() {
 
     ## Intel VMX 1 socket
     test_verify_cpu_helper "verify_cpu Gen3 success Intel" "3" '[
-      {"id": "cpu:0", "product": "Foobar CPU", "capabilities": {"vmx": "true"}},
+      {"id": "cpu:0", "product": "Foobar CPU", "capabilities": {"vmx": "true"}}
     ]' 1 0
 
     ## One unpopulated socket ignored


### PR DESCRIPTION
In certain cases the server might have an unpopulated CPU socket and this case isn't handled correctly currently, e.g.:
<img width="650" height="348" alt="image" src="https://github.com/user-attachments/assets/a9f1f3ec-8752-4257-9f09-bade2cd0a827" />

This PR adds a filter that excludes CPUs with `disabled` flag present. This mostly affects Cloud Engine nodes since Gen1/2 ones have CPU count requirements applied on top, but also should catch Gen1/2 cases when they have a CPU missing.

Also this fixes an extra comma in test.