### PR TITLE
chore: remove deprecated ic-cdk imports in ic-sender-canister

### DIFF
--- a/rs/rosetta-api/icp/test_utils/sender_canister/src/lib.rs
+++ b/rs/rosetta-api/icp/test_utils/sender_canister/src/lib.rs
@@ -1,6 +1,4 @@
-#![allow(deprecated)]
 use candid::{CandidType, Principal};
-use ic_cdk::api::call::RejectionCode;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, CandidType, Deserialize, Serialize)]
@@ -9,6 +7,38 @@ pub struct SendArg {
     pub method: String,
     pub arg: Vec<u8>,
     pub payment: u128,
+}
+
+/// The reject code returned by `send`.
+///
+/// Mirrors the variants exposed by the deprecated
+/// `ic_cdk::api::call::RejectionCode` so the public Candid interface of this
+/// test canister stays stable after the ic-cdk 0.18 upgrade.
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize)]
+pub enum RejectionCode {
+    NoError,
+    SysFatal,
+    SysTransient,
+    DestinationInvalid,
+    CanisterReject,
+    CanisterError,
+    Unknown,
+}
+
+impl RejectionCode {
+    /// Translates the raw u32 reject code returned by `ic_cdk::call::CallRejected`
+    /// into the variant the test canister exposes over Candid.
+    pub fn from_raw(raw: u32) -> Self {
+        match raw {
+            0 => Self::NoError,
+            1 => Self::SysFatal,
+            2 => Self::SysTransient,
+            3 => Self::DestinationInvalid,
+            4 => Self::CanisterReject,
+            5 => Self::CanisterError,
+            _ => Self::Unknown,
+        }
+    }
 }
 
 pub type SendError = (RejectionCode, String);

--- a/rs/rosetta-api/icp/test_utils/sender_canister/src/main.rs
+++ b/rs/rosetta-api/icp/test_utils/sender_canister/src/main.rs
@@ -1,6 +1,6 @@
-#![allow(deprecated)]
+use ic_cdk::call::{Call, CallFailed};
 use ic_cdk::update;
-use ic_sender_canister_lib::{SendArg, SendResult};
+use ic_sender_canister_lib::{RejectionCode, SendArg, SendResult};
 
 #[update]
 async fn send(calls: Vec<SendArg>) -> Vec<SendResult> {
@@ -12,10 +12,28 @@ async fn send(calls: Vec<SendArg>) -> Vec<SendResult> {
         payment,
     } in calls
     {
-        futures.push(ic_cdk::api::call::call_raw128(to, &method, arg, payment));
+        futures.push(async move {
+            Call::unbounded_wait(to, &method)
+                .take_raw_args(arg)
+                .with_cycles(payment)
+                .await
+                .map(|response| response.into_bytes())
+                .map_err(map_call_error)
+        });
     }
 
     futures::future::join_all(futures).await
+}
+
+fn map_call_error(err: CallFailed) -> (RejectionCode, String) {
+    match err {
+        CallFailed::CallRejected(rejected) => (
+            RejectionCode::from_raw(rejected.raw_reject_code()),
+            rejected.reject_message().to_string(),
+        ),
+        CallFailed::InsufficientLiquidCycleBalance(e) => (RejectionCode::Unknown, e.to_string()),
+        CallFailed::CallPerformFailed(e) => (RejectionCode::Unknown, e.to_string()),
+    }
 }
 
 fn main() {}


### PR DESCRIPTION
## Summary

Extends [DEFI-2304](https://dfinity.atlassian.net/browse/DEFI-2304) — removing the file-level `#![allow(deprecated)]` attributes introduced in #6264.

This PR handles `ic-sender-canister`:

- `ic_cdk::api::call::call_raw128(to, &method, arg, payment).await` → `ic_cdk::call::Call::unbounded_wait(to, &method).take_raw_args(arg).with_cycles(payment).await` + `Response::into_bytes` to recover the raw reply bytes.
- `ic_cdk::api::call::RejectionCode` → a local `RejectionCode` enum that mirrors the 7 variants previously exposed by the deprecated cdk type. The Candid interface declared in `sender.did` is unchanged.
- The new `CallFailed` error is mapped back to `(RejectionCode, String)` so the public `SendError = (RejectionCode, String)` type alias keeps the same wire shape.

No behavior change.

[DEFI-2304]: https://dfinity.atlassian.net/browse/DEFI-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ