### PR TITLE
fix: uninstall_code does not deallocate canister log

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -2013,9 +2013,10 @@ impl CanisterManager {
         }
 
         let uninstalled_canister_size = if uninstall_code {
-            canister.execution_memory_usage()
-                + canister.wasm_chunk_store_memory_usage()
-                + canister.log_memory_store_memory_usage()
+            // Note: log_memory_store is NOT included here because uninstall_code
+            // only clears the log records (clear_log) while keeping the store
+            // allocated, so log_memory_store_memory_usage() does not decrease.
+            canister.execution_memory_usage() + canister.wasm_chunk_store_memory_usage()
         } else {
             NumBytes::from(0)
         };
@@ -3093,8 +3094,8 @@ pub fn uninstall_canister(
     // Drop the canister's execution state.
     canister.execution_state = None;
 
-    // Remove canister log.
-    canister.remove_log();
+    // Clear canister log.
+    canister.clear_log();
 
     // Clear the Wasm chunk store.
     canister.system_state.wasm_chunk_store = WasmChunkStore::new(fd_factory);

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -4941,16 +4941,6 @@ fn uninstall_code_on_empty_canister_updates_subnet_available_memory() {
     // Assert that canister history memory was non empty.
     let initial_canister_history_memory_usage = canister_history_memory_usage(&mut test);
     assert_gt!(initial_canister_history_memory_usage, 0);
-    let initial_log_memory_store_memory_usage = test
-        .canister_state(canister_id)
-        .log_memory_store_memory_usage()
-        .get();
-    if LOG_MEMORY_STORE_FEATURE_ENABLED {
-        // Assert that canister log memory store memory was non empty.
-        assert_gt!(initial_log_memory_store_memory_usage, 0);
-    } else {
-        assert_eq!(initial_log_memory_store_memory_usage, 0);
-    }
 
     test.uninstall_code(canister_id).unwrap();
 
@@ -4962,23 +4952,15 @@ fn uninstall_code_on_empty_canister_updates_subnet_available_memory() {
         final_canister_history_memory_usage,
         initial_canister_history_memory_usage
     );
-    // Assert that canister log memory store memory was cleared.
-    let final_log_memory_store_memory_usage = test
-        .canister_state(canister_id)
-        .log_memory_store_memory_usage()
-        .get();
-    assert_eq!(final_log_memory_store_memory_usage, 0);
 
     let extra_subnet_available_memory_usage =
         final_subnet_available_memory as i64 - initial_subnet_available_memory as i64;
     let extra_canister_history_memory_usage =
         final_canister_history_memory_usage as i64 - initial_canister_history_memory_usage as i64;
-    let extra_canister_log_memory_store_memory_usage =
-        final_log_memory_store_memory_usage as i64 - initial_log_memory_store_memory_usage as i64;
-    // Assert that subnet available memory usage has opposite sign to canister memory usage.
+    // Assert that subnet available memory change has opposite sign to canister history memory change.
     assert_eq!(
         -extra_subnet_available_memory_usage,
-        extra_canister_history_memory_usage + extra_canister_log_memory_store_memory_usage
+        extra_canister_history_memory_usage
     );
 }
 

--- a/rs/execution_environment/src/execution_environment/tests.rs
+++ b/rs/execution_environment/src/execution_environment/tests.rs
@@ -4717,7 +4717,7 @@ fn output_requests_on_application_subnets_update_subnet_available_memory_reserve
 fn test_canister_settings_log_visibility_default_controllers() {
     // Arrange.
     let mut test = ExecutionTestBuilder::new().build();
-    let canister_id = test.create_canister(Cycles::new(1_000_000_000));
+    let canister_id = test.create_canister(Cycles::new(1_000_000_000_000));
     // Act.
     let canister_status = test.canister_status(canister_id).unwrap();
     // Assert.
@@ -4734,7 +4734,7 @@ fn test_canister_settings_log_visibility_create_with_settings() {
     // Act.
     let canister_id = test
         .create_canister_with_settings(
-            Cycles::new(1_000_000_000),
+            Cycles::new(1_000_000_000_000),
             ic00::CanisterSettingsArgsBuilder::new()
                 .with_log_visibility(LogVisibilityV2::Public)
                 .build(),
@@ -4752,7 +4752,7 @@ fn test_canister_settings_log_visibility_create_with_settings() {
 fn test_canister_settings_log_visibility_set_to_public() {
     // Arrange.
     let mut test = ExecutionTestBuilder::new().build();
-    let canister_id = test.create_canister(Cycles::new(1_000_000_000));
+    let canister_id = test.create_canister(Cycles::new(1_000_000_000_000));
     // Act.
     test.set_log_visibility(canister_id, LogVisibilityV2::Public)
         .unwrap();

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -891,6 +891,7 @@ impl SchedulerImpl {
                 canister.system_state.compute_allocation = ComputeAllocation::zero();
                 canister.system_state.memory_allocation = MemoryAllocation::default();
                 canister.system_state.clear_canister_history();
+                canister.remove_log();
                 // Burn the remaining balance of the canister.
                 canister
                     .system_state

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -2179,7 +2179,7 @@ fn test_canister_uninstall_code_clears_logs() {
 }
 
 #[test]
-fn test_canister_uninstall_and_install_clears_log_memory() {
+fn test_canister_uninstall_and_install_clears_log() {
     if !LOG_MEMORY_STORE_FEATURE_ENABLED {
         return;
     }

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -2135,14 +2135,21 @@ fn test_canister_reinstall_clears_logs_but_preserves_log_memory_limit() {
 }
 
 #[test]
-fn test_canister_uninstall_code_deallocates_logs() {
+fn test_canister_uninstall_code_clears_logs() {
     if !LOG_MEMORY_STORE_FEATURE_ENABLED {
         return;
     }
-    let (env, canister_id) = setup_with_controller(
-        PrincipalId::new_anonymous(),
-        UNIVERSAL_CANISTER_WASM.to_vec(),
-    );
+    let controller = PrincipalId::new_anonymous();
+    let wasm = wat_canister()
+        .update("test", wat_fn().debug_print(b"hello"))
+        .build_wasm();
+    let (env, canister_id) = setup_with_controller(controller, wasm);
+
+    // Populate the log before uninstall.
+    let _ = env.execute_ingress(canister_id, "test", vec![]);
+    let _ = env.execute_ingress(canister_id, "test", vec![]);
+    let logs_before = fetch_log_records(&env, controller, canister_id);
+    assert_eq!(logs_before.len(), 2);
 
     // Before uninstall code.
     let status = env.canister_status(canister_id).unwrap().unwrap();
@@ -2157,13 +2164,18 @@ fn test_canister_uninstall_code_deallocates_logs() {
 
     let _ = env.uninstall_code(canister_id).unwrap();
 
-    // After uninstall code.
+    // After uninstall code, the log entries are cleared but the memory store is not deallocated.
+    let logs_after = fetch_log_records(&env, controller, canister_id);
+    assert_eq!(logs_after.len(), 0);
     let status = env.canister_status(canister_id).unwrap().unwrap();
     assert_eq!(
         status.settings().log_memory_limit(),
-        candid::Nat::from(0_u64)
+        candid::Nat::from(TEST_DEFAULT_LOG_MEMORY_LIMIT)
     );
-    assert_eq!(status.log_memory_store_size().get(), 0_u64);
+    assert_eq!(
+        status.log_memory_store_size().get(),
+        TEST_DEFAULT_LOG_MEMORY_USAGE
+    );
 }
 
 #[test]
@@ -2193,11 +2205,11 @@ fn test_canister_uninstall_and_install_clears_log_memory() {
         vec![],
     );
 
-    // After uninstall code.
+    // After uninstall+install, the log is cleared but the memory store is kept.
     let _ = env.execute_ingress(canister_id, "test", vec![]);
     let logs_after = fetch_log_records(&env, controller, canister_id);
-    // Expect zero, because log memory store is deallocated.
-    assert_eq!(logs_after.len(), 0);
+    // Expect one entry from the single execution after reinstall.
+    assert_eq!(logs_after.len(), 1);
 }
 
 #[test]
@@ -3070,4 +3082,73 @@ fn test_canister_log_with_zero_log_memory_limit() {
 
     let env = env.restart_node_with_config(config);
     check_next_idx(&env);
+}
+
+#[test]
+fn test_log_memory_store_deallocated_when_canister_out_of_cycles() {
+    // Test that the log memory store is deallocated when a canister runs out of cycles.
+    if !LOG_MEMORY_STORE_FEATURE_ENABLED {
+        return;
+    }
+    let controller = PrincipalId::new_anonymous();
+    let env = setup_env();
+    // Use 300T cycles — enough to satisfy the freeze-threshold reserve for
+    // compute_allocation=1 (~25.52T) while still being drainable by time advance.
+    let canister_id = env.create_canister_with_cycles(
+        None,
+        Cycles::new(300_000_000_000_000_u128),
+        Some(
+            CanisterSettingsArgsBuilder::new()
+                .with_controllers(vec![controller])
+                .with_compute_allocation(1)
+                .build(),
+        ),
+    );
+    env.install_wasm_in_mode(
+        canister_id,
+        CanisterInstallMode::Install,
+        wat_canister()
+            .update("test", wat_fn().debug_print(b"hello"))
+            .build_wasm(),
+        vec![],
+    )
+    .unwrap();
+
+    // Populate the log memory store with a log record.
+    let _ = env.execute_ingress(canister_id, "test", vec![]);
+
+    // Verify the log memory store is allocated before cycles run out.
+    let state = env.get_latest_state();
+    assert!(
+        state
+            .canister_state(&canister_id)
+            .unwrap()
+            .system_state
+            .log_memory_store
+            .is_allocated()
+    );
+    drop(state);
+
+    // Advance time enough to drain the cycle balance given compute_allocation=1.
+    let compute_percent_allocated_per_second_fee =
+        SubnetConfig::new(SubnetType::Application, SubnetSecurity::None)
+            .cycles_account_manager_config
+            .compute_percent_allocated_per_second_fee;
+    let seconds_to_burn = env.cycle_balance(canister_id) as u64
+        / compute_percent_allocated_per_second_fee.get() as u64;
+    env.advance_time(Duration::from_secs(seconds_to_burn + 1));
+
+    // A checkpointed tick forces allocation charging and triggers the out-of-cycles uninstall.
+    env.checkpointed_tick();
+
+    // After running out of cycles, the log memory store must be deallocated.
+    let state = env.get_latest_state();
+    assert!(
+        !state
+            .canister_state(&canister_id)
+            .unwrap()
+            .system_state
+            .log_memory_store
+            .is_allocated()
+    );
 }

--- a/rs/execution_environment/tests/memory_matrix.rs
+++ b/rs/execution_environment/tests/memory_matrix.rs
@@ -1075,15 +1075,9 @@ fn test_memory_suite_take_snapshot_and_uninstall_code() {
         )
         .err()
     };
-    let memory_usage_change = if LOG_MEMORY_STORE_FEATURE_ENABLED {
-        // Uninstalling code removes canister log allocated memory.
-        MemoryUsageChange::Decrease
-    } else {
-        MemoryUsageChange::None
-    };
     let params = ScenarioParams {
         scenario: Scenario::OtherManagement,
-        memory_usage_change,
+        memory_usage_change: MemoryUsageChange::None,
         setup,
         op,
     };


### PR DESCRIPTION
This PR fixes the `uninstall_code` endpoint of the management canister to only clear the canister log records instead of fully deallocating the canister log (which is now only the case if the canister runs out of cycles). This is analogous to compute/memory allocation that are also not changed by the `uninstall_code` endpoint of the management canister, but only if the canister runs out of cycles.