### PR TITLE
fix: deflake //rs/dogecoin/ckdoge/minter:integration_tests

### DIFF
--- a/rs/dogecoin/ckdoge/minter/src/lib.rs
+++ b/rs/dogecoin/ckdoge/minter/src/lib.rs
@@ -48,6 +48,9 @@ use std::time::Duration;
 /// Maximum number of inputs for a Dogecoin transaction.
 pub const DOGECOIN_MAX_NUM_INPUTS_IN_TRANSACTION: usize = 500;
 
+/// How often the minter refreshes the Dogecoin fee percentiles.
+pub const REFRESH_FEE_PERCENTILES_FREQUENCY: Duration = Duration::from_secs(360);
+
 pub const DOGECOIN_CANISTER_RUNTIME: DogeCanisterRuntime = DogeCanisterRuntime {};
 
 #[derive(Copy, Clone)]
@@ -67,8 +70,7 @@ impl CanisterRuntime for DogeCanisterRuntime {
     }
 
     fn refresh_fee_percentiles_frequency(&self) -> Duration {
-        const SIX_MINUTES: Duration = Duration::from_secs(360);
-        SIX_MINUTES
+        REFRESH_FEE_PERCENTILES_FREQUENCY
     }
 
     async fn get_current_fee_percentiles(

--- a/rs/dogecoin/ckdoge/minter/tests/tests.rs
+++ b/rs/dogecoin/ckdoge/minter/tests/tests.rs
@@ -483,6 +483,13 @@ fn should_estimate_withdrawal_fee() {
         .minter_update_balance()
         .expect_mint();
 
+    // Ensure the fee percentile refresh task runs successfully now that the
+    // dogecoin canister is fully synced. Otherwise `last_median_fee_per_vbyte`
+    // could still be at its default of 1 millikoinu/byte if the initial refresh
+    // (scheduled at minter init) fired before the dogecoin canister was synced
+    // and trapped.
+    minter.refresh_fee_percentiles();
+
     assert_eq!(
         estimate_withdrawal_fee_and_check(&minter, DOGE),
         Err(EstimateWithdrawalFeeError::AmountTooLow {

--- a/rs/dogecoin/ckdoge/test_utils/src/minter.rs
+++ b/rs/dogecoin/ckdoge/test_utils/src/minter.rs
@@ -141,19 +141,17 @@ impl MinterCanister {
     }
 
     /// Trigger a refresh of the median fee percentiles by advancing time past
-    /// the `refresh_fee_percentiles_frequency` (6 minutes for ckDOGE) and
-    /// ticking. This is useful in tests to ensure that
-    /// `last_median_fee_per_vbyte` is updated to a value derived from the
-    /// dogecoin canister fee percentiles, rather than the default value of 1
-    /// millikoinu/byte. This is needed in cases where the periodic
-    /// `RefreshFeePercentiles` task scheduled at minter init fired before the
-    /// dogecoin canister was fully synced and trapped, leaving the median fee
-    /// at its default.
+    /// [`ic_ckdoge_minter::REFRESH_FEE_PERCENTILES_FREQUENCY`] and ticking.
+    /// This is useful in tests to ensure that `last_median_fee_per_vbyte` is
+    /// updated to a value derived from the dogecoin canister fee percentiles,
+    /// rather than the default value of 1 millikoinu/byte. This is needed in
+    /// cases where the periodic `RefreshFeePercentiles` task scheduled at
+    /// minter init fired before the dogecoin canister was fully synced and
+    /// trapped, leaving the median fee at its default.
     pub fn refresh_fee_percentiles(&self) {
-        // 6 minutes (the ckDOGE `refresh_fee_percentiles_frequency`) plus a buffer.
-        const REFRESH_FEE_PERCENTILES_FREQUENCY: Duration = Duration::from_secs(360);
-        self.env
-            .advance_time(REFRESH_FEE_PERCENTILES_FREQUENCY + Duration::from_secs(1));
+        self.env.advance_time(
+            ic_ckdoge_minter::REFRESH_FEE_PERCENTILES_FREQUENCY + Duration::from_secs(1),
+        );
         // Multiple ticks to allow the timer to fire and the inter-canister call
         // (and its response) to be processed.
         for _ in 0..5 {

--- a/rs/dogecoin/ckdoge/test_utils/src/minter.rs
+++ b/rs/dogecoin/ckdoge/test_utils/src/minter.rs
@@ -140,6 +140,27 @@ impl MinterCanister {
         Decode!(&call_result, MinterInfo).unwrap()
     }
 
+    /// Trigger a refresh of the median fee percentiles by advancing time past
+    /// the [`refresh_fee_percentiles_frequency`] (6 minutes for ckDOGE) and
+    /// ticking. This is useful in tests to ensure that
+    /// `last_median_fee_per_vbyte` is updated to a value derived from the
+    /// dogecoin canister fee percentiles, rather than the default value of 1
+    /// millikoinu/byte. This is needed in cases where the periodic
+    /// `RefreshFeePercentiles` task scheduled at minter init fired before the
+    /// dogecoin canister was fully synced and trapped, leaving the median fee
+    /// at its default.
+    pub fn refresh_fee_percentiles(&self) {
+        // 6 minutes (the ckDOGE `refresh_fee_percentiles_frequency`) plus a buffer.
+        const REFRESH_FEE_PERCENTILES_FREQUENCY: Duration = Duration::from_secs(360);
+        self.env
+            .advance_time(REFRESH_FEE_PERCENTILES_FREQUENCY + Duration::from_secs(1));
+        // Multiple ticks to allow the timer to fire and the inter-canister call
+        // (and its response) to be processed.
+        for _ in 0..5 {
+            self.env.tick();
+        }
+    }
+
     pub fn estimate_withdrawal_fee(
         &self,
         withdrawal_amount: u64,

--- a/rs/dogecoin/ckdoge/test_utils/src/minter.rs
+++ b/rs/dogecoin/ckdoge/test_utils/src/minter.rs
@@ -141,7 +141,7 @@ impl MinterCanister {
     }
 
     /// Trigger a refresh of the median fee percentiles by advancing time past
-    /// the [`refresh_fee_percentiles_frequency`] (6 minutes for ckDOGE) and
+    /// the `refresh_fee_percentiles_frequency` (6 minutes for ckDOGE) and
     /// ticking. This is useful in tests to ensure that
     /// `last_median_fee_per_vbyte` is updated to a value derived from the
     /// dogecoin canister fee percentiles, rather than the default value of 1


### PR DESCRIPTION
## Root cause

The `should_estimate_withdrawal_fee` test in `rs/dogecoin/ckdoge/minter/tests/tests.rs` would occasionally fail with:

```
left: Ok(WithdrawalFee { minter_fee: 180000000, dogecoin_fee: 1 })
right: Ok(WithdrawalFee { minter_fee: 180000000, dogecoin_fee: 227000000 })
```

See:
* [April 30th, 2026 at 12:12:48 pm](https://dash.dm1-idx1.dfinity.network/invocation/c58fbf91-bbf9-447f-97ee-1077c0dda9e5?target=//rs/dogecoin/ckdoge/minter:integration_tests#@10448).
* [April 29th, 2026 at 7:08:52 pm](https://dash.dm1-idx1.dfinity.network/invocation/71515a03-5dbf-4ac0-8712-7fa1b1b282a9?target=//rs/dogecoin/ckdoge/minter:integration_tests#@9443).

The `RefreshFeePercentiles` task scheduled by `setup_tasks` at minter init fires almost immediately. However, when this happens, the dogecoin feature canister is sometimes not yet fully synced and traps the inter-canister call to `bitcoin_get_current_fee_percentiles` with `Panicked at 'Canister state is not fully synced.', canister/src/lib.rs:386:13`. `estimate_fee_per_vbyte` then logs the error and returns without updating `last_median_fee_per_vbyte`. The next refresh is scheduled 6 minutes later (the ckDOGE `refresh_fee_percentiles_frequency`). Because the test does not advance virtual time by that much, `last_median_fee_per_vbyte` stays at its default of `FeeRate::from_millis_per_byte(1)`, yielding `dogecoin_fee: 1` (= 1 millikoinu/byte * 227 bytes ceil).

## Fix

Add a `MinterCanister::refresh_fee_percentiles` helper that advances virtual time past the refresh frequency and ticks the `PocketIc`, and call it in the test before asserting the expected fee. By that point, the dogecoin canister is fully synced (a deposit just succeeded), so the timer task fetches percentiles successfully and updates `last_median_fee_per_vbyte` to the expected regtest default.

## Verification

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 //rs/dogecoin/ckdoge/minter:integration_tests
```
3/3 runs PASSED.

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.