### PR TITLE
chore: bump aspect_bazel_lib and rules_foreign_cc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ register_toolchains("@rules_buf_toolchains//:all")
 
 # General Bazel helpers
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
-bazel_dep(name = "aspect_bazel_lib", version = "2.9.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
@@ -30,26 +30,23 @@ single_version_override(
 )
 
 # configure/make dependencies
-bazel_dep(name = "rules_foreign_cc", version = "0.14.0")
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
 
 register_toolchains(
     "@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain",
     "@rules_foreign_cc//toolchains:preinstalled_make_toolchain",
 )
 
-# Use HEAD to include this commit which is needed for preinstalled toolchains to work
-# https://github.com/bazel-contrib/rules_foreign_cc/commit/d03f7ae79ddda0ad228b17048b9e2dc0efcc8e95
-#
 # Use a patch to work around determinism issues in make & pkgconfig toolchains
 # https://github.com/bazel-contrib/rules_foreign_cc/issues/1313
 archive_override(
     module_name = "rules_foreign_cc",
-    integrity = "sha384-bTtlZejENu+3rnOsCg1nmSZJl54++7nB0zgzWT+jtZJ1QyMRwkV4ieOaeORQTdjY",
+    integrity = "sha256-MnWXKJE8N2ukWwEWhptxtoscLr+PK897QSIrwHt3PXM=",
     patch_strip = 1,
     patches = ["//bazel:rules_foreign_cc.patch"],
-    strip_prefix = "rules_foreign_cc-77d4483fadbb1b7bcace18ed8e8e87e8791050f6",
+    strip_prefix = "rules_foreign_cc-0.15.1",
     type = "tar.gz",
-    urls = ["https://codeload.github.com/bazelbuild/rules_foreign_cc/tar.gz/77d4483fadbb1b7bcace18ed8e8e87e8791050f6"],
+    urls = ["https://github.com/bazel-contrib/rules_foreign_cc/releases/download/0.15.1/rules_foreign_cc-0.15.1.tar.gz"],
 )
 
 # Misc tools

--- a/bazel/rules_foreign_cc.patch
+++ b/bazel/rules_foreign_cc.patch
@@ -1,14 +1,15 @@
-# Avoid build logs that create sources of non-determinism
+# Avoid build logs that create sources of non-determinism.
+# On a successful build we empty the build log (which is declared as an action
+# output) since it contains non-deterministic content (absolute paths,
+# timestamps). On failure the log is still printed for debugging.
 diff --git a/foreign_cc/private/framework.bzl b/foreign_cc/private/framework.bzl
-index 33129b8..7326107 100644
 --- a/foreign_cc/private/framework.bzl
 +++ b/foreign_cc/private/framework.bzl
-@@ -616,7 +616,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text, env_prelude, build_
-     cleanup_on_success_function = create_function(
-         ctx,
-         "cleanup_on_success",
--        "rm -rf $$BUILD_TMPDIR$$ $$EXT_BUILD_DEPS$$",
-+        "rm -rf $$BUILD_TMPDIR$$ $$EXT_BUILD_DEPS$$ && echo > $$BUILD_LOG$$",
+@@ -647,6 +647,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text, env_prelude, build_
+         "\n".join([
+             "##rm_rf## $$BUILD_TMPDIR$$",
+             "##rm_rf## $$EXT_BUILD_DEPS$$",
++            "echo > $$BUILD_LOG$$",
+         ]),
      )
      cleanup_on_failure_function = create_function(
-         ctx,

--- a/third_party/BUILD.e2fsprogs.bazel
+++ b/third_party/BUILD.e2fsprogs.bazel
@@ -51,10 +51,10 @@ configure_make(
     # The headers under include/ are kept since rules_foreign_cc declares them
     # as an output.
     postfix_script = (
-        "mkdir -p $$INSTALLDIR/bin"
-        + " && cp $$INSTALLDIR/sbin/mke2fs $$INSTALLDIR/bin/mke2fs"
-        + " && find $$INSTALLDIR -mindepth 1 -maxdepth 1 ! -name bin ! -name include -exec rm -rf {} +"
-        + " && find $$INSTALLDIR/bin -mindepth 1 ! -name mke2fs -delete"
+        "mkdir -p $$INSTALLDIR/bin" +
+        " && cp $$INSTALLDIR/sbin/mke2fs $$INSTALLDIR/bin/mke2fs" +
+        " && find $$INSTALLDIR -mindepth 1 -maxdepth 1 ! -name bin ! -name include -exec rm -rf {} +" +
+        " && find $$INSTALLDIR/bin -mindepth 1 ! -name mke2fs -delete"
     ),
     # Static glibc linking is a Linux/glibc thing; this isn't expected to work
     # elsewhere.

--- a/third_party/BUILD.e2fsprogs.bazel
+++ b/third_party/BUILD.e2fsprogs.bazel
@@ -51,10 +51,10 @@ configure_make(
     # The headers under include/ are kept since rules_foreign_cc declares them
     # as an output.
     postfix_script = (
-        "mkdir -p $$INSTALLDIR$$/bin && " +
-        "cp $$INSTALLDIR$$/sbin/mke2fs $$INSTALLDIR$$/bin/mke2fs && " +
-        "find $$INSTALLDIR$$ -mindepth 1 -maxdepth 1 ! -name bin ! -name include -exec rm -rf {} + && " +
-        "find $$INSTALLDIR$$/bin -mindepth 1 ! -name mke2fs -delete"
+        "mkdir -p $$INSTALLDIR/bin"
+        + " && cp $$INSTALLDIR/sbin/mke2fs $$INSTALLDIR/bin/mke2fs"
+        + " && find $$INSTALLDIR -mindepth 1 -maxdepth 1 ! -name bin ! -name include -exec rm -rf {} +"
+        + " && find $$INSTALLDIR/bin -mindepth 1 ! -name mke2fs -delete"
     ),
     # Static glibc linking is a Linux/glibc thing; this isn't expected to work
     # elsewhere.


### PR DESCRIPTION
This bumps some bazel dependencies. Updating these will make the upgrade to Bazel 9 smoother.