### PR TITLE
fix: introduce maximum wasm_memory_threshold

### DIFF
--- a/packages/ic-management-canister-types/src/lib.rs
+++ b/packages/ic-management-canister-types/src/lib.rs
@@ -158,7 +158,7 @@ pub struct CanisterSettings {
     ///
     /// If the remaining wasm memory size of the canister is below the threshold, execution of the "on low wasm memory" hook is scheduled.
     ///
-    /// Must be a number between 0 and 2<sup>64</sup>-1, inclusively.
+    /// Must be a number between 0 and 2<sup>48</sup> (i.e 256TB), inclusively.
     ///
     /// Default value: `0` (i.e., the "on low wasm memory" hook is never scheduled).
     pub wasm_memory_threshold: Option<Nat>,

--- a/rs/execution_environment/src/canister_settings.rs
+++ b/rs/execution_environment/src/canister_settings.rs
@@ -12,9 +12,10 @@ use std::convert::TryFrom;
 #[cfg(test)]
 mod tests;
 
-/// These limit comes from the spec and is not expected to change,
-/// which is why it is not part of the replica config.
+/// These limits come from the spec and are not expected to change,
+/// which is why they are not part of the replica config.
 const MAX_WASM_MEMORY_LIMIT: u64 = 1 << 48;
+const MAX_WASM_MEMORY_THRESHOLD: u64 = 1 << 48;
 /// Struct used for decoding CanisterSettingsArgs
 #[derive(Default)]
 pub(crate) struct CanisterSettings {
@@ -185,6 +186,11 @@ impl TryFrom<CanisterSettingsArgs> for CanisterSettings {
                     .0
                     .to_u64()
                     .ok_or(UpdateSettingsError::WasmMemoryThresholdOutOfRange { provided: wmt })?;
+                if wmt > MAX_WASM_MEMORY_THRESHOLD {
+                    return Err(UpdateSettingsError::WasmMemoryThresholdOutOfRange {
+                        provided: wmt.into(),
+                    });
+                }
                 Some(NumBytes::new(wmt))
             }
             None => None,
@@ -431,7 +437,7 @@ impl From<UpdateSettingsError> for UserError {
             UpdateSettingsError::WasmMemoryThresholdOutOfRange { provided } => UserError::new(
                 ErrorCode::CanisterContractViolation,
                 format!(
-                    "Wasm memory threshold expected to be in the range of [0..2^64-1], got {provided}"
+                    "Wasm memory threshold expected to be in the range of [0..2^48], got {provided}"
                 ),
             ),
             UpdateSettingsError::DuplicateEnvironmentVariables => UserError::new(

--- a/rs/execution_environment/tests/hypervisor.rs
+++ b/rs/execution_environment/tests/hypervisor.rs
@@ -9161,6 +9161,24 @@ fn wasm_memory_limit_cannot_exceed_256_tb() {
     assert_eq!(err.code(), ErrorCode::CanisterContractViolation);
 }
 
+#[test]
+fn wasm_memory_threshold_cannot_exceed_256_tb() {
+    let mut test = ExecutionTestBuilder::new().build();
+
+    let canister_id = test.create_canister(Cycles::new(1_000_000_000_000));
+
+    // Setting the threshold to 2^48 works.
+    test.canister_update_wasm_memory_threshold(canister_id, NumBytes::new(1 << 48))
+        .unwrap();
+
+    // Setting the threshold above 2^48 fails.
+    let err = test
+        .canister_update_wasm_memory_threshold(canister_id, NumBytes::new((1 << 48) + 1))
+        .unwrap_err();
+
+    assert_eq!(err.code(), ErrorCode::CanisterContractViolation);
+}
+
 // Test the result that is close to 2^64.
 #[test]
 fn ic0_canister_cycle_balance_u64() {

--- a/rs/test_utilities/execution_environment/src/lib.rs
+++ b/rs/test_utilities/execution_environment/src/lib.rs
@@ -828,6 +828,22 @@ impl ExecutionTest {
         self.subnet_message(Method::UpdateSettings, payload)
     }
 
+    pub fn canister_update_wasm_memory_threshold(
+        &mut self,
+        canister_id: CanisterId,
+        wasm_memory_threshold: NumBytes,
+    ) -> Result<WasmResult, UserError> {
+        let payload = UpdateSettingsArgs {
+            canister_id: canister_id.into(),
+            settings: CanisterSettingsArgsBuilder::new()
+                .with_wasm_memory_threshold(wasm_memory_threshold.get())
+                .build(),
+            sender_canister_version: None,
+        }
+        .encode();
+        self.subnet_message(Method::UpdateSettings, payload)
+    }
+
     pub fn canister_update_wasm_memory_limit_and_wasm_memory_threshold(
         &mut self,
         canister_id: CanisterId,


### PR DESCRIPTION
This PR introduces a maximum allowed value for `wasm_memory_threshold`, analogously to `wasm_memory_limit` which also restricts (with a different semantics) wasm memory usage and thus using the same maximum allowed value makes sense.