### PR TITLE
feat: Drop blessed versions from a few components

### DIFF
--- a/rs/recovery/src/app_subnet_recovery.rs
+++ b/rs/recovery/src/app_subnet_recovery.rs
@@ -70,10 +70,10 @@ pub enum StepType {
     /// This step is only required if we want to deploy a new replica version to the troubled subnet
     /// before we resume its computation. Obviously, this step should not be skipped if the subnet
     /// has stalled due to a deterministic bug. You can continue with this step, if a problem was
-    /// already identified, fixed and a hotfix version is ready to be proposed as a blessed version.
-    /// If a version exists that does not need to be blessed, this step can be skipped, as the
+    /// already identified, fixed and a hotfix version is ready to be proposed as an elected version.
+    /// If a version exists that does not need to be elected, this step can be skipped, as the
     /// actual subnet upgrade will happen in the next step.
-    BlessVersion,
+    ElectVersion,
     /// This step issues an ic-admin command that will create an upgrade proposal for the troubled
     /// subnet. Note that the subnet nodes will only upgrade after we proposed the corresponding
     /// recovery CUP referencing the new registry version.
@@ -361,7 +361,7 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                 }
             }
 
-            StepType::BlessVersion => {
+            StepType::ElectVersion => {
                 if self.params.upgrade_version.is_none() {
                     self.params.upgrade_version =
                         read_optional(&self.logger, "Version to bless (and upgrade to): ");
@@ -536,7 +536,7 @@ impl RecoveryIterator<StepType, StepTypeIter> for AppSubnetRecovery {
                 }
             }
 
-            StepType::BlessVersion => {
+            StepType::ElectVersion => {
                 if let Some(upgrade_version) = &self.params.upgrade_version {
                     let params = self.params.clone();
                     let (url, hash, measurements_path) = match (

--- a/rs/recovery/src/lib.rs
+++ b/rs/recovery/src/lib.rs
@@ -558,7 +558,7 @@ impl Recovery {
         upgrade_url: Url,
         sha256: String,
         guest_launch_measurements: GuestLaunchMeasurements,
-        add_and_bless_replica_version: bool,
+        add_replica_version: bool,
         replay_until_height: Option<u64>,
         skip_prompts: bool,
     ) -> RecoveryResult<impl Step + use<>> {
@@ -574,12 +574,12 @@ impl Recovery {
                 cmd: SubCommand::UpgradeSubnetToReplicaVersion(UpgradeSubnetToReplicaVersionCmd {
                     replica_version_id: upgrade_version.to_string(),
                     replica_version_record: version_record.clone(),
-                    add_and_bless_replica_version,
+                    add_replica_version,
                 }),
                 descr: format!(
                     r#" upgrade-subnet-to-replica-version{} "{}" "{}""#,
-                    if add_and_bless_replica_version {
-                        " --add-and-bless-replica-version"
+                    if add_replica_version {
+                        " --add-replica-version"
                     } else {
                         ""
                     },

--- a/rs/recovery/src/nns_recovery_failover_nodes.rs
+++ b/rs/recovery/src/nns_recovery_failover_nodes.rs
@@ -59,7 +59,7 @@ pub struct NNSRecoveryFailoverNodesArgs {
     #[clap(long, value_parser=crate::util::subnet_id_from_str)]
     pub subnet_id: SubnetId,
 
-    /// Replica version to start the new NNS with (has to be blessed by parent NNS)
+    /// Replica version to start the new NNS with (has to be elected by parent NNS)
     #[clap(long)]
     pub replica_version: Option<ReplicaVersion>,
 
@@ -212,7 +212,7 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoveryFailoverNodes {
                 if self.params.replica_version.is_none() {
                     self.params.replica_version = read_optional(
                         &self.logger,
-                        "New NNS version (current unassigned version or other version blessed by parent NNS): ",
+                        "New NNS version (current unassigned version or other version elected by parent NNS): ",
                     );
                 }
                 if self.params.replacement_nodes.is_none() {

--- a/rs/recovery/src/nns_recovery_same_nodes.rs
+++ b/rs/recovery/src/nns_recovery_same_nodes.rs
@@ -63,8 +63,8 @@ pub enum StepType {
     /// a "target replay height" in this step. This target height should be chosen such that it is
     /// below the height causing the panic, but above or equal to the height of the last certification
     /// (share).
-    /// This step will also add ingress messages to the registry canister to: (optionally) add and
-    /// bless an upgrade version, and update the NNS subnet record to point to this new version.
+    /// This step will also add ingress messages to the registry canister to: (optionally) add
+    /// an upgrade version, and update the NNS subnet record to point to this new version.
     /// ic-replay will stop at the given height (+ the added heights for the ingress messages) and
     /// create a checkpoint, which will then be used to create the recovery CUP.
     ICReplay,
@@ -134,9 +134,9 @@ pub struct NNSRecoverySameNodesArgs {
     #[clap(long)]
     pub upgrade_image_launch_measurements_path: Option<PathBuf>,
 
-    /// Whether to add and bless the upgrade version before upgrading the subnet to it.
+    /// Whether to add the upgrade version before upgrading the subnet to it.
     #[clap(long)]
-    pub add_and_bless_upgrade_version: Option<bool>,
+    pub add_upgrade_version: Option<bool>,
 
     #[clap(long)]
     /// The replay will stop at this height and make a checkpoint.
@@ -296,11 +296,11 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoverySameNodes {
                     self.params.upgrade_version = read_optional(&self.logger, "Upgrade version: ");
                 };
                 if self.params.upgrade_version.is_some()
-                    && self.params.add_and_bless_upgrade_version.is_none()
+                    && self.params.add_upgrade_version.is_none()
                 {
-                    self.params.add_and_bless_upgrade_version = Some(consent_given(
+                    self.params.add_upgrade_version = Some(consent_given(
                         &self.logger,
-                        "Add and bless the upgrade version before upgrading the subnet?",
+                        "Add the upgrade version before upgrading the subnet?",
                     ));
                 }
 
@@ -429,7 +429,7 @@ impl RecoveryIterator<StepType, StepTypeIter> for NNSRecoverySameNodes {
                         url,
                         hash,
                         measurements,
-                        params.add_and_bless_upgrade_version == Some(true),
+                        params.add_upgrade_version == Some(true),
                         self.params.replay_until_height,
                         !self.interactive(),
                     )?))

--- a/rs/registry/regedit/src/protobuf.rs
+++ b/rs/registry/regedit/src/protobuf.rs
@@ -9,7 +9,7 @@ use ic_protobuf::{
         nns::v1::NnsCanisterRecords,
         node_operator::v1::NodeOperatorRecord,
         provisional_whitelist::v1::ProvisionalWhitelist,
-        replica_version::v1::{BlessedReplicaVersions, ReplicaVersionRecord},
+        replica_version::v1::ReplicaVersionRecord,
         routing_table::v1::{CanisterMigrations, RoutingTable},
         subnet::v1::{CatchUpPackageContents, SubnetListRecord, SubnetRecord},
     },
@@ -20,9 +20,9 @@ use ic_registry_keys::{
     CANISTER_RANGES_PREFIX, CRYPTO_RECORD_KEY_PREFIX, CRYPTO_THRESHOLD_SIGNING_KEY_PREFIX,
     CRYPTO_TLS_CERT_KEY_PREFIX, NODE_OPERATOR_RECORD_KEY_PREFIX, NODE_RECORD_KEY_PREFIX,
     REPLICA_VERSION_KEY_PREFIX, ROOT_SUBNET_ID_KEY, SUBNET_RECORD_KEY_PREFIX,
-    make_blessed_replica_versions_key, make_canister_migrations_record_key,
-    make_firewall_config_record_key, make_nns_canister_records_key,
-    make_provisional_whitelist_record_key, make_subnet_list_record_key,
+    make_canister_migrations_record_key, make_firewall_config_record_key,
+    make_nns_canister_records_key, make_provisional_whitelist_record_key,
+    make_subnet_list_record_key,
 };
 pub(crate) trait Transformable {
     fn pb_to_value(data: &[u8]) -> Value;
@@ -88,8 +88,6 @@ fn get_transformer(key: &str) -> Transformers {
         PublicKey::transformers()
     } else if key.starts_with(&make_firewall_config_record_key()) {
         FirewallConfig::transformers()
-    } else if key.starts_with(&make_blessed_replica_versions_key()) {
-        BlessedReplicaVersions::transformers()
     } else if key.starts_with(CANISTER_RANGES_PREFIX) || key == "routing_table" {
         RoutingTable::transformers()
     } else if key.starts_with(&make_canister_migrations_record_key()) {

--- a/rs/replay/src/cmd.rs
+++ b/rs/replay/src/cmd.rs
@@ -107,10 +107,10 @@ pub struct UpgradeSubnetToReplicaVersionCmd {
     /// The Replica version record.
     #[clap(value_parser = parse_json::<ReplicaVersionRecord>)]
     pub replica_version_record: ReplicaVersionRecord,
-    /// If true, the replica version will be added and blessed in the registry
+    /// If true, the replica version will be added in the registry
     /// before upgrading the subnet to it.
     #[clap(long)]
-    pub add_and_bless_replica_version: bool,
+    pub add_replica_version: bool,
 }
 
 #[derive(Clone, Parser)]

--- a/rs/replay/src/ingress.rs
+++ b/rs/replay/src/ingress.rs
@@ -27,8 +27,7 @@ use ic_protobuf::registry::{
 };
 use ic_registry_client_helpers::subnet::get_node_ids_from_subnet_record;
 use ic_registry_keys::{
-    make_blessed_replica_versions_key, make_replica_version_key, make_subnet_list_record_key,
-    make_subnet_record_key,
+    make_replica_version_key, make_subnet_list_record_key, make_subnet_record_key,
 };
 use ic_registry_transport::{
     pb::v1::{Precondition, RegistryMutation, registry_mutation},
@@ -338,7 +337,7 @@ pub(crate) fn cmd_overwrite_subnet_list_with_singleton(
     Ok(vec![msg])
 }
 
-/// Creates signed ingress messages to potentially add a new blessed replica
+/// Creates signed ingress messages to potentially add a new replica
 /// version and updates the subnet record with this replica version.
 pub(crate) fn cmd_upgrade_subnet_to_replica_version(
     agent: &Agent,
@@ -351,17 +350,11 @@ pub(crate) fn cmd_upgrade_subnet_to_replica_version(
 
     let mut msgs = Vec::new();
 
-    if cmd.add_and_bless_replica_version {
+    if cmd.add_replica_version {
         msgs.push(add_replica_version(
             agent,
             replica_version_id.clone(),
             replica_version_record,
-            context_time,
-        )?);
-        msgs.push(bless_replica_version(
-            agent,
-            player,
-            replica_version_id.clone(),
             context_time,
         )?);
     }
@@ -489,35 +482,6 @@ fn atomic_mutate(
     let payload = serialize_atomic_mutate_request(mutations, pre_conditions);
 
     make_signed_ingress(agent, canister_id, "atomic_mutate", payload, expiry)
-}
-
-/// Bless a new replica version by mutating the registry canister.
-pub(crate) fn bless_replica_version(
-    agent: &Agent,
-    player: &crate::player::Player,
-    replica_version_id: String,
-    context_time: Time,
-) -> Result<SignedIngress, String> {
-    let mut mutation = RegistryMutation::default();
-    mutation.set_mutation_type(registry_mutation::Type::Upsert);
-    mutation.key = make_blessed_replica_versions_key().into_bytes();
-    let mut blessed_versions = player.get_blessed_replica_versions(context_time)?;
-    blessed_versions
-        .blessed_version_ids
-        .push(replica_version_id);
-
-    let mut buf = Vec::new();
-    match blessed_versions.encode(&mut buf) {
-        Ok(_) => mutation.value = buf,
-        Err(error) => panic!("Error encoding the value to protobuf: {error:?}"),
-    }
-    atomic_mutate(
-        agent,
-        REGISTRY_CANISTER_ID,
-        vec![mutation],
-        vec![],
-        context_time,
-    )
 }
 
 /// Add a new replica version by mutating the registry canister.

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -38,14 +38,11 @@ use ic_logger::{ReplicaLogger, error, info, new_replica_logger_from_config, warn
 use ic_messaging::MessageRoutingImpl;
 use ic_metrics::MetricsRegistry;
 use ic_nns_constants::REGISTRY_CANISTER_ID;
-use ic_protobuf::{
-    registry::{replica_version::v1::BlessedReplicaVersions, subnet::v1::SubnetRecord},
-    types::v1 as pb,
-};
+use ic_protobuf::{registry::subnet::v1::SubnetRecord, types::v1 as pb};
 use ic_registry_canister_api::{Chunk, GetChunkRequest};
 use ic_registry_client::client::RegistryClientImpl;
 use ic_registry_client_helpers::{deserialize_registry_value, subnet::SubnetRegistry};
-use ic_registry_keys::{make_blessed_replica_versions_key, make_subnet_record_key};
+use ic_registry_keys::make_subnet_record_key;
 use ic_registry_local_store::{
     Changelog, ChangelogEntry, KeyMutation, LocalStoreImpl, LocalStoreWriter,
 };
@@ -896,21 +893,6 @@ impl Player {
                 },
             },
         }
-    }
-
-    /// Return latest BlessedReplicaVersions record by querying the registry
-    /// canister.
-    pub fn get_blessed_replica_versions(
-        &self,
-        ingress_expiry: Time,
-    ) -> Result<BlessedReplicaVersions, String> {
-        self.certify_state_with_dummy_certification();
-        let perform_query = Arc::new(Mutex::new(self.query_handler.clone()));
-        self.runtime.block_on(registry_get_value(
-            &make_blessed_replica_versions_key(),
-            ingress_expiry,
-            &perform_query,
-        ))
     }
 
     /// Return the latest registry version by querying the registry canister.

--- a/rs/tests/consensus/subnet_recovery/utils.rs
+++ b/rs/tests/consensus/subnet_recovery/utils.rs
@@ -545,7 +545,7 @@ pub mod local {
             upgrade_image_url,
             upgrade_image_hash,
             upgrade_image_launch_measurements_path,
-            add_and_bless_upgrade_version,
+            add_upgrade_version,
             replay_until_height,
             download_pool_node,
             admin_access_location: _, // ignored to choose "local" in local recoveries, see below
@@ -579,7 +579,7 @@ pub mod local {
             };
         let upgrade_image_launch_measurements_path_cli =
             opt_cli_arg!(upgrade_image_launch_measurements_path);
-        let add_upgrade_version_cli = opt_cli_arg!(add_and_bless_upgrade_version);
+        let add_upgrade_version_cli = opt_cli_arg!(add_upgrade_version);
         let replay_until_height_cli = opt_cli_arg!(replay_until_height);
         let download_pool_node_cli = opt_cli_arg!(download_pool_node);
         // We are doing a local recovery, so we override the admin access location to "local"

--- a/rs/tests/nested/nns_recovery/common.rs
+++ b/rs/tests/nested/nns_recovery/common.rs
@@ -590,7 +590,7 @@ pub fn test(env: TestEnv, cfg: TestConfig) {
         upgrade_image_url: Some(upgrade_image_url),
         upgrade_image_hash: Some(upgrade_image_hash),
         upgrade_image_launch_measurements_path: Some(env.get_path(GUEST_LAUNCH_MEASUREMENTS_PATH)),
-        add_and_bless_upgrade_version: Some(cfg.add_upgrade_version),
+        add_upgrade_version: Some(cfg.add_upgrade_version),
         replay_until_height: Some(highest_cert_share),
         download_pool_node: Some(download_pool_node.get_ip_addr()),
         admin_access_location: Some(DataLocation::Remote(dfinity_owned_node.get_ip_addr())),


### PR DESCRIPTION
ReplicaVersionRecords and the blessed versions list are updated in sync, as we no longer require an extra proposal to have each version "blessed".

This updates a few tools with the change.