### PR TITLE
chore: use static IPv6 for GuestOS instead of RA in testnets

### DIFF
--- a/rs/tests/driver/src/driver/bootstrap.rs
+++ b/rs/tests/driver/src/driver/bootstrap.rs
@@ -34,9 +34,9 @@ use config_tool::setupos::{
     deployment_json::{self, DeploymentSettings},
 };
 use config_types::{
-    CONFIG_VERSION, DeploymentEnvironment, GuestOSConfig, GuestOSDevSettings, GuestOSSettings,
-    GuestOSUpgradeConfig, GuestVMType, ICOSDevSettings, ICOSSettings, IcBoundaryTlsCert,
-    Ipv4Config, Ipv6Config, NetworkSettings, RecoveryConfig,
+    CONFIG_VERSION, DeploymentEnvironment, FixedIpv6Config, GuestOSConfig, GuestOSDevSettings,
+    GuestOSSettings, GuestOSUpgradeConfig, GuestVMType, ICOSDevSettings, ICOSSettings,
+    IcBoundaryTlsCert, Ipv4Config, Ipv6Config, NetworkSettings, RecoveryConfig,
 };
 use ic_base_types::NodeId;
 use ic_prep_lib::{
@@ -56,7 +56,7 @@ use std::{
     fs::File,
     io,
     io::Write,
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     process::Command,
     thread::{self, JoinHandle},
@@ -550,8 +550,27 @@ fn create_guestos_config_for_node(
     test_env: &TestEnv,
     ic_name: &str,
 ) -> anyhow::Result<GuestOSConfig> {
-    // Build NetworkSettings
-    let ipv6_config = Ipv6Config::RouterAdvertisement;
+    // Build NetworkSettings.
+    //
+    // Use a fixed (static) IPv6 address derived from the node's allocated
+    // address instead of `RouterAdvertisement`. The RA path makes the GuestOS
+    // emit `DHCP=yes` (to support cloud metadata servers), which enables DHCP
+    // for *both* IPv4 and IPv6. On Farm this causes every node to request an
+    // IPv4 lease and exhausts the IPv4 address space in our testnet DCs. A
+    // fixed config sets `IPv6AcceptRA=false` and does not enable DHCP.
+    let ipv6_addr = match node.node_config.public_api.ip() {
+        IpAddr::V6(addr) => addr,
+        IpAddr::V4(addr) => bail!("Expected an IPv6 node address, got IPv4: {addr}"),
+    };
+    // The gateway is the `<prefix>::1` address of the node's /64 subnet. This
+    // mirrors the gateway derivation used for SetupOS configs and resolves to
+    // the same physical router that router advertisements point to.
+    let s = ipv6_addr.segments();
+    let ipv6_gateway = Ipv6Addr::new(s[0], s[1], s[2], s[3], 0, 0, 0, 1);
+    let ipv6_config = Ipv6Config::Fixed(FixedIpv6Config {
+        address: format!("{ipv6_addr}/64"),
+        gateway: ipv6_gateway,
+    });
 
     let ipv4_config = match ipv4_config {
         Some(config) => Some(Ipv4Config {


### PR DESCRIPTION
## Problem

After [ecf3caf](https://github.com/dfinity/ic/commit/ecf3cafd361d65566339aad729d0d9b0a8dff22b#diff-df1f327e008fa5fb894409aa5d4905e99c5e552dfcb0e924fd326331bdb74328R230) ("feat([NODE-1881](https://dfinity.atlassian.net/browse/NODE-1881)): Discover external IPv6 in the cloud environment (https://github.com/dfinity/ic/pull/9243)"), Farm testnet GuestOS nodes started requesting a **DHCPv4** lease on their `enp1s0` NIC, even though that interface should be IPv6-only. This started exhausting the IPv4 address space in the DCs where we run testnets after 557d727 ("chore(systests): force testnet allocation to the local DC for all system-tests (https://github.com/dfinity/ic/pull/10436)").

## Root cause

The test driver configures every Farm node with `Ipv6Config::RouterAdvertisement`. In the GuestOS network generator (`generate_network_config.rs`), the RA branch emits:

```ini
[Network]
IPv6AcceptRA=true
DHCP=yes
```

In `systemd-networkd`, `DHCP=yes` enables DHCP for **both** IPv4 and IPv6. That line exists to support cloud metadata servers (`169.254.169.254`), but on Farm it makes every node pull a DHCPv4 lease.

## Fix

Switch the test driver to build a static `Ipv6Config::Fixed` from the node's already-allocated IPv6 address (available via `node.node_config.public_api`). The gateway is derived as the `<prefix>::1` address of the node's `/64` subnet — the same derivation already used for SetupOS configs.

The `Fixed` branch emits `IPv6AcceptRA=false` and **no** `DHCP=`, so nodes no longer request an IPv4 lease.

Cloud/mainnet paths are unaffected: they do not go through this test-driver code and keep using RA + `DHCP=yes`.

## Validation

- `rustfmt` + `cargo clippy -p ic-system-test-driver -- -D warnings`: clean
- `bazel build //rs/tests/driver:ic-system-test-driver`: success
- `bazel test //rs/tests/idx:basic_health_test --cache_test_results=no --test_arg=--set-required-host-features=dc=dm1`: **PASSED in 72.3s**

An SSH check on a live Farm node confirmed `<prefix>::1` resolves to the same physical router (same MAC) as the RA-advertised link-local gateway, and is reachable.

[NODE-1881]: https://dfinity.atlassian.net/browse/NODE-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ