### PR TITLE
chore(deps): bump urllib3 to 2.7.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -37,7 +37,7 @@ tqdm
 uuid
 # packages not directly used, but required by other packages and need to be manually version pinned for python 3.12
 typing_extensions>=4.6.0
-urllib3>=2.6.3
+urllib3>=2.7.0
 
 # For ci/githubstats/query.py
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -994,9 +994,9 @@ tzdata==2025.3 \
     --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
     --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
     # via pandas
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
     #   -r requirements.in
     #   pygithub

--- a/rs/rosetta-api/examples/icp/python/requirements.txt
+++ b/rs/rosetta-api/examples/icp/python/requirements.txt
@@ -5,4 +5,4 @@ cryptography==46.0.7
 idna==3.10
 pycparser==2.22
 requests==2.33.0
-urllib3==2.6.3
+urllib3==2.7.0

--- a/rs/rosetta-api/examples/icrc1/python/requirements.txt
+++ b/rs/rosetta-api/examples/icrc1/python/requirements.txt
@@ -5,4 +5,4 @@ cryptography==46.0.7
 idna==3.10
 pycparser==2.22
 requests==2.33.0
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION
## Summary
- Bump `urllib3` pin in `requirements.in` from `>=2.6.3` to `>=2.7.0` and regenerate `requirements.txt` via `bazel run //:python-requirements.update`.
- Bump `urllib3` in the two hand-maintained rosetta-api example requirements files (`rs/rosetta-api/examples/{icp,icrc1}/python/requirements.txt`) from `2.6.3` to `2.7.0`.

## Test plan
- [x] CI green