### PR TITLE
chore: extract types into a shared libary for engine-controller canister

### DIFF
--- a/rs/engine_controller/BUILD.bazel
+++ b/rs/engine_controller/BUILD.bazel
@@ -1,7 +1,19 @@
-load("@rules_rust//rust:defs.bzl", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 load("//bazel:canisters.bzl", "rust_canister")
 
 package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "ic_engine_controller",
+    srcs = ["src/lib.rs"],
+    crate_name = "ic_engine_controller",
+    deps = [
+        # Keep sorted.
+        "//rs/registry/canister",
+        "@crate_index//:candid",
+        "@crate_index//:serde",
+    ],
+)
 
 rust_canister(
     name = "engine-controller-canister",
@@ -10,6 +22,7 @@ rust_canister(
     service_file = ":engine_controller.did",
     deps = [
         # Keep sorted.
+        ":ic_engine_controller",
         "//rs/nns/constants",
         "//rs/protobuf",
         "//rs/registry/canister",
@@ -17,7 +30,6 @@ rust_canister(
         "//rs/types/base_types",
         "@crate_index//:candid",
         "@crate_index//:ic-cdk",
-        "@crate_index//:serde",
     ],
 )
 
@@ -28,6 +40,7 @@ rust_test(
     crate_root = "canister/canister.rs",
     deps = [
         # Keep sorted.
+        ":ic_engine_controller",
         "//rs/nns/constants",
         "//rs/protobuf",
         "//rs/registry/canister",
@@ -36,7 +49,6 @@ rust_test(
         "@crate_index//:candid",
         "@crate_index//:candid_parser",
         "@crate_index//:ic-cdk",
-        "@crate_index//:serde",
     ],
 )
 
@@ -59,6 +71,7 @@ rust_test(
     },
     deps = [
         # Keep sorted.
+        ":ic_engine_controller",
         "//packages/pocket-ic",
         "//rs/nns/constants",
         "//rs/nns/test_utils",
@@ -72,7 +85,6 @@ rust_test(
         "@crate_index//:candid",
         "@crate_index//:ic-management-canister-types",
         "@crate_index//:prost",
-        "@crate_index//:serde",
         "@crate_index//:tokio",
     ],
 )

--- a/rs/engine_controller/Cargo.toml
+++ b/rs/engine_controller/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 name = "ic-engine-controller"
 version.workspace = true
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 name = "engine-controller-canister"
 path = "canister/canister.rs"

--- a/rs/engine_controller/canister/canister.rs
+++ b/rs/engine_controller/canister/canister.rs
@@ -3,17 +3,19 @@
 //! This canister provides a thin user-facing API on top of the registry
 //! canister's `create_subnet` / `delete_subnet` endpoints. Only a single,
 //! hard-coded authorized principal may invoke its methods.
-use candid::{CandidType, Principal};
+use candid::Principal;
 use ic_base_types::{NodeId, PrincipalId, SubnetId};
 use ic_cdk::{api::msg_caller, call::Call, init, post_upgrade, println, update};
+use ic_engine_controller::{
+    CreateEngineArgs, DeleteEngineArgs, EngineControllerInitArgs, NewSubnet,
+};
 use ic_nns_constants::REGISTRY_CANISTER_ID;
 use ic_protobuf::registry::subnet::v1::SubnetFeatures;
 use ic_registry_subnet_type::SubnetType;
 use registry_canister::mutations::do_create_subnet::{
-    CanisterCyclesCostSchedule, CreateSubnetPayload, NewSubnet,
+    CanisterCyclesCostSchedule, CreateSubnetPayload,
 };
 use registry_canister::mutations::do_delete_subnet::DeleteSubnetPayload;
-use serde::Deserialize;
 use std::cell::RefCell;
 use std::collections::HashSet;
 
@@ -60,17 +62,6 @@ fn default_initial_dkg_subnet_id() -> SubnetId {
     SubnetId::new(PrincipalId(p))
 }
 
-#[derive(Clone, Debug, Default, CandidType, Deserialize)]
-pub struct EngineControllerInitArgs {
-    /// If `Some`, replaces the default authorized caller; if `None`, the
-    /// default is kept.
-    pub authorized_caller: Option<Principal>,
-    /// If `Some`, replaces the default `initial_dkg_subnet_id` used when
-    /// forwarding `CreateSubnetPayload` to the registry; if `None`, the
-    /// hard-coded default is kept.
-    pub initial_dkg_subnet_id: Option<Principal>,
-}
-
 fn apply_init_args(args: Option<EngineControllerInitArgs>) {
     let args = args.unwrap_or_default();
     let authorized = args
@@ -96,19 +87,6 @@ fn init(args: Option<EngineControllerInitArgs>) {
 #[post_upgrade]
 fn post_upgrade(args: Option<EngineControllerInitArgs>) {
     apply_init_args(args);
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct CreateEngineArgs {
-    pub node_ids: Vec<Principal>,
-    pub subnet_admins: Vec<Principal>,
-    /// Blessed replica version that the new engine subnet should run.
-    pub replica_version_id: String,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct DeleteEngineArgs {
-    pub subnet_id: Principal,
 }
 
 fn ensure_authorized() -> Result<Principal, String> {

--- a/rs/engine_controller/src/lib.rs
+++ b/rs/engine_controller/src/lib.rs
@@ -1,0 +1,35 @@
+//! Shared types for the engine controller canister.
+//!
+//! This crate exposes the Candid-encoded argument and response types used by
+//! the engine controller canister so that clients (other canisters, agents,
+//! tests) can depend on a single source of truth instead of redeclaring them.
+use candid::{CandidType, Principal};
+use serde::Deserialize;
+
+// Re-export the response type returned by `create_engine` so clients don't
+// have to depend on `registry-canister` directly just to decode it.
+pub use registry_canister::mutations::do_create_subnet::NewSubnet;
+
+#[derive(Clone, Debug, Default, CandidType, Deserialize)]
+pub struct EngineControllerInitArgs {
+    /// If `Some`, replaces the default authorized caller; if `None`, the
+    /// default is kept.
+    pub authorized_caller: Option<Principal>,
+    /// If `Some`, replaces the default `initial_dkg_subnet_id` used when
+    /// forwarding `CreateSubnetPayload` to the registry; if `None`, the
+    /// hard-coded default is kept.
+    pub initial_dkg_subnet_id: Option<Principal>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct CreateEngineArgs {
+    pub node_ids: Vec<Principal>,
+    pub subnet_admins: Vec<Principal>,
+    /// Blessed replica version that the new engine subnet should run.
+    pub replica_version_id: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct DeleteEngineArgs {
+    pub subnet_id: Principal,
+}

--- a/rs/engine_controller/tests/tests.rs
+++ b/rs/engine_controller/tests/tests.rs
@@ -4,9 +4,12 @@
 //! set of nodes and an invariant-compliant base state, install the
 //! engine_controller canister at the canonical `ENGINE_CONTROLLER_CANISTER_ID`,
 //! and exercise its public API end-to-end.
-use candid::{CandidType, Decode, Encode, Principal};
+use candid::{Decode, Encode, Principal};
 use canister_test::Project;
 use ic_base_types::{NodeId, PrincipalId, SubnetId};
+use ic_engine_controller::{
+    CreateEngineArgs, DeleteEngineArgs, EngineControllerInitArgs, NewSubnet,
+};
 use ic_management_canister_types::CanisterSettings;
 use ic_nns_constants::{ENGINE_CONTROLLER_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_nns_test_utils::common::build_registry_wasm;
@@ -29,38 +32,14 @@ use prost::Message;
 use registry_canister::init::RegistryCanisterInitPayloadBuilder;
 use registry_canister::mutations::node_management::common::make_add_node_registry_mutations;
 use registry_canister::mutations::node_management::do_add_node::connection_endpoint_from_string;
-use serde::Deserialize;
 use std::convert::TryFrom;
 
 // Must match the principal hard-coded in `engine_controller`.
 const AUTHORIZED_CALLER: &str = "bct5z-vccu4-6q4t2-3lb6l-wm43p-ulppt-o5sqq-w6het-rthdz-qp4yn-fqe";
 
-#[derive(Clone, Debug, Default, CandidType, Deserialize)]
-struct EngineControllerInitArgs {
-    authorized_caller: Option<Principal>,
-    initial_dkg_subnet_id: Option<Principal>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct NewSubnet {
-    new_subnet_id: Option<Principal>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct CreateEngineArgs {
-    node_ids: Vec<Principal>,
-    subnet_admins: Vec<Principal>,
-    replica_version_id: String,
-}
-
 /// Replica version that the registry test fixtures have already blessed.
 fn test_replica_version() -> String {
     ReplicaVersion::default().to_string()
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct DeleteEngineArgs {
-    subnet_id: Principal,
 }
 
 fn authorized() -> Principal {
@@ -272,8 +251,7 @@ async fn create_engine_then_delete_engine_succeeds() {
     assert_eq!(new_subnets.len(), 1, "exactly one new subnet must appear");
     let new_subnet_id = SubnetId::new(PrincipalId::try_from(new_subnets[0].as_slice()).unwrap());
     assert_eq!(
-        returned_subnet_id,
-        new_subnet_id.get().0,
+        returned_subnet_id, new_subnet_id,
         "returned subnet id must match the one in the registry"
     );
 


### PR DESCRIPTION
Since the canister was very quickly built, we missed to extract its interface as a crate that is importable by other projects. This PR does that.