### PR TITLE
feat: [DSM-142] Improve `process_batch()` phase duration coverage

### DIFF
--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -52,7 +52,8 @@ use ic_utils_thread::JoinOnDrop;
 #[cfg(test)]
 use mockall::automock;
 use prometheus::{
-    Gauge, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    Gauge, Histogram, HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::convert::{AsRef, TryFrom};
@@ -85,6 +86,8 @@ const STATUS_QUEUE_FULL: &str = "queue_full";
 const STATUS_SUCCESS: &str = "success";
 
 const PHASE_LOAD_STATE: &str = "load_state";
+const PHASE_READ_REGISTRY: &str = "read_registry";
+const PHASE_GARBAGE_COLLECT: &str = "garbage_collect";
 const PHASE_COMMIT: &str = "commit";
 
 /// Label for message kind: "request" or "response".
@@ -526,6 +529,12 @@ impl MessageRoutingMetrics {
             batch_time
         );
     }
+
+    pub fn start_phase_timer(&self, phase: &str) -> HistogramTimer {
+        self.process_batch_phase_duration
+            .with_label_values(&[phase])
+            .start_timer()
+    }
 }
 
 impl DroppedMessageMetrics for MessageRoutingMetrics {
@@ -697,15 +706,6 @@ impl<RegistryClient_: RegistryClient> BatchProcessorImpl<RegistryClient_> {
             log,
             malicious_flags,
         }
-    }
-
-    /// Adds an observation to the `METRIC_PROCESS_BATCH_PHASE_DURATION`
-    /// histogram for the given phase.
-    fn observe_phase_duration(&self, phase: &str, since: &Instant) {
-        self.metrics
-            .process_batch_phase_duration
-            .with_label_values(&[phase])
-            .observe(since.elapsed().as_secs_f64());
     }
 
     /// Reads registry contents required by `BatchProcessorImpl::process_batch()`.
@@ -1321,7 +1321,7 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
     #[instrument(skip_all)]
     fn process_batch(&self, batch: Batch) {
         let since = Instant::now();
-        let _process_batch_start = since;
+        let load_state_timer = self.metrics.start_phase_timer(PHASE_LOAD_STATE);
 
         // Fetch the mutable tip from StateManager
         let mut state = match self
@@ -1380,10 +1380,11 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
                 .set(batch.batch_number.get() as i64);
             state.metadata.subnet_split_from = None;
         }
-        self.observe_phase_duration(PHASE_LOAD_STATE, &since);
+        load_state_timer.observe_duration();
 
         debug!(self.log, "Processing batch {}", batch.batch_number);
 
+        let read_registry_timer = self.metrics.start_phase_timer(PHASE_READ_REGISTRY);
         let certification_scope = if batch.requires_full_state_hash() {
             CertificationScope::Full
         } else {
@@ -1412,14 +1413,13 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
                 .with_label_values(&[&failed_blockmaker.to_string()])
                 .inc();
         }
-
         state
             .metadata
             .blockmaker_metrics_time_series
             .observe(batch.time, &batch.blockmaker_metrics);
+        read_registry_timer.observe_duration();
 
         let batch_summary = batch.batch_summary.clone();
-
         let batch_number = batch.batch_number;
         let mut state_after_round = self.state_machine.execute_round(
             state,
@@ -1431,6 +1431,8 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
             node_public_keys,
             api_boundary_nodes,
         );
+
+        let garbage_collect_timer = self.metrics.start_phase_timer(PHASE_GARBAGE_COLLECT);
         // Prune any orphaned canister priorities.
         state_after_round.garbage_collect_subnet_schedule();
         // Garbage collect empty canister queue pairs before checkpointing.
@@ -1451,18 +1453,18 @@ impl<RegistryClient_: RegistryClient> BatchProcessor for BatchProcessorImpl<Regi
         }
 
         #[cfg(feature = "malicious_code")]
-        if let Some(delay) = self.malicious_flags.delay_execution(_process_batch_start) {
+        if let Some(delay) = self.malicious_flags.delay_execution(since) {
             info!(self.log, "[MALICIOUS]: Delayed execution by {:?}", delay);
         }
+        garbage_collect_timer.observe_duration();
 
-        let phase_since = Instant::now();
-
+        let commit_timer = self.metrics.start_phase_timer(PHASE_COMMIT);
         self.state_manager.commit_and_certify(
             state_after_round,
             certification_scope,
             batch_summary,
         );
-        self.observe_phase_duration(PHASE_COMMIT, &phase_since);
+        commit_timer.observe_duration();
 
         self.metrics
             .process_batch_duration

--- a/rs/messaging/src/message_routing.rs
+++ b/rs/messaging/src/message_routing.rs
@@ -302,24 +302,24 @@ pub(crate) struct MessageRoutingMetrics {
     /// Most recently seen certified height, per remote subnet
     pub(crate) remote_certified_heights: IntGaugeVec,
     /// Batch processing phase durations, by phase.
-    pub(crate) process_batch_phase_duration: HistogramVec,
+    process_batch_phase_duration: HistogramVec,
     /// Number of timed out messages.
-    pub(crate) timed_out_messages_total: IntCounterVec,
+    timed_out_messages_total: IntCounterVec,
     /// Number of timed out callbacks.
     pub(crate) timed_out_callbacks_total: IntCounter,
     /// Number of shed best-effort messages.
-    pub(crate) shed_messages_total: IntCounterVec,
+    shed_messages_total: IntCounterVec,
     /// Byte size of shed best-effort messages.
-    pub(crate) shed_message_bytes_total: IntCounterVec,
+    shed_message_bytes_total: IntCounterVec,
     /// Height at which the subnet last split (if during the lifetime of this
     /// replica process; otherwise zero).
-    pub(crate) subnet_split_height: IntGaugeVec,
+    subnet_split_height: IntGaugeVec,
     /// Number of blocks proposed.
-    pub(crate) blocks_proposed_total: IntCounter,
+    blocks_proposed_total: IntCounter,
     /// Number of blocks not proposed.
-    pub(crate) blocks_not_proposed_total: IntCounter,
+    blocks_not_proposed_total: IntCounter,
     /// Number of blocks not proposed by blockmaker ID.
-    pub(crate) blocks_not_proposed_by_blockmaker_total: IntCounterVec,
+    blocks_not_proposed_by_blockmaker_total: IntCounterVec,
 
     subnet_info: IntGaugeVec,
     subnet_size: IntGauge,

--- a/rs/messaging/src/state_machine.rs
+++ b/rs/messaging/src/state_machine.rs
@@ -15,7 +15,6 @@ use ic_registry_subnet_features::SubnetFeatures;
 use ic_replicated_state::{NetworkTopology, ReplicatedState};
 use ic_types::batch::{Batch, BatchContent};
 use ic_types::{ExecutionRound, NumBytes, SubnetId};
-use std::time::Instant;
 
 #[cfg(test)]
 mod tests;
@@ -69,15 +68,6 @@ impl StateMachineImpl {
         }
     }
 
-    /// Adds an observation to the `METRIC_PROCESS_BATCH_PHASE_DURATION`
-    /// histogram for the given phase.
-    fn observe_phase_duration(&self, phase: &str, since: &Instant) {
-        self.metrics
-            .process_batch_phase_duration
-            .with_label_values(&[phase])
-            .observe(since.elapsed().as_secs_f64());
-    }
-
     /// Runs a special round during which the state is split (and no messages are
     /// inducted, executed or routed).
     ///
@@ -122,7 +112,7 @@ impl StateMachine for StateMachineImpl {
         node_public_keys: NodePublicKeys,
         api_boundary_nodes: ApiBoundaryNodes,
     ) -> ReplicatedState {
-        let since = Instant::now();
+        let time_out_messages_timer = self.metrics.start_phase_timer(PHASE_TIME_OUT_MESSAGES);
 
         if batch.time > state.metadata.batch_time {
             state.metadata.batch_time = batch.time;
@@ -190,10 +180,10 @@ impl StateMachine for StateMachineImpl {
         let balance_before_time_out = state.balance_with_messages();
 
         state.time_out_messages(&self.metrics);
-        self.observe_phase_duration(PHASE_TIME_OUT_MESSAGES, &since);
+        time_out_messages_timer.observe_duration();
 
         // Time out expired callbacks.
-        let since = Instant::now();
+        let time_out_callbacks_timer = self.metrics.start_phase_timer(PHASE_TIME_OUT_CALLBACKS);
         let (timed_out_callbacks, errors) = state.time_out_callbacks();
         self.metrics
             .timed_out_callbacks_total
@@ -210,11 +200,10 @@ impl StateMachine for StateMachineImpl {
         }
         #[cfg(debug_assertions)]
         state.assert_balance_with_messages(balance_before_time_out);
-
-        self.observe_phase_duration(PHASE_TIME_OUT_CALLBACKS, &since);
+        time_out_callbacks_timer.observe_duration();
 
         // Preprocess messages and add messages to the induction pool through the Demux.
-        let since = Instant::now();
+        let induction_timer = self.metrics.start_phase_timer(PHASE_INDUCTION);
         let current_round = ExecutionRound::from(batch.batch_number.get());
         let mut state_with_messages =
             self.demux
@@ -232,7 +221,7 @@ impl StateMachine for StateMachineImpl {
             .consensus_queue
             .append(&mut consensus_responses);
 
-        self.observe_phase_duration(PHASE_INDUCTION, &since);
+        induction_timer.observe_duration();
 
         let execution_round_type = if requires_full_state_hash {
             ExecutionRoundType::CheckpointRound
@@ -241,7 +230,7 @@ impl StateMachine for StateMachineImpl {
         };
 
         // Process messages from the induction pool through the Scheduler.
-        let since = Instant::now();
+        let execution_timer = self.metrics.start_phase_timer(PHASE_EXECUTION);
         let round_summary = batch.batch_summary.map(|b| ExecutionRoundSummary {
             next_checkpoint_round: ExecutionRound::from(b.next_checkpoint_height.get()),
             current_interval_length: ExecutionRound::from(b.current_interval_length.get()),
@@ -263,25 +252,25 @@ impl StateMachine for StateMachineImpl {
                 batch.batch_number
             )
         }
-        self.observe_phase_duration(PHASE_EXECUTION, &since);
+        execution_timer.observe_duration();
 
         // Postprocess the state: route messages into streams.
-        let since = Instant::now();
+        let message_routing_timer = self.metrics.start_phase_timer(PHASE_MESSAGE_ROUTING);
         #[cfg(debug_assertions)]
         let balance_before_routing = state_after_execution.balance_with_messages();
         let mut state_after_stream_builder =
             self.stream_builder.build_streams(state_after_execution);
-        self.observe_phase_duration(PHASE_MESSAGE_ROUTING, &since);
+        message_routing_timer.observe_duration();
 
         // Shed enough messages to stay below the best-effort message memory limit.
-        let since = Instant::now();
+        let shed_messages_timer = self.metrics.start_phase_timer(PHASE_SHED_MESSAGES);
         state_after_stream_builder.enforce_best_effort_message_limit(
             self.best_effort_message_memory_capacity,
             &self.metrics,
         );
         #[cfg(debug_assertions)]
         state_after_stream_builder.assert_balance_with_messages(balance_before_routing);
-        self.observe_phase_duration(PHASE_SHED_MESSAGES, &since);
+        shed_messages_timer.observe_duration();
 
         state_after_stream_builder
     }


### PR DESCRIPTION
Following the introduction of structured `CanisterStates` (hot vs cold canisters), almost half of the remaining DSM overhead is not covered by `mr_process_batch_phase_duration_seconds`, so it can only be bundled under "other" (the difference to `mr_process_batch_duration_seconds`).

Explicitly track `read_registry()` duration (including blockmaker metrics updates, likely insignificant); and schedule/queues garbage collection plus (heavy) `canister_state_bytes` computation.