### PR TITLE
refactor: [DSM-103] Debug-only `SubnetSchedule::fully_executed_canisters` field

### DIFF
--- a/rs/execution_environment/src/scheduler/round_schedule.rs
+++ b/rs/execution_environment/src/scheduler/round_schedule.rs
@@ -416,6 +416,12 @@ impl RoundSchedule {
                 .for_each(|canister| {
                     observe_scheduled_as_first(canister);
                 });
+
+            #[cfg(debug_assertions)]
+            {
+                // Clear the debug-only fully executed canisters set.
+                subnet_schedule.fully_executed_canisters = BTreeSet::new();
+            }
         }
 
         IterationSchedule {
@@ -501,6 +507,11 @@ impl RoundSchedule {
             let canister_priority = subnet_schedule.get_mut(*canister_id);
             canister_priority.executed_rounds += 1;
             canister_priority.last_full_execution_round = current_round;
+
+            #[cfg(debug_assertions)]
+            subnet_schedule
+                .fully_executed_canisters
+                .insert(*canister_id);
         }
 
         // Add all canisters to the subnet schedule; and charge any immediate or

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -198,11 +198,13 @@ impl SchedulerTest {
         &self.scheduler
     }
 
+    #[cfg(debug_assertions)]
     pub fn was_fully_executed(&self, canister_id: CanisterId) -> bool {
         self.state()
-            .canister_priority(&canister_id)
-            .last_full_execution_round
-            == self.last_round()
+            .metadata
+            .subnet_schedule
+            .fully_executed_canisters
+            .contains(&canister_id)
     }
 
     pub fn xnet_canister_id(&self) -> CanisterId {

--- a/rs/execution_environment/src/scheduler/tests/scheduling.rs
+++ b/rs/execution_environment/src/scheduler/tests/scheduling.rs
@@ -991,20 +991,20 @@ fn inner_round_long_execution_is_a_full_execution() {
 
     for canister in test.state().canisters_iter() {
         let system_state = &canister.system_state;
-        let priority = test.state().canister_priority(&canister.canister_id());
         // All canisters should be executed.
         assert_eq!(system_state.canister_metrics().executed(), 1);
         let execution_state = canister.execution_state.as_ref().unwrap();
         assert_eq!(execution_state.last_executed_round.get(), 1);
         if canister.canister_id() == target_id {
-            // The target canister was not executed first, and still have messages.
+            // The target canister was not executed first, and still has messages.
             assert_eq!(system_state.queues().ingress_queue_size(), 1);
         } else {
+            // All other canisters consumed all their inputs.
             assert_eq!(system_state.queues().ingress_queue_size(), 0);
         }
         // All canisters should be marked as fully executed. The target canister,
         // despite still having messages, executed a complete slice.
-        assert_eq!(priority.last_full_execution_round, test.last_round());
+        assert!(test.was_fully_executed(canister.canister_id()));
     }
     let mut total_accumulated_priority = 0;
     for (_, canister_priority) in test.state().metadata.subnet_schedule.iter() {

--- a/rs/replicated_state/src/metadata_state/subnet_schedule.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_schedule.rs
@@ -54,6 +54,9 @@ impl Default for CanisterPriority {
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
 pub struct SubnetSchedule {
     priorities: BTreeMap<CanisterId, CanisterPriority>,
+
+    #[cfg(debug_assertions)]
+    pub fully_executed_canisters: std::collections::BTreeSet<CanisterId>,
 }
 
 /// Two schedules are equal if they have the same canister priorities (modulo
@@ -79,7 +82,11 @@ impl ValidateEq for SubnetSchedule {
 
 impl SubnetSchedule {
     pub fn new(priorities: BTreeMap<CanisterId, CanisterPriority>) -> Self {
-        Self { priorities }
+        Self {
+            priorities,
+            #[cfg(debug_assertions)]
+            fully_executed_canisters: std::collections::BTreeSet::new(),
+        }
     }
 
     /// Returns the priority for the given canister, or the default priority if not


### PR DESCRIPTION
In debug mode, explicitly collect all fully executed canisters in a set within `SubnetSchedule`. This is because with active-canister-only scheduling, `CanisterPriority` entries for newly idle canisters may be dropped, making it impossible to test whether they had been fully executed or not.

Strictly speaking, this is no longer necessary -- we used to drop `CanisterPriority` entries in `RoundSchedule::finish_round()`, now we only drop them in the subsequent `RoundSchedule::start_iteration()`, i.e. in the next round -- but the implementation may change and it's nice to have a safety net.