### PR TITLE
fix: re-use container autobuild message

### DIFF
--- a/.github/workflows/container-autobuild.yml
+++ b/.github/workflows/container-autobuild.yml
@@ -155,7 +155,10 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         with:
           script: |
-            let message = 'Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n\n'
+            // Hidden marker used to find this workflow's comment on subsequent runs
+            const marker = '<!-- container-autobuild-image-tag -->';
+            let message = marker + '\n'
+            message += 'Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n\n'
             message += 'New container images with tag: `${{ needs.build-image-prep.outputs.image_tag }}`\n'
             message += 'ic-build: `${{ needs.ic-build-image.outputs.ic-build-imageid }}`\n'
             message += 'ic-dev: `${{ needs.ic-build-image.outputs.ic-dev-imageid }}`\n'
@@ -169,7 +172,7 @@ jobs:
 
             const botComment = comments.data.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('New container image:')
+              comment.body.includes(marker)
             );
 
             if (botComment) {


### PR DESCRIPTION
The container autobuild tries to reuse the same message to avoid spamming PRs, but as see in https://github.com/dfinity/ic/pull/10533 this broke along the way because the looked up string changed.

This changes the mechanism to use a marker hidden in an HTML comment.