### PR TITLE
fix: CON-1383 CON-1401 Abort download of stripped messages if surrounding block becomes unwanted

### DIFF
--- a/rs/p2p/artifact_downloader/Cargo.toml
+++ b/rs/p2p/artifact_downloader/Cargo.toml
@@ -29,6 +29,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 criterion = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 futures = { workspace = true }
 http-body-util = { workspace = true }
 ic-canister-client-sender = { path = "../../canister_client/sender" }

--- a/rs/p2p/artifact_downloader/src/fetch_artifact/download.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_artifact/download.rs
@@ -160,6 +160,13 @@ impl<Artifact: PbArtifact> FetchArtifact<Artifact> {
             build_axum_router(pool_clone),
         )
     }
+
+    /// Returns a watcher over the bouncer used by this assembler, so callers can react to the
+    /// artifact becoming [`BouncerValue::Unwanted`] (e.g. to cancel in-progress assembly work).
+    pub(crate) fn bouncer_watcher(&self) -> watch::Receiver<Bouncer<Artifact::Id>> {
+        self.bouncer_rx.clone()
+    }
+
     /// Waits until advert resolves to wanted. If the bouncer value becomes Unwanted, false is returned.
     #[instrument(skip_all)]
     async fn should_download(

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/assembler.rs
@@ -6,7 +6,7 @@ use std::{
 use thiserror::Error;
 
 use ic_interfaces::p2p::consensus::{
-    ArtifactAssembler, AssembleResult, BouncerFactory, Peers, ValidatedPoolReader,
+    ArtifactAssembler, AssembleResult, BouncerFactory, BouncerValue, Peers, ValidatedPoolReader,
 };
 use ic_logger::{ReplicaLogger, warn};
 use ic_metrics::MetricsRegistry;
@@ -228,7 +228,23 @@ impl ArtifactAssembler<ConsensusMessage, MaybeStrippedConsensusMessage>
         let mut messages_from_pool = BTreeMap::<StrippedMessageType, usize>::new();
         let mut messages_from_peers = BTreeMap::<StrippedMessageType, usize>::new();
 
-        while let Some(join_result) = join_set.join_next().await {
+        // Abort the assembly as soon as the block proposal is no longer wanted. Returning
+        // here drops `join_set`, which aborts all outstanding child fetch tasks.
+        let mut bouncer = self.fetch_stripped.bouncer_watcher();
+
+        loop {
+            let join_result = tokio::select! {
+                _ = bouncer.wait_for(|bouncer| matches!(bouncer(&id), BouncerValue::Unwanted)) => {
+                    self.metrics.report_aborted_block_assembly();
+                    return AssembleResult::Unwanted;
+                }
+                join_result = join_set.join_next() => join_result,
+            };
+
+            let Some(join_result) = join_result else {
+                break;
+            };
+
             let Ok((message, peer_id)) = join_result else {
                 return AssembleResult::Unwanted;
             };
@@ -1074,6 +1090,91 @@ mod tests {
                 peer_id: NODE_1
             }
         );
+    }
+
+    /// A peer set that advertises no peers (so missing stripped messages can never be fetched
+    /// from a peer) and signals the first time it is consulted, letting the test synchronize on
+    /// the assembler having reached the missing-stripped-message fetch.
+    #[derive(Clone)]
+    struct SignallingNoPeers(Arc<tokio::sync::Notify>);
+
+    impl Peers for SignallingNoPeers {
+        fn peers(&self) -> Vec<NodeId> {
+            self.0.notify_one();
+            Vec::new()
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn assemble_aborts_when_bouncer_becomes_unwanted() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        // A block proposal with a single ingress message that the receiver is missing.
+        let (ingress, _) = fake_ingress_message_with_sig("fake_1", vec![1, 2, 3]);
+        let block_proposal = fake_block_proposal_with_ingresses(vec![ingress]);
+
+        // The bouncer reports `Wants` until `wants` flips to `false`, after which it reports
+        // `Unwanted`.
+        let wants = Arc::new(AtomicBool::new(true));
+        let wants_clone = wants.clone();
+        let mut mock_bouncer_factory = MockBouncerFactory::default();
+        mock_bouncer_factory
+            .expect_new_bouncer()
+            .returning(move |_| {
+                let wants = wants_clone.clone();
+                Box::new(move |_: &ConsensusMessageId| {
+                    if wants.load(Ordering::SeqCst) {
+                        BouncerValue::Wants
+                    } else {
+                        BouncerValue::Unwanted
+                    }
+                })
+            });
+
+        // The missing ingress is never in the local pool, and there are no peers to fetch it
+        // from, so the fetch of the missing stripped message would otherwise stay pending forever.
+        let mut ingress_pool = MockValidatedPoolReader::<SignedIngress>::default();
+        ingress_pool.expect_get().returning(|_| None);
+        let consensus_pool = MockValidatedPoolReader::<ConsensusMessage>::default();
+        let idkg_pool = MockValidatedPoolReader::<IDkgMessage>::default();
+
+        let f = FetchStrippedConsensusArtifact::new(
+            no_op_logger(),
+            tokio::runtime::Handle::current(),
+            Arc::new(RwLock::new(consensus_pool)),
+            Arc::new(RwLock::new(ingress_pool)),
+            Arc::new(RwLock::new(idkg_pool)),
+            Arc::new(mock_bouncer_factory),
+            MetricsRegistry::new(),
+            NODE_1,
+        )
+        .0;
+        let assembler = (f)(Arc::new(MockTransport::new()));
+
+        let stripped_block_proposal =
+            assembler.disassemble_message(ConsensusMessage::BlockProposal(block_proposal));
+        let started = Arc::new(tokio::sync::Notify::new());
+        let peers = SignallingNoPeers(started.clone());
+        let handle = tokio::spawn(async move {
+            assembler
+                .assemble_message(
+                    stripped_block_proposal.id(),
+                    Some((stripped_block_proposal, NODE_1)),
+                    peers,
+                )
+                .await
+        });
+
+        // Wait until the assembler has downloaded the stripped proposal
+        started.notified().await;
+
+        // The proposal is no longer wanted. Advancing past the bouncer refresh period delivers
+        // the new `Unwanted` value, which must abort the assembly instead of waiting forever for
+        // the missing ingress.
+        wants.store(false, Ordering::SeqCst);
+        tokio::time::advance(Duration::from_secs(4)).await;
+
+        assert_eq!(handle.await.unwrap(), AssembleResult::Unwanted);
     }
 
     #[test]

--- a/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
+++ b/rs/p2p/artifact_downloader/src/fetch_stripped_artifact/metrics.rs
@@ -1,5 +1,5 @@
 use ic_metrics::{MetricsRegistry, buckets::decimal_buckets_with_zero};
-use prometheus::{Histogram, HistogramVec, IntCounterVec, IntGaugeVec};
+use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec};
 
 use crate::fetch_stripped_artifact::types::StrippedMessageType;
 
@@ -14,6 +14,7 @@ pub(super) struct FetchStrippedConsensusArtifactMetrics {
     pub(super) total_block_assembly_duration: Histogram,
     pub(super) active_stripped_message_downloads: IntGaugeVec,
     pub(super) total_stripped_message_download_errors: IntCounterVec,
+    pub(super) aborted_block_assemblies: IntCounter,
 }
 
 #[derive(Copy, Clone)]
@@ -69,6 +70,11 @@ impl FetchStrippedConsensusArtifactMetrics {
                     missing stripped messages",
                     &["error", STRIPPED_MESSAGE_TYPE_LABEL],
             ),
+            aborted_block_assemblies: metrics_registry.int_counter(
+                    "ic_stripped_consensus_artifact_aborted_block_assemblies_total",
+                    "The total number of block assemblies aborted because the block proposal \
+                    became unwanted before all of its missing stripped messages were downloaded",
+            ),
         }
     }
 
@@ -91,6 +97,10 @@ impl FetchStrippedConsensusArtifactMetrics {
         self.stripped_messages_in_a_block_count
             .with_label_values(&[source.as_str(), message_type.as_str()])
             .observe(count as f64)
+    }
+
+    pub(super) fn report_aborted_block_assembly(&self) {
+        self.aborted_block_assemblies.inc()
     }
 
     pub(super) fn report_download_error(&self, label: &str, message_type: StrippedMessageType) {


### PR DESCRIPTION
Block proposals are transmitted/downloaded in stages:
1. An advert is received containing the block id (height and hash). This ID is passed to the bouncer.
2. Once the bouncer returns `Wanted`, the _stripped_ proposal is downloaded (ingress and IDKG dealings are replaced with hashes). If the bouncer returns `Unwanted` before the download finishes, the advert is dropped instead.
3. The stripped proposal is assembled by collecting the missing ingress messages and IDKG dealings from the local pools or from peers.

Until now, we would continue to assemble the stripped proposal, even if the bouncer switched to `Unwanted` in the mean time. 

With this PR, we instead abort the assembly once the surrounding block becomes unwanted, for instance because the finalized height already advanced past it.