### PR TITLE
feat(node-rewards): reward type4.5 nodes as type1.1

### DIFF
--- a/rs/node_rewards/canister/src/registry_querier.rs
+++ b/rs/node_rewards/canister/src/registry_querier.rs
@@ -206,6 +206,13 @@ impl RegistryQuerier {
             let node_reward_type =
                 NodeRewardType::try_from(some_reward_type).expect("Invalid node_reward_type value");
 
+            // type4.5 nodes are rewarded as type1.1 nodes.
+            let node_reward_type = if node_reward_type == NodeRewardType::Type4dot5 {
+                NodeRewardType::Type1dot1
+            } else {
+                node_reward_type
+            };
+
             rewardable_nodes_per_provider
                 .entry(node_provider_id)
                 .or_default()

--- a/rs/node_rewards/canister/src/registry_querier/tests.rs
+++ b/rs/node_rewards/canister/src/registry_querier/tests.rs
@@ -309,6 +309,31 @@ fn test_node_re_registered_after_deletion() {
 }
 
 #[test]
+fn test_type4dot5_nodes_rewarded_as_type1dot1() {
+    let node_id = 5;
+    let no_id = 10;
+    let np_id = 20;
+
+    let (node_k, node_v) = generate_node_key_value(node_id, NodeRewardType::Type4dot5, no_id);
+    add_record_helper(&node_k, 39678, Some(node_v), "2025-07-17");
+
+    let client = client_for_tests();
+
+    let rewardables = client
+        .get_rewardable_nodes_per_provider(&to_native_date("2025-07-17"), None)
+        .unwrap()
+        .remove(&PrincipalId::new_user_test_id(np_id))
+        .unwrap();
+
+    let node = rewardables
+        .iter()
+        .find(|n| n.node_id == NodeId::from(PrincipalId::new_node_test_id(node_id)))
+        .expect("type4.5 node should be rewardable");
+
+    assert_eq!(node.node_reward_type, NodeRewardType::Type1dot1);
+}
+
+#[test]
 fn test_get_subnet_record_returns_correct_type() {
     let client = client_for_tests();
     let app_subnet: SubnetId = PrincipalId::new_subnet_test_id(10).into();


### PR DESCRIPTION
## What

Make nodes with `NodeRewardType::Type4dot5` (type4.5) be rewarded exactly as `NodeRewardType::Type1dot1` (type1.1).

## How

Minimal change in `registry_querier.rs`: right after deriving `node_reward_type` from the registry node record, remap `Type4dot5` to `Type1dot1` before constructing the `RewardableNode`. Since the whole reward calculation keys off `RewardableNode.node_reward_type` (base-rate lookup, type grouping, and per-node reporting), this single remap makes type4.5 nodes behave as type1.1 everywhere.

Note: this also changes the *reported* `node_reward_type` for those nodes to type1.1.

## Tests

Added `test_type4dot5_nodes_rewarded_as_type1dot1` to the registry querier tests, asserting a registered type4.5 node surfaces as type1.1 in the rewardable nodes.

```
//rs/node_rewards/canister:nrc_test ... PASSED
test registry_querier::tests::test_type4dot5_nodes_rewarded_as_type1dot1 ... ok
```