### PR TITLE
chore(ic-metrics-assert): bump to v0.5.0 with pocket-ic v13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11304,7 +11304,7 @@ dependencies = [
 
 [[package]]
 name = "ic-metrics-assert"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "candid",

--- a/packages/ic-metrics-assert/CHANGELOG.md
+++ b/packages/ic-metrics-assert/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-11
+
+### Changed
+
+- Bump `pocket-ic` to v13.0.0
+
 ## [0.4.0] - 2026-02-02
 
 ### Changed

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-metrics-assert"
-version = "0.4.0"
+version = "0.5.0"
 description = "Fluent assertions for metrics"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bumps `ic-metrics-assert` to `v0.5.0`, pinning its `pocket-ic` dependency to `v13.0.0`. The crate's `Cargo.toml` was already updated to depend on `pocket-ic = "13.0.0"` as part of the in-tree PocketIC v13 release, but the crate's own version and `CHANGELOG.md` were not bumped, so crates.io still serves `0.4.0` with `pocket-ic` v12.

Publishing `0.5.0` unblocks downstream consumers such as `evm-rpc-canister` and `sol-rpc-canister`, which today cannot upgrade to `pocket-ic` v13 without ending up with two semver-incompatible `pocket_ic` versions in their build graph.

This is a breaking change for downstream consumers of the `pocket_ic` feature.