### PR TITLE
refactor: Consolidate hash_lazy_tree and hash_lazy_tree_with_baseline

### DIFF
--- a/rs/canonical_state/src/lazy_tree_conversion.rs
+++ b/rs/canonical_state/src/lazy_tree_conversion.rs
@@ -863,7 +863,7 @@ fn expand_canister<const V: u32>(source: &SubtreeSource) -> Result<HashTree, Has
     let canister = source.downcast::<CanisterState>();
     let version = CertificationVersion::try_from(V)
         .expect("const version parameter is a valid certification version");
-    hash_lazy_tree(&fork(CanisterFork { canister, version }))
+    hash_lazy_tree(&fork(CanisterFork { canister, version }), None)
 }
 
 /// Selects the [`expand_canister`] monomorphization for `version`, so the

--- a/rs/canonical_state/tests/hash_tree.rs
+++ b/rs/canonical_state/tests/hash_tree.rs
@@ -16,7 +16,8 @@ use ic_types::time::UNIX_EPOCH;
 fn simple_state_old_vs_new_hashing() {
     let state = ReplicatedState::new(subnet_test_id(1), SubnetType::Application);
 
-    let hash_tree = hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0))).unwrap();
+    let hash_tree =
+        hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0)), None).unwrap();
     let crypto_hash_tree =
         crypto_hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0)));
 
@@ -30,7 +31,8 @@ fn many_canister_state_old_vs_new_hashing() {
         insert_dummy_canister(&mut state, canister_test_id(i), user_test_id(24).get());
     }
 
-    let hash_tree = hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0))).unwrap();
+    let hash_tree =
+        hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0)), None).unwrap();
     let crypto_hash_tree =
         crypto_hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0)));
 
@@ -54,7 +56,8 @@ fn large_history_state_old_vs_new_hashing() {
         );
     }
 
-    let hash_tree = hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0))).unwrap();
+    let hash_tree =
+        hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0)), None).unwrap();
     let crypto_hash_tree =
         crypto_hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0)));
 
@@ -80,7 +83,8 @@ fn large_history_and_canisters_state_old_vs_new_hashing() {
         );
     }
 
-    let hash_tree = hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0))).unwrap();
+    let hash_tree =
+        hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0)), None).unwrap();
     let crypto_hash_tree =
         crypto_hash_lazy_tree(&replicated_state_as_lazy_tree(&state, Height::new(0)));
 

--- a/rs/canonical_state/tree_hash/src/hash_tree.rs
+++ b/rs/canonical_state/tree_hash/src/hash_tree.rs
@@ -996,31 +996,16 @@ impl<'a> BaselineCursor<'a> {
 /// The resulting tree has the exact same root hash as a fully materialized
 /// build; witnesses that descend into a stubbed subtree rebuild it on demand
 /// from the [`SubtreeSource`] held in the stub (see [`HashTree::witness`]).
-pub fn hash_lazy_tree(t: &LazyTree<'_>) -> Result<HashTree, HashTreeError> {
-    hash_lazy_tree_impl(t, None)
-}
-
-/// Like [`hash_lazy_tree`], but reuses the [`NodeKind::Stub`] nodes of
-/// unchanged subtrees from `baseline`.
 ///
-/// The new lazy tree and the baseline tree are traversed in lockstep (children
-/// merge-joined by label). Wherever a child carries a [`SubtreeSource`] equal
-/// to the one the baseline stores under the same label the baseline's stored
-/// digest is reused instead of building and hashing the subtree.
-///
-/// The result is identical (same root hash, same witnesses) to a full
-/// [`hash_lazy_tree`] build, regardless of `baseline`. In particular, a
-/// `baseline` built under a different certification version is safe to pass:
-/// its subtrees carry a different expander, so none of them are reused (they
-/// are simply rebuilt).
-pub fn hash_lazy_tree_with_baseline<'a>(
-    t: &LazyTree<'a>,
-    baseline: &'a HashTree,
-) -> Result<HashTree, HashTreeError> {
-    hash_lazy_tree_impl(t, Some(baseline))
-}
-
-fn hash_lazy_tree_impl<'a>(
+/// If a `baseline` tree is provided, the [`NodeKind::Stub`] nodes of unchanged
+/// subtrees are reused from it: the lazy tree and the baseline are traversed in
+/// lockstep (children merge-joined by label), and wherever a child carries an
+/// equal [`SubtreeSource`], it is reused instead of rebuilt. The result is
+/// identical (same root hash, same witnesses) regardless of `baseline`; in
+/// particular, a `baseline` built under a different certification version is
+/// safe to pass: its subtrees carry a different expander, so none of them are
+/// reused (they are simply rebuilt).
+pub fn hash_lazy_tree<'a>(
     t: &LazyTree<'a>,
     baseline: Option<&'a HashTree>,
 ) -> Result<HashTree, HashTreeError> {

--- a/rs/canonical_state/tree_hash/test_utils/src/lib.rs
+++ b/rs/canonical_state/tree_hash/test_utils/src/lib.rs
@@ -25,7 +25,7 @@ const EMPTY_HASH: Digest = Digest([
 ///
 /// Also check that the new and old way of computing hash trees are equivalent.
 pub fn test_membership_witness<R: Rng + CryptoRng>(full_tree: &LabeledTree<Vec<u8>>, rng: &mut R) {
-    let hash_tree = hash_lazy_tree(&as_lazy(full_tree)).unwrap();
+    let hash_tree = hash_lazy_tree(&as_lazy(full_tree), None).unwrap();
     let witness_gen = build_witness_gen(full_tree);
 
     let paths = partial_trees_to_leaves_and_empty_subtrees(full_tree);

--- a/rs/canonical_state/tree_hash/tests/hash_tree.rs
+++ b/rs/canonical_state/tree_hash/tests/hash_tree.rs
@@ -75,7 +75,7 @@ fn test_too_many_recursions_error() {
         });
     }
 
-    assert!(hash_lazy_tree(&as_lazy(&tree)).is_ok());
+    assert!(hash_lazy_tree(&as_lazy(&tree), None).is_ok());
 
     // Error with one extra depth
     tree = LabeledTree::SubTree(flatmap! {
@@ -83,7 +83,7 @@ fn test_too_many_recursions_error() {
     });
 
     assert_matches!(
-        hash_lazy_tree(&as_lazy(&tree)),
+        hash_lazy_tree(&as_lazy(&tree), None),
         Err(HashTreeError::RecursionTooDeep(MAX_RECURSION_DEPTH))
     );
 }
@@ -100,7 +100,7 @@ fn test_non_existence_proof() {
         }),
     });
 
-    let hash_tree = hash_lazy_tree(&as_lazy(&t)).unwrap();
+    let hash_tree = hash_lazy_tree(&as_lazy(&t), None).unwrap();
     let ht_witness = hash_tree
         .witness::<MixedHashTree>(&LabeledTree::SubTree(
             flatmap! { Label::from("Z") => LabeledTree::Leaf(b"12345".to_vec()) },

--- a/rs/canonical_state/tree_hash/tests/subtree.rs
+++ b/rs/canonical_state/tree_hash/tests/subtree.rs
@@ -9,11 +9,12 @@
 //!   * has the exact same root hash as a fully materialized build,
 //!   * serves witnesses by expanding the stub on demand from the source `Arc`
 //!     it holds (via its [`SubtreeExpander`]), with no external source, and
-//!   * when built with a baseline ([`hash_lazy_tree_with_baseline`]), reuses the
-//!     stored digest of every unchanged subtree (matched by `SubtreeSource`).
+//!   * when built with a baseline (`hash_lazy_tree` with `Some(baseline)`),
+//!     reuses the stored digest of every unchanged subtree (matched by
+//!     `SubtreeSource`).
 
 use ic_canonical_state_tree_hash::hash_tree::{
-    HashTree, HashTreeError, PARALLEL_MIN_CHILDREN, hash_lazy_tree, hash_lazy_tree_with_baseline,
+    HashTree, HashTreeError, PARALLEL_MIN_CHILDREN, hash_lazy_tree,
 };
 use ic_canonical_state_tree_hash::lazy_tree::{LazyFork, LazyTree, SubtreeSource, fork};
 use ic_canonical_state_tree_hash_test_utils::as_lazy;
@@ -109,7 +110,7 @@ impl<'a> LazyFork<'a> for CanisterFork<'a> {
 /// `expand_canister` in production, minus the certification version).
 fn expand_test_canister(source: &SubtreeSource) -> Result<HashTree, HashTreeError> {
     let canister = source.downcast::<LabeledTree<Vec<u8>>>();
-    hash_lazy_tree(&canister_fork(canister))
+    hash_lazy_tree(&canister_fork(canister), None)
 }
 
 /// A `LazyFork` over the `/canister` subtree.
@@ -245,7 +246,7 @@ fn canister_partial(i: usize) -> LabeledTree<Vec<u8>> {
 #[test]
 fn every_canister_is_a_subtree() {
     let canisters = canisters();
-    let tree = hash_lazy_tree(&state_tree(&canisters, TIME)).unwrap();
+    let tree = hash_lazy_tree(&state_tree(&canisters, TIME), None).unwrap();
 
     assert_eq!(
         tree.stub_count(),
@@ -258,7 +259,7 @@ fn every_canister_is_a_subtree() {
 fn witnesses_into_canisters_expand_from_source() {
     let canisters = canisters();
     let source = state_tree(&canisters, TIME);
-    let tree = hash_lazy_tree(&source).unwrap();
+    let tree = hash_lazy_tree(&source, None).unwrap();
 
     // Whole-canister witnesses across both the sequential and parallel ranges.
     for i in [
@@ -301,7 +302,7 @@ fn witnesses_into_canisters_expand_from_source() {
 fn absence_witnesses_expand_from_source() {
     let canisters = canisters();
     let source = state_tree(&canisters, TIME);
-    let tree = hash_lazy_tree(&source).unwrap();
+    let tree = hash_lazy_tree(&source, None).unwrap();
 
     // Absent canister id (proven at the `/canister` node, no stub descent).
     let partial = LabeledTree::SubTree(flatmap! {
@@ -343,16 +344,15 @@ fn absence_witnesses_expand_from_source() {
 #[test]
 fn baseline_build_matches_from_scratch() {
     let canisters = canisters();
-    let baseline = hash_lazy_tree(&state_tree(&canisters, TIME)).unwrap();
+    let baseline = hash_lazy_tree(&state_tree(&canisters, TIME), None).unwrap();
 
     // Mutate a single canister (fresh `Arc`) and change `time`; keep the rest.
     let mut next = canisters.clone();
     next.insert(canister_id_label(50), Arc::new(canister_subtree(9999)));
     let new_time: &[u8] = &[9, 9, 9, 9];
 
-    let from_scratch = hash_lazy_tree(&state_tree(&next, new_time)).unwrap();
-    let with_baseline =
-        hash_lazy_tree_with_baseline(&state_tree(&next, new_time), &baseline).unwrap();
+    let from_scratch = hash_lazy_tree(&state_tree(&next, new_time), None).unwrap();
+    let with_baseline = hash_lazy_tree(&state_tree(&next, new_time), Some(&baseline)).unwrap();
 
     assert_eq!(
         from_scratch.root_hash(),
@@ -381,15 +381,15 @@ fn baseline_build_matches_from_scratch() {
 #[test]
 fn baseline_build_with_partial_change_matches_from_scratch() {
     let canisters = canisters();
-    let baseline = hash_lazy_tree(&state_tree(&canisters, TIME)).unwrap();
+    let baseline = hash_lazy_tree(&state_tree(&canisters, TIME), None).unwrap();
 
     // A `BTreeMap` clone shares the canister `Arc`s; only canister 50 gets a
     // fresh `Arc` (a real mutation), so only it is rebuilt.
     let mut next = canisters.clone();
     next.insert(canister_id_label(50), Arc::new(canister_subtree(50)));
 
-    let with_baseline = hash_lazy_tree_with_baseline(&state_tree(&next, TIME), &baseline).unwrap();
-    let from_scratch = hash_lazy_tree(&state_tree(&next, TIME)).unwrap();
+    let with_baseline = hash_lazy_tree(&state_tree(&next, TIME), Some(&baseline)).unwrap();
+    let from_scratch = hash_lazy_tree(&state_tree(&next, TIME), None).unwrap();
 
     assert_eq!(with_baseline.stub_count(), NUM_CANISTERS);
     assert_eq!(with_baseline.root_hash(), from_scratch.root_hash());
@@ -414,11 +414,11 @@ fn disjoint_stub_sources(a: &HashTree, b: &HashTree) -> bool {
 #[test]
 fn reuse_is_by_identity_not_by_value() {
     let canisters = canisters();
-    let baseline = hash_lazy_tree(&state_tree(&canisters, TIME)).unwrap();
+    let baseline = hash_lazy_tree(&state_tree(&canisters, TIME), None).unwrap();
 
     // Rebuilding against the baseline with the *same* `Arc`s: every stub holds the
     // very same source allocation as the baseline (identity is preserved).
-    let unchanged = hash_lazy_tree_with_baseline(&state_tree(&canisters, TIME), &baseline).unwrap();
+    let unchanged = hash_lazy_tree(&state_tree(&canisters, TIME), Some(&baseline)).unwrap();
     assert!(same_stub_sources(&baseline, &unchanged));
 
     // Replace *every* canister with a fresh `Arc` of the same contents.
@@ -426,7 +426,7 @@ fn reuse_is_by_identity_not_by_value() {
         .map(|i| (canister_id_label(i), Arc::new(canister_subtree(i))))
         .collect();
 
-    let with_baseline = hash_lazy_tree_with_baseline(&state_tree(&next, TIME), &baseline).unwrap();
+    let with_baseline = hash_lazy_tree(&state_tree(&next, TIME), Some(&baseline)).unwrap();
 
     // No stub shares a source `Arc` with the baseline, so no digest could have been
     // reused (every `Arc` is fresh, so no identity matches).

--- a/rs/canonical_state/tree_hash/tests/subtree.rs
+++ b/rs/canonical_state/tree_hash/tests/subtree.rs
@@ -9,9 +9,9 @@
 //!   * has the exact same root hash as a fully materialized build,
 //!   * serves witnesses by expanding the stub on demand from the source `Arc`
 //!     it holds (via its [`SubtreeExpander`]), with no external source, and
-//!   * when built with a baseline (`hash_lazy_tree` with `Some(baseline)`),
+//!   * when built with a baseline ([`hash_lazy_tree`] with `Some(baseline)`),
 //!     reuses the stored digest of every unchanged subtree (matched by
-//!     `SubtreeSource`).
+//!     [`SubtreeSource`]).
 
 use ic_canonical_state_tree_hash::hash_tree::{
     HashTree, HashTreeError, PARALLEL_MIN_CHILDREN, hash_lazy_tree,

--- a/rs/consensus/certification/src/certifier.rs
+++ b/rs/consensus/certification/src/certifier.rs
@@ -725,7 +725,7 @@ mod tests {
         height: Height,
     ) -> (Witness, CryptoHashOfPartialState) {
         let lazy_tree = replicated_state_as_lazy_tree(state, height);
-        let hash_tree = hash_lazy_tree(&lazy_tree).unwrap();
+        let hash_tree = hash_lazy_tree(&lazy_tree, None).unwrap();
         let paths = vec![vec![].into()];
         let labeled_tree = sparse_labeled_tree_from_paths(&paths).unwrap();
         let partial_tree = materialize_partial(&lazy_tree, &labeled_tree, None);

--- a/rs/crypto/tree_hash/fuzz/check_witness_equality_utils/src/lib.rs
+++ b/rs/crypto/tree_hash/fuzz/check_witness_equality_utils/src/lib.rs
@@ -19,7 +19,7 @@ mod tests;
 /// - and combinations of the former with existing paths in the tree
 ///   the witness looks the same for both implementations.
 pub fn test_absence_witness<R: Rng + CryptoRng>(full_tree: &LabeledTree<Vec<u8>>, rng: &mut R) {
-    let hash_tree = hash_lazy_tree(&as_lazy(full_tree)).expect("failed to create hash tree");
+    let hash_tree = hash_lazy_tree(&as_lazy(full_tree), None).expect("failed to create hash tree");
     let witness_gen = build_witness_gen(full_tree);
 
     // Traverse the tree and produce a list of paths and absent ranges,

--- a/rs/http_endpoints/public/tests/common/mod.rs
+++ b/rs/http_endpoints/public/tests/common/mod.rs
@@ -187,7 +187,7 @@ pub fn default_read_certified_state(
 )> {
     let height = latest_state.height();
     let lazy_tree = replicated_state_as_lazy_tree(latest_state.get_ref(), height);
-    let hash_tree = hash_lazy_tree(&lazy_tree).unwrap();
+    let hash_tree = hash_lazy_tree(&lazy_tree, None).unwrap();
     let partial_tree = materialize_partial(&lazy_tree, labeled_tree, None);
     let mht = hash_tree.witness::<MixedHashTree>(&partial_tree).unwrap();
     let cert = Certification {

--- a/rs/state_manager/benches/bench_traversal.rs
+++ b/rs/state_manager/benches/bench_traversal.rs
@@ -2,7 +2,7 @@ use criterion::measurement::Measurement;
 use criterion::{BatchSize, BenchmarkId, Criterion, black_box};
 use ic_base_types::{NumBytes, NumSeconds};
 use ic_canonical_state::{lazy_tree_conversion::replicated_state_as_lazy_tree, traverse};
-use ic_canonical_state_tree_hash::hash_tree::{hash_lazy_tree, hash_lazy_tree_with_baseline};
+use ic_canonical_state_tree_hash::hash_tree::hash_lazy_tree;
 use ic_canonical_state_tree_hash_test_utils::{build_witness_gen, crypto_hash_lazy_tree};
 use ic_certification_version::CURRENT_CERTIFICATION_VERSION;
 use ic_crypto_tree_hash::{FlatMap, Label, LabeledTree, MixedHashTree, WitnessGenerator, flatmap};
@@ -130,7 +130,7 @@ fn bench_traversal<M: Measurement + 'static>(c: &mut Criterion<M>) {
     let height = Height::new(0);
     assert_eq!(
         hash_state(&state, height).digest(),
-        hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height))
+        hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height), None)
             .unwrap()
             .root_hash(),
     );
@@ -143,19 +143,19 @@ fn bench_traversal<M: Measurement + 'static>(c: &mut Criterion<M>) {
         let mut tree = None;
         b.iter(|| {
             tree = Some(black_box(
-                hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height)).unwrap(),
+                hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height), None).unwrap(),
             ));
         });
         std::mem::drop(tree);
     });
 
-    let baseline = hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height)).unwrap();
+    let baseline = hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height), None).unwrap();
     c.bench_function("traverse/hash_tree_cached", |b| {
         b.iter(|| {
             black_box(
-                hash_lazy_tree_with_baseline(
+                hash_lazy_tree(
                     &replicated_state_as_lazy_tree(&state, height),
-                    &baseline,
+                    Some(&baseline),
                 )
                 .unwrap(),
             )
@@ -246,7 +246,8 @@ fn bench_traversal<M: Measurement + 'static>(c: &mut Criterion<M>) {
     });
 
     c.bench_function("traverse/certify_response/100/new", |b| {
-        let hash_tree = hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height)).unwrap();
+        let hash_tree =
+            hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height), None).unwrap();
         b.iter(|| {
             black_box(
                 hash_tree
@@ -275,10 +276,10 @@ fn bench_traversal<M: Measurement + 'static>(c: &mut Criterion<M>) {
     c.bench_function("traverse/hash_custom_sections/100", |b| {
         b.iter(|| {
             black_box(
-                hash_lazy_tree(&replicated_state_as_lazy_tree(
-                    &state_100_custom_sections,
-                    height,
-                ))
+                hash_lazy_tree(
+                    &replicated_state_as_lazy_tree(&state_100_custom_sections, height),
+                    None,
+                )
                 .unwrap(),
             )
         });
@@ -292,7 +293,8 @@ fn bench_traversal<M: Measurement + 'static>(c: &mut Criterion<M>) {
     group.bench_function(
         BenchmarkId::new("canonical_state::HashTree", NUM_STATUSES),
         |b| {
-            let hash_tree = hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height)).unwrap();
+            let hash_tree =
+                hash_lazy_tree(&replicated_state_as_lazy_tree(&state, height), None).unwrap();
             b.iter_batched(|| hash_tree.clone(), std::mem::drop, BatchSize::LargeInput)
         },
     );

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -1921,7 +1921,7 @@ impl StateManagerImpl {
     ) -> Result<CertificationMetadata, HashTreeError> {
         let started_hashing_at = Instant::now();
         let lazy_tree = replicated_state_as_lazy_tree(state, height);
-        let hash_tree = hash_lazy_tree(&lazy_tree)?;
+        let hash_tree = hash_lazy_tree(&lazy_tree, None)?;
         let elapsed = started_hashing_at.elapsed();
         debug!(log, "Computed hash tree in {:?}", elapsed);
 
@@ -2052,7 +2052,7 @@ impl StateManagerImpl {
         states: &mut RwLockWriteGuard<'_, SharedState>,
     ) {
         let lazy_tree = replicated_state_as_lazy_tree(&state, height);
-        let hash_tree = hash_lazy_tree(&lazy_tree)
+        let hash_tree = hash_lazy_tree(&lazy_tree, None)
             .unwrap_or_else(|err| fatal!(self.log, "Failed to compute hash tree: {:?}", err));
         update_hash_tree_metrics(&hash_tree, &self.metrics);
         let height_witness = state_height_witness(&lazy_tree, &hash_tree, &self.metrics);

--- a/rs/test_utilities/src/state_manager.rs
+++ b/rs/test_utilities/src/state_manager.rs
@@ -125,7 +125,7 @@ impl FakeStateManager {
         height: Height,
     ) -> (Witness, CryptoHashOfPartialState) {
         let lazy_tree = replicated_state_as_lazy_tree(state, height);
-        let hash_tree = hash_lazy_tree(&lazy_tree).unwrap();
+        let hash_tree = hash_lazy_tree(&lazy_tree, None).unwrap();
         let height_witness = compute_state_height_witness(&lazy_tree, &hash_tree);
         let partial_hash =
             CryptoHashOfPartialState::from(CryptoHash(hash_tree.root_hash().0.to_vec()));


### PR DESCRIPTION
Merge `hash_lazy_tree(t)` and `hash_lazy_tree_with_baseline(t, baseline)` (plus
the private `hash_lazy_tree_impl`) into a single
`hash_lazy_tree(t, baseline: Option<&HashTree>)`, and update all call sites.

Pure cleanup, no behavior change — reduces the public surface ahead of the
ingress/stream subtree-reuse follow-up that builds on it.
