### PR TITLE
feat: Add tee-recovery to HostOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17877,6 +17877,8 @@ name = "manual_guestos_recovery"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "clap 4.6.0",
+ "grub",
  "ratatui",
  "scopeguard",
  "shell-escape",

--- a/ic-os/components/hostos/misc/limited-console
+++ b/ic-os/components/hostos/misc/limited-console
@@ -24,10 +24,47 @@ show_menu() {
     echo "  routes                  - Show routing table"
     echo "  guestos-alternative     - Show or swap the GuestOS boot alternative (A/B)"
     echo "  manual-recovery         - Manual node recovery (ONLY FOR EMERGENCY USE)"
+    echo "  tee-recovery            - Install alternative GuestOS in TEE mode"
     echo "  rbash-console           - Drop into restricted bash console"
     echo "  clear                   - Clear the console"
     echo "  exit                    - Exit console"
     echo ""
+}
+
+run_manual_recovery() {
+    local recovery_mode="${1:-nns}"
+
+    echo "=== Manual Node Recovery ==="
+    echo "This will perform a manual node recovery. Do not attempt this unless you are certain it is appropriate."
+    echo "Manual node recovery should only occur in the event of a critical IC failure."
+    echo "In such cases, the process will be coordinated by reputable IC community leaders"
+    echo "and actively discussed publicly with node providers."
+    echo ""
+    echo "Are you sure you want to proceed? (y/n)"
+    read -r confirm
+    if [ "$confirm" == "y" ]; then
+        # Launch the recovery TUI tool via hostos_tool
+
+        # Fix for serial/remote consoles where window size may be missing or tiny
+        if ! size=$(stty size 2>/dev/null); then
+            echo "Error: could not determine terminal size. The manual-recovery TUI requires a TTY."
+            echo "Please see \"Manual Recovery Fallback\" in the Manual Node Recovery Guide for further direction."
+            exit 1
+        fi
+
+        read -r rows cols <<< "$size"
+        # Treat anything smaller than the Manual Recovery TUI minimum as unusable
+        min_rows=15
+        min_cols=10
+        if [ "${rows:-0}" -lt "$min_rows" ] || [ "${cols:-0}" -lt "$min_cols" ]; then
+            echo "Terminal size (${rows}x${cols}) is too small or invalid, setting to 24x80"
+            stty rows 24 cols 80
+            sleep 5 # Give the user a chance to see the message
+        fi
+
+        cmd=(/opt/ic/bin/hostos_tool manual-recovery "$recovery_mode")
+        "${cmd[@]}"
+    fi
 }
 
 # Command dispatcher
@@ -136,36 +173,10 @@ execute_command() {
             esac
             ;;
         "manual-recovery")
-            echo "=== Manual Node Recovery ==="
-            echo "This will perform a manual node recovery. Do not attempt this unless you are certain it is appropriate."
-            echo "Manual node recovery should only occur in the event of a critical IC failure."
-            echo "In such cases, the process will be coordinated by reputable IC community leaders"
-            echo "and actively discussed publicly with node providers."
-            echo ""
-            echo "Are you sure you want to proceed? (y/n)"
-            read -r confirm
-            if [ "$confirm" == "y" ]; then
-                # Launch the NNS recovery TUI tool via hostos_tool
-
-                # Fix for serial/remote consoles where window size may be missing or tiny
-                if ! size=$(stty size 2>/dev/null); then
-                    echo "Error: could not determine terminal size. The manual-recovery TUI requires a TTY."
-                    echo "Please see \"Manual Recovery Fallback\" in the Manual Node Recovery Guide for further direction."
-                    exit 1
-                fi
-
-                read -r rows cols <<< "$size"
-                # Treat anything smaller than the Manual Recovery TUI minimum as unusable
-                min_rows=15
-                min_cols=10
-                if [ "${rows:-0}" -lt "$min_rows" ] || [ "${cols:-0}" -lt "$min_cols" ]; then
-                    echo "Terminal size (${rows}x${cols}) is too small or invalid, setting to 24x80"
-                    stty rows 24 cols 80
-                    sleep 5 # Give the user a chance to see the message
-                fi
-
-                /opt/ic/bin/hostos_tool manual-recovery
-            fi
+            run_manual_recovery nns
+            ;;
+        "tee-recovery")
+            run_manual_recovery tee
             ;;
         "rbash-console")
             echo "=== Dropping into Restricted Bash Console ==="

--- a/ic-os/components/hostos/misc/limited-console
+++ b/ic-os/components/hostos/misc/limited-console
@@ -23,8 +23,8 @@ show_menu() {
     echo "  ping-gateway            - Test connectivity to IPv6 gateway"
     echo "  routes                  - Show routing table"
     echo "  guestos-alternative     - Show or swap the GuestOS boot alternative (A/B)"
-    echo "  manual-recovery         - Manual node recovery (ONLY FOR EMERGENCY USE)"
-    echo "  tee-recovery            - Install alternative GuestOS in TEE mode"
+    echo "  nns-recovery            - Manual node recovery (ONLY FOR EMERGENCY USE)"
+    echo "  tee-recovery            - Install alternative GuestOS in TEE mode (ONLY FOR EMERGENCY USE)"
     echo "  rbash-console           - Drop into restricted bash console"
     echo "  clear                   - Clear the console"
     echo "  exit                    - Exit console"
@@ -47,7 +47,7 @@ run_manual_recovery() {
 
         # Fix for serial/remote consoles where window size may be missing or tiny
         if ! size=$(stty size 2>/dev/null); then
-            echo "Error: could not determine terminal size. The manual-recovery TUI requires a TTY."
+            echo "Error: could not determine terminal size. The nns-recovery TUI requires a TTY."
             echo "Please see \"Manual Recovery Fallback\" in the Manual Node Recovery Guide for further direction."
             exit 1
         fi
@@ -172,7 +172,7 @@ execute_command() {
                     ;;
             esac
             ;;
-        "manual-recovery")
+        "nns-recovery")
             run_manual_recovery nns
             ;;
         "tee-recovery")

--- a/ic-os/components/hostos/misc/sudoers
+++ b/ic-os/components/hostos/misc/sudoers
@@ -30,7 +30,7 @@ root	ALL=(ALL:ALL) NOPASSWD:ALL
 %sudo	ALL=(ALL:ALL) NOPASSWD:ALL
 
 # Allow limited-console to run recovery via the secure launcher script
-limited-console ALL=(ALL:ALL) NOPASSWD: /opt/ic/bin/guestos-recovery-launcher.sh mode=* version=* recovery-hash-prefix=*
+limited-console ALL=(ALL:ALL) NOPASSWD: /opt/ic/bin/guestos-recovery-launcher.sh
 
 # Allow limited-console to swap the GuestOS boot alternative
 limited-console ALL=(ALL:ALL) NOPASSWD: /opt/ic/bin/hostos_tool guestos-alternative swap *

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-launcher.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-launcher.sh
@@ -10,7 +10,9 @@ validate_argument() {
     # NOTE: version=RECOVERY_VERSION is allowed as a dummy value for testing purposes.
     if [[ "$arg" =~ ^mode=(prep|install|run)$ ]] \
         || [[ "$arg" =~ ^version=[a-f0-9]{40}$ ]] \
-        || [[ "$arg" =~ ^recovery-hash-prefix=[a-f0-9]{6}$ ]] \
+        || [[ "$arg" =~ ^recovery-hash-prefix=([a-f0-9]{6})?$ ]] \
+        || [[ "$arg" =~ ^target-boot-alternative=(A|B)$ ]] \
+        || [[ "$arg" == "wipe-var-partition" ]] \
         || [[ "$arg" == "version=RECOVERY_VERSION" ]]; then
         return 0
     else
@@ -20,16 +22,34 @@ validate_argument() {
 }
 
 if [ $# -eq 0 ]; then
-    echo "Usage: $0 mode=<run|prep|install> version=<40-char-hex> recovery-hash-prefix=<6-char-hex>"
+    echo "Usage: $0 mode=<install> [target-boot-alternative=<A|B>] [wipe-var-partition]"
+    echo "   or: $0 mode=<prep|run> version=<40-char-hex> target-boot-alternative=<A|B> [recovery-hash-prefix=<6-char-hex>|recovery-hash-prefix=] [wipe-var-partition]"
     exit 1
 fi
 
+mode=""
+has_target_boot_alternative=false
+
 for arg in "$@"; do
     if ! validate_argument "$arg"; then
-        echo "Arguments must be: mode=<run|prep|install> version=<40-char-hex> recovery-hash-prefix=<6-char-hex>"
+        echo "Arguments must be valid recovery launcher arguments."
         exit 1
     fi
+
+    case "$arg" in
+        mode=*)
+            mode="${arg#*=}"
+            ;;
+        target-boot-alternative=*)
+            has_target_boot_alternative=true
+            ;;
+    esac
 done
+
+if [[ ( "$mode" == "prep" || "$mode" == "run" ) && "$has_target_boot_alternative" != true ]]; then
+    echo "ERROR: target-boot-alternative=<A|B> is required for mode=${mode}" >&2
+    exit 1
+fi
 
 exec /usr/bin/systemd-run \
     --unit=guestos-recovery-upgrader \

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-launcher.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-launcher.sh
@@ -27,29 +27,12 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-mode=""
-has_target_boot_alternative=false
-
 for arg in "$@"; do
     if ! validate_argument "$arg"; then
         echo "Arguments must be valid recovery launcher arguments."
         exit 1
     fi
-
-    case "$arg" in
-        mode=*)
-            mode="${arg#*=}"
-            ;;
-        target-boot-alternative=*)
-            has_target_boot_alternative=true
-            ;;
-    esac
 done
-
-if [[ ("$mode" == "prep" || "$mode" == "run") && "$has_target_boot_alternative" != true ]]; then
-    echo "ERROR: target-boot-alternative=<A|B> is required for mode=${mode}" >&2
-    exit 1
-fi
 
 exec /usr/bin/systemd-run \
     --unit=guestos-recovery-upgrader \

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-launcher.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-launcher.sh
@@ -46,7 +46,7 @@ for arg in "$@"; do
     esac
 done
 
-if [[ ( "$mode" == "prep" || "$mode" == "run" ) && "$has_target_boot_alternative" != true ]]; then
+if [[ ("$mode" == "prep" || "$mode" == "run") && "$has_target_boot_alternative" != true ]]; then
     echo "ERROR: target-boot-alternative=<A|B> is required for mode=${mode}" >&2
     exit 1
 fi

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
@@ -44,6 +44,11 @@ VERSION=""
 VERSION_HASH_FULL=""
 RECOVERY_HASH_PREFIX=""
 RECOVERY_HASH_FULL=""
+TARGET_BOOT_ALTERNATIVE=""
+WIPE_VAR_PARTITION=false
+GUESTOS_SERVICE_STOPPED=false
+RESTART_GUESTOS_SERVICE_ON_EXIT=false
+INSTALL_STARTED=false
 
 source /opt/ic/bin/boot-state.sh
 
@@ -60,8 +65,18 @@ parse_args() {
             recovery-hash-prefix=*)
                 RECOVERY_HASH_PREFIX="${arg#*=}"
                 ;;
+            target-boot-alternative=*)
+                TARGET_BOOT_ALTERNATIVE="${arg#*=}"
+                ;;
+            wipe-var-partition)
+                WIPE_VAR_PARTITION=true
+                ;;
         esac
     done
+}
+
+recovery_hash_enabled() {
+    [ -n "$RECOVERY_HASH_PREFIX" ]
 }
 
 # Helper function to log messages to logger and stdout
@@ -73,6 +88,28 @@ log_message() {
     echo "$message"
 }
 
+stop_guestos_service() {
+    local reason="$1"
+    if [ "$GUESTOS_SERVICE_STOPPED" = "true" ]; then
+        return 0
+    fi
+
+    log_message "$reason"
+    systemctl stop guestos.service
+    GUESTOS_SERVICE_STOPPED=true
+    RESTART_GUESTOS_SERVICE_ON_EXIT=true
+    log_message "GuestOS service stopped"
+}
+
+restart_guestos_service() {
+    local reason="$1"
+    log_message "$reason"
+    systemctl start guestos.service
+    GUESTOS_SERVICE_STOPPED=false
+    RESTART_GUESTOS_SERVICE_ON_EXIT=false
+    log_message "GuestOS service restarted successfully"
+}
+
 compute_sha256() {
     local file_path="$1"
     sha256sum "$file_path" | cut -d' ' -f1
@@ -82,6 +119,8 @@ write_prep_metadata() {
     cat >"${METADATA_FILE}" <<EOF
 VERSION=${VERSION}
 RECOVERY_HASH_PREFIX=${RECOVERY_HASH_PREFIX}
+TARGET_BOOT_ALTERNATIVE=${TARGET_BOOT_ALTERNATIVE}
+WIPE_VAR_PARTITION=${WIPE_VAR_PARTITION}
 VERSION_HASH_FULL=${VERSION_HASH_FULL}
 RECOVERY_HASH_FULL=${RECOVERY_HASH_FULL}
 EOF
@@ -98,6 +137,12 @@ load_prep_metadata() {
         case "$key" in
             VERSION) VERSION="$value" ;;
             RECOVERY_HASH_PREFIX) RECOVERY_HASH_PREFIX="$value" ;;
+            TARGET_BOOT_ALTERNATIVE) TARGET_BOOT_ALTERNATIVE="$value" ;;
+            WIPE_VAR_PARTITION)
+                if [ "$WIPE_VAR_PARTITION" != "true" ]; then
+                    WIPE_VAR_PARTITION="$value"
+                fi
+                ;;
             VERSION_HASH_FULL) VERSION_HASH_FULL="$value" ;;
             RECOVERY_HASH_FULL) RECOVERY_HASH_FULL="$value" ;;
         esac
@@ -193,13 +238,15 @@ retry_operation() {
 
 get_upgrade_target_partitions() {
     local lodev="$1"
-    local boot_alternative="$2"
+    local target_boot_alternative="$2"
 
-    # boot_alternative is the system that is *currently running*
-    if [ "$boot_alternative" = "A" ]; then
+    if [ "$target_boot_alternative" = "A" ]; then
+        echo "${lodev}p${BOOT_PARTITION_A} ${lodev}p${ROOT_PARTITION_A} ${lodev}p${VAR_PARTITION_A}"
+    elif [ "$target_boot_alternative" = "B" ]; then
         echo "${lodev}p${BOOT_PARTITION_B} ${lodev}p${ROOT_PARTITION_B} ${lodev}p${VAR_PARTITION_B}"
     else
-        echo "${lodev}p${BOOT_PARTITION_A} ${lodev}p${ROOT_PARTITION_A} ${lodev}p${VAR_PARTITION_A}"
+        log_message "ERROR: target-boot-alternative must be A or B"
+        exit 1
     fi
 }
 
@@ -219,8 +266,13 @@ prepare_guestos_upgrade() {
     boot_alternative="$(grep -oP '^boot_alternative=\K[a-zA-Z]+' "${grubdir}/grubenv")"
     log_message "Current boot alternative: $boot_alternative"
 
-    # Get upgrade partition targets
-    read -r boot_target root_target var_target < <(get_upgrade_target_partitions "$lodev" "$boot_alternative")
+    if [ -z "$TARGET_BOOT_ALTERNATIVE" ]; then
+        log_message "ERROR: target-boot-alternative must be set before preparing the upgrade target"
+        exit 1
+    fi
+
+    log_message "Target boot alternative: ${TARGET_BOOT_ALTERNATIVE}"
+    read -r boot_target root_target var_target < <(get_upgrade_target_partitions "$lodev" "$TARGET_BOOT_ALTERNATIVE")
     log_message "Target boot partition: $boot_target"
     log_message "Target root partition: $root_target"
     log_message "Target var partition: $var_target"
@@ -273,6 +325,9 @@ install_upgrade() {
 
     log_message "Current boot alternative: ${boot_alternative}"
     log_message "Current boot cycle: ${boot_cycle}"
+    log_message "Configured target boot alternative: ${TARGET_BOOT_ALTERNATIVE}"
+
+    INSTALL_STARTED=true
 
     log_message "Writing boot image to ${boot_target}..."
     dd if="$extract_dir/boot.img" of="${boot_target}" bs=1M status=progress
@@ -282,19 +337,16 @@ install_upgrade() {
     dd if="$extract_dir/root.img" of="${root_target}" bs=1M status=progress
     log_message "Root image written successfully"
 
-    log_message "Wiping var partition header on ${var_target}..."
-    dd if=/dev/zero of="${var_target}" bs=1M count=16 status=progress
-    log_message "Var partition header wiped successfully"
+    if [ "$WIPE_VAR_PARTITION" = "true" ]; then
+        log_message "Wiping var partition header on ${var_target}..."
+        dd if=/dev/zero of="${var_target}" bs=1M count=16 status=progress
+        log_message "Var partition header wiped successfully"
+    else
+        log_message "TEE mode selected; preserving var partition on ${var_target}"
+    fi
 
     log_message "Updating grubenv to prepare for next boot..."
-    if [[ "${boot_target}" == *"p7" ]]; then
-        boot_alternative="B"
-    elif [[ "${boot_target}" == *"p4" ]]; then
-        boot_alternative="A"
-    else
-        log_message "ERROR: Invalid boot device partition number"
-        exit 1
-    fi
+    boot_alternative="${TARGET_BOOT_ALTERNATIVE}"
     boot_cycle=first_boot
     log_message "Setting boot_alternative to ${boot_alternative} and boot_cycle to ${boot_cycle}"
     write_grubenv "${grubdir}/grubenv" "$boot_alternative" "$boot_cycle"
@@ -334,15 +386,24 @@ prep_phase() {
         return 1
     fi
 
-    if ! retry_operation "recovery artifact download and hashing" download_recovery_and_hash "$RECOVERY_HASH_PREFIX" "$STAGE_DIR"; then
-        return 1
+    if ! recovery_hash_enabled; then
+        log_message "TEE mode selected; skipping recovery artifact download and hashing"
+        RECOVERY_HASH_FULL=""
+    else
+        if ! retry_operation "recovery artifact download and hashing" download_recovery_and_hash "$RECOVERY_HASH_PREFIX" "$STAGE_DIR"; then
+            return 1
+        fi
     fi
 
     write_prep_metadata
 
     log_message "Prep phase complete. Calculated hashes:"
     log_message "  VERSION-HASH: ${VERSION_HASH_FULL}"
-    log_message "  RECOVERY-HASH: ${RECOVERY_HASH_FULL}"
+    if ! recovery_hash_enabled; then
+        log_message "  RECOVERY-HASH: skipped"
+    else
+        log_message "  RECOVERY-HASH: ${RECOVERY_HASH_FULL}"
+    fi
     return 0
 }
 
@@ -370,6 +431,17 @@ guestos_upgrade_cleanup() {
     elif [ -n "${STAGE_DIR}" ]; then
         log_message "Staging directory preserved at ${STAGE_DIR}"
     fi
+
+    if [ "$RESTART_GUESTOS_SERVICE_ON_EXIT" = "true" ] && [ "$INSTALL_STARTED" != "true" ]; then
+        log_message "Restarting guestos.service during cleanup after early exit"
+        if systemctl start guestos.service; then
+            log_message "GuestOS service restarted during cleanup"
+            GUESTOS_SERVICE_STOPPED=false
+            RESTART_GUESTOS_SERVICE_ON_EXIT=false
+        else
+            log_message "WARNING: Failed to restart guestos.service during cleanup"
+        fi
+    fi
 }
 
 main() {
@@ -377,16 +449,22 @@ main() {
 
     parse_args "$@"
 
-    log_message "Parsed MODE='$MODE' VERSION='$VERSION' RECOVERY_HASH_PREFIX='$RECOVERY_HASH_PREFIX'"
+    log_message "Parsed MODE='$MODE' VERSION='$VERSION' RECOVERY_HASH_PREFIX='$RECOVERY_HASH_PREFIX' TARGET_BOOT_ALTERNATIVE='$TARGET_BOOT_ALTERNATIVE' WIPE_VAR_PARTITION='$WIPE_VAR_PARTITION'"
 
     if [[ -z "$MODE" || ("$MODE" != "run" && "$MODE" != "prep" && "$MODE" != "install") ]]; then
         log_message "ERROR: mode must be one of run|prep|install"
         exit 1
     fi
 
-    if [ "$MODE" != "install" ] && { [ -z "$VERSION" ] || [ -z "$RECOVERY_HASH_PREFIX" ]; }; then
-        log_message "ERROR: version and recovery-hash-prefix parameters are required"
-        log_message "Usage: mode=<run|prep|install> version=<40-char-hex> recovery-hash-prefix=<6-char-hex>"
+    if [ "$MODE" != "install" ] && [ -z "$VERSION" ]; then
+        log_message "ERROR: version parameter is required"
+        log_message "Usage: mode=<prep|run> version=<40-char-hex> target-boot-alternative=<A|B> [recovery-hash-prefix=<6-char-hex>|recovery-hash-prefix=] [wipe-var-partition]"
+        exit 1
+    fi
+
+    if [ "$MODE" != "install" ] && [ -z "$TARGET_BOOT_ALTERNATIVE" ]; then
+        log_message "ERROR: target-boot-alternative parameter is required for mode=${MODE}"
+        log_message "Usage: mode=<prep|run> version=<40-char-hex> target-boot-alternative=<A|B> [recovery-hash-prefix=<6-char-hex>|recovery-hash-prefix=] [wipe-var-partition]"
         exit 1
     fi
 
@@ -414,13 +492,34 @@ main() {
         fi
         log_message "Loaded prep metadata from ${STAGE_DIR}"
         log_message "  VERSION: ${VERSION}"
+        log_message "  TARGET-BOOT-ALTERNATIVE: ${TARGET_BOOT_ALTERNATIVE}"
+        log_message "  WIPE-VAR-PARTITION: ${WIPE_VAR_PARTITION}"
         log_message "  VERSION-HASH: ${VERSION_HASH_FULL}"
-        log_message "  RECOVERY-HASH (prefix): ${RECOVERY_HASH_PREFIX}"
-        log_message "  RECOVERY-HASH (full): ${RECOVERY_HASH_FULL}"
+        if ! recovery_hash_enabled; then
+            log_message "  RECOVERY-HASH: skipped"
+        else
+            log_message "  RECOVERY-HASH (prefix): ${RECOVERY_HASH_PREFIX}"
+            log_message "  RECOVERY-HASH (full): ${RECOVERY_HASH_FULL}"
+        fi
     fi
 
-    if [ ! -f "${STAGE_DIR}/upgrade.tar.zst" ] || [ ! -f "${STAGE_DIR}/recovery.tar.zst" ]; then
-        log_message "ERROR: Staging directory is missing required artifacts (${STAGE_DIR})"
+    if [ -z "$TARGET_BOOT_ALTERNATIVE" ]; then
+        log_message "ERROR: target-boot-alternative must be provided via arguments or prep metadata"
+        exit 1
+    fi
+
+    if [ -n "$TARGET_BOOT_ALTERNATIVE" ] && [ "$TARGET_BOOT_ALTERNATIVE" != "A" ] && [ "$TARGET_BOOT_ALTERNATIVE" != "B" ]; then
+        log_message "ERROR: target-boot-alternative must be A or B"
+        exit 1
+    fi
+
+    if [ ! -f "${STAGE_DIR}/upgrade.tar.zst" ]; then
+        log_message "ERROR: Staging directory is missing the upgrade artifact (${STAGE_DIR})"
+        exit 1
+    fi
+
+    if recovery_hash_enabled && [ ! -f "${STAGE_DIR}/recovery.tar.zst" ]; then
+        log_message "ERROR: Staging directory is missing the recovery artifact (${STAGE_DIR})"
         exit 1
     fi
 
@@ -428,9 +527,11 @@ main() {
 
     extract_upgrade "$STAGE_DIR" "$extract_dir"
 
-    log_message "Stopping guestos.service for manual upgrade"
-    systemctl stop guestos.service
-    log_message "GuestOS service stopped"
+    if ! recovery_hash_enabled; then
+        stop_guestos_service "Stopping guestos.service before overwriting the currently running GuestOS alternative"
+    else
+        stop_guestos_service "Stopping guestos.service for manual upgrade"
+    fi
 
     install_upgrade "$STAGE_DIR" "$extract_dir"
 
@@ -438,15 +539,18 @@ main() {
 
     log_message "Launching GuestOS on the new version..."
 
-    log_message "Writing recovery hash to file"
     RECOVERY_FILE="/run/config/guestos_recovery_hash"
-    mkdir -p "$(dirname "$RECOVERY_FILE")"
-    echo "$RECOVERY_HASH_PREFIX" >"$RECOVERY_FILE"
-    log_message "Recovery hash written to $RECOVERY_FILE"
+    if ! recovery_hash_enabled; then
+        rm -f "$RECOVERY_FILE"
+        log_message "TEE mode selected; removed any existing recovery hash file"
+    else
+        log_message "Writing recovery hash to file"
+        mkdir -p "$(dirname "$RECOVERY_FILE")"
+        echo "$RECOVERY_HASH_PREFIX" >"$RECOVERY_FILE"
+        log_message "Recovery hash written to $RECOVERY_FILE"
+    fi
 
-    log_message "Restarting guestos.service after manual upgrade installation"
-    systemctl start guestos.service
-    log_message "GuestOS service restarted successfully"
+    restart_guestos_service "Restarting guestos.service after manual upgrade installation"
 
     # Log success banner in so that it is visible in manual recovery fallback method
     print_success_banner

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
@@ -89,21 +89,15 @@ log_message() {
 }
 
 stop_guestos_service() {
-    local reason="$1"
-    if [ "$GUESTOS_SERVICE_STOPPED" = "true" ]; then
-        return 0
-    fi
-
-    log_message "$reason"
+    log_message "Stopping guestos.service for upgrade"
     systemctl stop guestos.service
     GUESTOS_SERVICE_STOPPED=true
     RESTART_GUESTOS_SERVICE_ON_EXIT=true
     log_message "GuestOS service stopped"
 }
 
-restart_guestos_service() {
-    local reason="$1"
-    log_message "$reason"
+start_guestos_service() {
+    log_message "Restarting guestos.service after manual upgrade installation"
     systemctl start guestos.service
     GUESTOS_SERVICE_STOPPED=false
     RESTART_GUESTOS_SERVICE_ON_EXIT=false
@@ -527,11 +521,7 @@ main() {
 
     extract_upgrade "$STAGE_DIR" "$extract_dir"
 
-    if ! recovery_hash_enabled; then
-        stop_guestos_service "Stopping guestos.service before overwriting the currently running GuestOS alternative"
-    else
-        stop_guestos_service "Stopping guestos.service for manual upgrade"
-    fi
+    stop_guestos_service
 
     install_upgrade "$STAGE_DIR" "$extract_dir"
 
@@ -550,7 +540,7 @@ main() {
         log_message "Recovery hash written to $RECOVERY_FILE"
     fi
 
-    restart_guestos_service "Restarting guestos.service after manual upgrade installation"
+    start_guestos_service
 
     # Log success banner in so that it is visible in manual recovery fallback method
     print_success_banner

--- a/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
+++ b/ic-os/components/misc/guestos-recovery/guestos-recovery-upgrader/guestos-recovery-upgrader.sh
@@ -97,11 +97,15 @@ stop_guestos_service() {
 }
 
 start_guestos_service() {
-    log_message "Restarting guestos.service after manual upgrade installation"
-    systemctl start guestos.service
-    GUESTOS_SERVICE_STOPPED=false
-    RESTART_GUESTOS_SERVICE_ON_EXIT=false
-    log_message "GuestOS service restarted successfully"
+    local reason="$1"
+    log_message "$reason"
+    if systemctl start guestos.service; then
+        GUESTOS_SERVICE_STOPPED=false
+        RESTART_GUESTOS_SERVICE_ON_EXIT=false
+        log_message "GuestOS service restarted successfully"
+        return 0
+    fi
+    return 1
 }
 
 compute_sha256() {
@@ -427,12 +431,7 @@ guestos_upgrade_cleanup() {
     fi
 
     if [ "$RESTART_GUESTOS_SERVICE_ON_EXIT" = "true" ] && [ "$INSTALL_STARTED" != "true" ]; then
-        log_message "Restarting guestos.service during cleanup after early exit"
-        if systemctl start guestos.service; then
-            log_message "GuestOS service restarted during cleanup"
-            GUESTOS_SERVICE_STOPPED=false
-            RESTART_GUESTOS_SERVICE_ON_EXIT=false
-        else
+        if ! start_guestos_service "Restarting guestos.service during cleanup after early exit"; then
             log_message "WARNING: Failed to restart guestos.service during cleanup"
         fi
     fi
@@ -540,7 +539,7 @@ main() {
         log_message "Recovery hash written to $RECOVERY_FILE"
     fi
 
-    start_guestos_service
+    start_guestos_service "Restarting guestos.service after manual upgrade installation"
 
     # Log success banner in so that it is visible in manual recovery fallback method
     print_success_banner

--- a/rs/ic_os/os_tools/hostos_tool/src/guestos_alternative.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/guestos_alternative.rs
@@ -21,9 +21,36 @@ pub fn show_guestos_alternative() -> Result<()> {
     show_guestos_alternative_impl(&GptPartitionProvider::new(GUESTOS_DEVICE.into())?)
 }
 
+/// Returns the current GuestOS boot alternative.
+pub fn get_current_guestos_alternative() -> Result<grub::BootAlternative> {
+    get_current_guestos_alternative_impl(&GptPartitionProvider::new(GUESTOS_DEVICE.into())?)
+}
+
+fn get_current_guestos_alternative_impl(
+    partition_provider: &dyn ic_device::mount::PartitionProvider,
+) -> Result<grub::BootAlternative> {
+    let grub_partition = partition_provider
+        .mount_partition(
+            PartitionSelector::ByUuid(GRUB_PARTITION_UUID),
+            MountOptions {
+                file_system: FileSystem::Vfat,
+                read_only: true, // GuestOS may be running, we must mount readonly
+            },
+        )
+        .context("Could not mount grub partition")?;
+    let grubenv_path = grub_partition.mount_point().join("grubenv");
+
+    let grubenv_file = std::fs::File::open(&grubenv_path).context("Failed to open grubenv")?;
+    let grubenv = grub::GrubEnv::read_from(grubenv_file).context("Failed to read grubenv")?;
+    grubenv
+        .boot_alternative
+        .context("Invalid/missing boot alternative in grubenv")
+}
+
 fn show_guestos_alternative_impl(
     partition_provider: &dyn ic_device::mount::PartitionProvider,
 ) -> Result<()> {
+    let current_boot_alternative = get_current_guestos_alternative_impl(partition_provider);
     let grub_partition = partition_provider
         .mount_partition(
             PartitionSelector::ByUuid(GRUB_PARTITION_UUID),
@@ -39,9 +66,7 @@ fn show_guestos_alternative_impl(
     let grubenv = grub::GrubEnv::read_from(grubenv_file).context("Failed to read grubenv")?;
     println!(
         "GuestOS Boot alternative: {}",
-        grubenv
-            .boot_alternative
-            .map_or_else(|e| e.to_string(), |v| v.to_string())
+        current_boot_alternative.map_or_else(|e| e.to_string(), |v| v.to_string())
     );
     println!(
         "GuestOS Boot cycle: {}",
@@ -214,6 +239,15 @@ mod tests {
 
         let result = show_guestos_alternative_impl(&provider);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_get_current_guestos_alternative_impl() {
+        let (provider, _temp_dir) =
+            create_mock_partition_provider(Some(grub::BootAlternative::B), Some(BootCycle::Stable));
+
+        let result = get_current_guestos_alternative_impl(&provider);
+        assert_eq!(result.unwrap(), grub::BootAlternative::B);
     }
 
     #[test]

--- a/rs/ic_os/os_tools/hostos_tool/src/main.rs
+++ b/rs/ic_os/os_tools/hostos_tool/src/main.rs
@@ -5,7 +5,7 @@ use config_types::{HostOSConfig, Ipv6Config};
 use deterministic_ips::node_type::NodeType;
 use deterministic_ips::{MacAddr6Ext, calculate_deterministic_mac};
 use grub::BootAlternative;
-use manual_guestos_recovery::GuestOSRecoveryApp;
+use manual_guestos_recovery::{GuestOSRecoveryApp, RecoveryMode};
 use network::generate_network_config;
 use network::systemd::DEFAULT_SYSTEMD_NETWORK_DIR;
 use std::path::Path;
@@ -13,7 +13,9 @@ use tracing::warn;
 use utils::to_cidr;
 
 mod guestos_alternative;
-use guestos_alternative::{show_guestos_alternative, swap_guestos_alternative};
+use guestos_alternative::{
+    get_current_guestos_alternative, show_guestos_alternative, swap_guestos_alternative,
+};
 
 use ic_os_metrics_utils::write_registry_to_file;
 
@@ -47,7 +49,11 @@ pub enum Commands {
         output_path: String,
     },
     /// Launch the Recovery TUI tool for manual node recovery
-    ManualRecovery,
+    ManualRecovery {
+        /// Recovery mode: nns requires the recovery hash, tee hides it.
+        #[arg(value_enum, default_value_t = RecoveryMode::Nns)]
+        mode: RecoveryMode,
+    },
     /// Show or swap the GuestOS boot alternative (A/B)
     #[command(name = "guestos-alternative", subcommand)]
     GuestosAlternative(GuestosAlternativeCommands),
@@ -151,8 +157,9 @@ pub fn main() -> Result<()> {
             println!("{generated_mac}");
             Ok(())
         }
-        Some(Commands::ManualRecovery) => {
-            let mut app = GuestOSRecoveryApp::new();
+        Some(Commands::ManualRecovery { mode }) => {
+            let current_boot_alternative = get_current_guestos_alternative()?;
+            let mut app = GuestOSRecoveryApp::new(mode, current_boot_alternative);
             app.run()?;
             Ok(())
         }

--- a/rs/ic_os/os_tools/manual_guestos_recovery/BUILD.bazel
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//rs:ic-os-pkg"])
 
@@ -11,7 +11,27 @@ rust_library(
         "//rs:system-tests-pkg",
     ],
     deps = [
+        "//rs/ic_os/boot/grub",
         "@crate_index//:anyhow",
+        "@crate_index//:clap",
+        "@crate_index//:ratatui",
+        "@crate_index//:scopeguard",
+        "@crate_index//:shell-escape",
+        "@crate_index//:tracing",
+        "@crate_index//:tui-textarea",
+    ],
+)
+
+rust_test(
+    name = "manual_guestos_recovery_test",
+    crate = ":manual_guestos_recovery",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    deps = [
+        "//rs/ic_os/boot/grub",
+        "@crate_index//:anyhow",
+        "@crate_index//:clap",
         "@crate_index//:ratatui",
         "@crate_index//:scopeguard",
         "@crate_index//:shell-escape",

--- a/rs/ic_os/os_tools/manual_guestos_recovery/Cargo.toml
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true }
+grub = { path = "../../boot/grub" }
 ratatui = { workspace = true }
 tracing = { workspace = true }
 scopeguard = { workspace = true }

--- a/rs/ic_os/os_tools/manual_guestos_recovery/src/lib.rs
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/src/lib.rs
@@ -1,11 +1,13 @@
-//! Interactive TUI application for manual GuestOS recovery. Prompts the operator
-//! for a recovery version and hash prefix, downloads and verifies recovery
-//! artifacts, and installs the recovery GuestOS image.
+//! Interactive TUI application for manual GuestOS recovery.
+//! NNS mode prompts for a recovery version, recovery hash prefix, and target boot alternative.
+//! TEE mode prompts only for a recovery version and target boot alternative.
 
 pub mod recovery_utils;
 mod ui;
 
 use anyhow::{Context, Result};
+use clap::ValueEnum;
+use grub::BootAlternative;
 use ratatui::crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
 };
@@ -42,31 +44,98 @@ const PROCESS_POLL_INTERVAL_MS: u64 = 100; // Polling interval for process monit
 // Types and Data Structures
 // ============================================================================
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct RecoveryParams {
     /// The commit ID of the recovery-GuestOS update image (40 hex characters)
     pub version: String,
-    /// The recovery hash prefix provided by the user (6 hex characters)
-    pub recovery_hash_prefix: String,
+    /// The recovery hash prefix provided by the user (6 hex characters), if provided.
+    pub recovery_hash_prefix: Option<String>,
     /// Calculated full hash of the downloaded recovery-GuestOS upgrade tarball
     pub version_hash_full: Option<String>,
-    /// Calculated full hash of the downloaded recovery artifact
+    /// Calculated full hash of the downloaded recovery artifact, if enabled.
     pub recovery_hash_full: Option<String>,
+    /// Whether recovery operates in NNS or TEE mode.
+    pub mode: RecoveryMode,
+    /// The currently configured GuestOS boot alternative when the TUI started.
+    pub current_boot_alternative: BootAlternative,
+    /// Whether the target should be the current or opposite boot alternative.
+    pub target_boot_alternative_selection: TargetBootAlternativeSelection,
 }
 
 fn is_lowercase_hex(c: char) -> bool {
     matches!(c, '0'..='9' | 'a'..='f')
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum RecoveryMode {
+    #[default]
+    Nns,
+    Tee,
+}
+
+impl RecoveryMode {
+    fn requires_recovery_hash(self) -> bool {
+        matches!(self, Self::Nns)
+    }
+
+    fn default_target_boot_alternative_selection(self) -> TargetBootAlternativeSelection {
+        match self {
+            Self::Nns => TargetBootAlternativeSelection::Opposite,
+            Self::Tee => TargetBootAlternativeSelection::Current,
+        }
+    }
+}
+
+/// Where the GuestOS is written.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TargetBootAlternativeSelection {
+    /// Replace the GuestOS on the current boot alternative.
+    Current,
+    /// Write to the opposite boot alternative.
+    Opposite,
+}
+
+impl TargetBootAlternativeSelection {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::Opposite => "opposite",
+        }
+    }
+}
+
+fn create_text_area_with_text(text: &str) -> TextArea<'static> {
+    let mut t = TextArea::default();
+    t.set_cursor_line_style(ratatui::style::Style::default());
+    if !text.is_empty() {
+        t.insert_str(text);
+    }
+    t
+}
+
 impl RecoveryParams {
     pub fn validate_inputs(&self) -> Result<()> {
         Self::validate_hex_field(&self.version, VERSION_LENGTH, "VERSION")?;
-        Self::validate_hex_field(
-            &self.recovery_hash_prefix,
-            PREFIX_HASH_LENGTH,
-            "RECOVERY-HASH-PREFIX",
-        )?;
+        let recovery_hash_prefix = self.recovery_hash_prefix.as_deref().unwrap_or_default();
+        if self.mode.requires_recovery_hash() {
+            Self::validate_hex_field(
+                recovery_hash_prefix,
+                PREFIX_HASH_LENGTH,
+                "RECOVERY-HASH-PREFIX",
+            )?;
+        } else if !recovery_hash_prefix.is_empty() {
+            anyhow::bail!("RECOVERY-HASH-PREFIX must be empty in TEE mode");
+        }
         Ok(())
+    }
+
+    fn get_target_boot_alternative(&self) -> BootAlternative {
+        match self.target_boot_alternative_selection {
+            TargetBootAlternativeSelection::Current => self.current_boot_alternative,
+            TargetBootAlternativeSelection::Opposite => {
+                self.current_boot_alternative.get_opposite()
+            }
+        }
     }
 
     fn validate_hex_field(value: &str, required_len: usize, name: &str) -> Result<()> {
@@ -95,6 +164,7 @@ impl RecoveryParams {
 pub(crate) enum Field {
     Version,
     RecoveryHashPrefix,
+    TargetBootAlternative,
     CheckArtifactsButton,
     ExitButton,
 }
@@ -106,14 +176,42 @@ struct FieldMetadata {
 }
 
 impl Field {
-    const ALL: &'static [Field] = &[
+    const ALL_NNS: &'static [Field] = &[
         Field::Version,
         Field::RecoveryHashPrefix,
+        Field::TargetBootAlternative,
         Field::CheckArtifactsButton,
         Field::ExitButton,
     ];
 
-    const INPUT_FIELDS: &'static [Field] = &[Field::Version, Field::RecoveryHashPrefix];
+    const ALL_TEE: &'static [Field] = &[
+        Field::Version,
+        Field::TargetBootAlternative,
+        Field::CheckArtifactsButton,
+        Field::ExitButton,
+    ];
+
+    const INPUT_FIELDS_NNS: &'static [Field] = &[
+        Field::Version,
+        Field::RecoveryHashPrefix,
+        Field::TargetBootAlternative,
+    ];
+
+    const INPUT_FIELDS_TEE: &'static [Field] = &[Field::Version, Field::TargetBootAlternative];
+
+    fn all_fields(mode: RecoveryMode) -> &'static [Field] {
+        match mode {
+            RecoveryMode::Nns => Self::ALL_NNS,
+            RecoveryMode::Tee => Self::ALL_TEE,
+        }
+    }
+
+    fn input_fields(mode: RecoveryMode) -> &'static [Field] {
+        match mode {
+            RecoveryMode::Nns => Self::INPUT_FIELDS_NNS,
+            RecoveryMode::Tee => Self::INPUT_FIELDS_TEE,
+        }
+    }
 
     fn metadata(&self) -> FieldMetadata {
         match self {
@@ -125,6 +223,11 @@ impl Field {
             Field::RecoveryHashPrefix => FieldMetadata {
                 name: "RECOVERY-HASH-PREFIX",
                 required_len: Some(PREFIX_HASH_LENGTH),
+                is_input: true,
+            },
+            Field::TargetBootAlternative => FieldMetadata {
+                name: "TARGET-BOOT-ALTERNATIVE",
+                required_len: None,
                 is_input: true,
             },
             _ => FieldMetadata {
@@ -151,35 +254,53 @@ pub(crate) struct InputState {
     pub inputs: Vec<TextArea<'static>>,
     pub error_message: Option<String>,
     pub exit_message: Option<String>,
+    pub mode: RecoveryMode,
+    pub current_boot_alternative: BootAlternative,
+    pub target_boot_alternative_selection: TargetBootAlternativeSelection,
 }
 
-impl Default for InputState {
-    fn default() -> Self {
-        let inputs = Field::INPUT_FIELDS
-            .iter()
-            .map(|_| {
-                let mut t = TextArea::default();
-                t.set_cursor_line_style(ratatui::style::Style::default());
-                t
-            })
-            .collect::<Vec<_>>();
+impl InputState {
+    pub fn new(mode: RecoveryMode, current_boot_alternative: BootAlternative) -> Self {
+        let target_boot_alternative_selection = mode.default_target_boot_alternative_selection();
+        let inputs = vec![create_text_area_with_text(""); Field::input_fields(mode).len()];
 
         Self {
             focused_index: 0,
             inputs,
             error_message: None,
             exit_message: None,
+            mode,
+            current_boot_alternative,
+            target_boot_alternative_selection,
         }
     }
-}
 
-impl InputState {
     pub fn current_field(&self) -> Field {
-        Field::ALL[self.focused_index]
+        self.all_fields()[self.focused_index]
+    }
+
+    pub(crate) fn resolve_boot_alternative(
+        &self,
+        selection: TargetBootAlternativeSelection,
+    ) -> BootAlternative {
+        match selection {
+            TargetBootAlternativeSelection::Current => self.current_boot_alternative,
+            TargetBootAlternativeSelection::Opposite => {
+                self.current_boot_alternative.get_opposite()
+            }
+        }
+    }
+
+    fn all_fields(&self) -> &'static [Field] {
+        Field::all_fields(self.mode)
+    }
+
+    fn input_fields(&self) -> &'static [Field] {
+        Field::input_fields(self.mode)
     }
 
     pub fn get_input_index(&self, field: Field) -> Option<usize> {
-        Field::INPUT_FIELDS.iter().position(|&f| f == field)
+        self.input_fields().iter().position(|&f| f == field)
     }
 
     pub(crate) fn get_field_text(&self, field: Field) -> String {
@@ -192,6 +313,10 @@ impl InputState {
         } else {
             String::new()
         }
+    }
+
+    fn set_target_boot_alternative_selection(&mut self, selection: TargetBootAlternativeSelection) {
+        self.target_boot_alternative_selection = selection;
     }
 }
 
@@ -292,12 +417,6 @@ pub(crate) enum AppState {
     Failure(FailureState),
 }
 
-impl Default for AppState {
-    fn default() -> Self {
-        AppState::Input(InputState::default())
-    }
-}
-
 // ============================================================================
 // Terminal Management
 // ============================================================================
@@ -341,19 +460,16 @@ pub struct GuestOSRecoveryApp {
     result: Option<Result<()>>,
 }
 
-impl Default for GuestOSRecoveryApp {
-    fn default() -> Self {
+impl GuestOSRecoveryApp {
+    pub fn new(mode: RecoveryMode, current_boot_alternative: BootAlternative) -> Self {
         Self {
-            state: Some(AppState::default()),
+            state: Some(AppState::Input(InputState::new(
+                mode,
+                current_boot_alternative,
+            ))),
             should_quit: false,
             result: None,
         }
-    }
-}
-
-impl GuestOSRecoveryApp {
-    pub fn new() -> Self {
-        Self::default()
     }
 
     fn redraw(&self, terminal: &mut DefaultTerminal) -> Result<()> {
@@ -551,6 +667,11 @@ impl GuestOSRecoveryApp {
         }
 
         let current = input_state.current_field();
+        if current == Field::TargetBootAlternative {
+            self.handle_target_boot_alternative_input(input_state, key);
+            return Ok(false);
+        }
+
         if let Some(idx) = input_state.get_input_index(current) {
             self.handle_text_input(input_state, idx, key, current);
         } else {
@@ -563,7 +684,8 @@ impl GuestOSRecoveryApp {
     }
 
     fn handle_navigation(&mut self, input_state: &mut InputState, key_code: KeyCode) {
-        let count = Field::ALL.len();
+        let all_fields = input_state.all_fields();
+        let count = all_fields.len();
         match key_code {
             KeyCode::Tab | KeyCode::Down => {
                 input_state.focused_index = (input_state.focused_index + 1) % count;
@@ -576,10 +698,10 @@ impl GuestOSRecoveryApp {
                 if matches!(current, Field::CheckArtifactsButton | Field::ExitButton) {
                     // Toggle between the last two fields (buttons)
                     if current == Field::CheckArtifactsButton {
-                        if let Some(idx) = Field::ALL.iter().position(|&f| f == Field::ExitButton) {
+                        if let Some(idx) = all_fields.iter().position(|&f| f == Field::ExitButton) {
                             input_state.focused_index = idx;
                         }
-                    } else if let Some(idx) = Field::ALL
+                    } else if let Some(idx) = all_fields
                         .iter()
                         .position(|&f| f == Field::CheckArtifactsButton)
                     {
@@ -594,7 +716,8 @@ impl GuestOSRecoveryApp {
     fn handle_submission(&mut self, input_state: &mut InputState) -> Result<bool> {
         let current = input_state.current_field();
         if current.is_input_field() {
-            input_state.focused_index = (input_state.focused_index + 1) % Field::ALL.len();
+            input_state.focused_index =
+                (input_state.focused_index + 1) % input_state.all_fields().len();
             Ok(false)
         } else {
             match current {
@@ -604,11 +727,18 @@ impl GuestOSRecoveryApp {
                     Ok(false)
                 }
                 Field::CheckArtifactsButton => {
+                    let recovery_hash_prefix =
+                        Some(input_state.get_field_text(Field::RecoveryHashPrefix))
+                            .filter(|prefix| !prefix.is_empty());
                     let params = RecoveryParams {
                         version: input_state.get_field_text(Field::Version),
-                        recovery_hash_prefix: input_state.get_field_text(Field::RecoveryHashPrefix),
+                        current_boot_alternative: input_state.current_boot_alternative,
+                        target_boot_alternative_selection: input_state
+                            .target_boot_alternative_selection,
+                        recovery_hash_prefix,
                         version_hash_full: None,
                         recovery_hash_full: None,
+                        mode: input_state.mode,
                     };
 
                     // Validate and transition to running
@@ -625,6 +755,27 @@ impl GuestOSRecoveryApp {
         }
     }
 
+    fn handle_target_boot_alternative_input(&self, input_state: &mut InputState, key: KeyEvent) {
+        match key.code {
+            KeyCode::Left | KeyCode::Char('c') | KeyCode::Char('C') => input_state
+                .set_target_boot_alternative_selection(TargetBootAlternativeSelection::Current),
+            KeyCode::Right | KeyCode::Char('o') | KeyCode::Char('O') => input_state
+                .set_target_boot_alternative_selection(TargetBootAlternativeSelection::Opposite),
+            KeyCode::Char(' ') => {
+                let toggled = match input_state.target_boot_alternative_selection {
+                    TargetBootAlternativeSelection::Current => {
+                        TargetBootAlternativeSelection::Opposite
+                    }
+                    TargetBootAlternativeSelection::Opposite => {
+                        TargetBootAlternativeSelection::Current
+                    }
+                };
+                input_state.set_target_boot_alternative_selection(toggled);
+            }
+            _ => {}
+        }
+    }
+
     fn handle_text_input(
         &self,
         input_state: &mut InputState,
@@ -632,7 +783,6 @@ impl GuestOSRecoveryApp {
         key: KeyEvent,
         field: Field,
     ) {
-        // Pre-validation for character input (hex only, max length)
         if let KeyCode::Char(c) = key.code {
             if !is_lowercase_hex(c) {
                 return;
@@ -655,8 +805,12 @@ impl GuestOSRecoveryApp {
     }
 
     fn start_prep(&mut self, params: RecoveryParams, input_state: InputState) -> Result<()> {
-        let command =
-            build_recovery_upgrader_prep_command(&params.version, &params.recovery_hash_prefix);
+        let command = build_recovery_upgrader_prep_command(
+            &params.version,
+            Some(params.get_target_boot_alternative()),
+            params.recovery_hash_prefix.as_deref().unwrap_or(""),
+            params.mode.requires_recovery_hash(),
+        );
         let task = RecoveryTask::start(command)?;
 
         self.state = Some(AppState::Running(RunningState {
@@ -669,7 +823,7 @@ impl GuestOSRecoveryApp {
     }
 
     fn start_install(&mut self, params: RecoveryParams) -> Result<()> {
-        let command = build_recovery_upgrader_install_command();
+        let command = build_recovery_upgrader_install_command(params.mode.requires_recovery_hash());
         let task = RecoveryTask::start(command)?;
 
         self.state = Some(AppState::Running(RunningState {
@@ -706,9 +860,15 @@ impl GuestOSRecoveryApp {
                     Ok(prep) => {
                         let mut params = running.params.clone();
                         params.version_hash_full = Some(prep.version_hash_full);
-                        params.recovery_hash_full = Some(prep.recovery_hash_full);
+                        params.recovery_hash_full = prep.recovery_hash_full;
 
-                        let input_state = running.previous_input_state.clone().unwrap_or_default();
+                        let input_state =
+                            running.previous_input_state.clone().unwrap_or_else(|| {
+                                InputState::new(
+                                    running.params.mode,
+                                    running.params.current_boot_alternative,
+                                )
+                            });
 
                         self.state = Some(AppState::InputConfirmation(ConfirmationState {
                             input_state,
@@ -772,7 +932,7 @@ fn extract_errors_from_logs(log_lines: &[String]) -> Vec<String> {
 #[derive(Debug)]
 struct PrepResults {
     version_hash_full: String,
-    recovery_hash_full: String,
+    recovery_hash_full: Option<String>,
 }
 
 fn read_prep_metadata() -> Result<PrepResults> {
@@ -802,9 +962,6 @@ fn parse_prep_metadata(contents: &str) -> Result<PrepResults> {
 
     let version_hash_full = version_hash_full
         .ok_or_else(|| anyhow::anyhow!("Prep metadata missing VERSION_HASH_FULL"))?;
-    let recovery_hash_full = recovery_hash_full
-        .ok_or_else(|| anyhow::anyhow!("Prep metadata missing RECOVERY_HASH_FULL"))?;
-
     Ok(PrepResults {
         version_hash_full,
         recovery_hash_full,
@@ -854,6 +1011,8 @@ mod tests {
     use super::*;
     use ratatui::crossterm::event::{KeyEventKind, KeyEventState};
 
+    const TEST_CURRENT_BOOT_ALTERNATIVE: BootAlternative = BootAlternative::A;
+
     // ========================================================================
     // Test Helpers
     // ========================================================================
@@ -891,26 +1050,41 @@ mod tests {
             .status()
             .expect("Failed to run 'false' command");
         FailureState {
-            params: RecoveryParams::default(),
+            params: default_recovery_params(),
             logs: vec!["test log".to_string()],
             exit_status: status,
             error_messages: vec!["test error".to_string()],
         }
     }
 
+    fn default_recovery_params() -> RecoveryParams {
+        RecoveryParams {
+            version: String::new(),
+            recovery_hash_prefix: None,
+            version_hash_full: None,
+            recovery_hash_full: None,
+            mode: RecoveryMode::Nns,
+            current_boot_alternative: BootAlternative::A,
+            target_boot_alternative_selection: TargetBootAlternativeSelection::Opposite,
+        }
+    }
+
+    fn create_test_input_state(mode: RecoveryMode) -> InputState {
+        InputState::new(mode, TEST_CURRENT_BOOT_ALTERNATIVE)
+    }
+
+    fn create_test_app(mode: RecoveryMode) -> GuestOSRecoveryApp {
+        GuestOSRecoveryApp::new(mode, TEST_CURRENT_BOOT_ALTERNATIVE)
+    }
+
     fn set_field_text(state: &mut InputState, field: Field, text: &str) {
         if let Some(idx) = state.get_input_index(field) {
-            state.inputs[idx] = {
-                let mut ta = TextArea::default();
-                ta.set_cursor_line_style(ratatui::style::Style::default());
-                ta.insert_str(text);
-                ta
-            };
+            state.inputs[idx] = create_text_area_with_text(text);
         }
     }
 
     fn create_valid_input_state() -> InputState {
-        let mut state = InputState::default();
+        let mut state = create_test_input_state(RecoveryMode::Nns);
         set_field_text(&mut state, Field::Version, &"a".repeat(VERSION_LENGTH));
         set_field_text(
             &mut state,
@@ -947,10 +1121,43 @@ mod tests {
         fn validate_inputs_accepts_valid_params() {
             let params = RecoveryParams {
                 version: "0123456789abcdef0123456789abcdef01234567".to_string(),
-                recovery_hash_prefix: "a1b2c3".to_string(),
-                ..Default::default()
+                recovery_hash_prefix: Some("a1b2c3".to_string()),
+                ..default_recovery_params()
             };
             assert!(params.validate_inputs().is_ok());
+        }
+
+        #[test]
+        fn validate_inputs_allows_missing_recovery_hash_in_tee_mode() {
+            let params = RecoveryParams {
+                version: "0123456789abcdef0123456789abcdef01234567".to_string(),
+                recovery_hash_prefix: None,
+                mode: RecoveryMode::Tee,
+                ..default_recovery_params()
+            };
+            assert!(params.validate_inputs().is_ok());
+        }
+
+        #[test]
+        fn validate_inputs_allows_empty_recovery_hash_in_tee_mode() {
+            let params = RecoveryParams {
+                version: "0123456789abcdef0123456789abcdef01234567".to_string(),
+                recovery_hash_prefix: Some(String::new()),
+                mode: RecoveryMode::Tee,
+                ..default_recovery_params()
+            };
+            assert!(params.validate_inputs().is_ok());
+        }
+
+        #[test]
+        fn validate_inputs_rejects_invalid_recovery_hash_in_tee_mode() {
+            let params = RecoveryParams {
+                version: "0123456789abcdef0123456789abcdef01234567".to_string(),
+                recovery_hash_prefix: Some("ABCDEF".to_string()),
+                mode: RecoveryMode::Tee,
+                ..default_recovery_params()
+            };
+            assert!(params.validate_inputs().is_err());
         }
 
         #[test]
@@ -960,24 +1167,24 @@ mod tests {
             // Empty
             let params = RecoveryParams {
                 version: String::new(),
-                recovery_hash_prefix: valid_hash.clone(),
-                ..Default::default()
+                recovery_hash_prefix: Some(valid_hash.clone()),
+                ..default_recovery_params()
             };
             assert!(params.validate_inputs().is_err());
 
             // Wrong length
             let params = RecoveryParams {
                 version: "abc".to_string(),
-                recovery_hash_prefix: valid_hash.clone(),
-                ..Default::default()
+                recovery_hash_prefix: Some(valid_hash.clone()),
+                ..default_recovery_params()
             };
             assert!(params.validate_inputs().is_err());
 
             // Invalid chars (uppercase)
             let params = RecoveryParams {
                 version: "A".repeat(VERSION_LENGTH),
-                recovery_hash_prefix: valid_hash,
-                ..Default::default()
+                recovery_hash_prefix: Some(valid_hash),
+                ..default_recovery_params()
             };
             assert!(params.validate_inputs().is_err());
         }
@@ -989,26 +1196,43 @@ mod tests {
             // Empty
             let params = RecoveryParams {
                 version: valid_version.clone(),
-                recovery_hash_prefix: String::new(),
-                ..Default::default()
+                recovery_hash_prefix: Some(String::new()),
+                ..default_recovery_params()
             };
             assert!(params.validate_inputs().is_err());
 
             // Wrong length
             let params = RecoveryParams {
                 version: valid_version.clone(),
-                recovery_hash_prefix: "abc".to_string(),
-                ..Default::default()
+                recovery_hash_prefix: Some("abc".to_string()),
+                ..default_recovery_params()
             };
             assert!(params.validate_inputs().is_err());
 
             // Invalid chars (uppercase)
             let params = RecoveryParams {
                 version: valid_version,
-                recovery_hash_prefix: "ABCDEF".to_string(),
-                ..Default::default()
+                recovery_hash_prefix: Some("ABCDEF".to_string()),
+                ..default_recovery_params()
             };
             assert!(params.validate_inputs().is_err());
+        }
+
+        #[test]
+        fn resolved_target_boot_alternative_matches_selection() {
+            let current = RecoveryParams {
+                current_boot_alternative: BootAlternative::B,
+                target_boot_alternative_selection: TargetBootAlternativeSelection::Current,
+                ..default_recovery_params()
+            };
+            assert_eq!(current.get_target_boot_alternative(), BootAlternative::B);
+
+            let opposite = RecoveryParams {
+                current_boot_alternative: BootAlternative::B,
+                target_boot_alternative_selection: TargetBootAlternativeSelection::Opposite,
+                ..default_recovery_params()
+            };
+            assert_eq!(opposite.get_target_boot_alternative(), BootAlternative::A);
         }
     }
 
@@ -1021,7 +1245,16 @@ mod tests {
             let result = parse_prep_metadata(contents).unwrap();
 
             assert_eq!(result.version_hash_full, "abc123def456");
-            assert_eq!(result.recovery_hash_full, "789xyz");
+            assert_eq!(result.recovery_hash_full, Some("789xyz".to_string()));
+        }
+
+        #[test]
+        fn parses_metadata_without_recovery_hash() {
+            let contents = "VERSION_HASH_FULL=abc123def456";
+            let result = parse_prep_metadata(contents).unwrap();
+
+            assert_eq!(result.version_hash_full, "abc123def456");
+            assert_eq!(result.recovery_hash_full, None);
         }
 
         #[test]
@@ -1063,7 +1296,7 @@ mod tests {
 
         #[test]
         fn ctrl_c_quits_from_input_state() {
-            let mut app = GuestOSRecoveryApp::default();
+            let mut app = create_test_app(RecoveryMode::Nns);
             app.handle_event(Event::Key(ctrl_c_event())).unwrap();
             assert!(app.is_should_quit());
         }
@@ -1071,8 +1304,8 @@ mod tests {
         #[test]
         fn ctrl_c_quits_from_confirmation_state() {
             let confirmation = ConfirmationState {
-                input_state: InputState::default(),
-                params: RecoveryParams::default(),
+                input_state: create_test_input_state(RecoveryMode::Nns),
+                params: default_recovery_params(),
                 selected_option: ConfirmationOption::Yes,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));
@@ -1090,7 +1323,7 @@ mod tests {
 
         #[test]
         fn non_press_events_are_ignored() {
-            let mut app = GuestOSRecoveryApp::default();
+            let mut app = create_test_app(RecoveryMode::Nns);
 
             let release_event = KeyEvent {
                 code: KeyCode::Tab,
@@ -1108,7 +1341,7 @@ mod tests {
 
         #[test]
         fn repeat_events_are_handled() {
-            let mut app = GuestOSRecoveryApp::default();
+            let mut app = create_test_app(RecoveryMode::Nns);
 
             let repeat_event = KeyEvent {
                 code: KeyCode::Tab,
@@ -1123,6 +1356,31 @@ mod tests {
                 Some(AppState::Input(s)) if s.current_field() == Field::RecoveryHashPrefix
             ));
         }
+
+        #[test]
+        fn new_in_tee_mode_hides_recovery_hash_field() {
+            let app = create_test_app(RecoveryMode::Tee);
+            assert!(matches!(
+                app.get_state(),
+                Some(AppState::Input(s)) if s.current_field() == Field::Version && s.mode == RecoveryMode::Tee
+            ));
+        }
+
+        #[test]
+        fn input_state_prefills_target_boot_alternative_from_current_boot_alternative() {
+            let state = InputState::new(RecoveryMode::Nns, BootAlternative::B);
+            assert_eq!(state.current_boot_alternative, BootAlternative::B);
+            assert_eq!(
+                state.target_boot_alternative_selection,
+                TargetBootAlternativeSelection::Opposite
+            );
+
+            let alternative_state = InputState::new(RecoveryMode::Tee, BootAlternative::B);
+            assert_eq!(
+                alternative_state.target_boot_alternative_selection,
+                TargetBootAlternativeSelection::Current
+            );
+        }
     }
 
     mod input_state {
@@ -1133,7 +1391,7 @@ mod tests {
 
             #[test]
             fn tab_navigates_forward_through_all_fields() {
-                let mut app = GuestOSRecoveryApp::default();
+                let mut app = create_test_app(RecoveryMode::Nns);
 
                 assert!(matches!(
                     app.get_state(),
@@ -1145,6 +1403,13 @@ mod tests {
                 assert!(matches!(
                     app.get_state(),
                     Some(AppState::Input(s)) if s.current_field() == Field::RecoveryHashPrefix
+                ));
+
+                app.handle_event(Event::Key(key_event(KeyCode::Tab)))
+                    .unwrap();
+                assert!(matches!(
+                    app.get_state(),
+                    Some(AppState::Input(s)) if s.current_field() == Field::TargetBootAlternative
                 ));
 
                 app.handle_event(Event::Key(key_event(KeyCode::Tab)))
@@ -1171,7 +1436,7 @@ mod tests {
 
             #[test]
             fn up_arrow_navigates_backward() {
-                let mut app = GuestOSRecoveryApp::default();
+                let mut app = create_test_app(RecoveryMode::Nns);
 
                 app.handle_event(Event::Key(key_event(KeyCode::Up)))
                     .unwrap();
@@ -1191,8 +1456,8 @@ mod tests {
             #[test]
             fn left_right_toggles_buttons() {
                 let input_state = InputState {
-                    focused_index: 2, // CheckArtifactsButton
-                    ..Default::default()
+                    focused_index: 3, // CheckArtifactsButton
+                    ..create_test_input_state(RecoveryMode::Nns)
                 };
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
 
@@ -1212,8 +1477,34 @@ mod tests {
             }
 
             #[test]
+            fn tab_navigates_through_tee_mode_without_recovery_hash_field() {
+                let mut app = create_test_app(RecoveryMode::Tee);
+
+                app.handle_event(Event::Key(key_event(KeyCode::Tab)))
+                    .unwrap();
+                assert!(matches!(
+                    app.get_state(),
+                    Some(AppState::Input(s)) if s.current_field() == Field::TargetBootAlternative
+                ));
+
+                app.handle_event(Event::Key(key_event(KeyCode::Tab)))
+                    .unwrap();
+                assert!(matches!(
+                    app.get_state(),
+                    Some(AppState::Input(s)) if s.current_field() == Field::CheckArtifactsButton
+                ));
+
+                app.handle_event(Event::Key(key_event(KeyCode::Tab)))
+                    .unwrap();
+                assert!(matches!(
+                    app.get_state(),
+                    Some(AppState::Input(s)) if s.current_field() == Field::ExitButton
+                ));
+            }
+
+            #[test]
             fn left_right_does_nothing_on_text_fields() {
-                let mut app = GuestOSRecoveryApp::default();
+                let mut app = create_test_app(RecoveryMode::Nns);
 
                 app.handle_event(Event::Key(key_event(KeyCode::Left)))
                     .unwrap();
@@ -1232,7 +1523,7 @@ mod tests {
 
             #[test]
             fn escape_quits_with_message() {
-                let mut app = GuestOSRecoveryApp::default();
+                let mut app = create_test_app(RecoveryMode::Nns);
                 app.handle_event(Event::Key(key_event(KeyCode::Esc)))
                     .unwrap();
 
@@ -1250,7 +1541,7 @@ mod tests {
 
             #[test]
             fn accepts_lowercase_hex() {
-                let mut app = GuestOSRecoveryApp::default();
+                let mut app = create_test_app(RecoveryMode::Nns);
 
                 for c in ['0', '1', '9', 'a', 'b', 'f'] {
                     app.handle_event(Event::Key(char_event(c))).unwrap();
@@ -1265,7 +1556,7 @@ mod tests {
 
             #[test]
             fn rejects_invalid_characters() {
-                let mut app = GuestOSRecoveryApp::default();
+                let mut app = create_test_app(RecoveryMode::Nns);
 
                 for c in ['A', 'G', 'z', ' ', '!'] {
                     app.handle_event(Event::Key(char_event(c))).unwrap();
@@ -1280,7 +1571,7 @@ mod tests {
 
             #[test]
             fn respects_max_length() {
-                let mut app = GuestOSRecoveryApp::default();
+                let mut app = create_test_app(RecoveryMode::Nns);
 
                 for _ in 0..(VERSION_LENGTH + 10) {
                     app.handle_event(Event::Key(char_event('a'))).unwrap();
@@ -1295,7 +1586,7 @@ mod tests {
 
             #[test]
             fn enter_advances_focus() {
-                let mut app = GuestOSRecoveryApp::default();
+                let mut app = create_test_app(RecoveryMode::Nns);
                 app.handle_event(Event::Key(key_event(KeyCode::Enter)))
                     .unwrap();
 
@@ -1306,10 +1597,41 @@ mod tests {
             }
 
             #[test]
+            fn target_boot_alternative_field_switches_between_current_and_opposite() {
+                let mut input_state = create_test_input_state(RecoveryMode::Nns);
+                input_state.focused_index = 2;
+                let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
+
+                app.handle_event(Event::Key(key_event(KeyCode::Left)))
+                    .unwrap();
+
+                if let Some(AppState::Input(state)) = app.get_state() {
+                    assert_eq!(
+                        state.target_boot_alternative_selection,
+                        TargetBootAlternativeSelection::Current
+                    );
+                } else {
+                    panic!("Expected Input state");
+                }
+
+                app.handle_event(Event::Key(key_event(KeyCode::Right)))
+                    .unwrap();
+
+                if let Some(AppState::Input(state)) = app.get_state() {
+                    assert_eq!(
+                        state.target_boot_alternative_selection,
+                        TargetBootAlternativeSelection::Opposite
+                    );
+                } else {
+                    panic!("Expected Input state");
+                }
+            }
+
+            #[test]
             fn typing_clears_error_message() {
                 let input_state = InputState {
                     error_message: Some("Previous error".to_string()),
-                    ..Default::default()
+                    ..create_test_input_state(RecoveryMode::Nns)
                 };
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
 
@@ -1324,7 +1646,7 @@ mod tests {
 
             #[test]
             fn backspace_deletes_characters() {
-                let mut input_state = InputState::default();
+                let mut input_state = create_test_input_state(RecoveryMode::Nns);
                 set_field_text(&mut input_state, Field::Version, "abc123");
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
 
@@ -1345,8 +1667,8 @@ mod tests {
             #[test]
             fn exit_button_quits() {
                 let input_state = InputState {
-                    focused_index: 3, // ExitButton
-                    ..Default::default()
+                    focused_index: 4, // ExitButton
+                    ..create_test_input_state(RecoveryMode::Nns)
                 };
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
 
@@ -1359,8 +1681,8 @@ mod tests {
             #[test]
             fn empty_inputs_shows_error() {
                 let input_state = InputState {
-                    focused_index: 2, // CheckArtifactsButton
-                    ..Default::default()
+                    focused_index: 3, // CheckArtifactsButton
+                    ..create_test_input_state(RecoveryMode::Nns)
                 };
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
 
@@ -1377,10 +1699,10 @@ mod tests {
 
             #[test]
             fn invalid_version_length_shows_error() {
-                let mut input_state = InputState::default();
+                let mut input_state = create_test_input_state(RecoveryMode::Nns);
                 set_field_text(&mut input_state, Field::Version, "abc"); // Too short
                 set_field_text(&mut input_state, Field::RecoveryHashPrefix, "123456");
-                input_state.focused_index = 2; // CheckArtifactsButton
+                input_state.focused_index = 3; // CheckArtifactsButton
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
 
                 app.handle_event(Event::Key(key_event(KeyCode::Enter)))
@@ -1402,8 +1724,8 @@ mod tests {
         #[test]
         fn escape_returns_to_input() {
             let confirmation = ConfirmationState {
-                input_state: InputState::default(),
-                params: RecoveryParams::default(),
+                input_state: create_test_input_state(RecoveryMode::Nns),
+                params: default_recovery_params(),
                 selected_option: ConfirmationOption::Yes,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));
@@ -1418,8 +1740,8 @@ mod tests {
         #[test]
         fn tab_toggles_selection() {
             let confirmation = ConfirmationState {
-                input_state: InputState::default(),
-                params: RecoveryParams::default(),
+                input_state: create_test_input_state(RecoveryMode::Nns),
+                params: default_recovery_params(),
                 selected_option: ConfirmationOption::Yes,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));
@@ -1444,8 +1766,8 @@ mod tests {
         #[test]
         fn left_right_changes_selection() {
             let confirmation = ConfirmationState {
-                input_state: InputState::default(),
-                params: RecoveryParams::default(),
+                input_state: create_test_input_state(RecoveryMode::Nns),
+                params: default_recovery_params(),
                 selected_option: ConfirmationOption::Yes,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));
@@ -1471,7 +1793,7 @@ mod tests {
         fn enter_no_returns_to_input() {
             let confirmation = ConfirmationState {
                 input_state: create_valid_input_state(),
-                params: RecoveryParams::default(),
+                params: default_recovery_params(),
                 selected_option: ConfirmationOption::No,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));

--- a/rs/ic_os/os_tools/manual_guestos_recovery/src/lib.rs
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/src/lib.rs
@@ -78,6 +78,10 @@ impl RecoveryMode {
         matches!(self, Self::Nns)
     }
 
+    fn can_select_target_boot_alternative(self) -> bool {
+        matches!(self, Self::Tee)
+    }
+
     fn default_target_boot_alternative_selection(self) -> TargetBootAlternativeSelection {
         match self {
             Self::Nns => TargetBootAlternativeSelection::Opposite,
@@ -129,8 +133,16 @@ impl RecoveryParams {
         Ok(())
     }
 
+    fn effective_target_boot_alternative_selection(&self) -> TargetBootAlternativeSelection {
+        if self.mode.can_select_target_boot_alternative() {
+            self.target_boot_alternative_selection
+        } else {
+            self.mode.default_target_boot_alternative_selection()
+        }
+    }
+
     fn get_target_boot_alternative(&self) -> BootAlternative {
-        match self.target_boot_alternative_selection {
+        match self.effective_target_boot_alternative_selection() {
             TargetBootAlternativeSelection::Current => self.current_boot_alternative,
             TargetBootAlternativeSelection::Opposite => {
                 self.current_boot_alternative.get_opposite()
@@ -179,7 +191,6 @@ impl Field {
     const ALL_NNS: &'static [Field] = &[
         Field::Version,
         Field::RecoveryHashPrefix,
-        Field::TargetBootAlternative,
         Field::CheckArtifactsButton,
         Field::ExitButton,
     ];
@@ -191,11 +202,7 @@ impl Field {
         Field::ExitButton,
     ];
 
-    const INPUT_FIELDS_NNS: &'static [Field] = &[
-        Field::Version,
-        Field::RecoveryHashPrefix,
-        Field::TargetBootAlternative,
-    ];
+    const INPUT_FIELDS_NNS: &'static [Field] = &[Field::Version, Field::RecoveryHashPrefix];
 
     const INPUT_FIELDS_TEE: &'static [Field] = &[Field::Version, Field::TargetBootAlternative];
 
@@ -1219,10 +1226,11 @@ mod tests {
         }
 
         #[test]
-        fn resolved_target_boot_alternative_matches_selection() {
+        fn get_target_boot_alternative_honors_selection_in_tee_mode() {
             let current = RecoveryParams {
                 current_boot_alternative: BootAlternative::B,
                 target_boot_alternative_selection: TargetBootAlternativeSelection::Current,
+                mode: RecoveryMode::Tee,
                 ..default_recovery_params()
             };
             assert_eq!(current.get_target_boot_alternative(), BootAlternative::B);
@@ -1230,9 +1238,21 @@ mod tests {
             let opposite = RecoveryParams {
                 current_boot_alternative: BootAlternative::B,
                 target_boot_alternative_selection: TargetBootAlternativeSelection::Opposite,
+                mode: RecoveryMode::Tee,
                 ..default_recovery_params()
             };
             assert_eq!(opposite.get_target_boot_alternative(), BootAlternative::A);
+        }
+
+        #[test]
+        fn get_target_boot_alternative_uses_opposite_in_nns_mode() {
+            let params = RecoveryParams {
+                current_boot_alternative: BootAlternative::B,
+                target_boot_alternative_selection: TargetBootAlternativeSelection::Current,
+                mode: RecoveryMode::Nns,
+                ..default_recovery_params()
+            };
+            assert_eq!(params.get_target_boot_alternative(), BootAlternative::A);
         }
     }
 
@@ -1409,13 +1429,6 @@ mod tests {
                     .unwrap();
                 assert!(matches!(
                     app.get_state(),
-                    Some(AppState::Input(s)) if s.current_field() == Field::TargetBootAlternative
-                ));
-
-                app.handle_event(Event::Key(key_event(KeyCode::Tab)))
-                    .unwrap();
-                assert!(matches!(
-                    app.get_state(),
                     Some(AppState::Input(s)) if s.current_field() == Field::CheckArtifactsButton
                 ));
 
@@ -1456,7 +1469,7 @@ mod tests {
             #[test]
             fn left_right_toggles_buttons() {
                 let input_state = InputState {
-                    focused_index: 3, // CheckArtifactsButton
+                    focused_index: 2, // CheckArtifactsButton
                     ..create_test_input_state(RecoveryMode::Nns)
                 };
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
@@ -1597,9 +1610,9 @@ mod tests {
             }
 
             #[test]
-            fn target_boot_alternative_field_switches_between_current_and_opposite() {
-                let mut input_state = create_test_input_state(RecoveryMode::Nns);
-                input_state.focused_index = 2;
+            fn tee_target_boot_alternative_field_switches_between_current_and_opposite() {
+                let mut input_state = create_test_input_state(RecoveryMode::Tee);
+                input_state.focused_index = 1;
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
 
                 app.handle_event(Event::Key(key_event(KeyCode::Left)))
@@ -1667,7 +1680,7 @@ mod tests {
             #[test]
             fn exit_button_quits() {
                 let input_state = InputState {
-                    focused_index: 4, // ExitButton
+                    focused_index: 3, // ExitButton
                     ..create_test_input_state(RecoveryMode::Nns)
                 };
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
@@ -1681,7 +1694,7 @@ mod tests {
             #[test]
             fn empty_inputs_shows_error() {
                 let input_state = InputState {
-                    focused_index: 3, // CheckArtifactsButton
+                    focused_index: 2, // CheckArtifactsButton
                     ..create_test_input_state(RecoveryMode::Nns)
                 };
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
@@ -1702,7 +1715,7 @@ mod tests {
                 let mut input_state = create_test_input_state(RecoveryMode::Nns);
                 set_field_text(&mut input_state, Field::Version, "abc"); // Too short
                 set_field_text(&mut input_state, Field::RecoveryHashPrefix, "123456");
-                input_state.focused_index = 3; // CheckArtifactsButton
+                input_state.focused_index = 2; // CheckArtifactsButton
                 let mut app = GuestOSRecoveryApp::with_state(AppState::Input(input_state));
 
                 app.handle_event(Event::Key(key_event(KeyCode::Enter)))

--- a/rs/ic_os/os_tools/manual_guestos_recovery/src/lib.rs
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/src/lib.rs
@@ -1,6 +1,6 @@
 //! Interactive TUI application for manual GuestOS recovery.
-//! NNS mode prompts for a recovery version, recovery hash prefix, and target boot alternative.
-//! TEE mode prompts only for a recovery version and target boot alternative.
+//! NNS mode prompts for a recovery version and recovery hash prefix.
+//! TEE mode prompts for a recovery version and target boot alternative.
 
 pub mod recovery_utils;
 mod ui;
@@ -814,7 +814,7 @@ impl GuestOSRecoveryApp {
     fn start_prep(&mut self, params: RecoveryParams, input_state: InputState) -> Result<()> {
         let command = build_recovery_upgrader_prep_command(
             &params.version,
-            Some(params.get_target_boot_alternative()),
+            params.get_target_boot_alternative(),
             params.recovery_hash_prefix.as_deref().unwrap_or(""),
             params.mode.requires_recovery_hash(),
         );
@@ -1057,14 +1057,14 @@ mod tests {
             .status()
             .expect("Failed to run 'false' command");
         FailureState {
-            params: default_recovery_params(),
+            params: default_recovery_params_for_test(),
             logs: vec!["test log".to_string()],
             exit_status: status,
             error_messages: vec!["test error".to_string()],
         }
     }
 
-    fn default_recovery_params() -> RecoveryParams {
+    fn default_recovery_params_for_test() -> RecoveryParams {
         RecoveryParams {
             version: String::new(),
             recovery_hash_prefix: None,
@@ -1129,7 +1129,7 @@ mod tests {
             let params = RecoveryParams {
                 version: "0123456789abcdef0123456789abcdef01234567".to_string(),
                 recovery_hash_prefix: Some("a1b2c3".to_string()),
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_ok());
         }
@@ -1140,7 +1140,7 @@ mod tests {
                 version: "0123456789abcdef0123456789abcdef01234567".to_string(),
                 recovery_hash_prefix: None,
                 mode: RecoveryMode::Tee,
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_ok());
         }
@@ -1151,7 +1151,7 @@ mod tests {
                 version: "0123456789abcdef0123456789abcdef01234567".to_string(),
                 recovery_hash_prefix: Some(String::new()),
                 mode: RecoveryMode::Tee,
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_ok());
         }
@@ -1162,7 +1162,7 @@ mod tests {
                 version: "0123456789abcdef0123456789abcdef01234567".to_string(),
                 recovery_hash_prefix: Some("ABCDEF".to_string()),
                 mode: RecoveryMode::Tee,
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_err());
         }
@@ -1175,7 +1175,7 @@ mod tests {
             let params = RecoveryParams {
                 version: String::new(),
                 recovery_hash_prefix: Some(valid_hash.clone()),
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_err());
 
@@ -1183,7 +1183,7 @@ mod tests {
             let params = RecoveryParams {
                 version: "abc".to_string(),
                 recovery_hash_prefix: Some(valid_hash.clone()),
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_err());
 
@@ -1191,7 +1191,7 @@ mod tests {
             let params = RecoveryParams {
                 version: "A".repeat(VERSION_LENGTH),
                 recovery_hash_prefix: Some(valid_hash),
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_err());
         }
@@ -1204,7 +1204,7 @@ mod tests {
             let params = RecoveryParams {
                 version: valid_version.clone(),
                 recovery_hash_prefix: Some(String::new()),
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_err());
 
@@ -1212,7 +1212,7 @@ mod tests {
             let params = RecoveryParams {
                 version: valid_version.clone(),
                 recovery_hash_prefix: Some("abc".to_string()),
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_err());
 
@@ -1220,7 +1220,7 @@ mod tests {
             let params = RecoveryParams {
                 version: valid_version,
                 recovery_hash_prefix: Some("ABCDEF".to_string()),
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert!(params.validate_inputs().is_err());
         }
@@ -1231,7 +1231,7 @@ mod tests {
                 current_boot_alternative: BootAlternative::B,
                 target_boot_alternative_selection: TargetBootAlternativeSelection::Current,
                 mode: RecoveryMode::Tee,
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert_eq!(current.get_target_boot_alternative(), BootAlternative::B);
 
@@ -1239,7 +1239,7 @@ mod tests {
                 current_boot_alternative: BootAlternative::B,
                 target_boot_alternative_selection: TargetBootAlternativeSelection::Opposite,
                 mode: RecoveryMode::Tee,
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert_eq!(opposite.get_target_boot_alternative(), BootAlternative::A);
         }
@@ -1250,7 +1250,7 @@ mod tests {
                 current_boot_alternative: BootAlternative::B,
                 target_boot_alternative_selection: TargetBootAlternativeSelection::Current,
                 mode: RecoveryMode::Nns,
-                ..default_recovery_params()
+                ..default_recovery_params_for_test()
             };
             assert_eq!(params.get_target_boot_alternative(), BootAlternative::A);
         }
@@ -1325,7 +1325,7 @@ mod tests {
         fn ctrl_c_quits_from_confirmation_state() {
             let confirmation = ConfirmationState {
                 input_state: create_test_input_state(RecoveryMode::Nns),
-                params: default_recovery_params(),
+                params: default_recovery_params_for_test(),
                 selected_option: ConfirmationOption::Yes,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));
@@ -1492,7 +1492,10 @@ mod tests {
             #[test]
             fn tab_navigates_through_tee_mode_without_recovery_hash_field() {
                 let mut app = create_test_app(RecoveryMode::Tee);
-
+                assert!(matches!(
+                    app.get_state(),
+                    Some(AppState::Input(s)) if s.current_field() == Field::Version
+                ));
                 app.handle_event(Event::Key(key_event(KeyCode::Tab)))
                     .unwrap();
                 assert!(matches!(
@@ -1512,6 +1515,12 @@ mod tests {
                 assert!(matches!(
                     app.get_state(),
                     Some(AppState::Input(s)) if s.current_field() == Field::ExitButton
+                ));
+                app.handle_event(Event::Key(key_event(KeyCode::Tab)))
+                    .unwrap();
+                assert!(matches!(
+                    app.get_state(),
+                    Some(AppState::Input(s)) if s.current_field() == Field::Version
                 ));
             }
 
@@ -1738,7 +1747,7 @@ mod tests {
         fn escape_returns_to_input() {
             let confirmation = ConfirmationState {
                 input_state: create_test_input_state(RecoveryMode::Nns),
-                params: default_recovery_params(),
+                params: default_recovery_params_for_test(),
                 selected_option: ConfirmationOption::Yes,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));
@@ -1754,7 +1763,7 @@ mod tests {
         fn tab_toggles_selection() {
             let confirmation = ConfirmationState {
                 input_state: create_test_input_state(RecoveryMode::Nns),
-                params: default_recovery_params(),
+                params: default_recovery_params_for_test(),
                 selected_option: ConfirmationOption::Yes,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));
@@ -1780,7 +1789,7 @@ mod tests {
         fn left_right_changes_selection() {
             let confirmation = ConfirmationState {
                 input_state: create_test_input_state(RecoveryMode::Nns),
-                params: default_recovery_params(),
+                params: default_recovery_params_for_test(),
                 selected_option: ConfirmationOption::Yes,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));
@@ -1806,7 +1815,7 @@ mod tests {
         fn enter_no_returns_to_input() {
             let confirmation = ConfirmationState {
                 input_state: create_valid_input_state(),
-                params: default_recovery_params(),
+                params: default_recovery_params_for_test(),
                 selected_option: ConfirmationOption::No,
             };
             let mut app = GuestOSRecoveryApp::with_state(AppState::InputConfirmation(confirmation));

--- a/rs/ic_os/os_tools/manual_guestos_recovery/src/recovery_utils.rs
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/src/recovery_utils.rs
@@ -1,3 +1,4 @@
+use grub::BootAlternative;
 use std::process::Command;
 
 pub const RECOVERY_LAUNCHER_PATH: &str = "/opt/ic/bin/guestos-recovery-launcher.sh";
@@ -33,33 +34,99 @@ pub fn build_recovery_upgrader_command(mode: &str, args: &[String]) -> RecoveryU
     RecoveryUpgraderCommand { args: full_args }
 }
 
-pub fn build_recovery_upgrader_prep_command(
-    version: &str,
-    recovery_hash_prefix: &str,
-) -> RecoveryUpgraderCommand {
-    build_recovery_upgrader_command(
-        "prep",
-        &[
-            format!("version={version}"),
-            format!("recovery-hash-prefix={recovery_hash_prefix}"),
-        ],
-    )
+fn maybe_add_wipe_var_partition(args: &mut Vec<String>, wipe_var_partition: bool) {
+    if wipe_var_partition {
+        args.push("wipe-var-partition".to_string());
+    }
 }
 
-pub fn build_recovery_upgrader_install_command() -> RecoveryUpgraderCommand {
-    build_recovery_upgrader_command("install", &[])
+pub fn build_recovery_upgrader_prep_command(
+    version: &str,
+    target_boot_alternative: Option<BootAlternative>,
+    recovery_hash_prefix: &str,
+    wipe_var_partition: bool,
+) -> RecoveryUpgraderCommand {
+    let mut args = vec![format!("version={version}")];
+    if let Some(target_boot_alternative) = target_boot_alternative {
+        args.push(format!("target-boot-alternative={target_boot_alternative}"));
+    }
+    args.push(format!("recovery-hash-prefix={recovery_hash_prefix}"));
+    maybe_add_wipe_var_partition(&mut args, wipe_var_partition);
+    build_recovery_upgrader_command("prep", &args)
+}
+
+pub fn build_recovery_upgrader_install_command(
+    wipe_var_partition: bool,
+) -> RecoveryUpgraderCommand {
+    let mut args = Vec::new();
+    maybe_add_wipe_var_partition(&mut args, wipe_var_partition);
+    build_recovery_upgrader_command("install", &args)
 }
 
 /// Convenience helper to perform a single-shot run (prep + install) without TUI confirmation.
 pub fn build_recovery_upgrader_run_command(
     version: &str,
     recovery_hash_prefix: &str,
+    target_boot_alternative: &str,
+    wipe_var_partition: bool,
 ) -> RecoveryUpgraderCommand {
-    build_recovery_upgrader_command(
-        "run",
-        &[
-            format!("version={version}"),
-            format!("recovery-hash-prefix={recovery_hash_prefix}"),
-        ],
-    )
+    let mut args = vec![format!("version={version}")];
+    args.push(format!("recovery-hash-prefix={recovery_hash_prefix}"));
+    args.push(format!("target-boot-alternative={target_boot_alternative}"));
+    maybe_add_wipe_var_partition(&mut args, wipe_var_partition);
+    build_recovery_upgrader_command("run", &args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prep_command_includes_target_boot_alternative_and_empty_recovery_hash_prefix() {
+        let command =
+            build_recovery_upgrader_prep_command("aabbcc", Some(BootAlternative::B), "", false);
+
+        let shell = command.to_shell_string();
+        assert!(shell.contains("mode=prep"));
+        assert!(shell.contains("version=aabbcc"));
+        assert!(shell.contains("target-boot-alternative=B"));
+        assert!(shell.contains("recovery-hash-prefix="));
+    }
+
+    #[test]
+    fn prep_command_includes_recovery_hash_prefix_when_enabled() {
+        let command = build_recovery_upgrader_prep_command(
+            "aabbcc",
+            Some(BootAlternative::A),
+            "123abc",
+            true,
+        );
+
+        let shell = command.to_shell_string();
+        assert!(shell.contains("mode=prep"));
+        assert!(shell.contains("version=aabbcc"));
+        assert!(shell.contains("target-boot-alternative=A"));
+        assert!(shell.contains("recovery-hash-prefix=123abc"));
+        assert!(shell.contains("wipe-var-partition"));
+    }
+
+    #[test]
+    fn install_command_includes_wipe_var_partition_flag_when_requested() {
+        let command = build_recovery_upgrader_install_command(true);
+
+        let shell = command.to_shell_string();
+        assert!(shell.contains("mode=install"));
+        assert!(shell.contains("wipe-var-partition"));
+    }
+
+    #[test]
+    fn run_command_includes_wipe_var_partition_flag_when_requested() {
+        let command = build_recovery_upgrader_run_command("aabbcc", "123abc", "B", true);
+
+        let shell = command.to_shell_string();
+        assert!(shell.contains("mode=run"));
+        assert!(shell.contains("recovery-hash-prefix=123abc"));
+        assert!(shell.contains("target-boot-alternative=B"));
+        assert!(shell.contains("wipe-var-partition"));
+    }
 }

--- a/rs/ic_os/os_tools/manual_guestos_recovery/src/recovery_utils.rs
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/src/recovery_utils.rs
@@ -42,15 +42,15 @@ fn maybe_add_wipe_var_partition(args: &mut Vec<String>, wipe_var_partition: bool
 
 pub fn build_recovery_upgrader_prep_command(
     version: &str,
-    target_boot_alternative: Option<BootAlternative>,
+    target_boot_alternative: BootAlternative,
     recovery_hash_prefix: &str,
     wipe_var_partition: bool,
 ) -> RecoveryUpgraderCommand {
-    let mut args = vec![format!("version={version}")];
-    if let Some(target_boot_alternative) = target_boot_alternative {
-        args.push(format!("target-boot-alternative={target_boot_alternative}"));
-    }
-    args.push(format!("recovery-hash-prefix={recovery_hash_prefix}"));
+    let mut args = vec![
+        format!("version={version}"),
+        format!("target-boot-alternative={target_boot_alternative}"),
+        format!("recovery-hash-prefix={recovery_hash_prefix}"),
+    ];
     maybe_add_wipe_var_partition(&mut args, wipe_var_partition);
     build_recovery_upgrader_command("prep", &args)
 }
@@ -70,9 +70,11 @@ pub fn build_recovery_upgrader_run_command(
     target_boot_alternative: &str,
     wipe_var_partition: bool,
 ) -> RecoveryUpgraderCommand {
-    let mut args = vec![format!("version={version}")];
-    args.push(format!("recovery-hash-prefix={recovery_hash_prefix}"));
-    args.push(format!("target-boot-alternative={target_boot_alternative}"));
+    let mut args = vec![
+        format!("version={version}"),
+        format!("recovery-hash-prefix={recovery_hash_prefix}"),
+        format!("target-boot-alternative={target_boot_alternative}"),
+    ];
     maybe_add_wipe_var_partition(&mut args, wipe_var_partition);
     build_recovery_upgrader_command("run", &args)
 }
@@ -83,8 +85,7 @@ mod tests {
 
     #[test]
     fn prep_command_includes_target_boot_alternative_and_empty_recovery_hash_prefix() {
-        let command =
-            build_recovery_upgrader_prep_command("aabbcc", Some(BootAlternative::B), "", false);
+        let command = build_recovery_upgrader_prep_command("aabbcc", BootAlternative::B, "", false);
 
         let shell = command.to_shell_string();
         assert!(shell.contains("mode=prep"));
@@ -95,12 +96,8 @@ mod tests {
 
     #[test]
     fn prep_command_includes_recovery_hash_prefix_when_enabled() {
-        let command = build_recovery_upgrader_prep_command(
-            "aabbcc",
-            Some(BootAlternative::A),
-            "123abc",
-            true,
-        );
+        let command =
+            build_recovery_upgrader_prep_command("aabbcc", BootAlternative::A, "123abc", true);
 
         let shell = command.to_shell_string();
         assert!(shell.contains("mode=prep"));

--- a/rs/ic_os/os_tools/manual_guestos_recovery/src/ui.rs
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/src/ui.rs
@@ -132,12 +132,15 @@ fn create_parameter_lines(params: &RecoveryParams) -> Vec<Line<'_>> {
     let mut lines = vec![
         format!("Inputted parameters:"),
         format!("VERSION: {}", params.version),
-        format!(
+    ];
+
+    if params.mode.can_select_target_boot_alternative() {
+        lines.push(format!(
             "TARGET-BOOT-ALTERNATIVE: {} ({})",
             params.target_boot_alternative_selection.as_str(),
             params.get_target_boot_alternative()
-        ),
-    ];
+        ));
+    }
 
     if params.mode.requires_recovery_hash() {
         let recovery_hash_prefix = params.recovery_hash_prefix.as_deref().unwrap_or("<empty>");
@@ -326,8 +329,8 @@ fn render_input_screen(f: &mut Frame, state: &InputState, size: Rect) {
     } else {
         vec![
             Line::from("Enter the recovery version and the 6-character recovery hash prefix."),
-            Line::from("Adjust the target boot alternative if needed."),
-            Line::from("Use Left/Right on the target field; Up/Down or TAB moves focus."),
+            Line::from("The install target will use the opposite boot alternative."),
+            Line::from("Use Up/Down or TAB to move focus."),
         ]
     };
     let instructions_para = Paragraph::new(instructions)
@@ -806,15 +809,14 @@ mod tests {
             // Title and instructions
             assert!(buffer_contains(&terminal, "Manual Recovery TUI"));
             assert!(buffer_contains(&terminal, "recovery version"));
-            assert!(buffer_contains(&terminal, "Left/Right"));
+            assert!(buffer_contains(&terminal, "opposite boot alternative"));
 
             // Field labels
             assert!(buffer_contains(&terminal, "VERSION"));
             assert!(buffer_contains(&terminal, "RECOVERY-HASH-PREFIX"));
-            assert!(buffer_contains(&terminal, "TARGET-BOOT-ALTERNATIVE"));
-            assert!(buffer_contains(&terminal, "current alternative: A"));
-            assert!(buffer_contains(&terminal, "( ) current (A)"));
-            assert!(buffer_contains(&terminal, "(*) opposite (B)"));
+            assert!(!buffer_contains(&terminal, "TARGET-BOOT-ALTERNATIVE"));
+            assert!(!buffer_contains(&terminal, "current alternative: A"));
+            assert!(!buffer_contains(&terminal, "(*) opposite (B)"));
 
             // Buttons
             assert!(buffer_contains(&terminal, "<Run recovery>"));
@@ -886,10 +888,7 @@ mod tests {
             // Input parameters
             assert!(buffer_contains(&terminal, "VERSION:"));
             assert!(buffer_contains(&terminal, "abc123def456"));
-            assert!(buffer_contains(
-                &terminal,
-                "TARGET-BOOT-ALTERNATIVE: opposite (B)"
-            ));
+            assert!(!buffer_contains(&terminal, "TARGET-BOOT-ALTERNATIVE:"));
             assert!(buffer_contains(&terminal, "RECOVERY-HASH-PREFIX:"));
             assert!(buffer_contains(&terminal, "fedcba"));
 
@@ -938,10 +937,7 @@ mod tests {
             assert!(buffer_contains(&terminal, "GuestOS Recovery Upgrader"));
             assert!(buffer_contains(&terminal, "VERSION:"));
             assert!(buffer_contains(&terminal, "testversion123"));
-            assert!(buffer_contains(
-                &terminal,
-                "TARGET-BOOT-ALTERNATIVE: opposite (B)"
-            ));
+            assert!(!buffer_contains(&terminal, "TARGET-BOOT-ALTERNATIVE:"));
             assert!(buffer_contains(&terminal, "<pending>"));
             assert!(buffer_contains(&terminal, "Recovery process logs"));
         }

--- a/rs/ic_os/os_tools/manual_guestos_recovery/src/ui.rs
+++ b/rs/ic_os/os_tools/manual_guestos_recovery/src/ui.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use grub::BootAlternative;
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -9,8 +11,8 @@ use ratatui::{
 use tui_textarea::TextArea;
 
 use crate::{
-    AppState, ConfirmationOption, ConfirmationState, FailureState, Field, InputState,
-    RecoveryParams, RunningState,
+    AppState, ConfirmationOption, ConfirmationState, FailureState, Field, InputState, RecoveryMode,
+    RecoveryParams, RunningState, TargetBootAlternativeSelection,
 };
 
 // ============================================================================
@@ -127,16 +129,29 @@ fn render_if_too_small(f: &mut Frame, size: Rect) -> bool {
 
 fn create_parameter_lines(params: &RecoveryParams) -> Vec<Line<'_>> {
     let calculated_version_hash = params.version_hash_full.as_deref().unwrap_or("<pending>");
-    let calculated_recovery_hash = params.recovery_hash_full.as_deref().unwrap_or("<pending>");
-    let lines = vec![
+    let mut lines = vec![
         format!("Inputted parameters:"),
         format!("VERSION: {}", params.version),
-        format!("RECOVERY-HASH-PREFIX: {}", params.recovery_hash_prefix),
-        format!(""),
-        format!("Calculated hashes:"),
-        format!("    VERSION-HASH: {}", calculated_version_hash),
-        format!("    RECOVERY-HASH: {}", calculated_recovery_hash),
+        format!(
+            "TARGET-BOOT-ALTERNATIVE: {} ({})",
+            params.target_boot_alternative_selection.as_str(),
+            params.get_target_boot_alternative()
+        ),
     ];
+
+    if params.mode.requires_recovery_hash() {
+        let recovery_hash_prefix = params.recovery_hash_prefix.as_deref().unwrap_or("<empty>");
+        lines.push(format!("RECOVERY-HASH-PREFIX: {}", recovery_hash_prefix));
+    }
+
+    lines.push(String::new());
+    lines.push("Calculated hashes:".to_string());
+    lines.push(format!("    VERSION-HASH: {}", calculated_version_hash));
+
+    if params.mode.requires_recovery_hash() {
+        let calculated_recovery_hash = params.recovery_hash_full.as_deref().unwrap_or("<pending>");
+        lines.push(format!("    RECOVERY-HASH: {}", calculated_recovery_hash));
+    }
 
     lines
         .into_iter()
@@ -173,7 +188,7 @@ fn render_input_confirmation_screen(f: &mut Frame, state: &ConfirmationState, si
     render_input_screen(f, &state.input_state, size);
 
     // 2. Render the popup overlay
-    let area = centered_rect(Constraint::Percentage(85), 20, size);
+    let area = centered_rect(Constraint::Percentage(85), 21, size);
 
     f.render_widget(Clear, area);
 
@@ -185,7 +200,7 @@ fn render_input_confirmation_screen(f: &mut Frame, state: &ConfirmationState, si
             Constraint::Length(2), // Header spacing
             Constraint::Min(1),    // Parameters
             Constraint::Length(1), // Spacer
-            Constraint::Length(4), // Security warning
+            Constraint::Length(5), // Security warning
             Constraint::Length(1), // Spacer
             Constraint::Length(1), // Question
             Constraint::Length(1), // Buttons
@@ -201,26 +216,51 @@ fn render_input_confirmation_screen(f: &mut Frame, state: &ConfirmationState, si
 
     let warning_header_style = Style::default().fg(Color::Red).bold();
     let warning_text_style = Style::default().fg(Color::Yellow);
-    let warning = Paragraph::new(vec![
-        Line::styled("!! SECURITY WARNING !!", warning_header_style),
-        Line::styled(
-            "Only proceed if the calculated hashes exactly match those communicated",
-            warning_text_style,
-        ),
-        Line::styled(
-            "by the recovery coordinator on Matrix and the forum.",
-            warning_text_style,
-        ),
-        Line::styled(
-            "Proceeding with a wrong hash can have critical security implications.",
-            warning_text_style,
-        ),
-    ]);
+    let warning_lines = if state.params.mode == RecoveryMode::Tee {
+        vec![
+            Line::styled("!! SECURITY WARNING !!", warning_header_style),
+            Line::styled(
+                "Only proceed if the calculated version hash exactly matches what was",
+                warning_text_style,
+            ),
+            Line::styled(
+                "communicated by the recovery coordinator on Matrix and the forum.",
+                warning_text_style,
+            ),
+            Line::styled(
+                "Proceeding with a wrong version can have critical security implications.",
+                warning_text_style,
+            ),
+            Line::styled(
+                "TEE mode verifies only the version hash. Double-check it before continuing.",
+                warning_text_style,
+            ),
+        ]
+    } else {
+        vec![
+            Line::styled("!! SECURITY WARNING !!", warning_header_style),
+            Line::styled(
+                "Only proceed if the calculated hashes exactly match those communicated",
+                warning_text_style,
+            ),
+            Line::styled(
+                "by the recovery coordinator on Matrix and the forum.",
+                warning_text_style,
+            ),
+            Line::styled(
+                "Proceeding with a wrong hash can have critical security implications.",
+                warning_text_style,
+            ),
+        ]
+    };
+    let warning = Paragraph::new(warning_lines);
     f.render_widget(warning, layout[3]);
 
-    let question = Paragraph::new(
-        "Please confirm: do these input values match the recovery coordinator's information?",
-    )
+    let question = Paragraph::new(if state.params.mode == RecoveryMode::Tee {
+        "Please confirm: does this version information match the recovery coordinator's information?"
+    } else {
+        "Please confirm: do these input values match the recovery coordinator's information?"
+    })
     .alignment(Alignment::Center)
     .style(Style::default().fg(Color::White).bold());
     f.render_widget(question, layout[5]);
@@ -254,15 +294,16 @@ fn render_input_confirmation_screen(f: &mut Frame, state: &ConfirmationState, si
 // ============================================================================
 
 fn render_input_screen(f: &mut Frame, state: &InputState, size: Rect) {
+    let input_field_count = state.input_fields().len() as u16;
     let main_layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1), // Title area
-            Constraint::Length(3), // Instructions area
-            Constraint::Length(6), // Input fields area (2 fields × 3 rows each)
-            Constraint::Length(1), // Button area
-            Constraint::Length(1), // Spacing after buttons
-            Constraint::Min(0),    // Remaining space
+            Constraint::Length(1),                     // Title area
+            Constraint::Length(3),                     // Instructions area
+            Constraint::Length(input_field_count * 3), // Input fields area
+            Constraint::Length(1),                     // Button area
+            Constraint::Length(1),                     // Spacing after buttons
+            Constraint::Min(0),                        // Remaining space
         ])
         .split(size);
 
@@ -276,33 +317,40 @@ fn render_input_screen(f: &mut Frame, state: &InputState, size: Rect) {
         .style(Style::default().bold());
     f.render_widget(title, main_layout[0]);
 
-    let instructions = vec![
-        Line::from("Enter the recovery version and the 6-character recovery hash prefix."),
-        Line::from("Use Up/Down arrows or TAB to move between fields."),
-    ];
+    let instructions = if state.mode == RecoveryMode::Tee {
+        vec![
+            Line::from("Enter the recovery version for TEE mode."),
+            Line::from("Adjust the target boot alternative if needed."),
+            Line::from("Use Left/Right on the target field; Up/Down or TAB moves focus."),
+        ]
+    } else {
+        vec![
+            Line::from("Enter the recovery version and the 6-character recovery hash prefix."),
+            Line::from("Adjust the target boot alternative if needed."),
+            Line::from("Use Left/Right on the target field; Up/Down or TAB moves focus."),
+        ]
+    };
     let instructions_para = Paragraph::new(instructions)
         .style(Style::default().fg(Color::White))
         .wrap(Wrap { trim: true });
     f.render_widget(instructions_para, main_layout[1]);
 
+    let field_constraints = vec![Constraint::Length(3); input_field_count as usize];
     let fields_layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(3), // Version field
-            Constraint::Length(3), // Recovery hash prefix field
-        ])
+        .constraints(field_constraints)
         .split(main_layout[2]);
 
-    for (i, field) in Field::INPUT_FIELDS.iter().enumerate() {
+    for (i, field) in state.input_fields().iter().enumerate() {
         let meta = field.metadata();
-        render_input_field(
-            state,
-            f,
-            *field,
-            &format!("{}:", meta.name),
-            &state.inputs[i],
-            fields_layout[i],
-        );
+        let label = match *field {
+            Field::TargetBootAlternative => format!(
+                "{} (current alternative: {})",
+                meta.name, state.current_boot_alternative
+            ),
+            _ => format!("{}:", meta.name),
+        };
+        render_input_field(state, f, *field, &label, &state.inputs[i], fields_layout[i]);
     }
 
     let button_area = main_layout[3];
@@ -350,6 +398,11 @@ fn render_input_field(
     area: Rect,
 ) {
     let selected = state.current_field() == field;
+    if field == Field::TargetBootAlternative {
+        render_target_boot_alternative_field(state, f, label, area, selected);
+        return;
+    }
+
     let block = create_block(label, selected, false);
 
     // Clone textarea to modify styles for rendering without affecting state
@@ -365,6 +418,53 @@ fn render_input_field(
 
     ta.set_block(block);
     f.render_widget(&ta, area);
+}
+
+fn render_target_boot_alternative_field(
+    state: &InputState,
+    f: &mut Frame,
+    label: &str,
+    area: Rect,
+    selected: bool,
+) {
+    let block = create_block(label, selected, false);
+    let current_selected =
+        state.target_boot_alternative_selection == TargetBootAlternativeSelection::Current;
+    let current_boot_alternative =
+        state.resolve_boot_alternative(TargetBootAlternativeSelection::Current);
+    let opposite_boot_alternative =
+        state.resolve_boot_alternative(TargetBootAlternativeSelection::Opposite);
+
+    let selected_style = Style::default().fg(Color::White).bold();
+    let unselected_style = Style::default().fg(Color::Gray);
+    let (current_style, opposite_style) = if current_selected {
+        (selected_style, unselected_style)
+    } else {
+        (unselected_style, selected_style)
+    };
+
+    let line = Line::from(vec![
+        Span::styled(
+            if current_selected {
+                format!("(*) current ({current_boot_alternative})")
+            } else {
+                format!("( ) current ({current_boot_alternative})")
+            },
+            current_style,
+        ),
+        Span::raw("   "),
+        Span::styled(
+            if current_selected {
+                format!("( ) opposite ({opposite_boot_alternative})")
+            } else {
+                format!("(*) opposite ({opposite_boot_alternative})")
+            },
+            opposite_style,
+        ),
+    ]);
+
+    let para = Paragraph::new(line).block(block).wrap(Wrap { trim: true });
+    f.render_widget(para, area);
 }
 
 /// Renders buttons horizontally centered in the given area with spacing between them
@@ -616,6 +716,8 @@ mod tests {
         use crate::{RecoveryParams, RecoveryPhase, RecoveryTask};
         use ratatui::{Terminal, backend::TestBackend};
 
+        const TEST_CURRENT_BOOT_ALTERNATIVE: BootAlternative = BootAlternative::A;
+
         // ====================================================================
         // Test Helpers
         // ====================================================================
@@ -646,6 +748,22 @@ mod tests {
             buffer_to_string(terminal).contains(text)
         }
 
+        fn create_test_input_state(mode: RecoveryMode) -> InputState {
+            InputState::new(mode, TEST_CURRENT_BOOT_ALTERNATIVE)
+        }
+
+        fn default_recovery_params() -> RecoveryParams {
+            RecoveryParams {
+                version: String::new(),
+                recovery_hash_prefix: None,
+                version_hash_full: None,
+                recovery_hash_full: None,
+                mode: RecoveryMode::Nns,
+                current_boot_alternative: BootAlternative::A,
+                target_boot_alternative_selection: TargetBootAlternativeSelection::Opposite,
+            }
+        }
+
         fn create_test_failure_state() -> FailureState {
             let status = std::process::Command::new("false")
                 .status()
@@ -653,9 +771,12 @@ mod tests {
             FailureState {
                 params: RecoveryParams {
                     version: "a".repeat(40),
-                    recovery_hash_prefix: "abc123".to_string(),
+                    recovery_hash_prefix: Some("abc123".to_string()),
                     version_hash_full: Some("fullhash123".to_string()),
                     recovery_hash_full: Some("rechash456".to_string()),
+                    mode: RecoveryMode::Nns,
+                    current_boot_alternative: BootAlternative::A,
+                    target_boot_alternative_selection: TargetBootAlternativeSelection::Opposite,
                 },
                 logs: vec!["Error line 1".to_string(), "Error line 2".to_string()],
                 exit_status: status,
@@ -665,7 +786,7 @@ mod tests {
 
         #[test]
         fn too_small_terminal_hides_normal_ui() {
-            let state = AppState::Input(InputState::default());
+            let state = AppState::Input(create_test_input_state(RecoveryMode::Nns));
 
             // Width below minimum
             let terminal = render_state(&state, MIN_TERMINAL_WIDTH - 1, 20);
@@ -679,17 +800,21 @@ mod tests {
 
         #[test]
         fn input_screen_renders_all_elements() {
-            let state = AppState::Input(InputState::default());
+            let state = AppState::Input(create_test_input_state(RecoveryMode::Nns));
             let terminal = render_state(&state, 80, 24);
 
             // Title and instructions
             assert!(buffer_contains(&terminal, "Manual Recovery TUI"));
             assert!(buffer_contains(&terminal, "recovery version"));
-            assert!(buffer_contains(&terminal, "TAB"));
+            assert!(buffer_contains(&terminal, "Left/Right"));
 
             // Field labels
             assert!(buffer_contains(&terminal, "VERSION"));
             assert!(buffer_contains(&terminal, "RECOVERY-HASH-PREFIX"));
+            assert!(buffer_contains(&terminal, "TARGET-BOOT-ALTERNATIVE"));
+            assert!(buffer_contains(&terminal, "current alternative: A"));
+            assert!(buffer_contains(&terminal, "( ) current (A)"));
+            assert!(buffer_contains(&terminal, "(*) opposite (B)"));
 
             // Buttons
             assert!(buffer_contains(&terminal, "<Run recovery>"));
@@ -697,10 +822,26 @@ mod tests {
         }
 
         #[test]
+        fn tee_mode_input_screen_hides_recovery_hash_field() {
+            let state = AppState::Input(InputState::new(
+                RecoveryMode::Tee,
+                TEST_CURRENT_BOOT_ALTERNATIVE,
+            ));
+            let terminal = render_state(&state, 80, 24);
+
+            assert!(buffer_contains(&terminal, "Manual Recovery TUI"));
+            assert!(buffer_contains(&terminal, "TEE mode"));
+            assert!(buffer_contains(&terminal, "VERSION"));
+            assert!(!buffer_contains(&terminal, "RECOVERY-HASH-PREFIX"));
+            assert!(buffer_contains(&terminal, "TARGET-BOOT-ALTERNATIVE"));
+            assert!(buffer_contains(&terminal, "(*) current (A)"));
+        }
+
+        #[test]
         fn input_screen_shows_error_popup() {
             let input = InputState {
                 error_message: Some("Validation failed".to_string()),
-                ..Default::default()
+                ..create_test_input_state(RecoveryMode::Nns)
             };
             let state = AppState::Input(input);
             let terminal = render_state(&state, 80, 24);
@@ -713,7 +854,7 @@ mod tests {
         fn input_screen_shows_exit_message() {
             let input = InputState {
                 exit_message: Some("Recovery cancelled".to_string()),
-                ..Default::default()
+                ..create_test_input_state(RecoveryMode::Nns)
             };
             let state = AppState::Input(input);
             let terminal = render_state(&state, 80, 24);
@@ -724,12 +865,15 @@ mod tests {
         #[test]
         fn confirmation_screen_renders_all_elements() {
             let state = AppState::InputConfirmation(ConfirmationState {
-                input_state: InputState::default(),
+                input_state: create_test_input_state(RecoveryMode::Nns),
                 params: RecoveryParams {
                     version: "abc123def456".to_string(),
-                    recovery_hash_prefix: "fedcba".to_string(),
+                    recovery_hash_prefix: Some("fedcba".to_string()),
                     version_hash_full: Some("fullversionhash".to_string()),
                     recovery_hash_full: Some("fullrecoveryhash".to_string()),
+                    mode: RecoveryMode::Nns,
+                    current_boot_alternative: BootAlternative::A,
+                    target_boot_alternative_selection: TargetBootAlternativeSelection::Opposite,
                 },
                 selected_option: ConfirmationOption::Yes,
             });
@@ -742,6 +886,10 @@ mod tests {
             // Input parameters
             assert!(buffer_contains(&terminal, "VERSION:"));
             assert!(buffer_contains(&terminal, "abc123def456"));
+            assert!(buffer_contains(
+                &terminal,
+                "TARGET-BOOT-ALTERNATIVE: opposite (B)"
+            ));
             assert!(buffer_contains(&terminal, "RECOVERY-HASH-PREFIX:"));
             assert!(buffer_contains(&terminal, "fedcba"));
 
@@ -775,9 +923,12 @@ mod tests {
                 task: RecoveryTask::mock_with_logs(vec![]),
                 params: RecoveryParams {
                     version: "testversion123".to_string(),
-                    recovery_hash_prefix: "abc123".to_string(),
+                    recovery_hash_prefix: Some("abc123".to_string()),
                     version_hash_full: None,
                     recovery_hash_full: None,
+                    mode: RecoveryMode::Nns,
+                    current_boot_alternative: BootAlternative::A,
+                    target_boot_alternative_selection: TargetBootAlternativeSelection::Opposite,
                 },
                 phase: RecoveryPhase::Prep,
                 previous_input_state: None,
@@ -787,8 +938,39 @@ mod tests {
             assert!(buffer_contains(&terminal, "GuestOS Recovery Upgrader"));
             assert!(buffer_contains(&terminal, "VERSION:"));
             assert!(buffer_contains(&terminal, "testversion123"));
+            assert!(buffer_contains(
+                &terminal,
+                "TARGET-BOOT-ALTERNATIVE: opposite (B)"
+            ));
             assert!(buffer_contains(&terminal, "<pending>"));
             assert!(buffer_contains(&terminal, "Recovery process logs"));
+        }
+
+        #[test]
+        fn tee_mode_confirmation_screen_hides_recovery_hash_details() {
+            let state = AppState::InputConfirmation(ConfirmationState {
+                input_state: InputState::new(RecoveryMode::Tee, BootAlternative::B),
+                params: RecoveryParams {
+                    version: "abc123def456".to_string(),
+                    recovery_hash_prefix: None,
+                    version_hash_full: Some("fullversionhash".to_string()),
+                    recovery_hash_full: None,
+                    mode: RecoveryMode::Tee,
+                    current_boot_alternative: BootAlternative::B,
+                    target_boot_alternative_selection: TargetBootAlternativeSelection::Current,
+                },
+                selected_option: ConfirmationOption::Yes,
+            });
+            let terminal = render_state(&state, 100, 30);
+
+            assert!(buffer_contains(&terminal, "VERSION:"));
+            assert!(buffer_contains(&terminal, "fullversionhash"));
+            assert!(buffer_contains(
+                &terminal,
+                "TARGET-BOOT-ALTERNATIVE: current (B)"
+            ));
+            assert!(!buffer_contains(&terminal, "RECOVERY-HASH-PREFIX"));
+            assert!(!buffer_contains(&terminal, "RECOVERY-HASH:"));
         }
 
         #[test]
@@ -798,7 +980,7 @@ mod tests {
                     "Downloading artifacts...".to_string(),
                     "Verifying checksums...".to_string(),
                 ]),
-                params: RecoveryParams::default(),
+                params: default_recovery_params(),
                 phase: RecoveryPhase::Prep,
                 previous_input_state: None,
             });

--- a/rs/tests/nested/nns_recovery/common.rs
+++ b/rs/tests/nested/nns_recovery/common.rs
@@ -766,8 +766,25 @@ async fn simulate_node_provider_action(
         recovery_hash_prefix,
     );
 
-    let recovery_upgrader_cmd =
-        build_recovery_upgrader_run_command(img_version, recovery_hash_prefix).to_shell_string();
+    let current_boot_alternative = host
+        .block_on_bash_script_async(
+            "sudo /opt/ic/bin/hostos_tool guestos-alternative show | awk '/GuestOS Boot alternative:/ {print $4}'",
+        )
+        .await
+        .expect("Failed to read current GuestOS boot alternative");
+    let target_boot_alternative = match current_boot_alternative.trim() {
+        "A" => "B",
+        "B" => "A",
+        other => panic!("Unexpected GuestOS boot alternative: {other}"),
+    };
+
+    let recovery_upgrader_cmd = build_recovery_upgrader_run_command(
+        img_version,
+        recovery_hash_prefix,
+        target_boot_alternative,
+        true,
+    )
+    .to_shell_string();
 
     // Note: keep in sync with the limited-console invocation in cpp/infogetty-cpp/infogetty.cc.
     // We need TWO "exit" commands: one to exit rbash, and one to exit limited-console's main loop.


### PR DESCRIPTION
TEE recovery builds on the foundation that we created for NNS recoveries. There are a few differences:
- No recovery packages are used, only an alternative GuestOS image is written.
- The GuestOS's var partition is not wiped.
- The same GuestOS boot alternative must be used where a (broken) GuestOS is deployed that has access to the encrypted partitions.

This change adds a new `tee-recovery` command to the limited console which does not require the recovery package hash. Furthermore, a new field is added for TEE recovery which allows selecting the target boot alternative. This field's default value is current for TEE recoveries and opposite for NNS recoveries.

<img width="657" height="222" alt="image" src="https://github.com/user-attachments/assets/ab70ab9c-9b1d-402c-8842-6b5206f6062f" />
