### PR TITLE
fix: Use registry version of `CanisterHttpRequestContext` to determine committee membership

### DIFF
--- a/rs/artifact_pool/src/canister_http_pool.rs
+++ b/rs/artifact_pool/src/canister_http_pool.rs
@@ -232,7 +232,7 @@ mod tests {
     use ic_test_utilities_consensus::fake::FakeSigner;
     use ic_test_utilities_types::ids::node_test_id;
     use ic_types::{
-        CanisterId, RegistryVersion, ReplicaVersion,
+        CanisterId, ReplicaVersion,
         artifact::IdentifiableArtifact,
         canister_http::{
             CanisterHttpPaymentReceipt, CanisterHttpResponseContent, CanisterHttpResponseMetadata,
@@ -268,7 +268,6 @@ mod tests {
                     content_hash: CryptoHashOf::from(CryptoHash(vec![1, 2, 3])),
                     content_size: 42,
                     is_reject: false,
-                    registry_version: RegistryVersion::from(id),
                     replica_version: ReplicaVersion::default(),
                 },
                 payment_receipt: CanisterHttpPaymentReceipt::default(),

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -740,19 +740,17 @@ mod tests {
         }
     }
 
-    fn fake_state_with_canister_http_contexts(
-        contexts: Vec<CanisterHttpRequestContext>,
-    ) -> ReplicatedState {
-        fake_state_with_contexts(vec![], vec![], contexts)
-    }
-
     #[test]
     fn test_get_oldest_state_registry_version_canister_http_only() {
-        let state = fake_state_with_canister_http_contexts(vec![
-            fake_canister_http_context(RegistryVersion::from(8)),
-            fake_canister_http_context(RegistryVersion::from(4)),
-            fake_canister_http_context(RegistryVersion::from(6)),
-        ]);
+        let state = fake_state_with_contexts(
+            vec![],
+            vec![],
+            vec![
+                fake_canister_http_context(RegistryVersion::from(8)),
+                fake_canister_http_context(RegistryVersion::from(4)),
+                fake_canister_http_context(RegistryVersion::from(6)),
+            ],
+        );
         assert_eq!(
             Some(RegistryVersion::from(4)),
             get_oldest_state_registry_version(&state)

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -583,6 +583,7 @@ mod tests {
     fn fake_state_with_contexts(
         sign_with_threshold: Vec<SignWithThresholdContext>,
         setup_initial_dkg: Vec<SetupInitialDkgContext>,
+        canister_http: Vec<CanisterHttpRequestContext>,
     ) -> ReplicatedState {
         let mut state = ReplicatedStateBuilder::default().build();
         state
@@ -604,12 +605,21 @@ mod tests {
                 .map(|(i, c)| (CallbackId::from(i as u64), c)),
         );
         state
+            .metadata
+            .subnet_call_context_manager
+            .canister_http_request_contexts = BTreeMap::from_iter(
+            canister_http
+                .into_iter()
+                .enumerate()
+                .map(|(i, c)| (CallbackId::from(i as u64), c)),
+        );
+        state
     }
 
     fn fake_state_with_signature_contexts(
         contexts: Vec<SignWithThresholdContext>,
     ) -> ReplicatedState {
-        fake_state_with_contexts(contexts, vec![])
+        fake_state_with_contexts(contexts, vec![], vec![])
     }
 
     fn fake_setup_initial_dkg_context(registry_version: RegistryVersion) -> SetupInitialDkgContext {
@@ -625,7 +635,7 @@ mod tests {
     fn fake_state_with_setup_initial_dkg_contexts(
         contexts: Vec<SetupInitialDkgContext>,
     ) -> ReplicatedState {
-        fake_state_with_contexts(vec![], contexts)
+        fake_state_with_contexts(vec![], contexts, vec![])
     }
 
     fn fake_key_ids() -> Vec<MasterPublicKeyId> {
@@ -730,26 +740,18 @@ mod tests {
         }
     }
 
-    fn fake_state_with_canister_http_contexts(versions: Vec<RegistryVersion>) -> ReplicatedState {
-        let mut state = ReplicatedStateBuilder::default().build();
-        state
-            .metadata
-            .subnet_call_context_manager
-            .canister_http_request_contexts = BTreeMap::from_iter(
-            versions
-                .into_iter()
-                .enumerate()
-                .map(|(i, v)| (CallbackId::from(i as u64), fake_canister_http_context(v))),
-        );
-        state
+    fn fake_state_with_canister_http_contexts(
+        contexts: Vec<CanisterHttpRequestContext>,
+    ) -> ReplicatedState {
+        fake_state_with_contexts(vec![], vec![], contexts)
     }
 
     #[test]
     fn test_get_oldest_state_registry_version_canister_http_only() {
         let state = fake_state_with_canister_http_contexts(vec![
-            RegistryVersion::from(8),
-            RegistryVersion::from(4),
-            RegistryVersion::from(6),
+            fake_canister_http_context(RegistryVersion::from(8)),
+            fake_canister_http_context(RegistryVersion::from(4)),
+            fake_canister_http_context(RegistryVersion::from(6)),
         ]);
         assert_eq!(
             Some(RegistryVersion::from(4)),
@@ -762,21 +764,15 @@ mod tests {
         // Sign and setup-dkg contexts at v5, canister http at v2: the canister
         // http version must be reflected as the oldest.
         let key_id = fake_key_ids().into_iter().next().unwrap();
-        let mut state = fake_state_with_contexts(
+        let state = fake_state_with_contexts(
             vec![fake_signature_request_context_with_registry_version(
                 Some(PreSigId(0)),
                 &key_id,
                 RegistryVersion::from(5),
             )],
             vec![fake_setup_initial_dkg_context(RegistryVersion::from(5))],
+            vec![fake_canister_http_context(RegistryVersion::from(2))],
         );
-        state
-            .metadata
-            .subnet_call_context_manager
-            .canister_http_request_contexts = BTreeMap::from([(
-            CallbackId::from(0),
-            fake_canister_http_context(RegistryVersion::from(2)),
-        )]);
         assert_eq!(
             Some(RegistryVersion::from(2)),
             get_oldest_state_registry_version(&state)
@@ -799,6 +795,7 @@ mod tests {
         let state = fake_state_with_contexts(
             signature_contexts,
             vec![fake_setup_initial_dkg_context(RegistryVersion::from(2))],
+            vec![],
         );
         assert_eq!(
             Some(RegistryVersion::from(2)),
@@ -822,6 +819,7 @@ mod tests {
         let state = fake_state_with_contexts(
             signature_contexts,
             vec![fake_setup_initial_dkg_context(RegistryVersion::from(11))],
+            vec![],
         );
         assert_eq!(
             Some(RegistryVersion::from(2)),

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -456,10 +456,23 @@ pub fn get_oldest_state_registry_version(state: &ReplicatedState) -> Option<Regi
         .map(|context| context.registry_version)
         .min();
 
-    [oldest_chain_key_version, oldest_setup_initial_dkg_version]
-        .into_iter()
-        .flatten()
-        .min()
+    // Canister HTTP outcalls determine committee membership and verify share
+    // signatures at the registry version pinned in the request context, so that
+    // version must remain available until the request has been answered.
+    let oldest_canister_http_version = call_context_manager
+        .canister_http_request_contexts
+        .values()
+        .map(|context| context.registry_version)
+        .min();
+
+    [
+        oldest_chain_key_version,
+        oldest_setup_initial_dkg_version,
+        oldest_canister_http_version,
+    ]
+    .into_iter()
+    .flatten()
+    .min()
 }
 
 /// Calculate the number of heights in the given range (inclusive)
@@ -490,6 +503,10 @@ mod tests {
     use ic_test_utilities_state::ReplicatedStateBuilder;
     use ic_test_utilities_types::{ids::node_test_id, messages::RequestBuilder};
     use ic_types::{
+        canister_http::{
+            CanisterHttpMethod, CanisterHttpRequestContext, PricingVersion, RefundStatus,
+            Replication,
+        },
         consensus::{Rank, get_faults_tolerated, idkg::PreSigId},
         crypto::{ThresholdSigShare, ThresholdSigShareOf, threshold_sig::ni_dkg::NiDkgTargetId},
         messages::CallbackId,
@@ -695,6 +712,76 @@ mod tests {
         ]);
         assert_eq!(
             Some(RegistryVersion::from(3)),
+            get_oldest_state_registry_version(&state)
+        );
+    }
+
+    fn fake_canister_http_context(registry_version: RegistryVersion) -> CanisterHttpRequestContext {
+        CanisterHttpRequestContext {
+            request: RequestBuilder::new().build(),
+            url: "https://example.com".to_string(),
+            max_response_bytes: None,
+            headers: vec![],
+            body: None,
+            http_method: CanisterHttpMethod::GET,
+            transform: None,
+            time: UNIX_EPOCH,
+            replication: Replication::FullyReplicated,
+            pricing_version: PricingVersion::Legacy,
+            refund_status: RefundStatus::default(),
+            registry_version,
+        }
+    }
+
+    fn fake_state_with_canister_http_contexts(versions: Vec<RegistryVersion>) -> ReplicatedState {
+        let mut state = ReplicatedStateBuilder::default().build();
+        state
+            .metadata
+            .subnet_call_context_manager
+            .canister_http_request_contexts = BTreeMap::from_iter(
+            versions
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| (CallbackId::from(i as u64), fake_canister_http_context(v))),
+        );
+        state
+    }
+
+    #[test]
+    fn test_get_oldest_state_registry_version_canister_http_only() {
+        let state = fake_state_with_canister_http_contexts(vec![
+            RegistryVersion::from(8),
+            RegistryVersion::from(4),
+            RegistryVersion::from(6),
+        ]);
+        assert_eq!(
+            Some(RegistryVersion::from(4)),
+            get_oldest_state_registry_version(&state)
+        );
+    }
+
+    #[test]
+    fn test_get_oldest_state_registry_version_canister_http_younger_than_others() {
+        // Sign and setup-dkg contexts at v5, canister http at v2: the canister
+        // http version must be reflected as the oldest.
+        let key_id = fake_key_ids().into_iter().next().unwrap();
+        let mut state = fake_state_with_contexts(
+            vec![fake_signature_request_context_with_registry_version(
+                Some(PreSigId(0)),
+                &key_id,
+                RegistryVersion::from(5),
+            )],
+            vec![fake_setup_initial_dkg_context(RegistryVersion::from(5))],
+        );
+        state
+            .metadata
+            .subnet_call_context_manager
+            .canister_http_request_contexts = BTreeMap::from([(
+            CallbackId::from(0),
+            fake_canister_http_context(RegistryVersion::from(2)),
+        )]);
+        assert_eq!(
+            Some(RegistryVersion::from(2)),
             get_oldest_state_registry_version(&state)
         );
     }

--- a/rs/consensus/utils/src/lib.rs
+++ b/rs/consensus/utils/src/lib.rs
@@ -456,9 +456,6 @@ pub fn get_oldest_state_registry_version(state: &ReplicatedState) -> Option<Regi
         .map(|context| context.registry_version)
         .min();
 
-    // Canister HTTP outcalls determine committee membership and verify share
-    // signatures at the registry version pinned in the request context, so that
-    // version must remain available until the request has been answered.
     let oldest_canister_http_version = call_context_manager
         .canister_http_request_contexts
         .values()

--- a/rs/consensus/utils/src/membership.rs
+++ b/rs/consensus/utils/src/membership.rs
@@ -22,6 +22,18 @@ pub enum MembershipError {
     UnableToRetrieveDkgSummary(Height),
 }
 
+/// The canister http committee at a given registry version, together with the
+/// BFT parameters derived from its size.
+pub struct CanisterHttpCommittee {
+    /// The subnet node set acting as the canister http committee.
+    pub committee: Vec<NodeId>,
+    /// The number of matching shares required to form a response
+    /// (`committee.len() - faults_tolerated`).
+    pub threshold: Threshold,
+    /// The number of faults tolerated for a committee of this size.
+    pub faults_tolerated: usize,
+}
+
 /// Allow a node to determine what its roles are for the current round, e.g.
 /// what its rank is and what committees it belongs to.
 pub struct Membership {
@@ -182,17 +194,26 @@ impl Membership {
     }
 
     /// Get the committee to be used for canister http at the given registry
-    /// version.
+    /// version, along with the [`threshold`](CanisterHttpCommittee::threshold)
+    /// and [`faults_tolerated`](CanisterHttpCommittee::faults_tolerated)
+    /// derived from its size.
     pub fn get_canister_http_committee(
         &self,
         registry_version: RegistryVersion,
-    ) -> Result<Vec<NodeId>, MembershipError> {
+    ) -> Result<CanisterHttpCommittee, MembershipError> {
         // IMPORTANT: if this ever becomes something else, we should make sure that:
         // 1. Shares from non committee nodes are not included in the payload
         //    this should be enforced already by the pool validator, though it might
         //    make sense for the payload builder to check too.
         // 2. Non replicated request should only be sent to committee nodes.
-        self.get_nodes_at_version(registry_version)
+        let committee = self.get_nodes_at_version(registry_version)?;
+        let faults_tolerated = get_faults_tolerated(committee.len());
+        let threshold = committee.len() - faults_tolerated;
+        Ok(CanisterHttpCommittee {
+            committee,
+            threshold,
+            faults_tolerated,
+        })
     }
 
     /// Return true if the given node ID is part of the canister http committee
@@ -204,6 +225,7 @@ impl Membership {
     ) -> Result<bool, MembershipError> {
         Ok(self
             .get_canister_http_committee(registry_version)?
+            .committee
             .contains(&node_id))
     }
 

--- a/rs/consensus/utils/src/membership.rs
+++ b/rs/consensus/utils/src/membership.rs
@@ -221,12 +221,12 @@ impl Membership {
     pub fn node_belongs_to_canister_http_committee(
         &self,
         registry_version: RegistryVersion,
-        node_id: NodeId,
+        node_id: &NodeId,
     ) -> Result<bool, MembershipError> {
         Ok(self
             .get_canister_http_committee(registry_version)?
             .committee
-            .contains(&node_id))
+            .contains(node_id))
     }
 
     /// Return true if the given node ID is in the low threshold committee at

--- a/rs/consensus/utils/src/membership.rs
+++ b/rs/consensus/utils/src/membership.rs
@@ -145,9 +145,6 @@ impl Membership {
             Committee::Notarization => {
                 unreachable!("Notarization/Finalization does not use threshold committee")
             }
-            Committee::CanisterHttp => {
-                unreachable!("CanisterHttp does not use threshold committee")
-            }
         }
     }
 
@@ -162,7 +159,6 @@ impl Membership {
             Committee::HighThreshold => self.get_high_threshold_committee_threshold(height),
             Committee::LowThreshold => self.get_low_threshold_committee_threshold(height),
             Committee::Notarization => self.get_notarization_committee_threshold(height),
-            Committee::CanisterHttp => self.get_canister_http_committee_threshold(height),
         }
     }
 
@@ -185,38 +181,22 @@ impl Membership {
         })
     }
 
-    /// Get the committee to be used for canister http at the given height
-    pub fn get_canister_http_committee(
-        &self,
-        height: Height,
-    ) -> Result<Vec<NodeId>, MembershipError> {
-        // IMPORTANT: if this ever becomes something else, we should make sure that:
-        // 1. Shares from non committee nodes are not included in the payload
-        //    this should be enforced already by the pool validator, though it might
-        //    make sense for the payload builder to check too.
-        // 2. Non replicated request should only be sent to committee nodes.
-        self.get_nodes(height)
-    }
-
-    /// Return true if the given node ID is part of the canister http committee
-    /// at the given height
-    pub fn node_belongs_to_canister_http_committee(
-        &self,
-        height: Height,
-        node_id: NodeId,
-    ) -> Result<bool, MembershipError> {
-        Ok(self.get_canister_http_committee(height)?.contains(&node_id))
-    }
-
     /// Get the committee to be used for canister http at the given registry
     /// version.
     ///
-    /// In contrast to [`Self::get_canister_http_committee`], the committee is
-    /// determined by an explicit registry version rather than by the registry
-    /// version active at some block height. This is used to pin a canister http
-    /// request to the committee that was active at the registry version stored
-    /// in the request context, which is the source of truth for the request.
-    pub fn get_canister_http_committee_at_version(
+    /// The committee is determined by an explicit registry version rather than
+    /// by the registry version active at some block height. This is used to pin
+    /// a canister http request to the committee that was active at the registry
+    /// version stored in the request context, which is the source of truth for
+    /// the request.
+    ///
+    /// IMPORTANT: if this ever becomes something other than the full set of
+    /// subnet nodes, we should make sure that:
+    /// 1. Shares from non committee nodes are not included in the payload
+    ///    this should be enforced already by the pool validator, though it might
+    ///    make sense for the payload builder to check too.
+    /// 2. Non replicated request should only be sent to committee nodes.
+    pub fn get_canister_http_committee(
         &self,
         registry_version: RegistryVersion,
     ) -> Result<Vec<NodeId>, MembershipError> {
@@ -225,13 +205,13 @@ impl Membership {
 
     /// Return true if the given node ID is part of the canister http committee
     /// at the given registry version.
-    pub fn node_belongs_to_canister_http_committee_at_version(
+    pub fn node_belongs_to_canister_http_committee(
         &self,
         registry_version: RegistryVersion,
         node_id: NodeId,
     ) -> Result<bool, MembershipError> {
         Ok(self
-            .get_canister_http_committee_at_version(registry_version)?
+            .get_canister_http_committee(registry_version)?
             .contains(&node_id))
     }
 
@@ -292,14 +272,6 @@ impl Membership {
             Some((threshold, _)) => Ok(threshold),
             None => Err(MembershipError::UnableToRetrieveDkgSummary(height)),
         }
-    }
-
-    fn get_canister_http_committee_threshold(
-        &self,
-        height: Height,
-    ) -> Result<Threshold, MembershipError> {
-        let committee_size = self.get_canister_http_committee(height)?.len();
-        Ok(committee_size - get_faults_tolerated(committee_size))
     }
 }
 

--- a/rs/consensus/utils/src/membership.rs
+++ b/rs/consensus/utils/src/membership.rs
@@ -5,7 +5,7 @@ use ic_crypto_prng::{Csprng, RandomnessPurpose};
 use ic_interfaces::consensus_pool::ConsensusPoolCache;
 use ic_interfaces_registry::RegistryClient;
 use ic_types::{
-    Height, NodeId, SubnetId,
+    Height, NodeId, RegistryVersion, SubnetId,
     consensus::{
         Committee, HasHeight, RandomBeacon, Rank, Threshold, get_committee_size,
         get_faults_tolerated,
@@ -46,10 +46,17 @@ impl Membership {
 
     /// Return the node IDs from the registry.
     pub fn get_nodes(&self, height: Height) -> Result<Vec<NodeId>, MembershipError> {
-        use ic_registry_client_helpers::subnet::SubnetRegistry;
         let registry_version = registry_version_at_height(self.consensus_cache.as_ref(), height)
             .ok_or(MembershipError::UnableToRetrieveDkgSummary(height))?;
+        self.get_nodes_at_version(registry_version)
+    }
 
+    /// Return the node IDs on the subnet at the given registry version.
+    pub fn get_nodes_at_version(
+        &self,
+        registry_version: RegistryVersion,
+    ) -> Result<Vec<NodeId>, MembershipError> {
+        use ic_registry_client_helpers::subnet::SubnetRegistry;
         let list = self
             .registry_client
             .get_node_ids_on_subnet(self.subnet_id, registry_version)
@@ -199,6 +206,33 @@ impl Membership {
         node_id: NodeId,
     ) -> Result<bool, MembershipError> {
         Ok(self.get_canister_http_committee(height)?.contains(&node_id))
+    }
+
+    /// Get the committee to be used for canister http at the given registry
+    /// version.
+    ///
+    /// In contrast to [`Self::get_canister_http_committee`], the committee is
+    /// determined by an explicit registry version rather than by the registry
+    /// version active at some block height. This is used to pin a canister http
+    /// request to the committee that was active at the registry version stored
+    /// in the request context, which is the source of truth for the request.
+    pub fn get_canister_http_committee_at_version(
+        &self,
+        registry_version: RegistryVersion,
+    ) -> Result<Vec<NodeId>, MembershipError> {
+        self.get_nodes_at_version(registry_version)
+    }
+
+    /// Return true if the given node ID is part of the canister http committee
+    /// at the given registry version.
+    pub fn node_belongs_to_canister_http_committee_at_version(
+        &self,
+        registry_version: RegistryVersion,
+        node_id: NodeId,
+    ) -> Result<bool, MembershipError> {
+        Ok(self
+            .get_canister_http_committee_at_version(registry_version)?
+            .contains(&node_id))
     }
 
     /// Return true if the given node ID is in the low threshold committee at

--- a/rs/consensus/utils/src/membership.rs
+++ b/rs/consensus/utils/src/membership.rs
@@ -183,23 +183,15 @@ impl Membership {
 
     /// Get the committee to be used for canister http at the given registry
     /// version.
-    ///
-    /// The committee is determined by an explicit registry version rather than
-    /// by the registry version active at some block height. This is used to pin
-    /// a canister http request to the committee that was active at the registry
-    /// version stored in the request context, which is the source of truth for
-    /// the request.
-    ///
-    /// IMPORTANT: if this ever becomes something other than the full set of
-    /// subnet nodes, we should make sure that:
-    /// 1. Shares from non committee nodes are not included in the payload
-    ///    this should be enforced already by the pool validator, though it might
-    ///    make sense for the payload builder to check too.
-    /// 2. Non replicated request should only be sent to committee nodes.
     pub fn get_canister_http_committee(
         &self,
         registry_version: RegistryVersion,
     ) -> Result<Vec<NodeId>, MembershipError> {
+        // IMPORTANT: if this ever becomes something else, we should make sure that:
+        // 1. Shares from non committee nodes are not included in the payload
+        //    this should be enforced already by the pool validator, though it might
+        //    make sense for the payload builder to check too.
+        // 2. Non replicated request should only be sent to committee nodes.
         self.get_nodes_at_version(registry_version)
     }
 

--- a/rs/crypto/src/sign/basic_sig.rs
+++ b/rs/crypto/src/sign/basic_sig.rs
@@ -65,11 +65,14 @@ impl BasicSigVerifierInternal {
         Self::verify_basic_sig_batch_internal(
             csprng,
             registry,
-            signatures
-                .signatures_map
-                .iter()
-                .map(|(signer, signature)| (*signer, signature, message_bytes.as_slice())),
-            registry_version,
+            signatures.signatures_map.iter().map(|(signer, signature)| {
+                (
+                    *signer,
+                    signature,
+                    message_bytes.as_slice(),
+                    registry_version,
+                )
+            }),
         )
     }
 
@@ -80,8 +83,7 @@ impl BasicSigVerifierInternal {
     pub fn verify_basic_sig_batch_multi_msg<H: Signable, R: CryptoComponentRng>(
         csprng: &CspRwLock<R>,
         registry: &dyn RegistryClient,
-        inputs: &[(NodeId, &BasicSigOf<H>, &H)],
-        registry_version: RegistryVersion,
+        inputs: &[(NodeId, &BasicSigOf<H>, &H, RegistryVersion)],
     ) -> CryptoResult<()> {
         if inputs.is_empty() {
             return Err(CryptoError::InvalidArgument {
@@ -92,32 +94,42 @@ impl BasicSigVerifierInternal {
         };
         // Serialize each message once and keep the owned buffers alive so we
         // can borrow them into the helper's input iterator.
-        let entries: Vec<(NodeId, &BasicSigOf<H>, Vec<u8>)> = inputs
+        let entries: Vec<(NodeId, &BasicSigOf<H>, Vec<u8>, RegistryVersion)> = inputs
             .iter()
-            .map(|(signer, signature, message)| (*signer, *signature, message.as_signed_bytes()))
+            .map(|(signer, signature, message, registry_version)| {
+                (
+                    *signer,
+                    *signature,
+                    message.as_signed_bytes(),
+                    *registry_version,
+                )
+            })
             .collect();
         Self::verify_basic_sig_batch_internal(
             csprng,
             registry,
             entries
                 .iter()
-                .map(|(signer, signature, msg_bytes)| (*signer, *signature, msg_bytes.as_slice())),
-            registry_version,
+                .map(|(signer, signature, msg_bytes, registry_version)| {
+                    (*signer, *signature, msg_bytes.as_slice(), *registry_version)
+                }),
         )
     }
 
     /// Shared implementation of batched Ed25519 basic-sig verification.
+    ///
+    /// Each input carries its own registry version, at which that signer's
+    /// public key is resolved.
     fn verify_basic_sig_batch_internal<'a, H: 'a, R: CryptoComponentRng>(
         csprng: &CspRwLock<R>,
         registry: &dyn RegistryClient,
-        inputs: impl ExactSizeIterator<Item = (NodeId, &'a BasicSigOf<H>, &'a [u8])>,
-        registry_version: RegistryVersion,
+        inputs: impl ExactSizeIterator<Item = (NodeId, &'a BasicSigOf<H>, &'a [u8], RegistryVersion)>,
     ) -> CryptoResult<()> {
         let mut msgs = Vec::with_capacity(inputs.len());
         let mut sigs = Vec::with_capacity(inputs.len());
         let mut keys = Vec::with_capacity(inputs.len());
 
-        for (signer, signature, msg_bytes) in inputs {
+        for (signer, signature, msg_bytes, registry_version) in inputs {
             let pk_proto =
                 key_from_registry(registry, signer, KeyPurpose::NodeSigning, registry_version)?;
 

--- a/rs/crypto/src/sign/basic_sig.rs
+++ b/rs/crypto/src/sign/basic_sig.rs
@@ -117,9 +117,6 @@ impl BasicSigVerifierInternal {
     }
 
     /// Shared implementation of batched Ed25519 basic-sig verification.
-    ///
-    /// Each input carries its own registry version, at which that signer's
-    /// public key is resolved.
     fn verify_basic_sig_batch_internal<'a, H: 'a, R: CryptoComponentRng>(
         csprng: &CspRwLock<R>,
         registry: &dyn RegistryClient,

--- a/rs/crypto/src/sign/basic_sig.rs
+++ b/rs/crypto/src/sign/basic_sig.rs
@@ -83,7 +83,7 @@ impl BasicSigVerifierInternal {
     pub fn verify_basic_sig_batch_multi_msg<H: Signable, R: CryptoComponentRng>(
         csprng: &CspRwLock<R>,
         registry: &dyn RegistryClient,
-        inputs: &[(NodeId, &BasicSigOf<H>, &H, RegistryVersion)],
+        inputs: &[BasicSigBatchEntry<'_, H>],
     ) -> CryptoResult<()> {
         if inputs.is_empty() {
             return Err(CryptoError::InvalidArgument {
@@ -96,12 +96,12 @@ impl BasicSigVerifierInternal {
         // can borrow them into the helper's input iterator.
         let entries: Vec<(NodeId, &BasicSigOf<H>, Vec<u8>, RegistryVersion)> = inputs
             .iter()
-            .map(|(signer, signature, message, registry_version)| {
+            .map(|entry| {
                 (
-                    *signer,
-                    *signature,
-                    message.as_signed_bytes(),
-                    *registry_version,
+                    entry.signer,
+                    entry.signature,
+                    entry.message.as_signed_bytes(),
+                    entry.registry_version,
                 )
             })
             .collect();

--- a/rs/crypto/src/sign/basic_sig/tests.rs
+++ b/rs/crypto/src/sign/basic_sig/tests.rs
@@ -445,6 +445,7 @@ mod verify_sigs_batch {
     use ic_crypto_temp_crypto::TempCryptoComponent;
     use ic_registry_client_fake::FakeRegistryClient;
     use ic_registry_proto_data_provider::ProtoRegistryDataProvider;
+    use ic_types::signature::BasicSigBatchEntry;
     use ic_types_test_utils::ids::{NODE_1, NODE_2, NODE_3};
 
     fn two_node_crypto_components() -> (TempCryptoComponent, TempCryptoComponent) {
@@ -473,6 +474,20 @@ mod verify_sigs_batch {
         (crypto_1, crypto_2)
     }
 
+    /// Builds a batch entry at `REG_V2` (the version these tests register keys at).
+    fn entry<'a>(
+        signer: NodeId,
+        signature: &'a BasicSigOf<SignableMock>,
+        message: &'a SignableMock,
+    ) -> BasicSigBatchEntry<'a, SignableMock> {
+        BasicSigBatchEntry {
+            signer,
+            signature,
+            message,
+            registry_version: REG_V2,
+        }
+    }
+
     #[test]
     fn should_correctly_verify_batch_with_single_signature() {
         let crypto = TempCryptoComponent::builder()
@@ -483,7 +498,7 @@ mod verify_sigs_batch {
         let msg = SignableMock::new(b"Hello World!".to_vec());
         let sig = crypto.sign_basic(&msg).unwrap();
 
-        let inputs = vec![(NODE_1, &sig, &msg, REG_V2)];
+        let inputs = vec![entry(NODE_1, &sig, &msg)];
         assert_matches!(crypto.verify_basic_sig_batch_multi_msg(&inputs), Ok(()));
     }
 
@@ -496,10 +511,7 @@ mod verify_sigs_batch {
         let sig_1 = crypto_1.sign_basic(&msg_1).unwrap();
         let sig_2 = crypto_2.sign_basic(&msg_2).unwrap();
 
-        let inputs = vec![
-            (NODE_1, &sig_1, &msg_1, REG_V2),
-            (NODE_2, &sig_2, &msg_2, REG_V2),
-        ];
+        let inputs = vec![entry(NODE_1, &sig_1, &msg_1), entry(NODE_2, &sig_2, &msg_2)];
         assert_matches!(crypto_1.verify_basic_sig_batch_multi_msg(&inputs), Ok(()));
     }
 
@@ -515,10 +527,7 @@ mod verify_sigs_batch {
         let sig_1 = crypto.sign_basic(&msg_1).unwrap();
         let sig_2 = crypto.sign_basic(&msg_2).unwrap();
 
-        let inputs = vec![
-            (NODE_1, &sig_1, &msg_1, REG_V2),
-            (NODE_1, &sig_2, &msg_2, REG_V2),
-        ];
+        let inputs = vec![entry(NODE_1, &sig_1, &msg_1), entry(NODE_1, &sig_2, &msg_2)];
         assert_matches!(crypto.verify_basic_sig_batch_multi_msg(&inputs), Ok(()));
     }
 
@@ -530,10 +539,7 @@ mod verify_sigs_batch {
         let sig_1 = crypto_1.sign_basic(&msg).unwrap();
         let sig_2 = crypto_2.sign_basic(&msg).unwrap();
 
-        let inputs = vec![
-            (NODE_1, &sig_1, &msg, REG_V2),
-            (NODE_2, &sig_2, &msg, REG_V2),
-        ];
+        let inputs = vec![entry(NODE_1, &sig_1, &msg), entry(NODE_2, &sig_2, &msg)];
         assert_matches!(crypto_1.verify_basic_sig_batch_multi_msg(&inputs), Ok(()));
     }
 
@@ -546,10 +552,7 @@ mod verify_sigs_batch {
         let sig_1 = crypto_1.sign_basic(&msg_1).unwrap();
         let sig_2 = crypto_2.sign_basic(&msg_2).unwrap();
 
-        let inputs = vec![
-            (NODE_1, &sig_1, &msg_2, REG_V2),
-            (NODE_2, &sig_2, &msg_1, REG_V2),
-        ];
+        let inputs = vec![entry(NODE_1, &sig_1, &msg_2), entry(NODE_2, &sig_2, &msg_1)];
 
         assert_matches!(
             crypto_1.verify_basic_sig_batch_multi_msg(&inputs),
@@ -572,8 +575,8 @@ mod verify_sigs_batch {
         };
 
         let inputs = vec![
-            (NODE_1, &sig_1, &msg_1, REG_V2),
-            (NODE_2, &sig_2_corrupted, &msg_2, REG_V2),
+            entry(NODE_1, &sig_1, &msg_1),
+            entry(NODE_2, &sig_2_corrupted, &msg_2),
         ];
 
         assert_matches!(
@@ -594,12 +597,7 @@ mod verify_sigs_batch {
             rng,
         );
 
-        let empty_inputs: Vec<(
-            NodeId,
-            &BasicSigOf<SignableMock>,
-            &SignableMock,
-            ic_types::RegistryVersion,
-        )> = vec![];
+        let empty_inputs: Vec<BasicSigBatchEntry<'_, SignableMock>> = vec![];
 
         assert_matches!(
             crypto.verify_basic_sig_batch_multi_msg(&empty_inputs),
@@ -615,7 +613,7 @@ mod verify_sigs_batch {
         let msg = SignableMock::new(b"Hello World!".to_vec());
         let sig = crypto_1.sign_basic(&msg).unwrap();
 
-        let inputs = vec![(NODE_3, &sig, &msg, REG_V2)];
+        let inputs = vec![entry(NODE_3, &sig, &msg)];
 
         assert_matches!(
             crypto_1.verify_basic_sig_batch_multi_msg(&inputs),

--- a/rs/crypto/src/sign/basic_sig/tests.rs
+++ b/rs/crypto/src/sign/basic_sig/tests.rs
@@ -440,7 +440,7 @@ mod verify_sigs_batch {
     use crate::common::test_utils::basic_sig;
     use crate::common::test_utils::basic_sig::TestVector::ED25519_STABILITY_1;
     use crate::common::test_utils::crypto_component::crypto_component_with_csp;
-    use crate::sign::tests::REG_V2;
+    use crate::sign::tests::{REG_V1, REG_V2};
     use ic_crypto_temp_crypto::NodeKeysToGenerate;
     use ic_crypto_temp_crypto::TempCryptoComponent;
     use ic_registry_client_fake::FakeRegistryClient;
@@ -618,6 +618,83 @@ mod verify_sigs_batch {
         assert_matches!(
             crypto_1.verify_basic_sig_batch_multi_msg(&inputs),
             Err(CryptoError::PublicKeyNotFound { .. })
+        );
+    }
+
+    #[test]
+    fn should_resolve_each_signers_public_key_at_its_own_registry_version() {
+        // Register NODE_1's signing key at REG_V1 and NODE_2's at the later
+        // REG_V2, sharing a single registry. NODE_2's key is therefore present
+        // at REG_V2 but absent at REG_V1.
+        let registry_data = Arc::new(ProtoRegistryDataProvider::new());
+        let registry_client =
+            Arc::new(FakeRegistryClient::new(Arc::clone(&registry_data) as Arc<_>));
+        let crypto_1 = TempCryptoComponent::builder()
+            .with_keys_in_registry_version(NodeKeysToGenerate::only_node_signing_key(), REG_V1)
+            .with_registry_client_and_data(
+                Arc::clone(&registry_client) as Arc<_>,
+                Arc::clone(&registry_data) as Arc<_>,
+            )
+            .with_node_id(NODE_1)
+            .build();
+        let crypto_2 = TempCryptoComponent::builder()
+            .with_keys_in_registry_version(NodeKeysToGenerate::only_node_signing_key(), REG_V2)
+            .with_registry_client_and_data(
+                Arc::clone(&registry_client) as Arc<_>,
+                Arc::clone(&registry_data) as Arc<_>,
+            )
+            .with_node_id(NODE_2)
+            .build();
+        registry_client.reload();
+
+        let msg_1 = SignableMock::new(b"Hello World!".to_vec());
+        let msg_2 = SignableMock::new(b"Goodbye World!".to_vec());
+        let sig_1 = crypto_1.sign_basic(&msg_1).unwrap();
+        let sig_2 = crypto_2.sign_basic(&msg_2).unwrap();
+
+        // Each entry resolves its signer's key at its OWN registry version:
+        // NODE_1 at REG_V1 and NODE_2 at REG_V2 both resolve, so the batch
+        // verifies successfully.
+        let inputs_ok = vec![
+            BasicSigBatchEntry {
+                signer: NODE_1,
+                signature: &sig_1,
+                message: &msg_1,
+                registry_version: REG_V1,
+            },
+            BasicSigBatchEntry {
+                signer: NODE_2,
+                signature: &sig_2,
+                message: &msg_2,
+                registry_version: REG_V2,
+            },
+        ];
+        assert_matches!(
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs_ok),
+            Ok(())
+        );
+
+        // Pinning NODE_2's entry to the earlier REG_V1 (where its key is not yet
+        // registered) must fail with `PublicKeyNotFound`, even though NODE_1's
+        // entry still resolves at REG_V2.
+        let inputs_err = vec![
+            BasicSigBatchEntry {
+                signer: NODE_1,
+                signature: &sig_1,
+                message: &msg_1,
+                registry_version: REG_V2,
+            },
+            BasicSigBatchEntry {
+                signer: NODE_2,
+                signature: &sig_2,
+                message: &msg_2,
+                registry_version: REG_V1,
+            },
+        ];
+        assert_matches!(
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs_err),
+            Err(CryptoError::PublicKeyNotFound { node_id, registry_version, .. })
+            if node_id == NODE_2 && registry_version == REG_V1
         );
     }
 }

--- a/rs/crypto/src/sign/basic_sig/tests.rs
+++ b/rs/crypto/src/sign/basic_sig/tests.rs
@@ -483,11 +483,8 @@ mod verify_sigs_batch {
         let msg = SignableMock::new(b"Hello World!".to_vec());
         let sig = crypto.sign_basic(&msg).unwrap();
 
-        let inputs = vec![(NODE_1, &sig, &msg)];
-        assert_matches!(
-            crypto.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
-            Ok(())
-        );
+        let inputs = vec![(NODE_1, &sig, &msg, REG_V2)];
+        assert_matches!(crypto.verify_basic_sig_batch_multi_msg(&inputs), Ok(()));
     }
 
     #[test]
@@ -499,11 +496,11 @@ mod verify_sigs_batch {
         let sig_1 = crypto_1.sign_basic(&msg_1).unwrap();
         let sig_2 = crypto_2.sign_basic(&msg_2).unwrap();
 
-        let inputs = vec![(NODE_1, &sig_1, &msg_1), (NODE_2, &sig_2, &msg_2)];
-        assert_matches!(
-            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
-            Ok(())
-        );
+        let inputs = vec![
+            (NODE_1, &sig_1, &msg_1, REG_V2),
+            (NODE_2, &sig_2, &msg_2, REG_V2),
+        ];
+        assert_matches!(crypto_1.verify_basic_sig_batch_multi_msg(&inputs), Ok(()));
     }
 
     #[test]
@@ -518,11 +515,11 @@ mod verify_sigs_batch {
         let sig_1 = crypto.sign_basic(&msg_1).unwrap();
         let sig_2 = crypto.sign_basic(&msg_2).unwrap();
 
-        let inputs = vec![(NODE_1, &sig_1, &msg_1), (NODE_1, &sig_2, &msg_2)];
-        assert_matches!(
-            crypto.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
-            Ok(())
-        );
+        let inputs = vec![
+            (NODE_1, &sig_1, &msg_1, REG_V2),
+            (NODE_1, &sig_2, &msg_2, REG_V2),
+        ];
+        assert_matches!(crypto.verify_basic_sig_batch_multi_msg(&inputs), Ok(()));
     }
 
     #[test]
@@ -533,11 +530,11 @@ mod verify_sigs_batch {
         let sig_1 = crypto_1.sign_basic(&msg).unwrap();
         let sig_2 = crypto_2.sign_basic(&msg).unwrap();
 
-        let inputs = vec![(NODE_1, &sig_1, &msg), (NODE_2, &sig_2, &msg)];
-        assert_matches!(
-            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
-            Ok(())
-        );
+        let inputs = vec![
+            (NODE_1, &sig_1, &msg, REG_V2),
+            (NODE_2, &sig_2, &msg, REG_V2),
+        ];
+        assert_matches!(crypto_1.verify_basic_sig_batch_multi_msg(&inputs), Ok(()));
     }
 
     #[test]
@@ -549,10 +546,13 @@ mod verify_sigs_batch {
         let sig_1 = crypto_1.sign_basic(&msg_1).unwrap();
         let sig_2 = crypto_2.sign_basic(&msg_2).unwrap();
 
-        let inputs = vec![(NODE_1, &sig_1, &msg_2), (NODE_2, &sig_2, &msg_1)];
+        let inputs = vec![
+            (NODE_1, &sig_1, &msg_2, REG_V2),
+            (NODE_2, &sig_2, &msg_1, REG_V2),
+        ];
 
         assert_matches!(
-            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs),
             Err(CryptoError::SignatureVerification { .. })
         );
     }
@@ -571,10 +571,13 @@ mod verify_sigs_batch {
             BasicSigOf::new(BasicSig(bytes))
         };
 
-        let inputs = vec![(NODE_1, &sig_1, &msg_1), (NODE_2, &sig_2_corrupted, &msg_2)];
+        let inputs = vec![
+            (NODE_1, &sig_1, &msg_1, REG_V2),
+            (NODE_2, &sig_2_corrupted, &msg_2, REG_V2),
+        ];
 
         assert_matches!(
-            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs),
             Err(CryptoError::SignatureVerification { .. })
         );
     }
@@ -591,10 +594,15 @@ mod verify_sigs_batch {
             rng,
         );
 
-        let empty_inputs: Vec<(NodeId, &BasicSigOf<SignableMock>, &SignableMock)> = vec![];
+        let empty_inputs: Vec<(
+            NodeId,
+            &BasicSigOf<SignableMock>,
+            &SignableMock,
+            ic_types::RegistryVersion,
+        )> = vec![];
 
         assert_matches!(
-            crypto.verify_basic_sig_batch_multi_msg(&empty_inputs, REG_V2),
+            crypto.verify_basic_sig_batch_multi_msg(&empty_inputs),
             Err(CryptoError::InvalidArgument { message })
             if message.contains("Empty signature batch. At least one signature should be included in the batch.")
         );
@@ -607,10 +615,10 @@ mod verify_sigs_batch {
         let msg = SignableMock::new(b"Hello World!".to_vec());
         let sig = crypto_1.sign_basic(&msg).unwrap();
 
-        let inputs = vec![(NODE_3, &sig, &msg)];
+        let inputs = vec![(NODE_3, &sig, &msg, REG_V2)];
 
         assert_matches!(
-            crypto_1.verify_basic_sig_batch_multi_msg(&inputs, REG_V2),
+            crypto_1.verify_basic_sig_batch_multi_msg(&inputs),
             Err(CryptoError::PublicKeyNotFound { .. })
         );
     }

--- a/rs/crypto/src/sign/basic_sig/tests.rs
+++ b/rs/crypto/src/sign/basic_sig/tests.rs
@@ -652,47 +652,41 @@ mod verify_sigs_batch {
         let sig_1 = crypto_1.sign_basic(&msg_1).unwrap();
         let sig_2 = crypto_2.sign_basic(&msg_2).unwrap();
 
-        // Each entry resolves its signer's key at its OWN registry version:
-        // NODE_1 at REG_V1 and NODE_2 at REG_V2 both resolve, so the batch
-        // verifies successfully.
-        let inputs_ok = vec![
-            BasicSigBatchEntry {
-                signer: NODE_1,
-                signature: &sig_1,
-                message: &msg_1,
-                registry_version: REG_V1,
-            },
-            BasicSigBatchEntry {
-                signer: NODE_2,
-                signature: &sig_2,
-                message: &msg_2,
-                registry_version: REG_V2,
-            },
-        ];
+        let node_1_entry = |registry_version| BasicSigBatchEntry {
+            signer: NODE_1,
+            signature: &sig_1,
+            message: &msg_1,
+            registry_version,
+        };
+        let node_2_entry = |registry_version| BasicSigBatchEntry {
+            signer: NODE_2,
+            signature: &sig_2,
+            message: &msg_2,
+            registry_version,
+        };
+
         assert_matches!(
-            crypto_1.verify_basic_sig_batch_multi_msg(&inputs_ok),
+            crypto_1
+                .verify_basic_sig_batch_multi_msg(&[node_1_entry(REG_V1), node_2_entry(REG_V2)]),
             Ok(())
         );
 
-        // Pinning NODE_2's entry to the earlier REG_V1 (where its key is not yet
-        // registered) must fail with `PublicKeyNotFound`, even though NODE_1's
-        // entry still resolves at REG_V2.
-        let inputs_err = vec![
-            BasicSigBatchEntry {
-                signer: NODE_1,
-                signature: &sig_1,
-                message: &msg_1,
-                registry_version: REG_V2,
-            },
-            BasicSigBatchEntry {
-                signer: NODE_2,
-                signature: &sig_2,
-                message: &msg_2,
-                registry_version: REG_V1,
-            },
-        ];
         assert_matches!(
-            crypto_1.verify_basic_sig_batch_multi_msg(&inputs_err),
+            crypto_1
+                .verify_basic_sig_batch_multi_msg(&[node_1_entry(REG_V2), node_2_entry(REG_V2)]),
+            Ok(())
+        );
+
+        assert_matches!(
+            crypto_1
+                .verify_basic_sig_batch_multi_msg(&[node_1_entry(REG_V2), node_2_entry(REG_V1)]),
+            Err(CryptoError::PublicKeyNotFound { node_id, registry_version, .. })
+            if node_id == NODE_2 && registry_version == REG_V1
+        );
+
+        assert_matches!(
+            crypto_1
+                .verify_basic_sig_batch_multi_msg(&[node_1_entry(REG_V1), node_2_entry(REG_V1)]),
             Err(CryptoError::PublicKeyNotFound { node_id, registry_version, .. })
             if node_id == NODE_2 && registry_version == REG_V1
         );

--- a/rs/crypto/src/sign/mod.rs
+++ b/rs/crypto/src/sign/mod.rs
@@ -53,7 +53,7 @@ pub use canister_threshold_sig::{
 mod tests;
 use ic_crypto_internal_logmon::metrics::{MetricsDomain, MetricsResult, MetricsScope};
 use ic_types::crypto::threshold_sig::IcRootOfTrust;
-use ic_types::signature::BasicSignatureBatch;
+use ic_types::signature::{BasicSigBatchEntry, BasicSignatureBatch};
 
 impl<C: CryptoServiceProvider + Send + Sync, R: CryptoComponentRng, H: Signable> BasicSigner<H>
     for CryptoComponentImpl<C, R>
@@ -212,7 +212,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> BasicSigVerif
 
     fn verify_basic_sig_batch_multi_msg(
         &self,
-        inputs: &[(NodeId, &BasicSigOf<H>, &H, RegistryVersion)],
+        inputs: &[BasicSigBatchEntry<'_, H>],
     ) -> CryptoResult<()> {
         let log_id = get_log_id(&self.logger);
         let logger = new_logger!(&self.logger;
@@ -222,7 +222,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> BasicSigVerif
         );
         debug!(logger;
             crypto.description => "start",
-            crypto.signature => format!("{:?}", inputs.iter().map(|(s, sig, _, rv)| (s, sig, rv)).collect::<Vec<_>>()),
+            crypto.signature => format!("{:?}", inputs.iter().map(|entry| (entry.signer, entry.signature, entry.registry_version)).collect::<Vec<_>>()),
         );
         let start_time = self.metrics.now();
         let result = BasicSigVerifierInternal::verify_basic_sig_batch_multi_msg(

--- a/rs/crypto/src/sign/mod.rs
+++ b/rs/crypto/src/sign/mod.rs
@@ -212,8 +212,7 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> BasicSigVerif
 
     fn verify_basic_sig_batch_multi_msg(
         &self,
-        inputs: &[(NodeId, &BasicSigOf<H>, &H)],
-        registry_version: RegistryVersion,
+        inputs: &[(NodeId, &BasicSigOf<H>, &H, RegistryVersion)],
     ) -> CryptoResult<()> {
         let log_id = get_log_id(&self.logger);
         let logger = new_logger!(&self.logger;
@@ -223,15 +222,13 @@ impl<C: CryptoServiceProvider, R: CryptoComponentRng, H: Signable> BasicSigVerif
         );
         debug!(logger;
             crypto.description => "start",
-            crypto.registry_version => registry_version.get(),
-            crypto.signature => format!("{:?}", inputs.iter().map(|(s, sig, _)| (s, sig)).collect::<Vec<_>>()),
+            crypto.signature => format!("{:?}", inputs.iter().map(|(s, sig, _, rv)| (s, sig, rv)).collect::<Vec<_>>()),
         );
         let start_time = self.metrics.now();
         let result = BasicSigVerifierInternal::verify_basic_sig_batch_multi_msg(
             &self.csprng,
             self.registry_client.as_ref(),
             inputs,
-            registry_version,
         );
         self.metrics.observe_duration_seconds(
             MetricsDomain::BasicSignature,

--- a/rs/crypto/temp_crypto/src/lib.rs
+++ b/rs/crypto/temp_crypto/src/lib.rs
@@ -103,7 +103,7 @@ pub mod internal {
         CurrentNodePublicKeys, IndividualMultiSigOf, KeyPurpose, Signable, ThresholdSigShareOf,
         UserPublicKey,
     };
-    use ic_types::signature::BasicSignatureBatch;
+    use ic_types::signature::{BasicSigBatchEntry, BasicSignatureBatch};
     use ic_types::{NodeId, RegistryVersion, SubnetId};
     use rand::SeedableRng;
     use rand::rngs::OsRng;
@@ -875,7 +875,7 @@ pub mod internal {
 
         fn verify_basic_sig_batch_multi_msg(
             &self,
-            inputs: &[(NodeId, &BasicSigOf<T>, &T, RegistryVersion)],
+            inputs: &[BasicSigBatchEntry<'_, T>],
         ) -> CryptoResult<()> {
             self.crypto_component
                 .verify_basic_sig_batch_multi_msg(inputs)

--- a/rs/crypto/temp_crypto/src/lib.rs
+++ b/rs/crypto/temp_crypto/src/lib.rs
@@ -875,11 +875,10 @@ pub mod internal {
 
         fn verify_basic_sig_batch_multi_msg(
             &self,
-            inputs: &[(NodeId, &BasicSigOf<T>, &T)],
-            registry_version: RegistryVersion,
+            inputs: &[(NodeId, &BasicSigOf<T>, &T, RegistryVersion)],
         ) -> CryptoResult<()> {
             self.crypto_component
-                .verify_basic_sig_batch_multi_msg(inputs, registry_version)
+                .verify_basic_sig_batch_multi_msg(inputs)
         }
     }
 

--- a/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
+++ b/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
@@ -675,11 +675,10 @@ pub mod node {
 
         fn verify_basic_sig_batch_multi_msg(
             &self,
-            inputs: &[(NodeId, &BasicSigOf<T>, &T)],
-            registry_version: RegistryVersion,
+            inputs: &[(NodeId, &BasicSigOf<T>, &T, RegistryVersion)],
         ) -> CryptoResult<()> {
             self.crypto_component
-                .verify_basic_sig_batch_multi_msg(inputs, registry_version)
+                .verify_basic_sig_batch_multi_msg(inputs)
         }
     }
 

--- a/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
+++ b/rs/crypto/test_utils/canister_threshold_sigs/src/lib.rs
@@ -313,7 +313,7 @@ pub mod node {
         ThresholdSchnorrCombinedSignature, ThresholdSchnorrSigInputs, ThresholdSchnorrSigShare,
     };
     use ic_types::crypto::{BasicSigOf, CryptoResult, CurrentNodePublicKeys, Signable};
-    use ic_types::signature::BasicSignatureBatch;
+    use ic_types::signature::{BasicSigBatchEntry, BasicSignatureBatch};
     use ic_types::{NodeId, RegistryVersion};
     use rand::seq::IteratorRandom;
     use rand::{CryptoRng, Rng, RngCore, SeedableRng};
@@ -675,7 +675,7 @@ pub mod node {
 
         fn verify_basic_sig_batch_multi_msg(
             &self,
-            inputs: &[(NodeId, &BasicSigOf<T>, &T, RegistryVersion)],
+            inputs: &[BasicSigBatchEntry<'_, T>],
         ) -> CryptoResult<()> {
             self.crypto_component
                 .verify_basic_sig_batch_multi_msg(inputs)

--- a/rs/crypto/test_utils/crypto_returning_ok/src/lib.rs
+++ b/rs/crypto/test_utils/crypto_returning_ok/src/lib.rs
@@ -86,8 +86,7 @@ impl<T: Signable> BasicSigVerifier<T> for CryptoReturningOk {
 
     fn verify_basic_sig_batch_multi_msg(
         &self,
-        _inputs: &[(NodeId, &BasicSigOf<T>, &T)],
-        _registry_version: RegistryVersion,
+        _inputs: &[(NodeId, &BasicSigOf<T>, &T, RegistryVersion)],
     ) -> CryptoResult<()> {
         Ok(())
     }

--- a/rs/crypto/test_utils/crypto_returning_ok/src/lib.rs
+++ b/rs/crypto/test_utils/crypto_returning_ok/src/lib.rs
@@ -27,7 +27,7 @@ use ic_types::crypto::{
     IndividualMultiSig, IndividualMultiSigOf, Signable, ThresholdSigShare, ThresholdSigShareOf,
     UserPublicKey,
 };
-use ic_types::signature::{BasicSignature, BasicSignatureBatch};
+use ic_types::signature::{BasicSigBatchEntry, BasicSignature, BasicSignatureBatch};
 use ic_types::*;
 use ic_types::{NodeId, RegistryVersion};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -86,7 +86,7 @@ impl<T: Signable> BasicSigVerifier<T> for CryptoReturningOk {
 
     fn verify_basic_sig_batch_multi_msg(
         &self,
-        _inputs: &[(NodeId, &BasicSigOf<T>, &T, RegistryVersion)],
+        _inputs: &[BasicSigBatchEntry<'_, T>],
     ) -> CryptoResult<()> {
         Ok(())
     }

--- a/rs/https_outcalls/consensus/benches/payload_validation.rs
+++ b/rs/https_outcalls/consensus/benches/payload_validation.rs
@@ -126,7 +126,6 @@ struct BenchTarget {
     builder: CanisterHttpPayloadBuilderImpl,
     payload: CanisterHttpPayload,
     validation_context: ValidationContext,
-    height: Height,
     // Kept alive for the lifetime of the benchmark so that the consensus pool
     // (and its cache, held by the builder) and the registry remain valid.
     _deps: Dependencies,
@@ -142,7 +141,6 @@ fn bench_payload_verification(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::from_parameter(config.label), config, |b, _| {
                 b.iter(|| {
                     black_box(target.builder.validate_canister_http_payload_impl(
-                        black_box(target.height),
                         black_box(&target.payload),
                         black_box(&target.validation_context),
                         black_box(HashSet::new()),
@@ -237,7 +235,6 @@ fn build_target(
         builder,
         payload,
         validation_context: validation_context(),
-        height: Height::new(1),
         _deps: deps,
     }
 }

--- a/rs/https_outcalls/consensus/benches/payload_validation.rs
+++ b/rs/https_outcalls/consensus/benches/payload_validation.rs
@@ -473,7 +473,6 @@ fn response_and_metadata(
         content_hash: crypto_hash(&response),
         content_size: response.content.count_bytes() as u32,
         is_reject: response.content.is_reject(),
-        registry_version: REGISTRY_VERSION,
         replica_version: ReplicaVersion::default(),
     };
     (response, metadata)

--- a/rs/https_outcalls/consensus/src/gossip.rs
+++ b/rs/https_outcalls/consensus/src/gossip.rs
@@ -1,14 +1,11 @@
 //! This module contains the gossip implementation of the canister http feature.
 
 pub use crate::pool_manager::CanisterHttpPoolManagerImpl;
-use ic_consensus_utils::registry_version_at_height;
 use ic_interfaces::{
     canister_http::CanisterHttpPool,
-    consensus_pool::ConsensusPoolCache,
     p2p::consensus::{Bouncer, BouncerFactory, BouncerValue},
 };
 use ic_interfaces_state_manager::StateReader;
-use ic_logger::{ReplicaLogger, warn};
 use ic_replicated_state::ReplicatedState;
 use ic_types::{artifact::CanisterHttpResponseId, messages::CallbackId};
 use std::{collections::BTreeSet, sync::Arc};
@@ -20,23 +17,13 @@ const MAX_NUMBER_OF_REQUESTS_AHEAD: u64 = 3 * (100 + 15);
 
 /// The canonical implementation of [`BouncerFactory`]
 pub struct CanisterHttpGossipImpl {
-    consensus_cache: Arc<dyn ConsensusPoolCache>,
     state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
-    log: ReplicaLogger,
 }
 
 impl CanisterHttpGossipImpl {
     /// Construcet a new CanisterHttpGossipImpl instance
-    pub fn new(
-        consensus_cache: Arc<dyn ConsensusPoolCache>,
-        state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
-        log: ReplicaLogger,
-    ) -> Self {
-        CanisterHttpGossipImpl {
-            consensus_cache,
-            state_reader,
-            log,
-        }
+    pub fn new(state_reader: Arc<dyn StateReader<State = ReplicatedState>>) -> Self {
+        CanisterHttpGossipImpl { state_reader }
     }
 }
 
@@ -44,9 +31,6 @@ impl<Pool: CanisterHttpPool> BouncerFactory<CanisterHttpResponseId, Pool>
     for CanisterHttpGossipImpl
 {
     fn new_bouncer(&self, _canister_http_pool: &Pool) -> Bouncer<CanisterHttpResponseId> {
-        let finalized_height = self.consensus_cache.finalized_block().height;
-        let registry_version =
-            registry_version_at_height(self.consensus_cache.as_ref(), finalized_height).unwrap();
         let (known_request_ids, next_callback_id) = {
             let latest_state = self.state_reader.get_latest_state();
             let subnet_call_context_manger =
@@ -59,19 +43,7 @@ impl<Pool: CanisterHttpPool> BouncerFactory<CanisterHttpResponseId, Pool>
             let next_callback_id = subnet_call_context_manger.next_callback_id();
             (known_request_ids, next_callback_id)
         };
-        let log = self.log.clone();
         Box::new(move |id: &'_ CanisterHttpResponseId| {
-            if id.content.registry_version() != registry_version {
-                warn!(
-                    log,
-                    "Dropping canister http response share with callback id: {}, because registry version {} does not match expected version {}",
-                    id.content.id(),
-                    id.content.registry_version(),
-                    registry_version
-                );
-                return BouncerValue::Unwanted;
-            }
-
             // We derive the highest accepted request id from the next expected request id, plus the
             // number of maximal number of new requests we can get between the function calls.
             let highest_accepted_request_id =

--- a/rs/https_outcalls/consensus/src/metrics.rs
+++ b/rs/https_outcalls/consensus/src/metrics.rs
@@ -53,8 +53,9 @@ pub struct CanisterHttpPayloadBuilderMetrics {
     pub op_duration: HistogramVec,
     /// The total number of validated shares in the pool
     pub total_shares: IntGauge,
-    /// The number of shares which are not timed out or have ineligible registry
-    /// versions.
+    /// The number of validated shares whose request has not already been
+    /// answered in the chain (i.e. shares that are still candidates for
+    /// inclusion in a payload).
     pub active_shares: IntGauge,
 }
 
@@ -74,7 +75,7 @@ impl CanisterHttpPayloadBuilderMetrics {
             ),
             active_shares: metrics_registry.int_gauge(
                 "canister_http_total_active_validated_shares",
-                "The total number of validated shares that are not timed out or made with invalid registry version."
+                "The total number of validated shares whose request has not already been answered in the chain."
             ),
         }
     }

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -249,9 +249,10 @@ impl CanisterHttpPayloadBuilderImpl {
                             match thresholds_by_version.get(&request.registry_version) {
                                 Some(values) => *values,
                                 None => {
-                                    match self.membership.get_canister_http_committee_at_version(
-                                        request.registry_version,
-                                    ) {
+                                    match self
+                                        .membership
+                                        .get_canister_http_committee(request.registry_version)
+                                    {
                                         Ok(committee) => {
                                             let faults_tolerated =
                                                 ic_types::consensus::get_faults_tolerated(
@@ -472,7 +473,7 @@ impl CanisterHttpPayloadBuilderImpl {
                     // version pinned in the request context.
                     let committee = self
                         .membership
-                        .get_canister_http_committee_at_version(request_context.registry_version)
+                        .get_canister_http_committee(request_context.registry_version)
                         .map_err(|err| {
                             warn!(self.log, "Failed to get membership: {:?}", err);
                             CanisterHttpPayloadValidationError::ValidationFailed(
@@ -556,7 +557,7 @@ impl CanisterHttpPayloadBuilderImpl {
                 // pinned in the request context.
                 let committee = self
                     .membership
-                    .get_canister_http_committee_at_version(context.registry_version)
+                    .get_canister_http_committee(context.registry_version)
                     .map_err(|_| {
                         CanisterHttpPayloadValidationError::ValidationFailed(
                             CanisterHttpPayloadValidationFailure::Membership,

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -49,6 +49,7 @@ use ic_types::{
         CanisterHttpResponseContent, CanisterHttpResponseDivergence, CanisterHttpResponseShare,
         Replication,
     },
+    consensus::get_faults_tolerated,
     messages::{CallbackId, Payload, RejectContext},
     registry::RegistryClientError,
     signature::BasicSigBatchEntry,
@@ -135,12 +136,6 @@ impl CanisterHttpPayloadBuilderImpl {
         delivered_ids: HashSet<CallbackId>,
         max_payload_size: NumBytes,
     ) -> CanisterHttpPayload {
-        // Committee threshold and faults_tolerated are derived per request from
-        // the registry version pinned in the request context. Cache the
-        // resulting `(threshold, faults_tolerated)` by registry version to avoid
-        // repeated registry lookups within a single payload.
-        let mut thresholds_by_version: BTreeMap<RegistryVersion, (usize, usize)> = BTreeMap::new();
-
         let state = match self
             .state_reader
             .get_state_at(validation_context.certified_height)
@@ -241,37 +236,20 @@ impl CanisterHttpPayloadBuilderImpl {
                     Replication::FullyReplicated => {
                         // Committee threshold/faults_tolerated for this request
                         // are derived from the registry version pinned in its
-                        // context (cached across requests sharing a version).
-                        let (threshold, faults_tolerated) =
-                            match thresholds_by_version.get(&request.registry_version) {
-                                Some(values) => *values,
-                                None => {
-                                    match self
-                                        .membership
-                                        .get_canister_http_committee(request.registry_version)
-                                    {
-                                        Ok(committee) => {
-                                            let faults_tolerated =
-                                                ic_types::consensus::get_faults_tolerated(
-                                                    committee.len(),
-                                                );
-                                            let threshold = committee.len() - faults_tolerated;
-                                            thresholds_by_version.insert(
-                                                request.registry_version,
-                                                (threshold, faults_tolerated),
-                                            );
-                                            (threshold, faults_tolerated)
-                                        }
-                                        Err(err) => {
-                                            warn!(
-                                                self.log,
-                                                "Failed to get canister http committee: {:?}", err
-                                            );
-                                            continue;
-                                        }
-                                    }
-                                }
-                            };
+                        // context.
+                        let (threshold, faults_tolerated) = match self
+                            .membership
+                            .get_canister_http_committee(request.registry_version)
+                        {
+                            Ok(committee) => {
+                                let faults_tolerated = get_faults_tolerated(committee.len());
+                                (committee.len() - faults_tolerated, faults_tolerated)
+                            }
+                            Err(err) => {
+                                warn!(self.log, "Failed to get canister http committee: {:?}", err);
+                                continue;
+                            }
+                        };
                         if let Some(response) =
                             find_fully_replicated_response(grouped_shares, threshold, &*pool_access)
                         {
@@ -427,15 +405,11 @@ impl CanisterHttpPayloadBuilderImpl {
             }
         }
 
-        // Shares reconstructed from aggregated response proofs, each paired with
-        // the registry version pinned in its request context (at which the
-        // signer's public key is resolved during batched verification).
+        // Shares reconstructed from aggregated response proofs.
         let mut reconstructed_shares: Vec<(CanisterHttpResponseShare, RegistryVersion)> =
             Vec::new();
         // Accumulates all signatures in the payload, so that they can be checked
         // in a single batched multi-message verification call at the very end.
-        // Each input carries the registry version pinned in its request context,
-        // at which that signer's public key is resolved.
         let mut sig_inputs: Vec<ResponseShareSigInput> = Vec::new();
 
         // Check conditions on individual responses
@@ -472,8 +446,7 @@ impl CanisterHttpPayloadBuilderImpl {
                                 CanisterHttpPayloadValidationFailure::Membership,
                             )
                         })?;
-                    let threshold = committee.len()
-                        - ic_types::consensus::get_faults_tolerated(committee.len());
+                    let threshold = committee.len() - get_faults_tolerated(committee.len());
                     (committee, threshold)
                 }
                 Replication::Flexible { .. } => {
@@ -513,8 +486,7 @@ impl CanisterHttpPayloadBuilderImpl {
                 )
                 .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
             }
-            // Reconstruct the per-signer shares from the response proof, tagging
-            // each with the registry version pinned in this request's context.
+            // Reconstruct the per-signer shares from the response proof.
             reconstructed_shares.extend(
                 utils::reconstruct_individual_shares(&response.proof)
                     .map(|share| (share, request_context.registry_version)),
@@ -568,7 +540,7 @@ impl CanisterHttpPayloadBuilderImpl {
                             CanisterHttpPayloadValidationFailure::Membership,
                         )
                     })?;
-                let faults_tolerated = ic_types::consensus::get_faults_tolerated(committee.len());
+                let faults_tolerated = get_faults_tolerated(committee.len());
 
                 let (valid_signers, invalid_signers): (Vec<NodeId>, Vec<NodeId>) = response
                     .shares

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -14,7 +14,10 @@ use crate::{
     },
 };
 use candid::{Decode, Encode};
-use ic_consensus_utils::{crypto::ConsensusCrypto, membership::Membership};
+use ic_consensus_utils::{
+    crypto::ConsensusCrypto,
+    membership::{Membership, MembershipError},
+};
 use ic_error_types::RejectCode;
 use ic_interfaces::{
     batch_payload::{BatchPayloadBuilder, IntoMessages, PastPayload, ProposalContext},
@@ -82,6 +85,19 @@ pub struct CanisterHttpBatchStats {
     pub payload_bytes: usize,
 }
 
+/// The canister http committee for a fully-replicated request, together with
+/// the BFT parameters derived from its size.
+struct CanisterHttpCommittee {
+    /// The subnet node set at the registry version pinned in the request
+    /// context.
+    committee: Vec<NodeId>,
+    /// The number of matching shares required to form a response
+    /// (`committee.len() - faults_tolerated`).
+    threshold: usize,
+    /// The number of faults tolerated for a committee of this size.
+    faults_tolerated: usize,
+}
+
 /// Implementation of the [`BatchPayloadBuilder`] for the canister http feature.
 pub struct CanisterHttpPayloadBuilderImpl {
     pool: Arc<RwLock<dyn CanisterHttpPool>>,
@@ -128,6 +144,26 @@ impl CanisterHttpPayloadBuilderImpl {
         self.registry
             .get_features(self.subnet_id, validation_context.registry_version)
             .map(|features| features.unwrap_or_default().http_requests)
+    }
+
+    /// Returns the canister http committee at the given registry version,
+    /// along with the [`threshold`](CanisterHttpCommittee::threshold) and
+    /// [`faults_tolerated`](CanisterHttpCommittee::faults_tolerated) derived
+    /// from its size.
+    fn get_canister_http_committee(
+        &self,
+        registry_version: RegistryVersion,
+    ) -> Result<CanisterHttpCommittee, MembershipError> {
+        let committee = self
+            .membership
+            .get_canister_http_committee(registry_version)?;
+        let faults_tolerated = get_faults_tolerated(committee.len());
+        let threshold = committee.len() - faults_tolerated;
+        Ok(CanisterHttpCommittee {
+            committee,
+            threshold,
+            faults_tolerated,
+        })
     }
 
     fn get_canister_http_payload_impl(
@@ -237,14 +273,12 @@ impl CanisterHttpPayloadBuilderImpl {
                         // Committee threshold/faults_tolerated for this request
                         // are derived from the registry version pinned in its
                         // context.
-                        let (threshold, faults_tolerated) = match self
-                            .membership
-                            .get_canister_http_committee(request.registry_version)
-                        {
-                            Ok(committee) => {
-                                let faults_tolerated = get_faults_tolerated(committee.len());
-                                (committee.len() - faults_tolerated, faults_tolerated)
-                            }
+                        let CanisterHttpCommittee {
+                            threshold,
+                            faults_tolerated,
+                            ..
+                        } = match self.get_canister_http_committee(request.registry_version) {
+                            Ok(committee) => committee,
                             Err(err) => {
                                 warn!(self.log, "Failed to get canister http committee: {:?}", err);
                                 continue;
@@ -437,8 +471,11 @@ impl CanisterHttpPayloadBuilderImpl {
                 Replication::FullyReplicated => {
                     // The committee is the subnet node set at the registry
                     // version pinned in the request context.
-                    let committee = self
-                        .membership
+                    let CanisterHttpCommittee {
+                        committee,
+                        threshold,
+                        ..
+                    } = self
                         .get_canister_http_committee(request_context.registry_version)
                         .map_err(|err| {
                             warn!(self.log, "Failed to get membership: {:?}", err);
@@ -446,7 +483,6 @@ impl CanisterHttpPayloadBuilderImpl {
                                 CanisterHttpPayloadValidationFailure::Membership,
                             )
                         })?;
-                    let threshold = committee.len() - get_faults_tolerated(committee.len());
                     (committee, threshold)
                 }
                 Replication::Flexible { .. } => {
@@ -532,15 +568,17 @@ impl CanisterHttpPayloadBuilderImpl {
 
                 // The committee is the subnet node set at the registry version
                 // pinned in the request context.
-                let committee = self
-                    .membership
+                let CanisterHttpCommittee {
+                    committee,
+                    faults_tolerated,
+                    ..
+                } = self
                     .get_canister_http_committee(context.registry_version)
                     .map_err(|_| {
                         CanisterHttpPayloadValidationError::ValidationFailed(
                             CanisterHttpPayloadValidationFailure::Membership,
                         )
                     })?;
-                let faults_tolerated = get_faults_tolerated(committee.len());
 
                 let (valid_signers, invalid_signers): (Vec<NodeId>, Vec<NodeId>) = response
                     .shares

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -16,7 +16,7 @@ use crate::{
 use candid::{Decode, Encode};
 use ic_consensus_utils::{
     crypto::ConsensusCrypto,
-    membership::{Membership, MembershipError},
+    membership::{CanisterHttpCommittee, Membership},
 };
 use ic_error_types::RejectCode;
 use ic_interfaces::{
@@ -52,7 +52,6 @@ use ic_types::{
         CanisterHttpResponseContent, CanisterHttpResponseDivergence, CanisterHttpResponseShare,
         Replication,
     },
-    consensus::get_faults_tolerated,
     messages::{CallbackId, Payload, RejectContext},
     registry::RegistryClientError,
     signature::BasicSigBatchEntry,
@@ -83,19 +82,6 @@ pub struct CanisterHttpBatchStats {
     pub flexible_errors: usize,
     pub flexible_errors_candid_failures: usize,
     pub payload_bytes: usize,
-}
-
-/// The canister http committee for a fully-replicated request, together with
-/// the BFT parameters derived from its size.
-struct CanisterHttpCommittee {
-    /// The subnet node set at the registry version pinned in the request
-    /// context.
-    committee: Vec<NodeId>,
-    /// The number of matching shares required to form a response
-    /// (`committee.len() - faults_tolerated`).
-    threshold: usize,
-    /// The number of faults tolerated for a committee of this size.
-    faults_tolerated: usize,
 }
 
 /// Implementation of the [`BatchPayloadBuilder`] for the canister http feature.
@@ -144,26 +130,6 @@ impl CanisterHttpPayloadBuilderImpl {
         self.registry
             .get_features(self.subnet_id, validation_context.registry_version)
             .map(|features| features.unwrap_or_default().http_requests)
-    }
-
-    /// Returns the canister http committee at the given registry version,
-    /// along with the [`threshold`](CanisterHttpCommittee::threshold) and
-    /// [`faults_tolerated`](CanisterHttpCommittee::faults_tolerated) derived
-    /// from its size.
-    fn get_canister_http_committee(
-        &self,
-        registry_version: RegistryVersion,
-    ) -> Result<CanisterHttpCommittee, MembershipError> {
-        let committee = self
-            .membership
-            .get_canister_http_committee(registry_version)?;
-        let faults_tolerated = get_faults_tolerated(committee.len());
-        let threshold = committee.len() - faults_tolerated;
-        Ok(CanisterHttpCommittee {
-            committee,
-            threshold,
-            faults_tolerated,
-        })
     }
 
     fn get_canister_http_payload_impl(
@@ -277,7 +243,10 @@ impl CanisterHttpPayloadBuilderImpl {
                             threshold,
                             faults_tolerated,
                             ..
-                        } = match self.get_canister_http_committee(request.registry_version) {
+                        } = match self
+                            .membership
+                            .get_canister_http_committee(request.registry_version)
+                        {
                             Ok(committee) => committee,
                             Err(err) => {
                                 warn!(self.log, "Failed to get canister http committee: {:?}", err);
@@ -476,6 +445,7 @@ impl CanisterHttpPayloadBuilderImpl {
                         threshold,
                         ..
                     } = self
+                        .membership
                         .get_canister_http_committee(request_context.registry_version)
                         .map_err(|err| {
                             warn!(self.log, "Failed to get membership: {:?}", err);
@@ -573,6 +543,7 @@ impl CanisterHttpPayloadBuilderImpl {
                     faults_tolerated,
                     ..
                 } = self
+                    .membership
                     .get_canister_http_committee(context.registry_version)
                     .map_err(|_| {
                         CanisterHttpPayloadValidationError::ValidationFailed(

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -363,7 +363,6 @@ impl CanisterHttpPayloadBuilderImpl {
 
     pub fn validate_canister_http_payload_impl(
         &self,
-        _height: Height,
         payload: &CanisterHttpPayload,
         validation_context: &ValidationContext,
         mut delivered_ids: HashSet<CallbackId>,
@@ -888,7 +887,7 @@ impl BatchPayloadBuilder for CanisterHttpPayloadBuilderImpl {
 
     fn validate_payload(
         &self,
-        height: Height,
+        _height: Height,
         proposal_context: &ProposalContext,
         payload: &[u8],
         past_payloads: &[PastPayload],
@@ -924,7 +923,6 @@ impl BatchPayloadBuilder for CanisterHttpPayloadBuilderImpl {
             )
         })?;
         self.validate_canister_http_payload_impl(
-            height,
             &payload,
             proposal_context.validation_context,
             delivered_ids,

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -14,9 +14,7 @@ use crate::{
     },
 };
 use candid::{Decode, Encode};
-use ic_consensus_utils::{
-    crypto::ConsensusCrypto, membership::Membership, registry_version_at_height,
-};
+use ic_consensus_utils::{crypto::ConsensusCrypto, membership::Membership};
 use ic_error_types::RejectCode;
 use ic_interfaces::{
     batch_payload::{BatchPayloadBuilder, IntoMessages, PastPayload, ProposalContext},
@@ -85,7 +83,6 @@ pub struct CanisterHttpBatchStats {
 /// Implementation of the [`BatchPayloadBuilder`] for the canister http feature.
 pub struct CanisterHttpPayloadBuilderImpl {
     pool: Arc<RwLock<dyn CanisterHttpPool>>,
-    cache: Arc<dyn ConsensusPoolCache>,
     crypto: Arc<dyn ConsensusCrypto>,
     state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
     membership: Arc<Membership>,
@@ -111,7 +108,6 @@ impl CanisterHttpPayloadBuilderImpl {
 
         Self {
             pool,
-            cache,
             crypto,
             state_reader,
             membership,
@@ -366,7 +362,7 @@ impl CanisterHttpPayloadBuilderImpl {
 
     pub fn validate_canister_http_payload_impl(
         &self,
-        height: Height,
+        _height: Height,
         payload: &CanisterHttpPayload,
         validation_context: &ValidationContext,
         mut delivered_ids: HashSet<CallbackId>,
@@ -431,19 +427,15 @@ impl CanisterHttpPayloadBuilderImpl {
             }
         }
 
-        // Registry version used only to resolve signer public keys for the
-        // batched signature verification at the end. Committee membership and
-        // validity are derived per request from the registry version pinned in
-        // the request context (the source of truth for the request).
-        let consensus_registry_version = registry_version_at_height(self.cache.as_ref(), height)
-            .ok_or(CanisterHttpPayloadValidationError::ValidationFailed(
-                CanisterHttpPayloadValidationFailure::ConsensusRegistryVersionUnavailable,
-            ))?;
-
-        // Shares reconstructed from aggregated response proofs.
-        let mut reconstructed_shares: Vec<CanisterHttpResponseShare> = Vec::new();
+        // Shares reconstructed from aggregated response proofs, each paired with
+        // the registry version pinned in its request context (at which the
+        // signer's public key is resolved during batched verification).
+        let mut reconstructed_shares: Vec<(CanisterHttpResponseShare, RegistryVersion)> =
+            Vec::new();
         // Accumulates all signatures in the payload, so that they can be checked
         // in a single batched multi-message verification call at the very end.
+        // Each input carries the registry version pinned in its request context,
+        // at which that signer's public key is resolved.
         let mut sig_inputs: Vec<ResponseShareSigInput> = Vec::new();
 
         // Check conditions on individual responses
@@ -521,12 +513,27 @@ impl CanisterHttpPayloadBuilderImpl {
                 )
                 .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
             }
-            // Reconstruct the per-signer shares from the response proof.
-            reconstructed_shares.extend(utils::reconstruct_individual_shares(&response.proof));
+            // Reconstruct the per-signer shares from the response proof, tagging
+            // each with the registry version pinned in this request's context.
+            reconstructed_shares.extend(
+                utils::reconstruct_individual_shares(&response.proof)
+                    .map(|share| (share, request_context.registry_version)),
+            );
         }
 
         // Defer signature verification of the reconstructed response shares.
-        sig_inputs.extend(response_share_sig_inputs(&reconstructed_shares));
+        sig_inputs.extend(
+            reconstructed_shares
+                .iter()
+                .map(|(share, registry_version)| {
+                    (
+                        share.signature.signer,
+                        &share.signature.signature,
+                        &share.content,
+                        *registry_version,
+                    )
+                }),
+        );
 
         for response in &payload.divergence_responses {
             // A divergence proof must contain shares for exactly one callback id.
@@ -580,7 +587,10 @@ impl CanisterHttpPayloadBuilderImpl {
                 }
 
                 // Defer signature verification.
-                sig_inputs.extend(response_share_sig_inputs(&response.shares));
+                sig_inputs.extend(response_share_sig_inputs(
+                    &response.shares,
+                    context.registry_version,
+                ));
 
                 // Enforce per-replica refund allowance for divergence shares.
                 for share in grouped_shares.values().flatten() {
@@ -664,6 +674,7 @@ impl CanisterHttpPayloadBuilderImpl {
             // Defer signature verification.
             sig_inputs.extend(response_share_sig_inputs(
                 group.responses.iter().map(|r| &r.proof),
+                context.registry_version,
             ));
         }
 
@@ -741,6 +752,7 @@ impl CanisterHttpPayloadBuilderImpl {
                     // Defer signature verification.
                     sig_inputs.extend(response_share_sig_inputs(
                         reject_responses.iter().map(|r| &r.proof),
+                        context.registry_version,
                     ));
                 }
                 FlexibleCanisterHttpError::ResponsesTooLarge {
@@ -784,7 +796,10 @@ impl CanisterHttpPayloadBuilderImpl {
                     }
 
                     // Defer signature verification.
-                    sig_inputs.extend(response_share_sig_inputs(all_seen_shares));
+                    sig_inputs.extend(response_share_sig_inputs(
+                        all_seen_shares,
+                        context.registry_version,
+                    ));
 
                     let num_unseen = flex_committee.len().saturating_sub(all_seen_shares.len());
                     let min_known_ok_needed = min_responses.saturating_sub(num_unseen);
@@ -826,7 +841,7 @@ impl CanisterHttpPayloadBuilderImpl {
         // Batch-verify the signatures of the deferred shares.
         if !sig_inputs.is_empty() {
             self.crypto
-                .verify_basic_sig_batch_multi_msg(&sig_inputs, consensus_registry_version)
+                .verify_basic_sig_batch_multi_msg(&sig_inputs)
                 .map_err(|err| {
                     CanisterHttpPayloadValidationError::InvalidArtifact(
                         InvalidCanisterHttpPayloadReason::SignatureError(Box::new(err)),

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -40,7 +40,7 @@ use ic_metrics::MetricsRegistry;
 use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
-    CountBytes, Height, NodeId, NumBytes, SubnetId,
+    CountBytes, Height, NodeId, NumBytes, RegistryVersion, SubnetId,
     batch::{
         CanisterHttpPayload, ConsensusResponse, FlexibleCanisterHttpError,
         FlexibleCanisterHttpResponseWithProof, FlexibleCanisterHttpResponses,
@@ -51,7 +51,6 @@ use ic_types::{
         CanisterHttpResponseContent, CanisterHttpResponseDivergence, CanisterHttpResponseShare,
         Replication,
     },
-    consensus::Committee,
     messages::{CallbackId, Payload, RejectContext},
     registry::RegistryClientError,
 };
@@ -135,35 +134,15 @@ impl CanisterHttpPayloadBuilderImpl {
 
     fn get_canister_http_payload_impl(
         &self,
-        height: Height,
         validation_context: &ValidationContext,
         delivered_ids: HashSet<CallbackId>,
         max_payload_size: NumBytes,
     ) -> CanisterHttpPayload {
-        // Derive threshold and faults_tolerated from a single committee call
-        let committee_members = match self.membership.get_canister_http_committee(height) {
-            Ok(members) => members,
-            Err(err) => {
-                warn!(self.log, "Failed to get canister http committee: {:?}", err);
-                return CanisterHttpPayload::default();
-            }
-        };
-        let faults_tolerated = ic_types::consensus::get_faults_tolerated(committee_members.len());
-        let threshold = committee_members.len() - faults_tolerated;
-
-        let consensus_registry_version = match registry_version_at_height(
-            self.cache.as_ref(),
-            height,
-        ) {
-            Some(registry_version) => registry_version,
-            None => {
-                warn!(
-                    self.log,
-                    "Failed to obtain consensus registry version in canister http payload builder"
-                );
-                return CanisterHttpPayload::default();
-            }
-        };
+        // Committee threshold and faults_tolerated are derived per request from
+        // the registry version pinned in the request context. Cache the
+        // resulting `(threshold, faults_tolerated)` by registry version to avoid
+        // repeated registry lookups within a single payload.
+        let mut thresholds_by_version: BTreeMap<RegistryVersion, (usize, usize)> = BTreeMap::new();
 
         let state = match self
             .state_reader
@@ -209,15 +188,13 @@ impl CanisterHttpPayloadBuilderImpl {
                 .inspect(|_| {
                     total_share_count += 1;
                 })
-                // Filter out shares with the wrong registry version
-                .filter(|&share| share.content.registry_version() == consensus_registry_version)
-                .inspect(|_| {
-                    active_shares += 1;
-                })
                 // Filter out shares for responses to requests that already have
                 // responses in the block chain up to the point we are creating a
                 // new payload.
-                .filter(|&share| !delivered_ids.contains(&share.content.id()));
+                .filter(|&share| !delivered_ids.contains(&share.content.id()))
+                .inspect(|_| {
+                    active_shares += 1;
+                });
 
             // Group the shares by their metadata
             let shares_by_callback_id = group_shares_by_callback_id(share_candidates);
@@ -265,6 +242,38 @@ impl CanisterHttpPayloadBuilderImpl {
                 };
                 match &request.replication {
                     Replication::FullyReplicated => {
+                        // Committee threshold/faults_tolerated for this request
+                        // are derived from the registry version pinned in its
+                        // context (cached across requests sharing a version).
+                        let (threshold, faults_tolerated) =
+                            match thresholds_by_version.get(&request.registry_version) {
+                                Some(values) => *values,
+                                None => {
+                                    match self.membership.get_canister_http_committee_at_version(
+                                        request.registry_version,
+                                    ) {
+                                        Ok(committee) => {
+                                            let faults_tolerated =
+                                                ic_types::consensus::get_faults_tolerated(
+                                                    committee.len(),
+                                                );
+                                            let threshold = committee.len() - faults_tolerated;
+                                            thresholds_by_version.insert(
+                                                request.registry_version,
+                                                (threshold, faults_tolerated),
+                                            );
+                                            (threshold, faults_tolerated)
+                                        }
+                                        Err(err) => {
+                                            warn!(
+                                                self.log,
+                                                "Failed to get canister http committee: {:?}", err
+                                            );
+                                            continue;
+                                        }
+                                    }
+                                }
+                            };
                         if let Some(response) =
                             find_fully_replicated_response(grouped_shares, threshold, &*pool_access)
                         {
@@ -421,20 +430,14 @@ impl CanisterHttpPayloadBuilderImpl {
             }
         }
 
-        // Get the consensus registry version
+        // Registry version used only to resolve signer public keys for the
+        // batched signature verification at the end. Committee membership and
+        // validity are derived per request from the registry version pinned in
+        // the request context (the source of truth for the request).
         let consensus_registry_version = registry_version_at_height(self.cache.as_ref(), height)
             .ok_or(CanisterHttpPayloadValidationError::ValidationFailed(
                 CanisterHttpPayloadValidationFailure::ConsensusRegistryVersionUnavailable,
             ))?;
-
-        let committee = self
-            .membership
-            .get_canister_http_committee(height)
-            .map_err(|_| {
-                CanisterHttpPayloadValidationError::ValidationFailed(
-                    CanisterHttpPayloadValidationFailure::Membership,
-                )
-            })?;
 
         // Shares reconstructed from aggregated response proofs.
         let mut reconstructed_shares: Vec<CanisterHttpResponseShare> = Vec::new();
@@ -447,16 +450,6 @@ impl CanisterHttpPayloadBuilderImpl {
             // Check that response is consistent
             utils::check_response_consistency(response)
                 .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
-
-            // Validate response against consensus registry version
-            if response.proof.registry_version() != consensus_registry_version {
-                return invalid_artifact(
-                    InvalidCanisterHttpPayloadReason::RegistryVersionMismatch {
-                        expected: consensus_registry_version,
-                        received: response.proof.registry_version(),
-                    },
-                );
-            }
 
             // Check that the response is not submitted twice
             if !delivered_ids.insert(response.content.id) {
@@ -475,19 +468,20 @@ impl CanisterHttpPayloadBuilderImpl {
             let (effective_committee, effective_threshold) = match request_context.replication {
                 Replication::NonReplicated(node_id) => (vec![node_id], 1),
                 Replication::FullyReplicated => {
-                    let threshold = match self
+                    // The committee is the subnet node set at the registry
+                    // version pinned in the request context.
+                    let committee = self
                         .membership
-                        .get_committee_threshold(height, Committee::CanisterHttp)
-                    {
-                        Ok(threshold) => threshold,
-                        Err(err) => {
+                        .get_canister_http_committee_at_version(request_context.registry_version)
+                        .map_err(|err| {
                             warn!(self.log, "Failed to get membership: {:?}", err);
-                            return validation_failed(
+                            CanisterHttpPayloadValidationError::ValidationFailed(
                                 CanisterHttpPayloadValidationFailure::Membership,
-                            );
-                        }
-                    };
-                    (committee.clone(), threshold)
+                            )
+                        })?;
+                    let threshold = committee.len()
+                        - ic_types::consensus::get_faults_tolerated(committee.len());
+                    (committee, threshold)
                 }
                 Replication::Flexible { .. } => {
                     return invalid_artifact(
@@ -533,26 +527,8 @@ impl CanisterHttpPayloadBuilderImpl {
         // Defer signature verification of the reconstructed response shares.
         sig_inputs.extend(response_share_sig_inputs(&reconstructed_shares));
 
-        let faults_tolerated = ic_types::consensus::get_faults_tolerated(committee.len());
-
         for response in &payload.divergence_responses {
-            let (valid_signers, invalid_signers): (Vec<NodeId>, Vec<NodeId>) = response
-                .shares
-                .iter()
-                .map(|share| share.signature.signer)
-                .partition(|signer| committee.iter().any(|id| id == signer));
-
-            if !invalid_signers.is_empty() {
-                return invalid_artifact(InvalidCanisterHttpPayloadReason::SignersNotMembers {
-                    invalid_signers,
-                    committee,
-                    valid_signers,
-                });
-            }
-
-            // Defer signature verification.
-            sig_inputs.extend(response_share_sig_inputs(&response.shares));
-
+            // A divergence proof must contain shares for exactly one callback id.
             let grouped_shares = group_shares_by_callback_id(response.shares.iter());
             if grouped_shares.len() != 1 {
                 return invalid_artifact(
@@ -575,6 +551,35 @@ impl CanisterHttpPayloadBuilderImpl {
                         InvalidCanisterHttpPayloadReason::InvalidPayloadSection(callback_id),
                     );
                 }
+
+                // The committee is the subnet node set at the registry version
+                // pinned in the request context.
+                let committee = self
+                    .membership
+                    .get_canister_http_committee_at_version(context.registry_version)
+                    .map_err(|_| {
+                        CanisterHttpPayloadValidationError::ValidationFailed(
+                            CanisterHttpPayloadValidationFailure::Membership,
+                        )
+                    })?;
+                let faults_tolerated = ic_types::consensus::get_faults_tolerated(committee.len());
+
+                let (valid_signers, invalid_signers): (Vec<NodeId>, Vec<NodeId>) = response
+                    .shares
+                    .iter()
+                    .map(|share| share.signature.signer)
+                    .partition(|signer| committee.iter().any(|id| id == signer));
+
+                if !invalid_signers.is_empty() {
+                    return invalid_artifact(InvalidCanisterHttpPayloadReason::SignersNotMembers {
+                        invalid_signers,
+                        committee,
+                        valid_signers,
+                    });
+                }
+
+                // Defer signature verification.
+                sig_inputs.extend(response_share_sig_inputs(&response.shares));
 
                 // Enforce per-replica refund allowance for divergence shares.
                 for share in grouped_shares.values().flatten() {
@@ -642,7 +647,6 @@ impl CanisterHttpPayloadBuilderImpl {
                     callback_id,
                     flex_committee,
                     &mut seen_signers,
-                    consensus_registry_version,
                     context.refund_status.per_replica_allowance,
                 )
                 .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
@@ -709,7 +713,6 @@ impl CanisterHttpPayloadBuilderImpl {
                             callback_id,
                             flex_committee,
                             &mut seen_signers,
-                            consensus_registry_version,
                             context.refund_status.per_replica_allowance,
                         )
                         .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
@@ -774,7 +777,6 @@ impl CanisterHttpPayloadBuilderImpl {
                             callback_id,
                             flex_committee,
                             &mut seen_signers,
-                            consensus_registry_version,
                             context.refund_status.per_replica_allowance,
                         )
                         .map_err(CanisterHttpPayloadValidationError::InvalidArtifact)?;
@@ -838,7 +840,7 @@ impl CanisterHttpPayloadBuilderImpl {
 impl BatchPayloadBuilder for CanisterHttpPayloadBuilderImpl {
     fn build_payload(
         &self,
-        height: Height,
+        _height: Height,
         max_size: NumBytes,
         past_payloads: &[PastPayload],
         context: &ValidationContext,
@@ -865,7 +867,7 @@ impl BatchPayloadBuilder for CanisterHttpPayloadBuilderImpl {
             NumBytes::new(MAX_CANISTER_HTTP_PAYLOAD_SIZE as u64),
         );
         let delivered_ids = parse::parse_past_payload_ids(past_payloads, &self.log);
-        let payload = self.get_canister_http_payload_impl(height, context, delivered_ids, max_size);
+        let payload = self.get_canister_http_payload_impl(context, delivered_ids, max_size);
         parse::payload_to_bytes(payload, max_size)
     }
 

--- a/rs/https_outcalls/consensus/src/payload_builder.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder.rs
@@ -51,6 +51,7 @@ use ic_types::{
     },
     messages::{CallbackId, Payload, RejectContext},
     registry::RegistryClientError,
+    signature::BasicSigBatchEntry,
 };
 use std::{
     collections::{BTreeMap, HashSet},
@@ -525,13 +526,11 @@ impl CanisterHttpPayloadBuilderImpl {
         sig_inputs.extend(
             reconstructed_shares
                 .iter()
-                .map(|(share, registry_version)| {
-                    (
-                        share.signature.signer,
-                        &share.signature.signature,
-                        &share.content,
-                        *registry_version,
-                    )
+                .map(|(share, registry_version)| BasicSigBatchEntry {
+                    signer: share.signature.signer,
+                    signature: &share.signature.signature,
+                    message: &share.content,
+                    registry_version: *registry_version,
                 }),
         );
 

--- a/rs/https_outcalls/consensus/src/payload_builder/proptests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/proptests.rs
@@ -370,7 +370,6 @@ fn make_metadata(response: &CanisterHttpResponse) -> CanisterHttpResponseMetadat
         content_hash: crypto_hash(response),
         content_size: response.content.count_bytes() as u32,
         is_reject: response.content.is_reject(),
-        registry_version: RegistryVersion::new(1),
         replica_version: ReplicaVersion::default(),
     }
 }
@@ -517,7 +516,6 @@ fn prop_random_metadata() -> impl Strategy<Value = CanisterHttpResponseMetadata>
             content_hash: CryptoHashOf::new(CryptoHash(hash.to_vec())),
             content_size,
             is_reject,
-            registry_version: RegistryVersion::new(1),
             replica_version: ReplicaVersion::default(),
         }
     })

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -168,16 +168,6 @@ fn multiple_payload_test() {
                         );
                     }
 
-                    // Add a response with mismatching registry version
-                    let (response, mut metadata) = test_response_and_metadata(2);
-                    metadata.registry_version = RegistryVersion::new(5);
-                    let shares = metadata_to_shares(subnet_size, &metadata);
-                    add_own_share_to_pool(pool_access.deref_mut(), &shares[0], &response);
-                    add_received_shares_to_pool(
-                        pool_access.deref_mut(),
-                        shares[1..subnet_size].to_vec(),
-                    );
-
                     // Add a oversized response
                     let (mut response, metadata) = test_response_and_metadata(3);
                     response.content =
@@ -490,29 +480,6 @@ fn oversized_validation() {
             ),
         )) if expected == 2 * 1024 * 1024 && received > expected => (),
         x => panic!("Expected PayloadTooBig, got {x:?}"),
-    }
-}
-
-/// Test that payloads with wrong registry version don't validate
-#[test]
-fn registry_version_validation() {
-    let validation_result = run_non_flexible_validation_test(
-        true,
-        |_, metadata| {
-            // Set metadata to a newer registry version
-            metadata.registry_version = RegistryVersion::new(2);
-        },
-        &ValidationContext {
-            ..default_validation_context()
-        },
-    );
-    match validation_result {
-        Err(ValidationError::InvalidArtifact(
-            InvalidPayloadReason::InvalidCanisterHttpPayload(
-                InvalidCanisterHttpPayloadReason::RegistryVersionMismatch { .. },
-            ),
-        )) => (),
-        x => panic!("Expected RegistryVersionMismatch, got {x:?}"),
     }
 }
 
@@ -1542,7 +1509,6 @@ fn test_response_and_metadata_with_content(
         content_hash: crypto_hash(&response),
         content_size: response.content.count_bytes() as u32,
         is_reject: response.content.is_reject(),
-        registry_version: RegistryVersion::new(1),
         replica_version: ReplicaVersion::default(),
     };
     (response, metadata)
@@ -2799,43 +2765,6 @@ fn flexible_invalid_callback_id_mismatch_in_response() {
                     InvalidCanisterHttpPayloadReason::FlexibleCallbackIdMismatch { callback_id: cb_id, mismatched_id: mm_id }
                 )
             )) if cb_id == callback_id && mm_id == mismatched_id
-        );
-    });
-}
-
-#[test]
-fn flexible_invalid_registry_version_mismatch() {
-    let committee: BTreeSet<_> = (0..4).map(node_test_id).collect();
-    let callback_id = CallbackId::from(42);
-
-    setup_test_with_flexible_context(4, callback_id, committee, 1, 4, |payload_builder, _pool| {
-        let wrong_registry_version = RegistryVersion::new(999);
-        let mut entry = flexible_response(42, 0, b"data");
-        entry.proof.content.metadata.registry_version = wrong_registry_version;
-        let validation_context = default_validation_context();
-        let expected_registry_version = validation_context.registry_version;
-
-        let payload = flexible_payload(vec![FlexibleCanisterHttpResponses {
-            callback_id,
-            responses: vec![entry],
-        }]);
-
-        let result = payload_builder.validate_payload(
-            Height::from(1),
-            &test_proposal_context(&validation_context),
-            &payload_to_bytes_max_4mb(payload),
-            &[],
-        );
-        assert_matches!(
-            result,
-            Err(ValidationError::InvalidArtifact(
-                InvalidPayloadReason::InvalidCanisterHttpPayload(
-                    InvalidCanisterHttpPayloadReason::RegistryVersionMismatch {
-                        expected,
-                        received,
-                    }
-                )
-            )) if expected == expected_registry_version && received == wrong_registry_version
         );
     });
 }
@@ -4202,45 +4131,6 @@ fn flexible_error_responses_too_large_signer_not_in_committee() {
 }
 
 #[test]
-fn flexible_error_responses_too_large_registry_version_mismatch() {
-    let num_nodes = 4;
-    let committee: BTreeSet<_> = (0..num_nodes as u64).map(node_test_id).collect();
-    let callback_id = CallbackId::from(42);
-
-    let huge = (MAX_CANISTER_HTTP_PAYLOAD_SIZE as u32 / 2) + 100_000;
-    setup_test_with_flexible_context(num_nodes, callback_id, committee, 2, 4, |pb, _pool| {
-        let share_ok = metadata_share_with_content_size(callback_id.get(), 0, huge);
-        // Share with wrong registry version
-        let mut share_bad = metadata_share_with_content_size(callback_id.get(), 1, huge);
-        share_bad.content.metadata.registry_version = RegistryVersion::new(999);
-
-        let payload = CanisterHttpPayload {
-            flexible_errors: vec![FlexibleCanisterHttpError::ResponsesTooLarge {
-                callback_id,
-                all_seen_shares: vec![share_ok, share_bad],
-                total_requests: 4,
-                min_responses: 2,
-            }],
-            ..Default::default()
-        };
-        let result = pb.validate_payload(
-            Height::new(1),
-            &test_proposal_context(&default_validation_context()),
-            &payload_to_bytes_max_4mb(payload),
-            &[],
-        );
-        assert_matches!(
-            result,
-            Err(ValidationError::InvalidArtifact(
-                InvalidPayloadReason::InvalidCanisterHttpPayload(
-                    InvalidCanisterHttpPayloadReason::RegistryVersionMismatch { expected: e, received: r }
-                )
-            )) if e == RegistryVersion::new(1) && r == RegistryVersion::new(999)
-        );
-    });
-}
-
-#[test]
 fn flexible_error_responses_too_large_invalid_signature() {
     let committee: BTreeSet<_> = (0..4).map(node_test_id).collect();
     let callback_id = CallbackId::from(42);
@@ -4484,41 +4374,6 @@ fn flexible_error_too_many_rejects_callback_id_mismatch_in_response() {
                     InvalidCanisterHttpPayloadReason::FlexibleCallbackIdMismatch { callback_id: cb_id, mismatched_id: mm_id }
                 )
             )) if cb_id == callback_id && mm_id == CallbackId::new(999)
-        );
-    });
-}
-
-#[test]
-fn flexible_error_too_many_rejects_registry_version_mismatch() {
-    let num_nodes = 4;
-    let committee: BTreeSet<_> = (0..num_nodes as u64).map(node_test_id).collect();
-    let callback_id = CallbackId::from(42);
-
-    setup_test_with_flexible_context(num_nodes, callback_id, committee, 3, 4, |pb, _pool| {
-        let entry_ok = flexible_reject_response(callback_id.get(), 0);
-        let mut entry_bad = flexible_reject_response(callback_id.get(), 1);
-        entry_bad.proof.content.metadata.registry_version = RegistryVersion::new(999);
-
-        let payload = CanisterHttpPayload {
-            flexible_errors: vec![FlexibleCanisterHttpError::TooManyRejects {
-                callback_id,
-                reject_responses: vec![entry_ok, entry_bad],
-            }],
-            ..Default::default()
-        };
-        let result = pb.validate_payload(
-            Height::new(1),
-            &test_proposal_context(&default_validation_context()),
-            &payload_to_bytes_max_4mb(payload),
-            &[],
-        );
-        assert_matches!(
-            result,
-            Err(ValidationError::InvalidArtifact(
-                InvalidPayloadReason::InvalidCanisterHttpPayload(
-                    InvalidCanisterHttpPayloadReason::RegistryVersionMismatch { expected: e, received: r }
-                )
-            )) if e == RegistryVersion::new(1) && r == RegistryVersion::new(999)
         );
     });
 }
@@ -4865,7 +4720,6 @@ fn metadata_share_with_content_size(
         content_hash: CryptoHashOf::new(CryptoHash(vec![0xAB; 32])),
         content_size,
         is_reject: false,
-        registry_version: RegistryVersion::new(1),
         replica_version: ReplicaVersion::default(),
     };
     metadata_to_share(signer_node, &metadata)
@@ -4877,7 +4731,6 @@ fn reject_metadata_share(callback_id: u64, signer_node: u64) -> CanisterHttpResp
         content_hash: CryptoHashOf::new(CryptoHash(vec![0xCD; 32])),
         content_size: 50,
         is_reject: true,
-        registry_version: RegistryVersion::new(1),
         replica_version: ReplicaVersion::default(),
     };
     metadata_to_share(signer_node, &metadata)

--- a/rs/https_outcalls/consensus/src/payload_builder/tests.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/tests.rs
@@ -4797,7 +4797,7 @@ fn mock_crypto_rejecting_signatures() -> MockCrypto {
         });
     mock_crypto
         .expect_verify_basic_sig_batch_multi_msg_http()
-        .returning(|_, _| {
+        .returning(|_| {
             Err(ic_types::crypto::CryptoError::SignatureVerification {
                 algorithm: ic_types::crypto::AlgorithmId::Ed25519,
                 public_key_bytes: vec![],

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -241,15 +241,12 @@ pub(crate) fn validate_response_share(
 }
 
 /// A single signature input as consumed by
-/// [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`]. The registry version
-/// is the one pinned in the signer's request context, at which the signer's
-/// public key is resolved.
+/// [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`].
 pub(crate) type ResponseShareSigInput<'a> = BasicSigBatchEntry<'a, CanisterHttpResponseReceipt>;
 
 /// Maps response shares to the signature inputs consumed by
 /// [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`]. All shares produced
-/// here belong to the same request, so they share the `registry_version` pinned
-/// in that request's context.
+/// here belong to the same request, so they share the `registry_version`.
 pub(crate) fn response_share_sig_inputs<'a, I>(
     shares: I,
     registry_version: RegistryVersion,

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -241,9 +241,7 @@ pub(crate) fn validate_response_share(
 }
 
 /// A single `(signer, signature, message, registry_version)` input as consumed
-/// by [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`]. The registry
-/// version is the one pinned in the signer's request context, at which the
-/// signer's public key is resolved.
+/// by [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`].
 pub(crate) type ResponseShareSigInput<'a> = (
     NodeId,
     &'a BasicSigOf<CanisterHttpResponseReceipt>,

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -1,7 +1,7 @@
 use CanisterHttpResponseContent::Reject;
 use ic_interfaces::canister_http::{CanisterHttpPool, InvalidCanisterHttpPayloadReason};
 use ic_types::{
-    CountBytes, NodeId, NumBytes,
+    CountBytes, NodeId, NumBytes, RegistryVersion,
     batch::{
         FlexibleCanisterHttpError, FlexibleCanisterHttpResponseWithProof,
         FlexibleCanisterHttpResponses, MAX_CANISTER_HTTP_PAYLOAD_SIZE,
@@ -240,27 +240,34 @@ pub(crate) fn validate_response_share(
     Ok(())
 }
 
-/// A single `(signer, signature, message)` input as consumed by
-/// [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`].
+/// A single `(signer, signature, message, registry_version)` input as consumed
+/// by [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`]. The registry
+/// version is the one pinned in the signer's request context, at which the
+/// signer's public key is resolved.
 pub(crate) type ResponseShareSigInput<'a> = (
     NodeId,
     &'a BasicSigOf<CanisterHttpResponseReceipt>,
     &'a CanisterHttpResponseReceipt,
+    RegistryVersion,
 );
 
-/// Maps response shares to the `(signer, signature, message)` inputs consumed by
-/// [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`].
+/// Maps response shares to the `(signer, signature, message, registry_version)`
+/// inputs consumed by [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`].
+/// All shares produced here belong to the same request, so they share the
+/// `registry_version` pinned in that request's context.
 pub(crate) fn response_share_sig_inputs<'a, I>(
     shares: I,
+    registry_version: RegistryVersion,
 ) -> impl Iterator<Item = ResponseShareSigInput<'a>>
 where
     I: IntoIterator<Item = &'a CanisterHttpResponseShare>,
 {
-    shares.into_iter().map(|share| {
+    shares.into_iter().map(move |share| {
         (
             share.signature.signer,
             &share.signature.signature,
             &share.content,
+            registry_version,
         )
     })
 }

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -1,7 +1,7 @@
 use CanisterHttpResponseContent::Reject;
 use ic_interfaces::canister_http::{CanisterHttpPool, InvalidCanisterHttpPayloadReason};
 use ic_types::{
-    CountBytes, NodeId, NumBytes, RegistryVersion,
+    CountBytes, NodeId, NumBytes,
     batch::{
         FlexibleCanisterHttpError, FlexibleCanisterHttpResponseWithProof,
         FlexibleCanisterHttpResponses, MAX_CANISTER_HTTP_PAYLOAD_SIZE,
@@ -149,7 +149,6 @@ pub(crate) fn validate_flexible_response_with_proof(
     callback_id: CallbackId,
     flex_committee: &BTreeSet<NodeId>,
     seen_signers: &mut HashSet<NodeId>,
-    consensus_registry_version: RegistryVersion,
     per_replica_allowance: Cycles,
 ) -> Result<(), InvalidCanisterHttpPayloadReason> {
     if response_with_proof.response.id != callback_id {
@@ -166,7 +165,6 @@ pub(crate) fn validate_flexible_response_with_proof(
         callback_id,
         flex_committee,
         seen_signers,
-        consensus_registry_version,
         per_replica_allowance,
     )?;
 
@@ -200,7 +198,7 @@ pub(crate) fn validate_flexible_response_with_proof(
 /// Validates a single [`CanisterHttpResponseShare`]'s metadata.
 ///
 /// Checks callback-id consistency, duplicate signers, committee membership,
-/// registry version, and the per-replica refund allowance.
+/// and the per-replica refund allowance.
 ///
 /// **NOTE**: The signature is not verified. Callers are expected to
 /// batch-verify the signatures of all shares in the surrounding group via
@@ -210,7 +208,6 @@ pub(crate) fn validate_response_share(
     callback_id: CallbackId,
     flex_committee: &BTreeSet<NodeId>,
     seen_signers: &mut HashSet<NodeId>,
-    consensus_registry_version: RegistryVersion,
     per_replica_allowance: Cycles,
 ) -> Result<(), InvalidCanisterHttpPayloadReason> {
     check_refund_allowance(&share.content.payment_receipt, per_replica_allowance)?;
@@ -238,13 +235,6 @@ pub(crate) fn validate_response_share(
                 signer,
             },
         );
-    }
-
-    if share.content.registry_version() != consensus_registry_version {
-        return Err(InvalidCanisterHttpPayloadReason::RegistryVersionMismatch {
-            expected: consensus_registry_version,
-            received: share.content.registry_version(),
-        });
     }
 
     Ok(())

--- a/rs/https_outcalls/consensus/src/payload_builder/utils.rs
+++ b/rs/https_outcalls/consensus/src/payload_builder/utils.rs
@@ -12,9 +12,9 @@ use ic_types::{
         CanisterHttpResponseShare, CanisterHttpResponseSignature,
         CanisterHttpResponseWithConsensus,
     },
-    crypto::{BasicSigOf, Signed, crypto_hash},
+    crypto::{Signed, crypto_hash},
     messages::CallbackId,
-    signature::BasicSignature,
+    signature::{BasicSigBatchEntry, BasicSignature},
 };
 use ic_types_cycles::Cycles;
 use std::{
@@ -240,19 +240,16 @@ pub(crate) fn validate_response_share(
     Ok(())
 }
 
-/// A single `(signer, signature, message, registry_version)` input as consumed
-/// by [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`].
-pub(crate) type ResponseShareSigInput<'a> = (
-    NodeId,
-    &'a BasicSigOf<CanisterHttpResponseReceipt>,
-    &'a CanisterHttpResponseReceipt,
-    RegistryVersion,
-);
+/// A single signature input as consumed by
+/// [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`]. The registry version
+/// is the one pinned in the signer's request context, at which the signer's
+/// public key is resolved.
+pub(crate) type ResponseShareSigInput<'a> = BasicSigBatchEntry<'a, CanisterHttpResponseReceipt>;
 
-/// Maps response shares to the `(signer, signature, message, registry_version)`
-/// inputs consumed by [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`].
-/// All shares produced here belong to the same request, so they share the
-/// `registry_version` pinned in that request's context.
+/// Maps response shares to the signature inputs consumed by
+/// [`BasicSigVerifier::verify_basic_sig_batch_multi_msg`]. All shares produced
+/// here belong to the same request, so they share the `registry_version` pinned
+/// in that request's context.
 pub(crate) fn response_share_sig_inputs<'a, I>(
     shares: I,
     registry_version: RegistryVersion,
@@ -260,13 +257,11 @@ pub(crate) fn response_share_sig_inputs<'a, I>(
 where
     I: IntoIterator<Item = &'a CanisterHttpResponseShare>,
 {
-    shares.into_iter().map(move |share| {
-        (
-            share.signature.signer,
-            &share.signature.signature,
-            &share.content,
-            registry_version,
-        )
+    shares.into_iter().map(move |share| BasicSigBatchEntry {
+        signer: share.signature.signer,
+        signature: &share.signature.signature,
+        message: &share.content,
+        registry_version,
     })
 }
 

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -252,18 +252,7 @@ impl CanisterHttpPoolManagerImpl {
     /// subnet nodes at `context.registry_version`. For
     /// [`Replication::NonReplicated`]/[`Replication::Flexible`] the authorized
     /// signers are pinned in the context, so [`Replication::is_authorized_signer`]
-    /// suffices. Note that `is_authorized_signer` returns `true` unconditionally
-    /// for `FullyReplicated`, which is precisely why that case needs the explicit
-    /// committee lookup.
-    ///
-    /// This is only a local fast-path gate for producing and signing our own
-    /// shares. For `NonReplicated`/`Flexible` it intentionally does not re-check
-    /// that the pinned signers are subnet members at `context.registry_version`:
-    /// those signers are selected from the subnet node set at that version when
-    /// the request is created, so the check would be redundant here. The
-    /// authoritative committee gate for shares received from peers lives in
-    /// `validate_shares` (and ultimately in the payload builder), which verifies
-    /// every signer's membership at `context.registry_version`.
+    /// suffices.
     ///
     /// Fails closed: a failed or empty membership lookup is treated as "not a
     /// member". Results are cached per registry version to avoid repeated

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -270,7 +270,7 @@ impl CanisterHttpPoolManagerImpl {
                     warn!(
                         every_n_seconds => 10,
                         self.log,
-                        "Unable to check committee membership at registry version {}, {:?}",
+                        "Unable to check HTTP committee membership at registry version {}, {:?}",
                         context.registry_version,
                         e
                     );

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -4,7 +4,9 @@
 //! and eventually make it into consensus.
 use crate::metrics::CanisterHttpPoolManagerMetrics;
 use ic_consensus_utils::{
-    crypto::ConsensusCrypto, is_current_protocol_version, membership::Membership,
+    crypto::ConsensusCrypto,
+    is_current_protocol_version,
+    membership::{Membership, MembershipError},
 };
 use ic_interfaces::{
     canister_http::*, consensus_pool::ConsensusPoolCache, p2p::consensus::PoolMutationsProducer,
@@ -20,13 +22,13 @@ use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
-    CountBytes, NumBytes, RegistryVersion, ReplicaVersion, canister_http::*, crypto::Signed,
+    CountBytes, NodeId, NumBytes, ReplicaVersion, canister_http::*, crypto::Signed,
     messages::CallbackId, replica_config::ReplicaConfig,
 };
 use ic_utils::str::StrEllipsize;
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeSet, HashSet},
     convert::TryInto,
     sync::{Arc, Mutex},
 };
@@ -244,9 +246,9 @@ impl CanisterHttpPoolManagerImpl {
             .collect::<Vec<String>>()
     }
 
-    /// Returns whether the local node belongs to the committee responsible for
-    /// the given request, evaluated at the registry version pinned in the
-    /// request context (the source of truth for the request).
+    /// Returns whether `node_id` belongs to the committee responsible for the
+    /// given request, evaluated at the registry version pinned in the request
+    /// context.
     ///
     /// For [`Replication::FullyReplicated`] the committee is the full set of
     /// subnet nodes at `context.registry_version`. For
@@ -254,27 +256,18 @@ impl CanisterHttpPoolManagerImpl {
     /// signers are pinned in the context, so [`Replication::is_authorized_signer`]
     /// suffices.
     ///
-    /// Fails closed: a failed or empty membership lookup is treated as "not a
-    /// member". Results are cached per registry version to avoid repeated
-    /// registry lookups across requests sharing a version.
+    /// Returns `Err` only when the committee lookup fails.
     fn node_belongs_to_request_committee(
         &self,
         context: &CanisterHttpRequestContext,
-        membership_cache: &mut BTreeMap<RegistryVersion, bool>,
-    ) -> bool {
+        node_id: NodeId,
+    ) -> Result<bool, MembershipError> {
         match &context.replication {
-            Replication::FullyReplicated => *membership_cache
-                .entry(context.registry_version)
-                .or_insert_with(|| {
-                    self.membership
-                        .node_belongs_to_canister_http_committee(
-                            context.registry_version,
-                            self.replica_config.node_id,
-                        )
-                        .unwrap_or(false)
-                }),
+            Replication::FullyReplicated => self
+                .membership
+                .node_belongs_to_canister_http_committee(context.registry_version, node_id),
             replication @ (Replication::NonReplicated(_) | Replication::Flexible { .. }) => {
-                replication.is_authorized_signer(&self.replica_config.node_id)
+                Ok(replication.is_authorized_signer(&node_id))
             }
         }
     }
@@ -315,12 +308,13 @@ impl CanisterHttpPoolManagerImpl {
 
         let socks_proxy_addrs = self.get_socks_proxy_addrs();
 
-        let mut membership_cache = BTreeMap::new();
-
         for (id, context) in http_requests {
             // Only make a request if this node belongs to the request's committee
-            // at the registry version pinned in its context.
-            if !self.node_belongs_to_request_committee(context, &mut membership_cache) {
+            // at the registry version pinned in its context/
+            if !self
+                .node_belongs_to_request_committee(context, self.replica_config.node_id)
+                .unwrap_or(false)
+            {
                 continue;
             }
 
@@ -355,7 +349,6 @@ impl CanisterHttpPoolManagerImpl {
             .with_label_values(&["create_shares_from_responses"])
             .start_timer();
         let mut change_set = Vec::new();
-        let mut membership_cache = BTreeMap::new();
 
         let active_contexts = &self
             .latest_state()
@@ -379,13 +372,6 @@ impl CanisterHttpPoolManagerImpl {
                         self.requested_id_cache.borrow_mut().remove(&response.id);
                         continue;
                     };
-
-                    // Only sign a share for requests whose committee this node
-                    // belongs to, at the registry version pinned in the context.
-                    if !self.node_belongs_to_request_committee(context, &mut membership_cache) {
-                        self.requested_id_cache.borrow_mut().remove(&response.id);
-                        continue;
-                    }
 
                     // Truncate the reject message if it's too long.
                     //
@@ -529,15 +515,7 @@ impl CanisterHttpPoolManagerImpl {
                             ));
                         }
                     }
-                    replication @ Replication::NonReplicated(_)
-                    | replication @ Replication::Flexible { .. } => {
-                        if !replication.is_authorized_signer(&share.signature.signer) {
-                            return Some(CanisterHttpChangeAction::HandleInvalid(
-                                share.clone(),
-                                "Share signed by non-authorized node".to_string(),
-                            ));
-                        }
-
+                    Replication::NonReplicated(_) | Replication::Flexible { .. } => {
                         let Some(response) = &artifact.response else {
                             return Some(CanisterHttpChangeAction::HandleInvalid(
                                 share.clone(),
@@ -587,26 +565,20 @@ impl CanisterHttpPoolManagerImpl {
                 }
 
                 let node_is_in_committee = self
-                    .membership
-                    .node_belongs_to_canister_http_committee(
-                        context.registry_version,
-                        share.signature.signer,
-                    )
-                    .map_err(|e| {
+                    .node_belongs_to_request_committee(context, share.signature.signer)
+                    .inspect_err(|e| {
                         warn!(
                             self.log,
                             "Unable to check membership for share at registry version {}, {:?}",
                             context.registry_version,
                             e
                         );
-                        e
                     })
                     .ok()?;
                 if !node_is_in_committee {
                     return Some(CanisterHttpChangeAction::HandleInvalid(
                         share.clone(),
-                        "Share signed by node that is not a member of the canister http committee"
-                            .to_string(),
+                        "Share signed by node not in the request's committee".to_string(),
                     ));
                 }
                 // TODO: more precise error handling
@@ -1399,7 +1371,7 @@ pub mod test {
                 assert_matches!(
                     &change_set[0],
                     CanisterHttpChangeAction::HandleInvalid(_, reason) => {
-                        assert_eq!(reason, "Share signed by non-authorized node");
+                        assert_eq!(reason, "Share signed by node not in the request's committee");
                     }
                 );
             })
@@ -2923,7 +2895,7 @@ pub mod test {
                 assert_matches!(
                     &change_set[0],
                     CanisterHttpChangeAction::HandleInvalid(_, reason) => {
-                        assert_eq!(reason, "Share signed by non-authorized node");
+                        assert_eq!(reason, "Share signed by node not in the request's committee");
                     }
                 );
             })

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -244,7 +244,6 @@ impl CanisterHttpPoolManagerImpl {
             .collect::<Vec<String>>()
     }
 
-    /// Inform the HttpAdapterShim of any new requests that must be made.
     /// Returns whether the local node belongs to the committee responsible for
     /// the given request, evaluated at the registry version pinned in the
     /// request context (the source of truth for the request).
@@ -256,6 +255,15 @@ impl CanisterHttpPoolManagerImpl {
     /// suffices. Note that `is_authorized_signer` returns `true` unconditionally
     /// for `FullyReplicated`, which is precisely why that case needs the explicit
     /// committee lookup.
+    ///
+    /// This is only a local fast-path gate for producing and signing our own
+    /// shares. For `NonReplicated`/`Flexible` it intentionally does not re-check
+    /// that the pinned signers are subnet members at `context.registry_version`:
+    /// those signers are selected from the subnet node set at that version when
+    /// the request is created, so the check would be redundant here. The
+    /// authoritative committee gate for shares received from peers lives in
+    /// `validate_shares` (and ultimately in the payload builder), which verifies
+    /// every signer's membership at `context.registry_version`.
     ///
     /// Fails closed: a failed or empty membership lookup is treated as "not a
     /// member". Results are cached per registry version to avoid repeated
@@ -276,10 +284,13 @@ impl CanisterHttpPoolManagerImpl {
                         )
                         .unwrap_or(false)
                 }),
-            replication => replication.is_authorized_signer(&self.replica_config.node_id),
+            replication @ (Replication::NonReplicated(_) | Replication::Flexible { .. }) => {
+                replication.is_authorized_signer(&self.replica_config.node_id)
+            }
         }
     }
 
+    /// Inform the HttpAdapterShim of any new requests that must be made.
     fn make_new_requests(&self, canister_http_pool: &dyn CanisterHttpPool) {
         let _time = self
             .metrics

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -310,7 +310,6 @@ impl CanisterHttpPoolManagerImpl {
 
         for (id, context) in http_requests {
             // Only make a request if this node belongs to the request's committee
-            // at the registry version pinned in its context/
             if !self
                 .node_belongs_to_request_committee(context, self.replica_config.node_id)
                 .unwrap_or(false)
@@ -617,9 +616,7 @@ impl CanisterHttpPoolManagerImpl {
         change_set.extend(self.purge_shares_of_processed_requests(canister_http_pool));
 
         // Make any requests that need to be made and create shares from responses
-        // that are now available. Both steps are gated per request on whether this
-        // node belongs to the request's committee at the registry version pinned in
-        // its context, so there is no node-level committee gate here.
+        // that are now available.
         self.make_new_requests(canister_http_pool);
         change_set.extend(self.create_shares_from_responses());
 

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -21,13 +21,13 @@ use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
-    CountBytes, Height, NumBytes, ReplicaVersion, canister_http::*, consensus::HasHeight,
-    crypto::Signed, messages::CallbackId, replica_config::ReplicaConfig,
+    CountBytes, Height, NumBytes, RegistryVersion, ReplicaVersion, canister_http::*,
+    consensus::HasHeight, crypto::Signed, messages::CallbackId, replica_config::ReplicaConfig,
 };
 use ic_utils::str::StrEllipsize;
 use std::{
     cell::RefCell,
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     convert::TryInto,
     sync::{Arc, Mutex},
 };
@@ -248,6 +248,41 @@ impl CanisterHttpPoolManagerImpl {
     }
 
     /// Inform the HttpAdapterShim of any new requests that must be made.
+    /// Returns whether the local node belongs to the committee responsible for
+    /// the given request, evaluated at the registry version pinned in the
+    /// request context (the source of truth for the request).
+    ///
+    /// For [`Replication::FullyReplicated`] the committee is the full set of
+    /// subnet nodes at `context.registry_version`. For
+    /// [`Replication::NonReplicated`]/[`Replication::Flexible`] the authorized
+    /// signers are pinned in the context, so [`Replication::is_authorized_signer`]
+    /// suffices. Note that `is_authorized_signer` returns `true` unconditionally
+    /// for `FullyReplicated`, which is precisely why that case needs the explicit
+    /// committee lookup.
+    ///
+    /// Fails closed: a failed or empty membership lookup is treated as "not a
+    /// member". Results are cached per registry version to avoid repeated
+    /// registry lookups across requests sharing a version.
+    fn node_belongs_to_request_committee(
+        &self,
+        context: &CanisterHttpRequestContext,
+        membership_cache: &mut BTreeMap<RegistryVersion, bool>,
+    ) -> bool {
+        match &context.replication {
+            Replication::FullyReplicated => *membership_cache
+                .entry(context.registry_version)
+                .or_insert_with(|| {
+                    self.membership
+                        .node_belongs_to_canister_http_committee(
+                            context.registry_version,
+                            self.replica_config.node_id,
+                        )
+                        .unwrap_or(false)
+                }),
+            replication => replication.is_authorized_signer(&self.replica_config.node_id),
+        }
+    }
+
     fn make_new_requests(&self, canister_http_pool: &dyn CanisterHttpPool) {
         let _time = self
             .metrics
@@ -283,11 +318,12 @@ impl CanisterHttpPoolManagerImpl {
 
         let socks_proxy_addrs = self.get_socks_proxy_addrs();
 
+        let mut membership_cache = BTreeMap::new();
+
         for (id, context) in http_requests {
-            if !context
-                .replication
-                .is_authorized_signer(&self.replica_config.node_id)
-            {
+            // Only make a request if this node belongs to the request's committee
+            // at the registry version pinned in its context.
+            if !self.node_belongs_to_request_committee(context, &mut membership_cache) {
                 continue;
             }
 
@@ -333,6 +369,7 @@ impl CanisterHttpPoolManagerImpl {
             return Vec::new();
         };
         let mut change_set = Vec::new();
+        let mut membership_cache = BTreeMap::new();
 
         let active_contexts = &self
             .latest_state()
@@ -356,6 +393,13 @@ impl CanisterHttpPoolManagerImpl {
                         self.requested_id_cache.borrow_mut().remove(&response.id);
                         continue;
                     };
+
+                    // Only sign a share for requests whose committee this node
+                    // belongs to, at the registry version pinned in the context.
+                    if !self.node_belongs_to_request_committee(context, &mut membership_cache) {
+                        self.requested_id_cache.borrow_mut().remove(&response.id);
+                        continue;
+                    }
 
                     // Truncate the reject message if it's too long.
                     //
@@ -574,7 +618,7 @@ impl CanisterHttpPoolManagerImpl {
 
                 let node_is_in_committee = self
                     .membership
-                    .node_belongs_to_canister_http_committee_at_version(
+                    .node_belongs_to_canister_http_committee(
                         context.registry_version,
                         share.signature.signer,
                     )
@@ -632,17 +676,12 @@ impl CanisterHttpPoolManagerImpl {
 
         let finalized_height = self.consensus_pool_cache.finalized_block().height();
 
-        if self
-            .membership
-            .node_belongs_to_canister_http_committee(finalized_height, self.replica_config.node_id)
-            .unwrap_or(false)
-        {
-            // Make any requests that need to be made
-            self.make_new_requests(canister_http_pool);
-
-            // Create shares from any responses that are now available
-            change_set.extend(self.create_shares_from_responses(finalized_height));
-        }
+        // Make any requests that need to be made and create shares from responses
+        // that are now available. Both steps are gated per request on whether this
+        // node belongs to the request's committee at the registry version pinned in
+        // its context, so there is no node-level committee gate here.
+        self.make_new_requests(canister_http_pool);
+        change_set.extend(self.create_shares_from_responses(finalized_height));
 
         // Attempt to validate unvalidated shares
         change_set.extend(self.validate_shares(
@@ -1845,7 +1884,9 @@ pub mod test {
                 } = dependencies(pool_config.clone(), 4);
 
                 let callback_id = CallbackId::from(5);
-                let delegated_node_id = ic_test_utilities_types::ids::node_test_id(1);
+                // Delegate the request to this node so it is the authorized signer
+                // and creates a share for the injected response.
+                let delegated_node_id = replica_config.node_id;
 
                 // 2. CONTEXT: Set up a NonReplicated request context in the state manager.
                 // This ensures we test the gossiping code path.
@@ -1968,7 +2009,9 @@ pub mod test {
                 } = dependencies(pool_config.clone(), 4);
 
                 let callback_id = CallbackId::from(0); // Use ID that will pass validation filter
-                let delegated_node_id = ic_test_utilities_types::ids::node_test_id(1);
+                // Delegate the request to this node so it is the authorized signer
+                // and creates a share for the injected response.
+                let delegated_node_id = replica_config.node_id;
 
                 // 2. CONTEXT: Set up a NonReplicated request context.
                 let request_context = test_request_context(
@@ -2605,7 +2648,9 @@ pub mod test {
                     ..
                 } = dependencies(pool_config.clone(), 4);
 
-                let delegated_node_id = ic_test_utilities_types::ids::node_test_id(1);
+                // Delegate the request to this node so it is the authorized signer
+                // and creates a share for the injected response.
+                let delegated_node_id = replica_config.node_id;
                 let callback_id = CallbackId::from(5);
 
                 // 1. Set up the state to contain a non-replicated request context.

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -5,7 +5,6 @@
 use crate::metrics::CanisterHttpPoolManagerMetrics;
 use ic_consensus_utils::{
     crypto::ConsensusCrypto, is_current_protocol_version, membership::Membership,
-    registry_version_at_height,
 };
 use ic_interfaces::{
     canister_http::*, consensus_pool::ConsensusPoolCache, p2p::consensus::PoolMutationsProducer,
@@ -21,8 +20,8 @@ use ic_registry_client_helpers::subnet::SubnetRegistry;
 use ic_registry_subnet_type::SubnetType;
 use ic_replicated_state::ReplicatedState;
 use ic_types::{
-    CountBytes, Height, NumBytes, RegistryVersion, ReplicaVersion, canister_http::*,
-    consensus::HasHeight, crypto::Signed, messages::CallbackId, replica_config::ReplicaConfig,
+    CountBytes, NumBytes, RegistryVersion, ReplicaVersion, canister_http::*, crypto::Signed,
+    messages::CallbackId, replica_config::ReplicaConfig,
 };
 use ic_utils::str::StrEllipsize;
 use std::{
@@ -50,7 +49,6 @@ pub struct CanisterHttpPoolManagerImpl {
     registry_client: Arc<dyn RegistryClient>,
     state_reader: Arc<dyn StateReader<State = ReplicatedState>>,
     http_adapter_shim: Arc<Mutex<CanisterHttpAdapterClient>>,
-    consensus_pool_cache: Arc<dyn ConsensusPoolCache>,
     crypto: Arc<dyn ConsensusCrypto>,
     membership: Arc<Membership>,
     replica_config: ReplicaConfig,
@@ -131,7 +129,6 @@ impl CanisterHttpPoolManagerImpl {
             replica_config,
             subnet_type,
             membership,
-            consensus_pool_cache,
             registry_client,
             metrics: CanisterHttpPoolManagerMetrics::new(&metrics_registry),
             log,
@@ -351,23 +348,12 @@ impl CanisterHttpPoolManagerImpl {
 
     /// Create any shares that should be made from responses provided by the
     /// HttpAdapterShim.
-    fn create_shares_from_responses(&self, finalized_height: Height) -> CanisterHttpChangeSet {
+    fn create_shares_from_responses(&self) -> CanisterHttpChangeSet {
         let _time = self
             .metrics
             .op_duration
             .with_label_values(&["create_shares_from_responses"])
             .start_timer();
-        let registry_version = if let Some(registry_version) =
-            registry_version_at_height(self.consensus_pool_cache.as_ref(), finalized_height)
-        {
-            registry_version
-        } else {
-            error!(
-                self.log,
-                "Unable to obtain registry version for use for signing canister http responses",
-            );
-            return Vec::new();
-        };
         let mut change_set = Vec::new();
         let mut membership_cache = BTreeMap::new();
 
@@ -438,7 +424,7 @@ impl CanisterHttpPoolManagerImpl {
                         .sign(
                             &receipt_share,
                             self.replica_config.node_id,
-                            registry_version,
+                            context.registry_version,
                         )
                         .map_err(|err| error!(self.log, "Failed to sign http response {}", err))
                     {
@@ -483,28 +469,12 @@ impl CanisterHttpPoolManagerImpl {
     }
 
     /// Validate any shares found in the unvalidated section of the canister http pool.
-    fn validate_shares(
-        &self,
-        consensus_cache: &dyn ConsensusPoolCache,
-        canister_http_pool: &dyn CanisterHttpPool,
-        finalized_height: Height,
-    ) -> CanisterHttpChangeSet {
+    fn validate_shares(&self, canister_http_pool: &dyn CanisterHttpPool) -> CanisterHttpChangeSet {
         let _time = self
             .metrics
             .op_duration
             .with_label_values(&["validate_shares"])
             .start_timer();
-        let registry_version = if let Some(registry_version) =
-            registry_version_at_height(consensus_cache, finalized_height)
-        {
-            registry_version
-        } else {
-            error!(
-                self.log,
-                "Unable to obtain registry version for use for signing canister http responses",
-            );
-            return Vec::new();
-        };
 
         let active_contexts = &self
             .latest_state()
@@ -640,7 +610,7 @@ impl CanisterHttpPoolManagerImpl {
                     ));
                 }
                 // TODO: more precise error handling
-                if let Err(err) = self.crypto.verify(share, registry_version) {
+                if let Err(err) = self.crypto.verify(share, context.registry_version) {
                     error!(self.log, "Unable to verify signature of share, {}", err);
 
                     self.metrics.shares_marked_invalid.inc();
@@ -674,21 +644,15 @@ impl CanisterHttpPoolManagerImpl {
         // hence preserving the expected maximal number of artifacts in the pool.
         change_set.extend(self.purge_shares_of_processed_requests(canister_http_pool));
 
-        let finalized_height = self.consensus_pool_cache.finalized_block().height();
-
         // Make any requests that need to be made and create shares from responses
         // that are now available. Both steps are gated per request on whether this
         // node belongs to the request's committee at the registry version pinned in
         // its context, so there is no node-level committee gate here.
         self.make_new_requests(canister_http_pool);
-        change_set.extend(self.create_shares_from_responses(finalized_height));
+        change_set.extend(self.create_shares_from_responses());
 
         // Attempt to validate unvalidated shares
-        change_set.extend(self.validate_shares(
-            self.consensus_pool_cache.as_ref(),
-            canister_http_pool,
-            finalized_height,
-        ));
+        change_set.extend(self.validate_shares(canister_http_pool));
 
         self.metrics
             .in_client_requests
@@ -923,11 +887,7 @@ pub mod test {
                     log,
                 );
 
-                let changes = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(0),
-                );
+                let changes = pool_manager.validate_shares(&canister_http_pool);
 
                 // Make sure the changes are empty (share was filtered out)
                 assert!(changes.is_empty());
@@ -1034,11 +994,7 @@ pub mod test {
                     log,
                 );
 
-                let changes = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(0),
-                );
+                let changes = pool_manager.validate_shares(&canister_http_pool);
 
                 assert_matches!(&changes[0], CanisterHttpChangeAction::RemoveUnvalidated(_));
             })
@@ -1156,11 +1112,7 @@ pub mod test {
                     log,
                 );
 
-                let changes = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(0),
-                );
+                let changes = pool_manager.validate_shares(&canister_http_pool);
 
                 // Make sure the second share is sorted out as invalid, for the right reason.
                 if let CanisterHttpChangeAction::HandleInvalid(_, err) = &changes[0] {
@@ -1263,11 +1215,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(&changes[0], CanisterHttpChangeAction::HandleInvalid(_, reason) if reason == "Artifact should contain response");
                 }
@@ -1292,11 +1240,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(
                         &changes[0],
@@ -1325,11 +1269,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(
                         &changes[0],
@@ -1357,11 +1297,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(
                         &changes[0],
@@ -1456,11 +1392,7 @@ pub mod test {
                 );
 
                 // 4. ACTION: Our replica attempts to validate the artifact.
-                let change_set = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(1),
-                );
+                let change_set = pool_manager.validate_shares(&canister_http_pool);
 
                 // 5. ASSERTION: The artifact must be invalidated with the specific reason.
                 assert_eq!(change_set.len(), 1, "Expected exactly one change action");
@@ -1564,11 +1496,7 @@ pub mod test {
                     log,
                 );
 
-                let changes = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(0),
-                );
+                let changes = pool_manager.validate_shares(&canister_http_pool);
 
                 // The change action should be HandleInvalid because a fully replicated request's
                 // artifact must not contain a response in the unvalidated pool.
@@ -1679,11 +1607,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     // The error from `validate_response_size` itself.
                     let validation_err = format!(
@@ -1747,11 +1671,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(&changes[0], CanisterHttpChangeAction::MoveToValidated(_));
                 }
@@ -1856,11 +1776,7 @@ pub mod test {
                 });
 
                 // 4. VALIDATE: Call validate_shares and check the result.
-                let changes = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(0),
-                );
+                let changes = pool_manager.validate_shares(&canister_http_pool);
 
                 // 5. ASSERT: The artifact should be successfully validated and moved to the validated pool.
                 assert_eq!(changes.len(), 1);
@@ -1955,7 +1871,7 @@ pub mod test {
                 );
 
                 // 5. ACTION: Call the function to generate shares from responses.
-                let change_set = pool_manager.create_shares_from_responses(Height::from(1));
+                let change_set = pool_manager.create_shares_from_responses();
 
                 // 6. ASSERTIONS:
                 assert_eq!(
@@ -2082,7 +1998,7 @@ pub mod test {
 
                 // 5. ACTION: Call the function. The test will fail with a panic if
                 // the pruning logic is incorrect (i.e., not UTF-8 aware).
-                let change_set = pool_manager.create_shares_from_responses(Height::from(1));
+                let change_set = pool_manager.create_shares_from_responses();
 
                 // 6. ASSERTIONS:
                 assert_eq!(
@@ -2217,11 +2133,7 @@ pub mod test {
                 );
 
                 // 4. ACTION: Our replica attempts to validate the artifact.
-                let change_set = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(1),
-                );
+                let change_set = pool_manager.validate_shares(&canister_http_pool);
 
                 // 5. ASSERTION: The artifact is now correctly invalidated by the validate_response_size check.
                 assert_eq!(change_set.len(), 1, "Expected exactly one change action");
@@ -2345,11 +2257,7 @@ pub mod test {
                 });
 
                 // 3. Call validate_shares and assert that the share is considered VALID.
-                let changes = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(0),
-                );
+                let changes = pool_manager.validate_shares(&canister_http_pool);
 
                 assert_matches!(&changes[0], CanisterHttpChangeAction::MoveToValidated(_));
             })
@@ -2610,7 +2518,7 @@ pub mod test {
                     .borrow_mut()
                     .insert(stale_callback_id);
 
-                let change_set = pool_manager.create_shares_from_responses(Height::from(1));
+                let change_set = pool_manager.create_shares_from_responses();
 
                 // Only the response for the active context produces a share; the
                 // stale one is dropped.
@@ -2705,7 +2613,7 @@ pub mod test {
                 );
 
                 // 3. Call the function and get the change set.
-                let change_set = pool_manager.create_shares_from_responses(Height::from(1));
+                let change_set = pool_manager.create_shares_from_responses();
 
                 // 4. Assert that the correct change action for gossiping the response was produced.
                 assert_eq!(change_set.len(), 1);
@@ -3008,11 +2916,7 @@ pub mod test {
                 );
 
                 // 4. ACTION: Our replica attempts to validate the artifact.
-                let change_set = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(1),
-                );
+                let change_set = pool_manager.validate_shares(&canister_http_pool);
 
                 // 5. ASSERTION: The artifact must be invalidated with the specific reason.
                 assert_eq!(change_set.len(), 1);
@@ -3120,11 +3024,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(
                         &changes[0],
@@ -3151,11 +3051,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(
                         &changes[0],
@@ -3183,11 +3079,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(
                         &changes[0],
@@ -3214,11 +3106,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(
                         &changes[0],
@@ -3330,11 +3218,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     let validation_err = format!(
                         "Response size {} exceeds the maximum allowed size of {}",
@@ -3396,11 +3280,7 @@ pub mod test {
                         timestamp: UNIX_EPOCH,
                     });
 
-                    let changes = pool_manager.validate_shares(
-                        pool.get_cache().as_ref(),
-                        &canister_http_pool,
-                        Height::from(0),
-                    );
+                    let changes = pool_manager.validate_shares(&canister_http_pool);
 
                     assert_matches!(&changes[0], CanisterHttpChangeAction::MoveToValidated(_));
                 }
@@ -3479,7 +3359,7 @@ pub mod test {
                 );
 
                 // 3. Call the function and get the change set.
-                let change_set = pool_manager.create_shares_from_responses(Height::from(1));
+                let change_set = pool_manager.create_shares_from_responses();
 
                 // 4. Assert that the correct change action for gossiping the response was produced.
                 assert_eq!(change_set.len(), 1);
@@ -3589,11 +3469,7 @@ pub mod test {
                     log,
                 );
 
-                let changes = pool_manager.validate_shares(
-                    pool.get_cache().as_ref(),
-                    &canister_http_pool,
-                    Height::from(0),
-                );
+                let changes = pool_manager.validate_shares(&canister_http_pool);
 
                 assert_eq!(changes.len(), 1);
                 assert_matches!(

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -382,7 +382,6 @@ impl CanisterHttpPoolManagerImpl {
                     let receipt_share = CanisterHttpResponseReceipt {
                         metadata: CanisterHttpResponseMetadata {
                             id: response.id,
-                            registry_version,
                             content_hash: ic_types::crypto::crypto_hash(&response),
                             content_size: response.content.count_bytes() as u32,
                             is_reject: response.content.is_reject(),
@@ -575,15 +574,15 @@ impl CanisterHttpPoolManagerImpl {
 
                 let node_is_in_committee = self
                     .membership
-                    .node_belongs_to_canister_http_committee(
-                        finalized_height,
+                    .node_belongs_to_canister_http_committee_at_version(
+                        context.registry_version,
                         share.signature.signer,
                     )
                     .map_err(|e| {
                         warn!(
                             self.log,
-                            "Unable to check membership for share at height {}, {:?}",
-                            finalized_height,
+                            "Unable to check membership for share at registry version {}, {:?}",
+                            context.registry_version,
                             e
                         );
                         e
@@ -837,7 +836,6 @@ pub mod test {
                     let response_metadata = CanisterHttpResponseReceipt {
                         metadata: CanisterHttpResponseMetadata {
                             id: CallbackId::from(1),
-                            registry_version: RegistryVersion::from(1),
                             content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                             content_size: 0,
                             is_reject: false,
@@ -937,7 +935,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: CallbackId::from(0),
-                        registry_version: RegistryVersion::from(1),
                         content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                         content_size: 0,
                         is_reject: false,
@@ -1046,7 +1043,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: CallbackId::from(0),
-                        registry_version: RegistryVersion::from(1),
                         content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                         content_size: 0,
                         is_reject: false,
@@ -1177,7 +1173,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: CallbackId::from(0),
-                        registry_version: RegistryVersion::from(1),
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
                         is_reject: false,
@@ -1379,7 +1374,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: callback_id,
-                        registry_version: RegistryVersion::from(1),
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
                         is_reject: false,
@@ -1480,7 +1474,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: CallbackId::from(0),
-                        registry_version: RegistryVersion::from(1),
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
                         is_reject: false,
@@ -1621,7 +1614,6 @@ pub mod test {
                     let response_metadata = CanisterHttpResponseReceipt {
                         metadata: CanisterHttpResponseMetadata {
                             id: CallbackId::from(0),
-                            registry_version: RegistryVersion::from(1),
                             content_hash: ic_types::crypto::crypto_hash(&response),
                             content_size: response.content.count_bytes() as u32,
                             is_reject: false,
@@ -1690,7 +1682,6 @@ pub mod test {
                     let response_metadata = CanisterHttpResponseReceipt {
                         metadata: CanisterHttpResponseMetadata {
                             id: CallbackId::from(0),
-                            registry_version: RegistryVersion::from(1),
                             content_hash: ic_types::crypto::crypto_hash(&response),
                             content_size: response.content.count_bytes() as u32,
                             is_reject: false,
@@ -1797,7 +1788,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: CallbackId::from(0),
-                        registry_version: RegistryVersion::from(1),
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
                         is_reject: true,
@@ -2142,7 +2132,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: callback_id,
-                        registry_version: RegistryVersion::from(1),
                         content_hash: dishonest_hash,
                         content_size: dishonest_response.content.count_bytes() as u32,
                         is_reject: true,
@@ -2284,7 +2273,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: CallbackId::from(0),
-                        registry_version: RegistryVersion::from(1),
                         content_hash: ic_types::crypto::crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
                         is_reject: true,
@@ -2365,7 +2353,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: CallbackId::from(7),
-                        registry_version: RegistryVersion::from(1),
                         content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                         content_size: 0,
                         is_reject: false,
@@ -2689,7 +2676,6 @@ pub mod test {
                         share.content.content_hash(),
                         &ic_types::crypto::crypto_hash(&expected_response)
                     );
-                    assert_eq!(share.content.registry_version(), RegistryVersion::from(1));
                     assert_eq!(share.signature.signer, replica_config.node_id);
                 } else {
                     panic!(
@@ -2769,7 +2755,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: CallbackId::from(7),
-                        registry_version: RegistryVersion::from(1),
                         content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                         content_size: 0,
                         is_reject: false,
@@ -2936,7 +2921,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: callback_id,
-                        registry_version: RegistryVersion::from(1),
                         content_hash: crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
                         is_reject: false,
@@ -3038,7 +3022,6 @@ pub mod test {
                 let response_metadata = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: callback_id,
-                        registry_version: RegistryVersion::from(1),
                         content_hash: crypto_hash(&response),
                         content_size: response.content.count_bytes() as u32,
                         is_reject: false,
@@ -3276,7 +3259,6 @@ pub mod test {
                     let response_metadata = CanisterHttpResponseReceipt {
                         metadata: CanisterHttpResponseMetadata {
                             id: callback_id,
-                            registry_version: RegistryVersion::from(1),
                             content_hash: ic_types::crypto::crypto_hash(&response),
                             content_size: response.content.count_bytes() as u32,
                             is_reject: false,
@@ -3343,7 +3325,6 @@ pub mod test {
                     let response_metadata = CanisterHttpResponseReceipt {
                         metadata: CanisterHttpResponseMetadata {
                             id: callback_id,
-                            registry_version: RegistryVersion::from(1),
                             content_hash: ic_types::crypto::crypto_hash(&response),
                             content_size: response.content.count_bytes() as u32,
                             is_reject: false,
@@ -3521,7 +3502,6 @@ pub mod test {
                 let receipt_share = CanisterHttpResponseReceipt {
                     metadata: CanisterHttpResponseMetadata {
                         id: CallbackId::from(0),
-                        registry_version: RegistryVersion::from(1),
                         content_hash: CryptoHashOf::new(CryptoHash(vec![])),
                         content_size: 0,
                         is_reject: false,

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -265,7 +265,16 @@ impl CanisterHttpPoolManagerImpl {
         match &context.replication {
             Replication::FullyReplicated => self
                 .membership
-                .node_belongs_to_canister_http_committee(context.registry_version, node_id),
+                .node_belongs_to_canister_http_committee(context.registry_version, node_id)
+                .inspect_err(|e| {
+                    warn!(
+                        every_n_seconds => 10,
+                        self.log,
+                        "Unable to check committee membership at registry version {}, {:?}",
+                        context.registry_version,
+                        e
+                    );
+                }),
             replication @ (Replication::NonReplicated(_) | Replication::Flexible { .. }) => {
                 Ok(replication.is_authorized_signer(&node_id))
             }
@@ -565,14 +574,6 @@ impl CanisterHttpPoolManagerImpl {
 
                 let node_is_in_committee = self
                     .node_belongs_to_request_committee(context, share.signature.signer)
-                    .inspect_err(|e| {
-                        warn!(
-                            self.log,
-                            "Unable to check membership for share at registry version {}, {:?}",
-                            context.registry_version,
-                            e
-                        );
-                    })
                     .ok()?;
                 if !node_is_in_committee {
                     return Some(CanisterHttpChangeAction::HandleInvalid(

--- a/rs/https_outcalls/consensus/src/pool_manager.rs
+++ b/rs/https_outcalls/consensus/src/pool_manager.rs
@@ -260,7 +260,7 @@ impl CanisterHttpPoolManagerImpl {
     fn node_belongs_to_request_committee(
         &self,
         context: &CanisterHttpRequestContext,
-        node_id: NodeId,
+        node_id: &NodeId,
     ) -> Result<bool, MembershipError> {
         match &context.replication {
             Replication::FullyReplicated => self
@@ -275,9 +275,8 @@ impl CanisterHttpPoolManagerImpl {
                         e
                     );
                 }),
-            replication @ (Replication::NonReplicated(_) | Replication::Flexible { .. }) => {
-                Ok(replication.is_authorized_signer(&node_id))
-            }
+            Replication::NonReplicated(delegated_node_id) => Ok(node_id == delegated_node_id),
+            Replication::Flexible { committee, .. } => Ok(committee.contains(node_id)),
         }
     }
 
@@ -320,7 +319,7 @@ impl CanisterHttpPoolManagerImpl {
         for (id, context) in http_requests {
             // Only make a request if this node belongs to the request's committee
             if !self
-                .node_belongs_to_request_committee(context, self.replica_config.node_id)
+                .node_belongs_to_request_committee(context, &self.replica_config.node_id)
                 .unwrap_or(false)
             {
                 continue;
@@ -573,7 +572,7 @@ impl CanisterHttpPoolManagerImpl {
                 }
 
                 let node_is_in_committee = self
-                    .node_belongs_to_request_committee(context, share.signature.signer)
+                    .node_belongs_to_request_committee(context, &share.signature.signer)
                     .ok()?;
                 if !node_is_in_committee {
                     return Some(CanisterHttpChangeAction::HandleInvalid(

--- a/rs/interfaces/mocks/src/crypto.rs
+++ b/rs/interfaces/mocks/src/crypto.rs
@@ -67,7 +67,7 @@ use ic_types::crypto::{
     IndividualMultiSigOf, ThresholdSigShareOf, UserPublicKey,
 };
 use ic_types::messages::{MessageId, QueryResponseHash, WebAuthnEnvelope};
-use ic_types::signature::BasicSignatureBatch;
+use ic_types::signature::{BasicSigBatchEntry, BasicSignatureBatch};
 use ic_types::{NodeId, RegistryVersion, SubnetId};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
@@ -119,11 +119,18 @@ macro_rules! impl_basic_sig_verifier {
 
             fn verify_basic_sig_batch_multi_msg(
                 &self,
-                inputs: &[(NodeId, &BasicSigOf<$t>, &$t, RegistryVersion)],
+                inputs: &[BasicSigBatchEntry<'_, $t>],
             ) -> CryptoResult<()> {
                 let owned: Vec<(NodeId, BasicSigOf<$t>, $t, RegistryVersion)> = inputs
                     .iter()
-                    .map(|(signer, sig, msg, rv)| (*signer, (*sig).clone(), (*msg).clone(), *rv))
+                    .map(|entry| {
+                        (
+                            entry.signer,
+                            entry.signature.clone(),
+                            entry.message.clone(),
+                            entry.registry_version,
+                        )
+                    })
                     .collect();
                 self.$verify_sigs_batch(owned)
             }

--- a/rs/interfaces/mocks/src/crypto.rs
+++ b/rs/interfaces/mocks/src/crypto.rs
@@ -119,14 +119,13 @@ macro_rules! impl_basic_sig_verifier {
 
             fn verify_basic_sig_batch_multi_msg(
                 &self,
-                inputs: &[(NodeId, &BasicSigOf<$t>, &$t)],
-                registry_version: RegistryVersion,
+                inputs: &[(NodeId, &BasicSigOf<$t>, &$t, RegistryVersion)],
             ) -> CryptoResult<()> {
-                let owned: Vec<(NodeId, BasicSigOf<$t>, $t)> = inputs
+                let owned: Vec<(NodeId, BasicSigOf<$t>, $t, RegistryVersion)> = inputs
                     .iter()
-                    .map(|(signer, sig, msg)| (*signer, (*sig).clone(), (*msg).clone()))
+                    .map(|(signer, sig, msg, rv)| (*signer, (*sig).clone(), (*msg).clone(), *rv))
                     .collect();
-                self.$verify_sigs_batch(owned, registry_version)
+                self.$verify_sigs_batch(owned)
             }
         }
     };
@@ -329,8 +328,7 @@ mockall::mock! {
 
         pub fn verify_basic_sig_batch_multi_msg_block(
             &self,
-            inputs: Vec<(NodeId, BasicSigOf<BlockMetadata>, BlockMetadata)>,
-            registry_version: RegistryVersion,
+            inputs: Vec<(NodeId, BasicSigOf<BlockMetadata>, BlockMetadata, RegistryVersion)>,
         ) -> CryptoResult<()>;
 
         // consensus_dkg::DealingContent
@@ -355,8 +353,7 @@ mockall::mock! {
 
         pub fn verify_basic_sig_batch_multi_msg_dkg_dealing_content(
             &self,
-            inputs: Vec<(NodeId, BasicSigOf<consensus_dkg::DealingContent>, consensus_dkg::DealingContent)>,
-            registry_version: RegistryVersion,
+            inputs: Vec<(NodeId, BasicSigOf<consensus_dkg::DealingContent>, consensus_dkg::DealingContent, RegistryVersion)>,
         ) -> CryptoResult<()>;
 
         // SignedIDkgDealing
@@ -380,8 +377,7 @@ mockall::mock! {
 
         pub fn verify_basic_sig_batch_multi_msg_signed_idkg_dealing(
             &self,
-            inputs: Vec<(NodeId, BasicSigOf<SignedIDkgDealing>, SignedIDkgDealing)>,
-            registry_version: RegistryVersion,
+            inputs: Vec<(NodeId, BasicSigOf<SignedIDkgDealing>, SignedIDkgDealing, RegistryVersion)>,
         ) -> CryptoResult<()>;
 
         // IDkgDealing
@@ -403,8 +399,7 @@ mockall::mock! {
 
         pub fn verify_basic_sig_batch_multi_msg_idkg(
             &self,
-            inputs: Vec<(NodeId, BasicSigOf<IDkgDealing>, IDkgDealing)>,
-            registry_version: RegistryVersion,
+            inputs: Vec<(NodeId, BasicSigOf<IDkgDealing>, IDkgDealing, RegistryVersion)>,
         ) -> CryptoResult<()>;
 
         // IDkgComplaintContent
@@ -428,8 +423,7 @@ mockall::mock! {
 
         pub fn verify_basic_sig_batch_multi_msg_idkg_complaint(
             &self,
-            inputs: Vec<(NodeId, BasicSigOf<IDkgComplaintContent>, IDkgComplaintContent)>,
-            registry_version: RegistryVersion,
+            inputs: Vec<(NodeId, BasicSigOf<IDkgComplaintContent>, IDkgComplaintContent, RegistryVersion)>,
         ) -> CryptoResult<()>;
 
         // IDkgOpeningContent
@@ -453,8 +447,7 @@ mockall::mock! {
 
         pub fn verify_basic_sig_batch_multi_msg_idkg_opening(
             &self,
-            inputs: Vec<(NodeId, BasicSigOf<IDkgOpeningContent>, IDkgOpeningContent)>,
-            registry_version: RegistryVersion,
+            inputs: Vec<(NodeId, BasicSigOf<IDkgOpeningContent>, IDkgOpeningContent, RegistryVersion)>,
         ) -> CryptoResult<()>;
 
         // CanisterHttpResponseReceipt
@@ -484,8 +477,8 @@ mockall::mock! {
                 NodeId,
                 BasicSigOf<CanisterHttpResponseReceipt>,
                 CanisterHttpResponseReceipt,
+                RegistryVersion,
             )>,
-            registry_version: RegistryVersion,
         ) -> CryptoResult<()>;
 
         // ── ThresholdSigner<T> ──────────────────────────────────────────

--- a/rs/interfaces/src/canister_http.rs
+++ b/rs/interfaces/src/canister_http.rs
@@ -136,8 +136,6 @@ pub enum InvalidCanisterHttpPayloadReason {
 pub enum CanisterHttpPayloadValidationFailure {
     /// The state was not available at the time of validation
     StateUnavailable,
-    /// The consensus registry version could not be retrieved from the summary
-    ConsensusRegistryVersionUnavailable,
     /// The feature is not enabled
     Disabled,
     /// Membership Issue

--- a/rs/interfaces/src/canister_http.rs
+++ b/rs/interfaces/src/canister_http.rs
@@ -1,6 +1,5 @@
 //! Canister Http related public interfaces.
 use crate::validation::ValidationError;
-use ic_base_types::RegistryVersion;
 use ic_protobuf::proxy::ProxyDecodeError;
 use ic_types::{
     NodeId,
@@ -50,11 +49,6 @@ pub enum InvalidCanisterHttpPayloadReason {
     UnknownCallbackId(CallbackId),
     /// A CallbackId was included as a timeout, however the Request has not timed out at all
     NotTimedOut(CallbackId),
-    /// The registry version of a response does not match the validation context
-    RegistryVersionMismatch {
-        expected: RegistryVersion,
-        received: RegistryVersion,
-    },
     /// There was an error with a signature calculation
     SignatureError(Box<CryptoError>),
     /// A payment receipt claims a refund larger than the per-replica allowance

--- a/rs/interfaces/src/crypto/sign.rs
+++ b/rs/interfaces/src/crypto/sign.rs
@@ -25,7 +25,7 @@
 use ic_types::crypto::{
     BasicSigOf, CombinedMultiSigOf, CryptoResult, IndividualMultiSigOf, Signable,
 };
-use ic_types::signature::BasicSignatureBatch;
+use ic_types::signature::{BasicSigBatchEntry, BasicSignatureBatch};
 use ic_types::{NodeId, RegistryVersion};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -156,7 +156,7 @@ pub trait BasicSigVerifier<T: Signable> {
     /// * `CryptoError::InvalidArgument`: if `inputs` is empty.
     fn verify_basic_sig_batch_multi_msg(
         &self,
-        inputs: &[(NodeId, &BasicSigOf<T>, &T, RegistryVersion)],
+        inputs: &[BasicSigBatchEntry<'_, T>],
     ) -> CryptoResult<()>;
 }
 

--- a/rs/interfaces/src/crypto/sign.rs
+++ b/rs/interfaces/src/crypto/sign.rs
@@ -136,13 +136,15 @@ pub trait BasicSigVerifier<T: Signable> {
     ///
     /// In contrast to `verify_basic_sig_batch`, each signature in this batch
     /// may be on a different message. The same `NodeId` may appear multiple
-    /// times in `inputs` if a node signed multiple different messages.
+    /// times in `inputs` if a node signed multiple different messages. Each
+    /// input carries its own `RegistryVersion`, at which that signer's public
+    /// key is resolved; different inputs may use different registry versions.
     ///
     /// # Errors
     /// * `CryptoError::RegistryClient`: if the registry cannot be accessed at
-    ///   `registry_version`.
+    ///   an input's registry version.
     /// * `CryptoError::PublicKeyNotFound`: if at least one of the signers'
-    ///   public keys cannot be found at the given `registry_version`.
+    ///   public keys cannot be found at that input's registry version.
     /// * `CryptoError::MalformedSignature`: if a signature is malformed.
     /// * `CryptoError::AlgorithmNotSupported`: if a signature algorithm is
     ///   not supported, or if a signer's public key obtained from the
@@ -154,8 +156,7 @@ pub trait BasicSigVerifier<T: Signable> {
     /// * `CryptoError::InvalidArgument`: if `inputs` is empty.
     fn verify_basic_sig_batch_multi_msg(
         &self,
-        inputs: &[(NodeId, &BasicSigOf<T>, &T)],
-        registry_version: RegistryVersion,
+        inputs: &[(NodeId, &BasicSigOf<T>, &T, RegistryVersion)],
     ) -> CryptoResult<()>;
 }
 

--- a/rs/protobuf/def/types/v1/canister_http.proto
+++ b/rs/protobuf/def/types/v1/canister_http.proto
@@ -29,11 +29,9 @@ message CanisterHttpResponse {
 }
 
 message CanisterHttpResponseMetadata {
+  reserved 2, 4;
   uint64 id = 1;
-  reserved 2;
   bytes content_hash = 3;
-  reserved 4; // Previously registry_version; now sourced from the request context in replicated state.
-  reserved "registry_version";
   string replica_version = 5;
   uint32 content_size = 6;
   bool is_reject = 7;
@@ -61,14 +59,10 @@ message CanisterHttpResponseSignature {
 }
 
 message CanisterHttpResponseWithConsensus {
+  reserved 3, 4, 5, 6;
   CanisterHttpResponse response = 1;
   bytes hash = 2;
-  reserved 3; // Previously registry_version; now sourced from the request context in replicated state.
-  reserved "registry_version";
   string replica_version = 8;
-  reserved 4;
-  reserved 5;
-  reserved 6;
   repeated CanisterHttpResponseSignature signatures = 7;
   uint32 content_size = 9;
   bool is_reject = 10;

--- a/rs/protobuf/def/types/v1/canister_http.proto
+++ b/rs/protobuf/def/types/v1/canister_http.proto
@@ -32,7 +32,8 @@ message CanisterHttpResponseMetadata {
   uint64 id = 1;
   reserved 2;
   bytes content_hash = 3;
-  uint64 registry_version = 4;
+  reserved 4; // Previously registry_version; now sourced from the request context in replicated state.
+  reserved "registry_version";
   string replica_version = 5;
   uint32 content_size = 6;
   bool is_reject = 7;
@@ -62,7 +63,8 @@ message CanisterHttpResponseSignature {
 message CanisterHttpResponseWithConsensus {
   CanisterHttpResponse response = 1;
   bytes hash = 2;
-  uint64 registry_version = 3;
+  reserved 3; // Previously registry_version; now sourced from the request context in replicated state.
+  reserved "registry_version";
   string replica_version = 8;
   reserved 4;
   reserved 5;

--- a/rs/protobuf/src/gen/types/types.v1.rs
+++ b/rs/protobuf/src/gen/types/types.v1.rs
@@ -553,8 +553,6 @@ pub struct CanisterHttpResponseMetadata {
     pub id: u64,
     #[prost(bytes = "vec", tag = "3")]
     pub content_hash: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint64, tag = "4")]
-    pub registry_version: u64,
     #[prost(string, tag = "5")]
     pub replica_version: ::prost::alloc::string::String,
     #[prost(uint32, tag = "6")]
@@ -599,8 +597,6 @@ pub struct CanisterHttpResponseWithConsensus {
     pub response: ::core::option::Option<CanisterHttpResponse>,
     #[prost(bytes = "vec", tag = "2")]
     pub hash: ::prost::alloc::vec::Vec<u8>,
-    #[prost(uint64, tag = "3")]
-    pub registry_version: u64,
     #[prost(string, tag = "8")]
     pub replica_version: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "7")]

--- a/rs/replica/setup_ic_network/src/lib.rs
+++ b/rs/replica/setup_ic_network/src/lib.rs
@@ -166,11 +166,7 @@ impl Bouncers {
             state_reader.clone(),
         ));
 
-        let https_outcalls = Arc::new(CanisterHttpGossipImpl::new(
-            consensus_pool_cache.clone(),
-            state_reader.clone(),
-            log.clone(),
-        ));
+        let https_outcalls = Arc::new(CanisterHttpGossipImpl::new(state_reader.clone()));
 
         Self {
             ingress,

--- a/rs/replica/setup_ic_network/src/lib.rs
+++ b/rs/replica/setup_ic_network/src/lib.rs
@@ -144,7 +144,6 @@ struct Bouncers {
 
 impl Bouncers {
     fn new(
-        log: &ReplicaLogger,
         metrics_registry: &MetricsRegistry,
         subnet_id: SubnetId,
         time_source: Arc<dyn TimeSource>,
@@ -203,7 +202,6 @@ impl AbortableBroadcastChannels {
     ) -> (Self, AbortableBroadcastChannelBuilder) {
         let consensus_pool_cache = consensus_pool.read().unwrap().get_cache();
         let bouncers = Bouncers::new(
-            log,
             metrics_registry,
             subnet_id,
             time_source.clone(),

--- a/rs/state_machine_tests/src/lib.rs
+++ b/rs/state_machine_tests/src/lib.rs
@@ -2773,7 +2773,6 @@ impl StateMachine {
             let receipt_share = CanisterHttpResponseReceipt {
                 metadata: CanisterHttpResponseMetadata {
                     id: CallbackId::from(request_id),
-                    registry_version,
                     content_hash: ic_types::crypto::crypto_hash(&response),
                     content_size: content.count_bytes() as u32,
                     is_reject: content.is_reject(),

--- a/rs/types/types/src/batch/canister_http.rs
+++ b/rs/types/types/src/batch/canister_http.rs
@@ -11,7 +11,7 @@ use crate::{
     messages::CallbackId,
     signature::BasicSignature,
 };
-use ic_base_types::{NodeId, PrincipalId, RegistryVersion};
+use ic_base_types::{NodeId, PrincipalId};
 use ic_error_types::RejectCode;
 #[cfg(test)]
 use ic_exhaustive_derive::ExhaustiveSet;
@@ -215,7 +215,6 @@ impl From<CanisterHttpResponseWithConsensus> for pb::CanisterHttpResponseWithCon
                 canister_id: Some(pb::CanisterId::from(payload.content.canister_id)),
             }),
             hash: metadata.content_hash.get().0,
-            registry_version: metadata.registry_version.get(),
             replica_version: metadata.replica_version.into(),
             signatures: signatures
                 .into_iter()
@@ -285,7 +284,6 @@ impl TryFrom<pb::CanisterHttpResponseWithConsensus> for CanisterHttpResponseWith
                     )),
                     content_size: payload.content_size,
                     is_reject: payload.is_reject,
-                    registry_version: RegistryVersion::new(payload.registry_version),
                     replica_version: ReplicaVersion::try_from(payload.replica_version)
                         .map_err(|err| ProxyDecodeError::ReplicaVersionParseError(Box::new(err)))?,
                 },
@@ -370,7 +368,6 @@ impl From<CanisterHttpResponseShare> for pb::CanisterHttpShare {
             metadata: Some(pb::CanisterHttpResponseMetadata {
                 id: metadata.id.get(),
                 content_hash: metadata.content_hash.get().0,
-                registry_version: metadata.registry_version.get(),
                 replica_version: metadata.replica_version.into(),
                 content_size: metadata.content_size,
                 is_reject: metadata.is_reject,
@@ -392,7 +389,6 @@ impl TryFrom<pb::CanisterHttpShare> for CanisterHttpResponseShare {
             .ok_or(ProxyDecodeError::MissingField("share.metadata"))?;
         let id = CanisterHttpRequestId::new(metadata.id);
         let content_hash = CryptoHashOf::new(CryptoHash(metadata.content_hash));
-        let registry_version = RegistryVersion::new(metadata.registry_version);
         let replica_version = ReplicaVersion::try_from(metadata.replica_version)
             .map_err(|err| ProxyDecodeError::ReplicaVersionParseError(Box::new(err)))?;
         let signature = share
@@ -409,7 +405,6 @@ impl TryFrom<pb::CanisterHttpShare> for CanisterHttpResponseShare {
                     content_hash,
                     content_size: metadata.content_size,
                     is_reject: metadata.is_reject,
-                    registry_version,
                     replica_version,
                 },
                 payment_receipt,
@@ -642,7 +637,6 @@ mod tests {
                     ])),
                     content_size: 42,
                     is_reject: false,
-                    registry_version: RegistryVersion::new(2),
                     replica_version: ReplicaVersion::default(),
                 },
                 payment_receipt: CanisterHttpPaymentReceipt {

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -1041,7 +1041,6 @@ pub struct CanisterHttpResponseMetadata {
     pub content_hash: CryptoHashOf<CanisterHttpResponse>,
     pub content_size: u32,
     pub is_reject: bool,
-    pub registry_version: RegistryVersion,
     pub replica_version: ReplicaVersion,
 }
 
@@ -1052,14 +1051,12 @@ impl CountBytes for CanisterHttpResponseMetadata {
             content_hash,
             content_size,
             is_reject,
-            registry_version,
             replica_version,
         } = self;
         size_of_val(id)
             + content_hash.get_ref().0.len()
             + size_of_val(content_size)
             + size_of_val(is_reject)
-            + size_of_val(registry_version)
             + replica_version.as_ref().len()
     }
 }
@@ -1099,10 +1096,6 @@ impl CanisterHttpResponseReceipt {
 
     pub fn is_reject(&self) -> bool {
         self.metadata.is_reject
-    }
-
-    pub fn registry_version(&self) -> RegistryVersion {
-        self.metadata.registry_version
     }
 
     pub fn replica_version(&self) -> &ReplicaVersion {
@@ -1164,12 +1157,6 @@ impl CountBytes for CanisterHttpResponseProof {
                 .values()
                 .map(|s| std::mem::size_of::<NodeId>() + s.count_bytes())
                 .sum::<usize>()
-    }
-}
-
-impl CanisterHttpResponseProof {
-    pub fn registry_version(&self) -> RegistryVersion {
-        self.metadata.registry_version
     }
 }
 

--- a/rs/types/types/src/canister_http.rs
+++ b/rs/types/types/src/canister_http.rs
@@ -181,18 +181,6 @@ pub enum Replication {
     },
 }
 
-impl Replication {
-    /// Returns true if the given node is authorized to sign a share, assuming
-    /// it is part of the canister HTTP committee.
-    pub fn is_authorized_signer(&self, signer: &NodeId) -> bool {
-        match self {
-            Replication::FullyReplicated => true,
-            Replication::NonReplicated(node_id) => node_id == signer,
-            Replication::Flexible { committee, .. } => committee.contains(signer),
-        }
-    }
-}
-
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize, Serialize, FromRepr)]
 #[repr(u32)]
 pub enum PricingVersion {
@@ -1367,28 +1355,6 @@ mod tests {
             let round_trip: CanisterHttpRequestContext = pb.try_into().unwrap();
             assert_eq!(initial, round_trip);
         }
-    }
-
-    #[test]
-    fn replication_authorized_signer() {
-        let node1 = node_test_id(1);
-        let node2 = node_test_id(2);
-
-        let fully_replicated = Replication::FullyReplicated;
-        assert!(fully_replicated.is_authorized_signer(&node1));
-        assert!(fully_replicated.is_authorized_signer(&node2));
-
-        let non_replicated = Replication::NonReplicated(node1);
-        assert!(non_replicated.is_authorized_signer(&node1));
-        assert!(!non_replicated.is_authorized_signer(&node2));
-
-        let flexible = Replication::Flexible {
-            committee: BTreeSet::from([node1, node_test_id(3)]),
-            min_responses: 1,
-            max_responses: 2,
-        };
-        assert!(flexible.is_authorized_signer(&node1));
-        assert!(!flexible.is_authorized_signer(&node2));
     }
 
     #[rstest]

--- a/rs/types/types/src/consensus.rs
+++ b/rs/types/types/src/consensus.rs
@@ -1267,8 +1267,6 @@ pub enum Committee {
     /// Notarization indicates the committee that creates notarization and
     /// finalization artifacts by using multi-signatures.
     Notarization,
-    /// CanisterHttp indicates the committee for canister http.
-    CanisterHttp,
 }
 
 /// Threshold indicates how many replicas of a committee need to create a

--- a/rs/types/types/src/crypto/hash/tests.rs
+++ b/rs/types/types/src/crypto/hash/tests.rs
@@ -1078,7 +1078,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "ebf5373f06dadd9a3d7d3b59ce457533428ff27d4d588b8434f786d1d8c1a9db",
+            "10e5099acf02057c8dece601575e578f2289d1cca0aa27dfd793ed3a3d8ea4d7",
             "Hash of CanisterHttpResponseMetadata changed"
         );
     }
@@ -1109,7 +1109,7 @@ mod crypto_hash_stability {
         let hash = crypto_hash(&data);
         assert_eq!(
             hex::encode(hash.get_ref().0.as_slice()),
-            "a9372188df0e1057515013fa0208e8a6bf6aec7a5f5271c02585454c2bd32a2a",
+            "f3f73fb255a31933e6d4b10b99dbb77a92a0404c42fd075dd6394d52a56f6ccf",
             "Hash of CanisterHttpResponseShare changed"
         );
     }

--- a/rs/types/types/src/crypto/hash/tests.rs
+++ b/rs/types/types/src/crypto/hash/tests.rs
@@ -1073,7 +1073,6 @@ mod crypto_hash_stability {
             content_hash: test_crypto_hash_of(0x42),
             content_size: 0,
             is_reject: false,
-            registry_version: RegistryVersion::from(1),
             replica_version: ReplicaVersion::default(),
         };
         let hash = crypto_hash(&data);
@@ -1092,7 +1091,6 @@ mod crypto_hash_stability {
             content_hash: test_crypto_hash_of(0x42),
             content_size: 0,
             is_reject: false,
-            registry_version: RegistryVersion::from(1),
             replica_version: ReplicaVersion::default(),
         };
         let receipt_share = CanisterHttpResponseReceipt {

--- a/rs/types/types/src/signature.rs
+++ b/rs/types/types/src/signature.rs
@@ -43,7 +43,7 @@ impl<T> CountBytes for BasicSignatureBatch<T> {
 }
 
 /// A single entry in a batch of basic signatures to be verified together via
-/// [`crate::crypto::BasicSigVerifier::verify_basic_sig_batch_multi_msg`].
+/// `BasicSigVerifier::verify_basic_sig_batch_multi_msg`.
 ///
 /// Each entry pairs a `signer`, their `signature`, and the `message` that was
 /// signed with the `registry_version` at which that signer's public key is

--- a/rs/types/types/src/signature.rs
+++ b/rs/types/types/src/signature.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CountBytes, NodeId, crypto::threshold_sig::ni_dkg::NiDkgId, crypto::*, node_id_into_protobuf,
-    node_id_try_from_option,
+    CountBytes, NodeId, RegistryVersion, crypto::threshold_sig::ni_dkg::NiDkgId, crypto::*,
+    node_id_into_protobuf, node_id_try_from_option,
 };
 use ic_protobuf::{
     proxy::{ProxyDecodeError, try_from_option_field},
@@ -40,6 +40,20 @@ impl<T> CountBytes for BasicSignatureBatch<T> {
             .map(|sig| std::mem::size_of::<NodeId>() + sig.get_ref().count_bytes())
             .sum()
     }
+}
+
+/// A single entry in a batch of basic signatures to be verified together via
+/// [`crate::crypto::BasicSigVerifier::verify_basic_sig_batch_multi_msg`].
+///
+/// Each entry pairs a `signer`, their `signature`, and the `message` that was
+/// signed with the `registry_version` at which that signer's public key is
+/// resolved. Unlike [`BasicSignatureBatch`], entries may have distinct messages
+/// and registry versions, and the same `signer` may appear more than once.
+pub struct BasicSigBatchEntry<'a, T> {
+    pub signer: NodeId,
+    pub signature: &'a BasicSigOf<T>,
+    pub message: &'a T,
+    pub registry_version: RegistryVersion,
 }
 
 /// ThresholdSignature captures a threshold signature on a value and the


### PR DESCRIPTION
## Background

Before this PR, each node determined the registry version (thus committee) of an HTTP outcall by itself, depending on the current finalized height at the time of processing the request:
https://github.com/dfinity/ic/blob/fe9e1b7a9a98ebafbf38230368226f4e928cc14f/rs/https_outcalls/consensus/src/pool_manager.rs#L577-L599

Additionally, HTTP shares with the wrong registry version were filtered out by the payload builder:
https://github.com/dfinity/ic/blob/fe9e1b7a9a98ebafbf38230368226f4e928cc14f/rs/https_outcalls/consensus/src/payload_builder.rs#L212-L213

However, since the exact timing of when an HTTP request is handled on each replica may be different, the current finalized height (and therefore the registry version) may be different, as well.

This has some adverse effects:

1. If the registry version changes after shares were produced, but before they are combined, the HTTP request will time out because shares with the old registry version are filtered out by the payload builder (see [this metric](https://victoria.ch1-obs1.dfinity.network/select/0/vmui/#/?g0.range_input=4d20h20m29s519ms&g0.end_input=2026-06-16T15%3A16%3A04&g0.relative_time=none&g0.tab=0&g0.tenantID=0&g0.expr=increase%28max+%28canister_http_timeouts_delivered%7Bic_subnet%3D%22pzp6e-ekpqk-3c5x7-2h6so-njoeq-mt45d-h3h6c-q3mxf-vpeq5-fk5o7-yae%22%7D%29+%3E+0%29&g1.expr=increase%28max%28consensus_membership_registry_version%7Bic_subnet%3D%22pzp6e-ekpqk-3c5x7-2h6so-njoeq-mt45d-h3h6c-q3mxf-vpeq5-fk5o7-yae%22%7D%29%29&g1.range_input=4d20h20m29s519ms&g1.end_input=2026-06-16T15%3A16%3A04&g1.relative_time=none&g1.tab=0&g1.tenantID=0) for reference).
2. If a node produces some shares just before leaving the subnet, once these shares are received by its peers they might be invalidated, because to the rest of the subnet the node already left.
3. During membership changes, the HTTP outcalls committee will leave the subnet immediately without finishing outstanding requests first.

## Proposed Changes
Instead, this PR proposes to use the registry version of the `CanisterHttpRequestContext`. This registry version is used as the single source of truth for all nodes on the subnet, throughout the entire duration of the request. The registry version included in the share metadata is removed instead.

Additionally, during membership changes, this allows the committee of the request to remain on the subnet until the request context disappears from the state. This is achieved by considering HTTP contexts in `get_oldest_registry_version_in_use_by_repliated_state`.

One implication that this change has is that now, registry versions of signatures passed to `verify_basic_sig_batch_multi_msg` may be different. To solve this, we pass a separate registry version for each signature instead.