### PR TITLE
fix: update execution error doc links to new docs URL

### DIFF
--- a/rs/nervous_system/instruction_stats/src/lib.rs
+++ b/rs/nervous_system/instruction_stats/src/lib.rs
@@ -72,7 +72,7 @@ pub fn encode_instruction_metrics<MyWrite: std::io::Write>(
             "candid_call_instructions",
             "How many instructions were directly consumed to service requests. \
              Useful numbers: \
-             https://internetcomputer.org/docs/current/developer-docs/smart-contracts/maintain/resource-limits",
+             https://docs.internetcomputer.org/references/resource-limits",
         )?;
 
         for (metric_labels, histogram) in stats.borrow().iter() {

--- a/rs/types/wasm_types/src/errors.rs
+++ b/rs/types/wasm_types/src/errors.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Create a link to this section of the Execution Errors documentation.
 pub fn doc_ref(section: &str) -> String {
-    format!("https://internetcomputer.org/docs/current/references/execution-errors#{section}")
+    format!("https://docs.internetcomputer.org/references/execution-errors#{section}")
 }
 
 pub enum ErrorHelp {


### PR DESCRIPTION
## Summary

All execution error messages printed by the ICP protocol include documentation links generated by the `doc_ref()` function in `rs/types/wasm_types/src/errors.rs`. These links were pointing to old URLs that are no longer valid.

Changes:
- `rs/types/wasm_types/src/errors.rs`: updates the base URL in `doc_ref()`, fixing all **54 documentation links** embedded in execution error messages across hypervisor/execution errors, Wasm validation errors, canister manager errors, and system API errors
- `rs/nervous_system/instruction_stats/src/lib.rs`: updates the resource-limits link in the `candid_call_instructions` metric description

**Note:** Until this change is deployed to mainnet, the old URLs should remain reachable (e.g. via redirects) so that users on older replica versions still get valid links.