### PR TITLE
fix: keep writing blessed_replica_versions key in ic-prep

### DIFF
--- a/rs/prep/src/internet_computer.rs
+++ b/rs/prep/src/internet_computer.rs
@@ -649,17 +649,11 @@ impl IcConfig {
             opt_url.map(|u| vec![u.to_string()]).unwrap_or_default()
         }
 
-        let initial_replica_version = self.initial_replica_version_id.to_string();
         let replica_version_record = ReplicaVersionRecord {
             release_package_sha256_hex: self.initial_release_package_sha256_hex.unwrap_or_default(),
             release_package_urls: opturl_to_string_vec(self.initial_release_package_url),
             guest_launch_measurements: self.guest_launch_measurements,
         };
-
-        let blessed_replica_versions_record = BlessedReplicaVersions {
-            blessed_version_ids: vec![initial_replica_version],
-        };
-
         write_registry_entry(
             &data_provider,
             self.target_dir.as_path(),
@@ -668,6 +662,20 @@ impl IcConfig {
             replica_version_record,
         );
 
+        // TOOD: Commit d91a23fe (#10495, "Drop final active blessed version components")
+        // stopped writing the `blessed_replica_versions` registry key in `ic-prep`.
+        // However, the registry canister currently **deployed on mainnet** still reads this key
+        // when processing `ReviseElectedGuestosVersions` proposals and panics if it is absent:
+        //
+        //   'BlessedReplicaVersions key not found in registry', rs/registry/canister/src/mutations/do_revise_elected_replica_versions.rs:186:10
+        //
+        // This broke all system_test_nns tests which use the mainnet NNS and attempt an upgrade.
+        // To fix the following inserts a "blessed_replica_versions" entry into the registry.
+        // Remove this once the mainnet canister has been upgraded not to read it anymore.
+        let initial_replica_version = self.initial_replica_version_id.to_string();
+        let blessed_replica_versions_record = BlessedReplicaVersions {
+            blessed_version_ids: vec![initial_replica_version],
+        };
         write_registry_entry(
             &data_provider,
             self.target_dir.as_path(),

--- a/rs/prep/src/internet_computer.rs
+++ b/rs/prep/src/internet_computer.rs
@@ -27,11 +27,14 @@ use ic_interfaces_registry::{RegistryDataProvider, RegistryRecord, ZERO_REGISTRY
 
 use ic_protobuf::registry::replica_version::v1::GuestLaunchMeasurements;
 use ic_protobuf::registry::{
-    api_boundary_node::v1::ApiBoundaryNodeRecord, dc::v1::DataCenterRecord,
+    api_boundary_node::v1::ApiBoundaryNodeRecord,
+    dc::v1::DataCenterRecord,
     node_operator::v1::NodeOperatorRecord,
     provisional_whitelist::v1::ProvisionalWhitelist as PbProvisionalWhitelist,
-    replica_version::v1::ReplicaVersionRecord, routing_table::v1::RoutingTable as PbRoutingTable,
-    subnet::v1::SubnetListRecord, unassigned_nodes_config::v1::UnassignedNodesConfigRecord,
+    replica_version::v1::{BlessedReplicaVersions, ReplicaVersionRecord},
+    routing_table::v1::RoutingTable as PbRoutingTable,
+    subnet::v1::SubnetListRecord,
+    unassigned_nodes_config::v1::UnassignedNodesConfigRecord,
 };
 use ic_protobuf::registry::{
     dc::v1::Gps,
@@ -646,10 +649,15 @@ impl IcConfig {
             opt_url.map(|u| vec![u.to_string()]).unwrap_or_default()
         }
 
+        let initial_replica_version = self.initial_replica_version_id.to_string();
         let replica_version_record = ReplicaVersionRecord {
             release_package_sha256_hex: self.initial_release_package_sha256_hex.unwrap_or_default(),
             release_package_urls: opturl_to_string_vec(self.initial_release_package_url),
             guest_launch_measurements: self.guest_launch_measurements,
+        };
+
+        let blessed_replica_versions_record = BlessedReplicaVersions {
+            blessed_version_ids: vec![initial_replica_version],
         };
 
         write_registry_entry(
@@ -658,6 +666,18 @@ impl IcConfig {
             make_replica_version_key(self.initial_replica_version_id.clone()).as_ref(),
             version,
             replica_version_record,
+        );
+
+        write_registry_entry(
+            &data_provider,
+            self.target_dir.as_path(),
+            // Written inline (rather than via a helper in ic_registry_keys) for
+            // backwards compatibility only: the registry canister no longer
+            // maintains the blessed replica versions list, but mainnet versions
+            // of it still expect this key to be present.
+            "blessed_replica_versions",
+            version,
+            blessed_replica_versions_record,
         );
 
         let provisional_whitelist = match self.provisional_whitelist {


### PR DESCRIPTION
## Problem

Commit d91a23fe (#10495, "Drop final active blessed version components") stopped writing the `blessed_replica_versions` registry key in `ic-prep`. However, the registry canister currently **deployed on mainnet** still reads this key when processing `ReviseElectedGuestosVersions` proposals and panics if it is absent:

```
'BlessedReplicaVersions key not found in registry', rs/registry/canister/src/mutations/do_revise_elected_replica_versions.rs:186:10
```

The `system_test_nns` macro builds the default test variant against the **mainnet** NNS canisters, and these tests build their initial registry via `ic-prep`. So they hit this panic as soon as a replica version is elected. This broke many post-merge system tests, e.g.:

- `//rs/tests/consensus/orchestrator:unstuck_subnet_test`
- `//rs/tests/consensus/upgrade:upgrade_downgrade_*`
- `//rs/tests/consensus/subnet_recovery:sr_app_same_nodes*`
- `//rs/tests/consensus/backup:backup_manager_{up,down}grade_test_colocate`
- `//rs/tests/message_routing/xnet:xnet_compatibility`
- `//rs/tests/nested:guestos_upgrade_*`
- `//rs/tests/networking:nns_delegation_mainnet_nns_version_test`

(see https://github.com/dfinity/ic/actions/runs/28075660674)

These run post-merge, which is why #10495 passed its pre-merge checks.

## Fix

Restore the `blessed_replica_versions` write in `ic-prep` only. The key string is inlined so the `ic_registry_keys` helper that #10495 removed stays removed, and the registry canister cleanup from #10495 is otherwise preserved.

This is a more targeted alternative to fully reverting #10495 (#10553). Once a registry canister that no longer reads this key is live on mainnet, this single write can be dropped.

## Testing

- `rustfmt`, `cargo clippy -p ic-prep` (clean)
- `bazel build //rs/prep:ic-prep`
- `bazel test //rs/prep:prep_test //rs/registry/keys:keys_test`

The affected system tests run via `CI_ALL_BAZEL_TARGETS`.