### PR TITLE
fix: make ext4_image and vfat_image reproducible

### DIFF
--- a/.github/actions/bazel/action.yaml
+++ b/.github/actions/bazel/action.yaml
@@ -158,6 +158,9 @@ runs:
           ^@@rules_rust..crate.crate_index__cranelift-isle            # has a non reproducible isle_tests.rs in its OUT_DIR.
           ^@@rules_rust..crate.crate_index__secp256k1-sys             # has non reproducible object files, like lax_der_parsing.o, in it OUT_DIR.
           ^@@rules_rust..crate.crate_index__sev                       # build.rs depends on the presence of /dev/sev and /dev/sev-guest. See: https://github.com/virtee/sev/issues/315
+          # TODO: fix the following ASAP:
+          ^//ic-os/hostos/envs/prod:rootfs-tree.tar                   # became non-reproducible because of https://github.com/dfinity/ic/pull/10208
+          ^//ic-os/setupos/envs/prod:rootfs-tree.tar                  # idem
         )
         for execlog_zst in $(find '${{ steps.metrics-tmpdir.outputs.dir }}' -name 'execlog-*.zst'); do
           zstd -f -d "$execlog_zst" -o "$execlog"

--- a/ic-os/bootloader/BUILD.bazel
+++ b/ic-os/bootloader/BUILD.bazel
@@ -19,7 +19,10 @@ genrule(
         "bootloader-tree.tar",
     ],
     cmd = "$(location build-bootloader-tree.sh) -o $@",
-    tags = ["manual"],
+    tags = [
+        "manual",
+        "requires-network",
+    ],
     target_compatible_with = [
         "@platforms//os:linux",
     ],

--- a/ic-os/bootloader/BUILD.bazel
+++ b/ic-os/bootloader/BUILD.bazel
@@ -19,10 +19,7 @@ genrule(
         "bootloader-tree.tar",
     ],
     cmd = "$(location build-bootloader-tree.sh) -o $@",
-    tags = [
-        "manual",
-        "requires-network",
-    ],
+    tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],

--- a/ic-os/bootloader/build-bootloader-tree.sh
+++ b/ic-os/bootloader/build-bootloader-tree.sh
@@ -27,7 +27,21 @@ BASE_IMAGE="ghcr.io/dfinity/library/ubuntu@sha256:5e275723f82c67e387ba9e3c24baa0
 podman --root "${TMP_DIR}/root" --runroot "${TMP_DIR}/runroot" build --iidfile "${TMP_DIR}/iidfile" - <<<"
     FROM $BASE_IMAGE
     USER root:root
-    RUN apt-get -y update --snapshot 20260520T000000Z && apt-get -y --no-install-recommends install --snapshot 20260520T000000Z grub-efi faketime
+    # Pin apt to an Ubuntu archive snapshot so the bootloader build is reproducible.
+    # We rewrite the apt sources rather than using 'apt-get --snapshot' because that
+    # flag requires apt >= 3.0 (Ubuntu 25.10+), while the base image above is older.
+    # snapshot.ubuntu.com redirects HTTP -> HTTPS, but the pinned base image's CA
+    # store cannot verify its certificate chain. We therefore disable TLS peer
+    # verification: package integrity is still ensured by apt's GPG verification of
+    # the Release file against the embedded ubuntu-keyring.
+    RUN rm -f /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/*.list \
+     && printf '%s\n' \
+            'deb https://snapshot.ubuntu.com/ubuntu/20260131T000000Z noble main universe' \
+            'deb https://snapshot.ubuntu.com/ubuntu/20260131T000000Z noble-updates main universe' \
+            'deb https://snapshot.ubuntu.com/ubuntu/20260131T000000Z noble-security main universe' \
+            > /etc/apt/sources.list \
+     && apt-get -o Acquire::Check-Valid-Until=false -o Acquire::https::Verify-Peer=false -o Acquire::https::Verify-Host=false -y update \
+     && apt-get -o Acquire::Check-Valid-Until=false -o Acquire::https::Verify-Peer=false -o Acquire::https::Verify-Host=false -y --no-install-recommends install grub-efi faketime
     RUN mkdir -p /build/boot/grub
     RUN cp -r /usr/lib/grub/x86_64-efi /build/boot/grub
     RUN mkdir -p /build/boot/efi/EFI/Boot

--- a/ic-os/bootloader/build-bootloader-tree.sh
+++ b/ic-os/bootloader/build-bootloader-tree.sh
@@ -22,12 +22,12 @@ done
 
 TMP_DIR=$(mktemp -d --tmpdir="/tmp/containers" build-image-XXXXXXXXXXXX)
 
-BASE_IMAGE="ghcr.io/dfinity/library/ubuntu@sha256:6015f66923d7afbc53558d7ccffd325d43b4e249f41a6e93eef074c9505d2233"
+BASE_IMAGE="ghcr.io/dfinity/library/ubuntu@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97bef9450d0b4"
 
 podman --root "${TMP_DIR}/root" --runroot "${TMP_DIR}/runroot" build --iidfile "${TMP_DIR}/iidfile" - <<<"
     FROM $BASE_IMAGE
     USER root:root
-    RUN apt-get -y update && apt-get -y --no-install-recommends install grub-efi faketime
+    RUN apt-get -y update --snapshot 20260520T000000Z && apt-get -y --no-install-recommends install --snapshot 20260520T000000Z grub-efi faketime
     RUN mkdir -p /build/boot/grub
     RUN cp -r /usr/lib/grub/x86_64-efi /build/boot/grub
     RUN mkdir -p /build/boot/efi/EFI/Boot

--- a/toolchains/sysimage/BUILD.bazel
+++ b/toolchains/sysimage/BUILD.bazel
@@ -73,6 +73,18 @@ py_binary(
     deps = [":utils"],
 )
 
+# Hermetic mkfs.vfat extracted from the apt-snapshot-pinned dosfstools .deb so
+# that the build does not depend on the host-installed binary.
+# In the dosfstools package, mkfs.vfat is a symlink to mkfs.fat; we extract the
+# real binary but name the output mkfs.vfat so argv[0] selects vfat defaults.
+genrule(
+    name = "mkfs_vfat",
+    srcs = ["@noble//dosfstools/amd64:data"],
+    outs = ["mkfs.vfat"],
+    cmd = "tar -xzOf $(location @noble//dosfstools/amd64:data) ./usr/sbin/mkfs.fat > $@ && chmod +x $@",
+    executable = True,
+)
+
 py_binary(
     name = "verity_sign",
     srcs = ["verity_sign.py"],

--- a/toolchains/sysimage/BUILD.bazel
+++ b/toolchains/sysimage/BUILD.bazel
@@ -84,6 +84,7 @@ genrule(
     cmd = "tar -xzOf $(location @noble//dosfstools/amd64:data) ./usr/sbin/mkfs.fat > $@ && chmod +x $@",
     executable = True,
 )
+
 # Hermetic mkfs.ext4 extracted from the apt-snapshot-pinned e2fsprogs .deb and
 # its dynamic-library dependencies (libext2fs, libcom_err, libblkid, libuuid,
 # libe2p). The on-disk binary mkfs.ext4 is itself a symlink to mke2fs; we
@@ -128,6 +129,7 @@ filegroup(
     name = "mkfs_ext4_runfiles",
     srcs = [":mkfs_ext4_files"],
 )
+
 py_binary(
     name = "verity_sign",
     srcs = ["verity_sign.py"],

--- a/toolchains/sysimage/BUILD.bazel
+++ b/toolchains/sysimage/BUILD.bazel
@@ -84,7 +84,50 @@ genrule(
     cmd = "tar -xzOf $(location @noble//dosfstools/amd64:data) ./usr/sbin/mkfs.fat > $@ && chmod +x $@",
     executable = True,
 )
+# Hermetic mkfs.ext4 extracted from the apt-snapshot-pinned e2fsprogs .deb and
+# its dynamic-library dependencies (libext2fs, libcom_err, libblkid, libuuid,
+# libe2p). The on-disk binary mkfs.ext4 is itself a symlink to mke2fs; we
+# extract the real binary as `mke2fs` and name the symlink target accordingly.
+# mke2fs.conf is also included because mke2fs reads it at runtime to pick
+# default filesystem features (selected via MKE2FS_CONFIG by build_ext4_image).
+genrule(
+    name = "mkfs_ext4_files",
+    srcs = [
+        "@noble//e2fsprogs/amd64:data",
+        "@noble//libuuid1/amd64:data",
+        "@noble//libcom-err2/amd64:data",
+        "@noble//libext2fs2t64/amd64:data",
+        "@noble//libblkid1/amd64:data",
+    ],
+    outs = [
+        "mkfs.ext4.d/mke2fs",
+        "mkfs.ext4.d/mke2fs.conf",
+        "mkfs.ext4.d/lib/libuuid.so.1",
+        "mkfs.ext4.d/lib/libcom_err.so.2",
+        "mkfs.ext4.d/lib/libext2fs.so.2",
+        "mkfs.ext4.d/lib/libe2p.so.2",
+        "mkfs.ext4.d/lib/libblkid.so.1",
+    ],
+    cmd = """
+set -euo pipefail
+tmp=$$(mktemp -d)
+trap 'rm -rf $$tmp' EXIT
+for f in $(SRCS); do tar -xzf $$f -C $$tmp; done
+cp $$tmp/usr/sbin/mke2fs                              $(execpath mkfs.ext4.d/mke2fs)
+chmod +x                                              $(execpath mkfs.ext4.d/mke2fs)
+cp $$tmp/etc/mke2fs.conf                              $(execpath mkfs.ext4.d/mke2fs.conf)
+cp $$tmp/usr/lib/x86_64-linux-gnu/libuuid.so.1.3.0    $(execpath mkfs.ext4.d/lib/libuuid.so.1)
+cp $$tmp/usr/lib/x86_64-linux-gnu/libcom_err.so.2.1   $(execpath mkfs.ext4.d/lib/libcom_err.so.2)
+cp $$tmp/usr/lib/x86_64-linux-gnu/libext2fs.so.2.4    $(execpath mkfs.ext4.d/lib/libext2fs.so.2)
+cp $$tmp/usr/lib/x86_64-linux-gnu/libe2p.so.2.3       $(execpath mkfs.ext4.d/lib/libe2p.so.2)
+cp $$tmp/usr/lib/x86_64-linux-gnu/libblkid.so.1.1.0   $(execpath mkfs.ext4.d/lib/libblkid.so.1)
+""",
+)
 
+filegroup(
+    name = "mkfs_ext4_runfiles",
+    srcs = [":mkfs_ext4_files"],
+)
 py_binary(
     name = "verity_sign",
     srcs = ["verity_sign.py"],

--- a/toolchains/sysimage/build_ext4_image.py
+++ b/toolchains/sysimage/build_ext4_image.py
@@ -164,6 +164,12 @@ def make_argparser():
     )
     parser.add_argument("--dflate", help="Path to our dflate tool", type=str, required=True)
     parser.add_argument("--diroid", help="Path to our diroid tool", type=str, required=True)
+    parser.add_argument(
+        "--mkfs-ext4",
+        help="Path to our hermetic mke2fs binary. Sibling files mke2fs.conf and lib/ are also used.",
+        type=str,
+        required=True,
+    )
     return parser
 
 
@@ -205,11 +211,19 @@ def main():
 
     # Now build the basic filesystem image. Wrap again in fakeroot
     # so correct permissions are read for all files etc.
+    mke2fs_dir = os.path.dirname(args.mkfs_ext4)
+    mke2fs_env = {
+        "E2FSPROGS_FAKE_TIME": "0",
+        # Point mke2fs at our bundled libraries and config so its output does
+        # not depend on the host's installed e2fsprogs version.
+        "LD_LIBRARY_PATH": os.path.join(mke2fs_dir, "lib"),
+        "MKE2FS_CONFIG": os.path.join(mke2fs_dir, "mke2fs.conf"),
+    }
     mke2fs_args = [
         "faketime",
         "-f",
         "1970-1-1 0:0:0",
-        "/usr/sbin/mkfs.ext4",
+        args.mkfs_ext4,
         "-E",
         "hash_seed=c61251eb-100b-48fe-b089-57dea7368612",
         "-U",
@@ -220,7 +234,7 @@ def main():
         image_file,
         str(image_size),
     ]
-    subprocess.run(mke2fs_args, check=True, env={"E2FSPROGS_FAKE_TIME": "0"})
+    subprocess.run(mke2fs_args, check=True, env=mke2fs_env)
 
     # Use our tool, diroid, to create an fs_config file to be used by e2fsdroid.
     # This file is a simple list of files with their desired uid, gid, and mode.

--- a/toolchains/sysimage/build_fat32_image.py
+++ b/toolchains/sysimage/build_fat32_image.py
@@ -106,7 +106,9 @@ def main():
         help="Extra files to install; expects list of sourcefile:targetfile:mode",
     )
     parser.add_argument("--dflate", help="Path to our dflate tool", type=str)
-    parser.add_argument("--mkfs-vfat", help="Path to mkfs.vfat binary (used with -F 32 for FAT32)", type=str, required=True)
+    parser.add_argument(
+        "--mkfs-vfat", help="Path to mkfs.vfat binary (used with -F 32 for FAT32)", type=str, required=True
+    )
 
     args = parser.parse_args(sys.argv[1:])
 

--- a/toolchains/sysimage/build_fat32_image.py
+++ b/toolchains/sysimage/build_fat32_image.py
@@ -106,6 +106,7 @@ def main():
         help="Extra files to install; expects list of sourcefile:targetfile:mode",
     )
     parser.add_argument("--dflate", help="Path to our dflate tool", type=str)
+    parser.add_argument("--mkfs-vfat", help="Path to mkfs.vfat binary (used with -F 32 for FAT32)", type=str, required=True)
 
     args = parser.parse_args(sys.argv[1:])
 
@@ -131,7 +132,7 @@ def main():
 
     os.close(os.open(image_file, os.O_CREAT | os.O_RDWR | os.O_CLOEXEC | os.O_EXCL, 0o600))
     os.truncate(image_file, image_size)
-    subprocess.run(["/usr/sbin/mkfs.fat", "-F", "32", "-i", "0", image_file], check=True)
+    subprocess.run([args.mkfs_vfat, "-F", "32", "-i", "0", image_file], check=True)
     if image_label:
         subprocess.run(["faketime", "-f", "1970-1-1 0:0:0", "/usr/sbin/fatlabel", image_file, image_label], check=True)
 

--- a/toolchains/sysimage/build_vfat_image.py
+++ b/toolchains/sysimage/build_vfat_image.py
@@ -105,6 +105,7 @@ def main():
         help="Extra files to install; expects list of sourcefile:targetfile:mode",
     )
     parser.add_argument("--dflate", help="Path to our dflate tool", type=str)
+    parser.add_argument("--mkfs-vfat", help="Path to mkfs.vfat binary", type=str, required=True)
 
     args = parser.parse_args(sys.argv[1:])
 
@@ -129,7 +130,7 @@ def main():
 
     os.close(os.open(image_file, os.O_CREAT | os.O_RDWR | os.O_CLOEXEC | os.O_EXCL, 0o600))
     os.truncate(image_file, image_size)
-    subprocess.run(["/usr/sbin/mkfs.vfat", "-i", "0", image_file], check=True)
+    subprocess.run([args.mkfs_vfat, "-i", "0", image_file], check=True)
 
     if in_file:
         with tarfile.open(in_file, mode="r|*") as tf:

--- a/toolchains/sysimage/toolchain.bzl
+++ b/toolchains/sysimage/toolchain.bzl
@@ -181,6 +181,8 @@ def _vfat_image_impl(ctx):
         ctx.attr.subdir,
         "--dflate",
         ctx.executable._dflate.path,
+        "--mkfs-vfat",
+        ctx.executable._mkfs_vfat.path,
     ])
 
     for input_target, install_target in ctx.attr.extra_files.items():
@@ -193,7 +195,11 @@ def _vfat_image_impl(ctx):
         arguments = args,
         inputs = inputs,
         outputs = outputs,
-        tools = [ctx.attr._tool.files_to_run, ctx.attr._dflate.files_to_run],
+        tools = [
+            ctx.attr._tool.files_to_run,
+            ctx.attr._dflate.files_to_run,
+            ctx.attr._mkfs_vfat.files_to_run,
+        ],
     )
 
     return [DefaultInfo(files = depset(outputs))]
@@ -223,6 +229,12 @@ vfat_image = _icos_build_rule(
             executable = True,
             cfg = "exec",
         ),
+        "_mkfs_vfat": attr.label(
+            default = "//toolchains/sysimage:mkfs_vfat",
+            executable = True,
+            cfg = "exec",
+            allow_single_file = True,
+        ),
     },
 )
 
@@ -247,6 +259,8 @@ def _fat32_image_impl(ctx):
         ctx.attr.subdir,
         "--dflate",
         ctx.executable._dflate.path,
+        "--mkfs-vfat",
+        ctx.executable._mkfs_vfat.path,
     ])
 
     for input_target, install_target in ctx.attr.extra_files.items():
@@ -262,7 +276,11 @@ def _fat32_image_impl(ctx):
         arguments = args,
         inputs = inputs,
         outputs = outputs,
-        tools = [ctx.attr._tool.files_to_run, ctx.attr._dflate.files_to_run],
+        tools = [
+            ctx.attr._tool.files_to_run,
+            ctx.attr._dflate.files_to_run,
+            ctx.attr._mkfs_vfat.files_to_run,
+        ],
     )
 
     return [DefaultInfo(files = depset(outputs))]
@@ -292,6 +310,12 @@ fat32_image = _icos_build_rule(
             default = "//rs/ic_os/build_tools/dflate",
             executable = True,
             cfg = "exec",
+        ),
+        "_mkfs_vfat": attr.label(
+            default = "//toolchains/sysimage:mkfs_vfat",
+            executable = True,
+            cfg = "exec",
+            allow_single_file = True,
         ),
     },
 )

--- a/toolchains/sysimage/toolchain.bzl
+++ b/toolchains/sysimage/toolchain.bzl
@@ -343,7 +343,11 @@ def _ext4_image_impl(ctx):
         ctx.executable._diroid.path,
         "--dflate",
         ctx.executable._dflate.path,
+        "--mkfs-ext4",
+        ctx.file._mkfs_ext4.path,
     ])
+
+    inputs.extend(ctx.files._mkfs_ext4_runfiles)
 
     if ctx.attr.file_contexts:
         args.extend(["-S", ctx.files.file_contexts[0].path])
@@ -402,6 +406,14 @@ ext4_image = _icos_build_rule(
             default = "//rs/ic_os/build_tools/dflate",
             executable = True,
             cfg = "exec",
+        ),
+        "_mkfs_ext4": attr.label(
+            default = "//toolchains/sysimage:mkfs.ext4.d/mke2fs",
+            allow_single_file = True,
+        ),
+        "_mkfs_ext4_runfiles": attr.label(
+            default = "//toolchains/sysimage:mkfs_ext4_runfiles",
+            allow_files = True,
         ),
     },
 )


### PR DESCRIPTION
This effectively pins the grub version, but we don't really expect this to change often, anyway. Without this, we could (and may have in #10208,) run into build determinism issues, since the version can change upstream without bazel noticing.

Eventually we should look into tidying up this build, but maybe not priority right now.

This also makes `mkfs.vfat` and `mkfs.ext4` bazel inputs preventing Ubuntu upgrades to cause build determinism issues because they use a newer versions of those tools which were not tracked by bazel.