### PR TITLE
chore: remove unused consensus dependencies

### DIFF
--- a/rs/consensus/BUILD.bazel
+++ b/rs/consensus/BUILD.bazel
@@ -16,7 +16,6 @@ rust_library(
         # Keep sorted.
         "//packages/ic-error-types",
         "//rs/config",
-        "//rs/consensus/certification",
         "//rs/consensus/chain_key",
         "//rs/consensus/dkg",
         "//rs/consensus/idkg",

--- a/rs/cup_explorer/BUILD.bazel
+++ b/rs/cup_explorer/BUILD.bazel
@@ -17,7 +17,6 @@ rust_library(
         "//rs/interfaces",
         "//rs/interfaces/registry",
         "//rs/protobuf",
-        "//rs/registry/client",
         "//rs/registry/helpers",
         "//rs/registry/keys",
         "//rs/registry/nns_data_provider",

--- a/rs/prep/BUILD.bazel
+++ b/rs/prep/BUILD.bazel
@@ -40,7 +40,6 @@ rust_library(
         "@crate_index//:maplit",
         "@crate_index//:prost",
         "@crate_index//:rand",
-        "@crate_index//:reqwest",
         "@crate_index//:serde",
         "@crate_index//:serde_json",
         "@crate_index//:slog",


### PR DESCRIPTION
This removes some unused Rust dependencies from the Bazel build.