### PR TITLE
chore: log `networkctl status enp2s0` when timing out on acquiring IPv4 for UVMs

### DIFF
--- a/rs/tests/driver/src/driver/universal_vm.rs
+++ b/rs/tests/driver/src/driver/universal_vm.rs
@@ -351,6 +351,8 @@ until ipv4=$(ip -j address show dev enp2s0 \
 do
   if [ "$count" -ge 300 ]; then
     echo "Timed out waiting for IPv4 address!" >&2
+    echo "networkctl status enp2s0:" >&2
+    networkctl status enp2s0 >&2
     exit 1
   fi
   sleep 1


### PR DESCRIPTION
All `//rs/tests/networking:canister_http...` tests are [very flaky](https://dash.dm1-idx1.dfinity.network/invocation/34f3e50b-0713-40e2-a983-b71373683092) due to their `httpbin` UVMs failing to acquire an IPv4 address in time in the `dm1` DC.

To get a bit more insight into why this is the case we log `networkctl status enp2s0` on timeout.
