### PR TITLE
chore: Create ic-node tmpfiles early via dedicated service before local-fs.target

### DIFF
--- a/ic-os/components/guestos.bzl
+++ b/ic-os/components/guestos.bzl
@@ -79,6 +79,7 @@ def component_files(mode):
         Label("misc/vsock/10-vhost-vsock.rules"): "/etc/udev/rules.d/10-vhost-vsock.rules",
         Label("misc/sev/99-sev.rules"): "/etc/udev/rules.d/99-sev.rules",
         Label("guestos/misc/ic-node.conf"): "/etc/tmpfiles.d/ic-node.conf",
+        Label("guestos/misc/ic-node-tmpfiles.service"): "/etc/systemd/system/ic-node-tmpfiles.service",
         Label("guestos/misc/sudoers"): "/etc/sudoers",
         Label("guestos/misc/crypttab"): "/etc/crypttab",
         Label("guestos/misc/sysctl.d/dfn-max-map-count.conf"): "/etc/sysctl.d/dfn-max-map-count.conf",

--- a/ic-os/components/guestos/init/setup-encryption/setup-data-encryption.service
+++ b/ic-os/components/guestos/init/setup-encryption/setup-data-encryption.service
@@ -6,6 +6,9 @@ DefaultDependencies=no
 RequiresMountsFor=/boot/config /var
 Requires=init-config.service
 After=init-config.service
+Wants=ic-node-tmpfiles.service
+# needed for metrics
+After=ic-node-tmpfiles.service
 Wants=cryptsetup-pre.target
 Before=cryptsetup.target
 Conflicts=umount.target

--- a/ic-os/components/guestos/misc/ic-node-tmpfiles.service
+++ b/ic-os/components/guestos/misc/ic-node-tmpfiles.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Create IC node volatile directories and files
+DefaultDependencies=no
+RequiresMountsFor=/run
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/bin/systemd-tmpfiles --create /etc/tmpfiles.d/ic-node.conf
+
+[Install]
+WantedBy=local-fs.target

--- a/ic-os/components/guestos/misc/ic-node.conf
+++ b/ic-os/components/guestos/misc/ic-node.conf
@@ -1,6 +1,10 @@
 #  This file is part of ic-node configuration to support ro root.
-
-# See tmpfiles.d(5) for details
+#
+#  Normally tmpfiles.d configs are processed by systemd-tmpfiles-setup.service
+#  during sysinit (after local-fs.target). However, some of our early-boot services
+#  run with DefaultDependencies=no and Before=local-fs.target, so these paths
+#  must exist earlier. The dedicated ic-node-tmpfiles.service processes this
+#  file Before=local-fs.target to ensure the paths are ready in time.
 
 # Type Path                                        Mode User Group               Age    Argument
 d      /run/ic-node                                0755 root root                -

--- a/ic-os/components/upgrade/systemd-generators/mount-generator
+++ b/ic-os/components/upgrade/systemd-generators/mount-generator
@@ -138,6 +138,8 @@ function make_var_cryptsetup() {
     echo "Before=cryptsetup.target"
     echo "Requires=init-config.service"
     echo "After=init-config.service"
+    echo "Wants=ic-node-tmpfiles.service"
+    echo "After=ic-node-tmpfiles.service" # needed for metrics
     # We need /boot/config for the decryption key (unless SEV is enabled)
     echo "RequiresMountsFor=/boot/config"
     echo "BindsTo=${SYSTEMD_DEVICE}"


### PR DESCRIPTION
Add a dedicated `ic-node-tmpfiles.service` that creates the `/run/ic-node` and `/run/node_exporter` volatile paths before `local-fs.target`, so early-boot guest_disk-based encryption services (which run with DefaultDependencies=no) find the paths already available. The default `systemd-tmpfiles-setup.service` runs too late in the boot process.