### PR TITLE
chore: CON-1441 Set `empty_signature_agreements_flag` in all new `IDkgPayload`s

### DIFF
--- a/rs/consensus/idkg/src/payload_builder.rs
+++ b/rs/consensus/idkg/src/payload_builder.rs
@@ -367,6 +367,8 @@ fn create_summary_payload_helper(
     idkg_summary.uid_generator.update_height(height)?;
     update_summary_refs(height, &mut idkg_summary, block_reader)?;
 
+    idkg_summary.set_empty_signature_agreements_flag();
+
     Ok(Some(idkg_summary))
 }
 
@@ -618,6 +620,8 @@ pub(crate) fn create_data_payload_helper(
         idkg_payload_metrics,
         log,
     )?;
+
+    idkg_payload.set_empty_signature_agreements_flag();
 
     Ok(Some(idkg_payload))
 }

--- a/rs/consensus/idkg/src/payload_builder.rs
+++ b/rs/consensus/idkg/src/payload_builder.rs
@@ -367,7 +367,7 @@ fn create_summary_payload_helper(
     idkg_summary.uid_generator.update_height(height)?;
     update_summary_refs(height, &mut idkg_summary, block_reader)?;
 
-    idkg_summary.set_empty_signature_agreements_flag();
+    idkg_summary.empty_signature_agreements_flag = true;
 
     Ok(Some(idkg_summary))
 }
@@ -621,7 +621,7 @@ pub(crate) fn create_data_payload_helper(
         log,
     )?;
 
-    idkg_payload.set_empty_signature_agreements_flag();
+    idkg_payload.empty_signature_agreements_flag = true;
 
     Ok(Some(idkg_payload))
 }

--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -166,7 +166,7 @@ impl<'de> serde::Deserialize<'de> for IDkgMasterPublicKeyId {
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct IDkgPayload {
     /// Flag indicating if the deprecated signature agreements hash should be ignored.
-    pub empty_signature_agreements_flag: bool,
+    pub(crate) empty_signature_agreements_flag: bool,
 
     /// IDKG transcript Pre-Signatures that we can use to create threshold signatures.
     pub available_pre_signatures: BTreeMap<PreSigId, PreSignatureRef>,
@@ -219,7 +219,7 @@ impl IDkgPayload {
                 .map(|key_transcript| (key_transcript.key_id(), key_transcript))
                 .collect(),
             uid_generator: IDkgUIDGenerator::new(subnet_id, height),
-            empty_signature_agreements_flag: false,
+            empty_signature_agreements_flag: true,
             available_pre_signatures: BTreeMap::new(),
             pre_signatures_in_creation: BTreeMap::new(),
             idkg_transcripts: BTreeMap::new(),
@@ -416,6 +416,10 @@ impl IDkgPayload {
             .values()
             .map(|pre_sig| pre_sig.key_id().required_pre_sig_capacity())
             .sum()
+    }
+
+    pub fn set_empty_signature_agreements_flag(&mut self) {
+        self.empty_signature_agreements_flag = true;
     }
 }
 

--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -166,7 +166,7 @@ impl<'de> serde::Deserialize<'de> for IDkgMasterPublicKeyId {
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct IDkgPayload {
     /// Flag indicating if the deprecated signature agreements hash should be ignored.
-    pub(crate) empty_signature_agreements_flag: bool,
+    pub empty_signature_agreements_flag: bool,
 
     /// IDKG transcript Pre-Signatures that we can use to create threshold signatures.
     pub available_pre_signatures: BTreeMap<PreSigId, PreSignatureRef>,
@@ -416,10 +416,6 @@ impl IDkgPayload {
             .values()
             .map(|pre_sig| pre_sig.key_id().required_pre_sig_capacity())
             .sum()
-    }
-
-    pub fn set_empty_signature_agreements_flag(&mut self) {
-        self.empty_signature_agreements_flag = true;
     }
 }
 

--- a/rs/types/types/src/exhaustive.rs
+++ b/rs/types/types/src/exhaustive.rs
@@ -918,7 +918,7 @@ impl ExhaustiveSet for IDkgPayload {
         DerivedIDkgPayload::exhaustive_set(rng)
             .into_iter()
             .map(|payload| IDkgPayload {
-                empty_signature_agreements_flag: false,
+                empty_signature_agreements_flag: true,
                 available_pre_signatures: payload.available_pre_signatures,
                 pre_signatures_in_creation: payload.pre_signatures_in_creation,
                 uid_generator: payload.uid_generator,


### PR DESCRIPTION
The `IDkgPayload` used to contain a `signature_agreements` field, which is now unused and in the process of being removed. This requires migrating the struct's hash function to no longer consider this field without breaking compatibility. To do this, https://github.com/dfinity/ic/pull/9829 introduced a flag in the `IDkgPayload` which was initially set to `false`. This indicates that the hash function should still consider the old `signature_agreements` field.

This PR sets the flag to `true` for all new `IDkgPayload`s. This means the hash of new payloads will not consider the removed `signature_agreements` field anymore. 

In an upcoming release, we can then remove the custom Hash implementation, at which point all payloads will ignore the `signature_agreements` field, regardless of the flag value). In the final release we will then remove the flag again.