### PR TITLE
chore: upgrade UVM and P8s images

### DIFF
--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -42,7 +42,7 @@ const PROMETHEUS_VM_NAME: &str = "prometheus";
 /// Following through to the "Upload UVM images to S3" job and copying the <SHA256-HASH> from the line:
 /// upload: ../../../../../nix/store/...-nixos-disk-image-out-refs-discarded/nixos.img.zst to s3://dfinity-download/farm/prometheus-vm/<SHA256-HASH>/x86_64-linux/prometheus-vm.img.zst
 const DEFAULT_PROMETHEUS_VM_IMG_SHA256: &str =
-    "bdd9bd976e3210f382ae0810d13230dba13a660b2420662bdcb284f989842daa";
+    "71adf6a546c781a30621f0c9265cfe44f43a018f433abc96964014067517841b";
 
 fn get_default_prometheus_vm_img_url() -> String {
     format!(

--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -42,7 +42,7 @@ const PROMETHEUS_VM_NAME: &str = "prometheus";
 /// Following through to the "Upload UVM images to S3" job and copying the <SHA256-HASH> from the line:
 /// upload: ../../../../../nix/store/...-nixos-disk-image-out-refs-discarded/nixos.img.zst to s3://dfinity-download/farm/prometheus-vm/<SHA256-HASH>/x86_64-linux/prometheus-vm.img.zst
 const DEFAULT_PROMETHEUS_VM_IMG_SHA256: &str =
-    "49ecc84e46e5cc5b970fc9cf94aa3decd03161642c91f4d1153955110e0ee13f";
+    "bdd9bd976e3210f382ae0810d13230dba13a660b2420662bdcb284f989842daa";
 
 fn get_default_prometheus_vm_img_url() -> String {
     format!(

--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -42,7 +42,7 @@ const PROMETHEUS_VM_NAME: &str = "prometheus";
 /// Following through to the "Upload UVM images to S3" job and copying the <SHA256-HASH> from the line:
 /// upload: ../../../../../nix/store/...-nixos-disk-image-out-refs-discarded/nixos.img.zst to s3://dfinity-download/farm/prometheus-vm/<SHA256-HASH>/x86_64-linux/prometheus-vm.img.zst
 const DEFAULT_PROMETHEUS_VM_IMG_SHA256: &str =
-    "71adf6a546c781a30621f0c9265cfe44f43a018f433abc96964014067517841b";
+    "b9f77f869eda83b242b585f397a26f16d54199d764d52b5e69ea98b2510be67b";
 
 fn get_default_prometheus_vm_img_url() -> String {
     format!(

--- a/rs/tests/driver/src/driver/prometheus_vm.rs
+++ b/rs/tests/driver/src/driver/prometheus_vm.rs
@@ -42,7 +42,7 @@ const PROMETHEUS_VM_NAME: &str = "prometheus";
 /// Following through to the "Upload UVM images to S3" job and copying the <SHA256-HASH> from the line:
 /// upload: ../../../../../nix/store/...-nixos-disk-image-out-refs-discarded/nixos.img.zst to s3://dfinity-download/farm/prometheus-vm/<SHA256-HASH>/x86_64-linux/prometheus-vm.img.zst
 const DEFAULT_PROMETHEUS_VM_IMG_SHA256: &str =
-    "b9f77f869eda83b242b585f397a26f16d54199d764d52b5e69ea98b2510be67b";
+    "3568d6e7e8176636bcbd29f5469dec6b036345e61d2b57c276a0941df0b31c4a";
 
 fn get_default_prometheus_vm_img_url() -> String {
     format!(

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -244,7 +244,7 @@ pub fn get_resource_request_for_nested_nodes(
 /// Following through to the "Upload UVM images to S3" job and copying the <SHA256-HASH> from the line:
 /// upload: ../../../../../nix/store/...-nixos-disk-image-out-refs-discarded/nixos.img.zst to s3://dfinity-download/farm/universal-vm/<SHA256-HASH>/x86_64-linux/universal-vm.img.zst
 const DEFAULT_UNIVERSAL_VM_IMG_SHA256: &str =
-    "4ae74df520a1f9b3975c5612c04abc8abbc6712423417be3e9704784f48616a8";
+    "37cbe9d112058f066bad26d2428a56ba4f55f13e425f5be12768885fe7ca84ee";
 
 pub fn get_resource_request_for_universal_vm(
     universal_vm: &UniversalVm,

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -244,7 +244,7 @@ pub fn get_resource_request_for_nested_nodes(
 /// Following through to the "Upload UVM images to S3" job and copying the <SHA256-HASH> from the line:
 /// upload: ../../../../../nix/store/...-nixos-disk-image-out-refs-discarded/nixos.img.zst to s3://dfinity-download/farm/universal-vm/<SHA256-HASH>/x86_64-linux/universal-vm.img.zst
 const DEFAULT_UNIVERSAL_VM_IMG_SHA256: &str =
-    "585f4cb5866a576a1ba85ffb2c4fbd1836c7e39a7e9a02b5be44bfb4820a1443";
+    "4ae74df520a1f9b3975c5612c04abc8abbc6712423417be3e9704784f48616a8";
 
 pub fn get_resource_request_for_universal_vm(
     universal_vm: &UniversalVm,

--- a/rs/tests/driver/src/driver/resource.rs
+++ b/rs/tests/driver/src/driver/resource.rs
@@ -244,7 +244,7 @@ pub fn get_resource_request_for_nested_nodes(
 /// Following through to the "Upload UVM images to S3" job and copying the <SHA256-HASH> from the line:
 /// upload: ../../../../../nix/store/...-nixos-disk-image-out-refs-discarded/nixos.img.zst to s3://dfinity-download/farm/universal-vm/<SHA256-HASH>/x86_64-linux/universal-vm.img.zst
 const DEFAULT_UNIVERSAL_VM_IMG_SHA256: &str =
-    "37cbe9d112058f066bad26d2428a56ba4f55f13e425f5be12768885fe7ca84ee";
+    "ae94e672589c8cb47231976f8d0a4abaac4b8fde9ded1a664de6d7c32f0eac25";
 
 pub fn get_resource_request_for_universal_vm(
     universal_vm: &UniversalVm,


### PR DESCRIPTION
* [nixpkgs: 25.11 -> 26.05](https://github.com/dfinity-lab/farm/commit/adb884d87f3d5d0b41771de4557f9989225c97ef).
* Fixes for the `nixos` hostname LLMNR conflicts: https://github.com/dfinity-lab/farm/commit/f34ec25475c1017aeb7dbff50d4781299f9d1ae7, https://github.com/dfinity-lab/farm/commit/9c749160a33eaf7fb322270b39aad7badd9519bb and https://github.com/dfinity-lab/farm/commit/e5b2bbf0aaf7c574bbb286fdcc55305ad99a7c8c.

Tested that Prometheus and Grafana are working:
<img width="2649" height="1196" alt="Screenshot 2026-06-16 at 12 38 34" src="https://github.com/user-attachments/assets/66955edb-226e-4363-89b4-4aa9f31d89b4" />

