### PR TITLE
fix(registry): cargo fmt fixes for registry canister

### DIFF
--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -8,8 +8,8 @@ use ic_base_types::{NodeId, PrincipalId};
 use ic_certified_map::{AsHashTree, HashTree};
 use ic_nervous_system_string::clamp_debug_len;
 use ic_nns_constants::{
-    ENGINE_CONTROLLER_CANISTER_ID, GOVERNANCE_CANISTER_ID, MIGRATION_CANISTER_ID,
-    ROOT_CANISTER_ID, SUBNET_RENTAL_CANISTER_ID,
+    ENGINE_CONTROLLER_CANISTER_ID, GOVERNANCE_CANISTER_ID, MIGRATION_CANISTER_ID, ROOT_CANISTER_ID,
+    SUBNET_RENTAL_CANISTER_ID,
 };
 use ic_protobuf::registry::{
     dc::v1::{AddOrRemoveDataCentersProposalPayload, DataCenterRecord},
@@ -159,8 +159,7 @@ fn check_caller_is_governance_or_engine_controller_and_log(method_name: &str) {
     let caller = dfn_core::api::caller();
     println!("{LOG_PREFIX}call: {method_name} from: {caller}");
     assert!(
-        caller == GOVERNANCE_CANISTER_ID.into()
-            || caller == ENGINE_CONTROLLER_CANISTER_ID.into(),
+        caller == GOVERNANCE_CANISTER_ID.into() || caller == ENGINE_CONTROLLER_CANISTER_ID.into(),
         "{LOG_PREFIX}Principal: {caller} is not authorized to call this method: {method_name}"
     );
 }


### PR DESCRIPTION
## Summary

- Re-run `cargo fmt` on `rs/registry/canister/canister/canister.rs` to fix the `cargo fmt --check` failure introduced in commit `e347e30157` (engine-controller-canister authorization).
- Two trivial reflow-only changes: import grouping in `use ic_nns_constants::{...}` and the `assert!` condition in `check_caller_is_governance_or_engine_controller_and_log`.

## Test plan

- `cargo fmt --check` passes locally on the whole tree.