### PR TITLE
fix: filter canister log records during migration to new log memory store

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1150,7 +1150,32 @@ impl Scheduler for SchedulerImpl {
                     );
                     let mut canister_log = system_state.canister_log.clone();
                     let next_idx = canister_log.next_idx();
+                    // Remove records with invalid indices (idx >= next_idx).
                     canister_log.records_mut().retain(|r| r.idx < next_idx);
+                    // Keep only the contiguous suffix ending at next_idx - 1,
+                    // discarding any earlier records that precede a gap.
+                    if next_idx > 0 {
+                        let records = canister_log.records_mut();
+                        if records.back().map(|r| r.idx) != Some(next_idx - 1) {
+                            // Gap at the tail: no record at next_idx - 1.
+                            records.clear();
+                        } else {
+                            let mut expected = next_idx - 1;
+                            let mut contiguous_start = records.len() - 1;
+                            for i in (0..records.len() - 1).rev() {
+                                if expected == 0 {
+                                    break;
+                                }
+                                if records[i].idx == expected - 1 {
+                                    expected -= 1;
+                                    contiguous_start = i;
+                                } else {
+                                    break;
+                                }
+                            }
+                            records.drain(..contiguous_start);
+                        }
+                    }
                     system_state
                         .log_memory_store
                         .append_delta_log(&mut canister_log);

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1139,7 +1139,7 @@ impl Scheduler for SchedulerImpl {
                 .round_log_memory_store_migration_duration
                 .start_timer();
             let log_memory_store_feature = self.log_memory_store_feature;
-            state.canisters_for_each_mut(|_id, canister| {
+            state.canisters_for_each_mut(|canister_id, canister| {
                 if log_memory_store_feature == FlagStatus::Enabled
                     && !canister.system_state.log_memory_store.is_migrated()
                 {
@@ -1151,6 +1151,18 @@ impl Scheduler for SchedulerImpl {
                     let mut canister_log = system_state.canister_log.clone();
                     let next_idx = canister_log.next_idx();
                     // Remove records with invalid indices (idx >= next_idx).
+                    for record in canister_log.records().iter().filter(|r| r.idx >= next_idx) {
+                        warn!(
+                            self.log,
+                            "Canister {}: dropping log record with idx {} (>= next_idx {}), \
+                             timestamp {}, content \"{}\"",
+                            canister_id,
+                            record.idx,
+                            next_idx,
+                            record.timestamp_nanos,
+                            String::from_utf8_lossy(&record.content),
+                        );
+                    }
                     canister_log.records_mut().retain(|r| r.idx < next_idx);
                     // Keep only the contiguous suffix ending at next_idx - 1,
                     // discarding any earlier records that precede a gap.
@@ -1158,6 +1170,18 @@ impl Scheduler for SchedulerImpl {
                         let records = canister_log.records_mut();
                         if records.back().map(|r| r.idx) != Some(next_idx - 1) {
                             // Gap at the tail: no record at next_idx - 1.
+                            for record in records.iter() {
+                                warn!(
+                                    self.log,
+                                    "Canister {}: dropping log record with idx {} \
+                                     (gap before next_idx {}), timestamp {}, content \"{}\"",
+                                    canister_id,
+                                    record.idx,
+                                    next_idx,
+                                    record.timestamp_nanos,
+                                    String::from_utf8_lossy(&record.content),
+                                );
+                            }
                             records.clear();
                         } else {
                             let mut expected = next_idx - 1;
@@ -1172,6 +1196,18 @@ impl Scheduler for SchedulerImpl {
                                 } else {
                                     break;
                                 }
+                            }
+                            for record in records.iter().take(contiguous_start) {
+                                warn!(
+                                    self.log,
+                                    "Canister {}: dropping log record with idx {} \
+                                     (gap before next_idx {}), timestamp {}, content \"{}\"",
+                                    canister_id,
+                                    record.idx,
+                                    next_idx,
+                                    record.timestamp_nanos,
+                                    String::from_utf8_lossy(&record.content),
+                                );
                             }
                             records.drain(..contiguous_start);
                         }

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -41,7 +41,7 @@ use ic_types::batch::ChainKeyData;
 use ic_types::ingress::{IngressState, IngressStatus};
 use ic_types::messages::{Ingress, MessageId, NO_DEADLINE, Response, SubnetMessage};
 use ic_types::{
-    CanisterId, ComputeAllocation, DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT, ExecutionRound,
+    CanisterId, CanisterLog, ComputeAllocation, DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT, ExecutionRound,
     MemoryAllocation, NumBytes, NumInstructions, NumMessages, NumSlices, Randomness,
     ReplicaVersion, Time,
 };
@@ -1148,7 +1148,7 @@ impl Scheduler for SchedulerImpl {
                         DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT,
                         Arc::clone(&self.fd_factory),
                     );
-                    let mut canister_log = system_state.canister_log.clone();
+                    let canister_log = &system_state.canister_log;
                     let next_idx = canister_log.next_idx();
                     // Remove records with invalid indices (idx >= next_idx).
                     for record in canister_log.records().iter().filter(|r| r.idx >= next_idx) {
@@ -1163,14 +1163,14 @@ impl Scheduler for SchedulerImpl {
                             String::from_utf8_lossy(&record.content),
                         );
                     }
-                    canister_log.records_mut().retain(|r| r.idx < next_idx);
+                    let mut records: Vec<_> = canister_log.records().iter().cloned().collect();
+                    records.retain(|r| r.idx < next_idx);
                     // Keep only the contiguous suffix ending at next_idx - 1,
                     // discarding any earlier records that precede a gap.
                     if next_idx > 0 {
-                        let records = canister_log.records_mut();
-                        if records.back().map(|r| r.idx) != Some(next_idx - 1) {
+                        if records.last().map(|r| r.idx) != Some(next_idx - 1) {
                             // Gap at the tail: no record at next_idx - 1.
-                            for record in records.iter() {
+                            for record in &records {
                                 warn!(
                                     self.log,
                                     "Canister {}: dropping log record with idx {} \
@@ -1212,9 +1212,10 @@ impl Scheduler for SchedulerImpl {
                             records.drain(..contiguous_start);
                         }
                     }
+                    let mut filtered_log = CanisterLog::new_aggregate(next_idx, records);
                     system_state
                         .log_memory_store
-                        .append_delta_log(&mut canister_log);
+                        .append_delta_log(&mut filtered_log);
                     system_state.log_memory_store.set_migrated();
                 } else if log_memory_store_feature == FlagStatus::Disabled
                     && canister.system_state.log_memory_store.is_migrated()

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -26,7 +26,9 @@ use ic_interfaces::execution_environment::{
     IngressHistoryWriter, Scheduler, SubnetAvailableMemory,
 };
 use ic_logger::{ReplicaLogger, debug, error, fatal, info, new_logger, warn};
-use ic_management_canister_types_private::{CanisterStatusType, Method as Ic00Method};
+use ic_management_canister_types_private::{
+    CanisterLogRecord, CanisterStatusType, Method as Ic00Method,
+};
 use ic_metrics::MetricsRegistry;
 use ic_registry_resource_limits::ResourceLimits;
 use ic_registry_subnet_type::SubnetType;
@@ -48,7 +50,7 @@ use ic_types::{
 use ic_types_cycles::{CanisterCyclesCostSchedule, Cycles};
 use more_asserts::{debug_assert_ge, debug_assert_le, debug_assert_lt};
 use std::cell::RefCell;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, VecDeque};
 use std::str::FromStr;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
@@ -1150,68 +1152,12 @@ impl Scheduler for SchedulerImpl {
                     );
                     let canister_log = &system_state.canister_log;
                     let next_idx = canister_log.next_idx();
-                    // Remove records with invalid indices (idx >= next_idx).
-                    for record in canister_log.records().iter().filter(|r| r.idx >= next_idx) {
-                        warn!(
-                            self.log,
-                            "Canister {}: dropping log record with idx {} (>= next_idx {}), \
-                             timestamp {}, content \"{}\"",
-                            canister_id,
-                            record.idx,
-                            next_idx,
-                            record.timestamp_nanos,
-                            String::from_utf8_lossy(&record.content),
-                        );
-                    }
-                    let mut records: Vec<_> = canister_log.records().iter().cloned().collect();
-                    records.retain(|r| r.idx < next_idx);
-                    // Keep only the contiguous suffix ending at next_idx - 1,
-                    // discarding any earlier records that precede a gap.
-                    if next_idx > 0 {
-                        if records.last().map(|r| r.idx) != Some(next_idx - 1) {
-                            // Gap at the tail: no record at next_idx - 1.
-                            for record in &records {
-                                warn!(
-                                    self.log,
-                                    "Canister {}: dropping log record with idx {} \
-                                     (gap before next_idx {}), timestamp {}, content \"{}\"",
-                                    canister_id,
-                                    record.idx,
-                                    next_idx,
-                                    record.timestamp_nanos,
-                                    String::from_utf8_lossy(&record.content),
-                                );
-                            }
-                            records.clear();
-                        } else {
-                            let mut expected = next_idx - 1;
-                            let mut contiguous_start = records.len() - 1;
-                            for i in (0..records.len() - 1).rev() {
-                                if expected == 0 {
-                                    break;
-                                }
-                                if records[i].idx == expected - 1 {
-                                    expected -= 1;
-                                    contiguous_start = i;
-                                } else {
-                                    break;
-                                }
-                            }
-                            for record in records.iter().take(contiguous_start) {
-                                warn!(
-                                    self.log,
-                                    "Canister {}: dropping log record with idx {} \
-                                     (gap before next_idx {}), timestamp {}, content \"{}\"",
-                                    canister_id,
-                                    record.idx,
-                                    next_idx,
-                                    record.timestamp_nanos,
-                                    String::from_utf8_lossy(&record.content),
-                                );
-                            }
-                            records.drain(..contiguous_start);
-                        }
-                    }
+                    let records = filter_canister_log_records(
+                        canister_log.records(),
+                        next_idx,
+                        *canister_id,
+                        &self.log,
+                    );
                     let mut filtered_log = CanisterLog::new_aggregate(next_idx, records);
                     system_state
                         .log_memory_store
@@ -2198,6 +2144,63 @@ fn subnet_heap_delta_capacity(
         .unwrap_or(config.subnet_heap_delta_capacity)
 }
 
+/// Filters `records` to the contiguous suffix ending at `next_idx - 1`,
+/// logging and discarding any records with invalid or gap-preceding indices.
+fn filter_canister_log_records(
+    records: &VecDeque<CanisterLogRecord>,
+    next_idx: u64,
+    canister_id: CanisterId,
+    log: &ReplicaLogger,
+) -> Vec<CanisterLogRecord> {
+    let warn_drop = |record: &CanisterLogRecord, reason: &str| {
+        warn!(
+            log,
+            "Canister {}: dropping log record with idx {} ({} next_idx {}), \
+             timestamp {}, content \"{}\"",
+            canister_id,
+            record.idx,
+            reason,
+            next_idx,
+            record.timestamp_nanos,
+            String::from_utf8_lossy(&record.content),
+        );
+    };
+    for record in records.iter().filter(|r| r.idx >= next_idx) {
+        warn_drop(record, ">=");
+    }
+    let mut filtered: Vec<_> = records.iter().cloned().collect();
+    filtered.retain(|r| r.idx < next_idx);
+    // Keep only the contiguous suffix ending at next_idx - 1,
+    // discarding any earlier records that precede a gap.
+    if next_idx > 0 {
+        if filtered.last().map(|r| r.idx) != Some(next_idx - 1) {
+            for record in &filtered {
+                warn_drop(record, "gap before");
+            }
+            filtered.clear();
+        } else {
+            let mut expected = next_idx - 1;
+            let mut contiguous_start = filtered.len() - 1;
+            for i in (0..filtered.len() - 1).rev() {
+                if expected == 0 {
+                    break;
+                }
+                if filtered[i].idx == expected - 1 {
+                    expected -= 1;
+                    contiguous_start = i;
+                } else {
+                    break;
+                }
+            }
+            for record in filtered.iter().take(contiguous_start) {
+                warn_drop(record, "gap before");
+            }
+            filtered.drain(..contiguous_start);
+        }
+    }
+    filtered
+}
+
 /// Aborts the paused execution, if any, of the given canister.
 ///
 /// If a paused execution was aborted, resets the canister's executed rounds to
@@ -2230,5 +2233,106 @@ pub fn abort_all_paused_executions(
     let (canister_states, subnet_schedule) = state.canisters_and_schedule_mut();
     for canister in canister_states.hot_values_mut() {
         abort_canister(canister, subnet_schedule, exec_env, cost_schedule, log);
+    }
+}
+
+#[cfg(test)]
+mod canister_log_filter_tests {
+    use super::filter_canister_log_records;
+    use ic_logger::no_op_logger;
+    use ic_management_canister_types_private::CanisterLogRecord;
+    use ic_types_test_utils::ids::canister_test_id;
+    use std::collections::VecDeque;
+
+    fn make_records(idxs: &[u64]) -> VecDeque<CanisterLogRecord> {
+        idxs.iter()
+            .map(|&idx| CanisterLogRecord {
+                idx,
+                timestamp_nanos: idx * 1_000,
+                content: format!("record {idx}").into_bytes(),
+            })
+            .collect()
+    }
+
+    fn filtered_idxs(records: &VecDeque<CanisterLogRecord>, next_idx: u64) -> Vec<u64> {
+        filter_canister_log_records(records, next_idx, canister_test_id(0), &no_op_logger())
+            .into_iter()
+            .map(|r| r.idx)
+            .collect()
+    }
+
+    #[test]
+    fn test_filter_single_record_from_zero() {
+        let records = make_records(&[0]);
+        assert_eq!(filtered_idxs(&records, 1), vec![0]);
+    }
+
+    #[test]
+    fn test_filter_single_record_nonzero() {
+        let records = make_records(&[42]);
+        assert_eq!(filtered_idxs(&records, 43), vec![42]);
+    }
+
+    #[test]
+    fn test_filter_duplicate_zero() {
+        // Two records at idx=0: walk breaks immediately (expected==0), first is dropped.
+        let records = make_records(&[0, 0]);
+        assert_eq!(filtered_idxs(&records, 1), vec![0]);
+    }
+
+    #[test]
+    fn test_filter_duplicate_nonzero() {
+        // Two records at idx=42: 42 != expected-1=41, breaks, first is dropped.
+        let records = make_records(&[42, 42]);
+        assert_eq!(filtered_idxs(&records, 43), vec![42]);
+    }
+
+    #[test]
+    fn test_filter_leading_duplicate_then_consecutive() {
+        // Walk reaches the second 0 (0==expected-1=0), then expected==0 breaks; first 0 dropped.
+        let records = make_records(&[0, 0, 1, 2]);
+        assert_eq!(filtered_idxs(&records, 3), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_filter_duplicate_in_middle() {
+        // Walk: 3←2←1 (second 1), then first 1 != expected-1=0; first two records dropped.
+        let records = make_records(&[0, 1, 1, 2, 3]);
+        assert_eq!(filtered_idxs(&records, 4), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_filter_consecutive_from_zero() {
+        let records = make_records(&[0, 1, 2]);
+        assert_eq!(filtered_idxs(&records, 3), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_filter_consecutive_nonzero() {
+        let records = make_records(&[10, 11, 12]);
+        assert_eq!(filtered_idxs(&records, 13), vec![10, 11, 12]);
+    }
+
+    #[test]
+    fn test_filter_leading_duplicates_before_gap() {
+        // Walk: 12←11←10, then idx=0 != expected-1=9; first two records dropped.
+        let records = make_records(&[0, 0, 10, 11, 12]);
+        assert_eq!(filtered_idxs(&records, 13), vec![10, 11, 12]);
+    }
+
+    #[test]
+    fn test_filter_gap_suffix() {
+        // records [10, 11, 20, 21, 22], next_idx=23
+        // → [10, 11] precede a gap at [12..19]; only contiguous suffix [20, 21, 22] survives
+        let records = make_records(&[10, 11, 20, 21, 22]);
+        assert_eq!(filtered_idxs(&records, 23), vec![20, 21, 22]);
+    }
+
+    #[test]
+    fn test_filter_gap_end() {
+        // records [10, 11, 20, 21, 22], next_idx=24
+        // → last record (idx=22) != next_idx-1 (23), so all records are discarded
+        let records = make_records(&[10, 11, 20, 21, 22]);
+        assert_eq!(filtered_idxs(&records, 24), Vec::<u64>::new());
     }
 }

--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -1148,9 +1148,12 @@ impl Scheduler for SchedulerImpl {
                         DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT,
                         Arc::clone(&self.fd_factory),
                     );
+                    let mut canister_log = system_state.canister_log.clone();
+                    let next_idx = canister_log.next_idx();
+                    canister_log.records_mut().retain(|r| r.idx < next_idx);
                     system_state
                         .log_memory_store
-                        .append_delta_log(&mut system_state.canister_log.clone());
+                        .append_delta_log(&mut canister_log);
                     system_state.log_memory_store.set_migrated();
                 } else if log_memory_store_feature == FlagStatus::Disabled
                     && canister.system_state.log_memory_store.is_migrated()

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -6,6 +6,7 @@ use ic_config::execution_environment::{
 use ic_config::flag_status::FlagStatus;
 use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
 use ic_execution_environment::units::{KIB, MIB};
+use ic_interfaces_state_manager::{CertificationScope, StateManager};
 use ic_management_canister_types_private::{
     self as ic00, BoundedAllowedViewers, CanisterIdRecord, CanisterInstallMode, CanisterLogRecord,
     CanisterSettingsArgs, CanisterSettingsArgsBuilder, DataSize, EmptyBlob,
@@ -22,7 +23,7 @@ use ic_test_utilities_execution_environment::{
     ExecutionTestBuilder, get_reject, get_reply, wat_canister, wat_fn,
 };
 use ic_test_utilities_metrics::{fetch_histogram_stats, fetch_histogram_vec_stats, labels};
-use ic_types::{CanisterId, NumInstructions, ingress::WasmResult};
+use ic_types::{CanisterId, CanisterLog, NumInstructions, ingress::WasmResult};
 use ic_types_cycles::Cycles;
 use more_asserts::{assert_gt, assert_le, assert_lt};
 use proptest::{prelude::ProptestConfig, prop_assume};
@@ -3151,4 +3152,90 @@ fn test_log_memory_store_deallocated_when_canister_out_of_cycles() {
             .log_memory_store
             .is_allocated()
     );
+}
+
+#[test]
+fn test_log_memory_store_migration_filters_records_with_invalid_idx() {
+    // Regression test: canister_log may contain records whose idx >= next_idx
+    // (a corrupted state that can arise from old checkpoints). The migration must
+    // filter these out rather than blindly copying them into log_memory_store.
+    let controller = PrincipalId::new_anonymous();
+    let subnet_type = SubnetType::Application;
+
+    // Step 1: Create env with log_memory_store disabled and checkpoints enabled.
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            SubnetConfig::new(subnet_type, SubnetSecurity::None),
+            ExecutionConfig {
+                log_memory_store_feature: FlagStatus::Disabled,
+                ..Default::default()
+            },
+        )))
+        .with_subnet_type(subnet_type)
+        .with_checkpoints_enabled(true)
+        .build();
+
+    let canister_id = create_and_install_canister(
+        &env,
+        CanisterSettingsArgsBuilder::new()
+            .with_log_visibility(LogVisibilityV2::Public)
+            .with_controllers(vec![controller])
+            .build(),
+        UNIVERSAL_CANISTER_WASM.to_vec(),
+    );
+
+    // Step 2: Inject a corrupted canister_log: 3 records all with idx=0 but next_idx=0.
+    // This is invalid because valid records must have idx < next_idx.
+    {
+        let corrupted_record = CanisterLogRecord {
+            idx: 0,
+            timestamp_nanos: 1_000,
+            content: b"corrupted".to_vec(),
+        };
+        let (_height, mut state) = env.state_manager.take_tip();
+        let arc_canister = state.take_canister_state(&canister_id).unwrap();
+        let mut canister = (*arc_canister).clone();
+        canister.system_state.canister_log = CanisterLog::new_aggregate(
+            0,
+            vec![
+                corrupted_record.clone(),
+                corrupted_record.clone(),
+                corrupted_record,
+            ],
+        );
+        state.put_canister_state(canister);
+        env.state_manager
+            .commit_and_certify(state, CertificationScope::Full, None);
+    }
+
+    // Step 3: Restart with log_memory_store enabled. `logs_migrated` is transient
+    // and always resets to false on load, so migration runs on the first tick.
+    let env = env.restart_node_with_config(StateMachineConfig::new(
+        SubnetConfig::new(subnet_type, SubnetSecurity::None),
+        ExecutionConfig {
+            log_memory_store_feature: FlagStatus::Enabled,
+            ..Default::default()
+        },
+    ));
+
+    // Verify the corrupted state survived the checkpoint round-trip.
+    {
+        let state = env.get_latest_state();
+        let ss = &state.canister_state(&canister_id).unwrap().system_state;
+        assert_eq!(ss.canister_log.next_idx(), 0);
+        assert_eq!(ss.canister_log.records().len(), 3);
+        assert!(!ss.log_memory_store.is_migrated());
+    }
+
+    // Step 4: First tick triggers migration.
+    env.tick();
+
+    // Step 5: Migration must filter out all records whose idx >= next_idx (0 >= 0),
+    // so log_memory_store is migrated and allocated but empty with next_idx=0.
+    let state = env.get_latest_state();
+    let ss = &state.canister_state(&canister_id).unwrap().system_state;
+    assert!(ss.log_memory_store.is_migrated());
+    assert!(ss.log_memory_store.is_allocated());
+    assert!(ss.log_memory_store.is_empty());
+    assert_eq!(ss.log_memory_store.next_idx(), 0);
 }

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -3239,3 +3239,145 @@ fn test_log_memory_store_migration_filters_records_with_invalid_idx() {
     assert!(ss.log_memory_store.is_empty());
     assert_eq!(ss.log_memory_store.next_idx(), 0);
 }
+
+#[test]
+fn test_log_memory_store_migration_filters_gap_records() {
+    // Regression test: canister_log records may have gaps in their idx sequence,
+    // or contain duplicate/invalid idx values. Only the contiguous suffix ending
+    // at next_idx - 1 must be migrated.
+    //
+    // Each canister's log starts with two records both having idx=0 (invalid), then
+    // records [10, 11, 20, 21, 22] with a gap at [12..19].
+    //
+    // Two sub-cases:
+    //  - gap_suffix: next_idx=23 → only [20, 21, 22] survive (contiguous suffix ending at 22)
+    //  - gap_end:    next_idx=24 → no records survive (last record is 22, not next_idx-1=23)
+    let controller = PrincipalId::new_anonymous();
+    let subnet_type = SubnetType::Application;
+
+    let env = StateMachineBuilder::new()
+        .with_config(Some(StateMachineConfig::new(
+            SubnetConfig::new(subnet_type, SubnetSecurity::None),
+            ExecutionConfig {
+                log_memory_store_feature: FlagStatus::Disabled,
+                ..Default::default()
+            },
+        )))
+        .with_subnet_type(subnet_type)
+        .with_checkpoints_enabled(true)
+        .build();
+
+    let settings = || {
+        CanisterSettingsArgsBuilder::new()
+            .with_log_visibility(LogVisibilityV2::Public)
+            .with_controllers(vec![controller])
+            .build()
+    };
+
+    let canister_gap_suffix =
+        create_and_install_canister(&env, settings(), UNIVERSAL_CANISTER_WASM.to_vec());
+    let canister_gap_end =
+        create_and_install_canister(&env, settings(), UNIVERSAL_CANISTER_WASM.to_vec());
+
+    // Inject a canister_log combining invalid idx (two records with idx=0) and a gap:
+    // records idx [0, 0, 10, 11, 20, 21, 22].
+    let gap_records = || {
+        vec![
+            CanisterLogRecord {
+                idx: 0,
+                timestamp_nanos: 0,
+                content: b"corrupted_0a".to_vec(),
+            },
+            CanisterLogRecord {
+                idx: 0,
+                timestamp_nanos: 0,
+                content: b"corrupted_0b".to_vec(),
+            },
+            CanisterLogRecord {
+                idx: 10,
+                timestamp_nanos: 1_000,
+                content: b"a".to_vec(),
+            },
+            CanisterLogRecord {
+                idx: 11,
+                timestamp_nanos: 1_001,
+                content: b"b".to_vec(),
+            },
+            CanisterLogRecord {
+                idx: 20,
+                timestamp_nanos: 2_000,
+                content: b"c".to_vec(),
+            },
+            CanisterLogRecord {
+                idx: 21,
+                timestamp_nanos: 2_001,
+                content: b"d".to_vec(),
+            },
+            CanisterLogRecord {
+                idx: 22,
+                timestamp_nanos: 2_002,
+                content: b"e".to_vec(),
+            },
+        ]
+    };
+
+    {
+        let (_height, mut state) = env.state_manager.take_tip();
+
+        let arc = state.take_canister_state(&canister_gap_suffix).unwrap();
+        let mut c = (*arc).clone();
+        // next_idx=23: last record (idx=22) == next_idx-1, contiguous suffix [20,21,22]
+        c.system_state.canister_log = CanisterLog::new_aggregate(23, gap_records());
+        state.put_canister_state(c);
+
+        let arc = state.take_canister_state(&canister_gap_end).unwrap();
+        let mut c = (*arc).clone();
+        // next_idx=24: last record (idx=22) != next_idx-1=23, so all records are discarded
+        c.system_state.canister_log = CanisterLog::new_aggregate(24, gap_records());
+        state.put_canister_state(c);
+
+        env.state_manager
+            .commit_and_certify(state, CertificationScope::Full, None);
+    }
+
+    let env = env.restart_node_with_config(StateMachineConfig::new(
+        SubnetConfig::new(subnet_type, SubnetSecurity::None),
+        ExecutionConfig {
+            log_memory_store_feature: FlagStatus::Enabled,
+            ..Default::default()
+        },
+    ));
+
+    env.tick();
+
+    // canister_gap_suffix: only the contiguous suffix [20, 21, 22] migrated.
+    {
+        let state = env.get_latest_state();
+        let ss = &state
+            .canister_state(&canister_gap_suffix)
+            .unwrap()
+            .system_state;
+        assert!(ss.log_memory_store.is_migrated());
+        assert!(ss.log_memory_store.is_allocated());
+        assert!(!ss.log_memory_store.is_empty());
+        assert_eq!(ss.log_memory_store.next_idx(), 23);
+        let records = ss.log_memory_store.records(None);
+        assert_eq!(
+            records.iter().map(|r| r.idx).collect::<Vec<_>>(),
+            vec![20, 21, 22]
+        );
+    }
+
+    // canister_gap_end: last record (22) doesn't reach next_idx-1 (23), so all discarded.
+    {
+        let state = env.get_latest_state();
+        let ss = &state
+            .canister_state(&canister_gap_end)
+            .unwrap()
+            .system_state;
+        assert!(ss.log_memory_store.is_migrated());
+        assert!(ss.log_memory_store.is_allocated());
+        assert!(ss.log_memory_store.is_empty());
+        assert_eq!(ss.log_memory_store.next_idx(), 24);
+    }
+}

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -3155,14 +3155,15 @@ fn test_log_memory_store_deallocated_when_canister_out_of_cycles() {
 }
 
 #[test]
-fn test_log_memory_store_migration_filters_records_with_invalid_idx() {
-    // Regression test: canister_log may contain records whose idx >= next_idx
-    // (a corrupted state that can arise from old checkpoints). The migration must
-    // filter these out rather than blindly copying them into log_memory_store.
+fn test_log_memory_store_migration_filters_gap_records() {
+    // Regression test: canister_log records may have gaps in their idx sequence.
+    // Only the contiguous suffix ending at next_idx - 1 must be migrated.
+    //
+    // Records [10, 11, 20, 21, 22] have a gap at [12..19]; with next_idx=23
+    // only the contiguous suffix [20, 21, 22] survives.
     let controller = PrincipalId::new_anonymous();
     let subnet_type = SubnetType::Application;
 
-    // Step 1: Create env with log_memory_store disabled and checkpoints enabled.
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
             SubnetConfig::new(subnet_type, SubnetSecurity::None),
@@ -3184,40 +3185,47 @@ fn test_log_memory_store_migration_filters_records_with_invalid_idx() {
         UNIVERSAL_CANISTER_WASM.to_vec(),
     );
 
-    // Step 2: Inject a corrupted canister_log with next_idx=0 and three records:
-    // two with idx=0 (idx == next_idx) and one with idx=1 (idx > next_idx).
-    // All are invalid because valid records must have idx < next_idx.
     {
         let (_height, mut state) = env.state_manager.take_tip();
-        let arc_canister = state.take_canister_state(&canister_id).unwrap();
-        let mut canister = (*arc_canister).clone();
-        canister.system_state.canister_log = CanisterLog::new_aggregate(
-            0,
+        let arc = state.take_canister_state(&canister_id).unwrap();
+        let mut c = (*arc).clone();
+        // next_idx=23: last record (idx=22) == next_idx-1; gap at [12..19] causes
+        // [10, 11] to be dropped, leaving contiguous suffix [20, 21, 22].
+        c.system_state.canister_log = CanisterLog::new_aggregate(
+            23,
             vec![
                 CanisterLogRecord {
-                    idx: 0,
+                    idx: 10,
                     timestamp_nanos: 1_000,
-                    content: b"corrupted_eq_0".to_vec(),
+                    content: b"a".to_vec(),
                 },
                 CanisterLogRecord {
-                    idx: 0,
+                    idx: 11,
                     timestamp_nanos: 1_001,
-                    content: b"corrupted_eq_1".to_vec(),
+                    content: b"b".to_vec(),
                 },
                 CanisterLogRecord {
-                    idx: 1,
-                    timestamp_nanos: 1_002,
-                    content: b"corrupted_gt".to_vec(),
+                    idx: 20,
+                    timestamp_nanos: 2_000,
+                    content: b"c".to_vec(),
+                },
+                CanisterLogRecord {
+                    idx: 21,
+                    timestamp_nanos: 2_001,
+                    content: b"d".to_vec(),
+                },
+                CanisterLogRecord {
+                    idx: 22,
+                    timestamp_nanos: 2_002,
+                    content: b"e".to_vec(),
                 },
             ],
         );
-        state.put_canister_state(canister);
+        state.put_canister_state(c);
         env.state_manager
             .commit_and_certify(state, CertificationScope::Full, None);
     }
 
-    // Step 3: Restart with log_memory_store enabled. `logs_migrated` is transient
-    // and always resets to false on load, so migration runs on the first tick.
     let env = env.restart_node_with_config(StateMachineConfig::new(
         SubnetConfig::new(subnet_type, SubnetSecurity::None),
         ExecutionConfig {
@@ -3226,166 +3234,17 @@ fn test_log_memory_store_migration_filters_records_with_invalid_idx() {
         },
     ));
 
-    // Verify the corrupted state survived the checkpoint round-trip.
-    {
-        let state = env.get_latest_state();
-        let ss = &state.canister_state(&canister_id).unwrap().system_state;
-        assert_eq!(ss.canister_log.next_idx(), 0);
-        assert_eq!(ss.canister_log.records().len(), 3);
-        assert!(!ss.log_memory_store.is_migrated());
-    }
-
-    // Step 4: First tick triggers migration.
     env.tick();
 
-    // Step 5: Migration must filter out all records whose idx >= next_idx (0 >= 0),
-    // so log_memory_store is migrated and allocated but empty with next_idx=0.
     let state = env.get_latest_state();
     let ss = &state.canister_state(&canister_id).unwrap().system_state;
     assert!(ss.log_memory_store.is_migrated());
     assert!(ss.log_memory_store.is_allocated());
-    assert!(ss.log_memory_store.is_empty());
-    assert_eq!(ss.log_memory_store.next_idx(), 0);
-}
-
-#[test]
-fn test_log_memory_store_migration_filters_gap_records() {
-    // Regression test: canister_log records may have gaps in their idx sequence,
-    // or contain duplicate/invalid idx values. Only the contiguous suffix ending
-    // at next_idx - 1 must be migrated.
-    //
-    // Each canister's log starts with two records both having idx=0 (invalid), then
-    // records [10, 11, 20, 21, 22] with a gap at [12..19].
-    //
-    // Two sub-cases:
-    //  - gap_suffix: next_idx=23 → only [20, 21, 22] survive (contiguous suffix ending at 22)
-    //  - gap_end:    next_idx=24 → no records survive (last record is 22, not next_idx-1=23)
-    let controller = PrincipalId::new_anonymous();
-    let subnet_type = SubnetType::Application;
-
-    let env = StateMachineBuilder::new()
-        .with_config(Some(StateMachineConfig::new(
-            SubnetConfig::new(subnet_type, SubnetSecurity::None),
-            ExecutionConfig {
-                log_memory_store_feature: FlagStatus::Disabled,
-                ..Default::default()
-            },
-        )))
-        .with_subnet_type(subnet_type)
-        .with_checkpoints_enabled(true)
-        .build();
-
-    let settings = || {
-        CanisterSettingsArgsBuilder::new()
-            .with_log_visibility(LogVisibilityV2::Public)
-            .with_controllers(vec![controller])
-            .build()
-    };
-
-    let canister_gap_suffix =
-        create_and_install_canister(&env, settings(), UNIVERSAL_CANISTER_WASM.to_vec());
-    let canister_gap_end =
-        create_and_install_canister(&env, settings(), UNIVERSAL_CANISTER_WASM.to_vec());
-
-    // Inject a canister_log combining invalid idx (two records with idx=0) and a gap:
-    // records idx [0, 0, 10, 11, 20, 21, 22].
-    let gap_records = || {
-        vec![
-            CanisterLogRecord {
-                idx: 0,
-                timestamp_nanos: 0,
-                content: b"corrupted_0a".to_vec(),
-            },
-            CanisterLogRecord {
-                idx: 0,
-                timestamp_nanos: 0,
-                content: b"corrupted_0b".to_vec(),
-            },
-            CanisterLogRecord {
-                idx: 10,
-                timestamp_nanos: 1_000,
-                content: b"a".to_vec(),
-            },
-            CanisterLogRecord {
-                idx: 11,
-                timestamp_nanos: 1_001,
-                content: b"b".to_vec(),
-            },
-            CanisterLogRecord {
-                idx: 20,
-                timestamp_nanos: 2_000,
-                content: b"c".to_vec(),
-            },
-            CanisterLogRecord {
-                idx: 21,
-                timestamp_nanos: 2_001,
-                content: b"d".to_vec(),
-            },
-            CanisterLogRecord {
-                idx: 22,
-                timestamp_nanos: 2_002,
-                content: b"e".to_vec(),
-            },
-        ]
-    };
-
-    {
-        let (_height, mut state) = env.state_manager.take_tip();
-
-        let arc = state.take_canister_state(&canister_gap_suffix).unwrap();
-        let mut c = (*arc).clone();
-        // next_idx=23: last record (idx=22) == next_idx-1, contiguous suffix [20,21,22]
-        c.system_state.canister_log = CanisterLog::new_aggregate(23, gap_records());
-        state.put_canister_state(c);
-
-        let arc = state.take_canister_state(&canister_gap_end).unwrap();
-        let mut c = (*arc).clone();
-        // next_idx=24: last record (idx=22) != next_idx-1=23, so all records are discarded
-        c.system_state.canister_log = CanisterLog::new_aggregate(24, gap_records());
-        state.put_canister_state(c);
-
-        env.state_manager
-            .commit_and_certify(state, CertificationScope::Full, None);
-    }
-
-    let env = env.restart_node_with_config(StateMachineConfig::new(
-        SubnetConfig::new(subnet_type, SubnetSecurity::None),
-        ExecutionConfig {
-            log_memory_store_feature: FlagStatus::Enabled,
-            ..Default::default()
-        },
-    ));
-
-    env.tick();
-
-    // canister_gap_suffix: only the contiguous suffix [20, 21, 22] migrated.
-    {
-        let state = env.get_latest_state();
-        let ss = &state
-            .canister_state(&canister_gap_suffix)
-            .unwrap()
-            .system_state;
-        assert!(ss.log_memory_store.is_migrated());
-        assert!(ss.log_memory_store.is_allocated());
-        assert!(!ss.log_memory_store.is_empty());
-        assert_eq!(ss.log_memory_store.next_idx(), 23);
-        let records = ss.log_memory_store.records(None);
-        assert_eq!(
-            records.iter().map(|r| r.idx).collect::<Vec<_>>(),
-            vec![20, 21, 22]
-        );
-    }
-
-    // canister_gap_end: last record (22) doesn't reach next_idx-1 (23), so all discarded.
-    {
-        let state = env.get_latest_state();
-        let ss = &state
-            .canister_state(&canister_gap_end)
-            .unwrap()
-            .system_state;
-        assert!(ss.log_memory_store.is_migrated());
-        assert!(ss.log_memory_store.is_allocated());
-        assert!(ss.log_memory_store.is_empty());
-        assert_eq!(ss.log_memory_store.next_idx(), 24);
-    }
+    assert!(!ss.log_memory_store.is_empty());
+    assert_eq!(ss.log_memory_store.next_idx(), 23);
+    let records = ss.log_memory_store.records(None);
+    assert_eq!(
+        records.iter().map(|r| r.idx).collect::<Vec<_>>(),
+        vec![20, 21, 22]
+    );
 }

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -3184,23 +3184,31 @@ fn test_log_memory_store_migration_filters_records_with_invalid_idx() {
         UNIVERSAL_CANISTER_WASM.to_vec(),
     );
 
-    // Step 2: Inject a corrupted canister_log: 3 records all with idx=0 but next_idx=0.
-    // This is invalid because valid records must have idx < next_idx.
+    // Step 2: Inject a corrupted canister_log with next_idx=0 and three records:
+    // two with idx=0 (idx == next_idx) and one with idx=1 (idx > next_idx).
+    // All are invalid because valid records must have idx < next_idx.
     {
-        let corrupted_record = CanisterLogRecord {
-            idx: 0,
-            timestamp_nanos: 1_000,
-            content: b"corrupted".to_vec(),
-        };
         let (_height, mut state) = env.state_manager.take_tip();
         let arc_canister = state.take_canister_state(&canister_id).unwrap();
         let mut canister = (*arc_canister).clone();
         canister.system_state.canister_log = CanisterLog::new_aggregate(
             0,
             vec![
-                corrupted_record.clone(),
-                corrupted_record.clone(),
-                corrupted_record,
+                CanisterLogRecord {
+                    idx: 0,
+                    timestamp_nanos: 1_000,
+                    content: b"corrupted_eq_0".to_vec(),
+                },
+                CanisterLogRecord {
+                    idx: 0,
+                    timestamp_nanos: 1_001,
+                    content: b"corrupted_eq_1".to_vec(),
+                },
+                CanisterLogRecord {
+                    idx: 1,
+                    timestamp_nanos: 1_002,
+                    content: b"corrupted_gt".to_vec(),
+                },
             ],
         );
         state.put_canister_state(canister);

--- a/rs/types/types/src/canister_log.rs
+++ b/rs/types/types/src/canister_log.rs
@@ -182,9 +182,7 @@ impl CanisterLog {
         self.records.get()
     }
 
-    // TODO(DSM-11): remove allow(dead_code) when log memory store is used in production.
     /// Returns mutable reference to the canister log records.
-    #[allow(dead_code)]
     pub fn records_mut(&mut self) -> &mut VecDeque<CanisterLogRecord> {
         self.records.get_mut()
     }

--- a/rs/types/types/src/canister_log.rs
+++ b/rs/types/types/src/canister_log.rs
@@ -182,7 +182,9 @@ impl CanisterLog {
         self.records.get()
     }
 
+    // TODO(DSM-11): remove allow(dead_code) when log memory store is used in production.
     /// Returns mutable reference to the canister log records.
+    #[allow(dead_code)]
     pub fn records_mut(&mut self) -> &mut VecDeque<CanisterLogRecord> {
         self.records.get_mut()
     }


### PR DESCRIPTION
This PR filters canister log records during their migration to the new log memory store to ensure that the indices of the migrated logs are consecutive integers ending at `next_idx - 1`.