### PR TITLE
fix: Reduce read_ahead size to previous

### DIFF
--- a/ic-os/components/guestos.bzl
+++ b/ic-os/components/guestos.bzl
@@ -83,6 +83,7 @@ def component_files(mode):
         Label("guestos/misc/sysctl.d/dfn-max-map-count.conf"): "/etc/sysctl.d/dfn-max-map-count.conf",
         Label("guestos/misc/sysctl.d/privileged-ports.conf"): "/etc/sysctl.d/privileged-ports.conf",
         Label("guestos/misc/sysfs.d/hugepage.conf"): "/etc/sysfs.d/hugepage.conf",
+        Label("guestos/misc/sysfs.d/read_ahead.conf"): "/etc/sysfs.d/read_ahead.conf",
         Label("guestos/misc/hsm/pcscd"): "/etc/default/pcscd",
         Label("misc/log-config/log-config-guestos.service"): "/etc/systemd/system/log-config.service",
         Label("guestos/misc/sync_fstrim.sh"): "/opt/ic/bin/sync_fstrim.sh",

--- a/ic-os/components/guestos/misc/sysfs.d/read_ahead.conf
+++ b/ic-os/components/guestos/misc/sysfs.d/read_ahead.conf
@@ -1,0 +1,4 @@
+# Block device read_ahead configuration
+#
+
+block/vda/queue/read_ahead_kb = 128


### PR DESCRIPTION
After the 26.04 upgrade of GuestOS, it was found that the `read_ahead_kb` went from `128` to `8192` for the virtual `vda` drive used by GuestOS. This led to a performance impact on subnets with large state, with so much extra data being read.

I believe this only impacts the vda devices we use from GuestOS. This change sets the defaults back to what they were before the upgrade.