### PR TITLE
chore: remove outdated unallowed log patterns

### DIFF
--- a/rs/tests/consensus/replica_determinism_test.rs
+++ b/rs/tests/consensus/replica_determinism_test.rs
@@ -185,6 +185,7 @@ fn main() -> Result<()> {
         //   Unexpected sandbox state for canister ...
         // Since this is expected we allow all panics in the "MR Batch Processor" thread:
         .add_unallowed_log_pattern_except("panicked", "MR Batch Processor")
+        .add_unallowed_log_pattern_except("panicked", "rs/state_manager/src/allowed_panics.rs")
         .execute_from_args()?;
     Ok(())
 }

--- a/rs/tests/driver/src/driver/group.rs
+++ b/rs/tests/driver/src/driver/group.rs
@@ -749,11 +749,7 @@ impl SystemTestGroup {
                     BTreeSet::from([
                         // Canisters are expected to panic:
                         "canister".to_string(),
-                        // TODO: remove the following two lines after mainnet has advanced to include the `allowed_panics.rs` changes:
-                        "rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs:2185".to_string(),
-                        "rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs:1030".to_string(),
                         "rs/canister_sandbox/src/replica_controller/allowed_panics.rs".to_string(),
-                        "rs/state_manager/src/allowed_panics.rs".to_string(),
                     ]),
                 ),
             ]),


### PR DESCRIPTION
Mainnet has long reached the `allowed_panics.rs` changes so follow the TODO.

Moreover, when `rs/state_manager/src/allowed_panics.rs` was included to the list of unallowed patterns (`"Replica diverged at height {}"`), I think (correct me if I'm wrong) it specifically targeted `replica_determinism_test`. Thus, move it there to avoid having false negatives on other tests that would fire this panic.