### PR TITLE
chore(P2P): Only increment error metric if transport infos of all registry versions are empty

### DIFF
--- a/rs/p2p/peer_manager/src/lib.rs
+++ b/rs/p2p/peer_manager/src/lib.rs
@@ -135,11 +135,6 @@ impl PeerManager {
                         self.log,
                         "Got transport infos but it's empty. Registry version {version}"
                     );
-                    self.metrics
-                        .topology_watcher_errors
-                        .with_label_values(&["empty_list_of_node_records"])
-                        .inc();
-
                     Vec::new()
                 }
                 Err(err) => {
@@ -192,6 +187,13 @@ impl PeerManager {
                     }
                 }
             }
+        }
+
+        if subnet_nodes.is_empty() {
+            self.metrics
+                .topology_watcher_errors
+                .with_label_values(&["empty_subnet_nodes"])
+                .inc();
         }
 
         SubnetTopology::new(


### PR DESCRIPTION
The peer manager maintains connections to all peers that are in the subnet record in any registry version between the "oldest version in use" and the latest locally available registry version.

The "oldest registry version in use" is determined by the CUP. In case of a subnet creation, this CUP is a registry CUP that contains the registry version just _before_ the subnet was created (see [here](https://sourcegraph.com/r/github.com/dfinity/ic@8cf338f5ef95432dc61233df889d98837d780466/-/blob/rs/registry/canister/src/mutations/do_create_subnet.rs?L63)).

This means that when the peer manager attempts to make connections to peers according to the "oldest registry version in use", the subnet doesn't actually exist yet, which then triggers the `empty_list_of_node_records` error. This is fine however, because it will find the correct peers in the subsequent registry version (which is guaranteed to exist, otherwise we would not have the registry CUP).

To improve the error signal of this metric, we change it such that it is only incremented if _all_ registry versions do not contain transport infos, meaning there are no peers shared with the new subnet topology.