### PR TITLE
feat(crypto): Introduce batched signature verification with multiple messages

### DIFF
--- a/rs/crypto/src/sign/basic_sig.rs
+++ b/rs/crypto/src/sign/basic_sig.rs
@@ -59,13 +59,41 @@ impl BasicSigVerifierInternal {
                 message: "Empty BasicSignatureBatch. At least one signature should be included in the batch.".to_string(),
             });
         };
+        let inputs: Vec<_> = signatures
+            .signatures_map
+            .iter()
+            .map(|(signer, signature)| (*signer, signature, message))
+            .collect();
+        Self::verify_basic_sigs_batch(csprng, registry, &inputs, registry_version)
+    }
 
-        let message = message.as_signed_bytes();
-        let mut msgs = Vec::with_capacity(signatures.signatures_map.len());
-        let mut sigs = Vec::with_capacity(signatures.signatures_map.len());
-        let mut keys = Vec::with_capacity(signatures.signatures_map.len());
+    /// Verifies a batch of basic signatures on potentially different messages.
+    ///
+    /// Unlike `verify_basic_sig_batch`, the entries in `inputs` may have
+    /// distinct messages, and the same `NodeId` may appear more than once.
+    pub fn verify_basic_sigs_batch<H: Signable, R: CryptoComponentRng>(
+        csprng: &CspRwLock<R>,
+        registry: &dyn RegistryClient,
+        inputs: &[(NodeId, &BasicSigOf<H>, &H)],
+        registry_version: RegistryVersion,
+    ) -> CryptoResult<()> {
+        if inputs.is_empty() {
+            return Err(CryptoError::InvalidArgument {
+                message:
+                    "Empty signature batch. At least one signature should be included in the batch."
+                        .to_string(),
+            });
+        };
 
-        for (signer, signature) in signatures.signatures_map.iter() {
+        let messages: Vec<Vec<u8>> = inputs
+            .iter()
+            .map(|(_, _, message)| message.as_signed_bytes())
+            .collect();
+        let mut msgs = Vec::with_capacity(inputs.len());
+        let mut sigs = Vec::with_capacity(inputs.len());
+        let mut keys = Vec::with_capacity(inputs.len());
+
+        for (i, (signer, signature, _)) in inputs.iter().enumerate() {
             let pk_proto =
                 key_from_registry(registry, *signer, KeyPurpose::NodeSigning, registry_version)?;
 
@@ -85,7 +113,7 @@ impl BasicSigVerifierInternal {
                 }
             })?;
 
-            msgs.push(&message[..]);
+            msgs.push(&messages[i][..]);
             sigs.push(&signature.get_ref().0[..]);
             keys.push(pk);
         }

--- a/rs/crypto/src/sign/basic_sig.rs
+++ b/rs/crypto/src/sign/basic_sig.rs
@@ -59,19 +59,25 @@ impl BasicSigVerifierInternal {
                 message: "Empty BasicSignatureBatch. At least one signature should be included in the batch.".to_string(),
             });
         };
-        let inputs: Vec<_> = signatures
-            .signatures_map
-            .iter()
-            .map(|(signer, signature)| (*signer, signature, message))
-            .collect();
-        Self::verify_basic_sigs_batch(csprng, registry, &inputs, registry_version)
+        // Compute the signed bytes once, since all signatures share the same
+        // message.
+        let message_bytes = message.as_signed_bytes();
+        Self::verify_basic_sig_batch_internal(
+            csprng,
+            registry,
+            signatures
+                .signatures_map
+                .iter()
+                .map(|(signer, signature)| (*signer, signature, message_bytes.as_slice())),
+            registry_version,
+        )
     }
 
     /// Verifies a batch of basic signatures on potentially different messages.
     ///
     /// Unlike `verify_basic_sig_batch`, the entries in `inputs` may have
     /// distinct messages, and the same `NodeId` may appear more than once.
-    pub fn verify_basic_sigs_batch<H: Signable, R: CryptoComponentRng>(
+    pub fn verify_basic_sig_batch_multi_msg<H: Signable, R: CryptoComponentRng>(
         csprng: &CspRwLock<R>,
         registry: &dyn RegistryClient,
         inputs: &[(NodeId, &BasicSigOf<H>, &H)],
@@ -84,18 +90,36 @@ impl BasicSigVerifierInternal {
                         .to_string(),
             });
         };
-
-        let messages: Vec<Vec<u8>> = inputs
+        // Serialize each message once and keep the owned buffers alive so we
+        // can borrow them into the helper's input iterator.
+        let entries: Vec<(NodeId, &BasicSigOf<H>, Vec<u8>)> = inputs
             .iter()
-            .map(|(_, _, message)| message.as_signed_bytes())
+            .map(|(signer, signature, message)| (*signer, *signature, message.as_signed_bytes()))
             .collect();
+        Self::verify_basic_sig_batch_internal(
+            csprng,
+            registry,
+            entries
+                .iter()
+                .map(|(signer, signature, msg_bytes)| (*signer, *signature, msg_bytes.as_slice())),
+            registry_version,
+        )
+    }
+
+    /// Shared implementation of batched Ed25519 basic-sig verification.
+    fn verify_basic_sig_batch_internal<'a, H: 'a, R: CryptoComponentRng>(
+        csprng: &CspRwLock<R>,
+        registry: &dyn RegistryClient,
+        inputs: impl ExactSizeIterator<Item = (NodeId, &'a BasicSigOf<H>, &'a [u8])>,
+        registry_version: RegistryVersion,
+    ) -> CryptoResult<()> {
         let mut msgs = Vec::with_capacity(inputs.len());
         let mut sigs = Vec::with_capacity(inputs.len());
         let mut keys = Vec::with_capacity(inputs.len());
 
-        for (i, (signer, signature, _)) in inputs.iter().enumerate() {
+        for (signer, signature, msg_bytes) in inputs {
             let pk_proto =
-                key_from_registry(registry, *signer, KeyPurpose::NodeSigning, registry_version)?;
+                key_from_registry(registry, signer, KeyPurpose::NodeSigning, registry_version)?;
 
             let pubkey_alg = AlgorithmId::from(pk_proto.algorithm);
             if pubkey_alg != AlgorithmId::Ed25519 {
@@ -113,8 +137,8 @@ impl BasicSigVerifierInternal {
                 }
             })?;
 
-            msgs.push(&messages[i][..]);
-            sigs.push(&signature.get_ref().0[..]);
+            msgs.push(msg_bytes);
+            sigs.push(signature.get_ref().0.as_slice());
             keys.push(pk);
         }
 

--- a/rs/crypto/src/sign/basic_sig/tests.rs
+++ b/rs/crypto/src/sign/basic_sig/tests.rs
@@ -435,6 +435,175 @@ mod verify_sig_batch {
     }
 }
 
+mod verify_sigs_batch {
+    use super::*;
+    use crate::common::test_utils::basic_sig;
+    use crate::common::test_utils::basic_sig::TestVector::ED25519_STABILITY_1;
+    use crate::common::test_utils::crypto_component::crypto_component_with_csp;
+    use crate::sign::tests::REG_V2;
+    use ic_crypto_temp_crypto::NodeKeysToGenerate;
+    use ic_crypto_temp_crypto::TempCryptoComponent;
+    use ic_registry_client_fake::FakeRegistryClient;
+    use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
+    use ic_types_test_utils::ids::{NODE_1, NODE_2, NODE_3};
+
+    fn two_node_crypto_components() -> (TempCryptoComponent, TempCryptoComponent) {
+        let registry_data = Arc::new(ProtoRegistryDataProvider::new());
+        let registry_client =
+            Arc::new(FakeRegistryClient::new(Arc::clone(&registry_data) as Arc<_>));
+
+        let crypto_1 = TempCryptoComponent::builder()
+            .with_keys_in_registry_version(NodeKeysToGenerate::only_node_signing_key(), REG_V2)
+            .with_registry_client_and_data(
+                Arc::clone(&registry_client) as Arc<_>,
+                Arc::clone(&registry_data) as Arc<_>,
+            )
+            .with_node_id(NODE_1)
+            .build();
+        let crypto_2 = TempCryptoComponent::builder()
+            .with_keys_in_registry_version(NodeKeysToGenerate::only_node_signing_key(), REG_V2)
+            .with_registry_client_and_data(
+                Arc::clone(&registry_client) as Arc<_>,
+                Arc::clone(&registry_data) as Arc<_>,
+            )
+            .with_node_id(NODE_2)
+            .build();
+        registry_client.reload();
+
+        (crypto_1, crypto_2)
+    }
+
+    #[test]
+    fn should_correctly_verify_batch_with_single_signature() {
+        let crypto = TempCryptoComponent::builder()
+            .with_keys_in_registry_version(NodeKeysToGenerate::only_node_signing_key(), REG_V2)
+            .with_node_id(NODE_1)
+            .build();
+
+        let msg = SignableMock::new(b"Hello World!".to_vec());
+        let sig = crypto.sign_basic(&msg).unwrap();
+
+        let inputs = vec![(NODE_1, &sig, &msg)];
+        assert_matches!(crypto.verify_basic_sigs_batch(&inputs, REG_V2), Ok(()));
+    }
+
+    #[test]
+    fn should_correctly_verify_batch_with_multiple_signatures_on_different_messages() {
+        let (crypto_1, crypto_2) = two_node_crypto_components();
+
+        let msg_1 = SignableMock::new(b"Hello World!".to_vec());
+        let msg_2 = SignableMock::new(b"Goodbye World!".to_vec());
+        let sig_1 = crypto_1.sign_basic(&msg_1).unwrap();
+        let sig_2 = crypto_2.sign_basic(&msg_2).unwrap();
+
+        let inputs = vec![(NODE_1, &sig_1, &msg_1), (NODE_2, &sig_2, &msg_2)];
+        assert_matches!(crypto_1.verify_basic_sigs_batch(&inputs, REG_V2), Ok(()));
+    }
+
+    #[test]
+    fn should_correctly_verify_batch_with_same_signer_on_different_messages() {
+        let crypto = TempCryptoComponent::builder()
+            .with_keys_in_registry_version(NodeKeysToGenerate::only_node_signing_key(), REG_V2)
+            .with_node_id(NODE_1)
+            .build();
+
+        let msg_1 = SignableMock::new(b"Hello World!".to_vec());
+        let msg_2 = SignableMock::new(b"Goodbye World!".to_vec());
+        let sig_1 = crypto.sign_basic(&msg_1).unwrap();
+        let sig_2 = crypto.sign_basic(&msg_2).unwrap();
+
+        let inputs = vec![(NODE_1, &sig_1, &msg_1), (NODE_1, &sig_2, &msg_2)];
+        assert_matches!(crypto.verify_basic_sigs_batch(&inputs, REG_V2), Ok(()));
+    }
+
+    #[test]
+    fn should_correctly_verify_batch_with_same_message_on_different_signers() {
+        let (crypto_1, crypto_2) = two_node_crypto_components();
+
+        let msg = SignableMock::new(b"Hello World!".to_vec());
+        let sig_1 = crypto_1.sign_basic(&msg).unwrap();
+        let sig_2 = crypto_2.sign_basic(&msg).unwrap();
+
+        let inputs = vec![(NODE_1, &sig_1, &msg), (NODE_2, &sig_2, &msg)];
+        assert_matches!(crypto_1.verify_basic_sigs_batch(&inputs, REG_V2), Ok(()));
+    }
+
+    #[test]
+    fn should_not_verify_batch_with_swapped_messages() {
+        let (crypto_1, crypto_2) = two_node_crypto_components();
+
+        let msg_1 = SignableMock::new(b"Hello World!".to_vec());
+        let msg_2 = SignableMock::new(b"Goodbye World!".to_vec());
+        let sig_1 = crypto_1.sign_basic(&msg_1).unwrap();
+        let sig_2 = crypto_2.sign_basic(&msg_2).unwrap();
+
+        let inputs = vec![(NODE_1, &sig_1, &msg_2), (NODE_2, &sig_2, &msg_1)];
+
+        assert_matches!(
+            crypto_1.verify_basic_sigs_batch(&inputs, REG_V2),
+            Err(CryptoError::SignatureVerification { .. })
+        );
+    }
+
+    #[test]
+    fn should_not_verify_batch_with_corrupted_signature() {
+        let (crypto_1, crypto_2) = two_node_crypto_components();
+
+        let msg_1 = SignableMock::new(b"Hello World!".to_vec());
+        let msg_2 = SignableMock::new(b"Goodbye World!".to_vec());
+        let sig_1 = crypto_1.sign_basic(&msg_1).unwrap();
+        let sig_2_corrupted = {
+            let sig = crypto_2.sign_basic(&msg_2).unwrap();
+            let mut bytes = sig.get().0;
+            bytes[0] ^= 0x80;
+            BasicSigOf::new(BasicSig(bytes))
+        };
+
+        let inputs = vec![(NODE_1, &sig_1, &msg_1), (NODE_2, &sig_2_corrupted, &msg_2)];
+
+        assert_matches!(
+            crypto_1.verify_basic_sigs_batch(&inputs, REG_V2),
+            Err(CryptoError::SignatureVerification { .. })
+        );
+    }
+
+    #[test]
+    fn should_not_verify_an_empty_batch() {
+        let rng = reproducible_rng();
+        let (_, pk, _, _) = basic_sig::testvec(ED25519_STABILITY_1);
+        let key_record =
+            node_signing_record_with(NODE_1, pk.ed25519_bytes().unwrap().to_vec(), REG_V2);
+        let crypto = crypto_component_with_csp(
+            MockAllCryptoServiceProvider::new(),
+            registry_with(key_record),
+            rng,
+        );
+
+        let empty_inputs: Vec<(NodeId, &BasicSigOf<SignableMock>, &SignableMock)> = vec![];
+
+        assert_matches!(
+            crypto.verify_basic_sigs_batch(&empty_inputs, REG_V2),
+            Err(CryptoError::InvalidArgument { message })
+            if message.contains("Empty signature batch. At least one signature should be included in the batch.")
+        );
+    }
+
+    #[test]
+    fn should_fail_with_key_not_found_if_signer_public_key_not_in_registry() {
+        let (crypto_1, _crypto_2) = two_node_crypto_components();
+
+        let msg = SignableMock::new(b"Hello World!".to_vec());
+        let sig = crypto_1.sign_basic(&msg).unwrap();
+
+        let inputs = vec![(NODE_3, &sig, &msg)];
+
+        assert_matches!(
+            crypto_1.verify_basic_sigs_batch(&inputs, REG_V2),
+            Err(CryptoError::PublicKeyNotFound { .. })
+        );
+    }
+}
+
 mod verify_basic_sig_by_public_key {
     use super::*;
     use crate::common::test_utils::crypto_component::crypto_component_with_csp;

--- a/rs/crypto/src/sign/basic_sig/tests.rs
+++ b/rs/crypto/src/sign/basic_sig/tests.rs
@@ -484,7 +484,10 @@ mod verify_sigs_batch {
         let sig = crypto.sign_basic(&msg).unwrap();
 
         let inputs = vec![(NODE_1, &sig, &msg)];
-        assert_matches!(crypto.verify_basic_sigs_batch(&inputs, REG_V2), Ok(()));
+        assert_matches!(
+            crypto.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
+            Ok(())
+        );
     }
 
     #[test]
@@ -497,7 +500,10 @@ mod verify_sigs_batch {
         let sig_2 = crypto_2.sign_basic(&msg_2).unwrap();
 
         let inputs = vec![(NODE_1, &sig_1, &msg_1), (NODE_2, &sig_2, &msg_2)];
-        assert_matches!(crypto_1.verify_basic_sigs_batch(&inputs, REG_V2), Ok(()));
+        assert_matches!(
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
+            Ok(())
+        );
     }
 
     #[test]
@@ -513,7 +519,10 @@ mod verify_sigs_batch {
         let sig_2 = crypto.sign_basic(&msg_2).unwrap();
 
         let inputs = vec![(NODE_1, &sig_1, &msg_1), (NODE_1, &sig_2, &msg_2)];
-        assert_matches!(crypto.verify_basic_sigs_batch(&inputs, REG_V2), Ok(()));
+        assert_matches!(
+            crypto.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
+            Ok(())
+        );
     }
 
     #[test]
@@ -525,7 +534,10 @@ mod verify_sigs_batch {
         let sig_2 = crypto_2.sign_basic(&msg).unwrap();
 
         let inputs = vec![(NODE_1, &sig_1, &msg), (NODE_2, &sig_2, &msg)];
-        assert_matches!(crypto_1.verify_basic_sigs_batch(&inputs, REG_V2), Ok(()));
+        assert_matches!(
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
+            Ok(())
+        );
     }
 
     #[test]
@@ -540,7 +552,7 @@ mod verify_sigs_batch {
         let inputs = vec![(NODE_1, &sig_1, &msg_2), (NODE_2, &sig_2, &msg_1)];
 
         assert_matches!(
-            crypto_1.verify_basic_sigs_batch(&inputs, REG_V2),
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
             Err(CryptoError::SignatureVerification { .. })
         );
     }
@@ -562,7 +574,7 @@ mod verify_sigs_batch {
         let inputs = vec![(NODE_1, &sig_1, &msg_1), (NODE_2, &sig_2_corrupted, &msg_2)];
 
         assert_matches!(
-            crypto_1.verify_basic_sigs_batch(&inputs, REG_V2),
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
             Err(CryptoError::SignatureVerification { .. })
         );
     }
@@ -582,7 +594,7 @@ mod verify_sigs_batch {
         let empty_inputs: Vec<(NodeId, &BasicSigOf<SignableMock>, &SignableMock)> = vec![];
 
         assert_matches!(
-            crypto.verify_basic_sigs_batch(&empty_inputs, REG_V2),
+            crypto.verify_basic_sig_batch_multi_msg(&empty_inputs, REG_V2),
             Err(CryptoError::InvalidArgument { message })
             if message.contains("Empty signature batch. At least one signature should be included in the batch.")
         );
@@ -598,7 +610,7 @@ mod verify_sigs_batch {
         let inputs = vec![(NODE_3, &sig, &msg)];
 
         assert_matches!(
-            crypto_1.verify_basic_sigs_batch(&inputs, REG_V2),
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
             Err(CryptoError::PublicKeyNotFound { .. })
         );
     }

--- a/rs/crypto/src/sign/mod.rs
+++ b/rs/crypto/src/sign/mod.rs
@@ -210,7 +210,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> BasicSigVerif
         result
     }
 
-    fn verify_basic_sigs_batch(
+    fn verify_basic_sig_batch_multi_msg(
         &self,
         inputs: &[(NodeId, &BasicSigOf<H>, &H)],
         registry_version: RegistryVersion,
@@ -219,7 +219,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> BasicSigVerif
         let logger = new_logger!(&self.logger;
             crypto.log_id => log_id,
             crypto.trait_name => "BasicSigVerifier",
-            crypto.method_name => "verify_basic_sigs_batch",
+            crypto.method_name => "verify_basic_sig_batch_multi_msg",
         );
         debug!(logger;
             crypto.description => "start",
@@ -227,7 +227,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> BasicSigVerif
             crypto.signature => format!("{:?}", inputs.iter().map(|(s, sig, _)| (s, sig)).collect::<Vec<_>>()),
         );
         let start_time = self.metrics.now();
-        let result = BasicSigVerifierInternal::verify_basic_sigs_batch(
+        let result = BasicSigVerifierInternal::verify_basic_sig_batch_multi_msg(
             &self.csprng,
             self.registry_client.as_ref(),
             inputs,
@@ -236,7 +236,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> BasicSigVerif
         self.metrics.observe_duration_seconds(
             MetricsDomain::BasicSignature,
             MetricsScope::Full,
-            "verify_basic_sigs_batch",
+            "verify_basic_sig_batch_multi_msg",
             MetricsResult::from(&result),
             start_time,
         );

--- a/rs/crypto/src/sign/mod.rs
+++ b/rs/crypto/src/sign/mod.rs
@@ -209,6 +209,44 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> BasicSigVerif
         );
         result
     }
+
+    fn verify_basic_sigs_batch(
+        &self,
+        inputs: &[(NodeId, &BasicSigOf<H>, &H)],
+        registry_version: RegistryVersion,
+    ) -> CryptoResult<()> {
+        let log_id = get_log_id(&self.logger);
+        let logger = new_logger!(&self.logger;
+            crypto.log_id => log_id,
+            crypto.trait_name => "BasicSigVerifier",
+            crypto.method_name => "verify_basic_sigs_batch",
+        );
+        debug!(logger;
+            crypto.description => "start",
+            crypto.registry_version => registry_version.get(),
+            crypto.signature => format!("{:?}", inputs.iter().map(|(s, sig, _)| (s, sig)).collect::<Vec<_>>()),
+        );
+        let start_time = self.metrics.now();
+        let result = BasicSigVerifierInternal::verify_basic_sigs_batch(
+            &self.csprng,
+            self.registry_client.as_ref(),
+            inputs,
+            registry_version,
+        );
+        self.metrics.observe_duration_seconds(
+            MetricsDomain::BasicSignature,
+            MetricsScope::Full,
+            "verify_basic_sigs_batch",
+            MetricsResult::from(&result),
+            start_time,
+        );
+        debug!(logger;
+            crypto.description => "end",
+            crypto.is_ok => result.is_ok(),
+            crypto.error => log_err(result.as_ref().err()),
+        );
+        result
+    }
 }
 
 impl<C: CryptoServiceProvider, R: CryptoComponentRng, S: Signable> BasicSigVerifierByPublicKey<S>

--- a/rs/crypto/temp_crypto/src/lib.rs
+++ b/rs/crypto/temp_crypto/src/lib.rs
@@ -872,6 +872,15 @@ pub mod internal {
             self.crypto_component
                 .verify_basic_sig_batch(signature, message, registry_version)
         }
+
+        fn verify_basic_sigs_batch(
+            &self,
+            inputs: &[(NodeId, &BasicSigOf<T>, &T)],
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()> {
+            self.crypto_component
+                .verify_basic_sigs_batch(inputs, registry_version)
+        }
     }
 
     impl<C: CryptoServiceProvider, T: Signable, R: CryptoComponentRng> MultiSigVerifier<T>

--- a/rs/crypto/temp_crypto/src/lib.rs
+++ b/rs/crypto/temp_crypto/src/lib.rs
@@ -873,13 +873,13 @@ pub mod internal {
                 .verify_basic_sig_batch(signature, message, registry_version)
         }
 
-        fn verify_basic_sigs_batch(
+        fn verify_basic_sig_batch_multi_msg(
             &self,
             inputs: &[(NodeId, &BasicSigOf<T>, &T)],
             registry_version: RegistryVersion,
         ) -> CryptoResult<()> {
             self.crypto_component
-                .verify_basic_sigs_batch(inputs, registry_version)
+                .verify_basic_sig_batch_multi_msg(inputs, registry_version)
         }
     }
 

--- a/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
+++ b/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
@@ -673,13 +673,13 @@ pub mod node {
                 .verify_basic_sig_batch(signature_batch, message, registry_version)
         }
 
-        fn verify_basic_sigs_batch(
+        fn verify_basic_sig_batch_multi_msg(
             &self,
             inputs: &[(NodeId, &BasicSigOf<T>, &T)],
             registry_version: RegistryVersion,
         ) -> CryptoResult<()> {
             self.crypto_component
-                .verify_basic_sigs_batch(inputs, registry_version)
+                .verify_basic_sig_batch_multi_msg(inputs, registry_version)
         }
     }
 

--- a/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
+++ b/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
@@ -672,6 +672,15 @@ pub mod node {
             self.crypto_component
                 .verify_basic_sig_batch(signature_batch, message, registry_version)
         }
+
+        fn verify_basic_sigs_batch(
+            &self,
+            inputs: &[(NodeId, &BasicSigOf<T>, &T)],
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()> {
+            self.crypto_component
+                .verify_basic_sigs_batch(inputs, registry_version)
+        }
     }
 
     fn create_crypto_component_with_sign_mega_and_multisign_keys_in_registry<R: Rng + CryptoRng>(

--- a/rs/crypto/test_utils/crypto_returning_ok/src/lib.rs
+++ b/rs/crypto/test_utils/crypto_returning_ok/src/lib.rs
@@ -83,6 +83,14 @@ impl<T: Signable> BasicSigVerifier<T> for CryptoReturningOk {
     ) -> CryptoResult<()> {
         Ok(())
     }
+
+    fn verify_basic_sigs_batch(
+        &self,
+        _inputs: &[(NodeId, &BasicSigOf<T>, &T)],
+        _registry_version: RegistryVersion,
+    ) -> CryptoResult<()> {
+        Ok(())
+    }
 }
 
 impl<T: Signable> BasicSigVerifierByPublicKey<T> for CryptoReturningOk {

--- a/rs/crypto/test_utils/crypto_returning_ok/src/lib.rs
+++ b/rs/crypto/test_utils/crypto_returning_ok/src/lib.rs
@@ -84,7 +84,7 @@ impl<T: Signable> BasicSigVerifier<T> for CryptoReturningOk {
         Ok(())
     }
 
-    fn verify_basic_sigs_batch(
+    fn verify_basic_sig_batch_multi_msg(
         &self,
         _inputs: &[(NodeId, &BasicSigOf<T>, &T)],
         _registry_version: RegistryVersion,

--- a/rs/interfaces/mocks/src/crypto.rs
+++ b/rs/interfaces/mocks/src/crypto.rs
@@ -84,7 +84,7 @@ macro_rules! impl_basic_signer {
 }
 
 macro_rules! impl_basic_sig_verifier {
-    ($t:ty, $verify:ident, $combine:ident, $verify_batch:ident) => {
+    ($t:ty, $verify:ident, $combine:ident, $verify_batch:ident, $verify_sigs_batch:ident) => {
         impl BasicSigVerifier<$t> for MockCrypto {
             fn verify_basic_sig(
                 &self,
@@ -115,6 +115,18 @@ macro_rules! impl_basic_sig_verifier {
                 registry_version: RegistryVersion,
             ) -> CryptoResult<()> {
                 self.$verify_batch(signature_batch, message, registry_version)
+            }
+
+            fn verify_basic_sigs_batch(
+                &self,
+                inputs: &[(NodeId, &BasicSigOf<$t>, &$t)],
+                registry_version: RegistryVersion,
+            ) -> CryptoResult<()> {
+                let owned: Vec<(NodeId, BasicSigOf<$t>, $t)> = inputs
+                    .iter()
+                    .map(|(signer, sig, msg)| (*signer, (*sig).clone(), (*msg).clone()))
+                    .collect();
+                self.$verify_sigs_batch(owned, registry_version)
             }
         }
     };
@@ -315,6 +327,12 @@ mockall::mock! {
             message: &BlockMetadata, registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
+        pub fn verify_basic_sigs_batch_block(
+            &self,
+            inputs: Vec<(NodeId, BasicSigOf<BlockMetadata>, BlockMetadata)>,
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()>;
+
         // consensus_dkg::DealingContent
         pub fn verify_basic_sig_dkg_dealing_content(
             &self, signature: &BasicSigOf<consensus_dkg::DealingContent>,
@@ -332,6 +350,12 @@ mockall::mock! {
             &self,
             signature_batch: &BasicSignatureBatch<consensus_dkg::DealingContent>,
             message: &consensus_dkg::DealingContent,
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()>;
+
+        pub fn verify_basic_sigs_batch_dkg_dealing_content(
+            &self,
+            inputs: Vec<(NodeId, BasicSigOf<consensus_dkg::DealingContent>, consensus_dkg::DealingContent)>,
             registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
@@ -354,6 +378,12 @@ mockall::mock! {
             message: &SignedIDkgDealing, registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
+        pub fn verify_basic_sigs_batch_signed_idkg_dealing(
+            &self,
+            inputs: Vec<(NodeId, BasicSigOf<SignedIDkgDealing>, SignedIDkgDealing)>,
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()>;
+
         // IDkgDealing
         pub fn verify_basic_sig_idkg_dealing(
             &self, signature: &BasicSigOf<IDkgDealing>,
@@ -369,6 +399,12 @@ mockall::mock! {
         pub fn verify_basic_sig_batch_idkg(
             &self, signature_batch: &BasicSignatureBatch<IDkgDealing>,
             message: &IDkgDealing, registry_version: RegistryVersion,
+        ) -> CryptoResult<()>;
+
+        pub fn verify_basic_sigs_batch_idkg(
+            &self,
+            inputs: Vec<(NodeId, BasicSigOf<IDkgDealing>, IDkgDealing)>,
+            registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
         // IDkgComplaintContent
@@ -390,6 +426,12 @@ mockall::mock! {
             message: &IDkgComplaintContent, registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
+        pub fn verify_basic_sigs_batch_idkg_complaint(
+            &self,
+            inputs: Vec<(NodeId, BasicSigOf<IDkgComplaintContent>, IDkgComplaintContent)>,
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()>;
+
         // IDkgOpeningContent
         pub fn verify_basic_sig_idkg_opening(
             &self, signature: &BasicSigOf<IDkgOpeningContent>,
@@ -407,6 +449,12 @@ mockall::mock! {
             &self,
             signature_batch: &BasicSignatureBatch<IDkgOpeningContent>,
             message: &IDkgOpeningContent, registry_version: RegistryVersion,
+        ) -> CryptoResult<()>;
+
+        pub fn verify_basic_sigs_batch_idkg_opening(
+            &self,
+            inputs: Vec<(NodeId, BasicSigOf<IDkgOpeningContent>, IDkgOpeningContent)>,
+            registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
         // CanisterHttpResponseMetadata
@@ -427,6 +475,16 @@ mockall::mock! {
             &self,
             signature_batch: &BasicSignatureBatch<CanisterHttpResponseMetadata>,
             message: &CanisterHttpResponseMetadata,
+            registry_version: RegistryVersion,
+        ) -> CryptoResult<()>;
+
+        pub fn verify_basic_sigs_batch_http(
+            &self,
+            inputs: Vec<(
+                NodeId,
+                BasicSigOf<CanisterHttpResponseMetadata>,
+                CanisterHttpResponseMetadata,
+            )>,
             registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
@@ -732,43 +790,50 @@ impl_basic_sig_verifier!(
     BlockMetadata,
     verify_basic_sig_block,
     combine_basic_sig_block,
-    verify_basic_sig_batch_block
+    verify_basic_sig_batch_block,
+    verify_basic_sigs_batch_block
 );
 impl_basic_sig_verifier!(
     consensus_dkg::DealingContent,
     verify_basic_sig_dkg_dealing_content,
     combine_basic_sig_dkg_dealing_content,
-    verify_basic_sig_batch_dkg_dealing_content
+    verify_basic_sig_batch_dkg_dealing_content,
+    verify_basic_sigs_batch_dkg_dealing_content
 );
 impl_basic_sig_verifier!(
     SignedIDkgDealing,
     verify_basic_sig_signed_idkg_dealing,
     combine_basic_sig_signed_idkg_dealing,
-    verify_basic_sig_batch_signed_idkg_dealing
+    verify_basic_sig_batch_signed_idkg_dealing,
+    verify_basic_sigs_batch_signed_idkg_dealing
 );
 impl_basic_sig_verifier!(
     IDkgDealing,
     verify_basic_sig_idkg_dealing,
     combine_basic_sig_idkg_dealing,
-    verify_basic_sig_batch_idkg
+    verify_basic_sig_batch_idkg,
+    verify_basic_sigs_batch_idkg
 );
 impl_basic_sig_verifier!(
     IDkgComplaintContent,
     verify_basic_sig_idkg_complaint,
     combine_basic_sig_idkg_complaint,
-    verify_basic_sig_batch_idkg_complaint
+    verify_basic_sig_batch_idkg_complaint,
+    verify_basic_sigs_batch_idkg_complaint
 );
 impl_basic_sig_verifier!(
     IDkgOpeningContent,
     verify_basic_sig_idkg_opening,
     combine_basic_sig_idkg_opening,
-    verify_basic_sig_batch_idkg_opening
+    verify_basic_sig_batch_idkg_opening,
+    verify_basic_sigs_batch_idkg_opening
 );
 impl_basic_sig_verifier!(
     CanisterHttpResponseMetadata,
     verify_basic_sig_http,
     combine_basic_sig_http,
-    verify_basic_sig_batch_http
+    verify_basic_sig_batch_http,
+    verify_basic_sigs_batch_http
 );
 
 impl_threshold_signer!(CertificationContent, sign_threshold_certification);

--- a/rs/interfaces/mocks/src/crypto.rs
+++ b/rs/interfaces/mocks/src/crypto.rs
@@ -117,7 +117,7 @@ macro_rules! impl_basic_sig_verifier {
                 self.$verify_batch(signature_batch, message, registry_version)
             }
 
-            fn verify_basic_sigs_batch(
+            fn verify_basic_sig_batch_multi_msg(
                 &self,
                 inputs: &[(NodeId, &BasicSigOf<$t>, &$t)],
                 registry_version: RegistryVersion,
@@ -327,7 +327,7 @@ mockall::mock! {
             message: &BlockMetadata, registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
-        pub fn verify_basic_sigs_batch_block(
+        pub fn verify_basic_sig_batch_multi_msg_block(
             &self,
             inputs: Vec<(NodeId, BasicSigOf<BlockMetadata>, BlockMetadata)>,
             registry_version: RegistryVersion,
@@ -353,7 +353,7 @@ mockall::mock! {
             registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
-        pub fn verify_basic_sigs_batch_dkg_dealing_content(
+        pub fn verify_basic_sig_batch_multi_msg_dkg_dealing_content(
             &self,
             inputs: Vec<(NodeId, BasicSigOf<consensus_dkg::DealingContent>, consensus_dkg::DealingContent)>,
             registry_version: RegistryVersion,
@@ -378,7 +378,7 @@ mockall::mock! {
             message: &SignedIDkgDealing, registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
-        pub fn verify_basic_sigs_batch_signed_idkg_dealing(
+        pub fn verify_basic_sig_batch_multi_msg_signed_idkg_dealing(
             &self,
             inputs: Vec<(NodeId, BasicSigOf<SignedIDkgDealing>, SignedIDkgDealing)>,
             registry_version: RegistryVersion,
@@ -401,7 +401,7 @@ mockall::mock! {
             message: &IDkgDealing, registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
-        pub fn verify_basic_sigs_batch_idkg(
+        pub fn verify_basic_sig_batch_multi_msg_idkg(
             &self,
             inputs: Vec<(NodeId, BasicSigOf<IDkgDealing>, IDkgDealing)>,
             registry_version: RegistryVersion,
@@ -426,7 +426,7 @@ mockall::mock! {
             message: &IDkgComplaintContent, registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
-        pub fn verify_basic_sigs_batch_idkg_complaint(
+        pub fn verify_basic_sig_batch_multi_msg_idkg_complaint(
             &self,
             inputs: Vec<(NodeId, BasicSigOf<IDkgComplaintContent>, IDkgComplaintContent)>,
             registry_version: RegistryVersion,
@@ -451,7 +451,7 @@ mockall::mock! {
             message: &IDkgOpeningContent, registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
-        pub fn verify_basic_sigs_batch_idkg_opening(
+        pub fn verify_basic_sig_batch_multi_msg_idkg_opening(
             &self,
             inputs: Vec<(NodeId, BasicSigOf<IDkgOpeningContent>, IDkgOpeningContent)>,
             registry_version: RegistryVersion,
@@ -478,7 +478,7 @@ mockall::mock! {
             registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
-        pub fn verify_basic_sigs_batch_http(
+        pub fn verify_basic_sig_batch_multi_msg_http(
             &self,
             inputs: Vec<(
                 NodeId,
@@ -791,49 +791,49 @@ impl_basic_sig_verifier!(
     verify_basic_sig_block,
     combine_basic_sig_block,
     verify_basic_sig_batch_block,
-    verify_basic_sigs_batch_block
+    verify_basic_sig_batch_multi_msg_block
 );
 impl_basic_sig_verifier!(
     consensus_dkg::DealingContent,
     verify_basic_sig_dkg_dealing_content,
     combine_basic_sig_dkg_dealing_content,
     verify_basic_sig_batch_dkg_dealing_content,
-    verify_basic_sigs_batch_dkg_dealing_content
+    verify_basic_sig_batch_multi_msg_dkg_dealing_content
 );
 impl_basic_sig_verifier!(
     SignedIDkgDealing,
     verify_basic_sig_signed_idkg_dealing,
     combine_basic_sig_signed_idkg_dealing,
     verify_basic_sig_batch_signed_idkg_dealing,
-    verify_basic_sigs_batch_signed_idkg_dealing
+    verify_basic_sig_batch_multi_msg_signed_idkg_dealing
 );
 impl_basic_sig_verifier!(
     IDkgDealing,
     verify_basic_sig_idkg_dealing,
     combine_basic_sig_idkg_dealing,
     verify_basic_sig_batch_idkg,
-    verify_basic_sigs_batch_idkg
+    verify_basic_sig_batch_multi_msg_idkg
 );
 impl_basic_sig_verifier!(
     IDkgComplaintContent,
     verify_basic_sig_idkg_complaint,
     combine_basic_sig_idkg_complaint,
     verify_basic_sig_batch_idkg_complaint,
-    verify_basic_sigs_batch_idkg_complaint
+    verify_basic_sig_batch_multi_msg_idkg_complaint
 );
 impl_basic_sig_verifier!(
     IDkgOpeningContent,
     verify_basic_sig_idkg_opening,
     combine_basic_sig_idkg_opening,
     verify_basic_sig_batch_idkg_opening,
-    verify_basic_sigs_batch_idkg_opening
+    verify_basic_sig_batch_multi_msg_idkg_opening
 );
 impl_basic_sig_verifier!(
     CanisterHttpResponseMetadata,
     verify_basic_sig_http,
     combine_basic_sig_http,
     verify_basic_sig_batch_http,
-    verify_basic_sigs_batch_http
+    verify_basic_sig_batch_multi_msg_http
 );
 
 impl_threshold_signer!(CertificationContent, sign_threshold_certification);

--- a/rs/interfaces/src/crypto/sign.rs
+++ b/rs/interfaces/src/crypto/sign.rs
@@ -152,7 +152,7 @@ pub trait BasicSigVerifier<T: Signable> {
     /// * `CryptoError::SignatureVerification`: if at least one signature in
     ///   the batch could not be verified for its corresponding message.
     /// * `CryptoError::InvalidArgument`: if `inputs` is empty.
-    fn verify_basic_sigs_batch(
+    fn verify_basic_sig_batch_multi_msg(
         &self,
         inputs: &[(NodeId, &BasicSigOf<T>, &T)],
         registry_version: RegistryVersion,

--- a/rs/interfaces/src/crypto/sign.rs
+++ b/rs/interfaces/src/crypto/sign.rs
@@ -131,6 +131,32 @@ pub trait BasicSigVerifier<T: Signable> {
         message: &T,
         registry_version: RegistryVersion,
     ) -> CryptoResult<()>;
+
+    /// Verifies a batch of basic signatures on potentially different messages.
+    ///
+    /// In contrast to `verify_basic_sig_batch`, each signature in this batch
+    /// may be on a different message. The same `NodeId` may appear multiple
+    /// times in `inputs` if a node signed multiple different messages.
+    ///
+    /// # Errors
+    /// * `CryptoError::RegistryClient`: if the registry cannot be accessed at
+    ///   `registry_version`.
+    /// * `CryptoError::PublicKeyNotFound`: if at least one of the signers'
+    ///   public keys cannot be found at the given `registry_version`.
+    /// * `CryptoError::MalformedSignature`: if a signature is malformed.
+    /// * `CryptoError::AlgorithmNotSupported`: if a signature algorithm is
+    ///   not supported, or if a signer's public key obtained from the
+    ///   registry is for an unsupported algorithm.
+    /// * `CryptoError::MalformedPublicKey`: if a signer's public key obtained
+    ///   from the registry is malformed.
+    /// * `CryptoError::SignatureVerification`: if at least one signature in
+    ///   the batch could not be verified for its corresponding message.
+    /// * `CryptoError::InvalidArgument`: if `inputs` is empty.
+    fn verify_basic_sigs_batch(
+        &self,
+        inputs: &[(NodeId, &BasicSigOf<T>, &T)],
+        registry_version: RegistryVersion,
+    ) -> CryptoResult<()>;
 }
 
 /// A Crypto Component interface to create multi-signatures.


### PR DESCRIPTION
This PR adds a new function `BasicSigVerifier::verify_basic_sig_batch_multi_msg` that batch-verifies basic signatures over potentially different messages. This complements the existing `verify_basic_sig_batch` (which requires all signatures to be over the same message). 

Note that the existing function is a special case, and in general it is not necessary for the messages to be equal in order to benefit from batching. Verifying batches with different messages is already supported and implemented by the underlying crypto primitive. 

In contrast to verifying all signatures one-by-one, batching N signature verifications replaces N independent elliptic-curve operations with one combined operation whose cost grows sublinearly in N, so the per-signature cost shrinks with larger batches.

## Motivation
The motivation for this is mainly HTTP outcalls: In the current happy case (fully replicated outcall, where all replicas derive the same HTTP response), the message signed by each replica is indeed the same. With the new pricing however, each replica will additionally sign the amount of cycles they want to return to the caller, which may be a different value for each of them.

Additionally, there are cases where the signed HTTP responses aren't equal already today, i.e. divergence responses and flexible outcalls responses. Signatures on these responses are currently verified individually, and could similarly be optimized by using the new function.

## Testing
We add the same unit test coverage that already exists for `verify_basic_sig_batch`.