### PR TITLE
fix: clean up registry after deleting subnet from PocketIC

### DIFF
--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -110,7 +110,8 @@ use ic_sns_wasm::pb::v1::{AddWasmRequest, AddWasmResponse, SnsCanisterType, SnsW
 use ic_state_machine_tests::{
     FakeVerifier, StateMachine, StateMachineBuilder, StateMachineConfig, StateMachineStateDir,
     SubmitIngressError, Subnets, WasmResult, add_global_registry_records,
-    add_initial_registry_records, update_global_registry_records,
+    add_initial_registry_records, remove_chain_key_registry_records,
+    remove_subnet_local_registry_records, update_global_registry_records,
 };
 use ic_state_manager::StateManagerImpl;
 use ic_types::batch::BlockmakerMetrics;
@@ -2801,6 +2802,12 @@ impl PocketIcSubnets {
         for subnets in self.chain_keys.values_mut() {
             subnets.retain(|&sid| sid != subnet_id);
         }
+        let empty_chain_key_ids: Vec<MasterPublicKeyId> = self
+            .chain_keys
+            .iter()
+            .filter(|(_, subnets)| subnets.is_empty())
+            .map(|(key_id, _)| key_id.clone())
+            .collect();
         self.chain_keys.retain(|_, subnets| !subnets.is_empty());
 
         // Delete the subnet state directory from disk.
@@ -2822,6 +2829,11 @@ impl PocketIcSubnets {
         if self.nns_subnet.is_some() {
             let next_version =
                 RegistryVersion::new(self.registry_data_provider.latest_version().get() + 1);
+            remove_chain_key_registry_records(
+                &empty_chain_key_ids,
+                self.registry_data_provider.clone(),
+                next_version,
+            );
             let subnet_list = self
                 .subnets
                 .get_all()
@@ -2834,6 +2846,12 @@ impl PocketIcSubnets {
                 subnet_list,
                 self.chain_keys.clone(),
                 self.registry_data_provider.clone(),
+            );
+            remove_subnet_local_registry_records(
+                subnet_id,
+                &subnet.state_machine.nodes,
+                self.registry_data_provider.clone(),
+                next_version,
             );
             self.persist_registry_changes();
         }

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -50,7 +50,7 @@ use ic_interfaces::{
 use ic_interfaces_certified_stream_store::{
     CertifiedStreamStore, DecodeStreamError, EncodeStreamError,
 };
-use ic_interfaces_registry::RegistryClient;
+use ic_interfaces_registry::{RegistryClient, RegistryRecord};
 use ic_interfaces_state_manager::{
     CertificationScope, CertifiedStateSnapshot, Labeled, StateHashError, StateHashMetadata,
     StateManager, StateReader,
@@ -101,8 +101,9 @@ use ic_registry_client_helpers::{
 use ic_registry_keys::{
     NODE_REWARDS_TABLE_KEY, ROOT_SUBNET_ID_KEY, make_canister_migrations_record_key,
     make_canister_ranges_key, make_catch_up_package_contents_key,
-    make_chain_key_enabled_subnet_list_key, make_crypto_node_key, make_crypto_tls_cert_key,
-    make_node_record_key, make_provisional_whitelist_record_key, make_replica_version_key,
+    make_chain_key_enabled_subnet_list_key, make_crypto_node_key,
+    make_crypto_threshold_signing_pubkey_key, make_crypto_tls_cert_key, make_node_record_key,
+    make_provisional_whitelist_record_key, make_replica_version_key, make_subnet_record_key,
 };
 use ic_registry_proto_data_provider::{INITIAL_REGISTRY_VERSION, ProtoRegistryDataProvider};
 use ic_registry_provisional_whitelist::ProvisionalWhitelist;
@@ -519,6 +520,56 @@ fn add_subnet_local_registry_records(
         subnet_id,
         record,
     );
+}
+
+pub fn remove_subnet_local_registry_records(
+    subnet_id: SubnetId,
+    nodes: &[StateMachineNode],
+    registry_data_provider: Arc<ProtoRegistryDataProvider>,
+    registry_version: RegistryVersion,
+) {
+    let mut keys = vec![
+        make_catch_up_package_contents_key(subnet_id),
+        make_crypto_threshold_signing_pubkey_key(subnet_id),
+        make_subnet_record_key(subnet_id),
+    ];
+    for node in nodes {
+        keys.push(make_node_record_key(node.node_id));
+        keys.push(make_crypto_tls_cert_key(node.node_id));
+        for key_purpose in [
+            KeyPurpose::NodeSigning,
+            KeyPurpose::CommitteeSigning,
+            KeyPurpose::DkgDealingEncryption,
+            KeyPurpose::IDkgMEGaEncryption,
+        ] {
+            keys.push(make_crypto_node_key(node.node_id, key_purpose));
+        }
+    }
+    let records = keys
+        .into_iter()
+        .map(|key| RegistryRecord {
+            key,
+            version: registry_version,
+            value: None,
+        })
+        .collect();
+    registry_data_provider.add_registry_records(records);
+}
+
+pub fn remove_chain_key_registry_records(
+    chain_key_ids: &[MasterPublicKeyId],
+    registry_data_provider: Arc<ProtoRegistryDataProvider>,
+    registry_version: RegistryVersion,
+) {
+    let records = chain_key_ids
+        .iter()
+        .map(|key_id| RegistryRecord {
+            key: make_chain_key_enabled_subnet_list_key(key_id),
+            version: registry_version,
+            value: None,
+        })
+        .collect();
+    registry_data_provider.add_registry_records(records);
 }
 
 fn add_cup_contents_and_key_record(

--- a/rs/state_machine_tests/src/tests.rs
+++ b/rs/state_machine_tests/src/tests.rs
@@ -1,6 +1,246 @@
 use ic_secp256k1::{DerivationIndex, DerivationPath, PrivateKey, PublicKey};
 use proptest::{collection::vec as pvec, prelude::*, prop_assert};
 
+#[test]
+fn test_remove_subnet_local_registry_records() {
+    use ic_crypto_test_utils_ni_dkg::dummy_initial_dkg_transcript_with_master_key;
+    use ic_crypto_utils_threshold_sig_der::threshold_sig_public_key_to_der;
+    use ic_interfaces_registry::{RegistryDataProvider, ZERO_REGISTRY_VERSION};
+    use ic_management_canister_types_private::{
+        EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdCurve,
+        VetKdKeyId,
+    };
+    use ic_registry_keys::{
+        NODE_REWARDS_TABLE_KEY, ROOT_SUBNET_ID_KEY, make_canister_ranges_key,
+        make_chain_key_enabled_subnet_list_key, make_provisional_whitelist_record_key,
+        make_replica_version_key, make_subnet_list_record_key,
+    };
+    use ic_registry_proto_data_provider::{INITIAL_REGISTRY_VERSION, ProtoRegistryDataProvider};
+    use ic_registry_resource_limits::ResourceLimits;
+    use ic_registry_routing_table::RoutingTable;
+    use ic_registry_subnet_features::SubnetFeatures;
+    use ic_registry_subnet_type::SubnetType;
+    use ic_types::{CanisterId, PrincipalId, ReplicaVersion, SubnetId};
+    use ic_types_cycles::CanisterCyclesCostSchedule;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::sync::Arc;
+
+    let seed = [42u8; 32];
+    let mut node_rng = StdRng::from_seed(seed);
+    let nodes: Vec<super::StateMachineNode> = (0..4)
+        .map(|_| super::StateMachineNode::new(&mut node_rng))
+        .collect();
+    let (ni_dkg_transcript, _) =
+        dummy_initial_dkg_transcript_with_master_key(&mut StdRng::from_seed(seed));
+    let public_key = (&ni_dkg_transcript).try_into().unwrap();
+    let public_key_der = threshold_sig_public_key_to_der(public_key).unwrap();
+    let subnet_id = PrincipalId::new_self_authenticating(&public_key_der).into();
+
+    let chain_key_ids: Vec<MasterPublicKeyId> = vec![
+        MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+            curve: EcdsaCurve::Secp256k1,
+            name: "test_ecdsa_key".to_string(),
+        }),
+        MasterPublicKeyId::Schnorr(SchnorrKeyId {
+            algorithm: SchnorrAlgorithm::Ed25519,
+            name: "test_schnorr_key".to_string(),
+        }),
+        MasterPublicKeyId::VetKd(VetKdKeyId {
+            curve: VetKdCurve::Bls12_381_G2,
+            name: "test_vetkd_key".to_string(),
+        }),
+    ];
+    let chain_keys_enabled_status: BTreeMap<MasterPublicKeyId, bool> = chain_key_ids
+        .iter()
+        .map(|key_id| (key_id.clone(), true))
+        .collect();
+    let chain_keys: BTreeMap<MasterPublicKeyId, Vec<SubnetId>> = chain_key_ids
+        .iter()
+        .map(|key_id| (key_id.clone(), vec![subnet_id]))
+        .collect();
+
+    let registry_data_provider = Arc::new(ProtoRegistryDataProvider::new());
+    super::add_initial_registry_records(registry_data_provider.clone());
+    super::add_global_registry_records(
+        subnet_id,
+        RoutingTable::new(),
+        vec![subnet_id],
+        chain_keys,
+        registry_data_provider.clone(),
+    );
+    super::add_subnet_local_registry_records(
+        subnet_id,
+        SubnetType::Application,
+        SubnetFeatures::default(),
+        &nodes,
+        public_key,
+        &chain_keys_enabled_status,
+        ni_dkg_transcript,
+        registry_data_provider.clone(),
+        INITIAL_REGISTRY_VERSION,
+        CanisterCyclesCostSchedule::Normal,
+        vec![],
+        ResourceLimits::default(),
+    );
+
+    let global_keys: HashSet<String> = HashSet::from([
+        ROOT_SUBNET_ID_KEY.to_string(),
+        NODE_REWARDS_TABLE_KEY.to_string(),
+        make_canister_ranges_key(CanisterId::from_u64(0)),
+        make_subnet_list_record_key(),
+        make_provisional_whitelist_record_key(),
+        make_replica_version_key(ReplicaVersion::default()),
+        make_chain_key_enabled_subnet_list_key(&MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+            curve: EcdsaCurve::Secp256k1,
+            name: "test_ecdsa_key".to_string(),
+        })),
+        make_chain_key_enabled_subnet_list_key(&MasterPublicKeyId::Schnorr(SchnorrKeyId {
+            algorithm: SchnorrAlgorithm::Ed25519,
+            name: "test_schnorr_key".to_string(),
+        })),
+        make_chain_key_enabled_subnet_list_key(&MasterPublicKeyId::VetKd(VetKdKeyId {
+            curve: VetKdCurve::Bls12_381_G2,
+            name: "test_vetkd_key".to_string(),
+        })),
+    ]);
+
+    let remove_version = INITIAL_REGISTRY_VERSION.increment();
+    super::remove_subnet_local_registry_records(
+        subnet_id,
+        &nodes,
+        registry_data_provider.clone(),
+        remove_version,
+    );
+
+    // Build a map: key -> latest value at or before remove_version.
+    let mut latest: HashMap<String, Option<Vec<u8>>> = HashMap::new();
+    let mut records: Vec<_> = registry_data_provider
+        .get_updates_since(ZERO_REGISTRY_VERSION)
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.version <= remove_version)
+        .collect();
+    records.sort_by_key(|r| r.version);
+    for r in records {
+        latest.insert(r.key, r.value);
+    }
+
+    // Global/initial keys must still have values; all other keys must be tombstoned.
+    for (key, value) in &latest {
+        if global_keys.contains(key) {
+            assert!(
+                value.is_some(),
+                "global/initial key '{}' should still exist but was removed",
+                key
+            );
+        } else {
+            assert!(
+                value.is_none(),
+                "subnet-local key '{}' should be removed but still has a value",
+                key
+            );
+        }
+    }
+    // Every global/initial key must still be present.
+    for key in &global_keys {
+        assert!(
+            latest.contains_key(key),
+            "global/initial key '{}' not found in registry",
+            key
+        );
+    }
+}
+
+#[test]
+fn test_remove_chain_key_registry_records() {
+    use ic_interfaces_registry::{RegistryDataProvider, ZERO_REGISTRY_VERSION};
+    use ic_management_canister_types_private::{
+        EcdsaCurve, EcdsaKeyId, MasterPublicKeyId, SchnorrAlgorithm, SchnorrKeyId, VetKdCurve,
+        VetKdKeyId,
+    };
+    use ic_registry_keys::make_chain_key_enabled_subnet_list_key;
+    use ic_registry_proto_data_provider::{INITIAL_REGISTRY_VERSION, ProtoRegistryDataProvider};
+    use ic_registry_routing_table::RoutingTable;
+    use ic_types::{PrincipalId, SubnetId};
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
+
+    let subnet_id: SubnetId = PrincipalId::new_subnet_test_id(1).into();
+
+    let all_key_ids: Vec<MasterPublicKeyId> = vec![
+        MasterPublicKeyId::Ecdsa(EcdsaKeyId {
+            curve: EcdsaCurve::Secp256k1,
+            name: "test_ecdsa_key".to_string(),
+        }),
+        MasterPublicKeyId::Schnorr(SchnorrKeyId {
+            algorithm: SchnorrAlgorithm::Ed25519,
+            name: "test_schnorr_key".to_string(),
+        }),
+        MasterPublicKeyId::VetKd(VetKdKeyId {
+            curve: VetKdCurve::Bls12_381_G2,
+            name: "test_vetkd_key".to_string(),
+        }),
+    ];
+
+    let registry_data_provider = Arc::new(ProtoRegistryDataProvider::new());
+
+    // Add chain key records at the initial version.
+    let chain_keys: BTreeMap<MasterPublicKeyId, Vec<SubnetId>> = all_key_ids
+        .iter()
+        .map(|key_id| (key_id.clone(), vec![subnet_id]))
+        .collect();
+    super::update_global_registry_records(
+        INITIAL_REGISTRY_VERSION,
+        RoutingTable::new(),
+        vec![],
+        chain_keys,
+        registry_data_provider.clone(),
+    );
+
+    // Remove only the first two keys (ECDSA and Schnorr) at version 2.
+    let keys_to_remove = &all_key_ids[..2];
+    let remove_version = INITIAL_REGISTRY_VERSION.increment();
+    super::remove_chain_key_registry_records(
+        keys_to_remove,
+        registry_data_provider.clone(),
+        remove_version,
+    );
+
+    // Build map: key -> latest value at or before remove_version.
+    let mut latest: HashMap<String, Option<Vec<u8>>> = HashMap::new();
+    let mut records: Vec<_> = registry_data_provider
+        .get_updates_since(ZERO_REGISTRY_VERSION)
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.version <= remove_version)
+        .collect();
+    records.sort_by_key(|r| r.version);
+    for r in records {
+        latest.insert(r.key, r.value);
+    }
+
+    // The removed keys must be tombstoned (value == None).
+    for key_id in keys_to_remove {
+        let reg_key = make_chain_key_enabled_subnet_list_key(key_id);
+        assert_eq!(
+            latest.get(&reg_key),
+            Some(&None),
+            "removed key '{}' should be tombstoned",
+            reg_key
+        );
+    }
+
+    // The remaining key (VetKD) must still have a value.
+    let kept_key = make_chain_key_enabled_subnet_list_key(&all_key_ids[2]);
+    assert!(
+        latest.get(&kept_key).and_then(|v| v.as_ref()).is_some(),
+        "non-removed key '{}' should still exist",
+        kept_key
+    );
+}
+
 #[test_strategy::proptest]
 fn test_derivation_prop(
     #[strategy(pvec(pvec(any::<u8>(), 1..10), 1..10))] derivation_path_bytes: Vec<Vec<u8>>,

--- a/rs/state_machine_tests/src/tests.rs
+++ b/rs/state_machine_tests/src/tests.rs
@@ -27,7 +27,7 @@ fn test_remove_subnet_local_registry_records() {
     use std::collections::{BTreeMap, HashMap, HashSet};
     use std::sync::Arc;
 
-    let seed = [42u8; 32];
+    let seed = [42_u8; 32];
     let mut node_rng = StdRng::from_seed(seed);
     let nodes: Vec<super::StateMachineNode> = (0..4)
         .map(|_| super::StateMachineNode::new(&mut node_rng))


### PR DESCRIPTION
This PR fixes subnet deletion in PocketIC by removing stale (subnet) registry records (orphaned after removing the subnet from the subnet list and routing table) as well as updating threshold signing registry records (defense-in-depth since threshold keys are only on "named" subnets which cannot be deleted).