### PR TITLE
feat: drop sudo in proc_wrapper.sh

### DIFF
--- a/toolchains/sysimage/proc_wrapper.sh
+++ b/toolchains/sysimage/proc_wrapper.sh
@@ -20,7 +20,7 @@ tmpdir=$(mktemp -d --tmpdir "icosbuildXXXX")
 # fallback in case `podman unshare` is unavailable for any reason.
 _cleanup() {
     if ! podman --root "$podman_storage_dir/root" --runroot "$podman_storage_dir/runroot" \
-        unshare rm -rf "$tmpdir" "$podman_storage_dir" 2>/dev/null ; then
+        unshare rm -rf "$tmpdir" "$podman_storage_dir" 2>/dev/null; then
 
         echo >&2 "WARNING: could not unshare podman runroot, forcing"
         sudo rm -rf "$tmpdir" "$podman_storage_dir"

--- a/toolchains/sysimage/proc_wrapper.sh
+++ b/toolchains/sysimage/proc_wrapper.sh
@@ -13,5 +13,18 @@ mkdir -p /tmp/containers
 podman_storage_dir=$(mktemp -d --tmpdir="/tmp/containers" "icosbuildXXXX")
 
 tmpdir=$(mktemp -d --tmpdir "icosbuildXXXX")
-trap 'sudo rm -rf "$tmpdir"; sudo rm -rf "$podman_storage_dir"' INT TERM EXIT
+# podman runs rootless and writes files under the storage dir owned by
+# mapped subordinate uids; the calling user can't `rm` them directly.
+# We use `podman unshare rm` so the cleanup runs inside the userns where
+# those uids are mapped to 0. The dev container has sudo NOPASSWD as a
+# fallback in case `podman unshare` is unavailable for any reason.
+_cleanup() {
+    if ! podman --root "$podman_storage_dir/root" --runroot "$podman_storage_dir/runroot" \
+        unshare rm -rf "$tmpdir" "$podman_storage_dir" 2>/dev/null ; then
+
+        echo >&2 "WARNING: could not unshare podman runroot, forcing"
+        sudo rm -rf "$tmpdir" "$podman_storage_dir"
+    fi
+}
+trap _cleanup INT TERM EXIT
 TMPDIR="$tmpdir" PODMAN_STORAGE_DIR="$podman_storage_dir" "$@"


### PR DESCRIPTION
This tries to avoid calling `sudo rm` in the icos `proc_wrapper.sh`. The sudo was required to nuke the storage dir from outside of podman, but instead we can use `podman unshare` which runs with the correct uids mapped inside the userns. The `sudo` command is left as a fallback if the unshare did not succeed.