### PR TITLE
chore: Log var_crypt output to console

### DIFF
--- a/ic-os/components/upgrade/systemd-generators/mount-generator
+++ b/ic-os/components/upgrade/systemd-generators/mount-generator
@@ -153,6 +153,8 @@ function make_var_cryptsetup() {
     echo "KeyringMode=shared"
     echo "ExecStart=/opt/ic/bin/setup-var-encryption.sh /dev/disk/by-partuuid/${PARTUUID} /dev/disk/by-partuuid/${ALT_PARTUUID}"
     echo "ExecStop=/lib/systemd/systemd-cryptsetup detach var_crypt"
+    echo "StandardOutput=journal+console"
+    echo "StandardError=journal+console"
 }
 
 CURRENT_SYSTEM=$(get_boot_arg_value dfinity.system)


### PR DESCRIPTION
We have found that `dev-mapper-var_crypt.device` sporadically fails to come up in system tests. Unfortunately, the GuestOS is often destroyed afterwards, and we can only see what's on the console.