### PR TITLE
fix: remove double '-w' in container-run.sh

### DIFF
--- a/ci/container/container-run.sh
+++ b/ci/container/container-run.sh
@@ -304,4 +304,4 @@ if [ -f "$HOME/.container-run.conf" ]; then
 fi
 
 set -x
-exec "${CONTAINER_CMD[@]}" run "${RUNTIME_RUN_ARGS[@]}" -w "$WORKDIR" "$IMAGE" "${cmd[@]}"
+exec "${CONTAINER_CMD[@]}" run "${RUNTIME_RUN_ARGS[@]}" "$IMAGE" "${cmd[@]}"


### PR DESCRIPTION
The workdir option was specified twice.