### PR TITLE
fix: [EXC-1783] Infinite loop with low memory hook and low cycles

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -1082,11 +1082,6 @@ impl MemoryUsage {
 
         self.add_execution_memory(usage_growth_bytes, execution_memory_type)?;
 
-        sandbox_safe_system_state.update_status_of_low_wasm_memory_hook_condition(
-            self.wasm_memory_limit,
-            self.wasm_memory_usage,
-        );
-
         Ok(())
     }
 
@@ -1730,7 +1725,6 @@ impl SystemApiImpl {
                     requests: vec![],
                     new_global_timer: None,
                     canister_log: CanisterLog::default_delta(),
-                    on_low_wasm_memory_hook_condition_check_result: None,
                     should_bump_canister_version: false,
                 }
             }
@@ -1753,7 +1747,6 @@ impl SystemApiImpl {
                     requests: vec![],
                     new_global_timer: None,
                     canister_log: CanisterLog::default_delta(),
-                    on_low_wasm_memory_hook_condition_check_result: None,
                     should_bump_canister_version: false,
                 },
                 None => SystemStateModifications {
@@ -1767,7 +1760,6 @@ impl SystemApiImpl {
                     requests: system_state_modifications.requests,
                     new_global_timer: None,
                     canister_log: CanisterLog::default_delta(),
-                    on_low_wasm_memory_hook_condition_check_result: None,
                     should_bump_canister_version: false,
                 },
             },
@@ -1788,7 +1780,6 @@ impl SystemApiImpl {
                         requests: vec![],
                         new_global_timer: None,
                         canister_log: system_state_modifications.canister_log,
-                        on_low_wasm_memory_hook_condition_check_result: None,
                         should_bump_canister_version: false,
                     }
                 }
@@ -1805,7 +1796,6 @@ impl SystemApiImpl {
                     requests: vec![],
                     new_global_timer: None,
                     canister_log: system_state_modifications.canister_log,
-                    on_low_wasm_memory_hook_condition_check_result: None,
                     should_bump_canister_version: true,
                 },
             },
@@ -1830,7 +1820,6 @@ impl SystemApiImpl {
                         requests: vec![],
                         new_global_timer: None,
                         canister_log: system_state_modifications.canister_log,
-                        on_low_wasm_memory_hook_condition_check_result: None,
                         should_bump_canister_version: false,
                     }
                 }
@@ -1861,7 +1850,6 @@ impl SystemApiImpl {
                         requests: vec![],
                         new_global_timer: None,
                         canister_log: system_state_modifications.canister_log,
-                        on_low_wasm_memory_hook_condition_check_result: None,
                         should_bump_canister_version: false,
                     }
                 }

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -22,9 +22,8 @@ use ic_management_canister_types_private::{
 use ic_nns_constants::CYCLES_MINTING_CANISTER_ID;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::execution_state::WasmExecutionMode;
-use ic_replicated_state::canister_state::system_state::is_low_wasm_memory_hook_condition_satisfied;
 use ic_replicated_state::{
-    CallOrigin, ExecutionTask, NetworkTopology, SystemState, canister_state::DEFAULT_QUEUE_CAPACITY,
+    CallOrigin, NetworkTopology, SystemState, canister_state::DEFAULT_QUEUE_CAPACITY,
 };
 use ic_types::canister_log::CanisterLogMetrics;
 use ic_types::{
@@ -145,7 +144,6 @@ pub struct SystemStateModifications {
     pub(super) requests: Vec<Request>,
     pub(super) new_global_timer: Option<CanisterTimer>,
     pub(super) canister_log: CanisterLog,
-    pub on_low_wasm_memory_hook_condition_check_result: Option<bool>,
     pub(super) should_bump_canister_version: bool,
 }
 
@@ -162,7 +160,6 @@ impl Default for SystemStateModifications {
             requests: vec![],
             new_global_timer: None,
             canister_log: CanisterLog::default_delta(),
-            on_low_wasm_memory_hook_condition_check_result: None,
             should_bump_canister_version: false,
         }
     }
@@ -422,20 +419,6 @@ impl SystemStateModifications {
         // Verify total cycle change is not positive and update cycles balance.
         self.validate_cycle_change(system_state.canister_id() == CYCLES_MINTING_CANISTER_ID)?;
         self.apply_balance_changes(system_state);
-
-        if let Some(hook_condition_check_result) =
-            self.on_low_wasm_memory_hook_condition_check_result
-        {
-            if hook_condition_check_result {
-                system_state
-                    .task_queue
-                    .enqueue(ExecutionTask::OnLowWasmMemory);
-            } else {
-                system_state
-                    .task_queue
-                    .remove(ExecutionTask::OnLowWasmMemory);
-            }
-        }
 
         // Verify we don't accept more cycles than are available from call
         // context and update the call context balance.
@@ -1476,26 +1459,6 @@ impl SandboxSafeSystemState {
         Ok(())
     }
 
-    /// Condition for `OnLowWasmMemoryHook` is satisfied if the following holds:
-    ///
-    ///   `wasm_memory_threshold > wasm_memory_limit - wasm_memory_usage`
-    ///
-    /// Note: if `wasm_memory_limit` is not set, its default value is 4 GiB.
-    pub fn update_status_of_low_wasm_memory_hook_condition(
-        &mut self,
-        wasm_memory_limit: Option<NumBytes>,
-        wasm_memory_usage: NumBytes,
-    ) {
-        let is_condition_satisfied = is_low_wasm_memory_hook_condition_satisfied(
-            wasm_memory_usage,
-            wasm_memory_limit,
-            self.wasm_memory_threshold,
-        );
-
-        self.system_state_modifications
-            .on_low_wasm_memory_hook_condition_check_result = Some(is_condition_satisfied);
-    }
-
     /// Appends a log record to the system state changes.
     pub fn append_canister_log(&mut self, time: &Time, content: Vec<u8>) {
         self.system_state_modifications
@@ -1739,94 +1702,6 @@ mod tests {
 
         // Otherwise the correct `deadline` is returned.
         assert_eq!(helper_msg_deadline(Some(deadline)), deadline);
-    }
-
-    fn helper_create_state_for_hook_status(wasm_memory_threshold: u64) -> SandboxSafeSystemState {
-        SandboxSafeSystemState::new_internal(
-            canister_test_id(0),
-            CanisterStatusView::Running,
-            NumSeconds::from(3600),
-            MemoryAllocation::default(),
-            NumBytes::new(wasm_memory_threshold),
-            ComputeAllocation::default(),
-            Default::default(),
-            Cycles::new(1_000_000),
-            Cycles::zero(),
-            None,
-            None,
-            None,
-            None,
-            CyclesAccountManager::new(
-                NumInstructions::from(1_000_000_000),
-                SubnetType::Application,
-                subnet_test_id(0),
-                CyclesAccountManagerConfig::application_subnet(),
-            ),
-            Some(0),
-            0,
-            BTreeMap::new(),
-            0,
-            BTreeSet::new(),
-            SMALL_APP_SUBNET_MAX_SIZE,
-            CanisterCyclesCostSchedule::Normal,
-            SchedulerConfig::application_subnet().dirty_page_overhead,
-            CanisterTimer::Inactive,
-            0,
-            BTreeSet::new(),
-            RequestMetadata::new(0, Time::from_nanos_since_unix_epoch(0)),
-            None,
-            0,
-            MAX_DELTA_LOG_MEMORY_LIMIT,
-            // Wasm32 execution environment. Sufficient in testing.
-            false,
-            NetworkTopology::default(),
-        )
-    }
-
-    const GIB: u64 = 1 << 30;
-
-    fn helper_is_condition_satisfied_for_on_low_wasm_memory_hook(
-        wasm_memory_threshold: u64,
-        wasm_memory_limit: Option<u64>,
-        wasm_memory_usage: u64,
-    ) -> bool {
-        let wasm_memory_limit = wasm_memory_limit.unwrap_or(4 * GIB);
-        wasm_memory_limit < wasm_memory_usage + wasm_memory_threshold
-    }
-    #[test]
-    fn test_on_low_wasm_memory_hook_condition_update() {
-        for wasm_memory_threshold in [0, GIB, 2 * GIB, 3 * GIB, 4 * GIB] {
-            for wasm_memory_limit in [None, Some(GIB), Some(2 * GIB), Some(3 * GIB), Some(4 * GIB)]
-            {
-                for wasm_memory_usage in [0, GIB, 2 * GIB, 3 * GIB, 4 * GIB] {
-                    let mut state = helper_create_state_for_hook_status(wasm_memory_threshold);
-
-                    assert_eq!(
-                        state
-                            .system_state_modifications
-                            .on_low_wasm_memory_hook_condition_check_result,
-                        None
-                    );
-
-                    state.update_status_of_low_wasm_memory_hook_condition(
-                        wasm_memory_limit.map(|m| m.into()),
-                        wasm_memory_usage.into(),
-                    );
-
-                    assert_eq!(
-                        state
-                            .system_state_modifications
-                            .on_low_wasm_memory_hook_condition_check_result
-                            .unwrap(),
-                        helper_is_condition_satisfied_for_on_low_wasm_memory_hook(
-                            wasm_memory_threshold,
-                            wasm_memory_limit,
-                            wasm_memory_usage
-                        )
-                    );
-                }
-            }
-        }
     }
 
     fn generate_inputs_expectations_for_use_case_both_some(

--- a/rs/embedders/tests/system_api.rs
+++ b/rs/embedders/tests/system_api.rs
@@ -1,4 +1,4 @@
-use ic_base_types::{NumBytes, NumSeconds, PrincipalIdBlobParseError};
+use ic_base_types::{NumSeconds, PrincipalIdBlobParseError};
 use ic_config::{embedders::Config as EmbeddersConfig, subnet_config::SchedulerConfig};
 use ic_cycles_account_manager::CyclesAccountManager;
 use ic_embedders::wasmtime_embedder::system_api::{
@@ -8,11 +8,10 @@ use ic_embedders::wasmtime_embedder::system_api::{
 use ic_error_types::RejectCode;
 use ic_interfaces::execution_environment::{
     CanisterOutOfCyclesError, HypervisorError, HypervisorResult, PerformanceCounterType,
-    StableMemoryApi, SubnetAvailableMemory, SystemApi, SystemApiCallId, TrapCode,
+    SubnetAvailableMemory, SystemApi, SystemApiCallId, TrapCode,
 };
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
 use ic_logger::replica_logger::no_op_logger;
-use ic_management_canister_types_private::OnLowWasmMemoryHookStatus;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     CallOrigin, Memory, NetworkTopology, NumWasmPages, SystemState, testing::CanisterQueuesTesting,
@@ -24,8 +23,7 @@ use ic_test_utilities_types::{
     messages::RequestBuilder,
 };
 use ic_types::{
-    CanisterTimer, CountBytes, MAX_STABLE_MEMORY_IN_BYTES, NumInstructions, PrincipalId, SubnetId,
-    Time,
+    CanisterTimer, CountBytes, NumInstructions, PrincipalId, SubnetId, Time,
     canister_log::CanisterLogMetrics,
     messages::{
         CallbackId, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, RejectContext, RequestOrResponse,
@@ -1612,212 +1610,6 @@ fn growing_wasm_memory_updates_subnet_available_memory() {
     assert_eq!(
         subnet_available_memory.get_wasm_custom_sections_memory(),
         wasm_custom_sections_available_memory_before
-    );
-}
-
-const GIB: i64 = 1 << 30;
-
-fn helper_test_on_low_wasm_memory(
-    wasm_memory_threshold: NumBytes,
-    wasm_memory_limit: Option<NumBytes>,
-    memory_allocation: Option<NumBytes>,
-    grow_memory_size: i64,
-    grow_wasm_memory: bool,
-    start_status: OnLowWasmMemoryHookStatus,
-    expected_status: OnLowWasmMemoryHookStatus,
-) {
-    let wasm_page_size = 64 << 10;
-    let subnet_available_memory_bytes = 20 * GIB;
-    let subnet_available_memory =
-        SubnetAvailableMemory::new_for_testing(subnet_available_memory_bytes, 0, 0);
-
-    let mut state_builder = SystemStateBuilder::default()
-        .wasm_memory_threshold(wasm_memory_threshold)
-        .wasm_memory_limit(wasm_memory_limit)
-        .empty_task_queue_with_on_low_wasm_memory_hook_status(start_status)
-        .initial_cycles(Cycles::from(10_000_000_000_000_000_u128));
-
-    if let Some(memory_allocation) = memory_allocation {
-        state_builder = state_builder.memory_allocation(memory_allocation);
-    };
-
-    let mut system_state = state_builder.build();
-
-    let api_type = ApiTypeBuilder::build_update_api();
-    let mut execution_parameters = execution_parameters(api_type.execution_mode());
-    execution_parameters.memory_allocation = system_state.memory_allocation;
-    execution_parameters.wasm_memory_limit = system_state.wasm_memory_limit;
-
-    let sandbox_safe_system_state = SandboxSafeSystemState::new_for_testing(
-        &system_state,
-        CyclesAccountManagerBuilder::new().build(),
-        &NetworkTopology::default(),
-        SchedulerConfig::application_subnet().dirty_page_overhead,
-        execution_parameters.compute_allocation,
-        execution_parameters.canister_guaranteed_callback_quota,
-        Default::default(),
-        api_type.caller(),
-        api_type.call_context_id(),
-        CanisterCyclesCostSchedule::Normal,
-    );
-
-    let mut api = SystemApiImpl::new(
-        api_type,
-        sandbox_safe_system_state,
-        CANISTER_CURRENT_MEMORY_USAGE,
-        CANISTER_CURRENT_MESSAGE_MEMORY_USAGE,
-        execution_parameters,
-        subnet_available_memory,
-        &EmbeddersConfig::default(),
-        Memory::new_for_testing(),
-        NumWasmPages::from(0),
-        Rc::new(DefaultOutOfInstructionsHandler::default()),
-        no_op_logger(),
-    );
-
-    let additional_wasm_pages = (grow_memory_size as u64).div_ceil(wasm_page_size as u64);
-
-    if grow_wasm_memory {
-        api.try_grow_wasm_memory(0, additional_wasm_pages).unwrap();
-    } else {
-        api.try_grow_stable_memory(
-            0,
-            additional_wasm_pages,
-            MAX_STABLE_MEMORY_IN_BYTES,
-            StableMemoryApi::Stable64,
-        )
-        .unwrap();
-    }
-
-    let system_state_modifications = api.take_system_state_modifications();
-    system_state_modifications
-        .apply_changes(
-            UNIX_EPOCH,
-            &mut system_state,
-            &default_network_topology(),
-            subnet_test_id(1),
-            false,
-            &NoOpMetrics {},
-            &no_op_logger(),
-        )
-        .unwrap();
-
-    // The hook status is re-evaluated after every successful execution by
-    // `apply_canister_state_changes`; mirror that here.
-    if grow_wasm_memory {
-        let new_wasm_memory_usage = NumBytes::new(additional_wasm_pages * wasm_page_size as u64);
-        system_state.update_on_low_wasm_memory_hook_status(new_wasm_memory_usage);
-    }
-
-    assert_eq!(system_state.task_queue.peek_hook_status(), expected_status);
-}
-
-#[test]
-fn test_on_low_wasm_memory_grow_wasm_memory_all_status_changes() {
-    let wasm_memory_threshold = NumBytes::new(GIB as u64);
-    let wasm_memory_limit = Some(NumBytes::new(3 * GIB as u64));
-    let memory_allocation = None;
-    // `max_allowed_wasm_memory` = `wasm_memory_limit` - `wasm_memory_threshold`
-    let max_allowed_wasm_memory = 2 * GIB;
-    let grow_wasm_memory = true;
-
-    // Hook condition is not satisfied.
-    helper_test_on_low_wasm_memory(
-        wasm_memory_threshold,
-        wasm_memory_limit,
-        memory_allocation,
-        max_allowed_wasm_memory,
-        grow_wasm_memory,
-        OnLowWasmMemoryHookStatus::ConditionNotSatisfied,
-        OnLowWasmMemoryHookStatus::ConditionNotSatisfied,
-    );
-
-    // Hook condition is satisfied.
-    helper_test_on_low_wasm_memory(
-        wasm_memory_threshold,
-        wasm_memory_limit,
-        memory_allocation,
-        max_allowed_wasm_memory + 1,
-        grow_wasm_memory,
-        OnLowWasmMemoryHookStatus::ConditionNotSatisfied,
-        OnLowWasmMemoryHookStatus::Ready,
-    );
-
-    // Hook condition is not satisfied.
-    helper_test_on_low_wasm_memory(
-        wasm_memory_threshold,
-        wasm_memory_limit,
-        memory_allocation,
-        max_allowed_wasm_memory,
-        grow_wasm_memory,
-        OnLowWasmMemoryHookStatus::Ready,
-        OnLowWasmMemoryHookStatus::ConditionNotSatisfied,
-    );
-
-    // Hook condition is satisfied.
-    helper_test_on_low_wasm_memory(
-        wasm_memory_threshold,
-        wasm_memory_limit,
-        memory_allocation,
-        max_allowed_wasm_memory + 1,
-        grow_wasm_memory,
-        OnLowWasmMemoryHookStatus::Ready,
-        OnLowWasmMemoryHookStatus::Ready,
-    );
-
-    // Hook condition is not satisfied.
-    helper_test_on_low_wasm_memory(
-        wasm_memory_threshold,
-        wasm_memory_limit,
-        memory_allocation,
-        max_allowed_wasm_memory,
-        grow_wasm_memory,
-        OnLowWasmMemoryHookStatus::Executed,
-        OnLowWasmMemoryHookStatus::ConditionNotSatisfied,
-    );
-
-    // Hook condition is satisfied.
-    helper_test_on_low_wasm_memory(
-        wasm_memory_threshold,
-        wasm_memory_limit,
-        memory_allocation,
-        max_allowed_wasm_memory + 1,
-        grow_wasm_memory,
-        OnLowWasmMemoryHookStatus::Executed,
-        OnLowWasmMemoryHookStatus::Executed,
-    );
-}
-
-#[test]
-fn test_on_low_wasm_memory_without_memory_limit() {
-    // When memory limit is not set, the default Wasm memory limit is 4 GIB.
-    let wasm_memory_threshold = NumBytes::new(GIB as u64);
-    // `max_allowed_wasm_memory` = `wasm_memory_limit` - `wasm_memory_threshold`
-    let max_allowed_wasm_memory = 3 * GIB;
-    let wasm_memory_limit = None;
-    let memory_allocation = None;
-    let grow_wasm_memory = true;
-
-    // Hook condition is not satisfied.
-    helper_test_on_low_wasm_memory(
-        wasm_memory_threshold,
-        wasm_memory_limit,
-        memory_allocation,
-        max_allowed_wasm_memory,
-        grow_wasm_memory,
-        OnLowWasmMemoryHookStatus::ConditionNotSatisfied,
-        OnLowWasmMemoryHookStatus::ConditionNotSatisfied,
-    );
-
-    // Hook condition is satisfied.
-    helper_test_on_low_wasm_memory(
-        wasm_memory_threshold,
-        wasm_memory_limit,
-        memory_allocation,
-        max_allowed_wasm_memory + 1,
-        grow_wasm_memory,
-        OnLowWasmMemoryHookStatus::ConditionNotSatisfied,
-        OnLowWasmMemoryHookStatus::Ready,
     );
 }
 

--- a/rs/embedders/tests/system_api.rs
+++ b/rs/embedders/tests/system_api.rs
@@ -1702,6 +1702,13 @@ fn helper_test_on_low_wasm_memory(
         )
         .unwrap();
 
+    // The hook status is re-evaluated after every successful execution by
+    // `apply_canister_state_changes`; mirror that here.
+    if grow_wasm_memory {
+        let new_wasm_memory_usage = NumBytes::new(additional_wasm_pages * wasm_page_size as u64);
+        system_state.update_on_low_wasm_memory_hook_status(new_wasm_memory_usage);
+    }
+
     assert_eq!(system_state.task_queue.peek_hook_status(), expected_status);
 }
 

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -92,6 +92,7 @@ rust_ic_test(
         "//rs/test_utilities",
         "//rs/test_utilities/consensus",
         "//rs/test_utilities/execution_environment",
+        "//rs/test_utilities/logger",
         "//rs/test_utilities/metrics",
         "//rs/test_utilities/state",
         "//rs/test_utilities/types",

--- a/rs/execution_environment/src/execution/call_or_task.rs
+++ b/rs/execution_environment/src/execution/call_or_task.rs
@@ -85,20 +85,29 @@ pub fn execute_call_or_task(
                     Ok(cycles) => cycles,
                     Err(err) => {
                         if call_or_task == CanisterCallOrTask::Task(CanisterTask::OnLowWasmMemory) {
-                            //`OnLowWasmMemoryHook` is taken from task_queue (i.e. `OnLowWasmMemoryHookStatus` is `Executed`),
-                            // but it was not executed due to the freezing of the canister. To ensure that the hook is executed
-                            // when the canister is unfrozen we need to set `OnLowWasmMemoryHookStatus` to `Ready`. Because of
-                            // the way `OnLowWasmMemoryHookStatus::update` is implemented we first need to remove it from the
-                            // task_queue (which calls `OnLowWasmMemoryHookStatus::update(false)`) followed with `enqueue`
-                            // (which calls `OnLowWasmMemoryHookStatus::update(true)`) to ensure desired behavior.
+                            // `OnLowWasmMemoryHook` was taken from `task_queue` (so `OnLowWasmMemoryHookStatus` is
+                            // `Executed`), but it could not run because the canister is frozen. If we left the
+                            // status as `Executed` or re-enqueued the hook to `Ready`, the scheduler would either
+                            // never re-fire the hook (because the memory condition is still satisfied so the
+                            // `Executed -> Ready` transition never happens) or would immediately pop it again,
+                            // re-enter this branch, and spin in a tight loop until the round instruction limit is
+                            // reached.
+                            //
+                            // Instead we reset the status to `ConditionNotSatisfied` and rely on
+                            // `finish_subnet_message_execution` to re-arm the hook on the next successful
+                            // management call against this canister (e.g. `deposit_cycles`, `update_settings`,
+                            // `provisional_top_up_canister`, ...): that path calls
+                            // `update_on_low_wasm_memory_hook_condition`, sees the live memory condition is still
+                            // satisfied, observes the status as inconsistent and flips it back to `Ready`.
+                            //
+                            // This leaves the canister in a transiently inconsistent state
+                            // (`(ConditionNotSatisfied, condition = true)`); `CanisterSnapshot::from_canister`
+                            // hides this by lifting the snapshot's stored status to `Ready` in this case, so
+                            // observers of snapshot metadata never see the lie.
                             canister
                                 .system_state
                                 .task_queue
                                 .remove(ic_replicated_state::ExecutionTask::OnLowWasmMemory);
-                            canister
-                                .system_state
-                                .task_queue
-                                .enqueue(ic_replicated_state::ExecutionTask::OnLowWasmMemory);
                         }
                         return finish_call_with_error(
                             UserError::new(ErrorCode::CanisterOutOfCycles, err),

--- a/rs/execution_environment/src/execution/call_or_task.rs
+++ b/rs/execution_environment/src/execution/call_or_task.rs
@@ -85,25 +85,17 @@ pub fn execute_call_or_task(
                     Ok(cycles) => cycles,
                     Err(err) => {
                         if call_or_task == CanisterCallOrTask::Task(CanisterTask::OnLowWasmMemory) {
-                            // `OnLowWasmMemoryHook` was taken from `task_queue` (so `OnLowWasmMemoryHookStatus` is
-                            // `Executed`), but it could not run because the canister is frozen. If we left the
-                            // status as `Executed` or re-enqueued the hook to `Ready`, the scheduler would either
-                            // never re-fire the hook (because the memory condition is still satisfied so the
-                            // `Executed -> Ready` transition never happens) or would immediately pop it again,
-                            // re-enter this branch, and spin in a tight loop until the round instruction limit is
-                            // reached.
+                            // `OnLowWasmMemoryHook` was taken from `task_queue` (so the hook status is now
+                            // `Executed`), but it could not run because not enough cycles were available.
+                            // If we left the status as `Executed`, the hook would never be executed; if we
+                            // re-enqueued the hook as `Ready`, we would immediately pop it again and enter
+                            // an infinite loop (or spin until the round instruction limit is reached).
                             //
-                            // Instead we reset the status to `ConditionNotSatisfied` and rely on
-                            // `finish_subnet_message_execution` to re-arm the hook on the next successful
-                            // management call against this canister (e.g. `deposit_cycles`, `update_settings`,
-                            // `provisional_top_up_canister`, ...): that path calls
-                            // `update_on_low_wasm_memory_hook_condition`, sees the live memory condition is still
-                            // satisfied, observes the status as inconsistent and flips it back to `Ready`.
+                            // Instead we "forget" the hook status and rely on the next message (or
+                            // management call) to re-enqueue it.
                             //
                             // This leaves the canister in a transiently inconsistent state
-                            // (`(ConditionNotSatisfied, condition = true)`); `CanisterSnapshot::from_canister`
-                            // hides this by lifting the snapshot's stored status to `Ready` in this case, so
-                            // observers of snapshot metadata never see the lie.
+                            // (`(ConditionNotSatisfied, condition = true)`).
                             canister
                                 .system_state
                                 .task_queue

--- a/rs/execution_environment/src/execution/common.rs
+++ b/rs/execution_environment/src/execution/common.rs
@@ -622,6 +622,12 @@ pub fn apply_canister_state_changes(
             output.wasm_result = Err(err);
         }
     }
+
+    // Re-evaluate the `OnLowWasmMemory` hook condition after every execution,
+    // regardless of whether memory was grown (or even of success), because the
+    // scheduler will sometimes "forget" a `Ready` status (if not enough cycles were
+    // available to execute the hook).
+    system_state.update_on_low_wasm_memory_hook_status(execution_state.wasm_memory_usage());
 }
 
 pub(crate) fn finish_call_with_error(

--- a/rs/execution_environment/src/execution/common.rs
+++ b/rs/execution_environment/src/execution/common.rs
@@ -710,54 +710,196 @@ pub fn log_dirty_pages(
 
 #[cfg(test)]
 mod test {
-    use super::wasm_result_to_query_response;
-    use crate::ExecutionResponse;
-    use ic_base_types::{CanisterId, NumSeconds};
-    use ic_error_types::UserError;
-    use ic_logger::{LoggerImpl, ReplicaLogger};
-    use ic_replicated_state::{
-        CanisterState, SchedulerState, SystemState,
-        canister_state::canister_snapshots::CanisterSnapshots,
-    };
-    use ic_types::Time;
-    use ic_types::messages::{CallbackId, NO_DEADLINE};
-    use ic_types_cycles::Cycles;
+    use super::*;
+
+    use crate::metrics::CallTreeMetricsNoOp;
+    use ic_base_types::NumSeconds;
+    use ic_management_canister_types_private::OnLowWasmMemoryHookStatus;
+    use ic_metrics::MetricsRegistry;
+    use ic_replicated_state::canister_state::WASM_PAGE_SIZE_IN_BYTES;
+    use ic_replicated_state::canister_state::canister_snapshots::CanisterSnapshots;
+    use ic_replicated_state::{Memory, NumWasmPages, PageMap, SchedulerState};
+    use ic_test_utilities_logger::with_test_replica_logger;
+    use ic_test_utilities_state::{ExecutionStateBuilder, SystemStateBuilder};
+    use ic_test_utilities_types::ids::subnet_test_id;
+    use ic_types::messages::NO_DEADLINE;
+    use ic_types::time::UNIX_EPOCH;
 
     #[test]
     fn test_wasm_result_to_query_response_refunds_correctly() {
-        let scheduler_state = SchedulerState::default();
-        let system_state = SystemState::new_running_for_testing(
-            CanisterId::from_u64(42),
-            CanisterId::from(100_u64).into(),
-            Cycles::new(1 << 36),
-            NumSeconds::from(100_000),
-        );
-        let canister_snapshots = CanisterSnapshots::default();
+        with_test_replica_logger(|log| {
+            let scheduler_state = SchedulerState::default();
+            let system_state = SystemState::new_running_for_testing(
+                CanisterId::from_u64(42),
+                CanisterId::from_u64(100).get(),
+                Cycles::new(1 << 36),
+                NumSeconds::new(100_000),
+            );
+            let canister_snapshots = CanisterSnapshots::default();
 
-        let logger = LoggerImpl::new(&Default::default(), "test".to_string());
-        let log = ReplicaLogger::new(logger.root.clone().into());
+            let response = wasm_result_to_query_response(
+                Err(UserError::new(
+                    ic_error_types::ErrorCode::CanisterCalledTrap,
+                    "",
+                )),
+                &CanisterState::new(system_state, None, scheduler_state, canister_snapshots),
+                Time::from_nanos_since_unix_epoch(100),
+                ic_replicated_state::CallOrigin::CanisterUpdate(
+                    CanisterId::from_u64(123),
+                    CallbackId::new(2),
+                    NO_DEADLINE,
+                    String::from(""),
+                ),
+                &log,
+                Cycles::new(1000_u128),
+            );
 
-        let response = wasm_result_to_query_response(
-            Err(UserError::new(
-                ic_error_types::ErrorCode::CanisterCalledTrap,
-                "",
-            )),
-            &CanisterState::new(system_state, None, scheduler_state, canister_snapshots),
-            Time::from_nanos_since_unix_epoch(100),
-            ic_replicated_state::CallOrigin::CanisterUpdate(
-                CanisterId::from(123_u64),
-                CallbackId::new(2),
-                NO_DEADLINE,
-                String::from(""),
-            ),
-            &log,
-            Cycles::from(1000_u128),
-        );
+            if let ExecutionResponse::Request(response) = response {
+                assert_eq!(response.refund, Cycles::new(1000_u128));
+            } else {
+                panic!("Unexpected response.");
+            }
+        })
+    }
 
-        if let ExecutionResponse::Request(response) = response {
-            assert_eq!(response.refund, Cycles::from(1000_u128));
-        } else {
-            panic!("Unexpected response.");
+    /// Runs `apply_canister_state_changes` with a `SystemState` parameterized by
+    /// `wasm_memory_threshold` / `wasm_memory_limit` / `start_status` and an
+    /// `ExecutionStateChanges` whose `wasm_memory` is sized to
+    /// `post_execution_wasm_pages`. Returns the resulting hook status to verify
+    /// that the hook is re-evaluated against the freshly committed Wasm memory
+    /// usage.
+    fn run_low_wasm_memory_hook_check(
+        wasm_memory_threshold: NumBytes,
+        wasm_memory_limit: Option<NumBytes>,
+        post_execution_wasm_pages: NumWasmPages,
+        start_status: OnLowWasmMemoryHookStatus,
+    ) -> OnLowWasmMemoryHookStatus {
+        with_test_replica_logger(|log| {
+            let mut system_state = SystemStateBuilder::default()
+                .wasm_memory_threshold(wasm_memory_threshold)
+                .wasm_memory_limit(wasm_memory_limit)
+                .empty_task_queue_with_on_low_wasm_memory_hook_status(start_status)
+                .build();
+            let mut execution_state = ExecutionStateBuilder::new().build();
+
+            let canister_state_changes = CanisterStateChanges {
+                execution_state_changes: Some(ExecutionStateChanges {
+                    globals: vec![],
+                    wasm_memory: Memory::new(PageMap::new_for_testing(), post_execution_wasm_pages),
+                    stable_memory: Memory::new_for_testing(),
+                }),
+                system_state_modifications: Default::default(),
+            };
+
+            let mut output = WasmExecutionOutput {
+                wasm_result: Ok(None),
+                num_instructions_left: NumInstructions::from(0),
+                allocated_bytes: NumBytes::from(0),
+                allocated_guaranteed_response_message_bytes: NumBytes::from(0),
+                new_memory_usage: None,
+                new_message_memory_usage: None,
+                instance_stats: Default::default(),
+                system_api_call_counters: Default::default(),
+            };
+            let mut round_limits = RoundLimits {
+                instructions: as_round_instructions(NumInstructions::from(i64::MAX as u64)),
+                subnet_available_memory: SubnetAvailableMemory::new_for_testing(i64::MAX, 0, 0),
+                subnet_available_callbacks: i64::MAX,
+                compute_allocation_used: 0,
+                subnet_memory_reservation: NumBytes::from(0),
+            };
+
+            let metrics_registry = MetricsRegistry::new();
+            let hypervisor_metrics = HypervisorMetrics::new(&metrics_registry);
+            let state_changes_error = IntCounter::new("test_state_changes_error", "test").unwrap();
+
+            apply_canister_state_changes(
+                canister_state_changes,
+                &mut execution_state,
+                &mut system_state,
+                &mut output,
+                &mut round_limits,
+                UNIX_EPOCH,
+                &Default::default(),
+                subnet_test_id(1),
+                &hypervisor_metrics,
+                &log,
+                &state_changes_error,
+                &CallTreeMetricsNoOp,
+                UNIX_EPOCH,
+                false,
+                &|_| {},
+            );
+
+            system_state.task_queue.peek_hook_status()
+        })
+    }
+
+    /// Returns a Wasm page count whose byte size equals `bytes` (rounded up).
+    fn wasm_pages_for(bytes: u64) -> NumWasmPages {
+        NumWasmPages::from(bytes.div_ceil(WASM_PAGE_SIZE_IN_BYTES as u64) as usize)
+    }
+
+    const GIB: u64 = 1 << 30;
+
+    #[test]
+    fn apply_canister_state_changes_updates_low_wasm_memory_hook() {
+        let wasm_memory_threshold = NumBytes::new(GIB);
+        let wasm_memory_limit = Some(NumBytes::new(3 * GIB));
+        // `max_allowed_wasm_memory` = `wasm_memory_limit` - `wasm_memory_threshold`
+        let max_allowed_wasm_memory = 2 * GIB;
+        let unsatisfied = wasm_pages_for(max_allowed_wasm_memory);
+        let satisfied = wasm_pages_for(max_allowed_wasm_memory + 1);
+
+        use OnLowWasmMemoryHookStatus::*;
+        let cases = [
+            (unsatisfied, ConditionNotSatisfied, ConditionNotSatisfied),
+            (unsatisfied, Ready, ConditionNotSatisfied),
+            (unsatisfied, Executed, ConditionNotSatisfied),
+            (satisfied, ConditionNotSatisfied, Ready),
+            (satisfied, Ready, Ready),
+            (satisfied, Executed, Executed),
+        ];
+        for (post_execution_wasm_pages, start_status, expected_status) in cases {
+            let actual = run_low_wasm_memory_hook_check(
+                wasm_memory_threshold,
+                wasm_memory_limit,
+                post_execution_wasm_pages,
+                start_status,
+            );
+            assert_eq!(
+                actual, expected_status,
+                "post_pages = {post_execution_wasm_pages:?}, start = {start_status:?}",
+            );
         }
+    }
+
+    #[test]
+    fn apply_canister_state_changes_uses_default_4gib_limit_when_unset() {
+        // When the memory limit is not set, the default Wasm memory limit is 4 GiB.
+        let wasm_memory_threshold = NumBytes::new(GIB);
+        let wasm_memory_limit = None;
+        // `max_allowed_wasm_memory` = `wasm_memory_limit` - `wasm_memory_threshold`
+        let max_allowed_wasm_memory = 3 * GIB;
+
+        use OnLowWasmMemoryHookStatus::*;
+        assert_eq!(
+            run_low_wasm_memory_hook_check(
+                wasm_memory_threshold,
+                wasm_memory_limit,
+                wasm_pages_for(max_allowed_wasm_memory),
+                ConditionNotSatisfied,
+            ),
+            ConditionNotSatisfied,
+        );
+        assert_eq!(
+            run_low_wasm_memory_hook_check(
+                wasm_memory_threshold,
+                wasm_memory_limit,
+                wasm_pages_for(max_allowed_wasm_memory + 1),
+                ConditionNotSatisfied,
+            ),
+            Ready,
+        );
     }
 }

--- a/rs/execution_environment/src/execution_environment/tests/canister_task.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_task.rs
@@ -1260,7 +1260,22 @@ fn on_low_wasm_memory_hook_is_run_after_freezing() {
         NumWasmPages::new(8)
     );
 
-    // The hook status is still `Ready`.
+    // The hook status was reset because it could not be executed.
+    assert_eq!(
+        test.state()
+            .canister_state(&canister_id)
+            .unwrap()
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::ConditionNotSatisfied
+    );
+
+    // We update `freezing_threshold` unfreezing canister.
+    test.update_freezing_threshold(canister_id, NumSeconds::new(100))
+        .unwrap();
+
+    // This re-evaluated the hook condition and set its status to `Ready`.
     assert_eq!(
         test.state()
             .canister_state(&canister_id)
@@ -1270,10 +1285,6 @@ fn on_low_wasm_memory_hook_is_run_after_freezing() {
             .peek_hook_status(),
         OnLowWasmMemoryHookStatus::Ready
     );
-
-    // We update `freezing_threshold` unfreezing canister.
-    test.update_freezing_threshold(canister_id, NumSeconds::new(100))
-        .unwrap();
 
     // The hook is executed.
     test.execute_slice(canister_id);

--- a/rs/execution_environment/src/scheduler/tests/scheduling.rs
+++ b/rs/execution_environment/src/scheduler/tests/scheduling.rs
@@ -5,6 +5,8 @@ use super::test_utilities::{
 };
 use super::*;
 use ic_config::subnet_config::SchedulerConfig;
+use ic_management_canister_types_private::OnLowWasmMemoryHookStatus;
+use ic_replicated_state::canister_state::canister_snapshots::CanisterSnapshot;
 use ic_replicated_state::testing::CanisterQueuesTesting;
 use ic_types::ComputeAllocation;
 use ic_types::methods::SystemMethod;
@@ -1200,4 +1202,112 @@ fn frozen_canisters_with_heartbeats_or_timers_are_not_scheduled() {
             0
         );
     }
+}
+
+/// Ensures that `inner_round()` continues with another iteration after the
+/// previous iteration only processed messages that got rejected (e.g. because
+/// the callee was low on cycles), with zero Wasm instructions executed.
+///
+/// Also exercises the recovery path for an `OnLowWasmMemory` hook that could
+/// not run because the canister was frozen: the live status is dropped to
+/// `ConditionNotSatisfied` so the per-canister loop terminates immediately,
+/// snapshots taken in that transient state still report `Ready` (since the
+/// memory condition is genuinely satisfied), and the next call to
+/// `update_on_low_wasm_memory_hook_condition` re-arms the live status to
+/// `Ready` ahead of the next round.
+#[test]
+fn frozen_canister_with_on_low_wasm_memory_hook() {
+    let mut test = SchedulerTestBuilder::new()
+        .with_scheduler_config(SchedulerConfig::application_subnet())
+        .build();
+
+    let canister = test.create_canister_with(
+        Cycles::new(1_000_000),
+        ComputeAllocation::zero(),
+        MemoryAllocation::default(),
+        Some(SystemMethod::CanisterOnLowWasmMemory),
+        None,
+        None,
+    );
+    // Make the hook condition genuinely satisfied so the snapshot-lift path
+    // is exercised. With no explicit `wasm_memory_limit` the limit defaults
+    // to 4 GiB, so any threshold larger than that triggers the condition
+    // regardless of actual memory usage:
+    //   `wasm_memory_threshold > wasm_memory_limit - wasm_memory_usage`.
+    let canister_state = test.canister_state_mut(canister);
+    canister_state.system_state.wasm_memory_threshold =
+        NumBytes::new(4 * 1024 * 1024 * 1024 + 1);
+    canister_state
+        .system_state
+        .task_queue
+        .enqueue(ExecutionTask::OnLowWasmMemory);
+    assert_eq!(
+        test.canister_state(canister)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Ready
+    );
+
+    test.execute_round(ExecutionRoundType::OrdinaryRound);
+
+    // The frozen canister could not pay for the hook execution, so the hook
+    // was reset to `ConditionNotSatisfied` to break what would otherwise be
+    // an infinite loop in the scheduler's per-canister inner loop. The round
+    // therefore terminates without exhausting the round instruction budget
+    // and without being marked as interrupted.
+    assert_eq!(
+        test.canister_state(canister)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::ConditionNotSatisfied
+    );
+    assert_eq!(
+        test.canister_state(canister)
+            .system_state
+            .canister_metrics()
+            .interrupted_during_execution(),
+        0
+    );
+    assert_eq!(
+        test.canister_state(canister)
+            .system_state
+            .canister_metrics()
+            .instructions_executed(),
+        NumInstructions::from(0)
+    );
+
+    // A snapshot taken while the canister is in the transient `(status =
+    // ConditionNotSatisfied, condition = true)` state must hide the
+    // inconsistency by lifting the recorded status to `Ready`. Otherwise a
+    // metadata round-trip via `upload_canister_snapshot_metadata` would be
+    // rejected by the `is_consistent_with` check.
+    let snapshot =
+        CanisterSnapshot::from_canister(test.canister_state(canister), test.state().time())
+            .unwrap();
+    assert_eq!(
+        snapshot
+            .execution_snapshot()
+            .on_low_wasm_memory_hook_status,
+        Some(OnLowWasmMemoryHookStatus::Ready)
+    );
+
+    // Simulate the work done by `finish_subnet_message_execution` after any
+    // successful management call against this canister (e.g. `deposit_cycles`
+    // or `update_settings`): re-evaluating the hook condition observes the
+    // live status as inconsistent with the actual memory condition and flips
+    // it back to `Ready`. The hook will then run in a subsequent round once
+    // the canister is no longer frozen.
+    test.state_mut()
+        .canister_state_mut_arc(&canister)
+        .unwrap()
+        .update_on_low_wasm_memory_hook_condition();
+    assert_eq!(
+        test.canister_state(canister)
+            .system_state
+            .task_queue
+            .peek_hook_status(),
+        OnLowWasmMemoryHookStatus::Ready
+    );
 }

--- a/rs/execution_environment/src/scheduler/tests/scheduling.rs
+++ b/rs/execution_environment/src/scheduler/tests/scheduling.rs
@@ -1204,11 +1204,7 @@ fn frozen_canisters_with_heartbeats_or_timers_are_not_scheduled() {
     }
 }
 
-/// Ensures that `inner_round()` continues with another iteration after the
-/// previous iteration only processed messages that got rejected (e.g. because
-/// the callee was low on cycles), with zero Wasm instructions executed.
-///
-/// Also exercises the recovery path for an `OnLowWasmMemory` hook that could
+/// Exercises the recovery path for an `OnLowWasmMemory` hook that could
 /// not run because the canister was frozen: the live status is dropped to
 /// `ConditionNotSatisfied` so the per-canister loop terminates immediately,
 /// snapshots taken in that transient state still report `Ready` (since the
@@ -1229,13 +1225,11 @@ fn frozen_canister_with_on_low_wasm_memory_hook() {
         None,
         None,
     );
-    // Make the hook condition genuinely satisfied so the snapshot-lift path
-    // is exercised. With no explicit `wasm_memory_limit` the limit defaults
-    // to 4 GiB, so any threshold larger than that triggers the condition
-    // regardless of actual memory usage:
-    //   `wasm_memory_threshold > wasm_memory_limit - wasm_memory_usage`.
+    // Make the hook condition genuinely satisfied.
     let canister_state = test.canister_state_mut(canister);
+    canister_state.system_state.wasm_memory_limit = Some(NumBytes::new(4 * 1024 * 1024 * 1024));
     canister_state.system_state.wasm_memory_threshold = NumBytes::new(4 * 1024 * 1024 * 1024 + 1);
+
     canister_state
         .system_state
         .task_queue
@@ -1253,21 +1247,13 @@ fn frozen_canister_with_on_low_wasm_memory_hook() {
     // The frozen canister could not pay for the hook execution, so the hook
     // was reset to `ConditionNotSatisfied` to break what would otherwise be
     // an infinite loop in the scheduler's per-canister inner loop. The round
-    // therefore terminates without exhausting the round instruction budget
-    // and without being marked as interrupted.
+    // therefore terminates without exhausting the round instruction budget.
     assert_eq!(
         test.canister_state(canister)
             .system_state
             .task_queue
             .peek_hook_status(),
         OnLowWasmMemoryHookStatus::ConditionNotSatisfied
-    );
-    assert_eq!(
-        test.canister_state(canister)
-            .system_state
-            .canister_metrics()
-            .interrupted_during_execution(),
-        0
     );
     assert_eq!(
         test.canister_state(canister)
@@ -1290,12 +1276,12 @@ fn frozen_canister_with_on_low_wasm_memory_hook() {
         Some(OnLowWasmMemoryHookStatus::Ready)
     );
 
-    // Simulate the work done by `finish_subnet_message_execution` after any
-    // successful management call against this canister (e.g. `deposit_cycles`
-    // or `update_settings`): re-evaluating the hook condition observes the
-    // live status as inconsistent with the actual memory condition and flips
-    // it back to `Ready`. The hook will then run in a subsequent round once
-    // the canister is no longer frozen.
+    // Simulate the work done by `apply_canister_state_changes` /
+    // `finish_subnet_message_execution` after any completed execution / management
+    // call against this canister: re-evaluating the hook condition observes the
+    // live status as inconsistent with the actual memory condition and flips it
+    // back to `Ready`. The hook will then be re-enqueued and run in a subsequent
+    // round, once the canister is no longer frozen.
     test.state_mut()
         .canister_state_mut_arc(&canister)
         .unwrap()

--- a/rs/execution_environment/src/scheduler/tests/scheduling.rs
+++ b/rs/execution_environment/src/scheduler/tests/scheduling.rs
@@ -1235,8 +1235,7 @@ fn frozen_canister_with_on_low_wasm_memory_hook() {
     // regardless of actual memory usage:
     //   `wasm_memory_threshold > wasm_memory_limit - wasm_memory_usage`.
     let canister_state = test.canister_state_mut(canister);
-    canister_state.system_state.wasm_memory_threshold =
-        NumBytes::new(4 * 1024 * 1024 * 1024 + 1);
+    canister_state.system_state.wasm_memory_threshold = NumBytes::new(4 * 1024 * 1024 * 1024 + 1);
     canister_state
         .system_state
         .task_queue
@@ -1287,9 +1286,7 @@ fn frozen_canister_with_on_low_wasm_memory_hook() {
         CanisterSnapshot::from_canister(test.canister_state(canister), test.state().time())
             .unwrap();
     assert_eq!(
-        snapshot
-            .execution_snapshot()
-            .on_low_wasm_memory_hook_status,
+        snapshot.execution_snapshot().on_low_wasm_memory_hook_status,
         Some(OnLowWasmMemoryHookStatus::Ready)
     );
 

--- a/rs/replicated_state/src/canister_state/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_state/canister_snapshots.rs
@@ -282,7 +282,23 @@ impl CanisterSnapshot {
             .as_ref()
             .ok_or(CanisterSnapshotError::EmptyExecutionState(canister_id))?;
         let global_timer = canister.system_state.global_timer;
-        let hook_status = canister.system_state.task_queue.peek_hook_status();
+        // A frozen canister whose `OnLowWasmMemory` hook could not run is left with
+        // `OnLowWasmMemoryHookStatus::ConditionNotSatisfied` while the underlying memory condition is still
+        // satisfied (see the matching comment in `execute_call_or_task`). The canister itself recovers from
+        // this transient inconsistency the next time `finish_subnet_message_execution` evaluates the hook
+        // condition, but the inconsistency must not leak into snapshots: it would (1) be reported as a lie
+        // through `read_canister_snapshot_metadata`, and (2) cause `upload_canister_snapshot_metadata` to
+        // reject any round-trip of the metadata via the `is_consistent_with` check. Lifting the recorded
+        // status to `Ready` whenever the condition is actually satisfied preserves the invariant that
+        // snapshots always agree with their memory contents.
+        let hook_status = match canister.system_state.task_queue.peek_hook_status() {
+            OnLowWasmMemoryHookStatus::ConditionNotSatisfied
+                if canister.is_low_wasm_memory_hook_condition_satisfied() =>
+            {
+                OnLowWasmMemoryHookStatus::Ready
+            }
+            other => other,
+        };
         let execution_snapshot = ExecutionStateSnapshot {
             wasm_binary: execution_state.wasm_binary.binary.clone(),
             exported_globals: execution_state.exported_globals.clone(),

--- a/rs/replicated_state/src/canister_state/canister_snapshots.rs
+++ b/rs/replicated_state/src/canister_state/canister_snapshots.rs
@@ -283,14 +283,17 @@ impl CanisterSnapshot {
             .ok_or(CanisterSnapshotError::EmptyExecutionState(canister_id))?;
         let global_timer = canister.system_state.global_timer;
         // A frozen canister whose `OnLowWasmMemory` hook could not run is left with
-        // `OnLowWasmMemoryHookStatus::ConditionNotSatisfied` while the underlying memory condition is still
-        // satisfied (see the matching comment in `execute_call_or_task`). The canister itself recovers from
-        // this transient inconsistency the next time `finish_subnet_message_execution` evaluates the hook
-        // condition, but the inconsistency must not leak into snapshots: it would (1) be reported as a lie
-        // through `read_canister_snapshot_metadata`, and (2) cause `upload_canister_snapshot_metadata` to
-        // reject any round-trip of the metadata via the `is_consistent_with` check. Lifting the recorded
-        // status to `Ready` whenever the condition is actually satisfied preserves the invariant that
-        // snapshots always agree with their memory contents.
+        // `OnLowWasmMemoryHookStatus::ConditionNotSatisfied` while the underlying
+        // memory condition is still satisfied (see the matching comment in
+        // `execute_call_or_task`). The canister itself recovers from
+        // this transient inconsistency the next time a message execution or management
+        // call re-evaluates the hook condition, but the inconsistency must not leak
+        // into snapshots, as it would cause `upload_canister_snapshot_metadata` to
+        // reject any round-trip of the metadata via the `is_consistent_with` check.
+        //
+        // Lifting the recorded status to `Ready` whenever the condition is actually
+        // satisfied preserves the invariant that the condition and hook status always
+        // agree.
         let hook_status = match canister.system_state.task_queue.peek_hook_status() {
             OnLowWasmMemoryHookStatus::ConditionNotSatisfied
                 if canister.is_low_wasm_memory_hook_condition_satisfied() =>


### PR DESCRIPTION
Replace the remove + enqueue block in `execute_call_or_task()` with just a remove. Override snapshot `on_low_wasm_memory_hook_status` with the actual condition when creating a snapshot, so it's accurate when loading the snapshot.