### PR TITLE
fix: producing canister logs with zero log memory limit

### DIFF
--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -3010,3 +3010,29 @@ fn test_log_memory_store_upgrade_downgrade() {
     check_lms(&env, canister_few, false, false, true, 0);
     check_records(&env, canister_few, 3, 2, &log_2);
 }
+
+#[test]
+fn produce_log_with_zero_log_memory_limit() {
+    let subnet_type = SubnetType::Application;
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            SubnetConfig::new(subnet_type, SubnetSecurity::None),
+            ExecutionConfig {
+                log_memory_store_feature: FlagStatus::Enabled,
+                ..Default::default()
+            },
+        )))
+        .with_subnet_type(subnet_type)
+        .with_checkpoints_enabled(true)
+        .build();
+
+    let settings = CanisterSettingsArgsBuilder::new()
+        .with_log_memory_limit(0)
+        .build();
+    let canister_id = create_and_install_canister(&env, settings, UNIVERSAL_CANISTER_WASM.to_vec());
+    let _ = env.execute_ingress(
+        canister_id,
+        "update",
+        wasm().debug_print(b"log").reply().build(),
+    );
+}

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
@@ -419,7 +419,11 @@ impl LogMemoryStore {
             return;
         }
         let Some(mut ring_buffer) = self.load_ring_buffer() else {
-            return; // No ring buffer exists.
+            // No ring buffer exists (e.g. log_memory_limit set to 0); still
+            // carry the monotone index forward so persistent_next_idx stays
+            // in sync with canister_log.next_idx().
+            self.persistent_next_idx = self.persistent_next_idx.max(delta_log.next_idx());
+            return;
         };
         // Append the delta records and persist the ring buffer.
         ring_buffer.append_log(delta_log.records_mut().drain(..));


### PR DESCRIPTION
This PR fixes the case of producing a canister log with zero log memory limit set on the canister: this case used to trigger
```
ERRO s:/n:/ic_state_manager/checkpoint state_manager_replicated_state_altered_after_checkpoint: Replicated state altered: system_state.log_memory_store.persistent_next_idx
```
because `persistent_next_idx` was not updated in such a case.

# Cause

The bug was introduced by the interaction of two commits:

  Root cause — 4e08ae32fe (PR #8542, Jan 27 2026) — "refactor: remove log_memory_limit from log_memory_store"

  Before this commit, append_delta_log used unwrap_or(RingBuffer::new(...)) so it always had a ring buffer to work with, even when none existed. PR #8542 replaced that with an early return; 
  // No ring buffer exists. when load_ring_buffer() returns None (the zero-limit case). That early return left delta log records un-drained and any index tracking un-updated.

  Symptom trigger — d7644c6ae7 (PR #9309, Mar 27 2026) — "fix: persist next_idx over checkpoint for LogMemoryStore"

  This commit introduced persistent_next_idx and added updates to it in save_ring_buffer, deallocate, and resize — but not in the early-return path of append_delta_log. That's exactly the
  missing line your fix adds (self.persistent_next_idx = self.persistent_next_idx.max(delta_log.next_idx())).

  So the observable error (state_manager_replicated_state_altered_after_checkpoint due to persistent_next_idx drift) was only possible after PR #9309 landed, but the structural defect —
  returning early without propagating state — was set up by PR #8542.