### PR TITLE
chore(systest): sync Grafana dashboards in run_systest.sh

### DIFF
--- a/rs/tests/README_NEW.md
+++ b/rs/tests/README_NEW.md
@@ -91,7 +91,7 @@ If you already have a local clone of the dashboards, point `IC_DASHBOARDS_DIR` a
 ```
 devenv-container$ IC_DASHBOARDS_DIR=~/k8s/bases/apps/ic-dashboards bazel run //rs/tests/testnets:small
 ```
-When creating a testnet via `ict testnet create`, the dashboards are synced automatically; use `--k8s-branch` to override the branch.
+When creating a testnet via `ict testnet create`, a dashboard sync is attempted automatically (use `--k8s-branch` to override the branch). The sync is best-effort: if it fails (e.g. because SSH access to the k8s repository is unavailable) a warning is logged and the testnet is deployed without the dashboards.
 # Where do I get test logs and logs of the IC nodes?
 During/after test execution one may naturally be interested in looking at the test logs and logs produced by the IC nodes.
 ## For manual test executions

--- a/rs/tests/README_NEW.md
+++ b/rs/tests/README_NEW.md
@@ -5,6 +5,7 @@
     - [Via native Bazel commands](#via-native-bazel-commands)
     - [Via `ict` command line tool](#via-ict-command-line-tool)
   - [Running a cargo-based (legacy) flavour of a system test](#running-a-cargo-based-legacy-flavour-of-a-system-test)
+- [How do I get Grafana dashboards on a testnet?](#how-do-i-get-grafana-dashboards-on-a-testnet)
 - [Where do I get test logs and logs of the IC nodes?](#where-do-i-get-test-logs-and-logs-of-the-ic-nodes)
   - [For manual test executions](#for-manual-test-executions)
   - [For CI/CD test executions](#for-cicd-test-executions)
@@ -79,6 +80,18 @@ Finally, execute `basic_health_test` (which resides in the `hourly` suite) via p
 If you omit *--include-pattern*, the whole `hourly` test suite will be executed.
 
 **Important**: GuestOs image specified by the IC_VERSION_ID should be available in http://download.proxy-global.dfinity.network:8080/ic/IC_VERSION_ID/guest-os/disk-img-dev/disk-img.tar.zst. Otherwise, Farm will fail to setup the IC nodes and the test will fail in the setup phase.
+# How do I get Grafana dashboards on a testnet?
+System tests and testnets declared with `enable_metrics = True` spawn a Prometheus VM that also runs Grafana. To additionally provision the IC's Grafana dashboards (maintained in the [dfinity-ops/k8s](https://github.com/dfinity-ops/k8s) repository under `bases/apps/ic-dashboards`), set the `IC_DASHBOARDS_BRANCH` environment variable to the k8s branch you want to sync the dashboards from:
+```
+devenv-container$ IC_DASHBOARDS_BRANCH=main bazel run //rs/tests/testnets:small -- --keepalive
+```
+The dashboards are checked out by [run_systest.sh](https://github.com/dfinity/ic/blob/master/rs/tests/run_systest.sh) (which requires SSH access to the k8s repository) and exposed to the test driver via the `IC_DASHBOARDS_DIR` environment variable. For colocated tests the checked out directory is forwarded to the colocated test-driver VM automatically.
+
+If you already have a local clone of the dashboards, point `IC_DASHBOARDS_DIR` at it directly to skip the checkout:
+```
+devenv-container$ IC_DASHBOARDS_DIR=~/k8s/bases/apps/ic-dashboards bazel run //rs/tests/testnets:small
+```
+When creating a testnet via `ict testnet create`, the dashboards are synced automatically; use `--k8s-branch` to override the branch.
 # Where do I get test logs and logs of the IC nodes?
 During/after test execution one may naturally be interested in looking at the test logs and logs produced by the IC nodes.
 ## For manual test executions

--- a/rs/tests/ict/cmd/helpers.go
+++ b/rs/tests/ict/cmd/helpers.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/schollz/closestmatch"
@@ -197,73 +195,4 @@ func get_closest_target_matches(all_targets []string, target string) []string {
 	return filter(closest_matches, func(s string) bool {
 		return len(s) > 0
 	})
-}
-
-func sparse_checkout(repoUrl, repoDir string, sparseCheckoutPaths []string, branch string) (string, error) {
-	startingPoint, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("Could not get current dir: %v", err)
-	}
-
-	if repoDir == "" {
-		tempDir, err := os.UserCacheDir()
-		if err != nil {
-			return "", fmt.Errorf("Could not get user cache dir: %v", err)
-		}
-		repoDir = filepath.Join(tempDir, "k8s_repo")
-	}
-
-	defer func() {
-		os.Chdir(startingPoint)
-	}()
-
-	if err := os.RemoveAll(repoDir); err != nil {
-		return "", fmt.Errorf("Failed to remove directory: %v", err)
-	}
-
-	err = os.MkdirAll(repoDir, 0775)
-	if err != nil {
-		return "", fmt.Errorf("Could not create repo directory: %v", err)
-	}
-
-	cloneCmd := exec.Command("git", "clone", "--filter=blob:none", "--no-checkout", "--branch", branch, repoUrl, repoDir)
-	stdErrBuffer := &bytes.Buffer{}
-	cloneCmd.Stderr = stdErrBuffer
-	if err := cloneCmd.Run(); err != nil {
-		return "", fmt.Errorf("Failed to clone repository: %v\nStderr: %s", err, stdErrBuffer.String())
-	}
-
-	if err := os.Chdir(repoDir); err != nil {
-		return "", fmt.Errorf("Failed to chdir to repository: %v", err)
-	}
-
-	sparseCmd := exec.Command("git", "config", "core.sparseCheckout", "true")
-	if err := sparseCmd.Run(); err != nil {
-		return "", fmt.Errorf("Could not enable sparseCheckout: %v", err)
-	}
-
-	sparseFile := ".git/info/sparse-checkout"
-	f, err := os.OpenFile(sparseFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return "", fmt.Errorf("Could not open sparse-checkout file: %v", err)
-	}
-	defer f.Close()
-
-	for _, path := range sparseCheckoutPaths {
-		_, err = f.WriteString(path + "\n")
-		if err != nil {
-			return "", fmt.Errorf("Could not write sparse checkout path: %v", err)
-		}
-	}
-
-	checkoutCmd := exec.Command("git", "checkout", "HEAD")
-	if err := checkoutCmd.Run(); err != nil {
-		return "", fmt.Errorf("Could not perform git checkout: %v", err)
-	}
-
-	if err := os.Chdir(startingPoint); err != nil {
-		return "", fmt.Errorf("Could not return to the original directory: %v", err)
-	}
-
-	return repoDir, nil
 }

--- a/rs/tests/ict/cmd/testCmd.go
+++ b/rs/tests/ict/cmd/testCmd.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -20,7 +19,6 @@ type Config struct {
 	filterTests          string
 	farmBaseUrl          string
 	requiredHostFeatures string
-	k8sBranch            string
 }
 
 func TestCommandWithConfig(cfg *Config) func(cmd *cobra.Command, args []string) error {
@@ -42,19 +40,6 @@ func TestCommandWithConfig(cfg *Config) func(cmd *cobra.Command, args []string) 
 		}
 		command := []string{"bazel", "test", target, "--test_output=streamed"}
 		command = append(command, "--cache_test_results=no")
-		// Try and sync k8s dashboards
-		cmd.Println(GREEN + "Will try to sync dashboards from k8s branch: " + cfg.k8sBranch)
-		icDashboardsDir, err := sparse_checkout("git@github.com:dfinity-ops/k8s.git", "", []string{"bases/apps/ic-dashboards"}, cfg.k8sBranch)
-		if err != nil {
-			cmd.PrintErrln(YELLOW + "Failed to sync k8s dashboards. Received the following error: " + err.Error())
-		} else {
-			cmd.PrintErrln(GREEN + "Successfully synced dashboards to path " + icDashboardsDir)
-			icDashboardsDir = filepath.Join(icDashboardsDir, "bases", "apps", "ic-dashboards")
-			cmd.Println(GREEN + "Will use " + icDashboardsDir + " as a root for dashboards")
-
-			command = append(command, fmt.Sprintf("--test_env=IC_DASHBOARDS_DIR=%s", icDashboardsDir))
-			command = append(command, fmt.Sprintf("--sandbox_add_mount_pair=%s", icDashboardsDir))
-		}
 		if len(cfg.filterTests) > 0 {
 			command = append(command, "--test_arg=--include-tests="+cfg.filterTests)
 		}
@@ -102,7 +87,6 @@ func NewTestCmd() *cobra.Command {
 	testCmd.PersistentFlags().StringVarP(&cfg.filterTests, "include-tests", "i", "", "Execute only those test functions which contain a substring.")
 	testCmd.PersistentFlags().StringVarP(&cfg.farmBaseUrl, "farm-url", "", "", "Use a custom url for the Farm webservice.")
 	testCmd.PersistentFlags().StringVarP(&cfg.requiredHostFeatures, "set-required-host-features", "", "", "Set and override required host features of all hosts spawned.\nFeatures must be one or more of [dc=<dc-name>, host=<host-name>, AMD-SEV-SNP, performance, io-performance, dll, spm, dmz], separated by comma (see Examples).")
-	testCmd.PersistentFlags().StringVarP(&cfg.k8sBranch, "k8s-branch", "", "main", "Override the branch from which the dashboards are being synced. Default: main")
 	testCmd.SetOut(os.Stdout)
 	return testCmd
 }

--- a/rs/tests/ict/cmd/testnetCreateCmd.go
+++ b/rs/tests/ict/cmd/testnetCreateCmd.go
@@ -178,12 +178,14 @@ func TestnetCommand(cfg *TestnetConfig) func(cmd *cobra.Command, args []string) 
 		// driver via the IC_DASHBOARDS_DIR environment variable. If IC_DASHBOARDS_DIR is
 		// already set to a non-empty value (e.g. a local clone) run_systest.sh uses it
 		// directly and skips the checkout, so we only request a sync from the k8s branch
-		// otherwise. We treat an empty value as unset to match run_systest.sh.
+		// otherwise. We treat empty values as unset to match run_systest.sh.
 		if dashboardsDir := os.Getenv("IC_DASHBOARDS_DIR"); dashboardsDir != "" {
 			cmd.Println(GREEN + "Using Grafana dashboards from IC_DASHBOARDS_DIR: " + dashboardsDir + NC)
-		} else {
+		} else if cfg.k8sBranch != "" {
 			cmd.Println(GREEN + "Dashboards will be synced from k8s branch: " + cfg.k8sBranch + NC)
 			env = append(env, "IC_DASHBOARDS_BRANCH="+cfg.k8sBranch)
+		} else {
+			cmd.PrintErrln(YELLOW + "Both IC_DASHBOARDS_DIR and --k8s-branch are empty; Grafana dashboards will not be synced." + NC)
 		}
 		if len(cfg.farmBaseUrl) > 0 {
 			command = append(command, "--farm-base-url="+cfg.farmBaseUrl)

--- a/rs/tests/ict/cmd/testnetCreateCmd.go
+++ b/rs/tests/ict/cmd/testnetCreateCmd.go
@@ -174,16 +174,10 @@ func TestnetCommand(cfg *TestnetConfig) func(cmd *cobra.Command, args []string) 
 		command = append(command, "--")
 
 		env := os.Environ()
-		cmd.Println(GREEN + "Will try to sync dashboards from k8s branch: " + cfg.k8sBranch)
-		icDashboardsDir, err := sparse_checkout("git@github.com:dfinity-ops/k8s.git", "", []string{"bases/apps/ic-dashboards"}, cfg.k8sBranch)
-		if err != nil {
-			cmd.PrintErrln(YELLOW + "Failed to sync k8s dashboards. Received the following error: " + err.Error())
-		} else {
-			cmd.PrintErrln(GREEN + "Successfully synced dashboards to path " + icDashboardsDir)
-			icDashboardsDir = filepath.Join(icDashboardsDir, "bases", "apps", "ic-dashboards")
-			cmd.Println(GREEN + "Will use " + icDashboardsDir + " as a root for dashboards")
-			env = append(env, "IC_DASHBOARDS_DIR="+icDashboardsDir)
-		}
+		// run_systest.sh syncs the Grafana dashboards from this k8s branch and exposes
+		// them to the test driver via the IC_DASHBOARDS_DIR environment variable.
+		cmd.Println(GREEN + "Dashboards will be synced from k8s branch: " + cfg.k8sBranch + NC)
+		env = append(env, "IC_DASHBOARDS_BRANCH="+cfg.k8sBranch)
 		if len(cfg.farmBaseUrl) > 0 {
 			command = append(command, "--farm-base-url="+cfg.farmBaseUrl)
 		}

--- a/rs/tests/ict/cmd/testnetCreateCmd.go
+++ b/rs/tests/ict/cmd/testnetCreateCmd.go
@@ -174,10 +174,16 @@ func TestnetCommand(cfg *TestnetConfig) func(cmd *cobra.Command, args []string) 
 		command = append(command, "--")
 
 		env := os.Environ()
-		// run_systest.sh syncs the Grafana dashboards from this k8s branch and exposes
-		// them to the test driver via the IC_DASHBOARDS_DIR environment variable.
-		cmd.Println(GREEN + "Dashboards will be synced from k8s branch: " + cfg.k8sBranch + NC)
-		env = append(env, "IC_DASHBOARDS_BRANCH="+cfg.k8sBranch)
+		// run_systest.sh syncs the Grafana dashboards and exposes them to the test
+		// driver via the IC_DASHBOARDS_DIR environment variable. If IC_DASHBOARDS_DIR is
+		// already set (e.g. a local clone) run_systest.sh uses it directly and skips the
+		// checkout, so we only request a sync from the k8s branch otherwise.
+		if dashboardsDir, ok := os.LookupEnv("IC_DASHBOARDS_DIR"); ok {
+			cmd.Println(GREEN + "Using Grafana dashboards from IC_DASHBOARDS_DIR: " + dashboardsDir + NC)
+		} else {
+			cmd.Println(GREEN + "Dashboards will be synced from k8s branch: " + cfg.k8sBranch + NC)
+			env = append(env, "IC_DASHBOARDS_BRANCH="+cfg.k8sBranch)
+		}
 		if len(cfg.farmBaseUrl) > 0 {
 			command = append(command, "--farm-base-url="+cfg.farmBaseUrl)
 		}

--- a/rs/tests/ict/cmd/testnetCreateCmd.go
+++ b/rs/tests/ict/cmd/testnetCreateCmd.go
@@ -176,9 +176,10 @@ func TestnetCommand(cfg *TestnetConfig) func(cmd *cobra.Command, args []string) 
 		env := os.Environ()
 		// run_systest.sh syncs the Grafana dashboards and exposes them to the test
 		// driver via the IC_DASHBOARDS_DIR environment variable. If IC_DASHBOARDS_DIR is
-		// already set (e.g. a local clone) run_systest.sh uses it directly and skips the
-		// checkout, so we only request a sync from the k8s branch otherwise.
-		if dashboardsDir, ok := os.LookupEnv("IC_DASHBOARDS_DIR"); ok {
+		// already set to a non-empty value (e.g. a local clone) run_systest.sh uses it
+		// directly and skips the checkout, so we only request a sync from the k8s branch
+		// otherwise. We treat an empty value as unset to match run_systest.sh.
+		if dashboardsDir := os.Getenv("IC_DASHBOARDS_DIR"); dashboardsDir != "" {
 			cmd.Println(GREEN + "Using Grafana dashboards from IC_DASHBOARDS_DIR: " + dashboardsDir + NC)
 		} else {
 			cmd.Println(GREEN + "Dashboards will be synced from k8s branch: " + cfg.k8sBranch + NC)

--- a/rs/tests/run_systest.sh
+++ b/rs/tests/run_systest.sh
@@ -93,9 +93,12 @@ fi
 # at a local clone) we use that directly and skip the checkout.
 if [ -z "${IC_DASHBOARDS_DIR:-}" ] && [ -n "${IC_DASHBOARDS_BRANCH:-}" ]; then
     dashboards_repo="$TEST_TMPDIR/k8s_dashboards"
-    rm -rf "$dashboards_repo"
+    rm -rf "$dashboards_repo" || true
     echo "Syncing Grafana dashboards from k8s branch '$IC_DASHBOARDS_BRANCH' ..." >&2
-    if git clone --filter=blob:none --no-checkout --branch "$IC_DASHBOARDS_BRANCH" \
+    # Don't let a missing SSH key / unknown host key block the run by prompting
+    # interactively; fail fast instead (the sync is best-effort, see below).
+    if GIT_SSH_COMMAND="ssh -oBatchMode=yes" \
+        git clone --depth 1 --filter=blob:none --no-checkout --branch "$IC_DASHBOARDS_BRANCH" \
         git@github.com:dfinity-ops/k8s.git "$dashboards_repo" \
         && git -C "$dashboards_repo" config core.sparseCheckout true \
         && echo "bases/apps/ic-dashboards" >>"$dashboards_repo/.git/info/sparse-checkout" \

--- a/rs/tests/run_systest.sh
+++ b/rs/tests/run_systest.sh
@@ -85,6 +85,28 @@ if [ -n "$DC" ]; then
     export DC
 fi
 
+# Optionally sync Grafana dashboards from the dfinity-ops/k8s repo so they can be
+# provisioned on the Prometheus VM (see prometheus_vm.rs). This is enabled by setting
+# IC_DASHBOARDS_BRANCH to the desired branch of the k8s repo. The resulting directory is
+# exported as IC_DASHBOARDS_DIR which is read by the test driver (and forwarded to the
+# colocated UVM by colocate_test.rs). If IC_DASHBOARDS_DIR is already set (e.g. pointing
+# at a local clone) we use that directly and skip the checkout.
+if [ -z "${IC_DASHBOARDS_DIR:-}" ] && [ -n "${IC_DASHBOARDS_BRANCH:-}" ]; then
+    dashboards_repo="$TEST_TMPDIR/k8s_dashboards"
+    rm -rf "$dashboards_repo"
+    echo "Syncing Grafana dashboards from k8s branch '$IC_DASHBOARDS_BRANCH' ..." >&2
+    if git clone --filter=blob:none --no-checkout --branch "$IC_DASHBOARDS_BRANCH" \
+            git@github.com:dfinity-ops/k8s.git "$dashboards_repo" \
+        && git -C "$dashboards_repo" config core.sparseCheckout true \
+        && echo "bases/apps/ic-dashboards" >>"$dashboards_repo/.git/info/sparse-checkout" \
+        && git -C "$dashboards_repo" checkout HEAD; then
+        export IC_DASHBOARDS_DIR="$dashboards_repo/bases/apps/ic-dashboards"
+        echo "Synced Grafana dashboards to $IC_DASHBOARDS_DIR" >&2
+    else
+        echo "WARNING: failed to sync Grafana dashboards from k8s branch '$IC_DASHBOARDS_BRANCH'; continuing without them" >&2
+    fi
+fi
+
 exec \
     env -C "$TEST_TMPDIR" \
     "$(realpath $RUN_SCRIPT_TEST_EXECUTABLE)" \

--- a/rs/tests/run_systest.sh
+++ b/rs/tests/run_systest.sh
@@ -91,7 +91,13 @@ fi
 # exported as IC_DASHBOARDS_DIR which is read by the test driver (and forwarded to the
 # colocated UVM by colocate_test.rs). If IC_DASHBOARDS_DIR is already set (e.g. pointing
 # at a local clone) we use that directly and skip the checkout.
-if [ -z "${IC_DASHBOARDS_DIR:-}" ] && [ -n "${IC_DASHBOARDS_BRANCH:-}" ]; then
+if [ -n "${IC_DASHBOARDS_DIR:-}" ]; then
+    # A dashboards directory was provided directly. The driver is later executed with
+    # `env -C "$TEST_TMPDIR"`, so normalize a relative path to an absolute one now;
+    # otherwise it would be resolved against $TEST_TMPDIR and the dashboards wouldn't
+    # be found. Keep the original value if realpath fails (best-effort, non-fatal).
+    export IC_DASHBOARDS_DIR="$(realpath "$IC_DASHBOARDS_DIR" 2>/dev/null || echo "$IC_DASHBOARDS_DIR")"
+elif [ -n "${IC_DASHBOARDS_BRANCH:-}" ]; then
     dashboards_repo="$TEST_TMPDIR/k8s_dashboards"
     rm -rf "$dashboards_repo" || true
     echo "Syncing Grafana dashboards from k8s branch '$IC_DASHBOARDS_BRANCH' ..." >&2

--- a/rs/tests/run_systest.sh
+++ b/rs/tests/run_systest.sh
@@ -96,7 +96,7 @@ if [ -z "${IC_DASHBOARDS_DIR:-}" ] && [ -n "${IC_DASHBOARDS_BRANCH:-}" ]; then
     rm -rf "$dashboards_repo"
     echo "Syncing Grafana dashboards from k8s branch '$IC_DASHBOARDS_BRANCH' ..." >&2
     if git clone --filter=blob:none --no-checkout --branch "$IC_DASHBOARDS_BRANCH" \
-            git@github.com:dfinity-ops/k8s.git "$dashboards_repo" \
+        git@github.com:dfinity-ops/k8s.git "$dashboards_repo" \
         && git -C "$dashboards_repo" config core.sparseCheckout true \
         && echo "bases/apps/ic-dashboards" >>"$dashboards_repo/.git/info/sparse-checkout" \
         && git -C "$dashboards_repo" checkout HEAD; then

--- a/rs/tests/run_systest.sh
+++ b/rs/tests/run_systest.sh
@@ -101,7 +101,9 @@ if [ -z "${IC_DASHBOARDS_DIR:-}" ] && [ -n "${IC_DASHBOARDS_BRANCH:-}" ]; then
     #   (but still rejects a changed key) instead of prompting to confirm it.
     # - An isolated UserKnownHostsFile under $TEST_TMPDIR avoids touching or locking
     #   the user's ~/.ssh/known_hosts.
-    if GIT_SSH_COMMAND="ssh -oBatchMode=yes -oStrictHostKeyChecking=accept-new -oUserKnownHostsFile=$TEST_TMPDIR/k8s_known_hosts" \
+    # - ConnectTimeout + a single ConnectionAttempt bound how long we wait on
+    #   network/DNS issues so this best-effort sync fails fast instead of stalling.
+    if GIT_SSH_COMMAND="ssh -oBatchMode=yes -oStrictHostKeyChecking=accept-new -oUserKnownHostsFile=$TEST_TMPDIR/k8s_known_hosts -oConnectTimeout=15 -oConnectionAttempts=1" \
         git clone --depth 1 --filter=blob:none --no-checkout --branch "$IC_DASHBOARDS_BRANCH" \
         git@github.com:dfinity-ops/k8s.git "$dashboards_repo" \
         && git -C "$dashboards_repo" config core.sparseCheckout true \

--- a/rs/tests/run_systest.sh
+++ b/rs/tests/run_systest.sh
@@ -95,9 +95,13 @@ if [ -z "${IC_DASHBOARDS_DIR:-}" ] && [ -n "${IC_DASHBOARDS_BRANCH:-}" ]; then
     dashboards_repo="$TEST_TMPDIR/k8s_dashboards"
     rm -rf "$dashboards_repo" || true
     echo "Syncing Grafana dashboards from k8s branch '$IC_DASHBOARDS_BRANCH' ..." >&2
-    # Don't let a missing SSH key / unknown host key block the run by prompting
-    # interactively; fail fast instead (the sync is best-effort, see below).
-    if GIT_SSH_COMMAND="ssh -oBatchMode=yes" \
+    # Keep the clone fully non-interactive so it can't hang a Bazel run:
+    # - BatchMode disables password/passphrase prompts.
+    # - StrictHostKeyChecking=accept-new auto-accepts the host key on first contact
+    #   (but still rejects a changed key) instead of prompting to confirm it.
+    # - An isolated UserKnownHostsFile under $TEST_TMPDIR avoids touching or locking
+    #   the user's ~/.ssh/known_hosts.
+    if GIT_SSH_COMMAND="ssh -oBatchMode=yes -oStrictHostKeyChecking=accept-new -oUserKnownHostsFile=$TEST_TMPDIR/k8s_known_hosts" \
         git clone --depth 1 --filter=blob:none --no-checkout --branch "$IC_DASHBOARDS_BRANCH" \
         git@github.com:dfinity-ops/k8s.git "$dashboards_repo" \
         && git -C "$dashboards_repo" config core.sparseCheckout true \

--- a/rs/tests/run_systest.sh
+++ b/rs/tests/run_systest.sh
@@ -100,10 +100,12 @@ if [ -z "${IC_DASHBOARDS_DIR:-}" ] && [ -n "${IC_DASHBOARDS_BRANCH:-}" ]; then
     # - StrictHostKeyChecking=accept-new auto-accepts the host key on first contact
     #   (but still rejects a changed key) instead of prompting to confirm it.
     # - An isolated UserKnownHostsFile under $TEST_TMPDIR avoids touching or locking
-    #   the user's ~/.ssh/known_hosts.
+    #   the user's ~/.ssh/known_hosts. Its value is single-quoted because git runs
+    #   GIT_SSH_COMMAND through a shell, so a $TEST_TMPDIR containing spaces would
+    #   otherwise be split into multiple arguments.
     # - ConnectTimeout + a single ConnectionAttempt bound how long we wait on
     #   network/DNS issues so this best-effort sync fails fast instead of stalling.
-    if GIT_SSH_COMMAND="ssh -oBatchMode=yes -oStrictHostKeyChecking=accept-new -oUserKnownHostsFile=$TEST_TMPDIR/k8s_known_hosts -oConnectTimeout=15 -oConnectionAttempts=1" \
+    if GIT_SSH_COMMAND="ssh -oBatchMode=yes -oStrictHostKeyChecking=accept-new -oUserKnownHostsFile='$TEST_TMPDIR/k8s_known_hosts' -oConnectTimeout=15 -oConnectionAttempts=1" \
         git clone --depth 1 --filter=blob:none --no-checkout --branch "$IC_DASHBOARDS_BRANCH" \
         git@github.com:dfinity-ops/k8s.git "$dashboards_repo" \
         && git -C "$dashboards_repo" config core.sparseCheckout true \


### PR DESCRIPTION
We're planning to deprecate the `ict` tool. The last remaining use case for `ict` was that it would automatically checkout the Grafana dashboards from the [`dfinity-ops/k8s`](https://github.com/dfinity-ops/k8s) repository. 

This functionality has been moved into `rs/tests/run_systest.sh`, gated by a new `IC_DASHBOARDS_BRANCH` environment variable. `run_systest.sh` is the single chokepoint for both the plain testnet driver and the colocated wrapper, so exporting `IC_DASHBOARDS_DIR` there makes dashboards work uniformly with **no Rust changes**:

- The non-colocated driver reads `IC_DASHBOARDS_DIR` as before (`prometheus_vm.rs`).
- The colocated wrapper (`colocate_test.rs`) already tars `IC_DASHBOARDS_DIR`, ships it to the UVM and re-exports it into the inner docker container.

A pre-set `IC_DASHBOARDS_DIR` (e.g. a local clone) is honored and skips the checkout.

### Changes

- **`run_systest.sh`**: sparse-checkout `bases/apps/ic-dashboards` when `IC_DASHBOARDS_BRANCH` is set and `IC_DASHBOARDS_DIR` is not; non-fatal on failure.
- **`ict testnet create`**: sets `IC_DASHBOARDS_BRANCH` from `--k8s-branch` instead of doing the checkout itself (dashboards remain on by default).
- **`ict test`**: drops its dashboard checkout (the driver runs in a sandbox without SSH/network, so a runtime checkout can't work there). Users are encouraged to use `bazel run` to run a test with dashboards.
- **`helpers.go`**: removes the now-unused `sparse_checkout` helper.
- **`README_NEW.md`**: documents the `IC_DASHBOARDS_BRANCH` workflow.

## Usage

```
IC_DASHBOARDS_BRANCH=main bazel run //rs/tests/testnets:small -- --keepalive
...
2026-06-17 08:16:02.950 INFO[metrics_setup:rs/tests/driver/src/driver/log_events.rs:20:0] {"event_name":"grafana_instance_created_event","body":"Grafana at http://grafana.small--1781684079276837.testnet.farm.dfinity.systems"}
2026-06-17 08:16:02.950 INFO[metrics_setup:rs/tests/driver/src/driver/log_events.rs:20:0] {"event_name":"ic_progress_clock_created_event","body":"IC Progress Clock at http://grafana.small--1781684079276837.testnet.farm.dfinity.systems/d/ic-progress-clock/ic-progress-clock?refresh=10s&from=now-5m&to=now"}
```
<img width="1840" height="1196" alt="Screenshot 2026-06-17 at 10 18 36" src="https://github.com/user-attachments/assets/04ecf669-c27f-4180-b69c-b22ba7f59769" />

## Future Work

Start emitting deprecation warnings from `ict` and eventually remove it.