### PR TITLE
chore: re-enable disabled rust_doc_tests

### DIFF
--- a/rs/prep/BUILD.bazel
+++ b/rs/prep/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_doc_test", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -256,8 +256,7 @@ rust_test(
     ],
 )
 
-# Disabled due to https://github.com/bazelbuild/rules_rust/issues/1233
-# rust_doc_test(
-#   name = "prep_doc_test",
-#   crate = ":prep",
-# )
+rust_doc_test(
+    name = "prep_doc_test",
+    crate = ":prep",
+)

--- a/rs/state_layout/BUILD.bazel
+++ b/rs/state_layout/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_doc_test", "rust_library")
 load("//bazel:defs.bzl", "rust_test_with_binary")
 
 package(default_visibility = ["//visibility:public"])
@@ -32,11 +32,10 @@ rust_library(
     ],
 )
 
-# Disabled due to https://github.com/bazelbuild/rules_rust/issues/1233
-# rust_doc_test(
-#     name = "state_layout_doc_test",
-#     crate = ":state_layout",
-# )
+rust_doc_test(
+    name = "state_layout_doc_test",
+    crate = ":state_layout",
+)
 
 rust_test_with_binary(
     name = "state_layout_test",


### PR DESCRIPTION
Some rust doc tests were disabled due to an upstream issue that's now fixed.