### PR TITLE
feat(ic-recovery): allow upgrading without blessing + make some steps non-optional

### DIFF
--- a/rs/recovery/src/app_subnet_recovery.rs
+++ b/rs/recovery/src/app_subnet_recovery.rs
@@ -1,7 +1,7 @@
 use crate::{
     DataLocation, NeuronArgs, Recovery, RecoveryArgs, RecoveryResult, Step,
     cli::{
-        consent_given, print_height_info, read, read_optional, read_optional_data_location,
+        consent_given, print_height_info, read, read_data_location, read_optional,
         read_optional_node_ids, read_optional_subnet_id, read_optional_type, wait_for_confirmation,
     },
     error::{GracefulExpect, RecoveryError},
@@ -324,16 +324,16 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                     );
 
                     self.params.download_pool_node =
-                        read_optional(&self.logger, "Enter consensus pool download IP:");
+                        Some(read(&self.logger, "Enter consensus pool download IP:"));
                 }
             }
 
             StepType::DownloadState => {
                 if self.params.download_state_method.is_none() {
-                    self.params.download_state_method = read_optional_data_location(
+                    self.params.download_state_method = Some(read_data_location(
                         &self.logger,
                         "Enter location of the subnet state to be recovered [local/<ipv6>]:",
-                    );
+                    ));
                 }
 
                 if self.params.keep_downloaded_state.is_none()
@@ -400,10 +400,10 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
 
             StepType::UploadState => {
                 if self.params.upload_method.is_none() {
-                    self.params.upload_method = read_optional_data_location(
+                    self.params.upload_method = Some(read_data_location(
                         &self.logger,
                         "Are you performing a local recovery directly on the node, or a remote recovery? [local/<ipv6>]",
-                    );
+                    ));
                 }
             }
 

--- a/rs/recovery/src/app_subnet_recovery.rs
+++ b/rs/recovery/src/app_subnet_recovery.rs
@@ -363,7 +363,17 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
 
             StepType::BlessVersion => {
                 if self.params.upgrade_version.is_none() {
-                    self.params.upgrade_version = read_optional(&self.logger, "Upgrade version: ");
+                    self.params.upgrade_version =
+                        read_optional(&self.logger, "Version to bless (and upgrade to): ");
+                }
+            }
+
+            StepType::UpgradeVersion => {
+                if self.params.upgrade_version.is_none() {
+                    self.params.upgrade_version = read_optional(
+                        &self.logger,
+                        "Version to upgrade to (WARN: it should already be blessed): ",
+                    );
                 }
             }
 

--- a/rs/recovery/src/cli.rs
+++ b/rs/recovery/src/cli.rs
@@ -314,6 +314,10 @@ where
     read_type(logger, prompt, FromStr::from_str)
 }
 
+pub fn read_data_location(logger: &Logger, prompt: &str) -> DataLocation {
+    read_type(logger, prompt, data_location_from_str)
+}
+
 /// Read an input of the generic type by applying the given deserialization function.
 fn read_type<T, E: Display>(
     logger: &Logger,

--- a/rs/recovery/src/nns_recovery_same_nodes.rs
+++ b/rs/recovery/src/nns_recovery_same_nodes.rs
@@ -1,6 +1,6 @@
 use crate::{
     RecoveryArgs, RecoveryResult,
-    cli::{consent_given, print_height_info, read_optional, read_optional_data_location},
+    cli::{consent_given, print_height_info, read, read_data_location, read_optional},
     error::{GracefulExpect, RecoveryError},
     recovery_iterator::RecoveryIterator,
     registry_helper::RegistryPollingStrategy,
@@ -246,10 +246,10 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoverySameNodes {
         match step_type {
             StepType::StopReplica | StepType::DownloadState | StepType::UploadState => {
                 if self.params.admin_access_location.is_none() {
-                    self.params.admin_access_location = read_optional_data_location(
+                    self.params.admin_access_location = Some(read_data_location(
                         &self.logger,
                         "Enter state download/upload location (admin access required) [local/<ipv6>]:",
-                    );
+                    ));
                 }
             }
             _ => {}
@@ -265,10 +265,10 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoverySameNodes {
                         self.params.subnet_id,
                     );
 
-                    self.params.download_pool_node = read_optional(
+                    self.params.download_pool_node = Some(read(
                         &self.logger,
                         "Enter consensus pool download IP (backup access required):",
-                    );
+                    ));
                 }
             }
 


### PR DESCRIPTION
This PR makes the following changes to `ic-recovery`:
- Allow to upgrade to a version without first blessing/electing it in case we want to do a simple rollback. This was possible by supplying `--skip BlessVersion` but the tool now asks for the upgrade question again during `UpgradeVersion` if not supplied in `BlessVersion`. If it was actually supplied in the latter, then it re-uses it during `UpgradeVersion` (unchanged).
- Makes `DownloadConsensusPool`, `DownloadState` and `UploadState` non-optional by asking for the input over and over again if not supplied/invalid. Note that it is still possible to hard skip them with `--skip ...`.
  - `DownloadState` and `UploadState` could be optional if we know for sure that there no blocks that were executed after a checkpoint (like at an upgrade height, for example if there is a bug in the orchestrator). Though this is relatively rare compared to bugs in the replica + I would argue that we could probably still want to download it to manually inspect it.
  - `DownloadConsensusPool` could also be optional if we have not downloaded any state. But if we did, even if no blocks are replayed, we still need it for the CUP, which validates the downloaded state.