### PR TITLE
chore: remove unused crypto dependencies

### DIFF
--- a/rs/crypto/BUILD.bazel
+++ b/rs/crypto/BUILD.bazel
@@ -38,7 +38,6 @@ rust_library(
         "//rs/crypto/standalone-sig-verifier",
         "//rs/crypto/tls_interfaces",
         "//rs/crypto/utils/basic_sig",
-        "//rs/crypto/utils/canister_threshold_sig",
         "//rs/crypto/utils/tls",
         "//rs/interfaces",
         "//rs/interfaces/registry",

--- a/rs/crypto/internal/crypto_lib/seed/BUILD.bazel
+++ b/rs/crypto/internal/crypto_lib/seed/BUILD.bazel
@@ -13,7 +13,6 @@ rust_library(
     deps = [
         # Keep sorted.
         "//rs/crypto/sha2",
-        "@crate_index//:hex",
         "@crate_index//:rand",
         "@crate_index//:rand_chacha",
         "@crate_index//:serde",

--- a/rs/crypto/internal/crypto_lib/tls/BUILD.bazel
+++ b/rs/crypto/internal/crypto_lib/tls/BUILD.bazel
@@ -12,7 +12,6 @@ rust_library(
         "//packages/ic-ed25519",
         "//rs/crypto/internal/crypto_lib/seed",
         "//rs/crypto/secrets_containers",
-        "//rs/types/types",
         "@crate_index//:rand",
         "@crate_index//:rcgen",
         "@crate_index//:serde",


### PR DESCRIPTION
This removes some unused Rust dependencies from the Bazel build.