### PR TITLE
fix: use proxy-local.dfinity.network

### DIFF
--- a/rs/tests/upload_systest_dep.sh
+++ b/rs/tests/upload_systest_dep.sh
@@ -106,6 +106,6 @@ fi
 echo "dep '$dep_filename': cluster is '$cluster'" >&2
 
 # Use the direct URL, without going through the redirect server
-dep_download_url="http://$cluster.artifacts.proxy-global.dfinity.network:8080/cas/$dep_sha256"
+dep_download_url="http://$cluster.artifacts.proxy-local.dfinity.network:8080/cas/$dep_sha256"
 echo "dep '$dep_filename': download_url: '$dep_download_url'" >&2
 echo "$dep_download_url"


### PR DESCRIPTION
A new domain besides `proxy-global.dfinity.network`has been introduced called `proxy-local.dfinity.network` which points to the link local `fe80::2` IPv6 address. Then in each DC where we have Farm hosts (fr1, dm1, zh1) we have one of the dc_http_proxy nginx servers listen on that link local `fe80::2` address. Then this commit repoints the URL to download images from from `proxy-global.dfinity.network` to `proxy-local.dfinity.network`. This will mean that when an IC node downloads an image it will always go to a local dc_http_proxy nginx server instead of hopping over the Atlantic. It could still mean that the local nginx has to hop over the Atlantic to download the image from its source but we avoid the double Atlantic transfers that have been causing flakiness.