### PR TITLE
fix: Try to fix var encryption ordering

### DIFF
--- a/ic-os/components/upgrade/systemd-generators/mount-generator
+++ b/ic-os/components/upgrade/systemd-generators/mount-generator
@@ -133,6 +133,7 @@ function make_var_cryptsetup() {
     echo "After=cryptsetup-pre.target"
     echo "Before=blockdev@dev-mapper-var_crypt.target"
     echo "Wants=blockdev@dev-mapper-var_crypt.target"
+    echo "Before=var.mount"
     echo "Conflicts=umount.target"
     echo "Before=cryptsetup.target"
     echo "Requires=init-config.service"


### PR DESCRIPTION
Wait for `setup-var-encryption.sh` to finish before trying `var.mount`. That way, there's no chance that the log copying races with the fstab mount.