### PR TITLE
fix: Also reduce read_ahead for dm-* devices

### DIFF
--- a/ic-os/components/guestos/misc/sysfs.d/read_ahead.conf
+++ b/ic-os/components/guestos/misc/sysfs.d/read_ahead.conf
@@ -1,10 +1,5 @@
 # Block device read_ahead configuration
 #
 
-block/dm-1/queue/read_ahead_kb = 128
-block/dm-2/queue/read_ahead_kb = 128
-block/dm-3/queue/read_ahead_kb = 128
-block/dm-4/queue/read_ahead_kb = 128
-block/dm-5/queue/read_ahead_kb = 128
-block/dm-6/queue/read_ahead_kb = 128
+block/dm-*/queue/read_ahead_kb = 128
 block/vda/queue/read_ahead_kb = 128

--- a/ic-os/components/guestos/misc/sysfs.d/read_ahead.conf
+++ b/ic-os/components/guestos/misc/sysfs.d/read_ahead.conf
@@ -1,4 +1,10 @@
 # Block device read_ahead configuration
 #
 
+block/dm-1/queue/read_ahead_kb = 128
+block/dm-2/queue/read_ahead_kb = 128
+block/dm-3/queue/read_ahead_kb = 128
+block/dm-4/queue/read_ahead_kb = 128
+block/dm-5/queue/read_ahead_kb = 128
+block/dm-6/queue/read_ahead_kb = 128
 block/vda/queue/read_ahead_kb = 128


### PR DESCRIPTION
Looks like it was actually dm-2 (store-crypt) and/or dm-4 (store-shared--data, more likely) suffering from read amplification, not vda. They're probably all the same (virtual?) device underneath, which is why reads appear to be spiking on all 3 at once. But it's likely the shared data partition that is actually being pounded.

Reduce the read-ahead for all these devices similar to what was done for vda, just to be safe.