### PR TITLE
feat: open app API BN's SOCKS proxy to cloud engines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10277,6 +10277,7 @@ dependencies = [
  "ic-metrics",
  "ic-protobuf",
  "ic-registry-client-helpers",
+ "ic-registry-keys",
  "ic-registry-subnet-features",
  "ic-registry-subnet-type",
  "ic-replicated-state",
@@ -10296,6 +10297,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "slog",
+ "strum 0.26.3",
 ]
 
 [[package]]

--- a/rs/https_outcalls/consensus/BUILD.bazel
+++ b/rs/https_outcalls/consensus/BUILD.bazel
@@ -66,6 +66,7 @@ rust_test(
         "//rs/monitoring/metrics",
         "//rs/protobuf",
         "//rs/registry/helpers",
+        "//rs/registry/keys",
         "//rs/registry/subnet_features",
         "//rs/registry/subnet_type",
         "//rs/replicated_state",
@@ -89,6 +90,7 @@ rust_test(
         "@crate_index//:rand",
         "@crate_index//:rand_chacha",
         "@crate_index//:slog",
+        "@crate_index//:strum",
     ],
 )
 

--- a/rs/https_outcalls/consensus/Cargo.toml
+++ b/rs/https_outcalls/consensus/Cargo.toml
@@ -36,6 +36,7 @@ ic-consensus-mocks = { path = "../../consensus/mocks" }
 ic-crypto-temp-crypto = { path = "../../crypto/temp_crypto" }
 ic-error-types = { path = "../../../packages/ic-error-types" }
 ic-interfaces-mocks = { path = "../../interfaces/mocks" }
+ic-registry-keys = { path = "../../registry/keys" }
 ic-registry-subnet-features = { path = "../../registry/subnet_features" }
 ic-test-utilities = { path = "../../test_utilities" }
 ic-test-utilities-consensus = { path = "../../test_utilities/consensus" }
@@ -50,6 +51,7 @@ criterion = { workspace = true }
 mockall = { workspace = true }
 proptest = { workspace = true }
 rand_chacha = { workspace = true }
+strum = { workspace = true }
 
 [features]
 proptest = []

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -3674,7 +3674,7 @@ pub mod test {
                     })
                     .collect::<Vec<_>>();
 
-                for (subnet_type, expected) in cases {
+                for (subnet_type, mut expected) in cases {
                     let shim: Arc<Mutex<CanisterHttpAdapterClient>> =
                         Arc::new(Mutex::new(Box::new(MockNonBlockingChannel::<
                             CanisterHttpRequest,
@@ -3694,7 +3694,6 @@ pub mod test {
 
                     let mut actual = pool_manager.get_socks_proxy_addrs();
                     actual.sort();
-                    let mut expected = expected.clone();
                     expected.sort();
 
                     assert_eq!(

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -208,11 +208,10 @@ impl CanisterHttpPoolManagerImpl {
             SubnetType::System => self
                 .registry_client
                 .get_system_api_boundary_node_ids(latest_registry_version),
-            SubnetType::Application | SubnetType::VerifiedApplication => self
-                .registry_client
-                .get_app_api_boundary_node_ids(latest_registry_version),
-            // Cloud engines are not allowed to use the SOCKS proxy of the API BNs
-            SubnetType::CloudEngine => Ok(Vec::new()),
+            SubnetType::Application | SubnetType::VerifiedApplication | SubnetType::CloudEngine => {
+                self.registry_client
+                    .get_app_api_boundary_node_ids(latest_registry_version)
+            }
         };
 
         allowed_boundary_nodes
@@ -713,13 +712,16 @@ pub mod test {
     use ic_interfaces_state_manager::Labeled;
     use ic_logger::replica_logger::no_op_logger;
     use ic_metrics::MetricsRegistry;
+    use ic_protobuf::registry::api_boundary_node::v1::ApiBoundaryNodeRecord;
+    use ic_protobuf::registry::node::v1::{ConnectionEndpoint, NodeRecord};
+    use ic_registry_keys::{make_api_boundary_node_record_key, make_node_record_key};
     use ic_replicated_state::metadata_state::subnet_call_context_manager::SubnetCallContext;
     use ic_test_utilities_logger::with_test_replica_logger;
-    use ic_test_utilities_types::ids::subnet_test_id;
+    use ic_test_utilities_types::ids::{node_test_id, subnet_test_id};
     use ic_types::CountBytes;
     use ic_types::crypto::crypto_hash;
     use ic_types::{
-        Height, NumBytes, RegistryVersion,
+        Height, NodeId, NumBytes, RegistryVersion,
         crypto::{CryptoHash, CryptoHashOf},
         messages::CallbackId,
         time::UNIX_EPOCH,
@@ -728,6 +730,7 @@ pub mod test {
     use mockall::predicate::*;
     use mockall::*;
     use std::{collections::BTreeMap, str::FromStr};
+    use strum::IntoEnumIterator;
 
     mock! {
         pub NonBlockingChannel<Request: 'static> {
@@ -3573,6 +3576,132 @@ pub mod test {
                     CanisterHttpChangeAction::HandleInvalid(_, reason)
                         if reason == "Refund is greater than replica allowance"
                 );
+            })
+        });
+    }
+
+    /// `get_socks_proxy_addrs` must route the SOCKS proxy through the API
+    /// boundary nodes that match the subnet type: `System` subnets use the
+    /// *system* API boundary nodes, while all other subnet types use the *app*
+    /// API boundary nodes.
+    #[test]
+    fn test_get_socks_proxy_addrs_selects_boundary_nodes_by_subnet_type() {
+        ic_test_utilities::artifact_pool_config::with_test_pool_config(|pool_config| {
+            with_test_replica_logger(|log| {
+                let Dependencies {
+                    pool,
+                    replica_config,
+                    crypto,
+                    state_manager,
+                    registry,
+                    registry_data_provider,
+                    ..
+                } = dependencies(pool_config.clone(), 1);
+
+                // Register a handful of API boundary nodes, each with a distinct
+                // HTTP endpoint. `get_{system,app}_api_boundary_node_ids` splits the
+                // sorted node IDs in half, so we need several nodes to obtain a
+                // non-empty, disjoint system/app split.
+                let registry_version = RegistryVersion::from(2);
+                let boundary_nodes: Vec<(NodeId, String)> = (1..=4)
+                    .map(|i| (node_test_id(i), format!("2001:db8::{i}")))
+                    .collect();
+
+                for (node_id, ip_addr) in &boundary_nodes {
+                    registry_data_provider
+                        .add(
+                            &make_api_boundary_node_record_key(*node_id),
+                            registry_version,
+                            Some(ApiBoundaryNodeRecord::default()),
+                        )
+                        .unwrap();
+                    registry_data_provider
+                        .add(
+                            &make_node_record_key(*node_id),
+                            registry_version,
+                            Some(NodeRecord {
+                                http: Some(ConnectionEndpoint {
+                                    ip_addr: ip_addr.clone(),
+                                    port: 8080,
+                                }),
+                                ..Default::default()
+                            }),
+                        )
+                        .unwrap();
+                }
+                registry.update_to_latest_version();
+
+                // Derive the SOCKS proxy address that the pool manager is expected to
+                // emit for a given boundary node.
+                let socks_addr = |node_id: &NodeId| {
+                    let ip_addr = &boundary_nodes
+                        .iter()
+                        .find(|(id, _)| id == node_id)
+                        .expect("unknown boundary node id")
+                        .1;
+                    format!("socks5h://[{ip_addr}]:1080")
+                };
+                let expected_system: Vec<String> = registry
+                    .get_system_api_boundary_node_ids(registry_version)
+                    .unwrap()
+                    .iter()
+                    .map(socks_addr)
+                    .collect();
+                let expected_app: Vec<String> = registry
+                    .get_app_api_boundary_node_ids(registry_version)
+                    .unwrap()
+                    .iter()
+                    .map(socks_addr)
+                    .collect();
+
+                // The two sets must be non-empty and disjoint, otherwise the test
+                // could not tell which group of boundary nodes was contacted.
+                assert!(!expected_system.is_empty());
+                assert!(!expected_app.is_empty());
+                assert!(expected_system.iter().all(|a| !expected_app.contains(a)));
+
+                // System subnets contact the system boundary nodes; every other
+                // subnet type contacts the app boundary nodes.
+                let cases = SubnetType::iter()
+                    .map(|subnet_type| {
+                        let expected = match subnet_type {
+                            SubnetType::System => expected_system.clone(),
+                            SubnetType::Application
+                            | SubnetType::VerifiedApplication
+                            | SubnetType::CloudEngine => expected_app.clone(),
+                        };
+                        (subnet_type, expected)
+                    })
+                    .collect::<Vec<_>>();
+
+                for (subnet_type, expected) in cases {
+                    let shim: Arc<Mutex<CanisterHttpAdapterClient>> =
+                        Arc::new(Mutex::new(Box::new(MockNonBlockingChannel::<
+                            CanisterHttpRequest,
+                        >::new())));
+
+                    let pool_manager = CanisterHttpPoolManagerImpl::new(
+                        state_manager.clone() as Arc<_>,
+                        shim,
+                        crypto.clone(),
+                        pool.get_cache(),
+                        replica_config.clone(),
+                        subnet_type,
+                        Arc::clone(&registry) as Arc<_>,
+                        MetricsRegistry::new(),
+                        log.clone(),
+                    );
+
+                    let mut actual = pool_manager.get_socks_proxy_addrs();
+                    actual.sort();
+                    let mut expected = expected.clone();
+                    expected.sort();
+
+                    assert_eq!(
+                        actual, expected,
+                        "subnet type {subnet_type:?} contacted the wrong API boundary nodes"
+                    );
+                }
             })
         });
     }

--- a/rs/orchestrator/src/firewall.rs
+++ b/rs/orchestrator/src/firewall.rs
@@ -436,7 +436,11 @@ impl Firewall {
             .is_system_api_boundary_node(self.node_id, registry_version)
         {
             Ok(true) => vec![SubnetType::System],
-            Ok(false) => vec![SubnetType::Application, SubnetType::VerifiedApplication],
+            Ok(false) => vec![
+                SubnetType::Application,
+                SubnetType::VerifiedApplication,
+                SubnetType::CloudEngine,
+            ],
             Err(err) => {
                 warn!(
                     every_n_seconds => 30,

--- a/rs/orchestrator/testdata/nftables_boundary_node_app_subnet.conf.golden
+++ b/rs/orchestrator/testdata/nftables_boundary_node_app_subnet.conf.golden
@@ -92,7 +92,7 @@ table ip6 filter {
     ip6 saddr { ::/64 } ct state { new } tcp dport { 7070, 9091, 9100, 9324, 19531, 19100, 19522 } accept
     ip6 saddr { ::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff } ct state new tcp dport 443 accept
 
-    ip6 saddr {3fda:92b7:4c1e:8a23:7d61:2f9c:ab42:19e5,3fda:92b7:4c1e:8a23:7d61:2f9c:ab42:19e6,3fda:92b7:4c1e:8a23:7d61:2f9c:ab42:19e7} ct state { new } tcp dport {1080} accept # nodes for SOCKS proxy
+    ip6 saddr {2001:db8:85a3::8a2e:1370:7334,3fda:92b7:4c1e:8a23:7d61:2f9c:ab42:19e5,3fda:92b7:4c1e:8a23:7d61:2f9c:ab42:19e6,3fda:92b7:4c1e:8a23:7d61:2f9c:ab42:19e7} ct state { new } tcp dport {1080} accept # nodes for SOCKS proxy
 ip6 saddr {::ffff:5.5.5.5} ct state { new } tcp dport {1005} accept # node_gol4s-2gsaq-aaaaa-aaaap-2ai
 ip6 saddr {::ffff:7.7.7.7} ct state { new } tcp dport {1007} accept # api_boundary_nodes
 ip6 saddr {::ffff:6.6.6.6} ct state { new } tcp dport {1006} accept # global

--- a/rs/tests/networking/canister_http/canister_http.rs
+++ b/rs/tests/networking/canister_http/canister_http.rs
@@ -318,6 +318,14 @@ pub fn get_node_snapshots(env: &TestEnv) -> Box<dyn Iterator<Item = IcNodeSnapsh
         .nodes()
 }
 
+pub fn get_cloud_engine_node_snapshots(env: &TestEnv) -> Box<dyn Iterator<Item = IcNodeSnapshot>> {
+    env.topology_snapshot()
+        .subnets()
+        .find(|subnet| subnet.subnet_type() == SubnetType::CloudEngine)
+        .expect("there is no cloud engine")
+        .nodes()
+}
+
 pub fn get_all_application_subnets(env: &TestEnv) -> Vec<SubnetSnapshot> {
     env.topology_snapshot()
         .subnets()

--- a/rs/tests/networking/canister_http_socks_test.rs
+++ b/rs/tests/networking/canister_http_socks_test.rs
@@ -4,15 +4,16 @@ Title:: HTTP requests from canisters to remote IPv4 service through socks proxy 
 Goal:: Ensure that only system subnets with the feature enabled can access IPv4 endpoints.
 
 Runbook::
-1. Instantiate an IC with one applications and one system subnet with the HTTP feature enabled.
+1. Instantiate an IC with one application, one cloud engine and one system subnet with the HTTP feature enabled.
 2. Install NNS canisters
 3. Install the proxy canister on both subnets.
 4. Make a http outcall request to the IPv4 interface of the http server from the system subnet.
 5. Make a http outcall request to the IPv4 interface of the http server from the application subnet.
+6. Make a http outcall request to the IPv4 interface of the http server from the cloud engine.
 
 Success::
-1. Received http response with status 200 for system subnet.
-2. Received failed to connect error from application subnet.
+1. Received http response with status 200 that is routed through the correct API boundary node (system
+   API BN for system subnet, application API BN for application and cloud engine subnets).
 
 end::catalog[] */
 #![allow(deprecated)]
@@ -48,6 +49,7 @@ fn main() -> Result<()> {
         .with_setup(setup)
         .add_test(systest!(test_system_subnet))
         .add_test(systest!(test_application_subnet))
+        .add_test(systest!(test_cloud_engine))
         .execute_from_args()?;
 
     Ok(())
@@ -84,8 +86,16 @@ pub fn setup(env: TestEnv) {
                 })
                 .add_nodes(4),
         )
+        .add_subnet(
+            Subnet::new(SubnetType::CloudEngine)
+                .with_features(SubnetFeatures {
+                    http_requests: true,
+                    ..SubnetFeatures::default()
+                })
+                .add_nodes(4),
+        )
         // 2 api boundary nodes, one for system subnets, one for application subnets
-        .with_api_boundary_nodes(2)
+        .with_api_boundary_nodes_playnet(2)
         .setup_and_start(&env)
         .expect("failed to setup IC under test");
 
@@ -118,6 +128,18 @@ pub fn test_application_subnet(env: TestEnv) {
     setup_and_run_subnet_test(env, "application", subnet_nodes, api_bn_ips);
 }
 
+/// Tests that an outcall from the cloud engine is routed via an APPLICATION API BN.
+pub fn test_cloud_engine(env: TestEnv) {
+    let subnet_nodes: Vec<IcNodeSnapshot> = get_cloud_engine_node_snapshots(&env).collect();
+    let api_bn_ips: Vec<String> = env
+        .topology_snapshot()
+        .app_api_boundary_nodes()
+        .map(|bn| bn.get_ip_addr().to_string())
+        .collect();
+
+    setup_and_run_subnet_test(env, "cloud engine", subnet_nodes, api_bn_ips);
+}
+
 fn setup_and_run_subnet_test(
     env: TestEnv,
     subnet_type_str: &str,
@@ -148,14 +170,19 @@ fn setup_and_run_subnet_test(
     let runtime = get_runtime_from_node(canister_node);
     let proxy_canister = create_proxy_canister(&env, &runtime, canister_node);
 
+    let api_bn_type = match subnet_type_str {
+        s @ "system" | s @ "application" => s,
+        "cloud engine" => "application",
+        _ => panic!("Unknown subnet type string"),
+    };
     info!(
         &logger,
-        "Expecting {} API BN IPs: {:?}", subnet_type_str, api_bn_ips
+        "Expecting {} API BN IPs: {:?}", api_bn_type, api_bn_ips
     );
     assert!(
         !api_bn_ips.is_empty(),
         "No {} API boundary nodes found!",
-        subnet_type_str
+        api_bn_type
     );
 
     run_http_outcall_test(

--- a/rs/tests/networking/canister_http_socks_test.rs
+++ b/rs/tests/networking/canister_http_socks_test.rs
@@ -1,7 +1,9 @@
 /* tag::catalog[]
 Title:: HTTP requests from canisters to remote IPv4 service through socks proxy on API boundary node.
 
-Goal:: Ensure that only system subnets with the feature enabled can access IPv4 endpoints.
+Goal:: Ensure that HTTP requests from canisters to a remote IPv4 service are routed through the
+correct API boundary node (system API BN for system subnet, application API BN for application and
+cloud engine subnets).
 
 Runbook::
 1. Instantiate an IC with one application, one cloud engine and one system subnet with the HTTP feature enabled.
@@ -12,8 +14,7 @@ Runbook::
 6. Make a http outcall request to the IPv4 interface of the http server from the cloud engine.
 
 Success::
-1. Received http response with status 200 that is routed through the correct API boundary node (system
-   API BN for system subnet, application API BN for application and cloud engine subnets).
+1. Received http response with status 200 that is routed through the correct API boundary node.
 
 end::catalog[] */
 #![allow(deprecated)]

--- a/rs/tests/networking/canister_http_socks_test.rs
+++ b/rs/tests/networking/canister_http_socks_test.rs
@@ -8,7 +8,7 @@ cloud engine subnets).
 Runbook::
 1. Instantiate an IC with one application, one cloud engine and one system subnet with the HTTP feature enabled.
 2. Install NNS canisters
-3. Install the proxy canister on both subnets.
+3. Install the proxy canister on all subnets.
 4. Make a http outcall request to the IPv4 interface of the http server from the system subnet.
 5. Make a http outcall request to the IPv4 interface of the http server from the application subnet.
 6. Make a http outcall request to the IPv4 interface of the http server from the cloud engine.


### PR DESCRIPTION
This PR enables cloud engines to make HTTP outcalls to IPv4-only upstreams by using the application API BNs' SOCKS proxies.

The `//rs/tests/networking:canister_http_socks_test` is tagged as manual because is flaky (see NET-1710) but I ran it manually and it passes.