### PR TITLE
chore: Miscellaneous variable rename

### DIFF
--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -510,13 +510,9 @@ impl CheckpointLoader {
             )
         });
 
-        for canister_state in results.into_iter() {
-            let (canister_state, durations) = canister_state?;
-            canister_states.insert(
-                canister_state.system_state.canister_id(),
-                Arc::new(canister_state),
-            );
-
+        for result in results.into_iter() {
+            let (canister_state, durations) = result?;
+            canister_states.insert(canister_state.canister_id(), Arc::new(canister_state));
             durations.apply(&self.metrics);
         }
 


### PR DESCRIPTION
Something I ran into while poking around for the scheduler refactoring. Rename the `canister_state` loop variable in `for canister_state in results` to `result`.