### PR TITLE
feat: CON-1467 CON-1705 Add registry version to `CanisterHttpRequestContext`

### DIFF
--- a/rs/https_outcalls/client/src/client.rs
+++ b/rs/https_outcalls/client/src/client.rs
@@ -560,8 +560,11 @@ mod tests {
     use ic_interfaces::execution_environment::{QueryExecutionError, QueryExecutionResponse};
     use ic_logger::replica_logger::no_op_logger;
     use ic_test_utilities_types::messages::RequestBuilder;
-    use ic_types::canister_http::{
-        MAX_CANISTER_HTTP_RESPONSE_BYTES, PricingVersion, RefundStatus, Replication, Transform,
+    use ic_types::{
+        RegistryVersion,
+        canister_http::{
+            MAX_CANISTER_HTTP_RESPONSE_BYTES, PricingVersion, RefundStatus, Replication, Transform,
+        },
     };
     use ic_types::{
         canister_http::CanisterHttpMethod, messages::CallbackId, time::UNIX_EPOCH,
@@ -654,6 +657,7 @@ mod tests {
                 replication: Replication::FullyReplicated,
                 pricing_version: PricingVersion::Legacy,
                 refund_status: RefundStatus::default(),
+                registry_version: RegistryVersion::from(1),
             },
             socks_proxy_addrs: vec![],
         }

--- a/rs/https_outcalls/consensus/benches/payload_validation.rs
+++ b/rs/https_outcalls/consensus/benches/payload_validation.rs
@@ -492,6 +492,7 @@ fn request_context(replication: Replication) -> CanisterHttpRequestContext {
         replication,
         pricing_version: PricingVersion::Legacy,
         refund_status: RefundStatus::default(),
+        registry_version: RegistryVersion::from(1),
     }
 }
 

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -846,7 +846,7 @@ fn non_replicated_request_response_coming_in_gossip_payload_created() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
-            registry_version: ic_types::RegistryVersion::from(0),
+            registry_version: RegistryVersion::from(1),
         };
 
         // Insert the context in the replicated state
@@ -918,7 +918,7 @@ fn non_replicated_request_with_extra_share_includes_only_delegated_share() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
-            registry_version: ic_types::RegistryVersion::from(0),
+            registry_version: RegistryVersion::from(1),
         };
 
         // Insert the context in the replicated state
@@ -991,7 +991,7 @@ fn non_replicated_share_is_ignored_if_content_is_missing() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
-            registry_version: ic_types::RegistryVersion::from(0),
+            registry_version: RegistryVersion::from(1),
         };
 
         inject_request_contexts(&mut payload_builder, [(callback_id, request_context)]);
@@ -1042,7 +1042,7 @@ fn validate_payload_succeeds_for_valid_non_replicated_response() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
-            registry_version: ic_types::RegistryVersion::from(0),
+            registry_version: RegistryVersion::from(1),
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1246,7 +1246,7 @@ fn validate_payload_fails_for_non_replicated_response_with_wrong_signer() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
-            registry_version: ic_types::RegistryVersion::from(0),
+            registry_version: RegistryVersion::from(1),
         };
 
         // Inject this context into the state reader.
@@ -1315,7 +1315,7 @@ fn validate_payload_fails_for_response_with_no_signatures() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
-            registry_version: ic_types::RegistryVersion::from(0),
+            registry_version: RegistryVersion::from(1),
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1391,7 +1391,7 @@ fn validate_payload_fails_when_non_replicated_proof_is_for_fully_replicated_requ
             replication: ic_types::canister_http::Replication::FullyReplicated,
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
-            registry_version: ic_types::RegistryVersion::from(0),
+            registry_version: RegistryVersion::from(1),
         };
 
         // Inject this context into the state reader.
@@ -1468,7 +1468,7 @@ fn validate_payload_fails_for_duplicate_non_replicated_response() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
-            registry_version: ic_types::RegistryVersion::from(0),
+            registry_version: RegistryVersion::from(1),
         };
 
         // 2. Inject this context into the state reader

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -846,6 +846,7 @@ fn non_replicated_request_response_coming_in_gossip_payload_created() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
+            registry_version: ic_types::RegistryVersion::from(0),
         };
 
         // Insert the context in the replicated state
@@ -917,6 +918,7 @@ fn non_replicated_request_with_extra_share_includes_only_delegated_share() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
+            registry_version: ic_types::RegistryVersion::from(0),
         };
 
         // Insert the context in the replicated state
@@ -989,6 +991,7 @@ fn non_replicated_share_is_ignored_if_content_is_missing() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
+            registry_version: ic_types::RegistryVersion::from(0),
         };
 
         inject_request_contexts(&mut payload_builder, [(callback_id, request_context)]);
@@ -1039,6 +1042,7 @@ fn validate_payload_succeeds_for_valid_non_replicated_response() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
+            registry_version: ic_types::RegistryVersion::from(0),
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1242,6 +1246,7 @@ fn validate_payload_fails_for_non_replicated_response_with_wrong_signer() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
+            registry_version: ic_types::RegistryVersion::from(0),
         };
 
         // Inject this context into the state reader.
@@ -1310,6 +1315,7 @@ fn validate_payload_fails_for_response_with_no_signatures() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
+            registry_version: ic_types::RegistryVersion::from(0),
         };
 
         // Inject this context into the state reader used by the validator.
@@ -1385,6 +1391,7 @@ fn validate_payload_fails_when_non_replicated_proof_is_for_fully_replicated_requ
             replication: ic_types::canister_http::Replication::FullyReplicated,
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
+            registry_version: ic_types::RegistryVersion::from(0),
         };
 
         // Inject this context into the state reader.
@@ -1461,6 +1468,7 @@ fn validate_payload_fails_for_duplicate_non_replicated_response() {
             replication: ic_types::canister_http::Replication::NonReplicated(delegated_node_id),
             pricing_version: ic_types::canister_http::PricingVersion::Legacy,
             refund_status: ic_types::canister_http::RefundStatus::default(),
+            registry_version: ic_types::RegistryVersion::from(0),
         };
 
         // 2. Inject this context into the state reader
@@ -4776,6 +4784,7 @@ pub(crate) fn request_context(replication: Replication) -> CanisterHttpRequestCo
         replication,
         pricing_version: ic_types::canister_http::PricingVersion::Legacy,
         refund_status: ic_types::canister_http::RefundStatus::default(),
+        registry_version: ic_types::RegistryVersion::from(0),
     }
 }
 
@@ -4800,6 +4809,7 @@ fn flexible_request_context(
         },
         pricing_version: ic_types::canister_http::PricingVersion::PayAsYouGo,
         refund_status: ic_types::canister_http::RefundStatus::default(),
+        registry_version: ic_types::RegistryVersion::from(0),
     }
 }
 

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -4784,7 +4784,7 @@ pub(crate) fn request_context(replication: Replication) -> CanisterHttpRequestCo
         replication,
         pricing_version: ic_types::canister_http::PricingVersion::Legacy,
         refund_status: ic_types::canister_http::RefundStatus::default(),
-        registry_version: ic_types::RegistryVersion::from(0),
+        registry_version: RegistryVersion::from(1),
     }
 }
 
@@ -4809,7 +4809,7 @@ fn flexible_request_context(
         },
         pricing_version: ic_types::canister_http::PricingVersion::PayAsYouGo,
         refund_status: ic_types::canister_http::RefundStatus::default(),
-        registry_version: ic_types::RegistryVersion::from(0),
+        registry_version: RegistryVersion::from(1),
     }
 }
 

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -787,6 +787,7 @@ pub mod test {
             replication,
             pricing_version,
             refund_status: RefundStatus::default(),
+            registry_version: RegistryVersion::from(1),
         }
     }
 

--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -161,6 +161,7 @@ message CanisterHttpRequestContext {
   optional Replication replication = 11;
   optional PricingVersion pricing_version = 12;
   optional RefundStatus refund_status = 13;
+  uint64 registry_version = 14;
   reserved 5;
 }
 

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -227,6 +227,8 @@ pub struct CanisterHttpRequestContext {
     pub pricing_version: ::core::option::Option<PricingVersion>,
     #[prost(message, optional, tag = "13")]
     pub refund_status: ::core::option::Option<RefundStatus>,
+    #[prost(uint64, tag = "14")]
+    pub registry_version: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RefundStatus {

--- a/rs/replicated_state/src/metadata_state/tests.rs
+++ b/rs/replicated_state/src/metadata_state/tests.rs
@@ -39,7 +39,7 @@ use ic_types::crypto::canister_threshold_sig::idkg::{IDkgDealers, IDkgReceivers,
 use ic_types::ingress::WasmResult;
 use ic_types::messages::{CallbackId, CanisterCall, Payload, Refund, Request, RequestMetadata};
 use ic_types::time::{CoarseTime, current_time};
-use ic_types::{ExecutionRound, Height};
+use ic_types::{ExecutionRound, Height, RegistryVersion};
 use ic_types_cycles::{Cycles, NominalCyclesTesting};
 use lazy_static::lazy_static;
 use maplit::btreemap;
@@ -868,6 +868,7 @@ fn subnet_call_contexts_deserialization() {
         replication: Replication::FullyReplicated,
         pricing_version: PricingVersion::Legacy,
         refund_status: RefundStatus::default(),
+        registry_version: RegistryVersion::from(1),
     };
     subnet_call_context_manager.push_context(SubnetCallContext::CanisterHttpRequest(
         canister_http_request,

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -137,6 +137,8 @@ pub struct CanisterHttpRequestContext {
     pub replication: Replication,
     pub pricing_version: PricingVersion,
     pub refund_status: RefundStatus,
+    /// The registry version at which this request is being processed.
+    pub registry_version: RegistryVersion,
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize)]
@@ -281,6 +283,7 @@ impl From<&CanisterHttpRequestContext> for pb_metadata::CanisterHttpRequestConte
             replication: Some(replication_message),
             pricing_version: Some(pricing_message),
             refund_status: Some(refund_status),
+            registry_version: context.registry_version.get(),
         }
     }
 }
@@ -405,6 +408,7 @@ impl TryFrom<pb_metadata::CanisterHttpRequestContext> for CanisterHttpRequestCon
             replication,
             pricing_version,
             refund_status,
+            registry_version: RegistryVersion::from(context.registry_version),
         })
     }
 }
@@ -595,6 +599,8 @@ impl CanisterHttpRequestContext {
                 refunded_cycles: Cycles::new(0),
                 refunding_nodes: BTreeSet::new(),
             },
+            // TODO: populate with the actual registry version this request is processed at.
+            registry_version: RegistryVersion::from(0),
         })
     }
 
@@ -704,6 +710,8 @@ impl CanisterHttpRequestContext {
                 refunded_cycles: Cycles::new(0),
                 refunding_nodes: BTreeSet::new(),
             },
+            // TODO: populate with the actual registry version this request is processed at.
+            registry_version: RegistryVersion::from(0),
         })
     }
 }
@@ -1264,6 +1272,7 @@ mod tests {
             replication: Replication::FullyReplicated,
             pricing_version: PricingVersion::Legacy,
             refund_status: RefundStatus::default(),
+            registry_version: RegistryVersion::from(1),
         };
 
         let expected_size = context.url.len()
@@ -1309,6 +1318,7 @@ mod tests {
             replication: Replication::FullyReplicated,
             pricing_version: PricingVersion::Legacy,
             refund_status: RefundStatus::default(),
+            registry_version: RegistryVersion::from(1),
         };
 
         let expected_size = context.url.len()
@@ -1388,6 +1398,7 @@ mod tests {
                     refunded_cycles: Cycles::new(123),
                     refunding_nodes: BTreeSet::from([node_test_id(1), node_test_id(2)]),
                 },
+                registry_version: RegistryVersion::from(7),
             };
 
             let pb: pb_metadata::CanisterHttpRequestContext = (&initial).into();


### PR DESCRIPTION
## Background

Currently, each node determines the registry version (thus committee) of an HTTP outcall by itself, depending on the  current finalized height at the time of the request:
https://github.com/dfinity/ic/blob/fe9e1b7a9a98ebafbf38230368226f4e928cc14f/rs/https_outcalls/consensus/src/pool_manager.rs#L577-L599

Additionally, HTTP shares with the wrong registry version are filtered out by the payload builder:
https://github.com/dfinity/ic/blob/fe9e1b7a9a98ebafbf38230368226f4e928cc14f/rs/https_outcalls/consensus/src/payload_builder.rs#L212-L213

However, since the exact timing of when an HTTP request is handled on each replica may be different, the current finalized height (and therefore the registry version) may be different, as well.

This has some adverse effects:

1. If the registry version changes after shares were produced, but before they were combined, the HTTP request will time out because shares with the old registry version are filtered out by the payload builder.
2. If a node produces some shares just before leaving the subnet, once these shares are received by its peers they might be invalidated, because to the rest of the subnet the node already left.
3. During membership changes, the HTTP outcalls committee will leave the subnet immediately without finishing outstanding requests first.

## Proposed Changes
Instead, the PR proposes to add a registry version to the `CanisterHttpRequestContext`. In the future, this registry version could be used as the single source of truth for all nodes on the subnet, throughout the entire duration of the request. Additionally, during membership changes, this would allow the committee of the request to remain on the subnet until the request context disappears from the state.

For compatibility reasons the registry version is still set to 0 (i.e. non-existent in the proto representation). Once this change is rolled out to all subnets, we can populate it with the actual registry version delivered to execution. In a subsequent release, we can then switch the source of truth to the new registry version in the context.