### PR TITLE
chore: use GitHub case syntax instead of ternary "if"

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -42,7 +42,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 256 || 0 }}
+          fetch-depth: ${{ case(github.event_name == 'pull_request', 256, 0) }}
           ref: ${{ inputs.commit-sha }}
       - name: Filter fuzzer related files
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -207,7 +207,7 @@ jobs:
       # It also requires the AWS and CF secrets which are only available in the `upload-artifacts` environment.
       # This environment is also only active on protected branches. That's why we require the `upload-artifacts` environment
       # when `release-build == 'true'` but not otherwise.
-      name: ${{ needs.config.outputs.release-build == 'true' && 'upload-artifacts' || ''}}
+      name: ${{ case(needs.config.outputs.release-build == 'true', 'upload-artifacts', '') }}
     runs-on: *dind-large-setup
     container: *container-setup
     timeout-minutes: 150

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -42,7 +42,7 @@ jobs:
           echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
           echo "message=${MESSAGE}" >> $GITHUB_OUTPUT
         env:
-          MESSAGE: ":github: ${{ github.event.pull_request.head.repo.full_name != github.repository && ':alert: EXTERNAL PR, review extra carefully! :alert: ' || '' }}`${{ github.repository }}` <${{ github.event.pull_request.html_url }}|${{ steps.sanitize.outputs.safe_title || '' }}>"
+          MESSAGE: ":github: ${{ case(github.event.pull_request.head.repo.full_name != github.repository, ':alert: EXTERNAL PR, review extra carefully! :alert: ', '') }}`${{ github.repository }}` <${{ github.event.pull_request.html_url }}|${{ steps.sanitize.outputs.safe_title || '' }}>"
 
       - name: Post to a Slack channel
         if: steps.get-reviewers.outputs.result != '""' && steps.lookup.outputs.channel != 'null'

--- a/.github/workflows/ci-pr-only.yml
+++ b/.github/workflows/ci-pr-only.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           # Ensures we fetch the merge-base, which we compare against
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.commit-sha }}
+          ref: ${{ case(github.event_name == 'pull_request', github.event.pull_request.head.sha, inputs.commit-sha) }}
       - uses: ./.github/actions/netrc
       - name: Run candid compatibility checks
         uses: ./.github/actions/bazel
@@ -74,7 +74,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || inputs.commit-sha }}
+          ref: ${{ case(github.event_name == 'pull_request', github.event.pull_request.head.ref, inputs.commit-sha) }}
           token: ${{ steps.app-token.outputs.token }}
       - uses: ./.github/actions/netrc
       - name: Run Linter

--- a/.github/workflows/update-mainnet-canister-revisions.yaml
+++ b/.github/workflows/update-mainnet-canister-revisions.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Update mainnet canister versions file
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          DRY_RUN: ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+          DRY_RUN: ${{ case(github.event_name == 'pull_request', '--dry-run', '') }}
         run: |
           set -eEuxo pipefail
 

--- a/.github/workflows/update-mainnet-icos-revisions.yaml
+++ b/.github/workflows/update-mainnet-icos-revisions.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Update mainnet ICOS versions file
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          DRY_RUN: ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+          DRY_RUN: ${{ case(github.event_name == 'pull_request', '--dry-run', '') }}
         run: |
           set -eEuxo pipefail
 


### PR DESCRIPTION
Replace ternary ifs (`condition && trueValue || falseValue`) GitHub Actions workflow files with the new first-class `case()` expression (actions/runner#409).

The `case()` expression is now the correct tool for the job and avoids some the "conditional if"
[footguns](https://github.com/actions/runner/issues/409#issuecomment-1013325196).