### PR TITLE
fix: Also consider oldest registry version in use by replicated state if no IDKG payload exists

### DIFF
--- a/rs/consensus/idkg/src/lib.rs
+++ b/rs/consensus/idkg/src/lib.rs
@@ -631,11 +631,13 @@ mod tests {
     use ic_logger::no_op_logger;
     use ic_management_canister_types_private::MasterPublicKeyId;
     use ic_test_utilities::state_manager::RefMockStateManager;
-    use ic_test_utilities_consensus::idkg::{
-        FakeCertifiedStateSnapshot, fake_ecdsa_idkg_master_public_key_id,
-        fake_master_public_key_ids_for_all_algorithms,
-        fake_master_public_key_ids_for_all_idkg_algorithms, fake_pre_signature_stash,
-        fake_signature_request_context_from_id, request_id,
+    use ic_test_utilities_consensus::{
+        FakeCertifiedStateSnapshot,
+        idkg::{
+            fake_ecdsa_idkg_master_public_key_id, fake_master_public_key_ids_for_all_algorithms,
+            fake_master_public_key_ids_for_all_idkg_algorithms, fake_pre_signature_stash,
+            fake_signature_request_context_from_id, request_id,
+        },
     };
     use ic_types::{
         consensus::idkg::{

--- a/rs/consensus/idkg/src/signer.rs
+++ b/rs/consensus/idkg/src/signer.rs
@@ -730,7 +730,7 @@ mod tests {
     use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
     use ic_interfaces::p2p::consensus::{MutablePool, UnvalidatedArtifact};
     use ic_management_canister_types_private::{MasterPublicKeyId, SchnorrAlgorithm};
-    use ic_test_utilities_consensus::{IDkgStatsNoOp, idkg::*};
+    use ic_test_utilities_consensus::{FakeCertifiedStateSnapshot, IDkgStatsNoOp, idkg::*};
     use ic_test_utilities_logger::with_test_replica_logger;
     use ic_test_utilities_types::ids::{NODE_1, NODE_2, NODE_3, subnet_test_id, user_test_id};
     use ic_types::{

--- a/rs/consensus/src/consensus/catchup_package_maker.rs
+++ b/rs/consensus/src/consensus/catchup_package_maker.rs
@@ -208,26 +208,21 @@ impl CatchUpPackageMaker {
                 panic!("Height {height} is not a fully certified height. This should not happen.",);
             }
             Ok(state_hash) => {
-                let summary = start_block.payload.as_ref().as_summary();
-                let registry_version = if summary.idkg.is_some() {
-                    // Should succeed as we already got the hash above
-                    let state = self
-                        .state_manager
-                        .get_state_at(height)
-                        .map_err(|err| {
-                            error!(
-                                self.log,
-                                "Cannot make IDKG CUP at height {}: `get_state_hash_at` \
-                                succeeded but `get_state_at` failed with {}. Will retry",
-                                height,
-                                err,
-                            )
-                        })
-                        .ok()?;
-                    get_oldest_state_registry_version(state.get_ref())
-                } else {
-                    None
-                };
+                // Should succeed as we already got the hash above
+                let state = self
+                    .state_manager
+                    .get_state_at(height)
+                    .map_err(|err| {
+                        error!(
+                            self.log,
+                            "Cannot make CUP at height {}: `get_state_hash_at` \
+                            succeeded but `get_state_at` failed with {}. Will retry",
+                            height,
+                            err,
+                        )
+                    })
+                    .ok()?;
+                let registry_version = get_oldest_state_registry_version(state.get_ref());
                 let content = CatchUpContent::new(
                     HashedBlock::new(ic_types::crypto::crypto_hash, start_block),
                     HashedRandomBeacon::new(ic_types::crypto::crypto_hash, random_beacon),
@@ -366,7 +361,19 @@ mod tests {
     }
 
     #[test]
-    fn test_catch_up_package_maker_with_registry_version() {
+    fn test_catch_up_package_maker_with_registry_version_with_idkg_payload() {
+        test_catch_up_package_maker_with_registry_version(/*with_idkg_payload=*/ true);
+    }
+
+    /// Even without an iDKG payload in the summary block, the CUP share must
+    /// still pin the oldest registry version that is in use by the replicated
+    /// state (e.g. through `setup_initial_dkg_contexts`).
+    #[test]
+    fn test_catch_up_package_maker_with_registry_version_without_idkg_payload() {
+        test_catch_up_package_maker_with_registry_version(/*with_idkg_payload=*/ false);
+    }
+
+    fn test_catch_up_package_maker_with_registry_version(with_idkg_payload: bool) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let interval_length = 5;
             let committee: Vec<_> = (0..4).map(node_test_id).collect();
@@ -459,16 +466,18 @@ mod tests {
             let block = proposal.content.as_mut();
             block.context.certified_height = block.height();
 
-            let idkg = empty_idkg_payload(subnet_test_id(0));
-            let dkg = block.payload.as_ref().as_summary().dkg.clone();
-            block.payload = Payload::new(
-                ic_types::crypto::crypto_hash,
-                BlockPayload::Summary(SummaryPayload {
-                    dkg,
-                    idkg: Some(idkg),
-                }),
-            );
-            proposal.content = HashedBlock::new(ic_types::crypto::crypto_hash, block.clone());
+            if with_idkg_payload {
+                let idkg = empty_idkg_payload(subnet_test_id(0));
+                let dkg = block.payload.as_ref().as_summary().dkg.clone();
+                block.payload = Payload::new(
+                    ic_types::crypto::crypto_hash,
+                    BlockPayload::Summary(SummaryPayload {
+                        dkg,
+                        idkg: Some(idkg),
+                    }),
+                );
+                proposal.content = HashedBlock::new(ic_types::crypto::crypto_hash, block.clone());
+            }
 
             pool.advance_round_with_block(&proposal);
 
@@ -483,6 +492,7 @@ mod tests {
             );
             // Since the quadruple using registry version 1 wasn't matched, the oldest one in use
             // by the replicated state should be the registry version of quadruple 3, which is 2.
+            // This must hold regardless of whether the summary block carries an iDKG payload.
             assert_eq!(
                 share
                     .content

--- a/rs/consensus/src/consensus/catchup_package_maker.rs
+++ b/rs/consensus/src/consensus/catchup_package_maker.rs
@@ -476,8 +476,8 @@ mod tests {
                         idkg: Some(idkg),
                     }),
                 );
-                proposal.content = HashedBlock::new(ic_types::crypto::crypto_hash, block.clone());
             }
+            proposal.content = HashedBlock::new(ic_types::crypto::crypto_hash, block.clone());
 
             pool.advance_round_with_block(&proposal);
 

--- a/rs/consensus/src/consensus/catchup_package_maker.rs
+++ b/rs/consensus/src/consensus/catchup_package_maker.rs
@@ -267,10 +267,17 @@ mod tests {
         dependencies_with_subnet_records_with_raw_state_manager,
     };
     use ic_logger::replica_logger::no_op_logger;
+    use ic_replicated_state::metadata_state::subnet_call_context_manager::{
+        SetupInitialDkgContext, SignWithThresholdContext,
+    };
     use ic_test_utilities::message_routing::FakeMessageRouting;
-    use ic_test_utilities_consensus::idkg::{
-        empty_idkg_payload, fake_ecdsa_idkg_master_public_key_id,
-        fake_signature_request_context_with_registry_version, fake_state_with_signature_requests,
+    use ic_test_utilities_consensus::{
+        dkg::fake_setup_initial_dkg_context,
+        fake_state_with_contexts,
+        idkg::{
+            empty_idkg_payload, fake_ecdsa_idkg_master_public_key_id,
+            fake_signature_request_context_with_registry_version,
+        },
     };
     use ic_test_utilities_registry::SubnetRecordBuilder;
     use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
@@ -278,8 +285,8 @@ mod tests {
         CryptoHashOfState, Height, RegistryVersion,
         consensus::{BlockPayload, Payload, SummaryPayload, idkg::PreSigId},
         crypto::CryptoHash,
-        messages::CallbackId,
     };
+    use rstest::rstest;
     use std::sync::{Arc, RwLock};
 
     #[test]
@@ -360,20 +367,59 @@ mod tests {
         })
     }
 
-    #[test]
-    fn test_catch_up_package_maker_with_registry_version_with_idkg_payload() {
-        test_catch_up_package_maker_with_registry_version(/*with_idkg_payload=*/ true);
+    /// Build a vector of signature contexts where the oldest matched
+    /// pre-signature is pinned at `RegistryVersion(2)`. The unmatched context
+    /// at `RegistryVersion(1)` should be ignored.
+    fn signature_contexts_with_oldest_v2() -> Vec<SignWithThresholdContext> {
+        let key_id = fake_ecdsa_idkg_master_public_key_id();
+        vec![
+            fake_signature_request_context_with_registry_version(
+                Some(PreSigId(1)),
+                key_id.inner(),
+                RegistryVersion::from(3),
+            ),
+            fake_signature_request_context_with_registry_version(
+                None,
+                key_id.inner(),
+                RegistryVersion::from(1),
+            ),
+            fake_signature_request_context_with_registry_version(
+                Some(PreSigId(3)),
+                key_id.inner(),
+                RegistryVersion::from(2),
+            ),
+        ]
     }
 
-    /// Even without an iDKG payload in the summary block, the CUP share must
-    /// still pin the oldest registry version that is in use by the replicated
-    /// state (e.g. through `setup_initial_dkg_contexts`).
-    #[test]
-    fn test_catch_up_package_maker_with_registry_version_without_idkg_payload() {
-        test_catch_up_package_maker_with_registry_version(/*with_idkg_payload=*/ false);
+    /// A single signature context pinning `RegistryVersion(5)`.
+    fn signature_contexts_pinning_v5() -> Vec<SignWithThresholdContext> {
+        let key_id = fake_ecdsa_idkg_master_public_key_id();
+        vec![fake_signature_request_context_with_registry_version(
+            Some(PreSigId(1)),
+            key_id.inner(),
+            RegistryVersion::from(5),
+        )]
     }
 
-    fn test_catch_up_package_maker_with_registry_version(with_idkg_payload: bool) {
+    #[rstest]
+    #[case::sign_requests_only(signature_contexts_with_oldest_v2(), vec![])]
+    #[case::setup_initial_dkg_only(
+        vec![],
+        vec![fake_setup_initial_dkg_context(RegistryVersion::from(2))],
+    )]
+    #[case::signature_older_than_setup_initial_dkg(
+        signature_contexts_with_oldest_v2(),
+        vec![fake_setup_initial_dkg_context(RegistryVersion::from(5))],
+    )]
+    #[case::setup_initial_dkg_older_than_signature(
+        signature_contexts_pinning_v5(),
+        vec![fake_setup_initial_dkg_context(RegistryVersion::from(2))],
+    )]
+    fn test_catch_up_package_maker_with_registry_version(
+        #[case] signature_contexts: Vec<SignWithThresholdContext>,
+        #[case] setup_initial_dkg_contexts: Vec<SetupInitialDkgContext>,
+        #[values(true, false)] with_idkg_payload: bool,
+    ) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let interval_length = 5;
             let committee: Vec<_> = (0..4).map(node_test_id).collect();
@@ -401,45 +447,13 @@ mod tests {
                 .expect_get_state_hash_at()
                 .return_const(Ok(CryptoHashOfState::from(CryptoHash(vec![1, 2, 3]))));
 
-            let key_id = fake_ecdsa_idkg_master_public_key_id();
-
-            // Create three quadruple Ids and contexts, context "2" will remain unmatched.
-            let pre_sig_id1 = PreSigId(1);
-            let pre_sig_id3 = PreSigId(3);
-
-            let contexts = vec![
-                (
-                    CallbackId::new(1),
-                    fake_signature_request_context_with_registry_version(
-                        Some(pre_sig_id1),
-                        key_id.inner(),
-                        RegistryVersion::from(3),
-                    ),
-                ),
-                (
-                    CallbackId::new(2),
-                    fake_signature_request_context_with_registry_version(
-                        None,
-                        key_id.inner(),
-                        RegistryVersion::from(1),
-                    ),
-                ),
-                (
-                    CallbackId::new(3),
-                    fake_signature_request_context_with_registry_version(
-                        Some(pre_sig_id3),
-                        key_id.inner(),
-                        RegistryVersion::from(2),
-                    ),
-                ),
-            ];
-
             state_manager
                 .get_mut()
                 .expect_get_state_at()
-                .return_const(Ok(fake_state_with_signature_requests(
+                .return_const(Ok(fake_state_with_contexts(
                     height,
-                    contexts.clone(),
+                    signature_contexts,
+                    setup_initial_dkg_contexts,
                 )
                 .get_labeled_state()));
 
@@ -490,9 +504,6 @@ mod tests {
                 share.content.state_hash,
                 state_manager.get_state_hash_at(height).unwrap()
             );
-            // Since the quadruple using registry version 1 wasn't matched, the oldest one in use
-            // by the replicated state should be the registry version of quadruple 3, which is 2.
-            // This must hold regardless of whether the summary block carries an iDKG payload.
             assert_eq!(
                 share
                     .content

--- a/rs/consensus/src/consensus/purger.rs
+++ b/rs/consensus/src/consensus/purger.rs
@@ -320,7 +320,7 @@ impl Purger {
 
         self.state_manager.update_fast_forward_height(height);
 
-        let extra_heights_to_keep = get_pending_idkg_cup_heights(pool);
+        let extra_heights_to_keep = get_pending_cup_heights(pool);
         self.state_manager
             .remove_inmemory_states_below(height, &extra_heights_to_keep);
         trace!(
@@ -453,9 +453,9 @@ fn get_purge_height(pool_reader: &PoolReader<'_>) -> Option<Height> {
         })
 }
 
-/// Return the heights of all finalized IDKG summary blocks for which
-/// there exists no CUP artifact yet.
-fn get_pending_idkg_cup_heights(pool: &PoolReader<'_>) -> BTreeSet<Height> {
+/// Return the heights of all finalized summary blocks above the latest CUP
+/// for which there exists no CUP artifact yet.
+fn get_pending_cup_heights(pool: &PoolReader<'_>) -> BTreeSet<Height> {
     let mut pending_cup_heights = BTreeSet::new();
     let cup = pool.get_highest_catch_up_package();
     let summary = cup.content.block.as_ref().payload.as_ref().as_summary();
@@ -463,9 +463,7 @@ fn get_pending_idkg_cup_heights(pool: &PoolReader<'_>) -> BTreeSet<Height> {
 
     while let Some(block) = pool.get_finalized_block(next_start_height) {
         let summary = block.payload.as_ref().as_summary();
-        if summary.idkg.is_some() {
-            pending_cup_heights.insert(next_start_height);
-        }
+        pending_cup_heights.insert(next_start_height);
         next_start_height = summary.dkg.get_next_start_height();
     }
     pending_cup_heights
@@ -479,14 +477,8 @@ mod tests {
     use ic_interfaces_mocks::messaging::MockMessageRouting;
     use ic_logger::replica_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
-    use ic_test_artifact_pool::consensus_pool::TestConsensusPool;
     use ic_test_utilities::message_routing::FakeMessageRouting;
-    use ic_test_utilities_consensus::{fake::FakeContentUpdate, idkg::empty_idkg_payload};
-    use ic_types::{
-        CryptoHashOfState, SubnetId,
-        consensus::{BlockPayload, BlockProposal, Payload, Rank},
-        crypto::CryptoHash,
-    };
+    use ic_types::{CryptoHashOfState, consensus::Rank, crypto::CryptoHash};
     use std::{
         collections::HashSet,
         sync::{Arc, RwLock},
@@ -737,23 +729,8 @@ mod tests {
         })
     }
 
-    /// Create the next block and initialize it with an empty IDKG payload,
-    /// then insert it into the test pool.
-    fn init_idkg_in_next_round(pool: &mut TestConsensusPool, subnet_id: SubnetId) {
-        let mut block: BlockProposal = pool.make_next_block();
-        let idkg_payload = empty_idkg_payload(subnet_id);
-        let mut block_payload = block.as_ref().payload.as_ref().clone();
-        match &mut block_payload {
-            BlockPayload::Summary(summary) => summary.idkg = Some(idkg_payload),
-            BlockPayload::Data(data) => data.idkg = Some(idkg_payload),
-        };
-        block.content.as_mut().payload = Payload::new(ic_types::crypto::crypto_hash, block_payload);
-        block.update_content();
-        pool.advance_round_with_block(&block);
-    }
-
     #[test]
-    fn test_get_pending_idkg_cup_heights() {
+    fn test_get_pending_cup_heights() {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let Dependencies {
                 mut pool,
@@ -780,7 +757,7 @@ mod tests {
                 .return_const(());
 
             let purger = Purger::new(
-                replica_config.clone(),
+                replica_config,
                 state_manager.clone(),
                 Arc::new(MockMessageRouting::new()),
                 registry,
@@ -791,31 +768,34 @@ mod tests {
             // Initially, there should be no pending cup heights.
             purger.purge_replicated_state_by_finalized_certified_height(&PoolReader::new(&pool));
 
-            // Put some stuff in the pool.
+            // Put some stuff in the pool, below the first CUP threshold.
             pool.advance_round_normal_operation_n(10);
-            // There should be no pending cup heights.
+            // There should still be no pending cup heights.
             purger.purge_replicated_state_by_finalized_certified_height(&PoolReader::new(&pool));
 
-            // Put more stuff in the pool above the CUP threshold,
-            // without creating a CUP (DKG interval length is 60).
+            // Advance past the first CUP threshold without creating a CUP
+            // (DKG interval length is 60).
             pool.advance_round_normal_operation_no_cup_n(60);
-            // There should still be no pending cup heights
+            // There should be one pending CUP height
+            *expected_extra_heights.write().unwrap() = BTreeSet::from([Height::from(60)]);
             purger.purge_replicated_state_by_finalized_certified_height(&PoolReader::new(&pool));
-
-            // Initialize IDKG payloads starting with the next round
-            init_idkg_in_next_round(&mut pool, replica_config.subnet_id);
 
             // Advance past another CUP height, without creating the CUP
             pool.advance_round_normal_operation_no_cup_n(60);
-            // There should be one pending CUP height
-            *expected_extra_heights.write().unwrap() = BTreeSet::from([Height::from(120)]);
+            // There should be two pending CUP heights
+            *expected_extra_heights.write().unwrap() =
+                BTreeSet::from([Height::from(60), Height::from(120)]);
             purger.purge_replicated_state_by_finalized_certified_height(&PoolReader::new(&pool));
 
             // Advance past another two CUP heights, without creating the CUP
             pool.advance_round_normal_operation_no_cup_n(120);
-            // There should be three pending CUP heights
-            *expected_extra_heights.write().unwrap() =
-                BTreeSet::from([Height::from(120), Height::from(180), Height::from(240)]);
+            // There should be four pending CUP heights
+            *expected_extra_heights.write().unwrap() = BTreeSet::from([
+                Height::from(60),
+                Height::from(120),
+                Height::from(180),
+                Height::from(240),
+            ]);
             purger.purge_replicated_state_by_finalized_certified_height(&PoolReader::new(&pool));
 
             // Insert the CUP at height 180

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -1960,15 +1960,19 @@ pub mod test {
     use ic_registry_client_fake::FakeRegistryClient;
     use ic_registry_client_helpers::subnet::SubnetRegistry;
     use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
+    use ic_replicated_state::metadata_state::subnet_call_context_manager::{
+        SetupInitialDkgContext, SignWithThresholdContext,
+    };
     use ic_test_artifact_pool::consensus_pool::TestConsensusPool;
     use ic_test_utilities::state_manager::RefMockStateManager;
     use ic_test_utilities_consensus::{
         assert_changeset_matches_pattern,
+        dkg::fake_setup_initial_dkg_context,
         fake::*,
+        fake_state_with_contexts,
         idkg::{
             empty_idkg_payload, fake_ecdsa_idkg_master_public_key_id,
             fake_signature_request_context_with_registry_version,
-            fake_state_with_signature_requests,
         },
     };
     use ic_test_utilities_registry::{SubnetRecordBuilder, add_subnet_record};
@@ -1990,7 +1994,6 @@ pub mod test {
             BasicSig, BasicSigOf, CombinedMultiSig, CombinedMultiSigOf, CombinedThresholdSig,
             CombinedThresholdSigOf, CryptoHash,
         },
-        messages::CallbackId,
         replica_config::ReplicaConfig,
         signature::ThresholdSignature,
     };
@@ -2187,25 +2190,60 @@ pub mod test {
         })
     }
 
-    #[test]
-    fn test_validate_catch_up_package_shares_with_registry_version_with_idkg_payload() {
-        test_validate_catch_up_package_shares_with_registry_version(
-            /*with_idkg_payload=*/ true,
-        );
+    /// Build a vector of signature contexts where the oldest matched
+    /// pre-signature is pinned at `RegistryVersion(2)`. The unmatched context
+    /// at `RegistryVersion(1)` should be ignored.
+    fn signature_contexts_with_oldest_v2() -> Vec<SignWithThresholdContext> {
+        let key_id = fake_ecdsa_idkg_master_public_key_id();
+        vec![
+            fake_signature_request_context_with_registry_version(
+                Some(PreSigId(1)),
+                key_id.inner(),
+                RegistryVersion::from(3),
+            ),
+            fake_signature_request_context_with_registry_version(
+                None,
+                key_id.inner(),
+                RegistryVersion::from(1),
+            ),
+            fake_signature_request_context_with_registry_version(
+                Some(PreSigId(3)),
+                key_id.inner(),
+                RegistryVersion::from(2),
+            ),
+        ]
     }
 
-    /// Even without an iDKG payload in the summary block, the validator must
-    /// still check that the CUP share's
-    /// `oldest_registry_version_in_use_by_replicated_state` matches what is
-    /// actually pinned by the replicated state.
-    #[test]
-    fn test_validate_catch_up_package_shares_with_registry_version_without_idkg_payload() {
-        test_validate_catch_up_package_shares_with_registry_version(
-            /*with_idkg_payload=*/ false,
-        );
+    /// A single signature context pinning `RegistryVersion(5)`.
+    fn signature_contexts_pinning_v5() -> Vec<SignWithThresholdContext> {
+        let key_id = fake_ecdsa_idkg_master_public_key_id();
+        vec![fake_signature_request_context_with_registry_version(
+            Some(PreSigId(1)),
+            key_id.inner(),
+            RegistryVersion::from(5),
+        )]
     }
 
-    fn test_validate_catch_up_package_shares_with_registry_version(with_idkg_payload: bool) {
+    #[rstest]
+    #[case::sign_requests_only(signature_contexts_with_oldest_v2(), vec![])]
+    #[case::setup_initial_dkg_only(
+        vec![],
+        vec![fake_setup_initial_dkg_context(RegistryVersion::from(2))],
+    )]
+    #[case::signature_older_than_setup_initial_dkg(
+        signature_contexts_with_oldest_v2(),
+        vec![fake_setup_initial_dkg_context(RegistryVersion::from(5))],
+    )]
+    #[case::setup_initial_dkg_older_than_signature(
+        signature_contexts_pinning_v5(),
+        vec![fake_setup_initial_dkg_context(RegistryVersion::from(2))],
+    )]
+    fn test_validate_catch_up_package_shares_with_registry_version(
+        #[case] signature_contexts: Vec<SignWithThresholdContext>,
+        #[case] setup_initial_dkg_contexts: Vec<SetupInitialDkgContext>,
+        #[values(true, false)] with_idkg_payload: bool,
+    ) {
+        let expected_oldest_registry_version = RegistryVersion::from(2);
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let ValidatorAndDependencies {
                 validator,
@@ -2226,44 +2264,13 @@ pub mod test {
                 .return_const(Ok(state_hash.clone()));
 
             let height = Height::from(0);
-            let key_id = fake_ecdsa_idkg_master_public_key_id();
-            // Create three quadruple Ids and contexts, context "2" will remain unmatched.
-            let pre_sig_id1 = PreSigId(1);
-            let pre_sig_id3 = PreSigId(3);
-
-            let contexts = vec![
-                (
-                    CallbackId::new(1),
-                    fake_signature_request_context_with_registry_version(
-                        Some(pre_sig_id1),
-                        key_id.inner(),
-                        RegistryVersion::from(3),
-                    ),
-                ),
-                (
-                    CallbackId::new(2),
-                    fake_signature_request_context_with_registry_version(
-                        None,
-                        key_id.inner(),
-                        RegistryVersion::from(1),
-                    ),
-                ),
-                (
-                    CallbackId::new(3),
-                    fake_signature_request_context_with_registry_version(
-                        Some(pre_sig_id3),
-                        key_id.inner(),
-                        RegistryVersion::from(2),
-                    ),
-                ),
-            ];
-
             state_manager
                 .get_mut()
                 .expect_get_state_at()
-                .return_const(Ok(fake_state_with_signature_requests(
+                .return_const(Ok(fake_state_with_contexts(
                     height,
-                    contexts.clone(),
+                    signature_contexts,
+                    setup_initial_dkg_contexts,
                 )
                 .get_labeled_state()));
 
@@ -2315,34 +2322,57 @@ pub mod test {
                 make_next_cup_share(proposal.clone(), beacon.clone(), None);
             pool.insert_unvalidated(cup_share_no_registry_version.clone());
 
+            // Pick a `wrong` registry version that is guaranteed to differ from
+            // `expected_oldest_registry_version`.
+            let wrong_registry_version =
+                expected_oldest_registry_version + RegistryVersion::from(1);
             let cup_share_wrong_registry_version = make_next_cup_share(
                 proposal.clone(),
                 beacon.clone(),
-                Some(RegistryVersion::from(1)),
+                Some(wrong_registry_version),
             );
             pool.insert_unvalidated(cup_share_wrong_registry_version.clone());
 
-            // Since the quadruple using registry version 1 wasn't matched, the oldest one in use
-            // by the replicated state should be the registry version of quadruple 3, which is 2.
-            // This must hold regardless of whether the summary block carries an iDKG payload.
+            // The CUP share whose pinned version matches the replicated state's
+            // oldest pinned version is the only one that should validate. This
+            // must hold regardless of whether the summary block carries an iDKG
+            // payload.
             let cup_share_valid =
-                make_next_cup_share(proposal, beacon, Some(RegistryVersion::from(2)));
+                make_next_cup_share(proposal, beacon, Some(expected_oldest_registry_version));
             pool.insert_unvalidated(cup_share_valid.clone());
 
             let pool_reader = PoolReader::new(&pool);
             let change_set = validator.validate_catch_up_package_shares(&pool_reader);
 
-            // Check that the change set contains exactly the one `CatchUpPackageShare` we
-            // expect it to.
+            // The change set contains exactly one action per CUP share, but
+            // the order depends on the share hashes and is therefore
+            // sensitive to the parameter values, so we look up each share
+            // explicitly.
             assert_eq!(change_set.len(), 3);
-            assert_matches!(&change_set[0], ChangeAction::HandleInvalid(ConsensusMessage::CatchUpPackageShare(s), m)
-                if s == &cup_share_no_registry_version && m.contains("MismatchedOldestRegistryVersion")
+            let find_action = |share: &CatchUpPackageShare| {
+                change_set
+                    .iter()
+                    .find(|action| match action {
+                        ChangeAction::HandleInvalid(
+                            ConsensusMessage::CatchUpPackageShare(s),
+                            _,
+                        )
+                        | ChangeAction::MoveToValidated(
+                            ConsensusMessage::CatchUpPackageShare(s),
+                        ) => s == share,
+                        _ => false,
+                    })
+                    .unwrap_or_else(|| panic!("CUP share not found in change set"))
+            };
+            assert_matches!(find_action(&cup_share_no_registry_version),
+                ChangeAction::HandleInvalid(_, m) if m.contains("MismatchedOldestRegistryVersion")
             );
-            assert_matches!(&change_set[1], ChangeAction::HandleInvalid(ConsensusMessage::CatchUpPackageShare(s), m)
-                if s == &cup_share_wrong_registry_version && m.contains("MismatchedOldestRegistryVersion")
+            assert_matches!(find_action(&cup_share_wrong_registry_version),
+                ChangeAction::HandleInvalid(_, m) if m.contains("MismatchedOldestRegistryVersion")
             );
-            assert_matches!(&change_set[2], ChangeAction::MoveToValidated(ConsensusMessage::CatchUpPackageShare(s))
-                if s == &cup_share_valid
+            assert_matches!(
+                find_action(&cup_share_valid),
+                ChangeAction::MoveToValidated(_)
             );
         })
     }

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -1684,12 +1684,9 @@ impl Validator {
             return Err(InvalidArtifactReason::MismatchedBlockInCatchUpPackageShare.into());
         }
 
-        let summary = match block.payload.as_ref() {
-            BlockPayload::Summary(summary_payload) => summary_payload,
-            BlockPayload::Data(_) => {
-                return Err(InvalidArtifactReason::DataPayloadBlockInCatchUpPackageShare.into());
-            }
-        };
+        if let BlockPayload::Data(_) = block.payload.as_ref() {
+            return Err(InvalidArtifactReason::DataPayloadBlockInCatchUpPackageShare.into());
+        }
 
         let beacon = pool_reader
             .get_random_beacon(height)
@@ -1706,16 +1703,12 @@ impl Validator {
             return Err(InvalidArtifactReason::MismatchedStateHashInCatchUpPackageShare.into());
         }
 
-        let registry_version = if summary.idkg.is_some() {
-            // Should succeed as we already got the hash above
-            let state = self
-                .state_manager
-                .get_state_at(height)
-                .map_err(ValidationFailure::StateManagerError)?;
-            get_oldest_state_registry_version(state.get_ref())
-        } else {
-            None
-        };
+        // Should succeed as we already got the hash above
+        let state = self
+            .state_manager
+            .get_state_at(height)
+            .map_err(ValidationFailure::StateManagerError)?;
+        let registry_version = get_oldest_state_registry_version(state.get_ref());
         if registry_version != share_content.oldest_registry_version_in_use_by_replicated_state {
             return Err(
                 InvalidArtifactReason::MismatchedOldestRegistryVersionInCatchUpPackageShare.into(),
@@ -2195,7 +2188,24 @@ pub mod test {
     }
 
     #[test]
-    fn test_validate_catch_up_package_shares_with_registry_version() {
+    fn test_validate_catch_up_package_shares_with_registry_version_with_idkg_payload() {
+        test_validate_catch_up_package_shares_with_registry_version(
+            /*with_idkg_payload=*/ true,
+        );
+    }
+
+    /// Even without an iDKG payload in the summary block, the validator must
+    /// still check that the CUP share's
+    /// `oldest_registry_version_in_use_by_replicated_state` matches what is
+    /// actually pinned by the replicated state.
+    #[test]
+    fn test_validate_catch_up_package_shares_with_registry_version_without_idkg_payload() {
+        test_validate_catch_up_package_shares_with_registry_version(
+            /*with_idkg_payload=*/ false,
+        );
+    }
+
+    fn test_validate_catch_up_package_shares_with_registry_version(with_idkg_payload: bool) {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let ValidatorAndDependencies {
                 validator,
@@ -2285,16 +2295,18 @@ pub mod test {
             let block = proposal.content.as_mut();
             block.context.certified_height = block.height();
 
-            let idkg = empty_idkg_payload(subnet_test_id(0));
-            let dkg = block.payload.as_ref().as_summary().dkg.clone();
-            block.payload = Payload::new(
-                ic_types::crypto::crypto_hash,
-                BlockPayload::Summary(SummaryPayload {
-                    dkg,
-                    idkg: Some(idkg),
-                }),
-            );
-            proposal.content = HashedBlock::new(ic_types::crypto::crypto_hash, block.clone());
+            if with_idkg_payload {
+                let idkg = empty_idkg_payload(subnet_test_id(0));
+                let dkg = block.payload.as_ref().as_summary().dkg.clone();
+                block.payload = Payload::new(
+                    ic_types::crypto::crypto_hash,
+                    BlockPayload::Summary(SummaryPayload {
+                        dkg,
+                        idkg: Some(idkg),
+                    }),
+                );
+                proposal.content = HashedBlock::new(ic_types::crypto::crypto_hash, block.clone());
+            }
 
             let beacon = pool.make_next_beacon();
             pool.advance_round_with_block(&proposal);
@@ -2312,6 +2324,7 @@ pub mod test {
 
             // Since the quadruple using registry version 1 wasn't matched, the oldest one in use
             // by the replicated state should be the registry version of quadruple 3, which is 2.
+            // This must hold regardless of whether the summary block carries an iDKG payload.
             let cup_share_valid =
                 make_next_cup_share(proposal, beacon, Some(RegistryVersion::from(2)));
             pool.insert_unvalidated(cup_share_valid.clone());

--- a/rs/consensus/src/consensus/validator.rs
+++ b/rs/consensus/src/consensus/validator.rs
@@ -2305,8 +2305,8 @@ pub mod test {
                         idkg: Some(idkg),
                     }),
                 );
-                proposal.content = HashedBlock::new(ic_types::crypto::crypto_hash, block.clone());
             }
+            proposal.content = HashedBlock::new(ic_types::crypto::crypto_hash, block.clone());
 
             let beacon = pool.make_next_beacon();
             pool.advance_round_with_block(&proposal);

--- a/rs/test_utilities/consensus/src/dkg.rs
+++ b/rs/test_utilities/consensus/src/dkg.rs
@@ -1,0 +1,33 @@
+use ic_management_canister_types_private::VetKdKeyId;
+use ic_replicated_state::metadata_state::subnet_call_context_manager::SetupInitialDkgContext;
+use ic_test_utilities_types::{
+    ids::{node_test_id, subnet_test_id},
+    messages::RequestBuilder,
+};
+use ic_types::{
+    Height, RegistryVersion,
+    crypto::threshold_sig::ni_dkg::{
+        NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
+    },
+    time::UNIX_EPOCH,
+};
+use std::collections::BTreeSet;
+
+pub fn fake_setup_initial_dkg_context(registry_version: RegistryVersion) -> SetupInitialDkgContext {
+    SetupInitialDkgContext {
+        request: RequestBuilder::new().build(),
+        nodes_in_target_subnet: BTreeSet::from([node_test_id(1)]),
+        target_id: NiDkgTargetId::new([7_u8; NiDkgTargetId::SIZE]),
+        registry_version,
+        time: UNIX_EPOCH,
+    }
+}
+
+pub fn fake_dkg_id(key_id: VetKdKeyId) -> NiDkgId {
+    NiDkgId {
+        start_block_height: Height::from(0),
+        dealer_subnet: subnet_test_id(0),
+        dkg_tag: NiDkgTag::HighThresholdForKey(NiDkgMasterPublicKeyId::VetKd(key_id)),
+        target_subnet: NiDkgTargetSubnet::Local,
+    }
+}

--- a/rs/test_utilities/consensus/src/idkg.rs
+++ b/rs/test_utilities/consensus/src/idkg.rs
@@ -1,3 +1,4 @@
+use crate::{FakeCertifiedStateSnapshot, dkg::fake_dkg_id};
 use ic_crypto_test_utils_canister_threshold_sigs::{
     CanisterThresholdSigTestEnvironment, IDkgParticipants, ThresholdEcdsaSigInputsOwned,
     ThresholdSchnorrSigInputsOwned, generate_ecdsa_presig_quadruple, generate_key_transcript,
@@ -5,37 +6,26 @@ use ic_crypto_test_utils_canister_threshold_sigs::{
 };
 use ic_crypto_test_utils_reproducible_rng::reproducible_rng;
 use ic_crypto_test_utils_vetkd::VetKdArgsOwned;
-use ic_crypto_tree_hash::{LabeledTree, MatchPatternPath, MixedHashTree};
-use ic_interfaces_state_manager::{CertifiedStateSnapshot, Labeled};
 use ic_management_canister_types_private::{
     EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdKeyId,
 };
-use ic_replicated_state::{
-    ReplicatedState,
-    metadata_state::subnet_call_context_manager::{
-        EcdsaArguments, EcdsaMatchedPreSignature, PreSignatureStash, ReshareChainKeyContext,
-        SchnorrArguments, SchnorrMatchedPreSignature, SignWithThresholdContext, ThresholdArguments,
-        VetKdArguments,
-    },
+use ic_replicated_state::metadata_state::subnet_call_context_manager::{
+    EcdsaArguments, EcdsaMatchedPreSignature, PreSignatureStash, ReshareChainKeyContext,
+    SchnorrArguments, SchnorrMatchedPreSignature, SignWithThresholdContext, ThresholdArguments,
+    VetKdArguments,
 };
 use ic_test_utilities_state::ReplicatedStateBuilder;
-use ic_test_utilities_types::{
-    ids::{node_test_id, subnet_test_id},
-    messages::RequestBuilder,
-};
+use ic_test_utilities_types::{ids::node_test_id, messages::RequestBuilder};
 use ic_types::{
     Height, NodeId, PrincipalId, Randomness, RegistryVersion, SubnetId,
     batch::ConsensusResponse,
-    consensus::{
-        certification::Certification,
-        idkg::{
-            HasIDkgMasterPublicKeyId, IDkgMasterPublicKeyId, IDkgPayload, IDkgReshareRequest,
-            KeyTranscriptCreation, MaskedTranscript, MasterKeyTranscript, PreSigId, RequestId,
-            TranscriptRef, UnmaskedTranscript,
-            common::{PreSignature, PreSignatureRef, ThresholdSigInputs},
-            ecdsa::PreSignatureQuadrupleRef,
-            schnorr::PreSignatureTranscriptRef,
-        },
+    consensus::idkg::{
+        HasIDkgMasterPublicKeyId, IDkgMasterPublicKeyId, IDkgPayload, IDkgReshareRequest,
+        KeyTranscriptCreation, MaskedTranscript, MasterKeyTranscript, PreSigId, RequestId,
+        TranscriptRef, UnmaskedTranscript,
+        common::{PreSignature, PreSignatureRef, ThresholdSigInputs},
+        ecdsa::PreSignatureQuadrupleRef,
+        schnorr::PreSignatureTranscriptRef,
     },
     crypto::{
         AlgorithmId, ExtendedDerivationPath,
@@ -46,9 +36,7 @@ use ic_types::{
                 IDkgTranscriptType, IDkgUnmaskedTranscriptOrigin,
             },
         },
-        threshold_sig::ni_dkg::{
-            NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
-        },
+        threshold_sig::ni_dkg::NiDkgTargetId,
     },
     messages::{CallbackId, Payload},
     time::UNIX_EPOCH,
@@ -340,43 +328,6 @@ where
 }
 
 #[derive(Clone)]
-pub struct FakeCertifiedStateSnapshot {
-    pub height: Height,
-    pub state: Arc<ReplicatedState>,
-}
-
-impl FakeCertifiedStateSnapshot {
-    pub fn get_labeled_state(&self) -> Labeled<Arc<ReplicatedState>> {
-        Labeled::new(self.height, self.state.clone())
-    }
-
-    pub fn inc_height_by(&mut self, height: u64) -> Height {
-        self.height += Height::from(height);
-        self.height
-    }
-}
-
-impl CertifiedStateSnapshot for FakeCertifiedStateSnapshot {
-    type State = ReplicatedState;
-
-    fn get_state(&self) -> &Self::State {
-        &self.state
-    }
-
-    fn get_height(&self) -> Height {
-        self.height
-    }
-
-    fn read_certified_state_with_exclusion(
-        &self,
-        _paths: &LabeledTree<()>,
-        _exclusion: Option<&MatchPatternPath>,
-    ) -> Option<(MixedHashTree, Certification)> {
-        None
-    }
-}
-
-#[derive(Clone)]
 /// A test struct that contains a pre-signature ref, and all of the IDkgTranscripts
 /// referenced by it.
 pub struct TestPreSigRef {
@@ -512,15 +463,6 @@ pub fn fake_vetkd_key_id() -> VetKdKeyId {
 
 pub fn fake_vetkd_master_public_key_id() -> MasterPublicKeyId {
     MasterPublicKeyId::VetKd(fake_vetkd_key_id())
-}
-
-pub fn fake_dkg_id(key_id: VetKdKeyId) -> NiDkgId {
-    NiDkgId {
-        start_block_height: Height::from(0),
-        dealer_subnet: subnet_test_id(0),
-        dkg_tag: NiDkgTag::HighThresholdForKey(NiDkgMasterPublicKeyId::VetKd(key_id)),
-        target_subnet: NiDkgTargetSubnet::Local,
-    }
 }
 
 pub fn fake_master_public_key_ids_for_all_idkg_algorithms() -> Vec<IDkgMasterPublicKeyId> {

--- a/rs/test_utilities/consensus/src/lib.rs
+++ b/rs/test_utilities/consensus/src/lib.rs
@@ -1,19 +1,30 @@
 pub mod batch;
+pub mod dkg;
 pub mod fake;
 pub mod idkg;
 
 use assert_matches::assert_matches;
+use ic_crypto_tree_hash::{LabeledTree, MatchPatternPath, MixedHashTree};
 use ic_interfaces::{
     consensus_pool::{ChangeAction, ConsensusPoolCache, ConsensusTime},
     validation::*,
 };
+use ic_interfaces_state_manager::{CertifiedStateSnapshot, Labeled};
 use ic_protobuf::types::v1 as pb;
+use ic_replicated_state::{
+    ReplicatedState,
+    metadata_state::subnet_call_context_manager::{
+        SetupInitialDkgContext, SignWithThresholdContext,
+    },
+};
+use ic_test_utilities_state::ReplicatedStateBuilder;
 use ic_types::{
     Height, Time,
     batch::ValidationContext,
     consensus::{
         Block, BlockPayload, CatchUpContent, CatchUpPackage, ConsensusMessageHashable, HasHeight,
         HashedBlock, HashedRandomBeacon, Payload, RandomBeaconContent, Rank, SummaryPayload,
+        certification::Certification,
         dkg::DkgSummary,
         idkg::{IDkgBlockReader, IDkgStats, RequestId},
     },
@@ -23,11 +34,92 @@ use ic_types::{
         crypto_hash,
         threshold_sig::ni_dkg::NiDkgTag,
     },
+    messages::CallbackId,
     signature::ThresholdSignature,
     time::UNIX_EPOCH,
 };
 use phantom_newtype::Id;
-use std::{fmt::Debug, sync::RwLock, time::Duration};
+use std::{
+    fmt::Debug,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+#[derive(Clone)]
+pub struct FakeCertifiedStateSnapshot {
+    pub height: Height,
+    pub state: Arc<ReplicatedState>,
+}
+
+impl FakeCertifiedStateSnapshot {
+    pub fn get_labeled_state(&self) -> Labeled<Arc<ReplicatedState>> {
+        Labeled::new(self.height, self.state.clone())
+    }
+
+    pub fn inc_height_by(&mut self, height: u64) -> Height {
+        self.height += Height::from(height);
+        self.height
+    }
+}
+
+impl CertifiedStateSnapshot for FakeCertifiedStateSnapshot {
+    type State = ReplicatedState;
+
+    fn get_state(&self) -> &Self::State {
+        &self.state
+    }
+
+    fn get_height(&self) -> Height {
+        self.height
+    }
+
+    fn read_certified_state_with_exclusion(
+        &self,
+        _paths: &LabeledTree<()>,
+        _exclusion: Option<&MatchPatternPath>,
+    ) -> Option<(MixedHashTree, Certification)> {
+        None
+    }
+}
+
+/// Builds a [`FakeCertifiedStateSnapshot`] whose replicated state has the
+/// given `sign_with_threshold_contexts` and `setup_initial_dkg_contexts`
+/// installed in its subnet call context manager. Callback IDs are assigned
+/// sequentially and are unique across both context types, matching production
+/// behaviour.
+pub fn fake_state_with_contexts<S, D>(
+    height: Height,
+    signature_contexts: S,
+    setup_initial_dkg_contexts: D,
+) -> FakeCertifiedStateSnapshot
+where
+    S: IntoIterator<Item = SignWithThresholdContext>,
+    D: IntoIterator<Item = SetupInitialDkgContext>,
+{
+    let mut callback_ids = 0..;
+    let mut next_callback_id = || CallbackId::from(callback_ids.next().unwrap());
+
+    let mut state: ReplicatedState = ReplicatedStateBuilder::default().build();
+    state
+        .metadata
+        .subnet_call_context_manager
+        .sign_with_threshold_contexts = signature_contexts
+        .into_iter()
+        .map(|c| (next_callback_id(), c))
+        .collect();
+    state
+        .metadata
+        .subnet_call_context_manager
+        .setup_initial_dkg_contexts = setup_initial_dkg_contexts
+        .into_iter()
+        .map(|c| (next_callback_id(), c))
+        .collect();
+
+    FakeCertifiedStateSnapshot {
+        height,
+        state: Arc::new(state),
+    }
+}
 
 #[macro_export]
 macro_rules! assert_changeset_matches_pattern {


### PR DESCRIPTION
## Background
Subnet membership changes are enforced on DKG interval boundaries, whenever a new CUP is created. However, even if a node is no longer part of the consensus committee at that point, its participation might still be required as part of other protocols (DKG, threshold signatures, ...).

For that reason, before killing the unassigned replica and closing connections to its peers, the orchestrator uses the latest CUP to calculate the "oldest registry version in use". If the replica is still part of the subnet according to this oldest version, the orchestrator will keep it running until all ongoing protocols are completed.

The oldest registry version is determined based on data in the summary block, and the state at the summary height (which is a checkpoint height). For instance, ECDSA signature request contexts contain a registry version which determines the subnet membership required to fulfil the request. Therefore, this registry version influences the "oldest registry version in use".

## Proposed Changes
Until now, tECDSA and tSchnorr contexts were the only structures in the state influencing the oldest registry version. For that reason, the "oldest registry version in use by replicated state" was only calculated for chain-key subnets running the IDKG protocol.

However, we should also consider the registry version of `SetupInitialDKG` contexts, which similarly determines the membership required to fulfil the request. In the future, the same should be done for HTTP outcalls. These call contexts may exist on ALL subnets. The function `get_oldest_state_registry_version` already considers `SetupInitialDKG` contexts when calculating the registry version, but it is only called if the summary has an IDKG payload.

With this PR, we will also start to consider the oldest state registry version on subnets that do not maintain an IDKG payload.

Note that in order to determine the oldest state registry version, we need to access the state at the checkpoint height. By default, this state is not guaranteed to exist in memory, since a call to `remove_inmemory_states_below` may have purged it already. For that reason, the purger excludes states at summary heights that do not have a CUP yet from this call. Until now, this was however also only done for summaries containing IDKG payloads. 

With this PR, we will protect states at summary heights which do not have a CUP yet from being purged too early, regardless of whether or not it is a chain-key subnet.