### PR TITLE
chore: drop overly verbose Bazel labels

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ec22472b8c37952cd16623fb019e126dc293d9ee4f573aeffcb6af5332790ce7",
+  "checksum": "43906af38113e17578413f1de1f6cf573f52d737b965fc21e82da5be6f593abc",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -45485,7 +45485,7 @@
         ],
         "data": {
           "common": [
-            "@@+_repo_rules+openssl//:gen_dir"
+            "@openssl//:gen_dir"
           ],
           "selects": {}
         },
@@ -46332,8 +46332,8 @@
         ],
         "data": {
           "common": [
-            "@@+_repo_rules+lmdb//:liblmdb",
-            "@@+_repo_rules+lmdb//:lmdb.h"
+            "@lmdb//:liblmdb",
+            "@lmdb//:lmdb.h"
           ],
           "selects": {}
         },
@@ -46355,8 +46355,8 @@
         },
         "build_script_env": {
           "common": {
-            "LMDB_H_PATH": "$(location @@+_repo_rules+lmdb//:lmdb.h)",
-            "LMDB_OVERRIDE": "$(location @@+_repo_rules+lmdb//:liblmdb)"
+            "LMDB_H_PATH": "$(location @lmdb//:lmdb.h)",
+            "LMDB_OVERRIDE": "$(location @lmdb//:liblmdb)"
           },
           "selects": {}
         }
@@ -53598,7 +53598,7 @@
         ],
         "data": {
           "common": [
-            "@@+_repo_rules+openssl//:gen_dir"
+            "@openssl//:gen_dir"
           ],
           "selects": {}
         },
@@ -53624,8 +53624,8 @@
         },
         "build_script_env": {
           "common": {
-            "OPENSSL_INCLUDE_DIR": "$(execpath @@+_repo_rules+openssl//:gen_dir)/include",
-            "OPENSSL_LIB_DIR": "$(execpath @@+_repo_rules+openssl//:gen_dir)/lib64",
+            "OPENSSL_INCLUDE_DIR": "$(execpath @openssl//:gen_dir)/include",
+            "OPENSSL_LIB_DIR": "$(execpath @openssl//:gen_dir)/lib64",
             "OPENSSL_NO_VENDOR": "1",
             "OPENSSL_STATIC": "1"
           },
@@ -58665,7 +58665,7 @@
         ],
         "data": {
           "common": [
-            "@@protobuf+//:protoc"
+            "@protobuf//:protoc"
           ],
           "selects": {}
         },
@@ -58687,7 +58687,7 @@
         },
         "build_script_env": {
           "common": {
-            "PROTOC": "$(execpath @@protobuf+//:protoc)"
+            "PROTOC": "$(execpath @protobuf//:protoc)"
           },
           "selects": {}
         }
@@ -81334,7 +81334,7 @@
           "common": [],
           "selects": {
             "x86_64-unknown-linux-gnu": [
-              "@@+_repo_rules+jemalloc//:libjemalloc"
+              "@jemalloc//:libjemalloc"
             ]
           }
         },
@@ -81354,7 +81354,7 @@
           "common": {},
           "selects": {
             "x86_64-unknown-linux-gnu": {
-              "JEMALLOC_OVERRIDE": "$(location @@+_repo_rules+jemalloc//:libjemalloc)"
+              "JEMALLOC_OVERRIDE": "$(location @jemalloc//:libjemalloc)"
             }
           }
         },

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -2196,6 +2196,7 @@ crate.from_specs(
         ],
 )
 
+# inject nice names for those repos to avoid canonical naming
 inject_repo(crate, "openssl", "lmdb", "jemalloc", "protobuf")
 
 use_repo(crate, "crate_index")

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -2195,7 +2195,9 @@ crate.from_specs(
             "x86_64-unknown-linux-gnu",
         ],
 )
+
 inject_repo(crate, "openssl", "lmdb", "jemalloc", "protobuf")
+
 use_repo(crate, "crate_index")
 
 ####

--- a/bazel/rust.MODULE.bazel
+++ b/bazel/rust.MODULE.bazel
@@ -2024,12 +2024,12 @@ crate.annotation_select(
 )
 crate.annotation(
     build_script_data = [
-        "@@+_repo_rules+openssl//:gen_dir",
+        "@openssl//:gen_dir",
     ],
     build_script_env = {
         "OPENSSL_NO_VENDOR": "1",
-        "OPENSSL_LIB_DIR": "$(execpath @@+_repo_rules+openssl//:gen_dir)/lib64",
-        "OPENSSL_INCLUDE_DIR": "$(execpath @@+_repo_rules+openssl//:gen_dir)/include",
+        "OPENSSL_LIB_DIR": "$(execpath @openssl//:gen_dir)/lib64",
+        "OPENSSL_INCLUDE_DIR": "$(execpath @openssl//:gen_dir)/include",
         "OPENSSL_STATIC": "1",
     },
     crate = "openssl-sys",
@@ -2045,7 +2045,7 @@ crate.annotation(
 )
 crate.annotation(
     build_script_data = [
-        "@@+_repo_rules+openssl//:gen_dir",
+        "@openssl//:gen_dir",
     ],
     crate = "libssh2-sys",
     # Patch for determinism issues
@@ -2089,12 +2089,12 @@ crate.annotation(
 )
 crate.annotation(
     build_script_data = [
-        "@@+_repo_rules+lmdb//:liblmdb",
-        "@@+_repo_rules+lmdb//:lmdb.h",
+        "@lmdb//:liblmdb",
+        "@lmdb//:lmdb.h",
     ],
     build_script_env = {
-        "LMDB_OVERRIDE": "$(location @@+_repo_rules+lmdb//:liblmdb)",
-        "LMDB_H_PATH": "$(location @@+_repo_rules+lmdb//:lmdb.h)",
+        "LMDB_OVERRIDE": "$(location @lmdb//:liblmdb)",
+        "LMDB_H_PATH": "$(location @lmdb//:lmdb.h)",
     },
     crate = "lmdb-rkv-sys",
     # patch our fork of the lmdb-rkv-sys to allow specifying the path
@@ -2111,8 +2111,8 @@ crate.annotation(
 )
 crate.annotation_select(
     # Avoid building jemalloc from rust (in part bc it creates builder-specific config files)
-    build_script_data = ["@@+_repo_rules+jemalloc//:libjemalloc"],
-    build_script_env = {"JEMALLOC_OVERRIDE": "$(location @@+_repo_rules+jemalloc//:libjemalloc)"},
+    build_script_data = ["@jemalloc//:libjemalloc"],
+    build_script_env = {"JEMALLOC_OVERRIDE": "$(location @jemalloc//:libjemalloc)"},
     crate = "tikv-jemalloc-sys",
     triples = ["x86_64-unknown-linux-gnu"],
 )
@@ -2162,10 +2162,10 @@ crate.annotation(
 )
 crate.annotation(
     build_script_data = [
-        "@@protobuf+//:protoc",
+        "@protobuf//:protoc",
     ],
     build_script_env = {
-        "PROTOC": "$(execpath @@protobuf+//:protoc)",
+        "PROTOC": "$(execpath @protobuf//:protoc)",
     },
     crate = "pprof",
 )
@@ -2195,6 +2195,7 @@ crate.from_specs(
             "x86_64-unknown-linux-gnu",
         ],
 )
+inject_repo(crate, "openssl", "lmdb", "jemalloc", "protobuf")
 use_repo(crate, "crate_index")
 
 ####


### PR DESCRIPTION
This uses `inject_repo` to shorten some Bazel labels. The labels were introduced in https://github.com/dfinity/ic/pull/7872 when rules_rust was migrated to MODULE.bazel. The workaround used here was suggested in this ticket: https://github.com/bazelbuild/rules_rust/issues/2736