### PR TITLE
feat: CON-1718 Introduce `default_initial_dkg_subnet_id` field to state's `NetworkTopology`

### DIFF
--- a/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/routing.rs
@@ -74,13 +74,17 @@ pub(super) fn resolve_destination(
         | Ok(Ic00Method::BitcoinGetSuccessors) => Ok(own_subnet.get()),
         Ok(Ic00Method::SetupInitialDKG) => {
             let args = SetupInitialDKGArgs::decode(payload)?;
-            // This message should be routed to the NNS subnet by default. We assume that
-            // this message can only be sent by canisters on the NNS subnet hence
-            // defaulting to `own_subnet` here is fine.
-            //
-            // It might be cleaner to pipe in the actual NNS subnet id to this
-            // function and return that instead.
-            Ok(args.get_subnet_id().unwrap_or(own_subnet).get())
+            // If the request specifies a subnet id explicitly, route to that
+            // subnet. Otherwise, route to the default initial DKG subnet
+            // configured in the registry, falling back to the NNS if no
+            // default is configured. We assume that this message can only be
+            // sent by canisters on the NNS subnet hence defaulting to `own_subnet`
+            // here is fine.
+            let subnet_id = args
+                .get_subnet_id()
+                .or(network_topology.default_initial_dkg_subnet_id)
+                .unwrap_or(own_subnet);
+            Ok(subnet_id.get())
         }
         Ok(Ic00Method::UpdateSettings) => {
             // Find the destination canister from the payload.
@@ -710,6 +714,51 @@ mod tests {
         assert_eq!(
             resolve_destination(
                 &network_with_ecdsa_subnets(),
+                &Ic00Method::SetupInitialDKG.to_string(),
+                &setup_initial_dkg_request(Some(requested_subnet)),
+                own_subnet,
+                canister_test_id(1),
+                false,
+                &logger,
+            )
+            .unwrap(),
+            requested_subnet.get()
+        );
+    }
+
+    #[test]
+    fn resolve_setup_initial_dkg_defaults_to_default_initial_dkg_subnet() {
+        let logger = no_op_logger();
+        let own_subnet = subnet_test_id(2);
+        let default_initial_dkg_subnet = subnet_test_id(0);
+        let mut network_topology = network_with_ecdsa_subnets();
+        network_topology.default_initial_dkg_subnet_id = Some(default_initial_dkg_subnet);
+        assert_eq!(
+            resolve_destination(
+                &network_topology,
+                &Ic00Method::SetupInitialDKG.to_string(),
+                &setup_initial_dkg_request(None),
+                own_subnet,
+                canister_test_id(1),
+                false,
+                &logger,
+            )
+            .unwrap(),
+            default_initial_dkg_subnet.get()
+        );
+    }
+
+    #[test]
+    fn resolve_setup_initial_dkg_requested_subnet_takes_precedence_over_default() {
+        let logger = no_op_logger();
+        let own_subnet = subnet_test_id(2);
+        let default_initial_dkg_subnet = subnet_test_id(0);
+        let requested_subnet = subnet_test_id(1);
+        let mut network_topology = network_with_ecdsa_subnets();
+        network_topology.default_initial_dkg_subnet_id = Some(default_initial_dkg_subnet);
+        assert_eq!(
+            resolve_destination(
+                &network_topology,
                 &Ic00Method::SetupInitialDKG.to_string(),
                 &setup_initial_dkg_request(Some(requested_subnet)),
                 own_subnet,

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -256,6 +256,7 @@ pub fn default_get_latest_state() -> Labeled<Arc<ReplicatedState>> {
         None,
         None,
         None,
+        None,
     );
 
     metadata.network_topology = network_topology;

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -1200,6 +1200,9 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             .map_err(|err| registry_error("NNS subnet ID", None, err))?
             .ok_or_else(|| not_found_error("NNS subnet ID", None))?;
 
+        // TODO(CON-1718): Populate this field once it is rolled out to all subnets.
+        let default_initial_dkg_subnet_id = None;
+
         let chain_key_enabled_subnets: BTreeMap<_, _> = self
             .registry
             .get_chain_key_enabled_subnets(registry_version)
@@ -1240,6 +1243,7 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             self.bitcoin_config.testnet_canister_id,
             self.bitcoin_config.mainnet_canister_id,
             full_topology,
+            default_initial_dkg_subnet_id,
         ))
     }
 

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -56,6 +56,7 @@ message NetworkTopology {
   repeated types.v1.CanisterId bitcoin_mainnet_canister_ids = 7;
   repeated ChainKeySubnetEntry chain_key_enabled_subnets = 8;
   FullTopology full_topology = 9;
+  types.v1.SubnetId default_initial_dkg_subnet_id = 10;
 }
 
 message FullTopology {

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -73,6 +73,9 @@ pub struct NetworkTopology {
     pub chain_key_enabled_subnets: ::prost::alloc::vec::Vec<ChainKeySubnetEntry>,
     #[prost(message, optional, tag = "9")]
     pub full_topology: ::core::option::Option<FullTopology>,
+    #[prost(message, optional, tag = "10")]
+    pub default_initial_dkg_subnet_id:
+        ::core::option::Option<super::super::super::types::v1::SubnetId>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FullTopology {

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -230,6 +230,11 @@ pub struct NetworkTopology {
     /// Unfiltered topology for the certified state tree.
     /// Only set on the NNS subnet; `None` everywhere else.
     full_topology: Option<FullTopology>,
+
+    /// Subnet to which `SetupInitialDKG` management canister calls are routed
+    /// by default, i.e., when no subnet id is specified explicitly in the
+    /// request. If `None`, such requests are routed to the calling subnet.
+    pub default_initial_dkg_subnet_id: Option<SubnetId>,
 }
 
 /// Full description of the API Boundary Node, which is saved in the metadata.
@@ -258,6 +263,7 @@ impl Default for NetworkTopology {
             bitcoin_testnet_canister_id: None,
             bitcoin_mainnet_canister_id: None,
             full_topology: None,
+            default_initial_dkg_subnet_id: None,
         }
     }
 }
@@ -273,6 +279,7 @@ impl NetworkTopology {
         bitcoin_testnet_canister_id: Option<CanisterId>,
         bitcoin_mainnet_canister_id: Option<CanisterId>,
         full_topology: Option<FullTopology>,
+        default_initial_dkg_subnet_id: Option<SubnetId>,
     ) -> Self {
         Self {
             subnets,
@@ -283,6 +290,7 @@ impl NetworkTopology {
             bitcoin_testnet_canister_id,
             bitcoin_mainnet_canister_id,
             full_topology,
+            default_initial_dkg_subnet_id,
         }
     }
 

--- a/rs/replicated_state/src/metadata_state/proto.rs
+++ b/rs/replicated_state/src/metadata_state/proto.rs
@@ -66,6 +66,9 @@ impl From<&NetworkTopology> for pb_metadata::NetworkTopology {
                         .collect(),
                     routing_table: Some(ft.routing_table.as_ref().into()),
                 }),
+            default_initial_dkg_subnet_id: item
+                .default_initial_dkg_subnet_id
+                .map(subnet_id_into_protobuf),
         }
     }
 }
@@ -105,6 +108,11 @@ impl TryFrom<pb_metadata::NetworkTopology> for NetworkTopology {
             Some(canister) => Some(CanisterId::try_from(canister.clone())?),
             None => None,
         };
+
+        let default_initial_dkg_subnet_id = item
+            .default_initial_dkg_subnet_id
+            .map(subnet_id_try_from_protobuf)
+            .transpose()?;
 
         Ok(Self {
             subnets,
@@ -146,6 +154,7 @@ impl TryFrom<pb_metadata::NetworkTopology> for NetworkTopology {
                     })
                 }
             },
+            default_initial_dkg_subnet_id,
         })
     }
 }

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -494,6 +494,7 @@ fn network_topology_roundtrip_encoding() {
         bitcoin_testnet_canister_id,
         bitcoin_mainnet_canister_id,
         None,
+        Some(app_subnet_id),
     );
 
     let proto = pb::NetworkTopology::from(&network_topology);
@@ -516,6 +517,7 @@ fn network_topology_roundtrip_encoding() {
             },
             routing_table: full_routing_table,
         }),
+        Some(app_subnet_id),
     );
 
     let proto = pb::NetworkTopology::from(&network_topology_with_full);


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/9782 introduced the ability to route `SetupInitialDKG` requests (caused by subnet creation/recovery/splitting) to arbitrary subnets, instead of always handling them on NNS.

This was done by extending proposal payloads to create/recover/split a subnet with an optional `SubnetId` field, to which the request should be routed.

However, this approach delegates the responsibility of choosing a suitable subnet to the proposer, which is brittle and difficult to test.

Instead, this PR begins the implementation for introducing a "default initial DKG subnet" to which all `SetupInitialDKG` requests should be routed, unless specified differently by the proposal payload. In particular, this PR introduces a new field holding the ID of the default initial DKG subnet, as part of the replicated state's `NetworkTopology`. For compatibility reasons, the field remains `None` for now, until it is rolled out to all subnets.

Note that it must still be possible to override the default initial DKG subnet (at least as part of the recovery proposal), for the case that the default DKG subnet is the one being recovered.