### PR TITLE
feat(NODE-1942): ic-boundary: support new call types

### DIFF
--- a/rs/boundary_node/ic_boundary/src/core.rs
+++ b/rs/boundary_node/ic_boundary/src/core.rs
@@ -69,8 +69,8 @@ use crate::{
     errors::ErrorCause,
     http::{
         PATH_CALL_V2, PATH_CALL_V3, PATH_CALL_V4, PATH_HEALTH, PATH_QUERY_V2, PATH_QUERY_V3,
-        PATH_READ_STATE_V2, PATH_READ_STATE_V3, PATH_STATUS, PATH_SUBNET_READ_STATE_V2,
-        PATH_SUBNET_READ_STATE_V3, RequestType,
+        PATH_READ_STATE_V2, PATH_READ_STATE_V3, PATH_STATUS, PATH_SUBNET_CALL_V4,
+        PATH_SUBNET_QUERY_V3, PATH_SUBNET_READ_STATE_V2, PATH_SUBNET_READ_STATE_V3, RequestType,
         handlers::{self, LogsState, logs_canister},
         middleware::{
             cache::{CacheState, cache_middleware},
@@ -853,11 +853,11 @@ pub fn setup_router(
     let canister_handler = post(handlers::handle_canister).with_state(proxy.clone());
     let subnet_handler = post(handlers::handle_subnet).with_state(proxy.clone());
 
-    let query_route = Router::new()
+    let canister_query_routes = Router::new()
         .route(PATH_QUERY_V2, canister_handler.clone())
         .route(PATH_QUERY_V3, canister_handler.clone());
 
-    let call_route = {
+    let canister_call_routes = {
         let mut route = Router::new()
             .route(PATH_CALL_V2, canister_handler.clone())
             .route(PATH_CALL_V3, canister_handler.clone())
@@ -999,7 +999,9 @@ pub fn setup_router(
 
     // Layers under ServiceBuilder are executed top-down (opposite to that under Router)
     // 1st layer wraps 2nd layer and so on
-    let common_service_layers = ServiceBuilder::new()
+
+    // Layers that are used everywhere
+    let common_layers = ServiceBuilder::new()
         .layer(middleware_bouncer)
         .layer(middleware_geoip)
         .set_x_request_id(MakeRequestUuid)
@@ -1010,10 +1012,11 @@ pub fn setup_router(
         .layer(middleware::from_fn(process::preprocess_request))
         .layer(load_shedder_latency_mw);
 
-    let service_canister_read_call_query = ServiceBuilder::new()
+    // Layers specific to the canister requests
+    let canister_layers = ServiceBuilder::new()
         .layer(middleware::from_fn(validate::validate_request))
         .layer(middleware::from_fn(validate::validate_canister_request))
-        .layer(common_service_layers.clone())
+        .layer(common_layers.clone())
         .layer(middleware_subnet_lookup.clone())
         .layer(middleware_generic_limiter.clone())
         .layer(option_layer(cache_state.map(|x| {
@@ -1021,36 +1024,39 @@ pub fn setup_router(
         })))
         .layer(middleware_retry.clone());
 
+    // Layers specific to the subnet requests
     let middleware_subnet_read_state_cache = option_layer(
         subnet_read_state_cache_state
             .map(|x| middleware::from_fn_with_state(x, subnet_read_state_cache_middleware)),
     );
 
-    let service_subnet_read = ServiceBuilder::new()
+    let subnet_layers = ServiceBuilder::new()
         .layer(middleware::from_fn(validate::validate_request))
         .layer(middleware::from_fn(validate::validate_subnet_request))
-        .layer(common_service_layers)
+        .layer(common_layers)
         .layer(middleware_subnet_read_state_cache)
         .layer(middleware_subnet_lookup)
         .layer(middleware_generic_limiter)
         .layer(middleware_retry);
 
-    let canister_read_state_route = Router::new()
+    let canister_read_state_routes = Router::new()
         .route(PATH_READ_STATE_V2, canister_handler.clone())
         .route(PATH_READ_STATE_V3, canister_handler.clone());
 
-    let canister_read_call_query_routes = query_route
-        .merge(call_route)
-        .merge(canister_read_state_route)
-        .layer(service_canister_read_call_query);
+    let canister_routes = canister_query_routes
+        .merge(canister_call_routes)
+        .merge(canister_read_state_routes)
+        .layer(canister_layers);
 
-    let subnet_read_state_route = Router::new()
+    let subnet_routes = Router::new()
         .route(PATH_SUBNET_READ_STATE_V2, subnet_handler.clone())
         .route(PATH_SUBNET_READ_STATE_V3, subnet_handler.clone())
-        .layer(service_subnet_read);
+        .route(PATH_SUBNET_QUERY_V3, subnet_handler.clone())
+        .route(PATH_SUBNET_CALL_V4, subnet_handler.clone())
+        .layer(subnet_layers);
 
-    let mut router = canister_read_call_query_routes
-        .merge(subnet_read_state_route)
+    let mut router = canister_routes
+        .merge(subnet_routes)
         .merge(status_route)
         .merge(health_route);
 

--- a/rs/boundary_node/ic_boundary/src/http/middleware/validate.rs
+++ b/rs/boundary_node/ic_boundary/src/http/middleware/validate.rs
@@ -17,7 +17,8 @@ use crate::{
     errors::{ApiError, ErrorCause},
     http::{
         PATH_CALL_V2, PATH_CALL_V3, PATH_CALL_V4, PATH_QUERY_V2, PATH_QUERY_V3, PATH_READ_STATE_V2,
-        PATH_READ_STATE_V3, PATH_SUBNET_READ_STATE_V2, PATH_SUBNET_READ_STATE_V3, RequestType,
+        PATH_READ_STATE_V3, PATH_SUBNET_CALL_V4, PATH_SUBNET_QUERY_V3, PATH_SUBNET_READ_STATE_V2,
+        PATH_SUBNET_READ_STATE_V3, RequestType,
     },
 };
 
@@ -70,12 +71,14 @@ pub async fn validate_subnet_request(
     let request_type = match matched_path.as_str() {
         PATH_SUBNET_READ_STATE_V2 => RequestType::ReadStateSubnetV2,
         PATH_SUBNET_READ_STATE_V3 => RequestType::ReadStateSubnetV3,
+        PATH_SUBNET_QUERY_V3 => RequestType::QuerySubnetV3,
+        PATH_SUBNET_CALL_V4 => RequestType::CallSubnetV4,
         _ => panic!("unknown path, should never happen"),
     };
 
     request.extensions_mut().insert(request_type);
 
-    // Decode canister_id from URL
+    // Decode subnet ID from URL
     let principal_id: PrincipalId = Principal::from_text(subnet_id.as_str())
         .map_err(|err| {
             ErrorCause::MalformedRequest(format!("Unable to decode subnet_id from URL: {err}"))

--- a/rs/boundary_node/ic_boundary/src/http/mod.rs
+++ b/rs/boundary_node/ic_boundary/src/http/mod.rs
@@ -18,6 +18,8 @@ pub const PATH_READ_STATE_V2: &str = "/api/v2/canister/{canister_id}/read_state"
 pub const PATH_READ_STATE_V3: &str = "/api/v3/canister/{canister_id}/read_state";
 pub const PATH_SUBNET_READ_STATE_V2: &str = "/api/v2/subnet/{subnet_id}/read_state";
 pub const PATH_SUBNET_READ_STATE_V3: &str = "/api/v3/subnet/{subnet_id}/read_state";
+pub const PATH_SUBNET_QUERY_V3: &str = "/api/v3/subnet/{subnet_id}/query";
+pub const PATH_SUBNET_CALL_V4: &str = "/api/v4/subnet/{subnet_id}/call";
 pub const PATH_HEALTH: &str = "/health";
 
 /// Type of IC API request
@@ -52,15 +54,20 @@ pub enum RequestType {
     ReadStateV3,
     ReadStateSubnetV2,
     ReadStateSubnetV3,
+    QuerySubnetV3,
+    CallSubnetV4,
 }
 
 impl RequestType {
     pub const fn is_query(&self) -> bool {
-        matches!(self, Self::QueryV2 | Self::QueryV3)
+        matches!(self, Self::QueryV2 | Self::QueryV3 | Self::QuerySubnetV3)
     }
 
     pub const fn is_call(&self) -> bool {
-        matches!(self, Self::CallV2 | Self::CallV3 | Self::CallV4)
+        matches!(
+            self,
+            Self::CallV2 | Self::CallV3 | Self::CallV4 | Self::CallSubnetV4
+        )
     }
 
     pub const fn is_read_state(&self) -> bool {

--- a/rs/boundary_node/ic_boundary/src/routes.rs
+++ b/rs/boundary_node/ic_boundary/src/routes.rs
@@ -790,7 +790,6 @@ pub(crate) mod test {
         };
 
         let body = serde_cbor::to_vec(&envelope).unwrap();
-
         let subnet_id: SubnetId = PrincipalId(subnets[0].id).into();
 
         let request = Request::builder()
@@ -803,6 +802,108 @@ pub(crate) mod test {
 
         let resp = app.call(request).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+
+        let (parts, body) = resp.into_parts();
+
+        // Check response headers
+        let headers = parts.headers;
+        // Make sure that the subnet_id is there even if the CBOR does not have it
+        assert_header(&headers, X_IC_SUBNET_ID, &subnet_id.to_string());
+        assert_header(&headers, CONTENT_TYPE, "application/cbor");
+        assert_header(&headers, X_CONTENT_TYPE_OPTIONS, "nosniff");
+        assert_header(&headers, X_FRAME_OPTIONS, "DENY");
+        let body = axum::body::to_bytes(body, usize::MAX)
+            .await
+            .unwrap()
+            .to_vec();
+        let body = String::from_utf8_lossy(&body);
+        assert_eq!(body, "a".repeat(1024));
+
+        // Test subnet query
+
+        // Not sure how the actual subnet query request should look like, but for now just use canister query.
+        // We don't have ready types for subnet query it seems.
+        let content = HttpQueryContent::Query {
+            query: HttpUserQuery {
+                canister_id: Blob(canister_id.get().as_slice().to_vec()),
+                method_name: "foobar".to_string(),
+                arg: Blob(vec![]),
+                sender: Blob(sender.as_slice().to_vec()),
+                nonce: None,
+                ingress_expiry: 1234,
+                sender_info: None,
+            },
+        };
+
+        let envelope = HttpRequestEnvelope::<HttpQueryContent> {
+            content,
+            sender_delegation: None,
+            sender_pubkey: None,
+            sender_sig: None,
+        };
+
+        let body = serde_cbor::to_vec(&envelope).unwrap();
+        let subnet_id: SubnetId = PrincipalId(subnets[0].id).into();
+
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("http://localhost/api/v3/subnet/{subnet_id}/query"))
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.call(request).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let (parts, body) = resp.into_parts();
+
+        // Check response headers
+        let headers = parts.headers;
+        // Make sure that the subnet_id is there even if the CBOR does not have it
+        assert_header(&headers, X_IC_SUBNET_ID, &subnet_id.to_string());
+        assert_header(&headers, CONTENT_TYPE, "application/cbor");
+        assert_header(&headers, X_CONTENT_TYPE_OPTIONS, "nosniff");
+        assert_header(&headers, X_FRAME_OPTIONS, "DENY");
+        let body = axum::body::to_bytes(body, usize::MAX)
+            .await
+            .unwrap()
+            .to_vec();
+        let body = String::from_utf8_lossy(&body);
+        assert_eq!(body, "a".repeat(1024));
+
+        // Test subnet call
+
+        // Not sure how the actual subnet call request should look like, but for now just use canister call.
+        // We don't have ready types for subnet call it seems.
+        let content = HttpCallContent::Call {
+            update: HttpCanisterUpdate {
+                canister_id: Blob(canister_id.get().as_slice().to_vec()),
+                method_name: "foobar".to_string(),
+                arg: Blob(vec![]),
+                sender: Blob(sender.as_slice().to_vec()),
+                nonce: None,
+                ingress_expiry: 1234,
+                sender_info: None,
+            },
+        };
+
+        let envelope = HttpRequestEnvelope::<HttpCallContent> {
+            content,
+            sender_delegation: None,
+            sender_pubkey: None,
+            sender_sig: None,
+        };
+
+        let body = serde_cbor::to_vec(&envelope).unwrap();
+        let subnet_id: SubnetId = PrincipalId(subnets[0].id).into();
+
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("http://localhost/api/v4/subnet/{subnet_id}/call"))
+            .body(Body::from(body))
+            .unwrap();
+
+        let resp = app.call(request).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
 
         let (parts, body) = resp.into_parts();
 

--- a/rs/boundary_node/ic_boundary/src/snapshot.rs
+++ b/rs/boundary_node/ic_boundary/src/snapshot.rs
@@ -104,6 +104,9 @@ impl Node {
             RequestType::QueryV3 => Url::from_str(&format!(
                 "https://{node_id}:{node_port}/api/v3/canister/{principal}/query",
             )),
+            RequestType::QuerySubnetV3 => Url::from_str(&format!(
+                "https://{node_id}:{node_port}/api/v3/subnet/{principal}/query",
+            )),
             RequestType::CallV2 => Url::from_str(&format!(
                 "https://{node_id}:{node_port}/api/v2/canister/{principal}/call",
             )),
@@ -112,6 +115,9 @@ impl Node {
             )),
             RequestType::CallV4 => Url::from_str(&format!(
                 "https://{node_id}:{node_port}/api/v4/canister/{principal}/call",
+            )),
+            RequestType::CallSubnetV4 => Url::from_str(&format!(
+                "https://{node_id}:{node_port}/api/v4/subnet/{principal}/call",
             )),
             RequestType::ReadStateV2 => Url::from_str(&format!(
                 "https://{node_id}:{node_port}/api/v2/canister/{principal}/read_state",


### PR DESCRIPTION
* Adds Subnet Query V3 and Call V4 call types
* Unit tests for them
* Renamed some vars for clarity
* It seems the Agent doesn't support these calls yet, so no integration tests added