### PR TITLE
fix: check for canister heap delta rate limit in update_settings

### DIFF
--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -561,6 +561,16 @@ impl CanisterManager {
                 .system_state
                 .log_memory_store
                 .would_resize(requested_limit.get() as usize);
+            if log_resize_needed
+                && self.config.rate_limiting_of_heap_delta == FlagStatus::Enabled
+                && canister.scheduler_state.heap_delta_debit >= self.config.heap_delta_rate_limit
+            {
+                return Err(CanisterManagerError::CanisterHeapDeltaRateLimited {
+                    canister_id: canister.canister_id(),
+                    value: canister.scheduler_state.heap_delta_debit,
+                    limit: self.config.heap_delta_rate_limit,
+                });
+            }
             let log_resize_instructions = if log_resize_needed {
                 let log_bytes_used_before =
                     NumBytes::new(canister.system_state.log_memory_store.bytes_used() as u64);

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -565,6 +565,7 @@ impl CanisterManager {
                 && requested_limit.get() != 0
                 && self.config.rate_limiting_of_heap_delta == FlagStatus::Enabled
                 && canister.scheduler_state.heap_delta_debit >= self.config.heap_delta_rate_limit
+            {
                 return Err(CanisterManagerError::CanisterHeapDeltaRateLimited {
                     canister_id: canister.canister_id(),
                     value: canister.scheduler_state.heap_delta_debit,

--- a/rs/execution_environment/src/canister_manager.rs
+++ b/rs/execution_environment/src/canister_manager.rs
@@ -562,9 +562,9 @@ impl CanisterManager {
                 .log_memory_store
                 .would_resize(requested_limit.get() as usize);
             if log_resize_needed
+                && requested_limit.get() != 0
                 && self.config.rate_limiting_of_heap_delta == FlagStatus::Enabled
                 && canister.scheduler_state.heap_delta_debit >= self.config.heap_delta_rate_limit
-            {
                 return Err(CanisterManagerError::CanisterHeapDeltaRateLimited {
                     canister_id: canister.canister_id(),
                     value: canister.scheduler_state.heap_delta_debit,

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -5647,6 +5647,15 @@ fn update_settings_fails_when_heap_delta_rate_limited() {
     test.install_canister(canister_id, UNIVERSAL_CANISTER_WASM.to_vec())
         .unwrap();
 
+    // Ensure the log store is non-empty so resize would rewrite log data.
+    const MSG: &[u8] = &[b'x'; 2100];
+    test.ingress(
+        canister_id,
+        "update",
+        wasm().debug_print(MSG).reply().build(),
+    )
+    .unwrap();
+
     test.canister_state_mut(canister_id)
         .scheduler_state
         .heap_delta_debit = LIMIT;

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -5626,6 +5626,47 @@ fn update_settings_heap_delta_log_memory_limit_increased() {
     );
 }
 
+#[test]
+fn update_settings_fails_when_heap_delta_rate_limited() {
+    const CYCLES: Cycles = Cycles::new(1_000_000_000_000_000);
+    const MIB: u64 = 1024 * 1024;
+    const LIMIT: NumBytes = NumBytes::new(10 * MIB);
+
+    let mut test = ExecutionTestBuilder::new()
+        .with_heap_delta_rate_limit(LIMIT)
+        .with_log_memory_store_feature_enabled()
+        .build();
+    let canister_id = test
+        .create_canister_with_settings(
+            CYCLES,
+            CanisterSettingsArgsBuilder::new()
+                .with_log_memory_limit(2 * MIB)
+                .build(),
+        )
+        .unwrap();
+    test.install_canister(canister_id, UNIVERSAL_CANISTER_WASM.to_vec())
+        .unwrap();
+
+    test.canister_state_mut(canister_id)
+        .scheduler_state
+        .heap_delta_debit = LIMIT;
+
+    let args = UpdateSettingsArgs {
+        canister_id: canister_id.get(),
+        settings: CanisterSettingsArgsBuilder::new()
+            .with_log_memory_limit(MIB)
+            .build(),
+        sender_canister_version: None,
+    }
+    .encode();
+    test.subnet_message(Method::UpdateSettings, args)
+        .unwrap_err()
+        .assert_contains(
+            ErrorCode::CanisterHeapDeltaRateLimited,
+            &format!("Canister {canister_id} is heap delta rate limited: current delta debit is 10485760, but limit is 10485760"),
+        );
+}
+
 // Canister creation without log_memory_limit → first-time log store allocation
 // must not contribute to heap delta.
 #[test]


### PR DESCRIPTION
This PR adds a check for canister heap delta rate limit in the `update_settings` endpoint of the management canister in case the canister's log memory store is resized and thus heap delta grows.