### PR TITLE
chore: Remove ExecutionState::canister_root

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -41,7 +41,6 @@ use std::collections::{HashMap, VecDeque};
 #[cfg(target_os = "linux")]
 use std::convert::TryInto;
 use std::os::fd::AsRawFd;
-use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::sync::Weak;
 use std::sync::mpsc::Receiver;
@@ -1056,7 +1055,6 @@ impl WasmExecutor for SandboxedExecutionController {
     fn create_execution_state(
         &self,
         canister_module: CanisterModule,
-        canister_root: PathBuf,
         canister_id: CanisterId,
         compilation_cache: Arc<CompilationCache>,
     ) -> HypervisorResult<(ExecutionState, NumInstructions, Option<CompilationResult>)> {
@@ -1238,7 +1236,6 @@ impl WasmExecutor for SandboxedExecutionController {
 
         let initial_state_data = serialized_module.initial_state_data();
         let execution_state = ExecutionState {
-            canister_root,
             wasm_binary,
             exports: ExportedFunctions::new(initial_state_data.exported_functions),
             wasm_memory,
@@ -2226,6 +2223,7 @@ mod tests {
     use std::{
         collections::BTreeMap,
         fs::{self, File},
+        path::PathBuf,
     };
 
     use super::*;
@@ -2309,7 +2307,6 @@ mod tests {
         controller
             .create_execution_state(
                 canister_module,
-                PathBuf::new(),
                 canister_id,
                 Arc::new(CompilationCacheBuilder::new().build()),
             )

--- a/rs/canonical_state/src/traversal.rs
+++ b/rs/canonical_state/src/traversal.rs
@@ -345,7 +345,6 @@ mod tests {
         };
 
         let execution_state = ExecutionState::new(
-            "NOT_USED".into(),
             wasm_binary,
             ExportedFunctions::new(BTreeSet::new()),
             wasm_memory,

--- a/rs/embedders/fuzz/src/wasm_executor.rs
+++ b/rs/embedders/fuzz/src/wasm_executor.rs
@@ -37,7 +37,7 @@ use ic_types::{
 use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use ic_wasm_types::CanisterModule;
 use lazy_static::lazy_static;
-use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
+use std::{collections::BTreeSet, sync::Arc};
 
 const SUBNET_MEMORY_CAPACITY: i64 = i64::MAX / 2;
 
@@ -76,7 +76,6 @@ pub fn run_fuzzer(module: ICWasmModule) {
 
     let result = wasm_executor.create_execution_state(
         canister_module,
-        PathBuf::new(),
         CanisterId::from_u64(1),
         compilation_cache.clone(),
     );

--- a/rs/embedders/src/wasm_executor.rs
+++ b/rs/embedders/src/wasm_executor.rs
@@ -1,6 +1,5 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -61,7 +60,6 @@ pub trait WasmExecutor: Send + Sync {
     fn create_execution_state(
         &self,
         canister_module: CanisterModule,
-        canister_root: PathBuf,
         canister_id: CanisterId,
         compilation_cache: Arc<CompilationCache>,
     ) -> HypervisorResult<(ExecutionState, NumInstructions, Option<CompilationResult>)>;
@@ -281,7 +279,6 @@ impl WasmExecutor for WasmExecutorImpl {
     fn create_execution_state(
         &self,
         canister_module: CanisterModule,
-        canister_root: PathBuf,
         canister_id: CanisterId,
         compilation_cache: Arc<CompilationCache>,
     ) -> HypervisorResult<(ExecutionState, NumInstructions, Option<CompilationResult>)> {
@@ -312,7 +309,6 @@ impl WasmExecutor for WasmExecutorImpl {
 
         // Create the execution state.
         let execution_state = ExecutionState {
-            canister_root,
             wasm_binary,
             exports: ExportedFunctions::new(initial_state_data.exported_functions),
             wasm_memory: Memory::new(wasm_page_map, wasm_memory_size),

--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -124,8 +124,6 @@ where
     let subnet_type = exec_env.own_subnet_type();
     let hypervisor = exec_env.hypervisor_for_testing();
 
-    let tmpdir = tempfile::Builder::new().prefix("test").tempdir().unwrap();
-    let canister_root = tmpdir.path().to_path_buf();
     // Create Canister state
     let canister_id = canister_test_id(LOCAL_CANISTER_ID);
     let mut round_limits = RoundLimits {
@@ -138,7 +136,6 @@ where
     let execution_state = hypervisor
         .create_execution_state(
             CanisterModule::new(wat::parse_str(wat.as_ref()).unwrap()),
-            canister_root,
             canister_id,
             &mut round_limits,
             CompilationCostHandling::CountFullAmount,

--- a/rs/execution_environment/benches/management_canister/create_execution_state.rs
+++ b/rs/execution_environment/benches/management_canister/create_execution_state.rs
@@ -18,12 +18,8 @@ fn run_benchmark(
     let canister_id = canister_test_id(1);
     c.bench_function(name, |b| {
         b.iter_batched(
-            || {
-                let exec_test = ExecutionTestBuilder::new().build();
-                let tmpdir = tempfile::TempDir::new().unwrap();
-                (exec_test, tmpdir)
-            },
-            |(exec_test, tmpdir)| {
+            || ExecutionTestBuilder::new().build(),
+            |exec_test| {
                 let exec_env = exec_test.execution_environment();
                 let hypervisor = exec_env.hypervisor_for_testing();
                 let mut round_limits = RoundLimits {
@@ -39,7 +35,6 @@ fn run_benchmark(
                 };
                 let _ = hypervisor.create_execution_state(
                     CanisterModule::new(wasm.clone()),
-                    tmpdir.path().to_path_buf(),
                     canister_id,
                     &mut round_limits,
                     compilation_cost_handling,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -71,7 +71,6 @@ use num_traits::{SaturatingAdd, SaturatingSub};
 use prometheus::IntCounter;
 use std::collections::BTreeSet;
 use std::iter::zip;
-use std::path::PathBuf;
 use std::{convert::TryFrom, str::FromStr, sync::Arc};
 
 use types::*;
@@ -826,7 +825,6 @@ impl CanisterManager {
         prepaid_execution_cycles: Option<CompoundCycles<Instructions>>,
         mut canister: CanisterState,
         time: Time,
-        canister_layout_path: PathBuf,
         network_topology: &NetworkTopology,
         execution_parameters: ExecutionParameters,
         round_limits: &mut RoundLimits,
@@ -883,7 +881,6 @@ impl CanisterManager {
         let original: OriginalContext = OriginalContext {
             execution_parameters,
             mode: context.mode,
-            canister_layout_path,
             config: self.config.clone(),
             message,
             call_id,
@@ -2243,7 +2240,6 @@ impl CanisterManager {
             let (instructions_for_execution, new_execution_state) =
                 self.hypervisor.create_execution_state(
                     execution_snapshot.wasm_binary.clone(),
-                    "NOT_USED".into(),
                     canister_id,
                     round_limits,
                     compilation_cost_handling,

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -406,7 +406,6 @@ fn install_code(
         None,
         old_canister,
         time,
-        "NOT_USED".into(),
         &network_topology,
         execution_parameters,
         round_limits,

--- a/rs/execution_environment/src/execution/install.rs
+++ b/rs/execution_environment/src/execution/install.rs
@@ -9,7 +9,7 @@ use crate::canister_manager::types::{
 use crate::execution::common::{ingress_status_with_processing_state, update_round_limits};
 use crate::execution::install_code::{
     CanisterMemoryHandling, InstallCodeHelper, MemoryHandling, OriginalContext,
-    PausedInstallCodeHelper, canister_layout, finish_err,
+    PausedInstallCodeHelper, finish_err,
 };
 use crate::execution_environment::{RoundContext, RoundLimits};
 use ic_base_types::PrincipalId;
@@ -96,7 +96,6 @@ pub(crate) fn execute_install(
 
     // Stage 1: create a new execution state based on the new Wasm binary, clear certified data and canister logs, deactivate global timer, and bump canister version.
     let canister_id = helper.canister().canister_id();
-    let layout = canister_layout(&original.canister_layout_path, &canister_id);
     let context_sender = context.sender();
     let instructions_to_assemble = context.wasm_source.instructions_to_assemble();
     helper.charge_for_large_wasm_assembly(instructions_to_assemble);
@@ -117,7 +116,6 @@ pub(crate) fn execute_install(
     let module_hash = wasm_module.module_hash();
     let (instructions_from_compilation, result) = round.hypervisor.create_execution_state(
         wasm_module,
-        layout.raw_path(),
         canister_id,
         round_limits,
         original.compilation_cost_handling,

--- a/rs/execution_environment/src/execution/install_code.rs
+++ b/rs/execution_environment/src/execution/install_code.rs
@@ -1,8 +1,6 @@
 // This module defines types and functions common between canister installation
 // and upgrades.
 
-use std::path::{Path, PathBuf};
-
 use crate::execution::common::{log_dirty_pages, validate_controller};
 use ic_base_types::{CanisterId, NumBytes, PrincipalId};
 use ic_config::flag_status::FlagStatus;
@@ -23,11 +21,9 @@ use ic_replicated_state::canister_state::system_state::{
 };
 use ic_replicated_state::metadata_state::subnet_call_context_manager::InstallCodeCallId;
 use ic_replicated_state::{CanisterState, ExecutionState, num_bytes_try_from};
-use ic_state_layout::{CanisterLayout, CheckpointLayout, ReadOnly};
 use ic_sys::PAGE_SIZE;
 use ic_types::{
-    CanisterLog, CanisterTimer, Height, MemoryAllocation, NumInstructions, Time,
-    messages::CanisterCall,
+    CanisterLog, CanisterTimer, MemoryAllocation, NumInstructions, Time, messages::CanisterCall,
 };
 use ic_types_cycles::{CompoundCycles, Cycles, CyclesUseCase, Instructions};
 use ic_wasm_types::WasmHash;
@@ -834,7 +830,6 @@ impl InstallCodeHelper {
 pub(crate) struct OriginalContext {
     pub execution_parameters: ExecutionParameters,
     pub mode: CanisterInstallModeV2,
-    pub canister_layout_path: PathBuf,
     pub config: CanisterMgrConfig,
     pub message: CanisterCall,
     pub call_id: InstallCodeCallId,
@@ -853,18 +848,6 @@ pub(crate) fn get_wasm_hash(canister: &CanisterState) -> Option<[u8; 32]> {
         .execution_state
         .as_ref()
         .map(|execution_state| execution_state.wasm_binary.binary.module_hash())
-}
-
-#[doc(hidden)] // pub for usage in tests
-pub(crate) fn canister_layout(
-    state_path: &Path,
-    canister_id: &CanisterId,
-) -> CanisterLayout<ReadOnly> {
-    // We use ReadOnly, as CheckpointLayouts with write permissions have side effects
-    // of creating directories
-    CheckpointLayout::<ReadOnly>::new_untracked(state_path.into(), Height::from(0))
-        .and_then(|layout| layout.canister(canister_id))
-        .expect("failed to obtain canister layout")
 }
 
 /// Finishes an `install_code` execution early due to an error.

--- a/rs/execution_environment/src/execution/upgrade.rs
+++ b/rs/execution_environment/src/execution/upgrade.rs
@@ -9,8 +9,7 @@ use crate::canister_manager::types::{
 };
 use crate::execution::common::{ingress_status_with_processing_state, update_round_limits};
 use crate::execution::install_code::{
-    CanisterMemoryHandling, InstallCodeHelper, OriginalContext, PausedInstallCodeHelper,
-    canister_layout, finish_err,
+    CanisterMemoryHandling, InstallCodeHelper, OriginalContext, PausedInstallCodeHelper, finish_err,
 };
 use crate::execution_environment::{RoundContext, RoundLimits};
 use ic_base_types::PrincipalId;
@@ -285,10 +284,8 @@ fn upgrade_stage_2_and_3a_create_execution_state_and_call_start(
     // Stage 2: create a new execution state based on the new Wasm code, deactivate global timer, and bump canister version.
     // Replace the execution state of the canister with a new execution state, but
     // persist the stable memory (if it exists).
-    let layout = canister_layout(&original.canister_layout_path, &canister_id);
     let (instructions_from_compilation, result) = round.hypervisor.create_execution_state(
         wasm_module,
-        layout.raw_path(),
         canister_id,
         round_limits,
         original.compilation_cost_handling,

--- a/rs/execution_environment/src/execution_environment.rs
+++ b/rs/execution_environment/src/execution_environment.rs
@@ -4103,7 +4103,6 @@ impl ExecutionEnvironment {
             prepaid_execution_cycles,
             old_canister,
             state.time(),
-            "NOT_USED".into(),
             &state.metadata.network_topology,
             execution_parameters,
             round_limits,

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -3046,7 +3046,6 @@ fn canister_snapshot_change_guard_do_not_modify_without_reading_doc_comment() {
     // DO NOT MODIFY WITHOUT READING DOC COMMENT!
     //
     let ExecutionState {
-        canister_root: _,
         wasm_binary,
         wasm_memory: _,
         stable_memory: _,

--- a/rs/execution_environment/src/execution_environment/tests/compilation.rs
+++ b/rs/execution_environment/src/execution_environment/tests/compilation.rs
@@ -13,7 +13,6 @@ mod execution_tests {
     use ic_wasm_types::CanisterModule;
     use maplit::btreemap;
     use std::collections::BTreeSet;
-    use std::path::PathBuf;
     use std::sync::Arc;
 
     const WAT_EMPTY: &str = "(module)";
@@ -330,7 +329,6 @@ mod execution_tests {
         let canister_state = test.canister_state_mut(canister_id);
         assert!(canister_state.execution_state.is_none());
         canister_state.execution_state = Some(ExecutionState::new(
-            PathBuf::new(),
             WasmBinary::new(CanisterModule::new(b"invalid wasm".to_vec())),
             ExportedFunctions::new(
                 vec![WasmMethod::Update("go".to_string())]
@@ -384,7 +382,6 @@ mod execution_tests {
         let canister_state = test.canister_state_mut(canister_id1);
         assert!(canister_state.execution_state.is_none());
         canister_state.execution_state = Some(ExecutionState::new(
-            PathBuf::new(),
             WasmBinary::new(CanisterModule::new(b"invalid wasm".to_vec())),
             ExportedFunctions::new(
                 vec![WasmMethod::Update("go".to_string())]
@@ -400,7 +397,6 @@ mod execution_tests {
         let canister_state = test.canister_state_mut(canister_id2);
         assert!(canister_state.execution_state.is_none());
         canister_state.execution_state = Some(ExecutionState::new(
-            PathBuf::new(),
             WasmBinary::new(CanisterModule::new(b"invalid wasm".to_vec())),
             ExportedFunctions::new(
                 vec![WasmMethod::Update("go".to_string())]
@@ -451,7 +447,6 @@ mod execution_tests {
         let canister_state = test.canister_state_mut(canister_id1);
         assert!(canister_state.execution_state.is_none());
         canister_state.execution_state = Some(ExecutionState::new(
-            PathBuf::new(),
             WasmBinary::new(CanisterModule::new(b"\x00asm invalid wasm".to_vec())),
             ExportedFunctions::new(
                 vec![WasmMethod::Update("go".to_string())]
@@ -508,7 +503,6 @@ mod execution_tests {
         let canister_state = test.canister_state_mut(canister_id1);
         assert!(canister_state.execution_state.is_none());
         canister_state.execution_state = Some(ExecutionState::new(
-            PathBuf::new(),
             // Without the '\x00asm' prefix, the check for wasm code length will fail.
             WasmBinary::new(CanisterModule::new(b"invalid wasm".to_vec())),
             ExportedFunctions::new(

--- a/rs/execution_environment/src/hypervisor.rs
+++ b/rs/execution_environment/src/hypervisor.rs
@@ -28,10 +28,7 @@ use ic_types::{
 use ic_types_cycles::CanisterCyclesCostSchedule;
 use ic_wasm_types::CanisterModule;
 use prometheus::{Histogram, IntCounter, IntGaugeVec};
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::Path, sync::Arc};
 
 use crate::canister_logs::check_log_visibility_permission;
 use crate::execution::common::{apply_canister_state_changes, update_round_limits};
@@ -148,7 +145,6 @@ impl Hypervisor {
     pub fn create_execution_state(
         &self,
         canister_module: CanisterModule,
-        canister_root: PathBuf,
         canister_id: CanisterId,
         round_limits: &mut RoundLimits,
         compilation_cost_handling: CompilationCostHandling,
@@ -173,7 +169,6 @@ impl Hypervisor {
 
         let creation_result = self.wasm_executor.create_execution_state(
             canister_module,
-            canister_root,
             canister_id,
             Arc::clone(&self.compilation_cache),
         );

--- a/rs/execution_environment/src/scheduler/round_schedule/tests.rs
+++ b/rs/execution_environment/src/scheduler/round_schedule/tests.rs
@@ -298,7 +298,6 @@ impl RoundScheduleFixture {
             SystemMethod::CanisterHeartbeat,
         )]));
         self.canister_state(&canister_id).execution_state = Some(ExecutionState::new(
-            "NOT_USED".into(),
             WasmBinary::new(CanisterModule::new(vec![])),
             exports,
             Memory::new_for_testing(),

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     convert::{TryFrom, TryInto},
-    path::PathBuf,
     sync::{Arc, Mutex},
 };
 
@@ -1289,7 +1288,6 @@ impl WasmExecutor for TestWasmExecutor {
     fn create_execution_state(
         &self,
         canister_module: CanisterModule,
-        _canister_root: PathBuf,
         canister_id: CanisterId,
         _compilation_cache: Arc<CompilationCache>,
     ) -> HypervisorResult<(ExecutionState, NumInstructions, Option<CompilationResult>)> {
@@ -1449,7 +1447,6 @@ impl TestWasmExecutorCore {
             exported_functions.push(WasmMethod::System(system_task));
         }
         let execution_state = ExecutionState::new(
-            Default::default(),
             execution_state::WasmBinary::new(canister_module),
             ExportedFunctions::new(exported_functions.into_iter().collect()),
             Memory::new_for_testing(),

--- a/rs/http_endpoints/public/templates/dashboard.html
+++ b/rs/http_endpoints/public/templates/dashboard.html
@@ -106,7 +106,6 @@
                     {% match c.execution_state.as_ref() %}
                     {% when Some with (exec_state) %}
                     <table>
-                        <tr><td>canister_root</td><td>{{ exec_state.canister_root.to_string_lossy() }}</td></tr>
                         <tr><td>wasm_binary size</td><td>{{ exec_state.wasm_binary.binary.len() }} bytes</td></tr>
                         <tr><td>wasm_binary sha256</td><td>{{ hex::encode(exec_state.wasm_binary.binary.module_hash()) }}</td></tr>
                         <tr><td>heap_size</td><td>{{ exec_state.wasm_memory.size }} pages</td></tr>

--- a/rs/pocket_ic_server/templates/dashboard.html
+++ b/rs/pocket_ic_server/templates/dashboard.html
@@ -88,7 +88,6 @@
                     {% match c.execution_state.as_ref() %}
                     {% when Some with (exec_state) %}
                     <table>
-                        <tr><td>canister_root</td><td>{{ exec_state.canister_root.to_string_lossy() }}</td></tr>
                         <tr><td>wasm_binary size</td><td>{{ exec_state.wasm_binary.binary.len() }} bytes</td></tr>
                         <tr><td>wasm_binary sha256</td><td>{{ hex::encode(exec_state.wasm_binary.binary.module_hash()) }}</td></tr>
                         <tr><td>heap_size</td><td>{{ exec_state.wasm_memory.size }} pages</td></tr>

--- a/rs/replicated_state/src/canister_state/execution_state.rs
+++ b/rs/replicated_state/src/canister_state/execution_state.rs
@@ -19,7 +19,6 @@ use std::{
     collections::BTreeSet,
     convert::{From, TryFrom},
     iter::FromIterator,
-    path::PathBuf,
     sync::{Arc, Mutex},
 };
 use strum_macros::EnumIter;
@@ -304,11 +303,6 @@ impl NextScheduledMethod {
 // Deserialization for `ExecutionState`.
 #[derive(Clone, Debug, ValidateEq)]
 pub struct ExecutionState {
-    /// The path where Canister memory is located. Needs to be stored in
-    /// ExecutionState in order to perform the exec system call.
-    #[validate_eq(Ignore)]
-    pub canister_root: std::path::PathBuf,
-
     /// The wasm executable associated with this state. It represented here as
     /// a reference-counted object such that:
     /// - it is "shallow-copied" when cloning the execution state
@@ -360,7 +354,6 @@ impl PartialEq for ExecutionState {
         // field is added to 'ExecutionState' compiler will throw
         // an error. Hence pointing to appropriate change here.
         let ExecutionState {
-            canister_root: _,
             wasm_binary,
             wasm_memory,
             stable_memory,
@@ -404,7 +397,6 @@ impl ExecutionState {
     /// default next_scheduled_method, and wasm_execution_mode = WasmExecutionMode::Wasm32.
     /// Be sure to change these if needed.
     pub fn new(
-        canister_root: PathBuf,
         wasm_binary: Arc<WasmBinary>,
         exports: ExportedFunctions,
         wasm_memory: Memory,
@@ -413,7 +405,6 @@ impl ExecutionState {
         wasm_metadata: WasmMetadata,
     ) -> Self {
         Self {
-            canister_root,
             wasm_binary,
             exports,
             wasm_memory,

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 
 use super::*;
 use crate::CallContext;
@@ -696,7 +695,6 @@ fn system_subnet_remote_push_input_request_ignores_memory_reservation_and_execut
     canister_state.system_state.memory_allocation = MemoryAllocation::from(NumBytes::new(13));
     // And an execution state with non-zero size.
     canister_state.execution_state = Some(ExecutionState::new(
-        Default::default(),
         execution_state::WasmBinary::new(CanisterModule::new(vec![1, 2, 3])),
         ExportedFunctions::new(Default::default()),
         Memory::new_for_testing(),
@@ -1049,7 +1047,6 @@ fn canister_state_canister_log_record_round_trip() {
 #[test]
 fn execution_state_test_partial_eq() {
     let state_1 = ExecutionState::new(
-        Default::default(),
         execution_state::WasmBinary::new(CanisterModule::new(vec![1, 2, 3])),
         ExportedFunctions::new(Default::default()),
         Memory::new_for_testing(),
@@ -1059,14 +1056,6 @@ fn execution_state_test_partial_eq() {
     );
 
     assert_eq!(state_1, state_1.clone());
-
-    assert_eq!(
-        ExecutionState {
-            canister_root: PathBuf::new(),
-            ..state_1.clone()
-        },
-        state_1
-    );
 
     assert_eq!(ExecutionState { ..state_1.clone() }, state_1);
 

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -3369,7 +3369,6 @@ impl StateMachine {
             &tip_canister_layout,
             &canister_id,
             CanisterSnapshots::default(),
-            ic_types::Height::new(0),
             self.state_manager.get_fd_factory(),
             &StrictCheckpointLoadingMetrics,
         )

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -711,7 +711,6 @@ pub fn load_canister_state(
     canister_layout: &CanisterLayout<ReadOnly>,
     canister_id: &CanisterId,
     canister_snapshots: CanisterSnapshots,
-    height: Height,
     fd_factory: Arc<dyn PageAllocatorFileDescriptor>,
     metrics: &dyn CheckpointLoadingMetrics,
 ) -> Result<(CanisterState, LoadCanisterMetrics), CheckpointError> {
@@ -761,12 +760,7 @@ pub fn load_canister_state(
             );
             durations.insert("wasm_binary", starting_time.elapsed());
 
-            let canister_root =
-                CheckpointLayout::<ReadOnly>::new_untracked("NOT_USED".into(), height)?
-                    .canister(canister_id)?
-                    .raw_path();
             Some(ExecutionState {
-                canister_root,
                 wasm_binary,
                 exports: execution_state_bits.exports,
                 wasm_memory,
@@ -907,7 +901,6 @@ fn load_canister_state_from_checkpoint(
         &canister_layout,
         canister_id,
         canister_snapshots,
-        checkpoint_layout.height(),
         Arc::clone(&fd_factory),
         metrics,
     )

--- a/rs/state_manager/src/checkpoint/tests.rs
+++ b/rs/state_manager/src/checkpoint/tests.rs
@@ -243,7 +243,6 @@ fn can_recover_from_a_checkpoint() {
         let page_map = PageMap::from(&[1, 2, 3, 4][..]);
         let stable_memory = Memory::new(page_map, NumWasmPages::new(1));
         let execution_state = ExecutionState::new(
-            "NOT_USED".into(),
             WasmBinary::new(wasm.clone()),
             ExportedFunctions::new(BTreeSet::new()),
             wasm_memory.clone(),
@@ -821,7 +820,6 @@ fn flush_checkpoint_ops_and_page_maps_strips_execution_state_memories() {
     let wasm_memory = one_page_of(1);
     let stable_memory = one_page_of(2);
     let execution_state = ExecutionState::new(
-        "NOT_USED".into(),
         WasmBinary::new(empty_wasm()),
         ExportedFunctions::new(BTreeSet::new()),
         wasm_memory,

--- a/rs/state_manager/src/tree_hash.rs
+++ b/rs/state_manager/src/tree_hash.rs
@@ -187,7 +187,6 @@ mod tests {
                 String::from("dummy1") => CustomSection::new(CustomSectionType::Private, vec![0, 2]),
             });
             let execution_state = ExecutionState::new(
-                "NOT_USED".into(),
                 wasm_binary,
                 ExportedFunctions::new(BTreeSet::new()),
                 wasm_memory,

--- a/rs/state_manager/tests/state_manager.rs
+++ b/rs/state_manager/tests/state_manager.rs
@@ -7371,7 +7371,6 @@ fn restore_snapshot(snapshot_id: SnapshotId, canister_id: CanisterId, state: &mu
 
     canister.system_state.wasm_chunk_store = snapshot.chunk_store().clone();
     canister.execution_state = Some(ExecutionState::new(
-        Default::default(),
         WasmBinary::new(snapshot.execution_snapshot().wasm_binary.clone()),
         ExportedFunctions::new(Default::default()),
         Memory::from(&snapshot.execution_snapshot().wasm_memory),

--- a/rs/test_utilities/state/src/lib.rs
+++ b/rs/test_utilities/state/src/lib.rs
@@ -608,7 +608,6 @@ impl Default for ExecutionStateBuilder {
 
         ExecutionStateBuilder {
             execution_state: ExecutionState::new(
-                "NOT_USED".into(),
                 WasmBinary::new(CanisterModule::new(vec![])),
                 ExportedFunctions::new(BTreeSet::new()),
                 Memory::new_for_testing(),


### PR DESCRIPTION
The canister_root field used to point to the files backing the canister states on disk. It has not been used or populated in a while, with successive state manager improvements (tip thread, LSMT, asynchronous checkpointing) decoupling the replicated state and the execution environment from the file system. The field was also set to "NOT_USED" to prevent any accidental misuse of the field by the execution layer.

This PR removes the field and simplifies the code where possible.