### PR TITLE
fix: deflake //rs/tests/nested/nns_recovery:nr_broken_dfinity_node by allowing panic

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/allowed_panics.rs
+++ b/rs/canister_sandbox/src/replica_controller/allowed_panics.rs
@@ -1,5 +1,9 @@
 //! This module contains panics that are allowed by default to occur in logs in system-tests.
 
+pub(crate) fn panic_sandboxed_execution_controller_reply_channel_closed() -> ! {
+    panic!("Sandboxed_execution_controller reply channel closed unexpectedly")
+}
+
 pub(crate) fn panic_launcher_exited_due_to_signal(pid: u32) -> ! {
     panic!(
         "Error from launcher process, pid {pid} exited due to signal! In test environments (e.g., PocketIC), you can safely ignore this message."

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -1,3 +1,4 @@
+use super::allowed_panics::panic_sandboxed_execution_controller_reply_channel_closed;
 use crate::compiler_sandbox::WasmCompilerProxy;
 use crate::controller_launcher_service::ControllerLauncherService;
 use crate::launcher_service::LauncherService;

--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -1028,7 +1028,7 @@ impl WasmExecutor for SandboxedExecutionController {
         // Wait for completion.
         let result = rx
             .recv()
-            .expect("Sandboxed_execution_controller reply channel closed unexpectedly");
+            .unwrap_or_else(|_| panic_sandboxed_execution_controller_reply_channel_closed());
         drop(wait_timer);
         let _finish_timer = self
             .metrics

--- a/rs/tests/nested/nns_recovery/nr_broken_dfinity_node.rs
+++ b/rs/tests/nested/nns_recovery/nr_broken_dfinity_node.rs
@@ -53,14 +53,6 @@ fn main() -> Result<()> {
             sequential_np_actions: false,
         }))
         .with_timeout_per_test(Duration::from_mins(30))
-        // The test performs a `systemctl restart ic-replica`
-        // which causes a SIGTERM to be sent to the replica process
-        // which sometimes causes the sandbox_execution_controller to panic with:
-        // "Sandboxed_execution_controller reply channel closed unexpectedly" which we allow:
-        .add_unallowed_log_pattern_except(
-            "panicked",
-            "rs/canister_sandbox/src/replica_controller/allowed_panics.rs:4",
-        )
         .execute_from_args()?;
 
     Ok(())

--- a/rs/tests/nested/nns_recovery/nr_broken_dfinity_node.rs
+++ b/rs/tests/nested/nns_recovery/nr_broken_dfinity_node.rs
@@ -53,6 +53,14 @@ fn main() -> Result<()> {
             sequential_np_actions: false,
         }))
         .with_timeout_per_test(Duration::from_mins(30))
+        // The test performs a `systemctl restart ic-replica`
+        // which causes a SIGTERM to be sent to the replica process
+        // which sometimes causes the sandbox_execution_controller to panic with:
+        // "Sandboxed_execution_controller reply channel closed unexpectedly" which we allow:
+        .add_unallowed_log_pattern_except(
+            "panicked",
+            "rs/canister_sandbox/src/replica_controller/allowed_panics.rs:4",
+        )
         .execute_from_args()?;
 
     Ok(())


### PR DESCRIPTION
The test performs a `systemctl restart ic-replica` which causes a SIGTERM to be sent to the replica process which sometimes causes the sandbox_execution_controller to panic with: "Sandboxed_execution_controller reply channel closed unexpectedly" which we now allow in all tests.