### PR TITLE
fix: do not record canister logs in replica logs

### DIFF
--- a/rs/execution_environment/src/scheduler.rs
+++ b/rs/execution_environment/src/scheduler.rs
@@ -2143,14 +2143,11 @@ fn filter_canister_log_records(
     let warn_drop = |record: &CanisterLogRecord, reason: &str| {
         warn!(
             log,
-            "Canister {}: dropping log record with idx {} ({} next_idx {}), \
-             timestamp {}, content \"{}\"",
+            "Canister {}: dropping log record with idx {} ({} next_idx {})",
             canister_id,
             record.idx,
             reason,
             next_idx,
-            record.timestamp_nanos,
-            String::from_utf8_lossy(&record.content),
         );
     };
     for record in records.iter().filter(|r| r.idx >= next_idx) {


### PR DESCRIPTION
Motivation: https://forum.dfinity.org/t/proposal-to-elect-new-release-rc-2026-06-18-04-52/72029/7

So far, the affected code has only been executed on 3 subnets to which the release [33d4bd8](https://dashboard.internetcomputer.org/release/33d4bd8ef292fb135e8a63ad232912b1459eef50) was rolled out.