### PR TITLE
fix(sns): Reduce heap memory usage in SNS governance

### DIFF
--- a/rs/sns/governance/src/governance.rs
+++ b/rs/sns/governance/src/governance.rs
@@ -944,9 +944,6 @@ impl Governance {
             .expect("Neuron must have a NeuronId")
             .clone();
 
-        // New neurons are not allowed when the heap is too large.
-        self.check_heap_can_grow()?;
-
         // New neurons are not allowed when the maximum configured is reached
         self.check_neuron_population_can_grow()?;
 
@@ -1295,9 +1292,6 @@ impl Governance {
         caller: &PrincipalId,
         split: &manage_neuron::Split,
     ) -> Result<NeuronId, GovernanceError> {
-        // New neurons are not allowed when the heap is too large.
-        self.check_heap_can_grow()?;
-
         let min_stake = self
             .proto
             .parameters
@@ -4439,6 +4433,15 @@ impl Governance {
             return ClaimSwapNeuronsResponse::new_with_error(ClaimSwapNeuronsError::Unauthorized);
         }
 
+        if let Err(err) = self.check_heap_can_grow() {
+            log!(
+                ERROR,
+                "Could not claim_swap_neurons due to heap growth limits. Err: {}",
+                err.error_message,
+            );
+            return ClaimSwapNeuronsResponse::new_with_error(ClaimSwapNeuronsError::Internal);
+        }
+
         // Validate NervousSystemParameters and it's underlying parameters.
         match self
             .proto
@@ -4791,6 +4794,10 @@ impl Governance {
                 command: Some(command.into()),
             },
         )?;
+
+        if !command.allowed_when_resources_are_low() {
+            self.check_heap_can_grow()?;
+        }
 
         use manage_neuron::Command as C;
         match command {
@@ -6077,7 +6084,7 @@ impl Governance {
             // At this point, we no longer need ballots for either of these
             // things, and since they take up a fair amount of space, we take
             // this opportunity to jettison them.
-            p.ballots.clear();
+            p.ballots = BTreeMap::new();
         }
 
         // Conclude this round of rewards.

--- a/rs/sns/governance/src/types.rs
+++ b/rs/sns/governance/src/types.rs
@@ -1480,6 +1480,16 @@ impl manage_neuron::Command {
         }
         .to_string()
     }
+
+    // Currently, the only thing that's allowed is proposals. I.e. making them, and voting on
+    // them. These are allowed, because they can be used to recover (e.g. from low on free
+    // memory).
+    pub fn allowed_when_resources_are_low(&self) -> bool {
+        matches!(
+            self,
+            manage_neuron::Command::MakeProposal(_) | manage_neuron::Command::RegisterVote(_)
+        )
+    }
 }
 
 impl ManageNeuronResponse {
@@ -1754,6 +1764,7 @@ impl Action {
             Action::UpgradeSnsControlledCanister(_) => true,
             // Due to possible need of an emergency upgrade of the SNS
             Action::UpgradeSnsToNextVersion(_) => true,
+            Action::AdvanceSnsTargetVersion(_) => true,
             // Due to possible need of emergency functions defined as
             // GenericNervousSystemFunctions
             Action::ExecuteGenericNervousSystemFunction(_) => true,

--- a/rs/sns/governance/unreleased_changelog.md
+++ b/rs/sns/governance/unreleased_changelog.md
@@ -17,4 +17,10 @@ on the process that this file is part of, see
 
 ## Fixed
 
+- Heap memory optimizations: proposal ballots now release their underlying
+  capacity after reward distribution, and `check_heap_can_grow` is enforced
+  more broadly across `manage_neuron` commands (except `MakeProposal` /
+  `RegisterVote`, which must remain available to recover from low-resource
+  situations), `claim_swap_neurons`, and non-emergency proposal validation.
+
 ## Security


### PR DESCRIPTION
## Summary

Two adjustments to optimize SNS governance heap usage.

### Free ballot capacity after reward distribution

Once a proposal reward round is complete, the proposal `ballots` map is jettisoned — but `BTreeMap::clear()` only removes entries while keeping the underlying capacity allocated, so the memory was not actually released. Replacing the field with `BTreeMap::new()` deallocates the backing storage.

### Broaden `check_heap_can_grow` coverage

`check_heap_can_grow` is now enforced in more places, so the canister rejects new allocations earlier when it is close to its heap limit:

1. Every `manage_neuron` command except `MakeProposal` and `RegisterVote`. These two must stay available so the SNS can vote on a recovery proposal even when heap is tight.
2. `claim_swap_neurons`, mirroring the check that used to live in `add_neuron`.
3. Non-emergency proposal validation, including the new `AdvanceSnsTargetVersion` action (successor of `UpgradeSnsToNextVersion`).

The check is removed from `add_neuron` and `split_neuron` because both are now covered transitively: `split_neuron` is only called from `manage_neuron`, and `add_neuron` is only called from `split_neuron`, `claim_neuron` (also under `manage_neuron`), and `claim_swap_neurons` (covered directly).

