### PR TITLE
feat: Strip timestamps from base images

### DIFF
--- a/.github/workflows/container-base-images.yml
+++ b/.github/workflows/container-base-images.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/container-base-images.yml'
+      - 'toolchains/sysimage/build_container_base_image.py'
       - '**/Dockerfile.base'
       - '**/packages.common'
       - '**/packages.dev'

--- a/toolchains/sysimage/build_container_base_image.py
+++ b/toolchains/sysimage/build_container_base_image.py
@@ -57,7 +57,7 @@ def build_image(image_tag: str, dockerfile: str, context_dir: str, build_args: L
     storage_args = get_storage_dir_args()
 
     log.info("Building image...")
-    cmd = f"podman {storage_args} build --squash-all --tag {image_tag} {build_arg_strings_joined} --file {dockerfile} {context_dir}"
+    cmd = f"podman {storage_args} build --timestamp 0 --squash-all --tag {image_tag} {build_arg_strings_joined} --file {dockerfile} {context_dir}"
     invoke.run(cmd)
     log.info("Image built successfully")
 

--- a/toolchains/sysimage/build_container_filesystem_tar.py
+++ b/toolchains/sysimage/build_container_filesystem_tar.py
@@ -78,7 +78,15 @@ def build_container(
         # Override the first FROM statement - grabs it from local cache
         cmd += f" --from {base_image_override.image_tag}"
 
-    # Set timestamp for all files for determinism
+    # Set timestamp for all new files for determinism
+    # NOTE: This does not touch base layers. As base images are currently built
+    # by Docker, not podman, they leak timestamps. (This doesn't really matter,
+    # because they are pinned.) If we could strip timestamps from the published
+    # base images as we do locally with `build_container_base_image.py`, we
+    # could remove the `mtime` handling from the tar below.
+    #
+    # We could also `--squash-all` instead, but since we're already re-packing
+    # the tar for determinism anyway, we handle it there.
     cmd += " --timestamp 0"
 
     if dockerfile:
@@ -111,7 +119,7 @@ def export_container_filesystem(image_tag: str, destination_tar_filename: str):
     invoke.run(f"mkdir -p {tar_dir}")
     invoke.run(f"fakeroot -s {fakeroot_statefile} tar xpf {tar_file} --same-owner --numeric-owner -C {tar_dir}")
     invoke.run(
-        f"fakeroot -i {fakeroot_statefile} tar cf {destination_tar_filename} --numeric-owner --sort=name --exclude='run/*' -C {tar_dir} $(ls -A {tar_dir})"
+        f"fakeroot -i {fakeroot_statefile} tar cf {destination_tar_filename} --mtime='UTC 1970-01-01 00:00:00' --numeric-owner --sort=name --exclude='run/*' -C {tar_dir} $(ls -A {tar_dir})"
     )
 
 


### PR DESCRIPTION
From the fallout of #10208

The new podman seems to be able to wrap more timestamps coming from base images (back to epoch), which leads to cache pollution across the upgrade to 26.04. To avoid this, we clear all timestamps before creating cached artifacts, and make some first steps to removing timestamps from the base images entirely.