### PR TITLE
feat(registry-canister): get_subnet endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19991,6 +19991,7 @@ dependencies = [
  "ic-registry-client",
  "ic-registry-client-helpers",
  "ic-registry-proto-data-provider",
+ "ic-registry-subnet-type",
  "ic-registry-transport",
  "ic-sns-wasm",
  "ic-transport-types",

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -172,6 +172,7 @@ rust_test(
             "tests/common.rs",
             "tests/icp_features.rs",
         ],
+        crate_features = ["head_nns"] if name_suffix == "-head-nns" else [],
         crate_root = "tests/icp_features.rs",
         data = [
             "//packages/pocket-ic/test_canister:test_canister.wasm.gz",
@@ -182,7 +183,6 @@ rust_test(
             "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server" + name_suffix + ")",
             "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
         },
-        crate_features = ["head_nns"] if name_suffix == "-head-nns" else [],
         tags = [
             "cpu:16",
             # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -215,7 +215,6 @@ rust_test(
         "",
     ]
 ]
-
 
 rust_test(
     name = "restart",

--- a/packages/pocket-ic/BUILD.bazel
+++ b/packages/pocket-ic/BUILD.bazel
@@ -182,6 +182,7 @@ rust_test(
             "POCKET_IC_BIN": "$(rootpath //rs/pocket_ic_server:pocket-ic-server" + name_suffix + ")",
             "TEST_WASM": "$(rootpath //packages/pocket-ic/test_canister:test_canister.wasm.gz)",
         },
+        crate_features = ["head_nns"] if name_suffix == "-head-nns" else [],
         tags = [
             "cpu:16",
             # TODO: remove 'requires-network' tag when the root cause for sporadic error below on Apple Silicon is identified and fixed.
@@ -198,6 +199,7 @@ rust_test(
             "//rs/nns/governance/api",
             "//rs/nns/sns-wasm",
             "//rs/registry/canister",
+            "//rs/registry/subnet_type",
             "//rs/types/base_types",
             "@crate_index//:candid",
             "@crate_index//:flate2",
@@ -213,6 +215,7 @@ rust_test(
         "",
     ]
 ]
+
 
 rust_test(
     name = "restart",

--- a/packages/pocket-ic/Cargo.toml
+++ b/packages/pocket-ic/Cargo.toml
@@ -19,6 +19,9 @@ include = [
 authors.workspace = true
 edition.workspace = true
 
+[features]
+head_nns = []
+
 [dependencies]
 backoff = { workspace = true }
 base64 = { workspace = true }
@@ -61,6 +64,7 @@ ic-cdk = { workspace = true }
 ic-error-types = { path = "../ic-error-types" }
 ic-management-canister-types-private = { path = "../../rs/types/management_canister_types" }
 ic-migration-canister = { path = "../../rs/migration_canister" }
+ic-registry-subnet-type = { path = "../../rs/registry/subnet_type" }
 ic-nns-governance-api = { path = "../../rs/nns/governance/api" }
 ic-sns-wasm = { path = "../../rs/nns/sns-wasm" }
 ic-utils = { workspace = true }

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -24,7 +24,7 @@ use pocket_ic::common::rest::{
 };
 use pocket_ic::{
     CreateCanisterParams, PocketIc, PocketIcBuilder, PocketIcState, StartServerParams,
-    start_server, update_candid, update_candid_as,
+    query_candid, start_server, update_candid, update_candid_as,
 };
 use registry_canister::pb::v1::{GetSubnetForCanisterRequest, SubnetForCanister};
 use reqwest::StatusCode;
@@ -1075,4 +1075,48 @@ async fn with_all_icp_features_and_nns_subnet_state() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert!(response.text().await.unwrap().contains("Subnet config failed to validate: The NNS subnet must be empty when specifying the `registry` ICP feature."));
+}
+
+#[cfg(feature = "head_nns")]
+#[test]
+fn test_get_subnet_cloud_engine() {
+    use ic_registry_subnet_type::SubnetType;
+    use pocket_ic::common::rest::{CanisterCyclesCostSchedule, ExtendedSubnetConfigSet, SubnetSpec};
+    use registry_canister::get_subnet::{GetSubnetRequest, SubnetRecord};
+
+    let registry_canister_id = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+
+    // Create a PocketIC instance with an NNS subnet, a CloudEngine subnet, and the registry
+    // ICP feature so that the registry canister is populated with the subnet records.
+    let icp_features = IcpFeatures {
+        registry: Some(IcpFeaturesConfig::DefaultConfig),
+        ..Default::default()
+    };
+    let subnet_spec = SubnetSpec::default().with_cost_schedule(CanisterCyclesCostSchedule::Free);
+    let config = ExtendedSubnetConfigSet {
+        nns: Some(SubnetSpec::default()),
+        cloud_engine: vec![subnet_spec],
+        ..Default::default()
+    };
+    let pic = PocketIcBuilder::new_with_config(config)
+        .with_icp_features(icp_features)
+        .build();
+
+    // Retrieve the cloud engine subnet ID from the PocketIC topology.
+    let subnet_id = pic.topology().get_cloud_engines()[0];
+
+    // Query get_subnet and verify the subnet type is CloudEngine.
+    let result = query_candid::<_, (Result<SubnetRecord, String>,)>(
+        &pic,
+        registry_canister_id,
+        "get_subnet",
+        (GetSubnetRequest {
+            subnet_id: Some(subnet_id.into()),
+        },),
+    )
+    .unwrap()
+    .0
+    .unwrap();
+
+    assert_eq!(result.subnet_type, SubnetType::CloudEngine);
 }

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -1081,7 +1081,9 @@ async fn with_all_icp_features_and_nns_subnet_state() {
 #[test]
 fn test_get_subnet_cloud_engine() {
     use ic_registry_subnet_type::SubnetType;
-    use pocket_ic::common::rest::{CanisterCyclesCostSchedule, ExtendedSubnetConfigSet, SubnetSpec};
+    use pocket_ic::common::rest::{
+        CanisterCyclesCostSchedule, ExtendedSubnetConfigSet, SubnetSpec,
+    };
     use registry_canister::get_subnet::{GetSubnetRequest, SubnetRecord};
 
     let registry_canister_id = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();

--- a/packages/pocket-ic/tests/icp_features.rs
+++ b/packages/pocket-ic/tests/icp_features.rs
@@ -24,7 +24,7 @@ use pocket_ic::common::rest::{
 };
 use pocket_ic::{
     CreateCanisterParams, PocketIc, PocketIcBuilder, PocketIcState, StartServerParams,
-    query_candid, start_server, update_candid, update_candid_as,
+    start_server, update_candid, update_candid_as,
 };
 use registry_canister::pb::v1::{GetSubnetForCanisterRequest, SubnetForCanister};
 use reqwest::StatusCode;
@@ -1084,6 +1084,7 @@ fn test_get_subnet_cloud_engine() {
     use pocket_ic::common::rest::{
         CanisterCyclesCostSchedule, ExtendedSubnetConfigSet, SubnetSpec,
     };
+    use pocket_ic::query_candid;
     use registry_canister::get_subnet::{GetSubnetRequest, SubnetRecord};
 
     let registry_canister_id = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -36,6 +36,7 @@ use prost::Message;
 use registry_canister::{
     certification::{current_version_tree, hash_tree_to_proto},
     common::LOG_PREFIX,
+    get_subnet::{GetSubnetRequest, SubnetRecord},
     init::RegistryCanisterInitPayload,
     mutations::{
         complete_canister_migration::CompleteCanisterMigrationPayload,
@@ -1170,6 +1171,16 @@ fn get_subnet_for_canister_(arg: GetSubnetForCanisterRequest) -> Result<SubnetFo
     registry()
         .get_subnet_for_canister(&principal)
         .map_err(|e| e.to_string())
+}
+
+#[unsafe(export_name = "canister_query get_subnet")]
+fn get_subnet() {
+    over(candid_one, get_subnet_)
+}
+
+#[candid_method(query, rename = "get_subnet")]
+fn get_subnet_(arg: GetSubnetRequest) -> Result<SubnetRecord, String> {
+    registry().get_subnet_record(arg)
 }
 
 #[unsafe(export_name = "canister_update add_node")]

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -218,6 +218,38 @@ type GetApiBoundaryNodeIdsRequest = record {
 
 };
 
+type GetApiBoundaryNodeIdsResponse = variant {
+    Ok : vec ApiBoundaryNodeIdRecord;
+    Err : text;
+};
+
+type ApiBoundaryNodeIdRecord = record {
+  id : opt principal;
+};
+
+type GetChunkRequest = record {
+  content_sha256 : opt blob;
+};
+
+type GetChunkResponse = variant {
+  Ok : Chunk;
+  Err : text;
+};
+
+type Chunk = record {
+  content : opt blob;
+};
+
+type GetNodeOperatorsAndDcsOfNodeProviderResponse = variant {
+  Ok : vec record { DataCenterRecord; NodeOperatorRecord };
+  Err : text;
+};
+
+type GetNodeProvidersMonthlyXdrRewardsResponse = variant {
+  Ok : NodeProvidersMonthlyXdrRewards;
+  Err : text;
+};
+
 type GetSubnetRequest = record {
   subnet_id : opt principal;
 };
@@ -250,38 +282,6 @@ type SubnetRecord = record {
 
 type GetSubnetResponse = variant {
   Ok : SubnetRecord;
-  Err : text;
-};
-
-type GetApiBoundaryNodeIdsResponse = variant {
-    Ok : vec ApiBoundaryNodeIdRecord;
-    Err : text;
-};
-
-type ApiBoundaryNodeIdRecord = record {
-  id : opt principal;
-};
-
-type GetChunkRequest = record {
-  content_sha256 : opt blob;
-};
-
-type GetChunkResponse = variant {
-  Ok : Chunk;
-  Err : text;
-};
-
-type Chunk = record {
-  content : opt blob;
-};
-
-type GetNodeOperatorsAndDcsOfNodeProviderResponse = variant {
-  Ok : vec record { DataCenterRecord; NodeOperatorRecord };
-  Err : text;
-};
-
-type GetNodeProvidersMonthlyXdrRewardsResponse = variant {
-  Ok : NodeProvidersMonthlyXdrRewards;
   Err : text;
 };
 

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -218,6 +218,41 @@ type GetApiBoundaryNodeIdsRequest = record {
 
 };
 
+type GetSubnetRequest = record {
+  subnet_id : opt principal;
+};
+
+type SubnetRecord = record {
+  membership : vec blob;
+  max_ingress_bytes_per_message : nat64;
+  unit_delay_millis : nat64;
+  initial_notary_delay_millis : nat64;
+  replica_version_id : text;
+  dkg_interval_length : nat64;
+  start_as_nns : bool;
+  subnet_type : SubnetType;
+  dkg_dealings_per_block : nat64;
+  is_halted : bool;
+  max_ingress_messages_per_block : nat64;
+  max_ingress_bytes_per_block : nat64;
+  max_block_payload_size : nat64;
+  features : opt SubnetFeatures;
+  max_number_of_canisters : nat64;
+  ssh_readonly_access : vec text;
+  ssh_backup_access : vec text;
+  halt_at_cup_height : bool;
+  chain_key_config : opt ChainKeyConfig;
+  canister_cycles_cost_schedule : CanisterCyclesCostSchedule;
+  subnet_admins : vec principal;
+  recalled_replica_version_ids : vec text;
+  resource_limits : opt ResourceLimits;
+};
+
+type GetSubnetResponse = variant {
+  Ok : SubnetRecord;
+  Err : text;
+};
+
 type GetApiBoundaryNodeIdsResponse = variant {
     Ok : vec ApiBoundaryNodeIdRecord;
     Err : text;
@@ -598,6 +633,7 @@ service : {
   get_chunk : (GetChunkRequest) -> (GetChunkResponse) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
   get_node_providers_monthly_xdr_rewards : (opt GetNodeProvidersMonthlyXdrRewardsRequest) -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
+  get_subnet : (GetSubnetRequest) -> (GetSubnetResponse) query;
   get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (GetSubnetForCanisterResponse) query;
   migrate_canisters: (MigrateCanistersPayload) -> (MigrateCanistersResponse);
   migrate_node_operator_directly : (MigrateNodeOperatorPayload) -> ();

--- a/rs/registry/canister/canister/registry_test.did
+++ b/rs/registry/canister/canister/registry_test.did
@@ -250,6 +250,41 @@ type GetNodeProvidersMonthlyXdrRewardsResponse = variant {
   Err : text;
 };
 
+type GetSubnetRequest = record {
+  subnet_id : opt principal;
+};
+
+type SubnetRecord = record {
+  membership : vec blob;
+  max_ingress_bytes_per_message : nat64;
+  unit_delay_millis : nat64;
+  initial_notary_delay_millis : nat64;
+  replica_version_id : text;
+  dkg_interval_length : nat64;
+  start_as_nns : bool;
+  subnet_type : SubnetType;
+  dkg_dealings_per_block : nat64;
+  is_halted : bool;
+  max_ingress_messages_per_block : nat64;
+  max_ingress_bytes_per_block : nat64;
+  max_block_payload_size : nat64;
+  features : opt SubnetFeatures;
+  max_number_of_canisters : nat64;
+  ssh_readonly_access : vec text;
+  ssh_backup_access : vec text;
+  halt_at_cup_height : bool;
+  chain_key_config : opt ChainKeyConfig;
+  canister_cycles_cost_schedule : CanisterCyclesCostSchedule;
+  subnet_admins : vec principal;
+  recalled_replica_version_ids : vec text;
+  resource_limits : opt ResourceLimits;
+};
+
+type GetSubnetResponse = variant {
+  Ok : SubnetRecord;
+  Err : text;
+};
+
 type GetSubnetForCanisterRequest = record { "principal" : opt principal };
 
 type GetSubnetForCanisterResponse = variant {
@@ -598,6 +633,7 @@ service : {
   get_chunk : (GetChunkRequest) -> (GetChunkResponse) query;
   get_node_operators_and_dcs_of_node_provider : (principal) -> (GetNodeOperatorsAndDcsOfNodeProviderResponse) query;
   get_node_providers_monthly_xdr_rewards : (opt GetNodeProvidersMonthlyXdrRewardsRequest) -> (GetNodeProvidersMonthlyXdrRewardsResponse) query;
+  get_subnet : (GetSubnetRequest) -> (GetSubnetResponse) query;
   get_subnet_for_canister : (GetSubnetForCanisterRequest) -> (GetSubnetForCanisterResponse) query;
   migrate_canisters: (MigrateCanistersPayload) -> (MigrateCanistersResponse);
   migrate_node_operator_directly : (MigrateNodeOperatorPayload) -> ();

--- a/rs/registry/canister/src/get_subnet.rs
+++ b/rs/registry/canister/src/get_subnet.rs
@@ -58,8 +58,9 @@ impl TryFrom<SubnetRecordPb> for SubnetRecord {
                 .unwrap_or(CanisterCyclesCostSchedulePb::Unspecified);
         let canister_cycles_cost_schedule = match cost_schedule_pb {
             CanisterCyclesCostSchedulePb::Free => CanisterCyclesCostSchedule::Free,
-            CanisterCyclesCostSchedulePb::Normal
-            | CanisterCyclesCostSchedulePb::Unspecified => CanisterCyclesCostSchedule::Normal,
+            CanisterCyclesCostSchedulePb::Normal | CanisterCyclesCostSchedulePb::Unspecified => {
+                CanisterCyclesCostSchedule::Normal
+            }
         };
 
         let chain_key_config = pb

--- a/rs/registry/canister/src/get_subnet.rs
+++ b/rs/registry/canister/src/get_subnet.rs
@@ -58,9 +58,9 @@ impl TryFrom<SubnetRecordPb> for SubnetRecord {
                 .map_err(|e| format!("Invalid canister_cycles_cost_schedule: {e}"))?;
         let canister_cycles_cost_schedule = match cost_schedule_pb {
             CanisterCyclesCostSchedulePb::Free => CanisterCyclesCostSchedule::Free,
-            CanisterCyclesCostSchedulePb::Normal => CanisterCyclesCostSchedule::Normal,
-            CanisterCyclesCostSchedulePb::Unspecified => {
-                return Err("canister_cycles_cost_schedule is Unspecified".to_string());
+            // Per proto comment, Unspecified should be treated the same as Normal.
+            CanisterCyclesCostSchedulePb::Normal | CanisterCyclesCostSchedulePb::Unspecified => {
+                CanisterCyclesCostSchedule::Normal
             }
         };
 

--- a/rs/registry/canister/src/get_subnet.rs
+++ b/rs/registry/canister/src/get_subnet.rs
@@ -58,7 +58,8 @@ impl TryFrom<SubnetRecordPb> for SubnetRecord {
                 .unwrap_or(CanisterCyclesCostSchedulePb::Unspecified);
         let canister_cycles_cost_schedule = match cost_schedule_pb {
             CanisterCyclesCostSchedulePb::Free => CanisterCyclesCostSchedule::Free,
-            _ => CanisterCyclesCostSchedule::Normal,
+            CanisterCyclesCostSchedulePb::Normal
+            | CanisterCyclesCostSchedulePb::Unspecified => CanisterCyclesCostSchedule::Normal,
         };
 
         let chain_key_config = pb

--- a/rs/registry/canister/src/get_subnet.rs
+++ b/rs/registry/canister/src/get_subnet.rs
@@ -1,0 +1,125 @@
+use crate::{
+    mutations::{do_create_subnet::CanisterCyclesCostSchedule, do_update_subnet::ChainKeyConfig},
+    registry::Registry,
+};
+use candid::{CandidType, Deserialize};
+use ic_base_types::{PrincipalId, SubnetId};
+use ic_protobuf::registry::subnet::v1::{
+    CanisterCyclesCostSchedule as CanisterCyclesCostSchedulePb, ResourceLimits, SubnetFeatures,
+    SubnetRecord as SubnetRecordPb,
+};
+use ic_registry_keys::make_subnet_record_key;
+use ic_registry_subnet_features::ChainKeyConfig as ChainKeyConfigInternal;
+use ic_registry_subnet_type::SubnetType;
+use prost::Message;
+use serde::Serialize;
+
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize)]
+pub struct GetSubnetRequest {
+    pub subnet_id: Option<PrincipalId>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize)]
+pub struct SubnetRecord {
+    pub membership: Vec<Vec<u8>>,
+    pub max_ingress_bytes_per_message: u64,
+    pub unit_delay_millis: u64,
+    pub initial_notary_delay_millis: u64,
+    pub replica_version_id: String,
+    pub dkg_interval_length: u64,
+    pub start_as_nns: bool,
+    pub subnet_type: SubnetType,
+    pub dkg_dealings_per_block: u64,
+    pub is_halted: bool,
+    pub max_ingress_messages_per_block: u64,
+    pub max_ingress_bytes_per_block: u64,
+    pub max_block_payload_size: u64,
+    pub features: Option<SubnetFeatures>,
+    pub max_number_of_canisters: u64,
+    pub ssh_readonly_access: Vec<String>,
+    pub ssh_backup_access: Vec<String>,
+    pub halt_at_cup_height: bool,
+    pub chain_key_config: Option<ChainKeyConfig>,
+    pub canister_cycles_cost_schedule: CanisterCyclesCostSchedule,
+    pub subnet_admins: Vec<PrincipalId>,
+    pub recalled_replica_version_ids: Vec<String>,
+    pub resource_limits: Option<ResourceLimits>,
+}
+
+impl TryFrom<SubnetRecordPb> for SubnetRecord {
+    type Error = String;
+
+    fn try_from(pb: SubnetRecordPb) -> Result<Self, Self::Error> {
+        let subnet_type = SubnetType::try_from(pb.subnet_type)
+            .map_err(|e| format!("Invalid subnet_type: {e}"))?;
+
+        let cost_schedule_pb =
+            CanisterCyclesCostSchedulePb::try_from(pb.canister_cycles_cost_schedule)
+                .unwrap_or(CanisterCyclesCostSchedulePb::Unspecified);
+        let canister_cycles_cost_schedule = match cost_schedule_pb {
+            CanisterCyclesCostSchedulePb::Free => CanisterCyclesCostSchedule::Free,
+            _ => CanisterCyclesCostSchedule::Normal,
+        };
+
+        let chain_key_config = pb
+            .chain_key_config
+            .map(|c| {
+                ChainKeyConfigInternal::try_from(c)
+                    .map(ChainKeyConfig::from)
+                    .map_err(|e| format!("Invalid chain_key_config: {e}"))
+            })
+            .transpose()?;
+
+        let subnet_admins = pb
+            .subnet_admins
+            .into_iter()
+            .map(PrincipalId::try_from)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Invalid subnet_admins: {e}"))?;
+
+        Ok(SubnetRecord {
+            membership: pb.membership,
+            max_ingress_bytes_per_message: pb.max_ingress_bytes_per_message,
+            unit_delay_millis: pb.unit_delay_millis,
+            initial_notary_delay_millis: pb.initial_notary_delay_millis,
+            replica_version_id: pb.replica_version_id,
+            dkg_interval_length: pb.dkg_interval_length,
+            start_as_nns: pb.start_as_nns,
+            subnet_type,
+            dkg_dealings_per_block: pb.dkg_dealings_per_block,
+            is_halted: pb.is_halted,
+            max_ingress_messages_per_block: pb.max_ingress_messages_per_block,
+            max_ingress_bytes_per_block: pb.max_ingress_bytes_per_block,
+            max_block_payload_size: pb.max_block_payload_size,
+            features: pb.features,
+            max_number_of_canisters: pb.max_number_of_canisters,
+            ssh_readonly_access: pb.ssh_readonly_access,
+            ssh_backup_access: pb.ssh_backup_access,
+            halt_at_cup_height: pb.halt_at_cup_height,
+            chain_key_config,
+            canister_cycles_cost_schedule,
+            subnet_admins,
+            recalled_replica_version_ids: pb.recalled_replica_version_ids,
+            resource_limits: pb.resource_limits,
+        })
+    }
+}
+
+impl Registry {
+    pub fn get_subnet_record(&self, request: GetSubnetRequest) -> Result<SubnetRecord, String> {
+        let subnet_id = request
+            .subnet_id
+            .ok_or_else(|| "No subnet_id supplied".to_string())?;
+
+        let key = make_subnet_record_key(SubnetId::from(subnet_id));
+        let record_bytes = self
+            .get(key.as_bytes(), self.latest_version())
+            .ok_or_else(|| format!("Subnet {subnet_id} not found in the Registry"))?
+            .value;
+
+        let record_pb = SubnetRecordPb::decode(record_bytes.as_slice())
+            .map_err(|e| format!("Failed to decode SubnetRecord: {e}"))?;
+
+        SubnetRecord::try_from(record_pb)
+    }
+}

--- a/rs/registry/canister/src/get_subnet.rs
+++ b/rs/registry/canister/src/get_subnet.rs
@@ -55,11 +55,12 @@ impl TryFrom<SubnetRecordPb> for SubnetRecord {
 
         let cost_schedule_pb =
             CanisterCyclesCostSchedulePb::try_from(pb.canister_cycles_cost_schedule)
-                .unwrap_or(CanisterCyclesCostSchedulePb::Unspecified);
+                .map_err(|e| format!("Invalid canister_cycles_cost_schedule: {e}"))?;
         let canister_cycles_cost_schedule = match cost_schedule_pb {
             CanisterCyclesCostSchedulePb::Free => CanisterCyclesCostSchedule::Free,
-            CanisterCyclesCostSchedulePb::Normal | CanisterCyclesCostSchedulePb::Unspecified => {
-                CanisterCyclesCostSchedule::Normal
+            CanisterCyclesCostSchedulePb::Normal => CanisterCyclesCostSchedule::Normal,
+            CanisterCyclesCostSchedulePb::Unspecified => {
+                return Err("canister_cycles_cost_schedule is Unspecified".to_string());
             }
         };
 

--- a/rs/registry/canister/src/lib.rs
+++ b/rs/registry/canister/src/lib.rs
@@ -4,6 +4,7 @@ pub mod common;
 pub mod flags;
 pub mod get_node_operators_and_dcs_of_node_provider;
 pub mod get_node_providers_monthly_xdr_rewards;
+pub mod get_subnet;
 pub mod init;
 pub mod mutations;
 pub mod pb;

--- a/rs/registry/canister/tests/get_subnet.rs
+++ b/rs/registry/canister/tests/get_subnet.rs
@@ -13,14 +13,12 @@ use registry_canister::{
 
 mod common;
 
-fn setup() -> impl std::future::Future<Output = pocket_ic::nonblocking::PocketIc> {
-    async {
-        let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
-        let mut builder = RegistryCanisterInitPayloadBuilder::new();
-        builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
-        install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), false).await;
-        pocket_ic
-    }
+async fn setup() -> pocket_ic::nonblocking::PocketIc {
+    let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
+    let mut builder = RegistryCanisterInitPayloadBuilder::new();
+    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
+    install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), false).await;
+    pocket_ic
 }
 
 async fn call_get_subnet(

--- a/rs/registry/canister/tests/get_subnet.rs
+++ b/rs/registry/canister/tests/get_subnet.rs
@@ -51,7 +51,7 @@ async fn test_get_subnet_returns_correct_record() {
         },
     )
     .await
-    .expect("get_subnet should succeed for the NNS subnet");
+    .expect("get_subnet should succeed for the System subnet");
 
     assert_eq!(result.subnet_type, SubnetType::System);
     assert_eq!(result.unit_delay_millis, 600);

--- a/rs/registry/canister/tests/get_subnet.rs
+++ b/rs/registry/canister/tests/get_subnet.rs
@@ -1,0 +1,96 @@
+use candid::{Decode, Encode};
+use common::test_helpers::install_registry_canister_with_payload_builder;
+use ic_base_types::PrincipalId;
+use ic_nns_constants::REGISTRY_CANISTER_ID;
+use ic_nns_test_utils::registry::{TEST_ID, invariant_compliant_mutation_as_atomic_req};
+use ic_registry_subnet_type::SubnetType;
+use ic_test_utilities_types::ids::subnet_test_id;
+use pocket_ic::PocketIcBuilder;
+use registry_canister::{
+    get_subnet::{GetSubnetRequest, SubnetRecord},
+    init::RegistryCanisterInitPayloadBuilder,
+};
+
+mod common;
+
+fn setup() -> impl std::future::Future<Output = pocket_ic::nonblocking::PocketIc> {
+    async {
+        let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
+        let mut builder = RegistryCanisterInitPayloadBuilder::new();
+        builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
+        install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), false).await;
+        pocket_ic
+    }
+}
+
+async fn call_get_subnet(
+    pocket_ic: &pocket_ic::nonblocking::PocketIc,
+    request: GetSubnetRequest,
+) -> Result<SubnetRecord, String> {
+    let result = pocket_ic
+        .query_call(
+            REGISTRY_CANISTER_ID.get().0,
+            candid::Principal::anonymous(),
+            "get_subnet",
+            Encode!(&request).unwrap(),
+        )
+        .await
+        .expect("query_call to get_subnet failed");
+    Decode!(&result, Result<SubnetRecord, String>).unwrap()
+}
+
+#[tokio::test]
+async fn test_get_subnet_returns_correct_record() {
+    let pocket_ic = setup().await;
+
+    // invariant_compliant_mutation_as_atomic_req(0) creates a System subnet with subnet_test_id(TEST_ID)
+    let subnet_id = subnet_test_id(TEST_ID).get();
+
+    let result = call_get_subnet(
+        &pocket_ic,
+        GetSubnetRequest {
+            subnet_id: Some(subnet_id),
+        },
+    )
+    .await
+    .expect("get_subnet should succeed for the NNS subnet");
+
+    assert_eq!(result.subnet_type, SubnetType::System);
+    assert_eq!(result.unit_delay_millis, 600);
+    assert!(!result.membership.is_empty());
+    assert!(!result.is_halted);
+}
+
+#[tokio::test]
+async fn test_get_subnet_missing_subnet_id() {
+    let pocket_ic = setup().await;
+
+    let err = call_get_subnet(&pocket_ic, GetSubnetRequest { subnet_id: None })
+        .await
+        .expect_err("get_subnet should fail when subnet_id is missing");
+
+    assert!(
+        err.contains("No subnet_id supplied"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_get_subnet_unknown_subnet_id() {
+    let pocket_ic = setup().await;
+
+    let unknown = PrincipalId::new_subnet_test_id(12345);
+    let err = call_get_subnet(
+        &pocket_ic,
+        GetSubnetRequest {
+            subnet_id: Some(unknown),
+        },
+    )
+    .await
+    .expect_err("get_subnet should fail for an unknown subnet");
+
+    assert!(
+        err.contains("not found in the Registry"),
+        "unexpected error: {err}"
+    );
+}

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -19,6 +19,8 @@ on the process that this file is part of, see
   leaves the existing list unchanged; `Some(vec![])` clears it; `Some(vec![..])`
   replaces it.
 * Added `vcpu_type` to `GuestLaunchMeasurementMetadata` to record the virtual CPU type used for a guest launch measurement.
+* Added a new endpoint `get_subnet` to the registry canister, returning the subnet record
+  of a given subnet.
 
 ## Changed
 


### PR DESCRIPTION
This PR introduces a `get_subnet` endpoint on the NNS registry canister that returns the SubnetRecord for a given subnet ID. The immediate motivation for this change is to enable the migration canister check if a subnet is a cloud engine (by retrieving the subnet type from the corresponding subnet record), but we implement a generic `get_subnet` endpoint in this PR to cover future use cases, too.

The sizes of subnet records on mainnet vary between 732 bytes and 2103 bytes and take between ~100k and ~150k instructions to produce.