### PR TITLE
chore(DSM-121): add critical_error_sync_call_unknown_certificate_status

### DIFF
--- a/rs/http_endpoints/public/src/call/call_sync.rs
+++ b/rs/http_endpoints/public/src/call/call_sync.rs
@@ -350,8 +350,8 @@ async fn call_sync(
         error!(
             every_n_seconds => LOG_EVERY_N_SECONDS,
             log,
-            "Unknown status of call {} in the certificate at height {}. This is a critical error: {}",
-            message_id, certification.height, CRITICAL_ERROR_SYNC_CALL_UNKNOWN_CERTIFICATE_STATUS
+            "{}: Unknown status of call {} in the certificate at height {}.",
+            CRITICAL_ERROR_SYNC_CALL_UNKNOWN_CERTIFICATE_STATUS, message_id, certification.height
         );
         metrics
             .critical_error_sync_call_unknown_certificate_status

--- a/rs/http_endpoints/public/src/call/call_sync.rs
+++ b/rs/http_endpoints/public/src/call/call_sync.rs
@@ -8,7 +8,8 @@ use crate::{
     HttpError,
     common::{Cbor, WithTimeout, into_cbor},
     metrics::{
-        HttpHandlerMetrics, SYNC_CALL_EARLY_RESPONSE_CERTIFICATION_TIMEOUT,
+        CRITICAL_ERROR_SYNC_CALL_UNKNOWN_CERTIFICATE_STATUS, HttpHandlerMetrics,
+        SYNC_CALL_EARLY_RESPONSE_CERTIFICATION_TIMEOUT,
         SYNC_CALL_EARLY_RESPONSE_DUPLICATE_SUBSCRIPTION,
         SYNC_CALL_EARLY_RESPONSE_INGRESS_WATCHER_NOT_RUNNING,
         SYNC_CALL_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE,
@@ -345,14 +346,16 @@ async fn call_sync(
         .with_label_values(&[status_label])
         .inc();
 
-    // TODO(DSM-121): ensure that `ParsedMessageStatus::Unknown` never occurs
-    // and trigger a critical error here if it does.
     if let ParsedMessageStatus::Unknown = message_status {
         error!(
             every_n_seconds => LOG_EVERY_N_SECONDS,
             log,
-            "Unknown status of call {} in the certificate at height {}.", message_id, certification.height
+            "Unknown status of call {} in the certificate at height {}. This is a critical error: {}",
+            message_id, certification.height, CRITICAL_ERROR_SYNC_CALL_UNKNOWN_CERTIFICATE_STATUS
         );
+        metrics
+            .critical_error_sync_call_unknown_certificate_status
+            .inc();
         return SyncCallResponse::Accepted(
             "Certified state does not contain request status. Please try /read_state.",
         );

--- a/rs/http_endpoints/public/src/metrics.rs
+++ b/rs/http_endpoints/public/src/metrics.rs
@@ -27,6 +27,8 @@ pub const SYNC_CALL_EARLY_RESPONSE_MESSAGE_ALREADY_IN_CERTIFIED_STATE: &str =
     "message_already_in_certified_state";
 pub const SYNC_CALL_STATUS_IS_NOT_LEAF: &str = "not_leaf";
 pub const SYNC_CALL_STATUS_IS_INVALID_UTF8: &str = "is_invalid_utf8";
+pub const CRITICAL_ERROR_SYNC_CALL_UNKNOWN_CERTIFICATE_STATUS: &str =
+    "http_handler_sync_call_unknown_certificate_status";
 
 /// Placeholder used when we can't determine the appropriate prometheus label.
 pub const LABEL_UNKNOWN: &str = "unknown";
@@ -71,6 +73,7 @@ pub struct HttpHandlerMetrics {
     // sync call handler metrics
     pub sync_call_early_response_trigger_total: IntCounterVec,
     pub sync_call_certificate_status_total: IntCounterVec,
+    pub critical_error_sync_call_unknown_certificate_status: IntCounter,
 
     // read_state metrics
     pub read_state_path_type_total: IntCounterVec,
@@ -210,6 +213,8 @@ impl HttpHandlerMetrics {
                 "The count of early response triggers for the /{v3,v4}/.../call endpoint.",
                 &[LABEL_SYNC_CALL_EARLY_RESPONSE_TRIGGER],
             ),
+            critical_error_sync_call_unknown_certificate_status: metrics_registry
+                .error_counter(CRITICAL_ERROR_SYNC_CALL_UNKNOWN_CERTIFICATE_STATUS),
             read_state_path_type_total: metrics_registry.int_counter_vec(
                 "replica_http_read_state_path_type_total",
                 "Count of read_state paths requested, by endpoint type and path type.",


### PR DESCRIPTION
This PR introduces a critical error for the case of the synchronous update call HTTP handler trying to return a certificate in which the update call status is unknown. This case has not happened in prod for ~10 days by now ([kibana](https://kibana.mainnet.dfinity.network/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-30d%2Fd,to:now))&_a=(columns:!(),filters:!(),hideChart:!f,index:ic-logs-mainnet,interval:auto,query:(language:kuery,query:'%22Unknown%20status%20of%20call%22'),sort:!(!(timestamp,desc))))) so it is safe to assume that the underlying issue has been fixed and raise a critical error going forward.