### PR TITLE
chore: Inline Crypto Bazel dependencies

### DIFF
--- a/packages/ic-ed25519/BUILD.bazel
+++ b/packages/ic-ed25519/BUILD.bazel
@@ -2,41 +2,24 @@ load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_doc_test", "rust_library", 
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:curve25519-dalek",
-    "@crate_index//:ed25519-dalek",
-    "@crate_index//:hex-literal",
-    "@crate_index//:hkdf",
-    "@crate_index//:ic_principal",
-    "@crate_index//:pem",
-    "@crate_index//:rand",
-    "@crate_index//:thiserror",
-    "@crate_index//:zeroize",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:hex",
-    "@crate_index//:rand_chacha",
-    "@crate_index//:wycheproof",
-]
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "ic-ed25519",
     srcs = glob(["src/**/*.rs"]),
-    aliases = ALIASES,
     crate_features = ["rand"],
     crate_name = "ic_ed25519",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.6.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:curve25519-dalek",
+        "@crate_index//:ed25519-dalek",
+        "@crate_index//:hex-literal",
+        "@crate_index//:hkdf",
+        "@crate_index//:ic_principal",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:thiserror",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_doc(
@@ -47,22 +30,62 @@ rust_doc(
 rust_doc_test(
     name = "doc_test",
     crate = ":ic-ed25519",
-    deps = [":ic-ed25519"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-ed25519",
+        "@crate_index//:curve25519-dalek",
+        "@crate_index//:ed25519-dalek",
+        "@crate_index//:hex",
+        "@crate_index//:hex-literal",
+        "@crate_index//:hkdf",
+        "@crate_index//:ic_principal",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:thiserror",
+        "@crate_index//:wycheproof",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_test(
     name = "test",
-    aliases = ALIASES,
     crate = ":ic-ed25519",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:curve25519-dalek",
+        "@crate_index//:ed25519-dalek",
+        "@crate_index//:hex",
+        "@crate_index//:hex-literal",
+        "@crate_index//:hkdf",
+        "@crate_index//:ic_principal",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:thiserror",
+        "@crate_index//:wycheproof",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_test_suite(
     name = "integration_tests",
     srcs = glob(["tests/**/*.rs"]),
-    aliases = ALIASES,
     compile_data = glob(["tests/data/*"]),
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":ic-ed25519"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-ed25519",
+        "@crate_index//:curve25519-dalek",
+        "@crate_index//:ed25519-dalek",
+        "@crate_index//:hex",
+        "@crate_index//:hex-literal",
+        "@crate_index//:hkdf",
+        "@crate_index//:ic_principal",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:thiserror",
+        "@crate_index//:wycheproof",
+        "@crate_index//:zeroize",
+    ],
 )

--- a/packages/ic-hpke/BUILD.bazel
+++ b/packages/ic-hpke/BUILD.bazel
@@ -2,32 +2,15 @@ load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_doc_test", "rust_library", 
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:hpke",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:hex",
-    "@crate_index//:rand",
-    "@crate_index//:rand_chacha",
-]
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "ic-hpke",
     srcs = glob(["src/**/*.rs"]),
-    aliases = ALIASES,
     crate_name = "ic_hpke",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.1.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:hpke",
+    ],
 )
 
 rust_doc(
@@ -38,21 +21,37 @@ rust_doc(
 rust_doc_test(
     name = "doc_test",
     crate = ":ic-hpke",
-    deps = [":ic-hpke"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-hpke",
+        "@crate_index//:hex",
+        "@crate_index//:hpke",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+    ],
 )
 
 rust_test(
     name = "test",
-    aliases = ALIASES,
     crate = ":ic-hpke",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:hex",
+        "@crate_index//:hpke",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+    ],
 )
 
 rust_test_suite(
     name = "integration_tests",
     srcs = glob(["tests/**/*.rs"]),
-    aliases = ALIASES,
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":ic-hpke"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-hpke",
+        "@crate_index//:hex",
+        "@crate_index//:hpke",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+    ],
 )

--- a/packages/ic-secp256k1/BUILD.bazel
+++ b/packages/ic-secp256k1/BUILD.bazel
@@ -2,43 +2,25 @@ load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_doc_test", "rust_library", 
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:hex-literal",
-    "@crate_index//:hmac",
-    "@crate_index//:ic_principal",
-    "@crate_index//:k256",
-    "@crate_index//:num-bigint",
-    "@crate_index//:pem",
-    "@crate_index//:rand",
-    "@crate_index//:rand_chacha",
-    "@crate_index//:sha2",
-    "@crate_index//:simple_asn1",
-    "@crate_index//:zeroize",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:bip32",
-    "@crate_index//:bitcoin-0.28.2",
-    "@crate_index//:hex",
-    "@crate_index//:wycheproof",
-]
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "ic-secp256k1",
     srcs = glob(["src/**"]),
-    aliases = ALIASES,
     crate_name = "ic_secp256k1",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.3.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:hex-literal",
+        "@crate_index//:hmac",
+        "@crate_index//:ic_principal",
+        "@crate_index//:k256",
+        "@crate_index//:num-bigint",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:sha2",
+        "@crate_index//:simple_asn1",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_doc(
@@ -49,21 +31,70 @@ rust_doc(
 rust_doc_test(
     name = "doc_test",
     crate = ":ic-secp256k1",
-    deps = [":ic-secp256k1"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-secp256k1",
+        "@crate_index//:bip32",
+        "@crate_index//:bitcoin-0.28.2",
+        "@crate_index//:hex",
+        "@crate_index//:hex-literal",
+        "@crate_index//:hmac",
+        "@crate_index//:ic_principal",
+        "@crate_index//:k256",
+        "@crate_index//:num-bigint",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:sha2",
+        "@crate_index//:simple_asn1",
+        "@crate_index//:wycheproof",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_test(
     name = "test",
-    aliases = ALIASES,
     crate = ":ic-secp256k1",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:bip32",
+        "@crate_index//:bitcoin-0.28.2",
+        "@crate_index//:hex",
+        "@crate_index//:hex-literal",
+        "@crate_index//:hmac",
+        "@crate_index//:ic_principal",
+        "@crate_index//:k256",
+        "@crate_index//:num-bigint",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:sha2",
+        "@crate_index//:simple_asn1",
+        "@crate_index//:wycheproof",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_test_suite(
     name = "integration_tests",
     srcs = glob(["tests/**/*.rs"]),
-    aliases = ALIASES,
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":ic-secp256k1"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-secp256k1",
+        "@crate_index//:bip32",
+        "@crate_index//:bitcoin-0.28.2",
+        "@crate_index//:hex",
+        "@crate_index//:hex-literal",
+        "@crate_index//:hmac",
+        "@crate_index//:ic_principal",
+        "@crate_index//:k256",
+        "@crate_index//:num-bigint",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:sha2",
+        "@crate_index//:simple_asn1",
+        "@crate_index//:wycheproof",
+        "@crate_index//:zeroize",
+    ],
 )

--- a/packages/ic-secp256r1/BUILD.bazel
+++ b/packages/ic-secp256r1/BUILD.bazel
@@ -2,56 +2,66 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:hmac",
-    "@crate_index//:num-bigint",
-    "@crate_index//:p256",
-    "@crate_index//:pem",
-    "@crate_index//:rand",
-    "@crate_index//:rand_chacha",
-    "@crate_index//:sha2",
-    "@crate_index//:simple_asn1",
-    "@crate_index//:zeroize",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/sha2",
-    "//rs/crypto/test_utils/reproducible_rng",
-    "@crate_index//:hex",
-    "@crate_index//:hex-literal",
-    "@crate_index//:wycheproof",
-]
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "ic-secp256r1",
     srcs = glob(["src/**"]),
-    aliases = ALIASES,
     crate_name = "ic_secp256r1",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.2.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:hmac",
+        "@crate_index//:num-bigint",
+        "@crate_index//:p256",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:sha2",
+        "@crate_index//:simple_asn1",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_test(
     name = "test",
-    aliases = ALIASES,
     crate = ":ic-secp256r1",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/sha2",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "@crate_index//:hex",
+        "@crate_index//:hex-literal",
+        "@crate_index//:hmac",
+        "@crate_index//:num-bigint",
+        "@crate_index//:p256",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:sha2",
+        "@crate_index//:simple_asn1",
+        "@crate_index//:wycheproof",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_test_suite(
     name = "integration",
     srcs = glob(["tests/**/*.rs"]),
-    aliases = ALIASES,
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":ic-secp256r1"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-secp256r1",
+        "//rs/crypto/sha2",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "@crate_index//:hex",
+        "@crate_index//:hex-literal",
+        "@crate_index//:hmac",
+        "@crate_index//:num-bigint",
+        "@crate_index//:p256",
+        "@crate_index//:pem",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:sha2",
+        "@crate_index//:simple_asn1",
+        "@crate_index//:wycheproof",
+        "@crate_index//:zeroize",
+    ],
 )

--- a/packages/ic-sha3/BUILD.bazel
+++ b/packages/ic-sha3/BUILD.bazel
@@ -2,20 +2,13 @@ load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_doc_test", "rust_library", 
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:sha3",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:hex",
-]
-
 rust_library(
     name = "ic-sha3",
     srcs = glob(["src/**/*.rs"]),
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:sha3",
+    ],
 )
 
 rust_test(
@@ -32,7 +25,12 @@ rust_test_suite(
         "test_resources/SHAKE256ShortMsg_subset.rsp",
         "test_resources/SHAKE256VariableOut_subset.rsp",
     ],
-    deps = [":ic-sha3"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-sha3",
+        "@crate_index//:hex",
+        "@crate_index//:sha3",
+    ],
 )
 
 rust_doc(
@@ -43,5 +41,10 @@ rust_doc(
 rust_doc_test(
     name = "doc_test",
     crate = ":ic-sha3",
-    deps = [":ic-sha3"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":ic-sha3",
+        "@crate_index//:hex",
+        "@crate_index//:sha3",
+    ],
 )

--- a/packages/ic-signature-verification/BUILD.bazel
+++ b/packages/ic-signature-verification/BUILD.bazel
@@ -2,36 +2,40 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    "@crate_index//:ic_principal",
-    "@crate_index//:ic-canister-sig-creation",
-    "@crate_index//:ic-certification",
-    "@crate_index//:ic-verify-bls-signature",
-    "@crate_index//:serde",
-    "@crate_index//:serde_bytes",
-    "@crate_index//:serde_cbor",
-    "@crate_index//:sha2",
-]
-
-TEST_DEPENDENCIES = [
-    "//rs/crypto/internal/crypto_lib/types",
-    "//rs/crypto/test_utils/canister_sigs",
-    "//rs/crypto/test_utils/reproducible_rng",
-    "//rs/types/types",
-    "@crate_index//:assert_matches",
-    "@crate_index//:hex",
-]
-
 rust_library(
     name = "ic-signature-verification",
     srcs = glob(["src/**/*.rs"]),
-    deps = DEPENDENCIES,
+    deps = [
+        "@crate_index//:ic_principal",
+        "@crate_index//:ic-canister-sig-creation",
+        "@crate_index//:ic-certification",
+        "@crate_index//:ic-verify-bls-signature",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:sha2",
+    ],
 )
 
 rust_test(
     name = "unit_tests",
     crate = ":ic-signature-verification",
-    deps = DEPENDENCIES + TEST_DEPENDENCIES,
+    deps = [
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/test_utils/canister_sigs",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/types/types",
+        "@crate_index//:assert_matches",
+        "@crate_index//:hex",
+        "@crate_index//:ic-canister-sig-creation",
+        "@crate_index//:ic-certification",
+        "@crate_index//:ic-verify-bls-signature",
+        "@crate_index//:ic_principal",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:sha2",
+    ],
 )
 
 rust_test_suite(
@@ -39,5 +43,21 @@ rust_test_suite(
     srcs = glob(
         ["tests/**/*.rs"],
     ),
-    deps = [":ic-signature-verification"] + DEPENDENCIES + TEST_DEPENDENCIES,
+    deps = [
+        ":ic-signature-verification",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/test_utils/canister_sigs",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/types/types",
+        "@crate_index//:assert_matches",
+        "@crate_index//:hex",
+        "@crate_index//:ic-canister-sig-creation",
+        "@crate_index//:ic-certification",
+        "@crate_index//:ic-verify-bls-signature",
+        "@crate_index//:ic_principal",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:sha2",
+    ],
 )

--- a/packages/ic-signature-verification/BUILD.bazel
+++ b/packages/ic-signature-verification/BUILD.bazel
@@ -6,10 +6,10 @@ rust_library(
     name = "ic-signature-verification",
     srcs = glob(["src/**/*.rs"]),
     deps = [
-        "@crate_index//:ic_principal",
         "@crate_index//:ic-canister-sig-creation",
         "@crate_index//:ic-certification",
         "@crate_index//:ic-verify-bls-signature",
+        "@crate_index//:ic_principal",
         "@crate_index//:serde",
         "@crate_index//:serde_bytes",
         "@crate_index//:serde_cbor",

--- a/rs/crypto/for_verification_only/BUILD.bazel
+++ b/rs/crypto/for_verification_only/BUILD.bazel
@@ -2,52 +2,53 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/temp_crypto",
-    "//rs/crypto/tls_interfaces",
-    "//rs/interfaces",
-    "//rs/interfaces/registry",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/interfaces/sig_verification",
-    "//rs/crypto/test_utils",
-    "//rs/crypto/test_utils/reproducible_rng",
-    "//rs/registry/fake",
-    "//rs/registry/proto_data_provider",
-    "//rs/types/types",
-]
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "for_verification_only",
     srcs = glob(["src/**/*.rs"]),
-    aliases = ALIASES,
     crate_name = "ic_crypto_for_verification_only",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/temp_crypto",
+        "//rs/crypto/tls_interfaces",
+        "//rs/interfaces",
+        "//rs/interfaces/registry",
+    ],
 )
 
 rust_test(
     name = "verification_test",
-    aliases = ALIASES,
     crate = ":for_verification_only",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/interfaces/sig_verification",
+        "//rs/crypto/temp_crypto",
+        "//rs/crypto/test_utils",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tls_interfaces",
+        "//rs/interfaces",
+        "//rs/interfaces/registry",
+        "//rs/registry/fake",
+        "//rs/registry/proto_data_provider",
+        "//rs/types/types",
+    ],
 )
 
 rust_test_suite(
     name = "for_verification_only_integration",
     srcs = glob(["tests/**/*.rs"]),
-    aliases = ALIASES,
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":for_verification_only"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":for_verification_only",
+        "//rs/crypto/interfaces/sig_verification",
+        "//rs/crypto/temp_crypto",
+        "//rs/crypto/test_utils",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tls_interfaces",
+        "//rs/interfaces",
+        "//rs/interfaces/registry",
+        "//rs/registry/fake",
+        "//rs/registry/proto_data_provider",
+        "//rs/types/types",
+    ],
 )

--- a/rs/crypto/iccsa/BUILD.bazel
+++ b/rs/crypto/iccsa/BUILD.bazel
@@ -2,52 +2,79 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/certification",
-    "//rs/crypto/internal/crypto_lib/basic_sig/der_utils",
-    "//rs/crypto/internal/crypto_lib/types",
-    "//rs/crypto/sha2",
-    "//rs/crypto/tree_hash",
-    "//rs/types/types",
-    "@crate_index//:base64",
-    "@crate_index//:hex",
-    "@crate_index//:serde",
-    "@crate_index//:serde_bytes",
-    "@crate_index//:serde_cbor",
-    "@crate_index//:simple_asn1",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/certification/test-utils",
-    "//rs/crypto/iccsa/test_utils",
-    "//rs/crypto/test_utils",
-    "//rs/crypto/test_utils/reproducible_rng",
-    "//rs/interfaces",
-    "@crate_index//:assert_matches",
-    "@crate_index//:rand",
-]
-
-ALIASES = {}
-
 rust_library(
     name = "iccsa",
     srcs = glob(["src/**"]),
-    aliases = ALIASES,
     crate_name = "ic_crypto_iccsa",
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/certification",
+        "//rs/crypto/internal/crypto_lib/basic_sig/der_utils",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/sha2",
+        "//rs/crypto/tree_hash",
+        "//rs/types/types",
+        "@crate_index//:base64",
+        "@crate_index//:hex",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:simple_asn1",
+    ],
 )
 
 rust_test(
     name = "unit_tests",
     crate = ":iccsa",
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/certification",
+        "//rs/certification/test-utils",
+        "//rs/crypto/iccsa/test_utils",
+        "//rs/crypto/internal/crypto_lib/basic_sig/der_utils",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/sha2",
+        "//rs/crypto/test_utils",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash",
+        "//rs/interfaces",
+        "//rs/types/types",
+        "@crate_index//:assert_matches",
+        "@crate_index//:base64",
+        "@crate_index//:hex",
+        "@crate_index//:rand",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:simple_asn1",
+    ],
 )
 
 rust_test_suite(
     name = "integration_tests",
     srcs = glob(["tests/**/*.rs"]),
-    deps = DEPENDENCIES + DEV_DEPENDENCIES + [":iccsa"],
+    deps = [
+        # Keep sorted.
+        ":iccsa",
+        "//rs/certification",
+        "//rs/certification/test-utils",
+        "//rs/crypto/iccsa/test_utils",
+        "//rs/crypto/internal/crypto_lib/basic_sig/der_utils",
+        "//rs/crypto/internal/crypto_lib/types",
+        "//rs/crypto/sha2",
+        "//rs/crypto/test_utils",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/tree_hash",
+        "//rs/interfaces",
+        "//rs/types/types",
+        "@crate_index//:assert_matches",
+        "@crate_index//:base64",
+        "@crate_index//:hex",
+        "@crate_index//:rand",
+        "@crate_index//:serde",
+        "@crate_index//:serde_bytes",
+        "@crate_index//:serde_cbor",
+        "@crate_index//:simple_asn1",
+    ],
 )

--- a/rs/crypto/iccsa/test_utils/BUILD.bazel
+++ b/rs/crypto/iccsa/test_utils/BUILD.bazel
@@ -5,20 +5,18 @@ package(default_visibility = [
     "//rs/validator/http_request_test_utils:__pkg__",
 ])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/certification/test-utils",
-    "//rs/crypto/sha2",
-    "//rs/crypto/tree_hash",
-    "//rs/types/types",
-    "@crate_index//:rand",
-]
-
 rust_library(
     name = "test_utils",
     testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_crypto_iccsa_test_utils",
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/certification/test-utils",
+        "//rs/crypto/sha2",
+        "//rs/crypto/tree_hash",
+        "//rs/types/types",
+        "@crate_index//:rand",
+    ],
 )

--- a/rs/crypto/interfaces/sig_verification/BUILD.bazel
+++ b/rs/crypto/interfaces/sig_verification/BUILD.bazel
@@ -2,17 +2,15 @@ load("@rules_rust//rust:defs.bzl", "rust_doc", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/types/types",
-]
-
 rust_library(
     name = "sig_verification",
     srcs = glob(["src/**/*.rs"]),
     crate_name = "ic_crypto_interfaces_sig_verification",
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/types/types",
+    ],
 )
 
 rust_doc(

--- a/rs/crypto/internal/crypto_lib/hmac/BUILD.bazel
+++ b/rs/crypto/internal/crypto_lib/hmac/BUILD.bazel
@@ -2,23 +2,6 @@ load("@rules_rust//rust:defs.bzl", "rust_doc_test", "rust_library", "rust_test",
 
 package(default_visibility = ["//rs/crypto:__subpackages__"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/sha2",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:hex",
-    "@crate_index//:wycheproof",
-]
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_doc_test(
     name = "hmac_doc_test",
     crate = ":hmac",
@@ -27,25 +10,33 @@ rust_doc_test(
 rust_library(
     name = "hmac",
     srcs = glob(["src/**"]),
-    aliases = ALIASES,
     crate_name = "ic_crypto_internal_hmac",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/sha2",
+    ],
 )
 
 rust_test(
     name = "hmac_test",
-    aliases = ALIASES,
     crate = ":hmac",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/sha2",
+        "@crate_index//:hex",
+        "@crate_index//:wycheproof",
+    ],
 )
 
 rust_test_suite(
     name = "hmac_integration",
     srcs = glob(["tests/**/*.rs"]),
-    aliases = ALIASES,
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":hmac"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":hmac",
+        "//rs/crypto/sha2",
+        "@crate_index//:hex",
+        "@crate_index//:wycheproof",
+    ],
 )

--- a/rs/crypto/internal/crypto_lib/seed/BUILD.bazel
+++ b/rs/crypto/internal/crypto_lib/seed/BUILD.bazel
@@ -5,46 +5,47 @@ package(default_visibility = [
     "//rs/crypto:__subpackages__",
 ])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/sha2",
-    "@crate_index//:hex",
-    "@crate_index//:rand",
-    "@crate_index//:rand_chacha",
-    "@crate_index//:serde",
-    "@crate_index//:zeroize",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = []
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "seed",
     srcs = glob(["src/**"]),
-    aliases = ALIASES,
     crate_name = "ic_crypto_internal_seed",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/sha2",
+        "@crate_index//:hex",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:serde",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_test(
     name = "seed_test",
-    aliases = ALIASES,
     crate = ":seed",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/sha2",
+        "@crate_index//:hex",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:serde",
+        "@crate_index//:zeroize",
+    ],
 )
 
 rust_test_suite(
     name = "seed_integration",
     srcs = glob(["tests/**/*.rs"]),
-    aliases = ALIASES,
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":seed"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":seed",
+        "//rs/crypto/sha2",
+        "@crate_index//:hex",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:serde",
+        "@crate_index//:zeroize",
+    ],
 )

--- a/rs/crypto/internal/logmon/BUILD.bazel
+++ b/rs/crypto/internal/logmon/BUILD.bazel
@@ -4,43 +4,37 @@ package(default_visibility = [
     "//rs/crypto:__subpackages__",
 ])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/monitoring/metrics",
-    "@crate_index//:prometheus",
-    "@crate_index//:strum",
-]
-
-MACRO_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:strum_macros",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:convert_case",
-]
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "logmon",
     srcs = glob(["src/**/*.rs"]),
-    aliases = ALIASES,
     crate_name = "ic_crypto_internal_logmon",
-    proc_macro_deps = MACRO_DEPENDENCIES,
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:strum_macros",
+    ],
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/monitoring/metrics",
+        "@crate_index//:prometheus",
+        "@crate_index//:strum",
+    ],
 )
 
 rust_test(
     name = "logmon_test",
-    aliases = ALIASES,
     crate = ":logmon",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:strum_macros",
+    ],
+    deps = [
+        # Keep sorted.
+        "//rs/monitoring/metrics",
+        "@crate_index//:convert_case",
+        "@crate_index//:prometheus",
+        "@crate_index//:strum",
+    ],
 )
 
 rust_doc_test(

--- a/rs/crypto/node_key_validation/tls_cert_validation/BUILD.bazel
+++ b/rs/crypto/node_key_validation/tls_cert_validation/BUILD.bazel
@@ -6,45 +6,37 @@ package(default_visibility = ["//visibility:public"])
 # Because this crate is used in a canister, we can only
 # use dependencies that can be compiled to WebAssembly.
 ########################################################
-DEPENDENCIES = [
-    # Keep sorted.
-    "//packages/ic-ed25519",
-    "//rs/protobuf",
-    "//rs/types/types",
-    "@crate_index//:hex",
-    "@crate_index//:serde",
-    "@crate_index//:x509-parser",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/test_utils/keys",
-    "//rs/crypto/test_utils/reproducible_rng",
-    "//rs/crypto/test_utils/tls",
-    "@crate_index//:assert_matches",
-    "@crate_index//:curve25519-dalek",
-]
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "tls_cert_validation",
     srcs = glob(["src/**"]),
-    aliases = ALIASES,
     crate_name = "ic_crypto_tls_cert_validation",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//packages/ic-ed25519",
+        "//rs/protobuf",
+        "//rs/types/types",
+        "@crate_index//:hex",
+        "@crate_index//:serde",
+        "@crate_index//:x509-parser",
+    ],
 )
 
 rust_test(
     name = "tls_cert_validation_test",
-    aliases = ALIASES,
     crate = ":tls_cert_validation",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//packages/ic-ed25519",
+        "//rs/crypto/test_utils/keys",
+        "//rs/crypto/test_utils/reproducible_rng",
+        "//rs/crypto/test_utils/tls",
+        "//rs/protobuf",
+        "//rs/types/types",
+        "@crate_index//:assert_matches",
+        "@crate_index//:curve25519-dalek",
+        "@crate_index//:hex",
+        "@crate_index//:serde",
+        "@crate_index//:x509-parser",
+    ],
 )

--- a/rs/crypto/prng/BUILD.bazel
+++ b/rs/crypto/prng/BUILD.bazel
@@ -7,20 +7,6 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/crypto/internal/crypto_lib/seed",
-    "//rs/types/types",
-    "@crate_index//:rand",
-    "@crate_index//:rand_chacha",
-    "@crate_index//:strum",
-]
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/types/types_test_utils",
-]
-
 rust_library(
     name = "prng",
     srcs = glob(["src/**/*.rs"]),
@@ -30,17 +16,41 @@ rust_library(
         "@crate_index//:strum_macros",
     ],
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/internal/crypto_lib/seed",
+        "//rs/types/types",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:strum",
+    ],
 )
 
 rust_test(
     name = "prng_unit_tests",
     crate = ":prng",
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/crypto/internal/crypto_lib/seed",
+        "//rs/types/types",
+        "//rs/types/types_test_utils",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:strum",
+    ],
 )
 
 rust_test_suite(
     name = "test_suite",
     srcs = glob(["tests/**"]),
-    deps = [":prng"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":prng",
+        "//rs/crypto/internal/crypto_lib/seed",
+        "//rs/types/types",
+        "//rs/types/types_test_utils",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+        "@crate_index//:strum",
+    ],
 )

--- a/rs/crypto/sha2/BUILD.bazel
+++ b/rs/crypto/sha2/BUILD.bazel
@@ -2,44 +2,34 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rust_test_suite
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:sha2",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:hex",
-]
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "sha2",
     srcs = glob(["src/**"]),
-    aliases = ALIASES,
     crate_name = "ic_crypto_sha2",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:sha2",
+    ],
 )
 
 rust_test(
     name = "sha2_test",
-    aliases = ALIASES,
     crate = ":sha2",
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:hex",
+        "@crate_index//:sha2",
+    ],
 )
 
 rust_test_suite(
     name = "sha2_integration",
     srcs = glob(["tests/**/*.rs"]),
-    aliases = ALIASES,
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":sha2"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":sha2",
+        "@crate_index//:hex",
+        "@crate_index//:sha2",
+    ],
 )

--- a/rs/crypto/test_utils/reproducible_rng/BUILD.bazel
+++ b/rs/crypto/test_utils/reproducible_rng/BUILD.bazel
@@ -2,35 +2,26 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "@crate_index//:rand",
-    "@crate_index//:rand_chacha",
-]
-
-MACRO_DEPENDENCIES = []
-
-DEV_DEPENDENCIES = []
-
-MACRO_DEV_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "reproducible_rng",
     testonly = True,
     srcs = glob(["src/**"]),
-    aliases = ALIASES,
     crate_name = "ic_crypto_test_utils_reproducible_rng",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+    ],
 )
 
 rust_test_suite(
     name = "reproducible_rng_integration_test",
     srcs = glob(["tests/*.rs"]),
-    aliases = ALIASES,
-    proc_macro_deps = MACRO_DEPENDENCIES + MACRO_DEV_DEPENDENCIES,
-    deps = [":reproducible_rng"] + DEPENDENCIES + DEV_DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        ":reproducible_rng",
+        "@crate_index//:rand",
+        "@crate_index//:rand_chacha",
+    ],
 )

--- a/rs/crypto/test_utils/root_of_trust/BUILD.bazel
+++ b/rs/crypto/test_utils/root_of_trust/BUILD.bazel
@@ -2,24 +2,16 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
-    # Keep sorted.
-    "//rs/types/types",
-    "@crate_index//:mockall",
-    "@crate_index//:thiserror",
-]
-
-MACRO_DEPENDENCIES = []
-
-ALIASES = {}
-
 rust_library(
     name = "root_of_trust",
     testonly = True,
     srcs = glob(["src/**/*.rs"]),
-    aliases = ALIASES,
     crate_name = "ic_crypto_test_utils_root_of_trust",
-    proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = [
+        # Keep sorted.
+        "//rs/types/types",
+        "@crate_index//:mockall",
+        "@crate_index//:thiserror",
+    ],
 )


### PR DESCRIPTION
This inlines dependencies in BUILD.bazel files. This helps readability and allows for automatic duplicate & unused dependency pruning. This aligns those packages with the rest of the codebase.