### PR TITLE
chore: CON-1453 Introduce a type for remote transcript results

### DIFF
--- a/rs/consensus/dkg/src/lib.rs
+++ b/rs/consensus/dkg/src/lib.rs
@@ -48,9 +48,9 @@ pub use payload_builder::{create_payload, get_dkg_summary_from_cup_contents};
 /// The maximal number of DKGs for other subnets we want to run in one interval.
 const MAX_REMOTE_DKGS_PER_INTERVAL: usize = 1;
 
-/// The maximum number of early remote DKG transcripts we want to include in a data payload.
+/// The maximum number of remote DKG transcripts we want to include in a data payload.
 /// Note that responses for `SetupInitialDKG` requests contain two transcripts.
-const MAX_EARLY_REMOTE_TRANSCRIPTS: usize = 2;
+const MAX_REMOTE_TRANSCRIPTS_PER_PAYLOAD: usize = 2;
 
 /// The maximum number of intervals during which an initial DKG request is
 /// attempted.
@@ -448,17 +448,16 @@ mod tests {
         batch::ValidationContext,
         consensus::{
             Block, BlockPayload, BlockProposal, DataPayload, HasHeight, Payload,
-            dkg::DkgDataPayload,
+            dkg::{DkgDataPayload, RemoteTranscriptResult},
         },
         crypto::{
             AlgorithmId, CryptoHash,
             error::MalformedPublicKeyError,
             threshold_sig::ni_dkg::{
                 NiDkgId, NiDkgMasterPublicKeyId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
-                NiDkgTranscript, errors::create_transcript_error::DkgCreateTranscriptError,
+                errors::create_transcript_error::DkgCreateTranscriptError,
             },
         },
-        messages::CallbackId,
         time::UNIX_EPOCH,
     };
     use payload_validator::validate_payload;
@@ -862,15 +861,18 @@ mod tests {
                 assert_eq!(remote_dealings, 2);
 
                 // Once enough remote dealings are available on chain, they are turned into
-                // early remote transcripts in the data payload.
+                // remote transcripts in the data payload.
                 pool.advance_round_normal_operation();
-                let early_remote = extract_remote_dkgs_from_highest_block(&pool);
-                assert_eq!(early_remote.len(), 2);
+                let remote_transcripts = extract_remote_dkgs_from_highest_block(&pool);
+                assert_eq!(remote_transcripts.len(), 2);
                 let mut tags = BTreeSet::new();
-                for (dkg_id, _, result) in &early_remote {
-                    assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Remote(target_id));
-                    assert!(result.is_ok());
-                    assert!(tags.insert(dkg_id.dkg_tag.clone()));
+                for transcript in &remote_transcripts {
+                    assert_eq!(
+                        transcript.dkg_id.target_subnet,
+                        NiDkgTargetSubnet::Remote(target_id)
+                    );
+                    assert!(transcript.transcript_result.is_ok());
+                    assert!(tags.insert(transcript.dkg_id.dkg_tag.clone()));
                 }
                 assert_eq!(
                     tags,
@@ -966,9 +968,12 @@ mod tests {
                 assert_eq!(data.dkg.transcripts_for_remote_subnets.len(), 2);
                 let mut tags = BTreeSet::new();
                 for dkg in data.dkg.transcripts_for_remote_subnets.iter() {
-                    assert_eq!(dkg.0.target_subnet, NiDkgTargetSubnet::Remote(target_id));
-                    assert!(dkg.2.is_err());
-                    assert!(tags.insert(dkg.0.dkg_tag.clone()));
+                    assert_eq!(
+                        dkg.dkg_id.target_subnet,
+                        NiDkgTargetSubnet::Remote(target_id)
+                    );
+                    assert!(dkg.transcript_result.is_err());
+                    assert!(tags.insert(dkg.dkg_id.dkg_tag.clone()));
                 }
                 assert_eq!(
                     tags,
@@ -1695,9 +1700,9 @@ mod tests {
         });
     }
 
-    const EARLY_DKG_INTERVAL: u64 = 99;
+    const REMOTE_DKG_INTERVAL: u64 = 99;
 
-    /// Common setup for early transcript tests using `setup_initial_dkg`.
+    /// Common setup for remote transcript tests using `setup_initial_dkg`.
     /// Advances to the first summary block and returns the deps, target id,
     /// and the two remote DKG ids (low + high threshold).
     fn setup_initial_dkg_test(
@@ -1711,7 +1716,7 @@ mod tests {
             vec![(
                 10,
                 SubnetRecordBuilder::from(&node_ids)
-                    .with_dkg_interval_length(EARLY_DKG_INTERVAL)
+                    .with_dkg_interval_length(REMOTE_DKG_INTERVAL)
                     .build(),
             )],
         );
@@ -1726,7 +1731,7 @@ mod tests {
         );
 
         deps.pool
-            .advance_round_normal_operation_n(EARLY_DKG_INTERVAL + 1);
+            .advance_round_normal_operation_n(REMOTE_DKG_INTERVAL + 1);
 
         // Verify that the highest summary block has no remote DKG configs and
         // does not contain remote transcripts.
@@ -1742,13 +1747,13 @@ mod tests {
         assert_eq!(extract_remote_dkgs_from_highest_block(&deps.pool).len(), 0);
         let remote_dkg_ids = vec![
             NiDkgId {
-                start_block_height: Height::from(EARLY_DKG_INTERVAL + 1),
+                start_block_height: Height::from(REMOTE_DKG_INTERVAL + 1),
                 dealer_subnet: deps.replica_config.subnet_id,
                 dkg_tag: NiDkgTag::LowThreshold,
                 target_subnet: NiDkgTargetSubnet::Remote(target_id),
             },
             NiDkgId {
-                start_block_height: Height::from(EARLY_DKG_INTERVAL + 1),
+                start_block_height: Height::from(REMOTE_DKG_INTERVAL + 1),
                 dealer_subnet: deps.replica_config.subnet_id,
                 dkg_tag: NiDkgTag::HighThreshold,
                 target_subnet: NiDkgTargetSubnet::Remote(target_id),
@@ -1809,9 +1814,9 @@ mod tests {
         );
     }
 
-    /// Advance through a full DKG interval and verify that no early remote
+    /// Advance through a full DKG interval and verify that no remote
     /// transcripts or dealings appear in any block.
-    fn assert_no_early_transcript_duplicates(pool: &mut TestConsensusPool, interval_length: u64) {
+    fn assert_no_remote_transcript_duplicates(pool: &mut TestConsensusPool, interval_length: u64) {
         for _ in 0..interval_length + 1 {
             pool.advance_round_normal_operation();
             assert_eq!(extract_dealings_from_highest_block(pool).len(), 0);
@@ -1853,7 +1858,7 @@ mod tests {
     }
 
     #[test]
-    fn test_early_setup_initial_dkg_transcripts() {
+    fn test_setup_initial_dkg_remote_transcripts() {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let (mut deps, target_id, remote_dkg_ids) = setup_initial_dkg_test(pool_config);
 
@@ -1882,30 +1887,34 @@ mod tests {
             assert_eq!(extract_dealings_from_highest_block(&deps.pool).len(), 3);
             assert_eq!(extract_remote_dkgs_from_highest_block(&deps.pool).len(), 0);
 
-            // Now sufficient dealings are on chain; early remote transcripts should appear
+            // Now sufficient dealings are on chain; remote transcripts should appear
             deps.pool.advance_round_normal_operation();
             assert_eq!(extract_dealings_from_highest_block(&deps.pool).len(), 0);
             let remote_dkgs = extract_remote_dkgs_from_highest_block(&deps.pool);
             assert_eq!(remote_dkgs.len(), 2);
-            for (dkg_id, _, result) in &remote_dkgs {
-                assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Remote(target_id));
-                assert!(result.is_ok());
+            for transcript in &remote_dkgs {
+                assert_eq!(
+                    transcript.dkg_id.target_subnet,
+                    NiDkgTargetSubnet::Remote(target_id)
+                );
+                assert!(transcript.transcript_result.is_ok());
             }
             assert!(
                 remote_dkgs
                     .iter()
-                    .any(|(id, _, _)| id.dkg_tag == NiDkgTag::HighThreshold)
+                    .any(|t| t.dkg_id.dkg_tag == NiDkgTag::HighThreshold)
             );
             assert!(
                 remote_dkgs
                     .iter()
-                    .any(|(id, _, _)| id.dkg_tag == NiDkgTag::LowThreshold)
+                    .any(|t| t.dkg_id.dkg_tag == NiDkgTag::LowThreshold)
             );
 
             assert_highest_block_validates(&deps);
 
-            // Also validate with empty transcripts_for_remote_subnets (early
-            // transcripts are only an optimization, so validation must still pass).
+            // Also validate with empty transcripts_for_remote_subnets (including
+            // the remote transcripts is only an optimization, so validation must
+            // still pass).
             let block: Block = deps
                 .pool
                 .validated()
@@ -1920,7 +1929,7 @@ mod tests {
                 .get_notarized_block(&block.parent, height)
                 .map(|block| block.into_inner())
                 .unwrap();
-            let payload_without_early_remote = match block.payload.as_ref() {
+            let payload_without_remote = match block.payload.as_ref() {
                 BlockPayload::Data(data) => {
                     let dkg_without_remote =
                         DkgDataPayload::new(data.dkg.start_height, data.dkg.messages.clone());
@@ -1940,7 +1949,7 @@ mod tests {
                     &pool_reader,
                     &*deps.dkg_pool.read().unwrap(),
                     parent,
-                    &payload_without_early_remote,
+                    &payload_without_remote,
                     deps.state_manager.as_ref(),
                     &block.context,
                     &MetricsRegistry::new().int_counter_vec(
@@ -1954,12 +1963,12 @@ mod tests {
             );
 
             // Verify that no more transcripts are created in later blocks.
-            assert_no_early_transcript_duplicates(&mut deps.pool, EARLY_DKG_INTERVAL);
+            assert_no_remote_transcript_duplicates(&mut deps.pool, REMOTE_DKG_INTERVAL);
         });
     }
 
     #[test]
-    fn test_early_remote_transcripts_with_reproducible_crypto_error() {
+    fn test_remote_transcripts_with_reproducible_crypto_error() {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let (mut deps, target_id, remote_dkg_ids) = setup_initial_dkg_test(pool_config);
 
@@ -2005,7 +2014,7 @@ mod tests {
                     &no_op_logger(),
                 )
                 .unwrap();
-                let early_transcripts = payload_builder::create_early_remote_transcripts(
+                let remote_transcripts = payload_builder::create_remote_transcripts(
                     &pool_reader,
                     &mock_crypto,
                     &parent,
@@ -2015,10 +2024,13 @@ mod tests {
                 )
                 .unwrap();
 
-                assert_eq!(early_transcripts.len(), 2);
-                for (dkg_id, _callback_id, result) in &early_transcripts {
-                    assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Remote(target_id));
-                    let error_msg = result.as_ref().unwrap_err();
+                assert_eq!(remote_transcripts.len(), 2);
+                for transcript in &remote_transcripts {
+                    assert_eq!(
+                        transcript.dkg_id.target_subnet,
+                        NiDkgTargetSubnet::Remote(target_id)
+                    );
+                    let error_msg = transcript.transcript_result.as_ref().unwrap_err();
                     assert!(
                         error_msg.contains("test error"),
                         "Error message should contain the original error, got: {error_msg}"
@@ -2030,7 +2042,7 @@ mod tests {
                     dkg: DkgDataPayload::new_with_remote_dkg_transcripts(
                         last_summary_block.height,
                         vec![],
-                        early_transcripts,
+                        remote_transcripts,
                     ),
                     idkg: Default::default(),
                 });
@@ -2067,7 +2079,7 @@ mod tests {
             deps.pool.advance_round_with_block(&proposal);
 
             // Verify that no more transcripts are created in later blocks.
-            assert_no_early_transcript_duplicates(&mut deps.pool, EARLY_DKG_INTERVAL);
+            assert_no_remote_transcript_duplicates(&mut deps.pool, REMOTE_DKG_INTERVAL);
         });
     }
 
@@ -2194,7 +2206,7 @@ mod tests {
     }
 
     #[test]
-    fn test_early_reshare_chain_key_transcripts() {
+    fn test_reshare_chain_key_remote_transcripts() {
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let node_ids = (1..5).map(node_test_id).collect::<Vec<_>>();
             let key_id = VetKdKeyId {
@@ -2209,7 +2221,7 @@ mod tests {
                 vec![(
                     10,
                     SubnetRecordBuilder::from(&node_ids)
-                        .with_dkg_interval_length(EARLY_DKG_INTERVAL)
+                        .with_dkg_interval_length(REMOTE_DKG_INTERVAL)
                         .with_chain_key_config(ChainKeyConfig {
                             key_configs: vec![KeyConfig {
                                 key_id: MasterPublicKeyId::VetKd(key_id.clone()),
@@ -2229,7 +2241,7 @@ mod tests {
 
             // Advance until the first vetkd transcript is created
             deps.pool
-                .advance_round_normal_operation_n(EARLY_DKG_INTERVAL + 3);
+                .advance_round_normal_operation_n(REMOTE_DKG_INTERVAL + 3);
 
             // Latest summary should contain only local configs.
             let summary_block = PoolReader::new(&deps.pool).get_highest_finalized_summary_block();
@@ -2253,7 +2265,7 @@ mod tests {
             complement_state_manager_with_dkg_contexts(deps.state_manager.clone(), contexts, None);
 
             let remote_dkg_ids = vec![NiDkgId {
-                start_block_height: Height::from(EARLY_DKG_INTERVAL + 1),
+                start_block_height: Height::from(REMOTE_DKG_INTERVAL + 1),
                 dealer_subnet: subnet_test_id(0),
                 dkg_tag: NiDkgTag::HighThresholdForKey(NiDkgMasterPublicKeyId::VetKd(
                     key_id.clone(),
@@ -2266,16 +2278,19 @@ mod tests {
             assert_eq!(extract_dealings_from_highest_block(&deps.pool).len(), 3);
             assert_eq!(extract_remote_dkgs_from_highest_block(&deps.pool).len(), 0);
 
-            // Now sufficient dealings are in the pool; early remote transcript should appear
+            // Now sufficient dealings are in the pool; remote transcript should appear
             deps.pool.advance_round_normal_operation();
             assert_eq!(extract_dealings_from_highest_block(&deps.pool).len(), 0);
             let remote_dkgs = extract_remote_dkgs_from_highest_block(&deps.pool);
             assert_eq!(remote_dkgs.len(), 1);
-            let (dkg_id, _, result) = &remote_dkgs[0];
-            assert_eq!(dkg_id.target_subnet, NiDkgTargetSubnet::Remote(target_id));
-            assert!(result.is_ok());
+            let transcript = &remote_dkgs[0];
             assert_eq!(
-                dkg_id.dkg_tag,
+                transcript.dkg_id.target_subnet,
+                NiDkgTargetSubnet::Remote(target_id)
+            );
+            assert!(transcript.transcript_result.is_ok());
+            assert_eq!(
+                transcript.dkg_id.dkg_tag,
                 NiDkgTag::HighThresholdForKey(NiDkgMasterPublicKeyId::VetKd(key_id))
             );
 
@@ -2283,7 +2298,7 @@ mod tests {
             assert_highest_block_validates(&deps);
 
             // Verify that no more transcripts are created in later blocks.
-            assert_no_early_transcript_duplicates(&mut deps.pool, EARLY_DKG_INTERVAL);
+            assert_no_remote_transcript_duplicates(&mut deps.pool, REMOTE_DKG_INTERVAL);
         });
     }
 
@@ -2292,10 +2307,10 @@ mod tests {
     /// additional SetupInitialDKG context (lowest target_id) with insufficient
     /// dealings for one of its configs:
     /// - The first setup target is skipped (insufficient dealings).
-    /// - The remaining two contexts compete for MAX_EARLY_REMOTE_TRANSCRIPTS
+    /// - The remaining two contexts compete for MAX_REMOTE_TRANSCRIPTS_PER_PAYLOAD
     ///   (= 2), and only the first context's transcripts are included.
     #[test]
-    fn test_early_remote_transcripts_respects_max() {
+    fn test_remote_transcripts_respects_max() {
         for (setup_first, desc) in [
             (true, "SetupInitialDKG first"),
             (false, "ReshareChainKey first"),
@@ -2315,7 +2330,7 @@ mod tests {
                     vec![(
                         10,
                         SubnetRecordBuilder::from(&node_ids)
-                            .with_dkg_interval_length(EARLY_DKG_INTERVAL)
+                            .with_dkg_interval_length(REMOTE_DKG_INTERVAL)
                             .with_chain_key_config(ChainKeyConfig {
                                 key_configs: vec![KeyConfig {
                                     key_id: MasterPublicKeyId::VetKd(key_id.clone()),
@@ -2396,11 +2411,10 @@ mod tests {
                 assert_eq!(
                     extract_remote_dkgs_from_highest_block(&deps.pool).len(),
                     0,
-                    "[{desc}] no early transcripts yet"
+                    "[{desc}] no remote transcripts yet"
                 );
 
-                type RemoteDkg = (NiDkgId, CallbackId, Result<NiDkgTranscript, String>);
-                let check_transcripts = |expect_setup_initial_dkg, remote_dkgs: Vec<RemoteDkg>| {
+                let check = |expect_setup_initial_dkg, remote_dkgs: Vec<RemoteTranscriptResult>| {
                     if expect_setup_initial_dkg {
                         assert_eq!(
                             remote_dkgs.len(),
@@ -2409,14 +2423,14 @@ mod tests {
                             remote_dkgs.len()
                         );
                         let mut tags = BTreeSet::new();
-                        for (dkg_id, _, result) in &remote_dkgs {
+                        for transcript in &remote_dkgs {
                             assert_eq!(
-                                dkg_id.target_subnet,
+                                transcript.dkg_id.target_subnet,
                                 NiDkgTargetSubnet::Remote(setup_target_id),
                                 "[{desc}] transcript should be for SetupInitialDKG target id"
                             );
-                            assert!(result.is_ok(), "[{desc}]");
-                            assert!(tags.insert(dkg_id.dkg_tag.clone()));
+                            assert!(transcript.transcript_result.is_ok(), "[{desc}]");
+                            assert!(tags.insert(transcript.dkg_id.dkg_tag.clone()));
                         }
                         assert_eq!(
                             tags,
@@ -2430,15 +2444,15 @@ mod tests {
                             "[{desc}] Expected 1 ReshareChainKey transcript, got {}",
                             remote_dkgs.len()
                         );
-                        let (dkg_id, _, result) = &remote_dkgs[0];
+                        let transcript = &remote_dkgs[0];
                         assert_eq!(
-                            dkg_id.target_subnet,
+                            transcript.dkg_id.target_subnet,
                             NiDkgTargetSubnet::Remote(reshare_target_id),
                             "[{desc}] transcript should be for ReshareChainKey target id"
                         );
-                        assert!(result.is_ok(), "[{desc}]");
+                        assert!(transcript.transcript_result.is_ok(), "[{desc}]");
                         assert_eq!(
-                            dkg_id.dkg_tag,
+                            transcript.dkg_id.dkg_tag,
                             NiDkgTag::HighThresholdForKey(NiDkgMasterPublicKeyId::VetKd(
                                 key_id.clone()
                             ))
@@ -2448,19 +2462,19 @@ mod tests {
 
                 // The skipped target is skipped (insufficient dealings for its
                 // second config). The remaining setup and reshare targets compete
-                // for MAX_EARLY_REMOTE_TRANSCRIPTS.
+                // for MAX_REMOTE_TRANSCRIPTS_PER_PAYLOAD.
                 deps.pool.advance_round_normal_operation();
                 assert_highest_block_validates(&deps);
                 assert_eq!(extract_dealings_from_highest_block(&deps.pool).len(), 0);
                 let remote_dkgs = extract_remote_dkgs_from_highest_block(&deps.pool);
-                check_transcripts(setup_first, remote_dkgs);
+                check(setup_first, remote_dkgs);
 
                 // Now transcripts for the opposite request should appear
                 deps.pool.advance_round_normal_operation();
                 assert_highest_block_validates(&deps);
                 assert_eq!(extract_dealings_from_highest_block(&deps.pool).len(), 0);
                 let remote_dkgs = extract_remote_dkgs_from_highest_block(&deps.pool);
-                check_transcripts(!setup_first, remote_dkgs);
+                check(!setup_first, remote_dkgs);
             });
         }
     }

--- a/rs/consensus/dkg/src/metrics.rs
+++ b/rs/consensus/dkg/src/metrics.rs
@@ -115,9 +115,9 @@ impl From<&BlockPayload> for DkgPayloadStats {
                         .or_insert(1);
                 }
 
-                for (dkg_id, _, _) in &data_payload.dkg.transcripts_for_remote_subnets {
+                for transcript in &data_payload.dkg.transcripts_for_remote_subnets {
                     remote_transcripts_delivered
-                        .entry(dkg_id.dkg_tag.clone())
+                        .entry(transcript.dkg_id.dkg_tag.clone())
                         .and_modify(|count| *count += 1)
                         .or_insert(1);
                 }

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    MAX_EARLY_REMOTE_TRANSCRIPTS, MAX_REMOTE_DKGS_PER_INTERVAL,
+    MAX_REMOTE_DKGS_PER_INTERVAL, MAX_REMOTE_TRANSCRIPTS_PER_PAYLOAD,
     metrics::{DkgPayloadMetrics, DkgPayloadMetricsOptionExt},
     remote::{
         ConfigResult, build_callback_id_config_map, get_updated_remote_dkg_attempts, merge_configs,
@@ -26,7 +26,10 @@ use ic_types::{
     batch::ValidationContext,
     consensus::{
         Block,
-        dkg::{DkgDataPayload, DkgPayload, DkgPayloadCreationError, DkgSummary, Message},
+        dkg::{
+            DkgDataPayload, DkgPayload, DkgPayloadCreationError, DkgSummary, Message,
+            RemoteTranscriptResult,
+        },
         get_faults_tolerated,
     },
     crypto::threshold_sig::ni_dkg::{
@@ -85,7 +88,7 @@ pub fn create_payload(
         .map(DkgPayload::Summary)
     } else {
         // If the height is not a start height, create a payload with new dealings,
-        // and possibly early remote transcripts.
+        // and possibly remote transcripts.
         create_data_payload(
             subnet_id,
             registry_client,
@@ -150,7 +153,7 @@ fn create_data_payload(
         max_dealings_per_block,
     );
 
-    let remote_dkg_transcripts = create_early_remote_transcripts(
+    let remote_dkg_transcripts = create_remote_transcripts(
         pool_reader,
         crypto,
         parent,
@@ -162,13 +165,12 @@ fn create_data_payload(
     if !remote_dkg_transcripts.is_empty() {
         info!(
             logger,
-            "Including {} early remote DKG transcripts in data block payload at height {}",
+            "Including {} remote DKG transcripts in data block payload at height {}",
             remote_dkg_transcripts.len(),
             parent.height.increment(),
         );
     }
 
-    // Include any early remote transcripts
     Ok(DkgDataPayload::new_with_remote_dkg_transcripts(
         last_summary_block.height,
         new_validated_dealings,
@@ -176,15 +178,14 @@ fn create_data_payload(
     ))
 }
 
-#[allow(clippy::type_complexity)]
-pub(crate) fn create_early_remote_transcripts(
+pub(crate) fn create_remote_transcripts(
     pool_reader: &PoolReader<'_>,
     crypto: &dyn ConsensusCrypto,
     parent: &Block,
     callback_id_map: BTreeMap<CallbackId, ConfigResult>,
     logger: &ReplicaLogger,
     dkg_payload_metrics: Option<&DkgPayloadMetrics>,
-) -> Result<Vec<(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)>, DkgPayloadCreationError> {
+) -> Result<Vec<RemoteTranscriptResult>, DkgPayloadCreationError> {
     //  Since this function is relatively expensive, we simply return if there are no outstanding DKG contexts
     if callback_id_map.is_empty() {
         return Ok(vec![]);
@@ -207,8 +208,8 @@ pub(crate) fn create_early_remote_transcripts(
                 {
                     continue;
                 }
-                // Skip requests that would exceed the maximum number of early remote transcripts.
-                if selected_transcripts.len() + errs.len() > MAX_EARLY_REMOTE_TRANSCRIPTS {
+                // Skip requests that would exceed the maximum number of remote transcripts.
+                if selected_transcripts.len() + errs.len() > MAX_REMOTE_TRANSCRIPTS_PER_PAYLOAD {
                     continue;
                 }
                 // Reject contexts for which we failed to create configs.
@@ -223,16 +224,20 @@ pub(crate) fn create_early_remote_transcripts(
                     );
                     // Including the error in the payload will cause the context to receive
                     // a reject response.
-                    selected_transcripts.push((dkg_id, callback_id, Err(err)));
+                    selected_transcripts.push(RemoteTranscriptResult::new(
+                        dkg_id,
+                        callback_id,
+                        Err(err),
+                    ));
                 }
                 continue;
             }
         };
 
-        // Ensure that creating these transcripts would not exceed the maximum number of early
+        // Ensure that creating these transcripts would not exceed the maximum number of
         // remote transcripts. We continue with the next target_id in case it requires less
         // transcripts.
-        if selected_transcripts.len() + configs.len() > MAX_EARLY_REMOTE_TRANSCRIPTS {
+        if selected_transcripts.len() + configs.len() > MAX_REMOTE_TRANSCRIPTS_PER_PAYLOAD {
             continue;
         }
 
@@ -246,7 +251,7 @@ pub(crate) fn create_early_remote_transcripts(
             continue;
         }
 
-        // For each config, try to build the necessary (dkg_id, callback_id, transcript_result) triple
+        // For each config, try to build the necessary [`RemoteTranscriptResult`].
         for config in configs.iter() {
             let dealings = all_dealings.remove(config.dkg_id()).unwrap_or_else(|| {
                 dkg_payload_metrics
@@ -262,32 +267,36 @@ pub(crate) fn create_early_remote_transcripts(
             });
             // Generate the transcript. We need to retry transient errors, as a payload containing
             // transient errors may not be verifiable by peers.
-            let transcript_result = match NiDkgAlgorithm::create_transcript(
-                crypto, config, dealings,
-            ) {
-                Ok(transcript) => Ok(transcript),
-                // Note that we handled the reproducible error case of not having enough dealings
-                // already beforehand.
-                Err(err) if err.is_reproducible() => {
-                    dkg_payload_metrics.payload_errors_inc("remote_transcript_reproducible_error");
-                    // Including the error in the payload will cause the context to receive
-                    // a reject response.
-                    let error_message = format!(
-                        "Failed to create early remote transcript for dkg id {:?} at height {}: {}",
-                        config.dkg_id(),
-                        parent.height.increment(),
-                        err
-                    );
-                    error!(logger, "{error_message}");
-                    Err(error_message)
-                }
-                Err(err) => {
-                    dkg_payload_metrics.payload_errors_inc("remote_transcript_transient_error");
-                    // Return on transient crypto errors
-                    return Err(DkgPayloadCreationError::DkgCreateTranscriptError(err));
-                }
-            };
-            selected_transcripts.push((config.dkg_id().clone(), callback_id, transcript_result));
+            let transcript_result =
+                match NiDkgAlgorithm::create_transcript(crypto, config, dealings) {
+                    Ok(transcript) => Ok(transcript),
+                    // Note that we handled the reproducible error case of not having enough dealings
+                    // already beforehand.
+                    Err(err) if err.is_reproducible() => {
+                        dkg_payload_metrics
+                            .payload_errors_inc("remote_transcript_reproducible_error");
+                        // Including the error in the payload will cause the context to receive
+                        // a reject response.
+                        let error_message = format!(
+                            "Failed to create remote transcript for dkg id {:?} at height {}: {}",
+                            config.dkg_id(),
+                            parent.height.increment(),
+                            err
+                        );
+                        error!(logger, "{error_message}");
+                        Err(error_message)
+                    }
+                    Err(err) => {
+                        dkg_payload_metrics.payload_errors_inc("remote_transcript_transient_error");
+                        // Return on transient crypto errors
+                        return Err(DkgPayloadCreationError::DkgCreateTranscriptError(err));
+                    }
+                };
+            selected_transcripts.push(RemoteTranscriptResult::new(
+                config.dkg_id().clone(),
+                callback_id,
+                transcript_result,
+            ));
         }
     }
 
@@ -1185,9 +1194,11 @@ mod tests {
                     dkg_data
                         .transcripts_for_remote_subnets
                         .iter()
-                        .filter(|(dkg_id, _, result)| {
-                            dkg_id.target_subnet == NiDkgTargetSubnet::Remote(setup_target)
-                                && *result == Err(REMOTE_DKG_REPEATED_FAILURE_ERROR.to_string())
+                        .filter(|transcript| {
+                            transcript.dkg_id.target_subnet
+                                == NiDkgTargetSubnet::Remote(setup_target)
+                                && transcript.transcript_result
+                                    == Err(REMOTE_DKG_REPEATED_FAILURE_ERROR.to_string())
                         })
                         .count(),
                     2
@@ -1204,9 +1215,11 @@ mod tests {
                     dkg_data
                         .transcripts_for_remote_subnets
                         .iter()
-                        .filter(|(dkg_id, _, result)| {
-                            dkg_id.target_subnet == NiDkgTargetSubnet::Remote(reshare_target)
-                                && *result == Err(REMOTE_DKG_REPEATED_FAILURE_ERROR.to_string())
+                        .filter(|transcript| {
+                            transcript.dkg_id.target_subnet
+                                == NiDkgTargetSubnet::Remote(reshare_target)
+                                && transcript.transcript_result
+                                    == Err(REMOTE_DKG_REPEATED_FAILURE_ERROR.to_string())
                         })
                         .count(),
                     1

--- a/rs/consensus/dkg/src/payload_builder.rs
+++ b/rs/consensus/dkg/src/payload_builder.rs
@@ -267,35 +267,33 @@ pub(crate) fn create_remote_transcripts(
             });
             // Generate the transcript. We need to retry transient errors, as a payload containing
             // transient errors may not be verifiable by peers.
-            let transcript_result =
-                match NiDkgAlgorithm::create_transcript(crypto, config, dealings) {
-                    Ok(transcript) => Ok(transcript),
-                    // Note that we handled the reproducible error case of not having enough dealings
-                    // already beforehand.
-                    Err(err) if err.is_reproducible() => {
-                        dkg_payload_metrics
-                            .payload_errors_inc("remote_transcript_reproducible_error");
-                        // Including the error in the payload will cause the context to receive
-                        // a reject response.
-                        let error_message = format!(
-                            "Failed to create remote transcript for dkg id {:?} at height {}: {}",
-                            config.dkg_id(),
-                            parent.height.increment(),
-                            err
-                        );
-                        error!(logger, "{error_message}");
-                        Err(error_message)
-                    }
-                    Err(err) => {
-                        dkg_payload_metrics.payload_errors_inc("remote_transcript_transient_error");
-                        // Return on transient crypto errors
-                        return Err(DkgPayloadCreationError::DkgCreateTranscriptError(err));
-                    }
-                };
+            let result = match NiDkgAlgorithm::create_transcript(crypto, config, dealings) {
+                Ok(transcript) => Ok(transcript),
+                // Note that we handled the reproducible error case of not having enough dealings
+                // already beforehand.
+                Err(err) if err.is_reproducible() => {
+                    dkg_payload_metrics.payload_errors_inc("remote_transcript_reproducible_error");
+                    // Including the error in the payload will cause the context to receive
+                    // a reject response.
+                    let error_message = format!(
+                        "Failed to create remote transcript for dkg id {:?} at height {}: {}",
+                        config.dkg_id(),
+                        parent.height.increment(),
+                        err
+                    );
+                    error!(logger, "{error_message}");
+                    Err(error_message)
+                }
+                Err(err) => {
+                    dkg_payload_metrics.payload_errors_inc("remote_transcript_transient_error");
+                    // Return on transient crypto errors
+                    return Err(DkgPayloadCreationError::DkgCreateTranscriptError(err));
+                }
+            };
             selected_transcripts.push(RemoteTranscriptResult::new(
                 config.dkg_id().clone(),
                 callback_id,
-                transcript_result,
+                result,
             ));
         }
     }

--- a/rs/consensus/dkg/src/payload_validator.rs
+++ b/rs/consensus/dkg/src/payload_validator.rs
@@ -223,9 +223,9 @@ fn validate_dealings_payload(
         crypto_validate_dealing(crypto, config, message)?;
     }
 
-    // If we have early transcripts, we compare them
+    // If we have remote transcripts, we compare them
     if !dealings.transcripts_for_remote_subnets.is_empty() {
-        let expected_transcripts = payload_builder::create_early_remote_transcripts(
+        let expected_transcripts = payload_builder::create_remote_transcripts(
             pool_reader,
             crypto,
             parent,
@@ -237,16 +237,16 @@ fn validate_dealings_payload(
         if dealings.transcripts_for_remote_subnets != expected_transcripts {
             warn!(
                 log,
-                "Failed to validate {} early remote DKG transcripts in data block payload at height {}",
+                "Failed to validate {} remote DKG transcripts in data block payload at height {}",
                 dealings.transcripts_for_remote_subnets.len(),
                 parent.height.increment(),
             );
-            return Err(InvalidDkgPayloadReason::InvalidEarlyNiDkgTranscripts.into());
+            return Err(InvalidDkgPayloadReason::InvalidRemoteNiDkgTranscripts.into());
         }
 
         info!(
             log,
-            "Validated {} early remote DKG transcripts in data block payload at height {}",
+            "Validated {} remote DKG transcripts in data block payload at height {}",
             dealings.transcripts_for_remote_subnets.len(),
             parent.height.increment(),
         );
@@ -283,7 +283,7 @@ mod tests {
         batch::BatchPayload,
         consensus::{
             DataPayload, Payload,
-            dkg::{DealingContent, Message},
+            dkg::{DealingContent, Message, RemoteTranscriptResult},
             idkg,
         },
         crypto::threshold_sig::ni_dkg::{NiDkgId, NiDkgTag, NiDkgTargetSubnet},
@@ -506,8 +506,8 @@ mod tests {
     }
 
     #[test]
-    fn validate_dealings_payload_when_invalid_early_remote_transcripts_present_fails_test() {
-        // Data payloads with invalid early/remote transcripts are rejected.
+    fn validate_dealings_payload_when_invalid_remote_transcripts_present_fails_test() {
+        // Data payloads with invalid remote transcripts are rejected.
         ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
             let registry_version = 1;
             let committee = [NODE_1, NODE_2, NODE_3];
@@ -550,7 +550,7 @@ mod tests {
                 start_height: Height::from(0),
                 messages: vec![],
                 transcripts_for_remote_subnets: vec![
-                    (
+                    RemoteTranscriptResult::new(
                         NiDkgId {
                             start_block_height: Height::from(0),
                             dealer_subnet: SUBNET_1,
@@ -560,7 +560,7 @@ mod tests {
                         CallbackId::from(0),
                         Err("dummy".to_string()),
                     ),
-                    (
+                    RemoteTranscriptResult::new(
                         NiDkgId {
                             start_block_height: Height::from(0),
                             dealer_subnet: SUBNET_1,
@@ -594,7 +594,7 @@ mod tests {
                     &no_op_logger(),
                 ),
                 Err(DkgPayloadValidationError::InvalidArtifact(
-                    InvalidDkgPayloadReason::InvalidEarlyNiDkgTranscripts
+                    InvalidDkgPayloadReason::InvalidRemoteNiDkgTranscripts
                 ))
             );
         })

--- a/rs/consensus/dkg/src/test_utils.rs
+++ b/rs/consensus/dkg/src/test_utils.rs
@@ -16,13 +16,12 @@ use ic_types::{
     Height, NumberOfNodes, RegistryVersion,
     consensus::{
         BlockPayload,
-        dkg::{DealingContent, DealingMessages, Message},
+        dkg::{DealingContent, DealingMessages, Message, RemoteTranscriptResult},
     },
     crypto::threshold_sig::ni_dkg::{
-        NiDkgId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet, NiDkgTranscript,
+        NiDkgId, NiDkgTag, NiDkgTargetId, NiDkgTargetSubnet,
         config::{NiDkgConfig, NiDkgConfigData},
     },
-    messages::CallbackId,
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -103,7 +102,7 @@ pub(super) fn complement_state_manager_with_setup_initial_dkg_request(
 /// Extract the remote dkg transcripts from the current highest validated block
 pub(super) fn extract_remote_dkgs_from_highest_block(
     pool: &TestConsensusPool,
-) -> Vec<(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)> {
+) -> Vec<RemoteTranscriptResult> {
     let block: ic_types::consensus::Block = pool
         .validated()
         .block_proposal()

--- a/rs/consensus/dkg/src/utils.rs
+++ b/rs/consensus/dkg/src/utils.rs
@@ -121,11 +121,11 @@ pub(super) fn get_dkg_dealings(
     {
         let payload = &block.payload.as_ref().as_data().dkg;
 
-        for (dkg_id, _, _) in payload.transcripts_for_remote_subnets.iter() {
+        for transcript in payload.transcripts_for_remote_subnets.iter() {
             // Add the finished DKG to excluded list
-            excluded.insert(dkg_id.clone());
+            excluded.insert(transcript.dkg_id.clone());
             // Remove already selected dealings
-            dealings.remove(dkg_id);
+            dealings.remove(&transcript.dkg_id);
         }
 
         for message in payload.messages.iter() {
@@ -206,7 +206,8 @@ mod tests {
         Height, RegistryVersion,
         batch::BatchPayload,
         consensus::{
-            Block, BlockPayload, BlockProposal, DataPayload, Payload, Rank, dkg::DkgDataPayload,
+            Block, BlockPayload, BlockProposal, DataPayload, Payload, Rank,
+            dkg::{DkgDataPayload, RemoteTranscriptResult},
             idkg,
         },
         crypto::{
@@ -371,7 +372,7 @@ mod tests {
                         dealings_included[0].clone(),
                         dealings_included[1].clone(),
                     ],
-                    transcripts_for_remote_subnets: vec![(
+                    transcripts_for_remote_subnets: vec![RemoteTranscriptResult::new(
                         dkg_id_with_transcript.clone(),
                         CallbackId::from(0),
                         Ok(dummy_transcript_for_tests()),

--- a/rs/consensus/src/consensus/batch_delivery.rs
+++ b/rs/consensus/src/consensus/batch_delivery.rs
@@ -31,6 +31,7 @@ use ic_types::{
     },
     consensus::{
         Block, BlockPayload, HasVersion,
+        dkg::RemoteTranscriptResult,
         idkg::{self},
     },
     crypto::randomness_from_crypto_hashable,
@@ -421,15 +422,23 @@ impl<'a> RemoteDkgResults<'a> {
 /// - Responses to `setup_initial_dkg` system calls
 /// - Responses to `reshare_chain_key`, if the requested key is a NiDkg key
 fn generate_responses_to_remote_dkgs(
-    transcripts_for_remote_subnets: &[(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)],
+    transcripts_for_remote_subnets: &[RemoteTranscriptResult],
     log: &ReplicaLogger,
 ) -> Vec<ConsensusResponse> {
     let mut dkg_results: BTreeMap<CallbackId, RemoteDkgResults> = BTreeMap::new();
-    for (id, callback_id, transcript) in transcripts_for_remote_subnets.iter() {
+    for transcript in transcripts_for_remote_subnets.iter() {
         dkg_results
-            .entry(*callback_id)
-            .and_modify(|transcript_result| transcript_result.add_transcript(id, transcript, log))
-            .or_insert_with(|| RemoteDkgResults::new(id, transcript));
+            .entry(transcript.callback_id)
+            .and_modify(|transcript_result| {
+                transcript_result.add_transcript(
+                    &transcript.dkg_id,
+                    &transcript.transcript_result,
+                    log,
+                )
+            })
+            .or_insert_with(|| {
+                RemoteDkgResults::new(&transcript.dkg_id, &transcript.transcript_result)
+            });
     }
 
     dkg_results
@@ -563,7 +572,10 @@ mod tests {
     use ic_types::{
         PrincipalId, RegistryVersion, SubnetId,
         batch::{BatchPayload, ValidationContext},
-        consensus::{DataPayload, Payload as ConsensusPayload, Rank, dkg::DkgDataPayload},
+        consensus::{
+            DataPayload, Payload as ConsensusPayload, Rank,
+            dkg::{DkgDataPayload, RemoteTranscriptResult},
+        },
         crypto::{
             CryptoHash, CryptoHashOf,
             threshold_sig::ni_dkg::{
@@ -593,12 +605,12 @@ mod tests {
     fn test_generate_setup_initial_dkg_response() {
         // Build some transcipts with matching ids and tags
         let transcripts_for_remote_subnets = [
-            (
+            RemoteTranscriptResult::new(
                 ni_dkg_id(NiDkgTag::LowThreshold),
                 CallbackId::from(1),
                 Ok(dummy_transcript_for_tests()),
             ),
-            (
+            RemoteTranscriptResult::new(
                 ni_dkg_id(NiDkgTag::HighThreshold),
                 CallbackId::from(1),
                 Ok(dummy_transcript_for_tests()),
@@ -628,7 +640,7 @@ mod tests {
         });
 
         // Build some transcipts with matching ids and tags
-        let transcripts_for_remote_subnets = [(
+        let transcripts_for_remote_subnets = [RemoteTranscriptResult::new(
             ni_dkg_id(NiDkgTag::HighThresholdForKey(key_id.clone())),
             CallbackId::from(2),
             Ok(dummy_transcript_for_tests()),
@@ -650,7 +662,7 @@ mod tests {
 
     #[test]
     fn test_generate_setup_initial_dkg_response_rejects_if_only_one_transcript_present() {
-        let transcripts_for_remote_subnets = [(
+        let transcripts_for_remote_subnets = [RemoteTranscriptResult::new(
             ni_dkg_id(NiDkgTag::LowThreshold),
             CallbackId::from(1),
             Ok(dummy_transcript_for_tests()),
@@ -671,7 +683,7 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_responses_for_early_remote_dkg_transcripts() {
+    fn test_generate_responses_for_remote_dkg_transcripts() {
         let key_id: NiDkgMasterPublicKeyId = NiDkgMasterPublicKeyId::VetKd(VetKdKeyId {
             curve: VetKdCurve::Bls12_381_G2,
             name: String::from("test_vetkd_key"),
@@ -683,18 +695,18 @@ mod tests {
             messages: vec![],
             transcripts_for_remote_subnets: vec![
                 // ReshareChainKey (NiDkg) → one response
-                (
+                RemoteTranscriptResult::new(
                     ni_dkg_id(NiDkgTag::HighThresholdForKey(key_id.clone())),
                     CallbackId::from(42),
                     Ok(dummy_transcript.clone()),
                 ),
                 // SetupInitialDKG: low + high threshold for same callback → one response
-                (
+                RemoteTranscriptResult::new(
                     ni_dkg_id(NiDkgTag::LowThreshold),
                     CallbackId::from(1),
                     Ok(dummy_transcript.clone()),
                 ),
-                (
+                RemoteTranscriptResult::new(
                     ni_dkg_id(NiDkgTag::HighThreshold),
                     CallbackId::from(1),
                     Ok(dummy_transcript),
@@ -741,7 +753,7 @@ mod tests {
         };
         let response = ReshareChainKeyResponse::decode(payload_data).unwrap();
         let ReshareChainKeyResponse::NiDkg(_) = response else {
-            panic!("Expected a NiDkg response for early remote DKG transcript");
+            panic!("Expected a NiDkg response for remote DKG transcript");
         };
 
         let setup_initial_response = responses

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -150,6 +150,35 @@ impl HasVersion for DealingContent {
     }
 }
 
+/// A NiDKG transcript result computed for a remote subnet, together with the
+/// originating DKG id and the callback id of the request it answers.
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(ExhaustiveSet))]
+pub struct RemoteTranscriptResult {
+    /// The id of the DKG instance this transcript belongs to.
+    pub dkg_id: NiDkgId,
+    /// The callback id of the request this transcript answers.
+    pub callback_id: CallbackId,
+    /// The transcript itself, or an error message describing why it could not
+    /// be created.
+    pub transcript_result: Result<NiDkgTranscript, String>,
+}
+
+impl RemoteTranscriptResult {
+    /// Create a new [`RemoteTranscriptResult`].
+    pub fn new(
+        dkg_id: NiDkgId,
+        callback_id: CallbackId,
+        transcript_result: Result<NiDkgTranscript, String>,
+    ) -> Self {
+        Self {
+            dkg_id,
+            callback_id,
+            transcript_result,
+        }
+    }
+}
+
 /// The DKG summary will be present as the DKG payload at every block,
 /// corresponding to the start of a new DKG interval.
 #[serde_as]
@@ -172,7 +201,7 @@ pub struct DkgSummary {
     #[serde_as(as = "Vec<(_, _)>")]
     next_transcripts: BTreeMap<NiDkgTag, NiDkgTranscript>,
     /// Transcripts that are computed for remote subnets.
-    pub transcripts_for_remote_subnets: Vec<(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)>,
+    pub transcripts_for_remote_subnets: Vec<RemoteTranscriptResult>,
     /// The length of the current interval in rounds (following the start
     /// block).
     pub interval_length: Height,
@@ -303,28 +332,26 @@ fn build_transcripts_vec(
 }
 
 fn build_callback_ided_transcripts_vec(
-    transcripts: &[(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)],
+    transcripts: &[RemoteTranscriptResult],
 ) -> Vec<pb::CallbackIdedNiDkgTranscript> {
     transcripts
         .iter()
-        .map(
-            |(id, callback_id, transcript_result)| pb::CallbackIdedNiDkgTranscript {
-                dkg_id: Some(pb::NiDkgId::from(id.clone())),
-                transcript_result: match transcript_result {
-                    Ok(transcript) => Some(pb::NiDkgTranscriptResult {
-                        val: Some(pb::ni_dkg_transcript_result::Val::Transcript(
-                            pb::NiDkgTranscript::from(transcript),
-                        )),
-                    }),
-                    Err(error_string) => Some(pb::NiDkgTranscriptResult {
-                        val: Some(pb::ni_dkg_transcript_result::Val::ErrorString(
-                            error_string.as_bytes().to_vec(),
-                        )),
-                    }),
-                },
-                callback_id: callback_id.get(),
+        .map(|transcript| pb::CallbackIdedNiDkgTranscript {
+            dkg_id: Some(pb::NiDkgId::from(transcript.dkg_id.clone())),
+            transcript_result: match &transcript.transcript_result {
+                Ok(transcript) => Some(pb::NiDkgTranscriptResult {
+                    val: Some(pb::ni_dkg_transcript_result::Val::Transcript(
+                        pb::NiDkgTranscript::from(transcript),
+                    )),
+                }),
+                Err(error_string) => Some(pb::NiDkgTranscriptResult {
+                    val: Some(pb::ni_dkg_transcript_result::Val::ErrorString(
+                        error_string.as_bytes().to_vec(),
+                    )),
+                }),
             },
-        )
+            callback_id: transcript.callback_id.get(),
+        })
         .collect()
 }
 
@@ -373,16 +400,15 @@ fn build_tagged_transcripts_map(
         .collect::<Result<BTreeMap<_, _>, _>>()
 }
 
-#[allow(clippy::type_complexity)]
 fn build_transcripts_vec_from_pb(
     transcripts: Vec<pb::CallbackIdedNiDkgTranscript>,
-) -> Result<Vec<(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)>, String> {
+) -> Result<Vec<RemoteTranscriptResult>, String> {
     let mut transcripts_for_remote_subnets = Vec::new();
     for transcript in transcripts.into_iter() {
         let id = transcript.dkg_id.ok_or_else(|| {
             "Missing DkgPayload::Summary::IdedNiDkgTranscript::NiDkgId".to_string()
         })?;
-        let id = NiDkgId::try_from(id)
+        let dkg_id = NiDkgId::try_from(id)
             .map_err(|e| format!("Failed to convert NiDkgId of transcript: {e:?}"))?;
         let callback_id = CallbackId::from(transcript.callback_id);
         let transcript_result = transcript
@@ -390,7 +416,11 @@ fn build_transcripts_vec_from_pb(
             .ok_or("Missing DkgPayload::Summary::IdedNiDkgTranscript::NiDkgTranscriptResult")?;
         let transcript_result = build_transcript_result(&transcript_result)
             .map_err(|e| format!("Failed to convert NiDkgTranscriptResult: {e:?}"))?;
-        transcripts_for_remote_subnets.push((id, callback_id, transcript_result));
+        transcripts_for_remote_subnets.push(RemoteTranscriptResult {
+            dkg_id,
+            callback_id,
+            transcript_result,
+        });
     }
     Ok(transcripts_for_remote_subnets)
 }
@@ -480,7 +510,7 @@ pub struct DkgDataPayload {
     /// The dealing messages
     pub messages: DealingMessages,
     /// Transcripts that are computed for remote subnets.
-    pub transcripts_for_remote_subnets: Vec<(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)>,
+    pub transcripts_for_remote_subnets: Vec<RemoteTranscriptResult>,
 }
 
 impl TryFrom<pb::DkgDataPayload> for DkgDataPayload {
@@ -521,7 +551,7 @@ impl DkgDataPayload {
     pub fn new_with_remote_dkg_transcripts(
         start_height: Height,
         messages: DealingMessages,
-        remote_dkg_transcripts: Vec<(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)>,
+        remote_dkg_transcripts: Vec<RemoteTranscriptResult>,
     ) -> Self {
         Self {
             start_height,
@@ -629,8 +659,8 @@ pub enum InvalidDkgPayloadReason {
         limit: usize,
         actual: usize,
     },
-    /// The early NiDKG transcripts that were included with this payload are invalid
-    InvalidEarlyNiDkgTranscripts,
+    /// The remote NiDKG transcripts that were included with this payload are invalid
+    InvalidRemoteNiDkgTranscripts,
 }
 
 /// Possible failures which could occur while validating a dkg payload. They don't imply that the


### PR DESCRIPTION
Instead of the verbose `(NiDkgId, CallbackId, Result<NiDkgTranscript, String>)` triple, this PR introduces a dedicated struct for remote NiDKG transcript creation results.

Additionally, we remove all mentions of "early" remote transcripts. After https://github.com/dfinity/ic/pull/10055, "early" transcript creation (i.e. as part of data blocks) is the only way for remote transcripts to be created, since they can no longer be part of summary blocks. Therefore, we can drop the "early" prefix.

Note that, although we change the type of the summary payload, this change is backward/forward compatible (see passing `cup_compatibility_test`). This is because the hash function of the triple is equal to the one of the struct, therefore no migration is necessary.