### PR TITLE
chore: move dotd/remote_download_all flags to .bazelrc.internal

### DIFF
--- a/bazel/conf/.bazelrc.build
+++ b/bazel/conf/.bazelrc.build
@@ -114,10 +114,6 @@ run:sandbox_fuzzing --run_under="ASAN_OPTIONS=detect_leaks=0:allow_user_segv_han
 query --ui_event_filters=-info,-debug --noshow_progress
 cquery --ui_event_filters=-info,-debug --noshow_progress
 
-# This is disabled by default on bazel 7+ some of our targets choke
-# on this (not yet clear why)
-common --remote_download_all
-
 # This is particularly helpful for canbench, but other tests that follow this
 # convention would also benefit. If the test does not support this, this "almost
 # certainly" does no harm.

--- a/bazel/conf/.bazelrc.internal
+++ b/bazel/conf/.bazelrc.internal
@@ -16,8 +16,8 @@ build --remote_cache_compression # If enabled, compress/decompress cache blobs w
 #build --remote_download_minimal # https://bazel.build/reference/command-line-reference#flag--remote_download_minimal
 #build --remote_download_outputs=toplevel # Still download outputs from top level targets.
 
-# This is disabled by default on bazel 7+ some of our targets choke
-# on this (not yet clear why)
+# Bazel 7+ defaults to minimal remote output downloads; some of our builds
+# require additional outputs to be present locally (reason TBD), so download all.
 common --remote_download_all
 
 # Keep C++ .d (dotd) dependency files on disk instead of in memory. With the

--- a/bazel/conf/.bazelrc.internal
+++ b/bazel/conf/.bazelrc.internal
@@ -16,6 +16,21 @@ build --remote_cache_compression # If enabled, compress/decompress cache blobs w
 #build --remote_download_minimal # https://bazel.build/reference/command-line-reference#flag--remote_download_minimal
 #build --remote_download_outputs=toplevel # Still download outputs from top level targets.
 
+# This is disabled by default on bazel 7+ some of our targets choke
+# on this (not yet clear why)
+common --remote_download_all
+
+# Keep C++ .d (dotd) dependency files on disk instead of in memory. With the
+# in-memory default, combined with our remote cache, C++ compile actions are
+# spuriously treated as not up-to-date in a *subsequent* bazel invocation
+# because their .d outputs don't persist on disk.
+#   https://github.com/bazelbuild/bazel/issues/22387
+# Concretely, this broke the `Upload artifacts` CI step which runs
+# `bazel run --check_up_to_date //:upload-artifacts` after `bazel build`: the
+# compression host-tools (zlib/pigz/lmdb/zstd/zopfli) were reported as "not
+# up-to-date" and --check_up_to_date aborted the upload.
+common --noexperimental_inmemory_dotd_files
+
 build --experimental_remote_downloader=bazel-remote.idx.dfinity.network --experimental_remote_downloader_local_fallback
 build:local --experimental_remote_downloader=
 build --remote_local_fallback


### PR DESCRIPTION
## Problem

Commit 91ae53071d8fe6484d12dae73f01cda67bc26010 (#10614) removed `common --noexperimental_inmemory_dotd_files` from `bazel/conf/.bazelrc.build`. This broke the `Upload artifacts` step of the `Bazel Test All` job on `master` (e.g. [this run](https://github.com/dfinity/ic/actions/runs/28447535750/job/84300998049)).

That step runs `bazel run --check_up_to_date //:upload-artifacts` in a **separate** bazel invocation after `bazel build`. With the in-memory `.d` (dotd) files default, combined with our remote cache, the C++ compile actions for the compression host-tools (zlib / pigz / lmdb `mdb.c`,`midl.c` / zstd / zopfli) were reported as `is not up-to-date`, so `--check_up_to_date` aborted the upload:

```
ERROR: action 'Compiling pigz.c [for tool]' is not up-to-date
...
Target //:upload-artifacts failed to build
```

This is [bazelbuild/bazel#22387](https://github.com/bazelbuild/bazel/issues/22387) (in-memory `.d` files don't reliably persist on disk between invocations with a remote cache).

## Fix

The bug only affects DFINITY's remote cache, so this restores `common --noexperimental_inmemory_dotd_files` in `bazel/conf/.bazelrc.internal` (the DFINITY-internal cache config) rather than in the minimal `bazel/conf/.bazelrc.build`. `common --remote_download_all` is moved there too since it is remote-cache related.

The main `Bazel Test All` job uses the CI bazel wrapper which calls `bazel` **without** `--noworkspace_rc`, so it loads the root `.bazelrc` (both fragments) and gets both flags — fixing the failure.

The arm64/Namespace jobs and the `build-without-dfinity-infra` path use `--noworkspace_rc --bazelrc=bazel/conf/.bazelrc.build` with their own cache + build-without-the-bytes, and intentionally want the opposite (`--experimental_inmemory_dotd_files`); keeping these flags out of `.bazelrc.build` is correct for them.