### PR TITLE
perf: Look up sandbox scheduler priorities per canister

### DIFF
--- a/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
+++ b/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
@@ -2071,11 +2071,7 @@ fn evict_sandbox_processes(
         Backend::Empty => false,
     });
 
-    let scheduler_priorities = state_reader
-        .get_latest_state()
-        .get_ref()
-        .canister_accumulated_priorities();
-
+    let state = state_reader.get_latest_state();
     let min_scheduler_priority = AccumulatedPriority::new(i64::MIN);
 
     let candidates: Vec<_> = backends
@@ -2085,10 +2081,12 @@ fn evict_sandbox_processes(
                 id: *id,
                 last_used: stats.last_used,
                 rss: stats.rss,
-                scheduler_priority: *scheduler_priorities
-                    .get(id)
-                    // This should happen only if the canister is deleted.
-                    .unwrap_or(&min_scheduler_priority),
+                scheduler_priority: if state.get_ref().canister_state(id).is_some() {
+                    state.get_ref().canister_priority(id).accumulated_priority
+                } else {
+                    // Canister was deleted.
+                    min_scheduler_priority
+                },
             }),
             Backend::Evicted { .. } | Backend::Empty => None,
         })

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -25,7 +25,7 @@ use ic_registry_resource_limits::ResourceLimits;
 use ic_registry_routing_table::RoutingTable;
 use ic_registry_subnet_type::SubnetType;
 use ic_types::{
-    AccumulatedPriority, CanisterId, NumBytes, SubnetId, Time,
+    CanisterId, NumBytes, SubnetId, Time,
     batch::{ConsensusResponse, RawQueryStats},
     consensus::idkg::IDkgMasterPublicKeyId,
     ingress::IngressStatus,
@@ -684,22 +684,6 @@ impl ReplicatedState {
             &mut self.canister_states,
             &mut self.metadata.subnet_schedule,
         )
-    }
-
-    /// Time complexity: `O(n)` in the number of active canisters.
-    pub fn canister_accumulated_priorities(&self) -> BTreeMap<CanisterId, AccumulatedPriority> {
-        self.canister_states
-            .keys()
-            .map(|canister_id| {
-                (
-                    *canister_id,
-                    self.metadata
-                        .subnet_schedule
-                        .get(canister_id)
-                        .accumulated_priority,
-                )
-            })
-            .collect()
     }
 
     /// Prunes the canister priorities of deleted canisters; and those that have


### PR DESCRIPTION
`evict_sandbox_processes` only needs the accumulated priority of the canisters that have an active sandbox backend, but currently asks `ReplicatedState` for the priorities of *all* canisters on the subnet, materializing a fresh `BTreeMap<CanisterId, AccumulatedPriority>` on every eviction pass.

Replace the bulk lookup with per-id `canister_state(id)` / `canister_priority(id)` calls inside the existing `backends.iter()` loop. Behaviour is unchanged: a missing canister still falls through to `AccumulatedPriority::MIN`.

With the sandbox controller migrated, `canister_accumulated_priorities()` has no remaining callers, so drop it (and its now-unused `AccumulatedPriority` import) from `ReplicatedState`.