### PR TITLE
chore(CI): don't notify teams on slack if the PR targets ai feature branch

### DIFF
--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -10,6 +10,8 @@ jobs:
   notify-slack:
     name: Notify Slack
     runs-on: ubuntu-latest
+    # TODO: Remove this when we no longer have a feature branch
+    if: github.event.pull_request.base.ref != 'feat-ai-on-engines'
     steps:
       # Sanitize PR title for Slack (<, >, &)
       - name: Sanitize PR title


### PR DESCRIPTION
Just to reduce the noise on slack for non actionable branches.