### PR TITLE
chore: use PerformanceOptimizedAllocation for all performance tests

### DIFF
--- a/rs/tests/boundary_nodes/api_bn_performance_test.rs
+++ b/rs/tests/boundary_nodes/api_bn_performance_test.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use ic_boundary_nodes_performance_test_common::{query_calls_test, setup, update_calls_test};
+use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::{driver::group::SystemTestGroup, systest};
 use std::time::Duration;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(update_calls_test))
         .add_test(systest!(query_calls_test))

--- a/rs/tests/boundary_nodes/api_bn_update_workload_test.rs
+++ b/rs/tests/boundary_nodes/api_bn_update_workload_test.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use ic_system_test_driver::driver::farm::HostFeature;
+use ic_system_test_driver::driver::farm::{HostFeature, VmAllocationMode};
 use std::time::Duration;
 
 use ic_networking_subnet_update_workload::{setup, test};
@@ -30,6 +30,7 @@ fn main() -> Result<()> {
         )
     };
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test))
         .with_timeout_per_test(per_task_timeout) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/consensus/consensus_performance.rs
+++ b/rs/tests/consensus/consensus_performance.rs
@@ -65,7 +65,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::get_ic_build_version;
 use ic_system_test_driver::driver::{
-    farm::HostFeature,
+    farm::{HostFeature, VmAllocationMode},
     ic::{
         AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet, VmResourceOverrides,
     },
@@ -219,6 +219,7 @@ fn main() -> Result<()> {
         // Since we setup VMs in sequence it takes more than the default timeout
         // of 10 minutes to setup this large testnet so let's increase the timeout:
         .with_timeout_per_test(Duration::from_secs(60 * 30))
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test; TestParameters { message_size: 1, rps: 1.0 }))
         .add_test(systest!(test; TestParameters { message_size: 9_500, rps: 1_000.0 }))

--- a/rs/tests/consensus/nidkg_performance_test.rs
+++ b/rs/tests/consensus/nidkg_performance_test.rs
@@ -8,7 +8,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::HasPublicApiUrl;
 use ic_system_test_driver::driver::{
-    farm::HostFeature,
+    farm::{HostFeature, VmAllocationMode},
     ic::{AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet},
     simulate_network::{FixedNetworkSimulation, SimulateNetwork},
     test_env::TestEnv,
@@ -226,6 +226,7 @@ fn test(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .with_timeout_per_test(Duration::from_secs(15 * 60))
         .add_test(systest!(test))

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -68,7 +68,7 @@ use ic_system_test_driver::canister_requests;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::HasPublicApiUrl;
 use ic_system_test_driver::driver::{
-    farm::HostFeature,
+    farm::{HostFeature, VmAllocationMode},
     ic::{
         AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet, VmResourceOverrides,
     },
@@ -490,6 +490,7 @@ fn main() -> Result<()> {
         // Since we setup VMs in sequence it takes more than the default timeout
         // of 10 minutes to setup this large testnet so let's increase the timeout:
         .with_timeout_per_test(Duration::from_secs(60 * 30))
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test))
         .execute_from_args()?;

--- a/rs/tests/driver/src/driver/farm.rs
+++ b/rs/tests/driver/src/driver/farm.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::driver::ic::{AmountOfMemoryKiB, ImageSizeGiB, NrOfVCPUs, VmAllocationStrategy};
+use crate::driver::ic::{AmountOfMemoryKiB, ImageSizeGiB, NrOfVCPUs};
 use crate::driver::log_events;
 use crate::driver::test_env::TestEnv;
 use crate::driver::test_env::{RequiredHostFeaturesFromCmdLine, TestEnvAttribute};
@@ -420,9 +420,19 @@ struct CreateGroupRequest {
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Deserialize, Serialize)]
+pub enum VmAllocationMode {
+    #[serde(rename = "minIntraDistanceLoadBalanceAllocation")]
+    MinIntraDistanceLoadBalanceAllocation,
+    #[serde(rename = "performanceOptimizedAllocation")]
+    PerformanceOptimizedAllocation,
+    #[serde(rename = "distributeAcrossDcs")]
+    DistributeAcrossDcs,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Deserialize, Serialize)]
 pub struct GroupSpec {
-    #[serde(rename = "vmAllocation")]
-    pub vm_allocation: Option<VmAllocationStrategy>,
+    #[serde(rename = "vmAllocationMode")]
+    pub vm_allocation_mode: Option<VmAllocationMode>,
     #[serde(rename = "requiredHostFeatures")]
     pub required_host_features: Vec<HostFeature>,
     #[serde(rename = "preferredNetwork")]
@@ -578,8 +588,8 @@ pub struct CreateVmRequest {
     pub primary_image_minimal_size_gibibytes: Option<ImageSizeGiB>,
     #[serde(rename = "hasIPv4")]
     pub has_ipv4: bool,
-    #[serde(rename = "vmAllocation")]
-    pub vm_allocation: Option<VmAllocationStrategy>,
+    #[serde(rename = "vmAllocationMode")]
+    pub vm_allocation_mode: Option<VmAllocationMode>,
     #[serde(rename = "requiredHostFeatures")]
     pub required_host_features: Vec<HostFeature>,
 }
@@ -594,7 +604,7 @@ impl CreateVmRequest {
         primary_image: ImageLocation,
         primary_image_minimal_size_gibibytes: Option<ImageSizeGiB>,
         has_ipv4: bool,
-        vm_allocation: Option<VmAllocationStrategy>,
+        vm_allocation_mode: Option<VmAllocationMode>,
         required_host_features: Vec<HostFeature>,
     ) -> Self {
         Self {
@@ -606,7 +616,7 @@ impl CreateVmRequest {
             primary_image,
             primary_image_minimal_size_gibibytes,
             has_ipv4,
-            vm_allocation,
+            vm_allocation_mode,
             required_host_features,
         }
     }

--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -4,7 +4,7 @@ use crate::driver::{
     context::{GroupContext, ProcessContext},
     dsl::{SubprocessFn, TestFunction},
     event::TaskId,
-    farm::{Farm, HostFeature},
+    farm::{Farm, HostFeature, VmAllocationMode},
     plan::{EvalOrder, Plan},
     report::Outcome,
     task::{DebugKeepaliveTask, EmptyTask},
@@ -648,6 +648,7 @@ impl SystemTestSubGroup {
 }
 
 pub struct SystemTestGroup {
+    vm_allocation_mode: Option<VmAllocationMode>,
     setup: Option<Box<dyn PotSetupFn>>,
     teardowns: Vec<Box<dyn PotSetupFn>>,
     tests: Vec<SystemTestSubGroup>,
@@ -692,6 +693,7 @@ impl TestEnvAttribute for CliArguments {
 impl SystemTestGroup {
     pub fn new() -> Self {
         Self {
+            vm_allocation_mode: Default::default(),
             setup: Default::default(),
             teardowns: Default::default(),
             tests: Default::default(),
@@ -741,6 +743,11 @@ impl SystemTestGroup {
 
     pub fn with_overall_timeout(mut self, overall_timeout: Duration) -> Self {
         self.overall_timeout = Some(overall_timeout);
+        self
+    }
+
+    pub fn with_vm_allocation_mode(mut self, mode: VmAllocationMode) -> Self {
+        self.vm_allocation_mode = Some(mode);
         self
     }
 

--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -1303,7 +1303,11 @@ impl SystemTestGroup {
             }
             InfraProvider::Farm.write_attribute(&root_env);
             if with_farm {
-                root_env.create_group_setup(group_ctx.group_base_name.clone(), args.no_group_ttl);
+                root_env.create_group_setup(
+                    group_ctx.group_base_name.clone(),
+                    self.vm_allocation_mode.clone(),
+                    args.no_group_ttl,
+                );
             }
             debug!(group_ctx.log(), "Created group context: {:?}", group_ctx);
         }

--- a/rs/tests/driver/src/driver/ic.rs
+++ b/rs/tests/driver/src/driver/ic.rs
@@ -41,7 +41,6 @@ use std::time::Duration;
 pub struct InternetComputer {
     pub initial_version: Option<NodeSoftwareVersion>,
     pub vm_resource_overrides: VmResourceOverrides,
-    pub vm_allocation: Option<VmAllocationStrategy>,
     pub required_host_features: Vec<HostFeature>,
     pub subnets: Vec<Subnet>,
     pub node_operator: Option<PrincipalId>,
@@ -72,16 +71,6 @@ pub struct NodeOperatorConfig {
     pub rewardable_nodes: BTreeMap<String, u32>,
 }
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Deserialize, Serialize)]
-pub enum VmAllocationStrategy {
-    #[serde(rename = "distributeToArbitraryHost")]
-    DistributeToArbitraryHost,
-    #[serde(rename = "distributeWithinSingleHost")]
-    DistributeWithinSingleHost,
-    #[serde(rename = "distributeAcrossDcs")]
-    DistributeAcrossDcs,
-}
-
 impl InternetComputer {
     pub fn new() -> Self {
         Self::default()
@@ -92,11 +81,6 @@ impl InternetComputer {
     /// Node > Subnet > IC > Group > Default
     pub fn with_resource_overrides(mut self, vm_resource_overrides: VmResourceOverrides) -> Self {
         self.vm_resource_overrides = vm_resource_overrides;
-        self
-    }
-
-    pub fn with_vm_allocation(mut self, vm_allocation: VmAllocationStrategy) -> Self {
-        self.vm_allocation = Some(vm_allocation);
         self
     }
 
@@ -116,7 +100,6 @@ impl InternetComputer {
     /// on the node is reduced.
     pub fn add_fast_single_node_subnet(mut self, subnet_type: SubnetType) -> Self {
         let mut subnet = Subnet::fast_single_node(subnet_type);
-        subnet.vm_allocation.clone_from(&self.vm_allocation);
         subnet
             .required_host_features
             .clone_from(&self.required_host_features);
@@ -164,7 +147,6 @@ impl InternetComputer {
         for _ in 0..no_of_nodes {
             self.unassigned_nodes.push(
                 Node::new()
-                    .with_vm_allocation(self.vm_allocation.clone())
                     .with_boot_image(BootImage::GroupDefault)
                     .with_required_host_features(self.required_host_features.clone()),
             );
@@ -184,7 +166,6 @@ impl InternetComputer {
         for idx in 0..no_of_nodes {
             self.api_boundary_nodes.push(
                 Node::new()
-                    .with_vm_allocation(self.vm_allocation.clone())
                     .with_boot_image(BootImage::GroupDefault)
                     .with_required_host_features(self.required_host_features.clone())
                     .with_domain(format!("apibn-{idx}.ic.net")),
@@ -202,7 +183,6 @@ impl InternetComputer {
         for _ in 0..no_of_nodes {
             self.api_boundary_nodes.push(
                 Node::new()
-                    .with_vm_allocation(self.vm_allocation.clone())
                     .with_boot_image(BootImage::GroupDefault)
                     .with_required_host_features(self.required_host_features.clone()),
             );
@@ -220,7 +200,6 @@ impl InternetComputer {
     pub fn with_ipv4_enabled_unassigned_node(mut self, ipv4_config: IPv4Config) -> Self {
         self.unassigned_nodes.push(
             Node::new()
-                .with_vm_allocation(self.vm_allocation.clone())
                 .with_boot_image(BootImage::GroupDefault)
                 .with_required_host_features(self.required_host_features.clone())
                 .with_ipv4_config(ipv4_config),
@@ -571,7 +550,6 @@ impl InternetComputer {
 #[derive(Clone, PartialEq, Debug, Deserialize)]
 pub struct Subnet {
     pub vm_resource_overrides: VmResourceOverrides,
-    pub vm_allocation: Option<VmAllocationStrategy>,
     pub boot_image: BootImage,
     pub required_host_features: Vec<HostFeature>,
     pub default_node_reward_type: Option<NodeRewardType>,
@@ -620,7 +598,6 @@ impl Subnet {
         };
         Self {
             vm_resource_overrides: Default::default(),
-            vm_allocation: Default::default(),
             boot_image: Default::default(),
             required_host_features: vec![],
             default_node_reward_type,
@@ -655,11 +632,6 @@ impl Subnet {
     /// Node > Subnet > IC > Group > Default
     pub fn with_resource_overrides(mut self, vm_resource_overrides: VmResourceOverrides) -> Self {
         self.vm_resource_overrides = vm_resource_overrides;
-        self
-    }
-
-    pub fn with_vm_allocation(mut self, vm_allocation: VmAllocationStrategy) -> Self {
-        self.vm_allocation = Some(vm_allocation);
         self
     }
 
@@ -734,12 +706,10 @@ impl Subnet {
     /// Add the given number of nodes to the subnet.
     pub fn add_nodes(self, no_of_nodes: usize) -> Self {
         (0..no_of_nodes).fold(self, |subnet, _| {
-            let vm_allocation = subnet.vm_allocation.clone();
             let boot_image = subnet.boot_image.clone();
             let required_host_features = subnet.required_host_features.clone();
             subnet.add_node(
                 Node::new()
-                    .with_vm_allocation(vm_allocation)
                     .with_boot_image(boot_image)
                     .with_required_host_features(required_host_features),
             )
@@ -764,13 +734,11 @@ impl Subnet {
         self,
         mut required_host_features: Vec<HostFeature>,
     ) -> Self {
-        let vm_allocation = self.vm_allocation.clone();
         let boot_image = self.boot_image.clone();
         required_host_features.extend_from_slice(&self.required_host_features);
 
         self.add_node(
             Node::new()
-                .with_vm_allocation(vm_allocation)
                 .with_boot_image(boot_image)
                 .with_required_host_features(required_host_features),
         )
@@ -858,12 +826,10 @@ impl Subnet {
         malicious_behavior: MaliciousBehavior,
     ) -> Self {
         (0..no_of_nodes).fold(self, |subnet, _| {
-            let vm_allocation = subnet.vm_allocation.clone();
             let boot_image = subnet.boot_image.clone();
             let required_host_features = subnet.required_host_features.clone();
             subnet.add_node(
                 Node::new()
-                    .with_vm_allocation(vm_allocation)
                     .with_boot_image(boot_image)
                     .with_required_host_features(required_host_features)
                     .with_malicious_behavior(malicious_behavior.clone()),
@@ -872,12 +838,10 @@ impl Subnet {
     }
 
     pub fn add_node_with_ipv4(self, ipv4_config: IPv4Config) -> Self {
-        let vm_allocation = self.vm_allocation.clone();
         let boot_image = self.boot_image.clone();
         let required_host_features = self.required_host_features.clone();
         self.add_node(
             Node::new()
-                .with_vm_allocation(vm_allocation)
                 .with_boot_image(boot_image)
                 .with_required_host_features(required_host_features)
                 .with_ipv4_config(ipv4_config),
@@ -899,7 +863,6 @@ impl Default for Subnet {
     fn default() -> Self {
         Self {
             vm_resource_overrides: Default::default(),
-            vm_allocation: Default::default(),
             boot_image: BootImage::GroupDefault,
             required_host_features: vec![],
             default_node_reward_type: None,
@@ -995,7 +958,6 @@ impl VmResourceOverrides {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Deserialize)]
 pub struct Node {
     pub vm_resource_overrides: VmResourceOverrides,
-    pub vm_allocation: Option<VmAllocationStrategy>,
     pub required_host_features: Vec<HostFeature>,
     pub secret_key_store: Option<NodeSecretKeyStore>,
     pub ipv6: Option<Ipv6Addr>,
@@ -1025,11 +987,6 @@ impl Node {
     /// Node > Subnet > IC > Group > Default
     pub fn with_resource_overrides(mut self, vm_resource_overrides: VmResourceOverrides) -> Self {
         self.vm_resource_overrides = vm_resource_overrides;
-        self
-    }
-
-    pub fn with_vm_allocation(mut self, vm_allocation: Option<VmAllocationStrategy>) -> Self {
-        self.vm_allocation = vm_allocation;
         self
     }
 

--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -19,7 +19,7 @@ use ic_registry_local_registry::LocalRegistry;
 use crate::driver::{
     constants::SSH_USERNAME,
     farm::{DnsRecord, DnsRecordType, HostFeature},
-    ic::{AmountOfMemoryKiB, ImageSizeGiB, NrOfVCPUs, VmAllocationStrategy, VmResourceOverrides},
+    ic::{AmountOfMemoryKiB, ImageSizeGiB, NrOfVCPUs, VmResourceOverrides},
     ic_gateway_vm::{HasIcGatewayVm, Playnet},
     log_events,
     nested::HasNestedVms,
@@ -151,11 +151,6 @@ impl PrometheusVm {
         self.universal_vm = self
             .universal_vm
             .with_resource_overrides(vm_resource_overrides);
-        self
-    }
-
-    pub fn with_vm_allocation(mut self, vm_allocation: VmAllocationStrategy) -> Self {
-        self.universal_vm = self.universal_vm.with_vm_allocation(vm_allocation);
         self
     }
 

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -3,11 +3,12 @@ use crate::driver::farm::FileId;
 use crate::driver::farm::ImageLocation;
 use crate::driver::farm::ImageLocation::{IcOsImageViaUrl, ImageViaUrl};
 use crate::driver::farm::VMCreateResponse;
+use crate::driver::farm::VmAllocationMode;
 use crate::driver::farm::{CreateVmRequest, HostFeature};
 use crate::driver::farm::{Farm, VmType};
 use crate::driver::ic::VmResources;
 use crate::driver::ic::{AmountOfMemoryKiB, InternetComputer, Node, NrOfVCPUs};
-use crate::driver::ic::{ImageSizeGiB, VmAllocationStrategy, VmResourceOverrides};
+use crate::driver::ic::{ImageSizeGiB, VmResourceOverrides};
 use crate::driver::nested::{NestedNode, NestedNodeSpec};
 use crate::driver::test_env::{TestEnv, TestEnvAttribute};
 use crate::driver::test_env_api::{
@@ -115,7 +116,7 @@ pub struct VmSpec {
     boot_image: BootImage,
     boot_image_minimal_size_gibibytes: Option<ImageSizeGiB>,
     has_ipv4: bool,
-    vm_allocation: Option<VmAllocationStrategy>,
+    vm_allocation_mode: Option<VmAllocationMode>,
     required_host_features: Vec<HostFeature>,
     alternate_template: Option<VmType>,
 }
@@ -274,7 +275,7 @@ pub fn get_resource_request_for_universal_vm(
         boot_image: BootImage::GroupDefault,
         boot_image_minimal_size_gibibytes: resolved_vm_resources.boot_image_minimal_size_gibibytes,
         has_ipv4: universal_vm.has_ipv4,
-        vm_allocation: universal_vm.vm_allocation.clone(),
+        vm_allocation_mode: None,
         required_host_features: universal_vm.required_host_features.clone(),
         alternate_template: None,
     });
@@ -308,7 +309,7 @@ pub fn allocate_resources(
             },
             vm_config.boot_image_minimal_size_gibibytes,
             vm_config.has_ipv4,
-            vm_config.vm_allocation.clone(),
+            None,
             vm_config.required_host_features.clone(),
         );
         let group_name = group_name.clone();
@@ -373,7 +374,7 @@ fn vm_spec_from_node(
         boot_image: n.boot_image.clone(),
         boot_image_minimal_size_gibibytes: resolved_vm_resources.boot_image_minimal_size_gibibytes,
         has_ipv4: false,
-        vm_allocation: n.vm_allocation.clone(),
+        vm_allocation_mode: None,
         required_host_features: n.required_host_features.clone(),
         alternate_template: None,
     }
@@ -408,7 +409,7 @@ fn vm_spec_from_nested_node(
         boot_image: node.boot_image.clone(),
         boot_image_minimal_size_gibibytes: resolved_vm_resources.boot_image_minimal_size_gibibytes,
         has_ipv4: false,
-        vm_allocation: None,
+        vm_allocation_mode: None,
         required_host_features,
         alternate_template: None,
     })

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -140,7 +140,7 @@ use super::{
 use crate::{
     driver::{
         constants::{self, GROUP_TTL, SSH_USERNAME},
-        farm::{Farm, GroupSpec},
+        farm::{Farm, GroupSpec, VmAllocationMode},
         log_events,
         test_env::{HasIcPrepDir, SshKeyGen, TestEnv, TestEnvAttribute},
     },
@@ -1482,11 +1482,21 @@ pub fn get_build_setupos_config_image_tool() -> PathBuf {
 }
 
 pub trait HasGroupSetup {
-    fn create_group_setup(&self, group_base_name: String, no_group_ttl: bool);
+    fn create_group_setup(
+        &self,
+        group_base_name: String,
+        vm_allocation_mode: Option<VmAllocationMode>,
+        no_group_ttl: bool,
+    );
 }
 
 impl HasGroupSetup for TestEnv {
-    fn create_group_setup(&self, group_base_name: String, no_group_ttl: bool) {
+    fn create_group_setup(
+        &self,
+        group_base_name: String,
+        vm_allocation_mode: Option<VmAllocationMode>,
+        no_group_ttl: bool,
+    ) {
         let log = self.logger();
         if GroupSetup::attribute_exists(self) {
             let group_setup = GroupSetup::read_attribute(self);
@@ -1504,7 +1514,7 @@ impl HasGroupSetup for TestEnv {
                     let farm_base_url = FarmBaseUrl::read_attribute(self);
                     let farm = Farm::new(farm_base_url.into(), self.logger());
                     let group_spec = GroupSpec {
-                        vm_allocation_mode: None,
+                        vm_allocation_mode,
                         required_host_features: vec![],
                         preferred_network: None,
                         metadata: None,

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -1504,7 +1504,7 @@ impl HasGroupSetup for TestEnv {
                     let farm_base_url = FarmBaseUrl::read_attribute(self);
                     let farm = Farm::new(farm_base_url.into(), self.logger());
                     let group_spec = GroupSpec {
-                        vm_allocation: None,
+                        vm_allocation_mode: None,
                         required_host_features: vec![],
                         preferred_network: None,
                         metadata: None,

--- a/rs/tests/driver/src/driver/universal_vm.rs
+++ b/rs/tests/driver/src/driver/universal_vm.rs
@@ -4,7 +4,6 @@ use crate::driver::farm::ClaimResult;
 use crate::driver::farm::Farm;
 use crate::driver::farm::HostFeature;
 use crate::driver::farm::id_of_file;
-use crate::driver::ic::VmAllocationStrategy;
 use crate::driver::ic::VmResourceOverrides;
 use crate::driver::resource::AllocatedVm;
 use crate::driver::resource::{
@@ -36,7 +35,6 @@ use crate::driver::constants::SSH_USERNAME;
 pub struct UniversalVm {
     pub name: String,
     pub vm_resource_overrides: VmResourceOverrides,
-    pub vm_allocation: Option<VmAllocationStrategy>,
     pub required_host_features: Vec<HostFeature>,
     pub has_ipv4: bool,
     pub primary_image: Option<DiskImage>,
@@ -65,7 +63,6 @@ impl UniversalVm {
         UniversalVm {
             name,
             vm_resource_overrides: Default::default(),
-            vm_allocation: Default::default(),
             required_host_features: Default::default(),
             has_ipv4: false,
             primary_image: Default::default(),
@@ -75,11 +72,6 @@ impl UniversalVm {
 
     pub fn with_resource_overrides(mut self, vm_resource_overrides: VmResourceOverrides) -> Self {
         self.vm_resource_overrides = vm_resource_overrides;
-        self
-    }
-
-    pub fn with_vm_allocation(mut self, vm_allocation: VmAllocationStrategy) -> Self {
-        self.vm_allocation = Some(vm_allocation);
         self
     }
 

--- a/rs/tests/execution/fill_execution_rounds_workload.rs
+++ b/rs/tests/execution/fill_execution_rounds_workload.rs
@@ -14,7 +14,7 @@ use ic_registry_routing_table::CanisterIdRanges;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
-        farm::HostFeature,
+        farm::{HostFeature, VmAllocationMode},
         group::SystemTestGroup,
         ic::{
             AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet,
@@ -79,6 +79,7 @@ fn main() -> Result<()> {
         )
     };
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test))
         .with_timeout_per_test(per_task_timeout) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/message_routing/rejoin_test_long_rounds.rs
+++ b/rs/tests/message_routing/rejoin_test_long_rounds.rs
@@ -20,6 +20,7 @@ end::catalog[] */
 use anyhow::Result;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::farm::HostFeature;
+use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::ic::{
     AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet, VmResourceOverrides,
@@ -46,6 +47,7 @@ fn main() -> Result<()> {
     let config = Config::new(NUM_NODES, NUM_CANISTERS);
     let test = config.clone().test();
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT)

--- a/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::systest;
 use std::time::Duration;
@@ -16,6 +17,7 @@ fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);
     let test = config.clone().test();
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/message_routing/xnet/xnet_slo_29_subnets_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_29_subnets_test.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::systest;
 use std::time::Duration;
@@ -16,6 +17,7 @@ fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);
     let test = config.clone().test();
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/message_routing/xnet/xnet_slo_3_subnets_hotfix_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_3_subnets_hotfix_test.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::systest;
 use std::time::Duration;
@@ -16,6 +17,7 @@ fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);
     let test = config.clone().test();
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/message_routing/xnet/xnet_slo_3_subnets_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_3_subnets_test.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::systest;
 use std::time::Duration;
@@ -16,6 +17,7 @@ fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);
     let test = config.clone().test();
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/networking/canister_http_soak_test.rs
+++ b/rs/tests/networking/canister_http_soak_test.rs
@@ -24,6 +24,7 @@ use canister_test::Canister;
 use dfn_candid::candid_one;
 use ic_cdk::api::call::RejectionCode;
 use ic_management_canister_types_private::{HttpMethod, TransformContext, TransformFunc};
+use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::IcNodeContainer;
 use ic_system_test_driver::driver::{
@@ -42,6 +43,7 @@ const INSTALLED_CANISTERS: usize = 6;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(stress_setup)
         .add_test(systest!(test))
         .execute_from_args()?;

--- a/rs/tests/networking/canister_http_stress_test.rs
+++ b/rs/tests/networking/canister_http_stress_test.rs
@@ -33,6 +33,7 @@ use canister_test::Canister;
 use dfn_candid::candid_one;
 use ic_cdk::api::call::RejectionCode;
 use ic_management_canister_types_private::{HttpMethod, TransformContext, TransformFunc};
+use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::IcNodeContainer;
 use ic_system_test_driver::driver::{
@@ -60,6 +61,7 @@ struct BenchmarkResult {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(stress_setup)
         .add_test(systest!(test))
         // This test takes consistently around 20 mintues, so setting 30 minutes to be safe.

--- a/rs/tests/networking/cloner_canister_workload.rs
+++ b/rs/tests/networking/cloner_canister_workload.rs
@@ -24,7 +24,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     canister_agent::{CanisterAgent, HasCanisterAgentCapability},
     driver::{
-        farm::HostFeature,
+        farm::{HostFeature, VmAllocationMode},
         group::SystemTestGroup,
         ic::{
             AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet,
@@ -57,6 +57,7 @@ const AMOUNT_OF_CLONER_CANISTERS: u64 =
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(install_cloner_canisters))
         .with_timeout_per_test(TEST_TIMEOUT)

--- a/rs/tests/networking/p2p_performance_test.rs
+++ b/rs/tests/networking/p2p_performance_test.rs
@@ -4,7 +4,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     canister_api::{CallMode, GenericRequest},
     driver::{
-        farm::HostFeature,
+        farm::{HostFeature, VmAllocationMode},
         group::SystemTestGroup,
         ic::{
             AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet,
@@ -287,6 +287,7 @@ fn main() -> Result<()> {
         )
     };
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test))
         .with_timeout_per_test(per_task_timeout) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/networking/query_workload_long_test.rs
+++ b/rs/tests/networking/query_workload_long_test.rs
@@ -25,7 +25,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     canister_api::{CallMode, GenericRequest},
     driver::{
-        farm::HostFeature,
+        farm::{HostFeature, VmAllocationMode},
         group::SystemTestGroup,
         ic::ImageSizeGiB,
         test_env::TestEnv,
@@ -153,6 +153,7 @@ fn main() -> Result<()> {
     let overall_timeout: Duration = per_task_timeout + OVERALL_TIMEOUT_DELTA; // This should be a bit larger than the per_task_timeout.
     let test = |env| test(env, RPS, WORKLOAD_RUNTIME);
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(|env| {
             setup(
                 env,

--- a/rs/tests/networking/state_sync_performance.rs
+++ b/rs/tests/networking/state_sync_performance.rs
@@ -20,7 +20,7 @@ use ic_nns_governance_api::NnsFunction;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
-        farm::HostFeature,
+        farm::{HostFeature, VmAllocationMode},
         group::SystemTestGroup,
         ic::{ImageSizeGiB, InternetComputer, Subnet, VmResourceOverrides},
         simulate_network::{FixedNetworkSimulation, SimulateNetwork},
@@ -204,6 +204,7 @@ fn test(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .with_timeout_per_test(Duration::from_secs(20 * 60))
         .add_test(systest!(test))

--- a/rs/tests/networking/update_workload_large_payload.rs
+++ b/rs/tests/networking/update_workload_large_payload.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use ic_system_test_driver::driver::farm::HostFeature;
+use ic_system_test_driver::driver::farm::VmAllocationMode;
 use std::time::Duration;
 
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
@@ -29,6 +30,7 @@ fn main() -> Result<()> {
         )
     };
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(|env| {
             setup(
                 env,

--- a/rs/tests/testnets/io_perf_benchmark.rs
+++ b/rs/tests/testnets/io_perf_benchmark.rs
@@ -57,7 +57,7 @@ use ic_system_test_driver::driver::ic::{
 use ic_system_test_driver::driver::ic_gateway_vm::IcGatewayVm;
 use ic_system_test_driver::driver::pot_dsl::PotSetupFn;
 use ic_system_test_driver::driver::{
-    farm::HostFeature,
+    farm::{HostFeature, VmAllocationMode},
     group::SystemTestGroup,
     test_env::TestEnv,
     test_env_api::{HasTopologySnapshot, IcNodeContainer},
@@ -86,6 +86,7 @@ fn main() -> Result<()> {
     let config = Config::new(perf_hosts, num_hosts, hostuser);
 
     SystemTestGroup::new()
+        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .with_timeout_per_test(std::time::Duration::MAX) // Switching to SSD takes long time
         .execute_from_args()?;


### PR DESCRIPTION
In https://github.com/dfinity-lab/farm/pull/276 we would like to increase the maximum vCPUs for performance hosts from 64 to the default 256 such that we can run more regular system-tests on them.

However, because of the extra room, this will cause performance system-tests to allocate more than one VM per host which will make their results unreliable. 

To work around this Farm recently gained a new `VmAllocationMode` called `PerformanceOptimizedAllocation` (https://github.com/dfinity-lab/farm/pull/275) which behaves the same as the default `MinIntraDistanceLoadBalanceAllocation` except that it doesn't have the first ordering property that compares the number of VMs of the group that the host has already allocated. This will have the effect of load-balancing VMs over the hosts in a single DC instead of colocating them to single hosts as much as possible.

This commit configures all performance system-tests to use this new `VmAllocationMode::PerformanceOptimizedAllocation`.

This also removes the ability to configure the `VmAllocationMode` per subnet and node since we never used that ability.