### PR TITLE
chore: refactor test_archiving_in_chunks_returns_disjoint_block_range_locations to not depend on canister performance

### DIFF
--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -5081,6 +5081,8 @@ pub mod archiving {
 
         // Install a ledger with a lot of initial balances
         let mut subnet_config = SubnetConfig::new(SubnetType::System, SubnetSecurity::None);
+        // Set max_instructions_per_round to max(max_instructions_per_slice, max_instructions_per_install_code_slice)
+        // to ensure that at most one canister message can be executed per round.
         subnet_config.scheduler_config.max_instructions_per_round = subnet_config
             .scheduler_config
             .max_instructions_per_slice

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -4676,7 +4676,6 @@ pub mod archiving {
     use ic_ledger_canister_core::range_utils;
     use ic_ledger_suite_state_machine_helpers::{get_logs, icrc3_get_blocks};
     use ic_state_machine_tests::StateMachineBuilder;
-    use ic_types::NumInstructions;
     use ic_types::ingress::{IngressState, IngressStatus};
     use ic_types::messages::MessageId;
     use icp_ledger::{GetEncodedBlocksResult, QueryEncodedBlocksResponse};

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -4676,6 +4676,7 @@ pub mod archiving {
     use ic_ledger_canister_core::range_utils;
     use ic_ledger_suite_state_machine_helpers::{get_logs, icrc3_get_blocks};
     use ic_state_machine_tests::StateMachineBuilder;
+    use ic_types::NumInstructions;
     use ic_types::ingress::{IngressState, IngressStatus};
     use ic_types::messages::MessageId;
     use icp_ledger::{GetEncodedBlocksResult, QueryEncodedBlocksResponse};
@@ -5080,7 +5081,21 @@ pub mod archiving {
         }
 
         // Install a ledger with a lot of initial balances
-        let env = StateMachine::new();
+        let mut subnet_config = SubnetConfig::new(SubnetType::System, SubnetSecurity::None);
+        subnet_config.scheduler_config.max_instructions_per_round = subnet_config
+            .scheduler_config
+            .max_instructions_per_slice
+            .max(
+                subnet_config
+                    .scheduler_config
+                    .max_instructions_per_install_code_slice,
+            );
+        let env = StateMachineBuilder::new()
+            .with_config(Some(StateMachineConfig::new(
+                subnet_config,
+                HypervisorConfig::default(),
+            )))
+            .build();
         let args = encode_init_args(InitArgs {
             archive_options: ArchiveOptions {
                 trigger_threshold: TRIGGER_THRESHOLD,
@@ -5134,16 +5149,13 @@ pub mod archiving {
         let archive_id = archive_info
             .first()
             .expect("should return one archive info");
-        let get_blocks_res = archive_get_blocks_fn(
-            &env,
-            CanisterId::unchecked_from_principal(PrincipalId::from(*archive_id)),
-            0,
-            1,
-        );
-        assert!(
-            !get_blocks_res.blocks.is_empty(),
-            "archive should contain at least one block"
-        );
+        let archive_canister_id =
+            CanisterId::unchecked_from_principal(PrincipalId::from(*archive_id));
+        let mut get_blocks_res = archive_get_blocks_fn(&env, archive_canister_id, 0, 1);
+        while get_blocks_res.blocks.is_empty() {
+            env.tick();
+            get_blocks_res = archive_get_blocks_fn(&env, archive_canister_id, 0, 1);
+        }
 
         // Tick until the transfer completes, meaning the archiving also completes.
         const MAX_TICKS: usize = 500;

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -5136,17 +5136,8 @@ pub mod archiving {
             env.tick();
             archive_info = get_archives(&env, ledger_id);
         }
-        // Verify that the ledger reports block `0` to be present only in the ledger
-        let get_blocks_res = get_blocks_fn(&env, ledger_id, 0, 1);
-        assert!(
-            !ledger_reports_first_block_in_two_places(0, &get_blocks_res),
-            "get_blocks_res: {get_blocks_res:?}"
-        );
-        // Verify that the ledger response contained no archive info.
-        assert!(get_blocks_res.archived_ranges.is_empty());
-        // Verify that the block was already archived. Since the archiving is done in chunks, the
-        // archiving is not yet completed, so the ledger reports the block `0` to be present only
-        // in the ledger, even though it is also present in the archive by now.
+        // Keep retrieving the block `0` from the archive and calling env.tick()
+        // until the block is archived.
         let archive_id = archive_info
             .first()
             .expect("should return one archive info");
@@ -5157,6 +5148,17 @@ pub mod archiving {
             env.tick();
             get_blocks_res = archive_get_blocks_fn(&env, archive_canister_id, 0, 1);
         }
+        // Since the archiving is done in chunks, the archiving is not yet completed,
+        // so the ledger reports the block `0` to be present only
+        // in the ledger, even though it is also present in the archive by now.
+        // Verify that the ledger reports block `0` to be present only in the ledger.
+        let get_blocks_res = get_blocks_fn(&env, ledger_id, 0, 1);
+        assert!(
+            !ledger_reports_first_block_in_two_places(0, &get_blocks_res),
+            "get_blocks_res: {get_blocks_res:?}"
+        );
+        // Verify that the ledger response contained no archive info.
+        assert!(get_blocks_res.archived_ranges.is_empty());
 
         // Tick until the transfer completes, meaning the archiving also completes.
         const MAX_TICKS: usize = 500;


### PR DESCRIPTION
This PR refactors the test `test_archiving_in_chunks_returns_disjoint_block_range_locations` to not depend on canister (WASM) performance (which changes in an upcoming PR bumping Rust compiler version to 1.95.0).

This goal is achieved by setting round instruction limits so that only a single canister message can be executed per round:
```
            let max_instructions_per_slice = std::cmp::max(
                self.config.max_instructions_per_slice,
                self.config.max_instructions_per_install_code_slice,
            );
            let round_instructions = as_round_instructions(self.config.max_instructions_per_round)
                - as_round_instructions(max_instructions_per_slice)
                + RoundInstructions::new(1);
```
in the scheduler yields `round_instructions` equal to 1 in the corresponding test (which means that the round instructions are certainly exhausted after a single message execution). There can still be multiple management canister messages per round, but this is not an issue for the test's robustness against canister (WASM) performance.

The only risk in this PR is its sensitivity to scheduler changes.