### PR TITLE
fix: deflake //rs/consensus:cup_explorer_test

### DIFF
--- a/rs/tests/consensus/cup_explorer_test.rs
+++ b/rs/tests/consensus/cup_explorer_test.rs
@@ -168,7 +168,7 @@ fn test(env: TestEnv) {
     );
     let update_subnet_payload = UpdateSubnetPayload {
         subnet_id: app_subnet.subnet_id,
-        dkg_interval_length: Some(14),
+        dkg_interval_length: Some(DKG_INTERVAL),
         subnet_admins: None,
         ..empty_subnet_update()
     };

--- a/rs/tests/consensus/cup_explorer_test.rs
+++ b/rs/tests/consensus/cup_explorer_test.rs
@@ -50,22 +50,11 @@ use slog::info;
 use tempfile::NamedTempFile;
 
 const DKG_INTERVAL: u64 = 14;
-// The recovery `setup_initial_dkg` is dealt by the NNS (system) subnet and must
-// complete within `MAX_REMOTE_DKG_ATTEMPTS` (= 5) of its DKG intervals, otherwise
-// the registry's `do_recover_subnet` traps and the RecoverSubnet proposal fails.
-// On the fast single-node NNS subnet a DKG interval lasts only a few wall-clock
-// seconds, which under CI load is not always enough for the single dealer to
-// produce the transcripts, making the test flaky. Use a longer interval for the
-// NNS subnet so each remote-DKG attempt has enough time to complete.
-const NNS_DKG_INTERVAL: u64 = 29;
 const NODES_COUNT: usize = 4;
 
 fn setup(env: TestEnv) {
     InternetComputer::new()
-        .add_subnet(
-            Subnet::fast_single_node(SubnetType::System)
-                .with_dkg_interval_length(Height::from(NNS_DKG_INTERVAL)),
-        )
+        .add_subnet(Subnet::fast_single_node(SubnetType::System))
         .add_subnet(
             Subnet::new(SubnetType::Application)
                 .with_dkg_interval_length(Height::from(DKG_INTERVAL))

--- a/rs/tests/consensus/cup_explorer_test.rs
+++ b/rs/tests/consensus/cup_explorer_test.rs
@@ -50,13 +50,22 @@ use slog::info;
 use tempfile::NamedTempFile;
 
 const DKG_INTERVAL: u64 = 14;
+// The recovery `setup_initial_dkg` is dealt by the NNS (system) subnet and must
+// complete within `MAX_REMOTE_DKG_ATTEMPTS` (= 5) of its DKG intervals, otherwise
+// the registry's `do_recover_subnet` traps and the RecoverSubnet proposal fails.
+// On the fast single-node NNS subnet a DKG interval lasts only a few wall-clock
+// seconds, which under CI load is not always enough for the single dealer to
+// produce and aggregate the recovery transcript, making the test flaky. Use a
+// longer interval for the NNS subnet so each remote-DKG attempt has enough time
+// to complete.
+const NNS_DKG_INTERVAL: u64 = 29;
 const NODES_COUNT: usize = 4;
 
 fn setup(env: TestEnv) {
     InternetComputer::new()
         .add_subnet(
             Subnet::fast_single_node(SubnetType::System)
-                .with_dkg_interval_length(Height::from(DKG_INTERVAL)),
+                .with_dkg_interval_length(Height::from(NNS_DKG_INTERVAL)),
         )
         .add_subnet(
             Subnet::new(SubnetType::Application)

--- a/rs/tests/consensus/cup_explorer_test.rs
+++ b/rs/tests/consensus/cup_explorer_test.rs
@@ -55,9 +55,8 @@ const DKG_INTERVAL: u64 = 14;
 // the registry's `do_recover_subnet` traps and the RecoverSubnet proposal fails.
 // On the fast single-node NNS subnet a DKG interval lasts only a few wall-clock
 // seconds, which under CI load is not always enough for the single dealer to
-// produce and aggregate the recovery transcript, making the test flaky. Use a
-// longer interval for the NNS subnet so each remote-DKG attempt has enough time
-// to complete.
+// produce the transcripts, making the test flaky. Use a longer interval for the
+// NNS subnet so each remote-DKG attempt has enough time to complete.
 const NNS_DKG_INTERVAL: u64 = 29;
 const NODES_COUNT: usize = 4;
 


### PR DESCRIPTION
`:cup_explorer_test` recently flaked with `Attempts to run this DKG repeatedly failed`. This happened to two runs already (on June 18th and on June 11th). Since this could be related to the recent DKG changes, I spent quite a bit of time to understand if there was a real regression, but it looks like the subnet genuinely does not have time to create the transcripts in one interval when CI is under load. The following is Claude's opinion, but @eichhorl you might want to take a closer look, here's the BuildBuddy [link](https://dash.dm1-idx1.dfinity.network/invocation/ebaae5b9-7402-4a0b-b827-5b662b81d096?target=%2F%2Frs%2Ftests%2Fconsensus%3Acup_explorer_test&targetStatus=11).

Why the DKG timed out — a timing/load race:

The NNS is `Subnet::fast_single_node(...)` with `DKG_INTERVAL = 14`. It produces a new DKG summary every ~3.5s (failed run: heights 300→315→330→345→360 at 15:01:36→…→15:01:50).
The recovery context appears at ~15:01:34.8, so it gets only ~5 fast intervals (~14–17s of wall-clock) to complete, while each interval already spends ~1.95s just loading the low‑threshold transcript on the single overloaded node.
**Failed run**: never completed in those 5 attempts. **Passed run**: the same DKG finished in ~1 interval (transcripts found at height 296, ~12s after the recover call). Purely a wall-clock-per-attempt race.