### PR TITLE
fix: deflake //rs/dogecoin/ckdoge/minter:integration_tests

### DIFF
--- a/rs/dogecoin/ckdoge/minter/src/main.rs
+++ b/rs/dogecoin/ckdoge/minter/src/main.rs
@@ -2,7 +2,7 @@ use ic_cdk::{init, post_upgrade, query, update};
 use ic_ckbtc_minter::reimbursement::InvalidTransactionError;
 use ic_ckbtc_minter::state::eventlog::EventLogger;
 use ic_ckbtc_minter::tasks::{TaskType, schedule_now};
-use ic_ckbtc_minter::{BuildTxError, CanisterRuntime};
+use ic_ckbtc_minter::{BuildTxError, CanisterRuntime, fees::FeeEstimator};
 use ic_ckdoge_minter::candid_api::{EstimateWithdrawalFeeError, MinterInfo};
 use ic_ckdoge_minter::event::CkDogeEventLogger;
 use ic_ckdoge_minter::{
@@ -105,11 +105,16 @@ fn estimate_withdrawal_fee(
         let fee_estimator = DOGECOIN_CANISTER_RUNTIME.fee_estimator(s);
         let withdrawal_amount = arg.amount.unwrap_or(s.fee_based_retrieve_btc_min_amount);
 
+        let fee_rate = fee_estimator
+            .estimate_median_fee(&s.last_fee_per_vbyte)
+            .unwrap_or_else(|| {
+                s.last_median_fee_per_vbyte
+                    .expect("Bitcoin current fee percentiles not retrieved yet.")
+            });
         ic_ckdoge_minter::fees::estimate_retrieve_doge_fee(
             &mut s.available_utxos,
             withdrawal_amount,
-            s.last_median_fee_per_vbyte
-                .expect("Bitcoin current fee percentiles not retrieved yet."),
+            fee_rate,
             s.max_num_inputs_in_transaction,
             &fee_estimator,
         )


### PR DESCRIPTION
This PR attempts to deflake the test `//rs/dogecoin/ckdoge/minter:integration_tests`.

PLEASE REVIEW EXTRA CAREFULLY since this PR has been fully Claude-generated.

Now I understand the root cause completely:

  1. last_median_fee_per_vbyte is initialized to FeeRate::from_millis_per_byte(1) in the minter state
  2. It only updates when estimate_fee_per_vbyte successfully calls the Dogecoin canister
  3. During setup, RefreshFeePercentiles fires while the Dogecoin canister is still syncing blocks → fails → last_median_fee_per_vbyte stays at 1
  4. estimate_withdrawal_fee (called before the transaction is built) uses the stale 1 value
  5. Later, ProcessLogic fires after the Dogecoin canister is synced → succeeds → updates last_median_fee_per_vbyte to DEFAULT_REGTEST_FEE → transaction built with dogecoin_fee: 
  227000000

  The fix: use fee_estimator.estimate_median_fee(&s.last_fee_per_vbyte) instead of s.last_median_fee_per_vbyte. For Regtest, estimate_nth_fee ignores fee percentiles and always returns
   DEFAULT_REGTEST_FEE, so this correctly uses DEFAULT_REGTEST_FEE even before the first successful fee refresh.