### PR TITLE
fix: deflake //rs/tests/consensus/orchestrator:ssh_access_to_nodes_test

### DIFF
--- a/rs/tests/consensus/utils/src/ssh_access.rs
+++ b/rs/tests/consensus/utils/src/ssh_access.rs
@@ -80,21 +80,35 @@ impl Default for SshSession {
 }
 
 impl SshSession {
-    /// Opens a TCP connection to the node and performs the SSH transport handshake
-    /// (protocol-version banner exchange and key exchange). This is the transport
-    /// layer, established before any authentication takes place. Failures here (e.g.
-    /// "Failed getting banner" when the node is briefly unresponsive right after a
-    /// restart) are transient and unrelated to whether a key grants access.
-    fn connect(&mut self, ip: &IpAddr) -> Result<(), String> {
+    pub fn login(&mut self, ip: &IpAddr, username: &str, mean: &AuthMean) -> Result<(), String> {
+        // The SSH transport handshake (TCP connect + protocol banner and key
+        // exchange) is retried for a bounded time because it can fail transiently
+        // (e.g. with "Failed getting banner") when the node is briefly unresponsive,
+        // for instance right after the replica/orchestrator is restarted. Such
+        // transport-level failures are unrelated to whether the key grants access,
+        // which is what the callers actually test. The authentication step below is
+        // not retried, so an actual loss of access (e.g. a key being incorrectly
+        // removed) is still reported immediately.
         let ip_str = format!("[{ip}]:22");
-        let tcp = TcpStream::connect(ip_str).map_err(|err| err.to_string())?;
-        self.session.set_tcp_stream(tcp);
-        self.session.handshake().map_err(|err| err.to_string())
-    }
+        let start = std::time::Instant::now();
+        loop {
+            let handshake_result = TcpStream::connect(&ip_str)
+                .map_err(|err| err.to_string())
+                .and_then(|tcp| {
+                    self.session.set_tcp_stream(tcp);
+                    self.session.handshake().map_err(|err| err.to_string())
+                });
+            match handshake_result {
+                Ok(()) => break,
+                Err(_) if start.elapsed() < SSH_ACCESS_TIMEOUT => {
+                    std::thread::sleep(SSH_ACCESS_BACKOFF);
+                    // A failed handshake can leave the session unusable, so replace it.
+                    self.session = Session::new().unwrap();
+                }
+                Err(err) => return Err(err),
+            }
+        }
 
-    /// Attempts to authenticate as `username` using `mean` on an already-handshaken
-    /// session. The result reflects whether the key actually grants access.
-    fn authenticate(&self, username: &str, mean: &AuthMean) -> Result<(), String> {
         match mean {
             AuthMean::PrivateKey(pk) => self
                 .session
@@ -104,35 +118,10 @@ impl SshSession {
         }
         .map_err(|err| err.to_string())
     }
-
-    pub fn login(&mut self, ip: &IpAddr, username: &str, mean: &AuthMean) -> Result<(), String> {
-        self.connect(ip)?;
-        self.authenticate(username, mean)
-    }
 }
 
 pub fn assert_authentication_works(ip: &IpAddr, username: &str, mean: &AuthMean) {
-    // The SSH transport handshake is retried for a bounded time because it can fail
-    // transiently (e.g. with "Failed getting banner") when the node is briefly
-    // unresponsive, for instance right after the replica/orchestrator is restarted.
-    // Such transport-level failures are unrelated to whether the key grants access.
-    // The authentication step itself is *not* retried, so an actual loss of access
-    // (e.g. a key being incorrectly removed) is still reported immediately.
-    let start = std::time::Instant::now();
-    let session = loop {
-        let mut session = SshSession::default();
-        match session.connect(ip) {
-            Ok(()) => break session,
-            Err(err) => {
-                assert!(
-                    start.elapsed() < SSH_ACCESS_TIMEOUT,
-                    "Failed to establish an SSH connection to {ip}: {err}"
-                );
-                std::thread::sleep(SSH_ACCESS_BACKOFF);
-            }
-        }
-    };
-    session.authenticate(username, mean).unwrap();
+    SshSession::default().login(ip, username, mean).unwrap();
 }
 
 pub fn assert_authentication_fails(ip: &IpAddr, username: &str, mean: &AuthMean) {

--- a/rs/tests/consensus/utils/src/ssh_access.rs
+++ b/rs/tests/consensus/utils/src/ssh_access.rs
@@ -80,12 +80,21 @@ impl Default for SshSession {
 }
 
 impl SshSession {
-    pub fn login(&mut self, ip: &IpAddr, username: &str, mean: &AuthMean) -> Result<(), String> {
+    /// Opens a TCP connection to the node and performs the SSH transport handshake
+    /// (protocol-version banner exchange and key exchange). This is the transport
+    /// layer, established before any authentication takes place. Failures here (e.g.
+    /// "Failed getting banner" when the node is briefly unresponsive right after a
+    /// restart) are transient and unrelated to whether a key grants access.
+    fn connect(&mut self, ip: &IpAddr) -> Result<(), String> {
         let ip_str = format!("[{ip}]:22");
         let tcp = TcpStream::connect(ip_str).map_err(|err| err.to_string())?;
         self.session.set_tcp_stream(tcp);
-        self.session.handshake().map_err(|err| err.to_string())?;
+        self.session.handshake().map_err(|err| err.to_string())
+    }
 
+    /// Attempts to authenticate as `username` using `mean` on an already-handshaken
+    /// session. The result reflects whether the key actually grants access.
+    fn authenticate(&self, username: &str, mean: &AuthMean) -> Result<(), String> {
         match mean {
             AuthMean::PrivateKey(pk) => self
                 .session
@@ -95,10 +104,35 @@ impl SshSession {
         }
         .map_err(|err| err.to_string())
     }
+
+    pub fn login(&mut self, ip: &IpAddr, username: &str, mean: &AuthMean) -> Result<(), String> {
+        self.connect(ip)?;
+        self.authenticate(username, mean)
+    }
 }
 
 pub fn assert_authentication_works(ip: &IpAddr, username: &str, mean: &AuthMean) {
-    SshSession::default().login(ip, username, mean).unwrap();
+    // The SSH transport handshake is retried for a bounded time because it can fail
+    // transiently (e.g. with "Failed getting banner") when the node is briefly
+    // unresponsive, for instance right after the replica/orchestrator is restarted.
+    // Such transport-level failures are unrelated to whether the key grants access.
+    // The authentication step itself is *not* retried, so an actual loss of access
+    // (e.g. a key being incorrectly removed) is still reported immediately.
+    let start = std::time::Instant::now();
+    let session = loop {
+        let mut session = SshSession::default();
+        match session.connect(ip) {
+            Ok(()) => break session,
+            Err(err) => {
+                assert!(
+                    start.elapsed() < SSH_ACCESS_TIMEOUT,
+                    "Failed to establish an SSH connection to {ip}: {err}"
+                );
+                std::thread::sleep(SSH_ACCESS_BACKOFF);
+            }
+        }
+    };
+    session.authenticate(username, mean).unwrap();
 }
 
 pub fn assert_authentication_fails(ip: &IpAddr, username: &str, mean: &AuthMean) {


### PR DESCRIPTION
## Summary

Deflakes `//rs/tests/consensus/orchestrator:ssh_access_to_nodes_test`, whose subtest `node_does_not_remove_keys_on_restart` was flaky.

## Root cause

All recent flaky runs failed identically: a panic at `rs/tests/consensus/utils/src/ssh_access.rs:101` (the `.unwrap()` in `assert_authentication_works`) with:

```
[Session(-43)] Failed getting banner
```

`Session(-43)` is `LIBSSH2_ERROR_SOCKET_RECV` and *"Failed getting banner"* means the SSH **transport** handshake (`session.handshake()`) failed **before any authentication took place**. This is a transient transport-level hiccup that occurs when the node is briefly unresponsive — in particular right after `sudo systemctl restart ic-replica`, which is exactly what this subtest does before repeatedly asserting (in two polling loops) that SSH access still works.

The SSH keys were present the entire time (that is precisely what the subtest verifies), so this was a **false failure**: a transport hiccup, not a missing key. Because `assert_authentication_works` did a single connect + handshake + auth with **no retry**, one transient transport failure was enough to panic the whole test.

This matches all 4 flaky runs observed in the last week, which always:
- failed in `node_does_not_remove_keys_on_restart`,
- panicked at `ssh_access.rs:101` with `Failed getting banner`,
- did so during the post-restart "still accept connections" polling loops.

## Fix

Split `SshSession::login` into two steps:
- `connect` — TCP connect + SSH transport handshake (the transport layer).
- `authenticate` — user authentication (reflects whether the key actually grants access).

`assert_authentication_works` now retries only the transport `connect` step for a bounded time (the existing `SSH_ACCESS_TIMEOUT` of 30s with `SSH_ACCESS_BACKOFF` of 5s), then authenticates **exactly once**. Transient transport failures are absorbed, while a genuine loss of access (e.g. a key being incorrectly removed) still fails immediately, because authentication is not retried. The public `login` signature is unchanged, so the other callers are unaffected.

## Verification

`bazel test --test_output=errors --runs_per_test=3 --jobs=3 --cache_test_results=no //rs/tests/consensus/orchestrator:ssh_access_to_nodes_test`

2 of 3 runs passed fully, including `node_does_not_remove_keys_on_restart`, and the `Failed getting banner` panic did not recur. The 1 remaining failure was an unrelated `Retried too many times: sending a request to Farm` infrastructure timeout during setup, which is explicitly ignored per the flaky-test guide.

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
