### PR TITLE
chore: harden assert_no_snapshot and get_registry_version in migration canister

### DIFF
--- a/rs/migration_canister/src/external_interfaces/management.rs
+++ b/rs/migration_canister/src/external_interfaces/management.rs
@@ -273,22 +273,30 @@ pub async fn assert_no_snapshots(canister_id: Principal) -> ProcessingResult<(),
                 ))
             }
         }
-        Err(e) => {
-            println!(
-                "Call `list_canister_snapshots` for {} failed: {:?}",
-                canister_id, e
-            );
-            match e {
-                CallError::CallRejected(e) => {
-                    if e.reject_code() == Ok(RejectCode::DestinationInvalid) {
-                        ProcessingResult::Success(())
-                    } else {
-                        ProcessingResult::NoProgress
-                    }
+        Err(e) => match e {
+            CallError::CallRejected(e) => {
+                if e.reject_code() == Ok(RejectCode::DestinationInvalid) {
+                    println!(
+                        "Call `list_canister_snapshots` for {} returned DestinationInvalid, treating as success",
+                        canister_id
+                    );
+                    ProcessingResult::Success(())
+                } else {
+                    println!(
+                        "Call `list_canister_snapshots` for {} failed: {:?}",
+                        canister_id, e
+                    );
+                    ProcessingResult::NoProgress
                 }
-                _ => ProcessingResult::NoProgress,
             }
-        }
+            _ => {
+                println!(
+                    "Call `list_canister_snapshots` for {} failed: {:?}",
+                    canister_id, e
+                );
+                ProcessingResult::NoProgress
+            }
+        },
     }
 }
 
@@ -327,22 +335,30 @@ pub async fn get_registry_version(
                 ProcessingResult::NoProgress
             }
         },
-        Err(e) => {
-            println!(
-                "Call `subnet_info` for subnet: {} failed: {:?}",
-                subnet_id, e
-            );
-            match e {
-                CallFailed::CallRejected(e) => {
-                    if e.reject_code() == Ok(RejectCode::DestinationInvalid) {
-                        ProcessingResult::Success(None)
-                    } else {
-                        ProcessingResult::NoProgress
-                    }
+        Err(e) => match e {
+            CallFailed::CallRejected(e) => {
+                if e.reject_code() == Ok(RejectCode::DestinationInvalid) {
+                    println!(
+                        "Call `subnet_info` for subnet: {} returned DestinationInvalid, treating as success",
+                        subnet_id
+                    );
+                    ProcessingResult::Success(None)
+                } else {
+                    println!(
+                        "Call `subnet_info` for subnet: {} failed: {:?}",
+                        subnet_id, e
+                    );
+                    ProcessingResult::NoProgress
                 }
-                _ => ProcessingResult::NoProgress,
             }
-        }
+            _ => {
+                println!(
+                    "Call `subnet_info` for subnet: {} failed: {:?}",
+                    subnet_id, e
+                );
+                ProcessingResult::NoProgress
+            }
+        },
     }
 }
 

--- a/rs/migration_canister/src/external_interfaces/management.rs
+++ b/rs/migration_canister/src/external_interfaces/management.rs
@@ -264,39 +264,26 @@ pub async fn rename_canister(
 
 pub async fn assert_no_snapshots(canister_id: Principal) -> ProcessingResult<(), ValidationError> {
     match list_canister_snapshots(&ListCanisterSnapshotsArgs { canister_id }).await {
-        Ok(snapshots) => {
-            if snapshots.is_empty() {
-                ProcessingResult::Success(())
-            } else {
-                ProcessingResult::FatalFailure(ValidationError::ReplacedCanisterHasSnapshots(
-                    Reserved,
-                ))
-            }
+        Ok(snapshots) if snapshots.is_empty() => ProcessingResult::Success(()),
+        Ok(_) => {
+            ProcessingResult::FatalFailure(ValidationError::ReplacedCanisterHasSnapshots(Reserved))
         }
-        Err(e) => match e {
-            CallError::CallRejected(e) => {
-                if e.reject_code() == Ok(RejectCode::DestinationInvalid) {
-                    println!(
-                        "Call `list_canister_snapshots` for {} returned DestinationInvalid, treating as success",
-                        canister_id
-                    );
-                    ProcessingResult::Success(())
-                } else {
-                    println!(
-                        "Call `list_canister_snapshots` for {} failed: {:?}",
-                        canister_id, e
-                    );
-                    ProcessingResult::NoProgress
-                }
-            }
-            _ => {
-                println!(
-                    "Call `list_canister_snapshots` for {} failed: {:?}",
-                    canister_id, e
-                );
-                ProcessingResult::NoProgress
-            }
-        },
+        Err(CallError::CallRejected(e))
+            if e.reject_code() == Ok(RejectCode::DestinationInvalid) =>
+        {
+            println!(
+                "Call `list_canister_snapshots` for {} returned DestinationInvalid, treating as success",
+                canister_id
+            );
+            ProcessingResult::Success(())
+        }
+        Err(e) => {
+            println!(
+                "Call `list_canister_snapshots` for {} failed: {:?}",
+                canister_id, e
+            );
+            ProcessingResult::NoProgress
+        }
     }
 }
 
@@ -335,30 +322,22 @@ pub async fn get_registry_version(
                 ProcessingResult::NoProgress
             }
         },
-        Err(e) => match e {
-            CallFailed::CallRejected(e) => {
-                if e.reject_code() == Ok(RejectCode::DestinationInvalid) {
-                    println!(
-                        "Call `subnet_info` for subnet: {} returned DestinationInvalid, treating as success",
-                        subnet_id
-                    );
-                    ProcessingResult::Success(None)
-                } else {
-                    println!(
-                        "Call `subnet_info` for subnet: {} failed: {:?}",
-                        subnet_id, e
-                    );
-                    ProcessingResult::NoProgress
-                }
-            }
-            _ => {
-                println!(
-                    "Call `subnet_info` for subnet: {} failed: {:?}",
-                    subnet_id, e
-                );
-                ProcessingResult::NoProgress
-            }
-        },
+        Err(CallFailed::CallRejected(e))
+            if e.reject_code() == Ok(RejectCode::DestinationInvalid) =>
+        {
+            println!(
+                "Call `subnet_info` for subnet: {} returned DestinationInvalid, treating as success",
+                subnet_id
+            );
+            ProcessingResult::Success(None)
+        }
+        Err(e) => {
+            println!(
+                "Call `subnet_info` for subnet: {} failed: {:?}",
+                subnet_id, e
+            );
+            ProcessingResult::NoProgress
+        }
     }
 }
 

--- a/rs/migration_canister/src/external_interfaces/management.rs
+++ b/rs/migration_canister/src/external_interfaces/management.rs
@@ -278,7 +278,16 @@ pub async fn assert_no_snapshots(canister_id: Principal) -> ProcessingResult<(),
                 "Call `list_canister_snapshots` for {} failed: {:?}",
                 canister_id, e
             );
-            ProcessingResult::NoProgress
+            match e {
+                CallError::CallRejected(e) => {
+                    if e.reject_code() == Ok(RejectCode::DestinationInvalid) {
+                        ProcessingResult::Success(())
+                    } else {
+                        ProcessingResult::NoProgress
+                    }
+                }
+                _ => ProcessingResult::NoProgress,
+            }
         }
     }
 }
@@ -298,7 +307,9 @@ pub struct SubnetInfoResponse {
     pub registry_version: u64,
 }
 
-pub async fn get_registry_version(subnet_id: Principal) -> ProcessingResult<u64, Infallible> {
+pub async fn get_registry_version(
+    subnet_id: Principal,
+) -> ProcessingResult<Option<u64>, Infallible> {
     let args = SubnetInfoArgs { subnet_id };
     match Call::bounded_wait(subnet_id, "subnet_info")
         .with_arg(&args)
@@ -307,7 +318,7 @@ pub async fn get_registry_version(subnet_id: Principal) -> ProcessingResult<u64,
         Ok(response) => match response.candid::<SubnetInfoResponse>() {
             Ok(SubnetInfoResponse {
                 registry_version, ..
-            }) => ProcessingResult::Success(registry_version),
+            }) => ProcessingResult::Success(Some(registry_version)),
             Err(e) => {
                 println!(
                     "Decoding `SubnetInfoResponse` for subnet: {} failed: {:?}",
@@ -321,7 +332,16 @@ pub async fn get_registry_version(subnet_id: Principal) -> ProcessingResult<u64,
                 "Call `subnet_info` for subnet: {} failed: {:?}",
                 subnet_id, e
             );
-            ProcessingResult::NoProgress
+            match e {
+                CallFailed::CallRejected(e) => {
+                    if e.reject_code() == Ok(RejectCode::DestinationInvalid) {
+                        ProcessingResult::Success(None)
+                    } else {
+                        ProcessingResult::NoProgress
+                    }
+                }
+                _ => ProcessingResult::NoProgress,
+            }
         }
     }
 }

--- a/rs/migration_canister/src/processing.rs
+++ b/rs/migration_canister/src/processing.rs
@@ -273,8 +273,8 @@ pub async fn process_updated(
     else {
         return ProcessingResult::NoProgress;
     };
-    if migrated_canister_subnet_version < registry_version
-        || replaced_canister_subnet_version < registry_version
+    if migrated_canister_subnet_version.is_some_and(|v| v < registry_version)
+        || replaced_canister_subnet_version.is_some_and(|v| v < registry_version)
     {
         return ProcessingResult::NoProgress;
     }


### PR DESCRIPTION
This PR hardens the following checks to work after subnet deletion:
- asserting no snapshots succeeds if the call returns `DestinationInvalid` (if the canister or subnet was deleted, then the canister has no snapshots trivially);
- waiting until a subnet is at a certain registry version only makes sense as long as the subnet exists.