### PR TITLE
feat: [DSM-144] Reuse `IngressStatus` subtrees in `HashTree`

### DIFF
--- a/rs/canonical_state/src/lazy_tree_conversion.rs
+++ b/rs/canonical_state/src/lazy_tree_conversion.rs
@@ -644,6 +644,17 @@ impl<'a> LazyFork<'a> for IngressHistoryFork<'a> {
     fn len(&self) -> usize {
         self.0.len()
     }
+
+    /// Collapse ingress messages into reusable stubs identified by their respective
+    /// `Arc<IngressStatus>`.
+    fn stub_sources(&self) -> Option<Box<dyn Iterator<Item = (Label, SubtreeSource)> + '_>> {
+        Some(Box::new(self.0.statuses_arc().map(|(id, status)| {
+            (
+                Label::from(id.as_bytes()),
+                SubtreeSource::new(status, expand_ingress_status),
+            )
+        })))
+    }
 }
 
 const ERROR_CODE_LABEL: &[u8] = b"error_code";
@@ -714,16 +725,17 @@ const REJECT_STATUS_LABELS: [&[u8]; 4] = [
 #[derive(Clone)]
 struct RejectStatus<'a> {
     reject_code: u64,
-    error_code: Option<ErrorCode>,
+    error_code: ErrorCode,
     message: &'a str,
 }
 
 impl<'a> LazyFork<'a> for RejectStatus<'a> {
     fn edge(&self, label: &Label) -> Option<LazyTree<'a>> {
         match label.as_bytes() {
-            ERROR_CODE_LABEL => self
-                .error_code
-                .map(|code| blob(move || code.to_string().into_bytes())),
+            ERROR_CODE_LABEL => {
+                let error_code = self.error_code;
+                Some(blob(move || error_code.to_string().into_bytes()))
+            }
             REJECT_CODE_LABEL => Some(num::<'a>(self.reject_code)),
             REJECT_MESSAGE_LABEL => Some(string(self.message)),
             STATUS_LABEL => Some(string("rejected")),
@@ -749,18 +761,20 @@ impl<'a> LazyFork<'a> for RejectStatus<'a> {
     }
 }
 
+/// Produces one of a few small, focused [`LazyFork`] shapes (reply / reject /
+/// status-only) for the given [`IngressStatus`].
 fn status_to_tree(status: &IngressStatus) -> LazyTree<'_> {
     match status {
         IngressStatus::Known { state, .. } => match state {
             IngressState::Completed(WasmResult::Reply(b)) => fork(ReplyStatus(b)),
             IngressState::Completed(WasmResult::Reject(s)) => fork(RejectStatus {
                 reject_code: RejectCode::CanisterReject as u64,
-                error_code: Some(ErrorCode::CanisterRejectedMessage),
+                error_code: ErrorCode::CanisterRejectedMessage,
                 message: s,
             }),
             IngressState::Failed(error) => fork(RejectStatus {
                 reject_code: error.reject_code() as u64,
-                error_code: Some(error.code()),
+                error_code: error.code(),
                 message: error.description(),
             }),
             IngressState::Processing | IngressState::Received | IngressState::Done => {
@@ -769,6 +783,13 @@ fn status_to_tree(status: &IngressStatus) -> LazyTree<'_> {
         },
         IngressStatus::Unknown => fork(OnlyStatus(status.as_str())),
     }
+}
+
+/// Materializes a stubbed ingress message's [`HashTree`], by recovering the
+/// `&IngressStatus` from the stub's [`SubtreeSource`].
+fn expand_ingress_status(source: &SubtreeSource) -> Result<HashTree, HashTreeError> {
+    let status = source.downcast::<IngressStatus>();
+    hash_lazy_tree(&status_to_tree(status), None)
 }
 
 const CERTIFIED_DATA_LABEL: &[u8] = b"certified_data";

--- a/rs/replicated_state/src/metadata_state.rs
+++ b/rs/replicated_state/src/metadata_state.rs
@@ -62,7 +62,7 @@ pub struct SystemMetadata {
     /// system.
     pub ingress_history: IngressHistoryState,
 
-    /// XNet stream state indexed by the _destination_ subnet id.
+    /// XNet stream state indexed by the _destination_ subnet ID.
     pub(super) streams: Arc<StreamMap>,
 
     /// Scheduling priorities of the canisters on this subnet.
@@ -174,7 +174,7 @@ pub struct SystemMetadata {
     pub bitcoin_get_successors_follow_up_responses: BTreeMap<CanisterId, Vec<BlockBlob>>,
 
     /// Metrics collecting blockmaker stats (block proposed and failures to propose a block)
-    /// by aggregating them and storing a running total over multiple days by node id and
+    /// by aggregating them and storing a running total over multiple days by node ID and
     /// timestamp. Observations of blockmaker stats are performed each time a batch is processed.
     pub blockmaker_metrics_time_series: BlockmakerMetricsTimeSeries,
 
@@ -244,7 +244,7 @@ pub struct NetworkTopology {
     full_topology: Option<FullTopology>,
 
     /// Subnet to which `SetupInitialDKG` management canister calls are routed
-    /// by default, i.e., when no subnet id is specified explicitly in the
+    /// by default, i.e., when no subnet ID is specified explicitly in the
     /// request. If `None`, such requests are routed to the calling subnet.
     pub default_initial_dkg_subnet_id: Option<SubnetId>,
 }
@@ -375,7 +375,7 @@ impl NetworkTopology {
             .unwrap_or(&self.routing_table)
     }
 
-    /// Find the subnet for `principal_id`. The input can either be a canister id, or a subnet id.
+    /// Find the subnet for `principal_id`. The input can either be a canister ID, or a subnet ID.
     pub fn route(&self, principal_id: PrincipalId) -> Option<SubnetId> {
         let as_subnet_id = SubnetId::from(principal_id);
         if self.subnets.contains_key(&as_subnet_id) {
@@ -1599,7 +1599,7 @@ impl IngressHistoryState {
         ingress_memory_capacity: NumBytes,
         observe_time_in_terminal_state: impl Fn(u64),
     ) -> Arc<IngressStatus> {
-        // Store the associated expiry time for the given message id only for a
+        // Store the associated expiry time for the given message ID only for a
         // "terminal" ingress status. This way we are not risking deleting any status
         // for a message that is still not in a terminal status.
         if let IngressStatus::Known { state, .. } = &status
@@ -1640,11 +1640,17 @@ impl IngressHistoryState {
     }
 
     /// Returns an iterator over response statuses, sorted lexicographically by
-    /// message id.
+    /// message ID.
     pub fn statuses(&self) -> impl Iterator<Item = (&MessageId, &IngressStatus)> {
         self.statuses
             .iter()
             .map(|(id, status)| (id, status.as_ref()))
+    }
+
+    /// Returns an iterator over the backing `Arc<IngressStatus>` of each entry,
+    /// sorted lexicographically by message ID.
+    pub fn statuses_arc(&self) -> impl Iterator<Item = (&MessageId, &Arc<IngressStatus>)> {
+        self.statuses.iter()
     }
 
     /// Returns an iterator over pruning times statuses, sorted


### PR DESCRIPTION
Extend canister subtree reuse to ingress history: each message's certified subtree is stored as a reusable stub keyed by its backing `Arc<IngressStatus>`. `IngressHistoryFork` declares `stub_sources` and `expand_ingress_status` rebuilds a stub. Adds an `Arc`-returning iterator (`statuses_arc`) to `IngressHistoryState`.