### PR TITLE
feat: [NODE-1963] Copy only the latest few logfiles

### DIFF
--- a/ic-os/components/guestos/init/setup-encryption/setup-var-encryption.sh
+++ b/ic-os/components/guestos/init/setup-encryption/setup-var-encryption.sh
@@ -9,9 +9,9 @@ function transfer_log_state() {
     MACHINE_ID=$(cat /etc/machine-id || echo invalid)
     echo "Successfully mounted old /var partition, copying contents for machine id: ${MACHINE_ID}"
 
-    # First, copy actual journal files.
-    mkdir -p /mnt/var_new/log/journal
-    if cp -vr /mnt/var_old/log/journal/"${MACHINE_ID}" /mnt/var_new/log/journal/"${MACHINE_ID}"; then
+    # First, copy latest journal files.
+    mkdir -p /mnt/var_new/log/journal/"${MACHINE_ID}"
+    if cp -pv $(ls -t /mnt/var_old/log/journal/"${MACHINE_ID}"/*.journal | head -3) /mnt/var_new/log/journal/"${MACHINE_ID}"/; then
         chown -R root.systemd-journal /mnt/var_new/log/journal/
         chcon -R system_u:object_r:systemd_journal_t:s0 /mnt/var_new/log/journal/"${MACHINE_ID}"
         ls -lZ /mnt/var_new/log/journal/"${MACHINE_ID}"


### PR DESCRIPTION
In theory, at this point, we have already collected all of the logs we need. Copying the logs here saves the last few logs before a shutdown, so a handful of the most recent logfiles should be fine.