### PR TITLE
revert: Revert "chore: Clean up legacy attestation custom data encoding"

### DIFF
--- a/rs/ic_os/guest_upgrade/shared/src/attestation.rs
+++ b/rs/ic_os/guest_upgrade/shared/src/attestation.rs
@@ -18,12 +18,41 @@ impl DerEncodedCustomData for GetDiskEncryptionKeyTokenCustomData<'_> {
     fn namespace(&self) -> SevCustomDataNamespace {
         SevCustomDataNamespace::GetDiskEncryptionKeyToken
     }
+
+    fn needs_legacy_encoding() -> bool {
+        true
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use attestation::custom_data::EncodeSevCustomData;
+
+    #[test]
+    fn test_get_disk_encryption_key_token_custom_data_is_stable_legacy() {
+        let client_tls_public_key = OctetStringRef::new(&[1, 2, 3, 4]).unwrap();
+        let server_tls_public_key = OctetStringRef::new(&[5, 6, 7, 8]).unwrap();
+        let custom_data = GetDiskEncryptionKeyTokenCustomData {
+            client_tls_public_key,
+            server_tls_public_key,
+        };
+
+        let result = custom_data.encode_for_sev_legacy().unwrap();
+        assert_eq!(
+            &result,
+            // The numbers below don't have any special meaning, but they should stay stable.
+            // If the encoding below has to be changed, the attestation report verification will
+            // probably fail because the old GuestOS version will still derive the previous
+            // encoding, so take extra care!
+            &[
+                31, 13, 254, 213, 44, 96, 47, 104, 171, 127, 68, 166, 43, 242, 61, 116, 55, 229,
+                214, 227, 107, 88, 24, 26, 223, 134, 119, 215, 136, 162, 198, 128, 60, 107, 133,
+                229, 145, 220, 92, 231, 186, 211, 34, 11, 30, 155, 53, 20, 23, 114, 250, 74, 83,
+                143, 28, 23, 30, 166, 65, 176, 215, 27, 136, 191
+            ]
+        );
+    }
 
     #[test]
     fn test_get_disk_encryption_key_token_custom_data_is_stable() {
@@ -37,8 +66,9 @@ mod tests {
         assert_eq!(
             &custom_data.encode_for_sev().unwrap().to_bytes(),
             // The numbers below don't have any special meaning, but they should stay stable.
-            // If the encoding below changes, attestation report verification will fail, so take
-            // extra care.
+            // If the encoding below has to be changed, the attestation report verification will
+            // probably fail because the old GuestOS version will still derive the previous
+            // encoding, so take extra care!
             &[
                 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 193, 239, 169, 57, 190, 108, 66, 46, 79, 92, 166, 152, 18, 27, 246, 6,

--- a/rs/ic_os/sev/attestation/src/attestation_package.rs
+++ b/rs/ic_os/sev/attestation/src/attestation_package.rs
@@ -204,8 +204,18 @@ impl<T: Borrow<ParsedSevAttestationPackage>> AttestationPackageVerifier for T {
             return Ok(self);
         }
 
+        // TODO(NODE-1784): remove this once clients no longer send legacy custom data
+        let expected_report_data_legacy = expected_custom_data.encode_for_sev_legacy();
+        if D::needs_legacy_encoding()
+            && let Ok(expected_report_data_legacy) = expected_report_data_legacy
+            && &expected_report_data_legacy == actual_report_data
+        {
+            return Ok(self);
+        }
+
         Err(VerificationError::invalid_custom_data(format!(
             "Expected attestation report custom data: {expected_report_data:?}, \
+             legacy: {expected_report_data_legacy:?}, \
              actual: {actual_report_data:?} \
              Debug info: \
              expected: {expected_custom_data:?} \

--- a/rs/ic_os/sev/attestation/src/custom_data.rs
+++ b/rs/ic_os/sev/attestation/src/custom_data.rs
@@ -1,5 +1,5 @@
 use der::Encode;
-use sha2::{Digest, Sha256};
+use sha2::{Digest, Sha256, Sha512};
 use std::error::Error;
 use std::fmt::Debug;
 use thiserror::Error;
@@ -87,11 +87,26 @@ pub struct EncodingError(#[from] pub Box<dyn Error + Send + Sync>);
 pub trait EncodeSevCustomData {
     /// Encodes the struct into a SevCustomData object for use as SEV custom data.
     fn encode_for_sev(&self) -> Result<SevCustomData, EncodingError>;
+
+    // TODO(NODE-1784): Remove encode_for_sev_legacy and needs_legacy_encoding after the migration to new
+    // encoding is done.
+    /// Encodes the struct into a legacy 64-byte array for use as SEV custom data.
+    fn encode_for_sev_legacy(&self) -> Result<[u8; 64], EncodingError>;
+
+    /// True if the type was available before the migration to new encoding.
+    /// New types should not override this method and return false.
+    fn needs_legacy_encoding() -> bool;
 }
 
 /// A trait for types that can be encoded into SEV custom data using DER encoding.
 pub trait DerEncodedCustomData: Encode {
     fn namespace(&self) -> SevCustomDataNamespace;
+
+    /// True if the type was available before the migration to new encoding.
+    /// New types should not override this method and return false.
+    fn needs_legacy_encoding() -> bool {
+        false
+    }
 }
 
 impl<T: DerEncodedCustomData> EncodeSevCustomData for T {
@@ -104,11 +119,32 @@ impl<T: DerEncodedCustomData> EncodeSevCustomData for T {
 
         Ok(SevCustomData::new(self.namespace(), hash_bytes))
     }
+
+    fn encode_for_sev_legacy(&self) -> Result<[u8; 64], EncodingError> {
+        let mut encoded = vec![];
+        self.encode(&mut encoded)
+            .map_err(|err| EncodingError(Box::new(err)))?;
+
+        let hash: [u8; 64] = Sha512::digest(&encoded).into();
+        Ok(hash)
+    }
+
+    fn needs_legacy_encoding() -> bool {
+        T::needs_legacy_encoding()
+    }
 }
 
 impl EncodeSevCustomData for SevCustomData {
     fn encode_for_sev(&self) -> Result<SevCustomData, EncodingError> {
         Ok(*self)
+    }
+
+    fn encode_for_sev_legacy(&self) -> Result<[u8; 64], EncodingError> {
+        Ok(self.to_bytes())
+    }
+
+    fn needs_legacy_encoding() -> bool {
+        false
     }
 }
 

--- a/rs/ic_os/sev/attestation/src/e2e_tests.rs
+++ b/rs/ic_os/sev/attestation/src/e2e_tests.rs
@@ -20,7 +20,22 @@ struct FooCustomData {
     b: i64,
 }
 
+#[derive(der::Sequence, Debug)]
+struct NewFooCustomData {
+    a: i32,
+}
+
 impl DerEncodedCustomData for FooCustomData {
+    fn namespace(&self) -> SevCustomDataNamespace {
+        SevCustomDataNamespace::Test
+    }
+
+    fn needs_legacy_encoding() -> bool {
+        true
+    }
+}
+
+impl DerEncodedCustomData for NewFooCustomData {
     fn namespace(&self) -> SevCustomDataNamespace {
         SevCustomDataNamespace::Test
     }
@@ -30,6 +45,8 @@ const CUSTOM_DATA: FooCustomData = FooCustomData {
     a: 42,
     b: 1234567890,
 };
+
+const NEW_CUSTOM_DATA: NewFooCustomData = NewFooCustomData { a: 42 };
 
 fn generate_valid_attestation_package() -> SevAttestationPackage {
     let signer = FakeAttestationReportSigner::default();
@@ -251,5 +268,84 @@ fn test_invalid_root_certificate() {
                 if message.contains("does not match expected root certificate")
         ),
         "Expected error about unexpected root certificate, got {error:?}",
+    );
+}
+
+#[test]
+fn test_legacy_custom_data_accepted() {
+    let signer = FakeAttestationReportSigner::default();
+
+    let legacy_custom_data = CUSTOM_DATA
+        .encode_for_sev_legacy()
+        .expect("Failed to encode custom data in legacy format");
+
+    let attestation_report_bytes = AttestationReportBuilder::new()
+        .with_custom_data(legacy_custom_data)
+        .with_measurement(MEASUREMENT)
+        .with_chip_id(CHIP_ID)
+        .build_signed(&signer)
+        .to_bytes()
+        .unwrap();
+
+    let attestation_package = SevAttestationPackage {
+        attestation_report: Some(attestation_report_bytes.to_vec()),
+        certificate_chain: Some(SevCertificateChain {
+            vcek_pem: Some(signer.get_vcek_pem()),
+            ask_pem: Some(signer.get_ask_pem()),
+            ark_pem: Some(signer.get_ark_pem()),
+        }),
+        custom_data_debug_info: None,
+    };
+
+    ParsedSevAttestationPackage::parse(
+        attestation_package,
+        SevRootCertificateVerification::TestOnlySkipVerification,
+    )
+    .verify_measurement(&[MEASUREMENT])
+    .verify_custom_data(&CUSTOM_DATA)
+    .verify_chip_id(&[CHIP_ID])
+    .expect("Failed to verify attestation package with legacy custom data format");
+}
+
+#[test]
+fn test_legacy_custom_data_not_accepted_for_new_types() {
+    let signer = FakeAttestationReportSigner::default();
+
+    let legacy_custom_data = NEW_CUSTOM_DATA
+        .encode_for_sev_legacy()
+        .expect("Failed to encode custom data in legacy format");
+
+    let attestation_report_bytes = AttestationReportBuilder::new()
+        .with_custom_data(legacy_custom_data)
+        .with_measurement(MEASUREMENT)
+        .with_chip_id(CHIP_ID)
+        .build_signed(&signer)
+        .to_bytes()
+        .unwrap();
+
+    let attestation_package = SevAttestationPackage {
+        attestation_report: Some(attestation_report_bytes.to_vec()),
+        certificate_chain: Some(SevCertificateChain {
+            vcek_pem: Some(signer.get_vcek_pem()),
+            ask_pem: Some(signer.get_ask_pem()),
+            ark_pem: Some(signer.get_ark_pem()),
+        }),
+        custom_data_debug_info: None,
+    };
+
+    let error = ParsedSevAttestationPackage::parse(
+        attestation_package,
+        SevRootCertificateVerification::TestOnlySkipVerification,
+    )
+    .verify_custom_data(&NEW_CUSTOM_DATA)
+    .expect_err(
+        "Verification should fail because legacy custom data format is not accepted for new types",
+    )
+    .detail
+    .unwrap();
+
+    assert!(
+        matches!(error, VerificationErrorDetail::InvalidCustomData { .. }),
+        "Expected InvalidCustomData error, got {error:?}",
     );
 }

--- a/rs/ic_os/sev/guest/src/attestation_package.rs
+++ b/rs/ic_os/sev/guest/src/attestation_package.rs
@@ -19,7 +19,12 @@ pub fn generate_attestation_package<T: EncodeSevCustomData + Debug>(
     trusted_execution_environment_config: &TrustedExecutionEnvironmentConfig,
     custom_data: &T,
 ) -> Result<ParsedSevAttestationPackage> {
-    let custom_data_bytes = custom_data.encode_for_sev()?.to_bytes();
+    let custom_data_bytes = if T::needs_legacy_encoding() {
+        // TODO(NODE-1784): Move to new SEV encoding once clients are updated
+        custom_data.encode_for_sev_legacy()?
+    } else {
+        custom_data.encode_for_sev()?.to_bytes()
+    };
     let attestation_report = sev_firmware
         .get_report(None, Some(custom_data_bytes), None)
         .context("Failed to get attestation report from SEV firmware")?;


### PR DESCRIPTION
Reverts dfinity/ic#10222

Attestation report verifiers still need to accept legacy encoding, but report generators can use the new encoding. A separate PR will be opened to remove legacy encoding from generators. Once that's rolled out, we'll need an additional step to stop accepting the legacy encoding.