### PR TITLE
chore: remove unused SNS dependencies

### DIFF
--- a/rs/sns/governance/api/BUILD.bazel
+++ b/rs/sns/governance/api/BUILD.bazel
@@ -18,17 +18,14 @@ rust_library(
     version = "0.9.0",
     deps = [
         # Keep sorted.
-        "//rs/ledger_suite/icp:icp_ledger",
         "//rs/nervous_system/proto",
         "//rs/protobuf",
         "//rs/types/base_types",
-        "//rs/types/types",
         "//rs/utils",
         "@crate_index//:bytes",
         "@crate_index//:candid",
         "@crate_index//:clap",
         "@crate_index//:comparable",
-        "@crate_index//:itertools",
         "@crate_index//:prost",
         "@crate_index//:serde",
         "@crate_index//:serde_bytes",


### PR DESCRIPTION
This removes some unused Rust dependencies from the Bazel build.