### PR TITLE
fix: filter out local_system_test in the release-system-tests job

### DIFF
--- a/.github/workflows/release-testing.yml
+++ b/.github/workflows/release-testing.yml
@@ -53,7 +53,7 @@ jobs:
             bazel test \
               --config=stamped \
               --config=flaky_retry \
-              --test_tag_filters=system_test_large \
+              --test_tag_filters=system_test_large,-local_system_test \
               //rs/tests/... \
               --keep_going
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
The `release-system-tests` job runs all system-tests tagged with `system_test_large`.
These include all the `_head_nns` variants of `system_test_nns` tests. 
Since 1500b86 these `system_test` tests will also declare a `_local` variant.
This meant the `release-system-tests` job would also try to test `_head_nns_local` variants of each `system_test_nns` test.  Since the job doesn't run `ci/container/init.sh` to setup the system for local system-tests the tests would fail with:
```
error: unsupported configuration: Emulator '/usr/bin/qemu-system-x86_64' does not support virt type 'kvm' [code=configunsupported (67), domain=qemu (10)]
```
We fix this by filtering out `local_system_test` tagged tests from the  `release-system-tests` job.