### PR TITLE
test: check for critical errors before replica restart in system tests

### DIFF
--- a/rs/tests/consensus/utils/src/upgrade.rs
+++ b/rs/tests/consensus/utils/src/upgrade.rs
@@ -197,7 +197,7 @@ pub async fn deploy_guestos_to_all_subnet_nodes(
     new_replica_version: &ReplicaVersion,
     subnet_id: SubnetId,
 ) {
-    assert_no_critical_errors(nns_node.test_env());
+    assert_no_critical_errors(&nns_node.test_env());
     let nns = runtime_from_url(nns_node.get_public_url(), nns_node.effective_canister_id());
     let governance_canister = get_governance_canister(&nns);
     let test_neuron_id = NeuronId(TEST_NEURON_1_ID);

--- a/rs/tests/consensus/utils/src/upgrade.rs
+++ b/rs/tests/consensus/utils/src/upgrade.rs
@@ -6,7 +6,7 @@ use ic_protobuf::registry::replica_version::v1::{BlessedReplicaVersions, GuestLa
 use ic_registry_keys::make_blessed_replica_versions_key;
 use ic_registry_nns_data_provider::registry::RegistryCanister;
 use ic_system_test_driver::{
-    driver::test_env_api::*,
+    driver::{group::assert_no_critical_errors, test_env_api::*},
     nns::{
         get_governance_canister, submit_deploy_guestos_to_all_subnet_nodes_proposal,
         submit_update_elected_replica_versions_proposal,
@@ -197,6 +197,7 @@ pub async fn deploy_guestos_to_all_subnet_nodes(
     new_replica_version: &ReplicaVersion,
     subnet_id: SubnetId,
 ) {
+    assert_no_critical_errors(nns_node.test_env());
     let nns = runtime_from_url(nns_node.get_public_url(), nns_node.effective_canister_id());
     let governance_canister = get_governance_canister(&nns);
     let test_neuron_id = NeuronId(TEST_NEURON_1_ID);

--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -11,7 +11,7 @@ use crate::driver::{
     task_scheduler::{TaskScheduler, TaskTable},
     test_env_api::{
         FarmBaseUrl, HasFarmUrl, HasGroupSetup, HasTopologySnapshot, IcNodeContainer,
-        ORCHESTRATOR_METRICS_PORT, REPLICA_METRICS_PORT,
+        ORCHESTRATOR_METRICS_PORT, REPLICA_METRICS_PORT, TopologySnapshot,
     },
 };
 use crate::driver::{
@@ -647,6 +647,48 @@ impl SystemTestSubGroup {
     }
 }
 
+fn default_replica_metrics() -> BTreeMap<&'static str, u64> {
+    BTreeMap::from([
+        ("critical_errors", 0),
+        ("consensus_invalidated_artifacts", 0),
+        ("dkg_invalidated_artifacts", 0),
+        ("idkg_invalidated_artifacts", 0),
+        ("certification_invalidated_artifacts", 0),
+        ("canister_http_invalidated_artifacts", 0),
+    ])
+}
+
+fn default_orchestrator_metrics() -> BTreeMap<&'static str, u64> {
+    BTreeMap::from([
+        ("orchestrator_cup_deserialization_failed_total", 0),
+        ("orchestrator_state_removal_failed_total", 0),
+        ("orchestrator_tasks_failed_total", 0),
+        ("orchestrator_replica_process_start_attempts_total", 1),
+    ])
+}
+
+fn check_metrics_for_nodes(
+    topology: &TopologySnapshot,
+    replica_metrics: &BTreeMap<&str, u64>,
+    orchestrator_metrics: &BTreeMap<&str, u64>,
+) {
+    for node in topology.subnets().flat_map(|subnet| subnet.nodes()) {
+        node.assert_metrics_values(replica_metrics, REPLICA_METRICS_PORT);
+        node.assert_metrics_values(orchestrator_metrics, ORCHESTRATOR_METRICS_PORT);
+    }
+}
+
+/// Checks replica and orchestrator error metrics on all subnet nodes, using the
+/// same thresholds as the default `SystemTestGroup` teardown. Call this before
+/// replica restart so that errors accumulated in the current process are not lost.
+pub fn assert_no_critical_errors(env: &TestEnv) {
+    check_metrics_for_nodes(
+        &env.topology_snapshot(),
+        &default_replica_metrics(),
+        &default_orchestrator_metrics(),
+    );
+}
+
 pub struct SystemTestGroup {
     allocate_testnet_to_local_dc: bool,
     vm_allocation_mode: Option<VmAllocationMode>,
@@ -702,20 +744,8 @@ impl SystemTestGroup {
             timeout_per_test: None,
             overall_timeout: None,
             with_farm: true,
-            replica_metrics_to_check: BTreeMap::from([
-                ("critical_errors", 0),
-                ("consensus_invalidated_artifacts", 0),
-                ("dkg_invalidated_artifacts", 0),
-                ("idkg_invalidated_artifacts", 0),
-                ("certification_invalidated_artifacts", 0),
-                ("canister_http_invalidated_artifacts", 0),
-            ]),
-            orchestrator_metrics_to_check: BTreeMap::from([
-                ("orchestrator_cup_deserialization_failed_total", 0),
-                ("orchestrator_state_removal_failed_total", 0),
-                ("orchestrator_tasks_failed_total", 0),
-                ("orchestrator_replica_process_start_attempts_total", 1),
-            ]),
+            replica_metrics_to_check: default_replica_metrics(),
+            orchestrator_metrics_to_check: default_orchestrator_metrics(),
             unallowed_log_patterns: BTreeMap::from([
                 ("This is a bug".to_string(), BTreeSet::new()),
                 (
@@ -1050,16 +1080,11 @@ impl SystemTestGroup {
                         }
                     };
 
-                    for node in topology.subnets().flat_map(|subnet| subnet.nodes()) {
-                        node.assert_metrics_values(
-                            &self.replica_metrics_to_check,
-                            REPLICA_METRICS_PORT,
-                        );
-                        node.assert_metrics_values(
-                            &self.orchestrator_metrics_to_check,
-                            ORCHESTRATOR_METRICS_PORT,
-                        );
-                    }
+                    check_metrics_for_nodes(
+                        &topology,
+                        &self.replica_metrics_to_check,
+                        &self.orchestrator_metrics_to_check,
+                    );
                 };
                 Some((
                     ASSERT_NO_METRICS_ERRORS_TASK_NAME.to_string(),

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -869,6 +869,10 @@ pub struct IcNodeSnapshot {
 }
 
 impl IcNodeSnapshot {
+    pub fn test_env(&self) -> &TestEnv {
+        &self.env
+    }
+
     pub fn is_malicious(&self) -> bool {
         self.malicious_behavior().is_some()
     }

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -869,10 +869,6 @@ pub struct IcNodeSnapshot {
 }
 
 impl IcNodeSnapshot {
-    pub fn test_env(&self) -> &TestEnv {
-        &self.env
-    }
-
     pub fn is_malicious(&self) -> bool {
         self.malicious_behavior().is_some()
     }

--- a/rs/tests/message_routing/xnet/xnet_compatibility.rs
+++ b/rs/tests/message_routing/xnet/xnet_compatibility.rs
@@ -38,10 +38,9 @@ use ic_system_test_driver::driver::test_env_api::{
     get_guestos_update_launch_measurements,
 };
 use ic_system_test_driver::systest;
-use ic_system_test_driver::util::{MetricsFetcher, block_on, runtime_from_url};
+use ic_system_test_driver::util::{block_on, runtime_from_url};
 use ic_types::ReplicaVersion;
 use slog::{Logger, info};
-use std::collections::BTreeMap;
 use std::time::Duration;
 
 const PER_TASK_TIMEOUT: Duration = Duration::from_secs(25 * 60);
@@ -190,8 +189,6 @@ pub async fn test_async(env: TestEnv) {
     )
     .await;
 
-    assert_no_critical_errors(&env, &logger).await;
-
     info!(&logger, "Upgrading 1 app subnet.");
 
     upgrade_to(
@@ -212,8 +209,6 @@ pub async fn test_async(env: TestEnv) {
         &logger,
     )
     .await;
-
-    assert_no_critical_errors(&env, &logger).await;
 
     info!(&logger, "Downgrading app subnet back to initial version.");
 
@@ -243,8 +238,6 @@ pub async fn test_async(env: TestEnv) {
         xnet_slo_test_lib::check_success(metrics, &long_xnet_config, &logger),
         "Long running canisters didn't meet success conditions."
     );
-
-    assert_no_critical_errors(&env, &logger).await;
 }
 
 async fn upgrade_to(
@@ -256,33 +249,4 @@ async fn upgrade_to(
 ) {
     deploy_guestos_to_all_subnet_nodes(nns_node, target_version, subnet_id).await;
     assert_assigned_replica_version(subnet_node, target_version, logger.clone());
-}
-
-async fn assert_no_critical_errors(env: &TestEnv, log: &slog::Logger) {
-    let nodes = env.topology_snapshot().subnets().flat_map(|s| s.nodes());
-    const NUM_RETRIES: u32 = 10;
-    const BACKOFF_TIME_MILLIS: u64 = 500;
-
-    let metrics = MetricsFetcher::new(nodes, vec!["critical_errors".to_string()]);
-    for i in 0..NUM_RETRIES {
-        match metrics.fetch::<u64>().await {
-            Ok(result) => {
-                assert!(!result.is_empty());
-                let filtered_results = result
-                    .iter()
-                    .filter(|(_, v)| v.iter().any(|x| *x > 0))
-                    .collect::<BTreeMap<_, _>>();
-                assert!(
-                    filtered_results.is_empty(),
-                    "Critical error detected: {filtered_results:?}"
-                );
-                return;
-            }
-            Err(e) => {
-                info!(log, "Could not scrape metrics: {e}, attempt {i}.");
-            }
-        }
-        tokio::time::sleep(Duration::from_millis(BACKOFF_TIME_MILLIS)).await;
-    }
-    panic!("Couldn't obtain metrics after {NUM_RETRIES} attempts.");
 }


### PR DESCRIPTION
This PR checks for critical errors before replica restart (due to guestOS deployment) in system tests. The motivation for this change is that critical errors after subnet upgrade are only checked in `//rs/tests/consensus/backup:backup_manager_upgrade_test`, but not in `//rs/tests/consensus/upgrade:upgrade_downgrade_nns_subnet_test` which downgrades the subnet after upgrade and thus the critical errors after upgrade are lost following the subsequent replica restart during downgrade.