### PR TITLE
chore: Remove deprecated protobuf fields

### DIFF
--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -75,8 +75,8 @@ message Callback {
   types.v1.CanisterId respondent = 7;
   // If non-zero, this is a best-effort call.
   uint32 deadline_seconds = 10;
-  state.queues.v1.CompoundCycles prepayment_for_response_execution = 11;
-  state.queues.v1.CompoundCycles prepayment_for_response_transmission = 12;
+  state.queues.v1.CompoundCycles prepayment_for_response_execution_compound = 11;
+  state.queues.v1.CompoundCycles prepayment_for_response_transmission_compound = 12;
   state.queues.v1.CompoundCycles prepayment_for_call_transmission = 13;
 }
 
@@ -225,7 +225,7 @@ message ExecutionTask {
     }
     // The execution cost that has already been charged from the canister.
     // Retried execution does not have to pay for it again.
-    state.queues.v1.CompoundCycles prepaid_execution_cycles = 7;
+    state.queues.v1.CompoundCycles prepaid_execution_compound_cycles = 7;
   }
 
   message AbortedInstallCode {
@@ -239,7 +239,7 @@ message ExecutionTask {
     optional uint64 call_id = 4;
     // The execution cost that has already been charged from the canister.
     // Retried execution does not have to pay for it again.
-    state.queues.v1.CompoundCycles prepaid_execution_cycles = 5;
+    state.queues.v1.CompoundCycles prepaid_execution_compound_cycles = 5;
   }
 
   oneof task {

--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -64,6 +64,8 @@ message WasmClosure {
 
 message Callback {
   reserved 6;
+  reserved 8;
+  reserved 9;
 
   uint64 call_context_id = 1;
   WasmClosure on_reply = 2;
@@ -71,14 +73,10 @@ message Callback {
   WasmClosure on_cleanup = 4;
   state.queues.v1.Cycles cycles_sent = 5;
   types.v1.CanisterId respondent = 7;
-  state.queues.v1.Cycles prepayment_for_response_execution = 8;
-  state.queues.v1.Cycles prepayment_for_response_transmission = 9;
   // If non-zero, this is a best-effort call.
   uint32 deadline_seconds = 10;
-  // To replace `prepayment_for_response_execution`.
-  state.queues.v1.CompoundCycles prepayment_for_response_execution_compound = 11;
-  // To replace `prepayment_for_response_transmission`.
-  state.queues.v1.CompoundCycles prepayment_for_response_transmission_compound = 12;
+  state.queues.v1.CompoundCycles prepayment_for_response_execution = 11;
+  state.queues.v1.CompoundCycles prepayment_for_response_transmission = 12;
   state.queues.v1.CompoundCycles prepayment_for_call_transmission = 13;
 }
 
@@ -212,6 +210,7 @@ message ExecutionTask {
 
   message AbortedExecution {
     reserved 2;
+    reserved 4;
 
     message AbortedResponse {
       state.queues.v1.Response response = 7;
@@ -226,27 +225,21 @@ message ExecutionTask {
     }
     // The execution cost that has already been charged from the canister.
     // Retried execution does not have to pay for it again.
-    state.queues.v1.Cycles prepaid_execution_cycles = 4;
-    // The execution cost that has already been charged from the canister.
-    // Retried execution does not have to pay for it again.
-    // This field will replace the existing `prepaid_execution_cycles`.
-    state.queues.v1.CompoundCycles prepaid_execution_compound_cycles = 7;
+    state.queues.v1.CompoundCycles prepaid_execution_cycles = 7;
   }
 
   message AbortedInstallCode {
+    reserved 3;
+
     oneof message {
       state.queues.v1.Request request = 1;
       ingress.v1.Ingress ingress = 2;
     }
-    // The execution cost that has already been charged from the canister.
-    // Retried execution does not have to pay for it again.
-    state.queues.v1.Cycles prepaid_execution_cycles = 3;
     reserved "request_id";
     optional uint64 call_id = 4;
     // The execution cost that has already been charged from the canister.
     // Retried execution does not have to pay for it again.
-    // Will replace the existing `prepaid_execution_cycles`.
-    state.queues.v1.CompoundCycles prepaid_execution_compound_cycles = 5;
+    state.queues.v1.CompoundCycles prepaid_execution_cycles = 5;
   }
 
   oneof task {

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -94,21 +94,14 @@ pub struct Callback {
     pub cycles_sent: ::core::option::Option<super::super::queues::v1::Cycles>,
     #[prost(message, optional, tag = "7")]
     pub respondent: ::core::option::Option<super::super::super::types::v1::CanisterId>,
-    #[prost(message, optional, tag = "8")]
-    pub prepayment_for_response_execution: ::core::option::Option<super::super::queues::v1::Cycles>,
-    #[prost(message, optional, tag = "9")]
-    pub prepayment_for_response_transmission:
-        ::core::option::Option<super::super::queues::v1::Cycles>,
     /// If non-zero, this is a best-effort call.
     #[prost(uint32, tag = "10")]
     pub deadline_seconds: u32,
-    /// To replace `prepayment_for_response_execution`.
     #[prost(message, optional, tag = "11")]
-    pub prepayment_for_response_execution_compound:
+    pub prepayment_for_response_execution:
         ::core::option::Option<super::super::queues::v1::CompoundCycles>,
-    /// To replace `prepayment_for_response_transmission`.
     #[prost(message, optional, tag = "12")]
-    pub prepayment_for_response_transmission_compound:
+    pub prepayment_for_response_transmission:
         ::core::option::Option<super::super::queues::v1::CompoundCycles>,
     #[prost(message, optional, tag = "13")]
     pub prepayment_for_call_transmission:
@@ -324,14 +317,8 @@ pub mod execution_task {
     pub struct AbortedExecution {
         /// The execution cost that has already been charged from the canister.
         /// Retried execution does not have to pay for it again.
-        #[prost(message, optional, tag = "4")]
-        pub prepaid_execution_cycles:
-            ::core::option::Option<super::super::super::queues::v1::Cycles>,
-        /// The execution cost that has already been charged from the canister.
-        /// Retried execution does not have to pay for it again.
-        /// This field will replace the existing `prepaid_execution_cycles`.
         #[prost(message, optional, tag = "7")]
-        pub prepaid_execution_compound_cycles:
+        pub prepaid_execution_cycles:
             ::core::option::Option<super::super::super::queues::v1::CompoundCycles>,
         #[prost(oneof = "aborted_execution::Input", tags = "1, 6, 3, 5")]
         pub input: ::core::option::Option<aborted_execution::Input>,
@@ -359,18 +346,12 @@ pub mod execution_task {
     }
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AbortedInstallCode {
-        /// The execution cost that has already been charged from the canister.
-        /// Retried execution does not have to pay for it again.
-        #[prost(message, optional, tag = "3")]
-        pub prepaid_execution_cycles:
-            ::core::option::Option<super::super::super::queues::v1::Cycles>,
         #[prost(uint64, optional, tag = "4")]
         pub call_id: ::core::option::Option<u64>,
         /// The execution cost that has already been charged from the canister.
         /// Retried execution does not have to pay for it again.
-        /// Will replace the existing `prepaid_execution_cycles`.
         #[prost(message, optional, tag = "5")]
-        pub prepaid_execution_compound_cycles:
+        pub prepaid_execution_cycles:
             ::core::option::Option<super::super::super::queues::v1::CompoundCycles>,
         #[prost(oneof = "aborted_install_code::Message", tags = "1, 2")]
         pub message: ::core::option::Option<aborted_install_code::Message>,

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -98,10 +98,10 @@ pub struct Callback {
     #[prost(uint32, tag = "10")]
     pub deadline_seconds: u32,
     #[prost(message, optional, tag = "11")]
-    pub prepayment_for_response_execution:
+    pub prepayment_for_response_execution_compound:
         ::core::option::Option<super::super::queues::v1::CompoundCycles>,
     #[prost(message, optional, tag = "12")]
-    pub prepayment_for_response_transmission:
+    pub prepayment_for_response_transmission_compound:
         ::core::option::Option<super::super::queues::v1::CompoundCycles>,
     #[prost(message, optional, tag = "13")]
     pub prepayment_for_call_transmission:
@@ -318,7 +318,7 @@ pub mod execution_task {
         /// The execution cost that has already been charged from the canister.
         /// Retried execution does not have to pay for it again.
         #[prost(message, optional, tag = "7")]
-        pub prepaid_execution_cycles:
+        pub prepaid_execution_compound_cycles:
             ::core::option::Option<super::super::super::queues::v1::CompoundCycles>,
         #[prost(oneof = "aborted_execution::Input", tags = "1, 6, 3, 5")]
         pub input: ::core::option::Option<aborted_execution::Input>,
@@ -351,7 +351,7 @@ pub mod execution_task {
         /// The execution cost that has already been charged from the canister.
         /// Retried execution does not have to pay for it again.
         #[prost(message, optional, tag = "5")]
-        pub prepaid_execution_cycles:
+        pub prepaid_execution_compound_cycles:
             ::core::option::Option<super::super::super::queues::v1::CompoundCycles>,
         #[prost(oneof = "aborted_install_code::Message", tags = "1, 2")]
         pub message: ::core::option::Option<aborted_install_code::Message>,

--- a/rs/replicated_state/src/canister_state/system_state/proto.rs
+++ b/rs/replicated_state/src/canister_state/system_state/proto.rs
@@ -1,6 +1,7 @@
 use super::*;
 use ic_protobuf::proxy::{ProxyDecodeError, try_from_option_field};
 use ic_protobuf::state::canister_state_bits::v1 as pb;
+use ic_protobuf::state::queues::v1::CompoundCycles as PbCompoundCycles;
 
 impl From<&CanisterStatus> for pb::canister_state_bits::CanisterStatus {
     fn from(item: &CanisterStatus) -> Self {
@@ -98,7 +99,9 @@ impl From<&ExecutionTask> for pb::ExecutionTask {
                     task: Some(pb::execution_task::Task::AbortedExecution(
                         pb::execution_task::AbortedExecution {
                             input: Some(input),
-                            prepaid_execution_cycles: Some((*prepaid_execution_cycles).into()),
+                            prepaid_execution_compound_cycles: Some(PbCompoundCycles::from(
+                                *prepaid_execution_cycles,
+                            )),
                         },
                     )),
                 }
@@ -118,7 +121,9 @@ impl From<&ExecutionTask> for pb::ExecutionTask {
                         pb::execution_task::AbortedInstallCode {
                             message: Some(message),
                             call_id: Some(call_id.get()),
-                            prepaid_execution_cycles: Some((*prepaid_execution_cycles).into()),
+                            prepaid_execution_compound_cycles: Some(PbCompoundCycles::from(
+                                *prepaid_execution_cycles,
+                            )),
                         },
                     )),
                 }
@@ -174,8 +179,8 @@ impl TryFrom<pb::ExecutionTask> for ExecutionTask {
                     }
                 };
                 let prepaid_execution_cycles = try_from_option_field(
-                    aborted.prepaid_execution_cycles,
-                    "AbortedExecution::prepaid_execution_cycles",
+                    aborted.prepaid_execution_compound_cycles,
+                    "AbortedExecution::prepaid_execution_compound_cycles",
                 )?;
                 ExecutionTask::AbortedExecution {
                     input,
@@ -192,8 +197,8 @@ impl TryFrom<pb::ExecutionTask> for ExecutionTask {
                     Message::Ingress(v) => CanisterCall::Ingress(Arc::new(v.try_into()?)),
                 };
                 let prepaid_execution_cycles = try_from_option_field(
-                    aborted.prepaid_execution_cycles,
-                    "AbortedExecution::prepaid_execution_cycles",
+                    aborted.prepaid_execution_compound_cycles,
+                    "AbortedExecution::prepaid_execution_compound_cycles",
                 )?;
                 let call_id = aborted.call_id.ok_or(ProxyDecodeError::MissingField(
                     "AbortedInstallCode::call_id",

--- a/rs/replicated_state/src/canister_state/system_state/proto.rs
+++ b/rs/replicated_state/src/canister_state/system_state/proto.rs
@@ -1,8 +1,6 @@
 use super::*;
 use ic_protobuf::proxy::{ProxyDecodeError, try_from_option_field};
 use ic_protobuf::state::canister_state_bits::v1 as pb;
-use ic_protobuf::state::queues::v1::CompoundCycles as PbCompoundCycles;
-use ic_types_cycles::{CanisterCyclesCostSchedule, CompoundCycles, Instructions};
 
 impl From<&CanisterStatus> for pb::canister_state_bits::CanisterStatus {
     fn from(item: &CanisterStatus) -> Self {
@@ -100,12 +98,7 @@ impl From<&ExecutionTask> for pb::ExecutionTask {
                     task: Some(pb::execution_task::Task::AbortedExecution(
                         pb::execution_task::AbortedExecution {
                             input: Some(input),
-                            prepaid_execution_cycles: Some(
-                                (prepaid_execution_cycles.real()).into(),
-                            ),
-                            prepaid_execution_compound_cycles: Some(PbCompoundCycles::from(
-                                *prepaid_execution_cycles,
-                            )),
+                            prepaid_execution_cycles: Some((*prepaid_execution_cycles).into()),
                         },
                     )),
                 }
@@ -125,12 +118,7 @@ impl From<&ExecutionTask> for pb::ExecutionTask {
                         pb::execution_task::AbortedInstallCode {
                             message: Some(message),
                             call_id: Some(call_id.get()),
-                            prepaid_execution_cycles: Some(
-                                (prepaid_execution_cycles.real()).into(),
-                            ),
-                            prepaid_execution_compound_cycles: Some(PbCompoundCycles::from(
-                                *prepaid_execution_cycles,
-                            )),
+                            prepaid_execution_cycles: Some((*prepaid_execution_cycles).into()),
                         },
                     )),
                 }
@@ -146,14 +134,6 @@ impl TryFrom<pb::ExecutionTask> for ExecutionTask {
         let task = value
             .task
             .ok_or(ProxyDecodeError::MissingField("ExecutionTask::task"))?;
-        // cost_schedule should ideally be read from the checkpoint, however there
-        // is no easy access to it here (will need to be propagated from `StateManager`).
-        // Given that the current state is that the values for `Cycles` and `NominalCycles`
-        // should still match and that they should be 0 on `Free` schedule, we can use `Normal`
-        // without any loss (to maintain values on subnets with `Normal` schedule).
-        // This code will be removed anyway when the new fields are set and the old fields
-        // containing just `Cycles` can be retired.
-        let cost_schedule = CanisterCyclesCostSchedule::Normal;
         let task = match task {
             pb::execution_task::Task::AbortedExecution(aborted) => {
                 use pb::execution_task::{
@@ -193,15 +173,10 @@ impl TryFrom<pb::ExecutionTask> for ExecutionTask {
                         CanisterMessageOrTask::Task(task)
                     }
                 };
-                let prepaid_execution_cycles = match aborted.prepaid_execution_compound_cycles {
-                    Some(value) => CompoundCycles::try_from(value)?,
-                    None => {
-                        let prepaid_execution_cycles = aborted
-                            .prepaid_execution_cycles
-                            .map_or_else(Cycles::zero, |c| c.into());
-                        CompoundCycles::<Instructions>::new(prepaid_execution_cycles, cost_schedule)
-                    }
-                };
+                let prepaid_execution_cycles = try_from_option_field(
+                    aborted.prepaid_execution_cycles,
+                    "AbortedExecution::prepaid_execution_cycles",
+                )?;
                 ExecutionTask::AbortedExecution {
                     input,
                     prepaid_execution_cycles,
@@ -216,15 +191,10 @@ impl TryFrom<pb::ExecutionTask> for ExecutionTask {
                     Message::Request(v) => CanisterCall::Request(Arc::new(v.try_into()?)),
                     Message::Ingress(v) => CanisterCall::Ingress(Arc::new(v.try_into()?)),
                 };
-                let prepaid_execution_cycles = match aborted.prepaid_execution_compound_cycles {
-                    Some(value) => CompoundCycles::try_from(value)?,
-                    None => {
-                        let prepaid_execution_cycles = aborted
-                            .prepaid_execution_cycles
-                            .map_or_else(Cycles::zero, |c| c.into());
-                        CompoundCycles::<Instructions>::new(prepaid_execution_cycles, cost_schedule)
-                    }
-                };
+                let prepaid_execution_cycles = try_from_option_field(
+                    aborted.prepaid_execution_cycles,
+                    "AbortedExecution::prepaid_execution_cycles",
+                )?;
                 let call_id = aborted.call_id.ok_or(ProxyDecodeError::MissingField(
                     "AbortedInstallCode::call_id",
                 ))?;

--- a/rs/types/types/src/methods.rs
+++ b/rs/types/types/src/methods.rs
@@ -330,8 +330,10 @@ impl From<&Callback> for pb::Callback {
             call_context_id: item.call_context_id.get(),
             respondent: Some(pb_types::CanisterId::from(item.respondent)),
             cycles_sent: Some(item.cycles_sent.into()),
-            prepayment_for_response_execution: Some(item.prepayment_for_response_execution.into()),
-            prepayment_for_response_transmission: Some(
+            prepayment_for_response_execution_compound: Some(
+                item.prepayment_for_response_execution.into(),
+            ),
+            prepayment_for_response_transmission_compound: Some(
                 item.prepayment_for_response_transmission.into(),
             ),
             prepayment_for_call_transmission: Some(item.prepayment_for_call_transmission.into()),
@@ -364,11 +366,11 @@ impl TryFrom<pb::Callback> for Callback {
             try_from_option_field(value.cycles_sent, "Callback::cycles_sent")?;
 
         let prepayment_for_response_execution = try_from_option_field(
-            value.prepayment_for_response_execution,
+            value.prepayment_for_response_execution_compound,
             "Callback::prepayment_for_response_execution",
         )?;
         let prepayment_for_response_transmission = try_from_option_field(
-            value.prepayment_for_response_transmission,
+            value.prepayment_for_response_transmission_compound,
             "Callback::prepayment_for_response_transmission",
         )?;
         let prepayment_for_call_transmission = try_from_option_field(

--- a/rs/types/types/src/methods.rs
+++ b/rs/types/types/src/methods.rs
@@ -9,10 +9,7 @@ use ic_heap_bytes::DeterministicHeapBytes;
 use ic_protobuf::proxy::{ProxyDecodeError, try_from_option_field};
 use ic_protobuf::state::{canister_state_bits::v1 as pb, queues::v1::Cycles as PbCycles};
 use ic_protobuf::types::v1 as pb_types;
-use ic_types_cycles::{
-    CanisterCyclesCostSchedule, CompoundCycles, Cycles, Instructions,
-    RequestAndResponseTransmission,
-};
+use ic_types_cycles::{CompoundCycles, Cycles, Instructions, RequestAndResponseTransmission};
 use serde::{Deserialize, Serialize};
 use std::{
     convert::{From, TryFrom},
@@ -333,16 +330,8 @@ impl From<&Callback> for pb::Callback {
             call_context_id: item.call_context_id.get(),
             respondent: Some(pb_types::CanisterId::from(item.respondent)),
             cycles_sent: Some(item.cycles_sent.into()),
-            prepayment_for_response_execution: Some(
-                item.prepayment_for_response_execution.real().into(),
-            ),
+            prepayment_for_response_execution: Some(item.prepayment_for_response_execution.into()),
             prepayment_for_response_transmission: Some(
-                item.prepayment_for_response_transmission.real().into(),
-            ),
-            prepayment_for_response_execution_compound: Some(
-                item.prepayment_for_response_execution.into(),
-            ),
-            prepayment_for_response_transmission_compound: Some(
                 item.prepayment_for_response_transmission.into(),
             ),
             prepayment_for_call_transmission: Some(item.prepayment_for_call_transmission.into()),
@@ -374,44 +363,18 @@ impl TryFrom<pb::Callback> for Callback {
         let cycles_sent: PbCycles =
             try_from_option_field(value.cycles_sent, "Callback::cycles_sent")?;
 
-        // cost_schedule should ideally be read from the checkpoint, however there
-        // is no easy access to it here (will need to be propagated from `StateManager`).
-        // Given that the current state is that the values for `Cycles` and `NominalCycles`
-        // should still match and that they should be 0 on `Free` schedule, we can use `Normal`
-        // without any loss (to maintain values on subnets with `Normal` schedule).
-        // This code will be removed anyway when the new fields are set and the old fields
-        // containing just `Cycles` can be retired.
-        let cost_schedule = CanisterCyclesCostSchedule::Normal;
-        let prepayment_for_response_execution =
-            match value.prepayment_for_response_execution_compound {
-                Some(value) => CompoundCycles::try_from(value)?,
-                None => CompoundCycles::new(
-                    try_from_option_field(
-                        value.prepayment_for_response_execution,
-                        "Callback::prepayment_for_response_execution",
-                    )?,
-                    cost_schedule,
-                ),
-            };
-        let prepayment_for_response_transmission =
-            match value.prepayment_for_response_transmission_compound {
-                Some(value) => CompoundCycles::try_from(value)?,
-                None => CompoundCycles::new(
-                    try_from_option_field(
-                        value.prepayment_for_response_transmission,
-                        "Callback::prepayment_for_response_transmission",
-                    )?,
-                    cost_schedule,
-                ),
-            };
-        let prepayment_for_call_transmission = match value.prepayment_for_call_transmission {
-            Some(value) => CompoundCycles::try_from(value)?,
-            // Temporary code until the change is deployed and the field starts
-            // being populated in checkpoints. If no "old" callbacks exist,
-            // this can be changed to fail on `None` instead and always
-            // expect to find some value.
-            None => CompoundCycles::new(Cycles::zero(), cost_schedule),
-        };
+        let prepayment_for_response_execution = try_from_option_field(
+            value.prepayment_for_response_execution,
+            "Callback::prepayment_for_response_execution",
+        )?;
+        let prepayment_for_response_transmission = try_from_option_field(
+            value.prepayment_for_response_transmission,
+            "Callback::prepayment_for_response_transmission",
+        )?;
+        let prepayment_for_call_transmission = try_from_option_field(
+            value.prepayment_for_call_transmission,
+            "Callback::prepayment_for_call_transmission",
+        )?;
 
         Ok(Self {
             call_context_id: CallContextId::from(value.call_context_id),


### PR DESCRIPTION
Several fields regarding storing `Cycles` prepayments are now obsolete after introducing new versions of them that deal with `CompoundCycles`. The relevant code has been deployed to production for a couple weeks already so we can now remove the fallback code that was trying to backfill data from the old fields.

Additionally, we make the parsing code for a new field `prepayment_for_call_transmission` that was introduced stricter as it should also be populated now in production.