### PR TITLE
feat: make reference subnet size in CyclesAccountManager configurable at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18461,6 +18461,7 @@ dependencies = [
  "ic-canonical-state",
  "ic-cdk",
  "ic-certification 0.9.0",
+ "ic-config",
  "ic-crypto-tree-hash",
  "ic-crypto-utils-threshold-sig-der",
  "ic-cycles-account-manager",

--- a/rs/canister_sandbox/src/protocol/sbxsvc.rs
+++ b/rs/canister_sandbox/src/protocol/sbxsvc.rs
@@ -318,7 +318,7 @@ mod tests {
     use std::time::Duration;
 
     use ic_base_types::NumSeconds;
-    use ic_config::subnet_config::{CyclesAccountManagerConfig, SubnetSecurity};
+    use ic_config::subnet_config::{CyclesAccountManagerConfig, DEFAULT_REFERENCE_SUBNET_SIZE};
     use ic_cycles_account_manager::{
         CyclesAccountManager, CyclesAccountManagerSubnetConfig, ResourceSaturation,
     };
@@ -492,7 +492,7 @@ mod tests {
                         NumInstructions::new(10),
                         SubnetType::Application,
                         SubnetId::new(canister_test_id(1).get()),
-                        CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None),
+                        CyclesAccountManagerConfig::application_subnet(),
                     ),
                     &NetworkTopology::default(),
                     NumInstructions::new(42),
@@ -505,6 +505,7 @@ mod tests {
                     CyclesAccountManagerSubnetConfig::new(
                         SMALL_APP_SUBNET_MAX_SIZE,
                         CanisterCyclesCostSchedule::Normal,
+                        DEFAULT_REFERENCE_SUBNET_SIZE,
                     ),
                 ),
                 wasm_reserved_pages: NumWasmPages::new(1),

--- a/rs/canister_sandbox/src/sandbox_server.rs
+++ b/rs/canister_sandbox/src/sandbox_server.rs
@@ -126,7 +126,9 @@ mod tests {
     };
     use ic_base_types::{NumSeconds, PrincipalId};
     use ic_config::embedders::Config as EmbeddersConfig;
-    use ic_config::subnet_config::{CyclesAccountManagerConfig, SchedulerConfig, SubnetSecurity};
+    use ic_config::subnet_config::{
+        CyclesAccountManagerConfig, DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig,
+    };
     use ic_cycles_account_manager::{
         CyclesAccountManager, CyclesAccountManagerSubnetConfig, ResourceSaturation,
     };
@@ -209,7 +211,7 @@ mod tests {
                 NumInstructions::from(1_000_000_000),
                 SubnetType::Application,
                 subnet_test_id(0),
-                CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None),
+                CyclesAccountManagerConfig::application_subnet(),
             ),
             0,
             BTreeMap::new(),
@@ -218,6 +220,7 @@ mod tests {
             CyclesAccountManagerSubnetConfig::new(
                 SMALL_APP_SUBNET_MAX_SIZE,
                 CanisterCyclesCostSchedule::Normal,
+                DEFAULT_REFERENCE_SUBNET_SIZE,
             ),
             SchedulerConfig::application_subnet().dirty_page_overhead,
             CanisterTimer::Inactive,

--- a/rs/config/src/subnet_config.rs
+++ b/rs/config/src/subnet_config.rs
@@ -10,22 +10,6 @@ use ic_types::{ExecutionRound, NumInstructions};
 use ic_types_cycles::Cycles;
 use serde::{Deserialize, Serialize};
 
-/// Security model under which a subnet runs. Currently distinguishes subnets
-/// that use AMD SEV-SNP confidential VMs from those that don't.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SubnetSecurity {
-    /// Subnet uses SEV-SNP confidential VMs.
-    Sev,
-    /// Subnet does not use SEV-SNP.
-    None,
-}
-
-impl SubnetSecurity {
-    pub fn from_sev_enabled(sev_enabled: bool) -> Self {
-        if sev_enabled { Self::Sev } else { Self::None }
-    }
-}
-
 const GIB: u64 = 1024 * 1024 * 1024;
 const M: u64 = 1_000_000;
 const B: u64 = 1_000_000_000;
@@ -394,10 +378,6 @@ impl SchedulerConfig {
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub struct CyclesAccountManagerConfig {
-    /// Reference value of a subnet size that all the fees below are calculated for.
-    /// Fees for a real subnet are calculated proportionally to this reference value.
-    pub reference_subnet_size: usize,
-
     /// Fee for creating canisters on a subnet
     pub canister_creation_fee: Cycles,
 
@@ -479,13 +459,9 @@ pub struct CyclesAccountManagerConfig {
 }
 
 impl CyclesAccountManagerConfig {
-    pub fn application_subnet(subnet_security: SubnetSecurity) -> Self {
+    pub fn application_subnet() -> Self {
         let ten_update_instructions_execution_fee_in_cycles = 10;
         Self {
-            reference_subnet_size: match subnet_security {
-                SubnetSecurity::Sev => SEV_REFERENCE_SUBNET_SIZE,
-                SubnetSecurity::None => DEFAULT_REFERENCE_SUBNET_SIZE,
-            },
             canister_creation_fee: CANISTER_CREATION_FEE,
             compute_percent_allocated_per_second_fee: Cycles::new(10_000_000),
 
@@ -521,14 +497,13 @@ impl CyclesAccountManagerConfig {
         }
     }
 
-    pub fn verified_application_subnet(subnet_security: SubnetSecurity) -> Self {
-        Self::application_subnet(subnet_security)
+    pub fn verified_application_subnet() -> Self {
+        Self::application_subnet()
     }
 
     /// All processing is free on system subnets
     pub fn system_subnet() -> Self {
         Self {
-            reference_subnet_size: DEFAULT_REFERENCE_SUBNET_SIZE,
             canister_creation_fee: Cycles::new(0),
             compute_percent_allocated_per_second_fee: Cycles::new(0),
             update_message_execution_fee: Cycles::new(0),
@@ -564,9 +539,8 @@ impl CyclesAccountManagerConfig {
         }
     }
 
-    pub fn zero_cost(subnet_size: usize) -> Self {
+    pub fn zero_cost() -> Self {
         Self {
-            reference_subnet_size: subnet_size,
             canister_creation_fee: Cycles::zero(),
             update_message_execution_fee: Cycles::zero(),
             ten_update_instructions_execution_fee: Cycles::zero(),
@@ -594,7 +568,7 @@ impl CyclesAccountManagerConfig {
     }
 
     pub fn cloud_engine() -> Self {
-        Self::application_subnet(SubnetSecurity::None)
+        Self::application_subnet()
     }
 }
 
@@ -607,28 +581,20 @@ pub struct SubnetConfig {
 }
 
 impl SubnetConfig {
-    /// `subnet_security` only affects the cycles cost scaling for `Application`
-    /// and `VerifiedApplication` subnets. For `System` and `CloudEngine`
-    /// subnets it is ignored, because those subnets either don't charge cycles
-    /// or use a separate cost model.
-    pub fn new(own_subnet_type: SubnetType, subnet_security: SubnetSecurity) -> Self {
+    pub fn new(own_subnet_type: SubnetType) -> Self {
         match own_subnet_type {
-            SubnetType::Application => Self::default_application_subnet(subnet_security),
+            SubnetType::Application => Self::default_application_subnet(),
             SubnetType::System => Self::default_system_subnet(),
-            SubnetType::VerifiedApplication => {
-                Self::default_verified_application_subnet(subnet_security)
-            }
+            SubnetType::VerifiedApplication => Self::default_verified_application_subnet(),
             SubnetType::CloudEngine => Self::default_cloud_engine(),
         }
     }
 
     /// Returns the subnet configuration for the application subnet type.
-    fn default_application_subnet(subnet_security: SubnetSecurity) -> Self {
+    fn default_application_subnet() -> Self {
         Self {
             scheduler_config: SchedulerConfig::application_subnet(),
-            cycles_account_manager_config: CyclesAccountManagerConfig::application_subnet(
-                subnet_security,
-            ),
+            cycles_account_manager_config: CyclesAccountManagerConfig::application_subnet(),
         }
     }
 
@@ -642,11 +608,10 @@ impl SubnetConfig {
 
     /// Returns the subnet configuration for the verified application subnet
     /// type.
-    fn default_verified_application_subnet(subnet_security: SubnetSecurity) -> Self {
+    fn default_verified_application_subnet() -> Self {
         Self {
             scheduler_config: SchedulerConfig::verified_application_subnet(),
             cycles_account_manager_config: CyclesAccountManagerConfig::verified_application_subnet(
-                subnet_security,
             ),
         }
     }
@@ -663,11 +628,9 @@ impl SubnetConfig {
 #[cfg(test)]
 mod tests {
     use super::{
-        B, DEFAULT_REFERENCE_SUBNET_SIZE, MAX_INSTRUCTIONS_PER_INSTALL_CODE_SLICE,
-        MAX_INSTRUCTIONS_PER_ROUND, MAX_INSTRUCTIONS_PER_SLICE, SEV_REFERENCE_SUBNET_SIZE,
+        B, MAX_INSTRUCTIONS_PER_INSTALL_CODE_SLICE, MAX_INSTRUCTIONS_PER_ROUND,
+        MAX_INSTRUCTIONS_PER_SLICE,
     };
-    use crate::subnet_config::{SubnetConfig, SubnetSecurity};
-    use ic_registry_subnet_type::SubnetType;
     use ic_types::NumInstructions;
 
     #[test]
@@ -676,47 +639,6 @@ mod tests {
             MAX_INSTRUCTIONS_PER_ROUND,
             MAX_INSTRUCTIONS_PER_SLICE.max(MAX_INSTRUCTIONS_PER_INSTALL_CODE_SLICE)
                 + NumInstructions::from(2 * B)
-        );
-    }
-
-    #[test]
-    fn subnet_config_application_sev_disabled_uses_default_reference_subnet_size() {
-        let config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
-        assert_eq!(
-            config.cycles_account_manager_config.reference_subnet_size,
-            DEFAULT_REFERENCE_SUBNET_SIZE
-        );
-    }
-
-    #[test]
-    fn subnet_config_application_sev_enabled_uses_sev_reference_subnet_size() {
-        let config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::Sev);
-        assert_eq!(
-            config.cycles_account_manager_config.reference_subnet_size,
-            SEV_REFERENCE_SUBNET_SIZE
-        );
-    }
-
-    #[test]
-    fn subnet_config_verified_application_sev_enabled_uses_sev_reference_subnet_size() {
-        let config = SubnetConfig::new(SubnetType::VerifiedApplication, SubnetSecurity::Sev);
-        assert_eq!(
-            config.cycles_account_manager_config.reference_subnet_size,
-            SEV_REFERENCE_SUBNET_SIZE
-        );
-    }
-
-    #[test]
-    fn subnet_config_system_ignores_sev_flag() {
-        let config_sev = SubnetConfig::new(SubnetType::System, SubnetSecurity::Sev);
-        let config_no_sev = SubnetConfig::new(SubnetType::System, SubnetSecurity::None);
-        assert_eq!(
-            config_sev
-                .cycles_account_manager_config
-                .reference_subnet_size,
-            config_no_sev
-                .cycles_account_manager_config
-                .reference_subnet_size
         );
     }
 }

--- a/rs/cycles_account_manager/src/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager.rs
@@ -104,11 +104,11 @@ impl CyclesAccountManager {
         subnet_cycles_config: CyclesAccountManagerSubnetConfig,
     ) -> CompoundCycles<T> {
         debug_assert_ne!(
-            self.config.reference_subnet_size, 0,
+            subnet_cycles_config.reference_subnet_size, 0,
             "prevent divide by zero panic"
         );
-        let real =
-            (cycles * subnet_cycles_config.subnet_size) / self.config.reference_subnet_size.max(1);
+        let real = (cycles * subnet_cycles_config.subnet_size)
+            / subnet_cycles_config.reference_subnet_size.max(1);
         CompoundCycles::<T>::new(real, subnet_cycles_config.cost_schedule)
     }
 

--- a/rs/cycles_account_manager/src/cycles_account_manager/tests.rs
+++ b/rs/cycles_account_manager/src/cycles_account_manager/tests.rs
@@ -1,14 +1,12 @@
 use super::*;
 use candid::Encode;
-use ic_config::subnet_config::SubnetSecurity;
 use ic_management_canister_types_private::{CanisterSettingsArgsBuilder, UpdateSettingsArgs};
 use ic_test_utilities_types::ids::subnet_test_id;
 
 const WASM_EXECUTION_MODE: WasmExecutionMode = WasmExecutionMode::Wasm32;
 
-fn create_cycles_account_manager(reference_subnet_size: usize) -> CyclesAccountManager {
-    let mut config = CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None);
-    config.reference_subnet_size = reference_subnet_size;
+fn create_cycles_account_manager() -> CyclesAccountManager {
+    let config = CyclesAccountManagerConfig::application_subnet();
 
     CyclesAccountManager {
         max_num_instructions: NumInstructions::from(1_000_000_000),
@@ -40,13 +38,17 @@ fn max_delayed_ingress_cost_payload_size_test() {
 #[test]
 fn test_scale_cost() {
     let reference_subnet_size = 13;
-    let cam = create_cycles_account_manager(reference_subnet_size);
+    let cam = create_cycles_account_manager();
 
     let cost = Cycles::new(13_000);
     assert_eq!(
         cam.scale_cost::<Memory>(
             cost,
-            CyclesAccountManagerSubnetConfig::new(0, CanisterCyclesCostSchedule::Normal)
+            CyclesAccountManagerSubnetConfig::new(
+                0,
+                CanisterCyclesCostSchedule::Normal,
+                reference_subnet_size
+            )
         )
         .real(),
         Cycles::new(0)
@@ -54,7 +56,11 @@ fn test_scale_cost() {
     assert_eq!(
         cam.scale_cost::<Memory>(
             cost,
-            CyclesAccountManagerSubnetConfig::new(1, CanisterCyclesCostSchedule::Normal)
+            CyclesAccountManagerSubnetConfig::new(
+                1,
+                CanisterCyclesCostSchedule::Normal,
+                reference_subnet_size
+            )
         )
         .real(),
         Cycles::new(1_000)
@@ -62,7 +68,11 @@ fn test_scale_cost() {
     assert_eq!(
         cam.scale_cost::<Memory>(
             cost,
-            CyclesAccountManagerSubnetConfig::new(6, CanisterCyclesCostSchedule::Normal)
+            CyclesAccountManagerSubnetConfig::new(
+                6,
+                CanisterCyclesCostSchedule::Normal,
+                reference_subnet_size
+            )
         )
         .real(),
         Cycles::new(6_000)
@@ -70,7 +80,11 @@ fn test_scale_cost() {
     assert_eq!(
         cam.scale_cost::<Memory>(
             cost,
-            CyclesAccountManagerSubnetConfig::new(13, CanisterCyclesCostSchedule::Normal)
+            CyclesAccountManagerSubnetConfig::new(
+                13,
+                CanisterCyclesCostSchedule::Normal,
+                reference_subnet_size
+            )
         )
         .real(),
         Cycles::new(13_000)
@@ -78,7 +92,11 @@ fn test_scale_cost() {
     assert_eq!(
         cam.scale_cost::<Memory>(
             cost,
-            CyclesAccountManagerSubnetConfig::new(26, CanisterCyclesCostSchedule::Normal)
+            CyclesAccountManagerSubnetConfig::new(
+                26,
+                CanisterCyclesCostSchedule::Normal,
+                reference_subnet_size
+            )
         )
         .real(),
         Cycles::new(26_000)
@@ -87,7 +105,11 @@ fn test_scale_cost() {
     assert_eq!(
         cam.scale_cost::<Memory>(
             cost,
-            CyclesAccountManagerSubnetConfig::new(26, CanisterCyclesCostSchedule::Free)
+            CyclesAccountManagerSubnetConfig::new(
+                26,
+                CanisterCyclesCostSchedule::Free,
+                reference_subnet_size
+            )
         )
         .real(),
         Cycles::new(0)
@@ -97,7 +119,11 @@ fn test_scale_cost() {
     assert_eq!(
         cam.scale_cost::<Memory>(
             Cycles::new(u128::MAX),
-            CyclesAccountManagerSubnetConfig::new(1_000_000, CanisterCyclesCostSchedule::Normal)
+            CyclesAccountManagerSubnetConfig::new(
+                1_000_000,
+                CanisterCyclesCostSchedule::Normal,
+                reference_subnet_size
+            )
         )
         .real(),
         Cycles::new(u128::MAX) / reference_subnet_size
@@ -105,57 +131,11 @@ fn test_scale_cost() {
 }
 
 #[test]
-fn test_reference_subnet_size_is_not_zero() {
-    // `reference_subnet_size` is used to scale cost according to a subnet size.
-    // It should never be equal to zero.
-    assert_ne!(
-        CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None).reference_subnet_size,
-        0
-    );
-    assert_ne!(
-        CyclesAccountManagerConfig::application_subnet(SubnetSecurity::Sev).reference_subnet_size,
-        0
-    );
-    assert_ne!(
-        CyclesAccountManagerConfig::verified_application_subnet(SubnetSecurity::None)
-            .reference_subnet_size,
-        0
-    );
-    assert_ne!(
-        CyclesAccountManagerConfig::verified_application_subnet(SubnetSecurity::Sev)
-            .reference_subnet_size,
-        0
-    );
-    assert_ne!(
-        CyclesAccountManagerConfig::system_subnet().reference_subnet_size,
-        0
-    );
-    assert_ne!(
-        CyclesAccountManagerConfig::cloud_engine().reference_subnet_size,
-        0
-    );
-}
-
-#[test]
-fn application_subnet_sev_disabled_uses_default_reference_subnet_size() {
-    use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
-    let config = CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None);
-    assert_eq!(config.reference_subnet_size, DEFAULT_REFERENCE_SUBNET_SIZE);
-}
-
-#[test]
-fn application_subnet_sev_enabled_uses_sev_reference_subnet_size() {
-    use ic_config::subnet_config::SEV_REFERENCE_SUBNET_SIZE;
-    let config = CyclesAccountManagerConfig::application_subnet(SubnetSecurity::Sev);
-    assert_eq!(config.reference_subnet_size, SEV_REFERENCE_SUBNET_SIZE);
-}
-
-#[test]
 fn http_requests_fee_scale() {
     let subnet_size: u64 = 34;
     let reference_subnet_size: u64 = 13;
     let request_size = NumBytes::from(17);
-    let cycles_account_manager = create_cycles_account_manager(reference_subnet_size as usize);
+    let cycles_account_manager = create_cycles_account_manager();
 
     // Check the fee for a 13-node subnet.
     assert_eq!(
@@ -166,6 +146,7 @@ fn http_requests_fee_scale() {
                 CyclesAccountManagerSubnetConfig::new(
                     reference_subnet_size as usize,
                     CanisterCyclesCostSchedule::Normal,
+                    reference_subnet_size as usize,
                 ),
             )
             .real(),
@@ -181,6 +162,7 @@ fn http_requests_fee_scale() {
                 CyclesAccountManagerSubnetConfig::new(
                     subnet_size as usize,
                     CanisterCyclesCostSchedule::Normal,
+                    reference_subnet_size as usize,
                 ),
             )
             .real(),
@@ -191,7 +173,7 @@ fn http_requests_fee_scale() {
 #[test]
 fn test_cycles_burn() {
     let subnet_size = 13;
-    let cycles_account_manager = create_cycles_account_manager(subnet_size);
+    let cycles_account_manager = create_cycles_account_manager();
     let initial_balance = Cycles::new(1_000_000_000);
     let mut balance = initial_balance;
     let amount_to_burn = Cycles::new(1_000_000);
@@ -205,7 +187,11 @@ fn test_cycles_burn() {
             0.into(),
             MessageMemoryUsage::ZERO,
             ComputeAllocation::default(),
-            CyclesAccountManagerSubnetConfig::new(13, CanisterCyclesCostSchedule::Normal),
+            CyclesAccountManagerSubnetConfig::new(
+                13,
+                CanisterCyclesCostSchedule::Normal,
+                subnet_size
+            ),
             Cycles::new(0)
         ),
         amount_to_burn
@@ -223,7 +209,11 @@ fn test_cycles_burn() {
             0.into(),
             MessageMemoryUsage::ZERO,
             ComputeAllocation::default(),
-            CyclesAccountManagerSubnetConfig::new(13, CanisterCyclesCostSchedule::Free),
+            CyclesAccountManagerSubnetConfig::new(
+                13,
+                CanisterCyclesCostSchedule::Free,
+                subnet_size
+            ),
             Cycles::new(0)
         ),
         amount_to_burn
@@ -235,8 +225,7 @@ fn test_cycles_burn() {
 
 #[test]
 fn test_convert_instructions_to_cycles() {
-    let subnet_size = 13;
-    let cycles_account_manager = create_cycles_account_manager(subnet_size);
+    let cycles_account_manager = create_cycles_account_manager();
 
     // Everything up to `u128::MAX / 4` should be converted as normal:
     // `(ten_update_instructions_execution_fee * num_instructions) / 10`

--- a/rs/cycles_account_manager/tests/cycles_account_manager.rs
+++ b/rs/cycles_account_manager/tests/cycles_account_manager.rs
@@ -1,5 +1,5 @@
 use ic_base_types::NumSeconds;
-use ic_config::subnet_config::{CyclesAccountManagerConfig, SubnetSecurity};
+use ic_config::subnet_config::{CyclesAccountManagerConfig, DEFAULT_REFERENCE_SUBNET_SIZE};
 use ic_cycles_account_manager::{
     CyclesAccountManagerSubnetConfig, IngressInductionCost, ResourceSaturation,
 };
@@ -46,7 +46,11 @@ fn xnet_call_total_fee_free() {
         Cycles::new(0),
         cam.xnet_call_total_fee(
             NumBytes::new(9999),
-            CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule),
+            CyclesAccountManagerSubnetConfig::new(
+                SMALL_APP_SUBNET_MAX_SIZE,
+                cost_schedule,
+                DEFAULT_REFERENCE_SUBNET_SIZE
+            ),
             WasmExecutionMode::Wasm32,
         ),
     );
@@ -55,8 +59,11 @@ fn xnet_call_total_fee_free() {
 #[test]
 fn test_can_charge_application_subnets() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
-    let subnet_cycles_config =
-        CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     with_test_replica_logger(|log| {
         for subnet_type in &[
             SubnetType::Application,
@@ -127,8 +134,11 @@ fn withdraw_cycles_with_not_enough_balance_returns_error() {
         best_effort: NumBytes::new(2 << 20),
     };
     let amount = Cycles::new(200);
-    let subnet_cycles_config =
-        CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     {
         let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
         let mut system_state = SystemState::new_running_for_testing(
@@ -291,7 +301,11 @@ fn withdraw_cycles_with_not_enough_balance_returns_error() {
 fn verify_no_cycles_charged_for_message_execution_on_system_subnets() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
     let subnet_size = SMALL_APP_SUBNET_MAX_SIZE;
-    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(subnet_size, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        subnet_size,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     let mut system_state = SystemStateBuilder::new().build();
     let cycles_account_manager = CyclesAccountManagerBuilder::new()
         .with_subnet_type(SubnetType::System)
@@ -330,7 +344,11 @@ fn verify_no_cycles_charged_for_message_execution_on_system_subnets() {
 fn verify_no_cycles_charged_for_message_execution_on_free_schedule() {
     let cost_schedule = CanisterCyclesCostSchedule::Free;
     let subnet_size = SMALL_APP_SUBNET_MAX_SIZE;
-    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(subnet_size, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        subnet_size,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     let mut system_state = SystemStateBuilder::new().build();
     let cycles_account_manager = CyclesAccountManagerBuilder::new()
         .with_subnet_type(SubnetType::Application)
@@ -381,8 +399,11 @@ fn ingress_induction_cost_valid_subnet_message() {
         let effective_canister_id = extract_effective_canister_id(signed_ingress_content).unwrap();
         let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
         let num_bytes = msg.binary().len();
-        let subnet_cycles_config =
-            CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+        let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+            SMALL_APP_SUBNET_MAX_SIZE,
+            cost_schedule,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
+        );
 
         let cost = cycles_account_manager
             .ingress_induction_cost_from_bytes(
@@ -412,8 +433,11 @@ fn charging_removes_canisters_with_insufficient_balance() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
     with_test_replica_logger(|log| {
         let subnet_size = SMALL_APP_SUBNET_MAX_SIZE;
-        let subnet_cycles_config =
-            CyclesAccountManagerSubnetConfig::new(subnet_size, cost_schedule);
+        let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+            subnet_size,
+            cost_schedule,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
+        );
         let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
 
         let mut canister = new_canister_state(
@@ -477,8 +501,11 @@ fn charge_canister_for_memory_usage() {
         const MEMORY_ALLOCATION: NumBytes = NumBytes::new(1 << 30);
         const HOUR: Duration = Duration::from_secs(3600);
 
-        let subnet_cycles_config =
-            CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+        let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+            SMALL_APP_SUBNET_MAX_SIZE,
+            cost_schedule,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
+        );
         let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
 
         let canister_id = canister_test_id(1);
@@ -539,8 +566,11 @@ fn do_not_charge_canister_for_memory_usage_free_schedule() {
         const MEMORY_ALLOCATION: NumBytes = NumBytes::new(1 << 30);
         const HOUR: Duration = Duration::from_secs(3600);
 
-        let subnet_cycles_config =
-            CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+        let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+            SMALL_APP_SUBNET_MAX_SIZE,
+            cost_schedule,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
+        );
         let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
 
         let canister_id = canister_test_id(1);
@@ -597,8 +627,11 @@ fn do_not_charge_canister_for_compute_allocation_free_schedule() {
     with_test_replica_logger(|log| {
         const HOUR: Duration = Duration::from_secs(3600);
         let compute_allocation = ComputeAllocation::try_from(20).unwrap();
-        let subnet_cycles_config =
-            CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+        let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+            SMALL_APP_SUBNET_MAX_SIZE,
+            cost_schedule,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
+        );
 
         let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
 
@@ -802,8 +835,11 @@ fn test_consume_with_threshold() {
 fn cycles_withdraw_for_execution() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
     let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
-    let subnet_cycles_config =
-        CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     let memory_usage = NumBytes::from(4 << 30);
     let message_memory_usage = MessageMemoryUsage {
         guaranteed_response: NumBytes::new(6 << 20),
@@ -965,8 +1001,11 @@ fn cycles_withdraw_for_execution() {
 fn do_not_withdraw_cycles_for_execution_free_schedule() {
     let cost_schedule = CanisterCyclesCostSchedule::Free;
     let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
-    let subnet_cycles_config =
-        CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     let memory_usage = NumBytes::from(4 << 30);
     let message_memory_usage = MessageMemoryUsage {
         guaranteed_response: NumBytes::new(6 << 20),
@@ -1044,7 +1083,11 @@ fn withdraw_execution_cycles_consumes_cycles() {
             MessageMemoryUsage::ZERO,
             ComputeAllocation::default(),
             NumInstructions::from(1_000_000),
-            CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule),
+            CyclesAccountManagerSubnetConfig::new(
+                SMALL_APP_SUBNET_MAX_SIZE,
+                cost_schedule,
+                DEFAULT_REFERENCE_SUBNET_SIZE,
+            ),
             false,
             WASM_EXECUTION_MODE,
         )
@@ -1072,7 +1115,11 @@ fn withdraw_for_transfer_does_not_consume_cycles() {
             ComputeAllocation::default(),
             &mut balance,
             Cycles::new(1_000_000),
-            CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule),
+            CyclesAccountManagerSubnetConfig::new(
+                SMALL_APP_SUBNET_MAX_SIZE,
+                cost_schedule,
+                DEFAULT_REFERENCE_SUBNET_SIZE,
+            ),
             system_state.reserved_balance(),
             false,
         )
@@ -1098,7 +1145,11 @@ fn consume_cycles_updates_consumed_cycles() {
             NumBytes::from(0),
             MessageMemoryUsage::ZERO,
             CompoundCycles::<Memory>::new(Cycles::new(1_000_000), cost_schedule),
-            CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule),
+            CyclesAccountManagerSubnetConfig::new(
+                SMALL_APP_SUBNET_MAX_SIZE,
+                cost_schedule,
+                DEFAULT_REFERENCE_SUBNET_SIZE,
+            ),
             false,
         )
         .unwrap();
@@ -1228,7 +1279,11 @@ fn withdraw_cycles_for_transfer_checks_reserved_balance() {
             ComputeAllocation::default(),
             &mut new_balance,
             Cycles::new(1_000_000),
-            CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule),
+            CyclesAccountManagerSubnetConfig::new(
+                SMALL_APP_SUBNET_MAX_SIZE,
+                cost_schedule,
+                DEFAULT_REFERENCE_SUBNET_SIZE,
+            ),
             system_state.reserved_balance(),
             false,
         )
@@ -1240,8 +1295,11 @@ fn withdraw_cycles_for_transfer_checks_reserved_balance() {
 fn freezing_threshold_uses_reserved_balance() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
     let cycles_account_manager = CyclesAccountManagerBuilder::new().build();
-    let subnet_cycles_config =
-        CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     let threshold_without_reserved = cycles_account_manager.freeze_threshold_cycles(
         NumSeconds::from(1_000),
         MemoryAllocation::default(),
@@ -1317,11 +1375,14 @@ fn scaling_of_resource_saturation() {
 #[test]
 fn test_storage_reservation_cycles() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
-    let subnet_cycles_config =
-        CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     const GB: u64 = 1024 * 1024 * 1024;
 
-    let cfg = CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None);
+    let cfg = CyclesAccountManagerConfig::application_subnet();
     let cam = CyclesAccountManagerBuilder::new().build();
 
     // Allocation of 100GB below the threshold.
@@ -1425,7 +1486,8 @@ fn test_storage_reservation_cycles() {
 
     // The total reserved cycles of small allocations should match that of one
     // large allocation.
-    let thirteen_node_config = CyclesAccountManagerSubnetConfig::new(13, cost_schedule);
+    let thirteen_node_config =
+        CyclesAccountManagerSubnetConfig::new(13, cost_schedule, DEFAULT_REFERENCE_SUBNET_SIZE);
     let rs0 = ResourceSaturation::new(0, 100 * GB, 1000 * GB);
     let mut total = Cycles::zero();
     let mut rs = rs0.clone();
@@ -1445,8 +1507,11 @@ fn test_storage_reservation_cycles() {
 #[test]
 fn test_storage_reservation_cycles_free() {
     let cost_schedule = CanisterCyclesCostSchedule::Free;
-    let subnet_cycles_config =
-        CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     const GB: u64 = 1024 * 1024 * 1024;
 
     let cam = CyclesAccountManagerBuilder::new().build();
@@ -1511,7 +1576,11 @@ fn test_storage_reservation_cycles_free() {
 fn variable_execution_cost_matches_refund() {
     let cost_schedule = CanisterCyclesCostSchedule::Normal;
     let subnet_size = SMALL_APP_SUBNET_MAX_SIZE;
-    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(subnet_size, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        subnet_size,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     let cam = CyclesAccountManagerBuilder::new()
         .with_subnet_type(SubnetType::Application)
         .build();

--- a/rs/determinism_test/src/setup.rs
+++ b/rs/determinism_test/src/setup.rs
@@ -1,7 +1,4 @@
-use ic_config::{
-    Config,
-    subnet_config::{SubnetConfig, SubnetSecurity},
-};
+use ic_config::{Config, subnet_config::SubnetConfig};
 use ic_execution_environment::ExecutionServices;
 use ic_interfaces::execution_environment::IngressHistoryReader;
 use ic_messaging::MessageRoutingImpl;
@@ -100,7 +97,7 @@ pub(crate) fn setup() -> (
     let subnet_id = subnet_test_id(1);
     let root_subnet_id = subnet_test_id(2);
     let (config, _) = Config::temp_config();
-    let subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(subnet_type);
     let replica_config = ReplicaConfig {
         node_id: NodeId::from(PrincipalId::new_node_test_id(27)),
         subnet_id,

--- a/rs/embedders/fuzz/src/wasm_executor.rs
+++ b/rs/embedders/fuzz/src/wasm_executor.rs
@@ -1,7 +1,8 @@
 use crate::ic_wasm::{ICWasmModule, get_system_api_type_for_wasm_method};
 use ic_config::{
-    embedders::Config as EmbeddersConfig, execution_environment::Config as HypervisorConfig,
-    subnet_config::SchedulerConfig,
+    embedders::Config as EmbeddersConfig,
+    execution_environment::Config as HypervisorConfig,
+    subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig},
 };
 use ic_cycles_account_manager::{CyclesAccountManagerSubnetConfig, ResourceSaturation};
 use ic_embedders::{
@@ -168,6 +169,7 @@ pub(crate) fn get_sandbox_safe_system_state(
         CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ),
     )
 }

--- a/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
+++ b/rs/embedders/src/wasmtime_embedder/system_api/sandbox_safe_system_state.rs
@@ -1424,10 +1424,14 @@ impl SandboxSafeSystemState {
                     .subnets()
                     .get(subnet_id)?
                     .cost_schedule;
-                Some((size, cost_schedule))
+                let reference_subnet_size =
+                    self.network_topology.get_reference_subnet_size(subnet_id)?;
+                Some((size, cost_schedule, reference_subnet_size))
             })
-            .max()
-            .map(|(size, cost_schedule)| CyclesAccountManagerSubnetConfig::new(size, cost_schedule))
+            .max_by_key(|&(size, cost_schedule, _)| (size, cost_schedule))
+            .map(|(size, cost_schedule, reference_subnet_size)| {
+                CyclesAccountManagerSubnetConfig::new(size, cost_schedule, reference_subnet_size)
+            })
     }
 }
 
@@ -1447,7 +1451,7 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
 
     use ic_base_types::NumSeconds;
-    use ic_config::subnet_config::{CyclesAccountManagerConfig, SchedulerConfig, SubnetSecurity};
+    use ic_config::subnet_config::{CyclesAccountManagerConfig, SchedulerConfig};
     use ic_cycles_account_manager::{CyclesAccountManager, CyclesAccountManagerSubnetConfig};
     use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
     use ic_registry_subnet_type::SubnetType;
@@ -1576,7 +1580,7 @@ mod tests {
                 NumInstructions::from(1_000_000_000),
                 SubnetType::Application,
                 subnet_test_id(0),
-                CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None),
+                CyclesAccountManagerConfig::application_subnet(),
             ),
             0,
             BTreeMap::new(),
@@ -1585,6 +1589,7 @@ mod tests {
             CyclesAccountManagerSubnetConfig::new(
                 SMALL_APP_SUBNET_MAX_SIZE,
                 CanisterCyclesCostSchedule::Normal,
+                ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE,
             ),
             SchedulerConfig::application_subnet().dirty_page_overhead,
             CanisterTimer::Inactive,

--- a/rs/embedders/src/wasmtime_embedder/tests.rs
+++ b/rs/embedders/src/wasmtime_embedder/tests.rs
@@ -19,7 +19,7 @@ use ic_base_types::NumSeconds;
 use ic_config::{
     embedders::Config as EmbeddersConfig,
     execution_environment::{Config as HypervisorConfig, LOG_MEMORY_STORE_FEATURE},
-    subnet_config::SchedulerConfig,
+    subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig},
 };
 use ic_cycles_account_manager::{CyclesAccountManagerSubnetConfig, ResourceSaturation};
 use ic_interfaces::execution_environment::{
@@ -82,6 +82,7 @@ fn test_wasmtime_system_api() {
         CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ),
     );
     let canister_current_memory_usage = NumBytes::from(0);

--- a/rs/embedders/tests/common/mod.rs
+++ b/rs/embedders/tests/common/mod.rs
@@ -1,7 +1,10 @@
 use std::rc::Rc;
 
 use ic_base_types::{CanisterId, NumBytes, SubnetId};
-use ic_config::{embedders::Config as EmbeddersConfig, subnet_config::SchedulerConfig};
+use ic_config::{
+    embedders::Config as EmbeddersConfig,
+    subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig},
+};
 use ic_cycles_account_manager::{
     CyclesAccountManager, CyclesAccountManagerSubnetConfig, ResourceSaturation,
 };
@@ -236,6 +239,7 @@ pub fn get_system_api(
         CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ),
     );
     SystemApiImpl::new(

--- a/rs/embedders/tests/sandbox_safe_system_state.rs
+++ b/rs/embedders/tests/sandbox_safe_system_state.rs
@@ -1,6 +1,6 @@
 use ic_base_types::{CanisterId, NumBytes, NumSeconds, SubnetId};
 use ic_config::execution_environment::SUBNET_CALLBACK_SOFT_LIMIT;
-use ic_config::subnet_config::SchedulerConfig;
+use ic_config::subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig};
 use ic_cycles_account_manager::CyclesAccountManagerSubnetConfig;
 use ic_embedders::wasmtime_embedder::system_api::SystemApiImpl;
 use ic_embedders::wasmtime_embedder::system_api::sandbox_safe_system_state::SandboxSafeSystemState;
@@ -47,6 +47,7 @@ fn push_output_request_fails_not_enough_cycles_for_request() {
     let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
         SMALL_APP_SUBNET_MAX_SIZE,
         CanisterCyclesCostSchedule::Normal,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
     );
 
     let request_payload_cost = cycles_account_manager
@@ -100,6 +101,7 @@ fn push_output_request_fails_not_enough_cycles_for_response() {
     let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
         SMALL_APP_SUBNET_MAX_SIZE,
         CanisterCyclesCostSchedule::Normal,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
     );
 
     request.prepayment_for_response_execution = cycles_account_manager
@@ -147,8 +149,11 @@ fn push_output_request_succeeds_with_enough_cycles() {
     let cycles_account_manager = CyclesAccountManagerBuilder::new()
         .with_max_num_instructions(MAX_NUM_INSTRUCTIONS)
         .build();
-    let subnet_cycles_config =
-        CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
 
     let system_state = SystemState::new_running_for_testing(
         canister_test_id(0),
@@ -198,8 +203,11 @@ fn correct_charging_source_canister_for_a_request() {
         .with_max_num_instructions(MAX_NUM_INSTRUCTIONS)
         .with_subnet_type(subnet_type)
         .build();
-    let subnet_cycles_config =
-        CyclesAccountManagerSubnetConfig::new(SMALL_APP_SUBNET_MAX_SIZE, cost_schedule);
+    let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+        SMALL_APP_SUBNET_MAX_SIZE,
+        cost_schedule,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
+    );
     let mut system_state = SystemState::new_running_for_testing(
         canister_test_id(0),
         user_test_id(1).get(),
@@ -443,6 +451,7 @@ fn is_controller_test() {
         CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ),
     );
 
@@ -521,6 +530,7 @@ fn test_inter_canister_call(
     let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
         SMALL_APP_SUBNET_MAX_SIZE,
         CanisterCyclesCostSchedule::Normal,
+        DEFAULT_REFERENCE_SUBNET_SIZE,
     );
     let mut sandbox_safe_system_state = SandboxSafeSystemState::new_for_testing(
         &system_state,

--- a/rs/embedders/tests/system_api.rs
+++ b/rs/embedders/tests/system_api.rs
@@ -1,5 +1,8 @@
 use ic_base_types::{NumSeconds, PrincipalIdBlobParseError};
-use ic_config::{embedders::Config as EmbeddersConfig, subnet_config::SchedulerConfig};
+use ic_config::{
+    embedders::Config as EmbeddersConfig,
+    subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig},
+};
 use ic_cycles_account_manager::{CyclesAccountManager, CyclesAccountManagerSubnetConfig};
 use ic_embedders::wasmtime_embedder::system_api::{
     ApiType, DefaultOutOfInstructionsHandler, MAX_ENV_VAR_NAME_SIZE, SystemApiImpl,
@@ -1440,6 +1443,7 @@ fn call_perform_not_enough_cycles_does_not_trap() {
         .xnet_call_performed_fee(CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ))
         .real()
         - Cycles::from(10_u128);
@@ -1576,6 +1580,7 @@ fn growing_wasm_memory_updates_subnet_available_memory() {
         CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ),
     );
     let mut api = SystemApiImpl::new(
@@ -1642,6 +1647,7 @@ fn push_output_request_respects_memory_limits() {
         CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ),
     );
     let own_canister_id = system_state.canister_id();
@@ -1738,6 +1744,7 @@ fn push_output_request_oversized_request_memory_limits() {
         CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ),
     );
     let own_canister_id = system_state.canister_id();
@@ -2153,6 +2160,7 @@ fn get_system_api_for_best_effort_response(
         CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ),
     );
 

--- a/rs/embedders/tests/wasmtime_random_memory_writes.rs
+++ b/rs/embedders/tests/wasmtime_random_memory_writes.rs
@@ -1,6 +1,7 @@
 use ic_config::{
-    embedders::Config as EmbeddersConfig, execution_environment::Config as HypervisorConfig,
-    subnet_config::SchedulerConfig,
+    embedders::Config as EmbeddersConfig,
+    execution_environment::Config as HypervisorConfig,
+    subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig},
 };
 use ic_cycles_account_manager::{CyclesAccountManagerSubnetConfig, ResourceSaturation};
 use ic_embedders::{
@@ -118,6 +119,7 @@ fn test_api_for_update(
         CyclesAccountManagerSubnetConfig::new(
             SMALL_APP_SUBNET_MAX_SIZE,
             CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
         ),
     );
     let canister_current_memory_usage = NumBytes::from(0);

--- a/rs/execution_environment/BUILD.bazel
+++ b/rs/execution_environment/BUILD.bazel
@@ -326,6 +326,7 @@ rust_ic_bench(
     deps = [
         # Keep sorted.
         ":execution_environment",
+        "//rs/config",
         "//rs/cycles_account_manager",
         "//rs/execution_environment/benches/lib:execution_environment_bench",
         "//rs/limits",
@@ -345,6 +346,7 @@ rust_ic_bench(
     deps = [
         # Keep sorted.
         ":execution_environment",
+        "//rs/config",
         "//rs/cycles_account_manager",
         "//rs/execution_environment/benches/lib:execution_environment_bench",
         "//rs/interfaces",
@@ -363,6 +365,7 @@ rust_ic_bench(
         # Keep sorted.
         ":execution_environment",
         "//packages/ic-error-types",
+        "//rs/config",
         "//rs/cycles_account_manager",
         "//rs/execution_environment/benches/lib:execution_environment_bench",
         "//rs/limits",
@@ -381,6 +384,7 @@ rust_ic_bench(
         # Keep sorted.
         ":execution_environment",
         "//packages/ic-error-types",
+        "//rs/config",
         "//rs/cycles_account_manager",
         "//rs/execution_environment/benches/lib:execution_environment_bench",
         "//rs/limits",

--- a/rs/execution_environment/benches/lib/src/common.rs
+++ b/rs/execution_environment/benches/lib/src/common.rs
@@ -7,7 +7,7 @@ use ic_config::execution_environment::{
     CANISTER_GUARANTEED_CALLBACK_QUOTA, Config, SUBNET_CALLBACK_SOFT_LIMIT,
     SUBNET_MEMORY_RESERVATION,
 };
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_cycles_account_manager::ResourceSaturation;
 use ic_embedders::wasmtime_embedder::system_api::{ExecutionParameters, InstructionLimits};
 use ic_error_types::RejectCode;
@@ -279,7 +279,7 @@ where
     let log = no_op_logger();
     let own_subnet_id = subnet_test_id(1);
     let own_subnet_type = SubnetType::Application;
-    let subnet_configs = SubnetConfig::new(own_subnet_type, SubnetSecurity::None);
+    let subnet_configs = SubnetConfig::new(own_subnet_type);
 
     let embedders_config = EmbeddersConfig {
         // Set up larger heap, of 8GB for the Wasm64 feature.

--- a/rs/execution_environment/benches/management_canister/canister_logging.rs
+++ b/rs/execution_environment/benches/management_canister/canister_logging.rs
@@ -4,7 +4,7 @@ use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_config::execution_environment::{Config as ExecutionConfig, LOG_MEMORY_STORE_FEATURE};
 use ic_config::flag_status::FlagStatus;
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_management_canister_types_private::{
     CanisterIdRecord, CanisterInstallMode, CanisterSettingsArgsBuilder, FetchCanisterLogsRequest,
     LogVisibilityV2, Payload,
@@ -70,7 +70,7 @@ fn setup_fetch_bench(
 
     let subnet_type = SubnetType::Application;
     let config = StateMachineConfig::new(
-        SubnetConfig::new(subnet_type, SubnetSecurity::None),
+        SubnetConfig::new(subnet_type),
         ExecutionConfig {
             replicated_inter_canister_log_fetch: FlagStatus::Enabled,
             log_memory_store_feature: LOG_MEMORY_STORE_FEATURE,

--- a/rs/execution_environment/benches/management_canister/utils.rs
+++ b/rs/execution_environment/benches/management_canister/utils.rs
@@ -1,6 +1,6 @@
 use candid::Decode;
 use ic_base_types::CanisterId;
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_config::{execution_environment::Config as HypervisorConfig, flag_status::FlagStatus};
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{
@@ -29,7 +29,7 @@ pub fn env() -> StateMachine {
     };
     StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
-            SubnetConfig::new(SubnetType::Application, SubnetSecurity::None),
+            SubnetConfig::new(SubnetType::Application),
             hypervisor_config,
         )))
         .with_checkpoints_enabled(false)

--- a/rs/execution_environment/benches/system_api/execute_inspect_message.rs
+++ b/rs/execution_environment/benches/system_api/execute_inspect_message.rs
@@ -13,6 +13,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use execution_environment_bench::{common, wat::*};
 use ic_execution_environment::execution::inspect_message;
 
+use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
 use ic_cycles_account_manager::CyclesAccountManagerSubnetConfig;
 use ic_execution_environment::{ExecutionEnvironment, IngressFilterMetrics};
 use ic_limits::SMALL_APP_SUBNET_MAX_SIZE;
@@ -135,6 +136,7 @@ pub fn execute_inspect_message_bench(c: &mut Criterion) {
                 CyclesAccountManagerSubnetConfig::new(
                     SMALL_APP_SUBNET_MAX_SIZE,
                     CanisterCyclesCostSchedule::Normal,
+                    DEFAULT_REFERENCE_SUBNET_SIZE,
                 ),
             );
             assert_eq!(result, Ok(()), "Error executing inspect message method");

--- a/rs/execution_environment/benches/system_api/execute_query.rs
+++ b/rs/execution_environment/benches/system_api/execute_query.rs
@@ -11,6 +11,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use execution_environment_bench::{common, wat::*};
+use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
 use ic_cycles_account_manager::CyclesAccountManagerSubnetConfig;
 use ic_execution_environment::{
     ExecutionEnvironment, NonReplicatedQueryKind, RoundLimits, as_num_instructions,
@@ -135,6 +136,7 @@ pub fn execute_query_bench(c: &mut Criterion) {
                 CyclesAccountManagerSubnetConfig::new(
                     SMALL_APP_SUBNET_MAX_SIZE,
                     CanisterCyclesCostSchedule::Normal,
+                    DEFAULT_REFERENCE_SUBNET_SIZE,
                 ),
             )
             .2;

--- a/rs/execution_environment/benches/system_api/execute_update.rs
+++ b/rs/execution_environment/benches/system_api/execute_update.rs
@@ -12,6 +12,7 @@
 use candid::{CandidType, Deserialize};
 use criterion::{Criterion, criterion_group, criterion_main};
 use execution_environment_bench::{common, wat::*};
+use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
 use ic_cycles_account_manager::CyclesAccountManagerSubnetConfig;
 use ic_error_types::ErrorCode;
 use ic_execution_environment::{
@@ -1217,6 +1218,7 @@ pub fn execute_update_bench(c: &mut Criterion) {
                 CyclesAccountManagerSubnetConfig::new(
                     SMALL_APP_SUBNET_MAX_SIZE,
                     CanisterCyclesCostSchedule::Normal,
+                    DEFAULT_REFERENCE_SUBNET_SIZE,
                 ),
             );
             let executed_instructions =

--- a/rs/execution_environment/benches/wasm_instructions/main.rs
+++ b/rs/execution_environment/benches/wasm_instructions/main.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use execution_environment_bench::common;
+use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
 use ic_cycles_account_manager::CyclesAccountManagerSubnetConfig;
 use ic_error_types::ErrorCode;
 use ic_execution_environment::{
@@ -79,6 +80,7 @@ pub fn wasm_instructions_bench(c: &mut Criterion) {
                 CyclesAccountManagerSubnetConfig::new(
                     SMALL_APP_SUBNET_MAX_SIZE,
                     CanisterCyclesCostSchedule::Normal,
+                    DEFAULT_REFERENCE_SUBNET_SIZE,
                 ),
             );
             // We do not validate the number of executed instructions.

--- a/rs/execution_environment/src/canister_manager/tests.rs
+++ b/rs/execution_environment/src/canister_manager/tests.rs
@@ -26,7 +26,7 @@ use ic_config::{
         SUBNET_CALLBACK_SOFT_LIMIT, SUBNET_MEMORY_RESERVATION, TEST_DEFAULT_LOG_MEMORY_USAGE,
     },
     flag_status::FlagStatus,
-    subnet_config::{CANISTER_CREATION_FEE, SchedulerConfig, SubnetSecurity},
+    subnet_config::{CANISTER_CREATION_FEE, SchedulerConfig},
 };
 use ic_cycles_account_manager::{CyclesAccountManager, ResourceSaturation};
 use ic_embedders::{
@@ -5833,8 +5833,7 @@ fn empty_canister_memory_usage() {
 /// This test checks that the wasm chunk store is accounted for then.
 #[test]
 fn chunk_store_counts_against_subnet_memory_in_initial_round_computation() {
-    let subnet_config =
-        ic_config::subnet_config::SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = ic_config::subnet_config::SubnetConfig::new(SubnetType::Application);
     // Initialize subnet with enough memory for one chunk but not two.
     assert_lt!(EMPTY_CANISTER_MEMORY_USAGE, wasm_chunk_store::chunk_size());
     let hypervisor_config = Config {

--- a/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
@@ -2,7 +2,7 @@ use crate::units::MIB;
 use assert_matches::assert_matches;
 use candid::{Decode, Encode, Reserved};
 use ic_base_types::NumBytes;
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_error_types::{ErrorCode, RejectCode, UserError};
 use ic_management_canister_types_private::{
     self as ic00, CanisterChange, CanisterChangeDetails, CanisterSettingsArgsBuilder,
@@ -1778,7 +1778,7 @@ fn take_canister_snapshot_charges_canister_cycles() {
     let caller_canister = canister_test_id(1);
 
     let subnet_type = SubnetType::Application;
-    let scheduler_config = SubnetConfig::new(subnet_type, SubnetSecurity::None).scheduler_config;
+    let scheduler_config = SubnetConfig::new(subnet_type).scheduler_config;
 
     let mut test = ExecutionTestBuilder::new()
         .with_own_subnet_id(own_subnet)
@@ -1839,7 +1839,7 @@ fn load_canister_snapshot_charges_canister_cycles() {
     let caller_canister = canister_test_id(1);
 
     let subnet_type = SubnetType::Application;
-    let scheduler_config = SubnetConfig::new(subnet_type, SubnetSecurity::None).scheduler_config;
+    let scheduler_config = SubnetConfig::new(subnet_type).scheduler_config;
 
     let mut test = ExecutionTestBuilder::new()
         .with_own_subnet_id(own_subnet)

--- a/rs/execution_environment/src/execution_environment/tests/canister_task.rs
+++ b/rs/execution_environment/src/execution_environment/tests/canister_task.rs
@@ -1,10 +1,7 @@
 use assert_matches::assert_matches;
 use ic_base_types::{NumSeconds, PrincipalId};
 use ic_config::embedders::DEFAULT_CREATE_EXECUTION_STATE_BASE_COST;
-use ic_config::{
-    execution_environment::Config as HypervisorConfig,
-    subnet_config::{SubnetConfig, SubnetSecurity},
-};
+use ic_config::{execution_environment::Config as HypervisorConfig, subnet_config::SubnetConfig};
 use ic_error_types::RejectCode;
 use ic_management_canister_types_private::{
     CanisterIdRecord, CanisterSettingsArgsBuilder, CanisterStatusType, CanisterUpgradeOptions,
@@ -1039,7 +1036,7 @@ where
     F: FnOnce(&StateMachine, CanisterId),
     G: FnOnce(&StateMachine, CanisterId),
 {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config.clone(),
         HypervisorConfig::default(),

--- a/rs/execution_environment/src/scheduler/test_utilities.rs
+++ b/rs/execution_environment/src/scheduler/test_utilities.rs
@@ -8,7 +8,7 @@ use ic_base_types::{CanisterId, NumBytes, PrincipalId, SubnetId};
 use ic_config::{
     embedders::Config as HypervisorConfig,
     flag_status::FlagStatus,
-    subnet_config::{SchedulerConfig, SubnetConfig, SubnetSecurity},
+    subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig, SubnetConfig},
 };
 use ic_cycles_account_manager::{CyclesAccountManager, CyclesAccountManagerSubnetConfig};
 use ic_embedders::{
@@ -832,8 +832,7 @@ pub(crate) struct SchedulerTestBuilder {
 impl Default for SchedulerTestBuilder {
     fn default() -> Self {
         let subnet_type = SubnetType::Application;
-        let scheduler_config =
-            SubnetConfig::new(subnet_type, SubnetSecurity::None).scheduler_config;
+        let scheduler_config = SubnetConfig::new(subnet_type).scheduler_config;
         let config = ic_config::execution_environment::Config::default();
         let mut hypervisor_config = config.embedders_config;
         hypervisor_config.create_execution_state_base_cost = NumInstructions::from(0);
@@ -872,8 +871,7 @@ impl SchedulerTestBuilder {
     }
 
     pub fn with_subnet_type(self, subnet_type: SubnetType) -> Self {
-        let scheduler_config =
-            SubnetConfig::new(subnet_type, SubnetSecurity::None).scheduler_config;
+        let scheduler_config = SubnetConfig::new(subnet_type).scheduler_config;
         Self {
             subnet_type,
             scheduler_config,
@@ -1006,7 +1004,7 @@ impl SchedulerTestBuilder {
         state.metadata.network_topology.nns_subnet_id = self.nns_subnet_id;
         state.metadata.batch_time = self.batch_time;
 
-        let mut subnet_config = SubnetConfig::new(self.subnet_type, SubnetSecurity::None);
+        let mut subnet_config = SubnetConfig::new(self.subnet_type);
         subnet_config.scheduler_config = self.scheduler_config.clone();
 
         for key_id in &self.master_public_key_ids {
@@ -1507,8 +1505,11 @@ impl TestWasmExecutorCore {
         let call_message_id = self.next_message_id();
         let response_message_id = self.next_message_id();
         let closure = WasmClosure::new(0, response_message_id.into());
-        let subnet_cycles_config =
-            CyclesAccountManagerSubnetConfig::new(self.subnet_size, system_state.cost_schedule());
+        let subnet_cycles_config = CyclesAccountManagerSubnetConfig::new(
+            self.subnet_size,
+            system_state.cost_schedule(),
+            DEFAULT_REFERENCE_SUBNET_SIZE,
+        );
         let prepayment_for_response_execution = self
             .cycles_account_manager
             .prepayment_for_response_execution(

--- a/rs/execution_environment/src/scheduler/tests/charging.rs
+++ b/rs/execution_environment/src/scheduler/tests/charging.rs
@@ -5,9 +5,7 @@ use super::super::test_utilities::{
 };
 use super::super::*;
 use super::zero_instruction_overhead_config;
-use ic_config::subnet_config::{
-    CyclesAccountManagerConfig, SchedulerConfig, SubnetConfig, SubnetSecurity,
-};
+use ic_config::subnet_config::{CyclesAccountManagerConfig, SchedulerConfig, SubnetConfig};
 use ic_management_canister_types_private::{
     Method, Payload as _, TakeCanisterSnapshotArgs, UninstallCodeArgs,
 };
@@ -33,7 +31,7 @@ fn only_charge_for_allocation_after_specified_duration() {
     // Just enough memory to cost us one cycle per second.
     let bytes_per_cycle = (1_u128 << 30)
         .checked_div(
-            CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None)
+            CyclesAccountManagerConfig::application_subnet()
                 .gib_storage_per_second_fee
                 .get(),
         )
@@ -434,7 +432,7 @@ fn snapshot_is_deleted_when_canister_is_out_of_cycles() {
     // Taking a snapshot of the canister will decrease the balance.
     // Increase the canister balance to be able to take a new snapshot.
     let subnet_type = SubnetType::Application;
-    let scheduler_config = SubnetConfig::new(subnet_type, SubnetSecurity::None).scheduler_config;
+    let scheduler_config = SubnetConfig::new(subnet_type).scheduler_config;
     let canister_snapshot_size = test.canister_state(canister_id).snapshot_size_bytes();
     let instructions = scheduler_config.canister_snapshot_baseline_instructions
         + NumInstructions::new(canister_snapshot_size.get());
@@ -547,7 +545,7 @@ fn snapshot_is_deleted_when_uninstalled_canister_is_out_of_cycles() {
     // Taking a snapshot of the canister will decrease the balance.
     // Increase the canister balance to be able to take a new snapshot.
     let subnet_type = SubnetType::Application;
-    let scheduler_config = SubnetConfig::new(subnet_type, SubnetSecurity::None).scheduler_config;
+    let scheduler_config = SubnetConfig::new(subnet_type).scheduler_config;
     let canister_snapshot_size = test.canister_state(canister_id).snapshot_size_bytes();
     let instructions = scheduler_config.canister_snapshot_baseline_instructions
         + NumInstructions::new(canister_snapshot_size.get());

--- a/rs/execution_environment/tests/backtraces.rs
+++ b/rs/execution_environment/tests/backtraces.rs
@@ -1,8 +1,5 @@
 use candid::Encode;
-use ic_config::{
-    execution_environment::Config as HypervisorConfig,
-    subnet_config::{SubnetConfig, SubnetSecurity},
-};
+use ic_config::{execution_environment::Config as HypervisorConfig, subnet_config::SubnetConfig};
 use ic_management_canister_types_private::{CanisterSettingsArgsBuilder, LogVisibilityV2};
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{ErrorCode, StateMachine, StateMachineBuilder, StateMachineConfig};
@@ -43,7 +40,7 @@ fn env_with_backtrace_canister_and_visibility(
 
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
-            SubnetConfig::new(subnet_type, SubnetSecurity::None),
+            SubnetConfig::new(subnet_type),
             hypervisor_config,
         )))
         .with_subnet_type(subnet_type)

--- a/rs/execution_environment/tests/canister_history.rs
+++ b/rs/execution_environment/tests/canister_history.rs
@@ -1,8 +1,5 @@
 use ic_base_types::{EnvironmentVariables, PrincipalId};
-use ic_config::{
-    execution_environment::Config as HypervisorConfig,
-    subnet_config::{SubnetConfig, SubnetSecurity},
-};
+use ic_config::{execution_environment::Config as HypervisorConfig, subnet_config::SubnetConfig};
 use ic_crypto_sha2::Sha256;
 use ic_error_types::{ErrorCode, UserError};
 use ic_management_canister_types_private::CanisterInstallMode::{Install, Reinstall, Upgrade};
@@ -99,7 +96,7 @@ fn test_setup(
     let test_canister_sha256 = hasher.finish();
 
     // set up StateMachine
-    let subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(subnet_type);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
         HypervisorConfig::default(),
@@ -630,7 +627,7 @@ fn canister_history_cleared_if_canister_out_of_cycles() {
     ));
 
     // drain cycle balance of test_canister to trigger code uninstall from system
-    let subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(subnet_type);
     let compute_percent_allocated_per_second_fee = subnet_config
         .cycles_account_manager_config
         .compute_percent_allocated_per_second_fee;
@@ -1204,7 +1201,7 @@ fn canister_history_load_snapshot_fails_incorrect_sender_version() {
 
 fn setup_with_application_subnet() -> StateMachine {
     StateMachine::new_with_config(StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::Application, SubnetSecurity::None),
+        SubnetConfig::new(SubnetType::Application),
         HypervisorConfig::default(),
     ))
 }

--- a/rs/execution_environment/tests/canister_logging.rs
+++ b/rs/execution_environment/tests/canister_logging.rs
@@ -4,7 +4,7 @@ use ic_config::execution_environment::{
     TEST_DEFAULT_LOG_MEMORY_USAGE,
 };
 use ic_config::flag_status::FlagStatus;
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_execution_environment::units::{KIB, MIB};
 use ic_interfaces_state_manager::{CertificationScope, StateManager};
 use ic_management_canister_types_private::{
@@ -94,7 +94,7 @@ fn readable_logs_without_backtraces(
 
 fn setup_env_with(replicated_inter_canister_log_fetch: FlagStatus) -> StateMachine {
     let subnet_type = SubnetType::Application;
-    let mut subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(subnet_type);
     subnet_config.scheduler_config.max_instructions_per_round = MAX_INSTRUCTIONS_PER_ROUND;
     subnet_config.scheduler_config.max_instructions_per_message = MAX_INSTRUCTIONS_PER_MESSAGE;
     subnet_config.scheduler_config.max_instructions_per_slice = MAX_INSTRUCTIONS_PER_SLICE;
@@ -149,7 +149,7 @@ fn setup_with_controller(controller: PrincipalId, wasm: Vec<u8>) -> (StateMachin
 
 fn restart_node(env: StateMachine) -> StateMachine {
     env.restart_node_with_config(StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::Application, SubnetSecurity::None),
+        SubnetConfig::new(SubnetType::Application),
         ExecutionConfig::default(),
     ))
 }
@@ -2768,7 +2768,7 @@ fn test_log_memory_store_upgrade_downgrade() {
     // and produce log entries that land in canister_log (legacy storage).
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
-            SubnetConfig::new(subnet_type, SubnetSecurity::None),
+            SubnetConfig::new(subnet_type),
             ExecutionConfig {
                 log_memory_store_feature: FlagStatus::Disabled,
                 ..Default::default()
@@ -2855,7 +2855,7 @@ fn test_log_memory_store_upgrade_downgrade() {
     // executes, migration has not run yet: is_migrated=false, is_allocated=false,
     // but fetch_canister_logs still works via the canister_log fallback.
     let env = env.restart_node_with_config(StateMachineConfig::new(
-        SubnetConfig::new(subnet_type, SubnetSecurity::None),
+        SubnetConfig::new(subnet_type),
         ExecutionConfig {
             log_memory_store_feature: FlagStatus::Enabled,
             ..Default::default()
@@ -2970,7 +2970,7 @@ fn test_log_memory_store_upgrade_downgrade() {
     // Step 5: Downgrade — restart with log_memory_store feature disabled.
     // The checkpoint still has migrated=true since it was saved after step 3.
     let env = env.restart_node_with_config(StateMachineConfig::new(
-        SubnetConfig::new(subnet_type, SubnetSecurity::None),
+        SubnetConfig::new(subnet_type),
         ExecutionConfig {
             log_memory_store_feature: FlagStatus::Disabled,
             ..Default::default()
@@ -3078,7 +3078,7 @@ fn test_log_memory_store_upgrade_downgrade() {
 fn test_canister_log_with_zero_log_memory_limit() {
     let subnet_type = SubnetType::Application;
     let config = StateMachineConfig::new(
-        SubnetConfig::new(subnet_type, SubnetSecurity::None),
+        SubnetConfig::new(subnet_type),
         ExecutionConfig {
             log_memory_store_feature: FlagStatus::Enabled,
             ..Default::default()
@@ -3179,10 +3179,9 @@ fn test_log_memory_store_deallocated_when_canister_out_of_cycles() {
     drop(state);
 
     // Advance time enough to drain the cycle balance given compute_allocation=1.
-    let compute_percent_allocated_per_second_fee =
-        SubnetConfig::new(SubnetType::Application, SubnetSecurity::None)
-            .cycles_account_manager_config
-            .compute_percent_allocated_per_second_fee;
+    let compute_percent_allocated_per_second_fee = SubnetConfig::new(SubnetType::Application)
+        .cycles_account_manager_config
+        .compute_percent_allocated_per_second_fee;
     let seconds_to_burn = env.cycle_balance(canister_id) as u64
         / compute_percent_allocated_per_second_fee.get() as u64;
     env.advance_time(Duration::from_secs(seconds_to_burn + 1));
@@ -3214,7 +3213,7 @@ fn test_log_memory_store_migration_filters_gap_records() {
 
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
-            SubnetConfig::new(subnet_type, SubnetSecurity::None),
+            SubnetConfig::new(subnet_type),
             ExecutionConfig {
                 log_memory_store_feature: FlagStatus::Disabled,
                 ..Default::default()
@@ -3275,7 +3274,7 @@ fn test_log_memory_store_migration_filters_gap_records() {
     }
 
     let env = env.restart_node_with_config(StateMachineConfig::new(
-        SubnetConfig::new(subnet_type, SubnetSecurity::None),
+        SubnetConfig::new(subnet_type),
         ExecutionConfig {
             log_memory_store_feature: FlagStatus::Enabled,
             ..Default::default()

--- a/rs/execution_environment/tests/canister_snapshots.rs
+++ b/rs/execution_environment/tests/canister_snapshots.rs
@@ -2,7 +2,7 @@ use candid::{Decode, Reserved};
 use canister_test::WasmResult;
 use ic_base_types::SnapshotId;
 use ic_config::execution_environment::Config as ExecutionConfig;
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_error_types::ErrorCode;
 use ic_management_canister_types_private::{
     CanisterChangeDetails, CanisterIdRecord, CanisterSettingsArgsBuilder,
@@ -812,7 +812,7 @@ const COUNTER_GROW_CANISTER_WAT: &str = r#"
 fn take_frozen_canister_snapshot_fails() {
     // Create application subnet `StateMachine`.
     let subnet_type = SubnetType::Application;
-    let subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(subnet_type);
     let execution_config = ExecutionConfig::default();
     let config = StateMachineConfig::new(subnet_config, execution_config);
     let env = StateMachineBuilder::new()
@@ -887,7 +887,7 @@ fn take_frozen_canister_snapshot_fails() {
 #[test]
 fn load_canister_snapshot_works_on_another_canister() {
     let subnet_type = SubnetType::Application;
-    let subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(subnet_type);
     let execution_config = ExecutionConfig::default();
     let config = StateMachineConfig::new(subnet_config, execution_config);
     let env = StateMachineBuilder::new()

--- a/rs/execution_environment/tests/canister_version.rs
+++ b/rs/execution_environment/tests/canister_version.rs
@@ -1,6 +1,6 @@
 use ic_base_types::PrincipalId;
 use ic_config::execution_environment;
-use ic_config::subnet_config::{SchedulerConfig, SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::{SchedulerConfig, SubnetConfig};
 use ic_management_canister_types_private::CanisterInstallMode::{Install, Reinstall, Upgrade};
 use ic_management_canister_types_private::{
     self as ic00, CanisterIdRecord, CanisterInstallMode, InstallCodeArgs, Method, Payload,
@@ -74,7 +74,7 @@ fn execute_ingress_with_dts(
 fn test(wat: &str, mode: CanisterInstallMode, dts_install: bool, dts_upgrade: bool) {
     let test_canister = wat::parse_str(wat).expect("invalid WAT");
 
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let subnet_config = SubnetConfig {
         scheduler_config: SchedulerConfig {
             max_instructions_per_install_code_slice: 100_000.into(),

--- a/rs/execution_environment/tests/dts.rs
+++ b/rs/execution_environment/tests/dts.rs
@@ -6,7 +6,7 @@ use ic_base_types::{CanisterId, PrincipalId};
 use ic_config::{
     embedders::Config as EmbeddersConfig,
     execution_environment::Config as HypervisorConfig,
-    subnet_config::{SchedulerConfig, SubnetConfig, SubnetSecurity},
+    subnet_config::{SchedulerConfig, SubnetConfig},
 };
 use ic_cycles_account_manager::IngressInductionCost;
 use ic_error_types::UserError;
@@ -97,7 +97,7 @@ fn dts_subnet_config(
     message_instruction_limit: NumInstructions,
     slice_instruction_limit: NumInstructions,
 ) -> SubnetConfig {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     SubnetConfig {
         scheduler_config: SchedulerConfig {
             max_instructions_per_install_code: message_instruction_limit,
@@ -146,8 +146,7 @@ fn dts_install_code_env(
     message_instruction_limit: NumInstructions,
     slice_instruction_limit: NumInstructions,
 ) -> (StateMachine, SubnetConfig) {
-    let default_app_subnet_config =
-        SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let default_app_subnet_config = SubnetConfig::new(SubnetType::Application);
     let subnet_config = SubnetConfig {
         scheduler_config: SchedulerConfig {
             max_instructions_per_install_code: message_instruction_limit,

--- a/rs/execution_environment/tests/execution_test.rs
+++ b/rs/execution_environment/tests/execution_test.rs
@@ -5,7 +5,7 @@ use ic_base_types::PrincipalId;
 use ic_config::{
     execution_environment::{Config as HypervisorConfig, DEFAULT_WASM_MEMORY_LIMIT},
     flag_status::FlagStatus,
-    subnet_config::{CyclesAccountManagerConfig, SubnetConfig, SubnetSecurity},
+    subnet_config::{CyclesAccountManagerConfig, SubnetConfig},
 };
 use ic_embedders::wasmtime_embedder::system_api::MAX_CALL_TIMEOUT_SECONDS;
 use ic_execution_environment::units::{GIB, MIB};
@@ -387,7 +387,7 @@ fn test_canister_stable_memory_upgrade_restart() {
 #[test]
 fn test_canister_out_of_cycles() {
     // Start a node with a config where all computation/storage is free.
-    let mut subnet_config = SubnetConfig::new(SubnetType::System, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(SubnetType::System);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config.clone(),
         HypervisorConfig::default(),
@@ -430,8 +430,7 @@ fn test_canister_out_of_cycles() {
     // We don't charge for allocation periodically, we advance the state machine
     // time to trigger allocation charging.
     let now = now
-        + 2 * CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None)
-            .duration_between_allocation_charges;
+        + 2 * CyclesAccountManagerConfig::application_subnet().duration_between_allocation_charges;
     env.set_time(now);
     env.tick();
 
@@ -446,7 +445,7 @@ fn test_canister_out_of_cycles() {
 
 #[test]
 fn canister_has_zero_balance_when_uninstalled_due_to_low_cycles() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let compute_percent_allocated_per_second_fee = subnet_config
         .cycles_account_manager_config
         .compute_percent_allocated_per_second_fee;
@@ -488,8 +487,7 @@ fn canister_has_zero_balance_when_uninstalled_due_to_low_cycles() {
     // Advance the statem machine time a bit more and confirm the canister is
     // still uninstalled.
     env.advance_time(
-        2 * CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None)
-            .duration_between_allocation_charges,
+        2 * CyclesAccountManagerConfig::application_subnet().duration_between_allocation_charges,
     );
     env.tick();
 
@@ -688,7 +686,7 @@ fn can_query_cycle_balance_and_top_up_canisters() {
 
 #[test]
 fn exceeding_memory_capacity_fails_when_memory_allocation_changes() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
         HypervisorConfig {
@@ -733,7 +731,7 @@ fn exceeding_memory_capacity_fails_when_memory_allocation_changes() {
 
 #[test]
 fn take_canister_snapshot_request_fails_when_subnet_capacity_reached() {
-    let mut subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(SubnetType::Application);
     subnet_config.scheduler_config.scheduler_cores = 2;
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
@@ -804,7 +802,7 @@ fn take_canister_snapshot_request_fails_when_subnet_capacity_reached() {
 
 #[test]
 fn load_canister_snapshot_request_fails_when_subnet_capacity_reached() {
-    let mut subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(SubnetType::Application);
     subnet_config.scheduler_config.scheduler_cores = 2;
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
@@ -889,7 +887,7 @@ fn load_canister_snapshot_request_fails_when_subnet_capacity_reached() {
 
 #[test]
 fn canister_snapshot_metrics_are_observed() {
-    let mut subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(SubnetType::Application);
     subnet_config.scheduler_config.scheduler_cores = 2;
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
@@ -1041,7 +1039,7 @@ fn assert_rejected(result: Result<WasmResult, UserError>) {
 
 #[test]
 fn exceeding_memory_capacity_fails_during_message_execution() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
         HypervisorConfig {
@@ -1093,7 +1091,7 @@ fn exceeding_memory_capacity_fails_during_message_execution() {
 
 #[test]
 fn subnet_memory_reservation_works() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let num_cores = subnet_config.scheduler_config.scheduler_cores as u64;
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
@@ -1149,7 +1147,7 @@ fn subnet_memory_reservation_works() {
 
 #[test]
 fn subnet_memory_reservation_scales_with_number_of_cores() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let num_cores = subnet_config.scheduler_config.scheduler_cores as u64;
     assert_lt!(1, num_cores);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
@@ -1210,7 +1208,7 @@ fn subnet_memory_reservation_scales_with_number_of_cores() {
 
 #[test]
 fn canister_with_reserved_balance_is_not_uninstalled_too_early() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
         HypervisorConfig::default(),
@@ -1268,7 +1266,7 @@ fn canister_with_reserved_balance_is_not_uninstalled_too_early() {
 
 #[test]
 fn canister_with_reserved_balance_is_not_frozen_too_early() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config,
         HypervisorConfig::default(),
@@ -1542,7 +1540,7 @@ fn test_consensus_queue_invariant_on_exceeding_heap_delta_limit() {
 
     let heap_delta_limit = 100 * MIB;
 
-    let mut subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(SubnetType::Application);
     subnet_config.scheduler_config.subnet_heap_delta_capacity = NumBytes::new(heap_delta_limit);
     let key_id = EcdsaKeyId::from_str("Secp256k1:valid_key").unwrap();
     let env = StateMachineBuilder::new()
@@ -1610,7 +1608,7 @@ fn test_consensus_queue_invariant_on_exceeding_heap_delta_limit() {
 #[test]
 fn heap_delta_initial_reserve_allows_round_executions_right_after_checkpoint() {
     fn setup(subnet_heap_delta_capacity: u64, heap_delta_initial_reserve: u64) -> StateMachine {
-        let mut subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+        let mut subnet_config = SubnetConfig::new(SubnetType::Application);
         subnet_config.scheduler_config.subnet_heap_delta_capacity =
             subnet_heap_delta_capacity.into();
         subnet_config.scheduler_config.heap_delta_initial_reserve =
@@ -1938,7 +1936,7 @@ fn helper_best_effort_responses(
     timeout_seconds: Option<u32>,
     expected_deadline_seconds: u32,
 ) {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
 
     let env = StateMachineBuilder::new()
         .with_time(Time::from_secs_since_unix_epoch(start_time_seconds as u64).unwrap())
@@ -2615,7 +2613,7 @@ fn failed_stable_memory_grow_cost_and_time_multiple_canisters() {
 #[test]
 fn test_canister_liquid_cycle_balance() {
     let env = StateMachine::new_with_config(StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::Application, SubnetSecurity::None),
+        SubnetConfig::new(SubnetType::Application),
         HypervisorConfig::default(),
     ));
 
@@ -2689,7 +2687,7 @@ fn test_canister_liquid_cycle_balance() {
 #[test]
 fn large_ipc_call_fails() {
     let wasm = canister_test::Project::cargo_bin_maybe_from_env("call_loop_canister", &[]);
-    let subnet_config = SubnetConfig::new(SubnetType::System, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::System);
     let instruction_limit = subnet_config.scheduler_config.max_instructions_per_message;
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
@@ -2775,7 +2773,7 @@ fn canister_status_count(env: &StateMachine) -> u64 {
 
 #[test]
 fn canister_status_via_query_call_by_controller_succeeds() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
             subnet_config,
@@ -2802,7 +2800,7 @@ fn canister_status_via_query_call_by_controller_succeeds() {
 
 #[test]
 fn canister_status_via_query_call_by_subnet_admin_succeeds() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let subnet_admin = user_test_id(100);
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
@@ -2836,7 +2834,7 @@ fn canister_status_via_query_call_by_subnet_admin_succeeds() {
 
 #[test]
 fn canister_status_via_query_call_by_neither_controller_nor_subnet_admin_fails() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let subnet_admin = user_test_id(100);
     let test_user = user_test_id(101);
     let env = StateMachineBuilder::new()
@@ -2885,7 +2883,7 @@ fn maximum_state_size() {
         maximum_state_size: Some(maximum_state_size),
         maximum_state_delta: None,
     };
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let hypervisor_config = HypervisorConfig {
         subnet_memory_reservation: NumBytes::new(0),
         ..Default::default()
@@ -2923,7 +2921,7 @@ fn maximum_state_delta() {
         maximum_state_size: None,
         maximum_state_delta: Some(maximum_state_delta),
     };
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     // We disable per-canister rate-limiting of heap delta to simplify the test.
     let hypervisor_config = HypervisorConfig {
         rate_limiting_of_heap_delta: FlagStatus::Disabled,
@@ -3147,7 +3145,7 @@ fn canister_metrics_count(env: &StateMachine) -> u64 {
 
 #[test]
 fn canister_metrics_via_query_call_by_controller_succeeds() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
             subnet_config,
@@ -3174,7 +3172,7 @@ fn canister_metrics_via_query_call_by_controller_succeeds() {
 
 #[test]
 fn canister_metrics_via_query_call_by_subnet_admin_succeeds() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let subnet_admin = user_test_id(100);
     let env = StateMachineBuilder::new()
         .with_config(Some(StateMachineConfig::new(
@@ -3208,7 +3206,7 @@ fn canister_metrics_via_query_call_by_subnet_admin_succeeds() {
 
 #[test]
 fn canister_metrics_via_query_call_by_neither_controller_nor_subnet_admin_fails() {
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let subnet_admin = user_test_id(100);
     let test_user = user_test_id(101);
     let env = StateMachineBuilder::new()

--- a/rs/execution_environment/tests/storage_reservation.rs
+++ b/rs/execution_environment/tests/storage_reservation.rs
@@ -1,5 +1,5 @@
 use ic_config::execution_environment::Config as ExecutionConfig;
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_error_types::ErrorCode;
 use ic_management_canister_types_private::CanisterSettingsArgsBuilder;
 use ic_registry_subnet_type::SubnetType;
@@ -20,7 +20,7 @@ fn reserved_cycles_memory_grow_to_full_capacity<F>(
 {
     // Create application subnet `StateMachine`.
     let subnet_type = SubnetType::Application;
-    let mut subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(subnet_type);
     // 2 cores, so we don't have to retry every allocation 4 times (due to the
     // memory being split 4 ways).
     subnet_config.scheduler_config.scheduler_cores = 2;

--- a/rs/execution_environment/tests/subnet_size_test.rs
+++ b/rs/execution_environment/tests/subnet_size_test.rs
@@ -1488,8 +1488,8 @@ fn test_sev_reference_subnet_size_reflected_in_execution_costs() {
         / SEV_REFERENCE_SUBNET_SIZE as u128;
     assert!(
         cost_sev.get().abs_diff(expected) <= 1,
-        "SEV cost ({}) should be ~DEFAULT_REFERENCE_SUBNET_SIZE/SEV_REFERENCE_SUBNET_SIZE times \
-         non-SEV cost ({expected}), but differ by more than 1 (integer rounding)",
+        "SEV cost ({}) should be ~DEFAULT_REFERENCE_SUBNET_SIZE/SEV_REFERENCE_SUBNET_SIZE times non-SEV cost ({}), i.e. expected ~{expected}, but differs by more than 1 (integer rounding)",
         cost_sev.get(),
+        cost_non_sev.get(),
     );
 }

--- a/rs/execution_environment/tests/subnet_size_test.rs
+++ b/rs/execution_environment/tests/subnet_size_test.rs
@@ -1423,8 +1423,7 @@ fn test_subnet_size_system_subnet_has_zero_cost() {
 /// given `SubnetFeatures` and measures the execution cost.
 ///
 /// The `features` parameter sets `sev_enabled` in the registry subnet record;
-/// `execute_round` will then call `set_reference_subnet_size` from the registry
-/// value at the start of each round.
+/// the reference subnet size is then derived via `NetworkTopology`.
 fn simulate_execute_message_cost_with_registry_features(
     subnet_size: usize,
     features: SubnetFeatures,
@@ -1451,8 +1450,8 @@ fn simulate_execute_message_cost_with_registry_features(
     Cycles::from(balance_before - balance_after)
 }
 
-/// Tests that the reference subnet size read from the registry at the start of
-/// each `execute_round` is correctly reflected in the execution cycle costs.
+/// Tests that the reference subnet size derived from the registry via `NetworkTopology`
+/// is correctly reflected in the execution cycle costs.
 ///
 /// For an Application subnet with `DEFAULT_REFERENCE_SUBNET_SIZE` nodes (13):
 /// * without SEV: cost = base × 13 / 13 = base
@@ -1460,7 +1459,7 @@ fn simulate_execute_message_cost_with_registry_features(
 ///   making costs higher for the same actual subnet)
 ///
 /// Only the registry-driven `sev_enabled` flag differentiates the two cases,
-/// confirming the runtime update path through `set_reference_subnet_size`.
+/// confirming the runtime update path through `NetworkTopology`.
 #[test]
 fn test_sev_reference_subnet_size_reflected_in_execution_costs() {
     let subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
@@ -1474,8 +1473,7 @@ fn test_sev_reference_subnet_size_reflected_in_execution_costs() {
         },
     );
 
-    // SEV: registry sets reference_subnet_size = SEV = 7 via set_reference_subnet_size.
-    // cost = base * 13 / 7 > cost_non_sev.
+    // SEV: reference_subnet_size = SEV = 7, cost = base * 13 / 7 > cost_non_sev.
     let cost_sev = simulate_execute_message_cost_with_registry_features(
         subnet_size,
         SubnetFeatures {

--- a/rs/execution_environment/tests/subnet_size_test.rs
+++ b/rs/execution_environment/tests/subnet_size_test.rs
@@ -2,7 +2,7 @@ use candid::{Decode, Encode};
 use ic_config::{
     embedders::Config as EmbeddersConfig,
     execution_environment::Config as HypervisorConfig,
-    subnet_config::{CyclesAccountManagerConfig, SubnetConfig, SubnetSecurity},
+    subnet_config::{CyclesAccountManagerConfig, SubnetConfig},
 };
 use ic_management_canister_types_private::{
     self as ic00, BoundedHttpHeaders, CanisterHttpRequestArgs, CanisterIdRecord,
@@ -27,6 +27,7 @@ use wirm::wasmparser;
 const B: u64 = 1_000_000_000;
 
 const DEFAULT_REFERENCE_SUBNET_SIZE: usize = 13;
+const SEV_REFERENCE_SUBNET_SIZE: usize = 7;
 const TEST_SUBNET_SIZES: [usize; 3] = [4, 13, 34];
 
 pub const ECDSA_SIGNATURE_FEE: Cycles = Cycles::new(10 * B as u128);
@@ -360,7 +361,7 @@ fn apply_filter(
 /// Create a `SubnetConfig` with a redacted `CyclesAccountManagerConfig` to have only the fees
 /// for specific operation.
 fn filtered_subnet_config(subnet_type: SubnetType, filter: KeepFeesFilter) -> SubnetConfig {
-    let mut subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(subnet_type);
     subnet_config.cycles_account_manager_config =
         apply_filter(subnet_config.cycles_account_manager_config, filter);
 
@@ -676,7 +677,7 @@ fn calculate_create_canister_cost(
     config: &CyclesAccountManagerConfig,
     subnet_size: usize,
 ) -> Cycles {
-    scale_cost(config, config.canister_creation_fee, subnet_size)
+    scale_cost(config.canister_creation_fee, subnet_size)
 }
 
 fn calculate_xnet_call_cost(
@@ -687,13 +688,11 @@ fn calculate_xnet_call_cost(
 ) -> Cycles {
     // Prepayed cost.
     let prepayment_for_response_transmission = scale_cost(
-        config,
         config.xnet_byte_transmission_fee * MAX_INTER_CANISTER_PAYLOAD_IN_BYTES.get(),
         subnet_size,
     );
     let prepayment_for_response_execution = Cycles::new(0);
     let prepayed = scale_cost(
-        config,
         config.xnet_call_fee + config.xnet_byte_transmission_fee * request_size.get(),
         subnet_size,
     ) + prepayment_for_response_transmission
@@ -701,7 +700,6 @@ fn calculate_xnet_call_cost(
 
     // Actually transmitted cost and refund.
     let transmission_cost = scale_cost(
-        config,
         config.xnet_byte_transmission_fee * response_size.get(),
         subnet_size,
     );
@@ -733,7 +731,7 @@ fn calculate_sign_with_ecdsa_cost(
     config: &CyclesAccountManagerConfig,
     subnet_size: usize,
 ) -> Cycles {
-    scale_cost(config, config.ecdsa_signature_fee, subnet_size)
+    scale_cost(config.ecdsa_signature_fee, subnet_size)
 }
 
 fn trillion_cycles(value: f64) -> Cycles {
@@ -758,7 +756,6 @@ fn get_cycles_account_manager_config(subnet_type: SubnetType) -> CyclesAccountMa
     const WASM64_INSTRUCTION_COST_MULTIPLIER: u128 = 2;
     match subnet_type {
         SubnetType::System => CyclesAccountManagerConfig {
-            reference_subnet_size: DEFAULT_REFERENCE_SUBNET_SIZE,
             canister_creation_fee: Cycles::new(0),
             compute_percent_allocated_per_second_fee: Cycles::new(0),
             update_message_execution_fee: Cycles::new(0),
@@ -791,7 +788,6 @@ fn get_cycles_account_manager_config(subnet_type: SubnetType) -> CyclesAccountMa
         },
         SubnetType::Application | SubnetType::VerifiedApplication | SubnetType::CloudEngine => {
             CyclesAccountManagerConfig {
-                reference_subnet_size: DEFAULT_REFERENCE_SUBNET_SIZE,
                 canister_creation_fee: Cycles::new(500_000_000_000),
                 compute_percent_allocated_per_second_fee: Cycles::new(10_000_000),
 
@@ -822,10 +818,8 @@ fn get_cycles_account_manager_config(subnet_type: SubnetType) -> CyclesAccountMa
                 http_request_per_byte_fee: Cycles::new(400),
                 http_response_per_byte_fee: Cycles::new(800),
                 max_storage_reservation_period: Duration::from_secs(0),
-                default_reserved_balance_limit: CyclesAccountManagerConfig::application_subnet(
-                    SubnetSecurity::None,
-                )
-                .default_reserved_balance_limit,
+                default_reserved_balance_limit: CyclesAccountManagerConfig::application_subnet()
+                    .default_reserved_balance_limit,
                 fetch_canister_logs_base_fee: Cycles::new(5_000_000),
                 fetch_canister_logs_per_byte_fee: Cycles::new(80),
             }
@@ -833,8 +827,8 @@ fn get_cycles_account_manager_config(subnet_type: SubnetType) -> CyclesAccountMa
     }
 }
 
-fn scale_cost(config: &CyclesAccountManagerConfig, cycles: Cycles, subnet_size: usize) -> Cycles {
-    (cycles * subnet_size) / config.reference_subnet_size
+fn scale_cost(cycles: Cycles, subnet_size: usize) -> Cycles {
+    (cycles * subnet_size) / DEFAULT_REFERENCE_SUBNET_SIZE
 }
 
 fn memory_cost(
@@ -850,7 +844,7 @@ fn memory_cost(
             * duration.as_secs() as u128)
             / one_gib,
     );
-    scale_cost(config, cycles, subnet_size)
+    scale_cost(cycles, subnet_size)
 }
 
 fn compute_allocation_cost(
@@ -862,7 +856,7 @@ fn compute_allocation_cost(
     let cycles = config.compute_percent_allocated_per_second_fee
         * duration.as_secs()
         * compute_allocation.as_percent();
-    scale_cost(config, cycles, subnet_size)
+    scale_cost(cycles, subnet_size)
 }
 
 fn canister_base_cost(
@@ -873,7 +867,7 @@ fn canister_base_cost(
 ) -> Cycles {
     if bytes.get() > 0 {
         let cycles = config.base_per_second_fee * duration.as_secs() as u128;
-        scale_cost(config, cycles, subnet_size)
+        scale_cost(cycles, subnet_size)
     } else {
         Cycles::zero()
     }
@@ -925,7 +919,6 @@ fn prepay_execution_cycles(
     subnet_size: usize,
 ) -> Cycles {
     scale_cost(
-        config,
         config.update_message_execution_fee
             + convert_instructions_to_cycles(config, num_instructions),
         subnet_size,
@@ -943,7 +936,7 @@ fn refund_unused_execution_cycles(
         std::cmp::min(num_instructions, num_instructions_initially_charged);
     let cycles = convert_instructions_to_cycles(config, num_instructions_to_refund);
 
-    scale_cost(config, cycles, subnet_size).min(prepaid_execution_cycles)
+    scale_cost(cycles, subnet_size).min(prepaid_execution_cycles)
 }
 
 fn calculate_execution_cost(
@@ -972,7 +965,6 @@ fn ingress_induction_cost_from_bytes(
     subnet_size: usize,
 ) -> Cycles {
     scale_cost(
-        config,
         config.ingress_message_reception_fee + config.ingress_byte_reception_fee * bytes.get(),
         subnet_size,
     )
@@ -1024,7 +1016,7 @@ fn test_subnet_size_one_gib_storage_zero_compute_allocation_cost() {
     let compute_allocation = ComputeAllocation::zero();
     let subnet_type = SubnetType::Application;
     let config = get_cycles_account_manager_config(subnet_type);
-    let reference_subnet_size = config.reference_subnet_size;
+    let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
     let reference_cost =
         calculate_one_gib_per_second_cost(&config, reference_subnet_size, compute_allocation);
 
@@ -1055,7 +1047,7 @@ fn test_subnet_size_one_gib_storage_non_zero_compute_allocation_cost() {
     ] {
         let subnet_type = SubnetType::Application;
         let config = get_cycles_account_manager_config(subnet_type);
-        let reference_subnet_size = config.reference_subnet_size;
+        let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
         let reference_cost =
             calculate_one_gib_per_second_cost(&config, reference_subnet_size, compute_allocation);
 
@@ -1086,7 +1078,7 @@ fn test_subnet_size_one_gib_storage_non_zero_compute_allocation_cost() {
 fn test_subnet_size_execute_install_code_cost() {
     let subnet_type = SubnetType::Application;
     let config = get_cycles_account_manager_config(subnet_type);
-    let reference_subnet_size = config.reference_subnet_size;
+    let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
     let reference_cost = calculate_execution_cost(
         &config,
         NumInstructions::from(TEST_CANISTER_INSTALL_EXECUTION_INSTRUCTIONS),
@@ -1114,7 +1106,7 @@ fn test_subnet_size_execute_install_code_cost() {
 fn test_subnet_size_ingress_induction_cost() {
     let subnet_type = SubnetType::Application;
     let config = get_cycles_account_manager_config(subnet_type);
-    let reference_subnet_size = config.reference_subnet_size;
+    let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
     let signed_ingress = SignedIngressBuilder::new()
         .method_name("inc")
         .nonce(3)
@@ -1142,7 +1134,7 @@ fn test_subnet_size_ingress_induction_cost() {
 fn test_subnet_size_execute_message_cost() {
     let subnet_type = SubnetType::Application;
     let config = get_cycles_account_manager_config(subnet_type);
-    let reference_subnet_size = config.reference_subnet_size;
+    let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
     // The `inc` method writes to the heap (first access), so the deterministic
     // memory tracker charges an extra 32 instructions in-band (accessed + dirty
     // for 1 Wasm page) when enabled.
@@ -1180,7 +1172,7 @@ fn test_subnet_size_execute_message_cost() {
 fn test_subnet_size_execute_heartbeat_cost() {
     let subnet_type = SubnetType::Application;
     let config = get_cycles_account_manager_config(subnet_type);
-    let reference_subnet_size = config.reference_subnet_size;
+    let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
     let reference_cost = calculate_execution_cost(
         &config,
         NumInstructions::from(TEST_HEARTBEAT_CANISTER_EXECUTE_HEARTBEAT_INSTRUCTIONS),
@@ -1241,7 +1233,7 @@ fn test_subnet_size_sign_with_ecdsa_non_zero_cost() {
 
     for subnet_type in [SubnetType::Application, SubnetType::System] {
         let config = get_cycles_account_manager_config(subnet_type);
-        let reference_subnet_size = config.reference_subnet_size;
+        let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
         let reference_cost = calculate_sign_with_ecdsa_cost(&config, reference_subnet_size);
 
         // Check default cost.
@@ -1289,7 +1281,7 @@ fn test_subnet_size_sign_with_ecdsa_zero_cost() {
 fn test_subnet_size_http_request_cost() {
     let subnet_type = SubnetType::Application;
     let config = get_cycles_account_manager_config(subnet_type);
-    let reference_subnet_size = config.reference_subnet_size;
+    let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
     let reference_cost =
         calculate_http_request_cost(&config, NumBytes::new(17), None, reference_subnet_size);
 
@@ -1314,7 +1306,7 @@ fn test_subnet_size_http_request_cost() {
 fn test_subnet_size_xnet_call_cost() {
     let subnet_type = SubnetType::Application;
     let config = get_cycles_account_manager_config(subnet_type);
-    let reference_subnet_size = config.reference_subnet_size;
+    let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
     let reference_cost = calculate_xnet_call_cost(
         &config,
         NumBytes::new(25),
@@ -1343,7 +1335,7 @@ fn test_subnet_size_xnet_call_cost() {
 fn test_subnet_size_create_canister_cost() {
     let subnet_type = SubnetType::Application;
     let config = get_cycles_account_manager_config(subnet_type);
-    let reference_subnet_size = config.reference_subnet_size;
+    let reference_subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
     let reference_cost = calculate_create_canister_cost(&config, reference_subnet_size);
 
     // Check default cost.
@@ -1425,4 +1417,79 @@ fn test_subnet_size_system_subnet_has_zero_cost() {
             "subnet_size={subnet_size}"
         );
     }
+}
+
+/// Simulates an ingress message execution on an Application subnet with the
+/// given `SubnetFeatures` and measures the execution cost.
+///
+/// The `features` parameter sets `sev_enabled` in the registry subnet record;
+/// `execute_round` will then call `set_reference_subnet_size` from the registry
+/// value at the start of each round.
+fn simulate_execute_message_cost_with_registry_features(
+    subnet_size: usize,
+    features: SubnetFeatures,
+) -> Cycles {
+    let env = StateMachineBuilder::new()
+        .with_subnet_type(SubnetType::Application)
+        .with_subnet_size(subnet_size)
+        .with_features(features)
+        .with_config(Some(StateMachineConfig::new(
+            filtered_subnet_config(SubnetType::Application, KeepFeesFilter::Execution),
+            HypervisorConfig::default(),
+        )))
+        .build();
+    let canister_id = create_canister_with_cycles_install_wasm(
+        &env,
+        DEFAULT_CYCLES_PER_NODE * subnet_size,
+        wat::parse_str(TEST_CANISTER).expect("invalid WAT"),
+    );
+
+    let balance_before = env.cycle_balance(canister_id);
+    env.execute_ingress(canister_id, "inc", vec![]).unwrap();
+    let balance_after = env.cycle_balance(canister_id);
+
+    Cycles::from(balance_before - balance_after)
+}
+
+/// Tests that the reference subnet size read from the registry at the start of
+/// each `execute_round` is correctly reflected in the execution cycle costs.
+///
+/// For an Application subnet with `DEFAULT_REFERENCE_SUBNET_SIZE` nodes (13):
+/// * without SEV: cost = base × 13 / 13 = base
+/// * with SEV:    cost = base × 13 / 7  (SEV lowers the reference size to 7,
+///   making costs higher for the same actual subnet)
+///
+/// Only the registry-driven `sev_enabled` flag differentiates the two cases,
+/// confirming the runtime update path through `set_reference_subnet_size`.
+#[test]
+fn test_sev_reference_subnet_size_reflected_in_execution_costs() {
+    let subnet_size = DEFAULT_REFERENCE_SUBNET_SIZE;
+
+    // Non-SEV: reference_subnet_size = DEFAULT = 13, cost = base * 13 / 13 = base.
+    let cost_non_sev = simulate_execute_message_cost_with_registry_features(
+        subnet_size,
+        SubnetFeatures {
+            sev_enabled: false,
+            ..Default::default()
+        },
+    );
+
+    // SEV: registry sets reference_subnet_size = SEV = 7 via set_reference_subnet_size.
+    // cost = base * 13 / 7 > cost_non_sev.
+    let cost_sev = simulate_execute_message_cost_with_registry_features(
+        subnet_size,
+        SubnetFeatures {
+            sev_enabled: true,
+            ..Default::default()
+        },
+    );
+
+    let expected = cost_non_sev.get() * DEFAULT_REFERENCE_SUBNET_SIZE as u128
+        / SEV_REFERENCE_SUBNET_SIZE as u128;
+    assert!(
+        cost_sev.get().abs_diff(expected) <= 1,
+        "SEV cost ({}) should be ~DEFAULT_REFERENCE_SUBNET_SIZE/SEV_REFERENCE_SUBNET_SIZE times \
+         non-SEV cost ({expected}), but differ by more than 1 (integer rounding)",
+        cost_sev.get(),
+    );
 }

--- a/rs/execution_environment/tools/src/icp_config.rs
+++ b/rs/execution_environment/tools/src/icp_config.rs
@@ -2,7 +2,7 @@ use clap::{Arg, ArgMatches};
 use eyre::Result;
 use ic_config::{
     embedders, execution_environment,
-    subnet_config::{CyclesAccountManagerConfig, SchedulerConfig, SubnetSecurity},
+    subnet_config::{CyclesAccountManagerConfig, SchedulerConfig},
 };
 use serde_json::json;
 
@@ -50,14 +50,14 @@ fn icp_config_as_json(version: &str) -> serde_json::Value {
     let execution = execution_environment::Config::default();
 
     let application = json_config(
-        &CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None),
+        &CyclesAccountManagerConfig::application_subnet(),
         &SchedulerConfig::application_subnet(),
         &embedder,
         &execution,
     );
 
     let verified_application = json_config(
-        &CyclesAccountManagerConfig::verified_application_subnet(SubnetSecurity::None),
+        &CyclesAccountManagerConfig::verified_application_subnet(),
         &SchedulerConfig::verified_application_subnet(),
         &embedder,
         &execution,

--- a/rs/ingress_manager/src/ingress_selector.rs
+++ b/rs/ingress_manager/src/ingress_selector.rs
@@ -766,6 +766,7 @@ pub(crate) mod tests {
     };
     use assert_matches::assert_matches;
     use ic_artifact_pool::ingress_pool::IngressPoolImpl;
+    use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
     use ic_crypto_temp_crypto::temp_crypto_component_with_fake_registry;
     use ic_cycles_account_manager::CyclesAccountManagerSubnetConfig;
     use ic_interfaces::{
@@ -1614,6 +1615,7 @@ pub(crate) mod tests {
                                         CyclesAccountManagerSubnetConfig::new(
                                             SMALL_APP_SUBNET_MAX_SIZE,
                                             CanisterCyclesCostSchedule::Normal,
+                                            DEFAULT_REFERENCE_SUBNET_SIZE,
                                         ),
                                     )
                                     .cost(),

--- a/rs/ledger_suite/tests/sm-tests/src/lib.rs
+++ b/rs/ledger_suite/tests/sm-tests/src/lib.rs
@@ -3,10 +3,7 @@ use candid::{CandidType, Decode, Encode, Int, Nat, Principal};
 use ic_agent::identity::{BasicIdentity, Identity};
 use ic_base_types::CanisterId;
 use ic_base_types::PrincipalId;
-use ic_config::{
-    execution_environment::Config as HypervisorConfig,
-    subnet_config::{SubnetConfig, SubnetSecurity},
-};
+use ic_config::{execution_environment::Config as HypervisorConfig, subnet_config::SubnetConfig};
 use ic_error_types::UserError;
 use ic_http_types::{HttpRequest, HttpResponse};
 use ic_icrc1::blocks::{encoded_block_to_generic_block, generic_block_to_encoded_block};
@@ -4394,7 +4391,7 @@ pub fn test_cycles_for_archive_creation_default_spawns_archive<T>(
     let account = Account::from(PrincipalId::new_user_test_id(1).0);
     let initial_balances = vec![(account, 100_000_000_u64)];
 
-    let subnet_config = SubnetConfig::new(SubnetType::Application, SubnetSecurity::None);
+    let subnet_config = SubnetConfig::new(SubnetType::Application);
     let env = StateMachine::new_with_config(StateMachineConfig::new(
         subnet_config.clone(),
         HypervisorConfig::default(),
@@ -5080,7 +5077,7 @@ pub mod archiving {
         }
 
         // Install a ledger with a lot of initial balances
-        let mut subnet_config = SubnetConfig::new(SubnetType::System, SubnetSecurity::None);
+        let mut subnet_config = SubnetConfig::new(SubnetType::System);
         // Set max_instructions_per_round to max(max_instructions_per_slice, max_instructions_per_install_code_slice)
         // to ensure that at most one canister message can be executed per round.
         subnet_config.scheduler_config.max_instructions_per_round = subnet_config

--- a/rs/messaging/tests/common/mod.rs
+++ b/rs/messaging/tests/common/mod.rs
@@ -1,9 +1,7 @@
 use canister_test::Project;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_config::execution_environment::Config as HypervisorConfig;
-use ic_config::subnet_config::{
-    CyclesAccountManagerConfig, SchedulerConfig, SubnetConfig, SubnetSecurity,
-};
+use ic_config::subnet_config::{CyclesAccountManagerConfig, SchedulerConfig, SubnetConfig};
 use ic_management_canister_types_private::CanisterStatusType;
 use ic_replicated_state::testing::CanisterQueuesTesting;
 use ic_state_machine_tests::{StateMachine, StateMachineConfig, SubmitIngressError, UserError};
@@ -241,9 +239,7 @@ impl TestSubnetConfig {
                     max_instructions_per_install_code_slice: self.max_instructions_per_round.into(),
                     ..SchedulerConfig::application_subnet()
                 },
-                cycles_account_manager_config: CyclesAccountManagerConfig::application_subnet(
-                    SubnetSecurity::None,
-                ),
+                cycles_account_manager_config: CyclesAccountManagerConfig::application_subnet(),
             },
             HypervisorConfig {
                 guaranteed_response_message_memory_capacity: self

--- a/rs/nervous_system/long_message/tests/test_message_breaks.rs
+++ b/rs/nervous_system/long_message/tests/test_message_breaks.rs
@@ -1,6 +1,6 @@
 use candid::CandidType;
 use canister_test::Project;
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_nns_test_utils::state_test_helpers::{create_canister, update_with_sender};
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
@@ -16,7 +16,7 @@ struct BreakMessageParams {
 
 fn state_machine_for_test(instructions_limit: u64) -> StateMachine {
     let mut hypervisor_config = ic_config::execution_environment::Config::default();
-    let mut subnet_config = SubnetConfig::new(SubnetType::System, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(SubnetType::System);
 
     let instruction_limit = NumInstructions::new(instructions_limit);
     if instruction_limit > subnet_config.scheduler_config.max_instructions_per_round {

--- a/rs/nervous_system/timer_task/tests/tests.rs
+++ b/rs/nervous_system/timer_task/tests/tests.rs
@@ -1,6 +1,6 @@
 use candid::{Decode, Encode};
 use canister_test::Project;
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
 use ic_types::{CanisterId, ingress::WasmResult};
@@ -8,7 +8,7 @@ use ic_types::{CanisterId, ingress::WasmResult};
 fn state_machine_for_test() -> StateMachine {
     // Setting up the state machine with a lower instruction limit to make the tests run faster.
     let mut hypervisor_config = ic_config::execution_environment::Config::default();
-    let mut subnet_config = SubnetConfig::new(SubnetType::System, SubnetSecurity::None);
+    let mut subnet_config = SubnetConfig::new(SubnetType::System);
     let instruction_divisor = 10;
     subnet_config.scheduler_config.max_instructions_per_round /= instruction_divisor;
     subnet_config.scheduler_config.max_instructions_per_message /= instruction_divisor;

--- a/rs/nns/test_utils/golden_nns_state/src/lib.rs
+++ b/rs/nns/test_utils/golden_nns_state/src/lib.rs
@@ -1,8 +1,5 @@
 use ic_base_types::{CanisterId, PrincipalId, SubnetId};
-use ic_config::{
-    execution_environment::Config,
-    subnet_config::{SubnetConfig, SubnetSecurity},
-};
+use ic_config::{execution_environment::Config, subnet_config::SubnetConfig};
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{StateMachine, StateMachineBuilder, StateMachineConfig};
 
@@ -100,7 +97,7 @@ fn new_state_machine_with_golden_state_or_panic(setup_config: SetupConfig) -> St
         .with_routing_table(routing_table);
 
     let state_machine_builder = state_machine_builder.with_config(Some(StateMachineConfig::new(
-        SubnetConfig::new(subnet_type, SubnetSecurity::None),
+        SubnetConfig::new(subnet_type),
         hypervisor_config.unwrap_or_default(),
     )));
 

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -35,11 +35,8 @@ use ic_btc_interface::{
 use ic_config::adapters::AdaptersConfig;
 use ic_config::execution_environment::MAX_CANISTER_HTTP_REQUESTS_IN_FLIGHT;
 use ic_config::{
-    execution_environment,
-    flag_status::FlagStatus,
-    http_handler,
-    logger::Config as LoggerConfig,
-    subnet_config::{SubnetConfig, SubnetSecurity},
+    execution_environment, flag_status::FlagStatus, http_handler, logger::Config as LoggerConfig,
+    subnet_config::SubnetConfig,
 };
 use ic_crypto_sha2::Sha256;
 use ic_doge_interface::{
@@ -655,7 +652,7 @@ impl PocketIcSubnets {
     ) -> StateMachineBuilder {
         let subnet_type = conv_type(subnet_kind);
         let subnet_size = subnet_size(subnet_kind);
-        let mut subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+        let mut subnet_config = SubnetConfig::new(subnet_type);
         // using `let IcpConfig { }` with explicit field names
         // to force an update after adding a new field to `IcpConfig`
         let IcpConfig {

--- a/rs/replay/src/player.rs
+++ b/rs/replay/src/player.rs
@@ -10,11 +10,7 @@ use ic_artifact_pool::{
     certification_pool::CertificationPoolImpl,
     consensus_pool::{ConsensusPoolImpl, UncachedConsensusPoolImpl},
 };
-use ic_config::{
-    Config,
-    artifact_pool::ArtifactPoolConfig,
-    subnet_config::{SubnetConfig, SubnetSecurity},
-};
+use ic_config::{Config, artifact_pool::ArtifactPoolConfig, subnet_config::SubnetConfig};
 use ic_consensus::consensus::batch_delivery::deliver_batches;
 use ic_consensus_certification::VerifierImpl;
 use ic_consensus_utils::{lookup_replica_version, membership::Membership, pool_reader::PoolReader};
@@ -47,7 +43,6 @@ use ic_registry_local_store::{
     Changelog, ChangelogEntry, KeyMutation, LocalStoreImpl, LocalStoreWriter,
 };
 use ic_registry_nns_data_provider::registry::registry_deltas_to_registry_records;
-use ic_registry_subnet_features::SubnetFeatures;
 use ic_registry_subnet_type::SubnetType;
 use ic_registry_transport::{
     GetChunk, dechunkify_delta, dechunkify_get_value_response_content,
@@ -280,24 +275,15 @@ impl Player {
         }
 
         let registry_version = registry.get_latest_version();
-        let (subnet_type, subnet_security) = match registry
-            .get_subnet_record(subnet_id, registry_version)
-        {
+        let subnet_type = match registry.get_subnet_record(subnet_id, registry_version) {
             Ok(Some(record)) => {
-                let subnet_type =
-                    SubnetType::try_from(record.subnet_type).expect("Failed to decode subnet type");
-                let sev_enabled = record
-                    .features
-                    .map(SubnetFeatures::from)
-                    .unwrap_or_default()
-                    .sev_enabled;
-                (subnet_type, SubnetSecurity::from_sev_enabled(sev_enabled))
+                SubnetType::try_from(record.subnet_type).expect("Failed to decode subnet type")
             }
             err => panic!("Failed to read subnet record for {subnet_id:?} from registry: {err:?}"),
         };
 
         let metrics_registry = MetricsRegistry::new();
-        let subnet_config = SubnetConfig::new(subnet_type, subnet_security);
+        let subnet_config = SubnetConfig::new(subnet_type);
 
         let crypto = ic_crypto_for_verification_only::new(registry.clone());
         let crypto = Arc::new(crypto);

--- a/rs/replica/src/setup.rs
+++ b/rs/replica/src/setup.rs
@@ -1,8 +1,6 @@
 use crate::args::ReplicaArgs;
 use clap::Parser;
-use ic_config::{
-    Config, ConfigSource, SAMPLE_CONFIG, crypto::CryptoConfig, subnet_config::SubnetSecurity,
-};
+use ic_config::{Config, ConfigSource, SAMPLE_CONFIG, crypto::CryptoConfig};
 use ic_crypto::CryptoComponent;
 use ic_interfaces_registry::RegistryClient;
 use ic_logger::{ReplicaLogger, fatal, info, warn};
@@ -11,7 +9,6 @@ use ic_protobuf::types::v1 as pb;
 use ic_registry_client::client::RegistryClientImpl;
 use ic_registry_client_helpers::subnet::{SubnetListRegistry, SubnetRegistry};
 use ic_registry_local_store::LocalStoreImpl;
-use ic_registry_subnet_features::SubnetFeatures;
 use ic_registry_subnet_type::SubnetType;
 use ic_types::{
     NodeId, RegistryVersion, ReplicaVersion, SubnetId, consensus::catchup::CatchUpPackage,
@@ -124,17 +121,16 @@ pub fn get_subnet_id(
     }
 }
 
-/// Return the subnet type and security model of the given subnet.
+/// Return the subnet type of the given subnet.
 ///
-/// Both values are read from the same `SubnetRecord` so they are guaranteed to
-/// be consistent across replicas. Retries until the registry returns a record;
-/// crashes if the record is missing or malformed.
-pub fn get_subnet_type_and_security(
+/// Retries until the registry returns a record; crashes if the record is
+/// missing or malformed.
+pub fn get_subnet_type(
     logger: &ReplicaLogger,
     subnet_id: SubnetId,
     registry_version: RegistryVersion,
     registry: &dyn RegistryClient,
-) -> (SubnetType, SubnetSecurity) {
+) -> SubnetType {
     loop {
         match registry.get_subnet_record(subnet_id, registry_version) {
             Ok(subnet_record) => {
@@ -147,12 +143,7 @@ pub fn get_subnet_type_and_security(
                                 record,
                                 subnet_id
                             );
-                            let sev_enabled = record
-                                .features
-                                .map(SubnetFeatures::from)
-                                .unwrap_or_default()
-                                .sev_enabled;
-                            (subnet_type, SubnetSecurity::from_sev_enabled(sev_enabled))
+                            subnet_type
                         }
                         Err(e) => fatal!(logger, "Could not parse SubnetType: {}", e),
                     },

--- a/rs/replica/src/setup_ic_stack.rs
+++ b/rs/replica/src/setup_ic_stack.rs
@@ -1,4 +1,4 @@
-use crate::setup::get_subnet_type_and_security;
+use crate::setup::get_subnet_type;
 use ic_artifact_pool::{
     consensus_pool::ConsensusPoolImpl, ensure_persistent_pool_replica_version_compatibility,
 };
@@ -127,8 +127,7 @@ pub fn construct_ic_stack(
         .expect("cannot read from registry")
         .expect("cannot find root subnet id");
     let registry_version = registry.get_latest_version();
-    let (subnet_type, subnet_security) =
-        get_subnet_type_and_security(log, subnet_id, registry_version, registry.as_ref());
+    let subnet_type = get_subnet_type(log, subnet_id, registry_version, registry.as_ref());
 
     // ---------- THE PERSISTED CONSENSUS ARTIFACT POOL DEPS FOLLOW ----------
     // This is the first object that is required for the creation of the IC stack. Initializing the
@@ -187,7 +186,7 @@ pub fn construct_ic_stack(
     let max_canister_http_requests_in_flight =
         config.hypervisor.max_canister_http_requests_in_flight;
 
-    let subnet_config = SubnetConfig::new(subnet_type, subnet_security);
+    let subnet_config = SubnetConfig::new(subnet_type);
 
     let execution_services = ExecutionServices::setup_execution(
         log.clone(),

--- a/rs/replica_tests/tests/bitcoin.rs
+++ b/rs/replica_tests/tests/bitcoin.rs
@@ -9,7 +9,7 @@ use ic_btc_service::{
 use ic_config::bitcoin_payload_builder_config::Config as BitcoinPayloadBuilderConfig;
 use ic_config::{
     execution_environment::{BitcoinConfig, Config as HypervisorConfig},
-    subnet_config::{SubnetConfig, SubnetSecurity},
+    subnet_config::SubnetConfig,
 };
 use ic_error_types::RejectCode;
 use ic_http_endpoints_async_utils::incoming_from_path;
@@ -547,7 +547,7 @@ fn testnet_requests_are_routed_to_testnet_canister() {
         CanisterId::from_str("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
 
     let env = StateMachine::new_with_config(StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::System, SubnetSecurity::None),
+        SubnetConfig::new(SubnetType::System),
         HypervisorConfig {
             bitcoin: BitcoinConfig {
                 testnet_canister_id: Some(bitcoin_canister_id),
@@ -575,7 +575,7 @@ fn regtest_requests_are_routed_to_testnet_canister() {
         CanisterId::from_str("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
 
     let env = StateMachine::new_with_config(StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::System, SubnetSecurity::None),
+        SubnetConfig::new(SubnetType::System),
         HypervisorConfig {
             bitcoin: BitcoinConfig {
                 testnet_canister_id: Some(bitcoin_canister_id),
@@ -603,7 +603,7 @@ fn mainnet_requests_are_routed_to_mainnet_canister() {
         CanisterId::from_str("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
 
     let env = StateMachine::new_with_config(StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::System, SubnetSecurity::None),
+        SubnetConfig::new(SubnetType::System),
         HypervisorConfig {
             bitcoin: BitcoinConfig {
                 mainnet_canister_id: Some(bitcoin_canister_id),
@@ -628,7 +628,7 @@ fn mainnet_requests_are_routed_to_mainnet_canister() {
 #[test]
 fn requests_are_rejected_if_no_bitcoin_canisters_are_set() {
     let env = StateMachine::new_with_config(StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::System, SubnetSecurity::None),
+        SubnetConfig::new(SubnetType::System),
         HypervisorConfig {
             // No bitcoin canisters set.
             bitcoin: BitcoinConfig::default(),

--- a/rs/replica_tests/tests/canister_lifecycle.rs
+++ b/rs/replica_tests/tests/canister_lifecycle.rs
@@ -4,7 +4,7 @@ use ic_config::Config;
 use ic_config::execution_environment::{
     DEFAULT_WASM_MEMORY_LIMIT, TEST_DEFAULT_LOG_MEMORY_LIMIT, TEST_DEFAULT_LOG_MEMORY_USAGE,
 };
-use ic_config::subnet_config::{CyclesAccountManagerConfig, SubnetSecurity};
+use ic_config::subnet_config::CyclesAccountManagerConfig;
 use ic_error_types::{ErrorCode, RejectCode};
 use ic_management_canister_types_private::{
     self as ic00, CanisterChange, CanisterIdRecord, CanisterInstallMode,
@@ -502,7 +502,7 @@ fn can_create_canister_with_cycles_from_another_canister() {
             test.canister_state(&canister_id).system_state.balance();
 
         // Create another canister with some cycles.
-        let config = CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None);
+        let config = CyclesAccountManagerConfig::application_subnet();
         let cycles_for_new_canister = config.canister_creation_fee + Cycles::new(100_000_000);
         let new_canister_id_payload = test
             .ingress(

--- a/rs/replica_tests/tests/funds.rs
+++ b/rs/replica_tests/tests/funds.rs
@@ -1,4 +1,4 @@
-use ic_config::subnet_config::{CyclesAccountManagerConfig, SubnetSecurity};
+use ic_config::subnet_config::CyclesAccountManagerConfig;
 use ic_management_canister_types_private::{CanisterIdRecord, EmptyBlob, IC_00, Method, Payload};
 use ic_replica_tests as utils;
 use ic_test_utilities::assert_utils::assert_balance_equals;
@@ -80,7 +80,7 @@ fn can_deposit_cycles_via_the_management_canister() {
         let canister_id = test.create_universal_canister_with_args(vec![], num_cycles);
 
         // Create another canister with some cycles and ICP tokens.
-        let config = CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None);
+        let config = CyclesAccountManagerConfig::application_subnet();
         let cycles_for_new_canister = config.canister_creation_fee + Cycles::new(100_000_000);
         let new_canister_id_payload = test
             .ingress(

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -337,6 +337,21 @@ impl NetworkTopology {
             .map(|subnet_topology| subnet_topology.cost_schedule)
     }
 
+    /// Returns the reference subnet size of the given subnet, derived from its type and SEV status.
+    /// System subnets always use the default reference size regardless of SEV.
+    pub fn get_reference_subnet_size(&self, subnet_id: &SubnetId) -> Option<usize> {
+        use ic_config::subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SEV_REFERENCE_SUBNET_SIZE};
+        self.subnets.get(subnet_id).map(|subnet_topology| {
+            if subnet_topology.subnet_type != SubnetType::System
+                && subnet_topology.subnet_features.sev_enabled
+            {
+                SEV_REFERENCE_SUBNET_SIZE
+            } else {
+                DEFAULT_REFERENCE_SUBNET_SIZE
+            }
+        })
+    }
+
     /// Returns the subnets map used for the certified state tree.
     ///
     /// On the NNS subnet this returns the full, unfiltered map (including cloud
@@ -571,6 +586,13 @@ impl SystemMetadata {
     /// not populated.
     pub fn own_cost_schedule(&self) -> Option<CanisterCyclesCostSchedule> {
         self.network_topology.get_cost_schedule(&self.own_subnet_id)
+    }
+
+    /// Returns the reference subnet size of this subnet derived from its SEV
+    /// status, `None` if `network_topology` is not populated.
+    pub fn own_reference_subnet_size(&self) -> Option<usize> {
+        self.network_topology
+            .get_reference_subnet_size(&self.own_subnet_id)
     }
 
     /// One-off initialization: populate `canister_allocation_ranges` with the only

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -2995,19 +2995,18 @@ fn network_topology_reference_subnet_size_is_never_zero() {
     assert_ne!(SEV_REFERENCE_SUBNET_SIZE, 0);
 
     let subnet_id = subnet_test_id(1);
-    for (subnet_type, sev_enabled) in [
-        (SubnetType::Application, false),
-        (SubnetType::Application, true),
-        (SubnetType::VerifiedApplication, false),
-        (SubnetType::VerifiedApplication, true),
-        (SubnetType::System, false),
-        (SubnetType::System, true),
+    for subnet_type in [
+        SubnetType::Application,
+        SubnetType::VerifiedApplication,
+        SubnetType::System,
     ] {
-        let topology = make_network_topology_with_subnet(subnet_id, subnet_type, sev_enabled);
-        assert_ne!(
-            topology.get_reference_subnet_size(&subnet_id).unwrap(),
-            0,
-            "reference_subnet_size must not be zero for {subnet_type:?} sev={sev_enabled}"
-        );
+        for sev_enabled in [false, true] {
+            let topology = make_network_topology_with_subnet(subnet_id, subnet_type, sev_enabled);
+            assert_ne!(
+                topology.get_reference_subnet_size(&subnet_id).unwrap(),
+                0,
+                "reference_subnet_size must not be zero for {subnet_type:?} sev={sev_enabled}"
+            );
+        }
     }
 }

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -2917,3 +2917,97 @@ fn blockmaker_metrics_check_soft_invariants(
 
     prop_assert!(metrics.check_soft_invariants().is_ok());
 }
+
+fn make_network_topology_with_subnet(
+    subnet_id: SubnetId,
+    subnet_type: SubnetType,
+    sev_enabled: bool,
+) -> NetworkTopology {
+    let subnet_topology = SubnetTopology {
+        subnet_type,
+        subnet_features: SubnetFeatures {
+            sev_enabled,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    NetworkTopology {
+        subnets: btreemap! { subnet_id => subnet_topology },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn network_topology_application_sev_disabled_uses_default_reference_subnet_size() {
+    use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
+    let subnet_id = subnet_test_id(1);
+    let topology = make_network_topology_with_subnet(subnet_id, SubnetType::Application, false);
+    assert_eq!(
+        topology.get_reference_subnet_size(&subnet_id),
+        Some(DEFAULT_REFERENCE_SUBNET_SIZE)
+    );
+}
+
+#[test]
+fn network_topology_application_sev_enabled_uses_sev_reference_subnet_size() {
+    use ic_config::subnet_config::SEV_REFERENCE_SUBNET_SIZE;
+    let subnet_id = subnet_test_id(1);
+    let topology = make_network_topology_with_subnet(subnet_id, SubnetType::Application, true);
+    assert_eq!(
+        topology.get_reference_subnet_size(&subnet_id),
+        Some(SEV_REFERENCE_SUBNET_SIZE)
+    );
+}
+
+#[test]
+fn network_topology_verified_application_sev_enabled_uses_sev_reference_subnet_size() {
+    use ic_config::subnet_config::SEV_REFERENCE_SUBNET_SIZE;
+    let subnet_id = subnet_test_id(1);
+    let topology =
+        make_network_topology_with_subnet(subnet_id, SubnetType::VerifiedApplication, true);
+    assert_eq!(
+        topology.get_reference_subnet_size(&subnet_id),
+        Some(SEV_REFERENCE_SUBNET_SIZE)
+    );
+}
+
+#[test]
+fn network_topology_system_ignores_sev_flag() {
+    use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
+    let subnet_id = subnet_test_id(1);
+    let topology_sev = make_network_topology_with_subnet(subnet_id, SubnetType::System, true);
+    let topology_no_sev = make_network_topology_with_subnet(subnet_id, SubnetType::System, false);
+    assert_eq!(
+        topology_sev.get_reference_subnet_size(&subnet_id),
+        Some(DEFAULT_REFERENCE_SUBNET_SIZE)
+    );
+    assert_eq!(
+        topology_no_sev.get_reference_subnet_size(&subnet_id),
+        Some(DEFAULT_REFERENCE_SUBNET_SIZE)
+    );
+}
+
+#[test]
+fn network_topology_reference_subnet_size_is_never_zero() {
+    use ic_config::subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SEV_REFERENCE_SUBNET_SIZE};
+    // reference_subnet_size is used as a divisor in scale_cost; it must never be zero.
+    assert_ne!(DEFAULT_REFERENCE_SUBNET_SIZE, 0);
+    assert_ne!(SEV_REFERENCE_SUBNET_SIZE, 0);
+
+    let subnet_id = subnet_test_id(1);
+    for (subnet_type, sev_enabled) in [
+        (SubnetType::Application, false),
+        (SubnetType::Application, true),
+        (SubnetType::VerifiedApplication, false),
+        (SubnetType::VerifiedApplication, true),
+        (SubnetType::System, false),
+        (SubnetType::System, true),
+    ] {
+        let topology = make_network_topology_with_subnet(subnet_id, subnet_type, sev_enabled);
+        assert_ne!(
+            topology.get_reference_subnet_size(&subnet_id).unwrap(),
+            0,
+            "reference_subnet_size must not be zero for {subnet_type:?} sev={sev_enabled}"
+        );
+    }
+}

--- a/rs/replicated_state/src/replicated_state.rs
+++ b/rs/replicated_state/src/replicated_state.rs
@@ -770,11 +770,21 @@ impl ReplicatedState {
         self.metadata.own_cost_schedule().unwrap_or_default()
     }
 
+    /// Returns the reference subnet size of this subnet, derived from its SEV status.
+    /// Defaults to `DEFAULT_REFERENCE_SUBNET_SIZE` if the network topology is not populated.
+    pub fn get_own_reference_subnet_size(&self) -> usize {
+        use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
+        self.metadata
+            .own_reference_subnet_size()
+            .unwrap_or(DEFAULT_REFERENCE_SUBNET_SIZE)
+    }
+
     /// Returns the cycles account manager subnet config for this subnet.
     pub fn get_own_subnet_cycles_config(&self) -> CyclesAccountManagerSubnetConfig {
         CyclesAccountManagerSubnetConfig::new(
             self.get_own_subnet_size(),
             self.get_own_cost_schedule(),
+            self.get_own_reference_subnet_size(),
         )
     }
 

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -9,7 +9,7 @@ use ic_config::{
     execution_environment::Config as HypervisorConfig,
     message_routing::{MAX_STREAM_MESSAGES, TARGET_STREAM_SIZE_BYTES},
     state_manager::LsmtConfig,
-    subnet_config::{SubnetConfig, SubnetSecurity},
+    subnet_config::SubnetConfig,
 };
 use ic_consensus::consensus::payload_builder::PayloadBuilderImpl;
 use ic_consensus_cup_utils::make_registry_cup_from_cup_contents;
@@ -2067,10 +2067,7 @@ impl StateMachine {
 
         let (mut subnet_config, hypervisor_config) = match config {
             Some(config) => (config.subnet_config, config.hypervisor_config),
-            None => (
-                SubnetConfig::new(subnet_type, SubnetSecurity::None),
-                HypervisorConfig::default(),
-            ),
+            None => (SubnetConfig::new(subnet_type), HypervisorConfig::default()),
         };
         if let Some(ecdsa_signature_fee) = ecdsa_signature_fee {
             subnet_config
@@ -5673,7 +5670,7 @@ pub fn two_subnets_with_config(
 /// Sets up two `StateMachine` that can communicate with each other.
 pub fn two_subnets_simple() -> (Arc<StateMachine>, Arc<StateMachine>) {
     let config = StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::Application, SubnetSecurity::None),
+        SubnetConfig::new(SubnetType::Application),
         HypervisorConfig::default(),
     );
     two_subnets_with_config(config.clone(), config)

--- a/rs/state_machine_tests/src/main.rs
+++ b/rs/state_machine_tests/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use ic_config::execution_environment;
-use ic_config::subnet_config::{SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::SubnetConfig;
 use ic_crypto_iccsa::types::SignatureBytes;
 use ic_crypto_iccsa::{public_key_bytes_from_der, verify};
 use ic_crypto_utils_threshold_sig_der::{
@@ -67,10 +67,7 @@ fn main() {
         default_provisional_cycles_balance: Cycles::new(0),
         ..Default::default()
     };
-    let config = StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::System, SubnetSecurity::None),
-        hypervisor_config,
-    );
+    let config = StateMachineConfig::new(SubnetConfig::new(SubnetType::System), hypervisor_config);
     let env = StateMachineBuilder::new().with_config(Some(config)).build();
     loop {
         debug_print!(&opts, "enter request loop");

--- a/rs/state_machine_tests/tests/dts.rs
+++ b/rs/state_machine_tests/tests/dts.rs
@@ -1,8 +1,5 @@
 use ic_base_types::PrincipalId;
-use ic_config::{
-    execution_environment::Config as HypervisorConfig,
-    subnet_config::{SubnetConfig, SubnetSecurity},
-};
+use ic_config::{execution_environment::Config as HypervisorConfig, subnet_config::SubnetConfig};
 use ic_registry_subnet_type::SubnetType;
 use ic_state_machine_tests::{StateMachineBuilder, StateMachineConfig};
 use ic_types_cycles::Cycles;
@@ -66,7 +63,7 @@ fn very_slow_wasm(n: u64) -> Vec<u8> {
 #[test]
 fn test_dts() {
     let config = StateMachineConfig::new(
-        SubnetConfig::new(SubnetType::Application, SubnetSecurity::None),
+        SubnetConfig::new(SubnetType::Application),
         HypervisorConfig::default(),
     );
     let sm = StateMachineBuilder::new()

--- a/rs/test_utilities/embedders/src/lib.rs
+++ b/rs/test_utilities/embedders/src/lib.rs
@@ -4,7 +4,7 @@ use std::{convert::TryFrom, rc::Rc};
 use ic_base_types::NumBytes;
 use ic_config::execution_environment::Config as HypervisorConfig;
 use ic_config::flag_status::FlagStatus;
-use ic_config::subnet_config::SchedulerConfig;
+use ic_config::subnet_config::{DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig};
 use ic_cycles_account_manager::{CyclesAccountManagerSubnetConfig, ResourceSaturation};
 use ic_embedders::{
     WasmtimeEmbedder,
@@ -180,6 +180,7 @@ impl WasmtimeInstanceBuilder {
             CyclesAccountManagerSubnetConfig::new(
                 SMALL_APP_SUBNET_MAX_SIZE,
                 CanisterCyclesCostSchedule::Normal,
+                DEFAULT_REFERENCE_SUBNET_SIZE,
             ),
         );
 

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -5,7 +5,7 @@ use ic_config::{
     execution_environment::Config,
     flag_status::FlagStatus,
     subnet_config::SchedulerConfig,
-    subnet_config::{SubnetConfig, SubnetSecurity},
+    subnet_config::SubnetConfig,
 };
 use ic_crypto_test_utils_reproducible_rng::ReproducibleRng;
 use ic_cycles_account_manager::{
@@ -2378,7 +2378,7 @@ pub struct ExecutionTestBuilder {
 impl Default for ExecutionTestBuilder {
     fn default() -> Self {
         let subnet_type = SubnetType::Application;
-        let mut subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+        let mut subnet_config = SubnetConfig::new(subnet_type);
         subnet_config.scheduler_config.scheduler_cores = 2;
         Self {
             execution_config: Config {
@@ -2471,7 +2471,7 @@ impl ExecutionTestBuilder {
         self.subnet_type = subnet_type;
         // If `subnet_type` is updated, then we need to update the subnet config
         // to match it.
-        self.subnet_config = SubnetConfig::new(subnet_type, SubnetSecurity::None);
+        self.subnet_config = SubnetConfig::new(subnet_type);
         self
     }
 

--- a/rs/test_utilities/src/cycles_account_manager.rs
+++ b/rs/test_utilities/src/cycles_account_manager.rs
@@ -1,4 +1,4 @@
-use ic_config::subnet_config::{CyclesAccountManagerConfig, SubnetConfig, SubnetSecurity};
+use ic_config::subnet_config::{CyclesAccountManagerConfig, SubnetConfig};
 use ic_cycles_account_manager::CyclesAccountManager;
 use ic_registry_subnet_type::SubnetType;
 use ic_test_utilities_types::ids::subnet_test_id;
@@ -20,14 +20,13 @@ impl CyclesAccountManagerBuilder {
             subnet_id: subnet_test_id(0),
             subnet_type: SubnetType::Application,
             cycles_limit_per_canister: Some(Cycles::new(100_000_000_000_000)),
-            config: CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None),
+            config: CyclesAccountManagerConfig::application_subnet(),
         }
     }
 
     pub fn with_subnet_type(mut self, subnet_type: SubnetType) -> Self {
         self.subnet_type = subnet_type;
-        self.config =
-            SubnetConfig::new(subnet_type, SubnetSecurity::None).cycles_account_manager_config;
+        self.config = SubnetConfig::new(subnet_type).cycles_account_manager_config;
         self
     }
 

--- a/rs/tests/execution/general_execution_tests/canister_lifecycle.rs
+++ b/rs/tests/execution/general_execution_tests/canister_lifecycle.rs
@@ -106,7 +106,9 @@ pub fn create_canister_via_canister_succeeds(env: TestEnv) {
 pub fn update_settings_of_frozen_canister(env: TestEnv) {
     use ic_base_types::NumBytes;
     use ic_cdk::api::management_canister::main::{CanisterSettings, UpdateSettingsArgument};
-    use ic_config::subnet_config::{CyclesAccountManagerConfig, SchedulerConfig, SubnetSecurity};
+    use ic_config::subnet_config::{
+        CyclesAccountManagerConfig, DEFAULT_REFERENCE_SUBNET_SIZE, SchedulerConfig,
+    };
     use ic_cycles_account_manager::{CyclesAccountManager, CyclesAccountManagerSubnetConfig};
 
     let logger = env.logger();
@@ -220,7 +222,7 @@ pub fn update_settings_of_frozen_canister(env: TestEnv) {
                 SchedulerConfig::application_subnet().max_instructions_per_message,
                 SubnetType::Application,
                 app_node.subnet_id().unwrap(),
-                CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None),
+                CyclesAccountManagerConfig::application_subnet(),
             );
 
             assert!(
@@ -232,6 +234,7 @@ pub fn update_settings_of_frozen_canister(env: TestEnv) {
                                 CyclesAccountManagerSubnetConfig::new(
                                     1,
                                     CanisterCyclesCostSchedule::Normal,
+                                    DEFAULT_REFERENCE_SUBNET_SIZE,
                                 ),
                             )
                             .real()

--- a/rs/tests/networking/BUILD.bazel
+++ b/rs/tests/networking/BUILD.bazel
@@ -141,6 +141,7 @@ system_test_nns(
         "PROXY_WASM_PATH": "//rs/rust_canisters/proxy_canister:proxy_canister",
     },
     deps = CANISTER_HTTP_BASE_DEPS + [
+        "//rs/config",
         "//rs/cycles_account_manager",
         "//rs/registry/subnet_type",
         "//rs/rust_canisters/canister_test",

--- a/rs/tests/networking/Cargo.toml
+++ b/rs/tests/networking/Cargo.toml
@@ -26,6 +26,7 @@ ic-http-endpoints-public = { path = "../../http_endpoints/public" }
 ic-http-endpoints-test-agent = { path = "../../http_endpoints/test_agent" }
 ic_consensus_system_test_utils = { path = "../consensus/utils" }
 ic_consensus_threshold_sig_system_test_utils = { path = "../consensus/tecdsa/utils" }
+ic-config = { path = "../../config" }
 ic-cycles-account-manager = { path = "../../cycles_account_manager" }
 ic-limits = { path = "../../limits" }
 ic-management-canister-types-private = { path = "../../types/management_canister_types" }

--- a/rs/tests/networking/canister_http_correctness_test.rs
+++ b/rs/tests/networking/canister_http_correctness_test.rs
@@ -27,6 +27,7 @@ use ic_agent::{
 };
 use ic_base_types::{CanisterId, NumBytes, PrincipalId};
 use ic_cdk::api::call::RejectionCode;
+use ic_config::subnet_config::DEFAULT_REFERENCE_SUBNET_SIZE;
 use ic_cycles_account_manager::CyclesAccountManagerSubnetConfig;
 use ic_management_canister_types_private::{
     HttpHeader, HttpMethod, TransformContext, TransformFunc,
@@ -2725,7 +2726,11 @@ fn expected_cycle_cost(
     let cycle_fee = cm.http_request_fee(
         req_size,
         Some(NumBytes::from(response_size)),
-        CyclesAccountManagerSubnetConfig::new(subnet_size, CanisterCyclesCostSchedule::Normal),
+        CyclesAccountManagerSubnetConfig::new(
+            subnet_size,
+            CanisterCyclesCostSchedule::Normal,
+            DEFAULT_REFERENCE_SUBNET_SIZE,
+        ),
     );
     cycle_fee.real().get().try_into().unwrap()
 }

--- a/rs/tests/nns/nns_cycles_minting_test.rs
+++ b/rs/tests/nns/nns_cycles_minting_test.rs
@@ -5,7 +5,7 @@ use cycles_minting::{TestAgent, UserHandle, make_user_ed25519};
 use cycles_minting_canister::{CREATE_CANISTER_REFUND_FEE, DEFAULT_CYCLES_PER_XDR, TokensToCycles};
 use dfn_candid::candid_one;
 use ic_canister_client::{HttpClient, Sender};
-use ic_config::subnet_config::{CyclesAccountManagerConfig, SubnetSecurity};
+use ic_config::subnet_config::CyclesAccountManagerConfig;
 use ic_ledger_core::tokens::CheckedAdd;
 use ic_limits::{MAX_INGRESS_BYTES_PER_MESSAGE_APP_SUBNET, SMALL_APP_SUBNET_MAX_SIZE};
 use ic_management_canister_types_private::{CanisterIdRecord, CanisterStatusResultV2};
@@ -310,7 +310,7 @@ pub fn test(env: TestEnv) {
                 .await
                 .unwrap();
         assert_eq!(new_canister_status.controller(), controller_pid);
-        let config = CyclesAccountManagerConfig::application_subnet(SubnetSecurity::None);
+        let config = CyclesAccountManagerConfig::application_subnet();
         let max_fees = scale_cycles(
             config.canister_creation_fee
                 + config.ingress_message_reception_fee

--- a/rs/types/cycles/src/cycles_account_manager_subnet_config.rs
+++ b/rs/types/cycles/src/cycles_account_manager_subnet_config.rs
@@ -6,13 +6,21 @@ use serde::{Deserialize, Serialize};
 pub struct CyclesAccountManagerSubnetConfig {
     pub subnet_size: usize,
     pub cost_schedule: CanisterCyclesCostSchedule,
+    /// Reference value of a subnet size that all fees are calculated for.
+    /// Fees for a real subnet are calculated proportionally to this reference value.
+    pub reference_subnet_size: usize,
 }
 
 impl CyclesAccountManagerSubnetConfig {
-    pub fn new(subnet_size: usize, cost_schedule: CanisterCyclesCostSchedule) -> Self {
+    pub fn new(
+        subnet_size: usize,
+        cost_schedule: CanisterCyclesCostSchedule,
+        reference_subnet_size: usize,
+    ) -> Self {
         Self {
             subnet_size,
             cost_schedule,
+            reference_subnet_size,
         }
     }
 }


### PR DESCRIPTION
This PR makes the reference subnet size in CyclesAccountManager configurable at runtime so that a subnet's security can be changed from `None` to SEV-SNP and this change is properly picked up from the registry and reflected in cycles scaling at runtime.

The implementation proceeds by moving the reference subnet size from the (static) `CyclesAccountManagerConfig` to the (dynamic) `CyclesAccountManagerSubnetConfig` derived via `NetworkTopology` in `ReplicatedState` at runtime.