### PR TITLE
fix: revert "fix: Fix some issues in detached LUKS header exchange (#10179)"

### DIFF
--- a/rs/ic_os/guest_upgrade/client/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/client/src/lib.rs
@@ -50,9 +50,6 @@ pub struct DiskEncryptionKeyExchangeClientAgent {
     crypto_ops: Box<dyn DiskCryptoOps>,
 }
 
-// Allow 32MB ingress messages - we need 16MB for the LUKS header
-const MAX_INCOMING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
-
 impl DiskEncryptionKeyExchangeClientAgent {
     pub fn new(
         guestos_config: GuestOSConfig,
@@ -300,8 +297,7 @@ impl DiskEncryptionKeyExchangeClientAgent {
             .context("Failed to connect to server")?;
 
         Ok((
-            DiskEncryptionKeyExchangeServiceClient::new(channel)
-                .max_decoding_message_size(MAX_INCOMING_MESSAGE_SIZE),
+            DiskEncryptionKeyExchangeServiceClient::new(channel),
             server_public_key_der,
         ))
     }

--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -251,10 +251,7 @@ pub fn backup_luks_header_to_file(device_path: &Path, header_path: &Path) -> Res
                 temp_header_path.display()
             )
         })?;
-
-    // We allow every user to read the header. The replica (running as user ic-replica) needs
-    // access to this file so that it can share it during an upgrade.
-    fs::set_permissions(&temp_header_path, fs::Permissions::from_mode(0o644))
+    fs::set_permissions(&temp_header_path, fs::Permissions::from_mode(0o600))
         .context("Failed to set permissions on temporary detached LUKS header file")?;
 
     fs::rename(&temp_header_path, header_path)


### PR DESCRIPTION
This reverts commit cdaafdd9455a4b608fbbec11b32e5da05b007dc4 since it breaks the `//rs/tests/node:root_tests`.