### PR TITLE
feat: [EXC-1783] Prepay potential `OnLowWasmMemory` hook executions

### DIFF
--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -498,6 +498,87 @@ impl CyclesAccountManager {
         .map(|_| cost)
     }
 
+    /// Like [`Self::prepay_execution_cycles`], but additionally prepays for a
+    /// worst-case `OnLowWasmMemory` hook execution. The freezing-threshold
+    /// check accounts for both prepayments as a single atomic deduction, so
+    /// that a canister with a low-memory hook can never enter a state where
+    /// it has enough cycles to run the message but not the hook that the
+    /// message may have triggered.
+    ///
+    /// Returns a tuple `(message_prepayment, hook_reservation)`. The caller
+    /// owns both `CompoundCycles<Instructions>` values:
+    ///
+    /// - `message_prepayment` is refunded via
+    ///   [`Self::refund_unused_execution_cycles`] after the message executes
+    ///   (exactly as for [`Self::prepay_execution_cycles`]).
+    /// - `hook_reservation` is either:
+    ///   - handed to
+    ///     [`TaskQueue::enqueue_on_low_wasm_memory_hook`](ic_replicated_state::canister_state::system_state::task_queue::TaskQueue::enqueue_on_low_wasm_memory_hook)
+    ///     to fund a newly-armed hook execution, in which case its eventual
+    ///     leftover is refunded when the hook task itself runs; or
+    ///   - refunded to the canister balance via
+    ///     [`SystemState::refund_cycles`] if the hook is already enqueued
+    ///     (a previous message already funded it) or if the memory condition
+    ///     is not satisfied after this message.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `CanisterOutOfCyclesError` if the canister cannot pay for
+    /// both the message and the hook prepayment without dropping below the
+    /// freezing threshold.
+    pub fn prepay_execution_cycles_with_hook_reservation(
+        &self,
+        system_state: &mut SystemState,
+        canister_current_memory_usage: NumBytes,
+        canister_current_message_memory_usage: MessageMemoryUsage,
+        canister_compute_allocation: ComputeAllocation,
+        message_num_instructions: NumInstructions,
+        hook_num_instructions: NumInstructions,
+        subnet_size: usize,
+        cost_schedule: CanisterCyclesCostSchedule,
+        reveal_top_up: bool,
+        execution_mode: WasmExecutionMode,
+    ) -> Result<
+        (
+            CompoundCycles<Instructions>,
+            CompoundCycles<Instructions>,
+        ),
+        CanisterOutOfCyclesError,
+    > {
+        let message_cost = self.execution_cost(
+            message_num_instructions,
+            subnet_size,
+            cost_schedule,
+            execution_mode,
+        );
+        let hook_cost = self.execution_cost(
+            hook_num_instructions,
+            subnet_size,
+            cost_schedule,
+            execution_mode,
+        );
+        // Sum the two `CompoundCycles<Instructions>` values (both `real` and
+        // `nominal`) so the freezing-threshold check and the consumed-cycles
+        // bookkeeping see a single atomic deduction.
+        let total = message_cost + hook_cost;
+        self.consume_with_threshold(
+            system_state,
+            total,
+            self.freeze_threshold_cycles(
+                system_state.freeze_threshold,
+                system_state.memory_allocation,
+                canister_current_memory_usage,
+                canister_current_message_memory_usage,
+                canister_compute_allocation,
+                subnet_size,
+                cost_schedule,
+                system_state.reserved_balance(),
+            ),
+            reveal_top_up,
+        )?;
+        Ok((message_cost, hook_cost))
+    }
+
     /// Checks whether the canister has enough cycles to prepay the execution of a
     /// message with the given maximum number of instructions while respecting the
     /// freezing threshold.

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -539,10 +539,7 @@ impl CyclesAccountManager {
         reveal_top_up: bool,
         execution_mode: WasmExecutionMode,
     ) -> Result<
-        (
-            CompoundCycles<Instructions>,
-            CompoundCycles<Instructions>,
-        ),
+        (CompoundCycles<Instructions>, CompoundCycles<Instructions>),
         CanisterOutOfCyclesError,
     > {
         let message_cost = self.execution_cost(

--- a/rs/cycles_account_manager/tests/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/tests/cycles_account_manager.rs
@@ -1074,6 +1074,103 @@ fn withdraw_execution_cycles_consumes_cycles() {
 }
 
 #[test]
+fn prepay_execution_cycles_with_hook_reservation_charges_both_portions() {
+    let cost_schedule = CanisterCyclesCostSchedule::Normal;
+    let subnet_size = SMALL_APP_SUBNET_MAX_SIZE;
+    let cycles_account_manager = CyclesAccountManagerBuilder::new()
+        .with_subnet_type(SubnetType::Application)
+        .build();
+    let message_instructions = NumInstructions::from(2_000_000);
+    let hook_instructions = NumInstructions::from(500_000);
+
+    // Reference: what would each portion cost in isolation.
+    let expected_msg = cycles_account_manager.execution_cost(
+        message_instructions,
+        subnet_size,
+        cost_schedule,
+        WASM_EXECUTION_MODE,
+    );
+    let expected_hook = cycles_account_manager.execution_cost(
+        hook_instructions,
+        subnet_size,
+        cost_schedule,
+        WASM_EXECUTION_MODE,
+    );
+
+    let mut system_state = SystemStateBuilder::new().build();
+    let balance_before = system_state.balance();
+
+    let (msg_prepay, hook_reservation) = cycles_account_manager
+        .prepay_execution_cycles_with_hook_reservation(
+            &mut system_state,
+            NumBytes::from(0),
+            MessageMemoryUsage::ZERO,
+            ComputeAllocation::default(),
+            message_instructions,
+            hook_instructions,
+            subnet_size,
+            cost_schedule,
+            false,
+            WASM_EXECUTION_MODE,
+        )
+        .unwrap();
+
+    // Each returned portion matches what a standalone `execution_cost` call
+    // would yield. The two portions are charged together as a single deduction
+    // from the balance.
+    assert_eq!(msg_prepay, expected_msg);
+    assert_eq!(hook_reservation, expected_hook);
+    assert_eq!(
+        balance_before - system_state.balance(),
+        (expected_msg + expected_hook).real(),
+    );
+}
+
+#[test]
+fn prepay_execution_cycles_with_hook_reservation_is_atomic_on_insufficient_funds() {
+    let cost_schedule = CanisterCyclesCostSchedule::Normal;
+    let subnet_size = SMALL_APP_SUBNET_MAX_SIZE;
+    let cycles_account_manager = CyclesAccountManagerBuilder::new()
+        .with_subnet_type(SubnetType::Application)
+        .build();
+    let message_instructions = NumInstructions::from(2_000_000);
+    let hook_instructions = NumInstructions::from(2_000_000);
+
+    let msg_cost = cycles_account_manager.execution_cost(
+        message_instructions,
+        subnet_size,
+        cost_schedule,
+        WASM_EXECUTION_MODE,
+    );
+
+    // Fund the canister with exactly enough to cover the message alone but
+    // not the message plus the hook reservation.
+    let mut system_state = SystemStateBuilder::new()
+        .initial_cycles(msg_cost.real() + Cycles::new(1))
+        .build();
+    let balance_before = system_state.balance();
+
+    let err = cycles_account_manager
+        .prepay_execution_cycles_with_hook_reservation(
+            &mut system_state,
+            NumBytes::from(0),
+            MessageMemoryUsage::ZERO,
+            ComputeAllocation::default(),
+            message_instructions,
+            hook_instructions,
+            subnet_size,
+            cost_schedule,
+            false,
+            WASM_EXECUTION_MODE,
+        )
+        .unwrap_err();
+    assert!(matches!(err, CanisterOutOfCyclesError { .. }));
+    // Nothing should have been deducted: the message prepay alone would have
+    // succeeded, so this exercises the atomicity of the joint check.
+    assert_eq!(system_state.balance(), balance_before);
+}
+
+#[test]
 fn withdraw_for_transfer_does_not_consume_cycles() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
     let system_state = SystemStateBuilder::new().build();

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -436,9 +436,8 @@ impl SystemStateModifications {
             // Note: this path is currently never exercised because Wasm
             // memory growth is monotonic. We still refund a stale reservation
             // if it somehow exists to keep the invariant tight.
-            if let Some(stale_reservation) = system_state
-                .task_queue
-                .dequeue_on_low_wasm_memory_hook()
+            if let Some(stale_reservation) =
+                system_state.task_queue.dequeue_on_low_wasm_memory_hook()
             {
                 system_state.refund_cycles(stale_reservation, stale_reservation);
             }

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -24,7 +24,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::execution_state::WasmExecutionMode;
 use ic_replicated_state::canister_state::system_state::is_low_wasm_memory_hook_condition_satisfied;
 use ic_replicated_state::{
-    CallOrigin, ExecutionTask, NetworkTopology, SystemState, canister_state::DEFAULT_QUEUE_CAPACITY,
+    CallOrigin, NetworkTopology, SystemState, canister_state::DEFAULT_QUEUE_CAPACITY,
 };
 use ic_types::canister_log::CanisterLogMetrics;
 use ic_types::{
@@ -423,17 +423,24 @@ impl SystemStateModifications {
         self.validate_cycle_change(system_state.canister_id() == CYCLES_MINTING_CANISTER_ID)?;
         self.apply_balance_changes(system_state);
 
-        if let Some(hook_condition_check_result) =
-            self.on_low_wasm_memory_hook_condition_check_result
-        {
-            if hook_condition_check_result {
-                system_state
-                    .task_queue
-                    .enqueue(ExecutionTask::OnLowWasmMemory);
-            } else {
-                system_state
-                    .task_queue
-                    .remove(ExecutionTask::OnLowWasmMemory);
+        if let Some(false) = self.on_low_wasm_memory_hook_condition_check_result {
+            // The enqueue direction is intentionally not handled here.
+            // Enqueueing the `OnLowWasmMemory` hook requires a prepayment, which lives
+            // with the orchestrating execution path (see
+            // `crate::execute_call_or_task` and friends): the orchestrator
+            // reads `on_low_wasm_memory_hook_condition_check_result` after
+            // `apply_changes` to decide whether to enqueue or refund the hook
+            // prepayment. Here we only handle the dequeue direction so that
+            // a stale hook reservation does not linger past a memory shrink.
+            //
+            // Note: this path is currently never exercised because Wasm
+            // memory growth is monotonic. We still refund a stale reservation
+            // if it somehow exists to keep the invariant tight.
+            if let Some(stale_reservation) = system_state
+                .task_queue
+                .dequeue_on_low_wasm_memory_hook()
+            {
+                system_state.refund_cycles(stale_reservation, stale_reservation);
             }
         }
 

--- a/rs/execution_environment/benches/system_api/execute_update.rs
+++ b/rs/execution_environment/benches/system_api/execute_update.rs
@@ -1209,6 +1209,7 @@ pub fn execute_update_bench(c: &mut Criterion) {
                 execution_parameters.instruction_limits.message(),
                 CanisterMessageOrTask::Message(ingress),
                 None,
+                None,
                 time,
                 network_topology,
                 &mut round_limits,

--- a/rs/execution_environment/benches/wasm_instructions/main.rs
+++ b/rs/execution_environment/benches/wasm_instructions/main.rs
@@ -71,6 +71,7 @@ pub fn wasm_instructions_bench(c: &mut Criterion) {
                 execution_parameters.instruction_limits.message(),
                 CanisterMessageOrTask::Message(ingress),
                 None,
+                None,
                 time,
                 network_topology,
                 &mut round_limits,

--- a/rs/execution_environment/src/execution/call_or_task.rs
+++ b/rs/execution_environment/src/execution/call_or_task.rs
@@ -164,12 +164,7 @@ pub fn execute_call_or_task(
                         );
                     }
                 };
-                (
-                    canister,
-                    prepaid_execution_cycles,
-                    hook_reservation,
-                    false,
-                )
+                (canister, prepaid_execution_cycles, hook_reservation, false)
             }
         };
 
@@ -767,8 +762,7 @@ impl CallOrTaskHelper {
         // fired for the current memory-limit crossing), it returns the
         // supplied reservation back for refund.
         if let Some(hook_reservation) = original.hook_reservation {
-            let should_enqueue = wasm_result_is_ok
-                && hook_condition_check_result == Some(true);
+            let should_enqueue = wasm_result_is_ok && hook_condition_check_result == Some(true);
             let leftover = if should_enqueue {
                 self.canister
                     .system_state

--- a/rs/execution_environment/src/execution/call_or_task.rs
+++ b/rs/execution_environment/src/execution/call_or_task.rs
@@ -43,6 +43,7 @@ pub fn execute_call_or_task(
     call_or_task: CanisterCallOrTask,
     method: WasmMethod,
     prepaid_execution_cycles: Option<CompoundCycles<Instructions>>,
+    prepaid_hook_reservation: Option<CompoundCycles<Instructions>>,
     execution_parameters: ExecutionParameters,
     time: Time,
     round: RoundContext,
@@ -52,9 +53,29 @@ pub fn execute_call_or_task(
     log_dirty_pages: FlagStatus,
     deallocation_sender: &DeallocationSender,
 ) -> ExecuteMessageResult {
-    let (clean_canister, prepaid_execution_cycles, resuming_aborted) =
+    // A caller-supplied hook reservation only makes sense alongside a
+    // caller-supplied message prepayment (i.e. when resuming an aborted
+    // execution). Fresh calls do their own joint prepayment below.
+    debug_assert!(
+        prepaid_execution_cycles.is_some() || prepaid_hook_reservation.is_none(),
+        "prepaid_hook_reservation requires prepaid_execution_cycles",
+    );
+
+    let (clean_canister, prepaid_execution_cycles, hook_reservation, resuming_aborted) =
         match prepaid_execution_cycles {
-            Some(prepaid_execution_cycles) => (clean_canister, prepaid_execution_cycles, true),
+            // Resumed aborted executions and the `OnLowWasmMemory` task itself
+            // arrive with their own prepayment already in hand. For aborted
+            // executions, the hook reservation (if the original message
+            // charged one) was preserved inside the `AbortedExecution` task
+            // and is now passed back in via `prepaid_hook_reservation`. For
+            // the `OnLowWasmMemory` task itself, no further hook reservation
+            // is held (its own prepayment IS the reservation).
+            Some(prepaid_execution_cycles) => (
+                clean_canister,
+                prepaid_execution_cycles,
+                prepaid_hook_reservation,
+                true,
+            ),
             None => {
                 let mut canister = clean_canister;
                 let memory_usage = canister.memory_usage();
@@ -69,37 +90,69 @@ pub fn execute_call_or_task(
                     .as_ref()
                     .map_or(WasmExecutionMode::Wasm32, |es| es.wasm_execution_mode);
 
-                let prepaid_execution_cycles = match round
-                    .cycles_account_manager
-                    .prepay_execution_cycles(
-                        &mut canister.system_state,
-                        memory_usage,
-                        message_memory_usage,
-                        execution_parameters.compute_allocation,
-                        execution_parameters.instruction_limits.message(),
-                        subnet_size,
-                        round.cost_schedule,
-                        reveal_top_up,
-                        wasm_execution_mode,
-                    ) {
-                    Ok(cycles) => cycles,
+                // Charge the hook reservation alongside the message prepayment
+                // for canisters that export `canister_on_low_wasm_memory` and
+                // whose replicated message may cause Wasm memory to grow past
+                // the threshold (i.e. updates, heartbeat, global timer). Query
+                // execution does not persist state changes, so it cannot
+                // enqueue the hook; we therefore skip the joint prepay for
+                // queries.
+                let charge_hook_reservation = canister.exports_on_low_wasm_memory()
+                    && matches!(
+                        call_or_task,
+                        CanisterCallOrTask::Update(_)
+                            | CanisterCallOrTask::Task(
+                                CanisterTask::Heartbeat | CanisterTask::GlobalTimer
+                            ),
+                    );
+
+                let prepay_result = if charge_hook_reservation {
+                    round
+                        .cycles_account_manager
+                        .prepay_execution_cycles_with_hook_reservation(
+                            &mut canister.system_state,
+                            memory_usage,
+                            message_memory_usage,
+                            execution_parameters.compute_allocation,
+                            execution_parameters.instruction_limits.message(),
+                            execution_parameters.instruction_limits.message(),
+                            subnet_size,
+                            round.cost_schedule,
+                            reveal_top_up,
+                            wasm_execution_mode,
+                        )
+                        .map(|(msg, hook)| (msg, Some(hook)))
+                } else {
+                    round
+                        .cycles_account_manager
+                        .prepay_execution_cycles(
+                            &mut canister.system_state,
+                            memory_usage,
+                            message_memory_usage,
+                            execution_parameters.compute_allocation,
+                            execution_parameters.instruction_limits.message(),
+                            subnet_size,
+                            round.cost_schedule,
+                            reveal_top_up,
+                            wasm_execution_mode,
+                        )
+                        .map(|msg| (msg, None))
+                };
+
+                let (prepaid_execution_cycles, hook_reservation) = match prepay_result {
+                    Ok(prepaid) => prepaid,
                     Err(err) => {
-                        if call_or_task == CanisterCallOrTask::Task(CanisterTask::OnLowWasmMemory) {
-                            //`OnLowWasmMemoryHook` is taken from task_queue (i.e. `OnLowWasmMemoryHookStatus` is `Executed`),
-                            // but it was not executed due to the freezing of the canister. To ensure that the hook is executed
-                            // when the canister is unfrozen we need to set `OnLowWasmMemoryHookStatus` to `Ready`. Because of
-                            // the way `OnLowWasmMemoryHookStatus::update` is implemented we first need to remove it from the
-                            // task_queue (which calls `OnLowWasmMemoryHookStatus::update(false)`) followed with `enqueue`
-                            // (which calls `OnLowWasmMemoryHookStatus::update(true)`) to ensure desired behavior.
-                            canister
-                                .system_state
-                                .task_queue
-                                .remove(ic_replicated_state::ExecutionTask::OnLowWasmMemory);
-                            canister
-                                .system_state
-                                .task_queue
-                                .enqueue(ic_replicated_state::ExecutionTask::OnLowWasmMemory);
-                        }
+                        // The `OnLowWasmMemory` task always carries its
+                        // prepayment in the variant (see
+                        // `TaskQueue::enqueue_on_low_wasm_memory_hook`), so it
+                        // is dispatched through this function with
+                        // `prepaid_execution_cycles == Some(_)` and never
+                        // reaches this branch.
+                        debug_assert_ne!(
+                            call_or_task,
+                            CanisterCallOrTask::Task(CanisterTask::OnLowWasmMemory),
+                            "OnLowWasmMemory must always arrive with a prepaid reservation",
+                        );
                         return finish_call_with_error(
                             UserError::new(ErrorCode::CanisterOutOfCycles, err),
                             canister,
@@ -111,7 +164,12 @@ pub fn execute_call_or_task(
                         );
                     }
                 };
-                (canister, prepaid_execution_cycles, false)
+                (
+                    canister,
+                    prepaid_execution_cycles,
+                    hook_reservation,
+                    false,
+                )
             }
         };
 
@@ -130,6 +188,7 @@ pub fn execute_call_or_task(
         method,
         call_or_task,
         prepaid_execution_cycles,
+        hook_reservation,
         execution_parameters,
         subnet_size,
         time,
@@ -287,6 +346,13 @@ fn finish_err(
         wasm_execution_mode,
         round.log,
     );
+    // The hook never ran in this error path. Refund the held reservation in
+    // full, if any.
+    if let Some(hook_reservation) = original.hook_reservation {
+        canister
+            .system_state
+            .refund_cycles(hook_reservation, hook_reservation);
+    }
     let instructions_used = instruction_limit - instructions_left;
     finish_call_with_error(
         err,
@@ -306,6 +372,14 @@ struct OriginalContext {
     call_origin: CallOrigin,
     call_or_task: CanisterCallOrTask,
     prepaid_execution_cycles: CompoundCycles<Instructions>,
+    /// Worst-case `OnLowWasmMemory` hook prepayment, charged alongside the
+    /// message prepayment for canisters that export the hook (see the prepay
+    /// branch in `execute_call_or_task`). Resolved at the end of execution by
+    /// either feeding it to
+    /// [`TaskQueue::enqueue_on_low_wasm_memory_hook`](ic_replicated_state::canister_state::system_state::task_queue::TaskQueue::enqueue_on_low_wasm_memory_hook)
+    /// (when the hook condition just became satisfied) or refunding it back
+    /// to the canister balance.
+    hook_reservation: Option<CompoundCycles<Instructions>>,
     method: WasmMethod,
     execution_parameters: ExecutionParameters,
     subnet_size: usize,
@@ -540,6 +614,15 @@ impl CallOrTaskHelper {
             );
         }
 
+        // Capture the hook condition check result before
+        // `apply_canister_state_changes` consumes `canister_state_changes`.
+        // This drives the post-execution enqueue-or-refund of
+        // `original.hook_reservation`, if any (handled after
+        // `refund_unused_execution_cycles` below).
+        let hook_condition_check_result = canister_state_changes
+            .system_state_modifications
+            .on_low_wasm_memory_hook_condition_check_result;
+
         let is_composite_query = matches!(original.method, WasmMethod::CompositeQuery(_));
         let heap_delta = match original.call_or_task {
             // Update methods and tasks can persist changes to the canister's state.
@@ -614,6 +697,12 @@ impl CallOrTaskHelper {
             )
             .unwrap();
 
+        // Capture whether the Wasm execution completed successfully before
+        // the Query branch below consumes `output.wasm_result` via
+        // `map_err(...)`. This drives the post-execution hook accounting
+        // further down.
+        let wasm_result_is_ok = output.wasm_result.is_ok();
+
         let response = match original.call_or_task {
             CanisterCallOrTask::Update(_) | CanisterCallOrTask::Task(_) => action_to_response(
                 &self.canister,
@@ -664,6 +753,34 @@ impl CallOrTaskHelper {
             wasm_execution_mode,
             round.log,
         );
+
+        // Resolve the hook reservation that was charged together with the
+        // message prepayment (if any). If the hook condition just became
+        // satisfied for the first time since the last crossing AND the
+        // execution applied successfully, hand the reservation to the task
+        // queue so the upcoming `OnLowWasmMemory` task can spend it; otherwise
+        // refund it back to the canister balance.
+        //
+        // `enqueue_on_low_wasm_memory_hook` itself enforces "fire exactly
+        // once": if the hook is already `Ready` (a previous message has
+        // already enqueued and funded it) or `Executed` (the hook already
+        // fired for the current memory-limit crossing), it returns the
+        // supplied reservation back for refund.
+        if let Some(hook_reservation) = original.hook_reservation {
+            let should_enqueue = wasm_result_is_ok
+                && hook_condition_check_result == Some(true);
+            let leftover = if should_enqueue {
+                self.canister
+                    .system_state
+                    .task_queue
+                    .enqueue_on_low_wasm_memory_hook(hook_reservation)
+            } else {
+                Some(hook_reservation)
+            };
+            if let Some(refund) = leftover {
+                self.canister.system_state.refund_cycles(refund, refund);
+            }
+        }
 
         if original.log_dirty_pages == FlagStatus::Enabled {
             log_dirty_pages(
@@ -803,7 +920,11 @@ impl PausedExecution for PausedCallOrTaskExecution {
     fn abort(
         self: Box<Self>,
         log: &ReplicaLogger,
-    ) -> (CanisterMessageOrTask, CompoundCycles<Instructions>) {
+    ) -> (
+        CanisterMessageOrTask,
+        CompoundCycles<Instructions>,
+        Option<CompoundCycles<Instructions>>,
+    ) {
         info!(
             log,
             "[DTS] Aborting {:?} execution of canister {}",
@@ -812,7 +933,11 @@ impl PausedExecution for PausedCallOrTaskExecution {
         );
         self.paused_wasm_execution.abort();
         let message_or_task = into_message_or_task(self.original.call_or_task);
-        (message_or_task, self.original.prepaid_execution_cycles)
+        (
+            message_or_task,
+            self.original.prepaid_execution_cycles,
+            self.original.hook_reservation,
+        )
     }
 
     fn input(&self) -> CanisterMessageOrTask {

--- a/rs/execution_environment/src/execution/response.rs
+++ b/rs/execution_environment/src/execution/response.rs
@@ -805,7 +805,11 @@ impl PausedExecution for PausedResponseExecution {
     fn abort(
         self: Box<Self>,
         log: &ReplicaLogger,
-    ) -> (CanisterMessageOrTask, CompoundCycles<Instructions>) {
+    ) -> (
+        CanisterMessageOrTask,
+        CompoundCycles<Instructions>,
+        Option<CompoundCycles<Instructions>>,
+    ) {
         info!(
             log,
             "[DTS] Aborting paused response callback {:?} of canister {}.",
@@ -817,10 +821,13 @@ impl PausedExecution for PausedResponseExecution {
             response: self.original.message,
             callback: self.original.callback,
         };
-        // No cycles were prepaid for execution during this DTS execution.
+        // No cycles were prepaid for execution during this DTS execution; the
+        // response prepayment lives elsewhere (see the request-side
+        // reservation). No hook reservation is held on this path.
         (
             CanisterMessageOrTask::Message(message),
             CompoundCycles::new(Cycles::zero(), self.original.cost_schedule),
+            None,
         )
     }
 
@@ -917,7 +924,11 @@ impl PausedExecution for PausedCleanupExecution {
     fn abort(
         self: Box<Self>,
         log: &ReplicaLogger,
-    ) -> (CanisterMessageOrTask, CompoundCycles<Instructions>) {
+    ) -> (
+        CanisterMessageOrTask,
+        CompoundCycles<Instructions>,
+        Option<CompoundCycles<Instructions>>,
+    ) {
         info!(
             log,
             "[DTS] Aborting paused cleanup callback {:?} of canister {}.",
@@ -929,10 +940,12 @@ impl PausedExecution for PausedCleanupExecution {
             response: self.original.message,
             callback: self.original.callback,
         };
-        // No cycles were prepaid for execution during this DTS execution.
+        // No cycles were prepaid for execution during this DTS execution; no
+        // hook reservation is held on this path either.
         (
             CanisterMessageOrTask::Message(message),
             CompoundCycles::new(Cycles::zero(), self.original.cost_schedule),
+            None,
         )
     }
 

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -387,11 +387,27 @@ pub trait PausedExecution: std::fmt::Debug + Send {
     ) -> ExecuteMessageResult;
 
     /// Aborts the paused execution.
-    /// Returns the original message and the cycles prepaid for execution.
+    ///
+    /// Returns:
+    /// - the original message,
+    /// - the cycles prepaid for the message's execution, and
+    /// - any `OnLowWasmMemory` hook reservation that the paused execution was
+    ///   holding (see `OriginalContext::hook_reservation` in `call_or_task`).
+    ///
+    /// Both prepayments are carried into the resulting `AbortedExecution`
+    /// task: aborted executions correspond to messages that have already been
+    /// popped from their input queue and have started executing, so resuming
+    /// them requires all of the original prepayments to still be in hand.
+    /// Implementations that never charge a hook reservation (e.g. response /
+    /// cleanup callbacks) return `None` for the third element.
     fn abort(
         self: Box<Self>,
         log: &ReplicaLogger,
-    ) -> (CanisterMessageOrTask, CompoundCycles<Instructions>);
+    ) -> (
+        CanisterMessageOrTask,
+        CompoundCycles<Instructions>,
+        Option<CompoundCycles<Instructions>>,
+    );
 
     /// Returns a reference to the message or task being executed.
     fn input(&self) -> CanisterMessageOrTask;
@@ -2249,6 +2265,7 @@ impl ExecutionEnvironment {
 
     /// Executes a replicated message sent to a canister or a canister task.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn execute_canister_input(
         &self,
         canister: CanisterState,
@@ -2256,6 +2273,7 @@ impl ExecutionEnvironment {
         max_instructions_per_query_message: NumInstructions,
         input: CanisterMessageOrTask,
         prepaid_execution_cycles: Option<CompoundCycles<Instructions>>,
+        prepaid_hook_reservation: Option<CompoundCycles<Instructions>>,
         time: Time,
         network_topology: Arc<NetworkTopology>,
         round_limits: &mut RoundLimits,
@@ -2297,6 +2315,7 @@ impl ExecutionEnvironment {
                     canister,
                     task,
                     prepaid_execution_cycles,
+                    prepaid_hook_reservation,
                     instruction_limits,
                     round,
                     round_limits,
@@ -2361,6 +2380,7 @@ impl ExecutionEnvironment {
                     CanisterCallOrTask::Query(req),
                     method,
                     prepaid_execution_cycles,
+                    prepaid_hook_reservation,
                     execution_parameters,
                     time,
                     round,
@@ -2397,6 +2417,7 @@ impl ExecutionEnvironment {
                     CanisterCallOrTask::Update(req),
                     method,
                     prepaid_execution_cycles,
+                    prepaid_hook_reservation,
                     execution_parameters,
                     time,
                     round,
@@ -2414,11 +2435,13 @@ impl ExecutionEnvironment {
     }
 
     /// Executes a canister task of a given canister.
+    #[allow(clippy::too_many_arguments)]
     fn execute_canister_task(
         &self,
         canister: CanisterState,
         task: CanisterTask,
         prepaid_execution_cycles: Option<CompoundCycles<Instructions>>,
+        prepaid_hook_reservation: Option<CompoundCycles<Instructions>>,
         instruction_limits: InstructionLimits,
         round: RoundContext,
         round_limits: &mut RoundLimits,
@@ -2436,6 +2459,7 @@ impl ExecutionEnvironment {
             CanisterCallOrTask::Task(task.clone()),
             WasmMethod::System(SystemMethod::from(task)),
             prepaid_execution_cycles,
+            prepaid_hook_reservation,
             execution_parameters,
             round.time,
             round,
@@ -4263,7 +4287,7 @@ impl ExecutionEnvironment {
         match task {
             ExecutionTask::Heartbeat
             | ExecutionTask::GlobalTimer
-            | ExecutionTask::OnLowWasmMemory
+            | ExecutionTask::OnLowWasmMemory(_)
             | ExecutionTask::PausedExecution { .. }
             | ExecutionTask::AbortedExecution { .. } => {
                 panic!("Unexpected task {task:?} in `resume_install_code` (broken precondition).");
@@ -4335,6 +4359,12 @@ impl ExecutionEnvironment {
         guard.paused_install_code.remove(&id)
     }
 
+    /// Aborts the given paused task and returns the resulting
+    /// `AbortedExecution` / `AbortedInstallCode` task to be stored in the
+    /// canister's task queue. Both the message prepayment and (where
+    /// applicable) the `OnLowWasmMemory` hook reservation are preserved
+    /// inside the aborted task so the resumed execution sees all the
+    /// prepayments that the original execution started with.
     fn abort_paused_execution_and_return_task(
         &self,
         paused_task: &ExecutionTask,
@@ -4343,11 +4373,13 @@ impl ExecutionEnvironment {
         match *paused_task {
             ExecutionTask::PausedExecution { id, .. } => {
                 let paused = self.take_paused_execution(id).unwrap();
-                let (input, prepaid_execution_cycles) = paused.abort(log);
+                let (input, prepaid_execution_cycles, prepaid_hook_reservation) =
+                    paused.abort(log);
 
                 ExecutionTask::AbortedExecution {
                     input,
                     prepaid_execution_cycles,
+                    prepaid_hook_reservation,
                 }
             }
             ExecutionTask::PausedInstallCode(id) => {
@@ -4364,7 +4396,7 @@ impl ExecutionEnvironment {
             | ExecutionTask::AbortedInstallCode { .. }
             | ExecutionTask::Heartbeat
             | ExecutionTask::GlobalTimer
-            | ExecutionTask::OnLowWasmMemory => {
+            | ExecutionTask::OnLowWasmMemory(_) => {
                 unreachable!(
                     "Function abort_paused_execution_and_return_task is only called after
                     the paused task is returned from TaskQueue, hence no task other than PausedExecution
@@ -4410,6 +4442,12 @@ impl ExecutionEnvironment {
             // TODO: EXC-1730 if `PausedExecutionRegistry` becomes local we can abort
             // paused execution on the canister without requesting ID from TaskQueue.
             let aborted_task = self.abort_paused_execution_and_return_task(paused_task, log);
+            // Both the message prepayment and any `OnLowWasmMemory` hook
+            // reservation that the paused execution was holding are carried
+            // inside `aborted_task`; resuming it later picks them back up,
+            // matching the invariant that an aborted execution corresponds
+            // to a message that has already been popped from its input queue
+            // and has all its prepayments accounted for.
             Arc::make_mut(canister)
                 .system_state
                 .task_queue
@@ -4879,9 +4917,11 @@ pub struct ExecuteCanisterResult {
 
 /// Executes the given input message or task.
 /// This is a helper for `execute_canister()`.
+#[allow(clippy::too_many_arguments)]
 fn execute_canister_input(
     input: CanisterMessageOrTask,
     prepaid_execution_cycles: Option<CompoundCycles<Instructions>>,
+    prepaid_hook_reservation: Option<CompoundCycles<Instructions>>,
     exec_env: &ExecutionEnvironment,
     mut canister: CanisterState,
     instruction_limits: InstructionLimits,
@@ -4930,6 +4970,7 @@ fn execute_canister_input(
         max_instructions_per_query_message,
         input,
         prepaid_execution_cycles,
+        prepaid_hook_reservation,
         time,
         network_topology,
         round_limits,
@@ -4976,7 +5017,11 @@ pub fn execute_canister(
     }
 
     let mut canister = Arc::unwrap_or_clone(canister);
-    let (input, prepaid_execution_cycles) = match canister.system_state.task_queue.pop_front() {
+    let (input, prepaid_execution_cycles, prepaid_hook_reservation) = match canister
+        .system_state
+        .task_queue
+        .pop_front()
+    {
         Some(task) => match task {
             ExecutionTask::PausedExecution { id, .. } => {
                 let paused = exec_env.take_paused_execution(id).unwrap();
@@ -5019,20 +5064,28 @@ pub fn execute_canister(
             }
             ExecutionTask::Heartbeat => {
                 let task = CanisterMessageOrTask::Task(CanisterTask::Heartbeat);
-                (task, None)
+                (task, None, None)
             }
             ExecutionTask::GlobalTimer => {
                 let task = CanisterMessageOrTask::Task(CanisterTask::GlobalTimer);
-                (task, None)
+                (task, None, None)
             }
-            ExecutionTask::OnLowWasmMemory => {
+            ExecutionTask::OnLowWasmMemory(reservation) => {
                 let task = CanisterMessageOrTask::Task(CanisterTask::OnLowWasmMemory);
-                (task, None)
+                // The hook task's own prepayment IS the reservation it was
+                // enqueued with; there is no further hook reservation to
+                // carry alongside it.
+                (task, Some(reservation), None)
             }
             ExecutionTask::AbortedExecution {
                 input,
                 prepaid_execution_cycles,
-            } => (input, Some(prepaid_execution_cycles)),
+                prepaid_hook_reservation,
+            } => (
+                input,
+                Some(prepaid_execution_cycles),
+                prepaid_hook_reservation,
+            ),
             ExecutionTask::PausedInstallCode(..) | ExecutionTask::AbortedInstallCode { .. } => {
                 unreachable!("The guard at the beginning filters these cases out")
             }
@@ -5044,12 +5097,13 @@ pub fn execute_canister(
             {
                 exec_env.metrics.oversize_intra_subnet_messages.inc();
             }
-            (CanisterMessageOrTask::Message(message), None)
+            (CanisterMessageOrTask::Message(message), None, None)
         }
     };
     execute_canister_input(
         input,
         prepaid_execution_cycles,
+        prepaid_hook_reservation,
         exec_env,
         canister,
         instruction_limits,

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -4373,8 +4373,7 @@ impl ExecutionEnvironment {
         match *paused_task {
             ExecutionTask::PausedExecution { id, .. } => {
                 let paused = self.take_paused_execution(id).unwrap();
-                let (input, prepaid_execution_cycles, prepaid_hook_reservation) =
-                    paused.abort(log);
+                let (input, prepaid_execution_cycles, prepaid_hook_reservation) = paused.abort(log);
 
                 ExecutionTask::AbortedExecution {
                     input,

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1891,7 +1891,7 @@ fn can_execute_subnet_msg(
             None
             | Some(ExecutionTask::Heartbeat)
             | Some(ExecutionTask::GlobalTimer)
-            | Some(ExecutionTask::OnLowWasmMemory) => false,
+            | Some(ExecutionTask::OnLowWasmMemory(_)) => false,
             Some(ExecutionTask::AbortedExecution { .. }) => true,
             Some(ExecutionTask::PausedExecution { .. })
             | Some(ExecutionTask::PausedInstallCode(_)) => {

--- a/rs/execution_environment/src/scheduler/tests/subnet_messages.rs
+++ b/rs/execution_environment/src/scheduler/tests/subnet_messages.rs
@@ -637,6 +637,7 @@ mod can_execute_subnet_msg_tests {
                 Cycles::zero(),
                 CanisterCyclesCostSchedule::Normal,
             ),
+            prepaid_hook_reservation: None,
         });
         test.inject_call(Method::StopCanister, &CanisterIdRecord::from(test.canister));
 
@@ -655,6 +656,7 @@ mod can_execute_subnet_msg_tests {
                 Cycles::zero(),
                 CanisterCyclesCostSchedule::Normal,
             ),
+            prepaid_hook_reservation: None,
         });
         test.inject_canister_status_call(test.canister);
 

--- a/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
+++ b/rs/protobuf/def/state/canister_state_bits/v1/canister_state_bits.proto
@@ -226,6 +226,12 @@ message ExecutionTask {
     // The execution cost that has already been charged from the canister.
     // Retried execution does not have to pay for it again.
     state.queues.v1.CompoundCycles prepaid_execution_compound_cycles = 7;
+    // The worst-case `OnLowWasmMemory` hook prepayment, charged together with
+    // `prepaid_execution_compound_cycles` for canisters that export the hook.
+    // Aborted executions correspond to messages that have already started
+    // executing, so they must preserve every prepayment across the
+    // abort/resume cycle.
+    optional state.queues.v1.CompoundCycles prepaid_hook_reservation = 8;
   }
 
   message AbortedInstallCode {
@@ -426,6 +432,9 @@ message TaskQueue {
   optional ExecutionTask paused_or_aborted_task = 1;
   // Status of on_low_wasm_memory hook execution.
   OnLowWasmMemoryHookStatus on_low_wasm_memory_hook_status = 2;
+  // Cycles prepaid for the next `OnLowWasmMemory` hook execution. Set iff
+  // `on_low_wasm_memory_hook_status` is `READY`.
+  optional state.queues.v1.CompoundCycles on_low_wasm_memory_hook_reservation = 4;
   // Queue of `Heartbeat` and `GlobalTimer` tasks.
   repeated ExecutionTask queue = 3;
 }

--- a/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
+++ b/rs/protobuf/src/gen/state/state.canister_state_bits.v1.rs
@@ -320,6 +320,14 @@ pub mod execution_task {
         #[prost(message, optional, tag = "7")]
         pub prepaid_execution_compound_cycles:
             ::core::option::Option<super::super::super::queues::v1::CompoundCycles>,
+        /// The worst-case `OnLowWasmMemory` hook prepayment, charged together with
+        /// `prepaid_execution_compound_cycles` for canisters that export the hook.
+        /// Aborted executions correspond to messages that have already started
+        /// executing, so they must preserve every prepayment across the
+        /// abort/resume cycle.
+        #[prost(message, optional, tag = "8")]
+        pub prepaid_hook_reservation:
+            ::core::option::Option<super::super::super::queues::v1::CompoundCycles>,
         #[prost(oneof = "aborted_execution::Input", tags = "1, 6, 3, 5")]
         pub input: ::core::option::Option<aborted_execution::Input>,
     }
@@ -644,6 +652,15 @@ pub struct TaskQueue {
     /// Queue of `Heartbeat` and `GlobalTimer` tasks.
     #[prost(message, repeated, tag = "3")]
     pub queue: ::prost::alloc::vec::Vec<ExecutionTask>,
+    /// Cycles prepaid for the next `OnLowWasmMemory` hook execution. Set iff
+    /// `on_low_wasm_memory_hook_status` is `READY`; reserved at the end of the
+    /// replicated message that armed the hook and consumed when the hook runs.
+    /// Checkpoint round-trip must preserve this field precisely so that replicas
+    /// that continue across the checkpoint and replicas that restart from it end
+    /// up in the exact same state.
+    #[prost(message, optional, tag = "4")]
+    pub on_low_wasm_memory_hook_reservation:
+        ::core::option::Option<super::super::queues::v1::CompoundCycles>,
 }
 /// Next ID: 65
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -174,7 +174,7 @@ impl CanisterState {
         match self.system_state.task_queue.front() {
             Some(ExecutionTask::Heartbeat)
             | Some(ExecutionTask::GlobalTimer)
-            | Some(ExecutionTask::OnLowWasmMemory) => NextExecution::StartNew,
+            | Some(ExecutionTask::OnLowWasmMemory(_)) => NextExecution::StartNew,
 
             Some(ExecutionTask::AbortedExecution { .. })
             | Some(ExecutionTask::PausedExecution { .. }) => NextExecution::ContinueLong,
@@ -619,22 +619,38 @@ impl CanisterState {
             + self.system_state.wasm_chunk_store.heap_delta()
     }
 
-    /// Updates status of `OnLowWasmMemory` hook.
+    /// Updates the status of the `OnLowWasmMemory` hook in the dequeue
+    /// direction only: if the canister was previously holding a hook
+    /// reservation but the underlying condition is no longer satisfied, the
+    /// reservation is refunded to the canister balance.
+    ///
+    /// Auto-enqueueing was removed: enqueueing the hook requires a
+    /// prepayment, which is only available within replicated message
+    /// execution paths.
     pub fn update_on_low_wasm_memory_hook_condition(self: &mut Arc<Self>) {
         let wasm_memory_usage = self.wasm_memory_usage();
         let hook_condition = self
             .system_state
             .is_low_wasm_memory_hook_condition_satisfied(wasm_memory_usage);
-        // Only `make_mut` if the hook condition has changed.
         if !self
             .system_state
             .task_queue
             .peek_hook_status()
             .is_consistent_with(hook_condition)
         {
-            Arc::make_mut(self)
+            let canister = Arc::make_mut(self);
+            let stale_reservation = canister
                 .system_state
                 .update_on_low_wasm_memory_hook_status(wasm_memory_usage);
+            if let Some(stale_reservation) = stale_reservation {
+                // The held reservation no longer belongs to a hook that will
+                // fire (the condition is no longer satisfied). Refund the full
+                // prepayment to the canister balance, observing it as a refund
+                // of an `Instructions` prepayment.
+                canister
+                    .system_state
+                    .refund_cycles(stale_reservation, stale_reservation);
+            }
         }
     }
 

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -517,7 +517,11 @@ pub enum ExecutionTask {
 
     /// On low Wasm memory hook.
     /// The task exists only within an execution round, it never gets serialized.
-    OnLowWasmMemory,
+    ///
+    /// Carries the prepayment that funds the hook's execution. The prepayment
+    /// is taken from the replicated message whose execution enqueued the hook
+    /// (see `TaskQueue::enqueue_on_low_wasm_memory_hook`).
+    OnLowWasmMemory(CompoundCycles<Instructions>),
 
     /// A paused execution task exists only within an epoch (between
     /// checkpoints). It is never serialized, and it turns into `AbortedExecution`
@@ -542,6 +546,17 @@ pub enum ExecutionTask {
         /// The execution cost that has already been charged from the canister.
         /// Retried execution does not have to pay for it again.
         prepaid_execution_cycles: CompoundCycles<Instructions>,
+        /// The worst-case `OnLowWasmMemory` hook prepayment charged together
+        /// with `prepaid_execution_cycles` for canisters that export the hook
+        /// (see
+        /// [`CyclesAccountManager::prepay_execution_cycles_with_hook_reservation`]).
+        /// Aborted executions correspond to messages that have already been
+        /// popped from the canister's input queue and have started executing,
+        /// so they must preserve every prepayment across the abort/resume
+        /// cycle — including this one. The resumed execution either consumes
+        /// the reservation (when the memory-limit crossing happens at the
+        /// end of execution) or refunds it.
+        prepaid_hook_reservation: Option<CompoundCycles<Instructions>>,
     },
 
     /// Any paused `install_code` that doesn't finish until the next checkpoint
@@ -562,7 +577,7 @@ pub enum ExecutionTask {
 impl ExecutionTask {
     pub fn is_hook(&self) -> bool {
         match self {
-            Self::OnLowWasmMemory => true,
+            Self::OnLowWasmMemory(_) => true,
             Self::Heartbeat
             | Self::GlobalTimer
             | Self::PausedExecution { .. }
@@ -2156,17 +2171,35 @@ impl SystemState {
         }
     }
 
-    /// Enqueues or removes `OnLowWasmMemory` task from `task_queue`
-    /// depending if the condition for `OnLowWasmMemoryHook` is satisfied:
+    /// Dequeues the `OnLowWasmMemory` hook if the condition is no longer
+    /// satisfied. The auto-enqueue direction was removed: enqueueing the hook
+    /// requires a prepayment, which is only available within replicated
+    /// message execution paths (see
+    /// `TaskQueue::enqueue_on_low_wasm_memory_hook`). Subnet messages that
+    /// satisfy the condition (e.g. `update_settings` lowering the threshold)
+    /// therefore do not auto-enqueue; the next replicated message will
+    /// enqueue the hook through its prepayment.
+    ///
+    /// Hook condition:
     ///
     ///   `wasm_memory_threshold > wasm_memory_limit - wasm_memory_usage`
     ///
     /// Note: if `wasm_memory_limit` is not set, its default value is 4 GiB.
-    pub fn update_on_low_wasm_memory_hook_status(&mut self, wasm_memory_usage: NumBytes) {
+    ///
+    /// If the hook was previously enqueued and the condition is no longer
+    /// satisfied, the held reservation is returned for the caller to refund
+    /// to the canister balance via `system_state.refund_cycles`.
+    #[must_use = "the returned reservation, if any, must be refunded to the canister balance"]
+    pub fn update_on_low_wasm_memory_hook_status(
+        &mut self,
+        wasm_memory_usage: NumBytes,
+    ) -> Option<CompoundCycles<Instructions>> {
         if self.is_low_wasm_memory_hook_condition_satisfied(wasm_memory_usage) {
-            self.task_queue.enqueue(ExecutionTask::OnLowWasmMemory);
+            // Auto-enqueue removed: callers with a prepayment use
+            // `TaskQueue::enqueue_on_low_wasm_memory_hook` directly.
+            None
         } else {
-            self.task_queue.remove(ExecutionTask::OnLowWasmMemory);
+            self.task_queue.dequeue_on_low_wasm_memory_hook()
         }
     }
 

--- a/rs/replicated_state/src/canister_state/system_state/proto.rs
+++ b/rs/replicated_state/src/canister_state/system_state/proto.rs
@@ -64,7 +64,7 @@ impl From<&ExecutionTask> for pb::ExecutionTask {
         match item {
             ExecutionTask::Heartbeat
             | ExecutionTask::GlobalTimer
-            | ExecutionTask::OnLowWasmMemory
+            | ExecutionTask::OnLowWasmMemory(_)
             | ExecutionTask::PausedExecution { .. }
             | ExecutionTask::PausedInstallCode(_) => {
                 panic!("Attempt to serialize ephemeral task: {item:?}.");
@@ -72,6 +72,7 @@ impl From<&ExecutionTask> for pb::ExecutionTask {
             ExecutionTask::AbortedExecution {
                 input,
                 prepaid_execution_cycles,
+                prepaid_hook_reservation,
             } => {
                 use pb::execution_task::{
                     CanisterTask as PbCanisterTask, aborted_execution::AbortedResponse,
@@ -102,6 +103,10 @@ impl From<&ExecutionTask> for pb::ExecutionTask {
                             prepaid_execution_compound_cycles: Some(PbCompoundCycles::from(
                                 *prepaid_execution_cycles,
                             )),
+                            prepaid_hook_reservation: prepaid_hook_reservation
+                                .as_ref()
+                                .copied()
+                                .map(PbCompoundCycles::from),
                         },
                     )),
                 }
@@ -182,9 +187,14 @@ impl TryFrom<pb::ExecutionTask> for ExecutionTask {
                     aborted.prepaid_execution_compound_cycles,
                     "AbortedExecution::prepaid_execution_compound_cycles",
                 )?;
+                let prepaid_hook_reservation = aborted
+                    .prepaid_hook_reservation
+                    .map(CompoundCycles::try_from)
+                    .transpose()?;
                 ExecutionTask::AbortedExecution {
                     input,
                     prepaid_execution_cycles,
+                    prepaid_hook_reservation,
                 }
             }
             pb::execution_task::Task::AbortedInstallCode(aborted) => {

--- a/rs/replicated_state/src/canister_state/system_state/task_queue.rs
+++ b/rs/replicated_state/src/canister_state/system_state/task_queue.rs
@@ -5,13 +5,42 @@ use ic_interfaces::execution_environment::ExecutionRoundType;
 use ic_management_canister_types_private::OnLowWasmMemoryHookStatus;
 use ic_types::CanisterId;
 use ic_types::NumBytes;
+use ic_types_cycles::{CompoundCycles, Instructions};
 use std::collections::VecDeque;
 
 /// `TaskQueue` represents the implementation of queue structure for canister tasks satisfying the following conditions:
 ///
 /// 1. If there is a `Paused` or `Aborted` task it will be returned first.
 /// 2. If an `OnLowWasmMemoryHook` is ready to be executed, it will be returned next.
-/// 3. All other tasks will be returned based on the order in which they are added to the queue.
+/// 3. All other tasks will be returned in the order in which they were enqueued.
+///
+/// # OnLowWasmMemory hook reservation
+///
+/// The `OnLowWasmMemory` hook costs cycles to execute. Those cycles are prepaid
+/// by the replicated message whose execution may grow Wasm memory enough to
+/// trigger the hook (request, response, ingress, install_code, heartbeat,
+/// global timer). When that message's execution observes the hook condition to
+/// be satisfied, it transfers the prepayment into this `TaskQueue` via
+/// [`TaskQueue::enqueue_on_low_wasm_memory_hook`]; the hook execution path later
+/// reclaims it by popping the `OnLowWasmMemory(reservation)` task from the queue.
+///
+/// The reservation is conceptually attached to the enqueued `OnLowWasmMemory`
+/// task; the corresponding state-level invariant is:
+///
+/// ```text
+///   on_low_wasm_memory_hook_status == Ready
+///       ⇔
+///   on_low_wasm_memory_hook_task == Some(OnLowWasmMemory(reservation))
+/// ```
+///
+/// This invariant is enforced inside this module; external callers must enqueue
+/// and dequeue the hook exclusively through `enqueue_on_low_wasm_memory_hook` /
+/// `dequeue_on_low_wasm_memory_hook` (and pop the enqueued task via `pop_front`).
+///
+/// The reservation is *not* persisted into canister snapshots: snapshots must
+/// never carry held cycles, so restoring a snapshot with a `Ready` hook
+/// withdraws fresh cycles from the canister balance to fund the reservation
+/// (see `CanisterSnapshot::try_load`).
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
 pub struct TaskQueue {
     /// Keeps `PausedExecution`, or `PausedInstallCode`, or `AbortedExecution`,
@@ -19,32 +48,128 @@ pub struct TaskQueue {
     paused_or_aborted_task: Option<ExecutionTask>,
 
     /// Status of low_on_wasm_memory hook execution.
+    ///
+    /// Invariant: `Ready` iff `on_low_wasm_memory_hook_task` is `Some` (i.e.,
+    /// the hook has been enqueued with a prepayment). Other states never carry
+    /// reserved cycles.
     on_low_wasm_memory_hook_status: OnLowWasmMemoryHookStatus,
+
+    /// The enqueued `OnLowWasmMemory` task with its prepaid execution cycles,
+    /// present iff `on_low_wasm_memory_hook_status == Ready`. Stored here so
+    /// that `front()` can return a stable reference without synthesizing a
+    /// transient value.
+    on_low_wasm_memory_hook_task: Option<ExecutionTask>,
 
     /// Queue of `Heartbeat` and `GlobalTimer` tasks.
     queue: VecDeque<ExecutionTask>,
 }
 
 impl TaskQueue {
+    /// Asserts the internal invariants relating the hook status and the held
+    /// hook task. Called from the bottom of every method that mutates either
+    /// field. In release builds the body is compiled away.
+    ///
+    /// Invariants:
+    /// 1. `on_low_wasm_memory_hook_task.is_some() ⇔ status == Ready`.
+    /// 2. If `on_low_wasm_memory_hook_task` is `Some`, it is an
+    ///    `ExecutionTask::OnLowWasmMemory(_)` variant.
+    fn check_invariants(&self) {
+        debug_assert_eq!(
+            self.on_low_wasm_memory_hook_status == OnLowWasmMemoryHookStatus::Ready,
+            self.on_low_wasm_memory_hook_task.is_some(),
+            "BUG: `Ready ⇔ on_low_wasm_memory_hook_task.is_some()` invariant violated: \
+             status={:?}, task={:?}",
+            self.on_low_wasm_memory_hook_status,
+            self.on_low_wasm_memory_hook_task,
+        );
+        if let Some(task) = &self.on_low_wasm_memory_hook_task {
+            debug_assert!(
+                matches!(task, ExecutionTask::OnLowWasmMemory(_)),
+                "BUG: unexpected task stored in `on_low_wasm_memory_hook_task`: {task:?}",
+            );
+        }
+    }
+
     pub fn front(&self) -> Option<&ExecutionTask> {
-        self.paused_or_aborted_task.as_ref().or_else(|| {
-            if self.on_low_wasm_memory_hook_status.is_ready() {
-                Some(&ExecutionTask::OnLowWasmMemory)
-            } else {
-                self.queue.front()
-            }
-        })
+        self.paused_or_aborted_task
+            .as_ref()
+            .or(self.on_low_wasm_memory_hook_task.as_ref())
+            .or_else(|| self.queue.front())
     }
 
     pub fn pop_front(&mut self) -> Option<ExecutionTask> {
-        self.paused_or_aborted_task.take().or_else(|| {
-            if self.on_low_wasm_memory_hook_status.is_ready() {
+        let popped = self.paused_or_aborted_task.take().or_else(|| {
+            if let Some(task) = self.on_low_wasm_memory_hook_task.take() {
                 self.on_low_wasm_memory_hook_status = OnLowWasmMemoryHookStatus::Executed;
-                Some(ExecutionTask::OnLowWasmMemory)
+                Some(task)
             } else {
                 self.queue.pop_front()
             }
-        })
+        });
+        self.check_invariants();
+        popped
+    }
+
+    /// Enqueues the `OnLowWasmMemory` hook with the supplied prepayment when
+    /// the canister transitions from "below the limit" to "over the limit".
+    ///
+    /// The hook is meant to fire exactly once per such transition.
+    /// `OnLowWasmMemoryHookStatus::update(true)` returns `true` iff the status
+    /// just transitioned `ConditionNotSatisfied -> Ready`; we install the
+    /// reservation in that case and refund it otherwise (status was already
+    /// `Ready`, meaning a previous message has already enqueued and funded the
+    /// hook; or `Executed`, meaning the hook already fired for the current
+    /// memory-limit crossing and must not fire again).
+    ///
+    /// In short, the caller can unconditionally hand the hook prepayment to
+    /// this method whenever the memory condition is satisfied at the end of a
+    /// replicated message execution; this method decides whether the hook
+    /// actually needs to be (re-)enqueued and returns any unused cycles for
+    /// refund.
+    #[must_use = "the returned reservation, if any, must be refunded to the canister balance"]
+    pub fn enqueue_on_low_wasm_memory_hook(
+        &mut self,
+        reservation: CompoundCycles<Instructions>,
+    ) -> Option<CompoundCycles<Instructions>> {
+        let refund = if self.on_low_wasm_memory_hook_status.update(true) {
+            // Status transitioned `ConditionNotSatisfied -> Ready`: hold the
+            // prepayment with the enqueued task.
+            self.on_low_wasm_memory_hook_task =
+                Some(ExecutionTask::OnLowWasmMemory(reservation));
+            None
+        } else {
+            // No transition (status was `Ready` or `Executed`): refund.
+            Some(reservation)
+        };
+        self.check_invariants();
+        refund
+    }
+
+    /// Dequeues the `OnLowWasmMemory` hook (if any), transitioning the status
+    /// to `ConditionNotSatisfied` and returning the previously held
+    /// reservation (if any). The caller must refund the returned cycles to the
+    /// canister balance via `system_state.refund_cycles`.
+    #[must_use = "the returned reservation, if any, must be refunded to the canister balance"]
+    pub fn dequeue_on_low_wasm_memory_hook(&mut self) -> Option<CompoundCycles<Instructions>> {
+        // `update(false)` always returns `false` (no `Ready` transition) and
+        // resets the status to `ConditionNotSatisfied`; release the held task
+        // in lockstep and hand its reservation back to the caller for refund.
+        let _ = self.on_low_wasm_memory_hook_status.update(false);
+        let refund = match self.on_low_wasm_memory_hook_task.take() {
+            Some(ExecutionTask::OnLowWasmMemory(reservation)) => Some(reservation),
+            Some(other) => {
+                panic!("BUG: unexpected task stored in `on_low_wasm_memory_hook_task`: {other:?}")
+            }
+            None => None,
+        };
+        self.check_invariants();
+        refund
+    }
+
+    /// Returns `true` if the `OnLowWasmMemory` hook is currently enqueued
+    /// (status `Ready`, reservation held).
+    pub fn is_on_low_wasm_memory_hook_enqueued(&self) -> bool {
+        self.on_low_wasm_memory_hook_task.is_some()
     }
 
     pub fn paused_or_aborted_task(&self) -> &Option<ExecutionTask> {
@@ -53,23 +178,6 @@ impl TaskQueue {
 
     pub fn has_paused_or_aborted_task(&self) -> bool {
         self.paused_or_aborted_task.is_some()
-    }
-
-    pub fn remove(&mut self, task: ExecutionTask) {
-        match task {
-            ExecutionTask::OnLowWasmMemory => {
-                self.on_low_wasm_memory_hook_status.update(false);
-            }
-            ExecutionTask::Heartbeat
-            | ExecutionTask::GlobalTimer
-            | ExecutionTask::AbortedInstallCode { .. }
-            | ExecutionTask::PausedExecution { .. }
-            | ExecutionTask::PausedInstallCode(_)
-            | ExecutionTask::AbortedExecution { .. } => unreachable!(
-                "Unsuccessful removal of the task {:?}. Removal of task from TaskQueue is only supported for OnLowWasmMemory type.",
-                task
-            ),
-        };
     }
 
     pub fn enqueue(&mut self, task: ExecutionTask) {
@@ -81,23 +189,24 @@ impl TaskQueue {
                 debug_assert!(self.paused_or_aborted_task.is_none());
                 self.paused_or_aborted_task = Some(task);
             }
-            ExecutionTask::OnLowWasmMemory => {
-                self.on_low_wasm_memory_hook_status.update(true);
-            }
+            ExecutionTask::OnLowWasmMemory(_) => panic!(
+                "OnLowWasmMemory must not be enqueued via `TaskQueue::enqueue`. \
+                 Use `TaskQueue::enqueue_on_low_wasm_memory_hook(reservation)` instead.",
+            ),
             ExecutionTask::Heartbeat | ExecutionTask::GlobalTimer => self.queue.push_front(task),
         };
     }
 
     pub fn is_empty(&self) -> bool {
         self.paused_or_aborted_task.is_none()
-            && !self.on_low_wasm_memory_hook_status.is_ready()
+            && self.on_low_wasm_memory_hook_task.is_none()
             && self.queue.is_empty()
     }
 
     pub fn len(&self) -> usize {
         self.queue.len()
             + self.paused_or_aborted_task.as_ref().map_or(0, |_| 1)
-            + if self.on_low_wasm_memory_hook_status.is_ready() {
+            + if self.on_low_wasm_memory_hook_task.is_some() {
                 1
             } else {
                 0
@@ -108,14 +217,21 @@ impl TaskQueue {
         self.on_low_wasm_memory_hook_status
     }
 
-    /// This function should only be used to restore the hook status
-    /// when loading a canister snapshot.
-    /// Otherwise, invalid state transitions might happen.
+    /// Sets the hook status without a reservation. This should only be used by
+    /// the canister snapshot restore path for non-`Ready` statuses; if the
+    /// snapshot's status is `Ready`, the caller must instead enqueue the hook
+    /// with a reservation withdrawn from the canister balance via
+    /// `enqueue_on_low_wasm_memory_hook`.
     pub fn set_on_low_wasm_memory_hook_status_from_snapshot(
         &mut self,
         on_low_wasm_memory_hook_status: OnLowWasmMemoryHookStatus,
     ) {
+        debug_assert!(
+            !on_low_wasm_memory_hook_status.is_ready(),
+            "`Ready` status must be installed via `enqueue_on_low_wasm_memory_hook`."
+        );
         self.on_low_wasm_memory_hook_status = on_low_wasm_memory_hook_status;
+        self.check_invariants();
     }
 
     /// `check_dts_invariants` should only be called after round execution.
@@ -139,7 +255,7 @@ impl TaskQueue {
                 | ExecutionTask::AbortedInstallCode { .. } => {}
                 ExecutionTask::Heartbeat
                 | ExecutionTask::GlobalTimer
-                | ExecutionTask::OnLowWasmMemory => {
+                | ExecutionTask::OnLowWasmMemory(_) => {
                     unreachable!(
                         "Unexpected on task type {:?} in TaskQueue::paused_or_aborted_task in canister {:?} .",
                         paused_or_aborted_task, id
@@ -156,7 +272,7 @@ impl TaskQueue {
                 ExecutionTask::GlobalTimer => {
                     panic!("Unexpected global timer task after a round in canister {id:?}");
                 }
-                ExecutionTask::OnLowWasmMemory
+                ExecutionTask::OnLowWasmMemory(_)
                 | ExecutionTask::AbortedExecution { .. }
                 | ExecutionTask::AbortedInstallCode { .. }
                 | ExecutionTask::PausedExecution { .. }
@@ -209,7 +325,7 @@ impl TaskQueue {
                 | ExecutionTask::AbortedInstallCode { .. } => None,
                 ExecutionTask::Heartbeat
                 | ExecutionTask::GlobalTimer
-                | ExecutionTask::OnLowWasmMemory => unreachable!(
+                | ExecutionTask::OnLowWasmMemory(_) => unreachable!(
                     "Unexpected on task type in the in TaskQueue::paused_or_aborted_task."
                 ),
             }
@@ -242,7 +358,7 @@ impl TaskQueue {
             ),
             ExecutionTask::Heartbeat
             | ExecutionTask::GlobalTimer
-            | ExecutionTask::OnLowWasmMemory
+            | ExecutionTask::OnLowWasmMemory(_)
             | ExecutionTask::PausedExecution { .. }
             | ExecutionTask::PausedInstallCode(_) => {
                 unreachable!(
@@ -293,38 +409,47 @@ mod tests {
     use ic_management_canister_types_private::OnLowWasmMemoryHookStatus;
     use ic_test_utilities_types::messages::IngressBuilder;
     use ic_types::messages::{CanisterCall, CanisterMessageOrTask, CanisterTask};
-    use ic_types_cycles::{CanisterCyclesCostSchedule, CompoundCycles, Cycles};
+    use ic_types_cycles::{CanisterCyclesCostSchedule, CompoundCycles, Cycles, Instructions};
+
+    fn dummy_reservation() -> CompoundCycles<Instructions> {
+        CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal)
+    }
 
     #[test]
     fn test_on_low_wasm_memory_hook_start_status_condition_not_satisfied() {
         let mut status = OnLowWasmMemoryHookStatus::ConditionNotSatisfied;
-        status.update(false);
+        assert!(!status.update(false));
         assert_eq!(status, OnLowWasmMemoryHookStatus::ConditionNotSatisfied);
 
+        // `update(true)` transitions `ConditionNotSatisfied -> Ready` and
+        // returns `true` so the caller (`enqueue_on_low_wasm_memory_hook`) knows
+        // to hold on to the supplied reservation.
         let mut status = OnLowWasmMemoryHookStatus::ConditionNotSatisfied;
-        status.update(true);
+        assert!(status.update(true));
         assert_eq!(status, OnLowWasmMemoryHookStatus::Ready);
     }
 
     #[test]
     fn test_on_low_wasm_memory_hook_start_status_ready() {
         let mut status = OnLowWasmMemoryHookStatus::Ready;
-        status.update(false);
+        assert!(!status.update(false));
         assert_eq!(status, OnLowWasmMemoryHookStatus::ConditionNotSatisfied);
 
+        // Already `Ready`: no transition, no new reservation needed.
         let mut status = OnLowWasmMemoryHookStatus::Ready;
-        status.update(true);
+        assert!(!status.update(true));
         assert_eq!(status, OnLowWasmMemoryHookStatus::Ready);
     }
 
     #[test]
     fn test_on_low_wasm_memory_hook_start_status_executed() {
         let mut status = OnLowWasmMemoryHookStatus::Executed;
-        status.update(false);
+        assert!(!status.update(false));
         assert_eq!(status, OnLowWasmMemoryHookStatus::ConditionNotSatisfied);
 
+        // The hook already fired for the current crossing; do not re-enqueue.
         let mut status = OnLowWasmMemoryHookStatus::Executed;
-        status.update(true);
+        assert!(!status.update(true));
         assert_eq!(status, OnLowWasmMemoryHookStatus::Executed);
     }
 
@@ -346,7 +471,8 @@ mod tests {
     #[should_panic(expected = "Unexpected task type")]
     fn test_replace_paused_with_aborted_task_on_low_wasm_memory() {
         let mut task_queue = TaskQueue::default();
-        task_queue.replace_paused_with_aborted_task(ExecutionTask::OnLowWasmMemory);
+        task_queue
+            .replace_paused_with_aborted_task(ExecutionTask::OnLowWasmMemory(dummy_reservation()));
     }
 
     #[test]
@@ -380,6 +506,7 @@ mod tests {
                 Cycles::zero(),
                 CanisterCyclesCostSchedule::Normal,
             ),
+            prepaid_hook_reservation: None,
         });
     }
 
@@ -407,114 +534,157 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Unsuccessful removal of the task")]
-    fn test_task_queue_remove_heartbeat() {
+    fn test_task_queue_dequeue_on_low_wasm_memory_hook_empty_is_noop() {
         let mut task_queue = TaskQueue::default();
-        task_queue.remove(ExecutionTask::Heartbeat);
+        assert!(task_queue.is_empty());
+        // Dequeueing an empty hook is a no-op and returns no reservation.
+        assert!(task_queue.dequeue_on_low_wasm_memory_hook().is_none());
+        assert!(task_queue.is_empty());
     }
 
     #[test]
-    #[should_panic(expected = "Unsuccessful removal of the task")]
-    fn test_task_queue_remove_global_timer() {
-        let mut task_queue = TaskQueue::default();
-        task_queue.remove(ExecutionTask::GlobalTimer);
-    }
-
-    #[test]
-    #[should_panic(expected = "Unsuccessful removal of the task")]
-    fn test_task_queue_remove_paused_install_code() {
-        let mut task_queue = TaskQueue::default();
-        task_queue.remove(ExecutionTask::PausedInstallCode(PausedExecutionId(0)));
-    }
-
-    #[test]
-    #[should_panic(expected = "Unsuccessful removal of the task")]
-    fn test_task_queue_remove_paused_execution() {
-        let mut task_queue = TaskQueue::default();
-        task_queue.remove(ExecutionTask::PausedInstallCode(PausedExecutionId(0)));
-    }
-
-    #[test]
-    #[should_panic(expected = "Unsuccessful removal of the task")]
-    fn test_task_queue_remove_aborted_install_code() {
-        let mut task_queue = TaskQueue::default();
-
-        let ingress = Arc::new(IngressBuilder::new().method_name("test_ingress").build());
-
-        task_queue.remove(ExecutionTask::AbortedInstallCode {
-            message: CanisterCall::Ingress(Arc::clone(&ingress)),
-            prepaid_execution_cycles: CompoundCycles::new(
-                Cycles::new(1),
-                CanisterCyclesCostSchedule::Normal,
-            ),
-            call_id: InstallCodeCallId::new(0),
-        });
-    }
-
-    #[test]
-    #[should_panic(expected = "Unsuccessful removal of the task")]
-    fn test_task_queue_remove_aborted_execution() {
-        let mut task_queue = TaskQueue::default();
-        task_queue.remove(ExecutionTask::AbortedExecution {
-            input: CanisterMessageOrTask::Task(CanisterTask::Heartbeat),
-            prepaid_execution_cycles: CompoundCycles::new(
-                Cycles::zero(),
-                CanisterCyclesCostSchedule::Normal,
-            ),
-        });
-    }
-
-    #[test]
-    fn test_task_queue_remove_on_low_wasm_memory_hook() {
+    fn test_task_queue_enqueue_dequeue_on_low_wasm_memory_hook() {
         let mut task_queue = TaskQueue::default();
         assert!(task_queue.is_empty());
 
-        // Queue is empty, so remove should be no_op.
-        task_queue.remove(ExecutionTask::OnLowWasmMemory);
-        assert!(task_queue.is_empty());
-
-        // ExecutionTask::OnLowWasmMemory is added to queue.
-        task_queue.enqueue(ExecutionTask::OnLowWasmMemory);
+        // Enqueueing with a fresh reservation transitions
+        // `ConditionNotSatisfied -> Ready`.
+        let reservation = CompoundCycles::new(Cycles::new(123), CanisterCyclesCostSchedule::Normal);
+        assert!(
+            task_queue
+                .enqueue_on_low_wasm_memory_hook(reservation)
+                .is_none()
+        );
         assert_eq!(task_queue.len(), 1);
-        assert_eq!(task_queue.front(), Some(&ExecutionTask::OnLowWasmMemory));
+        assert_eq!(
+            task_queue.peek_hook_status(),
+            OnLowWasmMemoryHookStatus::Ready
+        );
+        assert!(task_queue.is_on_low_wasm_memory_hook_enqueued());
 
-        // After removing queue is empty.
-        task_queue.remove(ExecutionTask::OnLowWasmMemory);
+        // Enqueueing again from `Ready` returns the new reservation unchanged;
+        // the existing reservation is kept.
+        let second = CompoundCycles::new(Cycles::new(456), CanisterCyclesCostSchedule::Normal);
+        let refund = task_queue.enqueue_on_low_wasm_memory_hook(second);
+        assert_eq!(refund, Some(second));
+        assert_eq!(
+            task_queue.peek_hook_status(),
+            OnLowWasmMemoryHookStatus::Ready
+        );
+
+        // Dequeueing returns the held reservation and resets the status.
+        let refund = task_queue.dequeue_on_low_wasm_memory_hook();
+        assert_eq!(refund, Some(reservation));
         assert!(task_queue.is_empty());
+        assert_eq!(
+            task_queue.peek_hook_status(),
+            OnLowWasmMemoryHookStatus::ConditionNotSatisfied
+        );
 
-        // ExecutionTask::OnLowWasmMemory can be added to the queue again.
-        task_queue.enqueue(ExecutionTask::OnLowWasmMemory);
+        // Re-enqueueing is allowed after dequeue.
+        let third = CompoundCycles::new(Cycles::new(789), CanisterCyclesCostSchedule::Normal);
+        assert!(task_queue.enqueue_on_low_wasm_memory_hook(third).is_none());
         assert_eq!(task_queue.len(), 1);
-        assert_eq!(task_queue.front(), Some(&ExecutionTask::OnLowWasmMemory));
+    }
+
+    #[test]
+    fn test_task_queue_enqueue_on_low_wasm_memory_hook_does_not_re_enqueue_executed() {
+        let mut task_queue = TaskQueue::default();
+
+        // Enqueue the hook and pop it for execution: status transitions
+        // `ConditionNotSatisfied -> Ready -> Executed`.
+        let reservation = CompoundCycles::new(Cycles::new(100), CanisterCyclesCostSchedule::Normal);
+        assert!(
+            task_queue
+                .enqueue_on_low_wasm_memory_hook(reservation)
+                .is_none()
+        );
+        assert_eq!(
+            task_queue.pop_front(),
+            Some(ExecutionTask::OnLowWasmMemory(reservation))
+        );
+        assert_eq!(
+            task_queue.peek_hook_status(),
+            OnLowWasmMemoryHookStatus::Executed
+        );
+
+        // The hook fired for the current memory-limit crossing. Subsequent
+        // messages that observe the condition is still satisfied must not
+        // re-enqueue; their hook prepayment is returned for refund.
+        let redundant = CompoundCycles::new(Cycles::new(200), CanisterCyclesCostSchedule::Normal);
+        let refund = task_queue.enqueue_on_low_wasm_memory_hook(redundant);
+        assert_eq!(refund, Some(redundant));
+        assert_eq!(
+            task_queue.peek_hook_status(),
+            OnLowWasmMemoryHookStatus::Executed
+        );
+        assert!(!task_queue.is_on_low_wasm_memory_hook_enqueued());
+
+        // Only when the condition becomes unsatisfied (e.g. memory shrinks
+        // or `update_settings` raises the threshold) does `Executed` reset
+        // to `ConditionNotSatisfied` via `dequeue_on_low_wasm_memory_hook`,
+        // at which point enqueueing is allowed again.
+        assert!(task_queue.dequeue_on_low_wasm_memory_hook().is_none());
+        assert_eq!(
+            task_queue.peek_hook_status(),
+            OnLowWasmMemoryHookStatus::ConditionNotSatisfied
+        );
+        let next_crossing =
+            CompoundCycles::new(Cycles::new(300), CanisterCyclesCostSchedule::Normal);
+        assert!(
+            task_queue
+                .enqueue_on_low_wasm_memory_hook(next_crossing)
+                .is_none()
+        );
+        assert_eq!(
+            task_queue.peek_hook_status(),
+            OnLowWasmMemoryHookStatus::Ready
+        );
     }
 
     #[test]
     fn test_task_queue_pop_front_on_low_wasm_memory() {
         let mut task_queue = TaskQueue::default();
 
-        // `ExecutionTask::OnLowWasmMemory` is added to queue.
-        task_queue.enqueue(ExecutionTask::OnLowWasmMemory);
+        // Enqueue the hook.
+        let reservation = CompoundCycles::new(Cycles::new(42), CanisterCyclesCostSchedule::Normal);
+        assert!(
+            task_queue
+                .enqueue_on_low_wasm_memory_hook(reservation)
+                .is_none()
+        );
         assert_eq!(task_queue.len(), 1);
 
-        assert_eq!(task_queue.pop_front(), Some(ExecutionTask::OnLowWasmMemory));
+        // Pop returns the hook task with its reservation; status -> Executed.
+        assert_eq!(
+            task_queue.pop_front(),
+            Some(ExecutionTask::OnLowWasmMemory(reservation))
+        );
         assert!(task_queue.is_empty());
+        assert_eq!(
+            task_queue.peek_hook_status(),
+            OnLowWasmMemoryHookStatus::Executed
+        );
 
-        // After `pop` of `OnLowWasmMemory` from queue `OnLowWasmMemoryHookStatus`
-        // will be `Executed` so `enqueue` of `OnLowWasmMemory` is no-op.
-        task_queue.enqueue(ExecutionTask::OnLowWasmMemory);
-        assert!(task_queue.is_empty());
+        // From `Executed`, dequeueing brings us back to `ConditionNotSatisfied`.
+        assert!(task_queue.dequeue_on_low_wasm_memory_hook().is_none());
+        assert_eq!(
+            task_queue.peek_hook_status(),
+            OnLowWasmMemoryHookStatus::ConditionNotSatisfied
+        );
 
-        // After removing `OnLowWasmMemory` from queue `OnLowWasmMemoryHookStatus`
-        // will become `ConditionNotSatisfied`.
-        task_queue.remove(ExecutionTask::OnLowWasmMemory);
-        assert!(task_queue.is_empty());
-
-        // So now `enqueue` of `OnLowWasmMemory` will set `OnLowWasmMemoryHookStatus`
-        // to `Ready`.
-        task_queue.enqueue(ExecutionTask::OnLowWasmMemory);
+        // And we can enqueue again.
+        let reservation2 = CompoundCycles::new(Cycles::new(7), CanisterCyclesCostSchedule::Normal);
+        assert!(
+            task_queue
+                .enqueue_on_low_wasm_memory_hook(reservation2)
+                .is_none()
+        );
         assert_eq!(task_queue.len(), 1);
-
-        assert_eq!(task_queue.pop_front(), Some(ExecutionTask::OnLowWasmMemory));
+        assert_eq!(
+            task_queue.pop_front(),
+            Some(ExecutionTask::OnLowWasmMemory(reservation2))
+        );
     }
 
     #[test]
@@ -525,7 +695,12 @@ mod tests {
         task_queue.enqueue(ExecutionTask::Heartbeat);
         task_queue.enqueue(ExecutionTask::PausedInstallCode(PausedExecutionId(0)));
         task_queue.enqueue(ExecutionTask::GlobalTimer);
-        task_queue.enqueue(ExecutionTask::OnLowWasmMemory);
+        let reservation = CompoundCycles::new(Cycles::new(1), CanisterCyclesCostSchedule::Normal);
+        assert!(
+            task_queue
+                .enqueue_on_low_wasm_memory_hook(reservation)
+                .is_none()
+        );
 
         assert!(!task_queue.is_empty());
         assert_eq!(task_queue.len(), 4);
@@ -539,10 +714,20 @@ mod tests {
 
         // Disregarding order of `enqueue` operations, if there is OnLowWasmMemory
         // task, it should be returned right after paused or aborted task if there is one.
-        assert_eq!(task_queue.pop_front(), Some(ExecutionTask::OnLowWasmMemory));
+        assert_eq!(
+            task_queue.pop_front(),
+            Some(ExecutionTask::OnLowWasmMemory(reservation))
+        );
 
         // The rest of the tasks should be returned in the LIFO order.
         assert_eq!(task_queue.pop_front(), Some(ExecutionTask::GlobalTimer));
         assert_eq!(task_queue.pop_front(), Some(ExecutionTask::Heartbeat));
+    }
+
+    #[test]
+    #[should_panic(expected = "OnLowWasmMemory must not be enqueued")]
+    fn test_task_queue_enqueue_on_low_wasm_memory_panics() {
+        let mut task_queue = TaskQueue::default();
+        task_queue.enqueue(ExecutionTask::OnLowWasmMemory(dummy_reservation()));
     }
 }

--- a/rs/replicated_state/src/canister_state/system_state/task_queue.rs
+++ b/rs/replicated_state/src/canister_state/system_state/task_queue.rs
@@ -134,8 +134,7 @@ impl TaskQueue {
         let refund = if self.on_low_wasm_memory_hook_status.update(true) {
             // Status transitioned `ConditionNotSatisfied -> Ready`: hold the
             // prepayment with the enqueued task.
-            self.on_low_wasm_memory_hook_task =
-                Some(ExecutionTask::OnLowWasmMemory(reservation));
+            self.on_low_wasm_memory_hook_task = Some(ExecutionTask::OnLowWasmMemory(reservation));
             None
         } else {
             // No transition (status was `Ready` or `Executed`): refund.

--- a/rs/replicated_state/src/canister_state/system_state/task_queue/proto.rs
+++ b/rs/replicated_state/src/canister_state/system_state/task_queue/proto.rs
@@ -1,15 +1,26 @@
 use super::*;
 use ic_protobuf::proxy::ProxyDecodeError;
 use ic_protobuf::state::canister_state_bits::v1 as pb;
+use ic_protobuf::state::queues::v1::CompoundCycles as PbCompoundCycles;
 
 impl From<&TaskQueue> for pb::TaskQueue {
     fn from(item: &TaskQueue) -> Self {
+        let on_low_wasm_memory_hook_reservation = match item.on_low_wasm_memory_hook_task.as_ref() {
+            Some(ExecutionTask::OnLowWasmMemory(reservation)) => {
+                Some(PbCompoundCycles::from(*reservation))
+            }
+            Some(other) => {
+                panic!("BUG: unexpected task stored in `on_low_wasm_memory_hook_task`: {other:?}")
+            }
+            None => None,
+        };
         Self {
             paused_or_aborted_task: item.paused_or_aborted_task.as_ref().map(|task| task.into()),
             on_low_wasm_memory_hook_status: pb::OnLowWasmMemoryHookStatus::from(
                 &item.on_low_wasm_memory_hook_status,
             )
             .into(),
+            on_low_wasm_memory_hook_reservation,
             queue: item.queue.iter().map(|task| task.into()).collect(),
         }
     }
@@ -19,17 +30,51 @@ impl TryFrom<pb::TaskQueue> for TaskQueue {
     type Error = ProxyDecodeError;
 
     fn try_from(item: pb::TaskQueue) -> Result<Self, Self::Error> {
+        let on_low_wasm_memory_hook_status: OnLowWasmMemoryHookStatus =
+            pb::OnLowWasmMemoryHookStatus::try_from(item.on_low_wasm_memory_hook_status)
+                .map_err(|e| {
+                    ProxyDecodeError::Other(format!(
+                        "Error while trying to decode pb::TaskQueue::on_low_wasm_memory_hook_status, {e:?}"
+                    ))
+                })?
+                .try_into()?;
+        let on_low_wasm_memory_hook_reservation: Option<CompoundCycles<Instructions>> = item
+            .on_low_wasm_memory_hook_reservation
+            .map(CompoundCycles::try_from)
+            .transpose()?;
+        // The invariant `Ready ⇔ reservation.is_some()` is enforced by the
+        // encode path; reject any persisted state that violates it here so a
+        // bug is surfaced at the checkpoint boundary rather than silently.
+        let on_low_wasm_memory_hook_task = match (
+            on_low_wasm_memory_hook_status,
+            on_low_wasm_memory_hook_reservation,
+        ) {
+            (OnLowWasmMemoryHookStatus::Ready, Some(reservation)) => {
+                Some(ExecutionTask::OnLowWasmMemory(reservation))
+            }
+            // FIXME: This could happen when loading a checkpoint from an earlier replica version.
+            (OnLowWasmMemoryHookStatus::Ready, None) => {
+                return Err(ProxyDecodeError::Other(
+                    "pb::TaskQueue::on_low_wasm_memory_hook_status was `Ready` but \
+                     `on_low_wasm_memory_hook_reservation` is missing."
+                        .into(),
+                ));
+            }
+            (status, Some(_)) => {
+                return Err(ProxyDecodeError::Other(format!(
+                    "pb::TaskQueue::on_low_wasm_memory_hook_reservation is set but \
+                     `on_low_wasm_memory_hook_status` is {status:?} (expected `Ready`)."
+                )));
+            }
+            (_, None) => None,
+        };
         Ok(Self {
             paused_or_aborted_task: item
                 .paused_or_aborted_task
                 .map(|task| task.try_into())
                 .transpose()?,
-            on_low_wasm_memory_hook_status: pb::OnLowWasmMemoryHookStatus::try_from(
-                item.on_low_wasm_memory_hook_status,
-            )
-            .map_err(|e| ProxyDecodeError::Other(
-                format!("Error while trying to decode pb::TaskQueue::on_low_wasm_memory_hook_status, {e:?}")))?
-            .try_into()?,
+            on_low_wasm_memory_hook_status,
+            on_low_wasm_memory_hook_task,
             queue: item
                 .queue
                 .into_iter()

--- a/rs/replicated_state/src/metrics.rs
+++ b/rs/replicated_state/src/metrics.rs
@@ -385,7 +385,7 @@ impl ReplicatedStateMetrics {
                 }
                 Some(ExecutionTask::Heartbeat)
                 | Some(ExecutionTask::GlobalTimer)
-                | Some(ExecutionTask::OnLowWasmMemory)
+                | Some(ExecutionTask::OnLowWasmMemory(_))
                 | None => {}
             }
             consumed_cycles_total += canister.system_state.canister_metrics().consumed_cycles();

--- a/rs/state_layout/src/state_layout/tests.rs
+++ b/rs/state_layout/src/state_layout/tests.rs
@@ -345,6 +345,7 @@ fn test_encode_decode_task_queue() {
                 Cycles::new(2),
                 CanisterCyclesCostSchedule::Normal,
             ),
+            prepaid_hook_reservation: None,
         },
         ExecutionTask::AbortedInstallCode {
             message: CanisterCall::Request(Arc::clone(&request)),
@@ -363,6 +364,7 @@ fn test_encode_decode_task_queue() {
                 Cycles::new(4),
                 CanisterCyclesCostSchedule::Normal,
             ),
+            prepaid_hook_reservation: None,
         },
         ExecutionTask::AbortedExecution {
             input: CanisterMessageOrTask::Message(CanisterMessage::Ingress(Arc::clone(&ingress))),
@@ -370,6 +372,10 @@ fn test_encode_decode_task_queue() {
                 Cycles::new(5),
                 CanisterCyclesCostSchedule::Normal,
             ),
+            prepaid_hook_reservation: Some(CompoundCycles::new(
+                Cycles::new(6),
+                CanisterCyclesCostSchedule::Normal,
+            )),
         },
     ] {
         let mut task_queue = TaskQueue::default();
@@ -1193,7 +1199,16 @@ fn test_encode_decode_empty_task_queue() {
 #[test]
 fn test_encode_decode_non_empty_task_queue() {
     let mut task_queue = TaskQueue::default();
-    task_queue.enqueue(ExecutionTask::OnLowWasmMemory);
+
+    // A low Wasm memory hook with a non-zero reservation.
+    assert!(
+        task_queue
+            .enqueue_on_low_wasm_memory_hook(CompoundCycles::new(
+                Cycles::new(7_654_321),
+                CanisterCyclesCostSchedule::Normal,
+            ))
+            .is_none()
+    );
 
     task_queue.enqueue(ExecutionTask::AbortedExecution {
         input: CanisterMessageOrTask::Task(CanisterTask::Heartbeat),
@@ -1201,6 +1216,7 @@ fn test_encode_decode_non_empty_task_queue() {
             Cycles::zero(),
             CanisterCyclesCostSchedule::Normal,
         ),
+        prepaid_hook_reservation: None,
     });
 
     // A canister state with non empty TaskQueue.
@@ -1304,6 +1320,7 @@ mod mainnet_compatibility_tests {
                     Cycles::new(10),
                     CanisterCyclesCostSchedule::Normal,
                 ),
+                prepaid_hook_reservation: None,
             });
 
             CanisterStateBits {

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -1280,16 +1280,23 @@ impl ExecutionTest {
                     .enqueue(ExecutionTask::GlobalTimer);
             }
             CanisterTask::OnLowWasmMemory => {
-                // Set `OnLowWasmMemoryHookStatus` to `ConditionNotSatisfied`.
-                canister
+                // Start from `ConditionNotSatisfied` and enqueue with a
+                // zero-cycles reservation, since this is a test helper that
+                // bypasses the regular message prepay path.
+                let _ = canister
                     .system_state
                     .task_queue
-                    .remove(ExecutionTask::OnLowWasmMemory);
-                // Set `OnLowWasmMemoryHookStatus` to `Ready`.
-                canister
-                    .system_state
-                    .task_queue
-                    .enqueue(ExecutionTask::OnLowWasmMemory);
+                    .dequeue_on_low_wasm_memory_hook();
+                assert_eq!(
+                    canister
+                        .system_state
+                        .task_queue
+                        .enqueue_on_low_wasm_memory_hook(ic_types_cycles::CompoundCycles::new(
+                            ic_types_cycles::Cycles::zero(),
+                            ic_types_cycles::CanisterCyclesCostSchedule::Normal,
+                        )),
+                    None
+                );
             }
         }
         let result = execute_canister(

--- a/rs/test_utilities/state/src/lib.rs
+++ b/rs/test_utilities/state/src/lib.rs
@@ -502,18 +502,35 @@ impl SystemStateBuilder {
         match on_low_wasm_memory_hook_status {
             // Default hook status is `ConditionNotSatisfied`.
             OnLowWasmMemoryHookStatus::ConditionNotSatisfied => (),
-            // To make hook status `Ready`, we should enqueue `ExecutionTask::OnLowWasmMemory`.
-            OnLowWasmMemoryHookStatus::Ready => self
-                .system_state
-                .task_queue
-                .enqueue(ic_replicated_state::ExecutionTask::OnLowWasmMemory),
-            // To make hook status `Executed`, we should enqueue `ExecutionTask::OnLowWasmMemory`,
-            // followed by `pop_front()`, which from the standpoint of `TaskQueue` is equivalent to
-            // executing task.
+            // Enqueue the hook with a zero-cycles reservation: tests that
+            // only care about the hook *status* don't exercise the cycles
+            // plumbing.
+            OnLowWasmMemoryHookStatus::Ready => {
+                assert!(
+                    self.system_state
+                        .task_queue
+                        .enqueue_on_low_wasm_memory_hook(
+                            ic_types_cycles::CompoundCycles::new(
+                                ic_types_cycles::Cycles::zero(),
+                                ic_types_cycles::CanisterCyclesCostSchedule::Normal,
+                            ),
+                        )
+                        .is_none()
+                );
+            }
+            // To produce the `Executed` state we enqueue then pop the hook.
             OnLowWasmMemoryHookStatus::Executed => {
-                self.system_state
-                    .task_queue
-                    .enqueue(ic_replicated_state::ExecutionTask::OnLowWasmMemory);
+                assert!(
+                    self.system_state
+                        .task_queue
+                        .enqueue_on_low_wasm_memory_hook(
+                            ic_types_cycles::CompoundCycles::new(
+                                ic_types_cycles::Cycles::zero(),
+                                ic_types_cycles::CanisterCyclesCostSchedule::Normal,
+                            ),
+                        )
+                        .is_none()
+                );
                 self.system_state.task_queue.pop_front();
             }
         };

--- a/rs/test_utilities/state/src/lib.rs
+++ b/rs/test_utilities/state/src/lib.rs
@@ -509,12 +509,10 @@ impl SystemStateBuilder {
                 assert!(
                     self.system_state
                         .task_queue
-                        .enqueue_on_low_wasm_memory_hook(
-                            ic_types_cycles::CompoundCycles::new(
-                                ic_types_cycles::Cycles::zero(),
-                                ic_types_cycles::CanisterCyclesCostSchedule::Normal,
-                            ),
-                        )
+                        .enqueue_on_low_wasm_memory_hook(ic_types_cycles::CompoundCycles::new(
+                            ic_types_cycles::Cycles::zero(),
+                            ic_types_cycles::CanisterCyclesCostSchedule::Normal,
+                        ),)
                         .is_none()
                 );
             }
@@ -523,12 +521,10 @@ impl SystemStateBuilder {
                 assert!(
                     self.system_state
                         .task_queue
-                        .enqueue_on_low_wasm_memory_hook(
-                            ic_types_cycles::CompoundCycles::new(
-                                ic_types_cycles::Cycles::zero(),
-                                ic_types_cycles::CanisterCyclesCostSchedule::Normal,
-                            ),
-                        )
+                        .enqueue_on_low_wasm_memory_hook(ic_types_cycles::CompoundCycles::new(
+                            ic_types_cycles::Cycles::zero(),
+                            ic_types_cycles::CanisterCyclesCostSchedule::Normal,
+                        ),)
                         .is_none()
                 );
                 self.system_state.task_queue.pop_front();

--- a/rs/types/management_canister_types/src/lib.rs
+++ b/rs/types/management_canister_types/src/lib.rs
@@ -4570,15 +4570,24 @@ pub enum OnLowWasmMemoryHookStatus {
 }
 
 impl OnLowWasmMemoryHookStatus {
-    pub fn update(&mut self, is_hook_condition_satisfied: bool) {
-        *self = if is_hook_condition_satisfied {
-            match *self {
-                Self::ConditionNotSatisfied | Self::Ready => Self::Ready,
-                Self::Executed => Self::Executed,
+    /// Updates the status based on the live hook condition.
+    ///
+    /// Returns true if the status transitioned from `ConditionNotSatisfied` to
+    /// `Ready`, false otherwise.
+    pub fn update(&mut self, is_hook_condition_satisfied: bool) -> bool {
+        if !is_hook_condition_satisfied {
+            *self = Self::ConditionNotSatisfied;
+            return false;
+        }
+
+        match *self {
+            Self::ConditionNotSatisfied => {
+                *self = Self::Ready;
+                true
             }
-        } else {
-            Self::ConditionNotSatisfied
-        };
+            Self::Ready => false,
+            Self::Executed => false,
+        }
     }
 
     pub fn is_ready(&self) -> bool {


### PR DESCRIPTION
When a canister implements an `OnLowWasmMemory` hook, have every message execution prepay for the potential hook execution that it may trigger. This ensures that we can always execute `OnLowWasmMemory` hooks and don't have to hold on to a Ready task for a frozen canister.