### PR TITLE
test(guestos_no_failed_systemd_units): log journal of failed units

### DIFF
--- a/rs/tests/node/guestos_no_failed_systemd_units.rs
+++ b/rs/tests/node/guestos_no_failed_systemd_units.rs
@@ -31,7 +31,7 @@ fn check_no_failed_systemd_units(env: TestEnv) {
             .expect("Failed to establish SSH session to GuestOS node");
 
         let failed_units = node
-            .block_on_bash_script("systemctl list-units --failed --no-legend --no-pager")
+            .block_on_bash_script("systemctl list-units --failed --no-legend --no-pager --plain")
             .expect("Failed to run systemctl list-units --failed on GuestOS node");
         info!(
             logger,
@@ -43,13 +43,10 @@ fn check_no_failed_systemd_units(env: TestEnv) {
                 if line.is_empty() {
                     continue;
                 }
-                // Lines from `systemctl list-units --failed --no-legend` typically
-                // start with a status glyph (e.g. `●`) followed by the unit name.
-                // Skip the glyph if present and take the unit name as the next token.
-                let unit = line
-                    .split_whitespace()
-                    .find(|tok: &&str| !tok.chars().all(|c| !c.is_alphanumeric()));
-                let Some(unit) = unit else {
+                // With `--plain`, lines have no leading status glyph or tree
+                // structure, so the first whitespace-separated token is the
+                // unit name.
+                let Some(unit) = line.split_whitespace().next() else {
                     continue;
                 };
                 let cmd = format!("journalctl -u '{}' --no-pager -n 500", unit);

--- a/rs/tests/node/guestos_no_failed_systemd_units.rs
+++ b/rs/tests/node/guestos_no_failed_systemd_units.rs
@@ -37,6 +37,40 @@ fn check_no_failed_systemd_units(env: TestEnv) {
             logger,
             "Node {}: systemctl list-units --failed:\n{}", node.node_id, failed_units
         );
+        if !failed_units.trim().is_empty() {
+            for line in failed_units.lines() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                // Lines from `systemctl list-units --failed --no-legend` typically
+                // start with a status glyph (e.g. `●`) followed by the unit name.
+                // Skip the glyph if present and take the unit name as the next token.
+                let unit = line
+                    .split_whitespace()
+                    .find(|tok: &&str| !tok.chars().all(|c| !c.is_alphanumeric()));
+                let Some(unit) = unit else {
+                    continue;
+                };
+                let cmd = format!("journalctl -u '{}' --no-pager -n 500", unit);
+                match node.block_on_bash_script(&cmd) {
+                    Ok(journal) => info!(
+                        logger,
+                        "Node {}: journalctl -u {} (last 500 lines):\n{}",
+                        node.node_id,
+                        unit,
+                        journal
+                    ),
+                    Err(err) => info!(
+                        logger,
+                        "Node {}: failed to fetch journalctl logs for unit {}: {}",
+                        node.node_id,
+                        unit,
+                        err
+                    ),
+                }
+            }
+        }
         assert!(
             failed_units.trim().is_empty(),
             "Node {} has failed systemd units:\n{}",


### PR DESCRIPTION
When `systemctl list-units --failed` returns non-empty output, parse each failed unit name and fetch its journalctl logs over SSH before the `assert!` fails the test, to aid debugging of flaky failures.

In particular we would like to debug the failing `reload_nftables.service` that failed this test twice on [April 27th, 2026 at 12:36:36 pm](https://dash.dm1-idx1.dfinity.network/invocation/b861247c-5114-4b38-985c-717e4ca91bfb?target=//rs/tests/node:guestos_no_failed_systemd_units#@217) and on [April 23rd, 2026 at 6:28:42 pm](https://dash.zh1-idx1.dfinity.network/invocation/72a57525-3631-4f39-92f8-2ce152e7b207?target=//rs/tests/node:guestos_no_failed_systemd_units#@226).

Note we can't rely on the logs being shipped to ElasticSearch since the test completes either too quickly for the logs to be shipped or something in the nodes fails such that shipping can't be done successfully.
