### PR TITLE
chore: migration canister rejects canister migration from/to cloud engine

### DIFF
--- a/rs/migration_canister/migration_canister.did
+++ b/rs/migration_canister/migration_canister.did
@@ -23,6 +23,7 @@ type ValidationError = variant {
   MigrationsDisabled : reserved;
   MigratedCanisterNotReady : reserved;
   MigratedCanisterInsufficientCycles : reserved;
+  CloudEngineSubnet : record { subnet : principal };
   SameSubnet : reserved;
   ReplacedCanisterNotStopped : reserved;
 };

--- a/rs/migration_canister/src/external_interfaces/registry.rs
+++ b/rs/migration_canister/src/external_interfaces/registry.rs
@@ -8,6 +8,18 @@ use crate::{ValidationError, processing::ProcessingResult};
 
 const REGISTRY_CANISTER_ID: &str = "rwlgt-iiaaa-aaaaa-aaaaa-cai";
 
+#[derive(Clone, Debug, CandidType, Deserialize, PartialEq)]
+pub enum SubnetType {
+    #[serde(rename = "application")]
+    Application,
+    #[serde(rename = "system")]
+    System,
+    #[serde(rename = "verified_application")]
+    VerifiedApplication,
+    #[serde(rename = "cloud_engine")]
+    CloudEngine,
+}
+
 #[derive(Clone, Debug, CandidType, Deserialize)]
 struct GetSubnetForCanisterArgs {
     principal: Option<Principal>,
@@ -45,19 +57,60 @@ pub async fn get_subnet_for_canister(canister_id: Principal) -> Result<Principal
                 }),
                 Some(subnet_id) => Ok(subnet_id),
             },
-            Ok(Err(e)) => {
-                let msg = format!(
-                    "Call `GetSubnetForCanisterResponse` for {} failed: {}",
-                    canister_id, e
-                );
-                println!("{}", msg);
-                Err(ValidationError::CallFailed { reason: msg })
-            }
+            Ok(Err(_)) => Err(ValidationError::CanisterNotFound {
+                canister: canister_id,
+            }),
             Err(e) => {
                 let msg = format!(
                     "Decoding `get_subnet_for_canister` for {} failed: {:?}",
                     canister_id, e
                 );
+                println!("{}", msg);
+                Err(ValidationError::CallFailed { reason: msg })
+            }
+        },
+    }
+}
+
+// ========================================================================= //
+// `get_subnet`
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+struct GetSubnetArgs {
+    subnet_id: Option<Principal>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+struct SubnetRecord {
+    subnet_type: SubnetType,
+}
+
+pub async fn get_subnet(subnet_id: Principal) -> Result<SubnetType, ValidationError> {
+    let args = GetSubnetArgs {
+        subnet_id: Some(subnet_id),
+    };
+
+    match Call::bounded_wait(
+        Principal::from_text(REGISTRY_CANISTER_ID).unwrap(),
+        "get_subnet",
+    )
+    .with_arg(args)
+    .await
+    {
+        Err(e) => {
+            let msg = format!("Call `get_subnet` for {} failed: {:?}", subnet_id, e);
+            println!("{}", msg);
+            Err(ValidationError::CallFailed { reason: msg })
+        }
+        Ok(response) => match response.candid::<Result<SubnetRecord, String>>() {
+            Ok(Ok(SubnetRecord { subnet_type })) => Ok(subnet_type),
+            Ok(Err(e)) => {
+                let msg = format!("Call `get_subnet` for {} failed: {}", subnet_id, e);
+                println!("{}", msg);
+                Err(ValidationError::CallFailed { reason: msg })
+            }
+            Err(e) => {
+                let msg = format!("Decoding `get_subnet` for {} failed: {:?}", subnet_id, e);
                 println!("{}", msg);
                 Err(ValidationError::CallFailed { reason: msg })
             }

--- a/rs/migration_canister/src/lib.rs
+++ b/rs/migration_canister/src/lib.rs
@@ -73,6 +73,10 @@ pub enum ValidationError {
     ReplacedCanisterNotStopped(Reserved),
     ReplacedCanisterHasSnapshots(Reserved),
     MigratedCanisterInsufficientCycles(Reserved),
+    #[strum(to_string = "ValidationError::CloudEngineSubnet {{ subnet: {subnet} }}")]
+    CloudEngineSubnet {
+        subnet: Principal,
+    },
     #[strum(to_string = "ValidationError::CallFailed {{ reason: {reason} }}")]
     CallFailed {
         reason: String,

--- a/rs/migration_canister/src/validation.rs
+++ b/rs/migration_canister/src/validation.rs
@@ -77,21 +77,25 @@ pub async fn validate_request(
         return Err(ValidationError::SameSubnet(Reserved));
     }
 
-    // 2. Are the migrated and replaced canisters on cloud engine subnets?
-    // It is safe to perform this check before acquiring locks because the fact that
-    // neither the migrated nor the replaced canister is on a cloud engine subnet
-    // cannot change later.
-    let migrated_canister_subnet = get_subnet_for_canister(migrated_canister).await?;
-    let replaced_canister_subnet = get_subnet_for_canister(replaced_canister).await?;
-    if get_subnet(migrated_canister_subnet).await? == SubnetType::CloudEngine {
-        return Err(ValidationError::CloudEngineSubnet {
-            subnet: migrated_canister_subnet,
-        });
-    }
-    if get_subnet(replaced_canister_subnet).await? == SubnetType::CloudEngine {
-        return Err(ValidationError::CloudEngineSubnet {
-            subnet: replaced_canister_subnet,
-        });
+    // The scope ensures that `migrated_canister_subnet` and `replaced_canister_subnet`
+    // cannot be used below (step 6 re-fetches the subnets after acquiring the locks).
+    {
+        // 2. Are the migrated and replaced canisters on cloud engine subnets?
+        // It is safe to perform this check before acquiring locks because the fact that
+        // neither the migrated nor the replaced canister is on a cloud engine subnet
+        // cannot change later.
+        let migrated_canister_subnet = get_subnet_for_canister(migrated_canister).await?;
+        let replaced_canister_subnet = get_subnet_for_canister(replaced_canister).await?;
+        if get_subnet(migrated_canister_subnet).await? == SubnetType::CloudEngine {
+            return Err(ValidationError::CloudEngineSubnet {
+                subnet: migrated_canister_subnet,
+            });
+        }
+        if get_subnet(replaced_canister_subnet).await? == SubnetType::CloudEngine {
+            return Err(ValidationError::CloudEngineSubnet {
+                subnet: replaced_canister_subnet,
+            });
+        }
     }
 
     // We check if the caller is authorized (i.e.,

--- a/rs/migration_canister/src/validation.rs
+++ b/rs/migration_canister/src/validation.rs
@@ -20,7 +20,7 @@ use crate::{
             CanisterStatusResponse, CanisterStatusType, assert_no_snapshots, canister_status,
             get_canister_info,
         },
-        registry::get_subnet_for_canister,
+        registry::{SubnetType, get_subnet, get_subnet_for_canister},
     },
     processing::ProcessingResult,
 };
@@ -72,21 +72,39 @@ pub async fn validate_request(
     replaced_canister: Principal,
     caller: Principal,
 ) -> Result<(Request, Vec<CanisterGuard>), ValidationError> {
-    // We first check if the caller is authorized (i.e.,
-    // if the caller is a controller of both the migrated and replaced canisters)
-    // before acquiring locks for the migrated and replaced canisters
-    // to prevent unauthorized callers from acquiring the lock
-    // and blocking authorized callers from performing canister migration.
-
     // 1. The migrated canister must not be equal to the replaced canister.
     if migrated_canister == replaced_canister {
         return Err(ValidationError::SameSubnet(Reserved));
     }
 
-    // 2. Is the caller controller of the migrated canister?
+    // 2. Are the migrated and replaced canisters on the same subnet?
+    let migrated_canister_subnet = get_subnet_for_canister(migrated_canister).await?;
+    let replaced_canister_subnet = get_subnet_for_canister(replaced_canister).await?;
+    if migrated_canister_subnet == replaced_canister_subnet {
+        return Err(ValidationError::SameSubnet(Reserved));
+    }
+    // 3. Are the migrated and replaced canisters on cloud engine subnets?
+    if get_subnet(migrated_canister_subnet).await? == SubnetType::CloudEngine {
+        return Err(ValidationError::CloudEngineSubnet {
+            subnet: migrated_canister_subnet,
+        });
+    }
+    if get_subnet(replaced_canister_subnet).await? == SubnetType::CloudEngine {
+        return Err(ValidationError::CloudEngineSubnet {
+            subnet: replaced_canister_subnet,
+        });
+    }
+
+    // We check if the caller is authorized (i.e.,
+    // if the caller is a controller of both the migrated and replaced canisters)
+    // before acquiring locks for the migrated and replaced canisters
+    // to prevent unauthorized callers from acquiring the lock
+    // and blocking authorized callers from performing canister migration.
+
+    // 4. Is the caller controller of the migrated canister?
     let migrated_canister_status =
         check_controllers_and_get_status(migrated_canister, caller).await?;
-    // 3. Is the caller controller of the replaced canister?
+    // 5. Is the caller controller of the replaced canister?
     let replaced_canister_status =
         check_controllers_and_get_status(replaced_canister, caller).await?;
 
@@ -104,7 +122,7 @@ pub async fn validate_request(
         });
     };
 
-    // 4. Is any of these canisters already in a migration process?
+    // 6. Is any of these canisters already in a migration process?
     for request in list_by(|_| true) {
         if let Some(id) = request
             .request()
@@ -113,30 +131,24 @@ pub async fn validate_request(
             return Err(ValidationError::MigrationInProgress { canister: id });
         }
     }
-    // 5. Are the migrated and replaced canisters on the same subnet?
-    let migrated_canister_subnet = get_subnet_for_canister(migrated_canister).await?;
-    let replaced_canister_subnet = get_subnet_for_canister(replaced_canister).await?;
-    if migrated_canister_subnet == replaced_canister_subnet {
-        return Err(ValidationError::SameSubnet(Reserved));
-    }
-    // 6. Is the migrated canister stopped?
+    // 7. Is the migrated canister stopped?
     if migrated_canister_status.status != CanisterStatusType::Stopped {
         return Err(ValidationError::MigratedCanisterNotStopped(Reserved));
     }
-    // 7. Is the migrated canister ready for migration?
+    // 8. Is the migrated canister ready for migration?
     if !migrated_canister_status.ready_for_migration {
         return Err(ValidationError::MigratedCanisterNotReady(Reserved));
     }
-    // 8. Is the replaced canister stopped?
+    // 9. Is the replaced canister stopped?
     if replaced_canister_status.status != CanisterStatusType::Stopped {
         return Err(ValidationError::ReplacedCanisterNotStopped(Reserved));
     }
-    // 9. Does the replaced canister have snapshots?
+    // 10. Does the replaced canister have snapshots?
     assert_no_snapshots(replaced_canister).await.into_result(
         "Call to management canister `list_canister_snapshots` failed. Try again later.",
     )?;
 
-    // 10. Does the migrated canister have sufficient cycles for the migration?
+    // 11. Does the migrated canister have sufficient cycles for the migration?
     if migrated_canister_status.cycles < CYCLES_COST_PER_MIGRATION {
         return Err(ValidationError::MigratedCanisterInsufficientCycles(
             Reserved,

--- a/rs/migration_canister/src/validation.rs
+++ b/rs/migration_canister/src/validation.rs
@@ -77,13 +77,12 @@ pub async fn validate_request(
         return Err(ValidationError::SameSubnet(Reserved));
     }
 
-    // 2. Are the migrated and replaced canisters on the same subnet?
+    // 2. Are the migrated and replaced canisters on cloud engine subnets?
+    // It is safe to perform this check before acquiring locks because the fact that
+    // neither the migrated nor the replaced canister is on a cloud engine subnet
+    // cannot change later.
     let migrated_canister_subnet = get_subnet_for_canister(migrated_canister).await?;
     let replaced_canister_subnet = get_subnet_for_canister(replaced_canister).await?;
-    if migrated_canister_subnet == replaced_canister_subnet {
-        return Err(ValidationError::SameSubnet(Reserved));
-    }
-    // 3. Are the migrated and replaced canisters on cloud engine subnets?
     if get_subnet(migrated_canister_subnet).await? == SubnetType::CloudEngine {
         return Err(ValidationError::CloudEngineSubnet {
             subnet: migrated_canister_subnet,
@@ -101,10 +100,10 @@ pub async fn validate_request(
     // to prevent unauthorized callers from acquiring the lock
     // and blocking authorized callers from performing canister migration.
 
-    // 4. Is the caller controller of the migrated canister?
+    // 3. Is the caller controller of the migrated canister?
     let migrated_canister_status =
         check_controllers_and_get_status(migrated_canister, caller).await?;
-    // 5. Is the caller controller of the replaced canister?
+    // 4. Is the caller controller of the replaced canister?
     let replaced_canister_status =
         check_controllers_and_get_status(replaced_canister, caller).await?;
 
@@ -122,7 +121,7 @@ pub async fn validate_request(
         });
     };
 
-    // 6. Is any of these canisters already in a migration process?
+    // 5. Is any of these canisters already in a migration process?
     for request in list_by(|_| true) {
         if let Some(id) = request
             .request()
@@ -130,6 +129,12 @@ pub async fn validate_request(
         {
             return Err(ValidationError::MigrationInProgress { canister: id });
         }
+    }
+    // 6. Are the migrated and replaced canisters on the same subnet?
+    let migrated_canister_subnet = get_subnet_for_canister(migrated_canister).await?;
+    let replaced_canister_subnet = get_subnet_for_canister(replaced_canister).await?;
+    if migrated_canister_subnet == replaced_canister_subnet {
+        return Err(ValidationError::SameSubnet(Reserved));
     }
     // 7. Is the migrated canister stopped?
     if migrated_canister_status.status != CanisterStatusType::Stopped {

--- a/rs/migration_canister/tests/tests.rs
+++ b/rs/migration_canister/tests/tests.rs
@@ -13,7 +13,10 @@ use ic_universal_canister::{CallArgs, UNIVERSAL_CANISTER_WASM, wasm};
 use itertools::Itertools;
 use pocket_ic::{
     CreateCanisterParams, CreateCanisterPlacement, PocketIcBuilder,
-    common::rest::{IcpFeatures, IcpFeaturesConfig},
+    common::rest::{
+        CanisterCyclesCostSchedule, ExtendedSubnetConfigSet, IcpFeatures, IcpFeaturesConfig,
+        SubnetSpec,
+    },
     nonblocking::PocketIc,
 };
 use prometheus_parse::Scrape;
@@ -53,6 +56,7 @@ pub enum ValidationError {
     ReplacedCanisterNotStopped(Reserved),
     ReplacedCanisterHasSnapshots(Reserved),
     MigratedCanisterInsufficientCycles(Reserved),
+    CloudEngineSubnet { subnet: Principal },
     CallFailed { reason: String },
 }
 
@@ -1783,4 +1787,148 @@ async fn parallel_validations() {
     }
     assert_eq!(not_controller_counter, 200);
     assert_eq!(rate_limited_counter, 60);
+}
+
+async fn migrate_with_cloud_engine_subnet(
+    migrated_on_cloud_engine: bool,
+    replaced_on_cloud_engine: bool,
+) -> Result<(), ValidationError> {
+    let pic = PocketIcBuilder::new_with_config(ExtendedSubnetConfigSet {
+        application: vec![SubnetSpec::default(), SubnetSpec::default()],
+        cloud_engine: vec![
+            SubnetSpec::default().with_cost_schedule(CanisterCyclesCostSchedule::Free),
+            SubnetSpec::default().with_cost_schedule(CanisterCyclesCostSchedule::Free),
+        ],
+        ..Default::default()
+    })
+    .with_icp_features(IcpFeatures {
+        registry: Some(IcpFeaturesConfig::DefaultConfig),
+        ..Default::default()
+    })
+    .build_async()
+    .await;
+
+    let system_controller = Principal::anonymous();
+    let c1 = Principal::self_authenticating(vec![1]);
+
+    let registry_wasm = Project::cargo_bin_maybe_from_env("registry-canister", &[]);
+    pic.upgrade_canister(
+        REGISTRY_CANISTER_ID.into(),
+        registry_wasm.bytes(),
+        vec![],
+        Some(Principal::from_text("r7inp-6aaaa-aaaaa-aaabq-cai").unwrap()),
+    )
+    .await
+    .unwrap();
+
+    let migration_canister_wasm = Project::cargo_bin_maybe_from_env("migration-canister", &[]);
+    pic.create_canister_with_id(
+        Some(system_controller),
+        Some(CanisterSettings {
+            controllers: Some(vec![system_controller]),
+            ..Default::default()
+        }),
+        MIGRATION_CANISTER_ID.into(),
+    )
+    .await
+    .unwrap();
+    pic.install_canister(
+        MIGRATION_CANISTER_ID.into(),
+        migration_canister_wasm.bytes(),
+        Encode!(&MigrationCanisterInitArgs { allowlist: None }).unwrap(),
+        Some(system_controller),
+    )
+    .await;
+
+    let topology = pic.topology().await;
+    let app_subnets = topology.get_app_subnets();
+    let cloud_engine_subnets = topology.get_cloud_engines();
+
+    let controllers = vec![c1, MIGRATION_CANISTER_ID.into()];
+
+    let migrated_subnet = if migrated_on_cloud_engine {
+        cloud_engine_subnets[0]
+    } else {
+        app_subnets[0]
+    };
+    let migrated_canister = pic
+        .create_canister_with_params(
+            Some(c1),
+            CreateCanisterParams {
+                cycles: None,
+                settings: Some(CanisterSettings {
+                    controllers: Some(controllers.clone()),
+                    ..Default::default()
+                }),
+                placement: Some(CreateCanisterPlacement::SubnetId(migrated_subnet)),
+            },
+        )
+        .await
+        .unwrap();
+    pic.add_cycles(migrated_canister, u128::MAX / 2).await;
+    pic.stop_canister(migrated_canister, Some(c1))
+        .await
+        .unwrap();
+
+    let replaced_subnet = if replaced_on_cloud_engine {
+        cloud_engine_subnets[1]
+    } else {
+        app_subnets[1]
+    };
+    let replaced_canister = pic
+        .create_canister_with_params(
+            Some(c1),
+            CreateCanisterParams {
+                cycles: None,
+                settings: Some(CanisterSettings {
+                    controllers: Some(controllers),
+                    ..Default::default()
+                }),
+                placement: Some(CreateCanisterPlacement::SubnetId(replaced_subnet)),
+            },
+        )
+        .await
+        .unwrap();
+    pic.add_cycles(replaced_canister, u128::MAX / 2).await;
+    pic.stop_canister(replaced_canister, Some(c1))
+        .await
+        .unwrap();
+
+    migrate_canister(
+        &pic,
+        c1,
+        &MigrateCanisterArgs {
+            migrated_canister_id: migrated_canister,
+            replaced_canister_id: replaced_canister,
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn validation_fails_cloud_engine_subnet() {
+    let result = migrate_with_cloud_engine_subnet(false, true).await;
+    let Err(ValidationError::CloudEngineSubnet { .. }) = result else {
+        panic!("unexpected result: {:?}", result)
+    };
+
+    let result = migrate_with_cloud_engine_subnet(true, false).await;
+    let Err(ValidationError::CloudEngineSubnet { .. }) = result else {
+        panic!("unexpected result: {:?}", result)
+    };
+}
+
+#[tokio::test]
+async fn validation_succeeds_both_app_subnets() {
+    migrate_with_cloud_engine_subnet(false, false)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn validation_fails_both_cloud_engine_subnets() {
+    let result = migrate_with_cloud_engine_subnet(true, true).await;
+    let Err(ValidationError::CloudEngineSubnet { .. }) = result else {
+        panic!("unexpected result: {:?}", result)
+    };
 }


### PR DESCRIPTION
This PR extends the migration canister to reject canister migration requests in which the migrated or replaced canister is on a cloud engine. Currently, such a canister migration is rejected because xnet calls to a cloud engine are not allowed. This PR makes the requirement explicit so that canister migration from/to a cloud engine keeps being rejected once xnet calls to a cloud engine are allowed.