### PR TITLE
fix: Fix python bazel wrapper after upgrade

### DIFF
--- a/ic-os/dev-tools/bare_metal_deployment/deploy.py
+++ b/ic-os/dev-tools/bare_metal_deployment/deploy.py
@@ -431,7 +431,7 @@ def gen_failure(result: invoke.Result, bmc_info: BMCInfo) -> DeploymentError:
 
 def run_script(idrac_script_dir: Path, bmc_info: BMCInfo, script_and_args: str, permissive: bool = True) -> None:
     """Run a given script from the given bin dir and raise an exception if anything went wrong"""
-    command = f"python3 {idrac_script_dir}/{script_and_args}"
+    command = f"{sys.executable} {idrac_script_dir}/{script_and_args}"
     result = invoke.run(command)
 
     if result and not result.ok:

--- a/ic-os/dev-tools/bare_metal_deployment/tools.bzl
+++ b/ic-os/dev-tools/bare_metal_deployment/tools.bzl
@@ -22,13 +22,15 @@ def launch_bare_metal(name, image_zst_file):
             requirement("simple-parsing"),
             requirement("tqdm"),
         ],
+        config_settings = {
+            "@rules_python//python/config_settings:bootstrap_impl": "script",
+        },
         tags = ["manual"],
     )
     sh_binary(
         name = name,
         srcs = ["//toolchains/sysimage:proc_wrapper.sh"],
         args = [
-            "python3",
             "$(location :" + binary_name + ")",
             "--inject_configuration_tool",
             "$(location //rs/ic_os/dev_test_tools/setupos-image-config:setupos-inject-config)",


### PR DESCRIPTION
After https://github.com/dfinity/ic/pull/10413 upgraded `rules_python`, nightly bare metal jobs started failing. This updates how we bazel wrap our tools, to match the new environment format.