### PR TITLE
chore: move FARM_METADATA to volatile status file

### DIFF
--- a/bazel/workspace_status.sh
+++ b/bazel/workspace_status.sh
@@ -22,11 +22,11 @@ else
 fi
 
 # Used as farm metadata
-STABLE_FARM_METADATA="USER=${USER:-${HOSTUSER:-$(whoami)}}"
+FARM_METADATA="USER=${USER:-${HOSTUSER:-$(whoami)}}"
 if [ -n "${CI_JOB_NAME:-}" ]; then
-    STABLE_FARM_METADATA="$STABLE_FARM_METADATA;JOB_NAME=$CI_JOB_NAME"
+    FARM_METADATA="$FARM_METADATA;JOB_NAME=$CI_JOB_NAME"
 fi
-echo "STABLE_FARM_METADATA $STABLE_FARM_METADATA"
+echo "FARM_METADATA $FARM_METADATA"
 
 # Used for allocating a Farm testnet to the local DC in CI (Search for allocate_testnet_to_local_dc)
 NODE_NAME="${NODE_NAME:-}"

--- a/rs/tests/BUILD.bazel
+++ b/rs/tests/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_distroless//apt:defs.bzl", "dpkg_status")
 load("@rules_distroless//distroless:defs.bzl", "passwd")
 load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("//bazel:defs.bzl", "write_info_file_var", "write_version_file_var")
+load("//bazel:defs.bzl", "write_version_file_var")
 load(":system_tests.bzl", "oci_tar", "uvm_config_image")
 
 package(default_visibility = ["//rs:system-tests-pkg"])
@@ -279,10 +279,9 @@ genrule(
     cmd = "sed < $< 's/$$/-test/' > $@",
 )
 
-write_info_file_var(
+write_version_file_var(
     name = "farm_metadata.txt",
-    varname = "STABLE_FARM_METADATA",
-    visibility = ["//visibility:public"],
+    varname = "FARM_METADATA",
 )
 
 write_version_file_var(


### PR DESCRIPTION
Move the `FARM_META` from stable to volatile such that they won't invalidate cached system-tests.