### PR TITLE
chore: remove testonly for non-test targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6481,6 +6481,7 @@ dependencies = [
  "ic-nns-constants",
  "ic-nns-governance-api",
  "ic-nns-governance-conversions",
+ "ic-nns-handler-lifeline-interface",
  "ic-nns-handler-root",
  "ic-nns-init",
  "ic-nns-test-utils",

--- a/ic-os/guestos/envs/dev/BUILD.bazel
+++ b/ic-os/guestos/envs/dev/BUILD.bazel
@@ -39,7 +39,6 @@ file_size_check(
 # Export checksums & build artifacts for update images
 artifact_bundle(
     name = "bundle-update",
-    testonly = True,
     inputs = [
         icos_images.update_image,
         icos_images.update_image_test,

--- a/ic-os/hostos/envs/dev/BUILD.bazel
+++ b/ic-os/hostos/envs/dev/BUILD.bazel
@@ -19,7 +19,6 @@ icos_images = icos_build(
 # Export checksums & build artifacts for update images
 artifact_bundle(
     name = "bundle-update",
-    testonly = True,
     inputs = [
         icos_images.update_image,
         icos_images.update_image_test,

--- a/ic-os/hostos/envs/prod/BUILD.bazel
+++ b/ic-os/hostos/envs/prod/BUILD.bazel
@@ -30,7 +30,6 @@ file_size_check(
 # (image is used for HostOS upgrades)
 artifact_bundle(
     name = "bundle-update",
-    testonly = True,
     inputs = [
         icos_images.update_image,
         icos_images.update_image_test,

--- a/ic-os/setupos/envs/dev/BUILD.bazel
+++ b/ic-os/setupos/envs/dev/BUILD.bazel
@@ -26,7 +26,6 @@ launch_bare_metal(
 # Export checksums & build artifacts
 artifact_bundle(
     name = "bundle",
-    testonly = True,
     inputs = [":dev"],
     prefix = "setup-os/disk-img-dev",
     visibility = ["//visibility:public"],

--- a/ic-os/setupos/envs/prod/BUILD.bazel
+++ b/ic-os/setupos/envs/prod/BUILD.bazel
@@ -30,7 +30,6 @@ launch_bare_metal(
 # (image is used as the IC-OS installation image downloaded by Node Providers)
 artifact_bundle(
     name = "bundle",
-    testonly = True,
     inputs = [":prod"],
     prefix = "setup-os/disk-img",
     visibility = ["//visibility:public"],

--- a/publish/binaries/BUILD.bazel
+++ b/publish/binaries/BUILD.bazel
@@ -41,14 +41,7 @@ ALL_BINARIES = {
 # test binaries or binaries using test utils
 TESTONLY_BINARIES = [
     # Keep sorted
-    "e2e-test-driver",
-    "ic-admin",
-    "ic-boundary",
-    "ic-https-outcalls-adapter",
     "ic-nns-init",
-    "ic-prep",
-    "ic-test-state-machine",
-    "pocket-ic",
     "replicated-state-test",
     "state-layout-test",
     "types-test",
@@ -88,8 +81,7 @@ TEST_BINARIES = [
     binary = ALL_BINARIES[name],
 ) for name in TEST_BINARIES]
 
-# all targets below are tesonly because the targets violating the testonly flag
-# would error at this point
+# targets below use testonly conditionally for the remaining test-only binaries
 
 [
     genrule(

--- a/rs/crypto/iccsa/test_utils/BUILD.bazel
+++ b/rs/crypto/iccsa/test_utils/BUILD.bazel
@@ -7,7 +7,6 @@ package(default_visibility = [
 
 rust_library(
     name = "test_utils",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_crypto_iccsa_test_utils",
     version = "0.9.0",

--- a/rs/crypto/internal/csp_test_utils/BUILD.bazel
+++ b/rs/crypto/internal/csp_test_utils/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//rs/crypto:__subpackages__"])
 
 rust_library(
     name = "csp_test_utils",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_crypto_internal_csp_test_utils",
     version = "0.9.0",

--- a/rs/crypto/test_utils/BUILD.bazel
+++ b/rs/crypto/test_utils/BUILD.bazel
@@ -2,7 +2,6 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 
 rust_library(
     name = "test_utils",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_crypto_test_utils",
     version = "0.9.0",

--- a/rs/crypto/test_utils/canister_threshold_sigs/BUILD.bazel
+++ b/rs/crypto/test_utils/canister_threshold_sigs/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "canister_threshold_sigs",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_crypto_test_utils_canister_threshold_sigs",
     proc_macro_deps = [

--- a/rs/crypto/test_utils/crypto_returning_ok/BUILD.bazel
+++ b/rs/crypto/test_utils/crypto_returning_ok/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "crypto_returning_ok",
-    testonly = True,
     srcs = glob(["src/**/*.rs"]),
     crate_name = "ic_crypto_test_utils_crypto_returning_ok",
     version = "0.9.0",

--- a/rs/crypto/test_utils/ni-dkg/BUILD.bazel
+++ b/rs/crypto/test_utils/ni-dkg/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "ni-dkg",
-    testonly = True,
     srcs = glob(["src/**/*.rs"]),
     crate_name = "ic_crypto_test_utils_ni_dkg",
     version = "0.9.0",

--- a/rs/crypto/test_utils/reproducible_rng/BUILD.bazel
+++ b/rs/crypto/test_utils/reproducible_rng/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "reproducible_rng",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_crypto_test_utils_reproducible_rng",
     version = "0.9.0",

--- a/rs/crypto/test_utils/vetkd/BUILD.bazel
+++ b/rs/crypto/test_utils/vetkd/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "vetkd",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_crypto_test_utils_vetkd",
     version = "0.1.0",

--- a/rs/https_outcalls/adapter/BUILD.bazel
+++ b/rs/https_outcalls/adapter/BUILD.bazel
@@ -40,7 +40,6 @@ rust_library(
 # Same target as above but allows the adapter to make HTTP calls.
 rust_library(
     name = "adapter_with_http",
-    testonly = True,
     srcs = glob(
         ["src/**"],
         exclude = [
@@ -122,7 +121,6 @@ rust_binary(
 # This target is used for local testing (e.g. DFX)
 rust_binary(
     name = "ic-outcalls-adapter-with-http",
-    testonly = True,
     srcs = [
         "src/cli.rs",
         "src/main.rs",

--- a/rs/nns/init/BUILD.bazel
+++ b/rs/nns/init/BUILD.bazel
@@ -2,24 +2,28 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
-DEPENDENCIES = [
+LIB_DEPENDENCIES = [
     # Keep sorted.
     "//rs/canister_client",
     "//rs/interfaces/registry",
     "//rs/ledger_suite/icp:icp_ledger",
     "//rs/nns/common",
     "//rs/nns/constants",
-    "//rs/nns/test_utils",
     "//rs/registry/local_store",
     "//rs/registry/proto_data_provider",
     "//rs/registry/transport",
-    "//rs/rust_canisters/canister_test",
     "//rs/sys",
-    "//rs/test_utilities/identity",
     "//rs/types/base_types",
     "@crate_index//:clap",
     "@crate_index//:tokio",
     "@crate_index//:url",
+]
+
+DEPENDENCIES = LIB_DEPENDENCIES + [
+    # Keep sorted.
+    "//rs/nns/test_utils",
+    "//rs/rust_canisters/canister_test",
+    "//rs/test_utilities/identity",
 ]
 
 MACRO_DEPENDENCIES = []
@@ -35,13 +39,12 @@ MACRO_DEV_DEPENDENCIES = []
 
 rust_library(
     name = "init",
-    testonly = True,
     srcs = glob(["src/**/*.rs"]),
     aliases = ALIASES,
     crate_name = "ic_nns_init",
     proc_macro_deps = MACRO_DEPENDENCIES,
     version = "0.9.0",
-    deps = DEPENDENCIES,
+    deps = LIB_DEPENDENCIES,
 )
 
 rust_binary(

--- a/rs/nns/init/src/lib.rs
+++ b/rs/nns/init/src/lib.rs
@@ -2,7 +2,6 @@
 //! initial payloads and install nns canisters in a fresh IC.
 //! Was used at genesis, but now only used to install the nns in testnets.
 
-use canister_test::Wasm;
 use ic_canister_client::Sender;
 use ic_interfaces_registry::{RegistryDataProvider, ZERO_REGISTRY_VERSION};
 use ic_nns_constants::NNS_CANISTER_WASMS;
@@ -154,12 +153,13 @@ pub fn set_up_env_vars_for_all_canisters<P: AsRef<Path>>(wasm_dir: P) {
             let mut path = wasm_dir.as_ref().to_path_buf();
             path.push(file_part.as_str());
             if path.is_file() {
-                // Sets up the env var following the pattern expected by
+                // Set the env var in a way that is expected by
                 // WASM::from_location_specified_by_env_var
                 // TODO: Audit that the environment access only happens in single-threaded code.
-                unsafe {
-                    std::env::set_var(Wasm::env_var_name(canister, &[]), path.to_str().unwrap())
-                };
+                let env_var = format!("{}_WASM_PATH", canister)
+                    .replace('-', "_")
+                    .to_uppercase();
+                unsafe { std::env::set_var(env_var, path.to_str().unwrap()) };
                 continue 'outer;
             }
         }

--- a/rs/pocket_ic_server/BUILD.bazel
+++ b/rs/pocket_ic_server/BUILD.bazel
@@ -265,7 +265,6 @@ MAINNET_NNS_CANISTER_ENV = {
 [
     rust_library(
         name = "pocket-ic-server-lib" + name_suffix,
-        testonly = True,
         srcs = [
             "src/beta_features.rs",
             "src/external_canister_types.rs",
@@ -290,7 +289,6 @@ MAINNET_NNS_CANISTER_ENV = {
 [
     rust_binary(
         name = "pocket-ic-server" + name_suffix,
-        testonly = True,
         srcs = ["src/main.rs"],
         compile_data = ["//:mainnet-routing-table.json"],
         proc_macro_deps = MACRO_DEPENDENCIES,

--- a/rs/prep/BUILD.bazel
+++ b/rs/prep/BUILD.bazel
@@ -61,7 +61,6 @@ ALIASES = {}
 
 rust_library(
     name = "prep",
-    testonly = True,
     srcs = glob(["src/**/*.rs"]),
     aliases = ALIASES,
     crate_name = "ic_prep_lib",
@@ -71,7 +70,6 @@ rust_library(
 
 rust_binary(
     name = "ic-prep",
-    testonly = True,
     srcs = ["src/bin/prep.rs"],
     aliases = ALIASES,
     proc_macro_deps = MACRO_DEPENDENCIES,
@@ -80,7 +78,6 @@ rust_binary(
 
 rust_binary(
     name = "ic-principal-id",
-    testonly = True,
     srcs = ["src/bin/principal_id.rs"],
     aliases = ALIASES,
     proc_macro_deps = MACRO_DEPENDENCIES,

--- a/rs/registry/admin/BUILD.bazel
+++ b/rs/registry/admin/BUILD.bazel
@@ -40,7 +40,6 @@ cargo_build_script(
 
 rust_binary(
     name = "ic-admin",
-    testonly = True,
     srcs = glob(["bin/**/*.rs"]),
     proc_macro_deps = [
         # Keep sorted.
@@ -69,10 +68,10 @@ rust_binary(
         "//rs/nns/constants",
         "//rs/nns/governance/api",
         "//rs/nns/governance/conversions",
+        "//rs/nns/handlers/lifeline/interface",
         "//rs/nns/handlers/root/impl:root",
         "//rs/nns/init",
         "//rs/nns/sns-wasm",
-        "//rs/nns/test_utils",
         "//rs/prep",
         "//rs/protobuf",
         "//rs/registry/canister",

--- a/rs/registry/admin/Cargo.toml
+++ b/rs/registry/admin/Cargo.toml
@@ -36,9 +36,9 @@ ic-nns-common = { path = "../../nns/common" }
 ic-nns-constants = { path = "../../nns/constants" }
 ic-nns-governance-api = { path = "../../nns/governance/api" }
 ic-nns-governance-conversions = { path = "../../nns/governance/conversions" }
+ic-nns-handler-lifeline-interface = { path = "../../nns/handlers/lifeline/interface" }
 ic-nns-handler-root = { path = "../../nns/handlers/root/impl" }
 ic-nns-init = { path = "../../nns/init" }
-ic-nns-test-utils = { path = "../../nns/test_utils" }
 ic-prep = { path = "../../prep" }
 ic-protobuf = { path = "../../protobuf" }
 ic-registry-client = { path = "../client" }
@@ -75,6 +75,7 @@ assert_matches = { workspace = true }
 ic-nervous-system-agent = { path = "../../nervous_system/agent" }
 ic-nervous-system-chunks = { path = "../../nervous_system/chunks" }
 ic-nervous-system-integration-tests = { path = "../../nervous_system/integration_tests" }
+ic-nns-test-utils = { path = "../../nns/test_utils" }
 ic-registry-canister-api = { path = "../canister/api" }
 pocket-ic = { path = "../../../packages/pocket-ic" }
 

--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -68,9 +68,9 @@ use ic_nns_governance_api::{
     subnet_rental::{RentalConditionId, SubnetRentalRequest},
 };
 use ic_nns_governance_conversions::convert_guest_launch_measurements_from_pb_to_api;
+use ic_nns_handler_lifeline_interface::{HardResetNnsRootToVersionPayload, UpgradeRootProposal};
 use ic_nns_handler_root::root_proposals::{GovernanceUpgradeRootProposal, RootProposalBallot};
 use ic_nns_init::make_hsm_sender;
-use ic_nns_test_utils::governance::{HardResetNnsRootToVersionPayload, UpgradeRootProposal};
 use ic_protobuf::registry::replica_version::v1::GuestLaunchMeasurements;
 use ic_protobuf::registry::{
     api_boundary_node::v1::ApiBoundaryNodeRecord,

--- a/rs/state_machine_tests/BUILD.bazel
+++ b/rs/state_machine_tests/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "state_machine_tests",
-    testonly = True,
     srcs = [
         "src/lib.rs",
         "src/tests.rs",
@@ -84,7 +83,6 @@ rust_library(
 
 rust_binary(
     name = "ic-test-state-machine",
-    testonly = True,
     srcs = ["src/main.rs"],
     deps = [
         # Keep sorted.

--- a/rs/test_utilities/BUILD.bazel
+++ b/rs/test_utilities/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "test_utilities",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_test_utilities",
     version = "0.9.0",

--- a/rs/test_utilities/consensus/BUILD.bazel
+++ b/rs/test_utilities/consensus/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "consensus",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_test_utilities_consensus",
     version = "0.9.0",

--- a/rs/test_utilities/logger/BUILD.bazel
+++ b/rs/test_utilities/logger/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "logger",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_test_utilities_logger",
     version = "0.9.0",

--- a/rs/test_utilities/registry/BUILD.bazel
+++ b/rs/test_utilities/registry/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "registry",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_test_utilities_registry",
     version = "0.9.0",

--- a/rs/test_utilities/state/BUILD.bazel
+++ b/rs/test_utilities/state/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "state",
-    testonly = True,
     srcs = glob(["src/**/*.rs"]),
     crate_name = "ic_test_utilities_state",
     version = "0.9.0",

--- a/rs/test_utilities/time/BUILD.bazel
+++ b/rs/test_utilities/time/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "time",
-    testonly = True,
     srcs = glob(["src/**/*.rs"]),
     crate_name = "ic_test_utilities_time",
     version = "0.9.0",

--- a/rs/test_utilities/types/BUILD.bazel
+++ b/rs/test_utilities/types/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "types",
-    testonly = True,
     srcs = glob(["src/**"]),
     crate_name = "ic_test_utilities_types",
     version = "0.9.0",

--- a/rs/validator/http_request_test_utils/BUILD.bazel
+++ b/rs/validator/http_request_test_utils/BUILD.bazel
@@ -4,7 +4,6 @@ package(default_visibility = ["//visibility:public"])
 
 rust_library(
     name = "http_request_test_utils",
-    testonly = True,
     srcs = glob(["src/**/*.rs"]),
     crate_name = "ic_validator_http_request_test_utils",
     proc_macro_deps = [


### PR DESCRIPTION
The `testonly` tag was used very liberally throughout the codebase, and was applied to many targets that definitely were not test only (like ic-admin, published pocket-ic executables, etc). This removes some of the uses of `testonly` (it tends to spread like wildfire).