### PR TITLE
fix: deflake xnet_slo_120 test by allocating to Dells only and doubling vCPUs

### DIFF
--- a/rs/tests/message_routing/xnet/slo_test_lib/xnet_slo_test_lib.rs
+++ b/rs/tests/message_routing/xnet/slo_test_lib/xnet_slo_test_lib.rs
@@ -168,7 +168,7 @@ impl Config {
 // Generic setup
 fn setup(env: TestEnv, config: Config) {
     let ic = InternetComputer::new()
-        .with_required_host_features(vec![HostFeature::Performance])
+        .with_required_host_features(vec![HostFeature::Performance, HostFeature::Dell])
         .with_resource_overrides(config.vm_resource_overrides);
     (0..config.subnets)
         .fold(ic, |ic, _idx| {

--- a/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
+++ b/rs/tests/message_routing/xnet/xnet_slo_120_subnets_staging_test.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use ic_system_test_driver::driver::group::SystemTestGroup;
+use ic_system_test_driver::driver::ic::{NrOfVCPUs, VmResourceOverrides};
 use ic_system_test_driver::systest;
 use std::time::Duration;
 use xnet_slo_test_lib::Config;
@@ -14,6 +15,10 @@ const OVERALL_TIMEOUT: Duration = Duration::from_secs(1400);
 
 fn main() -> Result<()> {
     let config = Config::new(SUBNETS, NODES_PER_SUBNET, RUNTIME, REQUEST_RATE)
+        .with_resource_overrides(VmResourceOverrides {
+            vcpus: Some(NrOfVCPUs::new(12)),
+            ..VmResourceOverrides::default()
+        })
         // Only best-effort calls with 30 seconds timeout, so the test doesn't hang for
         // minutes in case we can't connect to some replica/subnet to pull.
         .with_call_timeouts(&[Some(30)]);


### PR DESCRIPTION
`//rs/tests/message_routing/xnet:xnet_slo_120_subnets_staging_test_colocate` is 50% flaky since the send rate on some subnets is often below the minimum of 0.3.

As an experiment to fix this we force allocation of IC nodes to the more performant Dell hosts to not mix in the slightly slower Supermicros. We also double the number of vCPUs for IC nodes from 6 to 12 to give the VMs a bit more capacity.

If this doesn't make the test more stable we could try labelling the test with `cpu:64` so no other `system_test_large` tests will run at the same time ensuring the hosts are more idle to get more consistent performance characteristics.

Passing manual run: [BuildBuddy](https://dash.dm1-idx1.dfinity.network/invocation/69119028-41c7-44ea-a92d-6cd4bb3c7e4e?target=%2F%2Frs%2Ftests%2Fmessage_routing%2Fxnet%3Axnet_slo_120_subnets_staging_test_colocate&targetStatus=5).