### PR TITLE
chore: bump rules_foreign_cc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,14 +10,14 @@ use_repo(ext, "rules_buf_toolchains")
 register_toolchains("@rules_buf_toolchains//:all")
 
 # General Bazel helpers
-bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
 
 # CC dependencies (for C libs like miracl-core, etc)
-bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "hermetic_cc_toolchain", version = "4.1.0")
 single_version_override(
@@ -30,7 +30,7 @@ single_version_override(
 )
 
 # configure/make dependencies
-bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+bazel_dep(name = "rules_foreign_cc", version = "0.15.2")
 
 register_toolchains(
     "@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain",
@@ -39,14 +39,16 @@ register_toolchains(
 
 # Use a patch to work around determinism issues in make & pkgconfig toolchains
 # https://github.com/bazel-contrib/rules_foreign_cc/issues/1313
+# Also we use HEAD to have the latest version of the dependencies (Meson in
+# particular which otherwise cannot use the zig toolchain)
 archive_override(
     module_name = "rules_foreign_cc",
-    integrity = "sha256-MnWXKJE8N2ukWwEWhptxtoscLr+PK897QSIrwHt3PXM=",
+    sha256 = "7f05eb9cc4b1c600c643e69221c88203244ccadc75ae28c4ade960f0f0742f26",
     patch_strip = 1,
     patches = ["//bazel:rules_foreign_cc.patch"],
-    strip_prefix = "rules_foreign_cc-0.15.1",
+    strip_prefix = "rules_foreign_cc-f68b351c4691e747f889dc5e4c2cac3cd3b66ea2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_foreign_cc/releases/download/0.15.1/rules_foreign_cc-0.15.1.tar.gz"],
+    urls = ["https://codeload.github.com/bazel-contrib/rules_foreign_cc/tar.gz/f68b351c4691e747f889dc5e4c2cac3cd3b66ea2"],
 )
 
 # Misc tools
@@ -60,7 +62,7 @@ include("//bazel:rust.MODULE.bazel")
 
 # Python dependencies
 
-bazel_dep(name = "rules_python", version = "1.7.0")
+bazel_dep(name = "rules_python", version = "1.9.0")
 
 python_version = "3.12"
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,9 +43,9 @@ register_toolchains(
 # particular which otherwise cannot use the zig toolchain)
 archive_override(
     module_name = "rules_foreign_cc",
-    sha256 = "7f05eb9cc4b1c600c643e69221c88203244ccadc75ae28c4ade960f0f0742f26",
     patch_strip = 1,
     patches = ["//bazel:rules_foreign_cc.patch"],
+    sha256 = "7f05eb9cc4b1c600c643e69221c88203244ccadc75ae28c4ade960f0f0742f26",
     strip_prefix = "rules_foreign_cc-f68b351c4691e747f889dc5e4c2cac3cd3b66ea2",
     type = "tar.gz",
     urls = ["https://codeload.github.com/bazel-contrib/rules_foreign_cc/tar.gz/f68b351c4691e747f889dc5e4c2cac3cd3b66ea2"],

--- a/bazel/rules_foreign_cc.patch
+++ b/bazel/rules_foreign_cc.patch
@@ -3,13 +3,14 @@
 # output) since it contains non-deterministic content (absolute paths,
 # timestamps). On failure the log is still printed for debugging.
 diff --git a/foreign_cc/private/framework.bzl b/foreign_cc/private/framework.bzl
+index b822e2b..058f7a3 100644
 --- a/foreign_cc/private/framework.bzl
 +++ b/foreign_cc/private/framework.bzl
-@@ -647,6 +647,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text, env_prelude, build_
-         "\n".join([
-             "##rm_rf## $$BUILD_TMPDIR$$",
-             "##rm_rf## $$EXT_BUILD_DEPS$$",
+@@ -720,6 +720,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text, env_prelude, build_
+             # parent temp dir too. On non-Windows this var is unset.
+             "if [ -n \"${RFCC_SHORT_PATH_ROOT:-}\" ]; then",
+             "##rm_rf## ${RFCC_SHORT_PATH_ROOT}",
 +            "echo > $$BUILD_LOG$$",
+             "fi",
          ]),
      )
-     cleanup_on_failure_function = create_function(

--- a/bazel/rules_foreign_cc.patch
+++ b/bazel/rules_foreign_cc.patch
@@ -2,15 +2,14 @@
 # On a successful build we empty the build log (which is declared as an action
 # output) since it contains non-deterministic content (absolute paths,
 # timestamps). On failure the log is still printed for debugging.
-diff --git a/foreign_cc/private/framework.bzl b/foreign_cc/private/framework.bzl
-index b822e2b..058f7a3 100644
+index b822e2b..2b1eae1 100644
 --- a/foreign_cc/private/framework.bzl
 +++ b/foreign_cc/private/framework.bzl
-@@ -720,6 +720,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text, env_prelude, build_
-             # parent temp dir too. On non-Windows this var is unset.
-             "if [ -n \"${RFCC_SHORT_PATH_ROOT:-}\" ]; then",
-             "##rm_rf## ${RFCC_SHORT_PATH_ROOT}",
+@@ -715,6 +715,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text, env_prelude, build_
+         "\n".join([
+             "##rm_rf## $$BUILD_TMPDIR$$",
+             "##rm_rf## $$EXT_BUILD_DEPS$$",
 +            "echo > $$BUILD_LOG$$",
-             "fi",
-         ]),
-     )
+             # On Windows with short paths, BUILD_TMPDIR and EXT_BUILD_DEPS are
+             # inside RFCC_SHORT_PATH_ROOT (already removed above). Clean up the
+             # parent temp dir too. On non-Windows this var is unset.


### PR DESCRIPTION
This upgrades rules_foreign_cc to 0.15.1+ (unreleased). This includes a Meson version upgrade which will allow us to use the `meson` rule with the zig toolchain:

>  The default built meson jumped from 1.5.1 to 1.10.1

(Zig support was introduced in 1.6)

Other MODULE.bazel dependencies are updated to reflect the actual versions resolved in the dep graph.