### PR TITLE
feat: Re-pin the kernel to avoid mem bug

### DIFF
--- a/ic-os/guestos/context/Dockerfile.base
+++ b/ic-os/guestos/context/Dockerfile.base
@@ -62,8 +62,10 @@ COPY packages.* /tmp/
 RUN apt-get -y update && \
     apt-get -y upgrade && \
     apt-get -y --no-install-recommends install $(for P in ${PACKAGE_FILES}; do cat /tmp/$P | sed -e "s/#.*//" ; done) \
-        ${_KERNEL_PACKAGE} \
-        linux-modules-extra-$(apt-cache depends ${_KERNEL_PACKAGE} | sed -n -e 's/  Depends: linux-image-\(.*\)-generic/\1/p')-generic && \
+        # TODO(NODE-1852): Temporarily pin the kernel here.
+        # ${_KERNEL_PACKAGE} \
+        # linux-modules-extra-$(apt-cache depends ${_KERNEL_PACKAGE} | sed -n -e 's/  Depends: linux-image-\(.*\)-generic/\1/p')-generic && \
+        linux-image-6.14.0-37-generic linux-modules-extra-6.14.0-37-generic && \
     rm /tmp/packages.*
 
 # Install node_exporter


### PR DESCRIPTION
First pinned in #8957 and unpinned in #9843, pin it once again to avoid the [memory bug](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=577a1f495fd78d8fb61b67ac3d3b595b01f6fcb0). We thought the patch was backported to our ubuntu, but it was not.

We will update the kernel to a version with the patch, with the efforts in #9989.