### PR TITLE
chore: consolidation of security teams

### DIFF
--- a/.github/workflows/team-channels.json
+++ b/.github/workflows/team-channels.json
@@ -7,15 +7,16 @@
     "ic-support": "ic-support-notifications",
     "ic-interface-owners": "interface-owners",
     "ic-owners-owners": "owners-owners",
-    "InfraSec": "eng-infrasec",
+    "InfraSec": "security",
     "languages": "eng-motoko",
     "governance": "eng-nns-prs",
     "node": "eng-node-prs",
     "Platform Operations": "eng-platform-ops",
     "pocket-ic": "pocket-ic",
-    "Product Security": "eng-prodsec",
+    "Product Security": "security",
     "research": "team-research",
     "sdk": "eng-sdk",
+    "Security": "security",
     "team-dsm": "eng-dsm-prs",
     "utopia": "eng-utopia"
 }


### PR DESCRIPTION
We are currently consolidating infrasec/prodsec into one security team and channel. So currently we still have 3 teams, but long-term the plan is to only use "Security".