### PR TITLE
chore: drop unused canister_sandboxing subnet feature from registry

### DIFF
--- a/rs/engine_controller/canister/canister.rs
+++ b/rs/engine_controller/canister/canister.rs
@@ -171,7 +171,6 @@ async fn create_engine(args: CreateEngineArgs) -> Result<NewSubnet, String> {
         unit_delay_millis: 1000,
         canister_cycles_cost_schedule: Some(CanisterCyclesCostSchedule::Free),
         features: SubnetFeatures {
-            canister_sandboxing: false,
             http_requests: true,
             sev_enabled: Some(false),
         },

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -877,14 +877,9 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             .set(network_topology.routing_table().ranges(own_subnet_id).len() as i64);
         // Please export any new features via the `subnet_features` metric below.
         let SubnetFeatures {
-            canister_sandboxing,
             http_requests,
             sev_enabled,
         } = &subnet_features;
-        self.metrics
-            .subnet_features
-            .with_label_values(&["canister_sandboxing"])
-            .set(*canister_sandboxing as i64);
         self.metrics
             .subnet_features
             .with_label_values(&["http_requests"])

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -728,7 +728,7 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
             membership: &[node_test_id(1), node_test_id(2)],
             subnet_type: SubnetType::Application,
             features: SubnetFeatures {
-                http_requests: true,
+                sev_enabled: true,
                 ..Default::default()
             },
             chain_key_config: ChainKeyConfig {

--- a/rs/messaging/src/message_routing/tests.rs
+++ b/rs/messaging/src/message_routing/tests.rs
@@ -728,7 +728,6 @@ fn try_read_registry_succeeds_with_fully_specified_registry_records() {
             membership: &[node_test_id(1), node_test_id(2)],
             subnet_type: SubnetType::Application,
             features: SubnetFeatures {
-                canister_sandboxing: true,
                 http_requests: true,
                 ..Default::default()
             },
@@ -2062,7 +2061,6 @@ fn process_batch_updates_subnet_metrics() {
             membership: &[node_test_id(1), node_test_id(2)],
             subnet_type: SubnetType::Application,
             features: SubnetFeatures {
-                canister_sandboxing: true,
                 http_requests: true,
                 ..Default::default()
             },

--- a/rs/nns/governance/src/proposals/fulfill_subnet_rental_request.rs
+++ b/rs/nns/governance/src/proposals/fulfill_subnet_rental_request.rs
@@ -237,7 +237,6 @@ impl ValidFulfillSubnetRentalRequest {
             // from an ic_limits constant, then, I most likely grabbed the value
             // seen here from an adopted create application subnet NNS proposal.
             features: SubnetFeatures {
-                canister_sandboxing: false,
                 http_requests: true,
                 sev_enabled: None,
             },

--- a/rs/protobuf/def/registry/subnet/v1/subnet.proto
+++ b/rs/protobuf/def/registry/subnet/v1/subnet.proto
@@ -340,9 +340,8 @@ enum SubnetType {
 
 message SubnetFeatures {
   reserved 1;
-  // This feature flag controls whether canister execution happens
-  // in sandboxed process or not. It is disabled by default.
-  bool canister_sandboxing = 2;
+  reserved 2;
+  reserved "canister_sandboxing";
   // This feature flag controls whether canisters of this subnet are capable of
   // performing http(s) requests to the web2.
   bool http_requests = 3;

--- a/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/registry/registry.subnet.v1.rs
@@ -374,10 +374,6 @@ pub struct ExtendedDerivationPath {
     ::prost::Message,
 )]
 pub struct SubnetFeatures {
-    /// This feature flag controls whether canister execution happens
-    /// in sandboxed process or not. It is disabled by default.
-    #[prost(bool, tag = "2")]
-    pub canister_sandboxing: bool,
     /// This feature flag controls whether canisters of this subnet are capable of
     /// performing http(s) requests to the web2.
     #[prost(bool, tag = "3")]

--- a/rs/protobuf/src/gen/state/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/state/registry.subnet.v1.rs
@@ -365,10 +365,6 @@ pub struct ExtendedDerivationPath {
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct SubnetFeatures {
-    /// This feature flag controls whether canister execution happens
-    /// in sandboxed process or not. It is disabled by default.
-    #[prost(bool, tag = "2")]
-    pub canister_sandboxing: bool,
     /// This feature flag controls whether canisters of this subnet are capable of
     /// performing http(s) requests to the web2.
     #[prost(bool, tag = "3")]

--- a/rs/protobuf/src/gen/types/registry.subnet.v1.rs
+++ b/rs/protobuf/src/gen/types/registry.subnet.v1.rs
@@ -365,10 +365,6 @@ pub struct ExtendedDerivationPath {
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct SubnetFeatures {
-    /// This feature flag controls whether canister execution happens
-    /// in sandboxed process or not. It is disabled by default.
-    #[prost(bool, tag = "2")]
-    pub canister_sandboxing: bool,
     /// This feature flag controls whether canisters of this subnet are capable of
     /// performing http(s) requests to the web2.
     #[prost(bool, tag = "3")]

--- a/rs/registry/canister/canister/registry.did
+++ b/rs/registry/canister/canister/registry.did
@@ -403,7 +403,6 @@ type SetFirewallConfigPayload = record {
 };
 
 type SubnetFeatures = record {
-  canister_sandboxing : bool;
   http_requests : bool;
   sev_enabled : opt bool;
 };

--- a/rs/registry/canister/canister/registry_test.did
+++ b/rs/registry/canister/canister/registry_test.did
@@ -403,7 +403,6 @@ type SetFirewallConfigPayload = record {
 };
 
 type SubnetFeatures = record {
-  canister_sandboxing : bool;
   http_requests : bool;
   sev_enabled : opt bool;
 };

--- a/rs/registry/canister/src/mutations/do_update_subnet.rs
+++ b/rs/registry/canister/src/mutations/do_update_subnet.rs
@@ -654,7 +654,6 @@ mod tests {
             halt_at_cup_height: Some(false),
             features: Some(
                 SubnetFeatures {
-                    canister_sandboxing: false,
                     http_requests: false,
                     sev_enabled: false,
                 }
@@ -705,7 +704,6 @@ mod tests {
                 halt_at_cup_height: false,
                 features: Some(
                     SubnetFeatures {
-                        canister_sandboxing: false,
                         http_requests: false,
                         sev_enabled: false,
                     }
@@ -1128,7 +1126,6 @@ mod tests {
             .expect("should contain at least one node ID");
         let mut subnet_record = get_invariant_compliant_subnet_record(vec![*first_node_id]);
         subnet_record.features = Some(SubnetFeaturesPb {
-            canister_sandboxing: false,
             http_requests: false,
             sev_enabled: Some(true),
         });
@@ -1153,7 +1150,6 @@ mod tests {
 
         let mut payload = make_empty_update_payload(subnet_id);
         payload.features = Some(SubnetFeaturesPb {
-            canister_sandboxing: false,
             http_requests: false,
             sev_enabled: Some(true),
         });
@@ -1170,7 +1166,6 @@ mod tests {
 
         let mut payload = make_empty_update_payload(subnet_id);
         payload.features = Some(SubnetFeaturesPb {
-            canister_sandboxing: false,
             http_requests: false,
             sev_enabled: Some(false),
         });
@@ -1190,7 +1185,6 @@ mod tests {
 
         let mut payload = make_empty_update_payload(subnet_id);
         payload.features = Some(SubnetFeaturesPb {
-            canister_sandboxing: true,
             http_requests: true,
             sev_enabled: None,
         });
@@ -1205,7 +1199,6 @@ mod tests {
         // Update non-SEV features while explicitly preserving sev_enabled = true.
         let mut payload = make_empty_update_payload(subnet_id);
         payload.features = Some(SubnetFeaturesPb {
-            canister_sandboxing: true,
             http_requests: true,
             sev_enabled: Some(true),
         });
@@ -1217,7 +1210,6 @@ mod tests {
             .features
             .expect("subnet should have features set");
         assert_eq!(subnet_features.sev_enabled, Some(true));
-        assert!(subnet_features.canister_sandboxing);
         assert!(subnet_features.http_requests);
     }
 
@@ -1227,7 +1219,6 @@ mod tests {
 
         let mut payload = make_empty_update_payload(subnet_id);
         payload.features = Some(SubnetFeaturesPb {
-            canister_sandboxing: true,
             http_requests: true,
             sev_enabled: None,
         });
@@ -1251,7 +1242,6 @@ mod tests {
         {
             let mut payload = make_empty_update_payload(subnet_id);
             payload.features = Some(SubnetFeaturesPb {
-                canister_sandboxing: true,
                 http_requests: true,
                 sev_enabled: None,
             });

--- a/rs/registry/subnet_features/src/lib.rs
+++ b/rs/registry/subnet_features/src/lib.rs
@@ -14,10 +14,6 @@ pub const DEFAULT_ECDSA_MAX_QUEUE_SIZE: u32 = 20;
 #[derive(Copy, Clone, Eq, PartialEq, Debug, CandidType, Deserialize, Serialize)]
 #[serde(default)]
 pub struct SubnetFeatures {
-    /// This feature flag controls whether canister execution happens
-    /// in sandboxed process or not. It is disabled by default.
-    pub canister_sandboxing: bool,
-
     /// This feature flag controls whether canisters of this subnet are capable of
     /// performing http(s) requests to the web2. It is enabled by default.
     /// TODO: The feature should be disabled only in special circumstances.
@@ -37,7 +33,6 @@ fn default_http_requests() -> bool {
 impl Default for SubnetFeatures {
     fn default() -> Self {
         Self {
-            canister_sandboxing: bool::default(),
             http_requests: default_http_requests(),
             sev_enabled: bool::default(),
         }
@@ -47,7 +42,6 @@ impl Default for SubnetFeatures {
 impl From<SubnetFeatures> for pb::SubnetFeatures {
     fn from(features: SubnetFeatures) -> pb::SubnetFeatures {
         Self {
-            canister_sandboxing: features.canister_sandboxing,
             http_requests: features.http_requests,
             sev_enabled: features.sev_enabled.then_some(true),
         }
@@ -57,7 +51,6 @@ impl From<SubnetFeatures> for pb::SubnetFeatures {
 impl From<pb::SubnetFeatures> for SubnetFeatures {
     fn from(features: pb::SubnetFeatures) -> SubnetFeatures {
         Self {
-            canister_sandboxing: features.canister_sandboxing,
             http_requests: features.http_requests,
             sev_enabled: features.sev_enabled.unwrap_or_default(),
         }
@@ -77,7 +70,6 @@ impl FromStr for SubnetFeatures {
 
         for feature in string.split(',') {
             match feature {
-                "canister_sandboxing" => features.canister_sandboxing = true,
                 "http_requests" => features.http_requests = true,
                 "sev_enabled" => features.sev_enabled = true,
                 _ => return Err(format!("Unknown feature {feature:?} in {string:?}")),
@@ -214,11 +206,11 @@ mod tests {
 
     #[test]
     fn test_double_entries_are_handled() {
-        let result = SubnetFeatures::from_str("canister_sandboxing,canister_sandboxing").unwrap();
+        let result = SubnetFeatures::from_str("http_requests,http_requests").unwrap();
         assert_eq!(
             result,
             SubnetFeatures {
-                canister_sandboxing: true,
+                http_requests: true,
                 ..SubnetFeatures::default()
             }
         );


### PR DESCRIPTION
This PR drops the unused `canister_sandboxing` subnet feature from registry.

The fact that the feature flag is unused is obvious since it is set to false for all ICP mainnet subnets subnets although canister sandboxing is enabled on all of them.