### PR TITLE
fix(NODE-1958): Make cloud GuestOS great again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,7 @@ dependencies = [
  "sev_guest",
  "strum 0.26.3",
  "tempfile",
+ "tracing",
  "url",
  "utils",
 ]

--- a/ic-os/bootloader/guestos_boot_args.template
+++ b/ic-os/bootloader/guestos_boot_args.template
@@ -5,7 +5,7 @@
 # the system will use SELinux and keep track of operations that would
 # be prohibited, but will only log but not actually deny them. This is
 # useful for debug and policy development.
-BOOT_ARGS_A="root=/dev/disk/by-partuuid/7c0a626e-e5ea-e543-b5c5-300eb8304db7 console=ttyS0 console=tty0 nomodeset dfinity.system=A security=selinux selinux=1 enforcing=1 root_hash=ROOT_HASH"
-BOOT_ARGS_B="root=/dev/disk/by-partuuid/a78bc3a8-376c-054a-96e7-3904b915d0c5 console=ttyS0 console=tty0 nomodeset dfinity.system=B security=selinux selinux=1 enforcing=1 root_hash=ROOT_HASH"
-BOOT_ARGS_TEE_A="root=/dev/disk/by-partuuid/7c0a626e-e5ea-e543-b5c5-300eb8304db7 console=ttyS0 console=tty0 nomodeset dfinity.system=A dfinity.tee=1 security=selinux selinux=1 enforcing=1 root_hash=ROOT_HASH"
-BOOT_ARGS_TEE_B="root=/dev/disk/by-partuuid/a78bc3a8-376c-054a-96e7-3904b915d0c5 console=ttyS0 console=tty0 nomodeset dfinity.system=B dfinity.tee=1 security=selinux selinux=1 enforcing=1 root_hash=ROOT_HASH"
+BOOT_ARGS_A="root=/dev/disk/by-partuuid/7c0a626e-e5ea-e543-b5c5-300eb8304db7 console=ttyS0 nomodeset dfinity.system=A security=selinux selinux=1 enforcing=1 root_hash=ROOT_HASH"
+BOOT_ARGS_B="root=/dev/disk/by-partuuid/a78bc3a8-376c-054a-96e7-3904b915d0c5 console=ttyS0 nomodeset dfinity.system=B security=selinux selinux=1 enforcing=1 root_hash=ROOT_HASH"
+BOOT_ARGS_TEE_A="root=/dev/disk/by-partuuid/7c0a626e-e5ea-e543-b5c5-300eb8304db7 console=ttyS0 nomodeset dfinity.system=A dfinity.tee=1 security=selinux selinux=1 enforcing=1 root_hash=ROOT_HASH"
+BOOT_ARGS_TEE_B="root=/dev/disk/by-partuuid/a78bc3a8-376c-054a-96e7-3904b915d0c5 console=ttyS0 nomodeset dfinity.system=B dfinity.tee=1 security=selinux selinux=1 enforcing=1 root_hash=ROOT_HASH"

--- a/ic-os/components/guestos/init/init-config/init-config.service
+++ b/ic-os/components/guestos/init/init-config/init-config.service
@@ -8,7 +8,6 @@ RequiresMountsFor=/run
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/opt/ic/bin/init-config.sh
-TimeoutSec=60
 Restart=on-failure
 RestartSec=10
 

--- a/rs/ic_os/config/tool/BUILD.bazel
+++ b/rs/ic_os/config/tool/BUILD.bazel
@@ -51,6 +51,7 @@ rust_library(
         "@crate_index//:serde_with",
         "@crate_index//:strum",
         "@crate_index//:tempfile",
+        "@crate_index//:tracing",
         "@crate_index//:url",
     ],
 )
@@ -91,6 +92,7 @@ rust_library(
         "@crate_index//:serde_with",
         "@crate_index//:strum",
         "@crate_index//:tempfile",
+        "@crate_index//:tracing",
         "@crate_index//:url",
     ],
 )
@@ -154,6 +156,7 @@ rust_binary(
         "@crate_index//:serde_with",
         "@crate_index//:strum",
         "@crate_index//:tempfile",
+        "@crate_index//:tracing",
         "@crate_index//:url",
     ],
 )
@@ -194,6 +197,7 @@ rust_binary(
         "@crate_index//:serde_with",
         "@crate_index//:strum",
         "@crate_index//:tempfile",
+        "@crate_index//:tracing",
         "@crate_index//:url",
     ],
 )

--- a/rs/ic_os/config/tool/Cargo.toml
+++ b/rs/ic_os/config/tool/Cargo.toml
@@ -28,6 +28,7 @@ getifs = { workspace = true }
 sev_guest = { path = "../../sev/guest" }
 strum = { workspace = true }
 securefmt = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 once_cell = "1.8"

--- a/rs/ic_os/config/tool/src/guestos/cloud.rs
+++ b/rs/ic_os/config/tool/src/guestos/cloud.rs
@@ -4,14 +4,13 @@ use std::{
     time::Duration,
 };
 
+use ::reqwest::Method;
 use anyhow::{Context, Error, Result, anyhow, bail};
 use config_types::GuestOSConfig;
-
 use reqwest::header::{HeaderMap, HeaderValue};
-
-use ::reqwest::Method;
 use serde_json::Value;
 use strum::{Display, EnumString};
+use tracing::info;
 
 /// URL of the metadata server
 const METADATA_URL: &str = "http://169.254.169.254";
@@ -27,7 +26,7 @@ pub enum CloudType {
 impl CloudType {
     /// Discovers the cloud type by making a request to the metadata server
     pub fn discover() -> Result<Self, Error> {
-        let mut retries = 30;
+        let mut retries = 120;
 
         let resp = loop {
             match reqwest::blocking::get(METADATA_URL) {
@@ -38,7 +37,7 @@ impl CloudType {
                         return Err(anyhow!("unable to discover cloud type: retries exhausted"));
                     }
 
-                    println!("Unable to contact metadata server (retries left {retries}): {e:#}");
+                    info!("Unable to contact metadata server (retries left {retries}): {e:#}");
                     std::thread::sleep(Duration::from_secs(1));
                 }
             }
@@ -50,12 +49,20 @@ impl CloudType {
     /// Tries to fetch the GuestOS config from the cloud's metadata service
     pub fn obtain_config(&self) -> Result<GuestOSConfig, Error> {
         let json = match self {
-            Self::Aws => reqwest::blocking::get(format!("{METADATA_URL}/latest/user-data"))
-                .context("unable to execute request")?
-                .bytes()
-                .context("unable to fetch config JSON")?
-                .to_vec(),
+            Self::Aws => {
+                let mut req = reqwest::blocking::Request::new(
+                    Method::GET,
+                    format!("{METADATA_URL}/latest/user-data").parse().unwrap(),
+                );
+                *req.timeout_mut() = Some(Duration::from_secs(30));
 
+                reqwest::blocking::Client::new()
+                    .execute(req)
+                    .context("unable to execute request")?
+                    .bytes()
+                    .context("unable to fetch config JSON")?
+                    .to_vec()
+            }
             Self::Gcp => {
                 let mut req = reqwest::blocking::Request::new(
                     Method::GET,
@@ -63,6 +70,7 @@ impl CloudType {
                         .parse()
                         .unwrap(),
                 );
+                *req.timeout_mut() = Some(Duration::from_secs(30));
                 req.headers_mut()
                     .insert("Metadata-Flavor", "Google".try_into().unwrap());
 
@@ -76,6 +84,7 @@ impl CloudType {
 
             Self::Azure => {
                 let mut req = reqwest::blocking::Request::new(Method::GET, format!("{METADATA_URL}/metadata/instance/compute/userData?api-version=2025-04-07&format=text").parse().unwrap());
+                *req.timeout_mut() = Some(Duration::from_secs(30));
                 req.headers_mut()
                     .insert("Metadata", "true".try_into().unwrap());
 
@@ -108,6 +117,7 @@ impl CloudType {
                         .parse()
                         .unwrap(),
                 );
+                *req.timeout_mut() = Some(Duration::from_secs(30));
                 req.headers_mut()
                     .insert("Metadata", "true".try_into().unwrap());
 

--- a/rs/ic_os/config/tool/src/guestos/cloud.rs
+++ b/rs/ic_os/config/tool/src/guestos/cloud.rs
@@ -15,6 +15,9 @@ use tracing::info;
 /// URL of the metadata server
 const METADATA_URL: &str = "http://169.254.169.254";
 
+/// Timeout for HTTP calls
+const TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Type of the cloud that we provision from
 #[derive(Debug, Clone, PartialEq, Eq, Display, EnumString)]
 pub enum CloudType {
@@ -29,7 +32,11 @@ impl CloudType {
         let mut retries = 120;
 
         let resp = loop {
-            match reqwest::blocking::get(METADATA_URL) {
+            let mut req =
+                reqwest::blocking::Request::new(Method::GET, METADATA_URL.parse().unwrap());
+            *req.timeout_mut() = Some(TIMEOUT);
+
+            match reqwest::blocking::Client::new().execute(req) {
                 Ok(v) => break v,
                 Err(e) => {
                     retries -= 1;
@@ -54,7 +61,7 @@ impl CloudType {
                     Method::GET,
                     format!("{METADATA_URL}/latest/user-data").parse().unwrap(),
                 );
-                *req.timeout_mut() = Some(Duration::from_secs(30));
+                *req.timeout_mut() = Some(TIMEOUT);
 
                 reqwest::blocking::Client::new()
                     .execute(req)
@@ -70,7 +77,7 @@ impl CloudType {
                         .parse()
                         .unwrap(),
                 );
-                *req.timeout_mut() = Some(Duration::from_secs(30));
+                *req.timeout_mut() = Some(TIMEOUT);
                 req.headers_mut()
                     .insert("Metadata-Flavor", "Google".try_into().unwrap());
 
@@ -84,7 +91,7 @@ impl CloudType {
 
             Self::Azure => {
                 let mut req = reqwest::blocking::Request::new(Method::GET, format!("{METADATA_URL}/metadata/instance/compute/userData?api-version=2025-04-07&format=text").parse().unwrap());
-                *req.timeout_mut() = Some(Duration::from_secs(30));
+                *req.timeout_mut() = Some(TIMEOUT);
                 req.headers_mut()
                     .insert("Metadata", "true".try_into().unwrap());
 
@@ -117,7 +124,7 @@ impl CloudType {
                         .parse()
                         .unwrap(),
                 );
-                *req.timeout_mut() = Some(Duration::from_secs(30));
+                *req.timeout_mut() = Some(TIMEOUT);
                 req.headers_mut()
                     .insert("Metadata", "true".try_into().unwrap());
 

--- a/rs/ic_os/logging/src/lib.rs
+++ b/rs/ic_os/logging/src/lib.rs
@@ -7,8 +7,9 @@ use tracing_subscriber::{
     Layer,
     filter::LevelFilter,
     fmt::{
-        FmtContext, format,
+        FmtContext,
         format::{FormatEvent, FormatFields, Writer},
+        writer::MakeWriterExt,
     },
     layer::SubscriberExt,
     registry::LookupSpan,
@@ -65,22 +66,27 @@ fn syslog_identifier() -> String {
     syslog_identifier_from_arg0(arg0.as_deref())
 }
 
-/// Initialize tracing, using journald if available and falling back to stderr.
+/// Initialize tracing, using journald+stderr if journald is available and falling back to just stderr.
+/// Logs with TRACE level.
 pub fn init_logging() {
     init_logging_with_level(Level::TRACE);
 }
 
-/// Initialize tracing, using journald if available and falling back to stderr.
+/// Initialize tracing, using journald+stderr if journald is available and falling back to just stderr.
 pub fn init_logging_with_level(max_level: Level) {
     let level_filter = LevelFilter::from_level(max_level);
 
     match tracing_journald::layer() {
         Ok(layer) => tracing_subscriber::registry()
             .with(layer.with_filter(level_filter))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(std::io::stderr.with_max_level(max_level)),
+            )
             .init(),
         Err(_) => tracing_subscriber::fmt()
             .with_writer(std::io::stderr)
-            .with_max_level(max_level)
+            .with_max_level(level_filter)
             .init(),
     }
 }
@@ -95,7 +101,7 @@ pub fn init_kmsg_logging() {
                 tracing_subscriber::fmt::layer()
                     .event_format(KmsgFormatter {
                         identifier: identifier.clone(),
-                        inner: format()
+                        inner: tracing_subscriber::fmt::format()
                             .without_time()
                             .with_target(false)
                             .with_level(false)
@@ -113,7 +119,7 @@ pub fn init_kmsg_logging() {
                 tracing_subscriber::fmt::layer()
                     .event_format(KmsgFormatter {
                         identifier,
-                        inner: format()
+                        inner: tracing_subscriber::fmt::format()
                             .without_time()
                             .with_target(false)
                             .with_level(false)

--- a/rs/ic_os/logging/src/lib.rs
+++ b/rs/ic_os/logging/src/lib.rs
@@ -9,7 +9,6 @@ use tracing_subscriber::{
     fmt::{
         FmtContext,
         format::{FormatEvent, FormatFields, Writer},
-        writer::MakeWriterExt,
     },
     layer::SubscriberExt,
     registry::LookupSpan,
@@ -81,7 +80,8 @@ pub fn init_logging_with_level(max_level: Level) {
             .with(layer.with_filter(level_filter))
             .with(
                 tracing_subscriber::fmt::layer()
-                    .with_writer(std::io::stderr.with_max_level(max_level)),
+                    .with_writer(std::io::stderr)
+                    .with_filter(level_filter),
             )
             .init(),
         Err(_) => tracing_subscriber::fmt()

--- a/rs/ic_os/os_tools/guestos_tool/src/cloud_provision.rs
+++ b/rs/ic_os/os_tools/guestos_tool/src/cloud_provision.rs
@@ -89,7 +89,7 @@ pub fn obtain_guestos_config() -> Result<GuestOSConfig, Error> {
             Err(e) => {
                 retries -= 1;
                 if retries == 0 {
-                    bail!("unable to obtain config: reties exhausted");
+                    bail!("unable to obtain config: retries exhausted");
                 }
 
                 info!("Unable to obtain GuestOS config (retries left: {retries}): {e:#}");

--- a/rs/ic_os/os_tools/guestos_tool/src/cloud_provision.rs
+++ b/rs/ic_os/os_tools/guestos_tool/src/cloud_provision.rs
@@ -1,5 +1,4 @@
 use std::{
-    path::PathBuf,
     process::{Child, Command, Stdio},
     time::Duration,
 };
@@ -13,67 +12,56 @@ use tracing::info;
 /// Assigns IPv4 DHCP address to the interface and unassigns it when dropped
 #[derive(Debug)]
 struct DHCPConfig {
-    config_path: PathBuf,
     process: Child,
 }
 
 impl DHCPConfig {
-    /// Installs a temporary systemd-networkd config to obtain a DHCP lease
-    fn new(interface: String, systemd_network_dir: PathBuf) -> Result<Self, Error> {
-        std::fs::create_dir_all(&systemd_network_dir)
-            .context("unable to create the systemd-networkd dir")?;
-
-        let intf_config = indoc::formatdoc!(
-            r#"
-                [Match]
-                Name={interface}
-                Virtualization=!container
-
-                [Network]
-                DHCP=ipv4
-            "#,
-        );
-
-        // Write the config
-        let config_path = systemd_network_dir.join(format!("10-{interface}.network"));
-        std::fs::write(&config_path, intf_config)
-            .context("unable to write systemd network config")?;
-
-        // Fire up systemd-networkd
-        let process = Command::new("/usr/lib/systemd/systemd-networkd")
+    /// Starts dhcpcd to obtain a DHCP lease
+    fn new(interface: String) -> Result<Self, Error> {
+        // Fire up DHCP client.
+        // Avoid reading default config since it might contain unneeded options and they take precedence.
+        info!("Starting dhcpcd");
+        let process = Command::new("/usr/sbin/dhcpcd")
+            .args([
+                "--nobackground",
+                "--ipv4only",
+                "--noipv4ll",
+                "--config",
+                "/dev/null",
+                &interface,
+            ])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .context("unable to execute systemd-networkd")?;
+            .context("unable to execute /usr/sbin/dhcpcd")?;
 
-        Ok(Self {
-            config_path,
-            process,
-        })
+        Ok(Self { process })
     }
 }
 
 impl Drop for DHCPConfig {
     fn drop(&mut self) {
-        // Tell systemd-networkd to shutdown & wait for it to happen
+        // Tell dhcpcd to shutdown & wait for it to happen
+        info!("Sending SIGTERM to dhcpcd");
         let _ = nix::sys::signal::kill(Pid::from_raw(self.process.id() as i32), SIGTERM);
         let _ = self.process.wait();
-
-        // Remove the config
-        let _ = std::fs::remove_file(&self.config_path);
+        info!("dhcpcd successfully stopped");
     }
 }
 
 /// Tries to obtain the GuestOS config from the cloud's metadata service
-pub fn obtain_guestos_config(systemd_network_dir: PathBuf) -> Result<GuestOSConfig, Error> {
+pub fn obtain_guestos_config() -> Result<GuestOSConfig, Error> {
+    info!("Figuring out the network interface to use...");
+
     // Find the network interface to work on, it might not be initialized yet so give it a few tries
-    let mut retries = 10;
+    let mut retries = 30;
     let intf = loop {
         match get_best_interface_name() {
             Ok(v) => break v,
             Err(e) => {
-                info!("unable to choose interface: {e:#}");
+                info!("Unable to choose interface: {e:#}");
+
                 retries -= 1;
                 if retries == 0 {
                     bail!("unable to choose interface: retries exhausted");
@@ -83,10 +71,10 @@ pub fn obtain_guestos_config(systemd_network_dir: PathBuf) -> Result<GuestOSConf
             }
         }
     };
+    info!("Interface found: {intf}");
 
     // Configure it with a DHCP
-    let _dhcp = DHCPConfig::new(intf.clone(), systemd_network_dir)
-        .context("unable to configure IPv4 DHCP")?;
+    let _dhcp = DHCPConfig::new(intf.clone()).context("unable to configure IPv4 DHCP")?;
     info!("DHCP on the interface {intf} configured");
 
     // Discover the cloud we're running in.
@@ -94,9 +82,21 @@ pub fn obtain_guestos_config(systemd_network_dir: PathBuf) -> Result<GuestOSConf
     info!("Cloud type detected: {cloud_type:?}");
 
     // Get the config from the MDS
-    let config = cloud_type
-        .obtain_config()
-        .context("unable to obtain GuestOS config")?;
+    let mut retries = 120;
+    let config = loop {
+        match cloud_type.obtain_config() {
+            Ok(v) => break v,
+            Err(e) => {
+                retries -= 1;
+                if retries == 0 {
+                    bail!("unable to obtain config: reties exhausted");
+                }
+
+                info!("Unable to obtain GuestOS config (retries left: {retries}): {e:#}");
+                std::thread::sleep(Duration::from_secs(1));
+            }
+        };
+    };
 
     Ok(config)
 }

--- a/rs/ic_os/os_tools/guestos_tool/src/main.rs
+++ b/rs/ic_os/os_tools/guestos_tool/src/main.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use tracing::{info, warn};
+use tracing::{Level, info, warn};
 
 use cloud_provision::obtain_guestos_config;
 use generate_network_config::{generate_networkd_config, validate_and_construct_ipv4_address_info};
@@ -55,10 +55,6 @@ pub enum Commands {
         /// Path where to save the obtained config.json
         #[arg(long, default_value = "/mnt/config/config.json")]
         config_path: PathBuf,
-
-        /// systemd-networkd output directory
-        #[arg(long, default_value = DEFAULT_SYSTEMD_NETWORK_DIR)]
-        systemd_network_dir: PathBuf,
     },
 }
 
@@ -70,7 +66,7 @@ struct GuestOSArgs {
 }
 
 pub fn main() -> Result<()> {
-    ic_os_logging::init_logging();
+    ic_os_logging::init_logging_with_level(Level::INFO);
 
     #[cfg(not(target_os = "linux"))]
     {
@@ -118,12 +114,17 @@ pub fn main() -> Result<()> {
             Ok(())
         }
 
-        Some(Commands::CloudProvision {
-            config_path,
-            systemd_network_dir,
-        }) => {
-            let config = obtain_guestos_config(systemd_network_dir)
-                .context("unable to obtain GuestOS config")?;
+        Some(Commands::CloudProvision { config_path }) => {
+            info!("Obtaining GuestOS config from the Cloud MDS...");
+
+            let config = match obtain_guestos_config().context("unable to obtain GuestOS config") {
+                Ok(v) => v,
+                Err(e) => {
+                    info!("{e:#}");
+                    return Err(e);
+                }
+            };
+
             let json = serde_json::to_vec_pretty(&config).context("unable to encode to JSON")?;
             std::fs::write(&config_path, &json)
                 .context("unable to write GuestOS config to disk")?;


### PR DESCRIPTION
It seems that Ubuntu 26 upgrade changed the way the network is initialized by `systemd` which breaks our intermediate DHCP step. It's hard to debug especially in combination with SELinux policies.

* Use `dhcpcd` instead of `systemd-networkd` to obtain a temporary DHCP address. This avoids problems with new Ubuntu 26 init order (`systemd-networkd` is started now by `systemd` early it seems and if we launch a 2nd instance - it falls apart).
* Remove `console=tty0` from kernel boot args. It was added to support logging on serial-port-less clouds, but the problem is that when both `ttyX` and `ttySX` are present - the kernel makes the normal (graphical / ttyX) console the main one (regardless of their order) and serial console doesn't get any recovery shell or proper logging. We can try later to improve that somehow to get the best of the both worlds, though it's not easy. Also see https://github.com/systemd/systemd/issues/9899 about that.
* Alter the `icos_logging` so that it logs to both `stderr` and `journald` by default to ease debugging
* Remove timeout for `init-config` service since it anyway is critical and it makes not much sense to kill it if it hangs around longer
* Add timeouts to cloud-related HTTP calls, add more verbose logging