### PR TITLE
docs: add docs for dependencies jobs

### DIFF
--- a/ci/src/dependencies/README.md
+++ b/ci/src/dependencies/README.md
@@ -1,0 +1,56 @@
+# Dependency Management & Vulnerability Scanning
+
+This directory contains the Python tooling that the IC repository uses to track
+its dependencies and scan them for known vulnerabilities. The tooling runs from
+GitHub Actions workflows (see [`.github/workflows`](../../../.github/workflows))
+and reports findings to GitHub, Jira, and Slack.
+
+## Overview
+
+There are two independent jobs, each documented in detail under [`docs/`](docs):
+
+| Job | What it does | Entry point | Documentation |
+| --- | --- | --- | --- |
+| **Dependency submission** | Parses the Rust Bazel lock file (`Cargo.Bazel.toml.lock`) and submits the resolved dependency graph to GitHub, feeding Dependabot alerts and the PR dependency-review check. | [`job/bazel_rust_gh_submission_job.py`](job/bazel_rust_gh_submission_job.py) | [docs/dependency_submission_job.md](docs/dependency_submission_job.md) |
+| **Trivy container scanner** | Periodically scans the IC OS container image(s) with Trivy for vulnerable OS packages, vulnerable binaries, and leaked secrets, tracking each finding in Jira and notifying owners via Slack. | [`job/bazel_trivy_container_ic_scanner_periodic_job.py`](job/bazel_trivy_container_ic_scanner_periodic_job.py) | [docs/trivy_scanner_job.md](docs/trivy_scanner_job.md) |
+
+The two jobs are complementary:
+
+- the **dependency submission** job covers the repo's **Rust crate** dependencies
+  and routes findings through GitHub's native supply-chain tooling;
+- the **Trivy** job covers what is actually **baked into the shipped container
+  image** (OS packages, binaries, secrets) and routes findings through Jira and
+  Slack.
+
+## CI jobs at a glance
+
+| Workflow / action | Trigger | Runs |
+| --- | --- | --- |
+| [`bazel-dependency-submission.yml`](../../../.github/workflows/bazel-dependency-submission.yml) | push to `master` | dependency submission job |
+| [`security-checks.yml`](../../../.github/workflows/security-checks.yml) | `pull_request_target` | dependency submission job (PR lock file) + `dependency-review-action` |
+| [`container-scan-nightly.yml`](../../../.github/workflows/container-scan-nightly.yml) | nightly cron + `workflow_dispatch` | Trivy container scanner job |
+
+See the per-job docs for triggers, required environment variables, and the full
+data flow.
+
+## Directory layout
+
+| Path | Contents |
+| --- | --- |
+| [`job/`](job) | Job entry points (run from CI). |
+| [`config/`](config) | Static configuration, e.g. which images the Trivy job scans. |
+| [`scanner/`](scanner) | Generic scan orchestration and the Trivy dependency manager + result parsers. |
+| [`parser/`](parser) | `Cargo.Bazel.toml.lock` → GitHub manifest parser used by the submission job. |
+| [`data_source/`](data_source) | Finding persistence (Jira) and the Slack failover store. |
+| [`integration/`](integration) | GitHub and Slack API integrations. |
+| [`notification/`](notification) | Notification configuration and dispatch. |
+| [`model/`](model) | Shared domain types (`Finding`, `Dependency`, `Project`, `Team`, ...). |
+| [`docs/`](docs) | Per-job documentation (see table above). |
+
+## Running locally
+
+Both jobs expect `PYTHONPATH` to include `ci/src` and `ci/src/dependencies` and
+the packages in [`requirements.txt`](requirements.txt) to be installed. They also
+require the credentials listed in each job's documentation (GitHub token, and for
+the Trivy job a Jira token and a Slack bot token). Refer to the workflow files and
+the per-job docs for the exact environment.

--- a/ci/src/dependencies/docs/dependency_submission_job.md
+++ b/ci/src/dependencies/docs/dependency_submission_job.md
@@ -1,0 +1,120 @@
+# Dependency Submission Job
+
+## Purpose
+
+The dependency submission job parses the Bazel-managed Rust dependency lock file
+(`Cargo.Bazel.toml.lock`) and submits the resolved dependency graph to GitHub via
+the [Dependency submission REST API][gh-dep-submission]. Once submitted, the
+dependencies show up in the repository's
+[dependency graph][gh-dep-graph], which in turn powers
+[Dependabot alerts][gh-dependabot] and the
+[`dependency-review-action`][gh-dep-review] used by the
+[`security-checks.yml`](#security-checksyml-pull-requests) workflow.
+
+In short: this job is how the IC repo's Rust crate dependencies become visible to
+GitHub's vulnerability tooling.
+
+[gh-dep-submission]: https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository
+[gh-dep-graph]: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph
+[gh-dependabot]: https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts
+[gh-dep-review]: https://github.com/actions/dependency-review-action
+
+## Entry point
+
+[`job/bazel_rust_gh_submission_job.py`](../job/bazel_rust_gh_submission_job.py)
+
+The entry point is intentionally tiny:
+
+1. It determines the base directory that contains the lock file:
+   - `GITHUB_PR_DIR` if set (used by the PR workflow to point at the PR checkout
+     while running from the base-branch checkout), otherwise
+   - `GITHUB_WORKSPACE` (the default checkout directory).
+2. It calls `GithubApi.submit_dependencies([(basedir, "Cargo.Bazel.toml.lock")])`.
+
+## How it works
+
+```
+Cargo.Bazel.toml.lock
+        │
+        ▼
+parser/bazel_toml_parser.py        parse_bazel_toml_to_gh_manifest()
+        │   resolves every package + its dependencies into a
+        │   GitHub "manifest" of pkg:cargo/<name>@<version> entries
+        ▼
+integration/github/github_dependency_submission.py   (dataclasses for the
+        │   GitHub snapshot payload: detector, job, manifests, ...)
+        ▼
+integration/github/github_api.py   GithubApi.submit_dependencies()
+        │   builds the snapshot request and POSTs it to
+        │   /repos/{owner}/{repo}/dependency-graph/snapshots
+        ▼
+GitHub dependency graph
+```
+
+Key implementation details:
+
+- **Parsing** ([`parser/bazel_toml_parser.py`](../parser/bazel_toml_parser.py)):
+  `parse_bazel_toml_to_gh_manifest` reads the TOML lock file and emits a
+  `GHSubManifest` of resolved `pkg:cargo/<name>@<version>` package URLs. Direct
+  dependencies in the lock file may be written as either `"<name>"` or
+  `"<name> <version>"`, so packages are scanned twice to build lookup maps before
+  the dependency references are resolved. Ambiguous or missing references raise a
+  `RuntimeError`.
+- **Submission** ([`integration/github/github_api.py`](../integration/github/github_api.py)):
+  `submit_dependencies` assembles a `GHSubRequest` (detector
+  `bazel-rust-detector`, correlator
+  `Bazel Dependency Submission / bazel-dependency-submission`) and POSTs the
+  JSON snapshot. The call is retried up to 6 times with exponential backoff and
+  only treats HTTP `201` as success.
+
+## Required environment
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `GITHUB_TOKEN` | yes | Token used to authenticate the snapshot POST. If unset the job raises. |
+| `GITHUB_REPOSITORY` | yes | `owner/repo` used to build the snapshot URL. |
+| `GITHUB_RUN_ID` | yes | Used as the submission job id. |
+| `GITHUB_REF` | yes | Git ref recorded on the snapshot. |
+| `GITHUB_SHA` / `GITHUB_PR_SHA` | yes | Commit recorded on the snapshot (`GITHUB_PR_SHA` wins if set). |
+| `GITHUB_WORKSPACE` / `GITHUB_PR_DIR` | yes | Directory containing `Cargo.Bazel.toml.lock` (`GITHUB_PR_DIR` wins if set). |
+
+## CI jobs that use this job
+
+### `bazel-dependency-submission.yml` (push to master)
+
+[`.github/workflows/bazel-dependency-submission.yml`](../../../../.github/workflows/bazel-dependency-submission.yml)
+
+- **Trigger:** every push to `master`.
+- **What it does:** checks out the repo, installs `requirements.txt`, and runs
+  `job/bazel_rust_gh_submission_job.py` with `GITHUB_WORKSPACE` as the base
+  directory. This keeps the dependency graph on `master` up to date so Dependabot
+  has an accurate baseline.
+- **Permissions:** `contents: write` (required to write the snapshot).
+
+### `security-checks.yml` (pull requests)
+
+[`.github/workflows/security-checks.yml`](../../../../.github/workflows/security-checks.yml)
+
+- **Trigger:** `pull_request_target`.
+- **What it does:**
+  1. Checks out the base branch (`master`) into `base/` and the PR head into
+     `pr/` (sparse checkout of just `Cargo.Bazel.toml.lock`).
+  2. Runs `job/bazel_rust_gh_submission_job.py` from the `base/` checkout but with
+     `GITHUB_PR_DIR` pointing at the `pr/` checkout, so the **PR's** lock file is
+     submitted as a snapshot for the PR's head commit.
+  3. Runs [`actions/dependency-review-action`][gh-dep-review] with
+     `fail-on-severity: moderate`, which compares the submitted snapshot against
+     the base and fails the PR if it introduces dependencies with known
+     vulnerabilities of moderate severity or higher.
+- **Permissions:** `contents: write`.
+
+> Note: this workflow uses `pull_request_target`, so it runs trusted code from
+> the base branch with access to secrets while only the PR's lock file is checked
+> out into `pr/`.
+
+## Related files
+
+- [`job/bazel_rust_gh_submission_job.py`](../job/bazel_rust_gh_submission_job.py) — entry point.
+- [`parser/bazel_toml_parser.py`](../parser/bazel_toml_parser.py) — lock-file parser.
+- [`integration/github/github_dependency_submission.py`](../integration/github/github_dependency_submission.py) — snapshot payload dataclasses.
+- [`integration/github/github_api.py`](../integration/github/github_api.py) — `submit_dependencies` implementation.

--- a/ci/src/dependencies/docs/trivy_scanner_job.md
+++ b/ci/src/dependencies/docs/trivy_scanner_job.md
@@ -1,0 +1,164 @@
+# Trivy Container Scanner Job
+
+## Purpose
+
+The Trivy scanner job periodically scans the IC OS container image(s) for
+vulnerable OS packages, vulnerable binaries, and leaked secrets using
+[Trivy][trivy]. Each finding is tracked as a Jira ticket (so it can be
+risk-assessed and tracked to resolution) and surfaced to the responsible team
+via Slack. Findings that can't be represented in Jira are handled by a Slack
+failover data store instead.
+
+This is the nightly "are there known vulnerabilities in the image we ship?"
+check, as opposed to the [dependency submission job](dependency_submission_job.md)
+which feeds GitHub's dependency graph for Rust crates.
+
+[trivy]: https://github.com/aquasecurity/trivy
+
+## Entry point
+
+[`job/bazel_trivy_container_ic_scanner_periodic_job.py`](../job/bazel_trivy_container_ic_scanner_periodic_job.py)
+
+The `main()` function wires together the moving parts and runs a periodic scan:
+
+1. Builds a [`NotificationConfig`](../notification/notification_config.py) that
+   enables notifications for:
+   - findings that need a risk assessment,
+   - findings for which a patched version is available,
+   - deleted findings,
+   - scan job succeeded / failed (only for the `PERIODIC_SCAN` job type),
+   and registers two Slack notification handlers
+   ([`SlackTrivyFindingNotificationHandler`](../integration/slack/slack_trivy_finding_notification_handler.py)
+   and [`SlackDefaultNotificationHandler`](../integration/slack/slack_default_notification_handler.py)).
+2. Constructs a [`DependencyScanner`](../scanner/dependency_scanner.py) from:
+   - [`BazelTrivyContainer`](../scanner/manager/bazel_trivy_dependency_manager.py) — the dependency manager that actually runs Trivy and parses its output,
+   - [`JiraFindingDataSource`](../data_source/jira_finding_data_source.py) — persists findings as Jira tickets,
+   - the notifier as the scanner subscriber,
+   - [`SlackFindingsFailoverDataStore`](../data_source/slack_findings_failover_data_store.py) — handles findings that can't be stored in Jira.
+3. Calls `scanner_job.do_periodic_scan(REPOS_TO_SCAN)`.
+
+The set of images to scan is configured in
+[`config/bazel_trivy_periodic.py`](../config/bazel_trivy_periodic.py)
+(`REPOS_TO_SCAN`). Today it scans the GuestOS prod image
+(`ic-os/guestos/envs/prod`), owned by the Node team.
+
+## How it works
+
+```
+config/bazel_trivy_periodic.py  REPOS_TO_SCAN (image projects + owning teams)
+        │
+        ▼
+scanner/dependency_scanner.py   DependencyScanner.do_periodic_scan()
+        │   for each project:
+        ▼
+scanner/manager/bazel_trivy_dependency_manager.py   BazelTrivyContainer.get_findings()
+        │   runs `bazel run vuln-scan -- --format json ...`
+        │   (the vuln-scan target is defined in ic-os/defs.bzl and backed by
+        │    ic-os/vuln-scan/vuln-scan.sh, which untars the rootfs and runs trivy)
+        │   parses the JSON results into Finding objects via three parsers:
+        │     - OSPackageTrivyResultParser  (os-pkgs)
+        │     - BinaryTrivyResultParser     (lang-pkgs / *binary)
+        │     - SecretTrivyResultParser     (secret)
+        ▼
+        │   reconcile findings against existing ones:
+        ├─► data_source/jira_finding_data_source.py        create/update/delete Jira tickets
+        ├─► data_source/slack_findings_failover_data_store.py  findings not representable in Jira
+        └─► notification/notification_creator.py           Slack notifications
+                                                            (risk assessment needed,
+                                                             patch available, deleted,
+                                                             job succeeded/failed)
+```
+
+Key implementation details:
+
+- **Running Trivy**
+  ([`TrivyExecutor.run_trivy_and_parse_data`](../scanner/manager/bazel_trivy_dependency_manager.py)):
+  invokes `bazel run vuln-scan -- --output-path <findings.json> --format json
+  --hash-output-path <file-hashes.txt>`. The `vuln-scan` Bazel target is generated
+  per image in [`ic-os/defs.bzl`](../../../../ic-os/defs.bzl) and runs
+  [`ic-os/vuln-scan/vuln-scan.sh`](../../../../ic-os/vuln-scan/vuln-scan.sh),
+  which untars the image rootfs and runs `trivy rootfs` over it. Trivy ships its
+  vulnerability DB over ghcr.io, which is frequently rate limited, so the scan is
+  retried up to `TRIVY_SCAN_RETRIES` (10) times when the output file is missing or
+  empty.
+- **Parsing** ([`BazelTrivyContainer.get_findings`](../scanner/manager/bazel_trivy_dependency_manager.py)):
+  each Trivy result is routed to one of three parsers based on its `Class`/`Type`.
+  OS packages with the same set of vulnerabilities are grouped into a single
+  finding; binaries become a single finding with their vulnerable sub-packages as
+  first-level dependencies; secrets each become a finding. Results that no parser
+  can handle produce a warning and an app-owner notification.
+- **Reconciliation** ([`DependencyScanner.do_periodic_scan`](../scanner/dependency_scanner.py)):
+  current findings are merged with the open findings already in Jira — existing
+  tickets get their vulnerabilities/dependencies/owning-teams/score updated (risk
+  is cleared when new vulnerabilities appear), brand-new findings are created and
+  linked to related/previously-deleted findings, and findings that no longer
+  appear are deleted. Failures per repository are reported via
+  `on_scan_job_failed`.
+- **Jira vs. Slack failover store**
+  ([`SlackFindingsFailoverDataStore.can_handle`](../data_source/slack_findings_failover_data_store.py)):
+  most findings are stored in Jira as **one ticket per vulnerable dependency**,
+  listing all of that dependency's vulnerabilities. A few dependencies, however,
+  have so many vulnerabilities that the full list does not fit into a single Jira
+  ticket. For those, the findings are routed to the Slack failover store instead,
+  which stores a **separate entry per vulnerability**. A finding is sent to the
+  failover store when its vulnerable dependency id starts with one of the prefixes
+  configured in `FAILOVER_FINDING_PREFIXES` in
+  [`data_source/slack_findings_failover_data_store.py`](../data_source/slack_findings_failover_data_store.py)
+  (currently `linux-libc-dev` and `linux-modules` for the `ic` repo /
+  `BAZEL_TRIVY_CS` scanner). When a finding is handled by the failover store, any
+  pre-existing Jira ticket for it is deleted to avoid duplication.
+- **Triggering a base-image bump when a patch is available**
+  ([`GithubTrivyFindingNotificationHandler`](../integration/github/github_trivy_finding_notification_handler.py)):
+  when the scan detects that a **new patch version** has become available for an
+  OS-package finding, the
+  [`container-base-images.yml`](../../../../.github/workflows/container-base-images.yml)
+  workflow is invoked (via a `workflow_dispatch` on `master`) to rebuild and bump
+  the base container images so the patched package version is picked up. This is
+  wired through the Slack notification handler — when a finding has a patch
+  version available, the Slack message notes that a base image rebuild was
+  triggered and the GitHub handler dispatches the workflow. The workflow is only
+  dispatched **once per scan job** (guarded by `pipeline_run`), regardless of how
+  many findings have patches available. On `master`,
+  `container-base-images.yml` pushes the rebuilt images to DockerHub and updates
+  the image references via an automated PR.
+
+## Required environment
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `GITHUB_TOKEN` | yes | Used by the GitHub integration. |
+| `JIRA_API_TOKEN` | yes | Used by `JiraFindingDataSource` to create/update tickets. |
+| `SLACK_PSEC_BOT_OAUTH_TOKEN` | yes | Used by the Slack notification handlers / failover store. |
+| `REPO_NAME` | yes | `owner/repo`, used to build PR / CI pipeline links in notifications. |
+| `CI_PIPELINE_ID` | recommended | Recorded as the scan job id (defaults to a placeholder otherwise). |
+| `LOG_LEVEL` | optional | Logging verbosity (e.g. `INFO`). |
+
+## CI jobs that use this job
+
+### `container-scan-nightly.yml` (scheduled / manual)
+
+[`.github/workflows/container-scan-nightly.yml`](../../../../.github/workflows/container-scan-nightly.yml)
+
+- **Trigger:** scheduled nightly (`cron: "0 1 * * *"`) and `workflow_dispatch`.
+- **Runner / container:** runs inside the `ic-build` container on a `dind-large`,
+  privileged runner (Bazel + Trivy need to build/untar the image), with a 60
+  minute timeout and the `dependency-scan` environment (which holds the secrets).
+- **What it does:** installs `requirements.txt`, sets
+  `PYTHONPATH=ci/src:ci/src/dependencies`, then runs
+  `job/bazel_trivy_container_ic_scanner_periodic_job.py` from
+  `ci/src/dependencies/`. Secrets (`GITHUB_TOKEN`, `JIRA_API_TOKEN`,
+  `SLACK_PSEC_BOT_OAUTH_TOKEN`) are provided as env vars.
+
+## Related files
+
+- [`job/bazel_trivy_container_ic_scanner_periodic_job.py`](../job/bazel_trivy_container_ic_scanner_periodic_job.py) — entry point.
+- [`config/bazel_trivy_periodic.py`](../config/bazel_trivy_periodic.py) — images to scan.
+- [`scanner/dependency_scanner.py`](../scanner/dependency_scanner.py) — generic scan orchestration / reconciliation.
+- [`scanner/manager/bazel_trivy_dependency_manager.py`](../scanner/manager/bazel_trivy_dependency_manager.py) — Trivy runner + result parsers.
+- [`data_source/jira_finding_data_source.py`](../data_source/jira_finding_data_source.py) — Jira ticket storage.
+- [`data_source/slack_findings_failover_data_store.py`](../data_source/slack_findings_failover_data_store.py) — Slack failover storage.
+- [`notification/notification_creator.py`](../notification/notification_creator.py) and [`notification/notification_config.py`](../notification/notification_config.py) — notification wiring.
+- [`integration/slack/slack_trivy_finding_notification_handler.py`](../integration/slack/slack_trivy_finding_notification_handler.py) — Slack finding notifications; delegates the patch-available case to the GitHub handler.
+- [`integration/github/github_trivy_finding_notification_handler.py`](../integration/github/github_trivy_finding_notification_handler.py) and [`integration/github/github_workflow_config.py`](../integration/github/github_workflow_config.py) — dispatch of `container-base-images.yml` on patch availability.
+- [`.github/workflows/container-base-images.yml`](../../../../.github/workflows/container-base-images.yml) — rebuilds / bumps the base container images.
+- [`ic-os/vuln-scan/vuln-scan.sh`](../../../../ic-os/vuln-scan/vuln-scan.sh) and [`ic-os/defs.bzl`](../../../../ic-os/defs.bzl) — the `vuln-scan` Bazel target.


### PR DESCRIPTION
## Summary

Adds documentation for the dependency-management tooling under `ci/src/dependencies`.

- New `ci/src/dependencies/docs/` folder with:
  - `dependency_submission_job.md` — explains the Bazel/Rust GitHub dependency submission job (`job/bazel_rust_gh_submission_job.py`), how it parses `Cargo.Bazel.toml.lock` and submits the dependency graph to GitHub, and the CI workflows that invoke it (`bazel-dependency-submission.yml` on push to master, and `security-checks.yml` on PRs).
  - `trivy_scanner_job.md` — explains the periodic Trivy container scanner job (`job/bazel_trivy_container_ic_scanner_periodic_job.py`), the scan/parse/reconcile flow, the CI job that invokes it (`container-scan-nightly.yml`), the Jira vs. Slack failover store split for dependencies with very large vulnerability lists (`FAILOVER_FINDING_PREFIXES`), and the dispatch of `container-base-images.yml` to bump base images when a patch version becomes available.
- New `ci/src/dependencies/README.md` giving an overview of the directory and referencing both docs.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)