### PR TITLE
fix: [DSM-103] Reliably burn down idle canisters' positive AP

### DIFF
--- a/rs/execution_environment/src/scheduler/round_schedule.rs
+++ b/rs/execution_environment/src/scheduler/round_schedule.rs
@@ -602,6 +602,10 @@ impl RoundSchedule {
             {
                 canister_priority.accumulated_priority -=
                     ONE_HUNDRED_PERCENT.min(canister_priority.accumulated_priority);
+                // Don't distribute any free compute to idle canisters with positive AP.
+                // And don't bother with the exponential decay either.
+                total_ap += canister_priority.accumulated_priority;
+                continue;
             }
 
             // Apply an exponential decay to AP values outside the [AP_ROUNDS_MIN,

--- a/rs/execution_environment/src/scheduler/round_schedule/tests.rs
+++ b/rs/execution_environment/src/scheduler/round_schedule/tests.rs
@@ -1261,15 +1261,50 @@ fn finish_round_burns_down_idle_canister_accumulated_priority() {
 
     // Nothing changes for canisters with AP <= 0.
     assert_eq!(fixture.canister_priority(&ap_minus_1), &priority(-1));
-    assert!(
-        fixture.has_canister_priority(&ap_0) && fixture.canister_priority(&ap_0) == &priority(0)
-    );
+    assert!(fixture.has_canister_priority(&ap_0));
+    assert_eq!(fixture.canister_priority(&ap_0), &priority(0));
     // Canisters with 0 < AP < 100 have their AP burned down to 0.
-    assert!(
-        fixture.has_canister_priority(&ap_99) && fixture.canister_priority(&ap_99) == &priority(0)
-    );
+    assert!(fixture.has_canister_priority(&ap_99));
+    assert_eq!(fixture.canister_priority(&ap_99), &priority(0));
     // Canisters with AP >= 100 have 100 AP burned.
     assert_eq!(fixture.canister_priority(&ap_101), &priority(1));
+}
+
+/// On a mostly idle subnet, idle canisters with positive AP must not capture
+/// the free compute that should go to actively executing canisters: otherwise,
+/// the active canister can never burn its negative AP back to zero, and the
+/// idle canister never drops out of the subnet schedule.
+///
+/// Starts from a steady state (`sum(AP) == 0`) with one canister executing
+/// every round and one strictly idle canister, and checks that within a small
+/// number of rounds the idle canister's AP burns down enough for it to be
+/// dropped from the subnet schedule.
+#[test]
+fn finish_round_idle_positive_ap_does_not_capture_free_compute() {
+    let mut fixture = RoundScheduleFixture::new();
+
+    // A canister that executes every round and starts with a negative AP.
+    let active = fixture.canister();
+    fixture.push_input(active);
+    *fixture.canister_priority_mut(active) = priority(-300);
+
+    // An idle canister with a matching positive AP, so that `sum(AP) == 0`.
+    let idle = fixture.canister();
+    *fixture.canister_priority_mut(idle) = priority(300);
+
+    for round in 1..=5 {
+        fixture.round_schedule = RoundScheduleBuilder::new().build();
+        fixture.current_round = ExecutionRound::new(round);
+
+        fixture.start_iteration(true);
+        fixture.end_iteration(&btreeset! {active}, &btreeset! {active}, &btreeset! {});
+        fixture.finish_round();
+    }
+
+    // `idle`'s AP got burned down and it was dropped from the subnet schedule.
+    assert!(!fixture.has_canister_priority(&idle));
+    // `active` is still scheduled.
+    assert!(fixture.has_canister_priority(&active));
 }
 
 /// finish_round applies an exponential decay to AP values outside the


### PR DESCRIPTION
The scheduler does not remove canisters from the schedule as soon as they become idle. Instead, in order to ensure that a canister with huge negative accumulated priority (AP) does not get scheduled with neutral priority (i.e. AP=0) a couple of rounds later by simply becoming idle for a round; and similarly, to preserve some AP for a couple of rounds for canisters that accumulated a lot of it before getting executed and becoming idle; we keep canisters in the schedule until their AP reaches zero, before dropping them. Canisters with negative AP simply accumulate it the same as active canisters; and positive AP canisters get charged every round as if they had a full execution round (which they would have, had they had any inputs).

The problem with the latter is that, on a mostly idle subnet, in the presence of a few canisters with heartbeats accumulating negative AP, an idle canister with positive AP cannot burn it down fast enough to compensate for the free priority that results from charging it and the heartbeat canisters.

The mitigation is to stop distributing free priority to idle canisters with positive AP, ensuring that they quickly reach AP=0.