### PR TITLE
test: keep backup-pod ssh-agent socket outside ~/.ssh

### DIFF
--- a/.github/workflows/schedule-daily.yml
+++ b/.github/workflows/schedule-daily.yml
@@ -27,14 +27,15 @@ jobs:
       - &backup-pod-access
         name: Set up backup pod access
         run: |
-          # The following adds the SSH private key to the ssh-agent such that CI can SSH into the backup pod.
-          if [ -z "${SSH_AUTH_SOCK:-}" ]; then
-            eval "$(ssh-agent -s)"
-            ssh-add - <<'EOF'
+          # Start a dedicated ssh-agent with an explicit socket path under /tmp (outside ~/.ssh, so it
+          # survives the `rm -rf ~/.ssh` below) and load the backup-pod private key so CI can SSH into
+          # the backup pod. We don't reuse any pre-existing agent because its socket may live under
+          # ~/.ssh (as in the 26.04 image) and would be removed below.
+          eval "$(ssh-agent -s -a /tmp/backup-pod-agent.sock)"
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          ssh-add - <<'EOF'
           ${{ secrets.SSH_PRIVATE_KEY_BACKUP_POD }}
           EOF
-            echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
-          fi
 
           rm -rf ~/.ssh
           mkdir -p ~/.ssh


### PR DESCRIPTION
The nightly `Set up backup pod access` step started an ssh-agent, loaded the backup-pod private key, and then ran `rm -rf ~/.ssh`. After the build image was updated to Ubuntu 26.04 (OpenSSH 10.2), ssh-agent began placing its default socket under `~/.ssh/agent/`, so that `rm -rf ~/.ssh` deleted the live agent socket. `SSH_AUTH_SOCK` was still forwarded into the bazel test sandbox but pointed at a socket that no longer existed, so `scp` from the backup pod failed with `Permission denied (publickey)`. This broke the FI nightly, NNS recovery, and NNS nightly jobs, which all share this setup step.

This change starts a dedicated ssh-agent with an explicit socket path under `/tmp` — outside `~/.ssh`, so it survives the `rm -rf ~/.ssh` and remains reachable from the bazel test sandbox (where `/tmp` is available). It also always starts its own agent rather than reusing a pre-existing one whose socket might live under `~/.ssh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)