### PR TITLE
fix(IDX): point rollout-dashboard endpoint at dm1-dre1

### DIFF
--- a/ci/scripts/determine-initial-guest-os-versions.py
+++ b/ci/scripts/determine-initial-guest-os-versions.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, TypedDict, cast
 from urllib.request import urlopen
 
-ROLLOUT_DASHBOARD_ENDPOINT = "https://rollout-dashboard.ch1-rel1.dfinity.network/api/v1/rollouts"
+ROLLOUT_DASHBOARD_ENDPOINT = "https://rollout-dashboard.dm1-dre1.dfinity.network/api/v1/rollouts"
 PUBLIC_DASHBOARD_ENDPOINT = "https://ic-api.internetcomputer.org/api/v3/subnets?format=json"
 
 # Key definitions


### PR DESCRIPTION
## Summary

- The `ch1-rel1` cluster was removed in [dfinity-ops/k8s#2462](https://github.com/dfinity-ops/k8s/pull/2462) and the rollout dashboard now lives on `dm1-dre1` (see the ingress on `zz_generated/clusters/dm1-dre1/apps/rollout-dashboard_networking.k8s.io_v1_ingress_rollout-dashboard.yaml`).
- `ci/scripts/determine-initial-guest-os-versions.py` still hit `rollout-dashboard.ch1-rel1.dfinity.network`, so the `Setting up guest os qualification pipeline -> Fetch beginning versions for qualification` step failed with `urlopen error [Errno 113] No route to host` and then fell through to the public dashboard endpoint (`ic-api.internetcomputer.org/api/v3/subnets?format=json`), which is currently 403'ing -- killing release-testing CI (e.g. `Release Testing / CI Main / Setting up guest os qualification pipeline` on PR #1344).
- Updates `ROLLOUT_DASHBOARD_ENDPOINT` to `https://rollout-dashboard.dm1-dre1.dfinity.network/api/v1/rollouts`.

## Test plan

- [ ] `Setting up guest os qualification pipeline` job on `release-testing` succeeds on this PR.
- [ ] `python3 ci/scripts/determine-initial-guest-os-versions.py` locally with internet access prints non-empty versions (or at least no longer raises `No route to host`).