### PR TITLE
fix(ic-metrics-assert): gate doctest behind `pocket_ic` feature

### DIFF
--- a/packages/ic-metrics-assert/BUILD.bazel
+++ b/packages/ic-metrics-assert/BUILD.bazel
@@ -44,7 +44,13 @@ rust_doc(
     crate = ":ic-metrics-assert",
 )
 
-rust_doc_test(
-    name = "doc_test",
-    crate = ":ic-metrics-assert_pocket_ic",
-)
+[
+    rust_doc_test(
+        name = "doc_test" + name_suffix,
+        crate = ":ic-metrics-assert" + name_suffix,
+    )
+    for name_suffix in [
+        "",
+        "_pocket_ic",
+    ]
+]

--- a/packages/ic-metrics-assert/Cargo.toml
+++ b/packages/ic-metrics-assert/Cargo.toml
@@ -8,7 +8,7 @@ include = ["src", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md"]
 repository = "https://github.com/dfinity/ic"
 authors.workspace = true
 edition.workspace = true
-documentation.workspace = true
+documentation = "https://docs.rs/ic_metrics_assert"
 
 [dependencies]
 async-trait = { workspace = true }

--- a/packages/ic-metrics-assert/src/lib.rs
+++ b/packages/ic-metrics-assert/src/lib.rs
@@ -16,7 +16,8 @@ use std::fmt::Debug;
 ///
 /// # Examples
 ///
-/// ```rust
+#[cfg_attr(feature = "pocket_ic", doc = "```rust")]
+#[cfg_attr(not(feature = "pocket_ic"), doc = "```ignore")]
 /// use ic_metrics_assert::{MetricsAssert, PocketIcHttpQuery};
 /// use pocket_ic::PocketIc;
 /// use ic_management_canister_types::CanisterId;


### PR DESCRIPTION
- Gate the `MetricsAssert` doctest at `src/lib.rs:19` behind the `pocket_ic` feature via `cfg_attr`, so `cargo test --doc` no longer fails to resolve feature-only imports when the publish workflow runs without features (see [run 25734384450](https://github.com/dfinity/ic/actions/runs/25734384450/job/75567397660)).
- Add a bazel `doc_test` target for the default-features library variant so CI catches this kind of regression instead of the next publish attempt.
- Override `documentation.workspace = true` (the generic `internetcomputer.org/docs/` portal) to the crate-specific `https://docs.rs/ic_metrics_assert`.