### PR TITLE
feat: [DSM-144] Reuse stream message subtrees in `HashTree`

### DIFF
--- a/rs/canonical_state/src/lazy_tree_conversion.rs
+++ b/rs/canonical_state/src/lazy_tree_conversion.rs
@@ -32,7 +32,7 @@ use ic_replicated_state::{
 use ic_types::{
     CanisterId, Height, NodeId, PrincipalId, SubnetId,
     ingress::{IngressState, IngressStatus, WasmResult},
-    messages::{EXPECTED_MESSAGE_ID_LENGTH, MessageId},
+    messages::{EXPECTED_MESSAGE_ID_LENGTH, MessageId, Refund, Request, Response, StreamMessage},
     xnet::{StreamHeader, StreamIndex, StreamIndexedQueue},
 };
 use std::convert::{AsRef, TryFrom, TryInto};
@@ -293,6 +293,10 @@ where
     queue: &'a StreamIndexedQueue<T>,
     certification_version: CertificationVersion,
     mk_tree: fn(StreamIndex, &'a T, CertificationVersion) -> LazyTree<'a>,
+    /// Produces a [`SubtreeSource`] for a child, to be used to create a reusable
+    /// [stub](`NodeKind::Stub`). Stream messages' contents are immutable once
+    /// enqueued, so the digest of any index present in a baseline can be reused.
+    mk_source: fn(&'a T, CertificationVersion) -> SubtreeSource,
 }
 
 impl<'a, T: Send + Sync> LazyFork<'a> for StreamQueueFork<'a, T> {
@@ -318,6 +322,14 @@ impl<'a, T: Send + Sync> LazyFork<'a> for StreamQueueFork<'a, T> {
 
     fn len(&self) -> usize {
         self.queue.len()
+    }
+
+    fn stub_sources(&self) -> Option<Box<dyn Iterator<Item = (Label, SubtreeSource)> + '_>> {
+        let mk_source = self.mk_source;
+        let version = self.certification_version;
+        Some(Box::new(self.queue.iter().map(move |(idx, v)| {
+            (idx.to_label(), mk_source(v, version))
+        })))
     }
 }
 
@@ -536,6 +548,7 @@ fn streams_as_tree<'a>(
                         mk_tree: |_idx, msg, certification_version| {
                             blob(move || encode_message(msg, certification_version))
                         },
+                        mk_source: message_source,
                     }),
                 ),
         )
@@ -557,6 +570,73 @@ fn streams_as_tree<'a>(
             certification_version,
             mk_tree,
         })
+    }
+}
+
+/// Expands `$ty`/`$variant` to a 1-leaf [`HashTree`] (re-encoding the message
+/// under the const certification version `V`), and a `select_*` helper that
+/// picks the `V`-specific monomorphization — so the stored function pointer
+/// alone fully determines the expansion. See [`message_source`].
+macro_rules! message_expander {
+    ($expand:ident, $select:ident, $ty:ty, $variant:path) => {
+        fn $expand<const V: u32>(source: &SubtreeSource) -> Result<HashTree, HashTreeError> {
+            let inner = source.downcast_arc::<$ty>();
+            let version = CertificationVersion::try_from(V)
+                .expect("const version parameter is a valid certification version");
+            let msg = $variant(inner);
+            hash_lazy_tree(&blob(move || encode_message(&msg, version)), None)
+        }
+
+        fn $select(version: CertificationVersion) -> SubtreeExpander {
+            match version {
+                CertificationVersion::V19 => $expand::<{ CertificationVersion::V19 as u32 }>,
+                CertificationVersion::V20 => $expand::<{ CertificationVersion::V20 as u32 }>,
+                CertificationVersion::V21 => $expand::<{ CertificationVersion::V21 as u32 }>,
+                CertificationVersion::V22 => $expand::<{ CertificationVersion::V22 as u32 }>,
+                CertificationVersion::V23 => $expand::<{ CertificationVersion::V23 as u32 }>,
+                CertificationVersion::V24 => $expand::<{ CertificationVersion::V24 as u32 }>,
+                CertificationVersion::V25 => $expand::<{ CertificationVersion::V25 as u32 }>,
+                CertificationVersion::V26 => $expand::<{ CertificationVersion::V26 as u32 }>,
+            }
+        }
+    };
+}
+
+message_expander!(
+    expand_request,
+    select_request_expander,
+    Request,
+    StreamMessage::Request
+);
+message_expander!(
+    expand_response,
+    select_response_expander,
+    Response,
+    StreamMessage::Response
+);
+message_expander!(
+    expand_refund,
+    select_refund_expander,
+    Refund,
+    StreamMessage::Refund
+);
+
+/// Produces a [`SubtreeSource`] for a stream message, identified by its backing
+/// `Arc<Request|Response|Refund>`, used to create a reusable
+/// [stub](`NodeKind::Stub`).
+///
+/// A message's contents never change once enqueued, so any index present in a
+/// baseline keeps the same `Arc` and its precomputed digest can be reused; only
+/// newly enqueued messages must be encoded and hashed.
+fn message_source(msg: &StreamMessage, version: CertificationVersion) -> SubtreeSource {
+    match msg {
+        StreamMessage::Request(req) => SubtreeSource::new(req, select_request_expander(version)),
+        StreamMessage::Response(resp) => {
+            SubtreeSource::new(resp, select_response_expander(version))
+        }
+        StreamMessage::Refund(refund) => {
+            SubtreeSource::new(refund, select_refund_expander(version))
+        }
     }
 }
 

--- a/rs/canonical_state/tree_hash/src/hash_tree.rs
+++ b/rs/canonical_state/tree_hash/src/hash_tree.rs
@@ -779,9 +779,16 @@ impl HashTree {
             if pos.kind() == NodeKind::Stub {
                 // A stub, only storing its root digest.
                 return match t {
-                    // Requested partial tree descends into the subtree: rebuild it from source and
-                    // continue witness generation there.
-                    LabeledTree::SubTree(children) if !children.is_empty() => {
+                    // Witness only needs the precomputed digest.
+                    LabeledTree::SubTree(children) if children.is_empty() => {
+                        Ok(B::make_pruned(ht.digest(pos).clone()))
+                    }
+
+                    // Requested partial tree descends into the subtree or requests its leaf value:
+                    // rebuild the subtree from source and continue witness generation there. (A
+                    // stubbed subtree may itself be a single leaf, e.g. a stream message, in which
+                    // case `t` is a `Leaf` whose value the witness must carry.)
+                    _ => {
                         // Sanity check: a complete `HashTree` has no bucket offset.
                         debug_assert_eq!(ht.bucket_offset, 0);
 
@@ -791,9 +798,6 @@ impl HashTree {
                             .expect("expanding a stub should not fail");
                         go::<B>(&expanded, NodeId::empty(), expanded.root, t)
                     }
-
-                    // Witness only needs the precomputed digest.
-                    _ => Ok(B::make_pruned(ht.digest(pos).clone())),
                 };
             }
 

--- a/rs/canonical_state/tree_hash/src/lazy_tree.rs
+++ b/rs/canonical_state/tree_hash/src/lazy_tree.rs
@@ -188,8 +188,11 @@ impl SubtreeSource {
         Arc::as_ptr(&self.source) as *const ()
     }
 
-    /// Borrows the source as a `&T`, for a [`SubtreeExpander`] to rebuild the
+    /// Borrows the source as a `&T`. Used by a [`SubtreeExpander`] to rebuild the
     /// subtree from its source without bumping the `Arc`'s refcount.
+    ///
+    /// Expanders that need shared ownership (i.e. to move the `Arc` somewhere) use
+    /// [`downcast_arc`](Self::downcast_arc).
     ///
     /// Panics if this handle was not created from an `Arc<T>`.
     pub fn downcast<T: Any + Send + Sync>(&self) -> &T {
@@ -199,6 +202,23 @@ impl SubtreeSource {
                 std::any::type_name::<T>()
             )
         })
+    }
+
+    /// Recovers shared ownership of the source as an `Arc<T>`. Used by a
+    /// [`SubtreeExpander`] that has to *move* the `Arc` into the rebuilt subtree;
+    /// expanders that only need to read the source should use the clone-free
+    /// [`downcast`](Self::downcast) instead.
+    ///
+    /// Panics if this handle was not created from an `Arc<T>`.
+    pub fn downcast_arc<T: Any + Send + Sync>(&self) -> Arc<T> {
+        Arc::clone(&self.source)
+            .downcast::<T>()
+            .unwrap_or_else(|_| {
+                panic!(
+                    "subtree source is not an Arc<{}>",
+                    std::any::type_name::<T>()
+                )
+            })
     }
 
     /// Rebuilds the subtree's [`HashTree`](crate::hash_tree::HashTree) from this

--- a/rs/canonical_state/tree_hash/tests/subtree.rs
+++ b/rs/canonical_state/tree_hash/tests/subtree.rs
@@ -408,6 +408,177 @@ fn disjoint_stub_sources(a: &HashTree, b: &HashTree) -> bool {
     a.stub_count() == b.stub_count() && a.stub_sources().zip(b.stub_sources()).all(|(x, y)| x != y)
 }
 
+// --- Leaf stubs (mirroring stream messages) -------------------------------
+//
+// Unlike canisters (whose subtree is a fork), a stream message's subtree is a
+// single *leaf*. A stubbed leaf must still serve its value in a witness (XNet
+// certification carries the actual message bytes), so requesting it as a
+// `LabeledTree::Leaf` expands the stub rather than pruning it.
+
+const MESSAGE_LABEL: &[u8] = b"message";
+
+/// A collection of messages, each behind its own `Arc` (as in production, where
+/// a `StreamMessage`'s payload is `Arc`-shared and immutable once enqueued).
+type Messages = BTreeMap<Label, Arc<Vec<u8>>>;
+
+fn message_id_label(i: usize) -> Label {
+    Label::from(format!("{i:08}"))
+}
+fn message_bytes(i: usize) -> Vec<u8> {
+    format!("message-payload-{i}").into_bytes()
+}
+
+fn messages(n: usize) -> Messages {
+    (0..n)
+        .map(|i| (message_id_label(i), Arc::new(message_bytes(i))))
+        .collect()
+}
+
+/// Rebuilds a stubbed message leaf from its source `Arc` (mirrors the per-variant
+/// `expand_*` message expanders in production).
+fn expand_test_message(source: &SubtreeSource) -> Result<HashTree, HashTreeError> {
+    let bytes = source.downcast::<Vec<u8>>();
+    hash_lazy_tree(&LazyTree::Blob(bytes.as_slice(), None), None)
+}
+
+/// A `LazyFork` whose children are all *leaves* (each a message blob), collapsed
+/// to reusable stubs via `stub_sources` (mirrors `StreamQueueFork` for messages).
+struct MessagesFork<'a> {
+    messages: &'a Messages,
+}
+
+impl<'a> LazyFork<'a> for MessagesFork<'a> {
+    fn edge(&self, l: &Label) -> Option<LazyTree<'a>> {
+        self.messages
+            .get(l)
+            .map(|arc| LazyTree::Blob(arc.as_slice(), None))
+    }
+
+    fn labels(&self) -> Box<dyn Iterator<Item = Label> + '_> {
+        Box::new(self.messages.keys().cloned())
+    }
+
+    fn children(&self) -> Box<dyn Iterator<Item = (Label, LazyTree<'a>)> + 'a> {
+        Box::new(
+            self.messages
+                .iter()
+                .map(|(l, arc)| (l.clone(), LazyTree::Blob(arc.as_slice(), None))),
+        )
+    }
+
+    fn len(&self) -> usize {
+        self.messages.len()
+    }
+
+    fn stub_sources(&self) -> Option<Box<dyn Iterator<Item = (Label, SubtreeSource)> + '_>> {
+        Some(Box::new(self.messages.iter().map(|(l, arc)| {
+            (l.clone(), SubtreeSource::new(arc, expand_test_message))
+        })))
+    }
+}
+
+/// The top-level fork `{message: {<id>: <blob>}}`.
+struct MessagesStateFork<'a> {
+    messages: &'a Messages,
+}
+
+fn messages_fork(messages: &Messages) -> LazyTree<'_> {
+    fork(MessagesFork { messages })
+}
+
+impl<'a> LazyFork<'a> for MessagesStateFork<'a> {
+    fn edge(&self, l: &Label) -> Option<LazyTree<'a>> {
+        (l.as_bytes() == MESSAGE_LABEL).then(|| messages_fork(self.messages))
+    }
+
+    fn labels(&self) -> Box<dyn Iterator<Item = Label> + '_> {
+        Box::new(std::iter::once(Label::from(MESSAGE_LABEL)))
+    }
+
+    fn children(&self) -> Box<dyn Iterator<Item = (Label, LazyTree<'a>)> + 'a> {
+        Box::new(std::iter::once((
+            Label::from(MESSAGE_LABEL),
+            messages_fork(self.messages),
+        )))
+    }
+
+    fn len(&self) -> usize {
+        1
+    }
+}
+
+fn messages_state_tree(messages: &Messages) -> LazyTree<'_> {
+    fork(MessagesStateFork { messages })
+}
+
+/// A partial tree `{message: {<id>: Leaf(bytes)}}` requesting one message value.
+fn message_query(i: usize) -> LabeledTree<Vec<u8>> {
+    LabeledTree::SubTree(flatmap! {
+        Label::from(MESSAGE_LABEL) => LabeledTree::SubTree(flatmap!{
+            message_id_label(i) => LabeledTree::Leaf(message_bytes(i)),
+        }),
+    })
+}
+
+#[test]
+fn every_message_is_a_leaf_stub() {
+    let messages = messages(NUM_CANISTERS);
+    let tree = hash_lazy_tree(&messages_state_tree(&messages), None).unwrap();
+    assert_eq!(tree.stub_count(), NUM_CANISTERS);
+}
+
+/// A witness descending into a stubbed message leaf must carry the message
+/// *value* (expanded from source), not a pruned digest.
+#[test]
+fn witness_into_message_leaf_carries_value() {
+    let messages = messages(NUM_CANISTERS);
+    let tree = hash_lazy_tree(&messages_state_tree(&messages), None).unwrap();
+
+    // Across both the sequential and parallel build ranges.
+    for i in [0, 1, PARALLEL_MIN_CHILDREN + 1, NUM_CANISTERS - 1] {
+        let partial = message_query(i);
+        let mixed = tree.witness::<MixedHashTree>(&partial).unwrap();
+        assert_eq!(&mixed.digest(), tree.root_hash());
+        // The value is present (a stubbed leaf would be pruned if not expanded).
+        assert!(
+            mixed
+                .lookup(&[MESSAGE_LABEL, message_id_label(i).as_bytes()])
+                .is_found(),
+            "expected message {i} value in the witness, got {mixed:?}"
+        );
+    }
+}
+
+/// Messages are immutable per index: reusing a baseline (shared `Arc`s for the
+/// retained suffix, only newly enqueued messages fresh) yields the same tree as
+/// a from-scratch build, reusing every retained message's digest by identity.
+#[test]
+fn message_baseline_reuse_matches_from_scratch() {
+    let messages = messages(NUM_CANISTERS);
+    let baseline = hash_lazy_tree(&messages_state_tree(&messages), None).unwrap();
+
+    // Drop a prefix and enqueue new messages at higher indices, keeping the
+    // shared `Arc`s of the retained suffix (as a real stream queue does).
+    let mut next: Messages = messages
+        .iter()
+        .filter(|(l, _)| l.as_bytes() >= message_id_label(2).as_bytes())
+        .map(|(l, arc)| (l.clone(), Arc::clone(arc)))
+        .collect();
+    for i in NUM_CANISTERS..NUM_CANISTERS + 3 {
+        next.insert(message_id_label(i), Arc::new(message_bytes(i)));
+    }
+
+    let from_scratch = hash_lazy_tree(&messages_state_tree(&next), None).unwrap();
+    let with_baseline = hash_lazy_tree(&messages_state_tree(&next), Some(&baseline)).unwrap();
+
+    assert_eq!(from_scratch.root_hash(), with_baseline.root_hash());
+
+    // Witnesses must agree for a retained message and a newly enqueued one.
+    for i in [5, NUM_CANISTERS + 1] {
+        assert_same_witness(&from_scratch, &with_baseline, &message_query(i));
+    }
+}
+
 /// Reuse is by identity, not by value: replacing every canister with a fresh
 /// `Arc` of identical contents skips all digest reuse, yet still yields the same
 /// root hash (the canonical encoding depends only on the contents).

--- a/rs/canonical_state/tree_hash/tests/subtree.rs
+++ b/rs/canonical_state/tree_hash/tests/subtree.rs
@@ -437,7 +437,7 @@ fn messages(n: usize) -> Messages {
 /// Rebuilds a stubbed message leaf from its source `Arc` (mirrors the per-variant
 /// `expand_*` message expanders in production).
 fn expand_test_message(source: &SubtreeSource) -> Result<HashTree, HashTreeError> {
-    let bytes = source.downcast::<Vec<u8>>();
+    let bytes = source.downcast_arc::<Vec<u8>>();
     hash_lazy_tree(&LazyTree::Blob(bytes.as_slice(), None), None)
 }
 


### PR DESCRIPTION
Extend subtree reuse to stream messages: each message's certified subtree (a single leaf) is stored as a reusable stub keyed by its backing `Arc<Request|Response|Refund>`. `StreamQueueFork` gains an `mk_source` function; per-variant `expand_*` expanders (and `message_source`) rebuild a stub. Witness generation expands a stubbed *leaf* (carrying its value, not a pruned digest), and `SubtreeSource::downcast_arc` recovers the owned `Arc` that the message expanders move into the rebuilt subtree.