### PR TITLE
feat: [DSM-144] Have `StateManager` reuse the previous `HashTree` as a baseline

### DIFF
--- a/rs/canonical_state/tree_hash/src/hash_tree.rs
+++ b/rs/canonical_state/tree_hash/src/hash_tree.rs
@@ -325,6 +325,13 @@ pub struct HashTree {
     /// they are rebuilt on demand from the `SubtreeSource` (see
     /// [`HashTree::witness`]).
     stubs: Vec<Vec<StubNode>>,
+
+    /// Number of digests (stubs) reused from a baseline during the construction of
+    /// this [`HashTree`].
+    reused_stubs: usize,
+    /// Number of children built in parallel during the construction of this
+    /// [`HashTree`].
+    parallel_built_children: usize,
 }
 
 /// A reusable subtree collapsed to a single digest ("stub"), stored in a
@@ -368,6 +375,8 @@ impl HashTree {
             node_children: vec![Default::default()],
             node_children_labels_ranges: vec![Default::default()],
             stubs: vec![Default::default()],
+            reused_stubs: 0,
+            parallel_built_children: 0,
         }
     }
 
@@ -412,6 +421,18 @@ impl HashTree {
             .unwrap_or(0);
 
         leaf_size.max(fork_size).max(node_size).max(stub_size)
+    }
+
+    /// Number of subtree digests reused from a baseline `HashTree` during this
+    /// tree's construction (rather than recomputed).
+    pub fn reused_stubs(&self) -> usize {
+        self.reused_stubs
+    }
+
+    /// Number of labeled nodes (fork children) built in parallel during this
+    /// tree's construction.
+    pub fn parallel_built_children(&self) -> usize {
+        self.parallel_built_children
     }
 
     /// Number of [`NodeKind::Stub`] nodes in this tree.
@@ -848,6 +869,12 @@ impl HashTree {
 
         // Reusable stubs
         self.stubs.extend(subtree.stubs);
+
+        // Roll up the worker's build statistics. (`parallel_built_children` is
+        // always 0 in a worker, which builds sequentially, but is folded in for
+        // symmetry.)
+        self.reused_stubs += subtree.reused_stubs;
+        self.parallel_built_children += subtree.parallel_built_children;
     }
 }
 
@@ -1081,7 +1108,10 @@ pub fn hash_lazy_tree<'a>(
                     // Unchanged: the baseline carries an equal `SubtreeSource` — same source
                     // allocation *and* same expander (hence same certification version) — so its
                     // digest is reused without materializing the child.
-                    Some(stub) if stub.source == source => (stub.digest.clone(), false),
+                    Some(stub) if stub.source == source => {
+                        ht.reused_stubs += 1;
+                        (stub.digest.clone(), false)
+                    }
 
                     // New, changed, or built under a different version: rebuild the subtree from
                     // its (current) `source` only to capture its root digest; if later needed for
@@ -1292,6 +1322,8 @@ pub fn hash_lazy_tree<'a>(
         mut tail: impl Iterator<Item = (usize, (Label, Child<'a>, Option<BaselineCursor<'a>>))>,
         tail_len: usize,
     ) -> Result<(), HashTreeError> {
+        ht.parallel_built_children += tail_len;
+
         let bucket_offset = ht.node_children.len();
         let threads = thread_pool.thread_count() as usize;
         debug_assert!(threads > 0);

--- a/rs/canonical_state/tree_hash/tests/subtree.rs
+++ b/rs/canonical_state/tree_hash/tests/subtree.rs
@@ -253,6 +253,11 @@ fn every_canister_is_a_subtree() {
         NUM_CANISTERS,
         "every canister should be stored as a stub"
     );
+
+    // No baseline, so nothing is reused; and a from-scratch fork this large is
+    // built entirely in parallel.
+    assert_eq!(tree.reused_stubs(), 0);
+    assert_eq!(tree.parallel_built_children(), NUM_CANISTERS);
 }
 
 #[test]
@@ -393,6 +398,14 @@ fn baseline_build_with_partial_change_matches_from_scratch() {
 
     assert_eq!(with_baseline.stub_count(), NUM_CANISTERS);
     assert_eq!(with_baseline.root_hash(), from_scratch.root_hash());
+
+    // With the baseline, every canister but the mutated one is reused; the build
+    // stays sequential (the rebuild rate never projects enough work to parallelize).
+    assert_eq!(with_baseline.reused_stubs(), NUM_CANISTERS - 1);
+    assert_eq!(with_baseline.parallel_built_children(), 0);
+    // The from-scratch build reuses nothing and parallelizes the whole fork.
+    assert_eq!(from_scratch.reused_stubs(), 0);
+    assert_eq!(from_scratch.parallel_built_children(), NUM_CANISTERS);
 }
 
 /// Whether `a` and `b` hold the same stub [`SubtreeSource`]s by identity: each

--- a/rs/state_manager/src/lib.rs
+++ b/rs/state_manager/src/lib.rs
@@ -193,6 +193,9 @@ pub struct StateManagerMetrics {
     merge_metrics: MergeMetrics,
     latest_hash_tree_size: IntGauge,
     latest_hash_tree_max_index: IntGauge,
+    hash_tree_size: Histogram,
+    hash_tree_reused_stubs: Histogram,
+    hash_tree_parallel_built_children: Histogram,
     fast_forward_height: IntGauge,
     no_state_clone_count: IntCounter,
     skip_optimization_missing_cert_count: IntCounter,
@@ -489,6 +492,27 @@ impl StateManagerMetrics {
             "Largest index in the latest hash tree.",
         );
 
+        let hash_tree_size = metrics_registry.histogram(
+            "state_manager_hash_tree_size",
+            "Number of digests in the hash tree.",
+            // 1, 2, 5, …, 1M, 2M, 5M
+            decimal_buckets(0, 6),
+        );
+
+        let hash_tree_reused_stubs = metrics_registry.histogram(
+            "state_manager_hash_tree_reused_stubs",
+            "Number of digests (stubs) reused from the previous hash tree.",
+            // 1, 2, 5, …, 1M, 2M, 5M
+            decimal_buckets(0, 6),
+        );
+
+        let hash_tree_parallel_built_children = metrics_registry.histogram(
+            "state_manager_hash_tree_parallel_built_children",
+            "Number of children built in parallel during the construction of the hash tree.",
+            // 1, 2, 5, …, 1M, 2M, 5M
+            decimal_buckets(0, 6),
+        );
+
         let fast_forward_height = metrics_registry.int_gauge(
             "state_manager_fast_forward_height",
             "Height below which states do not need to be cloned and hashed.",
@@ -535,6 +559,9 @@ impl StateManagerMetrics {
             merge_metrics: MergeMetrics::new(metrics_registry),
             latest_hash_tree_size,
             latest_hash_tree_max_index,
+            hash_tree_size,
+            hash_tree_reused_stubs,
+            hash_tree_parallel_built_children,
             fast_forward_height,
             no_state_clone_count,
             skip_optimization_missing_cert_count,
@@ -1913,15 +1940,23 @@ impl StateManagerImpl {
             })
     }
 
+    /// Computes the certification metadata (hash tree, root hash, height
+    /// witness) for `state` at `height`.
+    ///
+    /// If a `baseline` hash tree (typically the immediately preceding height's)
+    /// is provided, the stubbed subtrees that are unchanged relative to the
+    /// baseline (i.e. backed by the same `Arc`) are reused instead of being
+    /// recomputed.
     fn compute_certification_metadata(
         state: &ReplicatedState,
         height: Height,
+        baseline: Option<&HashTree>,
         metrics: &StateManagerMetrics,
         log: &ReplicaLogger,
     ) -> Result<CertificationMetadata, HashTreeError> {
         let started_hashing_at = Instant::now();
         let lazy_tree = replicated_state_as_lazy_tree(state, height);
-        let hash_tree = hash_lazy_tree(&lazy_tree, None)?;
+        let hash_tree = hash_lazy_tree(&lazy_tree, baseline)?;
         let elapsed = started_hashing_at.elapsed();
         debug!(log, "Computed hash tree in {:?}", elapsed);
 
@@ -1961,8 +1996,9 @@ impl StateManagerImpl {
 
         for (checkpoint_layout, state) in states {
             let height = checkpoint_layout.height();
-            let certification = Self::compute_certification_metadata(&state, height, metrics, log)
-                .unwrap_or_else(|err| fatal!(log, "Failed to compute hash tree: {:?}", err));
+            let certification =
+                Self::compute_certification_metadata(&state, height, None, metrics, log)
+                    .unwrap_or_else(|err| fatal!(log, "Failed to compute hash tree: {:?}", err));
             info!(
                 log,
                 "Certification hash for height {} at startup: {:?}",
@@ -2740,10 +2776,18 @@ fn update_latest_height(cached: &AtomicU64, h: Height) -> u64 {
 
 /// Helper function to set metrics related to hash trees
 fn update_hash_tree_metrics(hash_tree: &HashTree, metrics: &StateManagerMetrics) {
-    metrics.latest_hash_tree_size.set(hash_tree.size() as i64);
+    let hash_tree_size = hash_tree.size();
+    metrics.latest_hash_tree_size.set(hash_tree_size as i64);
     metrics
         .latest_hash_tree_max_index
         .set(hash_tree.max_index() as i64);
+    metrics.hash_tree_size.observe(hash_tree_size as f64);
+    metrics
+        .hash_tree_reused_stubs
+        .observe(hash_tree.reused_stubs() as f64);
+    metrics
+        .hash_tree_parallel_built_children
+        .observe(hash_tree.parallel_built_children() as f64);
 }
 
 impl StateManager for StateManagerImpl {
@@ -3381,6 +3425,7 @@ impl StateManager for StateManagerImpl {
                 let certification = StateManagerImpl::compute_certification_metadata(
                     initial_state,
                     prev_height,
+                    None,
                     &self.metrics,
                     &self.log,
                 )
@@ -3703,9 +3748,23 @@ fn spawn_hash_thread(
                             max_certified_height_tx,
                             state_metadata,
                         } => {
+                            // Reuse the most recent resident hash tree as a baseline: the state being
+                            // hashed derives from it via copy-on-write, so unchanged stubbed subtrees share
+                            // the same underlying `Arc` and can be reused directly.
+                            let baseline = states
+                                .read()
+                                .certifications_metadata
+                                .last_key_value()
+                                .and_then(|(_, md)| {
+                                    md.hash_tree.as_ref().map(|(tree, _)| Arc::clone(tree))
+                                });
                             let mut certification_metadata =
                                 StateManagerImpl::compute_certification_metadata(
-                                    &state, height, &metrics, &log,
+                                    &state,
+                                    height,
+                                    baseline.as_deref(),
+                                    &metrics,
+                                    &log,
                                 )
                                 .unwrap_or_else(|err| {
                                     fatal!(log, "Failed to compute hash tree: {:?}", err)


### PR DESCRIPTION
Thread an optional `baseline` hash tree through `compute_certification_metadata` and pass the most recent resident hash tree from the certification hash thread. The state being hashed derives from it copy-on-write, so unchanged stubbed subtrees share the same backing `Arc` and their digests are reused instead of recomputed.