### PR TITLE
fix: evict dead pooled XNet connections via HTTP/2 keep-alive pings

### DIFF
--- a/rs/xnet/hyper/src/lib.rs
+++ b/rs/xnet/hyper/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    time::Duration,
 };
 use tokio::net::TcpStream;
 use tower::{BoxError, Service};
@@ -39,6 +40,9 @@ impl TlsConnector {
     pub fn new(tls: Arc<dyn TlsConfig>) -> Self {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
+        // Fail fast on a stuck TCP connect instead of relying solely on the
+        // per-query timeout (defense in depth against connection-setup storms).
+        http.set_connect_timeout(Some(Duration::from_secs(5)));
         Self {
             connection_type: ConnectionType::Tls,
             http,
@@ -51,6 +55,9 @@ impl TlsConnector {
     pub fn new_for_tests(tls: Arc<dyn TlsConfig>) -> Self {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
+        // Fail fast on a stuck TCP connect instead of relying solely on the
+        // per-query timeout (defense in depth against connection-setup storms).
+        http.set_connect_timeout(Some(Duration::from_secs(5)));
         Self {
             connection_type: ConnectionType::Raw,
             http,

--- a/rs/xnet/payload_builder/src/lib.rs
+++ b/rs/xnet/payload_builder/src/lib.rs
@@ -1754,8 +1754,8 @@ struct XNetClientImpl {
 }
 
 impl XNetClientImpl {
-    /// Creates a new `XNetClientImpl` with a request timeout of 1 second and at
-    /// most 1 idle connection per host.
+    /// Creates a new `XNetClientImpl` with a request timeout of 5 seconds, at
+    /// most 1 idle connection per host and HTTP/2 keep-alive pings.
     fn new(
         metrics_registry: &MetricsRegistry,
         tls: Arc<dyn TlsConfig>,
@@ -1767,9 +1767,24 @@ impl XNetClientImpl {
         let https = TlsConnector::new_for_tests(tls);
 
         // TODO(MR-28) Make timeout configurable.
+        //
+        // HTTP/2 keep-alive pings are necessary to evict dead pooled connections:
+        // cancelling a request (e.g. due to the 5-second query timeout) only resets
+        // the respective stream, it does not affect the underlying connection. And
+        // the pool only drops connections that report themselves as closed. So
+        // without keep-alive a connection that is dead or stalled (e.g. due to
+        // packet loss while under load) would be reused indefinitely, with every
+        // query against it timing out. With keep-alive, such a connection is closed
+        // within `interval + timeout` seconds and a fresh connection is established
+        // on the next query.
         let http_client: Client<TlsConnector, Request<XNetRequestBody>> =
             Client::builder(TokioExecutor::new())
                 .http2_only(true)
+                // Timer required by HTTP/2 keep-alive.
+                .timer(TokioTimer::new())
+                .http2_keep_alive_interval(Some(Duration::from_secs(5)))
+                .http2_keep_alive_timeout(Duration::from_secs(5))
+                .http2_keep_alive_while_idle(true)
                 .pool_timer(TokioTimer::new())
                 .pool_idle_timeout(Some(Duration::from_secs(600)))
                 .pool_max_idle_per_host(1)

--- a/rs/xnet/payload_builder/src/lib.rs
+++ b/rs/xnet/payload_builder/src/lib.rs
@@ -1782,7 +1782,7 @@ impl XNetClientImpl {
                 .http2_only(true)
                 // Timer required by HTTP/2 keep-alive.
                 .timer(TokioTimer::new())
-                .http2_keep_alive_interval(Some(Duration::from_secs(5)))
+                .http2_keep_alive_interval(Some(Duration::from_secs(10)))
                 .http2_keep_alive_timeout(Duration::from_secs(5))
                 .http2_keep_alive_while_idle(true)
                 .pool_timer(TokioTimer::new())


### PR DESCRIPTION
## Problem

Since the migration of the XNet payload builder to HTTP/2 (#1506), a dead or stalled pooled connection to an XNet endpoint is reused **indefinitely**:

- Cancelling a request (e.g. due to the 5-second query timeout in `XNetClientImpl::query`) only resets the respective h2 *stream*; it does not affect the underlying connection.
- The connection pool only drops connections that report themselves as closed; a stalled-but-established h2 connection never does.

A connection that ends up dead/stalled (e.g. due to packet loss or CPU starvation while under load) therefore black-holes **all** pulls from the respective subnet pair until the replica restarts. Under the previous HTTP/1.1 client this could not happen, because cancelling a request closes its connection.

### Observed impact

`//rs/tests/message_routing/xnet:xnet_slo_120_subnets_staging_test` failed reproducibly: the synchronized startup of 120×119 TLS connections (while replicas were CPU-starved) wedged 191 directed subnet pairs. Each wedged pair timed out on every pull (at the 5s timeout, ~2.3/s) for the entire run with zero recovery, pushing best-effort calls on 20 subnets past their 30s deadline (5.7%–13.7% failed calls vs. the 5% threshold). Per-subnet error rate was predicted by the number of wedged pairs involving that subnet with correlation 0.997.

## Fix

Enable HTTP/2 keep-alive pings on the XNet client: 10s interval, 5s timeout, also while idle (`pool_max_idle_per_host(1)` keeps an idle connection pooled for up to 600s). A dead connection is now detected and closed within ~15s — well below the 30s best-effort deadline — after which the next query establishes a fresh connection.

Note: this requires supplying an h2 timer via `.timer(TokioTimer::new())` in addition to the existing `.pool_timer(...)`; without it hyper panics at runtime once keep-alive is enabled.

As defense in depth, also set a 5s TCP connect timeout on the `HttpConnector` underlying `TlsConnector` (both `new` and `new_for_tests`), so a stuck handshake fails fast rather than relying solely on the per-query timeout. This does not address the observed failure on its own — the wedged connections had completed TCP+TLS and stalled at the h2 layer — but it bounds connection-setup stalls.

Cost: at most ~119 connections per node → ~12 PING frames/s/node; both endpoints are replica-controlled (hyper's h2 server ACKs pings natively).

## Verification

On CI the `Release System Tests` job [succeeds](https://github.com/dfinity/ic/actions/runs/27438248671/job/81105591015) including `//rs/tests/message_routing/xnet:xnet_slo_120_subnets_staging_test_colocate` ([BuildBuddy](https://dash.dm1-idx1.dfinity.network/invocation/2d53507f-fe7d-45a8-a006-1fecfd20666e?target=%2F%2Frs%2Ftests%2Fmessage_routing%2Fxnet%3Axnet_slo_120_subnets_staging_test_colocate&targetStatus=5)). Manual runs (from `dm1`) succeed as well:

```
bazel test //rs/tests/message_routing/xnet:xnet_slo_120_subnets_staging_test \
  --cache_test_results=no --test_output=errors \
  --test_arg=--set-required-host-features=dc=dm1
```

- Before: FAILED — 20/120 subnets above the 5% failed-call threshold (5.7%–13.7%).
- After: **PASSED in 745.8s — 0 failed calls on all 120 subnets** (worst subnet: 0/56049).
- `//rs/xnet/payload_builder:payload_builder_test` and `:payload_builder_integration` pass (the latter exercises real client queries and would catch the missing-timer panic).

After reducing the ping frequency to a 10s interval and adding the connect timeout (review follow-up), `bazel test //rs/tests/message_routing/xnet:xnet_slo_120_subnets_staging_test --cache_test_results=no` still succeeds, and the unit/integration tests above still pass.
