### PR TITLE
fix: update lockfiles

### DIFF
--- a/Cargo.Bazel.json.lock
+++ b/Cargo.Bazel.json.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "2d3dc07f101e9aab9fa001ab446b1b2cb2deb304fc03320dc5c5d7e39bd68b2c",
+  "checksum": "9ea5770d986baa66aa3da4ec83e884235aed25447ea910f677cbed62229ef697",
   "crates": {
     "abnf 0.12.0": {
       "name": "abnf",
@@ -30303,7 +30303,13 @@
             "custom",
             "std"
           ],
-          "selects": {}
+          "selects": {
+            "wasm32-unknown-unknown": [
+              "js",
+              "js-sys",
+              "wasm-bindgen"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -30323,6 +30329,16 @@
               {
                 "id": "libc 0.2.177",
                 "target": "libc"
+              }
+            ],
+            "wasm32-unknown-unknown": [
+              {
+                "id": "js-sys 0.3.77",
+                "target": "js_sys"
+              },
+              {
+                "id": "wasm-bindgen 0.2.100",
+                "target": "wasm_bindgen"
               }
             ]
           }

--- a/Cargo.Bazel.toml.lock
+++ b/Cargo.Bazel.toml.lock
@@ -5217,8 +5217,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]


### PR DESCRIPTION
The lockfiles were out of date. This is the result of running `./bin/bazel-pin.sh`.