### PR TITLE
fix: deflake //rs/tests/networking:canister_http_* tests

### DIFF
--- a/ic-os/components/networking/nftables/reload_nftables.service
+++ b/ic-os/components/networking/nftables/reload_nftables.service
@@ -16,7 +16,9 @@ Type=oneshot
 # the old ruleset and loading the new one happen in a single nft transaction:
 # if loading fails the previously active ruleset stays in effect instead of
 # leaving the node without a firewall (nft -f is transactional).
-ExecStart=/usr/sbin/nft -f /etc/nftables.conf
+# Note: /etc/nftables.conf is a symlink to the file loaded below (see the
+# GuestOS Dockerfile), so nftables.service at boot loads the same config.
+ExecStart=/usr/sbin/nft -f /run/ic-node/nftables-ruleset/nftables.conf
 # Loading can still fail transiently, e.g. when the "hostos" hostname cannot
 # be resolved yet early during boot. Since the load is atomic it is safe to
 # simply retry until it succeeds. If it keeps failing, the unit ends up in a

--- a/ic-os/components/networking/nftables/reload_nftables.service
+++ b/ic-os/components/networking/nftables/reload_nftables.service
@@ -2,12 +2,25 @@
 Description=Reload nftables when the configuration changes
 # The orchestrator-generated nftables config uses the hostname "hostos" which
 # is resolved via the nss_icos NSS plugin. We must wait for name resolution to
-# be available, otherwise the nft reload fails with "Could not resolve hostname"
-# and the entire ruleset is discarded (nft is transactional).
+# be available, otherwise the nft load fails with "Could not resolve hostname".
 After=nss-lookup.target systemd-resolved.service
 Wants=nss-lookup.target
+# Allow the restarts configured below (Restart=on-failure with RestartSec=2)
+# to go on for up to ~60s before giving up and marking the unit as failed.
+StartLimitIntervalSec=300
+StartLimitBurst=30
 
 [Service]
 Type=oneshot
-ExecStartPre=/usr/sbin/nft flush ruleset
-ExecStart=systemctl reload nftables.service
+# The orchestrator-generated config starts with "flush ruleset" so flushing
+# the old ruleset and loading the new one happen in a single nft transaction:
+# if loading fails the previously active ruleset stays in effect instead of
+# leaving the node without a firewall (nft -f is transactional).
+ExecStart=/usr/sbin/nft -f /etc/nftables.conf
+# Loading can still fail transiently, e.g. when the "hostos" hostname cannot
+# be resolved yet early during boot. Since the load is atomic it is safe to
+# simply retry until it succeeds. If it keeps failing, the unit ends up in a
+# failed state, making the problem visible (e.g. to
+# //rs/tests/node:guestos_no_failed_systemd_units).
+Restart=on-failure
+RestartSec=2

--- a/rs/ic_os/config/tool/templates/ic.json5.template
+++ b/rs/ic_os/config/tool/templates/ic.json5.template
@@ -184,7 +184,9 @@
 
     firewall: {
         config_file: "/run/ic-node/nftables-ruleset/nftables.conf",
-        file_template: "table filter {\n\
+        file_template: "flush ruleset\n\
+\n\
+table filter {\n\
   define icmp_v4_types_accept = {\n\
     destination-unreachable,\n\
     time-exceeded,\n\
@@ -331,7 +333,9 @@ table ip6 filter {\n\
 
     boundary_node_firewall: {
         config_file: "/run/ic-node/nftables-ruleset/nftables.conf",
-        file_template: "table filter {\n\
+        file_template: "flush ruleset\n\
+\n\
+table filter {\n\
   set rate_limit {\n\
     type ipv4_addr\n\
     size 65535\n\

--- a/rs/orchestrator/testdata/nftables_assigned_cloud_engine.conf.golden
+++ b/rs/orchestrator/testdata/nftables_assigned_cloud_engine.conf.golden
@@ -1,3 +1,5 @@
+flush ruleset
+
 table filter {
   define icmp_v4_types_accept = {
     destination-unreachable,

--- a/rs/orchestrator/testdata/nftables_assigned_replica.conf.golden
+++ b/rs/orchestrator/testdata/nftables_assigned_replica.conf.golden
@@ -1,3 +1,5 @@
+flush ruleset
+
 table filter {
   define icmp_v4_types_accept = {
     destination-unreachable,

--- a/rs/orchestrator/testdata/nftables_boundary_node_app_subnet.conf.golden
+++ b/rs/orchestrator/testdata/nftables_boundary_node_app_subnet.conf.golden
@@ -1,3 +1,5 @@
+flush ruleset
+
 table filter {
   set rate_limit {
     type ipv4_addr

--- a/rs/orchestrator/testdata/nftables_boundary_node_system_subnet.conf.golden
+++ b/rs/orchestrator/testdata/nftables_boundary_node_system_subnet.conf.golden
@@ -1,3 +1,5 @@
+flush ruleset
+
 table filter {
   set rate_limit {
     type ipv4_addr

--- a/rs/orchestrator/testdata/nftables_unassigned_cloud_engine.conf.golden
+++ b/rs/orchestrator/testdata/nftables_unassigned_cloud_engine.conf.golden
@@ -1,3 +1,5 @@
+flush ruleset
+
 table filter {
   define icmp_v4_types_accept = {
     destination-unreachable,

--- a/rs/orchestrator/testdata/nftables_unassigned_replica.conf.golden
+++ b/rs/orchestrator/testdata/nftables_unassigned_replica.conf.golden
@@ -1,3 +1,5 @@
+flush ruleset
+
 table filter {
   define icmp_v4_types_accept = {
     destination-unreachable,


### PR DESCRIPTION
## Root Cause

The `//rs/tests/networking:canister_http_*` tests fail in `setup` with:

```
Orchestrator rule did not appear in time.: Timed out waiting for orchestrator rule.
...
Output:  Err: Error: No such file or directory
list chain ip6 filter OUTPUT
```

`canister_http::setup` → `start_httpbin_on_uvm` → `wait_for_orchestrator_fw_rules` polls every node for the orchestrator-applied `ip6 filter OUTPUT` chain. In the analyzed failure the **entire `ip6 filter` table** was missing on one node and never appeared during the whole 60s retry window — long after all replicas reported healthy. That's a *permanent* condition, not a slow one.

The GuestOS firewall application pipeline is:

1. The orchestrator generates the nftables ruleset and writes it to `/run/ic-node/nftables-ruleset/nftables.conf` — but **only when its content changes** (or on the very first check after start).
2. `reload_nftables.path` (`PathChanged=`) triggers `reload_nftables.service`, which ran:
   - `ExecStartPre=/usr/sbin/nft flush ruleset`
   - `ExecStart=systemctl reload nftables.service` (→ `nft -f /etc/nftables.conf`)

This sequence is **neither atomic nor retried**:

- The flush runs *outside* the nft transaction. If the subsequent load fails for any transient reason, the node is left with an **empty ruleset**.
- The canonical transient failure is hostname resolution of `hostos` in the template rule `ip6 saddr { hostos } ct state { new } tcp dport { 42372 } accept`, which is resolved at `nft` load time (via the `nss_icos` NSS plugin, falling through to DNS) and can fail with `Error: Could not resolve hostname: Temporary failure in name resolution` early after boot.
- Nothing retries: the service is `Type=oneshot` without restart, and the path unit only re-fires when the orchestrator rewrites the file — which it effectively never does again on a short-lived testnet.

A single transient `nft` load failure therefore permanently disables the firewall on that node, and the test times out waiting for a chain that will never exist. The `canister_http_*` family is the canary because it's the only test family that explicitly waits for this rule on **every** node of its testnet.

PR #9857 previously narrowed this race by adding `After=nss-lookup.target` ordering to `reload_nftables.service`, but `After=` is pure start ordering — by the time the path unit fires, those targets are long active, so it doesn't guarantee that resolving `hostos` succeeds. The race window was narrowed, not closed.

## Fix

Make the firewall apply **atomic** and **retried**:

- Prepend `flush ruleset` to the orchestrator-generated nftables config (both the replica and the boundary-node firewall templates in `ic.json5.template`), so flushing the old ruleset and loading the new one happen in a single `nft` transaction. A failed load now leaves the previously active ruleset in effect instead of leaving the node without a firewall.
- In `reload_nftables.service`, drop the non-atomic `ExecStartPre` flush, run `nft -f /etc/nftables.conf` directly, and add `Restart=on-failure` / `RestartSec=2` (bounded by `StartLimitIntervalSec=300` / `StartLimitBurst=30`, i.e. ~60s of retries). Since the load is atomic, retrying is safe. If it keeps failing, the unit ends up in a failed state, making the problem visible (e.g. to `//rs/tests/node:guestos_no_failed_systemd_units`).

The 6 nftables golden files are updated accordingly.

## Verification

- `bazel test //rs/orchestrator:orchestrator_test` (nftables golden tests) passes.
- `bazel test --runs_per_test=//rs/tests/networking:canister_http_test@3 //rs/tests/networking:canister_http_test //rs/tests/node:guestos_no_failed_systemd_units`

---
This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
