### PR TITLE
chore: Inline DeFi Bazel dependencies

### DIFF
--- a/packages/canlog/BUILD.bazel
+++ b/packages/canlog/BUILD.bazel
@@ -2,36 +2,35 @@ load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_doc_test", "rust_library", 
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    "@crate_index//:candid",
-    "@crate_index//:ic-canister-log",
-    "@crate_index//:ic0",
-    "@crate_index//:regex-lite",
-    "@crate_index//:serde",
-    "@crate_index//:serde_json",
-]
-
-MACRO_DEPENDENCIES = [
-    # Keep sorted.
-    "//packages/canlog_derive",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:proptest",
-]
-
 rust_library(
     name = "canlog",
     srcs = glob(["src/**/*.rs"]),
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    deps = DEPENDENCIES,
+    proc_macro_deps = [
+        # Keep sorted.
+        "//packages/canlog_derive",
+    ],
+    deps = [
+        "@crate_index//:candid",
+        "@crate_index//:ic-canister-log",
+        "@crate_index//:ic0",
+        "@crate_index//:regex-lite",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
 )
 
 rust_test(
     name = "unit_tests",
     crate = ":canlog",
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        "@crate_index//:candid",
+        "@crate_index//:ic-canister-log",
+        "@crate_index//:ic0",
+        "@crate_index//:proptest",
+        "@crate_index//:regex-lite",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
 )
 
 rust_doc(
@@ -42,5 +41,14 @@ rust_doc(
 rust_doc_test(
     name = "doc_test",
     crate = ":canlog",
-    deps = [":canlog"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        ":canlog",
+        "@crate_index//:candid",
+        "@crate_index//:ic-canister-log",
+        "@crate_index//:ic0",
+        "@crate_index//:proptest",
+        "@crate_index//:regex-lite",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
 )

--- a/packages/canlog_derive/BUILD.bazel
+++ b/packages/canlog_derive/BUILD.bazel
@@ -2,22 +2,16 @@ load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_doc_test", "rust_proc_macro
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:darling",
-    "@crate_index//:proc-macro2",
-    "@crate_index//:quote",
-    "@crate_index//:syn",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-]
-
 rust_proc_macro(
     name = "canlog_derive",
     srcs = glob(["src/**/*.rs"]),
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:darling",
+        "@crate_index//:proc-macro2",
+        "@crate_index//:quote",
+        "@crate_index//:syn",
+    ],
 )
 
 rust_doc(
@@ -28,5 +22,12 @@ rust_doc(
 rust_doc_test(
     name = "doc_test",
     crate = ":canlog_derive",
-    deps = [":canlog_derive"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":canlog_derive",
+        "@crate_index//:darling",
+        "@crate_index//:proc-macro2",
+        "@crate_index//:quote",
+        "@crate_index//:syn",
+    ],
 )

--- a/packages/ic-ethereum-types/BUILD.bazel
+++ b/packages/ic-ethereum-types/BUILD.bazel
@@ -2,31 +2,27 @@ load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_doc_test", "rust_library", 
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:hex",
-    "@crate_index//:ic-sha3",
-    "@crate_index//:minicbor",
-    "@crate_index//:serde",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:assert_matches",
-    "@crate_index//:proptest",
-    "@crate_index//:serde_json",
-]
-
 rust_library(
     name = "ic-ethereum-types",
     srcs = glob(["src/**/*.rs"]),
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:hex",
+        "@crate_index//:ic-sha3",
+        "@crate_index//:minicbor",
+        "@crate_index//:serde",
+    ],
 )
 
 rust_test(
     name = "unit_tests",
     crate = ":ic-ethereum-types",
-    deps = DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:assert_matches",
+        "@crate_index//:proptest",
+        "@crate_index//:serde_json",
+    ],
 )
 
 rust_doc(
@@ -37,5 +33,15 @@ rust_doc(
 rust_doc_test(
     name = "doc_test",
     crate = ":ic-ethereum-types",
-    deps = [":ic-ethereum-types"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-ethereum-types",
+        "@crate_index//:assert_matches",
+        "@crate_index//:hex",
+        "@crate_index//:ic-sha3",
+        "@crate_index//:minicbor",
+        "@crate_index//:proptest",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
 )

--- a/packages/ic-http-types/BUILD.bazel
+++ b/packages/ic-http-types/BUILD.bazel
@@ -2,18 +2,16 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:candid",
-    "@crate_index//:serde",
-    "@crate_index//:serde_bytes",
-]
-
 rust_library(
     name = "ic-http-types",
     srcs = glob(["src/**"]),
     version = "0.1.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:candid",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+    ],
 )
 
 rust_test(

--- a/rs/cross-chain/proposal-cli/BUILD.bazel
+++ b/rs/cross-chain/proposal-cli/BUILD.bazel
@@ -1,37 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:askama",
-    "@crate_index//:candid",
-    "@crate_index//:candid_parser",
-    "@crate_index//:clap",
-    "@crate_index//:futures",
-    "@crate_index//:hex",
-    "@crate_index//:maplit",
-    "@crate_index//:reqwest",
-    "@crate_index//:serde",
-    "@crate_index//:serde_json",
-    "@crate_index//:sha2",
-    "@crate_index//:strum",
-    "@crate_index//:tempfile",
-    "@crate_index//:tokio",
-    "@crate_index//:url",
-]
-
-MACRO_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:strum_macros",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:assert_matches",
-    "@crate_index//:maplit",
-]
-
-DEV_MACRO_DEPENDENCIES = []
-
 rust_binary(
     name = "make_proposal",
     srcs = glob(["src/**/*.rs"]),
@@ -41,8 +9,28 @@ rust_binary(
         "templates/reinstall.md",
         "templates/submit_with_ic_admin.shx",
     ],
-    proc_macro_deps = MACRO_DEPENDENCIES,
-    deps = DEPENDENCIES,
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:strum_macros",
+    ],
+    deps = [
+        # Keep sorted.
+        "@crate_index//:askama",
+        "@crate_index//:candid",
+        "@crate_index//:candid_parser",
+        "@crate_index//:clap",
+        "@crate_index//:futures",
+        "@crate_index//:hex",
+        "@crate_index//:maplit",
+        "@crate_index//:reqwest",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+        "@crate_index//:sha2",
+        "@crate_index//:strum",
+        "@crate_index//:tempfile",
+        "@crate_index//:tokio",
+        "@crate_index//:url",
+    ],
 )
 
 rust_test(
@@ -61,6 +49,9 @@ rust_test(
         "//rs/ledger_suite/icrc1/index-ng:index-ng.did",
         "//rs/ledger_suite/icrc1/ledger:ledger.did",
     ],
-    proc_macro_deps = DEV_MACRO_DEPENDENCIES,
-    deps = DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:assert_matches",
+        "@crate_index//:maplit",
+    ],
 )


### PR DESCRIPTION
This inlines dependencies in BUILD.bazel files. This helps readability and allows for automatic duplicate & unused dependency pruning. This aligns those packages with the rest of the codebase.