### PR TITLE
chore: remove deprecated ic-cdk imports in ic-icrc1-index-ng

### DIFF
--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -1,7 +1,7 @@
-#![allow(deprecated)]
 use candid::{CandidType, Decode, Encode, Nat, Principal};
 use ic_canister_log::{export as export_logs, log};
 use ic_canister_profiler::{SpanName, SpanStats, measure_span};
+use ic_cdk::call::Call;
 use ic_cdk::trap;
 use ic_cdk::{init, post_upgrade, query};
 use ic_crypto_sha2::Sha256;
@@ -317,6 +317,7 @@ fn balance_key(account: Account) -> (AccountDataType, (Blob<29>, [u8; 32])) {
 
 #[init]
 fn init(index_arg: Option<IndexArg>) {
+    #[allow(deprecated)]
     let InitArg {
         ledger_id,
         retrieve_blocks_from_ledger_interval_seconds,
@@ -372,7 +373,7 @@ fn post_upgrade(index_arg: Option<IndexArg>) {
     // storage scheme. This trick allows SNSes to update the legacy
     // index to index-ng.
     if let Ok(old_state) = ciborium::de::from_reader::<LegacyIndexState, _>(
-        ic_cdk::api::stable::StableReader::default().take(MAX_LEGACY_STATE_BYTES),
+        ic_cdk::stable::StableReader::default().take(MAX_LEGACY_STATE_BYTES),
     ) {
         log!(
             P1,
@@ -388,6 +389,7 @@ fn post_upgrade(index_arg: Option<IndexArg>) {
         Some(IndexArg::Upgrade(upgrade)) => {
             log!(P1, "Possible upgrade configuration changes: {:#?}", upgrade,);
 
+            #[allow(deprecated)]
             let UpgradeArg {
                 ledger_id,
                 retrieve_blocks_from_ledger_interval_seconds,
@@ -515,14 +517,15 @@ async fn get_supported_standards_from_ledger() -> Vec<String> {
         P1,
         "[get_supported_standards_from_ledger]: making the call..."
     );
-    let res = ic_cdk::api::call::call::<_, (Vec<StandardRecord>,)>(
-        ledger_id,
-        "icrc1_supported_standards",
-        (),
-    )
-    .await;
+    let res: Result<Vec<StandardRecord>, String> =
+        match Call::unbounded_wait(ledger_id, "icrc1_supported_standards").await {
+            Ok(response) => response
+                .candid::<Vec<StandardRecord>>()
+                .map_err(|err| err.to_string()),
+            Err(err) => Err(err.to_string()),
+        };
     match res {
-        Ok((res,)) => {
+        Ok(res) => {
             let supported_standard_names = res.into_iter().map(|s| s.name).collect::<Vec<_>>();
             log!(
                 P1,
@@ -532,14 +535,13 @@ async fn get_supported_standards_from_ledger() -> Vec<String> {
             );
             supported_standard_names
         }
-        Err((code, msg)) => {
+        Err(err) => {
             // log the error but do not propagate it
             log!(
                 P0,
-                "[get_supported_standards_from_ledger]: failed to call get_supported_standards_from_ledger on ledger {}. Error code: {:?} message: {}",
+                "[get_supported_standards_from_ledger]: failed to call get_supported_standards_from_ledger on ledger {}: {}",
                 ledger_id,
-                code,
-                msg
+                err,
             );
             vec![]
         }
@@ -559,9 +561,11 @@ where
 {
     let req = measure_span(&PROFILING_DATA, encode_span_name, || Encode!(i))
         .map_err(|err| format!("failed to candid encode the input {i:?}: {err}"))?;
-    let res = ic_cdk::api::call::call_raw(id, method, &req, 0)
+    let res = Call::unbounded_wait(id, method)
+        .with_raw_args(&req)
         .await
-        .map_err(|(code, str)| format!("code: {code:#?} message: {str}"))?;
+        .map(|response| response.into_bytes())
+        .map_err(|err| format!("{err}"))?;
     measure_span(&PROFILING_DATA, decode_span_name, || Decode!(&res, O))
         .map_err(|err| format!("failed to candid decode the output: {err}"))
 }
@@ -1404,12 +1408,12 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     w.encode_gauge(
         "index_stable_memory_pages",
-        ic_cdk::api::stable::stable_size() as f64,
+        ic_cdk::stable::stable_size() as f64,
         "Size of the stable memory allocated by this canister measured in 64K Wasm pages.",
     )?;
     w.encode_gauge(
         "stable_memory_bytes",
-        (ic_cdk::api::stable::stable_size() * 64 * 1024) as f64,
+        (ic_cdk::stable::stable_size() * 64 * 1024) as f64,
         "Size of the stable memory allocated by this canister measured in bytes.",
     )?;
     w.encode_gauge(
@@ -1418,7 +1422,7 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
         "Size of the heap memory allocated by this canister measured in bytes.",
     )?;
 
-    let cycle_balance = ic_cdk::api::canister_balance128() as f64;
+    let cycle_balance = ic_cdk::api::canister_cycle_balance() as f64;
     w.encode_gauge(
         "index_cycle_balance",
         cycle_balance,

--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -539,7 +539,7 @@ async fn get_supported_standards_from_ledger() -> Vec<String> {
             // log the error but do not propagate it
             log!(
                 P0,
-                "[get_supported_standards_from_ledger]: failed to call get_supported_standards_from_ledger on ledger {}: {}",
+                "[get_supported_standards_from_ledger]: failed to call icrc1_supported_standards on ledger {}: {}",
                 ledger_id,
                 err,
             );
@@ -562,7 +562,7 @@ where
     let req = measure_span(&PROFILING_DATA, encode_span_name, || Encode!(i))
         .map_err(|err| format!("failed to candid encode the input {i:?}: {err}"))?;
     let res = Call::unbounded_wait(id, method)
-        .with_raw_args(&req)
+        .take_raw_args(req)
         .await
         .map(|response| response.into_bytes())
         .map_err(|err| format!("{err}"))?;

--- a/rs/ledger_suite/icrc1/index-ng/src/main.rs
+++ b/rs/ledger_suite/icrc1/index-ng/src/main.rs
@@ -317,6 +317,10 @@ fn balance_key(account: Account) -> (AccountDataType, (Blob<29>, [u8; 32])) {
 
 #[init]
 fn init(index_arg: Option<IndexArg>) {
+    // `InitArg::retrieve_blocks_from_ledger_interval_seconds` is itself
+    // `#[deprecated]` (see `lib.rs`); we still observe it here so
+    // `parse_timer_configuration_options` can enforce the backwards-compat
+    // rule that it cannot be set alongside the new `min_`/`max_` fields.
     #[allow(deprecated)]
     let InitArg {
         ledger_id,
@@ -389,6 +393,11 @@ fn post_upgrade(index_arg: Option<IndexArg>) {
         Some(IndexArg::Upgrade(upgrade)) => {
             log!(P1, "Possible upgrade configuration changes: {:#?}", upgrade,);
 
+            // `UpgradeArg::retrieve_blocks_from_ledger_interval_seconds` is
+            // itself `#[deprecated]` (see `lib.rs`); we still observe it here
+            // so `parse_timer_configuration_options` can enforce the
+            // backwards-compat rule that it cannot be set alongside the new
+            // `min_`/`max_` fields.
             #[allow(deprecated)]
             let UpgradeArg {
                 ledger_id,


### PR DESCRIPTION
## Summary

Closes [DEFI-2304](https://dfinity.atlassian.net/browse/DEFI-2304) — removing the final file-level `#![allow(deprecated)]` attribute introduced in #6264 across the defi-owned crates in the `ic` repo.

This PR handles `ic-icrc1-index-ng`:

- `ic_cdk::api::call::call(...)` → `ic_cdk::call::Call::unbounded_wait(...).await?.candid::<T>()?` for the `icrc1_supported_standards` query on the ledger.
- `ic_cdk::api::call::call_raw(...)` → `ic_cdk::call::Call::unbounded_wait(...).take_raw_args(req)` + `Response::into_bytes` in the `measured_call` helper, keeping the existing `candid::Decode!`-based decoding.
- `ic_cdk::api::stable::StableReader` → `ic_cdk::stable::StableReader`.
- `ic_cdk::api::stable::stable_size` → `ic_cdk::stable::stable_size`.
- `ic_cdk::api::canister_balance128` → `ic_cdk::api::canister_cycle_balance`.

`InitArg::retrieve_blocks_from_ledger_interval_seconds` is itself separately deprecated (tracked by a different ticket); its two destructuring patterns keep a narrowly scoped `#[allow(deprecated)]` so this PR stays focused on the DEFI-2304 surface.

No behavior change.

[DEFI-2304]: https://dfinity.atlassian.net/browse/DEFI-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ