### PR TITLE
fix: specify VM allocation mode for system tests via environment variable

### DIFF
--- a/rs/tests/boundary_nodes/BUILD.bazel
+++ b/rs/tests/boundary_nodes/BUILD.bazel
@@ -31,6 +31,7 @@ system_test_nns(
         "colocate",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",
@@ -111,6 +112,7 @@ system_test_nns(
     enable_metrics = True,
     prometheus_vm_required_host_features = ["performance"],
     tags = ["manual"],
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS,
     deps = [
         # Keep sorted.
@@ -135,6 +137,7 @@ system_test(
     tags = [
         "manual",
     ],
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS,
     deps = [
         # Keep sorted.
@@ -158,6 +161,7 @@ system_test(
     tags = [
         "manual",
     ],
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS,
     deps = [
         # Keep sorted.

--- a/rs/tests/boundary_nodes/api_bn_performance_test.rs
+++ b/rs/tests/boundary_nodes/api_bn_performance_test.rs
@@ -1,12 +1,10 @@
 use anyhow::Result;
 use ic_boundary_nodes_performance_test_common::{query_calls_test, setup, update_calls_test};
-use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::{driver::group::SystemTestGroup, systest};
 use std::time::Duration;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(update_calls_test))
         .add_test(systest!(query_calls_test))

--- a/rs/tests/boundary_nodes/api_bn_update_workload_test.rs
+++ b/rs/tests/boundary_nodes/api_bn_update_workload_test.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use ic_system_test_driver::driver::farm::{HostFeature, VmAllocationMode};
+use ic_system_test_driver::driver::farm::HostFeature;
 use std::time::Duration;
 
 use ic_networking_subnet_update_workload::{setup, test};
@@ -30,7 +30,6 @@ fn main() -> Result<()> {
         )
     };
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test))
         .with_timeout_per_test(per_task_timeout) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/consensus/BUILD.bazel
+++ b/rs/tests/consensus/BUILD.bazel
@@ -409,6 +409,7 @@ system_test_nns(
     ],
     test_driver_target = ":consensus_performance_bin",
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS | {
         "IC_VERSION_FILE": "//bazel:version.txt",
         "JAEGER_UVM_CONFIG_IMAGE_ZST": "//rs/tests:jaeger_uvm_config_image",
@@ -438,6 +439,7 @@ system_test_nns(
     ],
     test_driver_target = ":consensus_performance_bin",
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS | {
         "IC_VERSION_FILE": "//bazel:version.txt",
         "JAEGER_UVM_CONFIG_IMAGE_ZST": "//rs/tests:jaeger_uvm_config_image",
@@ -487,6 +489,7 @@ system_test_nns(
         "manual",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     deps = [
         # Keep sorted.
         "//rs/registry/canister",

--- a/rs/tests/consensus/consensus_performance.rs
+++ b/rs/tests/consensus/consensus_performance.rs
@@ -65,7 +65,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::get_ic_build_version;
 use ic_system_test_driver::driver::{
-    farm::{HostFeature, VmAllocationMode},
+    farm::HostFeature,
     ic::{
         AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet, VmResourceOverrides,
     },
@@ -219,7 +219,6 @@ fn main() -> Result<()> {
         // Since we setup VMs in sequence it takes more than the default timeout
         // of 10 minutes to setup this large testnet so let's increase the timeout:
         .with_timeout_per_test(Duration::from_secs(60 * 30))
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test; TestParameters { message_size: 1, rps: 1.0 }))
         .add_test(systest!(test; TestParameters { message_size: 9_500, rps: 1_000.0 }))

--- a/rs/tests/consensus/nidkg_performance_test.rs
+++ b/rs/tests/consensus/nidkg_performance_test.rs
@@ -8,7 +8,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::HasPublicApiUrl;
 use ic_system_test_driver::driver::{
-    farm::{HostFeature, VmAllocationMode},
+    farm::HostFeature,
     ic::{AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet},
     simulate_network::{FixedNetworkSimulation, SimulateNetwork},
     test_env::TestEnv,
@@ -226,7 +226,6 @@ fn test(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .with_timeout_per_test(Duration::from_secs(15 * 60))
         .add_test(systest!(test))

--- a/rs/tests/consensus/tecdsa/BUILD.bazel
+++ b/rs/tests/consensus/tecdsa/BUILD.bazel
@@ -297,6 +297,7 @@ tecdsa_performance_test_template = system_test_nns(
         "manual",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     deps = [
         # Keep sorted.
         "//rs/registry/subnet_features",
@@ -350,6 +351,7 @@ system_test_nns(
     ],
     test_driver_target = tecdsa_performance_test_template.test_driver_target,
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = SIGNER_CANISTER_RUNTIME_DEPS | MESSAGE_CANISTER_RUNTIME_DEPS,
 )
 
@@ -384,6 +386,7 @@ system_test_nns(
     ],
     test_driver_target = tecdsa_performance_test_template.test_driver_target,
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = MESSAGE_CANISTER_RUNTIME_DEPS | SIGNER_CANISTER_RUNTIME_DEPS,
 )
 
@@ -418,6 +421,7 @@ system_test_nns(
     ],
     test_driver_target = tecdsa_performance_test_template.test_driver_target,
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = SIGNER_CANISTER_RUNTIME_DEPS | MESSAGE_CANISTER_RUNTIME_DEPS,
 )
 
@@ -452,5 +456,6 @@ system_test_nns(
     ],
     test_driver_target = tecdsa_performance_test_template.test_driver_target,
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = SIGNER_CANISTER_RUNTIME_DEPS | MESSAGE_CANISTER_RUNTIME_DEPS,
 )

--- a/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
+++ b/rs/tests/consensus/tecdsa/tecdsa_performance_test_template.rs
@@ -68,7 +68,7 @@ use ic_system_test_driver::canister_requests;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::HasPublicApiUrl;
 use ic_system_test_driver::driver::{
-    farm::{HostFeature, VmAllocationMode},
+    farm::HostFeature,
     ic::{
         AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet, VmResourceOverrides,
     },
@@ -490,7 +490,6 @@ fn main() -> Result<()> {
         // Since we setup VMs in sequence it takes more than the default timeout
         // of 10 minutes to setup this large testnet so let's increase the timeout:
         .with_timeout_per_test(Duration::from_secs(60 * 30))
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test))
         .execute_from_args()?;

--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -4,7 +4,7 @@ use crate::driver::{
     context::{GroupContext, ProcessContext},
     dsl::{SubprocessFn, TestFunction},
     event::TaskId,
-    farm::{Farm, HostFeature, VmAllocationMode},
+    farm::{Farm, HostFeature},
     plan::{EvalOrder, Plan},
     report::Outcome,
     task::{DebugKeepaliveTask, EmptyTask},
@@ -649,7 +649,6 @@ impl SystemTestSubGroup {
 
 pub struct SystemTestGroup {
     allocate_testnet_to_local_dc: bool,
-    vm_allocation_mode: Option<VmAllocationMode>,
     setup: Option<Box<dyn PotSetupFn>>,
     teardowns: Vec<Box<dyn PotSetupFn>>,
     tests: Vec<SystemTestSubGroup>,
@@ -695,7 +694,6 @@ impl SystemTestGroup {
     pub fn new() -> Self {
         Self {
             allocate_testnet_to_local_dc: false,
-            vm_allocation_mode: Default::default(),
             setup: Default::default(),
             teardowns: Default::default(),
             tests: Default::default(),
@@ -750,11 +748,6 @@ impl SystemTestGroup {
 
     pub fn allocate_testnet_to_local_dc(mut self) -> Self {
         self.allocate_testnet_to_local_dc = true;
-        self
-    }
-
-    pub fn with_vm_allocation_mode(mut self, mode: VmAllocationMode) -> Self {
-        self.vm_allocation_mode = Some(mode);
         self
     }
 
@@ -1313,7 +1306,6 @@ impl SystemTestGroup {
                 root_env.create_group_setup(
                     group_ctx.group_base_name.clone(),
                     self.allocate_testnet_to_local_dc,
-                    self.vm_allocation_mode.clone(),
                     args.no_group_ttl,
                 );
             }

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -1486,9 +1486,27 @@ pub trait HasGroupSetup {
         &self,
         group_base_name: String,
         allocate_testnet_to_local_dc: bool,
-        vm_allocation_mode: Option<VmAllocationMode>,
         no_group_ttl: bool,
     );
+}
+
+/// Name of the environment variable that controls the VM allocation mode used
+/// when creating a Farm group. The value must match one of the serde rename
+/// strings of [`VmAllocationMode`] (e.g. `performanceOptimizedAllocation`).
+const VM_ALLOCATION_MODE_ENV_VAR: &str = "VM_ALLOCATION_MODE";
+
+fn vm_allocation_mode_from_env() -> Option<VmAllocationMode> {
+    let raw = match std::env::var(VM_ALLOCATION_MODE_ENV_VAR) {
+        Ok(v) if !v.is_empty() => v,
+        _ => return None,
+    };
+    let mode = serde_json::from_value::<VmAllocationMode>(serde_json::Value::String(raw.clone()))
+        .unwrap_or_else(|e| {
+            panic!(
+                "Invalid value {raw:?} for environment variable {VM_ALLOCATION_MODE_ENV_VAR}: {e}"
+            )
+        });
+    Some(mode)
 }
 
 impl HasGroupSetup for TestEnv {
@@ -1496,10 +1514,10 @@ impl HasGroupSetup for TestEnv {
         &self,
         group_base_name: String,
         allocate_testnet_to_local_dc: bool,
-        vm_allocation_mode: Option<VmAllocationMode>,
         no_group_ttl: bool,
     ) {
         let log = self.logger();
+        let vm_allocation_mode = vm_allocation_mode_from_env();
         if GroupSetup::attribute_exists(self) {
             let group_setup = GroupSetup::read_attribute(self);
             info!(
@@ -1520,9 +1538,10 @@ impl HasGroupSetup for TestEnv {
                         .unwrap_or_default();
                     info!(
                         log,
-                        "Creating group {} with required_host_features: {:?} ...",
+                        "Creating group {} with required_host_features: {:?} and vm_allocation_mode: {:?} ...",
                         group_setup.infra_group_name,
-                        required_host_features
+                        required_host_features,
+                        vm_allocation_mode,
                     );
 
                     let farm_base_url = FarmBaseUrl::read_attribute(self);

--- a/rs/tests/execution/BUILD.bazel
+++ b/rs/tests/execution/BUILD.bazel
@@ -207,6 +207,7 @@ system_test(
         "manual",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS | {
         "JAEGER_UVM_CONFIG_IMAGE_ZST": "//rs/tests:jaeger_uvm_config_image",
     },

--- a/rs/tests/execution/fill_execution_rounds_workload.rs
+++ b/rs/tests/execution/fill_execution_rounds_workload.rs
@@ -14,7 +14,7 @@ use ic_registry_routing_table::CanisterIdRanges;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
-        farm::{HostFeature, VmAllocationMode},
+        farm::HostFeature,
         group::SystemTestGroup,
         ic::{
             AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet,
@@ -79,7 +79,6 @@ fn main() -> Result<()> {
         )
     };
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test))
         .with_timeout_per_test(per_task_timeout) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/message_routing/BUILD.bazel
+++ b/rs/tests/message_routing/BUILD.bazel
@@ -97,6 +97,7 @@ system_test_nns(
         "manual",  # TODO: replace with "system_test_large" when the test has been made to work with d28780e
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS | {
         "STATESYNC_TEST_CANISTER_WASM_PATH": "//rs/rust_canisters/statesync_test:statesync-test-canister",
     },

--- a/rs/tests/message_routing/rejoin_test_long_rounds.rs
+++ b/rs/tests/message_routing/rejoin_test_long_rounds.rs
@@ -20,7 +20,6 @@ end::catalog[] */
 use anyhow::Result;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::driver::farm::HostFeature;
-use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::ic::{
     AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet, VmResourceOverrides,
@@ -47,7 +46,6 @@ fn main() -> Result<()> {
     let config = Config::new(NUM_NODES, NUM_CANISTERS);
     let test = config.clone().test();
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT)

--- a/rs/tests/message_routing/xnet/BUILD.bazel
+++ b/rs/tests/message_routing/xnet/BUILD.bazel
@@ -12,6 +12,7 @@ system_test_nns(
         "system_test_large",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = XNET_TEST_CANISTER_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",
@@ -28,6 +29,7 @@ system_test_nns(
         "colocate",
         "system_test_large",
     ],
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = XNET_TEST_CANISTER_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",
@@ -44,6 +46,7 @@ system_test_nns(
         "colocate",
         "system_test_large",
     ],
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = XNET_TEST_CANISTER_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",
@@ -61,6 +64,7 @@ system_test_nns(
         "system_test_large",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = XNET_TEST_CANISTER_RUNTIME_DEPS,
     deps = [
         "//rs/tests/driver:ic-system-test-driver",

--- a/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::systest;
 use std::time::Duration;
@@ -17,7 +16,6 @@ fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);
     let test = config.clone().test();
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/message_routing/xnet/xnet_slo_29_subnets_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_29_subnets_test.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::systest;
 use std::time::Duration;
@@ -17,7 +16,6 @@ fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);
     let test = config.clone().test();
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/message_routing/xnet/xnet_slo_3_subnets_hotfix_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_3_subnets_hotfix_test.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::systest;
 use std::time::Duration;
@@ -17,7 +16,6 @@ fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);
     let test = config.clone().test();
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/message_routing/xnet/xnet_slo_3_subnets_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_3_subnets_test.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::systest;
 use std::time::Duration;
@@ -17,7 +16,6 @@ fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);
     let test = config.clone().test();
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .add_test(systest!(test))
         .with_timeout_per_test(PER_TASK_TIMEOUT) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -76,6 +76,7 @@ system_test_nns(
     enable_metrics = True,
     tags = ["manual"],  # not meant to be run on CI
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = CANISTER_HTTP_RUNTIME_DEPS | {
         "PROXY_WASM_PATH": "//rs/rust_canisters/proxy_canister:proxy_canister",
     },
@@ -100,6 +101,7 @@ system_test_nns(
         "manual",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = CANISTER_HTTP_RUNTIME_DEPS | {
         "PROXY_WASM_PATH": "//rs/rust_canisters/proxy_canister:proxy_canister",
     },
@@ -360,6 +362,7 @@ system_test_nns(
         "manual",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS | {
         "JAEGER_UVM_CONFIG_IMAGE_ZST": "//rs/tests:jaeger_uvm_config_image",
     },
@@ -384,6 +387,7 @@ system_test_nns(
         "colocate",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS,
     deps = COMMON_DEPS + [
         "//rs/tests/networking/subnet_update_workload",
@@ -401,6 +405,7 @@ system_test_nns(
         "manual",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = UNIVERSAL_CANISTER_RUNTIME_DEPS | {
         "STATESYNC_TEST_CANISTER_WASM_PATH": "//rs/rust_canisters/statesync_test:statesync-test-canister",
     },
@@ -433,6 +438,7 @@ system_test_nns(
         "colocate",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS,
     deps = COMMON_DEPS + [
         "//rs/tests/networking/subnet_update_workload",
@@ -446,6 +452,7 @@ system_test(
         "manual",
     ],
     test_timeout = "eternal",
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = COUNTER_CANISTER_RUNTIME_DEPS | {
         "CLONER_CANISTER_WASM_PATH": "//rs/tests/networking/canisters:cloner_canister",
     },

--- a/rs/tests/networking/canister_http_soak_test.rs
+++ b/rs/tests/networking/canister_http_soak_test.rs
@@ -24,7 +24,6 @@ use canister_test::Canister;
 use dfn_candid::candid_one;
 use ic_cdk::api::call::RejectionCode;
 use ic_management_canister_types_private::{HttpMethod, TransformContext, TransformFunc};
-use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::IcNodeContainer;
 use ic_system_test_driver::driver::{
@@ -43,7 +42,6 @@ const INSTALLED_CANISTERS: usize = 6;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(stress_setup)
         .add_test(systest!(test))
         .execute_from_args()?;

--- a/rs/tests/networking/canister_http_stress_test.rs
+++ b/rs/tests/networking/canister_http_stress_test.rs
@@ -33,7 +33,6 @@ use canister_test::Canister;
 use dfn_candid::candid_one;
 use ic_cdk::api::call::RejectionCode;
 use ic_management_canister_types_private::{HttpMethod, TransformContext, TransformFunc};
-use ic_system_test_driver::driver::farm::VmAllocationMode;
 use ic_system_test_driver::driver::group::SystemTestGroup;
 use ic_system_test_driver::driver::test_env_api::IcNodeContainer;
 use ic_system_test_driver::driver::{
@@ -61,7 +60,6 @@ struct BenchmarkResult {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(stress_setup)
         .add_test(systest!(test))
         // This test takes consistently around 20 mintues, so setting 30 minutes to be safe.

--- a/rs/tests/networking/cloner_canister_workload.rs
+++ b/rs/tests/networking/cloner_canister_workload.rs
@@ -24,7 +24,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     canister_agent::{CanisterAgent, HasCanisterAgentCapability},
     driver::{
-        farm::{HostFeature, VmAllocationMode},
+        farm::HostFeature,
         group::SystemTestGroup,
         ic::{
             AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet,
@@ -57,7 +57,6 @@ const AMOUNT_OF_CLONER_CANISTERS: u64 =
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(install_cloner_canisters))
         .with_timeout_per_test(TEST_TIMEOUT)

--- a/rs/tests/networking/p2p_performance_test.rs
+++ b/rs/tests/networking/p2p_performance_test.rs
@@ -4,7 +4,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     canister_api::{CallMode, GenericRequest},
     driver::{
-        farm::{HostFeature, VmAllocationMode},
+        farm::HostFeature,
         group::SystemTestGroup,
         ic::{
             AmountOfMemoryKiB, ImageSizeGiB, InternetComputer, NrOfVCPUs, Subnet,
@@ -287,7 +287,6 @@ fn main() -> Result<()> {
         )
     };
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .add_test(systest!(test))
         .with_timeout_per_test(per_task_timeout) // each task (including the setup function) may take up to `per_task_timeout`.

--- a/rs/tests/networking/query_workload_long_test.rs
+++ b/rs/tests/networking/query_workload_long_test.rs
@@ -25,7 +25,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     canister_api::{CallMode, GenericRequest},
     driver::{
-        farm::{HostFeature, VmAllocationMode},
+        farm::HostFeature,
         group::SystemTestGroup,
         ic::ImageSizeGiB,
         test_env::TestEnv,
@@ -153,7 +153,6 @@ fn main() -> Result<()> {
     let overall_timeout: Duration = per_task_timeout + OVERALL_TIMEOUT_DELTA; // This should be a bit larger than the per_task_timeout.
     let test = |env| test(env, RPS, WORKLOAD_RUNTIME);
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(|env| {
             setup(
                 env,

--- a/rs/tests/networking/state_sync_performance.rs
+++ b/rs/tests/networking/state_sync_performance.rs
@@ -20,7 +20,7 @@ use ic_nns_governance_api::NnsFunction;
 use ic_registry_subnet_type::SubnetType;
 use ic_system_test_driver::{
     driver::{
-        farm::{HostFeature, VmAllocationMode},
+        farm::HostFeature,
         group::SystemTestGroup,
         ic::{ImageSizeGiB, InternetComputer, Subnet, VmResourceOverrides},
         simulate_network::{FixedNetworkSimulation, SimulateNetwork},
@@ -204,7 +204,6 @@ fn test(env: TestEnv) {
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(setup)
         .with_timeout_per_test(Duration::from_secs(20 * 60))
         .add_test(systest!(test))

--- a/rs/tests/networking/update_workload_large_payload.rs
+++ b/rs/tests/networking/update_workload_large_payload.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use ic_system_test_driver::driver::farm::HostFeature;
-use ic_system_test_driver::driver::farm::VmAllocationMode;
 use std::time::Duration;
 
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
@@ -30,7 +29,6 @@ fn main() -> Result<()> {
         )
     };
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(|env| {
             setup(
                 env,

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -193,6 +193,16 @@ def system_test(
     }
 
     if vm_allocation_mode != None:
+        allowed_vm_allocation_modes = [
+            "minIntraDistanceLoadBalanceAllocation",
+            "performanceOptimizedAllocation",
+            "distributeAcrossDcs",
+        ]
+        if vm_allocation_mode not in allowed_vm_allocation_modes:
+            fail("Invalid vm_allocation_mode {}: must be one of {}".format(
+                repr(vm_allocation_mode),
+                allowed_vm_allocation_modes,
+            ))
         env |= {"VM_ALLOCATION_MODE": vm_allocation_mode}
 
     # RUN_SCRIPT_ICOS_IMAGES:

--- a/rs/tests/system_tests.bzl
+++ b/rs/tests/system_tests.bzl
@@ -41,6 +41,7 @@ def system_test(
         data = [],
         additional_colocate_tags = [],
         logs = True,
+        vm_allocation_mode = None,
         **kwargs):
     """Declares a system-test.
 
@@ -85,6 +86,12 @@ def system_test(
       logs: Specifies if vector vm for scraping logs should not be spawned.
       exclude_logs: Specifies uvm name patterns to exclude from streaming.
       data: List of files used by the test driver.
+      vm_allocation_mode: Optional VM allocation mode string forwarded to the
+        test driver via the `VM_ALLOCATION_MODE` environment variable. Must
+        match one of the serde rename strings of `VmAllocationMode`, e.g.
+        `"performanceOptimizedAllocation"`,
+        `"minIntraDistanceLoadBalanceAllocation"` or `"distributeAcrossDcs"`.
+        When None it defaults to `"minIntraDistanceLoadBalanceAllocation"`.
       **kwargs: additional arguments to pass to the rust_binary rule.
 
     Returns:
@@ -184,6 +191,9 @@ def system_test(
         "PROMETHEUS_VM_RESOURCES": json.encode(prometheus_vm_resources),
         "PROMETHEUS_VM_SCRAPE_INTERVAL_SECS": json.encode(prometheus_vm_scrape_interval_secs),
     }
+
+    if vm_allocation_mode != None:
+        env |= {"VM_ALLOCATION_MODE": vm_allocation_mode}
 
     # RUN_SCRIPT_ICOS_IMAGES:
     # Have the run script resolve repo based ICOS images.

--- a/rs/tests/testnets/BUILD.bazel
+++ b/rs/tests/testnets/BUILD.bazel
@@ -287,6 +287,7 @@ system_test_nns(
         "dynamic_testnet",
         "manual",
     ],
+    vm_allocation_mode = "performanceOptimizedAllocation",
     runtime_deps = IC_GATEWAY_RUNTIME_DEPS,
     deps = [
         # Keep sorted.

--- a/rs/tests/testnets/io_perf_benchmark.rs
+++ b/rs/tests/testnets/io_perf_benchmark.rs
@@ -57,7 +57,7 @@ use ic_system_test_driver::driver::ic::{
 use ic_system_test_driver::driver::ic_gateway_vm::IcGatewayVm;
 use ic_system_test_driver::driver::pot_dsl::PotSetupFn;
 use ic_system_test_driver::driver::{
-    farm::{HostFeature, VmAllocationMode},
+    farm::HostFeature,
     group::SystemTestGroup,
     test_env::TestEnv,
     test_env_api::{HasTopologySnapshot, IcNodeContainer},
@@ -86,7 +86,6 @@ fn main() -> Result<()> {
     let config = Config::new(perf_hosts, num_hosts, hostuser);
 
     SystemTestGroup::new()
-        .with_vm_allocation_mode(VmAllocationMode::PerformanceOptimizedAllocation)
         .with_setup(config.build())
         .with_timeout_per_test(std::time::Duration::MAX) // Switching to SSD takes long time
         .execute_from_args()?;


### PR DESCRIPTION
Set the `vm_allocation_mode` for system-tests via an environment variable instead of via Rust. 

This is to fix the issue that colocated performance tests would not set the required `performanceOptimizedAllocation` VM allocation mode because the group is created in the wrapper driver which would not set the `vm_allocation_mode`.

Now we specify the optional `vm_allocation_mode` via a parameter of the `system_test` macro which when specified sets the `VM_ALLOCATION_MODE` environment variable. This variable is then read and parsed when creating the group which also works for colocated tests.