### PR TITLE
docs: add missing firewall rule scope in `ic-admin` docs

### DIFF
--- a/rs/registry/admin/bin/main.rs
+++ b/rs/registry/admin/bin/main.rs
@@ -3351,7 +3351,7 @@ impl ProposalPayload<UpdateFirewallRulesPayload> for ProposeToUpdateFirewallRule
 /// Sub-command to get all firewall rules for a given scope.
 #[derive(Parser)]
 struct GetFirewallRulesCmd {
-    /// The scope to apply new rules at (can be "global", "replica_nodes", "subnet(id)", or "node(id)")
+    /// The scope to apply new rules at (can be "global", "replica_nodes", "api_boundary_nodes", "subnet(id)", or "node(id)")
     pub scope: FirewallRulesScope,
 }
 


### PR DESCRIPTION
This tiny PR adds `api_boundary_nodes` as possible scope when fetching firewall rules in `ic-admin`'s documentation (see [source](https://sourcegraph.com/r/github.com/dfinity/ic@58168c8e1c6373a5e439729af87ddebebe369622/-/blob/rs/registry/keys/src/lib.rs?L192)).