### PR TITLE
feat: Update registry client and GuestOS tools away from blessed versions

### DIFF
--- a/rs/ic_os/guest_upgrade/client/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/client/src/lib.rs
@@ -15,7 +15,7 @@ use hyper_util::rt::TokioIo;
 use ic_crypto_utils_threshold_sig_der::parse_threshold_sig_key_from_pem_file;
 use ic_interfaces_registry::RegistryClient;
 use ic_registry_client::client::RegistryClientImpl;
-use ic_registry_client_helpers::blessed_replica_version::BlessedReplicaVersionRegistry;
+use ic_registry_client_helpers::replica_version::ReplicaVersionRegistry;
 use ic_registry_nns_data_provider_wrappers::CertifiedNnsDataProvider;
 use rcgen::CertifiedKey;
 use rustls::ClientConfig;
@@ -175,10 +175,10 @@ impl DiskEncryptionKeyExchangeClientAgent {
             .context("Server attestation report is missing")?;
 
         let registry_version = self.nns_registry_client.get_latest_version();
-        let blessed_measurements = self
+        let elected_measurements = self
             .nns_registry_client
-            .get_blessed_guest_launch_measurements(registry_version)
-            .map_err(|e| anyhow!("Failed to get blessed measurements from registry: {e}"))?;
+            .get_guest_launch_measurements(registry_version)
+            .map_err(|e| anyhow!("Failed to get elected measurements from registry: {e}"))?;
 
         // Verify the server's attestation report. This is to ensure that the key comes from a
         // trusted source. Without this check, an attacker could start with a malicious GuestOS,
@@ -188,7 +188,7 @@ impl DiskEncryptionKeyExchangeClientAgent {
             server_attestation_package,
             self.sev_root_certificate_verification,
         )
-        .verify_measurement(&blessed_measurements)
+        .verify_measurement(&elected_measurements)
         .verify_custom_data(&custom_data)
         .verify_chip_id(&[my_attestation_report.chip_id])
         .context("Server attestation report verification failed")?;

--- a/rs/ic_os/guest_upgrade/server/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/server/src/lib.rs
@@ -80,7 +80,7 @@ impl DiskEncryptionKeyExchangeServerAgent {
     }
 
     /// Runs the key exchange flow for upgrading to `replica_version`.
-    /// Note that the implementation does not verify that `replica_version` is a blessed version,
+    /// Note that the implementation does not verify that `replica_version` is an elected version,
     /// it is the caller's responsibility to select the right target version.
     pub async fn exchange_keys(
         &self,

--- a/rs/ic_os/guest_upgrade/tests/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/tests/src/lib.rs
@@ -17,7 +17,7 @@ use ic_protobuf::registry::replica_version::v1::{
 };
 use ic_registry_client_fake::FakeRegistryClient;
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
-use ic_test_utilities_registry::{add_blessed_replica_versions, add_replica_version_record};
+use ic_test_utilities_registry::add_replica_version_record;
 use ic_types::ReplicaVersion;
 use sev_guest::key_deriver::{Key, derive_key_from_sev_measurement};
 use sev_guest_testing::{FakeAttestationReportSigner, MockSevGuestFirmwareBuilder};
@@ -114,8 +114,6 @@ impl DiskEncryptionKeyExchangeTestFixture {
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let registry_data_provider = Arc::new(ProtoRegistryDataProvider::new());
-
-        add_blessed_replica_versions(&registry_data_provider, 1, &[REPLICA_VERSION]);
 
         add_replica_version_record(
             &registry_data_provider,

--- a/rs/registry/helpers/src/lib.rs
+++ b/rs/registry/helpers/src/lib.rs
@@ -4,7 +4,6 @@
 //! to the respective crate/component at some point in the future.
 
 pub mod api_boundary_node;
-pub mod blessed_replica_version;
 pub mod chain_keys;
 pub mod crypto;
 pub mod ecdsa_keys;
@@ -13,6 +12,7 @@ pub mod hostos_version;
 pub mod node;
 pub mod node_operator;
 pub mod provisional_whitelist;
+pub mod replica_version;
 pub mod routing_table;
 pub mod subnet;
 pub mod test_proto;

--- a/rs/registry/helpers/src/replica_version.rs
+++ b/rs/registry/helpers/src/replica_version.rs
@@ -1,55 +1,71 @@
 use crate::deserialize_registry_value;
-use crate::subnet::SubnetRegistry;
-use ic_base_types::RegistryVersion;
 use ic_interfaces_registry::{RegistryClient, RegistryClientResult};
-use ic_protobuf::registry::replica_version::v1::BlessedReplicaVersions;
-use ic_registry_keys::make_blessed_replica_versions_key;
-use ic_types::ReplicaVersion;
-use std::str::FromStr;
+use ic_protobuf::registry::replica_version::v1::ReplicaVersionRecord;
+use ic_registry_keys::{REPLICA_VERSION_KEY_PREFIX, make_replica_version_key};
+pub use ic_types::replica_version::ReplicaVersion;
+pub use ic_types::{NodeId, RegistryVersion, SubnetId};
 
-pub trait BlessedReplicaVersionRegistry {
-    fn get_blessed_replica_versions(
+pub trait ReplicaVersionRegistry {
+    fn get_replica_versions(
         &self,
         version: RegistryVersion,
-    ) -> RegistryClientResult<BlessedReplicaVersions>;
+    ) -> RegistryClientResult<Vec<ReplicaVersionRecord>>;
 
-    /// Returns all guest launch measurements from all blessed replica versions.
+    fn get_replica_version_record(
+        &self,
+        replica_version_id: &ReplicaVersion,
+        version: RegistryVersion,
+    ) -> RegistryClientResult<ReplicaVersionRecord>;
+
+    /// Returns all guest launch measurements from all replica versions.
     ///
-    /// This method fetches the blessed replica versions from the registry at the given version,
-    /// then retrieves the replica version records for each blessed version, and finally collects
-    /// all guest launch measurements from those records.
-    fn get_blessed_guest_launch_measurements(
+    /// This method fetches all replica version records from the registry at
+    /// the given version, and collects all guest launch measurements from
+    /// those records.
+    fn get_guest_launch_measurements(
         &self,
         version: RegistryVersion,
     ) -> Result<Vec<Vec<u8>>, String>;
 }
 
-impl<T: RegistryClient + ?Sized> BlessedReplicaVersionRegistry for T {
-    fn get_blessed_replica_versions(
+impl<T: RegistryClient + ?Sized> ReplicaVersionRegistry for T {
+    fn get_replica_versions(
         &self,
         version: RegistryVersion,
-    ) -> RegistryClientResult<BlessedReplicaVersions> {
-        deserialize_registry_value(self.get_value(&make_blessed_replica_versions_key(), version))
+    ) -> RegistryClientResult<Vec<ReplicaVersionRecord>> {
+        let keys = self.get_key_family(REPLICA_VERSION_KEY_PREFIX, version)?;
+
+        let mut records = Vec::new();
+        for key in keys {
+            let bytes = self.get_value(&key, version);
+            let replica_version_proto =
+                deserialize_registry_value::<ReplicaVersionRecord>(bytes)?.unwrap_or_default();
+            records.push(replica_version_proto)
+        }
+
+        Ok(Some(records))
     }
 
-    fn get_blessed_guest_launch_measurements(
+    fn get_replica_version_record(
+        &self,
+        replica_version_id: &ReplicaVersion,
+        version: RegistryVersion,
+    ) -> RegistryClientResult<ReplicaVersionRecord> {
+        let bytes = self.get_value(&make_replica_version_key(replica_version_id), version);
+        deserialize_registry_value::<ReplicaVersionRecord>(bytes)
+    }
+
+    fn get_guest_launch_measurements(
         &self,
         version: RegistryVersion,
     ) -> Result<Vec<Vec<u8>>, String> {
-        let blessed_replica_versions = self
-            .get_blessed_replica_versions(version)
-            .map_err(|err| format!("Failed to get blessed replica versions: {err}"))?
+        let replica_versions = self
+            .get_replica_versions(version)
+            .map_err(|err| format!("Failed to get replica versions: {err}"))?
             .ok_or_else(|| "Blessed replica versions not found in registry".to_string())?;
 
-        let measurements = blessed_replica_versions
-            .blessed_version_ids
-            .iter()
-            .filter_map(|version_id| ReplicaVersion::from_str(version_id).ok())
-            .filter_map(|replica_version| {
-                self.get_replica_version_record_from_version_id(&replica_version, version)
-                    .ok()
-                    .flatten()
-            })
+        let measurements = replica_versions
+            .into_iter()
             .flat_map(|record| {
                 record
                     .guest_launch_measurements
@@ -102,14 +118,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_blessed_guest_launch_measurements() {
+    fn test_get_guest_launch_measurements() {
         let registry_version = RegistryVersion::from(42);
-        let blessed_versions = ["version1", "version2"];
 
         let measurement1 = [1, 2, 3, 4, 5];
         let measurement2 = [6, 7, 8, 9, 10];
         let measurement3 = [11, 12, 13, 14, 15];
-        let measurement4 = [16, 17, 18, 19, 20]; // From unblessed version
+        let measurement4 = [16, 17, 18, 19, 20]; // From removed version
 
         let replica_versions_and_records = vec![
             (
@@ -127,18 +142,6 @@ mod tests {
         // Set up registry data provider
         let data_provider = ProtoRegistryDataProvider::new();
 
-        // Add blessed replica versions
-        let blessed_versions_proto = BlessedReplicaVersions {
-            blessed_version_ids: blessed_versions.iter().map(|x| x.to_string()).collect(),
-        };
-        data_provider
-            .add(
-                &make_blessed_replica_versions_key(),
-                registry_version,
-                Some(blessed_versions_proto),
-            )
-            .expect("Failed to add blessed replica versions");
-
         // Add replica version records
         for (version_id, record) in &replica_versions_and_records {
             data_provider
@@ -150,12 +153,34 @@ mod tests {
                 .expect("Failed to add replica version record");
         }
 
+        // Later, remove a version
+        data_provider
+            .add(
+                &make_replica_version_key("version3"),
+                registry_version + RegistryVersion::from(1),
+                None::<ReplicaVersionRecord>,
+            )
+            .expect("Failed to remove replica version record");
+
         // Create registry client and update to latest version
         let registry_client = FakeRegistryClient::new(Arc::new(data_provider));
         registry_client.update_to_latest_version();
 
-        let result = registry_client.get_blessed_guest_launch_measurements(registry_version);
+        // Check that all measurements initially existed
+        let result = registry_client.get_guest_launch_measurements(registry_version);
+        assert_eq!(
+            result,
+            Ok(vec![
+                measurement1.to_vec(),
+                measurement2.to_vec(),
+                measurement3.to_vec(),
+                measurement4.to_vec()
+            ])
+        );
 
+        // Check that one is successfully removed, along with the version
+        let result = registry_client
+            .get_guest_launch_measurements(registry_version + RegistryVersion::from(1));
         assert_eq!(
             result,
             Ok(vec![


### PR DESCRIPTION
ReplicaVersionRecords and the blessed versions list are updated in sync, as we no longer require an extra proposal to have each version "blessed".

This moves the GuestOS upgrade tools and registry client helpers to use the list of ReplicaVersionRecords, instead of the blessed versions list, as a step towards removing the redundant blessed versions list entirely.