### PR TITLE
test(ckdoge): fix ckdoge test setup

### DIFF
--- a/rs/dogecoin/ckdoge/minter/tests/tests.rs
+++ b/rs/dogecoin/ckdoge/minter/tests/tests.rs
@@ -455,6 +455,7 @@ fn should_estimate_withdrawal_fee() {
     fn estimate_withdrawal_fee_and_check(
         minter: &MinterCanister,
         withdrawal_amount: u64,
+        expected_num_utxos: usize,
     ) -> Result<WithdrawalFee, EstimateWithdrawalFeeError> {
         let utxos_before = minter.get_known_utxos(USER_PRINCIPAL);
         let result = minter.estimate_withdrawal_fee(withdrawal_amount);
@@ -463,6 +464,7 @@ fn should_estimate_withdrawal_fee() {
             utxos_before, utxos_after,
             "BUG: a query endpoint should not be able to modify state!"
         );
+        assert_eq!(utxos_before.len(), expected_num_utxos);
         result
     }
 
@@ -470,7 +472,7 @@ fn should_estimate_withdrawal_fee() {
     let minter = setup.minter();
 
     assert_eq!(
-        estimate_withdrawal_fee_and_check(&minter, DOGE),
+        estimate_withdrawal_fee_and_check(&minter, DOGE, 0),
         Err(EstimateWithdrawalFeeError::AmountTooHigh),
         "Any amount should be too high since there are no UTXOs"
     );
@@ -484,7 +486,7 @@ fn should_estimate_withdrawal_fee() {
         .expect_mint();
 
     assert_eq!(
-        estimate_withdrawal_fee_and_check(&minter, DOGE),
+        estimate_withdrawal_fee_and_check(&minter, DOGE, 2),
         Err(EstimateWithdrawalFeeError::AmountTooLow {
             min_amount: RETRIEVE_DOGE_MIN_AMOUNT
         })
@@ -495,11 +497,13 @@ fn should_estimate_withdrawal_fee() {
         dogecoin_fee: 227_000_000,
     };
     assert_eq!(
-        estimate_withdrawal_fee_and_check(&minter, RETRIEVE_DOGE_MIN_AMOUNT),
-        Ok(expected_fee)
+        estimate_withdrawal_fee_and_check(&minter, RETRIEVE_DOGE_MIN_AMOUNT, 2),
+        Ok(expected_fee),
+        "Minter logs {:?}",
+        minter.get_logs()
     );
     assert_eq!(
-        estimate_withdrawal_fee_and_check(&minter, RETRIEVE_DOGE_MIN_AMOUNT),
+        estimate_withdrawal_fee_and_check(&minter, RETRIEVE_DOGE_MIN_AMOUNT, 2),
         Ok(expected_fee),
         "BUG: estimate_withdrawal_fee should be idempotent"
     );

--- a/rs/dogecoin/ckdoge/test_utils/src/dogecoin.rs
+++ b/rs/dogecoin/ckdoge/test_utils/src/dogecoin.rs
@@ -214,15 +214,20 @@ impl Drop for DogecoinSyncGuard<'_> {
             .await_ok(|dogecoind| dogecoind.get_blockchain_info())
             .blocks;
 
-        for _ in 0..MAX_TICKS {
+        for i in 0..MAX_TICKS {
             match dogecoin_canister.get_block_height() {
                 Ok(dogecoin_canister_block_height)
                     if dogecoin_canister_block_height >= dogecoin_block_height =>
                 {
+                    println!(
+                        "Dogecoin canister ready ({i}/{MAX_TICKS}). Has block height {dogecoin_canister_block_height} (wanted at least {dogecoin_block_height})."
+                    );
                     return;
                 }
                 result => {
-                    println!("Dogecoin canister not ready {result:?}");
+                    println!(
+                        "Dogecoin canister not ready ({i}/{MAX_TICKS}). Got {result:?}, expected at least {dogecoin_block_height}"
+                    );
                     self.daemon.env.tick();
                 }
             }

--- a/rs/dogecoin/ckdoge/test_utils/src/lib.rs
+++ b/rs/dogecoin/ckdoge/test_utils/src/lib.rs
@@ -87,7 +87,14 @@ impl Setup {
                     .with_icp_features(icp_features)
                     .build();
                 pic.set_time(SystemTime::now().into());
-                Arc::new(pic)
+                let env = Arc::new(pic);
+                let dogecoind = DogecoinDaemon {
+                    env: env.clone(),
+                    daemon: daemon.clone(),
+                };
+                // Ensure that dogecoin canister is up and running.
+                dogecoind.mine_blocks(1);
+                env
             }
             None => Arc::new(
                 PocketIcBuilder::new()


### PR DESCRIPTION
## Summary
- Mine a block during `Setup` so the dogecoin canister is guaranteed up and running before tests start
- Improve `DogecoinSyncGuard` logging to show progress and target block height

## Details

Fix flakyness in ckDOGE integration tests that is visible in #8885 and #9985 but currently not on master (`63f33dc741a0e5ab50891e3532f52fa027fb3ff1`). The reason is apparent when looking at the ckDOGE minter logs. For example for `should_estimate_withdrawal_fee`:

1. Failed run
    ```
    [init]: Initializing canister with args InitArgs {...}
    
    [estimate_fee_per_vbyte]: failed to get median fee per vbyte: management call 'dogecoin_get_fee_percentiles' failed: the management canister rejected the call: call rejected: 5 - IC0503: Error from Canister gordg-fyaaa-aaaan-aaadq-cai: Canister called `ic0.trap` with message: 'Panicked at 'Canister state is not fully synced.'
    
    Minted 5000000000 ckTESTBTC for account tjrnw-kiafi corresponding to utxo f3fb3723df1f2b1189438c7c2429a712b974ba6aba418f7ba096bcf4aacc3822:0 with value 50.0
    ```
2. Successful run
    ```
    [init]: Initializing canister with args InitArgs {...}
    
    [estimate_fee_per_vbyte]: update median fee per vbyte to FeeRate(1000000000) and fee-based minimum retrieve amount to 5000000000 with []
    
    Minted 5000000000 ckTESTBTC for account tjrnw-kiafi corresponding to utxo f3fb3723df1f2b1189438c7c2429a712b974ba6aba418f7ba096bcf4aacc3822:0 with value 50.0
    ```

That means that:

1. The task to refresh fee percentiles runs directly after canister initialization.
2. In rare occurrences the dogecoin canister is not yet available (not synced to tip), hence the error.

The fix consists in ensuring as part of the test `Setup` instantiation that the dogecoin canister is ready _before_ installing the ckDOGE minter.

This subsumes #10072.