### PR TITLE
fix: forward SSH agent to colocated test driver VM

### DIFF
--- a/rs/tests/nested/nns_recovery/BUILD.bazel
+++ b/rs/tests/nested/nns_recovery/BUILD.bazel
@@ -72,6 +72,7 @@ system_test_nns(
 # should be running and have permission to fetch mainnet test data.
 system_test_nns(
     name = "nr_large_with_mainnet_state",
+    colocated_test_driver_vm_forward_ssh_agent = True,
     colocated_test_driver_vm_required_host_features = ["dc=zh1"],
     colocated_test_driver_vm_resources = {
         "vcpus": None,


### PR DESCRIPTION
[Now that](https://github.com/dfinity/ic/pull/10106) the mainnet NNS Recovery system test runs colocated, we also need to forward the SSH agent to the colocated test driver VM, sorry for the overlook.