### PR TITLE
feat: publish to crates.io from a pinned commit

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -43,27 +43,28 @@ jobs:
 
       - name: Verify commit and check out
         if: ${{ github.event.inputs.commit != '' }}
+        env:
+          COMMIT: ${{ github.event.inputs.commit }}
         run: |
           set -euo pipefail
-          commit="${{ github.event.inputs.commit }}"
-          if ! git merge-base --is-ancestor -- "${commit}" HEAD; then
-            echo "Commit '${commit}' is not an ancestor of HEAD — aborting for security"
+          if ! git merge-base --is-ancestor -- "${COMMIT}" HEAD; then
+            echo "Commit '${COMMIT}' is not an ancestor of HEAD — aborting for security"
             exit 1
           fi
-          git checkout --detach -- "${commit}"
+          git checkout --detach -- "${COMMIT}"
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
         id: auth
 
       - name: Check crate version
+        env:
+          CRATE_NAME: ${{ github.event.inputs.crate-name }}
+          CRATE_VERSION: ${{ github.event.inputs.crate-version }}
         run: |
           set -euo pipefail
-          crate_name="${{ github.event.inputs.crate-name }}"
-          crate_version="${{ github.event.inputs.crate-version }}"
-
-          current_crate_version=$(cargo metadata --no-deps --format-version 1 | jq -r ".packages[] | select(.name==\"${crate_name}\") | .version")
-          if [ "$current_crate_version" != "$crate_version" ]; then
-            echo "Crate version mismatch: expected $crate_version, found $current_crate_version"
+          current_crate_version=$(cargo metadata --no-deps --format-version 1 | jq -r ".packages[] | select(.name==\"${CRATE_NAME}\") | .version")
+          if [ "$current_crate_version" != "$CRATE_VERSION" ]; then
+            echo "Crate version mismatch: expected $CRATE_VERSION, found $current_crate_version"
             exit 1
           fi
 
@@ -71,18 +72,26 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Build Crate
-        run: cargo build --package ${{ github.event.inputs.crate-name }}
+        env:
+          CRATE_NAME: ${{ github.event.inputs.crate-name }}
+        run: cargo build --package "${CRATE_NAME}"
 
       - name: Test Crate
         if: ${{ github.event.inputs.skip-tests == 'false' }}
-        run: cargo test --package ${{ github.event.inputs.crate-name }}
+        env:
+          CRATE_NAME: ${{ github.event.inputs.crate-name }}
+        run: cargo test --package "${CRATE_NAME}"
 
       - name: Publish Dry Run
         if: ${{ github.event.inputs.dry-run == 'true' }}
-        run: cargo publish --package ${{ github.event.inputs.crate-name }} --allow-dirty --dry-run
+        env:
+          CRATE_NAME: ${{ github.event.inputs.crate-name }}
+        run: cargo publish --package "${CRATE_NAME}" --allow-dirty --dry-run
 
       - name: Publish Crate
         if: ${{ github.event.inputs.dry-run == 'false' }}
-        run: cargo publish --package ${{ github.event.inputs.crate-name }} --allow-dirty
+        env:
+          CRATE_NAME: ${{ github.event.inputs.crate-name }}
+        run: cargo publish --package "${CRATE_NAME}" --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -9,6 +9,10 @@ on:
       crate-version:
         description: 'The version of the crate to publish'
         required: true
+      commit:
+        description: 'Commit hash to publish from (must be an ancestor of HEAD; defaults to HEAD)'
+        required: false
+        default: ''
       dry-run:
         description: "If true, run publish in dry-run mode (don't actually publish the crate)"
         required: false
@@ -34,6 +38,19 @@ jobs:
     environment: publish-crates
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify commit and check out
+        if: ${{ github.event.inputs.commit != '' }}
+        run: |
+          set -euo pipefail
+          commit="${{ github.event.inputs.commit }}"
+          if ! git merge-base --is-ancestor "${commit}" HEAD; then
+            echo "Commit '${commit}' is not an ancestor of HEAD — aborting for security"
+            exit 1
+          fi
+          git checkout "${commit}"
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
         id: auth

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -9,8 +9,8 @@ on:
       crate-version:
         description: 'The version of the crate to publish'
         required: true
-      commit:
-        description: 'Commit hash to publish from (must be an ancestor of HEAD; defaults to HEAD)'
+      ref:
+        description: 'Branch, tag, or commit to publish from (must be an ancestor of master; defaults to HEAD)'
         required: false
         default: ''
       dry-run:
@@ -39,26 +39,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: ${{ github.event.inputs.commit != '' && '0' || '1' }}
+          fetch-depth: ${{ github.event.inputs.ref != '' && '0' || '1' }}
 
-      - name: Verify commit and check out
-        if: ${{ github.event.inputs.commit != '' }}
+      - name: Verify ref and check out
+        if: ${{ github.event.inputs.ref != '' }}
         run: |
           set -euo pipefail
-          commit="${{ github.event.inputs.commit }}"
-          if [[ ! "${commit}" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
-            echo "Invalid commit hash '${commit}' (expected 7-40 hex characters)"
+          ref="${{ github.event.inputs.ref }}"
+          if ! git merge-base --is-ancestor -- "${ref}" HEAD; then
+            echo "Ref '${ref}' is not an ancestor of HEAD — aborting for security"
             exit 1
           fi
-          resolved_commit=$(git rev-parse --verify --quiet "${commit}^{commit}") || {
-            echo "Invalid or unknown commit hash '${commit}'"
-            exit 1
-          }
-          if ! git merge-base --is-ancestor -- "${resolved_commit}" HEAD; then
-            echo "Commit '${resolved_commit}' is not an ancestor of HEAD — aborting for security"
-            exit 1
-          fi
-          git checkout --detach -- "${resolved_commit}"
+          git checkout --detach -- "${ref}"
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
         id: auth

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -50,14 +50,15 @@ jobs:
             echo "Invalid commit hash '${commit}' (expected 7-40 hex characters)"
             exit 1
           fi
-          if ! git merge-base --is-ancestor -- "${commit}" HEAD; then
-            echo "Commit '${commit}' is not an ancestor of HEAD — aborting for security"
+          resolved_commit=$(git rev-parse --verify --quiet "${commit}^{commit}") || {
+            echo "Invalid or unknown commit hash '${commit}'"
+            exit 1
+          }
+          if ! git merge-base --is-ancestor -- "${resolved_commit}" HEAD; then
+            echo "Commit '${resolved_commit}' is not an ancestor of HEAD — aborting for security"
             exit 1
           fi
-          n=$(git rev-list --count "${commit}..HEAD")
-          # We checkout by commit count offset from HEAD (not directly from user input) to avoid
-          # git checkout on user-controlled data, which could be used for command injection.
-          git checkout --detach "HEAD~${n}"
+          git checkout --detach -- "${resolved_commit}"
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
         id: auth

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -46,11 +46,15 @@ jobs:
         run: |
           set -euo pipefail
           commit="${{ github.event.inputs.commit }}"
-          if ! git merge-base --is-ancestor "${commit}" HEAD; then
+          if [[ ! "${commit}" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+            echo "Invalid commit hash '${commit}' (expected 7-40 hex characters)"
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor -- "${commit}" HEAD; then
             echo "Commit '${commit}' is not an ancestor of HEAD — aborting for security"
             exit 1
           fi
-          git checkout "${commit}"
+          git checkout --detach "${commit}"
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
         id: auth

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -10,7 +10,7 @@ on:
         description: 'The version of the crate to publish'
         required: true
       ref:
-        description: 'Branch, tag, or commit to publish from (must be an ancestor of master; defaults to HEAD)'
+        description: 'Branch, tag, or commit to publish from (must be an ancestor of HEAD; defaults to the workflow run\'s HEAD)'
         required: false
         default: ''
       dry-run:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -9,8 +9,8 @@ on:
       crate-version:
         description: 'The version of the crate to publish'
         required: true
-      ref:
-        description: 'Branch, tag, or commit to publish from (must be an ancestor of HEAD; defaults to the workflow run\'s HEAD)'
+      commit:
+        description: 'Commit to publish from (must be an ancestor of HEAD; defaults to the workflow run\'s HEAD)'
         required: false
         default: ''
       dry-run:
@@ -39,18 +39,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: ${{ github.event.inputs.ref != '' && '0' || '1' }}
+          fetch-depth: ${{ github.event.inputs.commit != '' && '0' || '1' }}
 
-      - name: Verify ref and check out
-        if: ${{ github.event.inputs.ref != '' }}
+      - name: Verify commit and check out
+        if: ${{ github.event.inputs.commit != '' }}
         run: |
           set -euo pipefail
-          ref="${{ github.event.inputs.ref }}"
-          if ! git merge-base --is-ancestor -- "${ref}" HEAD; then
-            echo "Ref '${ref}' is not an ancestor of HEAD — aborting for security"
+          commit="${{ github.event.inputs.commit }}"
+          if ! git merge-base --is-ancestor -- "${commit}" HEAD; then
+            echo "Commit '${commit}' is not an ancestor of HEAD — aborting for security"
             exit 1
           fi
-          git checkout --detach -- "${ref}"
+          git checkout --detach -- "${commit}"
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
         id: auth

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -54,7 +54,10 @@ jobs:
             echo "Commit '${commit}' is not an ancestor of HEAD — aborting for security"
             exit 1
           fi
-          git checkout --detach "${commit}"
+          n=$(git rev-list --count "${commit}..HEAD")
+          # We checkout by commit count offset from HEAD (not directly from user input) to avoid
+          # git checkout on user-controlled data, which could be used for command injection.
+          git checkout --detach "HEAD~${n}"
 
       - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe
         id: auth

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ github.event.inputs.commit != '' && '0' || '1' }}
 
       - name: Verify commit and check out
         if: ${{ github.event.inputs.commit != '' }}


### PR DESCRIPTION
This PR allows to publish crates to crates.io from a pinned commit. For security reasons, the commit must be an ancestor of HEAD to not bypass the branch whitelist for crates publishing.