### PR TITLE
feat: allow engine controller to halt cloud engine subnets

### DIFF
--- a/rs/engine_controller/canister/canister.rs
+++ b/rs/engine_controller/canister/canister.rs
@@ -187,20 +187,22 @@ async fn delete_engine(args: DeleteEngineArgs) -> Result<(), String> {
     response
 }
 
-/// Validates that the only field set on the proxied `UpdateSubnetPayload` is
-/// `subnet_admins`. Every other `Option<_>` field must be `None`, and the
-/// single non-optional knob (`set_gossip_config_to_default`) must hold its
-/// default value (`false`). The required `subnet_id` is exempt because it
-/// merely identifies the target.
+/// Validates that the only fields set on the proxied `UpdateSubnetPayload`
+/// are the ones the engine controller is allowed to manage: `subnet_admins`
+/// and `is_halted` (subnet halting / unhalting). Every other `Option<_>`
+/// field must be `None`, and the single non-optional knob
+/// (`set_gossip_config_to_default`) must hold its default value (`false`).
+/// The required `subnet_id` is exempt because it merely identifies the target.
 ///
 /// This keeps the surface of `update_subnet` deliberately tiny: only the
 /// fields the engine controller is intended to manage flow through. Adding a
 /// new allowed field is a conscious, code-level decision.
-fn ensure_only_subnet_admins_set(payload: &UpdateSubnetPayload) -> Result<(), String> {
+fn ensure_only_allowed_fields_set(payload: &UpdateSubnetPayload) -> Result<(), String> {
     let UpdateSubnetPayload {
         subnet_id: _,
-        // The single field we allow.
+        // The fields we allow.
         subnet_admins: _,
+        is_halted: _,
 
         max_ingress_bytes_per_message,
         max_ingress_bytes_per_block,
@@ -212,7 +214,6 @@ fn ensure_only_subnet_admins_set(payload: &UpdateSubnetPayload) -> Result<(), St
         dkg_dealings_per_block,
         start_as_nns,
         subnet_type,
-        is_halted,
         halt_at_cup_height,
         features,
         resource_limits,
@@ -260,7 +261,6 @@ fn ensure_only_subnet_admins_set(payload: &UpdateSubnetPayload) -> Result<(), St
     check_none!(dkg_dealings_per_block, "dkg_dealings_per_block");
     check_none!(start_as_nns, "start_as_nns");
     check_none!(subnet_type, "subnet_type");
-    check_none!(is_halted, "is_halted");
     check_none!(halt_at_cup_height, "halt_at_cup_height");
     check_none!(features, "features");
     check_none!(resource_limits, "resource_limits");
@@ -290,7 +290,7 @@ fn ensure_only_subnet_admins_set(payload: &UpdateSubnetPayload) -> Result<(), St
     } else {
         Err(format!(
             "Updating these fields via the engine controller is not allowed: {}. \
-             Only `subnet_admins` may be updated.",
+             Only `subnet_admins` and `is_halted` may be updated.",
             disallowed.join(", ")
         ))
     }
@@ -309,8 +309,8 @@ fn normalize_subnet_admins(admins: Vec<PrincipalId>) -> Vec<PrincipalId> {
 }
 
 /// Proxies to the registry's `update_subnet` endpoint. Only `subnet_admins`
-/// may be updated through this path; every other field must be left at its
-/// default value (`None` / `false`) or the call is rejected.
+/// and `is_halted` may be updated through this path; every other field must be
+/// left at its default value (`None` / `false`) or the call is rejected.
 ///
 /// The `subnet_admins` list is always normalized to include the engine
 /// controller's authorized caller (the super admin), so callers cannot
@@ -318,7 +318,7 @@ fn normalize_subnet_admins(admins: Vec<PrincipalId>) -> Vec<PrincipalId> {
 #[update]
 async fn update_subnet(payload: UpdateSubnetPayload) -> Result<(), String> {
     ensure_authorized()?;
-    ensure_only_subnet_admins_set(&payload)?;
+    ensure_only_allowed_fields_set(&payload)?;
 
     // Normalize `subnet_admins` so the super admin is always present.
     // The caller may omit the field entirely (no change requested), but if

--- a/rs/engine_controller/canister/tests.rs
+++ b/rs/engine_controller/canister/tests.rs
@@ -75,43 +75,64 @@ fn test_implemented_interface_matches_declared_interface_exactly() {
 }
 
 #[test]
-fn ensure_only_subnet_admins_set_accepts_empty_payload() {
+fn ensure_only_allowed_fields_set_accepts_empty_payload() {
     // Pure no-op: no fields set at all. We don't actually want to allow this
     // in practice (the call would be useless), but the validator's job is
     // purely structural — it must accept any payload where the only mutated
-    // field is `subnet_admins`.
-    ensure_only_subnet_admins_set(&empty_update_payload())
+    // fields are the allowed ones.
+    ensure_only_allowed_fields_set(&empty_update_payload())
         .expect("an empty payload must pass the structural check");
 }
 
 #[test]
-fn ensure_only_subnet_admins_set_accepts_subnet_admins_only() {
+fn ensure_only_allowed_fields_set_accepts_subnet_admins_only() {
     let mut payload = empty_update_payload();
     payload.subnet_admins = Some(vec![PrincipalId::new_user_test_id(42)]);
-    ensure_only_subnet_admins_set(&payload).expect("subnet_admins-only payload must be allowed");
+    ensure_only_allowed_fields_set(&payload).expect("subnet_admins-only payload must be allowed");
 }
 
 #[test]
-fn ensure_only_subnet_admins_set_rejects_other_fields() {
+fn ensure_only_allowed_fields_set_accepts_is_halted() {
+    for is_halted in [true, false] {
+        let mut payload = empty_update_payload();
+        payload.is_halted = Some(is_halted);
+        ensure_only_allowed_fields_set(&payload)
+            .unwrap_or_else(|e| panic!("is_halted={is_halted} payload must be allowed: {e}"));
+    }
+}
+
+#[test]
+fn ensure_only_allowed_fields_set_accepts_subnet_admins_and_is_halted() {
+    let mut payload = empty_update_payload();
+    payload.subnet_admins = Some(vec![PrincipalId::new_user_test_id(42)]);
+    payload.is_halted = Some(true);
+    ensure_only_allowed_fields_set(&payload)
+        .expect("subnet_admins + is_halted payload must be allowed");
+}
+
+#[test]
+fn ensure_only_allowed_fields_set_rejects_other_fields() {
     let mut payload = empty_update_payload();
     payload.max_number_of_canisters = Some(100);
-    payload.is_halted = Some(true);
-    let err = ensure_only_subnet_admins_set(&payload).expect_err("should reject");
+    // `halt_at_cup_height` is intentionally *not* part of the allowed surface,
+    // even though it is halting-adjacent: only `is_halted` is.
+    payload.halt_at_cup_height = Some(true);
+    let err = ensure_only_allowed_fields_set(&payload).expect_err("should reject");
     assert!(
         err.contains("max_number_of_canisters"),
         "error must mention disallowed field: {err}"
     );
     assert!(
-        err.contains("is_halted"),
+        err.contains("halt_at_cup_height"),
         "error must mention disallowed field: {err}"
     );
 }
 
 #[test]
-fn ensure_only_subnet_admins_set_rejects_non_default_gossip_flag() {
+fn ensure_only_allowed_fields_set_rejects_non_default_gossip_flag() {
     let mut payload = empty_update_payload();
     payload.set_gossip_config_to_default = true;
-    let err = ensure_only_subnet_admins_set(&payload).expect_err("should reject");
+    let err = ensure_only_allowed_fields_set(&payload).expect_err("should reject");
     assert!(
         err.contains("set_gossip_config_to_default"),
         "error must mention the non-default bool: {err}"


### PR DESCRIPTION
## What

Stacked on top of #10431. That PR lets the engine-controller canister proxy
`update_subnet`, but its field allow-list (`ensure_only_subnet_admins_set`)
currently permits **only** `subnet_admins`. This PR widens that allow-list to
also permit `is_halted`, so the engine controller can halt / unhalt the
cloud-engine subnets it manages.

## Changes

- `rs/engine_controller/canister/canister.rs`
  - Renamed `ensure_only_subnet_admins_set` → `ensure_only_allowed_fields_set`
    and moved `is_halted` into the allowed group; every other field still must
    be left at its default (`None` / `false`) or the call is rejected.
  - Updated the validator error message and the `update_subnet` doc comments.
- `rs/engine_controller/canister/tests.rs`
  - Renamed the validator tests, added coverage that `is_halted` (both `true`
    and `false`) and `subnet_admins + is_halted` are accepted, and switched the
    "rejects other fields" test to assert on a still-disallowed field.

## Scope notes

- The registry side is unchanged: `do_update_subnet` already accepts `is_halted`
  and only gates the engine controller to `CloudEngine` subnets, so no
  registry-level changes are needed.
- `halt_at_cup_height` is intentionally **not** added — only the direct
  `is_halted` flag. Adding a new allowed field stays a conscious, code-level
  decision, matching the design intent of the base PR.
- No `.did` change: `is_halted` is already part of the mirrored
  `UpdateSubnetPayload`, and the candid interface-equality test still passes.

## Testing

`cargo test -p ic-engine-controller --bin engine-controller-canister` — all 10
unit tests pass (including the candid interface-match test). `cargo fmt --check`
is clean.

> Draft because it stacks on the not-yet-merged #10431; base is set to that
> PR's branch (`nim-update-subnet`).