### PR TITLE
feat(ai-agent): add Ollama provider; runtime-configurable tool set

### DIFF
--- a/rs/ai_agent/src/config.rs
+++ b/rs/ai_agent/src/config.rs
@@ -16,6 +16,23 @@ use crate::sessions::{DEFAULT_IDLE_TTL, DEFAULT_MAX_SESSIONS};
 /// version. Callers can still override per-config via the `model` field.
 pub const DEFAULT_GEMINI_MODEL: &str = "gemini-flash-latest";
 
+/// Default Ollama model. Matches the model pre-pulled into
+/// `/opt/ollama-models` at GuestOS base-image build time (see
+/// `ic-os/guestos/context/ollama-pull-gemma.sh`). Callers can override
+/// per-config via the `model` field.
+pub const DEFAULT_OLLAMA_MODEL: &str = "gemma3:1b";
+
+/// Default Ollama base URL. Points at the plaintext loopback that
+/// `ollama.service` binds to on a deployed AiNode (see
+/// `ic-os/components/guestos/ollama/ollama.service`). Public traffic
+/// reaches ollama through the stunnel TLS proxy on `:11434`; the agent
+/// process talks to the backend directly to skip TLS entirely.
+pub const DEFAULT_OLLAMA_BASE_URL: &str = "http://127.0.0.1:11435";
+
+/// Default provider used when the service starts and when `/v1/config`
+/// is called without an explicit `provider` field.
+pub const DEFAULT_PROVIDER: &str = "ollama";
+
 /// Default agent system prompt.
 ///
 /// IC observability tools (`ic_state`, `ic_metrics`) are described here so
@@ -50,7 +67,15 @@ pub const DEFAULT_IC_CONFIG_PATH: &str = "/run/ic-node/config/ic.json5";
 /// created later, when `/v1/config` is invoked with the API key.
 #[derive(Clone, Debug)]
 pub struct AppConfig {
-    pub default_model: String,
+    /// Default Gemini model used when `/v1/config` selects gemini without
+    /// an explicit `model` field.
+    pub default_gemini_model: String,
+    /// Default Ollama model used at startup and when `/v1/config` selects
+    /// ollama without an explicit `model` field.
+    pub default_ollama_model: String,
+    /// Default Ollama base URL used at startup and when `/v1/config`
+    /// selects ollama without an explicit `base_url` field.
+    pub default_ollama_base_url: String,
     pub default_preamble: String,
     pub default_max_turns: usize,
     /// Path to the replica `ic.json5` config. Used by `ic_state` to discover
@@ -69,7 +94,9 @@ pub struct AppConfig {
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
-            default_model: DEFAULT_GEMINI_MODEL.to_string(),
+            default_gemini_model: DEFAULT_GEMINI_MODEL.to_string(),
+            default_ollama_model: DEFAULT_OLLAMA_MODEL.to_string(),
+            default_ollama_base_url: DEFAULT_OLLAMA_BASE_URL.to_string(),
             default_preamble: DEFAULT_PREAMBLE.to_string(),
             default_max_turns: DEFAULT_MAX_TURNS,
             ic_config_path: PathBuf::from(DEFAULT_IC_CONFIG_PATH),
@@ -79,22 +106,28 @@ impl Default for AppConfig {
     }
 }
 
-/// Body of `POST /v1/config`. Currently only Gemini is supported.
+/// Body of `POST /v1/config`. Supports `ollama` (default) and `gemini`.
 #[derive(Debug, Deserialize)]
 pub struct ConfigRequest {
-    /// Provider name. Defaults to `gemini`.
+    /// Provider name. Defaults to `ollama`.
     #[serde(default = "default_provider")]
     pub provider: String,
-    /// Provider API key. Required for `gemini`.
-    pub api_key: String,
-    /// Optional model override.
+    /// Provider API key. Required for `gemini`; optional for `ollama`
+    /// (only needed when talking to a proxied/secured ollama instance).
+    #[serde(default)]
+    pub api_key: Option<String>,
+    /// Optional model override. Defaults depend on the provider; see
+    /// `DEFAULT_GEMINI_MODEL` / `DEFAULT_OLLAMA_MODEL`.
     pub model: Option<String>,
+    /// Optional ollama base URL override (ignored for other providers).
+    /// Defaults to `DEFAULT_OLLAMA_BASE_URL`.
+    pub base_url: Option<String>,
     /// Optional default preamble override.
     pub preamble: Option<String>,
 }
 
 fn default_provider() -> String {
-    "gemini".to_string()
+    DEFAULT_PROVIDER.to_string()
 }
 
 #[derive(Debug, Serialize)]

--- a/rs/ai_agent/src/handlers/chat.rs
+++ b/rs/ai_agent/src/handlers/chat.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
-use rig::completion::Prompt;
 use slog::{info, warn};
 
 use crate::{
+    handlers::tools::read_defaults as read_default_tools,
     models::{ChatRequest, ChatResponse, ErrorBody},
     providers::{AiProvider, provider_not_configured},
     state::AppState,
@@ -38,7 +38,14 @@ pub async fn chat(
         )
             .into_response();
     }
-    if let Err(unknown) = validate_tool_names(&req.tools) {
+    // Resolve the effective tool list: per-request override (including
+    // an explicit empty list) wins; otherwise fall back to the
+    // server-wide default (`POST /v1/tools`, empty out of the box).
+    let tools = req
+        .tools
+        .clone()
+        .unwrap_or_else(|| read_default_tools(&state));
+    if let Err(unknown) = validate_tool_names(&tools) {
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorBody::new(format!("unknown tool: {unknown}"))),
@@ -74,40 +81,28 @@ pub async fn chat(
         .unwrap_or(state.config.default_preamble.as_str());
     let max_turns = req.max_turns.unwrap_or(state.config.default_max_turns);
 
-    let agent = match provider.build_agent(&state, preamble, &[]).await {
-        Ok(a) => a,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody::new(format!("agent build failed: {e}"))),
-            )
-                .into_response();
-        }
-    };
-
-    // We use `prompt(...).with_history(...).extended_details()` rather
-    // than `Chat::chat(...)` because the former returns a
-    // `PromptResponse` whose `messages` field carries the new turns
-    // (user prompt + tool calls/results + final assistant) in the
-    // right order. That's exactly what we need to append to the
-    // cached transcript so the next turn sees a faithful history,
-    // including any tool-call interleavings.
-    let result = agent
-        .prompt(req.prompt.as_str())
-        .with_history(history.clone())
-        .max_turns(max_turns)
-        .extended_details()
+    // `AiProvider::prompt` matches on the variant internally to construct
+    // the right concretely-typed `rig::Agent<M>` and return a unified
+    // `ProviderRun { output, new_messages }` (new_messages carries the
+    // user prompt + tool-call interleavings + assistant reply, in the
+    // order needed to extend the cached transcript).
+    let result = provider
+        .prompt(
+            &state,
+            preamble,
+            &[],
+            &tools,
+            req.prompt.as_str(),
+            history.clone(),
+            max_turns,
+        )
         .await;
 
     match result {
-        Ok(resp) => {
+        Ok(run) => {
             // Extend the snapshot with the new turns produced by this
-            // request. `messages` is `Option<Vec<Message>>`; rig only
-            // sets `None` when no new turn happened (defensive — in
-            // practice it's always populated for prompt requests).
-            if let Some(new_turns) = resp.messages.as_ref() {
-                history.extend(new_turns.iter().cloned());
-            }
+            // request.
+            history.extend(run.new_messages.into_iter());
 
             // Persist the updated transcript. For new sessions this
             // is the first `put`; for existing ones it's an
@@ -133,7 +128,7 @@ pub async fn chat(
             }
 
             let body = ChatResponse {
-                response: resp.output,
+                response: run.output,
                 session_id,
                 provider: provider.name().to_string(),
                 model: provider.model().to_string(),

--- a/rs/ai_agent/src/handlers/config.rs
+++ b/rs/ai_agent/src/handlers/config.rs
@@ -18,7 +18,7 @@ pub async fn configure(
     State(state): State<Arc<AppState>>,
     Json(req): Json<ConfigRequest>,
 ) -> impl IntoResponse {
-    match AiProvider::from_request(&req, &state.config.default_model) {
+    match AiProvider::from_request(&req, &state.config) {
         Ok(provider) => {
             let resp = ConfigResponse {
                 status: "ok",

--- a/rs/ai_agent/src/handlers/mod.rs
+++ b/rs/ai_agent/src/handlers/mod.rs
@@ -3,3 +3,4 @@ pub mod config;
 pub mod health;
 pub mod run;
 pub mod sessions;
+pub mod tools;

--- a/rs/ai_agent/src/handlers/run.rs
+++ b/rs/ai_agent/src/handlers/run.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
-use rig::completion::Prompt;
 use slog::warn;
 
 use crate::{
+    handlers::tools::read_defaults as read_default_tools,
     models::{ErrorBody, RunRequest, RunResponse},
     providers::provider_not_configured,
     state::AppState,
@@ -34,7 +34,14 @@ pub async fn run(
         )
             .into_response();
     }
-    if let Err(unknown) = validate_tool_names(&req.tools) {
+    // Resolve the effective tool list: per-request override (including
+    // an explicit empty list) wins; otherwise fall back to the
+    // server-wide default (`POST /v1/tools`, empty out of the box).
+    let tools = req
+        .tools
+        .clone()
+        .unwrap_or_else(|| read_default_tools(&state));
+    if let Err(unknown) = validate_tool_names(&tools) {
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorBody::new(format!("unknown tool: {unknown}"))),
@@ -74,28 +81,25 @@ pub async fn run(
         .unwrap_or(state.config.default_preamble.as_str());
     let max_turns = req.max_turns.unwrap_or(state.config.default_max_turns);
 
-    let agent = match provider.build_agent(&state, preamble, &req.context).await {
-        Ok(a) => a,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody::new(format!("agent build failed: {e}"))),
-            )
-                .into_response();
-        }
-    };
-
-    let result = agent
-        .prompt(req.prompt.as_str())
-        .max_turns(max_turns)
-        .extended_details()
+    // `AiProvider::prompt` matches on the variant internally and returns
+    // a unified `ProviderRun` regardless of the underlying provider.
+    let result = provider
+        .prompt(
+            &state,
+            preamble,
+            &req.context,
+            &tools,
+            req.prompt.as_str(),
+            Vec::new(),
+            max_turns,
+        )
         .await;
 
     match result {
-        Ok(resp) => {
-            let turns_used = resp.messages.as_ref().map(Vec::len).unwrap_or(1);
+        Ok(run) => {
+            let turns_used = run.new_messages.len().max(1);
             let body = RunResponse {
-                response: resp.output,
+                response: run.output,
                 turns_used,
                 provider: provider.name().to_string(),
                 model: provider.model().to_string(),
@@ -108,7 +112,9 @@ pub async fn run(
             // source chain. Walk `Error::source()` ourselves so the
             // failing transport-level cause makes it into the log /
             // response body where it can actually be debugged.
-            let chain = error_chain(&e);
+            // `anyhow::Error` doesn't impl `std::error::Error` directly;
+            // deref it to the inner trait object so we can walk `.source()`.
+            let chain = error_chain(e.as_ref());
             warn!(state.log, "agent run failed"; "error" => %e, "chain" => &chain);
             let msg = format!("Agent failed: {e}: {chain}");
             (StatusCode::INTERNAL_SERVER_ERROR, Json(ErrorBody::new(msg))).into_response()

--- a/rs/ai_agent/src/handlers/tools.rs
+++ b/rs/ai_agent/src/handlers/tools.rs
@@ -1,0 +1,73 @@
+//! `GET /v1/tools` and `POST /v1/tools` — read and update the
+//! server-wide default tool set used when a request omits its own
+//! `tools` field.
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use slog::info;
+
+use crate::{
+    models::{ErrorBody, ToolsConfigRequest, ToolsConfigResponse},
+    state::AppState,
+    tools::{registered_tool_names, validate_tool_names},
+};
+
+/// `GET /v1/tools` — current default tool set + all known tool names.
+pub async fn get_tools(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let defaults = read_defaults(&state);
+    (
+        StatusCode::OK,
+        Json(ToolsConfigResponse {
+            default_tools: defaults,
+            available_tools: registered_tool_names().to_vec(),
+        }),
+    )
+        .into_response()
+}
+
+/// `POST /v1/tools` — replace the server-wide default tool set.
+///
+/// Validates every name against the registry; rejects with 400 on the
+/// first unknown name. Pass an empty list to disable tools by default.
+pub async fn set_tools(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ToolsConfigRequest>,
+) -> impl IntoResponse {
+    if let Err(unknown) = validate_tool_names(&req.tools) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorBody::new(format!("unknown tool: {unknown}"))),
+        )
+            .into_response();
+    }
+
+    // Sync RwLock; no `.await` while the guard is alive. Recover from a
+    // poisoned lock the same way `/v1/config` does — by overwriting.
+    let new_tools = req.tools.clone();
+    match state.default_tools.write() {
+        Ok(mut g) => *g = new_tools,
+        Err(poisoned) => *poisoned.into_inner() = new_tools,
+    }
+
+    info!(state.log, "default tools updated"; "tools" => ?req.tools);
+
+    (
+        StatusCode::OK,
+        Json(ToolsConfigResponse {
+            default_tools: req.tools,
+            available_tools: registered_tool_names().to_vec(),
+        }),
+    )
+        .into_response()
+}
+
+/// Snapshot the current default tool list. Cheap (`Vec<String>` clone).
+/// A poisoned lock is treated as "no defaults" — the request can still
+/// run with no tools, which is the safe fallback.
+pub fn read_defaults(state: &Arc<AppState>) -> Vec<String> {
+    match state.default_tools.read() {
+        Ok(g) => g.clone(),
+        Err(_) => Vec::new(),
+    }
+}

--- a/rs/ai_agent/src/main.rs
+++ b/rs/ai_agent/src/main.rs
@@ -6,12 +6,13 @@
 
 use clap::Parser;
 use ic_ai_agent::{
-    config::{AppConfig, DEFAULT_IC_CONFIG_PATH},
+    config::{AppConfig, DEFAULT_IC_CONFIG_PATH, DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_MODEL},
+    providers::AiProvider,
     router::build_router,
     sessions::{DEFAULT_IDLE_TTL, DEFAULT_MAX_SESSIONS},
     state::AppState,
 };
-use slog::{Drain, Logger, info, o};
+use slog::{Drain, Logger, info, o, warn};
 use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 #[derive(Debug, Parser)]
@@ -36,6 +37,17 @@ struct Cli {
     /// than this are evicted on next access.
     #[arg(long, env = "IC_AI_AGENT_SESSION_IDLE_TTL_SECS", default_value_t = DEFAULT_IDLE_TTL.as_secs())]
     session_idle_ttl_secs: u64,
+
+    /// Default Ollama base URL. Points at the local plaintext loopback
+    /// that `ollama.service` binds to on a deployed AiNode.
+    #[arg(long, env = "IC_AI_AGENT_OLLAMA_BASE_URL", default_value = DEFAULT_OLLAMA_BASE_URL)]
+    ollama_base_url: String,
+
+    /// Default Ollama model. Must match a model pre-pulled into
+    /// `/opt/ollama-models` (see `ollama-pull-gemma.sh`) or one
+    /// otherwise made available to `ollama.service`.
+    #[arg(long, env = "IC_AI_AGENT_OLLAMA_MODEL", default_value = DEFAULT_OLLAMA_MODEL)]
+    ollama_model: String,
 }
 
 fn make_logger() -> Logger {
@@ -68,9 +80,35 @@ async fn main() -> anyhow::Result<()> {
         ic_config_path: cli.ic_config.clone(),
         max_sessions: cli.max_sessions,
         session_idle_ttl: Duration::from_secs(cli.session_idle_ttl_secs),
+        default_ollama_base_url: cli.ollama_base_url.clone(),
+        default_ollama_model: cli.ollama_model.clone(),
         ..AppConfig::default()
     };
     let state = Arc::new(AppState::new(config, log.clone()));
+
+    // Pre-install the default Ollama provider so the agent is usable
+    // without a prior `/v1/config` call. A failure here only means the
+    // initial provider couldn't be constructed (e.g. malformed URL);
+    // callers can still install a working provider via `/v1/config`,
+    // so we log a warning and continue rather than abort startup.
+    match AiProvider::default_ollama(&state.config) {
+        Ok(p) => {
+            info!(
+                log, "default ollama provider installed";
+                "model" => p.model(), "base_url" => &cli.ollama_base_url
+            );
+            match state.provider.write() {
+                Ok(mut g) => *g = Some(p),
+                Err(poisoned) => *poisoned.into_inner() = Some(p),
+            }
+        }
+        Err(e) => warn!(
+            log, "failed to install default ollama provider; \
+                  /v1/config will be required before the agent is usable";
+            "error" => %e
+        ),
+    }
+
     let app = build_router(state);
 
     info!(log, "ic-ai-agent listening"; "addr" => %cli.addr);

--- a/rs/ai_agent/src/models/mod.rs
+++ b/rs/ai_agent/src/models/mod.rs
@@ -3,5 +3,7 @@
 pub mod request;
 pub mod response;
 
-pub use request::{ChatRequest, RunRequest};
-pub use response::{ChatResponse, ClearResponse, ErrorBody, HealthResponse, RunResponse};
+pub use request::{ChatRequest, RunRequest, ToolsConfigRequest};
+pub use response::{
+    ChatResponse, ClearResponse, ErrorBody, HealthResponse, RunResponse, ToolsConfigResponse,
+};

--- a/rs/ai_agent/src/models/request.rs
+++ b/rs/ai_agent/src/models/request.rs
@@ -7,8 +7,13 @@ pub struct RunRequest {
     pub preamble: Option<String>,
     #[serde(default)]
     pub context: Vec<String>,
-    #[serde(default)]
-    pub tools: Vec<String>,
+    /// Tool selection. Three states:
+    /// * omitted (`None`) — fall back to the currently-configured default
+    ///   (see `POST /v1/tools`; empty out of the box).
+    /// * empty list (`Some([])`) — explicitly disable all tools for this
+    ///   request.
+    /// * non-empty list — wire only the named tools.
+    pub tools: Option<Vec<String>>,
     pub max_turns: Option<usize>,
 }
 
@@ -30,7 +35,15 @@ pub struct ChatRequest {
     /// the id is returned in the response.
     pub session_id: Option<String>,
     pub preamble: Option<String>,
-    #[serde(default)]
-    pub tools: Vec<String>,
+    /// Tool selection. Same three-state semantics as `RunRequest::tools`.
+    pub tools: Option<Vec<String>>,
     pub max_turns: Option<usize>,
+}
+
+/// Body of `POST /v1/tools` — replaces the server-wide default tool set
+/// used when a request omits its own `tools` field. Pass an empty list
+/// to disable tools by default.
+#[derive(Debug, Deserialize)]
+pub struct ToolsConfigRequest {
+    pub tools: Vec<String>,
 }

--- a/rs/ai_agent/src/models/response.rs
+++ b/rs/ai_agent/src/models/response.rs
@@ -39,6 +39,18 @@ pub struct ClearResponse {
     pub cleared: usize,
 }
 
+/// Body of `GET /v1/tools` and `POST /v1/tools` — echoes the current
+/// default tool set plus the full list of names the server recognises,
+/// so clients can discover what's available.
+#[derive(Debug, Serialize)]
+pub struct ToolsConfigResponse {
+    /// Tools applied when a request omits its own `tools` field.
+    pub default_tools: Vec<String>,
+    /// Every tool name the server knows about. A subset of these is
+    /// considered valid in `default_tools` and per-request overrides.
+    pub available_tools: Vec<&'static str>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct ErrorBody {
     pub error: String,

--- a/rs/ai_agent/src/providers/mod.rs
+++ b/rs/ai_agent/src/providers/mod.rs
@@ -1,113 +1,255 @@
 //! Provider abstraction.
 //!
-//! Wraps the underlying `rig` provider client behind an enum so new
-//! providers can be added without touching handler code: extend
-//! [`AiProvider`] with a new variant, add an arm in [`AiProvider::from_request`]
-//! and in [`AiProvider::build_agent`], done.
+//! Wraps the underlying `rig` provider clients behind an enum. Each request
+//! branches on the variant to construct the concretely-typed `rig::Agent<M>`
+//! and run a single prompt. The unified [`ProviderRun`] return type lets
+//! handlers stay provider-agnostic.
+//!
+//! To add a new provider:
+//! - extend [`AiProvider`] with a new variant carrying its client + model,
+//! - add an arm in [`AiProvider::from_request`],
+//! - add an arm in [`AiProvider::prompt`] that builds the agent and runs it.
 
 use std::sync::Arc;
 
 use anyhow::anyhow;
 use rig::{
-    agent::Agent,
-    client::CompletionClient,
-    providers::gemini::{Client as GeminiClient, completion::CompletionModel as GeminiCompletion},
+    client::{CompletionClient, Nothing},
+    completion::Prompt,
+    message::Message,
+    providers::{
+        gemini::Client as GeminiClient,
+        ollama::{Client as OllamaClient, OllamaApiKey},
+    },
 };
 use slog::warn;
 
 use crate::{
-    config::ConfigRequest,
+    config::{AppConfig, ConfigRequest},
     state::AppState,
     tools::{Calculator, CurrentDateTime, IcMetrics, IcState},
 };
 
-/// Active AI provider client. Currently Gemini-only; new providers slot in
-/// here as additional variants.
+use rig::tool::{Tool, ToolDyn};
+
+/// Unified outcome of a single prompt run, regardless of underlying provider.
+pub struct ProviderRun {
+    /// Final assistant text returned to the caller.
+    pub output: String,
+    /// New turns produced by this request (user prompt + any tool-call
+    /// interleavings + assistant reply), in order. Append to the cached
+    /// transcript on the chat path; ignore on the single-turn run path.
+    pub new_messages: Vec<Message>,
+}
+
+/// Active AI provider client.
 #[derive(Clone)]
 pub enum AiProvider {
-    Gemini { client: GeminiClient, model: String },
+    Gemini {
+        client: GeminiClient,
+        model: String,
+    },
+    Ollama {
+        client: OllamaClient,
+        model: String,
+        /// Kept for `/v1/config` echo / diagnostics; the client already
+        /// holds the URL internally.
+        base_url: String,
+    },
 }
 
 impl AiProvider {
+    /// Build a default `Ollama` provider pointing at the local plaintext
+    /// loopback (`127.0.0.1:11435`), which is where the on-node
+    /// `ollama.service` listens. This is installed at process startup so
+    /// the agent is usable without a prior `/v1/config` call.
+    pub fn default_ollama(cfg: &AppConfig) -> anyhow::Result<Self> {
+        Self::build_ollama(
+            &cfg.default_ollama_base_url,
+            None,
+            &cfg.default_ollama_model,
+        )
+    }
+
     /// Build a provider client from a `POST /v1/config` body.
-    pub fn from_request(req: &ConfigRequest, default_model: &str) -> anyhow::Result<Self> {
+    pub fn from_request(req: &ConfigRequest, cfg: &AppConfig) -> anyhow::Result<Self> {
         match req.provider.as_str() {
             "gemini" => {
-                if req.api_key.trim().is_empty() {
-                    return Err(anyhow!("api_key must not be empty"));
-                }
-                let client = GeminiClient::new(&req.api_key)
+                let api_key = req
+                    .api_key
+                    .as_deref()
+                    .filter(|k| !k.trim().is_empty())
+                    .ok_or_else(|| anyhow!("api_key is required for the gemini provider"))?;
+                let client = GeminiClient::new(api_key)
                     .map_err(|e| anyhow!("failed to construct Gemini client: {e}"))?;
                 let model = req
                     .model
                     .clone()
-                    .unwrap_or_else(|| default_model.to_string());
+                    .unwrap_or_else(|| cfg.default_gemini_model.clone());
                 Ok(Self::Gemini { client, model })
+            }
+            "ollama" => {
+                let base_url = req
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| cfg.default_ollama_base_url.clone());
+                let model = req
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| cfg.default_ollama_model.clone());
+                Self::build_ollama(&base_url, req.api_key.as_deref(), &model)
             }
             other => Err(anyhow!("unknown provider: {other}")),
         }
     }
 
+    fn build_ollama(base_url: &str, api_key: Option<&str>, model: &str) -> anyhow::Result<Self> {
+        // The rig ollama client defaults to `http://localhost:11434`, which
+        // on a deployed AiNode is the *TLS* endpoint terminated by stunnel.
+        // We always point at the plaintext loopback explicitly to keep this
+        // working in-process without TLS.
+        let builder = OllamaClient::builder();
+        let builder = match api_key.filter(|k| !k.trim().is_empty()) {
+            Some(key) => builder.api_key::<OllamaApiKey>(key.to_string()),
+            None => builder.api_key::<OllamaApiKey>(Nothing),
+        };
+        let client = builder
+            .base_url(base_url)
+            .build()
+            .map_err(|e| anyhow!("failed to construct Ollama client: {e}"))?;
+        Ok(Self::Ollama {
+            client,
+            model: model.to_string(),
+            base_url: base_url.to_string(),
+        })
+    }
+
     pub fn name(&self) -> &'static str {
         match self {
             AiProvider::Gemini { .. } => "gemini",
+            AiProvider::Ollama { .. } => "ollama",
         }
     }
 
     pub fn model(&self) -> &str {
         match self {
             AiProvider::Gemini { model, .. } => model.as_str(),
+            AiProvider::Ollama { model, .. } => model.as_str(),
         }
     }
 
-    /// Build a configured agent. Tools and context can be filtered/added by
-    /// the caller, but in v1 we always wire all built-in tools so requests
-    /// can reference any of them by name.
-    ///
-    /// Takes `Arc<AppState>` so the IC observability tools (`ic_state`,
-    /// `ic_metrics`) can pick up the shared replica config path and
-    /// lazily-built node directory. Tools that fail to construct
-    /// (typically `ic_state` on a node where `ic.json5` is missing or
-    /// unreadable) are skipped with a warning rather than failing the
-    /// whole agent build — the other tools may still be useful and we
-    /// don't want one bad path to take the agent down.
-    ///
-    /// `ic_logs` is intentionally not wired up here — it's a TODO,
-    /// see `tools/ic_logs.rs`.
-    pub async fn build_agent(
+    /// Run a single prompt through the active provider, optionally with a
+    /// prior transcript (`history`) and a context list. Returns the
+    /// assistant text together with the new turns produced by this
+    /// request, ready to be appended to the cached transcript.
+    pub async fn prompt(
         &self,
         state: &Arc<AppState>,
         preamble: &str,
         contexts: &[String],
-    ) -> anyhow::Result<Agent<GeminiCompletion>> {
+        tools: &[String],
+        user_prompt: &str,
+        history: Vec<Message>,
+        max_turns: usize,
+    ) -> anyhow::Result<ProviderRun> {
+        // The agent type differs per provider (`Agent<M>` is concretely
+        // parametric on the completion model), so each arm builds its own
+        // agent and runs the prompt. The duplication is small and keeps
+        // the call sites free of generics.
         match self {
             AiProvider::Gemini { client, model } => {
                 let mut builder = client.agent(model).preamble(preamble);
                 for ctx in contexts {
                     builder = builder.context(ctx);
                 }
-                let mut builder = builder.tool(Calculator).tool(CurrentDateTime);
+                // Tool wiring is opt-in: only attach the tools named in
+                // `tools`. Names are validated upstream by the handler.
+                // We collect into a single `Vec<Box<dyn ToolDyn>>` and
+                // call `.tools(...)` once (or skip it altogether when
+                // empty) because `AgentBuilder` uses a typestate that
+                // makes per-tool `if` branches awkward to reassign.
+                let tool_objs = collect_tools(state, tools).await;
+                let agent = if tool_objs.is_empty() {
+                    builder.build()
+                } else {
+                    builder.tools(tool_objs).build()
+                };
 
-                match IcState::new(state.clone()).await {
-                    Ok(t) => builder = builder.tool(t),
-                    Err(e) => {
-                        warn!(
-                            state.log,
-                            "skipping ic_state tool: {}", e;
-                            "ic_config_path" => %state.config.ic_config_path.display()
-                        );
-                    }
+                let resp = agent
+                    .prompt(user_prompt)
+                    .with_history(history)
+                    .max_turns(max_turns)
+                    .extended_details()
+                    .await?;
+                Ok(ProviderRun {
+                    output: resp.output,
+                    new_messages: resp.messages.unwrap_or_default(),
+                })
+            }
+            AiProvider::Ollama { client, model, .. } => {
+                let mut builder = client.agent(model).preamble(preamble);
+                for ctx in contexts {
+                    builder = builder.context(ctx);
                 }
+                // See the gemini arm above for the rationale behind the
+                // collect-then-`.tools(...)` pattern. Tool support
+                // across ollama models is patchy (gemma3 small variants
+                // in particular reject tool-augmented prompts), which
+                // is why the default tool set is empty.
+                let tool_objs = collect_tools(state, tools).await;
+                let agent = if tool_objs.is_empty() {
+                    builder.build()
+                } else {
+                    builder.tools(tool_objs).build()
+                };
 
-                builder = builder.tool(IcMetrics::new(state.clone()));
-
-                Ok(builder.build())
+                let resp = agent
+                    .prompt(user_prompt)
+                    .with_history(history)
+                    .max_turns(max_turns)
+                    .extended_details()
+                    .await?;
+                Ok(ProviderRun {
+                    output: resp.output,
+                    new_messages: resp.messages.unwrap_or_default(),
+                })
             }
         }
     }
 }
 
-/// Shared error message helper for missing-provider conditions.
+/// Build the boxed tool list for a request, given the resolved names.
+///
+/// Names are validated upstream by the handlers; unknown entries here
+/// are silently dropped (defensive — the 400 path catches them first).
+/// `IcState` is async-constructed and can legitimately fail on a node
+/// where `ic.json5` is missing; we log and skip rather than fail the
+/// whole prompt, matching the original behavior.
+async fn collect_tools(state: &Arc<AppState>, names: &[String]) -> Vec<Box<dyn ToolDyn>> {
+    let mut out: Vec<Box<dyn ToolDyn>> = Vec::new();
+    for name in names {
+        match name.as_str() {
+            n if n == Calculator::NAME => out.push(Box::new(Calculator)),
+            n if n == CurrentDateTime::NAME => out.push(Box::new(CurrentDateTime)),
+            n if n == IcState::NAME => match IcState::new(state.clone()).await {
+                Ok(t) => out.push(Box::new(t)),
+                Err(e) => warn!(
+                    state.log,
+                    "skipping ic_state tool: {}", e;
+                    "ic_config_path" => %state.config.ic_config_path.display()
+                ),
+            },
+            n if n == IcMetrics::NAME => out.push(Box::new(IcMetrics::new(state.clone()))),
+            _ => {} // unknown name; handler-level validation already rejects these
+        }
+    }
+    out
+}
+
+/// Shared error message helper for missing-provider conditions. The default
+/// provider is installed at startup, so this should only fire if a
+/// `/v1/config` write left the slot empty (it currently never does, but
+/// keep the helper for symmetry with the lock-poisoned recovery path).
 pub fn provider_not_configured() -> anyhow::Error {
     anyhow!("provider not configured; POST /v1/config first")
 }

--- a/rs/ai_agent/src/router.rs
+++ b/rs/ai_agent/src/router.rs
@@ -15,6 +15,7 @@ use crate::{
         health::health,
         run::run,
         sessions::{delete_all as delete_all_sessions, delete_one as delete_one_session},
+        tools::{get_tools, set_tools},
     },
     state::AppState,
 };
@@ -23,6 +24,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/v1/health", get(health))
         .route("/v1/config", post(configure))
+        // Read / replace the server-wide default tool set. Tools are
+        // disabled by default; POST a JSON `{"tools": ["calculator", ...]}`
+        // to enable, or `{"tools": []}` to disable.
+        .route("/v1/tools", get(get_tools).post(set_tools))
         .route("/v1/agent/run", post(run))
         .route("/v1/agent/chat", post(chat))
         // Drop a single chat session (404 if unknown).

--- a/rs/ai_agent/src/state.rs
+++ b/rs/ai_agent/src/state.rs
@@ -26,6 +26,12 @@ pub struct AppState {
     /// one in. None of them `.await` while the guard is alive, which
     /// is the criterion for using a blocking lock under tokio.
     pub provider: RwLock<Option<AiProvider>>,
+    /// Tools wired into the agent when a request omits the `tools`
+    /// field. Starts empty — many open-weight models (including some
+    /// gemma3 variants served via ollama) reject tool-augmented prompts
+    /// outright, so tools are opt-in by default. Mutable at runtime via
+    /// `POST /v1/tools`.
+    pub default_tools: RwLock<Vec<String>>,
     /// Lazily constructed registry-backed node lookup. Built on first
     /// use because (a) it touches the filesystem and we want
     /// `AppState::new` to stay infallible, and (b) on a fresh AiNode
@@ -43,6 +49,7 @@ impl AppState {
             config,
             log,
             provider: RwLock::new(None),
+            default_tools: RwLock::new(Vec::new()),
             node_directory: OnceCell::new(),
             sessions,
         }

--- a/rs/ai_agent/src/tools/ic_logs.rs
+++ b/rs/ai_agent/src/tools/ic_logs.rs
@@ -24,7 +24,7 @@
 //!   chrony) — this is the only thing keeping the LLM from being able
 //!   to ask for arbitrary host logs.
 //! * Re-add the registration in `tools/mod.rs`, `tools/registry.rs`,
-//!   `providers/mod.rs::build_agent`, and the preamble in `config.rs`.
+//!   `providers/mod.rs::AiProvider::prompt`, and the preamble in `config.rs`.
 //!
 //! The shared `NodeDirectory` (in `tools/node_directory.rs`) is
 //! already wired up for this — `ic_logs` will resolve `node_id ->

--- a/rs/ai_agent/src/tools/mod.rs
+++ b/rs/ai_agent/src/tools/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! v1 tools are statically defined Rust types implementing `rig::tool::Tool`.
 //! New tools are added by creating a new sibling module and re-exporting it
-//! here. The agent in `providers::AiProvider::build_agent` wires every entry
+//! here. The agent in `providers::AiProvider::prompt` wires every entry
 //! returned by [`registered_tool_names`] into the agent at construction
 //! time.
 

--- a/rs/ai_agent/src/tools/registry.rs
+++ b/rs/ai_agent/src/tools/registry.rs
@@ -1,5 +1,5 @@
 //! Tool name registry. The actual tool *types* are wired into the agent
-//! via [`crate::providers::AiProvider::build_agent`]; this module just
+//! via [`crate::providers::AiProvider::prompt`]; this module just
 //! exposes their *names* so requests can be validated against the set of
 //! supported tools.
 


### PR DESCRIPTION
Adds Ollama as a second provider alongside the existing Gemini client, and makes it the startup default so the agent is usable out of the box without a prior /v1/config call. The previous build_agent + agent.prompt two-step is collapsed into a single AiProvider::prompt that matches on the variant internally and returns a unified ProviderRun (output text + new turns produced by the request).

Tool support across open-weight ollama models is patchy (some gemma3 variants reject tool-augmented prompts outright), so tools are now opt-in. Two new endpoints control the server-wide default tool set:

  GET  /v1/tools  -> { default_tools, available_tools }
  POST /v1/tools  -> { tools: [name, ...] }   # replace defaults

Per-request override:
  RunRequest.tools / ChatRequest.tools is now Option<Vec<String>>:
    - omitted      -> use server-wide default (empty by default)
    - Some([])     -> explicitly no tools for this call
    - Some([...])  -> wire only the named tools

The set of available tool *names* is the existing preset (Calculator, CurrentDateTime, IcState, IcMetrics); only which subset is wired into the agent per request is configurable.

Other changes:
* ConfigRequest.api_key is now optional (required for gemini, optional for ollama which is typically unauthenticated).
* Add --ollama-base-url / --ollama-model CLI flags (env-equivalent: IC_AI_AGENT_OLLAMA_BASE_URL / IC_AI_AGENT_OLLAMA_MODEL). Default base URL is the 127.0.0.1:11435 plaintext loopback that ollama.service binds to on a deployed AiNode.