### PR TITLE
fix(crypto): CRP-2979: Guard SKS old-file zeroing against shared inodes

### DIFF
--- a/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store.rs
@@ -176,6 +176,33 @@ impl ProtoSecretKeyStore {
             return Err(cleanup_errors);
         }
 
+        self.zeroize_or_unlink_old_file()
+    }
+
+    /// Disposes of `old_proto_file_to_zeroize` after a successful write.
+    ///
+    /// If `old_proto_file_to_zeroize` and `proto_file` share an inode, zeroing would
+    /// overwrite the live keystore — so just unlink the extra link. The new content
+    /// has already been written into that inode, so there is no separate old-inode
+    /// copy left to scrub. Otherwise, zero-and-delete the old file as usual. If
+    /// `old_proto_file_to_zeroize` does not exist (e.g. the first write to a fresh
+    /// keystore), this is a no-op.
+    ///
+    /// Inode sharing is not expected on filesystems where `rename(2)` atomically
+    /// swaps the destination directory entry to a new inode (Linux ext4 / xfs /
+    /// btrfs, tmpfs, …), but has been observed on virtiofs bind mounts (Docker
+    /// Desktop on macOS), where `rename(2)` reuses the destination inode.
+    fn zeroize_or_unlink_old_file(&self) -> Result<(), Vec<CleanupError>> {
+        let old_file_exists = self.old_proto_file_to_zeroize.try_exists().map_err(|err| {
+            vec![CleanupError::OldFileExistenceDetermination {
+                old_sks_file: self.old_proto_file_to_zeroize.to_string_lossy().to_string(),
+                source: err,
+            }]
+        })?;
+        if !old_file_exists {
+            return Ok(());
+        }
+
         let are_same_file = ic_sys::fs::are_hard_links_to_the_same_inode(
             &self.proto_file,
             &self.old_proto_file_to_zeroize,
@@ -233,8 +260,10 @@ impl ProtoSecretKeyStore {
         let write_result = self.write_secret_keys_to_disk(secret_keys);
         if write_result.is_ok() {
             // Use the previously created hard link to zeroize and delete the old keystore file.
-            let overwrite_result =
-                overwrite_file_with_zeroes_and_delete_if_it_exists(&self.old_proto_file_to_zeroize);
+            // Note: must guard against `proto_file` and `old_proto_file_to_zeroize` sharing an
+            // inode after the rename in `write_secret_keys_to_disk` — otherwise zeroing would
+            // clobber the file we just wrote. See `zeroize_or_unlink_old_file` for details.
+            let overwrite_result = self.zeroize_or_unlink_old_file();
             cleanup_result = combine_cleanup_results(cleanup_result, overwrite_result);
         };
         self.log_cleanup_errors_and_observe_metrics(cleanup_result);

--- a/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store.rs
@@ -179,14 +179,15 @@ impl ProtoSecretKeyStore {
         self.zeroize_or_unlink_old_file()
     }
 
-    /// Disposes of `old_proto_file_to_zeroize` after a successful write.
+    /// Disposes of `old_proto_file_to_zeroize` during cleanup, whether after a
+    /// successful write, or when cleaning up stale files during startup.
     ///
     /// If `old_proto_file_to_zeroize` and `proto_file` share an inode, zeroing would
     /// overwrite the live keystore — so just unlink the extra link. The new content
     /// has already been written into that inode, so there is no separate old-inode
     /// copy left to scrub. Otherwise, zero-and-delete the old file as usual. If
     /// `old_proto_file_to_zeroize` does not exist (e.g. the first write to a fresh
-    /// keystore), this is a no-op.
+    /// keystore, or there is nothing left to clean up at startup), this is a no-op.
     ///
     /// Inode sharing is not expected on filesystems where `rename(2)` atomically
     /// swaps the destination directory entry to a new inode (Linux ext4 / xfs /

--- a/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store/tests.rs
@@ -1149,19 +1149,20 @@ mod zeroize_old_secret_key_store {
         }
 
         #[test]
-        fn should_observe_cleanup_error_metrics_on_write_if_inode_of_current_and_old_sks_are_the_same()
-         {
+        fn should_observe_cleanup_error_metric_on_write_when_stale_old_sks_file_exists() {
             let mut setup = Setup::new();
-            // Make the current and old SKS files point to the same inode. This is a reasonable
-            // situation if e.g., the vault process crashed during
-            // `[ProtoSecretKeyStore::write_secret_keys_to_disk]`, `[ProtoSecretKeyStore::drop]` was
-            // not executed, and the old SKS file was not cleaned up. However, on the next startup
-            // of the vault process, this situation should be cleaned up.
-            // This situation is NOT expected to occur once the vault process is running. In
-            // particular, it is not expected to be the current state when
-            // `[ProtoSecretKeyStore::write_secret_keys_to_disk]` is called. It is therefore treated
-            // internally as an error, and the cleanup error metric counter is expected to be
-            // incremented.
+            // Simulate a stale `.old` left behind by a prior process that crashed between
+            // creating the hard link and finishing the write. The current vault process is
+            // expected to clean this up at startup; encountering it mid-write means the
+            // hard-link-creation step of the write path fails (the link target already
+            // exists) and that failure is reported as a cleanup error metric.
+            //
+            // Note: post-rename inode sharing between `proto_file` and `.old` (which can
+            // arise on filesystems where `rename(2)` reuses the destination inode) is
+            // handled separately by `zeroize_or_unlink_old_file` so the just-written
+            // keystore is preserved. That property is covered by dedicated unit tests on
+            // the helper; here we assert the metric is incremented and the on-disk
+            // keystore still contains the inserted key.
             ic_sys::fs::create_hard_link_to_existing_file(
                 &setup.secret_key_store.proto_file,
                 &setup.secret_key_store.old_proto_file_to_zeroize,
@@ -1177,6 +1178,14 @@ mod zeroize_old_secret_key_store {
 
             MetricsObservationsAssert::assert_that(setup.metrics)
                 .contains_crypto_secret_key_store_cleanup_error(1);
+
+            let reopened_sks = ProtoSecretKeyStore::open(
+                setup.temp_dir.as_ref(),
+                &existing_secret_key_store_file_name(&SecretKeyStoreVersion::V3),
+                None,
+                Arc::new(CryptoMetrics::none()),
+            );
+            assert!(reopened_sks.contains(&key_id));
         }
     }
 
@@ -1186,17 +1195,17 @@ mod zeroize_old_secret_key_store {
         use slog::Level;
 
         #[test]
-        fn should_log_warning_on_write_if_inode_of_current_and_old_sks_are_the_same() {
+        fn should_log_warning_on_write_when_stale_old_sks_file_exists() {
             let mut setup = Setup::new();
-            // Make the current and old SKS files point to the same inode. This is a reasonable
-            // situation if e.g., the vault process crashed during
-            // `[ProtoSecretKeyStore::write_secret_keys_to_disk]`, `[ProtoSecretKeyStore::drop]` was
-            // not executed, and the old SKS file was not cleaned up. However, on the next startup
-            // of the vault process, this situation should be cleaned up.
-            // This situation is NOT expected to occur once the vault process is running. In
-            // particular, it is not expected to be the current state when
-            // `[ProtoSecretKeyStore::write_secret_keys_to_disk]` is called. It is therefore treated
-            // internally as an error, and a cleanup error log warning is expected to be written.
+            // Simulate a stale `.old` left behind by a prior process that crashed between
+            // creating the hard link and finishing the write. The hard-link-creation step
+            // of the write path then fails (the link target already exists) and that
+            // failure surfaces as a warning log line.
+            //
+            // The post-rename inode-sharing case (where, on filesystems like virtiofs that
+            // reuse inodes on `rename(2)`, `.old` and `proto_file` end up sharing an
+            // inode) is handled by `zeroize_or_unlink_old_file` and covered by separate
+            // unit tests on the helper.
             ic_sys::fs::create_hard_link_to_existing_file(
                 &setup.secret_key_store.proto_file,
                 &setup.secret_key_store.old_proto_file_to_zeroize,

--- a/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store/tests.rs
@@ -1023,6 +1023,36 @@ mod zeroize_old_secret_key_store {
     }
 
     #[test]
+    fn zeroize_or_unlink_old_file_is_noop_when_old_file_does_not_exist() {
+        // First write to a fresh keystore: `try_create_hard_link_to_existing_file` was a
+        // no-op (no existing `proto_file` at the time), so `.old` does not exist when
+        // `zeroize_or_unlink_old_file` is reached after the write completes. The helper
+        // must short-circuit without erroring (calling `are_hard_links_to_the_same_inode`
+        // on a non-existent path would return `NotFound`).
+        let setup = Setup::new();
+        let _ = fs::remove_file(&setup.secret_key_store.old_proto_file_to_zeroize);
+        assert_matches!(
+            Path::try_exists(&setup.secret_key_store.old_proto_file_to_zeroize),
+            Ok(false)
+        );
+        let initial_sks_bytes = fs::read(&setup.secret_key_store.proto_file)
+            .expect("error reading initial secret key store");
+
+        setup
+            .secret_key_store
+            .zeroize_or_unlink_old_file()
+            .expect("zeroize_or_unlink_old_file should succeed when .old does not exist");
+
+        assert_matches!(
+            Path::try_exists(&setup.secret_key_store.old_proto_file_to_zeroize),
+            Ok(false)
+        );
+        let current_sks_bytes = fs::read(&setup.secret_key_store.proto_file)
+            .expect("error reading current secret key store");
+        assert_eq!(current_sks_bytes, initial_sks_bytes);
+    }
+
+    #[test]
     fn zeroize_or_unlink_old_file_zeroes_and_deletes_when_inodes_differ() {
         let setup = Setup::new();
         // Simulate the normal-filesystem post-rename state: `.old` is a distinct file

--- a/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store/tests.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/secret_key_store/proto_store/tests.rs
@@ -991,6 +991,65 @@ mod zeroize_old_secret_key_store {
         assert_eq!(current_sks_bytes, initial_sks_bytes);
     }
 
+    // Regression test for CRP-2979: on filesystems where `rename(2)` reuses the destination
+    // inode (e.g. virtiofs bind mounts via Docker Desktop on macOS), the post-rename state
+    // has `proto_file` and `old_proto_file_to_zeroize` pointing to the same inode. Zeroing
+    // that inode would clobber the keystore we just wrote. `zeroize_or_unlink_old_file` must
+    // detect the shared inode and unlink the extra link instead of zeroing.
+    #[test]
+    fn zeroize_or_unlink_old_file_unlinks_without_zeroing_when_inodes_are_shared() {
+        let setup = Setup::new();
+        ic_sys::fs::create_hard_link_to_existing_file(
+            &setup.secret_key_store.proto_file,
+            &setup.secret_key_store.old_proto_file_to_zeroize,
+        )
+        .expect("error creating hard link from current secret key store file to backup file");
+        let initial_sks_bytes = fs::read(&setup.secret_key_store.proto_file)
+            .expect("error reading initial secret key store");
+        assert!(!initial_sks_bytes.is_empty());
+
+        setup
+            .secret_key_store
+            .zeroize_or_unlink_old_file()
+            .expect("zeroize_or_unlink_old_file should succeed when inodes are shared");
+
+        assert_matches!(
+            Path::try_exists(&setup.secret_key_store.old_proto_file_to_zeroize),
+            Ok(false)
+        );
+        let current_sks_bytes = fs::read(&setup.secret_key_store.proto_file)
+            .expect("error reading current secret key store");
+        assert_eq!(current_sks_bytes, initial_sks_bytes);
+    }
+
+    #[test]
+    fn zeroize_or_unlink_old_file_zeroes_and_deletes_when_inodes_differ() {
+        let setup = Setup::new();
+        // Simulate the normal-filesystem post-rename state: `.old` is a distinct file
+        // (different inode) holding stale content that must be zeroed before deletion.
+        fs::copy(
+            &setup.secret_key_store.proto_file,
+            &setup.secret_key_store.old_proto_file_to_zeroize,
+        )
+        .expect("error copying current sks to old sks");
+        ic_sys::fs::create_hard_link_to_existing_file(
+            &setup.secret_key_store.old_proto_file_to_zeroize,
+            &setup.hard_link_to_test_zeroization,
+        )
+        .expect("error creating hard link to old secret key store file");
+
+        setup
+            .secret_key_store
+            .zeroize_or_unlink_old_file()
+            .expect("zeroize_or_unlink_old_file should succeed when inodes differ");
+
+        assert_matches!(
+            Path::try_exists(&setup.secret_key_store.old_proto_file_to_zeroize),
+            Ok(false)
+        );
+        assert_contains_only_zeroes(&setup.hard_link_to_test_zeroization);
+    }
+
     #[test]
     fn should_clean_up_leftover_old_file_when_dropping_secret_key_store() {
         let setup = Setup::new();


### PR DESCRIPTION
Fix a data-loss bug in `ProtoSecretKeyStore` where the write path unconditionally zeroed `sks_data.pb.old` after every write, without checking whether it still shared an inode with the just-written `sks_data.pb`.

On filesystems where `rename(2)` atomically swaps the destination directory entry to a new inode (Linux ext4/xfs/btrfs/tmpfs/…) the bug was latent: `.old` always pointed to the pre-rename inode, so zeroing scrubbed old plaintext as intended. On filesystems where `rename(2)` reuses the destination inode — observed with virtiofs bind mounts via Docker Desktop on macOS — the post-rename `.old` shared the inode of the new keystore, and zeroing corrupted the file just written. The symptom was every replica panicking at startup with `"error parsing SKS protobuf data"` after the keystore came back truncated to the trailing map entry.

The startup-cleanup path (`clean_up_old_sks`) already had the inode guard via `are_hard_links_to_the_same_inode`; the write path (`write_secret_keys_to_disk_and_cleanup_old_file`) did not. This PR extracts the guard into a shared helper `zeroize_or_unlink_old_file` and wires it into both paths. When `.old` and `proto_file` share an inode, the helper just unlinks the extra link — the new content has already been written into that inode, so there is no separate old-inode copy left to scrub and the secure-erase invariant is preserved.