### PR TITLE
feat: bump end-to-end HTTPS outcall timeouts to 120s

### DIFF
--- a/rs/https_outcalls/adapter/src/config.rs
+++ b/rs/https_outcalls/adapter/src/config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 const DEFAULT_HTTP_CONNECT_TIMEOUT_SECS: u64 = 2;
-const DEFAULT_HTTP_REQUEST_TIMEOUT_SECS: u64 = 120;
+const DEFAULT_HTTP_REQUEST_TIMEOUT_SECS: u64 = 150;
 
 #[derive(Clone, Eq, PartialEq, Debug, Default, Deserialize, Serialize)]
 /// The source of the unix domain socket to be used for inter-process

--- a/rs/https_outcalls/pricing/src/legacy.rs
+++ b/rs/https_outcalls/pricing/src/legacy.rs
@@ -22,9 +22,9 @@ impl BudgetTracker for LegacyTracker {
     fn get_adapter_limits(&self) -> AdapterLimits {
         AdapterLimits {
             max_response_size: self.max_response_size,
-            // Note: there is already a timeout limit on the server itself (120 seconds, see DEFAULT_HTTP_REQUEST_TIMEOUT_SECS).
+            // Note: there is already a timeout limit on the server itself (150 seconds, see DEFAULT_HTTP_REQUEST_TIMEOUT_SECS).
             // Setting higher than that just to be safe.
-            max_response_time: Duration::from_secs(150),
+            max_response_time: Duration::from_secs(180),
         }
     }
 

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -1045,21 +1045,21 @@ fn test_http_endpoint_with_delayed_response_is_rejected(env: TestEnv) {
 
     // We pick a delay that exceeds the consensus-side timeout for canister
     // HTTP requests (`CANISTER_HTTP_TIMEOUT_INTERVAL` in
-    // rs/types/types/src/canister_http.rs, currently 60s). When the adapter
+    // rs/types/types/src/canister_http.rs, currently 120s). When the adapter
     // does not return within that interval, the consensus payload builder
     // injects a synthetic timeout response with reject code `SysTransient`
     // and message "Canister http request timed out". This is the canonical
     // user-visible behaviour for an outcall whose endpoint is too slow.
     //
     // Note: the adapter has its own request timeout
-    // (`DEFAULT_HTTP_REQUEST_TIMEOUT_SECS`, currently 120s) which would
+    // (`DEFAULT_HTTP_REQUEST_TIMEOUT_SECS`, currently 150s) which would
     // otherwise turn the call into a `SysFatal`, but the consensus interval
     // is shorter and fires first.
     let (response, _) = block_on(submit_outcall(
         &handlers,
         RemoteHttpRequest {
             request: UnvalidatedCanisterHttpRequestArgs {
-                url: format!("https://[{webserver_ipv6}]/delay/70"),
+                url: format!("https://[{webserver_ipv6}]/delay/130"),
                 headers: vec![],
                 method: HttpMethod::GET,
                 body: Some("".as_bytes().to_vec()),

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -76,7 +76,7 @@ use strum::FromRepr;
 use strum_macros::EnumIter;
 
 /// Time after which a response is considered timed out and a timeout error will be returned to execution
-pub const CANISTER_HTTP_TIMEOUT_INTERVAL: Duration = Duration::from_secs(60);
+pub const CANISTER_HTTP_TIMEOUT_INTERVAL: Duration = Duration::from_secs(120);
 
 /// Number of CanisterHttpResponses to be included in a block.
 ///


### PR DESCRIPTION
Long-running upstream requests (LLM completions in particular) were hitting the 60s consensus-side deadline well before the adapter's 120s server timeout had a chance to apply. Raise the consensus deadline to 120s and shift the layered backstops up so the invariant 'consensus < adapter < client wrapper' still holds:

* consensus CANISTER_HTTP_TIMEOUT_INTERVAL: 60s -> 120s
* adapter DEFAULT_HTTP_REQUEST_TIMEOUT_SECS: 120s -> 150s
* replica client wrapper max_response_time:  150s -> 180s

The 2s outbound TCP connect timeout in the adapter is unchanged.