### PR TITLE
feat: subnet deletion in PocketIC

### DIFF
--- a/packages/pocket-ic/CHANGELOG.md
+++ b/packages/pocket-ic/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added the `PATCH` variant to the `CanisterHttpMethod` enum (canister HTTPS outcalls). Note: `PATCH` outcalls are currently rejected by the execution layer until support has rolled out to all replicas.
+- The function `PocketIc::delete_subnet` to delete a subnet. Only non-named subnets (application, cloud engine, system, or verified application) can be deleted.
 
 ## 14.0.0 - 2026-05-26
 

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 pub type InstanceId = usize;
@@ -482,6 +483,23 @@ pub enum SubnetKind {
     VerifiedApplication,
 }
 
+impl SubnetKind {
+    pub fn is_named(self) -> bool {
+        match self {
+            SubnetKind::NNS
+            | SubnetKind::SNS
+            | SubnetKind::II
+            | SubnetKind::Fiduciary
+            | SubnetKind::Bitcoin
+            | SubnetKind::TestThresholdKeys => true,
+            SubnetKind::Application
+            | SubnetKind::CloudEngine
+            | SubnetKind::System
+            | SubnetKind::VerifiedApplication => false,
+        }
+    }
+}
+
 /// This represents which named subnets the user wants to create, and how
 /// many of the general app/system subnets, which are indistinguishable.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
@@ -805,25 +823,36 @@ impl SubnetStateConfig {
 }
 
 impl ExtendedSubnetConfigSet {
+    fn named_subnet_spec(&self, kind: SubnetKind) -> Option<SubnetSpec> {
+        match kind {
+            SubnetKind::NNS => self.nns.clone(),
+            SubnetKind::SNS => self.sns.clone(),
+            SubnetKind::II => self.ii.clone(),
+            SubnetKind::Fiduciary => self.fiduciary.clone(),
+            SubnetKind::Bitcoin => self.bitcoin.clone(),
+            SubnetKind::TestThresholdKeys => self.test_threshold_keys.clone(),
+            SubnetKind::Application
+            | SubnetKind::CloudEngine
+            | SubnetKind::System
+            | SubnetKind::VerifiedApplication => {
+                panic!(
+                    "named_subnet_spec called with non-named subnet kind {:?}",
+                    kind
+                )
+            }
+        }
+    }
+
     // Return the configured named subnets in order.
     #[allow(clippy::type_complexity)]
     pub fn get_named(&self) -> Vec<(SubnetKind, Option<PathBuf>, SubnetInstructionConfig)> {
-        use SubnetKind::*;
-        vec![
-            (self.nns.clone(), NNS),
-            (self.sns.clone(), SNS),
-            (self.ii.clone(), II),
-            (self.fiduciary.clone(), Fiduciary),
-            (self.bitcoin.clone(), Bitcoin),
-            (self.test_threshold_keys.clone(), TestThresholdKeys),
-        ]
-        .into_iter()
-        .filter(|(mb, _)| mb.is_some())
-        .map(|(mb, kind)| {
-            let spec = mb.unwrap();
-            (kind, spec.get_state_path(), spec.get_instruction_config())
-        })
-        .collect()
+        SubnetKind::iter()
+            .filter(|kind| kind.is_named())
+            .filter_map(|kind| {
+                self.named_subnet_spec(kind)
+                    .map(|spec| (kind, spec.get_state_path(), spec.get_instruction_config()))
+            })
+            .collect()
     }
 
     pub fn validate(&self) -> Result<(), String> {

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -485,7 +485,7 @@ pub enum SubnetKind {
 
 impl SubnetKind {
     pub fn is_named(self) -> bool {
-        NamedSubnet::iter().any(|n| SubnetKind::from(n) == self)
+        NamedSubnet::try_from(self).is_ok()
     }
 }
 
@@ -510,6 +510,27 @@ impl From<NamedSubnet> for SubnetKind {
             NamedSubnet::Fiduciary => SubnetKind::Fiduciary,
             NamedSubnet::Bitcoin => SubnetKind::Bitcoin,
             NamedSubnet::TestThresholdKeys => SubnetKind::TestThresholdKeys,
+        }
+    }
+}
+
+/// The exhaustive match over `SubnetKind` enforces structural consistency: adding a new
+/// `SubnetKind` variant is a compile error until it is explicitly placed in either the named
+/// or unnamed arm here and in `From<NamedSubnet> for SubnetKind`.
+impl TryFrom<SubnetKind> for NamedSubnet {
+    type Error = ();
+    fn try_from(kind: SubnetKind) -> Result<Self, Self::Error> {
+        match kind {
+            SubnetKind::NNS => Ok(NamedSubnet::NNS),
+            SubnetKind::SNS => Ok(NamedSubnet::SNS),
+            SubnetKind::II => Ok(NamedSubnet::II),
+            SubnetKind::Fiduciary => Ok(NamedSubnet::Fiduciary),
+            SubnetKind::Bitcoin => Ok(NamedSubnet::Bitcoin),
+            SubnetKind::TestThresholdKeys => Ok(NamedSubnet::TestThresholdKeys),
+            SubnetKind::Application
+            | SubnetKind::CloudEngine
+            | SubnetKind::System
+            | SubnetKind::VerifiedApplication => Err(()),
         }
     }
 }

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 pub type InstanceId = usize;
@@ -484,17 +485,31 @@ pub enum SubnetKind {
 
 impl SubnetKind {
     pub fn is_named(self) -> bool {
-        match self {
-            SubnetKind::NNS
-            | SubnetKind::SNS
-            | SubnetKind::II
-            | SubnetKind::Fiduciary
-            | SubnetKind::Bitcoin
-            | SubnetKind::TestThresholdKeys => true,
-            SubnetKind::Application
-            | SubnetKind::CloudEngine
-            | SubnetKind::System
-            | SubnetKind::VerifiedApplication => false,
+        NamedSubnet::iter().any(|n| SubnetKind::from(n) == self)
+    }
+}
+
+/// Named subnets have a fixed canister ID range on the IC mainnet and at most one
+/// instance per PocketIC instance.
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, EnumIter)]
+pub enum NamedSubnet {
+    NNS,
+    SNS,
+    II,
+    Fiduciary,
+    Bitcoin,
+    TestThresholdKeys,
+}
+
+impl From<NamedSubnet> for SubnetKind {
+    fn from(named: NamedSubnet) -> Self {
+        match named {
+            NamedSubnet::NNS => SubnetKind::NNS,
+            NamedSubnet::SNS => SubnetKind::SNS,
+            NamedSubnet::II => SubnetKind::II,
+            NamedSubnet::Fiduciary => SubnetKind::Fiduciary,
+            NamedSubnet::Bitcoin => SubnetKind::Bitcoin,
+            NamedSubnet::TestThresholdKeys => SubnetKind::TestThresholdKeys,
         }
     }
 }
@@ -822,35 +837,29 @@ impl SubnetStateConfig {
 }
 
 impl ExtendedSubnetConfigSet {
-    fn named_subnet_spec(&self, kind: SubnetKind) -> Option<SubnetSpec> {
-        match kind {
-            SubnetKind::NNS => self.nns.clone(),
-            SubnetKind::SNS => self.sns.clone(),
-            SubnetKind::II => self.ii.clone(),
-            SubnetKind::Fiduciary => self.fiduciary.clone(),
-            SubnetKind::Bitcoin => self.bitcoin.clone(),
-            SubnetKind::TestThresholdKeys => self.test_threshold_keys.clone(),
-            SubnetKind::Application
-            | SubnetKind::CloudEngine
-            | SubnetKind::System
-            | SubnetKind::VerifiedApplication => {
-                panic!(
-                    "named_subnet_spec called with non-named subnet kind {:?}",
-                    kind
-                )
-            }
+    fn named_subnet_spec(&self, named: NamedSubnet) -> Option<SubnetSpec> {
+        match named {
+            NamedSubnet::NNS => self.nns.clone(),
+            NamedSubnet::SNS => self.sns.clone(),
+            NamedSubnet::II => self.ii.clone(),
+            NamedSubnet::Fiduciary => self.fiduciary.clone(),
+            NamedSubnet::Bitcoin => self.bitcoin.clone(),
+            NamedSubnet::TestThresholdKeys => self.test_threshold_keys.clone(),
         }
     }
 
     // Return the configured named subnets in order.
     #[allow(clippy::type_complexity)]
     pub fn get_named(&self) -> Vec<(SubnetKind, Option<PathBuf>, SubnetInstructionConfig)> {
-        use SubnetKind::*;
-        [NNS, SNS, II, Fiduciary, Bitcoin, TestThresholdKeys]
-            .into_iter()
-            .filter_map(|kind| {
-                self.named_subnet_spec(kind)
-                    .map(|spec| (kind, spec.get_state_path(), spec.get_instruction_config()))
+        NamedSubnet::iter()
+            .filter_map(|named| {
+                self.named_subnet_spec(named).map(|spec| {
+                    (
+                        SubnetKind::from(named),
+                        spec.get_state_path(),
+                        spec.get_instruction_config(),
+                    )
+                })
             })
             .collect()
     }

--- a/packages/pocket-ic/src/common/rest.rs
+++ b/packages/pocket-ic/src/common/rest.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 pub type InstanceId = usize;
@@ -846,8 +845,9 @@ impl ExtendedSubnetConfigSet {
     // Return the configured named subnets in order.
     #[allow(clippy::type_complexity)]
     pub fn get_named(&self) -> Vec<(SubnetKind, Option<PathBuf>, SubnetInstructionConfig)> {
-        SubnetKind::iter()
-            .filter(|kind| kind.is_named())
+        use SubnetKind::*;
+        [NNS, SNS, II, Fiduciary, Bitcoin, TestThresholdKeys]
+            .into_iter()
             .filter_map(|kind| {
                 self.named_subnet_spec(kind)
                     .map(|spec| (kind, spec.get_state_path(), spec.get_instruction_config()))

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1480,8 +1480,14 @@ impl PocketIc {
         runtime.block_on(async { self.pocket_ic.canister_exists(canister_id).await })
     }
 
+    /// Deletes a subnet. Panics if the subnet does not exist or is a named subnet.
+    #[instrument(ret, skip(self), fields(instance_id=self.pocket_ic.instance_id, subnet_id = %subnet_id.to_string()))]
+    pub fn delete_subnet(&self, subnet_id: SubnetId) {
+        let runtime = self.runtime.clone();
+        runtime.block_on(async { self.pocket_ic.delete_subnet(subnet_id).await })
+    }
+
     /// Returns the subnet ID of the canister if the canister exists.
-    #[instrument(ret, skip(self), fields(instance_id=self.pocket_ic.instance_id, canister_id = %canister_id.to_string()))]
     pub fn get_subnet(&self, canister_id: CanisterId) -> Option<SubnetId> {
         let runtime = self.runtime.clone();
         runtime.block_on(async { self.pocket_ic.get_subnet(canister_id).await })

--- a/packages/pocket-ic/src/lib.rs
+++ b/packages/pocket-ic/src/lib.rs
@@ -1488,6 +1488,7 @@ impl PocketIc {
     }
 
     /// Returns the subnet ID of the canister if the canister exists.
+    #[instrument(ret, skip(self), fields(instance_id=self.pocket_ic.instance_id, canister_id = %canister_id.to_string()))]
     pub fn get_subnet(&self, canister_id: CanisterId) -> Option<SubnetId> {
         let runtime = self.runtime.clone();
         runtime.block_on(async { self.pocket_ic.get_subnet(canister_id).await })

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1601,6 +1601,8 @@ impl PocketIc {
     }
 
     /// Deletes a subnet. Panics if the subnet does not exist or is a named subnet.
+    #[instrument(ret, skip(self), fields(instance_id=self.instance_id, subnet_id = %subnet_id.to_string()))]
+    pub async fn delete_subnet(&self, subnet_id: SubnetId) {
         let endpoint = "update/delete_subnet";
         self.post::<(), RawSubnetId>(
             endpoint,

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1600,9 +1600,7 @@ impl PocketIc {
         self.get_subnet(canister_id).await.is_some()
     }
 
-    /// Deletes a subnet. Returns an error if the subnet does not exist or is a named subnet.
-    #[instrument(ret, skip(self), fields(instance_id=self.instance_id, subnet_id = %subnet_id.to_string()))]
-    pub async fn delete_subnet(&self, subnet_id: SubnetId) {
+    /// Deletes a subnet. Panics if the subnet does not exist or is a named subnet.
         let endpoint = "update/delete_subnet";
         self.post::<(), RawSubnetId>(
             endpoint,

--- a/packages/pocket-ic/src/nonblocking.rs
+++ b/packages/pocket-ic/src/nonblocking.rs
@@ -1600,6 +1600,19 @@ impl PocketIc {
         self.get_subnet(canister_id).await.is_some()
     }
 
+    /// Deletes a subnet. Returns an error if the subnet does not exist or is a named subnet.
+    #[instrument(ret, skip(self), fields(instance_id=self.instance_id, subnet_id = %subnet_id.to_string()))]
+    pub async fn delete_subnet(&self, subnet_id: SubnetId) {
+        let endpoint = "update/delete_subnet";
+        self.post::<(), RawSubnetId>(
+            endpoint,
+            RawSubnetId {
+                subnet_id: subnet_id.as_slice().to_vec(),
+            },
+        )
+        .await;
+    }
+
     /// Returns the subnet ID of the canister if the canister exists.
     #[instrument(ret, skip(self), fields(instance_id=self.instance_id, canister_id = %canister_id.to_string()))]
     pub async fn get_subnet(&self, canister_id: CanisterId) -> Option<SubnetId> {

--- a/packages/pocket-ic/test_canister/src/canister.rs
+++ b/packages/pocket-ic/test_canister/src/canister.rs
@@ -399,6 +399,14 @@ async fn whois(canister: Principal) -> String {
 }
 
 #[update]
+async fn call_and_get_rejection_code(canister: Principal) -> u32 {
+    match ic_cdk::call::<_, (String,)>(canister, "whoami", ((),)).await {
+        Ok(_) => 0,
+        Err((code, _)) => code as u32,
+    }
+}
+
+#[update]
 async fn blob_len(blob: Vec<u8>) -> usize {
     blob.len()
 }

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -3749,6 +3749,8 @@ fn test_delete_subnet_state_dir() {
 
     let subnet_ids = pic.topology().get_app_subnets();
     assert_eq!(subnet_ids.len(), 2);
+    // On Windows, the state_dir is only synced back from the WSL-native state directory on drop.
+    #[cfg(not(windows))]
     assert_eq!(subnet_dirs_count(), 2);
 
     pic.delete_subnet(subnet_ids[1]);

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -3708,6 +3708,43 @@ fn test_delete_subnet() {
 }
 
 #[test]
+fn test_delete_default_effective_canister_id_subnet_fails() {
+    // Create a PocketIC instance with one NNS subnet and two application subnets.
+    let pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_application_subnet()
+        .with_application_subnet()
+        .build();
+
+    let topology = pic.topology();
+    let default_effective_canister_id =
+        Principal::from(topology.default_effective_canister_id.clone());
+
+    // Identify which app subnet contains the default effective canister ID.
+    let default_subnet_id = topology
+        .get_subnet(default_effective_canister_id)
+        .expect("default effective canister ID must belong to a subnet");
+    let other_subnet_id = topology
+        .get_app_subnets()
+        .into_iter()
+        .find(|&id| id != default_subnet_id)
+        .expect("there must be a second app subnet");
+
+    // The app subnet containing the default effective canister ID cannot be deleted.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        pic.delete_subnet(default_subnet_id);
+    }));
+    assert!(
+        result.is_err(),
+        "deleting the subnet containing the default effective canister ID should fail"
+    );
+
+    // The other app subnet can be deleted.
+    pic.delete_subnet(other_subnet_id);
+    assert_eq!(pic.topology().get_app_subnets(), vec![default_subnet_id]);
+}
+
+#[test]
 fn test_delete_named_subnet_fails() {
     let pic = PocketIcBuilder::new()
         .with_nns_subnet()

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -3729,6 +3729,23 @@ fn test_delete_named_subnet_fails() {
 }
 
 #[test]
+fn test_delete_root_app_subnet_fails() {
+    // Create a PocketIC instance with a single application subnet.
+    // The first subnet created becomes the root subnet and cannot be deleted.
+    let pic = PocketIcBuilder::new().with_application_subnet().build();
+
+    let app_subnet_id = pic.topology().get_app_subnets()[0];
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        pic.delete_subnet(app_subnet_id);
+    }));
+    assert!(
+        result.is_err(),
+        "deleting the root app subnet should fail"
+    );
+}
+
+#[test]
 fn test_delete_subnet_state_dir() {
     let state_dir = TempDir::new().unwrap();
     let state_dir_path = state_dir.path().to_path_buf();

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -3631,3 +3631,126 @@ fn cloud_engine_default_effective_canister_id() {
         topology.default_effective_canister_id.clone().into();
     assert_eq!(effective_canister_id, default_effective_canister_id);
 }
+
+#[test]
+fn test_delete_subnet() {
+    // Create a PocketIC instance with two application subnets.
+    let pic = PocketIcBuilder::new()
+        .with_application_subnet()
+        .with_application_subnet()
+        .build();
+
+    let subnet_id_1 = pic.topology().get_app_subnets()[0];
+    let subnet_id_2 = pic.topology().get_app_subnets()[1];
+    assert_ne!(subnet_id_1, subnet_id_2);
+
+    // Deploy test canisters on both subnets.
+    let canister_1 = pic.create_canister_on_subnet(None, None, subnet_id_1);
+    pic.add_cycles(canister_1, INIT_CYCLES);
+    pic.install_canister(canister_1, test_canister_wasm(), vec![], None);
+
+    let canister_2 = pic.create_canister_on_subnet(None, None, subnet_id_2);
+    pic.add_cycles(canister_2, INIT_CYCLES);
+    pic.install_canister(canister_2, test_canister_wasm(), vec![], None);
+
+    // (1) Verify that ingress message and inter-canister call to canister_2 work.
+    let reply = pic
+        .update_call(
+            canister_2,
+            Principal::anonymous(),
+            "whoami",
+            encode_one(()).unwrap(),
+        )
+        .expect("ingress call to canister_2 failed before subnet deletion");
+    assert_eq!(Decode!(&reply, String).unwrap(), canister_2.to_string());
+
+    let reply = pic
+        .update_call(
+            canister_1,
+            Principal::anonymous(),
+            "call_and_get_rejection_code",
+            Encode!(&canister_2).unwrap(),
+        )
+        .expect("inter-canister call via canister_1 failed before subnet deletion");
+    assert_eq!(Decode!(&reply, u32).unwrap(), 0);
+
+    // (2) Delete subnet_2.
+    pic.delete_subnet(subnet_id_2);
+
+    // (3) Verify that ingress message to canister_2 fails after subnet deletion.
+    // The server rejects the message before execution (BadIngressMessage), which panics in the client.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        pic.update_call(
+            canister_2,
+            Principal::anonymous(),
+            "whoami",
+            encode_one(()).unwrap(),
+        )
+    }));
+    assert!(
+        result.is_err(),
+        "ingress call to canister_2 should fail after subnet deletion"
+    );
+
+    // (3) Verify that inter-canister call to canister_2 fails with DestinationInvalid (3).
+    let reply = pic
+        .update_call(
+            canister_1,
+            Principal::anonymous(),
+            "call_and_get_rejection_code",
+            Encode!(&canister_2).unwrap(),
+        )
+        .expect("inter-canister call via canister_1 should succeed");
+    assert_eq!(
+        Decode!(&reply, u32).unwrap(),
+        RejectCode::DestinationInvalid as u32
+    );
+}
+
+#[test]
+fn test_delete_named_subnet_fails() {
+    let pic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_fiduciary_subnet()
+        .build();
+
+    let nns_subnet_id = pic.topology().get_nns().unwrap();
+    let fiduciary_subnet_id = pic.topology().get_fiduciary().unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        pic.delete_subnet(nns_subnet_id);
+    }));
+    assert!(result.is_err(), "deleting NNS subnet should fail");
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        pic.delete_subnet(fiduciary_subnet_id);
+    }));
+    assert!(result.is_err(), "deleting fiduciary subnet should fail");
+}
+
+#[test]
+fn test_delete_subnet_state_dir() {
+    let state_dir = TempDir::new().unwrap();
+    let state_dir_path = state_dir.path().to_path_buf();
+
+    let pic = PocketIcBuilder::new()
+        .with_state_dir(state_dir_path.clone())
+        .with_application_subnet()
+        .with_application_subnet()
+        .build();
+
+    let subnet_ids = pic.topology().get_app_subnets();
+    assert_eq!(subnet_ids.len(), 2);
+    pic.delete_subnet(subnet_ids[1]);
+
+    // Drop to flush state to disk.
+    drop(pic);
+
+    // After deletion, only the remaining subnet's state directory should exist.
+    let subnet_dirs: Vec<_> = std::fs::read_dir(&state_dir_path)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    assert_eq!(subnet_dirs.len(), 1);
+}

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -3678,7 +3678,7 @@ fn test_delete_subnet() {
     pic.delete_subnet(subnet_id_2);
 
     // (3) Verify that ingress message to canister_2 fails after subnet deletion.
-    // The server rejects the message before execution (BadIngressMessage), which panics in the client.
+    // The server rejects the message with a 4xx HTTP status (BadIngressMessage), causing the client to panic.
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         pic.update_call(
             canister_2,
@@ -3692,7 +3692,7 @@ fn test_delete_subnet() {
         "ingress call to canister_2 should fail after subnet deletion"
     );
 
-    // (3) Verify that inter-canister call to canister_2 fails with DestinationInvalid (3).
+    // (4) Verify that inter-canister call to canister_2 fails with DestinationInvalid (3).
     let reply = pic
         .update_call(
             canister_1,
@@ -3739,18 +3739,24 @@ fn test_delete_subnet_state_dir() {
         .with_application_subnet()
         .build();
 
+    let subnet_dirs_count = || {
+        std::fs::read_dir(&state_dir_path)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .count()
+    };
+
     let subnet_ids = pic.topology().get_app_subnets();
     assert_eq!(subnet_ids.len(), 2);
+    assert_eq!(subnet_dirs_count(), 2);
+
     pic.delete_subnet(subnet_ids[1]);
+    assert_eq!(pic.topology().get_app_subnets(), vec![subnet_ids[0]]);
 
     // Drop to flush state to disk.
     drop(pic);
 
     // After deletion, only the remaining subnet's state directory should exist.
-    let subnet_dirs: Vec<_> = std::fs::read_dir(&state_dir_path)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
-        .collect();
-    assert_eq!(subnet_dirs.len(), 1);
+    assert_eq!(subnet_dirs_count(), 1);
 }

--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -3776,10 +3776,7 @@ fn test_delete_root_app_subnet_fails() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         pic.delete_subnet(app_subnet_id);
     }));
-    assert!(
-        result.is_err(),
-        "deleting the root app subnet should fail"
-    );
+    assert!(result.is_err(), "deleting the root app subnet should fail");
 }
 
 #[test]

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- The endpoint `/instances/<instance_id>/update/delete_subnet` to delete a subnet (non-named subnets only: application, cloud engine, system, or verified application subnets).
+  Named subnets (NNS, SNS, II, Fiduciary, Bitcoin, TestThresholdKeys) cannot be deleted.
+  If a state directory is configured for the instance, the deleted subnet's state directory is removed from disk.
+
 ## 14.0.0 - 2026-05-26
 
 ### Added

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - The endpoint `/instances/<instance_id>/update/delete_subnet` to delete a subnet (non-named subnets only: application, cloud engine, system, or verified application subnets).
-  Named subnets (NNS, SNS, II, Fiduciary, Bitcoin, TestThresholdKeys) cannot be deleted.
   If a state directory is configured for the instance, the deleted subnet's state directory is removed from disk.
 
 ## 14.0.0 - 2026-05-26

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2759,6 +2759,14 @@ impl PocketIcSubnets {
             )));
         }
 
+        if let Some(root_subnet) = self.nns_subnet.as_ref()
+            && root_subnet.get_subnet_id() == subnet_id
+        {
+            return Err(PocketIcError::Forbidden(
+                "Cannot delete the root subnet of the PocketIC instance.".to_string(),
+            ));
+        }
+
         let config = self.subnet_configs.remove(config_pos);
 
         let subnet = self

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -110,7 +110,7 @@ use ic_sns_wasm::pb::v1::{AddWasmRequest, AddWasmResponse, SnsCanisterType, SnsW
 use ic_state_machine_tests::{
     FakeVerifier, StateMachine, StateMachineBuilder, StateMachineConfig, StateMachineStateDir,
     SubmitIngressError, Subnets, WasmResult, add_global_registry_records,
-    add_initial_registry_records,
+    add_initial_registry_records, update_global_registry_records,
 };
 use ic_state_manager::StateManagerImpl;
 use ic_types::batch::BlockmakerMetrics;
@@ -532,6 +532,9 @@ impl SubnetsImpl {
     }
     pub(crate) fn get_all(&self) -> Vec<Arc<Subnet>> {
         self.subnets.read().unwrap().values().cloned().collect()
+    }
+    fn remove(&self, subnet_id: SubnetId) -> Option<Arc<Subnet>> {
+        self.subnets.write().unwrap().remove(&subnet_id)
     }
     fn clear(&self) {
         self.subnets.write().unwrap().clear();
@@ -2740,6 +2743,80 @@ impl PocketIcSubnets {
             subnet.state_machine.reload_registry();
         }
     }
+
+    fn delete_subnet(&mut self, subnet_id: SubnetId) -> Result<(), PocketIcError> {
+        let config_pos = self
+            .subnet_configs
+            .iter()
+            .position(|c| c.subnet_id == subnet_id)
+            .ok_or(PocketIcError::SubnetNotFound(subnet_id.get().0))?;
+
+        let subnet_kind = self.subnet_configs[config_pos].subnet_kind;
+        if subnet_kind.is_named() {
+            return Err(PocketIcError::Forbidden(format!(
+                "Cannot delete named subnet {} (kind: {:?}).",
+                subnet_id, subnet_kind
+            )));
+        }
+
+        let config = self.subnet_configs.remove(config_pos);
+
+        let subnet = self
+            .subnets
+            .remove(subnet_id)
+            .expect("subnet in subnet_configs must be in subnets");
+
+        subnet.state_machine.drop_payload_builder();
+
+        self.routing_table.remove_subnet(subnet_id);
+
+        for subnets in self.chain_keys.values_mut() {
+            subnets.retain(|&sid| sid != subnet_id);
+        }
+        self.chain_keys.retain(|_, subnets| !subnets.is_empty());
+
+        // Delete the subnet state directory from disk.
+        if let Some(state_dir) = self.state_dir.get() {
+            let subnet_seed = compute_subnet_seed(config.ranges.clone(), config.alloc_range);
+            let subnet_state_dir = state_dir.join(hex::encode(subnet_seed));
+            if subnet_state_dir.exists() {
+                std::fs::remove_dir_all(&subnet_state_dir).unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to delete state directory {}: {}",
+                        subnet_state_dir.display(),
+                        e
+                    )
+                });
+            }
+        }
+
+        // Update global registry records to reflect the removed subnet.
+        if self.nns_subnet.is_some() {
+            let next_version =
+                RegistryVersion::new(self.registry_data_provider.latest_version().get() + 1);
+            let subnet_list = self
+                .subnets
+                .get_all()
+                .into_iter()
+                .map(|s| s.get_subnet_id())
+                .collect();
+            update_global_registry_records(
+                next_version,
+                self.routing_table.clone(),
+                subnet_list,
+                self.chain_keys.clone(),
+                self.registry_data_provider.clone(),
+            );
+            self.persist_registry_changes();
+        }
+
+        // Drop the StateMachine, waiting until no other Arc holders remain.
+        let state_machine = subnet.state_machine.clone();
+        drop(subnet);
+        drop_state_machine(state_machine);
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -2776,6 +2853,25 @@ pub struct PocketIc {
     default_effective_canister_id: Principal,
 }
 
+fn drop_state_machine(state_machine: Arc<StateMachine>) {
+    let start = std::time::Instant::now();
+    let mut state_machine = Some(state_machine);
+    loop {
+        match Arc::try_unwrap(state_machine.take().unwrap()) {
+            Ok(sm) => {
+                sm.drop();
+                break;
+            }
+            Err(sm) => {
+                state_machine = Some(sm);
+            }
+        }
+        if start.elapsed() > std::time::Duration::from_secs(5 * 60) {
+            panic!("Timed out while dropping StateMachine.");
+        }
+    }
+}
+
 impl Drop for PocketIc {
     fn drop(&mut self) {
         if self.subnets.state_dir.get().is_some() {
@@ -2801,23 +2897,8 @@ impl Drop for PocketIc {
         self.subnets.clear();
         // for every StateMachine, wait until nobody else has an Arc to that StateMachine
         // and then drop that StateMachine
-        let start = std::time::Instant::now();
         for state_machine in state_machines {
-            let mut state_machine = Some(state_machine);
-            while state_machine.is_some() {
-                match Arc::try_unwrap(state_machine.take().unwrap()) {
-                    Ok(sm) => {
-                        sm.drop();
-                        break;
-                    }
-                    Err(sm) => {
-                        state_machine = Some(sm);
-                    }
-                }
-                if start.elapsed() > std::time::Duration::from_secs(5 * 60) {
-                    panic!("Timed out while dropping PocketIC.");
-                }
-            }
+            drop_state_machine(state_machine);
         }
     }
 }
@@ -5457,6 +5538,24 @@ impl Operation for GetSubnet {
 
     fn id(&self) -> OpId {
         OpId(format!("get_subnet({})", self.canister_id))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DeleteSubnet {
+    pub subnet_id: SubnetId,
+}
+
+impl Operation for DeleteSubnet {
+    fn compute(&self, pic: &mut PocketIc) -> OpOut {
+        match pic.subnets.delete_subnet(self.subnet_id) {
+            Ok(()) => OpOut::NoOutput,
+            Err(e) => OpOut::Error(e),
+        }
+    }
+
+    fn id(&self) -> OpId {
+        OpId(format!("delete_subnet({})", self.subnet_id))
     }
 }
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2774,6 +2774,10 @@ impl PocketIcSubnets {
         let default_canister_id: CanisterId = PrincipalId(default_effective_canister_id)
             .try_into()
             .unwrap();
+        // The default effective canister ID is used as the routing target for canister
+        // creation calls that don't specify an explicit subnet (provisional API with ic_00
+        // as effective ID, or no effective principal). Deleting its subnet would break
+        // all such calls.
         if let Some((_, default_subnet_id)) = self.routing_table.lookup_entry(default_canister_id)
             && default_subnet_id == subnet_id
         {
@@ -2837,7 +2841,8 @@ impl PocketIcSubnets {
         // Drop the StateMachine, waiting until no other Arc holders remain.
         let state_machine = subnet.state_machine.clone();
         drop(subnet);
-        drop_state_machine(state_machine);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5 * 60);
+        drop_state_machine(state_machine, deadline);
 
         Ok(())
     }
@@ -2877,8 +2882,7 @@ pub struct PocketIc {
     default_effective_canister_id: Principal,
 }
 
-fn drop_state_machine(state_machine: Arc<StateMachine>) {
-    let start = std::time::Instant::now();
+fn drop_state_machine(state_machine: Arc<StateMachine>, deadline: std::time::Instant) {
     let mut state_machine = Some(state_machine);
     loop {
         match Arc::try_unwrap(state_machine.take().unwrap()) {
@@ -2891,7 +2895,7 @@ fn drop_state_machine(state_machine: Arc<StateMachine>) {
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
         }
-        if start.elapsed() > std::time::Duration::from_secs(5 * 60) {
+        if std::time::Instant::now() > deadline {
             panic!("Timed out while dropping StateMachine.");
         }
     }
@@ -2921,9 +2925,10 @@ impl Drop for PocketIc {
             .collect();
         self.subnets.clear();
         // for every StateMachine, wait until nobody else has an Arc to that StateMachine
-        // and then drop that StateMachine
+        // and then drop that StateMachine; the deadline is shared across all StateMachines
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5 * 60);
         for state_machine in state_machines {
-            drop_state_machine(state_machine);
+            drop_state_machine(state_machine, deadline);
         }
     }
 }

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2803,14 +2803,14 @@ impl PocketIcSubnets {
         if let Some(state_dir) = self.state_dir.get() {
             let subnet_seed = compute_subnet_seed(config.ranges.clone(), config.alloc_range);
             let subnet_state_dir = state_dir.join(hex::encode(subnet_seed));
-            if subnet_state_dir.exists() {
-                if let Err(e) = std::fs::remove_dir_all(&subnet_state_dir) {
-                    eprintln!(
-                        "Failed to delete subnet state directory {}: {}",
-                        subnet_state_dir.display(),
-                        e
-                    );
-                }
+            if subnet_state_dir.exists()
+                && let Err(e) = std::fs::remove_dir_all(&subnet_state_dir)
+            {
+                eprintln!(
+                    "Failed to delete subnet state directory {}: {}",
+                    subnet_state_dir.display(),
+                    e
+                );
             }
         }
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2780,13 +2780,13 @@ impl PocketIcSubnets {
             let subnet_seed = compute_subnet_seed(config.ranges.clone(), config.alloc_range);
             let subnet_state_dir = state_dir.join(hex::encode(subnet_seed));
             if subnet_state_dir.exists() {
-                std::fs::remove_dir_all(&subnet_state_dir).unwrap_or_else(|e| {
-                    panic!(
-                        "Failed to delete state directory {}: {}",
+                if let Err(e) = std::fs::remove_dir_all(&subnet_state_dir) {
+                    eprintln!(
+                        "Failed to delete subnet state directory {}: {}",
                         subnet_state_dir.display(),
                         e
-                    )
-                });
+                    );
+                }
             }
         }
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2744,7 +2744,11 @@ impl PocketIcSubnets {
         }
     }
 
-    fn delete_subnet(&mut self, subnet_id: SubnetId) -> Result<(), PocketIcError> {
+    fn delete_subnet(
+        &mut self,
+        subnet_id: SubnetId,
+        default_effective_canister_id: Principal,
+    ) -> Result<(), PocketIcError> {
         let config_pos = self
             .subnet_configs
             .iter()
@@ -2765,6 +2769,18 @@ impl PocketIcSubnets {
             return Err(PocketIcError::Forbidden(
                 "Cannot delete the root subnet of the PocketIC instance.".to_string(),
             ));
+        }
+
+        let default_canister_id: CanisterId = PrincipalId(default_effective_canister_id)
+            .try_into()
+            .unwrap();
+        if let Some((_, default_subnet_id)) = self.routing_table.lookup_entry(default_canister_id)
+            && default_subnet_id == subnet_id
+        {
+            return Err(PocketIcError::Forbidden(format!(
+                "Cannot delete subnet {} which contains the default effective canister ID.",
+                subnet_id
+            )));
         }
 
         let config = self.subnet_configs.remove(config_pos);
@@ -5557,7 +5573,11 @@ pub struct DeleteSubnet {
 
 impl Operation for DeleteSubnet {
     fn compute(&self, pic: &mut PocketIc) -> OpOut {
-        match pic.subnets.delete_subnet(self.subnet_id) {
+        let default_effective_canister_id = pic.default_effective_canister_id;
+        match pic
+            .subnets
+            .delete_subnet(self.subnet_id, default_effective_canister_id)
+        {
             Ok(()) => OpOut::NoOutput,
             Err(e) => OpOut::Error(e),
         }

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -2864,6 +2864,7 @@ fn drop_state_machine(state_machine: Arc<StateMachine>) {
             }
             Err(sm) => {
                 state_machine = Some(sm);
+                std::thread::sleep(std::time::Duration::from_millis(10));
             }
         }
         if start.elapsed() > std::time::Duration::from_secs(5 * 60) {

--- a/rs/pocket_ic_server/src/state_api/routes.rs
+++ b/rs/pocket_ic_server/src/state_api/routes.rs
@@ -10,10 +10,11 @@ use super::state::{
 };
 use crate::pocket_ic::{
     AddCycles, AwaitIngressMessage, CallRequest, CallRequestVersion, CanisterReadStateRequest,
-    CanisterSnapshotDownload, CanisterSnapshotUpload, DashboardRequest, GetCanisterHttp,
-    GetControllers, GetCyclesBalance, GetStableMemory, GetSubnet, GetTime, GetTopology,
-    IngressMessageStatus, MockCanisterHttp, PubKey, Query, QueryRequest, SetCertifiedTime,
-    SetStableMemory, SetTime, StatusRequest, SubmitIngressMessage, SubnetReadStateRequest, Tick,
+    CanisterSnapshotDownload, CanisterSnapshotUpload, DashboardRequest, DeleteSubnet,
+    GetCanisterHttp, GetControllers, GetCyclesBalance, GetStableMemory, GetSubnet, GetTime,
+    GetTopology, IngressMessageStatus, MockCanisterHttp, PubKey, Query, QueryRequest,
+    SetCertifiedTime, SetStableMemory, SetTime, StatusRequest, SubmitIngressMessage,
+    SubnetReadStateRequest, Tick,
 };
 use crate::{
     BlobStore, InstanceId, OpId, Operation, SubnetBlockmakers, async_trait, pocket_ic::PocketIc,
@@ -146,6 +147,7 @@ where
             "/canister_snapshot_upload",
             post(handler_canister_snapshot_upload),
         )
+        .directory_route("/delete_subnet", post(handler_delete_subnet))
 }
 
 async fn handle_limit_error(req: Request, next: Next) -> Response {
@@ -806,6 +808,21 @@ pub async fn handler_pub_key(
         &subnet_id,
     )));
     let op = PubKey { subnet_id };
+    let (code, res) = run_operation(api_state, instance_id, timeout, op).await;
+    (code, Json(res))
+}
+
+pub async fn handler_delete_subnet(
+    State(AppState { api_state, .. }): State<AppState>,
+    Path(instance_id): Path<InstanceId>,
+    headers: HeaderMap,
+    extract::Json(RawSubnetId { subnet_id }): extract::Json<RawSubnetId>,
+) -> (StatusCode, Json<ApiResponse<()>>) {
+    let timeout = timeout_or_default(headers);
+    let subnet_id = ic_types::SubnetId::new(ic_types::PrincipalId(candid::Principal::from_slice(
+        &subnet_id,
+    )));
+    let op = DeleteSubnet { subnet_id };
     let (code, res) = run_operation(api_state, instance_id, timeout, op).await;
     (code, Json(res))
 }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -270,6 +270,35 @@ pub fn add_global_registry_records(
         )
         .unwrap();
 
+    update_global_registry_records(
+        registry_version,
+        routing_table,
+        subnet_list,
+        chain_keys,
+        registry_data_provider.clone(),
+    );
+
+    // node rewards table
+    registry_data_provider
+        .add(
+            NODE_REWARDS_TABLE_KEY,
+            registry_version,
+            Some(NodeRewardsTable {
+                table: BTreeMap::new(),
+            }),
+        )
+        .unwrap();
+}
+
+/// Updates global registry records (routing table, subnet list, chain keys) at the given
+/// registry version. Used both during initial setup and after removing a subnet.
+pub fn update_global_registry_records(
+    registry_version: RegistryVersion,
+    routing_table: RoutingTable,
+    subnet_list: Vec<SubnetId>,
+    chain_keys: BTreeMap<MasterPublicKeyId, Vec<SubnetId>>,
+    registry_data_provider: Arc<ProtoRegistryDataProvider>,
+) {
     // routing table record
     let pb_routing_table = PbRoutingTable::from(routing_table.clone());
     registry_data_provider
@@ -301,17 +330,6 @@ pub fn add_global_registry_records(
             )
             .unwrap();
     }
-
-    // node rewards table
-    registry_data_provider
-        .add(
-            NODE_REWARDS_TABLE_KEY,
-            registry_version,
-            Some(NodeRewardsTable {
-                table: BTreeMap::new(),
-            }),
-        )
-        .unwrap();
 }
 
 /// Adds initial registry records to the registry managed by the registry data provider:


### PR DESCRIPTION
This PR adds a PocketIC operation to delete a subnet:
- the subnet's `StateMachine` is properly dropped from the PocketIC state (including state directory removal);
- the registry is updated accordingly (including registry changes in the registry canister if the registry canister has been bootstrapped by PocketIC, i.e., not manually).

Note. This PR does not implement subnet deletion in DSM! Stale artifacts (such as stale streams and hanging unbounded-wait calls) might persist.