### PR TITLE
chore: Inline State and cert Bazel dependencies

### DIFF
--- a/rs/canonical_state/BUILD.bazel
+++ b/rs/canonical_state/BUILD.bazel
@@ -2,89 +2,195 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//packages/ic-error-types",
-    "//rs/canonical_state/certification_version",
-    "//rs/canonical_state/tree_hash",
-    "//rs/crypto/tree_hash",
-    "//rs/phantom_newtype",
-    "//rs/protobuf",
-    "//rs/registry/routing_table",
-    "//rs/registry/subnet_type",
-    "//rs/replicated_state",
-    "//rs/types/base_types",
-    "//rs/types/cycles",
-    "//rs/types/types",
-    "@crate_index//:leb128",
-    "@crate_index//:serde",
-    "@crate_index//:serde_bytes",
-    "@crate_index//:serde_cbor",
-    "@crate_index//:strum",
-]
-
-MACRO_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:strum_macros",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/canonical_state/tree_hash/test_utils",
-    "//rs/crypto/sha2",
-    "//rs/registry/subnet_features",
-    "//rs/sys",
-    "//rs/test_utilities/state",
-    "//rs/test_utilities/time",
-    "//rs/test_utilities/types",
-    "//rs/types/management_canister_types",
-    "//rs/types/wasm_types",
-    "//rs/utils",
-    "@crate_index//:assert_matches",
-    "@crate_index//:hex",
-    "@crate_index//:lazy_static",
-    "@crate_index//:maplit",
-    "@crate_index//:proptest",
-    "@crate_index//:tempfile",
-]
-
-MACRO_DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:test-strategy",
-]
-
 rust_library(
     name = "canonical_state",
     srcs = glob(["src/**"]),
     crate_name = "ic_canonical_state",
-    proc_macro_deps = MACRO_DEPENDENCIES,
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:strum_macros",
+    ],
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//packages/ic-error-types",
+        "//rs/canonical_state/certification_version",
+        "//rs/canonical_state/tree_hash",
+        "//rs/crypto/tree_hash",
+        "//rs/phantom_newtype",
+        "//rs/protobuf",
+        "//rs/registry/routing_table",
+        "//rs/registry/subnet_type",
+        "//rs/replicated_state",
+        "//rs/types/base_types",
+        "//rs/types/cycles",
+        "//rs/types/types",
+        "@crate_index//:leb128",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:strum",
+    ],
 )
 
 rust_test(
     name = "canonical_state_test",
     crate = ":canonical_state",
-    deps = DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/canonical_state/tree_hash/test_utils",
+        "//rs/crypto/sha2",
+        "//rs/registry/subnet_features",
+        "//rs/sys",
+        "//rs/test_utilities/state",
+        "//rs/test_utilities/time",
+        "//rs/test_utilities/types",
+        "//rs/types/management_canister_types",
+        "//rs/types/wasm_types",
+        "//rs/utils",
+        "@crate_index//:assert_matches",
+        "@crate_index//:hex",
+        "@crate_index//:lazy_static",
+        "@crate_index//:maplit",
+        "@crate_index//:proptest",
+        "@crate_index//:tempfile",
+    ],
 )
 
 rust_test(
     name = "compatibility_test",
     srcs = ["tests/compatibility.rs"],
-    proc_macro_deps = MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":canonical_state"],
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:test-strategy",
+    ],
+    deps = [
+        # Keep sorted.
+        ":canonical_state",
+        "//packages/ic-error-types",
+        "//rs/canonical_state/certification_version",
+        "//rs/canonical_state/tree_hash",
+        "//rs/canonical_state/tree_hash/test_utils",
+        "//rs/crypto/sha2",
+        "//rs/crypto/tree_hash",
+        "//rs/phantom_newtype",
+        "//rs/protobuf",
+        "//rs/registry/routing_table",
+        "//rs/registry/subnet_features",
+        "//rs/registry/subnet_type",
+        "//rs/replicated_state",
+        "//rs/sys",
+        "//rs/test_utilities/state",
+        "//rs/test_utilities/time",
+        "//rs/test_utilities/types",
+        "//rs/types/base_types",
+        "//rs/types/cycles",
+        "//rs/types/management_canister_types",
+        "//rs/types/types",
+        "//rs/types/wasm_types",
+        "//rs/utils",
+        "@crate_index//:assert_matches",
+        "@crate_index//:hex",
+        "@crate_index//:lazy_static",
+        "@crate_index//:leb128",
+        "@crate_index//:maplit",
+        "@crate_index//:proptest",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:strum",
+        "@crate_index//:tempfile",
+    ],
 )
 
 rust_test(
     name = "size_limit_visitor_test",
     srcs = ["tests/size_limit_visitor.rs"],
-    proc_macro_deps = MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":canonical_state"],
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:test-strategy",
+    ],
+    deps = [
+        # Keep sorted.
+        ":canonical_state",
+        "//packages/ic-error-types",
+        "//rs/canonical_state/certification_version",
+        "//rs/canonical_state/tree_hash",
+        "//rs/canonical_state/tree_hash/test_utils",
+        "//rs/crypto/sha2",
+        "//rs/crypto/tree_hash",
+        "//rs/phantom_newtype",
+        "//rs/protobuf",
+        "//rs/registry/routing_table",
+        "//rs/registry/subnet_features",
+        "//rs/registry/subnet_type",
+        "//rs/replicated_state",
+        "//rs/sys",
+        "//rs/test_utilities/state",
+        "//rs/test_utilities/time",
+        "//rs/test_utilities/types",
+        "//rs/types/base_types",
+        "//rs/types/cycles",
+        "//rs/types/management_canister_types",
+        "//rs/types/types",
+        "//rs/types/wasm_types",
+        "//rs/utils",
+        "@crate_index//:assert_matches",
+        "@crate_index//:hex",
+        "@crate_index//:lazy_static",
+        "@crate_index//:leb128",
+        "@crate_index//:maplit",
+        "@crate_index//:proptest",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:strum",
+        "@crate_index//:tempfile",
+    ],
 )
 
 rust_test(
     name = "hash_tree_test",
     srcs = ["tests/hash_tree.rs"],
-    proc_macro_deps = MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":canonical_state"],
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:test-strategy",
+    ],
+    deps = [
+        # Keep sorted.
+        ":canonical_state",
+        "//packages/ic-error-types",
+        "//rs/canonical_state/certification_version",
+        "//rs/canonical_state/tree_hash",
+        "//rs/canonical_state/tree_hash/test_utils",
+        "//rs/crypto/sha2",
+        "//rs/crypto/tree_hash",
+        "//rs/phantom_newtype",
+        "//rs/protobuf",
+        "//rs/registry/routing_table",
+        "//rs/registry/subnet_features",
+        "//rs/registry/subnet_type",
+        "//rs/replicated_state",
+        "//rs/sys",
+        "//rs/test_utilities/state",
+        "//rs/test_utilities/time",
+        "//rs/test_utilities/types",
+        "//rs/types/base_types",
+        "//rs/types/cycles",
+        "//rs/types/management_canister_types",
+        "//rs/types/types",
+        "//rs/types/wasm_types",
+        "//rs/utils",
+        "@crate_index//:assert_matches",
+        "@crate_index//:hex",
+        "@crate_index//:lazy_static",
+        "@crate_index//:leb128",
+        "@crate_index//:maplit",
+        "@crate_index//:proptest",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:strum",
+        "@crate_index//:tempfile",
+    ],
 )

--- a/rs/canonical_state/tree_hash/BUILD.bazel
+++ b/rs/canonical_state/tree_hash/BUILD.bazel
@@ -2,42 +2,42 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/tree_hash",
-    "@crate_index//:itertools",
-    "@crate_index//:leb128",
-    "@crate_index//:scoped_threadpool",
-    "@crate_index//:thiserror",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/canonical_state/tree_hash/test_utils",
-    "//rs/crypto/test_utils/reproducible_rng",
-    "//rs/crypto/tree_hash/test_utils",
-    "@crate_index//:assert_matches",
-    "@crate_index//:proptest",
-    "@crate_index//:rand",
-    "@crate_index//:rand_chacha",
-]
-
-MACRO_DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:test-strategy",
-]
-
 rust_library(
     name = "tree_hash",
     srcs = glob(["src/**/*.rs"]),
     crate_name = "ic_canonical_state_tree_hash",
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/tree_hash",
+        "@crate_index//:itertools",
+        "@crate_index//:leb128",
+        "@crate_index//:scoped_threadpool",
+        "@crate_index//:thiserror",
+    ],
 )
 
 rust_test_suite(
     name = "tree_hash_integration",
     srcs = glob(["tests/**/*.rs"]),
-    proc_macro_deps = MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":tree_hash"],
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:test-strategy",
+    ],
+    deps = [
+        # Keep sorted.
+        ":tree_hash",
+        "//rs/canonical_state/tree_hash/test_utils",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash",
+        "//rs/crypto/tree_hash/test_utils",
+        "@crate_index//:assert_matches",
+        "@crate_index//:itertools",
+        "@crate_index//:leb128",
+        "@crate_index//:proptest",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:scoped_threadpool",
+        "@crate_index//:thiserror",
+    ],
 )

--- a/rs/canonical_state/tree_hash/test_utils/BUILD.bazel
+++ b/rs/canonical_state/tree_hash/test_utils/BUILD.bazel
@@ -3,14 +3,6 @@ load("//bazel:fuzz_testing.bzl", "DEFAULT_RUSTC_FLAGS_FOR_FUZZING")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/canonical_state/tree_hash",
-    "//rs/crypto/tree_hash",
-    "//rs/crypto/tree_hash/test_utils",
-    "@crate_index//:rand",
-]
-
 rust_library(
     name = "test_utils",
     testonly = True,
@@ -21,5 +13,11 @@ rust_library(
         "//conditions:default": [],
     }),
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/canonical_state/tree_hash",
+        "//rs/crypto/tree_hash",
+        "//rs/crypto/tree_hash/test_utils",
+        "@crate_index//:rand",
+    ],
 )

--- a/rs/certification/BUILD.bazel
+++ b/rs/certification/BUILD.bazel
@@ -3,50 +3,71 @@ load("//bazel:defs.bzl", "rust_bench")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/tree_hash",
-    "//rs/crypto/utils/threshold_sig",
-    "//rs/crypto/utils/threshold_sig_der",
-    "//rs/tree_deserializer",
-    "//rs/types/types",
-    "@crate_index//:hex",
-    "@crate_index//:serde",
-    "@crate_index//:serde_cbor",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/canonical_state",
-    "//rs/certification/test-utils",
-    "//rs/crypto/internal/crypto_lib/types",
-    "//rs/crypto/test_utils/reproducible_rng",
-    "//rs/types/base_types",
-    "@crate_index//:assert_matches",
-    "@crate_index//:rand",
-    "@crate_index//:rstest",
-]
-
 rust_library(
     name = "certification",
     srcs = glob(["src/**"]),
     crate_name = "ic_certification",
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/tree_hash",
+        "//rs/crypto/utils/threshold_sig",
+        "//rs/crypto/utils/threshold_sig_der",
+        "//rs/tree_deserializer",
+        "//rs/types/types",
+        "@crate_index//:hex",
+        "@crate_index//:serde",
+        "@crate_index//:serde_cbor",
+    ],
 )
 
 rust_test(
     name = "certification_test",
     crate = ":certification",
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/canonical_state",
+        "//rs/certification/test-utils",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash",
+        "//rs/crypto/utils/threshold_sig",
+        "//rs/crypto/utils/threshold_sig_der",
+        "//rs/tree_deserializer",
+        "//rs/types/base_types",
+        "//rs/types/types",
+        "@crate_index//:assert_matches",
+        "@crate_index//:hex",
+        "@crate_index//:rand",
+        "@crate_index//:rstest",
+        "@crate_index//:serde",
+        "@crate_index//:serde_cbor",
+    ],
 )
 
 rust_bench(
     name = "certification_bench",
     srcs = ["benches/certification.rs"],
     crate_root = "benches/certification.rs",
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [
+    deps = [
+        # Keep sorted.
         ":certification",
+        "//rs/canonical_state",
+        "//rs/certification/test-utils",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash",
+        "//rs/crypto/utils/threshold_sig",
+        "//rs/crypto/utils/threshold_sig_der",
+        "//rs/tree_deserializer",
+        "//rs/types/base_types",
+        "//rs/types/types",
+        "@crate_index//:assert_matches",
         "@crate_index//:criterion",
+        "@crate_index//:hex",
+        "@crate_index//:rand",
+        "@crate_index//:rstest",
+        "@crate_index//:serde",
+        "@crate_index//:serde_cbor",
     ],
 )

--- a/rs/certification/test-utils/BUILD.bazel
+++ b/rs/certification/test-utils/BUILD.bazel
@@ -2,26 +2,24 @@ load("@rules_rust//rust:defs.bzl", "rust_doc_test", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/internal/crypto_lib/seed",
-    "//rs/crypto/internal/crypto_lib/threshold_sig/bls12_381",
-    "//rs/crypto/internal/crypto_lib/types",
-    "//rs/crypto/tree_hash",
-    "//rs/crypto/utils/threshold_sig_der",
-    "//rs/types/types",
-    "@crate_index//:leb128",
-    "@crate_index//:rand",
-    "@crate_index//:serde",
-    "@crate_index//:serde_cbor",
-]
-
 rust_library(
     name = "test-utils",
     srcs = glob(["src/**"]),
     crate_name = "ic_certification_test_utils",
     version = "0.1.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/internal/crypto_lib/seed",
+        "//rs/crypto/internal/crypto_lib/threshold_sig/bls12_381",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/tree_hash",
+        "//rs/crypto/utils/threshold_sig_der",
+        "//rs/types/types",
+        "@crate_index//:leb128",
+        "@crate_index//:rand",
+        "@crate_index//:serde",
+        "@crate_index//:serde_cbor",
+    ],
 )
 
 rust_doc_test(

--- a/rs/crypto/tree_hash/BUILD.bazel
+++ b/rs/crypto/tree_hash/BUILD.bazel
@@ -4,34 +4,6 @@ load("//bazel:fuzz_testing.bzl", "DEFAULT_RUSTC_FLAGS_FOR_FUZZING")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/internal/crypto_lib/types",
-    "//rs/crypto/sha2",
-    "//rs/protobuf",
-    "@crate_index//:serde",
-    "@crate_index//:serde_bytes",
-    "@crate_index//:thiserror",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/test_utils/reproducible_rng",
-    "//rs/crypto/tree_hash/test_utils",
-    "@crate_index//:assert_matches",
-    "@crate_index//:criterion",
-    "@crate_index//:maplit",
-    "@crate_index//:proptest",
-    "@crate_index//:prost",
-    "@crate_index//:rand",
-    "@crate_index//:serde_cbor",
-]
-
-MACRO_DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:test-strategy",
-]
-
 rust_library(
     name = "tree_hash",
     srcs = glob(["src/**"]),
@@ -41,38 +13,126 @@ rust_library(
         "//conditions:default": [],
     }),
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/sha2",
+        "//rs/protobuf",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:thiserror",
+    ],
 )
 
 rust_test(
     name = "tree_hash_test",
     crate = ":tree_hash",
-    deps = DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash/test_utils",
+        "@crate_index//:assert_matches",
+        "@crate_index//:criterion",
+        "@crate_index//:maplit",
+        "@crate_index//:proptest",
+        "@crate_index//:prost",
+        "@crate_index//:rand",
+        "@crate_index//:serde_cbor",
+    ],
 )
 
 rust_test_suite(
     name = "tree_hash_integration",
     srcs = glob(["tests/**"]),
-    proc_macro_deps = MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":tree_hash"],
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:test-strategy",
+    ],
+    deps = [
+        # Keep sorted.
+        ":tree_hash",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/sha2",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash/test_utils",
+        "//rs/protobuf",
+        "@crate_index//:assert_matches",
+        "@crate_index//:criterion",
+        "@crate_index//:maplit",
+        "@crate_index//:proptest",
+        "@crate_index//:prost",
+        "@crate_index//:rand",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:thiserror",
+    ],
 )
 
 rust_doc_test(
     name = "tree_hash_doc_test",
     crate = ":tree_hash",
-    deps = DEV_DEPENDENCIES + ["@crate_index//:rand_chacha"],
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash/test_utils",
+        "@crate_index//:assert_matches",
+        "@crate_index//:criterion",
+        "@crate_index//:maplit",
+        "@crate_index//:proptest",
+        "@crate_index//:prost",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:serde_cbor",
+    ],
 )
 
 rust_bench(
     name = "tree_hash_bench",
     testonly = True,
     srcs = ["benches/tree_hash.rs"],
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":tree_hash"],
+    deps = [
+        # Keep sorted.
+        ":tree_hash",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/sha2",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash/test_utils",
+        "//rs/protobuf",
+        "@crate_index//:assert_matches",
+        "@crate_index//:criterion",
+        "@crate_index//:maplit",
+        "@crate_index//:proptest",
+        "@crate_index//:prost",
+        "@crate_index//:rand",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:thiserror",
+    ],
 )
 
 rust_bench(
     name = "flat_map_bench",
     testonly = True,
     srcs = ["benches/flat_map.rs"],
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":tree_hash"],
+    deps = [
+        # Keep sorted.
+        ":tree_hash",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/sha2",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash/test_utils",
+        "//rs/protobuf",
+        "@crate_index//:assert_matches",
+        "@crate_index//:criterion",
+        "@crate_index//:maplit",
+        "@crate_index//:proptest",
+        "@crate_index//:prost",
+        "@crate_index//:rand",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:thiserror",
+    ],
 )

--- a/rs/crypto/tree_hash/test_utils/BUILD.bazel
+++ b/rs/crypto/tree_hash/test_utils/BUILD.bazel
@@ -3,25 +3,6 @@ load("//bazel:fuzz_testing.bzl", "DEFAULT_RUSTC_FLAGS_FOR_FUZZING")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/tree_hash",
-    "@crate_index//:assert_matches",
-    "@crate_index//:proptest",
-    "@crate_index//:rand",
-    "@crate_index//:thiserror",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/test_utils/reproducible_rng",
-]
-
-MACRO_DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:test-strategy",
-]
-
 rust_library(
     name = "test_utils",
     testonly = True,
@@ -32,12 +13,31 @@ rust_library(
         "//conditions:default": [],
     }),
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/tree_hash",
+        "@crate_index//:assert_matches",
+        "@crate_index//:proptest",
+        "@crate_index//:rand",
+        "@crate_index//:thiserror",
+    ],
 )
 
 rust_test_suite(
     name = "test_utils_integration",
     srcs = glob(["tests/**"]),
-    proc_macro_deps = MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":test_utils"],
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:test-strategy",
+    ],
+    deps = [
+        # Keep sorted.
+        ":test_utils",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash",
+        "@crate_index//:assert_matches",
+        "@crate_index//:proptest",
+        "@crate_index//:rand",
+        "@crate_index//:thiserror",
+    ],
 )

--- a/rs/utils/thread/BUILD.bazel
+++ b/rs/utils/thread/BUILD.bazel
@@ -2,21 +2,20 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:crossbeam-channel",
-]
-
 rust_library(
     name = "thread",
     srcs = glob(["src/**"]),
     crate_name = "ic_utils_thread",
     version = "0.1.0",
-    deps = DEPENDENCIES,
+    deps = [
+        "@crate_index//:crossbeam-channel",
+    ],
 )
 
 rust_test(
     name = "thread_test",
     crate = ":thread",
-    deps = DEPENDENCIES,
+    deps = [
+        "@crate_index//:crossbeam-channel",
+    ],
 )

--- a/rs/xnet/uri/BUILD.bazel
+++ b/rs/xnet/uri/BUILD.bazel
@@ -2,22 +2,24 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/types/types",
-    "@crate_index//:http",
-]
-
 rust_library(
     name = "uri",
     srcs = glob(["src/**"]),
     crate_name = "ic_xnet_uri",
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/types/types",
+        "@crate_index//:http",
+    ],
 )
 
 rust_test(
     name = "uri_test",
     crate = ":uri",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/types/types",
+        "@crate_index//:http",
+    ],
 )


### PR DESCRIPTION
This inlines dependencies in BUILD.bazel files. This helps readability and allows for automatic duplicate & unused dependency pruning. This aligns those packages with the rest of the codebase.