### PR TITLE
feat: [DSM-143] Atomic outbound `Request` enqueuing and `Callback` registration

### DIFF
--- a/rs/canister_sandbox/src/sandbox_server.rs
+++ b/rs/canister_sandbox/src/sandbox_server.rs
@@ -209,7 +209,6 @@ mod tests {
                 subnet_test_id(0),
                 CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None),
             ),
-            Some(0),
             0,
             BTreeMap::new(),
             0,

--- a/rs/cycles_account_manager/tests/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/tests/cycles_account_manager.rs
@@ -7,7 +7,9 @@ use ic_logger::replica_logger::no_op_logger;
 use ic_management_canister_types_private::{CanisterIdRecord, IC_00, Payload};
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
-    SystemState, canister_state::execution_state::WasmExecutionMode, testing::SystemStateTesting,
+    SystemState,
+    canister_state::execution_state::WasmExecutionMode,
+    testing::{OutputRequestBuilder, SystemStateTesting},
 };
 use ic_test_utilities::cycles_account_manager::CyclesAccountManagerBuilder;
 use ic_test_utilities_logger::with_test_replica_logger;
@@ -16,7 +18,7 @@ use ic_test_utilities_state::{
 };
 use ic_test_utilities_types::{
     ids::{canister_test_id, user_test_id},
-    messages::{RequestBuilder, SignedIngressBuilder},
+    messages::SignedIngressBuilder,
 };
 use ic_types::{
     ComputeAllocation, MemoryAllocation, NumBytes, NumInstructions,
@@ -500,17 +502,16 @@ fn charge_canister_for_memory_usage() {
         canister.system_state.memory_allocation = MemoryAllocation::from(MEMORY_ALLOCATION);
         canister
             .push_output_request(
-                RequestBuilder::new().sender(canister_id).build().into(),
+                OutputRequestBuilder::default().sender(canister_id).build(),
                 UNIX_EPOCH,
             )
             .unwrap();
         canister
             .push_output_request(
-                RequestBuilder::new()
+                OutputRequestBuilder::default()
                     .sender(canister_id)
                     .deadline(CoarseTime::from_secs_since_unix_epoch(1))
-                    .build()
-                    .into(),
+                    .build(),
                 UNIX_EPOCH,
             )
             .unwrap();
@@ -567,17 +568,16 @@ fn do_not_charge_canister_for_memory_usage_free_schedule() {
         canister.system_state.memory_allocation = MemoryAllocation::from(MEMORY_ALLOCATION);
         canister
             .push_output_request(
-                RequestBuilder::new().sender(canister_id).build().into(),
+                OutputRequestBuilder::default().sender(canister_id).build(),
                 UNIX_EPOCH,
             )
             .unwrap();
         canister
             .push_output_request(
-                RequestBuilder::new()
+                OutputRequestBuilder::default()
                     .sender(canister_id)
                     .deadline(CoarseTime::from_secs_since_unix_epoch(1))
-                    .build()
-                    .into(),
+                    .build(),
                 UNIX_EPOCH,
             )
             .unwrap();
@@ -626,17 +626,16 @@ fn do_not_charge_canister_for_compute_allocation_free_schedule() {
         canister.system_state.compute_allocation = compute_allocation;
         canister
             .push_output_request(
-                RequestBuilder::new().sender(canister_id).build().into(),
+                OutputRequestBuilder::default().sender(canister_id).build(),
                 UNIX_EPOCH,
             )
             .unwrap();
         canister
             .push_output_request(
-                RequestBuilder::new()
+                OutputRequestBuilder::default()
                     .sender(canister_id)
                     .deadline(CoarseTime::from_secs_since_unix_epoch(1))
-                    .build()
-                    .into(),
+                    .build(),
                 UNIX_EPOCH,
             )
             .unwrap();

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -18,21 +18,16 @@ use ic_management_canister_types_private::{
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::execution_state::WasmExecutionMode;
 use ic_replicated_state::{
-    Memory, NumWasmPages, canister_state::WASM_PAGE_SIZE_IN_BYTES, memory_usage_of_request,
+    Memory, NumWasmPages, OutputRequest, canister_state::WASM_PAGE_SIZE_IN_BYTES,
 };
 use ic_types::{
     CanisterId, CanisterLog, CanisterTimer, ComputeAllocation, MemoryAllocation, NumBytes,
     NumInstructions, NumOsPages, PrincipalId, SubnetId, Time,
     ingress::WasmResult,
-    messages::{
-        CallContextId, MAX_INTER_CANISTER_PAYLOAD_IN_BYTES, RejectContext, Request, SenderInfo,
-    },
+    messages::{CallContextId, MAX_INTER_CANISTER_PAYLOAD_IN_BYTES, RejectContext, SenderInfo},
     methods::{SystemMethod, WasmClosure},
 };
-use ic_types_cycles::{
-    CanisterCyclesCostSchedule, CompoundCycles, Cycles, Instructions,
-    RequestAndResponseTransmission,
-};
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use ic_utils::deterministic_operations::deterministic_copy_from_slice;
 use ic_wasm_types::doc_ref;
 use request_in_prep::{RequestInPrep, into_request};
@@ -1716,7 +1711,6 @@ impl SystemApiImpl {
             ApiType::InspectMessage { .. } | ApiType::NonReplicatedQuery { .. } => {
                 SystemStateModifications {
                     new_certified_data: None,
-                    callback_updates: vec![],
                     cycles_balance_change: CyclesBalanceChange::zero(),
                     reserved_cycles: Cycles::zero(),
                     consumed_cycles_by_use_case: ConsumedCyclesDuringExecution::default(),
@@ -1738,7 +1732,6 @@ impl SystemApiImpl {
             | ApiType::CompositeCleanup { .. } => match &self.execution_error {
                 Some(_) => SystemStateModifications {
                     new_certified_data: None,
-                    callback_updates: vec![],
                     cycles_balance_change: CyclesBalanceChange::zero(),
                     reserved_cycles: Cycles::zero(),
                     consumed_cycles_by_use_case: ConsumedCyclesDuringExecution::default(),
@@ -1751,7 +1744,6 @@ impl SystemApiImpl {
                 },
                 None => SystemStateModifications {
                     new_certified_data: None,
-                    callback_updates: system_state_modifications.callback_updates,
                     cycles_balance_change: CyclesBalanceChange::zero(),
                     reserved_cycles: Cycles::zero(),
                     consumed_cycles_by_use_case: ConsumedCyclesDuringExecution::default(),
@@ -1771,7 +1763,6 @@ impl SystemApiImpl {
                     self.add_canister_log_for_trap(err, time, &mut system_state_modifications);
                     SystemStateModifications {
                         new_certified_data: None,
-                        callback_updates: vec![],
                         cycles_balance_change: CyclesBalanceChange::zero(),
                         reserved_cycles: Cycles::zero(),
                         consumed_cycles_by_use_case: ConsumedCyclesDuringExecution::default(),
@@ -1785,7 +1776,6 @@ impl SystemApiImpl {
                 }
                 None => SystemStateModifications {
                     new_certified_data: None,
-                    callback_updates: vec![],
                     cycles_balance_change: system_state_modifications.cycles_balance_change,
                     reserved_cycles: Cycles::zero(),
                     consumed_cycles_by_use_case: system_state_modifications
@@ -1811,7 +1801,6 @@ impl SystemApiImpl {
                     self.add_canister_log_for_trap(err, time, &mut system_state_modifications);
                     SystemStateModifications {
                         new_certified_data: None,
-                        callback_updates: vec![],
                         cycles_balance_change: CyclesBalanceChange::zero(),
                         reserved_cycles: Cycles::zero(),
                         consumed_cycles_by_use_case: ConsumedCyclesDuringExecution::default(),
@@ -1841,7 +1830,6 @@ impl SystemApiImpl {
                     self.add_canister_log_for_trap(err, time, &mut system_state_modifications);
                     SystemStateModifications {
                         new_certified_data: None,
-                        callback_updates: vec![],
                         cycles_balance_change: CyclesBalanceChange::zero(),
                         reserved_cycles: Cycles::zero(),
                         consumed_cycles_by_use_case: ConsumedCyclesDuringExecution::default(),
@@ -1866,30 +1854,20 @@ impl SystemApiImpl {
     ///
     /// Note that this function is made public only for the tests
     #[doc(hidden)]
-    pub fn push_output_request(
-        &mut self,
-        req: Request,
-        prepayment_for_response_execution: CompoundCycles<Instructions>,
-        prepayment_for_call_transmission: CompoundCycles<RequestAndResponseTransmission>,
-    ) -> HypervisorResult<i32> {
-        let abort = |request: Request, sandbox_safe_system_state: &mut SandboxSafeSystemState| {
-            sandbox_safe_system_state.refund_cycles(request.payment);
-            sandbox_safe_system_state.unregister_callback(request.sender_reply_callback);
-        };
-
+    pub fn push_output_request(&mut self, req: OutputRequest) -> HypervisorResult<i32> {
         let memory_usage_of_request = if self.execution_parameters.subnet_type == SubnetType::System
         {
             // Effectively disable the memory limit checks on system subnets.
             MessageMemoryUsage::ZERO
         } else {
-            memory_usage_of_request(&req)
+            req.message_memory_usage()
         };
         if let Err(_err) = self.memory_usage.allocate_message_memory(
             memory_usage_of_request,
             &self.api_type,
             &self.sandbox_safe_system_state,
         ) {
-            abort(req, &mut self.sandbox_safe_system_state);
+            self.sandbox_safe_system_state.refund_cycles(req.payment);
             // Return an error code instead of trapping here in order to allow
             // the user code to handle the error gracefully.
             return Ok(RejectCode::SysTransient as i32);
@@ -1899,14 +1877,12 @@ impl SystemApiImpl {
             self.memory_usage.current_usage,
             self.memory_usage.current_message_usage,
             req,
-            prepayment_for_response_execution,
-            prepayment_for_call_transmission,
         ) {
             Ok(()) => Ok(0),
-            Err(request) => {
+            Err(req) => {
                 self.memory_usage
                     .deallocate_message_memory(memory_usage_of_request);
-                abort(request, &mut self.sandbox_safe_system_state);
+                self.sandbox_safe_system_state.refund_cycles(req.payment);
                 Ok(RejectCode::SysTransient as i32)
             }
         }
@@ -3294,12 +3270,7 @@ impl SystemApi for SystemApiImpl {
                     &self.log,
                     *time,
                 )?;
-
-                self.push_output_request(
-                    req.request,
-                    req.prepayment_for_response_execution,
-                    req.prepayment_for_call_transmission,
-                )
+                self.push_output_request(req)
             }
         };
         trace_syscall!(self, CallPerform, result);

--- a/rs/embedders/src/wasmtime_embedder/system_api.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api.rs
@@ -30,7 +30,7 @@ use ic_types::{
 use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use ic_utils::deterministic_operations::deterministic_copy_from_slice;
 use ic_wasm_types::doc_ref;
-use request_in_prep::{RequestInPrep, into_request};
+use request_in_prep::{RequestInPrep, into_output_request};
 use sandbox_safe_system_state::{
     ConsumedCyclesDuringExecution, SandboxSafeSystemState, SystemStateModifications,
 };
@@ -3263,7 +3263,7 @@ impl SystemApi for SystemApiImpl {
                                 .to_string(),
                         })?;
 
-                let req = into_request(
+                let req = into_output_request(
                     req_in_prep,
                     *call_context_id,
                     &mut self.sandbox_safe_system_state,

--- a/rs/embedders/src/wasmtime_embedder/system_api/request_in_prep.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/request_in_prep.rs
@@ -205,7 +205,7 @@ impl RequestInPrep {
 
 /// Turns a `RequestInPrep` into an `OutputRequest`.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn into_request(
+pub(crate) fn into_output_request(
     RequestInPrep {
         sender,
         callee,

--- a/rs/embedders/src/wasmtime_embedder/system_api/request_in_prep.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/request_in_prep.rs
@@ -2,14 +2,15 @@ use super::{sandbox_safe_system_state::SandboxSafeSystemState, valid_subslice};
 use ic_base_types::InternalAddress;
 use ic_interfaces::execution_environment::{HypervisorError, HypervisorResult};
 use ic_logger::ReplicaLogger;
+use ic_replicated_state::OutputRequest;
 use ic_types::Time;
 use ic_types::{
     CanisterId, NumBytes, PrincipalId,
-    messages::{CallContextId, NO_DEADLINE, Request},
-    methods::{Callback, WasmClosure},
+    messages::{CallContextId, NO_DEADLINE},
+    methods::WasmClosure,
     time::CoarseTime,
 };
-use ic_types_cycles::{CompoundCycles, Cycles, Instructions, RequestAndResponseTransmission};
+use ic_types_cycles::Cycles;
 use ic_wasm_types::doc_ref;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, time::Duration};
@@ -202,13 +203,7 @@ impl RequestInPrep {
     }
 }
 
-pub(crate) struct RequestWithPrepayment {
-    pub request: Request,
-    pub prepayment_for_response_execution: CompoundCycles<Instructions>,
-    pub prepayment_for_call_transmission: CompoundCycles<RequestAndResponseTransmission>,
-}
-
-/// Turns a `RequestInPrep` into a `Request`.
+/// Turns a `RequestInPrep` into an `OutputRequest`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn into_request(
     RequestInPrep {
@@ -228,7 +223,7 @@ pub(crate) fn into_request(
     sandbox_safe_system_state: &mut SandboxSafeSystemState,
     _logger: &ReplicaLogger,
     time: Time,
-) -> HypervisorResult<RequestWithPrepayment> {
+) -> HypervisorResult<OutputRequest> {
     let destination_canister = CanisterId::unchecked_from_principal(callee);
 
     let payload_size = (method_name.len() + method_payload.len()) as u64;
@@ -270,30 +265,23 @@ pub(crate) fn into_request(
         NO_DEADLINE
     };
 
-    let callback_id = sandbox_safe_system_state.register_callback(Callback::new(
+    let req = OutputRequest {
+        receiver: destination_canister,
+        payment: cycles,
+        deadline,
+        sender,
+        method_name,
+        method_payload,
+        metadata: sandbox_safe_system_state.request_metadata.clone(),
         call_context_id,
-        destination_canister,
-        cycles,
         prepayment_for_response_execution,
         prepayment_for_response_transmission,
         prepayment_for_call_transmission,
         on_reply,
         on_reject,
         on_cleanup,
-        deadline,
-    ))?;
-
-    let req = Request {
-        sender,
-        receiver: destination_canister,
-        method_name,
-        method_payload,
-        sender_reply_callback: callback_id,
-        payment: cycles,
-        metadata: sandbox_safe_system_state.request_metadata.clone(),
-        deadline,
     };
-    // We cannot call `Request::payload_size_bytes()` before constructing the
+    // We cannot call `OutputRequest::payload_size_bytes()` before constructing the
     // request, so ensure our separate calculation matches the actual size.
     debug_assert_eq!(
         req.payload_size_bytes().get(),
@@ -301,11 +289,7 @@ pub(crate) fn into_request(
         "Inconsistent request payload size calculation"
     );
 
-    Ok(RequestWithPrepayment {
-        request: req,
-        prepayment_for_response_execution,
-        prepayment_for_call_transmission,
-    })
+    Ok(req)
 }
 
 #[cfg(test)]

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -22,13 +22,12 @@ use ic_nns_constants::CYCLES_MINTING_CANISTER_ID;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::execution_state::WasmExecutionMode;
 use ic_replicated_state::{
-    CallOrigin, NetworkTopology, SystemState, canister_state::DEFAULT_QUEUE_CAPACITY,
+    CallOrigin, NetworkTopology, OutputRequest, SystemState, canister_state::DEFAULT_QUEUE_CAPACITY,
 };
 use ic_types::canister_log::CanisterLogMetrics;
 use ic_types::{
     CanisterLog, CanisterTimer, ComputeAllocation, MemoryAllocation, NumInstructions, Time,
-    messages::{CallContextId, CallbackId, NO_DEADLINE, RejectContext, Request, RequestMetadata},
-    methods::Callback,
+    messages::{CallContextId, NO_DEADLINE, RejectContext, RequestMetadata},
     time::CoarseTime,
 };
 use ic_types_cycles::{
@@ -58,13 +57,6 @@ impl CanisterStatusView {
             CanisterStatusType::Stopped => Self::Stopped,
         }
     }
-}
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-pub enum CallbackUpdate {
-    Register(CallbackId, Callback),
-    Unregister(CallbackId),
 }
 
 /// Cycles consumed via System API calls during message execution.
@@ -130,8 +122,6 @@ impl ConsumedCyclesDuringExecution {
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct SystemStateModifications {
     pub(super) new_certified_data: Option<Vec<u8>>,
-    // pub for testing
-    pub callback_updates: Vec<CallbackUpdate>,
     pub(super) cycles_balance_change: CyclesBalanceChange,
     // The cycles that move from the main balance to the reserved balance.
     // Invariant: `cycles_balance_change` contains
@@ -140,7 +130,7 @@ pub struct SystemStateModifications {
     pub(super) consumed_cycles_by_use_case: ConsumedCyclesDuringExecution,
     pub(super) call_context_balance_taken: Option<(CallContextId, Cycles)>,
     pub(super) request_slots_used: BTreeMap<CanisterId, usize>,
-    pub(super) requests: Vec<Request>,
+    pub(super) requests: Vec<OutputRequest>,
     pub(super) new_global_timer: Option<CanisterTimer>,
     pub(super) canister_log: CanisterLog,
     pub(super) should_bump_canister_version: bool,
@@ -150,7 +140,6 @@ impl Default for SystemStateModifications {
     fn default() -> Self {
         Self {
             new_certified_data: None,
-            callback_updates: vec![],
             cycles_balance_change: CyclesBalanceChange::zero(),
             reserved_cycles: Cycles::zero(),
             consumed_cycles_by_use_case: ConsumedCyclesDuringExecution::default(),
@@ -210,6 +199,11 @@ impl SystemStateModifications {
         self.reserved_cycles
     }
 
+    /// Returns the requests that have been enqueued.
+    pub fn requests(&self) -> &[OutputRequest] {
+        &self.requests
+    }
+
     /// Returns number of newly created callbacks (i.e. enqueued requests).
     pub fn callbacks_created(&self) -> usize {
         self.requests.len()
@@ -224,7 +218,7 @@ impl SystemStateModifications {
     fn reject_subnet_message_routing(
         system_state: &mut SystemState,
         subnet_ids: &BTreeSet<PrincipalId>,
-        msg: Request,
+        msg: OutputRequest,
         err: ResolveDestinationError,
         logger: &ReplicaLogger,
     ) -> HypervisorResult<()> {
@@ -251,7 +245,7 @@ impl SystemStateModifications {
     fn reject_subnet_message_user_error(
         system_state: &mut SystemState,
         subnet_ids: &BTreeSet<PrincipalId>,
-        msg: Request,
+        msg: OutputRequest,
         err: UserError,
         logger: &ReplicaLogger,
     ) -> HypervisorResult<()> {
@@ -273,13 +267,13 @@ impl SystemStateModifications {
     fn push_message(
         system_state: &mut SystemState,
         time: Time,
-        msg: Request,
+        msg: OutputRequest,
         logger: &ReplicaLogger,
     ) -> HypervisorResult<()> {
         let sent_cycles = msg.payment.get();
         let msg_receiver = msg.receiver;
         system_state
-            .push_output_request(msg.into(), time)
+            .push_output_request(msg, time)
             .map_err(|e| Self::error(format!("Failed to push output request: {e:?}")))?;
         if sent_cycles > LOG_CANISTER_OPERATION_CYCLES_THRESHOLD {
             info!(
@@ -293,9 +287,9 @@ impl SystemStateModifications {
         Ok(())
     }
 
-    fn get_sender_canister_version(msg: &Request) -> Result<Option<u64>, UserError> {
+    fn get_sender_canister_version(msg: &OutputRequest) -> Result<Option<u64>, UserError> {
         let method = Ic00Method::from_str(&msg.method_name);
-        let payload = msg.method_payload();
+        let payload = msg.method_payload.as_slice();
         match method {
             Ok(Ic00Method::InstallCode) => InstallCodeArgsV2::decode(payload)
                 .map(|record| record.get_sender_canister_version()),
@@ -363,7 +357,7 @@ impl SystemStateModifications {
     }
 
     fn validate_sender_canister_version(
-        msg: &Request,
+        msg: &OutputRequest,
         canister_version_from_system: u64,
     ) -> Result<(), UserError> {
         match Self::get_sender_canister_version(msg)? {
@@ -456,7 +450,6 @@ impl SystemStateModifications {
         };
 
         // Push outgoing messages.
-        let mut callback_changes = BTreeMap::new();
         let nns_subnet_id = network_topology.nns_subnet_id;
         let subnet_ids: BTreeSet<PrincipalId> =
             network_topology.subnets().keys().map(|s| s.get()).collect();
@@ -465,8 +458,7 @@ impl SystemStateModifications {
                 match Self::validate_sender_canister_version(&msg, system_state.canister_version())
                 {
                     Ok(()) => {
-                        // This is a request to ic:00. Update the receiver to be the appropriate
-                        // subnet and also update the corresponding callback.
+                        // This is a request to ic:00. Update the receiver to the appropriate subnet.
                         match routing::resolve_destination(
                             network_topology,
                             msg.method_name.as_str(),
@@ -480,8 +472,6 @@ impl SystemStateModifications {
                         {
                             Ok(destination_subnet) => {
                                 msg.receiver = destination_subnet;
-                                callback_changes
-                                    .insert(msg.sender_reply_callback, destination_subnet);
                                 Self::push_message(system_state, time, msg, logger)?;
                             }
                             Err(err) => {
@@ -536,31 +526,6 @@ impl SystemStateModifications {
                 }
             } else {
                 Self::push_message(system_state, time, msg, logger)?;
-            }
-        }
-
-        // Register and unregister callbacks.
-        for update in self.callback_updates {
-            match update {
-                CallbackUpdate::Register(expected_id, mut callback) => {
-                    if let Some(receiver) = callback_changes.get(&expected_id) {
-                        callback.respondent = *receiver;
-                    }
-                    let id = system_state
-                        .register_callback(callback)
-                        .map_err(|_| Self::error("Call context manager does not exist"))?;
-                    if id != expected_id {
-                        return Err(Self::error("Failed to register update callback"));
-                    }
-                }
-                CallbackUpdate::Unregister(callback_id) => {
-                    system_state
-                        .unregister_callback(callback_id)
-                        .map_err(|_| Self::error("Call context manager does not exist"))?
-                        .ok_or_else(|| {
-                            Self::error("Tried to unregister callback with an ID that isn't in use")
-                        })?;
-                }
             }
         }
 
@@ -680,10 +645,6 @@ pub struct SandboxSafeSystemState {
     call_context_balance: Option<Cycles>,
     call_context_deadline: Option<CoarseTime>,
     cycles_account_manager: CyclesAccountManager,
-    // None indicates that we are in a context where the canister cannot
-    // register callbacks (e.g. running the `start` method when installing a
-    // canister.)
-    next_callback_id: Option<u64>,
     /// The number of calls / callbacks that can still be made. This is the maximum
     /// available in either the subnet shared pool or the canister quota.
     available_callbacks: u64,
@@ -718,7 +679,6 @@ impl SandboxSafeSystemState {
         call_context_balance: Option<Cycles>,
         call_context_deadline: Option<CoarseTime>,
         cycles_account_manager: CyclesAccountManager,
-        next_callback_id: Option<u64>,
         available_callbacks: u64,
         available_request_slots: BTreeMap<CanisterId, usize>,
         ic00_available_request_slots: usize,
@@ -764,7 +724,6 @@ impl SandboxSafeSystemState {
             call_context_balance,
             call_context_deadline,
             cycles_account_manager,
-            next_callback_id,
             available_callbacks,
             available_request_slots,
             ic00_available_request_slots,
@@ -887,9 +846,6 @@ impl SandboxSafeSystemState {
             call_context_balance,
             call_context_deadline,
             cycles_account_manager,
-            system_state
-                .call_context_manager()
-                .map(|c| c.next_callback_id()),
             available_callbacks,
             available_request_slots,
             ic00_available_request_slots,
@@ -937,33 +893,6 @@ impl SandboxSafeSystemState {
 
     pub fn take_changes(&mut self) -> SystemStateModifications {
         std::mem::take(&mut self.system_state_modifications)
-    }
-
-    /// Only public for use in tests.
-    #[doc(hidden)]
-    pub fn register_callback(&mut self, callback: Callback) -> HypervisorResult<CallbackId> {
-        match &mut self.next_callback_id {
-            Some(next_callback_id) => {
-                *next_callback_id += 1;
-                let id = CallbackId::from(*next_callback_id);
-                self.system_state_modifications
-                    .callback_updates
-                    .push(CallbackUpdate::Register(id, callback));
-                Ok(id)
-            }
-            None => Err(HypervisorError::ToolchainContractViolation {
-                error: "Tried to register a callback in a context where it isn't allowed."
-                    .to_string(),
-            }),
-        }
-    }
-
-    /// Only public for use in tests.
-    #[doc(hidden)]
-    pub fn unregister_callback(&mut self, id: CallbackId) {
-        self.system_state_modifications
-            .callback_updates
-            .push(CallbackUpdate::Unregister(id))
     }
 
     /// Computes the current main balance of the canister based
@@ -1193,10 +1122,8 @@ impl SandboxSafeSystemState {
         &mut self,
         canister_current_memory_usage: NumBytes,
         canister_current_message_memory_usage: MessageMemoryUsage,
-        msg: Request,
-        prepayment_for_response_execution: CompoundCycles<Instructions>,
-        prepayment_for_call_transmission: CompoundCycles<RequestAndResponseTransmission>,
-    ) -> Result<(), Request> {
+        msg: OutputRequest,
+    ) -> Result<(), OutputRequest> {
         if self.available_callbacks == 0 {
             return Err(msg);
         }
@@ -1213,8 +1140,8 @@ impl SandboxSafeSystemState {
                 canister_current_memory_usage,
                 canister_current_message_memory_usage,
                 self.compute_allocation,
-                prepayment_for_response_execution,
-                prepayment_for_call_transmission,
+                msg.prepayment_for_response_execution,
+                msg.prepayment_for_call_transmission,
                 self.subnet_size,
                 self.cost_schedule,
                 self.reserved_balance(),
@@ -1249,13 +1176,14 @@ impl SandboxSafeSystemState {
         if *used_slots >= *initial_available_slots {
             return Err(msg);
         }
-        self.system_state_modifications.requests.push(msg);
+
         *used_slots += 1;
         let consumed_cycles = ConsumedCyclesDuringExecution {
-            instructions: Some(prepayment_for_response_execution),
-            request_and_response_transmission: Some(prepayment_for_call_transmission),
+            instructions: Some(msg.prepayment_for_response_execution),
+            request_and_response_transmission: Some(msg.prepayment_for_call_transmission),
             ..Default::default()
         };
+        self.system_state_modifications.requests.push(msg);
         self.update_balance_change_consuming(new_balance, consumed_cycles);
         Ok(())
     }
@@ -1664,7 +1592,6 @@ mod tests {
                 subnet_test_id(0),
                 CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None),
             ),
-            Some(0),
             0,
             BTreeMap::new(),
             0,

--- a/rs/embedders/tests/common/mod.rs
+++ b/rs/embedders/tests/common/mod.rs
@@ -17,7 +17,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::metadata_state::testing::NetworkTopologyTesting;
 use ic_replicated_state::testing::SystemStateTesting;
 use ic_replicated_state::{
-    CallOrigin, Memory, NetworkTopology, NumWasmPages, OutputRequest, SubnetTopology, SystemState,
+    CallOrigin, Memory, NetworkTopology, NumWasmPages, SubnetTopology, SystemState,
 };
 use ic_test_utilities_state::SystemStateBuilder;
 use ic_test_utilities_types::ids::{
@@ -29,10 +29,7 @@ use ic_types::{
     methods::SystemMethod,
     time::UNIX_EPOCH,
 };
-use ic_types_cycles::{
-    CanisterCyclesCostSchedule, CompoundCycles, Cycles, Instructions,
-    RequestAndResponseTransmission,
-};
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use std::collections::BTreeMap;
 
 pub const CANISTER_CURRENT_MEMORY_USAGE: NumBytes = NumBytes::new(0);
@@ -282,113 +279,4 @@ pub fn get_cmc_system_state() -> SystemState {
     let mut system_state = get_system_state();
     system_state.set_canister_id(CYCLES_MINTING_CANISTER_ID);
     system_state
-}
-
-// Not used in all tests.
-#[allow(dead_code)]
-pub struct OutputRequestBuilder {
-    request: OutputRequest,
-}
-
-impl Default for OutputRequestBuilder {
-    /// Creates a dummy Request message with default values.
-    fn default() -> Self {
-        let name = "No-Op";
-        fn prepayment<T: ic_types_cycles::CyclesUseCaseKind>() -> ic_types_cycles::CompoundCycles<T>
-        {
-            ic_types_cycles::CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal)
-        }
-
-        Self {
-            request: OutputRequest {
-                receiver: canister_test_id(0),
-                payment: Cycles::zero(),
-                deadline: NO_DEADLINE,
-                sender: canister_test_id(1),
-                method_name: name.to_string(),
-                method_payload: Vec::new(),
-                metadata: Default::default(),
-                call_context_id: call_context_test_id(1),
-                prepayment_for_response_execution: prepayment(),
-                prepayment_for_response_transmission: prepayment(),
-                prepayment_for_call_transmission: prepayment(),
-                on_reply: ic_types::methods::WasmClosure::new(0, 0),
-                on_reject: ic_types::methods::WasmClosure::new(0, 0),
-                on_cleanup: None,
-            },
-        }
-    }
-}
-
-// Not used in all tests.
-#[allow(dead_code)]
-impl OutputRequestBuilder {
-    /// Creates a new `RequestBuilder`.
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    /// Sets the `receiver` field.
-    pub fn receiver(mut self, receiver: CanisterId) -> Self {
-        self.request.receiver = receiver;
-        self
-    }
-
-    /// Sets the `sender` field.
-    pub fn sender(mut self, sender: CanisterId) -> Self {
-        self.request.sender = sender;
-        self
-    }
-
-    /// Sets the `payment` field.
-    pub fn payment(mut self, payment: Cycles) -> Self {
-        self.request.payment = payment;
-        self
-    }
-
-    /// Sets the `method_name` field.
-    pub fn method_name<S: ToString>(mut self, method_name: S) -> Self {
-        self.request.method_name = method_name.to_string();
-        self
-    }
-
-    /// Sets the `method_payload` field.
-    pub fn method_payload(mut self, method_payload: Vec<u8>) -> Self {
-        self.request.method_payload = method_payload;
-        self
-    }
-
-    /// Sets the `deadline` field.
-    pub fn deadline(mut self, deadline: ic_types::time::CoarseTime) -> Self {
-        self.request.deadline = deadline;
-        self
-    }
-
-    pub fn prepayment_for_response_execution(
-        mut self,
-        prepayment: CompoundCycles<Instructions>,
-    ) -> Self {
-        self.request.prepayment_for_response_execution = prepayment;
-        self
-    }
-
-    pub fn prepayment_for_response_transmission(
-        mut self,
-        prepayment: CompoundCycles<RequestAndResponseTransmission>,
-    ) -> Self {
-        self.request.prepayment_for_response_transmission = prepayment;
-        self
-    }
-
-    pub fn prepayment_for_call_transmission(
-        mut self,
-        prepayment: CompoundCycles<RequestAndResponseTransmission>,
-    ) -> Self {
-        self.request.prepayment_for_call_transmission = prepayment;
-        self
-    }
-    /// Returns the built `OutputRequest`.
-    pub fn build(self) -> OutputRequest {
-        self.request
-    }
 }

--- a/rs/embedders/tests/common/mod.rs
+++ b/rs/embedders/tests/common/mod.rs
@@ -17,7 +17,7 @@ use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::metadata_state::testing::NetworkTopologyTesting;
 use ic_replicated_state::testing::SystemStateTesting;
 use ic_replicated_state::{
-    CallOrigin, Memory, NetworkTopology, NumWasmPages, SubnetTopology, SystemState,
+    CallOrigin, Memory, NetworkTopology, NumWasmPages, OutputRequest, SubnetTopology, SystemState,
 };
 use ic_test_utilities_state::SystemStateBuilder;
 use ic_test_utilities_types::ids::{
@@ -29,7 +29,10 @@ use ic_types::{
     methods::SystemMethod,
     time::UNIX_EPOCH,
 };
-use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
+use ic_types_cycles::{
+    CanisterCyclesCostSchedule, CompoundCycles, Cycles, Instructions,
+    RequestAndResponseTransmission,
+};
 use std::collections::BTreeMap;
 
 pub const CANISTER_CURRENT_MEMORY_USAGE: NumBytes = NumBytes::new(0);
@@ -279,4 +282,113 @@ pub fn get_cmc_system_state() -> SystemState {
     let mut system_state = get_system_state();
     system_state.set_canister_id(CYCLES_MINTING_CANISTER_ID);
     system_state
+}
+
+// Not used in all tests.
+#[allow(dead_code)]
+pub struct OutputRequestBuilder {
+    request: OutputRequest,
+}
+
+impl Default for OutputRequestBuilder {
+    /// Creates a dummy Request message with default values.
+    fn default() -> Self {
+        let name = "No-Op";
+        fn prepayment<T: ic_types_cycles::CyclesUseCaseKind>() -> ic_types_cycles::CompoundCycles<T>
+        {
+            ic_types_cycles::CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal)
+        }
+
+        Self {
+            request: OutputRequest {
+                receiver: canister_test_id(0),
+                payment: Cycles::zero(),
+                deadline: NO_DEADLINE,
+                sender: canister_test_id(1),
+                method_name: name.to_string(),
+                method_payload: Vec::new(),
+                metadata: Default::default(),
+                call_context_id: call_context_test_id(1),
+                prepayment_for_response_execution: prepayment(),
+                prepayment_for_response_transmission: prepayment(),
+                prepayment_for_call_transmission: prepayment(),
+                on_reply: ic_types::methods::WasmClosure::new(0, 0),
+                on_reject: ic_types::methods::WasmClosure::new(0, 0),
+                on_cleanup: None,
+            },
+        }
+    }
+}
+
+// Not used in all tests.
+#[allow(dead_code)]
+impl OutputRequestBuilder {
+    /// Creates a new `RequestBuilder`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Sets the `receiver` field.
+    pub fn receiver(mut self, receiver: CanisterId) -> Self {
+        self.request.receiver = receiver;
+        self
+    }
+
+    /// Sets the `sender` field.
+    pub fn sender(mut self, sender: CanisterId) -> Self {
+        self.request.sender = sender;
+        self
+    }
+
+    /// Sets the `payment` field.
+    pub fn payment(mut self, payment: Cycles) -> Self {
+        self.request.payment = payment;
+        self
+    }
+
+    /// Sets the `method_name` field.
+    pub fn method_name<S: ToString>(mut self, method_name: S) -> Self {
+        self.request.method_name = method_name.to_string();
+        self
+    }
+
+    /// Sets the `method_payload` field.
+    pub fn method_payload(mut self, method_payload: Vec<u8>) -> Self {
+        self.request.method_payload = method_payload;
+        self
+    }
+
+    /// Sets the `deadline` field.
+    pub fn deadline(mut self, deadline: ic_types::time::CoarseTime) -> Self {
+        self.request.deadline = deadline;
+        self
+    }
+
+    pub fn prepayment_for_response_execution(
+        mut self,
+        prepayment: CompoundCycles<Instructions>,
+    ) -> Self {
+        self.request.prepayment_for_response_execution = prepayment;
+        self
+    }
+
+    pub fn prepayment_for_response_transmission(
+        mut self,
+        prepayment: CompoundCycles<RequestAndResponseTransmission>,
+    ) -> Self {
+        self.request.prepayment_for_response_transmission = prepayment;
+        self
+    }
+
+    pub fn prepayment_for_call_transmission(
+        mut self,
+        prepayment: CompoundCycles<RequestAndResponseTransmission>,
+    ) -> Self {
+        self.request.prepayment_for_call_transmission = prepayment;
+        self
+    }
+    /// Returns the built `OutputRequest`.
+    pub fn build(self) -> OutputRequest {
+        self.request
+    }
 }

--- a/rs/embedders/tests/sandbox_safe_system_state.rs
+++ b/rs/embedders/tests/sandbox_safe_system_state.rs
@@ -188,6 +188,11 @@ fn push_output_request_succeeds_with_enough_cycles() {
         );
     request.prepayment_for_response_transmission = cycles_account_manager
         .prepayment_for_response_transmission(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    request.prepayment_for_call_transmission = cycles_account_manager.xnet_total_transmission_fee(
+        request.payload_size_bytes(),
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+    );
 
     assert_eq!(
         sandbox_safe_system_state.push_output_request(

--- a/rs/embedders/tests/sandbox_safe_system_state.rs
+++ b/rs/embedders/tests/sandbox_safe_system_state.rs
@@ -12,18 +12,16 @@ use ic_management_canister_types_private::{
 use ic_nns_constants::CYCLES_MINTING_CANISTER_ID;
 use ic_registry_routing_table::CanisterIdRange;
 use ic_registry_subnet_type::SubnetType;
+use ic_replicated_state::canister_state::execution_state::WasmExecutionMode;
 use ic_replicated_state::metadata_state::testing::NetworkTopologyTesting;
 use ic_replicated_state::testing::SystemStateTesting;
 use ic_replicated_state::{NetworkTopology, SystemState};
 use ic_test_utilities::cycles_account_manager::CyclesAccountManagerBuilder;
 use ic_test_utilities_state::SystemStateBuilder;
-use ic_test_utilities_types::ids::{
-    call_context_test_id, canister_test_id, subnet_test_id, user_test_id,
-};
-use ic_test_utilities_types::messages::{RequestBuilder, ResponseBuilder};
+use ic_test_utilities_types::ids::{canister_test_id, subnet_test_id, user_test_id};
+use ic_test_utilities_types::messages::ResponseBuilder;
 use ic_types::canister_log::CanisterLogMetrics;
-use ic_types::messages::{CanisterMessage, MAX_INTER_CANISTER_PAYLOAD_IN_BYTES, NO_DEADLINE};
-use ic_types::methods::{Callback, WasmClosure};
+use ic_types::messages::{CanisterMessage, MAX_INTER_CANISTER_PAYLOAD_IN_BYTES};
 use ic_types::time::UNIX_EPOCH;
 use ic_types::{ComputeAllocation, NumInstructions};
 use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles, CyclesUseCase, NominalCycles};
@@ -34,17 +32,13 @@ use std::convert::From;
 mod common;
 use common::*;
 
-use ic_replicated_state::canister_state::execution_state::WasmExecutionMode;
-
 const MAX_NUM_INSTRUCTIONS: NumInstructions = NumInstructions::new(1 << 30);
 const INITIAL_CYCLES: Cycles = Cycles::new(5_000_000_000_000);
 const WASM_EXECUTION_MODE: WasmExecutionMode = WasmExecutionMode::Wasm32;
 
 #[test]
 fn push_output_request_fails_not_enough_cycles_for_request() {
-    let request = RequestBuilder::default()
-        .sender(canister_test_id(0))
-        .build();
+    let mut request = OutputRequestBuilder::default().build();
 
     let cycles_account_manager = CyclesAccountManagerBuilder::new()
         .with_max_num_instructions(MAX_NUM_INSTRUCTIONS)
@@ -67,13 +61,13 @@ fn push_output_request_fails_not_enough_cycles_for_request() {
         NumSeconds::from(100_000),
     );
 
-    let prepayment_for_response_execution = cycles_account_manager
+    request.prepayment_for_response_execution = cycles_account_manager
         .prepayment_for_response_execution(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
             WASM_EXECUTION_MODE,
         );
-    let prepayment_for_call_transmission = cycles_account_manager.xnet_total_transmission_fee(
+    request.prepayment_for_call_transmission = cycles_account_manager.xnet_total_transmission_fee(
         request.payload_size_bytes(),
         SMALL_APP_SUBNET_MAX_SIZE,
         CanisterCyclesCostSchedule::Normal,
@@ -87,7 +81,7 @@ fn push_output_request_fails_not_enough_cycles_for_request() {
         ComputeAllocation::default(),
         SUBNET_CALLBACK_SOFT_LIMIT as u64,
         Default::default(),
-        Some(request.sender().into()),
+        Some(request.sender.into()),
         None,
         CanisterCyclesCostSchedule::Normal,
     );
@@ -97,8 +91,6 @@ fn push_output_request_fails_not_enough_cycles_for_request() {
             NumBytes::from(0),
             MessageMemoryUsage::ZERO,
             request.clone(),
-            prepayment_for_response_execution,
-            prepayment_for_call_transmission,
         ),
         Err(request)
     );
@@ -106,27 +98,25 @@ fn push_output_request_fails_not_enough_cycles_for_request() {
 
 #[test]
 fn push_output_request_fails_not_enough_cycles_for_response() {
-    let request = RequestBuilder::default()
-        .sender(canister_test_id(0))
-        .build();
+    let mut request = OutputRequestBuilder::default().build();
 
     let cycles_account_manager = CyclesAccountManagerBuilder::new()
         .with_max_num_instructions(MAX_NUM_INSTRUCTIONS)
         .build();
 
-    let prepayment_for_response_execution = cycles_account_manager
+    request.prepayment_for_response_execution = cycles_account_manager
         .prepayment_for_response_execution(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
             WASM_EXECUTION_MODE,
         );
-    let prepayment_for_call_transmission = cycles_account_manager.xnet_total_transmission_fee(
+    request.prepayment_for_call_transmission = cycles_account_manager.xnet_total_transmission_fee(
         request.payload_size_bytes(),
         SMALL_APP_SUBNET_MAX_SIZE,
         CanisterCyclesCostSchedule::Normal,
     );
-    let total_cost =
-        prepayment_for_response_execution.real() + prepayment_for_call_transmission.real();
+    let total_cost = request.prepayment_for_response_execution.real()
+        + request.prepayment_for_call_transmission.real();
 
     // Set cycles balance to a number that is enough to cover for the request
     // transfer but not to cover the cost of processing the expected response.
@@ -145,7 +135,7 @@ fn push_output_request_fails_not_enough_cycles_for_response() {
         ComputeAllocation::default(),
         SUBNET_CALLBACK_SOFT_LIMIT as u64,
         Default::default(),
-        Some(request.sender().into()),
+        Some(request.sender.into()),
         None,
         CanisterCyclesCostSchedule::Normal,
     );
@@ -155,8 +145,6 @@ fn push_output_request_fails_not_enough_cycles_for_response() {
             NumBytes::from(0),
             MessageMemoryUsage::ZERO,
             request.clone(),
-            prepayment_for_response_execution,
-            prepayment_for_call_transmission,
         ),
         Err(request)
     );
@@ -190,24 +178,22 @@ fn push_output_request_succeeds_with_enough_cycles() {
         cost_schedule,
     );
 
-    let prepayment_for_response_execution = cycles_account_manager
+    let mut request = OutputRequestBuilder::default().build();
+
+    request.prepayment_for_response_execution = cycles_account_manager
         .prepayment_for_response_execution(
             SMALL_APP_SUBNET_MAX_SIZE,
             cost_schedule,
             WASM_EXECUTION_MODE,
         );
-    let prepayment_for_response_transmission = cycles_account_manager
+    request.prepayment_for_response_transmission = cycles_account_manager
         .prepayment_for_response_transmission(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
 
     assert_eq!(
         sandbox_safe_system_state.push_output_request(
             NumBytes::from(0),
             MessageMemoryUsage::ZERO,
-            RequestBuilder::default()
-                .sender(canister_test_id(0))
-                .build(),
-            prepayment_for_response_execution,
-            prepayment_for_response_transmission,
+            request,
         ),
         Ok(())
     );
@@ -230,7 +216,7 @@ fn correct_charging_source_canister_for_a_request() {
 
     let initial_cycles_balance = system_state.balance();
 
-    let request = RequestBuilder::default()
+    let mut request = OutputRequestBuilder::default()
         .sender(canister_test_id(0))
         .receiver(canister_test_id(1))
         .build();
@@ -243,36 +229,30 @@ fn correct_charging_source_canister_for_a_request() {
         ComputeAllocation::default(),
         SUBNET_CALLBACK_SOFT_LIMIT as u64,
         Default::default(),
-        Some(request.sender().into()),
+        Some(request.sender.into()),
         None,
         CanisterCyclesCostSchedule::Normal,
     );
 
-    let prepayment_for_response_execution = cycles_account_manager
+    request.prepayment_for_response_execution = cycles_account_manager
         .prepayment_for_response_execution(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
             WASM_EXECUTION_MODE,
         );
-    let prepayment_for_response_transmission = cycles_account_manager
+    request.prepayment_for_response_transmission = cycles_account_manager
         .prepayment_for_response_transmission(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
-    let prepayment_for_call_transmission = cycles_account_manager.xnet_total_transmission_fee(
+    request.prepayment_for_call_transmission = cycles_account_manager.xnet_total_transmission_fee(
         request.payload_size_bytes(),
         SMALL_APP_SUBNET_MAX_SIZE,
         cost_schedule,
     );
-    let total_cost =
-        prepayment_for_response_execution.real() + prepayment_for_call_transmission.real();
+    let total_cost = request.prepayment_for_response_execution.real()
+        + request.prepayment_for_call_transmission.real();
 
     // Enqueue the Request.
     sandbox_safe_system_state
-        .push_output_request(
-            NumBytes::from(0),
-            MessageMemoryUsage::ZERO,
-            request,
-            prepayment_for_response_execution,
-            prepayment_for_call_transmission,
-        )
+        .push_output_request(NumBytes::from(0), MessageMemoryUsage::ZERO, request.clone())
         .unwrap();
 
     // Assume the destination canister got the message and prepared a response
@@ -302,12 +282,12 @@ fn correct_charging_source_canister_for_a_request() {
         &no_op_logger(),
         &no_op_counter,
         &response.response_payload,
-        prepayment_for_response_transmission,
+        request.prepayment_for_response_transmission,
         SMALL_APP_SUBNET_MAX_SIZE,
         cost_schedule,
     );
 
-    system_state.refund_cycles(prepayment_for_call_transmission, refund_cycles);
+    system_state.refund_cycles(request.prepayment_for_call_transmission, refund_cycles);
 
     // MAX_NUM_INSTRUCTIONS also gets partially refunded in the real
     // ExecutionEnvironmentImpl::execute_canister_response()
@@ -582,43 +562,22 @@ fn test_inter_canister_call(
         CanisterCyclesCostSchedule::Normal,
     );
 
-    // Register a callback for the response.
-    let callback = Callback::new(
-        call_context_test_id(0),
-        recv,
-        Cycles::zero(),
-        prepayment_for_response_execution,
-        prepayment_for_response_transmission,
-        prepayment_for_call_transmission,
-        WasmClosure::new(0, 0),
-        WasmClosure::new(0, 0),
-        None,
-        NO_DEADLINE,
-    );
-    let callback_id = sandbox_safe_system_state
-        .register_callback(callback)
-        .unwrap();
-
-    let request = RequestBuilder::default()
+    let request = OutputRequestBuilder::default()
         .sender(sender)
         .receiver(recv)
         .method_name(method_name)
         .method_payload(arg)
-        .sender_reply_callback(callback_id)
+        .prepayment_for_response_execution(prepayment_for_response_execution)
+        .prepayment_for_response_transmission(prepayment_for_response_transmission)
+        .prepayment_for_call_transmission(prepayment_for_call_transmission)
         .build();
 
     // Sanity check that the payload calculation is consistent.
     assert_eq!(request.payload_size_bytes(), payload_size);
 
-    // Enqueue the Request.
+    // Enqueue the request.
     sandbox_safe_system_state
-        .push_output_request(
-            NumBytes::from(0),
-            MessageMemoryUsage::ZERO,
-            request,
-            prepayment_for_response_execution,
-            prepayment_for_response_transmission,
-        )
+        .push_output_request(NumBytes::from(0), MessageMemoryUsage::ZERO, request)
         .unwrap();
 
     sandbox_safe_system_state

--- a/rs/embedders/tests/sandbox_safe_system_state.rs
+++ b/rs/embedders/tests/sandbox_safe_system_state.rs
@@ -14,7 +14,7 @@ use ic_registry_routing_table::CanisterIdRange;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::execution_state::WasmExecutionMode;
 use ic_replicated_state::metadata_state::testing::NetworkTopologyTesting;
-use ic_replicated_state::testing::SystemStateTesting;
+use ic_replicated_state::testing::{OutputRequestBuilder, SystemStateTesting};
 use ic_replicated_state::{NetworkTopology, SystemState};
 use ic_test_utilities::cycles_account_manager::CyclesAccountManagerBuilder;
 use ic_test_utilities_state::SystemStateBuilder;

--- a/rs/embedders/tests/system_api.rs
+++ b/rs/embedders/tests/system_api.rs
@@ -18,20 +18,18 @@ use ic_replicated_state::{
 };
 use ic_test_utilities::cycles_account_manager::CyclesAccountManagerBuilder;
 use ic_test_utilities_state::SystemStateBuilder;
-use ic_test_utilities_types::{
-    ids::{call_context_test_id, canister_test_id, subnet_test_id, user_test_id},
-    messages::RequestBuilder,
+use ic_test_utilities_types::ids::{
+    call_context_test_id, canister_test_id, subnet_test_id, user_test_id,
 };
 use ic_types::{
-    CanisterTimer, CountBytes, NumInstructions, PrincipalId, SubnetId, Time,
+    CanisterTimer, NumInstructions, PrincipalId, SubnetId, Time,
     canister_log::CanisterLogMetrics,
     messages::{
         CallbackId, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, RejectContext, RequestOrResponse,
     },
-    methods::{Callback, WasmClosure},
-    time::{self, UNIX_EPOCH},
+    time::UNIX_EPOCH,
 };
-use ic_types_cycles::{CanisterCyclesCostSchedule, CompoundCycles, Cycles};
+use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use maplit::btreemap;
 use more_asserts::assert_le;
 use std::{
@@ -611,7 +609,7 @@ fn api_availability_test(
         }
         SystemApiCallId::GlobalTimerSet => {
             assert_api_availability(
-                |mut api| api.ic0_global_timer_set(time::UNIX_EPOCH),
+                |mut api| api.ic0_global_timer_set(UNIX_EPOCH),
                 api_type,
                 &system_state,
                 cycles_account_manager,
@@ -1629,7 +1627,7 @@ fn push_output_request_respects_memory_limits() {
     let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
     let api_type = ApiTypeBuilder::build_update_api();
     let execution_parameters = execution_parameters(api_type.execution_mode());
-    let mut sandbox_safe_system_state = SandboxSafeSystemState::new_for_testing(
+    let sandbox_safe_system_state = SandboxSafeSystemState::new_for_testing(
         &system_state,
         cycles_account_manager,
         &NetworkTopology::default(),
@@ -1642,20 +1640,6 @@ fn push_output_request_respects_memory_limits() {
         CanisterCyclesCostSchedule::Normal,
     );
     let own_canister_id = system_state.canister_id();
-    let callback_id = sandbox_safe_system_state
-        .register_callback(Callback::new(
-            call_context_test_id(0),
-            canister_test_id(0),
-            Cycles::zero(),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            WasmClosure::new(0, 0),
-            WasmClosure::new(0, 0),
-            None,
-            NO_DEADLINE,
-        ))
-        .unwrap();
     let mut api = SystemApiImpl::new(
         api_type,
         sandbox_safe_system_state,
@@ -1670,22 +1654,13 @@ fn push_output_request_respects_memory_limits() {
         no_op_logger(),
     );
 
-    let req = RequestBuilder::default()
+    let req = OutputRequestBuilder::default()
         .sender(own_canister_id)
-        .sender_reply_callback(callback_id)
         .build();
 
     // First push succeeds with or without message memory usage accounting, as the
     // initial subnet available memory is `MAX_RESPONSE_COUNT_BYTES + 13`.
-    assert_eq!(
-        0,
-        api.push_output_request(
-            req.clone(),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal)
-        )
-        .unwrap()
-    );
+    assert_eq!(0, api.push_output_request(req.clone()).unwrap());
 
     // Nothing is consumed for execution memory.
     assert_eq!(api.get_allocated_bytes().get(), 0);
@@ -1702,12 +1677,7 @@ fn push_output_request_respects_memory_limits() {
     // And the second push fails.
     assert_eq!(
         RejectCode::SysTransient as i32,
-        api.push_output_request(
-            req,
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal)
-        )
-        .unwrap()
+        api.push_output_request(req).unwrap()
     );
     // Without altering memory usage.
     assert_eq!(api.get_allocated_bytes().get(), 0,);
@@ -1750,7 +1720,7 @@ fn push_output_request_oversized_request_memory_limits() {
     let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
     let api_type = ApiTypeBuilder::build_update_api();
     let execution_parameters = execution_parameters(api_type.execution_mode());
-    let mut sandbox_safe_system_state = SandboxSafeSystemState::new_for_testing(
+    let sandbox_safe_system_state = SandboxSafeSystemState::new_for_testing(
         &system_state,
         cycles_account_manager,
         &NetworkTopology::default(),
@@ -1763,20 +1733,6 @@ fn push_output_request_oversized_request_memory_limits() {
         CanisterCyclesCostSchedule::Normal,
     );
     let own_canister_id = system_state.canister_id();
-    let callback_id = sandbox_safe_system_state
-        .register_callback(Callback::new(
-            call_context_test_id(0),
-            canister_test_id(0),
-            Cycles::zero(),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            WasmClosure::new(0, 0),
-            WasmClosure::new(0, 0),
-            None,
-            NO_DEADLINE,
-        ))
-        .unwrap();
     let mut api = SystemApiImpl::new(
         api_type,
         sandbox_safe_system_state,
@@ -1792,21 +1748,15 @@ fn push_output_request_oversized_request_memory_limits() {
     );
 
     // Oversized payload larger than available memory.
-    let req = RequestBuilder::default()
+    let req = OutputRequestBuilder::default()
         .sender(own_canister_id)
-        .sender_reply_callback(callback_id)
         .method_payload(vec![13; 4 * MAX_RESPONSE_COUNT_BYTES])
         .build();
 
     // Not enough memory to push the request.
     assert_eq!(
         RejectCode::SysTransient as i32,
-        api.push_output_request(
-            req,
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal)
-        )
-        .unwrap()
+        api.push_output_request(req).unwrap()
     );
 
     // Memory usage unchanged.
@@ -1817,7 +1767,7 @@ fn push_output_request_oversized_request_memory_limits() {
     );
 
     // Slightly smaller, still oversized request.
-    let req = RequestBuilder::default()
+    let req = OutputRequestBuilder::default()
         .sender(own_canister_id)
         .method_payload(vec![13; 2 * MAX_RESPONSE_COUNT_BYTES])
         .build();
@@ -1825,15 +1775,7 @@ fn push_output_request_oversized_request_memory_limits() {
     assert!(req_size_bytes > MAX_RESPONSE_COUNT_BYTES);
 
     // Pushing succeeds.
-    assert_eq!(
-        0,
-        api.push_output_request(
-            req,
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal)
-        )
-        .unwrap()
-    );
+    assert_eq!(0, api.push_output_request(req).unwrap());
 
     // `req_size_bytes` are consumed.
     assert_eq!(0, api.get_allocated_bytes().get());
@@ -1875,7 +1817,7 @@ fn ic0_global_timer_set_is_propagated_from_sandbox() {
     assert_eq!(
         api.ic0_global_timer_set(Time::from_nanos_since_unix_epoch(1))
             .unwrap(),
-        time::UNIX_EPOCH
+        UNIX_EPOCH
     );
     assert_eq!(
         api.ic0_global_timer_set(Time::from_nanos_since_unix_epoch(2))

--- a/rs/embedders/tests/system_api.rs
+++ b/rs/embedders/tests/system_api.rs
@@ -13,9 +13,8 @@ use ic_interfaces::execution_environment::{
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
 use ic_logger::replica_logger::no_op_logger;
 use ic_registry_subnet_type::SubnetType;
-use ic_replicated_state::{
-    CallOrigin, Memory, NetworkTopology, NumWasmPages, SystemState, testing::CanisterQueuesTesting,
-};
+use ic_replicated_state::testing::{CanisterQueuesTesting, OutputRequestBuilder};
+use ic_replicated_state::{CallOrigin, Memory, NetworkTopology, NumWasmPages, SystemState};
 use ic_test_utilities::cycles_account_manager::CyclesAccountManagerBuilder;
 use ic_test_utilities_state::SystemStateBuilder;
 use ic_test_utilities_types::ids::{

--- a/rs/embedders/tests/wasmtime_embedder.rs
+++ b/rs/embedders/tests/wasmtime_embedder.rs
@@ -6,11 +6,7 @@ use ic_config::{
 use ic_embedders::{
     wasm_utils::instrumentation::WasmMemoryType,
     wasm_utils::instrumentation::instruction_to_cost,
-    wasmtime_embedder::{
-        CanisterMemoryType,
-        system_api::{ApiType, sandbox_safe_system_state::CallbackUpdate},
-        system_api_complexity,
-    },
+    wasmtime_embedder::{CanisterMemoryType, system_api::ApiType, system_api_complexity},
 };
 use ic_interfaces::execution_environment::{
     CanisterBacktrace, HypervisorError, SystemApi, TrapCode,
@@ -3375,40 +3371,32 @@ fn wasm64_saturate_fun_index() {
         .unwrap()
         .take_system_state_modifications();
 
-    // call_perform should trigger one callback update
-    let callback_update = system_state_modifications
-        .callback_updates
+    // call_perform should enqueue one OutputRequest carrying its callback closures.
+    let output_request = system_state_modifications
+        .requests()
         .first()
-        .unwrap()
-        .clone();
-    match callback_update {
-        CallbackUpdate::Register(_id, callback) => {
-            assert_eq!(
-                callback.on_reply,
-                WasmClosure {
-                    func_idx: u32::MAX,
-                    env: 22
-                }
-            );
-            assert_eq!(
-                callback.on_reject,
-                WasmClosure {
-                    func_idx: u32::MAX,
-                    env: 44
-                }
-            );
-            assert_eq!(
-                callback.on_cleanup,
-                Some(WasmClosure {
-                    func_idx: u32::MAX,
-                    env: 66
-                })
-            );
+        .expect("Expected an outgoing request with its callback");
+    assert_eq!(
+        output_request.on_reply,
+        WasmClosure {
+            func_idx: u32::MAX,
+            env: 22
         }
-        CallbackUpdate::Unregister(_) => {
-            panic!("Expected registration of new calback")
+    );
+    assert_eq!(
+        output_request.on_reject,
+        WasmClosure {
+            func_idx: u32::MAX,
+            env: 44
         }
-    }
+    );
+    assert_eq!(
+        output_request.on_cleanup,
+        Some(WasmClosure {
+            func_idx: u32::MAX,
+            env: 66
+        })
+    );
 }
 
 #[test]

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -38,7 +38,7 @@ use ic_registry_routing_table::{CanisterIdRange, RoutingTable};
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     CanisterState, ExecutionState, ExportedFunctions, InputQueueType, Memory, NumWasmPages,
-    ReplicatedState,
+    OutputRequest, ReplicatedState,
     canister_state::execution_state::{self, WasmExecutionMode, WasmMetadata},
     metadata_state::testing::NetworkTopologyTesting,
     metrics::ReplicatedStateMetrics,
@@ -60,10 +60,8 @@ use ic_types::{
     consensus::idkg::IDkgMasterPublicKeyId,
     crypto::{AlgorithmId, canister_threshold_sig::MasterPublicKey},
     ingress::{IngressState, IngressStatus},
-    messages::{
-        CallContextId, Ingress, MessageId, NO_DEADLINE, Request, RequestOrResponse, Response,
-    },
-    methods::{Callback, FuncRef, SystemMethod, WasmClosure, WasmMethod},
+    messages::{CallContextId, Ingress, MessageId, NO_DEADLINE, RequestOrResponse, Response},
+    methods::{FuncRef, SystemMethod, WasmClosure, WasmMethod},
 };
 use ic_types_cycles::{
     CanisterCyclesCostSchedule, CompoundCycles, Cycles, ECDSAOutcalls, HTTPOutcalls,
@@ -1539,38 +1537,27 @@ impl TestWasmExecutorCore {
                 system_state.cost_schedule(),
             );
         let deadline = NO_DEADLINE;
-        let callback = system_state
-            .register_callback(Callback {
-                call_context_id,
-                respondent: receiver,
-                cycles_sent: Cycles::zero(),
-                prepayment_for_response_execution,
-                prepayment_for_response_transmission,
-                prepayment_for_call_transmission,
-                on_reply: closure.clone(),
-                on_reject: closure,
-                on_cleanup: None,
-                deadline,
-            })
-            .map_err(|err| err.to_string())?;
-        let request = Request {
+        let request = OutputRequest {
             receiver,
-            sender,
-            sender_reply_callback: callback,
             payment: Cycles::zero(),
+            deadline,
+            sender,
             method_name: "update".into(),
             method_payload: encode_message_id_as_payload(call_message_id),
             metadata: Default::default(),
-            deadline,
+            call_context_id,
+            prepayment_for_response_execution,
+            prepayment_for_response_transmission,
+            prepayment_for_call_transmission,
+            on_reply: closure.clone(),
+            on_reject: closure,
+            on_cleanup: None,
         };
         if let Err(req) = system_state.push_output_request(
             canister_current_memory_usage,
             canister_current_message_memory_usage,
             request,
-            prepayment_for_response_execution,
-            prepayment_for_response_transmission,
         ) {
-            system_state.unregister_callback(callback);
             return Err(format!("Failed pushing request {req:?} to output queue."));
         }
         self.messages.insert(call_message_id, call.other_side);

--- a/rs/execution_environment/src/scheduler/tests/routing.rs
+++ b/rs/execution_environment/src/scheduler/tests/routing.rs
@@ -5,11 +5,10 @@ use super::super::*;
 use super::zero_instruction_overhead_config;
 use ic_config::subnet_config::SchedulerConfig;
 use ic_registry_subnet_type::SubnetType;
-use ic_test_utilities_types::messages::RequestBuilder;
+use ic_replicated_state::testing::OutputRequestBuilder;
 use ic_types::messages::MAX_RESPONSE_COUNT_BYTES;
 use ic_types::time::{CoarseTime, UNIX_EPOCH};
 use ic_types_test_utils::ids::canister_test_id;
-use std::sync::Arc;
 
 const SOME_DEADLINE: CoarseTime = CoarseTime::from_secs_since_unix_epoch(1);
 
@@ -158,7 +157,7 @@ fn induct_messages_on_same_subnet_respects_memory_limits() {
         let source = test.create_canister();
         let dest = test.create_canister();
         let request_to = |canister: CanisterId, deadline: CoarseTime| {
-            RequestBuilder::default()
+            OutputRequestBuilder::default()
                 .sender(source)
                 .receiver(canister)
                 .deadline(deadline)
@@ -168,23 +167,23 @@ fn induct_messages_on_same_subnet_respects_memory_limits() {
         let source_canister = test.canister_state_mut(source);
         // First, best-effort messages to `source` and `dest`.
         source_canister
-            .push_output_request(request_to(source, SOME_DEADLINE).into(), UNIX_EPOCH)
+            .push_output_request(request_to(source, SOME_DEADLINE), UNIX_EPOCH)
             .unwrap();
         source_canister
-            .push_output_request(request_to(dest, SOME_DEADLINE).into(), UNIX_EPOCH)
+            .push_output_request(request_to(dest, SOME_DEADLINE), UNIX_EPOCH)
             .unwrap();
         // Then a couple of guaranteed response messages to each of `source` and `dest`.
         source_canister
-            .push_output_request(request_to(source, NO_DEADLINE).into(), UNIX_EPOCH)
+            .push_output_request(request_to(source, NO_DEADLINE), UNIX_EPOCH)
             .unwrap();
         source_canister
-            .push_output_request(request_to(source, NO_DEADLINE).into(), UNIX_EPOCH)
+            .push_output_request(request_to(source, NO_DEADLINE), UNIX_EPOCH)
             .unwrap();
         source_canister
-            .push_output_request(request_to(dest, NO_DEADLINE).into(), UNIX_EPOCH)
+            .push_output_request(request_to(dest, NO_DEADLINE), UNIX_EPOCH)
             .unwrap();
         source_canister
-            .push_output_request(request_to(dest, NO_DEADLINE).into(), UNIX_EPOCH)
+            .push_output_request(request_to(dest, NO_DEADLINE), UNIX_EPOCH)
             .unwrap();
         test.induct_messages_on_same_subnet();
 
@@ -233,12 +232,10 @@ fn induct_messages_on_same_subnet_destination_not_found() {
         Some(test.state().metadata.own_subnet_id)
     );
 
-    let request = Arc::new(
-        RequestBuilder::default()
-            .sender(source)
-            .receiver(dest)
-            .build(),
-    );
+    let request = OutputRequestBuilder::default()
+        .sender(source)
+        .receiver(dest)
+        .build();
     test.canister_state_mut(source)
         .push_output_request(request, UNIX_EPOCH)
         .unwrap();

--- a/rs/messaging/src/routing/stream_builder/tests.rs
+++ b/rs/messaging/src/routing/stream_builder/tests.rs
@@ -11,14 +11,17 @@ use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
     CanisterState, CanisterStates, InputQueueType, ReplicatedState, Stream, SubnetTopology,
     metadata_state::testing::NetworkTopologyTesting,
-    testing::{CanisterQueuesTesting, ReplicatedStateTesting, StreamTesting, SystemStateTesting},
+    testing::{
+        CanisterQueuesTesting, OutputRequestBuilder, ReplicatedStateTesting, StreamTesting,
+        SystemStateTesting,
+    },
 };
 use ic_test_utilities_logger::with_test_replica_logger;
 use ic_test_utilities_metrics::{
     MetricVec, fetch_histogram_stats, fetch_int_counter_vec, fetch_int_gauge_vec, metric_vec,
     nonzero_values,
 };
-use ic_test_utilities_state::{new_canister_state, register_callback};
+use ic_test_utilities_state::new_canister_state;
 use ic_test_utilities_types::ids::{
     SUBNET_3, SUBNET_4, SUBNET_5, SUBNET_27, SUBNET_42, canister_test_id, user_test_id,
 };
@@ -100,19 +103,19 @@ fn reject_local_request() {
 
         // With a reservation on an input queue.
         let payment = Cycles::new(100);
-        let callback_id = register_callback(&mut canister_state, receiver, NO_DEADLINE);
-        let msg = generate_message_for_test(
-            sender,
-            receiver,
-            callback_id,
-            "method".to_string(),
-            payment,
-            NO_DEADLINE,
-        );
+        let msg = OutputRequestBuilder::default()
+            .sender(sender)
+            .receiver(receiver)
+            .method_name("method".to_string())
+            .payment(payment)
+            .deadline(NO_DEADLINE)
+            .build();
 
-        canister_state
-            .push_output_request(msg.clone().into(), UNIX_EPOCH)
+        let callback_id = canister_state
+            .push_output_request(msg.clone(), UNIX_EPOCH)
             .unwrap();
+        let msg = msg.into_request(callback_id);
+
         canister_state
             .system_state
             .queues_mut()
@@ -1621,13 +1624,22 @@ fn canister_states_with_outputs<M: Into<RequestOrResponse>>(msgs: Vec<M>) -> Can
 
         match msg {
             RequestOrResponse::Request(req) => {
-                let callback_id = register_callback(canister_state, req.receiver, req.deadline);
+                let output_request = OutputRequestBuilder::default()
+                    .sender(req.sender)
+                    .receiver(req.receiver)
+                    .method_name(req.method_name.clone())
+                    .method_payload(req.method_payload.clone())
+                    .payment(req.payment)
+                    .deadline(req.deadline)
+                    .build();
+                let callback_id = canister_state
+                    .push_output_request(output_request, UNIX_EPOCH)
+                    .unwrap();
+
                 // Check the implicit assumption that the test messages were generated with a
                 // `sender_reply_callback` that is consistent with the callback IDs that the
                 // `CallContextManager` generates and registers.
                 assert_eq!(req.sender_reply_callback, callback_id);
-
-                canister_state.push_output_request(req, UNIX_EPOCH).unwrap();
             }
 
             RequestOrResponse::Response(rep) => {

--- a/rs/messaging/src/routing/stream_handler/tests.rs
+++ b/rs/messaging/src/routing/stream_handler/tests.rs
@@ -13,14 +13,14 @@ use ic_replicated_state::{
     CanisterStatus, ReplicatedState, Stream,
     metadata_state::{StreamMap, testing::NetworkTopologyTesting},
     replicated_state::LABEL_VALUE_OUT_OF_MEMORY,
-    testing::{ReplicatedStateTesting, StreamTesting, SystemStateTesting},
+    testing::{OutputRequestBuilder, ReplicatedStateTesting, StreamTesting, SystemStateTesting},
 };
 use ic_test_utilities_logger::with_test_replica_logger;
 use ic_test_utilities_metrics::{
     HistogramStats, MetricVec, fetch_histogram_stats, fetch_histogram_vec_count, fetch_int_counter,
     fetch_int_counter_vec, fetch_int_gauge_vec, metric_vec, nonzero_values,
 };
-use ic_test_utilities_state::{CanisterStateBuilder, register_callback};
+use ic_test_utilities_state::CanisterStateBuilder;
 use ic_test_utilities_types::ids::{SUBNET_12, SUBNET_23, SUBNET_27, user_test_id};
 use ic_test_utilities_types::messages::{RequestBuilder, ResponseBuilder};
 use ic_test_utilities_types::xnet::StreamHeaderBuilder;
@@ -3371,20 +3371,14 @@ fn with_test_setup_and_config(
                     // Register a callback and make an input queue reservation if `msg_config`
                     // corresponds to `LOCAL_CANISTER`; else use a dummy callback id.
                     if originator == *LOCAL_CANISTER {
-                        // Register a `Callback` and get a `CallbackId`.
-                        let callback_id =
-                            register_callback(&mut canister_state, respondent, deadline);
-
                         // Make an input queue reservation.
-                        canister_state
+                        let callback_id = canister_state
                             .push_output_request(
-                                RequestBuilder::new()
+                                OutputRequestBuilder::new()
                                     .sender(originator)
                                     .receiver(respondent)
-                                    .sender_reply_callback(callback_id)
                                     .deadline(deadline)
-                                    .build()
-                                    .into(),
+                                    .build(),
                                 UNIX_EPOCH,
                             )
                             .unwrap();

--- a/rs/replicated_state/src/canister_state.rs
+++ b/rs/replicated_state/src/canister_state.rs
@@ -11,7 +11,7 @@ use crate::canister_state::queues::CanisterOutputQueuesIterator;
 use crate::canister_state::system_state::{
     ExecutionTask, SystemState, log_memory_store::LogMemoryStore,
 };
-use crate::{InputQueueType, StateError};
+use crate::{InputQueueType, OutputRequest, StateError};
 pub use execution_state::{EmbedderCache, ExecutionState, ExportedFunctions};
 use ic_config::embedders::Config as HypervisorConfig;
 use ic_interfaces::execution_environment::{
@@ -22,7 +22,7 @@ use ic_management_canister_types_private::{
     SnapshotVisibility,
 };
 use ic_registry_subnet_type::SubnetType;
-use ic_types::messages::{CanisterMessage, Ingress, Request, RequestOrResponse, Response};
+use ic_types::messages::{CallbackId, CanisterMessage, Ingress, RequestOrResponse, Response};
 use ic_types::methods::{SystemMethod, WasmMethod};
 use ic_types::{
     CanisterId, CanisterLog, ComputeAllocation, MemoryAllocation, NumBytes, NumInstructions,
@@ -325,10 +325,10 @@ impl CanisterState {
     /// See `SystemState::push_output_request` for documentation.
     pub fn push_output_request(
         &mut self,
-        msg: Arc<Request>,
+        request: OutputRequest,
         time: Time,
-    ) -> Result<(), (StateError, Arc<Request>)> {
-        self.system_state.push_output_request(msg, time)
+    ) -> Result<CallbackId, StateError> {
+        self.system_state.push_output_request(request, time)
     }
 
     /// See `SystemState::push_output_response` for documentation.

--- a/rs/replicated_state/src/canister_state/queues.rs
+++ b/rs/replicated_state/src/canister_state/queues.rs
@@ -21,14 +21,13 @@ use crate::{
 };
 use ic_base_types::PrincipalId;
 use ic_error_types::RejectCode;
-use ic_interfaces::execution_environment::MessageMemoryUsage;
 use ic_management_canister_types_private::IC_00;
 use ic_protobuf::state::queues::v1 as pb_queues;
 use ic_types::messages::{
     CallbackId, Ingress, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, Payload, RejectContext, Request,
     RequestOrResponse, Response,
 };
-use ic_types::{CanisterId, CountBytes, NumBytes, Time};
+use ic_types::{CanisterId, CountBytes, Time};
 use ic_types_cycles::Cycles;
 use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;
@@ -1961,27 +1960,6 @@ pub fn can_push(
             }
         }
         RequestOrResponse::Response(_) => Ok(()),
-    }
-}
-
-/// Returns the guaranteed response and best-effort memory used by `req` if
-/// enqueued into an input or output queue.
-///
-/// Best-effort requests use `req.count_bytes()` worth of best-effort memory.
-/// Guaranteed response requests use the maximum of `MAX_RESPONSE_COUNT_BYTES`
-/// (reservation for the largest possible response) and `req.count_bytes()` (if
-/// larger).
-pub fn memory_usage_of_request(req: &Request) -> MessageMemoryUsage {
-    if req.is_best_effort() {
-        MessageMemoryUsage {
-            guaranteed_response: NumBytes::new(0),
-            best_effort: (req.count_bytes() as u64).into(),
-        }
-    } else {
-        MessageMemoryUsage {
-            guaranteed_response: (req.count_bytes().max(MAX_RESPONSE_COUNT_BYTES) as u64).into(),
-            best_effort: NumBytes::new(0),
-        }
     }
 }
 

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -2689,12 +2689,13 @@ pub mod testing {
         };
     }
 
+    /// Builder for `OutputRequest`, for use in tests.
     pub struct OutputRequestBuilder {
         request: OutputRequest,
     }
 
     impl Default for OutputRequestBuilder {
-        /// Creates a dummy Request message with default values.
+        /// Creates an `OutputRequestBuilder`` with default values.
         fn default() -> Self {
             let name = "No-Op";
             fn prepayment<T: ic_types_cycles::CyclesUseCaseKind>() -> CompoundCycles<T> {
@@ -2728,37 +2729,31 @@ pub mod testing {
             Default::default()
         }
 
-        /// Sets the `receiver` field.
         pub fn receiver(mut self, receiver: CanisterId) -> Self {
             self.request.receiver = receiver;
             self
         }
 
-        /// Sets the `sender` field.
         pub fn sender(mut self, sender: CanisterId) -> Self {
             self.request.sender = sender;
             self
         }
 
-        /// Sets the `payment` field.
         pub fn payment(mut self, payment: Cycles) -> Self {
             self.request.payment = payment;
             self
         }
 
-        /// Sets the `method_name` field.
         pub fn method_name<S: ToString>(mut self, method_name: S) -> Self {
             self.request.method_name = method_name.to_string();
             self
         }
 
-        /// Sets the `method_payload` field.
         pub fn method_payload(mut self, method_payload: Vec<u8>) -> Self {
             self.request.method_payload = method_payload;
             self
         }
 
-        /// Sets the `deadline` field.
         pub fn deadline(mut self, deadline: ic_types::time::CoarseTime) -> Self {
             self.request.deadline = deadline;
             self
@@ -2787,6 +2782,7 @@ pub mod testing {
             self.request.prepayment_for_call_transmission = prepayment;
             self
         }
+
         /// Returns the built `OutputRequest`.
         pub fn build(self) -> OutputRequest {
             self.request

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -10,9 +10,9 @@ use self::{
     log_memory_store::LogMemoryStore,
     wasm_chunk_store::{WasmChunkStore, WasmChunkStoreMetadata},
 };
+pub use super::queues::CanisterOutputQueuesIterator;
 use super::queues::refunds::RefundPool;
 use super::queues::{CanisterInput, can_push};
-pub use super::queues::{CanisterOutputQueuesIterator, memory_usage_of_request};
 use crate::metadata_state::subnet_call_context_manager::InstallCodeCallId;
 use crate::page_map::PageAllocatorFileDescriptor;
 use crate::replicated_state::MR_SYNTHETIC_REJECT_MESSAGE_MAX_LEN;
@@ -25,7 +25,7 @@ use ic_base_types::{EnvironmentVariables, NumSeconds};
 use ic_config::execution_environment::LOG_MEMORY_STORE_FEATURE;
 use ic_config::flag_status::FlagStatus;
 use ic_error_types::RejectCode;
-use ic_interfaces::execution_environment::HypervisorError;
+use ic_interfaces::execution_environment::{HypervisorError, MessageMemoryUsage};
 use ic_logger::{ReplicaLogger, error};
 use ic_management_canister_types_private::{
     CanisterChange, CanisterChangeDetails, CanisterChangeOrigin, CanisterStatusType,
@@ -36,24 +36,27 @@ use ic_types::batch::TotalQueryStats;
 use ic_types::ingress::WasmResult;
 use ic_types::messages::{
     CallContextId, CallbackId, CanisterCall, CanisterMessage, CanisterMessageOrTask, CanisterTask,
-    Ingress, NO_DEADLINE, Payload, RejectContext, Request, RequestMetadata, RequestOrResponse,
-    Response, SenderInfo, StopCanisterCallId, StopCanisterContext,
+    Ingress, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, Payload, RejectContext, Request,
+    RequestMetadata, RequestOrResponse, Response, SenderInfo, StopCanisterCallId,
+    StopCanisterContext,
 };
 use ic_types::methods::{Callback, WasmClosure};
 use ic_types::time::{CoarseTime, UNIX_EPOCH};
 use ic_types::{
-    CanisterId, CanisterLog, CanisterTimer, ComputeAllocation, MemoryAllocation, NumBytes,
-    NumInstructions, PrincipalId, Time,
+    CanisterId, CanisterLog, CanisterTimer, ComputeAllocation, CountBytes, MemoryAllocation,
+    NumBytes, NumInstructions, PrincipalId, Time,
 };
 use ic_types_cycles::{
     CanisterCyclesCostSchedule, CompoundCycles, Cycles, CyclesUseCase, CyclesUseCaseKind,
-    CyclesUseCaseRefundableKind, IngressInduction, Instructions, NominalCycles, Uninstall,
+    CyclesUseCaseRefundableKind, IngressInduction, Instructions, NominalCycles,
+    RequestAndResponseTransmission, Uninstall,
 };
 use ic_validate_eq::ValidateEq;
 use ic_validate_eq_derive::ValidateEq;
 use lazy_static::lazy_static;
 use maplit::btreeset;
 use prometheus::IntCounter;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
@@ -68,6 +71,131 @@ lazy_static! {
 
 /// Maximum number of canister changes stored in the canister history.
 pub const MAX_CANISTER_HISTORY_CHANGES: u64 = 20;
+
+/// A bundle of outgoing inter-canister `Request and matching `Callback`.
+///
+/// A `Request` and its `Callback` share several fields (destination, payment,
+/// deadline). And the request's `sender_reply_callback` cannot be known until
+/// the callback has actually been registered. `OutputRequest` holds the union
+/// of the distinct fields exactly once, and produces both the `Callback` (via
+/// [`OutputRequest::to_callback`]) and, once a `CallbackId` has been assigned,
+/// the `Request` (via [`OutputRequest::into_request`]).
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct OutputRequest {
+    // Fields shared by `Request` and `Callback`.
+    /// The destination canister (`Request::receiver` / `Callback::respondent`).
+    pub receiver: CanisterId,
+    /// Cycles attached to the request (`Request::payment` /
+    /// `Callback::cycles_sent`).
+    pub payment: Cycles,
+    /// If non-zero, this is a best-effort call (`Request::deadline` /
+    /// `Callback::deadline`).
+    pub deadline: CoarseTime,
+
+    // `Request`-only fields.
+    pub sender: CanisterId,
+    pub method_name: String,
+    pub method_payload: Vec<u8>,
+    pub metadata: RequestMetadata,
+
+    // `Callback`-only fields.
+    pub call_context_id: CallContextId,
+    pub prepayment_for_response_execution: CompoundCycles<Instructions>,
+    pub prepayment_for_response_transmission: CompoundCycles<RequestAndResponseTransmission>,
+    pub prepayment_for_call_transmission: CompoundCycles<RequestAndResponseTransmission>,
+    pub on_reply: WasmClosure,
+    pub on_reject: WasmClosure,
+    pub on_cleanup: Option<WasmClosure>,
+}
+
+impl OutputRequest {
+    /// Returns `true` if this is a best-effort call (i.e. if it has a non-zero
+    /// deadline).
+    pub fn is_best_effort(&self) -> bool {
+        self.deadline != NO_DEADLINE
+    }
+
+    /// Returns the size of the user-controlled part of the eventual `Request`,
+    /// in bytes.
+    ///
+    /// Mirrors `Request::payload_size_bytes()`.
+    pub fn payload_size_bytes(&self) -> NumBytes {
+        let payload_size_bytes =
+            NumBytes::from((self.method_name.len() + self.method_payload.len()) as u64);
+        debug_assert_eq!(
+            payload_size_bytes,
+            self.clone().into_request(0.into()).payload_size_bytes()
+        );
+        payload_size_bytes
+    }
+
+    /// Returns the byte size of the eventual `Request`.
+    ///
+    /// Mirrors `Request::count_bytes()`.
+    pub fn count_bytes(&self) -> usize {
+        let count_bytes = std::mem::size_of::<RequestOrResponse>()
+            + std::mem::size_of::<Request>()
+            + self.payload_size_bytes().get() as usize;
+        debug_assert_eq!(
+            count_bytes,
+            self.clone().into_request(0.into()).count_bytes()
+        );
+        count_bytes
+    }
+
+    /// Returns the guaranteed response and best-effort memory used by the eventual
+    /// `Request` if enqueued into an input or output queue.
+    ///
+    /// Best-effort requests use `self.count_bytes()` worth of best-effort memory.
+    /// Guaranteed response requests use the maximum of `MAX_RESPONSE_COUNT_BYTES`
+    /// (reservation for the largest possible response) and `self.count_bytes()`
+    pub fn message_memory_usage(&self) -> MessageMemoryUsage {
+        let count_bytes = self.count_bytes();
+        if self.is_best_effort() {
+            MessageMemoryUsage {
+                guaranteed_response: NumBytes::new(0),
+                best_effort: (count_bytes as u64).into(),
+            }
+        } else {
+            MessageMemoryUsage {
+                guaranteed_response: (count_bytes.max(MAX_RESPONSE_COUNT_BYTES) as u64).into(),
+                best_effort: NumBytes::new(0),
+            }
+        }
+    }
+
+    /// Builds the `Callback` that the response to this request should be routed
+    /// to.
+    fn to_callback(&self) -> Callback {
+        Callback {
+            call_context_id: self.call_context_id,
+            respondent: self.receiver,
+            cycles_sent: self.payment,
+            prepayment_for_response_execution: self.prepayment_for_response_execution,
+            prepayment_for_response_transmission: self.prepayment_for_response_transmission,
+            prepayment_for_call_transmission: self.prepayment_for_call_transmission,
+            on_reply: self.on_reply.clone(),
+            on_reject: self.on_reject.clone(),
+            on_cleanup: self.on_cleanup.clone(),
+            deadline: self.deadline,
+        }
+    }
+
+    /// Consumes `self`, producing the `Request` with the given (already registered)
+    /// `sender_reply_callback`.
+    pub fn into_request(self, sender_reply_callback: CallbackId) -> Request {
+        Request {
+            receiver: self.receiver,
+            sender: self.sender,
+            sender_reply_callback,
+            payment: self.payment,
+            method_name: self.method_name,
+            method_payload: self.method_payload,
+            metadata: self.metadata,
+            deadline: self.deadline,
+        }
+    }
+}
 
 #[derive(PartialEq)]
 enum ConsumingCycles {
@@ -1000,10 +1128,7 @@ impl SystemState {
 
     /// Registers a callback and returns its ID. Returns an error if the canister is
     /// `Stopped`.
-    //
-    // TODO: Check whether this could be done implicitly, when pushing an outbound
-    // request.
-    pub fn register_callback(&mut self, callback: Callback) -> Result<CallbackId, StateError> {
+    fn register_callback(&mut self, callback: Callback) -> Result<CallbackId, StateError> {
         Ok(call_context_manager_mut(&mut self.status)
             .ok_or(StateError::CanisterStopped(self.canister_id))?
             .register_callback(callback))
@@ -1020,33 +1145,42 @@ impl SystemState {
             .unregister_callback(callback_id))
     }
 
-    /// Pushes a `Request` type message into the relevant output queue.
-    /// This is preceded by withdrawing the cycles for sending the `Request` and
-    /// receiving and processing the corresponding `Response`.
-    /// If cycles withdrawal succeeds, the function also reserves a slot on the
-    /// matching input queue for the `Response`.
+    /// Atomically registers the `Callback` carried by the given `OutputRequest` and
+    /// enqueues the `Request` (with the resulting `CallbackId`) onto the relevant
+    /// output queue.
     ///
-    /// # Errors
-    ///
-    /// Returns a `QueueFull` error along with the provided message if either
-    /// the output queue or the matching input queue is full.
+    /// Returns the assigned `CallbackId` on success. Returns an error if the
+    /// canister is `Stopped` (callback cannot be registered); or if the output or
+    /// matching input queue is full.
     pub fn push_output_request(
         &mut self,
-        msg: Arc<Request>,
+        request: OutputRequest,
         time: Time,
-    ) -> Result<(), (StateError, Arc<Request>)> {
+    ) -> Result<CallbackId, StateError> {
         assert_eq!(
-            msg.sender, self.canister_id,
+            request.sender, self.canister_id,
             "Expected `Request` to have been sent by canister ID {}, but instead got {}",
-            self.canister_id, msg.sender
+            self.canister_id, request.sender
         );
-        self.queues.push_output_request(msg, time)
+
+        let callback = request.to_callback();
+        let callback_id = self.register_callback(callback)?;
+        let request = request.into_request(callback_id);
+        let result = self.queues.push_output_request(request.into(), time);
+        match result {
+            Ok(()) => Ok(callback_id),
+            Err((err, _msg)) => {
+                self.unregister_callback(callback_id)?;
+                Err(err)
+            }
+        }
     }
 
-    /// See documentation for [`CanisterQueues::reject_subnet_output_request`].
+    /// Atomically registers the `Callback` carried by the given `OutputRequest` and
+    /// enqueues a matching reject response with the given `RejectContext`.
     pub fn reject_subnet_output_request(
         &mut self,
-        request: Request,
+        request: OutputRequest,
         reject_context: RejectContext,
         subnet_ids: &BTreeSet<PrincipalId>,
     ) -> Result<(), StateError> {
@@ -1055,8 +1189,16 @@ impl SystemState {
             "Expected `Request` to have been sent from canister ID {}, but instead got {}",
             self.canister_id, request.sender
         );
-        self.queues
-            .reject_subnet_output_request(request, reject_context, subnet_ids)
+        let callback = request.to_callback();
+        let callback_id = self.register_callback(callback)?;
+        let request = request.into_request(callback_id);
+        let result = self
+            .queues
+            .reject_subnet_output_request(request, reject_context, subnet_ids);
+        if result.is_err() {
+            self.unregister_callback(callback_id)?;
+        }
+        result
     }
 
     /// Returns the number of output requests that can be pushed onto the queue
@@ -2545,5 +2687,109 @@ pub mod testing {
             next_snapshot_id: Default::default(),
             environment_variables: Default::default(),
         };
+    }
+
+    pub struct OutputRequestBuilder {
+        request: OutputRequest,
+    }
+
+    impl Default for OutputRequestBuilder {
+        /// Creates a dummy Request message with default values.
+        fn default() -> Self {
+            let name = "No-Op";
+            fn prepayment<T: ic_types_cycles::CyclesUseCaseKind>() -> CompoundCycles<T> {
+                CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal)
+            }
+
+            Self {
+                request: OutputRequest {
+                    receiver: 0.into(),
+                    payment: Cycles::zero(),
+                    deadline: NO_DEADLINE,
+                    sender: 1.into(),
+                    method_name: name.to_string(),
+                    method_payload: Vec::new(),
+                    metadata: Default::default(),
+                    call_context_id: 2.into(),
+                    prepayment_for_response_execution: prepayment(),
+                    prepayment_for_response_transmission: prepayment(),
+                    prepayment_for_call_transmission: prepayment(),
+                    on_reply: ic_types::methods::WasmClosure::new(0, 0),
+                    on_reject: ic_types::methods::WasmClosure::new(0, 0),
+                    on_cleanup: None,
+                },
+            }
+        }
+    }
+
+    impl OutputRequestBuilder {
+        /// Creates a new `RequestBuilder`.
+        pub fn new() -> Self {
+            Default::default()
+        }
+
+        /// Sets the `receiver` field.
+        pub fn receiver(mut self, receiver: CanisterId) -> Self {
+            self.request.receiver = receiver;
+            self
+        }
+
+        /// Sets the `sender` field.
+        pub fn sender(mut self, sender: CanisterId) -> Self {
+            self.request.sender = sender;
+            self
+        }
+
+        /// Sets the `payment` field.
+        pub fn payment(mut self, payment: Cycles) -> Self {
+            self.request.payment = payment;
+            self
+        }
+
+        /// Sets the `method_name` field.
+        pub fn method_name<S: ToString>(mut self, method_name: S) -> Self {
+            self.request.method_name = method_name.to_string();
+            self
+        }
+
+        /// Sets the `method_payload` field.
+        pub fn method_payload(mut self, method_payload: Vec<u8>) -> Self {
+            self.request.method_payload = method_payload;
+            self
+        }
+
+        /// Sets the `deadline` field.
+        pub fn deadline(mut self, deadline: ic_types::time::CoarseTime) -> Self {
+            self.request.deadline = deadline;
+            self
+        }
+
+        pub fn prepayment_for_response_execution(
+            mut self,
+            prepayment: CompoundCycles<Instructions>,
+        ) -> Self {
+            self.request.prepayment_for_response_execution = prepayment;
+            self
+        }
+
+        pub fn prepayment_for_response_transmission(
+            mut self,
+            prepayment: CompoundCycles<RequestAndResponseTransmission>,
+        ) -> Self {
+            self.request.prepayment_for_response_transmission = prepayment;
+            self
+        }
+
+        pub fn prepayment_for_call_transmission(
+            mut self,
+            prepayment: CompoundCycles<RequestAndResponseTransmission>,
+        ) -> Self {
+            self.request.prepayment_for_call_transmission = prepayment;
+            self
+        }
+        /// Returns the built `OutputRequest`.
+        pub fn build(self) -> OutputRequest {
+            self.request
+        }
     }
 }

--- a/rs/replicated_state/src/canister_state/system_state.rs
+++ b/rs/replicated_state/src/canister_state/system_state.rs
@@ -72,7 +72,7 @@ lazy_static! {
 /// Maximum number of canister changes stored in the canister history.
 pub const MAX_CANISTER_HISTORY_CHANGES: u64 = 20;
 
-/// A bundle of outgoing inter-canister `Request and matching `Callback`.
+/// A bundle of outgoing inter-canister `Request` and matching `Callback`.
 ///
 /// A `Request` and its `Callback` share several fields (destination, payment,
 /// deadline). And the request's `sender_reply_callback` cannot be known until
@@ -2695,7 +2695,7 @@ pub mod testing {
     }
 
     impl Default for OutputRequestBuilder {
-        /// Creates an `OutputRequestBuilder`` with default values.
+        /// Creates an `OutputRequestBuilder` with default values.
         fn default() -> Self {
             let name = "No-Op";
             fn prepayment<T: ic_types_cycles::CyclesUseCaseKind>() -> CompoundCycles<T> {
@@ -2724,7 +2724,7 @@ pub mod testing {
     }
 
     impl OutputRequestBuilder {
-        /// Creates a new `RequestBuilder`.
+        /// Creates a new `OutputRequestBuilder`.
         pub fn new() -> Self {
             Default::default()
         }

--- a/rs/replicated_state/src/canister_state/tests.rs
+++ b/rs/replicated_state/src/canister_state/tests.rs
@@ -5,10 +5,8 @@ use crate::CallContext;
 use crate::CallOrigin;
 use crate::Memory;
 use crate::canister_state::canister_snapshots::CanisterSnapshots;
-use crate::canister_state::execution_state::CustomSection;
-use crate::canister_state::execution_state::CustomSectionType;
-use crate::canister_state::execution_state::WasmMetadata;
-use crate::canister_state::system_state::testing::SystemStateTesting;
+use crate::canister_state::execution_state::{CustomSection, CustomSectionType, WasmMetadata};
+use crate::canister_state::system_state::testing::{OutputRequestBuilder, SystemStateTesting};
 use crate::canister_state::system_state::{
     CallContextManager, CanisterHistory, CanisterStatus, MAX_CANISTER_HISTORY_CHANGES,
 };
@@ -66,14 +64,12 @@ fn default_input_response(callback_id: CallbackId, deadline: CoarseTime) -> Resp
         .build()
 }
 
-fn default_output_request() -> Arc<Request> {
-    Arc::new(
-        RequestBuilder::default()
-            .sender(CANISTER_ID)
-            .receiver(OTHER_CANISTER_ID)
-            .payment(Cycles::new(3))
-            .build(),
-    )
+fn default_output_request() -> OutputRequest {
+    OutputRequestBuilder::default()
+        .sender(CANISTER_ID)
+        .receiver(OTHER_CANISTER_ID)
+        .payment(Cycles::new(3))
+        .build()
 }
 
 fn mock_metrics() -> IntCounter {
@@ -110,37 +106,10 @@ impl CanisterStateFixture {
     }
 
     fn make_callback_to(&mut self, respondent: CanisterId, deadline: CoarseTime) -> CallbackId {
-        let call_context_id = self
-            .canister_state
-            .system_state
-            .new_call_context(
-                CallOrigin::CanisterUpdate(
-                    CANISTER_ID,
-                    CallbackId::from(1),
-                    NO_DEADLINE,
-                    String::from(""),
-                ),
-                Cycles::zero(),
-                Time::from_nanos_since_unix_epoch(0),
-                Default::default(),
-                None,
-            )
-            .unwrap();
         self.canister_state
             .system_state
-            .register_callback(Callback::new(
-                call_context_id,
-                respondent,
-                Cycles::zero(),
-                CompoundCycles::new(Cycles::new(42), CanisterCyclesCostSchedule::Normal),
-                CompoundCycles::new(Cycles::new(84), CanisterCyclesCostSchedule::Normal),
-                CompoundCycles::new(Cycles::new(168), CanisterCyclesCostSchedule::Normal),
-                WasmClosure::new(0, 2),
-                WasmClosure::new(0, 2),
-                None,
-                deadline,
-            ))
-            .unwrap()
+            .with_callback(respondent, deadline)
+            .0
     }
 
     fn push_input(
@@ -324,7 +293,7 @@ fn canister_state_push_input_guaranteed_response_no_matching_callback() {
     // Reserve a slot in the input queue.
     fixture.with_input_slot_reservation();
     // Pushing an input response with a mismatched callback should fail.
-    let response = default_input_response(CallbackId::from(1), NO_DEADLINE).into();
+    let response = default_input_response(CallbackId::from(13), NO_DEADLINE).into();
     assert_matches!(
         fixture.push_input(
             response,
@@ -344,7 +313,7 @@ fn canister_state_push_input_best_effort_response_no_matching_callback() {
     // Reserve a slot in the input queue.
     fixture.with_input_slot_reservation();
     // Push a best-effort input response with a nonexistent callback.
-    let response = default_input_response(CallbackId::from(1), SOME_DEADLINE).into();
+    let response = default_input_response(CallbackId::from(13), SOME_DEADLINE).into();
     assert!(
         !fixture
             .push_input(
@@ -483,31 +452,28 @@ fn canister_state_induct_messages_to_self_best_effort_duplicate_of_paused_respon
 fn canister_state_induct_messages_to_self_duplicate_of_paused_response(deadline: CoarseTime) {
     let mut fixture = CanisterStateFixture::new();
 
-    // Pair of request and response to self.
-    let callback_id = fixture.make_callback_to(CANISTER_ID, deadline);
-    let request = RequestBuilder::default()
+    // Request to self.
+    let request = OutputRequestBuilder::default()
         .sender(CANISTER_ID)
         .receiver(CANISTER_ID)
-        .sender_reply_callback(callback_id)
         .deadline(deadline)
         .payment(Cycles::new(2))
         .build();
-    let response = ResponseBuilder::default()
-        .originator(CANISTER_ID)
-        .respondent(CANISTER_ID)
-        .originator_reply_callback(callback_id)
-        .deadline(deadline)
-        .refund(Cycles::new(1))
-        .build();
 
     // Make two input queue slot reservations (for response and duplicate).
+    let mut callback_id = None;
     for _ in 0..2 {
-        fixture
-            .canister_state
-            .push_output_request(request.clone().into(), UNIX_EPOCH)
-            .unwrap();
+        callback_id = Some(
+            fixture
+                .canister_state
+                .push_output_request(request.clone(), UNIX_EPOCH)
+                .unwrap(),
+        );
         fixture.pop_output().unwrap();
     }
+    // Convert the `OutputRequest` to a `Request`.
+    let callback_id = callback_id.unwrap();
+    let request = request.into_request(callback_id);
 
     // And an output queue slot reservation, for the duplicate.
     assert!(
@@ -522,6 +488,13 @@ fn canister_state_induct_messages_to_self_duplicate_of_paused_response(deadline:
     fixture.canister_state.pop_input().unwrap();
 
     // Enqueue the inbound response.
+    let response = ResponseBuilder::default()
+        .originator(CANISTER_ID)
+        .respondent(CANISTER_ID)
+        .originator_reply_callback(callback_id)
+        .deadline(deadline)
+        .refund(Cycles::new(1))
+        .build();
     assert!(
         fixture
             .push_input(
@@ -811,7 +784,9 @@ fn canister_state_push_output_request_mismatched_sender() {
     fixture
         .canister_state
         .push_output_request(
-            Arc::new(RequestBuilder::default().sender(OTHER_CANISTER_ID).build()),
+            OutputRequestBuilder::default()
+                .sender(OTHER_CANISTER_ID)
+                .build(),
             UNIX_EPOCH,
         )
         .unwrap();

--- a/rs/replicated_state/src/canister_states/tests.rs
+++ b/rs/replicated_state/src/canister_states/tests.rs
@@ -3,7 +3,7 @@ use crate::canister_state::canister_snapshots::CanisterSnapshots;
 use crate::canister_state::execution_state::{
     CustomSection, CustomSectionType, WasmBinary, WasmMetadata,
 };
-use crate::canister_state::system_state::testing::SystemStateTesting;
+use crate::canister_state::system_state::testing::{OutputRequestBuilder, SystemStateTesting};
 use crate::{
     CallContextManager, CanisterState, CanisterStatus, ExecutionState, ExecutionTask,
     ExportedFunctions, InputQueueType, Memory, SchedulerState, SystemState,
@@ -13,11 +13,11 @@ use ic_management_canister_types_private::{CanisterChangeDetails, CanisterChange
 use ic_registry_subnet_type::SubnetType;
 use ic_test_utilities_types::ids::canister_test_id;
 use ic_test_utilities_types::messages::RequestBuilder;
-use ic_types::messages::{CallContextId, NO_DEADLINE, RequestOrResponse};
-use ic_types::methods::{Callback, SystemMethod, WasmClosure, WasmMethod};
+use ic_types::messages::{NO_DEADLINE, RequestOrResponse};
+use ic_types::methods::{SystemMethod, WasmMethod};
 use ic_types::time::{CoarseTime, UNIX_EPOCH};
 use ic_types::{CanisterTimer, ComputeAllocation, NumBytes, NumInstructions, Time};
-use ic_types_cycles::{CanisterCyclesCostSchedule, CompoundCycles, Cycles};
+use ic_types_cycles::Cycles;
 use ic_wasm_types::CanisterModule;
 use maplit::{btreemap, btreeset};
 use std::sync::Arc;
@@ -61,12 +61,12 @@ fn push_input_with_deadline(canister: &mut Arc<CanisterState>, deadline: CoarseT
 }
 
 fn push_output(canister: &mut Arc<CanisterState>) {
-    let msg = RequestBuilder::default()
+    let request = OutputRequestBuilder::default()
         .sender(canister.canister_id())
         .receiver(canister_test_id(999))
         .build();
     Arc::make_mut(canister)
-        .push_output_request(Arc::new(msg), UNIX_EPOCH)
+        .push_output_request(request, UNIX_EPOCH)
         .unwrap();
 }
 
@@ -91,12 +91,12 @@ fn cold_canister(id: u64) -> Arc<CanisterState> {
 fn cold_canister_with_guaranteed_response_reservation(id: u64) -> Arc<CanisterState> {
     let mut canister = make_canister(id);
     // Push an output request, making an input queue slot reservation.
-    let request = ic_test_utilities_types::messages::RequestBuilder::default()
+    let request = crate::testing::OutputRequestBuilder::default()
         .sender(canister.canister_id())
         .receiver(canister_test_id(999))
         .build();
     Arc::make_mut(&mut canister)
-        .push_output_request(Arc::new(request), UNIX_EPOCH)
+        .push_output_request(request, UNIX_EPOCH)
         .unwrap();
     // Drain the output queue to leave only the reservation behind.
     let _ = Arc::make_mut(&mut canister).output_into_iter().count();
@@ -824,20 +824,7 @@ fn cold_canister_with_guaranteed_response_reservation_is_aggregated() {
 
 #[test]
 fn callback_count_combines_hot_and_cold() {
-    fn make_callback(deadline: CoarseTime) -> Callback {
-        Callback::new(
-            CallContextId::from(1),
-            canister_test_id(999),
-            Cycles::zero(),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::zero(), CanisterCyclesCostSchedule::Normal),
-            WasmClosure::new(0, 0),
-            WasmClosure::new(0, 0),
-            None,
-            deadline,
-        )
-    }
+    let callee = canister_test_id(999);
 
     // A canister with only guaranteed-response (never-expiring) callbacks is
     // still cold by definition (see `CanisterState::is_cold`), which lets us
@@ -845,20 +832,17 @@ fn callback_count_combines_hot_and_cold() {
     let mut cold = cold_canister(1);
     Arc::make_mut(&mut cold)
         .system_state
-        .register_callback(make_callback(NO_DEADLINE))
-        .unwrap();
+        .with_callback(callee, NO_DEADLINE);
     assert!(cold.is_cold());
 
     // A hot canister with two callbacks (one guaranteed, one best-effort).
     let mut hot = hot_canister(2);
     Arc::make_mut(&mut hot)
         .system_state
-        .register_callback(make_callback(NO_DEADLINE))
-        .unwrap();
+        .with_callback(callee, NO_DEADLINE);
     Arc::make_mut(&mut hot)
         .system_state
-        .register_callback(make_callback(CoarseTime::from_secs_since_unix_epoch(1)))
-        .unwrap();
+        .with_callback(callee, CoarseTime::from_secs_since_unix_epoch(1));
     assert!(!hot.is_cold());
 
     let mut states = CanisterStates::default();

--- a/rs/replicated_state/src/lib.rs
+++ b/rs/replicated_state/src/lib.rs
@@ -69,7 +69,7 @@ pub use canister_state::{
     num_bytes_try_from,
     system_state::{
         CallContext, CallContextAction, CallContextManager, CallOrigin, CanisterMetrics,
-        CanisterStatus, ExecutionTask, SystemState, memory_usage_of_request,
+        CanisterStatus, ExecutionTask, OutputRequest, SystemState,
     },
 };
 pub use canister_states::CanisterStates;
@@ -110,6 +110,7 @@ pub trait DroppedMessageMetrics {
 }
 
 pub mod testing {
+    pub use super::canister_state::system_state::testing::OutputRequestBuilder;
     pub use super::canister_state::system_state::testing::SystemStateTesting;
     pub use super::canister_state::testing::CanisterQueuesTesting;
     pub use super::metadata_state::testing::StreamTesting;

--- a/rs/replicated_state/tests/canister_state.rs
+++ b/rs/replicated_state/tests/canister_state.rs
@@ -1,20 +1,18 @@
 use assert_matches::assert_matches;
 use ic_base_types::CanisterId;
 use ic_registry_subnet_type::SubnetType;
-use ic_replicated_state::{CanisterState, InputQueueType, StateError};
-use ic_test_utilities_state::{
-    get_running_canister, get_stopped_canister, get_stopping_canister, register_callback,
-};
+use ic_replicated_state::testing::OutputRequestBuilder;
+use ic_replicated_state::{CanisterState, InputQueueType, OutputRequest, StateError};
+use ic_test_utilities_state::{get_running_canister, get_stopped_canister, get_stopping_canister};
 use ic_test_utilities_types::{
     ids::canister_test_id,
     messages::{RequestBuilder, ResponseBuilder},
 };
 use ic_types::{
     Time,
-    messages::{CallbackId, NO_DEADLINE, Request, RequestOrResponse},
+    messages::{CallbackId, NO_DEADLINE, RequestOrResponse},
     time::{CoarseTime, UNIX_EPOCH},
 };
-use std::sync::Arc;
 
 const CANISTER_ID: CanisterId = CanisterId::from_u64(0);
 const OTHER_CANISTER_ID: CanisterId = CanisterId::from_u64(1);
@@ -40,11 +38,10 @@ fn default_input_response(callback_id: CallbackId) -> RequestOrResponse {
     input_response_from(OTHER_CANISTER_ID, callback_id)
 }
 
-fn output_request_to(canister_id: CanisterId, callback_id: CallbackId) -> Request {
-    RequestBuilder::new()
+fn output_request_to(canister_id: CanisterId) -> OutputRequest {
+    OutputRequestBuilder::new()
         .sender(CANISTER_ID)
         .receiver(canister_id)
-        .sender_reply_callback(callback_id)
         .build()
 }
 
@@ -88,9 +85,8 @@ impl CanisterFixture {
         )
     }
 
-    fn push_output_request(&mut self, request: Request) -> Result<(), (StateError, Arc<Request>)> {
-        self.canister_state
-            .push_output_request(request.into(), UNIX_EPOCH)
+    fn push_output_request(&mut self, request: OutputRequest) -> Result<CallbackId, StateError> {
+        self.canister_state.push_output_request(request, UNIX_EPOCH)
     }
 
     fn pop_output(&mut self) -> Option<RequestOrResponse> {
@@ -99,10 +95,8 @@ impl CanisterFixture {
     }
 
     fn with_input_slot_reservation(&mut self) -> CallbackId {
-        let callback_id =
-            register_callback(&mut self.canister_state, OTHER_CANISTER_ID, NO_DEADLINE);
-
-        self.push_output_request(output_request_to(OTHER_CANISTER_ID, callback_id))
+        let callback_id = self
+            .push_output_request(output_request_to(OTHER_CANISTER_ID))
             .unwrap();
         self.pop_output().unwrap();
 
@@ -202,21 +196,15 @@ fn validate_responses_against_callback_details() {
     let canister_b_id = canister_test_id(13);
     let canister_c_id = canister_test_id(17);
 
-    // Creating the CallContext and registering the callback for a request from this canister -> canister B.
-    let callback_id_1 = register_callback(&mut fixture.canister_state, canister_b_id, NO_DEADLINE);
-
-    // Creating the CallContext and registering the callback for a request from this canister -> canister C.
-    let callback_id_2 = register_callback(&mut fixture.canister_state, canister_c_id, NO_DEADLINE);
-
     // Reserving slots in the input queue for the corresponding responses.
     // Request from this canister to canister B.
-    fixture
-        .push_output_request(output_request_to(canister_b_id, callback_id_1))
+    let callback_id_1 = fixture
+        .push_output_request(output_request_to(canister_b_id))
         .unwrap();
     fixture.pop_output();
     // Request from this canister to canister C.
-    fixture
-        .push_output_request(output_request_to(canister_c_id, callback_id_2))
+    let callback_id_2 = fixture
+        .push_output_request(output_request_to(canister_c_id))
         .unwrap();
     fixture.pop_output();
 
@@ -261,16 +249,14 @@ fn validate_responses_against_callback_details() {
 
 #[test]
 fn validate_response_fails_with_mismatching_deadline() {
-    const CALLBACK_ID: CallbackId = CallbackId::new(123);
     const DEADLINE_1: CoarseTime = CoarseTime::from_secs_since_unix_epoch(13);
     const DEADLINE_2: CoarseTime = CoarseTime::from_secs_since_unix_epoch(17);
 
-    // Creates a request with the given deadline.
-    fn output_request(deadline: CoarseTime) -> Request {
-        RequestBuilder::new()
+    // Creates an `OutputRequest` with the given deadline.
+    fn output_request(deadline: CoarseTime) -> OutputRequest {
+        OutputRequestBuilder::new()
             .sender(CANISTER_ID)
             .receiver(OTHER_CANISTER_ID)
-            .sender_reply_callback(CALLBACK_ID)
             .deadline(deadline)
             .build()
     }
@@ -283,16 +269,8 @@ fn validate_response_fails_with_mismatching_deadline() {
     ) -> Result<bool, StateError> {
         let mut fixture = CanisterFixture::running();
 
-        // Register a callback with the given `callback_deadline`.
-        let callback_id = register_callback(
-            &mut fixture.canister_state,
-            OTHER_CANISTER_ID,
-            callback_deadline,
-        );
-
-        // Push and pop an output request with the same `callback_deadline`, to reserve
-        // a slot.
-        fixture
+        // Push and pop an output request, to reserve a slot.
+        let callback_id = fixture
             .push_output_request(output_request(callback_deadline))
             .unwrap();
         fixture.pop_output().unwrap();

--- a/rs/replicated_state/tests/replicated_state.rs
+++ b/rs/replicated_state/tests/replicated_state.rs
@@ -12,10 +12,12 @@ use ic_management_canister_types_private::{
 use ic_registry_routing_table::{CANISTER_IDS_PER_SUBNET, CanisterIdRange, RoutingTable};
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::{
-    CanisterState, ExecutionTask, IngressHistoryState, InputSource, ReplicatedState,
+    CanisterState, ExecutionTask, IngressHistoryState, InputSource, OutputRequest, ReplicatedState,
     SchedulerState, StateError, SystemState,
-    canister_state::canister_snapshots::{CanisterSnapshot, CanisterSnapshots},
-    canister_state::execution_state::{CustomSection, CustomSectionType, WasmMetadata},
+    canister_state::{
+        canister_snapshots::{CanisterSnapshot, CanisterSnapshots},
+        execution_state::{CustomSection, CustomSectionType, WasmMetadata},
+    },
     metadata_state::{
         subnet_call_context_manager::{
             BitcoinGetSuccessorsContext, BitcoinSendTransactionInternalContext, InstallCodeCallId,
@@ -27,7 +29,9 @@ use ic_replicated_state::{
         MemoryTaken, PeekableOutputIterator, ReplicatedStateMessageRouting,
         testing::ReplicatedStateTesting,
     },
-    testing::{CanisterQueuesTesting, FakeDropMessageMetrics, SystemStateTesting},
+    testing::{
+        CanisterQueuesTesting, FakeDropMessageMetrics, OutputRequestBuilder, SystemStateTesting,
+    },
 };
 use ic_test_utilities_state::{ExecutionStateBuilder, arb_replicated_state_with_output_queues};
 use ic_test_utilities_types::ids::{SUBNET_1, canister_test_id, message_test_id, user_test_id};
@@ -174,13 +178,13 @@ impl ReplicatedStateFixture {
 
     fn push_output_request(
         &mut self,
-        request: Request,
+        request: OutputRequest,
         time: Time,
-    ) -> Result<(), (StateError, Arc<Request>)> {
+    ) -> Result<CallbackId, StateError> {
         self.state
             .canister_state_make_mut(&CANISTER_ID)
             .unwrap()
-            .push_output_request(request.into(), time)
+            .push_output_request(request, time)
     }
 
     fn push_output_response(&mut self, response: Response) {
@@ -901,15 +905,13 @@ fn time_out_messages_updates_subnet_input_schedules_correctly() {
     // - one to a another local canister.
     // - one to a remote canister.
     let remote_canister_id = CanisterId::from_u64(123);
-    for (i, receiver) in [CANISTER_ID, OTHER_CANISTER_ID, remote_canister_id]
-        .iter()
-        .enumerate()
-    {
-        let mut request = Request {
-            payment: Cycles::new(13),
-            ..best_effort_request_to(*receiver)
-        };
-        request.sender_reply_callback = CallbackId::from(i as u64);
+    for receiver in [CANISTER_ID, OTHER_CANISTER_ID, remote_canister_id] {
+        let request = OutputRequestBuilder::default()
+            .sender(CANISTER_ID)
+            .receiver(receiver)
+            .payment(Cycles::new(13))
+            .deadline(SOME_DEADLINE)
+            .build();
         fixture.push_output_request(request, UNIX_EPOCH).unwrap();
     }
 

--- a/rs/replicated_state/tests/system_state.rs
+++ b/rs/replicated_state/tests/system_state.rs
@@ -86,14 +86,14 @@ impl SystemStateFixture {
         }
     }
 
-    fn to_stopping(&mut self) {
+    fn set_stopping(&mut self) {
         self.system_state.set_status(CanisterStatus::Stopping {
             call_context_manager: self.system_state.call_context_manager().unwrap().clone(),
             stop_contexts: Vec::default(),
         });
     }
 
-    fn to_stopped(&mut self) {
+    fn set_stopped(&mut self) {
         self.system_state.set_status(CanisterStatus::Stopped);
     }
 
@@ -245,7 +245,7 @@ fn induct_messages_to_self_in_stopped_status_does_not_work() {
         .push_output_request(default_request_to_self())
         .unwrap();
 
-    fixture.to_stopped();
+    fixture.set_stopped();
     fixture.induct_messages_to_self();
 
     assert!(!fixture.system_state.has_input());
@@ -259,7 +259,7 @@ fn induct_messages_to_self_in_stopping_status_does_not_work() {
         .push_output_request(default_request_to_self())
         .unwrap();
 
-    fixture.to_stopping();
+    fixture.set_stopping();
     fixture.induct_messages_to_self();
 
     assert!(!fixture.system_state.has_input());
@@ -349,12 +349,6 @@ fn induct_messages_to_self_memory_limit_test_impl(
         CANISTER_ID,
         CoarseTime::from_secs_since_unix_epoch(deadline),
     );
-
-    // let second_request = OutputRequestBuilder::default()
-    //     .sender(CANISTER_ID)
-    //     .receiver(CANISTER_ID)
-    //     .deadline(CoarseTime::from_secs_since_unix_epoch(deadline))
-    //     .build();
 
     fixture
         .system_state
@@ -527,7 +521,7 @@ fn simulate_outbound_call(
     // Reserve a response slot.
     fixture.pop_output().unwrap();
 
-    (response, callback.into())
+    (response, callback)
 }
 
 #[test]

--- a/rs/replicated_state/tests/system_state.rs
+++ b/rs/replicated_state/tests/system_state.rs
@@ -223,6 +223,19 @@ fn correct_charging_target_canister_for_a_response() {
 }
 
 #[test]
+fn push_output_request_in_stopped_status_does_not_work() {
+    let mut fixture = SystemStateFixture::running();
+    fixture.set_stopped();
+
+    assert_matches!(
+        fixture.push_output_request(default_request_to_self()),
+        Err(StateError::CanisterStopped(CANISTER_ID))
+    );
+
+    assert!(!fixture.system_state.queues().has_output());
+}
+
+#[test]
 fn induct_messages_to_self_in_running_status_works() {
     let mut fixture = SystemStateFixture::running();
 

--- a/rs/replicated_state/tests/system_state.rs
+++ b/rs/replicated_state/tests/system_state.rs
@@ -4,14 +4,19 @@ use ic_error_types::RejectCode;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::canister_state::DEFAULT_QUEUE_CAPACITY;
 use ic_replicated_state::canister_state::system_state::PausedExecutionId;
-use ic_replicated_state::testing::{CanisterQueuesTesting, SystemStateTesting};
-use ic_replicated_state::{CanisterStates, ExecutionTask, InputQueueType, StateError, SystemState};
+use ic_replicated_state::testing::{
+    CanisterQueuesTesting, OutputRequestBuilder, SystemStateTesting,
+};
+use ic_replicated_state::{
+    CanisterStates, CanisterStatus, ExecutionTask, InputQueueType, OutputRequest, StateError,
+    SystemState,
+};
 use ic_test_utilities_types::ids::{canister_test_id, user_test_id};
 use ic_test_utilities_types::messages::{RequestBuilder, ResponseBuilder};
 use ic_types::CanisterId;
 use ic_types::messages::{
-    CanisterMessage, CanisterMessageOrTask, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE, Payload,
-    RejectContext, Request, RequestOrResponse, Response,
+    CallbackId, CanisterMessage, CanisterMessageOrTask, MAX_RESPONSE_COUNT_BYTES, NO_DEADLINE,
+    Payload, RejectContext, RequestOrResponse, Response,
 };
 use ic_types::methods::Callback;
 use ic_types::time::{CoarseTime, UNIX_EPOCH};
@@ -57,13 +62,12 @@ fn default_output_response() -> Arc<Response> {
         .into()
 }
 
-fn default_request_to_self() -> Arc<Request> {
-    RequestBuilder::default()
+fn default_request_to_self() -> OutputRequest {
+    OutputRequestBuilder::default()
         .sender(CANISTER_ID)
         .receiver(CANISTER_ID)
         .payment(Cycles::new(3))
         .build()
-        .into()
 }
 
 struct SystemStateFixture {
@@ -82,46 +86,30 @@ impl SystemStateFixture {
         }
     }
 
-    fn stopping() -> SystemStateFixture {
-        SystemStateFixture {
-            system_state: SystemState::new_stopping_for_testing(
-                CANISTER_ID,
-                user_test_id(1).get(),
-                Cycles::new(5_000_000_000_000),
-                NumSeconds::new(0),
-            ),
-        }
+    fn to_stopping(&mut self) {
+        self.system_state.set_status(CanisterStatus::Stopping {
+            call_context_manager: self.system_state.call_context_manager().unwrap().clone(),
+            stop_contexts: Vec::default(),
+        });
     }
 
-    fn stopped() -> SystemStateFixture {
-        SystemStateFixture {
-            system_state: SystemState::new_stopped_for_testing(
-                CANISTER_ID,
-                user_test_id(1).get(),
-                Cycles::new(5_000_000_000_000),
-                NumSeconds::new(0),
-            ),
-        }
+    fn to_stopped(&mut self) {
+        self.system_state.set_status(CanisterStatus::Stopped);
     }
 
-    /// Produces a request and response pair for a call to `callee`, backed by a
-    /// registered callback.
-    fn prepare_call(
+    fn issue_outbound_call(
         &mut self,
         callee: CanisterId,
         deadline: CoarseTime,
-    ) -> (Arc<Request>, Arc<Response>, Arc<Callback>) {
-        // Register a callback.
-        let (callback_id, callback) = self.system_state.with_callback(callee, deadline);
-
-        let request = RequestBuilder::default()
+    ) -> (Arc<Response>, Arc<Callback>) {
+        let request = OutputRequestBuilder::default()
             .sender(CANISTER_ID)
             .receiver(callee)
-            .sender_reply_callback(callback_id)
             .deadline(deadline)
             .payment(Cycles::new(10))
-            .build()
-            .into();
+            .build();
+        let callback_id = self.push_output_request(request).unwrap();
+
         let response = ResponseBuilder::default()
             .respondent(callee)
             .originator(CANISTER_ID)
@@ -130,7 +118,11 @@ impl SystemStateFixture {
             .refund(Cycles::new(5))
             .build()
             .into();
-        (request, response, callback)
+
+        let call_context_manager = self.system_state.call_context_manager().unwrap();
+        let callback = call_context_manager.callback(callback_id).unwrap().clone();
+
+        (response, callback.into())
     }
 
     fn push_input(
@@ -151,10 +143,7 @@ impl SystemStateFixture {
         self.system_state.push_output_response(response);
     }
 
-    fn push_output_request(
-        &mut self,
-        request: Arc<Request>,
-    ) -> Result<(), (StateError, Arc<Request>)> {
+    fn push_output_request(&mut self, request: OutputRequest) -> Result<CallbackId, StateError> {
         self.system_state.push_output_request(request, UNIX_EPOCH)
     }
 
@@ -237,7 +226,11 @@ fn correct_charging_target_canister_for_a_response() {
 fn induct_messages_to_self_in_running_status_works() {
     let mut fixture = SystemStateFixture::running();
 
-    let (request_to_self, _, _) = fixture.prepare_call(CANISTER_ID, NO_DEADLINE);
+    let request_to_self = OutputRequestBuilder::default()
+        .sender(CANISTER_ID)
+        .receiver(CANISTER_ID)
+        .deadline(NO_DEADLINE)
+        .build();
     fixture.push_output_request(request_to_self).unwrap();
     fixture.induct_messages_to_self();
 
@@ -247,11 +240,12 @@ fn induct_messages_to_self_in_running_status_works() {
 
 #[test]
 fn induct_messages_to_self_in_stopped_status_does_not_work() {
-    let mut fixture = SystemStateFixture::stopped();
-
+    let mut fixture = SystemStateFixture::running();
     fixture
         .push_output_request(default_request_to_self())
         .unwrap();
+
+    fixture.to_stopped();
     fixture.induct_messages_to_self();
 
     assert!(!fixture.system_state.has_input());
@@ -260,11 +254,12 @@ fn induct_messages_to_self_in_stopped_status_does_not_work() {
 
 #[test]
 fn induct_messages_to_self_in_stopping_status_does_not_work() {
-    let mut fixture = SystemStateFixture::stopping();
-
+    let mut fixture = SystemStateFixture::running();
     fixture
         .push_output_request(default_request_to_self())
         .unwrap();
+
+    fixture.to_stopping();
     fixture.induct_messages_to_self();
 
     assert!(!fixture.system_state.has_input());
@@ -327,18 +322,12 @@ fn induct_messages_to_self_memory_limit_test_impl(
 ) {
     let mut fixture = SystemStateFixture::running();
 
-    // One guaranteed response self-call response and one self-call request.
-    let (request0, response, callback) = fixture.prepare_call(CANISTER_ID, NO_DEADLINE);
-    let (request, _, _) = fixture.prepare_call(CANISTER_ID, NO_DEADLINE);
-
-    // A second request that might exceed the available memory (if guaranteed
-    // response; and on an application subnet).
-    let (second_request, _, _) = fixture.prepare_call(
-        CANISTER_ID,
-        CoarseTime::from_secs_since_unix_epoch(deadline),
-    );
-
-    // Make a slot reservation for `response``.
+    // Simulate issuing and inducting a guaranteed-response self-call.
+    let (response, callback) = fixture.issue_outbound_call(CANISTER_ID, NO_DEADLINE);
+    let RequestOrResponse::Request(request0) = fixture.pop_output().unwrap() else {
+        panic!("Expected a request");
+    };
+    // Induct the request and pop it.
     assert_eq!(
         Ok(None),
         fixture.push_input(
@@ -350,11 +339,22 @@ fn induct_messages_to_self_memory_limit_test_impl(
 
     // Pushing an outgoing response will release `MAX_RESPONSE_COUNT_BYTES`.
     fixture.push_output_response(response.clone());
+
     // So there should be memory for this request.
-    fixture.push_output_request(request.clone()).unwrap();
+    fixture.issue_outbound_call(CANISTER_ID, NO_DEADLINE);
+
     // But potentially not for this one (if guaranteed response; and on an
     // application subnet).
-    fixture.push_output_request(second_request.clone()).unwrap();
+    fixture.issue_outbound_call(
+        CANISTER_ID,
+        CoarseTime::from_secs_since_unix_epoch(deadline),
+    );
+
+    // let second_request = OutputRequestBuilder::default()
+    //     .sender(CANISTER_ID)
+    //     .receiver(CANISTER_ID)
+    //     .deadline(CoarseTime::from_secs_since_unix_epoch(deadline))
+    //     .build();
 
     fixture
         .system_state
@@ -365,21 +365,15 @@ fn induct_messages_to_self_memory_limit_test_impl(
         Some(CanisterMessage::Response { response, callback }),
         fixture.pop_input(),
     );
-    assert_eq!(Some(CanisterMessage::Request(request)), fixture.pop_input(),);
+    assert_matches!(fixture.pop_input(), Some(CanisterMessage::Request(_)));
 
     if should_enforce_limit {
         assert_eq!(None, fixture.pop_input());
 
         // Expect the second request to still be in the output queue.
-        assert_eq!(
-            Some(RequestOrResponse::Request(second_request)),
-            fixture.pop_output(),
-        );
+        assert_matches!(fixture.pop_output(), Some(RequestOrResponse::Request(_)));
     } else {
-        assert_eq!(
-            Some(CanisterMessage::Request(second_request)),
-            fixture.pop_input()
-        );
+        assert_matches!(fixture.pop_input(), Some(CanisterMessage::Request(_)));
     }
 
     // Expect both the input and the output queues to be empty.
@@ -392,25 +386,16 @@ fn induct_messages_to_self_memory_limit_test_impl(
 fn induct_messages_to_self_full_queue() {
     let mut fixture = SystemStateFixture::running();
 
-    // Push`DEFAULT_QUEUE_CAPACITY` requests.
-    let mut requests = Vec::new();
+    // Enqueue `DEFAULT_QUEUE_CAPACITY` outbound requests to self.
     for _ in 0..DEFAULT_QUEUE_CAPACITY {
-        let (request, _, _) = fixture.prepare_call(CANISTER_ID, NO_DEADLINE);
-        requests.push(request.clone());
-        assert_eq!(
-            Ok(None),
-            fixture.push_input(
-                RequestOrResponse::Request(request),
-                InputQueueType::LocalSubnet,
-            )
-        );
+        fixture.issue_outbound_call(CANISTER_ID, NO_DEADLINE);
     }
 
     fixture.induct_messages_to_self();
 
     // Expect all requests to have been inducted.
-    for request in requests {
-        assert_eq!(Some(CanisterMessage::Request(request)), fixture.pop_input());
+    for _ in 0..DEFAULT_QUEUE_CAPACITY {
+        assert_matches!(fixture.pop_input(), Some(CanisterMessage::Request(_)));
     }
 
     assert_eq!(None, fixture.pop_input());
@@ -426,17 +411,14 @@ fn induct_messages_to_self_full_queue() {
 fn induct_messages_to_self_duplicate_best_effort_response() {
     let mut fixture = SystemStateFixture::running();
 
-    let (request, response, callback) = fixture.prepare_call(CANISTER_ID, SOME_DEADLINE);
-
-    // Enqueue the outgoing request.
-    fixture.push_output_request(request.clone()).unwrap();
+    let (response, callback) = fixture.issue_outbound_call(CANISTER_ID, SOME_DEADLINE);
 
     // Induct it into the input queue.
     fixture.induct_messages_to_self();
 
     // Pop and start executing it (pretend it's waiting multiple rounds for
     // downstream calls).
-    assert_eq!(Some(CanisterMessage::Request(request)), fixture.pop_input());
+    assert_matches!(fixture.pop_input(), Some(CanisterMessage::Request(_)));
 
     // Expire the callback.
     assert_eq!(
@@ -475,17 +457,14 @@ fn induct_messages_to_self_duplicate_best_effort_response() {
 fn induct_messages_to_self_best_effort_callback_gone() {
     let mut fixture = SystemStateFixture::running();
 
-    let (request, response, _) = fixture.prepare_call(CANISTER_ID, SOME_DEADLINE);
-
-    // Enqueue the outgoing request.
-    fixture.push_output_request(request.clone()).unwrap();
+    let (response, _) = fixture.issue_outbound_call(CANISTER_ID, SOME_DEADLINE);
 
     // Induct it into the input queue.
     fixture.induct_messages_to_self();
 
     // Pop and start executing it (pretend it's waiting multiple rounds for
     // downstream calls).
-    assert_eq!(Some(CanisterMessage::Request(request)), fixture.pop_input());
+    assert_matches!(fixture.pop_input(), Some(CanisterMessage::Request(_)));
 
     // Expire the callback.
     fixture.time_out_callbacks(CoarseTime::from_secs_since_unix_epoch(u32::MAX));
@@ -517,17 +496,14 @@ fn induct_messages_to_self_best_effort_callback_gone() {
 fn induct_messages_to_self_guaranteed_response_callback_gone() {
     let mut fixture = SystemStateFixture::running();
 
-    let (request, response, _) = fixture.prepare_call(CANISTER_ID, NO_DEADLINE);
+    let (response, _) = fixture.issue_outbound_call(CANISTER_ID, NO_DEADLINE);
     let callback = response.originator_reply_callback;
-
-    // Enqueue the outgoing request.
-    fixture.push_output_request(request.clone()).unwrap();
 
     // Induct it into the input queue.
     fixture.induct_messages_to_self();
 
     // Pop and execute it, producing a response.
-    assert_eq!(Some(CanisterMessage::Request(request)), fixture.pop_input());
+    assert_matches!(fixture.pop_input(), Some(CanisterMessage::Request(_)));
     fixture.push_output_response(response.clone());
 
     // Pretend that a duplicate response has consumed the callback.
@@ -546,13 +522,12 @@ fn simulate_outbound_call(
     fixture: &mut SystemStateFixture,
     deadline: CoarseTime,
 ) -> (Arc<Response>, Arc<Callback>) {
-    let (request, response, callback) = fixture.prepare_call(OTHER_CANISTER_ID, deadline);
+    let (response, callback) = fixture.issue_outbound_call(OTHER_CANISTER_ID, deadline);
 
     // Reserve a response slot.
-    fixture.push_output_request(request).unwrap();
     fixture.pop_output().unwrap();
 
-    (response, callback)
+    (response, callback.into())
 }
 
 #[test]

--- a/rs/test_utilities/state/src/lib.rs
+++ b/rs/test_utilities/state/src/lib.rs
@@ -32,19 +32,17 @@ use ic_test_utilities_types::{
     ids::{canister_test_id, message_test_id, node_test_id, subnet_test_id, user_test_id},
     messages::{RequestBuilder, SignedIngressBuilder},
 };
-use ic_types::time::{CoarseTime, UNIX_EPOCH};
+use ic_types::time::UNIX_EPOCH;
 use ic_types::{
     CanisterId, ComputeAllocation, MemoryAllocation, NodeId, NumBytes, PrincipalId, SubnetId, Time,
     batch::RawQueryStats,
-    messages::{CallbackId, Ingress, Request, RequestOrResponse},
-    methods::{Callback, WasmClosure},
+    messages::{Ingress, Request, RequestOrResponse},
     xnet::{
         RejectReason, RejectSignal, StreamFlags, StreamHeader, StreamIndex, StreamIndexedQueue,
     },
 };
 use ic_types_cycles::{
-    CanisterCyclesCostSchedule, CompoundCycles, Cycles, CyclesUseCase, NominalCycles,
-    NominalCyclesTesting,
+    CanisterCyclesCostSchedule, Cycles, CyclesUseCase, NominalCycles, NominalCyclesTesting,
 };
 use ic_wasm_types::CanisterModule;
 use proptest::prelude::*;
@@ -850,40 +848,6 @@ pub fn new_canister_state_with_execution(
         scheduler_state,
         canister_snapshots,
     )
-}
-
-/// Helper function to register a callback.
-pub fn register_callback(
-    canister_state: &mut CanisterState,
-    respondent: CanisterId,
-    deadline: CoarseTime,
-) -> CallbackId {
-    let call_context_id = canister_state
-        .system_state
-        .new_call_context(
-            CallOrigin::SystemTask,
-            Cycles::zero(),
-            Time::from_nanos_since_unix_epoch(0),
-            Default::default(),
-            None,
-        )
-        .unwrap();
-
-    canister_state
-        .system_state
-        .register_callback(Callback::new(
-            call_context_id,
-            respondent,
-            Cycles::zero(),
-            CompoundCycles::new(Cycles::new(42), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::new(84), CanisterCyclesCostSchedule::Normal),
-            CompoundCycles::new(Cycles::new(168), CanisterCyclesCostSchedule::Normal),
-            WasmClosure::new(0, 2),
-            WasmClosure::new(0, 2),
-            None,
-            deadline,
-        ))
-        .unwrap()
 }
 
 /// Helper function to insert a canister in the provided `ReplicatedState`.


### PR DESCRIPTION
Encapsulate `Request` enqueueing and `Callback` registration within `SystemState`. We already have `pop_output()` returning a `(Response, Callback)` tuple. This change addresses the other end: atomic `Callback` creation while enqueuing an outbound `Request`.

There is still a gap in `unregister_callback()`, which is public to allow Execution to unregister unreplicated (only) query callbacks. Other than that, `Callbacks` are now atomically registered and unregistered when `Requests` are enqueued and `Responses` are dequeued.