### PR TITLE
chore(engine-controller): sending the return value for subnet id creation

### DIFF
--- a/rs/engine_controller/canister/canister.rs
+++ b/rs/engine_controller/canister/canister.rs
@@ -123,7 +123,7 @@ fn ensure_authorized() -> Result<Principal, String> {
 }
 
 #[update]
-async fn create_engine(args: CreateEngineArgs) -> Result<(), String> {
+async fn create_engine(args: CreateEngineArgs) -> Result<NewSubnet, String> {
     let caller = ensure_authorized()?;
 
     // Validate node list.
@@ -186,7 +186,7 @@ async fn create_engine(args: CreateEngineArgs) -> Result<(), String> {
             .candid()
             .map_err(|e| format!("Failed to decode registry response: {e}"))?;
 
-    response.map(|_new_subnet| ())
+    response
 }
 
 #[update]

--- a/rs/engine_controller/engine_controller.did
+++ b/rs/engine_controller/engine_controller.did
@@ -10,12 +10,18 @@ type DeleteEngineArgs = record {
 
 type Result = variant { Ok; Err : text };
 
+type NewSubnet = record {
+  new_subnet_id : opt principal;
+};
+
+type CreateEngineResult = variant { Ok : NewSubnet; Err : text };
+
 type EngineControllerInitArgs = record {
   authorized_caller : opt principal;
   initial_dkg_subnet_id : opt principal;
 };
 
 service : (opt EngineControllerInitArgs) -> {
-  create_engine : (CreateEngineArgs) -> (Result);
+  create_engine : (CreateEngineArgs) -> (CreateEngineResult);
   delete_engine : (DeleteEngineArgs) -> (Result);
 }

--- a/rs/engine_controller/tests/tests.rs
+++ b/rs/engine_controller/tests/tests.rs
@@ -42,6 +42,11 @@ struct EngineControllerInitArgs {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
+struct NewSubnet {
+    new_subnet_id: Option<Principal>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
 struct CreateEngineArgs {
     node_ids: Vec<Principal>,
     subnet_admins: Vec<Principal>,
@@ -181,7 +186,7 @@ async fn call_create_engine(
     pic: &PocketIc,
     sender: Principal,
     args: &CreateEngineArgs,
-) -> Result<(), String> {
+) -> Result<NewSubnet, String> {
     let raw = pic
         .update_call(
             ENGINE_CONTROLLER_CANISTER_ID.get().0,
@@ -191,7 +196,7 @@ async fn call_create_engine(
         )
         .await
         .expect("ingress call should succeed");
-    Decode!(&raw, Result<(), String>).unwrap()
+    Decode!(&raw, Result<NewSubnet, String>).unwrap()
 }
 
 async fn call_delete_engine(
@@ -252,9 +257,12 @@ async fn create_engine_then_delete_engine_succeeds() {
         replica_version_id: test_replica_version(),
     };
 
-    call_create_engine(&pic, authorized(), &create_args)
+    let new_subnet = call_create_engine(&pic, authorized(), &create_args)
         .await
         .expect("create_engine should succeed");
+    let returned_subnet_id = new_subnet
+        .new_subnet_id
+        .expect("create_engine should return a new subnet id");
 
     let after_create = subnet_list(&pic).await;
     let new_subnets: Vec<_> = after_create
@@ -263,6 +271,11 @@ async fn create_engine_then_delete_engine_succeeds() {
         .collect();
     assert_eq!(new_subnets.len(), 1, "exactly one new subnet must appear");
     let new_subnet_id = SubnetId::new(PrincipalId::try_from(new_subnets[0].as_slice()).unwrap());
+    assert_eq!(
+        returned_subnet_id,
+        new_subnet_id.get().0,
+        "returned subnet id must match the one in the registry"
+    );
 
     // Verify the new subnet was registered as a CloudEngine.
     let raw = registry_get_value(


### PR DESCRIPTION
This PR will enable us to not have to poll and match nodes with subnets after the subnet creation as we will receive it as a response already.

## NOTE
This is a breaking change