### PR TITLE
perf: Directly serialize signed bytes into `Vec` holding domain separator

### DIFF
--- a/rs/crypto/internal/crypto_service_provider/src/key_id/mod.rs
+++ b/rs/crypto/internal/crypto_service_provider/src/key_id/mod.rs
@@ -162,9 +162,9 @@ impl TryFrom<&CspPublicCoefficients> for KeyId {
         let mut hash = Sha256::new_with_context(&DomainSeparationContext::new(
             THRESHOLD_PUBLIC_COEFFICIENTS_KEY_ID_DOMAIN,
         ));
-        hash.write(&serde_cbor::to_vec(&coefficients).map_err(|err| {
+        serde_cbor::to_writer(&mut hash, &coefficients).map_err(|err| {
             Self::Error::InvalidArguments(format!("Failed to serialize public coefficients: {err}"))
-        })?);
+        })?;
         Ok(KeyId::from(hash.finish()))
     }
 }

--- a/rs/protobuf/src/types.rs
+++ b/rs/protobuf/src/types.rs
@@ -29,15 +29,6 @@ pub mod v1 {
         }
     }
 
-    impl CatchUpContent {
-        pub fn as_protobuf_vec(&self) -> Vec<u8> {
-            let mut buf = Vec::<u8>::new();
-            self.encode(&mut buf)
-                .expect("CatchUpContent should serialize");
-            buf
-        }
-    }
-
     impl From<RejectCodePublic> for RejectCode {
         fn from(value: RejectCodePublic) -> Self {
             match value {

--- a/rs/tests/consensus/request_auth_malicious_replica_test.rs
+++ b/rs/tests/consensus/request_auth_malicious_replica_test.rs
@@ -598,7 +598,7 @@ async fn test_request_with_delegation<T: Identity + 'static>(
 
 fn sign_delegation(delegation: Delegation, identity: &impl Identity) -> SignedDelegation {
     let mut msg = b"\x1Aic-request-auth-delegation".to_vec();
-    msg.extend(&delegation.as_signed_bytes_without_domain_separator());
+    delegation.write_signed_bytes_without_domain_separator(&mut msg);
     let signature = identity.sign_arbitrary(&msg).unwrap();
 
     SignedDelegation::new(delegation, signature.signature.unwrap())

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -1039,8 +1039,8 @@ impl CountBytes for CanisterHttpResponseMetadata {
 }
 
 impl crate::crypto::SignedBytesWithoutDomainSeparator for CanisterHttpResponseMetadata {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 

--- a/rs/types/types/src/consensus.rs
+++ b/rs/types/types/src/consensus.rs
@@ -300,8 +300,8 @@ impl Block {
 }
 
 impl SignedBytesWithoutDomainSeparator for BlockMetadata {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 
@@ -439,8 +439,8 @@ impl NotarizationContent {
 }
 
 impl SignedBytesWithoutDomainSeparator for NotarizationContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 
@@ -539,8 +539,8 @@ impl FinalizationContent {
 }
 
 impl SignedBytesWithoutDomainSeparator for FinalizationContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 
@@ -647,8 +647,8 @@ impl RandomBeaconContent {
 }
 
 impl SignedBytesWithoutDomainSeparator for RandomBeaconContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 
@@ -734,8 +734,8 @@ pub struct RandomTapeContent {
 }
 
 impl SignedBytesWithoutDomainSeparator for RandomTapeContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 

--- a/rs/types/types/src/consensus/catchup.rs
+++ b/rs/types/types/src/consensus/catchup.rs
@@ -143,8 +143,10 @@ impl TryFrom<pb::CatchUpContent> for CatchUpContent {
 }
 
 impl SignedBytesWithoutDomainSeparator for CatchUpContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        pb::CatchUpContent::from(self.clone()).as_protobuf_vec()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        pb::CatchUpContent::from(self.clone())
+            .encode(bytes)
+            .expect("CatchUpContent should serialize");
     }
 }
 
@@ -211,7 +213,7 @@ impl From<CatchUpPackage> for pb::CatchUpPackage {
         Self {
             signer: Some(pb::NiDkgId::from(cup.signature.signer)),
             signature: cup.signature.signature.get().0,
-            content: pb::CatchUpContent::from(cup.content).as_protobuf_vec(),
+            content: pb::CatchUpContent::from(cup.content).encode_to_vec(),
         }
     }
 }
@@ -379,8 +381,8 @@ impl From<&pb::CatchUpPackage> for CatchUpContentProtobufBytes {
 }
 
 impl SignedBytesWithoutDomainSeparator for CatchUpContentProtobufBytes {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        self.0.clone()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&self.0);
     }
 }
 

--- a/rs/types/types/src/consensus/certification.rs
+++ b/rs/types/types/src/consensus/certification.rs
@@ -178,8 +178,8 @@ impl CertificationContent {
 }
 
 impl SignedBytesWithoutDomainSeparator for CertificationContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        self.hash.get_ref().0.clone()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&self.hash.get_ref().0);
     }
 }
 

--- a/rs/types/types/src/consensus/dkg.rs
+++ b/rs/types/types/src/consensus/dkg.rs
@@ -97,8 +97,8 @@ impl DealingContent {
 }
 
 impl SignedBytesWithoutDomainSeparator for DealingContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 

--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -1688,14 +1688,14 @@ impl Display for SignedIDkgComplaint {
 }
 
 impl SignedBytesWithoutDomainSeparator for IDkgComplaintContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 
 impl SignedBytesWithoutDomainSeparator for SignedIDkgComplaint {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 
@@ -1765,14 +1765,14 @@ impl Display for SignedIDkgOpening {
 }
 
 impl SignedBytesWithoutDomainSeparator for IDkgOpeningContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 
 impl SignedBytesWithoutDomainSeparator for SignedIDkgOpening {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 

--- a/rs/types/types/src/crypto.rs
+++ b/rs/types/types/src/crypto.rs
@@ -101,13 +101,18 @@ impl<T: CountBytes, S: CountBytes> CountBytes for Signed<T, S> {
 
 /// Signed bytes, not containing a domain separator. Also refer to the doc of
 /// `SignedBytesWithoutDomainSeparator::
-/// as_signed_bytes_without_domain_separator`.
+/// write_signed_bytes_without_domain_separator`.
 pub trait SignedBytesWithoutDomainSeparator {
-    /// Returns a bytes-representation of the object for digital signatures.
-    /// The returned value together with a domain-separator (that can be empty,
-    /// depending on the type) are the bytes that are used for
+    /// Appends the bytes-representation of the object for digital signatures to
+    /// `bytes`. The appended value together with a domain-separator (that can
+    /// be empty, depending on the type) are the bytes that are used for
     /// signing/verification.
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8>;
+    ///
+    /// Writing directly into `bytes` allows callers that assemble the full
+    /// signed bytes (e.g. a domain separator followed by these bytes) to avoid
+    /// materializing an intermediate `Vec` and copying it into the output
+    /// buffer.
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>);
 }
 
 /// A purpose of a key. This is used for storing and retrieving keys from the

--- a/rs/types/types/src/crypto/canister_threshold_sig/idkg.rs
+++ b/rs/types/types/src/crypto/canister_threshold_sig/idkg.rs
@@ -1045,8 +1045,8 @@ impl Display for IDkgDealing {
 }
 
 impl SignedBytesWithoutDomainSeparator for IDkgDealing {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 
@@ -1090,8 +1090,8 @@ impl Display for SignedIDkgDealing {
 }
 
 impl SignedBytesWithoutDomainSeparator for SignedIDkgDealing {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        serde_cbor::to_writer(bytes, &self).unwrap();
     }
 }
 

--- a/rs/types/types/src/crypto/sign.rs
+++ b/rs/types/types/src/crypto/sign.rs
@@ -37,7 +37,7 @@ where
 {
     fn as_signed_bytes(&self) -> Vec<u8> {
         let mut bytes = self.domain();
-        bytes.append(&mut self.as_signed_bytes_without_domain_separator());
+        self.write_signed_bytes_without_domain_separator(&mut bytes);
         bytes
     }
 }
@@ -260,7 +260,7 @@ impl SignatureDomain for SignableMock {
 }
 
 impl SignedBytesWithoutDomainSeparator for SignableMock {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        self.signed_bytes_without_domain.clone()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&self.signed_bytes_without_domain);
     }
 }

--- a/rs/types/types/src/crypto/vetkd.rs
+++ b/rs/types/types/src/crypto/vetkd.rs
@@ -47,8 +47,8 @@ impl std::fmt::Debug for VetKdEncryptedKeyShareContent {
 impl_display_using_debug!(VetKdEncryptedKeyShareContent);
 
 impl SignedBytesWithoutDomainSeparator for VetKdEncryptedKeyShareContent {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        self.0.clone()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&self.0);
     }
 }
 

--- a/rs/types/types/src/messages/http.rs
+++ b/rs/types/types/src/messages/http.rs
@@ -342,8 +342,8 @@ pub struct SignedSenderInfo {
 pub struct SenderInfoContent<'a>(pub &'a [u8]);
 
 impl crate::crypto::SignedBytesWithoutDomainSeparator for SenderInfoContent<'_> {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        self.0.to_vec()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(self.0);
     }
 }
 
@@ -593,7 +593,7 @@ impl Delegation {
 }
 
 impl SignedBytesWithoutDomainSeparator for Delegation {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
         use RawHttpRequestVal::*;
 
         let mut map = btreemap! {
@@ -607,7 +607,7 @@ impl SignedBytesWithoutDomainSeparator for Delegation {
             );
         }
 
-        hash_of_map(&map, |key, value| hash_key_val(key, value)).to_vec()
+        bytes.extend_from_slice(&hash_of_map(&map, |key, value| hash_key_val(key, value)));
     }
 }
 
@@ -726,8 +726,8 @@ impl QueryResponseHash {
 }
 
 impl SignedBytesWithoutDomainSeparator for QueryResponseHash {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        self.0.to_vec()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&self.0);
     }
 }
 

--- a/rs/types/types/src/messages/message_id.rs
+++ b/rs/types/types/src/messages/message_id.rs
@@ -69,8 +69,8 @@ impl MessageId {
 }
 
 impl SignedBytesWithoutDomainSeparator for MessageId {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        self.0.to_vec()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&self.0);
     }
 }
 

--- a/rs/types/types/src/messages/webauthn.rs
+++ b/rs/types/types/src/messages/webauthn.rs
@@ -76,8 +76,8 @@ pub struct WebAuthnEnvelope {
 }
 
 impl WebAuthnEnvelope {
-    pub fn challenge(&self) -> Vec<u8> {
-        self.challenge.clone()
+    pub fn challenge(&self) -> &[u8] {
+        &self.challenge
     }
 }
 

--- a/rs/types/types/src/messages/webauthn.rs
+++ b/rs/types/types/src/messages/webauthn.rs
@@ -97,7 +97,7 @@ impl TryFrom<&WebAuthnSignature> for WebAuthnEnvelope {
         };
 
         let mut signed_bytes = signature.authenticator_data.0.clone();
-        signed_bytes.append(&mut Sha256::hash(&signature.client_data_json.0.clone()[..]).to_vec());
+        signed_bytes.extend_from_slice(&Sha256::hash(&signature.client_data_json.0));
 
         Ok(WebAuthnEnvelope {
             client_data_json: signature.client_data_json.0.clone(),

--- a/rs/types/types/src/messages/webauthn.rs
+++ b/rs/types/types/src/messages/webauthn.rs
@@ -110,8 +110,8 @@ impl TryFrom<&WebAuthnSignature> for WebAuthnEnvelope {
 }
 
 impl SignedBytesWithoutDomainSeparator for WebAuthnEnvelope {
-    fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8> {
-        self.signed_bytes.clone()
+    fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&self.signed_bytes);
     }
 }
 
@@ -143,6 +143,8 @@ mod tests {
             hex!("2f1b671a93f444b8ec77e0211f9624c9c2612182b864f0d4ac9d335f5b4fe5020100000053")
                 .to_vec()
         );
-        assert_eq!(result.as_signed_bytes_without_domain_separator().to_vec(), hex!("2f1b671a93f444b8ec77e0211f9624c9c2612182b864f0d4ac9d335f5b4fe50201000000537f91225ffff1e2912a0f8ca7a0ef61df01ae3d8898fca283036239259bab4f82").to_vec());
+        let mut signed_bytes = Vec::new();
+        result.write_signed_bytes_without_domain_separator(&mut signed_bytes);
+        assert_eq!(signed_bytes, hex!("2f1b671a93f444b8ec77e0211f9624c9c2612182b864f0d4ac9d335f5b4fe50201000000537f91225ffff1e2912a0f8ca7a0ef61df01ae3d8898fca283036239259bab4f82").to_vec());
     }
 }

--- a/rs/validator/src/webauthn.rs
+++ b/rs/validator/src/webauthn.rs
@@ -36,7 +36,7 @@ pub(crate) fn validate_webauthn_sig(
 
     // The challenge in the webauthn envelope must match signed bytes.
     let signed_bytes = signable.as_signed_bytes();
-    if envelope.challenge() != signed_bytes {
+    if envelope.challenge() != signed_bytes.as_slice() {
         Err(format!(
             "Challenge in webauthn is {:?} while it is expected to be {:?}",
             envelope.challenge(),


### PR DESCRIPTION
Currently there are two kinds of messages that are signed by the replica:
1. Structured data which is serialized on the fly (e.g. consensus artifacts via serde_cbor, or protobuf).
2. Data that is already present as raw bytes (e.g. message IDs).

In both cases, the function `as_signed_bytes_without_domain_separator` currently produces a newly owned vec (a fresh serialization for 1. and a clone for 2.), which is then appended onto a different vector holding the domain prefix. 

Instead, this PR replaces `fn as_signed_bytes_without_domain_separator(&self) -> Vec<u8>` with `fn write_signed_bytes_without_domain_separator(&self, bytes: &mut Vec<u8>)` which appends/serializes the message bytes directly into the buffer that already holds the domain separator. This saves one clone/allocation of the data to be signed/verified in both cases.

Additionally we remove a few other unnecessary allocations.