### PR TITLE
chore: remove unused DSM dependencies

### DIFF
--- a/rs/embedders/BUILD.bazel
+++ b/rs/embedders/BUILD.bazel
@@ -68,7 +68,6 @@ rust_library(
         "@crate_index//:tempfile",
         "@crate_index//:wasm-encoder",
         "@crate_index//:wasmparser",
-        "@crate_index//:wasmprinter",
         "@crate_index//:wasmtime",
         "@crate_index//:wirm",
     ],

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -32,7 +32,6 @@ rust_library(
         "//rs/registry/routing_table",
         "//rs/registry/subnet_type",
         "//rs/replicated_state",
-        "//rs/state_layout",
         "//rs/sys",
         "//rs/types/base_types",
         "//rs/types/cycles",

--- a/rs/execution_environment/benches/lib/BUILD.bazel
+++ b/rs/execution_environment/benches/lib/BUILD.bazel
@@ -25,7 +25,6 @@ rust_library(
         "//rs/test_utilities",
         "//rs/test_utilities/execution_environment",
         "//rs/test_utilities/state",
-        "//rs/test_utilities/time",
         "//rs/test_utilities/types",
         "//rs/types/cycles",
         "//rs/types/types",


### PR DESCRIPTION
This removes some unused Rust dependencies from the Bazel build.