### PR TITLE
fix(systest): broader allowed panic sources in system tests

### DIFF
--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -719,8 +719,9 @@ impl SystemTestGroup {
                     BTreeSet::from([
                         // Canisters are expected to panic:
                         "canister".to_string(),
-                        // TODO: remove the following line after mainnet has advanced to include the `allowed_panics.rs` changes:
-                        "rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs".to_string(),
+                        // TODO: remove the following two lines after mainnet has advanced to include the `allowed_panics.rs` changes:
+                        "rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs:2185".to_string(),
+                        "rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs:1030".to_string(),
                         "rs/canister_sandbox/src/replica_controller/allowed_panics.rs".to_string(),
                         "rs/state_manager/src/allowed_panics.rs".to_string(),
                     ]),

--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -720,7 +720,7 @@ impl SystemTestGroup {
                         // Canisters are expected to panic:
                         "canister".to_string(),
                         // TODO: remove the following line after mainnet has advanced to include the `allowed_panics.rs` changes:
-                        "rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs:2185".to_string(),
+                        "rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs".to_string(),
                         "rs/canister_sandbox/src/replica_controller/allowed_panics.rs".to_string(),
                         "rs/state_manager/src/allowed_panics.rs".to_string(),
                     ]),


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/10041 added a new allowed panic pattern but did not add its original location in `sandboxed_execution_controller.rs` to the allowed pattern, flaking tests using mainnet versions.