### PR TITLE
feat: let the engine controller update subnets via update_subnet

### DIFF
--- a/rs/engine_controller/canister/canister.rs
+++ b/rs/engine_controller/canister/canister.rs
@@ -1,8 +1,8 @@
 //! The engine controller canister.
 //!
 //! This canister provides a thin user-facing API on top of the registry
-//! canister's `create_subnet` / `delete_subnet` endpoints. Only a single,
-//! hard-coded authorized principal may invoke its methods.
+//! canister's `create_subnet` / `delete_subnet` / `update_subnet` endpoints.
+//! Only a single, hard-coded authorized principal may invoke its methods.
 use candid::Principal;
 use ic_base_types::{NodeId, PrincipalId, SubnetId};
 use ic_cdk::{api::msg_caller, call::Call, init, post_upgrade, println, update};
@@ -16,6 +16,7 @@ use registry_canister::mutations::do_create_subnet::{
     CanisterCyclesCostSchedule, CreateSubnetPayload,
 };
 use registry_canister::mutations::do_delete_subnet::DeleteSubnetPayload;
+use registry_canister::mutations::do_update_subnet::UpdateSubnetPayload;
 use std::cell::RefCell;
 use std::collections::HashSet;
 
@@ -184,6 +185,22 @@ async fn delete_engine(args: DeleteEngineArgs) -> Result<(), String> {
             .map_err(|e| format!("Failed to decode registry response: {e}"))?;
 
     response
+}
+
+/// Forward an `update_subnet` request to the registry. The engine
+/// controller is an authorized caller of the registry's `update_subnet`,
+/// so this lets the single authorized principal update any field of a
+/// subnet (e.g. toggle `is_halted` to halt/resume an engine subnet).
+#[update]
+async fn update_engine(payload: UpdateSubnetPayload) -> Result<(), String> {
+    ensure_authorized()?;
+    // `update_subnet` returns unit on success and traps on failure, so a
+    // failed call surfaces here as a call error rather than a decoded `Err`.
+    Call::unbounded_wait(REGISTRY_CANISTER_ID.into(), "update_subnet")
+        .with_arg(payload)
+        .await
+        .map_err(|e| format!("registry.update_subnet call failed: {e:?}"))?;
+    Ok(())
 }
 
 fn main() {

--- a/rs/engine_controller/engine_controller.did
+++ b/rs/engine_controller/engine_controller.did
@@ -10,6 +10,80 @@ type DeleteEngineArgs = record {
 
 type Result = variant { Ok; Err : text };
 
+type ResourceLimits = record {
+  maximum_state_size : opt nat64;
+  maximum_state_delta : opt nat64;
+};
+
+type SubnetFeatures = record {
+  canister_sandboxing : bool;
+  http_requests : bool;
+  sev_enabled : opt bool;
+};
+
+type SubnetType = variant { application; verified_application; system; cloud_engine };
+
+type EcdsaCurve = variant { secp256k1 };
+
+type EcdsaKeyId = record { name : text; curve : EcdsaCurve };
+
+type SchnorrAlgorithm = variant { ed25519; bip340secp256k1 };
+
+type SchnorrKeyId = record { algorithm : SchnorrAlgorithm; name : text };
+
+type VetKdCurve = variant { bls12_381_g2 };
+
+type VetKdKeyId = record { curve: VetKdCurve; name: text };
+
+type MasterPublicKeyId = variant { Schnorr : SchnorrKeyId; Ecdsa : EcdsaKeyId; VetKd : VetKdKeyId };
+
+type KeyConfig = record {
+  key_id : opt MasterPublicKeyId;
+  pre_signatures_to_create_in_advance : opt nat32;
+  max_queue_size : opt nat32;
+};
+
+type ChainKeyConfig = record {
+  key_configs : vec KeyConfig;
+  signature_request_timeout_ns : opt nat64;
+  idkg_key_rotation_period_ms : opt nat64;
+  max_parallel_pre_signature_transcripts_in_creation : opt nat32;
+};
+
+type UpdateSubnetPayload = record {
+  unit_delay_millis : opt nat64;
+  max_duplicity : opt nat32;
+  features : opt SubnetFeatures;
+  resource_limits : opt ResourceLimits;
+  set_gossip_config_to_default : bool;
+  halt_at_cup_height : opt bool;
+  pfn_evaluation_period_ms : opt nat32;
+  subnet_id : principal;
+  max_ingress_bytes_per_message : opt nat64;
+  dkg_dealings_per_block : opt nat64;
+  max_block_payload_size : opt nat64;
+  start_as_nns : opt bool;
+  is_halted : opt bool;
+  max_ingress_messages_per_block : opt nat64;
+  max_ingress_bytes_per_block: opt nat64;
+  max_number_of_canisters : opt nat64;
+  retransmission_request_ms : opt nat32;
+  dkg_interval_length : opt nat64;
+  registry_poll_period_ms : opt nat32;
+  max_chunk_wait_ms : opt nat32;
+  receive_check_cache_size : opt nat32;
+  ssh_backup_access : opt vec text;
+  max_chunk_size : opt nat32;
+  initial_notary_delay_millis : opt nat64;
+  max_artifact_streams_per_peer : opt nat32;
+  subnet_type : opt SubnetType;
+  ssh_readonly_access : opt vec text;
+  subnet_admins : opt vec principal;
+  chain_key_config : opt ChainKeyConfig;
+  chain_key_signing_enable : opt vec MasterPublicKeyId;
+  chain_key_signing_disable : opt vec MasterPublicKeyId;
+};
+
 type NewSubnet = record {
   new_subnet_id : opt principal;
 };
@@ -24,4 +98,5 @@ type EngineControllerInitArgs = record {
 service : (opt EngineControllerInitArgs) -> {
   create_engine : (CreateEngineArgs) -> (CreateEngineResult);
   delete_engine : (DeleteEngineArgs) -> (Result);
+  update_engine : (UpdateSubnetPayload) -> (Result);
 }

--- a/rs/engine_controller/src/lib.rs
+++ b/rs/engine_controller/src/lib.rs
@@ -9,6 +9,9 @@ use serde::Deserialize;
 // Re-export the response type returned by `create_engine` so clients don't
 // have to depend on `registry-canister` directly just to decode it.
 pub use registry_canister::mutations::do_create_subnet::NewSubnet;
+// Re-export the registry payload forwarded by `update_engine` so clients can
+// build it without depending on `registry-canister` directly.
+pub use registry_canister::mutations::do_update_subnet::UpdateSubnetPayload;
 
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
 pub struct EngineControllerInitArgs {

--- a/rs/engine_controller/tests/tests.rs
+++ b/rs/engine_controller/tests/tests.rs
@@ -282,8 +282,7 @@ fn node_principals(node_ids: &[NodeId]) -> Vec<Principal> {
 }
 
 async fn subnet_is_halted(pic: &PocketIc, subnet_id: SubnetId) -> bool {
-    let raw =
-        registry_get_value(pic, make_subnet_record_key(subnet_id).as_bytes().to_vec()).await;
+    let raw = registry_get_value(pic, make_subnet_record_key(subnet_id).as_bytes().to_vec()).await;
     SubnetRecordPb::decode(raw.as_slice()).unwrap().is_halted
 }
 

--- a/rs/engine_controller/tests/tests.rs
+++ b/rs/engine_controller/tests/tests.rs
@@ -8,7 +8,7 @@ use candid::{Decode, Encode, Principal};
 use canister_test::Project;
 use ic_base_types::{NodeId, PrincipalId, SubnetId};
 use ic_engine_controller::{
-    CreateEngineArgs, DeleteEngineArgs, EngineControllerInitArgs, NewSubnet,
+    CreateEngineArgs, DeleteEngineArgs, EngineControllerInitArgs, NewSubnet, UpdateSubnetPayload,
 };
 use ic_management_canister_types::CanisterSettings;
 use ic_nns_constants::{ENGINE_CONTROLLER_CANISTER_ID, REGISTRY_CANISTER_ID, ROOT_CANISTER_ID};
@@ -195,6 +195,63 @@ async fn call_delete_engine(
     Decode!(&raw, Result<(), String>).unwrap()
 }
 
+async fn call_update_engine(
+    pic: &PocketIc,
+    sender: Principal,
+    payload: &UpdateSubnetPayload,
+) -> Result<(), String> {
+    let raw = pic
+        .update_call(
+            ENGINE_CONTROLLER_CANISTER_ID.get().0,
+            sender,
+            "update_engine",
+            Encode!(payload).unwrap(),
+        )
+        .await
+        .expect("ingress call should succeed");
+    Decode!(&raw, Result<(), String>).unwrap()
+}
+
+/// Build an `UpdateSubnetPayload` that targets `subnet_id` and only toggles
+/// `is_halted`, leaving every other field unchanged. `UpdateSubnetPayload`
+/// does not implement `Default`, so the full field list is spelled out here
+/// (mirrors `rs/registry/canister/src/mutations/do_update_subnet.rs`).
+fn halt_payload(subnet_id: SubnetId, is_halted: bool) -> UpdateSubnetPayload {
+    UpdateSubnetPayload {
+        subnet_id,
+        is_halted: Some(is_halted),
+        max_ingress_bytes_per_message: None,
+        max_ingress_bytes_per_block: None,
+        max_ingress_messages_per_block: None,
+        max_block_payload_size: None,
+        unit_delay_millis: None,
+        initial_notary_delay_millis: None,
+        dkg_interval_length: None,
+        dkg_dealings_per_block: None,
+        start_as_nns: None,
+        subnet_type: None,
+        halt_at_cup_height: None,
+        features: None,
+        resource_limits: None,
+        chain_key_config: None,
+        chain_key_signing_enable: None,
+        chain_key_signing_disable: None,
+        max_number_of_canisters: None,
+        ssh_readonly_access: None,
+        ssh_backup_access: None,
+        subnet_admins: None,
+        max_artifact_streams_per_peer: None,
+        max_chunk_wait_ms: None,
+        max_duplicity: None,
+        max_chunk_size: None,
+        receive_check_cache_size: None,
+        pfn_evaluation_period_ms: None,
+        registry_poll_period_ms: None,
+        retransmission_request_ms: None,
+        set_gossip_config_to_default: false,
+    }
+}
+
 async fn registry_get_value(pic: &PocketIc, key: Vec<u8>) -> Vec<u8> {
     let request = serialize_get_value_request(key, None).unwrap();
     let raw = pic
@@ -222,6 +279,12 @@ async fn subnet_list(pic: &PocketIc) -> Vec<Vec<u8>> {
 
 fn node_principals(node_ids: &[NodeId]) -> Vec<Principal> {
     node_ids.iter().map(|n| n.get().0).collect()
+}
+
+async fn subnet_is_halted(pic: &PocketIc, subnet_id: SubnetId) -> bool {
+    let raw =
+        registry_get_value(pic, make_subnet_record_key(subnet_id).as_bytes().to_vec()).await;
+    SubnetRecordPb::decode(raw.as_slice()).unwrap().is_halted
 }
 
 #[tokio::test]
@@ -445,5 +508,51 @@ async fn delete_engine_caller_must_be_authorized() {
     )
     .await
     .unwrap_err();
+    assert!(err.contains("not authorized"), "unexpected error: {err}");
+}
+
+#[tokio::test]
+async fn update_engine_can_halt_and_resume_a_subnet() {
+    let (pic, node_ids, _nns_subnet_id) = setup(4).await;
+
+    let new_subnet = call_create_engine(
+        &pic,
+        authorized(),
+        &CreateEngineArgs {
+            node_ids: node_principals(&node_ids),
+            subnet_admins: vec![],
+            replica_version_id: test_replica_version(),
+        },
+    )
+    .await
+    .expect("create_engine should succeed");
+    let subnet_id = new_subnet
+        .new_subnet_id
+        .expect("create_engine should return a new subnet id");
+
+    // A freshly created engine subnet starts unhalted.
+    assert!(!subnet_is_halted(&pic, subnet_id).await);
+
+    // Halt it.
+    call_update_engine(&pic, authorized(), &halt_payload(subnet_id, true))
+        .await
+        .expect("update_engine should halt the subnet");
+    assert!(subnet_is_halted(&pic, subnet_id).await);
+
+    // Resume it again.
+    call_update_engine(&pic, authorized(), &halt_payload(subnet_id, false))
+        .await
+        .expect("update_engine should resume the subnet");
+    assert!(!subnet_is_halted(&pic, subnet_id).await);
+}
+
+#[tokio::test]
+async fn update_engine_caller_must_be_authorized() {
+    let (pic, _, _) = setup(4).await;
+    let attacker = Principal::self_authenticating(b"attacker");
+    let subnet_id = SubnetId::new(PrincipalId(Principal::management_canister()));
+    let err = call_update_engine(&pic, attacker, &halt_payload(subnet_id, true))
+        .await
+        .unwrap_err();
     assert!(err.contains("not authorized"), "unexpected error: {err}");
 }


### PR DESCRIPTION
## What

Replace the halt-specific `halt_engine` method with a general `update_engine(UpdateSubnetPayload)` method on the engine controller canister. It forwards the full payload straight to the registry's `update_subnet`, so the single authorized caller can update *any* field of an engine subnet (e.g. toggle `is_halted` to halt/resume it) instead of just a hardcoded flag.

## Details

- `update_engine` is a thin pass-through to `registry.update_subnet`, restricted to the single authorized caller.
- Re-exports `UpdateSubnetPayload` so clients can build the payload without depending on `registry-canister` directly.
- Adds the candid declaration of `UpdateSubnetPayload` (and all transitively-referenced types) to `engine_controller.did`, kept in sync with the exported service.

## Stacking

Stacked on #10433 (registry `update_subnet` auth relaxation, which makes the engine controller an authorized caller). Kept as a **draft** until #10433 merges.

## Testing

PocketIC integration test halts then resumes a freshly-created engine subnet (asserting `SubnetRecord.is_halted` flips) plus an auth-rejection test, and the candid `service_equal` test. Both `engine_controller_canister_test` and `engine_controller_integration_test` pass locally.
