### PR TITLE
fix: deflake //rs/tests/message_routing/xnet:xnet_slo_120_subnets_staging_test_colocate

### DIFF
--- a/rs/tests/message_routing/xnet/slo_test_lib/xnet_slo_test_lib.rs
+++ b/rs/tests/message_routing/xnet/slo_test_lib/xnet_slo_test_lib.rs
@@ -135,10 +135,9 @@ impl Config {
         config
     }
 
-    pub fn with_send_rate_threshold(self, send_rate_threshold: f64) -> Self {
-        let mut config = self.clone();
-        config.send_rate_threshold = send_rate_threshold;
-        config
+    pub fn with_send_rate_threshold(mut self, send_rate_threshold: f64) -> Self {
+        self.send_rate_threshold = send_rate_threshold;
+        self
     }
 
     pub fn with_payload_bytes(self, payload_size_bytes: u64) -> Self {

--- a/rs/tests/message_routing/xnet/slo_test_lib/xnet_slo_test_lib.rs
+++ b/rs/tests/message_routing/xnet/slo_test_lib/xnet_slo_test_lib.rs
@@ -135,6 +135,12 @@ impl Config {
         config
     }
 
+    pub fn with_send_rate_threshold(self, send_rate_threshold: f64) -> Self {
+        let mut config = self.clone();
+        config.send_rate_threshold = send_rate_threshold;
+        config
+    }
+
     pub fn with_payload_bytes(self, payload_size_bytes: u64) -> Self {
         let mut config = self.clone();
         config.request_payload_size_bytes = payload_size_bytes;

--- a/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
@@ -16,7 +16,14 @@ fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE)
         // Only best-effort calls with 30 seconds timeout, so the test doesn't hang for
         // minutes in case we can't connect to some replica/subnet to pull.
-        .with_call_timeouts(&[Some(30)]);
+        .with_call_timeouts(&[Some(30)])
+        // With 120 single-node subnets colocated on shared performance hardware, the
+        // per-subnet block production rate varies between runs. On loaded runs a few
+        // "straggler" subnets dip just below the default 0.3 send rate threshold (down
+        // to ~0.28), while on unloaded runs the minimum is ~0.43. Lower the threshold to
+        // 0.2 to absorb this hardware variance while still catching systemic XNet
+        // regressions (the median send rate is ~0.7).
+        .with_send_rate_threshold(0.2);
     let test = config.clone().test();
 
     SystemTestGroup::new()


### PR DESCRIPTION
## Summary

Deflakes `//rs/tests/message_routing/xnet:xnet_slo_120_subnets_staging_test_colocate`, which intermittently fails the **"Send rate below 0.3"** SLO check.

## Root cause analysis

I downloaded the last week's flaky runs and inspected the `FAILED.log` of each (attempt 1) alongside the `PASSED.log` retry (attempt 2). In **every** flaky run the *only* failure was the send-rate check, failing on just 2–3 of the 120 subnets:

| Invocation (date) | Attempt 1 (FAILED) min send rate | # subnets < 0.3 | Attempt 2 (PASSED) min send rate | # subnets < 0.3 |
|---|---|---|---|---|
| 2026-06-19 | 0.292 | 2 | 0.452 | 0 |
| 2026-06-21 | 0.290 | 3 | 0.442 | 0 |
| 2026-06-22 | 0.295 | 2 | 0.453 | 0 |
| 2026-06-23 | 0.280 | 2 | 0.433 | 0 |

The `send_rate` metric is essentially the fraction of the theoretical maximum block/message rate a subnet achieves. The test asserts every subnet stays `>= SEND_RATE_THRESHOLD` (0.3).

This test colocates **120 single-node subnets on shared performance hardware**, so the per-subnet block production rate varies between runs depending on load. The bulk of subnets land at 0.46–0.95 (median ~0.7), but on loaded runs a couple of "straggler" subnets dip just below 0.3 (0.28–0.297). On the retry the same subnets comfortably exceed 0.3 (min ~0.43–0.45). The 0.3 threshold sits right in this run-to-run variance band, which is what makes the test flaky.

This is a different root cause from the previous fix attempt (#10243), which addressed call timeouts/latency.

## Fix

- Add a `with_send_rate_threshold` builder to the shared `Config` (consistent with the existing `with_call_timeouts` / `with_payload_bytes` builders).
- Lower this test's send-rate threshold from 0.3 to **0.2**.

0.2 sits safely below the worst observed straggler (0.28) while still catching systemic XNet regressions: a genuine messaging regression would depress send rates across *all* subnets (median ~0.7), not just a couple of stragglers, and a subnet producing fewer than 0.2 blocks/s (1 block per 5 s) clearly indicates a real problem. Only this test is affected; the 3-/29-subnet and compatibility tests keep their existing thresholds.

## Verification

- `cargo clippy` on `xnet-slo-test-lib` and `message-routing-system-tests-xnet`: clean.
- `bazel build //rs/tests/message_routing/xnet:xnet_slo_120_subnets_staging_test_colocate`: succeeds.
- The full system test is left to CI (it allocates 120+ VMs on shared Farm infrastructure per run).

---
This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.
