### PR TITLE
feat(PocketIC): canister creation with cycles

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PocketIc::query_call_with_effective_principal_and_sender_info`, and `PocketIc::query_call_with_sender_info`
   to make canister calls with sender info (additional information provided by the canister with which the sender principal is associated).
 - The function `PocketIcBuilder::with_test_threshold_keys_subnet` to create a test threshold keys subnet.
+- The function `PocketIc::create_canister_with_params` and supporting types `CreateCanisterParams` and `CreateCanisterPlacement` to create a canister with custom cycles, settings, and/or placement (specific subnet or canister ID).
+
+### Changed
+- The functions `PocketIc::create_canister`, `PocketIc::create_canister_with_settings`, `PocketIc::create_canister_with_id`, and `PocketIc::create_canister_on_subnet` now create a canister with 100T cycles by default.
 
 
 

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -574,6 +574,24 @@ impl TryFrom<Time> for SystemTime {
     }
 }
 
+/// Specifies where to place a newly created canister.
+#[derive(Debug)]
+pub enum CreateCanisterPlacement {
+    /// Place the canister on the given subnet.
+    SubnetId(SubnetId),
+    /// Create the canister with the given specific canister ID.
+    CanisterId(CanisterId),
+}
+
+/// Parameters for [`PocketIc::create_canister_with_params`].
+#[derive(Debug, Default)]
+pub struct CreateCanisterParams {
+    /// Initial cycles balance; defaults to 100T if `None`.
+    pub cycles: Option<u128>,
+    pub settings: Option<CanisterSettings>,
+    pub placement: Option<CreateCanisterPlacement>,
+}
+
 /// Main entry point for interacting with PocketIC.
 pub struct PocketIc {
     pocket_ic: PocketIcAsync,
@@ -1098,6 +1116,7 @@ impl PocketIc {
     }
 
     /// Create a canister with default settings as the anonymous principal.
+    /// The canister is created with 100T cycles.
     #[instrument(ret(Display), skip(self), fields(instance_id=self.pocket_ic.instance_id))]
     pub fn create_canister(&self) -> CanisterId {
         let runtime = self.runtime.clone();
@@ -1105,6 +1124,7 @@ impl PocketIc {
     }
 
     /// Create a canister with optional custom settings and a sender.
+    /// The canister is created with 100T cycles.
     #[instrument(ret(Display), skip(self), fields(instance_id=self.pocket_ic.instance_id, settings = ?settings, sender = %sender.unwrap_or(Principal::anonymous()).to_string()))]
     pub fn create_canister_with_settings(
         &self,
@@ -1120,6 +1140,7 @@ impl PocketIc {
     }
 
     /// Creates a canister with a specific canister ID and optional custom settings.
+    /// The canister is created with 100T cycles.
     /// Returns an error if the canister ID is already in use.
     /// Creates a new subnet if the canister ID is not contained in any of the subnets.
     ///
@@ -1142,6 +1163,7 @@ impl PocketIc {
     }
 
     /// Create a canister on a specific subnet with optional custom settings.
+    /// The canister is created with 100T cycles.
     #[instrument(ret(Display), skip(self), fields(instance_id=self.pocket_ic.instance_id, sender = %sender.unwrap_or(Principal::anonymous()).to_string(), settings = ?settings, subnet_id = %subnet_id.to_string()))]
     pub fn create_canister_on_subnet(
         &self,
@@ -1153,6 +1175,24 @@ impl PocketIc {
         runtime.block_on(async {
             self.pocket_ic
                 .create_canister_on_subnet(sender, settings, subnet_id)
+                .await
+        })
+    }
+
+    /// Create a canister with optional cycles, settings, and placement.
+    /// The placement specifies either a target subnet or a specific canister ID.
+    /// Defaults to 100T cycles if `params.cycles` is `None`.
+    /// Returns an error if the specified canister ID is already in use.
+    #[instrument(ret, skip(self), fields(instance_id=self.pocket_ic.instance_id, sender = %sender.unwrap_or(Principal::anonymous()).to_string()))]
+    pub fn create_canister_with_params(
+        &self,
+        sender: Option<Principal>,
+        params: CreateCanisterParams,
+    ) -> Result<CanisterId, String> {
+        let runtime = self.runtime.clone();
+        runtime.block_on(async {
+            self.pocket_ic
+                .create_canister_with_params(sender, params)
                 .await
         })
     }

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -575,7 +575,7 @@ impl TryFrom<Time> for SystemTime {
 }
 
 /// Specifies where to place a newly created canister.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum CreateCanisterPlacement {
     /// Place the canister on the given subnet.
     SubnetId(SubnetId),
@@ -584,11 +584,13 @@ pub enum CreateCanisterPlacement {
 }
 
 /// Parameters for [`PocketIc::create_canister_with_params`].
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateCanisterParams {
     /// Initial cycles balance; defaults to 100T if `None`.
     pub cycles: Option<u128>,
+    /// Canister settings; defaults to default canister settings if `None`.
     pub settings: Option<CanisterSettings>,
+    /// Canister placement (subnet or specific canister ID); a random application subnet is chosen if `None`.
     pub placement: Option<CreateCanisterPlacement>,
 }
 

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -13,8 +13,8 @@ use crate::common::rest::{
 #[cfg(windows)]
 use crate::wsl_path;
 use crate::{
-    IngressStatusResult, PocketIcBuilder, PocketIcState, RejectResponse, StartServerParams,
-    TickConfigs, Time, copy_dir, start_server,
+    CreateCanisterParams, CreateCanisterPlacement, IngressStatusResult, PocketIcBuilder,
+    PocketIcState, RejectResponse, StartServerParams, TickConfigs, Time, copy_dir, start_server,
 };
 use backoff::backoff::Backoff;
 use backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
@@ -1048,54 +1048,35 @@ impl PocketIc {
     }
 
     /// Create a canister with default settings as the anonymous principal.
+    /// The canister is created with 100T cycles.
     #[instrument(ret(Display), skip(self), fields(instance_id=self.instance_id))]
     pub async fn create_canister(&self) -> CanisterId {
-        let CanisterIdRecord { canister_id } = call_candid_as(
-            self,
-            Principal::management_canister(),
-            RawEffectivePrincipal::None,
-            Principal::anonymous(),
-            "provisional_create_canister_with_cycles",
-            (ProvisionalCreateCanisterWithCyclesArgs {
-                settings: None,
-                amount: Some(0_u64.into()),
-                specified_id: None,
-                sender_canister_version: None,
-            },),
-        )
-        .await
-        .map(|(x,)| x)
-        .unwrap();
-        canister_id
+        self.create_canister_with_params(None, CreateCanisterParams::default())
+            .await
+            .unwrap()
     }
 
     /// Create a canister with optional custom settings and a sender.
+    /// The canister is created with 100T cycles.
     #[instrument(ret(Display), skip(self), fields(instance_id=self.instance_id, settings = ?settings, sender = %sender.unwrap_or(Principal::anonymous()).to_string()))]
     pub async fn create_canister_with_settings(
         &self,
         sender: Option<Principal>,
         settings: Option<CanisterSettings>,
     ) -> CanisterId {
-        let CanisterIdRecord { canister_id } = call_candid_as(
-            self,
-            Principal::management_canister(),
-            RawEffectivePrincipal::None,
-            sender.unwrap_or(Principal::anonymous()),
-            "provisional_create_canister_with_cycles",
-            (ProvisionalCreateCanisterWithCyclesArgs {
+        self.create_canister_with_params(
+            sender,
+            CreateCanisterParams {
                 settings,
-                amount: Some(0_u64.into()),
-                specified_id: None,
-                sender_canister_version: None,
-            },),
+                ..Default::default()
+            },
         )
         .await
-        .map(|(x,)| x)
-        .unwrap();
-        canister_id
+        .unwrap()
     }
 
     /// Creates a canister with a specific canister ID and optional custom settings.
+    /// The canister is created with 100T cycles.
     /// Returns an error if the canister ID is already in use.
     /// Creates a new subnet if the canister ID is not contained in any of the subnets.
     ///
@@ -1109,16 +1090,70 @@ impl PocketIc {
         settings: Option<CanisterSettings>,
         canister_id: CanisterId,
     ) -> Result<CanisterId, String> {
+        self.create_canister_with_params(
+            sender,
+            CreateCanisterParams {
+                settings,
+                placement: Some(CreateCanisterPlacement::CanisterId(canister_id)),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    /// Create a canister on a specific subnet with optional custom settings.
+    /// The canister is created with 100T cycles.
+    #[instrument(ret(Display), skip(self), fields(instance_id=self.instance_id, sender = %sender.unwrap_or(Principal::anonymous()).to_string(), settings = ?settings, subnet_id = %subnet_id.to_string()))]
+    pub async fn create_canister_on_subnet(
+        &self,
+        sender: Option<Principal>,
+        settings: Option<CanisterSettings>,
+        subnet_id: SubnetId,
+    ) -> CanisterId {
+        self.create_canister_with_params(
+            sender,
+            CreateCanisterParams {
+                settings,
+                placement: Some(CreateCanisterPlacement::SubnetId(subnet_id)),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+    }
+
+    /// Create a canister with optional cycles, settings, and placement.
+    /// The placement specifies either a target subnet or a specific canister ID.
+    /// Defaults to 100T cycles if `params.cycles` is `None`.
+    /// Returns an error if the specified canister ID is already in use.
+    #[instrument(ret, skip(self), fields(instance_id=self.instance_id, sender = %sender.unwrap_or(Principal::anonymous()).to_string()))]
+    pub async fn create_canister_with_params(
+        &self,
+        sender: Option<Principal>,
+        params: CreateCanisterParams,
+    ) -> Result<CanisterId, String> {
+        let cycles = params.cycles.unwrap_or(100_000_000_000_000);
+        let (effective_principal, specified_id) = match params.placement {
+            None => (RawEffectivePrincipal::None, None),
+            Some(CreateCanisterPlacement::SubnetId(subnet_id)) => (
+                RawEffectivePrincipal::SubnetId(subnet_id.as_slice().to_vec()),
+                None,
+            ),
+            Some(CreateCanisterPlacement::CanisterId(canister_id)) => (
+                RawEffectivePrincipal::CanisterId(canister_id.as_slice().to_vec()),
+                Some(canister_id),
+            ),
+        };
         let res = call_candid_as(
             self,
             Principal::management_canister(),
-            RawEffectivePrincipal::CanisterId(canister_id.as_slice().to_vec()),
+            effective_principal,
             sender.unwrap_or(Principal::anonymous()),
             "provisional_create_canister_with_cycles",
             (ProvisionalCreateCanisterWithCyclesArgs {
-                settings,
-                specified_id: Some(canister_id),
-                amount: Some(0_u64.into()),
+                settings: params.settings,
+                amount: Some(cycles.into()),
+                specified_id,
                 sender_canister_version: None,
             },),
         )
@@ -1130,33 +1165,6 @@ impl PocketIc {
             }) => Ok(actual_canister_id),
             Err(e) => Err(format!("{e:?}")),
         }
-    }
-
-    /// Create a canister on a specific subnet with optional custom settings.
-    #[instrument(ret(Display), skip(self), fields(instance_id=self.instance_id, sender = %sender.unwrap_or(Principal::anonymous()).to_string(), settings = ?settings, subnet_id = %subnet_id.to_string()))]
-    pub async fn create_canister_on_subnet(
-        &self,
-        sender: Option<Principal>,
-        settings: Option<CanisterSettings>,
-        subnet_id: SubnetId,
-    ) -> CanisterId {
-        let CanisterIdRecord { canister_id } = call_candid_as(
-            self,
-            Principal::management_canister(),
-            RawEffectivePrincipal::SubnetId(subnet_id.as_slice().to_vec()),
-            sender.unwrap_or(Principal::anonymous()),
-            "provisional_create_canister_with_cycles",
-            (ProvisionalCreateCanisterWithCyclesArgs {
-                settings,
-                amount: Some(0_u64.into()),
-                specified_id: None,
-                sender_canister_version: None,
-            },),
-        )
-        .await
-        .map(|(x,)| x)
-        .unwrap();
-        canister_id
     }
 
     /// Upload a WASM chunk to the WASM chunk store of a canister.

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1144,7 +1144,7 @@ impl PocketIc {
                 Some(canister_id),
             ),
         };
-        let res = call_candid_as(
+        call_candid_as::<_, (CanisterIdRecord,)>(
             self,
             Principal::management_canister(),
             effective_principal,

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1158,13 +1158,8 @@ impl PocketIc {
             },),
         )
         .await
-        .map(|(x,)| x);
-        match res {
-            Ok(CanisterIdRecord {
-                canister_id: actual_canister_id,
-            }) => Ok(actual_canister_id),
-            Err(e) => Err(format!("{e:?}")),
-        }
+        .map(|(x,)| x.canister_id)
+        .map_err(|e| format!("{e:?}"))
     }
 
     /// Upload a WASM chunk to the WASM chunk store of a canister.

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -23,8 +23,8 @@ use pocket_ic::common::rest::{
     InstanceHttpGatewayConfig, SubnetSpec,
 };
 use pocket_ic::{
-    PocketIc, PocketIcBuilder, PocketIcState, StartServerParams, start_server, update_candid,
-    update_candid_as,
+    CreateCanisterParams, PocketIc, PocketIcBuilder, PocketIcState, StartServerParams,
+    start_server, update_candid, update_candid_as,
 };
 use registry_canister::pb::v1::{GetSubnetForCanisterRequest, SubnetForCanister};
 use reqwest::StatusCode;
@@ -613,13 +613,20 @@ fn test_cycles_ledger() {
         .with_application_subnet()
         .build();
 
-    let canister_id = pic.create_canister();
+    let init_cycles = u128::MAX / 2;
+    let canister_id = pic
+        .create_canister_with_params(
+            None,
+            CreateCanisterParams {
+                cycles: Some(init_cycles),
+                ..Default::default()
+            },
+        )
+        .unwrap();
     assert_eq!(
         pic.get_subnet(canister_id).unwrap(),
         pic.topology().get_app_subnets()[0]
     );
-    let init_cycles = u128::MAX / 2;
-    pic.add_cycles(canister_id, init_cycles);
     pic.install_canister(canister_id, test_canister_wasm(), vec![], None);
 
     let check_balance = |owner: Principal, expected_balance: u128| {

--- a/packages/pocket-ic/tests/slow.rs
+++ b/packages/pocket-ic/tests/slow.rs
@@ -23,10 +23,10 @@ fn execute_many_instructions(
     assert_eq!(t1, t0 + Duration::from_nanos(1)); // canister creation should take one round, i.e., 1ns
 
     // Charge the canister with 200T cycles.
+    let cycles_before = pic.cycle_balance(can_id);
     pic.add_cycles(can_id, INIT_CYCLES);
-
-    let initial_cycles = pic.cycle_balance(can_id);
-    assert_eq!(initial_cycles, INIT_CYCLES);
+    let cycles_after = pic.cycle_balance(can_id);
+    assert_eq!(cycles_after, cycles_before + INIT_CYCLES);
 
     // Install the test canister wasm on the canister.
     pic.install_canister(can_id, test_canister_wasm(), vec![], None);
@@ -46,7 +46,7 @@ fn execute_many_instructions(
 
     if system_subnet {
         let cycles = pic.cycle_balance(can_id);
-        assert_eq!(cycles, initial_cycles);
+        assert_eq!(cycles, cycles_after);
     }
 
     res

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -226,7 +226,7 @@ fn test_create_canister_with_params_default() {
 #[test]
 fn test_create_canister_with_params_cycles() {
     let pic = PocketIc::new();
-    let cycles = 42_000_000_000_000u128;
+    let cycles = 42_000_000_000_000_u128;
     let canister_id = pic
         .create_canister_with_params(
             None,

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -11,8 +11,9 @@ use ic_transport_types::Envelope;
 use ic_transport_types::EnvelopeContent::{Call, ReadState};
 use ic_utils::interfaces::ManagementCanister;
 use pocket_ic::{
-    DefaultEffectiveCanisterIdError, ErrorCode, IngressStatusResult, PocketIc, PocketIcBuilder,
-    PocketIcState, RejectCode, StartServerParams, Time,
+    CreateCanisterParams, CreateCanisterPlacement, DefaultEffectiveCanisterIdError, ErrorCode,
+    IngressStatusResult, PocketIc, PocketIcBuilder, PocketIcState, RejectCode, StartServerParams,
+    Time,
     common::rest::{
         AutoProgressConfig, BlobCompression, CanisterCyclesCostSchedule, CanisterHttpReply,
         CanisterHttpResponse, CanisterIdRange, CreateInstanceResponse, ExtendedSubnetConfigSet,
@@ -210,6 +211,94 @@ fn test_create_canister_with_not_mainnet_id_panics() {
         None,
         Principal::from_slice(&[0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01]),
     );
+}
+
+#[test]
+fn test_create_canister_with_params_default() {
+    let pic = PocketIc::new();
+    let canister_id = pic
+        .create_canister_with_params(None, CreateCanisterParams::default())
+        .unwrap();
+    // Default cycles balance is 100T.
+    assert_eq!(pic.cycle_balance(canister_id), 100_000_000_000_000);
+}
+
+#[test]
+fn test_create_canister_with_params_cycles() {
+    let pic = PocketIc::new();
+    let cycles = 42_000_000_000_000u128;
+    let canister_id = pic
+        .create_canister_with_params(
+            None,
+            CreateCanisterParams {
+                cycles: Some(cycles),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(pic.cycle_balance(canister_id), cycles);
+}
+
+#[test]
+fn test_create_canister_with_params_subnet() {
+    let pic = PocketIcBuilder::new()
+        .with_application_subnet()
+        .with_fiduciary_subnet()
+        .build();
+    let topology = pic.topology();
+    let fidu_subnet_id = topology.get_fiduciary().unwrap();
+    let canister_id = pic
+        .create_canister_with_params(
+            None,
+            CreateCanisterParams {
+                placement: Some(CreateCanisterPlacement::SubnetId(fidu_subnet_id)),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(pic.get_subnet(canister_id).unwrap(), fidu_subnet_id);
+}
+
+#[test]
+fn test_create_canister_with_params_canister_id() {
+    let pic = PocketIcBuilder::new().with_nns_subnet().build();
+    let canister_id = Principal::from_text("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
+    let actual_canister_id = pic
+        .create_canister_with_params(
+            None,
+            CreateCanisterParams {
+                placement: Some(CreateCanisterPlacement::CanisterId(canister_id)),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(actual_canister_id, canister_id);
+    assert_eq!(
+        pic.get_subnet(canister_id).unwrap(),
+        pic.topology().get_nns().unwrap()
+    );
+}
+
+#[test]
+fn test_create_canister_with_params_duplicate_id_fails() {
+    let pic = PocketIcBuilder::new().with_nns_subnet().build();
+    let canister_id = Principal::from_text("rrkah-fqaaa-aaaaa-aaaaq-cai").unwrap();
+    let res = pic.create_canister_with_params(
+        None,
+        CreateCanisterParams {
+            placement: Some(CreateCanisterPlacement::CanisterId(canister_id)),
+            ..Default::default()
+        },
+    );
+    assert!(res.is_ok());
+    let res = pic.create_canister_with_params(
+        None,
+        CreateCanisterParams {
+            placement: Some(CreateCanisterPlacement::CanisterId(canister_id)),
+            ..Default::default()
+        },
+    );
+    assert!(res.is_err());
 }
 
 #[test]

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -142,15 +142,6 @@ fn test_create_canister_with_id() {
 }
 
 #[test]
-#[should_panic(expected = "is out of cycles")]
-fn test_install_canister_with_no_cycles() {
-    let pic = PocketIc::new();
-    let canister_id = pic.create_canister();
-    let wasm = b"\x00\x61\x73\x6d\x01\x00\x00\x00".to_vec();
-    pic.install_canister(canister_id, wasm.clone(), vec![], None);
-}
-
-#[test]
 #[should_panic(expected = "not found")]
 fn test_canister_routing_not_found() {
     let pic = PocketIc::new();

--- a/rs/bitcoin/ckbtc/minter/tests/dump_stable_memory.rs
+++ b/rs/bitcoin/ckbtc/minter/tests/dump_stable_memory.rs
@@ -42,7 +42,6 @@ impl Setup {
         let ledger_id = env.create_canister();
         let minter_id = env.create_canister();
         let btc_checker_id = env.create_canister();
-        env.add_cycles(minter_id, 100_000_000_000_000);
 
         let init_args = Encode!(&MinterArg::Init(CkbtcMinterInitArgs {
             btc_network,

--- a/rs/migration_canister/tests/tests.rs
+++ b/rs/migration_canister/tests/tests.rs
@@ -12,7 +12,7 @@ use ic_transport_types::EnvelopeContent::Call;
 use ic_universal_canister::{CallArgs, UNIVERSAL_CANISTER_WASM, wasm};
 use itertools::Itertools;
 use pocket_ic::{
-    PocketIcBuilder,
+    CreateCanisterParams, CreateCanisterPlacement, PocketIcBuilder,
     common::rest::{IcpFeatures, IcpFeaturesConfig},
     nonblocking::PocketIc,
 };
@@ -175,28 +175,31 @@ async fn setup(
         if let Some(ref allowlist) = allowlist {
             new_controllers.extend(allowlist.clone());
         }
-        let migrated_canister = pic
-            .create_canister_on_subnet(
-                Some(c1),
-                Some(CanisterSettings {
-                    controllers: Some(new_controllers),
-                    ..Default::default()
-                }),
-                migrated_canister_subnet,
-            )
-            .await;
-        if enough_cycles {
-            pic.add_cycles(migrated_canister, u128::MAX / 2).await;
+        let cycles = if enough_cycles {
+            None
         } else {
-            pic.add_cycles(
-                migrated_canister,
-                if LOG_MEMORY_STORE_FEATURE_ENABLED {
-                    11_200_000
-                } else {
-                    2_000_000
+            Some(if LOG_MEMORY_STORE_FEATURE_ENABLED {
+                11_200_000
+            } else {
+                2_000_000
+            })
+        };
+        let migrated_canister = pic
+            .create_canister_with_params(
+                Some(c1),
+                CreateCanisterParams {
+                    cycles,
+                    settings: Some(CanisterSettings {
+                        controllers: Some(new_controllers),
+                        ..Default::default()
+                    }),
+                    placement: Some(CreateCanisterPlacement::SubnetId(migrated_canister_subnet)),
                 },
             )
-            .await;
+            .await
+            .unwrap();
+        if enough_cycles {
+            pic.add_cycles(migrated_canister, u128::MAX / 2).await;
         }
         pic.stop_canister(migrated_canister, Some(c1))
             .await
@@ -212,27 +215,21 @@ async fn setup(
             new_controllers.extend(allowlist.clone());
         }
         let replaced_canister = pic
-            .create_canister_on_subnet(
+            .create_canister_with_params(
                 Some(c1),
-                Some(CanisterSettings {
-                    controllers: Some(new_controllers),
-                    ..Default::default()
-                }),
-                replaced_canister_subnet,
-            )
-            .await;
-        if enough_cycles {
-            pic.add_cycles(replaced_canister, u128::MAX / 2).await;
-        } else {
-            pic.add_cycles(
-                replaced_canister,
-                if LOG_MEMORY_STORE_FEATURE_ENABLED {
-                    11_200_000
-                } else {
-                    2_000_000
+                CreateCanisterParams {
+                    cycles,
+                    settings: Some(CanisterSettings {
+                        controllers: Some(new_controllers),
+                        ..Default::default()
+                    }),
+                    placement: Some(CreateCanisterPlacement::SubnetId(replaced_canister_subnet)),
                 },
             )
-            .await;
+            .await
+            .unwrap();
+        if enough_cycles {
+            pic.add_cycles(replaced_canister, u128::MAX / 2).await;
         }
         pic.stop_canister(replaced_canister, Some(c1))
             .await


### PR DESCRIPTION
This PR makes the existing PocketIC (Rust) library functions create canisters with a default amount of 100T cycles and adds a new function `PocketIc::create_canister_with_params` to create a canister with parameters specified in a struct with optional fields to use defaults as appropriate.

The motivation for this change is that the (upcoming) canister log memory store feature allocates canister log buffer memory at canister creation time and thus creating a canister with zero cycles is no longer allowed.