### PR TITLE
chore: Upgrade wasm tools to V248

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "356880300c525a56b2fcc28197b4aabd52d43cd035ed5cb78b29f9919ae504af",
+  "checksum": "025f207dfe6ae34a9829620499248d9be2ac79e6f1dce42824e56b36ced2107c",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -22793,19 +22793,19 @@
               "target": "wasm_bindgen"
             },
             {
-              "id": "wasm-encoder 0.245.1",
+              "id": "wasm-encoder 0.248.0",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasm-smith 0.245.1",
+              "id": "wasm-smith 0.248.0",
               "target": "wasm_smith"
             },
             {
-              "id": "wasmparser 0.245.1",
+              "id": "wasmparser 0.248.0",
               "target": "wasmparser"
             },
             {
-              "id": "wasmprinter 0.245.1",
+              "id": "wasmprinter 0.248.0",
               "target": "wasmprinter"
             },
             {
@@ -22813,11 +22813,11 @@
               "target": "wasmtime"
             },
             {
-              "id": "wast 244.0.0",
+              "id": "wast 248.0.0",
               "target": "wast"
             },
             {
-              "id": "wat 1.245.1",
+              "id": "wat 1.248.0",
               "target": "wat"
             },
             {
@@ -31430,8 +31430,7 @@
             "default-hasher",
             "equivalent",
             "inline-more",
-            "raw-entry",
-            "serde"
+            "raw-entry"
           ],
           "selects": {}
         },
@@ -31448,10 +31447,6 @@
             {
               "id": "foldhash 0.2.0",
               "target": "foldhash"
-            },
-            {
-              "id": "serde_core 1.0.228",
-              "target": "serde_core"
             }
           ],
           "selects": {}
@@ -31497,7 +31492,8 @@
         ],
         "crate_features": {
           "common": [
-            "default-hasher"
+            "default-hasher",
+            "serde"
           ],
           "selects": {}
         },
@@ -31506,6 +31502,10 @@
             {
               "id": "foldhash 0.2.0",
               "target": "foldhash"
+            },
+            {
+              "id": "serde_core 1.0.228",
+              "target": "serde_core"
             }
           ],
           "selects": {}
@@ -89784,122 +89784,6 @@
       ],
       "license_file": null
     },
-    "wasm-encoder 0.244.0": {
-      "name": "wasm-encoder",
-      "version": "0.244.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.244.0/download",
-          "sha256": "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_encoder",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasm_encoder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "leb128fmt 0.1.0",
-              "target": "leb128fmt"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.244.0"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasm-encoder 0.245.1": {
-      "name": "wasm-encoder",
-      "version": "0.245.1",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasm-encoder/0.245.1/download",
-          "sha256": "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasm_encoder",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasm_encoder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "default",
-            "std",
-            "wasmparser"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "leb128fmt 0.1.0",
-              "target": "leb128fmt"
-            },
-            {
-              "id": "wasmparser 0.245.1",
-              "target": "wasmparser"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.245.1"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
     "wasm-encoder 0.246.2": {
       "name": "wasm-encoder",
       "version": "0.246.2",
@@ -89956,14 +89840,75 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-smith 0.245.1": {
+    "wasm-encoder 0.248.0": {
+      "name": "wasm-encoder",
+      "version": "0.248.0",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasm-encoder/0.248.0/download",
+          "sha256": "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasm_encoder",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasm_encoder",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default",
+            "std",
+            "wasmparser"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "leb128fmt 0.1.0",
+              "target": "leb128fmt"
+            },
+            {
+              "id": "wasmparser 0.248.0",
+              "target": "wasmparser"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2024",
+        "version": "0.248.0"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "wasm-smith 0.248.0": {
       "name": "wasm-smith",
-      "version": "0.245.1",
+      "version": "0.248.0",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-smith/0.245.1/download",
-          "sha256": "7bbc45c58d90c7748d8a3cf095214531cf7733e6ff02aeda83471cab105da388"
+          "url": "https://static.crates.io/crates/wasm-smith/0.248.0/download",
+          "sha256": "050b559c1cec6dd6b9a558ae984d91d61e5e7b4c3e47081305a13efe6869eea0"
         }
       },
       "targets": [
@@ -90006,25 +89951,25 @@
               "target": "flagset"
             },
             {
-              "id": "wasm-encoder 0.245.1",
+              "id": "wasm-encoder 0.248.0",
               "target": "wasm_encoder"
             },
             {
-              "id": "wasmparser 0.245.1",
+              "id": "wasmparser 0.248.0",
               "target": "wasmparser"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.245.1"
+        "edition": "2024",
+        "version": "0.248.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
-      "license_file": null
+      "license_file": "LICENSE-APACHE"
     },
     "wasm-streams 0.4.0": {
       "name": "wasm-streams",
@@ -90450,131 +90395,6 @@
       ],
       "license_file": null
     },
-    "wasmparser 0.244.0": {
-      "name": "wasmparser",
-      "version": "0.244.0",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.244.0/download",
-          "sha256": "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmparser",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmparser",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 2.10.0",
-              "target": "bitflags"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.244.0"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wasmparser 0.245.1": {
-      "name": "wasmparser",
-      "version": "0.245.1",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wasmparser/0.245.1/download",
-          "sha256": "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasmparser",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wasmparser",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "default",
-            "features",
-            "hash-collections",
-            "serde",
-            "simd",
-            "std",
-            "validate"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bitflags 2.10.0",
-              "target": "bitflags"
-            },
-            {
-              "id": "hashbrown 0.16.1",
-              "target": "hashbrown"
-            },
-            {
-              "id": "indexmap 2.14.0",
-              "target": "indexmap"
-            },
-            {
-              "id": "semver 1.0.27",
-              "target": "semver"
-            },
-            {
-              "id": "serde 1.0.228",
-              "target": "serde"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.245.1"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
     "wasmparser 0.246.2": {
       "name": "wasmparser",
       "version": "0.246.2",
@@ -90642,20 +90462,20 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasmprinter 0.245.1": {
-      "name": "wasmprinter",
-      "version": "0.245.1",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter",
+    "wasmparser 0.248.0": {
+      "name": "wasmparser",
+      "version": "0.248.0",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasmprinter/0.245.1/download",
-          "sha256": "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
+          "url": "https://static.crates.io/crates/wasmparser/0.248.0/download",
+          "sha256": "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "wasmprinter",
+            "crate_name": "wasmparser",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -90666,7 +90486,7 @@
           }
         }
       ],
-      "library_target_name": "wasmprinter",
+      "library_target_name": "wasmparser",
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -90675,6 +90495,11 @@
           "common": [
             "component-model",
             "default",
+            "features",
+            "hash-collections",
+            "serde",
+            "simd",
+            "std",
             "validate"
           ],
           "selects": {}
@@ -90682,29 +90507,37 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.100",
-              "target": "anyhow"
+              "id": "bitflags 2.10.0",
+              "target": "bitflags"
             },
             {
-              "id": "termcolor 1.4.1",
-              "target": "termcolor"
+              "id": "hashbrown 0.17.0",
+              "target": "hashbrown"
             },
             {
-              "id": "wasmparser 0.245.1",
-              "target": "wasmparser"
+              "id": "indexmap 2.14.0",
+              "target": "indexmap"
+            },
+            {
+              "id": "semver 1.0.27",
+              "target": "semver"
+            },
+            {
+              "id": "serde 1.0.228",
+              "target": "serde"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.245.1"
+        "edition": "2024",
+        "version": "0.248.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
-      "license_file": null
+      "license_file": "LICENSE-APACHE"
     },
     "wasmprinter 0.246.2": {
       "name": "wasmprinter",
@@ -90762,6 +90595,70 @@
         },
         "edition": "2021",
         "version": "0.246.2"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "wasmprinter 0.248.0": {
+      "name": "wasmprinter",
+      "version": "0.248.0",
+      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/wasmprinter/0.248.0/download",
+          "sha256": "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "wasmprinter",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "wasmprinter",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "component-model",
+            "default",
+            "validate"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "anyhow 1.0.100",
+              "target": "anyhow"
+            },
+            {
+              "id": "termcolor 1.4.1",
+              "target": "termcolor"
+            },
+            {
+              "id": "wasmparser 0.248.0",
+              "target": "wasmparser"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2024",
+        "version": "0.248.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -91914,14 +91811,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "wast 244.0.0": {
+    "wast 248.0.0": {
       "name": "wast",
-      "version": "244.0.0",
+      "version": "248.0.0",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wast/244.0.0/download",
-          "sha256": "b2e7b9f9e23311275920e3d6b56d64137c160cf8af4f84a7283b36cfecbf4acb"
+          "url": "https://static.crates.io/crates/wast/248.0.0/download",
+          "sha256": "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
         }
       },
       "targets": [
@@ -91970,101 +91867,30 @@
               "target": "unicode_width"
             },
             {
-              "id": "wasm-encoder 0.244.0",
+              "id": "wasm-encoder 0.248.0",
               "target": "wasm_encoder"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "244.0.0"
+        "edition": "2024",
+        "version": "248.0.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
-      "license_file": null
+      "license_file": "LICENSE-APACHE"
     },
-    "wast 245.0.1": {
-      "name": "wast",
-      "version": "245.0.1",
-      "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/wast/245.0.1/download",
-          "sha256": "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wast",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "wast",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "component-model",
-            "wasm-module"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bumpalo 3.20.2",
-              "target": "bumpalo"
-            },
-            {
-              "id": "leb128fmt 0.1.0",
-              "target": "leb128fmt"
-            },
-            {
-              "id": "memchr 2.7.4",
-              "target": "memchr"
-            },
-            {
-              "id": "unicode-width 0.2.0",
-              "target": "unicode_width"
-            },
-            {
-              "id": "wasm-encoder 0.245.1",
-              "target": "wasm_encoder"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "245.0.1"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "wat 1.245.1": {
+    "wat 1.248.0": {
       "name": "wat",
-      "version": "1.245.1",
+      "version": "1.248.0",
       "package_url": "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wat",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wat/1.245.1/download",
-          "sha256": "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+          "url": "https://static.crates.io/crates/wat/1.248.0/download",
+          "sha256": "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
         }
       },
       "targets": [
@@ -92096,21 +91922,21 @@
         "deps": {
           "common": [
             {
-              "id": "wast 245.0.1",
+              "id": "wast 248.0.0",
               "target": "wast"
             }
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "1.245.1"
+        "edition": "2024",
+        "version": "1.248.0"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
       ],
-      "license_file": null
+      "license_file": "LICENSE-APACHE"
     },
     "web-sys 0.3.64": {
       "name": "web-sys",
@@ -99521,13 +99347,13 @@
     "walrus 0.23.3",
     "warp 0.3.7",
     "wasm-bindgen 0.2.100",
-    "wasm-encoder 0.245.1",
-    "wasm-smith 0.245.1",
-    "wasmparser 0.245.1",
-    "wasmprinter 0.245.1",
+    "wasm-encoder 0.248.0",
+    "wasm-smith 0.248.0",
+    "wasmparser 0.248.0",
+    "wasmprinter 0.248.0",
     "wasmtime 44.0.1",
-    "wast 244.0.0",
-    "wat 1.245.1",
+    "wast 248.0.0",
+    "wat 1.248.0",
     "webpki-roots 1.0.6",
     "which 4.4.0",
     "wirm 2.1.0",

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -3987,12 +3987,12 @@ dependencies = [
  "walrus 0.23.3",
  "warp",
  "wasm-bindgen",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.248.0",
  "wasm-smith",
- "wasmparser 0.245.1",
- "wasmprinter 0.245.1",
+ "wasmparser 0.248.0",
+ "wasmprinter 0.248.0",
  "wasmtime",
- "wast 244.0.0",
+ "wast",
  "wat",
  "webpki-roots 1.0.6",
  "which",
@@ -5425,6 +5425,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -15098,26 +15100,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.245.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
@@ -15127,16 +15109,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-smith"
-version = "0.245.1"
+name = "wasm-encoder"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbc45c58d90c7748d8a3cf095214531cf7733e6ff02aeda83471cab105da388"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasm-smith"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050b559c1cec6dd6b9a558ae984d91d61e5e7b4c3e47081305a13efe6869eea0"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -15208,30 +15200,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.10.0",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
-dependencies = [
- "bitflags 2.10.0",
- "hashbrown 0.16.1",
- "indexmap 2.14.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
@@ -15244,14 +15212,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.245.1"
+name = "wasmparser"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.245.1",
+ "bitflags 2.10.0",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -15263,6 +15233,17 @@ dependencies = [
  "anyhow",
  "termcolor",
  "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -15451,37 +15432,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "244.0.0"
+version = "248.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e7b9f9e23311275920e3d6b56d64137c160cf8af4f84a7283b36cfecbf4acb"
+checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.244.0",
-]
-
-[[package]]
-name = "wast"
-version = "245.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
-dependencies = [
- "bumpalo",
- "leb128fmt",
- "memchr",
- "unicode-width 0.2.0",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.248.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.245.1"
+version = "1.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
 dependencies = [
- "wast 245.0.1",
+ "wast",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
  "on_wire",
  "rand 0.8.5",
  "tokio",
- "wasmprinter 0.245.1",
+ "wasmprinter 0.248.0",
  "wat",
 ]
 
@@ -5797,6 +5797,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -9624,9 +9626,9 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
- "wasmprinter 0.245.1",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter 0.248.0",
  "wasmtime",
  "wast",
  "wat",
@@ -9750,7 +9752,7 @@ dependencies = [
  "tokio",
  "tower 0.5.3",
  "tracing",
- "wasmparser 0.245.1",
+ "wasmparser 0.248.0",
  "wat",
  "wirm",
 ]
@@ -15011,7 +15013,7 @@ dependencies = [
  "serde_cbor",
  "socket2 0.5.10",
  "tempfile",
- "wasmprinter 0.245.1",
+ "wasmprinter 0.248.0",
  "wat",
 ]
 
@@ -17549,7 +17551,7 @@ dependencies = [
  "ic-nns-common",
  "ic-nns-constants",
  "ic-nns-test-utils",
- "wasmprinter 0.245.1",
+ "wasmprinter 0.248.0",
 ]
 
 [[package]]
@@ -25740,22 +25742,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.245.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -25823,10 +25825,10 @@ dependencies = [
  "libfuzzer-sys",
  "num-traits",
  "tokio",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.248.0",
  "wasm-smith",
- "wasmparser 0.245.1",
- "wasmprinter 0.245.1",
+ "wasmparser 0.248.0",
+ "wasmprinter 0.248.0",
  "wasmtime",
 ]
 
@@ -25895,19 +25897,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.16.1",
- "indexmap 2.14.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
@@ -25920,14 +25909,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.245.1"
+name = "wasmparser"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.245.1",
+ "bitflags 2.11.0",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -25939,6 +25930,17 @@ dependencies = [
  "anyhow",
  "termcolor",
  "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -26127,22 +26129,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "245.0.1"
+version = "248.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.248.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.245.1"
+version = "1.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
 dependencies = [
  "wast",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -914,11 +914,11 @@ uuid = { version = "=1.12.1", features = ["v4", "serde"] }
 virt = "0.4"
 walkdir = "2.3.3"
 walrus = "0.23.3"
-wasm-encoder = { version = "0.245.0", features = ["wasmparser"] }
-wasmparser = "0.245.0"
-wasmprinter = "0.245.0"
-wast = "245.0.0"
-wat = "~1.245.0"
+wasm-encoder = { version = "0.248.0", features = ["wasmparser"] }
+wasmparser = "0.248.0"
+wasmprinter = "0.248.0"
+wast = "248.0.0"
+wat = "~1.248.0"
 webpki-roots = "1.0.6"
 which = "6.0.3"
 wirm = { version = "2.1.0", features = ["parallel"] }

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -1865,7 +1865,7 @@ crate.spec(
         "wasmparser",
     ],
     package = "wasm-encoder",
-    version = "^0.245.0",
+    version = "^0.248.0",
 )
 crate.spec(
     default_features = False,
@@ -1873,15 +1873,15 @@ crate.spec(
         "wasmparser",
     ],
     package = "wasm-smith",
-    version = "^0.245.0",
+    version = "^0.248.0",
 )
 crate.spec(
     package = "wasmparser",
-    version = "^0.245.0",
+    version = "^0.248.0",
 )
 crate.spec(
     package = "wasmprinter",
-    version = "^0.245.0",
+    version = "^0.248.0",
 )
 crate.spec(
     default_features = False,
@@ -1897,11 +1897,11 @@ crate.spec(
 )
 crate.spec(
     package = "wast",
-    version = "^244.0.0",
+    version = "^248.0.0",
 )
 crate.spec(
     package = "wat",
-    version = "~1.245.0",
+    version = "~1.248.0",
 )
 crate.spec(
     package = "webpki-roots",

--- a/rs/embedders/tests/spec_tests.rs
+++ b/rs/embedders/tests/spec_tests.rs
@@ -704,7 +704,9 @@ fn run_directive<'a>(
         | WastDirective::Wait { .. }
         | WastDirective::ModuleDefinition(_)
         | WastDirective::ModuleInstance { .. }
-        | WastDirective::AssertSuspension { .. } => todo!(),
+        | WastDirective::AssertSuspension { .. }
+        | WastDirective::AssertInvalidCustom { .. }
+        | WastDirective::AssertMalformedCustom { .. } => todo!(),
     }
 }
 


### PR DESCRIPTION
Changes needed: Fix syntax error caused by new enum variants WastDirective::AssertInvalidCustom and WastDirective::AssertMalformedCustom in the spec tests without actually implementing any relevant tests.