### PR TITLE
test: Deflake `//rs/tests/networking/firewall:firewall_correctness_test`

### DIFF
--- a/rs/tests/networking/firewall/firewall_correctness_test.rs
+++ b/rs/tests/networking/firewall/firewall_correctness_test.rs
@@ -123,19 +123,13 @@ pub fn firewall_correctness_test(env: TestEnv) {
             &logger,
         )
         .await;
-        let new_registry_version = env
-            .topology_snapshot()
-            .block_for_newer_registry_version()
-            .await
-            .unwrap()
-            .get_registry_version();
 
         // Wait for a while to make sure that all nodes have updated their firewall rules according
         // to the new registry configuration.
         for subnet in env.topology_snapshot().subnets() {
             await_subnet_firewall_registry_version_with_retries_async(
                 &subnet,
-                new_registry_version,
+                RegistryVersion::from(2),
                 &logger,
                 Duration::from_secs(60),
                 Duration::from_secs(10),

--- a/rs/tests/networking/firewall/firewall_correctness_test.rs
+++ b/rs/tests/networking/firewall/firewall_correctness_test.rs
@@ -100,10 +100,10 @@ pub fn setup(env: TestEnv) {
 
 pub fn firewall_correctness_test(env: TestEnv) {
     let logger = env.logger();
+    let topology_snapshot = env.topology_snapshot();
 
     let mut join_handles = vec![];
-    let all_nodes = env
-        .topology_snapshot()
+    let all_nodes = topology_snapshot
         .subnets()
         .flat_map(|s| s.nodes())
         .collect::<Vec<_>>();
@@ -115,21 +115,17 @@ pub fn firewall_correctness_test(env: TestEnv) {
         // The rule allows necessary ports (SSH and the metrics ports) to be open to everyone, such
         // that the test driver can still connect to the nodes and perform the test
         add_necessary_ports_registry_rule(
-            &env.topology_snapshot()
-                .root_subnet()
-                .nodes()
-                .next()
-                .unwrap(),
+            &topology_snapshot.root_subnet().nodes().next().unwrap(),
             &logger,
         )
         .await;
 
         // Wait for a while to make sure that all nodes have updated their firewall rules according
         // to the new registry configuration.
-        for subnet in env.topology_snapshot().subnets() {
+        for subnet in topology_snapshot.subnets() {
             await_subnet_firewall_registry_version_with_retries_async(
                 &subnet,
-                RegistryVersion::from(2),
+                topology_snapshot.get_registry_version().increment(),
                 &logger,
                 Duration::from_secs(60),
                 Duration::from_secs(10),


### PR DESCRIPTION
It always fails with:
```
Task firewall_correctness_test        FAILED  in 185.20s
     called `Result::unwrap()` on an `Err` value: Func="check if latest registry version >= 2 [rs/tests/driver/src/driver/test_env_api.rs:682]" timed out after 180.08830969s on attempt 26.
      Last error: Registry Transport Error

     Caused by:
         Registry Canister Error. Msg: An unknown error occurred in the registry canister: Failed to query get_certified_changes_since on canister rwlgt-iiaaa-aaaaa-aaaaa-cai: HttpClient: Request timed out for http://[2602:fb2b:110:10:502c:96ff:fec1:7da]:8080/api/v2/canister/rwlgt-iiaaa-aaaaa-aaaaa-cai/query: Elapsed(())
```

Most likely there is a race condition between accessing port 8080 to update the topology snapshot and blocking that same port. However we don't need to update the topology snapshot, since we await the new registry version based on metrics afterwards.