### PR TITLE
feat: Enable `PATCH` for HTTP outcalls

### DIFF
--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -128,7 +128,8 @@ fn main() -> Result<()> {
                 .add_test(systest!(test_put_without_non_replicated_rejected))
                 .add_test(systest!(test_delete_call))
                 .add_test(systest!(test_delete_without_non_replicated_rejected))
-                .add_test(systest!(test_patch_rejected))
+                .add_test(systest!(test_patch_call))
+                .add_test(systest!(test_patch_without_non_replicated_rejected))
                 .add_test(systest!(test_max_possible_request_size))
                 .add_test(systest!(test_max_possible_request_size_exceeded))
                 // This section tests the request headers limits scenarios
@@ -1941,11 +1942,7 @@ fn test_delete_without_non_replicated_rejected(env: TestEnv) {
     });
 }
 
-// PATCH is plumbed through the types but not yet enabled on replicated subnets:
-// the execution layer rejects it so no PATCH context enters the replicated
-// state until support has rolled out to all replicas. This holds even for a
-// non-replicated request.
-fn test_patch_rejected(env: TestEnv) {
+fn test_patch_call(env: TestEnv) {
     let handlers = Handlers::new(&env);
     let webserver_ipv6 = get_universal_vm_address(&env);
 
@@ -1975,8 +1972,39 @@ fn test_patch_rejected(env: TestEnv) {
         },
     ));
 
+    assert_matches!(response, Ok(response) => {
+        assert_matches!(response, RemoteHttpResponse { status: 200, .. });
+        assert_distinct_headers(&response);
+        assert_http_json_response(&request, &response);
+    });
+}
+
+fn test_patch_without_non_replicated_rejected(env: TestEnv) {
+    let handlers = Handlers::new(&env);
+    let webserver_ipv6 = get_universal_vm_address(&env);
+
+    let url = format!("https://[{}]/{}", webserver_ipv6, "anything");
+    let request = UnvalidatedCanisterHttpRequestArgs {
+        url,
+        headers: vec![],
+        method: HttpMethod::PATCH,
+        body: Some(vec![]),
+        transform: None,
+        max_response_bytes: Some(1024),
+        is_replicated: None,
+        pricing_version: None,
+    };
+
+    let (response, _) = block_on(submit_outcall(
+        &handlers,
+        RemoteHttpRequest {
+            request,
+            cycles: HTTP_REQUEST_CYCLE_PAYMENT,
+        },
+    ));
+
     assert_matches!(response, Err(RejectResponse { reject_message, .. }) => {
-        assert!(reject_message.contains("PATCH HTTP method is not yet supported"));
+        assert!(reject_message.contains("only allowed for non-replicated requests"));
     });
 }
 

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -534,26 +534,19 @@ impl CanisterHttpRequestContext {
             None => Ok(None),
         }?;
 
-        // PATCH is plumbed through the types but not yet enabled on replicated
-        // subnets: reject it here in the execution layer so that no PATCH
-        // `http_method` enters the replicated state until support has rolled
-        // out to all replicas (mirroring how PUT/DELETE were staged in #8715 /
-        // #8717). A follow-up PR enables it once the rollout is complete.
-        if matches!(args.method, HttpMethod::PATCH) {
-            return Err(CanisterHttpRequestContextError::HttpMethodNotYetSupported);
-        }
-
-        // Allow PUT and DELETE only in non-replicated mode to avoid
+        // Allow PUT, DELETE, and PATCH only in non-replicated mode to avoid
         // confusing race conditions that may occur.
         // For example, if first a DELETE outcall for resource R is made,
-        // directly followed by a PUT or POST outcall for R, in
+        // directly followed by a PUT, PATCH, or POST outcall for R, in
         // replicated mode it may happen that R is actually deleted after the
-        // PUT/POST outcall has finished, because the IC does not
+        // PUT/PATCH/POST outcall has finished, because the IC does not
         // necessarily wait for all outcalls to complete before a result is
         // delivered back to the canister: The IC only waits for sufficient
         // calls to complete to reach consensus on the result.
-        if matches!(args.method, HttpMethod::PUT | HttpMethod::DELETE)
-            && args.is_replicated != Some(false)
+        if matches!(
+            args.method,
+            HttpMethod::PUT | HttpMethod::DELETE | HttpMethod::PATCH
+        ) && args.is_replicated != Some(false)
         {
             return Err(CanisterHttpRequestContextError::DeterministicResponseCountRequired);
         }
@@ -665,12 +658,10 @@ impl CanisterHttpRequestContext {
         // does not necessarily wait for all outcalls to complete before a result
         // is delivered back to the canister: The IC only waits for sufficient
         // calls to complete to reach consensus on the result.
-        // PATCH is not yet enabled on replicated subnets (see generate_from_args).
-        if matches!(args.method, HttpMethod::PATCH) {
-            return Err(CanisterHttpRequestContextError::HttpMethodNotYetSupported);
-        }
-        if matches!(args.method, HttpMethod::PUT | HttpMethod::DELETE)
-            && !(min_responses == max_responses && max_responses == total_requests)
+        if matches!(
+            args.method,
+            HttpMethod::PUT | HttpMethod::DELETE | HttpMethod::PATCH
+        ) && !(min_responses == max_responses && max_responses == total_requests)
         {
             return Err(CanisterHttpRequestContextError::DeterministicResponseCountRequired);
         }
@@ -740,10 +731,6 @@ pub enum CanisterHttpRequestContextError {
     NoNodesAvailableForDelegation,
     DeterministicResponseCountRequired,
     InvalidReplicationCounts(String),
-    /// The requested HTTP method is plumbed through the types but not yet
-    /// enabled on replicated subnets (currently PATCH); rejected until support
-    /// has rolled out to all replicas.
-    HttpMethodNotYetSupported,
 }
 
 impl From<CanisterHttpRequestContextError> for UserError {
@@ -811,10 +798,6 @@ impl From<CanisterHttpRequestContextError> for UserError {
             CanisterHttpRequestContextError::InvalidReplicationCounts(msg) => {
                 UserError::new(ErrorCode::CanisterRejectedMessage, msg)
             }
-            CanisterHttpRequestContextError::HttpMethodNotYetSupported => UserError::new(
-                ErrorCode::CanisterRejectedMessage,
-                "The PATCH HTTP method is not yet supported.".to_string(),
-            ),
         }
     }
 }
@@ -1421,6 +1404,7 @@ mod tests {
     #[rstest]
     #[case(HttpMethod::PUT)]
     #[case(HttpMethod::DELETE)]
+    #[case(HttpMethod::PATCH)]
     fn put_delete_requires_non_replicated(#[case] method: HttpMethod) {
         let rng = &mut ReproducibleRng::new();
         let node_ids = BTreeSet::from([node_test_id(1)]);
@@ -1458,41 +1442,6 @@ mod tests {
                 assert_eq!(ctx.http_method, expected_method);
                 assert_matches!(ctx.replication, Replication::NonReplicated(_));
             }
-        );
-    }
-
-    #[test]
-    fn patch_is_rejected_until_rollout() {
-        let rng = &mut ReproducibleRng::new();
-        let node_ids = BTreeSet::from([node_test_id(1), node_test_id(2), node_test_id(3)]);
-        let request = dummy_request();
-
-        // Rejected outright, regardless of is_replicated, so no PATCH context
-        // enters the replicated state until support has rolled out.
-        for is_replicated in [None, Some(true), Some(false)] {
-            let args = dummy_args(HttpMethod::PATCH, is_replicated);
-            let result = CanisterHttpRequestContext::generate_from_args(
-                UNIX_EPOCH, &request, args, &node_ids, rng,
-            );
-            assert_matches!(
-                result,
-                Err(CanisterHttpRequestContextError::HttpMethodNotYetSupported)
-            );
-        }
-
-        // Also rejected via the flexible API.
-        let mut args = dummy_flexible_args(Some(ReplicationCounts {
-            total_requests: 3,
-            min_responses: 3,
-            max_responses: 3,
-        }));
-        args.method = HttpMethod::PATCH;
-        let result = CanisterHttpRequestContext::generate_from_flexible_args(
-            UNIX_EPOCH, &request, args, &node_ids, rng,
-        );
-        assert_matches!(
-            result,
-            Err(CanisterHttpRequestContextError::HttpMethodNotYetSupported)
         );
     }
 
@@ -1893,10 +1842,13 @@ mod tests {
     #[rstest]
     #[case(HttpMethod::PUT, 3, 2, 3, false)]
     #[case(HttpMethod::DELETE, 3, 2, 3, false)]
+    #[case(HttpMethod::PATCH, 3, 2, 3, false)]
     #[case(HttpMethod::PUT, 3, 3, 3, true)]
     #[case(HttpMethod::DELETE, 3, 3, 3, true)]
+    #[case(HttpMethod::PATCH, 3, 3, 3, true)]
     #[case(HttpMethod::PUT, 3, 2, 2, false)]
     #[case(HttpMethod::DELETE, 3, 2, 2, false)]
+    #[case(HttpMethod::PATCH, 3, 2, 2, false)]
     fn flexible_methods_require_deterministic_response_counts(
         #[case] method: HttpMethod,
         #[case] total_requests: u32,


### PR DESCRIPTION
https://github.com/dfinity/ic/pull/10378 introduced support for the `PATCH` method to the HTTP outcalls implementation. For backward compatibility reasons, the new method remained disabled such that requests specifying it are still rejected.

The change above is being rolled out this week as part of release [142256](https://dashboard.internetcomputer.org/proposal/142256).

Therefore, this PR enables the `PATCH` method such that it may be used in HTTP outcall requests.

For backward compatibility reasons, note that subnets upgraded to the version of this PR should not directly be downgraded to versions earlier than  release [142256](https://dashboard.internetcomputer.org/proposal/142256) mentioned above.

This reverts commit 26e3ae7d1b4cb5682edcaa4d828baa27fc7943e6.