### PR TITLE
chore: Revert "feat: [EXC-1783] No execution overhead on low cycles (#10096)"

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -228,11 +228,11 @@ impl SchedulerImpl {
                 as_num_instructions(instructions_before - round_limits.instructions);
 
             let messages = match execute_subnet_message_result_type {
-                ExecuteSubnetMessageResultType::Finished => NumMessages::new(1),
-                ExecuteSubnetMessageResultType::Processing => NumMessages::new(0),
-                ExecuteSubnetMessageResultType::Paused => NumMessages::new(0),
+                ExecuteSubnetMessageResultType::Finished => NumMessages::from(1),
+                ExecuteSubnetMessageResultType::Processing => NumMessages::from(0),
+                ExecuteSubnetMessageResultType::Paused => NumMessages::from(0),
             };
-            measurement_scope.add(round_instructions_executed, NumSlices::new(1), messages);
+            measurement_scope.add(round_instructions_executed, NumSlices::from(1), messages);
 
             // Break when round limits are reached or found a canister
             // that has a long install code message in progress.
@@ -338,11 +338,11 @@ impl SchedulerImpl {
         let round_instructions_executed =
             as_num_instructions(instructions_before - round_limits.instructions);
         let messages = match execute_subnet_message_result_type {
-            ExecuteSubnetMessageResultType::Finished => NumMessages::new(1),
-            ExecuteSubnetMessageResultType::Processing => NumMessages::new(0),
-            ExecuteSubnetMessageResultType::Paused => NumMessages::new(0),
+            ExecuteSubnetMessageResultType::Finished => NumMessages::from(1),
+            ExecuteSubnetMessageResultType::Processing => NumMessages::from(0),
+            ExecuteSubnetMessageResultType::Paused => NumMessages::from(0),
         };
-        measurement_scope.add(round_instructions_executed, NumSlices::new(1), messages);
+        measurement_scope.add(round_instructions_executed, NumSlices::from(1), messages);
         (new_state, execute_subnet_message_result_type)
     }
 
@@ -430,7 +430,7 @@ impl SchedulerImpl {
 
         let mut ingress_execution_results = Vec::new();
         let mut is_first_iteration = true;
-        let mut total_heap_delta = NumBytes::new(0);
+        let mut total_heap_delta = NumBytes::from(0);
         let mut heartbeat_and_timer_canisters = BTreeSet::new();
 
         // Start iteration loop:
@@ -571,16 +571,13 @@ impl SchedulerImpl {
                 "`subnet_available_callbacks` is a lower bound estimate for the number of available callbacks"
             );
 
-            // Stop iterating if no work was done (no instructions consumed and no system
-            // generated reject responses produced).
-            if instructions_consumed.get() == 0
-                && canisters_with_zero_instruction_executions.is_empty()
-            {
+            if instructions_consumed == RoundInstructions::from(0) {
                 break state;
+            } else {
+                self.metrics
+                    .inner_loop_consumed_non_zero_instructions_count
+                    .inc();
             }
-            self.metrics
-                .inner_loop_processed_non_zero_inputs_count
-                .inc();
 
             if total_heap_delta >= self.config.max_heap_delta_per_iteration {
                 break state;
@@ -715,8 +712,8 @@ impl SchedulerImpl {
         let mut canisters_with_completed_messages = BTreeSet::new();
         let mut canisters_with_zero_instruction_executions = BTreeSet::new();
         let mut ingress_results = Vec::new();
-        let mut max_instructions_executed_per_thread = NumInstructions::new(0);
-        let mut heap_delta = NumBytes::new(0);
+        let mut max_instructions_executed_per_thread = NumInstructions::from(0);
+        let mut heap_delta = NumBytes::from(0);
         let mut callbacks_created = 0;
         for mut result in results_by_thread.into_iter() {
             canisters.append(&mut result.canisters);
@@ -1086,7 +1083,7 @@ impl SchedulerImpl {
         let cost_schedule = state.get_own_cost_schedule();
         match current_round_type {
             ExecutionRoundType::CheckpointRound => {
-                state.metadata.heap_delta_estimate = NumBytes::new(0);
+                state.metadata.heap_delta_estimate = NumBytes::from(0);
                 // The set of compiled Wasms must be cleared when taking a
                 // checkpoint to keep it in sync with the protobuf serialization
                 // of `ReplicatedState` which doesn't store this field.
@@ -1290,7 +1287,7 @@ impl Scheduler for SchedulerImpl {
             );
             let round_instructions = as_round_instructions(self.config.max_instructions_per_round)
                 - as_round_instructions(max_instructions_per_slice)
-                + RoundInstructions::new(1);
+                + RoundInstructions::from(1);
 
             SchedulerRoundLimits {
                 instructions: round_instructions,
@@ -1678,9 +1675,9 @@ fn execute_canisters_on_thread(
     let mut canisters_with_completed_messages = BTreeSet::new();
     let mut canisters_with_zero_instruction_executions = BTreeSet::new();
     let mut ingress_results = vec![];
-    let mut total_slices_executed = NumSlices::new(0);
-    let mut total_messages_executed = NumMessages::new(0);
-    let mut total_heap_delta = NumBytes::new(0);
+    let mut total_slices_executed = NumSlices::from(0);
+    let mut total_messages_executed = NumMessages::from(0);
+    let mut total_heap_delta = NumBytes::from(0);
 
     let instruction_limits = InstructionLimits::new(
         config.max_instructions_per_message,
@@ -1748,15 +1745,14 @@ fn execute_canisters_on_thread(
             // A message was executed iff a non-zero number of instructions was consumed.
             // A paused execution outputs `instructions_used == None` and it also counts as
             // an executed message slice.
-            let mut messages = NumMessages::new(0);
-            let mut slices = NumSlices::new(0);
+            let mut messages = NumMessages::from(0);
             match instructions_used {
                 // Message completed.
                 Some(instructions) => {
                     if instructions.get() > 0 {
                         // Message actually executed.
-                        messages = NumMessages::new(1);
-                        slices = NumSlices::new(1);
+                        messages = NumMessages::from(1);
+                        total_slices_executed.inc_assign();
                         executed_canisters.insert(new_canister.canister_id());
                         canisters_with_completed_messages.insert(new_canister.canister_id());
                         total_instructions_used += instructions;
@@ -1777,21 +1773,16 @@ fn execute_canisters_on_thread(
                 }
                 // Paused execution.
                 None => {
-                    slices = NumSlices::new(1);
+                    total_slices_executed.inc_assign();
                     executed_canisters.insert(new_canister.canister_id());
                 }
             }
-            measurement_scope.add(round_instructions_executed, slices, messages);
+            measurement_scope.add(round_instructions_executed, NumSlices::from(1), messages);
             total_messages_executed += messages;
-            total_slices_executed += slices;
-            if slices.get() > 0 {
-                // A slice was actually executed, count the execution overhead toward the round limit.
-                round_limits.instructions -=
-                    as_round_instructions(config.instruction_overhead_per_execution);
-            }
-
             canister_arc = new_canister;
             canister = Arc::make_mut(&mut canister_arc);
+            round_limits.instructions -=
+                as_round_instructions(config.instruction_overhead_per_execution);
             total_heap_delta += heap_delta;
             if rate_limiting_of_heap_delta == FlagStatus::Enabled {
                 canister.scheduler_state.heap_delta_debit += heap_delta;
@@ -1928,7 +1919,7 @@ fn get_instruction_limits_for_subnet_message(
 ) -> InstructionLimits {
     // The default limits are unused since instruction limits only matter
     // for install code in which case the default limits are overriden.
-    let default_limits = InstructionLimits::new(NumInstructions::new(0), NumInstructions::new(0));
+    let default_limits = InstructionLimits::new(NumInstructions::from(0), NumInstructions::from(0));
     let method_name = match &msg {
         SubnetMessage::Response { .. } => {
             return default_limits;

--- a/rs/execution_environment/src/scheduler/scheduler_metrics.rs
+++ b/rs/execution_environment/src/scheduler/scheduler_metrics.rs
@@ -29,7 +29,7 @@ pub struct SchedulerMetrics {
     pub(super) expired_ingress_messages_count: IntCounter,
     pub(super) round_skipped_due_to_current_heap_delta_above_limit: IntCounter,
     pub(super) execute_round_called: IntCounter,
-    pub(super) inner_loop_processed_non_zero_inputs_count: IntCounter,
+    pub(super) inner_loop_consumed_non_zero_instructions_count: IntCounter,
     pub(super) inner_round_loop_consumed_max_instructions: IntCounter,
     pub(super) num_canisters_uninstalled_out_of_cycles: IntCounter,
     pub(super) round: ScopedMetrics,
@@ -147,9 +147,9 @@ impl SchedulerMetrics {
             // allows one to estimate how often we manage to execute multiple
             // loops of inner_round(), i.e. how often we manage to successfully
             // induct messages on the same subnet and make progress on them.
-            inner_loop_processed_non_zero_inputs_count: metrics_registry.int_counter(
-                "inner_loop_processed_non_zero_inputs_count",
-                "The number of times inner_round()'s loop processed at least 1 canister input.",
+            inner_loop_consumed_non_zero_instructions_count: metrics_registry.int_counter(
+                "inner_loop_consumed_non_zero_instructions_count",
+                "The number of times inner_round()'s loop consumed at least 1 instruction.",
             ),
             inner_round_loop_consumed_max_instructions: metrics_registry.int_counter(
                 "inner_round_loop_consumed_max_instructions",

--- a/rs/execution_environment/src/scheduler/tests/limits.rs
+++ b/rs/execution_environment/src/scheduler/tests/limits.rs
@@ -4,7 +4,7 @@ use super::super::test_utilities::{
     SchedulerTestBuilder, TestInstallCode, ingress, instructions, on_response, other_side,
 };
 use super::super::*;
-use super::zero_instruction_overhead_config;
+use super::{zero_instruction_messages, zero_instruction_overhead_config};
 use crate::scheduler::test_utilities::EMPTY_WASM;
 use ic_config::subnet_config::SchedulerConfig;
 use ic_replicated_state::testing::CanisterQueuesTesting;
@@ -93,7 +93,12 @@ fn inner_loop_stops_when_max_instructions_per_round_consumed() {
     let metrics = &test.scheduler().metrics;
     assert_eq!(metrics.execute_round_called.get(), 1);
     assert_eq!(metrics.inner_round_loop_consumed_max_instructions.get(), 1);
-    assert_eq!(metrics.inner_loop_processed_non_zero_inputs_count.get(), 1);
+    assert_eq!(
+        metrics
+            .inner_loop_consumed_non_zero_instructions_count
+            .get(),
+        1
+    );
 
     assert_eq!(
         test.state()
@@ -118,7 +123,7 @@ fn test_message_limit_from_message_overhead() {
         max_instructions_per_slice: NumInstructions::from(5_000_000_000),
         max_instructions_per_install_code_slice: NumInstructions::from(5_000_000_000),
         max_instructions_per_round: NumInstructions::from(7_000_000_000),
-        instruction_overhead_per_execution: NumInstructions::from(1_999_999),
+        instruction_overhead_per_execution: NumInstructions::from(2_000_000),
         instruction_overhead_per_canister: NumInstructions::from(0),
         instruction_overhead_per_canister_for_finalization: NumInstructions::from(0),
         ..SchedulerConfig::application_subnet()
@@ -142,7 +147,7 @@ fn test_message_limit_from_message_overhead() {
         + 1;
 
     let mut callee = canister0;
-    let mut call = other_side(callee, 1);
+    let mut call = other_side(callee, 0);
 
     for _ in 0..expected_number_of_messages * 3 {
         callee = if callee == canister1 {
@@ -150,28 +155,26 @@ fn test_message_limit_from_message_overhead() {
         } else {
             canister1
         };
-        call = other_side(callee, 1).call(call, on_response(1));
+        call = other_side(callee, 0).call(call, on_response(0));
     }
 
-    let message = ingress(1).call(call, on_response(1));
+    let message = ingress(0).call(call, on_response(0));
     test.send_ingress(canister0, message);
 
     test.execute_round(ExecutionRoundType::OrdinaryRound);
 
-    // The expected number of messages were executed.
+    // All messages are zero instruction messages.
     assert_eq!(
-        test.scheduler()
-            .metrics
-            .msg_execution_duration
-            .get_sample_count(),
+        zero_instruction_messages(test.metrics_registry()),
         expected_number_of_messages
     );
+
     assert_eq!(
         test.state()
             .metadata
             .subnet_metrics
             .update_transactions_total,
-        expected_number_of_messages
+        0
     );
     assert_eq!(test.state().metadata.subnet_metrics.num_canisters, 2);
 }
@@ -614,7 +617,9 @@ fn finalization_overhead_per_canister_reduces_instruction_budget() {
 
         let metrics = &test.scheduler().metrics;
         assert_eq!(
-            metrics.inner_loop_processed_non_zero_inputs_count.get(),
+            metrics
+                .inner_loop_consumed_non_zero_instructions_count
+                .get(),
             expected_iterations,
         );
         assert_eq!(
@@ -894,7 +899,12 @@ fn subnet_available_memory_is_refreshed_between_iterations() {
     //   iter 1 — A processes 2 ingress (20 instr on core 0)
     //   iter 2 — A processes 2 calls, B processes 2 calls (20 instr per core)
     let metrics = &test.scheduler().metrics;
-    assert_eq!(metrics.inner_loop_processed_non_zero_inputs_count.get(), 2);
+    assert_eq!(
+        metrics
+            .inner_loop_consumed_non_zero_instructions_count
+            .get(),
+        2
+    );
 
     // 6 messages executed in total: 2 ingress + 4 calls (2 succeed, 2 fail).
     assert_eq!(metrics.round_inner.messages.get_sample_sum(), 6.0);

--- a/rs/execution_environment/src/scheduler/tests/rate_limiting.rs
+++ b/rs/execution_environment/src/scheduler/tests/rate_limiting.rs
@@ -434,7 +434,7 @@ fn canister_can_run_for_multiple_iterations() {
     assert_eq!(
         test.scheduler()
             .metrics
-            .inner_loop_processed_non_zero_inputs_count
+            .inner_loop_consumed_non_zero_instructions_count
             .get(),
         6
     );

--- a/rs/execution_environment/src/scheduler/tests/scheduling.rs
+++ b/rs/execution_environment/src/scheduler/tests/scheduling.rs
@@ -89,7 +89,12 @@ fn inner_loop_stops_when_no_instructions_consumed() {
     let metrics = &test.scheduler().metrics;
     assert_eq!(metrics.execute_round_called.get(), 1);
     assert_eq!(metrics.inner_round_loop_consumed_max_instructions.get(), 0);
-    assert_eq!(metrics.inner_loop_processed_non_zero_inputs_count.get(), 1);
+    assert_eq!(
+        metrics
+            .inner_loop_consumed_non_zero_instructions_count
+            .get(),
+        1
+    );
 
     assert_eq!(
         test.state()
@@ -135,7 +140,12 @@ fn test_multiple_iterations_of_inner_loop() {
         3
     );
     assert_eq!(metrics.inner_round_loop_consumed_max_instructions.get(), 0);
-    assert_eq!(metrics.inner_loop_processed_non_zero_inputs_count.get(), 3);
+    assert_eq!(
+        metrics
+            .inner_loop_consumed_non_zero_instructions_count
+            .get(),
+        3
+    );
 
     assert_eq!(
         test.state()
@@ -145,62 +155,6 @@ fn test_multiple_iterations_of_inner_loop() {
         3
     );
     assert_eq!(test.state().metadata.subnet_metrics.num_canisters, 2);
-}
-
-/// Ensures that `inner_round()` continues with another iteration after the
-/// previous iteration only processed messages that got rejected (e.g. because
-/// the callee was low on cycles), with zero Wasm instructions executed.
-#[test]
-fn inner_loop_continues_after_zero_instructions_iteration() {
-    let mut test = SchedulerTestBuilder::new()
-        .with_scheduler_config(SchedulerConfig::application_subnet())
-        .build();
-
-    // Two canisters:
-    //   - canister A (well funded) makes a call to canister B;
-    //   - canister B (low on cycles) cannot execute the incoming request, which is
-    //     rejected without executing any Wasm.
-    let canister_a = test.create_canister();
-    let canister_b = test.create_canister_with(
-        // Too few cycles to execute the incoming request.
-        Cycles::new(1),
-        ComputeAllocation::zero(),
-        MemoryAllocation::default(),
-        None,
-        None,
-        None,
-    );
-    let message = ingress(50).call(other_side(canister_b, 50), on_response(50));
-    test.send_ingress(canister_a, message);
-
-    test.execute_round(ExecutionRoundType::OrdinaryRound);
-
-    // Expecting the full call tree to complete within one round:
-    //   - Iteration 1: A executes an ingress message that produces a request for B.
-    //   - Iteration 2: B cannot pay for executing the request so the DSM produces a
-    //                  reject response with no Wasm execution (zero instructions).
-    //   - Iteration 3: A executes the reject response.
-    //
-    // One round, 3 iterations that processed at least one input each.
-    let metrics = &test.scheduler().metrics;
-    assert_eq!(metrics.execute_round_called.get(), 1);
-    assert_eq!(metrics.inner_loop_processed_non_zero_inputs_count.get(), 3);
-
-    // Only A actually executed messages (the ingress and the reject response).
-    assert_eq!(
-        test.state()
-            .metadata
-            .subnet_metrics
-            .update_transactions_total,
-        2
-    );
-
-    // Neither canister should have any inputs or outputs.
-    for canister in [canister_a, canister_b] {
-        let queues = test.canister_state(canister).system_state.queues();
-        assert_eq!(queues.input_queues_message_count(), 0);
-        assert_eq!(queues.output_queues_message_count(), 0);
-    }
 }
 
 #[test]
@@ -1059,12 +1013,12 @@ fn frozen_canisters_are_fully_executed() {
         .with_scheduler_config(SchedulerConfig {
             scheduler_cores,
             max_instructions_per_round: (2 * slice).into(),
-            max_instructions_per_message: (10 * slice).into(),
+            max_instructions_per_message: slice.into(),
             max_instructions_per_slice: slice.into(),
             max_instructions_per_install_code_slice: slice.into(),
-            // Charge for every message execution more than the round limit, to ensure that.
-            // the overhead does not apply to executions skipped due to low cycles.
-            instruction_overhead_per_execution: (3 * slice).into(),
+            // Charge for every message execution enough to execute all but one canister on
+            // each core. And to prevent a second iteration.
+            instruction_overhead_per_execution: (slice / (canisters_per_core - 1) + 1).into(),
             instruction_overhead_per_canister: 0.into(),
             instruction_overhead_per_canister_for_finalization: 0.into(),
             ..SchedulerConfig::application_subnet()
@@ -1087,41 +1041,43 @@ fn frozen_canisters_are_fully_executed() {
             None,
         );
         test.send_ingress(frozen_canister_id, ingress(slice * 10));
-        // Give each canister enough AP to be able to observe charging without free
-        // compute distribution.
-        test.state_mut()
-            .canister_priority_mut(frozen_canister_id)
-            .accumulated_priority = ONE_HUNDRED_PERCENT * 2;
         canisters.push(frozen_canister_id);
     }
 
     test.execute_round(ExecutionRoundType::OrdinaryRound);
 
-    // All canisters were "executed".
+    // All but 2 canisters were "executed".
     assert_eq!(
         test.scheduler()
             .metrics
             .instructions_consumed_per_message
             .get_sample_count(),
-        canisters_per_core * 2
-    );
-    assert_eq!(
-        zero_instruction_messages(test.metrics_registry()),
-        canisters_per_core * 2
+        (canisters_per_core - 1) * 2
     );
 
+    let canister_priority = |canister_id: &CanisterId| -> &ic_replicated_state::CanisterPriority {
+        test.state().canister_priority(canister_id)
+    };
     for (i, canister) in canisters.iter().enumerate() {
-        assert!(
-            test.was_fully_executed(*canister),
-            "Canister {i} should have been fully executed",
-        );
-        assert_eq!(
-            test.state()
-                .canister_priority(canister)
-                .accumulated_priority,
-            ONE_HUNDRED_PERCENT,
-            "Canister {i} should have been charged"
-        );
+        if (i as u64) < (canisters_per_core - 1) * 2 {
+            assert!(
+                test.was_fully_executed(*canister),
+                "Canister {i} should have been fully executed",
+            );
+            assert!(
+                canister_priority(canister).accumulated_priority.get() < 0,
+                "Canister {i} should have been charged"
+            );
+        } else {
+            assert!(
+                !test.was_fully_executed(*canister),
+                "Canister {i} should not have been executed",
+            );
+            assert!(
+                canister_priority(canister).accumulated_priority.get() > 0,
+                "Canister {i} should not have been charged"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
This temporarily reverts commit dc3040c3f90cd85dff5a68fa11796cf6045a0d7c.

That change introduced a potential issue with the OnLowWasmMemory hook. Until we find the most appropriate fix that retains the intended semantics, revert to the previous behavior.