### PR TITLE
perf: Only migrate logs once per process

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1112,7 +1112,7 @@ impl Scheduler for SchedulerImpl {
         // The goal is to ensure that we can track the performance of `execute_round` and its individual components.
         let root_measurement_scope = MeasurementScope::root(&self.metrics.round);
 
-        {
+        if !state.metadata.logs_migrated {
             let _timer = self
                 .metrics
                 .round_log_memory_store_migration_duration
@@ -1141,6 +1141,7 @@ impl Scheduler for SchedulerImpl {
                     system_state.log_memory_store.clear_migrated();
                 }
             }
+            state.metadata.logs_migrated = true;
         }
 
         let round_log;

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -181,6 +181,18 @@ pub struct SystemMetadata {
     /// Modifications to the state that have not been applied yet to the next checkpoint.
     /// This field is transient and is emptied before writing the next checkpoint.
     pub unflushed_checkpoint_ops: UnflushedCheckpointOps,
+
+    /// Whether the logs have been migrated from `CanisterLog` to `LogMemoryStore`
+    /// or from `LogMemoryStore` to `CanisterLog`, as per the
+    /// `log_memory_store_feature` flag.
+    ///
+    /// This is a (temporary) transient field tracking whether all canisters are
+    /// definitely using the log store required by the `log_memory_store_feature`
+    /// flag. It is intended to be used as a one-time trigger (when `false`) to
+    /// launch the (idempotent, if already performed) logs migration exactly once
+    /// per replica process (since the flag is hardcoded into the binary).
+    #[validate_eq(Ignore)]
+    pub logs_migrated: bool,
 }
 
 /// Unfiltered topology, including all subnets and the full routing table.
@@ -536,6 +548,7 @@ impl SystemMetadata {
             bitcoin_get_successors_follow_up_responses: BTreeMap::default(),
             blockmaker_metrics_time_series: BlockmakerMetricsTimeSeries::default(),
             unflushed_checkpoint_ops: Default::default(),
+            logs_migrated: false,
         }
     }
 
@@ -838,6 +851,7 @@ impl SystemMetadata {
             bitcoin_get_successors_follow_up_responses: _,
             blockmaker_metrics_time_series: _,
             unflushed_checkpoint_ops: _,
+            logs_migrated: _,
         } = self;
 
         let split_from_subnet = split_from.expect("Not a state resulting from a subnet split");
@@ -942,6 +956,7 @@ impl SystemMetadata {
             mut bitcoin_get_successors_follow_up_responses,
             blockmaker_metrics_time_series,
             unflushed_checkpoint_ops,
+            logs_migrated,
         } = self;
 
         assert_eq!(None, split_from);
@@ -1051,6 +1066,7 @@ impl SystemMetadata {
             // Just updated by `ReplicatedState::online_split()`, adding delete operations
             // for the snapshots of no longer hosted canisters.
             unflushed_checkpoint_ops,
+            logs_migrated,
         })
     }
 
@@ -2152,6 +2168,7 @@ pub mod testing {
             bitcoin_get_successors_follow_up_responses: Default::default(),
             blockmaker_metrics_time_series: BlockmakerMetricsTimeSeries::default(),
             unflushed_checkpoint_ops: Default::default(),
+            logs_migrated: false,
         };
     }
 }

--- a/rs/replicated_state/src/metadata_state/proto.rs
+++ b/rs/replicated_state/src/metadata_state/proto.rs
@@ -571,6 +571,7 @@ impl TryFrom<(pb_metadata::SystemMetadata, &dyn CheckpointLoadingMetrics)> for S
                 None => BlockmakerMetricsTimeSeries::default(),
             },
             unflushed_checkpoint_ops: Default::default(),
+            logs_migrated: false,
         })
     }
 }


### PR DESCRIPTION
The log_memory_store_feature flag is hardcoded into the replica binary, meaning that logs migration is needed at most once per replica process. Since iterating over all `CanisterStates` is relatively expensive, add a transient field to `ReplicatedState` that tracks whether the (potential) migration has already been completed. Skip the `execute_round()` step altogether if the flag was set earlier.