### PR TITLE
feat: [DSM-142] state_manager_hot_canisters_count histogram

### DIFF
--- a/rs/replicated_state/src/canister_states.rs
+++ b/rs/replicated_state/src/canister_states.rs
@@ -247,6 +247,12 @@ impl CanisterStates {
         self.hot.len() + self.cold.len()
     }
 
+    /// Returns the number of canisters in the `hot` pool (which may or may not be
+    /// actually hot).
+    pub fn hot_len(&self) -> usize {
+        self.hot.len()
+    }
+
     /// Returns true iff there are no canisters at all.
     pub fn is_empty(&self) -> bool {
         self.hot.is_empty() && self.cold.is_empty()

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -45,7 +45,7 @@ use ic_interfaces_state_manager::{
 use ic_logger::{ReplicaLogger, debug, error, fatal, info, warn};
 use ic_metrics::{
     MetricsRegistry,
-    buckets::{decimal_buckets, exponential_buckets},
+    buckets::{decimal_buckets, decimal_buckets_with_zero, exponential_buckets},
 };
 use ic_protobuf::proxy::{ProtoProxy, ProxyDecodeError};
 use ic_protobuf::{messaging::xnet::v1, state::v1 as pb};
@@ -183,6 +183,7 @@ pub struct StateManagerMetrics {
     state_sync_metrics: StateSyncMetrics,
     state_size: IntGauge,
     states_metadata_pbuf_size: IntGauge,
+    hot_canisters_count: Histogram,
     checkpoint_metrics: CheckpointMetrics,
     manifest_metrics: ManifestMetrics,
     tip_handler_queue_length: IntGauge,
@@ -446,6 +447,13 @@ impl StateManagerMetrics {
             "Size of states_metadata.pbuf in bytes.",
         );
 
+        let hot_canisters_count = metrics_registry.histogram(
+            "state_manager_hot_canisters_count",
+            "Number of canisters in the hot pool before repartitioning.",
+            // 0, 1, 2, 5, 10, …, 500_000, 1_000_000
+            decimal_buckets_with_zero(0, 5),
+        );
+
         let tip_handler_queue_length = metrics_registry.int_gauge(
             "state_manager_tip_handler_queue_length",
             "Length of TipChannel queue.",
@@ -517,6 +525,7 @@ impl StateManagerMetrics {
             state_sync_metrics: StateSyncMetrics::new(metrics_registry),
             state_size,
             states_metadata_pbuf_size,
+            hot_canisters_count,
             checkpoint_metrics: CheckpointMetrics::new(metrics_registry, log),
             manifest_metrics: ManifestMetrics::new(metrics_registry),
             tip_handler_queue_length,
@@ -3420,6 +3429,9 @@ impl StateManager for StateManagerImpl {
         // during the round may have left canisters that are now cold in `hot`. The
         // partition must be canonical at checkpoint time so that a replica continuing
         // through a checkpoint and one (re)starting from it agree on the partition.
+        self.metrics
+            .hot_canisters_count
+            .observe(state.canister_states().hot_len() as f64);
         state.repartition_canister_states();
 
         let assert_tip_is_none = |states: &SharedState| {


### PR DESCRIPTION
Export a histogram of the `CanisterStates` hot pool size before it is repartitioned each round.