### PR TITLE
chore: simplify mtools setup

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -247,16 +247,6 @@ alias(
     }),
 )
 
-### mtools, used to populate FAT filesystem images (invoked as `mtools -c mcopy/mmd`)
-
-alias(
-    name = "mtools",
-    actual = select({
-        "@bazel_tools//src/conditions:linux_x86_64": "@mtools//:mtools",
-        "//conditions:default": "@platforms//:incompatible",
-    }),
-)
-
 ### e2fsdroid, used to populate ext4 filesystem images (fs_config + SELinux contexts)
 
 alias(

--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -87,16 +87,6 @@ def _mcopy(ctx):
     """
     out = ctx.actions.declare_file(ctx.label.name)
 
-    # //:mtools resolves to the mtools bundle (the mtools binary + an include
-    # dir); pick out the binary, which we drive as `mtools -c mcopy ...`.
-    mtools = None
-    for f in ctx.files._mtools:
-        if f.basename == "mtools":
-            mtools = f
-            break
-    if not mtools:
-        fail("could not locate mtools binary among //:mtools outputs")
-
     command = "cp -p {fs} {output} && chmod +w {output} ".format(fs = ctx.file.fs.path, output = out.path)
     inputs = []
     for srcs, dest in ctx.attr.srcmap.items():
@@ -107,8 +97,8 @@ def _mcopy(ctx):
                 dest_path = dest + src_file.basename
             else:
                 dest_path = dest
-            command += "&& {mtools} -c mcopy -mi {output} -sQ {src_path} ::/{dest} ".format(
-                mtools = mtools.path,
+            command += "&& {mcopy} -mi {output} -sQ {src_path} ::/{dest} ".format(
+                mcopy = ctx.file._mcopy.path,
                 output = out.path,
                 src_path = src_file.path,
                 dest = dest_path.removeprefix("/"),
@@ -116,7 +106,7 @@ def _mcopy(ctx):
 
     ctx.actions.run_shell(
         command = command,
-        inputs = inputs + [ctx.file.fs] + ctx.files._mtools,
+        inputs = inputs + [ctx.file.fs, ctx.file._mcopy],
         outputs = [out],
     )
     return [DefaultInfo(files = depset([out]), runfiles = ctx.runfiles(files = [out]))]
@@ -126,7 +116,7 @@ mcopy = rule(
     attrs = {
         "srcmap": attr.label_keyed_string_dict(allow_files = True),
         "fs": attr.label(allow_single_file = True),
-        "_mtools": attr.label(default = "//:mtools", cfg = "exec", allow_files = True),
+        "_mcopy": attr.label(default = "@mtools//:mcopy", cfg = "exec", allow_single_file = True),
     },
 )
 

--- a/third_party/BUILD.mtools.bazel
+++ b/third_party/BUILD.mtools.bazel
@@ -38,7 +38,10 @@ configure_make(
     # mtools compiles in its built-in codepage tables instead of calling iconv.
     env = {"ac_cv_header_iconv_h": "no"},
     lib_source = ":all_srcs",
-    out_binaries = ["mtools", "mcopy"],
+    out_binaries = [
+        "mtools",
+        "mcopy",
+    ],
     # We don't ship any libs out of this build.
     out_shared_libs = [],
     out_static_libs = [],

--- a/third_party/BUILD.mtools.bazel
+++ b/third_party/BUILD.mtools.bazel
@@ -1,6 +1,5 @@
 """
-mtools, built from source. Provides the `mtools` multi-call binary; IC-OS uses
-it as `mtools -c mcopy ...` and `mtools -c mmd ...` to populate FAT/VFAT images.
+mtools, built from source.
 
 Built without iconv (see ac_cv_header_iconv_h below) so mtools uses its
 compiled-in codepage tables (default CP850) rather than glibc's gconv modules:
@@ -39,7 +38,7 @@ configure_make(
     # mtools compiles in its built-in codepage tables instead of calling iconv.
     env = {"ac_cv_header_iconv_h": "no"},
     lib_source = ":all_srcs",
-    out_binaries = ["mtools"],
+    out_binaries = ["mtools", "mcopy"],
     # We don't ship any libs out of this build.
     out_shared_libs = [],
     out_static_libs = [],
@@ -57,5 +56,12 @@ filegroup(
     name = "mtools",
     srcs = [":mtools_build"],
     output_group = "mtools",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "mcopy",
+    srcs = [":mtools_build"],
+    output_group = "mcopy",
     visibility = ["//visibility:public"],
 )

--- a/toolchains/sysimage/build_fat32_image.py
+++ b/toolchains/sysimage/build_fat32_image.py
@@ -17,14 +17,6 @@ import tempfile
 from toolchains.sysimage.utils import parse_size
 
 
-def mtools_cmd(mtools, subcommand, *extra_args):
-    # mtools is a multi-call binary; invoke a subcommand (mmd, mcopy, ...) via
-    # `mtools -c <subcommand>`. Wrapped in faketime for deterministic timestamps;
-    # the binary path is made absolute so faketime (which execs it) treats it as
-    # a path rather than searching PATH.
-    return ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", subcommand, *extra_args]
-
-
 def untar_to_fat32(tf, fs_basedir, out_file, path_transform, mtools):
     """
     Put contents of tarfile into fat32 image.
@@ -47,12 +39,12 @@ def untar_to_fat32(tf, fs_basedir, out_file, path_transform, mtools):
             if path == "":
                 continue
             os.mkdir(os.path.join(fs_basedir, path))
-            subprocess.run(mtools_cmd(mtools, "mmd", "-i", out_file, "::/" + path), check=True)
+            subprocess.run(["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", "mmd", "-i", out_file, "::/" + path], check=True)
         elif member.type == tarfile.REGTYPE or member.type == tarfile.AREGTYPE:
             with open(os.path.join(fs_basedir, path), "wb") as f:
                 f.write(tf.extractfile(member).read())
             subprocess.run(
-                mtools_cmd(mtools, "mcopy", "-o", "-i", out_file, os.path.join(fs_basedir, path), "::/" + path),
+                ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c","mcopy", "-o", "-i", out_file, os.path.join(fs_basedir, path), "::/" + path],
                 check=True,
             )
         else:
@@ -65,7 +57,7 @@ def install_extra_files(out_file, extra_files, path_transform, mtools):
         if install_target[0] == "/":
             install_target = install_target[1:]
         subprocess.run(
-            mtools_cmd(mtools, "mcopy", "-o", "-i", out_file, source_file, "::/" + path_transform(install_target)),
+            ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c","mcopy", "-o", "-i", out_file, source_file, "::/" + path_transform(install_target)],
             check=True,
         )
 

--- a/toolchains/sysimage/build_fat32_image.py
+++ b/toolchains/sysimage/build_fat32_image.py
@@ -39,12 +39,37 @@ def untar_to_fat32(tf, fs_basedir, out_file, path_transform, mtools):
             if path == "":
                 continue
             os.mkdir(os.path.join(fs_basedir, path))
-            subprocess.run(["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", "mmd", "-i", out_file, "::/" + path], check=True)
+            subprocess.run(
+                [
+                    "faketime",
+                    "-f",
+                    "1970-1-1 0:0:0",
+                    os.path.abspath(mtools),
+                    "-c",
+                    "mmd",
+                    "-i",
+                    out_file,
+                    "::/" + path,
+                ],
+                check=True,
+            )
         elif member.type == tarfile.REGTYPE or member.type == tarfile.AREGTYPE:
             with open(os.path.join(fs_basedir, path), "wb") as f:
                 f.write(tf.extractfile(member).read())
             subprocess.run(
-                ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c","mcopy", "-o", "-i", out_file, os.path.join(fs_basedir, path), "::/" + path],
+                [
+                    "faketime",
+                    "-f",
+                    "1970-1-1 0:0:0",
+                    os.path.abspath(mtools),
+                    "-c",
+                    "mcopy",
+                    "-o",
+                    "-i",
+                    out_file,
+                    os.path.join(fs_basedir, path),
+                    "::/" + path,
+                ],
                 check=True,
             )
         else:
@@ -57,7 +82,19 @@ def install_extra_files(out_file, extra_files, path_transform, mtools):
         if install_target[0] == "/":
             install_target = install_target[1:]
         subprocess.run(
-            ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c","mcopy", "-o", "-i", out_file, source_file, "::/" + path_transform(install_target)],
+            [
+                "faketime",
+                "-f",
+                "1970-1-1 0:0:0",
+                os.path.abspath(mtools),
+                "-c",
+                "mcopy",
+                "-o",
+                "-i",
+                out_file,
+                source_file,
+                "::/" + path_transform(install_target),
+            ],
             check=True,
         )
 

--- a/toolchains/sysimage/build_vfat_image.py
+++ b/toolchains/sysimage/build_vfat_image.py
@@ -16,15 +16,6 @@ import tempfile
 
 from toolchains.sysimage.utils import parse_size
 
-
-def mtools_cmd(mtools, subcommand, *extra_args):
-    # mtools is a multi-call binary; invoke a subcommand (mmd, mcopy, ...) via
-    # `mtools -c <subcommand>`. Wrapped in faketime for deterministic timestamps;
-    # the binary path is made absolute so faketime (which execs it) treats it as
-    # a path rather than searching PATH.
-    return ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", subcommand, *extra_args]
-
-
 def untar_to_vfat(tf, fs_basedir, out_file, path_transform, mtools):
     """
     Put contents of tarfile into vfat image.
@@ -47,12 +38,12 @@ def untar_to_vfat(tf, fs_basedir, out_file, path_transform, mtools):
             if path == "":
                 continue
             os.mkdir(os.path.join(fs_basedir, path))
-            subprocess.run(mtools_cmd(mtools, "mmd", "-i", out_file, "::/" + path), check=True)
+            subprocess.run(["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", "mmd", "-i", out_file, "::/" + path], check=True)
         elif member.type == tarfile.REGTYPE or member.type == tarfile.AREGTYPE:
             with open(os.path.join(fs_basedir, path), "wb") as f:
                 f.write(tf.extractfile(member).read())
             subprocess.run(
-                mtools_cmd(mtools, "mcopy", "-o", "-i", out_file, os.path.join(fs_basedir, path), "::/" + path),
+                ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", "mcopy", "-o", "-i", out_file, os.path.join(fs_basedir, path), "::/" + path],
                 check=True,
             )
         else:
@@ -65,7 +56,7 @@ def install_extra_files(out_file, extra_files, path_transform, mtools):
         if install_target[0] == "/":
             install_target = install_target[1:]
         subprocess.run(
-            mtools_cmd(mtools, "mcopy", "-o", "-i", out_file, source_file, "::/" + path_transform(install_target)),
+            ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", "mcopy", "-o", "-i", out_file, source_file, "::/" + path_transform(install_target)],
             check=True,
         )
 

--- a/toolchains/sysimage/build_vfat_image.py
+++ b/toolchains/sysimage/build_vfat_image.py
@@ -16,6 +16,7 @@ import tempfile
 
 from toolchains.sysimage.utils import parse_size
 
+
 def untar_to_vfat(tf, fs_basedir, out_file, path_transform, mtools):
     """
     Put contents of tarfile into vfat image.
@@ -38,12 +39,37 @@ def untar_to_vfat(tf, fs_basedir, out_file, path_transform, mtools):
             if path == "":
                 continue
             os.mkdir(os.path.join(fs_basedir, path))
-            subprocess.run(["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", "mmd", "-i", out_file, "::/" + path], check=True)
+            subprocess.run(
+                [
+                    "faketime",
+                    "-f",
+                    "1970-1-1 0:0:0",
+                    os.path.abspath(mtools),
+                    "-c",
+                    "mmd",
+                    "-i",
+                    out_file,
+                    "::/" + path,
+                ],
+                check=True,
+            )
         elif member.type == tarfile.REGTYPE or member.type == tarfile.AREGTYPE:
             with open(os.path.join(fs_basedir, path), "wb") as f:
                 f.write(tf.extractfile(member).read())
             subprocess.run(
-                ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", "mcopy", "-o", "-i", out_file, os.path.join(fs_basedir, path), "::/" + path],
+                [
+                    "faketime",
+                    "-f",
+                    "1970-1-1 0:0:0",
+                    os.path.abspath(mtools),
+                    "-c",
+                    "mcopy",
+                    "-o",
+                    "-i",
+                    out_file,
+                    os.path.join(fs_basedir, path),
+                    "::/" + path,
+                ],
                 check=True,
             )
         else:
@@ -56,7 +82,19 @@ def install_extra_files(out_file, extra_files, path_transform, mtools):
         if install_target[0] == "/":
             install_target = install_target[1:]
         subprocess.run(
-            ["faketime", "-f", "1970-1-1 0:0:0", os.path.abspath(mtools), "-c", "mcopy", "-o", "-i", out_file, source_file, "::/" + path_transform(install_target)],
+            [
+                "faketime",
+                "-f",
+                "1970-1-1 0:0:0",
+                os.path.abspath(mtools),
+                "-c",
+                "mcopy",
+                "-o",
+                "-i",
+                out_file,
+                source_file,
+                "::/" + path_transform(install_target),
+            ],
             check=True,
         )
 

--- a/toolchains/sysimage/toolchain.bzl
+++ b/toolchains/sysimage/toolchain.bzl
@@ -242,7 +242,7 @@ vfat_image = _icos_build_rule(
             allow_single_file = True,
         ),
         "_mtools": attr.label(
-            default = "//:mtools",
+            default = "@mtools//:mtools",
             cfg = "exec",
             allow_single_file = True,
         ),
@@ -342,7 +342,7 @@ fat32_image = _icos_build_rule(
             allow_single_file = True,
         ),
         "_mtools": attr.label(
-            default = "//:mtools",
+            default = "@mtools//:mtools",
             cfg = "exec",
             allow_single_file = True,
         ),


### PR DESCRIPTION
This partly reverts, partly simplifies some of the slop introduced when `mtools` was moved from the Dockefile to Bazel.