### PR TITLE
chore(nns): add support in release scripts for engine-controller canister

### DIFF
--- a/rs/nervous_system/tools/release-runscript/src/main.rs
+++ b/rs/nervous_system/tools/release-runscript/src/main.rs
@@ -191,6 +191,7 @@ fn run_determine_targets(cmd: DetermineTargets) -> Result<()> {
         "Genesis-Token",
         "Node-Rewards",
         "Migration",
+        "Engine-Controller",
     ];
     let sns_candidates = ["Root", "Governance", "Swap", "Index", "Ledger", "Archive"];
 

--- a/rs/nns/canister_ids.json
+++ b/rs/nns/canister_ids.json
@@ -62,5 +62,9 @@
   "migration": {
     "local": "sbzkb-zqaaa-aaaaa-aaaiq-cai",
     "mainnet": "sbzkb-zqaaa-aaaaa-aaaiq-cai"
+  },
+  "engine-controller": {
+    "local": "si2b5-pyaaa-aaaaa-aaaja-cai",
+    "mainnet": "si2b5-pyaaa-aaaaa-aaaja-cai"
   }
 }


### PR DESCRIPTION
## Why

Onboards the **engine-controller** canister (`si2b5-pyaaa-aaaaa-aaaja-cai`, NNS subnet index 18) into the NNS release tooling so that, once it is live on the NNS subnet, future upgrades can be proposed through the standard `release-runscript` flow like every other NNS canister.
