### PR TITLE
feat: Add canister_metrics management canister endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11193,6 +11193,7 @@ dependencies = [
  "ic-btc-replica-types",
  "ic-error-types 0.2.0",
  "ic-protobuf",
+ "ic-types-cycles",
  "ic-utils 0.9.0",
  "num-traits",
  "serde",

--- a/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
@@ -8,10 +8,10 @@ use ic_logger::{ReplicaLogger, info};
 use ic_management_canister_types_private::{
     BitcoinGetBalanceArgs, BitcoinGetBlockHeadersArgs, BitcoinGetCurrentFeePercentilesArgs,
     BitcoinGetUtxosArgs, BitcoinSendTransactionArgs, CanisterIdRecord, CanisterInfoRequest,
-    CanisterMetadataRequest, ClearChunkStoreArgs, DeleteCanisterSnapshotArgs, ECDSAPublicKeyArgs,
-    FetchCanisterLogsRequest, InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs,
-    LoadCanisterSnapshotArgs, MasterPublicKeyId, Method as Ic00Method, NodeMetricsHistoryArgs,
-    Payload, ProvisionalTopUpCanisterArgs, ReadCanisterSnapshotDataArgs,
+    CanisterMetadataRequest, CanisterMetricsArgs, ClearChunkStoreArgs, DeleteCanisterSnapshotArgs,
+    ECDSAPublicKeyArgs, FetchCanisterLogsRequest, InstallChunkedCodeArgs, InstallCodeArgsV2,
+    ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs, MasterPublicKeyId, Method as Ic00Method,
+    NodeMetricsHistoryArgs, Payload, ProvisionalTopUpCanisterArgs, ReadCanisterSnapshotDataArgs,
     ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs, ReshareChainKeyArgs,
     SchnorrPublicKeyArgs, SetupInitialDKGArgs, SignWithECDSAArgs, SignWithSchnorrArgs,
     StoredChunksArgs, SubnetInfoArgs, TakeCanisterSnapshotArgs, UninstallCodeArgs,
@@ -366,6 +366,11 @@ pub(super) fn resolve_destination(
             let args = RenameCanisterArgs::decode(payload)?;
             let canister_id = args.get_canister_id();
             route_canister_id(canister_id, Ic00Method::RenameCanister, network_topology)
+        }
+        Ok(Ic00Method::CanisterMetrics) => {
+            let args = CanisterMetricsArgs::decode(payload)?;
+            let canister_id = args.get_canister_id();
+            route_canister_id(canister_id, Ic00Method::CanisterMetrics, network_topology)
         }
         Err(_) => Err(ResolveDestinationError::MethodNotFound(
             method_name.to_string(),

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -357,7 +357,8 @@ impl SystemStateModifications {
             | Ok(Ic00Method::ReadCanisterSnapshotMetadata)
             | Ok(Ic00Method::ReadCanisterSnapshotData)
             | Ok(Ic00Method::UploadCanisterSnapshotMetadata)
-            | Ok(Ic00Method::UploadCanisterSnapshotData) => Ok(None),
+            | Ok(Ic00Method::UploadCanisterSnapshotData)
+            | Ok(Ic00Method::CanisterMetrics) => Ok(None),
             Err(_) => Err(UserError::new(
                 ErrorCode::CanisterMethodNotFound,
                 format!("Management canister has no method '{}'", msg.method_name),

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -26,11 +26,11 @@ use ic_limits::LOG_CANISTER_OPERATION_CYCLES_THRESHOLD;
 use ic_logger::{ReplicaLogger, error, fatal, info};
 use ic_management_canister_types_private::{
     CanisterChangeDetails, CanisterChangeOrigin, CanisterInstallModeV2, CanisterMetadataResponse,
-    CanisterSnapshotDataKind, CanisterSnapshotDataOffset, CanisterSnapshotResponse,
-    CanisterStatusResultV2, CanisterStatusType, ChunkHash, EmptyBlob, Global, GlobalTimer,
-    Method as Ic00Method, Payload as _, ReadCanisterSnapshotDataResponse,
-    ReadCanisterSnapshotMetadataResponse, SnapshotSource, StoredChunksReply,
-    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs,
+    CanisterMetricsResult, CanisterSnapshotDataKind, CanisterSnapshotDataOffset,
+    CanisterSnapshotResponse, CanisterStatusResultV2, CanisterStatusType, ChunkHash,
+    CyclesConsumed, EmptyBlob, Global, GlobalTimer, Method as Ic00Method, Payload as _,
+    ReadCanisterSnapshotDataResponse, ReadCanisterSnapshotMetadataResponse, SnapshotSource,
+    StoredChunksReply, UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs,
     UploadCanisterSnapshotMetadataResponse, UploadChunkReply,
 };
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -64,7 +64,7 @@ use ic_types::{
 };
 use ic_types_cycles::{
     CanisterCreation, CanisterCyclesCostSchedule, CompoundCycles, Cycles, CyclesUseCase,
-    Instructions,
+    Instructions, NominalCycles,
 };
 use ic_wasm_types::WasmHash;
 use more_asserts::{debug_assert_ge, debug_assert_le};
@@ -188,7 +188,8 @@ impl CanisterManager {
             | Ok(Ic00Method::StartCanister)
             | Ok(Ic00Method::UninstallCode)
             | Ok(Ic00Method::StopCanister)
-            | Ok(Ic00Method::DeleteCanister) => {
+            | Ok(Ic00Method::DeleteCanister)
+            | Ok(Ic00Method::CanisterMetrics) => {
                 match effective_canister_id {
                     Some(canister_id) => {
                         let canister = state.canister_state(&canister_id).ok_or_else(|| UserError::new(
@@ -1316,6 +1317,61 @@ impl CanisterManager {
                 section_name: section_name.to_string(),
             })
         }
+    }
+
+    pub(crate) fn get_canister_metrics(
+        &self,
+        sender: PrincipalId,
+        canister: &CanisterState,
+        subnet_admins: Option<BTreeSet<PrincipalId>>,
+    ) -> Result<CanisterMetricsResult, CanisterManagerError> {
+        validate_controller_or_subnet_admin(canister, subnet_admins, &sender)?;
+
+        let consumed_cycles_by_use_case = canister
+            .system_state
+            .canister_metrics()
+            .consumed_cycles_by_use_cases_as_counters();
+        let memory = *consumed_cycles_by_use_case
+            .get(&CyclesUseCase::Memory)
+            .unwrap_or(&NominalCycles::zero());
+        let compute_allocation = *consumed_cycles_by_use_case
+            .get(&CyclesUseCase::ComputeAllocation)
+            .unwrap_or(&NominalCycles::zero());
+        let ingress_induction = *consumed_cycles_by_use_case
+            .get(&CyclesUseCase::IngressInduction)
+            .unwrap_or(&NominalCycles::zero());
+        let instructions = *consumed_cycles_by_use_case
+            .get(&CyclesUseCase::Instructions)
+            .unwrap_or(&NominalCycles::zero());
+        let request_and_response_transmission = *consumed_cycles_by_use_case
+            .get(&CyclesUseCase::RequestAndResponseTransmission)
+            .unwrap_or(&NominalCycles::zero());
+        let uninstall = *consumed_cycles_by_use_case
+            .get(&CyclesUseCase::Uninstall)
+            .unwrap_or(&NominalCycles::zero());
+        let canister_creation = *consumed_cycles_by_use_case
+            .get(&CyclesUseCase::CanisterCreation)
+            .unwrap_or(&NominalCycles::zero());
+        let http_outcalls = *consumed_cycles_by_use_case
+            .get(&CyclesUseCase::HTTPOutcalls)
+            .unwrap_or(&NominalCycles::zero());
+        let burned_cycles = *consumed_cycles_by_use_case
+            .get(&CyclesUseCase::BurnedCycles)
+            .unwrap_or(&NominalCycles::zero());
+        let cycles_consumed = CyclesConsumed::new(
+            memory,
+            compute_allocation,
+            ingress_induction,
+            instructions,
+            request_and_response_transmission,
+            uninstall,
+            canister_creation,
+            http_outcalls,
+            burned_cycles,
+        );
+
+        let result = CanisterMetricsResult::new(cycles_consumed);
+        Ok(result)
     }
 
     /// Permanently deletes a canister from `ReplicatedState`.

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -40,9 +40,9 @@ use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
 use ic_logger::replica_logger::no_op_logger;
 use ic_management_canister_types_private::{
     CanisterChange, CanisterChangeDetails, CanisterChangeOrigin, CanisterIdRecord,
-    CanisterInstallMode, CanisterInstallModeV2, CanisterSettingsArgsBuilder,
+    CanisterInstallMode, CanisterInstallModeV2, CanisterMetricsResult, CanisterSettingsArgsBuilder,
     CanisterStatusResultV2, CanisterStatusType, CanisterUpgradeOptions, ChunkHash,
-    ClearChunkStoreArgs, CreateCanisterArgs, EmptyBlob, EnvironmentVariable, IC_00,
+    ClearChunkStoreArgs, CreateCanisterArgs, CyclesConsumed, EmptyBlob, EnvironmentVariable, IC_00,
     InstallCodeArgsV2, Method, NodeMetricsHistoryArgs, NodeMetricsHistoryResponse,
     OnLowWasmMemoryHookStatus, Payload, ProvisionalCreateCanisterWithCyclesArgs,
     RenameCanisterArgs, RenameToArgs, StoredChunksArgs, StoredChunksReply, SubnetInfoArgs,
@@ -92,7 +92,9 @@ use ic_types::{
     time::UNIX_EPOCH,
 };
 use ic_types_cycles::{
-    CanisterCyclesCostSchedule, Cycles, CyclesUseCase, NominalCycles, NominalCyclesTesting,
+    BurnedCycles, CanisterCreation, CanisterCyclesCostSchedule, CompoundCycles, Cycles,
+    CyclesUseCase, HTTPOutcalls, IngressInduction, Instructions, Memory, NominalCycles,
+    NominalCyclesTesting, RequestAndResponseTransmission, Uninstall,
 };
 use ic_universal_canister::{CallArgs, PayloadBuilder};
 use ic_wasm_types::CanisterModule;
@@ -8170,6 +8172,9 @@ fn assert_subnet_admin_actions_can_be_performed(mut test: ExecutionTest, caniste
     let status = test.canister_status(canister_id).unwrap();
     assert_eq!(status.status(), CanisterStatusType::Running);
 
+    // ...canister metrics can be retrieved...
+    test.canister_metrics(canister_id).unwrap();
+
     // ...code can be uninstalled...
     test.uninstall_code(canister_id).unwrap();
     assert_eq!(test.canister_state(canister_id).execution_state, None);
@@ -8279,6 +8284,15 @@ fn non_controller_and_non_subnet_admin_cannot_perform_subnet_admin_actions_on_ca
     assert!(err.description().contains(&format!(
         "Only the controllers of the canister {canister_id} or subnet admins can perform certain actions"
     )));
+    // ...or canister metrics cannot be retrieved...
+    let err = test.canister_metrics(canister_id).unwrap_err();
+    assert_eq!(
+        err.code(),
+        ErrorCode::CanisterInvalidControllerOrSubnetAdmin
+    );
+    assert!(err.description().contains(&format!(
+        "Only the controllers of the canister {canister_id} or subnet admins can perform certain actions"
+    )));
 
     // ...or code be uninstalled...
     let err = test.uninstall_code(canister_id).unwrap_err();
@@ -8352,4 +8366,129 @@ fn subnet_admin_cannot_install_code() {
         .upgrade_canister(canister_id, UNIVERSAL_CANISTER_WASM.to_vec())
         .unwrap_err();
     assert_eq!(err.code(), ErrorCode::CanisterInvalidController);
+}
+
+fn assert_canister_metrics_can_be_retrieved(
+    test: &mut ExecutionTest,
+    canister_id: CanisterId,
+    cost_schedule: CanisterCyclesCostSchedule,
+) {
+    // Set dummy values for consumed cycles in the canister state.
+    let memory_cycles = CompoundCycles::<Memory>::new(Cycles::new(1), cost_schedule);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .consume_cycles(memory_cycles);
+
+    // `Instructions` follow the prepay/refund flow where metrics are updated
+    // only during the refund step.
+    let instructions_cycles = CompoundCycles::<Instructions>::new(Cycles::new(2), cost_schedule);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .consume_cycles(instructions_cycles);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .refund_cycles(
+            instructions_cycles,
+            CompoundCycles::<Instructions>::new(Cycles::new(0), cost_schedule),
+        );
+
+    let ingress_induction_cycles =
+        CompoundCycles::<IngressInduction>::new(Cycles::new(3), cost_schedule);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .consume_cycles(ingress_induction_cycles);
+
+    let compute_allocation_cycles =
+        CompoundCycles::<ic_types_cycles::ComputeAllocation>::new(Cycles::new(4), cost_schedule);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .consume_cycles(compute_allocation_cycles);
+
+    let canister_creation_cycles =
+        CompoundCycles::<CanisterCreation>::new(Cycles::new(5), cost_schedule);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .consume_cycles(canister_creation_cycles);
+
+    let uninstall_cycles = CompoundCycles::<Uninstall>::new(Cycles::new(6), cost_schedule);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .consume_cycles(uninstall_cycles);
+
+    // `RequestAndResponseTransmission` follow the prepay/refund flow where
+    // metrics are updated only during the refund step.
+    let request_and_response_transmission_cycles =
+        CompoundCycles::<RequestAndResponseTransmission>::new(Cycles::new(8), cost_schedule);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .consume_cycles(request_and_response_transmission_cycles);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .refund_cycles(
+            request_and_response_transmission_cycles,
+            CompoundCycles::<RequestAndResponseTransmission>::new(Cycles::new(0), cost_schedule),
+        );
+
+    let http_outcalls_cycles = CompoundCycles::<HTTPOutcalls>::new(Cycles::new(9), cost_schedule);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .observe_consumed_cycles_for_https_outcall(http_outcalls_cycles.nominal());
+
+    let burned_cycles = CompoundCycles::<BurnedCycles>::new(Cycles::new(10), cost_schedule);
+    test.canister_state_mut(canister_id)
+        .system_state
+        .consume_cycles(burned_cycles);
+
+    let expected_cycles_consumed = CyclesConsumed::new(
+        memory_cycles.nominal(),
+        compute_allocation_cycles.nominal(),
+        ingress_induction_cycles.nominal(),
+        // Instructions will include both the "fake" value set as well as the cost
+        // of executing `canister_metrics` for the canister.
+        instructions_cycles.nominal() + test.canister_execution_cost(canister_id).nominal(),
+        request_and_response_transmission_cycles.nominal(),
+        uninstall_cycles.nominal(),
+        canister_creation_cycles.nominal(),
+        http_outcalls_cycles.nominal(),
+        burned_cycles.nominal(),
+    );
+    let expected_metrics = CanisterMetricsResult::new(expected_cycles_consumed);
+
+    // The canister_metrics endpoint should return the correct values for consumed cycles.
+    let result = test.canister_metrics(canister_id).unwrap();
+    assert_eq!(result, expected_metrics);
+}
+
+#[test]
+fn can_retrieve_canister_metrics_for_canister_free_schedule() {
+    let cost_schedule = CanisterCyclesCostSchedule::Free;
+    let subnet_admin = user_test_id(42);
+    let mut test = ExecutionTestBuilder::new()
+        .with_cost_schedule(cost_schedule)
+        .with_subnet_admins(vec![subnet_admin.get()])
+        .build();
+    let canister_id = test.universal_canister().unwrap();
+
+    // Switch user id so the request comes from the subnet admin
+    // who should not be a controller.
+    test.set_user_id(subnet_admin);
+    assert!(
+        !test
+            .canister_state(canister_id)
+            .controllers()
+            .contains(subnet_admin.get_ref())
+    );
+
+    assert_canister_metrics_can_be_retrieved(&mut test, canister_id, cost_schedule);
+}
+
+#[test]
+fn can_retrieve_canister_metrics_for_canister_normal_schedule() {
+    let cost_schedule = CanisterCyclesCostSchedule::Normal;
+    let mut test = ExecutionTestBuilder::new()
+        .with_cost_schedule(cost_schedule)
+        .build();
+    let canister_id = test.universal_canister().unwrap();
+
+    assert_canister_metrics_can_be_retrieved(&mut test, canister_id, cost_schedule);
 }

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -30,12 +30,12 @@ use ic_limits::MAX_PAIRED_PRE_SIGNATURES;
 use ic_logger::{ReplicaLogger, error, info, warn};
 use ic_management_canister_types_private::{
     CanisterChangeOrigin, CanisterHttpRequestArgs, CanisterIdRecord, CanisterInfoRequest,
-    CanisterInfoResponse, CanisterMetadataRequest, CanisterStatusType, ClearChunkStoreArgs,
-    CreateCanisterArgs, DeleteCanisterSnapshotArgs, ECDSAPublicKeyArgs, ECDSAPublicKeyResponse,
-    EmptyBlob, FetchCanisterLogsRequest, FlexibleCanisterHttpRequestArgs, IC_00,
-    InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs,
-    MasterPublicKeyId, Method as Ic00Method, NodeMetricsHistoryArgs, Payload as Ic00Payload,
-    ProvisionalCreateCanisterWithCyclesArgs, ProvisionalTopUpCanisterArgs,
+    CanisterInfoResponse, CanisterMetadataRequest, CanisterMetricsArgs, CanisterStatusType,
+    ClearChunkStoreArgs, CreateCanisterArgs, DeleteCanisterSnapshotArgs, ECDSAPublicKeyArgs,
+    ECDSAPublicKeyResponse, EmptyBlob, FetchCanisterLogsRequest, FlexibleCanisterHttpRequestArgs,
+    IC_00, InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs,
+    LoadCanisterSnapshotArgs, MasterPublicKeyId, Method as Ic00Method, NodeMetricsHistoryArgs,
+    Payload as Ic00Payload, ProvisionalCreateCanisterWithCyclesArgs, ProvisionalTopUpCanisterArgs,
     ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs,
     ReshareChainKeyArgs, SchnorrAlgorithm, SchnorrPublicKeyArgs, SchnorrPublicKeyResponse,
     SetupInitialDKGArgs, SignWithECDSAArgs, SignWithSchnorrArgs, SignWithSchnorrAux,
@@ -2033,6 +2033,18 @@ impl ExecutionEnvironment {
                 }
             }
 
+            Ok(Ic00Method::CanisterMetrics) => {
+                let res = CanisterMetricsArgs::decode(payload).and_then(|args| {
+                    let canister_id = args.get_canister_id();
+                    self.get_canister_metrics(*msg.sender(), canister_id, &state)
+                        .map(|res| (res, Some(canister_id)))
+                });
+                ExecuteSubnetMessageResult::Finished {
+                    response: res,
+                    refund: msg.take_cycles(),
+                }
+            }
+
             Err(ParseError::VariantNotFound) => {
                 let res = Err(UserError::new(
                     ErrorCode::CanisterMethodNotFound,
@@ -2642,6 +2654,20 @@ impl ExecutionEnvironment {
                 subnet_admins,
             )
             .map(|status| status.encode())
+            .map_err(|err| err.into())
+    }
+
+    fn get_canister_metrics(
+        &self,
+        sender: PrincipalId,
+        canister_id: CanisterId,
+        state: &ReplicatedState,
+    ) -> Result<Vec<u8>, UserError> {
+        let canister = get_canister(canister_id, state)?;
+        let subnet_admins = state.get_own_subnet_admins();
+        self.canister_manager
+            .get_canister_metrics(sender, canister, subnet_admins)
+            .map(|canister_metrics_result| canister_metrics_result.encode())
             .map_err(|err| err.into())
     }
 

--- a/rs/execution_environment/src/execution_environment_metrics.rs
+++ b/rs/execution_environment/src/execution_environment_metrics.rs
@@ -327,7 +327,8 @@ impl ExecutionEnvironmentMetrics {
                     | ic00::Method::ReadCanisterSnapshotData
                     | ic00::Method::UploadCanisterSnapshotMetadata
                     | ic00::Method::UploadCanisterSnapshotData
-                    | ic00::Method::RenameCanister => String::from("fast"),
+                    | ic00::Method::RenameCanister
+                    | ic00::Method::CanisterMetrics => String::from("fast"),
 
                     // "Slow" management methods that might require several execution
                     // rounds to be completed, either due to using DTS or due to

--- a/rs/execution_environment/src/ic00_permissions.rs
+++ b/rs/execution_environment/src/ic00_permissions.rs
@@ -49,7 +49,8 @@ impl Ic00MethodPermissions {
             | Ic00Method::ProvisionalCreateCanisterWithCycles
             | Ic00Method::ProvisionalTopUpCanister
             | Ic00Method::StoredChunks
-            | Ic00Method::ListCanisterSnapshots => Self {
+            | Ic00Method::ListCanisterSnapshots
+            | Ic00Method::CanisterMetrics => Self {
                 method,
                 allow_remote_subnet_sender: true,
                 allow_only_nns_subnet_sender: false,

--- a/rs/execution_environment/src/query_handler.rs
+++ b/rs/execution_environment/src/query_handler.rs
@@ -57,8 +57,8 @@ use tower::{Service, util::BoxCloneService};
 pub(crate) use self::query_scheduler::QueryScheduler;
 use crate::execution::common::validate_subnet_admin;
 use ic_management_canister_types_private::{
-    CanisterIdRange, CanisterIdRecord, EmptyBlob, FetchCanisterLogsRequest, ListCanistersResponse,
-    Payload, QueryMethod,
+    CanisterIdRange, CanisterIdRecord, CanisterMetricsArgs, EmptyBlob, FetchCanisterLogsRequest,
+    ListCanistersResponse, Payload, QueryMethod,
 };
 use ic_registry_routing_table::canister_id_into_u64;
 
@@ -286,6 +286,33 @@ impl InternalHttpQueryHandler {
                         self.list_canisters(state.get_ref(), &caller, &query.method_payload);
                     self.metrics.observe_subnet_query_message(
                         QueryMethod::ListCanisters,
+                        since.elapsed().as_secs_f64(),
+                        &result,
+                    );
+                    return result;
+                }
+                Ok(QueryMethod::CanisterMetrics) => {
+                    let args = CanisterMetricsArgs::decode(&query.method_payload)?;
+                    let canister_id = args.get_canister_id();
+                    let canister =
+                        state
+                            .get_ref()
+                            .canister_state(&canister_id)
+                            .ok_or_else(|| {
+                                UserError::new(
+                                    ErrorCode::CanisterNotFound,
+                                    format!("Canister {canister_id} not found"),
+                                )
+                            })?;
+                    let since = Instant::now(); // Start logging execution time.
+                    let response = self.canister_manager.get_canister_metrics(
+                        query.source(),
+                        canister,
+                        state.get_ref().get_own_subnet_admins(),
+                    )?;
+                    let result = Ok(WasmResult::Reply(Encode!(&response).unwrap()));
+                    self.metrics.observe_subnet_query_message(
+                        QueryMethod::CanisterMetrics,
                         since.elapsed().as_secs_f64(),
                         &result,
                     );

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1972,7 +1972,8 @@ fn get_instruction_limits_for_subnet_message(
             | ReadCanisterSnapshotData
             | UploadCanisterSnapshotMetadata
             | UploadCanisterSnapshotData
-            | RenameCanister => default_limits,
+            | RenameCanister
+            | CanisterMetrics => default_limits,
             // `LoadCanisterSnapshot` compiles a Wasm module and charges for it
             // similar to `InstallCode`. It does not support DTS, so the slice
             // limit equals the message limit.

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -11,10 +11,10 @@ use ic_embedders::wasmtime_embedder::system_api::MAX_CALL_TIMEOUT_SECONDS;
 use ic_execution_environment::units::{GIB, MIB};
 use ic_management_canister_types_private::{
     CanisterIdRecord, CanisterInstallModeV2, CanisterMetadataRequest, CanisterMetadataResponse,
-    CanisterSettingsArgs, CanisterSettingsArgsBuilder, CanisterStatusResultV2, CreateCanisterArgs,
-    DerivationPath, EcdsaKeyId, EmptyBlob, IC_00, InstallCodeArgsV2, LoadCanisterSnapshotArgs,
-    MasterPublicKeyId, Method, Payload, SignWithECDSAArgs, TakeCanisterSnapshotArgs,
-    UpdateSettingsArgs,
+    CanisterMetricsArgs, CanisterSettingsArgs, CanisterSettingsArgsBuilder, CanisterStatusResultV2,
+    CreateCanisterArgs, DerivationPath, EcdsaKeyId, EmptyBlob, IC_00, InstallCodeArgsV2,
+    LoadCanisterSnapshotArgs, MasterPublicKeyId, Method, Payload, SignWithECDSAArgs,
+    TakeCanisterSnapshotArgs, UpdateSettingsArgs,
 };
 use ic_registry_resource_limits::ResourceLimits;
 use ic_registry_subnet_type::SubnetType;
@@ -3120,4 +3120,121 @@ fn no_subnet_message_reordering() {
     let _ = get_reply(res);
     let res = sm.await_ingress(status_msg_id, 100);
     let _ = get_reply(res);
+}
+
+fn canister_metrics_count(env: &StateMachine) -> u64 {
+    fetch_histogram_vec_stats(
+        env.metrics_registry(),
+        "execution_subnet_query_message_duration_seconds",
+    )
+    .get(&labels(&[
+        ("method_name", "query_ic00_canister_metrics"),
+        ("status", "success"),
+    ]))
+    .map_or(0, |stats| stats.count)
+}
+
+#[test]
+fn canister_metrics_via_query_call_by_controller_succeeds() {
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            subnet_config,
+            HypervisorConfig::default(),
+        )))
+        .build();
+    let canister_id = create_universal_canister_with_cycles(
+        &env,
+        Some(CanisterSettingsArgsBuilder::new().build()),
+        INITIAL_CYCLES_BALANCE,
+    );
+
+    assert_eq!(canister_metrics_count(&env), 0);
+
+    let result = env.query(
+        CanisterId::ic_00(),
+        "canister_metrics",
+        CanisterMetricsArgs::new(canister_id).encode(),
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(canister_metrics_count(&env), 1);
+}
+
+#[test]
+fn canister_metrics_via_query_call_by_subnet_admin_succeeds() {
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
+    let subnet_admin = user_test_id(100);
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            subnet_config,
+            HypervisorConfig::default(),
+        )))
+        .with_subnet_type(SubnetType::Application)
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![subnet_admin.get()])
+        .build();
+    let canister_id = create_universal_canister_with_cycles(
+        &env,
+        Some(CanisterSettingsArgsBuilder::new().build()),
+        INITIAL_CYCLES_BALANCE,
+    );
+    // Get the first canister controller.
+    let controller = env.get_controllers(canister_id).unwrap()[0];
+
+    assert_eq!(canister_metrics_count(&env), 0);
+    assert_ne!(subnet_admin.get(), controller);
+
+    let result = env.query_as(
+        subnet_admin.get(),
+        CanisterId::ic_00(),
+        "canister_metrics",
+        CanisterMetricsArgs::new(canister_id).encode(),
+    );
+    assert!(result.is_ok());
+    assert_eq!(canister_metrics_count(&env), 1);
+}
+
+#[test]
+fn canister_metrics_via_query_call_by_neither_controller_nor_subnet_admin_fails() {
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
+    let subnet_admin = user_test_id(100);
+    let test_user = user_test_id(101);
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            subnet_config,
+            HypervisorConfig::default(),
+        )))
+        .with_subnet_type(SubnetType::Application)
+        .with_cost_schedule(CanisterCyclesCostSchedule::Free)
+        .with_subnet_admins(vec![subnet_admin.get()])
+        .build();
+    let canister_id = create_universal_canister_with_cycles(
+        &env,
+        Some(CanisterSettingsArgsBuilder::new().build()),
+        INITIAL_CYCLES_BALANCE,
+    );
+    // Get the first canister controller.
+    let controller = env.get_controllers(canister_id).unwrap()[0];
+
+    assert_eq!(canister_metrics_count(&env), 0);
+    assert_ne!(subnet_admin.get(), controller);
+    assert_ne!(test_user.get(), controller);
+
+    let err = env
+        .query_as(
+            test_user.get(),
+            CanisterId::ic_00(),
+            "canister_metrics",
+            CanisterMetricsArgs::new(canister_id).encode(),
+        )
+        .unwrap_err();
+    assert_eq!(
+        err.code(),
+        ErrorCode::CanisterInvalidControllerOrSubnetAdmin
+    );
+    assert!(err.description().contains(&format!(
+        "Only the controllers of the canister {canister_id} or subnet admins can perform certain actions"
+    )));
+    assert_eq!(canister_metrics_count(&env), 0);
 }

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -34,11 +34,12 @@ use ic_logger::{
     replica_logger::{no_op_logger, test_logger},
 };
 use ic_management_canister_types_private::{
-    CanisterIdRecord, CanisterInstallMode, CanisterInstallModeV2, CanisterSettingsArgs,
-    CanisterSettingsArgsBuilder, CanisterStatusResultV2, CanisterStatusType,
-    CanisterUpgradeOptions, EmptyBlob, InstallChunkedCodeArgs, InstallCodeArgs, InstallCodeArgsV2,
-    LoadCanisterSnapshotArgs, LogVisibilityV2, MasterPublicKeyId, Method, Payload,
-    ProvisionalCreateCanisterWithCyclesArgs, SchnorrAlgorithm, UpdateSettingsArgs,
+    CanisterIdRecord, CanisterInstallMode, CanisterInstallModeV2, CanisterMetricsArgs,
+    CanisterMetricsResult, CanisterSettingsArgs, CanisterSettingsArgsBuilder,
+    CanisterStatusResultV2, CanisterStatusType, CanisterUpgradeOptions, EmptyBlob,
+    InstallChunkedCodeArgs, InstallCodeArgs, InstallCodeArgsV2, LoadCanisterSnapshotArgs,
+    LogVisibilityV2, MasterPublicKeyId, Method, Payload, ProvisionalCreateCanisterWithCyclesArgs,
+    SchnorrAlgorithm, UpdateSettingsArgs,
 };
 use ic_metrics::MetricsRegistry;
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -891,6 +892,20 @@ impl ExecutionTest {
         let result = self.subnet_message(Method::CanisterStatus, payload);
         match result {
             Ok(WasmResult::Reply(bytes)) => Ok(CanisterStatusResultV2::decode(&bytes).unwrap()),
+            Ok(WasmResult::Reject(err)) => panic!("Unexpected reject: {}", err),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Returns the canister metrics by canister id.
+    pub fn canister_metrics(
+        &mut self,
+        canister_id: CanisterId,
+    ) -> Result<CanisterMetricsResult, UserError> {
+        let payload = CanisterMetricsArgs::new(canister_id).encode();
+        let result = self.subnet_message(Method::CanisterMetrics, payload);
+        match result {
+            Ok(WasmResult::Reply(bytes)) => Ok(CanisterMetricsResult::decode(&bytes).unwrap()),
             Ok(WasmResult::Reject(err)) => panic!("Unexpected reject: {}", err),
             Err(err) => Err(err),
         }

--- a/rs/types/management_canister_types/BUILD.bazel
+++ b/rs/types/management_canister_types/BUILD.bazel
@@ -80,6 +80,7 @@ rust_library(
         "//rs/bitcoin/replica_types",
         "//rs/protobuf",
         "//rs/types/base_types",
+        "//rs/types/cycles",
         "//rs/utils",
         "@crate_index//:candid",
         "@crate_index//:ic-btc-interface",

--- a/rs/types/management_canister_types/Cargo.toml
+++ b/rs/types/management_canister_types/Cargo.toml
@@ -14,6 +14,7 @@ ic-btc-interface = { workspace = true }
 ic-btc-replica-types = { path = "../../bitcoin/replica_types" }
 ic-error-types = { path = "../../../packages/ic-error-types" }
 ic-protobuf = { path = "../../protobuf" }
+ic-types-cycles = { path = "../cycles" }
 ic-utils = { path = "../../utils" }
 num-traits = { workspace = true }
 serde = { workspace = true }

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -34,6 +34,7 @@ use ic_protobuf::types::v1::{
     CanisterUpgradeOptions as CanisterUpgradeOptionsProto,
     WasmMemoryPersistence as WasmMemoryPersistenceProto,
 };
+use ic_types_cycles::NominalCycles;
 use std::hash::{Hash, Hasher};
 
 use num_traits::cast::ToPrimitive;
@@ -143,6 +144,9 @@ pub enum Method {
 
     // Support for canister migration
     RenameCanister,
+
+    // Canister metrics
+    CanisterMetrics,
 }
 
 fn candid_error_to_user_error(err: candid::Error) -> UserError {
@@ -3605,6 +3609,7 @@ pub enum QueryMethod {
     FetchCanisterLogs,
     CanisterStatus,
     ListCanisters,
+    CanisterMetrics,
 }
 
 /// `CandidType` for `SubnetInfoArgs`
@@ -4949,6 +4954,95 @@ impl RenameToArgs {
         CanisterId::unchecked_from_principal(self.canister_id)
     }
 }
+
+/// Struct to encode/decode
+/// ```text
+/// record {
+///  memory : nat;
+///  compute_allocation : nat;
+///  ingress_induction : nat;
+///  instructions : nat;
+///  request_and_response_transmission : nat;
+///  uninstall : nat;
+///  canister_creation : nat;
+///  http_outcalls : nat;
+///  burned_cycles : nat;
+/// }
+/// ```
+#[derive(Clone, Debug, Deserialize, CandidType, Serialize, PartialEq)]
+pub struct CyclesConsumed {
+    memory: candid::Nat,
+    compute_allocation: candid::Nat,
+    ingress_induction: candid::Nat,
+    instructions: candid::Nat,
+    request_and_response_transmission: candid::Nat,
+    uninstall: candid::Nat,
+    canister_creation: candid::Nat,
+    http_outcalls: candid::Nat,
+    burned_cycles: candid::Nat,
+}
+
+impl CyclesConsumed {
+    pub fn new(
+        memory: NominalCycles,
+        compute_allocation: NominalCycles,
+        ingress_induction: NominalCycles,
+        instructions: NominalCycles,
+        request_and_response_transmission: NominalCycles,
+        uninstall: NominalCycles,
+        canister_creation: NominalCycles,
+        http_outcalls: NominalCycles,
+        burned_cycles: NominalCycles,
+    ) -> Self {
+        Self {
+            memory: candid::Nat::from(memory.get()),
+            compute_allocation: candid::Nat::from(compute_allocation.get()),
+            ingress_induction: candid::Nat::from(ingress_induction.get()),
+            instructions: candid::Nat::from(instructions.get()),
+            request_and_response_transmission: candid::Nat::from(
+                request_and_response_transmission.get(),
+            ),
+            uninstall: candid::Nat::from(uninstall.get()),
+            canister_creation: candid::Nat::from(canister_creation.get()),
+            http_outcalls: candid::Nat::from(http_outcalls.get()),
+            burned_cycles: candid::Nat::from(burned_cycles.get()),
+        }
+    }
+}
+
+impl Payload<'_> for CyclesConsumed {}
+
+#[derive(Clone, Debug, Deserialize, CandidType, Serialize, PartialEq)]
+pub struct CanisterMetricsArgs {
+    canister_id: PrincipalId,
+}
+
+impl CanisterMetricsArgs {
+    pub fn new(canister_id: CanisterId) -> Self {
+        Self {
+            canister_id: canister_id.get(),
+        }
+    }
+
+    pub fn get_canister_id(&self) -> CanisterId {
+        CanisterId::unchecked_from_principal(self.canister_id)
+    }
+}
+
+impl Payload<'_> for CanisterMetricsArgs {}
+
+#[derive(Clone, Debug, Deserialize, CandidType, Serialize, PartialEq)]
+pub struct CanisterMetricsResult {
+    cycles_consumed: CyclesConsumed,
+}
+
+impl CanisterMetricsResult {
+    pub fn new(cycles_consumed: CyclesConsumed) -> Self {
+        Self { cycles_consumed }
+    }
+}
+
+impl Payload<'_> for CanisterMetricsResult {}
 
 #[cfg(test)]
 mod tests {

--- a/rs/types/types/src/messages/ingress_messages.rs
+++ b/rs/types/types/src/messages/ingress_messages.rs
@@ -16,9 +16,9 @@ use crate::{
 use ic_error_types::{ErrorCode, UserError};
 use ic_heap_bytes::DeterministicHeapBytes;
 use ic_management_canister_types_private::{
-    CanisterIdRecord, CanisterInfoRequest, CanisterMetadataRequest, ClearChunkStoreArgs,
-    DeleteCanisterSnapshotArgs, IC_00, InstallChunkedCodeArgs, InstallCodeArgsV2,
-    ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs, Method, Payload,
+    CanisterIdRecord, CanisterInfoRequest, CanisterMetadataRequest, CanisterMetricsArgs,
+    ClearChunkStoreArgs, DeleteCanisterSnapshotArgs, IC_00, InstallChunkedCodeArgs,
+    InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs, Method, Payload,
     ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs,
     StoredChunksArgs, TakeCanisterSnapshotArgs, UpdateSettingsArgs, UploadCanisterSnapshotDataArgs,
     UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
@@ -670,6 +670,10 @@ pub fn extract_effective_canister_id(
             }
         }
         Ok(Method::RenameCanister) => match RenameCanisterArgs::decode(ingress.arg()) {
+            Ok(record) => Ok(Some(record.get_canister_id())),
+            Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
+        },
+        Ok(Method::CanisterMetrics) => match CanisterMetricsArgs::decode(ingress.arg()) {
             Ok(record) => Ok(Some(record.get_canister_id())),
             Err(err) => Err(ParseIngressError::InvalidSubnetPayload(err.to_string())),
         },

--- a/rs/types/types/src/messages/inter_canister.rs
+++ b/rs/types/types/src/messages/inter_canister.rs
@@ -7,12 +7,13 @@ use ic_error_types::{RejectCode, UserError};
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;
 use ic_management_canister_types_private::{
-    CanisterIdRecord, CanisterInfoRequest, CanisterMetadataRequest, ClearChunkStoreArgs,
-    DeleteCanisterSnapshotArgs, FetchCanisterLogsRequest, InstallChunkedCodeArgs,
-    InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs, Method, Payload as _,
-    ProvisionalTopUpCanisterArgs, ReadCanisterSnapshotDataArgs, ReadCanisterSnapshotMetadataArgs,
-    RenameCanisterArgs, StoredChunksArgs, TakeCanisterSnapshotArgs, UpdateSettingsArgs,
-    UploadCanisterSnapshotDataArgs, UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
+    CanisterIdRecord, CanisterInfoRequest, CanisterMetadataRequest, CanisterMetricsArgs,
+    ClearChunkStoreArgs, DeleteCanisterSnapshotArgs, FetchCanisterLogsRequest,
+    InstallChunkedCodeArgs, InstallCodeArgsV2, ListCanisterSnapshotArgs, LoadCanisterSnapshotArgs,
+    Method, Payload as _, ProvisionalTopUpCanisterArgs, ReadCanisterSnapshotDataArgs,
+    ReadCanisterSnapshotMetadataArgs, RenameCanisterArgs, StoredChunksArgs,
+    TakeCanisterSnapshotArgs, UpdateSettingsArgs, UploadCanisterSnapshotDataArgs,
+    UploadCanisterSnapshotMetadataArgs, UploadChunkArgs,
 };
 use ic_protobuf::{
     proxy::{ProxyDecodeError, try_from_option_field},
@@ -256,6 +257,12 @@ impl Request {
                 Ok(record) => Some(record.get_canister_id()),
                 Err(_) => None,
             },
+            Ok(Method::CanisterMetrics) => {
+                match CanisterMetricsArgs::decode(&self.method_payload) {
+                    Ok(record) => Some(record.get_canister_id()),
+                    Err(_) => None,
+                }
+            }
             Ok(Method::CreateCanister)
             | Ok(Method::SetupInitialDKG)
             | Ok(Method::HttpRequest)


### PR DESCRIPTION
Implement the `canister_metrics` endpoint as described in https://github.com/dfinity/portal/pull/6217 to allow controllers or subnet admins to retrieve canister level metrics for a target canister. The metrics currently contain some basic cycles related ones but can be extended in the future to contain more.

The necessary boilerplate is added to wire the new endpoint through the code stack. As defined in the interface spec, the API is available both in replicated mode as well as a query call.

A few tests are also added to ensure that the endpoint correctly returns the values that are present in the replicated state.