### PR TITLE
refactor(nns): drop inner Options on MaturityModulation

### DIFF
--- a/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
+++ b/rs/nns/governance/proto/ic_nns_governance/pb/v1/governance.proto
@@ -2081,10 +2081,12 @@ message IcpPriceHistory {
 // This might be unpopulated, which indicates that no value is currently available.
 message MaturityModulation {
   // Current maturity modulation in permyriad (0.01% per unit).
-  optional int32 current_value_permyriad = 1;
+  int32 current_value_permyriad = 1;
 
   // Day (days_since_epoch) when current_value_permyriad was last computed.
-  optional uint64 updated_at_days_since_epoch = 2;
+  // 0 acts as a "never measured" sentinel — `current_day` is always >> 0 in practice, so a real
+  // measurement can never collide with it.
+  uint64 updated_at_days_since_epoch = 2;
 }
 
 // This represents the whole NNS governance system. It contains all

--- a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
+++ b/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs
@@ -3196,11 +3196,13 @@ pub struct IcpPriceHistory {
 )]
 pub struct MaturityModulation {
     /// Current maturity modulation in permyriad (0.01% per unit).
-    #[prost(int32, optional, tag = "1")]
-    pub current_value_permyriad: ::core::option::Option<i32>,
+    #[prost(int32, tag = "1")]
+    pub current_value_permyriad: i32,
     /// Day (days_since_epoch) when current_value_permyriad was last computed.
-    #[prost(uint64, optional, tag = "2")]
-    pub updated_at_days_since_epoch: ::core::option::Option<u64>,
+    /// 0 acts as a "never measured" sentinel — `current_day` is always >> 0 in practice, so a real
+    /// measurement can never collide with it.
+    #[prost(uint64, tag = "2")]
+    pub updated_at_days_since_epoch: u64,
 }
 /// This represents the whole NNS governance system. It contains all
 /// information about the NNS governance system that must be kept

--- a/rs/nns/governance/src/governance.rs
+++ b/rs/nns/governance/src/governance.rs
@@ -6428,7 +6428,7 @@ impl Governance {
             .heap_data
             .maturity_modulation
             .as_ref()
-            .and_then(|m| m.current_value_permyriad)
+            .map(|m| m.current_value_permyriad)
         {
             None => return,
             Some(value) => value,

--- a/rs/nns/governance/src/governance/disburse_maturity.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity.rs
@@ -564,7 +564,7 @@ async fn try_finalize_maturity_disbursement(
             .heap_data
             .maturity_modulation
             .as_ref()
-            .and_then(|m| m.current_value_permyriad);
+            .map(|m| m.current_value_permyriad);
         let maturity_disbursement_finalization = next_maturity_disbursement_to_finalize(
             &governance.neuron_store,
             &governance.heap_data.in_flight_commands,

--- a/rs/nns/governance/src/governance/disburse_maturity_tests.rs
+++ b/rs/nns/governance/src/governance/disburse_maturity_tests.rs
@@ -544,7 +544,7 @@ fn set_governance_for_test(
         Box::new(MockRandomness::new()),
     );
     governance.heap_data.maturity_modulation = Some(MaturityModulation {
-        current_value_permyriad: Some(maturity_modulation),
+        current_value_permyriad: maturity_modulation,
         ..Default::default()
     });
     for neuron in neurons {

--- a/rs/nns/governance/src/governance/tests/get_maturity_modulation.rs
+++ b/rs/nns/governance/src/governance/tests/get_maturity_modulation.rs
@@ -25,7 +25,8 @@ fn defaults_to_zero_at_init() {
     // `initialize_governance` seeds `heap_data.maturity_modulation` with a neutral 0-permyriad
     // value at init so spawning and disbursement keep working immediately rather than early-
     // returning while the XRC-fed price history task accumulates enough data to compute a real
-    // value. `updated_at` is left absent until the task produces a real measurement.
+    // value. `updated_at_days_since_epoch` is left at 0 (the "never measured" sentinel), which
+    // the API conversion surfaces as `None`.
     let governance = make_governance();
 
     let response = governance.get_maturity_modulation();
@@ -45,8 +46,8 @@ fn defaults_to_zero_at_init() {
 fn converts_days_since_epoch_to_seconds() {
     let mut governance = make_governance();
     governance.heap_data.maturity_modulation = Some(MaturityModulation {
-        current_value_permyriad: Some(123),
-        updated_at_days_since_epoch: Some(20_000),
+        current_value_permyriad: 123,
+        updated_at_days_since_epoch: 20_000,
     });
 
     let response = governance.get_maturity_modulation();
@@ -66,8 +67,8 @@ fn converts_days_since_epoch_to_seconds() {
 fn updated_at_returns_none_when_days_overflow() {
     let mut governance = make_governance();
     governance.heap_data.maturity_modulation = Some(MaturityModulation {
-        current_value_permyriad: Some(123),
-        updated_at_days_since_epoch: Some(u64::MAX),
+        current_value_permyriad: 123,
+        updated_at_days_since_epoch: u64::MAX,
     });
 
     let response = governance.get_maturity_modulation();

--- a/rs/nns/governance/src/governance/tla/mod.rs
+++ b/rs/nns/governance/src/governance/tla/mod.rs
@@ -166,7 +166,7 @@ pub fn get_tla_globals(p: &UnsafeSendPtr<Governance>) -> GlobalState {
         gov.heap_data
             .maturity_modulation
             .as_ref()
-            .and_then(|m| m.current_value_permyriad)
+            .map(|m| m.current_value_permyriad)
             .unwrap_or(0)
             .to_tla_value(),
     );

--- a/rs/nns/governance/src/heap_governance_data.rs
+++ b/rs/nns/governance/src/heap_governance_data.rs
@@ -223,12 +223,12 @@ pub fn initialize_governance(
         icp_price_history: None,
         // Default to a neutral 0 permyriad so that spawning and maturity disbursement keep
         // working immediately after init, before `update_icp_xdr_rate_related_data` accumulates
-        // enough price history to compute a real one. `updated_at_days_since_epoch` is left
-        // `None` so the task treats this as "no prior measurement" rather than "already updated
-        // today".
+        // enough price history to compute a real one. `updated_at_days_since_epoch` is left at 0
+        // (the "never measured" sentinel) so the task treats this as "no prior measurement"
+        // rather than "already updated today".
         maturity_modulation: Some(MaturityModulation {
-            current_value_permyriad: Some(0),
-            updated_at_days_since_epoch: None,
+            current_value_permyriad: 0,
+            updated_at_days_since_epoch: 0,
         }),
     };
 

--- a/rs/nns/governance/src/pb/conversions/mod.rs
+++ b/rs/nns/governance/src/pb/conversions/mod.rs
@@ -4080,11 +4080,17 @@ impl From<api::TakeCanisterSnapshot> for pb::TakeCanisterSnapshot {
 
 impl From<pb::MaturityModulation> for api::MaturityModulation {
     fn from(item: pb::MaturityModulation) -> Self {
+        // `updated_at_days_since_epoch == 0` is the "never measured" sentinel; surface it to the
+        // API as `None` so callers can distinguish "no measurement yet" from a real timestamp.
+        let updated_at_timestamp_seconds = if item.updated_at_days_since_epoch == 0 {
+            None
+        } else {
+            item.updated_at_days_since_epoch
+                .checked_mul(ONE_DAY_SECONDS)
+        };
         Self {
-            current_value_permyriad: item.current_value_permyriad,
-            updated_at_timestamp_seconds: item
-                .updated_at_days_since_epoch
-                .and_then(|days| days.checked_mul(ONE_DAY_SECONDS)),
+            current_value_permyriad: Some(item.current_value_permyriad),
+            updated_at_timestamp_seconds,
         }
     }
 }

--- a/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data.rs
+++ b/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data.rs
@@ -393,16 +393,20 @@ fn update_maturity_modulation(
     maturity_modulation: &mut MaturityModulation,
     current_day: u64,
 ) {
-    if maturity_modulation.updated_at_days_since_epoch == Some(current_day) {
+    if maturity_modulation.updated_at_days_since_epoch == current_day {
         return;
     }
 
-    let previous = match (
-        maturity_modulation.current_value_permyriad,
-        maturity_modulation.updated_at_days_since_epoch,
-    ) {
-        (Some(p), Some(d)) => Some((p as i64, d)),
-        _ => None,
+    // `updated_at_days_since_epoch == 0` is the "never measured" sentinel; in that case there is
+    // no baseline to smooth from and `compute_maturity_modulation_permyriad` should jump straight
+    // to the target.
+    let previous = if maturity_modulation.updated_at_days_since_epoch == 0 {
+        None
+    } else {
+        Some((
+            maturity_modulation.current_value_permyriad as i64,
+            maturity_modulation.updated_at_days_since_epoch,
+        ))
     };
 
     match compute_maturity_modulation_permyriad(
@@ -411,8 +415,8 @@ fn update_maturity_modulation(
         previous,
     ) {
         Ok(new_permyriad) => {
-            maturity_modulation.current_value_permyriad = Some(new_permyriad as i32);
-            maturity_modulation.updated_at_days_since_epoch = Some(current_day);
+            maturity_modulation.current_value_permyriad = new_permyriad as i32;
+            maturity_modulation.updated_at_days_since_epoch = current_day;
         }
         Err(reason) => {
             // Reaches this branch only when the buffer has no rate at or before any day in the
@@ -450,7 +454,7 @@ impl RecurringAsyncTask for UpdateIcpXdrRateRelatedData {
             gov.heap_data
                 .maturity_modulation
                 .as_ref()
-                .and_then(|mm| mm.updated_at_days_since_epoch)
+                .map(|mm| mm.updated_at_days_since_epoch)
                 == Some(current_day)
         });
         if already_updated_today {
@@ -481,7 +485,7 @@ impl RecurringAsyncTask for UpdateIcpXdrRateRelatedData {
                     "{}UpdateIcpXdrRateRelatedData: maturity modulation {} permyriad \
                      (day={}, buffer_size={})",
                     LOG_PREFIX,
-                    maturity_modulation.current_value_permyriad.unwrap_or(0),
+                    maturity_modulation.current_value_permyriad,
                     current_day,
                     icp_price_history.icp_xdr_rates.len(),
                 );

--- a/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data_tests.rs
+++ b/rs/nns/governance/src/timer_tasks/update_icp_xdr_rate_related_data_tests.rs
@@ -594,8 +594,8 @@ async fn test_execute_stores_rate_and_computes_modulation() {
         assert_eq!(
             gov.heap_data.maturity_modulation,
             Some(MaturityModulation {
-                current_value_permyriad: Some(0),
-                updated_at_days_since_epoch: None,
+                current_value_permyriad: 0,
+                updated_at_days_since_epoch: 0,
             })
         );
     });
@@ -622,8 +622,8 @@ async fn test_execute_xrc_failure_leaves_state_unchanged() {
             }],
         });
         gov.heap_data.maturity_modulation = Some(MaturityModulation {
-            current_value_permyriad: Some(42),
-            updated_at_days_since_epoch: Some(current_day - 1),
+            current_value_permyriad: 42,
+            updated_at_days_since_epoch: current_day - 1,
         });
     });
 
@@ -654,8 +654,8 @@ async fn test_execute_xrc_failure_leaves_state_unchanged() {
         assert_eq!(
             *gov.heap_data.maturity_modulation.as_ref().unwrap(),
             MaturityModulation {
-                current_value_permyriad: Some(42),
-                updated_at_days_since_epoch: Some(current_day - 1),
+                current_value_permyriad: 42,
+                updated_at_days_since_epoch: current_day - 1,
             }
         );
     });
@@ -680,8 +680,8 @@ async fn test_execute_zero_rate_is_ignored() {
             }],
         });
         gov.heap_data.maturity_modulation = Some(MaturityModulation {
-            current_value_permyriad: Some(42),
-            updated_at_days_since_epoch: Some(current_day - 1),
+            current_value_permyriad: 42,
+            updated_at_days_since_epoch: current_day - 1,
         });
     });
 
@@ -707,8 +707,8 @@ async fn test_execute_zero_rate_is_ignored() {
         assert_eq!(
             *gov.heap_data.maturity_modulation.as_ref().unwrap(),
             MaturityModulation {
-                current_value_permyriad: Some(42),
-                updated_at_days_since_epoch: Some(current_day - 1),
+                current_value_permyriad: 42,
+                updated_at_days_since_epoch: current_day - 1,
             }
         );
     });
@@ -736,8 +736,8 @@ async fn test_execute_skips_when_already_updated_today() {
             }],
         });
         gov.heap_data.maturity_modulation = Some(MaturityModulation {
-            current_value_permyriad: Some(42),
-            updated_at_days_since_epoch: Some(current_day),
+            current_value_permyriad: 42,
+            updated_at_days_since_epoch: current_day,
         });
     });
 
@@ -752,8 +752,8 @@ async fn test_execute_skips_when_already_updated_today() {
         assert_eq!(
             *gov.heap_data.maturity_modulation.as_ref().unwrap(),
             MaturityModulation {
-                current_value_permyriad: Some(42),
-                updated_at_days_since_epoch: Some(current_day),
+                current_value_permyriad: 42,
+                updated_at_days_since_epoch: current_day,
             }
         );
     });
@@ -787,8 +787,8 @@ async fn test_execute_backfill_then_daily() {
             icp_xdr_rates: rates,
         });
         gov.heap_data.maturity_modulation = Some(MaturityModulation {
-            current_value_permyriad: Some(100),
-            updated_at_days_since_epoch: Some(current_day - 2),
+            current_value_permyriad: 100,
+            updated_at_days_since_epoch: current_day - 2,
         });
     });
 
@@ -829,8 +829,10 @@ async fn test_execute_backfill_then_daily() {
 
     GOV.with_borrow(|gov| {
         let mm = gov.heap_data.maturity_modulation.as_ref().unwrap();
-        assert!(mm.current_value_permyriad.is_some());
-        assert_eq!(mm.updated_at_days_since_epoch, Some(current_day));
+        assert_eq!(mm.updated_at_days_since_epoch, current_day);
+        // The recent-window (last 7 days) prices were 55_000 vs the reference-window's 50_000
+        // long-term average, so modulation should be strictly positive.
+        assert!(mm.current_value_permyriad > 0);
     });
 }
 
@@ -860,8 +862,8 @@ async fn test_execute_advances_cursor_on_failure_and_succeeds_on_next_day() {
             icp_xdr_rates: rates,
         });
         gov.heap_data.maturity_modulation = Some(MaturityModulation {
-            current_value_permyriad: Some(0),
-            updated_at_days_since_epoch: Some(current_day - 2),
+            current_value_permyriad: 0,
+            updated_at_days_since_epoch: current_day - 2,
         });
     });
 
@@ -925,8 +927,7 @@ async fn test_execute_advances_cursor_on_failure_and_succeeds_on_next_day() {
     assert_eq!(delay_3, duration_until_next_midnight_utc(now));
     GOV.with_borrow(|gov| {
         let mm = gov.heap_data.maturity_modulation.as_ref().unwrap();
-        assert_eq!(mm.updated_at_days_since_epoch, Some(current_day));
-        assert!(mm.current_value_permyriad.is_some());
+        assert_eq!(mm.updated_at_days_since_epoch, current_day);
     });
 }
 
@@ -1024,8 +1025,8 @@ async fn test_execute_repeated_calls_accumulate_rates() {
         assert_eq!(
             gov.heap_data.maturity_modulation,
             Some(MaturityModulation {
-                current_value_permyriad: Some(0),
-                updated_at_days_since_epoch: None,
+                current_value_permyriad: 0,
+                updated_at_days_since_epoch: 0,
             })
         );
     });

--- a/rs/nns/governance/tests/governance.rs
+++ b/rs/nns/governance/tests/governance.rs
@@ -5728,8 +5728,8 @@ fn run_periodic_tasks_often_enough_to_update_maturity_modulation(gov: &mut Gover
     // in unit tests (no XRC mock). Set it directly so consumers see a value consistent with
     // the FakeDriver's 100 bp.
     gov.heap_data.maturity_modulation = Some(MaturityModulation {
-        current_value_permyriad: Some(100),
-        updated_at_days_since_epoch: Some(gov.env.now() / ONE_DAY_SECONDS),
+        current_value_permyriad: 100,
+        updated_at_days_since_epoch: gov.env.now() / ONE_DAY_SECONDS,
     });
 }
 


### PR DESCRIPTION
### Why

`MaturityModulation`'s two scalar fields were `optional`, generating
`Option<i32>` / `Option<u64>` in prost. Both inner Options were
redundant: `current_value_permyriad` had no meaningful absent state
(only ever set, never read as `None` with distinct semantics), and
`updated_at_days_since_epoch` already had `0` available as a "never
measured" sentinel — `current_day` is always >> 0 in practice, so a
real measurement can never collide.

### What

- Drop `optional` from `MaturityModulation` in `governance.proto`;
  regenerate the prost bindings so the fields are bare `i32` / `u64`.
- `initialize_governance` continues to pre-seed
  `Some(MaturityModulation { current_value_permyriad: 0, updated_at_days_since_epoch: 0 })`
  so spawning and disbursement keep their pre-PR behavior at init.
- `update_maturity_modulation` keys the "first calculation, no
  speed-limit baseline" branch on `updated_at_days_since_epoch == 0`.
- pb→api conversion maps `updated_at_days_since_epoch == 0` back to
  `None` so the public API contract is preserved.

### Testing

The wire-format safety of dropping `optional` is demonstrated by a
review-time scaffold commit on a side branch:
https://github.com/dfinity/ic/commit/7b92bdec7337dd118572eb5eadda829b0e7c01ac
— it defines parallel prost messages with/without `optional` and
round-trips encoded bytes through the other shape, asserting
`Some(v) ↔ v` and the default-elision asymmetry (`None ↔ 0`,
`Some(0) → 0`) in both directions. Not merged here because the
`OldMaturityModulation` shape no longer exists in the tree.
