### PR TITLE
fix: gaps in canister logs

### DIFF
--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -1012,6 +1012,56 @@ fn test_canister_log_in_state_stays_within_limit() {
 }
 
 #[test]
+fn test_canister_log_overflow_evicts_oldest_records() {
+    // First update: 2 debug prints of 8 bytes (indices 0, 1).
+    // Second update: 16 debug prints of 256 bytes (indices 2..17).
+    //
+    // With DEFAULT_AGGREGATE_LOG_MEMORY_LIMIT = 4096 bytes:
+    //   data_size(8)   = 40 + 8   = 48 bytes
+    //   data_size(256) = 40 + 256 = 296 bytes
+    //
+    // The delta for the second update has capacity 4096 bytes and holds
+    // floor(4096 / 296) = 13 records (indices 5..17, bytes_used = 3848).
+    //
+    // Appending the delta to the aggregate (96 bytes for records 0 and 1):
+    //   delta.first.idx (5) > aggregate.next_idx (2) => gap detected => aggregate cleared.
+    //
+    // Result: records 5..17 (256-byte content) = 13 records.
+    let user_controller = PrincipalId::new_user_test_id(42);
+    let (env, canister_id) = setup_with_controller(
+        user_controller,
+        wat_canister()
+            .update(
+                "update1",
+                wat_fn().debug_print(&[1u8; 8]).debug_print(&[1u8; 8]),
+            )
+            .update(
+                "update2",
+                wat_fn().repeat(16, wat_fn().debug_print(&[2u8; 256])),
+            )
+            .build_wasm(),
+    );
+
+    env.advance_time(Duration::from_secs(1));
+    let _ = env.execute_ingress(canister_id, "update1", vec![]);
+    env.advance_time(Duration::from_secs(1));
+    let _ = env.execute_ingress(canister_id, "update2", vec![]);
+
+    let records = fetch_log_records(&env, user_controller, canister_id);
+    // The delta evicted records idx 2, 3, 4 (16 prints > floor(4096/296)=13 capacity),
+    // so the delta starts at idx 5 > aggregate next_idx 2. Both first-update records
+    // are dropped to maintain index continuity. Result: 13 records with 256-byte content.
+    assert_eq!(records.len(), 13);
+    for record in &records {
+        assert_eq!(record.content, vec![2u8; 256]);
+    }
+    // First record has idx 5 = 2 + (16 - 13) (second update starts at idx 2).
+    assert_eq!(records[0].idx, 5);
+    // Last record has idx 17 = 2 + 16 - 1.
+    assert_eq!(records.last().unwrap().idx, 17);
+}
+
+#[test]
 fn test_logging_trap_in_heartbeat() {
     let user_controller = PrincipalId::new_user_test_id(42);
     let (env, canister_id) = setup_with_controller(

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -1033,11 +1033,11 @@ fn test_canister_log_overflow_evicts_oldest_records() {
         wat_canister()
             .update(
                 "update1",
-                wat_fn().debug_print(&[1u8; 8]).debug_print(&[1u8; 8]),
+                wat_fn().debug_print(&[1_u8; 8]).debug_print(&[1_u8; 8]),
             )
             .update(
                 "update2",
-                wat_fn().repeat(16, wat_fn().debug_print(&[2u8; 256])),
+                wat_fn().repeat(16, wat_fn().debug_print(&[2_u8; 256])),
             )
             .build_wasm(),
     );
@@ -1053,7 +1053,7 @@ fn test_canister_log_overflow_evicts_oldest_records() {
     // are dropped to maintain index continuity. Result: 13 records with 256-byte content.
     assert_eq!(records.len(), 13);
     for record in &records {
-        assert_eq!(record.content, vec![2u8; 256]);
+        assert_eq!(record.content, vec![2_u8; 256]);
     }
     // First record has idx 5 = 2 + (16 - 13) (second update starts at idx 2).
     assert_eq!(records[0].idx, 5);

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/mod.rs
@@ -421,6 +421,14 @@ impl LogMemoryStore {
         let Some(mut ring_buffer) = self.load_ring_buffer() else {
             return; // No ring buffer exists.
         };
+        // If the delta overflowed and evicted records, there is a gap between the
+        // aggregate's next expected index and the delta's first record. Clear the
+        // ring buffer to maintain index continuity.
+        if let Some(first) = delta_log.records().front()
+            && first.idx > self.next_idx()
+        {
+            ring_buffer.clear();
+        }
         // Append the delta records and persist the ring buffer.
         ring_buffer.append_log(delta_log.records_mut().drain(..));
         self.save_ring_buffer(ring_buffer);

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
@@ -847,3 +847,35 @@ fn memory_usage_for_limit_at_minimum() {
 fn memory_usage_for_limit_above_minimum() {
     assert_memory_usage_for_limit(TEST_LOG_MEMORY_STORE_FEATURE, TEST_LOG_MEMORY_LIMIT);
 }
+
+#[test]
+fn test_gap_in_delta_clears_store() {
+    // Simulate a delta that overflowed its capacity and evicted older records,
+    // creating a gap between the store's next_idx and the delta's first record.
+    //
+    // Setup: store has records idx 0 and 1 (next_idx == 2).
+    // Delta: starts at idx 5 (gap: 2, 3, 4 were evicted from the delta).
+    // Expected: store is cleared before appending, so only idx 5 remains.
+    let mut s = LogMemoryStore::new(TEST_LOG_MEMORY_STORE_FEATURE);
+    s.resize_for_testing(TEST_LOG_MEMORY_LIMIT);
+
+    // Populate the store with records 0 and 1.
+    let mut initial = CanisterLog::new_delta_with_next_index(0, TEST_LOG_MEMORY_LIMIT);
+    initial.add_record(100, b"store #0".to_vec());
+    initial.add_record(101, b"store #1".to_vec());
+    s.append_delta_log(&mut initial);
+    assert_eq!(s.next_idx(), 2);
+    assert_eq!(s.records(None).len(), 2);
+
+    // Build a delta that starts at idx 5 (gap: 2, 3, 4 evicted).
+    let mut delta =
+        ic_types::CanisterLog::new_aggregate(5, vec![make_canister_record(5, 202, "delta #2")]);
+    s.append_delta_log(&mut delta);
+
+    // The gap (5 > 2) triggers a clear; only the delta record survives.
+    let records = s.records(None);
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].idx, 5);
+    assert_eq!(records[0].content, b"delta #2");
+    assert_eq!(s.next_idx(), 6);
+}

--- a/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
+++ b/rs/replicated_state/src/canister_state/system_state/log_memory_store/tests/log_memory_store.rs
@@ -868,8 +868,8 @@ fn test_gap_in_delta_clears_store() {
     assert_eq!(s.records(None).len(), 2);
 
     // Build a delta that starts at idx 5 (gap: 2, 3, 4 evicted).
-    let mut delta =
-        ic_types::CanisterLog::new_aggregate(5, vec![make_canister_record(5, 202, "delta #2")]);
+    let mut delta = CanisterLog::new_delta_with_next_index(5, TEST_LOG_MEMORY_LIMIT);
+    delta.add_record(202, b"delta #2".to_vec());
     s.append_delta_log(&mut delta);
 
     // The gap (5 > 2) triggers a clear; only the delta record survives.

--- a/rs/types/types/src/canister_log.rs
+++ b/rs/types/types/src/canister_log.rs
@@ -245,7 +245,16 @@ impl CanisterLog {
             return; // Don't append if delta is empty.
         }
 
-        // Assume records sorted cronologically (with increasing idx) and
+        // If the delta overflowed and evicted records, there is a gap between the
+        // aggregate's next expected index and the delta's first record. Drop all
+        // aggregate records to maintain index continuity.
+        if let Some(first) = delta_log.records.get().front()
+            && first.idx > self.next_idx
+        {
+            self.records.clear();
+        }
+
+        // Assume records sorted chronologically (with increasing idx) and
         // update the system state's next index with the last record's index.
         if let Some(last) = delta_log.records.get().back() {
             self.next_idx = last.idx + 1;
@@ -417,16 +426,11 @@ mod tests {
         // Act.
         main.append_delta_log(&mut delta);
 
-        // Assert main log had data loss.
+        // Assert main log was cleared due to the gap (delta evicted records 3 and 4,
+        // so delta starts at idx 5 > next_idx 3; aggregate records are dropped).
         assert_eq!(
             main.records(),
-            &VecDeque::from(canister_log_records(&[
-                (0, 100, b"main #0"),
-                (1, 101, b"main #1"),
-                (2, 102, b"main #2"),
-                // Expected data loss.
-                (5, 202, b"delta #2"),
-            ]))
+            &VecDeque::from(canister_log_records(&[(5, 202, b"delta #2"),]))
         );
     }
 


### PR DESCRIPTION
This PR makes sure that canister logs reported via `fetch_canister_logs` do not contain gaps in terms of log record indices. This is achieved by clearing the aggregate log if the delta log (produced by the latest message) starts with a gap.

The gaps currently arise from the fact that the delta log is collected and wrapped around in the canister sandbox separately from the aggregate log, but this is an implementation detail. If the canister sandbox appended logs directly to the delta log and wrapped it around, no gaps would arise. This PR achieves that without appending logs in the canister sandbox directly to the delta log by observing that if the delta log wraps around, then the aggregated log would have wrapped around exactly like that.