### PR TITLE
feat: [NODE-1962] Create baseimage for bootloader

### DIFF
--- a/.github/workflows/container-base-images.yml
+++ b/.github/workflows/container-base-images.yml
@@ -54,6 +54,10 @@ jobs:
             CONTEXT: "ic-os/setupos/context"
             REFFILE: "ic-os/setupos/context/docker-base.dev"
             BUILD_ARGS: "PACKAGE_FILES=packages.common packages.dev"
+          - IMAGE: "bootloader-base"
+            CONTEXT: "ic-os/bootloader/context"
+            REFFILE: "ic-os/bootloader/context/docker-base"
+            BUILD_ARGS: ""
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/ic-os/bootloader/BUILD.bazel
+++ b/ic-os/bootloader/BUILD.bazel
@@ -14,11 +14,13 @@ exports_files([
 
 genrule(
     name = "build-bootloader-tree",
-    srcs = [],
+    srcs = [
+        "context/docker-base",
+    ],
     outs = [
         "bootloader-tree.tar",
     ],
-    cmd = "$(location build-bootloader-tree.sh) -o $@",
+    cmd = "$(location build-bootloader-tree.sh) -b $< -o $@",
     tags = [
         "manual",
         "requires-network",

--- a/ic-os/bootloader/build-bootloader-tree.sh
+++ b/ic-os/bootloader/build-bootloader-tree.sh
@@ -8,10 +8,13 @@ set -euxo pipefail
 
 trap 'sudo rm -rf "${TMP_DIR}"' EXIT
 
-while getopts "o:" OPT; do
+while getopts "o:b:" OPT; do
     case "${OPT}" in
         o)
             OUT_FILE="${OPTARG}"
+            ;;
+        b)
+            BASE_IMAGE_FILE="${OPTARG}"
             ;;
         *)
             echo "No output file given" >&2
@@ -22,14 +25,11 @@ done
 
 TMP_DIR=$(mktemp -d --tmpdir="/tmp/containers" build-image-XXXXXXXXXXXX)
 
-BASE_IMAGE="ghcr.io/dfinity/library/ubuntu@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0561c97bef9450d0b4"
+BASE_IMAGE="$(cat ${BASE_IMAGE_FILE})"
 
 podman --root "${TMP_DIR}/root" --runroot "${TMP_DIR}/runroot" build --iidfile "${TMP_DIR}/iidfile" - <<<"
     FROM $BASE_IMAGE
     USER root:root
-    # First update the required certs
-    RUN apt-get -y update && apt-get -y --no-install-recommends install ca-certificates
-    RUN apt-get -y update --snapshot 20260520T000000Z && apt-get -y --no-install-recommends install --snapshot 20260520T000000Z grub-efi faketime
     RUN mkdir -p /build/boot/grub
     RUN cp -r /usr/lib/grub/x86_64-efi /build/boot/grub
     RUN mkdir -p /build/boot/efi/EFI/Boot

--- a/ic-os/bootloader/context/Dockerfile.base
+++ b/ic-os/bootloader/context/Dockerfile.base
@@ -2,8 +2,5 @@ FROM ubuntu:26.04
 
 USER root:root
 
-# First update the required certs
-RUN apt-get -y update && apt-get -y --no-install-recommends install ca-certificates
-
-# Then pull required packages
-RUN apt-get -y update --snapshot 20260520T000000Z && apt-get -y --no-install-recommends install --snapshot 20260520T000000Z grub-efi faketime
+# Pull required packages
+RUN apt-get -y update && apt-get -y --no-install-recommends install grub-efi faketime

--- a/ic-os/bootloader/context/Dockerfile.base
+++ b/ic-os/bootloader/context/Dockerfile.base
@@ -1,0 +1,9 @@
+FROM ubuntu:26.04
+
+USER root:root
+
+# First update the required certs
+RUN apt-get -y update && apt-get -y --no-install-recommends install ca-certificates
+
+# Then pull required packages
+RUN apt-get -y update --snapshot 20260520T000000Z && apt-get -y --no-install-recommends install --snapshot 20260520T000000Z grub-efi faketime

--- a/ic-os/bootloader/context/docker-base
+++ b/ic-os/bootloader/context/docker-base
@@ -1,0 +1,1 @@
+ghcr.io/dfinity/bootloader-base-branch@sha256:28146eac51aa807d809b66f9b9152d2965bd1ff4633ce469bde58d4dbc4386fa


### PR DESCRIPTION
Create a new baseimage for the bootloader, and use this instead of ubuntu snapshots for deterministic builds.

We've found that snapshots have a lower ratelimit, and so can fail builds on CI. For now, we move the bootloader to a baseimage like we have for other IC-OS builds, but going forward we should see about moving all of these to mirrored snapshots, or rework the bootloader build away from containers (we only run a single command).