### PR TITLE
fix: Roll forward #10186

### DIFF
--- a/rs/ic_os/guest_upgrade/client/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/client/src/lib.rs
@@ -50,6 +50,9 @@ pub struct DiskEncryptionKeyExchangeClientAgent {
     crypto_ops: Box<dyn DiskCryptoOps>,
 }
 
+// Allow 32MB ingress messages - we need 16MB for the LUKS header
+const MAX_INCOMING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+
 impl DiskEncryptionKeyExchangeClientAgent {
     pub fn new(
         guestos_config: GuestOSConfig,
@@ -297,7 +300,8 @@ impl DiskEncryptionKeyExchangeClientAgent {
             .context("Failed to connect to server")?;
 
         Ok((
-            DiskEncryptionKeyExchangeServiceClient::new(channel),
+            DiskEncryptionKeyExchangeServiceClient::new(channel)
+                .max_decoding_message_size(MAX_INCOMING_MESSAGE_SIZE),
             server_public_key_der,
         ))
     }

--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -251,7 +251,10 @@ pub fn backup_luks_header_to_file(device_path: &Path, header_path: &Path) -> Res
                 temp_header_path.display()
             )
         })?;
-    fs::set_permissions(&temp_header_path, fs::Permissions::from_mode(0o600))
+
+    // We allow every user to read the header. The replica (running as user ic-replica) needs
+    // access to this file so that it can share it during an upgrade.
+    fs::set_permissions(&temp_header_path, fs::Permissions::from_mode(0o644))
         .context("Failed to set permissions on temporary detached LUKS header file")?;
 
     fs::rename(&temp_header_path, header_path)

--- a/rs/ic_os/os_tools/guest_disk/src/tests.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/tests.rs
@@ -743,7 +743,7 @@ fn test_format_store_populates_detached_header_and_sets_permissions() {
             .permissions()
             .mode()
             & 0o777,
-        0o600,
+        0o644,
         "detached Store LUKS header should be readable and writable by owner only"
     );
 }

--- a/rs/tests/node/BUILD.bazel
+++ b/rs/tests/node/BUILD.bazel
@@ -34,9 +34,6 @@ system_test(
     proc_macro_deps = [
         "@crate_index//:indoc",
     ],
-    tags = [
-        "long_test",  # The P90 duration of this test was over 6 minutes for the week starting on 2025-08-21.
-    ],
     runtime_deps = {
         "NODE_ROOT_TESTS_UVM_CONFIG_PATH": ":root_tests_config_image",
     },


### PR DESCRIPTION
Fixed root_test and removed long_test so that it's not skipped by CI (these days it only takes 70-80seconds to execute it).