### PR TITLE
chore: introduce the protected long-lived featurebranch feat-ai-on-engines

### DIFF
--- a/.github/workflows/ci-kickoff.yml
+++ b/.github/workflows/ci-kickoff.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - feat-ai-on-engines # special protected long-lived feature branch for experimenting with AI on cloud engines.
       - 'dev-gh-*'
       - 'public-hotfix-*'
   pull_request:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -88,7 +88,7 @@ jobs:
 
           # List of "protected" branches, i.e. branches (not necessarily "protected" in the GitHub sense) where we need
           # the full build to occur (including versioning)
-          protected_branches=("^master$" "^rc--" "^hotfix-" "^public-hotfix-")
+          protected_branches=("^master$" "^feat-ai-on-engines$" "^rc--" "^hotfix-" "^public-hotfix-")
           for pattern in "${protected_branches[@]}"; do
               if [[ "$BRANCH_NAME" =~ $pattern ]]; then
                   is_protected_branch="true"
@@ -649,6 +649,7 @@ jobs:
           steps.filter.outputs.cargo == 'true' ||
           contains(github.event.pull_request.labels.*.name, 'CI_RUN_CARGO_JOBS') ||
           env.BRANCH_NAME == 'master' ||
+          env.BRANCH_NAME == 'feat-ai-on-engines' ||
           startsWith(env.BRANCH_NAME, 'rc--') ||
           startsWith(env.BRANCH_NAME, 'hotfix-') ||
           startsWith(env.BRANCH_NAME, 'public-hotfix-')
@@ -712,6 +713,7 @@ jobs:
         if: |
           steps.filter.outputs.container-run == 'true' ||
           env.BRANCH_NAME == 'master' ||
+          env.BRANCH_NAME == 'feat-ai-on-engines' ||
           startsWith(env.BRANCH_NAME, 'rc--') ||
           startsWith(env.BRANCH_NAME, 'hotfix-') ||
           startsWith(env.BRANCH_NAME, 'public-hotfix-')

--- a/.github/workflows/ci-pr-only-team-tags.yml
+++ b/.github/workflows/ci-pr-only-team-tags.yml
@@ -5,6 +5,7 @@ on:
     # Only tag PRs on the branches for which we have protection rules / rulesets
     branches:
       - master
+      - feat-ai-on-engines
       - 'rc--*'
       - 'hotfix-*'
       - 'follow-*'


### PR DESCRIPTION
For Cloud Engines we would like to have a long-lived feature branch for experimenting with AI called: 
`feat-ai-on-engines`.

This branch should be treated almost the same as `master` in particular:

* PRs will be created targeting `feat-ai-on-engines`.

* The branch should be protected such that nobody can push directly to it and you have to go via PRs. The @dfinity/dre team will be allowed to directly push to this branch such that they can push merge commit with `master` without going via a PR which would require many approvals.

* The `Kickoff / CI Main` workflow should be triggered on pushes to this branch and it should upload artifacts.

* The `upload-artifacts` environment, and thus its secrets, are accessible on this branch.

