### PR TITLE
chore: avoid container system tools in partition tools test

### DIFF
--- a/rs/ic_os/build_tools/partition_tools/BUILD.bazel
+++ b/rs/ic_os/build_tools/partition_tools/BUILD.bazel
@@ -23,10 +23,6 @@ rust_library(
 rust_test(
     name = "partition_tools_test",
     crate = ":partition_tools",
-    proc_macro_deps = [
-        # Keep sorted.
-        "@crate_index//:indoc",
-    ],
     data = [
         "@dosfstools//:mkfs.fat",
         "@mtools//:mcopy",
@@ -35,6 +31,10 @@ rust_test(
         "MKFS_FAT": "$(rootpath @dosfstools//:mkfs.fat)",
         "MCOPY": "$(rootpath @mtools//:mcopy)",
     },
+    proc_macro_deps = [
+        # Keep sorted.
+        "@crate_index//:indoc",
+    ],
     deps = [
         # Keep sorted.
         "@crate_index//:anyhow",

--- a/rs/ic_os/build_tools/partition_tools/BUILD.bazel
+++ b/rs/ic_os/build_tools/partition_tools/BUILD.bazel
@@ -27,6 +27,14 @@ rust_test(
         # Keep sorted.
         "@crate_index//:indoc",
     ],
+    data = [
+        "@dosfstools//:mkfs.fat",
+        "@mtools//:mcopy",
+    ],
+    env = {
+        "MKFS_FAT": "$(rootpath @dosfstools//:mkfs.fat)",
+        "MCOPY": "$(rootpath @mtools//:mcopy)",
+    },
     deps = [
         # Keep sorted.
         "@crate_index//:anyhow",

--- a/rs/ic_os/build_tools/partition_tools/src/fat.rs
+++ b/rs/ic_os/build_tools/partition_tools/src/fat.rs
@@ -11,6 +11,15 @@ pub struct FatPartition {
     original: PathBuf,
 }
 
+/// Try to infer the path of the mcopy binary
+fn mcopy_bin() -> String {
+    std::env::var("MCOPY").unwrap_or( "mcopy".to_string() /* default to PATH lookup */ )
+}
+
+fn mkfs_fat_bin() -> String {
+    std::env::var("MKFS_FAT").unwrap_or( "/usr/sbin/mkfs.fat".to_string() /* default to system binary */ )
+}
+
 impl Partition for FatPartition {
     /// Open a fat3 partition for writing, via mtools. There is nothing to do
     /// here, as mtools works in place.
@@ -41,7 +50,7 @@ impl Partition for FatPartition {
     /// Copy a file into place
     fn write_file(&mut self, input: &Path, output: &Path) -> Result<()> {
         let out = if let Some(offset) = self.offset_bytes {
-            Command::new("mcopy")
+            Command::new(mcopy_bin())
                 .args([
                     "-o",
                     "-i",
@@ -52,7 +61,7 @@ impl Partition for FatPartition {
                 .output()
                 .context("failed to run mcopy")?
         } else {
-            Command::new("mcopy")
+            Command::new(mcopy_bin())
                 .args([
                     "-o",
                     "-i",
@@ -83,7 +92,7 @@ impl Partition for FatPartition {
         );
 
         let out = if let Some(offset) = self.offset_bytes {
-            Command::new("mcopy")
+            Command::new(mcopy_bin())
                 .args([
                     "-s", // recursive copy
                     "-o", // overwrite existing files
@@ -95,7 +104,7 @@ impl Partition for FatPartition {
                 .output()
                 .context("failed to run mcopy")?
         } else {
-            Command::new("mcopy")
+            Command::new(mcopy_bin())
                 .args([
                     "-s", // recursive copy
                     "-o", // overwrite existing files
@@ -147,7 +156,7 @@ impl FatPartition {
     // Capture and return stdout, which may be used to "read" the file directly
     fn copy_file_inner(&mut self, from: &Path, to: &Path) -> Result<Vec<u8>> {
         let out = if let Some(offset) = self.offset_bytes {
-            Command::new("mcopy")
+            Command::new(mcopy_bin())
                 .args([
                     "-o",
                     "-i",
@@ -158,7 +167,7 @@ impl FatPartition {
                 .output()
                 .context("failed to run mcopy")?
         } else {
-            Command::new("mcopy")
+            Command::new(mcopy_bin())
                 .args([
                     "-o",
                     "-i",
@@ -194,7 +203,7 @@ mod test {
             ])
             .status()?;
 
-        Command::new("/usr/sbin/mkfs.fat")
+        Command::new(mkfs_fat_bin())
             .args(["-F", "32", "-i", "0"])
             .arg(path.as_os_str())
             .status()?;

--- a/rs/ic_os/build_tools/partition_tools/src/fat.rs
+++ b/rs/ic_os/build_tools/partition_tools/src/fat.rs
@@ -13,11 +13,13 @@ pub struct FatPartition {
 
 /// Try to infer the path of the mcopy binary
 fn mcopy_bin() -> String {
-    std::env::var("MCOPY").unwrap_or( "mcopy".to_string() /* default to PATH lookup */ )
+    std::env::var("MCOPY").unwrap_or("mcopy".to_string() /* default to PATH lookup */)
 }
 
 fn mkfs_fat_bin() -> String {
-    std::env::var("MKFS_FAT").unwrap_or( "/usr/sbin/mkfs.fat".to_string() /* default to system binary */ )
+    std::env::var("MKFS_FAT").unwrap_or(
+        "/usr/sbin/mkfs.fat".to_string(), /* default to system binary */
+    )
 }
 
 impl Partition for FatPartition {

--- a/rs/ic_os/build_tools/partition_tools/src/fat.rs
+++ b/rs/ic_os/build_tools/partition_tools/src/fat.rs
@@ -16,6 +16,7 @@ fn mcopy_bin() -> String {
     std::env::var("MCOPY").unwrap_or("mcopy".to_string() /* default to PATH lookup */)
 }
 
+#[cfg(test)]
 fn mkfs_fat_bin() -> String {
     std::env::var("MKFS_FAT").unwrap_or(
         "/usr/sbin/mkfs.fat".to_string(), /* default to system binary */

--- a/third_party/BUILD.mtools.bazel
+++ b/third_party/BUILD.mtools.bazel
@@ -39,7 +39,10 @@ configure_make(
     # mtools compiles in its built-in codepage tables instead of calling iconv.
     env = {"ac_cv_header_iconv_h": "no"},
     lib_source = ":all_srcs",
-    out_binaries = ["mtools", "mcopy"],
+    out_binaries = [
+        "mtools",
+        "mcopy",
+    ],
     # We don't ship any libs out of this build.
     out_shared_libs = [],
     out_static_libs = [],

--- a/third_party/BUILD.mtools.bazel
+++ b/third_party/BUILD.mtools.bazel
@@ -39,7 +39,7 @@ configure_make(
     # mtools compiles in its built-in codepage tables instead of calling iconv.
     env = {"ac_cv_header_iconv_h": "no"},
     lib_source = ":all_srcs",
-    out_binaries = ["mtools"],
+    out_binaries = ["mtools", "mcopy"],
     # We don't ship any libs out of this build.
     out_shared_libs = [],
     out_static_libs = [],
@@ -57,5 +57,12 @@ filegroup(
     name = "mtools",
     srcs = [":mtools_build"],
     output_group = "mtools",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "mcopy",
+    srcs = [":mtools_build"],
+    output_group = "mcopy",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This migrates the `partition_tools/src/fat.rs` and test to use the Bazel-provided tools whenever possible, keeping a system fallback for dependents that do not (yet) thread the Bazel-provided tools through.