### PR TITLE
chore: remove unused IDX rust dependencies

### DIFF
--- a/rs/tests/test_canisters/message/BUILD.bazel
+++ b/rs/tests/test_canisters/message/BUILD.bazel
@@ -12,7 +12,6 @@ rust_library(
     deps = [
         # Keep sorted.
         "@crate_index//:candid",
-        "@crate_index//:ic-cdk",
         "@crate_index//:serde",
     ],
 )

--- a/rs/tests/test_canisters/signer/BUILD.bazel
+++ b/rs/tests/test_canisters/signer/BUILD.bazel
@@ -13,7 +13,6 @@ rust_library(
         # Keep sorted.
         "@crate_index//:candid",
         "@crate_index//:ic-cdk",
-        "@crate_index//:ic_bls12_381",
         "@crate_index//:serde",
     ],
 )


### PR DESCRIPTION
This removes some unused Rust dependencies from the Bazel build.