### PR TITLE
chore: No longer generate attestation reports with old encoding

### DIFF
--- a/rs/ic_os/sev/guest/src/attestation_package.rs
+++ b/rs/ic_os/sev/guest/src/attestation_package.rs
@@ -19,14 +19,8 @@ pub fn generate_attestation_package<T: EncodeSevCustomData + Debug>(
     trusted_execution_environment_config: &TrustedExecutionEnvironmentConfig,
     custom_data: &T,
 ) -> Result<ParsedSevAttestationPackage> {
-    let custom_data_bytes = if T::needs_legacy_encoding() {
-        // TODO(NODE-1784): Move to new SEV encoding once clients are updated
-        custom_data.encode_for_sev_legacy()?
-    } else {
-        custom_data.encode_for_sev()?.to_bytes()
-    };
     let attestation_report = sev_firmware
-        .get_report(None, Some(custom_data_bytes), None)
+        .get_report(None, Some(custom_data.encode_for_sev()?.to_bytes()), None)
         .context("Failed to get attestation report from SEV firmware")?;
 
     let attestation_report = AttestationReport::from_bytes(&attestation_report)


### PR DESCRIPTION
Once this rolls out, we can stop accepting the legacy encoding.