### PR TITLE
chore(defi): remove deprecated ic-cdk imports in ic-bitcoin-canister-mock

### DIFF
--- a/rs/bitcoin/mock/src/main.rs
+++ b/rs/bitcoin/mock/src/main.rs
@@ -1,11 +1,10 @@
-#![allow(deprecated)]
 use candid::candid_method;
 use ic_bitcoin_canister_mock::PushUtxosToAddress;
 use ic_btc_interface::{
     Address, GetCurrentFeePercentilesRequest, GetUtxosRequest, GetUtxosResponse,
     MillisatoshiPerByte, Network, Utxo, UtxosFilterInRequest,
 };
-use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, SendTransactionRequest};
+use ic_cdk::bitcoin_canister::{Network as BitcoinNetwork, SendTransactionRequest};
 use ic_cdk::{init, update};
 use serde_bytes::ByteBuf;
 use std::cell::RefCell;

--- a/rs/bitcoin/mock/tests/tests.rs
+++ b/rs/bitcoin/mock/tests/tests.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use bitcoin::Transaction;
 use bitcoin::consensus::deserialize;
 use candid::{Decode, Encode};
@@ -9,7 +8,7 @@ use ic_btc_interface::{
     GetCurrentFeePercentilesRequest, GetUtxosRequest, GetUtxosResponse, MillisatoshiPerByte,
     Network, NetworkInRequest, OutPoint, Txid, Utxo,
 };
-use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, SendTransactionRequest};
+use ic_cdk::bitcoin_canister::{Network as BitcoinNetwork, SendTransactionRequest};
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder};
 use ic_test_utilities_load_wasm::load_wasm;
 use ic_types_cycles::Cycles;


### PR DESCRIPTION
## Summary

Continues [DEFI-2304](https://dfinity.atlassian.net/browse/DEFI-2304) — removing the file-level `#![allow(deprecated)]` attributes that were introduced in #6264 when `ic-cdk` was upgraded to 0.18, by migrating the affected files off the deprecated `ic_cdk::api::management_canister::*` surface.

This PR handles `ic-bitcoin-canister-mock`. The only deprecated APIs it referenced were the `BitcoinNetwork` and `SendTransactionRequest` types; both now live at `ic_cdk::bitcoin_canister::{Network, SendTransactionRequest}`. No behavior change.

Follows the same pattern as #6755 (`ic-btc-checker`) and #6761 (`ic-ckbtc-minter`).

[DEFI-2304]: https://dfinity.atlassian.net/browse/DEFI-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ