### PR TITLE
fix: [DSM-103] Ignore executed_rounds when computing total AP

### DIFF
--- a/rs/execution_environment/src/scheduler/tests/scheduling.rs
+++ b/rs/execution_environment/src/scheduler/tests/scheduling.rs
@@ -945,16 +945,11 @@ fn inner_round_first_execution_is_not_a_full_execution() {
         }
     }
     let mut total_accumulated_priority = 0;
-    let mut total_executed_rounds = 0;
     for (_, canister_priority) in test.state().metadata.subnet_schedule.iter() {
         total_accumulated_priority += canister_priority.accumulated_priority.get();
-        total_executed_rounds += canister_priority.executed_rounds;
     }
     // The accumulated priority invariant should be respected.
-    assert_eq!(
-        total_accumulated_priority - ONE_HUNDRED_PERCENT.get() * total_executed_rounds,
-        0
-    );
+    assert_eq!(total_accumulated_priority, 0);
 }
 
 #[test]
@@ -1059,15 +1054,10 @@ fn charge_canisters_for_full_execution(#[strategy(2..10_usize)] scheduler_cores:
         }
     }
     let mut total_accumulated_priority = 0;
-    let mut total_executed_rounds = 0;
     for (_, canister_priority) in test.state().metadata.subnet_schedule.iter() {
         total_accumulated_priority += canister_priority.accumulated_priority.get();
-        total_executed_rounds += canister_priority.executed_rounds;
     }
-    prop_assert_eq!(
-        total_accumulated_priority - ONE_HUNDRED_PERCENT.get() * total_executed_rounds,
-        0
-    );
+    prop_assert_eq!(total_accumulated_priority, 0);
 
     // Send one more message for first half of the canisters.
     for (i, canister) in canister_ids.iter().enumerate() {
@@ -1107,15 +1097,10 @@ fn charge_canisters_for_full_execution(#[strategy(2..10_usize)] scheduler_cores:
         }
     }
     let mut total_accumulated_priority = 0;
-    let mut total_executed_rounds = 0;
     for (_, canister_priority) in test.state().metadata.subnet_schedule.iter() {
         total_accumulated_priority += canister_priority.accumulated_priority.get();
-        total_executed_rounds += canister_priority.executed_rounds;
     }
-    prop_assert_eq!(
-        total_accumulated_priority - ONE_HUNDRED_PERCENT.get() * total_executed_rounds,
-        0
-    );
+    prop_assert_eq!(total_accumulated_priority, 0);
 }
 
 #[test]
@@ -1166,22 +1151,16 @@ fn charge_idle_canisters_for_full_execution_round() {
             }
         }
         let mut total_accumulated_priority = 0;
-        let mut total_executed_rounds = 0;
         for (_, canister_priority) in test.state().metadata.subnet_schedule.iter() {
             // Assert there is no divergency in accumulated priorities.
-            let priority = canister_priority.accumulated_priority
-                - ONE_HUNDRED_PERCENT * canister_priority.executed_rounds;
+            let priority = canister_priority.accumulated_priority;
             assert_le!(priority.get(), 100 * MULTIPLIER);
             assert_ge!(priority.get(), -100 * MULTIPLIER);
 
             total_accumulated_priority += canister_priority.accumulated_priority.get();
-            total_executed_rounds += canister_priority.executed_rounds;
         }
         // The accumulated priority invariant should be respected.
-        assert_eq!(
-            total_accumulated_priority - ONE_HUNDRED_PERCENT.get() * total_executed_rounds,
-            0
-        );
+        assert_eq!(total_accumulated_priority, 0);
     }
 }
 


### PR DESCRIPTION
In tests checking that the accumulated priority (AP) sum across all canisters is zero, ignore `executed_rounds`: the zero lower-bound invariant strictly applies to AP now.