### PR TITLE
fix: Fix LUKS keyslot params

### DIFF
--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -1,7 +1,7 @@
 use crate::metrics::export_luks_parameters;
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use itertools::Either::Right;
-use libcryptsetup_rs::consts::flags::{CryptActivate, CryptVolumeKey};
+use libcryptsetup_rs::consts::flags::{CryptActivate, CryptPbkdf, CryptVolumeKey};
 use libcryptsetup_rs::consts::vals::{CryptKdf, EncryptionFormat, KeyslotInfo};
 use libcryptsetup_rs::{CryptDevice, CryptInit, CryptParamsLuks2Ref, CryptSettingsHandle};
 use std::fs;
@@ -90,7 +90,7 @@ pub fn activate_crypt_device(
     device_path: &Path,
     header_location: LuksHeaderLocation,
     name: &str,
-    encryption_key: &[u8],
+    passphrase: &[u8],
     flags: CryptActivate,
     verify_luks_params: bool,
     metrics_file: Option<&Path>,
@@ -102,7 +102,7 @@ pub fn activate_crypt_device(
 
     let active_keyslot = crypt_device
         .activate_handle()
-        .activate_by_passphrase(Some(name), None, encryption_key, flags)
+        .activate_by_passphrase(Some(name), None, passphrase, flags)
         .context("Failed to activate cryptographic device")?;
 
     if let Some(metrics_file) = metrics_file {
@@ -129,6 +129,26 @@ pub fn deactivate_crypt_device(crypt_name: &str) -> Result<()> {
     Ok(())
 }
 
+fn apply_default_settings(crypt_device: &mut CryptDevice) -> Result<()> {
+    // The settings below are not preserved in the persisted metadata, therefore they need to be
+    // set every time the device is opened, otherwise the defaults are used.
+
+    // TODO: We should revisit the use of Pbkdf2 and consider using the LUKS2 default KDF, Argon2i
+    let mut pbkdf_params = CryptSettingsHandle::get_pbkdf_type_params(&PBKDF_TYPE)
+        .context("Failed to get PBKDF params")?;
+    // Set minimal iteration count and disable benchmarking -- we already use a random key with
+    // maximal entropy, pbkdf doesn't gain anything (besides slowing down boot by a couple seconds
+    // which needlessly annoys for testing).
+    pbkdf_params.iterations = PBKDF_ITERATIONS;
+    pbkdf_params.flags |= CryptPbkdf::NO_BENCHMARK;
+    crypt_device
+        .settings_handle()
+        .set_pbkdf_type(&pbkdf_params)
+        .context("Failed to set PBKDF type")?;
+
+    Ok(())
+}
+
 /// Formats the given cryptographic device with LUKS2 and initializes it with the provided
 /// encryption key.
 /// WARNING: Leads to data loss on the device!
@@ -149,17 +169,7 @@ pub fn format_crypt_device(
         "Formatting {} with LUKS2 and initializing it with an encryption key",
         device_path.display()
     );
-    // TODO: We should revisit the use of Pbkdf2 and consider using the LUKS2 default KDF, Argon2i
-    let mut pbkdf_params = CryptSettingsHandle::get_pbkdf_type_params(&PBKDF_TYPE)
-        .context("Failed to get PBKDF2 params")?;
-    // Set minimal iteration count -- we already use a random key with
-    // maximal entropy, pbkdf doesn't gain anything (besides slowing
-    // down boot by a couple seconds which needlessly annoys for testing).
-    pbkdf_params.iterations = PBKDF_ITERATIONS;
-    crypt_device
-        .settings_handle()
-        .set_pbkdf_type(&pbkdf_params)
-        .context("Failed to set PBKDF2 type")?;
+    apply_default_settings(&mut crypt_device)?;
     crypt_device
         .context_handle()
         .format::<CryptParamsLuks2Ref>(
@@ -178,7 +188,8 @@ pub fn format_crypt_device(
     Ok(crypt_device)
 }
 
-/// Opens a LUKS2 device at the specified path and loads its context. Does not activate the device.
+/// Opens a LUKS2 device at the specified path, loads its context, and prepares handle-local
+/// defaults for follow-on operations such as adding keyslots. Does not activate the device.
 pub fn open_luks2_device(
     device_path: &Path,
     header_location: LuksHeaderLocation,
@@ -188,6 +199,7 @@ pub fn open_luks2_device(
     crypt_device
         .context_handle()
         .load::<CryptParamsLuks2Ref>(Some(ENCRYPTION_FORMAT), None)?;
+    apply_default_settings(&mut crypt_device)?;
 
     Ok(crypt_device)
 }

--- a/rs/ic_os/os_tools/guest_disk/src/tests.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/tests.rs
@@ -10,7 +10,7 @@ use ic_device::device_mapping::{Bytes, TempDevice};
 use ic_os_logging::init_logging;
 use itertools::Either::Right;
 use libcryptsetup_rs::consts::flags::{CryptActivate, CryptVolumeKey};
-use libcryptsetup_rs::consts::vals::{CryptKdf, EncryptionFormat};
+use libcryptsetup_rs::consts::vals::{CryptKdf, EncryptionFormat, KeyslotInfo};
 use libcryptsetup_rs::{CryptInit, CryptParamsLuks2Ref, CryptSettingsHandle};
 use sev_guest::key_deriver::{Key, derive_key_from_sev_measurement};
 use sev_guest_testing::MockSevGuestFirmwareBuilder;
@@ -394,6 +394,8 @@ fn test_sev_unlock_store_partition_with_previous_key() {
         .add_by_passphrase(None, b"previous key", b"deprecated key")
         .expect("Failed to add deprecated key slot");
 
+    drop(device);
+
     // Write some data to the disk.
     activate_crypt_device(
         &fixture.device.path().unwrap(),
@@ -485,6 +487,32 @@ fn test_sev_unlock_store_partition_with_previous_key() {
         DEPRECATED_KEY,
     )
     .expect_err("deprecated key should not unlock the store partition");
+
+    let mut device = open_luks2_device(
+        &fixture.device.path().unwrap(),
+        LuksHeaderLocation::Detached(&fixture.store_luks_header_path),
+    )
+    .expect("Failed to open detached Store header");
+    let mut keyslot_handle = device.keyslot_handle();
+
+    // Test the all keys have correct params
+    let mut active_keyslot_count = 0;
+    for key_slot in 0..32 {
+        if matches!(
+            keyslot_handle
+                .status(key_slot)
+                .expect("Failed to get keyslot status"),
+            KeyslotInfo::Active | KeyslotInfo::ActiveLast
+        ) {
+            active_keyslot_count += 1;
+            let pbkdf = keyslot_handle
+                .get_pbkdf(key_slot)
+                .expect("Failed to get PBKDF params for active keyslot");
+            assert_eq!(pbkdf.type_, CryptKdf::Pbkdf2);
+            assert_eq!(pbkdf.iterations, TEST_PBKDF_ITERATIONS);
+        }
+    }
+    assert_eq!(active_keyslot_count, 2);
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes two minor issues:
1) LUKS pbkdf params are not persisted in the header. Previously, we only applied the settings at formatting but not when later adding a new passphrase, so the LUKS defaults were used. We now apply the settings every time we open the device.
2) We configured the key derivation iteration count to be the minimum for efficiency. However, without the NO_BENCHMARK flag, LUKS disregarded the setting.

With these changes, we could see a few seconds gain when booting GuestOS.