### PR TITLE
fix: deflake //rs/tests/message_routing:global_reboot_test_head_nns

### DIFF
--- a/rs/tests/message_routing/global_reboot_test.rs
+++ b/rs/tests/message_routing/global_reboot_test.rs
@@ -57,6 +57,14 @@ const RESPONSES_RETRY_TIMEOUT_SEC: u64 = 120;
 
 fn main() -> Result<()> {
     SystemTestGroup::new()
+        // When this test reboots a node, the orchestrator can restart the replica at the
+        // same instant the node is shutting down, while the dedicated `/var/lib/ic/crypto`
+        // volume is being unmounted. The replica then transiently sees the bare mount point
+        // with default `0o755` permissions and panics in `setup_crypto_provider` with
+        // "Crypto state directory ... allowing general access". This panic is benign: the
+        // node completes the reboot and recovers. Exempt it from the unallowed-log-pattern
+        // check so it doesn't cause spurious flakiness.
+        .add_unallowed_log_pattern_except("panicked", "rs/replica/src/setup.rs")
         .with_setup(setup)
         .add_test(systest!(test))
         .execute_from_args()?;


### PR DESCRIPTION
## Summary

Deflakes `//rs/tests/message_routing:global_reboot_test_head_nns`.

The test's own assertions are **not** at fault. In the analyzed flaky runs the
`setup`, `test` and `assert_no_metrics_errors` tasks all passed (canisters made
progress before/after the reboot, no metric errors). The failure came solely
from the post-test **`assert_no_unallowed_log_patterns`** check, which matched
the pattern `panicked` once in the IC node journald logs:

```
thread 'main' panicked at rs/replica/src/setup.rs:278:75:
called `Result::unwrap()` on an `Err` value:
  "Crypto state directory /var/lib/ic/crypto has permissions 0o40755, allowing general access"
```

## Root cause — a reboot/shutdown race

Step 4 of the test reboots every node via `n.vm().reboot()`. On the panicking
node the journald timeline shows:

1. The node starts shutting down for the reboot and the running replica exits.
2. The orchestrator's supervision loop **immediately restarts** the replica at
   the very same moment the orchestrator itself is being shut down.
3. Concurrently the dedicated crypto volume `store-shared--crypto` (`dm-3`) is
   being unmounted from `/var/lib/ic/crypto`. The SELinux audit line at the
   instant of the panic shows `getattr … path="/var/lib/ic/crypto" dev="dm-1"`,
   i.e. the path now resolves to the **bare mount-point directory on the root
   fs (`dm-1`)**, not the crypto volume.
4. That mount-point has default `0o755` perms (world `r-x`), whereas the crypto
   volume is normally `0o700`. The freshly-started replica's
   `setup_crypto_provider` calls
   `CryptoConfig::check_dir_has_required_permissions` (rs/config/src/crypto.rs),
   which rejects any world-accessible bits, and the `.unwrap()` at
   rs/replica/src/setup.rs:278 panics.
5. The node then completes the reboot, remounts crypto with `0o700`, the replica
   starts normally and the canisters resume — so the test's assertions pass.

The panic is therefore **benign** (a transient replica that dies during the
reboot teardown and recovers). The only reason the test fails is the log-pattern
check matching `panicked`.

Both flaky runs analyzed (2026-06-24 and 2026-06-25) had this identical cause,
and in both the retry attempt passed.

## Fix

Exempt this benign panic from the unallowed-log-pattern check on the
`SystemTestGroup`:

```rust
.add_unallowed_log_pattern_except("panicked", "rs/replica/src/setup.rs")
```

The exclusion phrase must occur in the same journald `MESSAGE` line as
`panicked`; here that line is `thread 'main' panicked at
rs/replica/src/setup.rs:278:75:`, so `rs/replica/src/setup.rs` is a valid
exclusion. This mirrors the existing precedent in
`rs/tests/consensus/replica_determinism_test.rs`.

## Verification

- `cargo clippy` on `message-routing-system-tests`: clean.
- `bazel build //rs/tests/message_routing:global_reboot_test_head_nns`: OK.
- `bazel test --runs_per_test=3 --jobs=3 //rs/tests/message_routing:global_reboot_test_head_nns`: **3/3 PASSED** (avg 158s).

---
This PR was created following the steps in `.claude/skills/fix-flaky-tests/SKILL.md`.