### PR TITLE
fix: use PR number in concurrency group for nns-team-reminder workflow

### DIFF
--- a/.github/workflows/ci-pr-only-nns-team-reminder.yml
+++ b/.github/workflows/ci-pr-only-nns-team-reminder.yml
@@ -7,7 +7,7 @@ on:
 
 # This helps avoid duplicate reviews from this bot.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
With [`pull_request_target`](https://github.com/dfinity/ic/pull/8116), `github.ref` resolves to the base branch, meaning all concurrent PRs will share the same group. A PR will get cancelled if another PR is opened shortly after it was itself opened.