### PR TITLE
chore: Drop Bazel Build All No Cache

### DIFF
--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -74,22 +74,6 @@ jobs:
               --keep_going --test_timeout=7200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-# the main purpose of bazel-build-all-no-cache is to detect dead URLS of external dependencies, the actual build of the ic is tested in build-ic
-# we've moved it to schedule-daily because the ubuntu servers frequently return 503 errors and we don't want this job blocking releases
-  bazel-build-all-no-cache:
-    name: Bazel Build All No Cache
-    runs-on: *dind-large-setup
-    container: *container-setup
-    timeout-minutes: 90
-    steps:
-      - *checkout
-      - uses: ./.github/actions/netrc
-      - name: Run Bazel Build All No Cache
-        uses: ./.github/actions/bazel
-        with:
-          run: bazel build --config=stamped --config=local //...
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
   bazel-test-bare-metal:
     name: Bazel Test Bare Metal
     runs-on: *dind-large-setup


### PR DESCRIPTION
The job has a very high SNR and has been consistently failing for a while.