### PR TITLE
chore: remove unused DRE dependencies

### DIFF
--- a/rs/node_rewards/canister/api/BUILD.bazel
+++ b/rs/node_rewards/canister/api/BUILD.bazel
@@ -14,13 +14,11 @@ rust_library(
     version = "0.9.0",
     deps = [
         # Keep sorted.
-        "//rs/nervous_system/proto",
         "//rs/node_rewards/rewards_calculation",
         "//rs/protobuf",
         "//rs/types/base_types",
         "@crate_index//:candid",
         "@crate_index//:chrono_canisters",
-        "@crate_index//:ic-cdk",
         "@crate_index//:rust_decimal",
         "@crate_index//:serde",
     ],

--- a/rs/node_rewards/rewards_calculation/BUILD.bazel
+++ b/rs/node_rewards/rewards_calculation/BUILD.bazel
@@ -11,13 +11,10 @@ rust_library(
     ],
     deps = [
         # Keep sorted.
-        "//rs/nns/constants",
         "//rs/protobuf",
         "//rs/types/base_types",
-        "//rs/types/types",
         "@crate_index//:candid",
         "@crate_index//:chrono_canisters",
-        "@crate_index//:ic-cdk",
         "@crate_index//:itertools",
         "@crate_index//:lazy_static",
         "@crate_index//:maplit",


### PR DESCRIPTION
This removes some unused Rust dependencies from the Bazel build.