### PR TITLE
chore: require a unique subnet ID in /canister_ranges paths via read state

### DIFF
--- a/rs/http_endpoints/public/src/read_state.rs
+++ b/rs/http_endpoints/public/src/read_state.rs
@@ -421,6 +421,7 @@ fn verify_paths(
     };
 
     let mut last_request_status_id: Option<MessageId> = None;
+    let mut last_canister_ranges_subnet_id = None;
 
     // Convert the paths to slices to make it easier to match below.
     let paths: Vec<Vec<&[u8]>> = paths
@@ -506,7 +507,20 @@ fn verify_paths(
             {
                 metrics.observe_read_state_path(endpoint, "subnet_canister_ranges");
             }
-            [b"canister_ranges", _subnet_id] if target == Target::Subnet => {
+            [b"canister_ranges", subnet_id] if target == Target::Subnet => {
+                let subnet_id = parse_principal_id(subnet_id)?;
+                if let Some(last_id) = last_canister_ranges_subnet_id
+                    && subnet_id != last_id
+                {
+                    return Err(HttpError {
+                        status: StatusCode::BAD_REQUEST,
+                        message: format!(
+                            "More than one non-unique subnet ID exists \
+                                in canister_ranges paths: {last_id} and {subnet_id}."
+                        ),
+                    });
+                }
+                last_canister_ranges_subnet_id = Some(subnet_id);
                 metrics.observe_read_state_path(endpoint, "canister_ranges");
             }
             [b"request_status", request_id]
@@ -1067,6 +1081,113 @@ mod test {
         )
         .expect_err("Should fail");
         assert_eq!(err.status, StatusCode::NOT_FOUND);
+    }
+
+    #[rstest]
+    fn requesting_canister_ranges_with_multiple_non_unique_subnet_ids_fails(
+        #[values(Version::V2, Version::V3)] version: Version,
+    ) {
+        let metrics = test_metrics();
+        let state = fake_replicated_state();
+        let err = verify_paths(
+            &metrics,
+            Target::Subnet,
+            version,
+            &state,
+            &user_test_id(1),
+            &[
+                Path::new(vec![
+                    Label::from("canister_ranges"),
+                    subnet_test_id(2).get().to_vec().into(),
+                ]),
+                Path::new(vec![
+                    Label::from("canister_ranges"),
+                    subnet_test_id(3).get().to_vec().into(),
+                ]),
+            ],
+            &CanisterIdSet::all(),
+            APP_SUBNET_ID.get(),
+            NNS_SUBNET_ID,
+        )
+        .expect_err(
+            "Should fail because requesting /canister_ranges \
+            for multiple subnet ids is not allowed",
+        );
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            err.message,
+            format!(
+                "More than one non-unique subnet ID exists \
+                    in canister_ranges paths: {} and {}.",
+                subnet_test_id(2).get(),
+                subnet_test_id(3).get()
+            )
+        );
+    }
+
+    #[rstest]
+    fn requesting_canister_ranges_with_multiple_unique_subnet_ids_succeeds(
+        #[values(Version::V2, Version::V3)] version: Version,
+    ) {
+        let metrics = test_metrics();
+        let state = fake_replicated_state();
+        assert_eq!(
+            verify_paths(
+                &metrics,
+                Target::Subnet,
+                version,
+                &state,
+                &user_test_id(1),
+                &[
+                    Path::new(vec![
+                        Label::from("canister_ranges"),
+                        subnet_test_id(2).get().to_vec().into(),
+                    ]),
+                    Path::new(vec![
+                        Label::from("canister_ranges"),
+                        subnet_test_id(2).get().to_vec().into(),
+                    ]),
+                ],
+                &CanisterIdSet::all(),
+                APP_SUBNET_ID.get(),
+                NNS_SUBNET_ID,
+            ),
+            Ok(()),
+            "Should succeed because it is okay to request /canister_ranges \
+            path multiple times for the same subnet id"
+        );
+    }
+
+    #[rstest]
+    fn requesting_canister_ranges_with_invalid_subnet_id_fails(
+        #[values(Version::V2, Version::V3)] version: Version,
+    ) {
+        let metrics = test_metrics();
+        let state = fake_replicated_state();
+        let err = verify_paths(
+            &metrics,
+            Target::Subnet,
+            version,
+            &state,
+            &user_test_id(1),
+            &[Path::new(vec![
+                Label::from("canister_ranges"),
+                Label::from("very_much_invalid_subnet_id!!!"),
+            ])],
+            &CanisterIdSet::all(),
+            APP_SUBNET_ID.get(),
+            NNS_SUBNET_ID,
+        )
+        .expect_err(
+            "Should fail because requesting /canister_ranges \
+            with an invalid subnet id should be rejected",
+        );
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert!(
+            err.message.starts_with("Could not parse principal ID:"),
+            "unexpected message: {}",
+            err.message
+        );
     }
 
     #[rstest]

--- a/rs/tests/message_routing/xnet/xnet_cloud_engine_isolation_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_cloud_engine_isolation_test.rs
@@ -379,18 +379,18 @@ fn test(env: TestEnv) {
         ] {
             info!(logger, "Checking /subnet and /canister_ranges on {name}...");
 
-            // Build paths: /subnet/<id>/public_key and /canister_ranges/<id>
-            // for every known subnet ID. These are allowed on the subnet
-            // read_state endpoint.
-            let mut paths: Vec<Vec<Label<Vec<u8>>>> = Vec::new();
-            for (_target_name, id) in &all_subnets {
-                let id_label: Label<Vec<u8>> = id.get_ref().as_slice().into();
-                paths.push(vec!["subnet".into(), id_label.clone(), "public_key".into()]);
-                paths.push(vec!["canister_ranges".into(), id_label]);
-            }
+            // Query /subnet/<id>/public_key for all known subnet IDs in one
+            // call (no restriction on mixing subnet IDs in /subnet paths).
+            let subnet_paths: Vec<Vec<Label<Vec<u8>>>> = all_subnets
+                .iter()
+                .map(|(_target_name, id)| {
+                    let id_label: Label<Vec<u8>> = id.get_ref().as_slice().into();
+                    vec!["subnet".into(), id_label, "public_key".into()]
+                })
+                .collect();
 
             let cert = agent
-                .read_subnet_state_raw(paths, own_subnet_id.get().into())
+                .read_subnet_state_raw(subnet_paths, own_subnet_id.get().into())
                 .await
                 .expect("read_state should succeed");
 
@@ -411,8 +411,18 @@ fn test(env: TestEnv) {
                      (expected visible={should_be_visible}, got {subnet_result:?})"
                 );
 
-                // Check /canister_ranges/<id>
-                let cr_result = cert
+                // Check /canister_ranges/<id> in a separate call per subnet ID
+                // (the endpoint rejects requests with multiple distinct subnet IDs
+                // in canister_ranges paths).
+                let id_label: Label<Vec<u8>> = id.get_ref().as_slice().into();
+                let cr_cert = agent
+                    .read_subnet_state_raw(
+                        vec![vec!["canister_ranges".into(), id_label]],
+                        own_subnet_id.get().into(),
+                    )
+                    .await
+                    .expect("read_state for canister_ranges should succeed");
+                let cr_result = cr_cert
                     .tree
                     .lookup_subtree(&[b"canister_ranges".as_slice(), id_bytes]);
                 assert_eq!(

--- a/rs/tests/message_routing/xnet/xnet_cloud_engine_isolation_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_cloud_engine_isolation_test.rs
@@ -411,7 +411,7 @@ fn test(env: TestEnv) {
                      (expected visible={should_be_visible}, got {subnet_result:?})"
                 );
 
-                // Check /canister_ranges/<id> in a separate call per subnet ID
+                // Check /canister_ranges/<id> in separate calls per subnet ID
                 // (the endpoint rejects requests with multiple distinct subnet IDs
                 // in canister_ranges paths).
                 let id_label: Label<Vec<u8>> = id.get_ref().as_slice().into();


### PR DESCRIPTION
This PR tightens the conditions on `/canister_ranges` paths requested via the read state HTTP handler: all paths of the form `/canister_ranges/<subnet_id>` must refer to the same `<subnet_id>`. The motivation for this change is to prevent huge responses when the routing table gets more fragmented in the future.

This PR has been derived from [PR](https://github.com/dfinity/ic/pull/6671) which could not be easily merged due to conflicts.