### PR TITLE
feat(governance): skip speed limit on first Mission 70 maturity modulation

### DIFF
--- a/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data.rs
+++ b/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data.rs
@@ -94,43 +94,34 @@ pub(crate) fn compute_average_icp_xdr_rate(
 ///
 ///   `target = sensitivity * (current_price - reference_price) / reference_price`
 ///
-/// Then applies a daily speed limit (smoothing), followed by global bounds which have final say.
+/// On the first calculation (`previous` is `None`), the target is returned subject only to global
+/// bounds — the speed limit needs a baseline to be meaningful. On subsequent calculations a daily
+/// speed limit smooths day-to-day change, and global bounds have final say.
+///
+/// Returns `Err` with a reason if the inputs make the calculation impossible (e.g. price history
+/// is incomplete or the reference price is zero). Callers that hit `Err` should leave the prior
+/// modulation value untouched and log the reason.
 fn compute_maturity_modulation_permyriad(
     rates: &[SampledPrice],
     current_day: u64,
-    previous_permyriad: i64,
-    previous_day: u64,
-) -> i64 {
-    let Some(recent_icp_price) = compute_average_icp_xdr_rate(
+    previous: Option<(i64, u64)>,
+) -> Result<i64, String> {
+    let recent_icp_price = compute_average_icp_xdr_rate(
         rates,
         current_day,
         MATURITY_MODULATION_CURRENT_ICP_PRICE_WINDOW_DAYS,
-    ) else {
-        println!(
-            "{}compute_maturity_modulation_permyriad: insufficient recent price data; keeping previous value {}",
-            LOG_PREFIX, previous_permyriad
-        );
-        return previous_permyriad;
-    };
+    )
+    .ok_or_else(|| "insufficient recent price data despite full history".to_string())?;
 
-    let Some(reference_icp_price) = compute_average_icp_xdr_rate(
+    let reference_icp_price = compute_average_icp_xdr_rate(
         rates,
         current_day,
         MATURITY_MODULATION_REFERENCE_ICP_PRICE_WINDOW_DAYS,
-    ) else {
-        println!(
-            "{}compute_maturity_modulation_permyriad: insufficient reference price data; keeping previous value {}",
-            LOG_PREFIX, previous_permyriad
-        );
-        return previous_permyriad;
-    };
+    )
+    .ok_or_else(|| "insufficient reference price data despite full history".to_string())?;
 
     if reference_icp_price == 0 {
-        println!(
-            "{}compute_maturity_modulation_permyriad: reference price is zero; keeping previous value {}",
-            LOG_PREFIX, previous_permyriad
-        );
-        return previous_permyriad;
+        return Err("reference price averaged to zero".to_string());
     }
 
     let target_modulation = {
@@ -140,37 +131,43 @@ fn compute_maturity_modulation_permyriad(
         sensitivity * (recent - reference) / reference
     };
 
-    // Limit day-to-day change.
-    let days_elapsed = current_day.saturating_sub(previous_day);
-    let max_change = if days_elapsed > 1 {
-        // The timer missed one or more days — allow proportionally more change.
-        println!(
-            "{}compute_maturity_modulation_permyriad: {} days elapsed since last update (current_day={}, previous_day={})",
-            LOG_PREFIX, days_elapsed, current_day, previous_day
-        );
-        MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD.saturating_mul(days_elapsed as i64)
-    } else if days_elapsed == 1 {
-        MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD
-    } else {
-        // days_elapsed == 0: either same day or current_day < previous_day (should not happen).
-        // Allow at least one day of movement.
-        println!(
-            "{}compute_maturity_modulation_permyriad: days_elapsed=0 (current_day={}, previous_day={}); treating as 1 day",
-            LOG_PREFIX, current_day, previous_day
-        );
-        MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD
+    let speed_limited = match previous {
+        // First calculation: no baseline to smooth from, so jump straight to target.
+        None => target_modulation,
+        Some((previous_permyriad, previous_day)) => {
+            // Limit day-to-day change.
+            let days_elapsed = current_day.saturating_sub(previous_day);
+            let max_change = if days_elapsed > 1 {
+                // The timer missed one or more days — allow proportionally more change.
+                println!(
+                    "{}compute_maturity_modulation_permyriad: {} days elapsed since last update (current_day={}, previous_day={})",
+                    LOG_PREFIX, days_elapsed, current_day, previous_day
+                );
+                MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD.saturating_mul(days_elapsed as i64)
+            } else if days_elapsed == 1 {
+                MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD
+            } else {
+                // days_elapsed == 0: either same day or current_day < previous_day (should not happen).
+                // Allow at least one day of movement.
+                println!(
+                    "{}compute_maturity_modulation_permyriad: days_elapsed=0 (current_day={}, previous_day={}); treating as 1 day",
+                    LOG_PREFIX, current_day, previous_day
+                );
+                MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD
+            };
+            target_modulation.clamp(
+                previous_permyriad.saturating_sub(max_change) as i128,
+                previous_permyriad.saturating_add(max_change) as i128,
+            )
+        }
     };
-    let speed_limited = target_modulation.clamp(
-        previous_permyriad.saturating_sub(max_change) as i128,
-        previous_permyriad.saturating_add(max_change) as i128,
-    );
 
     // Global bounds have final say. The result is within [MIN, MAX] which fit in i64, so the
     // cast is safe.
-    speed_limited.clamp(
+    Ok(speed_limited.clamp(
         MATURITY_MODULATION_MIN_PERMYRIAD_MISSION_70 as i128,
         MATURITY_MODULATION_MAX_PERMYRIAD_MISSION_70 as i128,
-    ) as i64
+    ) as i64)
 }
 
 pub(super) struct UpdateIcpXdrRateRelatedData {
@@ -342,18 +339,32 @@ fn update_maturity_modulation(
         return;
     }
 
-    let previous_permyriad = maturity_modulation.current_value_permyriad.unwrap_or(0) as i64;
-    let previous_day = maturity_modulation.updated_at_days_since_epoch.unwrap_or(0);
+    let previous = match (
+        maturity_modulation.current_value_permyriad,
+        maturity_modulation.updated_at_days_since_epoch,
+    ) {
+        (Some(p), Some(d)) => Some((p as i64, d)),
+        _ => None,
+    };
 
-    let new_permyriad = compute_maturity_modulation_permyriad(
+    match compute_maturity_modulation_permyriad(
         &icp_price_history.icp_xdr_rates,
         current_day,
-        previous_permyriad,
-        previous_day,
-    );
-
-    maturity_modulation.current_value_permyriad = Some(new_permyriad as i32);
-    maturity_modulation.updated_at_days_since_epoch = Some(current_day);
+        previous,
+    ) {
+        Ok(new_permyriad) => {
+            maturity_modulation.current_value_permyriad = Some(new_permyriad as i32);
+            maturity_modulation.updated_at_days_since_epoch = Some(current_day);
+        }
+        Err(reason) => {
+            // None of these conditions should hit in practice (the buffer must be full before we
+            // call this, and XRC rejects zero rates). Log loudly and leave prior state untouched.
+            println!(
+                "{}update_maturity_modulation: BUG: {}; leaving prior modulation unchanged",
+                LOG_PREFIX, reason
+            );
+        }
+    }
 }
 
 #[async_trait]

--- a/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data_tests.rs
+++ b/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data_tests.rs
@@ -197,9 +197,35 @@ fn test_update_rates_buffer_caps_at_max() {
 }
 
 #[test]
-fn test_compute_maturity_modulation_no_data() {
-    let result = compute_maturity_modulation_permyriad(&[], 100, 50, 99);
-    assert_eq!(result, 50);
+fn test_compute_maturity_modulation_no_data_with_previous() {
+    let result = compute_maturity_modulation_permyriad(&[], 100, Some((50, 99)));
+    assert_eq!(
+        result,
+        Err("insufficient recent price data despite full history".to_string())
+    );
+}
+
+#[test]
+fn test_compute_maturity_modulation_no_data_no_previous() {
+    let result = compute_maturity_modulation_permyriad(&[], 100, None);
+    assert_eq!(
+        result,
+        Err("insufficient recent price data despite full history".to_string())
+    );
+}
+
+#[test]
+fn test_compute_maturity_modulation_zero_reference_price_returns_error() {
+    // 365 days of zero rates: 7-day and 365-day averages are both zero, hitting the
+    // reference-price-zero branch.
+    let rates: Vec<SampledPrice> = (1..=365)
+        .map(|d| SampledPrice {
+            timestamp_seconds: d * ONE_DAY_SECONDS,
+            xdr_permyriad_per_icp: 0,
+        })
+        .collect();
+    let result = compute_maturity_modulation_permyriad(&rates, 365, Some((10, 364)));
+    assert_eq!(result, Err("reference price averaged to zero".to_string()));
 }
 
 #[test]
@@ -214,8 +240,8 @@ fn test_compute_maturity_modulation_stable_price() {
             xdr_permyriad_per_icp: 50_000,
         })
         .collect();
-    let result = compute_maturity_modulation_permyriad(&rates, 365, 42, 364);
-    assert_eq!(result, 12);
+    let result = compute_maturity_modulation_permyriad(&rates, 365, Some((42, 364)));
+    assert_eq!(result, Ok(12));
 }
 
 #[test]
@@ -237,8 +263,8 @@ fn test_compute_maturity_modulation_price_increase() {
             xdr_permyriad_per_icp: 60_000,
         });
     }
-    let result = compute_maturity_modulation_permyriad(&rates, 365, 0, 364);
-    assert_eq!(result, MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD);
+    let result = compute_maturity_modulation_permyriad(&rates, 365, Some((0, 364)));
+    assert_eq!(result, Ok(MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD));
 }
 
 #[test]
@@ -259,8 +285,34 @@ fn test_compute_maturity_modulation_price_decrease() {
             xdr_permyriad_per_icp: 40_000,
         });
     }
-    let result = compute_maturity_modulation_permyriad(&rates, 365, 0, 364);
-    assert_eq!(result, -MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD);
+    let result = compute_maturity_modulation_permyriad(&rates, 365, Some((0, 364)));
+    assert_eq!(result, Ok(-MATURITY_MODULATION_DAILY_SPEED_LIMIT_PERMYRIAD));
+}
+
+#[test]
+fn test_compute_maturity_modulation_first_calculation_skips_speed_limit() {
+    // Same prices as test_compute_maturity_modulation_price_decrease (target ≈ -492 permyriad),
+    // but with no previous value: the speed limit must not apply, so the result should reflect
+    // the full target (subject to global bounds).
+    let mut rates: Vec<SampledPrice> = (1..=358)
+        .map(|d| SampledPrice {
+            timestamp_seconds: d * ONE_DAY_SECONDS,
+            xdr_permyriad_per_icp: 50_000,
+        })
+        .collect();
+    for d in 359..=365 {
+        rates.push(SampledPrice {
+            timestamp_seconds: d * ONE_DAY_SECONDS,
+            xdr_permyriad_per_icp: 40_000,
+        });
+    }
+    let result = compute_maturity_modulation_permyriad(&rates, 365, None)
+        .expect("complete history should yield Ok");
+    // Target is well within global bounds, so we should see roughly -492.
+    assert!(
+        (-500..=-450).contains(&result),
+        "expected target near -492, got {result}"
+    );
 }
 
 #[test]
@@ -269,7 +321,7 @@ fn test_compute_maturity_modulation_respects_global_bounds() {
     // 7-day average: 30_000.
     // 365-day average: (358*10_000 + 7*30_000) / 365 = 10_383.
     // target = 2_500 * (30_000 - 10_383) / 10_383 ≈ 4_720 permyriad >> MAX (200).
-    // With 1_000 days elapsed the speed limit is not binding, so global clamping takes over.
+    // First calculation: speed limit is skipped, so global clamping takes over directly.
     // Expected: result == MATURITY_MODULATION_MAX_PERMYRIAD_MISSION_70.
     let mut rates: Vec<SampledPrice> = (1..=358)
         .map(|d| SampledPrice {
@@ -283,8 +335,8 @@ fn test_compute_maturity_modulation_respects_global_bounds() {
             xdr_permyriad_per_icp: 30_000,
         });
     }
-    let result = compute_maturity_modulation_permyriad(&rates, 365, 0, 0);
-    assert_eq!(result, MATURITY_MODULATION_MAX_PERMYRIAD_MISSION_70);
+    let result = compute_maturity_modulation_permyriad(&rates, 365, None);
+    assert_eq!(result, Ok(MATURITY_MODULATION_MAX_PERMYRIAD_MISSION_70));
 }
 
 #[test]

--- a/rs/nns/governance/unreleased_changelog.md
+++ b/rs/nns/governance/unreleased_changelog.md
@@ -13,6 +13,10 @@ on the process that this file is part of, see
 
 ## Changed
 
+* The first Mission 70 maturity modulation calculation skips the daily speed limit, so the initial
+  value reflects the target directly (subject to global bounds) instead of being clamped to a tiny
+  step away from zero.
+
 ## Deprecated
 
 ## Removed


### PR DESCRIPTION
## Why

The first Mission 70 maturity-modulation calculation has no previous value to anchor the daily speed limit. Treating the missing baseline as 0 made the initial value step ±30 permyriad away from zero instead of reflecting the actual target. Skipping the speed limit on the first calculation lets the initial value snap straight to the target (subject to global bounds), and the daily smoothing then applies normally for subsequent updates.

https://dfinity.atlassian.net/browse/NNS1-4319

## What

- `compute_maturity_modulation_permyriad` now takes `Option<(previous_permyriad, previous_day)>` and returns `Result<i64, String>`.
  - `None` → bypass the daily speed limit; only the global Mission 70 bounds apply.
  - The three previously-implicit failure modes (recent/reference price unavailable, reference averaged to zero) are now explicit `Err` variants. None of them should occur in practice — the calculation is gated on a full 365-day buffer, and XRC validation rejects zero rates upstream.
- `update_maturity_modulation` builds the `Option` from `MaturityModulation`'s `current_value_permyriad` and `updated_at_days_since_epoch` (both must be `Some` to use a baseline). On `Err` it logs the reason and leaves prior state untouched.

## Testing

Unit tests cover the new `Result` API, the first-calculation skip-speed-limit behavior, and each error variant.