### PR TITLE
chore: [DSM-103] Drop canister priority from canister state

### DIFF
--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -438,11 +438,9 @@ message TaskQueue {
 
 // Next ID: 65
 message CanisterStateBits {
-  reserved 1, 3, 6, 9, 10, 14, 16, 17, 24, 30, 35, 42, 47, 52, 53;
+  reserved 1, 2, 3, 5, 6, 9, 10, 14, 16, 17, 24, 30, 35, 42, 47, 48, 49, 52, 53;
 
-  uint64 last_full_execution_round = 2;
   uint64 compute_allocation = 4;
-  int64 accumulated_priority = 5;
   ExecutionStateBits execution_state_bits = 7;
   uint64 memory_allocation = 8;
   oneof canister_status {
@@ -510,8 +508,6 @@ message CanisterStateBits {
   optional uint64 wasm_memory_limit = 45;
   // The next local snapshot ID.
   uint64 next_snapshot_id = 46;
-  int64 priority_credit = 48;
-  LongExecutionMode long_execution_mode = 49;
   optional uint64 wasm_memory_threshold = 50;
   // Contains tasks that need to be executed before processing any input of the
   // canister.

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -667,12 +667,8 @@ pub struct TaskQueue {
 /// Next ID: 65
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CanisterStateBits {
-    #[prost(uint64, tag = "2")]
-    pub last_full_execution_round: u64,
     #[prost(uint64, tag = "4")]
     pub compute_allocation: u64,
-    #[prost(int64, tag = "5")]
-    pub accumulated_priority: i64,
     #[prost(message, optional, tag = "7")]
     pub execution_state_bits: ::core::option::Option<ExecutionStateBits>,
     #[prost(uint64, tag = "8")]
@@ -771,10 +767,6 @@ pub struct CanisterStateBits {
     /// The next local snapshot ID.
     #[prost(uint64, tag = "46")]
     pub next_snapshot_id: u64,
-    #[prost(int64, tag = "48")]
-    pub priority_credit: i64,
-    #[prost(enumeration = "LongExecutionMode", tag = "49")]
-    pub long_execution_mode: i32,
     #[prost(uint64, optional, tag = "50")]
     pub wasm_memory_threshold: ::core::option::Option<u64>,
     /// Contains tasks that need to be executed before processing any input of the

--- a/rs/replicated_state/src/metadata_state/proto.rs
+++ b/rs/replicated_state/src/metadata_state/proto.rs
@@ -389,24 +389,11 @@ impl From<&SystemMetadata> for pb_metadata::SystemMetadata {
 
 /// Decodes a `SystemMetadata` proto. The metrics are provided as a side-channel
 /// for recording errors without being forced to return `Err(_)`.
-///
-/// `fallback_subnet_schedule` is used for backward compatibility when loading
-/// old checkpoints that don't have the `subnet_schedule` field in the proto.
-impl
-    TryFrom<(
-        pb_metadata::SystemMetadata,
-        SubnetSchedule,
-        &dyn CheckpointLoadingMetrics,
-    )> for SystemMetadata
-{
+impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for SystemMetadata {
     type Error = ProxyDecodeError;
 
     fn try_from(
-        (item, fallback_subnet_schedule, metrics): (
-            pb_metadata::SystemMetadata,
-            SubnetSchedule,
-            &dyn CheckpointLoadingMetrics,
-        ),
+        (item, metrics): (pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics),
     ) -> Result<Self, Self::Error> {
         let mut streams = BTreeMap::<SubnetId, Stream>::new();
         for entry in item.streams {
@@ -416,7 +403,7 @@ impl
             );
         }
 
-        let subnet_schedule = if !item.subnet_schedule.is_empty() {
+        let subnet_schedule = {
             let mut priorities = BTreeMap::new();
             for entry in &item.subnet_schedule {
                 let canister_id = CanisterId::try_from(entry.canister_id.clone().ok_or(
@@ -437,8 +424,6 @@ impl
                 );
             }
             SubnetSchedule::new(priorities)
-        } else {
-            fallback_subnet_schedule
         };
 
         let canister_allocation_ranges: CanisterIdRanges = match item.canister_allocation_ranges {

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -401,11 +401,7 @@ fn system_metadata_roundtrip_encoding() {
         let proto = pb::SystemMetadata::from(system_metadata);
         assert_eq!(
             *system_metadata,
-            (
-                proto,
-                SubnetSchedule::default(),
-                &DummyMetrics as &dyn CheckpointLoadingMetrics
-            )
+            (proto, &DummyMetrics as &dyn CheckpointLoadingMetrics)
                 .try_into()
                 .unwrap()
         );
@@ -425,36 +421,6 @@ fn system_metadata_roundtrip_encoding() {
     // Set `last_generated_canister_id` to valid, but migrated canister ID.
     system_metadata.last_generated_canister_id = Some(15.into());
     validate_roundtrip_encoding(&system_metadata);
-}
-
-#[test]
-fn subnet_schedule_backward_compatibility() {
-    // Old encoding: `SystemMetadata` without `subnet_schedule`, plus a
-    // `SubnetSchedule` aggregated from canister states.
-    let system_metadata = SystemMetadata::new(SUBNET_0, SubnetType::Application);
-    let mut subnet_schedule = SubnetSchedule::default();
-    *subnet_schedule.get_mut(CanisterId::from_u64(1)) = CanisterPriority {
-        accumulated_priority: 100.into(),
-        executed_rounds: 2,
-        long_execution_start_round: Some(3.into()),
-        last_full_execution_round: 4.into(),
-    };
-
-    // Expected decoded `SystemMetadata` has populated `subnet_schedule`.
-    let mut expected = system_metadata.clone();
-    expected.subnet_schedule = subnet_schedule.clone();
-
-    let proto = pb_metadata::SystemMetadata::from(&system_metadata);
-    assert_eq!(
-        expected,
-        (
-            proto,
-            subnet_schedule,
-            &DummyMetrics as &dyn CheckpointLoadingMetrics
-        )
-            .try_into()
-            .unwrap()
-    );
 }
 
 #[test]

--- a/rs/state_layout/src/state_layout.rs
+++ b/rs/state_layout/src/state_layout.rs
@@ -19,9 +19,8 @@ use ic_replicated_state::{
 };
 use ic_sys::{fs::sync_path, mmap::ScopedMmap};
 use ic_types::{
-    AccumulatedPriority, CanisterId, CanisterLog, CanisterTimer, ComputeAllocation, ExecutionRound,
-    Height, LongExecutionMode, MemoryAllocation, NumInstructions, PrincipalId, SnapshotId, Time,
-    batch::TotalQueryStats,
+    CanisterId, CanisterLog, CanisterTimer, ComputeAllocation, ExecutionRound, Height,
+    MemoryAllocation, NumInstructions, PrincipalId, SnapshotId, Time, batch::TotalQueryStats,
 };
 use ic_types_cycles::{Cycles, CyclesUseCase, NominalCycles};
 use ic_utils::thread::maybe_parallel_map;
@@ -168,11 +167,7 @@ pub struct ExecutionStateBits {
 #[derive(Debug)]
 pub struct CanisterStateBits {
     pub controllers: BTreeSet<PrincipalId>,
-    pub last_full_execution_round: ExecutionRound,
     pub compute_allocation: ComputeAllocation,
-    pub accumulated_priority: AccumulatedPriority,
-    pub priority_credit: AccumulatedPriority,
-    pub long_execution_mode: LongExecutionMode,
     pub execution_state_bits: Option<ExecutionStateBits>,
     pub memory_allocation: MemoryAllocation,
     pub wasm_memory_threshold: NumBytes,

--- a/rs/state_layout/src/state_layout/proto.rs
+++ b/rs/state_layout/src/state_layout/proto.rs
@@ -15,14 +15,7 @@ impl From<CanisterStateBits> for pb_canister_state_bits::CanisterStateBits {
                 .into_iter()
                 .map(|controller| controller.into())
                 .collect(),
-            last_full_execution_round: item.last_full_execution_round.get(),
             compute_allocation: item.compute_allocation.as_percent(),
-            accumulated_priority: item.accumulated_priority.get(),
-            priority_credit: item.priority_credit.get(),
-            long_execution_mode: pb_canister_state_bits::LongExecutionMode::from(
-                item.long_execution_mode,
-            )
-            .into(),
             execution_state_bits: item.execution_state_bits.as_ref().map(|v| v.into()),
             memory_allocation: item.memory_allocation.pre_allocated_bytes().get(),
             wasm_memory_threshold: Some(item.wasm_memory_threshold.get()),
@@ -137,20 +130,12 @@ impl TryFrom<pb_canister_state_bits::CanisterStateBits> for CanisterStateBits {
 
         Ok(Self {
             controllers,
-            last_full_execution_round: value.last_full_execution_round.into(),
             compute_allocation: ComputeAllocation::try_from(value.compute_allocation).map_err(
                 |e| ProxyDecodeError::ValueOutOfRange {
                     typ: "ComputeAllocation",
                     err: format!("{e:?}"),
                 },
             )?,
-            accumulated_priority: value.accumulated_priority.into(),
-            priority_credit: value.priority_credit.into(),
-            long_execution_mode: pb_canister_state_bits::LongExecutionMode::try_from(
-                value.long_execution_mode,
-            )
-            .unwrap_or_default()
-            .into(),
             execution_state_bits,
             memory_allocation: MemoryAllocation::from(NumBytes::from(value.memory_allocation)),
             wasm_memory_threshold: NumBytes::new(value.wasm_memory_threshold.unwrap_or(0)),

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -28,11 +28,7 @@ use std::sync::Arc;
 fn default_canister_state_bits() -> CanisterStateBits {
     CanisterStateBits {
         controllers: BTreeSet::new(),
-        last_full_execution_round: ExecutionRound::from(0),
         compute_allocation: ComputeAllocation::try_from(0).unwrap(),
-        accumulated_priority: AccumulatedPriority::default(),
-        priority_credit: AccumulatedPriority::default(),
-        long_execution_mode: LongExecutionMode::default(),
         execution_state_bits: None,
         memory_allocation: MemoryAllocation::default(),
         wasm_memory_threshold: NumBytes::new(0),

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -13,7 +13,7 @@ use ic_replicated_state::{
     canister_state::execution_state::{WasmBinary, WasmExecutionMode},
     page_map::PageMap,
 };
-use ic_replicated_state::{CanisterPriority, CheckpointLoadingMetrics, Memory, SubnetSchedule};
+use ic_replicated_state::{CheckpointLoadingMetrics, Memory};
 use ic_state_layout::{
     AccessPolicy, CanisterLayout, CanisterSnapshotBits, CanisterStateBits, CheckpointLayout,
     PageMapLayout, ReadOnly, SnapshotLayout, error::LayoutError, try_mmap_wasm_file,
@@ -404,10 +404,7 @@ impl CheckpointLoader {
         }
     }
 
-    fn load_system_metadata(
-        &self,
-        subnet_schedule: SubnetSchedule,
-    ) -> Result<ic_replicated_state::SystemMetadata, CheckpointError> {
+    fn load_system_metadata(&self) -> Result<ic_replicated_state::SystemMetadata, CheckpointError> {
         let _timer = self
             .metrics
             .load_checkpoint_step_duration
@@ -421,7 +418,6 @@ impl CheckpointLoader {
         let metadata_proto = self.checkpoint_layout.system_metadata().deserialize()?;
         let mut metadata = ic_replicated_state::SystemMetadata::try_from((
             metadata_proto,
-            subnet_schedule,
             &self.metrics as &dyn CheckpointLoadingMetrics,
         ))
         .map_err(|err| self.map_to_checkpoint_error("SystemMetadata".into(), err))?;
@@ -484,7 +480,7 @@ impl CheckpointLoader {
     fn load_canister_states(
         &self,
         thread_pool: &mut Option<&mut scoped_threadpool::Pool>,
-    ) -> Result<(BTreeMap<CanisterId, Arc<CanisterState>>, SubnetSchedule), CheckpointError> {
+    ) -> Result<BTreeMap<CanisterId, Arc<CanisterState>>, CheckpointError> {
         let _timer = self
             .metrics
             .load_checkpoint_step_duration
@@ -492,7 +488,6 @@ impl CheckpointLoader {
             .start_timer();
 
         let mut canister_states = BTreeMap::new();
-        let mut priorities = BTreeMap::new();
         let canister_ids = self.checkpoint_layout.canister_ids()?;
         let snapshot_ids = self.checkpoint_layout.snapshot_ids()?;
         let mut snapshot_ids_per_canister: BTreeMap<CanisterId, Vec<SnapshotId>> = BTreeMap::new();
@@ -515,24 +510,24 @@ impl CheckpointLoader {
             )
         });
 
-        for result in results.into_iter() {
-            let (canister_state, canister_priority, durations) = result?;
-            priorities.insert(canister_state.canister_id(), canister_priority);
-            canister_states.insert(canister_state.canister_id(), Arc::new(canister_state));
+        for canister_state in results.into_iter() {
+            let (canister_state, durations) = canister_state?;
+            canister_states.insert(
+                canister_state.system_state.canister_id(),
+                Arc::new(canister_state),
+            );
 
             durations.apply(&self.metrics);
         }
 
-        let subnet_schedule = SubnetSchedule::new(priorities);
-
-        Ok((canister_states, subnet_schedule))
+        Ok(canister_states)
     }
 
     fn validate_eq_canister_states(
         &self,
         thread_pool: &mut Option<&mut scoped_threadpool::Pool>,
         ref_canister_states: &BTreeMap<CanisterId, Arc<CanisterState>>,
-    ) -> Result<BTreeMap<CanisterId, CanisterPriority>, String> {
+    ) -> Result<(), String> {
         let on_disk_canister_ids = self
             .checkpoint_layout
             .canister_ids()
@@ -553,8 +548,8 @@ impl CheckpointLoader {
                 .or_default()
                 .push(snapshot_id);
         }
-        maybe_parallel_map(thread_pool, ref_canister_ids.iter(), |&canister_id| {
-            let (canister_state, canister_priority, _) = load_canister_state_from_checkpoint(
+        maybe_parallel_map(thread_pool, ref_canister_ids.iter(), |canister_id| {
+            load_canister_state_from_checkpoint(
                 &self.checkpoint_layout,
                 canister_id,
                 snapshot_ids_per_canister
@@ -568,16 +563,16 @@ impl CheckpointLoader {
                 format!(
                     "Failed to load canister state for validation for key #{canister_id}: {err}"
                 )
-            })?;
-            canister_state.validate_eq(
+            })?
+            .0
+            .validate_eq(
                 ref_canister_states
                     .get(canister_id)
                     .expect("Failed to get canister from canister_states"),
-            )?;
-            Ok::<_, String>((*canister_id, canister_priority))
+            )
         })
         .into_iter()
-        .collect()
+        .try_for_each(identity)
     }
 
     fn validate_eq_canister_snapshots_ids(
@@ -615,11 +610,9 @@ pub fn load_checkpoint(
         metrics: metrics.clone(),
         fd_factory,
     };
-    let (canister_states, subnet_schedule) =
-        checkpoint_loader.load_canister_states(&mut thread_pool)?;
     let state = ReplicatedState::new_from_checkpoint(
-        canister_states,
-        checkpoint_loader.load_system_metadata(subnet_schedule)?,
+        checkpoint_loader.load_canister_states(&mut thread_pool)?,
+        checkpoint_loader.load_system_metadata()?,
         checkpoint_loader.load_subnet_queues()?,
         checkpoint_loader.load_refunds()?,
         checkpoint_loader.load_epoch_query_stats()?,
@@ -672,9 +665,9 @@ fn validate_eq_checkpoint_internal(
         fd_factory,
     };
 
-    let priorities = checkpoint_loader.validate_eq_canister_states(thread_pool, canister_states)?;
+    checkpoint_loader.validate_eq_canister_states(thread_pool, canister_states)?;
     checkpoint_loader
-        .load_system_metadata(SubnetSchedule::new(priorities))
+        .load_system_metadata()
         .map_err(|err| format!("Failed to load system metadata: {err}"))?
         .validate_eq(metadata)?;
     if !metadata.unflushed_checkpoint_ops.is_empty() {
@@ -725,7 +718,7 @@ pub fn load_canister_state(
     height: Height,
     fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
     metrics: &dyn CheckpointLoadingMetrics,
-) -> Result<(CanisterState, CanisterPriority, LoadCanisterMetrics), CheckpointError> {
+) -> Result<(CanisterState, LoadCanisterMetrics), CheckpointError> {
     let mut durations = BTreeMap::<&str, Duration>::default();
 
     let into_checkpoint_error =
@@ -887,22 +880,10 @@ pub fn load_canister_state(
         },
         canister_snapshots,
     };
-    let priority = CanisterPriority {
-        accumulated_priority: canister_state_bits.accumulated_priority,
-        // We can only be loading an aborted execution, so zero executed rounds.
-        executed_rounds: 0,
-        // Set a long execution start round where necessary.
-        long_execution_start_round: if canister_state.has_long_execution() {
-            Some(0.into())
-        } else {
-            None
-        },
-        last_full_execution_round: canister_state_bits.last_full_execution_round,
-    };
 
     let metrics = LoadCanisterMetrics { durations };
 
-    Ok((canister_state, priority, metrics))
+    Ok((canister_state, metrics))
 }
 
 fn load_canister_state_from_checkpoint(
@@ -911,7 +892,7 @@ fn load_canister_state_from_checkpoint(
     snapshot_ids: Vec<SnapshotId>,
     fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
     metrics: &CheckpointMetrics,
-) -> Result<(CanisterState, CanisterPriority, LoadCanisterMetrics), CheckpointError> {
+) -> Result<(CanisterState, LoadCanisterMetrics), CheckpointError> {
     let canister_layout = checkpoint_layout.canister(canister_id)?;
     let mut canister_snapshots = CanisterSnapshots::default();
     for snapshot_id in snapshot_ids {

--- a/rs/state_manager/src/split/tests.rs
+++ b/rs/state_manager/src/split/tests.rs
@@ -16,7 +16,7 @@ use ic_metrics::MetricsRegistry;
 use ic_registry_routing_table::CanisterIdRange;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
-    CheckpointLoadingMetrics, ReplicatedState, SubnetSchedule, SystemMetadata,
+    CheckpointLoadingMetrics, ReplicatedState, SystemMetadata,
     canister_state::canister_snapshots::CanisterSnapshot,
     page_map::TestPageAllocatorFileDescriptorImpl, testing::ReplicatedStateTesting,
 };
@@ -604,7 +604,6 @@ fn deserialize_system_metadata(root: &Path, height: Height, log: &ReplicaLogger)
         .into();
     (
         system_metadata.deserialize().unwrap(),
-        SubnetSchedule::default(),
         &CheckpointMetrics::new(&MetricsRegistry::new(), log.clone())
             as &dyn CheckpointLoadingMetrics,
     )

--- a/rs/state_manager/src/tip.rs
+++ b/rs/state_manager/src/tip.rs
@@ -1207,15 +1207,7 @@ fn serialize_canister_protos_to_checkpoint_readwrite(
     canister_layout.canister().serialize(
         CanisterStateBits {
             controllers: canister_state.system_state.controllers.clone(),
-            // Ignored after the first checkpoint load during an upgrade.
-            last_full_execution_round: 0.into(),
             compute_allocation: canister_state.compute_allocation(),
-            // Value is ignored when loading.
-            priority_credit: 0.into(),
-            // Value is ignored when loading.
-            long_execution_mode: Default::default(),
-            // Ignored after the first checkpoint load during an upgrade.
-            accumulated_priority: Default::default(),
             memory_allocation: canister_state.system_state.memory_allocation,
             wasm_memory_threshold: canister_state.system_state.wasm_memory_threshold,
             freeze_threshold: canister_state.system_state.freeze_threshold,

--- a/rs/state_tool/src/commands/decode.rs
+++ b/rs/state_tool/src/commands/decode.rs
@@ -27,23 +27,10 @@ pub fn do_decode(path: PathBuf) -> Result<(), String> {
         .ok_or_else(|| format!("failed to convert path {} to UTF-8 string", path.display()))?;
     match fname {
         SYSTEM_METADATA_FILE => {
-            // display_proto_with_error_metric::<pb_metadata::SystemMetadata, SystemMetadata>(
-            //     path.clone(),
-            //     &dummy_metrics as &dyn CheckpointLoadingMetrics,
-            // )
-            let f: ProtoFileWith<pb_metadata::SystemMetadata, ReadOnly> = path.into();
-            let pb = f.deserialize().map_err(|e| format!("{e:?}"))?;
-            let metrics = &dummy_metrics as &dyn CheckpointLoadingMetrics;
-            let t = SystemMetadata::try_from((pb, Default::default(), metrics)).map_err(|e| {
-                format!(
-                    "failed to decode rust type {} from protobuf {}: {}",
-                    std::any::type_name::<SystemMetadata>(),
-                    std::any::type_name::<pb_metadata::SystemMetadata>(),
-                    e
-                )
-            })?;
-            println!("{t:#?}");
-            Ok(())
+            display_proto_with_error_metric::<pb_metadata::SystemMetadata, SystemMetadata>(
+                path.clone(),
+                &dummy_metrics as &dyn CheckpointLoadingMetrics,
+            )
         }
         INGRESS_HISTORY_FILE => {
             display_proto::<pb_ingress::IngressHistoryState, IngressHistoryState>(path.clone())


### PR DESCRIPTION
Stop persisting canister priority fields in `CanisterStateBits`. The whole subnet schedule (canister priorities for all canisters, soon for active canisters only) is now persisted as part of `SystemMetadata`.