### PR TITLE
chore: drop unused deps in nervous system

### DIFF
--- a/rs/nervous_system/governance/BUILD.bazel
+++ b/rs/nervous_system/governance/BUILD.bazel
@@ -12,7 +12,6 @@ rust_library(
         "//rs/types/base_types",
         "@crate_index//:ic-stable-structures",
         "@crate_index//:ic_principal",
-        "@crate_index//:maplit",
         "@crate_index//:num-traits",
     ],
 )

--- a/rs/nervous_system/instruction_stats/BUILD.bazel
+++ b/rs/nervous_system/instruction_stats/BUILD.bazel
@@ -26,7 +26,6 @@ rust_test(
     srcs = glob(["src/**/*.rs"]),
     deps = [
         "//rs/nervous_system/histogram",
-        "@crate_index//:ic-cdk",
         "@crate_index//:ic-metrics-encoder",
         "@crate_index//:itertools",
         "@crate_index//:lazy_static",

--- a/rs/nervous_system/instruction_stats_update_attribute/BUILD.bazel
+++ b/rs/nervous_system/instruction_stats_update_attribute/BUILD.bazel
@@ -27,7 +27,5 @@ rust_test(
     deps = [
         "@crate_index//:candid",
         "@crate_index//:ic-cdk",
-        "@crate_index//:quote",
-        "@crate_index//:syn",
     ],
 )

--- a/rs/nervous_system/query_instruction_logger/BUILD.bazel
+++ b/rs/nervous_system/query_instruction_logger/BUILD.bazel
@@ -25,7 +25,5 @@ rust_test(
     deps = [
         "@crate_index//:candid",
         "@crate_index//:ic-cdk",
-        "@crate_index//:quote",
-        "@crate_index//:syn",
     ],
 )

--- a/rs/nervous_system/temporary/BUILD.bazel
+++ b/rs/nervous_system/temporary/BUILD.bazel
@@ -17,7 +17,6 @@ rust_test_suite(
     srcs = glob(["tests/**/*.rs"]),
     deps = [
         ":temporary",
-        "@crate_index//:rand",  # Used by doc test.
     ],
 )
 


### PR DESCRIPTION
These dependencies are not used in the build.