### PR TITLE
feat(https_adapter): extending default https outcalls timeout

### DIFF
--- a/rs/https_outcalls/adapter/src/config.rs
+++ b/rs/https_outcalls/adapter/src/config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 const DEFAULT_HTTP_CONNECT_TIMEOUT_SECS: u64 = 2;
-const DEFAULT_HTTP_REQUEST_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_HTTP_REQUEST_TIMEOUT_SECS: u64 = 120;
 
 #[derive(Clone, Eq, PartialEq, Debug, Default, Deserialize, Serialize)]
 /// The source of the unix domain socket to be used for inter-process

--- a/rs/https_outcalls/pricing/src/legacy.rs
+++ b/rs/https_outcalls/pricing/src/legacy.rs
@@ -22,9 +22,9 @@ impl BudgetTracker for LegacyTracker {
     fn get_adapter_limits(&self) -> AdapterLimits {
         AdapterLimits {
             max_response_size: self.max_response_size,
-            // Note: there is already a timeout limit on the server itself (30 seconds, see DEFAULT_HTTP_REQUEST_TIMEOUT_SECS).
+            // Note: there is already a timeout limit on the server itself (120 seconds, see DEFAULT_HTTP_REQUEST_TIMEOUT_SECS).
             // Setting higher than that just to be safe.
-            max_response_time: Duration::from_secs(60),
+            max_response_time: Duration::from_secs(150),
         }
     }
 

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -1043,11 +1043,23 @@ fn test_http_endpoint_with_delayed_response_is_rejected(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
+    // We pick a delay that exceeds the consensus-side timeout for canister
+    // HTTP requests (`CANISTER_HTTP_TIMEOUT_INTERVAL` in
+    // rs/types/types/src/canister_http.rs, currently 60s). When the adapter
+    // does not return within that interval, the consensus payload builder
+    // injects a synthetic timeout response with reject code `SysTransient`
+    // and message "Canister http request timed out". This is the canonical
+    // user-visible behaviour for an outcall whose endpoint is too slow.
+    //
+    // Note: the adapter has its own request timeout
+    // (`DEFAULT_HTTP_REQUEST_TIMEOUT_SECS`, currently 120s) which would
+    // otherwise turn the call into a `SysFatal`, but the consensus interval
+    // is shorter and fires first.
     let (response, _) = block_on(submit_outcall(
         &handlers,
         RemoteHttpRequest {
             request: UnvalidatedCanisterHttpRequestArgs {
-                url: format!("https://[{webserver_ipv6}]/delay/40"),
+                url: format!("https://[{webserver_ipv6}]/delay/70"),
                 headers: vec![],
                 method: HttpMethod::GET,
                 body: Some("".as_bytes().to_vec()),
@@ -1069,9 +1081,10 @@ fn test_http_endpoint_with_delayed_response_is_rejected(env: TestEnv) {
     assert_matches!(
         response,
         Err(RejectResponse {
-            reject_code: RejectCode::SysFatal,
+            reject_code: RejectCode::SysTransient,
+            reject_message,
             ..
-        })
+        }) if reject_message.contains("timed out")
     );
 }
 


### PR DESCRIPTION
Since LLMs take some time, and we still use regular https outcalls, this PR extends the timeout from default 30 seconds to 120 seconds making it much more probable to receive a decent response.