### PR TITLE
chore: CON-1441 Remove unused `PseudoRandomId` and error types

### DIFF
--- a/rs/consensus/idkg/src/payload_verifier.rs
+++ b/rs/consensus/idkg/src/payload_verifier.rs
@@ -43,16 +43,12 @@ use ic_types::{
     batch::ValidationContext,
     consensus::{
         Block, BlockPayload, HasHeight,
-        idkg::{self, IDkgBlockReader, TranscriptRef, common::BuildSignatureInputsError},
+        idkg::{self, IDkgBlockReader, TranscriptRef},
     },
     crypto::canister_threshold_sig::{
-        error::{
-            IDkgVerifyInitialDealingsError, IDkgVerifyTranscriptError,
-            ThresholdEcdsaVerifyCombinedSignatureError, ThresholdSchnorrVerifyCombinedSigError,
-        },
+        error::{IDkgVerifyInitialDealingsError, IDkgVerifyTranscriptError},
         idkg::{IDkgTranscript, IDkgTranscriptId, InitialIDkgDealings, SignedIDkgDealing},
     },
-    messages::CallbackId,
     registry::RegistryClientError,
     state_manager::StateManagerError,
 };
@@ -74,11 +70,8 @@ pub enum IDkgPayloadValidationFailure {
     RegistryClientError(RegistryClientError),
     StateManagerError(StateManagerError),
     TranscriptParamsError(idkg::TranscriptParamsError),
-    ThresholdEcdsaVerifyCombinedSignatureError(ThresholdEcdsaVerifyCombinedSignatureError),
-    ThresholdSchnorrVerifyCombinedSignatureError(ThresholdSchnorrVerifyCombinedSigError),
     IDkgVerifyTranscriptError(IDkgVerifyTranscriptError),
     IDkgVerifyInitialDealingsError(IDkgVerifyInitialDealingsError),
-    NewSignatureBuildInputsError(BuildSignatureInputsError),
     InvalidChainCacheError(InvalidChainCacheError),
 }
 
@@ -92,11 +85,8 @@ pub enum InvalidIDkgPayloadReason {
     UnexpectedSummaryPayload(IDkgPayloadError),
     UnexpectedDataPayload(Option<IDkgPayloadError>),
     TranscriptParamsError(idkg::TranscriptParamsError),
-    ThresholdEcdsaVerifyCombinedSignatureError(ThresholdEcdsaVerifyCombinedSignatureError),
-    ThresholdSchnorrVerifyCombinedSignatureError(ThresholdSchnorrVerifyCombinedSigError),
     IDkgVerifyTranscriptError(IDkgVerifyTranscriptError),
     IDkgVerifyInitialDealingsError(IDkgVerifyInitialDealingsError),
-    NewSignatureBuildInputsError(BuildSignatureInputsError),
     // local errors
     ConsensusRegistryVersionNotFound(Height),
     ChainKeyConfigNotFound,
@@ -107,9 +97,6 @@ pub enum InvalidIDkgPayloadReason {
     NewTranscriptNotFound(IDkgTranscriptId),
     NewTranscriptMiscount(u64),
     NewTranscriptMissingParams(IDkgTranscriptId),
-    NewSignatureUnexpected(idkg::PseudoRandomId),
-    NewSignatureMissingContext(idkg::PseudoRandomId),
-    VetKdUnexpected(CallbackId),
     XNetReshareAgreementWithoutRequest(idkg::IDkgReshareRequest),
     XNetReshareRequestDisappeared(idkg::IDkgReshareRequest),
     DecodingError(String),
@@ -166,42 +153,6 @@ impl From<IDkgVerifyInitialDealingsError> for InvalidIDkgPayloadReason {
 impl From<IDkgVerifyInitialDealingsError> for IDkgPayloadValidationFailure {
     fn from(err: IDkgVerifyInitialDealingsError) -> Self {
         IDkgPayloadValidationFailure::IDkgVerifyInitialDealingsError(err)
-    }
-}
-
-impl From<ThresholdEcdsaVerifyCombinedSignatureError> for InvalidIDkgPayloadReason {
-    fn from(err: ThresholdEcdsaVerifyCombinedSignatureError) -> Self {
-        InvalidIDkgPayloadReason::ThresholdEcdsaVerifyCombinedSignatureError(err)
-    }
-}
-
-impl From<ThresholdEcdsaVerifyCombinedSignatureError> for IDkgPayloadValidationFailure {
-    fn from(err: ThresholdEcdsaVerifyCombinedSignatureError) -> Self {
-        IDkgPayloadValidationFailure::ThresholdEcdsaVerifyCombinedSignatureError(err)
-    }
-}
-
-impl From<BuildSignatureInputsError> for InvalidIDkgPayloadReason {
-    fn from(err: BuildSignatureInputsError) -> Self {
-        InvalidIDkgPayloadReason::NewSignatureBuildInputsError(err)
-    }
-}
-
-impl From<BuildSignatureInputsError> for IDkgPayloadValidationFailure {
-    fn from(err: BuildSignatureInputsError) -> Self {
-        IDkgPayloadValidationFailure::NewSignatureBuildInputsError(err)
-    }
-}
-
-impl From<ThresholdSchnorrVerifyCombinedSigError> for InvalidIDkgPayloadReason {
-    fn from(err: ThresholdSchnorrVerifyCombinedSigError) -> Self {
-        InvalidIDkgPayloadReason::ThresholdSchnorrVerifyCombinedSignatureError(err)
-    }
-}
-
-impl From<ThresholdSchnorrVerifyCombinedSigError> for IDkgPayloadValidationFailure {
-    fn from(err: ThresholdSchnorrVerifyCombinedSigError) -> Self {
-        IDkgPayloadValidationFailure::ThresholdSchnorrVerifyCombinedSignatureError(err)
     }
 }
 

--- a/rs/types/types/src/consensus/idkg.rs
+++ b/rs/types/types/src/consensus/idkg.rs
@@ -3,11 +3,10 @@
 use crate::artifact::{IdentifiableArtifact, PbArtifact};
 pub use crate::consensus::idkg::common::{
     IDkgBlockReader, IDkgTranscriptAttributes, IDkgTranscriptOperationRef, IDkgTranscriptParamsRef,
-    MaskedTranscript, PreSigId, PseudoRandomId, RandomTranscriptParams,
-    RandomUnmaskedTranscriptParams, RequestId, ReshareOfMaskedParams, ReshareOfUnmaskedParams,
-    TranscriptAttributes, TranscriptCastError, TranscriptLookupError, TranscriptParamsError,
-    TranscriptRef, UnmaskedTimesMaskedParams, UnmaskedTranscript,
-    unpack_reshare_of_unmasked_params,
+    MaskedTranscript, PreSigId, RandomTranscriptParams, RandomUnmaskedTranscriptParams, RequestId,
+    ReshareOfMaskedParams, ReshareOfUnmaskedParams, TranscriptAttributes, TranscriptCastError,
+    TranscriptLookupError, TranscriptParamsError, TranscriptRef, UnmaskedTimesMaskedParams,
+    UnmaskedTranscript, unpack_reshare_of_unmasked_params,
 };
 use crate::consensus::idkg::ecdsa::{PreSignatureQuadrupleRef, QuadrupleInCreation};
 use crate::crypto::vetkd::VetKdEncryptedKeyShareContent;

--- a/rs/types/types/src/consensus/idkg/common.rs
+++ b/rs/types/types/src/consensus/idkg/common.rs
@@ -46,9 +46,6 @@ use super::{
     schnorr::{PreSignatureTranscriptRef, TranscriptInCreation},
 };
 
-/// PseudoRandomId is defined in execution context as plain 32-byte vector, we give it a synonym here.
-pub type PseudoRandomId = [u8; 32];
-
 /// RequestId is used for two purposes:
 /// 1. to identify the matching request in signature request contexts.
 /// 2. to identify which pre-signature the request is matched to.


### PR DESCRIPTION
These types are no longer in use by the IDKG payload, after we switched to handling ECDSA/Schnorr as part of the batch payload.