### PR TITLE
fix: deflake //rs/nervous_system/integration_tests:integration_tests_test_tests/sns_lifecycle

### DIFF
--- a/rs/nervous_system/integration_tests/BUILD.bazel
+++ b/rs/nervous_system/integration_tests/BUILD.bazel
@@ -196,6 +196,7 @@ rust_test_suite_with_extra_srcs(
             "tests/sns_topics.rs",
             "tests/sns_extension_test.rs",
             "tests/custom_proposal_criticality.rs",
+            "tests/sns_lifecycle.rs",
         ],
     ),
     data = DEV_DATA,
@@ -207,6 +208,30 @@ rust_test_suite_with_extra_srcs(
     ],
     tags = [
         "cpu:6",
+    ],
+    deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
+)
+
+rust_test(
+    name = "sns_lifecycle",
+    timeout = "long",
+    srcs = ["tests/sns_lifecycle.rs"],
+    data = DEV_DATA,
+    env = DEV_ENV | {
+        "RUST_TEST_NOCAPTURE": "1",
+        # Each SNS lifecycle scenario spins up a full NNS + SNS on the shared
+        # PocketIC server. Running all scenarios concurrently exhausts the
+        # server's memory, causing it to drop connections ("Connection reset by
+        # peer") and flake the test. Cap the number of concurrently running
+        # scenarios to keep the server's memory usage bounded.
+        "RUST_TEST_THREADS": "4",
+    },
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:rust_decimal_macros",
+    ],
+    tags = [
+        "cpu:8",
     ],
     deps = [":nervous_system_integration_tests"] + DEPENDENCIES_WITH_TEST_FEATURES,
 )


### PR DESCRIPTION
## Summary

Deflakes `//rs/nervous_system/integration_tests:integration_tests_test_tests/sns_lifecycle` by moving it into a dedicated `rust_test` target that limits how many SNS lifecycle scenarios run concurrently against the shared PocketIC server.

## Root cause

The `sns_lifecycle` binary contains 10 `#[tokio::test]` scenarios, each of which spins up a full NNS + SNS. `libtest` runs them concurrently (one thread per available CPU), and they all share a single PocketIC server process (every instance talks to the same `127.0.0.1:<port>`).

In the flaky runs (2026-06-16) **every one of the 10 PocketIC instances failed simultaneously** with:

```
HTTP failure: reqwest::Error { ... /update/await_ingress_message,
  source: ... Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" } }
```

(and `hyper::Error(IncompleteMessage)`), panicking at `packages/pocket-ic/src/nonblocking.rs:1733` — `builder.send().await.expect("HTTP failure")`, which does not retry on transient connection errors.

All instances dying at once points to the shared PocketIC **server process** itself going down under memory pressure (running ~10 full NNS+SNS replicas at the same time). It is transient — the test passes on the next attempt — which is consistent with memory pressure rather than a logic bug.

## Fix

Move `sns_lifecycle` out of the shared `integration_tests_test` suite into its own `rust_test` target (the pattern already documented in this BUILD file for the other flaky tests) and cap concurrency:

- `RUST_TEST_THREADS = "4"` — at most 4 live PocketIC instances at a time, which bounds the shared server's memory usage (the established pattern for PocketIC tests, e.g. `packages/pocket-ic`).
- `cpu:8` — matches the sibling `rs/sns/integration_tests` SNS tests and gives more scheduling headroom.
- `RUST_TEST_NOCAPTURE = "1"` — better logging, consistent with the other dedicated targets in this file.

The test label changes to `//rs/nervous_system/integration_tests:sns_lifecycle` (same convention as the other dedicated targets in this package). No CI/Bazel config referenced the old label.

## Verification

```
bazel test --test_output=errors --runs_per_test=3 --jobs=3 //rs/nervous_system/integration_tests:sns_lifecycle
```

→ `Stats over 3 runs: max = 301.7s, min = 295.8s, avg = 298.8s` — 3/3 passed. Runtime settles at ~300s, well under the `long` (900s) timeout (it was ~125–231s at full 10-way parallelism).

---

This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
