### PR TITLE
chore: CON-1441 Ignore `empty_signature_agreements_flag` in hash function

### DIFF
--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -192,9 +192,6 @@ pub struct IDkgPayload {
 
 impl Hash for IDkgPayload {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        if !self.empty_signature_agreements_flag {
-            BTreeMap::<PseudoRandomId, CompletedSignature>::new().hash(state);
-        }
         // empty_signature_agreements_flag is ignored
         self.available_pre_signatures.hash(state);
         self.pre_signatures_in_creation.hash(state);


### PR DESCRIPTION
The `IDkgPayload` used to contain a `signature_agreements` field, which is now unused and in the process of being removed. In https://github.com/dfinity/ic/pull/10326 we set the `empty_signature_agreements_flag` flag to `true` for all new `IDkgPayload`s. This means the hash of new payloads do not consider the removed `signature_agreements` field anymore. 

This change was rolled out to all subnets with proposal [142136](https://dashboard.internetcomputer.org/proposal/142136).

Now that all payloads have their flag set to true (see [metric](https://victoria.ch1-obs1.dfinity.network/select/0/vmui/#/?g0.range_input=30m&g0.end_input=2026-06-08T09%3A32%3A22&g0.relative_time=last_30_minutes&g0.tab=0&g0.tenantID=0&g0.expr=min+by+%28ic_subnet%29+%28idkg_payload_metrics%7Btype%3D%22signature_agreements_flag%22%7D%29)), we remove the flag from the hash function again. This means that the hash function will remain the same, once we remove the flag entirely from the payload in an upcoming release.