### PR TITLE
chore: revert that log_memory_limit cannot be set together with memory allocation

### DIFF
--- a/rs/execution_environment/src/canister_settings.rs
+++ b/rs/execution_environment/src/canister_settings.rs
@@ -110,33 +110,6 @@ impl TryFrom<CanisterSettingsArgs> for CanisterSettings {
     type Error = UpdateSettingsError;
 
     fn try_from(input: CanisterSettingsArgs) -> Result<Self, Self::Error> {
-        if input.log_memory_limit.is_some() {
-            // The destructure is exhaustive so that adding a new field to
-            // CanisterSettingsArgs causes a compile error here, prompting the
-            // developer to decide whether the new field affects memory
-            // usage/allocation — if it does, it must also be rejected together
-            // with log_memory_limit below.
-            let CanisterSettingsArgs {
-                controllers: _,
-                compute_allocation: _,
-                memory_allocation,
-                freezing_threshold: _,
-                reserved_cycles_limit: _,
-                log_visibility: _,
-                snapshot_visibility: _,
-                log_memory_limit: _,
-                wasm_memory_limit: _,
-                wasm_memory_threshold: _,
-                environment_variables: _,
-            } = &input;
-            if memory_allocation.is_some() {
-                return Err(UpdateSettingsError::ForbiddenSettings {
-                    message: "log_memory_limit cannot be set together with memory_allocation"
-                        .to_string(),
-                });
-            }
-        }
-
         let compute_allocation = match input.compute_allocation {
             Some(ca) => Some(ComputeAllocation::try_from(ca.0.to_u64().ok_or_else(
                 || UpdateSettingsError::ComputeAllocation(InvalidComputeAllocationError::new(ca)),
@@ -380,7 +353,6 @@ pub enum UpdateSettingsError {
     WasmMemoryThresholdOutOfRange { provided: candid::Nat },
     DuplicateEnvironmentVariables,
     LogMemoryLimitOutOfRange { provided: candid::Nat },
-    ForbiddenSettings { message: String },
 }
 
 impl From<UpdateSettingsError> for UserError {
@@ -433,9 +405,6 @@ impl From<UpdateSettingsError> for UserError {
                     "Log memory limit expected to be in the range of [0..2^64-1], got {provided}"
                 ),
             ),
-            UpdateSettingsError::ForbiddenSettings { message } => {
-                UserError::new(ErrorCode::CanisterContractViolation, message)
-            }
         }
     }
 }

--- a/rs/execution_environment/src/canister_settings/tests.rs
+++ b/rs/execution_environment/src/canister_settings/tests.rs
@@ -1,6 +1,5 @@
-use crate::canister_settings::{CanisterSettings, EnvironmentVariables, UpdateSettingsError};
+use crate::canister_settings::EnvironmentVariables;
 use ic_crypto_sha2::Sha256;
-use ic_management_canister_types_private::CanisterSettingsArgsBuilder;
 use std::collections::BTreeMap;
 
 #[test]
@@ -86,40 +85,6 @@ fn test_environment_variables_hash_output() {
     // Verify that the actual hash matches the expected hash.
     let actual = EnvironmentVariables::new(env_vars).hash();
     assert_eq!(actual, expected);
-}
-
-mod log_memory_limit {
-    use super::*;
-    use std::convert::TryFrom;
-
-    #[test]
-    fn log_memory_limit_alone_is_valid() {
-        let args = CanisterSettingsArgsBuilder::new()
-            .with_log_memory_limit(4096)
-            .build();
-        assert!(CanisterSettings::try_from(args).is_ok());
-    }
-
-    #[test]
-    fn log_memory_limit_with_compute_allocation_is_valid() {
-        let args = CanisterSettingsArgsBuilder::new()
-            .with_log_memory_limit(4096)
-            .with_compute_allocation(50)
-            .build();
-        assert!(CanisterSettings::try_from(args).is_ok());
-    }
-
-    #[test]
-    fn log_memory_limit_with_memory_allocation_is_forbidden() {
-        let args = CanisterSettingsArgsBuilder::new()
-            .with_log_memory_limit(4096)
-            .with_memory_allocation(1 << 30)
-            .build();
-        assert!(matches!(
-            CanisterSettings::try_from(args),
-            Err(UpdateSettingsError::ForbiddenSettings { .. })
-        ));
-    }
 }
 
 mod visibility_settings {

--- a/rs/execution_environment/tests/canister_settings.rs
+++ b/rs/execution_environment/tests/canister_settings.rs
@@ -177,14 +177,6 @@ fn canister_settings_ranges() {
         Nat::from(invalid_freezing_threshold)
     );
 
-    let log_memory_limit_with_memory_allocation = CanisterSettingsArgsBuilder::new()
-        .with_log_memory_limit(4096)
-        .with_memory_allocation(1 << 20)
-        .build();
-    let expected_log_memory_limit_combined_err_code = ErrorCode::CanisterContractViolation;
-    let expected_log_memory_limit_combined_err =
-        "log_memory_limit cannot be set together with memory_allocation".to_string();
-
     for (invalid_settings, expected_err_code, expected_err) in [
         (
             invalid_compute_allocation_settings,
@@ -200,11 +192,6 @@ fn canister_settings_ranges() {
             invalid_freezing_threshold_settings,
             expected_invalid_freezing_threshold_err_code,
             expected_invalid_freezing_threshold_err,
-        ),
-        (
-            log_memory_limit_with_memory_allocation,
-            expected_log_memory_limit_combined_err_code,
-            expected_log_memory_limit_combined_err,
         ),
     ] {
         let err = via_update_settings(invalid_settings.clone()).unwrap_err();

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -1168,7 +1168,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -1252,7 +1252,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -1423,7 +1423,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -1505,7 +1505,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -1585,7 +1585,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -1650,7 +1650,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -1721,7 +1721,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(4_294_967_296_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -1799,7 +1799,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -1867,7 +1867,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -1966,7 +1966,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -2040,7 +2040,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -2243,7 +2243,7 @@ impl PocketIcSubnets {
             freezing_threshold: Some(2_592_000_u64.into()),
             reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
             log_visibility: Some(LogVisibilityV2::Controllers),
-            log_memory_limit: None, // 4_096 is the default
+            log_memory_limit: Some(4_096_u64.into()),
             wasm_memory_limit: Some(3_221_225_472_u64.into()),
             wasm_memory_threshold: Some(0_u64.into()),
             environment_variables: None,
@@ -2321,7 +2321,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -2419,7 +2419,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(2_000_000_000_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -2494,7 +2494,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,
@@ -2561,7 +2561,7 @@ impl PocketIcSubnets {
                 freezing_threshold: Some(2_592_000_u64.into()),
                 reserved_cycles_limit: Some(5_000_000_000_000_u128.into()),
                 log_visibility: Some(LogVisibilityV2::Controllers),
-                log_memory_limit: None, // 4_096 is the default
+                log_memory_limit: Some(4_096_u64.into()),
                 wasm_memory_limit: Some(3_221_225_472_u64.into()),
                 wasm_memory_threshold: Some(0_u64.into()),
                 environment_variables: None,


### PR DESCRIPTION
At canister creation time, the log memory limit is initialized to 4KiB by default and thus the implementation must be able to deal with simultaneous changes to log memory limit and memory allocation after all.