### PR TITLE
feat: Allow engine controller canister to create and delete subnets

### DIFF
--- a/rs/nns/constants/src/lib.rs
+++ b/rs/nns/constants/src/lib.rs
@@ -178,7 +178,7 @@ pub const SNS_AGGREGATOR_CANISTER_ID: CanisterId =
 ///
 /// As of May 2024, it looks like this is only used by (a whole bunch of) tests, mostly as the
 /// argument to send_whitelist.
-pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 18] = [
+pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 19] = [
     &REGISTRY_CANISTER_ID,
     &GOVERNANCE_CANISTER_ID,
     &LEDGER_CANISTER_ID,
@@ -197,9 +197,10 @@ pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 18] = [
     &ICP_LEDGER_ARCHIVE_3_CANISTER_ID,
     &NODE_REWARDS_CANISTER_ID,
     &MIGRATION_CANISTER_ID,
+    &ENGINE_CONTROLLER_CANISTER_ID,
 ];
 
-pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 23] = [
+pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 24] = [
     &REGISTRY_CANISTER_ID,
     &GOVERNANCE_CANISTER_ID,
     &LEDGER_CANISTER_ID,
@@ -223,6 +224,7 @@ pub const PROTOCOL_CANISTER_IDS: [&CanisterId; 23] = [
     &DOGECOIN_CANISTER_ID,
     &BITCOIN_WATCHDOG_CANISTER_ID,
     &DOGECOIN_WATCHDOG_CANISTER_ID,
+    &ENGINE_CONTROLLER_CANISTER_ID,
 ];
 
 /// The current value is 4 GiB, s.t. the SNS governance canister never hits the soft memory limit.
@@ -275,7 +277,8 @@ pub fn canister_id_to_nns_canister_name(canister_id: CanisterId) -> String {
         ROOT_CANISTER_ID                 => "root",
         SNS_WASM_CANISTER_ID             => "sns-wasm",
         SUBNET_RENTAL_CANISTER_ID        => "subnet-rental",
-        MIGRATION_CANISTER_ID            => "migration"
+        MIGRATION_CANISTER_ID            => "migration",
+        ENGINE_CONTROLLER_CANISTER_ID    => "engine-controller"
     };
     debug_assert_eq!(
         id_to_name.len(),

--- a/rs/nns/constants/src/lib.rs
+++ b/rs/nns/constants/src/lib.rs
@@ -33,6 +33,7 @@ pub const ICP_LEDGER_ARCHIVE_2_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 14;
 pub const ICP_LEDGER_ARCHIVE_3_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 15;
 pub const NODE_REWARDS_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 16;
 pub const MIGRATION_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 17;
+pub const ENGINE_CONTROLLER_CANISTER_INDEX_IN_NNS_SUBNET: u64 = 18;
 
 // Canisters belonging to the II subnet, whose ID begins with uzr34.
 pub const EXCHANGE_RATE_CANISTER_INDEX: u64 = 0x_0210_0001;
@@ -137,6 +138,9 @@ pub const NODE_REWARDS_CANISTER_ID: CanisterId =
 /// 17: sbzkb-zqaaa-aaaaa-aaaiq-cai
 pub const MIGRATION_CANISTER_ID: CanisterId =
     CanisterId::from_u64(MIGRATION_CANISTER_INDEX_IN_NNS_SUBNET);
+/// 18: si2b5-pyaaa-aaaaa-aaaja-cai
+pub const ENGINE_CONTROLLER_CANISTER_ID: CanisterId =
+    CanisterId::from_u64(ENGINE_CONTROLLER_CANISTER_INDEX_IN_NNS_SUBNET);
 /// 0x_0210_0001 (34_603_009): uf6dk-hyaaa-aaaaq-qaaaq-cai
 pub const EXCHANGE_RATE_CANISTER_ID: CanisterId =
     CanisterId::from_u64(EXCHANGE_RATE_CANISTER_INDEX);

--- a/rs/nns/constants/src/lib.rs
+++ b/rs/nns/constants/src/lib.rs
@@ -282,9 +282,9 @@ pub fn canister_id_to_nns_canister_name(canister_id: CanisterId) -> String {
     };
     debug_assert_eq!(
         id_to_name.len(),
-        // Because 0 through 14 accounts for the first 15 canister +
-        // 1 for exchange rate canister.
-        19,
+        // This must match the number of entries in the `id_to_name` map above;
+        // bump it whenever a canister is added or removed.
+        20,
         "{id_to_name:#?}"
     );
 

--- a/rs/registry/canister/canister/canister.rs
+++ b/rs/registry/canister/canister/canister.rs
@@ -8,7 +8,8 @@ use ic_base_types::{NodeId, PrincipalId};
 use ic_certified_map::{AsHashTree, HashTree};
 use ic_nervous_system_string::clamp_debug_len;
 use ic_nns_constants::{
-    GOVERNANCE_CANISTER_ID, MIGRATION_CANISTER_ID, ROOT_CANISTER_ID, SUBNET_RENTAL_CANISTER_ID,
+    ENGINE_CONTROLLER_CANISTER_ID, GOVERNANCE_CANISTER_ID, MIGRATION_CANISTER_ID, ROOT_CANISTER_ID,
+    SUBNET_RENTAL_CANISTER_ID,
 };
 use ic_protobuf::registry::{
     dc::v1::{AddOrRemoveDataCentersProposalPayload, DataCenterRecord},
@@ -128,6 +129,15 @@ fn check_caller_is_governance_and_log(method_name: &str) {
     assert_eq!(
         caller,
         GOVERNANCE_CANISTER_ID.into(),
+        "{LOG_PREFIX}Principal: {caller} is not authorized to call this method: {method_name}"
+    );
+}
+
+fn check_caller_is_governance_or_engine_controller_and_log(method_name: &str) {
+    let caller = dfn_core::api::caller();
+    println!("{LOG_PREFIX}call: {method_name} from: {caller}");
+    assert!(
+        caller == GOVERNANCE_CANISTER_ID.into() || caller == ENGINE_CONTROLLER_CANISTER_ID.into(),
         "{LOG_PREFIX}Principal: {caller} is not authorized to call this method: {method_name}"
     );
 }
@@ -624,7 +634,7 @@ fn add_node_operator_(payload: AddNodeOperatorPayload) {
 
 #[unsafe(export_name = "canister_update create_subnet")]
 fn create_subnet() {
-    check_caller_is_governance_and_log("create_subnet");
+    check_caller_is_governance_or_engine_controller_and_log("create_subnet");
     over_async(candid_one, |payload: CreateSubnetPayload| async move {
         create_subnet_(payload).await
     });
@@ -643,7 +653,7 @@ async fn create_subnet_(payload: CreateSubnetPayload) -> Result<NewSubnet, Strin
 
 #[unsafe(export_name = "canister_update delete_subnet")]
 fn delete_subnet() {
-    check_caller_is_governance_and_log("delete_subnet");
+    check_caller_is_governance_or_engine_controller_and_log("delete_subnet");
     over(candid_one, |payload: DeleteSubnetPayload| {
         delete_subnet_(payload)
     });

--- a/rs/registry/canister/tests/common/test_helpers.rs
+++ b/rs/registry/canister/tests/common/test_helpers.rs
@@ -15,11 +15,15 @@ use ic_nns_test_utils::common::{build_registry_wasm, build_test_registry_wasm};
 use ic_nns_test_utils::itest_helpers::{
     set_up_registry_canister, set_up_universal_canister, try_call_via_universal_canister,
 };
-use ic_nns_test_utils::registry::{get_value_or_panic, new_node_keys_and_node_id};
-use ic_protobuf::registry::node::v1::NodeRecord;
+use ic_nns_test_utils::registry::{
+    TEST_ID, create_subnet_threshold_signing_pubkey_and_cup_mutations, get_value_or_panic,
+    new_node_keys_and_node_id,
+};
+use ic_protobuf::registry::crypto::v1::PublicKey;
+use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
 use ic_protobuf::registry::subnet::v1::{
-    CatchUpPackageContents, ChainKeyConfig as ChainKeyConfigPb, KeyConfig as KeyConfigPb,
-    SubnetListRecord, SubnetRecord,
+    CanisterCyclesCostSchedule, CatchUpPackageContents, ChainKeyConfig as ChainKeyConfigPb,
+    KeyConfig as KeyConfigPb, SubnetListRecord, SubnetRecord,
 };
 use ic_protobuf::types::v1::MasterPublicKeyId as MasterPublicKeyIdPb;
 use ic_registry_client_fake::FakeRegistryClient;
@@ -28,9 +32,13 @@ use ic_registry_keys::{
 };
 use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
 use ic_registry_subnet_features::DEFAULT_ECDSA_MAX_QUEUE_SIZE;
+use ic_registry_subnet_type::SubnetType;
 use ic_registry_transport::pb::v1::RegistryAtomicMutateRequest;
+use ic_registry_transport::upsert;
+use ic_test_utilities_types::ids::subnet_test_id;
 use ic_types::ReplicaVersion;
 use pocket_ic::nonblocking::PocketIc;
+use prost::Message;
 use registry_canister::init::{RegistryCanisterInitPayload, RegistryCanisterInitPayloadBuilder};
 use registry_canister::mutations::do_create_subnet::CreateSubnetPayload;
 use registry_canister::mutations::node_management::common::make_add_node_registry_mutations;
@@ -194,6 +202,83 @@ pub fn prepare_registry_with_nodes_from_template(
     };
 
     (mutate_request, node_ids_and_valid_pks)
+}
+
+/// Prepares the mutations that add a CloudEngine subnet to a registry that was
+/// initialized with [`invariant_compliant_mutation_as_atomic_req`].
+///
+/// This first creates `node_count` fresh type-4 nodes (CloudEngine subnets may
+/// only contain type-4 nodes) and then a CloudEngine subnet record made up of
+/// those nodes, on the `Free` cost schedule (both required for CloudEngine
+/// subnets). The returned request is meant to be pushed as an additional init
+/// mutate request on top of the invariant-compliant base; it also returns the id
+/// of the new CloudEngine subnet.
+pub fn prepare_registry_with_cloud_engine_subnet(
+    node_count: u64,
+    starting_mutation_id: u8,
+) -> (RegistryAtomicMutateRequest, SubnetId) {
+    // CloudEngine subnets may only contain type-4 nodes (enforced by the
+    // `check_node_type4_iff_cloud_engine` invariant).
+    let node_template = NodeRecord {
+        node_operator_id: PrincipalId::new_user_test_id(999).into_vec(),
+        node_reward_type: Some(NodeRewardType::Type4 as i32),
+        ..Default::default()
+    };
+    let (nodes_request, node_ids_and_pks) =
+        prepare_registry_with_nodes_from_template(node_count, starting_mutation_id, node_template);
+    let mut mutations = nodes_request.mutations;
+
+    let node_ids_and_dkg_pks: BTreeMap<NodeId, PublicKey> = node_ids_and_pks
+        .iter()
+        .map(|(node_id, valid_pks)| (*node_id, valid_pks.dkg_dealing_encryption_key().clone()))
+        .collect();
+
+    // CloudEngine subnets are not charged cycles, i.e. they use the `Free` cost
+    // schedule.
+    let subnet_record = SubnetRecord {
+        membership: node_ids_and_pks
+            .keys()
+            .map(|node_id| node_id.get().to_vec())
+            .collect(),
+        subnet_type: i32::from(SubnetType::CloudEngine),
+        canister_cycles_cost_schedule: i32::from(CanisterCyclesCostSchedule::Free),
+        replica_version_id: ReplicaVersion::default().to_string(),
+        unit_delay_millis: 600,
+        ..Default::default()
+    };
+
+    // The invariant-compliant base contains a single system subnet (`TEST_ID`);
+    // append the new CloudEngine subnet to the subnet list.
+    let cloud_engine_subnet_id = subnet_test_id(TEST_ID + 1);
+    let subnet_list_record = SubnetListRecord {
+        subnets: vec![
+            subnet_test_id(TEST_ID).get().to_vec(),
+            cloud_engine_subnet_id.get().to_vec(),
+        ],
+    };
+
+    mutations.push(upsert(
+        make_subnet_list_record_key().as_bytes(),
+        subnet_list_record.encode_to_vec(),
+    ));
+    mutations.push(upsert(
+        make_subnet_record_key(cloud_engine_subnet_id).as_bytes(),
+        subnet_record.encode_to_vec(),
+    ));
+    mutations.append(
+        &mut create_subnet_threshold_signing_pubkey_and_cup_mutations(
+            cloud_engine_subnet_id,
+            &node_ids_and_dkg_pks,
+        ),
+    );
+
+    (
+        RegistryAtomicMutateRequest {
+            mutations,
+            preconditions: vec![],
+        },
+        cloud_engine_subnet_id,
+    )
 }
 
 fn get_added_subnets(

--- a/rs/registry/canister/tests/create_subnet.rs
+++ b/rs/registry/canister/tests/create_subnet.rs
@@ -151,7 +151,7 @@ fn test_a_canister_other_than_the_governance_canister_cannot_create_a_subnet() {
 }
 
 #[tokio::test]
-async fn test_accepted_proposal_mutates_the_registry_some_subnets_present() {
+async fn test_governance_canister_can_create_a_subnet() {
     create_subnet_succeeds_when_called_by(GOVERNANCE_CANISTER_ID.get()).await;
 }
 

--- a/rs/registry/canister/tests/create_subnet.rs
+++ b/rs/registry/canister/tests/create_subnet.rs
@@ -16,7 +16,9 @@ use ic_management_canister_types_private::{
     VetKdKeyId,
 };
 use ic_nervous_system_integration_tests::pocket_ic_helpers::nns::registry::decode_registry_value;
-use ic_nns_constants::{GOVERNANCE_CANISTER_ID, REGISTRY_CANISTER_ID};
+use ic_nns_constants::{
+    ENGINE_CONTROLLER_CANISTER_ID, GOVERNANCE_CANISTER_ID, REGISTRY_CANISTER_ID,
+};
 use ic_nns_test_utils::itest_helpers::try_call_via_universal_canister;
 use ic_nns_test_utils::{
     itest_helpers::{
@@ -150,6 +152,17 @@ fn test_a_canister_other_than_the_governance_canister_cannot_create_a_subnet() {
 
 #[tokio::test]
 async fn test_accepted_proposal_mutates_the_registry_some_subnets_present() {
+    create_subnet_succeeds_when_called_by(GOVERNANCE_CANISTER_ID.get()).await;
+}
+
+#[tokio::test]
+async fn test_engine_controller_can_create_a_subnet() {
+    create_subnet_succeeds_when_called_by(ENGINE_CONTROLLER_CANISTER_ID.get()).await;
+}
+
+/// Verifies that `caller` is authorized to call `create_subnet` and that doing
+/// so actually adds a new subnet to the registry.
+async fn create_subnet_succeeds_when_called_by(caller: PrincipalId) {
     let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
 
     let (init_mutate, node_ids) = prepare_registry_with_nodes(5, INITIAL_MUTATION_ID);
@@ -170,16 +183,16 @@ async fn test_accepted_proposal_mutates_the_registry_some_subnets_present() {
 
     let payload = make_create_subnet_payload(node_ids.clone());
 
-    // Create a subnet via governance
+    // Create a subnet via the authorized caller
     pocket_ic
         .update_call(
             REGISTRY_CANISTER_ID.get().0,
-            GOVERNANCE_CANISTER_ID.get().0,
+            caller.0,
             "create_subnet",
             Encode!(&payload).unwrap(),
         )
         .await
-        .expect("create_subnet call via governance should succeed");
+        .expect("create_subnet call by an authorized caller should succeed");
 
     // Verify a new subnet appeared in the subnet list
     let updated_subnet_list_record =

--- a/rs/registry/canister/tests/delete_subnet.rs
+++ b/rs/registry/canister/tests/delete_subnet.rs
@@ -179,6 +179,51 @@ async fn test_engine_controller_can_delete_a_cloud_engine_subnet() {
     cloud_engine_subnet_can_be_deleted_by(ENGINE_CONTROLLER_CANISTER_ID.get()).await;
 }
 
+#[tokio::test]
+async fn test_authorized_callers_cannot_delete_a_non_cloud_engine_subnet() {
+    let (pocket_ic, subnet_id) = setup_with_existing_subnet().await;
+
+    let payload = DeleteSubnetPayload { subnet_id };
+
+    // The existing subnet is a system subnet, not a CloudEngine. Even authorized
+    // callers must not be able to delete it: the call passes the authorization
+    // check but is then rejected by the business logic. Deletion fails, so the
+    // subnet is not consumed and both callers can be checked against it.
+    for caller in [
+        GOVERNANCE_CANISTER_ID.get(),
+        ENGINE_CONTROLLER_CANISTER_ID.get(),
+    ] {
+        let response = pocket_ic
+            .update_call(
+                REGISTRY_CANISTER_ID.get().0,
+                caller.0,
+                "delete_subnet",
+                Encode!(&payload).unwrap(),
+            )
+            .await
+            .unwrap_or_else(|err| {
+                panic!("delete_subnet call by authorized caller {caller} was unexpectedly rejected: {err:?}")
+            });
+
+        let result = Decode!(&response, Result<(), String>).unwrap();
+        assert_eq!(
+            result,
+            Err("Only CloudEngines may be deleted".to_string()),
+            "caller {caller} should not be able to delete a non-cloud-engine subnet"
+        );
+    }
+
+    // The subnet should still be present.
+    let subnets =
+        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
+            .await
+            .subnets;
+    assert!(
+        subnets.contains(&subnet_id.as_slice().to_vec()),
+        "the non-cloud-engine subnet should not have been deleted"
+    );
+}
+
 /// Creates a CloudEngine subnet (the only subnet type that may be deleted) and
 /// verifies that `caller` is authorized to delete it and that the subnet is
 /// actually removed from the registry.

--- a/rs/registry/canister/tests/delete_subnet.rs
+++ b/rs/registry/canister/tests/delete_subnet.rs
@@ -11,26 +11,19 @@ use ic_nns_test_utils::itest_helpers::{
 use ic_nns_test_utils::registry::{
     INITIAL_MUTATION_ID, invariant_compliant_mutation_as_atomic_req,
 };
-use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
 use ic_protobuf::registry::subnet::v1::SubnetListRecord as SubnetListRecordPb;
 use ic_registry_keys::make_subnet_list_record_key;
-use ic_registry_subnet_type::SubnetType;
-use ic_types::{NodeId, ReplicaVersion};
 use pocket_ic::PocketIcBuilder;
 use pocket_ic::nonblocking::PocketIc;
 use registry_canister::{
-    init::RegistryCanisterInitPayloadBuilder,
-    mutations::{
-        do_create_subnet::{CanisterCyclesCostSchedule, CreateSubnetPayload},
-        do_delete_subnet::DeleteSubnetPayload,
-    },
+    init::RegistryCanisterInitPayloadBuilder, mutations::do_delete_subnet::DeleteSubnetPayload,
 };
 
 mod common;
 
 use common::test_helpers::{
     get_subnet_list_record, install_registry_canister_with_payload_builder,
-    prepare_registry_with_nodes, prepare_registry_with_nodes_from_template,
+    prepare_registry_with_cloud_engine_subnet, prepare_registry_with_nodes,
 };
 
 /// Installs an invariant-compliant registry (which already contains a single,
@@ -224,68 +217,30 @@ async fn test_authorized_callers_cannot_delete_a_non_cloud_engine_subnet() {
     );
 }
 
-/// Creates a CloudEngine subnet (the only subnet type that may be deleted) and
-/// verifies that `caller` is authorized to delete it and that the subnet is
-/// actually removed from the registry.
+/// Sets up a registry that contains a CloudEngine subnet (the only subnet type
+/// that may be deleted) and verifies that `caller` is authorized to delete it
+/// and that the subnet is actually removed from the registry.
 async fn cloud_engine_subnet_can_be_deleted_by(caller: PrincipalId) {
     let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
 
-    // CloudEngine subnets may only consist of type-4 nodes (enforced by the
-    // `check_node_type4_iff_cloud_engine` invariant), so provision such nodes.
-    let node_template = NodeRecord {
-        node_operator_id: PrincipalId::new_user_test_id(999).into_vec(),
-        node_reward_type: Some(NodeRewardType::Type4 as i32),
-        ..Default::default()
-    };
-    let (init_mutate, node_ids_and_pks) =
-        prepare_registry_with_nodes_from_template(4, INITIAL_MUTATION_ID, node_template);
-    let node_ids: Vec<NodeId> = node_ids_and_pks.keys().cloned().collect();
+    let (cloud_engine_mutate, cloud_engine_subnet_id) =
+        prepare_registry_with_cloud_engine_subnet(4, INITIAL_MUTATION_ID);
 
     let mut builder = RegistryCanisterInitPayloadBuilder::new();
-    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(
-        4 + INITIAL_MUTATION_ID,
-    ));
-    builder.push_init_mutate_request(init_mutate);
+    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
+    builder.push_init_mutate_request(cloud_engine_mutate);
     install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), true).await;
 
-    let initial_subnets =
-        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
-            .await
-            .subnets;
-
-    // Create the CloudEngine subnet via governance.
-    let create_payload = make_cloud_engine_create_subnet_payload(node_ids);
-    pocket_ic
-        .update_call(
-            REGISTRY_CANISTER_ID.get().0,
-            GOVERNANCE_CANISTER_ID.get().0,
-            "create_subnet",
-            Encode!(&create_payload).unwrap(),
-        )
-        .await
-        .expect("creating a cloud engine subnet via governance should succeed");
-
-    let subnets_after_create =
-        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
-            .await
-            .subnets;
-    let added_subnets: Vec<_> = subnets_after_create
-        .iter()
-        .filter(|s| !initial_subnets.contains(s))
-        .cloned()
-        .collect();
-    assert_eq!(added_subnets.len(), 1, "expected exactly one new subnet");
-    let cloud_engine_subnet = added_subnets[0].clone();
-    let subnet_id = Principal::try_from(cloud_engine_subnet.as_slice()).unwrap();
-
     // Delete the CloudEngine subnet via the caller under test.
-    let delete_payload = DeleteSubnetPayload { subnet_id };
+    let payload = DeleteSubnetPayload {
+        subnet_id: cloud_engine_subnet_id.get().0,
+    };
     let response = pocket_ic
         .update_call(
             REGISTRY_CANISTER_ID.get().0,
             caller.0,
             "delete_subnet",
-            Encode!(&delete_payload).unwrap(),
+            Encode!(&payload).unwrap(),
         )
         .await
         .unwrap_or_else(|err| {
@@ -300,53 +255,12 @@ async fn cloud_engine_subnet_can_be_deleted_by(caller: PrincipalId) {
     );
 
     // The subnet should no longer be in the subnet list.
-    let subnets_after_delete =
+    let subnets =
         decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
             .await
             .subnets;
     assert!(
-        !subnets_after_delete.contains(&cloud_engine_subnet),
+        !subnets.contains(&cloud_engine_subnet_id.get().to_vec()),
         "the cloud engine subnet should have been removed from the subnet list"
     );
-}
-
-/// Builds a `CreateSubnetPayload` for a CloudEngine subnet. CloudEngine subnets
-/// must be on the `Free` cost schedule and consist of type-4 nodes.
-fn make_cloud_engine_create_subnet_payload(node_ids: Vec<NodeId>) -> CreateSubnetPayload {
-    CreateSubnetPayload {
-        node_ids,
-        subnet_id_override: None,
-        initial_dkg_subnet_id: None,
-        max_ingress_bytes_per_message: 60 * 1024 * 1024,
-        max_ingress_bytes_per_block: None,
-        max_ingress_messages_per_block: 1000,
-        max_block_payload_size: 4 * 1024 * 1024,
-        unit_delay_millis: 500,
-        initial_notary_delay_millis: 1500,
-        replica_version_id: ReplicaVersion::default().into(),
-        dkg_interval_length: 0,
-        dkg_dealings_per_block: 1,
-        start_as_nns: false,
-        subnet_type: SubnetType::CloudEngine,
-        is_halted: false,
-        features: Default::default(),
-        max_number_of_canisters: 0,
-        ssh_readonly_access: vec![],
-        ssh_backup_access: vec![],
-        chain_key_config: None,
-        canister_cycles_cost_schedule: Some(CanisterCyclesCostSchedule::Free),
-        subnet_admins: Some(vec![]),
-        resource_limits: Default::default(),
-
-        // Unused section follows
-        ingress_bytes_per_block_soft_cap: Default::default(),
-        gossip_max_artifact_streams_per_peer: Default::default(),
-        gossip_max_chunk_wait_ms: Default::default(),
-        gossip_max_duplicity: Default::default(),
-        gossip_max_chunk_size: Default::default(),
-        gossip_receive_check_cache_size: Default::default(),
-        gossip_pfn_evaluation_period_ms: Default::default(),
-        gossip_registry_poll_period_ms: Default::default(),
-        gossip_retransmission_request_ms: Default::default(),
-    }
 }

--- a/rs/registry/canister/tests/delete_subnet.rs
+++ b/rs/registry/canister/tests/delete_subnet.rs
@@ -1,0 +1,129 @@
+use candid::{Decode, Encode, Principal};
+use ic_base_types::PrincipalId;
+use ic_nervous_system_integration_tests::pocket_ic_helpers::nns::registry::decode_registry_value;
+use ic_nns_constants::{
+    ENGINE_CONTROLLER_CANISTER_ID, GOVERNANCE_CANISTER_ID, REGISTRY_CANISTER_ID,
+};
+use ic_nns_test_utils::registry::invariant_compliant_mutation_as_atomic_req;
+use ic_protobuf::registry::subnet::v1::SubnetListRecord as SubnetListRecordPb;
+use ic_registry_keys::make_subnet_list_record_key;
+use pocket_ic::PocketIcBuilder;
+use pocket_ic::nonblocking::PocketIc;
+use registry_canister::{
+    init::RegistryCanisterInitPayloadBuilder, mutations::do_delete_subnet::DeleteSubnetPayload,
+};
+
+mod common;
+
+use common::test_helpers::install_registry_canister_with_payload_builder;
+
+/// Installs an invariant-compliant registry (which already contains a single,
+/// non-CloudEngine subnet) and returns the running `PocketIc` together with the
+/// principal of an existing subnet that can be used as a `delete_subnet` target.
+async fn setup_with_existing_subnet() -> (PocketIc, Principal) {
+    let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
+
+    let mut builder = RegistryCanisterInitPayloadBuilder::new();
+    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(0));
+    install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), true).await;
+
+    let subnet_list_record =
+        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
+            .await;
+    let subnet_id = subnet_list_record
+        .subnets
+        .first()
+        .expect("expected the invariant-compliant registry to contain at least one subnet");
+    let subnet_id = Principal::try_from(subnet_id.as_slice()).unwrap();
+
+    (pocket_ic, subnet_id)
+}
+
+#[tokio::test]
+async fn test_the_anonymous_user_cannot_delete_a_subnet() {
+    let (pocket_ic, subnet_id) = setup_with_existing_subnet().await;
+
+    let payload = DeleteSubnetPayload { subnet_id };
+
+    // The anonymous end-user tries to delete a subnet, bypassing governance.
+    // This should be rejected by the authorization check.
+    let response = pocket_ic
+        .update_call(
+            REGISTRY_CANISTER_ID.get().0,
+            PrincipalId::new_anonymous().0,
+            "delete_subnet",
+            Encode!(&payload).unwrap(),
+        )
+        .await;
+
+    assert!(
+        response.as_ref().is_err_and(|err| err
+            .reject_message
+            .contains("is not authorized to call this method: delete_subnet")),
+        "Expected an authorization rejection, but got {response:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_an_unauthorized_canister_cannot_delete_a_subnet() {
+    let (pocket_ic, subnet_id) = setup_with_existing_subnet().await;
+
+    // A principal that is neither governance nor the engine controller.
+    let unauthorized_caller = PrincipalId::new_user_test_id(1);
+    assert_ne!(unauthorized_caller, GOVERNANCE_CANISTER_ID.get());
+    assert_ne!(unauthorized_caller, ENGINE_CONTROLLER_CANISTER_ID.get());
+
+    let payload = DeleteSubnetPayload { subnet_id };
+
+    let response = pocket_ic
+        .update_call(
+            REGISTRY_CANISTER_ID.get().0,
+            unauthorized_caller.0,
+            "delete_subnet",
+            Encode!(&payload).unwrap(),
+        )
+        .await;
+
+    assert!(
+        response.as_ref().is_err_and(|err| err
+            .reject_message
+            .contains("is not authorized to call this method: delete_subnet")),
+        "Expected an authorization rejection, but got {response:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_governance_and_engine_controller_are_authorized_to_delete_a_subnet() {
+    let (pocket_ic, subnet_id) = setup_with_existing_subnet().await;
+
+    let payload = DeleteSubnetPayload { subnet_id };
+
+    // Both governance and the engine controller are allowed to call
+    // `delete_subnet`. The existing subnet is not a CloudEngine, so the call
+    // gets past the authorization check and is then rejected by the business
+    // logic. This proves the caller is authorized without depending on a
+    // CloudEngine subnet being present.
+    for caller in [
+        GOVERNANCE_CANISTER_ID.get(),
+        ENGINE_CONTROLLER_CANISTER_ID.get(),
+    ] {
+        let response = pocket_ic
+            .update_call(
+                REGISTRY_CANISTER_ID.get().0,
+                caller.0,
+                "delete_subnet",
+                Encode!(&payload).unwrap(),
+            )
+            .await
+            .unwrap_or_else(|err| {
+                panic!("delete_subnet call by authorized caller {caller} was unexpectedly rejected: {err:?}")
+            });
+
+        let result = Decode!(&response, Result<(), String>).unwrap();
+        assert_eq!(
+            result,
+            Err("Only CloudEngines may be deleted".to_string()),
+            "caller {caller} should pass authorization and reach the business logic"
+        );
+    }
+}

--- a/rs/registry/canister/tests/delete_subnet.rs
+++ b/rs/registry/canister/tests/delete_subnet.rs
@@ -65,7 +65,7 @@ async fn test_the_anonymous_user_cannot_delete_a_subnet() {
 }
 
 #[tokio::test]
-async fn test_an_unauthorized_canister_cannot_delete_a_subnet() {
+async fn test_an_unauthorized_principal_cannot_delete_a_subnet() {
     let (pocket_ic, subnet_id) = setup_with_existing_subnet().await;
 
     // A principal that is neither governance nor the engine controller.

--- a/rs/registry/canister/tests/delete_subnet.rs
+++ b/rs/registry/canister/tests/delete_subnet.rs
@@ -4,18 +4,34 @@ use ic_nervous_system_integration_tests::pocket_ic_helpers::nns::registry::decod
 use ic_nns_constants::{
     ENGINE_CONTROLLER_CANISTER_ID, GOVERNANCE_CANISTER_ID, REGISTRY_CANISTER_ID,
 };
-use ic_nns_test_utils::registry::invariant_compliant_mutation_as_atomic_req;
+use ic_nns_test_utils::itest_helpers::{
+    forward_call_via_universal_canister, set_up_registry_canister, set_up_universal_canister,
+    state_machine_test_on_nns_subnet,
+};
+use ic_nns_test_utils::registry::{
+    INITIAL_MUTATION_ID, invariant_compliant_mutation_as_atomic_req,
+};
+use ic_protobuf::registry::node::v1::{NodeRecord, NodeRewardType};
 use ic_protobuf::registry::subnet::v1::SubnetListRecord as SubnetListRecordPb;
 use ic_registry_keys::make_subnet_list_record_key;
+use ic_registry_subnet_type::SubnetType;
+use ic_types::{NodeId, ReplicaVersion};
 use pocket_ic::PocketIcBuilder;
 use pocket_ic::nonblocking::PocketIc;
 use registry_canister::{
-    init::RegistryCanisterInitPayloadBuilder, mutations::do_delete_subnet::DeleteSubnetPayload,
+    init::RegistryCanisterInitPayloadBuilder,
+    mutations::{
+        do_create_subnet::{CanisterCyclesCostSchedule, CreateSubnetPayload},
+        do_delete_subnet::DeleteSubnetPayload,
+    },
 };
 
 mod common;
 
-use common::test_helpers::install_registry_canister_with_payload_builder;
+use common::test_helpers::{
+    get_subnet_list_record, install_registry_canister_with_payload_builder,
+    prepare_registry_with_nodes, prepare_registry_with_nodes_from_template,
+};
 
 /// Installs an invariant-compliant registry (which already contains a single,
 /// non-CloudEngine subnet) and returns the running `PocketIc` together with the
@@ -45,8 +61,8 @@ async fn test_the_anonymous_user_cannot_delete_a_subnet() {
 
     let payload = DeleteSubnetPayload { subnet_id };
 
-    // The anonymous end-user tries to delete a subnet, bypassing governance.
-    // This should be rejected by the authorization check.
+    // The anonymous end-user tries to delete a subnet via an ingress message,
+    // bypassing governance. This should be rejected by the authorization check.
     let response = pocket_ic
         .update_call(
             REGISTRY_CANISTER_ID.get().0,
@@ -68,7 +84,8 @@ async fn test_the_anonymous_user_cannot_delete_a_subnet() {
 async fn test_an_unauthorized_principal_cannot_delete_a_subnet() {
     let (pocket_ic, subnet_id) = setup_with_existing_subnet().await;
 
-    // A principal that is neither governance nor the engine controller.
+    // A principal that is neither governance nor the engine controller, calling
+    // via an ingress message.
     let unauthorized_caller = PrincipalId::new_user_test_id(1);
     assert_ne!(unauthorized_caller, GOVERNANCE_CANISTER_ID.get());
     assert_ne!(unauthorized_caller, ENGINE_CONTROLLER_CANISTER_ID.get());
@@ -92,38 +109,199 @@ async fn test_an_unauthorized_principal_cannot_delete_a_subnet() {
     );
 }
 
-#[tokio::test]
-async fn test_governance_and_engine_controller_are_authorized_to_delete_a_subnet() {
-    let (pocket_ic, subnet_id) = setup_with_existing_subnet().await;
+#[test]
+fn test_a_canister_other_than_governance_or_engine_controller_cannot_delete_a_subnet() {
+    state_machine_test_on_nns_subnet(|runtime| async move {
+        // An attacker canister tries to delete a subnet via an inter-canister
+        // call. Going through a real canister (rather than an ingress message)
+        // ensures the access control cannot be bypassed by, e.g., only guarding
+        // ingress messages in `inspect_message`.
+        let attacker_canister = set_up_universal_canister(&runtime).await;
+        // ... but it has neither the governance nor the engine controller ID.
+        assert_ne!(
+            attacker_canister.canister_id(),
+            ic_nns_constants::GOVERNANCE_CANISTER_ID
+        );
+        assert_ne!(
+            attacker_canister.canister_id(),
+            ic_nns_constants::ENGINE_CONTROLLER_CANISTER_ID
+        );
 
-    let payload = DeleteSubnetPayload { subnet_id };
+        let (init_mutate, _node_ids) = prepare_registry_with_nodes(5, INITIAL_MUTATION_ID);
+        let registry = set_up_registry_canister(
+            &runtime,
+            RegistryCanisterInitPayloadBuilder::new()
+                .push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(
+                    5 + INITIAL_MUTATION_ID,
+                ))
+                .push_init_mutate_request(init_mutate)
+                .build(),
+        )
+        .await;
 
-    // Both governance and the engine controller are allowed to call
-    // `delete_subnet`. The existing subnet is not a CloudEngine, so the call
-    // gets past the authorization check and is then rejected by the business
-    // logic. This proves the caller is authorized without depending on a
-    // CloudEngine subnet being present.
-    for caller in [
-        GOVERNANCE_CANISTER_ID.get(),
-        ENGINE_CONTROLLER_CANISTER_ID.get(),
-    ] {
-        let response = pocket_ic
-            .update_call(
-                REGISTRY_CANISTER_ID.get().0,
-                caller.0,
+        let initial_subnet_list_record = get_subnet_list_record(&registry).await;
+        let subnet_id = Principal::try_from(
+            initial_subnet_list_record
+                .subnets
+                .first()
+                .expect("expected at least one subnet")
+                .as_slice(),
+        )
+        .unwrap();
+        let payload = DeleteSubnetPayload { subnet_id };
+
+        // The attacker canister tries to delete a subnet. This should have no effect.
+        assert!(
+            !forward_call_via_universal_canister(
+                &attacker_canister,
+                &registry,
                 "delete_subnet",
-                Encode!(&payload).unwrap(),
+                Encode!(&payload).unwrap()
             )
             .await
-            .unwrap_or_else(|err| {
-                panic!("delete_subnet call by authorized caller {caller} was unexpectedly rejected: {err:?}")
-            });
-
-        let result = Decode!(&response, Result<(), String>).unwrap();
-        assert_eq!(
-            result,
-            Err("Only CloudEngines may be deleted".to_string()),
-            "caller {caller} should pass authorization and reach the business logic"
         );
+
+        // .. And the subnet list should be unchanged.
+        let subnet_list_record = get_subnet_list_record(&registry).await;
+        assert_eq!(subnet_list_record, initial_subnet_list_record);
+
+        Ok(())
+    });
+}
+
+#[tokio::test]
+async fn test_governance_canister_can_delete_a_cloud_engine_subnet() {
+    cloud_engine_subnet_can_be_deleted_by(GOVERNANCE_CANISTER_ID.get()).await;
+}
+
+#[tokio::test]
+async fn test_engine_controller_can_delete_a_cloud_engine_subnet() {
+    cloud_engine_subnet_can_be_deleted_by(ENGINE_CONTROLLER_CANISTER_ID.get()).await;
+}
+
+/// Creates a CloudEngine subnet (the only subnet type that may be deleted) and
+/// verifies that `caller` is authorized to delete it and that the subnet is
+/// actually removed from the registry.
+async fn cloud_engine_subnet_can_be_deleted_by(caller: PrincipalId) {
+    let pocket_ic = PocketIcBuilder::new().with_nns_subnet().build_async().await;
+
+    // CloudEngine subnets may only consist of type-4 nodes (enforced by the
+    // `check_node_type4_iff_cloud_engine` invariant), so provision such nodes.
+    let node_template = NodeRecord {
+        node_operator_id: PrincipalId::new_user_test_id(999).into_vec(),
+        node_reward_type: Some(NodeRewardType::Type4 as i32),
+        ..Default::default()
+    };
+    let (init_mutate, node_ids_and_pks) =
+        prepare_registry_with_nodes_from_template(4, INITIAL_MUTATION_ID, node_template);
+    let node_ids: Vec<NodeId> = node_ids_and_pks.keys().cloned().collect();
+
+    let mut builder = RegistryCanisterInitPayloadBuilder::new();
+    builder.push_init_mutate_request(invariant_compliant_mutation_as_atomic_req(
+        4 + INITIAL_MUTATION_ID,
+    ));
+    builder.push_init_mutate_request(init_mutate);
+    install_registry_canister_with_payload_builder(&pocket_ic, builder.build(), true).await;
+
+    let initial_subnets =
+        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
+            .await
+            .subnets;
+
+    // Create the CloudEngine subnet via governance.
+    let create_payload = make_cloud_engine_create_subnet_payload(node_ids);
+    pocket_ic
+        .update_call(
+            REGISTRY_CANISTER_ID.get().0,
+            GOVERNANCE_CANISTER_ID.get().0,
+            "create_subnet",
+            Encode!(&create_payload).unwrap(),
+        )
+        .await
+        .expect("creating a cloud engine subnet via governance should succeed");
+
+    let subnets_after_create =
+        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
+            .await
+            .subnets;
+    let added_subnets: Vec<_> = subnets_after_create
+        .iter()
+        .filter(|s| !initial_subnets.contains(s))
+        .cloned()
+        .collect();
+    assert_eq!(added_subnets.len(), 1, "expected exactly one new subnet");
+    let cloud_engine_subnet = added_subnets[0].clone();
+    let subnet_id = Principal::try_from(cloud_engine_subnet.as_slice()).unwrap();
+
+    // Delete the CloudEngine subnet via the caller under test.
+    let delete_payload = DeleteSubnetPayload { subnet_id };
+    let response = pocket_ic
+        .update_call(
+            REGISTRY_CANISTER_ID.get().0,
+            caller.0,
+            "delete_subnet",
+            Encode!(&delete_payload).unwrap(),
+        )
+        .await
+        .unwrap_or_else(|err| {
+            panic!("delete_subnet call by authorized caller {caller} was unexpectedly rejected: {err:?}")
+        });
+
+    let result = Decode!(&response, Result<(), String>).unwrap();
+    assert_eq!(
+        result,
+        Ok(()),
+        "authorized caller {caller} should be able to delete a cloud engine subnet"
+    );
+
+    // The subnet should no longer be in the subnet list.
+    let subnets_after_delete =
+        decode_registry_value::<SubnetListRecordPb>(&pocket_ic, make_subnet_list_record_key())
+            .await
+            .subnets;
+    assert!(
+        !subnets_after_delete.contains(&cloud_engine_subnet),
+        "the cloud engine subnet should have been removed from the subnet list"
+    );
+}
+
+/// Builds a `CreateSubnetPayload` for a CloudEngine subnet. CloudEngine subnets
+/// must be on the `Free` cost schedule and consist of type-4 nodes.
+fn make_cloud_engine_create_subnet_payload(node_ids: Vec<NodeId>) -> CreateSubnetPayload {
+    CreateSubnetPayload {
+        node_ids,
+        subnet_id_override: None,
+        initial_dkg_subnet_id: None,
+        max_ingress_bytes_per_message: 60 * 1024 * 1024,
+        max_ingress_bytes_per_block: None,
+        max_ingress_messages_per_block: 1000,
+        max_block_payload_size: 4 * 1024 * 1024,
+        unit_delay_millis: 500,
+        initial_notary_delay_millis: 1500,
+        replica_version_id: ReplicaVersion::default().into(),
+        dkg_interval_length: 0,
+        dkg_dealings_per_block: 1,
+        start_as_nns: false,
+        subnet_type: SubnetType::CloudEngine,
+        is_halted: false,
+        features: Default::default(),
+        max_number_of_canisters: 0,
+        ssh_readonly_access: vec![],
+        ssh_backup_access: vec![],
+        chain_key_config: None,
+        canister_cycles_cost_schedule: Some(CanisterCyclesCostSchedule::Free),
+        subnet_admins: Some(vec![]),
+        resource_limits: Default::default(),
+
+        // Unused section follows
+        ingress_bytes_per_block_soft_cap: Default::default(),
+        gossip_max_artifact_streams_per_peer: Default::default(),
+        gossip_max_chunk_wait_ms: Default::default(),
+        gossip_max_duplicity: Default::default(),
+        gossip_max_chunk_size: Default::default(),
+        gossip_receive_check_cache_size: Default::default(),
+        gossip_pfn_evaluation_period_ms: Default::default(),
+        gossip_registry_poll_period_ms: Default::default(),
+        gossip_retransmission_request_ms: Default::default(),
     }
 }

--- a/rs/registry/canister/unreleased_changelog.md
+++ b/rs/registry/canister/unreleased_changelog.md
@@ -25,6 +25,9 @@ on the process that this file is part of, see
 * One-time post-upgrade migration converting the reward type of 100 currently
   unassigned nodes from `type1.1` to `type4.5`. The migration only mutates nodes
   whose reward type is still `type1.1`, so it is idempotent across upgrades.
+* The `create_subnet` and `delete_subnet` endpoints can now be called by the
+  engine controller canister (`si2b5-pyaaa-aaaaa-aaaja-cai`) in addition to the
+  governance canister.
 * **SEV on existing subnets:** Reverted — `sev_enabled` can once again only be set at subnet creation;
   any update_subnet proposal that would change the effective `sev_enabled` value (in either direction,
   including via wholesale `features` replacement with `sev_enabled` left unset) is rejected.


### PR DESCRIPTION
Add ENGINE_CONTROLLER_CANISTER_ID (`si2b5-pyaaa-aaaaa-aaaja-cai`) and authorize it, alongside governance, to call the registry create_subnet and delete_subnet methods.