### PR TITLE
test: log progress in backup_manager_downgrade_test wait-for-archive loop

### DIFF
--- a/rs/tests/consensus/backup/common.rs
+++ b/rs/tests/consensus/backup/common.rs
@@ -278,10 +278,29 @@ pub fn test(env: TestEnv) {
     info!(log, "Started process: {}", child.id());
 
     info!(log, "Wait for archived checkpoint");
+    let checkpoint_dir = backup_dir
+        .join("data")
+        .join(subnet_id.to_string())
+        .join("ic_state/checkpoints");
+    let orig_spool_dir = backup_dir
+        .join("spool")
+        .join(subnet_id.to_string())
+        .join(initial_replica_version.to_string())
+        .join("0");
     let archive_dir = backup_dir.join("archive").join(subnet_id.to_string());
     // make sure we have some archive of the old version before upgrading to the new one
     loop {
-        if highest_dir_entry(&archive_dir, 10) > 0 {
+        let spool_height = highest_dir_entry(&orig_spool_dir, 10);
+        let checkpoint = highest_dir_entry(&checkpoint_dir, 16);
+        let archive_height = highest_dir_entry(&archive_dir, 10);
+        info!(
+            log,
+            "Waiting for archived checkpoint - Spool: {}  Checkpoint: {}  Archive: {}",
+            spool_height,
+            checkpoint,
+            archive_height,
+        );
+        if archive_height > 0 {
             info!(log, "A checkpoint has been archived");
             break;
         }
@@ -298,15 +317,6 @@ pub fn test(env: TestEnv) {
     info!(log, "Wait until the upgrade happens");
     assert_assigned_replica_version(&nns_node, &target_version, env.logger());
 
-    let checkpoint_dir = backup_dir
-        .join("data")
-        .join(subnet_id.to_string())
-        .join("ic_state/checkpoints");
-    let orig_spool_dir = backup_dir
-        .join("spool")
-        .join(subnet_id.to_string())
-        .join(initial_replica_version.to_string())
-        .join("0");
     let new_spool_dir = backup_dir
         .join("spool")
         .join(subnet_id.to_string())


### PR DESCRIPTION
## Context

`//rs/tests/consensus/backup:backup_manager_downgrade_test_colocate` is currently flaky. The most recent flaky run timed out after 1500s (the per-task timeout) while still in the very first `Wait for archived checkpoint` loop in `rs/tests/consensus/backup/common.rs`:

```
Task setup                            PASSED  in  89.21s
Task assert_no_metrics_errors         PASSED  in   0.27s
Task assert_no_unallowed_log_patterns PASSED  in   0.46s
Task test                             FAILED  in 1500.00s  -- Timeout after 1500s
```

Buildbuddy invocation: <https://dash.dm1-idx1.dfinity.network/invocation/f0a4d807-50fd-4158-9cbe-d6f34f27146b?target=//rs/tests/consensus/backup:backup_manager_downgrade_test_colocate>

When the loop sits idle, the only progress signal in the FAILED log is the periodic `Replay/Sync - <subnet>: <checkpoint>/<spool>` line emitted by the inner `ic-backup` child process. Nothing in the test itself reports what it is observing, which makes diagnosing timeouts in this phase harder than it needs to be — for instance, in the failing run the `ic-replay` subprocess was wedged and `archive_state` was never reached, but there is no record from the test side showing whether the spool / checkpoint dirs were also stuck or just the archive dir.

## Change

Hoist the `checkpoint_dir` / `orig_spool_dir` / `archive_dir` definitions above the first wait loop and log spool height, latest checkpoint, and latest archive height on every iteration (every 5 s), in the same style as the second wait loop further down. Pure observability change — no functional difference.

```rust
loop {
    let spool_height = highest_dir_entry(&orig_spool_dir, 10);
    let checkpoint = highest_dir_entry(&checkpoint_dir, 16);
    let archive_height = highest_dir_entry(&archive_dir, 10);
    info!(
        log,
        "Waiting for archived checkpoint - Spool: {}  Checkpoint: {}  Archive: {}",
        spool_height,
        checkpoint,
        archive_height,
    );
    if archive_height > 0 {
        info!(log, "A checkpoint has been archived");
        break;
    }
    std::thread::sleep(std::time::Duration::from_secs(5));
}
```

This does not by itself fix the flake but makes future timeouts in this phase self-diagnosing so the underlying cause (slow / hung `ic-replay`, slow spool rsyncs, etc.) can be confirmed from the logs alone.

---

PR created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
