### PR TITLE
chore: remove deprecated ic-cdk imports in ic-icp-test-ledger

### DIFF
--- a/rs/ledger_suite/icp/test_utils/icp_test_ledger/src/main.rs
+++ b/rs/ledger_suite/icp/test_utils/icp_test_ledger/src/main.rs
@@ -1,6 +1,5 @@
-#![allow(deprecated)]
 use candid::Nat;
-use ic_cdk::api::call::{arg_data_raw, reply_raw};
+use ic_cdk::api::{msg_arg_data as arg_data_raw, msg_reply as reply_raw};
 use ic_cdk::futures::internals::in_query_executor_context;
 use ic_cdk::{init, query, update};
 use ic_icp_test_ledger::AddBlockResult;


### PR DESCRIPTION
## Summary

Extends [DEFI-2304](https://dfinity.atlassian.net/browse/DEFI-2304) — removing the file-level `#![allow(deprecated)]` attribute. For `ic-icp-test-ledger` the attribute was added later by #8490, but it has the same root cause as the rest of the DEFI-2304 surface: the canister was templated from another ledger canister that still used the deprecated `ic_cdk::api::call::{arg_data_raw, reply_raw}` imports.

- `ic_cdk::api::call::{arg_data_raw, reply_raw}` → `ic_cdk::api::{msg_arg_data, msg_reply}` (imported with `as` aliases so call sites stay untouched).

No behavior change.

[DEFI-2304]: https://dfinity.atlassian.net/browse/DEFI-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ