### PR TITLE
fix: Try fixing `xnet_slo_120_subnets_staging_test`

### DIFF
--- a/rs/rust_canisters/xnet_test/src/main.rs
+++ b/rs/rust_canisters/xnet_test/src/main.rs
@@ -6,7 +6,7 @@
 //! cargo build --target wasm32-unknown-unknown --release
 //! ```
 use candid::{CandidType, Deserialize, Principal};
-use futures::future::join_all;
+use futures::future::select_all;
 use ic_cdk::api::{canister_cycle_balance, canister_self, msg_caller, time};
 use ic_cdk::call::{Call, CallFailed};
 use ic_cdk::{heartbeat, query, update};
@@ -228,10 +228,11 @@ async fn fanout() {
         }
     }
 
-    let results = join_all(futures).await;
+    while !futures.is_empty() {
+        let (result, _, remaining_futures) = select_all(futures).await;
+        futures = remaining_futures;
 
-    for res in results {
-        match res {
+        match result {
             Ok(response) => match response.candid::<Reply>() {
                 Ok(reply) => {
                     let elapsed = Duration::from_nanos(time() - reply.time_nanos);

--- a/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
@@ -13,8 +13,12 @@ const PER_TASK_TIMEOUT: Duration = Duration::from_secs(800);
 const OVERALL_TIMEOUT: Duration = Duration::from_secs(1400);
 
 fn main() -> Result<()> {
-    let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE);
+    let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE)
+        // Only best-effort calls with 30 seconds timeout, so the test doesn't hang for
+        // minutes in case we can't connect to some replica/subnet to pull.
+        .with_call_timeouts(&[Some(30)]);
     let test = config.clone().test();
+
     SystemTestGroup::new()
         .with_setup(config.build())
         .add_test(systest!(test))


### PR DESCRIPTION
From the logs of failed `xnet_slo_120_subnets_staging_test` runs, it appears that most canister calls complete successfully, but a small proportion time out, likely because some VMs cannot connect to some other VMs to pull streams.

Try addressing this in 2 ways:
 1. Fully switch to best-effort calls and reduce the timeout to only 30 seconds, so that canisters can stop reasonably quickly after the chatter terminates.
 2. Switch from `join_all()` to `select_all()` in `xnet_test_canister`, so we record call outcomes as they complete instead of only after the full batch of calls completes (which also heavily skews latency, particularly when some calls time out).