### PR TITLE
fix: PocketIC routing table to allow calling create_subnet on registry canister

### DIFF
--- a/packages/pocket-ic/tests/tests.rs
+++ b/packages/pocket-ic/tests/tests.rs
@@ -1612,7 +1612,7 @@ fn test_canister_http_with_diverging_responses() {
         decode_one(&reply).unwrap();
     let (reject_code, err) = http_response.unwrap_err();
     assert!(matches!(reject_code, RejectionCode::SysTransient));
-    let expected = "No consensus could be reached. Replicas had different responses. Details: request_id: 0, hashes: [ec0118708cdb890175109b257aece4779a6453f1e2f0dc9cfd46978ee7b283ad: 2], [b0fa9e9985163dc782fd1a946e1582e1c51d2825f4fc1b0b65bb000cfe9a99af: 2], [7c8ce9fe660424bcb0deff10465eae77bd56ffacb0c13818ed04794ccb016f9a: 2], [705d1d39d67ee696c5ffae7f4b2f942c31339c8b794cb1eeda1d225ece27e96f: 2], [0fee579fc0e9ff601e95608fc45be95e4e8c359dc54797bba539d064356798ef: 2], [015213f728bffa8fdd27447b7656e110d3bbc32abe3109bcb56d508ca0140a0e: 2], [77aa54142121a597b7596d91a74b83c2ea51633ca3956b403a78815590db54bb: 1]";
+    let expected = "No consensus could be reached. Replicas had different responses. Details: request_id: 0, hashes: [e8203df12a1c1734aaae2aabbc5593c826f7c89101779b1d29660d651fc2e5a5: 2], [9f82d623c709937029b6f6856eda7aebbfa4c59365a0dc394b6f0cc74c27439a: 2], [8e042d4f8e00bea6c6a1c1d45e4914e9fb9a4d9202a811d22b36a86ebfed41d7: 2], [77fb14e10d9f5f6fe6ee0755cbf541e5dfcb111751a6b435728100346d79eaee: 2], [3c588a6ce2fb45101724c539ac37243c7a0ae0382f124e5d0fd2708419ba468b: 2], [11f192558ce351114ca480f0d1e379e584dd7409734ca1fff6ba0dfc3780ff57: 2], [e29abfc2204e35d2808ad5eb78d7ed82fb9fe2daf86842bbd47e28f47bef3997: 1]";
     assert_eq!(err, expected);
 }
 

--- a/packages/pocket-ic/tests/unix.rs
+++ b/packages/pocket-ic/tests/unix.rs
@@ -175,7 +175,7 @@ async fn resume_killed_instance_impl(
 #[tokio::test]
 async fn resume_killed_instance_default() {
     let err = resume_killed_instance_impl(None).await.unwrap_err();
-    assert!(err.contains("The state of subnet with seed 7712b2c09cb96b3aa3fbffd4034a21a39d5d13f80e043161d1d71f4c593434af is incomplete."));
+    assert!(err.contains("The state of subnet with seed c75e6e3e57387b40c79cb9503f7c18518284981467d26ccfa7097343fa8bb808 is incomplete."));
 }
 
 // Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
@@ -184,7 +184,7 @@ async fn resume_killed_instance_strict() {
     let err = resume_killed_instance_impl(Some(IncompleteStateFlag::Disabled))
         .await
         .unwrap_err();
-    assert!(err.contains("The state of subnet with seed 7712b2c09cb96b3aa3fbffd4034a21a39d5d13f80e043161d1d71f4c593434af is incomplete."));
+    assert!(err.contains("The state of subnet with seed c75e6e3e57387b40c79cb9503f7c18518284981467d26ccfa7097343fa8bb808 is incomplete."));
 }
 
 // Killing the PocketIC server inside WSL is challenging => skipping this test on Windows.
@@ -717,7 +717,7 @@ fn create_subnet_in_registry_canister() {
     let add_node_operator_payload = AddNodeOperatorPayload {
         node_operator_principal_id: Some(PrincipalId(node_operator)),
         node_provider_principal_id: Some(PrincipalId(node_operator)),
-        max_rewardable_nodes: Some(btreemap! { "type1".to_string() => 1 }),
+        max_rewardable_nodes: Some(btreemap! { "type1".to_string() => 2 }),
         ..Default::default()
     };
     update_candid_as::<_, ()>(
@@ -729,35 +729,44 @@ fn create_subnet_in_registry_canister() {
     )
     .unwrap();
 
-    // Add a node (every subnet must have a node)
-    let add_node_payload = prepare_add_node_payload(1, NodeRewardType::Type1);
-    let node_id = update_candid_as::<_, (Principal,)>(
+    // Add two nodes, one for each subnet.
+    let node_id_1 = update_candid_as::<_, (Principal,)>(
         &pic,
         registry_canister_id,
         node_operator,
         "add_node",
-        (add_node_payload,),
+        (prepare_add_node_payload(1, NodeRewardType::Type1),),
+    )
+    .unwrap()
+    .0;
+    let node_id_2 = update_candid_as::<_, (Principal,)>(
+        &pic,
+        registry_canister_id,
+        node_operator,
+        "add_node",
+        (prepare_add_node_payload(2, NodeRewardType::Type1),),
     )
     .unwrap()
     .0;
 
-    // Add a subnet
-    let node_ids = vec![NodeId::new(PrincipalId(node_id))];
-    let create_subnet_payload = CreateSubnetPayload {
-        node_ids,
-        replica_version_id: ReplicaVersion::default().to_string(),
-        ..Default::default()
-    };
-    update_candid_as::<_, (Result<NewSubnet, String>,)>(
-        &pic,
-        registry_canister_id,
-        governance_canister_id,
-        "create_subnet",
-        (create_subnet_payload,),
-    )
-    .unwrap()
-    .0
-    .unwrap();
+    // Create two subnets, each with one node.
+    for node_id in [node_id_1, node_id_2] {
+        let create_subnet_payload = CreateSubnetPayload {
+            node_ids: vec![NodeId::new(PrincipalId(node_id))],
+            replica_version_id: ReplicaVersion::default().to_string(),
+            ..Default::default()
+        };
+        update_candid_as::<_, (Result<NewSubnet, String>,)>(
+            &pic,
+            registry_canister_id,
+            governance_canister_id,
+            "create_subnet",
+            (create_subnet_payload,),
+        )
+        .unwrap()
+        .0
+        .unwrap();
+    }
 }
 
 fn deploy_universal_canister(pic: &PocketIc) -> Principal {

--- a/rs/dogecoin/ckdoge/minter/tests/tests.rs
+++ b/rs/dogecoin/ckdoge/minter/tests/tests.rs
@@ -284,7 +284,7 @@ mod get_doge_address {
 
         assert_eq!(address_from_caller, address_with_owner);
         assert_eq!(
-            address_from_caller, "D95u8BQWiN21ER5LqrNwSk4WDVe25WHWHT",
+            address_from_caller, "D6ngYFXhH7Sct9FbBanqqrsco5FwzSpt4X",
             "BUG: result of public key derivation changed!"
         );
 
@@ -297,7 +297,7 @@ mod get_doge_address {
         );
         assert_ne!(address_from_caller, address_with_subaccount);
         assert_eq!(
-            address_with_subaccount, "DPZ2c7wS53i9nGrMh25iCZABdPs718NRA9",
+            address_with_subaccount, "D7K8TmiiVy5WbHVrVnJ6tobHvrzBEQqwxa",
             "BUG: result of public key derivation changed!"
         );
     }

--- a/rs/pocket_ic_server/CHANGELOG.md
+++ b/rs/pocket_ic_server/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The endpoint `/instances/<instance_id>/update/delete_subnet` to delete a subnet (non-named subnets only: application, cloud engine, system, or verified application subnets).
   If a state directory is configured for the instance, the deleted subnet's state directory is removed from disk.
 
+### Changed
+- Canister IDs allocated to newly created canisters without a specified canister ID.
+
+
+
 ## 14.0.0 - 2026-05-26
 
 ### Added

--- a/rs/pocket_ic_server/src/pocket_ic.rs
+++ b/rs/pocket_ic_server/src/pocket_ic.rs
@@ -3541,10 +3541,15 @@ impl RangeGen {
         Ok(())
     }
 
-    /// Returns the next canister id range from the top
+    /// Returns the next canister id range from the middle of the canister ID space.
     pub fn next_range(&mut self) -> CanisterIdRange {
         loop {
-            let offset = (u64::MAX / CANISTER_IDS_PER_SUBNET) - 1 - self.range_offset;
+            // Use the midpoint instead of u64::MAX so that the upper half of the canister ID
+            // space remains available for subnets created via the registry canister's
+            // `create_subnet` endpoint, which allocates new ranges by appending directly after
+            // the last existing range in the routing table.
+            let midpoint = u64::MAX / 2;
+            let offset = (midpoint / CANISTER_IDS_PER_SUBNET) - 1 - self.range_offset;
             self.range_offset += 1;
             let start = offset * CANISTER_IDS_PER_SUBNET;
             let end = ((offset + 1) * CANISTER_IDS_PER_SUBNET) - 1;

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -374,7 +374,7 @@ fn canister_and_replica_logs() {
         .unwrap()
         .read_to_string(&mut stdout)
         .unwrap();
-    assert!(stdout.contains("Finished executing install_code message on canister CanisterId(lxzze-o7777-77777-aaaaa-cai)"));
+    assert!(stdout.contains("Finished executing install_code message on canister CanisterId(xp3jw-ot777-77777-aaaaa-cai)"));
 
     let mut stderr = String::new();
     out.stderr
@@ -411,7 +411,7 @@ fn canister_and_no_replica_logs() {
         .unwrap()
         .read_to_string(&mut stdout)
         .unwrap();
-    assert!(!stdout.contains("Finished executing install_code message on canister CanisterId(lxzze-o7777-77777-aaaaa-cai)"));
+    assert!(!stdout.contains("Finished executing install_code message on canister CanisterId(xp3jw-ot777-77777-aaaaa-cai)"));
 
     let mut stderr = String::new();
     out.stderr
@@ -838,7 +838,7 @@ fn with_app_subnet_state_twice() {
 
 #[test]
 #[should_panic(
-    expected = "The actual subnet canister ranges [CanisterIdRange { start: CanisterId(rwlgt-iiaaa-aaaaa-aaaaa-cai), end: CanisterId(renrk-eyaaa-aaaaa-aaada-cai) }, CanisterIdRange { start: CanisterId(qoctq-giaaa-aaaaa-aaaea-cai), end: CanisterId(n5n4y-3aaaa-aaaaa-p777q-cai) }, CanisterIdRange { start: CanisterId(lxzze-o7777-77777-aaaaa-cai), end: CanisterId(x47dp-5x777-77777-p777q-cai) }] for the subnet kind Application are not disjoint from the canister ranges [CanisterIdRange { start: CanisterId(rwlgt-iiaaa-aaaaa-aaaaa-cai), end: CanisterId(renrk-eyaaa-aaaaa-aaada-cai) }, CanisterIdRange { start: CanisterId(qoctq-giaaa-aaaaa-aaaea-cai), end: CanisterId(n5n4y-3aaaa-aaaaa-p777q-cai) }] for a different subnet kind NNS."
+    expected = "The actual subnet canister ranges [CanisterIdRange { start: CanisterId(rwlgt-iiaaa-aaaaa-aaaaa-cai), end: CanisterId(renrk-eyaaa-aaaaa-aaada-cai) }, CanisterIdRange { start: CanisterId(qoctq-giaaa-aaaaa-aaaea-cai), end: CanisterId(n5n4y-3aaaa-aaaaa-p777q-cai) }, CanisterIdRange { start: CanisterId(xp3jw-ot777-77777-aaaaa-cai), end: CanisterId(le5t5-53777-77777-p777q-cai) }] for the subnet kind Application are not disjoint from the canister ranges [CanisterIdRange { start: CanisterId(rwlgt-iiaaa-aaaaa-aaaaa-cai), end: CanisterId(renrk-eyaaa-aaaaa-aaada-cai) }, CanisterIdRange { start: CanisterId(qoctq-giaaa-aaaaa-aaaea-cai), end: CanisterId(n5n4y-3aaaa-aaaaa-p777q-cai) }] for a different subnet kind NNS."
 )]
 fn with_nns_as_app_subnet_state() {
     let (_state_dir, nns_state_dir) = create_nns_subnet_state();
@@ -851,7 +851,7 @@ fn with_nns_as_app_subnet_state() {
 
 #[test]
 #[should_panic(
-    expected = "The actual subnet canister ranges [CanisterIdRange { start: CanisterId(lxzze-o7777-77777-aaaaa-cai), end: CanisterId(x47dp-5x777-77777-p777q-cai) }] do not contain the canister ranges [CanisterIdRange { start: CanisterId(rwlgt-iiaaa-aaaaa-aaaaa-cai), end: CanisterId(renrk-eyaaa-aaaaa-aaada-cai) }, CanisterIdRange { start: CanisterId(qoctq-giaaa-aaaaa-aaaea-cai), end: CanisterId(n5n4y-3aaaa-aaaaa-p777q-cai) }] expected for the subnet kind NNS."
+    expected = "The actual subnet canister ranges [CanisterIdRange { start: CanisterId(xp3jw-ot777-77777-aaaaa-cai), end: CanisterId(le5t5-53777-77777-p777q-cai) }] do not contain the canister ranges [CanisterIdRange { start: CanisterId(rwlgt-iiaaa-aaaaa-aaaaa-cai), end: CanisterId(renrk-eyaaa-aaaaa-aaada-cai) }, CanisterIdRange { start: CanisterId(qoctq-giaaa-aaaaa-aaaea-cai), end: CanisterId(n5n4y-3aaaa-aaaaa-p777q-cai) }] expected for the subnet kind NNS."
 )]
 fn with_app_as_nns_subnet_state() {
     let (_state_dir, app_state_dir) = create_app_subnet_state();

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -374,7 +374,7 @@ fn canister_and_replica_logs() {
         .unwrap()
         .read_to_string(&mut stdout)
         .unwrap();
-    assert!(stdout.contains("Finished executing install_code message on canister CanisterId(xp3jw-ot777-77777-aaaaa-cai)"));
+assert!(stdout.contains(&format!("Finished executing install_code message on canister CanisterId({})", canister_id)));
 
     let mut stderr = String::new();
     out.stderr

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -374,7 +374,10 @@ fn canister_and_replica_logs() {
         .unwrap()
         .read_to_string(&mut stdout)
         .unwrap();
-assert!(stdout.contains(&format!("Finished executing install_code message on canister CanisterId({})", canister_id)));
+    assert!(stdout.contains(&format!(
+        "Finished executing install_code message on canister CanisterId({})",
+        canister_id
+    )));
 
     let mut stderr = String::new();
     out.stderr
@@ -411,7 +414,10 @@ fn canister_and_no_replica_logs() {
         .unwrap()
         .read_to_string(&mut stdout)
         .unwrap();
-assert!(!stdout.contains(&format!("Finished executing install_code message on canister CanisterId({})", canister_id)));
+    assert!(!stdout.contains(&format!(
+        "Finished executing install_code message on canister CanisterId({})",
+        canister_id
+    )));
 
     let mut stderr = String::new();
     out.stderr

--- a/rs/pocket_ic_server/tests/test.rs
+++ b/rs/pocket_ic_server/tests/test.rs
@@ -411,7 +411,7 @@ fn canister_and_no_replica_logs() {
         .unwrap()
         .read_to_string(&mut stdout)
         .unwrap();
-    assert!(!stdout.contains("Finished executing install_code message on canister CanisterId(xp3jw-ot777-77777-aaaaa-cai)"));
+assert!(!stdout.contains(&format!("Finished executing install_code message on canister CanisterId({})", canister_id)));
 
     let mut stderr = String::new();
     out.stderr


### PR DESCRIPTION
This PR fixes the PocketIC routing table so that there are many canister ranges of the default size (1M canisters) beyond its last range and repeatedly calling `create_subnet` on the registry canister succeeds.