### PR TITLE
feat: [DSM-103] Active-canister-only scheduling

### DIFF
--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -391,9 +391,11 @@ rust_ic_bench(
         # Keep sorted.
         ":execution_environment",
         "//rs/config",
+        "//rs/monitoring/logger",
         "//rs/monitoring/metrics",
         "//rs/registry/subnet_type",
         "//rs/replicated_state",
+        "//rs/test_utilities/types",
         "//rs/types/base_types",
         "//rs/types/cycles",
         "//rs/types/types",

--- a/rs/execution_environment/benches/scheduler.rs
+++ b/rs/execution_environment/benches/scheduler.rs
@@ -2,10 +2,16 @@ use criterion::Criterion;
 use ic_base_types::NumSeconds;
 use ic_config::flag_status::FlagStatus;
 use ic_execution_environment::{RoundSchedule, SchedulerMetrics};
+use ic_logger::new_replica_logger_from_config;
 use ic_metrics::MetricsRegistry;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::canister_snapshots::CanisterSnapshots;
-use ic_replicated_state::{CanisterState, ReplicatedState, SchedulerState, SystemState};
+use ic_replicated_state::canister_state::system_state::PausedExecutionId;
+use ic_replicated_state::{
+    CanisterState, ExecutionTask, InputQueueType, ReplicatedState, SchedulerState, SystemState,
+};
+use ic_test_utilities_types::messages::RequestBuilder;
+use ic_types::messages::{CanisterMessageOrTask, CanisterTask};
 use ic_types::{ExecutionRound, NumBytes, NumInstructions};
 use ic_types_cycles::Cycles;
 use ic_types_test_utils::ids::{canister_test_id, subnet_test_id, user_test_id};
@@ -15,8 +21,6 @@ use std::sync::Arc;
 fn main() {
     // 100k canisters, 5k active, 1k executed every round.
     let mut canisters = BTreeMap::new();
-    let mut ordered_new_execution_canister_ids = Vec::new();
-    let mut ordered_long_execution_canister_ids = Vec::new();
     let mut executed_canisters = BTreeSet::new();
     for i in 0..100_000 {
         let canister_id = canister_test_id(i);
@@ -28,15 +32,29 @@ fn main() {
             NumSeconds::from(100_000),
         );
         let canister_snapshots = CanisterSnapshots::default();
-        let canister_state =
+        let mut canister_state =
             CanisterState::new(system_state, None, scheduler_state, canister_snapshots);
         // 5k active canisters.
         if i < 5_000 {
             // Every 10th canister has a long execution, the rest have new inputs.
             if i % 10 == 0 {
-                ordered_long_execution_canister_ids.push(canister_id);
+                canister_state
+                    .system_state
+                    .task_queue
+                    .enqueue(ExecutionTask::PausedExecution {
+                        id: PausedExecutionId(0),
+                        input: CanisterMessageOrTask::Task(CanisterTask::Heartbeat),
+                    });
             } else {
-                ordered_new_execution_canister_ids.push(canister_id);
+                let mut available_memory = i64::MAX;
+                canister_state
+                    .push_input(
+                        RequestBuilder::new().receiver(canister_id).build().into(),
+                        &mut available_memory,
+                        SubnetType::Application,
+                        InputQueueType::RemoteSubnet,
+                    )
+                    .unwrap();
             }
         }
         // First 1k canisters complete an execution every round.
@@ -53,44 +71,42 @@ fn main() {
     let rate_limiting_of_heap_delta = FlagStatus::Enabled;
     let install_code_rate_limit = NumInstructions::from(1_000_000);
     let rate_limiting_of_instructions = FlagStatus::Enabled;
-    let long_execution_cores = 1;
     let mut round_schedule = RoundSchedule::new(
         scheduler_cores,
         heap_delta_rate_limit,
         rate_limiting_of_heap_delta,
         install_code_rate_limit,
         rate_limiting_of_instructions,
-        long_execution_cores,
-        ordered_new_execution_canister_ids,
-        ordered_long_execution_canister_ids,
     );
     let metrics_registry = MetricsRegistry::new();
     let metrics = SchedulerMetrics::new(&metrics_registry);
+    let (log, _async_guard) = new_replica_logger_from_config(&Default::default());
 
     let mut criterion = Criterion::default();
     let mut group = criterion.benchmark_group("RoundSchedule");
+    let current_round = ExecutionRound::from(13);
 
     group.bench_function("iteration", |bench| {
         bench.iter(|| {
-            round_schedule.start_iteration(&mut state, true);
+            round_schedule.start_iteration(&mut state, true, &metrics, &log);
             round_schedule.end_iteration(
                 &mut state,
                 &executed_canisters,
                 &executed_canisters,
                 &BTreeSet::new(),
-                ExecutionRound::from(1),
+                current_round,
             );
         });
     });
 
     // Populate the subnet schedule, even if the iteration benchmark is not run.
-    round_schedule.start_iteration(&mut state, true);
+    round_schedule.start_iteration(&mut state, true, &metrics, &log);
     round_schedule.end_iteration(
         &mut state,
         &executed_canisters,
         &executed_canisters,
         &BTreeSet::new(),
-        ExecutionRound::from(1),
+        current_round,
     );
 
     group.bench_function("finish_round", |bench| {

--- a/rs/execution_environment/src/lib.rs
+++ b/rs/execution_environment/src/lib.rs
@@ -52,7 +52,9 @@ pub use metrics::IngressFilterMetrics;
 pub use query_handler::{DataCertificateWithDelegationMetadata, InternalHttpQueryHandler};
 use query_handler::{HttpQueryHandler, QueryScheduler};
 use scheduler::SchedulerImpl;
-pub use scheduler::{RoundSchedule, SchedulerMetrics, abort_all_paused_executions};
+pub use scheduler::{
+    IterationSchedule, RoundSchedule, SchedulerMetrics, abort_all_paused_executions,
+};
 use std::{path::Path, sync::Arc};
 use tokio::sync::mpsc::Sender;
 

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1,5 +1,5 @@
-pub use self::round_schedule::RoundSchedule;
 use self::round_schedule::*;
+pub use self::round_schedule::{IterationSchedule, RoundSchedule};
 pub use self::scheduler_metrics::SchedulerMetrics;
 use self::scheduler_metrics::*;
 use self::threshold_signatures::*;
@@ -422,6 +422,7 @@ impl SchedulerImpl {
         canister_ingress_latencies: &mut CanisterIngressQueueLatencies,
         scheduler_round_limits: &mut SchedulerRoundLimits,
         root_measurement_scope: &MeasurementScope<'a>,
+        round_log: &ReplicaLogger,
     ) -> ReplicatedState {
         let cost_schedule = state.get_own_cost_schedule();
         let measurement_scope =
@@ -486,10 +487,12 @@ impl SchedulerImpl {
 
             // Scheduling.
             let scheduling_timer = self.metrics.round_inner_iteration_scheduling.start_timer();
-            round_schedule.charge_idle_canisters(state.canisters_and_schedule_mut().0);
-
-            // Obtain the active canisters for this iteration.
-            let iteration_schedule = round_schedule.start_iteration(&mut state, is_first_iteration);
+            let iteration_schedule = round_schedule.start_iteration(
+                &mut state,
+                is_first_iteration,
+                &self.metrics,
+                round_log,
+            );
             if iteration_schedule.is_empty() {
                 break state;
             }
@@ -593,6 +596,7 @@ impl SchedulerImpl {
                 .metrics
                 .round_inner_heartbeat_overhead_duration
                 .start_timer();
+
             // Remove all remaining `Heartbeat` and `GlobalTimer` tasks
             // because they will be added again in the next round.
             for canister_id in &heartbeat_and_timer_canisters {
@@ -723,7 +727,7 @@ impl SchedulerImpl {
             max_instructions_executed_per_thread =
                 max_instructions_executed_per_thread.max(instructions_executed);
 
-            let divisor = round_limits_per_thread.instructions.get();
+            let divisor = self.config.max_instructions_per_slice.get();
             debug_assert_ne!(divisor, 0, "prevent divide by zero panic");
             if divisor > 0 {
                 let value = instructions_executed.get() as f64 / divisor as f64;
@@ -1065,6 +1069,9 @@ impl SchedulerImpl {
     ///
     /// NOTE: This is also called by `checkpoint_round_with_no_execution()`, so it
     /// must be safe to call even when no execution has taken place.
+    //
+    // TODO(DSM-103): Consider only aborting / checking DTS invariants for actually
+    // scheduled canisters.
     fn finish_round(
         &self,
         state: &mut ReplicatedState,
@@ -1433,25 +1440,16 @@ impl Scheduler for SchedulerImpl {
             scheduler_round_limits.update_subnet_round_limits(&subnet_round_limits);
         }
 
-        // Scheduling.
-        let mut round_schedule = {
-            let _timer = self.metrics.round_scheduling_duration.start_timer();
-
-            RoundSchedule::apply_scheduling_strategy(
-                &mut state,
-                self.config.scheduler_cores,
-                self.config.heap_delta_rate_limit,
-                self.rate_limiting_of_heap_delta,
-                self.config.install_code_rate_limit,
-                self.rate_limiting_of_instructions,
-                current_round,
-                self.config.accumulated_priority_reset_interval,
-                &self.metrics,
-                &round_log,
-            )
-        };
+        // TODO(DSM-103): Consider routing messages from subnet output queues to local canisters.
 
         // Inner round.
+        let mut round_schedule = RoundSchedule::new(
+            self.config.scheduler_cores,
+            self.config.heap_delta_rate_limit,
+            self.rate_limiting_of_heap_delta,
+            self.config.install_code_rate_limit,
+            self.rate_limiting_of_instructions,
+        );
         let mut state = self.inner_round(
             state,
             current_round,
@@ -1463,6 +1461,7 @@ impl Scheduler for SchedulerImpl {
             &mut canister_ingress_latencies,
             &mut scheduler_round_limits,
             &root_measurement_scope,
+            &round_log,
         );
 
         // Update [`SignWithThresholdContext`]s by assigning randomness and matching pre-signatures.

--- a/rs/execution_environment/src/scheduler/round_schedule.rs
+++ b/rs/execution_environment/src/scheduler/round_schedule.rs
@@ -9,7 +9,6 @@ use ic_logger::{ReplicaLogger, error};
 use ic_replicated_state::canister_state::NextExecution;
 use ic_replicated_state::{CanisterPriority, CanisterState, ReplicatedState};
 use ic_types::{AccumulatedPriority, ComputeAllocation, ExecutionRound, NumInstructions};
-use ic_utils::iter::left_outer_join;
 use num_traits::SaturatingSub;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
@@ -199,10 +198,6 @@ impl IterationSchedule {
     pub fn is_empty(&self) -> bool {
         self.schedule.is_empty()
     }
-
-    pub fn iter(&self) -> impl Iterator<Item = &CanisterId> {
-        self.schedule.iter()
-    }
 }
 
 /// Round-level schedule and accounting: builds the iteration schedule each iteration,
@@ -211,13 +206,6 @@ impl IterationSchedule {
 pub struct RoundSchedule {
     /// Immutable configuration for this round.
     config: Config,
-
-    /// Number of cores dedicated for long executions.
-    long_execution_cores: usize,
-    /// Ordered Canister IDs with new executions.
-    ordered_new_execution_canister_ids: Vec<CanisterId>,
-    /// Ordered Canister IDs with long executions.
-    ordered_long_execution_canister_ids: Vec<CanisterId>,
 
     /// Canisters that were scheduled.
     scheduled_canisters: BTreeSet<CanisterId>,
@@ -242,9 +230,6 @@ impl RoundSchedule {
         rate_limiting_of_heap_delta: FlagStatus,
         install_code_rate_limit: NumInstructions,
         rate_limiting_of_instructions: FlagStatus,
-        long_execution_cores: usize,
-        ordered_new_execution_canister_ids: Vec<CanisterId>,
-        ordered_long_execution_canister_ids: Vec<CanisterId>,
     ) -> Self {
         let config = Config {
             scheduler_cores,
@@ -263,41 +248,12 @@ impl RoundSchedule {
         };
         Self {
             config,
-            long_execution_cores: long_execution_cores
-                .min(ordered_long_execution_canister_ids.len()),
-            ordered_new_execution_canister_ids,
-            ordered_long_execution_canister_ids,
             scheduled_canisters: BTreeSet::new(),
             executed_canisters: BTreeSet::new(),
             long_execution_canisters: BTreeSet::new(),
             canisters_with_completed_messages: BTreeSet::new(),
             fully_executed_canisters: BTreeSet::new(),
             rate_limited_canisters: BTreeSet::new(),
-        }
-    }
-
-    /// Marks idle canisters in front of the schedule as fully executed.
-    pub fn charge_idle_canisters(
-        &mut self,
-        canisters: &mut BTreeMap<CanisterId, Arc<CanisterState>>,
-    ) {
-        for canister_id in self.ordered_new_execution_canister_ids.iter() {
-            let canister = canisters.get(canister_id);
-            if let Some(canister) = canister {
-                let next_execution = canister.next_execution();
-                match next_execution {
-                    NextExecution::None => {
-                        self.fully_executed_canisters.insert(canister.canister_id());
-                    }
-                    // Skip install code canisters.
-                    NextExecution::ContinueInstallCode => {}
-
-                    NextExecution::StartNew | NextExecution::ContinueLong => {
-                        // Stop searching after the first non-idle canister.
-                        break;
-                    }
-                }
-            }
         }
     }
 
@@ -309,11 +265,23 @@ impl RoundSchedule {
         &mut self,
         state: &mut ReplicatedState,
         is_first_iteration: bool,
+        metrics: &SchedulerMetrics,
+        logger: &ReplicaLogger,
     ) -> IterationSchedule {
         let (canister_states, subnet_schedule) = state.canisters_and_schedule_mut();
 
+        // Sum of all scheduled canisters' compute allocations.
+        // This corresponds to |a| in Scheduler Analysis.
+        let mut total_compute_allocation = ZERO;
+        let mut long_executions_count = 0;
+        // Sum of all long execution canisters' compute allocations.
+        let mut long_executions_compute_allocation = ZERO;
+
         // Collect all active canisters and their next executions.
-        let canister_next_executions: BTreeMap<_, _> = canister_states
+        //
+        // Unfortunately, not all active canisters are in the subnet schedule, so we
+        // must iterate over all canister states to find them.
+        let mut schedule: Vec<CanisterRoundState> = canister_states
             .iter()
             .filter_map(|(canister_id, canister)| {
                 // Record and filter out rate limited canisters.
@@ -331,11 +299,7 @@ impl RoundSchedule {
                     return None;
                 }
 
-                let next_execution = canister.next_execution();
-                match next_execution {
-                    // Filter out canisters with no messages or with paused installations.
-                    NextExecution::None | NextExecution::ContinueInstallCode => None,
-
+                let canister_round_state = match canister.next_execution() {
                     NextExecution::StartNew => {
                         // Don't schedule canisters that completed a long execution this round. We need
                         // canisters to move between the long execution and new execution pools, so the
@@ -343,56 +307,102 @@ impl RoundSchedule {
                         if self.long_execution_canisters.contains(canister_id) {
                             return None;
                         }
-                        self.scheduled_canisters.insert(*canister_id);
-                        Some((canister_id, next_execution))
+                        CanisterRoundState::new(canister, subnet_schedule.get_mut(*canister_id))
                     }
 
                     NextExecution::ContinueLong => {
                         if is_first_iteration {
                             self.long_execution_canisters.insert(*canister_id);
                         }
-                        self.scheduled_canisters.insert(*canister_id);
-                        Some((canister_id, next_execution))
+                        let priority = subnet_schedule.get_mut(*canister_id);
+                        let rs = CanisterRoundState::new(canister, priority);
+                        long_executions_count += 1;
+                        long_executions_compute_allocation += rs.compute_allocation;
+                        rs
                     }
-                }
+
+                    NextExecution::None => {
+                        // (Only) drop from the schedule idle canisters with 0-100 AP.
+                        //
+                        // Idle canisters with negative AP are kept in the schedule until they reach 0
+                        // AP, to prevent them from jumping from the back of the schedule to the middle
+                        // just by being idle for a round. Similarly, idle canisters with positive AP
+                        // burn it down as if they had executed full rounds until they (almost) reach 0.
+                        if is_first_iteration && !canister.must_be_in_schedule() {
+                            let canister_priority = subnet_schedule.get(canister_id);
+                            if canister_priority.accumulated_priority >= ZERO
+                                && canister_priority.accumulated_priority <= ONE_HUNDRED_PERCENT
+                            {
+                                subnet_schedule.remove(canister_id);
+                            }
+                        }
+                        return None;
+                    }
+
+                    NextExecution::ContinueInstallCode => return None,
+                };
+
+                total_compute_allocation += canister_round_state.compute_allocation;
+                self.scheduled_canisters.insert(*canister_id);
+
+                Some(canister_round_state)
             })
             .collect();
+        schedule.sort();
 
-        let mut schedule: Vec<CanisterId> = self
-            .ordered_long_execution_canister_ids
-            .iter()
-            .filter(
-                |canister_id| match canister_next_executions.get(canister_id) {
-                    Some(NextExecution::ContinueLong) => true,
-
-                    // We expect long execution, but there is none,
-                    // so the long execution was finished in the
-                    // previous inner round.
-                    //
-                    // We should avoid scheduling this canister to:
-                    // 1. Avoid the canister to bypass the logic in
-                    //    `apply_scheduling_strategy()`.
-                    // 2. Charge canister for resources at the end
-                    //    of the round.
-                    Some(NextExecution::StartNew) => false,
-
-                    None
-                        | Some(NextExecution::None) // Idle canister.
-                        | Some(NextExecution::ContinueInstallCode) // Subnet message.
-                         => false,
-                },
+        let compute_capacity = self.compute_capacity();
+        let long_execution_cores = if long_executions_count == schedule.len() {
+            // Only long executions.
+            std::cmp::min(long_executions_count, self.config.scheduler_cores)
+        } else {
+            // Mix of long and short executions.
+            //
+            // Compute the number of long execution cores by dividing long executions'
+            // compute allocation plus free compute share by `100%` and rounding up (so that
+            // both long and new executions get enough cores to cover their respective
+            // cumulative compute allocations).
+            let free_compute = compute_capacity - total_compute_allocation;
+            let long_executions_compute = long_executions_compute_allocation
+                + (free_compute * long_executions_count as i64 / schedule.len() as i64);
+            std::cmp::min(
+                long_executions_count,
+                ((long_executions_compute + ONE_HUNDRED_PERCENT - AccumulatedPriority::new(1))
+                    / ONE_HUNDRED_PERCENT) as usize,
             )
-            .cloned()
-            .collect();
-        let long_executions_count = schedule.len();
-        let long_execution_cores = self.long_execution_cores.min(long_executions_count);
+        };
 
-        schedule.extend(
-            self.ordered_new_execution_canister_ids
-                .iter()
-                .filter(|canister_id| canister_next_executions.contains_key(canister_id)),
+        // There is at least `1%` of free capacity to distribute across canisters.
+        // This is guaranteed by `validate_compute_allocation()`.
+        debug_assert_or_critical_error!(
+            total_compute_allocation + ONE_PERCENT <= compute_capacity,
+            metrics.scheduler_compute_allocation_invariant_broken,
+            logger,
+            "{}: Total compute allocation {}% must be less than compute capacity {}%",
+            SCHEDULER_COMPUTE_ALLOCATION_INVARIANT_BROKEN,
+            total_compute_allocation,
+            compute_capacity
+        );
+        // If there are long executions, `long_execution_cores` must be non-zero.
+        debug_assert_or_critical_error!(
+            long_executions_count == 0 || long_execution_cores > 0,
+            metrics.scheduler_cores_invariant_broken,
+            logger,
+            "{}: Number of long execution cores {} must be more than 0",
+            SCHEDULER_CORES_INVARIANT_BROKEN,
+            long_execution_cores,
+        );
+        // Can't have more long execution cores than scheduler cores.
+        debug_assert_or_critical_error!(
+            long_execution_cores <= self.config.scheduler_cores,
+            metrics.scheduler_cores_invariant_broken,
+            logger,
+            "{}: Number of long execution cores {} must be <= scheduler cores {}",
+            SCHEDULER_CORES_INVARIANT_BROKEN,
+            long_execution_cores,
+            self.config.scheduler_cores
         );
 
+        let schedule: Vec<CanisterId> = schedule.into_iter().map(|rs| rs.canister_id).collect();
         if is_first_iteration {
             // First iteration: mark the first canister on each core as fully executed.
             let mut observe_scheduled_as_first = |canister: &CanisterId| {
@@ -514,11 +524,17 @@ impl RoundSchedule {
                 .insert(*canister_id);
         }
 
-        // Add all canisters to the subnet schedule; and charge any immediate or
-        // deferred (on long execution completion) execution rounds.
-        for canister in canister_states.values() {
+        // Remove any deleted canisters from the subnet schedule. Beyond this point it
+        // is safe to assume that the subnet schedule only refers to existing canisters.
+        subnet_schedule.retain(|canister_id, _| canister_states.contains_key(canister_id));
+
+        // Add all canisters that we (tried to) schedule this round to the subnet
+        // schedule; and charge any immediate or deferred (on long execution completion)
+        // full execution rounds.
+        for canister_id in &self.scheduled_canisters {
+            let canister = canister_states.get_mut(canister_id).unwrap();
             // Add the canister to the subnet schedule, if not already there.
-            let canister_priority = subnet_schedule.get_mut(canister.canister_id());
+            let canister_priority = subnet_schedule.get_mut(*canister_id);
 
             // Charge for the first round of every long execution immediately, to properly
             // account for newly started long executions (scheduled as new executions).
@@ -531,14 +547,28 @@ impl RoundSchedule {
             // On message completion (or short execution), charge for the remaining rounds.
             if canister_priority.executed_rounds > 0
                 && (!canister.has_long_execution()
-                    || self
-                        .canisters_with_completed_messages
-                        .contains(&canister.canister_id()))
+                    || self.canisters_with_completed_messages.contains(canister_id))
             {
                 canister_priority.accumulated_priority -=
                     ONE_HUNDRED_PERCENT * (canister_priority.executed_rounds - 1).max(1);
-                canister_priority.executed_rounds = 0;
+                if canister.has_long_execution()
+                    && self.long_execution_canisters.contains(canister_id)
+                {
+                    // Safety net: canister had a long execution at the start of this round;
+                    // completed it; and started another long execution; this branch is currently
+                    // never taken, because we never reschedule canisters that completed a long
+                    // execution this round; but if we ever change that behavior, skip charging for
+                    // the first round of the new long execution but do charge for the second round.
+                    canister_priority.executed_rounds = 1;
+                } else {
+                    canister_priority.executed_rounds = 0;
+                }
             }
+
+            Arc::make_mut(canister)
+                .system_state
+                .canister_metrics_mut()
+                .observe_round_scheduled();
         }
 
         self.grant_heap_delta_and_install_code_credits(state, metrics);
@@ -549,14 +579,21 @@ impl RoundSchedule {
         let mut total_ap = ZERO;
         let mut total_ca = ZERO;
         let mut compute_allocations = Vec::with_capacity(subnet_schedule.len());
-        for (_, canister, canister_priority) in
-            left_outer_join(canister_states.iter_mut(), subnet_schedule.iter_mut())
-        {
-            // Safe to unwrap, we called SubnetSchedule::get_mut() above for all canisters.
-            let canister_priority = canister_priority.unwrap();
-
+        for (canister_id, canister_priority) in subnet_schedule.iter_mut() {
+            let canister = canister_states.get_mut(canister_id).unwrap();
             let compute_allocation = from_ca(canister.compute_allocation());
             canister_priority.accumulated_priority += compute_allocation;
+
+            // Treat idle canisters with positive AP as fully executed (which is technically
+            // true). The goal is to gradually burn down their AP to zero, so that if they
+            // get new inputs soon, they will not have instantly lost all their previous AP.
+            if canister_priority.accumulated_priority > ZERO
+                && !self.scheduled_canisters.contains(canister_id)
+                && !self.rate_limited_canisters.contains(canister_id)
+            {
+                canister_priority.accumulated_priority -=
+                    ONE_HUNDRED_PERCENT.min(canister_priority.accumulated_priority);
+            }
 
             // Apply an exponential decay to AP values outside the [AP_ROUNDS_MIN,
             // AP_ROUNDS_MAX] range to soft bound any runaway AP.
@@ -574,10 +611,10 @@ impl RoundSchedule {
 
             total_ap += canister_priority.accumulated_priority;
             total_ca += compute_allocation;
-            compute_allocations.push((canister.canister_id(), compute_allocation));
+            compute_allocations.push((*canister_id, compute_allocation));
         }
 
-        // Distribute the "free compute" (negative of total AP) to all canisters.
+        // Distribute the "free compute" (negative of total AP) to scheduled canisters.
         //
         // Only ever apply positive free compute. If the total AP is positive (e.g. we
         // granted compute allocations after not having completed any execution this
@@ -628,6 +665,10 @@ impl RoundSchedule {
             .set((accumulated_priority_deviation / subnet_schedule.len().max(1) as f64).sqrt());
 
         self.observe_round_metrics(state, current_round, metrics);
+
+        // NOTE: Some active canisters may not be in the subnet schedule at this point,
+        // because we may have bailed out of inner_round() due to reaching some limit,
+        // either before we scheduled anything or after inducting subnet-local messages.
     }
 
     /// Deducts the heap delta and install code rate limits from the canisters'
@@ -637,8 +678,12 @@ impl RoundSchedule {
         state: &mut ReplicatedState,
         metrics: &SchedulerMetrics,
     ) {
-        let (canister_states, _) = state.canisters_and_schedule_mut();
-        for canister in canister_states.values_mut() {
+        let (canister_states, subnet_schedule) = state.canisters_and_schedule_mut();
+        for (canister_id, _) in subnet_schedule.iter() {
+            let Some(canister) = canister_states.get_mut(canister_id) else {
+                continue;
+            };
+
             let heap_delta_debit = canister.scheduler_state.heap_delta_debit.get();
             metrics
                 .canister_heap_delta_debits
@@ -711,163 +756,13 @@ impl RoundSchedule {
     /// Returns scheduler compute capacity in accumulated priority.
     ///
     /// For the DTS scheduler, it's `(number of cores - 1) * 100%`
-    fn compute_capacity(scheduler_cores: usize) -> AccumulatedPriority {
-        ONE_HUNDRED_PERCENT * (scheduler_cores as i64 - 1)
+    fn compute_capacity(&self) -> AccumulatedPriority {
+        ONE_HUNDRED_PERCENT * (self.config.scheduler_cores as i64 - 1)
     }
 
     /// Canisters that were scheduled this round.
     pub fn scheduled_canisters(&self) -> &BTreeSet<CanisterId> {
         &self.scheduled_canisters
-    }
-
-    /// Orders the canisters and updates their accumulated priorities according to
-    /// the strategy described in RUN-58.
-    ///
-    /// A shorter description of the scheduling strategy is available in the note
-    /// section about [Scheduler and AccumulatedPriority] in types/src/lib.rs
-    pub(super) fn apply_scheduling_strategy(
-        state: &mut ReplicatedState,
-        scheduler_cores: usize,
-        heap_delta_rate_limit: NumBytes,
-        rate_limiting_of_heap_delta: FlagStatus,
-        install_code_rate_limit: NumInstructions,
-        rate_limiting_of_instructions: FlagStatus,
-        current_round: ExecutionRound,
-        accumulated_priority_reset_interval: ExecutionRound,
-        metrics: &SchedulerMetrics,
-        logger: &ReplicaLogger,
-    ) -> RoundSchedule {
-        let number_of_canisters = state.canister_states().len();
-
-        // Total allocatable compute capacity.
-        // As one scheduler core is reserved to guarantee long executions progress,
-        // compute capacity is `(scheduler_cores - 1) * 100`
-        let compute_capacity = Self::compute_capacity(scheduler_cores);
-
-        // Sum of all scheduled canisters' compute allocations.
-        // This corresponds to |a| in Scheduler Analysis.
-        let mut total_compute_allocation = ZERO;
-        // Sum of all long execution canisters' compute allocations.
-        let mut long_executions_compute_allocation = ZERO;
-        let mut long_executions_count = 0;
-
-        // This corresponds to the vector p in the Scheduler Analysis document.
-        let mut round_states = Vec::with_capacity(number_of_canisters);
-
-        // Reset the accumulated priorities periodically.
-        // We want to reset the scheduler regularly to safely support changes in the set
-        // of canisters and their compute allocations.
-        let is_reset_round = current_round
-            .get()
-            .is_multiple_of(accumulated_priority_reset_interval.get());
-        let (canister_states, subnet_schedule) = state.canisters_and_schedule_mut();
-        if is_reset_round {
-            for &canister_id in canister_states.keys() {
-                let canister_priority = subnet_schedule.get_mut(canister_id);
-                canister_priority.accumulated_priority = Default::default();
-            }
-        }
-
-        // Collect the priority of the canisters for this round.
-        let mut accumulated_priority_invariant = ZERO;
-        for (_, canister, canister_priority) in
-            left_outer_join(canister_states.iter_mut(), subnet_schedule.iter())
-        {
-            let canister_priority = canister_priority.unwrap_or(&CanisterPriority::DEFAULT);
-            let compute_allocation = from_ca(canister.compute_allocation());
-            let accumulated_priority = canister_priority.accumulated_priority;
-            round_states.push(CanisterRoundState::new(canister, canister_priority));
-
-            total_compute_allocation += compute_allocation;
-            accumulated_priority_invariant += accumulated_priority;
-            if canister_priority.long_execution_start_round.is_some() {
-                long_executions_compute_allocation += compute_allocation;
-                long_executions_count += 1;
-            }
-            if canister.has_input() {
-                let canister = Arc::make_mut(canister);
-                canister
-                    .system_state
-                    .canister_metrics_mut()
-                    .observe_round_scheduled();
-            }
-        }
-        round_states.sort();
-
-        // Assert there is at least `1%` of free capacity to distribute across canisters.
-        // It's guaranteed by `validate_compute_allocation()`
-        debug_assert_or_critical_error!(
-            total_compute_allocation + ONE_PERCENT <= compute_capacity,
-            metrics.scheduler_compute_allocation_invariant_broken,
-            logger,
-            "{}: Total compute allocation {}% must be less than compute capacity {}%",
-            SCHEDULER_COMPUTE_ALLOCATION_INVARIANT_BROKEN,
-            total_compute_allocation,
-            compute_capacity
-        );
-        // Observe accumulated priority metrics
-        metrics
-            .scheduler_accumulated_priority_invariant
-            .set(accumulated_priority_invariant.get());
-
-        let long_execution_cores = if long_executions_count == canister_states.len() {
-            // Only long executions.
-            std::cmp::min(long_executions_count, scheduler_cores)
-        } else {
-            // Mix of long and short executions.
-            //
-            // Compute the number of long execution cores by dividing long executions'
-            // compute allocation plus free compute share by `100%` and rounding up (so that
-            // both long and new executions get enough cores to cover their respective
-            // cumulative compute allocations).
-            let free_compute = compute_capacity - total_compute_allocation;
-            let long_executions_compute = long_executions_compute_allocation
-                + (free_compute * long_executions_count as i64 / canister_states.len() as i64);
-            std::cmp::min(
-                long_executions_count,
-                ((long_executions_compute + ONE_HUNDRED_PERCENT - AccumulatedPriority::new(1))
-                    / ONE_HUNDRED_PERCENT) as usize,
-            )
-        };
-
-        // If there are long executions, `long_execution_cores` must be non-zero.
-        debug_assert_or_critical_error!(
-            long_executions_count == 0 || long_execution_cores > 0,
-            metrics.scheduler_cores_invariant_broken,
-            logger,
-            "{}: Number of long execution cores {} must be more than 0",
-            SCHEDULER_CORES_INVARIANT_BROKEN,
-            long_execution_cores,
-        );
-        // Can't have more long execution cores than scheduler cores.
-        debug_assert_or_critical_error!(
-            long_execution_cores <= scheduler_cores,
-            metrics.scheduler_cores_invariant_broken,
-            logger,
-            "{}: Number of long execution cores {} must be <= scheduler cores {}",
-            SCHEDULER_CORES_INVARIANT_BROKEN,
-            long_execution_cores,
-            scheduler_cores
-        );
-
-        RoundSchedule::new(
-            scheduler_cores,
-            heap_delta_rate_limit,
-            rate_limiting_of_heap_delta,
-            install_code_rate_limit,
-            rate_limiting_of_instructions,
-            long_execution_cores,
-            round_states
-                .iter()
-                .skip(long_executions_count)
-                .map(|rs| rs.canister_id)
-                .collect(),
-            round_states
-                .iter()
-                .take(long_executions_count)
-                .map(|rs| rs.canister_id)
-                .collect(),
-        )
     }
 }
 

--- a/rs/execution_environment/src/scheduler/round_schedule/tests.rs
+++ b/rs/execution_environment/src/scheduler/round_schedule/tests.rs
@@ -47,19 +47,21 @@ impl RoundScheduleFixture {
     /// Creates a new fixture with a sensible `RoundSchedule` default (4 cores,
     /// large heap delta rate limit), and an empty `ReplicatedState`.
     fn new() -> Self {
-        let mut state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
-        let current_round = ExecutionRound::new(1);
-        let metrics = SchedulerMetrics::new(&MetricsRegistry::new());
-        let logger = ic_logger::replica_logger::test_logger(Some(slog::Level::Info));
-        let round_schedule =
-            RoundScheduleBuilder::new().build(&mut state, current_round, &metrics, &logger);
+        Self::with_round_schedule(RoundScheduleBuilder::new().build())
+    }
+
+    /// Creates a new fixture with the given `RoundSchedule` and an empty
+    /// `ReplicatedState`.
+    fn with_round_schedule(round_schedule: RoundSchedule) -> Self {
+        let registry = MetricsRegistry::new();
+        let metrics = SchedulerMetrics::new(&registry);
         Self {
             round_schedule,
-            state,
-            current_round,
+            state: ReplicatedState::new(subnet_test_id(1), SubnetType::Application),
+            current_round: ExecutionRound::new(1),
             next_canister_id: 0,
             metrics,
-            logger,
+            logger: ic_logger::replica_logger::test_logger(Some(slog::Level::Info)),
         }
     }
 
@@ -92,40 +94,15 @@ impl RoundScheduleFixture {
         canister_id
     }
 
-    /// Creates a new `RoundSchedule` around the current `state`.
-    fn start_round(
-        &mut self,
-        current_round: ExecutionRound,
-        round_schedule_builder: RoundScheduleBuilder,
-    ) {
-        self.current_round = current_round;
-        self.round_schedule = round_schedule_builder.build(
-            &mut self.state,
-            current_round,
-            &self.metrics,
-            &self.logger,
-        );
-    }
-
-    /// Creates a new `RoundSchedule` around the current `state` and calls
-    /// `RoundSchedule::start_iteration` on it.
-    fn start_iteration(&mut self, is_first_iteration: bool) -> IterationSchedule {
-        self.round_schedule = RoundScheduleBuilder::new().build(
-            &mut self.state,
-            self.current_round,
-            &self.metrics,
-            &self.logger,
-        );
-
-        self.start_iteration_only(is_first_iteration)
-    }
-
     /// Calls `RoundSchedule::start_iteration`, mutating canister priorities and
     /// returning the iteration schedule.
-    fn start_iteration_only(&mut self, is_first_iteration: bool) -> IterationSchedule {
-        let iteration = self
-            .round_schedule
-            .start_iteration(&mut self.state, is_first_iteration);
+    fn start_iteration(&mut self, is_first_iteration: bool) -> IterationSchedule {
+        let iteration = self.round_schedule.start_iteration(
+            &mut self.state,
+            is_first_iteration,
+            &self.metrics,
+            &self.logger,
+        );
 
         // `IterationSchedule` sanity checks.
         assert_eq!(
@@ -415,24 +392,13 @@ impl RoundScheduleBuilder {
         self
     }
 
-    fn build(
-        self,
-        state: &mut ReplicatedState,
-        current_round: ExecutionRound,
-        metrics: &SchedulerMetrics,
-        logger: &ReplicaLogger,
-    ) -> RoundSchedule {
-        RoundSchedule::apply_scheduling_strategy(
-            state,
+    fn build(self) -> RoundSchedule {
+        RoundSchedule::new(
             self.cores,
             self.heap_delta_rate_limit,
             FlagStatus::Enabled,
             self.install_code_rate_limit,
             FlagStatus::Enabled,
-            current_round,
-            ExecutionRound::new(u64::MAX / 2),
-            metrics,
-            logger,
         )
     }
 }
@@ -622,17 +588,14 @@ fn start_iteration_long_executions_first_cores() {
 /// `fully_executed_canisters`.
 #[test]
 fn start_iteration_first_iteration_fully_executed() {
-    let mut fixture = RoundScheduleFixture::new();
+    let round_schedule = RoundScheduleBuilder::new().with_cores(2).build();
+    let mut fixture = RoundScheduleFixture::with_round_schedule(round_schedule);
     let first_long = fixture.canister_with_long_execution();
     let first_new = fixture.canister_with_input();
     let second_long = fixture.canister_with_long_execution();
     let second_new = fixture.canister_with_input();
 
-    fixture.start_round(
-        ExecutionRound::new(1),
-        RoundScheduleBuilder::new().with_cores(2),
-    );
-    fixture.start_iteration_only(true);
+    fixture.start_iteration(true);
 
     assert!(fixture.fully_executed_canisters().contains(&first_long));
     assert!(fixture.fully_executed_canisters().contains(&first_new));
@@ -698,9 +661,7 @@ fn start_iteration_later_iteration_exclude_completed_long() {
 
     fixture.remove_long_execution(canister_a);
     fixture.push_input(canister_a);
-    let iter2 = fixture
-        .round_schedule
-        .start_iteration(&mut fixture.state, false);
+    let iter2 = fixture.start_iteration(false);
 
     assert!(
         !iter2.schedule.contains(&canister_a),
@@ -712,17 +673,16 @@ fn start_iteration_later_iteration_exclude_completed_long() {
 #[test]
 fn start_iteration_with_heap_delta_rate_limit() {
     let limit = ic_base_types::NumBytes::new(1000);
-    let mut fixture = RoundScheduleFixture::new();
+    let mut fixture = RoundScheduleFixture::with_round_schedule(
+        RoundScheduleBuilder::new()
+            .with_heap_delta_rate_limit(limit)
+            .build(),
+    );
     let canister_id = fixture.canister_with_input();
     fixture.add_heap_delta_debit(canister_id, limit);
 
     for is_first_iteration in [true, false] {
-        fixture.start_round(
-            ExecutionRound::new(1),
-            RoundScheduleBuilder::new().with_heap_delta_rate_limit(limit),
-        );
-
-        let iteration = fixture.start_iteration_only(is_first_iteration);
+        let iteration = fixture.start_iteration(is_first_iteration);
 
         // Canister is rate-limited so not in the iteration schedule.
         assert!(iteration.is_empty());
@@ -734,17 +694,16 @@ fn start_iteration_with_heap_delta_rate_limit() {
 #[test]
 fn start_iteration_with_install_code_rate_limit() {
     let limit = NumInstructions::new(1000);
-    let mut fixture = RoundScheduleFixture::new();
+    let round_schedule = RoundScheduleBuilder::new()
+        .with_install_code_rate_limit(limit)
+        .build();
+    let mut fixture = RoundScheduleFixture::with_round_schedule(round_schedule);
+
     let canister_id = fixture.canister_with_input();
     fixture.add_install_code_debit(canister_id, limit);
 
     for is_first_iteration in [true, false] {
-        fixture.start_round(
-            ExecutionRound::new(1),
-            RoundScheduleBuilder::new().with_install_code_rate_limit(limit),
-        );
-
-        let iteration = fixture.start_iteration_only(is_first_iteration);
+        let iteration = fixture.start_iteration(is_first_iteration);
 
         // Canister is rate-limited so not in the iteration schedule.
         assert!(iteration.is_empty());
@@ -758,18 +717,22 @@ fn start_iteration_with_install_code_rate_limit() {
 /// a full round). Later iterations in the same round must not charge it again.
 #[test]
 fn start_iteration_first_iteration_charges_rate_limited_canisters() {
-    let mut fixture = RoundScheduleFixture::new();
+    let heap_delta_limit = ic_base_types::NumBytes::new(1000);
+    let install_code_limit = NumInstructions::new(2000);
+    let round_schedule = RoundScheduleBuilder::new()
+        .with_heap_delta_rate_limit(heap_delta_limit)
+        .with_install_code_rate_limit(install_code_limit)
+        .build();
+    let mut fixture = RoundScheduleFixture::with_round_schedule(round_schedule);
 
     // A heap delta rate-limited canister with a non-trivial starting AP, so we can
     // verify the exact 100% decrement.
-    let heap_delta_limit = ic_base_types::NumBytes::new(1000);
     let heap_delta = fixture.canister_with_input();
     fixture.add_heap_delta_debit(heap_delta, heap_delta_limit);
     *fixture.canister_priority_mut(heap_delta) = priority(40);
 
     // An install code rate-limited canister with a non-trivial starting AP, so we
     // can verify the exact 100% decrement.
-    let install_code_limit = NumInstructions::new(2000);
     let install_code = fixture.canister_with_input();
     fixture.add_install_code_debit(install_code, install_code_limit);
     *fixture.canister_priority_mut(install_code) = priority(50);
@@ -778,15 +741,8 @@ fn start_iteration_first_iteration_charges_rate_limited_canisters() {
     let control = fixture.canister_with_input();
     *fixture.canister_priority_mut(control) = priority(60);
 
-    fixture.start_round(
-        ExecutionRound::new(1),
-        RoundScheduleBuilder::new()
-            .with_heap_delta_rate_limit(heap_delta_limit)
-            .with_install_code_rate_limit(install_code_limit),
-    );
-
     for is_first_iteration in [true, false] {
-        fixture.start_iteration_only(is_first_iteration);
+        fixture.start_iteration(is_first_iteration);
 
         assert!(fixture.rate_limited_canisters().contains(&heap_delta));
         assert!(fixture.rate_limited_canisters().contains(&install_code));
@@ -810,21 +766,44 @@ fn start_iteration_first_iteration_charges_rate_limited_canisters() {
     }
 }
 
+/// start_iteration drops idle canisters (no inputs or heap delta / install
+/// code debits) with 0-100 accumulated priority from the subnet schedule.
+#[test]
+fn start_iteration_idle_between_0_and_100_dropped_from_schedule() {
+    let mut fixture = RoundScheduleFixture::new();
+
+    // Simulate a bunch of idle canisters with varying AP.
+    let ap_minus_1 = fixture.canister();
+    *fixture.canister_priority_mut(ap_minus_1) = priority(-1);
+    let ap_0 = fixture.canister();
+    *fixture.canister_priority_mut(ap_0) = priority(0);
+    let ap_99 = fixture.canister();
+    *fixture.canister_priority_mut(ap_99) = priority(99);
+    let ap_101 = fixture.canister();
+    *fixture.canister_priority_mut(ap_101) = priority(101);
+
+    fixture.start_iteration(true);
+
+    // `start_iteration()` drops idle canisters with 0-100 AP.
+    assert!(!fixture.has_canister_priority(&ap_0));
+    assert!(!fixture.has_canister_priority(&ap_99));
+    // But retains canisters with AP < 0 and AP > 100.
+    assert_eq!(fixture.canister_priority(&ap_minus_1), &priority(-1));
+    assert_eq!(fixture.canister_priority(&ap_101), &priority(101));
+}
+
 #[test]
 #[should_panic]
 fn start_iteration_scheduler_compute_allocation_invariant_broken() {
-    let mut fixture = RoundScheduleFixture::new();
+    let round_schedule = RoundScheduleBuilder::new().with_cores(2).build();
+    let mut fixture = RoundScheduleFixture::with_round_schedule(round_schedule);
     let canister_id = fixture.canister_with_input();
     fixture
         .canister_state(&canister_id)
         .system_state
         .compute_allocation = ComputeAllocation::try_from(100).unwrap();
 
-    fixture.start_round(
-        ExecutionRound::new(1),
-        RoundScheduleBuilder::new().with_cores(2),
-    );
-    let iteration = fixture.start_iteration_only(true);
+    let iteration = fixture.start_iteration(true);
 
     // Without debug_assertions, the canister would be scheduled normally.
     assert_eq!(iteration.schedule.as_slice(), &[canister_id]);
@@ -881,8 +860,7 @@ fn end_iteration_sets_long_execution_start_round() {
     let mut fixture = RoundScheduleFixture::new();
     let canister_id = fixture.canister_with_input();
 
-    fixture.start_round(ExecutionRound::new(1), RoundScheduleBuilder::new());
-    fixture.start_iteration_only(true);
+    fixture.start_iteration(true);
 
     // Replace the input with a long execution.
     fixture.pop_input(canister_id);
@@ -1034,7 +1012,8 @@ fn advance_long_execution_preserves_long_execution_start_round() {
 /// finish_round).
 #[test]
 fn finish_round_fully_executed_get_executed_rounds_bumped() {
-    let mut fixture = RoundScheduleFixture::new();
+    let round_schedule = RoundScheduleBuilder::new().with_cores(2).build();
+    let mut fixture = RoundScheduleFixture::with_round_schedule(round_schedule);
 
     let long = fixture.canister_with_long_execution();
     let new = fixture.canister_with_input();
@@ -1045,10 +1024,8 @@ fn finish_round_fully_executed_get_executed_rounds_bumped() {
     const NEW_AP: AccumulatedPriority = AccumulatedPriority::new(110 * MULTIPLIER);
     fixture.canister_priority_mut(new).accumulated_priority = NEW_AP;
 
-    let current_round = ExecutionRound::new(1);
-    fixture.start_round(current_round, RoundScheduleBuilder::new().with_cores(2));
-
-    fixture.start_iteration_only(true);
+    fixture.current_round = ExecutionRound::new(1);
+    fixture.start_iteration(true);
     fixture.end_iteration(&btreeset! {long, new}, &btreeset! {new}, &btreeset! {});
     assert_eq!(fixture.fully_executed_canisters(), &btreeset! {long, new});
 
@@ -1058,7 +1035,10 @@ fn finish_round_fully_executed_get_executed_rounds_bumped() {
     let long_priority = fixture.canister_priority(&long);
     assert_eq!(long_priority.accumulated_priority, LONG_AP);
     assert_eq!(long_priority.executed_rounds, 2);
-    assert_eq!(long_priority.last_full_execution_round, current_round);
+    assert_eq!(
+        long_priority.last_full_execution_round,
+        fixture.current_round
+    );
 
     // New execution canister was charged 100 AP.
     let new_priority = fixture.canister_priority(&new);
@@ -1067,14 +1047,18 @@ fn finish_round_fully_executed_get_executed_rounds_bumped() {
         NEW_AP - ONE_HUNDRED_PERCENT
     );
     assert_eq!(new_priority.executed_rounds, 0);
-    assert_eq!(new_priority.last_full_execution_round, current_round);
+    assert_eq!(
+        new_priority.last_full_execution_round,
+        fixture.current_round
+    );
 }
 
 /// finish_round grants scheduled canisters their compute allocation and
 /// calls observe_round_scheduled() on metrics.
 #[test]
 fn finish_round_scheduled_get_compute_allocation_and_metrics() {
-    let mut fixture = RoundScheduleFixture::new();
+    let round_schedule = RoundScheduleBuilder::new().with_cores(2).build();
+    let mut fixture = RoundScheduleFixture::with_round_schedule(round_schedule);
     // Add three canisters so the one we check is not in the first two (not fully
     // executed), so it does not get executed_rounds bumped, which would reduce its
     // accumulated priority.
@@ -1090,10 +1074,7 @@ fn finish_round_scheduled_get_compute_allocation_and_metrics() {
     let canister_b = canister_with_compute_allocation(20);
     let canister_c = canister_with_compute_allocation(10);
 
-    let current_round = ExecutionRound::new(1);
-    fixture.start_round(current_round, RoundScheduleBuilder::new().with_cores(2));
-
-    fixture.start_iteration_only(true);
+    fixture.start_iteration(true);
     let all = btreeset! {canister_a, canister_b, canister_c};
     fixture.end_iteration(&all, &all, &btreeset! {});
     assert_eq!(
@@ -1157,7 +1138,7 @@ fn finish_round_charge_first_slice_of_new_long_execution() {
         .canister_priority_mut(canister_id)
         .accumulated_priority = INITIAL_AP;
 
-    fixture.start_iteration_only(true);
+    fixture.start_iteration(true);
 
     // Consume the input, replacing it with a long execution.
     fixture.pop_input(canister_id);
@@ -1209,7 +1190,7 @@ fn finish_round_in_flight_long_execution_no_charge() {
     const INITIAL_AP: AccumulatedPriority = AccumulatedPriority::new(50 * MULTIPLIER);
     priority.accumulated_priority = INITIAL_AP;
 
-    fixture.start_iteration_only(true);
+    fixture.start_iteration(true);
     fixture.end_iteration(&btreeset! {canister_id}, &btreeset! {}, &btreeset! {});
 
     fixture.finish_round();
@@ -1258,6 +1239,39 @@ fn finish_round_charges_for_executed_rounds() {
     );
 }
 
+/// finish_round burns down to zero the positive AP of idle canisters (no inputs
+/// or heap delta / install code debits).
+#[test]
+fn finish_round_burns_down_idle_canister_accumulated_priority() {
+    let mut fixture = RoundScheduleFixture::new();
+    fixture.start_iteration(true);
+    fixture.end_iteration(&btreeset! {}, &btreeset! {}, &btreeset! {});
+
+    // A bunch of idle canisters with varying AP.
+    let ap_minus_1 = fixture.canister();
+    *fixture.canister_priority_mut(ap_minus_1) = priority(-1);
+    let ap_0 = fixture.canister();
+    *fixture.canister_priority_mut(ap_0) = priority(0);
+    let ap_99 = fixture.canister();
+    *fixture.canister_priority_mut(ap_99) = priority(99);
+    let ap_101 = fixture.canister();
+    *fixture.canister_priority_mut(ap_101) = priority(101);
+
+    fixture.finish_round();
+
+    // Nothing changes for canisters with AP <= 0.
+    assert_eq!(fixture.canister_priority(&ap_minus_1), &priority(-1));
+    assert!(
+        fixture.has_canister_priority(&ap_0) && fixture.canister_priority(&ap_0) == &priority(0)
+    );
+    // Canisters with 0 < AP < 100 have their AP burned down to 0.
+    assert!(
+        fixture.has_canister_priority(&ap_99) && fixture.canister_priority(&ap_99) == &priority(0)
+    );
+    // Canisters with AP >= 100 have 100 AP burned.
+    assert_eq!(fixture.canister_priority(&ap_101), &priority(1));
+}
+
 /// finish_round applies an exponential decay to AP values outside the
 /// `[AP_ROUNDS_MIN, AP_ROUNDS_MAX]` window, in both directions; values inside
 /// the window are left untouched.
@@ -1292,18 +1306,26 @@ fn finish_round_exponential_decay() {
     let mut fixture = RoundScheduleFixture::new();
 
     // A canister below AP_MIN.
-    let below_min_canister = fixture.canister();
+    let below_min_canister = fixture.canister_with_input();
     *fixture.canister_priority_mut(below_min_canister) = priority(LOW_AP_PERCENT);
     // 4 canisters above AP_MAX. With only one, the post-decay sum would be negative
     // (HIGH_DECAYED_PERCENT < |LOW_DECAYED_PERCENT|) and the free-compute
     // distribution would adjust the AP of `below_min_canister`.
     let above_max_canisters: Vec<_> = (0..4)
         .map(|_| {
-            let id = fixture.canister();
+            let id = fixture.canister_with_input();
             *fixture.canister_priority_mut(id) = priority(HIGH_AP_PERCENT);
             id
         })
         .collect();
+
+    // Record all canisters as scheduled, so they don't get treated as idle (and
+    // have 100 AP burned down).
+    fixture.round_schedule.scheduled_canisters = above_max_canisters.iter().cloned().collect();
+    fixture
+        .round_schedule
+        .scheduled_canisters
+        .insert(below_min_canister);
 
     fixture.finish_round();
 
@@ -1340,6 +1362,9 @@ fn check_finish_round_free_compute_grants(executed_rounds: i64, expected_aps: [i
         fixture.set_compute_allocation(id, COMPUTE_ALLOCATIONS[i]);
         // Add the canister to the subnet schedule with default (0) priority.
         fixture.canister_priority_mut(id);
+        // Mark the canister as scheduled, so it doesn't get treated as idle (and has
+        // 100 AP burned down).
+        fixture.round_schedule.scheduled_canisters.insert(id);
         id
     });
 
@@ -1454,22 +1479,25 @@ fn finish_round_grant_heap_delta_and_install_code_credits() {
             .get_sample_sum(),
         200.0
     );
+
+    // The next round / iteration drops `canister_b` from the schedule.
+    fixture.start_iteration(true);
+    assert!(fixture.has_canister_priority(&canister_a));
+    assert!(!fixture.has_canister_priority(&canister_b));
 }
 
 /// After `finish_round`, a canister with a pending heartbeat task receives
 /// the same accumulated priority as a canister with a pending input.
 #[test]
 fn finish_round_heartbeat_treated_same_as_input() {
-    let mut fixture = RoundScheduleFixture::new();
-    let current_round = ExecutionRound::new(1);
+    let round_schedule = RoundScheduleBuilder::new().with_cores(2).build();
+    let mut fixture = RoundScheduleFixture::with_round_schedule(round_schedule);
 
     let canister_a = fixture.canister_with_input();
     let canister_b = fixture.canister_with_input();
     fixture.set_heartbeat_export(canister_b);
 
-    fixture.start_round(current_round, RoundScheduleBuilder::new().with_cores(2));
-
-    fixture.start_iteration_only(true);
+    fixture.start_iteration(true);
     fixture.pop_input(canister_a);
     fixture.pop_input(canister_b);
     fixture.end_iteration(
@@ -1767,6 +1795,10 @@ prop_compose! {
 ///
 /// Only does one iteration per round. And one message or slice per canister.
 /// But this is sufficient to approximate the full range of scheduler behavior.
+///
+/// `debug_canister_idx` is a mechanism that enables verbose debugging output
+/// for a specific canister and for the scheduler state as a whole every round.
+/// Set to `Some(canister_idx)` to enable debug output.
 fn run_multi_round_simulation(
     scheduler_cores: usize,
     num_rounds: usize,
@@ -1827,16 +1859,14 @@ fn run_multi_round_simulation(
         }
 
         // --- Start round ---
-        let current_round = ExecutionRound::new(round as u64);
-        fixture.start_round(
-            current_round,
-            RoundScheduleBuilder::new()
-                .with_cores(scheduler_cores)
-                .with_heap_delta_rate_limit(HEAP_DELTA_RATE_LIMIT),
-        );
+        fixture.round_schedule = RoundScheduleBuilder::new()
+            .with_cores(scheduler_cores)
+            .with_heap_delta_rate_limit(HEAP_DELTA_RATE_LIMIT)
+            .build();
+        fixture.current_round = ExecutionRound::new(round as u64);
 
         // --- start_iteration ---
-        let iteration = fixture.start_iteration_only(true);
+        let iteration = fixture.start_iteration(true);
 
         // --- Simulate core assignment and execution ---
         let core_schedules = fixture.partition_to_cores(&iteration);
@@ -1959,6 +1989,24 @@ fn run_multi_round_simulation(
         }
     }
 
+    if debug_canister_idx.is_some() {
+        println!(
+            "executed rounds: {:?}",
+            sims.iter().map(|s| s.full_rounds).collect::<Vec<_>>()
+        );
+        println!(
+            "canister priorities: {:?}",
+            sims.iter()
+                .map(|sim| fixture
+                    .state
+                    .canister_priority(&sim.canister_id)
+                    .accumulated_priority
+                    .get()
+                    / MULTIPLIER)
+                .collect::<Vec<_>>()
+        );
+    }
+
     (fixture.state, sims)
 }
 
@@ -1969,23 +2017,8 @@ fn assert_multi_round_invariants(
     scheduler_cores: usize,
     num_rounds: usize,
     total_compute_allocation: usize,
-    expected_efficiency_percent: usize,
+    expected_long_execution_efficiency_percent: usize,
 ) -> Result<(), TestCaseError> {
-    println!(
-        "executed rounds: {:?}",
-        sims.iter().map(|s| s.full_rounds).collect::<Vec<_>>()
-    );
-    println!(
-        "canister priorities: {:?}",
-        sims.iter()
-            .map(|sim| state
-                .canister_priority(&sim.canister_id)
-                .accumulated_priority
-                .get()
-                / MULTIPLIER)
-            .collect::<Vec<_>>()
-    );
-
     // The sum of accumulated priorities should be zero (or slightly positive, in
     // case e.g. we just distributed compute allocation after not having executed
     // anything this round).
@@ -2039,7 +2072,11 @@ fn assert_multi_round_invariants(
                 .archetype
                 .expected_full_rounds(num_rounds, free_compute_per_canister);
 
-            expected_rounds = expected_rounds * expected_efficiency_percent / 100;
+            if sim.archetype.has_long_execution {
+                expected_rounds =
+                    expected_rounds * expected_long_execution_efficiency_percent / 100;
+            }
+
             prop_assert!(
                 executed_rounds + credit_rounds + 1 >= expected_rounds,
                 "canister {i}: executed_rounds {executed_rounds} + credit_rounds {credit_rounds} < expected_rounds {expected_rounds}"
@@ -2067,18 +2104,19 @@ fn multi_round_priority_invariants(
     let (state, sims) =
         run_multi_round_simulation(scheduler_cores, num_rounds, &archetype_configs, None);
 
-    // Expect 80%+ efficient scheduling with a mix of long and short executions.
+    // Expect 90%+ efficient scheduling of long executions.
     //
-    // This is due to idle canisters consuming free compute on rounds where not all
-    // cores are busy, reducing free compute available to active canisters.
-    let expected_efficiency_percent = 80;
+    // Because long executions are prioritized for throughput (in-progress ones get
+    // prioritized over new ones); and due to AP exponential decay; long executions
+    // are scheduled less efficiently.
+    let expected_long_execution_efficiency_percent = 90;
     assert_multi_round_invariants(
         &state,
         &sims,
         scheduler_cores,
         num_rounds,
         total_compute_allocation,
-        expected_efficiency_percent,
+        expected_long_execution_efficiency_percent,
     )?;
 }
 
@@ -2114,14 +2152,14 @@ fn multi_round_all_active_short_executions(
     let (state, sims) =
         run_multi_round_simulation(scheduler_cores, num_rounds, &archetype_configs, None);
 
-    // Expect 100% efficient scheduling with short executions only.
-    let expected_efficiency_percent = 100;
+    // No-op, we already expect 100% efficient scheduling of short executions.
+    let expected_long_execution_efficiency_percent = 100;
     assert_multi_round_invariants(
         &state,
         &sims,
         scheduler_cores,
         num_rounds,
         total_compute_allocation as usize,
-        expected_efficiency_percent,
+        expected_long_execution_efficiency_percent,
     )?;
 }

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -8,9 +8,7 @@ use ic_replicated_state::metrics::{
 };
 use ic_types::ingress::{IngressState, IngressStatus};
 use ic_types::{PrincipalId, Time};
-use prometheus::{
-    Gauge, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge,
-};
+use prometheus::{Gauge, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec};
 use std::collections::BTreeMap;
 
 pub(crate) const CANISTER_INVARIANT_BROKEN: &str = "scheduler_canister_invariant_broken";
@@ -42,7 +40,6 @@ pub struct SchedulerMetrics {
     pub(super) round_postponed_raw_rand_queue: ScopedMetrics,
     pub(super) round_inner_subnet_queue: ScopedMetrics,
     pub(super) round_advance_long_install_code: ScopedMetrics,
-    pub(super) round_scheduling_duration: Histogram,
     pub(super) round_update_signature_request_contexts_duration: Histogram,
     pub(super) round_inner: ScopedMetrics,
     pub(super) round_inner_heartbeat_overhead_duration: Histogram,
@@ -65,7 +62,6 @@ pub struct SchedulerMetrics {
     pub(super) subnet_memory_usage_invariant: IntCounter,
     pub(super) scheduler_compute_allocation_invariant_broken: IntCounter,
     pub(super) scheduler_cores_invariant_broken: IntCounter,
-    pub(super) scheduler_accumulated_priority_invariant: IntGauge,
     pub(super) scheduler_accumulated_priority_deviation: Gauge,
     pub(super) inducted_messages: IntCounterVec,
     pub(super) delivered_pre_signatures: HistogramVec,
@@ -91,7 +87,7 @@ impl SchedulerMetrics {
             ),
             compute_utilization_per_core: metrics_registry.histogram(
                 "scheduler_compute_utilization_per_core",
-                "The Internet Computer's compute utilization as a percent per cpu core.",
+                "The Internet Computer's compute utilization per CPU core as a 0.0-1.0 fraction.",
                 linear_buckets(0.0, 0.05, 21),
             ),
             msg_execution_duration: duration_histogram(
@@ -220,7 +216,6 @@ impl SchedulerMetrics {
                 slices: round_phase_slices_histogram("long install", metrics_registry),
                 messages: round_phase_messages_histogram("long install", metrics_registry),
             },
-            round_scheduling_duration: round_phase_duration_histogram("scheduling", metrics_registry),
             round_update_signature_request_contexts_duration: round_phase_duration_histogram("threshold sign", metrics_registry),
             // `inner_round()` processing.
             round_inner: ScopedMetrics {
@@ -316,10 +311,6 @@ impl SchedulerMetrics {
             subnet_memory_usage_invariant: metrics_registry.error_counter(SUBNET_MEMORY_USAGE_INVARIANT_BROKEN),
             scheduler_compute_allocation_invariant_broken: metrics_registry.error_counter(SCHEDULER_COMPUTE_ALLOCATION_INVARIANT_BROKEN),
             scheduler_cores_invariant_broken: metrics_registry.error_counter(SCHEDULER_CORES_INVARIANT_BROKEN),
-            scheduler_accumulated_priority_invariant: metrics_registry.int_gauge(
-                "scheduler_accumulated_priority_invariant",
-                "The sum of all accumulated priorities on the subnet."
-            ),
             scheduler_accumulated_priority_deviation: metrics_registry.gauge(
                 "scheduler_accumulated_priority_deviation",
                 "The standard deviation of accumulated priorities on the subnet."

--- a/rs/execution_environment/src/scheduler/tests/limits.rs
+++ b/rs/execution_environment/src/scheduler/tests/limits.rs
@@ -271,7 +271,7 @@ fn dont_execute_any_canisters_if_not_enough_instructions_in_round() {
         let system_state = &canister_state.system_state;
         assert_eq!(system_state.queues().ingress_queue_size(), 1);
         assert!(!test.was_fully_executed(canister_state.canister_id()));
-        assert_eq!(system_state.canister_metrics().rounds_scheduled(), 1);
+        assert_eq!(system_state.canister_metrics().rounds_scheduled(), 0);
         assert_eq!(system_state.canister_metrics().executed(), 0);
         assert_eq!(
             system_state

--- a/rs/execution_environment/src/scheduler/tests/metrics.rs
+++ b/rs/execution_environment/src/scheduler/tests/metrics.rs
@@ -188,7 +188,6 @@ fn can_record_metrics_for_a_round() {
     assert_eq!(metrics.canister_age.get_sample_sum() as i64, 0);
     assert_eq!(metrics.round_preparation_duration.get_sample_count(), 1);
     assert_eq!(metrics.round_preparation_ingress.get_sample_count(), 1);
-    assert_eq!(metrics.round_scheduling_duration.get_sample_count(), 1);
     assert_eq!(metrics.round_finalization_scheduling.get_sample_count(), 1);
     assert_eq!(
         metrics.round_inner_iteration_scheduling.get_sample_count(),

--- a/rs/execution_environment/src/scheduler/tests/scheduling.rs
+++ b/rs/execution_environment/src/scheduler/tests/scheduling.rs
@@ -4,11 +4,9 @@ use super::test_utilities::{
     SchedulerTest, SchedulerTestBuilder, ingress, instructions, on_response, other_side,
 };
 use super::*;
-use ic_config::subnet_config::{SchedulerConfig, SubnetConfig};
-use ic_registry_subnet_type::SubnetType;
+use ic_config::subnet_config::SchedulerConfig;
 use ic_replicated_state::testing::CanisterQueuesTesting;
 use ic_types::ComputeAllocation;
-use ic_types::ingress::IngressStatus;
 use ic_types::methods::SystemMethod;
 use ic_types_cycles::Cycles;
 use more_asserts::{assert_ge, assert_gt, assert_le};
@@ -180,10 +178,10 @@ fn execute_idle_and_canisters_with_messages() {
 
     test.execute_round(ExecutionRoundType::OrdinaryRound);
 
-    // We update `last_full_execution_round` for the canister without any
+    // We do not update `last_full_execution_round` for the canister without any
     // input messages.
-    assert!(test.was_fully_executed(idle));
-    // But not its counts of rounds scheduled or executed.
+    assert!(!test.was_fully_executed(idle));
+    // Nor its counts of rounds scheduled or executed.
     let idle = test.canister_state(idle);
     assert_eq!(idle.system_state.canister_metrics().rounds_scheduled(), 0);
     assert_eq!(idle.system_state.canister_metrics().executed(), 0);
@@ -732,7 +730,7 @@ fn scheduler_respects_compute_allocation(
     let (
         mut test,
         scheduler_cores,
-        _messages_per_canister,
+        messages_per_canister,
         _instructions_per_round,
         _instructions_per_message,
     ) = test;
@@ -745,10 +743,10 @@ fn scheduler_respects_compute_allocation(
     // to be executed by a thread.
     let mut scheduled_first_counters = HashMap::<CanisterId, usize>::new();
 
-    // Because we may be left with as little free compute capacity as 1, run for
+    // Because we may be left with as little free compute capacity as 100, run for
     // enough rounds that every canister gets a chance to be scheduled at least once
-    // for free, i.e. `100 * number_of_canisters` rounds.
-    let number_of_rounds = 100 * number_of_canisters;
+    // for free, i.e. `number_of_canisters` rounds.
+    let number_of_rounds = number_of_canisters;
 
     let canister_ids: Vec<_> = test.state().canister_states().keys().cloned().collect();
 
@@ -781,7 +779,7 @@ fn scheduler_respects_compute_allocation(
         };
 
         prop_assert!(
-            *count >= expected_count,
+            *count >= std::cmp::min(expected_count, messages_per_canister),
             "Canister {} (allocation {}) should have been scheduled \
                     {} out of {} rounds, was scheduled only {} rounds instead.",
             canister_id,
@@ -791,106 +789,6 @@ fn scheduler_respects_compute_allocation(
             *count
         );
     }
-}
-
-#[test]
-fn scheduler_resets_accumulated_priorities() {
-    /// Create `scheduler_cores * 2` canisters with 2 messages each and execute 2 rounds.
-    /// Return number of executed second ingress messages.
-    fn executed_messages_after_two_rounds(scheduler_cores: usize, reset_interval: u64) -> usize {
-        /// Count the number of executed ingress messages.
-        fn executed_messages(test: &SchedulerTest, ingress_ids: &[MessageId]) -> usize {
-            ingress_ids
-                .iter()
-                .filter_map(|ingress_id| match test.ingress_status(ingress_id) {
-                    IngressStatus::Known {
-                        // There is no response, so messages are in the failed state
-                        state: IngressState::Failed(_),
-                        ..
-                    } => Some(()),
-                    _ => None,
-                })
-                .count()
-        }
-
-        // There must twice more canisters than the scheduler cores
-        let num_canisters = scheduler_cores * 2;
-
-        let subnet_config = SubnetConfig::new(SubnetType::Application);
-        let mut test = SchedulerTestBuilder::new()
-            .with_scheduler_config(SchedulerConfig {
-                scheduler_cores,
-                // Increase the overhead to execute just one message per round per core
-                instruction_overhead_per_execution: subnet_config
-                    .scheduler_config
-                    .max_instructions_per_round,
-                // Reset accumulated priority every second round
-                accumulated_priority_reset_interval: reset_interval.into(),
-                ..subnet_config.scheduler_config
-            })
-            .build();
-
-        // Create canisters with 2 messages each
-        let mut canister_ids = Vec::with_capacity(num_canisters);
-        let mut first_ingress_ids = Vec::with_capacity(num_canisters);
-        let mut second_ingress_ids = Vec::with_capacity(num_canisters);
-        for _ in 0..num_canisters {
-            let canister_id = test.create_canister();
-            canister_ids.push(canister_id);
-            first_ingress_ids.push(test.send_ingress(canister_id, ingress(5)));
-            second_ingress_ids.push(test.send_ingress(canister_id, ingress(5)));
-        }
-
-        // Execute the first round. Only first `scheduler_cores` messages
-        // must be executed (marked as `E`):
-        // Canister ID:        0 1 2 3 (scheduler_cores * 2)
-        // 1st message states: E E . .
-        // 2nd message states: . . . .
-        test.execute_round(ExecutionRoundType::OrdinaryRound);
-        // After the first round, only the first `scheduler_cores` messages will be executed
-        assert_eq!(
-            scheduler_cores,
-            executed_messages(&test, &first_ingress_ids)
-        );
-        assert_eq!(0, executed_messages(&test, &second_ingress_ids));
-
-        // Execute the second round
-        test.execute_round(ExecutionRoundType::OrdinaryRound);
-        // Return number of executed second ingress messages
-        executed_messages(&test, &second_ingress_ids)
-    }
-
-    // Note: the DTS scheduler requires at least 2 scheduler cores
-    let scheduler_cores = 2;
-
-    // When there is no reset round, canisters with the same compute allocation
-    // get scheduled fairly, one by one:
-    //
-    // 1. After the first round, some two canisters will be executed.
-    // 2. After the second round, the other two canisters will be executed.
-    //
-    // After two rounds, all canisters will be executed once (marked as `E`):
-    //
-    //     Canister ID:        0 1 2 3 (scheduler_cores * 2)
-    //     1st message states: E E E E
-    //     2nd message states: . . . . <-- num_executed_second_messages == 0
-    let num_executed_second_messages = executed_messages_after_two_rounds(scheduler_cores, 100);
-    assert_eq!(0, num_executed_second_messages);
-
-    // When the accumulated priorities get reset every round, accumulated priority
-    // becomes irrelevant. Scheduler will be trying to execute every round
-    // the same two canisters:
-    //
-    // 1. After the first round, some two canister will be executed.
-    // 2. After the second round, the same two canisters will be executed.
-    //
-    // After two rounds, two canisters will be executed twice (marked as `E`):
-    //
-    //     Canister ID:        0 1 2 3 (scheduler_cores * 2)
-    //     1st message states: E E . .
-    //     2nd message states: E E . . <-- num_executed_second_messages == scheduler_cores
-    let num_executed_second_messages = executed_messages_after_two_rounds(scheduler_cores, 1);
-    assert_eq!(scheduler_cores, num_executed_second_messages);
 }
 
 #[test]
@@ -1103,67 +1001,6 @@ fn charge_canisters_for_full_execution(#[strategy(2..10_usize)] scheduler_cores:
     prop_assert_eq!(total_accumulated_priority, 0);
 }
 
-#[test]
-fn charge_idle_canisters_for_full_execution_round() {
-    let scheduler_cores = 2;
-    let num_rounds = 100;
-    let slice = 20;
-    let mut test = SchedulerTestBuilder::new()
-        .with_scheduler_config(SchedulerConfig {
-            scheduler_cores,
-            max_instructions_per_round: slice.into(),
-            max_instructions_per_message: slice.into(),
-            max_instructions_per_slice: slice.into(),
-            max_instructions_per_install_code_slice: slice.into(),
-            ..zero_instruction_overhead_config()
-        })
-        .build();
-
-    // Bump up the round number.
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
-
-    // Create many idle canisters.
-    for _ in 0..scheduler_cores * 2 {
-        test.create_canister();
-    }
-
-    // Create many busy canisters.
-    for _ in 0..scheduler_cores * 2 {
-        let canister_id = test.create_canister();
-        for _ in 0..num_rounds {
-            test.send_ingress(canister_id, ingress(slice));
-        }
-    }
-
-    for round in 0..num_rounds {
-        test.execute_round(ExecutionRoundType::OrdinaryRound);
-
-        for canister in test.state().canisters_iter() {
-            // Assert that we punished all idle canisters, not just top `scheduler_cores`.
-            if round == 0 && !canister.has_input() {
-                assert_ne!(test.last_round(), 0.into());
-                assert_eq!(
-                    test.state()
-                        .canister_priority(&canister.canister_id())
-                        .last_full_execution_round,
-                    test.last_round()
-                );
-            }
-        }
-        let mut total_accumulated_priority = 0;
-        for (_, canister_priority) in test.state().metadata.subnet_schedule.iter() {
-            // Assert there is no divergency in accumulated priorities.
-            let priority = canister_priority.accumulated_priority;
-            assert_le!(priority.get(), 100 * MULTIPLIER);
-            assert_ge!(priority.get(), -100 * MULTIPLIER);
-
-            total_accumulated_priority += canister_priority.accumulated_priority.get();
-        }
-        // The accumulated priority invariant should be respected.
-        assert_eq!(total_accumulated_priority, 0);
-    }
-}
-
 /// Canisters with inputs but without enough cycles to execute them do get
 /// categorized as "fully executed" when their inputs are consumed, even though
 /// they didn't actually execute any message.
@@ -1245,9 +1082,9 @@ fn frozen_canisters_are_fully_executed() {
 }
 
 /// Canisters with heartbeats or timers but without enough cycles to execute them
-/// do not get executed, but are charged as idle.
+/// do not get scheduled.
 #[test]
-fn frozen_canisters_with_heartbeats_or_timers_are_charged_as_idle() {
+fn frozen_canisters_with_heartbeats_or_timers_are_not_scheduled() {
     let scheduler_cores = 2;
     let canisters_per_core = 2;
     let slice = 100;
@@ -1308,11 +1145,15 @@ fn frozen_canisters_with_heartbeats_or_timers_are_charged_as_idle() {
         0
     );
 
-    // But all canisters were marked as fully executed, because they were idle.
-    for (i, canister) in canisters.iter().enumerate() {
-        assert!(
-            test.was_fully_executed(*canister),
-            "Canister {i} should have been charged as idle",
+    // Or scheduled.
+    assert_eq!(test.state().metadata.subnet_schedule.len(), 0);
+    for canister in canisters.iter() {
+        assert_eq!(
+            test.canister_state(*canister)
+                .system_state
+                .canister_metrics()
+                .rounds_scheduled(),
+            0
         );
     }
 }

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -275,6 +275,20 @@ impl CanisterState {
         self.system_state.queues().has_output()
     }
 
+    /// Returns true if the canister must be present in the `SubnetSchedule`,
+    /// regardless of new inputs or accumulated priority.
+    ///
+    /// This is different from "should be scheduled in an iteration", which also
+    /// considers whether the canister has inputs / tasks or non-zero AP / priority
+    /// credit. It is strictly about ensuring that canisters are retained in the
+    /// subnet schedule for as long as they have long-running executions or heap
+    /// delta or install code debits.
+    pub fn must_be_in_schedule(&self) -> bool {
+        self.scheduler_state.heap_delta_debit.get() > 0
+            || self.scheduler_state.install_code_debit.get() > 0
+            || self.has_long_execution_or_install_code()
+    }
+
     /// See `SystemState::push_output_request` for documentation.
     pub fn push_output_request(
         &mut self,

--- a/rs/replicated_state/src/metadata_state/subnet_schedule.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_schedule.rs
@@ -42,6 +42,14 @@ impl CanisterPriority {
         long_execution_start_round: None,
         last_full_execution_round: ExecutionRound::new(0),
     };
+
+    /// Returns true if the canister has non-zero accumulated priority or is in a
+    /// long execution.
+    pub fn is_non_zero(&self) -> bool {
+        self.accumulated_priority.get() != 0
+            || self.executed_rounds != 0
+            || self.long_execution_start_round.is_some()
+    }
 }
 
 impl Default for CanisterPriority {

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -607,11 +607,15 @@ impl ReplicatedState {
     /// cleaned up.
     pub fn put_canister_state<CS: Into<Arc<CanisterState>>>(&mut self, canister_state: CS) {
         let canister_state = canister_state.into();
-        // Also insert a scheduling priority for the canister. This is a temporary
-        // measure to ensure that every canister has an explicit priority.
-        self.metadata
-            .subnet_schedule
-            .get_mut(canister_state.canister_id());
+
+        // Add the canister to the subnet schedule if it has install code or heap delta
+        // debits or is in a long-running execution.
+        if canister_state.must_be_in_schedule() {
+            self.metadata
+                .subnet_schedule
+                .get_mut(canister_state.canister_id());
+        }
+
         self.canister_states
             .insert(canister_state.canister_id(), canister_state);
     }
@@ -737,12 +741,19 @@ impl ReplicatedState {
             .collect()
     }
 
-    /// Prunes all canister priorities for which a corresponding canister state no
-    /// longer exists.
+    /// Prunes the canister priorities of deleted canisters; and those that have
+    /// all-zero accumulated priority, priority credit, heap delta and install code
+    /// debits, and do not have a long-running execution.
     pub fn garbage_collect_subnet_schedule(&mut self) {
         self.metadata
             .subnet_schedule
-            .retain(|canister_id, _| self.canister_states.contains_key(canister_id));
+            .retain(|canister_id, priority| {
+                self.canister_states
+                    .get(canister_id)
+                    .is_some_and(|canister| {
+                        priority.is_non_zero() || canister.must_be_in_schedule()
+                    })
+            });
     }
 
     pub fn system_metadata(&self) -> &SystemMetadata {

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -1246,8 +1246,9 @@ fn split() {
     expected.put_canister_state(canister_state);
     // And the split marker should be reset.
     expected.metadata.split_from = None;
-    // The canister priority for `CANISTER_1` is gone, as it was not persisted.
-    expected.metadata.subnet_schedule.remove(&CANISTER_1);
+    // The canister priority for `CANISTER_2` is replaced with the default, as it
+    // was not persisted.
+    expected.metadata.subnet_schedule.get_mut(CANISTER_2);
     // Everything else should be the same as in phase 1.
     assert_eq!(expected, state_b);
 }
@@ -1352,6 +1353,8 @@ fn online_split() {
                     CanisterCyclesCostSchedule::Normal,
                 ),
             });
+        // Canister must be in the subnet schedule.
+        fixture.state.canister_priority_mut(canister_id);
     };
     add_aborted_install_code_task(CANISTER_1);
     add_aborted_install_code_task(CANISTER_2);


### PR DESCRIPTION
Only schedule active canisters instead of all canisters. This needs to be done on every scheduler loop iteration (as opposed to once per round followed by filtering per iteration), to account for canisters going idle / becoming active from one iteration to the next. But scheduling priorities continue to be updated only once, at the end of the round.

The sequence of `RoundScheduler` calls goes from:

```
apply_scheduling_strategy()  // Produce the actual schedule
loop {
    charge_idle_canisters()
    start_iteration()        // Filter for active canisters
    // Execute
    end_iteration()          // Update stats (fully executed, etc.)
}
finish_round()               // Update scheduling priorities
```

to a simplified:

```
new()                        // Basic constructor
loop {
    start_iteration()        // Prune SubnetSchedule, produce the actual schedule
    // Execute
    end_iteration()          // Update stats (fully executed, etc.)
}
finish_round()               // Update scheduling priorities
```

`SubnetSchedule` no longer holds a `CanisterPriority` entry for every canister on the subnet. It only holds entries for:
 * active canisters (that have inputs),
 * long execution canisters,
 * heap delta or install code rate limited canisters (while their respective debits are consumed) and
 * idle canisters with accumulated priorities (AP) outside the `[0, 100]` range (because we want to "recall" that a canister was scheduled too much/too little even after it has been idle for a few rounds).

Idle canisters with negative AP accumulate priority same as active canisters, until they reach zero; and idle canisters with > 100 AP are charged as "fully executed" every round (they do end the round with no inputs) until their AP is burned down to zero. Idle canisters with `[0, 100]` AP are pruned from the `SubnetSchedule` at the beginning of the next round, in `start_iteration()`, once we know for sure that they are still idle. As a result, there is no more need to charge truly idle canisters every round.

Finally, because we were already enforcing soft upper and lower AP bounds via exponential decay outside the `[-2000, 500]` range, there is no need to periodically reset AP, so that logic was dropped.