### PR TITLE
feat: support demo domains in system-test

### DIFF
--- a/rs/tests/driver/src/driver/farm.rs
+++ b/rs/tests/driver/src/driver/farm.rs
@@ -90,6 +90,19 @@ impl Farm {
         Ok(playnet_cert)
     }
 
+    pub fn acquire_demo_certificate(
+        &self,
+        group_name: &str,
+        domain: &str,
+    ) -> FarmResult<DemoCertificate> {
+        let path = format!("group/{group_name}/domain/{domain}/certificate");
+        let rb = self.post(&path);
+        let rbb = || rb.try_clone().expect("could not clone a request builder");
+        let resp = self.retry_until_success_long(rbb)?;
+        let demo_cert = resp.json::<DemoCertificate>()?;
+        Ok(demo_cert)
+    }
+
     pub fn create_group(
         &self,
         group_base_name: &str,
@@ -268,6 +281,23 @@ impl Farm {
         dns_records: Vec<DnsRecord>,
     ) -> FarmResult<String> {
         let path = format!("group/{group_name}/playnet/dns");
+        let rb = Self::json(self.post(&path), &dns_records);
+        let rbb = || rb.try_clone().expect("could not clone a request builder");
+        let resp = self.retry_until_success_long(rbb)?;
+        let create_dns_records_result = resp.json::<CreateDnsRecordsResult>()?;
+        Ok(create_dns_records_result.suffix)
+    }
+
+    /// Creates DNS records under the suffix: `{domain}.demo.farm.dfinity.systems`
+    /// The records will be garbage collected some time after the group has expired.
+    /// The suffix will be returned from this function such that the FQDNs can be constructed.
+    pub fn create_demo_dns_records(
+        &self,
+        group_name: &str,
+        domain: &str,
+        dns_records: Vec<DnsRecord>,
+    ) -> FarmResult<String> {
+        let path = format!("group/{group_name}/domain/{domain}/dns");
         let rb = Self::json(self.post(&path), &dns_records);
         let rbb = || rb.try_clone().expect("could not clone a request builder");
         let resp = self.retry_until_success_long(rbb)?;
@@ -724,6 +754,12 @@ impl AttachImageSpec {
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct PlaynetCertificate {
     pub playnet: String,
+    pub cert: Certificate,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
+pub struct DemoCertificate {
+    pub domain: String,
     pub cert: Certificate,
 }
 

--- a/rs/tests/driver/src/driver/ic_gateway_vm.rs
+++ b/rs/tests/driver/src/driver/ic_gateway_vm.rs
@@ -14,14 +14,16 @@ use url::Url;
 
 use crate::{
     driver::{
-        farm::{DnsRecord, DnsRecordType, HostFeature, PlaynetCertificate},
+        farm::{
+            Certificate, DemoCertificate, DnsRecord, DnsRecordType, HostFeature, PlaynetCertificate,
+        },
         log_events,
         resource::AllocatedVm,
         test_env::{TestEnv, TestEnvAttribute},
         test_env_api::{
-            AcquirePlaynetCertificate, CreatePlaynetDnsRecords, HasPublicApiUrl, HasTestEnv,
-            HasTopologySnapshot, IcNodeSnapshot, RetrieveIpv4Addr, SshSession,
-            get_dependency_path_from_env,
+            AcquireDemoCertificate, AcquirePlaynetCertificate, CreateDnsRecords,
+            CreatePlaynetDnsRecords, HasPublicApiUrl, HasTestEnv, HasTopologySnapshot,
+            IcNodeSnapshot, RetrieveIpv4Addr, SshSession, get_dependency_path_from_env,
         },
         test_setup::InfraProvider,
         universal_vm::{DeployedUniversalVm, UniversalVm, UniversalVms},
@@ -161,12 +163,33 @@ sudo networkctl reconfigure enp2s0
             None
         };
 
-        let playnet = self.load_or_create_playnet(env, vm_ipv6, vm_ipv4)?;
-        let ic_gateway_fqdn = playnet.playnet_cert.playnet.clone();
-        self.configure_dns_records(env, &playnet, &ic_gateway_fqdn)?;
+        let demo_domain_env = std::env::var("DEMO_DOMAIN").ok().filter(|s| !s.is_empty());
+
+        let (ic_gateway_fqdn, cert, aaaa_records, a_records) =
+            if let Some(demo_domain) = demo_domain_env {
+                let demo = self.load_or_create_demo_domain(env, &demo_domain, vm_ipv6, vm_ipv4)?;
+                let fqdn = demo.demo_cert.domain.clone();
+                self.configure_demo_domain_dns_records(env, &demo, &fqdn)?;
+                (
+                    fqdn,
+                    demo.demo_cert.cert.clone(),
+                    demo.aaaa_records.clone(),
+                    demo.a_records.clone(),
+                )
+            } else {
+                let playnet = self.load_or_create_playnet(env, vm_ipv6, vm_ipv4)?;
+                let fqdn = playnet.playnet_cert.playnet.clone();
+                self.configure_dns_records(env, &playnet, &fqdn)?;
+                (
+                    fqdn,
+                    playnet.playnet_cert.cert.clone(),
+                    playnet.aaaa_records.clone(),
+                    playnet.a_records.clone(),
+                )
+            };
 
         // Emit log events for A and AAAA records
-        emit_ic_gateway_records_event(&logger, &ic_gateway_fqdn, &playnet);
+        emit_ic_gateway_records_event(&logger, &ic_gateway_fqdn, &aaaa_records, &a_records);
 
         // Save playnet configuration and start the gateway
         let playnet_url = Url::parse(&format!("https://{ic_gateway_fqdn}"))?;
@@ -185,7 +208,7 @@ sudo networkctl reconfigure enp2s0
                 url
             })
             .collect();
-        self.start_gateway_container(&deployed_vm, &playnet, api_nodes_urls)?;
+        self.start_gateway_container(&deployed_vm, &ic_gateway_fqdn, &cert, api_nodes_urls)?;
 
         // Wait for the service to become ready.
         // Readiness is defined when some API boundary node used by ic-gateway responds with HTTP 200 to /api/v2/status.
@@ -283,7 +306,8 @@ sudo networkctl reconfigure enp2s0
     fn start_gateway_container(
         &self,
         deployed_universal_vm: &DeployedUniversalVm,
-        playnet: &Playnet,
+        domain: &str,
+        cert: &Certificate,
         api_nodes_urls: Vec<String>,
     ) -> Result<()> {
         let api_nodes_urls = (!api_nodes_urls.is_empty())
@@ -326,14 +350,98 @@ docker run --name=ic-gateway -d \
   --log-driver=journald \
   ic_gatewayd:image
 "#,
-            key = playnet.playnet_cert.cert.priv_key_pem,
-            cert = playnet.playnet_cert.cert.cert_pem,
-            cert_chain = playnet.playnet_cert.cert.chain_pem,
+            key = cert.priv_key_pem,
+            cert = cert.cert_pem,
+            cert_chain = cert.chain_pem,
             ic_url = api_nodes_urls,
-            domain = playnet.playnet_cert.playnet
+            domain = domain,
         );
 
         deployed_universal_vm.block_on_bash_script(&bash_script)?;
+        Ok(())
+    }
+
+    /// Loads existing demo-domain configuration or creates a new one by acquiring a
+    /// demo certificate for the given `domain`.
+    fn load_or_create_demo_domain(
+        &self,
+        env: &TestEnv,
+        domain: &str,
+        uvm_ipv6: Ipv6Addr,
+        uvm_ipv4: Option<Ipv4Addr>,
+    ) -> Result<DemoDomain> {
+        let logger = env.logger();
+        let mut demo = if DemoDomain::attribute_exists(env) {
+            let demo: DemoDomain = DemoDomain::read_attribute(env);
+            info!(
+                logger,
+                "Using existing demo domain: {}", demo.demo_cert.domain
+            );
+            demo
+        } else {
+            let demo_cert = env.acquire_demo_certificate(domain);
+            info!(logger, "Acquired new demo domain: {}", demo_cert.domain);
+            DemoDomain {
+                domain: domain.to_string(),
+                demo_cert,
+                aaaa_records: vec![],
+                a_records: vec![],
+            }
+        };
+
+        demo.aaaa_records.push(uvm_ipv6);
+        if let Some(ipv4) = uvm_ipv4 {
+            demo.a_records.push(ipv4);
+        }
+
+        // Write/overwrite file
+        demo.write_attribute(env);
+
+        Ok(demo)
+    }
+
+    /// Configures DNS records for the demo-domain flow based on infrastructure provider.
+    fn configure_demo_domain_dns_records(
+        &self,
+        env: &TestEnv,
+        demo: &DemoDomain,
+        ic_gateway_fqdn: &str,
+    ) -> Result<()> {
+        let mut records = match InfraProvider::read_attribute(env) {
+            InfraProvider::Farm => {
+                vec![
+                    DnsRecord {
+                        name: "".to_string(),
+                        record_type: DnsRecordType::AAAA,
+                        records: demo.aaaa_records.iter().map(|r| r.to_string()).collect(),
+                    },
+                    DnsRecord {
+                        name: "*".to_string(),
+                        record_type: DnsRecordType::CNAME,
+                        records: vec![ic_gateway_fqdn.to_string()],
+                    },
+                    DnsRecord {
+                        name: "*.raw".to_string(),
+                        record_type: DnsRecordType::CNAME,
+                        records: vec![ic_gateway_fqdn.to_string()],
+                    },
+                ]
+            }
+        };
+
+        if !demo.a_records.is_empty() {
+            records.push(DnsRecord {
+                name: "".to_string(),
+                record_type: DnsRecordType::A,
+                records: demo.a_records.iter().map(|r| r.to_string()).collect(),
+            })
+        }
+
+        let base_domain = env.create_demo_dns_records(&demo.domain, records);
+
+        // Wait for DNS propagation by checking a random subdomain
+        block_on(await_dns_propagation(&env.logger(), &base_domain))?;
+
         Ok(())
     }
 }
@@ -352,8 +460,29 @@ impl TestEnvAttribute for Playnet {
     }
 }
 
+/// Demo-domain configuration structure, analogous to [`Playnet`] but backed by a
+/// [`DemoCertificate`] for a caller-supplied domain.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DemoDomain {
+    pub domain: String,
+    pub demo_cert: DemoCertificate,
+    pub aaaa_records: Vec<Ipv6Addr>,
+    pub a_records: Vec<Ipv4Addr>,
+}
+
+impl TestEnvAttribute for DemoDomain {
+    fn attribute_name() -> String {
+        String::from("demo_domain")
+    }
+}
+
 /// Emits log events for IC gateway A and AAAA records.
-fn emit_ic_gateway_records_event(log: &slog::Logger, ic_gateway_fqdn: &str, playnet: &Playnet) {
+fn emit_ic_gateway_records_event(
+    log: &slog::Logger,
+    ic_gateway_fqdn: &str,
+    aaaa_records: &[Ipv6Addr],
+    a_records: &[Ipv4Addr],
+) {
     #[derive(Deserialize, Serialize)]
     struct IcGatewayARecords {
         url: String,
@@ -370,7 +499,7 @@ fn emit_ic_gateway_records_event(log: &slog::Logger, ic_gateway_fqdn: &str, play
         IC_GATEWAY_A_RECORDS_CREATED_EVENT_NAME.to_string(),
         IcGatewayARecords {
             url: ic_gateway_fqdn.to_string(),
-            a_records: playnet.a_records.clone(),
+            a_records: a_records.to_vec(),
         },
     );
     event_a_record.emit_log(log);
@@ -379,7 +508,7 @@ fn emit_ic_gateway_records_event(log: &slog::Logger, ic_gateway_fqdn: &str, play
         IC_GATEWAY_AAAA_RECORDS_CREATED_EVENT_NAME.to_string(),
         IcGatewayAAAARecords {
             url: ic_gateway_fqdn.to_string(),
-            aaaa_records: playnet.aaaa_records.clone(),
+            aaaa_records: aaaa_records.to_vec(),
         },
     );
     event_aaaa_record.emit_log(log);

--- a/rs/tests/driver/src/driver/test_env_api.rs
+++ b/rs/tests/driver/src/driver/test_env_api.rs
@@ -134,7 +134,7 @@
 use super::{
     config::NODES_INFO,
     driver_setup::SSH_AUTHORIZED_PRIV_KEYS_DIR,
-    farm::{DnsRecord, HostFeature, PlaynetCertificate},
+    farm::{DemoCertificate, DnsRecord, HostFeature, PlaynetCertificate},
     test_setup::{GroupSetup, InfraProvider},
 };
 use crate::{
@@ -2772,6 +2772,11 @@ pub trait CreateDnsRecords {
     /// The records will be garbage collected some time after the group has expired.
     /// The suffix will be returned from this function such that the FQDNs can be constructed.
     fn create_dns_records(&self, dns_records: Vec<DnsRecord>) -> String;
+
+    /// Creates DNS records under the suffix: `.<domain>.demo.farm.dfinity.systems`.
+    /// The records will be garbage collected some time after the group has expired.
+    /// The suffix will be returned from this function such that the FQDNs can be constructed.
+    fn create_demo_dns_records(&self, domain: &str, dns_records: Vec<DnsRecord>) -> String;
 }
 
 impl<T> CreateDnsRecords for T
@@ -2787,6 +2792,17 @@ where
         let group_name = group_setup.infra_group_name;
         farm.create_dns_records(&group_name, dns_records)
             .expect("Failed to create DNS records")
+    }
+
+    fn create_demo_dns_records(&self, domain: &str, dns_records: Vec<DnsRecord>) -> String {
+        let env = self.test_env();
+        let log = env.logger();
+        let farm_base_url = self.get_farm_url().unwrap();
+        let farm = Farm::new(farm_base_url, log);
+        let group_setup = GroupSetup::read_attribute(&env);
+        let group_name = group_setup.infra_group_name;
+        farm.create_demo_dns_records(&group_name, domain, dns_records)
+            .unwrap_or_else(|_| panic!("Failed to create demo DNS records for domain {}", domain))
     }
 }
 
@@ -2834,6 +2850,28 @@ where
         let group_name = group_setup.infra_group_name;
         farm.acquire_playnet_certificate(&group_name)
             .expect("Failed to acquire a certificate for a playnet")
+    }
+}
+
+pub trait AcquireDemoCertificate {
+    /// Get a certificate signed by Let's Encrypt from farm
+    /// for the domain `<domain>.demo.farm.dfinity.systems`.
+    fn acquire_demo_certificate(&self, domain: &str) -> DemoCertificate;
+}
+
+impl<T> AcquireDemoCertificate for T
+where
+    T: HasTestEnv,
+{
+    fn acquire_demo_certificate(&self, domain: &str) -> DemoCertificate {
+        let env = self.test_env();
+        let log = env.logger();
+        let farm_base_url = self.get_farm_url().unwrap();
+        let farm = Farm::new(farm_base_url, log);
+        let group_setup = GroupSetup::read_attribute(&env);
+        let group_name = group_setup.infra_group_name;
+        farm.acquire_demo_certificate(&group_name, domain)
+            .unwrap_or_else(|_| panic!("Failed to acquire a certificate for domain {}", domain))
     }
 }
 


### PR DESCRIPTION
Support acquiring so-called "demo" domains from Farm. These are like the dynamic playnets (`ic{N}.farm.dfinity.systems`) but instead lets the user specify a fixed domain using the `DEMO_DOMAIN` environment variable. The resulting domain will have the `.demo.farm.dfinity.systems` suffix. For example:
```
DEMO_DOMAIN="cloud-engine" ict testnet create small_nns --verbose
...
2026-05-16 13:12:45.504 INFO[setup:rs/tests/driver/src/driver/ic_gateway_vm.rs:383:0] Acquired new demo domain: cloud-engine.demo.farm.dfinity.systems
...
2026-05-16 13:13:08.684 INFO[setup:rs/tests/nns/nns_dapp/nns_dapp.rs:317:0] NNS frontend dapp: https://s55qq-oqaaa-aaaaa-aaakq-cai.cloud-engine.demo.farm.dfinity.systems
...
```
<img width="1165" height="877" alt="Screenshot 2026-05-16 at 15 16 59" src="https://github.com/user-attachments/assets/dc78743d-c91d-4b69-8d94-1077bb3f1fe5" />

Note that the last user to request a demo domain will cause it to be associated with his Farm group (testnet) causing the potential previous association to be lost.  

When the group expires the certificate and DNS records of the associated demo domain will be expired as well eventually. For certificates this may take up to a week.