### PR TITLE
chore: Use unbuffered sed for serial log processing

### DIFF
--- a/ic-os/components/monitoring/hostos/export-guestos-serial-logs.sh
+++ b/ic-os/components/monitoring/hostos/export-guestos-serial-logs.sh
@@ -5,6 +5,6 @@
 set -e
 
 # Strip ANSI color/escape codes from serial console output before forwarding to journald
-tail -F /var/log/libvirt/qemu/guestos-serial.log | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\[[0-9]\+;[0-9;]*m//g' | systemd-cat -t guestos-serial -p info &
-tail -F /var/log/libvirt/qemu/upgrade-guestos-serial.log | sed 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\[[0-9]\+;[0-9;]*m//g' | systemd-cat -t upgrade-guestos-serial -p info &
+tail -F /var/log/libvirt/qemu/guestos-serial.log | sed --unbuffered 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\[[0-9]\+;[0-9;]*m//g' | systemd-cat -t guestos-serial -p info &
+tail -F /var/log/libvirt/qemu/upgrade-guestos-serial.log | sed --unbuffered 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\[[0-9]\+;[0-9;]*m//g' | systemd-cat -t upgrade-guestos-serial -p info &
 wait


### PR DESCRIPTION
Sed buffering often causes the log tail not to be exported if no more logs are produced by the Guest VM.