### PR TITLE
fix: persistent_next_idx in log memory store for zero log memory limit

### DIFF
--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -3060,23 +3060,21 @@ fn test_canister_log_with_zero_log_memory_limit() {
             .build(),
     );
 
-    // Produce a second log with no ring buffer. canister_log advances to
-    // next_idx == 2, but persistent_next_idx stays at 1.
+    // Produce a second log with no ring buffer. Both canister_log and
+    // persistent_next_idx advance to next_idx == 2.
     let _ = env.execute_ingress(
         canister_id,
         "update",
         wasm().debug_print(b"log").reply().build(),
     );
 
-    // canister_log.next_idx() == 2 and lms.next_idx() == 1 must hold before
-    // and after a checkpoint/reload cycle. Before the CanisterStateBits fix,
-    // the reload would wrongly restore lms.persistent_next_idx from
-    // next_canister_log_record_idx (== 2) instead of the (by now) stored 1.
+    // Both canister_log.next_idx() and lms.next_idx() must be 2 before
+    // and after a checkpoint/reload cycle.
     let check_next_idx = |env: &StateMachine| {
         let state = env.get_latest_state();
         let ss = &state.canister_state(&canister_id).unwrap().system_state;
         assert_eq!(ss.canister_log.next_idx(), 2);
-        assert_eq!(ss.log_memory_store.next_idx(), 1);
+        assert_eq!(ss.log_memory_store.next_idx(), 2);
     };
     check_next_idx(&env);
 

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
@@ -419,7 +419,10 @@ impl LogMemoryStore {
             return;
         }
         let Some(mut ring_buffer) = self.load_ring_buffer() else {
-            return; // No ring buffer exists.
+            // No ring buffer exists (e.g., log_memory_limit is zero), but still
+            // carry the monotone index forward so consumers can track progress.
+            self.persistent_next_idx = self.persistent_next_idx.max(delta_log.next_idx());
+            return;
         };
         // Append the delta records and persist the ring buffer.
         ring_buffer.append_log(delta_log.records_mut().drain(..));

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/canister_lifecycle.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/canister_lifecycle.rs
@@ -247,11 +247,13 @@ fn test_canister_uninstall_and_install_drops_logs_until_resized() {
     canister.uninstall_code();
     canister.install_code();
 
-    // Test that without settings update, log memory remains cleared and drops msg
+    // Test that without settings update, log memory remains cleared and drops msg.
+    // next_idx still advances (tracking the global monotone sequence) even though
+    // the record is dropped due to no allocated ring buffer.
     canister.log("Message 2 ignored");
     assert_eq!(canister.fetch_canister_logs().len(), 0);
     assert_eq!(canister.log_memory_usage().get(), 0);
-    assert_eq!(canister.next_idx(), 1);
+    assert_eq!(canister.next_idx(), 2);
 }
 
 #[test]

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
@@ -119,21 +119,20 @@ fn test_retention_across_lifecycle() {
 }
 
 #[test]
-fn test_appending_to_uninitialized_store_is_no_op() {
+fn test_appending_to_uninitialized_store_updates_next_idx() {
     let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
     let mut delta = CanisterLog::default_delta();
     delta.add_record(1, b"data".to_vec());
 
-    // Append without setting limit
+    // Append without setting limit: no data stored, but next_idx advances.
     s.append_delta_log(&mut delta);
 
-    // Should still be empty
     assert!(s.is_empty());
     assert_eq!(s.memory_usage(), 0);
     assert_eq!(s.byte_capacity(), 0);
     assert_eq!(s.bytes_used(), 0);
     assert_eq!(s.records(None).len(), 0);
-    assert_eq!(s.next_idx(), 0);
+    assert_eq!(s.next_idx(), 1);
 }
 
 #[test]

--- a/rs/state_manager/src/checkpoint.rs
+++ b/rs/state_manager/src/checkpoint.rs
@@ -870,6 +870,17 @@ pub fn load_canister_state(
         metrics,
     );
 
+    if system_state.log_memory_store.is_migrated() {
+        let lms_next_idx = system_state.log_memory_store.next_idx();
+        let log_next_idx = system_state.canister_log.next_idx();
+        if lms_next_idx != log_next_idx {
+            metrics.observe_broken_soft_invariant(format!(
+                "canister {canister_id}: log_memory_store.next_idx ({lms_next_idx}) \
+                 != canister_log.next_idx ({log_next_idx})",
+            ));
+        }
+    }
+
     let canister_state = CanisterState {
         system_state,
         execution_state,


### PR DESCRIPTION
This PR fixes the `persistent_next_idx` in the new log memory store in case the log memory store is deallocated (e.g., if the log memory limit is set to zero or the canister runs out of cycles): before this PR, `persistent_next_idx` was not advanced in this case if the canister produced logs which leaves such canister logs undetectable; now `persistent_next_idx` is advanced and thus as soon as the log memory store is allocated, subsequent canister logs will be indexed with that advanced `persistent_next_idx` and the gap in log indices reveals that some canister logs were not observed (because the log memory store was deallocated).

This PR is safe to roll out because the new log memory store is not migrated on any subnet by the time this PR is being rolled out.