### PR TITLE
fix: colocate mainnet NNS Recovery system test

### DIFF
--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -69,7 +69,7 @@ jobs:
             bazel test \
               --config=flaky_retry \
               --config=stamped \
-              //rs/tests/nested/nns_recovery:nr_large_with_mainnet_state \
+              //rs/tests/nested/nns_recovery:nr_large_with_mainnet_state_colocate \
               --test_arg=--set-required-host-features=dc=zh1 \
               --keep_going --test_timeout=7200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -72,7 +72,6 @@ jobs:
               --config=flaky_retry \
               --config=stamped \
               //rs/tests/nested/nns_recovery:nr_large_with_mainnet_state_colocate \
-              --test_arg=--set-required-host-features=dc=zh1 \
               --keep_going --test_timeout=7200
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -58,7 +58,7 @@ jobs:
       group: zh1
       labels: dind-large
     container: *container-setup
-    timeout-minutes: 180
+    timeout-minutes: 120
     environment: Nightly Tests
     steps:
       - *checkout

--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -54,7 +54,9 @@ jobs:
 
   nns-recovery-mainnet-state:
     name: Bazel Test NNS Recovery with Mainnet State
-    runs-on: *dind-large-setup
+    runs-on:
+      group: zh1
+      labels: dind-large
     container: *container-setup
     timeout-minutes: 180
     environment: Nightly Tests

--- a/rs/tests/driver/src/driver/nested.rs
+++ b/rs/tests/driver/src/driver/nested.rs
@@ -6,7 +6,7 @@ use crate::driver::test_env::TestEnv;
 use crate::driver::test_env_api::*;
 use crate::driver::{
     bootstrap::setup_and_start_nested_vms,
-    farm::Farm,
+    farm::{Farm, HostFeature},
     resource::{allocate_resources, get_resource_request_for_nested_nodes},
     test_env::TestEnvAttribute,
     test_setup::GroupSetup,
@@ -45,20 +45,34 @@ pub struct NestedNodes {
 
 impl NestedNodes {
     pub fn new(names: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        NestedNodes::new_with_resource_overrides(names, VmResourceOverrides::default())
-    }
-
-    /// Allow specifying resource overrides to use for the nested VM.
-    ///
-    /// NOTE: The number of VCPUs must be divisible by 4.
-    pub fn new_with_resource_overrides(
-        names: impl IntoIterator<Item = impl Into<String>>,
-        vm_resource_overrides: VmResourceOverrides,
-    ) -> Self {
         NestedNodes {
             nodes: names
                 .into_iter()
-                .map(|v| NestedNode::new_farm(v.into(), vm_resource_overrides))
+                .map(|v| NestedNode::new_farm(v.into()))
+                .collect(),
+        }
+    }
+
+    /// Allow specifying resource overrides to use for the nested VMs.
+    ///
+    /// NOTE: The number of VCPUs must be divisible by 4.
+    pub fn with_resource_overrides(self, vm_resource_overrides: VmResourceOverrides) -> Self {
+        NestedNodes {
+            nodes: self
+                .nodes
+                .into_iter()
+                .map(|node| node.with_resource_overrides(vm_resource_overrides))
+                .collect(),
+        }
+    }
+
+    /// Allow specifying required host features for the nested VMs.
+    pub fn with_required_host_features(self, required_host_features: Vec<HostFeature>) -> Self {
+        NestedNodes {
+            nodes: self
+                .nodes
+                .into_iter()
+                .map(|node| node.with_required_host_features(required_host_features.clone()))
                 .collect(),
         }
     }
@@ -166,7 +180,10 @@ fn allocated_vm_for_bare_metal_instance(
 
 #[derive(Clone, PartialEq, Eq)]
 pub enum NestedNodeSpec {
-    Vm(VmResourceOverrides),
+    Vm {
+        vm_resource_overrides: VmResourceOverrides,
+        required_host_features: Vec<HostFeature>,
+    },
     BareMetal {
         host_address: Ipv6Addr,
         mgmt_mac: MacAddr6,
@@ -182,11 +199,14 @@ pub struct NestedNode {
 }
 
 impl NestedNode {
-    pub fn new_farm(name: String, vm_resource_overrides: VmResourceOverrides) -> Self {
+    pub fn new_farm(name: String) -> Self {
         NestedNode {
             name,
             boot_image: BootImage::default(),
-            node_spec: NestedNodeSpec::Vm(vm_resource_overrides),
+            node_spec: NestedNodeSpec::Vm {
+                vm_resource_overrides: VmResourceOverrides::default(),
+                required_host_features: Vec::default(),
+            },
         }
     }
 
@@ -205,6 +225,36 @@ impl NestedNode {
                 enable_trusted_execution_environment,
             },
         }
+    }
+
+    /// Allow specifying resource overrides to use for the nested VM.
+    ///
+    /// NOTE: The number of VCPUs must be divisible by 4.
+    pub fn with_resource_overrides(mut self, vm_resource_overrides: VmResourceOverrides) -> Self {
+        let NestedNodeSpec::Vm {
+            vm_resource_overrides: ref mut overrides,
+            ..
+        } = self.node_spec
+        else {
+            panic!("`with_vm_resource_overrides` can only be used with VM nodes");
+        };
+
+        *overrides = vm_resource_overrides;
+        self
+    }
+
+    /// Allow specifying required host features for the nested VM.
+    pub fn with_required_host_features(mut self, required_host_features: Vec<HostFeature>) -> Self {
+        let NestedNodeSpec::Vm {
+            required_host_features: ref mut features,
+            ..
+        } = self.node_spec
+        else {
+            panic!("`with_required_host_features` can only be used with VM nodes");
+        };
+
+        *features = required_host_features;
+        self
     }
 
     pub fn with_boot_image(mut self, boot_image: BootImage) -> Self {

--- a/rs/tests/driver/src/driver/nested.rs
+++ b/rs/tests/driver/src/driver/nested.rs
@@ -54,8 +54,6 @@ impl NestedNodes {
     }
 
     /// Allow specifying resource overrides to use for the nested VMs.
-    ///
-    /// NOTE: The number of VCPUs must be divisible by 4.
     pub fn with_resource_overrides(self, vm_resource_overrides: VmResourceOverrides) -> Self {
         NestedNodes {
             nodes: self
@@ -229,8 +227,17 @@ impl NestedNode {
 
     /// Allow specifying resource overrides to use for the nested VM.
     ///
-    /// NOTE: The number of VCPUs must be divisible by 4.
+    /// Panics if used on a bare metal node or if the number of VCPUs is not divisible by 4.
     pub fn with_resource_overrides(mut self, vm_resource_overrides: VmResourceOverrides) -> Self {
+        if let Some(vcpus) = vm_resource_overrides.vcpus
+            && vcpus.get() % 4 != 0
+        {
+            panic!(
+                "The number of VCPUs must be divisible by 4, but got {}",
+                vcpus.get()
+            );
+        }
+
         let NestedNodeSpec::Vm {
             vm_resource_overrides: ref mut overrides,
             ..
@@ -244,6 +251,8 @@ impl NestedNode {
     }
 
     /// Allow specifying required host features for the nested VM.
+    ///
+    /// Panics if used on a bare metal node.
     pub fn with_required_host_features(mut self, required_host_features: Vec<HostFeature>) -> Self {
         let NestedNodeSpec::Vm {
             required_host_features: ref mut features,

--- a/rs/tests/driver/src/driver/nested.rs
+++ b/rs/tests/driver/src/driver/nested.rs
@@ -236,7 +236,7 @@ impl NestedNode {
             ..
         } = self.node_spec
         else {
-            panic!("`with_vm_resource_overrides` can only be used with VM nodes");
+            panic!("`with_resource_overrides` can only be used with VM nodes");
         };
 
         *overrides = vm_resource_overrides;

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -387,8 +387,11 @@ fn vm_spec_from_nested_node(
     node: &NestedNode,
     group_vm_resource_overrides: VmResourceOverrides,
 ) -> anyhow::Result<VmSpec> {
-    let node_vm_resource_overrides = match &node.node_spec {
-        NestedNodeSpec::Vm(overrides) => overrides,
+    let (node_vm_resource_overrides, required_host_features) = match &node.node_spec {
+        NestedNodeSpec::Vm {
+            vm_resource_overrides,
+            required_host_features,
+        } => (*vm_resource_overrides, required_host_features.clone()),
         NestedNodeSpec::BareMetal { .. } => {
             bail!("Bare metal nodes are not supported by get_resource_request_for_nested_nodes")
         }
@@ -406,7 +409,7 @@ fn vm_spec_from_nested_node(
         boot_image_minimal_size_gibibytes: resolved_vm_resources.boot_image_minimal_size_gibibytes,
         has_ipv4: false,
         vm_allocation: None,
-        required_host_features: Vec::new(),
+        required_host_features,
         alternate_template: None,
     })
 }

--- a/rs/tests/nested/nns_recovery/BUILD.bazel
+++ b/rs/tests/nested/nns_recovery/BUILD.bazel
@@ -75,6 +75,12 @@ system_test_nns(
 # should be running and have permission to fetch mainnet test data.
 system_test_nns(
     name = "nr_large_with_mainnet_state",
+    colocated_test_driver_vm_required_host_features = ["dc=zh1"],
+    colocated_test_driver_vm_resources = {
+        "vcpus": None,
+        "memory_kibibytes": None,
+        "boot_image_minimal_size_gibibytes": 128,
+    },
     enable_head_nns_variant = False,
     env = ENV,
     env_inherit = ["SSH_AUTH_SOCK"],

--- a/rs/tests/nested/nns_recovery/BUILD.bazel
+++ b/rs/tests/nested/nns_recovery/BUILD.bazel
@@ -65,12 +65,9 @@ system_test_nns(
 #     bazel \
 #         test \
 #         --test_timeout=7200 \  # 2 hours
-#         --test_arg=--set-required-host-features=dc=zh1 \
-#         //rs/tests/nested/nns_recovery:nr_large_with_mainnet_state
+#         //rs/tests/nested/nns_recovery:nr_large_with_mainnet_state_colocate
 #
 # You should use `--test_timeout=7200` because the test is expected to take a very long time.
-# You should use `--test_arg=--set-required-host-features=dc=zh1` because the test fetches mainnet test
-# data from a location close to the `zh1` data center.
 # You should also have your `SSH_AUTH_SOCK` environment variable set, and the corresponding SSH agent
 # should be running and have permission to fetch mainnet test data.
 system_test_nns(

--- a/rs/tests/nested/nns_recovery/common.rs
+++ b/rs/tests/nested/nns_recovery/common.rs
@@ -257,7 +257,7 @@ pub fn setup(env: TestEnv, cfg: SetupConfig) {
         let required_host_features = if cfg.use_mainnet_state {
             mainnet_node_required_host_features()
         } else {
-            vec![]
+            Default::default()
         };
         NestedNodes::new(&host_vm_names)
             .with_resource_overrides(vm_resource_overrides)

--- a/rs/tests/nested/nns_recovery/common.rs
+++ b/rs/tests/nested/nns_recovery/common.rs
@@ -39,8 +39,8 @@ use ic_system_test_driver::{
     util::{MESSAGE_CANISTER_WASM, MessageCanister, assert_create_agent, block_on},
 };
 use ic_testnet_mainnet_nns::{
-    MAINNET_NODE_VM_RESOURCE_OVERRIDES, proposals::ProposalWithMainnetState,
-    setup as setup_with_mainnet_state,
+    MAINNET_NODE_VM_RESOURCE_OVERRIDES, mainnet_node_required_host_features,
+    proposals::ProposalWithMainnetState, setup as setup_with_mainnet_state,
 };
 use ic_types::ReplicaVersion;
 use manual_guestos_recovery::recovery_utils::build_recovery_upgrader_run_command;
@@ -254,7 +254,14 @@ pub fn setup(env: TestEnv, cfg: SetupConfig) {
             cfg.nested_nodes_vm_resource_overrides
                 .layer(&NNS_RECOVERY_VM_RESOURCE_OVERRIDES)
         };
-        NestedNodes::new_with_resource_overrides(&host_vm_names, vm_resource_overrides)
+        let required_host_features = if cfg.use_mainnet_state {
+            mainnet_node_required_host_features()
+        } else {
+            vec![]
+        };
+        NestedNodes::new(&host_vm_names)
+            .with_resource_overrides(vm_resource_overrides)
+            .with_required_host_features(required_host_features)
             .setup_and_start(&env)
             .unwrap();
 

--- a/rs/tests/testnets/mainnet_nns/src/lib.rs
+++ b/rs/tests/testnets/mainnet_nns/src/lib.rs
@@ -45,13 +45,13 @@ pub const MAINNET_NODE_VM_RESOURCE_OVERRIDES: VmResourceOverrides = VmResourceOv
     boot_image_minimal_size_gibibytes: Some(ImageSizeGiB::new(192)),
     ..VmResourceOverrides::const_default()
 };
-// Request to be deployed in `zh1` by default to be physically closer to the backup pod.
+/// Request to be deployed in `zh1` by default to be physically closer to the backup pod.
 pub fn mainnet_node_required_host_features() -> Vec<HostFeature> {
     vec![HostFeature::DC("zh1".to_string())]
 }
 
-// Default path to the mainnet NNS state tarball on the backup pod. Can be overridden through the
-// NNS_STATE_ON_BACKUP_POD environment variable.
+/// Default path to the mainnet NNS state tarball on the backup pod. Can be overridden through the
+/// NNS_STATE_ON_BACKUP_POD environment variable.
 const NNS_STATE_ON_BACKUP_POD: &str =
     "dev@zh1-pyr07.zh1.dfinity.network:/home/dev/nns_state.tar.zst";
 
@@ -860,9 +860,9 @@ fn write_sh_lib(env: &TestEnv, NeuronId(neuron_id): NeuronId, http_gateway: &Url
     info!(logger, "source {canonical_sh_lib_path:?}");
 }
 
-// Overwrite the local store of the test environment with the new one, corresponding to the
-// recovered NNS. Any topology snapshot taken after this will reflect the new topology. This means
-// it will contain all mainnet subnets and nodes.
+/// Overwrite the local store of the test environment with the new one, corresponding to the
+/// recovered NNS. Any topology snapshot taken after this will reflect the new topology. This means
+/// it will contain all mainnet subnets and nodes.
 async fn patch_env_local_store(env: &TestEnv) {
     let local_store_path = env
         .get_path(PATH_RECOVERY_WORKING_DIR)
@@ -900,8 +900,8 @@ async fn patch_env_local_store(env: &TestEnv) {
         .unwrap();
 }
 
-// Overwrite the root public key of the test environment with the new one, corresponding to the
-// recovered NNS. This enables future nested VMs to register using the correct root public key.
+/// Overwrite the root public key of the test environment with the new one, corresponding to the
+/// recovered NNS. This enables future nested VMs to register using the correct root public key.
 fn patch_env_root_public_key(env: &TestEnv) {
     std::fs::copy(
         env.get_path(PATH_RECOVERED_NNS_PUBLIC_KEY_PEM),
@@ -910,9 +910,9 @@ fn patch_env_root_public_key(env: &TestEnv) {
     .unwrap();
 }
 
-// Remove large files inside the test environment that are no longer needed to speed up the
-// transition between `setup` and following `test` tasks, since every `test` task will copy the
-// `setup` test environment to a new location.
+/// Remove large files inside the test environment that are no longer needed to speed up the
+/// transition between `setup` and following `test` tasks, since every `test` task will copy the
+/// `setup` test environment to a new location.
 fn remove_large_files(env: &TestEnv) {
     let mut rm = Command::new("rm");
     rm.arg("-rf")

--- a/rs/tests/testnets/mainnet_nns/src/lib.rs
+++ b/rs/tests/testnets/mainnet_nns/src/lib.rs
@@ -10,6 +10,7 @@ use ic_nns_common::types::NeuronId;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::constants::SSH_USERNAME;
 use ic_system_test_driver::driver::driver_setup::SSH_AUTHORIZED_PRIV_KEYS_DIR;
+use ic_system_test_driver::driver::farm::HostFeature;
 use ic_system_test_driver::driver::ic::{
     AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, Subnet, VmResourceOverrides,
 };
@@ -44,6 +45,10 @@ pub const MAINNET_NODE_VM_RESOURCE_OVERRIDES: VmResourceOverrides = VmResourceOv
     boot_image_minimal_size_gibibytes: Some(ImageSizeGiB::new(192)),
     ..VmResourceOverrides::const_default()
 };
+// Request to be deployed in `zh1` by default to be physically closer to the backup pod.
+pub fn mainnet_node_required_host_features() -> Vec<HostFeature> {
+    vec![HostFeature::DC("zh1".to_string())]
+}
 
 // Default path to the mainnet NNS state tarball on the backup pod. Can be overridden through the
 // NNS_STATE_ON_BACKUP_POD environment variable.
@@ -148,6 +153,7 @@ async fn setup_async(env: TestEnv, dkg_interval: Option<u64>) {
     let env_clone = env.clone();
     let deploy_gateway_task = tokio::task::spawn_blocking(move || {
         IcGatewayVm::new(IC_GATEWAY_VM_NAME)
+            .with_required_host_features(mainnet_node_required_host_features())
             .start(&env_clone)
             .expect("Failed to setup ic-gateway");
 
@@ -801,6 +807,7 @@ fn setup_ic(env: TestEnv) {
 
     InternetComputer::new()
         .with_resource_overrides(MAINNET_NODE_VM_RESOURCE_OVERRIDES)
+        .with_required_host_features(mainnet_node_required_host_features())
         .add_subnet(Subnet::fast_single_node(SubnetType::System))
         .with_api_boundary_nodes(1)
         .with_unassigned_nodes(1)

--- a/rs/tests/testnets/mainnet_nns_state.rs
+++ b/rs/tests/testnets/mainnet_nns_state.rs
@@ -14,13 +14,11 @@
 // their node operator principals must be added to the registry through a proposal (with enough node
 // allowance).
 //
-// If you do not want the testnet to be public, it is recommended to create it with
-// `--set-required-host-features=dc=zh1` to be deployed physically closer to the backup pod.
 // Note that the NNS backup is over 15GB so it will require around 3 minutes to download, 15 minutes
 // to unpack and 59G of disk space.
 //
 // ```
-// $ ict testnet create mainnet_nns_state --verbose --set-required-host-features=dc=zh1 -- --test_tmpdir=./mainnet_nns_state
+// $ ict testnet create mainnet_nns_state --verbose -- --test_tmpdir=./mainnet_nns_state
 // ```
 //
 // Additional configuration:

--- a/rs/tests/testnets/nns_recovery.rs
+++ b/rs/tests/testnets/nns_recovery.rs
@@ -3,9 +3,8 @@
 // The testnet will consist of a single system subnet with a single node running the NNS.
 //
 // The bazel target `mainnet_nns_recovery` also uses this testnet by setting the
-// `USE_MAINNET_STATE` environment variable to true, which makes the testnet use mainnet state. In
-// that case, it is recommended to also pass `--set-required-host-features=dc=zh1` to be physically
-// closer to the backup pod where the state is downloaded from.
+// `USE_MAINNET_STATE` environment variable to true, which makes the testnet use mainnet state.
+//
 // You can pass `--set-required-host-features=dmz` to make the testnet open to the Internet.
 //
 // Then SUBNET_SIZE VMs are deployed and started booting SetupOS which will install HostOS to their virtual disks


### PR DESCRIPTION
This PR does the following for mainnet NNS Recovery:
- Puts the GitHub runner in the `zh1` DC,
- Runs the colocated variant of mainnet NNS Recovery,
- Puts the colocated test driver in the `zh1` DC with a large enough disk,
- Allows to set the required host features for nested VMs and sets them to `dc=zh1` by default for mainnet NNS Recovery.
