### PR TITLE
feat: Add delivered HTTP call contexts to subnet call context manager 

### DIFF
--- a/rs/protobuf/def/state/metadata/v1/metadata.proto
+++ b/rs/protobuf/def/state/metadata/v1/metadata.proto
@@ -306,6 +306,7 @@ message SubnetCallContextManager {
   repeated ReshareChainKeyContextTree reshare_chain_key_contexts = 17;
   repeated SignWithThresholdContextTree sign_with_threshold_contexts = 18;
   repeated PreSignatureStashTree pre_signature_stashes = 19;
+  repeated CanisterHttpRequestContextTree delivered_canister_http_request_contexts = 20;
 }
 
 message SubnetMetrics {

--- a/rs/protobuf/src/gen/state/state.metadata.v1.rs
+++ b/rs/protobuf/src/gen/state/state.metadata.v1.rs
@@ -453,6 +453,9 @@ pub struct SubnetCallContextManager {
     pub sign_with_threshold_contexts: ::prost::alloc::vec::Vec<SignWithThresholdContextTree>,
     #[prost(message, repeated, tag = "19")]
     pub pre_signature_stashes: ::prost::alloc::vec::Vec<PreSignatureStashTree>,
+    #[prost(message, repeated, tag = "20")]
+    pub delivered_canister_http_request_contexts:
+        ::prost::alloc::vec::Vec<CanisterHttpRequestContextTree>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SubnetMetrics {

--- a/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_call_context_manager.rs
@@ -217,6 +217,9 @@ pub struct SubnetCallContextManager {
     pub setup_initial_dkg_contexts: BTreeMap<CallbackId, SetupInitialDkgContext>,
     pub sign_with_threshold_contexts: BTreeMap<CallbackId, SignWithThresholdContext>,
     pub canister_http_request_contexts: BTreeMap<CallbackId, CanisterHttpRequestContext>,
+    /// `CanisterHttpRequestContext`s whose responses have already been delivered to execution.
+    /// They are kept here such that asynchronous refunds may continue to be processed.
+    pub delivered_canister_http_request_contexts: BTreeMap<CallbackId, CanisterHttpRequestContext>,
     pub reshare_chain_key_contexts: BTreeMap<CallbackId, ReshareChainKeyContext>,
     pub bitcoin_get_successors_contexts: BTreeMap<CallbackId, BitcoinGetSuccessorsContext>,
     pub bitcoin_send_transaction_internal_contexts:
@@ -743,6 +746,7 @@ mod testing {
             setup_initial_dkg_contexts: Default::default(),
             sign_with_threshold_contexts: Default::default(),
             canister_http_request_contexts: Default::default(),
+            delivered_canister_http_request_contexts: Default::default(),
             reshare_chain_key_contexts: Default::default(),
             bitcoin_get_successors_contexts: Default::default(),
             bitcoin_send_transaction_internal_contexts: Default::default(),

--- a/rs/replicated_state/src/metadata_state/subnet_call_context_manager/proto.rs
+++ b/rs/replicated_state/src/metadata_state/subnet_call_context_manager/proto.rs
@@ -59,6 +59,16 @@ impl From<&SubnetCallContextManager> for pb_metadata::SubnetCallContextManager {
                     },
                 )
                 .collect(),
+            delivered_canister_http_request_contexts: item
+                .delivered_canister_http_request_contexts
+                .iter()
+                .map(
+                    |(callback_id, context)| pb_metadata::CanisterHttpRequestContextTree {
+                        callback_id: callback_id.get(),
+                        context: Some(context.into()),
+                    },
+                )
+                .collect(),
             bitcoin_get_successors_contexts: item
                 .bitcoin_get_successors_contexts
                 .iter()
@@ -188,6 +198,17 @@ impl TryFrom<(Time, pb_metadata::SubnetCallContextManager)> for SubnetCallContex
             canister_http_request_contexts.insert(CallbackId::new(entry.callback_id), context);
         }
 
+        let mut delivered_canister_http_request_contexts =
+            BTreeMap::<CallbackId, CanisterHttpRequestContext>::new();
+        for entry in item.delivered_canister_http_request_contexts {
+            let context: CanisterHttpRequestContext = try_from_option_field(
+                entry.context,
+                "SystemMetadata::DeliveredCanisterHttpRequestContext",
+            )?;
+            delivered_canister_http_request_contexts
+                .insert(CallbackId::new(entry.callback_id), context);
+        }
+
         let mut reshare_chain_key_contexts = BTreeMap::<CallbackId, ReshareChainKeyContext>::new();
         for entry in item.reshare_chain_key_contexts {
             let pb_context =
@@ -261,6 +282,7 @@ impl TryFrom<(Time, pb_metadata::SubnetCallContextManager)> for SubnetCallContex
             setup_initial_dkg_contexts,
             sign_with_threshold_contexts,
             canister_http_request_contexts,
+            delivered_canister_http_request_contexts,
             bitcoin_get_successors_contexts,
             bitcoin_send_transaction_internal_contexts,
             canister_management_calls: CanisterManagementCalls {


### PR DESCRIPTION
Currently, all HTTP request contexts are stored in the same collection of the subnet call context manager. They are removed once consensus delivers a response to the canister.

In the future, there will be a second "asynchronous refund" phase as part of the context's life cycle: After consensus delivers the HTTP response and an _initial_ refund, consensus may continue to deliver _asynchronous_ refunds, that correspond to shares which didn't make it into the original response.

To do this, the context needs to persist even after a response was delivered.

This PR proposes to support this by introducing a second collection, which will hold such delivered contexts. Whenever a response is delivered, the corresponding context is moved into the new collection.

An alternative would have been to mark the context as "delivered", e.g. by setting a boolean flag. However, introducing a second collection has some natural advantages:
1. The size of the collection holding undelivered contexts is limited. Including delivered contexts in the same collection would therefore adversely affect throughput.
2. Some places will only want to look at undelivered contexts (I.e. response share aggregation & validation).
3. Some places will only want to look at delivered contexts (I.e. async refund creation & validation)
4. Some places will want to look at both collections (I.e share validation & purging), for which we can simply take the union of both collections.

Note that for compatibility reasons, the new collection is still unused.