### PR TITLE
test: only reduce RUST_TEST_THREADS for memory_matrix_test on Linux

### DIFF
--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -280,8 +280,13 @@ rust_ic_test(
     env = {
         "UNIVERSAL_CANISTER_SERIALIZED_MODULE_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.module)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
-        "RUST_TEST_THREADS": "2",
     },
+    # Reduce parallelism on Linux to deflake the test (see PR #9647),
+    # but keep the higher parallelism on Darwin to avoid timeouts on arm64-darwin.
+    args = select({
+        "@platforms//os:linux": ["--test-threads=2"],
+        "//conditions:default": ["--test-threads=4"],
+    }),
     tags = [
         "cpu:4",
         "test_all_platforms_slow",

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -273,6 +273,12 @@ rust_ic_test(
     name = "memory_matrix_test",
     size = "large",
     srcs = ["tests/memory_matrix.rs"],
+    # Reduce parallelism on Linux to deflake the test (see PR #9647),
+    # but keep the higher parallelism on Darwin to avoid timeouts on arm64-darwin.
+    args = select({
+        "@platforms//os:linux": ["--test-threads=2"],
+        "//conditions:default": ["--test-threads=4"],
+    }),
     data = [
         "//rs/universal_canister/impl:universal_canister.module",
         "//rs/universal_canister/impl:universal_canister.wasm.gz",
@@ -281,12 +287,6 @@ rust_ic_test(
         "UNIVERSAL_CANISTER_SERIALIZED_MODULE_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.module)",
         "UNIVERSAL_CANISTER_WASM_PATH": "$(rootpath //rs/universal_canister/impl:universal_canister.wasm.gz)",
     },
-    # Reduce parallelism on Linux to deflake the test (see PR #9647),
-    # but keep the higher parallelism on Darwin to avoid timeouts on arm64-darwin.
-    args = select({
-        "@platforms//os:linux": ["--test-threads=2"],
-        "//conditions:default": ["--test-threads=4"],
-    }),
     tags = [
         "cpu:4",
         "test_all_platforms_slow",


### PR DESCRIPTION
PR #9647 reduced `RUST_TEST_THREADS` from 4 to 2 for `memory_matrix_test` to deflake the test on Linux. However, this seems to cause the test to time out more often on arm64-darwin.

This change uses `--test-threads` via `args` with a `select()` so that the parallelism is reduced only on Linux (`--test-threads=2`) while Darwin keeps the original parallelism (`--test-threads=4`).

`RUST_TEST_THREADS` could not be used directly because `rust_ic_test` materializes the `env` dict via `dict(env.items() + ...)`, which does not accept `select()` values.