### PR TITLE
chore(Ledgers): DEFI-2803: Update ICRC-21 URLs

### DIFF
--- a/packages/icrc-ledger-types/src/icrc21/mod.rs
+++ b/packages/icrc-ledger-types/src/icrc21/mod.rs
@@ -1,4 +1,4 @@
-//! The [ICRC-21](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/ICRC-21/icrc_21_consent_msg.md)
+//! The [ICRC-21](https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md)
 //! Canister Call Consent Messages standard.
 
 pub mod errors;

--- a/rs/ledger_suite/icp/ledger/src/main.rs
+++ b/rs/ledger_suite/icp/ledger/src/main.rs
@@ -466,12 +466,10 @@ fn icrc1_supported_standards() -> Vec<StandardRecord> {
             url: "https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-2".to_string(),
         });
     }
-    standards.push(
-        StandardRecord {
-            name: "ICRC-21".to_string(),
-            url: "https://github.com/dfinity/wg-identity-authentication/blob/main/topics/ICRC-21/icrc_21_consent_msg.md".to_string(),
-        }
-    );
+    standards.push(StandardRecord {
+        name: "ICRC-21".to_string(),
+        url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md".to_string(),
+    });
     standards.push(StandardRecord {
         name: "ICRC-10".to_string(),
         url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-10/ICRC-10.md".to_string(),

--- a/rs/ledger_suite/icrc1/ledger/src/main.rs
+++ b/rs/ledger_suite/icrc1/ledger/src/main.rs
@@ -770,7 +770,7 @@ fn supported_standards() -> Vec<StandardRecord> {
         },
         StandardRecord {
             name: "ICRC-21".to_string(),
-            url: "https://github.com/dfinity/wg-identity-authentication/blob/main/topics/ICRC-21/icrc_21_consent_msg.md".to_string(),
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-21/ICRC-21.md".to_string(),
         },
         StandardRecord {
             name: "ICRC-103".to_string(),


### PR DESCRIPTION
Update the URL for the ICRC-21 standard in responses to queries to the `icrc1_supported_standards` and `icrc10_supported_standards` endpoints. The standard was copied to the ICRC repository [here](https://github.com/dfinity/ICRC/pull/165).