### PR TITLE
feat: Allow changing subnet_admins via UpdateSubnetPayload

### DIFF
--- a/rs/nns/integration_tests/src/subnet_handler.rs
+++ b/rs/nns/integration_tests/src/subnet_handler.rs
@@ -96,6 +96,7 @@ fn test_submit_and_accept_update_subnet_proposal() {
                 max_number_of_canisters: Some(200),
                 ssh_readonly_access: Some(vec!["pub_key_0".to_string()]),
                 ssh_backup_access: Some(vec!["pub_key_1".to_string()]),
+                subnet_admins: None,
                 chain_key_config: None,
                 chain_key_signing_enable: None,
                 chain_key_signing_disable: None,

--- a/rs/registry/admin/bin/update_subnet.rs
+++ b/rs/registry/admin/bin/update_subnet.rs
@@ -13,7 +13,7 @@ use ic_nns_common::types::NeuronId;
 use ic_registry_nns_data_provider::registry::RegistryCanister;
 use ic_registry_resource_limits::ResourceLimits;
 use ic_registry_subnet_features::SubnetFeatures;
-use ic_types::SubnetId;
+use ic_types::{PrincipalId, SubnetId};
 use registry_canister::mutations::do_update_subnet;
 use std::collections::BTreeMap;
 use std::{collections::HashSet, path::PathBuf};
@@ -174,6 +174,12 @@ pub(crate) struct ProposeToUpdateSubnetCmd {
     /// on the NNS subnet.
     #[clap(long, num_args(1..))]
     ssh_backup_access: Option<Vec<String>>,
+
+    /// If set, replaces the subnet's admin list with the given principals
+    /// (passing zero principals clears the list). When unset, the existing
+    /// admin list is left unchanged.
+    #[clap(long, num_args(0..))]
+    pub subnet_admins: Option<Vec<PrincipalId>>,
 
     /// If set, the created proposal will contain a desired override of that
     /// field to the value set. See `ProposeToCreateSubnetCmd` for the semantic
@@ -374,6 +380,7 @@ impl ProposeToUpdateSubnetCmd {
 
             ssh_readonly_access: self.ssh_readonly_access.clone(),
             ssh_backup_access: self.ssh_backup_access.clone(),
+            subnet_admins: self.subnet_admins.clone(),
             max_number_of_canisters: self.max_number_of_canisters,
 
             chain_key_config,
@@ -443,6 +450,7 @@ mod tests {
             max_number_of_canisters: None,
             ssh_readonly_access: None,
             ssh_backup_access: None,
+            subnet_admins: None,
             chain_key_config: None,
             chain_key_signing_enable: None,
             chain_key_signing_disable: None,
@@ -481,6 +489,7 @@ mod tests {
             resource_limits: None,
             ssh_readonly_access: None,
             ssh_backup_access: None,
+            subnet_admins: None,
             max_number_of_canisters: None,
         }
     }
@@ -556,6 +565,7 @@ mod tests {
         assert_eq!(
             cmd.new_payload_for_subnet(subnet_id, subnet_record),
             do_update_subnet::UpdateSubnetPayload {
+                subnet_admins: None,
                 chain_key_config: Some(do_update_subnet::ChainKeyConfig {
                     // Note the order is not important so long as it is deterministic. As a matter
                     // of fact, the order is lexicographic, as the implementation uses `BTreeSet`.
@@ -666,6 +676,7 @@ mod tests {
         assert_eq!(
             cmd.new_payload_for_subnet(subnet_id, subnet_record),
             do_update_subnet::UpdateSubnetPayload {
+                subnet_admins: None,
                 chain_key_config: Some(do_update_subnet::ChainKeyConfig {
                     key_configs: vec![
                         do_update_subnet::KeyConfig {
@@ -757,6 +768,7 @@ mod tests {
         assert_eq!(
             cmd.new_payload_for_subnet(subnet_id, subnet_record),
             do_update_subnet::UpdateSubnetPayload {
+                subnet_admins: None,
                 chain_key_config: Some(do_update_subnet::ChainKeyConfig {
                     key_configs: vec![
                         // Existed before, now being updated.
@@ -847,6 +859,7 @@ mod tests {
             do_update_subnet::UpdateSubnetPayload {
                 resource_limits: expected_resource_limits
                     .map(|resource_limits| resource_limits.into()),
+                subnet_admins: None,
                 ..make_empty_update_payload(subnet_id)
             },
         );

--- a/rs/registry/canister/canbench/canbench_results.yml
+++ b/rs/registry/canister/canbench/canbench_results.yml
@@ -2,28 +2,28 @@ benches:
   get_subnet_for_canister_100_times_100:
     total:
       calls: 1
-      instructions: 31025759
+      instructions: 31023843
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_subnet_for_canister_100_times_10k:
     total:
       calls: 1
-      instructions: 694110012
+      instructions: 702766124
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_subnet_for_canister_100_times_1k:
     total:
       calls: 1
-      instructions: 90967747
+      instructions: 91777359
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   measure_routing_table_invariant_checks_shards_and_unsharded:
     total:
       calls: 1
-      instructions: 268353620
+      instructions: 266853620
       heap_increase: 138
       stable_memory_increase: 0
     scopes: {}
@@ -58,73 +58,73 @@ benches:
   migrate_canisters_10_times_100:
     total:
       calls: 1
-      instructions: 156361795
+      instructions: 153095442
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   migrate_canisters_10_times_10k:
     total:
       calls: 1
-      instructions: 10367776782
+      instructions: 10277865712
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   migrate_canisters_10_times_1k:
     total:
       calls: 1
-      instructions: 1032517212
+      instructions: 1021704126
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   upgrade_with_routing_table_100:
     total:
       calls: 1
-      instructions: 186143660
+      instructions: 186048560
       heap_increase: 7
       stable_memory_increase: 0
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 185263063
+        instructions: 185166586
         heap_increase: 4
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 669662
+        instructions: 671039
         heap_increase: 3
         stable_memory_increase: 0
   upgrade_with_routing_table_10k:
     total:
       calls: 1
-      instructions: 5626018276
+      instructions: 5619725836
       heap_increase: 342
       stable_memory_increase: 0
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 5603899441
+        instructions: 5597605966
         heap_increase: 217
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 16603376
+        instructions: 16604363
         heap_increase: 125
         stable_memory_increase: 0
   upgrade_with_routing_table_1k:
     total:
       calls: 1
-      instructions: 686509309
+      instructions: 685851194
       heap_increase: 40
       stable_memory_increase: 0
     scopes:
       post_upgrade:
         calls: 1
-        instructions: 683633916
+        instructions: 682974410
         heap_increase: 25
         stable_memory_increase: 0
       pre_upgrade:
         calls: 1
-        instructions: 2201525
+        instructions: 2202916
         heap_increase: 15
         stable_memory_increase: 0
 version: 0.4.1

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -486,6 +486,7 @@ type UpdateSubnetPayload = record {
   max_artifact_streams_per_peer : opt nat32;
   subnet_type : opt SubnetType;
   ssh_readonly_access : opt vec text;
+  subnet_admins : opt vec principal;
   chain_key_config : opt ChainKeyConfig;
   chain_key_signing_enable : opt vec MasterPublicKeyId;
   chain_key_signing_disable : opt vec MasterPublicKeyId;

--- a/rs/registry/canister/canister/registry_test.did
+++ b/rs/registry/canister/canister/registry_test.did
@@ -486,6 +486,7 @@ type UpdateSubnetPayload = record {
   max_artifact_streams_per_peer : opt nat32;
   subnet_type : opt SubnetType;
   ssh_readonly_access : opt vec text;
+  subnet_admins : opt vec principal;
   chain_key_config : opt ChainKeyConfig;
   chain_key_signing_enable : opt vec MasterPublicKeyId;
   chain_key_signing_disable : opt vec MasterPublicKeyId;

--- a/rs/registry/canister/src/invariants/mod.rs
+++ b/rs/registry/canister/src/invariants/mod.rs
@@ -10,5 +10,5 @@ mod node_operator;
 mod node_record;
 mod replica_version;
 mod routing_table;
-mod subnet;
+pub(crate) mod subnet;
 mod unassigned_nodes_config;

--- a/rs/registry/canister/src/invariants/subnet.rs
+++ b/rs/registry/canister/src/invariants/subnet.rs
@@ -20,6 +20,9 @@ use ic_registry_keys::{
 };
 use prost::Message;
 
+/// The maximum number of subnet admins a subnet may have.
+pub const MAX_SUBNET_ADMINS: usize = 10;
+
 /// Subnet invariants hold iff:
 ///    * Each SSH key access list does not contain more than 50 keys
 ///    * Subnet membership contains no repetition
@@ -33,7 +36,8 @@ use prost::Message;
 ///         * consist of nodes with reward type 4
 ///    * Conversely, only cloud engines can have nodes with reward type 4
 ///    * SEV-enabled subnets consist of SEV-enabled nodes only (i.e. nodes with a chip ID in the node record)
-///    * Only rented subnets can have subnet admins set to a non-empty list
+///    * Only rented subnets or cloud engines can have subnet admins set to a non-empty list
+///    * No subnet has more than `MAX_SUBNET_ADMINS` subnet admins
 ///    * The default initial DKG subnet, if set, refers to a subnet that
 ///      appears in the subnet list
 pub(crate) fn check_subnet_invariants(
@@ -216,7 +220,8 @@ fn check_default_initial_dkg_subnet_invariant(
     Ok(())
 }
 
-// Checks that only rented subnets or cloud engine subnets can have admins.
+// Checks that only rented subnets or cloud engine subnets can have admins, and
+// that no subnet has more than `MAX_SUBNET_ADMINS` admins.
 fn check_subnet_admins_invariant(
     subnet_record: &SubnetRecord,
     subnet_id: SubnetId,
@@ -242,6 +247,17 @@ fn check_subnet_admins_invariant(
             source: None,
         });
     }
+
+    if subnet_record.subnet_admins.len() > MAX_SUBNET_ADMINS {
+        return Err(InvariantCheckError {
+            msg: format!(
+                "Subnet {subnet_id:} has {} subnet admins, which exceeds the maximum of {MAX_SUBNET_ADMINS}",
+                subnet_record.subnet_admins.len()
+            ),
+            source: None,
+        });
+    }
+
     Ok(())
 }
 

--- a/rs/registry/canister/src/invariants/subnet/tests.rs
+++ b/rs/registry/canister/src/invariants/subnet/tests.rs
@@ -274,6 +274,43 @@ fn non_rented_application_subnets_cannot_have_subnet_admins() {
 }
 
 #[test]
+fn subnets_cannot_have_more_than_max_subnet_admins() {
+    let system_subnet_id = subnet_test_id(1);
+    let test_subnet_id = subnet_test_id(2);
+    let (mut snapshot, mut test_subnet_record) =
+        setup_minimal_registry_snapshot_for_check_subnet_invariants(
+            system_subnet_id,
+            test_subnet_id,
+            1,     // num_nodes_in_test_subnet
+            false, // with_chip_id
+        );
+
+    // Make the subnet rented so the type/cost-schedule check passes.
+    test_subnet_record.subnet_type = i32::from(SubnetType::Application);
+    test_subnet_record.canister_cycles_cost_schedule = i32::from(CanisterCyclesCostSchedule::Free);
+
+    // Exactly `MAX_SUBNET_ADMINS` admins is allowed.
+    test_subnet_record.subnet_admins = (0..MAX_SUBNET_ADMINS as u64)
+        .map(|i| PrincipalIdPb::from(user_test_id(i).get()))
+        .collect();
+    snapshot.insert(
+        make_subnet_record_key(test_subnet_id).into_bytes(),
+        test_subnet_record.encode_to_vec(),
+    );
+    check_subnet_invariants(&snapshot).unwrap();
+
+    // One more than `MAX_SUBNET_ADMINS` is not.
+    test_subnet_record.subnet_admins = (0..(MAX_SUBNET_ADMINS as u64 + 1))
+        .map(|i| PrincipalIdPb::from(user_test_id(i).get()))
+        .collect();
+    snapshot.insert(
+        make_subnet_record_key(test_subnet_id).into_bytes(),
+        test_subnet_record.encode_to_vec(),
+    );
+    assert_non_compliant_record(&snapshot, "subnet admins, which exceeds the maximum of");
+}
+
+#[test]
 fn cloud_engine_subnets_must_have_type4_nodes() {
     let system_subnet_id = subnet_test_id(1);
     let test_subnet_id = subnet_test_id(2);

--- a/rs/registry/canister/src/lib.rs
+++ b/rs/registry/canister/src/lib.rs
@@ -12,5 +12,5 @@ pub mod registry;
 pub mod registry_lifecycle;
 pub mod storage;
 
-mod invariants;
+pub(crate) mod invariants;
 mod rate_limits;

--- a/rs/registry/canister/src/mutations/do_update_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet.rs
@@ -1681,7 +1681,7 @@ mod tests {
         let (mut registry, subnet_id) = make_registry_with_rented_subnet();
 
         // 11 admins exceeds MAX_SUBNET_ADMINS (10).
-        let admins = (0..11u64)
+        let admins = (0..11_u64)
             .map(|i| PrincipalId::new_user_test_id(2000 + i))
             .collect::<Vec<_>>();
 

--- a/rs/registry/canister/src/mutations/do_update_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet.rs
@@ -1,11 +1,14 @@
 use crate::{common::LOG_PREFIX, mutations::common::has_duplicates, registry::Registry};
 use candid::{CandidType, Deserialize};
 use dfn_core::println;
-use ic_base_types::{SubnetId, subnet_id_into_protobuf};
+use ic_base_types::{PrincipalId, SubnetId, subnet_id_into_protobuf};
 use ic_management_canister_types_private::MasterPublicKeyId;
-use ic_protobuf::registry::subnet::v1::{
-    ResourceLimits as ResourceLimitsPb, SubnetFeatures as SubnetFeaturesPb,
-    SubnetRecord as SubnetRecordPb,
+use ic_protobuf::{
+    registry::subnet::v1::{
+        ResourceLimits as ResourceLimitsPb, SubnetFeatures as SubnetFeaturesPb,
+        SubnetRecord as SubnetRecordPb,
+    },
+    types::v1::PrincipalId as PrincipalIdPb,
 };
 use ic_registry_keys::{make_chain_key_enabled_subnet_list_key, make_subnet_record_key};
 use ic_registry_subnet_features::{
@@ -259,6 +262,11 @@ pub struct UpdateSubnetPayload {
     pub ssh_readonly_access: Option<Vec<String>>,
     pub ssh_backup_access: Option<Vec<String>>,
 
+    /// When `Some`, replaces the subnet's admin list with the given principals
+    /// (an empty `Vec` clears the list). `None` leaves the existing list
+    /// unchanged.
+    pub subnet_admins: Option<Vec<PrincipalId>>,
+
     // TODO(NNS1-2444): The fields below are deprecated and they are not read anywhere.
     pub max_artifact_streams_per_peer: Option<u32>,
     pub max_chunk_wait_ms: Option<u32>,
@@ -466,6 +474,7 @@ fn merge_subnet_record(
         max_number_of_canisters,
         ssh_readonly_access,
         ssh_backup_access,
+        subnet_admins,
         // Deprecated/unused values follow
         max_artifact_streams_per_peer: _,
         max_chunk_wait_ms: _,
@@ -512,6 +521,10 @@ fn merge_subnet_record(
 
     maybe_set!(subnet_record, ssh_readonly_access);
     maybe_set!(subnet_record, ssh_backup_access);
+
+    if let Some(subnet_admins) = subnet_admins {
+        subnet_record.subnet_admins = subnet_admins.into_iter().map(PrincipalIdPb::from).collect();
+    }
 
     subnet_record
 }
@@ -560,6 +573,7 @@ mod tests {
             max_number_of_canisters: None,
             ssh_readonly_access: None,
             ssh_backup_access: None,
+            subnet_admins: None,
             chain_key_config: None,
             chain_key_signing_enable: None,
             chain_key_signing_disable: None,
@@ -656,6 +670,7 @@ mod tests {
             max_number_of_canisters: Some(10),
             ssh_readonly_access: Some(vec!["pub_key_0".to_string()]),
             ssh_backup_access: Some(vec!["pub_key_1".to_string()]),
+            subnet_admins: None,
             chain_key_config: Some(chain_key_config.clone()),
             chain_key_signing_enable: None,
             chain_key_signing_disable: None,
@@ -774,6 +789,7 @@ mod tests {
             max_number_of_canisters: Some(50),
             ssh_readonly_access: None,
             ssh_backup_access: None,
+            subnet_admins: None,
             chain_key_config: None,
             chain_key_signing_enable: None,
             chain_key_signing_disable: None,
@@ -1565,5 +1581,128 @@ mod tests {
             max_parallel_pre_signature_transcripts_in_creation: None,
         });
         payload
+    }
+
+    /// Adds a rented (Application + Free cost schedule) subnet to the registry,
+    /// so that setting subnet admins is permitted by the registry invariant.
+    fn make_registry_with_rented_subnet() -> (Registry, SubnetId) {
+        let mut registry = invariant_compliant_registry(0);
+
+        let (mutate_request, node_ids_and_dkg_pks) = prepare_registry_with_nodes(1, 2);
+        registry.maybe_apply_mutation_internal(mutate_request.mutations);
+
+        let mut subnet_list_record = registry.get_subnet_list_record();
+
+        let (first_node_id, first_dkg_pk) = node_ids_and_dkg_pks
+            .iter()
+            .next()
+            .expect("should contain at least one node ID and key");
+        let mut subnet_record = get_invariant_compliant_subnet_record(vec![*first_node_id]);
+        subnet_record.subnet_type = i32::from(SubnetType::Application);
+        subnet_record.canister_cycles_cost_schedule = i32::from(CanisterCyclesCostSchedule::Free);
+
+        let subnet_id = subnet_test_id(1000);
+        registry.maybe_apply_mutation_internal(add_fake_subnet(
+            subnet_id,
+            &mut subnet_list_record,
+            subnet_record,
+            &btreemap!(*first_node_id => first_dkg_pk.clone()),
+        ));
+
+        (registry, subnet_id)
+    }
+
+    #[test]
+    fn can_set_subnet_admins() {
+        let (mut registry, subnet_id) = make_registry_with_rented_subnet();
+
+        let user1 = *TEST_USER1_PRINCIPAL;
+        let user2 = *TEST_USER2_PRINCIPAL;
+
+        let mut payload = make_empty_update_payload(subnet_id);
+        payload.subnet_admins = Some(vec![user1, user2]);
+
+        registry.do_update_subnet(payload);
+
+        assert_eq!(
+            registry.get_subnet_or_panic(subnet_id).subnet_admins,
+            vec![PrincipalIdPb::from(user1), PrincipalIdPb::from(user2)],
+        );
+    }
+
+    #[test]
+    fn can_clear_subnet_admins() {
+        let (mut registry, subnet_id) = make_registry_with_rented_subnet();
+
+        let user1 = *TEST_USER1_PRINCIPAL;
+
+        // First set an admin.
+        let mut payload = make_empty_update_payload(subnet_id);
+        payload.subnet_admins = Some(vec![user1]);
+        registry.do_update_subnet(payload);
+        assert_eq!(
+            registry.get_subnet_or_panic(subnet_id).subnet_admins,
+            vec![PrincipalIdPb::from(user1)],
+        );
+
+        // Then clear it via Some(vec![]).
+        let mut payload = make_empty_update_payload(subnet_id);
+        payload.subnet_admins = Some(vec![]);
+        registry.do_update_subnet(payload);
+        assert_eq!(
+            registry.get_subnet_or_panic(subnet_id).subnet_admins,
+            Vec::<PrincipalIdPb>::new(),
+        );
+    }
+
+    #[test]
+    fn none_subnet_admins_leaves_existing_admins_unchanged() {
+        let (mut registry, subnet_id) = make_registry_with_rented_subnet();
+
+        let user1 = *TEST_USER1_PRINCIPAL;
+
+        let mut payload = make_empty_update_payload(subnet_id);
+        payload.subnet_admins = Some(vec![user1]);
+        registry.do_update_subnet(payload);
+
+        // A subsequent update with `subnet_admins: None` must not change the list.
+        let payload = make_empty_update_payload(subnet_id);
+        registry.do_update_subnet(payload);
+
+        assert_eq!(
+            registry.get_subnet_or_panic(subnet_id).subnet_admins,
+            vec![PrincipalIdPb::from(user1)],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "subnet admins, which exceeds the maximum of")]
+    fn cannot_set_more_than_max_subnet_admins() {
+        let (mut registry, subnet_id) = make_registry_with_rented_subnet();
+
+        // 11 admins exceeds MAX_SUBNET_ADMINS (10).
+        let admins = (0..11u64)
+            .map(|i| PrincipalId::new_user_test_id(2000 + i))
+            .collect::<Vec<_>>();
+
+        let mut payload = make_empty_update_payload(subnet_id);
+        payload.subnet_admins = Some(admins);
+
+        registry.do_update_subnet(payload);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "is not a rented or cloud engine subnet but has a non-empty subnet admins list"
+    )]
+    fn cannot_set_subnet_admins_on_non_rented_subnet() {
+        // Use the default test fixture which produces an Application + Normal subnet
+        // (not rented), so setting admins must violate the invariant.
+        let (mut registry, subnet_id) = make_registry_for_update_subnet_tests();
+
+        let mut payload = make_empty_update_payload(subnet_id);
+        payload.subnet_admins = Some(vec![*TEST_USER1_PRINCIPAL]);
+
+        registry.do_update_subnet(payload);
     }
 }

--- a/rs/registry/canister/src/mutations/do_update_subnet_admins.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet_admins.rs
@@ -1,4 +1,4 @@
-use crate::{common::LOG_PREFIX, registry::Registry};
+use crate::{common::LOG_PREFIX, invariants::subnet::MAX_SUBNET_ADMINS, registry::Registry};
 use candid::{CandidType, Deserialize};
 use ic_base_types::{PrincipalId, SubnetId};
 use ic_nervous_system_time_helpers::now_system_time;
@@ -17,7 +17,6 @@ use std::collections::HashSet;
 mod rate_limits;
 use rate_limits::UpdateSubnetAdminsRateLimiter;
 
-const MAX_SUBNET_ADMINS: usize = 10;
 pub const MAX_SUSTAINED_SUBNET_ADMINS_PER_DAY: u64 = 10;
 
 #[derive(Clone, Eq, PartialEq, Debug, CandidType, Deserialize, Serialize)]

--- a/rs/registry/canister/tests/update_subnet.rs
+++ b/rs/registry/canister/tests/update_subnet.rs
@@ -75,6 +75,7 @@ fn test_the_anonymous_user_cannot_update_a_subnets_configuration() {
             max_number_of_canisters: Some(10),
             ssh_readonly_access: Some(vec!["pub_key_0".to_string()]),
             ssh_backup_access: Some(vec!["pub_key_1".to_string()]),
+            subnet_admins: None,
             chain_key_config: None,
             chain_key_signing_enable: None,
             chain_key_signing_disable: None,
@@ -205,6 +206,7 @@ fn test_a_canister_other_than_the_governance_canister_cannot_update_a_subnets_co
             max_number_of_canisters: Some(100),
             ssh_readonly_access: None,
             ssh_backup_access: None,
+            subnet_admins: None,
             chain_key_config: None,
             chain_key_signing_enable: None,
             chain_key_signing_disable: None,
@@ -327,6 +329,7 @@ fn test_the_governance_canister_can_update_a_subnets_configuration() {
             max_number_of_canisters: Some(42),
             ssh_readonly_access: Some(vec!["pub_key_0".to_string()]),
             ssh_backup_access: Some(vec!["pub_key_1".to_string()]),
+            subnet_admins: None,
             chain_key_config: None,
             chain_key_signing_enable: None,
             chain_key_signing_disable: None,
@@ -519,6 +522,7 @@ fn test_subnets_configuration_chain_key_fields_are_updated_correctly(key_id: Mas
 
         // update payload message
         let mut payload = UpdateSubnetPayload {
+            subnet_admins: None,
             chain_key_config: Some(chain_key_config.clone()),
             chain_key_signing_enable: Some(vec![key_id.clone()]),
             ..empty_update_subnet_payload(subnet_id)
@@ -548,6 +552,7 @@ fn test_subnets_configuration_chain_key_fields_are_updated_correctly(key_id: Mas
 
         // Change one field at a time in this payload
         payload = UpdateSubnetPayload {
+            subnet_admins: None,
             chain_key_config: None,
             chain_key_signing_enable: Some(vec![key_id.clone()]),
             ..empty_update_subnet_payload(subnet_id)
@@ -587,6 +592,7 @@ fn test_subnets_configuration_chain_key_fields_are_updated_correctly(key_id: Mas
         // First call:
         {
             let payload_1 = UpdateSubnetPayload {
+                subnet_admins: None,
                 chain_key_config: Some(chain_key_config.clone()),
                 ..empty_update_subnet_payload(subnet_id)
             };
@@ -620,6 +626,7 @@ fn test_subnets_configuration_chain_key_fields_are_updated_correctly(key_id: Mas
         {
             // This update should enable signing on our subnet for the given key.
             let payload_2 = UpdateSubnetPayload {
+                subnet_admins: None,
                 chain_key_signing_enable: Some(vec![key_id.clone()]),
                 ..empty_update_subnet_payload(subnet_id)
             };
@@ -684,6 +691,7 @@ fn empty_update_subnet_payload(subnet_id: SubnetId) -> UpdateSubnetPayload {
         max_number_of_canisters: None,
         ssh_readonly_access: None,
         ssh_backup_access: None,
+        subnet_admins: None,
         chain_key_config: None,
         chain_key_signing_enable: None,
         chain_key_signing_disable: None,

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -14,12 +14,19 @@ on the process that this file is part of, see
   `default_initial_dkg_subnet_id`. When set, `SetupInitialDKG` management
   canister calls that do not specify a subnet id explicitly are routed to the
   configured subnet instead of the calling subnet (NNS).
+* Added an optional `subnet_admins` field to `UpdateSubnetPayload`, allowing NNS
+  proposals to set, replace, or clear the list of admins of a subnet. `None`
+  leaves the existing list unchanged; `Some(vec![])` clears it; `Some(vec![..])`
+  replaces it.
 
 ## Changed
 
 * **SEV on existing subnets:** Reverted — `sev_enabled` can once again only be set at subnet creation;
   any update_subnet proposal that would change the effective `sev_enabled` value (in either direction,
   including via wholesale `features` replacement with `sev_enabled` left unset) is rejected.
+* Moved the max-10 cap on `subnet_admins` from a check local to
+  `update_subnet_admins` into a registry invariant, so the cap is now enforced
+  uniformly on every mutation that touches a subnet record.
 
 ## Deprecated
 

--- a/rs/tests/consensus/cup_explorer_test.rs
+++ b/rs/tests/consensus/cup_explorer_test.rs
@@ -124,6 +124,7 @@ fn test(env: TestEnv) {
     let halt_at_cup_height_payload = UpdateSubnetPayload {
         subnet_id: app_subnet.subnet_id,
         halt_at_cup_height: Some(true),
+        subnet_admins: None,
         ..empty_subnet_update()
     };
     block_on(execute_update_subnet_proposal(
@@ -171,6 +172,7 @@ fn test(env: TestEnv) {
     let update_subnet_payload = UpdateSubnetPayload {
         subnet_id: app_subnet.subnet_id,
         dkg_interval_length: Some(14),
+        subnet_admins: None,
         ..empty_subnet_update()
     };
     block_on(execute_update_subnet_proposal(

--- a/rs/tests/consensus/tecdsa/tecdsa_signature_life_cycle_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_signature_life_cycle_test.rs
@@ -227,6 +227,7 @@ fn test(env: TestEnv) {
         let disable_signing_payload = UpdateSubnetPayload {
             subnet_id: app_subnet.subnet_id,
             chain_key_signing_disable: Some(all_key_ids.clone()),
+            subnet_admins: None,
             ..empty_subnet_update()
         };
         execute_update_subnet_proposal(
@@ -284,6 +285,7 @@ fn test(env: TestEnv) {
         let proposal_payload = UpdateSubnetPayload {
             subnet_id: new_subnet_id,
             chain_key_signing_enable: Some(all_key_ids.clone()),
+            subnet_admins: None,
             ..empty_subnet_update()
         };
         execute_update_subnet_proposal(

--- a/rs/tests/consensus/tecdsa/tecdsa_two_signing_subnets_test.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_two_signing_subnets_test.rs
@@ -77,6 +77,7 @@ fn enable_signing(governance: &Canister<'_>, subnet_id: SubnetId, logger: &Logge
     let enable_signing_payload = UpdateSubnetPayload {
         subnet_id,
         chain_key_signing_enable: Some(vec![MasterPublicKeyId::Ecdsa(make_key(KEY_ID1))]),
+        subnet_admins: None,
         ..empty_subnet_update()
     };
     block_on(execute_update_subnet_proposal(
@@ -91,6 +92,7 @@ fn disable_signing(governance: &Canister<'_>, subnet_id: SubnetId, logger: &Logg
     let disable_signing_payload = UpdateSubnetPayload {
         subnet_id,
         chain_key_signing_disable: Some(vec![MasterPublicKeyId::Ecdsa(make_key(KEY_ID1))]),
+        subnet_admins: None,
         ..empty_subnet_update()
     };
     block_on(execute_update_subnet_proposal(

--- a/rs/tests/consensus/tecdsa/utils/src/lib.rs
+++ b/rs/tests/consensus/tecdsa/utils/src/lib.rs
@@ -223,6 +223,7 @@ pub fn empty_subnet_update() -> UpdateSubnetPayload {
         max_number_of_canisters: None,
         ssh_readonly_access: None,
         ssh_backup_access: None,
+        subnet_admins: None,
         // Deprecated/unused values follow
         max_artifact_streams_per_peer: None,
         max_chunk_wait_ms: None,
@@ -992,6 +993,7 @@ pub async fn add_chain_keys_with_timeout_and_rotation_period(
 ) {
     let proposal_payload = UpdateSubnetPayload {
         subnet_id,
+        subnet_admins: None,
         chain_key_config: Some(ChainKeyConfig {
             key_configs: key_ids
                 .into_iter()
@@ -1035,6 +1037,7 @@ pub async fn enable_chain_key_signing_with_timeout_and_rotation_period(
 
     let proposal_payload = UpdateSubnetPayload {
         subnet_id,
+        subnet_admins: None,
         chain_key_signing_enable: Some(key_ids),
         ..empty_subnet_update()
     };
@@ -1195,6 +1198,7 @@ pub async fn set_pre_signature_stash_size(
 ) {
     let proposal_payload = UpdateSubnetPayload {
         subnet_id,
+        subnet_admins: None,
         chain_key_config: Some(ChainKeyConfig {
             key_configs: key_ids
                 .iter()

--- a/rs/tests/consensus/utils/src/ssh_access.rs
+++ b/rs/tests/consensus/utils/src/ssh_access.rs
@@ -209,6 +209,7 @@ pub fn get_update_subnet_payload_with_keys(
         max_number_of_canisters: None,
         ssh_readonly_access: readonly_keys,
         ssh_backup_access: backup_keys,
+        subnet_admins: None,
         // Deprecated/unused values follow
         max_artifact_streams_per_peer: None,
         max_chunk_wait_ms: None,

--- a/rs/tests/consensus/utils/src/subnet.rs
+++ b/rs/tests/consensus/utils/src/subnet.rs
@@ -119,6 +119,7 @@ pub fn enable_chain_key_signing_on_subnet(
     let enable_signing_payload = UpdateSubnetPayload {
         subnet_id,
         chain_key_signing_enable: Some(key_ids.clone()),
+        subnet_admins: None,
         ..empty_subnet_update()
     };
     block_on(execute_update_subnet_proposal(
@@ -152,6 +153,7 @@ pub fn disable_chain_key_on_subnet(
     let disable_signing_payload = UpdateSubnetPayload {
         subnet_id,
         chain_key_signing_disable: Some(key_ids.clone()),
+        subnet_admins: None,
         ..empty_subnet_update()
     };
     block_on(execute_update_subnet_proposal(

--- a/rs/tests/testnets/mainnet_nns/src/lib.rs
+++ b/rs/tests/testnets/mainnet_nns/src/lib.rs
@@ -288,6 +288,7 @@ async fn setup_recovered_nns(
             max_number_of_canisters: None,
             ssh_readonly_access: None,
             ssh_backup_access: None,
+            subnet_admins: None,
             max_artifact_streams_per_peer: None,
             max_chunk_wait_ms: None,
             max_duplicity: None,


### PR DESCRIPTION
- Adds optional `subnet_admins: Option<Vec<PrincipalId>>` to `UpdateSubnetPayload` so NNS proposals can replace a subnet's admin list (`None` = leave unchanged, `Some(vec![])` = clear, `Some(vec![...])` = replace). Wired through `merge_subnet_record` and exposed in ic-admin as `--subnet-admins`.
- Promotes the max-10 cap on `subnet_admins` from a local constant in `do_update_subnet_admins` to a registry invariant in `invariants::subnet`, so it's enforced uniformly on every mutation. The existing rented/cloud-engine constraint on having admins at all stays in the same invariant.
- Coexists with the Subnet Rental Canister's existing `update_subnet_admins` ingress (unchanged); that path keeps its `Add`/`Remove`/`Clear` semantics, rate limiting, and stricter "Application + Free" check.

No new proposal type, and no new validation in `do_update_subnet` — relies on the registry invariant for both the type/cost-schedule rule and the count cap, mirroring `do_create_subnet`.

