### PR TITLE
fix: honor --json for ic-admin get-elected-{guestos,hostos}-versions

### DIFF
--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -4909,8 +4909,10 @@ async fn main() {
                 .unwrap_or_default();
 
             if opts.json {
-                let version_ids: Vec<String> =
-                    guestos_versions.into_iter().map(|(version, _)| version).collect();
+                let version_ids: Vec<String> = guestos_versions
+                    .into_iter()
+                    .map(|(version, _)| version)
+                    .collect();
                 println!("{}", serde_json::to_string_pretty(&version_ids).unwrap());
             } else {
                 for (version, _) in guestos_versions {

--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -4905,9 +4905,14 @@ async fn main() {
 
             let guestos_versions = registry_client
                 .get_all_replica_version_records(registry_client.get_latest_version())
-                .unwrap();
+                .unwrap()
+                .unwrap_or_default();
 
-            if let Some(guestos_versions) = guestos_versions {
+            if opts.json {
+                let version_ids: Vec<String> =
+                    guestos_versions.into_iter().map(|(version, _)| version).collect();
+                println!("{}", serde_json::to_string_pretty(&version_ids).unwrap());
+            } else {
                 for (version, _) in guestos_versions {
                     println!("{}", version);
                 }
@@ -5861,9 +5866,16 @@ async fn main() {
 
             let hostos_versions = registry_client
                 .get_hostos_versions(registry_client.get_latest_version())
-                .unwrap();
+                .unwrap()
+                .unwrap_or_default();
 
-            if let Some(hostos_versions) = hostos_versions {
+            if opts.json {
+                let version_ids: Vec<String> = hostos_versions
+                    .into_iter()
+                    .map(|version| version.hostos_version_id)
+                    .collect();
+                println!("{}", serde_json::to_string_pretty(&version_ids).unwrap());
+            } else {
                 for version in hostos_versions {
                     println!("{}", version.hostos_version_id);
                 }


### PR DESCRIPTION
## Summary

`ic-admin get-elected-guestos-versions --json` (alias `get-blessed-replica-versions`) stopped emitting JSON. The handler used to print JSON via the generic `print_and_get_last_value` helper, but #10301 rewrote it to enumerate `ReplicaVersionRecord` entries with a plain `println!` loop and never re-wired `opts.json`. Since `--json` is a global flag, it is still accepted but silently ignored, so the command always prints plaintext. `get-elected-hostos-versions` had the same plaintext-only behavior.

This broke downstream automation in `dre-airflow`, which parsed the JSON output and started failing with `JSONDecodeError: Extra data: line 1 column 7 (char 6)` (the first version hash's leading digits parsed as an integer).

This PR restores `--json` for both subcommands:
- with `--json`: print the elected version IDs as a JSON array (`["<hash>", ...]`)
- without `--json`: unchanged, newline-separated version IDs

## How was this tested?

`bazel build //rs/registry/admin:ic-admin` builds successfully.

Manual shape (with `--json`):
```json
[
  "abc...def",
  "012...789"
]
```