### PR TITLE
chore: Remove attached LUKS header from Store partition

### DIFF
--- a/rs/ic_os/guest_upgrade/client/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/client/src/lib.rs
@@ -197,13 +197,12 @@ impl DiskEncryptionKeyExchangeClientAgent {
             .key
             .context("GetKeyResponse does not contain a key")?;
 
-        self.persist_disk_encryption_artifacts(
-            disk_encryption_key,
-            // This can be None when upgrading from older GuestOS-s that do not populate this field.
-            // TODO: Error on None once all GuestOS-s support detached headers
-            disk_encryption_data.luks_header,
-        )
-        .await?;
+        let luks_header = disk_encryption_data
+            .luks_header
+            .context("Server did not send a Store LUKS header")?;
+
+        self.persist_disk_encryption_artifacts(disk_encryption_key, luks_header)
+            .await?;
 
         Ok(())
     }
@@ -211,32 +210,19 @@ impl DiskEncryptionKeyExchangeClientAgent {
     async fn persist_disk_encryption_artifacts(
         &self,
         disk_encryption_key: Vec<u8>,
-        luks_header: Option<Vec<u8>>,
+        luks_header: Vec<u8>,
     ) -> Result<()> {
         let disk_encryption_key =
             String::from_utf8(disk_encryption_key).context("Key is not valid UTF-8")?;
 
-        match luks_header {
-            Some(luks_header) => {
-                tokio::fs::write(&self.store_luks_header_path, &luks_header)
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "Failed to write store LUKS header to {}",
-                            self.store_luks_header_path.display()
-                        )
-                    })?;
-            }
-            None => {
-                println!(
-                    "GetKeyResponse does not contain a store LUKS header; recovering it locally from {}",
-                    self.store_device_path.display()
-                );
-                self.crypto_ops
-                    .backup_luks_header(&self.store_device_path, &self.store_luks_header_path)
-                    .context("Local LUKS header backup failed")?;
-            }
-        }
+        tokio::fs::write(&self.store_luks_header_path, &luks_header)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to write store LUKS header to {}",
+                    self.store_luks_header_path.display()
+                )
+            })?;
 
         tokio::fs::write(&self.previous_key_path, disk_encryption_key)
             .await

--- a/rs/ic_os/guest_upgrade/client/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/client/src/lib.rs
@@ -219,7 +219,7 @@ impl DiskEncryptionKeyExchangeClientAgent {
             .await
             .with_context(|| {
                 format!(
-                    "Failed to write store LUKS header to {}",
+                    "Failed to write Store LUKS header to {}",
                     self.store_luks_header_path.display()
                 )
             })?;

--- a/rs/ic_os/guest_upgrade/server/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/server/src/lib.rs
@@ -42,10 +42,6 @@ pub struct DiskEncryptionKeyExchangeServerAgent {
     registry_client: Arc<dyn RegistryClient>,
     store_device_path: PathBuf,
     store_luks_header_path: PathBuf,
-    /// If true, the server will send the Store LUKS header to the client.
-    /// Only false in unit tests testing backwards compatibility.
-    // TODO: Remove when all deployed GuestOS versions support sending the Store LUKS header.
-    send_luks_header: bool,
     port: u16,
     success_timeout: Duration,
 }
@@ -60,7 +56,6 @@ impl DiskEncryptionKeyExchangeServerAgent {
         registry_client: Arc<dyn RegistryClient>,
         store_device_path: PathBuf,
         store_luks_header_path: PathBuf,
-        send_luks_header: bool,
         port: u16,
         success_timeout: Duration,
     ) -> Self {
@@ -73,7 +68,6 @@ impl DiskEncryptionKeyExchangeServerAgent {
             registry_client,
             store_device_path,
             store_luks_header_path,
-            send_luks_header,
             port,
             success_timeout,
         }
@@ -105,7 +99,6 @@ impl DiskEncryptionKeyExchangeServerAgent {
             self.trusted_execution_environment_config.clone(),
             self.store_device_path.clone(),
             self.store_luks_header_path.clone(),
-            self.send_luks_header,
             status_sender,
             expected_measurements,
         ));

--- a/rs/ic_os/guest_upgrade/server/src/orchestrator.rs
+++ b/rs/ic_os/guest_upgrade/server/src/orchestrator.rs
@@ -75,7 +75,6 @@ pub fn new_disk_encryption_key_exchange_server_agent_for_orchestrator(
         registry_client,
         STORE_DEVICE.into(),
         DEFAULT_STORE_LUKS_HEADER_PATH.into(),
-        /*send_luks_header=*/ true,
         DEFAULT_SERVER_PORT,
         DEFAULT_SUCCESS_TIMEOUT,
     ))

--- a/rs/ic_os/guest_upgrade/server/src/service.rs
+++ b/rs/ic_os/guest_upgrade/server/src/service.rs
@@ -30,10 +30,6 @@ pub struct DiskEncryptionKeyExchangeServiceImpl {
     sev_root_certificate_verification: SevRootCertificateVerification,
     store_device_path: PathBuf,
     store_luks_header_path: PathBuf,
-    /// If true, the server will send the Store LUKS header to the client.
-    /// Only false in unit tests testing backwards compatibility.
-    // TODO: Remove when all deployed GuestOS versions support sending the Store LUKS header.
-    send_luks_header: bool,
 }
 
 impl DiskEncryptionKeyExchangeServiceImpl {
@@ -44,7 +40,6 @@ impl DiskEncryptionKeyExchangeServiceImpl {
         trusted_execution_environment_config: TrustedExecutionEnvironmentConfig,
         store_device_path: PathBuf,
         store_luks_header_path: PathBuf,
-        send_luks_header: bool,
         status_sender: Sender<Result<(), String>>,
         expected_measurements: Vec<Vec<u8>>,
     ) -> Self {
@@ -57,7 +52,6 @@ impl DiskEncryptionKeyExchangeServiceImpl {
             sev_root_certificate_verification,
             store_device_path,
             store_luks_header_path,
-            send_luks_header,
         }
     }
 
@@ -154,17 +148,9 @@ impl DiskEncryptionKeyExchangeServiceImpl {
         let mut sev_firmware = self.sev_firmware_factory.deref()()
             .map_err(|e| Status::internal(format!("Failed to create SEV firmware: {e:?}")))?;
 
-        let luks_header = if self.send_luks_header {
-            Some(
-                tokio::fs::read(&self.store_luks_header_path)
-                    .await
-                    .map_err(|e| {
-                        Status::internal(format!("Failed to read Store LUKS header: {e:#}"))
-                    })?,
-            )
-        } else {
-            None
-        };
+        let luks_header = tokio::fs::read(&self.store_luks_header_path)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to read Store LUKS header: {e:#}")))?;
 
         Ok(Response::new(GetDiskEncryptionKeyResponse {
             key: Some(
@@ -178,7 +164,7 @@ impl DiskEncryptionKeyExchangeServiceImpl {
                 .into_bytes(),
             ),
             sev_attestation_package: Some(my_attestation_package.into()),
-            luks_header,
+            luks_header: Some(luks_header),
         }))
     }
 

--- a/rs/ic_os/guest_upgrade/tests/src/lib.rs
+++ b/rs/ic_os/guest_upgrade/tests/src/lib.rs
@@ -68,8 +68,6 @@ struct TestConfig {
     /// Allows testing invalid client attestation data.
     client_custom_data_override: Option<[u8; 64]>,
     can_open_disk: bool,
-    server_returns_luks_header: bool,
-    client_recovered_luks_header: Option<Vec<u8>>,
 }
 
 impl Default for TestConfig {
@@ -84,8 +82,6 @@ impl Default for TestConfig {
             client_chip_id: DEFAULT_CHIP_ID,
             server_chip_id: DEFAULT_CHIP_ID,
             can_open_disk: false,
-            server_returns_luks_header: true,
-            client_recovered_luks_header: None,
         }
     }
 }
@@ -114,8 +110,6 @@ struct DiskEncryptionKeyExchangeTestFixture {
     server_port: u16,
     /// True to assume that the disk can already be opened without key exchange
     can_open_disk: bool,
-    server_returns_luks_header: bool,
-    client_recovered_luks_header: Option<Vec<u8>>,
 }
 
 impl DiskEncryptionKeyExchangeTestFixture {
@@ -206,8 +200,6 @@ impl DiskEncryptionKeyExchangeTestFixture {
             client_store_luks_header,
             server_port,
             can_open_disk: config.can_open_disk,
-            server_returns_luks_header: config.server_returns_luks_header,
-            client_recovered_luks_header: config.client_recovered_luks_header,
         }
     }
 
@@ -264,7 +256,6 @@ impl DiskEncryptionKeyExchangeTestFixture {
             self.registry_client.clone(),
             self.server_store.path().to_path_buf(),
             self.server_store_luks_header.path().to_path_buf(),
-            self.server_returns_luks_header,
             self.server_port,
             Duration::from_secs(2),
         )
@@ -280,22 +271,6 @@ impl DiskEncryptionKeyExchangeTestFixture {
         crypto_ops
             .expect_can_open_store()
             .returning(move |_, _, _, _| Ok(can_open_disk));
-
-        if let Some(recovered_luks_header) = self.client_recovered_luks_header.clone() {
-            let expected_store_device_path = store_device_path.clone();
-            crypto_ops
-                .expect_backup_luks_header()
-                .times(1)
-                .withf(move |store_device_path, _| {
-                    store_device_path == expected_store_device_path.as_path()
-                })
-                .returning(move |_, store_luks_header_path| {
-                    std::fs::write(store_luks_header_path, &recovered_luks_header)?;
-                    Ok(())
-                });
-        } else {
-            crypto_ops.expect_backup_luks_header().times(0);
-        }
 
         DiskEncryptionKeyExchangeClientAgent::new(
             self.client_guestos_config.clone(),
@@ -336,15 +311,6 @@ impl DiskEncryptionKeyExchangeTestFixture {
             luks_header,
             std::fs::read(self.server_store_luks_header.path()).unwrap(),
             "Store LUKS header file content does not match the exchanged header"
-        );
-    }
-
-    fn verify_client_luks_header_matches(&self, expected: &[u8]) {
-        let luks_header = std::fs::read(self.client_store_luks_header.path())
-            .expect("Failed to read client Store LUKS header");
-        assert_eq!(
-            luks_header, expected,
-            "Store LUKS header file content does not match expected content"
         );
     }
 
@@ -415,23 +381,6 @@ async fn test_exchange_keys_successfully() {
 
     fixture.verify_previous_key_populated();
     fixture.verify_luks_header_populated();
-}
-
-#[tokio::test]
-async fn test_exchange_keys_recovers_luks_header_when_server_omits_it() {
-    let recovered_luks_header = sample_luks_header_bytes();
-    let fixture = DiskEncryptionKeyExchangeTestFixture::new(TestConfig {
-        server_returns_luks_header: false,
-        client_recovered_luks_header: Some(recovered_luks_header.clone()),
-        ..Default::default()
-    });
-    let (server_result, client_result) = fixture.run_key_exchange_test().await;
-
-    server_result.expect("Key exchange should succeed");
-    client_result.expect("Key exchange should succeed");
-
-    fixture.verify_previous_key_populated();
-    fixture.verify_client_luks_header_matches(&recovered_luks_header);
 }
 
 #[tokio::test]

--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -6,6 +6,7 @@ use libcryptsetup_rs::consts::vals::{CryptKdf, EncryptionFormat, KeyslotInfo};
 use libcryptsetup_rs::{
     CryptDevice, CryptInit, CryptParamsLuks2Ref, CryptSettingsHandle, CryptTokenInfo, TokenInput,
 };
+use prometheus::Registry;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::fs::{File, OpenOptions};
@@ -142,7 +143,7 @@ pub fn activate_crypt_device(
     passphrase: &[u8],
     flags: CryptActivate,
     verify_luks_params: bool,
-    metrics_file: Option<&Path>,
+    metrics_registry: Option<&Registry>,
 ) -> Result<(CryptDevice, u32)> {
     let mut crypt_device = open_luks2_device(device_path, header_location)?;
 
@@ -154,9 +155,9 @@ pub fn activate_crypt_device(
         .activate_by_passphrase(Some(name), None, passphrase, flags)
         .context("Failed to activate cryptographic device")?;
 
-    if let Some(metrics_file) = metrics_file {
+    if let Some(registry) = metrics_registry {
         let log_result = luks_parameters.and_then(|luks_parameters| {
-            export_luks_parameters(metrics_file, &luks_parameters, device_path, active_keyslot)
+            export_luks_parameters(registry, &luks_parameters, device_path, active_keyslot)
         });
         if let Err(e) = log_result {
             warn!("Failed to export LUKS parameters: {e:#}");

--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -8,7 +8,8 @@ use libcryptsetup_rs::{
 };
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use tracing::{info, warn};
@@ -210,6 +211,10 @@ pub fn format_crypt_device(
             .context("Failed to create detached LUKS header file")?
             .set_len(16 * 1024 * 1024)
             .context("Failed to set size of detached LUKS header file")?;
+        // The replica (running as user ic-replica) needs read access to the detached header so
+        // that it can share it during an upgrade.
+        fs::set_permissions(header_path, fs::Permissions::from_mode(0o644))
+            .context("Failed to set permissions on detached LUKS header file")?;
     }
 
     let mut crypt_device = obtain_crypt_device_handle(device_path, header_location)?;
@@ -308,6 +313,45 @@ pub fn backup_luks_header_to_file(device_path: &Path, header_path: &Path) -> Res
     fs::rename(&temp_header_path, header_path)
         .with_context(|| format!("Failed to persist LUKS header to {}", header_path.display()))?;
 
+    Ok(())
+}
+
+/// The size of the LUKS2 header region in bytes. LUKS2 reserves the first 16 MiB of the device for
+/// the header and keyslot area.
+const LUKS2_HEADER_SIZE: usize = 16 * 1024 * 1024;
+
+/// Checks whether the device at `device_path` contains a valid LUKS2 header in the attached
+/// (on-device) position.
+pub fn has_attached_luks2_header(device_path: &Path) -> Result<bool> {
+    let mut crypt_device = CryptInit::init(device_path)
+        .context("Failed to initialize cryptographic device")?;
+    crypt_device
+        .context_handle()
+        .load::<CryptParamsLuks2Ref>(Some(EncryptionFormat::Luks2), None)?;
+    let format = crypt_device
+        .format_handle()
+        .get_type()
+        .context("Failed to get encryption format")?;
+    Ok(format == EncryptionFormat::Luks2)
+}
+
+/// Wipes (zeroizes) the first [`LUKS2_HEADER_SIZE`] bytes of the device at `device_path`, removing
+/// any attached LUKS2 header.
+///
+/// This is used when the Store partition is opened with a detached header: if the data device still
+/// carries a legacy attached header (from an older GuestOS that wrote both), we wipe it so that
+/// only the detached header remains going forward.
+pub fn wipe_attached_luks2_header(device_path: &Path) -> Result<()> {
+    let mut device = OpenOptions::new()
+        .write(true)
+        .open(device_path)
+        .with_context(|| format!("Failed to open device {} for writing", device_path.display()))?;
+    device
+        .write_all(&vec![0u8; LUKS2_HEADER_SIZE])
+        .with_context(|| format!("Failed to wipe LUKS2 header on device {}", device_path.display()))?;
+    device
+        .flush()
+        .with_context(|| format!("Failed to flush LUKS2 header wipe on device {}", device_path.display()))?;
     Ok(())
 }
 

--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -316,10 +316,6 @@ pub fn backup_luks_header_to_file(device_path: &Path, header_path: &Path) -> Res
     Ok(())
 }
 
-/// The size of the LUKS2 header region in bytes. LUKS2 reserves the first 16 MiB of the device for
-/// the header and keyslot area.
-const LUKS2_HEADER_SIZE: usize = 16 * 1024 * 1024;
-
 /// Checks whether the device at `device_path` contains a valid LUKS2 header in the attached
 /// (on-device) position.
 pub fn has_attached_luks2_header(device_path: &Path) -> Result<bool> {
@@ -335,19 +331,25 @@ pub fn has_attached_luks2_header(device_path: &Path) -> Result<bool> {
     Ok(format == EncryptionFormat::Luks2)
 }
 
-/// Wipes (zeroizes) the first [`LUKS2_HEADER_SIZE`] bytes of the device at `device_path`, removing
-/// any attached LUKS2 header.
+/// Wipes (zeroizes) the header area of the device at `device_path`, removing any attached LUKS2
+/// header.
 ///
 /// This is used when the Store partition is opened with a detached header: if the data device still
 /// carries a legacy attached header (from an older GuestOS that wrote both), we wipe it so that
 /// only the detached header remains going forward.
 pub fn wipe_attached_luks2_header(device_path: &Path) -> Result<()> {
+    let mut crypt_device = open_luks2_device(device_path, LuksHeaderLocation::Attached)
+        .context("Failed to open LUKS2 device to determine header size")?;
+    // `get_data_offset` returns the offset in 512-byte sectors; convert to bytes.
+    let data_offset_sectors = crypt_device.status_handle().get_data_offset();
+    let header_size_bytes = data_offset_sectors * 512;
+
     let mut device = OpenOptions::new()
         .write(true)
         .open(device_path)
         .with_context(|| format!("Failed to open device {} for writing", device_path.display()))?;
     device
-        .write_all(&vec![0u8; LUKS2_HEADER_SIZE])
+        .write_all(&vec![0u8; header_size_bytes as usize])
         .with_context(|| format!("Failed to wipe LUKS2 header on device {}", device_path.display()))?;
     device
         .flush()

--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -355,7 +355,7 @@ pub fn wipe_attached_luks_header(device_path: &Path) -> Result<()> {
             )
         })?;
     device
-        .write_all(&vec![0u8; header_size_bytes as usize])
+        .write_all(&vec![0_u8; header_size_bytes as usize])
         .with_context(|| {
             format!(
                 "Failed to wipe LUKS header on device {}",

--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -323,7 +323,8 @@ pub fn has_attached_luks_header(device_path: &Path) -> Result<bool> {
     const LUKS_MAGIC: &[u8; 4] = b"LUKS";
 
     let mut start = vec![];
-    std::fs::File::open(device_path).context("Failed to open device for header check")?
+    std::fs::File::open(device_path)
+        .context("Failed to open device for header check")?
         .take(LUKS_MAGIC.len() as u64)
         .read_to_end(&mut start)
         .context("Failed to read first few bytes for header check")?;
@@ -347,13 +348,26 @@ pub fn wipe_attached_luks_header(device_path: &Path) -> Result<()> {
     let mut device = OpenOptions::new()
         .write(true)
         .open(device_path)
-        .with_context(|| format!("Failed to open device {} for writing", device_path.display()))?;
+        .with_context(|| {
+            format!(
+                "Failed to open device {} for writing",
+                device_path.display()
+            )
+        })?;
     device
         .write_all(&vec![0u8; header_size_bytes as usize])
-        .with_context(|| format!("Failed to wipe LUKS header on device {}", device_path.display()))?;
-    device
-        .flush()
-        .with_context(|| format!("Failed to flush LUKS header wipe on device {}", device_path.display()))?;
+        .with_context(|| {
+            format!(
+                "Failed to wipe LUKS header on device {}",
+                device_path.display()
+            )
+        })?;
+    device.flush().with_context(|| {
+        format!(
+            "Failed to flush LUKS header wipe on device {}",
+            device_path.display()
+        )
+    })?;
     Ok(())
 }
 

--- a/rs/ic_os/os_tools/guest_disk/src/crypt.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/crypt.rs
@@ -10,7 +10,7 @@ use prometheus::Registry;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use tracing::{info, warn};
@@ -319,28 +319,27 @@ pub fn backup_luks_header_to_file(device_path: &Path, header_path: &Path) -> Res
 
 /// Checks whether the device at `device_path` contains a valid LUKS2 header in the attached
 /// (on-device) position.
-pub fn has_attached_luks2_header(device_path: &Path) -> Result<bool> {
-    let mut crypt_device = CryptInit::init(device_path)
-        .context("Failed to initialize cryptographic device")?;
-    crypt_device
-        .context_handle()
-        .load::<CryptParamsLuks2Ref>(Some(EncryptionFormat::Luks2), None)?;
-    let format = crypt_device
-        .format_handle()
-        .get_type()
-        .context("Failed to get encryption format")?;
-    Ok(format == EncryptionFormat::Luks2)
+pub fn has_attached_luks_header(device_path: &Path) -> Result<bool> {
+    const LUKS_MAGIC: &[u8; 4] = b"LUKS";
+
+    let mut start = vec![];
+    std::fs::File::open(device_path).context("Failed to open device for header check")?
+        .take(LUKS_MAGIC.len() as u64)
+        .read_to_end(&mut start)
+        .context("Failed to read first few bytes for header check")?;
+
+    Ok(start == LUKS_MAGIC)
 }
 
-/// Wipes (zeroizes) the header area of the device at `device_path`, removing any attached LUKS2
+/// Wipes (zeroizes) the header area of the device at `device_path`, removing any attached LUKS
 /// header.
 ///
 /// This is used when the Store partition is opened with a detached header: if the data device still
 /// carries a legacy attached header (from an older GuestOS that wrote both), we wipe it so that
 /// only the detached header remains going forward.
-pub fn wipe_attached_luks2_header(device_path: &Path) -> Result<()> {
+pub fn wipe_attached_luks_header(device_path: &Path) -> Result<()> {
     let mut crypt_device = open_luks2_device(device_path, LuksHeaderLocation::Attached)
-        .context("Failed to open LUKS2 device to determine header size")?;
+        .context("Failed to open LUKS device to determine header size")?;
     // `get_data_offset` returns the offset in 512-byte sectors; convert to bytes.
     let data_offset_sectors = crypt_device.status_handle().get_data_offset();
     let header_size_bytes = data_offset_sectors * 512;
@@ -351,10 +350,10 @@ pub fn wipe_attached_luks2_header(device_path: &Path) -> Result<()> {
         .with_context(|| format!("Failed to open device {} for writing", device_path.display()))?;
     device
         .write_all(&vec![0u8; header_size_bytes as usize])
-        .with_context(|| format!("Failed to wipe LUKS2 header on device {}", device_path.display()))?;
+        .with_context(|| format!("Failed to wipe LUKS header on device {}", device_path.display()))?;
     device
         .flush()
-        .with_context(|| format!("Failed to flush LUKS2 header wipe on device {}", device_path.display()))?;
+        .with_context(|| format!("Failed to flush LUKS header wipe on device {}", device_path.display()))?;
     Ok(())
 }
 

--- a/rs/ic_os/os_tools/guest_disk/src/generated_key.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/generated_key.rs
@@ -2,6 +2,7 @@ use crate::crypt::{LuksHeaderLocation, activate_crypt_device, format_crypt_devic
 use crate::{DiskEncryption, Partition, activate_flags};
 use anyhow::{Context, Result};
 use ic_sys::fs::{Clobber, write_atomically_using_tmp_file};
+use prometheus::Registry;
 use std::fs::Permissions;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
@@ -13,7 +14,7 @@ const GENERATED_KEY_SIZE_BYTES: usize = 16;
 
 pub struct GeneratedKeyDiskEncryption<'a> {
     pub key_path: &'a Path,
-    pub metrics_file: &'a Path,
+    pub metrics_registry: &'a Registry,
 }
 
 impl DiskEncryption for GeneratedKeyDiskEncryption<'_> {
@@ -31,7 +32,7 @@ impl DiskEncryption for GeneratedKeyDiskEncryption<'_> {
             // execution environment)
             /*verify_luks_params=*/
             false,
-            Some(self.metrics_file),
+            Some(self.metrics_registry),
         )
         .context("Failed to initialize crypt device")?;
 

--- a/rs/ic_os/os_tools/guest_disk/src/main.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/main.rs
@@ -6,12 +6,14 @@ use clap::Parser;
 use config_tool::{DEFAULT_GUESTOS_CONFIG_OBJECT_PATH, deserialize_config};
 use config_types::GuestOSConfig;
 use guest_disk::generated_key::{DEFAULT_GENERATED_KEY_PATH, GeneratedKeyDiskEncryption};
+use guest_disk::metrics::write_metrics;
 use guest_disk::sev::SevDiskEncryption;
 use guest_disk::{
     DEFAULT_PREVIOUS_SEV_KEY_PATH, DEFAULT_STORE_LUKS_HEADER_PATH, DiskEncryption, Partition,
     crypt_name,
 };
 use nix::unistd::getuid;
+use prometheus::Registry;
 use sev_guest::firmware::SevGuestFirmware;
 use std::ffi::{CStr, c_char, c_int, c_void};
 use std::path::{Path, PathBuf};
@@ -87,23 +89,23 @@ fn run(
 ) -> Result<()> {
     libcryptsetup_rs::set_log_callback::<()>(Some(cryptsetup_log), None);
 
-    let metrics_file = metrics_file_path(metrics_dir, args.partition());
+    let metrics_registry = Registry::new();
+
     let mut encryption: Box<dyn DiskEncryption> = if is_tee_enabled {
         Box::new(SevDiskEncryption {
             sev_firmware: sev_firmware_factory().context("Failed to open SEV firmware")?,
             guest_vm_type: guestos_config.guest_vm_type,
             previous_key_path: previous_key_path.to_path_buf(),
             store_luks_header_path: store_luks_header_path.to_path_buf(),
-            metrics_file,
+            metrics_registry: metrics_registry.clone(),
         })
     } else {
         Box::new(GeneratedKeyDiskEncryption {
             key_path: generated_key_path,
-            metrics_file: &metrics_file,
+            metrics_registry: &metrics_registry,
         })
     };
-
-    match args {
+    let result = match args {
         Args::CryptOpen {
             partition,
             device_path,
@@ -116,7 +118,15 @@ fn run(
         } => encryption
             .format(&device_path, partition)
             .with_context(|| format!("Failed to format device for partition {partition:?}")),
-    }
+    };
+
+    // Always write metrics, even if the operation failed.
+    write_metrics(
+        &metrics_registry,
+        &metrics_file_path(metrics_dir, args.partition()),
+    );
+
+    result
 }
 
 fn metrics_file_path(metrics_dir: &Path, partition: Partition) -> PathBuf {

--- a/rs/ic_os/os_tools/guest_disk/src/main.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/main.rs
@@ -105,6 +105,7 @@ fn run(
             metrics_registry: &metrics_registry,
         })
     };
+    let partition = args.partition();
     let result = match args {
         Args::CryptOpen {
             partition,
@@ -123,7 +124,7 @@ fn run(
     // Always write metrics, even if the operation failed.
     write_metrics(
         &metrics_registry,
-        &metrics_file_path(metrics_dir, args.partition()),
+        &metrics_file_path(metrics_dir, partition),
     );
 
     result

--- a/rs/ic_os/os_tools/guest_disk/src/metrics.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/metrics.rs
@@ -3,14 +3,14 @@ use anyhow::{Context, Result};
 use libcryptsetup_rs::consts::vals::KeyslotInfo;
 use prometheus::{Encoder, GaugeVec, Opts, Registry, TextEncoder};
 use std::path::Path;
+use tracing::warn;
 
 pub(crate) fn export_luks_parameters(
-    metrics_file: &Path,
+    registry: &Registry,
     luks_parameters: &LuksParameters,
     device_path: &Path,
     active_keyslot: u32,
 ) -> Result<()> {
-    let registry = Registry::new();
     let labels = build_luks_metric_labels(luks_parameters, device_path, active_keyslot)?;
     let label_names = labels.iter().map(|(name, _)| *name).collect::<Vec<_>>();
     let label_values = labels
@@ -30,15 +30,6 @@ pub(crate) fn export_luks_parameters(
     registry
         .register(Box::new(info_gauge))
         .context("Failed to register metric")?;
-
-    let mut buffer = vec![];
-    let encoder = TextEncoder::new();
-    encoder
-        .encode(&registry.gather(), &mut buffer)
-        .context("Failed to encode metrics")?;
-
-    std::fs::write(metrics_file, buffer)
-        .with_context(|| format!("Failed to write metrics to {:?}", metrics_file))?;
 
     Ok(())
 }
@@ -100,4 +91,54 @@ fn build_luks_metric_labels(
         ("num_keyslots", num_keyslots.to_string()),
         ("passes_verification", passes_verification.to_string()),
     ])
+}
+
+/// Registers the status of the attached LUKS2 header on the Store data device with the given
+/// registry. Call [`write_metrics`] at the end of the program to persist all registered metrics to
+/// disk.
+pub(crate) fn export_attached_luks2_header_status(
+    registry: &Registry,
+    device_path: &Path,
+    attached_header_present: Result<bool>,
+) -> Result<()> {
+    let opts = Opts::new(
+        "guest_disk_store_attached_luks2_header_status",
+        "Status of the attached (on-device) LUKS2 header on the Store partition data device",
+    );
+    let header_status = GaugeVec::new(opts, &["device_path", "status"])
+        .context("Failed to create attached LUKS2 header status gauge")?;
+
+    let device_path_str = device_path.to_string_lossy();
+    let status_str = match attached_header_present {
+        Ok(true) => "present",
+        Ok(false) => "absent",
+        Err(_) => "error",
+    };
+    let label_values: Vec<&str> = vec![&device_path_str, status_str];
+
+    header_status
+        .with_label_values(&label_values)
+        .set(1.0);
+
+    registry
+        .register(Box::new(header_status))
+        .context("Failed to register attached LUKS2 header status metric")?;
+
+    Ok(())
+}
+
+/// Encodes all metrics registered in `registry` and writes them to `metrics_file`.
+pub fn write_metrics(registry: &Registry, metrics_file: &Path) {
+    let mut buffer = vec![];
+    let encoder = TextEncoder::new();
+    if let Err(e) = encoder.encode(&registry.gather(), &mut buffer) {
+        warn!("Failed to encode metrics: {e:#}");
+        return;
+    }
+    if let Err(e) = std::fs::write(metrics_file, buffer) {
+        warn!(
+            "Failed to write metrics to {}: {e:#}",
+            metrics_file.display()
+        );
+    }
 }

--- a/rs/ic_os/os_tools/guest_disk/src/metrics.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/metrics.rs
@@ -116,9 +116,7 @@ pub(crate) fn export_attached_luks2_header_status(
     };
     let label_values: Vec<&str> = vec![&device_path_str, status_str];
 
-    header_status
-        .with_label_values(&label_values)
-        .set(1.0);
+    header_status.with_label_values(&label_values).set(1.0);
 
     registry
         .register(Box::new(header_status))

--- a/rs/ic_os/os_tools/guest_disk/src/sev.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/sev.rs
@@ -1,6 +1,7 @@
 use crate::crypt::{
     LuksHeaderLocation, SevMetadata, activate_crypt_device, add_sev_metadata,
-    backup_luks_header_to_file, check_encryption_key, destroy_keyslots_except, format_crypt_device,
+    check_encryption_key, destroy_keyslots_except, format_crypt_device,
+    has_attached_luks2_header, wipe_attached_luks2_header,
 };
 use crate::{DiskEncryption, Partition, activate_flags};
 use anyhow::{Context, Result, bail};
@@ -22,37 +23,6 @@ pub struct SevDiskEncryption {
 }
 
 impl SevDiskEncryption {
-    fn ensure_detached_store_luks_header(&self, device_path: &Path) -> Result<()> {
-        let detached_header_exists = self.store_luks_header_path.exists();
-
-        info!(
-            "Backing up attached Store LUKS header from {} to {}",
-            device_path.display(),
-            self.store_luks_header_path.display()
-        );
-        if let Err(err) = backup_luks_header_to_file(device_path, &self.store_luks_header_path)
-            .with_context(|| {
-                format!(
-                    "Failed to persist detached Store LUKS header to {}",
-                    self.store_luks_header_path.display()
-                )
-            })
-        {
-            if !detached_header_exists {
-                return Err(err);
-            }
-
-            warn!(
-                "Failed to refresh detached Store LUKS header from attached header on {}: \
-                {err:#}. Using existing detached header at {}",
-                device_path.display(),
-                self.store_luks_header_path.display()
-            );
-        }
-
-        Ok(())
-    }
-
     fn setup_store_with_previous_key(
         &self,
         device_path: &Path,
@@ -153,6 +123,37 @@ impl DiskEncryption for SevDiskEncryption {
             }
 
             Partition::Store => {
+                // If a detached header is available, ensure that no attached header remains on the
+                // data device. Devices formatted by older GuestOS versions carry both an attached
+                // and a detached header; wiping the attached header here ensures that only the
+                // detached header is used going forward.
+                if self.store_luks_header_path.exists()
+                    && match has_attached_luks2_header(device_path) {
+                        Ok(has_attached) => has_attached,
+                        Err(e) => {
+                            warn!(
+                                "Failed to check for attached LUKS2 header on {}: {e:#}. \
+                                Continuing without wiping.",
+                                device_path.display()
+                            );
+                            false
+                        }
+                    }
+                {
+                    info!(
+                        "Detached Store LUKS header available and attached header still present \
+                        on {}. Wiping attached header.",
+                        device_path.display()
+                    );
+                    if let Err(e) = wipe_attached_luks2_header(device_path) {
+                        warn!(
+                            "Failed to wipe attached LUKS2 header on {}: {e:#}. \
+                            Continuing with detached header.",
+                            device_path.display()
+                        );
+                    }
+                }
+
                 // Try to read the previous SEV key. This is the key that the previous version of the
                 // GuestOS used to unlock the store (data) partition. During the upgrade this key is
                 // written to `previous_key_path`. After the upgrade, when the GuestOS boots for the
@@ -196,14 +197,6 @@ impl DiskEncryption for SevDiskEncryption {
     }
 
     fn format(&mut self, device_path: &Path, partition: Partition) -> Result<()> {
-        if partition == Partition::Store && self.store_luks_header_path.exists() {
-            bail!(
-                "Refusing to format Store because detached LUKS header {} already exists. Remove \
-                the stale header first if you really want to reformat the device.",
-                self.store_luks_header_path.display()
-            );
-        }
-
         let key = derive_key_from_sev_measurement(
             self.sev_firmware.as_mut(),
             Key::DiskEncryptionKey { device_path },
@@ -211,19 +204,26 @@ impl DiskEncryption for SevDiskEncryption {
         .context("Failed to derive SEV key for disk encryption")?;
 
         let sev_metadata = self.get_sev_metadata_for_luks()?;
-        // For now, we use attached headers and for store partition, we create a detached
-        // backup. Once all GuestOS-s support detached headers, we can switch to using only detached
-        // headers.
-        // TODO: Remove attached header usage for store partition
+
+        let header_location = match partition {
+            Partition::Store => {
+                if self.store_luks_header_path.exists() {
+                    bail!(
+                        "Refusing to format Store because detached LUKS header {} already exists. \
+                        Remove the stale header first if you really want to reformat the device.",
+                        self.store_luks_header_path.display()
+                    );
+                }
+                LuksHeaderLocation::Detached(&self.store_luks_header_path)
+            }
+            Partition::Var => LuksHeaderLocation::Attached,
+        };
+
         let (mut crypt_device, keyslot) =
-            format_crypt_device(device_path, LuksHeaderLocation::Attached, key.as_bytes())
+            format_crypt_device(device_path, header_location, key.as_bytes())
                 .context("Failed to format partition")?;
         add_sev_metadata(&mut crypt_device, keyslot, sev_metadata)
             .context("Failed to write SEV keyslot metadata")?;
-
-        if partition == Partition::Store {
-            self.ensure_detached_store_luks_header(device_path)?;
-        }
 
         Ok(())
     }
@@ -274,9 +274,6 @@ pub trait DiskCryptoOps: Send + Sync {
         store_luks_header_path: &Path,
         sev_firmware: &mut dyn SevGuestFirmware,
     ) -> Result<bool>;
-
-    /// Persists a detached LUKS header for the Store partition at `luks_header_path`.
-    fn backup_luks_header(&self, device_path: &Path, luks_header_path: &Path) -> Result<()>;
 }
 
 pub struct DefaultSevStoreCryptoOps;
@@ -295,9 +292,5 @@ impl DiskCryptoOps for DefaultSevStoreCryptoOps {
             store_luks_header_path,
             sev_firmware,
         )
-    }
-
-    fn backup_luks_header(&self, device_path: &Path, luks_header_path: &Path) -> Result<()> {
-        backup_luks_header_to_file(device_path, luks_header_path)
     }
 }

--- a/rs/ic_os/os_tools/guest_disk/src/sev.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/sev.rs
@@ -1,6 +1,6 @@
 use crate::crypt::{
     LuksHeaderLocation, SevMetadata, activate_crypt_device, add_sev_metadata, check_encryption_key,
-    destroy_keyslots_except, format_crypt_device, has_attached_luks_header,
+    destroy_keyslots_except, format_crypt_device, has_attached_luks_header, open_luks2_device,
     wipe_attached_luks_header,
 };
 use crate::metrics::export_attached_luks2_header_status;
@@ -59,17 +59,29 @@ impl SevDiskEncryption {
         });
 
         if self.store_luks_header_path.exists() && attached_header_present {
-            info!(
-                "Detached Store LUKS header available and attached header still present \
-                on {}. Wiping attached header.",
-                device_path.display()
-            );
-            if let Err(e) = wipe_attached_luks_header(device_path) {
+            if let Err(e) = open_luks2_device(
+                device_path,
+                LuksHeaderLocation::Detached(&self.store_luks_header_path),
+            ) {
                 warn!(
-                    "Failed to wipe attached LUKS2 header on {}: {e:#}. \
-                    Continuing with detached header.",
+                    "Refusing to wipe attached LUKS2 header on {}: detached header {} \
+                    cannot be read by libcryptsetup: {e:#}",
+                    device_path.display(),
+                    self.store_luks_header_path.display()
+                );
+            } else {
+                info!(
+                    "Detached Store LUKS header available and attached header still present \
+                    on {}. Wiping attached header.",
                     device_path.display()
                 );
+                if let Err(e) = wipe_attached_luks_header(device_path) {
+                    warn!(
+                        "Failed to wipe attached LUKS2 header on {}: {e:#}. \
+                        Continuing with detached header.",
+                        device_path.display()
+                    );
+                }
             }
         }
 

--- a/rs/ic_os/os_tools/guest_disk/src/sev.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/sev.rs
@@ -1,12 +1,14 @@
 use crate::crypt::{
-    LuksHeaderLocation, SevMetadata, activate_crypt_device, add_sev_metadata,
-    check_encryption_key, destroy_keyslots_except, format_crypt_device,
-    has_attached_luks2_header, wipe_attached_luks2_header,
+    LuksHeaderLocation, SevMetadata, activate_crypt_device, add_sev_metadata, check_encryption_key,
+    destroy_keyslots_except, format_crypt_device, has_attached_luks2_header,
+    wipe_attached_luks2_header,
 };
+use crate::metrics::export_attached_luks2_header_status;
 use crate::{DiskEncryption, Partition, activate_flags};
 use anyhow::{Context, Result, bail};
 use attestation::attestation_report::AttestationReportExt;
 use config_types::GuestVMType;
+use prometheus::Registry;
 use sev::firmware::guest::AttestationReport;
 use sev::parser::ByteParser;
 use sev_guest::firmware::SevGuestFirmware;
@@ -19,10 +21,69 @@ pub struct SevDiskEncryption {
     pub previous_key_path: PathBuf,
     pub store_luks_header_path: PathBuf,
     pub guest_vm_type: GuestVMType,
-    pub metrics_file: PathBuf,
+    pub metrics_registry: Registry,
 }
 
 impl SevDiskEncryption {
+    /// Records the attached LUKS2 header status in the metrics registry. Failures are logged as
+    /// warnings and never propagated, because a metrics export failure must not prevent the
+    /// partition from being opened.
+    fn export_attached_header_status(
+        &self,
+        device_path: &Path,
+        attached_header_present: Result<bool>,
+    ) {
+        if let Err(e) = export_attached_luks2_header_status(
+            &self.metrics_registry,
+            device_path,
+            attached_header_present,
+        ) {
+            warn!("Failed to export attached LUKS2 header status metric: {e:#}");
+        }
+    }
+
+    /// Checks whether the device carries an attached (on-device) LUKS2 header. If a detached
+    /// header is available and an attached header is still present, the attached header is wiped
+    /// so that only the detached header is used going forward. Finally, the attached-header status
+    /// is recorded in the metrics registry.
+    ///
+    /// TODO: once no nodes with attached Store LUKS headers remain, remove this logic.
+    fn wipe_and_export_attached_luks2_header(&self, device_path: &Path) {
+        let mut attached_header_present = has_attached_luks2_header(device_path).unwrap_or_else(|e| {
+            warn!(
+                "Failed to check for attached LUKS2 header on {}: {e:#}. \
+                Continuing without wiping.",
+                device_path.display()
+            );
+            false
+        });
+
+        if self.store_luks_header_path.exists() && attached_header_present {
+            info!(
+                "Detached Store LUKS header available and attached header still present \
+                on {}. Wiping attached header.",
+                device_path.display()
+            );
+            match wipe_attached_luks2_header(device_path) {
+                Ok(()) => attached_header_present = false,
+                Err(e) => {
+                    warn!(
+                        "Failed to wipe attached LUKS2 header on {}: {e:#}. \
+                        Continuing with detached header.",
+                        device_path.display()
+                    );
+                }
+            }
+        }
+
+        self.export_attached_header_status(
+            device_path,
+            // Note that we don't use `attached_header_present` here, because the header may
+            // have been wiped above.
+            has_attached_luks2_header(device_path),
+        );
+    }
+
     fn setup_store_with_previous_key(
         &self,
         device_path: &Path,
@@ -45,7 +106,7 @@ impl SevDiskEncryption {
             &previous_key,
             activate_flags(Partition::Store),
             /*verify_luks_params=*/ true,
-            Some(self.metrics_file.as_path()),
+            Some(&self.metrics_registry),
         )
         .context("Failed to unlock store partition with previous key")?;
 
@@ -117,42 +178,13 @@ impl DiskEncryption for SevDiskEncryption {
                     key.as_bytes(),
                     activate_flags(partition),
                     /*verify_luks_params=*/ true,
-                    Some(&self.metrics_file),
+                    Some(&self.metrics_registry),
                 )
                 .context("Failed to open crypt device for var partition")?;
             }
 
             Partition::Store => {
-                // If a detached header is available, ensure that no attached header remains on the
-                // data device. Devices formatted by older GuestOS versions carry both an attached
-                // and a detached header; wiping the attached header here ensures that only the
-                // detached header is used going forward.
-                if self.store_luks_header_path.exists()
-                    && match has_attached_luks2_header(device_path) {
-                        Ok(has_attached) => has_attached,
-                        Err(e) => {
-                            warn!(
-                                "Failed to check for attached LUKS2 header on {}: {e:#}. \
-                                Continuing without wiping.",
-                                device_path.display()
-                            );
-                            false
-                        }
-                    }
-                {
-                    info!(
-                        "Detached Store LUKS header available and attached header still present \
-                        on {}. Wiping attached header.",
-                        device_path.display()
-                    );
-                    if let Err(e) = wipe_attached_luks2_header(device_path) {
-                        warn!(
-                            "Failed to wipe attached LUKS2 header on {}: {e:#}. \
-                            Continuing with detached header.",
-                            device_path.display()
-                        );
-                    }
-                }
+                self.wipe_and_export_attached_luks2_header(device_path);
 
                 // Try to read the previous SEV key. This is the key that the previous version of the
                 // GuestOS used to unlock the store (data) partition. During the upgrade this key is
@@ -187,7 +219,7 @@ impl DiskEncryption for SevDiskEncryption {
                     key.as_bytes(),
                     activate_flags(partition),
                     /*verify_luks_params=*/ true,
-                    Some(&self.metrics_file),
+                    Some(&self.metrics_registry),
                 )
                 .context("Failed to initialize crypt device for store partition")?;
             }

--- a/rs/ic_os/os_tools/guest_disk/src/sev.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/sev.rs
@@ -1,7 +1,7 @@
 use crate::crypt::{
     LuksHeaderLocation, SevMetadata, activate_crypt_device, add_sev_metadata, check_encryption_key,
-    destroy_keyslots_except, format_crypt_device, has_attached_luks2_header,
-    wipe_attached_luks2_header,
+    destroy_keyslots_except, format_crypt_device, has_attached_luks_header,
+    wipe_attached_luks_header,
 };
 use crate::metrics::export_attached_luks2_header_status;
 use crate::{DiskEncryption, Partition, activate_flags};
@@ -49,7 +49,7 @@ impl SevDiskEncryption {
     ///
     /// TODO: once no nodes with attached Store LUKS headers remain, remove this logic.
     fn wipe_and_export_attached_luks2_header(&self, device_path: &Path) {
-        let mut attached_header_present = has_attached_luks2_header(device_path).unwrap_or_else(|e| {
+        let attached_header_present = has_attached_luks_header(device_path).unwrap_or_else(|e| {
             warn!(
                 "Failed to check for attached LUKS2 header on {}: {e:#}. \
                 Continuing without wiping.",
@@ -64,15 +64,12 @@ impl SevDiskEncryption {
                 on {}. Wiping attached header.",
                 device_path.display()
             );
-            match wipe_attached_luks2_header(device_path) {
-                Ok(()) => attached_header_present = false,
-                Err(e) => {
-                    warn!(
-                        "Failed to wipe attached LUKS2 header on {}: {e:#}. \
-                        Continuing with detached header.",
-                        device_path.display()
-                    );
-                }
+            if let Err(e) = wipe_attached_luks_header(device_path) {
+                warn!(
+                    "Failed to wipe attached LUKS2 header on {}: {e:#}. \
+                    Continuing with detached header.",
+                    device_path.display()
+                );
             }
         }
 
@@ -80,7 +77,7 @@ impl SevDiskEncryption {
             device_path,
             // Note that we don't use `attached_header_present` here, because the header may
             // have been wiped above.
-            has_attached_luks2_header(device_path),
+            has_attached_luks_header(device_path),
         );
     }
 

--- a/rs/ic_os/os_tools/guest_disk/src/tests.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/tests.rs
@@ -15,6 +15,7 @@ use libcryptsetup_rs::consts::vals::{CryptKdf, EncryptionFormat, KeyslotInfo};
 use libcryptsetup_rs::{
     CryptInit, CryptParamsLuks2Ref, CryptSettingsHandle, CryptTokenInfo, TokenInput,
 };
+use prometheus::Registry;
 use sev::Generation;
 use sev::firmware::host::TcbVersion;
 use sev::parser::ByteParser;
@@ -504,7 +505,6 @@ fn test_fail_to_open_if_device_is_not_formatted() {
 fn test_format_store_refuses_existing_detached_header() {
     let temp_dir = tempdir().unwrap();
     let store_luks_header_path = temp_dir.path().join("store.header");
-    let metrics_file = temp_dir.path().join("metrics.prom");
 
     fs::write(&store_luks_header_path, b"stale header")
         .expect("Failed to write stale detached Store header");
@@ -514,7 +514,7 @@ fn test_format_store_refuses_existing_detached_header() {
         previous_key_path: temp_dir.path().join("previous_key"),
         store_luks_header_path: store_luks_header_path.clone(),
         guest_vm_type: GuestVMType::Default,
-        metrics_file,
+        metrics_registry: Registry::new(),
     };
 
     let err = guest_disk::DiskEncryption::format(
@@ -1358,6 +1358,92 @@ fn test_metrics_export() {
     assert!(
         metrics_content.contains("passes_verification=\"true\""),
         "Missing or incorrect passes_verification label: {metrics_content}"
+    );
+}
+
+#[test]
+fn test_store_attached_luks2_header_status_metric_absent() {
+    let mut fixture = TestFixture::new(true);
+
+    // Format the store partition with a detached header only; there is no attached header on the
+    // data device.
+    fixture
+        .format(Partition::Store)
+        .expect("Failed to format store partition");
+
+    fixture
+        .open(Partition::Store)
+        .expect("Failed to open store partition");
+
+    let metrics_content = fs::read_to_string(fixture.metrics_file(Partition::Store))
+        .expect("Failed to read metrics file");
+
+    assert!(
+        metrics_content.contains("guest_disk_store_attached_luks2_header_status"),
+        "Missing attached LUKS2 header status metric: {metrics_content}"
+    );
+    assert!(
+        metrics_content.contains("status=\"absent\""),
+        "Expected status=\"absent\" label: {metrics_content}"
+    );
+    assert!(
+        !metrics_content.contains("status=\"present\""),
+        "Did not expect status=\"present\" label: {metrics_content}"
+    );
+}
+
+#[test]
+fn test_store_attached_luks2_header_status_metric_present() {
+    const PREVIOUS_KEY: &[u8] = b"previous key";
+
+    let mut fixture = TestFixture::new(true);
+
+    fs::write(&fixture.previous_key_path, PREVIOUS_KEY)
+        .expect("Failed to write previous key for testing");
+
+    // Simulate a legacy device that has both an attached and a detached header.
+    format_crypt_device(
+        &fixture.device.path().unwrap(),
+        LuksHeaderLocation::Attached,
+        PREVIOUS_KEY,
+    )
+    .expect("Failed to format device with attached header");
+
+    backup_luks_header_to_file(
+        &fixture.device.path().unwrap(),
+        &fixture.store_luks_header_path,
+    )
+    .expect("Failed to create detached header backup");
+
+    assert!(fixture.has_attached_luks2_header());
+
+    fixture
+        .open(Partition::Store)
+        .expect("opening Store should succeed");
+
+    // After opening, the attached header is wiped because a detached header is available.
+    // The metric reflects the end result, so it must report "absent".
+    assert!(
+        !fixture.has_attached_luks2_header(),
+        "attached LUKS header should have been wiped during open()"
+    );
+
+    let metrics_content = fs::read_to_string(fixture.metrics_file(Partition::Store))
+        .expect("Failed to read metrics file");
+
+    assert!(
+        metrics_content.contains("guest_disk_store_attached_luks2_header_status"),
+        "Missing attached LUKS2 header status metric: {metrics_content}"
+    );
+    assert!(
+        metrics_content.contains("status=\"absent\""),
+        "Expected status=\"absent\" after wipe: {metrics_content}"
+    );
+    // The LUKS parameters metric must still be present (not overwritten by the header status
+    // metric).
+    assert!(
+        metrics_content.contains("guest_disk_encryption_info"),
+        "Missing encryption info metric: {metrics_content}"
     );
 }
 

--- a/rs/ic_os/os_tools/guest_disk/src/tests.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/tests.rs
@@ -1131,6 +1131,44 @@ fn test_open_store_succeeds_with_detached_header_after_attached_header_is_corrup
     assert!(Path::new("/dev/mapper/store-crypt").exists());
 }
 
+/// Test that the attached LUKS header is NOT wiped when the detached header cannot be read by
+/// libcryptsetup.
+#[test]
+fn test_open_store_keeps_attached_header_when_detached_header_is_corrupt() {
+    const PREVIOUS_KEY: &[u8] = b"previous key";
+
+    let mut fixture = TestFixture::new(true);
+
+    fs::write(&fixture.previous_key_path, PREVIOUS_KEY)
+        .expect("Failed to write previous key for testing");
+
+    // Simulate a legacy device that has both an attached and a detached header.
+    format_crypt_device(
+        &fixture.device.path().unwrap(),
+        LuksHeaderLocation::Attached,
+        PREVIOUS_KEY,
+    )
+    .expect("Failed to format device with attached header");
+
+    assert!(fixture.has_attached_luks2_header());
+
+    // Corrupt the detached header so libcryptsetup can no longer read it.
+    fs::write(&fixture.store_luks_header_path, b"not a valid LUKS header")
+        .expect("Failed to corrupt detached header");
+
+    // Opening the store must fail because the detached header is unreadable.
+    fixture
+        .open(Partition::Store)
+        .expect_err("opening Store should fail when the detached header is corrupt");
+
+    // Crucially, the attached header must still be present: the wipe guard must have refused
+    // to wipe it because the detached header could not be verified.
+    assert!(
+        fixture.has_attached_luks2_header(),
+        "attached LUKS header must not be wiped when the detached header is unreadable"
+    );
+}
+
 /// Test that opening the store partition wipes a legacy attached LUKS header when a detached
 /// header is available. This simulates upgrading from an older GuestOS that wrote both an
 /// attached and a detached header.

--- a/rs/ic_os/os_tools/guest_disk/src/tests.rs
+++ b/rs/ic_os/os_tools/guest_disk/src/tests.rs
@@ -419,7 +419,9 @@ fn test_sev_key_init_and_reopen() {
         if partition == Partition::Store {
             assert!(fixture.store_luks_header_path.exists());
             assert!(fixture.has_detached_luks2_header());
-            assert!(fixture.has_attached_luks2_header());
+            // The store partition is formatted with a detached header only; no attached
+            // LUKS header should be present on the data device.
+            assert!(!fixture.has_attached_luks2_header());
         }
     }
 }
@@ -445,10 +447,12 @@ fn test_sev_format_writes_keyslot_metadata() {
 
 #[test]
 fn test_detached_header_is_only_used_for_store_when_sev_is_enabled() {
-    for (enable_sev, partition, expect_detached_header) in [
-        (false, Partition::Store, false),
-        (true, Partition::Store, true),
-        (true, Partition::Var, false),
+    // When the store partition uses a detached header, there must not be an attached
+    // LUKS header on the data device. The var partition always uses an attached header.
+    for (enable_sev, partition, expect_detached_header, expect_attached_header) in [
+        (false, Partition::Store, false, true),
+        (true, Partition::Store, true, false),
+        (true, Partition::Var, false, true),
     ] {
         let mut fixture = TestFixture::new(enable_sev);
 
@@ -471,6 +475,14 @@ fn test_detached_header_is_only_used_for_store_when_sev_is_enabled() {
             fixture.has_detached_luks2_header(),
             expect_detached_header,
             "unexpected detached LUKS header state for {:?} with SEV enabled = {}",
+            partition,
+            enable_sev
+        );
+
+        assert_eq!(
+            fixture.has_attached_luks2_header(),
+            expect_attached_header,
+            "unexpected attached LUKS header state for {:?} with SEV enabled = {}",
             partition,
             enable_sev
         );
@@ -598,7 +610,6 @@ fn test_sev_unlock_store_partition_with_previous_key() {
     assert_device_has_content(Path::new("/dev/mapper/store-crypt"), b"hello world");
     assert!(fixture.store_luks_header_path.exists());
     assert!(fixture.has_detached_luks2_header());
-    assert!(fixture.has_attached_luks2_header());
 
     // Check that the previous key file has been deleted.
     assert!(!fixture.previous_key_path.exists());
@@ -611,12 +622,14 @@ fn test_sev_unlock_store_partition_with_previous_key() {
         PREVIOUS_KEY,
     )
     .expect("previous key should unlock the store partition");
+
+    // The attached header is wiped during open() when a detached header is available.
     check_encryption_key(
         &fixture.device.path().unwrap(),
         LuksHeaderLocation::Attached,
         PREVIOUS_KEY,
     )
-    .expect("previous key should unlock the attached Store header for rollback");
+    .expect_err("attached Store header should have been wiped during open()");
 
     let sev_key = derive_key_from_sev_measurement(
         &mut fixture.sev_firmware_builder.build(),
@@ -633,13 +646,13 @@ fn test_sev_unlock_store_partition_with_previous_key() {
     )
     .expect("SEV key should unlock the store partition");
 
-    // Attached is not updated with new key, only detached
+    // The attached header has been wiped, so no key should unlock it.
     check_encryption_key(
         &fixture.device.path().unwrap(),
         LuksHeaderLocation::Attached,
         sev_key.as_bytes(),
     )
-    .expect_err("SEV key should not unlock the attached Store header for rollback");
+    .expect_err("attached Store header should have been wiped during open()");
 
     check_encryption_key(
         &fixture.device.path().unwrap(),
@@ -834,7 +847,6 @@ fn test_sev_unlock_store_with_current_key_if_previous_key_does_not_work() {
         .open(Partition::Store)
         .expect("Failed to open store partition");
     assert!(fixture.has_detached_luks2_header());
-    assert!(fixture.has_attached_luks2_header());
     assert_eq!(fixture.active_keyslot_count(Partition::Store), 1);
 }
 
@@ -1043,6 +1055,8 @@ fn test_can_open_store_with_detached_header_after_attached_header_is_corrupted()
     let mut fixture = TestFixture::new(true);
 
     fixture.format(Partition::Store).unwrap();
+    // The store partition is formatted with a detached header only, so corrupting the area
+    // where an attached header would be must not affect the result.
     corrupt_attached_luks_header(&fixture.device.path().unwrap());
 
     let result = fixture
@@ -1102,13 +1116,74 @@ fn test_open_store_succeeds_with_detached_header_after_attached_header_is_corrup
     fixture.format(Partition::Store).unwrap();
 
     assert!(fixture.store_luks_header_path.exists());
-    assert!(fixture.has_attached_luks2_header());
+    // The store partition is formatted with a detached header only; there is no attached
+    // LUKS header on the data device.
+    assert!(!fixture.has_attached_luks2_header());
 
+    // Corrupting the area on the data device where an attached header would have been must
+    // not affect opening because only the detached header is used.
     corrupt_attached_luks_header(&fixture.device.path().unwrap());
 
     fixture
         .open(Partition::Store)
         .expect("opening Store should succeed with the detached header even if the attached header is corrupted");
+
+    assert!(Path::new("/dev/mapper/store-crypt").exists());
+}
+
+/// Test that opening the store partition wipes a legacy attached LUKS header when a detached
+/// header is available. This simulates upgrading from an older GuestOS that wrote both an
+/// attached and a detached header.
+#[test]
+fn test_open_store_wipes_attached_header_when_detached_header_is_available() {
+    const PREVIOUS_KEY: &[u8] = b"previous key";
+
+    let mut fixture = TestFixture::new(true);
+
+    fs::write(&fixture.previous_key_path, PREVIOUS_KEY)
+        .expect("Failed to write previous key for testing");
+
+    // Simulate a legacy device that has both an attached and a detached header.
+    format_crypt_device(
+        &fixture.device.path().unwrap(),
+        LuksHeaderLocation::Attached,
+        PREVIOUS_KEY,
+    )
+    .expect("Failed to format device with attached header");
+
+    backup_luks_header_to_file(
+        &fixture.device.path().unwrap(),
+        &fixture.store_luks_header_path,
+    )
+    .expect("Failed to create detached header backup");
+
+    // Both headers should be present before opening.
+    assert!(fixture.has_attached_luks2_header());
+    assert!(fixture.has_detached_luks2_header());
+
+    // Opening the store should wipe the attached header.
+    fixture
+        .open(Partition::Store)
+        .expect("opening Store should succeed");
+
+    // The attached header should now be gone.
+    assert!(
+        !fixture.has_attached_luks2_header(),
+        "attached LUKS header should have been wiped during open()"
+    );
+    // The detached header must still be present and valid.
+    assert!(
+        fixture.has_detached_luks2_header(),
+        "detached LUKS header should still be present after open()"
+    );
+    assert!(fixture.store_luks_header_path.exists());
+
+    deactive_crypt_device_with_check("store-crypt");
+
+    // Opening again should still succeed (using only the detached header).
+    fixture
+        .open(Partition::Store)
+        .expect("opening Store should succeed again after attached header wipe");
 
     assert!(Path::new("/dev/mapper/store-crypt").exists());
 }


### PR DESCRIPTION
The Store partition is now formatted with a detached LUKS header only. A legacy attached header still present on a device (which was the previous approach) is wiped on the next open, so only the detached header remains going forward.

In addition, `guest_disk` now uses a shared metrics `Registry` and writes all metrics once. The PR adds the `guest_disk_store_attached_luks2_header_status` gauge to track the header migration state.