### PR TITLE
fix: fix local NNS Recovery command parsing

### DIFF
--- a/rs/tests/nested/nns_recovery/common.rs
+++ b/rs/tests/nested/nns_recovery/common.rs
@@ -854,7 +854,7 @@ fn local_recovery(node: &IcNodeSnapshot, subnet_recovery: NNSRecoverySameNodes, 
     // Resume the recovery by re-executing the command starting from WaitForCUP. The command should
     // succeed this time.
     let session = node.block_on_ssh_session().unwrap(); // New session after reboot
-    let command = command + r#"--resume WaitForCUP \"#;
+    let command = command + r#"--resume WaitForCUP"#;
     info!(logger, "Resuming local recovery command: \n{command}");
     node.block_on_bash_script_from_session(&session, &command)
         .expect("Local recovery failed to complete");


### PR DESCRIPTION
Interestingly, a run [failed](https://dash.dm1-idx1.dfinity.network/invocation/2889a72a-86dd-4d02-922e-d579cc973a73?target=%2F%2Frs%2Ftests%2Fnested%2Fnns_recovery%3Anr_local&targetStatus=11#1@1937) because it would incorrectly parse `\` as an argument to `ic-recovery` even though the next try [succeeded](https://dash.dm1-idx1.dfinity.network/invocation/2889a72a-86dd-4d02-922e-d579cc973a73?target=%2F%2Frs%2Ftests%2Fnested%2Fnns_recovery%3Anr_local&targetStatus=11#2@1902) with the exact same command syntax.

Below is Claude's opinion, which does not look senseless, so I would give it a shot. The backslash was indeed not really needed anyways and was there mostly for aesthetics with the rest of the lines above. Thanks @Bownairo for the report!

**The bug**
Line 857:
```rust
let command = command + r#"--resume WaitForCUP \"#;
```
That `r#"..."#` literal has no trailing newline — the script you send to bash ends with the two bytes `\` then `EOF`. The first invocation (line 849) doesn't have this problem because it appends `" > /dev/null 2>&1"` after the trailing backslash from the `format!`, so there's real content on the continued line. The resume version puts the trailing `\` at the very end.

**Why it's non-deterministic**
`execute_bash_script_from_session` does (rs/tests/driver/src/driver/test_env_api.rs:1644):

```rust
channel.exec("bash")?;
channel.write_all(script.as_bytes())?;
channel.flush()?;
channel.send_eof()?;
```
The bytes and the EOF marker travel as separate SSH events over the network. On the remote side, bash's lexer reads from stdin and, when it sees `\`, calls the equivalent of "get next char with line-continuation handling":

If the SSH server delivers the final chunk together with the EOF flag (bash's `read()` returns the bytes and then immediately returns 0 on the next call), bash's lexer sees `\<EOF>` and silently drops the backslash. Command parses cleanly → success.
If the bytes arrive first and bash's `read()` returns `... WaitForCUP \` without having seen EOF yet, the lexer can't tell whether more input is coming. Depending on word state, it terminates the current word — emitting a literal `\` as a token — and only later sees EOF. The `\` ends up as a positional argument to ic-recovery. Clap then reports `unexpected argument '\' found`.
Which path you hit depends on TCP segmentation, SSH framing, and how `write_all` + `flush` + `send_eof` are scheduled — i.e., timing. So the same source code, the same logical command, two different outcomes across runs. The successful run isn't proving the code is correct; it just happened to land on the "both bytes and EOF in one read" path.

Fix
Drop the trailing backslash — there's nothing after it to continue to:

```rust
let command = command + "--resume WaitForCUP";
```
or, if you want to preserve the visual style, terminate the line cleanly:

```rust
let command = command + "--resume WaitForCUP\n";
```
Either makes the script well-formed and the behavior deterministic.


