### PR TITLE
chore: inline boundary node bazel crate dependencies

### DIFF
--- a/rs/boundary_node/ic_boundary/BUILD.bazel
+++ b/rs/boundary_node/ic_boundary/BUILD.bazel
@@ -2,8 +2,6 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
-VERSION = "0.1.0"
-
 rust_binary(
     name = "ic-boundary",
     srcs = glob(
@@ -15,7 +13,7 @@ rust_binary(
         "@crate_index//:async-trait",
         "@crate_index//:derive-new",
     ],
-    version = VERSION,
+    version = "0.1.0",
     deps = [
         # Keep sorted.
         "//packages/ic-ed25519",
@@ -205,7 +203,7 @@ rust_library(
         "@crate_index//:derive-new",
         "@crate_index//:indoc",
     ],
-    version = VERSION,
+    version = "0.1.0",
     deps = [
         # Keep sorted.
         "//packages/ic-ed25519",

--- a/rs/boundary_node/rate_limits/integration_tests/BUILD.bazel
+++ b/rs/boundary_node/rate_limits/integration_tests/BUILD.bazel
@@ -37,10 +37,10 @@ rust_test_suite(
         ["tests/**/*.rs"],
     ),
     data = [
-        "@mainnet_canisters//:registry.wasm.gz",
-        "//rs/registry/canister:registry-canister",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "//rs/boundary_node/rate_limits:rate_limit_canister",
+        "//rs/pocket_ic_server:pocket-ic-server",
+        "//rs/registry/canister:registry-canister",
+        "@mainnet_canisters//:registry.wasm.gz",
     ],
     env = {
         "CARGO_MANIFEST_DIR": "rs/nns/integration_tests",

--- a/rs/boundary_node/rate_limits/integration_tests/BUILD.bazel
+++ b/rs/boundary_node/rate_limits/integration_tests/BUILD.bazel
@@ -2,21 +2,6 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
-DEV_DATA = [
-    "@mainnet_canisters//:registry.wasm.gz",
-    "//rs/registry/canister:registry-canister",
-    "//rs/pocket_ic_server:pocket-ic-server",
-    "//rs/boundary_node/rate_limits:rate_limit_canister",
-]
-
-DEV_ENV = {
-    "CARGO_MANIFEST_DIR": "rs/nns/integration_tests",
-    "REGISTRY_CANISTER_WASM_PATH": "$(rootpath //rs/registry/canister:registry-canister)",
-    "MAINNET_REGISTRY_CANISTER_WASM_PATH": "$(rootpath @mainnet_canisters//:registry.wasm.gz)",
-    "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
-    "RATE_LIMITS_CANISTER_WASM_PATH": "$(rootpath //rs/boundary_node/rate_limits:rate_limit_canister)",
-}
-
 rust_library(
     name = "rate_limit_canister_integration_tests",
     testonly = True,
@@ -51,8 +36,19 @@ rust_test_suite(
     srcs = glob(
         ["tests/**/*.rs"],
     ),
-    data = DEV_DATA,
-    env = DEV_ENV,
+    data = [
+        "@mainnet_canisters//:registry.wasm.gz",
+        "//rs/registry/canister:registry-canister",
+        "//rs/pocket_ic_server:pocket-ic-server",
+        "//rs/boundary_node/rate_limits:rate_limit_canister",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": "rs/nns/integration_tests",
+        "REGISTRY_CANISTER_WASM_PATH": "$(rootpath //rs/registry/canister:registry-canister)",
+        "MAINNET_REGISTRY_CANISTER_WASM_PATH": "$(rootpath @mainnet_canisters//:registry.wasm.gz)",
+        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
+        "RATE_LIMITS_CANISTER_WASM_PATH": "$(rootpath //rs/boundary_node/rate_limits:rate_limit_canister)",
+    },
     deps = [
         ":rate_limit_canister_integration_tests",
         # Keep sorted.

--- a/rs/boundary_node/salt_sharing/integration_tests/BUILD.bazel
+++ b/rs/boundary_node/salt_sharing/integration_tests/BUILD.bazel
@@ -40,10 +40,10 @@ rust_test_suite(
         ["tests/**/*.rs"],
     ),
     data = [
-        "@mainnet_canisters//:registry.wasm.gz",
-        "//rs/registry/canister:registry-canister",
-        "//rs/pocket_ic_server:pocket-ic-server",
         "//rs/boundary_node/salt_sharing:salt_sharing_canister",
+        "//rs/pocket_ic_server:pocket-ic-server",
+        "//rs/registry/canister:registry-canister",
+        "@mainnet_canisters//:registry.wasm.gz",
     ],
     env = {
         "CARGO_MANIFEST_DIR": "rs/nns/integration_tests",

--- a/rs/boundary_node/salt_sharing/integration_tests/BUILD.bazel
+++ b/rs/boundary_node/salt_sharing/integration_tests/BUILD.bazel
@@ -2,21 +2,6 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
-DEV_DATA = [
-    "@mainnet_canisters//:registry.wasm.gz",
-    "//rs/registry/canister:registry-canister",
-    "//rs/pocket_ic_server:pocket-ic-server",
-    "//rs/boundary_node/salt_sharing:salt_sharing_canister",
-]
-
-DEV_ENV = {
-    "CARGO_MANIFEST_DIR": "rs/nns/integration_tests",
-    "REGISTRY_CANISTER_WASM_PATH": "$(rootpath //rs/registry/canister:registry-canister)",
-    "MAINNET_REGISTRY_CANISTER_WASM_PATH": "$(rootpath @mainnet_canisters//:registry.wasm.gz)",
-    "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
-    "SALT_SHARING_CANISTER_WASM_PATH": "$(rootpath //rs/boundary_node/salt_sharing:salt_sharing_canister)",
-}
-
 rust_library(
     name = "salt_sharing_canister_integration_tests",
     testonly = True,
@@ -54,8 +39,19 @@ rust_test_suite(
     srcs = glob(
         ["tests/**/*.rs"],
     ),
-    data = DEV_DATA,
-    env = DEV_ENV,
+    data = [
+        "@mainnet_canisters//:registry.wasm.gz",
+        "//rs/registry/canister:registry-canister",
+        "//rs/pocket_ic_server:pocket-ic-server",
+        "//rs/boundary_node/salt_sharing:salt_sharing_canister",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": "rs/nns/integration_tests",
+        "REGISTRY_CANISTER_WASM_PATH": "$(rootpath //rs/registry/canister:registry-canister)",
+        "MAINNET_REGISTRY_CANISTER_WASM_PATH": "$(rootpath @mainnet_canisters//:registry.wasm.gz)",
+        "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server)",
+        "SALT_SHARING_CANISTER_WASM_PATH": "$(rootpath //rs/boundary_node/salt_sharing:salt_sharing_canister)",
+    },
     deps = [
         # Keep sorted.
         ":salt_sharing_canister_integration_tests",


### PR DESCRIPTION
This inlines dependencies in BUILD.bazel files. This helps readability and allows for automatic duplicate & unused dependency pruning. This aligns those packages with the rest of the codebase.