### PR TITLE
chore(defi): remove deprecated ic-cdk imports in ic-cketh-minter

### DIFF
--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -732,6 +732,8 @@ service : (MinterArg) -> {
     is_address_blocked : (text) -> (bool) query;
 
     // Retrieve the status of the minter canister.
+    //
+    // This is a debug endpoint where backwards-compatibility is not guaranteed.
     get_canister_status : () -> (CanisterStatusResponse);
 
     // Retrieve events from the minter's audit log.

--- a/rs/ethereum/cketh/minter/cketh_minter.did
+++ b/rs/ethereum/cketh/minter/cketh_minter.did
@@ -7,18 +7,37 @@ type EthereumNetwork = variant {
 
 type Subaccount = blob;
 
+type environment_variable = record {
+    name: text;
+    value: text;
+};
+
 type CanisterStatusResponse = record {
-  query_stats : QueryStats;
   status : CanisterStatusType;
+  ready_for_migration : bool;
+  version : nat64;
   memory_size : nat;
   cycles : nat;
   settings : DefiniteCanisterSettings;
   idle_cycles_burned_per_day : nat;
   module_hash : opt vec nat8;
+  query_stats : QueryStats;
   reserved_cycles : nat;
+  memory_metrics : MemoryMetrics;
 };
 
 type CanisterStatusType = variant { stopped; stopping; running };
+
+type MemoryMetrics = record {
+    wasm_memory_size : nat;
+    stable_memory_size : nat;
+    global_memory_size : nat;
+    wasm_binary_size : nat;
+    custom_sections_size : nat;
+    canister_history_size : nat;
+    wasm_chunk_store_size : nat;
+    snapshots_size : nat;
+};
 
 type DefiniteCanisterSettings = record {
   freezing_threshold : nat;
@@ -28,6 +47,8 @@ type DefiniteCanisterSettings = record {
   reserved_cycles_limit : nat;
   log_visibility: LogVisibility;
   wasm_memory_limit : nat;
+  wasm_memory_threshold : nat;
+  environment_variables : vec environment_variable;
 };
 
 type LogVisibility = variant {

--- a/rs/ethereum/cketh/minter/src/main.rs
+++ b/rs/ethereum/cketh/minter/src/main.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use crate::dashboard::DashboardPaginationParameters;
 use candid::Nat;
 use dashboard::DashboardTemplate;
@@ -60,7 +59,7 @@ pub const SEPOLIA_TEST_CHAIN_ID: u64 = 11155111;
 pub const CKETH_LEDGER_TRANSACTION_FEE: Wei = Wei::new(2_000_000_000_000_u128);
 
 fn validate_caller_not_anonymous() -> candid::Principal {
-    let principal = ic_cdk::caller();
+    let principal = ic_cdk::api::msg_caller();
     if principal == candid::Principal::anonymous() {
         panic!("anonymous principal is not allowed");
     }
@@ -564,7 +563,7 @@ fn is_address_blocked(address_string: String) -> bool {
 async fn add_ckerc20_token(erc20_token: AddCkErc20Token) {
     let orchestrator_id = read_state(|s| s.ledger_suite_orchestrator_id)
         .unwrap_or_else(|| ic_cdk::trap("ERROR: ERC-20 feature is not activated"));
-    if orchestrator_id != ic_cdk::caller() {
+    if orchestrator_id != ic_cdk::api::msg_caller() {
         ic_cdk::trap(format!(
             "ERROR: only the orchestrator {orchestrator_id} can add ERC-20 tokens"
         ));
@@ -575,15 +574,12 @@ async fn add_ckerc20_token(erc20_token: AddCkErc20Token) {
 }
 
 #[update]
-async fn get_canister_status() -> ic_cdk::api::management_canister::main::CanisterStatusResponse {
-    ic_cdk::api::management_canister::main::canister_status(
-        ic_cdk::api::management_canister::main::CanisterIdRecord {
-            canister_id: ic_cdk::id(),
-        },
-    )
+async fn get_canister_status() -> ic_cdk::management_canister::CanisterStatusResult {
+    ic_cdk::management_canister::canister_status(&ic_cdk::management_canister::CanisterStatusArgs {
+        canister_id: ic_cdk::api::canister_self(),
+    })
     .await
     .expect("failed to fetch canister status")
-    .0
 }
 
 #[query]
@@ -919,7 +915,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
             read_state(|s| {
                 w.encode_gauge(
                     "stable_memory_bytes",
-                    ic_cdk::api::stable::stable_size() as f64 * WASM_PAGE_SIZE_IN_BYTES,
+                    ic_cdk::stable::stable_size() as f64 * WASM_PAGE_SIZE_IN_BYTES,
                     "Size of the stable memory allocated by this canister.",
                 )?;
 
@@ -932,7 +928,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                 w.gauge_vec("cycle_balance", "Cycle balance of this canister.")?
                     .value(
                         &[("canister", "cketh-minter")],
-                        ic_cdk::api::canister_balance128() as f64,
+                        ic_cdk::api::canister_cycle_balance() as f64,
                     )?;
 
                 w.encode_gauge(

--- a/rs/ethereum/cketh/minter/src/management.rs
+++ b/rs/ethereum/cketh/minter/src/management.rs
@@ -94,8 +94,8 @@ impl Reason {
                 }
             }
             CallFailed::InsufficientLiquidCycleBalance(_) => Self::OutOfCycles,
-            CallFailed::CallPerformFailed(_) => {
-                Self::InternalError("call_perform failed".to_string())
+            CallFailed::CallPerformFailed(e) => {
+                Self::InternalError(format!("call_perform failed: {e}"))
             }
         }
     }

--- a/rs/ethereum/cketh/minter/src/management.rs
+++ b/rs/ethereum/cketh/minter/src/management.rs
@@ -1,5 +1,5 @@
-#![allow(deprecated)]
-use ic_cdk::api::call::RejectionCode;
+use ic_cdk::call::{CallFailed, RejectCode};
+use ic_cdk::management_canister::SignCallError;
 use ic_management_canister_types_private::DerivationPath;
 use std::fmt;
 
@@ -64,17 +64,39 @@ impl fmt::Display for Reason {
 }
 
 impl Reason {
-    fn from_reject(reject_code: RejectionCode, reject_message: String) -> Self {
-        match reject_code {
-            RejectionCode::SysTransient => Self::TransientInternalError(reject_message),
-            RejectionCode::CanisterError => Self::CanisterError(reject_message),
-            RejectionCode::CanisterReject => Self::Rejected(reject_message),
-            RejectionCode::NoError
-            | RejectionCode::SysFatal
-            | RejectionCode::DestinationInvalid
-            | RejectionCode::Unknown => Self::InternalError(format!(
-                "rejection code: {reject_code:?}, rejection message: {reject_message}"
-            )),
+    fn from_sign_call_error(error: SignCallError) -> Self {
+        match error {
+            SignCallError::CallFailed(failed) => Self::from_call_failed(failed),
+            SignCallError::SignCostError(e) => {
+                Self::InternalError(format!("signature cost calculation failed: {e}"))
+            }
+            SignCallError::CandidDecodeFailed(e) => {
+                Self::InternalError(format!("candid decode failed: {e}"))
+            }
+        }
+    }
+
+    fn from_call_failed(failed: CallFailed) -> Self {
+        match failed {
+            CallFailed::CallRejected(rejected) => {
+                let message = rejected.reject_message().to_string();
+                match rejected.reject_code() {
+                    Ok(RejectCode::SysTransient) => Self::TransientInternalError(message),
+                    Ok(RejectCode::CanisterError) => Self::CanisterError(message),
+                    Ok(RejectCode::CanisterReject) => Self::Rejected(message),
+                    Ok(code) => Self::InternalError(format!(
+                        "rejection code: {code:?}, rejection message: {message}"
+                    )),
+                    Err(_) => Self::InternalError(format!(
+                        "unrecognized rejection code: {}, rejection message: {message}",
+                        rejected.raw_reject_code()
+                    )),
+                }
+            }
+            CallFailed::InsufficientLiquidCycleBalance(_) => Self::OutOfCycles,
+            CallFailed::CallPerformFailed(_) => {
+                Self::InternalError("call_perform failed".to_string())
+            }
         }
     }
 }
@@ -85,11 +107,9 @@ pub async fn sign_with_ecdsa(
     derivation_path: DerivationPath,
     message_hash: [u8; 32],
 ) -> Result<[u8; 64], CallError> {
-    use ic_cdk::api::management_canister::ecdsa::{
-        EcdsaCurve, EcdsaKeyId, SignWithEcdsaArgument, sign_with_ecdsa,
-    };
+    use ic_cdk::management_canister::{EcdsaCurve, EcdsaKeyId, SignWithEcdsaArgs, sign_with_ecdsa};
 
-    let result = sign_with_ecdsa(SignWithEcdsaArgument {
+    let result = sign_with_ecdsa(&SignWithEcdsaArgs {
         message_hash: message_hash.to_vec(),
         derivation_path: derivation_path.into_inner(),
         key_id: EcdsaKeyId {
@@ -100,7 +120,7 @@ pub async fn sign_with_ecdsa(
     .await;
 
     match result {
-        Ok((reply,)) => {
+        Ok(reply) => {
             let signature_length = reply.signature.len();
             Ok(<[u8; 64]>::try_from(reply.signature).unwrap_or_else(|_| {
                 panic!(
@@ -108,9 +128,9 @@ pub async fn sign_with_ecdsa(
                 )
             }))
         }
-        Err((code, msg)) => Err(CallError {
+        Err(error) => Err(CallError {
             method: "sign_with_ecdsa".to_string(),
-            reason: Reason::from_reject(code, msg),
+            reason: Reason::from_sign_call_error(error),
         }),
     }
 }

--- a/rs/ethereum/cketh/minter/src/management/mod.rs
+++ b/rs/ethereum/cketh/minter/src/management/mod.rs
@@ -3,6 +3,9 @@ use ic_cdk::management_canister::SignCallError;
 use ic_management_canister_types_private::DerivationPath;
 use std::fmt;
 
+#[cfg(test)]
+mod tests;
+
 /// Represents an error from a management canister call, such as
 /// `sign_with_ecdsa`.
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/rs/ethereum/cketh/minter/src/management/tests.rs
+++ b/rs/ethereum/cketh/minter/src/management/tests.rs
@@ -1,0 +1,55 @@
+use super::Reason;
+use ic_cdk::call::{CallFailed, CallPerformFailed, CallRejected, InsufficientLiquidCycleBalance};
+
+#[test]
+fn from_call_failed_maps_insufficient_liquid_cycle_balance_to_out_of_cycles() {
+    // The ic-cdk 0.19 `Call` builder does a pre-flight check comparing
+    // `canister_liquid_cycle_balance` against `Call::get_cost` and surfaces
+    // `InsufficientLiquidCycleBalance` *before* `ic0.call_perform`. The old
+    // `call_with_payment128` surface had no such check, so this is a new code
+    // path; we map it to `Reason::OutOfCycles` so the error message is accurate.
+    let err = CallFailed::InsufficientLiquidCycleBalance(InsufficientLiquidCycleBalance {
+        available: 100,
+        required: 1_000,
+    });
+    assert_eq!(Reason::from_call_failed(err), Reason::OutOfCycles);
+}
+
+#[test]
+fn from_call_failed_includes_underlying_error_on_call_perform_failed() {
+    match Reason::from_call_failed(CallFailed::CallPerformFailed(CallPerformFailed)) {
+        Reason::InternalError(msg) => {
+            assert!(msg.starts_with("call_perform failed: "), "got {msg}")
+        }
+        other => panic!("expected InternalError, got {other:?}"),
+    }
+}
+
+#[test]
+fn from_call_failed_maps_known_reject_codes_to_expected_reasons() {
+    let cases = [
+        (2_u32, Reason::TransientInternalError("msg".to_string())),
+        (5_u32, Reason::CanisterError("msg".to_string())),
+        (4_u32, Reason::Rejected("msg".to_string())),
+    ];
+    for (raw_code, expected) in cases {
+        let err =
+            CallFailed::CallRejected(CallRejected::with_rejection(raw_code, "msg".to_string()));
+        assert_eq!(
+            Reason::from_call_failed(err),
+            expected,
+            "raw_code={raw_code}"
+        );
+    }
+}
+
+#[test]
+fn from_call_failed_maps_unrecognized_reject_code_to_internal_error() {
+    let err = CallFailed::CallRejected(CallRejected::with_rejection(99, "huh".to_string()));
+    match Reason::from_call_failed(err) {
+        Reason::InternalError(msg) => {
+            assert!(msg.contains("99") && msg.contains("huh"), "got {msg}");
+        }
+        other => panic!("expected InternalError, got {other:?}"),
+    }
+}

--- a/rs/ethereum/cketh/minter/src/state.rs
+++ b/rs/ethereum/cketh/minter/src/state.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use crate::address::ecdsa_public_key_to_address;
 use crate::endpoints::CandidBlockTag;
 use crate::erc20::{CkErc20Token, CkTokenSymbol};
@@ -16,7 +15,7 @@ use crate::state::transactions::{Erc20WithdrawalRequest, TransactionCallData, Wi
 use crate::tx::GasFeeEstimate;
 use candid::Principal;
 use ic_canister_log::log;
-use ic_cdk::api::management_canister::ecdsa::EcdsaPublicKeyResponse;
+use ic_cdk::management_canister::EcdsaPublicKeyResult;
 use ic_ethereum_types::Address;
 use ic_secp256k1::PublicKey;
 use std::cell::RefCell;
@@ -57,7 +56,7 @@ pub struct State {
     pub ecdsa_key_name: String,
     pub cketh_ledger_id: Principal,
     pub log_scrapings: LogScrapings,
-    pub ecdsa_public_key: Option<EcdsaPublicKeyResponse>,
+    pub ecdsa_public_key: Option<EcdsaPublicKeyResult>,
     pub cketh_minimum_withdrawal_amount: Wei,
     pub ethereum_block_height: CandidBlockTag,
     pub first_scraped_block_number: BlockNumber,
@@ -609,11 +608,11 @@ where
 }
 
 pub async fn lazy_call_ecdsa_public_key() -> PublicKey {
-    use ic_cdk::api::management_canister::ecdsa::{
-        EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument, ecdsa_public_key,
+    use ic_cdk::management_canister::{
+        EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, ecdsa_public_key,
     };
 
-    fn to_public_key(response: &EcdsaPublicKeyResponse) -> PublicKey {
+    fn to_public_key(response: &EcdsaPublicKeyResult) -> PublicKey {
         PublicKey::deserialize_sec1(&response.public_key).unwrap_or_else(|e| {
             ic_cdk::trap(format!("failed to decode minter's public key: {e:?}"))
         })
@@ -624,7 +623,7 @@ pub async fn lazy_call_ecdsa_public_key() -> PublicKey {
     }
     let key_name = read_state(|s| s.ecdsa_key_name.clone());
     log!(DEBUG, "Fetching the ECDSA public key {key_name}");
-    let (response,) = ecdsa_public_key(EcdsaPublicKeyArgument {
+    let response = ecdsa_public_key(&EcdsaPublicKeyArgs {
         canister_id: None,
         derivation_path: crate::MAIN_DERIVATION_PATH
             .into_iter()
@@ -636,11 +635,7 @@ pub async fn lazy_call_ecdsa_public_key() -> PublicKey {
         },
     })
     .await
-    .unwrap_or_else(|(error_code, message)| {
-        ic_cdk::trap(format!(
-            "failed to get minter's public key: {message} (error code = {error_code:?})",
-        ))
-    });
+    .unwrap_or_else(|err| ic_cdk::trap(format!("failed to get minter's public key: {err}")));
     mutate_state(|s| s.ecdsa_public_key = Some(response.clone()));
     to_public_key(&response)
 }

--- a/rs/ethereum/cketh/minter/src/state/tests.rs
+++ b/rs/ethereum/cketh/minter/src/state/tests.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated)]
 use crate::endpoints::CandidBlockTag;
 use crate::eth_logs::{EventSource, ReceivedErc20Event, ReceivedEthEvent, ReceivedEvent};
 use crate::eth_rpc_client::responses::{TransactionReceipt, TransactionStatus};
@@ -807,7 +806,7 @@ fn state_equivalence() {
     use crate::tx::{
         Eip1559Signature, Eip1559TransactionRequest, SignedTransactionRequest, TransactionRequest,
     };
-    use ic_cdk::api::management_canister::ecdsa::EcdsaPublicKeyResponse;
+    use ic_cdk::management_canister::EcdsaPublicKeyResult;
     use maplit::{btreemap, btreeset};
 
     fn source(txhash: &str, index: u64) -> EventSource {
@@ -994,7 +993,7 @@ fn state_equivalence() {
         ecdsa_key_name: "test_key".to_string(),
         cketh_ledger_id: "apia6-jaaaa-aaaar-qabma-cai".parse().unwrap(),
         log_scrapings: log_scrapings.clone(),
-        ecdsa_public_key: Some(EcdsaPublicKeyResponse {
+        ecdsa_public_key: Some(EcdsaPublicKeyResult {
             public_key: vec![1; 32],
             chain_code: vec![2; 32],
         }),

--- a/rs/ethereum/cketh/test_utils/src/mock.rs
+++ b/rs/ethereum/cketh/test_utils/src/mock.rs
@@ -1,9 +1,6 @@
-#![allow(deprecated)]
 use crate::{CkEthSetup, JsonRpcProvider, MAX_TICKS, assert_reply};
 use candid::{Decode, Encode};
-use ic_cdk::api::management_canister::http_request::{
-    HttpResponse as OutCallHttpResponse, TransformArgs,
-};
+use ic_cdk::management_canister::{HttpRequestResult as OutCallHttpResponse, TransformArgs};
 use ic_error_types::RejectCode;
 use ic_management_canister_types_private::CanisterHttpResponsePayload;
 use ic_state_machine_tests::{PayloadBuilder, StateMachine};


### PR DESCRIPTION
## Summary

Continues [DEFI-2304](https://dfinity.atlassian.net/browse/DEFI-2304) — removing the `#![allow(deprecated)]` attributes that were introduced in #6264 when `ic-cdk` was upgraded to 0.18, by migrating the affected files off the deprecated `ic_cdk` surface.

This PR handles `ic-cketh-minter`:

- `ic_cdk::api::management_canister::{main, ecdsa, http_request}` → `ic_cdk::management_canister::*` + `EcdsaPublicKeyArgs` / `EcdsaPublicKeyResult` / `SignWithEcdsaArgs` / `CanisterStatusArgs` / `CanisterStatusResult` from `ic_management_canister_types`.
- `ic_cdk::api::call::RejectionCode` → `ic_cdk::call::CallFailed` and `ic_cdk::management_canister::SignCallError`; the existing `Reason::from_reject` mapping is rewritten as `from_call_failed` / `from_sign_call_error` while preserving the same `Reason` variants.
- `ic_cdk::caller()` / `ic_cdk::id()` → `ic_cdk::api::msg_caller()` / `ic_cdk::api::canister_self()`.
- `ic_cdk::api::canister_balance128()` → `ic_cdk::api::canister_cycle_balance()`.
- `ic_cdk::api::stable::stable_size()` → `ic_cdk::stable::stable_size()`.
- `get_canister_status` now returns the modern `CanisterStatusResult`; `cketh_minter.did` is updated to mirror the new fields (the same shape already adopted by ckBTC minter in #6761).

The changes in the ckETH minter API are due to changes in the return type of `get_canister_status`, which is a debug endpoint where backwards-compatibility is not guaranteed.

Follows the pattern set by #6755 (`ic-btc-checker`) and #6761 (`ic-ckbtc-minter`). No behavior change.

[DEFI-2304]: https://dfinity.atlassian.net/browse/DEFI-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ