### PR TITLE
feat: increase max environment variables per canister from 20 to 32

### DIFF
--- a/rs/config/src/execution_environment.rs
+++ b/rs/config/src/execution_environment.rs
@@ -211,7 +211,7 @@ pub const MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT: usize = 3000;
 pub const DEFAULT_WASM_MEMORY_LIMIT: NumBytes = NumBytes::new(3 * GIB);
 
 /// The maximum number of environment variables allowed per canister.
-pub const MAX_ENVIRONMENT_VARIABLES: usize = 20;
+pub const MAX_ENVIRONMENT_VARIABLES: usize = 32;
 
 /// The maximum length of an environment variable name.
 pub const MAX_ENVIRONMENT_VARIABLE_NAME_LENGTH: usize = 128;


### PR DESCRIPTION
## Summary
- Raises `MAX_ENVIRONMENT_VARIABLES` in `rs/config/src/execution_environment.rs` from 20 to 32.

## Test plan
- [x] `rustfmt` clean
- [x] `cargo clippy -p ic-config` clean
- [x] `bazel build //rs/config:config`
- [x] Ran directly-affected bazel tests (depth 2); env-var specific test (`test_environment_variable_system_api`) passes. Unrelated darwin-local flakes were observed in stable-memory / NNS / state_manager / consensus integration tests; none reference env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)