### PR TITLE
refactor: IC-1942 Return payment receipt from HTTP outcalls adapter

### DIFF
--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -126,7 +126,6 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
         // Spawn an async task that sends the canister http request to the adapter and awaits the response.
         // After receiving the response from the adapter an optional transform is applied by doing an upcall to execution.
         // Once final response is available send the response over to the channel making it available to the client.
-
         self.rt_handle.spawn(async move {
             let CanisterHttpRequest {
                 id: request_id,

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -186,7 +186,7 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                     request_headers,
                     request_body,
                     socks_proxy_addrs,
-                    &mut budget,
+                    &mut *budget,
                 )
                 .await?;
 
@@ -207,7 +207,7 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                 let transformed_payload = match &request_transform {
                     Some(transform) => {
                         let (transform_result, instruction_count) = transform_adapter_response(
-                            &mut budget,
+                            &mut *budget,
                             query_handler,
                             canister_http_payload,
                             request_sender,
@@ -320,7 +320,7 @@ async fn execute_http_request(
     headers: Vec<CanisterHttpHeader>,
     body: Option<Vec<u8>>,
     socks_proxy_addrs: Vec<String>,
-    budget: &mut Box<dyn BudgetTracker>,
+    budget: &mut dyn BudgetTracker,
 ) -> Result<(HttpsOutcallResponse, NumBytes, Duration), (RejectCode, String)> {
     let AdapterLimits {
         max_response_size,
@@ -430,7 +430,7 @@ fn validate_response(
 /// Make upcall to execution to transform the response.
 /// This gives the ability to prune volatile fields before passing the response to consensus.
 async fn transform_adapter_response(
-    budget: &mut Box<dyn BudgetTracker>,
+    budget: &mut dyn BudgetTracker,
     query_handler: TransformExecutionService,
     canister_http_response: CanisterHttpResponsePayload,
     transform_canister: CanisterId,

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -216,7 +216,7 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                         .await;
                         let transform_result_size = match &transform_result {
                             Ok(data) => data.len(),
-                            Err((_, msg)) => msg.len(),
+                            Err(reject) => reject.message.len(),
                         };
 
                         info!(
@@ -237,22 +237,24 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                         );
 
                         if transform_result_size as u64 > max_response_size_bytes {
-                            let err_msg = format!(
-                                "Transformed http response exceeds limit: {max_response_size_bytes}"
-                            );
-                            return Err((RejectCode::SysFatal, err_msg));
+                            return Err(CanisterHttpReject {
+                                reject_code: RejectCode::SysFatal,
+                                message: format!(
+                                    "Transformed http response exceeds limit: {max_response_size_bytes}"
+                                ),
+                            });
                         }
 
                         transform_result
                     }
                     None => Encode!(&canister_http_payload).map_err(|encode_error| {
-                        (
-                            RejectCode::SysFatal,
-                            format!(
+                        CanisterHttpReject {
+                            reject_code: RejectCode::SysFatal,
+                            message: format!(
                                 "Failed to parse adapter http response \
                                     to 'http_response' candid: {encode_error}"
                             ),
-                        )
+                        }
                     }),
                 };
                 transform_timer.observe_duration();
@@ -275,18 +277,15 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                                 .inc();
                             CanisterHttpResponseContent::Success(resp)
                         }
-                        Err((reject_code, message)) => {
+                        Err(reject) => {
                             metrics
                                 .request_total
                                 .with_label_values(&[
-                                    reject_code.as_str(),
+                                    reject.reject_code.as_str(),
                                     request_http_method.as_str(),
                                 ])
                                 .inc();
-                            CanisterHttpResponseContent::Reject(CanisterHttpReject {
-                                reject_code,
-                                message,
-                            })
+                            CanisterHttpResponseContent::Reject(reject)
                         }
                     },
                 },
@@ -321,7 +320,7 @@ async fn execute_http_request(
     body: Option<Vec<u8>>,
     socks_proxy_addrs: Vec<String>,
     budget: &mut dyn BudgetTracker,
-) -> Result<(HttpsOutcallResponse, NumBytes, Duration), (RejectCode, String)> {
+) -> Result<(HttpsOutcallResponse, NumBytes, Duration), CanisterHttpReject> {
     let AdapterLimits {
         max_response_size,
         max_response_time,
@@ -351,12 +350,13 @@ async fn execute_http_request(
     let (grpc_result, elapsed) =
         timeout_with_capped_metric(max_response_time, adapter_client.https_outcall(proto_req))
             .await
-            .map_err(|_| (RejectCode::SysTransient, "Deadline Exceeded".to_string()))?;
-    let adapter_response = grpc_result.map_err(|grpc_status| {
-        (
-            grpc_status_code_to_reject(grpc_status.code()),
-            grpc_status.message().to_string(),
-        )
+            .map_err(|_| CanisterHttpReject {
+                reject_code: RejectCode::SysTransient,
+                message: "Deadline Exceeded".to_string(),
+            })?;
+    let adapter_response = grpc_result.map_err(|grpc_status| CanisterHttpReject {
+        reject_code: grpc_status_code_to_reject(grpc_status.code()),
+        message: grpc_status.message().to_string(),
     })?;
     let HttpsOutcallResult {
         metrics: adapter_metrics,
@@ -370,8 +370,9 @@ async fn execute_http_request(
             response_size: downloaded_bytes,
             response_time: elapsed,
         })
-        .map_err(|PricingError::InsufficientCycles| {
-            (RejectCode::SysFatal, "Insufficient cycles".to_string())
+        .map_err(|PricingError::InsufficientCycles| CanisterHttpReject {
+            reject_code: RejectCode::SysFatal,
+            message: "Insufficient cycles".to_string(),
         })?;
 
     let response = match result {
@@ -379,19 +380,22 @@ async fn execute_http_request(
             Ok(https_outcall_response)
         }
         Some(https_outcall_result::Result::Error(canister_http_error)) => {
-            let code = match canister_http_error.kind() {
+            let reject_code = match canister_http_error.kind() {
                 CanisterHttpErrorKind::InvalidInput => RejectCode::SysFatal,
                 CanisterHttpErrorKind::Connection => RejectCode::SysTransient,
                 CanisterHttpErrorKind::LimitExceeded => RejectCode::SysFatal,
                 CanisterHttpErrorKind::Internal => RejectCode::SysTransient,
                 CanisterHttpErrorKind::Unspecified => RejectCode::SysFatal,
             };
-            Err((code, canister_http_error.message))
+            Err(CanisterHttpReject {
+                reject_code,
+                message: canister_http_error.message,
+            })
         }
-        None => Err((
-            RejectCode::SysFatal,
-            "Adapter returned empty result".to_string(),
-        )),
+        None => Err(CanisterHttpReject {
+            reject_code: RejectCode::SysFatal,
+            message: "Adapter returned empty result".to_string(),
+        }),
     }?;
     Ok((response, downloaded_bytes, elapsed))
 }
@@ -400,7 +404,7 @@ async fn execute_http_request(
 /// and validate its headers and body.
 fn validate_response(
     response: HttpsOutcallResponse,
-) -> Result<CanisterHttpResponsePayload, (RejectCode, String)> {
+) -> Result<CanisterHttpResponsePayload, CanisterHttpReject> {
     let HttpsOutcallResponse {
         status,
         headers,
@@ -418,11 +422,9 @@ fn validate_response(
             body,
         };
     validate_http_headers_and_body(&canister_http_payload.headers, &canister_http_payload.body)
-        .map_err(|e| {
-            (
-                RejectCode::SysFatal,
-                UserError::from(e).description().to_string(),
-            )
+        .map_err(|e| CanisterHttpReject {
+            reject_code: RejectCode::SysFatal,
+            message: UserError::from(e).description().to_string(),
         })?;
     Ok(canister_http_payload)
 }
@@ -435,7 +437,7 @@ async fn transform_adapter_response(
     canister_http_response: CanisterHttpResponsePayload,
     transform_canister: CanisterId,
     transform: &Transform,
-) -> (Result<Vec<u8>, (RejectCode, String)>, u64) {
+) -> (Result<Vec<u8>, CanisterHttpReject>, u64) {
     let transform_limit = budget.get_transform_limit();
 
     let transform_args = TransformArgs {
@@ -448,12 +450,13 @@ async fn transform_adapter_response(
     let instruction_observation_clone = instruction_observation.clone();
 
     let execution_result = async move {
-        let method_payload = Encode!(&transform_args).map_err(|encode_error| {
-            (
-                RejectCode::SysFatal,
-                format!("Failed to parse http response to 'http_response' candid: {encode_error}"),
-            )
-        })?;
+        let method_payload =
+            Encode!(&transform_args).map_err(|encode_error| CanisterHttpReject {
+                reject_code: RejectCode::SysFatal,
+                message: format!(
+                    "Failed to parse http response to 'http_response' candid: {encode_error}"
+                ),
+            })?;
 
         let query = Query {
             source: QuerySource::System,
@@ -473,23 +476,28 @@ async fn transform_adapter_response(
                 Ok((res, _time)) => match res {
                     Ok(wasm_result) => match wasm_result {
                         WasmResult::Reply(reply) => Ok(reply),
-                        WasmResult::Reject(reject_message) => {
-                            Err((RejectCode::CanisterReject, reject_message))
-                        }
+                        WasmResult::Reject(reject_message) => Err(CanisterHttpReject {
+                            reject_code: RejectCode::CanisterReject,
+                            message: reject_message,
+                        }),
                     },
-                    Err(user_error) => Err((user_error.reject_code(), user_error.to_string())),
+                    Err(user_error) => Err(CanisterHttpReject {
+                        reject_code: user_error.reject_code(),
+                        message: user_error.to_string(),
+                    }),
                 },
-                Err(query_execution_error) => {
-                    Err((RejectCode::SysTransient, query_execution_error.to_string()))
-                }
+                Err(query_execution_error) => Err(CanisterHttpReject {
+                    reject_code: RejectCode::SysTransient,
+                    message: query_execution_error.to_string(),
+                }),
             },
-            Err(err) => Err((
-                RejectCode::SysFatal,
-                format!(
+            Err(err) => Err(CanisterHttpReject {
+                reject_code: RejectCode::SysFatal,
+                message: format!(
                     "Calling transform function '{}' failed: {}",
                     transform.method_name, err
                 ),
-            )),
+            }),
         }
     }
     .await;
@@ -504,7 +512,10 @@ async fn transform_adapter_response(
             "Transform should fail if insufficient cycles"
         );
         (
-            Err((RejectCode::SysFatal, "Insufficient cycles".to_string())),
+            Err(CanisterHttpReject {
+                reject_code: RejectCode::SysFatal,
+                message: "Insufficient cycles".to_string(),
+            }),
             instructions_used,
         )
     } else {

--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -1,6 +1,5 @@
 use crate::metrics::Metrics;
 use candid::Encode;
-use futures::future::TryFutureExt;
 use ic_error_types::{RejectCode, UserError};
 use ic_https_outcalls_pricing::{
     AdapterLimits, BudgetTracker, NetworkUsage, PricingError, PricingFactory,
@@ -18,9 +17,9 @@ use ic_metrics::MetricsRegistry;
 use ic_types::{
     CanisterId, NumBytes, NumInstructions,
     canister_http::{
-        CanisterHttpMethod, CanisterHttpReject, CanisterHttpRequest, CanisterHttpRequestContext,
-        CanisterHttpResponse, CanisterHttpResponseContent, Transform,
-        validate_http_headers_and_body,
+        CanisterHttpHeader, CanisterHttpMethod, CanisterHttpPaymentReceipt, CanisterHttpReject,
+        CanisterHttpRequest, CanisterHttpRequestContext, CanisterHttpResponse,
+        CanisterHttpResponseContent, Transform, validate_http_headers_and_body,
     },
     ingress::WasmResult,
     messages::{Query, QuerySource, Request},
@@ -45,7 +44,7 @@ use tracing::instrument;
 pub struct BrokenCanisterHttpClient {}
 
 impl NonBlockingChannel<CanisterHttpRequest> for BrokenCanisterHttpClient {
-    type Response = CanisterHttpResponse;
+    type Response = (CanisterHttpResponse, CanisterHttpPaymentReceipt);
     fn send(
         &self,
         _canister_http_request: CanisterHttpRequest,
@@ -53,7 +52,7 @@ impl NonBlockingChannel<CanisterHttpRequest> for BrokenCanisterHttpClient {
         Err(SendError::BrokenConnection)
     }
 
-    fn try_receive(&mut self) -> Result<CanisterHttpResponse, TryReceiveError> {
+    fn try_receive(&mut self) -> Result<Self::Response, TryReceiveError> {
         Err(TryReceiveError::Empty)
     }
 }
@@ -62,8 +61,8 @@ impl NonBlockingChannel<CanisterHttpRequest> for BrokenCanisterHttpClient {
 pub struct CanisterHttpAdapterClientImpl {
     rt_handle: Handle,
     grpc_channel: Channel,
-    tx: Sender<CanisterHttpResponse>,
-    rx: Receiver<CanisterHttpResponse>,
+    tx: Sender<(CanisterHttpResponse, CanisterHttpPaymentReceipt)>,
+    rx: Receiver<(CanisterHttpResponse, CanisterHttpPaymentReceipt)>,
     query_service: TransformExecutionService,
     metrics: Metrics,
     log: ReplicaLogger,
@@ -93,7 +92,7 @@ impl CanisterHttpAdapterClientImpl {
 }
 
 impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
-    type Response = CanisterHttpResponse;
+    type Response = (CanisterHttpResponse, CanisterHttpPaymentReceipt);
     /// Enqueues a request that will be send to the canister http adapter iff we don't have
     /// more than 'inflight_requests' requests waiting to be consumed by the
     /// client.
@@ -129,30 +128,30 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
         // Once final response is available send the response over to the channel making it available to the client.
 
         self.rt_handle.spawn(async move {
-            let mut budget = PricingFactory::new_tracker(&canister_http_request.context);
-
-            let request_size = canister_http_request.context.variable_parts_size();
-            // Destruct canister http request to avoid partial moves of the canister http request.
             let CanisterHttpRequest {
                 id: request_id,
-                context:
-                    CanisterHttpRequestContext {
-                        request:
-                            Request {
-                                sender: request_sender,
-                                sender_reply_callback: reply_callback_id,
-                                ..
-                            },
-                        url: request_url,
-                        headers: request_headers,
-                        body: request_body,
-                        http_method: request_http_method,
-                        transform: request_transform,
-                        pricing_version: request_pricing_version,
-                        ..
-                    },
+                context: request_context,
                 socks_proxy_addrs,
             } = canister_http_request;
+
+            let mut budget = PricingFactory::new_tracker(&request_context);
+            let request_size = request_context.variable_parts_size();
+
+            let CanisterHttpRequestContext {
+                request:
+                    Request {
+                        sender: request_sender,
+                        sender_reply_callback: reply_callback_id,
+                        ..
+                    },
+                url: request_url,
+                headers: request_headers,
+                body: request_body,
+                http_method: request_http_method,
+                transform: request_transform,
+                pricing_version: request_pricing_version,
+                ..
+            } = request_context;
 
             if request_pricing_version == ic_types::canister_http::PricingVersion::PayAsYouGo {
                 warn!(
@@ -163,137 +162,50 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                     request_sender,
                     std::process::id(),
                 );
-                let _ = permit.send(CanisterHttpResponse {
-                    id: request_id,
-                    canister_id: request_sender,
-                    content: CanisterHttpResponseContent::Reject(CanisterHttpReject {
-                        reject_code: RejectCode::SysFatal,
-                        message: "Canister HTTP request with PayAsYouGo pricing is not supported"
-                            .to_string(),
-                    }),
-                });
+                let _ = permit.send((
+                    CanisterHttpResponse {
+                        id: request_id,
+                        canister_id: request_sender,
+                        content: CanisterHttpResponseContent::Reject(CanisterHttpReject {
+                            reject_code: RejectCode::SysFatal,
+                            message:
+                                "Canister HTTP request with PayAsYouGo pricing is not supported"
+                                    .to_string(),
+                        }),
+                    },
+                    budget.create_payment_receipt(),
+                ));
                 return;
             }
 
-            let AdapterLimits {
-                max_response_size,
-                max_response_time,
-            } = budget.get_adapter_limits();
-            let max_response_size_bytes = max_response_size.get();
-
-            // Build future that sends and transforms request.
-            let adapter_canister_http_response = async move {
-                let (result, elapsed) = timeout_with_capped_metric(
-                    max_response_time,
-                    http_adapter_client.https_outcall(HttpsOutcallRequest {
-                        url: request_url,
-                        method: match request_http_method {
-                            CanisterHttpMethod::GET => HttpMethod::Get.into(),
-                            CanisterHttpMethod::POST => HttpMethod::Post.into(),
-                            CanisterHttpMethod::HEAD => HttpMethod::Head.into(),
-                            CanisterHttpMethod::PUT => HttpMethod::Put.into(),
-                            CanisterHttpMethod::DELETE => HttpMethod::Delete.into(),
-                        },
-                        max_response_size_bytes,
-                        headers: request_headers
-                            .into_iter()
-                            .map(|h| HttpHeader {
-                                name: h.name,
-                                value: h.value,
-                            })
-                            .collect(),
-                        body: request_body.unwrap_or_default(),
-                        socks_proxy_addrs,
-                    }),
+            let payload = async {
+                // Execute the HTTP request and get the adapter response.
+                let (adapter_response, downloaded_bytes, elapsed) = execute_http_request(
+                    &mut http_adapter_client,
+                    request_url,
+                    request_http_method,
+                    request_headers,
+                    request_body,
+                    socks_proxy_addrs,
+                    &mut budget,
                 )
-                .await
-                .map_err(|_: tokio::time::error::Elapsed| {
-                    tonic::Status::new(Code::DeadlineExceeded, "Deadline Exceeded")
-                })?;
+                .await?;
 
-                result.map(|res| (res, elapsed))
-            }
-            .map_err(|grpc_status| {
-                (
-                    grpc_status_code_to_reject(grpc_status.code()),
-                    grpc_status.message().to_string(),
-                )
-            })
-            .and_then(|(adapter_response, elapsed)| async move {
-                let HttpsOutcallResult {
-                    metrics: adapter_metrics,
-                    result,
-                } = adapter_response.into_inner();
-
-                let network_usage = NetworkUsage {
-                    response_size: NumBytes::from(
-                        adapter_metrics.map_or(0, |m| m.downloaded_bytes),
-                    ),
-                    response_time: elapsed,
-                };
-
-                budget.subtract_network_usage(network_usage).map_err(
-                    |PricingError::InsufficientCycles| {
-                        (RejectCode::SysFatal, "Insufficient cycles".to_string())
-                    },
-                )?;
-
-                let response = match result {
-                    Some(https_outcall_result::Result::Response(https_outcall_response)) => {
-                        Ok(https_outcall_response)
-                    }
-                    Some(https_outcall_result::Result::Error(canister_http_error)) => {
-                        let code = match canister_http_error.kind() {
-                            CanisterHttpErrorKind::InvalidInput => RejectCode::SysFatal,
-                            CanisterHttpErrorKind::Connection => RejectCode::SysTransient,
-                            CanisterHttpErrorKind::LimitExceeded => RejectCode::SysFatal,
-                            CanisterHttpErrorKind::Internal => RejectCode::SysTransient,
-                            CanisterHttpErrorKind::Unspecified => RejectCode::SysFatal,
-                        };
-                        Err((code, canister_http_error.message))
-                    }
-                    None => Err((
-                        RejectCode::SysFatal,
-                        "Adapter returned empty result".to_string(),
-                    )),
-                }?;
-
-                let HttpsOutcallResponse {
-                    status,
-                    headers,
-                    content: body,
-                } = response;
-
-                let canister_http_payload = CanisterHttpResponsePayload {
-                    status: status as u128,
-                    headers: headers
-                        .into_iter()
-                        .map(|HttpHeader { name, value }| {
-                            ic_management_canister_types_private::HttpHeader { name, value }
-                        })
-                        .collect(),
-                    body,
-                };
+                // Validate and convert the adapter response.
+                let canister_http_payload = validate_response(adapter_response)?;
 
                 metrics
                     .http_request_duration
-                    .with_label_values(&[status.to_string().as_str(), request_http_method.as_str()])
+                    .with_label_values(&[
+                        canister_http_payload.status.to_string().as_str(),
+                        request_http_method.as_str(),
+                    ])
                     .observe(elapsed.as_secs_f64());
-
-                validate_http_headers_and_body(
-                    &canister_http_payload.headers,
-                    &canister_http_payload.body,
-                )
-                .map_err(|e| {
-                    (
-                        RejectCode::SysFatal,
-                        UserError::from(e).description().to_string(),
-                    )
-                })?;
 
                 // Only apply the transform if a function name is specified
                 let transform_timer = metrics.transform_execution_duration.start_timer();
-                let transform_response = match &request_transform {
+                let max_response_size_bytes = budget.get_adapter_limits().max_response_size.get();
+                let transformed_payload = match &request_transform {
                     Some(transform) => {
                         let (transform_result, instruction_count) = transform_adapter_response(
                             &mut budget,
@@ -316,7 +228,7 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                             transform_instructions_used: {}, max_response_size: {}",
                             request_size,
                             elapsed.as_millis(),
-                            adapter_metrics.map_or(0, |m| m.downloaded_bytes),
+                            downloaded_bytes,
                             reply_callback_id,
                             request_sender,
                             std::process::id(),
@@ -344,39 +256,43 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
                         )
                     }),
                 };
-
                 transform_timer.observe_duration();
+                transformed_payload
+            }
+            .await;
 
-                transform_response
-            });
+            // Create the payment receipt after all processing is complete.
+            let receipt = budget.create_payment_receipt();
 
-            // Drive created future to completion and make response available on the channel.
-            permit.send(CanisterHttpResponse {
-                id: request_id,
-                canister_id: request_sender,
-                content: match adapter_canister_http_response.await {
-                    Ok(resp) => {
-                        metrics
-                            .request_total
-                            .with_label_values(&["success", request_http_method.as_str()])
-                            .inc();
-                        CanisterHttpResponseContent::Success(resp)
-                    }
-                    Err((reject_code, message)) => {
-                        metrics
-                            .request_total
-                            .with_label_values(&[
-                                reject_code.as_str(),
-                                request_http_method.as_str(),
-                            ])
-                            .inc();
-                        CanisterHttpResponseContent::Reject(CanisterHttpReject {
-                            reject_code,
-                            message,
-                        })
-                    }
+            permit.send((
+                CanisterHttpResponse {
+                    id: request_id,
+                    canister_id: request_sender,
+                    content: match payload {
+                        Ok(resp) => {
+                            metrics
+                                .request_total
+                                .with_label_values(&["success", request_http_method.as_str()])
+                                .inc();
+                            CanisterHttpResponseContent::Success(resp)
+                        }
+                        Err((reject_code, message)) => {
+                            metrics
+                                .request_total
+                                .with_label_values(&[
+                                    reject_code.as_str(),
+                                    request_http_method.as_str(),
+                                ])
+                                .inc();
+                            CanisterHttpResponseContent::Reject(CanisterHttpReject {
+                                reject_code,
+                                message,
+                            })
+                        }
+                    },
                 },
-            });
+                receipt,
+            ));
         });
         Ok(())
     }
@@ -392,6 +308,124 @@ impl NonBlockingChannel<CanisterHttpRequest> for CanisterHttpAdapterClientImpl {
             }
         })
     }
+}
+
+/// Sends the HTTPS outcall via the adapter and accounts for the network
+/// resources consumed against `budget`. Returns the raw adapter response,
+/// the number of bytes downloaded as reported by the adapter, and the
+/// elapsed wall-clock duration as measured by the client.
+async fn execute_http_request(
+    adapter_client: &mut HttpsOutcallsServiceClient<Channel>,
+    url: String,
+    http_method: CanisterHttpMethod,
+    headers: Vec<CanisterHttpHeader>,
+    body: Option<Vec<u8>>,
+    socks_proxy_addrs: Vec<String>,
+    budget: &mut Box<dyn BudgetTracker>,
+) -> Result<(HttpsOutcallResponse, NumBytes, Duration), (RejectCode, String)> {
+    let AdapterLimits {
+        max_response_size,
+        max_response_time,
+    } = budget.get_adapter_limits();
+
+    let proto_req = HttpsOutcallRequest {
+        url,
+        method: match http_method {
+            CanisterHttpMethod::GET => HttpMethod::Get.into(),
+            CanisterHttpMethod::POST => HttpMethod::Post.into(),
+            CanisterHttpMethod::HEAD => HttpMethod::Head.into(),
+            CanisterHttpMethod::PUT => HttpMethod::Put.into(),
+            CanisterHttpMethod::DELETE => HttpMethod::Delete.into(),
+        },
+        max_response_size_bytes: max_response_size.get(),
+        headers: headers
+            .into_iter()
+            .map(|h| HttpHeader {
+                name: h.name,
+                value: h.value,
+            })
+            .collect(),
+        body: body.unwrap_or_default(),
+        socks_proxy_addrs,
+    };
+
+    let (grpc_result, elapsed) =
+        timeout_with_capped_metric(max_response_time, adapter_client.https_outcall(proto_req))
+            .await
+            .map_err(|_| (RejectCode::SysTransient, "Deadline Exceeded".to_string()))?;
+    let adapter_response = grpc_result.map_err(|grpc_status| {
+        (
+            grpc_status_code_to_reject(grpc_status.code()),
+            grpc_status.message().to_string(),
+        )
+    })?;
+    let HttpsOutcallResult {
+        metrics: adapter_metrics,
+        result,
+    } = adapter_response.into_inner();
+
+    let downloaded_bytes = NumBytes::from(adapter_metrics.map_or(0, |m| m.downloaded_bytes));
+
+    budget
+        .subtract_network_usage(NetworkUsage {
+            response_size: downloaded_bytes,
+            response_time: elapsed,
+        })
+        .map_err(|PricingError::InsufficientCycles| {
+            (RejectCode::SysFatal, "Insufficient cycles".to_string())
+        })?;
+
+    let response = match result {
+        Some(https_outcall_result::Result::Response(https_outcall_response)) => {
+            Ok(https_outcall_response)
+        }
+        Some(https_outcall_result::Result::Error(canister_http_error)) => {
+            let code = match canister_http_error.kind() {
+                CanisterHttpErrorKind::InvalidInput => RejectCode::SysFatal,
+                CanisterHttpErrorKind::Connection => RejectCode::SysTransient,
+                CanisterHttpErrorKind::LimitExceeded => RejectCode::SysFatal,
+                CanisterHttpErrorKind::Internal => RejectCode::SysTransient,
+                CanisterHttpErrorKind::Unspecified => RejectCode::SysFatal,
+            };
+            Err((code, canister_http_error.message))
+        }
+        None => Err((
+            RejectCode::SysFatal,
+            "Adapter returned empty result".to_string(),
+        )),
+    }?;
+    Ok((response, downloaded_bytes, elapsed))
+}
+
+/// Convert the raw adapter response into a [`CanisterHttpResponsePayload`]
+/// and validate its headers and body.
+fn validate_response(
+    response: HttpsOutcallResponse,
+) -> Result<CanisterHttpResponsePayload, (RejectCode, String)> {
+    let HttpsOutcallResponse {
+        status,
+        headers,
+        content: body,
+    } = response;
+    let canister_http_payload =
+        CanisterHttpResponsePayload {
+            status: status as u128,
+            headers: headers
+                .into_iter()
+                .map(|HttpHeader { name, value }| {
+                    ic_management_canister_types_private::HttpHeader { name, value }
+                })
+                .collect(),
+            body,
+        };
+    validate_http_headers_and_body(&canister_http_payload.headers, &canister_http_payload.body)
+        .map_err(|e| {
+            (
+                RejectCode::SysFatal,
+                UserError::from(e).description().to_string(),
+            )
+        })?;
+    Ok(canister_http_payload)
 }
 
 /// Make upcall to execution to transform the response.
@@ -739,9 +773,9 @@ mod tests {
         loop {
             match client.try_receive() {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
-                Ok(r) => {
+                Ok((response, payment_receipt)) => {
                     assert_eq!(
-                        r,
+                        response,
                         build_mock_canister_http_response_success(
                             420,
                             200,
@@ -749,6 +783,8 @@ mod tests {
                             adapter_body
                         )
                     );
+                    // Legacy pricing always produces an empty receipt.
+                    assert_eq!(payment_receipt, CanisterHttpPaymentReceipt::default());
                     break;
                 }
             }
@@ -788,7 +824,7 @@ mod tests {
         loop {
             match client.try_receive() {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
-                Ok(r) => {
+                Ok((r, _payment_receipt)) => {
                     assert_eq!(
                         r,
                         build_mock_canister_http_response_reject(
@@ -850,7 +886,7 @@ mod tests {
         loop {
             match client.try_receive() {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
-                Ok(r) => {
+                Ok((r, _payment_receipt)) => {
                     assert_eq!(
                         r,
                         build_mock_canister_http_response_reject(
@@ -903,7 +939,7 @@ mod tests {
         loop {
             match client.try_receive() {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
-                Ok(r) => {
+                Ok((r, _payment_receipt)) => {
                     assert_eq!(
                         r,
                         build_mock_canister_http_response_reject(
@@ -992,7 +1028,7 @@ mod tests {
         loop {
             match client.try_receive() {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
-                Ok(r) => {
+                Ok((r, _payment_receipt)) => {
                     assert_eq!(
                         r,
                         build_mock_canister_http_response_success(
@@ -1061,7 +1097,7 @@ mod tests {
         loop {
             match client.try_receive() {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
-                Ok(r) => {
+                Ok((r, _payment_receipt)) => {
                     assert_eq!(
                         r,
                         build_mock_canister_http_response_reject(
@@ -1120,7 +1156,7 @@ mod tests {
         loop {
             match client.try_receive() {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
-                Ok(r) => {
+                Ok((r, _payment_receipt)) => {
                     assert_eq!(
                         r,
                         build_mock_canister_http_response_reject(
@@ -1142,7 +1178,7 @@ mod tests {
         loop {
             match client.try_receive() {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
-                Ok(r) => {
+                Ok((r, _payment_receipt)) => {
                     assert_eq!(
                         r,
                         build_mock_canister_http_response_reject(
@@ -1158,7 +1194,7 @@ mod tests {
         loop {
             match client.try_receive() {
                 Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
-                Ok(r) => {
+                Ok((r, _payment_receipt)) => {
                     assert_eq!(
                         r,
                         build_mock_canister_http_response_reject(

--- a/rs/https_outcalls/client/src/lib.rs
+++ b/rs/https_outcalls/client/src/lib.rs
@@ -11,7 +11,9 @@ use ic_interfaces::execution_environment::TransformExecutionService;
 use ic_interfaces_adapter_client::NonBlockingChannel;
 use ic_logger::{ReplicaLogger, error, info};
 use ic_metrics::MetricsRegistry;
-use ic_types::canister_http::{CanisterHttpRequest, CanisterHttpResponse};
+use ic_types::canister_http::{
+    CanisterHttpPaymentReceipt, CanisterHttpRequest, CanisterHttpResponse,
+};
 use std::convert::TryFrom;
 use tokio::net::UnixStream;
 use tonic::transport::{Endpoint, Uri};
@@ -24,7 +26,12 @@ pub fn setup_canister_http_client(
     transform_handler: TransformExecutionService,
     max_canister_http_requests_in_flight: usize,
     log: ReplicaLogger,
-) -> Box<dyn NonBlockingChannel<CanisterHttpRequest, Response = CanisterHttpResponse> + Send> {
+) -> Box<
+    dyn NonBlockingChannel<
+            CanisterHttpRequest,
+            Response = (CanisterHttpResponse, CanisterHttpPaymentReceipt),
+        > + Send,
+> {
     match adapter_config.https_outcalls_uds_path {
         None => {
             error!(

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -32,8 +32,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-pub type CanisterHttpAdapterClient =
-    Box<dyn NonBlockingChannel<CanisterHttpRequest, Response = CanisterHttpResponse> + Send>;
+pub type CanisterHttpAdapterClient = Box<
+    dyn NonBlockingChannel<
+            CanisterHttpRequest,
+            Response = (CanisterHttpResponse, CanisterHttpPaymentReceipt),
+        > + Send,
+>;
 
 /// [`CanisterHttpPoolManagerImpl`] implements the pool and state monitoring
 /// functionality that is necessary to ensure that http requests are made and
@@ -340,7 +344,7 @@ impl CanisterHttpPoolManagerImpl {
         loop {
             match self.http_adapter_shim.lock().unwrap().try_receive() {
                 Err(TryReceiveError::Empty) => break,
-                Ok(mut response) => {
+                Ok((mut response, _payment_receipt)) => {
                     // Drop the response if its context is no longer present in the replicated state
                     // (e.g. the request has timed out or has already been answered by enough other nodes).
                     let Some(context) = active_contexts.get(&response.id) else {
@@ -716,10 +720,12 @@ pub mod test {
         }
 
         impl<Request> NonBlockingChannel<Request> for NonBlockingChannel<Request> {
-            type Response = CanisterHttpResponse;
+            type Response = (CanisterHttpResponse, CanisterHttpPaymentReceipt);
 
             fn send(&self, request: Request) -> Result<(), SendError<Request>>;
-            fn try_receive(&mut self) -> Result<CanisterHttpResponse, TryReceiveError>;
+            fn try_receive(
+                &mut self,
+            ) -> Result<(CanisterHttpResponse, CanisterHttpPaymentReceipt), TryReceiveError>;
         }
     }
 
@@ -1842,7 +1848,12 @@ pub mod test {
                 shim_mock
                     .expect_try_receive()
                     .times(1)
-                    .returning(move || Ok(oversized_response.clone()))
+                    .returning(move || {
+                        Ok((
+                            oversized_response.clone(),
+                            CanisterHttpPaymentReceipt::default(),
+                        ))
+                    })
                     .in_sequence(&mut sequence);
                 shim_mock
                     .expect_try_receive()
@@ -1964,7 +1975,12 @@ pub mod test {
                 shim_mock
                     .expect_try_receive()
                     .times(1)
-                    .return_once(move || Ok(oversized_response.clone()));
+                    .return_once(move || {
+                        Ok((
+                            oversized_response.clone(),
+                            CanisterHttpPaymentReceipt::default(),
+                        ))
+                    });
                 shim_mock
                     .expect_try_receive()
                     .return_const(Err(TryReceiveError::Empty));
@@ -2388,7 +2404,12 @@ pub mod test {
                     shim_mock
                         .expect_try_receive()
                         .times(1)
-                        .returning(move || Ok(empty_canister_http_response(i)))
+                        .returning(move || {
+                            Ok((
+                                empty_canister_http_response(i),
+                                CanisterHttpPaymentReceipt::default(),
+                            ))
+                        })
                         .in_sequence(&mut sequence);
                 }
 
@@ -2467,7 +2488,12 @@ pub mod test {
                     shim_mock
                         .expect_try_receive()
                         .times(1)
-                        .returning(move || Ok(empty_canister_http_response(id.get())))
+                        .returning(move || {
+                            Ok((
+                                empty_canister_http_response(id.get()),
+                                CanisterHttpPaymentReceipt::default(),
+                            ))
+                        })
                         .in_sequence(&mut sequence);
                 }
                 shim_mock
@@ -2562,7 +2588,12 @@ pub mod test {
                 shim_mock
                     .expect_try_receive()
                     .times(1)
-                    .returning(move || Ok(empty_canister_http_response(callback_id.get())))
+                    .returning(move || {
+                        Ok((
+                            empty_canister_http_response(callback_id.get()),
+                            CanisterHttpPaymentReceipt::default(),
+                        ))
+                    })
                     .in_sequence(&mut sequence);
                 shim_mock
                     .expect_try_receive()
@@ -3322,7 +3353,10 @@ pub mod test {
                 shim_mock
                     .expect_try_receive()
                     .times(1)
-                    .return_const(Ok(empty_response.clone()))
+                    .return_const(Ok((
+                        empty_response.clone(),
+                        CanisterHttpPaymentReceipt::default(),
+                    )))
                     .in_sequence(&mut sequence);
                 shim_mock
                     .expect_try_receive()

--- a/rs/https_outcalls/pricing/src/legacy.rs
+++ b/rs/https_outcalls/pricing/src/legacy.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
 use ic_config::subnet_config::MAX_INSTRUCTIONS_PER_QUERY_MESSAGE;
-use ic_types::{NumBytes, NumInstructions, canister_http::MAX_CANISTER_HTTP_RESPONSE_BYTES};
+use ic_types::{
+    NumBytes, NumInstructions,
+    canister_http::{CanisterHttpPaymentReceipt, MAX_CANISTER_HTTP_RESPONSE_BYTES},
+};
 
 use crate::{AdapterLimits, BudgetTracker, NetworkUsage, PricingError};
 
@@ -40,5 +43,11 @@ impl BudgetTracker for LegacyTracker {
 
     fn subtract_transform_usage(&mut self, _usage: NumInstructions) -> Result<(), PricingError> {
         Ok(())
+    }
+
+    fn create_payment_receipt(&self) -> CanisterHttpPaymentReceipt {
+        // Legacy pricing does not perform cycles accounting, so no cycles
+        // are ever refunded.
+        CanisterHttpPaymentReceipt::default()
     }
 }

--- a/rs/https_outcalls/pricing/src/lib.rs
+++ b/rs/https_outcalls/pricing/src/lib.rs
@@ -2,7 +2,10 @@ mod legacy;
 
 use std::time::Duration;
 
-use ic_types::{NumBytes, NumInstructions, canister_http::CanisterHttpRequestContext};
+use ic_types::{
+    NumBytes, NumInstructions,
+    canister_http::{CanisterHttpPaymentReceipt, CanisterHttpRequestContext},
+};
 use legacy::LegacyTracker;
 
 pub trait BudgetTracker: Send {
@@ -23,6 +26,10 @@ pub trait BudgetTracker: Send {
     /// # Invariants
     ///  - This method returns `Ok(())` if and only if `usage <= get_transform_limit()`.
     fn subtract_transform_usage(&mut self, usage: NumInstructions) -> Result<(), PricingError>;
+    /// Produces the per-replica payment receipt that summarizes the cycles
+    /// accounting outcome of the outcall, given the resources consumed so
+    /// far via the `subtract_*` methods.
+    fn create_payment_receipt(&self) -> CanisterHttpPaymentReceipt;
 }
 
 pub struct AdapterLimits {

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -119,9 +119,9 @@ use ic_types::{
     CanisterId, Height, NumInstructions, PrincipalId, RegistryVersion, SnapshotId, SubnetId,
     artifact::UnvalidatedArtifactMutation,
     canister_http::{
-        CanisterHttpReject, CanisterHttpRequest as AdapterCanisterHttpRequest,
-        CanisterHttpRequestId, CanisterHttpResponse as AdapterCanisterHttpResponse,
-        CanisterHttpResponseContent,
+        CanisterHttpPaymentReceipt, CanisterHttpReject,
+        CanisterHttpRequest as AdapterCanisterHttpRequest, CanisterHttpRequestId,
+        CanisterHttpResponse as AdapterCanisterHttpResponse, CanisterHttpResponseContent,
     },
     crypto::{BasicSig, BasicSigOf, CryptoResult, Signable, threshold_sig::IcRootOfTrust},
     malicious_flags::MaliciousFlags,
@@ -456,7 +456,7 @@ pub(crate) type CanisterHttpClient = Arc<
         Box<
             dyn NonBlockingChannel<
                     AdapterCanisterHttpRequest,
-                    Response = AdapterCanisterHttpResponse,
+                    Response = (AdapterCanisterHttpResponse, CanisterHttpPaymentReceipt),
                 > + Send,
         >,
     >,
@@ -3596,7 +3596,7 @@ impl Operation for ProcessCanisterHttpInternal {
                     Err(_) => {
                         break;
                     }
-                    Ok(response) => {
+                    Ok((response, _payment_receipt)) => {
                         canister_http.pending.remove(&response.id);
                         if let Some(context) = sm.canister_http_request_contexts().get(&response.id)
                         {
@@ -3766,7 +3766,7 @@ fn process_mock_canister_https_response(
             let response = loop {
                 match client.try_receive() {
                     Err(_) => std::thread::sleep(Duration::from_millis(10)),
-                    Ok(r) => {
+                    Ok((r, _payment_receipt)) => {
                         break r;
                     }
                 }

--- a/rs/protobuf/def/types/v1/canister_http.proto
+++ b/rs/protobuf/def/types/v1/canister_http.proto
@@ -2,8 +2,13 @@ syntax = "proto3";
 
 package types.v1;
 
+import "state/queues/v1/queues.proto";
 import "types/v1/errors.proto";
 import "types/v1/types.proto";
+
+message CanisterHttpPaymentReceipt {
+  state.queues.v1.Cycles refund = 1;
+}
 
 message HttpHeader {
   string name = 1;

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -518,6 +518,11 @@ pub struct ThresholdSignatureShare {
     pub signer: ::core::option::Option<NodeId>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CanisterHttpPaymentReceipt {
+    #[prost(message, optional, tag = "1")]
+    pub refund: ::core::option::Option<super::super::state::queues::v1::Cycles>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HttpHeader {
     #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,

--- a/rs/replica/setup_ic_network/src/lib.rs
+++ b/rs/replica/setup_ic_network/src/lib.rs
@@ -49,7 +49,10 @@ use ic_state_manager::state_sync::types::StateSyncMessage;
 use ic_types::{
     NodeId, SubnetId,
     artifact::UnvalidatedArtifactMutation,
-    canister_http::{CanisterHttpRequest, CanisterHttpResponse, CanisterHttpResponseArtifact},
+    canister_http::{
+        CanisterHttpPaymentReceipt, CanisterHttpRequest, CanisterHttpResponse,
+        CanisterHttpResponseArtifact,
+    },
     consensus::{
         CatchUpPackage, ConsensusMessage, HasHeight, certification::CertificationMessage, dkg,
         idkg::IDkgMessage,
@@ -314,8 +317,12 @@ impl AbortableBroadcastChannels {
     }
 }
 
-pub type CanisterHttpAdapterClient =
-    Box<dyn NonBlockingChannel<CanisterHttpRequest, Response = CanisterHttpResponse> + Send>;
+pub type CanisterHttpAdapterClient = Box<
+    dyn NonBlockingChannel<
+            CanisterHttpRequest,
+            Response = (CanisterHttpResponse, CanisterHttpPaymentReceipt),
+        > + Send,
+>;
 
 /// The function constructs a P2P instance. Currently, it constructs all the
 /// artifact pools and the Consensus/P2P time source. Artifact

--- a/rs/types/types/src/batch/canister_http.rs
+++ b/rs/types/types/src/batch/canister_http.rs
@@ -1,9 +1,10 @@
 use crate::{
     CanisterId, CountBytes, ReplicaVersion,
     canister_http::{
-        CanisterHttpReject, CanisterHttpRequestId, CanisterHttpResponse,
-        CanisterHttpResponseArtifact, CanisterHttpResponseContent, CanisterHttpResponseDivergence,
-        CanisterHttpResponseMetadata, CanisterHttpResponseShare, CanisterHttpResponseWithConsensus,
+        CanisterHttpPaymentReceipt, CanisterHttpReject, CanisterHttpRequestId,
+        CanisterHttpResponse, CanisterHttpResponseArtifact, CanisterHttpResponseContent,
+        CanisterHttpResponseDivergence, CanisterHttpResponseMetadata, CanisterHttpResponseShare,
+        CanisterHttpResponseWithConsensus,
     },
     crypto::{BasicSig, BasicSigOf, CryptoHash, CryptoHashOf, Signed},
     messages::CallbackId,
@@ -178,6 +179,23 @@ impl CanisterHttpPayload {
     /// Returns true, if this is an empty payload
     pub fn is_empty(&self) -> bool {
         self.num_responses() == 0
+    }
+}
+
+impl From<CanisterHttpPaymentReceipt> for pb::CanisterHttpPaymentReceipt {
+    fn from(receipt: CanisterHttpPaymentReceipt) -> Self {
+        pb::CanisterHttpPaymentReceipt {
+            refund: Some(receipt.refund.into()),
+        }
+    }
+}
+
+impl TryFrom<pb::CanisterHttpPaymentReceipt> for CanisterHttpPaymentReceipt {
+    type Error = ProxyDecodeError;
+    fn try_from(receipt: pb::CanisterHttpPaymentReceipt) -> Result<Self, Self::Error> {
+        Ok(CanisterHttpPaymentReceipt {
+            refund: try_from_option_field(receipt.refund, "CanisterHttpPaymentReceipt::refund")?,
+        })
     }
 }
 

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -1007,6 +1007,23 @@ impl CountBytes for CanisterHttpResponseDivergence {
     }
 }
 
+/// A per-replica receipt describing the cycles accounting outcome for a
+/// single canister HTTP outcall.
+#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+#[cfg_attr(test, derive(ExhaustiveSet))]
+pub struct CanisterHttpPaymentReceipt {
+    /// The amount of cycles, out of the per-replica allowance, that the
+    /// replica did not use and wishes to refund to the caller.
+    pub refund: Cycles,
+}
+
+impl CountBytes for CanisterHttpPaymentReceipt {
+    fn count_bytes(&self) -> usize {
+        let Self { refund } = self;
+        size_of_val(refund)
+    }
+}
+
 /// Metadata about some [`CanisterHttpResponseContent`].
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 #[cfg_attr(test, derive(ExhaustiveSet))]


### PR DESCRIPTION
Currently, the price for an HTTP outcall is calculated and charged upfront. In the future, we want to implement a "pay-as-you-go" pricing model. This model assigns a fraction (budget) of the total attached cycles to each participating replica (per-replica allowance). This is captured by the `BudgetTracker`, which is instantiated by the adapter for each new HTTP request that is made.

As the request passes through the target server and the transform function, the adapter subtracts cycles from this budget, based on the amount of resources it consumed (download time, downloaded bytes, transform instructions).

In the end, the amount of remaining cycles (refund) is passed back to the replica together with the HTTP response.

This PR adds the struct representing this payment receipt, and a function of the budget tracker to create the receipt.

In the current (legacy) pricing model, nothing is refunded yet, so the returned refund is always 0. Furthermore, the receipt is still ignored by the replica.