### PR TITLE
fix: Fix some issues in detached LUKS header exchange

### DIFF
--- a/rs/ic_os/guest_upgrade/client/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/client/src/lib.rs
@@ -50,6 +50,9 @@ pub struct DiskEncryptionKeyExchangeClientAgent {
     crypto_ops: Box<dyn DiskCryptoOps>,
 }
 
+// Allow 32MB ingress messages - we need 16MB for the LUKS header
+const MAX_INCOMING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+
 impl DiskEncryptionKeyExchangeClientAgent {
     pub fn new(
         guestos_config: GuestOSConfig,
@@ -297,7 +300,8 @@ impl DiskEncryptionKeyExchangeClientAgent {
             .context("Failed to connect to server")?;
 
         Ok((
-            DiskEncryptionKeyExchangeServiceClient::new(channel),
+            DiskEncryptionKeyExchangeServiceClient::new(channel)
+                .max_decoding_message_size(MAX_INCOMING_MESSAGE_SIZE),
             server_public_key_der,
         ))
     }

--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -239,7 +239,10 @@ pub fn backup_luks_header_to_file(device_path: &Path, header_path: &Path) -> Res
                 temp_header_path.display()
             )
         })?;
-    fs::set_permissions(&temp_header_path, fs::Permissions::from_mode(0o600))
+
+    // We allow every user to read the header. The replica (running as user ic-replica) needs
+    // access to this file so that it can share it during an upgrade.
+    fs::set_permissions(&temp_header_path, fs::Permissions::from_mode(0o644))
         .context("Failed to set permissions on temporary detached LUKS header file")?;
 
     fs::rename(&temp_header_path, header_path)


### PR DESCRIPTION
1) Increase incoming message size to 32MB (we need 16MB for the LUKS header)
2) Set the permission to 644 on the header so that the replica process running as ic-replica user can access it.

Unfortunately, these issues were only caught now by newly added integration tests.