### PR TITLE
test: cycles burn API in install_code

### DIFF
--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -29,7 +29,7 @@ use ic_types::{
     CanisterLog, CanisterTimer, Height, MemoryAllocation, NumInstructions, Time,
     messages::CanisterCall,
 };
-use ic_types_cycles::{CompoundCycles, Cycles, Instructions, CyclesUseCase};
+use ic_types_cycles::{CompoundCycles, Cycles, CyclesUseCase, Instructions};
 use ic_wasm_types::WasmHash;
 
 use crate::{

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -29,7 +29,7 @@ use ic_types::{
     CanisterLog, CanisterTimer, Height, MemoryAllocation, NumInstructions, Time,
     messages::CanisterCall,
 };
-use ic_types_cycles::{CompoundCycles, Cycles, Instructions};
+use ic_types_cycles::{CompoundCycles, Cycles, Instructions, CyclesUseCase};
 use ic_wasm_types::WasmHash;
 
 use crate::{
@@ -285,12 +285,24 @@ impl InstallCodeHelper {
         let message_instruction_limit = original.execution_parameters.instruction_limits.message();
         let instructions_left = self.instructions_left();
 
-        // The balance should not change because `install_code` cannot accept or
-        // send cycles. The execution cycles have already been accounted for in
-        // the clean canister state.
+        // The balance should only change due to cycles explicitly burned via
+        // `ic0.cycles_burn128`. The execution cycles are already accounted for
+        // in the clean canister state, and `install_code` cannot accept or send
+        // cycles.
+        let get_burned = |state: &CanisterState| {
+            state
+                .system_state
+                .canister_metrics()
+                .consumed_cycles_by_use_cases()
+                .get(&CyclesUseCase::BurnedCycles)
+                .map(|c| c.get())
+                .unwrap_or(0)
+        };
+        let burned_cycles_delta =
+            Cycles::new(get_burned(&self.canister).saturating_sub(get_burned(&clean_canister)));
         debug_assert_eq!(
             clean_canister.system_state.balance(),
-            self.canister.system_state.balance()
+            self.canister.system_state.balance() + burned_cycles_delta
         );
 
         let instructions_used = NumInstructions::from(

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -36,8 +36,8 @@ use ic_types::{
     consensus::idkg::{IDkgMasterPublicKeyId, PreSigId},
     ingress::{IngressState, IngressStatus, WasmResult},
     messages::{
-        CallbackId, CanisterCall, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, Payload, RejectContext,
-        RequestOrResponse, Response,
+        CallbackId, CanisterCall, CanisterTask, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, Payload,
+        RejectContext, RequestOrResponse, Response,
     },
     time::UNIX_EPOCH,
 };
@@ -4186,6 +4186,274 @@ fn replicated_query_does_not_burn_cycles_on_trap() {
             .get(&CyclesUseCase::BurnedCycles)
             .is_none()
     );
+}
+
+#[test]
+fn canister_init_can_burn_cycles() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let initial_cycles = Cycles::new(1_000_000_000_000);
+    let canister_id = test.create_canister(initial_cycles);
+    let cycles_to_burn = Cycles::new(10_000_000_u128);
+
+    let init_payload = wasm().cycles_burn128(cycles_to_burn).build();
+    test.install_canister_with_args(canister_id, UNIVERSAL_CANISTER_WASM.to_vec(), init_payload)
+        .unwrap();
+
+    // Canister loses `cycles_to_burn` from its balance (in addition to execution cost).
+    assert_eq!(
+        test.canister_state(canister_id).system_state.balance(),
+        initial_cycles - test.canister_execution_cost(canister_id).real() - cycles_to_burn
+    );
+
+    // The burned cycles are accounted for in the canister's metrics.
+    let burned_cycles = *test
+        .canister_state(canister_id)
+        .system_state
+        .canister_metrics()
+        .consumed_cycles_by_use_cases()
+        .get(&CyclesUseCase::BurnedCycles)
+        .unwrap();
+    assert_eq!(burned_cycles, NominalCycles::new(cycles_to_burn.get()));
+}
+
+#[test]
+fn canister_post_upgrade_can_burn_cycles() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let initial_cycles = Cycles::new(1_000_000_000_000);
+    let canister_id = test.create_canister(initial_cycles);
+    let cycles_to_burn = Cycles::new(10_000_000_u128);
+
+    test.install_canister_with_args(canister_id, UNIVERSAL_CANISTER_WASM.to_vec(), vec![])
+        .unwrap();
+    let post_upgrade_payload = wasm().cycles_burn128(cycles_to_burn).build();
+    test.upgrade_canister_with_args(
+        canister_id,
+        UNIVERSAL_CANISTER_WASM.to_vec(),
+        post_upgrade_payload,
+    )
+    .unwrap();
+
+    assert_eq!(
+        test.canister_state(canister_id).system_state.balance(),
+        initial_cycles - test.canister_execution_cost(canister_id).real() - cycles_to_burn
+    );
+
+    let burned_cycles = *test
+        .canister_state(canister_id)
+        .system_state
+        .canister_metrics()
+        .consumed_cycles_by_use_cases()
+        .get(&CyclesUseCase::BurnedCycles)
+        .unwrap();
+    assert_eq!(burned_cycles, NominalCycles::new(cycles_to_burn.get()));
+}
+
+#[test]
+fn canister_pre_upgrade_can_burn_cycles() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let initial_cycles = Cycles::new(1_000_000_000_000);
+    let canister_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+    let cycles_to_burn = Cycles::new(10_000_000_u128);
+
+    test.ingress(
+        canister_id,
+        "update",
+        wasm()
+            .set_pre_upgrade(wasm().cycles_burn128(cycles_to_burn))
+            .reply()
+            .build(),
+    )
+    .unwrap();
+    test.upgrade_canister(canister_id, UNIVERSAL_CANISTER_WASM.to_vec())
+        .unwrap();
+
+    assert_eq!(
+        test.canister_state(canister_id).system_state.balance(),
+        initial_cycles - test.canister_execution_cost(canister_id).real() - cycles_to_burn
+    );
+
+    let burned_cycles = *test
+        .canister_state(canister_id)
+        .system_state
+        .canister_metrics()
+        .consumed_cycles_by_use_cases()
+        .get(&CyclesUseCase::BurnedCycles)
+        .unwrap();
+    assert_eq!(burned_cycles, NominalCycles::new(cycles_to_burn.get()));
+}
+
+#[test]
+fn reply_callback_can_burn_cycles() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let initial_cycles = Cycles::new(1_000_000_000_000);
+    let caller_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+    let callee_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+    let cycles_to_burn = Cycles::new(10_000_000_u128);
+
+    test.ingress(
+        caller_id,
+        "update",
+        wasm()
+            .inter_update(
+                callee_id,
+                call_args()
+                    .other_side(wasm().reply())
+                    .on_reply(wasm().cycles_burn128(cycles_to_burn).reply()),
+            )
+            .build(),
+    )
+    .unwrap();
+
+    let use_cases = test
+        .canister_state(caller_id)
+        .system_state
+        .canister_metrics()
+        .consumed_cycles_by_use_cases()
+        .clone();
+    let transmission_cost = Cycles::new(
+        use_cases
+            .get(&CyclesUseCase::RequestAndResponseTransmission)
+            .map(|c| c.get())
+            .unwrap_or(0),
+    );
+    assert_eq!(
+        test.canister_state(caller_id).system_state.balance(),
+        initial_cycles
+            - test.canister_execution_cost(caller_id).real()
+            - transmission_cost
+            - cycles_to_burn
+    );
+
+    let burned_cycles = *use_cases.get(&CyclesUseCase::BurnedCycles).unwrap();
+    assert_eq!(burned_cycles, NominalCycles::new(cycles_to_burn.get()));
+}
+
+#[test]
+fn reject_callback_can_burn_cycles() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let initial_cycles = Cycles::new(1_000_000_000_000);
+    let caller_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+    let callee_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+    let cycles_to_burn = Cycles::new(10_000_000_u128);
+
+    test.ingress(
+        caller_id,
+        "update",
+        wasm()
+            .inter_update(
+                callee_id,
+                call_args()
+                    .other_side(wasm().trap())
+                    .on_reject(wasm().cycles_burn128(cycles_to_burn).reply()),
+            )
+            .build(),
+    )
+    .unwrap();
+
+    let use_cases = test
+        .canister_state(caller_id)
+        .system_state
+        .canister_metrics()
+        .consumed_cycles_by_use_cases()
+        .clone();
+    let transmission_cost = Cycles::new(
+        use_cases
+            .get(&CyclesUseCase::RequestAndResponseTransmission)
+            .map(|c| c.get())
+            .unwrap_or(0),
+    );
+    assert_eq!(
+        test.canister_state(caller_id).system_state.balance(),
+        initial_cycles
+            - test.canister_execution_cost(caller_id).real()
+            - transmission_cost
+            - cycles_to_burn
+    );
+
+    let burned_cycles = *use_cases.get(&CyclesUseCase::BurnedCycles).unwrap();
+    assert_eq!(burned_cycles, NominalCycles::new(cycles_to_burn.get()));
+}
+
+#[test]
+fn cleanup_callback_can_burn_cycles() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let initial_cycles = Cycles::new(1_000_000_000_000);
+    let caller_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+    let callee_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+    let cycles_to_burn = Cycles::new(10_000_000_u128);
+
+    // The reply callback traps, triggering the cleanup callback.
+    // The ingress fails because the reply callback trapped.
+    test.ingress(
+        caller_id,
+        "update",
+        wasm()
+            .inter_update(
+                callee_id,
+                call_args()
+                    .other_side(wasm().reply())
+                    .on_reply(wasm().trap())
+                    .on_cleanup(wasm().cycles_burn128(cycles_to_burn)),
+            )
+            .build(),
+    )
+    .unwrap_err();
+
+    let use_cases = test
+        .canister_state(caller_id)
+        .system_state
+        .canister_metrics()
+        .consumed_cycles_by_use_cases()
+        .clone();
+    let transmission_cost = Cycles::new(
+        use_cases
+            .get(&CyclesUseCase::RequestAndResponseTransmission)
+            .map(|c| c.get())
+            .unwrap_or(0),
+    );
+    assert_eq!(
+        test.canister_state(caller_id).system_state.balance(),
+        initial_cycles
+            - test.canister_execution_cost(caller_id).real()
+            - transmission_cost
+            - cycles_to_burn
+    );
+
+    let burned_cycles = *use_cases.get(&CyclesUseCase::BurnedCycles).unwrap();
+    assert_eq!(burned_cycles, NominalCycles::new(cycles_to_burn.get()));
+}
+
+#[test]
+fn heartbeat_can_burn_cycles() {
+    let mut test = ExecutionTestBuilder::new().build();
+    let initial_cycles = Cycles::new(1_000_000_000_000);
+    let canister_id = test.universal_canister_with_cycles(initial_cycles).unwrap();
+    let cycles_to_burn = Cycles::new(10_000_000_u128);
+
+    test.ingress(
+        canister_id,
+        "update",
+        wasm()
+            .set_heartbeat(wasm().cycles_burn128(cycles_to_burn))
+            .reply()
+            .build(),
+    )
+    .unwrap();
+    test.canister_task(canister_id, CanisterTask::Heartbeat);
+
+    assert_eq!(
+        test.canister_state(canister_id).system_state.balance(),
+        initial_cycles - test.canister_execution_cost(canister_id).real() - cycles_to_burn
+    );
+
+    let burned_cycles = *test
+        .canister_state(canister_id)
+        .system_state
+        .canister_metrics()
+        .consumed_cycles_by_use_cases()
+        .get(&CyclesUseCase::BurnedCycles)
+        .unwrap();
+    assert_eq!(burned_cycles, NominalCycles::new(cycles_to_burn.get()));
 }
 
 #[test]


### PR DESCRIPTION
This PR adds tests for `ic0.cycles_burn128` in `install_code`.